### PR TITLE
docs: update email i18n summary for Brazilian Portuguese support (2026-07-01)

### DIFF
--- a/docs/email/email-i18n-implementation-summary.md
+++ b/docs/email/email-i18n-implementation-summary.md
@@ -99,6 +99,7 @@ Added language support to ticket/invoice/payment notifications.
 - ✅ Spanish (es)
 - ✅ German (de)
 - ✅ Dutch (nl)
+- ✅ Brazilian Portuguese (pt)
 - ⚠️ Italian (it) — partial (18/36 templates; missing: projects, SLA, time entry, billing misc)
 - ⚠️ Polish (pl) — partial (17/36 templates; missing: emailVerification, projects, SLA, time entry, billing misc)
 
@@ -204,7 +205,9 @@ npm run migrate
 
 **Key migrations:**
 1. `20251027120000_add_system_auth_email_templates.cjs` - Adds auth templates
-2. `20251201090000_add_email_template_translations.cjs` - Adds all translations
+2. `20251201090000_add_email_template_translations.cjs` - Adds en/fr/es/de/nl/it/pl translations
+3. `20260625120000_add_portuguese_email_templates.cjs` - Adds Brazilian Portuguese (pt) email templates
+4. `20260625121000_add_portuguese_internal_notification_templates.cjs` - Adds Brazilian Portuguese (pt) internal notification templates
 
 ---
 
@@ -324,7 +327,7 @@ npm run migrate
 ## Future Enhancements
 
 **Potential additions:**
-- [ ] Add more languages (Portuguese, etc.)
+- [ ] Add more languages (e.g., Arabic)
 - [ ] Support for conditional template logic (handlebars/mustache)
 - [ ] Template versioning (track changes over time)
 - [ ] A/B testing for email content
@@ -340,7 +343,7 @@ The email system now fully supports internationalization! 🎉
 
 **Key achievements:**
 - 36 email templates (across auth, tickets, invoices, projects, SLA, time, surveys, appointments)
-- 5 fully translated languages (en, fr, es, de, nl), 2 partially translated (it, pl)
+- 6 fully translated languages (en, fr, es, de, nl, pt), 2 partially translated (it, pl)
 - Automatic language detection for client portal users
 - Database-driven (no code changes for updates)
 - Emergency fallbacks for reliability


### PR DESCRIPTION
## Source PRs

- [#2816 I18n/pt br email migration](https://github.com/Nine-Minds/alga-psa/pull/2816) — merged 2026-06-30

## Docs edited

| File | Rationale |
|---|---|
| `docs/email/email-i18n-implementation-summary.md` | PR #2816 seeded Brazilian Portuguese (`pt`) email and internal notification templates for all 36 template types via two new migrations, making `pt` a fully translated language. The doc previously listed Portuguese under "Future Enhancements" and counted only 5 fully-translated languages. Updated: (1) added `✅ Brazilian Portuguese (pt)` to the language list; (2) added the two new migrations to the key-migrations inventory; (3) removed "Portuguese, etc." from the future to-do; (4) updated the conclusion count from 5 to 6 fully translated languages. |

## Needs human review

**PR #2815 — Project status filter** (merged 2026-06-30)

PR #2815 adds a **Project Status** filter dropdown to the Projects list dashboard and changes the default view: projects with closed workflow statuses are now hidden by default (showing only "All open statuses"), matching the tickets dashboard behavior. Users can select "All open statuses", "All statuses", or a specific status.

No existing customer-facing doc covers the Projects list dashboard and its filtering behavior. The closest doc (`packages/nm-store/src/site/content/docs/1013-project-settings.md`) covers the Settings > Projects configuration page, not the dashboard. The closest project doc (`packages/nm-store/src/site/content/docs/61-creating-a-new-project.md`) covers project creation only.

Recommend adding a new nm-store doc (e.g., `60-navigating-the-projects-dashboard.md`) or adding a filtering section to `61-creating-a-new-project.md` that explains: (a) the Project Status filter, (b) the default "open only" behavior and how to show all projects including closed ones.

**BRL currency support (PR #2816)**

PR #2816 also added Brazilian Real (BRL) to the supported currency list (alongside the existing ARS). No existing doc enumerates the supported currencies; the billing settings doc (`142-tenant-billing-settings.md`) only says "pick from the dropdown." No action needed unless a dedicated currency reference doc is planned.


---
_Generated by [Claude Code](https://claude.ai/code/session_01Ph4Wyg9VVGVLDn5XR3h7NL)_