### PR TITLE
fix(tickets): handle non-string attributes.description in rich text parser

### DIFF
--- a/packages/tickets/src/components/ticket/TicketInfo.tsx
+++ b/packages/tickets/src/components/ticket/TicketInfo.tsx
@@ -505,13 +505,13 @@ const TicketInfo: React.FC<TicketInfoProps> = ({
   // Categories are managed through the regular onCategoryChange handler
 
   const [descriptionContent, setDescriptionContent] = useState<PartialBlock[]>(() =>
-    parseTicketRichTextContent(ticket.attributes?.description as string | undefined)
+    parseTicketRichTextContent(ticket.attributes?.description as string | object | undefined)
   );
 
   const discardDescriptionEdit = useCallback(() => {
     const originalDescription =
       originalDescriptionRef.current ??
-      parseTicketRichTextContent(ticket.attributes?.description as string | undefined);
+      parseTicketRichTextContent(ticket.attributes?.description as string | object | undefined);
     setDescriptionContent(originalDescription);
     setHasDescriptionContentChanged(false);
     setIsEditingDescription(false);
@@ -536,7 +536,7 @@ const TicketInfo: React.FC<TicketInfoProps> = ({
     }
 
     const parsedDescription = parseTicketRichTextContent(
-      ticket.attributes?.description as string | undefined
+      ticket.attributes?.description as string | object | undefined
     );
     setDescriptionContent(parsedDescription);
     originalDescriptionRef.current = parsedDescription;

--- a/packages/tickets/src/lib/ticketRichText.test.ts
+++ b/packages/tickets/src/lib/ticketRichText.test.ts
@@ -176,6 +176,43 @@ describe('ticketRichText', () => {
     ]);
   });
 
+  it('handles content that is already parsed JSON instead of a string', () => {
+    const blocks = [
+      {
+        type: 'paragraph',
+        content: [{ type: 'text', text: 'Stored as jsonb array', styles: {} }],
+      },
+    ];
+
+    expect(parseTicketMobileRichTextDocument(blocks)).toEqual({
+      format: 'blocknote',
+      sourceFormat: 'blocknote',
+      content: blocks,
+    });
+    expect(parseTicketRichTextContent(blocks)).toEqual(blocks);
+
+    const proseMirrorDoc = {
+      type: 'doc' as const,
+      content: [
+        { type: 'paragraph', content: [{ type: 'text', text: 'Stored as jsonb object' }] },
+      ],
+    };
+    expect(parseTicketMobileRichTextDocument(proseMirrorDoc)).toEqual({
+      format: 'prosemirror',
+      sourceFormat: 'prosemirror',
+      content: proseMirrorDoc,
+    });
+
+    expect(parseTicketMobileRichTextDocument([])).toEqual({
+      format: 'blocknote',
+      sourceFormat: 'blocknote',
+      content: createEmptyTicketMobileRichTextDocument().content,
+    });
+    expect(parseTicketMobileRichTextDocument({ unexpected: 'shape' })).toEqual(
+      createEmptyTicketMobileRichTextDocument()
+    );
+  });
+
   it('returns a safe empty mobile document for null, undefined, or blank values', () => {
     expect(parseTicketMobileRichTextDocument(undefined)).toEqual(
       createEmptyTicketMobileRichTextDocument()

--- a/packages/tickets/src/lib/ticketRichText.ts
+++ b/packages/tickets/src/lib/ticketRichText.ts
@@ -522,12 +522,30 @@ export function createEmptyTicketMobileRichTextDocument(): TicketMobileRichTextD
 }
 
 export function parseTicketMobileRichTextDocument(
-  content: string | null | undefined,
+  content: string | object | null | undefined,
   options?: {
     onParseError?: (error: unknown) => void;
   }
 ): TicketMobileRichTextDocument {
   if (!content) {
+    return createEmptyTicketMobileRichTextDocument();
+  }
+
+  if (typeof content !== 'string') {
+    if (Array.isArray(content)) {
+      return {
+        format: 'blocknote',
+        sourceFormat: 'blocknote',
+        content: content.length > 0 ? (content as PartialBlock[]) : cloneDefaultBlock(),
+      };
+    }
+    if (isProseMirrorDoc(content)) {
+      return {
+        format: 'prosemirror',
+        sourceFormat: 'prosemirror',
+        content: content,
+      };
+    }
     return createEmptyTicketMobileRichTextDocument();
   }
 
@@ -568,7 +586,7 @@ export function parseTicketMobileRichTextDocument(
 }
 
 export function parseTicketRichTextContent(
-  content: string | null | undefined,
+  content: string | object | null | undefined,
   options?: {
     onParseError?: (error: unknown) => void;
   }


### PR DESCRIPTION
## Summary

Ticket detail pages crash with **"Something went wrong — e.trim is not a function"** when `attributes.description` is stored as an already-parsed jsonb array instead of a serialized JSON string.

Production evidence: ticket `02148458-7559-4da6-9be5-76530d3c298e` (alga0002053) has `jsonb_typeof(attributes->'description') = 'array'`. Six tickets total (alga0002048–alga0002053, all API-created on 2026-07-01) share this shape and all crash the detail page; the 3,047 UI-created tickets store the description as a string and are unaffected.

## Root cause

`TicketInfo.tsx` casts `ticket.attributes?.description` (typed `unknown`, from a jsonb column) to `string | undefined` and passes it to `parseTicketRichTextContent`. `parseTicketMobileRichTextDocument` then calls `content.trim()` — a runtime crash when the value is an array/object, since the cast provides no runtime safety.

## Fix

- `parseTicketMobileRichTextDocument` / `parseTicketRichTextContent` now accept `string | object | null | undefined`:
  - arrays → treated as BlockNote content (empty array → default empty block)
  - ProseMirror doc objects → handled as ProseMirror
  - any other non-string → safe empty document
- `TicketInfo.tsx` casts widened to match.

No data migration needed — editing a description in the UI re-serializes it to a string on save.

## Testing

- Added regression test covering array, ProseMirror object, empty array, and unexpected-shape inputs (`ticketRichText.test.ts`, 9/9 passing)
- `npm run typecheck` clean in `packages/tickets`

https://claude.ai/code/session_01SVXiYP6fJUJfrZTTvLwYA4