### PR TITLE
fix(email): surface real outbound SMTP errors and support unauthenticated relays

### DIFF
--- a/packages/email/src/BaseEmailService.ts
+++ b/packages/email/src/BaseEmailService.ts
@@ -412,6 +412,10 @@ function deriveOutboundMessageIds(result: ProviderEmailSendResult, message?: Pro
 export abstract class BaseEmailService {
   protected initialized: boolean = false;
   protected emailProvider: IEmailProvider | null = null;
+  // Real reason the provider could not be initialized (e.g. SMTP auth/TLS
+  // failure). Set by subclasses when an explicitly-configured provider fails,
+  // so send attempts report the actual cause instead of a generic "disabled".
+  protected providerInitError: string | null = null;
   protected static readonly EMAIL_LOG_TABLE = 'email_sending_logs';
 
   /**
@@ -435,6 +439,7 @@ export abstract class BaseEmailService {
   public async initialize(): Promise<void> {
     if (this.initialized) return;
 
+    this.providerInitError = null;
     try {
       this.emailProvider = await this.getEmailProvider();
       if (!this.emailProvider) {
@@ -445,6 +450,7 @@ export abstract class BaseEmailService {
     } catch (error) {
       logger.error(`[${this.getServiceName()}] Failed to initialize email provider:`, error);
       this.emailProvider = null;
+      this.providerInitError = error instanceof Error ? error.message : String(error);
     }
 
     this.initialized = true;
@@ -459,6 +465,13 @@ export abstract class BaseEmailService {
     }
 
     if (!this.emailProvider) {
+      if (this.providerInitError) {
+        logger.warn(`[${this.getServiceName()}] Email provider failed to initialize: ${this.providerInitError}`);
+        return {
+          success: false,
+          error: `Email provider not ready: ${this.providerInitError}`
+        };
+      }
       logger.warn(`[${this.getServiceName()}] Service disabled or not configured`);
       return {
         success: false,
@@ -862,6 +875,19 @@ export abstract class BaseEmailService {
       await this.initialize();
     }
     return this.emailProvider !== null;
+  }
+
+  /**
+   * Real reason the provider could not be initialized, if any (e.g. an SMTP
+   * auth/TLS/connection failure). Null when no provider is configured at all or
+   * when a provider initialized successfully. Callers can surface this to admins
+   * instead of a generic "disabled or not configured" message.
+   */
+  public async getInitializationError(): Promise<string | null> {
+    if (!this.initialized) {
+      await this.initialize();
+    }
+    return this.providerInitError;
   }
 
   /**

--- a/packages/email/src/TenantEmailService.ts
+++ b/packages/email/src/TenantEmailService.ts
@@ -200,14 +200,23 @@ export class TenantEmailService extends BaseEmailService {
           this.tenantSettings = settings;
         }
 
+        // Preserve the real cause (e.g. "SMTP initialization failed: ...") so it
+        // can surface to the admin if no working provider is available.
+        const realError = error instanceof Error ? error.message : String(error);
+
         if (isEnterprise) {
           logger.info(`[${this.getServiceName()}] Using system email provider (Enterprise Edition)`);
           try {
             const systemProvider = await SystemEmailProviderFactory.createProvider();
-            return systemProvider;
+            if (systemProvider) {
+              return systemProvider;
+            }
           } catch (fallbackError) {
             logger.error(`[${this.getServiceName()}] Failed to create system email provider:`, fallbackError);
           }
+          // No system fallback available: the tenant provider error is the real
+          // reason sending is unavailable, so don't mask it as "disabled".
+          this.providerInitError = realError;
           return null;
         }
 
@@ -272,6 +281,69 @@ export class TenantEmailService extends BaseEmailService {
     } catch (error) {
       logger.error(`[TenantEmailService] Error fetching tenant email settings:`, error);
       return null;
+    }
+  }
+
+  /**
+   * Verify the tenant's outbound provider configuration and, optionally, send a
+   * test message. Uses a fresh provider manager (not the cached singleton) so it
+   * always reflects the currently-saved settings and returns the real failure
+   * reason (SMTP auth/TLS/connection error) rather than a generic message.
+   */
+  static async testConnection(
+    tenantId: string,
+    toAddress?: string
+  ): Promise<{ success: boolean; message?: string; error?: string }> {
+    const knex = await getConnection(tenantId);
+    const settings = await this.getTenantEmailSettings(tenantId, knex);
+
+    if (!settings) {
+      return { success: false, error: 'No outbound email settings are configured.' };
+    }
+
+    const enabled = settings.providerConfigs.find(config => config.isEnabled);
+    if (!enabled) {
+      return { success: false, error: 'No outbound email provider is enabled.' };
+    }
+
+    const manager = new EmailProviderManager();
+    try {
+      // For SMTP this opens a connection and runs verify() (incl. AUTH/TLS).
+      await manager.initialize(settings);
+    } catch (error) {
+      return { success: false, error: error instanceof Error ? error.message : String(error) };
+    }
+
+    const providers = await manager.getAvailableProviders(tenantId);
+    if (providers.length === 0) {
+      return { success: false, error: 'The provider did not initialize. Check host, port, and credentials.' };
+    }
+
+    const providerLabel = enabled.providerType.toUpperCase();
+    if (!toAddress) {
+      return { success: true, message: `${providerLabel} connection verified.` };
+    }
+
+    const fromEmail =
+      (typeof enabled.config?.from === 'string' && enabled.config.from.trim()) ||
+      (settings.defaultFromDomain ? `noreply@${settings.defaultFromDomain}` : 'noreply@localhost');
+
+    const message: EmailMessage = {
+      from: { email: fromEmail, name: 'Alga PSA' },
+      to: [{ email: toAddress }],
+      subject: 'Alga PSA outbound email test',
+      text: 'This is a test message confirming your outbound email configuration works.',
+      html: '<p>This is a test message confirming your outbound email configuration works.</p>'
+    };
+
+    try {
+      const result = await manager.sendEmail(message, tenantId);
+      if (result.success) {
+        return { success: true, message: `Test email sent to ${toAddress} via ${providerLabel}.` };
+      }
+      return { success: false, error: result.error || 'The provider rejected the test message.' };
+    } catch (error) {
+      return { success: false, error: error instanceof Error ? error.message : String(error) };
     }
   }
 

--- a/packages/email/src/providers/SMTPEmailProvider.ts
+++ b/packages/email/src/providers/SMTPEmailProvider.ts
@@ -18,8 +18,10 @@ interface SMTPConfig {
   host: string;
   port: number;
   secure?: boolean; // true for 465, false for other ports
-  username: string;
-  password: string;
+  // Optional: some relays (e.g. an on-LAN smtp-oauth-relay) accept mail
+  // without client authentication. When omitted, no AUTH is attempted.
+  username?: string;
+  password?: string;
   from: string;
   rejectUnauthorized?: boolean;
   requireTLS?: boolean;
@@ -163,11 +165,20 @@ export class SMTPEmailProvider implements IEmailProvider {
   }
 
   private validateConfig(config: Record<string, any>): SMTPConfig {
-    const requiredFields = ['host', 'port', 'username', 'password', 'from'];
+    // username/password are intentionally not required: relays that accept
+    // unauthenticated mail can be configured with host/port/from only.
+    const requiredFields = ['host', 'port', 'from'];
     const missingFields = requiredFields.filter(field => !config[field]);
-    
+
     if (missingFields.length > 0) {
       throw new Error(`Missing required SMTP configuration fields: ${missingFields.join(', ')}`);
+    }
+
+    // If either credential is supplied, both must be, otherwise AUTH is malformed.
+    const hasUsername = Boolean(config.username);
+    const hasPassword = Boolean(config.password);
+    if (hasUsername !== hasPassword) {
+      throw new Error('SMTP username and password must be provided together (or both omitted for an unauthenticated relay)');
     }
 
     // Validate port
@@ -180,8 +191,8 @@ export class SMTPEmailProvider implements IEmailProvider {
       host: config.host,
       port,
       secure: config.secure ?? (port === 465),
-      username: config.username,
-      password: config.password,
+      username: hasUsername ? config.username : undefined,
+      password: hasPassword ? config.password : undefined,
       from: config.from,
       rejectUnauthorized: config.rejectUnauthorized ?? true,
       requireTLS: config.requireTLS ?? false
@@ -197,14 +208,19 @@ export class SMTPEmailProvider implements IEmailProvider {
       host: this.config.host,
       port: this.config.port,
       secure: this.config.secure,
-      auth: {
-        user: this.config.username,
-        pass: this.config.password
-      },
       tls: {
         rejectUnauthorized: this.config.rejectUnauthorized
       }
     };
+
+    // Only send AUTH when credentials are configured. Relays that expect
+    // unauthenticated mail reject an AUTH handshake outright.
+    if (this.config.username && this.config.password) {
+      transportOptions.auth = {
+        user: this.config.username,
+        pass: this.config.password
+      };
+    }
 
     if (this.config.requireTLS) {
       transportOptions.requireTLS = true;

--- a/packages/email/src/providers/__tests__/SMTPEmailProvider.test.ts
+++ b/packages/email/src/providers/__tests__/SMTPEmailProvider.test.ts
@@ -170,13 +170,36 @@ describe('SMTPEmailProvider config validation', () => {
   it('rejects configs with missing required fields', async () => {
     const provider = new SMTPEmailProvider('smtp-test');
 
+    // username/password are optional (unauthenticated relays); host/port/from remain required.
     await expect(provider.initialize({ host: 'smtp.example.com' })).rejects.toMatchObject({
       name: 'EmailProviderError',
       errorCode: 'INIT_FAILED'
     });
     await expect(provider.initialize({ host: 'smtp.example.com' })).rejects.toThrow(
-      /Missing required SMTP configuration fields: port, username, password, from/
+      /Missing required SMTP configuration fields: port, from/
     );
+  });
+
+  it('omits AUTH when no credentials are supplied (unauthenticated relay)', async () => {
+    const provider = new SMTPEmailProvider('smtp-noauth');
+    const { username, password, ...noAuthConfig } = validConfig;
+    await provider.initialize(noAuthConfig);
+
+    expect(createTransportMock.mock.calls.at(-1)![0].auth).toBeUndefined();
+  });
+
+  it('sends AUTH when username and password are supplied', async () => {
+    const provider = new SMTPEmailProvider('smtp-auth');
+    await provider.initialize(validConfig);
+
+    expect(createTransportMock.mock.calls.at(-1)![0].auth).toEqual({ user: 'mailer', pass: 'secret' });
+  });
+
+  it('rejects a username without a matching password', async () => {
+    const provider = new SMTPEmailProvider('smtp-halfauth');
+    const { password, ...halfAuthConfig } = validConfig;
+
+    await expect(provider.initialize(halfAuthConfig)).rejects.toThrow(/username and password/i);
   });
 
   it('rejects invalid port numbers', async () => {

--- a/packages/email/src/system/SystemEmailProviderFactory.ts
+++ b/packages/email/src/system/SystemEmailProviderFactory.ts
@@ -79,9 +79,11 @@ export class SystemEmailProviderFactory {
       requireTLS: process.env.EMAIL_REQUIRE_TLS === 'true'
     };
 
-    // Validate required fields
-    if (!config.host || !config.username || !config.password) {
-      throw new Error('Missing required SMTP configuration: host, username, and password are required');
+    // Only host is strictly required here. Credentials are optional so an
+    // unauthenticated relay works; SMTPEmailProvider validates the rest
+    // (including the "both-or-neither" credential rule).
+    if (!config.host) {
+      throw new Error('Missing required SMTP configuration: EMAIL_HOST is required');
     }
 
     const provider = new SMTPEmailProvider(providerId);

--- a/packages/integrations/src/actions/email-actions/emailSettingsActions.ts
+++ b/packages/integrations/src/actions/email-actions/emailSettingsActions.ts
@@ -6,13 +6,43 @@
 
 import { createTenantKnex, tenantDb } from '@alga-psa/db';
 import { withAuth } from '@alga-psa/auth';
-import type { TenantEmailSettings } from '@alga-psa/types';
+import type { EmailProviderConfig, TenantEmailSettings } from '@alga-psa/types';
 import { TenantEmailService } from '@alga-psa/email';
 
 type EmailSettingsUpdateInput = Partial<TenantEmailSettings> & {
   defaultFromDomain?: string | null;
   ticketingFromEmail?: string | null;
 };
+
+// getEmailSettings masks stored secrets as this sentinel so they are never
+// sent to the browser. On save it means "unchanged" — restore the real value.
+const SECRET_MASK = '***';
+const SECRET_FIELDS = ['password', 'apiKey'] as const;
+
+function mergeProviderSecrets(
+  incoming: EmailProviderConfig[],
+  existing: EmailProviderConfig[] | undefined
+): EmailProviderConfig[] {
+  const existingById = new Map((existing ?? []).map(config => [config.providerId, config]));
+
+  return incoming.map(config => {
+    const prior = existingById.get(config.providerId);
+    const nextConfig: Record<string, any> = { ...(config.config ?? {}) };
+
+    for (const field of SECRET_FIELDS) {
+      if (nextConfig[field] !== SECRET_MASK) continue;
+      // The client only ever held the mask, so this is not a real change.
+      const priorValue = prior?.config?.[field];
+      if (priorValue) {
+        nextConfig[field] = priorValue;
+      } else {
+        delete nextConfig[field];
+      }
+    }
+
+    return { ...config, config: nextConfig };
+  });
+}
 
 function extractDomain(address?: string | null): string | null {
   if (!address) return null;
@@ -113,7 +143,9 @@ export const updateEmailSettings = withAuth(async (
       ticketingFromEmail: nextTicketingFromEmail,
       customDomains: updates.customDomains ?? existingSettings?.customDomains ?? [],
       emailProvider: updates.emailProvider ?? existingSettings?.emailProvider ?? 'smtp',
-      providerConfigs: updates.providerConfigs ?? existingSettings?.providerConfigs ?? [],
+      providerConfigs: updates.providerConfigs
+        ? mergeProviderSecrets(updates.providerConfigs, existingSettings?.providerConfigs)
+        : existingSettings?.providerConfigs ?? [],
       trackingEnabled: updates.trackingEnabled ?? existingSettings?.trackingEnabled ?? false,
       maxDailyEmails: updates.maxDailyEmails ?? existingSettings?.maxDailyEmails,
       createdAt: existingSettings?.createdAt ?? now,
@@ -172,5 +204,24 @@ export const updateEmailSettings = withAuth(async (
   } catch (error: any) {
     console.error('Error updating email settings:', error);
     throw new Error('Failed to update email settings');
+  }
+});
+
+/**
+ * Verify the saved outbound provider (and optionally send a test email to the
+ * given address). Returns the real failure reason so admins can diagnose SMTP
+ * problems from the Outbound Email tab without reading server logs.
+ */
+export const testOutboundEmail = withAuth(async (
+  _user,
+  { tenant },
+  toAddress?: string
+): Promise<{ success: boolean; message?: string; error?: string }> => {
+  try {
+    const recipient = toAddress?.trim() || undefined;
+    return await TenantEmailService.testConnection(tenant || '', recipient);
+  } catch (error: any) {
+    console.error('Error testing outbound email:', error);
+    return { success: false, error: error?.message || 'Failed to test outbound email' };
   }
 });

--- a/packages/integrations/src/actions/email-actions/index.ts
+++ b/packages/integrations/src/actions/email-actions/index.ts
@@ -1,7 +1,7 @@
 export { configureGmailProvider, type ConfigureGmailProviderResult } from './configureGmailProvider';
 export { getEmailProviders, upsertEmailProvider, createEmailProvider, updateEmailProvider, deleteEmailProvider, resyncImapProvider, testEmailProviderConnection, retryMicrosoftSubscriptionRenewal, runMicrosoft365Diagnostics } from './emailProviderActions';
 export { getEmailDomains, addEmailDomain, verifyEmailDomain, deleteEmailDomain } from './emailDomainActions';
-export { getEmailSettings, updateEmailSettings } from './emailSettingsActions';
+export { getEmailSettings, updateEmailSettings, testOutboundEmail } from './emailSettingsActions';
 export { getInboundTicketDefaults, createInboundTicketDefaults, updateInboundTicketDefaults, deleteInboundTicketDefaults } from './inboundTicketDefaultsActions';
 export { getInboundEmailRules, createInboundEmailRule, updateInboundEmailRule, setInboundEmailRuleActive, deleteInboundEmailRule, reorderInboundEmailRules, testInboundEmailRule } from './inboundEmailRulesActions';
 export { getTicketFieldOptions } from './ticketFieldOptionsActions';

--- a/packages/integrations/src/components/email/admin/EmailSettings.tsx
+++ b/packages/integrations/src/components/email/admin/EmailSettings.tsx
@@ -22,7 +22,8 @@ import {
 } from '@alga-psa/types';
 import {
   getEmailSettings,
-  updateEmailSettings
+  updateEmailSettings,
+  testOutboundEmail
 } from '../../../actions/email-actions/emailSettingsActions';
 import {
   getEmailDomains,
@@ -63,6 +64,9 @@ export const EmailSettings: React.FC<EmailSettingsProps> = () => {
   const [showPassword, setShowPassword] = useState(false);
   const [showApiKey, setShowApiKey] = useState(false);
   const [activeTab, setActiveTab] = useState('inbound');
+  const [testRecipient, setTestRecipient] = useState('');
+  const [testing, setTesting] = useState(false);
+  const [testResult, setTestResult] = useState<{ success: boolean; message?: string; error?: string } | null>(null);
 
   useEffect(() => {
     loadEmailSettings();
@@ -108,6 +112,27 @@ export const EmailSettings: React.FC<EmailSettingsProps> = () => {
       setError(err.message || t('email.errors.saveSettings', { defaultValue: 'Failed to save settings' }));
     } finally {
       setSaving(false);
+    }
+  };
+
+  const runOutboundTest = async () => {
+    if (!settings) return;
+
+    setTesting(true);
+    setTestResult(null);
+    try {
+      // Persist current edits first so the test reflects what's on screen.
+      // The masked password ('***') is resolved to the stored secret server-side.
+      await updateEmailSettings(settings);
+      const result = await testOutboundEmail(testRecipient.trim() || undefined);
+      setTestResult(result);
+    } catch (err: any) {
+      setTestResult({
+        success: false,
+        error: err?.message || t('email.errors.testOutbound', { defaultValue: 'Failed to test outbound email' })
+      });
+    } finally {
+      setTesting(false);
     }
   };
 
@@ -248,6 +273,12 @@ export const EmailSettings: React.FC<EmailSettingsProps> = () => {
           </div>
         </div>
 
+        <p className="text-sm text-muted-foreground">
+          {t('email.smtp.authHint', {
+            defaultValue: 'Leave username and password blank if your relay accepts mail without authentication.'
+          })}
+        </p>
+
         <div>
           <Label htmlFor="smtp-from">{t('email.smtp.fromAddress.label', { defaultValue: 'From Address' })}</Label>
           <Input
@@ -256,6 +287,50 @@ export const EmailSettings: React.FC<EmailSettingsProps> = () => {
             placeholder={t('email.smtp.fromAddress.placeholder', { defaultValue: 'noreply@example.com' })}
             onChange={(e) => updateProviderConfig(config.providerId, { from: e.target.value })}
           />
+        </div>
+
+        <div className="border-t pt-4 space-y-4">
+          <h4 className="text-sm font-medium">
+            {t('email.smtp.security.title', { defaultValue: 'Connection Security' })}
+          </h4>
+
+          <div className="flex items-center space-x-2">
+            <Switch
+              id="smtp-secure"
+              checked={config.config.secure ?? (Number(config.config.port) === 465)}
+              onCheckedChange={(checked: boolean) => updateProviderConfig(config.providerId, { secure: checked })}
+            />
+            <Label htmlFor="smtp-secure">
+              {t('email.smtp.security.secure', { defaultValue: 'Use implicit TLS (SSL on connect, typically port 465)' })}
+            </Label>
+          </div>
+
+          <div className="flex items-center space-x-2">
+            <Switch
+              id="smtp-require-tls"
+              checked={config.config.requireTLS ?? false}
+              onCheckedChange={(checked: boolean) => updateProviderConfig(config.providerId, { requireTLS: checked })}
+            />
+            <Label htmlFor="smtp-require-tls">
+              {t('email.smtp.security.requireTls', { defaultValue: 'Require STARTTLS upgrade (ports 587 / 25)' })}
+            </Label>
+          </div>
+
+          <div className="flex items-center space-x-2">
+            <Switch
+              id="smtp-reject-unauthorized"
+              checked={config.config.rejectUnauthorized !== false}
+              onCheckedChange={(checked: boolean) => updateProviderConfig(config.providerId, { rejectUnauthorized: checked })}
+            />
+            <Label htmlFor="smtp-reject-unauthorized">
+              {t('email.smtp.security.verifyCert', { defaultValue: 'Verify server certificate' })}
+            </Label>
+          </div>
+          <p className="text-sm text-muted-foreground">
+            {t('email.smtp.security.verifyCertHint', {
+              defaultValue: 'Turn this off only for a trusted relay on your own network that uses a self-signed certificate.'
+            })}
+          </p>
         </div>
       </div>
     );
@@ -508,6 +583,55 @@ export const EmailSettings: React.FC<EmailSettingsProps> = () => {
           </Card>
 
 
+
+            {/* Connection Test */}
+            <Card>
+              <CardHeader>
+                <CardTitle className="flex items-center gap-2">
+                  <Send className="h-5 w-5" />
+                  {t('email.test.title', { defaultValue: 'Test Outbound Email' })}
+                </CardTitle>
+              </CardHeader>
+              <CardContent className="space-y-4">
+                <p className="text-sm text-muted-foreground">
+                  {t('email.test.description', {
+                    defaultValue: 'Saves the current settings, then verifies the provider connection. Enter an address to also send a test message.'
+                  })}
+                </p>
+                <div className="flex items-end gap-2">
+                  <div className="flex-1">
+                    <Label htmlFor="test-recipient">
+                      {t('email.test.recipientLabel', { defaultValue: 'Send test to (optional)' })}
+                    </Label>
+                    <Input
+                      id="test-recipient"
+                      type="email"
+                      value={testRecipient}
+                      placeholder={t('email.test.recipientPlaceholder', { defaultValue: 'you@example.com' })}
+                      onChange={(e) => setTestRecipient(e.target.value)}
+                    />
+                  </div>
+                  <Button
+                    id="test-outbound-email"
+                    variant="outline"
+                    onClick={runOutboundTest}
+                    disabled={testing || !settings}
+                  >
+                    {testing
+                      ? t('email.test.testing', { defaultValue: 'Testing...' })
+                      : t('email.test.run', { defaultValue: 'Test Connection' })}
+                  </Button>
+                </div>
+                {testResult && (
+                  <div className={`flex items-start gap-2 text-sm ${testResult.success ? 'text-green-600' : 'text-red-600'}`}>
+                    {testResult.success
+                      ? <CheckCircle className="h-4 w-4 mt-0.5 shrink-0" />
+                      : <XCircle className="h-4 w-4 mt-0.5 shrink-0" />}
+                    <span>{testResult.success ? testResult.message : testResult.error}</span>
+                  </div>
+                )}
+              </CardContent>
+            </Card>
 
             {/* Save Button */}
             <div className="flex justify-end">

--- a/packages/portal-shared/src/actions/portalInvitationActions.ts
+++ b/packages/portal-shared/src/actions/portalInvitationActions.ts
@@ -449,9 +449,14 @@ export const sendPortalInvitation = withAuth(async (
       const systemEmailService = await getSystemEmailService();
       emailConfigured = await systemEmailService.isConfigured();
       if (!emailConfigured) {
+        // If a provider was configured but failed to initialize (e.g. an SMTP
+        // auth/TLS error), report the real cause instead of "disabled".
+        const initError = await tenantEmailService.getInitializationError();
         return {
           success: false,
-          error: 'Email service is disabled or not configured',
+          error: initError
+            ? `Email provider not ready: ${initError}`
+            : 'Email service is disabled or not configured',
           errorCode: 'EMAIL_NOT_CONFIGURED'
         };
       }

--- a/server/public/locales/de/msp/admin.json
+++ b/server/public/locales/de/msp/admin.json
@@ -140,6 +140,14 @@
       "fromAddress": {
         "label": "Absenderadresse",
         "placeholder": "noreply@example.com"
+      },
+      "authHint": "Lassen Sie Benutzername und Passwort leer, wenn Ihr Relay E-Mails ohne Authentifizierung akzeptiert.",
+      "security": {
+        "title": "Verbindungssicherheit",
+        "secure": "Implizites TLS verwenden (SSL beim Verbinden, üblicherweise Port 465)",
+        "requireTls": "STARTTLS-Upgrade erforderlich (Ports 587 / 25)",
+        "verifyCert": "Serverzertifikat überprüfen",
+        "verifyCertHint": "Deaktivieren Sie dies nur für ein vertrauenswürdiges Relay in Ihrem eigenen Netzwerk, das ein selbstsigniertes Zertifikat verwendet."
       }
     },
     "resend": {
@@ -169,7 +177,16 @@
       "loadEmailSettings": "E-Mail-Einstellungen konnten nicht geladen werden",
       "saveSettings": "Einstellungen konnten nicht gespeichert werden",
       "addDomain": "Domain konnte nicht hinzugefügt werden",
-      "verifyDomain": "Domain konnte nicht überprüft werden"
+      "verifyDomain": "Domain konnte nicht überprüft werden",
+      "testOutbound": "Test der ausgehenden E-Mail fehlgeschlagen"
+    },
+    "test": {
+      "title": "Ausgehende E-Mail testen",
+      "description": "Speichert die aktuellen Einstellungen und überprüft dann die Verbindung zum Anbieter. Geben Sie eine Adresse ein, um auch eine Testnachricht zu senden.",
+      "recipientLabel": "Test senden an (optional)",
+      "recipientPlaceholder": "sie@beispiel.com",
+      "run": "Verbindung testen",
+      "testing": "Wird getestet..."
     }
   },
   "microsoft365": {

--- a/server/public/locales/en/msp/admin.json
+++ b/server/public/locales/en/msp/admin.json
@@ -140,6 +140,14 @@
       "fromAddress": {
         "label": "From Address",
         "placeholder": "noreply@example.com"
+      },
+      "authHint": "Leave username and password blank if your relay accepts mail without authentication.",
+      "security": {
+        "title": "Connection Security",
+        "secure": "Use implicit TLS (SSL on connect, typically port 465)",
+        "requireTls": "Require STARTTLS upgrade (ports 587 / 25)",
+        "verifyCert": "Verify server certificate",
+        "verifyCertHint": "Turn this off only for a trusted relay on your own network that uses a self-signed certificate."
       }
     },
     "resend": {
@@ -169,7 +177,16 @@
       "loadEmailSettings": "Failed to load email settings",
       "saveSettings": "Failed to save settings",
       "addDomain": "Failed to add domain",
-      "verifyDomain": "Failed to verify domain"
+      "verifyDomain": "Failed to verify domain",
+      "testOutbound": "Failed to test outbound email"
+    },
+    "test": {
+      "title": "Test Outbound Email",
+      "description": "Saves the current settings, then verifies the provider connection. Enter an address to also send a test message.",
+      "recipientLabel": "Send test to (optional)",
+      "recipientPlaceholder": "you@example.com",
+      "run": "Test Connection",
+      "testing": "Testing..."
     }
   },
   "microsoft365": {

--- a/server/public/locales/es/msp/admin.json
+++ b/server/public/locales/es/msp/admin.json
@@ -140,6 +140,14 @@
       "fromAddress": {
         "label": "Dirección del remitente",
         "placeholder": "noreply@example.com"
+      },
+      "authHint": "Deje el nombre de usuario y la contraseña en blanco si su retransmisor acepta correo sin autenticación.",
+      "security": {
+        "title": "Seguridad de la conexión",
+        "secure": "Usar TLS implícito (SSL al conectar, normalmente el puerto 465)",
+        "requireTls": "Requerir actualización STARTTLS (puertos 587 / 25)",
+        "verifyCert": "Verificar el certificado del servidor",
+        "verifyCertHint": "Desactive esto solo para un retransmisor de confianza en su propia red que use un certificado autofirmado."
       }
     },
     "resend": {
@@ -169,7 +177,16 @@
       "loadEmailSettings": "No se pudo cargar la configuración de correo",
       "saveSettings": "No se pudo guardar la configuración",
       "addDomain": "No se pudo agregar el dominio",
-      "verifyDomain": "No se pudo verificar el dominio"
+      "verifyDomain": "No se pudo verificar el dominio",
+      "testOutbound": "Error al probar el correo saliente"
+    },
+    "test": {
+      "title": "Probar correo saliente",
+      "description": "Guarda la configuración actual y luego verifica la conexión con el proveedor. Introduzca una dirección para enviar también un mensaje de prueba.",
+      "recipientLabel": "Enviar prueba a (opcional)",
+      "recipientPlaceholder": "tu@ejemplo.com",
+      "run": "Probar conexión",
+      "testing": "Probando..."
     }
   },
   "microsoft365": {

--- a/server/public/locales/fr/msp/admin.json
+++ b/server/public/locales/fr/msp/admin.json
@@ -140,6 +140,14 @@
       "fromAddress": {
         "label": "Adresse d'expéditeur",
         "placeholder": "noreply@example.com"
+      },
+      "authHint": "Laissez le nom d'utilisateur et le mot de passe vides si votre relais accepte les e-mails sans authentification.",
+      "security": {
+        "title": "Sécurité de la connexion",
+        "secure": "Utiliser le TLS implicite (SSL à la connexion, généralement le port 465)",
+        "requireTls": "Exiger la mise à niveau STARTTLS (ports 587 / 25)",
+        "verifyCert": "Vérifier le certificat du serveur",
+        "verifyCertHint": "Ne désactivez cette option que pour un relais de confiance sur votre propre réseau utilisant un certificat auto-signé."
       }
     },
     "resend": {
@@ -169,7 +177,16 @@
       "loadEmailSettings": "Impossible de charger les paramètres de messagerie",
       "saveSettings": "Impossible d'enregistrer les paramètres",
       "addDomain": "Impossible d'ajouter le domaine",
-      "verifyDomain": "Impossible de vérifier le domaine"
+      "verifyDomain": "Impossible de vérifier le domaine",
+      "testOutbound": "Échec du test de l'e-mail sortant"
+    },
+    "test": {
+      "title": "Tester l'e-mail sortant",
+      "description": "Enregistre les paramètres actuels, puis vérifie la connexion au fournisseur. Saisissez une adresse pour envoyer aussi un message de test.",
+      "recipientLabel": "Envoyer le test à (facultatif)",
+      "recipientPlaceholder": "vous@exemple.com",
+      "run": "Tester la connexion",
+      "testing": "Test en cours..."
     }
   },
   "microsoft365": {

--- a/server/public/locales/it/msp/admin.json
+++ b/server/public/locales/it/msp/admin.json
@@ -140,6 +140,14 @@
       "fromAddress": {
         "label": "Indirizzo mittente",
         "placeholder": "noreply@example.com"
+      },
+      "authHint": "Lascia vuoti nome utente e password se il tuo relay accetta la posta senza autenticazione.",
+      "security": {
+        "title": "Sicurezza della connessione",
+        "secure": "Usa TLS implicito (SSL alla connessione, in genere porta 465)",
+        "requireTls": "Richiedi l'aggiornamento STARTTLS (porte 587 / 25)",
+        "verifyCert": "Verifica il certificato del server",
+        "verifyCertHint": "Disattiva questa opzione solo per un relay attendibile sulla tua rete che utilizza un certificato autofirmato."
       }
     },
     "resend": {
@@ -169,7 +177,16 @@
       "loadEmailSettings": "Impossibile caricare le impostazioni email",
       "saveSettings": "Impossibile salvare le impostazioni",
       "addDomain": "Impossibile aggiungere il dominio",
-      "verifyDomain": "Impossibile verificare il dominio"
+      "verifyDomain": "Impossibile verificare il dominio",
+      "testOutbound": "Test dell'e-mail in uscita non riuscito"
+    },
+    "test": {
+      "title": "Prova e-mail in uscita",
+      "description": "Salva le impostazioni attuali, quindi verifica la connessione al provider. Inserisci un indirizzo per inviare anche un messaggio di prova.",
+      "recipientLabel": "Invia prova a (facoltativo)",
+      "recipientPlaceholder": "tu@esempio.com",
+      "run": "Prova connessione",
+      "testing": "Prova in corso..."
     }
   },
   "microsoft365": {

--- a/server/public/locales/nl/msp/admin.json
+++ b/server/public/locales/nl/msp/admin.json
@@ -140,6 +140,14 @@
       "fromAddress": {
         "label": "Afzenderadres",
         "placeholder": "noreply@example.com"
+      },
+      "authHint": "Laat gebruikersnaam en wachtwoord leeg als uw relay e-mail zonder authenticatie accepteert.",
+      "security": {
+        "title": "Verbindingsbeveiliging",
+        "secure": "Impliciete TLS gebruiken (SSL bij verbinden, doorgaans poort 465)",
+        "requireTls": "STARTTLS-upgrade vereisen (poorten 587 / 25)",
+        "verifyCert": "Servercertificaat verifiëren",
+        "verifyCertHint": "Schakel dit alleen uit voor een vertrouwde relay op uw eigen netwerk met een zelfondertekend certificaat."
       }
     },
     "resend": {
@@ -169,7 +177,16 @@
       "loadEmailSettings": "Kan e-mailinstellingen niet laden",
       "saveSettings": "Kan instellingen niet opslaan",
       "addDomain": "Kan domein niet toevoegen",
-      "verifyDomain": "Kan domein niet verifiëren"
+      "verifyDomain": "Kan domein niet verifiëren",
+      "testOutbound": "Testen van uitgaande e-mail mislukt"
+    },
+    "test": {
+      "title": "Uitgaande e-mail testen",
+      "description": "Slaat de huidige instellingen op en verifieert vervolgens de verbinding met de provider. Voer een adres in om ook een testbericht te verzenden.",
+      "recipientLabel": "Test verzenden naar (optioneel)",
+      "recipientPlaceholder": "jij@voorbeeld.com",
+      "run": "Verbinding testen",
+      "testing": "Bezig met testen..."
     }
   },
   "microsoft365": {

--- a/server/public/locales/pl/msp/admin.json
+++ b/server/public/locales/pl/msp/admin.json
@@ -140,6 +140,14 @@
       "fromAddress": {
         "label": "Adres nadawcy",
         "placeholder": "noreply@example.com"
+      },
+      "authHint": "Pozostaw nazwę użytkownika i hasło puste, jeśli przekaźnik akceptuje pocztę bez uwierzytelniania.",
+      "security": {
+        "title": "Bezpieczeństwo połączenia",
+        "secure": "Użyj niejawnego TLS (SSL przy połączeniu, zwykle port 465)",
+        "requireTls": "Wymagaj uaktualnienia STARTTLS (porty 587 / 25)",
+        "verifyCert": "Weryfikuj certyfikat serwera",
+        "verifyCertHint": "Wyłącz tę opcję tylko dla zaufanego przekaźnika we własnej sieci używającego certyfikatu z podpisem własnym."
       }
     },
     "resend": {
@@ -169,7 +177,16 @@
       "loadEmailSettings": "Nie udało się załadować ustawień poczty",
       "saveSettings": "Nie udało się zapisać ustawień",
       "addDomain": "Nie udało się dodać domeny",
-      "verifyDomain": "Nie udało się zweryfikować domeny"
+      "verifyDomain": "Nie udało się zweryfikować domeny",
+      "testOutbound": "Nie udało się przetestować poczty wychodzącej"
+    },
+    "test": {
+      "title": "Przetestuj pocztę wychodzącą",
+      "description": "Zapisuje bieżące ustawienia, a następnie weryfikuje połączenie z dostawcą. Wpisz adres, aby wysłać także wiadomość testową.",
+      "recipientLabel": "Wyślij test do (opcjonalnie)",
+      "recipientPlaceholder": "ty@przyklad.com",
+      "run": "Testuj połączenie",
+      "testing": "Testowanie..."
     }
   },
   "microsoft365": {

--- a/server/public/locales/pt/msp/admin.json
+++ b/server/public/locales/pt/msp/admin.json
@@ -140,6 +140,14 @@
       "fromAddress": {
         "label": "Do endereço",
         "placeholder": "noreply@example.com"
+      },
+      "authHint": "Deixe o nome de usuário e a senha em branco se o seu relay aceitar e-mails sem autenticação.",
+      "security": {
+        "title": "Segurança da conexão",
+        "secure": "Usar TLS implícito (SSL ao conectar, normalmente a porta 465)",
+        "requireTls": "Exigir atualização STARTTLS (portas 587 / 25)",
+        "verifyCert": "Verificar o certificado do servidor",
+        "verifyCertHint": "Desative isto apenas para um relay confiável na sua própria rede que use um certificado autoassinado."
       }
     },
     "resend": {
@@ -169,7 +177,16 @@
       "loadEmailSettings": "Falha ao carregar as configurações de e-mail",
       "saveSettings": "Falha ao salvar as configurações",
       "addDomain": "Falha ao adicionar domínio",
-      "verifyDomain": "Falha ao verificar o domínio"
+      "verifyDomain": "Falha ao verificar o domínio",
+      "testOutbound": "Falha ao testar o e-mail de saída"
+    },
+    "test": {
+      "title": "Testar e-mail de saída",
+      "description": "Salva as configurações atuais e depois verifica a conexão com o provedor. Insira um endereço para também enviar uma mensagem de teste.",
+      "recipientLabel": "Enviar teste para (opcional)",
+      "recipientPlaceholder": "voce@exemplo.com",
+      "run": "Testar conexão",
+      "testing": "Testando..."
     }
   },
   "microsoft365": {

--- a/server/public/locales/xx/msp/admin.json
+++ b/server/public/locales/xx/msp/admin.json
@@ -140,6 +140,14 @@
       "fromAddress": {
         "label": "11111",
         "placeholder": "11111"
+      },
+      "authHint": "11111",
+      "security": {
+        "title": "11111",
+        "secure": "11111",
+        "requireTls": "11111",
+        "verifyCert": "11111",
+        "verifyCertHint": "11111"
       }
     },
     "resend": {
@@ -169,7 +177,16 @@
       "loadEmailSettings": "11111",
       "saveSettings": "11111",
       "addDomain": "11111",
-      "verifyDomain": "11111"
+      "verifyDomain": "11111",
+      "testOutbound": "11111"
+    },
+    "test": {
+      "title": "11111",
+      "description": "11111",
+      "recipientLabel": "11111",
+      "recipientPlaceholder": "11111",
+      "run": "11111",
+      "testing": "11111"
     }
   },
   "microsoft365": {

--- a/server/public/locales/yy/msp/admin.json
+++ b/server/public/locales/yy/msp/admin.json
@@ -140,6 +140,14 @@
       "fromAddress": {
         "label": "55555",
         "placeholder": "55555"
+      },
+      "authHint": "55555",
+      "security": {
+        "title": "55555",
+        "secure": "55555",
+        "requireTls": "55555",
+        "verifyCert": "55555",
+        "verifyCertHint": "55555"
       }
     },
     "resend": {
@@ -169,7 +177,16 @@
       "loadEmailSettings": "55555",
       "saveSettings": "55555",
       "addDomain": "55555",
-      "verifyDomain": "55555"
+      "verifyDomain": "55555",
+      "testOutbound": "55555"
+    },
+    "test": {
+      "title": "55555",
+      "description": "55555",
+      "recipientLabel": "55555",
+      "recipientPlaceholder": "55555",
+      "run": "55555",
+      "testing": "55555"
     }
   },
   "microsoft365": {


### PR DESCRIPTION
## Problem

On the on-prem appliance, all outbound mail (portal invitations, email templates) failed with **"Email service is disabled or not configured"** even with a correctly-configured SMTP relay. Reported by a customer on v1.2.10 (M365 inbound working, outbound to a local smtp-oauth-relay). Ticket **alga0002046**.

**Root cause:** the appliance ships `email.enabled=false` (`helm/values.yaml`) so `EMAIL_ENABLE=false` and there is no system-email fallback. The tenant SMTP provider is the only send path; when it failed to initialize, `TenantEmailService.getEmailProvider` swallowed the error and returned null, collapsing the real SMTP failure into the generic "disabled" message. The SMTP init itself failed because credentials were mandatory (a no-auth relay couldn't be configured), `verify()` ran with certificate verification forced on and no UI toggle, and the `***` password mask round-tripped back as the literal password.

## Changes

1. **Surface the real error (core fix).** `BaseEmailService` gains `providerInitError` + `getInitializationError()`; `TenantEmailService.getEmailProvider` records the real cause when the EE system fallback is unavailable; `sendEmail` returns `Email provider not ready: <cause>` and portal invitations report it too. `sendEventEmail` no longer silently skips a genuinely-failed provider.
2. **Support unauthenticated relays.** `SMTPEmailProvider` requires only host/port/from; AUTH is sent only when both credentials are present (both-or-neither enforced). `SystemEmailProviderFactory` aligned.
3. **Fix the `***` password/apiKey round-trip.** `updateEmailSettings` restores the stored secret when the masked sentinel is saved unchanged, so saving without re-typing no longer clobbers it.
4. **TLS controls on the Outbound Email tab** — implicit TLS, Require STARTTLS, Verify server certificate.
5. **Outbound "Test Connection".** `TenantEmailService.testConnection` + `testOutboundEmail` action + a UI card that verifies (and optionally sends a test), returning the real error — no more digging through pod logs.

## Testing

- Typecheck clean: `email`, `integrations`, `portal-shared`.
- `packages/email` — 64 tests pass (added no-auth / both-or-neither cases; updated the outdated required-fields assertion).
- `packages/integrations` email-actions — 8 tests pass.
- Not yet smoke-tested live on the appliance UI.

https://claude.ai/code/session_01Wc8vwHUJhMxHhVRXzCjn74