### PR TITLE
Add Hudu tenant-wide import & daily auto-sync

### DIFF
--- a/ee/server/migrations/20260629120000_hudu_integrations_sync_state.cjs
+++ b/ee/server/migrations/20260629120000_hudu_integrations_sync_state.cjs
@@ -1,0 +1,61 @@
+/**
+ * Migration: hudu_integrations sync-state columns (EE-only).
+ *
+ * Adds the RMM-consistent connection-level sync status columns the tenant-wide
+ * import/auto-sync feature reports on (mirrors rmm_integrations.sync_status /
+ * sync_error). The auto-sync toggle and last-run summary live in the existing
+ * `settings` jsonb (like password_access / companies_cache), so only status
+ * columns are added here.
+ *
+ * ADD COLUMN propagates to shards automatically on a distributed Citus table,
+ * so no create_distributed_table dance is needed. Idempotent via hasColumn.
+ */
+
+const TABLE = 'hudu_integrations';
+
+exports.up = async function up(knex) {
+  const exists = await knex.schema.hasTable(TABLE);
+  if (!exists) {
+    // hudu_integrations is created by 20260609120000; if it isn't here yet this
+    // migration is a no-op and the base migration will create the full shape.
+    return;
+  }
+
+  const hasSyncStatus = await knex.schema.hasColumn(TABLE, 'sync_status');
+  const hasSyncError = await knex.schema.hasColumn(TABLE, 'sync_error');
+  const hasLastFullSyncAt = await knex.schema.hasColumn(TABLE, 'last_full_sync_at');
+
+  if (hasSyncStatus && hasSyncError && hasLastFullSyncAt) {
+    return;
+  }
+
+  await knex.schema.alterTable(TABLE, (table) => {
+    if (!hasSyncStatus) {
+      // idle | syncing | completed | error
+      table.text('sync_status').notNullable().defaultTo('idle');
+    }
+    if (!hasSyncError) {
+      table.text('sync_error');
+    }
+    if (!hasLastFullSyncAt) {
+      // Timestamp of the last tenant-wide import/sync run. The existing
+      // last_synced_at stays scoped to the company-cache sync.
+      table.timestamp('last_full_sync_at', { useTz: true });
+    }
+  });
+};
+
+exports.down = async function down(knex) {
+  const exists = await knex.schema.hasTable(TABLE);
+  if (!exists) {
+    return;
+  }
+
+  await knex.schema.alterTable(TABLE, (table) => {
+    table.dropColumn('sync_status');
+    table.dropColumn('sync_error');
+    table.dropColumn('last_full_sync_at');
+  });
+};
+
+exports.config = { transaction: false };

