### PR TITLE
fix(workflow-worker): survive Temporal-frontend startup race on the appliance

### DIFF
--- a/ee/appliance/flux/base/releases/workflow-worker.yaml
+++ b/ee/appliance/flux/base/releases/workflow-worker.yaml
@@ -9,6 +9,9 @@ spec:
   dependsOn:
     - name: alga-core
     - name: pgbouncer
+    # The worker connects to Temporal on startup with no retry; gate the release
+    # on Temporal being Ready so it isn't installed into a race at the Flux layer.
+    - name: temporal
   releaseName: workflow-worker
   targetNamespace: msp
   install:

--- a/ee/appliance/flux/profiles/single-node/values/workflow-worker.single-node.yaml
+++ b/ee/appliance/flux/profiles/single-node/values/workflow-worker.single-node.yaml
@@ -30,11 +30,20 @@ db:
     name: db-credentials
     key: DB_PASSWORD_SUPERUSER
 
+# Liveness/readiness probes hit the worker's /health server (:4000) — 200 once
+# every sub-worker (including the Temporal connection) is up, 503/refused before.
+# These MUST stay enabled: the worker exits if Temporal isn't reachable at
+# startup, and with no liveness probe k8s never restarts the wedged container
+# (it falsely reports Ready because the entrypoint stays alive). The liveness
+# initialDelay is widened for single-node cold boot, where Temporal and the
+# worker come up together. See entrypoint.sh wait_for_temporal for the first
+# line of defense against the startup-ordering race.
 livenessProbe:
-  enabled: false
+  enabled: true
+  initialDelaySeconds: 90
 
 readinessProbe:
-  enabled: false
+  enabled: true
 
 extraEnv:
   - name: TEMPORAL_ADDRESS

--- a/services/workflow-worker/entrypoint.sh
+++ b/services/workflow-worker/entrypoint.sh
@@ -52,6 +52,30 @@ wait_for_redis() {
     log "Redis is up and running!"
 }
 
+# Function to check if the Temporal frontend is accepting connections.
+# The v2 workflow runtime connects to Temporal as its first action and does NOT
+# retry: if the frontend isn't up yet (a common startup-ordering race), the
+# worker process exits. Wait for it here, like postgres/redis, so the race never
+# crashes the worker. Set WAIT_FOR_TEMPORAL=false to skip (non-Temporal setups).
+wait_for_temporal() {
+    if [ "${WAIT_FOR_TEMPORAL:-true}" != "true" ]; then
+        log "Skipping Temporal readiness wait (WAIT_FOR_TEMPORAL=${WAIT_FOR_TEMPORAL})"
+        return 0
+    fi
+    local address="${TEMPORAL_ADDRESS:-temporal-frontend.temporal.svc.cluster.local:7233}"
+    local host="${address%%:*}"
+    local port="${address##*:}"
+    # Fall back to the default port if TEMPORAL_ADDRESS carried no ":port".
+    [ "$port" = "$host" ] && port=7233
+    log "Waiting for Temporal frontend at ${host}:${port} to be ready..."
+    # bash /dev/tcp avoids needing a temporal CLI or nc in the image.
+    until (exec 3<>"/dev/tcp/${host}/${port}") 2>/dev/null; do
+        log "Temporal is unavailable - sleeping"
+        sleep 1
+    done
+    log "Temporal is up and running!"
+}
+
 # Function to start the workflow worker
 start_workflow_worker() {
     # Set up application database connection using app_user
@@ -82,7 +106,8 @@ main() {
     # Wait for dependencies
     wait_for_postgres
     wait_for_redis
-    
+    wait_for_temporal
+
     # Start the workflow worker
     start_workflow_worker
 }
@@ -90,9 +115,16 @@ main() {
 # Execute main function with error handling
 if ! main; then
     log "Error: Workflow worker failed to start properly"
-    # Enter infinite sleep loop instead of exiting
-    log "Entering sleep loop after failure to keep container running for debugging"
-    while true; do
-        sleep 3600  # Sleep for 1 hour
-    done
+    # Exit non-zero so Kubernetes restarts the container (and the liveness probe
+    # catches a worker that wedged after start). Hanging here instead would mask
+    # the failure: with no process to fail a probe, k8s reports the pod healthy
+    # forever. Set DEBUG_HANG_ON_FAILURE=true to keep the container up for
+    # interactive debugging instead.
+    if [ "${DEBUG_HANG_ON_FAILURE:-false}" = "true" ]; then
+        log "DEBUG_HANG_ON_FAILURE=true - sleeping to keep the container running for debugging"
+        while true; do
+            sleep 3600  # Sleep for 1 hour
+        done
+    fi
+    exit 1
 fi


### PR DESCRIPTION
## Summary
On the appliance the **workflow-worker** could start before **Temporal frontend** was accepting connections, crash, and then stay **permanently dead** while Kubernetes reported the pod `1/1 Ready`. Reported by a user (worker log ended at a `ConnectionRefused` to `temporal-frontend:7233`).

## Root cause
A transient startup-ordering race made permanent by three disabled safety nets:
1. **No Temporal wait + no retry.** `entrypoint.sh` waits for Postgres and Redis but not Temporal; in v2 mode the worker's first action is `runtimeV2TemporalWorker.start()`, a one-shot connect that exits the process on first refusal.
2. **Infinite sleep-loop on failure.** The entrypoint caught the crash and slept forever "to keep the container for debugging", so PID 1 stayed alive while the worker was dead.
3. **Probes disabled on the appliance.** The chart defines `/health:4000` liveness/readiness probes, but `workflow-worker.single-node.yaml` set both `enabled: false` — so k8s never restarted the wedged container and falsely reported it `1/1 Ready`.

Verified live: a pod showing `1/1 Running` whose last log line was `Entering sleep loop after failure`; a `rollout restart` (Temporal healthy by then) recovered it with `All services started successfully`.

## Fix (defense in depth)
- **`entrypoint.sh`** — add `wait_for_temporal()` before start (like postgres/redis), and exit non-zero on failure instead of sleeping forever (`DEBUG_HANG_ON_FAILURE=true` preserves the old hang for interactive debugging).
- **appliance single-node values** — re-enable the liveness/readiness probes the chart already defines; widen liveness `initialDelaySeconds` to 90s for single-node cold boot.
- **Flux** — `workflow-worker` HelmRelease now `dependsOn: temporal` so it isn't installed ahead of Temporal at the orchestration layer.

## Testing
- `bash -n` clean on the entrypoint; unit-tested the new `wait_for_temporal` host/port parsing and the `/dev/tcp` reachability gate (open vs. closed port).
- `helm template` with the appliance values renders the `/health:4000` liveness (initialDelay 90) and readiness probes — confirming the deep-merge re-enables them.
- Both YAML files parse.
