### PR TITLE
Hide closed-project tasks; per-filter chip removal

### DIFF
--- a/ee/mobile/src/i18n/locales/en/userActivities.json
+++ b/ee/mobile/src/i18n/locales/en/userActivities.json
@@ -60,6 +60,7 @@
     "asc": "Ascending",
     "desc": "Descending",
     "clearAll": "Clear all",
+    "removeFilter": "Remove {{label}} filter",
     "viewResults": "View results",
     "viewResultsCount_one": "View {{count}} result",
     "viewResultsCount_other": "View {{count}} results",

--- a/ee/mobile/src/screens/UserActivitiesScreen.tsx
+++ b/ee/mobile/src/screens/UserActivitiesScreen.tsx
@@ -751,7 +751,7 @@ export function UserActivitiesScreen({ navigation }: Props) {
         />
       </View>
 
-      <FilterChipBar theme={theme} filters={filters} onPress={() => setFiltersOpen(true)} onClearAll={clearAllFilters} />
+      <FilterChipBar theme={theme} filters={filters} setFilters={setFilters} onPress={() => setFiltersOpen(true)} onClearAll={clearAllFilters} />
 
       {resultsTotal !== null ? (
         <Text style={{ ...theme.typography.caption, color: theme.colors.textSecondary, marginTop: theme.spacing.sm }}>
@@ -1022,34 +1022,115 @@ function GroupHeader({
 function FilterChipBar({
   theme,
   filters,
+  setFilters,
   onPress,
   onClearAll,
 }: {
   theme: Theme;
   filters: ActivitiesFilterState;
+  setFilters: Dispatch<SetStateAction<ActivitiesFilterState>>;
   onPress: () => void;
   onClearAll: () => void;
 }) {
   const { t } = useTranslation("userActivities");
-  const chips: string[] = [];
+  // Each chip carries its own reset so a single filter can be discarded without touching
+  // the others (the "Clear all" chip still resets everything at once).
+  const chips: { key: string; label: string; onRemove: () => void }[] = [];
   if (filters.status !== DEFAULT_ACTIVITY_FILTERS.status) {
-    chips.push(t(`filters.${filters.status}`, { defaultValue: filters.status }));
+    chips.push({
+      key: "status",
+      label: t(`filters.${filters.status}`, { defaultValue: filters.status }),
+      onRemove: () => setFilters((prev) => ({ ...prev, status: DEFAULT_ACTIVITY_FILTERS.status })),
+    });
   }
-  if (filters.types.length > 0) chips.push(t("filters.typesCount", { count: filters.types.length, defaultValue: "Types ({{count}})" }));
-  if (filters.priorityIds.length > 0) chips.push(t("filters.priorityCount", { count: filters.priorityIds.length, defaultValue: "Priority ({{count}})" }));
-  if (filters.due !== "any") chips.push(t(`filters.due.${filters.due}`, { defaultValue: filters.due }));
+  if (filters.types.length > 0) {
+    chips.push({
+      key: "types",
+      label: t("filters.typesCount", { count: filters.types.length, defaultValue: "Types ({{count}})" }),
+      onRemove: () => setFilters((prev) => ({ ...prev, types: [] })),
+    });
+  }
+  if (filters.priorityIds.length > 0) {
+    chips.push({
+      key: "priority",
+      label: t("filters.priorityCount", { count: filters.priorityIds.length, defaultValue: "Priority ({{count}})" }),
+      onRemove: () => setFilters((prev) => ({ ...prev, priorityIds: [] })),
+    });
+  }
+  if (filters.due !== "any") {
+    chips.push({
+      key: "due",
+      label: t(`filters.due.${filters.due}`, { defaultValue: filters.due }),
+      onRemove: () => setFilters((prev) => ({ ...prev, due: "any" })),
+    });
+  }
   // Grouping (incl. "My groups") is shown by the dedicated toggle pill, not as a chip here.
   if (filters.sortField !== "default") {
-    chips.push(t("filters.sortedBy", { field: t(`filters.sort.${filters.sortField}`, { defaultValue: filters.sortField }), defaultValue: "Sort: {{field}}" }));
+    chips.push({
+      key: "sort",
+      label: t("filters.sortedBy", { field: t(`filters.sort.${filters.sortField}`, { defaultValue: filters.sortField }), defaultValue: "Sort: {{field}}" }),
+      onRemove: () => setFilters((prev) => ({ ...prev, sortField: "default", sortOrder: DEFAULT_ACTIVITY_FILTERS.sortOrder })),
+    });
   }
 
   if (chips.length === 0) return null;
   return (
     <View style={{ flexDirection: "row", flexWrap: "wrap", marginTop: theme.spacing.sm, gap: theme.spacing.sm }}>
-      {chips.map((label) => (
-        <QuickChip key={label} theme={theme} label={label} onPress={onPress} />
+      {chips.map((chip) => (
+        <RemovableChip
+          key={chip.key}
+          theme={theme}
+          label={chip.label}
+          onPress={onPress}
+          onRemove={chip.onRemove}
+          removeAccessibilityLabel={t("filters.removeFilter", { label: chip.label, defaultValue: "Remove {{label}} filter" })}
+        />
       ))}
       <QuickChip theme={theme} label={t("filters.clearAll", { defaultValue: "Clear all" })} onPress={onClearAll} emphasized />
+    </View>
+  );
+}
+
+function RemovableChip({
+  theme,
+  label,
+  onPress,
+  onRemove,
+  removeAccessibilityLabel,
+}: {
+  theme: Theme;
+  label: string;
+  onPress: () => void;
+  onRemove: () => void;
+  removeAccessibilityLabel: string;
+}) {
+  return (
+    <View
+      style={{
+        flexDirection: "row",
+        alignItems: "center",
+        paddingLeft: theme.spacing.md,
+        paddingRight: theme.spacing.xs,
+        paddingVertical: 6,
+        borderRadius: theme.borderRadius.full,
+        borderWidth: 1,
+        borderColor: theme.colors.border,
+        backgroundColor: theme.colors.card,
+        gap: theme.spacing.xs,
+      }}
+    >
+      <Pressable onPress={onPress} accessibilityRole="button" accessibilityLabel={label}>
+        <Text style={{ ...theme.typography.caption, color: theme.colors.text, fontWeight: "600" }}>{label}</Text>
+      </Pressable>
+      <Pressable
+        onPress={onRemove}
+        accessibilityRole="button"
+        accessibilityLabel={removeAccessibilityLabel}
+        hitSlop={8}
+        style={{ padding: 2 }}
+      >
+        <Feather name="x" size={14} color={theme.colors.textSecondary} />
+      </Pressable>
     </View>
   );
 }

--- a/packages/user-activities/src/actions/activityAggregationActions.ts
+++ b/packages/user-activities/src/actions/activityAggregationActions.ts
@@ -648,6 +648,10 @@ export async function fetchProjectActivities(
           db.raw(
             "COALESCE(custom_statuses.is_closed, standard_statuses.is_closed, false) as is_closed"
           ),
+          // Whether the parent PROJECT itself is closed (its status maps to a closed status).
+          db.raw(
+            "COALESCE(project_statuses.is_closed, false) as project_is_closed"
+          ),
           "priorities.priority_name",
           "priorities.color as priority_color",
           db.raw("'#3b82f6' as status_color") // Blue color for consistency
@@ -655,6 +659,7 @@ export async function fetchProjectActivities(
 
       scopedDb.tenantJoin(projectTasksQuery, "project_phases", "project_tasks.phase_id", "project_phases.phase_id", { type: "left" });
       scopedDb.tenantJoin(projectTasksQuery, "projects", "project_phases.project_id", "projects.project_id", { type: "left" });
+      scopedDb.tenantJoin(projectTasksQuery, "statuses as project_statuses", "projects.status", "project_statuses.status_id", { type: "left" });
       scopedDb.tenantJoin(projectTasksQuery, "priorities", "project_tasks.priority_id", "priorities.priority_id", { type: "left" });
       scopedDb.tenantJoin(
         projectTasksQuery,
@@ -745,6 +750,11 @@ export async function fetchProjectActivities(
                 openStatusMappingIds
               );
           });
+
+          // Also hide tasks whose parent PROJECT is closed. When the whole project is
+          // done, its tasks shouldn't surface in the open activities view regardless of
+          // each task's own status. Projects with a NULL/open status are treated as open.
+          queryBuilder.whereRaw("COALESCE(project_statuses.is_closed, false) = false");
         }
         
         // Client filter
@@ -862,6 +872,8 @@ export async function fetchProjectActivities(
         type: ActivityType.PROJECT_TASK,
         status: task.status_name || 'To Do', // Use the status name from standard_statuses
         statusColor: task.status_color || '#3b82f6', // Use the blue color for consistency
+        // A task is effectively closed when its own status is closed OR its project is closed.
+        isClosed: Boolean(task.is_closed) || Boolean(task.project_is_closed),
         priority,
         priorityName: task.priority_name || undefined,
         priorityColor: task.priority_color || undefined,


### PR DESCRIPTION
Filter user-activities project tasks by the parent project's closed status, not just each task's own status — a fully-closed project no longer surfaces its open tasks in the activities view (web + mobile), and tasks carry an effective isClosed flag.

On mobile, each active-filter chip is now individually removable via its own ✕ (RemovableChip) instead of only "Clear all", so a single filter can be discarded without losing the rest.

"But the whole project is closed," said Alice, "so however can its tasks still be running about?" The Queen's project_statuses join tidied every stray task back through the little door, and each filter chip grew its own ✕ to vanish one at a time. 🐇🚪🃏