### PR TITLE
fix(mcp): dispatch tool calls over in-pod loopback, not the public origin

### DIFF
--- a/ee/server/src/lib/mcp/baseUrl.ts
+++ b/ee/server/src/lib/mcp/baseUrl.ts
@@ -29,3 +29,27 @@ export async function resolvePublicBaseUrl(req: NextRequest): Promise<string> {
     'http://localhost:3000';
   return base.replace(/\/$/, '');
 }
+
+/**
+ * INTERNAL base URL for dispatching MCP tool calls back into this server's own
+ * `/api/v1` surface. This is the opposite of the public discovery URL above: an
+ * in-pod loopback over plaintext HTTP that must NEVER be the public origin.
+ *
+ * Routing tool dispatch through the public hostname (`req.nextUrl.origin`) sends
+ * each call out via the ingress/TLS path and back into the pod; that round-trip
+ * intermittently fails the TLS handshake (`ERR_SSL_WRONG_VERSION_NUMBER` →
+ * `TypeError: fetch failed`) and surfaces to the MCP client as HTTP 500s. A
+ * fixed loopback target avoids the mesh/TLS path entirely. Port precedence
+ * mirrors `getSessionCookieName`'s server-port resolution.
+ *
+ * LEVERAGE: friction mcp-self-http-dispatch — dispatch needs an HTTP base at all
+ * only because `/api/v1` auth + rate-limit + RBAC are welded to `NextRequest` in
+ * `ApiBaseController`, and the registry maps tools to method+path, not to
+ * functions. The real fix is a transport-free `dispatch(entryId, args, authCtx)`
+ * core shared by the route handlers and this server (in-process, no HTTP hop).
+ */
+export function resolveInternalBaseUrl(): string {
+  const port =
+    process.env.PORT || process.env.APP_PORT || process.env.EXPOSE_SERVER_PORT || '3000';
+  return `http://127.0.0.1:${port}`;
+}

--- a/ee/server/src/lib/mcp/jsonRpcServer.ts
+++ b/ee/server/src/lib/mcp/jsonRpcServer.ts
@@ -14,7 +14,7 @@ import { loadMcpRegistry } from '@/lib/mcp/loadRegistry';
 import { authenticateAgentToken, looksLikeJwt } from './idpToken';
 import { mintAgentSessionKey } from './agents';
 import { writeAgentAudit } from './agentAudit';
-import { resolvePublicBaseUrl } from './baseUrl';
+import { resolvePublicBaseUrl, resolveInternalBaseUrl } from './baseUrl';
 import { looksLikeAlgaToken, verifyAccessToken } from './oauth/tokens';
 import { isGrantActive } from './oauth/grants';
 import { mintUserSessionKey } from './oauth/userSession';
@@ -172,23 +172,37 @@ async function handleOne(m: JsonRpcMessage, ctx: DispatchCtx): Promise<object | 
     case 'tools/call': {
       const name = (m.params?.name as string) ?? '';
       const args = (m.params?.arguments as Record<string, unknown>) ?? {};
-      const out = await dispatchTool(name, args, ctx);
+      // A transient dispatch failure (e.g. a self-fetch network error, or an
+      // unresolved path param from buildRequest) must surface as a JSON-RPC
+      // tool error — NOT bubble up and become a bare HTTP 500 that aborts the
+      // whole MCP request. The MCP client can then see the error and retry.
+      let out: ToolOutcome;
+      try {
+        out = await dispatchTool(name, args, ctx);
+      } catch (err) {
+        out = toolErr(`Tool dispatch failed: ${err instanceof Error ? err.message : String(err)}`);
+      }
       if (ctx.agentId && ctx.tenant) {
         const decision = !out.isError
           ? 'allow'
           : out.statusCode === 403 || out.statusCode === 401
             ? 'deny'
             : 'error';
-        await writeAgentAudit({
-          tenant: ctx.tenant,
-          agentId: ctx.agentId,
-          tool: name,
-          arguments: args,
-          ok: !out.isError,
-          statusCode: out.statusCode ?? null,
-          decision,
-          resultSummary: out.content?.[0]?.text,
-        });
+        // Audit is best-effort: a failed audit write must not 500 the tool call.
+        try {
+          await writeAgentAudit({
+            tenant: ctx.tenant,
+            agentId: ctx.agentId,
+            tool: name,
+            arguments: args,
+            ok: !out.isError,
+            statusCode: out.statusCode ?? null,
+            decision,
+            resultSummary: out.content?.[0]?.text,
+          });
+        } catch {
+          // swallow — auditing is non-critical to returning the tool result
+        }
       }
       return rpcResult(id, out);
     }
