### PR TITLE
fix(contracts): stop start date shifting a day in list and header views

### DIFF
--- a/packages/billing/src/components/billing-dashboard/contracts/ClientContractsTab.tsx
+++ b/packages/billing/src/components/billing-dashboard/contracts/ClientContractsTab.tsx
@@ -38,6 +38,7 @@ import {
   type RenewalQueueRow,
 } from '@alga-psa/billing/actions/renewalsQueueActions';
 import { updateClientContractForBilling } from '@alga-psa/billing/actions/billingClientsActions';
+import { toPlainDate } from '@alga-psa/core';
 import { ContractWizard } from './ContractWizard';
 import { ContractDialog } from './ContractDialog';
 import { handleError, isActionPermissionError } from '@alga-psa/ui/lib/errorHandling';
@@ -265,25 +266,20 @@ const ClientContractsTab: React.FC<ClientContractsTabProps> = ({ onRefreshNeeded
   };
 
   const formatDateValue = (value: unknown): string => {
-    if (!value) return t('contractsList.empty.dash', { defaultValue: '—' });
-    if (!(typeof value === 'string' || typeof value === 'number' || value instanceof Date)) {
+    if (value === null || value === undefined || value === '') {
       return t('contractsList.empty.dash', { defaultValue: '—' });
     }
 
-    // Treat YYYY-MM-DD as a date-only value to avoid timezone shifts.
-    if (typeof value === 'string') {
-      const dateOnlyMatch = value.match(/^(\d{4})-(\d{2})-(\d{2})$/);
-      if (dateOnlyMatch) {
-        const year = Number(dateOnlyMatch[1]);
-        const month = Number(dateOnlyMatch[2]);
-        const day = Number(dateOnlyMatch[3]);
-        const dateOnly = new Date(Date.UTC(year, month - 1, day, 12));
-        return isNaN(dateOnly.getTime()) ? t('contractsList.empty.dash', { defaultValue: '—' }) : dateOnly.toLocaleDateString();
-      }
+    // start_date/end_date are stored as timestamps but represent calendar dates.
+    // toPlainDate reads both YYYY-MM-DD strings and ISO timestamps in UTC; pinning
+    // to noon UTC keeps the intended day regardless of the viewer's timezone.
+    try {
+      const plainDate = toPlainDate(value as string | Date);
+      const dateOnly = new Date(Date.UTC(plainDate.year, plainDate.month - 1, plainDate.day, 12));
+      return dateOnly.toLocaleDateString();
+    } catch {
+      return t('contractsList.empty.dash', { defaultValue: '—' });
     }
-
-    const date = new Date(value);
-    return isNaN(date.getTime()) ? t('contractsList.empty.dash', { defaultValue: '—' }) : date.toLocaleDateString();
   };
 
   const clientContractColumns: ColumnDefinition<IContractWithClient>[] = [

--- a/packages/billing/src/components/billing-dashboard/contracts/ContractHeader.tsx
+++ b/packages/billing/src/components/billing-dashboard/contracts/ContractHeader.tsx
@@ -8,6 +8,7 @@ import type { IContractSummary } from '@alga-psa/billing/actions/contractActions
 import { Calendar, CalendarClock, FileCheck, Layers3, Coins } from 'lucide-react';
 import { useTranslation } from '@alga-psa/ui/lib/i18n/client';
 import { useFormatBillingFrequency } from '@alga-psa/billing/hooks/useBillingEnumOptions';
+import { toPlainDate } from '@alga-psa/core';
 
 interface ContractHeaderProps {
   contract: IContract;
@@ -32,6 +33,24 @@ const formatDate = (value?: string | Date | null, emptyLabel: string = '—'): s
   }
 
   return new Intl.DateTimeFormat(undefined, { dateStyle: 'medium' }).format(date);
+};
+
+// start_date/end_date are calendar dates stored as UTC-midnight timestamps.
+// Format via toPlainDate + noon-UTC so the day matches the detail body and never
+// shifts in negative-offset timezones. (Use formatDate above for true instants
+// like updated_at, where local-time rendering is intended.)
+const formatCalendarDate = (value?: string | Date | null, emptyLabel: string = '—'): string => {
+  if (!value) {
+    return emptyLabel;
+  }
+
+  try {
+    const plainDate = toPlainDate(value);
+    const displayDate = new Date(Date.UTC(plainDate.year, plainDate.month - 1, plainDate.day, 12));
+    return new Intl.DateTimeFormat(undefined, { dateStyle: 'medium' }).format(displayDate);
+  } catch {
+    return emptyLabel;
+  }
 };
 
 const formatNumber = (value?: number, emptyLabel: string = '—'): string => {
@@ -68,7 +87,7 @@ const ContractHeader: React.FC<ContractHeaderProps> = ({ contract, summary, live
     {
       label: t('contractHeader.labels.startDate', { defaultValue: 'Start Date' }),
       value: summary?.earliestStartDate
-        ? formatDate(summary.earliestStartDate, emptyLabel)
+        ? formatCalendarDate(summary.earliestStartDate, emptyLabel)
         : summary
           ? emptyLabel
           : emptyLabel,
@@ -78,7 +97,7 @@ const ContractHeader: React.FC<ContractHeaderProps> = ({ contract, summary, live
       label: t('contractHeader.labels.endDate', { defaultValue: 'End Date' }),
       value: summary
         ? summary.latestEndDate
-          ? formatDate(summary.latestEndDate, emptyLabel)
+          ? formatCalendarDate(summary.latestEndDate, emptyLabel)
           : summary.totalClientAssignments > 0
             ? t('contractHeader.values.ongoing', { defaultValue: 'Ongoing' })
             : emptyLabel

--- a/packages/billing/src/components/billing-dashboard/contracts/Contracts.tsx
+++ b/packages/billing/src/components/billing-dashboard/contracts/Contracts.tsx
@@ -43,6 +43,22 @@ import {
   getDraftTabBadgeCount,
   normalizeContractSubtab,
 } from './contractsTabs';
+import { toPlainDate } from '@alga-psa/core';
+
+// start_date/end_date are calendar dates. Parsing them with `new Date()` reads a
+// date-only/UTC-midnight value as UTC, so `.toLocaleDateString()` renders the
+// previous day in negative-offset timezones. Pin to noon UTC to stay on the
+// intended calendar day regardless of the viewer's timezone.
+const formatCalendarDate = (value: unknown): string | null => {
+  if (value === null || value === undefined || value === '') return null;
+  try {
+    const plainDate = toPlainDate(value as string | Date);
+    const displayDate = new Date(Date.UTC(plainDate.year, plainDate.month - 1, plainDate.day, 12));
+    return displayDate.toLocaleDateString();
+  } catch {
+    return null;
+  }
+};
 
 const Contracts: React.FC = () => {
   const { t } = useTranslation('msp/contracts');
@@ -382,28 +398,14 @@ const Contracts: React.FC = () => {
     {
       title: t('contractsList.columns.startDate', { defaultValue: 'Start Date' }),
       dataIndex: 'start_date',
-      render: (value: any) => {
-        if (!value) return t('contractsList.empty.dash', { defaultValue: '—' });
-        try {
-          const date = new Date(value);
-          return isNaN(date.getTime()) ? t('contractsList.empty.dash', { defaultValue: '—' }) : date.toLocaleDateString();
-        } catch {
-          return t('contractsList.empty.dash', { defaultValue: '—' });
-        }
-      },
+      render: (value: any) =>
+        formatCalendarDate(value) ?? t('contractsList.empty.dash', { defaultValue: '—' }),
     },
     {
       title: t('contractsList.columns.endDate', { defaultValue: 'End Date' }),
       dataIndex: 'end_date',
-      render: (value: any) => {
-        if (!value) return t('contractsList.empty.dash', { defaultValue: '—' });
-        try {
-          const date = new Date(value);
-          return isNaN(date.getTime()) ? t('contractsList.empty.dash', { defaultValue: '—' }) : date.toLocaleDateString();
-        } catch {
-          return t('contractsList.empty.dash', { defaultValue: '—' });
-        }
-      },
+      render: (value: any) =>
+        formatCalendarDate(value) ?? t('contractsList.empty.dash', { defaultValue: '—' }),
     },
     {
       title: t('contractsList.columns.status', { defaultValue: 'Status' }),


### PR DESCRIPTION
Contract start_date/end_date are calendar dates stored as UTC-midnight timestamps, but the list columns and detail header formatted them with new Date(value).toLocaleDateString(), rendering the previous day in any timezone west of UTC. Converge Contracts.tsx, ClientContractsTab.tsx, and ContractHeader.tsx on the detail body's UTC-safe pattern: toPlainDate
+ noon-UTC anchor. True instants (created_at/updated_at/Last Updated) stay on local-time rendering, where they belong.

"Why, sometimes I've believed a contract began six impossible days before breakfast," said the Queen — but toPlainDate pinned the calendar to high noon, and Sep 1 refused, at last, to become Aug 31. 🕛🐇📅