### PR TITLE
feat(appliance): surface "update available" in status UI and document the upgrade path

### DIFF
--- a/ee/appliance/host-service/server.mjs
+++ b/ee/appliance/host-service/server.mjs
@@ -498,6 +498,31 @@ const manageKube = {
   }
 };
 
+// Resolve the channel's current release manifest (best-effort, cached 60s).
+// /api/manage/status is polled by the Manage view and, since the Overview
+// gained an "update available" banner, by the status page too — without this
+// cache every poll would hit the OCI registry twice. On a resolve failure the
+// last-known-good value is kept so update availability doesn't flap during
+// transient registry hiccups.
+// LEVERAGE: pattern appliance-channel-digest-drift — same TTL/last-good shape
+// as resolveControlPlaneRef below.
+const RELEASE_RESOLVE_TTL_MS = 60_000;
+const releaseResolveCache = new Map();
+function resolveReleaseManifestCached(reference, options = {}) {
+  const key = `${options.registryHost || ''}|${options.releaseRepository || ''}|${String(reference || 'stable')}`;
+  const cached = releaseResolveCache.get(key);
+  if (cached && (Date.now() - cached.at) < RELEASE_RESOLVE_TTL_MS) {
+    return Promise.resolve(cached.value);
+  }
+  return resolveReleaseManifest(reference, options).then((value) => {
+    releaseResolveCache.set(key, { value, at: Date.now() });
+    return value;
+  }).catch((error) => {
+    if (cached) return cached.value;
+    throw error;
+  });
+}
+
 // Resolve the channel-pinned control-plane image ref (best-effort, cached 60s)
 // by running the same resolver bootstrap-control-plane.sh uses.
 const CP_RESOLVE_TTL_MS = 60_000;
@@ -985,7 +1010,7 @@ const server = http.createServer(async (req, res) => {
       installStateFile: stateFile,
       cpUpgradeStatusFile,
       resolveControlPlaneRef,
-      resolveReleaseManifest
+      resolveReleaseManifest: resolveReleaseManifestCached
     });
     jsonResponse(res, 200, status);
     return;

