### PR TITLE
docs: update feature flags, MCP Server, and Hudu docs (2026-06-30)

### DIFF
--- a/docs/features/feature-flags.md
+++ b/docs/features/feature-flags.md
@@ -68,8 +68,8 @@ Controls access to the delegated time-entry UI (editing/viewing time sheets for 
   - Time Sheet pages at `/msp/time-entry/timesheet/:id` (delegation UI + ability to edit delegated sheets)
 
 **Behavior:**
-- When disabled: The UI only allows working with the current user’s own time periods/time sheets (delegated sheets are shown as read-only if accessed directly).
-- When enabled: Authorized users can select a subject user and edit/view that user’s time sheets via the UI.
+- When disabled: The UI only allows working with the current user's own time periods/time sheets (delegated sheets are shown as read-only if accessed directly).
+- When enabled: Authorized users can select a subject user and edit/view that user's time sheets via the UI.
 
 ### 5. `email-logs`
 Controls access to email log UI surfaces for outbound email auditing/debugging.
@@ -83,18 +83,7 @@ Controls access to email log UI surfaces for outbound email auditing/debugging.
 **Behavior:**
 - When disabled: Email Logs page shows construction placeholder; navigation link and ticket section are hidden.
 
-### 6. `tactical-rmm-integration`
-Controls access to the Tactical RMM integration configuration UI.
-
-**Affected Areas:**
-- **MSP Portal:**
-  - Settings → Integrations → RMM
-
-**Behavior:**
-- When disabled (default): Tactical RMM configuration is hidden from the RMM setup screen.
-- When enabled: Tactical RMM appears as a selectable RMM provider (and its configuration UI is shown).
-
-### 7. `knowledge-base`
+### 6. `knowledge-base`
 Controls access to the Knowledge Base feature on both MSP and Client Portal.
 
 **Affected Areas:**
@@ -110,7 +99,7 @@ Controls access to the Knowledge Base feature on both MSP and Client Portal.
 **Behavior:**
 - When disabled: Navigation links are hidden; pages show construction placeholder if accessed directly.
 
-### 8. `document-folder-templates`
+### 7. `document-folder-templates`
 Controls access to new document features: client portal documents, folder structure configuration, and share links.
 
 **Affected Areas:**
@@ -127,7 +116,7 @@ Controls access to new document features: client portal documents, folder struct
 **Behavior:**
 - When disabled: Client portal documents nav link is hidden (page shows construction placeholder if accessed directly). Folder templates config and share link UI are completely hidden.
 
-### 9. `ai-assistant-activation`
+### 8. `ai-assistant-activation`
 Controls which tenants are allowed to enable the AI Assistant from Settings → Experimental Features.
 
 **Affected Areas:**
@@ -138,7 +127,7 @@ Controls which tenants are allowed to enable the AI Assistant from Settings → 
 - When disabled: The AI Assistant toggle is disabled and cannot be saved on for that tenant, even if the tenant previously had the experimental setting stored.
 - When enabled: The tenant may turn on the existing `experimentalFeatures.aiAssistant` setting, which continues to gate Quick Ask, chat sidebar access, and AI chat APIs.
 
-### 10. `quoting-enabled`
+### 9. `quoting-enabled`
 Controls access to the quoting functionality in the billing area.
 
 **Affected Areas:**
@@ -153,7 +142,7 @@ Controls access to the quoting functionality in the billing area.
 - When disabled (default): Quote-related sidebar items and billing tabs are hidden. Standalone quote pages show construction placeholder if accessed directly.
 - When enabled: Full quoting UI is accessible. Backend (models, actions, migrations) is always available regardless of flag state.
 
-### 11. `service-requests`
+### 10. `service-requests`
 Controls access to the new service request definition and client portal request-services UI.
 
 **Affected Areas:**
@@ -173,18 +162,6 @@ Controls access to the new service request definition and client portal request-
 - When disabled (default): MSP and client-portal navigation links are hidden. Direct page access shows the standard feature placeholder.
 - When enabled: The full service request UI is accessible.
 - Backend (tables, actions, provider execution, portal submission processing) remains active regardless of flag state.
-
-### 12. `mcp-server`
-Dark-release gate for the remote (governed) MCP server admin UI. Enterprise-only and off by default; used to roll the feature out per-tenant before general availability.
-
-**Affected Areas:**
-- **MSP Portal:**
-  - Settings → MCP Server tab (the IdP-provider / agent / audit admin surface). Hidden when disabled; the tab only appears when the tenant is Enterprise **and** the flag is on. Direct access via `?tab=mcp-server` falls back to the default tab.
-
-**Behavior:**
-- When disabled (default): The MCP Server settings tab is hidden. Because no flag exists in PostHog by default — and the flag resolves `false` when PostHog is unavailable — the tab is dark on every instance until explicitly enabled for a tenant.
-- When enabled: The MCP Server admin tab is shown (Enterprise builds only).
-- **UI-only gate.** The server endpoints (`POST /api/mcp`, `/.well-known/oauth-protected-resource`, and the `/api/v1/mcp/*` admin APIs) remain live regardless of flag state — they are already Enterprise-gated and harmless without agents/IdPs configured. The flag only hides the admin entry point in the UI.
 
 ## Implementation Details
 

--- a/docs/integrations/hudu.md
+++ b/docs/integrations/hudu.md
@@ -41,6 +41,43 @@ multi-source guard keeps a connected RMM as the authority for an asset's name an
 serial number. The asset-import field mapping is documented in
 [Custom Asset Types](../features/custom_asset_types.md).
 
+## Bulk import and daily auto-sync
+
+Once companies and asset layouts are mapped, a **Sync & automation** card at the
+bottom of the Hudu settings page lets you run a tenant-wide import or sync and
+optionally schedule one every day.
+
+### Manual operations
+
+- **Import all mapped clients** — imports every unmatched Hudu asset across all
+  mapped clients in one pass, using your asset-layout mappings. A summary toast
+  shows the counts of assets created, updated, skipped, and failed when the run
+  completes. Requires the `asset:create` permission.
+- **Sync all** — refreshes the name, serial number, and Hudu custom-field values
+  for every asset already linked in AlgaPSA, across all mapped clients. It does
+  not create new assets. Requires the `asset:update` permission.
+
+Both buttons are disabled while any sync is in progress.
+
+### Daily auto-sync
+
+Toggle **Daily auto-sync** to have AlgaPSA automatically import new assets and
+refresh all existing ones for every mapped client at **02:00 UTC each day**.
+Flipping the toggle immediately starts or cancels the recurring background job —
+no server restart needed. Requires the `system_settings` permission.
+
+### Sync status
+
+The card shows the live state of the most recent tenant-wide run:
+
+- **Status badge** (Idle / Syncing / Completed / Error) — updates every few
+  seconds while a run is in progress.
+- **Last-run summary** — timestamp and counts of assets created, updated,
+  skipped, and failed. Displays "No tenant-wide run yet." until the first run
+  completes.
+- **Error details** — when the last run ended in an error, the card shows the
+  error text so you can diagnose the problem without checking server logs.
+
 ## View documentation and credentials
 
 Once a client is connected, its record gains Hudu surfaces:

--- a/docs/mcp-server.md
+++ b/docs/mcp-server.md
@@ -41,11 +41,7 @@ A networked MCP endpoint (`POST /api/mcp`, Streamable HTTP / JSON-RPC) that auth
 **agents** via the tenant's identity provider and enforces governance: distinct agent
 identity, RBAC, and an exportable audit trail. Enterprise-only.
 
-> **Dark release.** The admin UI (**Settings → MCP Server**) is gated behind the
-> `mcp-server` PostHog feature flag and is **off by default** — it appears only when the
-> tenant is Enterprise *and* the flag is enabled for them. This is a UI-only gate: the
-> server endpoints below stay live regardless, so an operator can configure agents via the
-> admin API even before the tab is rolled out. See `docs/features/feature-flags.md`.
+The admin UI (**Settings → MCP Server**) is available to all Enterprise tenants. The server endpoints (`POST /api/mcp`, `/.well-known/oauth-protected-resource`, and the `/api/v1/mcp/*` admin APIs) are live for any Enterprise instance regardless of whether agents have been provisioned.
 
 ### Auth model — OAuth 2.1 resource server (IdP delegation)
 


### PR DESCRIPTION
## Summary

Automated documentation-drift update for PRs merged 2026-06-29 by @NatalliaBukhtsik.

### Changes

#### `docs/features/feature-flags.md` — reflects PR #2813 (Graduate 9 shipped feature flags)

Removed the two graduated entries that PR #2813 deleted from code:

- **Entry #6 `tactical-rmm-integration`** — all four RMM provider flags (`tactical-rmm-integration`, `tanium-rmm-integration`, `levelio-rmm-integration`, `huntress-rmm-integration`) were removed; RMM visibility is now based solely on `requiresEnterprise`.
- **Entry #12 `mcp-server`** — flag removed; the MCP Server admin tab is now unconditionally shown for Enterprise tenants.

Renumbered the remaining entries (#7–#11 → #6–#10) to keep the list contiguous.

#### `docs/mcp-server.md` — reflects PR #2813

Removed the "Dark release" blockquote that described the `mcp-server` PostHog gate. Replaced with a plain statement that **Settings → MCP Server** is available to all Enterprise tenants. The server endpoints were never gated and remain live as before.

#### `docs/integrations/hudu.md` — reflects PR #2810 (Add Hudu tenant-wide import & daily auto-sync)

Added a new **"## Bulk import and daily auto-sync"** section documenting:

- The new **Sync & automation** card in Hudu settings
- **Import all mapped clients** button (requires `asset:create`)
- **Sync all** button (requires `asset:update`)
- **Daily auto-sync** toggle — schedules a background job at 02:00 UTC (requires `system_settings`)
- Live **sync status** badge, last-run summary, and error display

---

## Source PRs

| PR | Title | Merged |
|---|---|---|
| #2813 | Graduate 9 shipped feature flags | 2026-06-29T22:30:17Z |
| #2810 | Add Hudu tenant-wide import & daily auto-sync | 2026-06-29T20:07:58Z |

---

## Needs human review

### New API endpoints from PR #2811 (Mobile/user activities) — no docs written

PR #2811 (merged 2026-06-29T20:55:44Z) added a full mobile Activities screen (v1.3.0) and a new REST API surface. No existing alga-psa or nm-store reference pages cover these endpoints, so no automated edit was made. A human author should decide where and how to document them.

**New endpoint groups:**

- `GET /api/v1/activities`, `POST /api/v1/activities`
- `GET /api/v1/activities/groups`, `GET /api/v1/activities/groups/{groupId}/items`, `POST /api/v1/activities/groups/items`
- `GET /api/v1/activities/ad-hoc/{id}`, `PATCH /api/v1/activities/ad-hoc/{id}`, `DELETE /api/v1/activities/ad-hoc/{id}`
- `POST /api/v1/activities/ad-hoc/{id}/done`
- `GET /api/v1/workflows/tasks`, `GET /api/v1/workflows/tasks/{id}`
- `POST /api/v1/workflows/tasks/{id}/claim`, `/unclaim`, `/complete`

**OpenAPI spec:** `activitiesV1.ts`, `workflowTasksV1.ts`, and `workflowsV1.ts` were added to alga-psa. `packages/nm-store/public/openapi/alga.json` (if it exists) is likely stale and needs regeneration via `cd sdk && npm run openapi:generate`, then synced to nm-store. **Do not regenerate in this PR** — flagging for manual handling.

**Mobile changelog:** Mobile app version bumped 1.2.0 → 1.3.0. If there is a mobile changelog or release notes file in `ee/mobile/` or `docs/`, it should be updated to describe the Activities screen.


---
_Generated by [Claude Code](https://claude.ai/code/session_01XKzPJcaxBh5uUnRbtW5SF5)_