### PR TITLE
docs: reflect mobile server-backed timer and Temporal self-healing jobs (#2837, #2827)

### DIFF
--- a/docs/architecture/job_scheduler.md
+++ b/docs/architecture/job_scheduler.md
@@ -24,6 +24,7 @@ Both backends write to the same database tables (`jobs` and `job_details`), prov
 - Job history tracking
 - **Edition-based backend selection** (CE: PG Boss, EE: Temporal)
 - **Unified job monitoring dashboard**
+- **Recurring job self-healing** (Temporal EE) — if a recurring schedule's baked-in tracker row is missing from the database, the next `scheduleRecurringJob` call creates a fresh row and re-points the schedule automatically
 
 ## Architecture
 
@@ -206,6 +207,50 @@ await runner.scheduleJob('my-new-job', {
 });
 ```
 
+## Recurring Job Lifecycle (Temporal EE)
+
+Recurring schedules (created via `scheduleRecurringJob`) manage their `jobs` table tracker row differently from one-shot jobs. Understanding this lifecycle is important when querying the database or building on top of the job system.
+
+### Tracker row status stays `queued`
+
+After each fire (success or failure), the recurring job's tracker row is reset to **`queued`** status — it never transitions to `completed` or `failed`. The actual outcome of the most-recent fire is stored in the row's `metadata` JSON column:
+
+```json
+{
+  "recurring": true,
+  "lastRunStatus": "completed",
+  "lastRunAt": "2026-07-02T14:30:00.000Z"
+}
+```
+
+This mirrors how pg-boss handles recurring rows and ensures schedule reconcilers — which check for non-terminal rows to detect live schedules — can always find the tracker.
+
+> **When reading the jobs table:** a recurring Temporal job perpetually in `queued` status is healthy and expected behavior, not a sign that the job is stuck. Check `metadata.lastRunStatus` for the outcome of the most recent fire.
+
+### Self-healing for orphaned tracker rows
+
+A recurring Temporal schedule bakes one `jobId` into its workflow action args at creation time. If that row is later missing from the `jobs` table (e.g. the row was deleted, or the schedule was provisioned against a different database), `scheduleRecurringJob` detects this on the next call and automatically:
+
+1. Detects that the baked `jobId` no longer exists in the tenant's `jobs` table.
+2. Creates a fresh `jobs` row.
+3. Re-points the schedule's workflow action args to the new `jobId`.
+4. Logs a `WARN`-level entry in the Temporal worker log so the repair is visible.
+
+Without this self-healing, every subsequent schedule fire would fail at bookkeeping before the handler ran, generating orphan `pending` rows (~13k rows/day in a busy installation) while appearing COMPLETED in Temporal.
+
+### Job handler failures surface as FAILED in Temporal
+
+When `genericJobWorkflow` runs a handler that reports failure, it throws `ApplicationFailure.create({ type: 'GenericJobFailure', nonRetryable: true })`. Temporal marks the workflow run as **FAILED**, which surfaces in:
+
+- Temporal's UI schedule history (Last Result shows FAILED)
+- Any Temporal SDK metric collectors watching for FAILED workflow runs
+
+> **Historical note:** Before the July 2026 fix, handler failures returned a failure-shaped result object that Temporal interpreted as a successful workflow completion (COMPLETED). Historical runs from before this fix may appear as COMPLETED even if the underlying handler encountered an error.
+
+### Bookkeeping failures do not block the handler
+
+Pre- and post-handler status updates (`updateJobStatus`, `createJobDetail`) are wrapped in a best-effort try/catch inside `genericJobWorkflow`. If the tracker row is inaccessible at runtime, the workflow logs a warning and continues to execute the handler. Real handler failures still throw `ApplicationFailure` and surface as FAILED in Temporal.
+
 ## Monitoring and Metrics
 
 ### Dashboard
@@ -244,6 +289,14 @@ SELECT * FROM jobs WHERE runner_type = 'temporal';
 
 -- Find job by Temporal workflow ID
 SELECT * FROM jobs WHERE external_id = 'workflow-id';
+
+-- Find recurring job tracker rows (always in 'queued' status; last outcome in metadata)
+SELECT job_id, type, status,
+       metadata->>'lastRunStatus' AS last_run_status,
+       metadata->>'lastRunAt'     AS last_run_at
+FROM jobs
+WHERE runner_type = 'temporal'
+  AND metadata->>'recurring' = 'true';
 ```
 
 ## Error Handling
@@ -287,7 +340,7 @@ CREATE TABLE jobs (
   updated_at TIMESTAMP,
   user_id UUID NOT NULL,
   runner_type VARCHAR DEFAULT 'pgboss' NOT NULL,  -- 'pgboss' or 'temporal'
-  external_id VARCHAR,          -- PG Boss job ID or Temporal workflow ID
+  external_id VARCHAR,          -- PG Boss job ID or Temporal workflow ID (nulled on cancel)
   external_run_id VARCHAR,      -- Temporal run ID
   PRIMARY KEY (tenant, job_id)
 );
@@ -365,6 +418,14 @@ If you see "No handler registered for job: X":
 1. Verify `TEMPORAL_ADDRESS` is correct
 2. Check Temporal server is running
 3. If `JOB_RUNNER_FALLBACK_TO_PGBOSS=true`, jobs will use PG Boss
+
+### Recurring Jobs Appear Stuck in `queued`
+
+This is expected behavior for Temporal recurring jobs — see [Recurring Job Lifecycle](#recurring-job-lifecycle-temporal-ee). The tracker row stays `queued` between fires; check `metadata.lastRunStatus` and `metadata.lastRunAt` for the last run outcome.
+
+### Recurring Jobs Show COMPLETED in Temporal Despite Handler Errors
+
+This applies only to runs before the July 2026 self-healing fix. After that fix, handler failures throw `ApplicationFailure` and surface as FAILED in Temporal's UI. If you are seeing COMPLETED for jobs you expect to have failed, check whether those runs pre-date the fix.
 
 ## See Also
 

--- a/docs/features/time_entry.md
+++ b/docs/features/time_entry.md
@@ -17,6 +17,7 @@
    - [Time Sheets and Billing](#time-sheets-and-billing)
 4. [Interval Tracking](#interval-tracking)
    - [Automatic Ticket Time Tracking](#automatic-ticket-time-tracking)
+   - [Mobile App Time Tracking](#mobile-app-time-tracking)
    - [Interval Management](#interval-management)
    - [Converting Intervals to Time Entries](#converting-intervals-to-time-entries)
    - [Integration Points](#integration-points)
@@ -189,11 +190,11 @@ The generated time periods serve as templates or headers for **Time Sheets**. Us
 
 ## Interval Tracking
 
-The system includes a lightweight ticket time-tracking feature that automatically captures when users view tickets, providing a foundation for accurate time entries with minimal manual effort.
+The system includes time-tracking features that automatically capture when users interact with tickets, providing a foundation for accurate time entries with minimal manual effort. Two separate tracking mechanisms exist: a browser-based tracker (web app) and a server-backed tracker (mobile app).
 
 ### Automatic Ticket Time Tracking
 
-When users interact with tickets in the system, their viewing sessions are automatically tracked:
+When users interact with tickets in the **web application**, their viewing sessions are automatically tracked using the browser's IndexedDB:
 
 - **Start Time**: Recorded when a user opens a ticket
 - **End Time**: Captured when the user navigates away from the ticket
@@ -223,6 +224,37 @@ The system includes an intelligent auto-close feature for abandoned intervals:
 - Intervals from previous days with no end time are automatically closed at 5:00 PM of their start date
 - If the start time was after 5:00 PM, the interval is closed at the start time
 - Auto-closed intervals are clearly marked for user review
+
+### Mobile App Time Tracking
+
+The Alga PSA mobile app (iOS and Android) uses a different, **server-backed** time tracking mechanism. Unlike the browser tracker, mobile timer sessions are persisted to the server so they survive app kills, relaunches, and device switches.
+
+**How it works — three REST endpoints drive the full lifecycle:**
+
+| Step | Endpoint | Description |
+|------|----------|-------------|
+| Start | `POST /api/v1/time-tracking/start-tracking` | Opens a server-side session for the current user, ticket, and selected service |
+| Restore | `GET /api/v1/time-tracking/active-session` | Returns the running session on app launch or device switch |
+| Stop | `POST /api/v1/time-tracking/stop-tracking` | Closes the session and creates a time entry |
+
+**Key differences from browser interval tracking:**
+
+| | Browser (IndexedDB) | Mobile (server-backed) |
+|---|---|---|
+| Storage | Local browser storage only | Server database |
+| Survives close | No — auto-closed at 5 PM of start date | Yes — session persists until explicitly stopped |
+| Multi-device | No | Yes — active session is visible on any signed-in device |
+| Privacy | Local until converted | Persisted to server on start |
+
+**Mobile-specific UX features:**
+
+- **One-tap start chip**: Appears on the ticket detail screen. The last-used service is remembered across sessions so technicians can start billing with a single tap.
+- **App-wide timer banner**: A live banner is displayed across all screens while a timer is running, giving technicians a constant reminder and one-tap access to stop.
+- **Stop-and-review modal**: When stopping, technicians see a modal to add notes, toggle billability, and adjust the end time before the entry is recorded.
+- **Android sticky notification**: A persistent notification in the notification shade shows the running timer and lets technicians stop it without reopening the app.
+- **Still-running reminders**: Notifications fire at 1, 2, 4, and 8 hours if the timer is still active, respecting the device's hide-sensitive-notifications setting.
+
+Stopping the mobile timer creates a standard time entry subject to the same time period boundaries and approval workflow as manually entered time.
 
 ### Interval Management
 
@@ -410,7 +442,7 @@ export async function createTimePeriodSettings(settings: Partial<ITimePeriodSett
 
 **Interval Tracking Service:**
 
-The `IntervalTrackingService` class manages the storage and retrieval of ticket viewing intervals:
+The `IntervalTrackingService` class manages the storage and retrieval of ticket viewing intervals in the browser:
 
 ```typescript
 // Key methods in IntervalTrackingService
@@ -549,7 +581,7 @@ These tests cover various scenarios including:
 The Time Entry system provides a robust solution for tracking work hours, managing approvals, and generating time periods. Key features include:
 
 - Flexible time entry recording with both manual and automatic options
-- Automatic interval tracking for ticket-based work
+- Automatic interval tracking for ticket-based work — browser-based (IndexedDB) in the web app and server-backed (REST API sessions) in the mobile app
 - Intelligent interval management with merging and adjustment capabilities
 - Configurable time period settings
 - Automatic time period generation

--- a/docs/ticket_timer_flow.mmd
+++ b/docs/ticket_timer_flow.mmd
@@ -1,4 +1,8 @@
 %% Ticket Timer Flow: Opening a ticket to stopping on leave
+%% Scope: Web browser (Next.js app) only.
+%% The mobile app (iOS/Android) uses server-backed sessions via the start-tracking /
+%% active-session / stop-tracking REST APIs so timers survive app kills and device
+%% switches. See docs/features/time_entry.md § "Mobile App Time Tracking" for that architecture.
 %% This sequence shows current behavior with IntervalTrackingService + State Machine + UI setInterval
 
 sequenceDiagram


### PR DESCRIPTION
## Documentation drift audit — 2026-07-03

**Automated draft. Human review required before merging.**

---

### Source PRs

| # | Title | Link |
|---|-------|------|
| #2837 | Add ticket timer with server-backed sessions | https://github.com/Nine-Minds/alga-psa/pull/2837 |
| #2827 | fix(jobs): make Temporal recurring jobs self-heal | https://github.com/Nine-Minds/alga-psa/pull/2827 |

---

### Files edited

| File | Rationale |
|------|-----------|
| `docs/ticket_timer_flow.mmd` | The diagram title claims to show "the" ticket timer flow, but PR #2837 introduced a completely different server-backed timer in the mobile app (start-tracking / active-session / stop-tracking REST APIs) that persists across app kills and device switches — nothing in the diagram or its title indicated it only covers the browser/IndexedDB path. Added a scope header directing readers to the new mobile architecture section in time_entry.md. |
| `docs/features/time_entry.md` | The Interval Tracking section described only the browser-based IndexedDB tracker (local storage, auto-closed at 5 PM, not multi-device). PR #2837 added a mobile timer with the opposite properties: server-persisted, survives app kills, accessible on any device. Updated the section introduction to name both mechanisms, added a new "Mobile App Time Tracking" subsection documenting the three-endpoint lifecycle, the UX features (timer chip, banner, stop-and-review modal, Android sticky notification, 1/2/4/8h still-running reminders), and the key behavioral differences in a comparison table. Updated the Summary to reflect both tracking mechanisms. |
| `docs/architecture/job_scheduler.md` | PR #2827 changed three significant behaviors not documented anywhere: (1) recurring Temporal tracker rows now reset to `queued` after each fire rather than transitioning to `completed`/`failed` (with outcome in `metadata.lastRunStatus`); (2) handler failures now throw `ApplicationFailure` so runs surface as FAILED in Temporal instead of COMPLETED; (3) a missing tracker row for a live recurring schedule is now detected and self-healed automatically. Added a "Recurring Job Lifecycle (Temporal EE)" section covering all three behaviors, a diagnostic SQL query for recurring rows, and two new Troubleshooting entries (stuck-in-queued and false-COMPLETED history). Added self-healing to the Key Features list. Updated the `external_id` schema comment to note it is nulled on cancel. |

---

### PRs skipped (no doc drift)

| # | Title | Reason |
|---|-------|--------|
| #2836 | Unify ticket list styling across MSP and portal | Pure UI/visual refactor. The substantive fix (status pill color now derived from the status definition rather than the per-ticket `is_closed` flag) corrects an inconsistency but no existing doc describes the coloring logic. The response-state badge visibility fix is also not documented. No in-scope doc is stale. |
| #2835 | Re-point mixed-currency wiring probe at the strengthened invariant | Test-only fix. No behavioral change. |
| #2828 | Update unit tests for tenantDb facade migration | Test updates only. No behavioral change. |

---

### Needs human review

- **Mobile timer API documentation** (PR #2837): The three time-tracking REST endpoints (`start-tracking`, `active-session`, `stop-tracking`) are undocumented beyond what has been added to `docs/features/time_entry.md`. If there is a dedicated API reference for these endpoints (request/response shapes, authentication, error codes), it should be added to `docs/api/`. This auditor was not able to draft that content confidently from the PR diff alone.

- **Portrait lock / barcode scanner change** (PR #2837): The PR also lifts the portrait-lock Play Console flags on the bundled GMS barcode scanner activity. If there is customer-facing or deployment documentation about Android Play Console configuration or the barcode scanner feature, it should be checked for accuracy.

- **OpenAPI staleness**: The time-tracking endpoints may be reflected in the OpenAPI spec. `/sdk/docs/openapi/alga-openapi*.{json,yaml}` and `/packages/nm-store/public/openapi/alga.json` are out of scope for this auditor — please verify via `cd sdk && npm run openapi:generate` and re-sync to nm-store if needed.

- **`docs/architecture/scheduling.md`**: Not read during this audit. If it covers Temporal recurring job scheduling in detail, it may need the same recurring-tracker-lifecycle update applied to `job_scheduler.md`.

---

_Generated by documentation-drift auditor_

---
_Generated by [Claude Code](https://claude.ai/code/session_0162JkQw1NoiQYL5TNZH4ZXZ)_