--- a/ee/appliance/status-ui/app/manage/ManageView.tsx
+++ b/ee/appliance/status-ui/app/manage/ManageView.tsx
@@ -128,6 +128,11 @@ function UpdatesTab({
   return (
     <div className={styles.manageSection}>
       <h2>App updates</h2>
+      <p className={styles.helpText}>
+        The appliance checks the {app.channel} release channel for newer
+        versions but never applies them automatically — updates run only when
+        you start them here.
+      </p>
       <dl className={styles.kv}>
         <div>
           <dt>Current version</dt>
@@ -751,20 +756,35 @@ export function ManageView() {
     <div className={styles.manageView}>
       {/* Sub-tab strip */}
       <div className={styles.manageTabStrip} role="tablist" aria-label="Manage sections">
-        {manageTabs.map(({ value, label }) => (
-          <button
-            key={value}
-            type="button"
-            role="tab"
-            id={`manage-tab-${value}`}
-            aria-selected={activeTab === value}
-            aria-controls={`manage-panel-${value}`}
-            className={`${styles.manageTabButton} ${activeTab === value ? styles.manageTabActive : ""}`}
-            onClick={() => setActiveTab(value)}
-          >
-            {label}
-          </button>
-        ))}
+        {manageTabs.map(({ value, label }) => {
+          // Dot the tab that has something to apply, so "update available" is
+          // visible from any Manage sub-tab without opening each one.
+          const hasUpdate =
+            (value === "updates" && Boolean(manageStatus?.app.updateAvailable)) ||
+            (value === "control-plane" &&
+              Boolean(manageStatus?.controlPlane.upgradeAvailable));
+          return (
+            <button
+              key={value}
+              type="button"
+              role="tab"
+              id={`manage-tab-${value}`}
+              aria-selected={activeTab === value}
+              aria-controls={`manage-panel-${value}`}
+              className={`${styles.manageTabButton} ${activeTab === value ? styles.manageTabActive : ""}`}
+              onClick={() => setActiveTab(value)}
+            >
+              {label}
+              {hasUpdate ? (
+                <span
+                  className={styles.updateDot}
+                  title="Update available"
+                  aria-label="Update available"
+                />
+              ) : null}
+            </button>
+          );
+        })}
         <button
           type="button"
           className={styles.manageRefreshButton}

--- a/ee/appliance/status-ui/app/page.tsx
+++ b/ee/appliance/status-ui/app/page.tsx
@@ -34,6 +34,19 @@ type EventItem = {
   timestamp?: string | null;
 };
 type SetupConfigResponse = { mode?: string };
+// Slice of /api/manage/status the status page needs to surface "update
+// available" outside the Manage view (Overview banner + sidebar badge).
+type ManageSummary = {
+  app?: {
+    version?: string | null;
+    channel?: string;
+    updateAvailable?: boolean;
+    availableVersion?: string | null;
+  };
+  controlPlane?: {
+    upgradeAvailable?: boolean;
+  };
+};
 type StatusResponse = {
   status?: string;
   // True when setup is blocked on a correctable install code; the UI offers a
@@ -315,6 +328,9 @@ export default function StatusPage() {
   const [topView, setTopView] = useState<TopView>("status");
   const [activeTab, setActiveTab] = useState<Tab>("overview");
   const [status, setStatus] = useState<StatusResponse | null>(null);
+  const [manageSummary, setManageSummary] = useState<ManageSummary | null>(
+    null,
+  );
   const [setupMode, setSetupMode] = useState<string | null>(null);
   const [error, setError] = useState<string | null>(null);
   const [recovering, setRecovering] = useState(false);
@@ -377,6 +393,23 @@ export default function StatusPage() {
         statusAbortController.current = null;
         setLoadingStatus(false);
       }
+    }
+  }, []);
+
+  // Best-effort update-availability check so the Overview can surface "update
+  // available" without the operator opening Manage. Polled on its own slow
+  // cadence: the endpoint resolves the release channel from the registry
+  // (60s-cached server-side), and availability changes rarely.
+  const loadManageSummary = useCallback(async () => {
+    try {
+      const response = await fetch(apiPath("/api/manage/status"), {
+        credentials: "same-origin",
+        cache: "no-store",
+      });
+      if (!response.ok) return; // keep the last snapshot; banner is best-effort
+      setManageSummary((await response.json()) as ManageSummary);
+    } catch {
+      /* keep the last snapshot across transient failures */
     }
   }, []);
 
@@ -558,6 +591,12 @@ export default function StatusPage() {
   }, [loadNamespaces, loadStatus]);
 
   useEffect(() => {
+    loadManageSummary();
+    const timer = setInterval(loadManageSummary, 60000);
+    return () => clearInterval(timer);
+  }, [loadManageSummary]);
+
+  useEffect(() => {
     if (activeTab === "deployments") loadDeployments();
     if (activeTab === "pods" || activeTab === "logs") loadPods();
   }, [activeTab, loadDeployments, loadPods]);
@@ -612,6 +651,11 @@ export default function StatusPage() {
     status?.rollup?.nextAction ||
     status?.installState?.lastAction ||
     "Waiting for the next appliance update";
+  const appUpdateAvailable = Boolean(manageSummary?.app?.updateAvailable);
+  const cpUpgradeAvailable = Boolean(
+    manageSummary?.controlPlane?.upgradeAvailable,
+  );
+  const anyUpdateAvailable = appUpdateAvailable || cpUpgradeAvailable;
 
   useEffect(() => {
     setActiveMatch(0);
@@ -678,6 +722,13 @@ export default function StatusPage() {
         >
           <Settings2 className={styles.navIcon} aria-hidden="true" />
           <span>Manage</span>
+          {anyUpdateAvailable ? (
+            <span
+              className={`${styles.updateDot} ${styles.updateDotEnd}`}
+              title="Update available"
+              aria-label="Update available"
+            />
+          ) : null}
         </button>
         <LogoutButton />
       </aside>
@@ -739,6 +790,39 @@ export default function StatusPage() {
             <a className={styles.primaryButton} href="/setup/">
               Re-enter install code
             </a>
+          </div>
+        ) : null}
+
+        {anyUpdateAvailable && setupMode !== "setup" ? (
+          <div className={styles.setupCta} role="status">
+            <div>
+              <strong>
+                {appUpdateAvailable
+                  ? "Update available"
+                  : "Control-plane update available"}
+              </strong>
+              <p>
+                {appUpdateAvailable
+                  ? `A newer Alga PSA version${
+                      manageSummary?.app?.availableVersion
+                        ? ` (${manageSummary.app.availableVersion})`
+                        : ""
+                    } is available on the ${
+                      manageSummary?.app?.channel || "stable"
+                    } channel. The appliance does not update itself — apply it from Manage → Updates.`
+                  : "A newer appliance setup & manage UI (control plane) is available. Apply it from Manage → Control-plane, or reboot the appliance to pick it up at boot."}
+                {appUpdateAvailable && cpUpgradeAvailable
+                  ? " A control-plane (setup & manage UI) update is also available."
+                  : ""}
+              </p>
+            </div>
+            <button
+              type="button"
+              className={styles.primaryButton}
+              onClick={() => setTopView("manage")}
+            >
+              Open Manage
+            </button>
           </div>
         ) : null}
 

--- a/ee/appliance/status-ui/app/status.module.css
+++ b/ee/appliance/status-ui/app/status.module.css
@@ -156,6 +156,29 @@
   text-decoration: none;
 }
 
+/* Small "update available" indicator used on the sidebar Manage button and the
+   Manage sub-tab buttons. */
+.updateDot {
+  display: inline-block;
+  flex: 0 0 auto;
+  width: 8px;
+  height: 8px;
+  border-radius: 999px;
+  background: var(--operator-purple);
+  box-shadow: 0 0 0 3px
+    color-mix(in oklch, var(--operator-purple) 22%, transparent);
+}
+
+.updateDotEnd {
+  margin-left: auto;
+}
+
+/* Inside the (non-flex) manage sub-tab buttons the dot sits after the label. */
+.manageTabButton .updateDot {
+  margin-left: 8px;
+  vertical-align: middle;
+}
+
 .sidebar > .setupLink {
   margin-top: var(--space-xl);
 }

--- a/ee/docs/appliance/README.md
+++ b/ee/docs/appliance/README.md
@@ -21,6 +21,7 @@ Ubuntu Server 24.04 LTS is the supported appliance OS path for v1. Talos applian
 
 ## Support Boundary
 
-- Supported v1 update automation: Alga app-channel updates (`stable`/`nightly`) through host status UI.
+- Supported v1 update automation: Alga app-channel updates (`stable`/`nightly`) through the host status UI. Updates are operator-initiated — the appliance surfaces "Update available" but never applies an app update on its own.
+- Applied automatically: the appliance control plane (setup/status UI) refreshes to the channel's current image at boot when the registry is reachable; it can also be upgraded in place from Manage → Control-plane.
 - Not automated in v1: Ubuntu package updates and k3s version upgrades.
 - v2 direction: managed maintenance windows for OS/k3s upgrades, with preflight, history, and remediation guidance.

--- a/ee/docs/appliance/operators-manual.md
+++ b/ee/docs/appliance/operators-manual.md
@@ -7,7 +7,8 @@ This manual covers day-2 operation for installed Ubuntu appliances.
 - Setup/Status plane: `http://<node-ip>:8080`
 - Setup flow: `http://<node-ip>:8080/setup?token=<setup-token>`
 - Support bundle: `http://<node-ip>:8080/support-bundle?token=<status-token>`
-- App updates: `http://<node-ip>:8080/updates?token=<status-token>`
+- App updates: Manage → Updates in the status UI (legacy form:
+  `http://<node-ip>:8080/updates?token=<status-token>`)
 
 ## Status And Failures
 
@@ -33,18 +34,38 @@ Bundle includes:
 - disk usage
 - release-selection metadata
 
-## App-Channel Updates
+## Updates And The Upgrade Path
 
-Use updates UI to apply `stable` or `nightly` channel changes.
+The appliance does **not** update the Alga PSA application by itself. It checks
+the selected release channel (`stable` or `nightly`), surfaces "Update
+available" in the UI, and waits for an operator to apply the update. Moving
+between versions — including minor jumps such as 1.1.x -> 1.2.x — is this same
+operator-initiated flow: once the new release is published to your channel, the
+appliance shows it as available and one click applies it. There is nothing to
+stage or download manually.
 
-Update flow:
+What updates how:
+
+- **Alga PSA application** (the version in Manage → Updates): operator-initiated.
+  When the channel points at a newer release, the status Overview shows an
+  "Update available" banner and the Manage button gains an indicator dot; the
+  Manage → Updates tab shows the available version and a "Run update" button.
+- **Appliance control plane** (the setup/status/manage UI on port `8080`):
+  refreshed automatically at boot when the release channel is reachable — a
+  registry failure keeps the currently installed image and never rolls back —
+  and can also be upgraded in place from Manage → Control-plane.
+- **Ubuntu OS and k3s**: not automated in v1; run them through
+  support/operations procedures (see below).
+
+Application update flow (what "Run update" does):
 
 1. resolve selected channel metadata
 2. apply Flux source/release selection
 3. request Flux/Helm reconcile
 4. store update history
 
-This flow is application-only in v1.
+This flow is application-only in v1: it moves all Alga PSA services to the
+release pinned by the channel without touching the OS or k3s.
 
 ## OS/K3s Maintenance In v1
 

--- a/ee/docs/appliance/quick-start.md
+++ b/ee/docs/appliance/quick-start.md
@@ -50,6 +50,9 @@ Background service issues do not block login readiness.
 
 ## 6. App Updates
 
-Use `http://<node-ip>:8080/updates?token=<status-token>` for app-channel updates (`stable` or `nightly`).
+The appliance does not update itself. When a newer release is published to your
+channel (`stable` or `nightly`), the status page at `http://<node-ip>:8080`
+shows an "Update available" banner; apply the update from Manage → Updates.
 
 v1 scope is app-only updates. Ubuntu and k3s updates are manual/support-run.
+See the operator's manual "Updates And The Upgrade Path" for the full picture.


### PR DESCRIPTION
## Summary
Ticket **alga0002049**: appliance operators (reported by Marc, serverstart managed IT) had no clear answer to "will the appliance upgrade itself from 1.1.x to 1.2.x, or do I have to act?" — and unless they opened Manage → Updates, nothing in the product told them an update existed.

## UI (`ee/appliance/status-ui`)
- The status page now polls `/api/manage/status` on its own slow cadence (60s) and shows an **"Update available" banner** across the status tabs with an "Open Manage" CTA — covering both app updates and control-plane upgrades, with the available version and channel.
- The sidebar **Manage** button and the Manage **Updates** / **Control-plane** sub-tabs get an indicator dot when something is available.
- The Updates tab now states explicitly that the appliance checks the channel but **never applies updates automatically**.

## Host service (`ee/appliance/host-service`)
- `server.mjs`: cache the release-manifest resolve (60s TTL, keep last-known-good across transient registry failures) so the added status-page polling doesn't hit the OCI registry on every request — mirroring the existing `resolveControlPlaneRef` cache.

## Docs (`ee/docs/appliance`)
- Operator's manual: new **"Updates And The Upgrade Path"** section spelling out auto vs manual per layer — app updates are operator-initiated (1.1.x → 1.2.x is the same one-click channel update once published); the control plane refreshes at boot when the registry is reachable (holds last-good, never rolls back — per #2817) and can be upgraded in place; OS/k3s remain manual in v1.
- Quick-start and docs README updated to match.

## Testing
- `next build` of the status UI passes (TypeScript clean).
- Host-service tests: 79/80 pass; the one failure is the Docker-dependent fresh-install smoke test, which cannot run in this environment (no Docker daemon) and is unrelated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RtcuGv6AE4HFBH8nPKdvwX

---
_Generated by [Claude Code](https://claude.ai/code/session_01RtcuGv6AE4HFBH8nPKdvwX)_