### PR TITLE
Unify ticket list styling across MSP and portal

### DIFF
--- a/packages/client-portal/src/components/tickets/TicketList.tsx
+++ b/packages/client-portal/src/components/tickets/TicketList.tsx
@@ -39,6 +39,10 @@ import {
   TICKET_STATUS_FILTER_CLOSED,
   TICKET_STATUS_FILTER_OPEN,
   type TicketStatusFilterOption,
+  statusPillHue,
+  formatDuePrimary,
+  daysUntil,
+  formatCategoryLabel,
 } from '@alga-psa/tickets/lib';
 
 const useDebounce = <T,>(value: T, delay: number): T => {
@@ -262,6 +266,15 @@ export function TicketList() {
     ];
   }, [rawStatusOptions, selectedStatus, t]);
 
+  // Authoritative status_id → is_closed, so the status pill colors green from
+  // the status definition (consistent per status) rather than the per-ticket
+  // is_closed flag, which can drift so two tickets sharing a status differ.
+  // Falls back to the record flag only when the status isn't in the list.
+  const statusClosedById = useMemo(
+    () => new Map(rawStatusOptions.map((o) => [o.value, !!o.isClosed])),
+    [rawStatusOptions]
+  );
+
   const loadTickets = useCallback(async () => {
     setLoading(true);
     try {
@@ -420,35 +433,42 @@ export function TicketList() {
   }, []);
 
   const columns: ColumnDefinition<ITicketListItem>[] = [
-    {
-      title: t('fields.ticketNumber'),
-      dataIndex: 'ticket_number',
-      width: '75px',
-      render: (value: string, record: ITicketListItem) => (
-        <Link
-          href={`/client-portal/tickets/${record.ticket_id}`}
-          className="font-medium hover:text-[rgb(var(--color-secondary-600))]"
-          onClick={(e) => e.stopPropagation()}
-        >
-          {value}
-        </Link>
-      ),
-    },
+    // Ticket — the hero cell: bold title with the mono ticket number and
+    // category folded underneath (mirrors the MSP Refined List design).
     {
       title: t('fields.title'),
       dataIndex: 'title',
-      width: '25%',
-      render: (value: string, record: ITicketListItem) => (
-        <div className="overflow-hidden">
-          <Link
-            href={`/client-portal/tickets/${record.ticket_id}`}
-            className="font-medium hover:text-[rgb(var(--color-secondary-600))] block whitespace-normal break-words"
-            onClick={(e) => e.stopPropagation()}
-          >
-            {value}
-          </Link>
-        </div>
-      ),
+      width: '32%',
+      render: (value: string, record: ITicketListItem) => {
+        const hasCategory = !!(record.category_id || record.subcategory_id);
+        const categoryLabel = hasCategory ? formatCategoryLabel(record, categories) : null;
+        return (
+          <div className="flex flex-col gap-0.5 overflow-hidden">
+            <Link
+              href={`/client-portal/tickets/${record.ticket_id}`}
+              className="block truncate font-semibold text-[rgb(var(--color-text-900))] hover:text-[rgb(var(--color-secondary-600))]"
+              onClick={(e) => e.stopPropagation()}
+            >
+              {value}
+            </Link>
+            <div className="flex items-center gap-1.5 overflow-hidden text-[11px] leading-tight text-[rgb(var(--color-text-500))]">
+              <Link
+                href={`/client-portal/tickets/${record.ticket_id}`}
+                className="shrink-0 font-mono text-[11px] text-[rgb(var(--color-text-400))] hover:text-[rgb(var(--color-secondary-600))]"
+                onClick={(e) => e.stopPropagation()}
+              >
+                {record.ticket_number}
+              </Link>
+              {categoryLabel && (
+                <>
+                  <span className="text-[rgb(var(--color-text-300))]">·</span>
+                  <span className="truncate">{categoryLabel}</span>
+                </>
+              )}
+            </div>
+          </div>
+        );
+      },
     },
     {
       title: t('fields.status'),
@@ -457,17 +477,26 @@ export function TicketList() {
       render: (value: string, record: ITicketListItem) => {
         // Get response_state from the record (F026-F030)
         const responseState = record.response_state as TicketResponseState | undefined;
+        const closed =
+          record.status_id && statusClosedById.has(record.status_id)
+            ? !!statusClosedById.get(record.status_id)
+            : ((record as { is_closed?: boolean }).is_closed ?? false);
+        const hue = statusPillHue(value || '', closed);
         return (
-          <div className="flex items-center gap-2 flex-wrap">
+          <div className="flex items-center gap-2">
             <DropdownMenu.Root>
               <DropdownMenu.Trigger asChild>
-                <div
-                  id="change-ticket-category-button"
-                  className="text-sm cursor-pointer flex items-center gap-2"
+                <button
+                  id="change-ticket-status-button"
+                  type="button"
+                  className="inline-flex min-w-0 items-center gap-1.5 rounded-full border px-2.5 py-1 text-xs font-medium text-[rgb(var(--color-text-700))] cursor-pointer"
+                  style={{ backgroundColor: `rgb(${hue} / 0.14)`, borderColor: `rgb(${hue} / 0.30)` }}
+                  onClick={(e) => e.stopPropagation()}
                 >
-                  {value}
-                  <ChevronDown className="h-3 w-3 text-gray-400" />
-                </div>
+                  <span className="h-1.5 w-1.5 shrink-0 rounded-full" style={{ backgroundColor: `rgb(${hue})` }} />
+                  <span className="overflow-hidden text-ellipsis">{value || 'No Status'}</span>
+                  <ChevronDown className="h-3 w-3 shrink-0 text-[rgb(var(--color-text-400))]" />
+                </button>
               </DropdownMenu.Trigger>
 
               <DropdownMenu.Content
@@ -498,6 +527,7 @@ export function TicketList() {
                 responseState={responseState}
                 isClientPortal={true}
                 size="sm"
+                className="ml-auto shrink-0"
                 labels={{
                   awaitingClient: t('responseState.awaitingYourResponse', 'Awaiting Your Response'),
                   awaitingInternal: t('responseState.awaitingSupportResponse', 'Awaiting Support Response'),
@@ -516,49 +546,41 @@ export function TicketList() {
       width: '12%',
       render: (value: string, record: ITicketListItem) => (
         <div className="flex items-center gap-2">
-          <div
-            className={`w-3 h-3 rounded-full border border-gray-300 ${!record.priority_color ? 'bg-gray-500' : ''}`}
-            style={record.priority_color ? { backgroundColor: record.priority_color } : undefined}
+          <span
+            className="h-3.5 w-[3px] shrink-0 rounded-full"
+            style={{ backgroundColor: record.priority_color || '#94a3b8' }}
           />
-          <span className="capitalize">{value}</span>
+          <span className="font-medium text-[rgb(var(--color-text-700))]">{value || 'No Priority'}</span>
         </div>
       ),
     },
     {
+      // Two-line due cell: smart primary label + a relative "in N days" hint,
+      // colored for overdue/soon urgency. (No SLA line — clients don't see SLA.)
       title: t('fields.dueDate', 'Due Date'),
       dataIndex: 'due_date',
-      width: '12%',
+      width: '13%',
       render: (value: string | null) => {
         if (!value) {
-          return <span className="text-sm text-gray-500">-</span>;
+          return <span className="text-sm text-[rgb(var(--color-text-400))]">No due date</span>;
         }
 
-        const dueDate = new Date(value);
         const now = new Date();
+        const dueDate = new Date(value);
         const hoursUntilDue = (dueDate.getTime() - now.getTime()) / (1000 * 60 * 60);
 
-        // Check if time is midnight (00:00) - show date only
-        const isMidnight = dueDate.getHours() === 0 && dueDate.getMinutes() === 0;
-        const displayFormat = isMidnight ? 'MMM d, yyyy' : 'MMM d, yyyy h:mm a';
+        let primaryClass = 'text-[rgb(var(--color-text-700))]';
+        if (hoursUntilDue < 0) primaryClass = 'text-red-600 dark:text-red-400';
+        else if (hoursUntilDue <= 24) primaryClass = 'text-orange-600 dark:text-orange-400';
 
-        // Determine styling based on due date status
-        let textColorClass = 'text-gray-500';
-        let bgColorClass = '';
-
-        if (hoursUntilDue < 0) {
-          // Overdue - red/warning style
-          textColorClass = 'text-red-700';
-          bgColorClass = 'bg-destructive/10';
-        } else if (hoursUntilDue <= 24) {
-          // Approaching due date (within 24 hours) - orange/caution style
-          textColorClass = 'text-orange-700';
-          bgColorClass = 'bg-warning/10';
-        }
+        const d = daysUntil(dueDate, now);
+        const secondary = d >= 2 ? `in ${d} days` : null;
 
         return (
-          <span className={`text-sm inline-block ${textColorClass} ${bgColorClass ? `${bgColorClass} px-2 py-0.5 rounded-full` : ''}`}>
-            {format(dueDate, displayFormat)}
-          </span>
+          <div className="flex flex-col leading-tight">
+            <span className={`text-sm font-medium ${primaryClass}`}>{formatDuePrimary(dueDate, now)}</span>
+            {secondary && <span className="text-[11px] text-[rgb(var(--color-text-400))]">{secondary}</span>}
+          </div>
         );
       },
     },
@@ -570,8 +592,20 @@ export function TicketList() {
         const additionalCount = record.additional_agent_count || 0;
         const additionalAgents = record.additional_agents || [];
         return (
-          <div className="text-sm flex items-center gap-1.5">
-            {value || '-'}
+          <div className="text-sm text-[rgb(var(--color-text-700))] flex items-center gap-2">
+            {value ? (
+              <UserAvatar
+                userId={record.assigned_to || value}
+                userName={value}
+                avatarUrl={additionalAgentAvatarUrls[record.assigned_to ?? ''] ?? null}
+                size="xs"
+              />
+            ) : (
+              <span className="flex h-6 w-6 shrink-0 items-center justify-center rounded-full border border-dashed border-[rgb(var(--color-border-400))] text-xs text-[rgb(var(--color-text-400))]">
+                +
+              </span>
+            )}
+            <span className="truncate">{value || 'Unassigned'}</span>
             {record.assigned_team_id && record.assigned_team_name && (
               <Tooltip content={record.assigned_team_name}>
                 <span className="inline-flex items-center cursor-help">
@@ -619,21 +653,11 @@ export function TicketList() {
       },
     },
     {
-      title: t('fields.createdAt'),
-      dataIndex: 'entered_at',
-      width: '15%',
-      render: (value: string | null) => (
-        <div className="text-sm text-gray-500">
-          {value ? format(new Date(value), 'MMM d, yyyy h:mm a') : '-'}
-        </div>
-      ),
-    },
-    {
       title: t('fields.updatedAt'),
       dataIndex: 'updated_at',
-      width: '15%',
+      width: '14%',
       render: (value: string | null) => (
-        <div className="text-sm text-gray-500">
+        <div className="text-sm text-[rgb(var(--color-text-500))]">
           {value ? format(new Date(value), 'MMM d, yyyy h:mm a') : '-'}
         </div>
       ),

--- a/packages/tickets/src/components/TicketingDashboard.tsx
+++ b/packages/tickets/src/components/TicketingDashboard.tsx
@@ -1050,6 +1050,13 @@ const TicketingDashboard: React.FC<TicketingDashboardProps> = ({
     });
   }, []);
 
+  // Authoritative status_id → is_closed so the status pill colors by the status
+  // definition (consistent per status) rather than the drift-prone per-ticket flag.
+  const statusIsClosedById = useMemo(
+    () => Object.fromEntries(rawStatusOptions.map((o) => [o.value, !!o.isClosed])),
+    [rawStatusOptions]
+  );
+
   const columns = useMemo(() => {
     const baseColumns = createTicketColumns({
       categories,
@@ -1061,6 +1068,7 @@ const TicketingDashboard: React.FC<TicketingDashboardProps> = ({
       tagSize: densityClasses.tagSize,
       showClient: true,
       onClientClick: onQuickViewClient,
+      statusIsClosedById,
       additionalAgentAvatarUrls,
       teamAvatarUrls,
       isBundleExpanded: bundleView === 'bundled' ? isBundleExpanded : undefined,
@@ -1178,6 +1186,7 @@ const TicketingDashboard: React.FC<TicketingDashboardProps> = ({
     clearSelection,
     handleSelectAllMatchingTickets,
     allMatchingMode,
+    statusIsClosedById,
     additionalAgentAvatarUrls,
     teamAvatarUrls,
     isBundleExpanded,

--- a/packages/tickets/src/lib/index.ts
+++ b/packages/tickets/src/lib/index.ts
@@ -1,5 +1,15 @@
 export { createTicketColumns } from './ticket-columns';
 export {
+  hashString,
+  statusPillHue,
+  relativeDueLabel,
+  formatDuePrimary,
+  daysUntil,
+  formatCategoryLabel,
+  STATUS_PILL_HUES,
+  STATUS_PILL_CLOSED_HUE,
+} from './ticketListPresentation';
+export {
   TICKET_COLUMNS,
   TOGGLEABLE_TICKET_COLUMNS,
   resolveTicketColumnVisibility,

--- a/packages/tickets/src/lib/ticket-columns.tsx
+++ b/packages/tickets/src/lib/ticket-columns.tsx
@@ -12,6 +12,12 @@ import { format } from 'date-fns';
 import { ResponseStateBadge } from '@alga-psa/ui/components/tickets/ResponseStateBadge';
 import type { SlaTimerStatus } from '@alga-psa/types';
 import { resolveTicketColumnVisibility, type TicketListColumnKey } from './ticketColumnCatalog';
+import {
+  statusPillHue,
+  formatDuePrimary,
+  daysUntil,
+  formatCategoryLabel,
+} from './ticketListPresentation';
 
 /**
  * Calculate SLA status from ticket data
@@ -81,95 +87,6 @@ function calculateSlaStatus(ticket: ITicketListItem): {
   return null;
 }
 
-// ---------------------------------------------------------------------------
-// Presentation helpers — "Refined List" look (redesign candidate #1):
-// hero title + mono id/category subtitle, semantic status pills, priority
-// bars, initials avatars, and a relative Due column.
-// ---------------------------------------------------------------------------
-
-// Hash used for deterministic status-pill hue selection (avatar colors come from
-// the shared ClientAvatar/UserAvatar components, which derive their own hues).
-function hashString(str: string): number {
-  let h = 0;
-  for (let i = 0; i < str.length; i++) {
-    h = (h * 31 + str.charCodeAt(i)) | 0;
-  }
-  return Math.abs(h);
-}
-
-// Status pill hues. The pill background is a translucent tint of the hue so it
-// blends with the surface in BOTH light and dark mode (rather than a fixed light
-// fill that glares on a dark card); the solid hue is used for the dot, and pill
-// text stays neutral (--color-text-700, which flips with the theme) so it reads
-// on either background. Open statuses get a stable hue by name (Alga statuses are
-// per-board/custom, no fixed semantic set); closed statuses always read green.
-//
-// The first three entries are live brand tokens, so the pills track the active
-// theme and any tenant rebrand; the rest are fixed decorative accents that widen
-// the palette (statuses are hashed across all of them, so more hues => fewer
-// same-board color collisions). The accents are not arbitrary: they all sit on
-// the brand's cool arc (purple -> indigo -> blue -> cyan -> teal), with one
-// desaturated slate for the low-key long tail. Deliberately excluded: pink/red
-// (alarm — this coloring is non-semantic, so a hot hue makes unimportant statuses
-// read as if they stood out) and amber (redundant with the brand orange). Each
-// entry is anything valid inside CSS rgb(): a space-separated "R G B" literal or a
-// var() that resolves to one — both interpolate cleanly into rgb(${hue} / a).
-const STATUS_PILL_HUES = [
-  'var(--color-primary-500)',    // brand violet (live token)
-  'var(--color-secondary-500)',  // brand cyan (live token)
-  'var(--color-accent-500)',     // brand orange (live token)
-  '99 102 241',                  // indigo — fixed accent (purple↔blue)
-  '59 130 246',                  // blue — fixed accent (indigo↔cyan)
-  '20 184 166',                  // teal — fixed accent (cyan↔green)
-  '100 116 139',                 // slate — fixed accent (desaturated, low-key)
-];
-const STATUS_PILL_CLOSED_HUE = 'var(--color-status-success)'; // green (live token)
-
-function statusPillHue(statusName: string, closed: boolean): string {
-  if (closed) return STATUS_PILL_CLOSED_HUE;
-  return STATUS_PILL_HUES[hashString(statusName || 'status') % STATUS_PILL_HUES.length];
-}
-
-// Compact relative due label, e.g. "Overdue 2d", "in 5h", "in 3 days".
-function relativeDueLabel(due: Date, now: Date): string {
-  const ms = due.getTime() - now.getTime();
-  const dayMs = 24 * 60 * 60 * 1000;
-  const overdue = ms < 0;
-  const absMs = Math.abs(ms);
-  const days = Math.floor(absMs / dayMs);
-  const hours = Math.floor(absMs / (60 * 60 * 1000));
-  let magnitude: string;
-  if (days >= 1) magnitude = `${days}d`;
-  else if (hours >= 1) magnitude = `${hours}h`;
-  else magnitude = `${Math.max(1, Math.round(absMs / 60000))}m`;
-  if (overdue) return `Overdue ${magnitude}`;
-  return days >= 1 ? `in ${days} days` : `in ${magnitude}`;
-}
-
-// Smart due-date label matching candidate #1: "Overdue 1d" / "Today 4:00 PM" /
-// "Tomorrow 9:00 AM" / "Fri, Jun 21" (year added only when not the current year).
-function formatDuePrimary(due: Date, now: Date): string {
-  if (due.getTime() < now.getTime()) {
-    return relativeDueLabel(due, now); // "Overdue 5h" / "Overdue 1d"
-  }
-  const startOfToday = new Date(now);
-  startOfToday.setHours(0, 0, 0, 0);
-  const dueDay = new Date(due);
-  dueDay.setHours(0, 0, 0, 0);
-  const dayDiff = Math.round((dueDay.getTime() - startOfToday.getTime()) / 86400000);
-  const isMidnight = due.getHours() === 0 && due.getMinutes() === 0;
-  if (dayDiff === 0) return isMidnight ? 'Today' : `Today ${format(due, 'h:mm a')}`;
-  if (dayDiff === 1) return isMidnight ? 'Tomorrow' : `Tomorrow ${format(due, 'h:mm a')}`;
-  return format(due, due.getFullYear() === now.getFullYear() ? 'EEE, MMM d' : 'MMM d, yyyy');
-}
-
-// Calendar-day count to a future due date, for the secondary "in N days" hint.
-function daysUntil(due: Date, now: Date): number {
-  const a = new Date(now); a.setHours(0, 0, 0, 0);
-  const b = new Date(due); b.setHours(0, 0, 0, 0);
-  return Math.round((b.getTime() - a.getTime()) / 86400000);
-}
-
 // Compact SLA status for the merged Due/SLA cell — the sole place SLA state is
 // shown in the list. Derived from calculateSlaStatus; tone drives urgency color.
 function slaMagnitude(minutes: number): string {
@@ -190,22 +107,6 @@ function formatSlaCell(
   const mag = sla.remainingMinutes !== undefined ? slaMagnitude(sla.remainingMinutes) : null;
   if (sla.status === 'at_risk') return { text: mag ? `${mag} left` : 'At risk', tone: 'soon' };
   return { text: mag ? `${mag} left` : 'On track', tone: 'ok' };
-}
-
-// Shared category label resolver, used by both the category column and the
-// category subtitle folded under the title cell.
-function formatCategoryLabel(record: ITicketListItem, categories: ITicketCategory[]): string {
-  const categoryId = record.category_id || null;
-  if (!categoryId && !record.subcategory_id) return 'No Category';
-  if (record.subcategory_id) {
-    const subcategory = categories.find(c => c.category_id === record.subcategory_id);
-    if (!subcategory) return 'Unknown Category';
-    const parent = categories.find(c => c.category_id === subcategory.parent_category);
-    return parent ? `${parent.category_name} → ${subcategory.category_name}` : subcategory.category_name;
-  }
-  const category = categories.find(c => c.category_id === categoryId);
-  if (!category) return 'Unknown Category';
-  return category.category_name;
 }
 
 type TicketListSettings = {
@@ -230,6 +131,13 @@ interface CreateTicketColumnsOptions {
   showTags?: boolean;
   showClient?: boolean;
   onClientClick?: (clientId: string) => void;
+  /**
+   * Authoritative status_id → is_closed map. Used to color the status pill
+   * (closed = green) from the status definition instead of the per-ticket
+   * is_closed flag, which can drift so two tickets sharing a status render
+   * different colors. Falls back to the record flag when a status is absent.
+   */
+  statusIsClosedById?: Record<string, boolean>;
   /** Map of user IDs to avatar URLs for displaying in additional agents tooltip */
   additionalAgentAvatarUrls?: Record<string, string | null>;
   /** Map of team IDs to avatar URLs for displaying team badges */
@@ -251,6 +159,7 @@ export function createTicketColumns(options: CreateTicketColumnsOptions): Column
     showTags = true,
     showClient = true,
     onClientClick,
+    statusIsClosedById = {},
     additionalAgentAvatarUrls = {},
     teamAvatarUrls = {},
     isBundleExpanded,
@@ -267,6 +176,14 @@ export function createTicketColumns(options: CreateTicketColumnsOptions): Column
 
   const showInlineTagsInTitle = columnVisibility.tags && showTags;
   const dateTimeFormat = displaySettings?.dateTimeFormat || 'MMM d, yyyy h:mm a';
+
+  // Internal (MSP) response-state wording for the status-cell badge.
+  const responseLabels = {
+    awaitingClient: t('responseState.awaitingClient', 'Awaiting Client'),
+    awaitingInternal: t('responseState.awaitingInternal', 'Awaiting Internal'),
+    awaitingClientTooltip: t('responseState.awaitingClientTooltip', 'Waiting for client to respond'),
+    awaitingInternalTooltip: t('responseState.awaitingInternalTooltip', 'Client has responded, waiting for internal action'),
+  };
 
   // Ticket number and category always fold into the "Ticket" hero cell; the flat
   // per-column layout lives only in the export path (see ticketColumnCatalog).
@@ -385,29 +302,46 @@ export function createTicketColumns(options: CreateTicketColumnsOptions): Column
       col: {
         title: t('fields.status', 'Status'),
         dataIndex: 'status_name',
-        width: '8%',
+        width: '12%',
         render: (value: string, record: ITicketListItem) => {
           // Get response_state from the record - it may be on the record if fetched
           const responseState = (record as any).response_state as TicketResponseState | undefined;
           const showResponseState = displaySettings?.responseStateTrackingEnabled !== false;
-          const closed = !!(record as { is_closed?: boolean }).is_closed;
+          // Color from the status definition (consistent per status), not the
+          // per-ticket is_closed flag, which can drift across rows sharing a status.
+          const statusId = record.status_id ?? '';
+          const closed = statusId in statusIsClosedById
+            ? statusIsClosedById[statusId]
+            : !!(record as { is_closed?: boolean }).is_closed;
           const hue = statusPillHue(value || '', closed);
           return (
-            <div className="flex items-center gap-1.5 overflow-hidden whitespace-nowrap">
+            <div className="@container flex items-center gap-1.5 whitespace-nowrap">
               <span
-                className="inline-flex max-w-full items-center gap-1.5 rounded-full border px-2.5 py-1 text-xs font-medium text-[rgb(var(--color-text-700))]"
+                className="inline-flex min-w-0 items-center gap-1.5 rounded-full border px-2.5 py-1 text-xs font-medium text-[rgb(var(--color-text-700))]"
                 style={{ backgroundColor: `rgb(${hue} / 0.14)`, borderColor: `rgb(${hue} / 0.30)` }}
               >
                 <span className="h-1.5 w-1.5 shrink-0 rounded-full" style={{ backgroundColor: `rgb(${hue})` }} />
                 <span className="overflow-hidden text-ellipsis">{value || 'No Status'}</span>
               </span>
+              {/* Response state degrades with the column width: full label → icon
+                  → hidden. Thresholds are container queries on the status cell. */}
               {showResponseState && responseState && (
-                <ResponseStateBadge
-                  responseState={responseState}
-                  variant="text"
-                  size="sm"
-                  className="h-5 w-5 shrink-0 justify-center overflow-hidden border-transparent !bg-transparent px-0 py-0 text-transparent opacity-75 [&_span]:hidden"
-                />
+                <span className="ml-auto flex shrink-0 items-center">
+                  <ResponseStateBadge
+                    responseState={responseState}
+                    variant="badge"
+                    size="sm"
+                    labels={responseLabels}
+                    className="hidden @[184px]:inline-flex"
+                  />
+                  <ResponseStateBadge
+                    responseState={responseState}
+                    variant="text"
+                    size="sm"
+                    labels={responseLabels}
+                    className="hidden @[112px]:inline-flex @[184px]:hidden"
+                  />
+                </span>
               )}
             </div>
           );

--- a/packages/tickets/src/lib/ticketListPresentation.ts
+++ b/packages/tickets/src/lib/ticketListPresentation.ts
@@ -1,0 +1,109 @@
+import { format } from 'date-fns';
+import type { ITicketListItem, ITicketCategory } from '@alga-psa/types';
+
+// ---------------------------------------------------------------------------
+// Presentation helpers — "Refined List" look (redesign candidate #1):
+// semantic status pills, a relative Due column, and the category label folded
+// under the title. Shared by the MSP Ticketing Dashboard columns
+// (ticket-columns.tsx) and the client-portal ticket list so both surfaces read
+// identically.
+// ---------------------------------------------------------------------------
+
+// Hash used for deterministic status-pill hue selection (avatar colors come from
+// the shared ClientAvatar/UserAvatar components, which derive their own hues).
+export function hashString(str: string): number {
+  let h = 0;
+  for (let i = 0; i < str.length; i++) {
+    h = (h * 31 + str.charCodeAt(i)) | 0;
+  }
+  return Math.abs(h);
+}
+
+// Status pill hues. The pill background is a translucent tint of the hue so it
+// blends with the surface in BOTH light and dark mode (rather than a fixed light
+// fill that glares on a dark card); the solid hue is used for the dot, and pill
+// text stays neutral (--color-text-700, which flips with the theme) so it reads
+// on either background. Open statuses get a stable hue by name (Alga statuses are
+// per-board/custom, no fixed semantic set); closed statuses always read green.
+//
+// The first three entries are live brand tokens, so the pills track the active
+// theme and any tenant rebrand; the rest are fixed decorative accents that widen
+// the palette (statuses are hashed across all of them, so more hues => fewer
+// same-board color collisions). The accents are not arbitrary: they all sit on
+// the brand's cool arc (purple -> indigo -> blue -> cyan -> teal), with one
+// desaturated slate for the low-key long tail. Deliberately excluded: pink/red
+// (alarm — this coloring is non-semantic, so a hot hue makes unimportant statuses
+// read as if they stood out) and amber (redundant with the brand orange). Each
+// entry is anything valid inside CSS rgb(): a space-separated "R G B" literal or a
+// var() that resolves to one — both interpolate cleanly into rgb(${hue} / a).
+export const STATUS_PILL_HUES = [
+  'var(--color-primary-500)',    // brand violet (live token)
+  'var(--color-secondary-500)',  // brand cyan (live token)
+  'var(--color-accent-500)',     // brand orange (live token)
+  '99 102 241',                  // indigo — fixed accent (purple↔blue)
+  '59 130 246',                  // blue — fixed accent (indigo↔cyan)
+  '20 184 166',                  // teal — fixed accent (cyan↔green)
+  '100 116 139',                 // slate — fixed accent (desaturated, low-key)
+];
+export const STATUS_PILL_CLOSED_HUE = 'var(--color-status-success)'; // green (live token)
+
+export function statusPillHue(statusName: string, closed: boolean): string {
+  if (closed) return STATUS_PILL_CLOSED_HUE;
+  return STATUS_PILL_HUES[hashString(statusName || 'status') % STATUS_PILL_HUES.length];
+}
+
+// Compact relative due label, e.g. "Overdue 2d", "in 5h", "in 3 days".
+export function relativeDueLabel(due: Date, now: Date): string {
+  const ms = due.getTime() - now.getTime();
+  const dayMs = 24 * 60 * 60 * 1000;
+  const overdue = ms < 0;
+  const absMs = Math.abs(ms);
+  const days = Math.floor(absMs / dayMs);
+  const hours = Math.floor(absMs / (60 * 60 * 1000));
+  let magnitude: string;
+  if (days >= 1) magnitude = `${days}d`;
+  else if (hours >= 1) magnitude = `${hours}h`;
+  else magnitude = `${Math.max(1, Math.round(absMs / 60000))}m`;
+  if (overdue) return `Overdue ${magnitude}`;
+  return days >= 1 ? `in ${days} days` : `in ${magnitude}`;
+}
+
+// Smart due-date label matching candidate #1: "Overdue 1d" / "Today 4:00 PM" /
+// "Tomorrow 9:00 AM" / "Fri, Jun 21" (year added only when not the current year).
+export function formatDuePrimary(due: Date, now: Date): string {
+  if (due.getTime() < now.getTime()) {
+    return relativeDueLabel(due, now); // "Overdue 5h" / "Overdue 1d"
+  }
+  const startOfToday = new Date(now);
+  startOfToday.setHours(0, 0, 0, 0);
+  const dueDay = new Date(due);
+  dueDay.setHours(0, 0, 0, 0);
+  const dayDiff = Math.round((dueDay.getTime() - startOfToday.getTime()) / 86400000);
+  const isMidnight = due.getHours() === 0 && due.getMinutes() === 0;
+  if (dayDiff === 0) return isMidnight ? 'Today' : `Today ${format(due, 'h:mm a')}`;
+  if (dayDiff === 1) return isMidnight ? 'Tomorrow' : `Tomorrow ${format(due, 'h:mm a')}`;
+  return format(due, due.getFullYear() === now.getFullYear() ? 'EEE, MMM d' : 'MMM d, yyyy');
+}
+
+// Calendar-day count to a future due date, for the secondary "in N days" hint.
+export function daysUntil(due: Date, now: Date): number {
+  const a = new Date(now); a.setHours(0, 0, 0, 0);
+  const b = new Date(due); b.setHours(0, 0, 0, 0);
+  return Math.round((b.getTime() - a.getTime()) / 86400000);
+}
+
+// Shared category label resolver, used by both the category column and the
+// category subtitle folded under the title cell.
+export function formatCategoryLabel(record: ITicketListItem, categories: ITicketCategory[]): string {
+  const categoryId = record.category_id || null;
+  if (!categoryId && !record.subcategory_id) return 'No Category';
+  if (record.subcategory_id) {
+    const subcategory = categories.find(c => c.category_id === record.subcategory_id);
+    if (!subcategory) return 'Unknown Category';
+    const parent = categories.find(c => c.category_id === subcategory.parent_category);
+    return parent ? `${parent.category_name} → ${subcategory.category_name}` : subcategory.category_name;
+  }
+  const category = categories.find(c => c.category_id === categoryId);
+  if (!category) return 'Unknown Category';
+  return category.category_name;
+}


### PR DESCRIPTION
Extract the "Refined List" presentation helpers (statusPillHue, formatDuePrimary, daysUntil, formatCategoryLabel) into a shared ticketListPresentation module and restyle the client-portal ticket list to match the MSP dashboard: hero title cell with folded ticket-# and category, soft status pills, priority bars, two-line due dates, and initials avatars.

Color the status pill from the status definition (a status_id → is_closed map) instead of the drift-prone per-ticket is_closed flag, so tickets sharing a status no longer render different colors.

Restore the MSP response-state badge (it was rendered invisible) with a full label that degrades to icon then hides via container queries on the status column, and right-align the badge on both lists.

"But how can the same 'Resolved' wear two coats of paint at once?" asked Alice; the Cheshire Badge only grinned, faded to an icon, then vanished entirely as its column grew narrow — leaving nothing but a softly glowing pill and the memory of where its is_closed had wandered off to. 🎩🐈🫥