### PR TITLE
Fix EE typecheck: cast Hudu result unions

### DIFF
--- a/ee/server/src/components/settings/integrations/hudu/HuduSyncAutomationManager.tsx
+++ b/ee/server/src/components/settings/integrations/hudu/HuduSyncAutomationManager.tsx
@@ -114,7 +114,8 @@ export default function HuduSyncAutomationManager() {
       if (!result.success) {
         toast({
           title: t('integrations.hudu.settings.sync.toastErrorTitle', { defaultValue: 'Hudu auto-sync update failed' }),
-          description: result.error,
+          // EE tsconfig doesn't narrow this discriminated union on `!success`.
+          description: (result as { success: false; error: string }).error,
           variant: 'destructive',
         });
       }

--- a/ee/server/src/lib/actions/integrations/huduAssetImportActions.ts
+++ b/ee/server/src/lib/actions/integrations/huduAssetImportActions.ts
@@ -110,10 +110,14 @@ export const importAllUnmatchedHuduAssets = withHuduAssetCreateAccess(
 
       const result = await importUnmatchedHuduAssetsCore(tenant, user.user_id, input.clientId);
 
+      // EE tsconfig doesn't narrow the discriminated union on `.success`; read
+      // the counts (data on success, partial on failure) through a view.
+      const counts = (result as { data?: HuduAssetBulkImportSummary }).data
+        ?? (result as { partial?: HuduAssetBulkImportSummary }).partial;
       logger.info('[HuduAssetImportActions] bulk import finished', {
         tenant,
         clientId: input.clientId,
-        ...(result.success ? result.data : result.partial),
+        ...counts,
       });
 
       return result;

--- a/ee/server/src/lib/integrations/hudu/tenantSync.ts
+++ b/ee/server/src/lib/integrations/hudu/tenantSync.ts
@@ -19,6 +19,7 @@ import type { Knex } from 'knex';
 import { getHuduIntegration, setHuduSyncRunState } from './huduIntegrationRepository';
 import { getHuduCompanyMappingRows } from './companyMapping';
 import { importUnmatchedHuduAssetsCore } from './assetImportCore';
+import type { HuduAssetBulkImportSummary } from './assetImportCore';
 import { syncHuduClientAssetsCore } from './assetSyncCore';
 
 export interface HuduAutoSyncDesiredState {
@@ -134,12 +135,23 @@ export async function runHuduTenantSync(
 
       if (options.importNew) {
         const imp = await importUnmatchedHuduAssetsCore(tenant, actorUserId, clientId);
-        const counts = imp.success ? imp.data : imp.partial;
-        summary.items_created += counts.created;
-        summary.items_skipped += counts.skipped;
-        summary.items_failed += counts.failed.length;
-        if (!imp.success) {
-          summary.errors.push(`${clientId}: ${imp.error}`);
+        // EE tsconfig doesn't narrow the discriminated union on `.success`, so
+        // read both result shapes (data on success, partial on failure) through
+        // a permissive view.
+        const impView = imp as {
+          success: boolean;
+          data?: HuduAssetBulkImportSummary;
+          partial?: HuduAssetBulkImportSummary;
+          error?: string;
+        };
+        const counts = impView.data ?? impView.partial;
+        if (counts) {
+          summary.items_created += counts.created;
+          summary.items_skipped += counts.skipped;
+          summary.items_failed += counts.failed.length;
+        }
+        if (!impView.success && impView.error) {
+          summary.errors.push(`${clientId}: ${impView.error}`);
         }
       }
 


### PR DESCRIPTION
The ee/server tsconfig is non-strict and doesn't narrow {success:true}|{success:false} discriminated unions on `.success`, so `result.error` / `result.partial` accesses in
HuduSyncAutomationManager, huduAssetImportActions, and the tenantSync engine failed `tsc -p tsconfig.json`. Read each through an explicit cast / permissive view (data on success, partial on failure) instead of relying on narrowing.

The Cheshire tsconfig grinned and faded until only its `.success` remained — so we stopped asking the empty air for `.partial` and simply pointed at the view where the counts had been sitting all along. 🐱🌫️🔢