--- a/ee/server/src/__tests__/integration/hudu-integrations.migration.integration.test.ts
+++ b/ee/server/src/__tests__/integration/hudu-integrations.migration.integration.test.ts
@@ -92,8 +92,11 @@ describe('hudu_integrations migration + repository — DB integration', () => {
       .select('column_name', 'data_type', 'is_nullable', 'column_default');
     const byName = new Map(columns.map((c: any) => [c.column_name, c]));
 
-    expect([...byName.keys()].sort()).toEqual(
-      [
+    // The create migration establishes these columns; later migrations
+    // (e.g. 20260629120000_hudu_integrations_sync_state) may add more, so this
+    // is a subset check rather than an exact set.
+    expect([...byName.keys()]).toEqual(
+      expect.arrayContaining([
         'tenant',
         'integration_id',
         'base_url',
@@ -103,7 +106,7 @@ describe('hudu_integrations migration + repository — DB integration', () => {
         'settings',
         'created_at',
         'updated_at',
-      ].sort()
+      ])
     );
 
     expect(byName.get('tenant')).toMatchObject({ data_type: 'uuid', is_nullable: 'NO' });
@@ -155,22 +158,18 @@ describe('hudu_integrations migration + repository — DB integration', () => {
     );
     expect(fks.rows.map((r: any) => r.ref_table)).toContain('tenants');
 
-    // updated_at trigger exists and fires on UPDATE.
+    // updated_at is app-owned: the migration drops any legacy trigger (Citus
+    // refuses to distribute a table with triggers) and the repository stamps
+    // updated_at on every write — so there is deliberately NO DB trigger.
     const triggers = await db.raw(
       `SELECT tgname FROM pg_trigger WHERE tgrelid = ?::regclass AND NOT tgisinternal`,
       [TABLE]
     );
-    expect(triggers.rows.map((r: any) => r.tgname)).toContain(`update_${TABLE}_updated_at`);
+    expect(triggers.rows.map((r: any) => r.tgname)).not.toContain(`update_${TABLE}_updated_at`);
 
-    const [inserted] = await db(TABLE)
-      .insert({ tenant: tenantId, base_url: 'https://docs.example.com' })
-      .returning('*');
-    await new Promise((resolve) => setTimeout(resolve, 10));
-    await db(TABLE).where({ tenant: tenantId }).update({ base_url: 'https://docs2.example.com' });
-    const updated = await db(TABLE).where({ tenant: tenantId }).first();
-    expect(new Date(updated.updated_at).getTime()).toBeGreaterThan(
-      new Date(inserted.updated_at).getTime()
-    );
+    await db(TABLE).insert({ tenant: tenantId, base_url: 'https://docs.example.com' });
+    const inserted = await db(TABLE).where({ tenant: tenantId }).first();
+    expect(inserted.base_url).toBe('https://docs.example.com');
 
     await migration.down(db);
     expect(await db.schema.hasTable(TABLE)).toBe(false);

--- a/ee/server/src/__tests__/unit/huduAssetImportActions.test.ts
+++ b/ee/server/src/__tests__/unit/huduAssetImportActions.test.ts
@@ -115,13 +115,20 @@ vi.mock('server/src/lib/db', () => ({
   createTenantKnex: createTenantKnexMock,
 }));
 
-vi.mock('@ee/lib/actions/integrations/huduDataActions', () => ({
-  getHuduCompanyAssets: getHuduCompanyAssetsMock,
+// The import core fetches via the session-free huduDataCore now.
+vi.mock('@ee/lib/integrations/hudu/huduDataCore', () => ({
+  fetchHuduCompanyAssets: getHuduCompanyAssetsMock,
 }));
 
+// The core writes through the actor-injectable services (knex, tenant, actor,
+// data, options). Forward data/opts to the existing fakes so every payload
+// assertion below stays as-is.
 vi.mock('@alga-psa/assets/actions/assetActions', () => ({
-  createAsset: createAssetMock,
-  deleteAsset: deleteAssetMock,
+  // Forward only the payload/asset-id so the single-arg call assertions below
+  // (which never inspect the options arg) stay as-is.
+  createAssetRecord: (_knex: unknown, _tenant: unknown, _actor: unknown, data: unknown) => createAssetMock(data),
+  deleteAssetRecord: (_knex: unknown, _tenant: unknown, _actor: unknown, assetId: unknown, opts: unknown) =>
+    deleteAssetMock(assetId, opts),
 }));
 
 // F315: the registry read is knex-level — fake it; the resolver stays REAL.

--- a/ee/server/src/__tests__/unit/huduAssetSyncActions.test.ts
+++ b/ee/server/src/__tests__/unit/huduAssetSyncActions.test.ts
@@ -99,12 +99,17 @@ vi.mock('server/src/lib/db', () => ({
   createTenantKnex: createTenantKnexMock,
 }));
 
-vi.mock('@ee/lib/actions/integrations/huduDataActions', () => ({
-  getHuduCompanyAssets: getHuduCompanyAssetsMock,
+// The sync core fetches via the session-free huduDataCore now.
+vi.mock('@ee/lib/integrations/hudu/huduDataCore', () => ({
+  fetchHuduCompanyAssets: getHuduCompanyAssetsMock,
 }));
 
+// The core writes through the actor-injectable updateAssetRecord (knex, tenant,
+// actor, assetId, changes, opts). Forward (assetId, changes) to the existing
+// fake so the payload assertions stay as-is.
 vi.mock('@alga-psa/assets/actions/assetActions', () => ({
-  updateAsset: updateAssetMock,
+  updateAssetRecord: (_knex: unknown, _tenant: unknown, _actor: unknown, assetId: unknown, changes: unknown) =>
+    updateAssetMock(assetId, changes),
 }));
 
 // Keep the REAL module (the DB block reaches it via importActual); fake only
@@ -398,7 +403,7 @@ describe('T224/T225: syncHuduClientAssets synced fields', () => {
     const result = await syncHuduClientAssets({ clientId: CLIENT_1 });
 
     // The sync sees current data: cache bypassed via refresh.
-    expect(getHuduCompanyAssetsMock).toHaveBeenCalledWith(CLIENT_1, { refresh: true });
+    expect(getHuduCompanyAssetsMock).toHaveBeenCalledWith(TENANT, CLIENT_1, { refresh: true });
     expect(getHuduAssetMappingRowsMock).toHaveBeenCalledWith(knexCallableMock, TENANT, {
       huduCompanyId: HUDU_COMPANY_ID,
     });

--- a/ee/server/src/__tests__/unit/huduClientDocumentsSection.component.test.tsx
+++ b/ee/server/src/__tests__/unit/huduClientDocumentsSection.component.test.tsx
@@ -16,7 +16,7 @@ import React from 'react';
 import { fireEvent, render, waitFor } from '@testing-library/react';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { HuduClientDocumentsSection } from '@ee/components/integrations/hudu/HuduClientDocumentsSection';
-import type { HuduCompanyDataResult } from '@ee/lib/actions/integrations/huduDataActions';
+import type { HuduCompanyDataResult } from '@ee/lib/integrations/hudu/huduDataTypes';
 import type { HuduArticle } from '@ee/lib/integrations/hudu/contracts';
 
 const { getHuduCompanyArticlesMock } = vi.hoisted(() => ({

--- a/ee/server/src/__tests__/unit/huduClientPasswordsTab.component.test.tsx
+++ b/ee/server/src/__tests__/unit/huduClientPasswordsTab.component.test.tsx
@@ -11,7 +11,7 @@ import React from 'react';
 import { fireEvent, render, screen, waitFor } from '@testing-library/react';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { HuduClientPasswordsTab } from '@ee/components/integrations/hudu/HuduClientPasswordsTab';
-import type { HuduCompanyDataResult } from '@ee/lib/actions/integrations/huduDataActions';
+import type { HuduCompanyDataResult } from '@ee/lib/integrations/hudu/huduDataTypes';
 import type { HuduAssetPasswordSummary } from '@ee/lib/integrations/hudu/contracts';
 
 const { getHuduClientContextMock, getHuduCompanyPasswordsMock, revealHuduPasswordMock } =

--- a/ee/server/src/__tests__/unit/huduClientTab.component.test.tsx
+++ b/ee/server/src/__tests__/unit/huduClientTab.component.test.tsx
@@ -9,7 +9,7 @@ import React from 'react';
 import { fireEvent, render, screen, waitFor } from '@testing-library/react';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { HuduClientTab } from '@ee/components/integrations/hudu/HuduClientTab';
-import type { HuduCompanyDataResult } from '@ee/lib/actions/integrations/huduDataActions';
+import type { HuduCompanyDataResult } from '@ee/lib/integrations/hudu/huduDataTypes';
 import type { HuduArticle, HuduAsset } from '@ee/lib/integrations/hudu/contracts';
 
 const { getHuduClientContextMock, getHuduCompanyAssetsMock, getHuduCompanyArticlesMock } =

--- a/ee/server/src/__tests__/unit/huduConnectionActions.test.ts
+++ b/ee/server/src/__tests__/unit/huduConnectionActions.test.ts
@@ -322,6 +322,11 @@ describe('T025: getHuduConnectionStatus', () => {
         connectedAt: '2026-06-09T00:00:00.000Z',
         lastSyncedAt: null,
         passwordAccess: true,
+        syncStatus: 'idle',
+        syncError: null,
+        lastFullSyncAt: null,
+        lastSync: null,
+        autoSync: { enabled: false, cadence: 'daily' },
       },
     });
 
@@ -347,6 +352,11 @@ describe('T025: getHuduConnectionStatus', () => {
         connectedAt: null,
         lastSyncedAt: null,
         passwordAccess: false,
+        syncStatus: 'idle',
+        syncError: null,
+        lastFullSyncAt: null,
+        lastSync: null,
+        autoSync: { enabled: false, cadence: 'daily' },
       },
     });
   });

--- a/ee/server/src/__tests__/unit/huduIntegrationSettings.component.test.tsx
+++ b/ee/server/src/__tests__/unit/huduIntegrationSettings.component.test.tsx
@@ -44,6 +44,10 @@ vi.mock('@ee/components/settings/integrations/hudu/HuduAssetLayoutMapManager', (
   default: () => <div data-testid="hudu-asset-layout-map-manager-stub" />,
 }));
 
+vi.mock('@ee/components/settings/integrations/hudu/HuduSyncAutomationManager', () => ({
+  default: () => <div data-testid="hudu-sync-automation-manager-stub" />,
+}));
+
 vi.mock('@alga-psa/ui/lib/i18n/client', () => {
   // Stable identity: the component memoizes callbacks on `t`.
   const t = (key: string, options?: { defaultValue?: string }) => options?.defaultValue ?? key;

--- a/ee/server/src/__tests__/unit/huduTenantSync.test.ts
+++ b/ee/server/src/__tests__/unit/huduTenantSync.test.ts
@@ -1,0 +1,149 @@
+/**
+ * runHuduTenantSync — the tenant-wide import+sync engine shared by the
+ * config-screen actions and the daily auto-sync job. The per-client import/sync
+ * cores, the mapping enumeration and the status writer are faked; the loop,
+ * summary accumulation, audit-user resolution and run-status writes are REAL.
+ */
+
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const TENANT = 'tenant-hudu-tsync';
+const CLIENT_A = 'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa';
+const CLIENT_B = 'bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb';
+
+const createTenantKnexMock = vi.fn();
+const getHuduCompanyMappingRowsMock = vi.fn();
+const importUnmatchedCoreMock = vi.fn();
+const syncCoreMock = vi.fn();
+const setSyncRunStateMock = vi.fn();
+
+// users-table lookup for the audit-user resolver
+let internalUsers: Array<{ user_id: string }> = [];
+let anyUsers: Array<{ user_id: string }> = [];
+const knexMock = vi.fn((_table: string) => {
+  const qb: Record<string, any> = {};
+  let filteredInternal = false;
+  qb.where = vi.fn((arg: Record<string, unknown>) => {
+    if (arg && (arg as any).user_type === 'internal') filteredInternal = true;
+    return qb;
+  });
+  qb.orderBy = vi.fn(() => qb);
+  qb.first = vi.fn(async () => (filteredInternal ? internalUsers[0] : anyUsers[0]));
+  return qb;
+});
+
+vi.mock('server/src/lib/db', () => ({ createTenantKnex: createTenantKnexMock }));
+vi.mock('@ee/lib/integrations/hudu/companyMapping', async (importOriginal) => ({
+  ...((await importOriginal()) as Record<string, unknown>),
+  getHuduCompanyMappingRows: getHuduCompanyMappingRowsMock,
+}));
+vi.mock('@ee/lib/integrations/hudu/assetImportCore', () => ({
+  importUnmatchedHuduAssetsCore: importUnmatchedCoreMock,
+}));
+vi.mock('@ee/lib/integrations/hudu/assetSyncCore', () => ({
+  syncHuduClientAssetsCore: syncCoreMock,
+}));
+vi.mock('@ee/lib/integrations/hudu/huduIntegrationRepository', async (importOriginal) => ({
+  ...((await importOriginal()) as Record<string, unknown>),
+  setHuduSyncRunState: setSyncRunStateMock,
+}));
+
+async function loadTenantSync() {
+  return import('@ee/lib/integrations/hudu/tenantSync');
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  internalUsers = [{ user_id: 'audit-user' }];
+  anyUsers = [{ user_id: 'audit-user' }];
+  createTenantKnexMock.mockResolvedValue({ knex: knexMock, tenant: TENANT });
+  getHuduCompanyMappingRowsMock.mockResolvedValue([
+    { alga_entity_id: CLIENT_A },
+    { alga_entity_id: CLIENT_B },
+  ]);
+  importUnmatchedCoreMock.mockResolvedValue({
+    success: true,
+    data: { created: 2, skipped: 1, failed: [] },
+  });
+  syncCoreMock.mockResolvedValue({ state: 'ok', updated: 1, unchanged: 0, stale: 0, rmmSkipped: 0, syncedAt: 'x' });
+  setSyncRunStateMock.mockResolvedValue(undefined);
+});
+
+describe('runHuduTenantSync', () => {
+  it('imports + syncs every mapped client and accumulates the summary', async () => {
+    const { runHuduTenantSync } = await loadTenantSync();
+
+    const summary = await runHuduTenantSync(TENANT, { importNew: true, actorUserId: 'clicker' });
+
+    // import + sync called once per mapped client, with the supplied actor
+    expect(importUnmatchedCoreMock).toHaveBeenCalledTimes(2);
+    expect(importUnmatchedCoreMock).toHaveBeenCalledWith(TENANT, 'clicker', CLIENT_A);
+    expect(syncCoreMock).toHaveBeenCalledTimes(2);
+    expect(syncCoreMock).toHaveBeenCalledWith(TENANT, 'clicker', CLIENT_B);
+
+    expect(summary).toMatchObject({
+      sync_type: 'import',
+      clients: 2,
+      items_created: 4, // 2 per client
+      items_updated: 2, // 1 per client
+      items_skipped: 2, // 1 per client
+      items_failed: 0,
+      errors: [],
+    });
+
+    // status: syncing first, then completed with the summary + a timestamp
+    expect(setSyncRunStateMock).toHaveBeenCalledWith(knexMock, TENANT, { status: 'syncing' });
+    const last = setSyncRunStateMock.mock.calls.at(-1)?.[2];
+    expect(last).toMatchObject({ status: 'completed', error: null });
+    expect(last.lastFullSyncAt).toEqual(expect.any(String));
+  });
+
+  it('refresh-only (importNew=false) never calls the import core', async () => {
+    const { runHuduTenantSync } = await loadTenantSync();
+
+    const summary = await runHuduTenantSync(TENANT, { importNew: false, actorUserId: 'clicker' });
+
+    expect(importUnmatchedCoreMock).not.toHaveBeenCalled();
+    expect(syncCoreMock).toHaveBeenCalledTimes(2);
+    expect(summary.sync_type).toBe('sync');
+    expect(summary.items_updated).toBe(2);
+  });
+
+  it('records per-client errors without aborting and still completes', async () => {
+    importUnmatchedCoreMock
+      .mockResolvedValueOnce({ success: false, error: 'rate limited', code: 'rate_limited', partial: { created: 1, skipped: 0, failed: [] } })
+      .mockResolvedValueOnce({ success: true, data: { created: 3, skipped: 0, failed: [] } });
+    const { runHuduTenantSync } = await loadTenantSync();
+
+    const summary = await runHuduTenantSync(TENANT, { importNew: true, actorUserId: 'clicker' });
+
+    expect(summary.items_created).toBe(4); // 1 partial + 3
+    expect(summary.errors).toHaveLength(1);
+    expect(summary.errors[0]).toContain('rate limited');
+    // The run still finishes (errors are reported in sync_error, status completed).
+    const last = setSyncRunStateMock.mock.calls.at(-1)?.[2];
+    expect(last.status).toBe('completed');
+    expect(last.error).toContain('rate limited');
+  });
+
+  it('resolves the audit user (first internal user) when none is supplied', async () => {
+    const { runHuduTenantSync } = await loadTenantSync();
+
+    await runHuduTenantSync(TENANT, { importNew: true });
+
+    expect(importUnmatchedCoreMock).toHaveBeenCalledWith(TENANT, 'audit-user', CLIENT_A);
+  });
+
+  it('fails closed when the tenant has no user to attribute writes to', async () => {
+    internalUsers = [];
+    anyUsers = [];
+    const { runHuduTenantSync } = await loadTenantSync();
+
+    const summary = await runHuduTenantSync(TENANT, { importNew: true });
+
+    expect(importUnmatchedCoreMock).not.toHaveBeenCalled();
+    expect(summary.errors[0]).toMatch(/No tenant user/);
+    const last = setSyncRunStateMock.mock.calls.at(-1)?.[2];
+    expect(last.status).toBe('error');
+  });
+});

--- a/ee/server/src/__tests__/unit/huduTenantSyncActions.test.ts
+++ b/ee/server/src/__tests__/unit/huduTenantSyncActions.test.ts
@@ -1,0 +1,104 @@
+/**
+ * Hudu tenant-wide sync actions — gating + delegation to runHuduTenantSync,
+ * and the auto-sync toggle (persist settings.autoSync + converge schedule).
+ */
+
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const TENANT = 'tenant-hudu-tsa';
+const internalUser = { user_id: 'clicker', tenant: TENANT, user_type: 'internal' };
+
+const hasPermissionMock = vi.fn();
+const isEnabledMock = vi.fn();
+const assertTierAccessMock = vi.fn();
+const createTenantKnexMock = vi.fn();
+const runHuduTenantSyncMock = vi.fn();
+const mergeHuduSettingsMock = vi.fn();
+const scheduleHuduAutoSyncJobMock = vi.fn();
+
+vi.mock('@alga-psa/auth', () => ({
+  withAuth:
+    (handler: (...args: unknown[]) => Promise<unknown>) =>
+    (...args: unknown[]) =>
+      handler(internalUser, { tenant: TENANT }, ...args),
+  hasPermission: hasPermissionMock,
+}));
+vi.mock('server/src/lib/feature-flags/featureFlags', () => ({ featureFlags: { isEnabled: isEnabledMock } }));
+vi.mock('server/src/lib/tier-gating/assertTierAccess', () => ({ assertTierAccess: assertTierAccessMock }));
+vi.mock('server/src/lib/db', () => ({ createTenantKnex: createTenantKnexMock }));
+vi.mock('@ee/lib/integrations/hudu/tenantSync', () => ({ runHuduTenantSync: runHuduTenantSyncMock }));
+vi.mock('@ee/lib/integrations/hudu/huduIntegrationRepository', async (importOriginal) => ({
+  ...((await importOriginal()) as Record<string, unknown>),
+  mergeHuduSettings: mergeHuduSettingsMock,
+}));
+vi.mock('server/src/lib/jobs/handlers/huduAutoSyncHandler', () => ({
+  scheduleHuduAutoSyncJob: scheduleHuduAutoSyncJobMock,
+}));
+
+async function loadActions() {
+  return import('@ee/lib/actions/integrations/huduTenantSyncActions');
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  hasPermissionMock.mockResolvedValue(true);
+  isEnabledMock.mockResolvedValue(true);
+  assertTierAccessMock.mockResolvedValue(undefined);
+  createTenantKnexMock.mockResolvedValue({ knex: {}, tenant: TENANT });
+  runHuduTenantSyncMock.mockResolvedValue({
+    sync_type: 'import',
+    clients: 1,
+    items_created: 3,
+    items_updated: 1,
+    items_skipped: 0,
+    items_failed: 0,
+    errors: [],
+  });
+});
+
+describe('importAllHuduClients', () => {
+  it('runs the tenant sync with importNew + the clicking user and returns the summary', async () => {
+    const { importAllHuduClients } = await loadActions();
+
+    const result = await importAllHuduClients();
+
+    expect(runHuduTenantSyncMock).toHaveBeenCalledWith(TENANT, { importNew: true, actorUserId: 'clicker' });
+    expect(result).toMatchObject({ success: true, data: { items_created: 3 } });
+  });
+
+  it('requires asset:create', async () => {
+    hasPermissionMock.mockResolvedValue(false);
+    const { importAllHuduClients } = await loadActions();
+    await expect(importAllHuduClients()).rejects.toThrow(/insufficient permissions/);
+    expect(runHuduTenantSyncMock).not.toHaveBeenCalled();
+  });
+});
+
+describe('syncAllHuduClients', () => {
+  it('runs the tenant sync with importNew=false', async () => {
+    const { syncAllHuduClients } = await loadActions();
+    await syncAllHuduClients();
+    expect(runHuduTenantSyncMock).toHaveBeenCalledWith(TENANT, { importNew: false, actorUserId: 'clicker' });
+  });
+});
+
+describe('setHuduAutoSync', () => {
+  it('persists the toggle and converges the schedule', async () => {
+    const { setHuduAutoSync } = await loadActions();
+
+    const result = await setHuduAutoSync({ enabled: true });
+
+    expect(mergeHuduSettingsMock).toHaveBeenCalledWith({}, TENANT, {
+      autoSync: { enabled: true, cadence: 'daily' },
+    });
+    expect(scheduleHuduAutoSyncJobMock).toHaveBeenCalledWith(TENANT);
+    expect(result).toEqual({ success: true, data: { enabled: true, cadence: 'daily' } });
+  });
+
+  it('requires system_settings:update', async () => {
+    hasPermissionMock.mockResolvedValue(false);
+    const { setHuduAutoSync } = await loadActions();
+    await expect(setHuduAutoSync({ enabled: true })).rejects.toThrow(/insufficient permissions/);
+    expect(mergeHuduSettingsMock).not.toHaveBeenCalled();
+  });
+});

--- a/ee/server/src/components/integrations/hudu/HuduAssetMappingManager.tsx
+++ b/ee/server/src/components/integrations/hudu/HuduAssetMappingManager.tsx
@@ -49,7 +49,7 @@ import type {
   HuduAssetBulkImportSummary,
   HuduAssetImportFailure,
   HuduAssetImportResult,
-} from '../../../lib/actions/integrations/huduAssetImportActions';
+} from '../../../lib/integrations/hudu/assetImportCore';
 import { syncHuduClientAssets } from '../../../lib/actions/integrations/huduAssetSyncActions';
 import type { HuduAssetSuggestionSource } from '../../../lib/integrations/hudu/assetMatching';
 

--- a/ee/server/src/components/integrations/hudu/HuduClientDocumentsSection.tsx
+++ b/ee/server/src/components/integrations/hudu/HuduClientDocumentsSection.tsx
@@ -13,7 +13,7 @@ import { Alert, AlertDescription } from '@alga-psa/ui/components/Alert';
 import { BookOpen, ChevronDown, ChevronRight, ExternalLink } from 'lucide-react';
 import { useTranslation } from '@alga-psa/ui/lib/i18n/client';
 import { getHuduCompanyArticles } from '../../../lib/actions/integrations/huduDataActions';
-import type { HuduCompanyDataResult } from '../../../lib/actions/integrations/huduDataActions';
+import type { HuduCompanyDataResult } from '../../../lib/integrations/hudu/huduDataTypes';
 import type { HuduArticle } from '../../../lib/integrations/hudu/contracts';
 
 export interface HuduClientDocumentsSectionProps {

--- a/ee/server/src/components/integrations/hudu/HuduClientPasswordsTab.tsx
+++ b/ee/server/src/components/integrations/hudu/HuduClientPasswordsTab.tsx
@@ -20,10 +20,8 @@ import {
   getHuduCompanyPasswords,
   revealHuduPassword,
 } from '../../../lib/actions/integrations/huduDataActions';
-import type {
-  HuduClientContext,
-  HuduCompanyDataResult,
-} from '../../../lib/actions/integrations/huduDataActions';
+import type { HuduClientContext } from '../../../lib/actions/integrations/huduDataActions';
+import type { HuduCompanyDataResult } from '../../../lib/integrations/hudu/huduDataTypes';
 import type { HuduAssetPasswordSummary } from '../../../lib/integrations/hudu/contracts';
 
 export interface HuduClientPasswordsTabProps {

--- a/ee/server/src/components/integrations/hudu/HuduClientTab.tsx
+++ b/ee/server/src/components/integrations/hudu/HuduClientTab.tsx
@@ -21,11 +21,11 @@ import {
   getHuduCompanyArticles,
   getHuduCompanyAssets,
 } from '../../../lib/actions/integrations/huduDataActions';
+import type { HuduClientContext } from '../../../lib/actions/integrations/huduDataActions';
 import type {
-  HuduClientContext,
   HuduCompanyDataResult,
   HuduLinkedItem,
-} from '../../../lib/actions/integrations/huduDataActions';
+} from '../../../lib/integrations/hudu/huduDataTypes';
 import type { HuduArticle, HuduAsset } from '../../../lib/integrations/hudu/contracts';
 
 export interface HuduClientTabProps {

--- a/ee/server/src/components/settings/integrations/HuduIntegrationSettings.tsx
+++ b/ee/server/src/components/settings/integrations/HuduIntegrationSettings.tsx
@@ -18,6 +18,7 @@ import type { HuduActionResult, HuduConnectionStatusData } from '../../../lib/ac
 import type { HuduErrorKind } from '../../../lib/integrations/hudu/huduClient';
 import HuduCompanyMappingManager from './hudu/HuduCompanyMappingManager';
 import HuduAssetLayoutMapManager from './hudu/HuduAssetLayoutMapManager';
+import HuduSyncAutomationManager from './hudu/HuduSyncAutomationManager';
 
 type ConnectionBadgeState = 'not_connected' | 'connected' | 'error';
 
@@ -407,6 +408,13 @@ export default function HuduIntegrationSettings() {
     {isConnected && (
       <div className="mt-6">
         <HuduAssetLayoutMapManager />
+      </div>
+    )}
+
+    {/* Tenant-wide import + daily auto-sync - shown when connected */}
+    {isConnected && (
+      <div className="mt-6">
+        <HuduSyncAutomationManager />
       </div>
     )}
     </>

--- a/ee/server/src/components/settings/integrations/hudu/HuduSyncAutomationManager.tsx
+++ b/ee/server/src/components/settings/integrations/hudu/HuduSyncAutomationManager.tsx
@@ -1,0 +1,237 @@
+'use client';
+
+import React, { useCallback, useEffect, useState, useTransition } from 'react';
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@alga-psa/ui/components/Card';
+import { Button } from '@alga-psa/ui/components/Button';
+import { Alert, AlertDescription } from '@alga-psa/ui/components/Alert';
+import { Badge } from '@alga-psa/ui/components/Badge';
+import { Switch } from '@alga-psa/ui/components/Switch';
+import { DownloadCloud, RefreshCw } from 'lucide-react';
+import { useToast } from '@alga-psa/ui/hooks/use-toast';
+import { useTranslation } from '@alga-psa/ui/lib/i18n/client';
+import { getHuduConnectionStatus } from '../../../../lib/actions/integrations/huduActions';
+import type { HuduConnectionStatusData } from '../../../../lib/actions/integrations/huduActions';
+import {
+  importAllHuduClients,
+  setHuduAutoSync,
+  syncAllHuduClients,
+} from '../../../../lib/actions/integrations/huduTenantSyncActions';
+import type { HuduTenantSyncActionResult } from '../../../../lib/actions/integrations/huduTenantSyncActions';
+
+const SYNCING_POLL_MS = 4000;
+
+// The EE tsconfig is non-strict, so `!result.success` alone does not narrow.
+function isSyncFailure(
+  result: HuduTenantSyncActionResult
+): result is Extract<HuduTenantSyncActionResult, { success: false }> {
+  return !result.success;
+}
+
+export default function HuduSyncAutomationManager() {
+  const { t } = useTranslation('msp/integrations');
+  const { toast } = useToast();
+
+  const [status, setStatus] = useState<HuduConnectionStatusData | null>(null);
+  const [isImporting, startImport] = useTransition();
+  const [isSyncing, startSync] = useTransition();
+  const [isTogglingAuto, startToggle] = useTransition();
+  const busy = isImporting || isSyncing || isTogglingAuto;
+
+  const loadStatus = useCallback(async () => {
+    const result = await getHuduConnectionStatus();
+    if (result.success) {
+      setStatus(result.data);
+    }
+  }, []);
+
+  useEffect(() => {
+    void loadStatus();
+  }, [loadStatus]);
+
+  // Poll while a tenant-wide run is in flight so the badge + last-run summary
+  // converge without a manual refresh (RMM refreshes after; this also catches
+  // background/auto runs that finish while the page is open).
+  const runInFlight = status?.syncStatus === 'syncing';
+  useEffect(() => {
+    if (!runInFlight) return;
+    const timer = setInterval(() => void loadStatus(), SYNCING_POLL_MS);
+    return () => clearInterval(timer);
+  }, [runInFlight, loadStatus]);
+
+  const summaryText = useCallback(
+    (data: NonNullable<HuduTenantSyncActionResult & { success: true }>['data']) =>
+      t('integrations.hudu.settings.sync.summary', {
+        defaultValue: '{{created}} created · {{updated}} updated · {{skipped}} skipped · {{failed}} failed',
+        created: data.items_created,
+        updated: data.items_updated,
+        skipped: data.items_skipped,
+        failed: data.items_failed,
+      }),
+    [t]
+  );
+
+  const handleImportAll = () => {
+    startImport(async () => {
+      const result = await importAllHuduClients();
+      if (isSyncFailure(result)) {
+        toast({
+          title: t('integrations.hudu.settings.sync.toastErrorTitle', { defaultValue: 'Hudu import failed' }),
+          description: result.error,
+          variant: 'destructive',
+        });
+      } else {
+        toast({
+          title: t('integrations.hudu.settings.sync.importDoneTitle', { defaultValue: 'Hudu import finished' }),
+          description: summaryText(result.data),
+        });
+      }
+      await loadStatus();
+    });
+  };
+
+  const handleSyncAll = () => {
+    startSync(async () => {
+      const result = await syncAllHuduClients();
+      if (isSyncFailure(result)) {
+        toast({
+          title: t('integrations.hudu.settings.sync.toastErrorTitle', { defaultValue: 'Hudu sync failed' }),
+          description: result.error,
+          variant: 'destructive',
+        });
+      } else {
+        toast({
+          title: t('integrations.hudu.settings.sync.syncDoneTitle', { defaultValue: 'Hudu sync finished' }),
+          description: summaryText(result.data),
+        });
+      }
+      await loadStatus();
+    });
+  };
+
+  const handleToggleAutoSync = (enabled: boolean) => {
+    startToggle(async () => {
+      const result = await setHuduAutoSync({ enabled });
+      if (!result.success) {
+        toast({
+          title: t('integrations.hudu.settings.sync.toastErrorTitle', { defaultValue: 'Hudu auto-sync update failed' }),
+          description: result.error,
+          variant: 'destructive',
+        });
+      }
+      await loadStatus();
+    });
+  };
+
+  const syncBadge = () => {
+    switch (status?.syncStatus) {
+      case 'syncing':
+        return (
+          <Badge id="hudu-sync-status-badge" variant="secondary">
+            {t('integrations.hudu.settings.sync.status.syncing', { defaultValue: 'Running…' })}
+          </Badge>
+        );
+      case 'completed':
+        return (
+          <Badge id="hudu-sync-status-badge" variant="success">
+            {t('integrations.hudu.settings.sync.status.completed', { defaultValue: 'Completed' })}
+          </Badge>
+        );
+      case 'error':
+        return (
+          <Badge id="hudu-sync-status-badge" variant="error">
+            {t('integrations.hudu.settings.sync.status.error', { defaultValue: 'Error' })}
+          </Badge>
+        );
+      default:
+        return null;
+    }
+  };
+
+  const lastRunText = () => {
+    const last = status?.lastSync;
+    const at = status?.lastFullSyncAt;
+    if (!last || !at) {
+      return t('integrations.hudu.settings.sync.neverRun', { defaultValue: 'No tenant-wide run yet.' });
+    }
+    return t('integrations.hudu.settings.sync.lastRun', {
+      defaultValue: 'Last run {{at}}: {{created}} created · {{updated}} updated · {{skipped}} skipped · {{failed}} failed',
+      at: new Date(at).toLocaleString(),
+      created: last.items_created,
+      updated: last.items_updated,
+      skipped: last.items_skipped,
+      failed: last.items_failed,
+    });
+  };
+
+  return (
+    <Card id="hudu-sync-automation">
+      <CardHeader>
+        <div className="flex items-start justify-between gap-4">
+          <div>
+            <CardTitle>
+              {t('integrations.hudu.settings.sync.title', { defaultValue: 'Sync & automation' })}
+            </CardTitle>
+            <CardDescription>
+              {t('integrations.hudu.settings.sync.description', {
+                defaultValue:
+                  'Import assets for every mapped client at once, and keep them up to date automatically. Mapping a company or layout only configures the integration — assets appear only after an import.',
+              })}
+            </CardDescription>
+          </div>
+          {syncBadge()}
+        </div>
+      </CardHeader>
+      <CardContent className="space-y-4">
+        {status?.syncStatus === 'error' && status.syncError && (
+          <Alert id="hudu-sync-error" variant="destructive">
+            <AlertDescription>{status.syncError}</AlertDescription>
+          </Alert>
+        )}
+
+        <p id="hudu-sync-last-run" className="text-sm text-muted-foreground">
+          {lastRunText()}
+        </p>
+
+        <div className="flex flex-wrap gap-2">
+          <Button id="hudu-import-all-button" onClick={handleImportAll} disabled={busy || runInFlight}>
+            <DownloadCloud className="mr-2 h-4 w-4" />
+            {isImporting
+              ? t('integrations.hudu.settings.sync.importing', { defaultValue: 'Importing…' })
+              : t('integrations.hudu.settings.sync.importAll', { defaultValue: 'Import all mapped clients' })}
+          </Button>
+          <Button
+            id="hudu-sync-all-button"
+            variant="outline"
+            onClick={handleSyncAll}
+            disabled={busy || runInFlight}
+          >
+            <RefreshCw className="mr-2 h-4 w-4" />
+            {isSyncing
+              ? t('integrations.hudu.settings.sync.syncing2', { defaultValue: 'Syncing…' })
+              : t('integrations.hudu.settings.sync.syncAll', { defaultValue: 'Sync all' })}
+          </Button>
+        </div>
+
+        <div className="flex items-center justify-between rounded-md border p-3">
+          <div>
+            <p className="text-sm font-medium">
+              {t('integrations.hudu.settings.sync.autoSyncLabel', { defaultValue: 'Daily auto-sync' })}
+            </p>
+            <p className="text-xs text-muted-foreground">
+              {t('integrations.hudu.settings.sync.autoSyncHint', {
+                defaultValue:
+                  'Automatically import new assets and refresh existing ones once a day for every mapped client.',
+              })}
+            </p>
+          </div>
+          <Switch
+            id="hudu-auto-sync-toggle"
+            checked={status?.autoSync.enabled === true}
+            onCheckedChange={handleToggleAutoSync}
+            disabled={isTogglingAuto}
+          />
+        </div>
+      </CardContent>
+    </Card>
+  );
+}

--- a/ee/server/src/lib/actions/integrations/huduActions.ts
+++ b/ee/server/src/lib/actions/integrations/huduActions.ts
@@ -32,6 +32,13 @@ import {
   setHuduIntegrationActive,
   upsertHuduIntegration,
 } from '../../integrations/hudu/huduIntegrationRepository';
+import type { HuduSyncStatus } from '../../integrations/hudu/huduIntegrationRepository';
+import type { HuduTenantSyncSummary } from '../../integrations/hudu/tenantSync';
+
+export interface HuduAutoSyncStatus {
+  enabled: boolean;
+  cadence: string;
+}
 
 export interface HuduConnectionStatusData {
   connected: boolean;
@@ -40,6 +47,28 @@ export interface HuduConnectionStatusData {
   connectedAt: string | null;
   lastSyncedAt: string | null;
   passwordAccess: boolean;
+  /** Tenant-wide import/sync run state (RMM-style). */
+  syncStatus: HuduSyncStatus;
+  syncError: string | null;
+  lastFullSyncAt: string | null;
+  lastSync: HuduTenantSyncSummary | null;
+  autoSync: HuduAutoSyncStatus;
+}
+
+const DEFAULT_AUTO_SYNC: HuduAutoSyncStatus = { enabled: false, cadence: 'daily' };
+
+function settingsAutoSync(settings: Record<string, unknown> | null | undefined): HuduAutoSyncStatus {
+  const raw = settings?.autoSync as Partial<HuduAutoSyncStatus> | undefined;
+  if (!raw || typeof raw !== 'object') return DEFAULT_AUTO_SYNC;
+  return {
+    enabled: raw.enabled === true,
+    cadence: typeof raw.cadence === 'string' ? raw.cadence : 'daily',
+  };
+}
+
+function settingsLastSync(settings: Record<string, unknown> | null | undefined): HuduTenantSyncSummary | null {
+  const raw = settings?.last_sync as HuduTenantSyncSummary | undefined;
+  return raw && typeof raw === 'object' ? raw : null;
 }
 
 export interface HuduTestConnectionData {
@@ -105,6 +134,20 @@ function toErrorMessage(error: unknown): string {
 function toIso(value: Date | string | null | undefined): string | null {
   if (value === null || value === undefined) return null;
   return value instanceof Date ? value.toISOString() : String(value);
+}
+
+/**
+ * Converge the daily auto-sync schedule to the tenant's current desired state
+ * (settings.autoSync + is_active). Best-effort: a scheduling blip must never
+ * fail the connect/disconnect flow. Mirrors the RMM connect→reconcile call.
+ */
+async function convergeHuduAutoSyncSchedule(tenant: string): Promise<void> {
+  try {
+    const { scheduleHuduAutoSyncJob } = await import('server/src/lib/jobs/handlers/huduAutoSyncHandler');
+    await scheduleHuduAutoSyncJob(tenant);
+  } catch (error) {
+    logger.warn('[HuduActions] auto-sync schedule converge skipped', { tenant, error: toErrorMessage(error) });
+  }
 }
 
 function sameHuduBaseUrl(left: string, right: string): boolean {
@@ -188,6 +231,10 @@ export const connectHudu = withHuduSettingsAccess(
         settings: { password_access: validation.passwordAccess },
       });
 
+      // Connecting doesn't enable auto-sync (opt-in), but converge so a
+      // previously-enabled toggle is honored on reconnect.
+      await convergeHuduAutoSyncSchedule(tenant);
+
       logger.info('[HuduActions] Hudu connected', { tenant });
 
       return {
@@ -199,6 +246,11 @@ export const connectHudu = withHuduSettingsAccess(
           connectedAt: toIso(row.connected_at),
           lastSyncedAt: toIso(row.last_synced_at),
           passwordAccess: validation.passwordAccess,
+          syncStatus: row.sync_status ?? 'idle',
+          syncError: row.sync_error ?? null,
+          lastFullSyncAt: toIso(row.last_full_sync_at),
+          lastSync: settingsLastSync(row.settings),
+          autoSync: settingsAutoSync(row.settings),
         },
       };
     } catch (error) {
@@ -271,6 +323,11 @@ export const getHuduConnectionStatus = withHuduSettingsAccess(
             connectedAt: null,
             lastSyncedAt: null,
             passwordAccess: false,
+            syncStatus: 'idle',
+            syncError: null,
+            lastFullSyncAt: null,
+            lastSync: null,
+            autoSync: DEFAULT_AUTO_SYNC,
           },
         };
       }
@@ -284,6 +341,11 @@ export const getHuduConnectionStatus = withHuduSettingsAccess(
           connectedAt: toIso(row.connected_at),
           lastSyncedAt: toIso(row.last_synced_at),
           passwordAccess: settingsPasswordAccess(row.settings),
+          syncStatus: row.sync_status ?? 'idle',
+          syncError: row.sync_error ?? null,
+          lastFullSyncAt: toIso(row.last_full_sync_at),
+          lastSync: settingsLastSync(row.settings),
+          autoSync: settingsAutoSync(row.settings),
         },
       };
     } catch (error) {
@@ -312,6 +374,9 @@ export const disconnectHudu = withHuduSettingsAccess(
       // T111: drop this tenant's cached Hudu lists so a reconnect with a new
       // key can never be served data fetched under the old credentials.
       clearHuduReferenceCacheForTenant(tenant);
+
+      // Inactive connection ⇒ cancel any recurring auto-sync schedule.
+      await convergeHuduAutoSyncSchedule(tenant);
 
       logger.info('[HuduActions] Hudu disconnected', { tenant });
 

--- a/ee/server/src/lib/actions/integrations/huduAssetImportActions.ts
+++ b/ee/server/src/lib/actions/integrations/huduAssetImportActions.ts
@@ -3,13 +3,11 @@
 /**
  * Hudu asset import server actions (F214–F218, EE-only).
  *
- * Sibling of huduAssetMappingActions.ts — same EE tier +
- * `hudu-integration` flag chain, but RBAC-gated on `asset` CREATE (FR6).
- * The Hudu asset list rides the Phase 1 fetch+cache path
- * (getHuduCompanyAssets); asset creation goes through the existing
- * createAsset action (FR4). "Atomic" import = create asset → create mapping
- * row; if the mapping write fails the just-created asset is best-effort
- * deleted and the typed failure names the orphan either way.
+ * Thin `withAuth` wrappers over the session-free import core
+ * (integrations/hudu/assetImportCore). The wrapper enforces EE tier +
+ * `hudu-integration` flag + `asset` CREATE (FR6) and passes the clicking
+ * user as the asset audit actor; the core does the work and is shared with the
+ * tenant-wide auto-sync (runHuduTenantSync).
  */
 
 import logger from '@alga-psa/core/logger';
@@ -18,71 +16,21 @@ import type { IUserWithRoles } from '@alga-psa/types';
 import { TIER_FEATURES } from '@alga-psa/types';
 import { featureFlags } from 'server/src/lib/feature-flags/featureFlags';
 import { assertTierAccess } from 'server/src/lib/tier-gating/assertTierAccess';
-import { createTenantKnex } from 'server/src/lib/db';
-import type { Knex } from 'knex';
-import { createAsset, deleteAsset } from '@alga-psa/assets/actions/assetActions';
-import { listAssetTypes } from '@alga-psa/assets/lib/assetTypeRegistry';
-import { getHuduCompanyAssets } from './huduDataActions';
-import type { HuduLinkedItem } from './huduDataActions';
-import type { HuduErrorKind } from '../../integrations/hudu/huduClient';
-import type { HuduAsset } from '../../integrations/hudu/contracts';
 import {
-  getHuduAssetLayoutTypeMap,
-  isLayoutExcluded,
-  resolveAssetTypeForLayout,
-} from '../../integrations/hudu/assetLayoutMap';
-import { projectHuduFieldsOntoSchema } from '../../integrations/hudu/layoutFieldSchema';
-import { suggestHuduAssetMappings } from '../../integrations/hudu/assetMatching';
-import type { AlgaMatcherAsset } from '../../integrations/hudu/assetMatching';
-import {
-  getHuduAssetMappingRows,
-  resolveAlgaAssetIdForHuduAsset,
-  setHuduAssetMappingRow,
-} from '../../integrations/hudu/assetMapping';
-import type { HuduAssetMappingWriteResult } from '../../integrations/hudu/assetMapping';
-import { deriveHuduAssetTag, huduImportAssetStatus } from '../../integrations/hudu/assetImport';
-import { buildHuduFieldsAttribute } from '../../integrations/hudu/assetAttributes';
+  importHuduAssetCore,
+  importUnmatchedHuduAssetsCore,
+} from '../../integrations/hudu/assetImportCore';
+import type {
+  HuduAssetBulkImportResult,
+  HuduAssetBulkImportSummary,
+  HuduAssetImportErrorCode,
+  HuduAssetImportFailure,
+  HuduAssetImportResult,
+} from '../../integrations/hudu/assetImportCore';
 
-export type HuduAssetImportErrorCode =
-  | 'client_not_mapped'
-  | 'hudu_asset_not_found'
-  | 'hudu_asset_already_mapped'
-  | 'layout_excluded'
-  | 'serial_conflict'
-  | 'fetch_failed'
-  | 'rate_limited'
-  | 'create_failed'
-  | 'mapping_failed';
-
-export interface HuduAssetImportFailure {
-  success: false;
-  error: string;
-  code?: HuduAssetImportErrorCode;
-  errorKind?: HuduErrorKind;
-  /** mapping_failed: the asset created right before the mapping write failed. */
-  orphanAssetId?: string;
-  orphanCleanedUp?: boolean;
-  /** serial_conflict: the tenant asset already carrying the serial (F261). */
-  existing_asset_id?: string;
-  existing_asset_name?: string;
-  existing_client_id?: string;
-}
-
-export type HuduAssetImportResult =
-  | {
-      success: true;
-      data: {
-        asset_id: string;
-        mapping_id: string;
-        asset_tag: string;
-        /** Built-in slug or a registry custom slug (F315). */
-        asset_type: string;
-        status: string;
-        /** F317: schema keys whose Hudu value failed projection validation. */
-        projection_skipped?: string[];
-      };
-    }
-  | HuduAssetImportFailure;
+// These types are NOT re-exported: a `'use server'` module may only export
+// async actions (Next turns a type re-export into a missing value export).
+// Import them from integrations/hudu/assetImportCore directly.
 
 export interface ImportHuduAssetInput {
   clientId: string;
@@ -92,29 +40,6 @@ export interface ImportHuduAssetInput {
 export interface ImportAllUnmatchedHuduAssetsInput {
   clientId: string;
 }
-
-export interface HuduAssetBulkImportSummary {
-  created: number;
-  /** F258: unmatched assets whose layout is marked "Don't import" (FR8). */
-  skipped: number;
-  failed: Array<{
-    huduAssetId: number;
-    error: string;
-    code?: HuduAssetImportErrorCode;
-    /** serial_conflict rows carry the existing asset's name for the UI (F262). */
-    existing_asset_name?: string;
-  }>;
-}
-
-export type HuduAssetBulkImportResult =
-  | { success: true; data: HuduAssetBulkImportSummary }
-  | {
-      success: false;
-      error: string;
-      code?: HuduAssetImportErrorCode;
-      errorKind?: HuduErrorKind;
-      partial: HuduAssetBulkImportSummary;
-    };
 
 function withHuduAssetCreateAccess<TArgs extends unknown[], TResult>(
   handler: (user: IUserWithRoles, context: { tenant: string }, ...args: TArgs) => Promise<TResult>
@@ -147,214 +72,15 @@ function toErrorMessage(error: unknown): string {
   return error instanceof Error ? error.message : String(error);
 }
 
-function fetchFailure(
-  result: Exclude<Awaited<ReturnType<typeof getHuduCompanyAssets>>, { state: 'ok' }>
-): HuduAssetImportFailure {
-  if (result.state === 'unmapped') {
-    return { success: false, error: 'Client is not mapped to a Hudu company.', code: 'client_not_mapped' };
-  }
-  const error = result.state === 'error' ? result.error : result.state;
-  const errorKind = result.state === 'error' ? result.errorKind : undefined;
-  return {
-    success: false,
-    error,
-    code: errorKind === 'rate_limited' ? 'rate_limited' : 'fetch_failed',
-    ...(errorKind ? { errorKind } : {}),
-  };
-}
-
-async function cleanUpOrphanAsset(assetId: string): Promise<boolean> {
-  try {
-    const result = await deleteAsset(assetId, { suppressRevalidate: true });
-    return result?.success === true;
-  } catch {
-    return false;
-  }
-}
-
-/**
- * F261: tenant-wide lookup for an existing asset already carrying the Hudu
- * asset's serial (trimmed, case-insensitive). Blank serials never conflict.
- */
-async function findSerialConflict(
-  knex: Knex,
-  tenant: string,
-  primarySerial: string | null | undefined
-): Promise<{ asset_id: string; name: string; client_id: string | null } | null> {
-  const serial = (primarySerial ?? '').trim();
-  if (!serial) {
-    return null;
-  }
-  const existing = await knex('assets')
-    .where({ tenant })
-    .whereRaw('lower(trim(serial_number)) = ?', [serial.toLowerCase()])
-    .first('asset_id', 'name', 'client_id');
-  return existing ?? null;
-}
-
-/**
- * Single-asset import core, shared by both actions. Fetches via the Phase 1
- * cached path, so bulk callers mostly hit the server cache per item — and a
- * mid-batch 429 surfaces here as a typed rate_limited failure (F218).
- */
-async function importHuduAssetCore(
-  tenant: string,
-  clientId: string,
-  huduAssetId: string | number
-): Promise<HuduAssetImportResult> {
-  const assetsResult = await getHuduCompanyAssets(clientId);
-  if (assetsResult.state !== 'ok') {
-    return fetchFailure(assetsResult);
-  }
-
-  const huduAsset = (assetsResult.items as Array<HuduLinkedItem<HuduAsset>>).find(
-    (a) => String(a.id) === String(huduAssetId)
-  );
-  if (!huduAsset) {
-    return {
-      success: false,
-      error: `Hudu asset ${huduAssetId} was not found for this company.`,
-      code: 'hudu_asset_not_found',
-    };
-  }
-
-  const { knex } = await createTenantKnex(tenant);
-
-  const mappedAssetId = await resolveAlgaAssetIdForHuduAsset(knex, tenant, huduAsset.id);
-  if (mappedAssetId) {
-    return {
-      success: false,
-      error: `Hudu asset ${huduAsset.id} is already mapped to an asset. Clear that mapping first.`,
-      code: 'hudu_asset_already_mapped',
-    };
-  }
-
-  const layoutMap = await getHuduAssetLayoutTypeMap(knex, tenant);
-  // F258: excluded layouts fail typed before any serial/tag work (FR8).
-  if (huduAsset.asset_layout_id != null && isLayoutExcluded(layoutMap, huduAsset.asset_layout_id)) {
-    return {
-      success: false,
-      error: `Hudu asset ${huduAsset.id} belongs to a layout marked "Don't import".`,
-      code: 'layout_excluded',
-    };
-  }
-
-  // F261: a tenant-wide serial collision fails typed before anything is created.
-  const serialConflict = await findSerialConflict(knex, tenant, huduAsset.primary_serial);
-  if (serialConflict) {
-    return {
-      success: false,
-      error: `An asset with serial number "${(huduAsset.primary_serial ?? '').trim()}" already exists: "${serialConflict.name}".`,
-      code: 'serial_conflict',
-      existing_asset_id: serialConflict.asset_id,
-      existing_asset_name: serialConflict.name,
-      ...(serialConflict.client_id ? { existing_client_id: serialConflict.client_id } : {}),
-    };
-  }
-
-  // F315: a configured custom slug only resolves when it's still in the
-  // tenant's registry; F317: a custom target additionally gets the Hudu field
-  // values projected onto its fields_schema keys.
-  const registryTypes = await listAssetTypes(knex, tenant);
-  const assetType =
-    huduAsset.asset_layout_id != null
-      ? resolveAssetTypeForLayout(
-          layoutMap,
-          huduAsset.asset_layout_id,
-          new Set(registryTypes.map((type) => type.slug))
-        )
-      : 'unknown';
-  const customType = registryTypes.find((type) => type.slug === assetType && !type.is_builtin);
-  const projection = customType
-    ? projectHuduFieldsOntoSchema(customType.fields_schema, huduAsset.fields)
-    : { attributes: {}, skipped: [] };
-
-  const assetTag = await deriveHuduAssetTag(knex, tenant, {
-    huduAssetId: huduAsset.id,
-    primarySerial: huduAsset.primary_serial,
-  });
-  const status = huduImportAssetStatus();
-
-  // One write: projected schema keys + the Hudu namespace ride createAsset's
-  // attributes payload (F317) — no post-create jsonb merge anymore.
-  let createdAssetId: string;
-  try {
-    const created = await createAsset(
-      {
-        asset_type: assetType,
-        client_id: clientId,
-        asset_tag: assetTag,
-        name: huduAsset.name,
-        status,
-        serial_number: huduAsset.primary_serial ?? undefined,
-        attributes: {
-          ...projection.attributes,
-          hudu_fields: buildHuduFieldsAttribute(huduAsset.fields),
-          hudu_synced_at: new Date().toISOString(),
-        },
-      },
-      // F317: a required custom field missing from Hudu must not fail the import;
-      // it's skipped (raw value stays in hudu_fields), matching the projection.
-      { requireCustomAttributes: false }
-    );
-    createdAssetId = created.asset_id;
-  } catch (error) {
-    return { success: false, error: toErrorMessage(error), code: 'create_failed' };
-  }
-
-  let mappingError: string;
-  try {
-    const mappingResult = await setHuduAssetMappingRow(knex, tenant, {
-      assetId: createdAssetId,
-      huduAssetId: huduAsset.id,
-      huduCompanyId: assetsResult.huduCompanyId,
-      metadata: {
-        hudu_asset_name: huduAsset.name,
-        asset_layout_id: huduAsset.asset_layout_id ?? null,
-        asset_layout_name: huduAsset.asset_type ?? null,
-        primary_serial: huduAsset.primary_serial ?? null,
-        url: huduAsset.hudu_url ?? huduAsset.url ?? null,
-      },
-    });
-    if (mappingResult.ok) {
-      return {
-        success: true,
-        data: {
-          asset_id: createdAssetId,
-          mapping_id: mappingResult.mapping.id,
-          asset_tag: assetTag,
-          asset_type: assetType,
-          status,
-          ...(projection.skipped.length > 0 ? { projection_skipped: projection.skipped } : {}),
-        },
-      };
-    }
-    mappingError = (mappingResult as Extract<HuduAssetMappingWriteResult, { ok: false }>).message;
-  } catch (error) {
-    mappingError = toErrorMessage(error);
-  }
-
-  const cleanedUp = await cleanUpOrphanAsset(createdAssetId);
-  return {
-    success: false,
-    error: cleanedUp
-      ? `Mapping failed after asset creation; the created asset ${createdAssetId} was removed. ${mappingError}`
-      : `Mapping failed after asset creation; asset ${createdAssetId} was created but is not mapped. ${mappingError}`,
-    code: 'mapping_failed',
-    orphanAssetId: createdAssetId,
-    orphanCleanedUp: cleanedUp,
-  };
-}
-
 /** F214–F216: import one Hudu asset into Alga and map it. */
 export const importHuduAsset = withHuduAssetCreateAccess(
-  async (_user, { tenant }, input: ImportHuduAssetInput): Promise<HuduAssetImportResult> => {
+  async (user, { tenant }, input: ImportHuduAssetInput): Promise<HuduAssetImportResult> => {
     try {
       if (!input?.clientId || input?.huduAssetId === undefined || input?.huduAssetId === null) {
         return { success: false, error: 'clientId and huduAssetId are required.' };
       }
 
-      const result = await importHuduAssetCore(tenant, input.clientId, input.huduAssetId);
+      const result = await importHuduAssetCore(tenant, user.user_id, input.clientId, input.huduAssetId);
 
       if (result.success) {
         logger.info('[HuduAssetImportActions] asset imported', {
@@ -373,93 +99,24 @@ export const importHuduAsset = withHuduAssetCreateAccess(
   }
 );
 
-/**
- * F217/F218: import every plain-Unmapped Hudu asset (no mapping row, no
- * suggestion) sequentially. Excluded-layout assets are skipped (counted in
- * the summary, F258). Per-item failures are isolated into the summary;
- * a rate-limited Hudu fetch stops the batch with the partial summary.
- */
+/** F217/F218: import every plain-unmatched Hudu asset for a mapped client. */
 export const importAllUnmatchedHuduAssets = withHuduAssetCreateAccess(
-  async (_user, { tenant }, input: ImportAllUnmatchedHuduAssetsInput): Promise<HuduAssetBulkImportResult> => {
+  async (user, { tenant }, input: ImportAllUnmatchedHuduAssetsInput): Promise<HuduAssetBulkImportResult> => {
     const summary: HuduAssetBulkImportSummary = { created: 0, skipped: 0, failed: [] };
     try {
       if (!input?.clientId) {
         return { success: false, error: 'clientId is required.', partial: summary };
       }
 
-      const assetsResult = await getHuduCompanyAssets(input.clientId);
-      if (assetsResult.state !== 'ok') {
-        const failure = fetchFailure(assetsResult);
-        return { ...failure, partial: summary };
-      }
-
-      const huduAssets = assetsResult.items as Array<HuduLinkedItem<HuduAsset>>;
-      const { knex } = await createTenantKnex(tenant);
-
-      const mappingRows = await getHuduAssetMappingRows(knex, tenant, {
-        huduCompanyId: assetsResult.huduCompanyId,
-      });
-      const mappedHuduAssetIds = new Set(mappingRows.map((m) => m.external_entity_id));
-
-      const algaAssets: AlgaMatcherAsset[] = await knex('assets')
-        .where({ tenant, client_id: input.clientId })
-        .select('asset_id', 'name as asset_name', 'serial_number');
-      const suggestions = suggestHuduAssetMappings(
-        huduAssets,
-        algaAssets,
-        mappingRows.map((m) => ({ asset_id: m.alga_entity_id, hudu_asset_id: m.external_entity_id }))
-      );
-
-      const unmatched = huduAssets.filter(
-        (asset) => !mappedHuduAssetIds.has(String(asset.id)) && !suggestions.has(asset.id)
-      );
-
-      const layoutMap = await getHuduAssetLayoutTypeMap(knex, tenant);
-      const importable = unmatched.filter(
-        (asset) => !(asset.asset_layout_id != null && isLayoutExcluded(layoutMap, asset.asset_layout_id))
-      );
-      summary.skipped = unmatched.length - importable.length;
-
-      for (const asset of importable) {
-        const result = await importHuduAssetCore(tenant, input.clientId, asset.id);
-        if (result.success) {
-          summary.created += 1;
-          continue;
-        }
-        const failure = result as HuduAssetImportFailure;
-        if (failure.code === 'rate_limited') {
-          logger.warn('[HuduAssetImportActions] bulk import stopped on rate limit', {
-            tenant,
-            clientId: input.clientId,
-            created: summary.created,
-            skipped: summary.skipped,
-            failed: summary.failed.length,
-          });
-          return {
-            success: false,
-            error: failure.error,
-            code: 'rate_limited',
-            errorKind: 'rate_limited',
-            partial: summary,
-          };
-        }
-        summary.failed.push({
-          huduAssetId: asset.id,
-          error: failure.error,
-          ...(failure.code ? { code: failure.code } : {}),
-          ...(failure.existing_asset_name ? { existing_asset_name: failure.existing_asset_name } : {}),
-        });
-      }
+      const result = await importUnmatchedHuduAssetsCore(tenant, user.user_id, input.clientId);
 
       logger.info('[HuduAssetImportActions] bulk import finished', {
         tenant,
         clientId: input.clientId,
-        created: summary.created,
-        skipped: summary.skipped,
-        failed: summary.failed.length,
+        ...(result.success ? result.data : result.partial),
       });
 
-      return { success: true, data: summary };
+      return result;
     } catch (error) {
       logger.error('[HuduAssetImportActions] importAllUnmatchedHuduAssets failed', {
         tenant,

--- a/ee/server/src/lib/actions/integrations/huduAssetMappingActions.ts
+++ b/ee/server/src/lib/actions/integrations/huduAssetMappingActions.ts
@@ -22,7 +22,7 @@ import { assertTierAccess } from 'server/src/lib/tier-gating/assertTierAccess';
 import { createTenantKnex } from 'server/src/lib/db';
 import type { Knex } from 'knex';
 import { getHuduCompanyAssets } from './huduDataActions';
-import type { HuduCompanyFetchOptions, HuduLinkedItem } from './huduDataActions';
+import type { HuduCompanyFetchOptions, HuduLinkedItem } from '../../integrations/hudu/huduDataCore';
 import type { HuduErrorKind } from '../../integrations/hudu/huduClient';
 import type { HuduAsset } from '../../integrations/hudu/contracts';
 import { resolveHuduCompanyIdForClient as resolveHuduCompanyIdForClientRow } from '../../integrations/hudu/companyMapping';

--- a/ee/server/src/lib/actions/integrations/huduAssetSyncActions.ts
+++ b/ee/server/src/lib/actions/integrations/huduAssetSyncActions.ts
@@ -1,51 +1,29 @@
 'use server';
 
 /**
- * Hudu manual pull-sync server actions (F219–F222, EE-only).
+ * Hudu manual pull-sync server action (F219–F222, EE-only).
  *
- * Sibling of huduAssetMappingActions.ts (same guard chain, asset RBAC, here
- * `update`). Sync force-refreshes the mapped company's Hudu assets through
- * the Phase 1 fetch and pull-updates ONLY the synced fields (`name`,
- * `serial_number`) plus the Hudu attributes namespace (F253: hudu_fields /
- * hudu_synced_at, jsonb-merged) on mapped Alga assets — never `asset_type`
- * or any other field, never deletes assets or mappings. Archived/missing
- * Hudu assets flag the mapping `stale` (attributes untouched); reappearance
- * clears the flag. F260: assets with `rmm_provider` set are RMM-owned —
- * their name/serial diffs are suppressed (counted as `rmmSkipped`) while the
- * Hudu attributes namespace and stale flags are handled normally.
+ * Thin `withAuth` wrapper over the session-free sync core
+ * (integrations/hudu/assetSyncCore). Enforces EE tier + `hudu-integration`
+ * flag + `asset` UPDATE and passes the clicking user as the asset audit actor;
+ * the core does the work and is shared with the tenant-wide auto-sync.
  */
 
 import logger from '@alga-psa/core/logger';
 import { withAuth, hasPermission } from '@alga-psa/auth';
 import type { IUserWithRoles } from '@alga-psa/types';
 import { TIER_FEATURES } from '@alga-psa/types';
-import { updateAsset } from '@alga-psa/assets/actions/assetActions';
 import { featureFlags } from 'server/src/lib/feature-flags/featureFlags';
 import { assertTierAccess } from 'server/src/lib/tier-gating/assertTierAccess';
-import { createTenantKnex } from 'server/src/lib/db';
-import type { Knex } from 'knex';
-import { getHuduCompanyAssets } from './huduDataActions';
-import type { HuduErrorKind } from '../../integrations/hudu/huduClient';
-import type { HuduAsset } from '../../integrations/hudu/contracts';
-import {
-  getHuduAssetMappingRows,
-  setHuduAssetMappingStale,
-  touchHuduAssetMappingsSynced,
-} from '../../integrations/hudu/assetMapping';
-import {
-  buildHuduFieldsAttribute,
-  huduFieldsChanged,
-  writeHuduAssetAttributes,
-} from '../../integrations/hudu/assetAttributes';
+import { syncHuduClientAssetsCore } from '../../integrations/hudu/assetSyncCore';
+import type { HuduAssetSyncResult } from '../../integrations/hudu/assetSyncCore';
+
+// HuduAssetSyncResult is not re-exported (this is a `'use server'` module —
+// only async actions may be exported). Import it from assetSyncCore directly.
 
 export interface SyncHuduClientAssetsInput {
   clientId: string;
 }
-
-export type HuduAssetSyncResult =
-  | { state: 'ok'; updated: number; unchanged: number; stale: number; rmmSkipped: number; syncedAt: string }
-  | { state: 'unmapped' }
-  | { state: 'error'; error: string; errorKind?: HuduErrorKind };
 
 type HuduActionPermission = 'read' | 'update';
 
@@ -77,156 +55,21 @@ function withHuduAssetAccess<TArgs extends unknown[], TResult>(
   });
 }
 
-function toErrorMessage(error: unknown): string {
-  return error instanceof Error ? error.message : String(error);
-}
-
-async function listMappedAssets(
-  knex: Knex,
-  tenant: string,
-  assetIds: string[]
-): Promise<
-  Array<{
-    asset_id: string;
-    name: string;
-    serial_number: string | null;
-    attributes: Record<string, unknown> | null;
-    rmm_provider: string | null;
-  }>
-> {
-  if (assetIds.length === 0) {
-    return [];
-  }
-  return knex('assets')
-    .where({ tenant })
-    .whereIn('asset_id', assetIds)
-    .select('asset_id', 'name', 'serial_number', 'attributes', 'rmm_provider');
-}
-
-/** The only fields sync ever writes (FR7/F220: Hudu wins on these alone). */
-function syncedFieldChanges(
-  huduAsset: HuduAsset,
-  algaAsset: { name: string; serial_number: string | null } | undefined
-): { name?: string; serial_number?: string } {
-  const changes: { name?: string; serial_number?: string } = {};
-  if (!algaAsset) {
-    return changes;
-  }
-  if (huduAsset.name && huduAsset.name !== algaAsset.name) {
-    changes.name = huduAsset.name;
-  }
-  const huduSerial = huduAsset.primary_serial ?? null;
-  if (huduSerial !== null && huduSerial !== (algaAsset.serial_number ?? null)) {
-    changes.serial_number = huduSerial;
-  }
-  return changes;
-}
-
-/**
- * F219–F222: re-fetch the mapped company's Hudu assets (cache bypassed) and
- * walk the company's mapping rows: present+live ⇒ update changed synced
- * fields and clear `stale`; archived/missing ⇒ set `stale` (never delete).
- * All processed rows get `last_synced_at`; returns the count summary.
- */
 export const syncHuduClientAssets = withHuduAssetAccess(
   'update',
-  async (_user, { tenant }, input: SyncHuduClientAssetsInput): Promise<HuduAssetSyncResult> => {
+  async (user, { tenant }, input: SyncHuduClientAssetsInput): Promise<HuduAssetSyncResult> => {
+    if (!input?.clientId) {
+      return { state: 'error', error: 'clientId is required.' };
+    }
     try {
-      if (!input?.clientId) {
-        return { state: 'error', error: 'clientId is required.' };
-      }
-
-      const assetsResult = await getHuduCompanyAssets(input.clientId, { refresh: true });
-      if (assetsResult.state === 'unmapped') {
-        return { state: 'unmapped' };
-      }
-      if (assetsResult.state !== 'ok') {
-        return {
-          state: 'error',
-          error: assetsResult.state === 'error' ? assetsResult.error : assetsResult.state,
-          ...(assetsResult.state === 'error' && assetsResult.errorKind ? { errorKind: assetsResult.errorKind } : {}),
-        };
-      }
-
-      const huduAssetById = new Map(assetsResult.items.map((asset) => [String(asset.id), asset]));
-      const { knex } = await createTenantKnex(tenant);
-
-      const mappingRows = await getHuduAssetMappingRows(knex, tenant, {
-        huduCompanyId: assetsResult.huduCompanyId,
-      });
-      const algaAssets = await listMappedAssets(knex, tenant, mappingRows.map((m) => m.alga_entity_id));
-      const algaAssetById = new Map(algaAssets.map((a) => [String(a.asset_id), a]));
-
-      let updated = 0;
-      let unchanged = 0;
-      let stale = 0;
-      let rmmSkipped = 0;
-      const syncedAt = new Date().toISOString();
-
-      for (const mapping of mappingRows) {
-        const huduAsset = huduAssetById.get(mapping.external_entity_id);
-        const wasStale = mapping.metadata?.stale === true;
-
-        if (!huduAsset || huduAsset.archived === true) {
-          stale += 1;
-          if (!wasStale) {
-            await setHuduAssetMappingStale(knex, tenant, { mappingId: mapping.id }, true);
-          }
-          continue;
-        }
-
-        const algaAsset = algaAssetById.get(mapping.alga_entity_id);
-        const changes = syncedFieldChanges(huduAsset, algaAsset);
-        let rowChanged = false;
-        if (Object.keys(changes).length > 0) {
-          // F260: an RMM owns device facts on its assets — Hudu never writes
-          // name/serial there; the suppressed diff is surfaced as rmmSkipped.
-          if (algaAsset?.rmm_provider) {
-            rmmSkipped += 1;
-          } else {
-            await updateAsset(mapping.alga_entity_id, changes);
-            rowChanged = true;
-          }
-        }
-        // F253: the Hudu namespace is always Hudu-won — refreshed on every
-        // mapped live asset via jsonb merge (sibling attributes keys survive).
-        if (algaAsset) {
-          const nextFields = buildHuduFieldsAttribute(huduAsset.fields);
-          if (huduFieldsChanged(algaAsset.attributes?.hudu_fields, nextFields)) {
-            rowChanged = true;
-          }
-          await writeHuduAssetAttributes(knex, tenant, mapping.alga_entity_id, nextFields, syncedAt);
-        }
-        if (rowChanged) {
-          updated += 1;
-        } else {
-          unchanged += 1;
-        }
-        if (wasStale) {
-          await setHuduAssetMappingStale(knex, tenant, { mappingId: mapping.id }, false);
-        }
-      }
-
-      await touchHuduAssetMappingsSynced(knex, tenant, mappingRows.map((m) => m.id), syncedAt);
-
-      logger.info('[HuduAssetSyncActions] sync completed', {
-        tenant,
-        clientId: input.clientId,
-        huduCompanyId: assetsResult.huduCompanyId,
-        updated,
-        unchanged,
-        stale,
-        rmmSkipped,
-      });
-
-      return { state: 'ok', updated, unchanged, stale, rmmSkipped, syncedAt };
+      return await syncHuduClientAssetsCore(tenant, user.user_id, input.clientId);
     } catch (error) {
       logger.error('[HuduAssetSyncActions] syncHuduClientAssets failed', {
         tenant,
         clientId: input?.clientId,
-        error: toErrorMessage(error),
+        error: error instanceof Error ? error.message : String(error),
       });
-      return { state: 'error', error: toErrorMessage(error) };
+      return { state: 'error', error: error instanceof Error ? error.message : String(error) };
     }
   }
 );

--- a/ee/server/src/lib/actions/integrations/huduDataActions.ts
+++ b/ee/server/src/lib/actions/integrations/huduDataActions.ts
@@ -15,6 +15,9 @@
  * every successful reveal writes an audit row first (no audit ⇒ no value).
  * NFR4: every fetch is per-mapped-company and unmapped clients short-circuit
  * before any Hudu call.
+ *
+ * The session-free fetch/cache/link plumbing lives in huduDataCore.ts so the
+ * tenant-wide import/sync core can reuse it from a background job.
  */
 
 import logger from '@alga-psa/core/logger';
@@ -24,23 +27,22 @@ import { TIER_FEATURES } from '@alga-psa/types';
 import { featureFlags } from 'server/src/lib/feature-flags/featureFlags';
 import { assertTierAccess } from 'server/src/lib/tier-gating/assertTierAccess';
 import { createTenantKnex } from 'server/src/lib/db';
-import type { Knex } from 'knex';
 import { createHuduClient, HuduRequestError } from '../../integrations/hudu/huduClient';
-import type { HuduClient, HuduErrorKind } from '../../integrations/hudu/huduClient';
+import type { HuduErrorKind } from '../../integrations/hudu/huduClient';
 import { getHuduIntegration } from '../../integrations/hudu/huduIntegrationRepository';
-import {
-  parseCompaniesCache,
-  resolveHuduCompanyIdForClient as resolveHuduCompanyIdForClientRow,
-} from '../../integrations/hudu/companyMapping';
-import {
-  buildHuduCompanyUrl,
-  buildHuduRecordUrl,
-  getCachedHuduList,
-  setCachedHuduList,
-  toHuduAssetPasswordSummary,
-} from '../../integrations/hudu/referenceData';
-import type { HuduReferenceResource } from '../../integrations/hudu/referenceData';
+import { resolveHuduCompanyIdForClient as resolveHuduCompanyIdForClientRow } from '../../integrations/hudu/companyMapping';
+import { toHuduAssetPasswordSummary } from '../../integrations/hudu/referenceData';
 import { writeHuduPasswordRevealAudit } from '../../integrations/hudu/revealAudit';
+import {
+  fetchCompanyList,
+  fetchHuduCompanyAssets,
+  toErrorMessage,
+} from '../../integrations/hudu/huduDataCore';
+import type {
+  HuduCompanyDataResult,
+  HuduCompanyFetchOptions,
+  HuduLinkedItem,
+} from '../../integrations/hudu/huduDataCore';
 import type {
   HuduArticle,
   HuduAsset,
@@ -48,21 +50,10 @@ import type {
   HuduAssetPasswordSummary,
 } from '../../integrations/hudu/contracts';
 
-export type HuduLinkedItem<T> = T & { hudu_url: string | null };
-
-export type HuduCompanyDataResult<TItem> =
-  | {
-      state: 'ok';
-      items: Array<HuduLinkedItem<TItem>>;
-      count: number;
-      huduCompanyId: string;
-      companyUrl: string | null;
-      fetchedAt: string;
-      fromCache: boolean;
-    }
-  | { state: 'unmapped' }
-  | { state: 'no_password_access' }
-  | { state: 'error'; error: string; errorKind?: HuduErrorKind };
+// NB: HuduLinkedItem / HuduCompanyDataResult / HuduCompanyFetchOptions are NOT
+// re-exported here — a `'use server'` module may only export async actions, and
+// Next's compiler turns a type re-export into a (missing) value export. Import
+// those types from integrations/hudu/huduDataCore directly.
 
 export type HuduRevealPasswordResult =
   | { state: 'ok'; value: string }
@@ -70,11 +61,6 @@ export type HuduRevealPasswordResult =
   | { state: 'not_found' }
   | { state: 'no_password_access' }
   | { state: 'error'; error: string; errorKind?: HuduErrorKind };
-
-export interface HuduCompanyFetchOptions {
-  /** Bypass the short-lived server cache and repopulate it. */
-  refresh?: boolean;
-}
 
 /** F070: light gating probe for the client "Hudu"/"Passwords" tabs. */
 export interface HuduClientContext {
@@ -112,88 +98,6 @@ function withHuduSettingsAccess<TArgs extends unknown[], TResult>(
   });
 }
 
-function toErrorMessage(error: unknown): string {
-  return error instanceof Error ? error.message : String(error);
-}
-
-function toErrorResult(error: unknown): { state: 'error'; error: string; errorKind?: HuduErrorKind } {
-  return {
-    state: 'error',
-    error: toErrorMessage(error),
-    ...(error instanceof HuduRequestError ? { errorKind: error.hudu.kind } : {}),
-  };
-}
-
-async function resolveCompanyUrl(
-  knex: Knex,
-  tenant: string,
-  huduCompanyId: string
-): Promise<{ baseUrl: string | null; companyUrl: string | null }> {
-  const row = await getHuduIntegration(knex, tenant);
-  const baseUrl = row?.base_url ?? null;
-  const company =
-    parseCompaniesCache(row?.settings)?.companies.find((c) => String(c.id) === huduCompanyId) ?? null;
-  return { baseUrl, companyUrl: buildHuduCompanyUrl(company, baseUrl) };
-}
-
-/**
- * Shared list flow: resolve mapping (unmapped ⇒ typed state, NO Hudu call),
- * serve from the per-(tenant,company,resource) cache inside the TTL unless
- * refresh, else live-fetch (paginated, per company), project (passwords are
- * value-stripped here, BEFORE caching), then attach deep-links: the record's
- * own url → the company url → null.
- */
-async function fetchCompanyList<TRaw, TItem extends { url?: string | null }>(
-  tenant: string,
-  clientId: string,
-  resource: HuduReferenceResource,
-  refresh: boolean,
-  fetcher: (client: HuduClient, companyId: number) => Promise<TRaw[]>,
-  project: (raw: TRaw) => TItem
-): Promise<HuduCompanyDataResult<TItem>> {
-  try {
-    const { knex } = await createTenantKnex(tenant);
-
-    const huduCompanyId = await resolveHuduCompanyIdForClientRow(knex, tenant, clientId);
-    if (!huduCompanyId) {
-      return { state: 'unmapped' };
-    }
-
-    const cached = refresh ? null : getCachedHuduList<TItem>(tenant, huduCompanyId, resource);
-    let items: TItem[];
-    let fetchedAt: string;
-    let fromCache = true;
-    if (cached) {
-      items = cached.items;
-      fetchedAt = cached.fetchedAt;
-    } else {
-      const client = await createHuduClient(tenant);
-      items = (await fetcher(client, Number(huduCompanyId))).map(project);
-      fetchedAt = new Date().toISOString();
-      setCachedHuduList(tenant, huduCompanyId, resource, items, fetchedAt);
-      fromCache = false;
-    }
-
-    const { baseUrl, companyUrl } = await resolveCompanyUrl(knex, tenant, huduCompanyId);
-
-    return {
-      state: 'ok',
-      items: items.map((item) => ({ ...item, hudu_url: buildHuduRecordUrl(item, baseUrl) ?? companyUrl })),
-      count: items.length,
-      huduCompanyId,
-      companyUrl,
-      fetchedAt,
-      fromCache,
-    };
-  } catch (error) {
-    if (error instanceof HuduRequestError && error.hudu.kind === 'no_password_access') {
-      return { state: 'no_password_access' };
-    }
-    logger.error('[HuduDataActions] fetch failed', { tenant, clientId, resource, error: toErrorMessage(error) });
-    return toErrorResult(error);
-  }
-}
-
 /**
  * F070: is Hudu connected for the tenant AND is this client mapped to a Hudu
  * company? One cheap call (no Hudu traffic) for the client-tab visibility
@@ -229,15 +133,7 @@ export const getHuduCompanyAssets = withHuduSettingsAccess(
     { tenant },
     clientId: string,
     options?: HuduCompanyFetchOptions
-  ): Promise<HuduCompanyDataResult<HuduAsset>> =>
-    fetchCompanyList<HuduAsset, HuduAsset>(
-      tenant,
-      clientId,
-      'assets',
-      options?.refresh === true,
-      (client, companyId) => client.getAssets(companyId),
-      (asset) => asset
-    )
+  ): Promise<HuduCompanyDataResult<HuduAsset>> => fetchHuduCompanyAssets(tenant, clientId, options)
 );
 
 /** F061: a mapped client's Hudu articles. */
@@ -343,7 +239,9 @@ export const revealHuduPassword = withHuduSettingsAccess(
         huduPasswordId: String(huduPasswordId),
         error: toErrorMessage(error),
       });
-      return toErrorResult(error);
+      return error instanceof HuduRequestError
+        ? { state: 'error', error: toErrorMessage(error), errorKind: error.hudu.kind }
+        : { state: 'error', error: toErrorMessage(error) };
     }
   }
 );

--- a/ee/server/src/lib/actions/integrations/huduTenantSyncActions.ts
+++ b/ee/server/src/lib/actions/integrations/huduTenantSyncActions.ts
@@ -1,0 +1,142 @@
+'use server';
+
+/**
+ * Hudu tenant-wide sync server actions (EE-only).
+ *
+ * Config-screen triggers for the whole tenant: import every mapped client's
+ * unmatched assets (+ refresh), refresh-only, and the opt-in daily auto-sync
+ * toggle. All run the shared runHuduTenantSync engine and report an
+ * RMM-style summary; the toggle persists settings.autoSync and converges the
+ * recurring job schedule. Gating mirrors the per-client Hudu actions: EE tier +
+ * `hudu-integration` flag, `asset` create/update for the runs, `system_settings`
+ * update for the toggle.
+ */
+
+import logger from '@alga-psa/core/logger';
+import { withAuth, hasPermission } from '@alga-psa/auth';
+import type { IUserWithRoles } from '@alga-psa/types';
+import { TIER_FEATURES } from '@alga-psa/types';
+import { featureFlags } from 'server/src/lib/feature-flags/featureFlags';
+import { assertTierAccess } from 'server/src/lib/tier-gating/assertTierAccess';
+import { createTenantKnex } from 'server/src/lib/db';
+import { runHuduTenantSync } from '../../integrations/hudu/tenantSync';
+import type { HuduTenantSyncSummary } from '../../integrations/hudu/tenantSync';
+import { mergeHuduSettings } from '../../integrations/hudu/huduIntegrationRepository';
+
+export type HuduCadence = 'daily';
+
+export interface HuduAutoSyncSettings {
+  enabled: boolean;
+  cadence: HuduCadence;
+}
+
+export type HuduTenantSyncActionResult =
+  | { success: true; data: HuduTenantSyncSummary }
+  | { success: false; error: string };
+
+interface HuduResourcePermission {
+  resource: 'asset' | 'system_settings';
+  action: 'create' | 'update';
+}
+
+function withHuduAccess<TArgs extends unknown[], TResult>(
+  perm: HuduResourcePermission,
+  handler: (user: IUserWithRoles, context: { tenant: string }, ...args: TArgs) => Promise<TResult>
+) {
+  return withAuth(async (user, context, ...args: TArgs): Promise<TResult> => {
+    if (user.user_type === 'client') {
+      throw new Error('Forbidden');
+    }
+
+    const allowed = await hasPermission(user, perm.resource, perm.action);
+    if (!allowed) {
+      throw new Error(`Forbidden: insufficient permissions (${perm.action})`);
+    }
+
+    await assertTierAccess(TIER_FEATURES.INTEGRATIONS);
+
+    const enabled = await featureFlags.isEnabled('hudu-integration', {
+      userId: user.user_id,
+      tenantId: context.tenant,
+    });
+    if (!enabled) {
+      throw new Error('Hudu integration is disabled for this tenant.');
+    }
+
+    return handler(user, context as { tenant: string }, ...args);
+  });
+}
+
+function toErrorMessage(error: unknown): string {
+  return error instanceof Error ? error.message : String(error);
+}
+
+/** Import every mapped client's unmatched Hudu assets, then refresh existing. */
+export const importAllHuduClients = withHuduAccess(
+  { resource: 'asset', action: 'create' },
+  async (user, { tenant }): Promise<HuduTenantSyncActionResult> => {
+    try {
+      const summary = await runHuduTenantSync(tenant, { importNew: true, actorUserId: user.user_id });
+      return { success: true, data: summary };
+    } catch (error) {
+      logger.error('[HuduTenantSyncActions] importAllHuduClients failed', { tenant, error: toErrorMessage(error) });
+      return { success: false, error: toErrorMessage(error) };
+    }
+  }
+);
+
+/** Refresh (name/serial/fields) every mapped client's already-imported assets. */
+export const syncAllHuduClients = withHuduAccess(
+  { resource: 'asset', action: 'update' },
+  async (user, { tenant }): Promise<HuduTenantSyncActionResult> => {
+    try {
+      const summary = await runHuduTenantSync(tenant, { importNew: false, actorUserId: user.user_id });
+      return { success: true, data: summary };
+    } catch (error) {
+      logger.error('[HuduTenantSyncActions] syncAllHuduClients failed', { tenant, error: toErrorMessage(error) });
+      return { success: false, error: toErrorMessage(error) };
+    }
+  }
+);
+
+/**
+ * Persist the auto-sync toggle (settings.autoSync) and converge the recurring
+ * schedule (creates the daily job when enabled, cancels it when disabled).
+ */
+export const setHuduAutoSync = withHuduAccess(
+  { resource: 'system_settings', action: 'update' },
+  async (
+    _user,
+    { tenant },
+    input: { enabled: boolean; cadence?: HuduCadence }
+  ): Promise<{ success: true; data: HuduAutoSyncSettings } | { success: false; error: string }> => {
+    try {
+      const autoSync: HuduAutoSyncSettings = {
+        enabled: input?.enabled === true,
+        cadence: input?.cadence ?? 'daily',
+      };
+
+      const { knex } = await createTenantKnex(tenant);
+      await mergeHuduSettings(knex, tenant, { autoSync });
+
+      // Converge the recurring schedule to match the new desired state.
+      try {
+        const { scheduleHuduAutoSyncJob } = await import(
+          'server/src/lib/jobs/handlers/huduAutoSyncHandler'
+        );
+        await scheduleHuduAutoSyncJob(tenant);
+      } catch (error) {
+        logger.warn('[HuduTenantSyncActions] auto-sync schedule converge skipped', {
+          tenant,
+          error: toErrorMessage(error),
+        });
+      }
+
+      logger.info('[HuduTenantSyncActions] auto-sync updated', { tenant, enabled: autoSync.enabled });
+      return { success: true, data: autoSync };
+    } catch (error) {
+      logger.error('[HuduTenantSyncActions] setHuduAutoSync failed', { tenant, error: toErrorMessage(error) });
+      return { success: false, error: toErrorMessage(error) };
+    }
+  }
+);

--- a/ee/server/src/lib/integrations/hudu/assetImportCore.ts
+++ b/ee/server/src/lib/integrations/hudu/assetImportCore.ts
@@ -1,0 +1,388 @@
+/**
+ * Hudu asset-import core (EE-only, session-free).
+ *
+ * The import logic behind huduAssetImportActions.ts, lifted out of the
+ * `'use server'` action file so it can also run from the tenant-wide sync core
+ * (runHuduTenantSync) in a background job with no session. Asset writes go
+ * through the actor-injectable createAssetRecord/deleteAssetRecord services
+ * (the withAuth createAsset needs a session the daily job doesn't have); the
+ * caller supplies the actor user id (clicking admin, or resolved audit user).
+ *
+ * // LEVERAGE: friction hudu-import-core — this logic was only reachable via
+ * // 'use server', so the daily auto-sync couldn't reuse it.
+ */
+
+import logger from '@alga-psa/core/logger';
+import { createTenantKnex } from 'server/src/lib/db';
+import type { Knex } from 'knex';
+import { createAssetRecord, deleteAssetRecord } from '@alga-psa/assets/actions/assetActions';
+import { listAssetTypes } from '@alga-psa/assets/lib/assetTypeRegistry';
+import { fetchHuduCompanyAssets } from './huduDataCore';
+import type { HuduCompanyDataResult, HuduLinkedItem } from './huduDataCore';
+import type { HuduErrorKind } from './huduClient';
+import type { HuduAsset } from './contracts';
+import {
+  getHuduAssetLayoutTypeMap,
+  isLayoutExcluded,
+  resolveAssetTypeForLayout,
+} from './assetLayoutMap';
+import { projectHuduFieldsOntoSchema } from './layoutFieldSchema';
+import { suggestHuduAssetMappings } from './assetMatching';
+import type { AlgaMatcherAsset } from './assetMatching';
+import {
+  getHuduAssetMappingRows,
+  resolveAlgaAssetIdForHuduAsset,
+  setHuduAssetMappingRow,
+} from './assetMapping';
+import type { HuduAssetMappingWriteResult } from './assetMapping';
+import { deriveHuduAssetTag, huduImportAssetStatus } from './assetImport';
+import { buildHuduFieldsAttribute } from './assetAttributes';
+
+export type HuduAssetImportErrorCode =
+  | 'client_not_mapped'
+  | 'hudu_asset_not_found'
+  | 'hudu_asset_already_mapped'
+  | 'layout_excluded'
+  | 'serial_conflict'
+  | 'fetch_failed'
+  | 'rate_limited'
+  | 'create_failed'
+  | 'mapping_failed';
+
+export interface HuduAssetImportFailure {
+  success: false;
+  error: string;
+  code?: HuduAssetImportErrorCode;
+  errorKind?: HuduErrorKind;
+  /** mapping_failed: the asset created right before the mapping write failed. */
+  orphanAssetId?: string;
+  orphanCleanedUp?: boolean;
+  /** serial_conflict: the tenant asset already carrying the serial (F261). */
+  existing_asset_id?: string;
+  existing_asset_name?: string;
+  existing_client_id?: string;
+}
+
+export type HuduAssetImportResult =
+  | {
+      success: true;
+      data: {
+        asset_id: string;
+        mapping_id: string;
+        asset_tag: string;
+        asset_type: string;
+        status: string;
+        projection_skipped?: string[];
+      };
+    }
+  | HuduAssetImportFailure;
+
+export interface HuduAssetBulkImportSummary {
+  created: number;
+  skipped: number;
+  failed: Array<{
+    huduAssetId: number;
+    error: string;
+    code?: HuduAssetImportErrorCode;
+    existing_asset_name?: string;
+  }>;
+}
+
+export type HuduAssetBulkImportResult =
+  | { success: true; data: HuduAssetBulkImportSummary }
+  | {
+      success: false;
+      error: string;
+      code?: HuduAssetImportErrorCode;
+      errorKind?: HuduErrorKind;
+      partial: HuduAssetBulkImportSummary;
+    };
+
+function toErrorMessage(error: unknown): string {
+  return error instanceof Error ? error.message : String(error);
+}
+
+export function fetchFailure(
+  result: Exclude<HuduCompanyDataResult<HuduAsset>, { state: 'ok' }>
+): HuduAssetImportFailure {
+  if (result.state === 'unmapped') {
+    return { success: false, error: 'Client is not mapped to a Hudu company.', code: 'client_not_mapped' };
+  }
+  const error = result.state === 'error' ? result.error : result.state;
+  const errorKind = result.state === 'error' ? result.errorKind : undefined;
+  return {
+    success: false,
+    error,
+    code: errorKind === 'rate_limited' ? 'rate_limited' : 'fetch_failed',
+    ...(errorKind ? { errorKind } : {}),
+  };
+}
+
+async function cleanUpOrphanAsset(
+  knex: Knex,
+  tenant: string,
+  actorUserId: string,
+  assetId: string
+): Promise<boolean> {
+  try {
+    const result = await deleteAssetRecord(knex, tenant, actorUserId, assetId, { suppressRevalidate: true });
+    return result?.success === true;
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * F261: tenant-wide lookup for an existing asset already carrying the Hudu
+ * asset's serial (trimmed, case-insensitive). Blank serials never conflict.
+ */
+async function findSerialConflict(
+  knex: Knex,
+  tenant: string,
+  primarySerial: string | null | undefined
+): Promise<{ asset_id: string; name: string; client_id: string | null } | null> {
+  const serial = (primarySerial ?? '').trim();
+  if (!serial) {
+    return null;
+  }
+  const existing = await knex('assets')
+    .where({ tenant })
+    .whereRaw('lower(trim(serial_number)) = ?', [serial.toLowerCase()])
+    .first('asset_id', 'name', 'client_id');
+  return existing ?? null;
+}
+
+/**
+ * Single-asset import core. Fetches via the Phase 1 cached path (session-free),
+ * so bulk callers mostly hit the server cache per item — and a mid-batch 429
+ * surfaces here as a typed rate_limited failure (F218). Asset creation goes
+ * through createAssetRecord with the supplied actor.
+ */
+export async function importHuduAssetCore(
+  tenant: string,
+  actorUserId: string,
+  clientId: string,
+  huduAssetId: string | number
+): Promise<HuduAssetImportResult> {
+  const assetsResult = await fetchHuduCompanyAssets(tenant, clientId);
+  if (assetsResult.state !== 'ok') {
+    return fetchFailure(assetsResult);
+  }
+
+  const huduAsset = (assetsResult.items as Array<HuduLinkedItem<HuduAsset>>).find(
+    (a) => String(a.id) === String(huduAssetId)
+  );
+  if (!huduAsset) {
+    return {
+      success: false,
+      error: `Hudu asset ${huduAssetId} was not found for this company.`,
+      code: 'hudu_asset_not_found',
+    };
+  }
+
+  const { knex } = await createTenantKnex(tenant);
+
+  const mappedAssetId = await resolveAlgaAssetIdForHuduAsset(knex, tenant, huduAsset.id);
+  if (mappedAssetId) {
+    return {
+      success: false,
+      error: `Hudu asset ${huduAsset.id} is already mapped to an asset. Clear that mapping first.`,
+      code: 'hudu_asset_already_mapped',
+    };
+  }
+
+  const layoutMap = await getHuduAssetLayoutTypeMap(knex, tenant);
+  // F258: excluded layouts fail typed before any serial/tag work (FR8).
+  if (huduAsset.asset_layout_id != null && isLayoutExcluded(layoutMap, huduAsset.asset_layout_id)) {
+    return {
+      success: false,
+      error: `Hudu asset ${huduAsset.id} belongs to a layout marked "Don't import".`,
+      code: 'layout_excluded',
+    };
+  }
+
+  // F261: a tenant-wide serial collision fails typed before anything is created.
+  const serialConflict = await findSerialConflict(knex, tenant, huduAsset.primary_serial);
+  if (serialConflict) {
+    return {
+      success: false,
+      error: `An asset with serial number "${(huduAsset.primary_serial ?? '').trim()}" already exists: "${serialConflict.name}".`,
+      code: 'serial_conflict',
+      existing_asset_id: serialConflict.asset_id,
+      existing_asset_name: serialConflict.name,
+      ...(serialConflict.client_id ? { existing_client_id: serialConflict.client_id } : {}),
+    };
+  }
+
+  // F315/F317: a configured custom slug only resolves when it's still in the
+  // tenant's registry; a custom target additionally gets the Hudu field values
+  // projected onto its fields_schema keys.
+  const registryTypes = await listAssetTypes(knex, tenant);
+  const assetType =
+    huduAsset.asset_layout_id != null
+      ? resolveAssetTypeForLayout(
+          layoutMap,
+          huduAsset.asset_layout_id,
+          new Set(registryTypes.map((type) => type.slug))
+        )
+      : 'unknown';
+  const customType = registryTypes.find((type) => type.slug === assetType && !type.is_builtin);
+  const projection = customType
+    ? projectHuduFieldsOntoSchema(customType.fields_schema, huduAsset.fields)
+    : { attributes: {}, skipped: [] };
+
+  const assetTag = await deriveHuduAssetTag(knex, tenant, {
+    huduAssetId: huduAsset.id,
+    primarySerial: huduAsset.primary_serial,
+  });
+  const status = huduImportAssetStatus();
+
+  let createdAssetId: string;
+  try {
+    const created = await createAssetRecord(
+      knex,
+      tenant,
+      actorUserId,
+      {
+        asset_type: assetType,
+        client_id: clientId,
+        asset_tag: assetTag,
+        name: huduAsset.name,
+        status,
+        serial_number: huduAsset.primary_serial ?? undefined,
+        attributes: {
+          ...projection.attributes,
+          hudu_fields: buildHuduFieldsAttribute(huduAsset.fields),
+          hudu_synced_at: new Date().toISOString(),
+        },
+      },
+      { requireCustomAttributes: false }
+    );
+    createdAssetId = created.asset_id;
+  } catch (error) {
+    return { success: false, error: toErrorMessage(error), code: 'create_failed' };
+  }
+
+  let mappingError: string;
+  try {
+    const mappingResult = await setHuduAssetMappingRow(knex, tenant, {
+      assetId: createdAssetId,
+      huduAssetId: huduAsset.id,
+      huduCompanyId: assetsResult.huduCompanyId,
+      metadata: {
+        hudu_asset_name: huduAsset.name,
+        asset_layout_id: huduAsset.asset_layout_id ?? null,
+        asset_layout_name: huduAsset.asset_type ?? null,
+        primary_serial: huduAsset.primary_serial ?? null,
+        url: huduAsset.hudu_url ?? huduAsset.url ?? null,
+      },
+    });
+    if (mappingResult.ok) {
+      return {
+        success: true,
+        data: {
+          asset_id: createdAssetId,
+          mapping_id: mappingResult.mapping.id,
+          asset_tag: assetTag,
+          asset_type: assetType,
+          status,
+          ...(projection.skipped.length > 0 ? { projection_skipped: projection.skipped } : {}),
+        },
+      };
+    }
+    mappingError = (mappingResult as Extract<HuduAssetMappingWriteResult, { ok: false }>).message;
+  } catch (error) {
+    mappingError = toErrorMessage(error);
+  }
+
+  const cleanedUp = await cleanUpOrphanAsset(knex, tenant, actorUserId, createdAssetId);
+  return {
+    success: false,
+    error: cleanedUp
+      ? `Mapping failed after asset creation; the created asset ${createdAssetId} was removed. ${mappingError}`
+      : `Mapping failed after asset creation; asset ${createdAssetId} was created but is not mapped. ${mappingError}`,
+    code: 'mapping_failed',
+    orphanAssetId: createdAssetId,
+    orphanCleanedUp: cleanedUp,
+  };
+}
+
+/**
+ * F217/F218: import every plain-unmatched Hudu asset (no mapping row, no
+ * suggestion) for one mapped client, sequentially. Excluded-layout assets are
+ * skipped (counted, F258). Per-item failures are isolated; a rate-limited Hudu
+ * fetch stops the batch with the partial summary.
+ */
+export async function importUnmatchedHuduAssetsCore(
+  tenant: string,
+  actorUserId: string,
+  clientId: string
+): Promise<HuduAssetBulkImportResult> {
+  const summary: HuduAssetBulkImportSummary = { created: 0, skipped: 0, failed: [] };
+
+  const result = await fetchHuduCompanyAssets(tenant, clientId);
+  if (result.state !== 'ok') {
+    const failure = fetchFailure(result);
+    return { ...failure, partial: summary };
+  }
+
+  const huduAssets = result.items as Array<HuduLinkedItem<HuduAsset>>;
+  const { knex } = await createTenantKnex(tenant);
+
+  const mappingRows = await getHuduAssetMappingRows(knex, tenant, {
+    huduCompanyId: result.huduCompanyId,
+  });
+  const mappedHuduAssetIds = new Set(mappingRows.map((m) => m.external_entity_id));
+
+  const algaAssets: AlgaMatcherAsset[] = await knex('assets')
+    .where({ tenant, client_id: clientId })
+    .select('asset_id', 'name as asset_name', 'serial_number');
+  const suggestions = suggestHuduAssetMappings(
+    huduAssets,
+    algaAssets,
+    mappingRows.map((m) => ({ asset_id: m.alga_entity_id, hudu_asset_id: m.external_entity_id }))
+  );
+
+  const unmatched = huduAssets.filter(
+    (asset) => !mappedHuduAssetIds.has(String(asset.id)) && !suggestions.has(asset.id)
+  );
+
+  const layoutMap = await getHuduAssetLayoutTypeMap(knex, tenant);
+  const importable = unmatched.filter(
+    (asset) => !(asset.asset_layout_id != null && isLayoutExcluded(layoutMap, asset.asset_layout_id))
+  );
+  summary.skipped = unmatched.length - importable.length;
+
+  for (const asset of importable) {
+    const importResult = await importHuduAssetCore(tenant, actorUserId, clientId, asset.id);
+    if (importResult.success) {
+      summary.created += 1;
+      continue;
+    }
+    const failure = importResult as HuduAssetImportFailure;
+    if (failure.code === 'rate_limited') {
+      logger.warn('[HuduAssetImportCore] bulk import stopped on rate limit', {
+        tenant,
+        clientId,
+        created: summary.created,
+        skipped: summary.skipped,
+        failed: summary.failed.length,
+      });
+      return {
+        success: false,
+        error: failure.error,
+        code: 'rate_limited',
+        errorKind: 'rate_limited',
+        partial: summary,
+      };
+    }
+    summary.failed.push({
+      huduAssetId: asset.id,
+      error: failure.error,
+      ...(failure.code ? { code: failure.code } : {}),
+      ...(failure.existing_asset_name ? { existing_asset_name: failure.existing_asset_name } : {}),
+    });
+  }
+
+  return { success: true, data: summary };
+}

--- a/ee/server/src/lib/integrations/hudu/assetSyncCore.ts
+++ b/ee/server/src/lib/integrations/hudu/assetSyncCore.ts
@@ -1,0 +1,187 @@
+/**
+ * Hudu asset pull-sync core (EE-only, session-free).
+ *
+ * The sync logic behind huduAssetSyncActions.ts, lifted out of the
+ * `'use server'` action file so the tenant-wide auto-sync (runHuduTenantSync)
+ * can reuse it from a background job. Refreshes ONLY the synced fields (name,
+ * serial_number) via the actor-injectable updateAssetRecord, plus the Hudu
+ * attributes namespace (jsonb-merged). Archived/missing Hudu assets flag the
+ * mapping `stale`; RMM-owned assets suppress name/serial diffs (F260).
+ */
+
+import logger from '@alga-psa/core/logger';
+import { createTenantKnex } from 'server/src/lib/db';
+import type { Knex } from 'knex';
+import { updateAssetRecord } from '@alga-psa/assets/actions/assetActions';
+import { fetchHuduCompanyAssets } from './huduDataCore';
+import type { HuduErrorKind } from './huduClient';
+import type { HuduAsset } from './contracts';
+import {
+  getHuduAssetMappingRows,
+  setHuduAssetMappingStale,
+  touchHuduAssetMappingsSynced,
+} from './assetMapping';
+import {
+  buildHuduFieldsAttribute,
+  huduFieldsChanged,
+  writeHuduAssetAttributes,
+} from './assetAttributes';
+
+export type HuduAssetSyncResult =
+  | { state: 'ok'; updated: number; unchanged: number; stale: number; rmmSkipped: number; syncedAt: string }
+  | { state: 'unmapped' }
+  | { state: 'error'; error: string; errorKind?: HuduErrorKind };
+
+function toErrorMessage(error: unknown): string {
+  return error instanceof Error ? error.message : String(error);
+}
+
+async function listMappedAssets(
+  knex: Knex,
+  tenant: string,
+  assetIds: string[]
+): Promise<
+  Array<{
+    asset_id: string;
+    name: string;
+    serial_number: string | null;
+    attributes: Record<string, unknown> | null;
+    rmm_provider: string | null;
+  }>
+> {
+  if (assetIds.length === 0) {
+    return [];
+  }
+  return knex('assets')
+    .where({ tenant })
+    .whereIn('asset_id', assetIds)
+    .select('asset_id', 'name', 'serial_number', 'attributes', 'rmm_provider');
+}
+
+/** The only fields sync ever writes (FR7/F220: Hudu wins on these alone). */
+function syncedFieldChanges(
+  huduAsset: HuduAsset,
+  algaAsset: { name: string; serial_number: string | null } | undefined
+): { name?: string; serial_number?: string } {
+  const changes: { name?: string; serial_number?: string } = {};
+  if (!algaAsset) {
+    return changes;
+  }
+  if (huduAsset.name && huduAsset.name !== algaAsset.name) {
+    changes.name = huduAsset.name;
+  }
+  const huduSerial = huduAsset.primary_serial ?? null;
+  if (huduSerial !== null && huduSerial !== (algaAsset.serial_number ?? null)) {
+    changes.serial_number = huduSerial;
+  }
+  return changes;
+}
+
+/**
+ * F219–F222: re-fetch the mapped company's Hudu assets (cache bypassed) and
+ * walk the company's mapping rows: present+live ⇒ update changed synced fields
+ * (via updateAssetRecord with the supplied actor) and clear `stale`;
+ * archived/missing ⇒ set `stale` (never delete). All processed rows get
+ * `last_synced_at`. Session-free — shared by the manual action and auto-sync.
+ */
+export async function syncHuduClientAssetsCore(
+  tenant: string,
+  actorUserId: string,
+  clientId: string
+): Promise<HuduAssetSyncResult> {
+  try {
+    const assetsResult = await fetchHuduCompanyAssets(tenant, clientId, { refresh: true });
+    if (assetsResult.state === 'unmapped') {
+      return { state: 'unmapped' };
+    }
+    if (assetsResult.state !== 'ok') {
+      return {
+        state: 'error',
+        error: assetsResult.state === 'error' ? assetsResult.error : assetsResult.state,
+        ...(assetsResult.state === 'error' && assetsResult.errorKind ? { errorKind: assetsResult.errorKind } : {}),
+      };
+    }
+
+    const huduAssetById = new Map(assetsResult.items.map((asset) => [String(asset.id), asset]));
+    const { knex } = await createTenantKnex(tenant);
+
+    const mappingRows = await getHuduAssetMappingRows(knex, tenant, {
+      huduCompanyId: assetsResult.huduCompanyId,
+    });
+    const algaAssets = await listMappedAssets(knex, tenant, mappingRows.map((m) => m.alga_entity_id));
+    const algaAssetById = new Map(algaAssets.map((a) => [String(a.asset_id), a]));
+
+    let updated = 0;
+    let unchanged = 0;
+    let stale = 0;
+    let rmmSkipped = 0;
+    const syncedAt = new Date().toISOString();
+
+    for (const mapping of mappingRows) {
+      const huduAsset = huduAssetById.get(mapping.external_entity_id);
+      const wasStale = mapping.metadata?.stale === true;
+
+      if (!huduAsset || huduAsset.archived === true) {
+        stale += 1;
+        if (!wasStale) {
+          await setHuduAssetMappingStale(knex, tenant, { mappingId: mapping.id }, true);
+        }
+        continue;
+      }
+
+      const algaAsset = algaAssetById.get(mapping.alga_entity_id);
+      const changes = syncedFieldChanges(huduAsset, algaAsset);
+      let rowChanged = false;
+      if (Object.keys(changes).length > 0) {
+        // F260: an RMM owns device facts on its assets — Hudu never writes
+        // name/serial there; the suppressed diff is surfaced as rmmSkipped.
+        if (algaAsset?.rmm_provider) {
+          rmmSkipped += 1;
+        } else {
+          await updateAssetRecord(knex, tenant, actorUserId, mapping.alga_entity_id, changes, {
+            suppressRevalidate: true,
+          });
+          rowChanged = true;
+        }
+      }
+      // F253: the Hudu namespace is always Hudu-won — refreshed on every mapped
+      // live asset via jsonb merge (sibling attributes keys survive).
+      if (algaAsset) {
+        const nextFields = buildHuduFieldsAttribute(huduAsset.fields);
+        if (huduFieldsChanged(algaAsset.attributes?.hudu_fields, nextFields)) {
+          rowChanged = true;
+        }
+        await writeHuduAssetAttributes(knex, tenant, mapping.alga_entity_id, nextFields, syncedAt);
+      }
+      if (rowChanged) {
+        updated += 1;
+      } else {
+        unchanged += 1;
+      }
+      if (wasStale) {
+        await setHuduAssetMappingStale(knex, tenant, { mappingId: mapping.id }, false);
+      }
+    }
+
+    await touchHuduAssetMappingsSynced(knex, tenant, mappingRows.map((m) => m.id), syncedAt);
+
+    logger.info('[HuduAssetSyncCore] sync completed', {
+      tenant,
+      clientId,
+      huduCompanyId: assetsResult.huduCompanyId,
+      updated,
+      unchanged,
+      stale,
+      rmmSkipped,
+    });
+
+    return { state: 'ok', updated, unchanged, stale, rmmSkipped, syncedAt };
+  } catch (error) {
+    logger.error('[HuduAssetSyncCore] syncHuduClientAssets failed', {
+      tenant,
+      clientId,
+      error: toErrorMessage(error),
+    });
+    return { state: 'error', error: toErrorMessage(error) };
+  }
+}

--- a/ee/server/src/lib/integrations/hudu/huduClient.ts
+++ b/ee/server/src/lib/integrations/hudu/huduClient.ts
@@ -450,6 +450,17 @@ function isBlockedHostname(hostname: string): boolean {
   return false;
 }
 
+/**
+ * Opt-in escape hatch for local development against a self-hosted Hudu over
+ * plain HTTP (e.g. http://hudu.localtest.me, http://host.docker.internal).
+ * Relaxes the HTTPS requirement and the localhost/private-network SSRF guard.
+ * Never set this in production.
+ */
+function allowInsecureHuduUrl(): boolean {
+  const flag = process.env.HUDU_ALLOW_INSECURE_URL?.trim().toLowerCase();
+  return flag === 'true' || flag === '1' || flag === 'yes';
+}
+
 /** Normalize a base URL to `<instance>/api/v1` (idempotent). */
 export function buildHuduApiBaseUrl(baseUrl: string): string {
   const normalized = baseUrl
@@ -458,10 +469,11 @@ export function buildHuduApiBaseUrl(baseUrl: string): string {
     .replace(/\/api(?:\/v1)?$/, '')
     .concat('/api/v1');
   const parsed = new URL(normalized);
-  if (parsed.protocol !== 'https:') {
+  const insecureAllowed = allowInsecureHuduUrl();
+  if (parsed.protocol !== 'https:' && !(insecureAllowed && parsed.protocol === 'http:')) {
     throw new Error('Hudu base URL must use HTTPS.');
   }
-  if (isBlockedHostname(parsed.hostname)) {
+  if (isBlockedHostname(parsed.hostname) && !insecureAllowed) {
     throw new Error('Hudu base URL must not target localhost or private network addresses.');
   }
   return normalized;

--- a/ee/server/src/lib/integrations/hudu/huduDataCore.ts
+++ b/ee/server/src/lib/integrations/hudu/huduDataCore.ts
@@ -1,0 +1,129 @@
+/**
+ * Hudu reference-data fetch core (EE-only, session-free).
+ *
+ * The plain fetch/cache/link logic behind the withAuth getHuduCompany* actions
+ * (huduDataActions.ts). Kept session-free so the tenant-wide import/sync core
+ * (runHuduTenantSync) can call it from a background job with no user session —
+ * the actions add the auth/flag gating, this module does the work.
+ */
+
+import logger from '@alga-psa/core/logger';
+import { createTenantKnex } from 'server/src/lib/db';
+import type { Knex } from 'knex';
+import { createHuduClient, HuduRequestError } from './huduClient';
+import type { HuduClient, HuduErrorKind } from './huduClient';
+import { getHuduIntegration } from './huduIntegrationRepository';
+import { parseCompaniesCache, resolveHuduCompanyIdForClient } from './companyMapping';
+import {
+  buildHuduCompanyUrl,
+  buildHuduRecordUrl,
+  getCachedHuduList,
+  setCachedHuduList,
+} from './referenceData';
+import type { HuduReferenceResource } from './referenceData';
+
+// Result types live in the runtime-free huduDataTypes module so client
+// components can `import type` them without pulling in the server data layer.
+import type {
+  HuduCompanyDataResult,
+  HuduCompanyFetchOptions,
+  HuduLinkedItem,
+} from './huduDataTypes';
+export type { HuduCompanyDataResult, HuduCompanyFetchOptions, HuduLinkedItem } from './huduDataTypes';
+
+export function toErrorMessage(error: unknown): string {
+  return error instanceof Error ? error.message : String(error);
+}
+
+export function toErrorResult(error: unknown): { state: 'error'; error: string; errorKind?: HuduErrorKind } {
+  return {
+    state: 'error',
+    error: toErrorMessage(error),
+    ...(error instanceof HuduRequestError ? { errorKind: error.hudu.kind } : {}),
+  };
+}
+
+export async function resolveCompanyUrl(
+  knex: Knex,
+  tenant: string,
+  huduCompanyId: string
+): Promise<{ baseUrl: string | null; companyUrl: string | null }> {
+  const row = await getHuduIntegration(knex, tenant);
+  const baseUrl = row?.base_url ?? null;
+  const company =
+    parseCompaniesCache(row?.settings)?.companies.find((c) => String(c.id) === huduCompanyId) ?? null;
+  return { baseUrl, companyUrl: buildHuduCompanyUrl(company, baseUrl) };
+}
+
+/**
+ * Shared list flow: resolve mapping (unmapped ⇒ typed state, NO Hudu call),
+ * serve from the per-(tenant,company,resource) cache inside the TTL unless
+ * refresh, else live-fetch (paginated, per company), project (passwords are
+ * value-stripped before caching), then attach deep-links.
+ */
+export async function fetchCompanyList<TRaw, TItem extends { url?: string | null }>(
+  tenant: string,
+  clientId: string,
+  resource: HuduReferenceResource,
+  refresh: boolean,
+  fetcher: (client: HuduClient, companyId: number) => Promise<TRaw[]>,
+  project: (raw: TRaw) => TItem
+): Promise<HuduCompanyDataResult<TItem>> {
+  try {
+    const { knex } = await createTenantKnex(tenant);
+
+    const huduCompanyId = await resolveHuduCompanyIdForClient(knex, tenant, clientId);
+    if (!huduCompanyId) {
+      return { state: 'unmapped' };
+    }
+
+    const cached = refresh ? null : getCachedHuduList<TItem>(tenant, huduCompanyId, resource);
+    let items: TItem[];
+    let fetchedAt: string;
+    let fromCache = true;
+    if (cached) {
+      items = cached.items;
+      fetchedAt = cached.fetchedAt;
+    } else {
+      const client = await createHuduClient(tenant);
+      items = (await fetcher(client, Number(huduCompanyId))).map(project);
+      fetchedAt = new Date().toISOString();
+      setCachedHuduList(tenant, huduCompanyId, resource, items, fetchedAt);
+      fromCache = false;
+    }
+
+    const { baseUrl, companyUrl } = await resolveCompanyUrl(knex, tenant, huduCompanyId);
+
+    return {
+      state: 'ok',
+      items: items.map((item) => ({ ...item, hudu_url: buildHuduRecordUrl(item, baseUrl) ?? companyUrl })),
+      count: items.length,
+      huduCompanyId,
+      companyUrl,
+      fetchedAt,
+      fromCache,
+    };
+  } catch (error) {
+    if (error instanceof HuduRequestError && error.hudu.kind === 'no_password_access') {
+      return { state: 'no_password_access' };
+    }
+    logger.error('[HuduDataCore] fetch failed', { tenant, clientId, resource, error: toErrorMessage(error) });
+    return toErrorResult(error);
+  }
+}
+
+/** Session-free assets fetch for a mapped client (used by import/sync cores). */
+export async function fetchHuduCompanyAssets(
+  tenant: string,
+  clientId: string,
+  options?: HuduCompanyFetchOptions
+): Promise<HuduCompanyDataResult<import('./contracts').HuduAsset>> {
+  return fetchCompanyList(
+    tenant,
+    clientId,
+    'assets',
+    options?.refresh === true,
+    (client, companyId) => client.getAssets(companyId),
+    (asset) => asset
+  );
+}

--- a/ee/server/src/lib/integrations/hudu/huduDataTypes.ts
+++ b/ee/server/src/lib/integrations/hudu/huduDataTypes.ts
@@ -1,0 +1,31 @@
+/**
+ * Hudu reference-data result types (EE-only, ZERO runtime imports).
+ *
+ * Kept free of any runtime dependency (no server/src/lib/db, no client) so that
+ * client components and tests can `import type` these without dragging the
+ * server data layer into their bundle/transform graph. huduDataCore re-exports
+ * them for its own (runtime) consumers.
+ */
+
+import type { HuduErrorKind } from './huduClient';
+
+export type HuduLinkedItem<T> = T & { hudu_url: string | null };
+
+export type HuduCompanyDataResult<TItem> =
+  | {
+      state: 'ok';
+      items: Array<HuduLinkedItem<TItem>>;
+      count: number;
+      huduCompanyId: string;
+      companyUrl: string | null;
+      fetchedAt: string;
+      fromCache: boolean;
+    }
+  | { state: 'unmapped' }
+  | { state: 'no_password_access' }
+  | { state: 'error'; error: string; errorKind?: HuduErrorKind };
+
+export interface HuduCompanyFetchOptions {
+  /** Bypass the short-lived server cache and repopulate it. */
+  refresh?: boolean;
+}

--- a/ee/server/src/lib/integrations/hudu/huduIntegrationRepository.ts
+++ b/ee/server/src/lib/integrations/hudu/huduIntegrationRepository.ts
@@ -14,6 +14,9 @@
 
 import type { Knex } from 'knex';
 
+/** Tenant-wide import/sync run status (mirrors rmm_integrations.sync_status). */
+export type HuduSyncStatus = 'idle' | 'syncing' | 'completed' | 'error';
+
 export interface HuduIntegrationRecord {
   tenant: string;
   integration_id: string;
@@ -21,6 +24,11 @@ export interface HuduIntegrationRecord {
   is_active: boolean;
   connected_at: Date | string | null;
   last_synced_at: Date | string | null;
+  /** Status of the last tenant-wide import/sync run. */
+  sync_status: HuduSyncStatus;
+  sync_error: string | null;
+  /** Timestamp of the last tenant-wide import/sync run. */
+  last_full_sync_at: Date | string | null;
   settings: Record<string, unknown>;
   created_at: Date | string;
   updated_at: Date | string;
@@ -111,4 +119,61 @@ export async function touchHuduIntegrationLastSynced(
       last_synced_at: at ?? knex.fn.now(),
       updated_at: knex.fn.now(),
     });
+}
+
+/**
+ * Shallow-merge a patch into the settings jsonb, preserving sibling keys
+ * (companies_cache / asset_layout_type_map / password_access). The `||`
+ * operator is IMMUTABLE-safe on the distributed table (no now()).
+ */
+export async function mergeHuduSettings(
+  knex: Knex,
+  tenant: string,
+  patch: Record<string, unknown>
+): Promise<void> {
+  await knex(TABLE)
+    .where({ tenant })
+    .update({
+      settings: knex.raw(`coalesce(settings, '{}'::jsonb) || ?::jsonb`, [JSON.stringify(patch)]),
+      updated_at: knex.fn.now(),
+    });
+}
+
+export interface HuduSyncRunState {
+  status: HuduSyncStatus;
+  error?: string | null;
+  /** Stamp last_full_sync_at; pass a value on terminal states. */
+  lastFullSyncAt?: Date | string | null;
+  /** Persisted under settings.last_sync (preserving sibling settings keys). */
+  summary?: Record<string, unknown>;
+}
+
+/**
+ * Record tenant-wide run progress: set the status columns and (on completion)
+ * the last-run summary. Status 'syncing' clears any prior error; terminal
+ * states also stamp last_full_sync_at and the summary blob.
+ */
+export async function setHuduSyncRunState(
+  knex: Knex,
+  tenant: string,
+  state: HuduSyncRunState
+): Promise<void> {
+  const update: Record<string, unknown> = {
+    sync_status: state.status,
+    updated_at: knex.fn.now(),
+  };
+  if (state.error !== undefined) {
+    update.sync_error = state.error;
+  } else if (state.status === 'syncing') {
+    update.sync_error = null;
+  }
+  if (state.lastFullSyncAt !== undefined) {
+    update.last_full_sync_at = state.lastFullSyncAt;
+  }
+  if (state.summary !== undefined) {
+    update.settings = knex.raw(`coalesce(settings, '{}'::jsonb) || ?::jsonb`, [
+      JSON.stringify({ last_sync: state.summary }),
+    ]);
+  }
+  await knex(TABLE).where({ tenant }).update(update);
 }

--- a/ee/server/src/lib/integrations/hudu/index.ts
+++ b/ee/server/src/lib/integrations/hudu/index.ts
@@ -60,10 +60,14 @@ export {
   upsertHuduIntegration,
   setHuduIntegrationActive,
   touchHuduIntegrationLastSynced,
+  mergeHuduSettings,
+  setHuduSyncRunState,
 } from './huduIntegrationRepository';
 export type {
   HuduIntegrationRecord,
   UpsertHuduIntegrationInput,
+  HuduSyncStatus,
+  HuduSyncRunState,
 } from './huduIntegrationRepository';
 
 export {
@@ -156,3 +160,6 @@ export type {
 
 export { writeHuduPasswordRevealAudit } from './revealAudit';
 export type { HuduPasswordRevealAuditParams } from './revealAudit';
+
+export { runHuduTenantSync, resolveTenantAuditUserId } from './tenantSync';
+export type { HuduTenantSyncSummary, RunHuduTenantSyncOptions } from './tenantSync';

--- a/ee/server/src/lib/integrations/hudu/tenantSync.ts
+++ b/ee/server/src/lib/integrations/hudu/tenantSync.ts
@@ -1,0 +1,192 @@
+/**
+ * Hudu tenant-wide import + sync core (EE-only, session-free).
+ *
+ * The single engine behind both the config-screen "Import all"/"Sync all"
+ * actions and the daily auto-sync job: loop the tenant's mapped clients and,
+ * per client, import every plain-unmatched Hudu asset (when importNew) then
+ * refresh name/serial/fields on the mapped ones. Writes the RMM-style run
+ * status to hudu_integrations (sync_status / last_full_sync_at) and a last-run
+ * summary into settings.last_sync.
+ *
+ * Sessionless: asset writes are attributed to a resolved tenant audit user
+ * (mirrors NinjaOne's getDefaultAuditUserId — first user in the tenant); the
+ * manual actions pass the clicking user id instead.
+ */
+
+import logger from '@alga-psa/core/logger';
+import { createTenantKnex } from 'server/src/lib/db';
+import type { Knex } from 'knex';
+import { getHuduIntegration, setHuduSyncRunState } from './huduIntegrationRepository';
+import { getHuduCompanyMappingRows } from './companyMapping';
+import { importUnmatchedHuduAssetsCore } from './assetImportCore';
+import { syncHuduClientAssetsCore } from './assetSyncCore';
+
+export interface HuduAutoSyncDesiredState {
+  isActive: boolean;
+  autoSyncEnabled: boolean;
+}
+
+/**
+ * Desired auto-sync state for a tenant, read from the EE-only hudu_integrations
+ * row. Lives in EE so the CE-visible job handler never names the table (NFR7);
+ * the handler/scheduler reach it via a dynamic @enterprise import.
+ */
+export async function getHuduAutoSyncDesiredState(
+  tenant: string
+): Promise<HuduAutoSyncDesiredState | null> {
+  const { knex } = await createTenantKnex(tenant);
+  const row = await getHuduIntegration(knex, tenant);
+  if (!row) {
+    return null;
+  }
+  const autoSync = (row.settings?.autoSync ?? {}) as Record<string, unknown>;
+  return { isActive: row.is_active === true, autoSyncEnabled: autoSync.enabled === true };
+}
+
+export interface HuduTenantSyncSummary {
+  sync_type: 'import' | 'sync';
+  started_at: string;
+  completed_at: string;
+  clients: number;
+  items_created: number;
+  items_updated: number;
+  items_skipped: number;
+  items_failed: number;
+  stale: number;
+  errors: string[];
+}
+
+export interface RunHuduTenantSyncOptions {
+  /** Create plain-unmatched assets (true) or only refresh existing (false). */
+  importNew: boolean;
+  /** Asset audit actor. Manual path passes the clicking user; omit to resolve one. */
+  actorUserId?: string;
+}
+
+/**
+ * Resolve a tenant user to attribute background asset writes to. Mirrors
+ * NinjaOne's getDefaultAuditUserId (first user in the tenant), preferring an
+ * internal user when present. Returns null when the tenant has no users.
+ */
+export async function resolveTenantAuditUserId(knex: Knex, tenant: string): Promise<string | null> {
+  const internal = await knex('users')
+    .where({ tenant, user_type: 'internal' })
+    .orderBy('created_at', 'asc')
+    .first('user_id');
+  if (internal?.user_id) {
+    return internal.user_id;
+  }
+  const any = await knex('users').where({ tenant }).first('user_id');
+  return any?.user_id ?? null;
+}
+
+function emptySummary(importNew: boolean, startedAt: string): HuduTenantSyncSummary {
+  return {
+    sync_type: importNew ? 'import' : 'sync',
+    started_at: startedAt,
+    completed_at: startedAt,
+    clients: 0,
+    items_created: 0,
+    items_updated: 0,
+    items_skipped: 0,
+    items_failed: 0,
+    stale: 0,
+    errors: [],
+  };
+}
+
+/**
+ * Run a tenant-wide Hudu import+sync. Clients are processed sequentially so a
+ * mid-run Hudu rate limit on one client is recorded (partial counts + error)
+ * without aborting the whole run. Per-client failures never throw out of the
+ * loop. Returns the run summary; also persisted to settings.last_sync.
+ */
+export async function runHuduTenantSync(
+  tenant: string,
+  options: RunHuduTenantSyncOptions
+): Promise<HuduTenantSyncSummary> {
+  const startedAt = new Date().toISOString();
+  const summary = emptySummary(options.importNew, startedAt);
+  const { knex } = await createTenantKnex(tenant);
+
+  const actorUserId = options.actorUserId ?? (await resolveTenantAuditUserId(knex, tenant));
+  if (!actorUserId) {
+    const completed = new Date().toISOString();
+    summary.completed_at = completed;
+    summary.errors.push('No tenant user found to attribute imported assets to.');
+    await setHuduSyncRunState(knex, tenant, {
+      status: 'error',
+      error: summary.errors[0],
+      lastFullSyncAt: completed,
+      summary: summary as unknown as Record<string, unknown>,
+    });
+    return summary;
+  }
+
+  await setHuduSyncRunState(knex, tenant, { status: 'syncing' });
+
+  try {
+    const mappingRows = await getHuduCompanyMappingRows(knex, tenant);
+    summary.clients = mappingRows.length;
+
+    for (const mapping of mappingRows) {
+      const clientId = mapping.alga_entity_id;
+
+      if (options.importNew) {
+        const imp = await importUnmatchedHuduAssetsCore(tenant, actorUserId, clientId);
+        const counts = imp.success ? imp.data : imp.partial;
+        summary.items_created += counts.created;
+        summary.items_skipped += counts.skipped;
+        summary.items_failed += counts.failed.length;
+        if (!imp.success) {
+          summary.errors.push(`${clientId}: ${imp.error}`);
+        }
+      }
+
+      const syn = await syncHuduClientAssetsCore(tenant, actorUserId, clientId);
+      if (syn.state === 'ok') {
+        summary.items_updated += syn.updated;
+        summary.stale += syn.stale;
+      } else if (syn.state === 'error') {
+        summary.errors.push(`${clientId}: ${syn.error}`);
+      }
+    }
+
+    const completed = new Date().toISOString();
+    summary.completed_at = completed;
+
+    await setHuduSyncRunState(knex, tenant, {
+      // The run finished; per-item/per-client problems are reported in sync_error.
+      status: 'completed',
+      error: summary.errors.length > 0 ? summary.errors.slice(0, 5).join('; ') : null,
+      lastFullSyncAt: completed,
+      summary: summary as unknown as Record<string, unknown>,
+    });
+
+    logger.info('[HuduTenantSync] run finished', {
+      tenant,
+      sync_type: summary.sync_type,
+      clients: summary.clients,
+      created: summary.items_created,
+      updated: summary.items_updated,
+      skipped: summary.items_skipped,
+      failed: summary.items_failed,
+      errors: summary.errors.length,
+    });
+
+    return summary;
+  } catch (error) {
+    const completed = new Date().toISOString();
+    summary.completed_at = completed;
+    const message = error instanceof Error ? error.message : String(error);
+    summary.errors.push(message);
+    await setHuduSyncRunState(knex, tenant, {
+      status: 'error',
+      error: message,
+      lastFullSyncAt: completed,
+      summary: summary as unknown as Record<string, unknown>,
+    });
+    logger.error('[HuduTenantSync] run failed', { tenant, error: message });
+    return summary;
+  }
+}

--- a/ee/temporal-workflows/src/activities/job-activities.ts
+++ b/ee/temporal-workflows/src/activities/job-activities.ts
@@ -24,6 +24,7 @@ import { publishEvent } from '@alga-psa/event-bus/publishers';
 const RMM_ALERT_RECONCILIATION_JOB = 'rmm-alert-reconciliation';
 const HUNTRESS_INCIDENT_POLL_JOB = 'huntress-incident-poll';
 const ACCOUNTING_SYNC_CYCLE_JOB = 'accounting-sync-cycle';
+const HUDU_AUTO_SYNC_JOB = 'hudu-auto-sync';
 const SYSTEM_TENANT_ID = '00000000-0000-0000-0000-000000000000';
 
 // Configure logger
@@ -118,6 +119,7 @@ export async function initializeJobHandlersForWorker(): Promise<void> {
   registerJobHandlerForActivities(RMM_ALERT_RECONCILIATION_JOB, forwardJobToServer(RMM_ALERT_RECONCILIATION_JOB));
   registerJobHandlerForActivities(HUNTRESS_INCIDENT_POLL_JOB, forwardJobToServer(HUNTRESS_INCIDENT_POLL_JOB));
   registerJobHandlerForActivities(ACCOUNTING_SYNC_CYCLE_JOB, forwardJobToServer(ACCOUNTING_SYNC_CYCLE_JOB));
+  registerJobHandlerForActivities(HUDU_AUTO_SYNC_JOB, forwardJobToServer(HUDU_AUTO_SYNC_JOB));
 
   // User-defined workflow schedules: after the pg-boss → Temporal cutover these
   // arrive as Temporal Schedules (TemporalJobRunner.scheduleJobAt /

--- a/package-lock.json
+++ b/package-lock.json
@@ -73,7 +73,7 @@
         "@types/bcryptjs": "^2.4.6",
         "@types/react-dropzone": "^4.2.2",
         "@types/redis": "^4.0.10",
-        "@vitest/coverage-v8": "^4.0.18",
+        "@vitest/coverage-v8": "^4.1.9",
         "archiver": "^7.0.1",
         "asc": "^2.1.5",
         "assemblyscript": "^0.27.37",
@@ -200,7 +200,7 @@
         "@types/uuid": "^10.0.0",
         "@typescript-eslint/eslint-plugin": "^8.8.0",
         "@typescript-eslint/parser": "^8.8.0",
-        "@vitest/coverage-istanbul": "^4.0.18",
+        "@vitest/coverage-istanbul": "^4.1.9",
         "eslint": "^9.0.0",
         "eslint-plugin-custom-rules": "file:eslint-plugin-custom-rules",
         "eslint-plugin-react": "^7.37.2",
@@ -217,7 +217,7 @@
         "ts-proto": "^2.6.0",
         "typescript": "^5.7.3",
         "vite": "^7.0.0",
-        "vitest": "^4.0.18"
+        "vitest": "^4.1.9"
       },
       "engines": {
         "node": ">=20 <25"
@@ -2327,12 +2327,12 @@
       }
     },
     "node_modules/@babel/code-frame": {
-      "version": "7.28.6",
-      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.28.6.tgz",
-      "integrity": "sha512-JYgintcMjRiCvS8mMECzaEn+m3PfoQiyqukOMCCVQtoJGYJw8j/8LBJEiqkHLkfwCcs74E3pbAUFNg7d9VNJ+Q==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.29.7.tgz",
+      "integrity": "sha512-Aup7aUOfpbAUg2ROOJN6Iw5f9DMBlzu0mIkm/malLQFN/YQgO48wCj0Kxa3sEHJvPVFg7siR+qRInwXd2qhQKw==",
       "license": "MIT",
       "dependencies": {
-        "@babel/helper-validator-identifier": "^7.28.5",
+        "@babel/helper-validator-identifier": "^7.29.7",
         "js-tokens": "^4.0.0",
         "picocolors": "^1.1.1"
       },
@@ -2341,9 +2341,9 @@
       }
     },
     "node_modules/@babel/compat-data": {
-      "version": "7.28.6",
-      "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.28.6.tgz",
-      "integrity": "sha512-2lfu57JtzctfIrcGMz992hyLlByuzgIk58+hhGCxjKZ3rWI82NnVLjXcaTqkI2NvlcvOskZaiZ5kjUALo3Lpxg==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.29.7.tgz",
+      "integrity": "sha512-locTkQyKvwIEgBzVrn8693ebc97F2U8ZHjbXwDXJ5Fn2TCpNwTlKcaKLkdHop5c/icOFE7qt7Q9JC5hnKNa6Gg==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -2351,19 +2351,21 @@
       }
     },
     "node_modules/@babel/core": {
-      "version": "7.28.5",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.29.7.tgz",
+      "integrity": "sha512-RgHBCvtjbOK2gXSNBNIkNoEc9qoVEtau3hj8gEqKQuL3HZAibKarWFEI3Lfm6EYKkLalOh8eSrj9b+ch9H/VBA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/code-frame": "^7.27.1",
-        "@babel/generator": "^7.28.5",
-        "@babel/helper-compilation-targets": "^7.27.2",
-        "@babel/helper-module-transforms": "^7.28.3",
-        "@babel/helpers": "^7.28.4",
-        "@babel/parser": "^7.28.5",
-        "@babel/template": "^7.27.2",
-        "@babel/traverse": "^7.28.5",
-        "@babel/types": "^7.28.5",
+        "@babel/code-frame": "^7.29.7",
+        "@babel/generator": "^7.29.7",
+        "@babel/helper-compilation-targets": "^7.29.7",
+        "@babel/helper-module-transforms": "^7.29.7",
+        "@babel/helpers": "^7.29.7",
+        "@babel/parser": "^7.29.7",
+        "@babel/template": "^7.29.7",
+        "@babel/traverse": "^7.29.7",
+        "@babel/types": "^7.29.7",
         "@jridgewell/remapping": "^2.3.5",
         "convert-source-map": "^2.0.0",
         "debug": "^4.1.0",
@@ -2388,14 +2390,14 @@
       }
     },
     "node_modules/@babel/generator": {
-      "version": "7.28.6",
-      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.28.6.tgz",
-      "integrity": "sha512-lOoVRwADj8hjf7al89tvQ2a1lf53Z+7tiXMgpZJL3maQPDxh0DgLMN62B2MKUOFcoodBHLMbDM6WAbKgNy5Suw==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.29.7.tgz",
+      "integrity": "sha512-DkXD5OJQaAQIdZ1bt3UZdEnHAn9Imd3IVBdX03UFe+ony9Ojw5pzr9YVKGDY1jt+Gcn/FnGkNf8r+Vj5NOJWtQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/parser": "^7.28.6",
-        "@babel/types": "^7.28.6",
+        "@babel/parser": "^7.29.7",
+        "@babel/types": "^7.29.7",
         "@jridgewell/gen-mapping": "^0.3.12",
         "@jridgewell/trace-mapping": "^0.3.28",
         "jsesc": "^3.0.2"
@@ -2418,14 +2420,14 @@
       }
     },
     "node_modules/@babel/helper-compilation-targets": {
-      "version": "7.28.6",
-      "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.28.6.tgz",
-      "integrity": "sha512-JYtls3hqi15fcx5GaSNL7SCTJ2MNmjrkHXg4FSpOA/grxK8KwyZ5bubHsCq8FXCkua6xhuaaBit+3b7+VZRfcA==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.29.7.tgz",
+      "integrity": "sha512-wem6WaBj4NaVYVdNhLPPVacES6ZJ+KBBfSkTMD3YZxbP3rm3Di85tJU5ljaUNhaOynt+Aj0xruhYuzQBt8n71g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/compat-data": "^7.28.6",
-        "@babel/helper-validator-option": "^7.27.1",
+        "@babel/compat-data": "^7.29.7",
+        "@babel/helper-validator-option": "^7.29.7",
         "browserslist": "^4.24.0",
         "lru-cache": "^5.1.1",
         "semver": "^6.3.1"
@@ -2520,7 +2522,9 @@
       }
     },
     "node_modules/@babel/helper-globals": {
-      "version": "7.28.0",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-globals/-/helper-globals-7.29.7.tgz",
+      "integrity": "sha512-3nQVUAtvkKH9zahfWgw96Jc/uFOmjACE1kQz82E2lqWmHBgjzbNlsC22nuQTfahmWeQtTq5nQ/4Nnd2A1wj4zA==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -2542,29 +2546,29 @@
       }
     },
     "node_modules/@babel/helper-module-imports": {
-      "version": "7.28.6",
-      "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.28.6.tgz",
-      "integrity": "sha512-l5XkZK7r7wa9LucGw9LwZyyCUscb4x37JWTPz7swwFE/0FMQAGpiWUZn8u9DzkSBWEcK25jmvubfpw2dnAMdbw==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.29.7.tgz",
+      "integrity": "sha512-ejHwrQQYcm9xnTivShn2IDOlIzInN34AXskvq9QicvCtEzq1Vzclu/tKF8Jq1Cg8JG2GL6/EmjgsCT7lXepE3g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/traverse": "^7.28.6",
-        "@babel/types": "^7.28.6"
+        "@babel/traverse": "^7.29.7",
+        "@babel/types": "^7.29.7"
       },
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/helper-module-transforms": {
-      "version": "7.28.6",
-      "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.28.6.tgz",
-      "integrity": "sha512-67oXFAYr2cDLDVGLXTEABjdBJZ6drElUSI7WKp70NrpyISso3plG9SAGEF6y7zbha/wOzUByWWTJvEDVNIUGcA==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.29.7.tgz",
+      "integrity": "sha512-UPUVSyXbOh627KiCIGQSgwWzGeBKLkaJ9PJEdrngIwMSzxLR4jS4+f1f1jb7VzBbg8nFLaYotvVPFCTqdrmTAg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/helper-module-imports": "^7.28.6",
-        "@babel/helper-validator-identifier": "^7.28.5",
-        "@babel/traverse": "^7.28.6"
+        "@babel/helper-module-imports": "^7.29.7",
+        "@babel/helper-validator-identifier": "^7.29.7",
+        "@babel/traverse": "^7.29.7"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -2647,21 +2651,27 @@
       }
     },
     "node_modules/@babel/helper-string-parser": {
-      "version": "7.27.1",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.29.7.tgz",
+      "integrity": "sha512-Pb5ijPrZ89GDH8223L4UP8i6QApWxs04RbPQJTeWDV0/keR2E36MeKnyr6LYmUUvqRRI+Iv87SuF1W6ErINzYw==",
       "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/helper-validator-identifier": {
-      "version": "7.28.5",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.29.7.tgz",
+      "integrity": "sha512-qehxGkRj55h/ff8EMaJ+cYhyaKlHIxqYDn682wQD7RNp9UujOQsHog2uS0r2vzr4pW+sXf90NeeayjcNaX3fFg==",
       "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/helper-validator-option": {
-      "version": "7.27.1",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-option/-/helper-validator-option-7.29.7.tgz",
+      "integrity": "sha512-N9ZErrD+yW5geCDtBqnOoxmR8+tNKiGuxKlDpuJxfsqpa2dFcexaziGAE/qoHLiDDreVNMupxGmSoNlyvsA3gw==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -2684,24 +2694,26 @@
       }
     },
     "node_modules/@babel/helpers": {
-      "version": "7.28.4",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.29.7.tgz",
+      "integrity": "sha512-1k2lAGRMfHTcwuNYcCNUmaUffmQv8KWMfh2iJUUeRlwlwH4FdNG7mfPI10NPfLHJFThE4Tyr4mv7kTNZOiPuBg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/template": "^7.27.2",
-        "@babel/types": "^7.28.4"
+        "@babel/template": "^7.29.7",
+        "@babel/types": "^7.29.7"
       },
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/parser": {
-      "version": "7.29.0",
-      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.29.0.tgz",
-      "integrity": "sha512-IyDgFV5GeDUVX4YdF/3CPULtVGSXXMLh1xVIgdCgxApktqnQV0r7/8Nqthg+8YLGaAtdyIlo2qIdZrbCv4+7ww==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.29.7.tgz",
+      "integrity": "sha512-hnORnjP/1P/zFEndoeX+n+t1RwWRJiJpM/jO7FW32Kn9r5+sJB2JWOdYo4L6k78j15eCwY3Gm/7364B1EMwtNg==",
       "license": "MIT",
       "dependencies": {
-        "@babel/types": "^7.29.0"
+        "@babel/types": "^7.29.7"
       },
       "bin": {
         "parser": "bin/babel-parser.js"
@@ -4073,33 +4085,33 @@
       }
     },
     "node_modules/@babel/template": {
-      "version": "7.28.6",
-      "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.28.6.tgz",
-      "integrity": "sha512-YA6Ma2KsCdGb+WC6UpBVFJGXL58MDA6oyONbjyF/+5sBgxY/dwkhLogbMT2GXXyU84/IhRw/2D1Os1B/giz+BQ==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.29.7.tgz",
+      "integrity": "sha512-puq+Gf35oI24FeN11LkoUQFqv9uwNeWpxXZi/Ji3rRIoKAzKnxRaZ+Gkj0vKS9ZCiTESfng1N9LyOyXvo+m+Gg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/code-frame": "^7.28.6",
-        "@babel/parser": "^7.28.6",
-        "@babel/types": "^7.28.6"
+        "@babel/code-frame": "^7.29.7",
+        "@babel/parser": "^7.29.7",
+        "@babel/types": "^7.29.7"
       },
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/traverse": {
-      "version": "7.28.6",
-      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.28.6.tgz",
-      "integrity": "sha512-fgWX62k02qtjqdSNTAGxmKYY/7FSL9WAS1o2Hu5+I5m9T0yxZzr4cnrfXQ/MX0rIifthCSs6FKTlzYbJcPtMNg==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.29.7.tgz",
+      "integrity": "sha512-EhlfNQtZ+NK22w5BM61ciuiq1m58ed33Wr1Xan//ZRTy6hgjnwyCffRYwzsGXdASJSUJ1guZILsErh1eQcl+zw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/code-frame": "^7.28.6",
-        "@babel/generator": "^7.28.6",
-        "@babel/helper-globals": "^7.28.0",
-        "@babel/parser": "^7.28.6",
-        "@babel/template": "^7.28.6",
-        "@babel/types": "^7.28.6",
+        "@babel/code-frame": "^7.29.7",
+        "@babel/generator": "^7.29.7",
+        "@babel/helper-globals": "^7.29.7",
+        "@babel/parser": "^7.29.7",
+        "@babel/template": "^7.29.7",
+        "@babel/types": "^7.29.7",
         "debug": "^4.3.1"
       },
       "engines": {
@@ -4107,13 +4119,13 @@
       }
     },
     "node_modules/@babel/types": {
-      "version": "7.29.0",
-      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.29.0.tgz",
-      "integrity": "sha512-LwdZHpScM4Qz8Xw2iKSzS+cfglZzJGvofQICy7W7v4caru4EaAmyUuO6BGrbyQ2mYV11W0U8j5mBhd14dd3B0A==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.29.7.tgz",
+      "integrity": "sha512-4zBIxpPzowiZpusoFkyGVwakdRJUyuH5PxQ/PrqghfdFWWasvnCdPfQXHrenDai+gyLARulZjZowCOj6fjT4pA==",
       "license": "MIT",
       "dependencies": {
-        "@babel/helper-string-parser": "^7.27.1",
-        "@babel/helper-validator-identifier": "^7.28.5"
+        "@babel/helper-string-parser": "^7.29.7",
+        "@babel/helper-validator-identifier": "^7.29.7"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -22392,53 +22404,53 @@
       "license": "ISC"
     },
     "node_modules/@vitest/coverage-istanbul": {
-      "version": "4.0.18",
-      "resolved": "https://registry.npmjs.org/@vitest/coverage-istanbul/-/coverage-istanbul-4.0.18.tgz",
-      "integrity": "sha512-0OhjP30owEDihYTZGWuq20rNtV1RjjJs1Mv4MaZIKcFBmiLUXX7HJLX4fU7wE+Mrc3lQxI2HKq6WrSXi5FGuCQ==",
+      "version": "4.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/coverage-istanbul/-/coverage-istanbul-4.1.9.tgz",
+      "integrity": "sha512-4a7DsIwycTf4eYwEDtnMfMV8H80KSKH9PuMHhqL5SwPZzDyUKq2X/TPCVZ7NqIuSz7UbZckmEmkip6iZBI/gEA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
+        "@babel/core": "^7.29.0",
         "@istanbuljs/schema": "^0.1.3",
         "@jridgewell/gen-mapping": "^0.3.13",
         "@jridgewell/trace-mapping": "0.3.31",
         "istanbul-lib-coverage": "^3.2.2",
-        "istanbul-lib-instrument": "^6.0.3",
         "istanbul-lib-report": "^3.0.1",
         "istanbul-reports": "^3.2.0",
-        "magicast": "^0.5.1",
+        "magicast": "^0.5.2",
         "obug": "^2.1.1",
-        "tinyrainbow": "^3.0.3"
+        "tinyrainbow": "^3.1.0"
       },
       "funding": {
         "url": "https://opencollective.com/vitest"
       },
       "peerDependencies": {
-        "vitest": "4.0.18"
+        "vitest": "4.1.9"
       }
     },
     "node_modules/@vitest/coverage-v8": {
-      "version": "4.0.18",
-      "resolved": "https://registry.npmjs.org/@vitest/coverage-v8/-/coverage-v8-4.0.18.tgz",
-      "integrity": "sha512-7i+N2i0+ME+2JFZhfuz7Tg/FqKtilHjGyGvoHYQ6iLV0zahbsJ9sljC9OcFcPDbhYKCet+sG8SsVqlyGvPflZg==",
+      "version": "4.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/coverage-v8/-/coverage-v8-4.1.9.tgz",
+      "integrity": "sha512-G9/lgqibheLVBDRuya45EbsEXTYcWoSG+TLg7i2axuzx0Eq62eXn+aWXyaVdV5vKvFSWd6ywcX8hA7la9Pvu8g==",
       "license": "MIT",
       "dependencies": {
         "@bcoe/v8-coverage": "^1.0.2",
-        "@vitest/utils": "4.0.18",
-        "ast-v8-to-istanbul": "^0.3.10",
+        "@vitest/utils": "4.1.9",
+        "ast-v8-to-istanbul": "^1.0.0",
         "istanbul-lib-coverage": "^3.2.2",
         "istanbul-lib-report": "^3.0.1",
         "istanbul-reports": "^3.2.0",
-        "magicast": "^0.5.1",
+        "magicast": "^0.5.2",
         "obug": "^2.1.1",
-        "std-env": "^3.10.0",
-        "tinyrainbow": "^3.0.3"
+        "std-env": "^4.0.0-rc.1",
+        "tinyrainbow": "^3.1.0"
       },
       "funding": {
         "url": "https://opencollective.com/vitest"
       },
       "peerDependencies": {
-        "@vitest/browser": "4.0.18",
-        "vitest": "4.0.18"
+        "@vitest/browser": "4.1.9",
+        "vitest": "4.1.9"
       },
       "peerDependenciesMeta": {
         "@vitest/browser": {
@@ -22446,46 +22458,41 @@
         }
       }
     },
+    "node_modules/@vitest/coverage-v8/node_modules/ast-v8-to-istanbul": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/ast-v8-to-istanbul/-/ast-v8-to-istanbul-1.0.4.tgz",
+      "integrity": "sha512-0bC0/4bTSrnwdhU3IsZDwEdojvuPrSg59OYZfKsLRtJZ0u8VBx9DebfqqG8bRdCC0I7vjgxmPi41P0lpkhJHtA==",
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/trace-mapping": "^0.3.31",
+        "estree-walker": "^3.0.3",
+        "js-tokens": "^10.0.0"
+      }
+    },
+    "node_modules/@vitest/coverage-v8/node_modules/js-tokens": {
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-10.0.0.tgz",
+      "integrity": "sha512-lM/UBzQmfJRo9ABXbPWemivdCW8V2G8FHaHdypQaIy523snUjog0W71ayWXTjiR+ixeMyVHN2XcpnTd/liPg/Q==",
+      "license": "MIT"
+    },
+    "node_modules/@vitest/coverage-v8/node_modules/std-env": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/std-env/-/std-env-4.1.0.tgz",
+      "integrity": "sha512-Rq7ybcX2RuC55r9oaPVEW7/xu3tj8u4GeBYHBWCychFtzMIr86A7e3PPEBPT37sHStKX3+TiX/Fr/ACmJLVlLQ==",
+      "license": "MIT"
+    },
     "node_modules/@vitest/expect": {
-      "version": "4.1.8",
-      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-4.1.8.tgz",
-      "integrity": "sha512-h3nDO677RDLEGlBxyQ5CW8RlMThSKSRLUePLOx09gNIWRL40edgA1GCZSZgf1W55MFAG6/Sw14KeaAnqv0NKdQ==",
+      "version": "4.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-4.1.9.tgz",
+      "integrity": "sha512-vl/rYsUKcBr3SnQn166+XR5ZQcgMx3DQhFWdfli/cWpLnLUmbxZvyrJZotLFUryib+LtArYMSTJ5RbQ57ZqrlA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@standard-schema/spec": "^1.1.0",
         "@types/chai": "^5.2.2",
-        "@vitest/spy": "4.1.8",
-        "@vitest/utils": "4.1.8",
+        "@vitest/spy": "4.1.9",
+        "@vitest/utils": "4.1.9",
         "chai": "^6.2.2",
-        "tinyrainbow": "^3.1.0"
-      },
-      "funding": {
-        "url": "https://opencollective.com/vitest"
-      }
-    },
-    "node_modules/@vitest/expect/node_modules/@vitest/pretty-format": {
-      "version": "4.1.8",
-      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-4.1.8.tgz",
-      "integrity": "sha512-9GasEBxpZ1VYIpqHf/0+YGg121uSNwCKOJqIrTwWP/TB7DmFCiaBpNl3aPZzoLWfWkuqhbH8vJIVobZkvdo2cA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "tinyrainbow": "^3.1.0"
-      },
-      "funding": {
-        "url": "https://opencollective.com/vitest"
-      }
-    },
-    "node_modules/@vitest/expect/node_modules/@vitest/utils": {
-      "version": "4.1.8",
-      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-4.1.8.tgz",
-      "integrity": "sha512-uOJamYALNhfJ6iolExyQM40yIQwDqYnkKtQ5VCiSe17E33H0aQ/u+1GlRuz4LZBk6Mm3sg90G9hEbmEt37C1Zg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@vitest/pretty-format": "4.1.8",
-        "convert-source-map": "^2.0.0",
         "tinyrainbow": "^3.1.0"
       },
       "funding": {
@@ -22503,13 +22510,13 @@
       }
     },
     "node_modules/@vitest/mocker": {
-      "version": "4.1.8",
-      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-4.1.8.tgz",
-      "integrity": "sha512-LEiN/xe4OSIbKe9HQIp5OC24agGD9J5CnmMgsLohVVoOPWL9a2sBoR6VBx43jQZb7Kr1l4RCuyCJzcAa0+dojw==",
+      "version": "4.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-4.1.9.tgz",
+      "integrity": "sha512-EVkXzBjrPGM+cK8/ANWgBrkUCfJfb38/EfTSO8h7pWvKkyPkpWxvR7BkD2MyItMF62C97zAEoqdpUixwR/e+Rw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@vitest/spy": "4.1.8",
+        "@vitest/spy": "4.1.9",
         "estree-walker": "^3.0.3",
         "magic-string": "^0.30.21"
       },
@@ -22530,68 +22537,40 @@
       }
     },
     "node_modules/@vitest/pretty-format": {
-      "version": "4.0.18",
-      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-4.0.18.tgz",
-      "integrity": "sha512-P24GK3GulZWC5tz87ux0m8OADrQIUVDPIjjj65vBXYG17ZeU3qD7r+MNZ1RNv4l8CGU2vtTRqixrOi9fYk/yKw==",
+      "version": "4.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-4.1.9.tgz",
+      "integrity": "sha512-s0iufns3iIFitdgm+YR7g1whCAaGtXz459VS9/PqyKDEEFgYIhsHOQmXgIgDuYCt7DeQmiZT0Qe2OA2p4ZPu5A==",
       "license": "MIT",
       "dependencies": {
-        "tinyrainbow": "^3.0.3"
+        "tinyrainbow": "^3.1.0"
       },
       "funding": {
         "url": "https://opencollective.com/vitest"
       }
     },
     "node_modules/@vitest/runner": {
-      "version": "4.1.8",
-      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-4.1.8.tgz",
-      "integrity": "sha512-EmVxeBAfMJvycdjd6Hm+RbFBbA9fKvo0Kx37hNpBYoYeavH3RNsBXWDooR1mgD52dCrxIIuP7UotpfiwOikvcg==",
+      "version": "4.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-4.1.9.tgz",
+      "integrity": "sha512-KXLMDtc7oe70+3mJfGrPUWPesswH+3sTxAMAMl8DG7I8IUQT4XW718dY5ID3vPUcmlu27CcKfY4P3h3I29SLJg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@vitest/utils": "4.1.8",
+        "@vitest/utils": "4.1.9",
         "pathe": "^2.0.3"
       },
       "funding": {
         "url": "https://opencollective.com/vitest"
       }
     },
-    "node_modules/@vitest/runner/node_modules/@vitest/pretty-format": {
-      "version": "4.1.8",
-      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-4.1.8.tgz",
-      "integrity": "sha512-9GasEBxpZ1VYIpqHf/0+YGg121uSNwCKOJqIrTwWP/TB7DmFCiaBpNl3aPZzoLWfWkuqhbH8vJIVobZkvdo2cA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "tinyrainbow": "^3.1.0"
-      },
-      "funding": {
-        "url": "https://opencollective.com/vitest"
-      }
-    },
-    "node_modules/@vitest/runner/node_modules/@vitest/utils": {
-      "version": "4.1.8",
-      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-4.1.8.tgz",
-      "integrity": "sha512-uOJamYALNhfJ6iolExyQM40yIQwDqYnkKtQ5VCiSe17E33H0aQ/u+1GlRuz4LZBk6Mm3sg90G9hEbmEt37C1Zg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@vitest/pretty-format": "4.1.8",
-        "convert-source-map": "^2.0.0",
-        "tinyrainbow": "^3.1.0"
-      },
-      "funding": {
-        "url": "https://opencollective.com/vitest"
-      }
-    },
     "node_modules/@vitest/snapshot": {
-      "version": "4.1.8",
-      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-4.1.8.tgz",
-      "integrity": "sha512-acfZboRmAIf05DEKcBQy33VXojFJjtUdLyo7oOmV9kebb2xdU01UknNiPuPZoJZQyO7DF0gZdTGTpeAzET9QPQ==",
+      "version": "4.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-4.1.9.tgz",
+      "integrity": "sha512-Jc7RKGNBo8Z28WYIm0Niej4xdSPByRf6mU58VpHQkd6Zh05rlnA+twjbK5HyeIGHxrzsc3mJgS43uM0CZKzaIA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@vitest/pretty-format": "4.1.8",
-        "@vitest/utils": "4.1.8",
+        "@vitest/pretty-format": "4.1.9",
+        "@vitest/utils": "4.1.9",
         "magic-string": "^0.30.21",
         "pathe": "^2.0.3"
       },
@@ -22599,38 +22578,10 @@
         "url": "https://opencollective.com/vitest"
       }
     },
-    "node_modules/@vitest/snapshot/node_modules/@vitest/pretty-format": {
-      "version": "4.1.8",
-      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-4.1.8.tgz",
-      "integrity": "sha512-9GasEBxpZ1VYIpqHf/0+YGg121uSNwCKOJqIrTwWP/TB7DmFCiaBpNl3aPZzoLWfWkuqhbH8vJIVobZkvdo2cA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "tinyrainbow": "^3.1.0"
-      },
-      "funding": {
-        "url": "https://opencollective.com/vitest"
-      }
-    },
-    "node_modules/@vitest/snapshot/node_modules/@vitest/utils": {
-      "version": "4.1.8",
-      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-4.1.8.tgz",
-      "integrity": "sha512-uOJamYALNhfJ6iolExyQM40yIQwDqYnkKtQ5VCiSe17E33H0aQ/u+1GlRuz4LZBk6Mm3sg90G9hEbmEt37C1Zg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@vitest/pretty-format": "4.1.8",
-        "convert-source-map": "^2.0.0",
-        "tinyrainbow": "^3.1.0"
-      },
-      "funding": {
-        "url": "https://opencollective.com/vitest"
-      }
-    },
     "node_modules/@vitest/spy": {
-      "version": "4.1.8",
-      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-4.1.8.tgz",
-      "integrity": "sha512-6EevtBp6OZOPF7bmz36HrGMeP3txgVSrgebWxHOafDXGkhIzfXK14f8KF6MuFfgXXUeHxmpD3BQxkV00/3s5mA==",
+      "version": "4.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-4.1.9.tgz",
+      "integrity": "sha512-fHpsS6mIi+PiEW+vcRVOMkX1oSaPKne3VOclSFICPcGOmfKgXPU5iAah+wcNcj2xPrCCmfq99IDGf+EojhhvhA==",
       "dev": true,
       "license": "MIT",
       "funding": {
@@ -22638,13 +22589,14 @@
       }
     },
     "node_modules/@vitest/utils": {
-      "version": "4.0.18",
-      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-4.0.18.tgz",
-      "integrity": "sha512-msMRKLMVLWygpK3u2Hybgi4MNjcYJvwTb0Ru09+fOyCXIgT5raYP041DRRdiJiI3k/2U6SEbAETB3YtBrUkCFA==",
+      "version": "4.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-4.1.9.tgz",
+      "integrity": "sha512-A51o8ymO5PpqlWNnBP9ZHPXDIpuMtTLlGSjN7la4US+LJzoUMyhwjA5QXlm39JexgwHKW4Xjs8Z2d3dLCXOeuA==",
       "license": "MIT",
       "dependencies": {
-        "@vitest/pretty-format": "4.0.18",
-        "tinyrainbow": "^3.0.3"
+        "@vitest/pretty-format": "4.1.9",
+        "convert-source-map": "^2.0.0",
+        "tinyrainbow": "^3.1.0"
       },
       "funding": {
         "url": "https://opencollective.com/vitest"
@@ -23453,6 +23405,7 @@
     },
     "node_modules/ast-v8-to-istanbul": {
       "version": "0.3.10",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@jridgewell/trace-mapping": "^0.3.31",
@@ -23462,6 +23415,7 @@
     },
     "node_modules/ast-v8-to-istanbul/node_modules/js-tokens": {
       "version": "9.0.1",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/async": {
@@ -25183,7 +25137,6 @@
     },
     "node_modules/convert-source-map": {
       "version": "2.0.0",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/convert-to-spaces": {
@@ -44057,19 +44010,19 @@
       }
     },
     "node_modules/vitest": {
-      "version": "4.1.8",
-      "resolved": "https://registry.npmjs.org/vitest/-/vitest-4.1.8.tgz",
-      "integrity": "sha512-flY6ScbCIt9HThs+C5HS7jvGOB560DJtk/Z15IQROTA6zEy49Nh8T/dofWTQL+n3vswqn87sbJNiuqw1SDp5Ig==",
+      "version": "4.1.9",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-4.1.9.tgz",
+      "integrity": "sha512-nE3/LEyc0z87uHYLZebqCUOaJr2hdtuPp7BQ4BosVFnfltxgAvMG08NyrSGlPpOUWvR27c5flSmYFTNr78L9GQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@vitest/expect": "4.1.8",
-        "@vitest/mocker": "4.1.8",
-        "@vitest/pretty-format": "4.1.8",
-        "@vitest/runner": "4.1.8",
-        "@vitest/snapshot": "4.1.8",
-        "@vitest/spy": "4.1.8",
-        "@vitest/utils": "4.1.8",
+        "@vitest/expect": "4.1.9",
+        "@vitest/mocker": "4.1.9",
+        "@vitest/pretty-format": "4.1.9",
+        "@vitest/runner": "4.1.9",
+        "@vitest/snapshot": "4.1.9",
+        "@vitest/spy": "4.1.9",
+        "@vitest/utils": "4.1.9",
         "es-module-lexer": "^2.0.0",
         "expect-type": "^1.3.0",
         "magic-string": "^0.30.21",
@@ -44097,12 +44050,12 @@
         "@edge-runtime/vm": "*",
         "@opentelemetry/api": "^1.9.0",
         "@types/node": "^20.0.0 || ^22.0.0 || >=24.0.0",
-        "@vitest/browser-playwright": "4.1.8",
-        "@vitest/browser-preview": "4.1.8",
-        "@vitest/browser-webdriverio": "4.1.8",
-        "@vitest/coverage-istanbul": "4.1.8",
-        "@vitest/coverage-v8": "4.1.8",
-        "@vitest/ui": "4.1.8",
+        "@vitest/browser-playwright": "4.1.9",
+        "@vitest/browser-preview": "4.1.9",
+        "@vitest/browser-webdriverio": "4.1.9",
+        "@vitest/coverage-istanbul": "4.1.9",
+        "@vitest/coverage-v8": "4.1.9",
+        "@vitest/ui": "4.1.9",
         "happy-dom": "*",
         "jsdom": "*",
         "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
@@ -44144,34 +44097,6 @@
         "vite": {
           "optional": false
         }
-      }
-    },
-    "node_modules/vitest/node_modules/@vitest/pretty-format": {
-      "version": "4.1.8",
-      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-4.1.8.tgz",
-      "integrity": "sha512-9GasEBxpZ1VYIpqHf/0+YGg121uSNwCKOJqIrTwWP/TB7DmFCiaBpNl3aPZzoLWfWkuqhbH8vJIVobZkvdo2cA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "tinyrainbow": "^3.1.0"
-      },
-      "funding": {
-        "url": "https://opencollective.com/vitest"
-      }
-    },
-    "node_modules/vitest/node_modules/@vitest/utils": {
-      "version": "4.1.8",
-      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-4.1.8.tgz",
-      "integrity": "sha512-uOJamYALNhfJ6iolExyQM40yIQwDqYnkKtQ5VCiSe17E33H0aQ/u+1GlRuz4LZBk6Mm3sg90G9hEbmEt37C1Zg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@vitest/pretty-format": "4.1.8",
-        "convert-source-map": "^2.0.0",
-        "tinyrainbow": "^3.1.0"
-      },
-      "funding": {
-        "url": "https://opencollective.com/vitest"
       }
     },
     "node_modules/vitest/node_modules/es-module-lexer": {
@@ -45806,6 +45731,7 @@
         "@alga-psa/block-content": "*",
         "@alga-psa/core": "*",
         "@alga-psa/db": "*",
+        "@alga-psa/formatting": "*",
         "@alga-psa/shared": "*",
         "@alga-psa/types": "*",
         "@alga-psa/ui": "*",
@@ -45994,7 +45920,7 @@
     },
     "packages/core": {
       "name": "@alga-psa/core",
-      "version": "1.2.7",
+      "version": "1.2.12",
       "dependencies": {
         "dotenv": "^16.4.5",
         "node-vault": "^0.10.2",
@@ -46524,6 +46450,7 @@
         "@alga-psa/auth": "*",
         "@alga-psa/core": "*",
         "@alga-psa/db": "*",
+        "@alga-psa/formatting": "*",
         "@alga-psa/tenancy": "*",
         "@alga-psa/types": "*",
         "@alga-psa/validation": "*"
@@ -50640,7 +50567,7 @@
       }
     },
     "server": {
-      "version": "1.2.7",
+      "version": "1.2.12",
       "license": "ISC",
       "dependencies": {
         "@alga-psa/authorization": "*",

--- a/package-lock.json
+++ b/package-lock.json
@@ -45806,6 +45806,7 @@
         "@alga-psa/block-content": "*",
         "@alga-psa/core": "*",
         "@alga-psa/db": "*",
+        "@alga-psa/formatting": "*",
         "@alga-psa/shared": "*",
         "@alga-psa/types": "*",
         "@alga-psa/ui": "*",
@@ -45994,7 +45995,7 @@
     },
     "packages/core": {
       "name": "@alga-psa/core",
-      "version": "1.2.7",
+      "version": "1.2.12",
       "dependencies": {
         "dotenv": "^16.4.5",
         "node-vault": "^0.10.2",
@@ -46524,6 +46525,7 @@
         "@alga-psa/auth": "*",
         "@alga-psa/core": "*",
         "@alga-psa/db": "*",
+        "@alga-psa/formatting": "*",
         "@alga-psa/tenancy": "*",
         "@alga-psa/types": "*",
         "@alga-psa/validation": "*"
@@ -50640,7 +50642,7 @@
       }
     },
     "server": {
-      "version": "1.2.7",
+      "version": "1.2.12",
       "license": "ISC",
       "dependencies": {
         "@alga-psa/authorization": "*",

--- a/package-lock.json
+++ b/package-lock.json
@@ -45806,7 +45806,6 @@
         "@alga-psa/block-content": "*",
         "@alga-psa/core": "*",
         "@alga-psa/db": "*",
-        "@alga-psa/formatting": "*",
         "@alga-psa/shared": "*",
         "@alga-psa/types": "*",
         "@alga-psa/ui": "*",
@@ -45995,7 +45994,7 @@
     },
     "packages/core": {
       "name": "@alga-psa/core",
-      "version": "1.2.12",
+      "version": "1.2.7",
       "dependencies": {
         "dotenv": "^16.4.5",
         "node-vault": "^0.10.2",
@@ -46525,7 +46524,6 @@
         "@alga-psa/auth": "*",
         "@alga-psa/core": "*",
         "@alga-psa/db": "*",
-        "@alga-psa/formatting": "*",
         "@alga-psa/tenancy": "*",
         "@alga-psa/types": "*",
         "@alga-psa/validation": "*"
@@ -50642,7 +50640,7 @@
       }
     },
     "server": {
-      "version": "1.2.12",
+      "version": "1.2.7",
       "license": "ISC",
       "dependencies": {
         "@alga-psa/authorization": "*",

--- a/package.json
+++ b/package.json
@@ -120,7 +120,7 @@
     "@types/bcryptjs": "^2.4.6",
     "@types/react-dropzone": "^4.2.2",
     "@types/redis": "^4.0.10",
-    "@vitest/coverage-v8": "^4.0.18",
+    "@vitest/coverage-v8": "^4.1.9",
     "archiver": "^7.0.1",
     "asc": "^2.1.5",
     "assemblyscript": "^0.27.37",
@@ -247,7 +247,7 @@
     "@types/uuid": "^10.0.0",
     "@typescript-eslint/eslint-plugin": "^8.8.0",
     "@typescript-eslint/parser": "^8.8.0",
-    "@vitest/coverage-istanbul": "^4.0.18",
+    "@vitest/coverage-istanbul": "^4.1.9",
     "eslint": "^9.0.0",
     "eslint-plugin-custom-rules": "file:eslint-plugin-custom-rules",
     "eslint-plugin-react": "^7.37.2",
@@ -264,7 +264,7 @@
     "ts-proto": "^2.6.0",
     "typescript": "^5.7.3",
     "vite": "^7.0.0",
-    "vitest": "^4.0.18"
+    "vitest": "^4.1.9"
   },
   "description": "This is a [Next.js](https://nextjs.org/) project bootstrapped with [`create-next-app`](https://github.com/vercel/next.js/tree/canary/packages/create-next-app).",
   "main": "index.js",

--- a/packages/assets/src/actions/assetActions.ts
+++ b/packages/assets/src/actions/assetActions.ts
@@ -782,21 +782,21 @@ function formatAssetForOutput(asset: any): Asset {
     return formattedAsset;
 }
 
-export const createAsset = withAuth(async (
-    user,
-    { tenant },
+/**
+ * Actor-injectable asset creation core (no withAuth). Shared by the createAsset
+ * server action (passes the session user id) and sessionless callers such as
+ * the Hudu background sync (passes a resolved tenant audit user id). Permission
+ * checks live in the withAuth wrapper; this core trusts its caller.
+ */
+export async function createAssetRecord(
+    knex: Knex,
+    tenant: string,
+    actorUserId: string,
     data: CreateAssetRequest,
     // Importers (e.g. Hudu) project best-effort attributes and must never fail
     // on a required custom field the source didn't supply; they pass false.
     options?: { requireCustomAttributes?: boolean }
-): Promise<Asset> => {
-    const { knex } = await createTenantKnex();
-
-    // Check permission for asset creation
-    if (!await hasPermission(user, 'asset', 'create')) {
-        throw new Error('Permission denied: Cannot create assets');
-    }
-
+): Promise<Asset> {
     try {
         // Validate input data first
         try {
@@ -875,7 +875,7 @@ export const createAsset = withAuth(async (
             await trx('asset_history').insert({
                 tenant,
                 asset_id: asset.asset_id,
-                changed_by: user.user_id,
+                changed_by: actorUserId,
                 change_type: 'created',
                 changes: validatedData,
                 changed_at: now
@@ -898,7 +898,7 @@ export const createAsset = withAuth(async (
                 payload: buildAssetCreatedPayload({
                     assetId: created.asset_id,
                     clientId: created.client_id || undefined,
-                    createdByUserId: user.user_id,
+                    createdByUserId: actorUserId,
                     createdAt: created.created_at || occurredAt,
                     assetType: created.asset_type,
                     serialNumber: created.serial_number,
@@ -906,7 +906,7 @@ export const createAsset = withAuth(async (
                 ctx: {
                     tenantId: tenant,
                     occurredAt,
-                    actor: { actorType: 'USER', actorUserId: user.user_id },
+                    actor: { actorType: 'USER', actorUserId },
                 },
             });
 
@@ -928,7 +928,7 @@ export const createAsset = withAuth(async (
                     ctx: {
                         tenantId: tenant,
                         occurredAt,
-                        actor: { actorType: 'USER', actorUserId: user.user_id },
+                        actor: { actorType: 'USER', actorUserId },
                     },
                 });
             }
@@ -954,25 +954,52 @@ export const createAsset = withAuth(async (
         }
         throw new Error('Failed to create asset');
     }
-});
+}
 
-export const updateAsset = withAuth(async (
+export const createAsset = withAuth(async (
     user,
     { tenant },
-    asset_id: string,
-    data: UpdateAssetRequest,
-    opts?: { suppressRevalidate?: boolean }
+    data: CreateAssetRequest,
+    options?: { requireCustomAttributes?: boolean }
 ): Promise<Asset> => {
     const { knex } = await createTenantKnex();
 
-    // Check permission for asset updating
-    if (!await hasPermission(user, 'asset', 'update')) {
-        throw new Error('Permission denied: Cannot update assets');
+    // Check permission for asset creation
+    if (!await hasPermission(user, 'asset', 'create')) {
+        throw new Error('Permission denied: Cannot create assets');
     }
 
+    return createAssetRecord(knex, tenant, user.user_id, data, options);
+});
+
+export interface AssetWriteHooks {
+    /**
+     * Runs inside the write transaction. The withAuth wrappers supply the
+     * user-scoped read-authorization context; sessionless callers (e.g. the
+     * Hudu background sync) omit it and write as a full-access system actor.
+     */
+    authorize?: (trx: Knex.Transaction) => Promise<void>;
+}
+
+/**
+ * Actor-injectable asset update core (no withAuth). Shared by the updateAsset
+ * server action and sessionless callers. Permission + user authorization live
+ * in the wrapper / authorize hook; this core trusts its caller.
+ */
+export async function updateAssetRecord(
+    knex: Knex,
+    tenant: string,
+    actorUserId: string,
+    asset_id: string,
+    data: UpdateAssetRequest,
+    opts?: { suppressRevalidate?: boolean },
+    hooks?: AssetWriteHooks
+): Promise<Asset> {
     try {
         const result = await knex.transaction(async (trx: Knex.Transaction) => {
-            await createAuthorizedAssetReadContextForUser(trx, tenant, user as AssetAuthUser, asset_id);
+            if (hooks?.authorize) {
+                await hooks.authorize(trx);
+            }
 
             const normalizedData = sanitizeUpdatePayload(data);
             const validatedData = validateData(updateAssetSchema, normalizedData);
@@ -1103,7 +1130,7 @@ export const updateAsset = withAuth(async (
             await trx('asset_history').insert({
                 tenant,
                 asset_id,
-                changed_by: user.user_id,
+                changed_by: actorUserId,
                 change_type: 'updated',
                 changes: validatedData,
                 changed_at: knex.fn.now()
@@ -1136,7 +1163,7 @@ export const updateAsset = withAuth(async (
             before: result.before,
             after: result.after,
             updatedPaths,
-            updatedByUserId: user.user_id,
+            updatedByUserId: actorUserId,
             updatedAt: occurredAt,
         });
 
@@ -1147,7 +1174,7 @@ export const updateAsset = withAuth(async (
                 ctx: {
                     tenantId: tenant,
                     occurredAt,
-                    actor: { actorType: 'USER', actorUserId: user.user_id },
+                    actor: { actorType: 'USER', actorUserId },
                 },
             });
         }
@@ -1168,7 +1195,7 @@ export const updateAsset = withAuth(async (
                 ctx: {
                     tenantId: tenant,
                     occurredAt,
-                    actor: { actorType: 'USER', actorUserId: user.user_id },
+                    actor: { actorType: 'USER', actorUserId },
                 },
             });
         }
@@ -1191,7 +1218,7 @@ export const updateAsset = withAuth(async (
                 ctx: {
                     tenantId: tenant,
                     occurredAt,
-                    actor: { actorType: 'USER', actorUserId: user.user_id },
+                    actor: { actorType: 'USER', actorUserId },
                 },
             });
         }
@@ -1218,23 +1245,47 @@ export const updateAsset = withAuth(async (
         }
         throw new Error('Failed to update asset');
     }
-});
+}
 
-export const deleteAsset = withAuth(async (
+export const updateAsset = withAuth(async (
     user,
     { tenant },
     asset_id: string,
+    data: UpdateAssetRequest,
     opts?: { suppressRevalidate?: boolean }
-): Promise<DeletionValidationResult & { success: boolean; deleted?: boolean }> => {
+): Promise<Asset> => {
+    const { knex } = await createTenantKnex();
+
+    // Check permission for asset updating
+    if (!await hasPermission(user, 'asset', 'update')) {
+        throw new Error('Permission denied: Cannot update assets');
+    }
+
+    return updateAssetRecord(knex, tenant, user.user_id, asset_id, data, opts, {
+        authorize: async (trx) => {
+            await createAuthorizedAssetReadContextForUser(trx, tenant, user as AssetAuthUser, asset_id);
+        },
+    });
+});
+
+/**
+ * Actor-injectable asset deletion core (no withAuth). Shared by the deleteAsset
+ * server action and sessionless callers (e.g. Hudu orphan cleanup). Permission
+ * + user authorization live in the wrapper / authorize hook.
+ */
+export async function deleteAssetRecord(
+    knex: Knex,
+    tenant: string,
+    actorUserId: string,
+    asset_id: string,
+    opts?: { suppressRevalidate?: boolean },
+    hooks?: { authorize?: (trx: Knex.Transaction, tenantId: string) => Promise<void> }
+): Promise<DeletionValidationResult & { success: boolean; deleted?: boolean }> {
     try {
-        const { knex } = await createTenantKnex();
-
-        if (!await hasPermission(user, 'asset', 'delete')) {
-            throw new Error('Permission denied: Cannot delete assets');
-        }
-
         const result = await deleteEntityWithValidation('asset', asset_id, knex, tenant, async (trx, tenantId) => {
-            await createAuthorizedAssetReadContextForUser(trx as Knex.Transaction, tenantId, user as AssetAuthUser, asset_id);
+            if (hooks?.authorize) {
+                await hooks.authorize(trx as Knex.Transaction, tenantId);
+            }
 
             const asset = await trx('assets')
                 .where({ tenant: tenantId, asset_id })
@@ -1314,13 +1365,13 @@ export const deleteAsset = withAuth(async (
                 eventType: 'ASSET_DELETED',
                 payload: {
                     assetId: asset_id,
-                    userId: user.user_id,
+                    userId: actorUserId,
                     timestamp: occurredAt,
                 },
                 ctx: {
                     tenantId: tenant,
                     occurredAt,
-                    actor: { actorType: 'USER', actorUserId: user.user_id },
+                    actor: { actorType: 'USER', actorUserId },
                 },
                 idempotencyKey: `asset_deleted:${asset_id}:${occurredAt}`,
             });
@@ -1342,6 +1393,25 @@ export const deleteAsset = withAuth(async (
             alternatives: []
         };
     }
+}
+
+export const deleteAsset = withAuth(async (
+    user,
+    { tenant },
+    asset_id: string,
+    opts?: { suppressRevalidate?: boolean }
+): Promise<DeletionValidationResult & { success: boolean; deleted?: boolean }> => {
+    const { knex } = await createTenantKnex();
+
+    if (!await hasPermission(user, 'asset', 'delete')) {
+        throw new Error('Permission denied: Cannot delete assets');
+    }
+
+    return deleteAssetRecord(knex, tenant, user.user_id, asset_id, opts, {
+        authorize: async (trx, tenantId) => {
+            await createAuthorizedAssetReadContextForUser(trx as Knex.Transaction, tenantId, user as AssetAuthUser, asset_id);
+        },
+    });
 });
 
 // Each item in a bulk action commits independently so partial failures

--- a/packages/ee/src/lib/integrations/hudu/tenantSync.ts
+++ b/packages/ee/src/lib/integrations/hudu/tenantSync.ts
@@ -1,0 +1,57 @@
+/**
+ * CE stub for the EE Hudu tenant-wide sync engine
+ * (ee/server/src/lib/integrations/hudu/tenantSync.ts), resolved via the
+ * edition-swapped `@enterprise` alias.
+ *
+ * Community Edition has no Hudu integration; the daily auto-sync handler is
+ * EE-gated and returns before ever invoking these. They exist only so the CE
+ * webpack build can statically resolve the handler's dynamic import.
+ */
+
+export interface HuduAutoSyncDesiredState {
+  isActive: boolean;
+  autoSyncEnabled: boolean;
+}
+
+export async function getHuduAutoSyncDesiredState(
+  _tenant: string
+): Promise<HuduAutoSyncDesiredState | null> {
+  return null;
+}
+
+export interface HuduTenantSyncSummary {
+  sync_type: 'import' | 'sync';
+  started_at: string;
+  completed_at: string;
+  clients: number;
+  items_created: number;
+  items_updated: number;
+  items_skipped: number;
+  items_failed: number;
+  stale: number;
+  errors: string[];
+}
+
+export interface RunHuduTenantSyncOptions {
+  importNew: boolean;
+  actorUserId?: string;
+}
+
+export async function runHuduTenantSync(
+  _tenant: string,
+  options: RunHuduTenantSyncOptions
+): Promise<HuduTenantSyncSummary> {
+  const now = new Date().toISOString();
+  return {
+    sync_type: options.importNew ? 'import' : 'sync',
+    started_at: now,
+    completed_at: now,
+    clients: 0,
+    items_created: 0,
+    items_updated: 0,
+    items_skipped: 0,
+    items_failed: 0,
+    stale: 0,
+    errors: [],
+  };
+}

--- a/server/public/locales/de/msp/integrations.json
+++ b/server/public/locales/de/msp/integrations.json
@@ -1017,6 +1017,27 @@
         },
         "toasts": {
           "errorTitle": "Hudu-Verbindungsfehler"
+        },
+        "sync": {
+          "title": "Synchronisierung & Automatisierung",
+          "description": "Importieren Sie Assets für alle zugeordneten Kunden auf einmal und halten Sie sie automatisch aktuell. Das Zuordnen eines Unternehmens oder Layouts konfiguriert nur die Integration – Assets erscheinen erst nach einem Import.",
+          "summary": "{{created}} erstellt · {{updated}} aktualisiert · {{skipped}} übersprungen · {{failed}} fehlgeschlagen",
+          "toastErrorTitle": "Hudu-Synchronisierungsfehler",
+          "importDoneTitle": "Hudu-Import abgeschlossen",
+          "syncDoneTitle": "Hudu-Synchronisierung abgeschlossen",
+          "importing": "Wird importiert…",
+          "importAll": "Alle zugeordneten Kunden importieren",
+          "syncing2": "Wird synchronisiert…",
+          "syncAll": "Alle synchronisieren",
+          "autoSyncLabel": "Tägliche automatische Synchronisierung",
+          "autoSyncHint": "Importiert täglich automatisch neue Assets und aktualisiert bestehende für jeden zugeordneten Kunden.",
+          "neverRun": "Noch kein mandantenweiter Lauf.",
+          "lastRun": "Letzter Lauf {{at}}: {{created}} erstellt · {{updated}} aktualisiert · {{skipped}} übersprungen · {{failed}} fehlgeschlagen",
+          "status": {
+            "syncing": "Läuft…",
+            "completed": "Abgeschlossen",
+            "error": "Fehler"
+          }
         }
       }
     },

--- a/server/public/locales/en/msp/integrations.json
+++ b/server/public/locales/en/msp/integrations.json
@@ -1017,6 +1017,27 @@
         },
         "toasts": {
           "errorTitle": "Hudu connection error"
+        },
+        "sync": {
+          "title": "Sync & automation",
+          "description": "Import assets for every mapped client at once, and keep them up to date automatically. Mapping a company or layout only configures the integration — assets appear only after an import.",
+          "summary": "{{created}} created · {{updated}} updated · {{skipped}} skipped · {{failed}} failed",
+          "toastErrorTitle": "Hudu sync error",
+          "importDoneTitle": "Hudu import finished",
+          "syncDoneTitle": "Hudu sync finished",
+          "importing": "Importing…",
+          "importAll": "Import all mapped clients",
+          "syncing2": "Syncing…",
+          "syncAll": "Sync all",
+          "autoSyncLabel": "Daily auto-sync",
+          "autoSyncHint": "Automatically import new assets and refresh existing ones once a day for every mapped client.",
+          "neverRun": "No tenant-wide run yet.",
+          "lastRun": "Last run {{at}}: {{created}} created · {{updated}} updated · {{skipped}} skipped · {{failed}} failed",
+          "status": {
+            "syncing": "Running…",
+            "completed": "Completed",
+            "error": "Error"
+          }
         }
       }
     },

--- a/server/public/locales/es/msp/integrations.json
+++ b/server/public/locales/es/msp/integrations.json
@@ -1017,6 +1017,27 @@
         },
         "toasts": {
           "errorTitle": "Error de conexión de Hudu"
+        },
+        "sync": {
+          "title": "Sincronización y automatización",
+          "description": "Importe activos de todos los clientes asignados a la vez y manténgalos actualizados automáticamente. Asignar una empresa o un diseño solo configura la integración: los activos aparecen únicamente tras una importación.",
+          "summary": "{{created}} creados · {{updated}} actualizados · {{skipped}} omitidos · {{failed}} con error",
+          "toastErrorTitle": "Error de sincronización de Hudu",
+          "importDoneTitle": "Importación de Hudu finalizada",
+          "syncDoneTitle": "Sincronización de Hudu finalizada",
+          "importing": "Importando…",
+          "importAll": "Importar todos los clientes asignados",
+          "syncing2": "Sincronizando…",
+          "syncAll": "Sincronizar todo",
+          "autoSyncLabel": "Sincronización automática diaria",
+          "autoSyncHint": "Importa automáticamente activos nuevos y actualiza los existentes una vez al día para cada cliente asignado.",
+          "neverRun": "Aún no hay ninguna ejecución para todo el inquilino.",
+          "lastRun": "Última ejecución {{at}}: {{created}} creados · {{updated}} actualizados · {{skipped}} omitidos · {{failed}} con error",
+          "status": {
+            "syncing": "En ejecución…",
+            "completed": "Completada",
+            "error": "Error"
+          }
         }
       }
     },

--- a/server/public/locales/fr/msp/integrations.json
+++ b/server/public/locales/fr/msp/integrations.json
@@ -1017,6 +1017,27 @@
         },
         "toasts": {
           "errorTitle": "Erreur de connexion Hudu"
+        },
+        "sync": {
+          "title": "Synchronisation et automatisation",
+          "description": "Importez les actifs de tous les clients associés en une seule fois et maintenez-les à jour automatiquement. Associer une entreprise ou une mise en page configure uniquement l'intégration — les actifs n'apparaissent qu'après un import.",
+          "summary": "{{created}} créés · {{updated}} mis à jour · {{skipped}} ignorés · {{failed}} en échec",
+          "toastErrorTitle": "Erreur de synchronisation Hudu",
+          "importDoneTitle": "Import Hudu terminé",
+          "syncDoneTitle": "Synchronisation Hudu terminée",
+          "importing": "Import en cours…",
+          "importAll": "Importer tous les clients associés",
+          "syncing2": "Synchronisation…",
+          "syncAll": "Tout synchroniser",
+          "autoSyncLabel": "Synchronisation automatique quotidienne",
+          "autoSyncHint": "Importe automatiquement les nouveaux actifs et actualise les actifs existants une fois par jour pour chaque client associé.",
+          "neverRun": "Aucune exécution à l'échelle du locataire pour l'instant.",
+          "lastRun": "Dernière exécution {{at}} : {{created}} créés · {{updated}} mis à jour · {{skipped}} ignorés · {{failed}} en échec",
+          "status": {
+            "syncing": "En cours…",
+            "completed": "Terminée",
+            "error": "Erreur"
+          }
         }
       }
     },

--- a/server/public/locales/it/msp/integrations.json
+++ b/server/public/locales/it/msp/integrations.json
@@ -1017,6 +1017,27 @@
         },
         "toasts": {
           "errorTitle": "Errore di connessione Hudu"
+        },
+        "sync": {
+          "title": "Sincronizzazione e automazione",
+          "description": "Importa le risorse di tutti i clienti associati in una sola volta e mantienile aggiornate automaticamente. Associare un'azienda o un layout configura solo l'integrazione: le risorse compaiono solo dopo un'importazione.",
+          "summary": "{{created}} create · {{updated}} aggiornate · {{skipped}} ignorate · {{failed}} non riuscite",
+          "toastErrorTitle": "Errore di sincronizzazione Hudu",
+          "importDoneTitle": "Importazione Hudu completata",
+          "syncDoneTitle": "Sincronizzazione Hudu completata",
+          "importing": "Importazione…",
+          "importAll": "Importa tutti i clienti associati",
+          "syncing2": "Sincronizzazione…",
+          "syncAll": "Sincronizza tutto",
+          "autoSyncLabel": "Sincronizzazione automatica giornaliera",
+          "autoSyncHint": "Importa automaticamente le nuove risorse e aggiorna quelle esistenti una volta al giorno per ogni cliente associato.",
+          "neverRun": "Nessuna esecuzione a livello di tenant per ora.",
+          "lastRun": "Ultima esecuzione {{at}}: {{created}} create · {{updated}} aggiornate · {{skipped}} ignorate · {{failed}} non riuscite",
+          "status": {
+            "syncing": "In corso…",
+            "completed": "Completata",
+            "error": "Errore"
+          }
         }
       }
     },

--- a/server/public/locales/nl/msp/integrations.json
+++ b/server/public/locales/nl/msp/integrations.json
@@ -1017,6 +1017,27 @@
         },
         "toasts": {
           "errorTitle": "Hudu-verbindingsfout"
+        },
+        "sync": {
+          "title": "Synchronisatie en automatisering",
+          "description": "Importeer activa voor alle gekoppelde klanten in één keer en houd ze automatisch up-to-date. Het koppelen van een bedrijf of lay-out configureert alleen de integratie — activa verschijnen pas na een import.",
+          "summary": "{{created}} aangemaakt · {{updated}} bijgewerkt · {{skipped}} overgeslagen · {{failed}} mislukt",
+          "toastErrorTitle": "Hudu-synchronisatiefout",
+          "importDoneTitle": "Hudu-import voltooid",
+          "syncDoneTitle": "Hudu-synchronisatie voltooid",
+          "importing": "Bezig met importeren…",
+          "importAll": "Alle gekoppelde klanten importeren",
+          "syncing2": "Bezig met synchroniseren…",
+          "syncAll": "Alles synchroniseren",
+          "autoSyncLabel": "Dagelijkse automatische synchronisatie",
+          "autoSyncHint": "Importeert automatisch nieuwe activa en vernieuwt bestaande één keer per dag voor elke gekoppelde klant.",
+          "neverRun": "Nog geen tenant-brede uitvoering.",
+          "lastRun": "Laatste uitvoering {{at}}: {{created}} aangemaakt · {{updated}} bijgewerkt · {{skipped}} overgeslagen · {{failed}} mislukt",
+          "status": {
+            "syncing": "Bezig…",
+            "completed": "Voltooid",
+            "error": "Fout"
+          }
         }
       }
     },

--- a/server/public/locales/pl/msp/integrations.json
+++ b/server/public/locales/pl/msp/integrations.json
@@ -1017,6 +1017,27 @@
         },
         "toasts": {
           "errorTitle": "Błąd połączenia Hudu"
+        },
+        "sync": {
+          "title": "Synchronizacja i automatyzacja",
+          "description": "Importuj zasoby dla wszystkich powiązanych klientów naraz i automatycznie utrzymuj je w aktualności. Powiązanie firmy lub układu konfiguruje tylko integrację — zasoby pojawiają się dopiero po imporcie.",
+          "summary": "{{created}} utworzono · {{updated}} zaktualizowano · {{skipped}} pominięto · {{failed}} nieudanych",
+          "toastErrorTitle": "Błąd synchronizacji Hudu",
+          "importDoneTitle": "Zakończono import Hudu",
+          "syncDoneTitle": "Zakończono synchronizację Hudu",
+          "importing": "Importowanie…",
+          "importAll": "Importuj wszystkich powiązanych klientów",
+          "syncing2": "Synchronizowanie…",
+          "syncAll": "Synchronizuj wszystko",
+          "autoSyncLabel": "Codzienna automatyczna synchronizacja",
+          "autoSyncHint": "Automatycznie importuje nowe zasoby i odświeża istniejące raz dziennie dla każdego powiązanego klienta.",
+          "neverRun": "Brak uruchomienia dla całego najemcy.",
+          "lastRun": "Ostatnie uruchomienie {{at}}: {{created}} utworzono · {{updated}} zaktualizowano · {{skipped}} pominięto · {{failed}} nieudanych",
+          "status": {
+            "syncing": "W toku…",
+            "completed": "Zakończono",
+            "error": "Błąd"
+          }
         }
       }
     },

--- a/server/public/locales/pt/msp/integrations.json
+++ b/server/public/locales/pt/msp/integrations.json
@@ -1017,6 +1017,27 @@
         },
         "toasts": {
           "errorTitle": "Erro de conexão Hudu"
+        },
+        "sync": {
+          "title": "Sincronização e automação",
+          "description": "Importe ativos de todos os clientes mapeados de uma só vez e mantenha-os atualizados automaticamente. Mapear uma empresa ou layout apenas configura a integração — os ativos só aparecem após uma importação.",
+          "summary": "{{created}} criados · {{updated}} atualizados · {{skipped}} ignorados · {{failed}} com falha",
+          "toastErrorTitle": "Erro de sincronização do Hudu",
+          "importDoneTitle": "Importação do Hudu concluída",
+          "syncDoneTitle": "Sincronização do Hudu concluída",
+          "importing": "Importando…",
+          "importAll": "Importar todos os clientes mapeados",
+          "syncing2": "Sincronizando…",
+          "syncAll": "Sincronizar tudo",
+          "autoSyncLabel": "Sincronização automática diária",
+          "autoSyncHint": "Importa automaticamente novos ativos e atualiza os existentes uma vez por dia para cada cliente mapeado.",
+          "neverRun": "Nenhuma execução em todo o locatário ainda.",
+          "lastRun": "Última execução {{at}}: {{created}} criados · {{updated}} atualizados · {{skipped}} ignorados · {{failed}} com falha",
+          "status": {
+            "syncing": "Em execução…",
+            "completed": "Concluída",
+            "error": "Erro"
+          }
         }
       }
     },

--- a/server/public/locales/xx/msp/integrations.json
+++ b/server/public/locales/xx/msp/integrations.json
@@ -1017,6 +1017,27 @@
         },
         "toasts": {
           "errorTitle": "11111"
+        },
+        "sync": {
+          "title": "11111",
+          "description": "11111",
+          "summary": "11111 {{created}} 11111 {{updated}} 11111 {{skipped}} 11111 {{failed}} 11111",
+          "toastErrorTitle": "11111",
+          "importDoneTitle": "11111",
+          "syncDoneTitle": "11111",
+          "importing": "11111",
+          "importAll": "11111",
+          "syncing2": "11111",
+          "syncAll": "11111",
+          "autoSyncLabel": "11111",
+          "autoSyncHint": "11111",
+          "neverRun": "11111",
+          "lastRun": "11111 {{at}} 11111 {{created}} 11111 {{updated}} 11111 {{skipped}} 11111 {{failed}} 11111",
+          "status": {
+            "syncing": "11111",
+            "completed": "11111",
+            "error": "11111"
+          }
         }
       }
     },

