### PR TITLE
Port outbound SMTP TLS controls and connection test to EE ManagedEmailSettings

### DIFF
--- a/ee/server/src/__tests__/unit/ManagedEmailSettings.actions.test.tsx
+++ b/ee/server/src/__tests__/unit/ManagedEmailSettings.actions.test.tsx
@@ -1,7 +1,9 @@
 // @vitest-environment jsdom
 import React from 'react';
 import { fireEvent, render, screen, waitFor } from '@testing-library/react';
-import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { beforeAll, beforeEach, describe, expect, it, vi } from 'vitest';
+import i18n from 'i18next';
+import emailProvidersEn from 'server/public/locales/en/msp/email-providers.json';
 import ManagedEmailSettings from '@ee/components/settings/email/ManagedEmailSettings';
 
 const {
@@ -12,6 +14,7 @@ const {
   getEmailSettingsMock,
   updateEmailSettingsMock,
   getEmailProvidersMock,
+  testOutboundEmailMock,
   toastSuccessMock,
   toastErrorMock,
 } = vi.hoisted(() => ({
@@ -22,6 +25,7 @@ const {
   getEmailSettingsMock: vi.fn(),
   updateEmailSettingsMock: vi.fn(),
   getEmailProvidersMock: vi.fn(),
+  testOutboundEmailMock: vi.fn(),
   toastSuccessMock: vi.fn(),
   toastErrorMock: vi.fn(),
 }));
@@ -37,6 +41,11 @@ vi.mock('@alga-psa/integrations/actions', () => ({
   getEmailSettings: getEmailSettingsMock,
   updateEmailSettings: updateEmailSettingsMock,
   getEmailProviders: getEmailProvidersMock,
+  testOutboundEmail: testOutboundEmailMock,
+}));
+
+vi.mock('server/src/context/TierContext', () => ({
+  useTier: () => ({ hasFeature: () => true }),
 }));
 
 vi.mock('react-hot-toast', () => ({
@@ -117,6 +126,25 @@ vi.mock('@alga-psa/ui/components/Tabs', () => ({
   TabsContent: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
 }));
 
+vi.mock('@alga-psa/ui/components/Switch', () => ({
+  Switch: ({
+    checked,
+    onCheckedChange,
+    id,
+  }: {
+    checked?: boolean;
+    onCheckedChange?: (checked: boolean) => void;
+    id?: string;
+  }) => (
+    <input
+      id={id}
+      type="checkbox"
+      checked={!!checked}
+      onChange={(event) => onCheckedChange?.(event.target.checked)}
+    />
+  ),
+}));
+
 vi.mock('@alga-psa/ui/components/CustomSelect', () => ({
   default: ({
     value,
@@ -165,6 +193,31 @@ const baseSettings = {
   updatedAt: new Date('2026-03-01T00:00:00.000Z'),
 };
 
+const smtpSettings = {
+  ...baseSettings,
+  emailProvider: 'smtp' as const,
+  providerConfigs: [
+    {
+      providerId: 'smtp-provider',
+      providerType: 'smtp' as const,
+      isEnabled: true,
+      config: {
+        host: 'relay.lan',
+        port: 587,
+        username: '',
+        password: '',
+        from: 'noreply@acme.com',
+      },
+    },
+  ],
+};
+
+beforeAll(() => {
+  // The shared test setup initializes i18next with empty resources; load the
+  // real English namespace so assertions can target user-visible strings.
+  i18n.addResourceBundle('en', 'msp/email-providers', emailProvidersEn, true, true);
+});
+
 describe('ManagedEmailSettings removal actions', () => {
   beforeEach(() => {
     getManagedEmailDomainsMock.mockReset();
@@ -174,6 +227,7 @@ describe('ManagedEmailSettings removal actions', () => {
     getEmailSettingsMock.mockReset();
     updateEmailSettingsMock.mockReset();
     getEmailProvidersMock.mockReset();
+    testOutboundEmailMock.mockReset();
     toastSuccessMock.mockReset();
     toastErrorMock.mockReset();
 
@@ -249,5 +303,109 @@ describe('ManagedEmailSettings removal actions', () => {
       );
     });
     expect(toastSuccessMock).toHaveBeenCalledWith('Domain removal scheduled and ticketing From address cleared');
+  });
+});
+
+describe('ManagedEmailSettings outbound SMTP test and TLS controls', () => {
+  beforeEach(() => {
+    getManagedEmailDomainsMock.mockReset();
+    requestManagedEmailDomainMock.mockReset();
+    refreshManagedEmailDomainMock.mockReset();
+    deleteManagedEmailDomainMock.mockReset();
+    getEmailSettingsMock.mockReset();
+    updateEmailSettingsMock.mockReset();
+    getEmailProvidersMock.mockReset();
+    testOutboundEmailMock.mockReset();
+    toastSuccessMock.mockReset();
+    toastErrorMock.mockReset();
+
+    getManagedEmailDomainsMock.mockResolvedValue([]);
+    getEmailSettingsMock.mockResolvedValue(smtpSettings);
+    updateEmailSettingsMock.mockResolvedValue(smtpSettings);
+    getEmailProvidersMock.mockResolvedValue({ providers: [] });
+  });
+
+  it('persists current edits and reports success from the connection test', async () => {
+    testOutboundEmailMock.mockResolvedValue({ success: true, message: 'SMTP connection verified.' });
+
+    render(<ManagedEmailSettings />);
+
+    const testButton = await screen.findByRole('button', { name: /test connection/i });
+    fireEvent.click(testButton);
+
+    await waitFor(() => {
+      expect(updateEmailSettingsMock).toHaveBeenCalledWith(
+        expect.objectContaining({ emailProvider: 'smtp' })
+      );
+      expect(testOutboundEmailMock).toHaveBeenCalledWith(undefined);
+    });
+    expect(await screen.findByText('SMTP connection verified.')).toBeInTheDocument();
+  });
+
+  it('surfaces the real provider error when the connection test fails', async () => {
+    testOutboundEmailMock.mockResolvedValue({
+      success: false,
+      error: 'self-signed certificate in certificate chain',
+    });
+
+    render(<ManagedEmailSettings />);
+
+    const testButton = await screen.findByRole('button', { name: /test connection/i });
+    fireEvent.click(testButton);
+
+    expect(
+      await screen.findByText('self-signed certificate in certificate chain')
+    ).toBeInTheDocument();
+  });
+
+  it('sends the test message to the entered recipient', async () => {
+    testOutboundEmailMock.mockResolvedValue({ success: true, message: 'Test email sent.' });
+
+    render(<ManagedEmailSettings />);
+
+    const recipientInput = await screen.findByLabelText(/send test to/i);
+    fireEvent.change(recipientInput, { target: { value: 'admin@acme.com' } });
+    fireEvent.click(screen.getByRole('button', { name: /test connection/i }));
+
+    await waitFor(() => {
+      expect(testOutboundEmailMock).toHaveBeenCalledWith('admin@acme.com');
+    });
+  });
+
+  it('persists the TLS security toggles with the SMTP config', async () => {
+    render(<ManagedEmailSettings />);
+
+    // rejectUnauthorized defaults to on; turning it off must be saved so
+    // self-signed LAN relays can be configured.
+    const verifyCertToggle = await waitFor(() => {
+      const el = document.getElementById('smtp-reject-unauthorized');
+      expect(el).not.toBeNull();
+      return el as HTMLInputElement;
+    });
+    expect(verifyCertToggle.checked).toBe(true);
+    fireEvent.click(verifyCertToggle);
+
+    const requireTlsToggle = document.getElementById('smtp-require-tls') as HTMLInputElement;
+    expect(requireTlsToggle.checked).toBe(false);
+    fireEvent.click(requireTlsToggle);
+
+    fireEvent.click(screen.getByRole('button', { name: /save smtp settings/i }));
+
+    await waitFor(() => {
+      expect(updateEmailSettingsMock).toHaveBeenCalledWith(
+        expect.objectContaining({
+          emailProvider: 'smtp',
+          providerConfigs: [
+            expect.objectContaining({
+              providerType: 'smtp',
+              config: expect.objectContaining({
+                rejectUnauthorized: false,
+                requireTLS: true,
+              }),
+            }),
+          ],
+        })
+      );
+    });
   });
 });

--- a/ee/server/src/components/settings/email/ManagedEmailSettings.tsx
+++ b/ee/server/src/components/settings/email/ManagedEmailSettings.tsx
@@ -15,7 +15,8 @@ import { Alert, AlertDescription, AlertTitle } from '@alga-psa/ui/components/Ale
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '@alga-psa/ui/components/Tabs';
 import { ConfirmationDialog } from '@alga-psa/ui/components/ConfirmationDialog';
 import CustomSelect from '@alga-psa/ui/components/CustomSelect';
-import { Globe, Send, Inbox, Mail, Eye, EyeOff, Lock } from 'lucide-react';
+import { Switch } from '@alga-psa/ui/components/Switch';
+import { Globe, Send, Inbox, Mail, Eye, EyeOff, Lock, CheckCircle, XCircle } from 'lucide-react';
 import { TIER_FEATURES } from '@alga-psa/types';
 import { useTier } from 'server/src/context/TierContext';
 import {
@@ -28,7 +29,7 @@ import {
 import { EmailProviderConfiguration } from '@alga-psa/integrations/components';
 import type { EmailProvider } from '@alga-psa/integrations/components';
 import type { TenantEmailSettings, EmailProviderConfig } from 'server/src/types/email.types';
-import { getEmailSettings, updateEmailSettings, getEmailProviders } from '@alga-psa/integrations/actions';
+import { getEmailSettings, updateEmailSettings, getEmailProviders, testOutboundEmail } from '@alga-psa/integrations/actions';
 import ManagedDomainList from './ManagedDomainList';
 
 type OutboundProvider = 'resend' | 'smtp';
@@ -106,6 +107,9 @@ export const ManagedEmailSettings: React.FC<EmailSettingsProps> = () => {
   const [outboundProvider, setOutboundProvider] = useState<OutboundProvider>('resend');
   const [showSmtpPassword, setShowSmtpPassword] = useState(false);
   const [savingSmtp, setSavingSmtp] = useState(false);
+  const [smtpTestRecipient, setSmtpTestRecipient] = useState('');
+  const [testingSmtp, setTestingSmtp] = useState(false);
+  const [smtpTestResult, setSmtpTestResult] = useState<{ success: boolean; message?: string; error?: string } | null>(null);
   const [pendingDomainRemoval, setPendingDomainRemoval] = useState<string | null>(null);
 
   useEffect(() => {
@@ -358,7 +362,7 @@ export const ManagedEmailSettings: React.FC<EmailSettingsProps> = () => {
     return emailSettings?.providerConfigs.find(c => c.providerType === 'smtp');
   };
 
-  const updateSmtpField = (field: string, value: string | number) => {
+  const updateSmtpField = (field: string, value: string | number | boolean) => {
     if (!emailSettings) return;
     const smtpConfig = getSmtpConfig();
     if (!smtpConfig) return;
@@ -371,34 +375,62 @@ export const ManagedEmailSettings: React.FC<EmailSettingsProps> = () => {
     setEmailSettings({ ...emailSettings, providerConfigs: updatedConfigs });
   };
 
-  const handleSaveSmtp = async () => {
+  const persistSmtpSettings = async (): Promise<TenantEmailSettings | null> => {
     const smtpConfig = getSmtpConfig();
-    if (!smtpConfig || !emailSettings) return;
+    if (!smtpConfig || !emailSettings) return null;
 
     const { host, from } = smtpConfig.config;
     if (!host?.trim()) {
       toast.error(t('managed.messages.smtpHostRequired'));
-      return;
+      return null;
     }
     if (!from?.trim()) {
       toast.error(t('managed.messages.fromAddressRequired'));
-      return;
+      return null;
     }
 
+    const updated = await updateEmailSettings({
+      emailProvider: 'smtp',
+      providerConfigs: emailSettings.providerConfigs,
+      defaultFromDomain: from.trim().split('@').pop() || emailSettings.defaultFromDomain
+    });
+    setEmailSettings(updated);
+    return updated;
+  };
+
+  const handleSaveSmtp = async () => {
     setSavingSmtp(true);
     try {
-      const updated = await updateEmailSettings({
-        emailProvider: 'smtp',
-        providerConfigs: emailSettings.providerConfigs,
-        defaultFromDomain: from.trim().split('@').pop() || emailSettings.defaultFromDomain
-      });
-      setEmailSettings(updated);
-      toast.success(t('managed.messages.smtpSaved'));
+      const updated = await persistSmtpSettings();
+      if (updated) {
+        toast.success(t('managed.messages.smtpSaved'));
+      }
     } catch (err: any) {
       console.error('[ManagedEmailSettings] Failed to save SMTP settings', err);
       toast.error(err.message || t('managed.messages.smtpSaveFailed'));
     } finally {
       setSavingSmtp(false);
+    }
+  };
+
+  const handleTestSmtp = async () => {
+    setTestingSmtp(true);
+    setSmtpTestResult(null);
+    try {
+      // Persist current edits first so the test reflects what's on screen.
+      // The masked password ('***') is resolved to the stored secret server-side.
+      const updated = await persistSmtpSettings();
+      if (!updated) return;
+      const result = await testOutboundEmail(smtpTestRecipient.trim() || undefined);
+      setSmtpTestResult(result);
+    } catch (err: any) {
+      console.error('[ManagedEmailSettings] Failed to test outbound email', err);
+      setSmtpTestResult({
+        success: false,
+        error: err?.message || t('managed.messages.testOutboundFailed')
+      });
+    } finally {
+      setTestingSmtp(false);
     }
   };
 
@@ -657,6 +689,10 @@ export const ManagedEmailSettings: React.FC<EmailSettingsProps> = () => {
                       </div>
                     </div>
 
+                    <p className="text-sm text-muted-foreground">
+                      {t('managed.outbound.smtp.authHint')}
+                    </p>
+
                     <div>
                       <Label htmlFor="smtp-from">{t('managed.outbound.smtp.fromLabel')}</Label>
                       <Input
@@ -670,14 +706,98 @@ export const ManagedEmailSettings: React.FC<EmailSettingsProps> = () => {
                       </p>
                     </div>
 
+                    <div className="border-t pt-4 space-y-4">
+                      <h4 className="text-sm font-medium">
+                        {t('managed.outbound.smtp.security.title')}
+                      </h4>
+
+                      <div className="flex items-center space-x-2">
+                        <Switch
+                          id="smtp-secure"
+                          checked={smtpConfig?.config.secure ?? (Number(smtpConfig?.config.port) === 465)}
+                          onCheckedChange={(checked: boolean) => updateSmtpField('secure', checked)}
+                        />
+                        <Label htmlFor="smtp-secure">
+                          {t('managed.outbound.smtp.security.secure')}
+                        </Label>
+                      </div>
+
+                      <div className="flex items-center space-x-2">
+                        <Switch
+                          id="smtp-require-tls"
+                          checked={smtpConfig?.config.requireTLS ?? false}
+                          onCheckedChange={(checked: boolean) => updateSmtpField('requireTLS', checked)}
+                        />
+                        <Label htmlFor="smtp-require-tls">
+                          {t('managed.outbound.smtp.security.requireTls')}
+                        </Label>
+                      </div>
+
+                      <div className="flex items-center space-x-2">
+                        <Switch
+                          id="smtp-reject-unauthorized"
+                          checked={smtpConfig?.config.rejectUnauthorized !== false}
+                          onCheckedChange={(checked: boolean) => updateSmtpField('rejectUnauthorized', checked)}
+                        />
+                        <Label htmlFor="smtp-reject-unauthorized">
+                          {t('managed.outbound.smtp.security.verifyCert')}
+                        </Label>
+                      </div>
+                      <p className="text-sm text-muted-foreground">
+                        {t('managed.outbound.smtp.security.verifyCertHint')}
+                      </p>
+                    </div>
+
                     <div className="flex justify-end">
                       <Button
                         id="save-smtp-settings"
                         onClick={handleSaveSmtp}
-                        disabled={savingSmtp || loadingOutbound}
+                        disabled={savingSmtp || testingSmtp || loadingOutbound}
                       >
                         {savingSmtp ? t('managed.outbound.smtp.savingButton') : t('managed.outbound.smtp.saveButton')}
                       </Button>
+                    </div>
+
+                    <div className="border-t pt-4 space-y-4">
+                      <h4 className="text-sm font-medium flex items-center gap-2">
+                        <Send className="h-4 w-4" />
+                        {t('managed.outbound.smtp.test.title')}
+                      </h4>
+                      <p className="text-sm text-muted-foreground">
+                        {t('managed.outbound.smtp.test.description')}
+                      </p>
+                      <div className="flex items-end gap-2">
+                        <div className="flex-1">
+                          <Label htmlFor="test-recipient">
+                            {t('managed.outbound.smtp.test.recipientLabel')}
+                          </Label>
+                          <Input
+                            id="test-recipient"
+                            type="email"
+                            value={smtpTestRecipient}
+                            placeholder={t('managed.outbound.smtp.test.recipientPlaceholder')}
+                            onChange={(e) => setSmtpTestRecipient(e.target.value)}
+                          />
+                        </div>
+                        <Button
+                          id="test-outbound-email"
+                          variant="outline"
+                          onClick={handleTestSmtp}
+                          disabled={testingSmtp || savingSmtp || loadingOutbound}
+                        >
+                          {testingSmtp
+                            ? t('managed.outbound.smtp.test.testingButton')
+                            : t('managed.outbound.smtp.test.runButton')}
+                        </Button>
+                      </div>
+                      {smtpTestResult && (
+                        <div className={`flex items-start gap-2 text-sm ${smtpTestResult.success ? 'text-green-600' : 'text-red-600'}`}>
+                          {smtpTestResult.success
+                            ? <CheckCircle className="h-4 w-4 mt-0.5 shrink-0" />
+                            : <XCircle className="h-4 w-4 mt-0.5 shrink-0" />}
+                          <span>{smtpTestResult.success ? smtpTestResult.message : smtpTestResult.error}</span>
+                        </div>
+                      )}
                     </div>
                   </div>
                 );

--- a/packages/integrations/src/actions/index.ts
+++ b/packages/integrations/src/actions/index.ts
@@ -74,7 +74,8 @@ export {
 } from './email-actions/emailDomainActions';
 export {
   getEmailSettings,
-  updateEmailSettings
+  updateEmailSettings,
+  testOutboundEmail
 } from './email-actions/emailSettingsActions';
 export {
   getInboundTicketDefaults,

--- a/server/public/locales/de/msp/email-providers.json
+++ b/server/public/locales/de/msp/email-providers.json
@@ -707,7 +707,8 @@
       "refreshStatusFailed": "Domainstatus konnte nicht aktualisiert werden",
       "domainRemovalScheduled": "Domainentfernung geplant",
       "domainRemovalScheduledWithClear": "Domainentfernung geplant und Ticketing-Absenderadresse gelöscht",
-      "removeDomainFailed": "Domain konnte nicht entfernt werden"
+      "removeDomainFailed": "Domain konnte nicht entfernt werden",
+      "testOutboundFailed": "Test der ausgehenden E-Mail fehlgeschlagen"
     },
     "tabs": {
       "inboundEmail": "Eingehende E-Mail",
@@ -741,11 +742,27 @@
         "usernamePlaceholder": "ihre-email@beispiel.de",
         "passwordLabel": "Passwort",
         "passwordPlaceholder": "Passwort eingeben",
+        "authHint": "Lassen Sie Benutzername und Passwort leer, wenn Ihr Relay E-Mails ohne Authentifizierung akzeptiert.",
         "fromLabel": "Absenderadresse",
         "fromPlaceholder": "noreply@beispiel.de",
         "fromHelp": "Die Standardabsenderadresse für ausgehende E-Mails.",
+        "security": {
+          "title": "Verbindungssicherheit",
+          "secure": "Implizites TLS verwenden (SSL beim Verbinden, üblicherweise Port 465)",
+          "requireTls": "STARTTLS-Upgrade erforderlich (Ports 587 / 25)",
+          "verifyCert": "Serverzertifikat überprüfen",
+          "verifyCertHint": "Deaktivieren Sie dies nur für ein vertrauenswürdiges Relay in Ihrem eigenen Netzwerk, das ein selbstsigniertes Zertifikat verwendet."
+        },
         "savingButton": "Speichern…",
-        "saveButton": "SMTP-Einstellungen speichern"
+        "saveButton": "SMTP-Einstellungen speichern",
+        "test": {
+          "title": "Ausgehende E-Mail testen",
+          "description": "Speichert die aktuellen Einstellungen und überprüft dann die Verbindung zum Anbieter. Geben Sie eine Adresse ein, um auch eine Testnachricht zu senden.",
+          "recipientLabel": "Test senden an (optional)",
+          "recipientPlaceholder": "sie@beispiel.com",
+          "testingButton": "Wird getestet...",
+          "runButton": "Verbindung testen"
+        }
       },
       "ticketingFrom": {
         "title": "Absenderadresse für Ticketing",

--- a/server/public/locales/en/msp/email-providers.json
+++ b/server/public/locales/en/msp/email-providers.json
@@ -707,7 +707,8 @@
       "refreshStatusFailed": "Failed to refresh domain status",
       "domainRemovalScheduled": "Domain removal scheduled",
       "domainRemovalScheduledWithClear": "Domain removal scheduled and ticketing From address cleared",
-      "removeDomainFailed": "Failed to remove domain"
+      "removeDomainFailed": "Failed to remove domain",
+      "testOutboundFailed": "Failed to test outbound email"
     },
     "tabs": {
       "inboundEmail": "Inbound Email",
@@ -741,11 +742,27 @@
         "usernamePlaceholder": "your-email@example.com",
         "passwordLabel": "Password",
         "passwordPlaceholder": "Enter password",
+        "authHint": "Leave username and password blank if your relay accepts mail without authentication.",
         "fromLabel": "From Address",
         "fromPlaceholder": "noreply@example.com",
         "fromHelp": "The default sender address for outbound emails.",
+        "security": {
+          "title": "Connection Security",
+          "secure": "Use implicit TLS (SSL on connect, typically port 465)",
+          "requireTls": "Require STARTTLS upgrade (ports 587 / 25)",
+          "verifyCert": "Verify server certificate",
+          "verifyCertHint": "Turn this off only for a trusted relay on your own network that uses a self-signed certificate."
+        },
         "savingButton": "Saving...",
-        "saveButton": "Save SMTP Settings"
+        "saveButton": "Save SMTP Settings",
+        "test": {
+          "title": "Test Outbound Email",
+          "description": "Saves the current settings, then verifies the provider connection. Enter an address to also send a test message.",
+          "recipientLabel": "Send test to (optional)",
+          "recipientPlaceholder": "you@example.com",
+          "testingButton": "Testing...",
+          "runButton": "Test Connection"
+        }
       },
       "ticketingFrom": {
         "title": "Ticketing From Address",

--- a/server/public/locales/es/msp/email-providers.json
+++ b/server/public/locales/es/msp/email-providers.json
@@ -707,7 +707,8 @@
       "refreshStatusFailed": "Error al actualizar el estado del dominio",
       "domainRemovalScheduled": "Eliminación de dominio programada",
       "domainRemovalScheduledWithClear": "Eliminación de dominio programada y dirección de remitente de tickets eliminada",
-      "removeDomainFailed": "Error al eliminar el dominio"
+      "removeDomainFailed": "Error al eliminar el dominio",
+      "testOutboundFailed": "Error al probar el correo saliente"
     },
     "tabs": {
       "inboundEmail": "Correo entrante",
@@ -741,11 +742,27 @@
         "usernamePlaceholder": "su-correo@ejemplo.com",
         "passwordLabel": "Contraseña",
         "passwordPlaceholder": "Introduzca la contraseña",
+        "authHint": "Deje el nombre de usuario y la contraseña en blanco si su retransmisor acepta correo sin autenticación.",
         "fromLabel": "Dirección de remitente",
         "fromPlaceholder": "noreply@ejemplo.com",
         "fromHelp": "Dirección de remitente predeterminada para los correos salientes.",
+        "security": {
+          "title": "Seguridad de la conexión",
+          "secure": "Usar TLS implícito (SSL al conectar, normalmente el puerto 465)",
+          "requireTls": "Requerir actualización STARTTLS (puertos 587 / 25)",
+          "verifyCert": "Verificar el certificado del servidor",
+          "verifyCertHint": "Desactive esto solo para un retransmisor de confianza en su propia red que use un certificado autofirmado."
+        },
         "savingButton": "Guardando…",
-        "saveButton": "Guardar configuración SMTP"
+        "saveButton": "Guardar configuración SMTP",
+        "test": {
+          "title": "Probar correo saliente",
+          "description": "Guarda la configuración actual y luego verifica la conexión con el proveedor. Introduzca una dirección para enviar también un mensaje de prueba.",
+          "recipientLabel": "Enviar prueba a (opcional)",
+          "recipientPlaceholder": "tu@ejemplo.com",
+          "testingButton": "Probando...",
+          "runButton": "Probar conexión"
+        }
       },
       "ticketingFrom": {
         "title": "Dirección de remitente de tickets",

--- a/server/public/locales/fr/msp/email-providers.json
+++ b/server/public/locales/fr/msp/email-providers.json
@@ -707,7 +707,8 @@
       "refreshStatusFailed": "Échec de l'actualisation du statut du domaine",
       "domainRemovalScheduled": "Suppression du domaine planifiée",
       "domainRemovalScheduledWithClear": "Suppression du domaine planifiée et adresse d'expéditeur de ticket effacée",
-      "removeDomainFailed": "Échec de la suppression du domaine"
+      "removeDomainFailed": "Échec de la suppression du domaine",
+      "testOutboundFailed": "Échec du test de l'e-mail sortant"
     },
     "tabs": {
       "inboundEmail": "E-mail entrant",
@@ -741,11 +742,27 @@
         "usernamePlaceholder": "votre-email@exemple.com",
         "passwordLabel": "Mot de passe",
         "passwordPlaceholder": "Saisissez le mot de passe",
+        "authHint": "Laissez le nom d'utilisateur et le mot de passe vides si votre relais accepte les e-mails sans authentification.",
         "fromLabel": "Adresse d'expéditeur",
         "fromPlaceholder": "noreply@exemple.com",
         "fromHelp": "Adresse d'expéditeur par défaut pour les e-mails sortants.",
+        "security": {
+          "title": "Sécurité de la connexion",
+          "secure": "Utiliser le TLS implicite (SSL à la connexion, généralement le port 465)",
+          "requireTls": "Exiger la mise à niveau STARTTLS (ports 587 / 25)",
+          "verifyCert": "Vérifier le certificat du serveur",
+          "verifyCertHint": "Ne désactivez cette option que pour un relais de confiance sur votre propre réseau utilisant un certificat auto-signé."
+        },
         "savingButton": "Enregistrement…",
-        "saveButton": "Enregistrer les paramètres SMTP"
+        "saveButton": "Enregistrer les paramètres SMTP",
+        "test": {
+          "title": "Tester l'e-mail sortant",
+          "description": "Enregistre les paramètres actuels, puis vérifie la connexion au fournisseur. Saisissez une adresse pour envoyer aussi un message de test.",
+          "recipientLabel": "Envoyer le test à (facultatif)",
+          "recipientPlaceholder": "vous@exemple.com",
+          "testingButton": "Test en cours...",
+          "runButton": "Tester la connexion"
+        }
       },
       "ticketingFrom": {
         "title": "Adresse d'expéditeur de ticket",

--- a/server/public/locales/it/msp/email-providers.json
+++ b/server/public/locales/it/msp/email-providers.json
@@ -707,7 +707,8 @@
       "refreshStatusFailed": "Impossibile aggiornare lo stato del dominio",
       "domainRemovalScheduled": "Rimozione del dominio pianificata",
       "domainRemovalScheduledWithClear": "Rimozione del dominio pianificata e indirizzo mittente per ticketing cancellato",
-      "removeDomainFailed": "Impossibile rimuovere il dominio"
+      "removeDomainFailed": "Impossibile rimuovere il dominio",
+      "testOutboundFailed": "Test dell'e-mail in uscita non riuscito"
     },
     "tabs": {
       "inboundEmail": "Email in entrata",
@@ -741,11 +742,27 @@
         "usernamePlaceholder": "la-tua-email@esempio.it",
         "passwordLabel": "Password",
         "passwordPlaceholder": "Inserisci la password",
+        "authHint": "Lascia vuoti nome utente e password se il tuo relay accetta la posta senza autenticazione.",
         "fromLabel": "Indirizzo mittente",
         "fromPlaceholder": "noreply@esempio.it",
         "fromHelp": "Indirizzo mittente predefinito per le email in uscita.",
+        "security": {
+          "title": "Sicurezza della connessione",
+          "secure": "Usa TLS implicito (SSL alla connessione, in genere porta 465)",
+          "requireTls": "Richiedi l'aggiornamento STARTTLS (porte 587 / 25)",
+          "verifyCert": "Verifica il certificato del server",
+          "verifyCertHint": "Disattiva questa opzione solo per un relay attendibile sulla tua rete che utilizza un certificato autofirmato."
+        },
         "savingButton": "Salvataggio…",
-        "saveButton": "Salva impostazioni SMTP"
+        "saveButton": "Salva impostazioni SMTP",
+        "test": {
+          "title": "Prova e-mail in uscita",
+          "description": "Salva le impostazioni attuali, quindi verifica la connessione al provider. Inserisci un indirizzo per inviare anche un messaggio di prova.",
+          "recipientLabel": "Invia prova a (facoltativo)",
+          "recipientPlaceholder": "tu@esempio.com",
+          "testingButton": "Prova in corso...",
+          "runButton": "Prova connessione"
+        }
       },
       "ticketingFrom": {
         "title": "Indirizzo mittente per ticketing",

--- a/server/public/locales/nl/msp/email-providers.json
+++ b/server/public/locales/nl/msp/email-providers.json
@@ -707,7 +707,8 @@
       "refreshStatusFailed": "Kan domeinstatus niet vernieuwen",
       "domainRemovalScheduled": "Domeinverwijdering gepland",
       "domainRemovalScheduledWithClear": "Domeinverwijdering gepland en afzenderadres voor ticketing gewist",
-      "removeDomainFailed": "Kan domein niet verwijderen"
+      "removeDomainFailed": "Kan domein niet verwijderen",
+      "testOutboundFailed": "Testen van uitgaande e-mail mislukt"
     },
     "tabs": {
       "inboundEmail": "Inkomende e-mail",
@@ -741,11 +742,27 @@
         "usernamePlaceholder": "uw-email@voorbeeld.nl",
         "passwordLabel": "Wachtwoord",
         "passwordPlaceholder": "Voer wachtwoord in",
+        "authHint": "Laat gebruikersnaam en wachtwoord leeg als uw relay e-mail zonder authenticatie accepteert.",
         "fromLabel": "Afzenderadres",
         "fromPlaceholder": "noreply@voorbeeld.nl",
         "fromHelp": "Het standaard afzenderadres voor uitgaande e-mails.",
+        "security": {
+          "title": "Verbindingsbeveiliging",
+          "secure": "Impliciete TLS gebruiken (SSL bij verbinden, doorgaans poort 465)",
+          "requireTls": "STARTTLS-upgrade vereisen (poorten 587 / 25)",
+          "verifyCert": "Servercertificaat verifiëren",
+          "verifyCertHint": "Schakel dit alleen uit voor een vertrouwde relay op uw eigen netwerk met een zelfondertekend certificaat."
+        },
         "savingButton": "Opslaan…",
-        "saveButton": "SMTP-instellingen opslaan"
+        "saveButton": "SMTP-instellingen opslaan",
+        "test": {
+          "title": "Uitgaande e-mail testen",
+          "description": "Slaat de huidige instellingen op en verifieert vervolgens de verbinding met de provider. Voer een adres in om ook een testbericht te verzenden.",
+          "recipientLabel": "Test verzenden naar (optioneel)",
+          "recipientPlaceholder": "jij@voorbeeld.com",
+          "testingButton": "Bezig met testen...",
+          "runButton": "Verbinding testen"
+        }
       },
       "ticketingFrom": {
         "title": "Afzenderadres voor ticketing",

--- a/server/public/locales/pl/msp/email-providers.json
+++ b/server/public/locales/pl/msp/email-providers.json
@@ -707,7 +707,8 @@
       "refreshStatusFailed": "Nie udało się odświeżyć stanu domeny",
       "domainRemovalScheduled": "Zaplanowano usunięcie domeny",
       "domainRemovalScheduledWithClear": "Zaplanowano usunięcie domeny i wyczyszczono adres nadawcy zgłoszeń",
-      "removeDomainFailed": "Nie udało się usunąć domeny"
+      "removeDomainFailed": "Nie udało się usunąć domeny",
+      "testOutboundFailed": "Nie udało się przetestować poczty wychodzącej"
     },
     "tabs": {
       "inboundEmail": "Poczta przychodząca",
@@ -741,11 +742,27 @@
         "usernamePlaceholder": "twoj-email@przyklad.pl",
         "passwordLabel": "Hasło",
         "passwordPlaceholder": "Wprowadź hasło",
+        "authHint": "Pozostaw nazwę użytkownika i hasło puste, jeśli przekaźnik akceptuje pocztę bez uwierzytelniania.",
         "fromLabel": "Adres nadawcy",
         "fromPlaceholder": "noreply@przyklad.pl",
         "fromHelp": "Domyślny adres nadawcy dla poczty wychodzącej.",
+        "security": {
+          "title": "Bezpieczeństwo połączenia",
+          "secure": "Użyj niejawnego TLS (SSL przy połączeniu, zwykle port 465)",
+          "requireTls": "Wymagaj uaktualnienia STARTTLS (porty 587 / 25)",
+          "verifyCert": "Weryfikuj certyfikat serwera",
+          "verifyCertHint": "Wyłącz tę opcję tylko dla zaufanego przekaźnika we własnej sieci używającego certyfikatu z podpisem własnym."
+        },
         "savingButton": "Zapisywanie…",
-        "saveButton": "Zapisz ustawienia SMTP"
+        "saveButton": "Zapisz ustawienia SMTP",
+        "test": {
+          "title": "Przetestuj pocztę wychodzącą",
+          "description": "Zapisuje bieżące ustawienia, a następnie weryfikuje połączenie z dostawcą. Wpisz adres, aby wysłać także wiadomość testową.",
+          "recipientLabel": "Wyślij test do (opcjonalnie)",
+          "recipientPlaceholder": "ty@przyklad.com",
+          "testingButton": "Testowanie...",
+          "runButton": "Testuj połączenie"
+        }
       },
       "ticketingFrom": {
         "title": "Adres nadawcy zgłoszeń",

--- a/server/public/locales/pt/msp/email-providers.json
+++ b/server/public/locales/pt/msp/email-providers.json
@@ -707,7 +707,8 @@
       "refreshStatusFailed": "Falha ao atualizar o status do domínio",
       "domainRemovalScheduled": "Remoção de domínio agendada",
       "domainRemovalScheduledWithClear": "Remoção de domínio agendada e emissão de tickets Do endereço apagado",
-      "removeDomainFailed": "Falha ao remover o domínio"
+      "removeDomainFailed": "Falha ao remover o domínio",
+      "testOutboundFailed": "Falha ao testar o e-mail de saída"
     },
     "tabs": {
       "inboundEmail": "E-mail de entrada",
@@ -741,11 +742,27 @@
         "usernamePlaceholder": "seu-e-mail@exemplo.com",
         "passwordLabel": "Senha",
         "passwordPlaceholder": "Digite a senha",
+        "authHint": "Deixe o nome de usuário e a senha em branco se o seu relay aceitar e-mails sem autenticação.",
         "fromLabel": "Do endereço",
         "fromPlaceholder": "noreply@example.com",
         "fromHelp": "O endereço do remetente padrão para e-mails enviados.",
+        "security": {
+          "title": "Segurança da conexão",
+          "secure": "Usar TLS implícito (SSL ao conectar, normalmente a porta 465)",
+          "requireTls": "Exigir atualização STARTTLS (portas 587 / 25)",
+          "verifyCert": "Verificar o certificado do servidor",
+          "verifyCertHint": "Desative isto apenas para um relay confiável na sua própria rede que use um certificado autoassinado."
+        },
         "savingButton": "Salvando...",
-        "saveButton": "Salvar configurações SMTP"
+        "saveButton": "Salvar configurações SMTP",
+        "test": {
+          "title": "Testar e-mail de saída",
+          "description": "Salva as configurações atuais e depois verifica a conexão com o provedor. Insira um endereço para também enviar uma mensagem de teste.",
+          "recipientLabel": "Enviar teste para (opcional)",
+          "recipientPlaceholder": "voce@exemplo.com",
+          "testingButton": "Testando...",
+          "runButton": "Testar conexão"
+        }
       },
       "ticketingFrom": {
         "title": "Emissão de tickets no endereço",

--- a/server/public/locales/xx/msp/email-providers.json
+++ b/server/public/locales/xx/msp/email-providers.json
@@ -707,7 +707,8 @@
       "refreshStatusFailed": "11111",
       "domainRemovalScheduled": "11111",
       "domainRemovalScheduledWithClear": "11111",
-      "removeDomainFailed": "11111"
+      "removeDomainFailed": "11111",
+      "testOutboundFailed": "11111"
     },
     "tabs": {
       "inboundEmail": "11111",
@@ -741,11 +742,27 @@
         "usernamePlaceholder": "11111",
         "passwordLabel": "11111",
         "passwordPlaceholder": "11111",
+        "authHint": "11111",
         "fromLabel": "11111",
         "fromPlaceholder": "11111",
         "fromHelp": "11111",
+        "security": {
+          "title": "11111",
+          "secure": "11111",
+          "requireTls": "11111",
+          "verifyCert": "11111",
+          "verifyCertHint": "11111"
+        },
         "savingButton": "11111",
-        "saveButton": "11111"
+        "saveButton": "11111",
+        "test": {
+          "title": "11111",
+          "description": "11111",
+          "recipientLabel": "11111",
+          "recipientPlaceholder": "11111",
+          "testingButton": "11111",
+          "runButton": "11111"
+        }
       },
       "ticketingFrom": {
         "title": "11111",

--- a/server/public/locales/xx/msp/settings.json
+++ b/server/public/locales/xx/msp/settings.json
@@ -1180,7 +1180,7 @@
         "step3": "11111",
         "step4": "11111",
         "docLinkText": "11111",
-        "neverSeenWarning": "11111"
+        "neverSeenWarning": "11111 {{domain}} 11111"
       },
       "badges": {
         "pending_dns": "11111",

--- a/server/public/locales/yy/msp/email-providers.json
+++ b/server/public/locales/yy/msp/email-providers.json
@@ -707,7 +707,8 @@
       "refreshStatusFailed": "55555",
       "domainRemovalScheduled": "55555",
       "domainRemovalScheduledWithClear": "55555",
-      "removeDomainFailed": "55555"
+      "removeDomainFailed": "55555",
+      "testOutboundFailed": "55555"
     },
     "tabs": {
       "inboundEmail": "55555",
@@ -741,11 +742,27 @@
         "usernamePlaceholder": "55555",
         "passwordLabel": "55555",
         "passwordPlaceholder": "55555",
+        "authHint": "55555",
         "fromLabel": "55555",
         "fromPlaceholder": "55555",
         "fromHelp": "55555",
+        "security": {
+          "title": "55555",
+          "secure": "55555",
+          "requireTls": "55555",
+          "verifyCert": "55555",
+          "verifyCertHint": "55555"
+        },
         "savingButton": "55555",
-        "saveButton": "55555"
+        "saveButton": "55555",
+        "test": {
+          "title": "55555",
+          "description": "55555",
+          "recipientLabel": "55555",
+          "recipientPlaceholder": "55555",
+          "testingButton": "55555",
+          "runButton": "55555"
+        }
       },
       "ticketingFrom": {
         "title": "55555",

--- a/server/public/locales/yy/msp/settings.json
+++ b/server/public/locales/yy/msp/settings.json
@@ -1180,7 +1180,7 @@
         "step3": "55555",
         "step4": "55555",
         "docLinkText": "55555",
-        "neverSeenWarning": "55555"
+        "neverSeenWarning": "55555 {{domain}} 55555"
       },
       "badges": {
         "pending_dns": "55555",


### PR DESCRIPTION
## Summary

Follow-up to #2823 for ticket alga0002046 ("Appliance outbound SMTP fails with misleading 'Email service is disabled or not configured'").

#2823 added no-auth relay support, TLS controls, and a Test Connection card for outbound SMTP — but the UI half landed only in the OSS `EmailSettings.tsx`. The appliance runs enterprise edition, which renders the EE `ManagedEmailSettings.tsx` instead (`@ee` alias), so none of those controls reached the reporter. This PR ports them to the EE component:

- **Connection Security toggles** on the outbound SMTP card — implicit TLS (`secure`), Require STARTTLS (`requireTLS`), and Verify server certificate (`rejectUnauthorized`, with self-signed-relay hint) — wired to the same config fields the backend already reads. Unblocks self-signed LAN relays.
- **Test Connection section** on the SMTP card — persists current edits (masked `***` password resolves to the stored secret server-side), runs the existing `testOutboundEmail` action, and surfaces the real provider error instead of a generic message; optional recipient field sends a test message.
- **No-auth hint** under username/password, matching the OSS form.
- Export `testOutboundEmail` from the integrations actions barrel (previously only in the email-actions sub-barrel).
- Add the 13 new `msp/email-providers` i18n keys across all 10 locales, reusing the translations #2823 added to `msp/admin`; regenerated `xx`/`yy` pseudo-locales (also picks up stale `neverSeenWarning` `{{domain}}` drift in `msp/settings`).
- Repair `ManagedEmailSettings.actions.test.tsx`, which was failing on main (`useTier` outside `TierProvider`, empty i18n resources; CI excludes the `sebastian-ee` unit suite so it went unnoticed) and add 4 tests covering the new SMTP connection test and TLS toggle flows.

## Verification

- `nx typecheck sebastian-ee` and `nx typecheck @alga-psa/integrations` clean
- EE unit suite `ManagedEmailSettings.actions.test.tsx` 6/6 passing (2 repaired + 4 new)
- Integrations email-actions tests 8/8 passing
- `scripts/validate-translations.cjs` and `scripts/find-missing-i18n-keys.cjs` both pass

Still open after merge: live UI smoke test of the Outbound Email tab on the appliance/dev.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MLncqkn5oWX8eetRuKN6nY

---
_Generated by [Claude Code](https://claude.ai/code/session_01MLncqkn5oWX8eetRuKN6nY)_