### PR TITLE
Graduate 9 shipped feature flags

### DIFF
--- a/ee/server/src/__tests__/integration/ticket-live-updates.playwright.test.ts
+++ b/ee/server/src/__tests__/integration/ticket-live-updates.playwright.test.ts
@@ -17,11 +17,6 @@ import {
 applyPlaywrightAuthEnvDefaults();
 
 const BASE_URL = resolvePlaywrightBaseUrl();
-const LIVE_UPDATES_ENABLED =
-  process.env.NEXT_PUBLIC_DISABLE_FEATURE_FLAGS === 'false' &&
-  (process.env.NEXT_PUBLIC_FORCE_FEATURE_FLAGS ?? '')
-    .split(',')
-    .some((entry) => entry.trim() === 'live-ticket-updates:true');
 const LIVE_TICKET_PERF_SMOKE = process.env.LIVE_TICKET_PERF_SMOKE === 'true';
 const LIVE_TICKET_PERF_ITERATIONS = Number.parseInt(process.env.LIVE_TICKET_PERF_ITERATIONS ?? '50', 10);
 const LIVE_TICKET_PERF_THRESHOLD_MS = Number.parseInt(process.env.LIVE_TICKET_PERF_THRESHOLD_MS ?? '500', 10);
@@ -445,8 +440,6 @@ async function openContextWithUser(browserContext: BrowserContext, tenantData: T
 }
 
 test.describe('Ticket live updates (Playwright)', () => {
-  test.skip(!LIVE_UPDATES_ENABLED, 'Set NEXT_PUBLIC_DISABLE_FEATURE_FLAGS=false and NEXT_PUBLIC_FORCE_FEATURE_FLAGS=live-ticket-updates:true');
-
   test('T046: B saves status and A refreshes without losing a local title draft', async ({ browser }) => {
     test.setTimeout(300_000);
 

--- a/ee/server/src/__tests__/unit/huduAssetImportActions.test.ts
+++ b/ee/server/src/__tests__/unit/huduAssetImportActions.test.ts
@@ -7,7 +7,7 @@
  * T320 — custom-target import: registry-validated resolve (F315) + schema-key
  * projection alongside hudu_fields (F317).
  *
- * Unit-mocked like huduAssetMappingActions.test.ts: auth, flag, tiers, knex,
+ * Unit-mocked like huduAssetMappingActions.test.ts: auth, tiers, knex,
  * the Phase 1 fetch (huduDataActions), createAsset/deleteAsset, the registry
  * read (listAssetTypes) and the mapping-row writes are fakes; the matcher
  * (assetMatching), the layout-type resolver and the import/attributes/
@@ -28,7 +28,6 @@ const HUDU_COMPANY_ID = '55';
 const internalUser = { user_id: 'user-1', tenant: TENANT, user_type: 'internal' };
 
 const hasPermissionMock = vi.fn();
-const isEnabledMock = vi.fn();
 const assertTierAccessMock = vi.fn();
 
 const createTenantKnexMock = vi.fn();
@@ -101,10 +100,6 @@ vi.mock('@alga-psa/auth', () => ({
     (...args: unknown[]) =>
       handler(internalUser, { tenant: TENANT }, ...args),
   hasPermission: hasPermissionMock,
-}));
-
-vi.mock('server/src/lib/feature-flags/featureFlags', () => ({
-  featureFlags: { isEnabled: isEnabledMock },
 }));
 
 vi.mock('server/src/lib/tier-gating/assertTierAccess', () => ({
@@ -229,7 +224,6 @@ beforeEach(() => {
   attributeUpdates = [];
 
   hasPermissionMock.mockResolvedValue(true);
-  isEnabledMock.mockResolvedValue(true);
   assertTierAccessMock.mockResolvedValue(undefined);
 
   createTenantKnexMock.mockResolvedValue({ knex: knexCallableMock, tenant: TENANT });
@@ -432,7 +426,7 @@ describe('T220: status default', () => {
 });
 
 // ============================================================================
-// T221 — guard chain (asset create RBAC + flag)
+// T221 — guard chain (asset create RBAC)
 // ============================================================================
 
 describe('T221: guards', () => {
@@ -449,15 +443,6 @@ describe('T221: guards', () => {
     expect(hasPermissionMock).toHaveBeenCalledWith(internalUser, 'asset', 'create');
     expect(createAssetMock).not.toHaveBeenCalled();
     expect(setHuduAssetMappingRowMock).not.toHaveBeenCalled();
-  });
-
-  it('rejects both actions when the hudu-integration flag is off (404 semantics)', async () => {
-    isEnabledMock.mockResolvedValue(false);
-    const { importHuduAsset, importAllUnmatchedHuduAssets } = await importActions();
-
-    await expect(importHuduAsset({ clientId: CLIENT_1, huduAssetId: 1 })).rejects.toThrow(/disabled for this tenant/);
-    await expect(importAllUnmatchedHuduAssets({ clientId: CLIENT_1 })).rejects.toThrow(/disabled for this tenant/);
-    expect(createAssetMock).not.toHaveBeenCalled();
   });
 });
 

--- a/ee/server/src/__tests__/unit/huduAssetLayoutMap.test.ts
+++ b/ee/server/src/__tests__/unit/huduAssetLayoutMap.test.ts
@@ -2,7 +2,7 @@
  * T205/T206/T207/T209 — layout-type-config group: the asset_layout_type_map
  * contract (parse/normalize), the layout-name heuristic, the resolver, and the
  * get/set server actions. Action mocks mirror huduMappingActions.test.ts
- * (auth/flag/tiers/knex/repository/client mocked; the lib module stays REAL).
+ * (auth/tiers/knex/repository/client mocked; the lib module stays REAL).
  * T318/T319 — hudu-tie-in group: slug-shaped storage + registry-validated
  * resolve (F315) and createAssetTypeFromHuduLayout (F316) — the registry
  * module is mocked (knex-level); layoutFieldSchema stays REAL so the
@@ -18,7 +18,6 @@ const TENANT = 'tenant-hudu-1';
 const internalUser = { user_id: 'user-1', tenant: TENANT, user_type: 'internal' };
 
 const hasPermissionMock = vi.fn();
-const isEnabledMock = vi.fn();
 const assertTierAccessMock = vi.fn();
 
 const createTenantKnexMock = vi.fn();
@@ -43,10 +42,6 @@ vi.mock('@alga-psa/auth', () => ({
     (...args: unknown[]) =>
       handler(internalUser, { tenant: TENANT }, ...args),
   hasPermission: hasPermissionMock,
-}));
-
-vi.mock('server/src/lib/feature-flags/featureFlags', () => ({
-  featureFlags: { isEnabled: isEnabledMock },
 }));
 
 vi.mock('server/src/lib/tier-gating/assertTierAccess', () => ({
@@ -108,7 +103,6 @@ beforeEach(() => {
   vi.clearAllMocks();
 
   hasPermissionMock.mockResolvedValue(true);
-  isEnabledMock.mockResolvedValue(true);
   assertTierAccessMock.mockResolvedValue(undefined);
 
   createTenantKnexMock.mockResolvedValue({ knex: knexCallableMock, tenant: TENANT });
@@ -454,19 +448,6 @@ describe('T206: setHuduAssetLayoutMap guard', () => {
     );
     expect(hasPermissionMock).toHaveBeenCalledWith(internalUser, 'system_settings', 'update');
     expect(upsertHuduIntegrationMock).not.toHaveBeenCalled();
-  });
-
-  it('rejects when the hudu-integration flag is off', async () => {
-    isEnabledMock.mockResolvedValue(false);
-    const { setHuduAssetLayoutMap, getHuduAssetLayoutMap } = await importActions();
-
-    await expect(setHuduAssetLayoutMap({ '7': 'workstation' })).rejects.toThrow(/disabled for this tenant/);
-    await expect(getHuduAssetLayoutMap()).rejects.toThrow(/disabled for this tenant/);
-    expect(isEnabledMock).toHaveBeenCalledWith('hudu-integration', {
-      userId: 'user-1',
-      tenantId: TENANT,
-    });
-    expect(createTenantKnexMock).not.toHaveBeenCalled();
   });
 });
 

--- a/ee/server/src/__tests__/unit/huduAssetMappingActions.test.ts
+++ b/ee/server/src/__tests__/unit/huduAssetMappingActions.test.ts
@@ -6,7 +6,7 @@
  * hudu-company-mappings.integration.test.ts incl. the advisory-lock
  * serialization; the real row functions are reached via vi.importActual.
  * The action layer (T216/T217) is unit-mocked like huduMappingActions.test.ts:
- * auth, flag, tiers, knex, huduDataActions and the row functions are fakes;
+ * auth, tiers, knex, huduDataActions and the row functions are fakes;
  * the matcher (assetMatching) and the reference cache stay REAL.
  */
 
@@ -29,7 +29,6 @@ const HUDU_COMPANY_ID = '55';
 const internalUser = { user_id: 'user-1', tenant: TENANT, user_type: 'internal' };
 
 const hasPermissionMock = vi.fn();
-const isEnabledMock = vi.fn();
 const assertTierAccessMock = vi.fn();
 
 const createTenantKnexMock = vi.fn();
@@ -55,10 +54,6 @@ vi.mock('@alga-psa/auth', () => ({
     (...args: unknown[]) =>
       handler(internalUser, { tenant: TENANT }, ...args),
   hasPermission: hasPermissionMock,
-}));
-
-vi.mock('server/src/lib/feature-flags/featureFlags', () => ({
-  featureFlags: { isEnabled: isEnabledMock },
 }));
 
 vi.mock('server/src/lib/tier-gating/assertTierAccess', () => ({
@@ -132,7 +127,6 @@ beforeEach(() => {
   assetsRows = [];
 
   hasPermissionMock.mockResolvedValue(true);
-  isEnabledMock.mockResolvedValue(true);
   assertTierAccessMock.mockResolvedValue(undefined);
 
   createTenantKnexMock.mockResolvedValue({ knex: knexCallableMock, tenant: TENANT });
@@ -658,16 +652,5 @@ describe('F213 action wrappers: setHuduAssetMapping / clearHuduAssetMapping', ()
     expect(hasPermissionMock).toHaveBeenCalledWith(internalUser, 'asset', 'update');
     expect(setHuduAssetMappingRowMock).not.toHaveBeenCalled();
     expect(clearHuduAssetMappingRowMock).not.toHaveBeenCalled();
-  });
-
-  it('T217: every action rejects when the hudu-integration flag is off (404 semantics)', async () => {
-    isEnabledMock.mockResolvedValue(false);
-    const { getHuduAssetMappings, setHuduAssetMapping, clearHuduAssetMapping } = await importActions();
-
-    await expect(getHuduAssetMappings(CLIENT_1)).rejects.toThrow(/disabled for this tenant/);
-    await expect(setHuduAssetMapping({ clientId: CLIENT_1, assetId: ASSET_1, huduAssetId: 1 })).rejects.toThrow(
-      /disabled for this tenant/
-    );
-    await expect(clearHuduAssetMapping({ mappingId: 'am-1' })).rejects.toThrow(/disabled for this tenant/);
   });
 });

--- a/ee/server/src/__tests__/unit/huduAssetSyncActions.test.ts
+++ b/ee/server/src/__tests__/unit/huduAssetSyncActions.test.ts
@@ -7,7 +7,7 @@
  * Helper persistence (stale metadata merge, last_synced_at stamping, and the
  * assets.attributes jsonb merge) runs against the REAL local dev DB exactly
  * like huduAssetMappingActions.test.ts (shared advisory lock, importActual).
- * The action layer is unit-mocked like the sibling: auth, flag, tiers, knex,
+ * The action layer is unit-mocked like the sibling: auth, tiers, knex,
  * huduDataActions, updateAsset and the mapping-row functions are fakes; the
  * attributes helpers (assetAttributes) stay REAL.
  */
@@ -32,7 +32,6 @@ const HUDU_COMPANY_ID = '55';
 const internalUser = { user_id: 'user-1', tenant: TENANT, user_type: 'internal' };
 
 const hasPermissionMock = vi.fn();
-const isEnabledMock = vi.fn();
 const assertTierAccessMock = vi.fn();
 
 const createTenantKnexMock = vi.fn();
@@ -85,10 +84,6 @@ vi.mock('@alga-psa/auth', () => ({
     (...args: unknown[]) =>
       handler(internalUser, { tenant: TENANT }, ...args),
   hasPermission: hasPermissionMock,
-}));
-
-vi.mock('server/src/lib/feature-flags/featureFlags', () => ({
-  featureFlags: { isEnabled: isEnabledMock },
 }));
 
 vi.mock('server/src/lib/tier-gating/assertTierAccess', () => ({
@@ -167,7 +162,6 @@ beforeEach(() => {
   attributeUpdates = [];
 
   hasPermissionMock.mockResolvedValue(true);
-  isEnabledMock.mockResolvedValue(true);
   assertTierAccessMock.mockResolvedValue(undefined);
 
   createTenantKnexMock.mockResolvedValue({ knex: knexCallableMock, tenant: TENANT });
@@ -929,13 +923,5 @@ describe('T229: guard chain', () => {
     expect(hasPermissionMock).toHaveBeenCalledWith(internalUser, 'asset', 'update');
     expect(getHuduCompanyAssetsMock).not.toHaveBeenCalled();
     expect(updateAssetMock).not.toHaveBeenCalled();
-  });
-
-  it('rejects when the hudu-integration flag is off (404 semantics)', async () => {
-    isEnabledMock.mockResolvedValue(false);
-    const { syncHuduClientAssets } = await importActions();
-
-    await expect(syncHuduClientAssets({ clientId: CLIENT_1 })).rejects.toThrow(/disabled for this tenant/);
-    expect(getHuduCompanyAssetsMock).not.toHaveBeenCalled();
   });
 });

--- a/ee/server/src/__tests__/unit/huduClientPasswordsTabGate.test.tsx
+++ b/ee/server/src/__tests__/unit/huduClientPasswordsTabGate.test.tsx
@@ -2,8 +2,8 @@
 /**
  * T080 — registration gating for the client "Passwords" tab
  * (client-passwords-tab group). Same gate as the Hudu tab: useHuduClientTab
- * (packages/clients) resolves visible ONLY when EE edition + the
- * `hudu-integration` flag AND the edition-swapped probe reports Hudu
+ * (packages/clients) resolves visible ONLY when EE edition AND the
+ * edition-swapped probe reports Hudu
  * connected + this client mapped. ClientDetails registers BOTH Hudu tabs in
  * the same `visible`-gated spread, so hidden here = both tabs absent. A
  * registration probe mirrors that spread, and a source-wiring check
@@ -17,14 +17,9 @@ import { useHuduClientTab } from '@alga-psa/clients/components/clients/useHuduCl
 // @ts-expect-error Vite raw import (source-wiring assertion).
 import clientDetailsSource from '@alga-psa/clients/components/clients/ClientDetails.tsx?raw';
 
-const { useFeatureFlagMock, isEnterpriseRef, getHuduClientContextMock } = vi.hoisted(() => ({
-  useFeatureFlagMock: vi.fn(),
+const { isEnterpriseRef, getHuduClientContextMock } = vi.hoisted(() => ({
   isEnterpriseRef: { value: true },
   getHuduClientContextMock: vi.fn(),
-}));
-
-vi.mock('@alga-psa/ui/hooks', () => ({
-  useFeatureFlag: useFeatureFlagMock,
 }));
 
 vi.mock('@alga-psa/core', () => ({
@@ -76,25 +71,13 @@ function passwordsTab() {
 }
 
 beforeEach(() => {
-  useFeatureFlagMock.mockReset();
   getHuduClientContextMock.mockReset();
   isEnterpriseRef.value = true;
-  useFeatureFlagMock.mockReturnValue({ enabled: true, loading: false, error: null });
   getHuduClientContextMock.mockResolvedValue({ connected: true, mapped: true });
 });
 
 describe('T080: client "Passwords" tab registration gate', () => {
-  it('is absent when the feature flag is off (and never probes)', async () => {
-    useFeatureFlagMock.mockReturnValue({ enabled: false, loading: false, error: null });
-
-    await renderTabs();
-
-    expect(passwordsTab()).toBeNull();
-    expect(screen.queryByTestId('tab-hudu')).toBeNull();
-    expect(getHuduClientContextMock).not.toHaveBeenCalled();
-  });
-
-  it('is absent in Community Edition even with the flag on', async () => {
+  it('is absent in Community Edition', async () => {
     isEnterpriseRef.value = false;
 
     await renderTabs();
@@ -128,7 +111,7 @@ describe('T080: client "Passwords" tab registration gate', () => {
     expect(passwordsTab()).toBeNull();
   });
 
-  it('appears directly after the Hudu tab when EE + flag + connected + mapped', async () => {
+  it('appears directly after the Hudu tab when EE + connected + mapped', async () => {
     const tabs = await renderTabs();
 
     await waitFor(() => {

--- a/ee/server/src/__tests__/unit/huduClientTabGate.test.tsx
+++ b/ee/server/src/__tests__/unit/huduClientTabGate.test.tsx
@@ -2,7 +2,7 @@
 /**
  * T070 — registration gating for the client "Hudu" tab (client-hudu-tab
  * group): useHuduClientTab (packages/clients) resolves visible ONLY when
- * EE edition + `hudu-integration` flag AND the edition-swapped probe reports
+ * EE edition AND the edition-swapped probe reports
  * Hudu connected + this client mapped. ClientDetails registers the tab in its
  * tabs array only when `visible` is true, so hidden here = tab absent.
  */
@@ -11,14 +11,9 @@ import { render, screen, waitFor } from '@testing-library/react';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { useHuduClientTab } from '@alga-psa/clients/components/clients/useHuduClientTab';
 
-const { useFeatureFlagMock, isEnterpriseRef, getHuduClientContextMock } = vi.hoisted(() => ({
-  useFeatureFlagMock: vi.fn(),
+const { isEnterpriseRef, getHuduClientContextMock } = vi.hoisted(() => ({
   isEnterpriseRef: { value: true },
   getHuduClientContextMock: vi.fn(),
-}));
-
-vi.mock('@alga-psa/ui/hooks', () => ({
-  useFeatureFlag: useFeatureFlagMock,
 }));
 
 vi.mock('@alga-psa/core', () => ({
@@ -56,25 +51,13 @@ async function renderGate(clientId?: string) {
 }
 
 beforeEach(() => {
-  useFeatureFlagMock.mockReset();
   getHuduClientContextMock.mockReset();
   isEnterpriseRef.value = true;
-  useFeatureFlagMock.mockReturnValue({ enabled: true, loading: false, error: null });
   getHuduClientContextMock.mockResolvedValue({ connected: true, mapped: true });
 });
 
 describe('T070: useHuduClientTab registration gate', () => {
-  it('is hidden and never probes when the feature flag is off', async () => {
-    useFeatureFlagMock.mockReturnValue({ enabled: false, loading: false, error: null });
-
-    const gate = await renderGate();
-
-    expect(gate.getAttribute('data-visible')).toBe('false');
-    expect(getHuduClientContextMock).not.toHaveBeenCalled();
-    expect(useFeatureFlagMock).toHaveBeenCalledWith('hudu-integration', { defaultValue: false });
-  });
-
-  it('is hidden and never probes in Community Edition even with the flag on', async () => {
+  it('is hidden and never probes in Community Edition', async () => {
     isEnterpriseRef.value = false;
 
     const gate = await renderGate();
@@ -100,7 +83,7 @@ describe('T070: useHuduClientTab registration gate', () => {
     expect(gate.getAttribute('data-visible')).toBe('false');
   });
 
-  it('is visible when EE + flag + connected + mapped all hold', async () => {
+  it('is visible when EE + connected + mapped all hold', async () => {
     const gate = await renderGate();
 
     await waitFor(() => {

--- a/ee/server/src/__tests__/unit/huduConnectionActions.test.ts
+++ b/ee/server/src/__tests__/unit/huduConnectionActions.test.ts
@@ -14,7 +14,6 @@ const BASE_URL = 'https://docs.example.com';
 const internalUser = { user_id: 'user-1', tenant: TENANT, user_type: 'internal' };
 
 const hasPermissionMock = vi.fn();
-const isEnabledMock = vi.fn();
 const assertTierAccessMock = vi.fn();
 
 const getTenantSecretMock = vi.fn();
@@ -38,10 +37,6 @@ vi.mock('@alga-psa/auth', () => ({
     (...args: unknown[]) =>
       handler(internalUser, { tenant: TENANT }, ...args),
   hasPermission: hasPermissionMock,
-}));
-
-vi.mock('server/src/lib/feature-flags/featureFlags', () => ({
-  featureFlags: { isEnabled: isEnabledMock },
 }));
 
 vi.mock('server/src/lib/tier-gating/assertTierAccess', () => ({
@@ -96,7 +91,6 @@ beforeEach(() => {
   delete process.env.HUDU_BASE_URL;
 
   hasPermissionMock.mockResolvedValue(true);
-  isEnabledMock.mockResolvedValue(true);
   assertTierAccessMock.mockResolvedValue(undefined);
 
   getTenantSecretMock.mockResolvedValue(null);
@@ -212,15 +206,6 @@ describe('T023: connectHudu', () => {
       /insufficient permissions \(update\)/
     );
     expect(hasPermissionMock).toHaveBeenCalledWith(internalUser, 'system_settings', 'update');
-  });
-
-  it('rejects when the hudu-integration flag is off', async () => {
-    isEnabledMock.mockResolvedValue(false);
-    const { connectHudu } = await importActions();
-
-    await expect(connectHudu({ baseUrl: BASE_URL, apiKey: API_KEY })).rejects.toThrow(
-      /disabled for this tenant/
-    );
   });
 });
 

--- a/ee/server/src/__tests__/unit/huduDocumentsTabGate.test.tsx
+++ b/ee/server/src/__tests__/unit/huduDocumentsTabGate.test.tsx
@@ -3,7 +3,7 @@
  * T243/T245 — registration gating for the Documents page "Hudu" tab
  * (global-docs group), mirroring huduClientTabGate.test.tsx:
  * useHuduDocumentsTab (packages/documents) resolves visible ONLY when EE
- * edition + `hudu-integration` flag AND the edition-swapped probe
+ * edition AND the edition-swapped probe
  * (getHuduConnectionStatus — the existing settings status action, reused as
  * the connected-only probe) reports Hudu connected. DocumentsPage renders the
  * CustomTabs switcher only when `visible` is true, so hidden here = no trace
@@ -19,14 +19,9 @@ import documentsPageSource from '@alga-psa/documents/components/DocumentsPage.ts
 // @ts-expect-error Vite raw import (source-wiring assertion).
 import ceWrapperSource from '@alga-psa/documents/components/HuduDocumentsTab.tsx?raw';
 
-const { useFeatureFlagMock, isEnterpriseRef, getHuduConnectionStatusMock } = vi.hoisted(() => ({
-  useFeatureFlagMock: vi.fn(),
+const { isEnterpriseRef, getHuduConnectionStatusMock } = vi.hoisted(() => ({
   isEnterpriseRef: { value: true },
   getHuduConnectionStatusMock: vi.fn(),
-}));
-
-vi.mock('@alga-psa/ui/hooks', () => ({
-  useFeatureFlag: useFeatureFlagMock,
 }));
 
 vi.mock('@alga-psa/core', () => ({
@@ -76,25 +71,13 @@ async function renderGate() {
 }
 
 beforeEach(() => {
-  useFeatureFlagMock.mockReset();
   getHuduConnectionStatusMock.mockReset();
   isEnterpriseRef.value = true;
-  useFeatureFlagMock.mockReturnValue({ enabled: true, loading: false, error: null });
   getHuduConnectionStatusMock.mockResolvedValue(connectedStatus(true));
 });
 
 describe('T243: useHuduDocumentsTab registration gate', () => {
-  it('is hidden and never probes when the feature flag is off', async () => {
-    useFeatureFlagMock.mockReturnValue({ enabled: false, loading: false, error: null });
-
-    const gate = await renderGate();
-
-    expect(gate.getAttribute('data-visible')).toBe('false');
-    expect(getHuduConnectionStatusMock).not.toHaveBeenCalled();
-    expect(useFeatureFlagMock).toHaveBeenCalledWith('hudu-integration', { defaultValue: false });
-  });
-
-  it('is hidden and never probes in Community Edition even with the flag on', async () => {
+  it('is hidden and never probes in Community Edition', async () => {
     isEnterpriseRef.value = false;
 
     const gate = await renderGate();
@@ -128,7 +111,7 @@ describe('T243: useHuduDocumentsTab registration gate', () => {
     expect(gate.getAttribute('data-visible')).toBe('false');
   });
 
-  it('is visible when EE + flag + connected all hold', async () => {
+  it('is visible when EE + connected all hold', async () => {
     const gate = await renderGate();
 
     await waitFor(() => {

--- a/ee/server/src/__tests__/unit/huduFlagGuard.test.ts
+++ b/ee/server/src/__tests__/unit/huduFlagGuard.test.ts
@@ -2,7 +2,6 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 const getCurrentUserMock = vi.fn();
 const hasPermissionMock = vi.fn();
-const isEnabledMock = vi.fn();
 const assertTierAccessMock = vi.fn();
 
 class TierAccessErrorMock extends Error {}
@@ -13,12 +12,6 @@ vi.mock('@alga-psa/user-composition/actions', () => ({
 
 vi.mock('@alga-psa/auth/rbac', () => ({
   hasPermission: hasPermissionMock,
-}));
-
-vi.mock('server/src/lib/feature-flags/featureFlags', () => ({
-  featureFlags: {
-    isEnabled: isEnabledMock,
-  },
 }));
 
 vi.mock('server/src/lib/tier-gating/assertTierAccess', () => ({
@@ -41,40 +34,21 @@ describe('T001: requireHuduUiFlagEnabled', () => {
     vi.resetModules();
     getCurrentUserMock.mockReset();
     hasPermissionMock.mockReset();
-    isEnabledMock.mockReset();
     assertTierAccessMock.mockReset();
 
     // Happy-path defaults; individual tests override as needed.
     getCurrentUserMock.mockResolvedValue(internalUser);
     hasPermissionMock.mockResolvedValue(true);
     assertTierAccessMock.mockResolvedValue(undefined);
-    isEnabledMock.mockResolvedValue(true);
   });
 
-  it('returns the tenant/user context when EE access and the flag are both on', async () => {
+  it('returns the tenant/user context when EE access is granted', async () => {
     const { requireHuduUiFlagEnabled } = await importGuard();
 
     const result = await requireHuduUiFlagEnabled('read');
 
     expect(result).not.toBeInstanceOf(Response);
     expect(result).toEqual({ tenantId: 'tenant-1', userId: 'user-1' });
-    expect(isEnabledMock).toHaveBeenCalledWith('hudu-integration', {
-      userId: 'user-1',
-      tenantId: 'tenant-1',
-    });
-  });
-
-  it('returns a 404 blocked response when the hudu-integration flag is disabled', async () => {
-    isEnabledMock.mockResolvedValue(false);
-    const { requireHuduUiFlagEnabled } = await importGuard();
-
-    const result = await requireHuduUiFlagEnabled('read');
-
-    expect(result).toBeInstanceOf(Response);
-    const response = result as Response;
-    expect(response.status).toBe(404);
-    const payload = await response.json();
-    expect(payload.success).toBe(false);
   });
 
   it('returns a 403 blocked response when the integrations tier is denied', async () => {
@@ -85,7 +59,6 @@ describe('T001: requireHuduUiFlagEnabled', () => {
 
     expect(result).toBeInstanceOf(Response);
     expect((result as Response).status).toBe(403);
-    expect(isEnabledMock).not.toHaveBeenCalled();
   });
 
   it('returns a 401 when there is no authenticated user', async () => {

--- a/ee/server/src/__tests__/unit/huduGlobalDocsActions.test.ts
+++ b/ee/server/src/__tests__/unit/huduGlobalDocsActions.test.ts
@@ -1,7 +1,7 @@
 /**
  * T240–T242 — listHuduArticlesAcrossCompanies (global-docs group), unit-mocked
  * like the sibling action tests (huduDataActions.test.ts idioms): auth gate,
- * feature flag, tiers, knex, the integration repository, the mapping rows and
+ * tiers, knex, the integration repository, the mapping rows and
  * the Hudu client factory are fakes; parseCompaniesCache and buildHuduRecordUrl
  * stay REAL so the company-name + deep-link resolution is exercised for real.
  */
@@ -17,7 +17,6 @@ const internalUser = { user_id: 'user-1', tenant: TENANT, user_type: 'internal' 
 const currentUserRef: { value: Record<string, unknown> | null } = { value: internalUser };
 
 const hasPermissionMock = vi.fn();
-const isEnabledMock = vi.fn();
 const assertTierAccessMock = vi.fn();
 
 const knexCallableMock = vi.fn();
@@ -41,10 +40,6 @@ vi.mock('@alga-psa/auth', () => ({
       return handler(currentUserRef.value, { tenant: TENANT }, ...args);
     },
   hasPermission: hasPermissionMock,
-}));
-
-vi.mock('server/src/lib/feature-flags/featureFlags', () => ({
-  featureFlags: { isEnabled: isEnabledMock },
 }));
 
 vi.mock('server/src/lib/tier-gating/assertTierAccess', () => ({
@@ -125,7 +120,6 @@ beforeEach(() => {
   currentUserRef.value = internalUser;
 
   hasPermissionMock.mockResolvedValue(true);
-  isEnabledMock.mockResolvedValue(true);
   assertTierAccessMock.mockResolvedValue(undefined);
   createTenantKnexMock.mockResolvedValue({ knex: knexCallableMock, tenant: TENANT });
 
@@ -264,22 +258,10 @@ describe('T242: guard chain + disconnected state', () => {
     expect(createTenantKnexMock).not.toHaveBeenCalled();
   });
 
-  it('rejects when the hudu-integration flag is off (404 semantics)', async () => {
-    isEnabledMock.mockResolvedValue(false);
-
-    await expect(listHuduArticlesAcrossCompanies()).rejects.toThrow(/disabled for this tenant/);
-    expect(isEnabledMock).toHaveBeenCalledWith('hudu-integration', {
-      userId: 'user-1',
-      tenantId: TENANT,
-    });
-    expect(createTenantKnexMock).not.toHaveBeenCalled();
-  });
-
   it('rejects when the integrations tier is missing', async () => {
     assertTierAccessMock.mockRejectedValue(new Error('Integrations tier required'));
 
     await expect(listHuduArticlesAcrossCompanies()).rejects.toThrow(/Integrations tier required/);
-    expect(isEnabledMock).not.toHaveBeenCalled();
   });
 
   it('returns the typed disconnected state without any Hudu call when no active connection', async () => {

--- a/ee/server/src/__tests__/unit/huduMappingActions.test.ts
+++ b/ee/server/src/__tests__/unit/huduMappingActions.test.ts
@@ -1,6 +1,6 @@
 /**
  * T040/T046 — Hudu company-mapping server actions, unit-mocked: auth gate,
- * feature flag, tiers, knex, the hudu_integrations repository and the Hudu
+ * tiers, knex, the hudu_integrations repository and the Hudu
  * client are mocked; the matcher + cache shaping stay REAL (partial module
  * mock keeps only the knex-level row functions fake). The row functions
  * themselves run against the real DB in
@@ -16,7 +16,6 @@ const CLIENT_2 = '22222222-2222-2222-2222-222222222222';
 const internalUser = { user_id: 'user-1', tenant: TENANT, user_type: 'internal' };
 
 const hasPermissionMock = vi.fn();
-const isEnabledMock = vi.fn();
 const assertTierAccessMock = vi.fn();
 
 const createTenantKnexMock = vi.fn();
@@ -44,10 +43,6 @@ vi.mock('@alga-psa/auth', () => ({
     (...args: unknown[]) =>
       handler(internalUser, { tenant: TENANT }, ...args),
   hasPermission: hasPermissionMock,
-}));
-
-vi.mock('server/src/lib/feature-flags/featureFlags', () => ({
-  featureFlags: { isEnabled: isEnabledMock },
 }));
 
 vi.mock('server/src/lib/tier-gating/assertTierAccess', () => ({
@@ -96,7 +91,6 @@ beforeEach(() => {
   clientsRows = [];
 
   hasPermissionMock.mockResolvedValue(true);
-  isEnabledMock.mockResolvedValue(true);
   assertTierAccessMock.mockResolvedValue(undefined);
 
   createTenantKnexMock.mockResolvedValue({ knex: knexCallableMock, tenant: TENANT });
@@ -154,13 +148,6 @@ describe('T040: syncHuduCompanies', () => {
 
     await expect(syncHuduCompanies()).rejects.toThrow(/insufficient permissions \(update\)/);
     expect(hasPermissionMock).toHaveBeenCalledWith(internalUser, 'system_settings', 'update');
-  });
-
-  it('rejects when the hudu-integration flag is off', async () => {
-    isEnabledMock.mockResolvedValue(false);
-    const { syncHuduCompanies } = await importActions();
-
-    await expect(syncHuduCompanies()).rejects.toThrow(/disabled for this tenant/);
   });
 
   it('returns a failure envelope when the Hudu fetch fails', async () => {

--- a/ee/server/src/__tests__/unit/huduPermissions.test.ts
+++ b/ee/server/src/__tests__/unit/huduPermissions.test.ts
@@ -1,7 +1,7 @@
 /**
  * T090/T091/T093 (Phase 1) + T249/F238 (Phase 2) — permissions sweep: every
- * Hudu server action enforces its guard chain (RBAC, EE tier,
- * `hudu-integration` flag) at the correct level. Phase 1 modules gate on
+ * Hudu server action enforces its guard chain (RBAC, EE tier) at the correct
+ * level. Phase 1 modules gate on
  * system_settings (update = connect/disconnect/test/sync/map, read = status/
  * mappings/data/reveal/context); Phase 2 layout-map actions reuse
  * system_settings, while the Technician flows gate on asset (read = view
@@ -27,7 +27,6 @@ const internalUser = { user_id: 'user-1', tenant: TENANT, user_type: 'internal' 
 let authenticatedUser: typeof internalUser | null = internalUser;
 
 const hasPermissionMock = vi.fn();
-const isEnabledMock = vi.fn();
 const assertTierAccessMock = vi.fn();
 
 const createTenantKnexMock = vi.fn();
@@ -58,10 +57,6 @@ vi.mock('@alga-psa/auth', () => ({
       return handler(authenticatedUser, { tenant: TENANT }, ...args);
     },
   hasPermission: hasPermissionMock,
-}));
-
-vi.mock('server/src/lib/feature-flags/featureFlags', () => ({
-  featureFlags: { isEnabled: isEnabledMock },
 }));
 
 vi.mock('server/src/lib/tier-gating/assertTierAccess', () => ({
@@ -172,7 +167,6 @@ beforeEach(() => {
 
   // Happy-path defaults; each describe flips exactly one gate input.
   hasPermissionMock.mockResolvedValue(true);
-  isEnabledMock.mockResolvedValue(true);
   assertTierAccessMock.mockResolvedValue(undefined);
   createTenantKnexMock.mockResolvedValue({ knex: vi.fn(), tenant: TENANT });
 });
@@ -257,26 +251,11 @@ describe('T249/F238: every action rejects when unauthenticated', () => {
   });
 });
 
-describe('T093/T249: every action rejects when the hudu-integration flag is off', () => {
-  it.each(allEntries)('$name rejects with permission granted but the flag off', async ({ run }) => {
-    isEnabledMock.mockResolvedValue(false);
-
-    await expect(run()).rejects.toThrow(/disabled for this tenant/);
-    expect(isEnabledMock).toHaveBeenCalledWith('hudu-integration', {
-      userId: 'user-1',
-      tenantId: TENANT,
-    });
-    expect(createTenantKnexMock).not.toHaveBeenCalled();
-  });
-});
-
 describe('T093/T249: every action rejects when the integrations tier is denied', () => {
   it.each(allEntries)('$name rejects when the integrations tier is missing', async ({ run }) => {
     assertTierAccessMock.mockRejectedValue(new Error('Integrations tier required'));
 
     await expect(run()).rejects.toThrow(/Integrations tier required/);
-    // Tier access is checked before the flag is even consulted.
-    expect(isEnabledMock).not.toHaveBeenCalled();
     expect(createTenantKnexMock).not.toHaveBeenCalled();
   });
 });

--- a/ee/server/src/__tests__/unit/huduSettingsPageCategory.test.tsx
+++ b/ee/server/src/__tests__/unit/huduSettingsPageCategory.test.tsx
@@ -1,8 +1,8 @@
 // @vitest-environment jsdom
 /**
  * T030 — IntegrationsSettingsPage renders the Hudu item under the
- * "IT Documentation" category only when the Hudu gate (EE + the
- * `hudu-integration` feature flag, via useHuduIntegrationEnabled) is enabled.
+ * "IT Documentation" category only when the Hudu gate (EE edition, via
+ * useHuduIntegrationEnabled) is enabled.
  *
  * The page's sibling integration components, UI primitives, and i18n are
  * mocked; calendarAvailability keeps its real category-id logic with the
@@ -113,7 +113,7 @@ describe('IntegrationsSettingsPage — Hudu IT Documentation category gating (T0
     isEEMock.mockReturnValue(true);
   });
 
-  it('renders the Hudu item under IT Documentation when the gate (EE + flag) is enabled', () => {
+  it('renders the Hudu item under IT Documentation when the gate (EE) is enabled', () => {
     useHuduIntegrationEnabledMock.mockReturnValue({ enabled: true, loading: false });
 
     render(<IntegrationsSettingsPage />);
@@ -125,7 +125,7 @@ describe('IntegrationsSettingsPage — Hudu IT Documentation category gating (T0
     expect(tab?.querySelectorAll('[data-testid="dynamic-integration-stub"]')).toHaveLength(1);
   });
 
-  it('hides the IT Documentation category when the gate is disabled (flag off)', () => {
+  it('hides the IT Documentation category when the gate is disabled', () => {
     useHuduIntegrationEnabledMock.mockReturnValue({ enabled: false, loading: false });
 
     render(<IntegrationsSettingsPage />);

--- a/ee/server/src/app/api/integrations/hudu/_guards.ts
+++ b/ee/server/src/app/api/integrations/hudu/_guards.ts
@@ -2,19 +2,16 @@ import { NextResponse } from 'next/server';
 import { TIER_FEATURES } from '@alga-psa/types';
 import { getCurrentUser } from '@alga-psa/user-composition/actions';
 import { hasPermission } from '@alga-psa/auth/rbac';
-import { featureFlags } from 'server/src/lib/feature-flags/featureFlags';
 import { TierAccessError, assertTierAccess } from 'server/src/lib/tier-gating/assertTierAccess';
 
 type HuduGuardPermission = 'read' | 'update';
 
 /**
- * Hudu UI flag guard — mirrors requireEntraUiFlagEnabled.
+ * Hudu UI access guard — mirrors requireEntraUiFlagEnabled.
  *
- * Requires the integrations tier and the
- * `hudu-integration` feature flag. Returns a Response (401/403/404) when the
- * caller is unauthorized or the integration is disabled, otherwise resolves the
- * tenant + user ids for the handler. Hudu reuses the existing `system_settings`
- * RBAC resource (read=view, update=connect/disconnect/manage mappings).
+ * Requires the integrations tier and `system_settings` RBAC. Returns a Response
+ * (401/403) when the caller is unauthorized, otherwise resolves the tenant +
+ * user ids for the handler (read=view, update=connect/disconnect/manage mappings).
  */
 export async function requireHuduUiFlagEnabled(
   requiredPermission: HuduGuardPermission = 'read'
@@ -65,21 +62,6 @@ export async function requireHuduUiFlagEnabled(
       );
     }
     throw error;
-  }
-
-  const enabled = await featureFlags.isEnabled('hudu-integration', {
-    userId: user.user_id,
-    tenantId: user.tenant,
-  });
-
-  if (!enabled) {
-    return NextResponse.json(
-      {
-        success: false,
-        error: 'Hudu integration is disabled for this tenant.',
-      },
-      { status: 404 }
-    );
   }
 
   return { tenantId: user.tenant, userId: user.user_id };

--- a/ee/server/src/app/api/integrations/hudu/route.ts
+++ b/ee/server/src/app/api/integrations/hudu/route.ts
@@ -8,7 +8,7 @@ export { dynamic, runtime };
 /**
  * GET /api/integrations/hudu — Hudu connection status (EE-only).
  *
- * Gates on EE + `hudu-integration` flag + `system_settings` read, then returns
+ * Gates on EE + `system_settings` read, then returns
  * the tenant's hudu_integrations connection state. SECURITY: the payload never
  * contains the api key — connection metadata only.
  */

--- a/ee/server/src/lib/actions/integrations/huduActions.ts
+++ b/ee/server/src/lib/actions/integrations/huduActions.ts
@@ -5,8 +5,8 @@
  *
  * connect / test / getStatus / disconnect for the per-tenant Hudu connection.
  * Gating mirrors requireHuduUiFlagEnabled (and the Entra action gating): EE
- * tier, `system_settings` RBAC (read=view, update=manage),
- * and the `hudu-integration` feature flag — enforced on every action.
+ * tier and `system_settings` RBAC (read=view, update=manage) — enforced on
+ * every action.
  *
  * SECURITY: the api key is only ever written to the secret provider
  * (`hudu_api_key`/`hudu_base_url` tenant secrets) and is never returned to the
@@ -20,7 +20,6 @@ import { getSecretProviderInstance } from '@alga-psa/core/secrets';
 import { withAuth, hasPermission } from '@alga-psa/auth';
 import type { IUserWithRoles } from '@alga-psa/types';
 import { TIER_FEATURES } from '@alga-psa/types';
-import { featureFlags } from 'server/src/lib/feature-flags/featureFlags';
 import { assertTierAccess } from 'server/src/lib/tier-gating/assertTierAccess';
 import { createTenantKnex } from 'server/src/lib/db';
 import { HuduClient, buildHuduApiBaseUrl } from '../../integrations/hudu/huduClient';
@@ -114,14 +113,6 @@ function withHuduSettingsAccess<TArgs extends unknown[], TResult>(
     }
 
     await assertTierAccess(TIER_FEATURES.INTEGRATIONS);
-
-    const enabled = await featureFlags.isEnabled('hudu-integration', {
-      userId: user.user_id,
-      tenantId: context.tenant,
-    });
-    if (!enabled) {
-      throw new Error('Hudu integration is disabled for this tenant.');
-    }
 
     return handler(user, context as { tenant: string }, ...args);
   });

--- a/ee/server/src/lib/actions/integrations/huduAssetImportActions.ts
+++ b/ee/server/src/lib/actions/integrations/huduAssetImportActions.ts
@@ -5,7 +5,7 @@
  *
  * Thin `withAuth` wrappers over the session-free import core
  * (integrations/hudu/assetImportCore). The wrapper enforces EE tier +
- * `hudu-integration` flag + `asset` CREATE (FR6) and passes the clicking
+ * `asset` CREATE (FR6) and passes the clicking
  * user as the asset audit actor; the core does the work and is shared with the
  * tenant-wide auto-sync (runHuduTenantSync).
  */
@@ -14,7 +14,6 @@ import logger from '@alga-psa/core/logger';
 import { withAuth, hasPermission } from '@alga-psa/auth';
 import type { IUserWithRoles } from '@alga-psa/types';
 import { TIER_FEATURES } from '@alga-psa/types';
-import { featureFlags } from 'server/src/lib/feature-flags/featureFlags';
 import { assertTierAccess } from 'server/src/lib/tier-gating/assertTierAccess';
 import {
   importHuduAssetCore,
@@ -55,14 +54,6 @@ function withHuduAssetCreateAccess<TArgs extends unknown[], TResult>(
     }
 
     await assertTierAccess(TIER_FEATURES.INTEGRATIONS);
-
-    const enabled = await featureFlags.isEnabled('hudu-integration', {
-      userId: user.user_id,
-      tenantId: context.tenant,
-    });
-    if (!enabled) {
-      throw new Error('Hudu integration is disabled for this tenant.');
-    }
 
     return handler(user, context as { tenant: string }, ...args);
   });

--- a/ee/server/src/lib/actions/integrations/huduAssetMappingActions.ts
+++ b/ee/server/src/lib/actions/integrations/huduAssetMappingActions.ts
@@ -5,8 +5,7 @@
  *
  * Sibling of huduMappingActions.ts, but RBAC-gated on the `asset` resource
  * (FR16/FR6/FR10: mapping is a Technician flow — read=view, update=mutate)
- * instead of system_settings. Same EE tier +
- * `hudu-integration` flag chain otherwise.
+ * instead of system_settings. Same EE tier gate otherwise.
  *
  * The Hudu asset list is fetched through the Phase 1 path
  * (getHuduCompanyAssets: per-mapped-company, short server cache) — never a
@@ -17,7 +16,6 @@ import logger from '@alga-psa/core/logger';
 import { withAuth, hasPermission } from '@alga-psa/auth';
 import type { IUserWithRoles } from '@alga-psa/types';
 import { TIER_FEATURES } from '@alga-psa/types';
-import { featureFlags } from 'server/src/lib/feature-flags/featureFlags';
 import { assertTierAccess } from 'server/src/lib/tier-gating/assertTierAccess';
 import { createTenantKnex } from 'server/src/lib/db';
 import type { Knex } from 'knex';
@@ -99,14 +97,6 @@ function withHuduAssetAccess<TArgs extends unknown[], TResult>(
     }
 
     await assertTierAccess(TIER_FEATURES.INTEGRATIONS);
-
-    const enabled = await featureFlags.isEnabled('hudu-integration', {
-      userId: user.user_id,
-      tenantId: context.tenant,
-    });
-    if (!enabled) {
-      throw new Error('Hudu integration is disabled for this tenant.');
-    }
 
     return handler(user, context as { tenant: string }, ...args);
   });

--- a/ee/server/src/lib/actions/integrations/huduAssetSyncActions.ts
+++ b/ee/server/src/lib/actions/integrations/huduAssetSyncActions.ts
@@ -4,8 +4,8 @@
  * Hudu manual pull-sync server action (F219–F222, EE-only).
  *
  * Thin `withAuth` wrapper over the session-free sync core
- * (integrations/hudu/assetSyncCore). Enforces EE tier + `hudu-integration`
- * flag + `asset` UPDATE and passes the clicking user as the asset audit actor;
+ * (integrations/hudu/assetSyncCore). Enforces EE tier + `asset` UPDATE and
+ * passes the clicking user as the asset audit actor;
  * the core does the work and is shared with the tenant-wide auto-sync.
  */
 
@@ -13,7 +13,6 @@ import logger from '@alga-psa/core/logger';
 import { withAuth, hasPermission } from '@alga-psa/auth';
 import type { IUserWithRoles } from '@alga-psa/types';
 import { TIER_FEATURES } from '@alga-psa/types';
-import { featureFlags } from 'server/src/lib/feature-flags/featureFlags';
 import { assertTierAccess } from 'server/src/lib/tier-gating/assertTierAccess';
 import { syncHuduClientAssetsCore } from '../../integrations/hudu/assetSyncCore';
 import type { HuduAssetSyncResult } from '../../integrations/hudu/assetSyncCore';
@@ -42,14 +41,6 @@ function withHuduAssetAccess<TArgs extends unknown[], TResult>(
     }
 
     await assertTierAccess(TIER_FEATURES.INTEGRATIONS);
-
-    const enabled = await featureFlags.isEnabled('hudu-integration', {
-      userId: user.user_id,
-      tenantId: context.tenant,
-    });
-    if (!enabled) {
-      throw new Error('Hudu integration is disabled for this tenant.');
-    }
 
     return handler(user, context as { tenant: string }, ...args);
   });

--- a/ee/server/src/lib/actions/integrations/huduDataActions.ts
+++ b/ee/server/src/lib/actions/integrations/huduDataActions.ts
@@ -4,8 +4,8 @@
  * Hudu reference-data server actions (EE-only): per-mapped-company assets /
  * articles / asset-password lists (F060–F066) and the on-demand password
  * reveal (F067/F068). Gating mirrors huduActions (withHuduSettingsAccess):
- * EE tier, `system_settings` RBAC, `hudu-integration`
- * flag. All actions — including reveal — use the READ gate: PRD flow 4 makes
+ * EE tier and `system_settings` RBAC. All actions — including reveal — use the
+ * READ gate: PRD flow 4 makes
  * viewing/revealing credentials a Technician flow, and the compensating
  * control for reveal is the mandatory fail-closed audit, not a stricter gate.
  *
@@ -24,7 +24,6 @@ import logger from '@alga-psa/core/logger';
 import { withAuth, hasPermission } from '@alga-psa/auth';
 import type { IUserWithRoles } from '@alga-psa/types';
 import { TIER_FEATURES } from '@alga-psa/types';
-import { featureFlags } from 'server/src/lib/feature-flags/featureFlags';
 import { assertTierAccess } from 'server/src/lib/tier-gating/assertTierAccess';
 import { createTenantKnex } from 'server/src/lib/db';
 import { createHuduClient, HuduRequestError } from '../../integrations/hudu/huduClient';
@@ -85,14 +84,6 @@ function withHuduSettingsAccess<TArgs extends unknown[], TResult>(
     }
 
     await assertTierAccess(TIER_FEATURES.INTEGRATIONS);
-
-    const enabled = await featureFlags.isEnabled('hudu-integration', {
-      userId: user.user_id,
-      tenantId: context.tenant,
-    });
-    if (!enabled) {
-      throw new Error('Hudu integration is disabled for this tenant.');
-    }
 
     return handler(user, context as { tenant: string }, ...args);
   });

--- a/ee/server/src/lib/actions/integrations/huduGlobalDocsActions.ts
+++ b/ee/server/src/lib/actions/integrations/huduGlobalDocsActions.ts
@@ -5,16 +5,15 @@
  * (F231, FR14/FR16). One Hudu page (25 items) per invocation — never a page
  * fan-out (NFR2) — with the user's search term passed through to Hudu and
  * each article's company resolved to its Alga client via the companies cache
- * + client mapping rows. Gating mirrors the sibling action wrappers (EE tier
- * + `hudu-integration` flag) but on `client` read RBAC:
- * browsing articles is a Technician flow, not settings administration.
+ * + client mapping rows. Gating mirrors the sibling action wrappers (EE tier)
+ * but on `client` read RBAC: browsing articles is a Technician flow, not
+ * settings administration.
  */
 
 import logger from '@alga-psa/core/logger';
 import { withAuth, hasPermission } from '@alga-psa/auth';
 import type { IUserWithRoles } from '@alga-psa/types';
 import { TIER_FEATURES } from '@alga-psa/types';
-import { featureFlags } from 'server/src/lib/feature-flags/featureFlags';
 import { assertTierAccess } from 'server/src/lib/tier-gating/assertTierAccess';
 import { createTenantKnex } from 'server/src/lib/db';
 import { createHuduClient, HuduRequestError } from '../../integrations/hudu/huduClient';
@@ -67,14 +66,6 @@ function withHuduClientReadAccess<TArgs extends unknown[], TResult>(
     }
 
     await assertTierAccess(TIER_FEATURES.INTEGRATIONS);
-
-    const enabled = await featureFlags.isEnabled('hudu-integration', {
-      userId: user.user_id,
-      tenantId: context.tenant,
-    });
-    if (!enabled) {
-      throw new Error('Hudu integration is disabled for this tenant.');
-    }
 
     return handler(user, context as { tenant: string }, ...args);
   });

--- a/ee/server/src/lib/actions/integrations/huduLayoutMapActions.ts
+++ b/ee/server/src/lib/actions/integrations/huduLayoutMapActions.ts
@@ -4,16 +4,15 @@
  * Hudu asset-layout→asset-type map server actions (EE-only, Phase 2 FR11).
  *
  * get/set for `hudu_integrations.settings.asset_layout_type_map`. Gating
- * mirrors huduActions (withHuduSettingsAccess): EE tier,
- * `system_settings` RBAC (read=view, update=persist), and the
- * `hudu-integration` flag — enforced on every action.
+ * mirrors huduActions (withHuduSettingsAccess): EE tier and
+ * `system_settings` RBAC (read=view, update=persist) — enforced on every
+ * action.
  */
 
 import logger from '@alga-psa/core/logger';
 import { withAuth, hasPermission } from '@alga-psa/auth';
 import type { IUserWithRoles } from '@alga-psa/types';
 import { TIER_FEATURES } from '@alga-psa/types';
-import { featureFlags } from 'server/src/lib/feature-flags/featureFlags';
 import { assertTierAccess } from 'server/src/lib/tier-gating/assertTierAccess';
 import { createTenantKnex } from 'server/src/lib/db';
 import { createAssetType, listAssetTypes } from '@alga-psa/assets/lib/assetTypeRegistry';
@@ -76,14 +75,6 @@ function withHuduSettingsAccess<TArgs extends unknown[], TResult>(
     }
 
     await assertTierAccess(TIER_FEATURES.INTEGRATIONS);
-
-    const enabled = await featureFlags.isEnabled('hudu-integration', {
-      userId: user.user_id,
-      tenantId: context.tenant,
-    });
-    if (!enabled) {
-      throw new Error('Hudu integration is disabled for this tenant.');
-    }
 
     return handler(user, context as { tenant: string }, ...args);
   });

--- a/ee/server/src/lib/actions/integrations/huduMappingActions.ts
+++ b/ee/server/src/lib/actions/integrations/huduMappingActions.ts
@@ -6,8 +6,8 @@
  * sync / list / set / clear for company mappings in the SHARED CE table
  * `tenant_external_entity_mappings`. Gating mirrors huduActions
  * (withHuduSettingsAccess): EE tier, `system_settings`
- * RBAC (read=list, update=mutate), and the `hudu-integration` flag — NOT the
- * billing_settings-gated externalMappingActions wrappers (OQ3).
+ * RBAC (read=list, update=mutate) — NOT the billing_settings-gated
+ * externalMappingActions wrappers (OQ3).
  *
  * "Cache the list for mapping" (F040) = a compact companies snapshot in
  * hudu_integrations.settings.companies_cache so the mapping UI renders
@@ -18,7 +18,6 @@ import logger from '@alga-psa/core/logger';
 import { withAuth, hasPermission } from '@alga-psa/auth';
 import type { IUserWithRoles } from '@alga-psa/types';
 import { TIER_FEATURES } from '@alga-psa/types';
-import { featureFlags } from 'server/src/lib/feature-flags/featureFlags';
 import { assertTierAccess } from 'server/src/lib/tier-gating/assertTierAccess';
 import { createTenantKnex } from 'server/src/lib/db';
 import type { Knex } from 'knex';
@@ -94,14 +93,6 @@ function withHuduSettingsAccess<TArgs extends unknown[], TResult>(
     }
 
     await assertTierAccess(TIER_FEATURES.INTEGRATIONS);
-
-    const enabled = await featureFlags.isEnabled('hudu-integration', {
-      userId: user.user_id,
-      tenantId: context.tenant,
-    });
-    if (!enabled) {
-      throw new Error('Hudu integration is disabled for this tenant.');
-    }
 
     return handler(user, context as { tenant: string }, ...args);
   });

--- a/ee/server/src/lib/actions/integrations/huduTenantSyncActions.ts
+++ b/ee/server/src/lib/actions/integrations/huduTenantSyncActions.ts
@@ -8,7 +8,7 @@
  * toggle. All run the shared runHuduTenantSync engine and report an
  * RMM-style summary; the toggle persists settings.autoSync and converges the
  * recurring job schedule. Gating mirrors the per-client Hudu actions: EE tier +
- * `hudu-integration` flag, `asset` create/update for the runs, `system_settings`
+ * `asset` create/update for the runs, `system_settings`
  * update for the toggle.
  */
 
@@ -16,7 +16,6 @@ import logger from '@alga-psa/core/logger';
 import { withAuth, hasPermission } from '@alga-psa/auth';
 import type { IUserWithRoles } from '@alga-psa/types';
 import { TIER_FEATURES } from '@alga-psa/types';
-import { featureFlags } from 'server/src/lib/feature-flags/featureFlags';
 import { assertTierAccess } from 'server/src/lib/tier-gating/assertTierAccess';
 import { createTenantKnex } from 'server/src/lib/db';
 import { runHuduTenantSync } from '../../integrations/hudu/tenantSync';
@@ -54,14 +53,6 @@ function withHuduAccess<TArgs extends unknown[], TResult>(
     }
 
     await assertTierAccess(TIER_FEATURES.INTEGRATIONS);
-
-    const enabled = await featureFlags.isEnabled('hudu-integration', {
-      userId: user.user_id,
-      tenantId: context.tenant,
-    });
-    if (!enabled) {
-      throw new Error('Hudu integration is disabled for this tenant.');
-    }
 
     return handler(user, context as { tenant: string }, ...args);
   });

--- a/ee/server/src/lib/actions/integrations/huntressActions.ts
+++ b/ee/server/src/lib/actions/integrations/huntressActions.ts
@@ -35,8 +35,8 @@ import type { RmmOrganizationMapping } from '../../../interfaces/rmm.interfaces'
 
 const SETTINGS_PATH = '/msp/settings';
 
-// Huntress visibility is gated in the UI via the huntress-rmm-integration
-// feature flag; server actions enforce tier + permissions only.
+// Huntress visibility in the UI is EE-gated (requiresEnterprise); server
+// actions enforce tier + permissions only.
 function withHuntressAccess<TArgs extends unknown[], TResult>(
   handler: (user: any, context: { tenant: string }, ...args: TArgs) => Promise<TResult>
 ) {

--- a/packages/clients/src/components/clients/ClientDetails.tsx
+++ b/packages/clients/src/components/clients/ClientDetails.tsx
@@ -274,7 +274,7 @@ const ClientDetails: React.FC<ClientDetailsProps> = ({
     editedClient
   );
   const shouldRenderPsaOnlyClientSurfaces = !isAlgaDeskMode;
-  // F070: EE + hudu-integration flag + Hudu connected + this client mapped.
+  // F070: EE + Hudu connected + this client mapped.
   const huduClientTab = useHuduClientTab(client.client_id);
 
   const fetchEntraSyncRunStatus = useCallback(async (runId: string): Promise<string | null> => {

--- a/packages/clients/src/components/clients/useHuduClientTab.ts
+++ b/packages/clients/src/components/clients/useHuduClientTab.ts
@@ -2,7 +2,6 @@
 
 import { useEffect, useState } from 'react';
 import { isEnterprise } from '@alga-psa/core';
-import { useFeatureFlag } from '@alga-psa/ui/hooks';
 
 export interface HuduClientTabGate {
   visible: boolean;
@@ -10,15 +9,12 @@ export interface HuduClientTabGate {
 }
 
 /**
- * Visibility gate for the client "Hudu" tab (F070): EE edition + the
- * `hudu-integration` feature flag (same gate as useHuduIntegrationEnabled in
- * @alga-psa/integrations, inlined here to avoid a package dependency), then a
- * light edition-swapped probe — Hudu connected AND this client mapped. Any
- * probe failure resolves hidden.
+ * Visibility gate for the client "Hudu" tab (F070): EE edition, then a light
+ * edition-swapped probe — Hudu connected AND this client mapped. Any probe
+ * failure resolves hidden.
  */
 export function useHuduClientTab(clientId: string): HuduClientTabGate {
-  const flag = useFeatureFlag('hudu-integration', { defaultValue: false });
-  const enabled = isEnterprise && !!flag.enabled;
+  const enabled = isEnterprise;
 
   const [context, setContext] = useState<{ connected: boolean; mapped: boolean } | null>(null);
   const [checking, setChecking] = useState(false);
@@ -50,6 +46,6 @@ export function useHuduClientTab(clientId: string): HuduClientTabGate {
 
   return {
     visible: enabled && context?.connected === true && context?.mapped === true,
-    loading: flag.loading || checking,
+    loading: checking,
   };
 }

--- a/packages/documents/src/components/useHuduDocumentsTab.ts
+++ b/packages/documents/src/components/useHuduDocumentsTab.ts
@@ -2,7 +2,6 @@
 
 import { useEffect, useState } from 'react';
 import { isEnterprise } from '@alga-psa/core';
-import { useFeatureFlag } from '@alga-psa/ui/hooks';
 
 export interface HuduDocumentsTabGate {
   visible: boolean;
@@ -10,14 +9,12 @@ export interface HuduDocumentsTabGate {
 }
 
 /**
- * Visibility gate for the Documents page "Hudu" tab (F232): EE edition + the
- * `hudu-integration` feature flag (useHuduClientTab precedent), then a light
- * edition-swapped probe — Hudu connected for the tenant (no client mapping
- * required). Any probe failure resolves hidden.
+ * Visibility gate for the Documents page "Hudu" tab (F232): EE edition, then a
+ * light edition-swapped probe — Hudu connected for the tenant (no client
+ * mapping required). Any probe failure resolves hidden.
  */
 export function useHuduDocumentsTab(): HuduDocumentsTabGate {
-  const flag = useFeatureFlag('hudu-integration', { defaultValue: false });
-  const enabled = isEnterprise && !!flag.enabled;
+  const enabled = isEnterprise;
 
   const [connected, setConnected] = useState<boolean | null>(null);
   const [checking, setChecking] = useState(false);
@@ -51,6 +48,6 @@ export function useHuduDocumentsTab(): HuduDocumentsTabGate {
 
   return {
     visible: enabled && connected === true,
-    loading: flag.loading || checking,
+    loading: checking,
   };
 }

--- a/packages/integrations/src/components/email/EmailProviderConfiguration.tsx
+++ b/packages/integrations/src/components/email/EmailProviderConfiguration.tsx
@@ -25,7 +25,6 @@ import { Microsoft365DiagnosticsDialog } from './admin/Microsoft365DiagnosticsDi
 import { DrawerOutlet, DrawerProvider, useDrawer } from '@alga-psa/ui';
 import LoadingIndicator from '@alga-psa/ui/components/LoadingIndicator';
 import { useTranslation } from '@alga-psa/ui/lib/i18n/client';
-import { useFeatureFlag } from '@alga-psa/ui/hooks';
 import {
   getEmailProviders,
   deleteEmailProvider,
@@ -55,10 +54,6 @@ function EmailProviderConfigurationContent({
 }: EmailProviderConfigurationProps) {
   const { t } = useTranslation('msp/email-providers');
   const isEnterpriseEdition = isMicrosoftConsumerEnterpriseEdition();
-  // Dark-release gate for the inbound email rules UI. Off by default (PostHog
-  // returns false for an unknown flag); UI-only — rule evaluation and server
-  // actions stay live regardless.
-  const { enabled: inboundEmailRulesUiEnabled } = useFeatureFlag('inbound-email-rules');
   const [providers, setProviders] = useState<EmailProvider[]>([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
@@ -511,22 +506,20 @@ function EmailProviderConfigurationContent({
               defaultValue: 'Defaults',
             })}
           </Button>
-          {inboundEmailRulesUiEnabled && (
-            <Button
-              id="nav-inbound-rules"
-              variant="ghost"
-              className={`justify-start w-full px-2 py-2 rounded-md ${
-                activeSection === 'rules'
-                  ? 'text-[rgb(var(--color-primary-700))] font-semibold underline decoration-[rgb(var(--color-primary-600))] decoration-2 underline-offset-4 bg-primary-500/10'
-                  : 'text-[rgb(var(--color-text-700))] hover:text-[rgb(var(--color-text-900))] hover:bg-[rgb(var(--color-border-50))]'
-              }`}
-              onClick={() => setActiveSection('rules')}
-            >
-              {t('configuration.nav.inboundRules', {
-                defaultValue: 'Inbound Rules',
-              })}
-            </Button>
-          )}
+          <Button
+            id="nav-inbound-rules"
+            variant="ghost"
+            className={`justify-start w-full px-2 py-2 rounded-md ${
+              activeSection === 'rules'
+                ? 'text-[rgb(var(--color-primary-700))] font-semibold underline decoration-[rgb(var(--color-primary-600))] decoration-2 underline-offset-4 bg-primary-500/10'
+                : 'text-[rgb(var(--color-text-700))] hover:text-[rgb(var(--color-text-900))] hover:bg-[rgb(var(--color-border-50))]'
+            }`}
+            onClick={() => setActiveSection('rules')}
+          >
+            {t('configuration.nav.inboundRules', {
+              defaultValue: 'Inbound Rules',
+            })}
+          </Button>
         </nav>
       </div>
       <div className="flex-1 min-w-0">
@@ -553,11 +546,11 @@ function EmailProviderConfigurationContent({
               window.dispatchEvent(new CustomEvent('inbound-defaults-updated'));
             }} />
           </div>
-        ) : inboundEmailRulesUiEnabled ? (
+        ) : (
           <div className="space-y-4">
             <InboundEmailRulesManager />
           </div>
-        ) : null}
+        )}
       </div>
     </div>
   );

--- a/packages/integrations/src/components/settings/integrations/RmmIntegrationsSetup.registry.test.tsx
+++ b/packages/integrations/src/components/settings/integrations/RmmIntegrationsSetup.registry.test.tsx
@@ -15,10 +15,6 @@ vi.mock('next/navigation', () => ({
   useSearchParams: () => new URLSearchParams(''),
 }));
 
-vi.mock('@alga-psa/ui/hooks', () => ({
-  useFeatureFlag: vi.fn((flag: string) => ({ enabled: flag === 'tactical-rmm-integration' })),
-}));
-
 vi.mock('./TacticalRmmIntegrationSettings', () => ({
   default: () => <div data-testid="tactical-settings">Tactical Settings</div>,
 }));

--- a/packages/integrations/src/components/settings/integrations/RmmIntegrationsSetup.tsx
+++ b/packages/integrations/src/components/settings/integrations/RmmIntegrationsSetup.tsx
@@ -6,10 +6,9 @@ import { usePathname, useRouter, useSearchParams } from 'next/navigation';
 import { ChevronLeft, ChevronRight } from 'lucide-react';
 import { Badge } from '@alga-psa/ui/components/Badge';
 import { Button } from '@alga-psa/ui/components/Button';
-import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@alga-psa/ui/components/Card';
+import { Card, CardContent } from '@alga-psa/ui/components/Card';
 import Spinner from '@alga-psa/ui/components/Spinner';
 import { cn } from '@alga-psa/ui/lib/utils';
-import { useFeatureFlag } from '@alga-psa/ui/hooks';
 import type { RmmProvider } from '@alga-psa/types';
 import { useTranslation } from '@alga-psa/ui/lib/i18n/client';
 import {
@@ -156,25 +155,11 @@ export default function RmmIntegrationsSetup() {
   const pathname = usePathname();
   const searchParams = useSearchParams();
   const isEEAvailable = process.env.NEXT_PUBLIC_EDITION === 'enterprise';
-  const tacticalFlag = useFeatureFlag('tactical-rmm-integration', { defaultValue: false });
-  const taniumFlag = useFeatureFlag('tanium-rmm-integration', { defaultValue: false });
-  const levelIoFlag = useFeatureFlag('levelio-rmm-integration', { defaultValue: false });
-  const huntressFlag = useFeatureFlag('huntress-rmm-integration', { defaultValue: false });
-  const isTacticalEnabled = !!tacticalFlag?.enabled;
-  const isTaniumEnabled = !!taniumFlag?.enabled;
-  const isLevelIoEnabled = !!levelIoFlag?.enabled;
-  const isHuntressEnabled = !!huntressFlag?.enabled;
 
   const options = useMemo<RmmIntegrationOption[]>(
     () => {
       const availableProviders = getAvailableRmmProviderRegistry({
-        isEnterprise: isEEAvailable,
-        enabledFeatureFlags: {
-          'tactical-rmm-integration': isTacticalEnabled,
-          'tanium-rmm-integration': isTaniumEnabled,
-          'levelio-rmm-integration': isLevelIoEnabled,
-          'huntress-rmm-integration': isHuntressEnabled
-        }
+        isEnterprise: isEEAvailable
       });
 
       return availableProviders
@@ -188,7 +173,7 @@ export default function RmmIntegrationsSetup() {
         })
         .filter((option): option is RmmIntegrationOption => option !== null);
     },
-    [isEEAvailable, isTacticalEnabled, isTaniumEnabled, isLevelIoEnabled, isHuntressEnabled]
+    [isEEAvailable]
   );
 
   const [selected, setSelected] = useState<RmmProvider | null>(
@@ -240,16 +225,6 @@ export default function RmmIntegrationsSetup() {
 
   // In CE, Tactical is the only supported RMM provider UI we expose today.
   if (!isEEAvailable) {
-    if (!isTacticalEnabled) {
-      return (
-        <Card>
-          <CardHeader>
-            <CardTitle>{t('integrations.rmm.setup.title', { defaultValue: 'RMM Integrations' })}</CardTitle>
-            <CardDescription>{t('integrations.rmm.setup.comingSoon', { defaultValue: 'RMM integration coming soon' })}</CardDescription>
-          </CardHeader>
-        </Card>
-      );
-    }
     return <TacticalRmmIntegrationSettings />;
   }
 

--- a/packages/integrations/src/components/settings/integrations/useHuduIntegrationEnabled.test.ts
+++ b/packages/integrations/src/components/settings/integrations/useHuduIntegrationEnabled.test.ts
@@ -1,11 +1,6 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
-const useFeatureFlagMock = vi.fn();
 const isCalendarEnterpriseEditionMock = vi.fn();
-
-vi.mock('@alga-psa/ui/hooks', () => ({
-  useFeatureFlag: useFeatureFlagMock,
-}));
 
 vi.mock('../../../lib/calendarAvailability', () => ({
   isCalendarEnterpriseEdition: isCalendarEnterpriseEditionMock,
@@ -18,7 +13,6 @@ async function importHook() {
 describe('T002: useHuduIntegrationEnabled', () => {
   beforeEach(() => {
     vi.resetModules();
-    useFeatureFlagMock.mockReset();
     isCalendarEnterpriseEditionMock.mockReset();
   });
 
@@ -26,44 +20,27 @@ describe('T002: useHuduIntegrationEnabled', () => {
     vi.restoreAllMocks();
   });
 
-  it('returns enabled=false by default when the flag is absent (defaults off)', async () => {
-    // EE detected, but the flag has never been set => useFeatureFlag yields its
-    // defaultValue of false.
+  it('returns enabled=true in EE', async () => {
     isCalendarEnterpriseEditionMock.mockReturnValue(true);
-    useFeatureFlagMock.mockReturnValue({ enabled: false, loading: false, error: null });
-
-    const { useHuduIntegrationEnabled } = await importHook();
-    const result = useHuduIntegrationEnabled();
-
-    expect(result.enabled).toBe(false);
-    // The hook asks for the hudu-integration flag with a false default.
-    expect(useFeatureFlagMock).toHaveBeenCalledWith('hudu-integration', { defaultValue: false });
-  });
-
-  it('returns enabled=false in CE even if the flag is somehow on', async () => {
-    isCalendarEnterpriseEditionMock.mockReturnValue(false);
-    useFeatureFlagMock.mockReturnValue({ enabled: true, loading: false, error: null });
-
-    const { useHuduIntegrationEnabled } = await importHook();
-
-    expect(useHuduIntegrationEnabled().enabled).toBe(false);
-  });
-
-  it('returns enabled=true only when EE and the flag are both on', async () => {
-    isCalendarEnterpriseEditionMock.mockReturnValue(true);
-    useFeatureFlagMock.mockReturnValue({ enabled: true, loading: false, error: null });
 
     const { useHuduIntegrationEnabled } = await importHook();
 
     expect(useHuduIntegrationEnabled().enabled).toBe(true);
   });
 
-  it('surfaces the underlying flag loading state', async () => {
-    isCalendarEnterpriseEditionMock.mockReturnValue(true);
-    useFeatureFlagMock.mockReturnValue({ enabled: false, loading: true, error: null });
+  it('returns enabled=false in CE', async () => {
+    isCalendarEnterpriseEditionMock.mockReturnValue(false);
 
     const { useHuduIntegrationEnabled } = await importHook();
 
-    expect(useHuduIntegrationEnabled().loading).toBe(true);
+    expect(useHuduIntegrationEnabled().enabled).toBe(false);
+  });
+
+  it('never reports a loading state', async () => {
+    isCalendarEnterpriseEditionMock.mockReturnValue(true);
+
+    const { useHuduIntegrationEnabled } = await importHook();
+
+    expect(useHuduIntegrationEnabled().loading).toBe(false);
   });
 });

--- a/packages/integrations/src/components/settings/integrations/useHuduIntegrationEnabled.ts
+++ b/packages/integrations/src/components/settings/integrations/useHuduIntegrationEnabled.ts
@@ -1,27 +1,21 @@
 'use client';
 
-import { useFeatureFlag } from '@alga-psa/ui/hooks';
 import { isCalendarEnterpriseEdition } from '../../../lib/calendarAvailability';
 
 /**
  * Client-side gating helper for Hudu UI surfaces.
  *
- * Mirrors the Entra UI gate (IntegrationsSettingsPage.tsx): combine EE-edition
- * detection with the `hudu-integration` feature flag. Use this to decide
- * whether to render the Hudu settings item, the client "Hudu" tab, and the
- * client "Passwords" tab.
- *
- * The flag defaults off; `loading` reflects the underlying PostHog probe.
+ * EE-edition detection only. Use this to decide whether to render the Hudu
+ * settings item, the client "Hudu" tab, and the client "Passwords" tab.
  */
 export function useHuduIntegrationEnabled(): {
   enabled: boolean;
   loading: boolean;
 } {
   const isEEAvailable = isCalendarEnterpriseEdition();
-  const flag = useFeatureFlag('hudu-integration', { defaultValue: false });
 
   return {
-    enabled: isEEAvailable && !!flag.enabled,
-    loading: flag.loading,
+    enabled: isEEAvailable,
+    loading: false,
   };
 }

--- a/packages/integrations/src/lib/calendarAvailability.ts
+++ b/packages/integrations/src/lib/calendarAvailability.ts
@@ -31,7 +31,7 @@ export function getVisibleIntegrationCategoryIds(isEnterpriseEdition = isCalenda
     ? [
         ...BASE_INTEGRATION_CATEGORY_IDS.slice(0, 2),
         // EE-only: the category itself is rendered only when the Hudu gate
-        // (EE + `hudu-integration` flag) is enabled.
+        // (EE edition) is enabled.
         IT_DOCUMENTATION_SETTINGS_CATEGORY,
         BASE_INTEGRATION_CATEGORY_IDS[2],
         CALENDAR_SETTINGS_CATEGORY,

--- a/packages/integrations/src/lib/rmm/providerRegistry.test.ts
+++ b/packages/integrations/src/lib/rmm/providerRegistry.test.ts
@@ -15,12 +15,11 @@ describe('RMM provider registry', () => {
     });
   });
 
-  it('exposes Level metadata gated by enterprise and feature flag', () => {
+  it('exposes Level metadata gated by enterprise', () => {
     const levelio = getRmmProviderMetadata('levelio');
     expect(levelio).toBeDefined();
     expect(levelio?.title).toBe('Level');
     expect(levelio?.requiresEnterprise).toBe(true);
-    expect(levelio?.featureFlagKey).toBe('levelio-rmm-integration');
     expect(levelio?.capabilities).toEqual({
       connection: true,
       scopeSync: true,
@@ -30,12 +29,11 @@ describe('RMM provider registry', () => {
     });
   });
 
-  it('exposes Huntress metadata gated by enterprise and feature flag', () => {
+  it('exposes Huntress metadata gated by enterprise', () => {
     const huntress = getRmmProviderMetadata('huntress');
     expect(huntress).toBeDefined();
     expect(huntress?.title).toBe('Huntress');
     expect(huntress?.requiresEnterprise).toBe(true);
-    expect(huntress?.featureFlagKey).toBe('huntress-rmm-integration');
     expect(huntress?.capabilities).toEqual({
       connection: true,
       scopeSync: true,

--- a/packages/integrations/src/lib/rmm/providerRegistry.ts
+++ b/packages/integrations/src/lib/rmm/providerRegistry.ts
@@ -21,12 +21,10 @@ export interface RmmProviderMetadata {
   badge?: RmmProviderBadge;
   capabilities: RmmProviderCapabilityFlags;
   requiresEnterprise: boolean;
-  featureFlagKey?: 'tactical-rmm-integration' | 'tanium-rmm-integration' | 'levelio-rmm-integration' | 'huntress-rmm-integration';
 }
 
 export interface RmmProviderAvailabilityContext {
   isEnterprise: boolean;
-  enabledFeatureFlags: Partial<Record<'tactical-rmm-integration' | 'tanium-rmm-integration' | 'levelio-rmm-integration' | 'huntress-rmm-integration', boolean>>;
 }
 
 const RMM_PROVIDER_REGISTRY: RmmProviderMetadata[] = [
@@ -42,8 +40,7 @@ const RMM_PROVIDER_REGISTRY: RmmProviderMetadata[] = [
       events: true,
       remoteActions: true
     },
-    requiresEnterprise: false,
-    featureFlagKey: 'tactical-rmm-integration'
+    requiresEnterprise: false
   },
   {
     id: 'ninjaone',
@@ -73,8 +70,7 @@ const RMM_PROVIDER_REGISTRY: RmmProviderMetadata[] = [
       events: false,
       remoteActions: false
     },
-    requiresEnterprise: true,
-    featureFlagKey: 'tanium-rmm-integration'
+    requiresEnterprise: true
   },
   {
     id: 'levelio',
@@ -89,8 +85,7 @@ const RMM_PROVIDER_REGISTRY: RmmProviderMetadata[] = [
       events: true,
       remoteActions: false
     },
-    requiresEnterprise: true,
-    featureFlagKey: 'levelio-rmm-integration'
+    requiresEnterprise: true
   },
   {
     id: 'huntress',
@@ -105,8 +100,7 @@ const RMM_PROVIDER_REGISTRY: RmmProviderMetadata[] = [
       events: false,
       remoteActions: false
     },
-    requiresEnterprise: true,
-    featureFlagKey: 'huntress-rmm-integration'
+    requiresEnterprise: true
   }
 ];
 
@@ -115,10 +109,6 @@ export function getAvailableRmmProviderRegistry(
 ): RmmProviderMetadata[] {
   return RMM_PROVIDER_REGISTRY.filter((provider) => {
     if (provider.requiresEnterprise && !context.isEnterprise) {
-      return false;
-    }
-
-    if (provider.featureFlagKey && !context.enabledFeatureFlags[provider.featureFlagKey]) {
       return false;
     }
 

--- a/packages/tickets/src/components/settings/BoardsSettings.tsx
+++ b/packages/tickets/src/components/settings/BoardsSettings.tsx
@@ -50,7 +50,6 @@ import {
   DropdownMenuItem,
 } from '@alga-psa/ui/components/DropdownMenu';
 import { useTranslation } from '@alga-psa/ui/lib/i18n/client';
-import { useFeatureFlag } from '@alga-psa/ui/hooks';
 
 type TicketStatusSeedMode = 'copy_existing' | 'create_inline';
 type ManagedTicketStatus = {
@@ -311,10 +310,6 @@ interface BoardsSettingsProps {
 
 const BoardsSettings: React.FC<BoardsSettingsProps> = ({ isAlgaDesk = false, getSlaPolicies }) => {
   const { t } = useTranslation('msp/settings');
-  // Dark-release gate for the auto-close rules UI. Off by default (PostHog
-  // returns false for an unknown flag); UI-only — the auto-close engine and
-  // server actions stay live regardless.
-  const { enabled: autoCloseRulesUiEnabled } = useFeatureFlag('ticket-auto-close-rules');
   const createEmptyFormData = () => ({
     board_name: '',
     description: '',
@@ -846,7 +841,7 @@ const BoardsSettings: React.FC<BoardsSettingsProps> = ({ isAlgaDesk = false, get
         return;
       }
 
-      if (editingBoard && autoCloseRulesUiEnabled) {
+      if (editingBoard) {
         for (const rule of autoCloseRulesForm) {
           if (!rule.trigger_status_id || !rule.close_to_status_id) {
             failInSection('automation', t('ticketing.boards.closeRules.messages.autoCloseStatusRequired'));
@@ -892,23 +887,21 @@ const BoardsSettings: React.FC<BoardsSettingsProps> = ({ isAlgaDesk = false, get
 
         await upsertBoardCloseRules(editingBoard.board_id!, closeRulesForm);
 
-        if (autoCloseRulesUiEnabled) {
-          for (const ruleId of removedAutoCloseRuleIds) {
-            await deleteBoardAutoCloseRule(ruleId);
-          }
-          for (const rule of autoCloseRulesForm) {
-            const payload = {
-              trigger_status_id: rule.trigger_status_id,
-              inactivity_days: rule.inactivity_days,
-              warning_days_before: rule.warning_days_before,
-              close_to_status_id: rule.close_to_status_id,
-              is_enabled: rule.is_enabled,
-            };
-            if (rule.rule_id) {
-              await updateBoardAutoCloseRule(rule.rule_id, payload);
-            } else {
-              await createBoardAutoCloseRule(editingBoard.board_id!, payload);
-            }
+        for (const ruleId of removedAutoCloseRuleIds) {
+          await deleteBoardAutoCloseRule(ruleId);
+        }
+        for (const rule of autoCloseRulesForm) {
+          const payload = {
+            trigger_status_id: rule.trigger_status_id,
+            inactivity_days: rule.inactivity_days,
+            warning_days_before: rule.warning_days_before,
+            close_to_status_id: rule.close_to_status_id,
+            is_enabled: rule.is_enabled,
+          };
+          if (rule.rule_id) {
+            await updateBoardAutoCloseRule(rule.rule_id, payload);
+          } else {
+            await createBoardAutoCloseRule(editingBoard.board_id!, payload);
           }
         }
 
@@ -1789,7 +1782,7 @@ const BoardsSettings: React.FC<BoardsSettingsProps> = ({ isAlgaDesk = false, get
               </EditorAccordionSection>
             )}
 
-            {editingBoard && autoCloseRulesUiEnabled && (
+            {editingBoard && (
               <EditorAccordionSection
                 id="automation"
             error={sectionErrors['automation']}

--- a/packages/tickets/src/components/ticket/TicketDetailsContainer.tsx
+++ b/packages/tickets/src/components/ticket/TicketDetailsContainer.tsx
@@ -5,7 +5,6 @@ import { useRouter } from 'next/navigation';
 import { useSession } from 'next-auth/react';
 import { toast } from 'react-hot-toast';
 import { handleError } from '@alga-psa/ui/lib/errorHandling';
-import { useFeatureFlag } from '@alga-psa/ui/hooks/useFeatureFlag';
 import { useTranslation } from '@alga-psa/ui/lib/i18n/client';
 import {
   addTicketCommentWithCacheForCurrentUser,
@@ -108,7 +107,6 @@ export default function TicketDetailsContainer({
   const router = useRouter();
   const { data: session } = useSession();
   const { t } = useTranslation('features/tickets');
-  const liveTicketUpdatesFlag = useFeatureFlag('live-ticket-updates', { defaultValue: false });
   const [isSubmitting, setIsSubmitting] = useState(false);
 
   // Local comments state to avoid mutating ticketData directly
@@ -253,8 +251,6 @@ export default function TicketDetailsContainer({
     : null;
 
   const shouldEnableTicketLiveUpdates =
-    liveTicketUpdatesFlag.enabled &&
-    !liveTicketUpdatesFlag.loading &&
     Boolean(liveCurrentUser && ticketData.ticket.tenant && ticketData.ticket.ticket_id);
 
   const ticketDetailsContent = (

--- a/packages/tickets/src/components/ticket/__tests__/TicketDetailsContainerCreateTask.test.tsx
+++ b/packages/tickets/src/components/ticket/__tests__/TicketDetailsContainerCreateTask.test.tsx
@@ -6,7 +6,6 @@ import { cleanup, render, screen } from '@testing-library/react';
 import TicketDetailsContainer from '../TicketDetailsContainer';
 
 let lastTicketDetailsProps: any = null;
-let liveTicketUpdatesEnabled = false;
 
 vi.mock('next/server', () => ({
   NextRequest: class NextRequest {},
@@ -44,10 +43,6 @@ vi.mock('@alga-psa/ui/context', () => ({
   UnsavedChangesProvider: ({ children }: { children: React.ReactNode }) => <>{children}</>,
 }));
 
-vi.mock('@alga-psa/ui/hooks/useFeatureFlag', () => ({
-  useFeatureFlag: () => ({ enabled: liveTicketUpdatesEnabled, loading: false, error: null }),
-}));
-
 vi.mock('../TicketLiveProvider', () => ({
   TicketLiveProvider: ({ children }: { children: React.ReactNode }) => (
     <div data-testid="ticket-live-provider">{children}</div>
@@ -68,7 +63,6 @@ describe('TicketDetailsContainer renderCreateProjectTask passthrough', () => {
   });
 
   beforeEach(() => {
-    liveTicketUpdatesEnabled = false;
     lastTicketDetailsProps = null;
   });
 
@@ -102,7 +96,7 @@ describe('TicketDetailsContainer renderCreateProjectTask passthrough', () => {
     expect(lastTicketDetailsProps.renderCreateProjectTask).toBe(renderCreateProjectTask);
   });
 
-  it('T045: does not mount the live provider when the feature flag is off', () => {
+  it('T045: mounts the live provider for a ticket with tenant + ticket id', () => {
     render(
       <TicketDetailsContainer
         ticketData={{
@@ -126,7 +120,7 @@ describe('TicketDetailsContainer renderCreateProjectTask passthrough', () => {
       />
     );
 
-    expect(screen.queryByTestId('ticket-live-provider')).toBeNull();
+    expect(screen.getByTestId('ticket-live-provider')).toBeTruthy();
     expect(screen.getByTestId('ticket-details')).toBeTruthy();
   });
 });

--- a/server/playwright.config.ts
+++ b/server/playwright.config.ts
@@ -64,8 +64,8 @@ export default defineConfig({
       APP_ENV: 'test',
       NODE_ENV: 'development',
       PORT: PORT,
-      // Keep Tactical RMM UI visible in Playwright runs even when PostHog is not configured.
-      NEXT_PUBLIC_FORCE_FEATURE_FLAGS: process.env.NEXT_PUBLIC_FORCE_FEATURE_FLAGS || 'tactical-rmm-integration:true',
+      // Feature-flag overrides for e2e, forwarded from the environment when set.
+      NEXT_PUBLIC_FORCE_FEATURE_FLAGS: process.env.NEXT_PUBLIC_FORCE_FEATURE_FLAGS || '',
     },
   },
 });

--- a/server/src/components/settings/SettingsPage.tsx
+++ b/server/src/components/settings/SettingsPage.tsx
@@ -74,7 +74,6 @@ import { useSearchParams } from 'next/navigation';
 import ImportExportSettings from '@/components/settings/import-export/ImportExportSettings';
 import ExtensionManagement from '@/components/settings/extensions/ExtensionManagement';
 import McpServerSettings from '@/components/settings/mcp/McpServerSettings';
-import { useFeatureFlag } from '@/hooks/useFeatureFlag';
 // Extensions are only available in Enterprise Edition
 import { EmailSettings } from '@alga-psa/integrations/email/settings/entry';
 import { EmailProviderConfiguration } from '@alga-psa/integrations/components';
@@ -116,11 +115,6 @@ const SettingsPageContent = ({ initialTabParam }: SettingsPageProps): React.JSX.
   // Extensions are conditionally available based on edition
   // The webpack alias will resolve to either the EE component or empty component
   const isEEAvailable = process.env.NEXT_PUBLIC_EDITION === 'enterprise';
-  // Dark-release gate for the remote MCP server admin UI. Off by default
-  // everywhere (PostHog returns false for an unknown flag, and it resolves false
-  // when PostHog is unavailable); Nine Minds enables it per-tenant in PostHog.
-  // UI-only: the /api/mcp + /api/v1/mcp endpoints stay live regardless.
-  const { enabled: mcpServerUiEnabled } = useFeatureFlag('mcp-server');
   const canUseCipp = useTierFeature(TIER_FEATURES.CIPP);
   const { hasFeature, hasAddOn } = useTier();
   const canUseEntraSync = hasAddOn(ADD_ONS.ENTERPRISE);
@@ -348,10 +342,10 @@ const SettingsPageContent = ({ initialTabParam }: SettingsPageProps): React.JSX.
   };
 
   // Create a map of tab content by label for easy lookup
-  // LEVERAGE: pattern settings-tabs-twice — this tab set is duplicated by settingsNavigationSections in menuConfig.ts (the sidebar's settings menu); they drift. The EE+flag gate below adds 'mcp-server' here, but there's no matching entry/gate over there, so the tab has no side-menu link. Both should derive from one gated registry.
+  // LEVERAGE: pattern settings-tabs-twice — this tab set is duplicated by settingsNavigationSections in menuConfig.ts (the sidebar's settings menu); they drift. The EE gate below adds 'mcp-server' here, but there's no matching entry/gate over there, so the tab has no side-menu link. Both should derive from one gated registry.
   const allTabs = useMemo(() => {
     const tabs = [...baseTabContent, extensionsTab];
-    if (isEEAvailable && mcpServerUiEnabled) {
+    if (isEEAvailable) {
       tabs.push(mcpTab);
     }
     if (!isAlgaDesk) {
@@ -359,7 +353,7 @@ const SettingsPageContent = ({ initialTabParam }: SettingsPageProps): React.JSX.
     }
 
     return tabs.filter((tab) => allowedTabIds.has(tab.id));
-  }, [allowedTabIds, baseTabContent, extensionsTab, mcpTab, isEEAvailable, mcpServerUiEnabled, isAlgaDesk]);
+  }, [allowedTabIds, baseTabContent, extensionsTab, mcpTab, isEEAvailable, isAlgaDesk]);
 
   const initialTabId = useMemo(() => {
     const requestedTab = tabParam?.toLowerCase();

--- a/server/src/config/menuConfig.ts
+++ b/server/src/config/menuConfig.ts
@@ -226,7 +226,7 @@ export const bottomMenuItems: MenuItem[] = [
 
 // Settings navigation sections - used when sidebar is in 'settings' mode
 // These correspond to the settings tabs in SettingsPage
-// LEVERAGE: pattern settings-tabs-twice — the settings tab set is defined twice (here, and in SettingsPage.tsx's allTabs builder); the two lists drift. The EE+flag-gated 'mcp-server' tab exists there but is missing here, so it never appears in the side menu. This nav config also has no EE/feature-flag gating primitive (only product + tier), so a gated tab can't be expressed as data. Both lists should derive from one gated registry (cf. providerRegistry.ts requiresEnterprise + featureFlagKey).
+// LEVERAGE: pattern settings-tabs-twice — the settings tab set is defined twice (here, and in SettingsPage.tsx's allTabs builder); the two lists drift. The EE-gated 'mcp-server' tab exists there but is missing here, so it never appears in the side menu. This nav config also has no EE gating primitive (only product + tier), so a gated tab can't be expressed as data. Both lists should derive from one gated registry (cf. providerRegistry.ts requiresEnterprise).
 export const settingsNavigationSections: NavigationSection[] = [
   {
     title: 'Organization & Access',


### PR DESCRIPTION
Remove flag gating for nine fully-rolled-out PostHog flags and inline the enabled paths:
- UI dark-release gates: live-ticket-updates, mcp-server, ticket-auto-close-rules, inbound-email-rules
- RMM provider flags via providerRegistry featureFlagKey; Tactical RMM is now GA in Community Edition
- hudu-integration full-stack: 10 server gates (9 actions + guard) and 3 client hooks, now EE-tier + system_settings RBAC only

Tests, doc comments, and the playwright force-flag updated to match; net -424 lines.

And so the Cheshire flag faded from all thirteen `isEnabled` gates until only its `enabled: true` grin remained, the Tactical RMM card slipped past the Enterprise gate into the Community garden, and every dark-release curtain was drawn back to reveal no wizard behind it. 🎭🐈🚪