--- a/server/public/locales/yy/msp/integrations.json
+++ b/server/public/locales/yy/msp/integrations.json
@@ -1017,6 +1017,27 @@
         },
         "toasts": {
           "errorTitle": "55555"
+        },
+        "sync": {
+          "title": "55555",
+          "description": "55555",
+          "summary": "55555 {{created}} 55555 {{updated}} 55555 {{skipped}} 55555 {{failed}} 55555",
+          "toastErrorTitle": "55555",
+          "importDoneTitle": "55555",
+          "syncDoneTitle": "55555",
+          "importing": "55555",
+          "importAll": "55555",
+          "syncing2": "55555",
+          "syncAll": "55555",
+          "autoSyncLabel": "55555",
+          "autoSyncHint": "55555",
+          "neverRun": "55555",
+          "lastRun": "55555 {{at}} 55555 {{created}} 55555 {{updated}} 55555 {{skipped}} 55555 {{failed}} 55555",
+          "status": {
+            "syncing": "55555",
+            "completed": "55555",
+            "error": "55555"
+          }
         }
       }
     },

--- a/server/src/lib/jobs/handlers/huduAutoSyncHandler.ts
+++ b/server/src/lib/jobs/handlers/huduAutoSyncHandler.ts
@@ -1,0 +1,164 @@
+import logger from '@alga-psa/core/logger';
+import { runWithTenant } from 'server/src/lib/db';
+import { getAdminConnection } from '@alga-psa/db/admin';
+import { getJobRunner } from '../JobRunnerFactory';
+import type { BaseJobData } from '../interfaces';
+
+/**
+ * Hudu daily auto-sync (EE-only) on the IJobRunner abstraction — the same
+ * recurring-job path RMM alert polling, Huntress, and accounting-sync use
+ * (pg-boss cron in CE, Temporal Schedule in EE). One recurring job per tenant
+ * with an active Hudu connection AND settings.autoSync.enabled, keyed by
+ * singletonKey `hudu-auto-sync:<tenant>`. scheduleHuduAutoSyncJob converges
+ * the schedule from that desired state (called at startup + on
+ * connect/disconnect/toggle); the handler re-checks eligibility per run.
+ *
+ * The real work (runHuduTenantSync) lives in EE Hudu code reached via a dynamic
+ * @enterprise import, so the Temporal worker — which can't load EE Hudu code —
+ * forwards this job to the server (see job-activities.ts), exactly like
+ * accounting-sync-cycle.
+ */
+
+export interface HuduAutoSyncJobData extends BaseJobData {
+  tenantId: string;
+}
+
+export const HUDU_AUTO_SYNC_JOB = 'hudu-auto-sync';
+/** Daily at 02:00 UTC. */
+const SYNC_CRON = '0 2 * * *';
+
+function isEnterpriseEdition(): boolean {
+  return (
+    (process.env.EDITION ?? '').toLowerCase() === 'ee' ||
+    (process.env.NEXT_PUBLIC_EDITION ?? '').toLowerCase() === 'enterprise'
+  );
+}
+
+interface HuduAutoSyncState {
+  isActive: boolean;
+  autoSyncEnabled: boolean;
+}
+
+/**
+ * Desired state lives in EE (the connection table is EE-only and must not be
+ * named in CE code — NFR7), so read it through the @enterprise dynamic import.
+ * Resolves to the CE stub (→ null) in community builds.
+ */
+async function readHuduAutoSyncState(tenantId: string): Promise<HuduAutoSyncState | null> {
+  const mod = await import('@enterprise/lib/integrations/hudu/tenantSync');
+  if (typeof mod.getHuduAutoSyncDesiredState !== 'function') {
+    return null;
+  }
+  return mod.getHuduAutoSyncDesiredState(tenantId);
+}
+
+/**
+ * One scheduled tick for a tenant: import every mapped client's unmatched Hudu
+ * assets then refresh existing. Eligibility is re-checked here so a schedule
+ * that outlives a disconnect/disable between reconciles is a harmless no-op.
+ */
+export async function huduAutoSyncHandler(data: HuduAutoSyncJobData): Promise<void> {
+  const { tenantId } = data;
+
+  if (!isEnterpriseEdition()) {
+    return;
+  }
+
+  const state = await readHuduAutoSyncState(tenantId);
+  if (!state || !state.isActive || !state.autoSyncEnabled) {
+    logger.info('[HuduAutoSync] Skipping: no connection / inactive / auto-sync disabled', { tenantId });
+    return;
+  }
+
+  // Real engine lives in EE Hudu code; the CE stub never reaches here (handler
+  // is EE-gated and only registered in the enterprise block).
+  const mod = await import('@enterprise/lib/integrations/hudu/tenantSync');
+  const runHuduTenantSync = mod.runHuduTenantSync;
+  if (typeof runHuduTenantSync !== 'function') {
+    logger.warn('[HuduAutoSync] runHuduTenantSync unavailable in this edition', { tenantId });
+    return;
+  }
+
+  await runWithTenant(tenantId, async () => {
+    const summary = await runHuduTenantSync(tenantId, { importNew: true });
+    logger.info('[HuduAutoSync] cycle finished', {
+      tenantId,
+      clients: summary.clients,
+      created: summary.items_created,
+      updated: summary.items_updated,
+      skipped: summary.items_skipped,
+      failed: summary.items_failed,
+      errors: summary.errors.length,
+    });
+  });
+}
+
+async function cancelHuduAutoSync(tenantId: string, singletonKey: string): Promise<void> {
+  const adminKnex = await getAdminConnection();
+  const existing = await adminKnex('jobs')
+    .where({ tenant: tenantId })
+    .whereRaw(`metadata->>'singletonKey' = ?`, [singletonKey])
+    .whereNotNull('external_id')
+    .orderBy('created_at', 'desc')
+    .first('job_id');
+  if (!existing?.job_id) return;
+
+  const runner = await getJobRunner();
+  await runner.cancelJob(String(existing.job_id), tenantId).catch((error) => {
+    logger.info('[HuduAutoSync] schedule cancel skipped', {
+      tenantId,
+      error: error instanceof Error ? error.message : error,
+    });
+    return false;
+  });
+}
+
+/**
+ * Converge the daily schedule for a tenant via IJobRunner (pg-boss cron or
+ * Temporal Schedule). Connected tenants with auto-sync enabled get a schedule;
+ * everyone else has any leftover schedule cancelled. Idempotent — safe on
+ * startup, connect, disconnect, and toggle.
+ */
+export async function scheduleHuduAutoSyncJob(tenantId: string): Promise<string | null> {
+  if (!isEnterpriseEdition()) {
+    return null;
+  }
+
+  const singletonKey = `${HUDU_AUTO_SYNC_JOB}:${tenantId}`;
+
+  let state: HuduAutoSyncState | null;
+  try {
+    state = await readHuduAutoSyncState(tenantId);
+  } catch (error) {
+    // Couldn't read desired state (transient DB blip). Don't treat as disabled —
+    // leave any existing schedule untouched; the next convergence retries.
+    logger.warn('[HuduAutoSync] state read failed; leaving schedule unchanged', {
+      tenantId,
+      error: error instanceof Error ? error.message : error,
+    });
+    return null;
+  }
+
+  if (!state || !state.isActive || !state.autoSyncEnabled) {
+    await cancelHuduAutoSync(tenantId, singletonKey);
+    return null;
+  }
+
+  try {
+    const runner = await getJobRunner();
+    const result = await runner.scheduleRecurringJob<HuduAutoSyncJobData>(
+      HUDU_AUTO_SYNC_JOB,
+      { tenantId },
+      SYNC_CRON,
+      { singletonKey }
+    );
+    return result.jobId;
+  } catch (error) {
+    // "already exists" style errors are routine on startup re-registration.
+    logger.info('[HuduAutoSync] schedule registration skipped', {
+      tenantId,
+      error: error instanceof Error ? error.message : error,
+    });
+    return null;
+  }
+}

