### PR TITLE
fix(jobs): make Temporal recurring jobs self-heal

### DIFF
--- a/ee/temporal-workflows/src/activities/job-activities.ts
+++ b/ee/temporal-workflows/src/activities/job-activities.ts
@@ -251,18 +251,29 @@ export async function updateJobStatus(input: {
         : currentJob.metadata
       : {};
 
+    // A recurring schedule reuses one jobs row as its per-fire tracker; a
+    // terminal status would make it invisible to schedule reconcilers, which
+    // then re-schedule on every pass. pg-boss returns tracker rows to queued
+    // after each run — keep parity, and record the run outcome in metadata.
+    const isRecurringTracker = Boolean(currentMetadata?.recurring);
+    const isTerminal = status === 'completed' || status === 'failed';
+    const effectiveStatus = isRecurringTracker && isTerminal ? 'queued' : status;
+
     // Merge metadata
     const updatedMetadata = {
       ...currentMetadata,
       ...metadata,
       ...(error ? { error } : {}),
+      ...(isRecurringTracker && isTerminal
+        ? { lastRunStatus: status, lastRunAt: new Date().toISOString() }
+        : {}),
     };
 
     // Update job record
     await db.table('jobs')
       .where({ job_id: jobId })
       .update({
-        status,
+        status: effectiveStatus,
         metadata: JSON.stringify(updatedMetadata),
         updated_at: new Date(),
       });

--- a/ee/temporal-workflows/src/workflows/__tests__/generic-job-workflow.temporal.test.ts
+++ b/ee/temporal-workflows/src/workflows/__tests__/generic-job-workflow.temporal.test.ts
@@ -16,10 +16,16 @@ vi.mock('@temporalio/workflow', () => ({
   setHandler: vi.fn(),
   log: {
     info: vi.fn(),
+    warn: vi.fn(),
     error: vi.fn(),
   },
   sleep: vi.fn(async () => {}),
   workflowInfo: vi.fn(() => ({ workflowId: 'wf-test-123' })),
+  ApplicationFailure: {
+    create: vi.fn((opts: { message: string; type?: string; nonRetryable?: boolean }) =>
+      Object.assign(new Error(opts.message), opts)
+    ),
+  },
 }));
 
 const loadWorkflow = async () => {
@@ -87,7 +93,7 @@ describe('genericJobWorkflow', () => {
     );
   });
 
-  it('marks a job failed and returns terminal failure result when handler returns failure', async () => {
+  it('marks a job failed and fails the workflow when handler returns failure', async () => {
     mockActivities.executeJobHandler.mockResolvedValue({
       success: false,
       error: 'simulated handler failure',
@@ -101,11 +107,11 @@ describe('genericJobWorkflow', () => {
       data: { scheduleId: 'sched-2' },
     };
 
-    const result = await genericJobWorkflow(input);
-
-    expect(result.success).toBe(false);
-    expect(result.jobId).toBe(input.jobId);
-    expect(result.error).toBe('simulated handler failure');
+    await expect(genericJobWorkflow(input)).rejects.toMatchObject({
+      message: 'simulated handler failure',
+      type: 'GenericJobFailure',
+      nonRetryable: true,
+    });
 
     expect(mockActivities.updateJobStatus).toHaveBeenNthCalledWith(
       1,
@@ -137,6 +143,31 @@ describe('genericJobWorkflow', () => {
         stepName: 'execution_failed',
         status: 'failed',
       })
+    );
+  });
+
+  it('still executes the handler when pre-run bookkeeping fails', async () => {
+    mockActivities.updateJobStatus.mockRejectedValueOnce(
+      new Error('tracker row missing')
+    );
+    mockActivities.executeJobHandler.mockResolvedValue({
+      success: true,
+      result: { ok: true },
+    });
+
+    const { genericJobWorkflow } = await loadWorkflow();
+    const input: GenericJobInput = {
+      jobId: 'job-orphan-1',
+      jobName: 'rmm-alert-reconciliation',
+      tenantId: 'tenant-3',
+      data: { integrationId: 'integ-1' },
+    };
+
+    const result = await genericJobWorkflow(input);
+
+    expect(result.success).toBe(true);
+    expect(mockActivities.executeJobHandler).toHaveBeenCalledWith(
+      expect.objectContaining({ jobId: input.jobId, jobName: input.jobName })
     );
   });
 });

--- a/ee/temporal-workflows/src/workflows/generic-job-workflow.ts
+++ b/ee/temporal-workflows/src/workflows/generic-job-workflow.ts
@@ -6,6 +6,7 @@ import {
   log,
   sleep,
   workflowInfo,
+  ApplicationFailure,
 } from '@temporalio/workflow';
 import type { JobStatus } from '../types/job.js';
 
@@ -182,25 +183,39 @@ export async function genericJobWorkflow(
     state.step = 'executing';
     state.progress = 10;
 
-    await activities.updateJobStatus({
-      jobId,
-      tenantId,
-      status: 'processing' as JobStatus,
-      metadata: { workflowId: workflowInfo().workflowId },
-    });
+    // Status/detail tracking is bookkeeping — it must never block the actual
+    // job (a broken tracker row once kept handlers from running for 9 days
+    // while every run looked green).
+    try {
+      await activities.updateJobStatus({
+        jobId,
+        tenantId,
+        status: 'processing' as JobStatus,
+        metadata: { workflowId: workflowInfo().workflowId },
+      });
 
-    // Create a job detail for the execution start
-    await activities.createJobDetail({
-      jobId,
-      tenantId,
-      stepName: 'execution_started',
-      status: 'processing',
-      metadata: {
+      // Create a job detail for the execution start
+      await activities.createJobDetail({
+        jobId,
+        tenantId,
+        stepName: 'execution_started',
+        status: 'processing',
+        metadata: {
+          jobName,
+          workflowId: workflowInfo().workflowId,
+          startedAt: state.startedAt,
+        },
+      });
+    } catch (bookkeepingError) {
+      log.warn('Job bookkeeping failed before handler execution; continuing', {
+        jobId,
         jobName,
-        workflowId: workflowInfo().workflowId,
-        startedAt: state.startedAt,
-      },
-    });
+        error:
+          bookkeepingError instanceof Error
+            ? bookkeepingError.message
+            : String(bookkeepingError),
+      });
+    }
 
     state.progress = 20;
 
@@ -231,29 +246,40 @@ export async function genericJobWorkflow(
     state.progress = 100;
     state.completedAt = new Date().toISOString();
 
-    await activities.updateJobStatus({
-      jobId,
-      tenantId,
-      status: 'completed' as JobStatus,
-      metadata: {
-        workflowId: workflowInfo().workflowId,
-        completedAt: state.completedAt,
-      },
-    });
+    try {
+      await activities.updateJobStatus({
+        jobId,
+        tenantId,
+        status: 'completed' as JobStatus,
+        metadata: {
+          workflowId: workflowInfo().workflowId,
+          completedAt: state.completedAt,
+        },
+      });
 
-    // Create a job detail for the execution completion
-    await activities.createJobDetail({
-      jobId,
-      tenantId,
-      stepName: 'execution_completed',
-      status: 'completed',
-      metadata: {
+      // Create a job detail for the execution completion
+      await activities.createJobDetail({
+        jobId,
+        tenantId,
+        stepName: 'execution_completed',
+        status: 'completed',
+        metadata: {
+          jobName,
+          workflowId: workflowInfo().workflowId,
+          completedAt: state.completedAt,
+          result: result.result,
+        },
+      });
+    } catch (bookkeepingError) {
+      log.warn('Job bookkeeping failed after successful handler run', {
+        jobId,
         jobName,
-        workflowId: workflowInfo().workflowId,
-        completedAt: state.completedAt,
-        result: result.result,
-      },
-    });
+        error:
+          bookkeepingError instanceof Error
+            ? bookkeepingError.message
+            : String(bookkeepingError),
+      });
+    }
 
     log.info('Generic job workflow completed successfully', {
       jobId,
@@ -311,14 +337,16 @@ export async function genericJobWorkflow(
       });
     }
 
-    // Return a terminal failure result so schedule-driven workflows close cleanly.
-    // Re-throwing a plain Error here causes workflow-task failures and can leave
-    // the schedule run wedged in Running state.
-    return {
-      success: false,
-      jobId,
-      error: state.error,
-      completedAt: state.completedAt,
-    };
+    // Fail the workflow so the run is visible as FAILED in Temporal (returning
+    // a failure-shaped result showed every broken run as COMPLETED, which hid
+    // a multi-day outage). ApplicationFailure closes the run cleanly — the
+    // wedged-in-Running hazard only applies to non-Temporal errors, which fail
+    // the workflow task and retry forever.
+    throw ApplicationFailure.create({
+      message: state.error ?? 'Job handler failed',
+      type: 'GenericJobFailure',
+      nonRetryable: true,
+      details: [{ jobId, jobName, completedAt: state.completedAt }],
+    });
   }
 }

--- a/packages/jobs/src/lib/jobs/runners/TemporalJobRunner.ts
+++ b/packages/jobs/src/lib/jobs/runners/TemporalJobRunner.ts
@@ -282,6 +282,109 @@ export class TemporalJobRunner implements IJobRunner {
     const scheduleId =
       options?.singletonKey ?? `recurring-${jobName}-${data.tenantId}`;
 
+    const scheduleSpec = this.parseScheduleSpec(interval);
+    const ianaTimeZone = (options?.metadata as { timezone?: unknown })?.timezone;
+    const spec: Record<string, unknown> = { ...scheduleSpec };
+    if (typeof ianaTimeZone === 'string' && ianaTimeZone.trim().length > 0) {
+      // @temporalio/client encodeScheduleSpec reads `timezone` and maps it to protobuf timezoneName.
+      spec.timezone = ianaTimeZone.trim();
+    }
+
+    // Upsert, existence-first: convergence loops (RMM reconciler, accounting
+    // startup) re-invoke this with the same singletonKey on every pass. The
+    // tracker row is only created once we know the schedule needs it —
+    // creating it up-front leaked an orphan row per pass when the schedule
+    // already existed.
+    const existingHandle = this.client.schedule.getHandle(scheduleId);
+    let existingDescription: { action: { args?: unknown[] } } | null = null;
+    try {
+      existingDescription = (await existingHandle.describe()) as unknown as {
+        action: { args?: unknown[] };
+      };
+    } catch {
+      // Schedule doesn't exist, create it below
+    }
+
+    if (existingDescription) {
+      const bakedArgs = existingDescription.action.args?.[0] as
+        | { jobId?: string }
+        | undefined;
+      const bakedJobId = bakedArgs?.jobId;
+      const trackerExists = bakedJobId
+        ? await runWithTenant(data.tenantId, async () => {
+            const { knex } = await createTenantKnex();
+            const row = await tenantScopedTable(knex, 'jobs', data.tenantId)
+              .where({ job_id: bakedJobId })
+              .first('job_id');
+            return Boolean(row);
+          })
+        : false;
+
+      if (trackerExists && bakedJobId) {
+        await existingHandle.update((prev) => ({ ...prev, spec }));
+        logger.info('Updated existing recurring job schedule', {
+          scheduleId,
+          jobName,
+          interval,
+        });
+        return {
+          jobId: bakedJobId,
+          externalId: scheduleId,
+        };
+      }
+
+      // The schedule's baked-in jobId has no tracker row in this database
+      // (e.g. it was created against another environment): every fire fails
+      // its bookkeeping until the args are re-pointed at a row that exists.
+      const jobRecord = await this.createJobRecord(jobName, data, {
+        ...options,
+        singletonKey: scheduleId,
+        metadata: {
+          ...options?.metadata,
+          recurring: true,
+          interval,
+        },
+      });
+      try {
+        await existingHandle.update((prev) => ({
+          ...prev,
+          spec,
+          action: {
+            ...prev.action,
+            args: [
+              {
+                jobId: jobRecord.jobId,
+                jobName,
+                tenantId: data.tenantId,
+                data,
+              },
+            ],
+          } as typeof prev.action,
+        }));
+        await this.updateJobExternalIds(
+          jobRecord.jobId,
+          scheduleId,
+          null,
+          data.tenantId
+        );
+        logger.warn('Re-pointed recurring job schedule at a fresh tracker row', {
+          scheduleId,
+          jobName,
+          previousJobId: bakedJobId ?? null,
+          jobId: jobRecord.jobId,
+        });
+        return {
+          jobId: jobRecord.jobId,
+          externalId: scheduleId,
+        };
+      } catch (error) {
+        await this.updateJobStatus(jobRecord.jobId, data.tenantId, JobStatus.Failed, {
+          error: error instanceof Error ? error.message : String(error),
+        });
+        throw error;
+      }
+    }
+
     // Create job record in database
     const jobRecord = await this.createJobRecord(jobName, data, {
       ...options,
@@ -294,33 +397,6 @@ export class TemporalJobRunner implements IJobRunner {
     });
 
     try {
-      const scheduleSpec = this.parseScheduleSpec(interval);
-      const ianaTimeZone = (options?.metadata as { timezone?: unknown })?.timezone;
-      const spec: Record<string, unknown> = { ...scheduleSpec };
-      if (typeof ianaTimeZone === 'string' && ianaTimeZone.trim().length > 0) {
-        // @temporalio/client encodeScheduleSpec reads `timezone` and maps it to protobuf timezoneName.
-        spec.timezone = ianaTimeZone.trim();
-      }
-
-      // Upsert: callers (e.g. the RMM polling reconciler) re-invoke this with
-      // the same singletonKey when an interval changes, so an existing
-      // schedule gets its spec updated rather than being silently kept as-is.
-      try {
-        const existingHandle = this.client.schedule.getHandle(scheduleId);
-        await existingHandle.describe();
-        await existingHandle.update((prev) => ({ ...prev, spec }));
-        logger.info('Updated existing recurring job schedule', {
-          scheduleId,
-          jobName,
-          interval,
-        });
-        return {
-          jobId: jobRecord.jobId,
-          externalId: scheduleId,
-        };
-      } catch {
-        // Schedule doesn't exist, create it
-      }
       await this.client.schedule.create({
         scheduleId,
         spec,
@@ -400,6 +476,13 @@ export class TemporalJobRunner implements IJobRunner {
         }
         await this.updateJobStatus(jobId, tenantId, JobStatus.Failed, {
           error: 'Schedule cancelled',
+        });
+        // Null external_id so reconcilers see the tracker as torn down
+        // (pg-boss parity — external_id is the cross-backend liveness marker).
+        await runWithTenant(tenantId, async () => {
+          await tenantScopedTable(knex, 'jobs', tenantId)
+            .where({ job_id: jobId })
+            .update({ external_id: null, updated_at: new Date() });
         });
         return true;
       }


### PR DESCRIPTION
Recurring schedules bake one jobs-row id into their action args; when that tracker row is missing, every fire died at createJobDetail before the handler ran — while returning a success-shaped result that Temporal displayed as COMPLETED. Meanwhile each reconcile pass created an orphan pending row it could never see again (~13k rows/day).

- TemporalJobRunner.scheduleRecurringJob: check schedule existence first (no tracker row created on the converged path), and re-point the schedule args at a fresh row when the baked jobId has no parent; cancelJob nulls external_id on teardown (pg-boss parity)
- job-activities.updateJobStatus: recurring trackers return to 'queued' after each fire, run outcome kept in metadata.lastRunStatus
- genericJobWorkflow: bookkeeping is best-effort and can no longer block the handler; real failures throw ApplicationFailure so runs surface as FAILED instead of quietly completing

"Off with the bookkeeping!" cried the Queen of Workflows, but the genericJobWorkflow merely curtsied and ran the handler anyway — for it had learned, nine days down the rabbit hole, that a jobs row which was never born cannot be asked to die, and that a schedule pointing at nothing must simply be handed a fresh white rabbit to chase. 🐇⏰💥