### PR TITLE
Re-point mixed-currency wiring probe at the strengthened invariant

### DIFF
--- a/server/src/test/unit/billing/multiActiveContracts.remainingChecklist.wiring.test.ts
+++ b/server/src/test/unit/billing/multiActiveContracts.remainingChecklist.wiring.test.ts
@@ -61,7 +61,10 @@ describe('multi-active remaining checklist wiring coverage', () => {
     expect(wizardSource).toContain('createClientContractAssignment(trx, tenant, {');
     expect(clientActionsSource).toContain('createClientContractAssignment(trx, tenant, {');
     expect(clientModelSource).toContain('createClientContractAssignment(db, tenant, {');
-    expect(mixedCurrencyIntegrationSource).toContain("expect(warningOrError?.message).toContain('currency');");
+    // The mixed-currency policy test now asserts the stronger invariant:
+    // contracts derive currency from the client, so a mixed state cannot be
+    // constructed (was: a warning-message expectation).
+    expect(mixedCurrencyIntegrationSource).toContain("expect(currencies).toEqual(['USD', 'USD']);");
   });
 
   it('T069: activation/reactivation logic remains free of sibling-active singleton blockers', () => {


### PR DESCRIPTION
Fixes the single "Server unit coverage (informational)" failure on main after #2828: the checklist wiring test asserts the source text of `multiCurrencyGaps.integration.test.ts`, whose mixed-currency assertion was realigned to the derive-currency-from-client invariant. Verified: the wiring file 8/8 and both other unit tests that read integration sources 69/69 locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)