@@ -278,7 +292,9 @@ export async function handleMcpJsonRpc(req: NextRequest): Promise<NextResponse> 
   const ctx: DispatchCtx = {
     registry: entries,
     apiKey: auth.apiKey,
-    baseUrl: req.nextUrl.origin,
+    // In-pod loopback (plaintext HTTP), NOT the public origin — see
+    // resolveInternalBaseUrl(). The public origin is only for OAuth discovery.
+    baseUrl: resolveInternalBaseUrl(),
     agentId: auth.agentId,
     tenant: auth.tenant,
   };


### PR DESCRIPTION
## Summary

Remote MCP tool calls were intermittently returning **HTTP 500** to clients (e.g. claude.ai). Root cause: the MCP JSON-RPC handler dispatches each `tools/call` back into the app's own `/api/v1` surface, but used **`req.nextUrl.origin`** — the *public* hostname — as the dispatch base. Behind Istio that loops every tool call back out through the ingress/TLS path and into the pod again, and that round-trip intermittently fails the TLS handshake:

```
TypeError: fetch failed
  cause: ERR_SSL_WRONG_VERSION_NUMBER (tls_validate_record_header: wrong version number)
```

Because `tools/call` didn't guard the dispatch, the thrown error bubbled up and Next returned a bare 500, aborting the entire MCP request.

## Production evidence (cloudlab, active `sebastian-green`)

- `POST /api/mcp` last 6h: **20×200, 8×202, 12×500**, zero 401/403 (auth + OAuth token exchange are fine).
- The **12 `ERR_SSL_WRONG_VERSION_NUMBER` "fetch failed" log lines match the 12 HTTP 500s one-to-one** by timestamp and pod.
- Failures **interleave** with successful tool calls (e.g. a clean `404 ticket not found` proves the self-fetch sometimes completes) → intermittent, not a constant misconfig.

## Changes

- **`baseUrl.ts`**: add `resolveInternalBaseUrl()` → `http://127.0.0.1:$PORT` (in-pod loopback, plaintext), the deliberate counterpart to the existing public discovery URL.
- **`jsonRpcServer.ts`**:
  - Dispatch via `resolveInternalBaseUrl()` instead of `req.nextUrl.origin`. The public origin remains in use **only** for OAuth resource-metadata advertisement (`WWW-Authenticate`), which external clients must reach — exactly as intended.
  - Guard `dispatchTool` and the `writeAgentAudit` call so a transient failure becomes a JSON-RPC tool error (`isError`) instead of a transport 500.

## Scope / follow-up

This is the surgical fix that stops the 500s. The deeper issue — MCP re-entering the server over HTTP at all — is marked in code with `// LEVERAGE: friction mcp-self-http-dispatch`: it exists only because `/api/v1` auth + rate-limit + RBAC are welded to `NextRequest` in `ApiBaseController` and the registry maps tools to method+path, not functions. A transport-free `dispatch(entryId, args, authCtx)` core shared by the route handlers and the MCP server (no HTTP hop) is the real fix and is tracked separately.

## Testing

- `tsc --noEmit` clean for both edited files.
- No existing unit tests cover the dispatch path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)