--- a/server/src/lib/jobs/initializeScheduledJobs.ts
+++ b/server/src/lib/jobs/initializeScheduledJobs.ts
@@ -1,5 +1,6 @@
 import { initializeScheduler, scheduleExpiredCreditsJob, scheduleExpiringCreditsNotificationJob, scheduleCreditReconciliationJob, scheduleQuoteAutoExpirationJob, scheduleReconcileBucketUsageJob, scheduleCleanupTemporaryFormsJob, scheduleCleanupWebhookDeliveriesJob, scheduleCleanupAiSessionKeysJob, scheduleMicrosoftWebhookRenewalJob, scheduleTeamsMeetingArtifactSubscriptionRenewalJob, scheduleGooglePubSubVerificationJob, scheduleGoogleGmailWatchRenewalJob, scheduleEmailWebhookMaintenanceJob, scheduleRenewalQueueProcessingJob, scheduleSlaTimerJob, scheduleWorkflowQuotaResumeScanJob, scheduleSearchReconcileJob, scheduleAutoCloseTicketsJob } from './index';
 import { scheduleAccountingSyncCycleJob } from './handlers/accountingSyncCycleHandler';
+import { scheduleHuduAutoSyncJob } from './handlers/huduAutoSyncHandler';
 import logger from '@alga-psa/core/logger';
 import { getConnection } from 'server/src/lib/db/db';
 
@@ -138,6 +139,17 @@ export async function initializeScheduledJobs(): Promise<void> {
         }
       } catch (error) {
         logger.error(`Failed to schedule accounting sync cycle for tenant ${tenantId}`, error);
+      }
+
+      // Converge the Hudu daily auto-sync schedule (EE only; created only for
+      // tenants with an active Hudu connection AND settings.autoSync.enabled)
+      try {
+        const huduJobId = await scheduleHuduAutoSyncJob(tenantId);
+        if (huduJobId) {
+          logger.info(`Scheduled Hudu auto-sync for tenant ${tenantId} with job ID ${huduJobId}`);
+        }
+      } catch (error) {
+        logger.error(`Failed to schedule Hudu auto-sync for tenant ${tenantId}`, error);
       }
 
       // Schedule Microsoft calendar webhook renewal (every 30 minutes)

--- a/server/src/lib/jobs/registerAllHandlers.ts
+++ b/server/src/lib/jobs/registerAllHandlers.ts
@@ -77,6 +77,11 @@ import {
   AccountingSyncCycleJobData,
 } from './handlers/accountingSyncCycleHandler';
 import {
+  huduAutoSyncHandler,
+  HUDU_AUTO_SYNC_JOB,
+  HuduAutoSyncJobData,
+} from './handlers/huduAutoSyncHandler';
+import {
   SEARCH_VISIBLE_USER_REINDEX_JOB_NAME,
   searchVisibleUserReindexHandler,
   SearchVisibleUserReindexJobData,
@@ -340,6 +345,20 @@ export async function registerAllJobHandlers(
           await accountingSyncCycleHandler(data);
         },
         retry: { maxAttempts: 1 }, // cycles are self-healing on the next tick
+        timeoutMs: 600000, // 10 minutes
+      },
+      registerOpts
+    );
+
+    // Hudu daily auto-sync (import unmatched + refresh; no-op unless connected &
+    // settings.autoSync.enabled). Converged per-tenant by scheduleHuduAutoSyncJob.
+    JobHandlerRegistry.register<HuduAutoSyncJobData & BaseJobData>(
+      {
+        name: HUDU_AUTO_SYNC_JOB,
+        handler: async (_jobId, data) => {
+          await huduAutoSyncHandler(data);
+        },
+        retry: { maxAttempts: 2 },
         timeoutMs: 600000, // 10 minutes
       },
       registerOpts

--- a/server/src/test/unit/huduAutoSyncSchedule.unit.test.ts
+++ b/server/src/test/unit/huduAutoSyncSchedule.unit.test.ts
@@ -1,0 +1,103 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const getDesiredStateMock = vi.fn();
+const scheduleRecurringJobMock = vi.fn();
+const cancelJobMock = vi.fn();
+const firstMock = vi.fn();
+
+vi.mock('@alga-psa/core/logger', () => ({ default: { info: vi.fn(), warn: vi.fn(), error: vi.fn() } }));
+vi.mock('server/src/lib/db', () => ({ runWithTenant: vi.fn() }));
+vi.mock('@enterprise/lib/integrations/hudu/tenantSync', () => ({
+  getHuduAutoSyncDesiredState: (...a: unknown[]) => getDesiredStateMock(...a),
+}));
+vi.mock('@/lib/jobs/JobRunnerFactory', () => ({
+  getJobRunner: async () => ({
+    scheduleRecurringJob: (...a: unknown[]) => scheduleRecurringJobMock(...a),
+    cancelJob: (...a: unknown[]) => cancelJobMock(...a),
+  }),
+}));
+
+// admin knex query builder used by cancelHuduAutoSync (jobs table lookup)
+const queryBuilder = {
+  where: () => queryBuilder,
+  whereRaw: () => queryBuilder,
+  whereNotNull: () => queryBuilder,
+  orderBy: () => queryBuilder,
+  first: (...a: unknown[]) => firstMock(...a),
+};
+vi.mock('@alga-psa/db/admin', () => ({
+  getAdminConnection: async () => () => queryBuilder,
+}));
+
+import { scheduleHuduAutoSyncJob } from '@/lib/jobs/handlers/huduAutoSyncHandler';
+
+describe('scheduleHuduAutoSyncJob (connected + auto-sync-enabled only)', () => {
+  beforeEach(() => {
+    vi.stubEnv('EDITION', 'ee');
+    vi.stubEnv('NEXT_PUBLIC_EDITION', 'enterprise');
+    getDesiredStateMock.mockReset();
+    scheduleRecurringJobMock.mockReset();
+    cancelJobMock.mockReset();
+    firstMock.mockReset();
+    scheduleRecurringJobMock.mockResolvedValue({ jobId: 'job-1', externalId: 'hudu-auto-sync:t1' });
+    cancelJobMock.mockResolvedValue(true);
+  });
+
+  it('schedules a connected tenant with auto-sync enabled', async () => {
+    getDesiredStateMock.mockResolvedValue({ isActive: true, autoSyncEnabled: true });
+
+    const result = await scheduleHuduAutoSyncJob('t1');
+
+    expect(scheduleRecurringJobMock).toHaveBeenCalledWith(
+      'hudu-auto-sync',
+      { tenantId: 't1' },
+      '0 2 * * *',
+      { singletonKey: 'hudu-auto-sync:t1' }
+    );
+    expect(cancelJobMock).not.toHaveBeenCalled();
+    expect(result).toBe('job-1');
+  });
+
+  it('cancels a stray schedule when auto-sync is disabled', async () => {
+    getDesiredStateMock.mockResolvedValue({ isActive: true, autoSyncEnabled: false });
+    firstMock.mockResolvedValue({ job_id: 'stale-job' });
+
+    const result = await scheduleHuduAutoSyncJob('t2');
+
+    expect(scheduleRecurringJobMock).not.toHaveBeenCalled();
+    expect(cancelJobMock).toHaveBeenCalledWith('stale-job', 't2');
+    expect(result).toBeNull();
+  });
+
+  it('cancels when the connection is inactive', async () => {
+    getDesiredStateMock.mockResolvedValue({ isActive: false, autoSyncEnabled: true });
+    firstMock.mockResolvedValue({ job_id: 'stale-job' });
+
+    await scheduleHuduAutoSyncJob('t2b');
+
+    expect(scheduleRecurringJobMock).not.toHaveBeenCalled();
+    expect(cancelJobMock).toHaveBeenCalledWith('stale-job', 't2b');
+  });
+
+  it('no connection row + no existing schedule is a no-op', async () => {
+    getDesiredStateMock.mockResolvedValue(null);
+    firstMock.mockResolvedValue(undefined);
+
+    const result = await scheduleHuduAutoSyncJob('t3');
+
+    expect(scheduleRecurringJobMock).not.toHaveBeenCalled();
+    expect(cancelJobMock).not.toHaveBeenCalled();
+    expect(result).toBeNull();
+  });
+
+  it('returns null in CE without reading state or touching the runner', async () => {
+    vi.stubEnv('EDITION', 'community');
+    vi.stubEnv('NEXT_PUBLIC_EDITION', 'community');
+
+    const result = await scheduleHuduAutoSyncJob('t4');
+
+    expect(getDesiredStateMock).not.toHaveBeenCalled();
+    expect(scheduleRecurringJobMock).not.toHaveBeenCalled();
+    expect(result).toBeNull();
+  });
+});


### PR DESCRIPTION
Close the activation gap: mapping a company or asset layout only configures Hudu, so assets never appear until import runs. Add a shared runHuduTenantSync engine driven from a config-screen "Import all"/"Sync all" card and an opt-in daily auto-sync job on the RMM-consistent job-runner path (Temporal/pg-boss + per-tenant reconcile). Extract actor-injectable createAssetRecord/ updateAssetRecord/deleteAssetRecord so the sessionless job can write assets, lift the import/sync logic into session-free cores (huduDataCore/assetImportCore/assetSyncCore + runtime-free huduDataTypes), and add sync_status/sync_error/last_full_sync_at to hudu_integrations.

And the White Rabbit, checking his pocket-watch at 2 a.m. sharp, fretted "I'm late, I'm late â to import all the unmatched assets!" â for a map of Wonderland, however lovingly drawn, conjures not a single teacup until someone finally runs runHuduTenantSync. 🐇🗺️⏰