### PR TITLE
Expose user-activities APIs to the MCP registry

### DIFF
--- a/docs/openapi/route-inventory.csv
+++ b/docs/openapi/route-inventory.csv
@@ -12,6 +12,7 @@ CE,/api/accounting/exports/{batchId}/download,POST,server/src/app/api/accounting
 CE,/api/accounting/exports/{batchId}/errors,POST,server/src/app/api/accounting/exports/[batchId]/errors/route.ts,ApiAccountingExportController,../../../../../../lib/api/controllers/ApiAccountingExportController,server/src/lib/api/controllers/ApiAccountingExportController.ts
 CE,/api/accounting/exports/{batchId}/execute,POST,server/src/app/api/accounting/exports/[batchId]/execute/route.ts,ApiAccountingExportController,../../../../../../lib/api/controllers/ApiAccountingExportController,server/src/lib/api/controllers/ApiAccountingExportController.ts
 CE,/api/accounting/exports/{batchId}/lines,POST,server/src/app/api/accounting/exports/[batchId]/lines/route.ts,ApiAccountingExportController,../../../../../../lib/api/controllers/ApiAccountingExportController,server/src/lib/api/controllers/ApiAccountingExportController.ts
+CE,/api/auth/captcha-config,GET,server/src/app/api/auth/captcha-config/route.ts,,,
 CE,/api/auth/e2e/google/authorize,GET,server/src/app/api/auth/e2e/google/authorize/route.ts,,,
 CE,/api/auth/e2e/google/complete,GET,server/src/app/api/auth/e2e/google/complete/route.ts,,,
 CE,/api/auth/e2e/google/token,POST,server/src/app/api/auth/e2e/google/token/route.ts,,,
@@ -32,7 +33,12 @@ CE,/api/auth/validate-api-key,POST,server/src/app/api/auth/validate-api-key/rout
 CE,/api/auth/validate-token,POST,server/src/app/api/auth/validate-token/route.ts,,,
 CE,/api/auth/{nextauth},GET POST,server/src/app/api/auth/[...nextauth]/route.ts,,,
 CE,/api/billing/check-tenant,GET,server/src/app/api/billing/check-tenant/route.ts,,,
+CE,/api/billing/complete-reactivation,POST,server/src/app/api/billing/complete-reactivation/route.ts,,,
 CE,/api/billing/licence-count,GET POST,server/src/app/api/billing/licence-count/route.ts,,,
+CE,/api/billing/reactivation-password-reset,POST,server/src/app/api/billing/reactivation-password-reset/route.ts,,,
+CE,/api/billing/reactivation-token,POST,server/src/app/api/billing/reactivation-token/route.ts,,,
+CE,/api/billing/reactivation-token/session,POST,server/src/app/api/billing/reactivation-token/session/route.ts,,,
+CE,/api/billing/request-reactivation,POST,server/src/app/api/billing/request-reactivation/route.ts,,,
 CE,/api/calendar/appointment/{id},GET,server/src/app/api/calendar/appointment/[id]/route.ts,,,
 CE,/api/calendar/webhooks/google,GET OPTIONS POST,server/src/app/api/calendar/webhooks/google/route.ts,,,
 CE,/api/calendar/webhooks/microsoft,GET OPTIONS POST,server/src/app/api/calendar/webhooks/microsoft/route.ts,,,
@@ -103,6 +109,7 @@ CE,/api/integrations/entra/sync/runs,GET OPTIONS,server/src/app/api/integrations
 CE,/api/integrations/entra/sync/runs/{runId},GET OPTIONS,server/src/app/api/integrations/entra/sync/runs/[runId]/route.ts,,,
 CE,/api/integrations/entra/validate-cipp,OPTIONS POST,server/src/app/api/integrations/entra/validate-cipp/route.ts,,,
 CE,/api/integrations/entra/validate-direct,OPTIONS POST,server/src/app/api/integrations/entra/validate-direct/route.ts,,,
+CE,/api/integrations/hudu,GET OPTIONS,server/src/app/api/integrations/hudu/route.ts,,,
 CE,/api/integrations/ninjaone/callback,GET,server/src/app/api/integrations/ninjaone/callback/route.ts,,,
 CE,/api/integrations/qbo/callback,GET,server/src/app/api/integrations/qbo/callback/route.ts,,,
 CE,/api/integrations/qbo/connect,GET,server/src/app/api/integrations/qbo/connect/route.ts,,,
@@ -116,6 +123,10 @@ CE,/api/internal/ext-runner/install-config,POST,server/src/app/api/internal/ext-
 CE,/api/internal/ext-scheduler/install/{installId},POST,server/src/app/api/internal/ext-scheduler/install/[installId]/route.ts,,,
 CE,/api/internal/ext-services/install/{installId},POST,server/src/app/api/internal/ext-services/install/[installId]/route.ts,,,
 CE,/api/internal/ext-storage/install/{installId},POST,server/src/app/api/internal/ext-storage/install/[installId]/route.ts,,,
+CE,/api/mcp,GET POST,server/src/app/api/mcp/route.ts,,,
+CE,/api/mcp/oauth/authorize,GET POST,server/src/app/api/mcp/oauth/authorize/route.ts,,,
+CE,/api/mcp/oauth/revoke,POST,server/src/app/api/mcp/oauth/revoke/route.ts,,,
+CE,/api/mcp/oauth/token,POST,server/src/app/api/mcp/oauth/token/route.ts,,,
 CE,/api/online-meetings/recordings/{artifactId},GET,server/src/app/api/online-meetings/recordings/[artifactId]/route.ts,,,
 CE,/api/projects,GET,server/src/app/api/projects/route.ts,,,
 CE,/api/projects/templates,GET POST,server/src/app/api/projects/templates/route.ts,,,
@@ -146,8 +157,18 @@ CE,/api/v1/accounting-exports/xero-csv/client-export,GET,server/src/app/api/v1/a
 CE,/api/v1/accounting-exports/xero-csv/client-import,POST,server/src/app/api/v1/accounting-exports/xero-csv/client-import/route.ts,,,
 CE,/api/v1/accounting-exports/xero-csv/tax-import,POST,server/src/app/api/v1/accounting-exports/xero-csv/tax-import/route.ts,,,
 CE,/api/v1/accounting-exports/{batchId}/download,GET,server/src/app/api/v1/accounting-exports/[batchId]/download/route.ts,,,
+CE,/api/v1/activities,GET,server/src/app/api/v1/activities/route.ts,,,
+CE,/api/v1/activities/ad-hoc,POST,server/src/app/api/v1/activities/ad-hoc/route.ts,,,
+CE,/api/v1/activities/ad-hoc/{id},DELETE PATCH,server/src/app/api/v1/activities/ad-hoc/[id]/route.ts,,,
+CE,/api/v1/activities/ad-hoc/{id}/done,POST,server/src/app/api/v1/activities/ad-hoc/[id]/done/route.ts,,,
+CE,/api/v1/activities/groups,GET,server/src/app/api/v1/activities/groups/route.ts,,,
+CE,/api/v1/activities/groups/items,DELETE POST,server/src/app/api/v1/activities/groups/items/route.ts,,,
+CE,/api/v1/activities/groups/{groupId}/items,PATCH,server/src/app/api/v1/activities/groups/[groupId]/items/route.ts,,,
 CE,/api/v1/admin/telemetry-settings,GET POST,server/src/app/api/v1/admin/telemetry-settings/route.ts,,,
 CE,/api/v1/ai/document-assist,POST,server/src/app/api/v1/ai/document-assist/route.ts,,,
+CE,/api/v1/appliance-installs,GET OPTIONS,server/src/app/api/v1/appliance-installs/route.ts,,,
+CE,/api/v1/appliance-installs/access,OPTIONS POST,server/src/app/api/v1/appliance-installs/access/route.ts,,,
+CE,/api/v1/appliance-installs/{tenantId},GET OPTIONS,server/src/app/api/v1/appliance-installs/[tenantId]/route.ts,,,
 CE,/api/v1/assets,GET POST,server/src/app/api/v1/assets/route.ts,ApiAssetController,@/lib/api/controllers/ApiAssetController,server/src/lib/api/controllers/ApiAssetController.ts
 CE,/api/v1/assets/bulk-status,PUT,server/src/app/api/v1/assets/bulk-status/route.ts,ApiAssetController,@/lib/api/controllers/ApiAssetController,server/src/lib/api/controllers/ApiAssetController.ts
 CE,/api/v1/assets/bulk-update,PUT,server/src/app/api/v1/assets/bulk-update/route.ts,ApiAssetController,@/lib/api/controllers/ApiAssetController,server/src/lib/api/controllers/ApiAssetController.ts
@@ -340,9 +361,19 @@ CE,/api/v1/kb-articles/{id},DELETE GET PUT,server/src/app/api/v1/kb-articles/[id
 CE,/api/v1/kb-articles/{id}/archive,POST,server/src/app/api/v1/kb-articles/[id]/archive/route.ts,ApiKbArticleController,@/lib/api/controllers/ApiKbArticleController,server/src/lib/api/controllers/ApiKbArticleController.ts
 CE,/api/v1/kb-articles/{id}/content,GET PUT,server/src/app/api/v1/kb-articles/[id]/content/route.ts,ApiKbArticleController,@/lib/api/controllers/ApiKbArticleController,server/src/lib/api/controllers/ApiKbArticleController.ts
 CE,/api/v1/kb-articles/{id}/publish,POST,server/src/app/api/v1/kb-articles/[id]/publish/route.ts,ApiKbArticleController,@/lib/api/controllers/ApiKbArticleController,server/src/lib/api/controllers/ApiKbArticleController.ts
+CE,/api/v1/mcp/agents,DELETE GET PATCH POST,server/src/app/api/v1/mcp/agents/route.ts,,,
+CE,/api/v1/mcp/audit,GET,server/src/app/api/v1/mcp/audit/route.ts,,,
+CE,/api/v1/mcp/connect/callback,GET,server/src/app/api/v1/mcp/connect/callback/route.ts,,,
+CE,/api/v1/mcp/connect/start,POST,server/src/app/api/v1/mcp/connect/start/route.ts,,,
+CE,/api/v1/mcp/connections,DELETE GET,server/src/app/api/v1/mcp/connections/route.ts,,,
+CE,/api/v1/mcp/idp-providers,GET POST,server/src/app/api/v1/mcp/idp-providers/route.ts,,,
+CE,/api/v1/mcp/idp-suggestions,GET,server/src/app/api/v1/mcp/idp-suggestions/route.ts,,,
+CE,/api/v1/mcp/platform-providers,GET,server/src/app/api/v1/mcp/platform-providers/route.ts,,,
+CE,/api/v1/mcp/roles,GET,server/src/app/api/v1/mcp/roles/route.ts,,,
 CE,/api/v1/meta/docs,GET,server/src/app/api/v1/meta/docs/route.ts,ApiMetadataController,@/lib/api/controllers/ApiMetadataController,server/src/lib/api/controllers/ApiMetadataController.ts
 CE,/api/v1/meta/endpoints,GET,server/src/app/api/v1/meta/endpoints/route.ts,ApiMetadataController,@/lib/api/controllers/ApiMetadataController,server/src/lib/api/controllers/ApiMetadataController.ts
 CE,/api/v1/meta/health,GET,server/src/app/api/v1/meta/health/route.ts,ApiMetadataController,@/lib/api/controllers/ApiMetadataController,server/src/lib/api/controllers/ApiMetadataController.ts
+CE,/api/v1/meta/mcp-registry,GET,server/src/app/api/v1/meta/mcp-registry/route.ts,ApiMetadataController,@/lib/api/controllers/ApiMetadataController,server/src/lib/api/controllers/ApiMetadataController.ts
 CE,/api/v1/meta/openapi,GET,server/src/app/api/v1/meta/openapi/route.ts,ApiMetadataController,@/lib/api/controllers/ApiMetadataController,server/src/lib/api/controllers/ApiMetadataController.ts
 CE,/api/v1/meta/permissions,GET,server/src/app/api/v1/meta/permissions/route.ts,ApiMetadataController,@/lib/api/controllers/ApiMetadataController,server/src/lib/api/controllers/ApiMetadataController.ts
 CE,/api/v1/meta/schemas,GET,server/src/app/api/v1/meta/schemas/route.ts,ApiMetadataController,@/lib/api/controllers/ApiMetadataController,server/src/lib/api/controllers/ApiMetadataController.ts
@@ -606,6 +637,13 @@ CE,/api/v1/webhooks/{id}/secret/rotate,POST,server/src/app/api/v1/webhooks/[id]/
 CE,/api/v1/webhooks/{id}/subscriptions,GET,server/src/app/api/v1/webhooks/[id]/subscriptions/route.ts,ApiWebhookController,server/src/lib/api/controllers/ApiWebhookController,server/src/lib/api/controllers/ApiWebhookController.ts
 CE,/api/v1/webhooks/{id}/test,POST,server/src/app/api/v1/webhooks/[id]/test/route.ts,ApiWebhookController,server/src/lib/api/controllers/ApiWebhookController,server/src/lib/api/controllers/ApiWebhookController.ts
 CE,/api/v1/workflows,GET,server/src/app/api/v1/workflows/route.ts,,,
+CE,/api/v1/workflows/tasks,GET,server/src/app/api/v1/workflows/tasks/route.ts,,,
+CE,/api/v1/workflows/tasks/{id},GET,server/src/app/api/v1/workflows/tasks/[id]/route.ts,,,
+CE,/api/v1/workflows/tasks/{id}/claim,POST,server/src/app/api/v1/workflows/tasks/[id]/claim/route.ts,,,
+CE,/api/v1/workflows/tasks/{id}/complete,POST,server/src/app/api/v1/workflows/tasks/[id]/complete/route.ts,,,
+CE,/api/v1/workflows/tasks/{id}/unclaim,POST,server/src/app/api/v1/workflows/tasks/[id]/unclaim/route.ts,,,
+CE,/api/webhooks/alternative-payments,GET POST,server/src/app/api/webhooks/alternative-payments/route.ts,,,
+CE,/api/webhooks/levelio,OPTIONS POST,server/src/app/api/webhooks/levelio/route.ts,,,
 CE,/api/webhooks/ninjaone,GET OPTIONS POST,server/src/app/api/webhooks/ninjaone/route.ts,,,
 CE,/api/webhooks/stripe,POST,server/src/app/api/webhooks/stripe/route.ts,,,
 CE,/api/webhooks/stripe/payments,POST,server/src/app/api/webhooks/stripe/payments/route.ts,,,
@@ -630,9 +668,6 @@ CE,/api/workflow-runs/{runId}/audit/export,GET,server/src/app/api/workflow-runs/
 CE,/api/workflow-runs/{runId}/cancel,POST,server/src/app/api/workflow-runs/[runId]/cancel/route.ts,,,
 CE,/api/workflow-runs/{runId}/export,GET,server/src/app/api/workflow-runs/[runId]/export/route.ts,,,
 CE,/api/workflow-runs/{runId}/replay,POST,server/src/app/api/workflow-runs/[runId]/replay/route.ts,,,
-CE,/api/workflow-runs/{runId}/requeue,POST,server/src/app/api/workflow-runs/[runId]/requeue/route.ts,,,
-CE,/api/workflow-runs/{runId}/resume,POST,server/src/app/api/workflow-runs/[runId]/resume/route.ts,,,
-CE,/api/workflow-runs/{runId}/retry,POST,server/src/app/api/workflow-runs/[runId]/retry/route.ts,,,
 CE,/api/workflow-runs/{runId}/steps,GET,server/src/app/api/workflow-runs/[runId]/steps/route.ts,,,
 CE,/api/workflow-runs/{runId}/summary,GET,server/src/app/api/workflow-runs/[runId]/summary/route.ts,,,
 CE,/api/workflow-runs/{runId}/timeline,GET,server/src/app/api/workflow-runs/[runId]/timeline/route.ts,,,
@@ -647,6 +682,12 @@ CE,/api/workflow/registry/schemas/{schemaRef},GET,server/src/app/api/workflow/re
 EE,/api/auth/google/calendar/callback,GET,ee/server/src/app/api/auth/google/calendar/callback/route.ts,,,
 EE,/api/auth/microsoft/calendar/callback,GET,ee/server/src/app/api/auth/microsoft/calendar/callback/route.ts,,,
 EE,/api/auth/microsoft/entra/callback,GET,ee/server/src/app/api/auth/microsoft/entra/callback/route.ts,,,
+EE,/api/billing/check-tenant,GET,ee/server/src/app/api/billing/check-tenant/route.ts,,,
+EE,/api/billing/complete-reactivation,POST,ee/server/src/app/api/billing/complete-reactivation/route.ts,,,
+EE,/api/billing/reactivation-password-reset,POST,ee/server/src/app/api/billing/reactivation-password-reset/route.ts,,,
+EE,/api/billing/reactivation-token,POST,ee/server/src/app/api/billing/reactivation-token/route.ts,,,
+EE,/api/billing/reactivation-token/session,POST,ee/server/src/app/api/billing/reactivation-token/session/route.ts,,,
+EE,/api/billing/request-reactivation,POST,ee/server/src/app/api/billing/request-reactivation/route.ts,,,
 EE,/api/calendar/webhooks/google,GET OPTIONS POST,ee/server/src/app/api/calendar/webhooks/google/route.ts,,,
 EE,/api/calendar/webhooks/microsoft,GET OPTIONS POST,ee/server/src/app/api/calendar/webhooks/microsoft/route.ts,,,
 EE,/api/ext-bundles/abort,POST,ee/server/src/app/api/ext-bundles/abort/route.ts,,,
@@ -680,6 +721,7 @@ EE,/api/integrations/entra/sync/runs,GET,ee/server/src/app/api/integrations/entr
 EE,/api/integrations/entra/sync/runs/{runId},GET,ee/server/src/app/api/integrations/entra/sync/runs/[runId]/route.ts,,,
 EE,/api/integrations/entra/validate-cipp,POST,ee/server/src/app/api/integrations/entra/validate-cipp/route.ts,,,
 EE,/api/integrations/entra/validate-direct,POST,ee/server/src/app/api/integrations/entra/validate-direct/route.ts,,,
+EE,/api/integrations/hudu,GET,ee/server/src/app/api/integrations/hudu/route.ts,,,
 EE,/api/integrations/ninjaone/callback,GET,ee/server/src/app/api/integrations/ninjaone/callback/route.ts,,,
 EE,/api/internal/ext-clients/install/{installId},POST,ee/server/src/app/api/internal/ext-clients/install/[installId]/route.ts,,,
 EE,/api/internal/ext-invoicing/install/{installId},POST,ee/server/src/app/api/internal/ext-invoicing/install/[installId]/route.ts,,,
@@ -696,6 +738,9 @@ EE,/api/teams/message-extension/query,POST,ee/server/src/app/api/teams/message-e
 EE,/api/teams/package,GET OPTIONS POST,ee/server/src/app/api/teams/package/route.ts,,,
 EE,/api/teams/package/download,GET OPTIONS,ee/server/src/app/api/teams/package/download/route.ts,,,
 EE,/api/teams/quick-actions,POST,ee/server/src/app/api/teams/quick-actions/route.ts,,,
+EE,/api/v1/appliance-installs,GET,ee/server/src/app/api/v1/appliance-installs/route.ts,,,
+EE,/api/v1/appliance-installs/access,POST,ee/server/src/app/api/v1/appliance-installs/access/route.ts,,,
+EE,/api/v1/appliance-installs/{tenantId},GET,ee/server/src/app/api/v1/appliance-installs/[tenantId]/route.ts,,,
 EE,/api/v1/auth/verify,POST,ee/server/src/app/api/v1/auth/verify/route.ts,,,
 EE,/api/v1/extensions/install,POST,ee/server/src/app/api/v1/extensions/install/route.ts,,,
 EE,/api/v1/extensions/uninstall,POST,ee/server/src/app/api/v1/extensions/uninstall/route.ts,,,
@@ -729,4 +774,5 @@ EE,/api/v1/tenant-management/start-deletion,POST,ee/server/src/app/api/v1/tenant
 EE,/api/v1/tenant-management/start-premium-trial,POST,ee/server/src/app/api/v1/tenant-management/start-premium-trial/route.ts,,,
 EE,/api/v1/tenant-management/tenants,GET,ee/server/src/app/api/v1/tenant-management/tenants/route.ts,,,
 EE,/api/v1/tenant-management/tenants/{tenantId}/addons,POST,ee/server/src/app/api/v1/tenant-management/tenants/[tenantId]/addons/route.ts,,,
+EE,/api/webhooks/levelio,OPTIONS POST,ee/server/src/app/api/webhooks/levelio/route.ts,,,
 EE,/api/webhooks/ninjaone,GET OPTIONS POST,ee/server/src/app/api/webhooks/ninjaone/route.ts,,,

--- a/docs/openapi/route-inventory.json
+++ b/docs/openapi/route-inventory.json
@@ -146,6 +146,17 @@
   },
   {
     "edition": "CE",
+    "route_path": "/api/auth/captcha-config",
+    "methods": [
+      "GET"
+    ],
+    "route_file": "server/src/app/api/auth/captcha-config/route.ts",
+    "controller": "",
+    "controller_import": "",
+    "controller_file": ""
+  },
+  {
+    "edition": "CE",
     "route_path": "/api/auth/e2e/google/authorize",
     "methods": [
       "GET"
@@ -368,12 +379,67 @@
   },
   {
     "edition": "CE",
+    "route_path": "/api/billing/complete-reactivation",
+    "methods": [
+      "POST"
+    ],
+    "route_file": "server/src/app/api/billing/complete-reactivation/route.ts",
+    "controller": "",
+    "controller_import": "",
+    "controller_file": ""
+  },
+  {
+    "edition": "CE",
     "route_path": "/api/billing/licence-count",
     "methods": [
       "GET",
       "POST"
     ],
     "route_file": "server/src/app/api/billing/licence-count/route.ts",
+    "controller": "",
+    "controller_import": "",
+    "controller_file": ""
+  },
+  {
+    "edition": "CE",
+    "route_path": "/api/billing/reactivation-password-reset",
+    "methods": [
+      "POST"
+    ],
+    "route_file": "server/src/app/api/billing/reactivation-password-reset/route.ts",
+    "controller": "",
+    "controller_import": "",
+    "controller_file": ""
+  },
+  {
+    "edition": "CE",
+    "route_path": "/api/billing/reactivation-token",
+    "methods": [
+      "POST"
+    ],
+    "route_file": "server/src/app/api/billing/reactivation-token/route.ts",
+    "controller": "",
+    "controller_import": "",
+    "controller_file": ""
+  },
+  {
+    "edition": "CE",
+    "route_path": "/api/billing/reactivation-token/session",
+    "methods": [
+      "POST"
+    ],
+    "route_file": "server/src/app/api/billing/reactivation-token/session/route.ts",
+    "controller": "",
+    "controller_import": "",
+    "controller_file": ""
+  },
+  {
+    "edition": "CE",
+    "route_path": "/api/billing/request-reactivation",
+    "methods": [
+      "POST"
+    ],
+    "route_file": "server/src/app/api/billing/request-reactivation/route.ts",
     "controller": "",
     "controller_import": "",
     "controller_file": ""
@@ -1184,6 +1250,18 @@
   },
   {
     "edition": "CE",
+    "route_path": "/api/integrations/hudu",
+    "methods": [
+      "GET",
+      "OPTIONS"
+    ],
+    "route_file": "server/src/app/api/integrations/hudu/route.ts",
+    "controller": "",
+    "controller_import": "",
+    "controller_file": ""
+  },
+  {
+    "edition": "CE",
     "route_path": "/api/integrations/ninjaone/callback",
     "methods": [
       "GET"
@@ -1321,6 +1399,52 @@
       "POST"
     ],
     "route_file": "server/src/app/api/internal/ext-storage/install/[installId]/route.ts",
+    "controller": "",
+    "controller_import": "",
+    "controller_file": ""
+  },
+  {
+    "edition": "CE",
+    "route_path": "/api/mcp",
+    "methods": [
+      "GET",
+      "POST"
+    ],
+    "route_file": "server/src/app/api/mcp/route.ts",
+    "controller": "",
+    "controller_import": "",
+    "controller_file": ""
+  },
+  {
+    "edition": "CE",
+    "route_path": "/api/mcp/oauth/authorize",
+    "methods": [
+      "GET",
+      "POST"
+    ],
+    "route_file": "server/src/app/api/mcp/oauth/authorize/route.ts",
+    "controller": "",
+    "controller_import": "",
+    "controller_file": ""
+  },
+  {
+    "edition": "CE",
+    "route_path": "/api/mcp/oauth/revoke",
+    "methods": [
+      "POST"
+    ],
+    "route_file": "server/src/app/api/mcp/oauth/revoke/route.ts",
+    "controller": "",
+    "controller_import": "",
+    "controller_file": ""
+  },
+  {
+    "edition": "CE",
+    "route_path": "/api/mcp/oauth/token",
+    "methods": [
+      "POST"
+    ],
+    "route_file": "server/src/app/api/mcp/oauth/token/route.ts",
     "controller": "",
     "controller_import": "",
     "controller_file": ""
@@ -1675,6 +1799,85 @@
   },
   {
     "edition": "CE",
+    "route_path": "/api/v1/activities",
+    "methods": [
+      "GET"
+    ],
+    "route_file": "server/src/app/api/v1/activities/route.ts",
+    "controller": "",
+    "controller_import": "",
+    "controller_file": ""
+  },
+  {
+    "edition": "CE",
+    "route_path": "/api/v1/activities/ad-hoc",
+    "methods": [
+      "POST"
+    ],
+    "route_file": "server/src/app/api/v1/activities/ad-hoc/route.ts",
+    "controller": "",
+    "controller_import": "",
+    "controller_file": ""
+  },
+  {
+    "edition": "CE",
+    "route_path": "/api/v1/activities/ad-hoc/{id}",
+    "methods": [
+      "DELETE",
+      "PATCH"
+    ],
+    "route_file": "server/src/app/api/v1/activities/ad-hoc/[id]/route.ts",
+    "controller": "",
+    "controller_import": "",
+    "controller_file": ""
+  },
+  {
+    "edition": "CE",
+    "route_path": "/api/v1/activities/ad-hoc/{id}/done",
+    "methods": [
+      "POST"
+    ],
+    "route_file": "server/src/app/api/v1/activities/ad-hoc/[id]/done/route.ts",
+    "controller": "",
+    "controller_import": "",
+    "controller_file": ""
+  },
+  {
+    "edition": "CE",
+    "route_path": "/api/v1/activities/groups",
+    "methods": [
+      "GET"
+    ],
+    "route_file": "server/src/app/api/v1/activities/groups/route.ts",
+    "controller": "",
+    "controller_import": "",
+    "controller_file": ""
+  },
+  {
+    "edition": "CE",
+    "route_path": "/api/v1/activities/groups/items",
+    "methods": [
+      "DELETE",
+      "POST"
+    ],
+    "route_file": "server/src/app/api/v1/activities/groups/items/route.ts",
+    "controller": "",
+    "controller_import": "",
+    "controller_file": ""
+  },
+  {
+    "edition": "CE",
+    "route_path": "/api/v1/activities/groups/{groupId}/items",
+    "methods": [
+      "PATCH"
+    ],
+    "route_file": "server/src/app/api/v1/activities/groups/[groupId]/items/route.ts",
+    "controller": "",
+    "controller_import": "",
+    "controller_file": ""
+  },
+  {
+    "edition": "CE",
     "route_path": "/api/v1/admin/telemetry-settings",
     "methods": [
       "GET",
@@ -1692,6 +1895,42 @@
       "POST"
     ],
     "route_file": "server/src/app/api/v1/ai/document-assist/route.ts",
+    "controller": "",
+    "controller_import": "",
+    "controller_file": ""
+  },
+  {
+    "edition": "CE",
+    "route_path": "/api/v1/appliance-installs",
+    "methods": [
+      "GET",
+      "OPTIONS"
+    ],
+    "route_file": "server/src/app/api/v1/appliance-installs/route.ts",
+    "controller": "",
+    "controller_import": "",
+    "controller_file": ""
+  },
+  {
+    "edition": "CE",
+    "route_path": "/api/v1/appliance-installs/access",
+    "methods": [
+      "OPTIONS",
+      "POST"
+    ],
+    "route_file": "server/src/app/api/v1/appliance-installs/access/route.ts",
+    "controller": "",
+    "controller_import": "",
+    "controller_file": ""
+  },
+  {
+    "edition": "CE",
+    "route_path": "/api/v1/appliance-installs/{tenantId}",
+    "methods": [
+      "GET",
+      "OPTIONS"
+    ],
+    "route_file": "server/src/app/api/v1/appliance-installs/[tenantId]/route.ts",
     "controller": "",
     "controller_import": "",
     "controller_file": ""
@@ -3878,6 +4117,110 @@
   },
   {
     "edition": "CE",
+    "route_path": "/api/v1/mcp/agents",
+    "methods": [
+      "DELETE",
+      "GET",
+      "PATCH",
+      "POST"
+    ],
+    "route_file": "server/src/app/api/v1/mcp/agents/route.ts",
+    "controller": "",
+    "controller_import": "",
+    "controller_file": ""
+  },
+  {
+    "edition": "CE",
+    "route_path": "/api/v1/mcp/audit",
+    "methods": [
+      "GET"
+    ],
+    "route_file": "server/src/app/api/v1/mcp/audit/route.ts",
+    "controller": "",
+    "controller_import": "",
+    "controller_file": ""
+  },
+  {
+    "edition": "CE",
+    "route_path": "/api/v1/mcp/connect/callback",
+    "methods": [
+      "GET"
+    ],
+    "route_file": "server/src/app/api/v1/mcp/connect/callback/route.ts",
+    "controller": "",
+    "controller_import": "",
+    "controller_file": ""
+  },
+  {
+    "edition": "CE",
+    "route_path": "/api/v1/mcp/connect/start",
+    "methods": [
+      "POST"
+    ],
+    "route_file": "server/src/app/api/v1/mcp/connect/start/route.ts",
+    "controller": "",
+    "controller_import": "",
+    "controller_file": ""
+  },
+  {
+    "edition": "CE",
+    "route_path": "/api/v1/mcp/connections",
+    "methods": [
+      "DELETE",
+      "GET"
+    ],
+    "route_file": "server/src/app/api/v1/mcp/connections/route.ts",
+    "controller": "",
+    "controller_import": "",
+    "controller_file": ""
+  },
+  {
+    "edition": "CE",
+    "route_path": "/api/v1/mcp/idp-providers",
+    "methods": [
+      "GET",
+      "POST"
+    ],
+    "route_file": "server/src/app/api/v1/mcp/idp-providers/route.ts",
+    "controller": "",
+    "controller_import": "",
+    "controller_file": ""
+  },
+  {
+    "edition": "CE",
+    "route_path": "/api/v1/mcp/idp-suggestions",
+    "methods": [
+      "GET"
+    ],
+    "route_file": "server/src/app/api/v1/mcp/idp-suggestions/route.ts",
+    "controller": "",
+    "controller_import": "",
+    "controller_file": ""
+  },
+  {
+    "edition": "CE",
+    "route_path": "/api/v1/mcp/platform-providers",
+    "methods": [
+      "GET"
+    ],
+    "route_file": "server/src/app/api/v1/mcp/platform-providers/route.ts",
+    "controller": "",
+    "controller_import": "",
+    "controller_file": ""
+  },
+  {
+    "edition": "CE",
+    "route_path": "/api/v1/mcp/roles",
+    "methods": [
+      "GET"
+    ],
+    "route_file": "server/src/app/api/v1/mcp/roles/route.ts",
+    "controller": "",
+    "controller_import": "",
+    "controller_file": ""
+  },
+  {
+    "edition": "CE",
     "route_path": "/api/v1/meta/docs",
     "methods": [
       "GET"
@@ -3905,6 +4248,17 @@
       "GET"
     ],
     "route_file": "server/src/app/api/v1/meta/health/route.ts",
+    "controller": "ApiMetadataController",
+    "controller_import": "@/lib/api/controllers/ApiMetadataController",
+    "controller_file": "server/src/lib/api/controllers/ApiMetadataController.ts"
+  },
+  {
+    "edition": "CE",
+    "route_path": "/api/v1/meta/mcp-registry",
+    "methods": [
+      "GET"
+    ],
+    "route_file": "server/src/app/api/v1/meta/mcp-registry/route.ts",
     "controller": "ApiMetadataController",
     "controller_import": "@/lib/api/controllers/ApiMetadataController",
     "controller_file": "server/src/lib/api/controllers/ApiMetadataController.ts"
@@ -6927,6 +7281,85 @@
   },
   {
     "edition": "CE",
+    "route_path": "/api/v1/workflows/tasks",
+    "methods": [
+      "GET"
+    ],
+    "route_file": "server/src/app/api/v1/workflows/tasks/route.ts",
+    "controller": "",
+    "controller_import": "",
+    "controller_file": ""
+  },
+  {
+    "edition": "CE",
+    "route_path": "/api/v1/workflows/tasks/{id}",
+    "methods": [
+      "GET"
+    ],
+    "route_file": "server/src/app/api/v1/workflows/tasks/[id]/route.ts",
+    "controller": "",
+    "controller_import": "",
+    "controller_file": ""
+  },
+  {
+    "edition": "CE",
+    "route_path": "/api/v1/workflows/tasks/{id}/claim",
+    "methods": [
+      "POST"
+    ],
+    "route_file": "server/src/app/api/v1/workflows/tasks/[id]/claim/route.ts",
+    "controller": "",
+    "controller_import": "",
+    "controller_file": ""
+  },
+  {
+    "edition": "CE",
+    "route_path": "/api/v1/workflows/tasks/{id}/complete",
+    "methods": [
+      "POST"
+    ],
+    "route_file": "server/src/app/api/v1/workflows/tasks/[id]/complete/route.ts",
+    "controller": "",
+    "controller_import": "",
+    "controller_file": ""
+  },
+  {
+    "edition": "CE",
+    "route_path": "/api/v1/workflows/tasks/{id}/unclaim",
+    "methods": [
+      "POST"
+    ],
+    "route_file": "server/src/app/api/v1/workflows/tasks/[id]/unclaim/route.ts",
+    "controller": "",
+    "controller_import": "",
+    "controller_file": ""
+  },
+  {
+    "edition": "CE",
+    "route_path": "/api/webhooks/alternative-payments",
+    "methods": [
+      "GET",
+      "POST"
+    ],
+    "route_file": "server/src/app/api/webhooks/alternative-payments/route.ts",
+    "controller": "",
+    "controller_import": "",
+    "controller_file": ""
+  },
+  {
+    "edition": "CE",
+    "route_path": "/api/webhooks/levelio",
+    "methods": [
+      "OPTIONS",
+      "POST"
+    ],
+    "route_file": "server/src/app/api/webhooks/levelio/route.ts",
+    "controller": "",
+    "controller_import": "",
+    "controller_file": ""
+  },
+  {
+    "edition": "CE",
     "route_path": "/api/webhooks/ninjaone",
     "methods": [
       "GET",
@@ -7197,39 +7630,6 @@
   },
   {
     "edition": "CE",
-    "route_path": "/api/workflow-runs/{runId}/requeue",
-    "methods": [
-      "POST"
-    ],
-    "route_file": "server/src/app/api/workflow-runs/[runId]/requeue/route.ts",
-    "controller": "",
-    "controller_import": "",
-    "controller_file": ""
-  },
-  {
-    "edition": "CE",
-    "route_path": "/api/workflow-runs/{runId}/resume",
-    "methods": [
-      "POST"
-    ],
-    "route_file": "server/src/app/api/workflow-runs/[runId]/resume/route.ts",
-    "controller": "",
-    "controller_import": "",
-    "controller_file": ""
-  },
-  {
-    "edition": "CE",
-    "route_path": "/api/workflow-runs/{runId}/retry",
-    "methods": [
-      "POST"
-    ],
-    "route_file": "server/src/app/api/workflow-runs/[runId]/retry/route.ts",
-    "controller": "",
-    "controller_import": "",
-    "controller_file": ""
-  },
-  {
-    "edition": "CE",
     "route_path": "/api/workflow-runs/{runId}/steps",
     "methods": [
       "GET"
@@ -7379,6 +7779,72 @@
       "GET"
     ],
     "route_file": "ee/server/src/app/api/auth/microsoft/entra/callback/route.ts",
+    "controller": "",
+    "controller_import": "",
+    "controller_file": ""
+  },
+  {
+    "edition": "EE",
+    "route_path": "/api/billing/check-tenant",
+    "methods": [
+      "GET"
+    ],
+    "route_file": "ee/server/src/app/api/billing/check-tenant/route.ts",
+    "controller": "",
+    "controller_import": "",
+    "controller_file": ""
+  },
+  {
+    "edition": "EE",
+    "route_path": "/api/billing/complete-reactivation",
+    "methods": [
+      "POST"
+    ],
+    "route_file": "ee/server/src/app/api/billing/complete-reactivation/route.ts",
+    "controller": "",
+    "controller_import": "",
+    "controller_file": ""
+  },
+  {
+    "edition": "EE",
+    "route_path": "/api/billing/reactivation-password-reset",
+    "methods": [
+      "POST"
+    ],
+    "route_file": "ee/server/src/app/api/billing/reactivation-password-reset/route.ts",
+    "controller": "",
+    "controller_import": "",
+    "controller_file": ""
+  },
+  {
+    "edition": "EE",
+    "route_path": "/api/billing/reactivation-token",
+    "methods": [
+      "POST"
+    ],
+    "route_file": "ee/server/src/app/api/billing/reactivation-token/route.ts",
+    "controller": "",
+    "controller_import": "",
+    "controller_file": ""
+  },
+  {
+    "edition": "EE",
+    "route_path": "/api/billing/reactivation-token/session",
+    "methods": [
+      "POST"
+    ],
+    "route_file": "ee/server/src/app/api/billing/reactivation-token/session/route.ts",
+    "controller": "",
+    "controller_import": "",
+    "controller_file": ""
+  },
+  {
+    "edition": "EE",
+    "route_path": "/api/billing/request-reactivation",
+    "methods": [
+      "POST"
+    ],
+    "route_file": "ee/server/src/app/api/billing/request-reactivation/route.ts",
     "controller": "",
     "controller_import": "",
     "controller_file": ""
@@ -7758,6 +8224,17 @@
   },
   {
     "edition": "EE",
+    "route_path": "/api/integrations/hudu",
+    "methods": [
+      "GET"
+    ],
+    "route_file": "ee/server/src/app/api/integrations/hudu/route.ts",
+    "controller": "",
+    "controller_import": "",
+    "controller_file": ""
+  },
+  {
+    "edition": "EE",
     "route_path": "/api/integrations/ninjaone/callback",
     "methods": [
       "GET"
@@ -7931,6 +8408,39 @@
       "POST"
     ],
     "route_file": "ee/server/src/app/api/teams/quick-actions/route.ts",
+    "controller": "",
+    "controller_import": "",
+    "controller_file": ""
+  },
+  {
+    "edition": "EE",
+    "route_path": "/api/v1/appliance-installs",
+    "methods": [
+      "GET"
+    ],
+    "route_file": "ee/server/src/app/api/v1/appliance-installs/route.ts",
+    "controller": "",
+    "controller_import": "",
+    "controller_file": ""
+  },
+  {
+    "edition": "EE",
+    "route_path": "/api/v1/appliance-installs/access",
+    "methods": [
+      "POST"
+    ],
+    "route_file": "ee/server/src/app/api/v1/appliance-installs/access/route.ts",
+    "controller": "",
+    "controller_import": "",
+    "controller_file": ""
+  },
+  {
+    "edition": "EE",
+    "route_path": "/api/v1/appliance-installs/{tenantId}",
+    "methods": [
+      "GET"
+    ],
+    "route_file": "ee/server/src/app/api/v1/appliance-installs/[tenantId]/route.ts",
     "controller": "",
     "controller_import": "",
     "controller_file": ""
@@ -8309,6 +8819,18 @@
       "POST"
     ],
     "route_file": "ee/server/src/app/api/v1/tenant-management/tenants/[tenantId]/addons/route.ts",
+    "controller": "",
+    "controller_import": "",
+    "controller_file": ""
+  },
+  {
+    "edition": "EE",
+    "route_path": "/api/webhooks/levelio",
+    "methods": [
+      "OPTIONS",
+      "POST"
+    ],
+    "route_file": "ee/server/src/app/api/webhooks/levelio/route.ts",
     "controller": "",
     "controller_import": "",
     "controller_file": ""

--- a/ee/docs/api-registry/activities.json
+++ b/ee/docs/api-registry/activities.json
@@ -1,0 +1,79 @@
+{
+  "entries": [
+    {
+      "match": {
+        "method": "get",
+        "path": "/api/v1/activities"
+      },
+      "metadata": {
+        "displayName": "List My Activities",
+        "summary": "Fetch the authenticated user's unified activity list (the User Activities screen)",
+        "description": "Returns the caller's own work items exactly as the User Activities screen shows them: a unified, paginated fan-out across tickets, project tasks, schedule entries, ad-hoc to-dos, workflow tasks, time entries and notifications. Each activity carries id, type, title, status and priority. Filter with type (comma-separated: ticket, projectTask, schedule, workflowTask, timeEntry, notification, document; ad-hoc to-dos surface as schedule), status (open/closed/all), search, due-date and created-date windows; sort with sortBy/sortDirection. This endpoint is always scoped to the authenticated caller — use it for questions like \"what is on my plate\" or \"my open tickets on my activities screen\". For tenant-wide ticket queries use GET /api/v1/tickets instead.",
+        "examples": [
+          {
+            "name": "My open ticket activities",
+            "request": {
+              "query": {
+                "type": "ticket",
+                "status": "open",
+                "pageSize": 50
+              }
+            },
+            "notes": "Returns the ticket activities the caller sees on their User Activities screen. Each activity's id is the ticket UUID, usable with GET /api/v1/tickets/{id}."
+          }
+        ]
+      }
+    },
+    {
+      "match": {
+        "method": "get",
+        "path": "/api/v1/activities/groups"
+      },
+      "metadata": {
+        "displayName": "List My Activity Groups",
+        "summary": "Fetch the caller's named custom groups from the User Activities screen",
+        "description": "Returns the personal, user-defined groups the caller created on the User Activities screen (for example a group named \"Basics\"), each with its ordered items. Items are references: { activityId, activityType, sortOrder } — for activityType \"ticket\" the activityId is the ticket UUID. To answer \"what tickets are in my <name> group\": call this endpoint, find the group by groupName (case-insensitive match on what the user said), then resolve each item, e.g. ticket items via GET /api/v1/tickets/{id} or by matching ids against GET /api/v1/activities. Groups are per-user; pass targetUserId only to read another internal user's groups (requires user_schedule:update or user_schedule:read_all).",
+        "examples": [
+          {
+            "name": "What is in my \"Basics\" group?",
+            "request": {},
+            "notes": "Find the entry whose groupName is \"Basics\" in the response, then look up each item: for activityType \"ticket\" call GET /api/v1/tickets/{activityId} (or filter a GET /api/v1/activities?type=ticket result by the collected ids) to get titles and statuses."
+          }
+        ]
+      }
+    },
+    {
+      "match": {
+        "method": "post",
+        "path": "/api/v1/activities/groups/items"
+      },
+      "metadata": {
+        "displayName": "Move Activity Into My Group",
+        "summary": "Put one of the caller's activities into one of their custom groups",
+        "description": "Moves an activity into one of the caller's own User Activities groups at the given sortOrder position, removing it from any other of their groups first (an activity lives in at most one group). Get groupId values from GET /api/v1/activities/groups. Only organizes the caller's own view — it never changes the underlying ticket/task."
+      }
+    },
+    {
+      "match": {
+        "method": "delete",
+        "path": "/api/v1/activities/groups/items"
+      },
+      "metadata": {
+        "displayName": "Remove Activity From My Groups",
+        "summary": "Make one of the caller's activities ungrouped",
+        "description": "Removes an activity from all of the caller's User Activities groups so it shows as ungrouped. No-op when the activity is not in any group. Only affects the caller's own view."
+      }
+    },
+    {
+      "match": {
+        "method": "patch",
+        "path": "/api/v1/activities/groups/{groupId}/items"
+      },
+      "metadata": {
+        "displayName": "Reorder My Group's Activities",
+        "summary": "Persist a new ordering of the activities inside one of the caller's groups",
+        "description": "Replaces the ordering of a group's members: pass every item with its new sortOrder (position). Scoped to the caller's own groups from GET /api/v1/activities/groups."
+      }
+    }
+  ]
+}

--- a/ee/server/src/chat/registry/apiRegistry.generated.ts
+++ b/ee/server/src/chat/registry/apiRegistry.generated.ts
@@ -35398,8 +35398,7 @@ export const chatApiRegistry: ChatApiRegistryEntry[] = [
         "currency_code": {
           "type": "string",
           "minLength": 3,
-          "maxLength": 3,
-          "default": "USD"
+          "maxLength": 3
         },
         "unit_of_measure": {
           "type": "string",
@@ -35489,8 +35488,7 @@ export const chatApiRegistry: ChatApiRegistryEntry[] = [
             {
               "type": "null"
             }
-          ],
-          "default": "USD"
+          ]
         },
         "vendor": {
           "anyOf": [
@@ -35707,8 +35705,7 @@ export const chatApiRegistry: ChatApiRegistryEntry[] = [
         "currency_code": {
           "type": "string",
           "minLength": 3,
-          "maxLength": 3,
-          "default": "USD"
+          "maxLength": 3
         },
         "unit_of_measure": {
           "type": "string",
@@ -35798,8 +35795,7 @@ export const chatApiRegistry: ChatApiRegistryEntry[] = [
             {
               "type": "null"
             }
-          ],
-          "default": "USD"
+          ]
         },
         "vendor": {
           "anyOf": [
@@ -38276,14 +38272,195 @@ export const chatApiRegistry: ChatApiRegistryEntry[] = [
     "id": "get-_api_v1_workflows_tasks",
     "method": "get",
     "path": "/api/v1/workflows/tasks",
-    "displayName": "List workflow tasks (route inventory only)",
-    "summary": "List workflow tasks (route inventory only)",
-    "description": "This operation is currently present only in generated route inventory. No corresponding Next.js handler exists under server/src/app/api/v1/workflows in this worktree. Runtime behavior is middleware-dependent: missing/invalid x-api-key can return 401 before routing; with middleware requirements satisfied, Next.js returns not-found for the absent handler. Existing workflow APIs in this codebase are implemented under /api/workflow-definitions, /api/workflow-runs, and /api/workflow/events rather than /api/v1/workflows paths.",
+    "displayName": "List workflow tasks",
+    "summary": "List workflow tasks",
+    "description": "Returns the authenticated caller's workflow task inbox (tasks assigned to them directly or via a role), paginated. Items are summary rows without `formSchema`; fetch a single task to obtain its form schema. EE-only — on the Community build this returns an empty page.",
     "tags": [
-      "Workflows v1"
+      "Workflow Tasks v1"
     ],
     "approvalRequired": false,
-    "parameters": []
+    "parameters": [
+      {
+        "name": "status",
+        "in": "query",
+        "required": false,
+        "description": "Comma-separated WorkflowTaskStatus values (pending, claimed, completed, canceled, expired). Omit for the open inbox (pending + claimed).",
+        "schema": {
+          "type": "string",
+          "description": "Comma-separated WorkflowTaskStatus values (pending, claimed, completed, canceled, expired). Omit for the open inbox (pending + claimed)."
+        }
+      },
+      {
+        "name": "page",
+        "in": "query",
+        "required": false,
+        "description": "1-based page number (default 1).",
+        "schema": {
+          "type": "integer",
+          "minimum": 1,
+          "description": "1-based page number (default 1)."
+        }
+      },
+      {
+        "name": "pageSize",
+        "in": "query",
+        "required": false,
+        "description": "Items per page, max 100 (default 25).",
+        "schema": {
+          "type": "integer",
+          "minimum": 1,
+          "maximum": 100,
+          "description": "Items per page, max 100 (default 25)."
+        }
+      }
+    ],
+    "responseBodySchema": {
+      "type": "object",
+      "properties": {
+        "data": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "taskId": {
+                "type": "string"
+              },
+              "executionId": {
+                "type": "string"
+              },
+              "title": {
+                "type": "string"
+              },
+              "description": {
+                "type": "string"
+              },
+              "status": {
+                "type": "string",
+                "enum": [
+                  "pending",
+                  "claimed",
+                  "completed",
+                  "canceled",
+                  "expired"
+                ]
+              },
+              "priority": {
+                "type": "string"
+              },
+              "dueDate": {
+                "type": "string"
+              },
+              "assignedRoles": {
+                "type": "array",
+                "items": {
+                  "type": "string"
+                }
+              },
+              "assignedUsers": {
+                "type": "array",
+                "items": {
+                  "type": "string"
+                }
+              },
+              "contextData": {
+                "type": "object",
+                "additionalProperties": {}
+              },
+              "formId": {
+                "type": "string"
+              },
+              "formSchema": {
+                "type": "object",
+                "properties": {
+                  "jsonSchema": {
+                    "type": "object",
+                    "additionalProperties": {}
+                  },
+                  "uiSchema": {
+                    "type": "object",
+                    "additionalProperties": {}
+                  },
+                  "defaultValues": {
+                    "type": "object",
+                    "additionalProperties": {}
+                  }
+                },
+                "required": [
+                  "jsonSchema"
+                ]
+              },
+              "createdAt": {
+                "type": "string"
+              },
+              "createdBy": {
+                "type": "string"
+              },
+              "claimedAt": {
+                "type": "string"
+              },
+              "claimedBy": {
+                "type": "string"
+              },
+              "completedAt": {
+                "type": "string"
+              },
+              "completedBy": {
+                "type": "string"
+              },
+              "responseData": {
+                "type": "object",
+                "additionalProperties": {}
+              }
+            },
+            "required": [
+              "taskId",
+              "executionId",
+              "title",
+              "status",
+              "priority",
+              "formId",
+              "createdAt"
+            ]
+          }
+        },
+        "pagination": {
+          "type": "object",
+          "properties": {
+            "page": {
+              "type": "number"
+            },
+            "limit": {
+              "type": "number"
+            },
+            "total": {
+              "type": "number"
+            },
+            "totalPages": {
+              "type": "number"
+            },
+            "hasNext": {
+              "type": "boolean"
+            },
+            "hasPrev": {
+              "type": "boolean"
+            }
+          },
+          "required": [
+            "page",
+            "limit",
+            "total",
+            "totalPages",
+            "hasNext",
+            "hasPrev"
+          ]
+        },
+        "meta": {}
+      },
+      "required": [
+        "data",
+        "pagination"
+      ]
+    }
   },
   {
     "id": "post-_api_v1_workflows_tasks",
@@ -38315,11 +38492,11 @@ export const chatApiRegistry: ChatApiRegistryEntry[] = [
     "id": "get-_api_v1_workflows_tasks_id",
     "method": "get",
     "path": "/api/v1/workflows/tasks/{id}",
-    "displayName": "Get workflow task by id (route inventory only)",
-    "summary": "Get workflow task by id (route inventory only)",
-    "description": "This operation is currently present only in generated route inventory. No corresponding Next.js handler exists under server/src/app/api/v1/workflows in this worktree. Runtime behavior is middleware-dependent: missing/invalid x-api-key can return 401 before routing; with middleware requirements satisfied, Next.js returns not-found for the absent handler. Existing workflow APIs in this codebase are implemented under /api/workflow-definitions, /api/workflow-runs, and /api/workflow/events rather than /api/v1/workflows paths.",
+    "displayName": "Get workflow task",
+    "summary": "Get workflow task",
+    "description": "Returns full detail for a single workflow task, including `formSchema` ({ jsonSchema, uiSchema?, defaultValues? }) so a client can classify the form as simple (native completion) vs complex (web deep-link). EE-only — on the Community build this returns 404.",
     "tags": [
-      "Workflows v1"
+      "Workflow Tasks v1"
     ],
     "approvalRequired": false,
     "parameters": [
@@ -38327,13 +38504,125 @@ export const chatApiRegistry: ChatApiRegistryEntry[] = [
         "name": "id",
         "in": "path",
         "required": true,
-        "description": "Resource identifier.",
+        "description": "Workflow task identifier (taskId).",
         "schema": {
           "type": "string",
-          "format": "uuid"
+          "description": "Workflow task identifier (taskId)."
         }
       }
-    ]
+    ],
+    "responseBodySchema": {
+      "type": "object",
+      "properties": {
+        "data": {
+          "type": "object",
+          "properties": {
+            "taskId": {
+              "type": "string"
+            },
+            "executionId": {
+              "type": "string"
+            },
+            "title": {
+              "type": "string"
+            },
+            "description": {
+              "type": "string"
+            },
+            "status": {
+              "type": "string",
+              "enum": [
+                "pending",
+                "claimed",
+                "completed",
+                "canceled",
+                "expired"
+              ]
+            },
+            "priority": {
+              "type": "string"
+            },
+            "dueDate": {
+              "type": "string"
+            },
+            "assignedRoles": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            },
+            "assignedUsers": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            },
+            "contextData": {
+              "type": "object",
+              "additionalProperties": {}
+            },
+            "formId": {
+              "type": "string"
+            },
+            "formSchema": {
+              "type": "object",
+              "properties": {
+                "jsonSchema": {
+                  "type": "object",
+                  "additionalProperties": {}
+                },
+                "uiSchema": {
+                  "type": "object",
+                  "additionalProperties": {}
+                },
+                "defaultValues": {
+                  "type": "object",
+                  "additionalProperties": {}
+                }
+              },
+              "required": [
+                "jsonSchema"
+              ]
+            },
+            "createdAt": {
+              "type": "string"
+            },
+            "createdBy": {
+              "type": "string"
+            },
+            "claimedAt": {
+              "type": "string"
+            },
+            "claimedBy": {
+              "type": "string"
+            },
+            "completedAt": {
+              "type": "string"
+            },
+            "completedBy": {
+              "type": "string"
+            },
+            "responseData": {
+              "type": "object",
+              "additionalProperties": {}
+            }
+          },
+          "required": [
+            "taskId",
+            "executionId",
+            "title",
+            "status",
+            "priority",
+            "formId",
+            "createdAt"
+          ]
+        },
+        "meta": {}
+      },
+      "required": [
+        "data"
+      ]
+    }
   },
   {
     "id": "put-_api_v1_workflows_tasks_id",
@@ -38341,54 +38630,6 @@ export const chatApiRegistry: ChatApiRegistryEntry[] = [
     "path": "/api/v1/workflows/tasks/{id}",
     "displayName": "Update workflow task (route inventory only)",
     "summary": "Update workflow task (route inventory only)",
-    "description": "This operation is currently present only in generated route inventory. No corresponding Next.js handler exists under server/src/app/api/v1/workflows in this worktree. Runtime behavior is middleware-dependent: missing/invalid x-api-key can return 401 before routing; with middleware requirements satisfied, Next.js returns not-found for the absent handler. Existing workflow APIs in this codebase are implemented under /api/workflow-definitions, /api/workflow-runs, and /api/workflow/events rather than /api/v1/workflows paths.",
-    "tags": [
-      "Workflows v1"
-    ],
-    "approvalRequired": false,
-    "parameters": [
-      {
-        "name": "id",
-        "in": "path",
-        "required": true,
-        "description": "Resource identifier.",
-        "schema": {
-          "type": "string",
-          "format": "uuid"
-        }
-      }
-    ]
-  },
-  {
-    "id": "post-_api_v1_workflows_tasks_id_claim",
-    "method": "post",
-    "path": "/api/v1/workflows/tasks/{id}/claim",
-    "displayName": "Claim workflow task (route inventory only)",
-    "summary": "Claim workflow task (route inventory only)",
-    "description": "This operation is currently present only in generated route inventory. No corresponding Next.js handler exists under server/src/app/api/v1/workflows in this worktree. Runtime behavior is middleware-dependent: missing/invalid x-api-key can return 401 before routing; with middleware requirements satisfied, Next.js returns not-found for the absent handler. Existing workflow APIs in this codebase are implemented under /api/workflow-definitions, /api/workflow-runs, and /api/workflow/events rather than /api/v1/workflows paths.",
-    "tags": [
-      "Workflows v1"
-    ],
-    "approvalRequired": false,
-    "parameters": [
-      {
-        "name": "id",
-        "in": "path",
-        "required": true,
-        "description": "Resource identifier.",
-        "schema": {
-          "type": "string",
-          "format": "uuid"
-        }
-      }
-    ]
-  },
-  {
-    "id": "post-_api_v1_workflows_tasks_id_complete",
-    "method": "post",
-    "path": "/api/v1/workflows/tasks/{id}/complete",
-    "displayName": "Complete workflow task (route inventory only)",
-    "summary": "Complete workflow task (route inventory only)",
     "description": "This operation is currently present only in generated route inventory. No corresponding Next.js handler exists under server/src/app/api/v1/workflows in this worktree. Runtime behavior is middleware-dependent: missing/invalid x-api-key can return 401 before routing; with middleware requirements satisfied, Next.js returns not-found for the absent handler. Existing workflow APIs in this codebase are implemented under /api/workflow-definitions, /api/workflow-runs, and /api/workflow/events rather than /api/v1/workflows paths.",
     "tags": [
       "Workflows v1"
@@ -38576,6 +38817,1351 @@ export const chatApiRegistry: ChatApiRegistryEntry[] = [
         }
       }
     ]
+  },
+  {
+    "id": "post-_api_v1_workflows_tasks_id_claim",
+    "method": "post",
+    "path": "/api/v1/workflows/tasks/{id}/claim",
+    "displayName": "Claim workflow task",
+    "summary": "Claim workflow task",
+    "description": "Claims a pending task for the caller. No request body. EE-only — on the Community build this returns 404.",
+    "tags": [
+      "Workflow Tasks v1"
+    ],
+    "approvalRequired": false,
+    "parameters": [
+      {
+        "name": "id",
+        "in": "path",
+        "required": true,
+        "description": "Workflow task identifier (taskId).",
+        "schema": {
+          "type": "string",
+          "description": "Workflow task identifier (taskId)."
+        }
+      }
+    ],
+    "responseBodySchema": {
+      "type": "object",
+      "properties": {
+        "data": {
+          "type": "object",
+          "properties": {
+            "success": {
+              "type": "boolean"
+            }
+          },
+          "required": [
+            "success"
+          ]
+        },
+        "meta": {}
+      },
+      "required": [
+        "data"
+      ]
+    }
+  },
+  {
+    "id": "post-_api_v1_workflows_tasks_id_unclaim",
+    "method": "post",
+    "path": "/api/v1/workflows/tasks/{id}/unclaim",
+    "displayName": "Unclaim workflow task",
+    "summary": "Unclaim workflow task",
+    "description": "Releases a task the caller has claimed, returning it to the pending pool. No request body. EE-only — on the Community build this returns 404.",
+    "tags": [
+      "Workflow Tasks v1"
+    ],
+    "approvalRequired": false,
+    "parameters": [
+      {
+        "name": "id",
+        "in": "path",
+        "required": true,
+        "description": "Workflow task identifier (taskId).",
+        "schema": {
+          "type": "string",
+          "description": "Workflow task identifier (taskId)."
+        }
+      }
+    ],
+    "responseBodySchema": {
+      "type": "object",
+      "properties": {
+        "data": {
+          "type": "object",
+          "properties": {
+            "success": {
+              "type": "boolean"
+            }
+          },
+          "required": [
+            "success"
+          ]
+        },
+        "meta": {}
+      },
+      "required": [
+        "data"
+      ]
+    }
+  },
+  {
+    "id": "post-_api_v1_workflows_tasks_id_complete",
+    "method": "post",
+    "path": "/api/v1/workflows/tasks/{id}/complete",
+    "displayName": "Complete workflow task",
+    "summary": "Complete workflow task",
+    "description": "Submits the task's form payload and completes it. The form data is validated server-side against the task's JSON Schema; validation failures return 400 with the schema errors in `error.details`. EE-only — on the Community build this returns 404.",
+    "tags": [
+      "Workflow Tasks v1"
+    ],
+    "approvalRequired": false,
+    "parameters": [
+      {
+        "name": "id",
+        "in": "path",
+        "required": true,
+        "description": "Workflow task identifier (taskId).",
+        "schema": {
+          "type": "string",
+          "description": "Workflow task identifier (taskId)."
+        }
+      }
+    ],
+    "requestBodySchema": {
+      "type": "object",
+      "properties": {
+        "formData": {
+          "type": "object",
+          "additionalProperties": {},
+          "default": {}
+        },
+        "comments": {
+          "type": "string"
+        }
+      }
+    },
+    "responseBodySchema": {
+      "type": "object",
+      "properties": {
+        "data": {
+          "type": "object",
+          "properties": {
+            "success": {
+              "type": "boolean"
+            }
+          },
+          "required": [
+            "success"
+          ]
+        },
+        "meta": {}
+      },
+      "required": [
+        "data"
+      ]
+    }
+  },
+  {
+    "id": "get-_api_v1_activities",
+    "method": "get",
+    "path": "/api/v1/activities",
+    "displayName": "List My Activities",
+    "summary": "Fetch the authenticated user's unified activity list (the User Activities screen)",
+    "description": "Returns the caller's own work items exactly as the User Activities screen shows them: a unified, paginated fan-out across tickets, project tasks, schedule entries, ad-hoc to-dos, workflow tasks, time entries and notifications. Each activity carries id, type, title, status and priority. Filter with type (comma-separated: ticket, projectTask, schedule, workflowTask, timeEntry, notification, document; ad-hoc to-dos surface as schedule), status (open/closed/all), search, due-date and created-date windows; sort with sortBy/sortDirection. This endpoint is always scoped to the authenticated caller — use it for questions like \"what is on my plate\" or \"my open tickets on my activities screen\". For tenant-wide ticket queries use GET /api/v1/tickets instead.",
+    "tags": [
+      "Activities v1"
+    ],
+    "approvalRequired": false,
+    "parameters": [
+      {
+        "name": "type",
+        "in": "query",
+        "required": false,
+        "description": "Comma-separated ActivityType values (e.g. \"ticket,schedule\"). Omit for all types.",
+        "schema": {
+          "type": "string",
+          "description": "Comma-separated ActivityType values (e.g. \"ticket,schedule\"). Omit for all types."
+        }
+      },
+      {
+        "name": "status",
+        "in": "query",
+        "required": false,
+        "description": "Open/closed filter. `open`→active only, `closed`→closed, `all`→no filter (default).",
+        "schema": {
+          "type": "string",
+          "enum": [
+            "open",
+            "closed",
+            "all"
+          ],
+          "description": "Open/closed filter. `open`→active only, `closed`→closed, `all`→no filter (default)."
+        }
+      },
+      {
+        "name": "search",
+        "in": "query",
+        "required": false,
+        "description": "Free-text search across activity titles/descriptions.",
+        "schema": {
+          "type": "string",
+          "description": "Free-text search across activity titles/descriptions."
+        }
+      },
+      {
+        "name": "dateStart",
+        "in": "query",
+        "required": false,
+        "description": "ISO 8601 lower bound of the schedule/time-entry/notification window.",
+        "schema": {
+          "type": "string",
+          "format": "date-time",
+          "description": "ISO 8601 lower bound of the schedule/time-entry/notification window."
+        }
+      },
+      {
+        "name": "dateEnd",
+        "in": "query",
+        "required": false,
+        "description": "ISO 8601 upper bound of the window.",
+        "schema": {
+          "type": "string",
+          "format": "date-time",
+          "description": "ISO 8601 upper bound of the window."
+        }
+      },
+      {
+        "name": "priority",
+        "in": "query",
+        "required": false,
+        "description": "Comma-separated normalized ActivityPriority buckets (e.g. \"high,medium\"). Lossy for custom schemes; prefer `priorityIds`.",
+        "schema": {
+          "type": "string",
+          "description": "Comma-separated normalized ActivityPriority buckets (e.g. \"high,medium\"). Lossy for custom schemes; prefer `priorityIds`."
+        }
+      },
+      {
+        "name": "priorityIds",
+        "in": "query",
+        "required": false,
+        "description": "Comma-separated exact priority IDs (the tenant's real per-type priorities). Applies to ticket/project-task activities.",
+        "schema": {
+          "type": "string",
+          "description": "Comma-separated exact priority IDs (the tenant's real per-type priorities). Applies to ticket/project-task activities."
+        }
+      },
+      {
+        "name": "dueDateStart",
+        "in": "query",
+        "required": false,
+        "description": "ISO 8601 lower bound of the due-date filter (independent of the schedule window).",
+        "schema": {
+          "type": "string",
+          "format": "date-time",
+          "description": "ISO 8601 lower bound of the due-date filter (independent of the schedule window)."
+        }
+      },
+      {
+        "name": "dueDateEnd",
+        "in": "query",
+        "required": false,
+        "description": "ISO 8601 upper bound of the due-date filter.",
+        "schema": {
+          "type": "string",
+          "format": "date-time",
+          "description": "ISO 8601 upper bound of the due-date filter."
+        }
+      },
+      {
+        "name": "createdAtStart",
+        "in": "query",
+        "required": false,
+        "description": "ISO 8601 lower bound of the created-date (\"date entered\") filter. Applies to every activity type.",
+        "schema": {
+          "type": "string",
+          "format": "date-time",
+          "description": "ISO 8601 lower bound of the created-date (\"date entered\") filter. Applies to every activity type."
+        }
+      },
+      {
+        "name": "createdAtEnd",
+        "in": "query",
+        "required": false,
+        "description": "ISO 8601 upper bound of the created-date (\"date entered\") filter.",
+        "schema": {
+          "type": "string",
+          "format": "date-time",
+          "description": "ISO 8601 upper bound of the created-date (\"date entered\") filter."
+        }
+      },
+      {
+        "name": "sortBy",
+        "in": "query",
+        "required": false,
+        "description": "Sort column. Omit for the default sort (priority high→low, then due date ascending).",
+        "schema": {
+          "type": "string",
+          "enum": [
+            "type",
+            "title",
+            "status",
+            "priority",
+            "dueDate"
+          ],
+          "description": "Sort column. Omit for the default sort (priority high→low, then due date ascending)."
+        }
+      },
+      {
+        "name": "sortDirection",
+        "in": "query",
+        "required": false,
+        "description": "Sort direction for `sortBy` (default asc). Ignored when `sortBy` is omitted.",
+        "schema": {
+          "type": "string",
+          "enum": [
+            "asc",
+            "desc"
+          ],
+          "description": "Sort direction for `sortBy` (default asc). Ignored when `sortBy` is omitted."
+        }
+      },
+      {
+        "name": "groupBy",
+        "in": "query",
+        "required": false,
+        "description": "When set, the response is grouped by this dimension (ActivityGroupedResponseV1) instead of the paginated list; `page`/`pageSize` are ignored. `priority` groups by the real per-tenant priority name (not the normalized bucket), so it is only meaningful when scoped to a single prioritized type.",
+        "schema": {
+          "type": "string",
+          "enum": [
+            "type",
+            "priority",
+            "status",
+            "dueDate"
+          ],
+          "description": "When set, the response is grouped by this dimension (ActivityGroupedResponseV1) instead of the paginated list; `page`/`pageSize` are ignored. `priority` groups by the real per-tenant priority name (not the normalized bucket), so it is only meaningful when scoped to a single prioritized type."
+        }
+      },
+      {
+        "name": "page",
+        "in": "query",
+        "required": false,
+        "description": "1-based page number (default 1). Ignored when `groupBy` is set.",
+        "schema": {
+          "type": "integer",
+          "minimum": 1,
+          "description": "1-based page number (default 1). Ignored when `groupBy` is set."
+        }
+      },
+      {
+        "name": "pageSize",
+        "in": "query",
+        "required": false,
+        "description": "Items per page, max 100 (default 25). Ignored when `groupBy` is set.",
+        "schema": {
+          "type": "integer",
+          "minimum": 1,
+          "maximum": 100,
+          "description": "Items per page, max 100 (default 25). Ignored when `groupBy` is set."
+        }
+      }
+    ],
+    "responseBodySchema": {
+      "type": "object",
+      "properties": {
+        "data": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "id": {
+                "type": "string"
+              },
+              "title": {
+                "type": "string"
+              },
+              "description": {
+                "type": "string"
+              },
+              "type": {
+                "type": "string",
+                "enum": [
+                  "schedule",
+                  "projectTask",
+                  "ticket",
+                  "timeEntry",
+                  "workflowTask",
+                  "notification",
+                  "document"
+                ]
+              },
+              "status": {
+                "type": "string"
+              },
+              "statusColor": {
+                "type": "string"
+              },
+              "priority": {
+                "type": "string",
+                "enum": [
+                  "low",
+                  "medium",
+                  "high"
+                ]
+              },
+              "priorityName": {
+                "type": "string"
+              },
+              "priorityColor": {
+                "type": "string"
+              },
+              "dueDate": {
+                "type": "string"
+              },
+              "startDate": {
+                "type": "string"
+              },
+              "endDate": {
+                "type": "string"
+              },
+              "assignedTo": {
+                "type": "array",
+                "items": {
+                  "type": "string"
+                }
+              },
+              "assignedToNames": {
+                "type": "array",
+                "items": {
+                  "type": "string"
+                }
+              },
+              "sourceId": {
+                "type": "string"
+              },
+              "sourceType": {
+                "type": "string",
+                "enum": [
+                  "schedule",
+                  "projectTask",
+                  "ticket",
+                  "timeEntry",
+                  "workflowTask",
+                  "notification",
+                  "document"
+                ]
+              },
+              "actions": {
+                "type": "array",
+                "items": {
+                  "type": "object",
+                  "properties": {
+                    "id": {
+                      "type": "string"
+                    },
+                    "label": {
+                      "type": "string"
+                    },
+                    "icon": {
+                      "type": "string"
+                    },
+                    "disabled": {
+                      "type": "boolean"
+                    },
+                    "disabledReason": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "id",
+                    "label"
+                  ]
+                }
+              },
+              "isClosed": {
+                "type": "boolean"
+              },
+              "tenant": {
+                "type": "string"
+              },
+              "createdAt": {
+                "type": "string"
+              },
+              "updatedAt": {
+                "type": "string"
+              }
+            },
+            "required": [
+              "id",
+              "title",
+              "type",
+              "status",
+              "priority",
+              "sourceId",
+              "sourceType",
+              "actions",
+              "tenant",
+              "createdAt",
+              "updatedAt"
+            ]
+          }
+        },
+        "pagination": {
+          "type": "object",
+          "properties": {
+            "page": {
+              "type": "number"
+            },
+            "limit": {
+              "type": "number"
+            },
+            "total": {
+              "type": "number"
+            },
+            "totalPages": {
+              "type": "number"
+            },
+            "hasNext": {
+              "type": "boolean"
+            },
+            "hasPrev": {
+              "type": "boolean"
+            }
+          },
+          "required": [
+            "page",
+            "limit",
+            "total",
+            "totalPages",
+            "hasNext",
+            "hasPrev"
+          ]
+        },
+        "meta": {}
+      },
+      "required": [
+        "data",
+        "pagination"
+      ]
+    },
+    "examples": [
+      {
+        "name": "My open ticket activities",
+        "request": {
+          "query": {
+            "type": "ticket",
+            "status": "open",
+            "pageSize": 50
+          }
+        },
+        "notes": "Returns the ticket activities the caller sees on their User Activities screen. Each activity's id is the ticket UUID, usable with GET /api/v1/tickets/{id}."
+      }
+    ]
+  },
+  {
+    "id": "post-_api_v1_activities_adhoc",
+    "method": "post",
+    "path": "/api/v1/activities/ad-hoc",
+    "displayName": "Create ad-hoc activity",
+    "summary": "Create ad-hoc activity",
+    "description": "Creates a personal, self-assigned ad-hoc to-do rendered as a schedule activity. Times are optional; when both are supplied the end must be after the start. Gated by `user_schedule:read`.",
+    "tags": [
+      "Activities v1"
+    ],
+    "approvalRequired": false,
+    "parameters": [],
+    "requestBodySchema": {
+      "type": "object",
+      "properties": {
+        "title": {
+          "type": "string",
+          "minLength": 1
+        },
+        "notes": {
+          "type": "string"
+        },
+        "scheduledStart": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "format": "date-time"
+        },
+        "scheduledEnd": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "format": "date-time"
+        }
+      },
+      "required": [
+        "title"
+      ]
+    },
+    "responseBodySchema": {
+      "type": "object",
+      "properties": {
+        "data": {
+          "type": "object",
+          "properties": {
+            "id": {
+              "type": "string"
+            },
+            "title": {
+              "type": "string"
+            },
+            "description": {
+              "type": "string"
+            },
+            "type": {
+              "type": "string",
+              "enum": [
+                "schedule",
+                "projectTask",
+                "ticket",
+                "timeEntry",
+                "workflowTask",
+                "notification",
+                "document"
+              ]
+            },
+            "status": {
+              "type": "string"
+            },
+            "statusColor": {
+              "type": "string"
+            },
+            "priority": {
+              "type": "string",
+              "enum": [
+                "low",
+                "medium",
+                "high"
+              ]
+            },
+            "priorityName": {
+              "type": "string"
+            },
+            "priorityColor": {
+              "type": "string"
+            },
+            "dueDate": {
+              "type": "string"
+            },
+            "startDate": {
+              "type": "string"
+            },
+            "endDate": {
+              "type": "string"
+            },
+            "assignedTo": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            },
+            "assignedToNames": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            },
+            "sourceId": {
+              "type": "string"
+            },
+            "sourceType": {
+              "type": "string",
+              "enum": [
+                "schedule",
+                "projectTask",
+                "ticket",
+                "timeEntry",
+                "workflowTask",
+                "notification",
+                "document"
+              ]
+            },
+            "actions": {
+              "type": "array",
+              "items": {
+                "type": "object",
+                "properties": {
+                  "id": {
+                    "type": "string"
+                  },
+                  "label": {
+                    "type": "string"
+                  },
+                  "icon": {
+                    "type": "string"
+                  },
+                  "disabled": {
+                    "type": "boolean"
+                  },
+                  "disabledReason": {
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "id",
+                  "label"
+                ]
+              }
+            },
+            "isClosed": {
+              "type": "boolean"
+            },
+            "tenant": {
+              "type": "string"
+            },
+            "createdAt": {
+              "type": "string"
+            },
+            "updatedAt": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "id",
+            "title",
+            "type",
+            "status",
+            "priority",
+            "sourceId",
+            "sourceType",
+            "actions",
+            "tenant",
+            "createdAt",
+            "updatedAt"
+          ]
+        },
+        "meta": {}
+      },
+      "required": [
+        "data"
+      ]
+    }
+  },
+  {
+    "id": "patch-_api_v1_activities_adhoc_id",
+    "method": "patch",
+    "path": "/api/v1/activities/ad-hoc/{id}",
+    "displayName": "Update ad-hoc activity",
+    "summary": "Update ad-hoc activity",
+    "description": "Updates an ad-hoc item's title, notes or optional times. Omitted fields are left unchanged; `notes: null` clears the field. Requires the caller to be an assignee, or hold `user_schedule:update` / `user_schedule:read_all`.",
+    "tags": [
+      "Activities v1"
+    ],
+    "approvalRequired": false,
+    "parameters": [
+      {
+        "name": "id",
+        "in": "path",
+        "required": true,
+        "description": "Ad-hoc activity identifier (the backing schedule entry id).",
+        "schema": {
+          "type": "string",
+          "description": "Ad-hoc activity identifier (the backing schedule entry id)."
+        }
+      }
+    ],
+    "requestBodySchema": {
+      "type": "object",
+      "properties": {
+        "title": {
+          "type": "string",
+          "minLength": 1
+        },
+        "notes": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "scheduledStart": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "format": "date-time"
+        },
+        "scheduledEnd": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "format": "date-time"
+        }
+      }
+    },
+    "responseBodySchema": {
+      "type": "object",
+      "properties": {
+        "data": {
+          "type": "object",
+          "properties": {
+            "id": {
+              "type": "string"
+            },
+            "title": {
+              "type": "string"
+            },
+            "description": {
+              "type": "string"
+            },
+            "type": {
+              "type": "string",
+              "enum": [
+                "schedule",
+                "projectTask",
+                "ticket",
+                "timeEntry",
+                "workflowTask",
+                "notification",
+                "document"
+              ]
+            },
+            "status": {
+              "type": "string"
+            },
+            "statusColor": {
+              "type": "string"
+            },
+            "priority": {
+              "type": "string",
+              "enum": [
+                "low",
+                "medium",
+                "high"
+              ]
+            },
+            "priorityName": {
+              "type": "string"
+            },
+            "priorityColor": {
+              "type": "string"
+            },
+            "dueDate": {
+              "type": "string"
+            },
+            "startDate": {
+              "type": "string"
+            },
+            "endDate": {
+              "type": "string"
+            },
+            "assignedTo": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            },
+            "assignedToNames": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            },
+            "sourceId": {
+              "type": "string"
+            },
+            "sourceType": {
+              "type": "string",
+              "enum": [
+                "schedule",
+                "projectTask",
+                "ticket",
+                "timeEntry",
+                "workflowTask",
+                "notification",
+                "document"
+              ]
+            },
+            "actions": {
+              "type": "array",
+              "items": {
+                "type": "object",
+                "properties": {
+                  "id": {
+                    "type": "string"
+                  },
+                  "label": {
+                    "type": "string"
+                  },
+                  "icon": {
+                    "type": "string"
+                  },
+                  "disabled": {
+                    "type": "boolean"
+                  },
+                  "disabledReason": {
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "id",
+                  "label"
+                ]
+              }
+            },
+            "isClosed": {
+              "type": "boolean"
+            },
+            "tenant": {
+              "type": "string"
+            },
+            "createdAt": {
+              "type": "string"
+            },
+            "updatedAt": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "id",
+            "title",
+            "type",
+            "status",
+            "priority",
+            "sourceId",
+            "sourceType",
+            "actions",
+            "tenant",
+            "createdAt",
+            "updatedAt"
+          ]
+        },
+        "meta": {}
+      },
+      "required": [
+        "data"
+      ]
+    }
+  },
+  {
+    "id": "delete-_api_v1_activities_adhoc_id",
+    "method": "delete",
+    "path": "/api/v1/activities/ad-hoc/{id}",
+    "displayName": "Delete ad-hoc activity",
+    "summary": "Delete ad-hoc activity",
+    "description": "Permanently deletes an ad-hoc item. Requires the caller to be an assignee, or hold `user_schedule:update` / `user_schedule:read_all`.",
+    "tags": [
+      "Activities v1"
+    ],
+    "approvalRequired": false,
+    "parameters": [
+      {
+        "name": "id",
+        "in": "path",
+        "required": true,
+        "description": "Ad-hoc activity identifier (the backing schedule entry id).",
+        "schema": {
+          "type": "string",
+          "description": "Ad-hoc activity identifier (the backing schedule entry id)."
+        }
+      }
+    ]
+  },
+  {
+    "id": "post-_api_v1_activities_adhoc_id_done",
+    "method": "post",
+    "path": "/api/v1/activities/ad-hoc/{id}/done",
+    "displayName": "Toggle ad-hoc activity done",
+    "summary": "Toggle ad-hoc activity done",
+    "description": "Marks an ad-hoc item done/undone. `done: true` sets status to closed; `done: false` reopens it (status scheduled). Requires the caller to be an assignee, or hold `user_schedule:update` / `user_schedule:read_all`.",
+    "tags": [
+      "Activities v1"
+    ],
+    "approvalRequired": false,
+    "parameters": [
+      {
+        "name": "id",
+        "in": "path",
+        "required": true,
+        "description": "Ad-hoc activity identifier (the backing schedule entry id).",
+        "schema": {
+          "type": "string",
+          "description": "Ad-hoc activity identifier (the backing schedule entry id)."
+        }
+      }
+    ],
+    "requestBodySchema": {
+      "type": "object",
+      "properties": {
+        "done": {
+          "type": "boolean"
+        }
+      },
+      "required": [
+        "done"
+      ]
+    },
+    "responseBodySchema": {
+      "type": "object",
+      "properties": {
+        "data": {
+          "type": "object",
+          "properties": {
+            "id": {
+              "type": "string"
+            },
+            "title": {
+              "type": "string"
+            },
+            "description": {
+              "type": "string"
+            },
+            "type": {
+              "type": "string",
+              "enum": [
+                "schedule",
+                "projectTask",
+                "ticket",
+                "timeEntry",
+                "workflowTask",
+                "notification",
+                "document"
+              ]
+            },
+            "status": {
+              "type": "string"
+            },
+            "statusColor": {
+              "type": "string"
+            },
+            "priority": {
+              "type": "string",
+              "enum": [
+                "low",
+                "medium",
+                "high"
+              ]
+            },
+            "priorityName": {
+              "type": "string"
+            },
+            "priorityColor": {
+              "type": "string"
+            },
+            "dueDate": {
+              "type": "string"
+            },
+            "startDate": {
+              "type": "string"
+            },
+            "endDate": {
+              "type": "string"
+            },
+            "assignedTo": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            },
+            "assignedToNames": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            },
+            "sourceId": {
+              "type": "string"
+            },
+            "sourceType": {
+              "type": "string",
+              "enum": [
+                "schedule",
+                "projectTask",
+                "ticket",
+                "timeEntry",
+                "workflowTask",
+                "notification",
+                "document"
+              ]
+            },
+            "actions": {
+              "type": "array",
+              "items": {
+                "type": "object",
+                "properties": {
+                  "id": {
+                    "type": "string"
+                  },
+                  "label": {
+                    "type": "string"
+                  },
+                  "icon": {
+                    "type": "string"
+                  },
+                  "disabled": {
+                    "type": "boolean"
+                  },
+                  "disabledReason": {
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "id",
+                  "label"
+                ]
+              }
+            },
+            "isClosed": {
+              "type": "boolean"
+            },
+            "tenant": {
+              "type": "string"
+            },
+            "createdAt": {
+              "type": "string"
+            },
+            "updatedAt": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "id",
+            "title",
+            "type",
+            "status",
+            "priority",
+            "sourceId",
+            "sourceType",
+            "actions",
+            "tenant",
+            "createdAt",
+            "updatedAt"
+          ]
+        },
+        "meta": {}
+      },
+      "required": [
+        "data"
+      ]
+    }
+  },
+  {
+    "id": "get-_api_v1_activities_groups",
+    "method": "get",
+    "path": "/api/v1/activities/groups",
+    "displayName": "List My Activity Groups",
+    "summary": "Fetch the caller's named custom groups from the User Activities screen",
+    "description": "Returns the personal, user-defined groups the caller created on the User Activities screen (for example a group named \"Basics\"), each with its ordered items. Items are references: { activityId, activityType, sortOrder } — for activityType \"ticket\" the activityId is the ticket UUID. To answer \"what tickets are in my <name> group\": call this endpoint, find the group by groupName (case-insensitive match on what the user said), then resolve each item, e.g. ticket items via GET /api/v1/tickets/{id} or by matching ids against GET /api/v1/activities. Groups are per-user; pass targetUserId only to read another internal user's groups (requires user_schedule:update or user_schedule:read_all).",
+    "tags": [
+      "Activities v1"
+    ],
+    "approvalRequired": false,
+    "parameters": [
+      {
+        "name": "targetUserId",
+        "in": "query",
+        "required": false,
+        "description": "Another internal user whose groups to read (requires elevated schedule permission). Omit for self.",
+        "schema": {
+          "type": "string",
+          "description": "Another internal user whose groups to read (requires elevated schedule permission). Omit for self."
+        }
+      }
+    ],
+    "responseBodySchema": {
+      "type": "object",
+      "properties": {
+        "data": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "groupId": {
+                "type": "string"
+              },
+              "groupName": {
+                "type": "string"
+              },
+              "sortOrder": {
+                "type": "number"
+              },
+              "isCollapsed": {
+                "type": "boolean"
+              },
+              "items": {
+                "type": "array",
+                "items": {
+                  "type": "object",
+                  "properties": {
+                    "itemId": {
+                      "type": "string"
+                    },
+                    "activityId": {
+                      "type": "string"
+                    },
+                    "activityType": {
+                      "type": "string"
+                    },
+                    "sortOrder": {
+                      "type": "number"
+                    }
+                  },
+                  "required": [
+                    "itemId",
+                    "activityId",
+                    "activityType",
+                    "sortOrder"
+                  ]
+                }
+              }
+            },
+            "required": [
+              "groupId",
+              "groupName",
+              "sortOrder",
+              "isCollapsed",
+              "items"
+            ]
+          }
+        },
+        "meta": {}
+      },
+      "required": [
+        "data"
+      ]
+    },
+    "examples": [
+      {
+        "name": "What is in my \"Basics\" group?",
+        "request": {},
+        "notes": "Find the entry whose groupName is \"Basics\" in the response, then look up each item: for activityType \"ticket\" call GET /api/v1/tickets/{activityId} (or filter a GET /api/v1/activities?type=ticket result by the collected ids) to get titles and statuses."
+      }
+    ]
+  },
+  {
+    "id": "post-_api_v1_activities_groups_items",
+    "method": "post",
+    "path": "/api/v1/activities/groups/items",
+    "displayName": "Move Activity Into My Group",
+    "summary": "Put one of the caller's activities into one of their custom groups",
+    "description": "Moves an activity into one of the caller's own User Activities groups at the given sortOrder position, removing it from any other of their groups first (an activity lives in at most one group). Get groupId values from GET /api/v1/activities/groups. Only organizes the caller's own view — it never changes the underlying ticket/task.",
+    "tags": [
+      "Activities v1"
+    ],
+    "approvalRequired": false,
+    "parameters": [],
+    "requestBodySchema": {
+      "type": "object",
+      "properties": {
+        "activityId": {
+          "type": "string",
+          "minLength": 1
+        },
+        "activityType": {
+          "type": "string",
+          "minLength": 1
+        },
+        "groupId": {
+          "type": "string",
+          "minLength": 1
+        },
+        "sortOrder": {
+          "type": "integer",
+          "minimum": 0
+        }
+      },
+      "required": [
+        "activityId",
+        "activityType",
+        "groupId",
+        "sortOrder"
+      ]
+    }
+  },
+  {
+    "id": "delete-_api_v1_activities_groups_items",
+    "method": "delete",
+    "path": "/api/v1/activities/groups/items",
+    "displayName": "Remove Activity From My Groups",
+    "summary": "Make one of the caller's activities ungrouped",
+    "description": "Removes an activity from all of the caller's User Activities groups so it shows as ungrouped. No-op when the activity is not in any group. Only affects the caller's own view.",
+    "tags": [
+      "Activities v1"
+    ],
+    "approvalRequired": false,
+    "parameters": [],
+    "requestBodySchema": {
+      "type": "object",
+      "properties": {
+        "activityId": {
+          "type": "string",
+          "minLength": 1
+        },
+        "activityType": {
+          "type": "string",
+          "minLength": 1
+        }
+      },
+      "required": [
+        "activityId",
+        "activityType"
+      ]
+    }
+  },
+  {
+    "id": "patch-_api_v1_activities_groups_groupid_items",
+    "method": "patch",
+    "path": "/api/v1/activities/groups/{groupId}/items",
+    "displayName": "Reorder My Group's Activities",
+    "summary": "Persist a new ordering of the activities inside one of the caller's groups",
+    "description": "Replaces the ordering of a group's members: pass every item with its new sortOrder (position). Scoped to the caller's own groups from GET /api/v1/activities/groups.",
+    "tags": [
+      "Activities v1"
+    ],
+    "approvalRequired": false,
+    "parameters": [
+      {
+        "name": "groupId",
+        "in": "path",
+        "required": true,
+        "description": "Custom activity group identifier.",
+        "schema": {
+          "type": "string",
+          "description": "Custom activity group identifier."
+        }
+      }
+    ],
+    "requestBodySchema": {
+      "type": "object",
+      "properties": {
+        "items": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "activityId": {
+                "type": "string",
+                "minLength": 1
+              },
+              "activityType": {
+                "type": "string",
+                "minLength": 1
+              },
+              "sortOrder": {
+                "type": "integer",
+                "minimum": 0
+              }
+            },
+            "required": [
+              "activityId",
+              "activityType",
+              "sortOrder"
+            ]
+          },
+          "minItems": 1
+        }
+      },
+      "required": [
+        "items"
+      ]
+    }
   },
   {
     "id": "get-_api_v1_projects_id_taskstatusmappings",
@@ -52808,6 +54394,23 @@ export const chatApiRegistry: ChatApiRegistryEntry[] = [
     }
   },
   {
+    "id": "get-_api_auth_captchaconfig",
+    "method": "get",
+    "path": "/api/auth/captcha-config",
+    "displayName": "GET auth",
+    "summary": "GET auth",
+    "description": "This operation was generated automatically from the route inventory. Replace with canonical OpenAPI metadata.",
+    "tags": [
+      "auth"
+    ],
+    "approvalRequired": false,
+    "parameters": [],
+    "responseBodySchema": {
+      "type": "object",
+      "properties": {}
+    }
+  },
+  {
     "id": "get-_api_auth_e2e_google_authorize",
     "method": "get",
     "path": "/api/auth/e2e/google/authorize",
@@ -53083,6 +54686,111 @@ export const chatApiRegistry: ChatApiRegistryEntry[] = [
     ],
     "approvalRequired": false,
     "parameters": [],
+    "responseBodySchema": {
+      "type": "object",
+      "properties": {}
+    }
+  },
+  {
+    "id": "post-_api_billing_completereactivation",
+    "method": "post",
+    "path": "/api/billing/complete-reactivation",
+    "displayName": "POST billing",
+    "summary": "POST billing",
+    "description": "This operation was generated automatically from the route inventory. Replace with canonical OpenAPI metadata.",
+    "tags": [
+      "billing"
+    ],
+    "approvalRequired": false,
+    "parameters": [],
+    "requestBodySchema": {
+      "type": "object",
+      "properties": {}
+    },
+    "responseBodySchema": {
+      "type": "object",
+      "properties": {}
+    }
+  },
+  {
+    "id": "post-_api_billing_reactivationpasswordreset",
+    "method": "post",
+    "path": "/api/billing/reactivation-password-reset",
+    "displayName": "POST billing",
+    "summary": "POST billing",
+    "description": "This operation was generated automatically from the route inventory. Replace with canonical OpenAPI metadata.",
+    "tags": [
+      "billing"
+    ],
+    "approvalRequired": false,
+    "parameters": [],
+    "requestBodySchema": {
+      "type": "object",
+      "properties": {}
+    },
+    "responseBodySchema": {
+      "type": "object",
+      "properties": {}
+    }
+  },
+  {
+    "id": "post-_api_billing_reactivationtoken",
+    "method": "post",
+    "path": "/api/billing/reactivation-token",
+    "displayName": "POST billing",
+    "summary": "POST billing",
+    "description": "This operation was generated automatically from the route inventory. Replace with canonical OpenAPI metadata.",
+    "tags": [
+      "billing"
+    ],
+    "approvalRequired": false,
+    "parameters": [],
+    "requestBodySchema": {
+      "type": "object",
+      "properties": {}
+    },
+    "responseBodySchema": {
+      "type": "object",
+      "properties": {}
+    }
+  },
+  {
+    "id": "post-_api_billing_reactivationtoken_session",
+    "method": "post",
+    "path": "/api/billing/reactivation-token/session",
+    "displayName": "POST billing",
+    "summary": "POST billing",
+    "description": "This operation was generated automatically from the route inventory. Replace with canonical OpenAPI metadata.",
+    "tags": [
+      "billing"
+    ],
+    "approvalRequired": false,
+    "parameters": [],
+    "requestBodySchema": {
+      "type": "object",
+      "properties": {}
+    },
+    "responseBodySchema": {
+      "type": "object",
+      "properties": {}
+    }
+  },
+  {
+    "id": "post-_api_billing_requestreactivation",
+    "method": "post",
+    "path": "/api/billing/request-reactivation",
+    "displayName": "POST billing",
+    "summary": "POST billing",
+    "description": "This operation was generated automatically from the route inventory. Replace with canonical OpenAPI metadata.",
+    "tags": [
+      "billing"
+    ],
+    "approvalRequired": false,
+    "parameters": [],
+    "requestBodySchema": {
+      "type": "object",
+      "properties": {}
+    },
     "responseBodySchema": {
       "type": "object",
       "properties": {}
@@ -54099,6 +55807,23 @@ export const chatApiRegistry: ChatApiRegistryEntry[] = [
     }
   },
   {
+    "id": "get-_api_integrations_hudu",
+    "method": "get",
+    "path": "/api/integrations/hudu",
+    "displayName": "GET integrations",
+    "summary": "GET integrations",
+    "description": "This operation was generated automatically from the route inventory. Replace with canonical OpenAPI metadata.",
+    "tags": [
+      "integrations"
+    ],
+    "approvalRequired": false,
+    "parameters": [],
+    "responseBodySchema": {
+      "type": "object",
+      "properties": {}
+    }
+  },
+  {
     "id": "get-_api_integrations_ninjaone_callback",
     "method": "get",
     "path": "/api/integrations/ninjaone/callback",
@@ -54358,6 +56083,124 @@ export const chatApiRegistry: ChatApiRegistryEntry[] = [
         }
       }
     ],
+    "requestBodySchema": {
+      "type": "object",
+      "properties": {}
+    },
+    "responseBodySchema": {
+      "type": "object",
+      "properties": {}
+    }
+  },
+  {
+    "id": "get-_api_mcp",
+    "method": "get",
+    "path": "/api/mcp",
+    "displayName": "GET mcp",
+    "summary": "GET mcp",
+    "description": "This operation was generated automatically from the route inventory. Replace with canonical OpenAPI metadata.",
+    "tags": [
+      "mcp"
+    ],
+    "approvalRequired": false,
+    "parameters": [],
+    "responseBodySchema": {
+      "type": "object",
+      "properties": {}
+    }
+  },
+  {
+    "id": "post-_api_mcp",
+    "method": "post",
+    "path": "/api/mcp",
+    "displayName": "POST mcp",
+    "summary": "POST mcp",
+    "description": "This operation was generated automatically from the route inventory. Replace with canonical OpenAPI metadata.",
+    "tags": [
+      "mcp"
+    ],
+    "approvalRequired": false,
+    "parameters": [],
+    "requestBodySchema": {
+      "type": "object",
+      "properties": {}
+    },
+    "responseBodySchema": {
+      "type": "object",
+      "properties": {}
+    }
+  },
+  {
+    "id": "get-_api_mcp_oauth_authorize",
+    "method": "get",
+    "path": "/api/mcp/oauth/authorize",
+    "displayName": "GET mcp",
+    "summary": "GET mcp",
+    "description": "This operation was generated automatically from the route inventory. Replace with canonical OpenAPI metadata.",
+    "tags": [
+      "mcp"
+    ],
+    "approvalRequired": false,
+    "parameters": [],
+    "responseBodySchema": {
+      "type": "object",
+      "properties": {}
+    }
+  },
+  {
+    "id": "post-_api_mcp_oauth_authorize",
+    "method": "post",
+    "path": "/api/mcp/oauth/authorize",
+    "displayName": "POST mcp",
+    "summary": "POST mcp",
+    "description": "This operation was generated automatically from the route inventory. Replace with canonical OpenAPI metadata.",
+    "tags": [
+      "mcp"
+    ],
+    "approvalRequired": false,
+    "parameters": [],
+    "requestBodySchema": {
+      "type": "object",
+      "properties": {}
+    },
+    "responseBodySchema": {
+      "type": "object",
+      "properties": {}
+    }
+  },
+  {
+    "id": "post-_api_mcp_oauth_revoke",
+    "method": "post",
+    "path": "/api/mcp/oauth/revoke",
+    "displayName": "POST mcp",
+    "summary": "POST mcp",
+    "description": "This operation was generated automatically from the route inventory. Replace with canonical OpenAPI metadata.",
+    "tags": [
+      "mcp"
+    ],
+    "approvalRequired": false,
+    "parameters": [],
+    "requestBodySchema": {
+      "type": "object",
+      "properties": {}
+    },
+    "responseBodySchema": {
+      "type": "object",
+      "properties": {}
+    }
+  },
+  {
+    "id": "post-_api_mcp_oauth_token",
+    "method": "post",
+    "path": "/api/mcp/oauth/token",
+    "displayName": "POST mcp",
+    "summary": "POST mcp",
+    "description": "This operation was generated automatically from the route inventory. Replace with canonical OpenAPI metadata.",
+    "tags": [
+      "mcp"
+    ],
+    "approvalRequired": false,
+    "parameters": [],
     "requestBodySchema": {
       "type": "object",
       "properties": {}
@@ -54866,6 +56709,341 @@ export const chatApiRegistry: ChatApiRegistryEntry[] = [
         }
       }
     ],
+    "responseBodySchema": {
+      "type": "object",
+      "properties": {}
+    }
+  },
+  {
+    "id": "get-_api_v1_applianceinstalls",
+    "method": "get",
+    "path": "/api/v1/appliance-installs",
+    "displayName": "GET v1",
+    "summary": "GET v1",
+    "description": "This operation was generated automatically from the route inventory. Replace with canonical OpenAPI metadata.",
+    "tags": [
+      "appliance-installs"
+    ],
+    "approvalRequired": false,
+    "parameters": [],
+    "responseBodySchema": {
+      "type": "object",
+      "properties": {}
+    }
+  },
+  {
+    "id": "post-_api_v1_applianceinstalls_access",
+    "method": "post",
+    "path": "/api/v1/appliance-installs/access",
+    "displayName": "POST v1",
+    "summary": "POST v1",
+    "description": "This operation was generated automatically from the route inventory. Replace with canonical OpenAPI metadata.",
+    "tags": [
+      "appliance-installs"
+    ],
+    "approvalRequired": false,
+    "parameters": [],
+    "requestBodySchema": {
+      "type": "object",
+      "properties": {}
+    },
+    "responseBodySchema": {
+      "type": "object",
+      "properties": {}
+    }
+  },
+  {
+    "id": "get-_api_v1_applianceinstalls_tenantid",
+    "method": "get",
+    "path": "/api/v1/appliance-installs/{tenantId}",
+    "displayName": "GET v1",
+    "summary": "GET v1",
+    "tags": [
+      "appliance-installs"
+    ],
+    "approvalRequired": false,
+    "parameters": [
+      {
+        "name": "tenantId",
+        "in": "path",
+        "required": true,
+        "description": "TenantId path parameter.",
+        "schema": {
+          "type": "string"
+        }
+      }
+    ],
+    "responseBodySchema": {
+      "type": "object",
+      "properties": {}
+    }
+  },
+  {
+    "id": "get-_api_v1_mcp_agents",
+    "method": "get",
+    "path": "/api/v1/mcp/agents",
+    "displayName": "GET v1",
+    "summary": "GET v1",
+    "description": "This operation was generated automatically from the route inventory. Replace with canonical OpenAPI metadata.",
+    "tags": [
+      "mcp"
+    ],
+    "approvalRequired": false,
+    "parameters": [],
+    "responseBodySchema": {
+      "type": "object",
+      "properties": {}
+    }
+  },
+  {
+    "id": "post-_api_v1_mcp_agents",
+    "method": "post",
+    "path": "/api/v1/mcp/agents",
+    "displayName": "POST v1",
+    "summary": "POST v1",
+    "description": "This operation was generated automatically from the route inventory. Replace with canonical OpenAPI metadata.",
+    "tags": [
+      "mcp"
+    ],
+    "approvalRequired": false,
+    "parameters": [],
+    "requestBodySchema": {
+      "type": "object",
+      "properties": {}
+    },
+    "responseBodySchema": {
+      "type": "object",
+      "properties": {}
+    }
+  },
+  {
+    "id": "patch-_api_v1_mcp_agents",
+    "method": "patch",
+    "path": "/api/v1/mcp/agents",
+    "displayName": "PATCH v1",
+    "summary": "PATCH v1",
+    "description": "This operation was generated automatically from the route inventory. Replace with canonical OpenAPI metadata.",
+    "tags": [
+      "mcp"
+    ],
+    "approvalRequired": false,
+    "parameters": [],
+    "requestBodySchema": {
+      "type": "object",
+      "properties": {}
+    },
+    "responseBodySchema": {
+      "type": "object",
+      "properties": {}
+    }
+  },
+  {
+    "id": "delete-_api_v1_mcp_agents",
+    "method": "delete",
+    "path": "/api/v1/mcp/agents",
+    "displayName": "DELETE v1",
+    "summary": "DELETE v1",
+    "description": "This operation was generated automatically from the route inventory. Replace with canonical OpenAPI metadata.",
+    "tags": [
+      "mcp"
+    ],
+    "approvalRequired": false,
+    "parameters": [],
+    "responseBodySchema": {
+      "type": "object",
+      "properties": {}
+    }
+  },
+  {
+    "id": "get-_api_v1_mcp_audit",
+    "method": "get",
+    "path": "/api/v1/mcp/audit",
+    "displayName": "GET v1",
+    "summary": "GET v1",
+    "description": "This operation was generated automatically from the route inventory. Replace with canonical OpenAPI metadata.",
+    "tags": [
+      "mcp"
+    ],
+    "approvalRequired": false,
+    "parameters": [],
+    "responseBodySchema": {
+      "type": "object",
+      "properties": {}
+    }
+  },
+  {
+    "id": "get-_api_v1_mcp_connect_callback",
+    "method": "get",
+    "path": "/api/v1/mcp/connect/callback",
+    "displayName": "GET v1",
+    "summary": "GET v1",
+    "description": "This operation was generated automatically from the route inventory. Replace with canonical OpenAPI metadata.",
+    "tags": [
+      "mcp"
+    ],
+    "approvalRequired": false,
+    "parameters": [],
+    "responseBodySchema": {
+      "type": "object",
+      "properties": {}
+    }
+  },
+  {
+    "id": "post-_api_v1_mcp_connect_start",
+    "method": "post",
+    "path": "/api/v1/mcp/connect/start",
+    "displayName": "POST v1",
+    "summary": "POST v1",
+    "description": "This operation was generated automatically from the route inventory. Replace with canonical OpenAPI metadata.",
+    "tags": [
+      "mcp"
+    ],
+    "approvalRequired": false,
+    "parameters": [],
+    "requestBodySchema": {
+      "type": "object",
+      "properties": {}
+    },
+    "responseBodySchema": {
+      "type": "object",
+      "properties": {}
+    }
+  },
+  {
+    "id": "get-_api_v1_mcp_connections",
+    "method": "get",
+    "path": "/api/v1/mcp/connections",
+    "displayName": "GET v1",
+    "summary": "GET v1",
+    "description": "This operation was generated automatically from the route inventory. Replace with canonical OpenAPI metadata.",
+    "tags": [
+      "mcp"
+    ],
+    "approvalRequired": false,
+    "parameters": [],
+    "responseBodySchema": {
+      "type": "object",
+      "properties": {}
+    }
+  },
+  {
+    "id": "delete-_api_v1_mcp_connections",
+    "method": "delete",
+    "path": "/api/v1/mcp/connections",
+    "displayName": "DELETE v1",
+    "summary": "DELETE v1",
+    "description": "This operation was generated automatically from the route inventory. Replace with canonical OpenAPI metadata.",
+    "tags": [
+      "mcp"
+    ],
+    "approvalRequired": false,
+    "parameters": [],
+    "responseBodySchema": {
+      "type": "object",
+      "properties": {}
+    }
+  },
+  {
+    "id": "get-_api_v1_mcp_idpproviders",
+    "method": "get",
+    "path": "/api/v1/mcp/idp-providers",
+    "displayName": "GET v1",
+    "summary": "GET v1",
+    "description": "This operation was generated automatically from the route inventory. Replace with canonical OpenAPI metadata.",
+    "tags": [
+      "mcp"
+    ],
+    "approvalRequired": false,
+    "parameters": [],
+    "responseBodySchema": {
+      "type": "object",
+      "properties": {}
+    }
+  },
+  {
+    "id": "post-_api_v1_mcp_idpproviders",
+    "method": "post",
+    "path": "/api/v1/mcp/idp-providers",
+    "displayName": "POST v1",
+    "summary": "POST v1",
+    "description": "This operation was generated automatically from the route inventory. Replace with canonical OpenAPI metadata.",
+    "tags": [
+      "mcp"
+    ],
+    "approvalRequired": false,
+    "parameters": [],
+    "requestBodySchema": {
+      "type": "object",
+      "properties": {}
+    },
+    "responseBodySchema": {
+      "type": "object",
+      "properties": {}
+    }
+  },
+  {
+    "id": "get-_api_v1_mcp_idpsuggestions",
+    "method": "get",
+    "path": "/api/v1/mcp/idp-suggestions",
+    "displayName": "GET v1",
+    "summary": "GET v1",
+    "description": "This operation was generated automatically from the route inventory. Replace with canonical OpenAPI metadata.",
+    "tags": [
+      "mcp"
+    ],
+    "approvalRequired": false,
+    "parameters": [],
+    "responseBodySchema": {
+      "type": "object",
+      "properties": {}
+    }
+  },
+  {
+    "id": "get-_api_v1_mcp_platformproviders",
+    "method": "get",
+    "path": "/api/v1/mcp/platform-providers",
+    "displayName": "GET v1",
+    "summary": "GET v1",
+    "description": "This operation was generated automatically from the route inventory. Replace with canonical OpenAPI metadata.",
+    "tags": [
+      "mcp"
+    ],
+    "approvalRequired": false,
+    "parameters": [],
+    "responseBodySchema": {
+      "type": "object",
+      "properties": {}
+    }
+  },
+  {
+    "id": "get-_api_v1_mcp_roles",
+    "method": "get",
+    "path": "/api/v1/mcp/roles",
+    "displayName": "GET v1",
+    "summary": "GET v1",
+    "description": "This operation was generated automatically from the route inventory. Replace with canonical OpenAPI metadata.",
+    "tags": [
+      "mcp"
+    ],
+    "approvalRequired": false,
+    "parameters": [],
+    "responseBodySchema": {
+      "type": "object",
+      "properties": {}
+    }
+  },
+  {
+    "id": "get-_api_v1_meta_mcpregistry",
+    "method": "get",
+    "path": "/api/v1/meta/mcp-registry",
+    "displayName": "GET v1",
+    "summary": "GET v1",
+    "description": "This operation was generated automatically from the route inventory. Replace with canonical OpenAPI metadata.",
+    "tags": [
+      "meta"
+    ],
+    "approvalRequired": false,
+    "parameters": [],
     "responseBodySchema": {
       "type": "object",
       "properties": {}
@@ -56443,6 +58621,65 @@ export const chatApiRegistry: ChatApiRegistryEntry[] = [
         }
       }
     ],
+    "requestBodySchema": {
+      "type": "object",
+      "properties": {}
+    },
+    "responseBodySchema": {
+      "type": "object",
+      "properties": {}
+    }
+  },
+  {
+    "id": "get-_api_webhooks_alternativepayments",
+    "method": "get",
+    "path": "/api/webhooks/alternative-payments",
+    "displayName": "GET webhooks",
+    "summary": "GET webhooks",
+    "description": "This operation was generated automatically from the route inventory. Replace with canonical OpenAPI metadata.",
+    "tags": [
+      "webhooks"
+    ],
+    "approvalRequired": false,
+    "parameters": [],
+    "responseBodySchema": {
+      "type": "object",
+      "properties": {}
+    }
+  },
+  {
+    "id": "post-_api_webhooks_alternativepayments",
+    "method": "post",
+    "path": "/api/webhooks/alternative-payments",
+    "displayName": "POST webhooks",
+    "summary": "POST webhooks",
+    "description": "This operation was generated automatically from the route inventory. Replace with canonical OpenAPI metadata.",
+    "tags": [
+      "webhooks"
+    ],
+    "approvalRequired": false,
+    "parameters": [],
+    "requestBodySchema": {
+      "type": "object",
+      "properties": {}
+    },
+    "responseBodySchema": {
+      "type": "object",
+      "properties": {}
+    }
+  },
+  {
+    "id": "post-_api_webhooks_levelio",
+    "method": "post",
+    "path": "/api/webhooks/levelio",
+    "displayName": "POST webhooks",
+    "summary": "POST webhooks",
+    "description": "This operation was generated automatically from the route inventory. Replace with canonical OpenAPI metadata.",
+    "tags": [
+      "webhooks"
+    ],
+    "approvalRequired": false,
+    "parameters": [],
     "requestBodySchema": {
       "type": "object",
       "properties": {}

--- a/sdk/docs/openapi/alga-openapi.ce.json
+++ b/sdk/docs/openapi/alga-openapi.ce.json
@@ -26,6 +26,9 @@
       "name": "Accounting Exports"
     },
     {
+      "name": "Activities v1"
+    },
+    {
       "name": "Admin"
     },
     {
@@ -173,10 +176,16 @@
       "name": "Workflow Runs"
     },
     {
+      "name": "Workflow Tasks v1"
+    },
+    {
       "name": "Workflows v1"
     },
     {
       "name": "accounting"
+    },
+    {
+      "name": "appliance-installs"
     },
     {
       "name": "auth"
@@ -225,6 +234,12 @@
     },
     {
       "name": "internal"
+    },
+    {
+      "name": "mcp"
+    },
+    {
+      "name": "meta"
     },
     {
       "name": "mobile"
@@ -18779,6 +18794,1473 @@
       "WorkflowV1MissingRouteResponse": {
         "type": "string",
         "description": "Default Next.js not-found response body for missing route handlers."
+      },
+      "WorkflowTasksApiErrorV1": {
+        "type": "object",
+        "properties": {
+          "error": {
+            "type": "object",
+            "properties": {
+              "code": {
+                "type": "string"
+              },
+              "message": {
+                "type": "string"
+              },
+              "details": {}
+            },
+            "required": [
+              "code",
+              "message"
+            ]
+          }
+        },
+        "required": [
+          "error"
+        ]
+      },
+      "WorkflowTaskIdParamV1": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string",
+            "description": "Workflow task identifier (taskId)."
+          }
+        },
+        "required": [
+          "id"
+        ]
+      },
+      "WorkflowTasksListQueryV1": {
+        "type": "object",
+        "properties": {
+          "status": {
+            "type": "string",
+            "description": "Comma-separated WorkflowTaskStatus values (pending, claimed, completed, canceled, expired). Omit for the open inbox (pending + claimed)."
+          },
+          "page": {
+            "type": "integer",
+            "minimum": 1,
+            "description": "1-based page number (default 1)."
+          },
+          "pageSize": {
+            "type": "integer",
+            "minimum": 1,
+            "maximum": 100,
+            "description": "Items per page, max 100 (default 25)."
+          }
+        }
+      },
+      "WorkflowTaskV1": {
+        "type": "object",
+        "properties": {
+          "taskId": {
+            "type": "string"
+          },
+          "executionId": {
+            "type": "string"
+          },
+          "title": {
+            "type": "string"
+          },
+          "description": {
+            "type": "string"
+          },
+          "status": {
+            "type": "string",
+            "enum": [
+              "pending",
+              "claimed",
+              "completed",
+              "canceled",
+              "expired"
+            ]
+          },
+          "priority": {
+            "type": "string"
+          },
+          "dueDate": {
+            "type": "string"
+          },
+          "assignedRoles": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          },
+          "assignedUsers": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          },
+          "contextData": {
+            "type": "object",
+            "additionalProperties": {}
+          },
+          "formId": {
+            "type": "string"
+          },
+          "formSchema": {
+            "type": "object",
+            "properties": {
+              "jsonSchema": {
+                "type": "object",
+                "additionalProperties": {}
+              },
+              "uiSchema": {
+                "type": "object",
+                "additionalProperties": {}
+              },
+              "defaultValues": {
+                "type": "object",
+                "additionalProperties": {}
+              }
+            },
+            "required": [
+              "jsonSchema"
+            ]
+          },
+          "createdAt": {
+            "type": "string"
+          },
+          "createdBy": {
+            "type": "string"
+          },
+          "claimedAt": {
+            "type": "string"
+          },
+          "claimedBy": {
+            "type": "string"
+          },
+          "completedAt": {
+            "type": "string"
+          },
+          "completedBy": {
+            "type": "string"
+          },
+          "responseData": {
+            "type": "object",
+            "additionalProperties": {}
+          }
+        },
+        "required": [
+          "taskId",
+          "executionId",
+          "title",
+          "status",
+          "priority",
+          "formId",
+          "createdAt"
+        ]
+      },
+      "WorkflowTaskListResponseV1": {
+        "type": "object",
+        "properties": {
+          "data": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "properties": {
+                "taskId": {
+                  "type": "string"
+                },
+                "executionId": {
+                  "type": "string"
+                },
+                "title": {
+                  "type": "string"
+                },
+                "description": {
+                  "type": "string"
+                },
+                "status": {
+                  "type": "string",
+                  "enum": [
+                    "pending",
+                    "claimed",
+                    "completed",
+                    "canceled",
+                    "expired"
+                  ]
+                },
+                "priority": {
+                  "type": "string"
+                },
+                "dueDate": {
+                  "type": "string"
+                },
+                "assignedRoles": {
+                  "type": "array",
+                  "items": {
+                    "type": "string"
+                  }
+                },
+                "assignedUsers": {
+                  "type": "array",
+                  "items": {
+                    "type": "string"
+                  }
+                },
+                "contextData": {
+                  "type": "object",
+                  "additionalProperties": {}
+                },
+                "formId": {
+                  "type": "string"
+                },
+                "formSchema": {
+                  "type": "object",
+                  "properties": {
+                    "jsonSchema": {
+                      "type": "object",
+                      "additionalProperties": {}
+                    },
+                    "uiSchema": {
+                      "type": "object",
+                      "additionalProperties": {}
+                    },
+                    "defaultValues": {
+                      "type": "object",
+                      "additionalProperties": {}
+                    }
+                  },
+                  "required": [
+                    "jsonSchema"
+                  ]
+                },
+                "createdAt": {
+                  "type": "string"
+                },
+                "createdBy": {
+                  "type": "string"
+                },
+                "claimedAt": {
+                  "type": "string"
+                },
+                "claimedBy": {
+                  "type": "string"
+                },
+                "completedAt": {
+                  "type": "string"
+                },
+                "completedBy": {
+                  "type": "string"
+                },
+                "responseData": {
+                  "type": "object",
+                  "additionalProperties": {}
+                }
+              },
+              "required": [
+                "taskId",
+                "executionId",
+                "title",
+                "status",
+                "priority",
+                "formId",
+                "createdAt"
+              ]
+            }
+          },
+          "pagination": {
+            "type": "object",
+            "properties": {
+              "page": {
+                "type": "number"
+              },
+              "limit": {
+                "type": "number"
+              },
+              "total": {
+                "type": "number"
+              },
+              "totalPages": {
+                "type": "number"
+              },
+              "hasNext": {
+                "type": "boolean"
+              },
+              "hasPrev": {
+                "type": "boolean"
+              }
+            },
+            "required": [
+              "page",
+              "limit",
+              "total",
+              "totalPages",
+              "hasNext",
+              "hasPrev"
+            ]
+          },
+          "meta": {}
+        },
+        "required": [
+          "data",
+          "pagination"
+        ]
+      },
+      "WorkflowTaskDetailResponseV1": {
+        "type": "object",
+        "properties": {
+          "data": {
+            "type": "object",
+            "properties": {
+              "taskId": {
+                "type": "string"
+              },
+              "executionId": {
+                "type": "string"
+              },
+              "title": {
+                "type": "string"
+              },
+              "description": {
+                "type": "string"
+              },
+              "status": {
+                "type": "string",
+                "enum": [
+                  "pending",
+                  "claimed",
+                  "completed",
+                  "canceled",
+                  "expired"
+                ]
+              },
+              "priority": {
+                "type": "string"
+              },
+              "dueDate": {
+                "type": "string"
+              },
+              "assignedRoles": {
+                "type": "array",
+                "items": {
+                  "type": "string"
+                }
+              },
+              "assignedUsers": {
+                "type": "array",
+                "items": {
+                  "type": "string"
+                }
+              },
+              "contextData": {
+                "type": "object",
+                "additionalProperties": {}
+              },
+              "formId": {
+                "type": "string"
+              },
+              "formSchema": {
+                "type": "object",
+                "properties": {
+                  "jsonSchema": {
+                    "type": "object",
+                    "additionalProperties": {}
+                  },
+                  "uiSchema": {
+                    "type": "object",
+                    "additionalProperties": {}
+                  },
+                  "defaultValues": {
+                    "type": "object",
+                    "additionalProperties": {}
+                  }
+                },
+                "required": [
+                  "jsonSchema"
+                ]
+              },
+              "createdAt": {
+                "type": "string"
+              },
+              "createdBy": {
+                "type": "string"
+              },
+              "claimedAt": {
+                "type": "string"
+              },
+              "claimedBy": {
+                "type": "string"
+              },
+              "completedAt": {
+                "type": "string"
+              },
+              "completedBy": {
+                "type": "string"
+              },
+              "responseData": {
+                "type": "object",
+                "additionalProperties": {}
+              }
+            },
+            "required": [
+              "taskId",
+              "executionId",
+              "title",
+              "status",
+              "priority",
+              "formId",
+              "createdAt"
+            ]
+          },
+          "meta": {}
+        },
+        "required": [
+          "data"
+        ]
+      },
+      "WorkflowTaskActionResponseV1": {
+        "type": "object",
+        "properties": {
+          "data": {
+            "type": "object",
+            "properties": {
+              "success": {
+                "type": "boolean"
+              }
+            },
+            "required": [
+              "success"
+            ]
+          },
+          "meta": {}
+        },
+        "required": [
+          "data"
+        ]
+      },
+      "CompleteWorkflowTaskBodyV1": {
+        "type": "object",
+        "properties": {
+          "formData": {
+            "type": "object",
+            "additionalProperties": {},
+            "default": {}
+          },
+          "comments": {
+            "type": "string"
+          }
+        }
+      },
+      "ActivitiesApiErrorV1": {
+        "type": "object",
+        "properties": {
+          "error": {
+            "type": "object",
+            "properties": {
+              "code": {
+                "type": "string"
+              },
+              "message": {
+                "type": "string"
+              },
+              "details": {}
+            },
+            "required": [
+              "code",
+              "message"
+            ]
+          }
+        },
+        "required": [
+          "error"
+        ]
+      },
+      "ActivitiesAdHocIdParamV1": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string",
+            "description": "Ad-hoc activity identifier (the backing schedule entry id)."
+          }
+        },
+        "required": [
+          "id"
+        ]
+      },
+      "ActivitiesListQueryV1": {
+        "type": "object",
+        "properties": {
+          "type": {
+            "type": "string",
+            "description": "Comma-separated ActivityType values (e.g. \"ticket,schedule\"). Omit for all types."
+          },
+          "status": {
+            "type": "string",
+            "enum": [
+              "open",
+              "closed",
+              "all"
+            ],
+            "description": "Open/closed filter. `open`→active only, `closed`→closed, `all`→no filter (default)."
+          },
+          "search": {
+            "type": "string",
+            "description": "Free-text search across activity titles/descriptions."
+          },
+          "dateStart": {
+            "type": "string",
+            "format": "date-time",
+            "description": "ISO 8601 lower bound of the schedule/time-entry/notification window."
+          },
+          "dateEnd": {
+            "type": "string",
+            "format": "date-time",
+            "description": "ISO 8601 upper bound of the window."
+          },
+          "priority": {
+            "type": "string",
+            "description": "Comma-separated normalized ActivityPriority buckets (e.g. \"high,medium\"). Lossy for custom schemes; prefer `priorityIds`."
+          },
+          "priorityIds": {
+            "type": "string",
+            "description": "Comma-separated exact priority IDs (the tenant's real per-type priorities). Applies to ticket/project-task activities."
+          },
+          "dueDateStart": {
+            "type": "string",
+            "format": "date-time",
+            "description": "ISO 8601 lower bound of the due-date filter (independent of the schedule window)."
+          },
+          "dueDateEnd": {
+            "type": "string",
+            "format": "date-time",
+            "description": "ISO 8601 upper bound of the due-date filter."
+          },
+          "createdAtStart": {
+            "type": "string",
+            "format": "date-time",
+            "description": "ISO 8601 lower bound of the created-date (\"date entered\") filter. Applies to every activity type."
+          },
+          "createdAtEnd": {
+            "type": "string",
+            "format": "date-time",
+            "description": "ISO 8601 upper bound of the created-date (\"date entered\") filter."
+          },
+          "sortBy": {
+            "type": "string",
+            "enum": [
+              "type",
+              "title",
+              "status",
+              "priority",
+              "dueDate"
+            ],
+            "description": "Sort column. Omit for the default sort (priority high→low, then due date ascending)."
+          },
+          "sortDirection": {
+            "type": "string",
+            "enum": [
+              "asc",
+              "desc"
+            ],
+            "description": "Sort direction for `sortBy` (default asc). Ignored when `sortBy` is omitted."
+          },
+          "groupBy": {
+            "type": "string",
+            "enum": [
+              "type",
+              "priority",
+              "status",
+              "dueDate"
+            ],
+            "description": "When set, the response is grouped by this dimension (ActivityGroupedResponseV1) instead of the paginated list; `page`/`pageSize` are ignored. `priority` groups by the real per-tenant priority name (not the normalized bucket), so it is only meaningful when scoped to a single prioritized type."
+          },
+          "page": {
+            "type": "integer",
+            "minimum": 1,
+            "description": "1-based page number (default 1). Ignored when `groupBy` is set."
+          },
+          "pageSize": {
+            "type": "integer",
+            "minimum": 1,
+            "maximum": 100,
+            "description": "Items per page, max 100 (default 25). Ignored when `groupBy` is set."
+          }
+        }
+      },
+      "ActivityV1": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string"
+          },
+          "title": {
+            "type": "string"
+          },
+          "description": {
+            "type": "string"
+          },
+          "type": {
+            "type": "string",
+            "enum": [
+              "schedule",
+              "projectTask",
+              "ticket",
+              "timeEntry",
+              "workflowTask",
+              "notification",
+              "document"
+            ]
+          },
+          "status": {
+            "type": "string"
+          },
+          "statusColor": {
+            "type": "string"
+          },
+          "priority": {
+            "type": "string",
+            "enum": [
+              "low",
+              "medium",
+              "high"
+            ]
+          },
+          "priorityName": {
+            "type": "string"
+          },
+          "priorityColor": {
+            "type": "string"
+          },
+          "dueDate": {
+            "type": "string"
+          },
+          "startDate": {
+            "type": "string"
+          },
+          "endDate": {
+            "type": "string"
+          },
+          "assignedTo": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          },
+          "assignedToNames": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          },
+          "sourceId": {
+            "type": "string"
+          },
+          "sourceType": {
+            "type": "string",
+            "enum": [
+              "schedule",
+              "projectTask",
+              "ticket",
+              "timeEntry",
+              "workflowTask",
+              "notification",
+              "document"
+            ]
+          },
+          "actions": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "properties": {
+                "id": {
+                  "type": "string"
+                },
+                "label": {
+                  "type": "string"
+                },
+                "icon": {
+                  "type": "string"
+                },
+                "disabled": {
+                  "type": "boolean"
+                },
+                "disabledReason": {
+                  "type": "string"
+                }
+              },
+              "required": [
+                "id",
+                "label"
+              ]
+            }
+          },
+          "isClosed": {
+            "type": "boolean"
+          },
+          "tenant": {
+            "type": "string"
+          },
+          "createdAt": {
+            "type": "string"
+          },
+          "updatedAt": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "id",
+          "title",
+          "type",
+          "status",
+          "priority",
+          "sourceId",
+          "sourceType",
+          "actions",
+          "tenant",
+          "createdAt",
+          "updatedAt"
+        ]
+      },
+      "ActivityListResponseV1": {
+        "type": "object",
+        "properties": {
+          "data": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "properties": {
+                "id": {
+                  "type": "string"
+                },
+                "title": {
+                  "type": "string"
+                },
+                "description": {
+                  "type": "string"
+                },
+                "type": {
+                  "type": "string",
+                  "enum": [
+                    "schedule",
+                    "projectTask",
+                    "ticket",
+                    "timeEntry",
+                    "workflowTask",
+                    "notification",
+                    "document"
+                  ]
+                },
+                "status": {
+                  "type": "string"
+                },
+                "statusColor": {
+                  "type": "string"
+                },
+                "priority": {
+                  "type": "string",
+                  "enum": [
+                    "low",
+                    "medium",
+                    "high"
+                  ]
+                },
+                "priorityName": {
+                  "type": "string"
+                },
+                "priorityColor": {
+                  "type": "string"
+                },
+                "dueDate": {
+                  "type": "string"
+                },
+                "startDate": {
+                  "type": "string"
+                },
+                "endDate": {
+                  "type": "string"
+                },
+                "assignedTo": {
+                  "type": "array",
+                  "items": {
+                    "type": "string"
+                  }
+                },
+                "assignedToNames": {
+                  "type": "array",
+                  "items": {
+                    "type": "string"
+                  }
+                },
+                "sourceId": {
+                  "type": "string"
+                },
+                "sourceType": {
+                  "type": "string",
+                  "enum": [
+                    "schedule",
+                    "projectTask",
+                    "ticket",
+                    "timeEntry",
+                    "workflowTask",
+                    "notification",
+                    "document"
+                  ]
+                },
+                "actions": {
+                  "type": "array",
+                  "items": {
+                    "type": "object",
+                    "properties": {
+                      "id": {
+                        "type": "string"
+                      },
+                      "label": {
+                        "type": "string"
+                      },
+                      "icon": {
+                        "type": "string"
+                      },
+                      "disabled": {
+                        "type": "boolean"
+                      },
+                      "disabledReason": {
+                        "type": "string"
+                      }
+                    },
+                    "required": [
+                      "id",
+                      "label"
+                    ]
+                  }
+                },
+                "isClosed": {
+                  "type": "boolean"
+                },
+                "tenant": {
+                  "type": "string"
+                },
+                "createdAt": {
+                  "type": "string"
+                },
+                "updatedAt": {
+                  "type": "string"
+                }
+              },
+              "required": [
+                "id",
+                "title",
+                "type",
+                "status",
+                "priority",
+                "sourceId",
+                "sourceType",
+                "actions",
+                "tenant",
+                "createdAt",
+                "updatedAt"
+              ]
+            }
+          },
+          "pagination": {
+            "type": "object",
+            "properties": {
+              "page": {
+                "type": "number"
+              },
+              "limit": {
+                "type": "number"
+              },
+              "total": {
+                "type": "number"
+              },
+              "totalPages": {
+                "type": "number"
+              },
+              "hasNext": {
+                "type": "boolean"
+              },
+              "hasPrev": {
+                "type": "boolean"
+              }
+            },
+            "required": [
+              "page",
+              "limit",
+              "total",
+              "totalPages",
+              "hasNext",
+              "hasPrev"
+            ]
+          },
+          "meta": {}
+        },
+        "required": [
+          "data",
+          "pagination"
+        ]
+      },
+      "ActivityGroupedResponseV1": {
+        "type": "object",
+        "properties": {
+          "data": {
+            "type": "object",
+            "properties": {
+              "groupBy": {
+                "type": "string",
+                "enum": [
+                  "type",
+                  "priority",
+                  "status",
+                  "dueDate"
+                ]
+              },
+              "groups": {
+                "type": "array",
+                "items": {
+                  "type": "object",
+                  "properties": {
+                    "key": {
+                      "type": "string"
+                    },
+                    "label": {
+                      "type": "string"
+                    },
+                    "count": {
+                      "type": "number"
+                    },
+                    "activities": {
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "properties": {
+                          "id": {
+                            "type": "string"
+                          },
+                          "title": {
+                            "type": "string"
+                          },
+                          "description": {
+                            "type": "string"
+                          },
+                          "type": {
+                            "type": "string",
+                            "enum": [
+                              "schedule",
+                              "projectTask",
+                              "ticket",
+                              "timeEntry",
+                              "workflowTask",
+                              "notification",
+                              "document"
+                            ]
+                          },
+                          "status": {
+                            "type": "string"
+                          },
+                          "statusColor": {
+                            "type": "string"
+                          },
+                          "priority": {
+                            "type": "string",
+                            "enum": [
+                              "low",
+                              "medium",
+                              "high"
+                            ]
+                          },
+                          "priorityName": {
+                            "type": "string"
+                          },
+                          "priorityColor": {
+                            "type": "string"
+                          },
+                          "dueDate": {
+                            "type": "string"
+                          },
+                          "startDate": {
+                            "type": "string"
+                          },
+                          "endDate": {
+                            "type": "string"
+                          },
+                          "assignedTo": {
+                            "type": "array",
+                            "items": {
+                              "type": "string"
+                            }
+                          },
+                          "assignedToNames": {
+                            "type": "array",
+                            "items": {
+                              "type": "string"
+                            }
+                          },
+                          "sourceId": {
+                            "type": "string"
+                          },
+                          "sourceType": {
+                            "type": "string",
+                            "enum": [
+                              "schedule",
+                              "projectTask",
+                              "ticket",
+                              "timeEntry",
+                              "workflowTask",
+                              "notification",
+                              "document"
+                            ]
+                          },
+                          "actions": {
+                            "type": "array",
+                            "items": {
+                              "type": "object",
+                              "properties": {
+                                "id": {
+                                  "type": "string"
+                                },
+                                "label": {
+                                  "type": "string"
+                                },
+                                "icon": {
+                                  "type": "string"
+                                },
+                                "disabled": {
+                                  "type": "boolean"
+                                },
+                                "disabledReason": {
+                                  "type": "string"
+                                }
+                              },
+                              "required": [
+                                "id",
+                                "label"
+                              ]
+                            }
+                          },
+                          "isClosed": {
+                            "type": "boolean"
+                          },
+                          "tenant": {
+                            "type": "string"
+                          },
+                          "createdAt": {
+                            "type": "string"
+                          },
+                          "updatedAt": {
+                            "type": "string"
+                          }
+                        },
+                        "required": [
+                          "id",
+                          "title",
+                          "type",
+                          "status",
+                          "priority",
+                          "sourceId",
+                          "sourceType",
+                          "actions",
+                          "tenant",
+                          "createdAt",
+                          "updatedAt"
+                        ]
+                      }
+                    }
+                  },
+                  "required": [
+                    "key",
+                    "label",
+                    "count",
+                    "activities"
+                  ]
+                }
+              },
+              "totalCount": {
+                "type": "number"
+              },
+              "truncated": {
+                "type": "boolean"
+              }
+            },
+            "required": [
+              "groupBy",
+              "groups",
+              "totalCount",
+              "truncated"
+            ]
+          },
+          "meta": {}
+        },
+        "required": [
+          "data"
+        ]
+      },
+      "AdHocActivityResponseV1": {
+        "type": "object",
+        "properties": {
+          "data": {
+            "type": "object",
+            "properties": {
+              "id": {
+                "type": "string"
+              },
+              "title": {
+                "type": "string"
+              },
+              "description": {
+                "type": "string"
+              },
+              "type": {
+                "type": "string",
+                "enum": [
+                  "schedule",
+                  "projectTask",
+                  "ticket",
+                  "timeEntry",
+                  "workflowTask",
+                  "notification",
+                  "document"
+                ]
+              },
+              "status": {
+                "type": "string"
+              },
+              "statusColor": {
+                "type": "string"
+              },
+              "priority": {
+                "type": "string",
+                "enum": [
+                  "low",
+                  "medium",
+                  "high"
+                ]
+              },
+              "priorityName": {
+                "type": "string"
+              },
+              "priorityColor": {
+                "type": "string"
+              },
+              "dueDate": {
+                "type": "string"
+              },
+              "startDate": {
+                "type": "string"
+              },
+              "endDate": {
+                "type": "string"
+              },
+              "assignedTo": {
+                "type": "array",
+                "items": {
+                  "type": "string"
+                }
+              },
+              "assignedToNames": {
+                "type": "array",
+                "items": {
+                  "type": "string"
+                }
+              },
+              "sourceId": {
+                "type": "string"
+              },
+              "sourceType": {
+                "type": "string",
+                "enum": [
+                  "schedule",
+                  "projectTask",
+                  "ticket",
+                  "timeEntry",
+                  "workflowTask",
+                  "notification",
+                  "document"
+                ]
+              },
+              "actions": {
+                "type": "array",
+                "items": {
+                  "type": "object",
+                  "properties": {
+                    "id": {
+                      "type": "string"
+                    },
+                    "label": {
+                      "type": "string"
+                    },
+                    "icon": {
+                      "type": "string"
+                    },
+                    "disabled": {
+                      "type": "boolean"
+                    },
+                    "disabledReason": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "id",
+                    "label"
+                  ]
+                }
+              },
+              "isClosed": {
+                "type": "boolean"
+              },
+              "tenant": {
+                "type": "string"
+              },
+              "createdAt": {
+                "type": "string"
+              },
+              "updatedAt": {
+                "type": "string"
+              }
+            },
+            "required": [
+              "id",
+              "title",
+              "type",
+              "status",
+              "priority",
+              "sourceId",
+              "sourceType",
+              "actions",
+              "tenant",
+              "createdAt",
+              "updatedAt"
+            ]
+          },
+          "meta": {}
+        },
+        "required": [
+          "data"
+        ]
+      },
+      "CreateAdHocActivityBodyV1": {
+        "type": "object",
+        "properties": {
+          "title": {
+            "type": "string",
+            "minLength": 1
+          },
+          "notes": {
+            "type": "string"
+          },
+          "scheduledStart": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "format": "date-time"
+          },
+          "scheduledEnd": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "format": "date-time"
+          }
+        },
+        "required": [
+          "title"
+        ]
+      },
+      "UpdateAdHocActivityBodyV1": {
+        "type": "object",
+        "properties": {
+          "title": {
+            "type": "string",
+            "minLength": 1
+          },
+          "notes": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "scheduledStart": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "format": "date-time"
+          },
+          "scheduledEnd": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "format": "date-time"
+          }
+        }
+      },
+      "SetAdHocActivityDoneBodyV1": {
+        "type": "object",
+        "properties": {
+          "done": {
+            "type": "boolean"
+          }
+        },
+        "required": [
+          "done"
+        ]
+      },
+      "CustomActivityGroupsResponseV1": {
+        "type": "object",
+        "properties": {
+          "data": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "properties": {
+                "groupId": {
+                  "type": "string"
+                },
+                "groupName": {
+                  "type": "string"
+                },
+                "sortOrder": {
+                  "type": "number"
+                },
+                "isCollapsed": {
+                  "type": "boolean"
+                },
+                "items": {
+                  "type": "array",
+                  "items": {
+                    "type": "object",
+                    "properties": {
+                      "itemId": {
+                        "type": "string"
+                      },
+                      "activityId": {
+                        "type": "string"
+                      },
+                      "activityType": {
+                        "type": "string"
+                      },
+                      "sortOrder": {
+                        "type": "number"
+                      }
+                    },
+                    "required": [
+                      "itemId",
+                      "activityId",
+                      "activityType",
+                      "sortOrder"
+                    ]
+                  }
+                }
+              },
+              "required": [
+                "groupId",
+                "groupName",
+                "sortOrder",
+                "isCollapsed",
+                "items"
+              ]
+            }
+          },
+          "meta": {}
+        },
+        "required": [
+          "data"
+        ]
+      },
+      "MoveActivityToGroupBodyV1": {
+        "type": "object",
+        "properties": {
+          "activityId": {
+            "type": "string",
+            "minLength": 1
+          },
+          "activityType": {
+            "type": "string",
+            "minLength": 1
+          },
+          "groupId": {
+            "type": "string",
+            "minLength": 1
+          },
+          "sortOrder": {
+            "type": "integer",
+            "minimum": 0
+          }
+        },
+        "required": [
+          "activityId",
+          "activityType",
+          "groupId",
+          "sortOrder"
+        ]
+      },
+      "RemoveActivityFromGroupBodyV1": {
+        "type": "object",
+        "properties": {
+          "activityId": {
+            "type": "string",
+            "minLength": 1
+          },
+          "activityType": {
+            "type": "string",
+            "minLength": 1
+          }
+        },
+        "required": [
+          "activityId",
+          "activityType"
+        ]
+      },
+      "ReorderActivitiesInGroupBodyV1": {
+        "type": "object",
+        "properties": {
+          "items": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "properties": {
+                "activityId": {
+                  "type": "string",
+                  "minLength": 1
+                },
+                "activityType": {
+                  "type": "string",
+                  "minLength": 1
+                },
+                "sortOrder": {
+                  "type": "integer",
+                  "minimum": 0
+                }
+              },
+              "required": [
+                "activityId",
+                "activityType",
+                "sortOrder"
+              ]
+            },
+            "minItems": 1
+          }
+        },
+        "required": [
+          "items"
+        ]
+      },
+      "ActivitiesGroupIdParamV1": {
+        "type": "object",
+        "properties": {
+          "groupId": {
+            "type": "string",
+            "description": "Custom activity group identifier."
+          }
+        },
+        "required": [
+          "groupId"
+        ]
+      },
+      "ActivitiesGroupsQueryV1": {
+        "type": "object",
+        "properties": {
+          "targetUserId": {
+            "type": "string",
+            "description": "Another internal user whose groups to read (requires elevated schedule permission). Omit for self."
+          }
+        }
       },
       "ProjectIdParams": {
         "type": "object",
@@ -71043,8 +72525,7 @@
                   "currency_code": {
                     "type": "string",
                     "minLength": 3,
-                    "maxLength": 3,
-                    "default": "USD"
+                    "maxLength": 3
                   },
                   "unit_of_measure": {
                     "type": "string",
@@ -71134,8 +72615,7 @@
                       {
                         "type": "null"
                       }
-                    ],
-                    "default": "USD"
+                    ]
                   },
                   "vendor": {
                     "anyOf": [
@@ -71439,8 +72919,7 @@
                   "currency_code": {
                     "type": "string",
                     "minLength": 3,
-                    "maxLength": 3,
-                    "default": "USD"
+                    "maxLength": 3
                   },
                   "unit_of_measure": {
                     "type": "string",
@@ -71530,8 +73009,7 @@
                       {
                         "type": "null"
                       }
-                    ],
-                    "default": "USD"
+                    ]
                   },
                   "vendor": {
                     "anyOf": [
@@ -75241,8 +76719,8 @@
       }
     },
     "/api/v1/workflows/tasks": {
-      "get": {
-        "summary": "List workflow tasks (route inventory only)",
+      "post": {
+        "summary": "Create workflow task (route inventory only)",
         "description": "This operation is currently present only in generated route inventory. No corresponding Next.js handler exists under server/src/app/api/v1/workflows in this worktree. Runtime behavior is middleware-dependent: missing/invalid x-api-key can return 401 before routing; with middleware requirements satisfied, Next.js returns not-found for the absent handler. Existing workflow APIs in this codebase are implemented under /api/workflow-definitions, /api/workflow-runs, and /api/workflow/events rather than /api/v1/workflows paths.",
         "tags": [
           "Workflows v1"
@@ -75283,11 +76761,11 @@
           }
         }
       },
-      "post": {
-        "summary": "Create workflow task (route inventory only)",
-        "description": "This operation is currently present only in generated route inventory. No corresponding Next.js handler exists under server/src/app/api/v1/workflows in this worktree. Runtime behavior is middleware-dependent: missing/invalid x-api-key can return 401 before routing; with middleware requirements satisfied, Next.js returns not-found for the absent handler. Existing workflow APIs in this codebase are implemented under /api/workflow-definitions, /api/workflow-runs, and /api/workflow/events rather than /api/v1/workflows paths.",
+      "get": {
+        "summary": "List workflow tasks",
+        "description": "Returns the authenticated caller's workflow task inbox (tasks assigned to them directly or via a role), paginated. Items are summary rows without `formSchema`; fetch a single task to obtain its form schema. EE-only — on the Community build this returns an empty page.",
         "tags": [
-          "Workflows v1"
+          "Workflow Tasks v1"
         ],
         "security": [
           {
@@ -75295,30 +76773,85 @@
           }
         ],
         "extensions": {
-          "x-route-inventory-only": true,
-          "x-route-file-missing": "server/src/app/api/v1/workflows/**/route.ts",
-          "x-family-status": "missing-handler"
+          "x-tenant-scoped": true,
+          "x-auth-mechanism": "NextAuth session, falling back to x-api-key (resolveWorkflowTaskAuthContext)",
+          "x-edition-behavior": "EE-only feature; CE returns an empty page (list) or 404 (detail/actions)."
         },
         "x-alga-products": [
           "psa"
         ],
+        "parameters": [
+          {
+            "schema": {
+              "type": "string",
+              "description": "Comma-separated WorkflowTaskStatus values (pending, claimed, completed, canceled, expired). Omit for the open inbox (pending + claimed)."
+            },
+            "required": false,
+            "description": "Comma-separated WorkflowTaskStatus values (pending, claimed, completed, canceled, expired). Omit for the open inbox (pending + claimed).",
+            "name": "status",
+            "in": "query"
+          },
+          {
+            "schema": {
+              "type": "integer",
+              "minimum": 1,
+              "description": "1-based page number (default 1)."
+            },
+            "required": false,
+            "description": "1-based page number (default 1).",
+            "name": "page",
+            "in": "query"
+          },
+          {
+            "schema": {
+              "type": "integer",
+              "minimum": 1,
+              "maximum": 100,
+              "description": "Items per page, max 100 (default 25)."
+            },
+            "required": false,
+            "description": "Items per page, max 100 (default 25).",
+            "name": "pageSize",
+            "in": "query"
+          }
+        ],
         "responses": {
-          "401": {
-            "description": "x-api-key missing/invalid at middleware.",
+          "200": {
+            "description": "Paginated workflow task inbox.",
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/WorkflowV1MissingApiError"
+                  "$ref": "#/components/schemas/WorkflowTaskListResponseV1"
                 }
               }
             }
           },
-          "404": {
-            "description": "No route handler exists for this inventory-only /api/v1/workflows path.",
+          "400": {
+            "description": "Invalid query parameters.",
             "content": {
-              "text/html": {
+              "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/WorkflowV1MissingRouteResponse"
+                  "$ref": "#/components/schemas/WorkflowTasksApiErrorV1"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Authentication required (no session and no/invalid x-api-key).",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/WorkflowTasksApiErrorV1"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Unexpected failure resolving the task inbox.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/WorkflowTasksApiErrorV1"
                 }
               }
             }
@@ -75371,48 +76904,6 @@
       }
     },
     "/api/v1/workflows/tasks/{id}": {
-      "get": {
-        "summary": "Get workflow task by id (route inventory only)",
-        "description": "This operation is currently present only in generated route inventory. No corresponding Next.js handler exists under server/src/app/api/v1/workflows in this worktree. Runtime behavior is middleware-dependent: missing/invalid x-api-key can return 401 before routing; with middleware requirements satisfied, Next.js returns not-found for the absent handler. Existing workflow APIs in this codebase are implemented under /api/workflow-definitions, /api/workflow-runs, and /api/workflow/events rather than /api/v1/workflows paths.",
-        "tags": [
-          "Workflows v1"
-        ],
-        "security": [
-          {
-            "ApiKeyAuth": []
-          }
-        ],
-        "extensions": {
-          "x-route-inventory-only": true,
-          "x-route-file-missing": "server/src/app/api/v1/workflows/**/route.ts",
-          "x-family-status": "missing-handler"
-        },
-        "x-alga-products": [
-          "psa"
-        ],
-        "responses": {
-          "401": {
-            "description": "x-api-key missing/invalid at middleware.",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/WorkflowV1MissingApiError"
-                }
-              }
-            }
-          },
-          "404": {
-            "description": "No route handler exists for this inventory-only /api/v1/workflows path.",
-            "content": {
-              "text/html": {
-                "schema": {
-                  "$ref": "#/components/schemas/WorkflowV1MissingRouteResponse"
-                }
-              }
-            }
-          }
-        }
-      },
       "put": {
         "summary": "Update workflow task (route inventory only)",
         "description": "This operation is currently present only in generated route inventory. No corresponding Next.js handler exists under server/src/app/api/v1/workflows in this worktree. Runtime behavior is middleware-dependent: missing/invalid x-api-key can return 401 before routing; with middleware requirements satisfied, Next.js returns not-found for the absent handler. Existing workflow APIs in this codebase are implemented under /api/workflow-definitions, /api/workflow-runs, and /api/workflow/events rather than /api/v1/workflows paths.",
@@ -75454,14 +76945,12 @@
             }
           }
         }
-      }
-    },
-    "/api/v1/workflows/tasks/{id}/claim": {
-      "post": {
-        "summary": "Claim workflow task (route inventory only)",
-        "description": "This operation is currently present only in generated route inventory. No corresponding Next.js handler exists under server/src/app/api/v1/workflows in this worktree. Runtime behavior is middleware-dependent: missing/invalid x-api-key can return 401 before routing; with middleware requirements satisfied, Next.js returns not-found for the absent handler. Existing workflow APIs in this codebase are implemented under /api/workflow-definitions, /api/workflow-runs, and /api/workflow/events rather than /api/v1/workflows paths.",
+      },
+      "get": {
+        "summary": "Get workflow task",
+        "description": "Returns full detail for a single workflow task, including `formSchema` ({ jsonSchema, uiSchema?, defaultValues? }) so a client can classify the form as simple (native completion) vs complex (web deep-link). EE-only — on the Community build this returns 404.",
         "tags": [
-          "Workflows v1"
+          "Workflow Tasks v1"
         ],
         "security": [
           {
@@ -75469,74 +76958,62 @@
           }
         ],
         "extensions": {
-          "x-route-inventory-only": true,
-          "x-route-file-missing": "server/src/app/api/v1/workflows/**/route.ts",
-          "x-family-status": "missing-handler"
+          "x-tenant-scoped": true,
+          "x-auth-mechanism": "NextAuth session, falling back to x-api-key (resolveWorkflowTaskAuthContext)",
+          "x-edition-behavior": "EE-only feature; CE returns an empty page (list) or 404 (detail/actions)."
         },
         "x-alga-products": [
           "psa"
         ],
-        "responses": {
-          "401": {
-            "description": "x-api-key missing/invalid at middleware.",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/WorkflowV1MissingApiError"
-                }
-              }
-            }
-          },
-          "404": {
-            "description": "No route handler exists for this inventory-only /api/v1/workflows path.",
-            "content": {
-              "text/html": {
-                "schema": {
-                  "$ref": "#/components/schemas/WorkflowV1MissingRouteResponse"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/api/v1/workflows/tasks/{id}/complete": {
-      "post": {
-        "summary": "Complete workflow task (route inventory only)",
-        "description": "This operation is currently present only in generated route inventory. No corresponding Next.js handler exists under server/src/app/api/v1/workflows in this worktree. Runtime behavior is middleware-dependent: missing/invalid x-api-key can return 401 before routing; with middleware requirements satisfied, Next.js returns not-found for the absent handler. Existing workflow APIs in this codebase are implemented under /api/workflow-definitions, /api/workflow-runs, and /api/workflow/events rather than /api/v1/workflows paths.",
-        "tags": [
-          "Workflows v1"
-        ],
-        "security": [
+        "parameters": [
           {
-            "ApiKeyAuth": []
+            "schema": {
+              "type": "string",
+              "description": "Workflow task identifier (taskId)."
+            },
+            "required": true,
+            "description": "Workflow task identifier (taskId).",
+            "name": "id",
+            "in": "path"
           }
         ],
-        "extensions": {
-          "x-route-inventory-only": true,
-          "x-route-file-missing": "server/src/app/api/v1/workflows/**/route.ts",
-          "x-family-status": "missing-handler"
-        },
-        "x-alga-products": [
-          "psa"
-        ],
         "responses": {
-          "401": {
-            "description": "x-api-key missing/invalid at middleware.",
+          "200": {
+            "description": "Workflow task detail including the resolved form schema.",
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/WorkflowV1MissingApiError"
+                  "$ref": "#/components/schemas/WorkflowTaskDetailResponseV1"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Authentication required.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/WorkflowTasksApiErrorV1"
                 }
               }
             }
           },
           "404": {
-            "description": "No route handler exists for this inventory-only /api/v1/workflows path.",
+            "description": "Task not found (or workflow tasks unavailable on this build).",
             "content": {
-              "text/html": {
+              "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/WorkflowV1MissingRouteResponse"
+                  "$ref": "#/components/schemas/WorkflowTasksApiErrorV1"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Unexpected failure resolving the task.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/WorkflowTasksApiErrorV1"
                 }
               }
             }
@@ -75879,6 +77356,1253 @@
               "text/html": {
                 "schema": {
                   "$ref": "#/components/schemas/WorkflowV1MissingRouteResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/workflows/tasks/{id}/claim": {
+      "post": {
+        "summary": "Claim workflow task",
+        "description": "Claims a pending task for the caller. No request body. EE-only — on the Community build this returns 404.",
+        "tags": [
+          "Workflow Tasks v1"
+        ],
+        "security": [
+          {
+            "ApiKeyAuth": []
+          }
+        ],
+        "extensions": {
+          "x-tenant-scoped": true,
+          "x-auth-mechanism": "NextAuth session, falling back to x-api-key (resolveWorkflowTaskAuthContext)",
+          "x-edition-behavior": "EE-only feature; CE returns an empty page (list) or 404 (detail/actions)."
+        },
+        "x-alga-products": [
+          "psa"
+        ],
+        "parameters": [
+          {
+            "schema": {
+              "type": "string",
+              "description": "Workflow task identifier (taskId)."
+            },
+            "required": true,
+            "description": "Workflow task identifier (taskId).",
+            "name": "id",
+            "in": "path"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Task claimed.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/WorkflowTaskActionResponseV1"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Authentication required.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/WorkflowTasksApiErrorV1"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Task not found (or workflow tasks unavailable on this build).",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/WorkflowTasksApiErrorV1"
+                }
+              }
+            }
+          },
+          "409": {
+            "description": "Task already claimed by another user or not in a claimable state.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/WorkflowTasksApiErrorV1"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Unexpected failure claiming the task.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/WorkflowTasksApiErrorV1"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/workflows/tasks/{id}/unclaim": {
+      "post": {
+        "summary": "Unclaim workflow task",
+        "description": "Releases a task the caller has claimed, returning it to the pending pool. No request body. EE-only — on the Community build this returns 404.",
+        "tags": [
+          "Workflow Tasks v1"
+        ],
+        "security": [
+          {
+            "ApiKeyAuth": []
+          }
+        ],
+        "extensions": {
+          "x-tenant-scoped": true,
+          "x-auth-mechanism": "NextAuth session, falling back to x-api-key (resolveWorkflowTaskAuthContext)",
+          "x-edition-behavior": "EE-only feature; CE returns an empty page (list) or 404 (detail/actions)."
+        },
+        "x-alga-products": [
+          "psa"
+        ],
+        "parameters": [
+          {
+            "schema": {
+              "type": "string",
+              "description": "Workflow task identifier (taskId)."
+            },
+            "required": true,
+            "description": "Workflow task identifier (taskId).",
+            "name": "id",
+            "in": "path"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Task released.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/WorkflowTaskActionResponseV1"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Authentication required.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/WorkflowTasksApiErrorV1"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Task not found (or workflow tasks unavailable on this build).",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/WorkflowTasksApiErrorV1"
+                }
+              }
+            }
+          },
+          "409": {
+            "description": "Task is not claimed by the caller.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/WorkflowTasksApiErrorV1"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Unexpected failure releasing the task.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/WorkflowTasksApiErrorV1"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/workflows/tasks/{id}/complete": {
+      "post": {
+        "summary": "Complete workflow task",
+        "description": "Submits the task's form payload and completes it. The form data is validated server-side against the task's JSON Schema; validation failures return 400 with the schema errors in `error.details`. EE-only — on the Community build this returns 404.",
+        "tags": [
+          "Workflow Tasks v1"
+        ],
+        "security": [
+          {
+            "ApiKeyAuth": []
+          }
+        ],
+        "extensions": {
+          "x-tenant-scoped": true,
+          "x-auth-mechanism": "NextAuth session, falling back to x-api-key (resolveWorkflowTaskAuthContext)",
+          "x-edition-behavior": "EE-only feature; CE returns an empty page (list) or 404 (detail/actions)."
+        },
+        "x-alga-products": [
+          "psa"
+        ],
+        "parameters": [
+          {
+            "schema": {
+              "type": "string",
+              "description": "Workflow task identifier (taskId)."
+            },
+            "required": true,
+            "description": "Workflow task identifier (taskId).",
+            "name": "id",
+            "in": "path"
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/CompleteWorkflowTaskBodyV1"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Task completed.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/WorkflowTaskActionResponseV1"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Form validation failed; schema errors are returned in `error.details`.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/WorkflowTasksApiErrorV1"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Authentication required.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/WorkflowTasksApiErrorV1"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Task not found (or workflow tasks unavailable on this build).",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/WorkflowTasksApiErrorV1"
+                }
+              }
+            }
+          },
+          "409": {
+            "description": "Task is not in a completable state for the caller.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/WorkflowTasksApiErrorV1"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Unexpected failure completing the task.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/WorkflowTasksApiErrorV1"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/activities": {
+      "get": {
+        "summary": "List user activities",
+        "description": "Returns the authenticated caller's unified activity list — a fan-out across tickets, project tasks, schedule entries, ad-hoc items, workflow tasks, time entries and notifications. Filter by activity type(s), open/closed status, priority, due-date window, free-text search and a date window; sort via `sortBy`/`sortDirection`. By default the result is paginated (ActivityListResponseV1). When `groupBy` is supplied the result is instead grouped server-side into ordered, counted buckets (ActivityGroupedResponseV1) and `page`/`pageSize` are ignored.",
+        "tags": [
+          "Activities v1"
+        ],
+        "security": [
+          {
+            "ApiKeyAuth": []
+          }
+        ],
+        "extensions": {
+          "x-tenant-scoped": true,
+          "x-auth-mechanism": "NextAuth session, falling back to x-api-key (resolveActivityAuthContext)",
+          "x-response-when-grouped": "#/components/schemas/ActivityGroupedResponseV1"
+        },
+        "x-alga-products": [
+          "psa"
+        ],
+        "parameters": [
+          {
+            "schema": {
+              "type": "string",
+              "description": "Comma-separated ActivityType values (e.g. \"ticket,schedule\"). Omit for all types."
+            },
+            "required": false,
+            "description": "Comma-separated ActivityType values (e.g. \"ticket,schedule\"). Omit for all types.",
+            "name": "type",
+            "in": "query"
+          },
+          {
+            "schema": {
+              "type": "string",
+              "enum": [
+                "open",
+                "closed",
+                "all"
+              ],
+              "description": "Open/closed filter. `open`→active only, `closed`→closed, `all`→no filter (default)."
+            },
+            "required": false,
+            "description": "Open/closed filter. `open`→active only, `closed`→closed, `all`→no filter (default).",
+            "name": "status",
+            "in": "query"
+          },
+          {
+            "schema": {
+              "type": "string",
+              "description": "Free-text search across activity titles/descriptions."
+            },
+            "required": false,
+            "description": "Free-text search across activity titles/descriptions.",
+            "name": "search",
+            "in": "query"
+          },
+          {
+            "schema": {
+              "type": "string",
+              "format": "date-time",
+              "description": "ISO 8601 lower bound of the schedule/time-entry/notification window."
+            },
+            "required": false,
+            "description": "ISO 8601 lower bound of the schedule/time-entry/notification window.",
+            "name": "dateStart",
+            "in": "query"
+          },
+          {
+            "schema": {
+              "type": "string",
+              "format": "date-time",
+              "description": "ISO 8601 upper bound of the window."
+            },
+            "required": false,
+            "description": "ISO 8601 upper bound of the window.",
+            "name": "dateEnd",
+            "in": "query"
+          },
+          {
+            "schema": {
+              "type": "string",
+              "description": "Comma-separated normalized ActivityPriority buckets (e.g. \"high,medium\"). Lossy for custom schemes; prefer `priorityIds`."
+            },
+            "required": false,
+            "description": "Comma-separated normalized ActivityPriority buckets (e.g. \"high,medium\"). Lossy for custom schemes; prefer `priorityIds`.",
+            "name": "priority",
+            "in": "query"
+          },
+          {
+            "schema": {
+              "type": "string",
+              "description": "Comma-separated exact priority IDs (the tenant's real per-type priorities). Applies to ticket/project-task activities."
+            },
+            "required": false,
+            "description": "Comma-separated exact priority IDs (the tenant's real per-type priorities). Applies to ticket/project-task activities.",
+            "name": "priorityIds",
+            "in": "query"
+          },
+          {
+            "schema": {
+              "type": "string",
+              "format": "date-time",
+              "description": "ISO 8601 lower bound of the due-date filter (independent of the schedule window)."
+            },
+            "required": false,
+            "description": "ISO 8601 lower bound of the due-date filter (independent of the schedule window).",
+            "name": "dueDateStart",
+            "in": "query"
+          },
+          {
+            "schema": {
+              "type": "string",
+              "format": "date-time",
+              "description": "ISO 8601 upper bound of the due-date filter."
+            },
+            "required": false,
+            "description": "ISO 8601 upper bound of the due-date filter.",
+            "name": "dueDateEnd",
+            "in": "query"
+          },
+          {
+            "schema": {
+              "type": "string",
+              "format": "date-time",
+              "description": "ISO 8601 lower bound of the created-date (\"date entered\") filter. Applies to every activity type."
+            },
+            "required": false,
+            "description": "ISO 8601 lower bound of the created-date (\"date entered\") filter. Applies to every activity type.",
+            "name": "createdAtStart",
+            "in": "query"
+          },
+          {
+            "schema": {
+              "type": "string",
+              "format": "date-time",
+              "description": "ISO 8601 upper bound of the created-date (\"date entered\") filter."
+            },
+            "required": false,
+            "description": "ISO 8601 upper bound of the created-date (\"date entered\") filter.",
+            "name": "createdAtEnd",
+            "in": "query"
+          },
+          {
+            "schema": {
+              "type": "string",
+              "enum": [
+                "type",
+                "title",
+                "status",
+                "priority",
+                "dueDate"
+              ],
+              "description": "Sort column. Omit for the default sort (priority high→low, then due date ascending)."
+            },
+            "required": false,
+            "description": "Sort column. Omit for the default sort (priority high→low, then due date ascending).",
+            "name": "sortBy",
+            "in": "query"
+          },
+          {
+            "schema": {
+              "type": "string",
+              "enum": [
+                "asc",
+                "desc"
+              ],
+              "description": "Sort direction for `sortBy` (default asc). Ignored when `sortBy` is omitted."
+            },
+            "required": false,
+            "description": "Sort direction for `sortBy` (default asc). Ignored when `sortBy` is omitted.",
+            "name": "sortDirection",
+            "in": "query"
+          },
+          {
+            "schema": {
+              "type": "string",
+              "enum": [
+                "type",
+                "priority",
+                "status",
+                "dueDate"
+              ],
+              "description": "When set, the response is grouped by this dimension (ActivityGroupedResponseV1) instead of the paginated list; `page`/`pageSize` are ignored. `priority` groups by the real per-tenant priority name (not the normalized bucket), so it is only meaningful when scoped to a single prioritized type."
+            },
+            "required": false,
+            "description": "When set, the response is grouped by this dimension (ActivityGroupedResponseV1) instead of the paginated list; `page`/`pageSize` are ignored. `priority` groups by the real per-tenant priority name (not the normalized bucket), so it is only meaningful when scoped to a single prioritized type.",
+            "name": "groupBy",
+            "in": "query"
+          },
+          {
+            "schema": {
+              "type": "integer",
+              "minimum": 1,
+              "description": "1-based page number (default 1). Ignored when `groupBy` is set."
+            },
+            "required": false,
+            "description": "1-based page number (default 1). Ignored when `groupBy` is set.",
+            "name": "page",
+            "in": "query"
+          },
+          {
+            "schema": {
+              "type": "integer",
+              "minimum": 1,
+              "maximum": 100,
+              "description": "Items per page, max 100 (default 25). Ignored when `groupBy` is set."
+            },
+            "required": false,
+            "description": "Items per page, max 100 (default 25). Ignored when `groupBy` is set.",
+            "name": "pageSize",
+            "in": "query"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Paginated activity list, or grouped buckets when `groupBy` is set.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ActivityListResponseV1"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Invalid query parameters.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ActivitiesApiErrorV1"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Authentication required (no session and no/invalid x-api-key).",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ActivitiesApiErrorV1"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Permission denied for one of the underlying activity sources.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ActivitiesApiErrorV1"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Unexpected failure resolving activities.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ActivitiesApiErrorV1"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/activities/ad-hoc": {
+      "post": {
+        "summary": "Create ad-hoc activity",
+        "description": "Creates a personal, self-assigned ad-hoc to-do rendered as a schedule activity. Times are optional; when both are supplied the end must be after the start. Gated by `user_schedule:read`.",
+        "tags": [
+          "Activities v1"
+        ],
+        "security": [
+          {
+            "ApiKeyAuth": []
+          }
+        ],
+        "extensions": {
+          "x-tenant-scoped": true,
+          "x-auth-mechanism": "NextAuth session, falling back to x-api-key (resolveActivityAuthContext)"
+        },
+        "x-alga-products": [
+          "psa"
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/CreateAdHocActivityBodyV1"
+              }
+            }
+          }
+        },
+        "responses": {
+          "201": {
+            "description": "Ad-hoc activity created.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/AdHocActivityResponseV1"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Invalid request body (e.g. missing title or end before start).",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ActivitiesApiErrorV1"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Authentication required.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ActivitiesApiErrorV1"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Permission denied (user_schedule:read).",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ActivitiesApiErrorV1"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Unexpected failure creating the ad-hoc activity.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ActivitiesApiErrorV1"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/activities/ad-hoc/{id}": {
+      "patch": {
+        "summary": "Update ad-hoc activity",
+        "description": "Updates an ad-hoc item's title, notes or optional times. Omitted fields are left unchanged; `notes: null` clears the field. Requires the caller to be an assignee, or hold `user_schedule:update` / `user_schedule:read_all`.",
+        "tags": [
+          "Activities v1"
+        ],
+        "security": [
+          {
+            "ApiKeyAuth": []
+          }
+        ],
+        "extensions": {
+          "x-tenant-scoped": true,
+          "x-auth-mechanism": "NextAuth session, falling back to x-api-key (resolveActivityAuthContext)"
+        },
+        "x-alga-products": [
+          "psa"
+        ],
+        "parameters": [
+          {
+            "schema": {
+              "type": "string",
+              "description": "Ad-hoc activity identifier (the backing schedule entry id)."
+            },
+            "required": true,
+            "description": "Ad-hoc activity identifier (the backing schedule entry id).",
+            "name": "id",
+            "in": "path"
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/UpdateAdHocActivityBodyV1"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Updated ad-hoc activity.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/AdHocActivityResponseV1"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Invalid request body (e.g. end before start).",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ActivitiesApiErrorV1"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Authentication required.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ActivitiesApiErrorV1"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Permission denied.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ActivitiesApiErrorV1"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Ad-hoc activity not found.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ActivitiesApiErrorV1"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Unexpected failure updating the ad-hoc activity.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ActivitiesApiErrorV1"
+                }
+              }
+            }
+          }
+        }
+      },
+      "delete": {
+        "summary": "Delete ad-hoc activity",
+        "description": "Permanently deletes an ad-hoc item. Requires the caller to be an assignee, or hold `user_schedule:update` / `user_schedule:read_all`.",
+        "tags": [
+          "Activities v1"
+        ],
+        "security": [
+          {
+            "ApiKeyAuth": []
+          }
+        ],
+        "extensions": {
+          "x-tenant-scoped": true,
+          "x-auth-mechanism": "NextAuth session, falling back to x-api-key (resolveActivityAuthContext)"
+        },
+        "x-alga-products": [
+          "psa"
+        ],
+        "parameters": [
+          {
+            "schema": {
+              "type": "string",
+              "description": "Ad-hoc activity identifier (the backing schedule entry id)."
+            },
+            "required": true,
+            "description": "Ad-hoc activity identifier (the backing schedule entry id).",
+            "name": "id",
+            "in": "path"
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "Ad-hoc activity deleted; no content."
+          },
+          "401": {
+            "description": "Authentication required.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ActivitiesApiErrorV1"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Permission denied.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ActivitiesApiErrorV1"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Ad-hoc activity not found.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ActivitiesApiErrorV1"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Unexpected failure deleting the ad-hoc activity.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ActivitiesApiErrorV1"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/activities/ad-hoc/{id}/done": {
+      "post": {
+        "summary": "Toggle ad-hoc activity done",
+        "description": "Marks an ad-hoc item done/undone. `done: true` sets status to closed; `done: false` reopens it (status scheduled). Requires the caller to be an assignee, or hold `user_schedule:update` / `user_schedule:read_all`.",
+        "tags": [
+          "Activities v1"
+        ],
+        "security": [
+          {
+            "ApiKeyAuth": []
+          }
+        ],
+        "extensions": {
+          "x-tenant-scoped": true,
+          "x-auth-mechanism": "NextAuth session, falling back to x-api-key (resolveActivityAuthContext)"
+        },
+        "x-alga-products": [
+          "psa"
+        ],
+        "parameters": [
+          {
+            "schema": {
+              "type": "string",
+              "description": "Ad-hoc activity identifier (the backing schedule entry id)."
+            },
+            "required": true,
+            "description": "Ad-hoc activity identifier (the backing schedule entry id).",
+            "name": "id",
+            "in": "path"
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/SetAdHocActivityDoneBodyV1"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Updated ad-hoc activity.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/AdHocActivityResponseV1"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Invalid request body (e.g. missing `done`).",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ActivitiesApiErrorV1"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Authentication required.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ActivitiesApiErrorV1"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Permission denied.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ActivitiesApiErrorV1"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Ad-hoc activity not found.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ActivitiesApiErrorV1"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Unexpected failure updating the ad-hoc activity.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ActivitiesApiErrorV1"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/activities/groups": {
+      "get": {
+        "summary": "List custom activity groups",
+        "description": "Returns the caller's saved custom activity groups (created and ordered in the web app), each with its ordered item references. Read-only: clients bucket the unified activity list into these groups for a \"My groups\" view. Pass `targetUserId` to read another user's groups (requires `user_schedule:update` / `user_schedule:read_all`). Membership and ordering are changed via the `/groups/items` endpoints.",
+        "tags": [
+          "Activities v1"
+        ],
+        "security": [
+          {
+            "ApiKeyAuth": []
+          }
+        ],
+        "extensions": {
+          "x-tenant-scoped": true,
+          "x-auth-mechanism": "NextAuth session, falling back to x-api-key (resolveActivityAuthContext)"
+        },
+        "x-alga-products": [
+          "psa"
+        ],
+        "parameters": [
+          {
+            "schema": {
+              "type": "string",
+              "description": "Another internal user whose groups to read (requires elevated schedule permission). Omit for self."
+            },
+            "required": false,
+            "description": "Another internal user whose groups to read (requires elevated schedule permission). Omit for self.",
+            "name": "targetUserId",
+            "in": "query"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "The caller's custom activity groups.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/CustomActivityGroupsResponseV1"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Authentication required.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ActivitiesApiErrorV1"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Permission denied (reading another user's groups).",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ActivitiesApiErrorV1"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Unexpected failure resolving groups.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ActivitiesApiErrorV1"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/activities/groups/items": {
+      "post": {
+        "summary": "Move an activity into a group",
+        "description": "Moves an activity into one of the caller's custom groups at the given position (`sortOrder`), removing it from any other group first so an activity belongs to at most one group. Rows at/after the index are shifted to keep ordering dense. Scoped to the caller's own groups; gated by `user_schedule:read`.",
+        "tags": [
+          "Activities v1"
+        ],
+        "security": [
+          {
+            "ApiKeyAuth": []
+          }
+        ],
+        "extensions": {
+          "x-tenant-scoped": true,
+          "x-auth-mechanism": "NextAuth session, falling back to x-api-key (resolveActivityAuthContext)"
+        },
+        "x-alga-products": [
+          "psa"
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/MoveActivityToGroupBodyV1"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Activity moved."
+          },
+          "400": {
+            "description": "Invalid request body.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ActivitiesApiErrorV1"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Authentication required.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ActivitiesApiErrorV1"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Permission denied (user_schedule:read).",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ActivitiesApiErrorV1"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Target group not found.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ActivitiesApiErrorV1"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Unexpected failure moving the activity.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ActivitiesApiErrorV1"
+                }
+              }
+            }
+          }
+        }
+      },
+      "delete": {
+        "summary": "Remove an activity from its group",
+        "description": "Removes an activity from all of the caller's custom groups (makes it \"ungrouped\"). No-op when the activity is not in any group. Scoped to the caller's own groups; gated by `user_schedule:read`.",
+        "tags": [
+          "Activities v1"
+        ],
+        "security": [
+          {
+            "ApiKeyAuth": []
+          }
+        ],
+        "extensions": {
+          "x-tenant-scoped": true,
+          "x-auth-mechanism": "NextAuth session, falling back to x-api-key (resolveActivityAuthContext)"
+        },
+        "x-alga-products": [
+          "psa"
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/RemoveActivityFromGroupBodyV1"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Activity removed from its group."
+          },
+          "400": {
+            "description": "Invalid request body.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ActivitiesApiErrorV1"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Authentication required.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ActivitiesApiErrorV1"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Permission denied (user_schedule:read).",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ActivitiesApiErrorV1"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Unexpected failure removing the activity.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ActivitiesApiErrorV1"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/activities/groups/{groupId}/items": {
+      "patch": {
+        "summary": "Reorder activities within a group",
+        "description": "Persists the full ordered membership of a group after a drag-to-reorder. Pass every item as it should appear; each row's `sortOrder` is set to its position. Scoped to the caller's own groups; gated by `user_schedule:read`.",
+        "tags": [
+          "Activities v1"
+        ],
+        "security": [
+          {
+            "ApiKeyAuth": []
+          }
+        ],
+        "extensions": {
+          "x-tenant-scoped": true,
+          "x-auth-mechanism": "NextAuth session, falling back to x-api-key (resolveActivityAuthContext)"
+        },
+        "x-alga-products": [
+          "psa"
+        ],
+        "parameters": [
+          {
+            "schema": {
+              "type": "string",
+              "description": "Custom activity group identifier."
+            },
+            "required": true,
+            "description": "Custom activity group identifier.",
+            "name": "groupId",
+            "in": "path"
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/ReorderActivitiesInGroupBodyV1"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Group order persisted."
+          },
+          "400": {
+            "description": "Invalid request body.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ActivitiesApiErrorV1"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Authentication required.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ActivitiesApiErrorV1"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Permission denied (user_schedule:read).",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ActivitiesApiErrorV1"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Group not found.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ActivitiesApiErrorV1"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Unexpected failure reordering the group.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ActivitiesApiErrorV1"
                 }
               }
             }
@@ -96469,6 +99193,54 @@
         }
       }
     },
+    "/api/auth/captcha-config": {
+      "get": {
+        "summary": "GET auth",
+        "description": "This operation was generated automatically from the route inventory. Replace with canonical OpenAPI metadata.",
+        "tags": [
+          "auth"
+        ],
+        "extensions": {
+          "x-generated-from": "docs/openapi/route-inventory.json",
+          "x-placeholder": true
+        },
+        "x-alga-products": [
+          "psa"
+        ],
+        "responses": {
+          "200": {
+            "description": "Placeholder success response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PlaceholderObject"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Authentication required",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     "/api/auth/e2e/google/authorize": {
       "get": {
         "summary": "GET auth",
@@ -97203,6 +99975,306 @@
         ],
         "responses": {
           "200": {
+            "description": "Placeholder success response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PlaceholderObject"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Authentication required",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/billing/complete-reactivation": {
+      "post": {
+        "summary": "POST billing",
+        "description": "This operation was generated automatically from the route inventory. Replace with canonical OpenAPI metadata.",
+        "tags": [
+          "billing"
+        ],
+        "extensions": {
+          "x-generated-from": "docs/openapi/route-inventory.json",
+          "x-placeholder": true
+        },
+        "x-alga-products": [
+          "psa"
+        ],
+        "requestBody": {
+          "description": "Placeholder request body",
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/PlaceholderObject"
+              },
+              "description": "Placeholder request body"
+            }
+          }
+        },
+        "responses": {
+          "201": {
+            "description": "Placeholder success response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PlaceholderObject"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Authentication required",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/billing/reactivation-password-reset": {
+      "post": {
+        "summary": "POST billing",
+        "description": "This operation was generated automatically from the route inventory. Replace with canonical OpenAPI metadata.",
+        "tags": [
+          "billing"
+        ],
+        "extensions": {
+          "x-generated-from": "docs/openapi/route-inventory.json",
+          "x-placeholder": true
+        },
+        "x-alga-products": [
+          "psa"
+        ],
+        "requestBody": {
+          "description": "Placeholder request body",
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/PlaceholderObject"
+              },
+              "description": "Placeholder request body"
+            }
+          }
+        },
+        "responses": {
+          "201": {
+            "description": "Placeholder success response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PlaceholderObject"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Authentication required",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/billing/reactivation-token": {
+      "post": {
+        "summary": "POST billing",
+        "description": "This operation was generated automatically from the route inventory. Replace with canonical OpenAPI metadata.",
+        "tags": [
+          "billing"
+        ],
+        "extensions": {
+          "x-generated-from": "docs/openapi/route-inventory.json",
+          "x-placeholder": true
+        },
+        "x-alga-products": [
+          "psa"
+        ],
+        "requestBody": {
+          "description": "Placeholder request body",
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/PlaceholderObject"
+              },
+              "description": "Placeholder request body"
+            }
+          }
+        },
+        "responses": {
+          "201": {
+            "description": "Placeholder success response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PlaceholderObject"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Authentication required",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/billing/reactivation-token/session": {
+      "post": {
+        "summary": "POST billing",
+        "description": "This operation was generated automatically from the route inventory. Replace with canonical OpenAPI metadata.",
+        "tags": [
+          "billing"
+        ],
+        "extensions": {
+          "x-generated-from": "docs/openapi/route-inventory.json",
+          "x-placeholder": true
+        },
+        "x-alga-products": [
+          "psa"
+        ],
+        "requestBody": {
+          "description": "Placeholder request body",
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/PlaceholderObject"
+              },
+              "description": "Placeholder request body"
+            }
+          }
+        },
+        "responses": {
+          "201": {
+            "description": "Placeholder success response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PlaceholderObject"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Authentication required",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/billing/request-reactivation": {
+      "post": {
+        "summary": "POST billing",
+        "description": "This operation was generated automatically from the route inventory. Replace with canonical OpenAPI metadata.",
+        "tags": [
+          "billing"
+        ],
+        "extensions": {
+          "x-generated-from": "docs/openapi/route-inventory.json",
+          "x-placeholder": true
+        },
+        "x-alga-products": [
+          "psa"
+        ],
+        "requestBody": {
+          "description": "Placeholder request body",
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/PlaceholderObject"
+              },
+              "description": "Placeholder request body"
+            }
+          }
+        },
+        "responses": {
+          "201": {
             "description": "Placeholder success response",
             "content": {
               "application/json": {
@@ -100613,6 +103685,100 @@
         }
       }
     },
+    "/api/integrations/hudu": {
+      "get": {
+        "summary": "GET integrations",
+        "description": "This operation was generated automatically from the route inventory. Replace with canonical OpenAPI metadata.",
+        "tags": [
+          "integrations"
+        ],
+        "extensions": {
+          "x-generated-from": "docs/openapi/route-inventory.json",
+          "x-placeholder": true
+        },
+        "x-alga-products": [
+          "psa"
+        ],
+        "responses": {
+          "200": {
+            "description": "Placeholder success response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PlaceholderObject"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Authentication required",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        }
+      },
+      "options": {
+        "summary": "OPTIONS integrations",
+        "description": "This operation was generated automatically from the route inventory. Replace with canonical OpenAPI metadata.",
+        "tags": [
+          "integrations"
+        ],
+        "extensions": {
+          "x-generated-from": "docs/openapi/route-inventory.json",
+          "x-placeholder": true
+        },
+        "x-alga-products": [
+          "psa"
+        ],
+        "responses": {
+          "200": {
+            "description": "Placeholder success response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PlaceholderObject"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Authentication required",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     "/api/integrations/ninjaone/callback": {
       "get": {
         "summary": "GET integrations",
@@ -101183,6 +104349,338 @@
         "description": "This operation was generated automatically from the route inventory. Replace with canonical OpenAPI metadata.",
         "tags": [
           "internal"
+        ],
+        "extensions": {
+          "x-generated-from": "docs/openapi/route-inventory.json",
+          "x-placeholder": true
+        },
+        "x-alga-products": [
+          "psa"
+        ],
+        "requestBody": {
+          "description": "Placeholder request body",
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/PlaceholderObject"
+              },
+              "description": "Placeholder request body"
+            }
+          }
+        },
+        "responses": {
+          "201": {
+            "description": "Placeholder success response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PlaceholderObject"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Authentication required",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/mcp": {
+      "get": {
+        "summary": "GET mcp",
+        "description": "This operation was generated automatically from the route inventory. Replace with canonical OpenAPI metadata.",
+        "tags": [
+          "mcp"
+        ],
+        "extensions": {
+          "x-generated-from": "docs/openapi/route-inventory.json",
+          "x-placeholder": true
+        },
+        "x-alga-products": [
+          "psa"
+        ],
+        "responses": {
+          "200": {
+            "description": "Placeholder success response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PlaceholderObject"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Authentication required",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        }
+      },
+      "post": {
+        "summary": "POST mcp",
+        "description": "This operation was generated automatically from the route inventory. Replace with canonical OpenAPI metadata.",
+        "tags": [
+          "mcp"
+        ],
+        "extensions": {
+          "x-generated-from": "docs/openapi/route-inventory.json",
+          "x-placeholder": true
+        },
+        "x-alga-products": [
+          "psa"
+        ],
+        "requestBody": {
+          "description": "Placeholder request body",
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/PlaceholderObject"
+              },
+              "description": "Placeholder request body"
+            }
+          }
+        },
+        "responses": {
+          "201": {
+            "description": "Placeholder success response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PlaceholderObject"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Authentication required",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/mcp/oauth/authorize": {
+      "get": {
+        "summary": "GET mcp",
+        "description": "This operation was generated automatically from the route inventory. Replace with canonical OpenAPI metadata.",
+        "tags": [
+          "mcp"
+        ],
+        "extensions": {
+          "x-generated-from": "docs/openapi/route-inventory.json",
+          "x-placeholder": true
+        },
+        "x-alga-products": [
+          "psa"
+        ],
+        "responses": {
+          "200": {
+            "description": "Placeholder success response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PlaceholderObject"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Authentication required",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        }
+      },
+      "post": {
+        "summary": "POST mcp",
+        "description": "This operation was generated automatically from the route inventory. Replace with canonical OpenAPI metadata.",
+        "tags": [
+          "mcp"
+        ],
+        "extensions": {
+          "x-generated-from": "docs/openapi/route-inventory.json",
+          "x-placeholder": true
+        },
+        "x-alga-products": [
+          "psa"
+        ],
+        "requestBody": {
+          "description": "Placeholder request body",
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/PlaceholderObject"
+              },
+              "description": "Placeholder request body"
+            }
+          }
+        },
+        "responses": {
+          "201": {
+            "description": "Placeholder success response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PlaceholderObject"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Authentication required",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/mcp/oauth/revoke": {
+      "post": {
+        "summary": "POST mcp",
+        "description": "This operation was generated automatically from the route inventory. Replace with canonical OpenAPI metadata.",
+        "tags": [
+          "mcp"
+        ],
+        "extensions": {
+          "x-generated-from": "docs/openapi/route-inventory.json",
+          "x-placeholder": true
+        },
+        "x-alga-products": [
+          "psa"
+        ],
+        "requestBody": {
+          "description": "Placeholder request body",
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/PlaceholderObject"
+              },
+              "description": "Placeholder request body"
+            }
+          }
+        },
+        "responses": {
+          "201": {
+            "description": "Placeholder success response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PlaceholderObject"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Authentication required",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/mcp/oauth/token": {
+      "post": {
+        "summary": "POST mcp",
+        "description": "This operation was generated automatically from the route inventory. Replace with canonical OpenAPI metadata.",
+        "tags": [
+          "mcp"
         ],
         "extensions": {
           "x-generated-from": "docs/openapi/route-inventory.json",
@@ -102900,6 +106398,1059 @@
         },
         "x-alga-products": [
           "psa"
+        ],
+        "responses": {
+          "200": {
+            "description": "Placeholder success response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PlaceholderObject"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Authentication required",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/appliance-installs": {
+      "get": {
+        "summary": "GET v1",
+        "description": "This operation was generated automatically from the route inventory. Replace with canonical OpenAPI metadata.",
+        "tags": [
+          "appliance-installs"
+        ],
+        "extensions": {
+          "x-generated-from": "docs/openapi/route-inventory.json",
+          "x-placeholder": true
+        },
+        "x-alga-products": [
+          "psa"
+        ],
+        "responses": {
+          "200": {
+            "description": "Placeholder success response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PlaceholderObject"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Authentication required",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        }
+      },
+      "options": {
+        "summary": "OPTIONS v1",
+        "description": "This operation was generated automatically from the route inventory. Replace with canonical OpenAPI metadata.",
+        "tags": [
+          "appliance-installs"
+        ],
+        "extensions": {
+          "x-generated-from": "docs/openapi/route-inventory.json",
+          "x-placeholder": true
+        },
+        "x-alga-products": [
+          "psa"
+        ],
+        "responses": {
+          "200": {
+            "description": "Placeholder success response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PlaceholderObject"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Authentication required",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/appliance-installs/access": {
+      "options": {
+        "summary": "OPTIONS v1",
+        "description": "This operation was generated automatically from the route inventory. Replace with canonical OpenAPI metadata.",
+        "tags": [
+          "appliance-installs"
+        ],
+        "extensions": {
+          "x-generated-from": "docs/openapi/route-inventory.json",
+          "x-placeholder": true
+        },
+        "x-alga-products": [
+          "psa"
+        ],
+        "responses": {
+          "200": {
+            "description": "Placeholder success response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PlaceholderObject"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Authentication required",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        }
+      },
+      "post": {
+        "summary": "POST v1",
+        "description": "This operation was generated automatically from the route inventory. Replace with canonical OpenAPI metadata.",
+        "tags": [
+          "appliance-installs"
+        ],
+        "extensions": {
+          "x-generated-from": "docs/openapi/route-inventory.json",
+          "x-placeholder": true
+        },
+        "x-alga-products": [
+          "psa"
+        ],
+        "requestBody": {
+          "description": "Placeholder request body",
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/PlaceholderObject"
+              },
+              "description": "Placeholder request body"
+            }
+          }
+        },
+        "responses": {
+          "201": {
+            "description": "Placeholder success response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PlaceholderObject"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Authentication required",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/appliance-installs/{tenantId}": {
+      "get": {
+        "summary": "GET v1",
+        "description": "This operation was generated automatically from the route inventory. Replace with canonical OpenAPI metadata.",
+        "tags": [
+          "appliance-installs"
+        ],
+        "extensions": {
+          "x-generated-from": "docs/openapi/route-inventory.json",
+          "x-placeholder": true
+        },
+        "x-alga-products": [
+          "psa"
+        ],
+        "responses": {
+          "200": {
+            "description": "Placeholder success response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PlaceholderObject"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Authentication required",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        }
+      },
+      "options": {
+        "summary": "OPTIONS v1",
+        "description": "This operation was generated automatically from the route inventory. Replace with canonical OpenAPI metadata.",
+        "tags": [
+          "appliance-installs"
+        ],
+        "extensions": {
+          "x-generated-from": "docs/openapi/route-inventory.json",
+          "x-placeholder": true
+        },
+        "x-alga-products": [
+          "psa"
+        ],
+        "responses": {
+          "200": {
+            "description": "Placeholder success response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PlaceholderObject"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Authentication required",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/mcp/agents": {
+      "delete": {
+        "summary": "DELETE v1",
+        "description": "This operation was generated automatically from the route inventory. Replace with canonical OpenAPI metadata.",
+        "tags": [
+          "mcp"
+        ],
+        "extensions": {
+          "x-generated-from": "docs/openapi/route-inventory.json",
+          "x-placeholder": true
+        },
+        "x-alga-products": [
+          "psa"
+        ],
+        "responses": {
+          "204": {
+            "description": "Placeholder success response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PlaceholderObject"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Authentication required",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        }
+      },
+      "get": {
+        "summary": "GET v1",
+        "description": "This operation was generated automatically from the route inventory. Replace with canonical OpenAPI metadata.",
+        "tags": [
+          "mcp"
+        ],
+        "extensions": {
+          "x-generated-from": "docs/openapi/route-inventory.json",
+          "x-placeholder": true
+        },
+        "x-alga-products": [
+          "psa"
+        ],
+        "responses": {
+          "200": {
+            "description": "Placeholder success response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PlaceholderObject"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Authentication required",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        }
+      },
+      "patch": {
+        "summary": "PATCH v1",
+        "description": "This operation was generated automatically from the route inventory. Replace with canonical OpenAPI metadata.",
+        "tags": [
+          "mcp"
+        ],
+        "extensions": {
+          "x-generated-from": "docs/openapi/route-inventory.json",
+          "x-placeholder": true
+        },
+        "x-alga-products": [
+          "psa"
+        ],
+        "requestBody": {
+          "description": "Placeholder request body",
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/PlaceholderObject"
+              },
+              "description": "Placeholder request body"
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Placeholder success response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PlaceholderObject"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Authentication required",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        }
+      },
+      "post": {
+        "summary": "POST v1",
+        "description": "This operation was generated automatically from the route inventory. Replace with canonical OpenAPI metadata.",
+        "tags": [
+          "mcp"
+        ],
+        "extensions": {
+          "x-generated-from": "docs/openapi/route-inventory.json",
+          "x-placeholder": true
+        },
+        "x-alga-products": [
+          "psa"
+        ],
+        "requestBody": {
+          "description": "Placeholder request body",
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/PlaceholderObject"
+              },
+              "description": "Placeholder request body"
+            }
+          }
+        },
+        "responses": {
+          "201": {
+            "description": "Placeholder success response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PlaceholderObject"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Authentication required",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/mcp/audit": {
+      "get": {
+        "summary": "GET v1",
+        "description": "This operation was generated automatically from the route inventory. Replace with canonical OpenAPI metadata.",
+        "tags": [
+          "mcp"
+        ],
+        "extensions": {
+          "x-generated-from": "docs/openapi/route-inventory.json",
+          "x-placeholder": true
+        },
+        "x-alga-products": [
+          "psa"
+        ],
+        "responses": {
+          "200": {
+            "description": "Placeholder success response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PlaceholderObject"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Authentication required",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/mcp/connect/callback": {
+      "get": {
+        "summary": "GET v1",
+        "description": "This operation was generated automatically from the route inventory. Replace with canonical OpenAPI metadata.",
+        "tags": [
+          "mcp"
+        ],
+        "extensions": {
+          "x-generated-from": "docs/openapi/route-inventory.json",
+          "x-placeholder": true
+        },
+        "x-alga-products": [
+          "psa"
+        ],
+        "responses": {
+          "200": {
+            "description": "Placeholder success response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PlaceholderObject"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Authentication required",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/mcp/connect/start": {
+      "post": {
+        "summary": "POST v1",
+        "description": "This operation was generated automatically from the route inventory. Replace with canonical OpenAPI metadata.",
+        "tags": [
+          "mcp"
+        ],
+        "extensions": {
+          "x-generated-from": "docs/openapi/route-inventory.json",
+          "x-placeholder": true
+        },
+        "x-alga-products": [
+          "psa"
+        ],
+        "requestBody": {
+          "description": "Placeholder request body",
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/PlaceholderObject"
+              },
+              "description": "Placeholder request body"
+            }
+          }
+        },
+        "responses": {
+          "201": {
+            "description": "Placeholder success response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PlaceholderObject"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Authentication required",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/mcp/connections": {
+      "delete": {
+        "summary": "DELETE v1",
+        "description": "This operation was generated automatically from the route inventory. Replace with canonical OpenAPI metadata.",
+        "tags": [
+          "mcp"
+        ],
+        "extensions": {
+          "x-generated-from": "docs/openapi/route-inventory.json",
+          "x-placeholder": true
+        },
+        "x-alga-products": [
+          "psa"
+        ],
+        "responses": {
+          "204": {
+            "description": "Placeholder success response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PlaceholderObject"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Authentication required",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        }
+      },
+      "get": {
+        "summary": "GET v1",
+        "description": "This operation was generated automatically from the route inventory. Replace with canonical OpenAPI metadata.",
+        "tags": [
+          "mcp"
+        ],
+        "extensions": {
+          "x-generated-from": "docs/openapi/route-inventory.json",
+          "x-placeholder": true
+        },
+        "x-alga-products": [
+          "psa"
+        ],
+        "responses": {
+          "200": {
+            "description": "Placeholder success response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PlaceholderObject"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Authentication required",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/mcp/idp-providers": {
+      "get": {
+        "summary": "GET v1",
+        "description": "This operation was generated automatically from the route inventory. Replace with canonical OpenAPI metadata.",
+        "tags": [
+          "mcp"
+        ],
+        "extensions": {
+          "x-generated-from": "docs/openapi/route-inventory.json",
+          "x-placeholder": true
+        },
+        "x-alga-products": [
+          "psa"
+        ],
+        "responses": {
+          "200": {
+            "description": "Placeholder success response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PlaceholderObject"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Authentication required",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        }
+      },
+      "post": {
+        "summary": "POST v1",
+        "description": "This operation was generated automatically from the route inventory. Replace with canonical OpenAPI metadata.",
+        "tags": [
+          "mcp"
+        ],
+        "extensions": {
+          "x-generated-from": "docs/openapi/route-inventory.json",
+          "x-placeholder": true
+        },
+        "x-alga-products": [
+          "psa"
+        ],
+        "requestBody": {
+          "description": "Placeholder request body",
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/PlaceholderObject"
+              },
+              "description": "Placeholder request body"
+            }
+          }
+        },
+        "responses": {
+          "201": {
+            "description": "Placeholder success response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PlaceholderObject"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Authentication required",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/mcp/idp-suggestions": {
+      "get": {
+        "summary": "GET v1",
+        "description": "This operation was generated automatically from the route inventory. Replace with canonical OpenAPI metadata.",
+        "tags": [
+          "mcp"
+        ],
+        "extensions": {
+          "x-generated-from": "docs/openapi/route-inventory.json",
+          "x-placeholder": true
+        },
+        "x-alga-products": [
+          "psa"
+        ],
+        "responses": {
+          "200": {
+            "description": "Placeholder success response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PlaceholderObject"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Authentication required",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/mcp/platform-providers": {
+      "get": {
+        "summary": "GET v1",
+        "description": "This operation was generated automatically from the route inventory. Replace with canonical OpenAPI metadata.",
+        "tags": [
+          "mcp"
+        ],
+        "extensions": {
+          "x-generated-from": "docs/openapi/route-inventory.json",
+          "x-placeholder": true
+        },
+        "x-alga-products": [
+          "psa"
+        ],
+        "responses": {
+          "200": {
+            "description": "Placeholder success response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PlaceholderObject"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Authentication required",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/mcp/roles": {
+      "get": {
+        "summary": "GET v1",
+        "description": "This operation was generated automatically from the route inventory. Replace with canonical OpenAPI metadata.",
+        "tags": [
+          "mcp"
+        ],
+        "extensions": {
+          "x-generated-from": "docs/openapi/route-inventory.json",
+          "x-placeholder": true
+        },
+        "x-alga-products": [
+          "psa"
+        ],
+        "responses": {
+          "200": {
+            "description": "Placeholder success response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PlaceholderObject"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Authentication required",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/meta/mcp-registry": {
+      "get": {
+        "summary": "GET v1",
+        "description": "This operation was generated automatically from the route inventory. Replace with canonical OpenAPI metadata.",
+        "tags": [
+          "meta"
+        ],
+        "extensions": {
+          "x-generated-from": "docs/openapi/route-inventory.json",
+          "x-placeholder": true
+        },
+        "x-alga-products": [
+          "psa",
+          "algadesk"
         ],
         "responses": {
           "200": {
@@ -107366,6 +111917,218 @@
         "description": "This operation was generated automatically from the route inventory. Replace with canonical OpenAPI metadata.",
         "tags": [
           "tenant-management"
+        ],
+        "extensions": {
+          "x-generated-from": "docs/openapi/route-inventory.json",
+          "x-placeholder": true
+        },
+        "x-alga-products": [
+          "psa"
+        ],
+        "requestBody": {
+          "description": "Placeholder request body",
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/PlaceholderObject"
+              },
+              "description": "Placeholder request body"
+            }
+          }
+        },
+        "responses": {
+          "201": {
+            "description": "Placeholder success response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PlaceholderObject"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Authentication required",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/webhooks/alternative-payments": {
+      "get": {
+        "summary": "GET webhooks",
+        "description": "This operation was generated automatically from the route inventory. Replace with canonical OpenAPI metadata.",
+        "tags": [
+          "webhooks"
+        ],
+        "extensions": {
+          "x-generated-from": "docs/openapi/route-inventory.json",
+          "x-placeholder": true
+        },
+        "x-alga-products": [
+          "psa"
+        ],
+        "responses": {
+          "200": {
+            "description": "Placeholder success response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PlaceholderObject"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Authentication required",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        }
+      },
+      "post": {
+        "summary": "POST webhooks",
+        "description": "This operation was generated automatically from the route inventory. Replace with canonical OpenAPI metadata.",
+        "tags": [
+          "webhooks"
+        ],
+        "extensions": {
+          "x-generated-from": "docs/openapi/route-inventory.json",
+          "x-placeholder": true
+        },
+        "x-alga-products": [
+          "psa"
+        ],
+        "requestBody": {
+          "description": "Placeholder request body",
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/PlaceholderObject"
+              },
+              "description": "Placeholder request body"
+            }
+          }
+        },
+        "responses": {
+          "201": {
+            "description": "Placeholder success response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PlaceholderObject"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Authentication required",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/webhooks/levelio": {
+      "options": {
+        "summary": "OPTIONS webhooks",
+        "description": "This operation was generated automatically from the route inventory. Replace with canonical OpenAPI metadata.",
+        "tags": [
+          "webhooks"
+        ],
+        "extensions": {
+          "x-generated-from": "docs/openapi/route-inventory.json",
+          "x-placeholder": true
+        },
+        "x-alga-products": [
+          "psa"
+        ],
+        "responses": {
+          "200": {
+            "description": "Placeholder success response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PlaceholderObject"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Authentication required",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        }
+      },
+      "post": {
+        "summary": "POST webhooks",
+        "description": "This operation was generated automatically from the route inventory. Replace with canonical OpenAPI metadata.",
+        "tags": [
+          "webhooks"
         ],
         "extensions": {
           "x-generated-from": "docs/openapi/route-inventory.json",

--- a/sdk/docs/openapi/alga-openapi.ce.yaml
+++ b/sdk/docs/openapi/alga-openapi.ce.yaml
@@ -12,6 +12,7 @@ tags:
   - name: AI
   - name: Access Control & Users v1
   - name: Accounting Exports
+  - name: Activities v1
   - name: Admin
   - name: Assets
   - name: Auth
@@ -61,8 +62,10 @@ tags:
   - name: Workflow Definitions
   - name: Workflow Registry
   - name: Workflow Runs
+  - name: Workflow Tasks v1
   - name: Workflows v1
   - name: accounting
+  - name: appliance-installs
   - name: auth
   - name: billing
   - name: calendar
@@ -79,6 +82,8 @@ tags:
   - name: inbound
   - name: integrations
   - name: internal
+  - name: mcp
+  - name: meta
   - name: mobile
   - name: online-meetings
   - name: platform-feature-flags
@@ -642,7 +647,7 @@ components:
           type: string
         order:
           type: string
-          enum: &a32
+          enum: &a33
             - asc
             - desc
         username:
@@ -655,7 +660,7 @@ components:
           type: string
         user_type:
           type: string
-          enum: &a33
+          enum: &a34
             - internal
             - client
             - admin
@@ -668,17 +673,17 @@ components:
           format: uuid
         is_inactive:
           type: string
-          enum: &a34
+          enum: &a35
             - "true"
             - "false"
         include_permissions:
           type: string
-          enum: &a35
+          enum: &a36
             - "true"
             - "false"
         include_teams:
           type: string
-          enum: &a36
+          enum: &a37
             - "true"
             - "false"
         fields:
@@ -694,7 +699,7 @@ components:
             field names.
         user_type:
           type: string
-          enum: &a37
+          enum: &a38
             - internal
             - client
             - admin
@@ -707,7 +712,7 @@ components:
           format: uuid
         include_inactive:
           type: string
-          enum: &a38
+          enum: &a39
             - "true"
             - "false"
         limit:
@@ -742,14 +747,14 @@ components:
           type: string
         is_inactive:
           type: string
-          enum: &a30
+          enum: &a31
             - "true"
             - "false"
         sort:
           type: string
         order:
           type: string
-          enum: &a31
+          enum: &a32
             - asc
             - desc
     AccessRoleListQueryV1:
@@ -763,14 +768,14 @@ components:
           type: string
         order:
           type: string
-          enum: &a23
+          enum: &a24
             - asc
             - desc
         role_name:
           type: string
         has_permissions:
           type: string
-          enum: &a24
+          enum: &a25
             - "true"
             - "false"
         permission_resource:
@@ -779,7 +784,7 @@ components:
           type: string
         is_template:
           type: string
-          enum: &a25
+          enum: &a26
             - "true"
             - "false"
     AccessPermissionListQueryV1:
@@ -793,7 +798,7 @@ components:
           type: string
         order:
           type: string
-          enum: &a22
+          enum: &a23
             - asc
             - desc
         resource:
@@ -811,7 +816,7 @@ components:
           type: string
         order:
           type: string
-          enum: &a26
+          enum: &a27
             - asc
             - desc
         team_name:
@@ -835,14 +840,14 @@ components:
           format: uuid
         has_manager:
           type: string
-          enum: &a27
+          enum: &a28
             - "true"
             - "false"
         sort:
           type: string
         order:
           type: string
-          enum: &a28
+          enum: &a29
             - asc
             - desc
     AccessTeamAnalyticsQueryV1:
@@ -858,7 +863,7 @@ components:
             array.
         granularity:
           type: string
-          enum: &a29
+          enum: &a30
             - daily
             - weekly
             - monthly
@@ -1273,7 +1278,7 @@ components:
           description: Sort column. Defaults to created_at.
         order:
           type: string
-          enum: &a39
+          enum: &a40
             - asc
             - desc
           description: Sort direction. Defaults to desc.
@@ -1303,7 +1308,7 @@ components:
             AssetService.list.
         is_active:
           type: string
-          enum: &a40
+          enum: &a41
             - "true"
             - "false"
           description: Accepted by validation, but not currently applied by
@@ -1336,21 +1341,21 @@ components:
           description: Partial client name match; joins clients on client_id and tenant.
         has_warranty:
           type: string
-          enum: &a41
+          enum: &a42
             - "true"
             - "false"
           description: true requires warranty_end_date to be non-null; false requires it
             to be null.
         warranty_expired:
           type: string
-          enum: &a42
+          enum: &a43
             - "true"
             - "false"
           description: true filters warranty_end_date before now; false filters future
             warranty dates or no warranty.
         maintenance_due:
           type: string
-          enum: &a43
+          enum: &a44
             - "true"
             - "false"
           description: Accepted by validation, but not currently applied by
@@ -1376,7 +1381,7 @@ components:
       properties:
         format:
           type: string
-          enum: &a44
+          enum: &a45
             - csv
             - json
           description: Export format. csv (default) returns text/csv as an attachment;
@@ -2662,7 +2667,7 @@ components:
           type: array
           items:
             type: string
-            enum: &a45
+            enum: &a46
               - asset_tag
               - name
               - serial_number
@@ -2689,7 +2694,7 @@ components:
           description: Optional client UUID filters.
         include_extension_data:
           type: string
-          enum: &a46
+          enum: &a47
             - "true"
             - "false"
           description: When true, the service fetches asset-type-specific extension data
@@ -3165,7 +3170,7 @@ components:
       properties:
         type:
           type: string
-          enum: &a47
+          enum: &a48
             - splashtop
             - teamviewer
             - vnc
@@ -3190,7 +3195,7 @@ components:
           type: string
         include_uninstalled:
           type: string
-          enum: &a48
+          enum: &a49
             - "true"
             - "false"
     AssetSoftwareResponse:
@@ -3287,7 +3292,7 @@ components:
             orders executions by started_at desc.
         order:
           type: string
-          enum: &a49
+          enum: &a50
             - asc
             - desc
           description: Accepted by shared list query validation.
@@ -3312,7 +3317,7 @@ components:
           description: Accepted by shared filter validation.
         is_active:
           type: string
-          enum: &a50
+          enum: &a51
             - "true"
             - "false"
           description: Accepted by shared filter validation and transformed to boolean.
@@ -3349,7 +3354,7 @@ components:
           description: Maximum execution duration in milliseconds.
         has_errors:
           type: string
-          enum: &a51
+          enum: &a52
             - "true"
             - "false"
           description: Filter by whether the execution has errors; transformed to boolean
@@ -3380,7 +3385,7 @@ components:
             rules by created_at desc.
         order:
           type: string
-          enum: &a52
+          enum: &a53
             - asc
             - desc
           description: Accepted by shared list query validation.
@@ -3405,7 +3410,7 @@ components:
           description: Accepted by shared filter validation.
         is_active:
           type: string
-          enum: &a53
+          enum: &a54
             - "true"
             - "false"
           description: Accepted by shared filter validation and transformed to boolean.
@@ -3471,7 +3476,7 @@ components:
             templates by created_at desc.
         order:
           type: string
-          enum: &a54
+          enum: &a55
             - asc
             - desc
           description: Accepted by shared list query validation.
@@ -3496,7 +3501,7 @@ components:
           description: Accepted by shared filter validation.
         is_active:
           type: string
-          enum: &a55
+          enum: &a56
             - "true"
             - "false"
           description: Accepted by shared filter validation and transformed to boolean.
@@ -3530,7 +3535,7 @@ components:
           description: Optional upper bound for performance window.
         group_by:
           type: string
-          enum: &a56
+          enum: &a57
             - hour
             - day
             - week
@@ -4852,7 +4857,7 @@ components:
           type: string
         order:
           type: string
-          enum: &a57
+          enum: &a58
             - asc
             - desc
         search:
@@ -4875,12 +4880,12 @@ components:
           type: string
         client_type:
           type: string
-          enum: &a58
+          enum: &a59
             - company
             - individual
         billing_cycle:
           type: string
-          enum: &a59
+          enum: &a60
             - weekly
             - bi-weekly
             - monthly
@@ -4889,12 +4894,12 @@ components:
             - annually
         is_inactive:
           type: string
-          enum: &a60
+          enum: &a61
             - "true"
             - "false"
         is_tax_exempt:
           type: string
-          enum: &a61
+          enum: &a62
             - "true"
             - "false"
         account_manager_id:
@@ -4908,7 +4913,7 @@ components:
           type: string
         has_credit_limit:
           type: string
-          enum: &a62
+          enum: &a63
             - "true"
             - "false"
         industry:
@@ -5058,7 +5063,7 @@ components:
           type: string
         order:
           type: string
-          enum: &a63
+          enum: &a64
             - asc
             - desc
         search:
@@ -5088,12 +5093,12 @@ components:
           type: string
         is_inactive:
           type: string
-          enum: &a64
+          enum: &a65
             - "true"
             - "false"
         has_client:
           type: string
-          enum: &a65
+          enum: &a66
             - "true"
             - "false"
         client_name:
@@ -5161,7 +5166,7 @@ components:
           format: uuid
         include_inactive:
           type: string
-          enum: &a66
+          enum: &a67
             - "true"
             - "false"
         limit:
@@ -5173,12 +5178,12 @@ components:
       properties:
         format:
           type: string
-          enum: &a67
+          enum: &a68
             - csv
             - json
         include_inactive:
           type: string
-          enum: &a68
+          enum: &a69
             - "true"
             - "false"
         client_id:
@@ -5198,7 +5203,7 @@ components:
           type: string
         order:
           type: string
-          enum: &a69
+          enum: &a70
             - asc
             - desc
         search:
@@ -5225,17 +5230,17 @@ components:
           type: string
         is_active:
           type: string
-          enum: &a70
+          enum: &a71
             - "true"
             - "false"
         has_custom_rate:
           type: string
-          enum: &a71
+          enum: &a72
             - "true"
             - "false"
         is_contractd:
           type: string
-          enum: &a72
+          enum: &a73
             - "true"
             - "false"
         start_date_from:
@@ -6384,7 +6389,7 @@ components:
           type: string
         order:
           type: string
-          enum: &a73
+          enum: &a74
             - asc
             - desc
         search:
@@ -6420,19 +6425,19 @@ components:
             - annually
         is_custom:
           type: string
-          enum: &a74
+          enum: &a75
             - "true"
             - "false"
         is_active:
           type: string
-          enum: &a75
+          enum: &a76
             - "true"
             - "false"
         service_category:
           type: string
         has_services:
           type: string
-          enum: &a76
+          enum: &a77
             - "true"
             - "false"
         clients_count_min:
@@ -6445,19 +6450,19 @@ components:
           type: string
         include_services:
           type: string
-          enum: &a77
+          enum: &a78
             - "true"
             - "false"
           description: Controller-level include flag parsed directly from query string.
         include_usage:
           type: string
-          enum: &a78
+          enum: &a79
             - "true"
             - "false"
           description: Controller-level include flag parsed directly from query string.
         include_clients:
           type: string
-          enum: &a79
+          enum: &a80
             - "true"
             - "false"
           description: Controller-level include flag parsed directly from query string.
@@ -6939,7 +6944,7 @@ components:
       properties:
         format:
           type: string
-          enum: &a80
+          enum: &a81
             - pdf
             - markdown
             - md
@@ -7555,7 +7560,7 @@ components:
           type: string
         order:
           type: string
-          enum: &a81
+          enum: &a82
             - asc
             - desc
         search:
@@ -7584,22 +7589,22 @@ components:
           type: string
         include_expired:
           type: string
-          enum: &a82
+          enum: &a83
             - "true"
             - "false"
         expiring_soon:
           type: string
-          enum: &a83
+          enum: &a84
             - "true"
             - "false"
         has_remaining:
           type: string
-          enum: &a84
+          enum: &a85
             - "true"
             - "false"
         has_expiration:
           type: string
-          enum: &a85
+          enum: &a86
             - "true"
             - "false"
         date_from:
@@ -7608,13 +7613,13 @@ components:
           type: string
         group_by:
           type: string
-          enum: &a86
+          enum: &a87
             - day
             - week
             - month
         include_projections:
           type: string
-          enum: &a87
+          enum: &a88
             - "true"
             - "false"
         as_of_date:
@@ -7630,27 +7635,27 @@ components:
           type: string
         order:
           type: string
-          enum: &a98
+          enum: &a99
             - asc
             - desc
         include_items:
           type: string
-          enum: &a99
+          enum: &a100
             - "true"
             - "false"
         include_client:
           type: string
-          enum: &a100
+          enum: &a101
             - "true"
             - "false"
         include_billing_cycle:
           type: string
-          enum: &a101
+          enum: &a102
             - "true"
             - "false"
         include_transactions:
           type: string
-          enum: &a102
+          enum: &a103
             - "true"
             - "false"
         q:
@@ -7661,7 +7666,7 @@ components:
           type: string
         format:
           type: string
-          enum: &a103
+          enum: &a104
             - json
             - csv
       additionalProperties:
@@ -7680,7 +7685,7 @@ components:
             created_at).
         order:
           type: string
-          enum: &a88
+          enum: &a89
             - asc
             - desc
         search:
@@ -7696,7 +7701,7 @@ components:
           type: string
         is_active:
           type: string
-          enum: &a89
+          enum: &a90
             - "true"
             - "false"
         client_id:
@@ -7704,7 +7709,7 @@ components:
           format: uuid
         status:
           type: string
-          enum: &a90
+          enum: &a91
             - draft
             - sent
             - paid
@@ -7726,12 +7731,12 @@ components:
           type: string
         is_manual:
           type: string
-          enum: &a91
+          enum: &a92
             - "true"
             - "false"
         has_credit_applied:
           type: string
-          enum: &a92
+          enum: &a93
             - "true"
             - "false"
     FinancialPaymentMethodListQuery:
@@ -7747,7 +7752,7 @@ components:
             (defaults to created_at).
         order:
           type: string
-          enum: &a93
+          enum: &a94
             - asc
             - desc
         search:
@@ -7763,7 +7768,7 @@ components:
           type: string
         is_active:
           type: string
-          enum: &a94
+          enum: &a95
             - "true"
             - "false"
         client_id:
@@ -7771,17 +7776,17 @@ components:
           format: uuid
         type:
           type: string
-          enum: &a95
+          enum: &a96
             - credit_card
             - bank_account
         is_default:
           type: string
-          enum: &a96
+          enum: &a97
             - "true"
             - "false"
         exclude_deleted:
           type: string
-          enum: &a97
+          enum: &a98
             - "true"
             - "false"
           description: Exclude soft-deleted payment methods. Defaults to true.
@@ -8749,12 +8754,12 @@ components:
           type: string
         is_managed:
           type: string
-          enum: &a104
+          enum: &a105
             - "true"
             - "false"
         is_security_relevant:
           type: string
-          enum: &a105
+          enum: &a106
             - "true"
             - "false"
         client_id:
@@ -8781,7 +8786,7 @@ components:
           type: string
         order:
           type: string
-          enum: &a106
+          enum: &a107
             - asc
             - desc
     PriorityIdParam:
@@ -8849,17 +8854,17 @@ components:
       properties:
         preview:
           type: string
-          enum: &a107
+          enum: &a108
             - "true"
             - "false"
         createNew:
           type: string
-          enum: &a108
+          enum: &a109
             - "true"
             - "false"
         updateExisting:
           type: string
-          enum: &a109
+          enum: &a110
             - "true"
             - "false"
         matchBy:
@@ -8869,7 +8874,7 @@ components:
       properties:
         preview:
           type: string
-          enum: &a110
+          enum: &a111
             - "true"
             - "false"
     AccountingBatchIdParam:
@@ -9016,7 +9021,7 @@ components:
       properties:
         force:
           type: string
-          enum: &a111
+          enum: &a112
             - "true"
             - "false"
     WorkflowImportBody:
@@ -10002,7 +10007,7 @@ components:
           type: string
         active:
           type: string
-          enum: &a112
+          enum: &a113
             - "true"
             - "false"
         search:
@@ -10011,7 +10016,7 @@ components:
           type: string
         force_refresh:
           type: string
-          enum: &a113
+          enum: &a114
             - "true"
             - "false"
     QuickBooksV1SyncHistoryQuery:
@@ -10023,7 +10028,7 @@ components:
           type: string
         status:
           type: string
-          enum: &a114
+          enum: &a115
             - pending
             - in_progress
             - completed
@@ -10032,7 +10037,7 @@ components:
             - partial
         operation_type:
           type: string
-          enum: &a115
+          enum: &a116
             - customer_sync
             - invoice_export
             - invoice_import
@@ -10757,7 +10762,7 @@ components:
           description: Opaque pagination cursor copied from a prior response's nextCursor.
         sort:
           type: string
-          enum: &a116
+          enum: &a117
             - relevance
             - recent
           description: Result ordering. "relevance" (default) ranks by full-text score;
@@ -11072,7 +11077,7 @@ components:
           type: string
         order:
           type: string
-          enum: &a117
+          enum: &a118
             - asc
             - desc
         search:
@@ -11099,19 +11104,19 @@ components:
           format: uuid
         is_parent:
           type: string
-          enum: &a118
+          enum: &a119
             - "true"
             - "false"
         is_child:
           type: string
-          enum: &a119
+          enum: &a120
             - "true"
             - "false"
         depth:
           type: string
         active:
           type: string
-          enum: &a120
+          enum: &a121
             - "true"
             - "false"
         offset:
@@ -11120,17 +11125,17 @@ components:
           type: string
         sort_order:
           type: string
-          enum: &a121
+          enum: &a122
             - asc
             - desc
         include_hierarchy:
           type: string
-          enum: &a122
+          enum: &a123
             - "true"
             - "false"
         category_type:
           type: string
-          enum: &a123
+          enum: &a124
             - service
             - ticket
     CategoryMoveRequest:
@@ -11157,7 +11162,7 @@ components:
           minLength: 1
         category_type:
           type: string
-          enum: &a124
+          enum: &a125
             - service
             - ticket
         board_id:
@@ -11165,7 +11170,7 @@ components:
           format: uuid
         include_inactive:
           type: string
-          enum: &a125
+          enum: &a126
             - "true"
             - "false"
         limit:
@@ -11179,7 +11184,7 @@ components:
       properties:
         category_type:
           type: string
-          enum: &a126
+          enum: &a127
             - service
             - ticket
         board_id:
@@ -11193,7 +11198,7 @@ components:
           format: date-time
         include_usage:
           type: string
-          enum: &a127
+          enum: &a128
             - "true"
             - "false"
     CategoryAnalyticsResponse:
@@ -11814,7 +11819,7 @@ components:
           type: string
         order:
           type: string
-          enum: &a133
+          enum: &a134
             - asc
             - desc
         name:
@@ -11825,24 +11830,24 @@ components:
           type: string
         is_active:
           type: string
-          enum: &a134
+          enum: &a135
             - "true"
             - "false"
         is_test_mode:
           type: string
-          enum: &a135
+          enum: &a136
             - "true"
             - "false"
         payload_format:
           type: string
-          enum: &a136
+          enum: &a137
             - json
             - xml
             - form_data
             - custom
         has_failures:
           type: string
-          enum: &a137
+          enum: &a138
             - "true"
             - "false"
         last_delivery_from:
@@ -11876,7 +11881,7 @@ components:
           type: string
         status:
           type: string
-          enum: &a138
+          enum: &a139
             - pending
             - delivered
             - failed
@@ -13318,6 +13323,1058 @@ components:
     WorkflowV1MissingRouteResponse:
       type: string
       description: Default Next.js not-found response body for missing route handlers.
+    WorkflowTasksApiErrorV1:
+      type: object
+      properties:
+        error:
+          type: object
+          properties:
+            code:
+              type: string
+            message:
+              type: string
+            details: {}
+          required:
+            - code
+            - message
+      required:
+        - error
+    WorkflowTaskIdParamV1:
+      type: object
+      properties:
+        id:
+          type: string
+          description: Workflow task identifier (taskId).
+      required:
+        - id
+    WorkflowTasksListQueryV1:
+      type: object
+      properties:
+        status:
+          type: string
+          description: Comma-separated WorkflowTaskStatus values (pending, claimed,
+            completed, canceled, expired). Omit for the open inbox (pending +
+            claimed).
+        page:
+          type: integer
+          minimum: 1
+          description: 1-based page number (default 1).
+        pageSize:
+          type: integer
+          minimum: 1
+          maximum: 100
+          description: Items per page, max 100 (default 25).
+    WorkflowTaskV1:
+      type: object
+      properties:
+        taskId:
+          type: string
+        executionId:
+          type: string
+        title:
+          type: string
+        description:
+          type: string
+        status:
+          type: string
+          enum: &a22
+            - pending
+            - claimed
+            - completed
+            - canceled
+            - expired
+        priority:
+          type: string
+        dueDate:
+          type: string
+        assignedRoles:
+          type: array
+          items:
+            type: string
+        assignedUsers:
+          type: array
+          items:
+            type: string
+        contextData:
+          type: object
+          additionalProperties: {}
+        formId:
+          type: string
+        formSchema:
+          type: object
+          properties:
+            jsonSchema:
+              type: object
+              additionalProperties: {}
+            uiSchema:
+              type: object
+              additionalProperties: {}
+            defaultValues:
+              type: object
+              additionalProperties: {}
+          required:
+            - jsonSchema
+        createdAt:
+          type: string
+        createdBy:
+          type: string
+        claimedAt:
+          type: string
+        claimedBy:
+          type: string
+        completedAt:
+          type: string
+        completedBy:
+          type: string
+        responseData:
+          type: object
+          additionalProperties: {}
+      required:
+        - taskId
+        - executionId
+        - title
+        - status
+        - priority
+        - formId
+        - createdAt
+    WorkflowTaskListResponseV1:
+      type: object
+      properties:
+        data:
+          type: array
+          items:
+            type: object
+            properties:
+              taskId:
+                type: string
+              executionId:
+                type: string
+              title:
+                type: string
+              description:
+                type: string
+              status:
+                type: string
+                enum: *a22
+              priority:
+                type: string
+              dueDate:
+                type: string
+              assignedRoles:
+                type: array
+                items:
+                  type: string
+              assignedUsers:
+                type: array
+                items:
+                  type: string
+              contextData:
+                type: object
+                additionalProperties: {}
+              formId:
+                type: string
+              formSchema:
+                type: object
+                properties:
+                  jsonSchema:
+                    type: object
+                    additionalProperties: {}
+                  uiSchema:
+                    type: object
+                    additionalProperties: {}
+                  defaultValues:
+                    type: object
+                    additionalProperties: {}
+                required:
+                  - jsonSchema
+              createdAt:
+                type: string
+              createdBy:
+                type: string
+              claimedAt:
+                type: string
+              claimedBy:
+                type: string
+              completedAt:
+                type: string
+              completedBy:
+                type: string
+              responseData:
+                type: object
+                additionalProperties: {}
+            required:
+              - taskId
+              - executionId
+              - title
+              - status
+              - priority
+              - formId
+              - createdAt
+        pagination:
+          type: object
+          properties:
+            page:
+              type: number
+            limit:
+              type: number
+            total:
+              type: number
+            totalPages:
+              type: number
+            hasNext:
+              type: boolean
+            hasPrev:
+              type: boolean
+          required:
+            - page
+            - limit
+            - total
+            - totalPages
+            - hasNext
+            - hasPrev
+        meta: {}
+      required:
+        - data
+        - pagination
+    WorkflowTaskDetailResponseV1:
+      type: object
+      properties:
+        data:
+          type: object
+          properties:
+            taskId:
+              type: string
+            executionId:
+              type: string
+            title:
+              type: string
+            description:
+              type: string
+            status:
+              type: string
+              enum: *a22
+            priority:
+              type: string
+            dueDate:
+              type: string
+            assignedRoles:
+              type: array
+              items:
+                type: string
+            assignedUsers:
+              type: array
+              items:
+                type: string
+            contextData:
+              type: object
+              additionalProperties: {}
+            formId:
+              type: string
+            formSchema:
+              type: object
+              properties:
+                jsonSchema:
+                  type: object
+                  additionalProperties: {}
+                uiSchema:
+                  type: object
+                  additionalProperties: {}
+                defaultValues:
+                  type: object
+                  additionalProperties: {}
+              required:
+                - jsonSchema
+            createdAt:
+              type: string
+            createdBy:
+              type: string
+            claimedAt:
+              type: string
+            claimedBy:
+              type: string
+            completedAt:
+              type: string
+            completedBy:
+              type: string
+            responseData:
+              type: object
+              additionalProperties: {}
+          required:
+            - taskId
+            - executionId
+            - title
+            - status
+            - priority
+            - formId
+            - createdAt
+        meta: {}
+      required:
+        - data
+    WorkflowTaskActionResponseV1:
+      type: object
+      properties:
+        data:
+          type: object
+          properties:
+            success:
+              type: boolean
+          required:
+            - success
+        meta: {}
+      required:
+        - data
+    CompleteWorkflowTaskBodyV1:
+      type: object
+      properties:
+        formData:
+          type: object
+          additionalProperties: {}
+          default: {}
+        comments:
+          type: string
+    ActivitiesApiErrorV1:
+      type: object
+      properties:
+        error:
+          type: object
+          properties:
+            code:
+              type: string
+            message:
+              type: string
+            details: {}
+          required:
+            - code
+            - message
+      required:
+        - error
+    ActivitiesAdHocIdParamV1:
+      type: object
+      properties:
+        id:
+          type: string
+          description: Ad-hoc activity identifier (the backing schedule entry id).
+      required:
+        - id
+    ActivitiesListQueryV1:
+      type: object
+      properties:
+        type:
+          type: string
+          description: Comma-separated ActivityType values (e.g. "ticket,schedule"). Omit
+            for all types.
+        status:
+          type: string
+          enum: &a140
+            - open
+            - closed
+            - all
+          description: Open/closed filter. `open`→active only, `closed`→closed, `all`→no
+            filter (default).
+        search:
+          type: string
+          description: Free-text search across activity titles/descriptions.
+        dateStart:
+          type: string
+          format: date-time
+          description: ISO 8601 lower bound of the schedule/time-entry/notification window.
+        dateEnd:
+          type: string
+          format: date-time
+          description: ISO 8601 upper bound of the window.
+        priority:
+          type: string
+          description: Comma-separated normalized ActivityPriority buckets (e.g.
+            "high,medium"). Lossy for custom schemes; prefer `priorityIds`.
+        priorityIds:
+          type: string
+          description: Comma-separated exact priority IDs (the tenant's real per-type
+            priorities). Applies to ticket/project-task activities.
+        dueDateStart:
+          type: string
+          format: date-time
+          description: ISO 8601 lower bound of the due-date filter (independent of the
+            schedule window).
+        dueDateEnd:
+          type: string
+          format: date-time
+          description: ISO 8601 upper bound of the due-date filter.
+        createdAtStart:
+          type: string
+          format: date-time
+          description: ISO 8601 lower bound of the created-date ("date entered") filter.
+            Applies to every activity type.
+        createdAtEnd:
+          type: string
+          format: date-time
+          description: ISO 8601 upper bound of the created-date ("date entered") filter.
+        sortBy:
+          type: string
+          enum: &a141
+            - type
+            - title
+            - status
+            - priority
+            - dueDate
+          description: Sort column. Omit for the default sort (priority high→low, then due
+            date ascending).
+        sortDirection:
+          type: string
+          enum: &a142
+            - asc
+            - desc
+          description: Sort direction for `sortBy` (default asc). Ignored when `sortBy` is
+            omitted.
+        groupBy:
+          type: string
+          enum: &a143
+            - type
+            - priority
+            - status
+            - dueDate
+          description: When set, the response is grouped by this dimension
+            (ActivityGroupedResponseV1) instead of the paginated list;
+            `page`/`pageSize` are ignored. `priority` groups by the real
+            per-tenant priority name (not the normalized bucket), so it is only
+            meaningful when scoped to a single prioritized type.
+        page:
+          type: integer
+          minimum: 1
+          description: 1-based page number (default 1). Ignored when `groupBy` is set.
+        pageSize:
+          type: integer
+          minimum: 1
+          maximum: 100
+          description: Items per page, max 100 (default 25). Ignored when `groupBy` is set.
+    ActivityV1:
+      type: object
+      properties:
+        id:
+          type: string
+        title:
+          type: string
+        description:
+          type: string
+        type:
+          type: string
+          enum:
+            - schedule
+            - projectTask
+            - ticket
+            - timeEntry
+            - workflowTask
+            - notification
+            - document
+        status:
+          type: string
+        statusColor:
+          type: string
+        priority:
+          type: string
+          enum:
+            - low
+            - medium
+            - high
+        priorityName:
+          type: string
+        priorityColor:
+          type: string
+        dueDate:
+          type: string
+        startDate:
+          type: string
+        endDate:
+          type: string
+        assignedTo:
+          type: array
+          items:
+            type: string
+        assignedToNames:
+          type: array
+          items:
+            type: string
+        sourceId:
+          type: string
+        sourceType:
+          type: string
+          enum:
+            - schedule
+            - projectTask
+            - ticket
+            - timeEntry
+            - workflowTask
+            - notification
+            - document
+        actions:
+          type: array
+          items:
+            type: object
+            properties:
+              id:
+                type: string
+              label:
+                type: string
+              icon:
+                type: string
+              disabled:
+                type: boolean
+              disabledReason:
+                type: string
+            required:
+              - id
+              - label
+        isClosed:
+          type: boolean
+        tenant:
+          type: string
+        createdAt:
+          type: string
+        updatedAt:
+          type: string
+      required:
+        - id
+        - title
+        - type
+        - status
+        - priority
+        - sourceId
+        - sourceType
+        - actions
+        - tenant
+        - createdAt
+        - updatedAt
+    ActivityListResponseV1:
+      type: object
+      properties:
+        data:
+          type: array
+          items:
+            type: object
+            properties:
+              id:
+                type: string
+              title:
+                type: string
+              description:
+                type: string
+              type:
+                type: string
+                enum:
+                  - schedule
+                  - projectTask
+                  - ticket
+                  - timeEntry
+                  - workflowTask
+                  - notification
+                  - document
+              status:
+                type: string
+              statusColor:
+                type: string
+              priority:
+                type: string
+                enum:
+                  - low
+                  - medium
+                  - high
+              priorityName:
+                type: string
+              priorityColor:
+                type: string
+              dueDate:
+                type: string
+              startDate:
+                type: string
+              endDate:
+                type: string
+              assignedTo:
+                type: array
+                items:
+                  type: string
+              assignedToNames:
+                type: array
+                items:
+                  type: string
+              sourceId:
+                type: string
+              sourceType:
+                type: string
+                enum:
+                  - schedule
+                  - projectTask
+                  - ticket
+                  - timeEntry
+                  - workflowTask
+                  - notification
+                  - document
+              actions:
+                type: array
+                items:
+                  type: object
+                  properties:
+                    id:
+                      type: string
+                    label:
+                      type: string
+                    icon:
+                      type: string
+                    disabled:
+                      type: boolean
+                    disabledReason:
+                      type: string
+                  required:
+                    - id
+                    - label
+              isClosed:
+                type: boolean
+              tenant:
+                type: string
+              createdAt:
+                type: string
+              updatedAt:
+                type: string
+            required:
+              - id
+              - title
+              - type
+              - status
+              - priority
+              - sourceId
+              - sourceType
+              - actions
+              - tenant
+              - createdAt
+              - updatedAt
+        pagination:
+          type: object
+          properties:
+            page:
+              type: number
+            limit:
+              type: number
+            total:
+              type: number
+            totalPages:
+              type: number
+            hasNext:
+              type: boolean
+            hasPrev:
+              type: boolean
+          required:
+            - page
+            - limit
+            - total
+            - totalPages
+            - hasNext
+            - hasPrev
+        meta: {}
+      required:
+        - data
+        - pagination
+    ActivityGroupedResponseV1:
+      type: object
+      properties:
+        data:
+          type: object
+          properties:
+            groupBy:
+              type: string
+              enum:
+                - type
+                - priority
+                - status
+                - dueDate
+            groups:
+              type: array
+              items:
+                type: object
+                properties:
+                  key:
+                    type: string
+                  label:
+                    type: string
+                  count:
+                    type: number
+                  activities:
+                    type: array
+                    items:
+                      type: object
+                      properties:
+                        id:
+                          type: string
+                        title:
+                          type: string
+                        description:
+                          type: string
+                        type:
+                          type: string
+                          enum:
+                            - schedule
+                            - projectTask
+                            - ticket
+                            - timeEntry
+                            - workflowTask
+                            - notification
+                            - document
+                        status:
+                          type: string
+                        statusColor:
+                          type: string
+                        priority:
+                          type: string
+                          enum:
+                            - low
+                            - medium
+                            - high
+                        priorityName:
+                          type: string
+                        priorityColor:
+                          type: string
+                        dueDate:
+                          type: string
+                        startDate:
+                          type: string
+                        endDate:
+                          type: string
+                        assignedTo:
+                          type: array
+                          items:
+                            type: string
+                        assignedToNames:
+                          type: array
+                          items:
+                            type: string
+                        sourceId:
+                          type: string
+                        sourceType:
+                          type: string
+                          enum:
+                            - schedule
+                            - projectTask
+                            - ticket
+                            - timeEntry
+                            - workflowTask
+                            - notification
+                            - document
+                        actions:
+                          type: array
+                          items:
+                            type: object
+                            properties:
+                              id:
+                                type: string
+                              label:
+                                type: string
+                              icon:
+                                type: string
+                              disabled:
+                                type: boolean
+                              disabledReason:
+                                type: string
+                            required:
+                              - id
+                              - label
+                        isClosed:
+                          type: boolean
+                        tenant:
+                          type: string
+                        createdAt:
+                          type: string
+                        updatedAt:
+                          type: string
+                      required:
+                        - id
+                        - title
+                        - type
+                        - status
+                        - priority
+                        - sourceId
+                        - sourceType
+                        - actions
+                        - tenant
+                        - createdAt
+                        - updatedAt
+                required:
+                  - key
+                  - label
+                  - count
+                  - activities
+            totalCount:
+              type: number
+            truncated:
+              type: boolean
+          required:
+            - groupBy
+            - groups
+            - totalCount
+            - truncated
+        meta: {}
+      required:
+        - data
+    AdHocActivityResponseV1:
+      type: object
+      properties:
+        data:
+          type: object
+          properties:
+            id:
+              type: string
+            title:
+              type: string
+            description:
+              type: string
+            type:
+              type: string
+              enum:
+                - schedule
+                - projectTask
+                - ticket
+                - timeEntry
+                - workflowTask
+                - notification
+                - document
+            status:
+              type: string
+            statusColor:
+              type: string
+            priority:
+              type: string
+              enum:
+                - low
+                - medium
+                - high
+            priorityName:
+              type: string
+            priorityColor:
+              type: string
+            dueDate:
+              type: string
+            startDate:
+              type: string
+            endDate:
+              type: string
+            assignedTo:
+              type: array
+              items:
+                type: string
+            assignedToNames:
+              type: array
+              items:
+                type: string
+            sourceId:
+              type: string
+            sourceType:
+              type: string
+              enum:
+                - schedule
+                - projectTask
+                - ticket
+                - timeEntry
+                - workflowTask
+                - notification
+                - document
+            actions:
+              type: array
+              items:
+                type: object
+                properties:
+                  id:
+                    type: string
+                  label:
+                    type: string
+                  icon:
+                    type: string
+                  disabled:
+                    type: boolean
+                  disabledReason:
+                    type: string
+                required:
+                  - id
+                  - label
+            isClosed:
+              type: boolean
+            tenant:
+              type: string
+            createdAt:
+              type: string
+            updatedAt:
+              type: string
+          required:
+            - id
+            - title
+            - type
+            - status
+            - priority
+            - sourceId
+            - sourceType
+            - actions
+            - tenant
+            - createdAt
+            - updatedAt
+        meta: {}
+      required:
+        - data
+    CreateAdHocActivityBodyV1:
+      type: object
+      properties:
+        title:
+          type: string
+          minLength: 1
+        notes:
+          type: string
+        scheduledStart:
+          type:
+            - string
+            - "null"
+          format: date-time
+        scheduledEnd:
+          type:
+            - string
+            - "null"
+          format: date-time
+      required:
+        - title
+    UpdateAdHocActivityBodyV1:
+      type: object
+      properties:
+        title:
+          type: string
+          minLength: 1
+        notes:
+          type:
+            - string
+            - "null"
+        scheduledStart:
+          type:
+            - string
+            - "null"
+          format: date-time
+        scheduledEnd:
+          type:
+            - string
+            - "null"
+          format: date-time
+    SetAdHocActivityDoneBodyV1:
+      type: object
+      properties:
+        done:
+          type: boolean
+      required:
+        - done
+    CustomActivityGroupsResponseV1:
+      type: object
+      properties:
+        data:
+          type: array
+          items:
+            type: object
+            properties:
+              groupId:
+                type: string
+              groupName:
+                type: string
+              sortOrder:
+                type: number
+              isCollapsed:
+                type: boolean
+              items:
+                type: array
+                items:
+                  type: object
+                  properties:
+                    itemId:
+                      type: string
+                    activityId:
+                      type: string
+                    activityType:
+                      type: string
+                    sortOrder:
+                      type: number
+                  required:
+                    - itemId
+                    - activityId
+                    - activityType
+                    - sortOrder
+            required:
+              - groupId
+              - groupName
+              - sortOrder
+              - isCollapsed
+              - items
+        meta: {}
+      required:
+        - data
+    MoveActivityToGroupBodyV1:
+      type: object
+      properties:
+        activityId:
+          type: string
+          minLength: 1
+        activityType:
+          type: string
+          minLength: 1
+        groupId:
+          type: string
+          minLength: 1
+        sortOrder:
+          type: integer
+          minimum: 0
+      required:
+        - activityId
+        - activityType
+        - groupId
+        - sortOrder
+    RemoveActivityFromGroupBodyV1:
+      type: object
+      properties:
+        activityId:
+          type: string
+          minLength: 1
+        activityType:
+          type: string
+          minLength: 1
+      required:
+        - activityId
+        - activityType
+    ReorderActivitiesInGroupBodyV1:
+      type: object
+      properties:
+        items:
+          type: array
+          items:
+            type: object
+            properties:
+              activityId:
+                type: string
+                minLength: 1
+              activityType:
+                type: string
+                minLength: 1
+              sortOrder:
+                type: integer
+                minimum: 0
+            required:
+              - activityId
+              - activityType
+              - sortOrder
+          minItems: 1
+      required:
+        - items
+    ActivitiesGroupIdParamV1:
+      type: object
+      properties:
+        groupId:
+          type: string
+          description: Custom activity group identifier.
+      required:
+        - groupId
+    ActivitiesGroupsQueryV1:
+      type: object
+      properties:
+        targetUserId:
+          type: string
+          description: Another internal user whose groups to read (requires elevated
+            schedule permission). Omit for self.
     ProjectIdParams:
       type: object
       properties:
@@ -13638,7 +14695,7 @@ components:
           type: string
         order:
           type: string
-          enum: &a139
+          enum: &a144
             - asc
             - desc
         fields:
@@ -13943,7 +15000,7 @@ components:
           type: string
         order:
           type: string
-          enum: &a140
+          enum: &a145
             - asc
             - desc
         search:
@@ -13952,12 +15009,12 @@ components:
           type: string
         include_items:
           type: string
-          enum: &a141
+          enum: &a146
             - "true"
             - "false"
         include_client:
           type: string
-          enum: &a142
+          enum: &a147
             - "true"
             - "false"
     QuotesContractsGenericBodyV1:
@@ -15638,7 +16695,7 @@ paths:
           in: query
         - schema:
             type: string
-            enum: *a22
+            enum: *a23
           required: false
           name: order
           in: query
@@ -16162,7 +17219,7 @@ paths:
           in: query
         - schema:
             type: string
-            enum: *a23
+            enum: *a24
           required: false
           name: order
           in: query
@@ -16173,7 +17230,7 @@ paths:
           in: query
         - schema:
             type: string
-            enum: *a24
+            enum: *a25
           required: false
           name: has_permissions
           in: query
@@ -16189,7 +17246,7 @@ paths:
           in: query
         - schema:
             type: string
-            enum: *a25
+            enum: *a26
           required: false
           name: is_template
           in: query
@@ -16786,7 +17843,7 @@ paths:
           in: query
         - schema:
             type: string
-            enum: *a26
+            enum: *a27
           required: false
           name: order
           in: query
@@ -17094,7 +18151,7 @@ paths:
           in: query
         - schema:
             type: string
-            enum: *a27
+            enum: *a28
           required: false
           name: has_manager
           in: query
@@ -17105,7 +18162,7 @@ paths:
           in: query
         - schema:
             type: string
-            enum: *a28
+            enum: *a29
           required: false
           name: order
           in: query
@@ -17422,7 +18479,7 @@ paths:
           in: query
         - schema:
             type: string
-            enum: *a29
+            enum: *a30
           required: false
           name: granularity
           in: query
@@ -18174,7 +19231,7 @@ paths:
           in: query
         - schema:
             type: string
-            enum: *a30
+            enum: *a31
           required: false
           name: is_inactive
           in: query
@@ -18185,7 +19242,7 @@ paths:
           in: query
         - schema:
             type: string
-            enum: *a31
+            enum: *a32
           required: false
           name: order
           in: query
@@ -18257,7 +19314,7 @@ paths:
           in: query
         - schema:
             type: string
-            enum: *a32
+            enum: *a33
           required: false
           name: order
           in: query
@@ -18283,7 +19340,7 @@ paths:
           in: query
         - schema:
             type: string
-            enum: *a33
+            enum: *a34
           required: false
           name: user_type
           in: query
@@ -18301,19 +19358,19 @@ paths:
           in: query
         - schema:
             type: string
-            enum: *a34
+            enum: *a35
           required: false
           name: is_inactive
           in: query
         - schema:
             type: string
-            enum: *a35
+            enum: *a36
           required: false
           name: include_permissions
           in: query
         - schema:
             type: string
-            enum: *a36
+            enum: *a37
           required: false
           name: include_teams
           in: query
@@ -18647,7 +19704,7 @@ paths:
           in: query
         - schema:
             type: string
-            enum: *a37
+            enum: *a38
           required: false
           name: user_type
           in: query
@@ -18665,7 +19722,7 @@ paths:
           in: query
         - schema:
             type: string
-            enum: *a38
+            enum: *a39
           required: false
           name: include_inactive
           in: query
@@ -20050,7 +21107,7 @@ paths:
           in: query
         - schema:
             type: string
-            enum: *a39
+            enum: *a40
             description: Sort direction. Defaults to desc.
           required: false
           description: Sort direction. Defaults to desc.
@@ -20108,7 +21165,7 @@ paths:
           in: query
         - schema:
             type: string
-            enum: *a40
+            enum: *a41
             description: Accepted by validation, but not currently applied by
               AssetService.list.
           required: false
@@ -20176,7 +21233,7 @@ paths:
           in: query
         - schema:
             type: string
-            enum: *a41
+            enum: *a42
             description: true requires warranty_end_date to be non-null; false requires it
               to be null.
           required: false
@@ -20186,7 +21243,7 @@ paths:
           in: query
         - schema:
             type: string
-            enum: *a42
+            enum: *a43
             description: true filters warranty_end_date before now; false filters future
               warranty dates or no warranty.
           required: false
@@ -20196,7 +21253,7 @@ paths:
           in: query
         - schema:
             type: string
-            enum: *a43
+            enum: *a44
             description: Accepted by validation, but not currently applied by
               AssetService.list.
           required: false
@@ -20536,7 +21593,7 @@ paths:
       parameters:
         - schema:
             type: string
-            enum: *a44
+            enum: *a45
             description: Export format. csv (default) returns text/csv as an attachment;
               json returns the success envelope with the rows in data.
           required: false
@@ -20854,7 +21911,7 @@ paths:
             type: array
             items:
               type: string
-              enum: *a45
+              enum: *a46
             description: Search fields. If omitted, the service searches asset_tag, name,
               serial_number, and location.
           required: false
@@ -20893,7 +21950,7 @@ paths:
           in: query
         - schema:
             type: string
-            enum: *a46
+            enum: *a47
             description: When true, the service fetches asset-type-specific extension data
               for every result.
           required: false
@@ -22614,7 +23671,7 @@ paths:
           in: path
         - schema:
             type: string
-            enum: *a47
+            enum: *a48
             description: Remote-control protocol (default splashtop).
           required: false
           description: Remote-control protocol (default splashtop).
@@ -22770,7 +23827,7 @@ paths:
           in: query
         - schema:
             type: string
-            enum: *a48
+            enum: *a49
           required: false
           name: include_uninstalled
           in: query
@@ -22911,7 +23968,7 @@ paths:
           in: query
         - schema:
             type: string
-            enum: *a49
+            enum: *a50
             description: Accepted by shared list query validation.
           required: false
           description: Accepted by shared list query validation.
@@ -22958,7 +24015,7 @@ paths:
           in: query
         - schema:
             type: string
-            enum: *a50
+            enum: *a51
             description: Accepted by shared filter validation and transformed to boolean.
           required: false
           description: Accepted by shared filter validation and transformed to boolean.
@@ -23014,7 +24071,7 @@ paths:
           in: query
         - schema:
             type: string
-            enum: *a51
+            enum: *a52
             description: Filter by whether the execution has errors; transformed to boolean
               by validation.
           required: false
@@ -23260,7 +24317,7 @@ paths:
           in: query
         - schema:
             type: string
-            enum: *a52
+            enum: *a53
             description: Accepted by shared list query validation.
           required: false
           description: Accepted by shared list query validation.
@@ -23307,7 +24364,7 @@ paths:
           in: query
         - schema:
             type: string
-            enum: *a53
+            enum: *a54
             description: Accepted by shared filter validation and transformed to boolean.
           required: false
           description: Accepted by shared filter validation and transformed to boolean.
@@ -23947,7 +25004,7 @@ paths:
           in: query
         - schema:
             type: string
-            enum: *a54
+            enum: *a55
             description: Accepted by shared list query validation.
           required: false
           description: Accepted by shared list query validation.
@@ -23994,7 +25051,7 @@ paths:
           in: query
         - schema:
             type: string
-            enum: *a55
+            enum: *a56
             description: Accepted by shared filter validation and transformed to boolean.
           required: false
           description: Accepted by shared filter validation and transformed to boolean.
@@ -24375,7 +25432,7 @@ paths:
           in: query
         - schema:
             type: string
-            enum: *a56
+            enum: *a57
             description: Aggregation bucket size; defaults to day.
           required: false
           description: Aggregation bucket size; defaults to day.
@@ -24802,7 +25859,7 @@ paths:
           in: query
         - schema:
             type: string
-            enum: *a57
+            enum: *a58
           required: false
           name: order
           in: query
@@ -24847,25 +25904,25 @@ paths:
           in: query
         - schema:
             type: string
-            enum: *a58
+            enum: *a59
           required: false
           name: client_type
           in: query
         - schema:
             type: string
-            enum: *a59
+            enum: *a60
           required: false
           name: billing_cycle
           in: query
         - schema:
             type: string
-            enum: *a60
+            enum: *a61
           required: false
           name: is_inactive
           in: query
         - schema:
             type: string
-            enum: *a61
+            enum: *a62
           required: false
           name: is_tax_exempt
           in: query
@@ -24892,7 +25949,7 @@ paths:
           in: query
         - schema:
             type: string
-            enum: *a62
+            enum: *a63
           required: false
           name: has_credit_limit
           in: query
@@ -25426,7 +26483,7 @@ paths:
           in: query
         - schema:
             type: string
-            enum: *a63
+            enum: *a64
           required: false
           name: order
           in: query
@@ -25487,13 +26544,13 @@ paths:
           in: query
         - schema:
             type: string
-            enum: *a64
+            enum: *a65
           required: false
           name: is_inactive
           in: query
         - schema:
             type: string
-            enum: *a65
+            enum: *a66
           required: false
           name: has_client
           in: query
@@ -25800,7 +26857,7 @@ paths:
           in: query
         - schema:
             type: string
-            enum: *a66
+            enum: *a67
           required: false
           name: include_inactive
           in: query
@@ -25860,13 +26917,13 @@ paths:
       parameters:
         - schema:
             type: string
-            enum: *a67
+            enum: *a68
           required: false
           name: format
           in: query
         - schema:
             type: string
-            enum: *a68
+            enum: *a69
           required: false
           name: include_inactive
           in: query
@@ -25986,7 +27043,7 @@ paths:
           in: query
         - schema:
             type: string
-            enum: *a69
+            enum: *a70
           required: false
           name: order
           in: query
@@ -26038,19 +27095,19 @@ paths:
           in: query
         - schema:
             type: string
-            enum: *a70
+            enum: *a71
           required: false
           name: is_active
           in: query
         - schema:
             type: string
-            enum: *a71
+            enum: *a72
           required: false
           name: has_custom_rate
           in: query
         - schema:
             type: string
-            enum: *a72
+            enum: *a73
           required: false
           name: is_contractd
           in: query
@@ -26228,7 +27285,7 @@ paths:
           in: query
         - schema:
             type: string
-            enum: *a73
+            enum: *a74
           required: false
           name: order
           in: query
@@ -26280,13 +27337,13 @@ paths:
           in: query
         - schema:
             type: string
-            enum: *a74
+            enum: *a75
           required: false
           name: is_custom
           in: query
         - schema:
             type: string
-            enum: *a75
+            enum: *a76
           required: false
           name: is_active
           in: query
@@ -26297,7 +27354,7 @@ paths:
           in: query
         - schema:
             type: string
-            enum: *a76
+            enum: *a77
           required: false
           name: has_services
           in: query
@@ -26323,7 +27380,7 @@ paths:
           in: query
         - schema:
             type: string
-            enum: *a77
+            enum: *a78
             description: Controller-level include flag parsed directly from query string.
           required: false
           description: Controller-level include flag parsed directly from query string.
@@ -26331,7 +27388,7 @@ paths:
           in: query
         - schema:
             type: string
-            enum: *a78
+            enum: *a79
             description: Controller-level include flag parsed directly from query string.
           required: false
           description: Controller-level include flag parsed directly from query string.
@@ -26339,7 +27396,7 @@ paths:
           in: query
         - schema:
             type: string
-            enum: *a79
+            enum: *a80
             description: Controller-level include flag parsed directly from query string.
           required: false
           description: Controller-level include flag parsed directly from query string.
@@ -27662,7 +28719,7 @@ paths:
           in: path
         - schema:
             type: string
-            enum: *a80
+            enum: *a81
             description: Optional export format. pdf generates a PDF; markdown or md exports
               markdown; omitted downloads the original stored file.
           required: false
@@ -29240,7 +30297,7 @@ paths:
           in: query
         - schema:
             type: string
-            enum: *a81
+            enum: *a82
           required: false
           name: order
           in: query
@@ -29303,25 +30360,25 @@ paths:
           in: query
         - schema:
             type: string
-            enum: *a82
+            enum: *a83
           required: false
           name: include_expired
           in: query
         - schema:
             type: string
-            enum: *a83
+            enum: *a84
           required: false
           name: expiring_soon
           in: query
         - schema:
             type: string
-            enum: *a84
+            enum: *a85
           required: false
           name: has_remaining
           in: query
         - schema:
             type: string
-            enum: *a85
+            enum: *a86
           required: false
           name: has_expiration
           in: query
@@ -29337,13 +30394,13 @@ paths:
           in: query
         - schema:
             type: string
-            enum: *a86
+            enum: *a87
           required: false
           name: group_by
           in: query
         - schema:
             type: string
-            enum: *a87
+            enum: *a88
           required: false
           name: include_projections
           in: query
@@ -29664,7 +30721,7 @@ paths:
           in: query
         - schema:
             type: string
-            enum: *a88
+            enum: *a89
           required: false
           name: order
           in: query
@@ -29697,7 +30754,7 @@ paths:
           in: query
         - schema:
             type: string
-            enum: *a89
+            enum: *a90
           required: false
           name: is_active
           in: query
@@ -29709,7 +30766,7 @@ paths:
           in: query
         - schema:
             type: string
-            enum: *a90
+            enum: *a91
           required: false
           name: status
           in: query
@@ -29741,13 +30798,13 @@ paths:
           in: query
         - schema:
             type: string
-            enum: *a91
+            enum: *a92
           required: false
           name: is_manual
           in: query
         - schema:
             type: string
-            enum: *a92
+            enum: *a93
           required: false
           name: has_credit_applied
           in: query
@@ -29969,7 +31026,7 @@ paths:
           in: query
         - schema:
             type: string
-            enum: *a93
+            enum: *a94
           required: false
           name: order
           in: query
@@ -30002,7 +31059,7 @@ paths:
           in: query
         - schema:
             type: string
-            enum: *a94
+            enum: *a95
           required: false
           name: is_active
           in: query
@@ -30014,19 +31071,19 @@ paths:
           in: query
         - schema:
             type: string
-            enum: *a95
+            enum: *a96
           required: false
           name: type
           in: query
         - schema:
             type: string
-            enum: *a96
+            enum: *a97
           required: false
           name: is_default
           in: query
         - schema:
             type: string
-            enum: *a97
+            enum: *a98
             description: Exclude soft-deleted payment methods. Defaults to true.
           required: false
           description: Exclude soft-deleted payment methods. Defaults to true.
@@ -30358,7 +31415,7 @@ paths:
           in: query
         - schema:
             type: string
-            enum: *a81
+            enum: *a82
           required: false
           name: order
           in: query
@@ -30421,25 +31478,25 @@ paths:
           in: query
         - schema:
             type: string
-            enum: *a82
+            enum: *a83
           required: false
           name: include_expired
           in: query
         - schema:
             type: string
-            enum: *a83
+            enum: *a84
           required: false
           name: expiring_soon
           in: query
         - schema:
             type: string
-            enum: *a84
+            enum: *a85
           required: false
           name: has_remaining
           in: query
         - schema:
             type: string
-            enum: *a85
+            enum: *a86
           required: false
           name: has_expiration
           in: query
@@ -30455,13 +31512,13 @@ paths:
           in: query
         - schema:
             type: string
-            enum: *a86
+            enum: *a87
           required: false
           name: group_by
           in: query
         - schema:
             type: string
-            enum: *a87
+            enum: *a88
           required: false
           name: include_projections
           in: query
@@ -30600,7 +31657,7 @@ paths:
           in: query
         - schema:
             type: string
-            enum: *a81
+            enum: *a82
           required: false
           name: order
           in: query
@@ -30663,25 +31720,25 @@ paths:
           in: query
         - schema:
             type: string
-            enum: *a82
+            enum: *a83
           required: false
           name: include_expired
           in: query
         - schema:
             type: string
-            enum: *a83
+            enum: *a84
           required: false
           name: expiring_soon
           in: query
         - schema:
             type: string
-            enum: *a84
+            enum: *a85
           required: false
           name: has_remaining
           in: query
         - schema:
             type: string
-            enum: *a85
+            enum: *a86
           required: false
           name: has_expiration
           in: query
@@ -30697,13 +31754,13 @@ paths:
           in: query
         - schema:
             type: string
-            enum: *a86
+            enum: *a87
           required: false
           name: group_by
           in: query
         - schema:
             type: string
-            enum: *a87
+            enum: *a88
           required: false
           name: include_projections
           in: query
@@ -30777,7 +31834,7 @@ paths:
           in: query
         - schema:
             type: string
-            enum: *a81
+            enum: *a82
           required: false
           name: order
           in: query
@@ -30840,25 +31897,25 @@ paths:
           in: query
         - schema:
             type: string
-            enum: *a82
+            enum: *a83
           required: false
           name: include_expired
           in: query
         - schema:
             type: string
-            enum: *a83
+            enum: *a84
           required: false
           name: expiring_soon
           in: query
         - schema:
             type: string
-            enum: *a84
+            enum: *a85
           required: false
           name: has_remaining
           in: query
         - schema:
             type: string
-            enum: *a85
+            enum: *a86
           required: false
           name: has_expiration
           in: query
@@ -30874,13 +31931,13 @@ paths:
           in: query
         - schema:
             type: string
-            enum: *a86
+            enum: *a87
           required: false
           name: group_by
           in: query
         - schema:
             type: string
-            enum: *a87
+            enum: *a88
           required: false
           name: include_projections
           in: query
@@ -30954,7 +32011,7 @@ paths:
           in: query
         - schema:
             type: string
-            enum: *a81
+            enum: *a82
           required: false
           name: order
           in: query
@@ -31017,25 +32074,25 @@ paths:
           in: query
         - schema:
             type: string
-            enum: *a82
+            enum: *a83
           required: false
           name: include_expired
           in: query
         - schema:
             type: string
-            enum: *a83
+            enum: *a84
           required: false
           name: expiring_soon
           in: query
         - schema:
             type: string
-            enum: *a84
+            enum: *a85
           required: false
           name: has_remaining
           in: query
         - schema:
             type: string
-            enum: *a85
+            enum: *a86
           required: false
           name: has_expiration
           in: query
@@ -31051,13 +32108,13 @@ paths:
           in: query
         - schema:
             type: string
-            enum: *a86
+            enum: *a87
           required: false
           name: group_by
           in: query
         - schema:
             type: string
-            enum: *a87
+            enum: *a88
           required: false
           name: include_projections
           in: query
@@ -31189,7 +32246,7 @@ paths:
           in: query
         - schema:
             type: string
-            enum: *a81
+            enum: *a82
           required: false
           name: order
           in: query
@@ -31252,25 +32309,25 @@ paths:
           in: query
         - schema:
             type: string
-            enum: *a82
+            enum: *a83
           required: false
           name: include_expired
           in: query
         - schema:
             type: string
-            enum: *a83
+            enum: *a84
           required: false
           name: expiring_soon
           in: query
         - schema:
             type: string
-            enum: *a84
+            enum: *a85
           required: false
           name: has_remaining
           in: query
         - schema:
             type: string
-            enum: *a85
+            enum: *a86
           required: false
           name: has_expiration
           in: query
@@ -31286,13 +32343,13 @@ paths:
           in: query
         - schema:
             type: string
-            enum: *a86
+            enum: *a87
           required: false
           name: group_by
           in: query
         - schema:
             type: string
-            enum: *a87
+            enum: *a88
           required: false
           name: include_projections
           in: query
@@ -31366,7 +32423,7 @@ paths:
           in: query
         - schema:
             type: string
-            enum: *a81
+            enum: *a82
           required: false
           name: order
           in: query
@@ -31429,25 +32486,25 @@ paths:
           in: query
         - schema:
             type: string
-            enum: *a82
+            enum: *a83
           required: false
           name: include_expired
           in: query
         - schema:
             type: string
-            enum: *a83
+            enum: *a84
           required: false
           name: expiring_soon
           in: query
         - schema:
             type: string
-            enum: *a84
+            enum: *a85
           required: false
           name: has_remaining
           in: query
         - schema:
             type: string
-            enum: *a85
+            enum: *a86
           required: false
           name: has_expiration
           in: query
@@ -31463,13 +32520,13 @@ paths:
           in: query
         - schema:
             type: string
-            enum: *a86
+            enum: *a87
           required: false
           name: group_by
           in: query
         - schema:
             type: string
-            enum: *a87
+            enum: *a88
           required: false
           name: include_projections
           in: query
@@ -31728,31 +32785,31 @@ paths:
           in: query
         - schema:
             type: string
-            enum: *a98
+            enum: *a99
           required: false
           name: order
           in: query
         - schema:
             type: string
-            enum: *a99
+            enum: *a100
           required: false
           name: include_items
           in: query
         - schema:
             type: string
-            enum: *a100
+            enum: *a101
           required: false
           name: include_client
           in: query
         - schema:
             type: string
-            enum: *a101
+            enum: *a102
           required: false
           name: include_billing_cycle
           in: query
         - schema:
             type: string
-            enum: *a102
+            enum: *a103
           required: false
           name: include_transactions
           in: query
@@ -31773,7 +32830,7 @@ paths:
           in: query
         - schema:
             type: string
-            enum: *a103
+            enum: *a104
           required: false
           name: format
           in: query
@@ -31896,31 +32953,31 @@ paths:
           in: query
         - schema:
             type: string
-            enum: *a98
+            enum: *a99
           required: false
           name: order
           in: query
         - schema:
             type: string
-            enum: *a99
+            enum: *a100
           required: false
           name: include_items
           in: query
         - schema:
             type: string
-            enum: *a100
+            enum: *a101
           required: false
           name: include_client
           in: query
         - schema:
             type: string
-            enum: *a101
+            enum: *a102
           required: false
           name: include_billing_cycle
           in: query
         - schema:
             type: string
-            enum: *a102
+            enum: *a103
           required: false
           name: include_transactions
           in: query
@@ -31941,7 +32998,7 @@ paths:
           in: query
         - schema:
             type: string
-            enum: *a103
+            enum: *a104
           required: false
           name: format
           in: query
@@ -32219,31 +33276,31 @@ paths:
           in: query
         - schema:
             type: string
-            enum: *a98
+            enum: *a99
           required: false
           name: order
           in: query
         - schema:
             type: string
-            enum: *a99
+            enum: *a100
           required: false
           name: include_items
           in: query
         - schema:
             type: string
-            enum: *a100
+            enum: *a101
           required: false
           name: include_client
           in: query
         - schema:
             type: string
-            enum: *a101
+            enum: *a102
           required: false
           name: include_billing_cycle
           in: query
         - schema:
             type: string
-            enum: *a102
+            enum: *a103
           required: false
           name: include_transactions
           in: query
@@ -32264,7 +33321,7 @@ paths:
           in: query
         - schema:
             type: string
-            enum: *a103
+            enum: *a104
           required: false
           name: format
           in: query
@@ -32697,31 +33754,31 @@ paths:
           in: query
         - schema:
             type: string
-            enum: *a98
+            enum: *a99
           required: false
           name: order
           in: query
         - schema:
             type: string
-            enum: *a99
+            enum: *a100
           required: false
           name: include_items
           in: query
         - schema:
             type: string
-            enum: *a100
+            enum: *a101
           required: false
           name: include_client
           in: query
         - schema:
             type: string
-            enum: *a101
+            enum: *a102
           required: false
           name: include_billing_cycle
           in: query
         - schema:
             type: string
-            enum: *a102
+            enum: *a103
           required: false
           name: include_transactions
           in: query
@@ -32742,7 +33799,7 @@ paths:
           in: query
         - schema:
             type: string
-            enum: *a103
+            enum: *a104
           required: false
           name: format
           in: query
@@ -32815,31 +33872,31 @@ paths:
           in: query
         - schema:
             type: string
-            enum: *a98
+            enum: *a99
           required: false
           name: order
           in: query
         - schema:
             type: string
-            enum: *a99
+            enum: *a100
           required: false
           name: include_items
           in: query
         - schema:
             type: string
-            enum: *a100
+            enum: *a101
           required: false
           name: include_client
           in: query
         - schema:
             type: string
-            enum: *a101
+            enum: *a102
           required: false
           name: include_billing_cycle
           in: query
         - schema:
             type: string
-            enum: *a102
+            enum: *a103
           required: false
           name: include_transactions
           in: query
@@ -32860,7 +33917,7 @@ paths:
           in: query
         - schema:
             type: string
-            enum: *a103
+            enum: *a104
           required: false
           name: format
           in: query
@@ -34878,13 +35935,13 @@ paths:
           in: query
         - schema:
             type: string
-            enum: *a104
+            enum: *a105
           required: false
           name: is_managed
           in: query
         - schema:
             type: string
-            enum: *a105
+            enum: *a106
           required: false
           name: is_security_relevant
           in: query
@@ -34974,7 +36031,7 @@ paths:
           in: query
         - schema:
             type: string
-            enum: *a106
+            enum: *a107
           required: false
           name: order
           in: query
@@ -35429,19 +36486,19 @@ paths:
       parameters:
         - schema:
             type: string
-            enum: *a107
+            enum: *a108
           required: false
           name: preview
           in: query
         - schema:
             type: string
-            enum: *a108
+            enum: *a109
           required: false
           name: createNew
           in: query
         - schema:
             type: string
-            enum: *a109
+            enum: *a110
           required: false
           name: updateExisting
           in: query
@@ -35502,7 +36559,7 @@ paths:
       parameters:
         - schema:
             type: string
-            enum: *a110
+            enum: *a111
           required: false
           name: preview
           in: query
@@ -36104,7 +37161,7 @@ paths:
       parameters:
         - schema:
             type: string
-            enum: *a111
+            enum: *a112
           required: false
           name: force
           in: query
@@ -40715,7 +41772,7 @@ paths:
           in: query
         - schema:
             type: string
-            enum: *a112
+            enum: *a113
           required: false
           name: active
           in: query
@@ -40731,7 +41788,7 @@ paths:
           in: query
         - schema:
             type: string
-            enum: *a113
+            enum: *a114
           required: false
           name: force_refresh
           in: query
@@ -41092,7 +42149,7 @@ paths:
           in: query
         - schema:
             type: string
-            enum: *a112
+            enum: *a113
           required: false
           name: active
           in: query
@@ -41108,7 +42165,7 @@ paths:
           in: query
         - schema:
             type: string
-            enum: *a113
+            enum: *a114
           required: false
           name: force_refresh
           in: query
@@ -41652,7 +42709,7 @@ paths:
           in: query
         - schema:
             type: string
-            enum: *a112
+            enum: *a113
           required: false
           name: active
           in: query
@@ -41668,7 +42725,7 @@ paths:
           in: query
         - schema:
             type: string
-            enum: *a113
+            enum: *a114
           required: false
           name: force_refresh
           in: query
@@ -41741,7 +42798,7 @@ paths:
           in: query
         - schema:
             type: string
-            enum: *a112
+            enum: *a113
           required: false
           name: active
           in: query
@@ -41757,7 +42814,7 @@ paths:
           in: query
         - schema:
             type: string
-            enum: *a113
+            enum: *a114
           required: false
           name: force_refresh
           in: query
@@ -42260,7 +43317,7 @@ paths:
           in: query
         - schema:
             type: string
-            enum: *a112
+            enum: *a113
           required: false
           name: active
           in: query
@@ -42276,7 +43333,7 @@ paths:
           in: query
         - schema:
             type: string
-            enum: *a113
+            enum: *a114
           required: false
           name: force_refresh
           in: query
@@ -42525,13 +43582,13 @@ paths:
           in: query
         - schema:
             type: string
-            enum: *a114
+            enum: *a115
           required: false
           name: status
           in: query
         - schema:
             type: string
-            enum: *a115
+            enum: *a116
           required: false
           name: operation_type
           in: query
@@ -42860,7 +43917,7 @@ paths:
           in: query
         - schema:
             type: string
-            enum: *a112
+            enum: *a113
           required: false
           name: active
           in: query
@@ -42876,7 +43933,7 @@ paths:
           in: query
         - schema:
             type: string
-            enum: *a113
+            enum: *a114
           required: false
           name: force_refresh
           in: query
@@ -43065,7 +44122,7 @@ paths:
           in: query
         - schema:
             type: string
-            enum: *a112
+            enum: *a113
           required: false
           name: active
           in: query
@@ -43081,7 +44138,7 @@ paths:
           in: query
         - schema:
             type: string
-            enum: *a113
+            enum: *a114
           required: false
           name: force_refresh
           in: query
@@ -43154,7 +44211,7 @@ paths:
           in: query
         - schema:
             type: string
-            enum: *a112
+            enum: *a113
           required: false
           name: active
           in: query
@@ -43170,7 +44227,7 @@ paths:
           in: query
         - schema:
             type: string
-            enum: *a113
+            enum: *a114
           required: false
           name: force_refresh
           in: query
@@ -43537,7 +44594,7 @@ paths:
           in: query
         - schema:
             type: string
-            enum: *a112
+            enum: *a113
           required: false
           name: active
           in: query
@@ -43553,7 +44610,7 @@ paths:
           in: query
         - schema:
             type: string
-            enum: *a113
+            enum: *a114
           required: false
           name: force_refresh
           in: query
@@ -44105,7 +45162,7 @@ paths:
           in: query
         - schema:
             type: string
-            enum: *a112
+            enum: *a113
           required: false
           name: active
           in: query
@@ -44121,7 +45178,7 @@ paths:
           in: query
         - schema:
             type: string
-            enum: *a113
+            enum: *a114
           required: false
           name: force_refresh
           in: query
@@ -44195,7 +45252,7 @@ paths:
           in: query
         - schema:
             type: string
-            enum: *a112
+            enum: *a113
           required: false
           name: active
           in: query
@@ -44211,7 +45268,7 @@ paths:
           in: query
         - schema:
             type: string
-            enum: *a113
+            enum: *a114
           required: false
           name: force_refresh
           in: query
@@ -44722,7 +45779,7 @@ paths:
           in: query
         - schema:
             type: string
-            enum: *a112
+            enum: *a113
           required: false
           name: active
           in: query
@@ -44738,7 +45795,7 @@ paths:
           in: query
         - schema:
             type: string
-            enum: *a113
+            enum: *a114
           required: false
           name: force_refresh
           in: query
@@ -44991,13 +46048,13 @@ paths:
           in: query
         - schema:
             type: string
-            enum: *a114
+            enum: *a115
           required: false
           name: status
           in: query
         - schema:
             type: string
-            enum: *a115
+            enum: *a116
           required: false
           name: operation_type
           in: query
@@ -45331,7 +46388,7 @@ paths:
           in: query
         - schema:
             type: string
-            enum: *a112
+            enum: *a113
           required: false
           name: active
           in: query
@@ -45347,7 +46404,7 @@ paths:
           in: query
         - schema:
             type: string
-            enum: *a113
+            enum: *a114
           required: false
           name: force_refresh
           in: query
@@ -45538,7 +46595,7 @@ paths:
           in: query
         - schema:
             type: string
-            enum: *a112
+            enum: *a113
           required: false
           name: active
           in: query
@@ -45554,7 +46611,7 @@ paths:
           in: query
         - schema:
             type: string
-            enum: *a113
+            enum: *a114
           required: false
           name: force_refresh
           in: query
@@ -46145,7 +47202,7 @@ paths:
           in: query
         - schema:
             type: string
-            enum: *a116
+            enum: *a117
             description: Result ordering. "relevance" (default) ranks by full-text score;
               "recent" orders by last update.
           required: false
@@ -46520,7 +47577,7 @@ paths:
           in: query
         - schema:
             type: string
-            enum: *a117
+            enum: *a118
           required: false
           name: order
           in: query
@@ -46572,13 +47629,13 @@ paths:
           in: query
         - schema:
             type: string
-            enum: *a118
+            enum: *a119
           required: false
           name: is_parent
           in: query
         - schema:
             type: string
-            enum: *a119
+            enum: *a120
           required: false
           name: is_child
           in: query
@@ -46589,7 +47646,7 @@ paths:
           in: query
         - schema:
             type: string
-            enum: *a120
+            enum: *a121
           required: false
           name: active
           in: query
@@ -46605,19 +47662,19 @@ paths:
           in: query
         - schema:
             type: string
-            enum: *a121
+            enum: *a122
           required: false
           name: sort_order
           in: query
         - schema:
             type: string
-            enum: *a122
+            enum: *a123
           required: false
           name: include_hierarchy
           in: query
         - schema:
             type: string
-            enum: *a123
+            enum: *a124
           required: false
           name: category_type
           in: query
@@ -47073,7 +48130,7 @@ paths:
           in: query
         - schema:
             type: string
-            enum: *a124
+            enum: *a125
           required: false
           name: category_type
           in: query
@@ -47085,7 +48142,7 @@ paths:
           in: query
         - schema:
             type: string
-            enum: *a125
+            enum: *a126
           required: false
           name: include_inactive
           in: query
@@ -47160,7 +48217,7 @@ paths:
       parameters:
         - schema:
             type: string
-            enum: *a126
+            enum: *a127
           required: false
           name: category_type
           in: query
@@ -47184,7 +48241,7 @@ paths:
           in: query
         - schema:
             type: string
-            enum: *a127
+            enum: *a128
           required: false
           name: include_usage
           in: query
@@ -47270,7 +48327,7 @@ paths:
         this endpoint to inspect existing service catalog records and to gather
         prerequisite IDs such as custom_service_type_id and category_id before
         creating a new service.
-      tags: &a128
+      tags: &a129
         - Services
         - Service Catalog
       security:
@@ -47346,7 +48403,7 @@ paths:
           in: query
         - schema:
             type: string
-            enum: &a129
+            enum: &a130
               - fixed
               - hourly
               - usage
@@ -47394,7 +48451,7 @@ paths:
         with GET /api/v1/service-types and category_id with GET
         /api/v1/categories/service before calling this endpoint. Use this
         endpoint for fixed, hourly, or usage-based service offerings.
-      tags: *a128
+      tags: *a129
       security:
         - ApiKeyAuth: []
       extensions:
@@ -47423,7 +48480,7 @@ paths:
                   format: uuid
                 billing_method:
                   type: string
-                  enum: *a129
+                  enum: *a130
                 default_rate:
                   type: number
                   minimum: 0
@@ -47485,7 +48542,7 @@ paths:
     get:
       summary: Get service
       description: Returns a single service catalog entry by UUID.
-      tags: *a128
+      tags: *a129
       security:
         - ApiKeyAuth: []
       extensions:
@@ -47534,7 +48591,7 @@ paths:
     put:
       summary: Update service
       description: Updates a service catalog entry by UUID.
-      tags: *a128
+      tags: *a129
       security:
         - ApiKeyAuth: []
       extensions:
@@ -47572,7 +48629,7 @@ paths:
                   format: uuid
                 billing_method:
                   type: string
-                  enum: *a129
+                  enum: *a130
                 default_rate:
                   type: number
                   minimum: 0
@@ -47633,7 +48690,7 @@ paths:
     delete:
       summary: Delete service
       description: Deletes a service catalog entry by UUID.
-      tags: *a128
+      tags: *a129
       security:
         - ApiKeyAuth: []
       extensions:
@@ -47682,7 +48739,7 @@ paths:
         this endpoint to inspect existing product catalog records and to gather
         prerequisite IDs such as custom_service_type_id and category_id before
         creating a new product.
-      tags: &a130
+      tags: &a131
         - Products
         - Service Catalog
       security:
@@ -47793,7 +48850,7 @@ paths:
         /api/v1/categories/service before calling this endpoint. Products are
         catalog entries with item_kind product and always use billing_method
         usage.
-      tags: *a130
+      tags: *a131
       security:
         - ApiKeyAuth: []
       extensions:
@@ -47822,7 +48879,7 @@ paths:
                   format: uuid
                 billing_method:
                   type: string
-                  enum: &a131
+                  enum: &a132
                     - usage
                   default: usage
                 default_rate:
@@ -47833,7 +48890,6 @@ paths:
                   type: string
                   minLength: 3
                   maxLength: 3
-                  default: USD
                 unit_of_measure:
                   type: string
                   minLength: 1
@@ -47875,7 +48931,6 @@ paths:
                       maxLength: 3
                     - type: "null"
                     - type: "null"
-                  default: USD
                 vendor:
                   anyOf:
                     - type: string
@@ -47961,7 +49016,7 @@ paths:
     get:
       summary: Get product
       description: Returns a single product catalog entry by UUID.
-      tags: *a130
+      tags: *a131
       security:
         - ApiKeyAuth: []
       extensions:
@@ -48010,7 +49065,7 @@ paths:
     put:
       summary: Update product
       description: Updates a product catalog entry by UUID.
-      tags: *a130
+      tags: *a131
       security:
         - ApiKeyAuth: []
       extensions:
@@ -48048,7 +49103,7 @@ paths:
                   format: uuid
                 billing_method:
                   type: string
-                  enum: *a131
+                  enum: *a132
                   default: usage
                 default_rate:
                   type: number
@@ -48058,7 +49113,6 @@ paths:
                   type: string
                   minLength: 3
                   maxLength: 3
-                  default: USD
                 unit_of_measure:
                   type: string
                   minLength: 1
@@ -48100,7 +49154,6 @@ paths:
                       maxLength: 3
                     - type: "null"
                     - type: "null"
-                  default: USD
                 vendor:
                   anyOf:
                     - type: string
@@ -48187,7 +49240,7 @@ paths:
     delete:
       summary: Delete product
       description: Deletes a product catalog entry by UUID.
-      tags: *a130
+      tags: *a131
       security:
         - ApiKeyAuth: []
       extensions:
@@ -48235,7 +49288,7 @@ paths:
       description: Returns tenant service types. Use this endpoint to resolve
         custom_service_type_id before creating or updating services and products
         in the service catalog.
-      tags: &a132
+      tags: &a133
         - Service Types
         - Service Catalog
       security:
@@ -48296,7 +49349,7 @@ paths:
     get:
       summary: Get service type
       description: Returns a single tenant service type by UUID.
-      tags: *a132
+      tags: *a133
       security:
         - ApiKeyAuth: []
       extensions:
@@ -48377,7 +49430,7 @@ paths:
           in: query
         - schema:
             type: string
-            enum: *a133
+            enum: *a134
           required: false
           name: order
           in: query
@@ -48398,25 +49451,25 @@ paths:
           in: query
         - schema:
             type: string
-            enum: *a134
+            enum: *a135
           required: false
           name: is_active
           in: query
         - schema:
             type: string
-            enum: *a135
+            enum: *a136
           required: false
           name: is_test_mode
           in: query
         - schema:
             type: string
-            enum: *a136
+            enum: *a137
           required: false
           name: payload_format
           in: query
         - schema:
             type: string
-            enum: *a137
+            enum: *a138
           required: false
           name: has_failures
           in: query
@@ -49447,7 +50500,7 @@ paths:
           in: query
         - schema:
             type: string
-            enum: *a138
+            enum: *a139
           required: false
           name: status
           in: query
@@ -50590,41 +51643,6 @@ paths:
               schema:
                 $ref: "#/components/schemas/WorkflowV1MissingRouteResponse"
   /api/v1/workflows/tasks:
-    get:
-      summary: List workflow tasks (route inventory only)
-      description: "This operation is currently present only in generated route
-        inventory. No corresponding Next.js handler exists under
-        server/src/app/api/v1/workflows in this worktree. Runtime behavior is
-        middleware-dependent: missing/invalid x-api-key can return 401 before
-        routing; with middleware requirements satisfied, Next.js returns
-        not-found for the absent handler. Existing workflow APIs in this
-        codebase are implemented under /api/workflow-definitions,
-        /api/workflow-runs, and /api/workflow/events rather than
-        /api/v1/workflows paths."
-      tags:
-        - Workflows v1
-      security:
-        - ApiKeyAuth: []
-      extensions:
-        x-route-inventory-only: true
-        x-route-file-missing: server/src/app/api/v1/workflows/**/route.ts
-        x-family-status: missing-handler
-      x-alga-products:
-        - psa
-      responses:
-        "401":
-          description: x-api-key missing/invalid at middleware.
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/WorkflowV1MissingApiError"
-        "404":
-          description: No route handler exists for this inventory-only /api/v1/workflows
-            path.
-          content:
-            text/html:
-              schema:
-                $ref: "#/components/schemas/WorkflowV1MissingRouteResponse"
     post:
       summary: Create workflow task (route inventory only)
       description: "This operation is currently present only in generated route
@@ -50660,6 +51678,78 @@ paths:
             text/html:
               schema:
                 $ref: "#/components/schemas/WorkflowV1MissingRouteResponse"
+    get:
+      summary: List workflow tasks
+      description: Returns the authenticated caller's workflow task inbox (tasks
+        assigned to them directly or via a role), paginated. Items are summary
+        rows without `formSchema`; fetch a single task to obtain its form
+        schema. EE-only — on the Community build this returns an empty page.
+      tags:
+        - Workflow Tasks v1
+      security:
+        - ApiKeyAuth: []
+      extensions:
+        x-tenant-scoped: true
+        x-auth-mechanism: NextAuth session, falling back to x-api-key
+          (resolveWorkflowTaskAuthContext)
+        x-edition-behavior: EE-only feature; CE returns an empty page (list) or 404
+          (detail/actions).
+      x-alga-products:
+        - psa
+      parameters:
+        - schema:
+            type: string
+            description: Comma-separated WorkflowTaskStatus values (pending, claimed,
+              completed, canceled, expired). Omit for the open inbox (pending +
+              claimed).
+          required: false
+          description: Comma-separated WorkflowTaskStatus values (pending, claimed,
+            completed, canceled, expired). Omit for the open inbox (pending +
+            claimed).
+          name: status
+          in: query
+        - schema:
+            type: integer
+            minimum: 1
+            description: 1-based page number (default 1).
+          required: false
+          description: 1-based page number (default 1).
+          name: page
+          in: query
+        - schema:
+            type: integer
+            minimum: 1
+            maximum: 100
+            description: Items per page, max 100 (default 25).
+          required: false
+          description: Items per page, max 100 (default 25).
+          name: pageSize
+          in: query
+      responses:
+        "200":
+          description: Paginated workflow task inbox.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/WorkflowTaskListResponseV1"
+        "400":
+          description: Invalid query parameters.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/WorkflowTasksApiErrorV1"
+        "401":
+          description: Authentication required (no session and no/invalid x-api-key).
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/WorkflowTasksApiErrorV1"
+        "500":
+          description: Unexpected failure resolving the task inbox.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/WorkflowTasksApiErrorV1"
   /api/v1/workflows/tasks/bulk-assign:
     post:
       summary: Bulk assign workflow tasks (route inventory only)
@@ -50697,41 +51787,6 @@ paths:
               schema:
                 $ref: "#/components/schemas/WorkflowV1MissingRouteResponse"
   /api/v1/workflows/tasks/{id}:
-    get:
-      summary: Get workflow task by id (route inventory only)
-      description: "This operation is currently present only in generated route
-        inventory. No corresponding Next.js handler exists under
-        server/src/app/api/v1/workflows in this worktree. Runtime behavior is
-        middleware-dependent: missing/invalid x-api-key can return 401 before
-        routing; with middleware requirements satisfied, Next.js returns
-        not-found for the absent handler. Existing workflow APIs in this
-        codebase are implemented under /api/workflow-definitions,
-        /api/workflow-runs, and /api/workflow/events rather than
-        /api/v1/workflows paths."
-      tags:
-        - Workflows v1
-      security:
-        - ApiKeyAuth: []
-      extensions:
-        x-route-inventory-only: true
-        x-route-file-missing: server/src/app/api/v1/workflows/**/route.ts
-        x-family-status: missing-handler
-      x-alga-products:
-        - psa
-      responses:
-        "401":
-          description: x-api-key missing/invalid at middleware.
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/WorkflowV1MissingApiError"
-        "404":
-          description: No route handler exists for this inventory-only /api/v1/workflows
-            path.
-          content:
-            text/html:
-              schema:
-                $ref: "#/components/schemas/WorkflowV1MissingRouteResponse"
     put:
       summary: Update workflow task (route inventory only)
       description: "This operation is currently present only in generated route
@@ -50767,78 +51822,57 @@ paths:
             text/html:
               schema:
                 $ref: "#/components/schemas/WorkflowV1MissingRouteResponse"
-  /api/v1/workflows/tasks/{id}/claim:
-    post:
-      summary: Claim workflow task (route inventory only)
-      description: "This operation is currently present only in generated route
-        inventory. No corresponding Next.js handler exists under
-        server/src/app/api/v1/workflows in this worktree. Runtime behavior is
-        middleware-dependent: missing/invalid x-api-key can return 401 before
-        routing; with middleware requirements satisfied, Next.js returns
-        not-found for the absent handler. Existing workflow APIs in this
-        codebase are implemented under /api/workflow-definitions,
-        /api/workflow-runs, and /api/workflow/events rather than
-        /api/v1/workflows paths."
+    get:
+      summary: Get workflow task
+      description: Returns full detail for a single workflow task, including
+        `formSchema` ({ jsonSchema, uiSchema?, defaultValues? }) so a client can
+        classify the form as simple (native completion) vs complex (web
+        deep-link). EE-only — on the Community build this returns 404.
       tags:
-        - Workflows v1
+        - Workflow Tasks v1
       security:
         - ApiKeyAuth: []
       extensions:
-        x-route-inventory-only: true
-        x-route-file-missing: server/src/app/api/v1/workflows/**/route.ts
-        x-family-status: missing-handler
+        x-tenant-scoped: true
+        x-auth-mechanism: NextAuth session, falling back to x-api-key
+          (resolveWorkflowTaskAuthContext)
+        x-edition-behavior: EE-only feature; CE returns an empty page (list) or 404
+          (detail/actions).
       x-alga-products:
         - psa
+      parameters:
+        - schema:
+            type: string
+            description: Workflow task identifier (taskId).
+          required: true
+          description: Workflow task identifier (taskId).
+          name: id
+          in: path
       responses:
-        "401":
-          description: x-api-key missing/invalid at middleware.
+        "200":
+          description: Workflow task detail including the resolved form schema.
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/WorkflowV1MissingApiError"
-        "404":
-          description: No route handler exists for this inventory-only /api/v1/workflows
-            path.
-          content:
-            text/html:
-              schema:
-                $ref: "#/components/schemas/WorkflowV1MissingRouteResponse"
-  /api/v1/workflows/tasks/{id}/complete:
-    post:
-      summary: Complete workflow task (route inventory only)
-      description: "This operation is currently present only in generated route
-        inventory. No corresponding Next.js handler exists under
-        server/src/app/api/v1/workflows in this worktree. Runtime behavior is
-        middleware-dependent: missing/invalid x-api-key can return 401 before
-        routing; with middleware requirements satisfied, Next.js returns
-        not-found for the absent handler. Existing workflow APIs in this
-        codebase are implemented under /api/workflow-definitions,
-        /api/workflow-runs, and /api/workflow/events rather than
-        /api/v1/workflows paths."
-      tags:
-        - Workflows v1
-      security:
-        - ApiKeyAuth: []
-      extensions:
-        x-route-inventory-only: true
-        x-route-file-missing: server/src/app/api/v1/workflows/**/route.ts
-        x-family-status: missing-handler
-      x-alga-products:
-        - psa
-      responses:
+                $ref: "#/components/schemas/WorkflowTaskDetailResponseV1"
         "401":
-          description: x-api-key missing/invalid at middleware.
+          description: Authentication required.
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/WorkflowV1MissingApiError"
+                $ref: "#/components/schemas/WorkflowTasksApiErrorV1"
         "404":
-          description: No route handler exists for this inventory-only /api/v1/workflows
-            path.
+          description: Task not found (or workflow tasks unavailable on this build).
           content:
-            text/html:
+            application/json:
               schema:
-                $ref: "#/components/schemas/WorkflowV1MissingRouteResponse"
+                $ref: "#/components/schemas/WorkflowTasksApiErrorV1"
+        "500":
+          description: Unexpected failure resolving the task.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/WorkflowTasksApiErrorV1"
   /api/v1/workflows/templates:
     get:
       summary: List workflow templates (route inventory only)
@@ -51122,6 +52156,856 @@ paths:
             text/html:
               schema:
                 $ref: "#/components/schemas/WorkflowV1MissingRouteResponse"
+  /api/v1/workflows/tasks/{id}/claim:
+    post:
+      summary: Claim workflow task
+      description: Claims a pending task for the caller. No request body. EE-only — on
+        the Community build this returns 404.
+      tags:
+        - Workflow Tasks v1
+      security:
+        - ApiKeyAuth: []
+      extensions:
+        x-tenant-scoped: true
+        x-auth-mechanism: NextAuth session, falling back to x-api-key
+          (resolveWorkflowTaskAuthContext)
+        x-edition-behavior: EE-only feature; CE returns an empty page (list) or 404
+          (detail/actions).
+      x-alga-products:
+        - psa
+      parameters:
+        - schema:
+            type: string
+            description: Workflow task identifier (taskId).
+          required: true
+          description: Workflow task identifier (taskId).
+          name: id
+          in: path
+      responses:
+        "200":
+          description: Task claimed.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/WorkflowTaskActionResponseV1"
+        "401":
+          description: Authentication required.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/WorkflowTasksApiErrorV1"
+        "404":
+          description: Task not found (or workflow tasks unavailable on this build).
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/WorkflowTasksApiErrorV1"
+        "409":
+          description: Task already claimed by another user or not in a claimable state.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/WorkflowTasksApiErrorV1"
+        "500":
+          description: Unexpected failure claiming the task.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/WorkflowTasksApiErrorV1"
+  /api/v1/workflows/tasks/{id}/unclaim:
+    post:
+      summary: Unclaim workflow task
+      description: Releases a task the caller has claimed, returning it to the pending
+        pool. No request body. EE-only — on the Community build this returns
+        404.
+      tags:
+        - Workflow Tasks v1
+      security:
+        - ApiKeyAuth: []
+      extensions:
+        x-tenant-scoped: true
+        x-auth-mechanism: NextAuth session, falling back to x-api-key
+          (resolveWorkflowTaskAuthContext)
+        x-edition-behavior: EE-only feature; CE returns an empty page (list) or 404
+          (detail/actions).
+      x-alga-products:
+        - psa
+      parameters:
+        - schema:
+            type: string
+            description: Workflow task identifier (taskId).
+          required: true
+          description: Workflow task identifier (taskId).
+          name: id
+          in: path
+      responses:
+        "200":
+          description: Task released.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/WorkflowTaskActionResponseV1"
+        "401":
+          description: Authentication required.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/WorkflowTasksApiErrorV1"
+        "404":
+          description: Task not found (or workflow tasks unavailable on this build).
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/WorkflowTasksApiErrorV1"
+        "409":
+          description: Task is not claimed by the caller.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/WorkflowTasksApiErrorV1"
+        "500":
+          description: Unexpected failure releasing the task.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/WorkflowTasksApiErrorV1"
+  /api/v1/workflows/tasks/{id}/complete:
+    post:
+      summary: Complete workflow task
+      description: Submits the task's form payload and completes it. The form data is
+        validated server-side against the task's JSON Schema; validation
+        failures return 400 with the schema errors in `error.details`. EE-only —
+        on the Community build this returns 404.
+      tags:
+        - Workflow Tasks v1
+      security:
+        - ApiKeyAuth: []
+      extensions:
+        x-tenant-scoped: true
+        x-auth-mechanism: NextAuth session, falling back to x-api-key
+          (resolveWorkflowTaskAuthContext)
+        x-edition-behavior: EE-only feature; CE returns an empty page (list) or 404
+          (detail/actions).
+      x-alga-products:
+        - psa
+      parameters:
+        - schema:
+            type: string
+            description: Workflow task identifier (taskId).
+          required: true
+          description: Workflow task identifier (taskId).
+          name: id
+          in: path
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/CompleteWorkflowTaskBodyV1"
+      responses:
+        "200":
+          description: Task completed.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/WorkflowTaskActionResponseV1"
+        "400":
+          description: Form validation failed; schema errors are returned in
+            `error.details`.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/WorkflowTasksApiErrorV1"
+        "401":
+          description: Authentication required.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/WorkflowTasksApiErrorV1"
+        "404":
+          description: Task not found (or workflow tasks unavailable on this build).
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/WorkflowTasksApiErrorV1"
+        "409":
+          description: Task is not in a completable state for the caller.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/WorkflowTasksApiErrorV1"
+        "500":
+          description: Unexpected failure completing the task.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/WorkflowTasksApiErrorV1"
+  /api/v1/activities:
+    get:
+      summary: List user activities
+      description: Returns the authenticated caller's unified activity list — a
+        fan-out across tickets, project tasks, schedule entries, ad-hoc items,
+        workflow tasks, time entries and notifications. Filter by activity
+        type(s), open/closed status, priority, due-date window, free-text search
+        and a date window; sort via `sortBy`/`sortDirection`. By default the
+        result is paginated (ActivityListResponseV1). When `groupBy` is supplied
+        the result is instead grouped server-side into ordered, counted buckets
+        (ActivityGroupedResponseV1) and `page`/`pageSize` are ignored.
+      tags:
+        - Activities v1
+      security:
+        - ApiKeyAuth: []
+      extensions:
+        x-tenant-scoped: true
+        x-auth-mechanism: NextAuth session, falling back to x-api-key
+          (resolveActivityAuthContext)
+        x-response-when-grouped: "#/components/schemas/ActivityGroupedResponseV1"
+      x-alga-products:
+        - psa
+      parameters:
+        - schema:
+            type: string
+            description: Comma-separated ActivityType values (e.g. "ticket,schedule"). Omit
+              for all types.
+          required: false
+          description: Comma-separated ActivityType values (e.g. "ticket,schedule"). Omit
+            for all types.
+          name: type
+          in: query
+        - schema:
+            type: string
+            enum: *a140
+            description: Open/closed filter. `open`→active only, `closed`→closed, `all`→no
+              filter (default).
+          required: false
+          description: Open/closed filter. `open`→active only, `closed`→closed, `all`→no
+            filter (default).
+          name: status
+          in: query
+        - schema:
+            type: string
+            description: Free-text search across activity titles/descriptions.
+          required: false
+          description: Free-text search across activity titles/descriptions.
+          name: search
+          in: query
+        - schema:
+            type: string
+            format: date-time
+            description: ISO 8601 lower bound of the schedule/time-entry/notification
+              window.
+          required: false
+          description: ISO 8601 lower bound of the schedule/time-entry/notification window.
+          name: dateStart
+          in: query
+        - schema:
+            type: string
+            format: date-time
+            description: ISO 8601 upper bound of the window.
+          required: false
+          description: ISO 8601 upper bound of the window.
+          name: dateEnd
+          in: query
+        - schema:
+            type: string
+            description: Comma-separated normalized ActivityPriority buckets (e.g.
+              "high,medium"). Lossy for custom schemes; prefer `priorityIds`.
+          required: false
+          description: Comma-separated normalized ActivityPriority buckets (e.g.
+            "high,medium"). Lossy for custom schemes; prefer `priorityIds`.
+          name: priority
+          in: query
+        - schema:
+            type: string
+            description: Comma-separated exact priority IDs (the tenant's real per-type
+              priorities). Applies to ticket/project-task activities.
+          required: false
+          description: Comma-separated exact priority IDs (the tenant's real per-type
+            priorities). Applies to ticket/project-task activities.
+          name: priorityIds
+          in: query
+        - schema:
+            type: string
+            format: date-time
+            description: ISO 8601 lower bound of the due-date filter (independent of the
+              schedule window).
+          required: false
+          description: ISO 8601 lower bound of the due-date filter (independent of the
+            schedule window).
+          name: dueDateStart
+          in: query
+        - schema:
+            type: string
+            format: date-time
+            description: ISO 8601 upper bound of the due-date filter.
+          required: false
+          description: ISO 8601 upper bound of the due-date filter.
+          name: dueDateEnd
+          in: query
+        - schema:
+            type: string
+            format: date-time
+            description: ISO 8601 lower bound of the created-date ("date entered") filter.
+              Applies to every activity type.
+          required: false
+          description: ISO 8601 lower bound of the created-date ("date entered") filter.
+            Applies to every activity type.
+          name: createdAtStart
+          in: query
+        - schema:
+            type: string
+            format: date-time
+            description: ISO 8601 upper bound of the created-date ("date entered") filter.
+          required: false
+          description: ISO 8601 upper bound of the created-date ("date entered") filter.
+          name: createdAtEnd
+          in: query
+        - schema:
+            type: string
+            enum: *a141
+            description: Sort column. Omit for the default sort (priority high→low, then due
+              date ascending).
+          required: false
+          description: Sort column. Omit for the default sort (priority high→low, then due
+            date ascending).
+          name: sortBy
+          in: query
+        - schema:
+            type: string
+            enum: *a142
+            description: Sort direction for `sortBy` (default asc). Ignored when `sortBy` is
+              omitted.
+          required: false
+          description: Sort direction for `sortBy` (default asc). Ignored when `sortBy` is
+            omitted.
+          name: sortDirection
+          in: query
+        - schema:
+            type: string
+            enum: *a143
+            description: When set, the response is grouped by this dimension
+              (ActivityGroupedResponseV1) instead of the paginated list;
+              `page`/`pageSize` are ignored. `priority` groups by the real
+              per-tenant priority name (not the normalized bucket), so it is
+              only meaningful when scoped to a single prioritized type.
+          required: false
+          description: When set, the response is grouped by this dimension
+            (ActivityGroupedResponseV1) instead of the paginated list;
+            `page`/`pageSize` are ignored. `priority` groups by the real
+            per-tenant priority name (not the normalized bucket), so it is only
+            meaningful when scoped to a single prioritized type.
+          name: groupBy
+          in: query
+        - schema:
+            type: integer
+            minimum: 1
+            description: 1-based page number (default 1). Ignored when `groupBy` is set.
+          required: false
+          description: 1-based page number (default 1). Ignored when `groupBy` is set.
+          name: page
+          in: query
+        - schema:
+            type: integer
+            minimum: 1
+            maximum: 100
+            description: Items per page, max 100 (default 25). Ignored when `groupBy` is
+              set.
+          required: false
+          description: Items per page, max 100 (default 25). Ignored when `groupBy` is set.
+          name: pageSize
+          in: query
+      responses:
+        "200":
+          description: Paginated activity list, or grouped buckets when `groupBy` is set.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ActivityListResponseV1"
+        "400":
+          description: Invalid query parameters.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ActivitiesApiErrorV1"
+        "401":
+          description: Authentication required (no session and no/invalid x-api-key).
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ActivitiesApiErrorV1"
+        "403":
+          description: Permission denied for one of the underlying activity sources.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ActivitiesApiErrorV1"
+        "500":
+          description: Unexpected failure resolving activities.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ActivitiesApiErrorV1"
+  /api/v1/activities/ad-hoc:
+    post:
+      summary: Create ad-hoc activity
+      description: Creates a personal, self-assigned ad-hoc to-do rendered as a
+        schedule activity. Times are optional; when both are supplied the end
+        must be after the start. Gated by `user_schedule:read`.
+      tags:
+        - Activities v1
+      security:
+        - ApiKeyAuth: []
+      extensions:
+        x-tenant-scoped: true
+        x-auth-mechanism: NextAuth session, falling back to x-api-key
+          (resolveActivityAuthContext)
+      x-alga-products:
+        - psa
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/CreateAdHocActivityBodyV1"
+      responses:
+        "201":
+          description: Ad-hoc activity created.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/AdHocActivityResponseV1"
+        "400":
+          description: Invalid request body (e.g. missing title or end before start).
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ActivitiesApiErrorV1"
+        "401":
+          description: Authentication required.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ActivitiesApiErrorV1"
+        "403":
+          description: Permission denied (user_schedule:read).
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ActivitiesApiErrorV1"
+        "500":
+          description: Unexpected failure creating the ad-hoc activity.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ActivitiesApiErrorV1"
+  /api/v1/activities/ad-hoc/{id}:
+    patch:
+      summary: Update ad-hoc activity
+      description: "Updates an ad-hoc item's title, notes or optional times. Omitted
+        fields are left unchanged; `notes: null` clears the field. Requires the
+        caller to be an assignee, or hold `user_schedule:update` /
+        `user_schedule:read_all`."
+      tags:
+        - Activities v1
+      security:
+        - ApiKeyAuth: []
+      extensions:
+        x-tenant-scoped: true
+        x-auth-mechanism: NextAuth session, falling back to x-api-key
+          (resolveActivityAuthContext)
+      x-alga-products:
+        - psa
+      parameters:
+        - schema:
+            type: string
+            description: Ad-hoc activity identifier (the backing schedule entry id).
+          required: true
+          description: Ad-hoc activity identifier (the backing schedule entry id).
+          name: id
+          in: path
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/UpdateAdHocActivityBodyV1"
+      responses:
+        "200":
+          description: Updated ad-hoc activity.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/AdHocActivityResponseV1"
+        "400":
+          description: Invalid request body (e.g. end before start).
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ActivitiesApiErrorV1"
+        "401":
+          description: Authentication required.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ActivitiesApiErrorV1"
+        "403":
+          description: Permission denied.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ActivitiesApiErrorV1"
+        "404":
+          description: Ad-hoc activity not found.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ActivitiesApiErrorV1"
+        "500":
+          description: Unexpected failure updating the ad-hoc activity.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ActivitiesApiErrorV1"
+    delete:
+      summary: Delete ad-hoc activity
+      description: Permanently deletes an ad-hoc item. Requires the caller to be an
+        assignee, or hold `user_schedule:update` / `user_schedule:read_all`.
+      tags:
+        - Activities v1
+      security:
+        - ApiKeyAuth: []
+      extensions:
+        x-tenant-scoped: true
+        x-auth-mechanism: NextAuth session, falling back to x-api-key
+          (resolveActivityAuthContext)
+      x-alga-products:
+        - psa
+      parameters:
+        - schema:
+            type: string
+            description: Ad-hoc activity identifier (the backing schedule entry id).
+          required: true
+          description: Ad-hoc activity identifier (the backing schedule entry id).
+          name: id
+          in: path
+      responses:
+        "204":
+          description: Ad-hoc activity deleted; no content.
+        "401":
+          description: Authentication required.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ActivitiesApiErrorV1"
+        "403":
+          description: Permission denied.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ActivitiesApiErrorV1"
+        "404":
+          description: Ad-hoc activity not found.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ActivitiesApiErrorV1"
+        "500":
+          description: Unexpected failure deleting the ad-hoc activity.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ActivitiesApiErrorV1"
+  /api/v1/activities/ad-hoc/{id}/done:
+    post:
+      summary: Toggle ad-hoc activity done
+      description: "Marks an ad-hoc item done/undone. `done: true` sets status to
+        closed; `done: false` reopens it (status scheduled). Requires the caller
+        to be an assignee, or hold `user_schedule:update` /
+        `user_schedule:read_all`."
+      tags:
+        - Activities v1
+      security:
+        - ApiKeyAuth: []
+      extensions:
+        x-tenant-scoped: true
+        x-auth-mechanism: NextAuth session, falling back to x-api-key
+          (resolveActivityAuthContext)
+      x-alga-products:
+        - psa
+      parameters:
+        - schema:
+            type: string
+            description: Ad-hoc activity identifier (the backing schedule entry id).
+          required: true
+          description: Ad-hoc activity identifier (the backing schedule entry id).
+          name: id
+          in: path
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/SetAdHocActivityDoneBodyV1"
+      responses:
+        "200":
+          description: Updated ad-hoc activity.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/AdHocActivityResponseV1"
+        "400":
+          description: Invalid request body (e.g. missing `done`).
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ActivitiesApiErrorV1"
+        "401":
+          description: Authentication required.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ActivitiesApiErrorV1"
+        "403":
+          description: Permission denied.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ActivitiesApiErrorV1"
+        "404":
+          description: Ad-hoc activity not found.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ActivitiesApiErrorV1"
+        "500":
+          description: Unexpected failure updating the ad-hoc activity.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ActivitiesApiErrorV1"
+  /api/v1/activities/groups:
+    get:
+      summary: List custom activity groups
+      description: "Returns the caller's saved custom activity groups (created and
+        ordered in the web app), each with its ordered item references.
+        Read-only: clients bucket the unified activity list into these groups
+        for a \"My groups\" view. Pass `targetUserId` to read another user's
+        groups (requires `user_schedule:update` / `user_schedule:read_all`).
+        Membership and ordering are changed via the `/groups/items` endpoints."
+      tags:
+        - Activities v1
+      security:
+        - ApiKeyAuth: []
+      extensions:
+        x-tenant-scoped: true
+        x-auth-mechanism: NextAuth session, falling back to x-api-key
+          (resolveActivityAuthContext)
+      x-alga-products:
+        - psa
+      parameters:
+        - schema:
+            type: string
+            description: Another internal user whose groups to read (requires elevated
+              schedule permission). Omit for self.
+          required: false
+          description: Another internal user whose groups to read (requires elevated
+            schedule permission). Omit for self.
+          name: targetUserId
+          in: query
+      responses:
+        "200":
+          description: The caller's custom activity groups.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/CustomActivityGroupsResponseV1"
+        "401":
+          description: Authentication required.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ActivitiesApiErrorV1"
+        "403":
+          description: Permission denied (reading another user's groups).
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ActivitiesApiErrorV1"
+        "500":
+          description: Unexpected failure resolving groups.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ActivitiesApiErrorV1"
+  /api/v1/activities/groups/items:
+    post:
+      summary: Move an activity into a group
+      description: Moves an activity into one of the caller's custom groups at the
+        given position (`sortOrder`), removing it from any other group first so
+        an activity belongs to at most one group. Rows at/after the index are
+        shifted to keep ordering dense. Scoped to the caller's own groups; gated
+        by `user_schedule:read`.
+      tags:
+        - Activities v1
+      security:
+        - ApiKeyAuth: []
+      extensions:
+        x-tenant-scoped: true
+        x-auth-mechanism: NextAuth session, falling back to x-api-key
+          (resolveActivityAuthContext)
+      x-alga-products:
+        - psa
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/MoveActivityToGroupBodyV1"
+      responses:
+        "200":
+          description: Activity moved.
+        "400":
+          description: Invalid request body.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ActivitiesApiErrorV1"
+        "401":
+          description: Authentication required.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ActivitiesApiErrorV1"
+        "403":
+          description: Permission denied (user_schedule:read).
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ActivitiesApiErrorV1"
+        "404":
+          description: Target group not found.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ActivitiesApiErrorV1"
+        "500":
+          description: Unexpected failure moving the activity.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ActivitiesApiErrorV1"
+    delete:
+      summary: Remove an activity from its group
+      description: Removes an activity from all of the caller's custom groups (makes
+        it "ungrouped"). No-op when the activity is not in any group. Scoped to
+        the caller's own groups; gated by `user_schedule:read`.
+      tags:
+        - Activities v1
+      security:
+        - ApiKeyAuth: []
+      extensions:
+        x-tenant-scoped: true
+        x-auth-mechanism: NextAuth session, falling back to x-api-key
+          (resolveActivityAuthContext)
+      x-alga-products:
+        - psa
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/RemoveActivityFromGroupBodyV1"
+      responses:
+        "200":
+          description: Activity removed from its group.
+        "400":
+          description: Invalid request body.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ActivitiesApiErrorV1"
+        "401":
+          description: Authentication required.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ActivitiesApiErrorV1"
+        "403":
+          description: Permission denied (user_schedule:read).
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ActivitiesApiErrorV1"
+        "500":
+          description: Unexpected failure removing the activity.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ActivitiesApiErrorV1"
+  /api/v1/activities/groups/{groupId}/items:
+    patch:
+      summary: Reorder activities within a group
+      description: Persists the full ordered membership of a group after a
+        drag-to-reorder. Pass every item as it should appear; each row's
+        `sortOrder` is set to its position. Scoped to the caller's own groups;
+        gated by `user_schedule:read`.
+      tags:
+        - Activities v1
+      security:
+        - ApiKeyAuth: []
+      extensions:
+        x-tenant-scoped: true
+        x-auth-mechanism: NextAuth session, falling back to x-api-key
+          (resolveActivityAuthContext)
+      x-alga-products:
+        - psa
+      parameters:
+        - schema:
+            type: string
+            description: Custom activity group identifier.
+          required: true
+          description: Custom activity group identifier.
+          name: groupId
+          in: path
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/ReorderActivitiesInGroupBodyV1"
+      responses:
+        "200":
+          description: Group order persisted.
+        "400":
+          description: Invalid request body.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ActivitiesApiErrorV1"
+        "401":
+          description: Authentication required.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ActivitiesApiErrorV1"
+        "403":
+          description: Permission denied (user_schedule:read).
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ActivitiesApiErrorV1"
+        "404":
+          description: Group not found.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ActivitiesApiErrorV1"
+        "500":
+          description: Unexpected failure reordering the group.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ActivitiesApiErrorV1"
   /api/v1/projects/{id}/task-status-mappings:
     get:
       summary: List project task status mappings
@@ -51565,7 +53449,7 @@ paths:
           in: query
         - schema:
             type: string
-            enum: *a139
+            enum: *a144
           required: false
           name: order
           in: query
@@ -51866,7 +53750,7 @@ paths:
           in: query
         - schema:
             type: string
-            enum: *a139
+            enum: *a144
           required: false
           name: order
           in: query
@@ -51950,7 +53834,7 @@ paths:
           in: query
         - schema:
             type: string
-            enum: *a139
+            enum: *a144
           required: false
           name: order
           in: query
@@ -52034,7 +53918,7 @@ paths:
           in: query
         - schema:
             type: string
-            enum: *a139
+            enum: *a144
           required: false
           name: order
           in: query
@@ -52127,7 +54011,7 @@ paths:
           in: query
         - schema:
             type: string
-            enum: *a139
+            enum: *a144
           required: false
           name: order
           in: query
@@ -52225,7 +54109,7 @@ paths:
           in: query
         - schema:
             type: string
-            enum: *a139
+            enum: *a144
           required: false
           name: order
           in: query
@@ -52528,7 +54412,7 @@ paths:
           in: query
         - schema:
             type: string
-            enum: *a139
+            enum: *a144
           required: false
           name: order
           in: query
@@ -52625,7 +54509,7 @@ paths:
           in: query
         - schema:
             type: string
-            enum: *a139
+            enum: *a144
           required: false
           name: order
           in: query
@@ -52883,7 +54767,7 @@ paths:
           in: query
         - schema:
             type: string
-            enum: *a139
+            enum: *a144
           required: false
           name: order
           in: query
@@ -52973,7 +54857,7 @@ paths:
           in: query
         - schema:
             type: string
-            enum: *a139
+            enum: *a144
           required: false
           name: order
           in: query
@@ -53117,7 +55001,7 @@ paths:
           in: query
         - schema:
             type: string
-            enum: *a139
+            enum: *a144
           required: false
           name: order
           in: query
@@ -53412,7 +55296,7 @@ paths:
           in: query
         - schema:
             type: string
-            enum: *a139
+            enum: *a144
           required: false
           name: order
           in: query
@@ -53503,7 +55387,7 @@ paths:
           in: query
         - schema:
             type: string
-            enum: *a139
+            enum: *a144
           required: false
           name: order
           in: query
@@ -53647,7 +55531,7 @@ paths:
           in: query
         - schema:
             type: string
-            enum: *a139
+            enum: *a144
           required: false
           name: order
           in: query
@@ -54082,7 +55966,7 @@ paths:
           in: query
         - schema:
             type: string
-            enum: *a139
+            enum: *a144
           required: false
           name: order
           in: query
@@ -54393,7 +56277,7 @@ paths:
           in: query
         - schema:
             type: string
-            enum: *a139
+            enum: *a144
           required: false
           name: order
           in: query
@@ -54819,7 +56703,7 @@ paths:
           in: query
         - schema:
             type: string
-            enum: *a139
+            enum: *a144
           required: false
           name: order
           in: query
@@ -54903,7 +56787,7 @@ paths:
           in: query
         - schema:
             type: string
-            enum: *a139
+            enum: *a144
           required: false
           name: order
           in: query
@@ -55088,7 +56972,7 @@ paths:
           in: query
         - schema:
             type: string
-            enum: *a139
+            enum: *a144
           required: false
           name: order
           in: query
@@ -55173,7 +57057,7 @@ paths:
           in: query
         - schema:
             type: string
-            enum: *a139
+            enum: *a144
           required: false
           name: order
           in: query
@@ -55539,7 +57423,7 @@ paths:
           in: query
         - schema:
             type: string
-            enum: *a139
+            enum: *a144
           required: false
           name: order
           in: query
@@ -55637,7 +57521,7 @@ paths:
           in: query
         - schema:
             type: string
-            enum: *a139
+            enum: *a144
           required: false
           name: order
           in: query
@@ -56365,7 +58249,7 @@ paths:
           in: query
         - schema:
             type: string
-            enum: *a139
+            enum: *a144
           required: false
           name: order
           in: query
@@ -56507,7 +58391,7 @@ paths:
           in: query
         - schema:
             type: string
-            enum: *a139
+            enum: *a144
           required: false
           name: order
           in: query
@@ -56816,7 +58700,7 @@ paths:
           in: query
         - schema:
             type: string
-            enum: *a139
+            enum: *a144
           required: false
           name: order
           in: query
@@ -56959,7 +58843,7 @@ paths:
           in: query
         - schema:
             type: string
-            enum: *a139
+            enum: *a144
           required: false
           name: order
           in: query
@@ -57102,7 +58986,7 @@ paths:
           in: query
         - schema:
             type: string
-            enum: *a139
+            enum: *a144
           required: false
           name: order
           in: query
@@ -57259,7 +59143,7 @@ paths:
           in: query
         - schema:
             type: string
-            enum: *a139
+            enum: *a144
           required: false
           name: order
           in: query
@@ -57542,7 +59426,7 @@ paths:
           in: query
         - schema:
             type: string
-            enum: *a139
+            enum: *a144
           required: false
           name: order
           in: query
@@ -57686,7 +59570,7 @@ paths:
           in: query
         - schema:
             type: string
-            enum: *a139
+            enum: *a144
           required: false
           name: order
           in: query
@@ -58121,7 +60005,7 @@ paths:
           in: query
         - schema:
             type: string
-            enum: *a139
+            enum: *a144
           required: false
           name: order
           in: query
@@ -58324,7 +60208,7 @@ paths:
           in: query
         - schema:
             type: string
-            enum: *a139
+            enum: *a144
           required: false
           name: order
           in: query
@@ -58410,7 +60294,7 @@ paths:
           in: query
         - schema:
             type: string
-            enum: *a139
+            enum: *a144
           required: false
           name: order
           in: query
@@ -58853,7 +60737,7 @@ paths:
           in: query
         - schema:
             type: string
-            enum: *a139
+            enum: *a144
           required: false
           name: order
           in: query
@@ -59324,7 +61208,7 @@ paths:
           in: query
         - schema:
             type: string
-            enum: *a139
+            enum: *a144
           required: false
           name: order
           in: query
@@ -60052,7 +61936,7 @@ paths:
           in: query
         - schema:
             type: string
-            enum: *a140
+            enum: *a145
           required: false
           name: order
           in: query
@@ -60068,13 +61952,13 @@ paths:
           in: query
         - schema:
             type: string
-            enum: *a141
+            enum: *a146
           required: false
           name: include_items
           in: query
         - schema:
             type: string
-            enum: *a142
+            enum: *a147
           required: false
           name: include_client
           in: query
@@ -60143,7 +62027,7 @@ paths:
           in: query
         - schema:
             type: string
-            enum: *a140
+            enum: *a145
           required: false
           name: order
           in: query
@@ -60159,13 +62043,13 @@ paths:
           in: query
         - schema:
             type: string
-            enum: *a141
+            enum: *a146
           required: false
           name: include_items
           in: query
         - schema:
             type: string
-            enum: *a142
+            enum: *a147
           required: false
           name: include_client
           in: query
@@ -61580,7 +63464,7 @@ paths:
           in: query
         - schema:
             type: string
-            enum: *a140
+            enum: *a145
           required: false
           name: order
           in: query
@@ -61596,13 +63480,13 @@ paths:
           in: query
         - schema:
             type: string
-            enum: *a141
+            enum: *a146
           required: false
           name: include_items
           in: query
         - schema:
             type: string
-            enum: *a142
+            enum: *a147
           required: false
           name: include_client
           in: query
@@ -61675,7 +63559,7 @@ paths:
           in: query
         - schema:
             type: string
-            enum: *a140
+            enum: *a145
           required: false
           name: order
           in: query
@@ -61691,13 +63575,13 @@ paths:
           in: query
         - schema:
             type: string
-            enum: *a141
+            enum: *a146
           required: false
           name: include_items
           in: query
         - schema:
             type: string
-            enum: *a142
+            enum: *a147
           required: false
           name: include_client
           in: query
@@ -64199,6 +66083,37 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/ErrorResponse"
+  /api/auth/captcha-config:
+    get:
+      summary: GET auth
+      description: This operation was generated automatically from the route
+        inventory. Replace with canonical OpenAPI metadata.
+      tags:
+        - auth
+      extensions:
+        x-generated-from: docs/openapi/route-inventory.json
+        x-placeholder: true
+      x-alga-products:
+        - psa
+      responses:
+        "200":
+          description: Placeholder success response
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/PlaceholderObject"
+        "401":
+          description: Authentication required
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        "403":
+          description: Forbidden
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
   /api/auth/e2e/google/authorize:
     get:
       summary: GET auth
@@ -64678,6 +66593,201 @@ paths:
         - psa
       responses:
         "200":
+          description: Placeholder success response
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/PlaceholderObject"
+        "401":
+          description: Authentication required
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        "403":
+          description: Forbidden
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+  /api/billing/complete-reactivation:
+    post:
+      summary: POST billing
+      description: This operation was generated automatically from the route
+        inventory. Replace with canonical OpenAPI metadata.
+      tags:
+        - billing
+      extensions:
+        x-generated-from: docs/openapi/route-inventory.json
+        x-placeholder: true
+      x-alga-products:
+        - psa
+      requestBody:
+        description: Placeholder request body
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/PlaceholderObject"
+            description: Placeholder request body
+      responses:
+        "201":
+          description: Placeholder success response
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/PlaceholderObject"
+        "401":
+          description: Authentication required
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        "403":
+          description: Forbidden
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+  /api/billing/reactivation-password-reset:
+    post:
+      summary: POST billing
+      description: This operation was generated automatically from the route
+        inventory. Replace with canonical OpenAPI metadata.
+      tags:
+        - billing
+      extensions:
+        x-generated-from: docs/openapi/route-inventory.json
+        x-placeholder: true
+      x-alga-products:
+        - psa
+      requestBody:
+        description: Placeholder request body
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/PlaceholderObject"
+            description: Placeholder request body
+      responses:
+        "201":
+          description: Placeholder success response
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/PlaceholderObject"
+        "401":
+          description: Authentication required
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        "403":
+          description: Forbidden
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+  /api/billing/reactivation-token:
+    post:
+      summary: POST billing
+      description: This operation was generated automatically from the route
+        inventory. Replace with canonical OpenAPI metadata.
+      tags:
+        - billing
+      extensions:
+        x-generated-from: docs/openapi/route-inventory.json
+        x-placeholder: true
+      x-alga-products:
+        - psa
+      requestBody:
+        description: Placeholder request body
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/PlaceholderObject"
+            description: Placeholder request body
+      responses:
+        "201":
+          description: Placeholder success response
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/PlaceholderObject"
+        "401":
+          description: Authentication required
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        "403":
+          description: Forbidden
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+  /api/billing/reactivation-token/session:
+    post:
+      summary: POST billing
+      description: This operation was generated automatically from the route
+        inventory. Replace with canonical OpenAPI metadata.
+      tags:
+        - billing
+      extensions:
+        x-generated-from: docs/openapi/route-inventory.json
+        x-placeholder: true
+      x-alga-products:
+        - psa
+      requestBody:
+        description: Placeholder request body
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/PlaceholderObject"
+            description: Placeholder request body
+      responses:
+        "201":
+          description: Placeholder success response
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/PlaceholderObject"
+        "401":
+          description: Authentication required
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        "403":
+          description: Forbidden
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+  /api/billing/request-reactivation:
+    post:
+      summary: POST billing
+      description: This operation was generated automatically from the route
+        inventory. Replace with canonical OpenAPI metadata.
+      tags:
+        - billing
+      extensions:
+        x-generated-from: docs/openapi/route-inventory.json
+        x-placeholder: true
+      x-alga-products:
+        - psa
+      requestBody:
+        description: Placeholder request body
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/PlaceholderObject"
+            description: Placeholder request body
+      responses:
+        "201":
           description: Placeholder success response
           content:
             application/json:
@@ -66892,6 +69002,67 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/ErrorResponse"
+  /api/integrations/hudu:
+    get:
+      summary: GET integrations
+      description: This operation was generated automatically from the route
+        inventory. Replace with canonical OpenAPI metadata.
+      tags:
+        - integrations
+      extensions:
+        x-generated-from: docs/openapi/route-inventory.json
+        x-placeholder: true
+      x-alga-products:
+        - psa
+      responses:
+        "200":
+          description: Placeholder success response
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/PlaceholderObject"
+        "401":
+          description: Authentication required
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        "403":
+          description: Forbidden
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+    options:
+      summary: OPTIONS integrations
+      description: This operation was generated automatically from the route
+        inventory. Replace with canonical OpenAPI metadata.
+      tags:
+        - integrations
+      extensions:
+        x-generated-from: docs/openapi/route-inventory.json
+        x-placeholder: true
+      x-alga-products:
+        - psa
+      responses:
+        "200":
+          description: Placeholder success response
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/PlaceholderObject"
+        "401":
+          description: Authentication required
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        "403":
+          description: Forbidden
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
   /api/integrations/ninjaone/callback:
     get:
       summary: GET integrations
@@ -67265,6 +69436,222 @@ paths:
         inventory. Replace with canonical OpenAPI metadata.
       tags:
         - internal
+      extensions:
+        x-generated-from: docs/openapi/route-inventory.json
+        x-placeholder: true
+      x-alga-products:
+        - psa
+      requestBody:
+        description: Placeholder request body
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/PlaceholderObject"
+            description: Placeholder request body
+      responses:
+        "201":
+          description: Placeholder success response
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/PlaceholderObject"
+        "401":
+          description: Authentication required
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        "403":
+          description: Forbidden
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+  /api/mcp:
+    get:
+      summary: GET mcp
+      description: This operation was generated automatically from the route
+        inventory. Replace with canonical OpenAPI metadata.
+      tags:
+        - mcp
+      extensions:
+        x-generated-from: docs/openapi/route-inventory.json
+        x-placeholder: true
+      x-alga-products:
+        - psa
+      responses:
+        "200":
+          description: Placeholder success response
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/PlaceholderObject"
+        "401":
+          description: Authentication required
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        "403":
+          description: Forbidden
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+    post:
+      summary: POST mcp
+      description: This operation was generated automatically from the route
+        inventory. Replace with canonical OpenAPI metadata.
+      tags:
+        - mcp
+      extensions:
+        x-generated-from: docs/openapi/route-inventory.json
+        x-placeholder: true
+      x-alga-products:
+        - psa
+      requestBody:
+        description: Placeholder request body
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/PlaceholderObject"
+            description: Placeholder request body
+      responses:
+        "201":
+          description: Placeholder success response
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/PlaceholderObject"
+        "401":
+          description: Authentication required
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        "403":
+          description: Forbidden
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+  /api/mcp/oauth/authorize:
+    get:
+      summary: GET mcp
+      description: This operation was generated automatically from the route
+        inventory. Replace with canonical OpenAPI metadata.
+      tags:
+        - mcp
+      extensions:
+        x-generated-from: docs/openapi/route-inventory.json
+        x-placeholder: true
+      x-alga-products:
+        - psa
+      responses:
+        "200":
+          description: Placeholder success response
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/PlaceholderObject"
+        "401":
+          description: Authentication required
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        "403":
+          description: Forbidden
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+    post:
+      summary: POST mcp
+      description: This operation was generated automatically from the route
+        inventory. Replace with canonical OpenAPI metadata.
+      tags:
+        - mcp
+      extensions:
+        x-generated-from: docs/openapi/route-inventory.json
+        x-placeholder: true
+      x-alga-products:
+        - psa
+      requestBody:
+        description: Placeholder request body
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/PlaceholderObject"
+            description: Placeholder request body
+      responses:
+        "201":
+          description: Placeholder success response
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/PlaceholderObject"
+        "401":
+          description: Authentication required
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        "403":
+          description: Forbidden
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+  /api/mcp/oauth/revoke:
+    post:
+      summary: POST mcp
+      description: This operation was generated automatically from the route
+        inventory. Replace with canonical OpenAPI metadata.
+      tags:
+        - mcp
+      extensions:
+        x-generated-from: docs/openapi/route-inventory.json
+        x-placeholder: true
+      x-alga-products:
+        - psa
+      requestBody:
+        description: Placeholder request body
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/PlaceholderObject"
+            description: Placeholder request body
+      responses:
+        "201":
+          description: Placeholder success response
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/PlaceholderObject"
+        "401":
+          description: Authentication required
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        "403":
+          description: Forbidden
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+  /api/mcp/oauth/token:
+    post:
+      summary: POST mcp
+      description: This operation was generated automatically from the route
+        inventory. Replace with canonical OpenAPI metadata.
+      tags:
+        - mcp
       extensions:
         x-generated-from: docs/openapi/route-inventory.json
         x-placeholder: true
@@ -68381,6 +70768,690 @@ paths:
         x-placeholder: true
       x-alga-products:
         - psa
+      responses:
+        "200":
+          description: Placeholder success response
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/PlaceholderObject"
+        "401":
+          description: Authentication required
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        "403":
+          description: Forbidden
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+  /api/v1/appliance-installs:
+    get:
+      summary: GET v1
+      description: This operation was generated automatically from the route
+        inventory. Replace with canonical OpenAPI metadata.
+      tags:
+        - appliance-installs
+      extensions:
+        x-generated-from: docs/openapi/route-inventory.json
+        x-placeholder: true
+      x-alga-products:
+        - psa
+      responses:
+        "200":
+          description: Placeholder success response
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/PlaceholderObject"
+        "401":
+          description: Authentication required
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        "403":
+          description: Forbidden
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+    options:
+      summary: OPTIONS v1
+      description: This operation was generated automatically from the route
+        inventory. Replace with canonical OpenAPI metadata.
+      tags:
+        - appliance-installs
+      extensions:
+        x-generated-from: docs/openapi/route-inventory.json
+        x-placeholder: true
+      x-alga-products:
+        - psa
+      responses:
+        "200":
+          description: Placeholder success response
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/PlaceholderObject"
+        "401":
+          description: Authentication required
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        "403":
+          description: Forbidden
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+  /api/v1/appliance-installs/access:
+    options:
+      summary: OPTIONS v1
+      description: This operation was generated automatically from the route
+        inventory. Replace with canonical OpenAPI metadata.
+      tags:
+        - appliance-installs
+      extensions:
+        x-generated-from: docs/openapi/route-inventory.json
+        x-placeholder: true
+      x-alga-products:
+        - psa
+      responses:
+        "200":
+          description: Placeholder success response
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/PlaceholderObject"
+        "401":
+          description: Authentication required
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        "403":
+          description: Forbidden
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+    post:
+      summary: POST v1
+      description: This operation was generated automatically from the route
+        inventory. Replace with canonical OpenAPI metadata.
+      tags:
+        - appliance-installs
+      extensions:
+        x-generated-from: docs/openapi/route-inventory.json
+        x-placeholder: true
+      x-alga-products:
+        - psa
+      requestBody:
+        description: Placeholder request body
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/PlaceholderObject"
+            description: Placeholder request body
+      responses:
+        "201":
+          description: Placeholder success response
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/PlaceholderObject"
+        "401":
+          description: Authentication required
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        "403":
+          description: Forbidden
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+  /api/v1/appliance-installs/{tenantId}:
+    get:
+      summary: GET v1
+      description: This operation was generated automatically from the route
+        inventory. Replace with canonical OpenAPI metadata.
+      tags:
+        - appliance-installs
+      extensions:
+        x-generated-from: docs/openapi/route-inventory.json
+        x-placeholder: true
+      x-alga-products:
+        - psa
+      responses:
+        "200":
+          description: Placeholder success response
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/PlaceholderObject"
+        "401":
+          description: Authentication required
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        "403":
+          description: Forbidden
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+    options:
+      summary: OPTIONS v1
+      description: This operation was generated automatically from the route
+        inventory. Replace with canonical OpenAPI metadata.
+      tags:
+        - appliance-installs
+      extensions:
+        x-generated-from: docs/openapi/route-inventory.json
+        x-placeholder: true
+      x-alga-products:
+        - psa
+      responses:
+        "200":
+          description: Placeholder success response
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/PlaceholderObject"
+        "401":
+          description: Authentication required
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        "403":
+          description: Forbidden
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+  /api/v1/mcp/agents:
+    delete:
+      summary: DELETE v1
+      description: This operation was generated automatically from the route
+        inventory. Replace with canonical OpenAPI metadata.
+      tags:
+        - mcp
+      extensions:
+        x-generated-from: docs/openapi/route-inventory.json
+        x-placeholder: true
+      x-alga-products:
+        - psa
+      responses:
+        "204":
+          description: Placeholder success response
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/PlaceholderObject"
+        "401":
+          description: Authentication required
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        "403":
+          description: Forbidden
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+    get:
+      summary: GET v1
+      description: This operation was generated automatically from the route
+        inventory. Replace with canonical OpenAPI metadata.
+      tags:
+        - mcp
+      extensions:
+        x-generated-from: docs/openapi/route-inventory.json
+        x-placeholder: true
+      x-alga-products:
+        - psa
+      responses:
+        "200":
+          description: Placeholder success response
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/PlaceholderObject"
+        "401":
+          description: Authentication required
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        "403":
+          description: Forbidden
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+    patch:
+      summary: PATCH v1
+      description: This operation was generated automatically from the route
+        inventory. Replace with canonical OpenAPI metadata.
+      tags:
+        - mcp
+      extensions:
+        x-generated-from: docs/openapi/route-inventory.json
+        x-placeholder: true
+      x-alga-products:
+        - psa
+      requestBody:
+        description: Placeholder request body
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/PlaceholderObject"
+            description: Placeholder request body
+      responses:
+        "200":
+          description: Placeholder success response
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/PlaceholderObject"
+        "401":
+          description: Authentication required
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        "403":
+          description: Forbidden
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+    post:
+      summary: POST v1
+      description: This operation was generated automatically from the route
+        inventory. Replace with canonical OpenAPI metadata.
+      tags:
+        - mcp
+      extensions:
+        x-generated-from: docs/openapi/route-inventory.json
+        x-placeholder: true
+      x-alga-products:
+        - psa
+      requestBody:
+        description: Placeholder request body
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/PlaceholderObject"
+            description: Placeholder request body
+      responses:
+        "201":
+          description: Placeholder success response
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/PlaceholderObject"
+        "401":
+          description: Authentication required
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        "403":
+          description: Forbidden
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+  /api/v1/mcp/audit:
+    get:
+      summary: GET v1
+      description: This operation was generated automatically from the route
+        inventory. Replace with canonical OpenAPI metadata.
+      tags:
+        - mcp
+      extensions:
+        x-generated-from: docs/openapi/route-inventory.json
+        x-placeholder: true
+      x-alga-products:
+        - psa
+      responses:
+        "200":
+          description: Placeholder success response
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/PlaceholderObject"
+        "401":
+          description: Authentication required
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        "403":
+          description: Forbidden
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+  /api/v1/mcp/connect/callback:
+    get:
+      summary: GET v1
+      description: This operation was generated automatically from the route
+        inventory. Replace with canonical OpenAPI metadata.
+      tags:
+        - mcp
+      extensions:
+        x-generated-from: docs/openapi/route-inventory.json
+        x-placeholder: true
+      x-alga-products:
+        - psa
+      responses:
+        "200":
+          description: Placeholder success response
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/PlaceholderObject"
+        "401":
+          description: Authentication required
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        "403":
+          description: Forbidden
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+  /api/v1/mcp/connect/start:
+    post:
+      summary: POST v1
+      description: This operation was generated automatically from the route
+        inventory. Replace with canonical OpenAPI metadata.
+      tags:
+        - mcp
+      extensions:
+        x-generated-from: docs/openapi/route-inventory.json
+        x-placeholder: true
+      x-alga-products:
+        - psa
+      requestBody:
+        description: Placeholder request body
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/PlaceholderObject"
+            description: Placeholder request body
+      responses:
+        "201":
+          description: Placeholder success response
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/PlaceholderObject"
+        "401":
+          description: Authentication required
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        "403":
+          description: Forbidden
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+  /api/v1/mcp/connections:
+    delete:
+      summary: DELETE v1
+      description: This operation was generated automatically from the route
+        inventory. Replace with canonical OpenAPI metadata.
+      tags:
+        - mcp
+      extensions:
+        x-generated-from: docs/openapi/route-inventory.json
+        x-placeholder: true
+      x-alga-products:
+        - psa
+      responses:
+        "204":
+          description: Placeholder success response
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/PlaceholderObject"
+        "401":
+          description: Authentication required
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        "403":
+          description: Forbidden
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+    get:
+      summary: GET v1
+      description: This operation was generated automatically from the route
+        inventory. Replace with canonical OpenAPI metadata.
+      tags:
+        - mcp
+      extensions:
+        x-generated-from: docs/openapi/route-inventory.json
+        x-placeholder: true
+      x-alga-products:
+        - psa
+      responses:
+        "200":
+          description: Placeholder success response
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/PlaceholderObject"
+        "401":
+          description: Authentication required
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        "403":
+          description: Forbidden
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+  /api/v1/mcp/idp-providers:
+    get:
+      summary: GET v1
+      description: This operation was generated automatically from the route
+        inventory. Replace with canonical OpenAPI metadata.
+      tags:
+        - mcp
+      extensions:
+        x-generated-from: docs/openapi/route-inventory.json
+        x-placeholder: true
+      x-alga-products:
+        - psa
+      responses:
+        "200":
+          description: Placeholder success response
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/PlaceholderObject"
+        "401":
+          description: Authentication required
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        "403":
+          description: Forbidden
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+    post:
+      summary: POST v1
+      description: This operation was generated automatically from the route
+        inventory. Replace with canonical OpenAPI metadata.
+      tags:
+        - mcp
+      extensions:
+        x-generated-from: docs/openapi/route-inventory.json
+        x-placeholder: true
+      x-alga-products:
+        - psa
+      requestBody:
+        description: Placeholder request body
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/PlaceholderObject"
+            description: Placeholder request body
+      responses:
+        "201":
+          description: Placeholder success response
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/PlaceholderObject"
+        "401":
+          description: Authentication required
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        "403":
+          description: Forbidden
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+  /api/v1/mcp/idp-suggestions:
+    get:
+      summary: GET v1
+      description: This operation was generated automatically from the route
+        inventory. Replace with canonical OpenAPI metadata.
+      tags:
+        - mcp
+      extensions:
+        x-generated-from: docs/openapi/route-inventory.json
+        x-placeholder: true
+      x-alga-products:
+        - psa
+      responses:
+        "200":
+          description: Placeholder success response
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/PlaceholderObject"
+        "401":
+          description: Authentication required
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        "403":
+          description: Forbidden
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+  /api/v1/mcp/platform-providers:
+    get:
+      summary: GET v1
+      description: This operation was generated automatically from the route
+        inventory. Replace with canonical OpenAPI metadata.
+      tags:
+        - mcp
+      extensions:
+        x-generated-from: docs/openapi/route-inventory.json
+        x-placeholder: true
+      x-alga-products:
+        - psa
+      responses:
+        "200":
+          description: Placeholder success response
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/PlaceholderObject"
+        "401":
+          description: Authentication required
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        "403":
+          description: Forbidden
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+  /api/v1/mcp/roles:
+    get:
+      summary: GET v1
+      description: This operation was generated automatically from the route
+        inventory. Replace with canonical OpenAPI metadata.
+      tags:
+        - mcp
+      extensions:
+        x-generated-from: docs/openapi/route-inventory.json
+        x-placeholder: true
+      x-alga-products:
+        - psa
+      responses:
+        "200":
+          description: Placeholder success response
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/PlaceholderObject"
+        "401":
+          description: Authentication required
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        "403":
+          description: Forbidden
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+  /api/v1/meta/mcp-registry:
+    get:
+      summary: GET v1
+      description: This operation was generated automatically from the route
+        inventory. Replace with canonical OpenAPI metadata.
+      tags:
+        - meta
+      extensions:
+        x-generated-from: docs/openapi/route-inventory.json
+        x-placeholder: true
+      x-alga-products:
+        - psa
+        - algadesk
       responses:
         "200":
           description: Placeholder success response
@@ -71275,6 +74346,144 @@ paths:
         inventory. Replace with canonical OpenAPI metadata.
       tags:
         - tenant-management
+      extensions:
+        x-generated-from: docs/openapi/route-inventory.json
+        x-placeholder: true
+      x-alga-products:
+        - psa
+      requestBody:
+        description: Placeholder request body
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/PlaceholderObject"
+            description: Placeholder request body
+      responses:
+        "201":
+          description: Placeholder success response
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/PlaceholderObject"
+        "401":
+          description: Authentication required
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        "403":
+          description: Forbidden
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+  /api/webhooks/alternative-payments:
+    get:
+      summary: GET webhooks
+      description: This operation was generated automatically from the route
+        inventory. Replace with canonical OpenAPI metadata.
+      tags:
+        - webhooks
+      extensions:
+        x-generated-from: docs/openapi/route-inventory.json
+        x-placeholder: true
+      x-alga-products:
+        - psa
+      responses:
+        "200":
+          description: Placeholder success response
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/PlaceholderObject"
+        "401":
+          description: Authentication required
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        "403":
+          description: Forbidden
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+    post:
+      summary: POST webhooks
+      description: This operation was generated automatically from the route
+        inventory. Replace with canonical OpenAPI metadata.
+      tags:
+        - webhooks
+      extensions:
+        x-generated-from: docs/openapi/route-inventory.json
+        x-placeholder: true
+      x-alga-products:
+        - psa
+      requestBody:
+        description: Placeholder request body
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/PlaceholderObject"
+            description: Placeholder request body
+      responses:
+        "201":
+          description: Placeholder success response
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/PlaceholderObject"
+        "401":
+          description: Authentication required
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        "403":
+          description: Forbidden
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+  /api/webhooks/levelio:
+    options:
+      summary: OPTIONS webhooks
+      description: This operation was generated automatically from the route
+        inventory. Replace with canonical OpenAPI metadata.
+      tags:
+        - webhooks
+      extensions:
+        x-generated-from: docs/openapi/route-inventory.json
+        x-placeholder: true
+      x-alga-products:
+        - psa
+      responses:
+        "200":
+          description: Placeholder success response
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/PlaceholderObject"
+        "401":
+          description: Authentication required
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        "403":
+          description: Forbidden
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+    post:
+      summary: POST webhooks
+      description: This operation was generated automatically from the route
+        inventory. Replace with canonical OpenAPI metadata.
+      tags:
+        - webhooks
       extensions:
         x-generated-from: docs/openapi/route-inventory.json
         x-placeholder: true

--- a/sdk/docs/openapi/alga-openapi.ee.json
+++ b/sdk/docs/openapi/alga-openapi.ee.json
@@ -26,6 +26,9 @@
       "name": "Accounting Exports"
     },
     {
+      "name": "Activities v1"
+    },
+    {
       "name": "Admin"
     },
     {
@@ -173,10 +176,16 @@
       "name": "Workflow Runs"
     },
     {
+      "name": "Workflow Tasks v1"
+    },
+    {
       "name": "Workflows v1"
     },
     {
       "name": "accounting"
+    },
+    {
+      "name": "appliance-installs"
     },
     {
       "name": "auth"
@@ -228,6 +237,12 @@
     },
     {
       "name": "internal"
+    },
+    {
+      "name": "mcp"
+    },
+    {
+      "name": "meta"
     },
     {
       "name": "mobile"
@@ -18782,6 +18797,1473 @@
       "WorkflowV1MissingRouteResponse": {
         "type": "string",
         "description": "Default Next.js not-found response body for missing route handlers."
+      },
+      "WorkflowTasksApiErrorV1": {
+        "type": "object",
+        "properties": {
+          "error": {
+            "type": "object",
+            "properties": {
+              "code": {
+                "type": "string"
+              },
+              "message": {
+                "type": "string"
+              },
+              "details": {}
+            },
+            "required": [
+              "code",
+              "message"
+            ]
+          }
+        },
+        "required": [
+          "error"
+        ]
+      },
+      "WorkflowTaskIdParamV1": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string",
+            "description": "Workflow task identifier (taskId)."
+          }
+        },
+        "required": [
+          "id"
+        ]
+      },
+      "WorkflowTasksListQueryV1": {
+        "type": "object",
+        "properties": {
+          "status": {
+            "type": "string",
+            "description": "Comma-separated WorkflowTaskStatus values (pending, claimed, completed, canceled, expired). Omit for the open inbox (pending + claimed)."
+          },
+          "page": {
+            "type": "integer",
+            "minimum": 1,
+            "description": "1-based page number (default 1)."
+          },
+          "pageSize": {
+            "type": "integer",
+            "minimum": 1,
+            "maximum": 100,
+            "description": "Items per page, max 100 (default 25)."
+          }
+        }
+      },
+      "WorkflowTaskV1": {
+        "type": "object",
+        "properties": {
+          "taskId": {
+            "type": "string"
+          },
+          "executionId": {
+            "type": "string"
+          },
+          "title": {
+            "type": "string"
+          },
+          "description": {
+            "type": "string"
+          },
+          "status": {
+            "type": "string",
+            "enum": [
+              "pending",
+              "claimed",
+              "completed",
+              "canceled",
+              "expired"
+            ]
+          },
+          "priority": {
+            "type": "string"
+          },
+          "dueDate": {
+            "type": "string"
+          },
+          "assignedRoles": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          },
+          "assignedUsers": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          },
+          "contextData": {
+            "type": "object",
+            "additionalProperties": {}
+          },
+          "formId": {
+            "type": "string"
+          },
+          "formSchema": {
+            "type": "object",
+            "properties": {
+              "jsonSchema": {
+                "type": "object",
+                "additionalProperties": {}
+              },
+              "uiSchema": {
+                "type": "object",
+                "additionalProperties": {}
+              },
+              "defaultValues": {
+                "type": "object",
+                "additionalProperties": {}
+              }
+            },
+            "required": [
+              "jsonSchema"
+            ]
+          },
+          "createdAt": {
+            "type": "string"
+          },
+          "createdBy": {
+            "type": "string"
+          },
+          "claimedAt": {
+            "type": "string"
+          },
+          "claimedBy": {
+            "type": "string"
+          },
+          "completedAt": {
+            "type": "string"
+          },
+          "completedBy": {
+            "type": "string"
+          },
+          "responseData": {
+            "type": "object",
+            "additionalProperties": {}
+          }
+        },
+        "required": [
+          "taskId",
+          "executionId",
+          "title",
+          "status",
+          "priority",
+          "formId",
+          "createdAt"
+        ]
+      },
+      "WorkflowTaskListResponseV1": {
+        "type": "object",
+        "properties": {
+          "data": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "properties": {
+                "taskId": {
+                  "type": "string"
+                },
+                "executionId": {
+                  "type": "string"
+                },
+                "title": {
+                  "type": "string"
+                },
+                "description": {
+                  "type": "string"
+                },
+                "status": {
+                  "type": "string",
+                  "enum": [
+                    "pending",
+                    "claimed",
+                    "completed",
+                    "canceled",
+                    "expired"
+                  ]
+                },
+                "priority": {
+                  "type": "string"
+                },
+                "dueDate": {
+                  "type": "string"
+                },
+                "assignedRoles": {
+                  "type": "array",
+                  "items": {
+                    "type": "string"
+                  }
+                },
+                "assignedUsers": {
+                  "type": "array",
+                  "items": {
+                    "type": "string"
+                  }
+                },
+                "contextData": {
+                  "type": "object",
+                  "additionalProperties": {}
+                },
+                "formId": {
+                  "type": "string"
+                },
+                "formSchema": {
+                  "type": "object",
+                  "properties": {
+                    "jsonSchema": {
+                      "type": "object",
+                      "additionalProperties": {}
+                    },
+                    "uiSchema": {
+                      "type": "object",
+                      "additionalProperties": {}
+                    },
+                    "defaultValues": {
+                      "type": "object",
+                      "additionalProperties": {}
+                    }
+                  },
+                  "required": [
+                    "jsonSchema"
+                  ]
+                },
+                "createdAt": {
+                  "type": "string"
+                },
+                "createdBy": {
+                  "type": "string"
+                },
+                "claimedAt": {
+                  "type": "string"
+                },
+                "claimedBy": {
+                  "type": "string"
+                },
+                "completedAt": {
+                  "type": "string"
+                },
+                "completedBy": {
+                  "type": "string"
+                },
+                "responseData": {
+                  "type": "object",
+                  "additionalProperties": {}
+                }
+              },
+              "required": [
+                "taskId",
+                "executionId",
+                "title",
+                "status",
+                "priority",
+                "formId",
+                "createdAt"
+              ]
+            }
+          },
+          "pagination": {
+            "type": "object",
+            "properties": {
+              "page": {
+                "type": "number"
+              },
+              "limit": {
+                "type": "number"
+              },
+              "total": {
+                "type": "number"
+              },
+              "totalPages": {
+                "type": "number"
+              },
+              "hasNext": {
+                "type": "boolean"
+              },
+              "hasPrev": {
+                "type": "boolean"
+              }
+            },
+            "required": [
+              "page",
+              "limit",
+              "total",
+              "totalPages",
+              "hasNext",
+              "hasPrev"
+            ]
+          },
+          "meta": {}
+        },
+        "required": [
+          "data",
+          "pagination"
+        ]
+      },
+      "WorkflowTaskDetailResponseV1": {
+        "type": "object",
+        "properties": {
+          "data": {
+            "type": "object",
+            "properties": {
+              "taskId": {
+                "type": "string"
+              },
+              "executionId": {
+                "type": "string"
+              },
+              "title": {
+                "type": "string"
+              },
+              "description": {
+                "type": "string"
+              },
+              "status": {
+                "type": "string",
+                "enum": [
+                  "pending",
+                  "claimed",
+                  "completed",
+                  "canceled",
+                  "expired"
+                ]
+              },
+              "priority": {
+                "type": "string"
+              },
+              "dueDate": {
+                "type": "string"
+              },
+              "assignedRoles": {
+                "type": "array",
+                "items": {
+                  "type": "string"
+                }
+              },
+              "assignedUsers": {
+                "type": "array",
+                "items": {
+                  "type": "string"
+                }
+              },
+              "contextData": {
+                "type": "object",
+                "additionalProperties": {}
+              },
+              "formId": {
+                "type": "string"
+              },
+              "formSchema": {
+                "type": "object",
+                "properties": {
+                  "jsonSchema": {
+                    "type": "object",
+                    "additionalProperties": {}
+                  },
+                  "uiSchema": {
+                    "type": "object",
+                    "additionalProperties": {}
+                  },
+                  "defaultValues": {
+                    "type": "object",
+                    "additionalProperties": {}
+                  }
+                },
+                "required": [
+                  "jsonSchema"
+                ]
+              },
+              "createdAt": {
+                "type": "string"
+              },
+              "createdBy": {
+                "type": "string"
+              },
+              "claimedAt": {
+                "type": "string"
+              },
+              "claimedBy": {
+                "type": "string"
+              },
+              "completedAt": {
+                "type": "string"
+              },
+              "completedBy": {
+                "type": "string"
+              },
+              "responseData": {
+                "type": "object",
+                "additionalProperties": {}
+              }
+            },
+            "required": [
+              "taskId",
+              "executionId",
+              "title",
+              "status",
+              "priority",
+              "formId",
+              "createdAt"
+            ]
+          },
+          "meta": {}
+        },
+        "required": [
+          "data"
+        ]
+      },
+      "WorkflowTaskActionResponseV1": {
+        "type": "object",
+        "properties": {
+          "data": {
+            "type": "object",
+            "properties": {
+              "success": {
+                "type": "boolean"
+              }
+            },
+            "required": [
+              "success"
+            ]
+          },
+          "meta": {}
+        },
+        "required": [
+          "data"
+        ]
+      },
+      "CompleteWorkflowTaskBodyV1": {
+        "type": "object",
+        "properties": {
+          "formData": {
+            "type": "object",
+            "additionalProperties": {},
+            "default": {}
+          },
+          "comments": {
+            "type": "string"
+          }
+        }
+      },
+      "ActivitiesApiErrorV1": {
+        "type": "object",
+        "properties": {
+          "error": {
+            "type": "object",
+            "properties": {
+              "code": {
+                "type": "string"
+              },
+              "message": {
+                "type": "string"
+              },
+              "details": {}
+            },
+            "required": [
+              "code",
+              "message"
+            ]
+          }
+        },
+        "required": [
+          "error"
+        ]
+      },
+      "ActivitiesAdHocIdParamV1": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string",
+            "description": "Ad-hoc activity identifier (the backing schedule entry id)."
+          }
+        },
+        "required": [
+          "id"
+        ]
+      },
+      "ActivitiesListQueryV1": {
+        "type": "object",
+        "properties": {
+          "type": {
+            "type": "string",
+            "description": "Comma-separated ActivityType values (e.g. \"ticket,schedule\"). Omit for all types."
+          },
+          "status": {
+            "type": "string",
+            "enum": [
+              "open",
+              "closed",
+              "all"
+            ],
+            "description": "Open/closed filter. `open`→active only, `closed`→closed, `all`→no filter (default)."
+          },
+          "search": {
+            "type": "string",
+            "description": "Free-text search across activity titles/descriptions."
+          },
+          "dateStart": {
+            "type": "string",
+            "format": "date-time",
+            "description": "ISO 8601 lower bound of the schedule/time-entry/notification window."
+          },
+          "dateEnd": {
+            "type": "string",
+            "format": "date-time",
+            "description": "ISO 8601 upper bound of the window."
+          },
+          "priority": {
+            "type": "string",
+            "description": "Comma-separated normalized ActivityPriority buckets (e.g. \"high,medium\"). Lossy for custom schemes; prefer `priorityIds`."
+          },
+          "priorityIds": {
+            "type": "string",
+            "description": "Comma-separated exact priority IDs (the tenant's real per-type priorities). Applies to ticket/project-task activities."
+          },
+          "dueDateStart": {
+            "type": "string",
+            "format": "date-time",
+            "description": "ISO 8601 lower bound of the due-date filter (independent of the schedule window)."
+          },
+          "dueDateEnd": {
+            "type": "string",
+            "format": "date-time",
+            "description": "ISO 8601 upper bound of the due-date filter."
+          },
+          "createdAtStart": {
+            "type": "string",
+            "format": "date-time",
+            "description": "ISO 8601 lower bound of the created-date (\"date entered\") filter. Applies to every activity type."
+          },
+          "createdAtEnd": {
+            "type": "string",
+            "format": "date-time",
+            "description": "ISO 8601 upper bound of the created-date (\"date entered\") filter."
+          },
+          "sortBy": {
+            "type": "string",
+            "enum": [
+              "type",
+              "title",
+              "status",
+              "priority",
+              "dueDate"
+            ],
+            "description": "Sort column. Omit for the default sort (priority high→low, then due date ascending)."
+          },
+          "sortDirection": {
+            "type": "string",
+            "enum": [
+              "asc",
+              "desc"
+            ],
+            "description": "Sort direction for `sortBy` (default asc). Ignored when `sortBy` is omitted."
+          },
+          "groupBy": {
+            "type": "string",
+            "enum": [
+              "type",
+              "priority",
+              "status",
+              "dueDate"
+            ],
+            "description": "When set, the response is grouped by this dimension (ActivityGroupedResponseV1) instead of the paginated list; `page`/`pageSize` are ignored. `priority` groups by the real per-tenant priority name (not the normalized bucket), so it is only meaningful when scoped to a single prioritized type."
+          },
+          "page": {
+            "type": "integer",
+            "minimum": 1,
+            "description": "1-based page number (default 1). Ignored when `groupBy` is set."
+          },
+          "pageSize": {
+            "type": "integer",
+            "minimum": 1,
+            "maximum": 100,
+            "description": "Items per page, max 100 (default 25). Ignored when `groupBy` is set."
+          }
+        }
+      },
+      "ActivityV1": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string"
+          },
+          "title": {
+            "type": "string"
+          },
+          "description": {
+            "type": "string"
+          },
+          "type": {
+            "type": "string",
+            "enum": [
+              "schedule",
+              "projectTask",
+              "ticket",
+              "timeEntry",
+              "workflowTask",
+              "notification",
+              "document"
+            ]
+          },
+          "status": {
+            "type": "string"
+          },
+          "statusColor": {
+            "type": "string"
+          },
+          "priority": {
+            "type": "string",
+            "enum": [
+              "low",
+              "medium",
+              "high"
+            ]
+          },
+          "priorityName": {
+            "type": "string"
+          },
+          "priorityColor": {
+            "type": "string"
+          },
+          "dueDate": {
+            "type": "string"
+          },
+          "startDate": {
+            "type": "string"
+          },
+          "endDate": {
+            "type": "string"
+          },
+          "assignedTo": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          },
+          "assignedToNames": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          },
+          "sourceId": {
+            "type": "string"
+          },
+          "sourceType": {
+            "type": "string",
+            "enum": [
+              "schedule",
+              "projectTask",
+              "ticket",
+              "timeEntry",
+              "workflowTask",
+              "notification",
+              "document"
+            ]
+          },
+          "actions": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "properties": {
+                "id": {
+                  "type": "string"
+                },
+                "label": {
+                  "type": "string"
+                },
+                "icon": {
+                  "type": "string"
+                },
+                "disabled": {
+                  "type": "boolean"
+                },
+                "disabledReason": {
+                  "type": "string"
+                }
+              },
+              "required": [
+                "id",
+                "label"
+              ]
+            }
+          },
+          "isClosed": {
+            "type": "boolean"
+          },
+          "tenant": {
+            "type": "string"
+          },
+          "createdAt": {
+            "type": "string"
+          },
+          "updatedAt": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "id",
+          "title",
+          "type",
+          "status",
+          "priority",
+          "sourceId",
+          "sourceType",
+          "actions",
+          "tenant",
+          "createdAt",
+          "updatedAt"
+        ]
+      },
+      "ActivityListResponseV1": {
+        "type": "object",
+        "properties": {
+          "data": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "properties": {
+                "id": {
+                  "type": "string"
+                },
+                "title": {
+                  "type": "string"
+                },
+                "description": {
+                  "type": "string"
+                },
+                "type": {
+                  "type": "string",
+                  "enum": [
+                    "schedule",
+                    "projectTask",
+                    "ticket",
+                    "timeEntry",
+                    "workflowTask",
+                    "notification",
+                    "document"
+                  ]
+                },
+                "status": {
+                  "type": "string"
+                },
+                "statusColor": {
+                  "type": "string"
+                },
+                "priority": {
+                  "type": "string",
+                  "enum": [
+                    "low",
+                    "medium",
+                    "high"
+                  ]
+                },
+                "priorityName": {
+                  "type": "string"
+                },
+                "priorityColor": {
+                  "type": "string"
+                },
+                "dueDate": {
+                  "type": "string"
+                },
+                "startDate": {
+                  "type": "string"
+                },
+                "endDate": {
+                  "type": "string"
+                },
+                "assignedTo": {
+                  "type": "array",
+                  "items": {
+                    "type": "string"
+                  }
+                },
+                "assignedToNames": {
+                  "type": "array",
+                  "items": {
+                    "type": "string"
+                  }
+                },
+                "sourceId": {
+                  "type": "string"
+                },
+                "sourceType": {
+                  "type": "string",
+                  "enum": [
+                    "schedule",
+                    "projectTask",
+                    "ticket",
+                    "timeEntry",
+                    "workflowTask",
+                    "notification",
+                    "document"
+                  ]
+                },
+                "actions": {
+                  "type": "array",
+                  "items": {
+                    "type": "object",
+                    "properties": {
+                      "id": {
+                        "type": "string"
+                      },
+                      "label": {
+                        "type": "string"
+                      },
+                      "icon": {
+                        "type": "string"
+                      },
+                      "disabled": {
+                        "type": "boolean"
+                      },
+                      "disabledReason": {
+                        "type": "string"
+                      }
+                    },
+                    "required": [
+                      "id",
+                      "label"
+                    ]
+                  }
+                },
+                "isClosed": {
+                  "type": "boolean"
+                },
+                "tenant": {
+                  "type": "string"
+                },
+                "createdAt": {
+                  "type": "string"
+                },
+                "updatedAt": {
+                  "type": "string"
+                }
+              },
+              "required": [
+                "id",
+                "title",
+                "type",
+                "status",
+                "priority",
+                "sourceId",
+                "sourceType",
+                "actions",
+                "tenant",
+                "createdAt",
+                "updatedAt"
+              ]
+            }
+          },
+          "pagination": {
+            "type": "object",
+            "properties": {
+              "page": {
+                "type": "number"
+              },
+              "limit": {
+                "type": "number"
+              },
+              "total": {
+                "type": "number"
+              },
+              "totalPages": {
+                "type": "number"
+              },
+              "hasNext": {
+                "type": "boolean"
+              },
+              "hasPrev": {
+                "type": "boolean"
+              }
+            },
+            "required": [
+              "page",
+              "limit",
+              "total",
+              "totalPages",
+              "hasNext",
+              "hasPrev"
+            ]
+          },
+          "meta": {}
+        },
+        "required": [
+          "data",
+          "pagination"
+        ]
+      },
+      "ActivityGroupedResponseV1": {
+        "type": "object",
+        "properties": {
+          "data": {
+            "type": "object",
+            "properties": {
+              "groupBy": {
+                "type": "string",
+                "enum": [
+                  "type",
+                  "priority",
+                  "status",
+                  "dueDate"
+                ]
+              },
+              "groups": {
+                "type": "array",
+                "items": {
+                  "type": "object",
+                  "properties": {
+                    "key": {
+                      "type": "string"
+                    },
+                    "label": {
+                      "type": "string"
+                    },
+                    "count": {
+                      "type": "number"
+                    },
+                    "activities": {
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "properties": {
+                          "id": {
+                            "type": "string"
+                          },
+                          "title": {
+                            "type": "string"
+                          },
+                          "description": {
+                            "type": "string"
+                          },
+                          "type": {
+                            "type": "string",
+                            "enum": [
+                              "schedule",
+                              "projectTask",
+                              "ticket",
+                              "timeEntry",
+                              "workflowTask",
+                              "notification",
+                              "document"
+                            ]
+                          },
+                          "status": {
+                            "type": "string"
+                          },
+                          "statusColor": {
+                            "type": "string"
+                          },
+                          "priority": {
+                            "type": "string",
+                            "enum": [
+                              "low",
+                              "medium",
+                              "high"
+                            ]
+                          },
+                          "priorityName": {
+                            "type": "string"
+                          },
+                          "priorityColor": {
+                            "type": "string"
+                          },
+                          "dueDate": {
+                            "type": "string"
+                          },
+                          "startDate": {
+                            "type": "string"
+                          },
+                          "endDate": {
+                            "type": "string"
+                          },
+                          "assignedTo": {
+                            "type": "array",
+                            "items": {
+                              "type": "string"
+                            }
+                          },
+                          "assignedToNames": {
+                            "type": "array",
+                            "items": {
+                              "type": "string"
+                            }
+                          },
+                          "sourceId": {
+                            "type": "string"
+                          },
+                          "sourceType": {
+                            "type": "string",
+                            "enum": [
+                              "schedule",
+                              "projectTask",
+                              "ticket",
+                              "timeEntry",
+                              "workflowTask",
+                              "notification",
+                              "document"
+                            ]
+                          },
+                          "actions": {
+                            "type": "array",
+                            "items": {
+                              "type": "object",
+                              "properties": {
+                                "id": {
+                                  "type": "string"
+                                },
+                                "label": {
+                                  "type": "string"
+                                },
+                                "icon": {
+                                  "type": "string"
+                                },
+                                "disabled": {
+                                  "type": "boolean"
+                                },
+                                "disabledReason": {
+                                  "type": "string"
+                                }
+                              },
+                              "required": [
+                                "id",
+                                "label"
+                              ]
+                            }
+                          },
+                          "isClosed": {
+                            "type": "boolean"
+                          },
+                          "tenant": {
+                            "type": "string"
+                          },
+                          "createdAt": {
+                            "type": "string"
+                          },
+                          "updatedAt": {
+                            "type": "string"
+                          }
+                        },
+                        "required": [
+                          "id",
+                          "title",
+                          "type",
+                          "status",
+                          "priority",
+                          "sourceId",
+                          "sourceType",
+                          "actions",
+                          "tenant",
+                          "createdAt",
+                          "updatedAt"
+                        ]
+                      }
+                    }
+                  },
+                  "required": [
+                    "key",
+                    "label",
+                    "count",
+                    "activities"
+                  ]
+                }
+              },
+              "totalCount": {
+                "type": "number"
+              },
+              "truncated": {
+                "type": "boolean"
+              }
+            },
+            "required": [
+              "groupBy",
+              "groups",
+              "totalCount",
+              "truncated"
+            ]
+          },
+          "meta": {}
+        },
+        "required": [
+          "data"
+        ]
+      },
+      "AdHocActivityResponseV1": {
+        "type": "object",
+        "properties": {
+          "data": {
+            "type": "object",
+            "properties": {
+              "id": {
+                "type": "string"
+              },
+              "title": {
+                "type": "string"
+              },
+              "description": {
+                "type": "string"
+              },
+              "type": {
+                "type": "string",
+                "enum": [
+                  "schedule",
+                  "projectTask",
+                  "ticket",
+                  "timeEntry",
+                  "workflowTask",
+                  "notification",
+                  "document"
+                ]
+              },
+              "status": {
+                "type": "string"
+              },
+              "statusColor": {
+                "type": "string"
+              },
+              "priority": {
+                "type": "string",
+                "enum": [
+                  "low",
+                  "medium",
+                  "high"
+                ]
+              },
+              "priorityName": {
+                "type": "string"
+              },
+              "priorityColor": {
+                "type": "string"
+              },
+              "dueDate": {
+                "type": "string"
+              },
+              "startDate": {
+                "type": "string"
+              },
+              "endDate": {
+                "type": "string"
+              },
+              "assignedTo": {
+                "type": "array",
+                "items": {
+                  "type": "string"
+                }
+              },
+              "assignedToNames": {
+                "type": "array",
+                "items": {
+                  "type": "string"
+                }
+              },
+              "sourceId": {
+                "type": "string"
+              },
+              "sourceType": {
+                "type": "string",
+                "enum": [
+                  "schedule",
+                  "projectTask",
+                  "ticket",
+                  "timeEntry",
+                  "workflowTask",
+                  "notification",
+                  "document"
+                ]
+              },
+              "actions": {
+                "type": "array",
+                "items": {
+                  "type": "object",
+                  "properties": {
+                    "id": {
+                      "type": "string"
+                    },
+                    "label": {
+                      "type": "string"
+                    },
+                    "icon": {
+                      "type": "string"
+                    },
+                    "disabled": {
+                      "type": "boolean"
+                    },
+                    "disabledReason": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "id",
+                    "label"
+                  ]
+                }
+              },
+              "isClosed": {
+                "type": "boolean"
+              },
+              "tenant": {
+                "type": "string"
+              },
+              "createdAt": {
+                "type": "string"
+              },
+              "updatedAt": {
+                "type": "string"
+              }
+            },
+            "required": [
+              "id",
+              "title",
+              "type",
+              "status",
+              "priority",
+              "sourceId",
+              "sourceType",
+              "actions",
+              "tenant",
+              "createdAt",
+              "updatedAt"
+            ]
+          },
+          "meta": {}
+        },
+        "required": [
+          "data"
+        ]
+      },
+      "CreateAdHocActivityBodyV1": {
+        "type": "object",
+        "properties": {
+          "title": {
+            "type": "string",
+            "minLength": 1
+          },
+          "notes": {
+            "type": "string"
+          },
+          "scheduledStart": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "format": "date-time"
+          },
+          "scheduledEnd": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "format": "date-time"
+          }
+        },
+        "required": [
+          "title"
+        ]
+      },
+      "UpdateAdHocActivityBodyV1": {
+        "type": "object",
+        "properties": {
+          "title": {
+            "type": "string",
+            "minLength": 1
+          },
+          "notes": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "scheduledStart": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "format": "date-time"
+          },
+          "scheduledEnd": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "format": "date-time"
+          }
+        }
+      },
+      "SetAdHocActivityDoneBodyV1": {
+        "type": "object",
+        "properties": {
+          "done": {
+            "type": "boolean"
+          }
+        },
+        "required": [
+          "done"
+        ]
+      },
+      "CustomActivityGroupsResponseV1": {
+        "type": "object",
+        "properties": {
+          "data": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "properties": {
+                "groupId": {
+                  "type": "string"
+                },
+                "groupName": {
+                  "type": "string"
+                },
+                "sortOrder": {
+                  "type": "number"
+                },
+                "isCollapsed": {
+                  "type": "boolean"
+                },
+                "items": {
+                  "type": "array",
+                  "items": {
+                    "type": "object",
+                    "properties": {
+                      "itemId": {
+                        "type": "string"
+                      },
+                      "activityId": {
+                        "type": "string"
+                      },
+                      "activityType": {
+                        "type": "string"
+                      },
+                      "sortOrder": {
+                        "type": "number"
+                      }
+                    },
+                    "required": [
+                      "itemId",
+                      "activityId",
+                      "activityType",
+                      "sortOrder"
+                    ]
+                  }
+                }
+              },
+              "required": [
+                "groupId",
+                "groupName",
+                "sortOrder",
+                "isCollapsed",
+                "items"
+              ]
+            }
+          },
+          "meta": {}
+        },
+        "required": [
+          "data"
+        ]
+      },
+      "MoveActivityToGroupBodyV1": {
+        "type": "object",
+        "properties": {
+          "activityId": {
+            "type": "string",
+            "minLength": 1
+          },
+          "activityType": {
+            "type": "string",
+            "minLength": 1
+          },
+          "groupId": {
+            "type": "string",
+            "minLength": 1
+          },
+          "sortOrder": {
+            "type": "integer",
+            "minimum": 0
+          }
+        },
+        "required": [
+          "activityId",
+          "activityType",
+          "groupId",
+          "sortOrder"
+        ]
+      },
+      "RemoveActivityFromGroupBodyV1": {
+        "type": "object",
+        "properties": {
+          "activityId": {
+            "type": "string",
+            "minLength": 1
+          },
+          "activityType": {
+            "type": "string",
+            "minLength": 1
+          }
+        },
+        "required": [
+          "activityId",
+          "activityType"
+        ]
+      },
+      "ReorderActivitiesInGroupBodyV1": {
+        "type": "object",
+        "properties": {
+          "items": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "properties": {
+                "activityId": {
+                  "type": "string",
+                  "minLength": 1
+                },
+                "activityType": {
+                  "type": "string",
+                  "minLength": 1
+                },
+                "sortOrder": {
+                  "type": "integer",
+                  "minimum": 0
+                }
+              },
+              "required": [
+                "activityId",
+                "activityType",
+                "sortOrder"
+              ]
+            },
+            "minItems": 1
+          }
+        },
+        "required": [
+          "items"
+        ]
+      },
+      "ActivitiesGroupIdParamV1": {
+        "type": "object",
+        "properties": {
+          "groupId": {
+            "type": "string",
+            "description": "Custom activity group identifier."
+          }
+        },
+        "required": [
+          "groupId"
+        ]
+      },
+      "ActivitiesGroupsQueryV1": {
+        "type": "object",
+        "properties": {
+          "targetUserId": {
+            "type": "string",
+            "description": "Another internal user whose groups to read (requires elevated schedule permission). Omit for self."
+          }
+        }
       },
       "ProjectIdParams": {
         "type": "object",
@@ -71046,8 +72528,7 @@
                   "currency_code": {
                     "type": "string",
                     "minLength": 3,
-                    "maxLength": 3,
-                    "default": "USD"
+                    "maxLength": 3
                   },
                   "unit_of_measure": {
                     "type": "string",
@@ -71137,8 +72618,7 @@
                       {
                         "type": "null"
                       }
-                    ],
-                    "default": "USD"
+                    ]
                   },
                   "vendor": {
                     "anyOf": [
@@ -71442,8 +72922,7 @@
                   "currency_code": {
                     "type": "string",
                     "minLength": 3,
-                    "maxLength": 3,
-                    "default": "USD"
+                    "maxLength": 3
                   },
                   "unit_of_measure": {
                     "type": "string",
@@ -71533,8 +73012,7 @@
                       {
                         "type": "null"
                       }
-                    ],
-                    "default": "USD"
+                    ]
                   },
                   "vendor": {
                     "anyOf": [
@@ -75244,8 +76722,8 @@
       }
     },
     "/api/v1/workflows/tasks": {
-      "get": {
-        "summary": "List workflow tasks (route inventory only)",
+      "post": {
+        "summary": "Create workflow task (route inventory only)",
         "description": "This operation is currently present only in generated route inventory. No corresponding Next.js handler exists under server/src/app/api/v1/workflows in this worktree. Runtime behavior is middleware-dependent: missing/invalid x-api-key can return 401 before routing; with middleware requirements satisfied, Next.js returns not-found for the absent handler. Existing workflow APIs in this codebase are implemented under /api/workflow-definitions, /api/workflow-runs, and /api/workflow/events rather than /api/v1/workflows paths.",
         "tags": [
           "Workflows v1"
@@ -75286,11 +76764,11 @@
           }
         }
       },
-      "post": {
-        "summary": "Create workflow task (route inventory only)",
-        "description": "This operation is currently present only in generated route inventory. No corresponding Next.js handler exists under server/src/app/api/v1/workflows in this worktree. Runtime behavior is middleware-dependent: missing/invalid x-api-key can return 401 before routing; with middleware requirements satisfied, Next.js returns not-found for the absent handler. Existing workflow APIs in this codebase are implemented under /api/workflow-definitions, /api/workflow-runs, and /api/workflow/events rather than /api/v1/workflows paths.",
+      "get": {
+        "summary": "List workflow tasks",
+        "description": "Returns the authenticated caller's workflow task inbox (tasks assigned to them directly or via a role), paginated. Items are summary rows without `formSchema`; fetch a single task to obtain its form schema. EE-only — on the Community build this returns an empty page.",
         "tags": [
-          "Workflows v1"
+          "Workflow Tasks v1"
         ],
         "security": [
           {
@@ -75298,30 +76776,85 @@
           }
         ],
         "extensions": {
-          "x-route-inventory-only": true,
-          "x-route-file-missing": "server/src/app/api/v1/workflows/**/route.ts",
-          "x-family-status": "missing-handler"
+          "x-tenant-scoped": true,
+          "x-auth-mechanism": "NextAuth session, falling back to x-api-key (resolveWorkflowTaskAuthContext)",
+          "x-edition-behavior": "EE-only feature; CE returns an empty page (list) or 404 (detail/actions)."
         },
         "x-alga-products": [
           "psa"
         ],
+        "parameters": [
+          {
+            "schema": {
+              "type": "string",
+              "description": "Comma-separated WorkflowTaskStatus values (pending, claimed, completed, canceled, expired). Omit for the open inbox (pending + claimed)."
+            },
+            "required": false,
+            "description": "Comma-separated WorkflowTaskStatus values (pending, claimed, completed, canceled, expired). Omit for the open inbox (pending + claimed).",
+            "name": "status",
+            "in": "query"
+          },
+          {
+            "schema": {
+              "type": "integer",
+              "minimum": 1,
+              "description": "1-based page number (default 1)."
+            },
+            "required": false,
+            "description": "1-based page number (default 1).",
+            "name": "page",
+            "in": "query"
+          },
+          {
+            "schema": {
+              "type": "integer",
+              "minimum": 1,
+              "maximum": 100,
+              "description": "Items per page, max 100 (default 25)."
+            },
+            "required": false,
+            "description": "Items per page, max 100 (default 25).",
+            "name": "pageSize",
+            "in": "query"
+          }
+        ],
         "responses": {
-          "401": {
-            "description": "x-api-key missing/invalid at middleware.",
+          "200": {
+            "description": "Paginated workflow task inbox.",
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/WorkflowV1MissingApiError"
+                  "$ref": "#/components/schemas/WorkflowTaskListResponseV1"
                 }
               }
             }
           },
-          "404": {
-            "description": "No route handler exists for this inventory-only /api/v1/workflows path.",
+          "400": {
+            "description": "Invalid query parameters.",
             "content": {
-              "text/html": {
+              "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/WorkflowV1MissingRouteResponse"
+                  "$ref": "#/components/schemas/WorkflowTasksApiErrorV1"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Authentication required (no session and no/invalid x-api-key).",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/WorkflowTasksApiErrorV1"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Unexpected failure resolving the task inbox.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/WorkflowTasksApiErrorV1"
                 }
               }
             }
@@ -75374,48 +76907,6 @@
       }
     },
     "/api/v1/workflows/tasks/{id}": {
-      "get": {
-        "summary": "Get workflow task by id (route inventory only)",
-        "description": "This operation is currently present only in generated route inventory. No corresponding Next.js handler exists under server/src/app/api/v1/workflows in this worktree. Runtime behavior is middleware-dependent: missing/invalid x-api-key can return 401 before routing; with middleware requirements satisfied, Next.js returns not-found for the absent handler. Existing workflow APIs in this codebase are implemented under /api/workflow-definitions, /api/workflow-runs, and /api/workflow/events rather than /api/v1/workflows paths.",
-        "tags": [
-          "Workflows v1"
-        ],
-        "security": [
-          {
-            "ApiKeyAuth": []
-          }
-        ],
-        "extensions": {
-          "x-route-inventory-only": true,
-          "x-route-file-missing": "server/src/app/api/v1/workflows/**/route.ts",
-          "x-family-status": "missing-handler"
-        },
-        "x-alga-products": [
-          "psa"
-        ],
-        "responses": {
-          "401": {
-            "description": "x-api-key missing/invalid at middleware.",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/WorkflowV1MissingApiError"
-                }
-              }
-            }
-          },
-          "404": {
-            "description": "No route handler exists for this inventory-only /api/v1/workflows path.",
-            "content": {
-              "text/html": {
-                "schema": {
-                  "$ref": "#/components/schemas/WorkflowV1MissingRouteResponse"
-                }
-              }
-            }
-          }
-        }
-      },
       "put": {
         "summary": "Update workflow task (route inventory only)",
         "description": "This operation is currently present only in generated route inventory. No corresponding Next.js handler exists under server/src/app/api/v1/workflows in this worktree. Runtime behavior is middleware-dependent: missing/invalid x-api-key can return 401 before routing; with middleware requirements satisfied, Next.js returns not-found for the absent handler. Existing workflow APIs in this codebase are implemented under /api/workflow-definitions, /api/workflow-runs, and /api/workflow/events rather than /api/v1/workflows paths.",
@@ -75457,14 +76948,12 @@
             }
           }
         }
-      }
-    },
-    "/api/v1/workflows/tasks/{id}/claim": {
-      "post": {
-        "summary": "Claim workflow task (route inventory only)",
-        "description": "This operation is currently present only in generated route inventory. No corresponding Next.js handler exists under server/src/app/api/v1/workflows in this worktree. Runtime behavior is middleware-dependent: missing/invalid x-api-key can return 401 before routing; with middleware requirements satisfied, Next.js returns not-found for the absent handler. Existing workflow APIs in this codebase are implemented under /api/workflow-definitions, /api/workflow-runs, and /api/workflow/events rather than /api/v1/workflows paths.",
+      },
+      "get": {
+        "summary": "Get workflow task",
+        "description": "Returns full detail for a single workflow task, including `formSchema` ({ jsonSchema, uiSchema?, defaultValues? }) so a client can classify the form as simple (native completion) vs complex (web deep-link). EE-only — on the Community build this returns 404.",
         "tags": [
-          "Workflows v1"
+          "Workflow Tasks v1"
         ],
         "security": [
           {
@@ -75472,74 +76961,62 @@
           }
         ],
         "extensions": {
-          "x-route-inventory-only": true,
-          "x-route-file-missing": "server/src/app/api/v1/workflows/**/route.ts",
-          "x-family-status": "missing-handler"
+          "x-tenant-scoped": true,
+          "x-auth-mechanism": "NextAuth session, falling back to x-api-key (resolveWorkflowTaskAuthContext)",
+          "x-edition-behavior": "EE-only feature; CE returns an empty page (list) or 404 (detail/actions)."
         },
         "x-alga-products": [
           "psa"
         ],
-        "responses": {
-          "401": {
-            "description": "x-api-key missing/invalid at middleware.",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/WorkflowV1MissingApiError"
-                }
-              }
-            }
-          },
-          "404": {
-            "description": "No route handler exists for this inventory-only /api/v1/workflows path.",
-            "content": {
-              "text/html": {
-                "schema": {
-                  "$ref": "#/components/schemas/WorkflowV1MissingRouteResponse"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/api/v1/workflows/tasks/{id}/complete": {
-      "post": {
-        "summary": "Complete workflow task (route inventory only)",
-        "description": "This operation is currently present only in generated route inventory. No corresponding Next.js handler exists under server/src/app/api/v1/workflows in this worktree. Runtime behavior is middleware-dependent: missing/invalid x-api-key can return 401 before routing; with middleware requirements satisfied, Next.js returns not-found for the absent handler. Existing workflow APIs in this codebase are implemented under /api/workflow-definitions, /api/workflow-runs, and /api/workflow/events rather than /api/v1/workflows paths.",
-        "tags": [
-          "Workflows v1"
-        ],
-        "security": [
+        "parameters": [
           {
-            "ApiKeyAuth": []
+            "schema": {
+              "type": "string",
+              "description": "Workflow task identifier (taskId)."
+            },
+            "required": true,
+            "description": "Workflow task identifier (taskId).",
+            "name": "id",
+            "in": "path"
           }
         ],
-        "extensions": {
-          "x-route-inventory-only": true,
-          "x-route-file-missing": "server/src/app/api/v1/workflows/**/route.ts",
-          "x-family-status": "missing-handler"
-        },
-        "x-alga-products": [
-          "psa"
-        ],
         "responses": {
-          "401": {
-            "description": "x-api-key missing/invalid at middleware.",
+          "200": {
+            "description": "Workflow task detail including the resolved form schema.",
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/WorkflowV1MissingApiError"
+                  "$ref": "#/components/schemas/WorkflowTaskDetailResponseV1"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Authentication required.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/WorkflowTasksApiErrorV1"
                 }
               }
             }
           },
           "404": {
-            "description": "No route handler exists for this inventory-only /api/v1/workflows path.",
+            "description": "Task not found (or workflow tasks unavailable on this build).",
             "content": {
-              "text/html": {
+              "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/WorkflowV1MissingRouteResponse"
+                  "$ref": "#/components/schemas/WorkflowTasksApiErrorV1"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Unexpected failure resolving the task.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/WorkflowTasksApiErrorV1"
                 }
               }
             }
@@ -75882,6 +77359,1253 @@
               "text/html": {
                 "schema": {
                   "$ref": "#/components/schemas/WorkflowV1MissingRouteResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/workflows/tasks/{id}/claim": {
+      "post": {
+        "summary": "Claim workflow task",
+        "description": "Claims a pending task for the caller. No request body. EE-only — on the Community build this returns 404.",
+        "tags": [
+          "Workflow Tasks v1"
+        ],
+        "security": [
+          {
+            "ApiKeyAuth": []
+          }
+        ],
+        "extensions": {
+          "x-tenant-scoped": true,
+          "x-auth-mechanism": "NextAuth session, falling back to x-api-key (resolveWorkflowTaskAuthContext)",
+          "x-edition-behavior": "EE-only feature; CE returns an empty page (list) or 404 (detail/actions)."
+        },
+        "x-alga-products": [
+          "psa"
+        ],
+        "parameters": [
+          {
+            "schema": {
+              "type": "string",
+              "description": "Workflow task identifier (taskId)."
+            },
+            "required": true,
+            "description": "Workflow task identifier (taskId).",
+            "name": "id",
+            "in": "path"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Task claimed.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/WorkflowTaskActionResponseV1"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Authentication required.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/WorkflowTasksApiErrorV1"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Task not found (or workflow tasks unavailable on this build).",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/WorkflowTasksApiErrorV1"
+                }
+              }
+            }
+          },
+          "409": {
+            "description": "Task already claimed by another user or not in a claimable state.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/WorkflowTasksApiErrorV1"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Unexpected failure claiming the task.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/WorkflowTasksApiErrorV1"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/workflows/tasks/{id}/unclaim": {
+      "post": {
+        "summary": "Unclaim workflow task",
+        "description": "Releases a task the caller has claimed, returning it to the pending pool. No request body. EE-only — on the Community build this returns 404.",
+        "tags": [
+          "Workflow Tasks v1"
+        ],
+        "security": [
+          {
+            "ApiKeyAuth": []
+          }
+        ],
+        "extensions": {
+          "x-tenant-scoped": true,
+          "x-auth-mechanism": "NextAuth session, falling back to x-api-key (resolveWorkflowTaskAuthContext)",
+          "x-edition-behavior": "EE-only feature; CE returns an empty page (list) or 404 (detail/actions)."
+        },
+        "x-alga-products": [
+          "psa"
+        ],
+        "parameters": [
+          {
+            "schema": {
+              "type": "string",
+              "description": "Workflow task identifier (taskId)."
+            },
+            "required": true,
+            "description": "Workflow task identifier (taskId).",
+            "name": "id",
+            "in": "path"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Task released.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/WorkflowTaskActionResponseV1"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Authentication required.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/WorkflowTasksApiErrorV1"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Task not found (or workflow tasks unavailable on this build).",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/WorkflowTasksApiErrorV1"
+                }
+              }
+            }
+          },
+          "409": {
+            "description": "Task is not claimed by the caller.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/WorkflowTasksApiErrorV1"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Unexpected failure releasing the task.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/WorkflowTasksApiErrorV1"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/workflows/tasks/{id}/complete": {
+      "post": {
+        "summary": "Complete workflow task",
+        "description": "Submits the task's form payload and completes it. The form data is validated server-side against the task's JSON Schema; validation failures return 400 with the schema errors in `error.details`. EE-only — on the Community build this returns 404.",
+        "tags": [
+          "Workflow Tasks v1"
+        ],
+        "security": [
+          {
+            "ApiKeyAuth": []
+          }
+        ],
+        "extensions": {
+          "x-tenant-scoped": true,
+          "x-auth-mechanism": "NextAuth session, falling back to x-api-key (resolveWorkflowTaskAuthContext)",
+          "x-edition-behavior": "EE-only feature; CE returns an empty page (list) or 404 (detail/actions)."
+        },
+        "x-alga-products": [
+          "psa"
+        ],
+        "parameters": [
+          {
+            "schema": {
+              "type": "string",
+              "description": "Workflow task identifier (taskId)."
+            },
+            "required": true,
+            "description": "Workflow task identifier (taskId).",
+            "name": "id",
+            "in": "path"
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/CompleteWorkflowTaskBodyV1"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Task completed.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/WorkflowTaskActionResponseV1"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Form validation failed; schema errors are returned in `error.details`.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/WorkflowTasksApiErrorV1"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Authentication required.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/WorkflowTasksApiErrorV1"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Task not found (or workflow tasks unavailable on this build).",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/WorkflowTasksApiErrorV1"
+                }
+              }
+            }
+          },
+          "409": {
+            "description": "Task is not in a completable state for the caller.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/WorkflowTasksApiErrorV1"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Unexpected failure completing the task.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/WorkflowTasksApiErrorV1"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/activities": {
+      "get": {
+        "summary": "List user activities",
+        "description": "Returns the authenticated caller's unified activity list — a fan-out across tickets, project tasks, schedule entries, ad-hoc items, workflow tasks, time entries and notifications. Filter by activity type(s), open/closed status, priority, due-date window, free-text search and a date window; sort via `sortBy`/`sortDirection`. By default the result is paginated (ActivityListResponseV1). When `groupBy` is supplied the result is instead grouped server-side into ordered, counted buckets (ActivityGroupedResponseV1) and `page`/`pageSize` are ignored.",
+        "tags": [
+          "Activities v1"
+        ],
+        "security": [
+          {
+            "ApiKeyAuth": []
+          }
+        ],
+        "extensions": {
+          "x-tenant-scoped": true,
+          "x-auth-mechanism": "NextAuth session, falling back to x-api-key (resolveActivityAuthContext)",
+          "x-response-when-grouped": "#/components/schemas/ActivityGroupedResponseV1"
+        },
+        "x-alga-products": [
+          "psa"
+        ],
+        "parameters": [
+          {
+            "schema": {
+              "type": "string",
+              "description": "Comma-separated ActivityType values (e.g. \"ticket,schedule\"). Omit for all types."
+            },
+            "required": false,
+            "description": "Comma-separated ActivityType values (e.g. \"ticket,schedule\"). Omit for all types.",
+            "name": "type",
+            "in": "query"
+          },
+          {
+            "schema": {
+              "type": "string",
+              "enum": [
+                "open",
+                "closed",
+                "all"
+              ],
+              "description": "Open/closed filter. `open`→active only, `closed`→closed, `all`→no filter (default)."
+            },
+            "required": false,
+            "description": "Open/closed filter. `open`→active only, `closed`→closed, `all`→no filter (default).",
+            "name": "status",
+            "in": "query"
+          },
+          {
+            "schema": {
+              "type": "string",
+              "description": "Free-text search across activity titles/descriptions."
+            },
+            "required": false,
+            "description": "Free-text search across activity titles/descriptions.",
+            "name": "search",
+            "in": "query"
+          },
+          {
+            "schema": {
+              "type": "string",
+              "format": "date-time",
+              "description": "ISO 8601 lower bound of the schedule/time-entry/notification window."
+            },
+            "required": false,
+            "description": "ISO 8601 lower bound of the schedule/time-entry/notification window.",
+            "name": "dateStart",
+            "in": "query"
+          },
+          {
+            "schema": {
+              "type": "string",
+              "format": "date-time",
+              "description": "ISO 8601 upper bound of the window."
+            },
+            "required": false,
+            "description": "ISO 8601 upper bound of the window.",
+            "name": "dateEnd",
+            "in": "query"
+          },
+          {
+            "schema": {
+              "type": "string",
+              "description": "Comma-separated normalized ActivityPriority buckets (e.g. \"high,medium\"). Lossy for custom schemes; prefer `priorityIds`."
+            },
+            "required": false,
+            "description": "Comma-separated normalized ActivityPriority buckets (e.g. \"high,medium\"). Lossy for custom schemes; prefer `priorityIds`.",
+            "name": "priority",
+            "in": "query"
+          },
+          {
+            "schema": {
+              "type": "string",
+              "description": "Comma-separated exact priority IDs (the tenant's real per-type priorities). Applies to ticket/project-task activities."
+            },
+            "required": false,
+            "description": "Comma-separated exact priority IDs (the tenant's real per-type priorities). Applies to ticket/project-task activities.",
+            "name": "priorityIds",
+            "in": "query"
+          },
+          {
+            "schema": {
+              "type": "string",
+              "format": "date-time",
+              "description": "ISO 8601 lower bound of the due-date filter (independent of the schedule window)."
+            },
+            "required": false,
+            "description": "ISO 8601 lower bound of the due-date filter (independent of the schedule window).",
+            "name": "dueDateStart",
+            "in": "query"
+          },
+          {
+            "schema": {
+              "type": "string",
+              "format": "date-time",
+              "description": "ISO 8601 upper bound of the due-date filter."
+            },
+            "required": false,
+            "description": "ISO 8601 upper bound of the due-date filter.",
+            "name": "dueDateEnd",
+            "in": "query"
+          },
+          {
+            "schema": {
+              "type": "string",
+              "format": "date-time",
+              "description": "ISO 8601 lower bound of the created-date (\"date entered\") filter. Applies to every activity type."
+            },
+            "required": false,
+            "description": "ISO 8601 lower bound of the created-date (\"date entered\") filter. Applies to every activity type.",
+            "name": "createdAtStart",
+            "in": "query"
+          },
+          {
+            "schema": {
+              "type": "string",
+              "format": "date-time",
+              "description": "ISO 8601 upper bound of the created-date (\"date entered\") filter."
+            },
+            "required": false,
+            "description": "ISO 8601 upper bound of the created-date (\"date entered\") filter.",
+            "name": "createdAtEnd",
+            "in": "query"
+          },
+          {
+            "schema": {
+              "type": "string",
+              "enum": [
+                "type",
+                "title",
+                "status",
+                "priority",
+                "dueDate"
+              ],
+              "description": "Sort column. Omit for the default sort (priority high→low, then due date ascending)."
+            },
+            "required": false,
+            "description": "Sort column. Omit for the default sort (priority high→low, then due date ascending).",
+            "name": "sortBy",
+            "in": "query"
+          },
+          {
+            "schema": {
+              "type": "string",
+              "enum": [
+                "asc",
+                "desc"
+              ],
+              "description": "Sort direction for `sortBy` (default asc). Ignored when `sortBy` is omitted."
+            },
+            "required": false,
+            "description": "Sort direction for `sortBy` (default asc). Ignored when `sortBy` is omitted.",
+            "name": "sortDirection",
+            "in": "query"
+          },
+          {
+            "schema": {
+              "type": "string",
+              "enum": [
+                "type",
+                "priority",
+                "status",
+                "dueDate"
+              ],
+              "description": "When set, the response is grouped by this dimension (ActivityGroupedResponseV1) instead of the paginated list; `page`/`pageSize` are ignored. `priority` groups by the real per-tenant priority name (not the normalized bucket), so it is only meaningful when scoped to a single prioritized type."
+            },
+            "required": false,
+            "description": "When set, the response is grouped by this dimension (ActivityGroupedResponseV1) instead of the paginated list; `page`/`pageSize` are ignored. `priority` groups by the real per-tenant priority name (not the normalized bucket), so it is only meaningful when scoped to a single prioritized type.",
+            "name": "groupBy",
+            "in": "query"
+          },
+          {
+            "schema": {
+              "type": "integer",
+              "minimum": 1,
+              "description": "1-based page number (default 1). Ignored when `groupBy` is set."
+            },
+            "required": false,
+            "description": "1-based page number (default 1). Ignored when `groupBy` is set.",
+            "name": "page",
+            "in": "query"
+          },
+          {
+            "schema": {
+              "type": "integer",
+              "minimum": 1,
+              "maximum": 100,
+              "description": "Items per page, max 100 (default 25). Ignored when `groupBy` is set."
+            },
+            "required": false,
+            "description": "Items per page, max 100 (default 25). Ignored when `groupBy` is set.",
+            "name": "pageSize",
+            "in": "query"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Paginated activity list, or grouped buckets when `groupBy` is set.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ActivityListResponseV1"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Invalid query parameters.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ActivitiesApiErrorV1"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Authentication required (no session and no/invalid x-api-key).",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ActivitiesApiErrorV1"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Permission denied for one of the underlying activity sources.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ActivitiesApiErrorV1"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Unexpected failure resolving activities.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ActivitiesApiErrorV1"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/activities/ad-hoc": {
+      "post": {
+        "summary": "Create ad-hoc activity",
+        "description": "Creates a personal, self-assigned ad-hoc to-do rendered as a schedule activity. Times are optional; when both are supplied the end must be after the start. Gated by `user_schedule:read`.",
+        "tags": [
+          "Activities v1"
+        ],
+        "security": [
+          {
+            "ApiKeyAuth": []
+          }
+        ],
+        "extensions": {
+          "x-tenant-scoped": true,
+          "x-auth-mechanism": "NextAuth session, falling back to x-api-key (resolveActivityAuthContext)"
+        },
+        "x-alga-products": [
+          "psa"
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/CreateAdHocActivityBodyV1"
+              }
+            }
+          }
+        },
+        "responses": {
+          "201": {
+            "description": "Ad-hoc activity created.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/AdHocActivityResponseV1"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Invalid request body (e.g. missing title or end before start).",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ActivitiesApiErrorV1"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Authentication required.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ActivitiesApiErrorV1"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Permission denied (user_schedule:read).",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ActivitiesApiErrorV1"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Unexpected failure creating the ad-hoc activity.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ActivitiesApiErrorV1"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/activities/ad-hoc/{id}": {
+      "patch": {
+        "summary": "Update ad-hoc activity",
+        "description": "Updates an ad-hoc item's title, notes or optional times. Omitted fields are left unchanged; `notes: null` clears the field. Requires the caller to be an assignee, or hold `user_schedule:update` / `user_schedule:read_all`.",
+        "tags": [
+          "Activities v1"
+        ],
+        "security": [
+          {
+            "ApiKeyAuth": []
+          }
+        ],
+        "extensions": {
+          "x-tenant-scoped": true,
+          "x-auth-mechanism": "NextAuth session, falling back to x-api-key (resolveActivityAuthContext)"
+        },
+        "x-alga-products": [
+          "psa"
+        ],
+        "parameters": [
+          {
+            "schema": {
+              "type": "string",
+              "description": "Ad-hoc activity identifier (the backing schedule entry id)."
+            },
+            "required": true,
+            "description": "Ad-hoc activity identifier (the backing schedule entry id).",
+            "name": "id",
+            "in": "path"
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/UpdateAdHocActivityBodyV1"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Updated ad-hoc activity.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/AdHocActivityResponseV1"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Invalid request body (e.g. end before start).",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ActivitiesApiErrorV1"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Authentication required.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ActivitiesApiErrorV1"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Permission denied.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ActivitiesApiErrorV1"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Ad-hoc activity not found.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ActivitiesApiErrorV1"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Unexpected failure updating the ad-hoc activity.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ActivitiesApiErrorV1"
+                }
+              }
+            }
+          }
+        }
+      },
+      "delete": {
+        "summary": "Delete ad-hoc activity",
+        "description": "Permanently deletes an ad-hoc item. Requires the caller to be an assignee, or hold `user_schedule:update` / `user_schedule:read_all`.",
+        "tags": [
+          "Activities v1"
+        ],
+        "security": [
+          {
+            "ApiKeyAuth": []
+          }
+        ],
+        "extensions": {
+          "x-tenant-scoped": true,
+          "x-auth-mechanism": "NextAuth session, falling back to x-api-key (resolveActivityAuthContext)"
+        },
+        "x-alga-products": [
+          "psa"
+        ],
+        "parameters": [
+          {
+            "schema": {
+              "type": "string",
+              "description": "Ad-hoc activity identifier (the backing schedule entry id)."
+            },
+            "required": true,
+            "description": "Ad-hoc activity identifier (the backing schedule entry id).",
+            "name": "id",
+            "in": "path"
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "Ad-hoc activity deleted; no content."
+          },
+          "401": {
+            "description": "Authentication required.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ActivitiesApiErrorV1"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Permission denied.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ActivitiesApiErrorV1"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Ad-hoc activity not found.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ActivitiesApiErrorV1"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Unexpected failure deleting the ad-hoc activity.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ActivitiesApiErrorV1"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/activities/ad-hoc/{id}/done": {
+      "post": {
+        "summary": "Toggle ad-hoc activity done",
+        "description": "Marks an ad-hoc item done/undone. `done: true` sets status to closed; `done: false` reopens it (status scheduled). Requires the caller to be an assignee, or hold `user_schedule:update` / `user_schedule:read_all`.",
+        "tags": [
+          "Activities v1"
+        ],
+        "security": [
+          {
+            "ApiKeyAuth": []
+          }
+        ],
+        "extensions": {
+          "x-tenant-scoped": true,
+          "x-auth-mechanism": "NextAuth session, falling back to x-api-key (resolveActivityAuthContext)"
+        },
+        "x-alga-products": [
+          "psa"
+        ],
+        "parameters": [
+          {
+            "schema": {
+              "type": "string",
+              "description": "Ad-hoc activity identifier (the backing schedule entry id)."
+            },
+            "required": true,
+            "description": "Ad-hoc activity identifier (the backing schedule entry id).",
+            "name": "id",
+            "in": "path"
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/SetAdHocActivityDoneBodyV1"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Updated ad-hoc activity.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/AdHocActivityResponseV1"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Invalid request body (e.g. missing `done`).",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ActivitiesApiErrorV1"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Authentication required.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ActivitiesApiErrorV1"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Permission denied.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ActivitiesApiErrorV1"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Ad-hoc activity not found.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ActivitiesApiErrorV1"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Unexpected failure updating the ad-hoc activity.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ActivitiesApiErrorV1"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/activities/groups": {
+      "get": {
+        "summary": "List custom activity groups",
+        "description": "Returns the caller's saved custom activity groups (created and ordered in the web app), each with its ordered item references. Read-only: clients bucket the unified activity list into these groups for a \"My groups\" view. Pass `targetUserId` to read another user's groups (requires `user_schedule:update` / `user_schedule:read_all`). Membership and ordering are changed via the `/groups/items` endpoints.",
+        "tags": [
+          "Activities v1"
+        ],
+        "security": [
+          {
+            "ApiKeyAuth": []
+          }
+        ],
+        "extensions": {
+          "x-tenant-scoped": true,
+          "x-auth-mechanism": "NextAuth session, falling back to x-api-key (resolveActivityAuthContext)"
+        },
+        "x-alga-products": [
+          "psa"
+        ],
+        "parameters": [
+          {
+            "schema": {
+              "type": "string",
+              "description": "Another internal user whose groups to read (requires elevated schedule permission). Omit for self."
+            },
+            "required": false,
+            "description": "Another internal user whose groups to read (requires elevated schedule permission). Omit for self.",
+            "name": "targetUserId",
+            "in": "query"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "The caller's custom activity groups.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/CustomActivityGroupsResponseV1"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Authentication required.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ActivitiesApiErrorV1"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Permission denied (reading another user's groups).",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ActivitiesApiErrorV1"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Unexpected failure resolving groups.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ActivitiesApiErrorV1"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/activities/groups/items": {
+      "post": {
+        "summary": "Move an activity into a group",
+        "description": "Moves an activity into one of the caller's custom groups at the given position (`sortOrder`), removing it from any other group first so an activity belongs to at most one group. Rows at/after the index are shifted to keep ordering dense. Scoped to the caller's own groups; gated by `user_schedule:read`.",
+        "tags": [
+          "Activities v1"
+        ],
+        "security": [
+          {
+            "ApiKeyAuth": []
+          }
+        ],
+        "extensions": {
+          "x-tenant-scoped": true,
+          "x-auth-mechanism": "NextAuth session, falling back to x-api-key (resolveActivityAuthContext)"
+        },
+        "x-alga-products": [
+          "psa"
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/MoveActivityToGroupBodyV1"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Activity moved."
+          },
+          "400": {
+            "description": "Invalid request body.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ActivitiesApiErrorV1"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Authentication required.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ActivitiesApiErrorV1"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Permission denied (user_schedule:read).",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ActivitiesApiErrorV1"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Target group not found.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ActivitiesApiErrorV1"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Unexpected failure moving the activity.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ActivitiesApiErrorV1"
+                }
+              }
+            }
+          }
+        }
+      },
+      "delete": {
+        "summary": "Remove an activity from its group",
+        "description": "Removes an activity from all of the caller's custom groups (makes it \"ungrouped\"). No-op when the activity is not in any group. Scoped to the caller's own groups; gated by `user_schedule:read`.",
+        "tags": [
+          "Activities v1"
+        ],
+        "security": [
+          {
+            "ApiKeyAuth": []
+          }
+        ],
+        "extensions": {
+          "x-tenant-scoped": true,
+          "x-auth-mechanism": "NextAuth session, falling back to x-api-key (resolveActivityAuthContext)"
+        },
+        "x-alga-products": [
+          "psa"
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/RemoveActivityFromGroupBodyV1"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Activity removed from its group."
+          },
+          "400": {
+            "description": "Invalid request body.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ActivitiesApiErrorV1"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Authentication required.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ActivitiesApiErrorV1"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Permission denied (user_schedule:read).",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ActivitiesApiErrorV1"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Unexpected failure removing the activity.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ActivitiesApiErrorV1"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/activities/groups/{groupId}/items": {
+      "patch": {
+        "summary": "Reorder activities within a group",
+        "description": "Persists the full ordered membership of a group after a drag-to-reorder. Pass every item as it should appear; each row's `sortOrder` is set to its position. Scoped to the caller's own groups; gated by `user_schedule:read`.",
+        "tags": [
+          "Activities v1"
+        ],
+        "security": [
+          {
+            "ApiKeyAuth": []
+          }
+        ],
+        "extensions": {
+          "x-tenant-scoped": true,
+          "x-auth-mechanism": "NextAuth session, falling back to x-api-key (resolveActivityAuthContext)"
+        },
+        "x-alga-products": [
+          "psa"
+        ],
+        "parameters": [
+          {
+            "schema": {
+              "type": "string",
+              "description": "Custom activity group identifier."
+            },
+            "required": true,
+            "description": "Custom activity group identifier.",
+            "name": "groupId",
+            "in": "path"
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/ReorderActivitiesInGroupBodyV1"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Group order persisted."
+          },
+          "400": {
+            "description": "Invalid request body.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ActivitiesApiErrorV1"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Authentication required.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ActivitiesApiErrorV1"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Permission denied (user_schedule:read).",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ActivitiesApiErrorV1"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Group not found.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ActivitiesApiErrorV1"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Unexpected failure reordering the group.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ActivitiesApiErrorV1"
                 }
               }
             }
@@ -96824,6 +99548,54 @@
         }
       }
     },
+    "/api/auth/captcha-config": {
+      "get": {
+        "summary": "GET auth",
+        "description": "This operation was generated automatically from the route inventory. Replace with canonical OpenAPI metadata.",
+        "tags": [
+          "auth"
+        ],
+        "extensions": {
+          "x-generated-from": "docs/openapi/route-inventory.json",
+          "x-placeholder": true
+        },
+        "x-alga-products": [
+          "psa"
+        ],
+        "responses": {
+          "200": {
+            "description": "Placeholder success response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PlaceholderObject"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Authentication required",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     "/api/auth/e2e/google/authorize": {
       "get": {
         "summary": "GET auth",
@@ -97558,6 +100330,306 @@
         ],
         "responses": {
           "200": {
+            "description": "Placeholder success response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PlaceholderObject"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Authentication required",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/billing/complete-reactivation": {
+      "post": {
+        "summary": "POST billing",
+        "description": "This operation was generated automatically from the route inventory. Replace with canonical OpenAPI metadata.",
+        "tags": [
+          "billing"
+        ],
+        "extensions": {
+          "x-generated-from": "docs/openapi/route-inventory.json",
+          "x-placeholder": true
+        },
+        "x-alga-products": [
+          "psa"
+        ],
+        "requestBody": {
+          "description": "Placeholder request body",
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/PlaceholderObject"
+              },
+              "description": "Placeholder request body"
+            }
+          }
+        },
+        "responses": {
+          "201": {
+            "description": "Placeholder success response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PlaceholderObject"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Authentication required",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/billing/reactivation-password-reset": {
+      "post": {
+        "summary": "POST billing",
+        "description": "This operation was generated automatically from the route inventory. Replace with canonical OpenAPI metadata.",
+        "tags": [
+          "billing"
+        ],
+        "extensions": {
+          "x-generated-from": "docs/openapi/route-inventory.json",
+          "x-placeholder": true
+        },
+        "x-alga-products": [
+          "psa"
+        ],
+        "requestBody": {
+          "description": "Placeholder request body",
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/PlaceholderObject"
+              },
+              "description": "Placeholder request body"
+            }
+          }
+        },
+        "responses": {
+          "201": {
+            "description": "Placeholder success response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PlaceholderObject"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Authentication required",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/billing/reactivation-token": {
+      "post": {
+        "summary": "POST billing",
+        "description": "This operation was generated automatically from the route inventory. Replace with canonical OpenAPI metadata.",
+        "tags": [
+          "billing"
+        ],
+        "extensions": {
+          "x-generated-from": "docs/openapi/route-inventory.json",
+          "x-placeholder": true
+        },
+        "x-alga-products": [
+          "psa"
+        ],
+        "requestBody": {
+          "description": "Placeholder request body",
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/PlaceholderObject"
+              },
+              "description": "Placeholder request body"
+            }
+          }
+        },
+        "responses": {
+          "201": {
+            "description": "Placeholder success response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PlaceholderObject"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Authentication required",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/billing/reactivation-token/session": {
+      "post": {
+        "summary": "POST billing",
+        "description": "This operation was generated automatically from the route inventory. Replace with canonical OpenAPI metadata.",
+        "tags": [
+          "billing"
+        ],
+        "extensions": {
+          "x-generated-from": "docs/openapi/route-inventory.json",
+          "x-placeholder": true
+        },
+        "x-alga-products": [
+          "psa"
+        ],
+        "requestBody": {
+          "description": "Placeholder request body",
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/PlaceholderObject"
+              },
+              "description": "Placeholder request body"
+            }
+          }
+        },
+        "responses": {
+          "201": {
+            "description": "Placeholder success response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PlaceholderObject"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Authentication required",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/billing/request-reactivation": {
+      "post": {
+        "summary": "POST billing",
+        "description": "This operation was generated automatically from the route inventory. Replace with canonical OpenAPI metadata.",
+        "tags": [
+          "billing"
+        ],
+        "extensions": {
+          "x-generated-from": "docs/openapi/route-inventory.json",
+          "x-placeholder": true
+        },
+        "x-alga-products": [
+          "psa"
+        ],
+        "requestBody": {
+          "description": "Placeholder request body",
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/PlaceholderObject"
+              },
+              "description": "Placeholder request body"
+            }
+          }
+        },
+        "responses": {
+          "201": {
             "description": "Placeholder success response",
             "content": {
               "application/json": {
@@ -100788,6 +103860,100 @@
         }
       }
     },
+    "/api/integrations/hudu": {
+      "get": {
+        "summary": "GET integrations",
+        "description": "This operation was generated automatically from the route inventory. Replace with canonical OpenAPI metadata.",
+        "tags": [
+          "integrations"
+        ],
+        "extensions": {
+          "x-generated-from": "docs/openapi/route-inventory.json",
+          "x-placeholder": true
+        },
+        "x-alga-products": [
+          "psa"
+        ],
+        "responses": {
+          "200": {
+            "description": "Placeholder success response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PlaceholderObject"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Authentication required",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        }
+      },
+      "options": {
+        "summary": "OPTIONS integrations",
+        "description": "This operation was generated automatically from the route inventory. Replace with canonical OpenAPI metadata.",
+        "tags": [
+          "integrations"
+        ],
+        "extensions": {
+          "x-generated-from": "docs/openapi/route-inventory.json",
+          "x-placeholder": true
+        },
+        "x-alga-products": [
+          "psa"
+        ],
+        "responses": {
+          "200": {
+            "description": "Placeholder success response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PlaceholderObject"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Authentication required",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     "/api/integrations/ninjaone/callback": {
       "get": {
         "summary": "GET integrations",
@@ -101358,6 +104524,338 @@
         "description": "This operation was generated automatically from the route inventory. Replace with canonical OpenAPI metadata.",
         "tags": [
           "internal"
+        ],
+        "extensions": {
+          "x-generated-from": "docs/openapi/route-inventory.json",
+          "x-placeholder": true
+        },
+        "x-alga-products": [
+          "psa"
+        ],
+        "requestBody": {
+          "description": "Placeholder request body",
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/PlaceholderObject"
+              },
+              "description": "Placeholder request body"
+            }
+          }
+        },
+        "responses": {
+          "201": {
+            "description": "Placeholder success response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PlaceholderObject"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Authentication required",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/mcp": {
+      "get": {
+        "summary": "GET mcp",
+        "description": "This operation was generated automatically from the route inventory. Replace with canonical OpenAPI metadata.",
+        "tags": [
+          "mcp"
+        ],
+        "extensions": {
+          "x-generated-from": "docs/openapi/route-inventory.json",
+          "x-placeholder": true
+        },
+        "x-alga-products": [
+          "psa"
+        ],
+        "responses": {
+          "200": {
+            "description": "Placeholder success response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PlaceholderObject"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Authentication required",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        }
+      },
+      "post": {
+        "summary": "POST mcp",
+        "description": "This operation was generated automatically from the route inventory. Replace with canonical OpenAPI metadata.",
+        "tags": [
+          "mcp"
+        ],
+        "extensions": {
+          "x-generated-from": "docs/openapi/route-inventory.json",
+          "x-placeholder": true
+        },
+        "x-alga-products": [
+          "psa"
+        ],
+        "requestBody": {
+          "description": "Placeholder request body",
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/PlaceholderObject"
+              },
+              "description": "Placeholder request body"
+            }
+          }
+        },
+        "responses": {
+          "201": {
+            "description": "Placeholder success response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PlaceholderObject"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Authentication required",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/mcp/oauth/authorize": {
+      "get": {
+        "summary": "GET mcp",
+        "description": "This operation was generated automatically from the route inventory. Replace with canonical OpenAPI metadata.",
+        "tags": [
+          "mcp"
+        ],
+        "extensions": {
+          "x-generated-from": "docs/openapi/route-inventory.json",
+          "x-placeholder": true
+        },
+        "x-alga-products": [
+          "psa"
+        ],
+        "responses": {
+          "200": {
+            "description": "Placeholder success response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PlaceholderObject"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Authentication required",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        }
+      },
+      "post": {
+        "summary": "POST mcp",
+        "description": "This operation was generated automatically from the route inventory. Replace with canonical OpenAPI metadata.",
+        "tags": [
+          "mcp"
+        ],
+        "extensions": {
+          "x-generated-from": "docs/openapi/route-inventory.json",
+          "x-placeholder": true
+        },
+        "x-alga-products": [
+          "psa"
+        ],
+        "requestBody": {
+          "description": "Placeholder request body",
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/PlaceholderObject"
+              },
+              "description": "Placeholder request body"
+            }
+          }
+        },
+        "responses": {
+          "201": {
+            "description": "Placeholder success response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PlaceholderObject"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Authentication required",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/mcp/oauth/revoke": {
+      "post": {
+        "summary": "POST mcp",
+        "description": "This operation was generated automatically from the route inventory. Replace with canonical OpenAPI metadata.",
+        "tags": [
+          "mcp"
+        ],
+        "extensions": {
+          "x-generated-from": "docs/openapi/route-inventory.json",
+          "x-placeholder": true
+        },
+        "x-alga-products": [
+          "psa"
+        ],
+        "requestBody": {
+          "description": "Placeholder request body",
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/PlaceholderObject"
+              },
+              "description": "Placeholder request body"
+            }
+          }
+        },
+        "responses": {
+          "201": {
+            "description": "Placeholder success response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PlaceholderObject"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Authentication required",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/mcp/oauth/token": {
+      "post": {
+        "summary": "POST mcp",
+        "description": "This operation was generated automatically from the route inventory. Replace with canonical OpenAPI metadata.",
+        "tags": [
+          "mcp"
         ],
         "extensions": {
           "x-generated-from": "docs/openapi/route-inventory.json",
@@ -103075,6 +106573,1059 @@
         },
         "x-alga-products": [
           "psa"
+        ],
+        "responses": {
+          "200": {
+            "description": "Placeholder success response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PlaceholderObject"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Authentication required",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/appliance-installs": {
+      "get": {
+        "summary": "GET v1",
+        "description": "This operation was generated automatically from the route inventory. Replace with canonical OpenAPI metadata.",
+        "tags": [
+          "appliance-installs"
+        ],
+        "extensions": {
+          "x-generated-from": "docs/openapi/route-inventory.json",
+          "x-placeholder": true
+        },
+        "x-alga-products": [
+          "psa"
+        ],
+        "responses": {
+          "200": {
+            "description": "Placeholder success response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PlaceholderObject"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Authentication required",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        }
+      },
+      "options": {
+        "summary": "OPTIONS v1",
+        "description": "This operation was generated automatically from the route inventory. Replace with canonical OpenAPI metadata.",
+        "tags": [
+          "appliance-installs"
+        ],
+        "extensions": {
+          "x-generated-from": "docs/openapi/route-inventory.json",
+          "x-placeholder": true
+        },
+        "x-alga-products": [
+          "psa"
+        ],
+        "responses": {
+          "200": {
+            "description": "Placeholder success response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PlaceholderObject"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Authentication required",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/appliance-installs/access": {
+      "options": {
+        "summary": "OPTIONS v1",
+        "description": "This operation was generated automatically from the route inventory. Replace with canonical OpenAPI metadata.",
+        "tags": [
+          "appliance-installs"
+        ],
+        "extensions": {
+          "x-generated-from": "docs/openapi/route-inventory.json",
+          "x-placeholder": true
+        },
+        "x-alga-products": [
+          "psa"
+        ],
+        "responses": {
+          "200": {
+            "description": "Placeholder success response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PlaceholderObject"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Authentication required",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        }
+      },
+      "post": {
+        "summary": "POST v1",
+        "description": "This operation was generated automatically from the route inventory. Replace with canonical OpenAPI metadata.",
+        "tags": [
+          "appliance-installs"
+        ],
+        "extensions": {
+          "x-generated-from": "docs/openapi/route-inventory.json",
+          "x-placeholder": true
+        },
+        "x-alga-products": [
+          "psa"
+        ],
+        "requestBody": {
+          "description": "Placeholder request body",
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/PlaceholderObject"
+              },
+              "description": "Placeholder request body"
+            }
+          }
+        },
+        "responses": {
+          "201": {
+            "description": "Placeholder success response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PlaceholderObject"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Authentication required",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/appliance-installs/{tenantId}": {
+      "get": {
+        "summary": "GET v1",
+        "description": "This operation was generated automatically from the route inventory. Replace with canonical OpenAPI metadata.",
+        "tags": [
+          "appliance-installs"
+        ],
+        "extensions": {
+          "x-generated-from": "docs/openapi/route-inventory.json",
+          "x-placeholder": true
+        },
+        "x-alga-products": [
+          "psa"
+        ],
+        "responses": {
+          "200": {
+            "description": "Placeholder success response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PlaceholderObject"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Authentication required",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        }
+      },
+      "options": {
+        "summary": "OPTIONS v1",
+        "description": "This operation was generated automatically from the route inventory. Replace with canonical OpenAPI metadata.",
+        "tags": [
+          "appliance-installs"
+        ],
+        "extensions": {
+          "x-generated-from": "docs/openapi/route-inventory.json",
+          "x-placeholder": true
+        },
+        "x-alga-products": [
+          "psa"
+        ],
+        "responses": {
+          "200": {
+            "description": "Placeholder success response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PlaceholderObject"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Authentication required",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/mcp/agents": {
+      "delete": {
+        "summary": "DELETE v1",
+        "description": "This operation was generated automatically from the route inventory. Replace with canonical OpenAPI metadata.",
+        "tags": [
+          "mcp"
+        ],
+        "extensions": {
+          "x-generated-from": "docs/openapi/route-inventory.json",
+          "x-placeholder": true
+        },
+        "x-alga-products": [
+          "psa"
+        ],
+        "responses": {
+          "204": {
+            "description": "Placeholder success response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PlaceholderObject"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Authentication required",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        }
+      },
+      "get": {
+        "summary": "GET v1",
+        "description": "This operation was generated automatically from the route inventory. Replace with canonical OpenAPI metadata.",
+        "tags": [
+          "mcp"
+        ],
+        "extensions": {
+          "x-generated-from": "docs/openapi/route-inventory.json",
+          "x-placeholder": true
+        },
+        "x-alga-products": [
+          "psa"
+        ],
+        "responses": {
+          "200": {
+            "description": "Placeholder success response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PlaceholderObject"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Authentication required",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        }
+      },
+      "patch": {
+        "summary": "PATCH v1",
+        "description": "This operation was generated automatically from the route inventory. Replace with canonical OpenAPI metadata.",
+        "tags": [
+          "mcp"
+        ],
+        "extensions": {
+          "x-generated-from": "docs/openapi/route-inventory.json",
+          "x-placeholder": true
+        },
+        "x-alga-products": [
+          "psa"
+        ],
+        "requestBody": {
+          "description": "Placeholder request body",
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/PlaceholderObject"
+              },
+              "description": "Placeholder request body"
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Placeholder success response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PlaceholderObject"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Authentication required",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        }
+      },
+      "post": {
+        "summary": "POST v1",
+        "description": "This operation was generated automatically from the route inventory. Replace with canonical OpenAPI metadata.",
+        "tags": [
+          "mcp"
+        ],
+        "extensions": {
+          "x-generated-from": "docs/openapi/route-inventory.json",
+          "x-placeholder": true
+        },
+        "x-alga-products": [
+          "psa"
+        ],
+        "requestBody": {
+          "description": "Placeholder request body",
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/PlaceholderObject"
+              },
+              "description": "Placeholder request body"
+            }
+          }
+        },
+        "responses": {
+          "201": {
+            "description": "Placeholder success response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PlaceholderObject"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Authentication required",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/mcp/audit": {
+      "get": {
+        "summary": "GET v1",
+        "description": "This operation was generated automatically from the route inventory. Replace with canonical OpenAPI metadata.",
+        "tags": [
+          "mcp"
+        ],
+        "extensions": {
+          "x-generated-from": "docs/openapi/route-inventory.json",
+          "x-placeholder": true
+        },
+        "x-alga-products": [
+          "psa"
+        ],
+        "responses": {
+          "200": {
+            "description": "Placeholder success response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PlaceholderObject"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Authentication required",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/mcp/connect/callback": {
+      "get": {
+        "summary": "GET v1",
+        "description": "This operation was generated automatically from the route inventory. Replace with canonical OpenAPI metadata.",
+        "tags": [
+          "mcp"
+        ],
+        "extensions": {
+          "x-generated-from": "docs/openapi/route-inventory.json",
+          "x-placeholder": true
+        },
+        "x-alga-products": [
+          "psa"
+        ],
+        "responses": {
+          "200": {
+            "description": "Placeholder success response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PlaceholderObject"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Authentication required",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/mcp/connect/start": {
+      "post": {
+        "summary": "POST v1",
+        "description": "This operation was generated automatically from the route inventory. Replace with canonical OpenAPI metadata.",
+        "tags": [
+          "mcp"
+        ],
+        "extensions": {
+          "x-generated-from": "docs/openapi/route-inventory.json",
+          "x-placeholder": true
+        },
+        "x-alga-products": [
+          "psa"
+        ],
+        "requestBody": {
+          "description": "Placeholder request body",
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/PlaceholderObject"
+              },
+              "description": "Placeholder request body"
+            }
+          }
+        },
+        "responses": {
+          "201": {
+            "description": "Placeholder success response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PlaceholderObject"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Authentication required",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/mcp/connections": {
+      "delete": {
+        "summary": "DELETE v1",
+        "description": "This operation was generated automatically from the route inventory. Replace with canonical OpenAPI metadata.",
+        "tags": [
+          "mcp"
+        ],
+        "extensions": {
+          "x-generated-from": "docs/openapi/route-inventory.json",
+          "x-placeholder": true
+        },
+        "x-alga-products": [
+          "psa"
+        ],
+        "responses": {
+          "204": {
+            "description": "Placeholder success response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PlaceholderObject"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Authentication required",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        }
+      },
+      "get": {
+        "summary": "GET v1",
+        "description": "This operation was generated automatically from the route inventory. Replace with canonical OpenAPI metadata.",
+        "tags": [
+          "mcp"
+        ],
+        "extensions": {
+          "x-generated-from": "docs/openapi/route-inventory.json",
+          "x-placeholder": true
+        },
+        "x-alga-products": [
+          "psa"
+        ],
+        "responses": {
+          "200": {
+            "description": "Placeholder success response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PlaceholderObject"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Authentication required",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/mcp/idp-providers": {
+      "get": {
+        "summary": "GET v1",
+        "description": "This operation was generated automatically from the route inventory. Replace with canonical OpenAPI metadata.",
+        "tags": [
+          "mcp"
+        ],
+        "extensions": {
+          "x-generated-from": "docs/openapi/route-inventory.json",
+          "x-placeholder": true
+        },
+        "x-alga-products": [
+          "psa"
+        ],
+        "responses": {
+          "200": {
+            "description": "Placeholder success response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PlaceholderObject"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Authentication required",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        }
+      },
+      "post": {
+        "summary": "POST v1",
+        "description": "This operation was generated automatically from the route inventory. Replace with canonical OpenAPI metadata.",
+        "tags": [
+          "mcp"
+        ],
+        "extensions": {
+          "x-generated-from": "docs/openapi/route-inventory.json",
+          "x-placeholder": true
+        },
+        "x-alga-products": [
+          "psa"
+        ],
+        "requestBody": {
+          "description": "Placeholder request body",
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/PlaceholderObject"
+              },
+              "description": "Placeholder request body"
+            }
+          }
+        },
+        "responses": {
+          "201": {
+            "description": "Placeholder success response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PlaceholderObject"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Authentication required",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/mcp/idp-suggestions": {
+      "get": {
+        "summary": "GET v1",
+        "description": "This operation was generated automatically from the route inventory. Replace with canonical OpenAPI metadata.",
+        "tags": [
+          "mcp"
+        ],
+        "extensions": {
+          "x-generated-from": "docs/openapi/route-inventory.json",
+          "x-placeholder": true
+        },
+        "x-alga-products": [
+          "psa"
+        ],
+        "responses": {
+          "200": {
+            "description": "Placeholder success response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PlaceholderObject"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Authentication required",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/mcp/platform-providers": {
+      "get": {
+        "summary": "GET v1",
+        "description": "This operation was generated automatically from the route inventory. Replace with canonical OpenAPI metadata.",
+        "tags": [
+          "mcp"
+        ],
+        "extensions": {
+          "x-generated-from": "docs/openapi/route-inventory.json",
+          "x-placeholder": true
+        },
+        "x-alga-products": [
+          "psa"
+        ],
+        "responses": {
+          "200": {
+            "description": "Placeholder success response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PlaceholderObject"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Authentication required",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/mcp/roles": {
+      "get": {
+        "summary": "GET v1",
+        "description": "This operation was generated automatically from the route inventory. Replace with canonical OpenAPI metadata.",
+        "tags": [
+          "mcp"
+        ],
+        "extensions": {
+          "x-generated-from": "docs/openapi/route-inventory.json",
+          "x-placeholder": true
+        },
+        "x-alga-products": [
+          "psa"
+        ],
+        "responses": {
+          "200": {
+            "description": "Placeholder success response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PlaceholderObject"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Authentication required",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/meta/mcp-registry": {
+      "get": {
+        "summary": "GET v1",
+        "description": "This operation was generated automatically from the route inventory. Replace with canonical OpenAPI metadata.",
+        "tags": [
+          "meta"
+        ],
+        "extensions": {
+          "x-generated-from": "docs/openapi/route-inventory.json",
+          "x-placeholder": true
+        },
+        "x-alga-products": [
+          "psa",
+          "algadesk"
         ],
         "responses": {
           "200": {
@@ -107238,6 +111789,218 @@
         "description": "This operation was generated automatically from the route inventory. Replace with canonical OpenAPI metadata.",
         "tags": [
           "tenant-management"
+        ],
+        "extensions": {
+          "x-generated-from": "docs/openapi/route-inventory.json",
+          "x-placeholder": true
+        },
+        "x-alga-products": [
+          "psa"
+        ],
+        "requestBody": {
+          "description": "Placeholder request body",
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/PlaceholderObject"
+              },
+              "description": "Placeholder request body"
+            }
+          }
+        },
+        "responses": {
+          "201": {
+            "description": "Placeholder success response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PlaceholderObject"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Authentication required",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/webhooks/alternative-payments": {
+      "get": {
+        "summary": "GET webhooks",
+        "description": "This operation was generated automatically from the route inventory. Replace with canonical OpenAPI metadata.",
+        "tags": [
+          "webhooks"
+        ],
+        "extensions": {
+          "x-generated-from": "docs/openapi/route-inventory.json",
+          "x-placeholder": true
+        },
+        "x-alga-products": [
+          "psa"
+        ],
+        "responses": {
+          "200": {
+            "description": "Placeholder success response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PlaceholderObject"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Authentication required",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        }
+      },
+      "post": {
+        "summary": "POST webhooks",
+        "description": "This operation was generated automatically from the route inventory. Replace with canonical OpenAPI metadata.",
+        "tags": [
+          "webhooks"
+        ],
+        "extensions": {
+          "x-generated-from": "docs/openapi/route-inventory.json",
+          "x-placeholder": true
+        },
+        "x-alga-products": [
+          "psa"
+        ],
+        "requestBody": {
+          "description": "Placeholder request body",
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/PlaceholderObject"
+              },
+              "description": "Placeholder request body"
+            }
+          }
+        },
+        "responses": {
+          "201": {
+            "description": "Placeholder success response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PlaceholderObject"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Authentication required",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/webhooks/levelio": {
+      "options": {
+        "summary": "OPTIONS webhooks",
+        "description": "This operation was generated automatically from the route inventory. Replace with canonical OpenAPI metadata.",
+        "tags": [
+          "webhooks"
+        ],
+        "extensions": {
+          "x-generated-from": "docs/openapi/route-inventory.json",
+          "x-placeholder": true
+        },
+        "x-alga-products": [
+          "psa"
+        ],
+        "responses": {
+          "200": {
+            "description": "Placeholder success response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PlaceholderObject"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Authentication required",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        }
+      },
+      "post": {
+        "summary": "POST webhooks",
+        "description": "This operation was generated automatically from the route inventory. Replace with canonical OpenAPI metadata.",
+        "tags": [
+          "webhooks"
         ],
         "extensions": {
           "x-generated-from": "docs/openapi/route-inventory.json",

--- a/sdk/docs/openapi/alga-openapi.ee.yaml
+++ b/sdk/docs/openapi/alga-openapi.ee.yaml
@@ -12,6 +12,7 @@ tags:
   - name: AI
   - name: Access Control & Users v1
   - name: Accounting Exports
+  - name: Activities v1
   - name: Admin
   - name: Assets
   - name: Auth
@@ -61,8 +62,10 @@ tags:
   - name: Workflow Definitions
   - name: Workflow Registry
   - name: Workflow Runs
+  - name: Workflow Tasks v1
   - name: Workflows v1
   - name: accounting
+  - name: appliance-installs
   - name: auth
   - name: billing
   - name: calendar
@@ -80,6 +83,8 @@ tags:
   - name: inbound
   - name: integrations
   - name: internal
+  - name: mcp
+  - name: meta
   - name: mobile
   - name: online-meetings
   - name: platform-feature-flags
@@ -643,7 +648,7 @@ components:
           type: string
         order:
           type: string
-          enum: &a32
+          enum: &a33
             - asc
             - desc
         username:
@@ -656,7 +661,7 @@ components:
           type: string
         user_type:
           type: string
-          enum: &a33
+          enum: &a34
             - internal
             - client
             - admin
@@ -669,17 +674,17 @@ components:
           format: uuid
         is_inactive:
           type: string
-          enum: &a34
+          enum: &a35
             - "true"
             - "false"
         include_permissions:
           type: string
-          enum: &a35
+          enum: &a36
             - "true"
             - "false"
         include_teams:
           type: string
-          enum: &a36
+          enum: &a37
             - "true"
             - "false"
         fields:
@@ -695,7 +700,7 @@ components:
             field names.
         user_type:
           type: string
-          enum: &a37
+          enum: &a38
             - internal
             - client
             - admin
@@ -708,7 +713,7 @@ components:
           format: uuid
         include_inactive:
           type: string
-          enum: &a38
+          enum: &a39
             - "true"
             - "false"
         limit:
@@ -743,14 +748,14 @@ components:
           type: string
         is_inactive:
           type: string
-          enum: &a30
+          enum: &a31
             - "true"
             - "false"
         sort:
           type: string
         order:
           type: string
-          enum: &a31
+          enum: &a32
             - asc
             - desc
     AccessRoleListQueryV1:
@@ -764,14 +769,14 @@ components:
           type: string
         order:
           type: string
-          enum: &a23
+          enum: &a24
             - asc
             - desc
         role_name:
           type: string
         has_permissions:
           type: string
-          enum: &a24
+          enum: &a25
             - "true"
             - "false"
         permission_resource:
@@ -780,7 +785,7 @@ components:
           type: string
         is_template:
           type: string
-          enum: &a25
+          enum: &a26
             - "true"
             - "false"
     AccessPermissionListQueryV1:
@@ -794,7 +799,7 @@ components:
           type: string
         order:
           type: string
-          enum: &a22
+          enum: &a23
             - asc
             - desc
         resource:
@@ -812,7 +817,7 @@ components:
           type: string
         order:
           type: string
-          enum: &a26
+          enum: &a27
             - asc
             - desc
         team_name:
@@ -836,14 +841,14 @@ components:
           format: uuid
         has_manager:
           type: string
-          enum: &a27
+          enum: &a28
             - "true"
             - "false"
         sort:
           type: string
         order:
           type: string
-          enum: &a28
+          enum: &a29
             - asc
             - desc
     AccessTeamAnalyticsQueryV1:
@@ -859,7 +864,7 @@ components:
             array.
         granularity:
           type: string
-          enum: &a29
+          enum: &a30
             - daily
             - weekly
             - monthly
@@ -1274,7 +1279,7 @@ components:
           description: Sort column. Defaults to created_at.
         order:
           type: string
-          enum: &a39
+          enum: &a40
             - asc
             - desc
           description: Sort direction. Defaults to desc.
@@ -1304,7 +1309,7 @@ components:
             AssetService.list.
         is_active:
           type: string
-          enum: &a40
+          enum: &a41
             - "true"
             - "false"
           description: Accepted by validation, but not currently applied by
@@ -1337,21 +1342,21 @@ components:
           description: Partial client name match; joins clients on client_id and tenant.
         has_warranty:
           type: string
-          enum: &a41
+          enum: &a42
             - "true"
             - "false"
           description: true requires warranty_end_date to be non-null; false requires it
             to be null.
         warranty_expired:
           type: string
-          enum: &a42
+          enum: &a43
             - "true"
             - "false"
           description: true filters warranty_end_date before now; false filters future
             warranty dates or no warranty.
         maintenance_due:
           type: string
-          enum: &a43
+          enum: &a44
             - "true"
             - "false"
           description: Accepted by validation, but not currently applied by
@@ -1377,7 +1382,7 @@ components:
       properties:
         format:
           type: string
-          enum: &a44
+          enum: &a45
             - csv
             - json
           description: Export format. csv (default) returns text/csv as an attachment;
@@ -2663,7 +2668,7 @@ components:
           type: array
           items:
             type: string
-            enum: &a45
+            enum: &a46
               - asset_tag
               - name
               - serial_number
@@ -2690,7 +2695,7 @@ components:
           description: Optional client UUID filters.
         include_extension_data:
           type: string
-          enum: &a46
+          enum: &a47
             - "true"
             - "false"
           description: When true, the service fetches asset-type-specific extension data
@@ -3166,7 +3171,7 @@ components:
       properties:
         type:
           type: string
-          enum: &a47
+          enum: &a48
             - splashtop
             - teamviewer
             - vnc
@@ -3191,7 +3196,7 @@ components:
           type: string
         include_uninstalled:
           type: string
-          enum: &a48
+          enum: &a49
             - "true"
             - "false"
     AssetSoftwareResponse:
@@ -3288,7 +3293,7 @@ components:
             orders executions by started_at desc.
         order:
           type: string
-          enum: &a49
+          enum: &a50
             - asc
             - desc
           description: Accepted by shared list query validation.
@@ -3313,7 +3318,7 @@ components:
           description: Accepted by shared filter validation.
         is_active:
           type: string
-          enum: &a50
+          enum: &a51
             - "true"
             - "false"
           description: Accepted by shared filter validation and transformed to boolean.
@@ -3350,7 +3355,7 @@ components:
           description: Maximum execution duration in milliseconds.
         has_errors:
           type: string
-          enum: &a51
+          enum: &a52
             - "true"
             - "false"
           description: Filter by whether the execution has errors; transformed to boolean
@@ -3381,7 +3386,7 @@ components:
             rules by created_at desc.
         order:
           type: string
-          enum: &a52
+          enum: &a53
             - asc
             - desc
           description: Accepted by shared list query validation.
@@ -3406,7 +3411,7 @@ components:
           description: Accepted by shared filter validation.
         is_active:
           type: string
-          enum: &a53
+          enum: &a54
             - "true"
             - "false"
           description: Accepted by shared filter validation and transformed to boolean.
@@ -3472,7 +3477,7 @@ components:
             templates by created_at desc.
         order:
           type: string
-          enum: &a54
+          enum: &a55
             - asc
             - desc
           description: Accepted by shared list query validation.
@@ -3497,7 +3502,7 @@ components:
           description: Accepted by shared filter validation.
         is_active:
           type: string
-          enum: &a55
+          enum: &a56
             - "true"
             - "false"
           description: Accepted by shared filter validation and transformed to boolean.
@@ -3531,7 +3536,7 @@ components:
           description: Optional upper bound for performance window.
         group_by:
           type: string
-          enum: &a56
+          enum: &a57
             - hour
             - day
             - week
@@ -4853,7 +4858,7 @@ components:
           type: string
         order:
           type: string
-          enum: &a57
+          enum: &a58
             - asc
             - desc
         search:
@@ -4876,12 +4881,12 @@ components:
           type: string
         client_type:
           type: string
-          enum: &a58
+          enum: &a59
             - company
             - individual
         billing_cycle:
           type: string
-          enum: &a59
+          enum: &a60
             - weekly
             - bi-weekly
             - monthly
@@ -4890,12 +4895,12 @@ components:
             - annually
         is_inactive:
           type: string
-          enum: &a60
+          enum: &a61
             - "true"
             - "false"
         is_tax_exempt:
           type: string
-          enum: &a61
+          enum: &a62
             - "true"
             - "false"
         account_manager_id:
@@ -4909,7 +4914,7 @@ components:
           type: string
         has_credit_limit:
           type: string
-          enum: &a62
+          enum: &a63
             - "true"
             - "false"
         industry:
@@ -5059,7 +5064,7 @@ components:
           type: string
         order:
           type: string
-          enum: &a63
+          enum: &a64
             - asc
             - desc
         search:
@@ -5089,12 +5094,12 @@ components:
           type: string
         is_inactive:
           type: string
-          enum: &a64
+          enum: &a65
             - "true"
             - "false"
         has_client:
           type: string
-          enum: &a65
+          enum: &a66
             - "true"
             - "false"
         client_name:
@@ -5162,7 +5167,7 @@ components:
           format: uuid
         include_inactive:
           type: string
-          enum: &a66
+          enum: &a67
             - "true"
             - "false"
         limit:
@@ -5174,12 +5179,12 @@ components:
       properties:
         format:
           type: string
-          enum: &a67
+          enum: &a68
             - csv
             - json
         include_inactive:
           type: string
-          enum: &a68
+          enum: &a69
             - "true"
             - "false"
         client_id:
@@ -5199,7 +5204,7 @@ components:
           type: string
         order:
           type: string
-          enum: &a69
+          enum: &a70
             - asc
             - desc
         search:
@@ -5226,17 +5231,17 @@ components:
           type: string
         is_active:
           type: string
-          enum: &a70
+          enum: &a71
             - "true"
             - "false"
         has_custom_rate:
           type: string
-          enum: &a71
+          enum: &a72
             - "true"
             - "false"
         is_contractd:
           type: string
-          enum: &a72
+          enum: &a73
             - "true"
             - "false"
         start_date_from:
@@ -6385,7 +6390,7 @@ components:
           type: string
         order:
           type: string
-          enum: &a73
+          enum: &a74
             - asc
             - desc
         search:
@@ -6421,19 +6426,19 @@ components:
             - annually
         is_custom:
           type: string
-          enum: &a74
+          enum: &a75
             - "true"
             - "false"
         is_active:
           type: string
-          enum: &a75
+          enum: &a76
             - "true"
             - "false"
         service_category:
           type: string
         has_services:
           type: string
-          enum: &a76
+          enum: &a77
             - "true"
             - "false"
         clients_count_min:
@@ -6446,19 +6451,19 @@ components:
           type: string
         include_services:
           type: string
-          enum: &a77
+          enum: &a78
             - "true"
             - "false"
           description: Controller-level include flag parsed directly from query string.
         include_usage:
           type: string
-          enum: &a78
+          enum: &a79
             - "true"
             - "false"
           description: Controller-level include flag parsed directly from query string.
         include_clients:
           type: string
-          enum: &a79
+          enum: &a80
             - "true"
             - "false"
           description: Controller-level include flag parsed directly from query string.
@@ -6940,7 +6945,7 @@ components:
       properties:
         format:
           type: string
-          enum: &a80
+          enum: &a81
             - pdf
             - markdown
             - md
@@ -7556,7 +7561,7 @@ components:
           type: string
         order:
           type: string
-          enum: &a81
+          enum: &a82
             - asc
             - desc
         search:
@@ -7585,22 +7590,22 @@ components:
           type: string
         include_expired:
           type: string
-          enum: &a82
+          enum: &a83
             - "true"
             - "false"
         expiring_soon:
           type: string
-          enum: &a83
+          enum: &a84
             - "true"
             - "false"
         has_remaining:
           type: string
-          enum: &a84
+          enum: &a85
             - "true"
             - "false"
         has_expiration:
           type: string
-          enum: &a85
+          enum: &a86
             - "true"
             - "false"
         date_from:
@@ -7609,13 +7614,13 @@ components:
           type: string
         group_by:
           type: string
-          enum: &a86
+          enum: &a87
             - day
             - week
             - month
         include_projections:
           type: string
-          enum: &a87
+          enum: &a88
             - "true"
             - "false"
         as_of_date:
@@ -7631,27 +7636,27 @@ components:
           type: string
         order:
           type: string
-          enum: &a98
+          enum: &a99
             - asc
             - desc
         include_items:
           type: string
-          enum: &a99
+          enum: &a100
             - "true"
             - "false"
         include_client:
           type: string
-          enum: &a100
+          enum: &a101
             - "true"
             - "false"
         include_billing_cycle:
           type: string
-          enum: &a101
+          enum: &a102
             - "true"
             - "false"
         include_transactions:
           type: string
-          enum: &a102
+          enum: &a103
             - "true"
             - "false"
         q:
@@ -7662,7 +7667,7 @@ components:
           type: string
         format:
           type: string
-          enum: &a103
+          enum: &a104
             - json
             - csv
       additionalProperties:
@@ -7681,7 +7686,7 @@ components:
             created_at).
         order:
           type: string
-          enum: &a88
+          enum: &a89
             - asc
             - desc
         search:
@@ -7697,7 +7702,7 @@ components:
           type: string
         is_active:
           type: string
-          enum: &a89
+          enum: &a90
             - "true"
             - "false"
         client_id:
@@ -7705,7 +7710,7 @@ components:
           format: uuid
         status:
           type: string
-          enum: &a90
+          enum: &a91
             - draft
             - sent
             - paid
@@ -7727,12 +7732,12 @@ components:
           type: string
         is_manual:
           type: string
-          enum: &a91
+          enum: &a92
             - "true"
             - "false"
         has_credit_applied:
           type: string
-          enum: &a92
+          enum: &a93
             - "true"
             - "false"
     FinancialPaymentMethodListQuery:
@@ -7748,7 +7753,7 @@ components:
             (defaults to created_at).
         order:
           type: string
-          enum: &a93
+          enum: &a94
             - asc
             - desc
         search:
@@ -7764,7 +7769,7 @@ components:
           type: string
         is_active:
           type: string
-          enum: &a94
+          enum: &a95
             - "true"
             - "false"
         client_id:
@@ -7772,17 +7777,17 @@ components:
           format: uuid
         type:
           type: string
-          enum: &a95
+          enum: &a96
             - credit_card
             - bank_account
         is_default:
           type: string
-          enum: &a96
+          enum: &a97
             - "true"
             - "false"
         exclude_deleted:
           type: string
-          enum: &a97
+          enum: &a98
             - "true"
             - "false"
           description: Exclude soft-deleted payment methods. Defaults to true.
@@ -8750,12 +8755,12 @@ components:
           type: string
         is_managed:
           type: string
-          enum: &a104
+          enum: &a105
             - "true"
             - "false"
         is_security_relevant:
           type: string
-          enum: &a105
+          enum: &a106
             - "true"
             - "false"
         client_id:
@@ -8782,7 +8787,7 @@ components:
           type: string
         order:
           type: string
-          enum: &a106
+          enum: &a107
             - asc
             - desc
     PriorityIdParam:
@@ -8850,17 +8855,17 @@ components:
       properties:
         preview:
           type: string
-          enum: &a107
+          enum: &a108
             - "true"
             - "false"
         createNew:
           type: string
-          enum: &a108
+          enum: &a109
             - "true"
             - "false"
         updateExisting:
           type: string
-          enum: &a109
+          enum: &a110
             - "true"
             - "false"
         matchBy:
@@ -8870,7 +8875,7 @@ components:
       properties:
         preview:
           type: string
-          enum: &a110
+          enum: &a111
             - "true"
             - "false"
     AccountingBatchIdParam:
@@ -9017,7 +9022,7 @@ components:
       properties:
         force:
           type: string
-          enum: &a111
+          enum: &a112
             - "true"
             - "false"
     WorkflowImportBody:
@@ -10003,7 +10008,7 @@ components:
           type: string
         active:
           type: string
-          enum: &a112
+          enum: &a113
             - "true"
             - "false"
         search:
@@ -10012,7 +10017,7 @@ components:
           type: string
         force_refresh:
           type: string
-          enum: &a113
+          enum: &a114
             - "true"
             - "false"
     QuickBooksV1SyncHistoryQuery:
@@ -10024,7 +10029,7 @@ components:
           type: string
         status:
           type: string
-          enum: &a114
+          enum: &a115
             - pending
             - in_progress
             - completed
@@ -10033,7 +10038,7 @@ components:
             - partial
         operation_type:
           type: string
-          enum: &a115
+          enum: &a116
             - customer_sync
             - invoice_export
             - invoice_import
@@ -10758,7 +10763,7 @@ components:
           description: Opaque pagination cursor copied from a prior response's nextCursor.
         sort:
           type: string
-          enum: &a116
+          enum: &a117
             - relevance
             - recent
           description: Result ordering. "relevance" (default) ranks by full-text score;
@@ -11073,7 +11078,7 @@ components:
           type: string
         order:
           type: string
-          enum: &a117
+          enum: &a118
             - asc
             - desc
         search:
@@ -11100,19 +11105,19 @@ components:
           format: uuid
         is_parent:
           type: string
-          enum: &a118
+          enum: &a119
             - "true"
             - "false"
         is_child:
           type: string
-          enum: &a119
+          enum: &a120
             - "true"
             - "false"
         depth:
           type: string
         active:
           type: string
-          enum: &a120
+          enum: &a121
             - "true"
             - "false"
         offset:
@@ -11121,17 +11126,17 @@ components:
           type: string
         sort_order:
           type: string
-          enum: &a121
+          enum: &a122
             - asc
             - desc
         include_hierarchy:
           type: string
-          enum: &a122
+          enum: &a123
             - "true"
             - "false"
         category_type:
           type: string
-          enum: &a123
+          enum: &a124
             - service
             - ticket
     CategoryMoveRequest:
@@ -11158,7 +11163,7 @@ components:
           minLength: 1
         category_type:
           type: string
-          enum: &a124
+          enum: &a125
             - service
             - ticket
         board_id:
@@ -11166,7 +11171,7 @@ components:
           format: uuid
         include_inactive:
           type: string
-          enum: &a125
+          enum: &a126
             - "true"
             - "false"
         limit:
@@ -11180,7 +11185,7 @@ components:
       properties:
         category_type:
           type: string
-          enum: &a126
+          enum: &a127
             - service
             - ticket
         board_id:
@@ -11194,7 +11199,7 @@ components:
           format: date-time
         include_usage:
           type: string
-          enum: &a127
+          enum: &a128
             - "true"
             - "false"
     CategoryAnalyticsResponse:
@@ -11815,7 +11820,7 @@ components:
           type: string
         order:
           type: string
-          enum: &a133
+          enum: &a134
             - asc
             - desc
         name:
@@ -11826,24 +11831,24 @@ components:
           type: string
         is_active:
           type: string
-          enum: &a134
+          enum: &a135
             - "true"
             - "false"
         is_test_mode:
           type: string
-          enum: &a135
+          enum: &a136
             - "true"
             - "false"
         payload_format:
           type: string
-          enum: &a136
+          enum: &a137
             - json
             - xml
             - form_data
             - custom
         has_failures:
           type: string
-          enum: &a137
+          enum: &a138
             - "true"
             - "false"
         last_delivery_from:
@@ -11877,7 +11882,7 @@ components:
           type: string
         status:
           type: string
-          enum: &a138
+          enum: &a139
             - pending
             - delivered
             - failed
@@ -13319,6 +13324,1058 @@ components:
     WorkflowV1MissingRouteResponse:
       type: string
       description: Default Next.js not-found response body for missing route handlers.
+    WorkflowTasksApiErrorV1:
+      type: object
+      properties:
+        error:
+          type: object
+          properties:
+            code:
+              type: string
+            message:
+              type: string
+            details: {}
+          required:
+            - code
+            - message
+      required:
+        - error
+    WorkflowTaskIdParamV1:
+      type: object
+      properties:
+        id:
+          type: string
+          description: Workflow task identifier (taskId).
+      required:
+        - id
+    WorkflowTasksListQueryV1:
+      type: object
+      properties:
+        status:
+          type: string
+          description: Comma-separated WorkflowTaskStatus values (pending, claimed,
+            completed, canceled, expired). Omit for the open inbox (pending +
+            claimed).
+        page:
+          type: integer
+          minimum: 1
+          description: 1-based page number (default 1).
+        pageSize:
+          type: integer
+          minimum: 1
+          maximum: 100
+          description: Items per page, max 100 (default 25).
+    WorkflowTaskV1:
+      type: object
+      properties:
+        taskId:
+          type: string
+        executionId:
+          type: string
+        title:
+          type: string
+        description:
+          type: string
+        status:
+          type: string
+          enum: &a22
+            - pending
+            - claimed
+            - completed
+            - canceled
+            - expired
+        priority:
+          type: string
+        dueDate:
+          type: string
+        assignedRoles:
+          type: array
+          items:
+            type: string
+        assignedUsers:
+          type: array
+          items:
+            type: string
+        contextData:
+          type: object
+          additionalProperties: {}
+        formId:
+          type: string
+        formSchema:
+          type: object
+          properties:
+            jsonSchema:
+              type: object
+              additionalProperties: {}
+            uiSchema:
+              type: object
+              additionalProperties: {}
+            defaultValues:
+              type: object
+              additionalProperties: {}
+          required:
+            - jsonSchema
+        createdAt:
+          type: string
+        createdBy:
+          type: string
+        claimedAt:
+          type: string
+        claimedBy:
+          type: string
+        completedAt:
+          type: string
+        completedBy:
+          type: string
+        responseData:
+          type: object
+          additionalProperties: {}
+      required:
+        - taskId
+        - executionId
+        - title
+        - status
+        - priority
+        - formId
+        - createdAt
+    WorkflowTaskListResponseV1:
+      type: object
+      properties:
+        data:
+          type: array
+          items:
+            type: object
+            properties:
+              taskId:
+                type: string
+              executionId:
+                type: string
+              title:
+                type: string
+              description:
+                type: string
+              status:
+                type: string
+                enum: *a22
+              priority:
+                type: string
+              dueDate:
+                type: string
+              assignedRoles:
+                type: array
+                items:
+                  type: string
+              assignedUsers:
+                type: array
+                items:
+                  type: string
+              contextData:
+                type: object
+                additionalProperties: {}
+              formId:
+                type: string
+              formSchema:
+                type: object
+                properties:
+                  jsonSchema:
+                    type: object
+                    additionalProperties: {}
+                  uiSchema:
+                    type: object
+                    additionalProperties: {}
+                  defaultValues:
+                    type: object
+                    additionalProperties: {}
+                required:
+                  - jsonSchema
+              createdAt:
+                type: string
+              createdBy:
+                type: string
+              claimedAt:
+                type: string
+              claimedBy:
+                type: string
+              completedAt:
+                type: string
+              completedBy:
+                type: string
+              responseData:
+                type: object
+                additionalProperties: {}
+            required:
+              - taskId
+              - executionId
+              - title
+              - status
+              - priority
+              - formId
+              - createdAt
+        pagination:
+          type: object
+          properties:
+            page:
+              type: number
+            limit:
+              type: number
+            total:
+              type: number
+            totalPages:
+              type: number
+            hasNext:
+              type: boolean
+            hasPrev:
+              type: boolean
+          required:
+            - page
+            - limit
+            - total
+            - totalPages
+            - hasNext
+            - hasPrev
+        meta: {}
+      required:
+        - data
+        - pagination
+    WorkflowTaskDetailResponseV1:
+      type: object
+      properties:
+        data:
+          type: object
+          properties:
+            taskId:
+              type: string
+            executionId:
+              type: string
+            title:
+              type: string
+            description:
+              type: string
+            status:
+              type: string
+              enum: *a22
+            priority:
+              type: string
+            dueDate:
+              type: string
+            assignedRoles:
+              type: array
+              items:
+                type: string
+            assignedUsers:
+              type: array
+              items:
+                type: string
+            contextData:
+              type: object
+              additionalProperties: {}
+            formId:
+              type: string
+            formSchema:
+              type: object
+              properties:
+                jsonSchema:
+                  type: object
+                  additionalProperties: {}
+                uiSchema:
+                  type: object
+                  additionalProperties: {}
+                defaultValues:
+                  type: object
+                  additionalProperties: {}
+              required:
+                - jsonSchema
+            createdAt:
+              type: string
+            createdBy:
+              type: string
+            claimedAt:
+              type: string
+            claimedBy:
+              type: string
+            completedAt:
+              type: string
+            completedBy:
+              type: string
+            responseData:
+              type: object
+              additionalProperties: {}
+          required:
+            - taskId
+            - executionId
+            - title
+            - status
+            - priority
+            - formId
+            - createdAt
+        meta: {}
+      required:
+        - data
+    WorkflowTaskActionResponseV1:
+      type: object
+      properties:
+        data:
+          type: object
+          properties:
+            success:
+              type: boolean
+          required:
+            - success
+        meta: {}
+      required:
+        - data
+    CompleteWorkflowTaskBodyV1:
+      type: object
+      properties:
+        formData:
+          type: object
+          additionalProperties: {}
+          default: {}
+        comments:
+          type: string
+    ActivitiesApiErrorV1:
+      type: object
+      properties:
+        error:
+          type: object
+          properties:
+            code:
+              type: string
+            message:
+              type: string
+            details: {}
+          required:
+            - code
+            - message
+      required:
+        - error
+    ActivitiesAdHocIdParamV1:
+      type: object
+      properties:
+        id:
+          type: string
+          description: Ad-hoc activity identifier (the backing schedule entry id).
+      required:
+        - id
+    ActivitiesListQueryV1:
+      type: object
+      properties:
+        type:
+          type: string
+          description: Comma-separated ActivityType values (e.g. "ticket,schedule"). Omit
+            for all types.
+        status:
+          type: string
+          enum: &a140
+            - open
+            - closed
+            - all
+          description: Open/closed filter. `open`→active only, `closed`→closed, `all`→no
+            filter (default).
+        search:
+          type: string
+          description: Free-text search across activity titles/descriptions.
+        dateStart:
+          type: string
+          format: date-time
+          description: ISO 8601 lower bound of the schedule/time-entry/notification window.
+        dateEnd:
+          type: string
+          format: date-time
+          description: ISO 8601 upper bound of the window.
+        priority:
+          type: string
+          description: Comma-separated normalized ActivityPriority buckets (e.g.
+            "high,medium"). Lossy for custom schemes; prefer `priorityIds`.
+        priorityIds:
+          type: string
+          description: Comma-separated exact priority IDs (the tenant's real per-type
+            priorities). Applies to ticket/project-task activities.
+        dueDateStart:
+          type: string
+          format: date-time
+          description: ISO 8601 lower bound of the due-date filter (independent of the
+            schedule window).
+        dueDateEnd:
+          type: string
+          format: date-time
+          description: ISO 8601 upper bound of the due-date filter.
+        createdAtStart:
+          type: string
+          format: date-time
+          description: ISO 8601 lower bound of the created-date ("date entered") filter.
+            Applies to every activity type.
+        createdAtEnd:
+          type: string
+          format: date-time
+          description: ISO 8601 upper bound of the created-date ("date entered") filter.
+        sortBy:
+          type: string
+          enum: &a141
+            - type
+            - title
+            - status
+            - priority
+            - dueDate
+          description: Sort column. Omit for the default sort (priority high→low, then due
+            date ascending).
+        sortDirection:
+          type: string
+          enum: &a142
+            - asc
+            - desc
+          description: Sort direction for `sortBy` (default asc). Ignored when `sortBy` is
+            omitted.
+        groupBy:
+          type: string
+          enum: &a143
+            - type
+            - priority
+            - status
+            - dueDate
+          description: When set, the response is grouped by this dimension
+            (ActivityGroupedResponseV1) instead of the paginated list;
+            `page`/`pageSize` are ignored. `priority` groups by the real
+            per-tenant priority name (not the normalized bucket), so it is only
+            meaningful when scoped to a single prioritized type.
+        page:
+          type: integer
+          minimum: 1
+          description: 1-based page number (default 1). Ignored when `groupBy` is set.
+        pageSize:
+          type: integer
+          minimum: 1
+          maximum: 100
+          description: Items per page, max 100 (default 25). Ignored when `groupBy` is set.
+    ActivityV1:
+      type: object
+      properties:
+        id:
+          type: string
+        title:
+          type: string
+        description:
+          type: string
+        type:
+          type: string
+          enum:
+            - schedule
+            - projectTask
+            - ticket
+            - timeEntry
+            - workflowTask
+            - notification
+            - document
+        status:
+          type: string
+        statusColor:
+          type: string
+        priority:
+          type: string
+          enum:
+            - low
+            - medium
+            - high
+        priorityName:
+          type: string
+        priorityColor:
+          type: string
+        dueDate:
+          type: string
+        startDate:
+          type: string
+        endDate:
+          type: string
+        assignedTo:
+          type: array
+          items:
+            type: string
+        assignedToNames:
+          type: array
+          items:
+            type: string
+        sourceId:
+          type: string
+        sourceType:
+          type: string
+          enum:
+            - schedule
+            - projectTask
+            - ticket
+            - timeEntry
+            - workflowTask
+            - notification
+            - document
+        actions:
+          type: array
+          items:
+            type: object
+            properties:
+              id:
+                type: string
+              label:
+                type: string
+              icon:
+                type: string
+              disabled:
+                type: boolean
+              disabledReason:
+                type: string
+            required:
+              - id
+              - label
+        isClosed:
+          type: boolean
+        tenant:
+          type: string
+        createdAt:
+          type: string
+        updatedAt:
+          type: string
+      required:
+        - id
+        - title
+        - type
+        - status
+        - priority
+        - sourceId
+        - sourceType
+        - actions
+        - tenant
+        - createdAt
+        - updatedAt
+    ActivityListResponseV1:
+      type: object
+      properties:
+        data:
+          type: array
+          items:
+            type: object
+            properties:
+              id:
+                type: string
+              title:
+                type: string
+              description:
+                type: string
+              type:
+                type: string
+                enum:
+                  - schedule
+                  - projectTask
+                  - ticket
+                  - timeEntry
+                  - workflowTask
+                  - notification
+                  - document
+              status:
+                type: string
+              statusColor:
+                type: string
+              priority:
+                type: string
+                enum:
+                  - low
+                  - medium
+                  - high
+              priorityName:
+                type: string
+              priorityColor:
+                type: string
+              dueDate:
+                type: string
+              startDate:
+                type: string
+              endDate:
+                type: string
+              assignedTo:
+                type: array
+                items:
+                  type: string
+              assignedToNames:
+                type: array
+                items:
+                  type: string
+              sourceId:
+                type: string
+              sourceType:
+                type: string
+                enum:
+                  - schedule
+                  - projectTask
+                  - ticket
+                  - timeEntry
+                  - workflowTask
+                  - notification
+                  - document
+              actions:
+                type: array
+                items:
+                  type: object
+                  properties:
+                    id:
+                      type: string
+                    label:
+                      type: string
+                    icon:
+                      type: string
+                    disabled:
+                      type: boolean
+                    disabledReason:
+                      type: string
+                  required:
+                    - id
+                    - label
+              isClosed:
+                type: boolean
+              tenant:
+                type: string
+              createdAt:
+                type: string
+              updatedAt:
+                type: string
+            required:
+              - id
+              - title
+              - type
+              - status
+              - priority
+              - sourceId
+              - sourceType
+              - actions
+              - tenant
+              - createdAt
+              - updatedAt
+        pagination:
+          type: object
+          properties:
+            page:
+              type: number
+            limit:
+              type: number
+            total:
+              type: number
+            totalPages:
+              type: number
+            hasNext:
+              type: boolean
+            hasPrev:
+              type: boolean
+          required:
+            - page
+            - limit
+            - total
+            - totalPages
+            - hasNext
+            - hasPrev
+        meta: {}
+      required:
+        - data
+        - pagination
+    ActivityGroupedResponseV1:
+      type: object
+      properties:
+        data:
+          type: object
+          properties:
+            groupBy:
+              type: string
+              enum:
+                - type
+                - priority
+                - status
+                - dueDate
+            groups:
+              type: array
+              items:
+                type: object
+                properties:
+                  key:
+                    type: string
+                  label:
+                    type: string
+                  count:
+                    type: number
+                  activities:
+                    type: array
+                    items:
+                      type: object
+                      properties:
+                        id:
+                          type: string
+                        title:
+                          type: string
+                        description:
+                          type: string
+                        type:
+                          type: string
+                          enum:
+                            - schedule
+                            - projectTask
+                            - ticket
+                            - timeEntry
+                            - workflowTask
+                            - notification
+                            - document
+                        status:
+                          type: string
+                        statusColor:
+                          type: string
+                        priority:
+                          type: string
+                          enum:
+                            - low
+                            - medium
+                            - high
+                        priorityName:
+                          type: string
+                        priorityColor:
+                          type: string
+                        dueDate:
+                          type: string
+                        startDate:
+                          type: string
+                        endDate:
+                          type: string
+                        assignedTo:
+                          type: array
+                          items:
+                            type: string
+                        assignedToNames:
+                          type: array
+                          items:
+                            type: string
+                        sourceId:
+                          type: string
+                        sourceType:
+                          type: string
+                          enum:
+                            - schedule
+                            - projectTask
+                            - ticket
+                            - timeEntry
+                            - workflowTask
+                            - notification
+                            - document
+                        actions:
+                          type: array
+                          items:
+                            type: object
+                            properties:
+                              id:
+                                type: string
+                              label:
+                                type: string
+                              icon:
+                                type: string
+                              disabled:
+                                type: boolean
+                              disabledReason:
+                                type: string
+                            required:
+                              - id
+                              - label
+                        isClosed:
+                          type: boolean
+                        tenant:
+                          type: string
+                        createdAt:
+                          type: string
+                        updatedAt:
+                          type: string
+                      required:
+                        - id
+                        - title
+                        - type
+                        - status
+                        - priority
+                        - sourceId
+                        - sourceType
+                        - actions
+                        - tenant
+                        - createdAt
+                        - updatedAt
+                required:
+                  - key
+                  - label
+                  - count
+                  - activities
+            totalCount:
+              type: number
+            truncated:
+              type: boolean
+          required:
+            - groupBy
+            - groups
+            - totalCount
+            - truncated
+        meta: {}
+      required:
+        - data
+    AdHocActivityResponseV1:
+      type: object
+      properties:
+        data:
+          type: object
+          properties:
+            id:
+              type: string
+            title:
+              type: string
+            description:
+              type: string
+            type:
+              type: string
+              enum:
+                - schedule
+                - projectTask
+                - ticket
+                - timeEntry
+                - workflowTask
+                - notification
+                - document
+            status:
+              type: string
+            statusColor:
+              type: string
+            priority:
+              type: string
+              enum:
+                - low
+                - medium
+                - high
+            priorityName:
+              type: string
+            priorityColor:
+              type: string
+            dueDate:
+              type: string
+            startDate:
+              type: string
+            endDate:
+              type: string
+            assignedTo:
+              type: array
+              items:
+                type: string
+            assignedToNames:
+              type: array
+              items:
+                type: string
+            sourceId:
+              type: string
+            sourceType:
+              type: string
+              enum:
+                - schedule
+                - projectTask
+                - ticket
+                - timeEntry
+                - workflowTask
+                - notification
+                - document
+            actions:
+              type: array
+              items:
+                type: object
+                properties:
+                  id:
+                    type: string
+                  label:
+                    type: string
+                  icon:
+                    type: string
+                  disabled:
+                    type: boolean
+                  disabledReason:
+                    type: string
+                required:
+                  - id
+                  - label
+            isClosed:
+              type: boolean
+            tenant:
+              type: string
+            createdAt:
+              type: string
+            updatedAt:
+              type: string
+          required:
+            - id
+            - title
+            - type
+            - status
+            - priority
+            - sourceId
+            - sourceType
+            - actions
+            - tenant
+            - createdAt
+            - updatedAt
+        meta: {}
+      required:
+        - data
+    CreateAdHocActivityBodyV1:
+      type: object
+      properties:
+        title:
+          type: string
+          minLength: 1
+        notes:
+          type: string
+        scheduledStart:
+          type:
+            - string
+            - "null"
+          format: date-time
+        scheduledEnd:
+          type:
+            - string
+            - "null"
+          format: date-time
+      required:
+        - title
+    UpdateAdHocActivityBodyV1:
+      type: object
+      properties:
+        title:
+          type: string
+          minLength: 1
+        notes:
+          type:
+            - string
+            - "null"
+        scheduledStart:
+          type:
+            - string
+            - "null"
+          format: date-time
+        scheduledEnd:
+          type:
+            - string
+            - "null"
+          format: date-time
+    SetAdHocActivityDoneBodyV1:
+      type: object
+      properties:
+        done:
+          type: boolean
+      required:
+        - done
+    CustomActivityGroupsResponseV1:
+      type: object
+      properties:
+        data:
+          type: array
+          items:
+            type: object
+            properties:
+              groupId:
+                type: string
+              groupName:
+                type: string
+              sortOrder:
+                type: number
+              isCollapsed:
+                type: boolean
+              items:
+                type: array
+                items:
+                  type: object
+                  properties:
+                    itemId:
+                      type: string
+                    activityId:
+                      type: string
+                    activityType:
+                      type: string
+                    sortOrder:
+                      type: number
+                  required:
+                    - itemId
+                    - activityId
+                    - activityType
+                    - sortOrder
+            required:
+              - groupId
+              - groupName
+              - sortOrder
+              - isCollapsed
+              - items
+        meta: {}
+      required:
+        - data
+    MoveActivityToGroupBodyV1:
+      type: object
+      properties:
+        activityId:
+          type: string
+          minLength: 1
+        activityType:
+          type: string
+          minLength: 1
+        groupId:
+          type: string
+          minLength: 1
+        sortOrder:
+          type: integer
+          minimum: 0
+      required:
+        - activityId
+        - activityType
+        - groupId
+        - sortOrder
+    RemoveActivityFromGroupBodyV1:
+      type: object
+      properties:
+        activityId:
+          type: string
+          minLength: 1
+        activityType:
+          type: string
+          minLength: 1
+      required:
+        - activityId
+        - activityType
+    ReorderActivitiesInGroupBodyV1:
+      type: object
+      properties:
+        items:
+          type: array
+          items:
+            type: object
+            properties:
+              activityId:
+                type: string
+                minLength: 1
+              activityType:
+                type: string
+                minLength: 1
+              sortOrder:
+                type: integer
+                minimum: 0
+            required:
+              - activityId
+              - activityType
+              - sortOrder
+          minItems: 1
+      required:
+        - items
+    ActivitiesGroupIdParamV1:
+      type: object
+      properties:
+        groupId:
+          type: string
+          description: Custom activity group identifier.
+      required:
+        - groupId
+    ActivitiesGroupsQueryV1:
+      type: object
+      properties:
+        targetUserId:
+          type: string
+          description: Another internal user whose groups to read (requires elevated
+            schedule permission). Omit for self.
     ProjectIdParams:
       type: object
       properties:
@@ -13639,7 +14696,7 @@ components:
           type: string
         order:
           type: string
-          enum: &a139
+          enum: &a144
             - asc
             - desc
         fields:
@@ -13944,7 +15001,7 @@ components:
           type: string
         order:
           type: string
-          enum: &a140
+          enum: &a145
             - asc
             - desc
         search:
@@ -13953,12 +15010,12 @@ components:
           type: string
         include_items:
           type: string
-          enum: &a141
+          enum: &a146
             - "true"
             - "false"
         include_client:
           type: string
-          enum: &a142
+          enum: &a147
             - "true"
             - "false"
     QuotesContractsGenericBodyV1:
@@ -15639,7 +16696,7 @@ paths:
           in: query
         - schema:
             type: string
-            enum: *a22
+            enum: *a23
           required: false
           name: order
           in: query
@@ -16163,7 +17220,7 @@ paths:
           in: query
         - schema:
             type: string
-            enum: *a23
+            enum: *a24
           required: false
           name: order
           in: query
@@ -16174,7 +17231,7 @@ paths:
           in: query
         - schema:
             type: string
-            enum: *a24
+            enum: *a25
           required: false
           name: has_permissions
           in: query
@@ -16190,7 +17247,7 @@ paths:
           in: query
         - schema:
             type: string
-            enum: *a25
+            enum: *a26
           required: false
           name: is_template
           in: query
@@ -16787,7 +17844,7 @@ paths:
           in: query
         - schema:
             type: string
-            enum: *a26
+            enum: *a27
           required: false
           name: order
           in: query
@@ -17095,7 +18152,7 @@ paths:
           in: query
         - schema:
             type: string
-            enum: *a27
+            enum: *a28
           required: false
           name: has_manager
           in: query
@@ -17106,7 +18163,7 @@ paths:
           in: query
         - schema:
             type: string
-            enum: *a28
+            enum: *a29
           required: false
           name: order
           in: query
@@ -17423,7 +18480,7 @@ paths:
           in: query
         - schema:
             type: string
-            enum: *a29
+            enum: *a30
           required: false
           name: granularity
           in: query
@@ -18175,7 +19232,7 @@ paths:
           in: query
         - schema:
             type: string
-            enum: *a30
+            enum: *a31
           required: false
           name: is_inactive
           in: query
@@ -18186,7 +19243,7 @@ paths:
           in: query
         - schema:
             type: string
-            enum: *a31
+            enum: *a32
           required: false
           name: order
           in: query
@@ -18258,7 +19315,7 @@ paths:
           in: query
         - schema:
             type: string
-            enum: *a32
+            enum: *a33
           required: false
           name: order
           in: query
@@ -18284,7 +19341,7 @@ paths:
           in: query
         - schema:
             type: string
-            enum: *a33
+            enum: *a34
           required: false
           name: user_type
           in: query
@@ -18302,19 +19359,19 @@ paths:
           in: query
         - schema:
             type: string
-            enum: *a34
+            enum: *a35
           required: false
           name: is_inactive
           in: query
         - schema:
             type: string
-            enum: *a35
+            enum: *a36
           required: false
           name: include_permissions
           in: query
         - schema:
             type: string
-            enum: *a36
+            enum: *a37
           required: false
           name: include_teams
           in: query
@@ -18648,7 +19705,7 @@ paths:
           in: query
         - schema:
             type: string
-            enum: *a37
+            enum: *a38
           required: false
           name: user_type
           in: query
@@ -18666,7 +19723,7 @@ paths:
           in: query
         - schema:
             type: string
-            enum: *a38
+            enum: *a39
           required: false
           name: include_inactive
           in: query
@@ -20051,7 +21108,7 @@ paths:
           in: query
         - schema:
             type: string
-            enum: *a39
+            enum: *a40
             description: Sort direction. Defaults to desc.
           required: false
           description: Sort direction. Defaults to desc.
@@ -20109,7 +21166,7 @@ paths:
           in: query
         - schema:
             type: string
-            enum: *a40
+            enum: *a41
             description: Accepted by validation, but not currently applied by
               AssetService.list.
           required: false
@@ -20177,7 +21234,7 @@ paths:
           in: query
         - schema:
             type: string
-            enum: *a41
+            enum: *a42
             description: true requires warranty_end_date to be non-null; false requires it
               to be null.
           required: false
@@ -20187,7 +21244,7 @@ paths:
           in: query
         - schema:
             type: string
-            enum: *a42
+            enum: *a43
             description: true filters warranty_end_date before now; false filters future
               warranty dates or no warranty.
           required: false
@@ -20197,7 +21254,7 @@ paths:
           in: query
         - schema:
             type: string
-            enum: *a43
+            enum: *a44
             description: Accepted by validation, but not currently applied by
               AssetService.list.
           required: false
@@ -20537,7 +21594,7 @@ paths:
       parameters:
         - schema:
             type: string
-            enum: *a44
+            enum: *a45
             description: Export format. csv (default) returns text/csv as an attachment;
               json returns the success envelope with the rows in data.
           required: false
@@ -20855,7 +21912,7 @@ paths:
             type: array
             items:
               type: string
-              enum: *a45
+              enum: *a46
             description: Search fields. If omitted, the service searches asset_tag, name,
               serial_number, and location.
           required: false
@@ -20894,7 +21951,7 @@ paths:
           in: query
         - schema:
             type: string
-            enum: *a46
+            enum: *a47
             description: When true, the service fetches asset-type-specific extension data
               for every result.
           required: false
@@ -22615,7 +23672,7 @@ paths:
           in: path
         - schema:
             type: string
-            enum: *a47
+            enum: *a48
             description: Remote-control protocol (default splashtop).
           required: false
           description: Remote-control protocol (default splashtop).
@@ -22771,7 +23828,7 @@ paths:
           in: query
         - schema:
             type: string
-            enum: *a48
+            enum: *a49
           required: false
           name: include_uninstalled
           in: query
@@ -22912,7 +23969,7 @@ paths:
           in: query
         - schema:
             type: string
-            enum: *a49
+            enum: *a50
             description: Accepted by shared list query validation.
           required: false
           description: Accepted by shared list query validation.
@@ -22959,7 +24016,7 @@ paths:
           in: query
         - schema:
             type: string
-            enum: *a50
+            enum: *a51
             description: Accepted by shared filter validation and transformed to boolean.
           required: false
           description: Accepted by shared filter validation and transformed to boolean.
@@ -23015,7 +24072,7 @@ paths:
           in: query
         - schema:
             type: string
-            enum: *a51
+            enum: *a52
             description: Filter by whether the execution has errors; transformed to boolean
               by validation.
           required: false
@@ -23261,7 +24318,7 @@ paths:
           in: query
         - schema:
             type: string
-            enum: *a52
+            enum: *a53
             description: Accepted by shared list query validation.
           required: false
           description: Accepted by shared list query validation.
@@ -23308,7 +24365,7 @@ paths:
           in: query
         - schema:
             type: string
-            enum: *a53
+            enum: *a54
             description: Accepted by shared filter validation and transformed to boolean.
           required: false
           description: Accepted by shared filter validation and transformed to boolean.
@@ -23948,7 +25005,7 @@ paths:
           in: query
         - schema:
             type: string
-            enum: *a54
+            enum: *a55
             description: Accepted by shared list query validation.
           required: false
           description: Accepted by shared list query validation.
@@ -23995,7 +25052,7 @@ paths:
           in: query
         - schema:
             type: string
-            enum: *a55
+            enum: *a56
             description: Accepted by shared filter validation and transformed to boolean.
           required: false
           description: Accepted by shared filter validation and transformed to boolean.
@@ -24376,7 +25433,7 @@ paths:
           in: query
         - schema:
             type: string
-            enum: *a56
+            enum: *a57
             description: Aggregation bucket size; defaults to day.
           required: false
           description: Aggregation bucket size; defaults to day.
@@ -24803,7 +25860,7 @@ paths:
           in: query
         - schema:
             type: string
-            enum: *a57
+            enum: *a58
           required: false
           name: order
           in: query
@@ -24848,25 +25905,25 @@ paths:
           in: query
         - schema:
             type: string
-            enum: *a58
+            enum: *a59
           required: false
           name: client_type
           in: query
         - schema:
             type: string
-            enum: *a59
+            enum: *a60
           required: false
           name: billing_cycle
           in: query
         - schema:
             type: string
-            enum: *a60
+            enum: *a61
           required: false
           name: is_inactive
           in: query
         - schema:
             type: string
-            enum: *a61
+            enum: *a62
           required: false
           name: is_tax_exempt
           in: query
@@ -24893,7 +25950,7 @@ paths:
           in: query
         - schema:
             type: string
-            enum: *a62
+            enum: *a63
           required: false
           name: has_credit_limit
           in: query
@@ -25427,7 +26484,7 @@ paths:
           in: query
         - schema:
             type: string
-            enum: *a63
+            enum: *a64
           required: false
           name: order
           in: query
@@ -25488,13 +26545,13 @@ paths:
           in: query
         - schema:
             type: string
-            enum: *a64
+            enum: *a65
           required: false
           name: is_inactive
           in: query
         - schema:
             type: string
-            enum: *a65
+            enum: *a66
           required: false
           name: has_client
           in: query
@@ -25801,7 +26858,7 @@ paths:
           in: query
         - schema:
             type: string
-            enum: *a66
+            enum: *a67
           required: false
           name: include_inactive
           in: query
@@ -25861,13 +26918,13 @@ paths:
       parameters:
         - schema:
             type: string
-            enum: *a67
+            enum: *a68
           required: false
           name: format
           in: query
         - schema:
             type: string
-            enum: *a68
+            enum: *a69
           required: false
           name: include_inactive
           in: query
@@ -25987,7 +27044,7 @@ paths:
           in: query
         - schema:
             type: string
-            enum: *a69
+            enum: *a70
           required: false
           name: order
           in: query
@@ -26039,19 +27096,19 @@ paths:
           in: query
         - schema:
             type: string
-            enum: *a70
+            enum: *a71
           required: false
           name: is_active
           in: query
         - schema:
             type: string
-            enum: *a71
+            enum: *a72
           required: false
           name: has_custom_rate
           in: query
         - schema:
             type: string
-            enum: *a72
+            enum: *a73
           required: false
           name: is_contractd
           in: query
@@ -26229,7 +27286,7 @@ paths:
           in: query
         - schema:
             type: string
-            enum: *a73
+            enum: *a74
           required: false
           name: order
           in: query
@@ -26281,13 +27338,13 @@ paths:
           in: query
         - schema:
             type: string
-            enum: *a74
+            enum: *a75
           required: false
           name: is_custom
           in: query
         - schema:
             type: string
-            enum: *a75
+            enum: *a76
           required: false
           name: is_active
           in: query
@@ -26298,7 +27355,7 @@ paths:
           in: query
         - schema:
             type: string
-            enum: *a76
+            enum: *a77
           required: false
           name: has_services
           in: query
@@ -26324,7 +27381,7 @@ paths:
           in: query
         - schema:
             type: string
-            enum: *a77
+            enum: *a78
             description: Controller-level include flag parsed directly from query string.
           required: false
           description: Controller-level include flag parsed directly from query string.
@@ -26332,7 +27389,7 @@ paths:
           in: query
         - schema:
             type: string
-            enum: *a78
+            enum: *a79
             description: Controller-level include flag parsed directly from query string.
           required: false
           description: Controller-level include flag parsed directly from query string.
@@ -26340,7 +27397,7 @@ paths:
           in: query
         - schema:
             type: string
-            enum: *a79
+            enum: *a80
             description: Controller-level include flag parsed directly from query string.
           required: false
           description: Controller-level include flag parsed directly from query string.
@@ -27663,7 +28720,7 @@ paths:
           in: path
         - schema:
             type: string
-            enum: *a80
+            enum: *a81
             description: Optional export format. pdf generates a PDF; markdown or md exports
               markdown; omitted downloads the original stored file.
           required: false
@@ -29241,7 +30298,7 @@ paths:
           in: query
         - schema:
             type: string
-            enum: *a81
+            enum: *a82
           required: false
           name: order
           in: query
@@ -29304,25 +30361,25 @@ paths:
           in: query
         - schema:
             type: string
-            enum: *a82
+            enum: *a83
           required: false
           name: include_expired
           in: query
         - schema:
             type: string
-            enum: *a83
+            enum: *a84
           required: false
           name: expiring_soon
           in: query
         - schema:
             type: string
-            enum: *a84
+            enum: *a85
           required: false
           name: has_remaining
           in: query
         - schema:
             type: string
-            enum: *a85
+            enum: *a86
           required: false
           name: has_expiration
           in: query
@@ -29338,13 +30395,13 @@ paths:
           in: query
         - schema:
             type: string
-            enum: *a86
+            enum: *a87
           required: false
           name: group_by
           in: query
         - schema:
             type: string
-            enum: *a87
+            enum: *a88
           required: false
           name: include_projections
           in: query
@@ -29665,7 +30722,7 @@ paths:
           in: query
         - schema:
             type: string
-            enum: *a88
+            enum: *a89
           required: false
           name: order
           in: query
@@ -29698,7 +30755,7 @@ paths:
           in: query
         - schema:
             type: string
-            enum: *a89
+            enum: *a90
           required: false
           name: is_active
           in: query
@@ -29710,7 +30767,7 @@ paths:
           in: query
         - schema:
             type: string
-            enum: *a90
+            enum: *a91
           required: false
           name: status
           in: query
@@ -29742,13 +30799,13 @@ paths:
           in: query
         - schema:
             type: string
-            enum: *a91
+            enum: *a92
           required: false
           name: is_manual
           in: query
         - schema:
             type: string
-            enum: *a92
+            enum: *a93
           required: false
           name: has_credit_applied
           in: query
@@ -29970,7 +31027,7 @@ paths:
           in: query
         - schema:
             type: string
-            enum: *a93
+            enum: *a94
           required: false
           name: order
           in: query
@@ -30003,7 +31060,7 @@ paths:
           in: query
         - schema:
             type: string
-            enum: *a94
+            enum: *a95
           required: false
           name: is_active
           in: query
@@ -30015,19 +31072,19 @@ paths:
           in: query
         - schema:
             type: string
-            enum: *a95
+            enum: *a96
           required: false
           name: type
           in: query
         - schema:
             type: string
-            enum: *a96
+            enum: *a97
           required: false
           name: is_default
           in: query
         - schema:
             type: string
-            enum: *a97
+            enum: *a98
             description: Exclude soft-deleted payment methods. Defaults to true.
           required: false
           description: Exclude soft-deleted payment methods. Defaults to true.
@@ -30359,7 +31416,7 @@ paths:
           in: query
         - schema:
             type: string
-            enum: *a81
+            enum: *a82
           required: false
           name: order
           in: query
@@ -30422,25 +31479,25 @@ paths:
           in: query
         - schema:
             type: string
-            enum: *a82
+            enum: *a83
           required: false
           name: include_expired
           in: query
         - schema:
             type: string
-            enum: *a83
+            enum: *a84
           required: false
           name: expiring_soon
           in: query
         - schema:
             type: string
-            enum: *a84
+            enum: *a85
           required: false
           name: has_remaining
           in: query
         - schema:
             type: string
-            enum: *a85
+            enum: *a86
           required: false
           name: has_expiration
           in: query
@@ -30456,13 +31513,13 @@ paths:
           in: query
         - schema:
             type: string
-            enum: *a86
+            enum: *a87
           required: false
           name: group_by
           in: query
         - schema:
             type: string
-            enum: *a87
+            enum: *a88
           required: false
           name: include_projections
           in: query
@@ -30601,7 +31658,7 @@ paths:
           in: query
         - schema:
             type: string
-            enum: *a81
+            enum: *a82
           required: false
           name: order
           in: query
@@ -30664,25 +31721,25 @@ paths:
           in: query
         - schema:
             type: string
-            enum: *a82
+            enum: *a83
           required: false
           name: include_expired
           in: query
         - schema:
             type: string
-            enum: *a83
+            enum: *a84
           required: false
           name: expiring_soon
           in: query
         - schema:
             type: string
-            enum: *a84
+            enum: *a85
           required: false
           name: has_remaining
           in: query
         - schema:
             type: string
-            enum: *a85
+            enum: *a86
           required: false
           name: has_expiration
           in: query
@@ -30698,13 +31755,13 @@ paths:
           in: query
         - schema:
             type: string
-            enum: *a86
+            enum: *a87
           required: false
           name: group_by
           in: query
         - schema:
             type: string
-            enum: *a87
+            enum: *a88
           required: false
           name: include_projections
           in: query
@@ -30778,7 +31835,7 @@ paths:
           in: query
         - schema:
             type: string
-            enum: *a81
+            enum: *a82
           required: false
           name: order
           in: query
@@ -30841,25 +31898,25 @@ paths:
           in: query
         - schema:
             type: string
-            enum: *a82
+            enum: *a83
           required: false
           name: include_expired
           in: query
         - schema:
             type: string
-            enum: *a83
+            enum: *a84
           required: false
           name: expiring_soon
           in: query
         - schema:
             type: string
-            enum: *a84
+            enum: *a85
           required: false
           name: has_remaining
           in: query
         - schema:
             type: string
-            enum: *a85
+            enum: *a86
           required: false
           name: has_expiration
           in: query
@@ -30875,13 +31932,13 @@ paths:
           in: query
         - schema:
             type: string
-            enum: *a86
+            enum: *a87
           required: false
           name: group_by
           in: query
         - schema:
             type: string
-            enum: *a87
+            enum: *a88
           required: false
           name: include_projections
           in: query
@@ -30955,7 +32012,7 @@ paths:
           in: query
         - schema:
             type: string
-            enum: *a81
+            enum: *a82
           required: false
           name: order
           in: query
@@ -31018,25 +32075,25 @@ paths:
           in: query
         - schema:
             type: string
-            enum: *a82
+            enum: *a83
           required: false
           name: include_expired
           in: query
         - schema:
             type: string
-            enum: *a83
+            enum: *a84
           required: false
           name: expiring_soon
           in: query
         - schema:
             type: string
-            enum: *a84
+            enum: *a85
           required: false
           name: has_remaining
           in: query
         - schema:
             type: string
-            enum: *a85
+            enum: *a86
           required: false
           name: has_expiration
           in: query
@@ -31052,13 +32109,13 @@ paths:
           in: query
         - schema:
             type: string
-            enum: *a86
+            enum: *a87
           required: false
           name: group_by
           in: query
         - schema:
             type: string
-            enum: *a87
+            enum: *a88
           required: false
           name: include_projections
           in: query
@@ -31190,7 +32247,7 @@ paths:
           in: query
         - schema:
             type: string
-            enum: *a81
+            enum: *a82
           required: false
           name: order
           in: query
@@ -31253,25 +32310,25 @@ paths:
           in: query
         - schema:
             type: string
-            enum: *a82
+            enum: *a83
           required: false
           name: include_expired
           in: query
         - schema:
             type: string
-            enum: *a83
+            enum: *a84
           required: false
           name: expiring_soon
           in: query
         - schema:
             type: string
-            enum: *a84
+            enum: *a85
           required: false
           name: has_remaining
           in: query
         - schema:
             type: string
-            enum: *a85
+            enum: *a86
           required: false
           name: has_expiration
           in: query
@@ -31287,13 +32344,13 @@ paths:
           in: query
         - schema:
             type: string
-            enum: *a86
+            enum: *a87
           required: false
           name: group_by
           in: query
         - schema:
             type: string
-            enum: *a87
+            enum: *a88
           required: false
           name: include_projections
           in: query
@@ -31367,7 +32424,7 @@ paths:
           in: query
         - schema:
             type: string
-            enum: *a81
+            enum: *a82
           required: false
           name: order
           in: query
@@ -31430,25 +32487,25 @@ paths:
           in: query
         - schema:
             type: string
-            enum: *a82
+            enum: *a83
           required: false
           name: include_expired
           in: query
         - schema:
             type: string
-            enum: *a83
+            enum: *a84
           required: false
           name: expiring_soon
           in: query
         - schema:
             type: string
-            enum: *a84
+            enum: *a85
           required: false
           name: has_remaining
           in: query
         - schema:
             type: string
-            enum: *a85
+            enum: *a86
           required: false
           name: has_expiration
           in: query
@@ -31464,13 +32521,13 @@ paths:
           in: query
         - schema:
             type: string
-            enum: *a86
+            enum: *a87
           required: false
           name: group_by
           in: query
         - schema:
             type: string
-            enum: *a87
+            enum: *a88
           required: false
           name: include_projections
           in: query
@@ -31729,31 +32786,31 @@ paths:
           in: query
         - schema:
             type: string
-            enum: *a98
+            enum: *a99
           required: false
           name: order
           in: query
         - schema:
             type: string
-            enum: *a99
+            enum: *a100
           required: false
           name: include_items
           in: query
         - schema:
             type: string
-            enum: *a100
+            enum: *a101
           required: false
           name: include_client
           in: query
         - schema:
             type: string
-            enum: *a101
+            enum: *a102
           required: false
           name: include_billing_cycle
           in: query
         - schema:
             type: string
-            enum: *a102
+            enum: *a103
           required: false
           name: include_transactions
           in: query
@@ -31774,7 +32831,7 @@ paths:
           in: query
         - schema:
             type: string
-            enum: *a103
+            enum: *a104
           required: false
           name: format
           in: query
@@ -31897,31 +32954,31 @@ paths:
           in: query
         - schema:
             type: string
-            enum: *a98
+            enum: *a99
           required: false
           name: order
           in: query
         - schema:
             type: string
-            enum: *a99
+            enum: *a100
           required: false
           name: include_items
           in: query
         - schema:
             type: string
-            enum: *a100
+            enum: *a101
           required: false
           name: include_client
           in: query
         - schema:
             type: string
-            enum: *a101
+            enum: *a102
           required: false
           name: include_billing_cycle
           in: query
         - schema:
             type: string
-            enum: *a102
+            enum: *a103
           required: false
           name: include_transactions
           in: query
@@ -31942,7 +32999,7 @@ paths:
           in: query
         - schema:
             type: string
-            enum: *a103
+            enum: *a104
           required: false
           name: format
           in: query
@@ -32220,31 +33277,31 @@ paths:
           in: query
         - schema:
             type: string
-            enum: *a98
+            enum: *a99
           required: false
           name: order
           in: query
         - schema:
             type: string
-            enum: *a99
+            enum: *a100
           required: false
           name: include_items
           in: query
         - schema:
             type: string
-            enum: *a100
+            enum: *a101
           required: false
           name: include_client
           in: query
         - schema:
             type: string
-            enum: *a101
+            enum: *a102
           required: false
           name: include_billing_cycle
           in: query
         - schema:
             type: string
-            enum: *a102
+            enum: *a103
           required: false
           name: include_transactions
           in: query
@@ -32265,7 +33322,7 @@ paths:
           in: query
         - schema:
             type: string
-            enum: *a103
+            enum: *a104
           required: false
           name: format
           in: query
@@ -32698,31 +33755,31 @@ paths:
           in: query
         - schema:
             type: string
-            enum: *a98
+            enum: *a99
           required: false
           name: order
           in: query
         - schema:
             type: string
-            enum: *a99
+            enum: *a100
           required: false
           name: include_items
           in: query
         - schema:
             type: string
-            enum: *a100
+            enum: *a101
           required: false
           name: include_client
           in: query
         - schema:
             type: string
-            enum: *a101
+            enum: *a102
           required: false
           name: include_billing_cycle
           in: query
         - schema:
             type: string
-            enum: *a102
+            enum: *a103
           required: false
           name: include_transactions
           in: query
@@ -32743,7 +33800,7 @@ paths:
           in: query
         - schema:
             type: string
-            enum: *a103
+            enum: *a104
           required: false
           name: format
           in: query
@@ -32816,31 +33873,31 @@ paths:
           in: query
         - schema:
             type: string
-            enum: *a98
+            enum: *a99
           required: false
           name: order
           in: query
         - schema:
             type: string
-            enum: *a99
+            enum: *a100
           required: false
           name: include_items
           in: query
         - schema:
             type: string
-            enum: *a100
+            enum: *a101
           required: false
           name: include_client
           in: query
         - schema:
             type: string
-            enum: *a101
+            enum: *a102
           required: false
           name: include_billing_cycle
           in: query
         - schema:
             type: string
-            enum: *a102
+            enum: *a103
           required: false
           name: include_transactions
           in: query
@@ -32861,7 +33918,7 @@ paths:
           in: query
         - schema:
             type: string
-            enum: *a103
+            enum: *a104
           required: false
           name: format
           in: query
@@ -34879,13 +35936,13 @@ paths:
           in: query
         - schema:
             type: string
-            enum: *a104
+            enum: *a105
           required: false
           name: is_managed
           in: query
         - schema:
             type: string
-            enum: *a105
+            enum: *a106
           required: false
           name: is_security_relevant
           in: query
@@ -34975,7 +36032,7 @@ paths:
           in: query
         - schema:
             type: string
-            enum: *a106
+            enum: *a107
           required: false
           name: order
           in: query
@@ -35430,19 +36487,19 @@ paths:
       parameters:
         - schema:
             type: string
-            enum: *a107
+            enum: *a108
           required: false
           name: preview
           in: query
         - schema:
             type: string
-            enum: *a108
+            enum: *a109
           required: false
           name: createNew
           in: query
         - schema:
             type: string
-            enum: *a109
+            enum: *a110
           required: false
           name: updateExisting
           in: query
@@ -35503,7 +36560,7 @@ paths:
       parameters:
         - schema:
             type: string
-            enum: *a110
+            enum: *a111
           required: false
           name: preview
           in: query
@@ -36105,7 +37162,7 @@ paths:
       parameters:
         - schema:
             type: string
-            enum: *a111
+            enum: *a112
           required: false
           name: force
           in: query
@@ -40716,7 +41773,7 @@ paths:
           in: query
         - schema:
             type: string
-            enum: *a112
+            enum: *a113
           required: false
           name: active
           in: query
@@ -40732,7 +41789,7 @@ paths:
           in: query
         - schema:
             type: string
-            enum: *a113
+            enum: *a114
           required: false
           name: force_refresh
           in: query
@@ -41093,7 +42150,7 @@ paths:
           in: query
         - schema:
             type: string
-            enum: *a112
+            enum: *a113
           required: false
           name: active
           in: query
@@ -41109,7 +42166,7 @@ paths:
           in: query
         - schema:
             type: string
-            enum: *a113
+            enum: *a114
           required: false
           name: force_refresh
           in: query
@@ -41653,7 +42710,7 @@ paths:
           in: query
         - schema:
             type: string
-            enum: *a112
+            enum: *a113
           required: false
           name: active
           in: query
@@ -41669,7 +42726,7 @@ paths:
           in: query
         - schema:
             type: string
-            enum: *a113
+            enum: *a114
           required: false
           name: force_refresh
           in: query
@@ -41742,7 +42799,7 @@ paths:
           in: query
         - schema:
             type: string
-            enum: *a112
+            enum: *a113
           required: false
           name: active
           in: query
@@ -41758,7 +42815,7 @@ paths:
           in: query
         - schema:
             type: string
-            enum: *a113
+            enum: *a114
           required: false
           name: force_refresh
           in: query
@@ -42261,7 +43318,7 @@ paths:
           in: query
         - schema:
             type: string
-            enum: *a112
+            enum: *a113
           required: false
           name: active
           in: query
@@ -42277,7 +43334,7 @@ paths:
           in: query
         - schema:
             type: string
-            enum: *a113
+            enum: *a114
           required: false
           name: force_refresh
           in: query
@@ -42526,13 +43583,13 @@ paths:
           in: query
         - schema:
             type: string
-            enum: *a114
+            enum: *a115
           required: false
           name: status
           in: query
         - schema:
             type: string
-            enum: *a115
+            enum: *a116
           required: false
           name: operation_type
           in: query
@@ -42861,7 +43918,7 @@ paths:
           in: query
         - schema:
             type: string
-            enum: *a112
+            enum: *a113
           required: false
           name: active
           in: query
@@ -42877,7 +43934,7 @@ paths:
           in: query
         - schema:
             type: string
-            enum: *a113
+            enum: *a114
           required: false
           name: force_refresh
           in: query
@@ -43066,7 +44123,7 @@ paths:
           in: query
         - schema:
             type: string
-            enum: *a112
+            enum: *a113
           required: false
           name: active
           in: query
@@ -43082,7 +44139,7 @@ paths:
           in: query
         - schema:
             type: string
-            enum: *a113
+            enum: *a114
           required: false
           name: force_refresh
           in: query
@@ -43155,7 +44212,7 @@ paths:
           in: query
         - schema:
             type: string
-            enum: *a112
+            enum: *a113
           required: false
           name: active
           in: query
@@ -43171,7 +44228,7 @@ paths:
           in: query
         - schema:
             type: string
-            enum: *a113
+            enum: *a114
           required: false
           name: force_refresh
           in: query
@@ -43538,7 +44595,7 @@ paths:
           in: query
         - schema:
             type: string
-            enum: *a112
+            enum: *a113
           required: false
           name: active
           in: query
@@ -43554,7 +44611,7 @@ paths:
           in: query
         - schema:
             type: string
-            enum: *a113
+            enum: *a114
           required: false
           name: force_refresh
           in: query
@@ -44106,7 +45163,7 @@ paths:
           in: query
         - schema:
             type: string
-            enum: *a112
+            enum: *a113
           required: false
           name: active
           in: query
@@ -44122,7 +45179,7 @@ paths:
           in: query
         - schema:
             type: string
-            enum: *a113
+            enum: *a114
           required: false
           name: force_refresh
           in: query
@@ -44196,7 +45253,7 @@ paths:
           in: query
         - schema:
             type: string
-            enum: *a112
+            enum: *a113
           required: false
           name: active
           in: query
@@ -44212,7 +45269,7 @@ paths:
           in: query
         - schema:
             type: string
-            enum: *a113
+            enum: *a114
           required: false
           name: force_refresh
           in: query
@@ -44723,7 +45780,7 @@ paths:
           in: query
         - schema:
             type: string
-            enum: *a112
+            enum: *a113
           required: false
           name: active
           in: query
@@ -44739,7 +45796,7 @@ paths:
           in: query
         - schema:
             type: string
-            enum: *a113
+            enum: *a114
           required: false
           name: force_refresh
           in: query
@@ -44992,13 +46049,13 @@ paths:
           in: query
         - schema:
             type: string
-            enum: *a114
+            enum: *a115
           required: false
           name: status
           in: query
         - schema:
             type: string
-            enum: *a115
+            enum: *a116
           required: false
           name: operation_type
           in: query
@@ -45332,7 +46389,7 @@ paths:
           in: query
         - schema:
             type: string
-            enum: *a112
+            enum: *a113
           required: false
           name: active
           in: query
@@ -45348,7 +46405,7 @@ paths:
           in: query
         - schema:
             type: string
-            enum: *a113
+            enum: *a114
           required: false
           name: force_refresh
           in: query
@@ -45539,7 +46596,7 @@ paths:
           in: query
         - schema:
             type: string
-            enum: *a112
+            enum: *a113
           required: false
           name: active
           in: query
@@ -45555,7 +46612,7 @@ paths:
           in: query
         - schema:
             type: string
-            enum: *a113
+            enum: *a114
           required: false
           name: force_refresh
           in: query
@@ -46146,7 +47203,7 @@ paths:
           in: query
         - schema:
             type: string
-            enum: *a116
+            enum: *a117
             description: Result ordering. "relevance" (default) ranks by full-text score;
               "recent" orders by last update.
           required: false
@@ -46521,7 +47578,7 @@ paths:
           in: query
         - schema:
             type: string
-            enum: *a117
+            enum: *a118
           required: false
           name: order
           in: query
@@ -46573,13 +47630,13 @@ paths:
           in: query
         - schema:
             type: string
-            enum: *a118
+            enum: *a119
           required: false
           name: is_parent
           in: query
         - schema:
             type: string
-            enum: *a119
+            enum: *a120
           required: false
           name: is_child
           in: query
@@ -46590,7 +47647,7 @@ paths:
           in: query
         - schema:
             type: string
-            enum: *a120
+            enum: *a121
           required: false
           name: active
           in: query
@@ -46606,19 +47663,19 @@ paths:
           in: query
         - schema:
             type: string
-            enum: *a121
+            enum: *a122
           required: false
           name: sort_order
           in: query
         - schema:
             type: string
-            enum: *a122
+            enum: *a123
           required: false
           name: include_hierarchy
           in: query
         - schema:
             type: string
-            enum: *a123
+            enum: *a124
           required: false
           name: category_type
           in: query
@@ -47074,7 +48131,7 @@ paths:
           in: query
         - schema:
             type: string
-            enum: *a124
+            enum: *a125
           required: false
           name: category_type
           in: query
@@ -47086,7 +48143,7 @@ paths:
           in: query
         - schema:
             type: string
-            enum: *a125
+            enum: *a126
           required: false
           name: include_inactive
           in: query
@@ -47161,7 +48218,7 @@ paths:
       parameters:
         - schema:
             type: string
-            enum: *a126
+            enum: *a127
           required: false
           name: category_type
           in: query
@@ -47185,7 +48242,7 @@ paths:
           in: query
         - schema:
             type: string
-            enum: *a127
+            enum: *a128
           required: false
           name: include_usage
           in: query
@@ -47271,7 +48328,7 @@ paths:
         this endpoint to inspect existing service catalog records and to gather
         prerequisite IDs such as custom_service_type_id and category_id before
         creating a new service.
-      tags: &a128
+      tags: &a129
         - Services
         - Service Catalog
       security:
@@ -47347,7 +48404,7 @@ paths:
           in: query
         - schema:
             type: string
-            enum: &a129
+            enum: &a130
               - fixed
               - hourly
               - usage
@@ -47395,7 +48452,7 @@ paths:
         with GET /api/v1/service-types and category_id with GET
         /api/v1/categories/service before calling this endpoint. Use this
         endpoint for fixed, hourly, or usage-based service offerings.
-      tags: *a128
+      tags: *a129
       security:
         - ApiKeyAuth: []
       extensions:
@@ -47424,7 +48481,7 @@ paths:
                   format: uuid
                 billing_method:
                   type: string
-                  enum: *a129
+                  enum: *a130
                 default_rate:
                   type: number
                   minimum: 0
@@ -47486,7 +48543,7 @@ paths:
     get:
       summary: Get service
       description: Returns a single service catalog entry by UUID.
-      tags: *a128
+      tags: *a129
       security:
         - ApiKeyAuth: []
       extensions:
@@ -47535,7 +48592,7 @@ paths:
     put:
       summary: Update service
       description: Updates a service catalog entry by UUID.
-      tags: *a128
+      tags: *a129
       security:
         - ApiKeyAuth: []
       extensions:
@@ -47573,7 +48630,7 @@ paths:
                   format: uuid
                 billing_method:
                   type: string
-                  enum: *a129
+                  enum: *a130
                 default_rate:
                   type: number
                   minimum: 0
@@ -47634,7 +48691,7 @@ paths:
     delete:
       summary: Delete service
       description: Deletes a service catalog entry by UUID.
-      tags: *a128
+      tags: *a129
       security:
         - ApiKeyAuth: []
       extensions:
@@ -47683,7 +48740,7 @@ paths:
         this endpoint to inspect existing product catalog records and to gather
         prerequisite IDs such as custom_service_type_id and category_id before
         creating a new product.
-      tags: &a130
+      tags: &a131
         - Products
         - Service Catalog
       security:
@@ -47794,7 +48851,7 @@ paths:
         /api/v1/categories/service before calling this endpoint. Products are
         catalog entries with item_kind product and always use billing_method
         usage.
-      tags: *a130
+      tags: *a131
       security:
         - ApiKeyAuth: []
       extensions:
@@ -47823,7 +48880,7 @@ paths:
                   format: uuid
                 billing_method:
                   type: string
-                  enum: &a131
+                  enum: &a132
                     - usage
                   default: usage
                 default_rate:
@@ -47834,7 +48891,6 @@ paths:
                   type: string
                   minLength: 3
                   maxLength: 3
-                  default: USD
                 unit_of_measure:
                   type: string
                   minLength: 1
@@ -47876,7 +48932,6 @@ paths:
                       maxLength: 3
                     - type: "null"
                     - type: "null"
-                  default: USD
                 vendor:
                   anyOf:
                     - type: string
@@ -47962,7 +49017,7 @@ paths:
     get:
       summary: Get product
       description: Returns a single product catalog entry by UUID.
-      tags: *a130
+      tags: *a131
       security:
         - ApiKeyAuth: []
       extensions:
@@ -48011,7 +49066,7 @@ paths:
     put:
       summary: Update product
       description: Updates a product catalog entry by UUID.
-      tags: *a130
+      tags: *a131
       security:
         - ApiKeyAuth: []
       extensions:
@@ -48049,7 +49104,7 @@ paths:
                   format: uuid
                 billing_method:
                   type: string
-                  enum: *a131
+                  enum: *a132
                   default: usage
                 default_rate:
                   type: number
@@ -48059,7 +49114,6 @@ paths:
                   type: string
                   minLength: 3
                   maxLength: 3
-                  default: USD
                 unit_of_measure:
                   type: string
                   minLength: 1
@@ -48101,7 +49155,6 @@ paths:
                       maxLength: 3
                     - type: "null"
                     - type: "null"
-                  default: USD
                 vendor:
                   anyOf:
                     - type: string
@@ -48188,7 +49241,7 @@ paths:
     delete:
       summary: Delete product
       description: Deletes a product catalog entry by UUID.
-      tags: *a130
+      tags: *a131
       security:
         - ApiKeyAuth: []
       extensions:
@@ -48236,7 +49289,7 @@ paths:
       description: Returns tenant service types. Use this endpoint to resolve
         custom_service_type_id before creating or updating services and products
         in the service catalog.
-      tags: &a132
+      tags: &a133
         - Service Types
         - Service Catalog
       security:
@@ -48297,7 +49350,7 @@ paths:
     get:
       summary: Get service type
       description: Returns a single tenant service type by UUID.
-      tags: *a132
+      tags: *a133
       security:
         - ApiKeyAuth: []
       extensions:
@@ -48378,7 +49431,7 @@ paths:
           in: query
         - schema:
             type: string
-            enum: *a133
+            enum: *a134
           required: false
           name: order
           in: query
@@ -48399,25 +49452,25 @@ paths:
           in: query
         - schema:
             type: string
-            enum: *a134
+            enum: *a135
           required: false
           name: is_active
           in: query
         - schema:
             type: string
-            enum: *a135
+            enum: *a136
           required: false
           name: is_test_mode
           in: query
         - schema:
             type: string
-            enum: *a136
+            enum: *a137
           required: false
           name: payload_format
           in: query
         - schema:
             type: string
-            enum: *a137
+            enum: *a138
           required: false
           name: has_failures
           in: query
@@ -49448,7 +50501,7 @@ paths:
           in: query
         - schema:
             type: string
-            enum: *a138
+            enum: *a139
           required: false
           name: status
           in: query
@@ -50591,41 +51644,6 @@ paths:
               schema:
                 $ref: "#/components/schemas/WorkflowV1MissingRouteResponse"
   /api/v1/workflows/tasks:
-    get:
-      summary: List workflow tasks (route inventory only)
-      description: "This operation is currently present only in generated route
-        inventory. No corresponding Next.js handler exists under
-        server/src/app/api/v1/workflows in this worktree. Runtime behavior is
-        middleware-dependent: missing/invalid x-api-key can return 401 before
-        routing; with middleware requirements satisfied, Next.js returns
-        not-found for the absent handler. Existing workflow APIs in this
-        codebase are implemented under /api/workflow-definitions,
-        /api/workflow-runs, and /api/workflow/events rather than
-        /api/v1/workflows paths."
-      tags:
-        - Workflows v1
-      security:
-        - ApiKeyAuth: []
-      extensions:
-        x-route-inventory-only: true
-        x-route-file-missing: server/src/app/api/v1/workflows/**/route.ts
-        x-family-status: missing-handler
-      x-alga-products:
-        - psa
-      responses:
-        "401":
-          description: x-api-key missing/invalid at middleware.
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/WorkflowV1MissingApiError"
-        "404":
-          description: No route handler exists for this inventory-only /api/v1/workflows
-            path.
-          content:
-            text/html:
-              schema:
-                $ref: "#/components/schemas/WorkflowV1MissingRouteResponse"
     post:
       summary: Create workflow task (route inventory only)
       description: "This operation is currently present only in generated route
@@ -50661,6 +51679,78 @@ paths:
             text/html:
               schema:
                 $ref: "#/components/schemas/WorkflowV1MissingRouteResponse"
+    get:
+      summary: List workflow tasks
+      description: Returns the authenticated caller's workflow task inbox (tasks
+        assigned to them directly or via a role), paginated. Items are summary
+        rows without `formSchema`; fetch a single task to obtain its form
+        schema. EE-only — on the Community build this returns an empty page.
+      tags:
+        - Workflow Tasks v1
+      security:
+        - ApiKeyAuth: []
+      extensions:
+        x-tenant-scoped: true
+        x-auth-mechanism: NextAuth session, falling back to x-api-key
+          (resolveWorkflowTaskAuthContext)
+        x-edition-behavior: EE-only feature; CE returns an empty page (list) or 404
+          (detail/actions).
+      x-alga-products:
+        - psa
+      parameters:
+        - schema:
+            type: string
+            description: Comma-separated WorkflowTaskStatus values (pending, claimed,
+              completed, canceled, expired). Omit for the open inbox (pending +
+              claimed).
+          required: false
+          description: Comma-separated WorkflowTaskStatus values (pending, claimed,
+            completed, canceled, expired). Omit for the open inbox (pending +
+            claimed).
+          name: status
+          in: query
+        - schema:
+            type: integer
+            minimum: 1
+            description: 1-based page number (default 1).
+          required: false
+          description: 1-based page number (default 1).
+          name: page
+          in: query
+        - schema:
+            type: integer
+            minimum: 1
+            maximum: 100
+            description: Items per page, max 100 (default 25).
+          required: false
+          description: Items per page, max 100 (default 25).
+          name: pageSize
+          in: query
+      responses:
+        "200":
+          description: Paginated workflow task inbox.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/WorkflowTaskListResponseV1"
+        "400":
+          description: Invalid query parameters.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/WorkflowTasksApiErrorV1"
+        "401":
+          description: Authentication required (no session and no/invalid x-api-key).
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/WorkflowTasksApiErrorV1"
+        "500":
+          description: Unexpected failure resolving the task inbox.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/WorkflowTasksApiErrorV1"
   /api/v1/workflows/tasks/bulk-assign:
     post:
       summary: Bulk assign workflow tasks (route inventory only)
@@ -50698,41 +51788,6 @@ paths:
               schema:
                 $ref: "#/components/schemas/WorkflowV1MissingRouteResponse"
   /api/v1/workflows/tasks/{id}:
-    get:
-      summary: Get workflow task by id (route inventory only)
-      description: "This operation is currently present only in generated route
-        inventory. No corresponding Next.js handler exists under
-        server/src/app/api/v1/workflows in this worktree. Runtime behavior is
-        middleware-dependent: missing/invalid x-api-key can return 401 before
-        routing; with middleware requirements satisfied, Next.js returns
-        not-found for the absent handler. Existing workflow APIs in this
-        codebase are implemented under /api/workflow-definitions,
-        /api/workflow-runs, and /api/workflow/events rather than
-        /api/v1/workflows paths."
-      tags:
-        - Workflows v1
-      security:
-        - ApiKeyAuth: []
-      extensions:
-        x-route-inventory-only: true
-        x-route-file-missing: server/src/app/api/v1/workflows/**/route.ts
-        x-family-status: missing-handler
-      x-alga-products:
-        - psa
-      responses:
-        "401":
-          description: x-api-key missing/invalid at middleware.
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/WorkflowV1MissingApiError"
-        "404":
-          description: No route handler exists for this inventory-only /api/v1/workflows
-            path.
-          content:
-            text/html:
-              schema:
-                $ref: "#/components/schemas/WorkflowV1MissingRouteResponse"
     put:
       summary: Update workflow task (route inventory only)
       description: "This operation is currently present only in generated route
@@ -50768,78 +51823,57 @@ paths:
             text/html:
               schema:
                 $ref: "#/components/schemas/WorkflowV1MissingRouteResponse"
-  /api/v1/workflows/tasks/{id}/claim:
-    post:
-      summary: Claim workflow task (route inventory only)
-      description: "This operation is currently present only in generated route
-        inventory. No corresponding Next.js handler exists under
-        server/src/app/api/v1/workflows in this worktree. Runtime behavior is
-        middleware-dependent: missing/invalid x-api-key can return 401 before
-        routing; with middleware requirements satisfied, Next.js returns
-        not-found for the absent handler. Existing workflow APIs in this
-        codebase are implemented under /api/workflow-definitions,
-        /api/workflow-runs, and /api/workflow/events rather than
-        /api/v1/workflows paths."
+    get:
+      summary: Get workflow task
+      description: Returns full detail for a single workflow task, including
+        `formSchema` ({ jsonSchema, uiSchema?, defaultValues? }) so a client can
+        classify the form as simple (native completion) vs complex (web
+        deep-link). EE-only — on the Community build this returns 404.
       tags:
-        - Workflows v1
+        - Workflow Tasks v1
       security:
         - ApiKeyAuth: []
       extensions:
-        x-route-inventory-only: true
-        x-route-file-missing: server/src/app/api/v1/workflows/**/route.ts
-        x-family-status: missing-handler
+        x-tenant-scoped: true
+        x-auth-mechanism: NextAuth session, falling back to x-api-key
+          (resolveWorkflowTaskAuthContext)
+        x-edition-behavior: EE-only feature; CE returns an empty page (list) or 404
+          (detail/actions).
       x-alga-products:
         - psa
+      parameters:
+        - schema:
+            type: string
+            description: Workflow task identifier (taskId).
+          required: true
+          description: Workflow task identifier (taskId).
+          name: id
+          in: path
       responses:
-        "401":
-          description: x-api-key missing/invalid at middleware.
+        "200":
+          description: Workflow task detail including the resolved form schema.
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/WorkflowV1MissingApiError"
-        "404":
-          description: No route handler exists for this inventory-only /api/v1/workflows
-            path.
-          content:
-            text/html:
-              schema:
-                $ref: "#/components/schemas/WorkflowV1MissingRouteResponse"
-  /api/v1/workflows/tasks/{id}/complete:
-    post:
-      summary: Complete workflow task (route inventory only)
-      description: "This operation is currently present only in generated route
-        inventory. No corresponding Next.js handler exists under
-        server/src/app/api/v1/workflows in this worktree. Runtime behavior is
-        middleware-dependent: missing/invalid x-api-key can return 401 before
-        routing; with middleware requirements satisfied, Next.js returns
-        not-found for the absent handler. Existing workflow APIs in this
-        codebase are implemented under /api/workflow-definitions,
-        /api/workflow-runs, and /api/workflow/events rather than
-        /api/v1/workflows paths."
-      tags:
-        - Workflows v1
-      security:
-        - ApiKeyAuth: []
-      extensions:
-        x-route-inventory-only: true
-        x-route-file-missing: server/src/app/api/v1/workflows/**/route.ts
-        x-family-status: missing-handler
-      x-alga-products:
-        - psa
-      responses:
+                $ref: "#/components/schemas/WorkflowTaskDetailResponseV1"
         "401":
-          description: x-api-key missing/invalid at middleware.
+          description: Authentication required.
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/WorkflowV1MissingApiError"
+                $ref: "#/components/schemas/WorkflowTasksApiErrorV1"
         "404":
-          description: No route handler exists for this inventory-only /api/v1/workflows
-            path.
+          description: Task not found (or workflow tasks unavailable on this build).
           content:
-            text/html:
+            application/json:
               schema:
-                $ref: "#/components/schemas/WorkflowV1MissingRouteResponse"
+                $ref: "#/components/schemas/WorkflowTasksApiErrorV1"
+        "500":
+          description: Unexpected failure resolving the task.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/WorkflowTasksApiErrorV1"
   /api/v1/workflows/templates:
     get:
       summary: List workflow templates (route inventory only)
@@ -51123,6 +52157,856 @@ paths:
             text/html:
               schema:
                 $ref: "#/components/schemas/WorkflowV1MissingRouteResponse"
+  /api/v1/workflows/tasks/{id}/claim:
+    post:
+      summary: Claim workflow task
+      description: Claims a pending task for the caller. No request body. EE-only — on
+        the Community build this returns 404.
+      tags:
+        - Workflow Tasks v1
+      security:
+        - ApiKeyAuth: []
+      extensions:
+        x-tenant-scoped: true
+        x-auth-mechanism: NextAuth session, falling back to x-api-key
+          (resolveWorkflowTaskAuthContext)
+        x-edition-behavior: EE-only feature; CE returns an empty page (list) or 404
+          (detail/actions).
+      x-alga-products:
+        - psa
+      parameters:
+        - schema:
+            type: string
+            description: Workflow task identifier (taskId).
+          required: true
+          description: Workflow task identifier (taskId).
+          name: id
+          in: path
+      responses:
+        "200":
+          description: Task claimed.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/WorkflowTaskActionResponseV1"
+        "401":
+          description: Authentication required.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/WorkflowTasksApiErrorV1"
+        "404":
+          description: Task not found (or workflow tasks unavailable on this build).
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/WorkflowTasksApiErrorV1"
+        "409":
+          description: Task already claimed by another user or not in a claimable state.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/WorkflowTasksApiErrorV1"
+        "500":
+          description: Unexpected failure claiming the task.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/WorkflowTasksApiErrorV1"
+  /api/v1/workflows/tasks/{id}/unclaim:
+    post:
+      summary: Unclaim workflow task
+      description: Releases a task the caller has claimed, returning it to the pending
+        pool. No request body. EE-only — on the Community build this returns
+        404.
+      tags:
+        - Workflow Tasks v1
+      security:
+        - ApiKeyAuth: []
+      extensions:
+        x-tenant-scoped: true
+        x-auth-mechanism: NextAuth session, falling back to x-api-key
+          (resolveWorkflowTaskAuthContext)
+        x-edition-behavior: EE-only feature; CE returns an empty page (list) or 404
+          (detail/actions).
+      x-alga-products:
+        - psa
+      parameters:
+        - schema:
+            type: string
+            description: Workflow task identifier (taskId).
+          required: true
+          description: Workflow task identifier (taskId).
+          name: id
+          in: path
+      responses:
+        "200":
+          description: Task released.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/WorkflowTaskActionResponseV1"
+        "401":
+          description: Authentication required.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/WorkflowTasksApiErrorV1"
+        "404":
+          description: Task not found (or workflow tasks unavailable on this build).
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/WorkflowTasksApiErrorV1"
+        "409":
+          description: Task is not claimed by the caller.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/WorkflowTasksApiErrorV1"
+        "500":
+          description: Unexpected failure releasing the task.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/WorkflowTasksApiErrorV1"
+  /api/v1/workflows/tasks/{id}/complete:
+    post:
+      summary: Complete workflow task
+      description: Submits the task's form payload and completes it. The form data is
+        validated server-side against the task's JSON Schema; validation
+        failures return 400 with the schema errors in `error.details`. EE-only —
+        on the Community build this returns 404.
+      tags:
+        - Workflow Tasks v1
+      security:
+        - ApiKeyAuth: []
+      extensions:
+        x-tenant-scoped: true
+        x-auth-mechanism: NextAuth session, falling back to x-api-key
+          (resolveWorkflowTaskAuthContext)
+        x-edition-behavior: EE-only feature; CE returns an empty page (list) or 404
+          (detail/actions).
+      x-alga-products:
+        - psa
+      parameters:
+        - schema:
+            type: string
+            description: Workflow task identifier (taskId).
+          required: true
+          description: Workflow task identifier (taskId).
+          name: id
+          in: path
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/CompleteWorkflowTaskBodyV1"
+      responses:
+        "200":
+          description: Task completed.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/WorkflowTaskActionResponseV1"
+        "400":
+          description: Form validation failed; schema errors are returned in
+            `error.details`.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/WorkflowTasksApiErrorV1"
+        "401":
+          description: Authentication required.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/WorkflowTasksApiErrorV1"
+        "404":
+          description: Task not found (or workflow tasks unavailable on this build).
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/WorkflowTasksApiErrorV1"
+        "409":
+          description: Task is not in a completable state for the caller.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/WorkflowTasksApiErrorV1"
+        "500":
+          description: Unexpected failure completing the task.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/WorkflowTasksApiErrorV1"
+  /api/v1/activities:
+    get:
+      summary: List user activities
+      description: Returns the authenticated caller's unified activity list — a
+        fan-out across tickets, project tasks, schedule entries, ad-hoc items,
+        workflow tasks, time entries and notifications. Filter by activity
+        type(s), open/closed status, priority, due-date window, free-text search
+        and a date window; sort via `sortBy`/`sortDirection`. By default the
+        result is paginated (ActivityListResponseV1). When `groupBy` is supplied
+        the result is instead grouped server-side into ordered, counted buckets
+        (ActivityGroupedResponseV1) and `page`/`pageSize` are ignored.
+      tags:
+        - Activities v1
+      security:
+        - ApiKeyAuth: []
+      extensions:
+        x-tenant-scoped: true
+        x-auth-mechanism: NextAuth session, falling back to x-api-key
+          (resolveActivityAuthContext)
+        x-response-when-grouped: "#/components/schemas/ActivityGroupedResponseV1"
+      x-alga-products:
+        - psa
+      parameters:
+        - schema:
+            type: string
+            description: Comma-separated ActivityType values (e.g. "ticket,schedule"). Omit
+              for all types.
+          required: false
+          description: Comma-separated ActivityType values (e.g. "ticket,schedule"). Omit
+            for all types.
+          name: type
+          in: query
+        - schema:
+            type: string
+            enum: *a140
+            description: Open/closed filter. `open`→active only, `closed`→closed, `all`→no
+              filter (default).
+          required: false
+          description: Open/closed filter. `open`→active only, `closed`→closed, `all`→no
+            filter (default).
+          name: status
+          in: query
+        - schema:
+            type: string
+            description: Free-text search across activity titles/descriptions.
+          required: false
+          description: Free-text search across activity titles/descriptions.
+          name: search
+          in: query
+        - schema:
+            type: string
+            format: date-time
+            description: ISO 8601 lower bound of the schedule/time-entry/notification
+              window.
+          required: false
+          description: ISO 8601 lower bound of the schedule/time-entry/notification window.
+          name: dateStart
+          in: query
+        - schema:
+            type: string
+            format: date-time
+            description: ISO 8601 upper bound of the window.
+          required: false
+          description: ISO 8601 upper bound of the window.
+          name: dateEnd
+          in: query
+        - schema:
+            type: string
+            description: Comma-separated normalized ActivityPriority buckets (e.g.
+              "high,medium"). Lossy for custom schemes; prefer `priorityIds`.
+          required: false
+          description: Comma-separated normalized ActivityPriority buckets (e.g.
+            "high,medium"). Lossy for custom schemes; prefer `priorityIds`.
+          name: priority
+          in: query
+        - schema:
+            type: string
+            description: Comma-separated exact priority IDs (the tenant's real per-type
+              priorities). Applies to ticket/project-task activities.
+          required: false
+          description: Comma-separated exact priority IDs (the tenant's real per-type
+            priorities). Applies to ticket/project-task activities.
+          name: priorityIds
+          in: query
+        - schema:
+            type: string
+            format: date-time
+            description: ISO 8601 lower bound of the due-date filter (independent of the
+              schedule window).
+          required: false
+          description: ISO 8601 lower bound of the due-date filter (independent of the
+            schedule window).
+          name: dueDateStart
+          in: query
+        - schema:
+            type: string
+            format: date-time
+            description: ISO 8601 upper bound of the due-date filter.
+          required: false
+          description: ISO 8601 upper bound of the due-date filter.
+          name: dueDateEnd
+          in: query
+        - schema:
+            type: string
+            format: date-time
+            description: ISO 8601 lower bound of the created-date ("date entered") filter.
+              Applies to every activity type.
+          required: false
+          description: ISO 8601 lower bound of the created-date ("date entered") filter.
+            Applies to every activity type.
+          name: createdAtStart
+          in: query
+        - schema:
+            type: string
+            format: date-time
+            description: ISO 8601 upper bound of the created-date ("date entered") filter.
+          required: false
+          description: ISO 8601 upper bound of the created-date ("date entered") filter.
+          name: createdAtEnd
+          in: query
+        - schema:
+            type: string
+            enum: *a141
+            description: Sort column. Omit for the default sort (priority high→low, then due
+              date ascending).
+          required: false
+          description: Sort column. Omit for the default sort (priority high→low, then due
+            date ascending).
+          name: sortBy
+          in: query
+        - schema:
+            type: string
+            enum: *a142
+            description: Sort direction for `sortBy` (default asc). Ignored when `sortBy` is
+              omitted.
+          required: false
+          description: Sort direction for `sortBy` (default asc). Ignored when `sortBy` is
+            omitted.
+          name: sortDirection
+          in: query
+        - schema:
+            type: string
+            enum: *a143
+            description: When set, the response is grouped by this dimension
+              (ActivityGroupedResponseV1) instead of the paginated list;
+              `page`/`pageSize` are ignored. `priority` groups by the real
+              per-tenant priority name (not the normalized bucket), so it is
+              only meaningful when scoped to a single prioritized type.
+          required: false
+          description: When set, the response is grouped by this dimension
+            (ActivityGroupedResponseV1) instead of the paginated list;
+            `page`/`pageSize` are ignored. `priority` groups by the real
+            per-tenant priority name (not the normalized bucket), so it is only
+            meaningful when scoped to a single prioritized type.
+          name: groupBy
+          in: query
+        - schema:
+            type: integer
+            minimum: 1
+            description: 1-based page number (default 1). Ignored when `groupBy` is set.
+          required: false
+          description: 1-based page number (default 1). Ignored when `groupBy` is set.
+          name: page
+          in: query
+        - schema:
+            type: integer
+            minimum: 1
+            maximum: 100
+            description: Items per page, max 100 (default 25). Ignored when `groupBy` is
+              set.
+          required: false
+          description: Items per page, max 100 (default 25). Ignored when `groupBy` is set.
+          name: pageSize
+          in: query
+      responses:
+        "200":
+          description: Paginated activity list, or grouped buckets when `groupBy` is set.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ActivityListResponseV1"
+        "400":
+          description: Invalid query parameters.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ActivitiesApiErrorV1"
+        "401":
+          description: Authentication required (no session and no/invalid x-api-key).
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ActivitiesApiErrorV1"
+        "403":
+          description: Permission denied for one of the underlying activity sources.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ActivitiesApiErrorV1"
+        "500":
+          description: Unexpected failure resolving activities.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ActivitiesApiErrorV1"
+  /api/v1/activities/ad-hoc:
+    post:
+      summary: Create ad-hoc activity
+      description: Creates a personal, self-assigned ad-hoc to-do rendered as a
+        schedule activity. Times are optional; when both are supplied the end
+        must be after the start. Gated by `user_schedule:read`.
+      tags:
+        - Activities v1
+      security:
+        - ApiKeyAuth: []
+      extensions:
+        x-tenant-scoped: true
+        x-auth-mechanism: NextAuth session, falling back to x-api-key
+          (resolveActivityAuthContext)
+      x-alga-products:
+        - psa
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/CreateAdHocActivityBodyV1"
+      responses:
+        "201":
+          description: Ad-hoc activity created.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/AdHocActivityResponseV1"
+        "400":
+          description: Invalid request body (e.g. missing title or end before start).
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ActivitiesApiErrorV1"
+        "401":
+          description: Authentication required.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ActivitiesApiErrorV1"
+        "403":
+          description: Permission denied (user_schedule:read).
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ActivitiesApiErrorV1"
+        "500":
+          description: Unexpected failure creating the ad-hoc activity.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ActivitiesApiErrorV1"
+  /api/v1/activities/ad-hoc/{id}:
+    patch:
+      summary: Update ad-hoc activity
+      description: "Updates an ad-hoc item's title, notes or optional times. Omitted
+        fields are left unchanged; `notes: null` clears the field. Requires the
+        caller to be an assignee, or hold `user_schedule:update` /
+        `user_schedule:read_all`."
+      tags:
+        - Activities v1
+      security:
+        - ApiKeyAuth: []
+      extensions:
+        x-tenant-scoped: true
+        x-auth-mechanism: NextAuth session, falling back to x-api-key
+          (resolveActivityAuthContext)
+      x-alga-products:
+        - psa
+      parameters:
+        - schema:
+            type: string
+            description: Ad-hoc activity identifier (the backing schedule entry id).
+          required: true
+          description: Ad-hoc activity identifier (the backing schedule entry id).
+          name: id
+          in: path
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/UpdateAdHocActivityBodyV1"
+      responses:
+        "200":
+          description: Updated ad-hoc activity.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/AdHocActivityResponseV1"
+        "400":
+          description: Invalid request body (e.g. end before start).
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ActivitiesApiErrorV1"
+        "401":
+          description: Authentication required.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ActivitiesApiErrorV1"
+        "403":
+          description: Permission denied.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ActivitiesApiErrorV1"
+        "404":
+          description: Ad-hoc activity not found.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ActivitiesApiErrorV1"
+        "500":
+          description: Unexpected failure updating the ad-hoc activity.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ActivitiesApiErrorV1"
+    delete:
+      summary: Delete ad-hoc activity
+      description: Permanently deletes an ad-hoc item. Requires the caller to be an
+        assignee, or hold `user_schedule:update` / `user_schedule:read_all`.
+      tags:
+        - Activities v1
+      security:
+        - ApiKeyAuth: []
+      extensions:
+        x-tenant-scoped: true
+        x-auth-mechanism: NextAuth session, falling back to x-api-key
+          (resolveActivityAuthContext)
+      x-alga-products:
+        - psa
+      parameters:
+        - schema:
+            type: string
+            description: Ad-hoc activity identifier (the backing schedule entry id).
+          required: true
+          description: Ad-hoc activity identifier (the backing schedule entry id).
+          name: id
+          in: path
+      responses:
+        "204":
+          description: Ad-hoc activity deleted; no content.
+        "401":
+          description: Authentication required.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ActivitiesApiErrorV1"
+        "403":
+          description: Permission denied.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ActivitiesApiErrorV1"
+        "404":
+          description: Ad-hoc activity not found.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ActivitiesApiErrorV1"
+        "500":
+          description: Unexpected failure deleting the ad-hoc activity.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ActivitiesApiErrorV1"
+  /api/v1/activities/ad-hoc/{id}/done:
+    post:
+      summary: Toggle ad-hoc activity done
+      description: "Marks an ad-hoc item done/undone. `done: true` sets status to
+        closed; `done: false` reopens it (status scheduled). Requires the caller
+        to be an assignee, or hold `user_schedule:update` /
+        `user_schedule:read_all`."
+      tags:
+        - Activities v1
+      security:
+        - ApiKeyAuth: []
+      extensions:
+        x-tenant-scoped: true
+        x-auth-mechanism: NextAuth session, falling back to x-api-key
+          (resolveActivityAuthContext)
+      x-alga-products:
+        - psa
+      parameters:
+        - schema:
+            type: string
+            description: Ad-hoc activity identifier (the backing schedule entry id).
+          required: true
+          description: Ad-hoc activity identifier (the backing schedule entry id).
+          name: id
+          in: path
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/SetAdHocActivityDoneBodyV1"
+      responses:
+        "200":
+          description: Updated ad-hoc activity.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/AdHocActivityResponseV1"
+        "400":
+          description: Invalid request body (e.g. missing `done`).
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ActivitiesApiErrorV1"
+        "401":
+          description: Authentication required.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ActivitiesApiErrorV1"
+        "403":
+          description: Permission denied.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ActivitiesApiErrorV1"
+        "404":
+          description: Ad-hoc activity not found.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ActivitiesApiErrorV1"
+        "500":
+          description: Unexpected failure updating the ad-hoc activity.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ActivitiesApiErrorV1"
+  /api/v1/activities/groups:
+    get:
+      summary: List custom activity groups
+      description: "Returns the caller's saved custom activity groups (created and
+        ordered in the web app), each with its ordered item references.
+        Read-only: clients bucket the unified activity list into these groups
+        for a \"My groups\" view. Pass `targetUserId` to read another user's
+        groups (requires `user_schedule:update` / `user_schedule:read_all`).
+        Membership and ordering are changed via the `/groups/items` endpoints."
+      tags:
+        - Activities v1
+      security:
+        - ApiKeyAuth: []
+      extensions:
+        x-tenant-scoped: true
+        x-auth-mechanism: NextAuth session, falling back to x-api-key
+          (resolveActivityAuthContext)
+      x-alga-products:
+        - psa
+      parameters:
+        - schema:
+            type: string
+            description: Another internal user whose groups to read (requires elevated
+              schedule permission). Omit for self.
+          required: false
+          description: Another internal user whose groups to read (requires elevated
+            schedule permission). Omit for self.
+          name: targetUserId
+          in: query
+      responses:
+        "200":
+          description: The caller's custom activity groups.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/CustomActivityGroupsResponseV1"
+        "401":
+          description: Authentication required.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ActivitiesApiErrorV1"
+        "403":
+          description: Permission denied (reading another user's groups).
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ActivitiesApiErrorV1"
+        "500":
+          description: Unexpected failure resolving groups.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ActivitiesApiErrorV1"
+  /api/v1/activities/groups/items:
+    post:
+      summary: Move an activity into a group
+      description: Moves an activity into one of the caller's custom groups at the
+        given position (`sortOrder`), removing it from any other group first so
+        an activity belongs to at most one group. Rows at/after the index are
+        shifted to keep ordering dense. Scoped to the caller's own groups; gated
+        by `user_schedule:read`.
+      tags:
+        - Activities v1
+      security:
+        - ApiKeyAuth: []
+      extensions:
+        x-tenant-scoped: true
+        x-auth-mechanism: NextAuth session, falling back to x-api-key
+          (resolveActivityAuthContext)
+      x-alga-products:
+        - psa
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/MoveActivityToGroupBodyV1"
+      responses:
+        "200":
+          description: Activity moved.
+        "400":
+          description: Invalid request body.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ActivitiesApiErrorV1"
+        "401":
+          description: Authentication required.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ActivitiesApiErrorV1"
+        "403":
+          description: Permission denied (user_schedule:read).
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ActivitiesApiErrorV1"
+        "404":
+          description: Target group not found.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ActivitiesApiErrorV1"
+        "500":
+          description: Unexpected failure moving the activity.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ActivitiesApiErrorV1"
+    delete:
+      summary: Remove an activity from its group
+      description: Removes an activity from all of the caller's custom groups (makes
+        it "ungrouped"). No-op when the activity is not in any group. Scoped to
+        the caller's own groups; gated by `user_schedule:read`.
+      tags:
+        - Activities v1
+      security:
+        - ApiKeyAuth: []
+      extensions:
+        x-tenant-scoped: true
+        x-auth-mechanism: NextAuth session, falling back to x-api-key
+          (resolveActivityAuthContext)
+      x-alga-products:
+        - psa
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/RemoveActivityFromGroupBodyV1"
+      responses:
+        "200":
+          description: Activity removed from its group.
+        "400":
+          description: Invalid request body.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ActivitiesApiErrorV1"
+        "401":
+          description: Authentication required.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ActivitiesApiErrorV1"
+        "403":
+          description: Permission denied (user_schedule:read).
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ActivitiesApiErrorV1"
+        "500":
+          description: Unexpected failure removing the activity.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ActivitiesApiErrorV1"
+  /api/v1/activities/groups/{groupId}/items:
+    patch:
+      summary: Reorder activities within a group
+      description: Persists the full ordered membership of a group after a
+        drag-to-reorder. Pass every item as it should appear; each row's
+        `sortOrder` is set to its position. Scoped to the caller's own groups;
+        gated by `user_schedule:read`.
+      tags:
+        - Activities v1
+      security:
+        - ApiKeyAuth: []
+      extensions:
+        x-tenant-scoped: true
+        x-auth-mechanism: NextAuth session, falling back to x-api-key
+          (resolveActivityAuthContext)
+      x-alga-products:
+        - psa
+      parameters:
+        - schema:
+            type: string
+            description: Custom activity group identifier.
+          required: true
+          description: Custom activity group identifier.
+          name: groupId
+          in: path
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/ReorderActivitiesInGroupBodyV1"
+      responses:
+        "200":
+          description: Group order persisted.
+        "400":
+          description: Invalid request body.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ActivitiesApiErrorV1"
+        "401":
+          description: Authentication required.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ActivitiesApiErrorV1"
+        "403":
+          description: Permission denied (user_schedule:read).
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ActivitiesApiErrorV1"
+        "404":
+          description: Group not found.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ActivitiesApiErrorV1"
+        "500":
+          description: Unexpected failure reordering the group.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ActivitiesApiErrorV1"
   /api/v1/projects/{id}/task-status-mappings:
     get:
       summary: List project task status mappings
@@ -51566,7 +53450,7 @@ paths:
           in: query
         - schema:
             type: string
-            enum: *a139
+            enum: *a144
           required: false
           name: order
           in: query
@@ -51867,7 +53751,7 @@ paths:
           in: query
         - schema:
             type: string
-            enum: *a139
+            enum: *a144
           required: false
           name: order
           in: query
@@ -51951,7 +53835,7 @@ paths:
           in: query
         - schema:
             type: string
-            enum: *a139
+            enum: *a144
           required: false
           name: order
           in: query
@@ -52035,7 +53919,7 @@ paths:
           in: query
         - schema:
             type: string
-            enum: *a139
+            enum: *a144
           required: false
           name: order
           in: query
@@ -52128,7 +54012,7 @@ paths:
           in: query
         - schema:
             type: string
-            enum: *a139
+            enum: *a144
           required: false
           name: order
           in: query
@@ -52226,7 +54110,7 @@ paths:
           in: query
         - schema:
             type: string
-            enum: *a139
+            enum: *a144
           required: false
           name: order
           in: query
@@ -52529,7 +54413,7 @@ paths:
           in: query
         - schema:
             type: string
-            enum: *a139
+            enum: *a144
           required: false
           name: order
           in: query
@@ -52626,7 +54510,7 @@ paths:
           in: query
         - schema:
             type: string
-            enum: *a139
+            enum: *a144
           required: false
           name: order
           in: query
@@ -52884,7 +54768,7 @@ paths:
           in: query
         - schema:
             type: string
-            enum: *a139
+            enum: *a144
           required: false
           name: order
           in: query
@@ -52974,7 +54858,7 @@ paths:
           in: query
         - schema:
             type: string
-            enum: *a139
+            enum: *a144
           required: false
           name: order
           in: query
@@ -53118,7 +55002,7 @@ paths:
           in: query
         - schema:
             type: string
-            enum: *a139
+            enum: *a144
           required: false
           name: order
           in: query
@@ -53413,7 +55297,7 @@ paths:
           in: query
         - schema:
             type: string
-            enum: *a139
+            enum: *a144
           required: false
           name: order
           in: query
@@ -53504,7 +55388,7 @@ paths:
           in: query
         - schema:
             type: string
-            enum: *a139
+            enum: *a144
           required: false
           name: order
           in: query
@@ -53648,7 +55532,7 @@ paths:
           in: query
         - schema:
             type: string
-            enum: *a139
+            enum: *a144
           required: false
           name: order
           in: query
@@ -54083,7 +55967,7 @@ paths:
           in: query
         - schema:
             type: string
-            enum: *a139
+            enum: *a144
           required: false
           name: order
           in: query
@@ -54394,7 +56278,7 @@ paths:
           in: query
         - schema:
             type: string
-            enum: *a139
+            enum: *a144
           required: false
           name: order
           in: query
@@ -54820,7 +56704,7 @@ paths:
           in: query
         - schema:
             type: string
-            enum: *a139
+            enum: *a144
           required: false
           name: order
           in: query
@@ -54904,7 +56788,7 @@ paths:
           in: query
         - schema:
             type: string
-            enum: *a139
+            enum: *a144
           required: false
           name: order
           in: query
@@ -55089,7 +56973,7 @@ paths:
           in: query
         - schema:
             type: string
-            enum: *a139
+            enum: *a144
           required: false
           name: order
           in: query
@@ -55174,7 +57058,7 @@ paths:
           in: query
         - schema:
             type: string
-            enum: *a139
+            enum: *a144
           required: false
           name: order
           in: query
@@ -55540,7 +57424,7 @@ paths:
           in: query
         - schema:
             type: string
-            enum: *a139
+            enum: *a144
           required: false
           name: order
           in: query
@@ -55638,7 +57522,7 @@ paths:
           in: query
         - schema:
             type: string
-            enum: *a139
+            enum: *a144
           required: false
           name: order
           in: query
@@ -56366,7 +58250,7 @@ paths:
           in: query
         - schema:
             type: string
-            enum: *a139
+            enum: *a144
           required: false
           name: order
           in: query
@@ -56508,7 +58392,7 @@ paths:
           in: query
         - schema:
             type: string
-            enum: *a139
+            enum: *a144
           required: false
           name: order
           in: query
@@ -56817,7 +58701,7 @@ paths:
           in: query
         - schema:
             type: string
-            enum: *a139
+            enum: *a144
           required: false
           name: order
           in: query
@@ -56960,7 +58844,7 @@ paths:
           in: query
         - schema:
             type: string
-            enum: *a139
+            enum: *a144
           required: false
           name: order
           in: query
@@ -57103,7 +58987,7 @@ paths:
           in: query
         - schema:
             type: string
-            enum: *a139
+            enum: *a144
           required: false
           name: order
           in: query
@@ -57260,7 +59144,7 @@ paths:
           in: query
         - schema:
             type: string
-            enum: *a139
+            enum: *a144
           required: false
           name: order
           in: query
@@ -57543,7 +59427,7 @@ paths:
           in: query
         - schema:
             type: string
-            enum: *a139
+            enum: *a144
           required: false
           name: order
           in: query
@@ -57687,7 +59571,7 @@ paths:
           in: query
         - schema:
             type: string
-            enum: *a139
+            enum: *a144
           required: false
           name: order
           in: query
@@ -58122,7 +60006,7 @@ paths:
           in: query
         - schema:
             type: string
-            enum: *a139
+            enum: *a144
           required: false
           name: order
           in: query
@@ -58325,7 +60209,7 @@ paths:
           in: query
         - schema:
             type: string
-            enum: *a139
+            enum: *a144
           required: false
           name: order
           in: query
@@ -58411,7 +60295,7 @@ paths:
           in: query
         - schema:
             type: string
-            enum: *a139
+            enum: *a144
           required: false
           name: order
           in: query
@@ -58854,7 +60738,7 @@ paths:
           in: query
         - schema:
             type: string
-            enum: *a139
+            enum: *a144
           required: false
           name: order
           in: query
@@ -59325,7 +61209,7 @@ paths:
           in: query
         - schema:
             type: string
-            enum: *a139
+            enum: *a144
           required: false
           name: order
           in: query
@@ -60053,7 +61937,7 @@ paths:
           in: query
         - schema:
             type: string
-            enum: *a140
+            enum: *a145
           required: false
           name: order
           in: query
@@ -60069,13 +61953,13 @@ paths:
           in: query
         - schema:
             type: string
-            enum: *a141
+            enum: *a146
           required: false
           name: include_items
           in: query
         - schema:
             type: string
-            enum: *a142
+            enum: *a147
           required: false
           name: include_client
           in: query
@@ -60144,7 +62028,7 @@ paths:
           in: query
         - schema:
             type: string
-            enum: *a140
+            enum: *a145
           required: false
           name: order
           in: query
@@ -60160,13 +62044,13 @@ paths:
           in: query
         - schema:
             type: string
-            enum: *a141
+            enum: *a146
           required: false
           name: include_items
           in: query
         - schema:
             type: string
-            enum: *a142
+            enum: *a147
           required: false
           name: include_client
           in: query
@@ -61581,7 +63465,7 @@ paths:
           in: query
         - schema:
             type: string
-            enum: *a140
+            enum: *a145
           required: false
           name: order
           in: query
@@ -61597,13 +63481,13 @@ paths:
           in: query
         - schema:
             type: string
-            enum: *a141
+            enum: *a146
           required: false
           name: include_items
           in: query
         - schema:
             type: string
-            enum: *a142
+            enum: *a147
           required: false
           name: include_client
           in: query
@@ -61676,7 +63560,7 @@ paths:
           in: query
         - schema:
             type: string
-            enum: *a140
+            enum: *a145
           required: false
           name: order
           in: query
@@ -61692,13 +63576,13 @@ paths:
           in: query
         - schema:
             type: string
-            enum: *a141
+            enum: *a146
           required: false
           name: include_items
           in: query
         - schema:
             type: string
-            enum: *a142
+            enum: *a147
           required: false
           name: include_client
           in: query
@@ -64448,6 +66332,37 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/ErrorResponse"
+  /api/auth/captcha-config:
+    get:
+      summary: GET auth
+      description: This operation was generated automatically from the route
+        inventory. Replace with canonical OpenAPI metadata.
+      tags:
+        - auth
+      extensions:
+        x-generated-from: docs/openapi/route-inventory.json
+        x-placeholder: true
+      x-alga-products:
+        - psa
+      responses:
+        "200":
+          description: Placeholder success response
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/PlaceholderObject"
+        "401":
+          description: Authentication required
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        "403":
+          description: Forbidden
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
   /api/auth/e2e/google/authorize:
     get:
       summary: GET auth
@@ -64927,6 +66842,201 @@ paths:
         - psa
       responses:
         "200":
+          description: Placeholder success response
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/PlaceholderObject"
+        "401":
+          description: Authentication required
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        "403":
+          description: Forbidden
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+  /api/billing/complete-reactivation:
+    post:
+      summary: POST billing
+      description: This operation was generated automatically from the route
+        inventory. Replace with canonical OpenAPI metadata.
+      tags:
+        - billing
+      extensions:
+        x-generated-from: docs/openapi/route-inventory.json
+        x-placeholder: true
+      x-alga-products:
+        - psa
+      requestBody:
+        description: Placeholder request body
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/PlaceholderObject"
+            description: Placeholder request body
+      responses:
+        "201":
+          description: Placeholder success response
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/PlaceholderObject"
+        "401":
+          description: Authentication required
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        "403":
+          description: Forbidden
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+  /api/billing/reactivation-password-reset:
+    post:
+      summary: POST billing
+      description: This operation was generated automatically from the route
+        inventory. Replace with canonical OpenAPI metadata.
+      tags:
+        - billing
+      extensions:
+        x-generated-from: docs/openapi/route-inventory.json
+        x-placeholder: true
+      x-alga-products:
+        - psa
+      requestBody:
+        description: Placeholder request body
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/PlaceholderObject"
+            description: Placeholder request body
+      responses:
+        "201":
+          description: Placeholder success response
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/PlaceholderObject"
+        "401":
+          description: Authentication required
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        "403":
+          description: Forbidden
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+  /api/billing/reactivation-token:
+    post:
+      summary: POST billing
+      description: This operation was generated automatically from the route
+        inventory. Replace with canonical OpenAPI metadata.
+      tags:
+        - billing
+      extensions:
+        x-generated-from: docs/openapi/route-inventory.json
+        x-placeholder: true
+      x-alga-products:
+        - psa
+      requestBody:
+        description: Placeholder request body
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/PlaceholderObject"
+            description: Placeholder request body
+      responses:
+        "201":
+          description: Placeholder success response
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/PlaceholderObject"
+        "401":
+          description: Authentication required
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        "403":
+          description: Forbidden
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+  /api/billing/reactivation-token/session:
+    post:
+      summary: POST billing
+      description: This operation was generated automatically from the route
+        inventory. Replace with canonical OpenAPI metadata.
+      tags:
+        - billing
+      extensions:
+        x-generated-from: docs/openapi/route-inventory.json
+        x-placeholder: true
+      x-alga-products:
+        - psa
+      requestBody:
+        description: Placeholder request body
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/PlaceholderObject"
+            description: Placeholder request body
+      responses:
+        "201":
+          description: Placeholder success response
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/PlaceholderObject"
+        "401":
+          description: Authentication required
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        "403":
+          description: Forbidden
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+  /api/billing/request-reactivation:
+    post:
+      summary: POST billing
+      description: This operation was generated automatically from the route
+        inventory. Replace with canonical OpenAPI metadata.
+      tags:
+        - billing
+      extensions:
+        x-generated-from: docs/openapi/route-inventory.json
+        x-placeholder: true
+      x-alga-products:
+        - psa
+      requestBody:
+        description: Placeholder request body
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/PlaceholderObject"
+            description: Placeholder request body
+      responses:
+        "201":
           description: Placeholder success response
           content:
             application/json:
@@ -67024,6 +69134,67 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/ErrorResponse"
+  /api/integrations/hudu:
+    get:
+      summary: GET integrations
+      description: This operation was generated automatically from the route
+        inventory. Replace with canonical OpenAPI metadata.
+      tags:
+        - integrations
+      extensions:
+        x-generated-from: docs/openapi/route-inventory.json
+        x-placeholder: true
+      x-alga-products:
+        - psa
+      responses:
+        "200":
+          description: Placeholder success response
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/PlaceholderObject"
+        "401":
+          description: Authentication required
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        "403":
+          description: Forbidden
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+    options:
+      summary: OPTIONS integrations
+      description: This operation was generated automatically from the route
+        inventory. Replace with canonical OpenAPI metadata.
+      tags:
+        - integrations
+      extensions:
+        x-generated-from: docs/openapi/route-inventory.json
+        x-placeholder: true
+      x-alga-products:
+        - psa
+      responses:
+        "200":
+          description: Placeholder success response
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/PlaceholderObject"
+        "401":
+          description: Authentication required
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        "403":
+          description: Forbidden
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
   /api/integrations/ninjaone/callback:
     get:
       summary: GET integrations
@@ -67397,6 +69568,222 @@ paths:
         inventory. Replace with canonical OpenAPI metadata.
       tags:
         - internal
+      extensions:
+        x-generated-from: docs/openapi/route-inventory.json
+        x-placeholder: true
+      x-alga-products:
+        - psa
+      requestBody:
+        description: Placeholder request body
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/PlaceholderObject"
+            description: Placeholder request body
+      responses:
+        "201":
+          description: Placeholder success response
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/PlaceholderObject"
+        "401":
+          description: Authentication required
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        "403":
+          description: Forbidden
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+  /api/mcp:
+    get:
+      summary: GET mcp
+      description: This operation was generated automatically from the route
+        inventory. Replace with canonical OpenAPI metadata.
+      tags:
+        - mcp
+      extensions:
+        x-generated-from: docs/openapi/route-inventory.json
+        x-placeholder: true
+      x-alga-products:
+        - psa
+      responses:
+        "200":
+          description: Placeholder success response
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/PlaceholderObject"
+        "401":
+          description: Authentication required
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        "403":
+          description: Forbidden
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+    post:
+      summary: POST mcp
+      description: This operation was generated automatically from the route
+        inventory. Replace with canonical OpenAPI metadata.
+      tags:
+        - mcp
+      extensions:
+        x-generated-from: docs/openapi/route-inventory.json
+        x-placeholder: true
+      x-alga-products:
+        - psa
+      requestBody:
+        description: Placeholder request body
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/PlaceholderObject"
+            description: Placeholder request body
+      responses:
+        "201":
+          description: Placeholder success response
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/PlaceholderObject"
+        "401":
+          description: Authentication required
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        "403":
+          description: Forbidden
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+  /api/mcp/oauth/authorize:
+    get:
+      summary: GET mcp
+      description: This operation was generated automatically from the route
+        inventory. Replace with canonical OpenAPI metadata.
+      tags:
+        - mcp
+      extensions:
+        x-generated-from: docs/openapi/route-inventory.json
+        x-placeholder: true
+      x-alga-products:
+        - psa
+      responses:
+        "200":
+          description: Placeholder success response
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/PlaceholderObject"
+        "401":
+          description: Authentication required
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        "403":
+          description: Forbidden
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+    post:
+      summary: POST mcp
+      description: This operation was generated automatically from the route
+        inventory. Replace with canonical OpenAPI metadata.
+      tags:
+        - mcp
+      extensions:
+        x-generated-from: docs/openapi/route-inventory.json
+        x-placeholder: true
+      x-alga-products:
+        - psa
+      requestBody:
+        description: Placeholder request body
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/PlaceholderObject"
+            description: Placeholder request body
+      responses:
+        "201":
+          description: Placeholder success response
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/PlaceholderObject"
+        "401":
+          description: Authentication required
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        "403":
+          description: Forbidden
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+  /api/mcp/oauth/revoke:
+    post:
+      summary: POST mcp
+      description: This operation was generated automatically from the route
+        inventory. Replace with canonical OpenAPI metadata.
+      tags:
+        - mcp
+      extensions:
+        x-generated-from: docs/openapi/route-inventory.json
+        x-placeholder: true
+      x-alga-products:
+        - psa
+      requestBody:
+        description: Placeholder request body
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/PlaceholderObject"
+            description: Placeholder request body
+      responses:
+        "201":
+          description: Placeholder success response
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/PlaceholderObject"
+        "401":
+          description: Authentication required
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        "403":
+          description: Forbidden
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+  /api/mcp/oauth/token:
+    post:
+      summary: POST mcp
+      description: This operation was generated automatically from the route
+        inventory. Replace with canonical OpenAPI metadata.
+      tags:
+        - mcp
       extensions:
         x-generated-from: docs/openapi/route-inventory.json
         x-placeholder: true
@@ -68513,6 +70900,690 @@ paths:
         x-placeholder: true
       x-alga-products:
         - psa
+      responses:
+        "200":
+          description: Placeholder success response
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/PlaceholderObject"
+        "401":
+          description: Authentication required
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        "403":
+          description: Forbidden
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+  /api/v1/appliance-installs:
+    get:
+      summary: GET v1
+      description: This operation was generated automatically from the route
+        inventory. Replace with canonical OpenAPI metadata.
+      tags:
+        - appliance-installs
+      extensions:
+        x-generated-from: docs/openapi/route-inventory.json
+        x-placeholder: true
+      x-alga-products:
+        - psa
+      responses:
+        "200":
+          description: Placeholder success response
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/PlaceholderObject"
+        "401":
+          description: Authentication required
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        "403":
+          description: Forbidden
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+    options:
+      summary: OPTIONS v1
+      description: This operation was generated automatically from the route
+        inventory. Replace with canonical OpenAPI metadata.
+      tags:
+        - appliance-installs
+      extensions:
+        x-generated-from: docs/openapi/route-inventory.json
+        x-placeholder: true
+      x-alga-products:
+        - psa
+      responses:
+        "200":
+          description: Placeholder success response
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/PlaceholderObject"
+        "401":
+          description: Authentication required
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        "403":
+          description: Forbidden
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+  /api/v1/appliance-installs/access:
+    options:
+      summary: OPTIONS v1
+      description: This operation was generated automatically from the route
+        inventory. Replace with canonical OpenAPI metadata.
+      tags:
+        - appliance-installs
+      extensions:
+        x-generated-from: docs/openapi/route-inventory.json
+        x-placeholder: true
+      x-alga-products:
+        - psa
+      responses:
+        "200":
+          description: Placeholder success response
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/PlaceholderObject"
+        "401":
+          description: Authentication required
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        "403":
+          description: Forbidden
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+    post:
+      summary: POST v1
+      description: This operation was generated automatically from the route
+        inventory. Replace with canonical OpenAPI metadata.
+      tags:
+        - appliance-installs
+      extensions:
+        x-generated-from: docs/openapi/route-inventory.json
+        x-placeholder: true
+      x-alga-products:
+        - psa
+      requestBody:
+        description: Placeholder request body
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/PlaceholderObject"
+            description: Placeholder request body
+      responses:
+        "201":
+          description: Placeholder success response
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/PlaceholderObject"
+        "401":
+          description: Authentication required
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        "403":
+          description: Forbidden
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+  /api/v1/appliance-installs/{tenantId}:
+    get:
+      summary: GET v1
+      description: This operation was generated automatically from the route
+        inventory. Replace with canonical OpenAPI metadata.
+      tags:
+        - appliance-installs
+      extensions:
+        x-generated-from: docs/openapi/route-inventory.json
+        x-placeholder: true
+      x-alga-products:
+        - psa
+      responses:
+        "200":
+          description: Placeholder success response
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/PlaceholderObject"
+        "401":
+          description: Authentication required
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        "403":
+          description: Forbidden
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+    options:
+      summary: OPTIONS v1
+      description: This operation was generated automatically from the route
+        inventory. Replace with canonical OpenAPI metadata.
+      tags:
+        - appliance-installs
+      extensions:
+        x-generated-from: docs/openapi/route-inventory.json
+        x-placeholder: true
+      x-alga-products:
+        - psa
+      responses:
+        "200":
+          description: Placeholder success response
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/PlaceholderObject"
+        "401":
+          description: Authentication required
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        "403":
+          description: Forbidden
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+  /api/v1/mcp/agents:
+    delete:
+      summary: DELETE v1
+      description: This operation was generated automatically from the route
+        inventory. Replace with canonical OpenAPI metadata.
+      tags:
+        - mcp
+      extensions:
+        x-generated-from: docs/openapi/route-inventory.json
+        x-placeholder: true
+      x-alga-products:
+        - psa
+      responses:
+        "204":
+          description: Placeholder success response
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/PlaceholderObject"
+        "401":
+          description: Authentication required
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        "403":
+          description: Forbidden
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+    get:
+      summary: GET v1
+      description: This operation was generated automatically from the route
+        inventory. Replace with canonical OpenAPI metadata.
+      tags:
+        - mcp
+      extensions:
+        x-generated-from: docs/openapi/route-inventory.json
+        x-placeholder: true
+      x-alga-products:
+        - psa
+      responses:
+        "200":
+          description: Placeholder success response
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/PlaceholderObject"
+        "401":
+          description: Authentication required
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        "403":
+          description: Forbidden
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+    patch:
+      summary: PATCH v1
+      description: This operation was generated automatically from the route
+        inventory. Replace with canonical OpenAPI metadata.
+      tags:
+        - mcp
+      extensions:
+        x-generated-from: docs/openapi/route-inventory.json
+        x-placeholder: true
+      x-alga-products:
+        - psa
+      requestBody:
+        description: Placeholder request body
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/PlaceholderObject"
+            description: Placeholder request body
+      responses:
+        "200":
+          description: Placeholder success response
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/PlaceholderObject"
+        "401":
+          description: Authentication required
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        "403":
+          description: Forbidden
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+    post:
+      summary: POST v1
+      description: This operation was generated automatically from the route
+        inventory. Replace with canonical OpenAPI metadata.
+      tags:
+        - mcp
+      extensions:
+        x-generated-from: docs/openapi/route-inventory.json
+        x-placeholder: true
+      x-alga-products:
+        - psa
+      requestBody:
+        description: Placeholder request body
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/PlaceholderObject"
+            description: Placeholder request body
+      responses:
+        "201":
+          description: Placeholder success response
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/PlaceholderObject"
+        "401":
+          description: Authentication required
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        "403":
+          description: Forbidden
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+  /api/v1/mcp/audit:
+    get:
+      summary: GET v1
+      description: This operation was generated automatically from the route
+        inventory. Replace with canonical OpenAPI metadata.
+      tags:
+        - mcp
+      extensions:
+        x-generated-from: docs/openapi/route-inventory.json
+        x-placeholder: true
+      x-alga-products:
+        - psa
+      responses:
+        "200":
+          description: Placeholder success response
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/PlaceholderObject"
+        "401":
+          description: Authentication required
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        "403":
+          description: Forbidden
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+  /api/v1/mcp/connect/callback:
+    get:
+      summary: GET v1
+      description: This operation was generated automatically from the route
+        inventory. Replace with canonical OpenAPI metadata.
+      tags:
+        - mcp
+      extensions:
+        x-generated-from: docs/openapi/route-inventory.json
+        x-placeholder: true
+      x-alga-products:
+        - psa
+      responses:
+        "200":
+          description: Placeholder success response
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/PlaceholderObject"
+        "401":
+          description: Authentication required
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        "403":
+          description: Forbidden
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+  /api/v1/mcp/connect/start:
+    post:
+      summary: POST v1
+      description: This operation was generated automatically from the route
+        inventory. Replace with canonical OpenAPI metadata.
+      tags:
+        - mcp
+      extensions:
+        x-generated-from: docs/openapi/route-inventory.json
+        x-placeholder: true
+      x-alga-products:
+        - psa
+      requestBody:
+        description: Placeholder request body
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/PlaceholderObject"
+            description: Placeholder request body
+      responses:
+        "201":
+          description: Placeholder success response
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/PlaceholderObject"
+        "401":
+          description: Authentication required
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        "403":
+          description: Forbidden
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+  /api/v1/mcp/connections:
+    delete:
+      summary: DELETE v1
+      description: This operation was generated automatically from the route
+        inventory. Replace with canonical OpenAPI metadata.
+      tags:
+        - mcp
+      extensions:
+        x-generated-from: docs/openapi/route-inventory.json
+        x-placeholder: true
+      x-alga-products:
+        - psa
+      responses:
+        "204":
+          description: Placeholder success response
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/PlaceholderObject"
+        "401":
+          description: Authentication required
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        "403":
+          description: Forbidden
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+    get:
+      summary: GET v1
+      description: This operation was generated automatically from the route
+        inventory. Replace with canonical OpenAPI metadata.
+      tags:
+        - mcp
+      extensions:
+        x-generated-from: docs/openapi/route-inventory.json
+        x-placeholder: true
+      x-alga-products:
+        - psa
+      responses:
+        "200":
+          description: Placeholder success response
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/PlaceholderObject"
+        "401":
+          description: Authentication required
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        "403":
+          description: Forbidden
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+  /api/v1/mcp/idp-providers:
+    get:
+      summary: GET v1
+      description: This operation was generated automatically from the route
+        inventory. Replace with canonical OpenAPI metadata.
+      tags:
+        - mcp
+      extensions:
+        x-generated-from: docs/openapi/route-inventory.json
+        x-placeholder: true
+      x-alga-products:
+        - psa
+      responses:
+        "200":
+          description: Placeholder success response
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/PlaceholderObject"
+        "401":
+          description: Authentication required
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        "403":
+          description: Forbidden
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+    post:
+      summary: POST v1
+      description: This operation was generated automatically from the route
+        inventory. Replace with canonical OpenAPI metadata.
+      tags:
+        - mcp
+      extensions:
+        x-generated-from: docs/openapi/route-inventory.json
+        x-placeholder: true
+      x-alga-products:
+        - psa
+      requestBody:
+        description: Placeholder request body
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/PlaceholderObject"
+            description: Placeholder request body
+      responses:
+        "201":
+          description: Placeholder success response
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/PlaceholderObject"
+        "401":
+          description: Authentication required
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        "403":
+          description: Forbidden
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+  /api/v1/mcp/idp-suggestions:
+    get:
+      summary: GET v1
+      description: This operation was generated automatically from the route
+        inventory. Replace with canonical OpenAPI metadata.
+      tags:
+        - mcp
+      extensions:
+        x-generated-from: docs/openapi/route-inventory.json
+        x-placeholder: true
+      x-alga-products:
+        - psa
+      responses:
+        "200":
+          description: Placeholder success response
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/PlaceholderObject"
+        "401":
+          description: Authentication required
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        "403":
+          description: Forbidden
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+  /api/v1/mcp/platform-providers:
+    get:
+      summary: GET v1
+      description: This operation was generated automatically from the route
+        inventory. Replace with canonical OpenAPI metadata.
+      tags:
+        - mcp
+      extensions:
+        x-generated-from: docs/openapi/route-inventory.json
+        x-placeholder: true
+      x-alga-products:
+        - psa
+      responses:
+        "200":
+          description: Placeholder success response
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/PlaceholderObject"
+        "401":
+          description: Authentication required
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        "403":
+          description: Forbidden
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+  /api/v1/mcp/roles:
+    get:
+      summary: GET v1
+      description: This operation was generated automatically from the route
+        inventory. Replace with canonical OpenAPI metadata.
+      tags:
+        - mcp
+      extensions:
+        x-generated-from: docs/openapi/route-inventory.json
+        x-placeholder: true
+      x-alga-products:
+        - psa
+      responses:
+        "200":
+          description: Placeholder success response
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/PlaceholderObject"
+        "401":
+          description: Authentication required
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        "403":
+          description: Forbidden
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+  /api/v1/meta/mcp-registry:
+    get:
+      summary: GET v1
+      description: This operation was generated automatically from the route
+        inventory. Replace with canonical OpenAPI metadata.
+      tags:
+        - meta
+      extensions:
+        x-generated-from: docs/openapi/route-inventory.json
+        x-placeholder: true
+      x-alga-products:
+        - psa
+        - algadesk
       responses:
         "200":
           description: Placeholder success response
@@ -71220,6 +74291,144 @@ paths:
         inventory. Replace with canonical OpenAPI metadata.
       tags:
         - tenant-management
+      extensions:
+        x-generated-from: docs/openapi/route-inventory.json
+        x-placeholder: true
+      x-alga-products:
+        - psa
+      requestBody:
+        description: Placeholder request body
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/PlaceholderObject"
+            description: Placeholder request body
+      responses:
+        "201":
+          description: Placeholder success response
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/PlaceholderObject"
+        "401":
+          description: Authentication required
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        "403":
+          description: Forbidden
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+  /api/webhooks/alternative-payments:
+    get:
+      summary: GET webhooks
+      description: This operation was generated automatically from the route
+        inventory. Replace with canonical OpenAPI metadata.
+      tags:
+        - webhooks
+      extensions:
+        x-generated-from: docs/openapi/route-inventory.json
+        x-placeholder: true
+      x-alga-products:
+        - psa
+      responses:
+        "200":
+          description: Placeholder success response
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/PlaceholderObject"
+        "401":
+          description: Authentication required
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        "403":
+          description: Forbidden
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+    post:
+      summary: POST webhooks
+      description: This operation was generated automatically from the route
+        inventory. Replace with canonical OpenAPI metadata.
+      tags:
+        - webhooks
+      extensions:
+        x-generated-from: docs/openapi/route-inventory.json
+        x-placeholder: true
+      x-alga-products:
+        - psa
+      requestBody:
+        description: Placeholder request body
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/PlaceholderObject"
+            description: Placeholder request body
+      responses:
+        "201":
+          description: Placeholder success response
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/PlaceholderObject"
+        "401":
+          description: Authentication required
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        "403":
+          description: Forbidden
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+  /api/webhooks/levelio:
+    options:
+      summary: OPTIONS webhooks
+      description: This operation was generated automatically from the route
+        inventory. Replace with canonical OpenAPI metadata.
+      tags:
+        - webhooks
+      extensions:
+        x-generated-from: docs/openapi/route-inventory.json
+        x-placeholder: true
+      x-alga-products:
+        - psa
+      responses:
+        "200":
+          description: Placeholder success response
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/PlaceholderObject"
+        "401":
+          description: Authentication required
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        "403":
+          description: Forbidden
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+    post:
+      summary: POST webhooks
+      description: This operation was generated automatically from the route
+        inventory. Replace with canonical OpenAPI metadata.
+      tags:
+        - webhooks
       extensions:
         x-generated-from: docs/openapi/route-inventory.json
         x-placeholder: true

--- a/sdk/docs/openapi/alga-openapi.json
+++ b/sdk/docs/openapi/alga-openapi.json
@@ -26,6 +26,9 @@
       "name": "Accounting Exports"
     },
     {
+      "name": "Activities v1"
+    },
+    {
       "name": "Admin"
     },
     {
@@ -173,10 +176,16 @@
       "name": "Workflow Runs"
     },
     {
+      "name": "Workflow Tasks v1"
+    },
+    {
       "name": "Workflows v1"
     },
     {
       "name": "accounting"
+    },
+    {
+      "name": "appliance-installs"
     },
     {
       "name": "auth"
@@ -225,6 +234,12 @@
     },
     {
       "name": "internal"
+    },
+    {
+      "name": "mcp"
+    },
+    {
+      "name": "meta"
     },
     {
       "name": "mobile"
@@ -18779,6 +18794,1473 @@
       "WorkflowV1MissingRouteResponse": {
         "type": "string",
         "description": "Default Next.js not-found response body for missing route handlers."
+      },
+      "WorkflowTasksApiErrorV1": {
+        "type": "object",
+        "properties": {
+          "error": {
+            "type": "object",
+            "properties": {
+              "code": {
+                "type": "string"
+              },
+              "message": {
+                "type": "string"
+              },
+              "details": {}
+            },
+            "required": [
+              "code",
+              "message"
+            ]
+          }
+        },
+        "required": [
+          "error"
+        ]
+      },
+      "WorkflowTaskIdParamV1": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string",
+            "description": "Workflow task identifier (taskId)."
+          }
+        },
+        "required": [
+          "id"
+        ]
+      },
+      "WorkflowTasksListQueryV1": {
+        "type": "object",
+        "properties": {
+          "status": {
+            "type": "string",
+            "description": "Comma-separated WorkflowTaskStatus values (pending, claimed, completed, canceled, expired). Omit for the open inbox (pending + claimed)."
+          },
+          "page": {
+            "type": "integer",
+            "minimum": 1,
+            "description": "1-based page number (default 1)."
+          },
+          "pageSize": {
+            "type": "integer",
+            "minimum": 1,
+            "maximum": 100,
+            "description": "Items per page, max 100 (default 25)."
+          }
+        }
+      },
+      "WorkflowTaskV1": {
+        "type": "object",
+        "properties": {
+          "taskId": {
+            "type": "string"
+          },
+          "executionId": {
+            "type": "string"
+          },
+          "title": {
+            "type": "string"
+          },
+          "description": {
+            "type": "string"
+          },
+          "status": {
+            "type": "string",
+            "enum": [
+              "pending",
+              "claimed",
+              "completed",
+              "canceled",
+              "expired"
+            ]
+          },
+          "priority": {
+            "type": "string"
+          },
+          "dueDate": {
+            "type": "string"
+          },
+          "assignedRoles": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          },
+          "assignedUsers": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          },
+          "contextData": {
+            "type": "object",
+            "additionalProperties": {}
+          },
+          "formId": {
+            "type": "string"
+          },
+          "formSchema": {
+            "type": "object",
+            "properties": {
+              "jsonSchema": {
+                "type": "object",
+                "additionalProperties": {}
+              },
+              "uiSchema": {
+                "type": "object",
+                "additionalProperties": {}
+              },
+              "defaultValues": {
+                "type": "object",
+                "additionalProperties": {}
+              }
+            },
+            "required": [
+              "jsonSchema"
+            ]
+          },
+          "createdAt": {
+            "type": "string"
+          },
+          "createdBy": {
+            "type": "string"
+          },
+          "claimedAt": {
+            "type": "string"
+          },
+          "claimedBy": {
+            "type": "string"
+          },
+          "completedAt": {
+            "type": "string"
+          },
+          "completedBy": {
+            "type": "string"
+          },
+          "responseData": {
+            "type": "object",
+            "additionalProperties": {}
+          }
+        },
+        "required": [
+          "taskId",
+          "executionId",
+          "title",
+          "status",
+          "priority",
+          "formId",
+          "createdAt"
+        ]
+      },
+      "WorkflowTaskListResponseV1": {
+        "type": "object",
+        "properties": {
+          "data": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "properties": {
+                "taskId": {
+                  "type": "string"
+                },
+                "executionId": {
+                  "type": "string"
+                },
+                "title": {
+                  "type": "string"
+                },
+                "description": {
+                  "type": "string"
+                },
+                "status": {
+                  "type": "string",
+                  "enum": [
+                    "pending",
+                    "claimed",
+                    "completed",
+                    "canceled",
+                    "expired"
+                  ]
+                },
+                "priority": {
+                  "type": "string"
+                },
+                "dueDate": {
+                  "type": "string"
+                },
+                "assignedRoles": {
+                  "type": "array",
+                  "items": {
+                    "type": "string"
+                  }
+                },
+                "assignedUsers": {
+                  "type": "array",
+                  "items": {
+                    "type": "string"
+                  }
+                },
+                "contextData": {
+                  "type": "object",
+                  "additionalProperties": {}
+                },
+                "formId": {
+                  "type": "string"
+                },
+                "formSchema": {
+                  "type": "object",
+                  "properties": {
+                    "jsonSchema": {
+                      "type": "object",
+                      "additionalProperties": {}
+                    },
+                    "uiSchema": {
+                      "type": "object",
+                      "additionalProperties": {}
+                    },
+                    "defaultValues": {
+                      "type": "object",
+                      "additionalProperties": {}
+                    }
+                  },
+                  "required": [
+                    "jsonSchema"
+                  ]
+                },
+                "createdAt": {
+                  "type": "string"
+                },
+                "createdBy": {
+                  "type": "string"
+                },
+                "claimedAt": {
+                  "type": "string"
+                },
+                "claimedBy": {
+                  "type": "string"
+                },
+                "completedAt": {
+                  "type": "string"
+                },
+                "completedBy": {
+                  "type": "string"
+                },
+                "responseData": {
+                  "type": "object",
+                  "additionalProperties": {}
+                }
+              },
+              "required": [
+                "taskId",
+                "executionId",
+                "title",
+                "status",
+                "priority",
+                "formId",
+                "createdAt"
+              ]
+            }
+          },
+          "pagination": {
+            "type": "object",
+            "properties": {
+              "page": {
+                "type": "number"
+              },
+              "limit": {
+                "type": "number"
+              },
+              "total": {
+                "type": "number"
+              },
+              "totalPages": {
+                "type": "number"
+              },
+              "hasNext": {
+                "type": "boolean"
+              },
+              "hasPrev": {
+                "type": "boolean"
+              }
+            },
+            "required": [
+              "page",
+              "limit",
+              "total",
+              "totalPages",
+              "hasNext",
+              "hasPrev"
+            ]
+          },
+          "meta": {}
+        },
+        "required": [
+          "data",
+          "pagination"
+        ]
+      },
+      "WorkflowTaskDetailResponseV1": {
+        "type": "object",
+        "properties": {
+          "data": {
+            "type": "object",
+            "properties": {
+              "taskId": {
+                "type": "string"
+              },
+              "executionId": {
+                "type": "string"
+              },
+              "title": {
+                "type": "string"
+              },
+              "description": {
+                "type": "string"
+              },
+              "status": {
+                "type": "string",
+                "enum": [
+                  "pending",
+                  "claimed",
+                  "completed",
+                  "canceled",
+                  "expired"
+                ]
+              },
+              "priority": {
+                "type": "string"
+              },
+              "dueDate": {
+                "type": "string"
+              },
+              "assignedRoles": {
+                "type": "array",
+                "items": {
+                  "type": "string"
+                }
+              },
+              "assignedUsers": {
+                "type": "array",
+                "items": {
+                  "type": "string"
+                }
+              },
+              "contextData": {
+                "type": "object",
+                "additionalProperties": {}
+              },
+              "formId": {
+                "type": "string"
+              },
+              "formSchema": {
+                "type": "object",
+                "properties": {
+                  "jsonSchema": {
+                    "type": "object",
+                    "additionalProperties": {}
+                  },
+                  "uiSchema": {
+                    "type": "object",
+                    "additionalProperties": {}
+                  },
+                  "defaultValues": {
+                    "type": "object",
+                    "additionalProperties": {}
+                  }
+                },
+                "required": [
+                  "jsonSchema"
+                ]
+              },
+              "createdAt": {
+                "type": "string"
+              },
+              "createdBy": {
+                "type": "string"
+              },
+              "claimedAt": {
+                "type": "string"
+              },
+              "claimedBy": {
+                "type": "string"
+              },
+              "completedAt": {
+                "type": "string"
+              },
+              "completedBy": {
+                "type": "string"
+              },
+              "responseData": {
+                "type": "object",
+                "additionalProperties": {}
+              }
+            },
+            "required": [
+              "taskId",
+              "executionId",
+              "title",
+              "status",
+              "priority",
+              "formId",
+              "createdAt"
+            ]
+          },
+          "meta": {}
+        },
+        "required": [
+          "data"
+        ]
+      },
+      "WorkflowTaskActionResponseV1": {
+        "type": "object",
+        "properties": {
+          "data": {
+            "type": "object",
+            "properties": {
+              "success": {
+                "type": "boolean"
+              }
+            },
+            "required": [
+              "success"
+            ]
+          },
+          "meta": {}
+        },
+        "required": [
+          "data"
+        ]
+      },
+      "CompleteWorkflowTaskBodyV1": {
+        "type": "object",
+        "properties": {
+          "formData": {
+            "type": "object",
+            "additionalProperties": {},
+            "default": {}
+          },
+          "comments": {
+            "type": "string"
+          }
+        }
+      },
+      "ActivitiesApiErrorV1": {
+        "type": "object",
+        "properties": {
+          "error": {
+            "type": "object",
+            "properties": {
+              "code": {
+                "type": "string"
+              },
+              "message": {
+                "type": "string"
+              },
+              "details": {}
+            },
+            "required": [
+              "code",
+              "message"
+            ]
+          }
+        },
+        "required": [
+          "error"
+        ]
+      },
+      "ActivitiesAdHocIdParamV1": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string",
+            "description": "Ad-hoc activity identifier (the backing schedule entry id)."
+          }
+        },
+        "required": [
+          "id"
+        ]
+      },
+      "ActivitiesListQueryV1": {
+        "type": "object",
+        "properties": {
+          "type": {
+            "type": "string",
+            "description": "Comma-separated ActivityType values (e.g. \"ticket,schedule\"). Omit for all types."
+          },
+          "status": {
+            "type": "string",
+            "enum": [
+              "open",
+              "closed",
+              "all"
+            ],
+            "description": "Open/closed filter. `open`→active only, `closed`→closed, `all`→no filter (default)."
+          },
+          "search": {
+            "type": "string",
+            "description": "Free-text search across activity titles/descriptions."
+          },
+          "dateStart": {
+            "type": "string",
+            "format": "date-time",
+            "description": "ISO 8601 lower bound of the schedule/time-entry/notification window."
+          },
+          "dateEnd": {
+            "type": "string",
+            "format": "date-time",
+            "description": "ISO 8601 upper bound of the window."
+          },
+          "priority": {
+            "type": "string",
+            "description": "Comma-separated normalized ActivityPriority buckets (e.g. \"high,medium\"). Lossy for custom schemes; prefer `priorityIds`."
+          },
+          "priorityIds": {
+            "type": "string",
+            "description": "Comma-separated exact priority IDs (the tenant's real per-type priorities). Applies to ticket/project-task activities."
+          },
+          "dueDateStart": {
+            "type": "string",
+            "format": "date-time",
+            "description": "ISO 8601 lower bound of the due-date filter (independent of the schedule window)."
+          },
+          "dueDateEnd": {
+            "type": "string",
+            "format": "date-time",
+            "description": "ISO 8601 upper bound of the due-date filter."
+          },
+          "createdAtStart": {
+            "type": "string",
+            "format": "date-time",
+            "description": "ISO 8601 lower bound of the created-date (\"date entered\") filter. Applies to every activity type."
+          },
+          "createdAtEnd": {
+            "type": "string",
+            "format": "date-time",
+            "description": "ISO 8601 upper bound of the created-date (\"date entered\") filter."
+          },
+          "sortBy": {
+            "type": "string",
+            "enum": [
+              "type",
+              "title",
+              "status",
+              "priority",
+              "dueDate"
+            ],
+            "description": "Sort column. Omit for the default sort (priority high→low, then due date ascending)."
+          },
+          "sortDirection": {
+            "type": "string",
+            "enum": [
+              "asc",
+              "desc"
+            ],
+            "description": "Sort direction for `sortBy` (default asc). Ignored when `sortBy` is omitted."
+          },
+          "groupBy": {
+            "type": "string",
+            "enum": [
+              "type",
+              "priority",
+              "status",
+              "dueDate"
+            ],
+            "description": "When set, the response is grouped by this dimension (ActivityGroupedResponseV1) instead of the paginated list; `page`/`pageSize` are ignored. `priority` groups by the real per-tenant priority name (not the normalized bucket), so it is only meaningful when scoped to a single prioritized type."
+          },
+          "page": {
+            "type": "integer",
+            "minimum": 1,
+            "description": "1-based page number (default 1). Ignored when `groupBy` is set."
+          },
+          "pageSize": {
+            "type": "integer",
+            "minimum": 1,
+            "maximum": 100,
+            "description": "Items per page, max 100 (default 25). Ignored when `groupBy` is set."
+          }
+        }
+      },
+      "ActivityV1": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string"
+          },
+          "title": {
+            "type": "string"
+          },
+          "description": {
+            "type": "string"
+          },
+          "type": {
+            "type": "string",
+            "enum": [
+              "schedule",
+              "projectTask",
+              "ticket",
+              "timeEntry",
+              "workflowTask",
+              "notification",
+              "document"
+            ]
+          },
+          "status": {
+            "type": "string"
+          },
+          "statusColor": {
+            "type": "string"
+          },
+          "priority": {
+            "type": "string",
+            "enum": [
+              "low",
+              "medium",
+              "high"
+            ]
+          },
+          "priorityName": {
+            "type": "string"
+          },
+          "priorityColor": {
+            "type": "string"
+          },
+          "dueDate": {
+            "type": "string"
+          },
+          "startDate": {
+            "type": "string"
+          },
+          "endDate": {
+            "type": "string"
+          },
+          "assignedTo": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          },
+          "assignedToNames": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          },
+          "sourceId": {
+            "type": "string"
+          },
+          "sourceType": {
+            "type": "string",
+            "enum": [
+              "schedule",
+              "projectTask",
+              "ticket",
+              "timeEntry",
+              "workflowTask",
+              "notification",
+              "document"
+            ]
+          },
+          "actions": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "properties": {
+                "id": {
+                  "type": "string"
+                },
+                "label": {
+                  "type": "string"
+                },
+                "icon": {
+                  "type": "string"
+                },
+                "disabled": {
+                  "type": "boolean"
+                },
+                "disabledReason": {
+                  "type": "string"
+                }
+              },
+              "required": [
+                "id",
+                "label"
+              ]
+            }
+          },
+          "isClosed": {
+            "type": "boolean"
+          },
+          "tenant": {
+            "type": "string"
+          },
+          "createdAt": {
+            "type": "string"
+          },
+          "updatedAt": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "id",
+          "title",
+          "type",
+          "status",
+          "priority",
+          "sourceId",
+          "sourceType",
+          "actions",
+          "tenant",
+          "createdAt",
+          "updatedAt"
+        ]
+      },
+      "ActivityListResponseV1": {
+        "type": "object",
+        "properties": {
+          "data": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "properties": {
+                "id": {
+                  "type": "string"
+                },
+                "title": {
+                  "type": "string"
+                },
+                "description": {
+                  "type": "string"
+                },
+                "type": {
+                  "type": "string",
+                  "enum": [
+                    "schedule",
+                    "projectTask",
+                    "ticket",
+                    "timeEntry",
+                    "workflowTask",
+                    "notification",
+                    "document"
+                  ]
+                },
+                "status": {
+                  "type": "string"
+                },
+                "statusColor": {
+                  "type": "string"
+                },
+                "priority": {
+                  "type": "string",
+                  "enum": [
+                    "low",
+                    "medium",
+                    "high"
+                  ]
+                },
+                "priorityName": {
+                  "type": "string"
+                },
+                "priorityColor": {
+                  "type": "string"
+                },
+                "dueDate": {
+                  "type": "string"
+                },
+                "startDate": {
+                  "type": "string"
+                },
+                "endDate": {
+                  "type": "string"
+                },
+                "assignedTo": {
+                  "type": "array",
+                  "items": {
+                    "type": "string"
+                  }
+                },
+                "assignedToNames": {
+                  "type": "array",
+                  "items": {
+                    "type": "string"
+                  }
+                },
+                "sourceId": {
+                  "type": "string"
+                },
+                "sourceType": {
+                  "type": "string",
+                  "enum": [
+                    "schedule",
+                    "projectTask",
+                    "ticket",
+                    "timeEntry",
+                    "workflowTask",
+                    "notification",
+                    "document"
+                  ]
+                },
+                "actions": {
+                  "type": "array",
+                  "items": {
+                    "type": "object",
+                    "properties": {
+                      "id": {
+                        "type": "string"
+                      },
+                      "label": {
+                        "type": "string"
+                      },
+                      "icon": {
+                        "type": "string"
+                      },
+                      "disabled": {
+                        "type": "boolean"
+                      },
+                      "disabledReason": {
+                        "type": "string"
+                      }
+                    },
+                    "required": [
+                      "id",
+                      "label"
+                    ]
+                  }
+                },
+                "isClosed": {
+                  "type": "boolean"
+                },
+                "tenant": {
+                  "type": "string"
+                },
+                "createdAt": {
+                  "type": "string"
+                },
+                "updatedAt": {
+                  "type": "string"
+                }
+              },
+              "required": [
+                "id",
+                "title",
+                "type",
+                "status",
+                "priority",
+                "sourceId",
+                "sourceType",
+                "actions",
+                "tenant",
+                "createdAt",
+                "updatedAt"
+              ]
+            }
+          },
+          "pagination": {
+            "type": "object",
+            "properties": {
+              "page": {
+                "type": "number"
+              },
+              "limit": {
+                "type": "number"
+              },
+              "total": {
+                "type": "number"
+              },
+              "totalPages": {
+                "type": "number"
+              },
+              "hasNext": {
+                "type": "boolean"
+              },
+              "hasPrev": {
+                "type": "boolean"
+              }
+            },
+            "required": [
+              "page",
+              "limit",
+              "total",
+              "totalPages",
+              "hasNext",
+              "hasPrev"
+            ]
+          },
+          "meta": {}
+        },
+        "required": [
+          "data",
+          "pagination"
+        ]
+      },
+      "ActivityGroupedResponseV1": {
+        "type": "object",
+        "properties": {
+          "data": {
+            "type": "object",
+            "properties": {
+              "groupBy": {
+                "type": "string",
+                "enum": [
+                  "type",
+                  "priority",
+                  "status",
+                  "dueDate"
+                ]
+              },
+              "groups": {
+                "type": "array",
+                "items": {
+                  "type": "object",
+                  "properties": {
+                    "key": {
+                      "type": "string"
+                    },
+                    "label": {
+                      "type": "string"
+                    },
+                    "count": {
+                      "type": "number"
+                    },
+                    "activities": {
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "properties": {
+                          "id": {
+                            "type": "string"
+                          },
+                          "title": {
+                            "type": "string"
+                          },
+                          "description": {
+                            "type": "string"
+                          },
+                          "type": {
+                            "type": "string",
+                            "enum": [
+                              "schedule",
+                              "projectTask",
+                              "ticket",
+                              "timeEntry",
+                              "workflowTask",
+                              "notification",
+                              "document"
+                            ]
+                          },
+                          "status": {
+                            "type": "string"
+                          },
+                          "statusColor": {
+                            "type": "string"
+                          },
+                          "priority": {
+                            "type": "string",
+                            "enum": [
+                              "low",
+                              "medium",
+                              "high"
+                            ]
+                          },
+                          "priorityName": {
+                            "type": "string"
+                          },
+                          "priorityColor": {
+                            "type": "string"
+                          },
+                          "dueDate": {
+                            "type": "string"
+                          },
+                          "startDate": {
+                            "type": "string"
+                          },
+                          "endDate": {
+                            "type": "string"
+                          },
+                          "assignedTo": {
+                            "type": "array",
+                            "items": {
+                              "type": "string"
+                            }
+                          },
+                          "assignedToNames": {
+                            "type": "array",
+                            "items": {
+                              "type": "string"
+                            }
+                          },
+                          "sourceId": {
+                            "type": "string"
+                          },
+                          "sourceType": {
+                            "type": "string",
+                            "enum": [
+                              "schedule",
+                              "projectTask",
+                              "ticket",
+                              "timeEntry",
+                              "workflowTask",
+                              "notification",
+                              "document"
+                            ]
+                          },
+                          "actions": {
+                            "type": "array",
+                            "items": {
+                              "type": "object",
+                              "properties": {
+                                "id": {
+                                  "type": "string"
+                                },
+                                "label": {
+                                  "type": "string"
+                                },
+                                "icon": {
+                                  "type": "string"
+                                },
+                                "disabled": {
+                                  "type": "boolean"
+                                },
+                                "disabledReason": {
+                                  "type": "string"
+                                }
+                              },
+                              "required": [
+                                "id",
+                                "label"
+                              ]
+                            }
+                          },
+                          "isClosed": {
+                            "type": "boolean"
+                          },
+                          "tenant": {
+                            "type": "string"
+                          },
+                          "createdAt": {
+                            "type": "string"
+                          },
+                          "updatedAt": {
+                            "type": "string"
+                          }
+                        },
+                        "required": [
+                          "id",
+                          "title",
+                          "type",
+                          "status",
+                          "priority",
+                          "sourceId",
+                          "sourceType",
+                          "actions",
+                          "tenant",
+                          "createdAt",
+                          "updatedAt"
+                        ]
+                      }
+                    }
+                  },
+                  "required": [
+                    "key",
+                    "label",
+                    "count",
+                    "activities"
+                  ]
+                }
+              },
+              "totalCount": {
+                "type": "number"
+              },
+              "truncated": {
+                "type": "boolean"
+              }
+            },
+            "required": [
+              "groupBy",
+              "groups",
+              "totalCount",
+              "truncated"
+            ]
+          },
+          "meta": {}
+        },
+        "required": [
+          "data"
+        ]
+      },
+      "AdHocActivityResponseV1": {
+        "type": "object",
+        "properties": {
+          "data": {
+            "type": "object",
+            "properties": {
+              "id": {
+                "type": "string"
+              },
+              "title": {
+                "type": "string"
+              },
+              "description": {
+                "type": "string"
+              },
+              "type": {
+                "type": "string",
+                "enum": [
+                  "schedule",
+                  "projectTask",
+                  "ticket",
+                  "timeEntry",
+                  "workflowTask",
+                  "notification",
+                  "document"
+                ]
+              },
+              "status": {
+                "type": "string"
+              },
+              "statusColor": {
+                "type": "string"
+              },
+              "priority": {
+                "type": "string",
+                "enum": [
+                  "low",
+                  "medium",
+                  "high"
+                ]
+              },
+              "priorityName": {
+                "type": "string"
+              },
+              "priorityColor": {
+                "type": "string"
+              },
+              "dueDate": {
+                "type": "string"
+              },
+              "startDate": {
+                "type": "string"
+              },
+              "endDate": {
+                "type": "string"
+              },
+              "assignedTo": {
+                "type": "array",
+                "items": {
+                  "type": "string"
+                }
+              },
+              "assignedToNames": {
+                "type": "array",
+                "items": {
+                  "type": "string"
+                }
+              },
+              "sourceId": {
+                "type": "string"
+              },
+              "sourceType": {
+                "type": "string",
+                "enum": [
+                  "schedule",
+                  "projectTask",
+                  "ticket",
+                  "timeEntry",
+                  "workflowTask",
+                  "notification",
+                  "document"
+                ]
+              },
+              "actions": {
+                "type": "array",
+                "items": {
+                  "type": "object",
+                  "properties": {
+                    "id": {
+                      "type": "string"
+                    },
+                    "label": {
+                      "type": "string"
+                    },
+                    "icon": {
+                      "type": "string"
+                    },
+                    "disabled": {
+                      "type": "boolean"
+                    },
+                    "disabledReason": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "id",
+                    "label"
+                  ]
+                }
+              },
+              "isClosed": {
+                "type": "boolean"
+              },
+              "tenant": {
+                "type": "string"
+              },
+              "createdAt": {
+                "type": "string"
+              },
+              "updatedAt": {
+                "type": "string"
+              }
+            },
+            "required": [
+              "id",
+              "title",
+              "type",
+              "status",
+              "priority",
+              "sourceId",
+              "sourceType",
+              "actions",
+              "tenant",
+              "createdAt",
+              "updatedAt"
+            ]
+          },
+          "meta": {}
+        },
+        "required": [
+          "data"
+        ]
+      },
+      "CreateAdHocActivityBodyV1": {
+        "type": "object",
+        "properties": {
+          "title": {
+            "type": "string",
+            "minLength": 1
+          },
+          "notes": {
+            "type": "string"
+          },
+          "scheduledStart": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "format": "date-time"
+          },
+          "scheduledEnd": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "format": "date-time"
+          }
+        },
+        "required": [
+          "title"
+        ]
+      },
+      "UpdateAdHocActivityBodyV1": {
+        "type": "object",
+        "properties": {
+          "title": {
+            "type": "string",
+            "minLength": 1
+          },
+          "notes": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "scheduledStart": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "format": "date-time"
+          },
+          "scheduledEnd": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "format": "date-time"
+          }
+        }
+      },
+      "SetAdHocActivityDoneBodyV1": {
+        "type": "object",
+        "properties": {
+          "done": {
+            "type": "boolean"
+          }
+        },
+        "required": [
+          "done"
+        ]
+      },
+      "CustomActivityGroupsResponseV1": {
+        "type": "object",
+        "properties": {
+          "data": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "properties": {
+                "groupId": {
+                  "type": "string"
+                },
+                "groupName": {
+                  "type": "string"
+                },
+                "sortOrder": {
+                  "type": "number"
+                },
+                "isCollapsed": {
+                  "type": "boolean"
+                },
+                "items": {
+                  "type": "array",
+                  "items": {
+                    "type": "object",
+                    "properties": {
+                      "itemId": {
+                        "type": "string"
+                      },
+                      "activityId": {
+                        "type": "string"
+                      },
+                      "activityType": {
+                        "type": "string"
+                      },
+                      "sortOrder": {
+                        "type": "number"
+                      }
+                    },
+                    "required": [
+                      "itemId",
+                      "activityId",
+                      "activityType",
+                      "sortOrder"
+                    ]
+                  }
+                }
+              },
+              "required": [
+                "groupId",
+                "groupName",
+                "sortOrder",
+                "isCollapsed",
+                "items"
+              ]
+            }
+          },
+          "meta": {}
+        },
+        "required": [
+          "data"
+        ]
+      },
+      "MoveActivityToGroupBodyV1": {
+        "type": "object",
+        "properties": {
+          "activityId": {
+            "type": "string",
+            "minLength": 1
+          },
+          "activityType": {
+            "type": "string",
+            "minLength": 1
+          },
+          "groupId": {
+            "type": "string",
+            "minLength": 1
+          },
+          "sortOrder": {
+            "type": "integer",
+            "minimum": 0
+          }
+        },
+        "required": [
+          "activityId",
+          "activityType",
+          "groupId",
+          "sortOrder"
+        ]
+      },
+      "RemoveActivityFromGroupBodyV1": {
+        "type": "object",
+        "properties": {
+          "activityId": {
+            "type": "string",
+            "minLength": 1
+          },
+          "activityType": {
+            "type": "string",
+            "minLength": 1
+          }
+        },
+        "required": [
+          "activityId",
+          "activityType"
+        ]
+      },
+      "ReorderActivitiesInGroupBodyV1": {
+        "type": "object",
+        "properties": {
+          "items": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "properties": {
+                "activityId": {
+                  "type": "string",
+                  "minLength": 1
+                },
+                "activityType": {
+                  "type": "string",
+                  "minLength": 1
+                },
+                "sortOrder": {
+                  "type": "integer",
+                  "minimum": 0
+                }
+              },
+              "required": [
+                "activityId",
+                "activityType",
+                "sortOrder"
+              ]
+            },
+            "minItems": 1
+          }
+        },
+        "required": [
+          "items"
+        ]
+      },
+      "ActivitiesGroupIdParamV1": {
+        "type": "object",
+        "properties": {
+          "groupId": {
+            "type": "string",
+            "description": "Custom activity group identifier."
+          }
+        },
+        "required": [
+          "groupId"
+        ]
+      },
+      "ActivitiesGroupsQueryV1": {
+        "type": "object",
+        "properties": {
+          "targetUserId": {
+            "type": "string",
+            "description": "Another internal user whose groups to read (requires elevated schedule permission). Omit for self."
+          }
+        }
       },
       "ProjectIdParams": {
         "type": "object",
@@ -71043,8 +72525,7 @@
                   "currency_code": {
                     "type": "string",
                     "minLength": 3,
-                    "maxLength": 3,
-                    "default": "USD"
+                    "maxLength": 3
                   },
                   "unit_of_measure": {
                     "type": "string",
@@ -71134,8 +72615,7 @@
                       {
                         "type": "null"
                       }
-                    ],
-                    "default": "USD"
+                    ]
                   },
                   "vendor": {
                     "anyOf": [
@@ -71439,8 +72919,7 @@
                   "currency_code": {
                     "type": "string",
                     "minLength": 3,
-                    "maxLength": 3,
-                    "default": "USD"
+                    "maxLength": 3
                   },
                   "unit_of_measure": {
                     "type": "string",
@@ -71530,8 +73009,7 @@
                       {
                         "type": "null"
                       }
-                    ],
-                    "default": "USD"
+                    ]
                   },
                   "vendor": {
                     "anyOf": [
@@ -75241,8 +76719,8 @@
       }
     },
     "/api/v1/workflows/tasks": {
-      "get": {
-        "summary": "List workflow tasks (route inventory only)",
+      "post": {
+        "summary": "Create workflow task (route inventory only)",
         "description": "This operation is currently present only in generated route inventory. No corresponding Next.js handler exists under server/src/app/api/v1/workflows in this worktree. Runtime behavior is middleware-dependent: missing/invalid x-api-key can return 401 before routing; with middleware requirements satisfied, Next.js returns not-found for the absent handler. Existing workflow APIs in this codebase are implemented under /api/workflow-definitions, /api/workflow-runs, and /api/workflow/events rather than /api/v1/workflows paths.",
         "tags": [
           "Workflows v1"
@@ -75283,11 +76761,11 @@
           }
         }
       },
-      "post": {
-        "summary": "Create workflow task (route inventory only)",
-        "description": "This operation is currently present only in generated route inventory. No corresponding Next.js handler exists under server/src/app/api/v1/workflows in this worktree. Runtime behavior is middleware-dependent: missing/invalid x-api-key can return 401 before routing; with middleware requirements satisfied, Next.js returns not-found for the absent handler. Existing workflow APIs in this codebase are implemented under /api/workflow-definitions, /api/workflow-runs, and /api/workflow/events rather than /api/v1/workflows paths.",
+      "get": {
+        "summary": "List workflow tasks",
+        "description": "Returns the authenticated caller's workflow task inbox (tasks assigned to them directly or via a role), paginated. Items are summary rows without `formSchema`; fetch a single task to obtain its form schema. EE-only — on the Community build this returns an empty page.",
         "tags": [
-          "Workflows v1"
+          "Workflow Tasks v1"
         ],
         "security": [
           {
@@ -75295,30 +76773,85 @@
           }
         ],
         "extensions": {
-          "x-route-inventory-only": true,
-          "x-route-file-missing": "server/src/app/api/v1/workflows/**/route.ts",
-          "x-family-status": "missing-handler"
+          "x-tenant-scoped": true,
+          "x-auth-mechanism": "NextAuth session, falling back to x-api-key (resolveWorkflowTaskAuthContext)",
+          "x-edition-behavior": "EE-only feature; CE returns an empty page (list) or 404 (detail/actions)."
         },
         "x-alga-products": [
           "psa"
         ],
+        "parameters": [
+          {
+            "schema": {
+              "type": "string",
+              "description": "Comma-separated WorkflowTaskStatus values (pending, claimed, completed, canceled, expired). Omit for the open inbox (pending + claimed)."
+            },
+            "required": false,
+            "description": "Comma-separated WorkflowTaskStatus values (pending, claimed, completed, canceled, expired). Omit for the open inbox (pending + claimed).",
+            "name": "status",
+            "in": "query"
+          },
+          {
+            "schema": {
+              "type": "integer",
+              "minimum": 1,
+              "description": "1-based page number (default 1)."
+            },
+            "required": false,
+            "description": "1-based page number (default 1).",
+            "name": "page",
+            "in": "query"
+          },
+          {
+            "schema": {
+              "type": "integer",
+              "minimum": 1,
+              "maximum": 100,
+              "description": "Items per page, max 100 (default 25)."
+            },
+            "required": false,
+            "description": "Items per page, max 100 (default 25).",
+            "name": "pageSize",
+            "in": "query"
+          }
+        ],
         "responses": {
-          "401": {
-            "description": "x-api-key missing/invalid at middleware.",
+          "200": {
+            "description": "Paginated workflow task inbox.",
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/WorkflowV1MissingApiError"
+                  "$ref": "#/components/schemas/WorkflowTaskListResponseV1"
                 }
               }
             }
           },
-          "404": {
-            "description": "No route handler exists for this inventory-only /api/v1/workflows path.",
+          "400": {
+            "description": "Invalid query parameters.",
             "content": {
-              "text/html": {
+              "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/WorkflowV1MissingRouteResponse"
+                  "$ref": "#/components/schemas/WorkflowTasksApiErrorV1"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Authentication required (no session and no/invalid x-api-key).",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/WorkflowTasksApiErrorV1"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Unexpected failure resolving the task inbox.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/WorkflowTasksApiErrorV1"
                 }
               }
             }
@@ -75371,48 +76904,6 @@
       }
     },
     "/api/v1/workflows/tasks/{id}": {
-      "get": {
-        "summary": "Get workflow task by id (route inventory only)",
-        "description": "This operation is currently present only in generated route inventory. No corresponding Next.js handler exists under server/src/app/api/v1/workflows in this worktree. Runtime behavior is middleware-dependent: missing/invalid x-api-key can return 401 before routing; with middleware requirements satisfied, Next.js returns not-found for the absent handler. Existing workflow APIs in this codebase are implemented under /api/workflow-definitions, /api/workflow-runs, and /api/workflow/events rather than /api/v1/workflows paths.",
-        "tags": [
-          "Workflows v1"
-        ],
-        "security": [
-          {
-            "ApiKeyAuth": []
-          }
-        ],
-        "extensions": {
-          "x-route-inventory-only": true,
-          "x-route-file-missing": "server/src/app/api/v1/workflows/**/route.ts",
-          "x-family-status": "missing-handler"
-        },
-        "x-alga-products": [
-          "psa"
-        ],
-        "responses": {
-          "401": {
-            "description": "x-api-key missing/invalid at middleware.",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/WorkflowV1MissingApiError"
-                }
-              }
-            }
-          },
-          "404": {
-            "description": "No route handler exists for this inventory-only /api/v1/workflows path.",
-            "content": {
-              "text/html": {
-                "schema": {
-                  "$ref": "#/components/schemas/WorkflowV1MissingRouteResponse"
-                }
-              }
-            }
-          }
-        }
-      },
       "put": {
         "summary": "Update workflow task (route inventory only)",
         "description": "This operation is currently present only in generated route inventory. No corresponding Next.js handler exists under server/src/app/api/v1/workflows in this worktree. Runtime behavior is middleware-dependent: missing/invalid x-api-key can return 401 before routing; with middleware requirements satisfied, Next.js returns not-found for the absent handler. Existing workflow APIs in this codebase are implemented under /api/workflow-definitions, /api/workflow-runs, and /api/workflow/events rather than /api/v1/workflows paths.",
@@ -75454,14 +76945,12 @@
             }
           }
         }
-      }
-    },
-    "/api/v1/workflows/tasks/{id}/claim": {
-      "post": {
-        "summary": "Claim workflow task (route inventory only)",
-        "description": "This operation is currently present only in generated route inventory. No corresponding Next.js handler exists under server/src/app/api/v1/workflows in this worktree. Runtime behavior is middleware-dependent: missing/invalid x-api-key can return 401 before routing; with middleware requirements satisfied, Next.js returns not-found for the absent handler. Existing workflow APIs in this codebase are implemented under /api/workflow-definitions, /api/workflow-runs, and /api/workflow/events rather than /api/v1/workflows paths.",
+      },
+      "get": {
+        "summary": "Get workflow task",
+        "description": "Returns full detail for a single workflow task, including `formSchema` ({ jsonSchema, uiSchema?, defaultValues? }) so a client can classify the form as simple (native completion) vs complex (web deep-link). EE-only — on the Community build this returns 404.",
         "tags": [
-          "Workflows v1"
+          "Workflow Tasks v1"
         ],
         "security": [
           {
@@ -75469,74 +76958,62 @@
           }
         ],
         "extensions": {
-          "x-route-inventory-only": true,
-          "x-route-file-missing": "server/src/app/api/v1/workflows/**/route.ts",
-          "x-family-status": "missing-handler"
+          "x-tenant-scoped": true,
+          "x-auth-mechanism": "NextAuth session, falling back to x-api-key (resolveWorkflowTaskAuthContext)",
+          "x-edition-behavior": "EE-only feature; CE returns an empty page (list) or 404 (detail/actions)."
         },
         "x-alga-products": [
           "psa"
         ],
-        "responses": {
-          "401": {
-            "description": "x-api-key missing/invalid at middleware.",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/WorkflowV1MissingApiError"
-                }
-              }
-            }
-          },
-          "404": {
-            "description": "No route handler exists for this inventory-only /api/v1/workflows path.",
-            "content": {
-              "text/html": {
-                "schema": {
-                  "$ref": "#/components/schemas/WorkflowV1MissingRouteResponse"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/api/v1/workflows/tasks/{id}/complete": {
-      "post": {
-        "summary": "Complete workflow task (route inventory only)",
-        "description": "This operation is currently present only in generated route inventory. No corresponding Next.js handler exists under server/src/app/api/v1/workflows in this worktree. Runtime behavior is middleware-dependent: missing/invalid x-api-key can return 401 before routing; with middleware requirements satisfied, Next.js returns not-found for the absent handler. Existing workflow APIs in this codebase are implemented under /api/workflow-definitions, /api/workflow-runs, and /api/workflow/events rather than /api/v1/workflows paths.",
-        "tags": [
-          "Workflows v1"
-        ],
-        "security": [
+        "parameters": [
           {
-            "ApiKeyAuth": []
+            "schema": {
+              "type": "string",
+              "description": "Workflow task identifier (taskId)."
+            },
+            "required": true,
+            "description": "Workflow task identifier (taskId).",
+            "name": "id",
+            "in": "path"
           }
         ],
-        "extensions": {
-          "x-route-inventory-only": true,
-          "x-route-file-missing": "server/src/app/api/v1/workflows/**/route.ts",
-          "x-family-status": "missing-handler"
-        },
-        "x-alga-products": [
-          "psa"
-        ],
         "responses": {
-          "401": {
-            "description": "x-api-key missing/invalid at middleware.",
+          "200": {
+            "description": "Workflow task detail including the resolved form schema.",
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/WorkflowV1MissingApiError"
+                  "$ref": "#/components/schemas/WorkflowTaskDetailResponseV1"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Authentication required.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/WorkflowTasksApiErrorV1"
                 }
               }
             }
           },
           "404": {
-            "description": "No route handler exists for this inventory-only /api/v1/workflows path.",
+            "description": "Task not found (or workflow tasks unavailable on this build).",
             "content": {
-              "text/html": {
+              "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/WorkflowV1MissingRouteResponse"
+                  "$ref": "#/components/schemas/WorkflowTasksApiErrorV1"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Unexpected failure resolving the task.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/WorkflowTasksApiErrorV1"
                 }
               }
             }
@@ -75879,6 +77356,1253 @@
               "text/html": {
                 "schema": {
                   "$ref": "#/components/schemas/WorkflowV1MissingRouteResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/workflows/tasks/{id}/claim": {
+      "post": {
+        "summary": "Claim workflow task",
+        "description": "Claims a pending task for the caller. No request body. EE-only — on the Community build this returns 404.",
+        "tags": [
+          "Workflow Tasks v1"
+        ],
+        "security": [
+          {
+            "ApiKeyAuth": []
+          }
+        ],
+        "extensions": {
+          "x-tenant-scoped": true,
+          "x-auth-mechanism": "NextAuth session, falling back to x-api-key (resolveWorkflowTaskAuthContext)",
+          "x-edition-behavior": "EE-only feature; CE returns an empty page (list) or 404 (detail/actions)."
+        },
+        "x-alga-products": [
+          "psa"
+        ],
+        "parameters": [
+          {
+            "schema": {
+              "type": "string",
+              "description": "Workflow task identifier (taskId)."
+            },
+            "required": true,
+            "description": "Workflow task identifier (taskId).",
+            "name": "id",
+            "in": "path"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Task claimed.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/WorkflowTaskActionResponseV1"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Authentication required.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/WorkflowTasksApiErrorV1"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Task not found (or workflow tasks unavailable on this build).",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/WorkflowTasksApiErrorV1"
+                }
+              }
+            }
+          },
+          "409": {
+            "description": "Task already claimed by another user or not in a claimable state.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/WorkflowTasksApiErrorV1"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Unexpected failure claiming the task.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/WorkflowTasksApiErrorV1"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/workflows/tasks/{id}/unclaim": {
+      "post": {
+        "summary": "Unclaim workflow task",
+        "description": "Releases a task the caller has claimed, returning it to the pending pool. No request body. EE-only — on the Community build this returns 404.",
+        "tags": [
+          "Workflow Tasks v1"
+        ],
+        "security": [
+          {
+            "ApiKeyAuth": []
+          }
+        ],
+        "extensions": {
+          "x-tenant-scoped": true,
+          "x-auth-mechanism": "NextAuth session, falling back to x-api-key (resolveWorkflowTaskAuthContext)",
+          "x-edition-behavior": "EE-only feature; CE returns an empty page (list) or 404 (detail/actions)."
+        },
+        "x-alga-products": [
+          "psa"
+        ],
+        "parameters": [
+          {
+            "schema": {
+              "type": "string",
+              "description": "Workflow task identifier (taskId)."
+            },
+            "required": true,
+            "description": "Workflow task identifier (taskId).",
+            "name": "id",
+            "in": "path"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Task released.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/WorkflowTaskActionResponseV1"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Authentication required.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/WorkflowTasksApiErrorV1"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Task not found (or workflow tasks unavailable on this build).",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/WorkflowTasksApiErrorV1"
+                }
+              }
+            }
+          },
+          "409": {
+            "description": "Task is not claimed by the caller.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/WorkflowTasksApiErrorV1"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Unexpected failure releasing the task.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/WorkflowTasksApiErrorV1"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/workflows/tasks/{id}/complete": {
+      "post": {
+        "summary": "Complete workflow task",
+        "description": "Submits the task's form payload and completes it. The form data is validated server-side against the task's JSON Schema; validation failures return 400 with the schema errors in `error.details`. EE-only — on the Community build this returns 404.",
+        "tags": [
+          "Workflow Tasks v1"
+        ],
+        "security": [
+          {
+            "ApiKeyAuth": []
+          }
+        ],
+        "extensions": {
+          "x-tenant-scoped": true,
+          "x-auth-mechanism": "NextAuth session, falling back to x-api-key (resolveWorkflowTaskAuthContext)",
+          "x-edition-behavior": "EE-only feature; CE returns an empty page (list) or 404 (detail/actions)."
+        },
+        "x-alga-products": [
+          "psa"
+        ],
+        "parameters": [
+          {
+            "schema": {
+              "type": "string",
+              "description": "Workflow task identifier (taskId)."
+            },
+            "required": true,
+            "description": "Workflow task identifier (taskId).",
+            "name": "id",
+            "in": "path"
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/CompleteWorkflowTaskBodyV1"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Task completed.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/WorkflowTaskActionResponseV1"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Form validation failed; schema errors are returned in `error.details`.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/WorkflowTasksApiErrorV1"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Authentication required.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/WorkflowTasksApiErrorV1"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Task not found (or workflow tasks unavailable on this build).",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/WorkflowTasksApiErrorV1"
+                }
+              }
+            }
+          },
+          "409": {
+            "description": "Task is not in a completable state for the caller.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/WorkflowTasksApiErrorV1"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Unexpected failure completing the task.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/WorkflowTasksApiErrorV1"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/activities": {
+      "get": {
+        "summary": "List user activities",
+        "description": "Returns the authenticated caller's unified activity list — a fan-out across tickets, project tasks, schedule entries, ad-hoc items, workflow tasks, time entries and notifications. Filter by activity type(s), open/closed status, priority, due-date window, free-text search and a date window; sort via `sortBy`/`sortDirection`. By default the result is paginated (ActivityListResponseV1). When `groupBy` is supplied the result is instead grouped server-side into ordered, counted buckets (ActivityGroupedResponseV1) and `page`/`pageSize` are ignored.",
+        "tags": [
+          "Activities v1"
+        ],
+        "security": [
+          {
+            "ApiKeyAuth": []
+          }
+        ],
+        "extensions": {
+          "x-tenant-scoped": true,
+          "x-auth-mechanism": "NextAuth session, falling back to x-api-key (resolveActivityAuthContext)",
+          "x-response-when-grouped": "#/components/schemas/ActivityGroupedResponseV1"
+        },
+        "x-alga-products": [
+          "psa"
+        ],
+        "parameters": [
+          {
+            "schema": {
+              "type": "string",
+              "description": "Comma-separated ActivityType values (e.g. \"ticket,schedule\"). Omit for all types."
+            },
+            "required": false,
+            "description": "Comma-separated ActivityType values (e.g. \"ticket,schedule\"). Omit for all types.",
+            "name": "type",
+            "in": "query"
+          },
+          {
+            "schema": {
+              "type": "string",
+              "enum": [
+                "open",
+                "closed",
+                "all"
+              ],
+              "description": "Open/closed filter. `open`→active only, `closed`→closed, `all`→no filter (default)."
+            },
+            "required": false,
+            "description": "Open/closed filter. `open`→active only, `closed`→closed, `all`→no filter (default).",
+            "name": "status",
+            "in": "query"
+          },
+          {
+            "schema": {
+              "type": "string",
+              "description": "Free-text search across activity titles/descriptions."
+            },
+            "required": false,
+            "description": "Free-text search across activity titles/descriptions.",
+            "name": "search",
+            "in": "query"
+          },
+          {
+            "schema": {
+              "type": "string",
+              "format": "date-time",
+              "description": "ISO 8601 lower bound of the schedule/time-entry/notification window."
+            },
+            "required": false,
+            "description": "ISO 8601 lower bound of the schedule/time-entry/notification window.",
+            "name": "dateStart",
+            "in": "query"
+          },
+          {
+            "schema": {
+              "type": "string",
+              "format": "date-time",
+              "description": "ISO 8601 upper bound of the window."
+            },
+            "required": false,
+            "description": "ISO 8601 upper bound of the window.",
+            "name": "dateEnd",
+            "in": "query"
+          },
+          {
+            "schema": {
+              "type": "string",
+              "description": "Comma-separated normalized ActivityPriority buckets (e.g. \"high,medium\"). Lossy for custom schemes; prefer `priorityIds`."
+            },
+            "required": false,
+            "description": "Comma-separated normalized ActivityPriority buckets (e.g. \"high,medium\"). Lossy for custom schemes; prefer `priorityIds`.",
+            "name": "priority",
+            "in": "query"
+          },
+          {
+            "schema": {
+              "type": "string",
+              "description": "Comma-separated exact priority IDs (the tenant's real per-type priorities). Applies to ticket/project-task activities."
+            },
+            "required": false,
+            "description": "Comma-separated exact priority IDs (the tenant's real per-type priorities). Applies to ticket/project-task activities.",
+            "name": "priorityIds",
+            "in": "query"
+          },
+          {
+            "schema": {
+              "type": "string",
+              "format": "date-time",
+              "description": "ISO 8601 lower bound of the due-date filter (independent of the schedule window)."
+            },
+            "required": false,
+            "description": "ISO 8601 lower bound of the due-date filter (independent of the schedule window).",
+            "name": "dueDateStart",
+            "in": "query"
+          },
+          {
+            "schema": {
+              "type": "string",
+              "format": "date-time",
+              "description": "ISO 8601 upper bound of the due-date filter."
+            },
+            "required": false,
+            "description": "ISO 8601 upper bound of the due-date filter.",
+            "name": "dueDateEnd",
+            "in": "query"
+          },
+          {
+            "schema": {
+              "type": "string",
+              "format": "date-time",
+              "description": "ISO 8601 lower bound of the created-date (\"date entered\") filter. Applies to every activity type."
+            },
+            "required": false,
+            "description": "ISO 8601 lower bound of the created-date (\"date entered\") filter. Applies to every activity type.",
+            "name": "createdAtStart",
+            "in": "query"
+          },
+          {
+            "schema": {
+              "type": "string",
+              "format": "date-time",
+              "description": "ISO 8601 upper bound of the created-date (\"date entered\") filter."
+            },
+            "required": false,
+            "description": "ISO 8601 upper bound of the created-date (\"date entered\") filter.",
+            "name": "createdAtEnd",
+            "in": "query"
+          },
+          {
+            "schema": {
+              "type": "string",
+              "enum": [
+                "type",
+                "title",
+                "status",
+                "priority",
+                "dueDate"
+              ],
+              "description": "Sort column. Omit for the default sort (priority high→low, then due date ascending)."
+            },
+            "required": false,
+            "description": "Sort column. Omit for the default sort (priority high→low, then due date ascending).",
+            "name": "sortBy",
+            "in": "query"
+          },
+          {
+            "schema": {
+              "type": "string",
+              "enum": [
+                "asc",
+                "desc"
+              ],
+              "description": "Sort direction for `sortBy` (default asc). Ignored when `sortBy` is omitted."
+            },
+            "required": false,
+            "description": "Sort direction for `sortBy` (default asc). Ignored when `sortBy` is omitted.",
+            "name": "sortDirection",
+            "in": "query"
+          },
+          {
+            "schema": {
+              "type": "string",
+              "enum": [
+                "type",
+                "priority",
+                "status",
+                "dueDate"
+              ],
+              "description": "When set, the response is grouped by this dimension (ActivityGroupedResponseV1) instead of the paginated list; `page`/`pageSize` are ignored. `priority` groups by the real per-tenant priority name (not the normalized bucket), so it is only meaningful when scoped to a single prioritized type."
+            },
+            "required": false,
+            "description": "When set, the response is grouped by this dimension (ActivityGroupedResponseV1) instead of the paginated list; `page`/`pageSize` are ignored. `priority` groups by the real per-tenant priority name (not the normalized bucket), so it is only meaningful when scoped to a single prioritized type.",
+            "name": "groupBy",
+            "in": "query"
+          },
+          {
+            "schema": {
+              "type": "integer",
+              "minimum": 1,
+              "description": "1-based page number (default 1). Ignored when `groupBy` is set."
+            },
+            "required": false,
+            "description": "1-based page number (default 1). Ignored when `groupBy` is set.",
+            "name": "page",
+            "in": "query"
+          },
+          {
+            "schema": {
+              "type": "integer",
+              "minimum": 1,
+              "maximum": 100,
+              "description": "Items per page, max 100 (default 25). Ignored when `groupBy` is set."
+            },
+            "required": false,
+            "description": "Items per page, max 100 (default 25). Ignored when `groupBy` is set.",
+            "name": "pageSize",
+            "in": "query"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Paginated activity list, or grouped buckets when `groupBy` is set.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ActivityListResponseV1"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Invalid query parameters.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ActivitiesApiErrorV1"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Authentication required (no session and no/invalid x-api-key).",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ActivitiesApiErrorV1"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Permission denied for one of the underlying activity sources.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ActivitiesApiErrorV1"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Unexpected failure resolving activities.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ActivitiesApiErrorV1"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/activities/ad-hoc": {
+      "post": {
+        "summary": "Create ad-hoc activity",
+        "description": "Creates a personal, self-assigned ad-hoc to-do rendered as a schedule activity. Times are optional; when both are supplied the end must be after the start. Gated by `user_schedule:read`.",
+        "tags": [
+          "Activities v1"
+        ],
+        "security": [
+          {
+            "ApiKeyAuth": []
+          }
+        ],
+        "extensions": {
+          "x-tenant-scoped": true,
+          "x-auth-mechanism": "NextAuth session, falling back to x-api-key (resolveActivityAuthContext)"
+        },
+        "x-alga-products": [
+          "psa"
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/CreateAdHocActivityBodyV1"
+              }
+            }
+          }
+        },
+        "responses": {
+          "201": {
+            "description": "Ad-hoc activity created.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/AdHocActivityResponseV1"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Invalid request body (e.g. missing title or end before start).",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ActivitiesApiErrorV1"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Authentication required.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ActivitiesApiErrorV1"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Permission denied (user_schedule:read).",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ActivitiesApiErrorV1"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Unexpected failure creating the ad-hoc activity.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ActivitiesApiErrorV1"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/activities/ad-hoc/{id}": {
+      "patch": {
+        "summary": "Update ad-hoc activity",
+        "description": "Updates an ad-hoc item's title, notes or optional times. Omitted fields are left unchanged; `notes: null` clears the field. Requires the caller to be an assignee, or hold `user_schedule:update` / `user_schedule:read_all`.",
+        "tags": [
+          "Activities v1"
+        ],
+        "security": [
+          {
+            "ApiKeyAuth": []
+          }
+        ],
+        "extensions": {
+          "x-tenant-scoped": true,
+          "x-auth-mechanism": "NextAuth session, falling back to x-api-key (resolveActivityAuthContext)"
+        },
+        "x-alga-products": [
+          "psa"
+        ],
+        "parameters": [
+          {
+            "schema": {
+              "type": "string",
+              "description": "Ad-hoc activity identifier (the backing schedule entry id)."
+            },
+            "required": true,
+            "description": "Ad-hoc activity identifier (the backing schedule entry id).",
+            "name": "id",
+            "in": "path"
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/UpdateAdHocActivityBodyV1"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Updated ad-hoc activity.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/AdHocActivityResponseV1"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Invalid request body (e.g. end before start).",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ActivitiesApiErrorV1"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Authentication required.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ActivitiesApiErrorV1"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Permission denied.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ActivitiesApiErrorV1"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Ad-hoc activity not found.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ActivitiesApiErrorV1"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Unexpected failure updating the ad-hoc activity.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ActivitiesApiErrorV1"
+                }
+              }
+            }
+          }
+        }
+      },
+      "delete": {
+        "summary": "Delete ad-hoc activity",
+        "description": "Permanently deletes an ad-hoc item. Requires the caller to be an assignee, or hold `user_schedule:update` / `user_schedule:read_all`.",
+        "tags": [
+          "Activities v1"
+        ],
+        "security": [
+          {
+            "ApiKeyAuth": []
+          }
+        ],
+        "extensions": {
+          "x-tenant-scoped": true,
+          "x-auth-mechanism": "NextAuth session, falling back to x-api-key (resolveActivityAuthContext)"
+        },
+        "x-alga-products": [
+          "psa"
+        ],
+        "parameters": [
+          {
+            "schema": {
+              "type": "string",
+              "description": "Ad-hoc activity identifier (the backing schedule entry id)."
+            },
+            "required": true,
+            "description": "Ad-hoc activity identifier (the backing schedule entry id).",
+            "name": "id",
+            "in": "path"
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "Ad-hoc activity deleted; no content."
+          },
+          "401": {
+            "description": "Authentication required.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ActivitiesApiErrorV1"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Permission denied.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ActivitiesApiErrorV1"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Ad-hoc activity not found.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ActivitiesApiErrorV1"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Unexpected failure deleting the ad-hoc activity.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ActivitiesApiErrorV1"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/activities/ad-hoc/{id}/done": {
+      "post": {
+        "summary": "Toggle ad-hoc activity done",
+        "description": "Marks an ad-hoc item done/undone. `done: true` sets status to closed; `done: false` reopens it (status scheduled). Requires the caller to be an assignee, or hold `user_schedule:update` / `user_schedule:read_all`.",
+        "tags": [
+          "Activities v1"
+        ],
+        "security": [
+          {
+            "ApiKeyAuth": []
+          }
+        ],
+        "extensions": {
+          "x-tenant-scoped": true,
+          "x-auth-mechanism": "NextAuth session, falling back to x-api-key (resolveActivityAuthContext)"
+        },
+        "x-alga-products": [
+          "psa"
+        ],
+        "parameters": [
+          {
+            "schema": {
+              "type": "string",
+              "description": "Ad-hoc activity identifier (the backing schedule entry id)."
+            },
+            "required": true,
+            "description": "Ad-hoc activity identifier (the backing schedule entry id).",
+            "name": "id",
+            "in": "path"
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/SetAdHocActivityDoneBodyV1"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Updated ad-hoc activity.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/AdHocActivityResponseV1"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Invalid request body (e.g. missing `done`).",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ActivitiesApiErrorV1"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Authentication required.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ActivitiesApiErrorV1"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Permission denied.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ActivitiesApiErrorV1"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Ad-hoc activity not found.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ActivitiesApiErrorV1"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Unexpected failure updating the ad-hoc activity.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ActivitiesApiErrorV1"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/activities/groups": {
+      "get": {
+        "summary": "List custom activity groups",
+        "description": "Returns the caller's saved custom activity groups (created and ordered in the web app), each with its ordered item references. Read-only: clients bucket the unified activity list into these groups for a \"My groups\" view. Pass `targetUserId` to read another user's groups (requires `user_schedule:update` / `user_schedule:read_all`). Membership and ordering are changed via the `/groups/items` endpoints.",
+        "tags": [
+          "Activities v1"
+        ],
+        "security": [
+          {
+            "ApiKeyAuth": []
+          }
+        ],
+        "extensions": {
+          "x-tenant-scoped": true,
+          "x-auth-mechanism": "NextAuth session, falling back to x-api-key (resolveActivityAuthContext)"
+        },
+        "x-alga-products": [
+          "psa"
+        ],
+        "parameters": [
+          {
+            "schema": {
+              "type": "string",
+              "description": "Another internal user whose groups to read (requires elevated schedule permission). Omit for self."
+            },
+            "required": false,
+            "description": "Another internal user whose groups to read (requires elevated schedule permission). Omit for self.",
+            "name": "targetUserId",
+            "in": "query"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "The caller's custom activity groups.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/CustomActivityGroupsResponseV1"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Authentication required.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ActivitiesApiErrorV1"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Permission denied (reading another user's groups).",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ActivitiesApiErrorV1"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Unexpected failure resolving groups.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ActivitiesApiErrorV1"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/activities/groups/items": {
+      "post": {
+        "summary": "Move an activity into a group",
+        "description": "Moves an activity into one of the caller's custom groups at the given position (`sortOrder`), removing it from any other group first so an activity belongs to at most one group. Rows at/after the index are shifted to keep ordering dense. Scoped to the caller's own groups; gated by `user_schedule:read`.",
+        "tags": [
+          "Activities v1"
+        ],
+        "security": [
+          {
+            "ApiKeyAuth": []
+          }
+        ],
+        "extensions": {
+          "x-tenant-scoped": true,
+          "x-auth-mechanism": "NextAuth session, falling back to x-api-key (resolveActivityAuthContext)"
+        },
+        "x-alga-products": [
+          "psa"
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/MoveActivityToGroupBodyV1"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Activity moved."
+          },
+          "400": {
+            "description": "Invalid request body.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ActivitiesApiErrorV1"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Authentication required.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ActivitiesApiErrorV1"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Permission denied (user_schedule:read).",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ActivitiesApiErrorV1"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Target group not found.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ActivitiesApiErrorV1"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Unexpected failure moving the activity.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ActivitiesApiErrorV1"
+                }
+              }
+            }
+          }
+        }
+      },
+      "delete": {
+        "summary": "Remove an activity from its group",
+        "description": "Removes an activity from all of the caller's custom groups (makes it \"ungrouped\"). No-op when the activity is not in any group. Scoped to the caller's own groups; gated by `user_schedule:read`.",
+        "tags": [
+          "Activities v1"
+        ],
+        "security": [
+          {
+            "ApiKeyAuth": []
+          }
+        ],
+        "extensions": {
+          "x-tenant-scoped": true,
+          "x-auth-mechanism": "NextAuth session, falling back to x-api-key (resolveActivityAuthContext)"
+        },
+        "x-alga-products": [
+          "psa"
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/RemoveActivityFromGroupBodyV1"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Activity removed from its group."
+          },
+          "400": {
+            "description": "Invalid request body.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ActivitiesApiErrorV1"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Authentication required.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ActivitiesApiErrorV1"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Permission denied (user_schedule:read).",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ActivitiesApiErrorV1"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Unexpected failure removing the activity.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ActivitiesApiErrorV1"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/activities/groups/{groupId}/items": {
+      "patch": {
+        "summary": "Reorder activities within a group",
+        "description": "Persists the full ordered membership of a group after a drag-to-reorder. Pass every item as it should appear; each row's `sortOrder` is set to its position. Scoped to the caller's own groups; gated by `user_schedule:read`.",
+        "tags": [
+          "Activities v1"
+        ],
+        "security": [
+          {
+            "ApiKeyAuth": []
+          }
+        ],
+        "extensions": {
+          "x-tenant-scoped": true,
+          "x-auth-mechanism": "NextAuth session, falling back to x-api-key (resolveActivityAuthContext)"
+        },
+        "x-alga-products": [
+          "psa"
+        ],
+        "parameters": [
+          {
+            "schema": {
+              "type": "string",
+              "description": "Custom activity group identifier."
+            },
+            "required": true,
+            "description": "Custom activity group identifier.",
+            "name": "groupId",
+            "in": "path"
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/ReorderActivitiesInGroupBodyV1"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Group order persisted."
+          },
+          "400": {
+            "description": "Invalid request body.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ActivitiesApiErrorV1"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Authentication required.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ActivitiesApiErrorV1"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Permission denied (user_schedule:read).",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ActivitiesApiErrorV1"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Group not found.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ActivitiesApiErrorV1"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Unexpected failure reordering the group.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ActivitiesApiErrorV1"
                 }
               }
             }
@@ -96469,6 +99193,54 @@
         }
       }
     },
+    "/api/auth/captcha-config": {
+      "get": {
+        "summary": "GET auth",
+        "description": "This operation was generated automatically from the route inventory. Replace with canonical OpenAPI metadata.",
+        "tags": [
+          "auth"
+        ],
+        "extensions": {
+          "x-generated-from": "docs/openapi/route-inventory.json",
+          "x-placeholder": true
+        },
+        "x-alga-products": [
+          "psa"
+        ],
+        "responses": {
+          "200": {
+            "description": "Placeholder success response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PlaceholderObject"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Authentication required",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     "/api/auth/e2e/google/authorize": {
       "get": {
         "summary": "GET auth",
@@ -97203,6 +99975,306 @@
         ],
         "responses": {
           "200": {
+            "description": "Placeholder success response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PlaceholderObject"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Authentication required",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/billing/complete-reactivation": {
+      "post": {
+        "summary": "POST billing",
+        "description": "This operation was generated automatically from the route inventory. Replace with canonical OpenAPI metadata.",
+        "tags": [
+          "billing"
+        ],
+        "extensions": {
+          "x-generated-from": "docs/openapi/route-inventory.json",
+          "x-placeholder": true
+        },
+        "x-alga-products": [
+          "psa"
+        ],
+        "requestBody": {
+          "description": "Placeholder request body",
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/PlaceholderObject"
+              },
+              "description": "Placeholder request body"
+            }
+          }
+        },
+        "responses": {
+          "201": {
+            "description": "Placeholder success response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PlaceholderObject"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Authentication required",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/billing/reactivation-password-reset": {
+      "post": {
+        "summary": "POST billing",
+        "description": "This operation was generated automatically from the route inventory. Replace with canonical OpenAPI metadata.",
+        "tags": [
+          "billing"
+        ],
+        "extensions": {
+          "x-generated-from": "docs/openapi/route-inventory.json",
+          "x-placeholder": true
+        },
+        "x-alga-products": [
+          "psa"
+        ],
+        "requestBody": {
+          "description": "Placeholder request body",
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/PlaceholderObject"
+              },
+              "description": "Placeholder request body"
+            }
+          }
+        },
+        "responses": {
+          "201": {
+            "description": "Placeholder success response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PlaceholderObject"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Authentication required",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/billing/reactivation-token": {
+      "post": {
+        "summary": "POST billing",
+        "description": "This operation was generated automatically from the route inventory. Replace with canonical OpenAPI metadata.",
+        "tags": [
+          "billing"
+        ],
+        "extensions": {
+          "x-generated-from": "docs/openapi/route-inventory.json",
+          "x-placeholder": true
+        },
+        "x-alga-products": [
+          "psa"
+        ],
+        "requestBody": {
+          "description": "Placeholder request body",
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/PlaceholderObject"
+              },
+              "description": "Placeholder request body"
+            }
+          }
+        },
+        "responses": {
+          "201": {
+            "description": "Placeholder success response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PlaceholderObject"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Authentication required",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/billing/reactivation-token/session": {
+      "post": {
+        "summary": "POST billing",
+        "description": "This operation was generated automatically from the route inventory. Replace with canonical OpenAPI metadata.",
+        "tags": [
+          "billing"
+        ],
+        "extensions": {
+          "x-generated-from": "docs/openapi/route-inventory.json",
+          "x-placeholder": true
+        },
+        "x-alga-products": [
+          "psa"
+        ],
+        "requestBody": {
+          "description": "Placeholder request body",
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/PlaceholderObject"
+              },
+              "description": "Placeholder request body"
+            }
+          }
+        },
+        "responses": {
+          "201": {
+            "description": "Placeholder success response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PlaceholderObject"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Authentication required",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/billing/request-reactivation": {
+      "post": {
+        "summary": "POST billing",
+        "description": "This operation was generated automatically from the route inventory. Replace with canonical OpenAPI metadata.",
+        "tags": [
+          "billing"
+        ],
+        "extensions": {
+          "x-generated-from": "docs/openapi/route-inventory.json",
+          "x-placeholder": true
+        },
+        "x-alga-products": [
+          "psa"
+        ],
+        "requestBody": {
+          "description": "Placeholder request body",
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/PlaceholderObject"
+              },
+              "description": "Placeholder request body"
+            }
+          }
+        },
+        "responses": {
+          "201": {
             "description": "Placeholder success response",
             "content": {
               "application/json": {
@@ -100613,6 +103685,100 @@
         }
       }
     },
+    "/api/integrations/hudu": {
+      "get": {
+        "summary": "GET integrations",
+        "description": "This operation was generated automatically from the route inventory. Replace with canonical OpenAPI metadata.",
+        "tags": [
+          "integrations"
+        ],
+        "extensions": {
+          "x-generated-from": "docs/openapi/route-inventory.json",
+          "x-placeholder": true
+        },
+        "x-alga-products": [
+          "psa"
+        ],
+        "responses": {
+          "200": {
+            "description": "Placeholder success response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PlaceholderObject"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Authentication required",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        }
+      },
+      "options": {
+        "summary": "OPTIONS integrations",
+        "description": "This operation was generated automatically from the route inventory. Replace with canonical OpenAPI metadata.",
+        "tags": [
+          "integrations"
+        ],
+        "extensions": {
+          "x-generated-from": "docs/openapi/route-inventory.json",
+          "x-placeholder": true
+        },
+        "x-alga-products": [
+          "psa"
+        ],
+        "responses": {
+          "200": {
+            "description": "Placeholder success response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PlaceholderObject"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Authentication required",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     "/api/integrations/ninjaone/callback": {
       "get": {
         "summary": "GET integrations",
@@ -101183,6 +104349,338 @@
         "description": "This operation was generated automatically from the route inventory. Replace with canonical OpenAPI metadata.",
         "tags": [
           "internal"
+        ],
+        "extensions": {
+          "x-generated-from": "docs/openapi/route-inventory.json",
+          "x-placeholder": true
+        },
+        "x-alga-products": [
+          "psa"
+        ],
+        "requestBody": {
+          "description": "Placeholder request body",
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/PlaceholderObject"
+              },
+              "description": "Placeholder request body"
+            }
+          }
+        },
+        "responses": {
+          "201": {
+            "description": "Placeholder success response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PlaceholderObject"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Authentication required",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/mcp": {
+      "get": {
+        "summary": "GET mcp",
+        "description": "This operation was generated automatically from the route inventory. Replace with canonical OpenAPI metadata.",
+        "tags": [
+          "mcp"
+        ],
+        "extensions": {
+          "x-generated-from": "docs/openapi/route-inventory.json",
+          "x-placeholder": true
+        },
+        "x-alga-products": [
+          "psa"
+        ],
+        "responses": {
+          "200": {
+            "description": "Placeholder success response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PlaceholderObject"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Authentication required",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        }
+      },
+      "post": {
+        "summary": "POST mcp",
+        "description": "This operation was generated automatically from the route inventory. Replace with canonical OpenAPI metadata.",
+        "tags": [
+          "mcp"
+        ],
+        "extensions": {
+          "x-generated-from": "docs/openapi/route-inventory.json",
+          "x-placeholder": true
+        },
+        "x-alga-products": [
+          "psa"
+        ],
+        "requestBody": {
+          "description": "Placeholder request body",
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/PlaceholderObject"
+              },
+              "description": "Placeholder request body"
+            }
+          }
+        },
+        "responses": {
+          "201": {
+            "description": "Placeholder success response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PlaceholderObject"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Authentication required",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/mcp/oauth/authorize": {
+      "get": {
+        "summary": "GET mcp",
+        "description": "This operation was generated automatically from the route inventory. Replace with canonical OpenAPI metadata.",
+        "tags": [
+          "mcp"
+        ],
+        "extensions": {
+          "x-generated-from": "docs/openapi/route-inventory.json",
+          "x-placeholder": true
+        },
+        "x-alga-products": [
+          "psa"
+        ],
+        "responses": {
+          "200": {
+            "description": "Placeholder success response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PlaceholderObject"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Authentication required",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        }
+      },
+      "post": {
+        "summary": "POST mcp",
+        "description": "This operation was generated automatically from the route inventory. Replace with canonical OpenAPI metadata.",
+        "tags": [
+          "mcp"
+        ],
+        "extensions": {
+          "x-generated-from": "docs/openapi/route-inventory.json",
+          "x-placeholder": true
+        },
+        "x-alga-products": [
+          "psa"
+        ],
+        "requestBody": {
+          "description": "Placeholder request body",
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/PlaceholderObject"
+              },
+              "description": "Placeholder request body"
+            }
+          }
+        },
+        "responses": {
+          "201": {
+            "description": "Placeholder success response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PlaceholderObject"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Authentication required",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/mcp/oauth/revoke": {
+      "post": {
+        "summary": "POST mcp",
+        "description": "This operation was generated automatically from the route inventory. Replace with canonical OpenAPI metadata.",
+        "tags": [
+          "mcp"
+        ],
+        "extensions": {
+          "x-generated-from": "docs/openapi/route-inventory.json",
+          "x-placeholder": true
+        },
+        "x-alga-products": [
+          "psa"
+        ],
+        "requestBody": {
+          "description": "Placeholder request body",
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/PlaceholderObject"
+              },
+              "description": "Placeholder request body"
+            }
+          }
+        },
+        "responses": {
+          "201": {
+            "description": "Placeholder success response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PlaceholderObject"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Authentication required",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/mcp/oauth/token": {
+      "post": {
+        "summary": "POST mcp",
+        "description": "This operation was generated automatically from the route inventory. Replace with canonical OpenAPI metadata.",
+        "tags": [
+          "mcp"
         ],
         "extensions": {
           "x-generated-from": "docs/openapi/route-inventory.json",
@@ -102900,6 +106398,1059 @@
         },
         "x-alga-products": [
           "psa"
+        ],
+        "responses": {
+          "200": {
+            "description": "Placeholder success response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PlaceholderObject"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Authentication required",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/appliance-installs": {
+      "get": {
+        "summary": "GET v1",
+        "description": "This operation was generated automatically from the route inventory. Replace with canonical OpenAPI metadata.",
+        "tags": [
+          "appliance-installs"
+        ],
+        "extensions": {
+          "x-generated-from": "docs/openapi/route-inventory.json",
+          "x-placeholder": true
+        },
+        "x-alga-products": [
+          "psa"
+        ],
+        "responses": {
+          "200": {
+            "description": "Placeholder success response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PlaceholderObject"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Authentication required",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        }
+      },
+      "options": {
+        "summary": "OPTIONS v1",
+        "description": "This operation was generated automatically from the route inventory. Replace with canonical OpenAPI metadata.",
+        "tags": [
+          "appliance-installs"
+        ],
+        "extensions": {
+          "x-generated-from": "docs/openapi/route-inventory.json",
+          "x-placeholder": true
+        },
+        "x-alga-products": [
+          "psa"
+        ],
+        "responses": {
+          "200": {
+            "description": "Placeholder success response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PlaceholderObject"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Authentication required",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/appliance-installs/access": {
+      "options": {
+        "summary": "OPTIONS v1",
+        "description": "This operation was generated automatically from the route inventory. Replace with canonical OpenAPI metadata.",
+        "tags": [
+          "appliance-installs"
+        ],
+        "extensions": {
+          "x-generated-from": "docs/openapi/route-inventory.json",
+          "x-placeholder": true
+        },
+        "x-alga-products": [
+          "psa"
+        ],
+        "responses": {
+          "200": {
+            "description": "Placeholder success response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PlaceholderObject"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Authentication required",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        }
+      },
+      "post": {
+        "summary": "POST v1",
+        "description": "This operation was generated automatically from the route inventory. Replace with canonical OpenAPI metadata.",
+        "tags": [
+          "appliance-installs"
+        ],
+        "extensions": {
+          "x-generated-from": "docs/openapi/route-inventory.json",
+          "x-placeholder": true
+        },
+        "x-alga-products": [
+          "psa"
+        ],
+        "requestBody": {
+          "description": "Placeholder request body",
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/PlaceholderObject"
+              },
+              "description": "Placeholder request body"
+            }
+          }
+        },
+        "responses": {
+          "201": {
+            "description": "Placeholder success response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PlaceholderObject"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Authentication required",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/appliance-installs/{tenantId}": {
+      "get": {
+        "summary": "GET v1",
+        "description": "This operation was generated automatically from the route inventory. Replace with canonical OpenAPI metadata.",
+        "tags": [
+          "appliance-installs"
+        ],
+        "extensions": {
+          "x-generated-from": "docs/openapi/route-inventory.json",
+          "x-placeholder": true
+        },
+        "x-alga-products": [
+          "psa"
+        ],
+        "responses": {
+          "200": {
+            "description": "Placeholder success response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PlaceholderObject"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Authentication required",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        }
+      },
+      "options": {
+        "summary": "OPTIONS v1",
+        "description": "This operation was generated automatically from the route inventory. Replace with canonical OpenAPI metadata.",
+        "tags": [
+          "appliance-installs"
+        ],
+        "extensions": {
+          "x-generated-from": "docs/openapi/route-inventory.json",
+          "x-placeholder": true
+        },
+        "x-alga-products": [
+          "psa"
+        ],
+        "responses": {
+          "200": {
+            "description": "Placeholder success response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PlaceholderObject"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Authentication required",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/mcp/agents": {
+      "delete": {
+        "summary": "DELETE v1",
+        "description": "This operation was generated automatically from the route inventory. Replace with canonical OpenAPI metadata.",
+        "tags": [
+          "mcp"
+        ],
+        "extensions": {
+          "x-generated-from": "docs/openapi/route-inventory.json",
+          "x-placeholder": true
+        },
+        "x-alga-products": [
+          "psa"
+        ],
+        "responses": {
+          "204": {
+            "description": "Placeholder success response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PlaceholderObject"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Authentication required",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        }
+      },
+      "get": {
+        "summary": "GET v1",
+        "description": "This operation was generated automatically from the route inventory. Replace with canonical OpenAPI metadata.",
+        "tags": [
+          "mcp"
+        ],
+        "extensions": {
+          "x-generated-from": "docs/openapi/route-inventory.json",
+          "x-placeholder": true
+        },
+        "x-alga-products": [
+          "psa"
+        ],
+        "responses": {
+          "200": {
+            "description": "Placeholder success response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PlaceholderObject"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Authentication required",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        }
+      },
+      "patch": {
+        "summary": "PATCH v1",
+        "description": "This operation was generated automatically from the route inventory. Replace with canonical OpenAPI metadata.",
+        "tags": [
+          "mcp"
+        ],
+        "extensions": {
+          "x-generated-from": "docs/openapi/route-inventory.json",
+          "x-placeholder": true
+        },
+        "x-alga-products": [
+          "psa"
+        ],
+        "requestBody": {
+          "description": "Placeholder request body",
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/PlaceholderObject"
+              },
+              "description": "Placeholder request body"
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Placeholder success response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PlaceholderObject"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Authentication required",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        }
+      },
+      "post": {
+        "summary": "POST v1",
+        "description": "This operation was generated automatically from the route inventory. Replace with canonical OpenAPI metadata.",
+        "tags": [
+          "mcp"
+        ],
+        "extensions": {
+          "x-generated-from": "docs/openapi/route-inventory.json",
+          "x-placeholder": true
+        },
+        "x-alga-products": [
+          "psa"
+        ],
+        "requestBody": {
+          "description": "Placeholder request body",
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/PlaceholderObject"
+              },
+              "description": "Placeholder request body"
+            }
+          }
+        },
+        "responses": {
+          "201": {
+            "description": "Placeholder success response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PlaceholderObject"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Authentication required",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/mcp/audit": {
+      "get": {
+        "summary": "GET v1",
+        "description": "This operation was generated automatically from the route inventory. Replace with canonical OpenAPI metadata.",
+        "tags": [
+          "mcp"
+        ],
+        "extensions": {
+          "x-generated-from": "docs/openapi/route-inventory.json",
+          "x-placeholder": true
+        },
+        "x-alga-products": [
+          "psa"
+        ],
+        "responses": {
+          "200": {
+            "description": "Placeholder success response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PlaceholderObject"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Authentication required",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/mcp/connect/callback": {
+      "get": {
+        "summary": "GET v1",
+        "description": "This operation was generated automatically from the route inventory. Replace with canonical OpenAPI metadata.",
+        "tags": [
+          "mcp"
+        ],
+        "extensions": {
+          "x-generated-from": "docs/openapi/route-inventory.json",
+          "x-placeholder": true
+        },
+        "x-alga-products": [
+          "psa"
+        ],
+        "responses": {
+          "200": {
+            "description": "Placeholder success response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PlaceholderObject"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Authentication required",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/mcp/connect/start": {
+      "post": {
+        "summary": "POST v1",
+        "description": "This operation was generated automatically from the route inventory. Replace with canonical OpenAPI metadata.",
+        "tags": [
+          "mcp"
+        ],
+        "extensions": {
+          "x-generated-from": "docs/openapi/route-inventory.json",
+          "x-placeholder": true
+        },
+        "x-alga-products": [
+          "psa"
+        ],
+        "requestBody": {
+          "description": "Placeholder request body",
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/PlaceholderObject"
+              },
+              "description": "Placeholder request body"
+            }
+          }
+        },
+        "responses": {
+          "201": {
+            "description": "Placeholder success response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PlaceholderObject"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Authentication required",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/mcp/connections": {
+      "delete": {
+        "summary": "DELETE v1",
+        "description": "This operation was generated automatically from the route inventory. Replace with canonical OpenAPI metadata.",
+        "tags": [
+          "mcp"
+        ],
+        "extensions": {
+          "x-generated-from": "docs/openapi/route-inventory.json",
+          "x-placeholder": true
+        },
+        "x-alga-products": [
+          "psa"
+        ],
+        "responses": {
+          "204": {
+            "description": "Placeholder success response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PlaceholderObject"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Authentication required",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        }
+      },
+      "get": {
+        "summary": "GET v1",
+        "description": "This operation was generated automatically from the route inventory. Replace with canonical OpenAPI metadata.",
+        "tags": [
+          "mcp"
+        ],
+        "extensions": {
+          "x-generated-from": "docs/openapi/route-inventory.json",
+          "x-placeholder": true
+        },
+        "x-alga-products": [
+          "psa"
+        ],
+        "responses": {
+          "200": {
+            "description": "Placeholder success response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PlaceholderObject"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Authentication required",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/mcp/idp-providers": {
+      "get": {
+        "summary": "GET v1",
+        "description": "This operation was generated automatically from the route inventory. Replace with canonical OpenAPI metadata.",
+        "tags": [
+          "mcp"
+        ],
+        "extensions": {
+          "x-generated-from": "docs/openapi/route-inventory.json",
+          "x-placeholder": true
+        },
+        "x-alga-products": [
+          "psa"
+        ],
+        "responses": {
+          "200": {
+            "description": "Placeholder success response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PlaceholderObject"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Authentication required",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        }
+      },
+      "post": {
+        "summary": "POST v1",
+        "description": "This operation was generated automatically from the route inventory. Replace with canonical OpenAPI metadata.",
+        "tags": [
+          "mcp"
+        ],
+        "extensions": {
+          "x-generated-from": "docs/openapi/route-inventory.json",
+          "x-placeholder": true
+        },
+        "x-alga-products": [
+          "psa"
+        ],
+        "requestBody": {
+          "description": "Placeholder request body",
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/PlaceholderObject"
+              },
+              "description": "Placeholder request body"
+            }
+          }
+        },
+        "responses": {
+          "201": {
+            "description": "Placeholder success response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PlaceholderObject"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Authentication required",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/mcp/idp-suggestions": {
+      "get": {
+        "summary": "GET v1",
+        "description": "This operation was generated automatically from the route inventory. Replace with canonical OpenAPI metadata.",
+        "tags": [
+          "mcp"
+        ],
+        "extensions": {
+          "x-generated-from": "docs/openapi/route-inventory.json",
+          "x-placeholder": true
+        },
+        "x-alga-products": [
+          "psa"
+        ],
+        "responses": {
+          "200": {
+            "description": "Placeholder success response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PlaceholderObject"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Authentication required",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/mcp/platform-providers": {
+      "get": {
+        "summary": "GET v1",
+        "description": "This operation was generated automatically from the route inventory. Replace with canonical OpenAPI metadata.",
+        "tags": [
+          "mcp"
+        ],
+        "extensions": {
+          "x-generated-from": "docs/openapi/route-inventory.json",
+          "x-placeholder": true
+        },
+        "x-alga-products": [
+          "psa"
+        ],
+        "responses": {
+          "200": {
+            "description": "Placeholder success response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PlaceholderObject"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Authentication required",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/mcp/roles": {
+      "get": {
+        "summary": "GET v1",
+        "description": "This operation was generated automatically from the route inventory. Replace with canonical OpenAPI metadata.",
+        "tags": [
+          "mcp"
+        ],
+        "extensions": {
+          "x-generated-from": "docs/openapi/route-inventory.json",
+          "x-placeholder": true
+        },
+        "x-alga-products": [
+          "psa"
+        ],
+        "responses": {
+          "200": {
+            "description": "Placeholder success response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PlaceholderObject"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Authentication required",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/meta/mcp-registry": {
+      "get": {
+        "summary": "GET v1",
+        "description": "This operation was generated automatically from the route inventory. Replace with canonical OpenAPI metadata.",
+        "tags": [
+          "meta"
+        ],
+        "extensions": {
+          "x-generated-from": "docs/openapi/route-inventory.json",
+          "x-placeholder": true
+        },
+        "x-alga-products": [
+          "psa",
+          "algadesk"
         ],
         "responses": {
           "200": {
@@ -107366,6 +111917,218 @@
         "description": "This operation was generated automatically from the route inventory. Replace with canonical OpenAPI metadata.",
         "tags": [
           "tenant-management"
+        ],
+        "extensions": {
+          "x-generated-from": "docs/openapi/route-inventory.json",
+          "x-placeholder": true
+        },
+        "x-alga-products": [
+          "psa"
+        ],
+        "requestBody": {
+          "description": "Placeholder request body",
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/PlaceholderObject"
+              },
+              "description": "Placeholder request body"
+            }
+          }
+        },
+        "responses": {
+          "201": {
+            "description": "Placeholder success response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PlaceholderObject"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Authentication required",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/webhooks/alternative-payments": {
+      "get": {
+        "summary": "GET webhooks",
+        "description": "This operation was generated automatically from the route inventory. Replace with canonical OpenAPI metadata.",
+        "tags": [
+          "webhooks"
+        ],
+        "extensions": {
+          "x-generated-from": "docs/openapi/route-inventory.json",
+          "x-placeholder": true
+        },
+        "x-alga-products": [
+          "psa"
+        ],
+        "responses": {
+          "200": {
+            "description": "Placeholder success response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PlaceholderObject"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Authentication required",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        }
+      },
+      "post": {
+        "summary": "POST webhooks",
+        "description": "This operation was generated automatically from the route inventory. Replace with canonical OpenAPI metadata.",
+        "tags": [
+          "webhooks"
+        ],
+        "extensions": {
+          "x-generated-from": "docs/openapi/route-inventory.json",
+          "x-placeholder": true
+        },
+        "x-alga-products": [
+          "psa"
+        ],
+        "requestBody": {
+          "description": "Placeholder request body",
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/PlaceholderObject"
+              },
+              "description": "Placeholder request body"
+            }
+          }
+        },
+        "responses": {
+          "201": {
+            "description": "Placeholder success response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PlaceholderObject"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Authentication required",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/webhooks/levelio": {
+      "options": {
+        "summary": "OPTIONS webhooks",
+        "description": "This operation was generated automatically from the route inventory. Replace with canonical OpenAPI metadata.",
+        "tags": [
+          "webhooks"
+        ],
+        "extensions": {
+          "x-generated-from": "docs/openapi/route-inventory.json",
+          "x-placeholder": true
+        },
+        "x-alga-products": [
+          "psa"
+        ],
+        "responses": {
+          "200": {
+            "description": "Placeholder success response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PlaceholderObject"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Authentication required",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        }
+      },
+      "post": {
+        "summary": "POST webhooks",
+        "description": "This operation was generated automatically from the route inventory. Replace with canonical OpenAPI metadata.",
+        "tags": [
+          "webhooks"
         ],
         "extensions": {
           "x-generated-from": "docs/openapi/route-inventory.json",

--- a/sdk/docs/openapi/alga-openapi.yaml
+++ b/sdk/docs/openapi/alga-openapi.yaml
@@ -12,6 +12,7 @@ tags:
   - name: AI
   - name: Access Control & Users v1
   - name: Accounting Exports
+  - name: Activities v1
   - name: Admin
   - name: Assets
   - name: Auth
@@ -61,8 +62,10 @@ tags:
   - name: Workflow Definitions
   - name: Workflow Registry
   - name: Workflow Runs
+  - name: Workflow Tasks v1
   - name: Workflows v1
   - name: accounting
+  - name: appliance-installs
   - name: auth
   - name: billing
   - name: calendar
@@ -79,6 +82,8 @@ tags:
   - name: inbound
   - name: integrations
   - name: internal
+  - name: mcp
+  - name: meta
   - name: mobile
   - name: online-meetings
   - name: platform-feature-flags
@@ -642,7 +647,7 @@ components:
           type: string
         order:
           type: string
-          enum: &a32
+          enum: &a33
             - asc
             - desc
         username:
@@ -655,7 +660,7 @@ components:
           type: string
         user_type:
           type: string
-          enum: &a33
+          enum: &a34
             - internal
             - client
             - admin
@@ -668,17 +673,17 @@ components:
           format: uuid
         is_inactive:
           type: string
-          enum: &a34
+          enum: &a35
             - "true"
             - "false"
         include_permissions:
           type: string
-          enum: &a35
+          enum: &a36
             - "true"
             - "false"
         include_teams:
           type: string
-          enum: &a36
+          enum: &a37
             - "true"
             - "false"
         fields:
@@ -694,7 +699,7 @@ components:
             field names.
         user_type:
           type: string
-          enum: &a37
+          enum: &a38
             - internal
             - client
             - admin
@@ -707,7 +712,7 @@ components:
           format: uuid
         include_inactive:
           type: string
-          enum: &a38
+          enum: &a39
             - "true"
             - "false"
         limit:
@@ -742,14 +747,14 @@ components:
           type: string
         is_inactive:
           type: string
-          enum: &a30
+          enum: &a31
             - "true"
             - "false"
         sort:
           type: string
         order:
           type: string
-          enum: &a31
+          enum: &a32
             - asc
             - desc
     AccessRoleListQueryV1:
@@ -763,14 +768,14 @@ components:
           type: string
         order:
           type: string
-          enum: &a23
+          enum: &a24
             - asc
             - desc
         role_name:
           type: string
         has_permissions:
           type: string
-          enum: &a24
+          enum: &a25
             - "true"
             - "false"
         permission_resource:
@@ -779,7 +784,7 @@ components:
           type: string
         is_template:
           type: string
-          enum: &a25
+          enum: &a26
             - "true"
             - "false"
     AccessPermissionListQueryV1:
@@ -793,7 +798,7 @@ components:
           type: string
         order:
           type: string
-          enum: &a22
+          enum: &a23
             - asc
             - desc
         resource:
@@ -811,7 +816,7 @@ components:
           type: string
         order:
           type: string
-          enum: &a26
+          enum: &a27
             - asc
             - desc
         team_name:
@@ -835,14 +840,14 @@ components:
           format: uuid
         has_manager:
           type: string
-          enum: &a27
+          enum: &a28
             - "true"
             - "false"
         sort:
           type: string
         order:
           type: string
-          enum: &a28
+          enum: &a29
             - asc
             - desc
     AccessTeamAnalyticsQueryV1:
@@ -858,7 +863,7 @@ components:
             array.
         granularity:
           type: string
-          enum: &a29
+          enum: &a30
             - daily
             - weekly
             - monthly
@@ -1273,7 +1278,7 @@ components:
           description: Sort column. Defaults to created_at.
         order:
           type: string
-          enum: &a39
+          enum: &a40
             - asc
             - desc
           description: Sort direction. Defaults to desc.
@@ -1303,7 +1308,7 @@ components:
             AssetService.list.
         is_active:
           type: string
-          enum: &a40
+          enum: &a41
             - "true"
             - "false"
           description: Accepted by validation, but not currently applied by
@@ -1336,21 +1341,21 @@ components:
           description: Partial client name match; joins clients on client_id and tenant.
         has_warranty:
           type: string
-          enum: &a41
+          enum: &a42
             - "true"
             - "false"
           description: true requires warranty_end_date to be non-null; false requires it
             to be null.
         warranty_expired:
           type: string
-          enum: &a42
+          enum: &a43
             - "true"
             - "false"
           description: true filters warranty_end_date before now; false filters future
             warranty dates or no warranty.
         maintenance_due:
           type: string
-          enum: &a43
+          enum: &a44
             - "true"
             - "false"
           description: Accepted by validation, but not currently applied by
@@ -1376,7 +1381,7 @@ components:
       properties:
         format:
           type: string
-          enum: &a44
+          enum: &a45
             - csv
             - json
           description: Export format. csv (default) returns text/csv as an attachment;
@@ -2662,7 +2667,7 @@ components:
           type: array
           items:
             type: string
-            enum: &a45
+            enum: &a46
               - asset_tag
               - name
               - serial_number
@@ -2689,7 +2694,7 @@ components:
           description: Optional client UUID filters.
         include_extension_data:
           type: string
-          enum: &a46
+          enum: &a47
             - "true"
             - "false"
           description: When true, the service fetches asset-type-specific extension data
@@ -3165,7 +3170,7 @@ components:
       properties:
         type:
           type: string
-          enum: &a47
+          enum: &a48
             - splashtop
             - teamviewer
             - vnc
@@ -3190,7 +3195,7 @@ components:
           type: string
         include_uninstalled:
           type: string
-          enum: &a48
+          enum: &a49
             - "true"
             - "false"
     AssetSoftwareResponse:
@@ -3287,7 +3292,7 @@ components:
             orders executions by started_at desc.
         order:
           type: string
-          enum: &a49
+          enum: &a50
             - asc
             - desc
           description: Accepted by shared list query validation.
@@ -3312,7 +3317,7 @@ components:
           description: Accepted by shared filter validation.
         is_active:
           type: string
-          enum: &a50
+          enum: &a51
             - "true"
             - "false"
           description: Accepted by shared filter validation and transformed to boolean.
@@ -3349,7 +3354,7 @@ components:
           description: Maximum execution duration in milliseconds.
         has_errors:
           type: string
-          enum: &a51
+          enum: &a52
             - "true"
             - "false"
           description: Filter by whether the execution has errors; transformed to boolean
@@ -3380,7 +3385,7 @@ components:
             rules by created_at desc.
         order:
           type: string
-          enum: &a52
+          enum: &a53
             - asc
             - desc
           description: Accepted by shared list query validation.
@@ -3405,7 +3410,7 @@ components:
           description: Accepted by shared filter validation.
         is_active:
           type: string
-          enum: &a53
+          enum: &a54
             - "true"
             - "false"
           description: Accepted by shared filter validation and transformed to boolean.
@@ -3471,7 +3476,7 @@ components:
             templates by created_at desc.
         order:
           type: string
-          enum: &a54
+          enum: &a55
             - asc
             - desc
           description: Accepted by shared list query validation.
@@ -3496,7 +3501,7 @@ components:
           description: Accepted by shared filter validation.
         is_active:
           type: string
-          enum: &a55
+          enum: &a56
             - "true"
             - "false"
           description: Accepted by shared filter validation and transformed to boolean.
@@ -3530,7 +3535,7 @@ components:
           description: Optional upper bound for performance window.
         group_by:
           type: string
-          enum: &a56
+          enum: &a57
             - hour
             - day
             - week
@@ -4852,7 +4857,7 @@ components:
           type: string
         order:
           type: string
-          enum: &a57
+          enum: &a58
             - asc
             - desc
         search:
@@ -4875,12 +4880,12 @@ components:
           type: string
         client_type:
           type: string
-          enum: &a58
+          enum: &a59
             - company
             - individual
         billing_cycle:
           type: string
-          enum: &a59
+          enum: &a60
             - weekly
             - bi-weekly
             - monthly
@@ -4889,12 +4894,12 @@ components:
             - annually
         is_inactive:
           type: string
-          enum: &a60
+          enum: &a61
             - "true"
             - "false"
         is_tax_exempt:
           type: string
-          enum: &a61
+          enum: &a62
             - "true"
             - "false"
         account_manager_id:
@@ -4908,7 +4913,7 @@ components:
           type: string
         has_credit_limit:
           type: string
-          enum: &a62
+          enum: &a63
             - "true"
             - "false"
         industry:
@@ -5058,7 +5063,7 @@ components:
           type: string
         order:
           type: string
-          enum: &a63
+          enum: &a64
             - asc
             - desc
         search:
@@ -5088,12 +5093,12 @@ components:
           type: string
         is_inactive:
           type: string
-          enum: &a64
+          enum: &a65
             - "true"
             - "false"
         has_client:
           type: string
-          enum: &a65
+          enum: &a66
             - "true"
             - "false"
         client_name:
@@ -5161,7 +5166,7 @@ components:
           format: uuid
         include_inactive:
           type: string
-          enum: &a66
+          enum: &a67
             - "true"
             - "false"
         limit:
@@ -5173,12 +5178,12 @@ components:
       properties:
         format:
           type: string
-          enum: &a67
+          enum: &a68
             - csv
             - json
         include_inactive:
           type: string
-          enum: &a68
+          enum: &a69
             - "true"
             - "false"
         client_id:
@@ -5198,7 +5203,7 @@ components:
           type: string
         order:
           type: string
-          enum: &a69
+          enum: &a70
             - asc
             - desc
         search:
@@ -5225,17 +5230,17 @@ components:
           type: string
         is_active:
           type: string
-          enum: &a70
+          enum: &a71
             - "true"
             - "false"
         has_custom_rate:
           type: string
-          enum: &a71
+          enum: &a72
             - "true"
             - "false"
         is_contractd:
           type: string
-          enum: &a72
+          enum: &a73
             - "true"
             - "false"
         start_date_from:
@@ -6384,7 +6389,7 @@ components:
           type: string
         order:
           type: string
-          enum: &a73
+          enum: &a74
             - asc
             - desc
         search:
@@ -6420,19 +6425,19 @@ components:
             - annually
         is_custom:
           type: string
-          enum: &a74
+          enum: &a75
             - "true"
             - "false"
         is_active:
           type: string
-          enum: &a75
+          enum: &a76
             - "true"
             - "false"
         service_category:
           type: string
         has_services:
           type: string
-          enum: &a76
+          enum: &a77
             - "true"
             - "false"
         clients_count_min:
@@ -6445,19 +6450,19 @@ components:
           type: string
         include_services:
           type: string
-          enum: &a77
+          enum: &a78
             - "true"
             - "false"
           description: Controller-level include flag parsed directly from query string.
         include_usage:
           type: string
-          enum: &a78
+          enum: &a79
             - "true"
             - "false"
           description: Controller-level include flag parsed directly from query string.
         include_clients:
           type: string
-          enum: &a79
+          enum: &a80
             - "true"
             - "false"
           description: Controller-level include flag parsed directly from query string.
@@ -6939,7 +6944,7 @@ components:
       properties:
         format:
           type: string
-          enum: &a80
+          enum: &a81
             - pdf
             - markdown
             - md
@@ -7555,7 +7560,7 @@ components:
           type: string
         order:
           type: string
-          enum: &a81
+          enum: &a82
             - asc
             - desc
         search:
@@ -7584,22 +7589,22 @@ components:
           type: string
         include_expired:
           type: string
-          enum: &a82
+          enum: &a83
             - "true"
             - "false"
         expiring_soon:
           type: string
-          enum: &a83
+          enum: &a84
             - "true"
             - "false"
         has_remaining:
           type: string
-          enum: &a84
+          enum: &a85
             - "true"
             - "false"
         has_expiration:
           type: string
-          enum: &a85
+          enum: &a86
             - "true"
             - "false"
         date_from:
@@ -7608,13 +7613,13 @@ components:
           type: string
         group_by:
           type: string
-          enum: &a86
+          enum: &a87
             - day
             - week
             - month
         include_projections:
           type: string
-          enum: &a87
+          enum: &a88
             - "true"
             - "false"
         as_of_date:
@@ -7630,27 +7635,27 @@ components:
           type: string
         order:
           type: string
-          enum: &a98
+          enum: &a99
             - asc
             - desc
         include_items:
           type: string
-          enum: &a99
+          enum: &a100
             - "true"
             - "false"
         include_client:
           type: string
-          enum: &a100
+          enum: &a101
             - "true"
             - "false"
         include_billing_cycle:
           type: string
-          enum: &a101
+          enum: &a102
             - "true"
             - "false"
         include_transactions:
           type: string
-          enum: &a102
+          enum: &a103
             - "true"
             - "false"
         q:
@@ -7661,7 +7666,7 @@ components:
           type: string
         format:
           type: string
-          enum: &a103
+          enum: &a104
             - json
             - csv
       additionalProperties:
@@ -7680,7 +7685,7 @@ components:
             created_at).
         order:
           type: string
-          enum: &a88
+          enum: &a89
             - asc
             - desc
         search:
@@ -7696,7 +7701,7 @@ components:
           type: string
         is_active:
           type: string
-          enum: &a89
+          enum: &a90
             - "true"
             - "false"
         client_id:
@@ -7704,7 +7709,7 @@ components:
           format: uuid
         status:
           type: string
-          enum: &a90
+          enum: &a91
             - draft
             - sent
             - paid
@@ -7726,12 +7731,12 @@ components:
           type: string
         is_manual:
           type: string
-          enum: &a91
+          enum: &a92
             - "true"
             - "false"
         has_credit_applied:
           type: string
-          enum: &a92
+          enum: &a93
             - "true"
             - "false"
     FinancialPaymentMethodListQuery:
@@ -7747,7 +7752,7 @@ components:
             (defaults to created_at).
         order:
           type: string
-          enum: &a93
+          enum: &a94
             - asc
             - desc
         search:
@@ -7763,7 +7768,7 @@ components:
           type: string
         is_active:
           type: string
-          enum: &a94
+          enum: &a95
             - "true"
             - "false"
         client_id:
@@ -7771,17 +7776,17 @@ components:
           format: uuid
         type:
           type: string
-          enum: &a95
+          enum: &a96
             - credit_card
             - bank_account
         is_default:
           type: string
-          enum: &a96
+          enum: &a97
             - "true"
             - "false"
         exclude_deleted:
           type: string
-          enum: &a97
+          enum: &a98
             - "true"
             - "false"
           description: Exclude soft-deleted payment methods. Defaults to true.
@@ -8749,12 +8754,12 @@ components:
           type: string
         is_managed:
           type: string
-          enum: &a104
+          enum: &a105
             - "true"
             - "false"
         is_security_relevant:
           type: string
-          enum: &a105
+          enum: &a106
             - "true"
             - "false"
         client_id:
@@ -8781,7 +8786,7 @@ components:
           type: string
         order:
           type: string
-          enum: &a106
+          enum: &a107
             - asc
             - desc
     PriorityIdParam:
@@ -8849,17 +8854,17 @@ components:
       properties:
         preview:
           type: string
-          enum: &a107
+          enum: &a108
             - "true"
             - "false"
         createNew:
           type: string
-          enum: &a108
+          enum: &a109
             - "true"
             - "false"
         updateExisting:
           type: string
-          enum: &a109
+          enum: &a110
             - "true"
             - "false"
         matchBy:
@@ -8869,7 +8874,7 @@ components:
       properties:
         preview:
           type: string
-          enum: &a110
+          enum: &a111
             - "true"
             - "false"
     AccountingBatchIdParam:
@@ -9016,7 +9021,7 @@ components:
       properties:
         force:
           type: string
-          enum: &a111
+          enum: &a112
             - "true"
             - "false"
     WorkflowImportBody:
@@ -10002,7 +10007,7 @@ components:
           type: string
         active:
           type: string
-          enum: &a112
+          enum: &a113
             - "true"
             - "false"
         search:
@@ -10011,7 +10016,7 @@ components:
           type: string
         force_refresh:
           type: string
-          enum: &a113
+          enum: &a114
             - "true"
             - "false"
     QuickBooksV1SyncHistoryQuery:
@@ -10023,7 +10028,7 @@ components:
           type: string
         status:
           type: string
-          enum: &a114
+          enum: &a115
             - pending
             - in_progress
             - completed
@@ -10032,7 +10037,7 @@ components:
             - partial
         operation_type:
           type: string
-          enum: &a115
+          enum: &a116
             - customer_sync
             - invoice_export
             - invoice_import
@@ -10757,7 +10762,7 @@ components:
           description: Opaque pagination cursor copied from a prior response's nextCursor.
         sort:
           type: string
-          enum: &a116
+          enum: &a117
             - relevance
             - recent
           description: Result ordering. "relevance" (default) ranks by full-text score;
@@ -11072,7 +11077,7 @@ components:
           type: string
         order:
           type: string
-          enum: &a117
+          enum: &a118
             - asc
             - desc
         search:
@@ -11099,19 +11104,19 @@ components:
           format: uuid
         is_parent:
           type: string
-          enum: &a118
+          enum: &a119
             - "true"
             - "false"
         is_child:
           type: string
-          enum: &a119
+          enum: &a120
             - "true"
             - "false"
         depth:
           type: string
         active:
           type: string
-          enum: &a120
+          enum: &a121
             - "true"
             - "false"
         offset:
@@ -11120,17 +11125,17 @@ components:
           type: string
         sort_order:
           type: string
-          enum: &a121
+          enum: &a122
             - asc
             - desc
         include_hierarchy:
           type: string
-          enum: &a122
+          enum: &a123
             - "true"
             - "false"
         category_type:
           type: string
-          enum: &a123
+          enum: &a124
             - service
             - ticket
     CategoryMoveRequest:
@@ -11157,7 +11162,7 @@ components:
           minLength: 1
         category_type:
           type: string
-          enum: &a124
+          enum: &a125
             - service
             - ticket
         board_id:
@@ -11165,7 +11170,7 @@ components:
           format: uuid
         include_inactive:
           type: string
-          enum: &a125
+          enum: &a126
             - "true"
             - "false"
         limit:
@@ -11179,7 +11184,7 @@ components:
       properties:
         category_type:
           type: string
-          enum: &a126
+          enum: &a127
             - service
             - ticket
         board_id:
@@ -11193,7 +11198,7 @@ components:
           format: date-time
         include_usage:
           type: string
-          enum: &a127
+          enum: &a128
             - "true"
             - "false"
     CategoryAnalyticsResponse:
@@ -11814,7 +11819,7 @@ components:
           type: string
         order:
           type: string
-          enum: &a133
+          enum: &a134
             - asc
             - desc
         name:
@@ -11825,24 +11830,24 @@ components:
           type: string
         is_active:
           type: string
-          enum: &a134
+          enum: &a135
             - "true"
             - "false"
         is_test_mode:
           type: string
-          enum: &a135
+          enum: &a136
             - "true"
             - "false"
         payload_format:
           type: string
-          enum: &a136
+          enum: &a137
             - json
             - xml
             - form_data
             - custom
         has_failures:
           type: string
-          enum: &a137
+          enum: &a138
             - "true"
             - "false"
         last_delivery_from:
@@ -11876,7 +11881,7 @@ components:
           type: string
         status:
           type: string
-          enum: &a138
+          enum: &a139
             - pending
             - delivered
             - failed
@@ -13318,6 +13323,1058 @@ components:
     WorkflowV1MissingRouteResponse:
       type: string
       description: Default Next.js not-found response body for missing route handlers.
+    WorkflowTasksApiErrorV1:
+      type: object
+      properties:
+        error:
+          type: object
+          properties:
+            code:
+              type: string
+            message:
+              type: string
+            details: {}
+          required:
+            - code
+            - message
+      required:
+        - error
+    WorkflowTaskIdParamV1:
+      type: object
+      properties:
+        id:
+          type: string
+          description: Workflow task identifier (taskId).
+      required:
+        - id
+    WorkflowTasksListQueryV1:
+      type: object
+      properties:
+        status:
+          type: string
+          description: Comma-separated WorkflowTaskStatus values (pending, claimed,
+            completed, canceled, expired). Omit for the open inbox (pending +
+            claimed).
+        page:
+          type: integer
+          minimum: 1
+          description: 1-based page number (default 1).
+        pageSize:
+          type: integer
+          minimum: 1
+          maximum: 100
+          description: Items per page, max 100 (default 25).
+    WorkflowTaskV1:
+      type: object
+      properties:
+        taskId:
+          type: string
+        executionId:
+          type: string
+        title:
+          type: string
+        description:
+          type: string
+        status:
+          type: string
+          enum: &a22
+            - pending
+            - claimed
+            - completed
+            - canceled
+            - expired
+        priority:
+          type: string
+        dueDate:
+          type: string
+        assignedRoles:
+          type: array
+          items:
+            type: string
+        assignedUsers:
+          type: array
+          items:
+            type: string
+        contextData:
+          type: object
+          additionalProperties: {}
+        formId:
+          type: string
+        formSchema:
+          type: object
+          properties:
+            jsonSchema:
+              type: object
+              additionalProperties: {}
+            uiSchema:
+              type: object
+              additionalProperties: {}
+            defaultValues:
+              type: object
+              additionalProperties: {}
+          required:
+            - jsonSchema
+        createdAt:
+          type: string
+        createdBy:
+          type: string
+        claimedAt:
+          type: string
+        claimedBy:
+          type: string
+        completedAt:
+          type: string
+        completedBy:
+          type: string
+        responseData:
+          type: object
+          additionalProperties: {}
+      required:
+        - taskId
+        - executionId
+        - title
+        - status
+        - priority
+        - formId
+        - createdAt
+    WorkflowTaskListResponseV1:
+      type: object
+      properties:
+        data:
+          type: array
+          items:
+            type: object
+            properties:
+              taskId:
+                type: string
+              executionId:
+                type: string
+              title:
+                type: string
+              description:
+                type: string
+              status:
+                type: string
+                enum: *a22
+              priority:
+                type: string
+              dueDate:
+                type: string
+              assignedRoles:
+                type: array
+                items:
+                  type: string
+              assignedUsers:
+                type: array
+                items:
+                  type: string
+              contextData:
+                type: object
+                additionalProperties: {}
+              formId:
+                type: string
+              formSchema:
+                type: object
+                properties:
+                  jsonSchema:
+                    type: object
+                    additionalProperties: {}
+                  uiSchema:
+                    type: object
+                    additionalProperties: {}
+                  defaultValues:
+                    type: object
+                    additionalProperties: {}
+                required:
+                  - jsonSchema
+              createdAt:
+                type: string
+              createdBy:
+                type: string
+              claimedAt:
+                type: string
+              claimedBy:
+                type: string
+              completedAt:
+                type: string
+              completedBy:
+                type: string
+              responseData:
+                type: object
+                additionalProperties: {}
+            required:
+              - taskId
+              - executionId
+              - title
+              - status
+              - priority
+              - formId
+              - createdAt
+        pagination:
+          type: object
+          properties:
+            page:
+              type: number
+            limit:
+              type: number
+            total:
+              type: number
+            totalPages:
+              type: number
+            hasNext:
+              type: boolean
+            hasPrev:
+              type: boolean
+          required:
+            - page
+            - limit
+            - total
+            - totalPages
+            - hasNext
+            - hasPrev
+        meta: {}
+      required:
+        - data
+        - pagination
+    WorkflowTaskDetailResponseV1:
+      type: object
+      properties:
+        data:
+          type: object
+          properties:
+            taskId:
+              type: string
+            executionId:
+              type: string
+            title:
+              type: string
+            description:
+              type: string
+            status:
+              type: string
+              enum: *a22
+            priority:
+              type: string
+            dueDate:
+              type: string
+            assignedRoles:
+              type: array
+              items:
+                type: string
+            assignedUsers:
+              type: array
+              items:
+                type: string
+            contextData:
+              type: object
+              additionalProperties: {}
+            formId:
+              type: string
+            formSchema:
+              type: object
+              properties:
+                jsonSchema:
+                  type: object
+                  additionalProperties: {}
+                uiSchema:
+                  type: object
+                  additionalProperties: {}
+                defaultValues:
+                  type: object
+                  additionalProperties: {}
+              required:
+                - jsonSchema
+            createdAt:
+              type: string
+            createdBy:
+              type: string
+            claimedAt:
+              type: string
+            claimedBy:
+              type: string
+            completedAt:
+              type: string
+            completedBy:
+              type: string
+            responseData:
+              type: object
+              additionalProperties: {}
+          required:
+            - taskId
+            - executionId
+            - title
+            - status
+            - priority
+            - formId
+            - createdAt
+        meta: {}
+      required:
+        - data
+    WorkflowTaskActionResponseV1:
+      type: object
+      properties:
+        data:
+          type: object
+          properties:
+            success:
+              type: boolean
+          required:
+            - success
+        meta: {}
+      required:
+        - data
+    CompleteWorkflowTaskBodyV1:
+      type: object
+      properties:
+        formData:
+          type: object
+          additionalProperties: {}
+          default: {}
+        comments:
+          type: string
+    ActivitiesApiErrorV1:
+      type: object
+      properties:
+        error:
+          type: object
+          properties:
+            code:
+              type: string
+            message:
+              type: string
+            details: {}
+          required:
+            - code
+            - message
+      required:
+        - error
+    ActivitiesAdHocIdParamV1:
+      type: object
+      properties:
+        id:
+          type: string
+          description: Ad-hoc activity identifier (the backing schedule entry id).
+      required:
+        - id
+    ActivitiesListQueryV1:
+      type: object
+      properties:
+        type:
+          type: string
+          description: Comma-separated ActivityType values (e.g. "ticket,schedule"). Omit
+            for all types.
+        status:
+          type: string
+          enum: &a140
+            - open
+            - closed
+            - all
+          description: Open/closed filter. `open`→active only, `closed`→closed, `all`→no
+            filter (default).
+        search:
+          type: string
+          description: Free-text search across activity titles/descriptions.
+        dateStart:
+          type: string
+          format: date-time
+          description: ISO 8601 lower bound of the schedule/time-entry/notification window.
+        dateEnd:
+          type: string
+          format: date-time
+          description: ISO 8601 upper bound of the window.
+        priority:
+          type: string
+          description: Comma-separated normalized ActivityPriority buckets (e.g.
+            "high,medium"). Lossy for custom schemes; prefer `priorityIds`.
+        priorityIds:
+          type: string
+          description: Comma-separated exact priority IDs (the tenant's real per-type
+            priorities). Applies to ticket/project-task activities.
+        dueDateStart:
+          type: string
+          format: date-time
+          description: ISO 8601 lower bound of the due-date filter (independent of the
+            schedule window).
+        dueDateEnd:
+          type: string
+          format: date-time
+          description: ISO 8601 upper bound of the due-date filter.
+        createdAtStart:
+          type: string
+          format: date-time
+          description: ISO 8601 lower bound of the created-date ("date entered") filter.
+            Applies to every activity type.
+        createdAtEnd:
+          type: string
+          format: date-time
+          description: ISO 8601 upper bound of the created-date ("date entered") filter.
+        sortBy:
+          type: string
+          enum: &a141
+            - type
+            - title
+            - status
+            - priority
+            - dueDate
+          description: Sort column. Omit for the default sort (priority high→low, then due
+            date ascending).
+        sortDirection:
+          type: string
+          enum: &a142
+            - asc
+            - desc
+          description: Sort direction for `sortBy` (default asc). Ignored when `sortBy` is
+            omitted.
+        groupBy:
+          type: string
+          enum: &a143
+            - type
+            - priority
+            - status
+            - dueDate
+          description: When set, the response is grouped by this dimension
+            (ActivityGroupedResponseV1) instead of the paginated list;
+            `page`/`pageSize` are ignored. `priority` groups by the real
+            per-tenant priority name (not the normalized bucket), so it is only
+            meaningful when scoped to a single prioritized type.
+        page:
+          type: integer
+          minimum: 1
+          description: 1-based page number (default 1). Ignored when `groupBy` is set.
+        pageSize:
+          type: integer
+          minimum: 1
+          maximum: 100
+          description: Items per page, max 100 (default 25). Ignored when `groupBy` is set.
+    ActivityV1:
+      type: object
+      properties:
+        id:
+          type: string
+        title:
+          type: string
+        description:
+          type: string
+        type:
+          type: string
+          enum:
+            - schedule
+            - projectTask
+            - ticket
+            - timeEntry
+            - workflowTask
+            - notification
+            - document
+        status:
+          type: string
+        statusColor:
+          type: string
+        priority:
+          type: string
+          enum:
+            - low
+            - medium
+            - high
+        priorityName:
+          type: string
+        priorityColor:
+          type: string
+        dueDate:
+          type: string
+        startDate:
+          type: string
+        endDate:
+          type: string
+        assignedTo:
+          type: array
+          items:
+            type: string
+        assignedToNames:
+          type: array
+          items:
+            type: string
+        sourceId:
+          type: string
+        sourceType:
+          type: string
+          enum:
+            - schedule
+            - projectTask
+            - ticket
+            - timeEntry
+            - workflowTask
+            - notification
+            - document
+        actions:
+          type: array
+          items:
+            type: object
+            properties:
+              id:
+                type: string
+              label:
+                type: string
+              icon:
+                type: string
+              disabled:
+                type: boolean
+              disabledReason:
+                type: string
+            required:
+              - id
+              - label
+        isClosed:
+          type: boolean
+        tenant:
+          type: string
+        createdAt:
+          type: string
+        updatedAt:
+          type: string
+      required:
+        - id
+        - title
+        - type
+        - status
+        - priority
+        - sourceId
+        - sourceType
+        - actions
+        - tenant
+        - createdAt
+        - updatedAt
+    ActivityListResponseV1:
+      type: object
+      properties:
+        data:
+          type: array
+          items:
+            type: object
+            properties:
+              id:
+                type: string
+              title:
+                type: string
+              description:
+                type: string
+              type:
+                type: string
+                enum:
+                  - schedule
+                  - projectTask
+                  - ticket
+                  - timeEntry
+                  - workflowTask
+                  - notification
+                  - document
+              status:
+                type: string
+              statusColor:
+                type: string
+              priority:
+                type: string
+                enum:
+                  - low
+                  - medium
+                  - high
+              priorityName:
+                type: string
+              priorityColor:
+                type: string
+              dueDate:
+                type: string
+              startDate:
+                type: string
+              endDate:
+                type: string
+              assignedTo:
+                type: array
+                items:
+                  type: string
+              assignedToNames:
+                type: array
+                items:
+                  type: string
+              sourceId:
+                type: string
+              sourceType:
+                type: string
+                enum:
+                  - schedule
+                  - projectTask
+                  - ticket
+                  - timeEntry
+                  - workflowTask
+                  - notification
+                  - document
+              actions:
+                type: array
+                items:
+                  type: object
+                  properties:
+                    id:
+                      type: string
+                    label:
+                      type: string
+                    icon:
+                      type: string
+                    disabled:
+                      type: boolean
+                    disabledReason:
+                      type: string
+                  required:
+                    - id
+                    - label
+              isClosed:
+                type: boolean
+              tenant:
+                type: string
+              createdAt:
+                type: string
+              updatedAt:
+                type: string
+            required:
+              - id
+              - title
+              - type
+              - status
+              - priority
+              - sourceId
+              - sourceType
+              - actions
+              - tenant
+              - createdAt
+              - updatedAt
+        pagination:
+          type: object
+          properties:
+            page:
+              type: number
+            limit:
+              type: number
+            total:
+              type: number
+            totalPages:
+              type: number
+            hasNext:
+              type: boolean
+            hasPrev:
+              type: boolean
+          required:
+            - page
+            - limit
+            - total
+            - totalPages
+            - hasNext
+            - hasPrev
+        meta: {}
+      required:
+        - data
+        - pagination
+    ActivityGroupedResponseV1:
+      type: object
+      properties:
+        data:
+          type: object
+          properties:
+            groupBy:
+              type: string
+              enum:
+                - type
+                - priority
+                - status
+                - dueDate
+            groups:
+              type: array
+              items:
+                type: object
+                properties:
+                  key:
+                    type: string
+                  label:
+                    type: string
+                  count:
+                    type: number
+                  activities:
+                    type: array
+                    items:
+                      type: object
+                      properties:
+                        id:
+                          type: string
+                        title:
+                          type: string
+                        description:
+                          type: string
+                        type:
+                          type: string
+                          enum:
+                            - schedule
+                            - projectTask
+                            - ticket
+                            - timeEntry
+                            - workflowTask
+                            - notification
+                            - document
+                        status:
+                          type: string
+                        statusColor:
+                          type: string
+                        priority:
+                          type: string
+                          enum:
+                            - low
+                            - medium
+                            - high
+                        priorityName:
+                          type: string
+                        priorityColor:
+                          type: string
+                        dueDate:
+                          type: string
+                        startDate:
+                          type: string
+                        endDate:
+                          type: string
+                        assignedTo:
+                          type: array
+                          items:
+                            type: string
+                        assignedToNames:
+                          type: array
+                          items:
+                            type: string
+                        sourceId:
+                          type: string
+                        sourceType:
+                          type: string
+                          enum:
+                            - schedule
+                            - projectTask
+                            - ticket
+                            - timeEntry
+                            - workflowTask
+                            - notification
+                            - document
+                        actions:
+                          type: array
+                          items:
+                            type: object
+                            properties:
+                              id:
+                                type: string
+                              label:
+                                type: string
+                              icon:
+                                type: string
+                              disabled:
+                                type: boolean
+                              disabledReason:
+                                type: string
+                            required:
+                              - id
+                              - label
+                        isClosed:
+                          type: boolean
+                        tenant:
+                          type: string
+                        createdAt:
+                          type: string
+                        updatedAt:
+                          type: string
+                      required:
+                        - id
+                        - title
+                        - type
+                        - status
+                        - priority
+                        - sourceId
+                        - sourceType
+                        - actions
+                        - tenant
+                        - createdAt
+                        - updatedAt
+                required:
+                  - key
+                  - label
+                  - count
+                  - activities
+            totalCount:
+              type: number
+            truncated:
+              type: boolean
+          required:
+            - groupBy
+            - groups
+            - totalCount
+            - truncated
+        meta: {}
+      required:
+        - data
+    AdHocActivityResponseV1:
+      type: object
+      properties:
+        data:
+          type: object
+          properties:
+            id:
+              type: string
+            title:
+              type: string
+            description:
+              type: string
+            type:
+              type: string
+              enum:
+                - schedule
+                - projectTask
+                - ticket
+                - timeEntry
+                - workflowTask
+                - notification
+                - document
+            status:
+              type: string
+            statusColor:
+              type: string
+            priority:
+              type: string
+              enum:
+                - low
+                - medium
+                - high
+            priorityName:
+              type: string
+            priorityColor:
+              type: string
+            dueDate:
+              type: string
+            startDate:
+              type: string
+            endDate:
+              type: string
+            assignedTo:
+              type: array
+              items:
+                type: string
+            assignedToNames:
+              type: array
+              items:
+                type: string
+            sourceId:
+              type: string
+            sourceType:
+              type: string
+              enum:
+                - schedule
+                - projectTask
+                - ticket
+                - timeEntry
+                - workflowTask
+                - notification
+                - document
+            actions:
+              type: array
+              items:
+                type: object
+                properties:
+                  id:
+                    type: string
+                  label:
+                    type: string
+                  icon:
+                    type: string
+                  disabled:
+                    type: boolean
+                  disabledReason:
+                    type: string
+                required:
+                  - id
+                  - label
+            isClosed:
+              type: boolean
+            tenant:
+              type: string
+            createdAt:
+              type: string
+            updatedAt:
+              type: string
+          required:
+            - id
+            - title
+            - type
+            - status
+            - priority
+            - sourceId
+            - sourceType
+            - actions
+            - tenant
+            - createdAt
+            - updatedAt
+        meta: {}
+      required:
+        - data
+    CreateAdHocActivityBodyV1:
+      type: object
+      properties:
+        title:
+          type: string
+          minLength: 1
+        notes:
+          type: string
+        scheduledStart:
+          type:
+            - string
+            - "null"
+          format: date-time
+        scheduledEnd:
+          type:
+            - string
+            - "null"
+          format: date-time
+      required:
+        - title
+    UpdateAdHocActivityBodyV1:
+      type: object
+      properties:
+        title:
+          type: string
+          minLength: 1
+        notes:
+          type:
+            - string
+            - "null"
+        scheduledStart:
+          type:
+            - string
+            - "null"
+          format: date-time
+        scheduledEnd:
+          type:
+            - string
+            - "null"
+          format: date-time
+    SetAdHocActivityDoneBodyV1:
+      type: object
+      properties:
+        done:
+          type: boolean
+      required:
+        - done
+    CustomActivityGroupsResponseV1:
+      type: object
+      properties:
+        data:
+          type: array
+          items:
+            type: object
+            properties:
+              groupId:
+                type: string
+              groupName:
+                type: string
+              sortOrder:
+                type: number
+              isCollapsed:
+                type: boolean
+              items:
+                type: array
+                items:
+                  type: object
+                  properties:
+                    itemId:
+                      type: string
+                    activityId:
+                      type: string
+                    activityType:
+                      type: string
+                    sortOrder:
+                      type: number
+                  required:
+                    - itemId
+                    - activityId
+                    - activityType
+                    - sortOrder
+            required:
+              - groupId
+              - groupName
+              - sortOrder
+              - isCollapsed
+              - items
+        meta: {}
+      required:
+        - data
+    MoveActivityToGroupBodyV1:
+      type: object
+      properties:
+        activityId:
+          type: string
+          minLength: 1
+        activityType:
+          type: string
+          minLength: 1
+        groupId:
+          type: string
+          minLength: 1
+        sortOrder:
+          type: integer
+          minimum: 0
+      required:
+        - activityId
+        - activityType
+        - groupId
+        - sortOrder
+    RemoveActivityFromGroupBodyV1:
+      type: object
+      properties:
+        activityId:
+          type: string
+          minLength: 1
+        activityType:
+          type: string
+          minLength: 1
+      required:
+        - activityId
+        - activityType
+    ReorderActivitiesInGroupBodyV1:
+      type: object
+      properties:
+        items:
+          type: array
+          items:
+            type: object
+            properties:
+              activityId:
+                type: string
+                minLength: 1
+              activityType:
+                type: string
+                minLength: 1
+              sortOrder:
+                type: integer
+                minimum: 0
+            required:
+              - activityId
+              - activityType
+              - sortOrder
+          minItems: 1
+      required:
+        - items
+    ActivitiesGroupIdParamV1:
+      type: object
+      properties:
+        groupId:
+          type: string
+          description: Custom activity group identifier.
+      required:
+        - groupId
+    ActivitiesGroupsQueryV1:
+      type: object
+      properties:
+        targetUserId:
+          type: string
+          description: Another internal user whose groups to read (requires elevated
+            schedule permission). Omit for self.
     ProjectIdParams:
       type: object
       properties:
@@ -13638,7 +14695,7 @@ components:
           type: string
         order:
           type: string
-          enum: &a139
+          enum: &a144
             - asc
             - desc
         fields:
@@ -13943,7 +15000,7 @@ components:
           type: string
         order:
           type: string
-          enum: &a140
+          enum: &a145
             - asc
             - desc
         search:
@@ -13952,12 +15009,12 @@ components:
           type: string
         include_items:
           type: string
-          enum: &a141
+          enum: &a146
             - "true"
             - "false"
         include_client:
           type: string
-          enum: &a142
+          enum: &a147
             - "true"
             - "false"
     QuotesContractsGenericBodyV1:
@@ -15638,7 +16695,7 @@ paths:
           in: query
         - schema:
             type: string
-            enum: *a22
+            enum: *a23
           required: false
           name: order
           in: query
@@ -16162,7 +17219,7 @@ paths:
           in: query
         - schema:
             type: string
-            enum: *a23
+            enum: *a24
           required: false
           name: order
           in: query
@@ -16173,7 +17230,7 @@ paths:
           in: query
         - schema:
             type: string
-            enum: *a24
+            enum: *a25
           required: false
           name: has_permissions
           in: query
@@ -16189,7 +17246,7 @@ paths:
           in: query
         - schema:
             type: string
-            enum: *a25
+            enum: *a26
           required: false
           name: is_template
           in: query
@@ -16786,7 +17843,7 @@ paths:
           in: query
         - schema:
             type: string
-            enum: *a26
+            enum: *a27
           required: false
           name: order
           in: query
@@ -17094,7 +18151,7 @@ paths:
           in: query
         - schema:
             type: string
-            enum: *a27
+            enum: *a28
           required: false
           name: has_manager
           in: query
@@ -17105,7 +18162,7 @@ paths:
           in: query
         - schema:
             type: string
-            enum: *a28
+            enum: *a29
           required: false
           name: order
           in: query
@@ -17422,7 +18479,7 @@ paths:
           in: query
         - schema:
             type: string
-            enum: *a29
+            enum: *a30
           required: false
           name: granularity
           in: query
@@ -18174,7 +19231,7 @@ paths:
           in: query
         - schema:
             type: string
-            enum: *a30
+            enum: *a31
           required: false
           name: is_inactive
           in: query
@@ -18185,7 +19242,7 @@ paths:
           in: query
         - schema:
             type: string
-            enum: *a31
+            enum: *a32
           required: false
           name: order
           in: query
@@ -18257,7 +19314,7 @@ paths:
           in: query
         - schema:
             type: string
-            enum: *a32
+            enum: *a33
           required: false
           name: order
           in: query
@@ -18283,7 +19340,7 @@ paths:
           in: query
         - schema:
             type: string
-            enum: *a33
+            enum: *a34
           required: false
           name: user_type
           in: query
@@ -18301,19 +19358,19 @@ paths:
           in: query
         - schema:
             type: string
-            enum: *a34
+            enum: *a35
           required: false
           name: is_inactive
           in: query
         - schema:
             type: string
-            enum: *a35
+            enum: *a36
           required: false
           name: include_permissions
           in: query
         - schema:
             type: string
-            enum: *a36
+            enum: *a37
           required: false
           name: include_teams
           in: query
@@ -18647,7 +19704,7 @@ paths:
           in: query
         - schema:
             type: string
-            enum: *a37
+            enum: *a38
           required: false
           name: user_type
           in: query
@@ -18665,7 +19722,7 @@ paths:
           in: query
         - schema:
             type: string
-            enum: *a38
+            enum: *a39
           required: false
           name: include_inactive
           in: query
@@ -20050,7 +21107,7 @@ paths:
           in: query
         - schema:
             type: string
-            enum: *a39
+            enum: *a40
             description: Sort direction. Defaults to desc.
           required: false
           description: Sort direction. Defaults to desc.
@@ -20108,7 +21165,7 @@ paths:
           in: query
         - schema:
             type: string
-            enum: *a40
+            enum: *a41
             description: Accepted by validation, but not currently applied by
               AssetService.list.
           required: false
@@ -20176,7 +21233,7 @@ paths:
           in: query
         - schema:
             type: string
-            enum: *a41
+            enum: *a42
             description: true requires warranty_end_date to be non-null; false requires it
               to be null.
           required: false
@@ -20186,7 +21243,7 @@ paths:
           in: query
         - schema:
             type: string
-            enum: *a42
+            enum: *a43
             description: true filters warranty_end_date before now; false filters future
               warranty dates or no warranty.
           required: false
@@ -20196,7 +21253,7 @@ paths:
           in: query
         - schema:
             type: string
-            enum: *a43
+            enum: *a44
             description: Accepted by validation, but not currently applied by
               AssetService.list.
           required: false
@@ -20536,7 +21593,7 @@ paths:
       parameters:
         - schema:
             type: string
-            enum: *a44
+            enum: *a45
             description: Export format. csv (default) returns text/csv as an attachment;
               json returns the success envelope with the rows in data.
           required: false
@@ -20854,7 +21911,7 @@ paths:
             type: array
             items:
               type: string
-              enum: *a45
+              enum: *a46
             description: Search fields. If omitted, the service searches asset_tag, name,
               serial_number, and location.
           required: false
@@ -20893,7 +21950,7 @@ paths:
           in: query
         - schema:
             type: string
-            enum: *a46
+            enum: *a47
             description: When true, the service fetches asset-type-specific extension data
               for every result.
           required: false
@@ -22614,7 +23671,7 @@ paths:
           in: path
         - schema:
             type: string
-            enum: *a47
+            enum: *a48
             description: Remote-control protocol (default splashtop).
           required: false
           description: Remote-control protocol (default splashtop).
@@ -22770,7 +23827,7 @@ paths:
           in: query
         - schema:
             type: string
-            enum: *a48
+            enum: *a49
           required: false
           name: include_uninstalled
           in: query
@@ -22911,7 +23968,7 @@ paths:
           in: query
         - schema:
             type: string
-            enum: *a49
+            enum: *a50
             description: Accepted by shared list query validation.
           required: false
           description: Accepted by shared list query validation.
@@ -22958,7 +24015,7 @@ paths:
           in: query
         - schema:
             type: string
-            enum: *a50
+            enum: *a51
             description: Accepted by shared filter validation and transformed to boolean.
           required: false
           description: Accepted by shared filter validation and transformed to boolean.
@@ -23014,7 +24071,7 @@ paths:
           in: query
         - schema:
             type: string
-            enum: *a51
+            enum: *a52
             description: Filter by whether the execution has errors; transformed to boolean
               by validation.
           required: false
@@ -23260,7 +24317,7 @@ paths:
           in: query
         - schema:
             type: string
-            enum: *a52
+            enum: *a53
             description: Accepted by shared list query validation.
           required: false
           description: Accepted by shared list query validation.
@@ -23307,7 +24364,7 @@ paths:
           in: query
         - schema:
             type: string
-            enum: *a53
+            enum: *a54
             description: Accepted by shared filter validation and transformed to boolean.
           required: false
           description: Accepted by shared filter validation and transformed to boolean.
@@ -23947,7 +25004,7 @@ paths:
           in: query
         - schema:
             type: string
-            enum: *a54
+            enum: *a55
             description: Accepted by shared list query validation.
           required: false
           description: Accepted by shared list query validation.
@@ -23994,7 +25051,7 @@ paths:
           in: query
         - schema:
             type: string
-            enum: *a55
+            enum: *a56
             description: Accepted by shared filter validation and transformed to boolean.
           required: false
           description: Accepted by shared filter validation and transformed to boolean.
@@ -24375,7 +25432,7 @@ paths:
           in: query
         - schema:
             type: string
-            enum: *a56
+            enum: *a57
             description: Aggregation bucket size; defaults to day.
           required: false
           description: Aggregation bucket size; defaults to day.
@@ -24802,7 +25859,7 @@ paths:
           in: query
         - schema:
             type: string
-            enum: *a57
+            enum: *a58
           required: false
           name: order
           in: query
@@ -24847,25 +25904,25 @@ paths:
           in: query
         - schema:
             type: string
-            enum: *a58
+            enum: *a59
           required: false
           name: client_type
           in: query
         - schema:
             type: string
-            enum: *a59
+            enum: *a60
           required: false
           name: billing_cycle
           in: query
         - schema:
             type: string
-            enum: *a60
+            enum: *a61
           required: false
           name: is_inactive
           in: query
         - schema:
             type: string
-            enum: *a61
+            enum: *a62
           required: false
           name: is_tax_exempt
           in: query
@@ -24892,7 +25949,7 @@ paths:
           in: query
         - schema:
             type: string
-            enum: *a62
+            enum: *a63
           required: false
           name: has_credit_limit
           in: query
@@ -25426,7 +26483,7 @@ paths:
           in: query
         - schema:
             type: string
-            enum: *a63
+            enum: *a64
           required: false
           name: order
           in: query
@@ -25487,13 +26544,13 @@ paths:
           in: query
         - schema:
             type: string
-            enum: *a64
+            enum: *a65
           required: false
           name: is_inactive
           in: query
         - schema:
             type: string
-            enum: *a65
+            enum: *a66
           required: false
           name: has_client
           in: query
@@ -25800,7 +26857,7 @@ paths:
           in: query
         - schema:
             type: string
-            enum: *a66
+            enum: *a67
           required: false
           name: include_inactive
           in: query
@@ -25860,13 +26917,13 @@ paths:
       parameters:
         - schema:
             type: string
-            enum: *a67
+            enum: *a68
           required: false
           name: format
           in: query
         - schema:
             type: string
-            enum: *a68
+            enum: *a69
           required: false
           name: include_inactive
           in: query
@@ -25986,7 +27043,7 @@ paths:
           in: query
         - schema:
             type: string
-            enum: *a69
+            enum: *a70
           required: false
           name: order
           in: query
@@ -26038,19 +27095,19 @@ paths:
           in: query
         - schema:
             type: string
-            enum: *a70
+            enum: *a71
           required: false
           name: is_active
           in: query
         - schema:
             type: string
-            enum: *a71
+            enum: *a72
           required: false
           name: has_custom_rate
           in: query
         - schema:
             type: string
-            enum: *a72
+            enum: *a73
           required: false
           name: is_contractd
           in: query
@@ -26228,7 +27285,7 @@ paths:
           in: query
         - schema:
             type: string
-            enum: *a73
+            enum: *a74
           required: false
           name: order
           in: query
@@ -26280,13 +27337,13 @@ paths:
           in: query
         - schema:
             type: string
-            enum: *a74
+            enum: *a75
           required: false
           name: is_custom
           in: query
         - schema:
             type: string
-            enum: *a75
+            enum: *a76
           required: false
           name: is_active
           in: query
@@ -26297,7 +27354,7 @@ paths:
           in: query
         - schema:
             type: string
-            enum: *a76
+            enum: *a77
           required: false
           name: has_services
           in: query
@@ -26323,7 +27380,7 @@ paths:
           in: query
         - schema:
             type: string
-            enum: *a77
+            enum: *a78
             description: Controller-level include flag parsed directly from query string.
           required: false
           description: Controller-level include flag parsed directly from query string.
@@ -26331,7 +27388,7 @@ paths:
           in: query
         - schema:
             type: string
-            enum: *a78
+            enum: *a79
             description: Controller-level include flag parsed directly from query string.
           required: false
           description: Controller-level include flag parsed directly from query string.
@@ -26339,7 +27396,7 @@ paths:
           in: query
         - schema:
             type: string
-            enum: *a79
+            enum: *a80
             description: Controller-level include flag parsed directly from query string.
           required: false
           description: Controller-level include flag parsed directly from query string.
@@ -27662,7 +28719,7 @@ paths:
           in: path
         - schema:
             type: string
-            enum: *a80
+            enum: *a81
             description: Optional export format. pdf generates a PDF; markdown or md exports
               markdown; omitted downloads the original stored file.
           required: false
@@ -29240,7 +30297,7 @@ paths:
           in: query
         - schema:
             type: string
-            enum: *a81
+            enum: *a82
           required: false
           name: order
           in: query
@@ -29303,25 +30360,25 @@ paths:
           in: query
         - schema:
             type: string
-            enum: *a82
+            enum: *a83
           required: false
           name: include_expired
           in: query
         - schema:
             type: string
-            enum: *a83
+            enum: *a84
           required: false
           name: expiring_soon
           in: query
         - schema:
             type: string
-            enum: *a84
+            enum: *a85
           required: false
           name: has_remaining
           in: query
         - schema:
             type: string
-            enum: *a85
+            enum: *a86
           required: false
           name: has_expiration
           in: query
@@ -29337,13 +30394,13 @@ paths:
           in: query
         - schema:
             type: string
-            enum: *a86
+            enum: *a87
           required: false
           name: group_by
           in: query
         - schema:
             type: string
-            enum: *a87
+            enum: *a88
           required: false
           name: include_projections
           in: query
@@ -29664,7 +30721,7 @@ paths:
           in: query
         - schema:
             type: string
-            enum: *a88
+            enum: *a89
           required: false
           name: order
           in: query
@@ -29697,7 +30754,7 @@ paths:
           in: query
         - schema:
             type: string
-            enum: *a89
+            enum: *a90
           required: false
           name: is_active
           in: query
@@ -29709,7 +30766,7 @@ paths:
           in: query
         - schema:
             type: string
-            enum: *a90
+            enum: *a91
           required: false
           name: status
           in: query
@@ -29741,13 +30798,13 @@ paths:
           in: query
         - schema:
             type: string
-            enum: *a91
+            enum: *a92
           required: false
           name: is_manual
           in: query
         - schema:
             type: string
-            enum: *a92
+            enum: *a93
           required: false
           name: has_credit_applied
           in: query
@@ -29969,7 +31026,7 @@ paths:
           in: query
         - schema:
             type: string
-            enum: *a93
+            enum: *a94
           required: false
           name: order
           in: query
@@ -30002,7 +31059,7 @@ paths:
           in: query
         - schema:
             type: string
-            enum: *a94
+            enum: *a95
           required: false
           name: is_active
           in: query
@@ -30014,19 +31071,19 @@ paths:
           in: query
         - schema:
             type: string
-            enum: *a95
+            enum: *a96
           required: false
           name: type
           in: query
         - schema:
             type: string
-            enum: *a96
+            enum: *a97
           required: false
           name: is_default
           in: query
         - schema:
             type: string
-            enum: *a97
+            enum: *a98
             description: Exclude soft-deleted payment methods. Defaults to true.
           required: false
           description: Exclude soft-deleted payment methods. Defaults to true.
@@ -30358,7 +31415,7 @@ paths:
           in: query
         - schema:
             type: string
-            enum: *a81
+            enum: *a82
           required: false
           name: order
           in: query
@@ -30421,25 +31478,25 @@ paths:
           in: query
         - schema:
             type: string
-            enum: *a82
+            enum: *a83
           required: false
           name: include_expired
           in: query
         - schema:
             type: string
-            enum: *a83
+            enum: *a84
           required: false
           name: expiring_soon
           in: query
         - schema:
             type: string
-            enum: *a84
+            enum: *a85
           required: false
           name: has_remaining
           in: query
         - schema:
             type: string
-            enum: *a85
+            enum: *a86
           required: false
           name: has_expiration
           in: query
@@ -30455,13 +31512,13 @@ paths:
           in: query
         - schema:
             type: string
-            enum: *a86
+            enum: *a87
           required: false
           name: group_by
           in: query
         - schema:
             type: string
-            enum: *a87
+            enum: *a88
           required: false
           name: include_projections
           in: query
@@ -30600,7 +31657,7 @@ paths:
           in: query
         - schema:
             type: string
-            enum: *a81
+            enum: *a82
           required: false
           name: order
           in: query
@@ -30663,25 +31720,25 @@ paths:
           in: query
         - schema:
             type: string
-            enum: *a82
+            enum: *a83
           required: false
           name: include_expired
           in: query
         - schema:
             type: string
-            enum: *a83
+            enum: *a84
           required: false
           name: expiring_soon
           in: query
         - schema:
             type: string
-            enum: *a84
+            enum: *a85
           required: false
           name: has_remaining
           in: query
         - schema:
             type: string
-            enum: *a85
+            enum: *a86
           required: false
           name: has_expiration
           in: query
@@ -30697,13 +31754,13 @@ paths:
           in: query
         - schema:
             type: string
-            enum: *a86
+            enum: *a87
           required: false
           name: group_by
           in: query
         - schema:
             type: string
-            enum: *a87
+            enum: *a88
           required: false
           name: include_projections
           in: query
@@ -30777,7 +31834,7 @@ paths:
           in: query
         - schema:
             type: string
-            enum: *a81
+            enum: *a82
           required: false
           name: order
           in: query
@@ -30840,25 +31897,25 @@ paths:
           in: query
         - schema:
             type: string
-            enum: *a82
+            enum: *a83
           required: false
           name: include_expired
           in: query
         - schema:
             type: string
-            enum: *a83
+            enum: *a84
           required: false
           name: expiring_soon
           in: query
         - schema:
             type: string
-            enum: *a84
+            enum: *a85
           required: false
           name: has_remaining
           in: query
         - schema:
             type: string
-            enum: *a85
+            enum: *a86
           required: false
           name: has_expiration
           in: query
@@ -30874,13 +31931,13 @@ paths:
           in: query
         - schema:
             type: string
-            enum: *a86
+            enum: *a87
           required: false
           name: group_by
           in: query
         - schema:
             type: string
-            enum: *a87
+            enum: *a88
           required: false
           name: include_projections
           in: query
@@ -30954,7 +32011,7 @@ paths:
           in: query
         - schema:
             type: string
-            enum: *a81
+            enum: *a82
           required: false
           name: order
           in: query
@@ -31017,25 +32074,25 @@ paths:
           in: query
         - schema:
             type: string
-            enum: *a82
+            enum: *a83
           required: false
           name: include_expired
           in: query
         - schema:
             type: string
-            enum: *a83
+            enum: *a84
           required: false
           name: expiring_soon
           in: query
         - schema:
             type: string
-            enum: *a84
+            enum: *a85
           required: false
           name: has_remaining
           in: query
         - schema:
             type: string
-            enum: *a85
+            enum: *a86
           required: false
           name: has_expiration
           in: query
@@ -31051,13 +32108,13 @@ paths:
           in: query
         - schema:
             type: string
-            enum: *a86
+            enum: *a87
           required: false
           name: group_by
           in: query
         - schema:
             type: string
-            enum: *a87
+            enum: *a88
           required: false
           name: include_projections
           in: query
@@ -31189,7 +32246,7 @@ paths:
           in: query
         - schema:
             type: string
-            enum: *a81
+            enum: *a82
           required: false
           name: order
           in: query
@@ -31252,25 +32309,25 @@ paths:
           in: query
         - schema:
             type: string
-            enum: *a82
+            enum: *a83
           required: false
           name: include_expired
           in: query
         - schema:
             type: string
-            enum: *a83
+            enum: *a84
           required: false
           name: expiring_soon
           in: query
         - schema:
             type: string
-            enum: *a84
+            enum: *a85
           required: false
           name: has_remaining
           in: query
         - schema:
             type: string
-            enum: *a85
+            enum: *a86
           required: false
           name: has_expiration
           in: query
@@ -31286,13 +32343,13 @@ paths:
           in: query
         - schema:
             type: string
-            enum: *a86
+            enum: *a87
           required: false
           name: group_by
           in: query
         - schema:
             type: string
-            enum: *a87
+            enum: *a88
           required: false
           name: include_projections
           in: query
@@ -31366,7 +32423,7 @@ paths:
           in: query
         - schema:
             type: string
-            enum: *a81
+            enum: *a82
           required: false
           name: order
           in: query
@@ -31429,25 +32486,25 @@ paths:
           in: query
         - schema:
             type: string
-            enum: *a82
+            enum: *a83
           required: false
           name: include_expired
           in: query
         - schema:
             type: string
-            enum: *a83
+            enum: *a84
           required: false
           name: expiring_soon
           in: query
         - schema:
             type: string
-            enum: *a84
+            enum: *a85
           required: false
           name: has_remaining
           in: query
         - schema:
             type: string
-            enum: *a85
+            enum: *a86
           required: false
           name: has_expiration
           in: query
@@ -31463,13 +32520,13 @@ paths:
           in: query
         - schema:
             type: string
-            enum: *a86
+            enum: *a87
           required: false
           name: group_by
           in: query
         - schema:
             type: string
-            enum: *a87
+            enum: *a88
           required: false
           name: include_projections
           in: query
@@ -31728,31 +32785,31 @@ paths:
           in: query
         - schema:
             type: string
-            enum: *a98
+            enum: *a99
           required: false
           name: order
           in: query
         - schema:
             type: string
-            enum: *a99
+            enum: *a100
           required: false
           name: include_items
           in: query
         - schema:
             type: string
-            enum: *a100
+            enum: *a101
           required: false
           name: include_client
           in: query
         - schema:
             type: string
-            enum: *a101
+            enum: *a102
           required: false
           name: include_billing_cycle
           in: query
         - schema:
             type: string
-            enum: *a102
+            enum: *a103
           required: false
           name: include_transactions
           in: query
@@ -31773,7 +32830,7 @@ paths:
           in: query
         - schema:
             type: string
-            enum: *a103
+            enum: *a104
           required: false
           name: format
           in: query
@@ -31896,31 +32953,31 @@ paths:
           in: query
         - schema:
             type: string
-            enum: *a98
+            enum: *a99
           required: false
           name: order
           in: query
         - schema:
             type: string
-            enum: *a99
+            enum: *a100
           required: false
           name: include_items
           in: query
         - schema:
             type: string
-            enum: *a100
+            enum: *a101
           required: false
           name: include_client
           in: query
         - schema:
             type: string
-            enum: *a101
+            enum: *a102
           required: false
           name: include_billing_cycle
           in: query
         - schema:
             type: string
-            enum: *a102
+            enum: *a103
           required: false
           name: include_transactions
           in: query
@@ -31941,7 +32998,7 @@ paths:
           in: query
         - schema:
             type: string
-            enum: *a103
+            enum: *a104
           required: false
           name: format
           in: query
@@ -32219,31 +33276,31 @@ paths:
           in: query
         - schema:
             type: string
-            enum: *a98
+            enum: *a99
           required: false
           name: order
           in: query
         - schema:
             type: string
-            enum: *a99
+            enum: *a100
           required: false
           name: include_items
           in: query
         - schema:
             type: string
-            enum: *a100
+            enum: *a101
           required: false
           name: include_client
           in: query
         - schema:
             type: string
-            enum: *a101
+            enum: *a102
           required: false
           name: include_billing_cycle
           in: query
         - schema:
             type: string
-            enum: *a102
+            enum: *a103
           required: false
           name: include_transactions
           in: query
@@ -32264,7 +33321,7 @@ paths:
           in: query
         - schema:
             type: string
-            enum: *a103
+            enum: *a104
           required: false
           name: format
           in: query
@@ -32697,31 +33754,31 @@ paths:
           in: query
         - schema:
             type: string
-            enum: *a98
+            enum: *a99
           required: false
           name: order
           in: query
         - schema:
             type: string
-            enum: *a99
+            enum: *a100
           required: false
           name: include_items
           in: query
         - schema:
             type: string
-            enum: *a100
+            enum: *a101
           required: false
           name: include_client
           in: query
         - schema:
             type: string
-            enum: *a101
+            enum: *a102
           required: false
           name: include_billing_cycle
           in: query
         - schema:
             type: string
-            enum: *a102
+            enum: *a103
           required: false
           name: include_transactions
           in: query
@@ -32742,7 +33799,7 @@ paths:
           in: query
         - schema:
             type: string
-            enum: *a103
+            enum: *a104
           required: false
           name: format
           in: query
@@ -32815,31 +33872,31 @@ paths:
           in: query
         - schema:
             type: string
-            enum: *a98
+            enum: *a99
           required: false
           name: order
           in: query
         - schema:
             type: string
-            enum: *a99
+            enum: *a100
           required: false
           name: include_items
           in: query
         - schema:
             type: string
-            enum: *a100
+            enum: *a101
           required: false
           name: include_client
           in: query
         - schema:
             type: string
-            enum: *a101
+            enum: *a102
           required: false
           name: include_billing_cycle
           in: query
         - schema:
             type: string
-            enum: *a102
+            enum: *a103
           required: false
           name: include_transactions
           in: query
@@ -32860,7 +33917,7 @@ paths:
           in: query
         - schema:
             type: string
-            enum: *a103
+            enum: *a104
           required: false
           name: format
           in: query
@@ -34878,13 +35935,13 @@ paths:
           in: query
         - schema:
             type: string
-            enum: *a104
+            enum: *a105
           required: false
           name: is_managed
           in: query
         - schema:
             type: string
-            enum: *a105
+            enum: *a106
           required: false
           name: is_security_relevant
           in: query
@@ -34974,7 +36031,7 @@ paths:
           in: query
         - schema:
             type: string
-            enum: *a106
+            enum: *a107
           required: false
           name: order
           in: query
@@ -35429,19 +36486,19 @@ paths:
       parameters:
         - schema:
             type: string
-            enum: *a107
+            enum: *a108
           required: false
           name: preview
           in: query
         - schema:
             type: string
-            enum: *a108
+            enum: *a109
           required: false
           name: createNew
           in: query
         - schema:
             type: string
-            enum: *a109
+            enum: *a110
           required: false
           name: updateExisting
           in: query
@@ -35502,7 +36559,7 @@ paths:
       parameters:
         - schema:
             type: string
-            enum: *a110
+            enum: *a111
           required: false
           name: preview
           in: query
@@ -36104,7 +37161,7 @@ paths:
       parameters:
         - schema:
             type: string
-            enum: *a111
+            enum: *a112
           required: false
           name: force
           in: query
@@ -40715,7 +41772,7 @@ paths:
           in: query
         - schema:
             type: string
-            enum: *a112
+            enum: *a113
           required: false
           name: active
           in: query
@@ -40731,7 +41788,7 @@ paths:
           in: query
         - schema:
             type: string
-            enum: *a113
+            enum: *a114
           required: false
           name: force_refresh
           in: query
@@ -41092,7 +42149,7 @@ paths:
           in: query
         - schema:
             type: string
-            enum: *a112
+            enum: *a113
           required: false
           name: active
           in: query
@@ -41108,7 +42165,7 @@ paths:
           in: query
         - schema:
             type: string
-            enum: *a113
+            enum: *a114
           required: false
           name: force_refresh
           in: query
@@ -41652,7 +42709,7 @@ paths:
           in: query
         - schema:
             type: string
-            enum: *a112
+            enum: *a113
           required: false
           name: active
           in: query
@@ -41668,7 +42725,7 @@ paths:
           in: query
         - schema:
             type: string
-            enum: *a113
+            enum: *a114
           required: false
           name: force_refresh
           in: query
@@ -41741,7 +42798,7 @@ paths:
           in: query
         - schema:
             type: string
-            enum: *a112
+            enum: *a113
           required: false
           name: active
           in: query
@@ -41757,7 +42814,7 @@ paths:
           in: query
         - schema:
             type: string
-            enum: *a113
+            enum: *a114
           required: false
           name: force_refresh
           in: query
@@ -42260,7 +43317,7 @@ paths:
           in: query
         - schema:
             type: string
-            enum: *a112
+            enum: *a113
           required: false
           name: active
           in: query
@@ -42276,7 +43333,7 @@ paths:
           in: query
         - schema:
             type: string
-            enum: *a113
+            enum: *a114
           required: false
           name: force_refresh
           in: query
@@ -42525,13 +43582,13 @@ paths:
           in: query
         - schema:
             type: string
-            enum: *a114
+            enum: *a115
           required: false
           name: status
           in: query
         - schema:
             type: string
-            enum: *a115
+            enum: *a116
           required: false
           name: operation_type
           in: query
@@ -42860,7 +43917,7 @@ paths:
           in: query
         - schema:
             type: string
-            enum: *a112
+            enum: *a113
           required: false
           name: active
           in: query
@@ -42876,7 +43933,7 @@ paths:
           in: query
         - schema:
             type: string
-            enum: *a113
+            enum: *a114
           required: false
           name: force_refresh
           in: query
@@ -43065,7 +44122,7 @@ paths:
           in: query
         - schema:
             type: string
-            enum: *a112
+            enum: *a113
           required: false
           name: active
           in: query
@@ -43081,7 +44138,7 @@ paths:
           in: query
         - schema:
             type: string
-            enum: *a113
+            enum: *a114
           required: false
           name: force_refresh
           in: query
@@ -43154,7 +44211,7 @@ paths:
           in: query
         - schema:
             type: string
-            enum: *a112
+            enum: *a113
           required: false
           name: active
           in: query
@@ -43170,7 +44227,7 @@ paths:
           in: query
         - schema:
             type: string
-            enum: *a113
+            enum: *a114
           required: false
           name: force_refresh
           in: query
@@ -43537,7 +44594,7 @@ paths:
           in: query
         - schema:
             type: string
-            enum: *a112
+            enum: *a113
           required: false
           name: active
           in: query
@@ -43553,7 +44610,7 @@ paths:
           in: query
         - schema:
             type: string
-            enum: *a113
+            enum: *a114
           required: false
           name: force_refresh
           in: query
@@ -44105,7 +45162,7 @@ paths:
           in: query
         - schema:
             type: string
-            enum: *a112
+            enum: *a113
           required: false
           name: active
           in: query
@@ -44121,7 +45178,7 @@ paths:
           in: query
         - schema:
             type: string
-            enum: *a113
+            enum: *a114
           required: false
           name: force_refresh
           in: query
@@ -44195,7 +45252,7 @@ paths:
           in: query
         - schema:
             type: string
-            enum: *a112
+            enum: *a113
           required: false
           name: active
           in: query
@@ -44211,7 +45268,7 @@ paths:
           in: query
         - schema:
             type: string
-            enum: *a113
+            enum: *a114
           required: false
           name: force_refresh
           in: query
@@ -44722,7 +45779,7 @@ paths:
           in: query
         - schema:
             type: string
-            enum: *a112
+            enum: *a113
           required: false
           name: active
           in: query
@@ -44738,7 +45795,7 @@ paths:
           in: query
         - schema:
             type: string
-            enum: *a113
+            enum: *a114
           required: false
           name: force_refresh
           in: query
@@ -44991,13 +46048,13 @@ paths:
           in: query
         - schema:
             type: string
-            enum: *a114
+            enum: *a115
           required: false
           name: status
           in: query
         - schema:
             type: string
-            enum: *a115
+            enum: *a116
           required: false
           name: operation_type
           in: query
@@ -45331,7 +46388,7 @@ paths:
           in: query
         - schema:
             type: string
-            enum: *a112
+            enum: *a113
           required: false
           name: active
           in: query
@@ -45347,7 +46404,7 @@ paths:
           in: query
         - schema:
             type: string
-            enum: *a113
+            enum: *a114
           required: false
           name: force_refresh
           in: query
@@ -45538,7 +46595,7 @@ paths:
           in: query
         - schema:
             type: string
-            enum: *a112
+            enum: *a113
           required: false
           name: active
           in: query
@@ -45554,7 +46611,7 @@ paths:
           in: query
         - schema:
             type: string
-            enum: *a113
+            enum: *a114
           required: false
           name: force_refresh
           in: query
@@ -46145,7 +47202,7 @@ paths:
           in: query
         - schema:
             type: string
-            enum: *a116
+            enum: *a117
             description: Result ordering. "relevance" (default) ranks by full-text score;
               "recent" orders by last update.
           required: false
@@ -46520,7 +47577,7 @@ paths:
           in: query
         - schema:
             type: string
-            enum: *a117
+            enum: *a118
           required: false
           name: order
           in: query
@@ -46572,13 +47629,13 @@ paths:
           in: query
         - schema:
             type: string
-            enum: *a118
+            enum: *a119
           required: false
           name: is_parent
           in: query
         - schema:
             type: string
-            enum: *a119
+            enum: *a120
           required: false
           name: is_child
           in: query
@@ -46589,7 +47646,7 @@ paths:
           in: query
         - schema:
             type: string
-            enum: *a120
+            enum: *a121
           required: false
           name: active
           in: query
@@ -46605,19 +47662,19 @@ paths:
           in: query
         - schema:
             type: string
-            enum: *a121
+            enum: *a122
           required: false
           name: sort_order
           in: query
         - schema:
             type: string
-            enum: *a122
+            enum: *a123
           required: false
           name: include_hierarchy
           in: query
         - schema:
             type: string
-            enum: *a123
+            enum: *a124
           required: false
           name: category_type
           in: query
@@ -47073,7 +48130,7 @@ paths:
           in: query
         - schema:
             type: string
-            enum: *a124
+            enum: *a125
           required: false
           name: category_type
           in: query
@@ -47085,7 +48142,7 @@ paths:
           in: query
         - schema:
             type: string
-            enum: *a125
+            enum: *a126
           required: false
           name: include_inactive
           in: query
@@ -47160,7 +48217,7 @@ paths:
       parameters:
         - schema:
             type: string
-            enum: *a126
+            enum: *a127
           required: false
           name: category_type
           in: query
@@ -47184,7 +48241,7 @@ paths:
           in: query
         - schema:
             type: string
-            enum: *a127
+            enum: *a128
           required: false
           name: include_usage
           in: query
@@ -47270,7 +48327,7 @@ paths:
         this endpoint to inspect existing service catalog records and to gather
         prerequisite IDs such as custom_service_type_id and category_id before
         creating a new service.
-      tags: &a128
+      tags: &a129
         - Services
         - Service Catalog
       security:
@@ -47346,7 +48403,7 @@ paths:
           in: query
         - schema:
             type: string
-            enum: &a129
+            enum: &a130
               - fixed
               - hourly
               - usage
@@ -47394,7 +48451,7 @@ paths:
         with GET /api/v1/service-types and category_id with GET
         /api/v1/categories/service before calling this endpoint. Use this
         endpoint for fixed, hourly, or usage-based service offerings.
-      tags: *a128
+      tags: *a129
       security:
         - ApiKeyAuth: []
       extensions:
@@ -47423,7 +48480,7 @@ paths:
                   format: uuid
                 billing_method:
                   type: string
-                  enum: *a129
+                  enum: *a130
                 default_rate:
                   type: number
                   minimum: 0
@@ -47485,7 +48542,7 @@ paths:
     get:
       summary: Get service
       description: Returns a single service catalog entry by UUID.
-      tags: *a128
+      tags: *a129
       security:
         - ApiKeyAuth: []
       extensions:
@@ -47534,7 +48591,7 @@ paths:
     put:
       summary: Update service
       description: Updates a service catalog entry by UUID.
-      tags: *a128
+      tags: *a129
       security:
         - ApiKeyAuth: []
       extensions:
@@ -47572,7 +48629,7 @@ paths:
                   format: uuid
                 billing_method:
                   type: string
-                  enum: *a129
+                  enum: *a130
                 default_rate:
                   type: number
                   minimum: 0
@@ -47633,7 +48690,7 @@ paths:
     delete:
       summary: Delete service
       description: Deletes a service catalog entry by UUID.
-      tags: *a128
+      tags: *a129
       security:
         - ApiKeyAuth: []
       extensions:
@@ -47682,7 +48739,7 @@ paths:
         this endpoint to inspect existing product catalog records and to gather
         prerequisite IDs such as custom_service_type_id and category_id before
         creating a new product.
-      tags: &a130
+      tags: &a131
         - Products
         - Service Catalog
       security:
@@ -47793,7 +48850,7 @@ paths:
         /api/v1/categories/service before calling this endpoint. Products are
         catalog entries with item_kind product and always use billing_method
         usage.
-      tags: *a130
+      tags: *a131
       security:
         - ApiKeyAuth: []
       extensions:
@@ -47822,7 +48879,7 @@ paths:
                   format: uuid
                 billing_method:
                   type: string
-                  enum: &a131
+                  enum: &a132
                     - usage
                   default: usage
                 default_rate:
@@ -47833,7 +48890,6 @@ paths:
                   type: string
                   minLength: 3
                   maxLength: 3
-                  default: USD
                 unit_of_measure:
                   type: string
                   minLength: 1
@@ -47875,7 +48931,6 @@ paths:
                       maxLength: 3
                     - type: "null"
                     - type: "null"
-                  default: USD
                 vendor:
                   anyOf:
                     - type: string
@@ -47961,7 +49016,7 @@ paths:
     get:
       summary: Get product
       description: Returns a single product catalog entry by UUID.
-      tags: *a130
+      tags: *a131
       security:
         - ApiKeyAuth: []
       extensions:
@@ -48010,7 +49065,7 @@ paths:
     put:
       summary: Update product
       description: Updates a product catalog entry by UUID.
-      tags: *a130
+      tags: *a131
       security:
         - ApiKeyAuth: []
       extensions:
@@ -48048,7 +49103,7 @@ paths:
                   format: uuid
                 billing_method:
                   type: string
-                  enum: *a131
+                  enum: *a132
                   default: usage
                 default_rate:
                   type: number
@@ -48058,7 +49113,6 @@ paths:
                   type: string
                   minLength: 3
                   maxLength: 3
-                  default: USD
                 unit_of_measure:
                   type: string
                   minLength: 1
@@ -48100,7 +49154,6 @@ paths:
                       maxLength: 3
                     - type: "null"
                     - type: "null"
-                  default: USD
                 vendor:
                   anyOf:
                     - type: string
@@ -48187,7 +49240,7 @@ paths:
     delete:
       summary: Delete product
       description: Deletes a product catalog entry by UUID.
-      tags: *a130
+      tags: *a131
       security:
         - ApiKeyAuth: []
       extensions:
@@ -48235,7 +49288,7 @@ paths:
       description: Returns tenant service types. Use this endpoint to resolve
         custom_service_type_id before creating or updating services and products
         in the service catalog.
-      tags: &a132
+      tags: &a133
         - Service Types
         - Service Catalog
       security:
@@ -48296,7 +49349,7 @@ paths:
     get:
       summary: Get service type
       description: Returns a single tenant service type by UUID.
-      tags: *a132
+      tags: *a133
       security:
         - ApiKeyAuth: []
       extensions:
@@ -48377,7 +49430,7 @@ paths:
           in: query
         - schema:
             type: string
-            enum: *a133
+            enum: *a134
           required: false
           name: order
           in: query
@@ -48398,25 +49451,25 @@ paths:
           in: query
         - schema:
             type: string
-            enum: *a134
+            enum: *a135
           required: false
           name: is_active
           in: query
         - schema:
             type: string
-            enum: *a135
+            enum: *a136
           required: false
           name: is_test_mode
           in: query
         - schema:
             type: string
-            enum: *a136
+            enum: *a137
           required: false
           name: payload_format
           in: query
         - schema:
             type: string
-            enum: *a137
+            enum: *a138
           required: false
           name: has_failures
           in: query
@@ -49447,7 +50500,7 @@ paths:
           in: query
         - schema:
             type: string
-            enum: *a138
+            enum: *a139
           required: false
           name: status
           in: query
@@ -50590,41 +51643,6 @@ paths:
               schema:
                 $ref: "#/components/schemas/WorkflowV1MissingRouteResponse"
   /api/v1/workflows/tasks:
-    get:
-      summary: List workflow tasks (route inventory only)
-      description: "This operation is currently present only in generated route
-        inventory. No corresponding Next.js handler exists under
-        server/src/app/api/v1/workflows in this worktree. Runtime behavior is
-        middleware-dependent: missing/invalid x-api-key can return 401 before
-        routing; with middleware requirements satisfied, Next.js returns
-        not-found for the absent handler. Existing workflow APIs in this
-        codebase are implemented under /api/workflow-definitions,
-        /api/workflow-runs, and /api/workflow/events rather than
-        /api/v1/workflows paths."
-      tags:
-        - Workflows v1
-      security:
-        - ApiKeyAuth: []
-      extensions:
-        x-route-inventory-only: true
-        x-route-file-missing: server/src/app/api/v1/workflows/**/route.ts
-        x-family-status: missing-handler
-      x-alga-products:
-        - psa
-      responses:
-        "401":
-          description: x-api-key missing/invalid at middleware.
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/WorkflowV1MissingApiError"
-        "404":
-          description: No route handler exists for this inventory-only /api/v1/workflows
-            path.
-          content:
-            text/html:
-              schema:
-                $ref: "#/components/schemas/WorkflowV1MissingRouteResponse"
     post:
       summary: Create workflow task (route inventory only)
       description: "This operation is currently present only in generated route
@@ -50660,6 +51678,78 @@ paths:
             text/html:
               schema:
                 $ref: "#/components/schemas/WorkflowV1MissingRouteResponse"
+    get:
+      summary: List workflow tasks
+      description: Returns the authenticated caller's workflow task inbox (tasks
+        assigned to them directly or via a role), paginated. Items are summary
+        rows without `formSchema`; fetch a single task to obtain its form
+        schema. EE-only — on the Community build this returns an empty page.
+      tags:
+        - Workflow Tasks v1
+      security:
+        - ApiKeyAuth: []
+      extensions:
+        x-tenant-scoped: true
+        x-auth-mechanism: NextAuth session, falling back to x-api-key
+          (resolveWorkflowTaskAuthContext)
+        x-edition-behavior: EE-only feature; CE returns an empty page (list) or 404
+          (detail/actions).
+      x-alga-products:
+        - psa
+      parameters:
+        - schema:
+            type: string
+            description: Comma-separated WorkflowTaskStatus values (pending, claimed,
+              completed, canceled, expired). Omit for the open inbox (pending +
+              claimed).
+          required: false
+          description: Comma-separated WorkflowTaskStatus values (pending, claimed,
+            completed, canceled, expired). Omit for the open inbox (pending +
+            claimed).
+          name: status
+          in: query
+        - schema:
+            type: integer
+            minimum: 1
+            description: 1-based page number (default 1).
+          required: false
+          description: 1-based page number (default 1).
+          name: page
+          in: query
+        - schema:
+            type: integer
+            minimum: 1
+            maximum: 100
+            description: Items per page, max 100 (default 25).
+          required: false
+          description: Items per page, max 100 (default 25).
+          name: pageSize
+          in: query
+      responses:
+        "200":
+          description: Paginated workflow task inbox.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/WorkflowTaskListResponseV1"
+        "400":
+          description: Invalid query parameters.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/WorkflowTasksApiErrorV1"
+        "401":
+          description: Authentication required (no session and no/invalid x-api-key).
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/WorkflowTasksApiErrorV1"
+        "500":
+          description: Unexpected failure resolving the task inbox.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/WorkflowTasksApiErrorV1"
   /api/v1/workflows/tasks/bulk-assign:
     post:
       summary: Bulk assign workflow tasks (route inventory only)
@@ -50697,41 +51787,6 @@ paths:
               schema:
                 $ref: "#/components/schemas/WorkflowV1MissingRouteResponse"
   /api/v1/workflows/tasks/{id}:
-    get:
-      summary: Get workflow task by id (route inventory only)
-      description: "This operation is currently present only in generated route
-        inventory. No corresponding Next.js handler exists under
-        server/src/app/api/v1/workflows in this worktree. Runtime behavior is
-        middleware-dependent: missing/invalid x-api-key can return 401 before
-        routing; with middleware requirements satisfied, Next.js returns
-        not-found for the absent handler. Existing workflow APIs in this
-        codebase are implemented under /api/workflow-definitions,
-        /api/workflow-runs, and /api/workflow/events rather than
-        /api/v1/workflows paths."
-      tags:
-        - Workflows v1
-      security:
-        - ApiKeyAuth: []
-      extensions:
-        x-route-inventory-only: true
-        x-route-file-missing: server/src/app/api/v1/workflows/**/route.ts
-        x-family-status: missing-handler
-      x-alga-products:
-        - psa
-      responses:
-        "401":
-          description: x-api-key missing/invalid at middleware.
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/WorkflowV1MissingApiError"
-        "404":
-          description: No route handler exists for this inventory-only /api/v1/workflows
-            path.
-          content:
-            text/html:
-              schema:
-                $ref: "#/components/schemas/WorkflowV1MissingRouteResponse"
     put:
       summary: Update workflow task (route inventory only)
       description: "This operation is currently present only in generated route
@@ -50767,78 +51822,57 @@ paths:
             text/html:
               schema:
                 $ref: "#/components/schemas/WorkflowV1MissingRouteResponse"
-  /api/v1/workflows/tasks/{id}/claim:
-    post:
-      summary: Claim workflow task (route inventory only)
-      description: "This operation is currently present only in generated route
-        inventory. No corresponding Next.js handler exists under
-        server/src/app/api/v1/workflows in this worktree. Runtime behavior is
-        middleware-dependent: missing/invalid x-api-key can return 401 before
-        routing; with middleware requirements satisfied, Next.js returns
-        not-found for the absent handler. Existing workflow APIs in this
-        codebase are implemented under /api/workflow-definitions,
-        /api/workflow-runs, and /api/workflow/events rather than
-        /api/v1/workflows paths."
+    get:
+      summary: Get workflow task
+      description: Returns full detail for a single workflow task, including
+        `formSchema` ({ jsonSchema, uiSchema?, defaultValues? }) so a client can
+        classify the form as simple (native completion) vs complex (web
+        deep-link). EE-only — on the Community build this returns 404.
       tags:
-        - Workflows v1
+        - Workflow Tasks v1
       security:
         - ApiKeyAuth: []
       extensions:
-        x-route-inventory-only: true
-        x-route-file-missing: server/src/app/api/v1/workflows/**/route.ts
-        x-family-status: missing-handler
+        x-tenant-scoped: true
+        x-auth-mechanism: NextAuth session, falling back to x-api-key
+          (resolveWorkflowTaskAuthContext)
+        x-edition-behavior: EE-only feature; CE returns an empty page (list) or 404
+          (detail/actions).
       x-alga-products:
         - psa
+      parameters:
+        - schema:
+            type: string
+            description: Workflow task identifier (taskId).
+          required: true
+          description: Workflow task identifier (taskId).
+          name: id
+          in: path
       responses:
-        "401":
-          description: x-api-key missing/invalid at middleware.
+        "200":
+          description: Workflow task detail including the resolved form schema.
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/WorkflowV1MissingApiError"
-        "404":
-          description: No route handler exists for this inventory-only /api/v1/workflows
-            path.
-          content:
-            text/html:
-              schema:
-                $ref: "#/components/schemas/WorkflowV1MissingRouteResponse"
-  /api/v1/workflows/tasks/{id}/complete:
-    post:
-      summary: Complete workflow task (route inventory only)
-      description: "This operation is currently present only in generated route
-        inventory. No corresponding Next.js handler exists under
-        server/src/app/api/v1/workflows in this worktree. Runtime behavior is
-        middleware-dependent: missing/invalid x-api-key can return 401 before
-        routing; with middleware requirements satisfied, Next.js returns
-        not-found for the absent handler. Existing workflow APIs in this
-        codebase are implemented under /api/workflow-definitions,
-        /api/workflow-runs, and /api/workflow/events rather than
-        /api/v1/workflows paths."
-      tags:
-        - Workflows v1
-      security:
-        - ApiKeyAuth: []
-      extensions:
-        x-route-inventory-only: true
-        x-route-file-missing: server/src/app/api/v1/workflows/**/route.ts
-        x-family-status: missing-handler
-      x-alga-products:
-        - psa
-      responses:
+                $ref: "#/components/schemas/WorkflowTaskDetailResponseV1"
         "401":
-          description: x-api-key missing/invalid at middleware.
+          description: Authentication required.
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/WorkflowV1MissingApiError"
+                $ref: "#/components/schemas/WorkflowTasksApiErrorV1"
         "404":
-          description: No route handler exists for this inventory-only /api/v1/workflows
-            path.
+          description: Task not found (or workflow tasks unavailable on this build).
           content:
-            text/html:
+            application/json:
               schema:
-                $ref: "#/components/schemas/WorkflowV1MissingRouteResponse"
+                $ref: "#/components/schemas/WorkflowTasksApiErrorV1"
+        "500":
+          description: Unexpected failure resolving the task.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/WorkflowTasksApiErrorV1"
   /api/v1/workflows/templates:
     get:
       summary: List workflow templates (route inventory only)
@@ -51122,6 +52156,856 @@ paths:
             text/html:
               schema:
                 $ref: "#/components/schemas/WorkflowV1MissingRouteResponse"
+  /api/v1/workflows/tasks/{id}/claim:
+    post:
+      summary: Claim workflow task
+      description: Claims a pending task for the caller. No request body. EE-only — on
+        the Community build this returns 404.
+      tags:
+        - Workflow Tasks v1
+      security:
+        - ApiKeyAuth: []
+      extensions:
+        x-tenant-scoped: true
+        x-auth-mechanism: NextAuth session, falling back to x-api-key
+          (resolveWorkflowTaskAuthContext)
+        x-edition-behavior: EE-only feature; CE returns an empty page (list) or 404
+          (detail/actions).
+      x-alga-products:
+        - psa
+      parameters:
+        - schema:
+            type: string
+            description: Workflow task identifier (taskId).
+          required: true
+          description: Workflow task identifier (taskId).
+          name: id
+          in: path
+      responses:
+        "200":
+          description: Task claimed.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/WorkflowTaskActionResponseV1"
+        "401":
+          description: Authentication required.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/WorkflowTasksApiErrorV1"
+        "404":
+          description: Task not found (or workflow tasks unavailable on this build).
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/WorkflowTasksApiErrorV1"
+        "409":
+          description: Task already claimed by another user or not in a claimable state.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/WorkflowTasksApiErrorV1"
+        "500":
+          description: Unexpected failure claiming the task.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/WorkflowTasksApiErrorV1"
+  /api/v1/workflows/tasks/{id}/unclaim:
+    post:
+      summary: Unclaim workflow task
+      description: Releases a task the caller has claimed, returning it to the pending
+        pool. No request body. EE-only — on the Community build this returns
+        404.
+      tags:
+        - Workflow Tasks v1
+      security:
+        - ApiKeyAuth: []
+      extensions:
+        x-tenant-scoped: true
+        x-auth-mechanism: NextAuth session, falling back to x-api-key
+          (resolveWorkflowTaskAuthContext)
+        x-edition-behavior: EE-only feature; CE returns an empty page (list) or 404
+          (detail/actions).
+      x-alga-products:
+        - psa
+      parameters:
+        - schema:
+            type: string
+            description: Workflow task identifier (taskId).
+          required: true
+          description: Workflow task identifier (taskId).
+          name: id
+          in: path
+      responses:
+        "200":
+          description: Task released.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/WorkflowTaskActionResponseV1"
+        "401":
+          description: Authentication required.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/WorkflowTasksApiErrorV1"
+        "404":
+          description: Task not found (or workflow tasks unavailable on this build).
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/WorkflowTasksApiErrorV1"
+        "409":
+          description: Task is not claimed by the caller.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/WorkflowTasksApiErrorV1"
+        "500":
+          description: Unexpected failure releasing the task.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/WorkflowTasksApiErrorV1"
+  /api/v1/workflows/tasks/{id}/complete:
+    post:
+      summary: Complete workflow task
+      description: Submits the task's form payload and completes it. The form data is
+        validated server-side against the task's JSON Schema; validation
+        failures return 400 with the schema errors in `error.details`. EE-only —
+        on the Community build this returns 404.
+      tags:
+        - Workflow Tasks v1
+      security:
+        - ApiKeyAuth: []
+      extensions:
+        x-tenant-scoped: true
+        x-auth-mechanism: NextAuth session, falling back to x-api-key
+          (resolveWorkflowTaskAuthContext)
+        x-edition-behavior: EE-only feature; CE returns an empty page (list) or 404
+          (detail/actions).
+      x-alga-products:
+        - psa
+      parameters:
+        - schema:
+            type: string
+            description: Workflow task identifier (taskId).
+          required: true
+          description: Workflow task identifier (taskId).
+          name: id
+          in: path
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/CompleteWorkflowTaskBodyV1"
+      responses:
+        "200":
+          description: Task completed.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/WorkflowTaskActionResponseV1"
+        "400":
+          description: Form validation failed; schema errors are returned in
+            `error.details`.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/WorkflowTasksApiErrorV1"
+        "401":
+          description: Authentication required.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/WorkflowTasksApiErrorV1"
+        "404":
+          description: Task not found (or workflow tasks unavailable on this build).
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/WorkflowTasksApiErrorV1"
+        "409":
+          description: Task is not in a completable state for the caller.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/WorkflowTasksApiErrorV1"
+        "500":
+          description: Unexpected failure completing the task.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/WorkflowTasksApiErrorV1"
+  /api/v1/activities:
+    get:
+      summary: List user activities
+      description: Returns the authenticated caller's unified activity list — a
+        fan-out across tickets, project tasks, schedule entries, ad-hoc items,
+        workflow tasks, time entries and notifications. Filter by activity
+        type(s), open/closed status, priority, due-date window, free-text search
+        and a date window; sort via `sortBy`/`sortDirection`. By default the
+        result is paginated (ActivityListResponseV1). When `groupBy` is supplied
+        the result is instead grouped server-side into ordered, counted buckets
+        (ActivityGroupedResponseV1) and `page`/`pageSize` are ignored.
+      tags:
+        - Activities v1
+      security:
+        - ApiKeyAuth: []
+      extensions:
+        x-tenant-scoped: true
+        x-auth-mechanism: NextAuth session, falling back to x-api-key
+          (resolveActivityAuthContext)
+        x-response-when-grouped: "#/components/schemas/ActivityGroupedResponseV1"
+      x-alga-products:
+        - psa
+      parameters:
+        - schema:
+            type: string
+            description: Comma-separated ActivityType values (e.g. "ticket,schedule"). Omit
+              for all types.
+          required: false
+          description: Comma-separated ActivityType values (e.g. "ticket,schedule"). Omit
+            for all types.
+          name: type
+          in: query
+        - schema:
+            type: string
+            enum: *a140
+            description: Open/closed filter. `open`→active only, `closed`→closed, `all`→no
+              filter (default).
+          required: false
+          description: Open/closed filter. `open`→active only, `closed`→closed, `all`→no
+            filter (default).
+          name: status
+          in: query
+        - schema:
+            type: string
+            description: Free-text search across activity titles/descriptions.
+          required: false
+          description: Free-text search across activity titles/descriptions.
+          name: search
+          in: query
+        - schema:
+            type: string
+            format: date-time
+            description: ISO 8601 lower bound of the schedule/time-entry/notification
+              window.
+          required: false
+          description: ISO 8601 lower bound of the schedule/time-entry/notification window.
+          name: dateStart
+          in: query
+        - schema:
+            type: string
+            format: date-time
+            description: ISO 8601 upper bound of the window.
+          required: false
+          description: ISO 8601 upper bound of the window.
+          name: dateEnd
+          in: query
+        - schema:
+            type: string
+            description: Comma-separated normalized ActivityPriority buckets (e.g.
+              "high,medium"). Lossy for custom schemes; prefer `priorityIds`.
+          required: false
+          description: Comma-separated normalized ActivityPriority buckets (e.g.
+            "high,medium"). Lossy for custom schemes; prefer `priorityIds`.
+          name: priority
+          in: query
+        - schema:
+            type: string
+            description: Comma-separated exact priority IDs (the tenant's real per-type
+              priorities). Applies to ticket/project-task activities.
+          required: false
+          description: Comma-separated exact priority IDs (the tenant's real per-type
+            priorities). Applies to ticket/project-task activities.
+          name: priorityIds
+          in: query
+        - schema:
+            type: string
+            format: date-time
+            description: ISO 8601 lower bound of the due-date filter (independent of the
+              schedule window).
+          required: false
+          description: ISO 8601 lower bound of the due-date filter (independent of the
+            schedule window).
+          name: dueDateStart
+          in: query
+        - schema:
+            type: string
+            format: date-time
+            description: ISO 8601 upper bound of the due-date filter.
+          required: false
+          description: ISO 8601 upper bound of the due-date filter.
+          name: dueDateEnd
+          in: query
+        - schema:
+            type: string
+            format: date-time
+            description: ISO 8601 lower bound of the created-date ("date entered") filter.
+              Applies to every activity type.
+          required: false
+          description: ISO 8601 lower bound of the created-date ("date entered") filter.
+            Applies to every activity type.
+          name: createdAtStart
+          in: query
+        - schema:
+            type: string
+            format: date-time
+            description: ISO 8601 upper bound of the created-date ("date entered") filter.
+          required: false
+          description: ISO 8601 upper bound of the created-date ("date entered") filter.
+          name: createdAtEnd
+          in: query
+        - schema:
+            type: string
+            enum: *a141
+            description: Sort column. Omit for the default sort (priority high→low, then due
+              date ascending).
+          required: false
+          description: Sort column. Omit for the default sort (priority high→low, then due
+            date ascending).
+          name: sortBy
+          in: query
+        - schema:
+            type: string
+            enum: *a142
+            description: Sort direction for `sortBy` (default asc). Ignored when `sortBy` is
+              omitted.
+          required: false
+          description: Sort direction for `sortBy` (default asc). Ignored when `sortBy` is
+            omitted.
+          name: sortDirection
+          in: query
+        - schema:
+            type: string
+            enum: *a143
+            description: When set, the response is grouped by this dimension
+              (ActivityGroupedResponseV1) instead of the paginated list;
+              `page`/`pageSize` are ignored. `priority` groups by the real
+              per-tenant priority name (not the normalized bucket), so it is
+              only meaningful when scoped to a single prioritized type.
+          required: false
+          description: When set, the response is grouped by this dimension
+            (ActivityGroupedResponseV1) instead of the paginated list;
+            `page`/`pageSize` are ignored. `priority` groups by the real
+            per-tenant priority name (not the normalized bucket), so it is only
+            meaningful when scoped to a single prioritized type.
+          name: groupBy
+          in: query
+        - schema:
+            type: integer
+            minimum: 1
+            description: 1-based page number (default 1). Ignored when `groupBy` is set.
+          required: false
+          description: 1-based page number (default 1). Ignored when `groupBy` is set.
+          name: page
+          in: query
+        - schema:
+            type: integer
+            minimum: 1
+            maximum: 100
+            description: Items per page, max 100 (default 25). Ignored when `groupBy` is
+              set.
+          required: false
+          description: Items per page, max 100 (default 25). Ignored when `groupBy` is set.
+          name: pageSize
+          in: query
+      responses:
+        "200":
+          description: Paginated activity list, or grouped buckets when `groupBy` is set.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ActivityListResponseV1"
+        "400":
+          description: Invalid query parameters.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ActivitiesApiErrorV1"
+        "401":
+          description: Authentication required (no session and no/invalid x-api-key).
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ActivitiesApiErrorV1"
+        "403":
+          description: Permission denied for one of the underlying activity sources.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ActivitiesApiErrorV1"
+        "500":
+          description: Unexpected failure resolving activities.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ActivitiesApiErrorV1"
+  /api/v1/activities/ad-hoc:
+    post:
+      summary: Create ad-hoc activity
+      description: Creates a personal, self-assigned ad-hoc to-do rendered as a
+        schedule activity. Times are optional; when both are supplied the end
+        must be after the start. Gated by `user_schedule:read`.
+      tags:
+        - Activities v1
+      security:
+        - ApiKeyAuth: []
+      extensions:
+        x-tenant-scoped: true
+        x-auth-mechanism: NextAuth session, falling back to x-api-key
+          (resolveActivityAuthContext)
+      x-alga-products:
+        - psa
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/CreateAdHocActivityBodyV1"
+      responses:
+        "201":
+          description: Ad-hoc activity created.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/AdHocActivityResponseV1"
+        "400":
+          description: Invalid request body (e.g. missing title or end before start).
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ActivitiesApiErrorV1"
+        "401":
+          description: Authentication required.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ActivitiesApiErrorV1"
+        "403":
+          description: Permission denied (user_schedule:read).
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ActivitiesApiErrorV1"
+        "500":
+          description: Unexpected failure creating the ad-hoc activity.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ActivitiesApiErrorV1"
+  /api/v1/activities/ad-hoc/{id}:
+    patch:
+      summary: Update ad-hoc activity
+      description: "Updates an ad-hoc item's title, notes or optional times. Omitted
+        fields are left unchanged; `notes: null` clears the field. Requires the
+        caller to be an assignee, or hold `user_schedule:update` /
+        `user_schedule:read_all`."
+      tags:
+        - Activities v1
+      security:
+        - ApiKeyAuth: []
+      extensions:
+        x-tenant-scoped: true
+        x-auth-mechanism: NextAuth session, falling back to x-api-key
+          (resolveActivityAuthContext)
+      x-alga-products:
+        - psa
+      parameters:
+        - schema:
+            type: string
+            description: Ad-hoc activity identifier (the backing schedule entry id).
+          required: true
+          description: Ad-hoc activity identifier (the backing schedule entry id).
+          name: id
+          in: path
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/UpdateAdHocActivityBodyV1"
+      responses:
+        "200":
+          description: Updated ad-hoc activity.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/AdHocActivityResponseV1"
+        "400":
+          description: Invalid request body (e.g. end before start).
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ActivitiesApiErrorV1"
+        "401":
+          description: Authentication required.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ActivitiesApiErrorV1"
+        "403":
+          description: Permission denied.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ActivitiesApiErrorV1"
+        "404":
+          description: Ad-hoc activity not found.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ActivitiesApiErrorV1"
+        "500":
+          description: Unexpected failure updating the ad-hoc activity.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ActivitiesApiErrorV1"
+    delete:
+      summary: Delete ad-hoc activity
+      description: Permanently deletes an ad-hoc item. Requires the caller to be an
+        assignee, or hold `user_schedule:update` / `user_schedule:read_all`.
+      tags:
+        - Activities v1
+      security:
+        - ApiKeyAuth: []
+      extensions:
+        x-tenant-scoped: true
+        x-auth-mechanism: NextAuth session, falling back to x-api-key
+          (resolveActivityAuthContext)
+      x-alga-products:
+        - psa
+      parameters:
+        - schema:
+            type: string
+            description: Ad-hoc activity identifier (the backing schedule entry id).
+          required: true
+          description: Ad-hoc activity identifier (the backing schedule entry id).
+          name: id
+          in: path
+      responses:
+        "204":
+          description: Ad-hoc activity deleted; no content.
+        "401":
+          description: Authentication required.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ActivitiesApiErrorV1"
+        "403":
+          description: Permission denied.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ActivitiesApiErrorV1"
+        "404":
+          description: Ad-hoc activity not found.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ActivitiesApiErrorV1"
+        "500":
+          description: Unexpected failure deleting the ad-hoc activity.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ActivitiesApiErrorV1"
+  /api/v1/activities/ad-hoc/{id}/done:
+    post:
+      summary: Toggle ad-hoc activity done
+      description: "Marks an ad-hoc item done/undone. `done: true` sets status to
+        closed; `done: false` reopens it (status scheduled). Requires the caller
+        to be an assignee, or hold `user_schedule:update` /
+        `user_schedule:read_all`."
+      tags:
+        - Activities v1
+      security:
+        - ApiKeyAuth: []
+      extensions:
+        x-tenant-scoped: true
+        x-auth-mechanism: NextAuth session, falling back to x-api-key
+          (resolveActivityAuthContext)
+      x-alga-products:
+        - psa
+      parameters:
+        - schema:
+            type: string
+            description: Ad-hoc activity identifier (the backing schedule entry id).
+          required: true
+          description: Ad-hoc activity identifier (the backing schedule entry id).
+          name: id
+          in: path
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/SetAdHocActivityDoneBodyV1"
+      responses:
+        "200":
+          description: Updated ad-hoc activity.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/AdHocActivityResponseV1"
+        "400":
+          description: Invalid request body (e.g. missing `done`).
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ActivitiesApiErrorV1"
+        "401":
+          description: Authentication required.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ActivitiesApiErrorV1"
+        "403":
+          description: Permission denied.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ActivitiesApiErrorV1"
+        "404":
+          description: Ad-hoc activity not found.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ActivitiesApiErrorV1"
+        "500":
+          description: Unexpected failure updating the ad-hoc activity.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ActivitiesApiErrorV1"
+  /api/v1/activities/groups:
+    get:
+      summary: List custom activity groups
+      description: "Returns the caller's saved custom activity groups (created and
+        ordered in the web app), each with its ordered item references.
+        Read-only: clients bucket the unified activity list into these groups
+        for a \"My groups\" view. Pass `targetUserId` to read another user's
+        groups (requires `user_schedule:update` / `user_schedule:read_all`).
+        Membership and ordering are changed via the `/groups/items` endpoints."
+      tags:
+        - Activities v1
+      security:
+        - ApiKeyAuth: []
+      extensions:
+        x-tenant-scoped: true
+        x-auth-mechanism: NextAuth session, falling back to x-api-key
+          (resolveActivityAuthContext)
+      x-alga-products:
+        - psa
+      parameters:
+        - schema:
+            type: string
+            description: Another internal user whose groups to read (requires elevated
+              schedule permission). Omit for self.
+          required: false
+          description: Another internal user whose groups to read (requires elevated
+            schedule permission). Omit for self.
+          name: targetUserId
+          in: query
+      responses:
+        "200":
+          description: The caller's custom activity groups.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/CustomActivityGroupsResponseV1"
+        "401":
+          description: Authentication required.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ActivitiesApiErrorV1"
+        "403":
+          description: Permission denied (reading another user's groups).
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ActivitiesApiErrorV1"
+        "500":
+          description: Unexpected failure resolving groups.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ActivitiesApiErrorV1"
+  /api/v1/activities/groups/items:
+    post:
+      summary: Move an activity into a group
+      description: Moves an activity into one of the caller's custom groups at the
+        given position (`sortOrder`), removing it from any other group first so
+        an activity belongs to at most one group. Rows at/after the index are
+        shifted to keep ordering dense. Scoped to the caller's own groups; gated
+        by `user_schedule:read`.
+      tags:
+        - Activities v1
+      security:
+        - ApiKeyAuth: []
+      extensions:
+        x-tenant-scoped: true
+        x-auth-mechanism: NextAuth session, falling back to x-api-key
+          (resolveActivityAuthContext)
+      x-alga-products:
+        - psa
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/MoveActivityToGroupBodyV1"
+      responses:
+        "200":
+          description: Activity moved.
+        "400":
+          description: Invalid request body.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ActivitiesApiErrorV1"
+        "401":
+          description: Authentication required.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ActivitiesApiErrorV1"
+        "403":
+          description: Permission denied (user_schedule:read).
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ActivitiesApiErrorV1"
+        "404":
+          description: Target group not found.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ActivitiesApiErrorV1"
+        "500":
+          description: Unexpected failure moving the activity.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ActivitiesApiErrorV1"
+    delete:
+      summary: Remove an activity from its group
+      description: Removes an activity from all of the caller's custom groups (makes
+        it "ungrouped"). No-op when the activity is not in any group. Scoped to
+        the caller's own groups; gated by `user_schedule:read`.
+      tags:
+        - Activities v1
+      security:
+        - ApiKeyAuth: []
+      extensions:
+        x-tenant-scoped: true
+        x-auth-mechanism: NextAuth session, falling back to x-api-key
+          (resolveActivityAuthContext)
+      x-alga-products:
+        - psa
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/RemoveActivityFromGroupBodyV1"
+      responses:
+        "200":
+          description: Activity removed from its group.
+        "400":
+          description: Invalid request body.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ActivitiesApiErrorV1"
+        "401":
+          description: Authentication required.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ActivitiesApiErrorV1"
+        "403":
+          description: Permission denied (user_schedule:read).
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ActivitiesApiErrorV1"
+        "500":
+          description: Unexpected failure removing the activity.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ActivitiesApiErrorV1"
+  /api/v1/activities/groups/{groupId}/items:
+    patch:
+      summary: Reorder activities within a group
+      description: Persists the full ordered membership of a group after a
+        drag-to-reorder. Pass every item as it should appear; each row's
+        `sortOrder` is set to its position. Scoped to the caller's own groups;
+        gated by `user_schedule:read`.
+      tags:
+        - Activities v1
+      security:
+        - ApiKeyAuth: []
+      extensions:
+        x-tenant-scoped: true
+        x-auth-mechanism: NextAuth session, falling back to x-api-key
+          (resolveActivityAuthContext)
+      x-alga-products:
+        - psa
+      parameters:
+        - schema:
+            type: string
+            description: Custom activity group identifier.
+          required: true
+          description: Custom activity group identifier.
+          name: groupId
+          in: path
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/ReorderActivitiesInGroupBodyV1"
+      responses:
+        "200":
+          description: Group order persisted.
+        "400":
+          description: Invalid request body.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ActivitiesApiErrorV1"
+        "401":
+          description: Authentication required.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ActivitiesApiErrorV1"
+        "403":
+          description: Permission denied (user_schedule:read).
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ActivitiesApiErrorV1"
+        "404":
+          description: Group not found.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ActivitiesApiErrorV1"
+        "500":
+          description: Unexpected failure reordering the group.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ActivitiesApiErrorV1"
   /api/v1/projects/{id}/task-status-mappings:
     get:
       summary: List project task status mappings
@@ -51565,7 +53449,7 @@ paths:
           in: query
         - schema:
             type: string
-            enum: *a139
+            enum: *a144
           required: false
           name: order
           in: query
@@ -51866,7 +53750,7 @@ paths:
           in: query
         - schema:
             type: string
-            enum: *a139
+            enum: *a144
           required: false
           name: order
           in: query
@@ -51950,7 +53834,7 @@ paths:
           in: query
         - schema:
             type: string
-            enum: *a139
+            enum: *a144
           required: false
           name: order
           in: query
@@ -52034,7 +53918,7 @@ paths:
           in: query
         - schema:
             type: string
-            enum: *a139
+            enum: *a144
           required: false
           name: order
           in: query
@@ -52127,7 +54011,7 @@ paths:
           in: query
         - schema:
             type: string
-            enum: *a139
+            enum: *a144
           required: false
           name: order
           in: query
@@ -52225,7 +54109,7 @@ paths:
           in: query
         - schema:
             type: string
-            enum: *a139
+            enum: *a144
           required: false
           name: order
           in: query
@@ -52528,7 +54412,7 @@ paths:
           in: query
         - schema:
             type: string
-            enum: *a139
+            enum: *a144
           required: false
           name: order
           in: query
@@ -52625,7 +54509,7 @@ paths:
           in: query
         - schema:
             type: string
-            enum: *a139
+            enum: *a144
           required: false
           name: order
           in: query
@@ -52883,7 +54767,7 @@ paths:
           in: query
         - schema:
             type: string
-            enum: *a139
+            enum: *a144
           required: false
           name: order
           in: query
@@ -52973,7 +54857,7 @@ paths:
           in: query
         - schema:
             type: string
-            enum: *a139
+            enum: *a144
           required: false
           name: order
           in: query
@@ -53117,7 +55001,7 @@ paths:
           in: query
         - schema:
             type: string
-            enum: *a139
+            enum: *a144
           required: false
           name: order
           in: query
@@ -53412,7 +55296,7 @@ paths:
           in: query
         - schema:
             type: string
-            enum: *a139
+            enum: *a144
           required: false
           name: order
           in: query
@@ -53503,7 +55387,7 @@ paths:
           in: query
         - schema:
             type: string
-            enum: *a139
+            enum: *a144
           required: false
           name: order
           in: query
@@ -53647,7 +55531,7 @@ paths:
           in: query
         - schema:
             type: string
-            enum: *a139
+            enum: *a144
           required: false
           name: order
           in: query
@@ -54082,7 +55966,7 @@ paths:
           in: query
         - schema:
             type: string
-            enum: *a139
+            enum: *a144
           required: false
           name: order
           in: query
@@ -54393,7 +56277,7 @@ paths:
           in: query
         - schema:
             type: string
-            enum: *a139
+            enum: *a144
           required: false
           name: order
           in: query
@@ -54819,7 +56703,7 @@ paths:
           in: query
         - schema:
             type: string
-            enum: *a139
+            enum: *a144
           required: false
           name: order
           in: query
@@ -54903,7 +56787,7 @@ paths:
           in: query
         - schema:
             type: string
-            enum: *a139
+            enum: *a144
           required: false
           name: order
           in: query
@@ -55088,7 +56972,7 @@ paths:
           in: query
         - schema:
             type: string
-            enum: *a139
+            enum: *a144
           required: false
           name: order
           in: query
@@ -55173,7 +57057,7 @@ paths:
           in: query
         - schema:
             type: string
-            enum: *a139
+            enum: *a144
           required: false
           name: order
           in: query
@@ -55539,7 +57423,7 @@ paths:
           in: query
         - schema:
             type: string
-            enum: *a139
+            enum: *a144
           required: false
           name: order
           in: query
@@ -55637,7 +57521,7 @@ paths:
           in: query
         - schema:
             type: string
-            enum: *a139
+            enum: *a144
           required: false
           name: order
           in: query
@@ -56365,7 +58249,7 @@ paths:
           in: query
         - schema:
             type: string
-            enum: *a139
+            enum: *a144
           required: false
           name: order
           in: query
@@ -56507,7 +58391,7 @@ paths:
           in: query
         - schema:
             type: string
-            enum: *a139
+            enum: *a144
           required: false
           name: order
           in: query
@@ -56816,7 +58700,7 @@ paths:
           in: query
         - schema:
             type: string
-            enum: *a139
+            enum: *a144
           required: false
           name: order
           in: query
@@ -56959,7 +58843,7 @@ paths:
           in: query
         - schema:
             type: string
-            enum: *a139
+            enum: *a144
           required: false
           name: order
           in: query
@@ -57102,7 +58986,7 @@ paths:
           in: query
         - schema:
             type: string
-            enum: *a139
+            enum: *a144
           required: false
           name: order
           in: query
@@ -57259,7 +59143,7 @@ paths:
           in: query
         - schema:
             type: string
-            enum: *a139
+            enum: *a144
           required: false
           name: order
           in: query
@@ -57542,7 +59426,7 @@ paths:
           in: query
         - schema:
             type: string
-            enum: *a139
+            enum: *a144
           required: false
           name: order
           in: query
@@ -57686,7 +59570,7 @@ paths:
           in: query
         - schema:
             type: string
-            enum: *a139
+            enum: *a144
           required: false
           name: order
           in: query
@@ -58121,7 +60005,7 @@ paths:
           in: query
         - schema:
             type: string
-            enum: *a139
+            enum: *a144
           required: false
           name: order
           in: query
@@ -58324,7 +60208,7 @@ paths:
           in: query
         - schema:
             type: string
-            enum: *a139
+            enum: *a144
           required: false
           name: order
           in: query
@@ -58410,7 +60294,7 @@ paths:
           in: query
         - schema:
             type: string
-            enum: *a139
+            enum: *a144
           required: false
           name: order
           in: query
@@ -58853,7 +60737,7 @@ paths:
           in: query
         - schema:
             type: string
-            enum: *a139
+            enum: *a144
           required: false
           name: order
           in: query
@@ -59324,7 +61208,7 @@ paths:
           in: query
         - schema:
             type: string
-            enum: *a139
+            enum: *a144
           required: false
           name: order
           in: query
@@ -60052,7 +61936,7 @@ paths:
           in: query
         - schema:
             type: string
-            enum: *a140
+            enum: *a145
           required: false
           name: order
           in: query
@@ -60068,13 +61952,13 @@ paths:
           in: query
         - schema:
             type: string
-            enum: *a141
+            enum: *a146
           required: false
           name: include_items
           in: query
         - schema:
             type: string
-            enum: *a142
+            enum: *a147
           required: false
           name: include_client
           in: query
@@ -60143,7 +62027,7 @@ paths:
           in: query
         - schema:
             type: string
-            enum: *a140
+            enum: *a145
           required: false
           name: order
           in: query
@@ -60159,13 +62043,13 @@ paths:
           in: query
         - schema:
             type: string
-            enum: *a141
+            enum: *a146
           required: false
           name: include_items
           in: query
         - schema:
             type: string
-            enum: *a142
+            enum: *a147
           required: false
           name: include_client
           in: query
@@ -61580,7 +63464,7 @@ paths:
           in: query
         - schema:
             type: string
-            enum: *a140
+            enum: *a145
           required: false
           name: order
           in: query
@@ -61596,13 +63480,13 @@ paths:
           in: query
         - schema:
             type: string
-            enum: *a141
+            enum: *a146
           required: false
           name: include_items
           in: query
         - schema:
             type: string
-            enum: *a142
+            enum: *a147
           required: false
           name: include_client
           in: query
@@ -61675,7 +63559,7 @@ paths:
           in: query
         - schema:
             type: string
-            enum: *a140
+            enum: *a145
           required: false
           name: order
           in: query
@@ -61691,13 +63575,13 @@ paths:
           in: query
         - schema:
             type: string
-            enum: *a141
+            enum: *a146
           required: false
           name: include_items
           in: query
         - schema:
             type: string
-            enum: *a142
+            enum: *a147
           required: false
           name: include_client
           in: query
@@ -64199,6 +66083,37 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/ErrorResponse"
+  /api/auth/captcha-config:
+    get:
+      summary: GET auth
+      description: This operation was generated automatically from the route
+        inventory. Replace with canonical OpenAPI metadata.
+      tags:
+        - auth
+      extensions:
+        x-generated-from: docs/openapi/route-inventory.json
+        x-placeholder: true
+      x-alga-products:
+        - psa
+      responses:
+        "200":
+          description: Placeholder success response
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/PlaceholderObject"
+        "401":
+          description: Authentication required
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        "403":
+          description: Forbidden
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
   /api/auth/e2e/google/authorize:
     get:
       summary: GET auth
@@ -64678,6 +66593,201 @@ paths:
         - psa
       responses:
         "200":
+          description: Placeholder success response
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/PlaceholderObject"
+        "401":
+          description: Authentication required
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        "403":
+          description: Forbidden
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+  /api/billing/complete-reactivation:
+    post:
+      summary: POST billing
+      description: This operation was generated automatically from the route
+        inventory. Replace with canonical OpenAPI metadata.
+      tags:
+        - billing
+      extensions:
+        x-generated-from: docs/openapi/route-inventory.json
+        x-placeholder: true
+      x-alga-products:
+        - psa
+      requestBody:
+        description: Placeholder request body
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/PlaceholderObject"
+            description: Placeholder request body
+      responses:
+        "201":
+          description: Placeholder success response
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/PlaceholderObject"
+        "401":
+          description: Authentication required
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        "403":
+          description: Forbidden
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+  /api/billing/reactivation-password-reset:
+    post:
+      summary: POST billing
+      description: This operation was generated automatically from the route
+        inventory. Replace with canonical OpenAPI metadata.
+      tags:
+        - billing
+      extensions:
+        x-generated-from: docs/openapi/route-inventory.json
+        x-placeholder: true
+      x-alga-products:
+        - psa
+      requestBody:
+        description: Placeholder request body
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/PlaceholderObject"
+            description: Placeholder request body
+      responses:
+        "201":
+          description: Placeholder success response
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/PlaceholderObject"
+        "401":
+          description: Authentication required
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        "403":
+          description: Forbidden
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+  /api/billing/reactivation-token:
+    post:
+      summary: POST billing
+      description: This operation was generated automatically from the route
+        inventory. Replace with canonical OpenAPI metadata.
+      tags:
+        - billing
+      extensions:
+        x-generated-from: docs/openapi/route-inventory.json
+        x-placeholder: true
+      x-alga-products:
+        - psa
+      requestBody:
+        description: Placeholder request body
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/PlaceholderObject"
+            description: Placeholder request body
+      responses:
+        "201":
+          description: Placeholder success response
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/PlaceholderObject"
+        "401":
+          description: Authentication required
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        "403":
+          description: Forbidden
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+  /api/billing/reactivation-token/session:
+    post:
+      summary: POST billing
+      description: This operation was generated automatically from the route
+        inventory. Replace with canonical OpenAPI metadata.
+      tags:
+        - billing
+      extensions:
+        x-generated-from: docs/openapi/route-inventory.json
+        x-placeholder: true
+      x-alga-products:
+        - psa
+      requestBody:
+        description: Placeholder request body
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/PlaceholderObject"
+            description: Placeholder request body
+      responses:
+        "201":
+          description: Placeholder success response
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/PlaceholderObject"
+        "401":
+          description: Authentication required
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        "403":
+          description: Forbidden
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+  /api/billing/request-reactivation:
+    post:
+      summary: POST billing
+      description: This operation was generated automatically from the route
+        inventory. Replace with canonical OpenAPI metadata.
+      tags:
+        - billing
+      extensions:
+        x-generated-from: docs/openapi/route-inventory.json
+        x-placeholder: true
+      x-alga-products:
+        - psa
+      requestBody:
+        description: Placeholder request body
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/PlaceholderObject"
+            description: Placeholder request body
+      responses:
+        "201":
           description: Placeholder success response
           content:
             application/json:
@@ -66892,6 +69002,67 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/ErrorResponse"
+  /api/integrations/hudu:
+    get:
+      summary: GET integrations
+      description: This operation was generated automatically from the route
+        inventory. Replace with canonical OpenAPI metadata.
+      tags:
+        - integrations
+      extensions:
+        x-generated-from: docs/openapi/route-inventory.json
+        x-placeholder: true
+      x-alga-products:
+        - psa
+      responses:
+        "200":
+          description: Placeholder success response
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/PlaceholderObject"
+        "401":
+          description: Authentication required
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        "403":
+          description: Forbidden
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+    options:
+      summary: OPTIONS integrations
+      description: This operation was generated automatically from the route
+        inventory. Replace with canonical OpenAPI metadata.
+      tags:
+        - integrations
+      extensions:
+        x-generated-from: docs/openapi/route-inventory.json
+        x-placeholder: true
+      x-alga-products:
+        - psa
+      responses:
+        "200":
+          description: Placeholder success response
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/PlaceholderObject"
+        "401":
+          description: Authentication required
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        "403":
+          description: Forbidden
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
   /api/integrations/ninjaone/callback:
     get:
       summary: GET integrations
@@ -67265,6 +69436,222 @@ paths:
         inventory. Replace with canonical OpenAPI metadata.
       tags:
         - internal
+      extensions:
+        x-generated-from: docs/openapi/route-inventory.json
+        x-placeholder: true
+      x-alga-products:
+        - psa
+      requestBody:
+        description: Placeholder request body
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/PlaceholderObject"
+            description: Placeholder request body
+      responses:
+        "201":
+          description: Placeholder success response
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/PlaceholderObject"
+        "401":
+          description: Authentication required
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        "403":
+          description: Forbidden
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+  /api/mcp:
+    get:
+      summary: GET mcp
+      description: This operation was generated automatically from the route
+        inventory. Replace with canonical OpenAPI metadata.
+      tags:
+        - mcp
+      extensions:
+        x-generated-from: docs/openapi/route-inventory.json
+        x-placeholder: true
+      x-alga-products:
+        - psa
+      responses:
+        "200":
+          description: Placeholder success response
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/PlaceholderObject"
+        "401":
+          description: Authentication required
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        "403":
+          description: Forbidden
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+    post:
+      summary: POST mcp
+      description: This operation was generated automatically from the route
+        inventory. Replace with canonical OpenAPI metadata.
+      tags:
+        - mcp
+      extensions:
+        x-generated-from: docs/openapi/route-inventory.json
+        x-placeholder: true
+      x-alga-products:
+        - psa
+      requestBody:
+        description: Placeholder request body
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/PlaceholderObject"
+            description: Placeholder request body
+      responses:
+        "201":
+          description: Placeholder success response
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/PlaceholderObject"
+        "401":
+          description: Authentication required
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        "403":
+          description: Forbidden
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+  /api/mcp/oauth/authorize:
+    get:
+      summary: GET mcp
+      description: This operation was generated automatically from the route
+        inventory. Replace with canonical OpenAPI metadata.
+      tags:
+        - mcp
+      extensions:
+        x-generated-from: docs/openapi/route-inventory.json
+        x-placeholder: true
+      x-alga-products:
+        - psa
+      responses:
+        "200":
+          description: Placeholder success response
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/PlaceholderObject"
+        "401":
+          description: Authentication required
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        "403":
+          description: Forbidden
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+    post:
+      summary: POST mcp
+      description: This operation was generated automatically from the route
+        inventory. Replace with canonical OpenAPI metadata.
+      tags:
+        - mcp
+      extensions:
+        x-generated-from: docs/openapi/route-inventory.json
+        x-placeholder: true
+      x-alga-products:
+        - psa
+      requestBody:
+        description: Placeholder request body
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/PlaceholderObject"
+            description: Placeholder request body
+      responses:
+        "201":
+          description: Placeholder success response
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/PlaceholderObject"
+        "401":
+          description: Authentication required
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        "403":
+          description: Forbidden
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+  /api/mcp/oauth/revoke:
+    post:
+      summary: POST mcp
+      description: This operation was generated automatically from the route
+        inventory. Replace with canonical OpenAPI metadata.
+      tags:
+        - mcp
+      extensions:
+        x-generated-from: docs/openapi/route-inventory.json
+        x-placeholder: true
+      x-alga-products:
+        - psa
+      requestBody:
+        description: Placeholder request body
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/PlaceholderObject"
+            description: Placeholder request body
+      responses:
+        "201":
+          description: Placeholder success response
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/PlaceholderObject"
+        "401":
+          description: Authentication required
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        "403":
+          description: Forbidden
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+  /api/mcp/oauth/token:
+    post:
+      summary: POST mcp
+      description: This operation was generated automatically from the route
+        inventory. Replace with canonical OpenAPI metadata.
+      tags:
+        - mcp
       extensions:
         x-generated-from: docs/openapi/route-inventory.json
         x-placeholder: true
@@ -68381,6 +70768,690 @@ paths:
         x-placeholder: true
       x-alga-products:
         - psa
+      responses:
+        "200":
+          description: Placeholder success response
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/PlaceholderObject"
+        "401":
+          description: Authentication required
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        "403":
+          description: Forbidden
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+  /api/v1/appliance-installs:
+    get:
+      summary: GET v1
+      description: This operation was generated automatically from the route
+        inventory. Replace with canonical OpenAPI metadata.
+      tags:
+        - appliance-installs
+      extensions:
+        x-generated-from: docs/openapi/route-inventory.json
+        x-placeholder: true
+      x-alga-products:
+        - psa
+      responses:
+        "200":
+          description: Placeholder success response
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/PlaceholderObject"
+        "401":
+          description: Authentication required
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        "403":
+          description: Forbidden
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+    options:
+      summary: OPTIONS v1
+      description: This operation was generated automatically from the route
+        inventory. Replace with canonical OpenAPI metadata.
+      tags:
+        - appliance-installs
+      extensions:
+        x-generated-from: docs/openapi/route-inventory.json
+        x-placeholder: true
+      x-alga-products:
+        - psa
+      responses:
+        "200":
+          description: Placeholder success response
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/PlaceholderObject"
+        "401":
+          description: Authentication required
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        "403":
+          description: Forbidden
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+  /api/v1/appliance-installs/access:
+    options:
+      summary: OPTIONS v1
+      description: This operation was generated automatically from the route
+        inventory. Replace with canonical OpenAPI metadata.
+      tags:
+        - appliance-installs
+      extensions:
+        x-generated-from: docs/openapi/route-inventory.json
+        x-placeholder: true
+      x-alga-products:
+        - psa
+      responses:
+        "200":
+          description: Placeholder success response
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/PlaceholderObject"
+        "401":
+          description: Authentication required
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        "403":
+          description: Forbidden
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+    post:
+      summary: POST v1
+      description: This operation was generated automatically from the route
+        inventory. Replace with canonical OpenAPI metadata.
+      tags:
+        - appliance-installs
+      extensions:
+        x-generated-from: docs/openapi/route-inventory.json
+        x-placeholder: true
+      x-alga-products:
+        - psa
+      requestBody:
+        description: Placeholder request body
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/PlaceholderObject"
+            description: Placeholder request body
+      responses:
+        "201":
+          description: Placeholder success response
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/PlaceholderObject"
+        "401":
+          description: Authentication required
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        "403":
+          description: Forbidden
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+  /api/v1/appliance-installs/{tenantId}:
+    get:
+      summary: GET v1
+      description: This operation was generated automatically from the route
+        inventory. Replace with canonical OpenAPI metadata.
+      tags:
+        - appliance-installs
+      extensions:
+        x-generated-from: docs/openapi/route-inventory.json
+        x-placeholder: true
+      x-alga-products:
+        - psa
+      responses:
+        "200":
+          description: Placeholder success response
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/PlaceholderObject"
+        "401":
+          description: Authentication required
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        "403":
+          description: Forbidden
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+    options:
+      summary: OPTIONS v1
+      description: This operation was generated automatically from the route
+        inventory. Replace with canonical OpenAPI metadata.
+      tags:
+        - appliance-installs
+      extensions:
+        x-generated-from: docs/openapi/route-inventory.json
+        x-placeholder: true
+      x-alga-products:
+        - psa
+      responses:
+        "200":
+          description: Placeholder success response
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/PlaceholderObject"
+        "401":
+          description: Authentication required
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        "403":
+          description: Forbidden
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+  /api/v1/mcp/agents:
+    delete:
+      summary: DELETE v1
+      description: This operation was generated automatically from the route
+        inventory. Replace with canonical OpenAPI metadata.
+      tags:
+        - mcp
+      extensions:
+        x-generated-from: docs/openapi/route-inventory.json
+        x-placeholder: true
+      x-alga-products:
+        - psa
+      responses:
+        "204":
+          description: Placeholder success response
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/PlaceholderObject"
+        "401":
+          description: Authentication required
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        "403":
+          description: Forbidden
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+    get:
+      summary: GET v1
+      description: This operation was generated automatically from the route
+        inventory. Replace with canonical OpenAPI metadata.
+      tags:
+        - mcp
+      extensions:
+        x-generated-from: docs/openapi/route-inventory.json
+        x-placeholder: true
+      x-alga-products:
+        - psa
+      responses:
+        "200":
+          description: Placeholder success response
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/PlaceholderObject"
+        "401":
+          description: Authentication required
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        "403":
+          description: Forbidden
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+    patch:
+      summary: PATCH v1
+      description: This operation was generated automatically from the route
+        inventory. Replace with canonical OpenAPI metadata.
+      tags:
+        - mcp
+      extensions:
+        x-generated-from: docs/openapi/route-inventory.json
+        x-placeholder: true
+      x-alga-products:
+        - psa
+      requestBody:
+        description: Placeholder request body
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/PlaceholderObject"
+            description: Placeholder request body
+      responses:
+        "200":
+          description: Placeholder success response
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/PlaceholderObject"
+        "401":
+          description: Authentication required
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        "403":
+          description: Forbidden
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+    post:
+      summary: POST v1
+      description: This operation was generated automatically from the route
+        inventory. Replace with canonical OpenAPI metadata.
+      tags:
+        - mcp
+      extensions:
+        x-generated-from: docs/openapi/route-inventory.json
+        x-placeholder: true
+      x-alga-products:
+        - psa
+      requestBody:
+        description: Placeholder request body
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/PlaceholderObject"
+            description: Placeholder request body
+      responses:
+        "201":
+          description: Placeholder success response
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/PlaceholderObject"
+        "401":
+          description: Authentication required
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        "403":
+          description: Forbidden
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+  /api/v1/mcp/audit:
+    get:
+      summary: GET v1
+      description: This operation was generated automatically from the route
+        inventory. Replace with canonical OpenAPI metadata.
+      tags:
+        - mcp
+      extensions:
+        x-generated-from: docs/openapi/route-inventory.json
+        x-placeholder: true
+      x-alga-products:
+        - psa
+      responses:
+        "200":
+          description: Placeholder success response
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/PlaceholderObject"
+        "401":
+          description: Authentication required
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        "403":
+          description: Forbidden
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+  /api/v1/mcp/connect/callback:
+    get:
+      summary: GET v1
+      description: This operation was generated automatically from the route
+        inventory. Replace with canonical OpenAPI metadata.
+      tags:
+        - mcp
+      extensions:
+        x-generated-from: docs/openapi/route-inventory.json
+        x-placeholder: true
+      x-alga-products:
+        - psa
+      responses:
+        "200":
+          description: Placeholder success response
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/PlaceholderObject"
+        "401":
+          description: Authentication required
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        "403":
+          description: Forbidden
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+  /api/v1/mcp/connect/start:
+    post:
+      summary: POST v1
+      description: This operation was generated automatically from the route
+        inventory. Replace with canonical OpenAPI metadata.
+      tags:
+        - mcp
+      extensions:
+        x-generated-from: docs/openapi/route-inventory.json
+        x-placeholder: true
+      x-alga-products:
+        - psa
+      requestBody:
+        description: Placeholder request body
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/PlaceholderObject"
+            description: Placeholder request body
+      responses:
+        "201":
+          description: Placeholder success response
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/PlaceholderObject"
+        "401":
+          description: Authentication required
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        "403":
+          description: Forbidden
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+  /api/v1/mcp/connections:
+    delete:
+      summary: DELETE v1
+      description: This operation was generated automatically from the route
+        inventory. Replace with canonical OpenAPI metadata.
+      tags:
+        - mcp
+      extensions:
+        x-generated-from: docs/openapi/route-inventory.json
+        x-placeholder: true
+      x-alga-products:
+        - psa
+      responses:
+        "204":
+          description: Placeholder success response
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/PlaceholderObject"
+        "401":
+          description: Authentication required
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        "403":
+          description: Forbidden
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+    get:
+      summary: GET v1
+      description: This operation was generated automatically from the route
+        inventory. Replace with canonical OpenAPI metadata.
+      tags:
+        - mcp
+      extensions:
+        x-generated-from: docs/openapi/route-inventory.json
+        x-placeholder: true
+      x-alga-products:
+        - psa
+      responses:
+        "200":
+          description: Placeholder success response
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/PlaceholderObject"
+        "401":
+          description: Authentication required
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        "403":
+          description: Forbidden
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+  /api/v1/mcp/idp-providers:
+    get:
+      summary: GET v1
+      description: This operation was generated automatically from the route
+        inventory. Replace with canonical OpenAPI metadata.
+      tags:
+        - mcp
+      extensions:
+        x-generated-from: docs/openapi/route-inventory.json
+        x-placeholder: true
+      x-alga-products:
+        - psa
+      responses:
+        "200":
+          description: Placeholder success response
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/PlaceholderObject"
+        "401":
+          description: Authentication required
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        "403":
+          description: Forbidden
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+    post:
+      summary: POST v1
+      description: This operation was generated automatically from the route
+        inventory. Replace with canonical OpenAPI metadata.
+      tags:
+        - mcp
+      extensions:
+        x-generated-from: docs/openapi/route-inventory.json
+        x-placeholder: true
+      x-alga-products:
+        - psa
+      requestBody:
+        description: Placeholder request body
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/PlaceholderObject"
+            description: Placeholder request body
+      responses:
+        "201":
+          description: Placeholder success response
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/PlaceholderObject"
+        "401":
+          description: Authentication required
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        "403":
+          description: Forbidden
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+  /api/v1/mcp/idp-suggestions:
+    get:
+      summary: GET v1
+      description: This operation was generated automatically from the route
+        inventory. Replace with canonical OpenAPI metadata.
+      tags:
+        - mcp
+      extensions:
+        x-generated-from: docs/openapi/route-inventory.json
+        x-placeholder: true
+      x-alga-products:
+        - psa
+      responses:
+        "200":
+          description: Placeholder success response
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/PlaceholderObject"
+        "401":
+          description: Authentication required
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        "403":
+          description: Forbidden
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+  /api/v1/mcp/platform-providers:
+    get:
+      summary: GET v1
+      description: This operation was generated automatically from the route
+        inventory. Replace with canonical OpenAPI metadata.
+      tags:
+        - mcp
+      extensions:
+        x-generated-from: docs/openapi/route-inventory.json
+        x-placeholder: true
+      x-alga-products:
+        - psa
+      responses:
+        "200":
+          description: Placeholder success response
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/PlaceholderObject"
+        "401":
+          description: Authentication required
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        "403":
+          description: Forbidden
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+  /api/v1/mcp/roles:
+    get:
+      summary: GET v1
+      description: This operation was generated automatically from the route
+        inventory. Replace with canonical OpenAPI metadata.
+      tags:
+        - mcp
+      extensions:
+        x-generated-from: docs/openapi/route-inventory.json
+        x-placeholder: true
+      x-alga-products:
+        - psa
+      responses:
+        "200":
+          description: Placeholder success response
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/PlaceholderObject"
+        "401":
+          description: Authentication required
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        "403":
+          description: Forbidden
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+  /api/v1/meta/mcp-registry:
+    get:
+      summary: GET v1
+      description: This operation was generated automatically from the route
+        inventory. Replace with canonical OpenAPI metadata.
+      tags:
+        - meta
+      extensions:
+        x-generated-from: docs/openapi/route-inventory.json
+        x-placeholder: true
+      x-alga-products:
+        - psa
+        - algadesk
       responses:
         "200":
           description: Placeholder success response
@@ -71275,6 +74346,144 @@ paths:
         inventory. Replace with canonical OpenAPI metadata.
       tags:
         - tenant-management
+      extensions:
+        x-generated-from: docs/openapi/route-inventory.json
+        x-placeholder: true
+      x-alga-products:
+        - psa
+      requestBody:
+        description: Placeholder request body
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/PlaceholderObject"
+            description: Placeholder request body
+      responses:
+        "201":
+          description: Placeholder success response
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/PlaceholderObject"
+        "401":
+          description: Authentication required
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        "403":
+          description: Forbidden
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+  /api/webhooks/alternative-payments:
+    get:
+      summary: GET webhooks
+      description: This operation was generated automatically from the route
+        inventory. Replace with canonical OpenAPI metadata.
+      tags:
+        - webhooks
+      extensions:
+        x-generated-from: docs/openapi/route-inventory.json
+        x-placeholder: true
+      x-alga-products:
+        - psa
+      responses:
+        "200":
+          description: Placeholder success response
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/PlaceholderObject"
+        "401":
+          description: Authentication required
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        "403":
+          description: Forbidden
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+    post:
+      summary: POST webhooks
+      description: This operation was generated automatically from the route
+        inventory. Replace with canonical OpenAPI metadata.
+      tags:
+        - webhooks
+      extensions:
+        x-generated-from: docs/openapi/route-inventory.json
+        x-placeholder: true
+      x-alga-products:
+        - psa
+      requestBody:
+        description: Placeholder request body
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/PlaceholderObject"
+            description: Placeholder request body
+      responses:
+        "201":
+          description: Placeholder success response
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/PlaceholderObject"
+        "401":
+          description: Authentication required
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        "403":
+          description: Forbidden
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+  /api/webhooks/levelio:
+    options:
+      summary: OPTIONS webhooks
+      description: This operation was generated automatically from the route
+        inventory. Replace with canonical OpenAPI metadata.
+      tags:
+        - webhooks
+      extensions:
+        x-generated-from: docs/openapi/route-inventory.json
+        x-placeholder: true
+      x-alga-products:
+        - psa
+      responses:
+        "200":
+          description: Placeholder success response
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/PlaceholderObject"
+        "401":
+          description: Authentication required
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        "403":
+          description: Forbidden
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+    post:
+      summary: POST webhooks
+      description: This operation was generated automatically from the route
+        inventory. Replace with canonical OpenAPI metadata.
+      tags:
+        - webhooks
       extensions:
         x-generated-from: docs/openapi/route-inventory.json
         x-placeholder: true

--- a/server/src/lib/api/openapi/routes/activitiesV1.ts
+++ b/server/src/lib/api/openapi/routes/activitiesV1.ts
@@ -120,10 +120,7 @@ export function registerActivitiesV1Routes(registry: ApiOpenApiRegistry) {
   registry.registerSchema('ActivityV1', activitySchema);
 
   const ActivityListResponse = registry.registerSchema('ActivityListResponseV1', activityListResponseSchema);
-  const GroupedActivitiesResponse = registry.registerSchema(
-    'ActivityGroupedResponseV1',
-    groupedActivitiesResponseSchema,
-  );
+  registry.registerSchema('ActivityGroupedResponseV1', groupedActivitiesResponseSchema);
   const AdHocActivityResponse = registry.registerSchema('AdHocActivityResponseV1', adHocActivityResponseSchema);
 
   const CreateAdHocBody = registry.registerSchema('CreateAdHocActivityBodyV1', createAdHocActivitySchema);
@@ -175,7 +172,7 @@ export function registerActivitiesV1Routes(registry: ApiOpenApiRegistry) {
       403: { description: 'Permission denied for one of the underlying activity sources.', schema: ApiError },
       500: { description: 'Unexpected failure resolving activities.', schema: ApiError },
     },
-    extensions: { ...extensions, 'x-response-when-grouped': GroupedActivitiesResponse },
+    extensions: { ...extensions, 'x-response-when-grouped': '#/components/schemas/ActivityGroupedResponseV1' },
     edition: 'both',
   });
 

--- a/server/src/lib/mcp/registry.generated.ts
+++ b/server/src/lib/mcp/registry.generated.ts
@@ -35398,8 +35398,7 @@ export const chatApiRegistry: ChatApiRegistryEntry[] = [
         "currency_code": {
           "type": "string",
           "minLength": 3,
-          "maxLength": 3,
-          "default": "USD"
+          "maxLength": 3
         },
         "unit_of_measure": {
           "type": "string",
@@ -35489,8 +35488,7 @@ export const chatApiRegistry: ChatApiRegistryEntry[] = [
             {
               "type": "null"
             }
-          ],
-          "default": "USD"
+          ]
         },
         "vendor": {
           "anyOf": [
@@ -35707,8 +35705,7 @@ export const chatApiRegistry: ChatApiRegistryEntry[] = [
         "currency_code": {
           "type": "string",
           "minLength": 3,
-          "maxLength": 3,
-          "default": "USD"
+          "maxLength": 3
         },
         "unit_of_measure": {
           "type": "string",
@@ -35798,8 +35795,7 @@ export const chatApiRegistry: ChatApiRegistryEntry[] = [
             {
               "type": "null"
             }
-          ],
-          "default": "USD"
+          ]
         },
         "vendor": {
           "anyOf": [
@@ -38276,14 +38272,195 @@ export const chatApiRegistry: ChatApiRegistryEntry[] = [
     "id": "get-_api_v1_workflows_tasks",
     "method": "get",
     "path": "/api/v1/workflows/tasks",
-    "displayName": "List workflow tasks (route inventory only)",
-    "summary": "List workflow tasks (route inventory only)",
-    "description": "This operation is currently present only in generated route inventory. No corresponding Next.js handler exists under server/src/app/api/v1/workflows in this worktree. Runtime behavior is middleware-dependent: missing/invalid x-api-key can return 401 before routing; with middleware requirements satisfied, Next.js returns not-found for the absent handler. Existing workflow APIs in this codebase are implemented under /api/workflow-definitions, /api/workflow-runs, and /api/workflow/events rather than /api/v1/workflows paths.",
+    "displayName": "List workflow tasks",
+    "summary": "List workflow tasks",
+    "description": "Returns the authenticated caller's workflow task inbox (tasks assigned to them directly or via a role), paginated. Items are summary rows without `formSchema`; fetch a single task to obtain its form schema. EE-only — on the Community build this returns an empty page.",
     "tags": [
-      "Workflows v1"
+      "Workflow Tasks v1"
     ],
     "approvalRequired": false,
-    "parameters": []
+    "parameters": [
+      {
+        "name": "status",
+        "in": "query",
+        "required": false,
+        "description": "Comma-separated WorkflowTaskStatus values (pending, claimed, completed, canceled, expired). Omit for the open inbox (pending + claimed).",
+        "schema": {
+          "type": "string",
+          "description": "Comma-separated WorkflowTaskStatus values (pending, claimed, completed, canceled, expired). Omit for the open inbox (pending + claimed)."
+        }
+      },
+      {
+        "name": "page",
+        "in": "query",
+        "required": false,
+        "description": "1-based page number (default 1).",
+        "schema": {
+          "type": "integer",
+          "minimum": 1,
+          "description": "1-based page number (default 1)."
+        }
+      },
+      {
+        "name": "pageSize",
+        "in": "query",
+        "required": false,
+        "description": "Items per page, max 100 (default 25).",
+        "schema": {
+          "type": "integer",
+          "minimum": 1,
+          "maximum": 100,
+          "description": "Items per page, max 100 (default 25)."
+        }
+      }
+    ],
+    "responseBodySchema": {
+      "type": "object",
+      "properties": {
+        "data": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "taskId": {
+                "type": "string"
+              },
+              "executionId": {
+                "type": "string"
+              },
+              "title": {
+                "type": "string"
+              },
+              "description": {
+                "type": "string"
+              },
+              "status": {
+                "type": "string",
+                "enum": [
+                  "pending",
+                  "claimed",
+                  "completed",
+                  "canceled",
+                  "expired"
+                ]
+              },
+              "priority": {
+                "type": "string"
+              },
+              "dueDate": {
+                "type": "string"
+              },
+              "assignedRoles": {
+                "type": "array",
+                "items": {
+                  "type": "string"
+                }
+              },
+              "assignedUsers": {
+                "type": "array",
+                "items": {
+                  "type": "string"
+                }
+              },
+              "contextData": {
+                "type": "object",
+                "additionalProperties": {}
+              },
+              "formId": {
+                "type": "string"
+              },
+              "formSchema": {
+                "type": "object",
+                "properties": {
+                  "jsonSchema": {
+                    "type": "object",
+                    "additionalProperties": {}
+                  },
+                  "uiSchema": {
+                    "type": "object",
+                    "additionalProperties": {}
+                  },
+                  "defaultValues": {
+                    "type": "object",
+                    "additionalProperties": {}
+                  }
+                },
+                "required": [
+                  "jsonSchema"
+                ]
+              },
+              "createdAt": {
+                "type": "string"
+              },
+              "createdBy": {
+                "type": "string"
+              },
+              "claimedAt": {
+                "type": "string"
+              },
+              "claimedBy": {
+                "type": "string"
+              },
+              "completedAt": {
+                "type": "string"
+              },
+              "completedBy": {
+                "type": "string"
+              },
+              "responseData": {
+                "type": "object",
+                "additionalProperties": {}
+              }
+            },
+            "required": [
+              "taskId",
+              "executionId",
+              "title",
+              "status",
+              "priority",
+              "formId",
+              "createdAt"
+            ]
+          }
+        },
+        "pagination": {
+          "type": "object",
+          "properties": {
+            "page": {
+              "type": "number"
+            },
+            "limit": {
+              "type": "number"
+            },
+            "total": {
+              "type": "number"
+            },
+            "totalPages": {
+              "type": "number"
+            },
+            "hasNext": {
+              "type": "boolean"
+            },
+            "hasPrev": {
+              "type": "boolean"
+            }
+          },
+          "required": [
+            "page",
+            "limit",
+            "total",
+            "totalPages",
+            "hasNext",
+            "hasPrev"
+          ]
+        },
+        "meta": {}
+      },
+      "required": [
+        "data",
+        "pagination"
+      ]
+    }
   },
   {
     "id": "post-_api_v1_workflows_tasks",
@@ -38315,11 +38492,11 @@ export const chatApiRegistry: ChatApiRegistryEntry[] = [
     "id": "get-_api_v1_workflows_tasks_id",
     "method": "get",
     "path": "/api/v1/workflows/tasks/{id}",
-    "displayName": "Get workflow task by id (route inventory only)",
-    "summary": "Get workflow task by id (route inventory only)",
-    "description": "This operation is currently present only in generated route inventory. No corresponding Next.js handler exists under server/src/app/api/v1/workflows in this worktree. Runtime behavior is middleware-dependent: missing/invalid x-api-key can return 401 before routing; with middleware requirements satisfied, Next.js returns not-found for the absent handler. Existing workflow APIs in this codebase are implemented under /api/workflow-definitions, /api/workflow-runs, and /api/workflow/events rather than /api/v1/workflows paths.",
+    "displayName": "Get workflow task",
+    "summary": "Get workflow task",
+    "description": "Returns full detail for a single workflow task, including `formSchema` ({ jsonSchema, uiSchema?, defaultValues? }) so a client can classify the form as simple (native completion) vs complex (web deep-link). EE-only — on the Community build this returns 404.",
     "tags": [
-      "Workflows v1"
+      "Workflow Tasks v1"
     ],
     "approvalRequired": false,
     "parameters": [
@@ -38327,13 +38504,125 @@ export const chatApiRegistry: ChatApiRegistryEntry[] = [
         "name": "id",
         "in": "path",
         "required": true,
-        "description": "Resource identifier.",
+        "description": "Workflow task identifier (taskId).",
         "schema": {
           "type": "string",
-          "format": "uuid"
+          "description": "Workflow task identifier (taskId)."
         }
       }
-    ]
+    ],
+    "responseBodySchema": {
+      "type": "object",
+      "properties": {
+        "data": {
+          "type": "object",
+          "properties": {
+            "taskId": {
+              "type": "string"
+            },
+            "executionId": {
+              "type": "string"
+            },
+            "title": {
+              "type": "string"
+            },
+            "description": {
+              "type": "string"
+            },
+            "status": {
+              "type": "string",
+              "enum": [
+                "pending",
+                "claimed",
+                "completed",
+                "canceled",
+                "expired"
+              ]
+            },
+            "priority": {
+              "type": "string"
+            },
+            "dueDate": {
+              "type": "string"
+            },
+            "assignedRoles": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            },
+            "assignedUsers": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            },
+            "contextData": {
+              "type": "object",
+              "additionalProperties": {}
+            },
+            "formId": {
+              "type": "string"
+            },
+            "formSchema": {
+              "type": "object",
+              "properties": {
+                "jsonSchema": {
+                  "type": "object",
+                  "additionalProperties": {}
+                },
+                "uiSchema": {
+                  "type": "object",
+                  "additionalProperties": {}
+                },
+                "defaultValues": {
+                  "type": "object",
+                  "additionalProperties": {}
+                }
+              },
+              "required": [
+                "jsonSchema"
+              ]
+            },
+            "createdAt": {
+              "type": "string"
+            },
+            "createdBy": {
+              "type": "string"
+            },
+            "claimedAt": {
+              "type": "string"
+            },
+            "claimedBy": {
+              "type": "string"
+            },
+            "completedAt": {
+              "type": "string"
+            },
+            "completedBy": {
+              "type": "string"
+            },
+            "responseData": {
+              "type": "object",
+              "additionalProperties": {}
+            }
+          },
+          "required": [
+            "taskId",
+            "executionId",
+            "title",
+            "status",
+            "priority",
+            "formId",
+            "createdAt"
+          ]
+        },
+        "meta": {}
+      },
+      "required": [
+        "data"
+      ]
+    }
   },
   {
     "id": "put-_api_v1_workflows_tasks_id",
@@ -38341,54 +38630,6 @@ export const chatApiRegistry: ChatApiRegistryEntry[] = [
     "path": "/api/v1/workflows/tasks/{id}",
     "displayName": "Update workflow task (route inventory only)",
     "summary": "Update workflow task (route inventory only)",
-    "description": "This operation is currently present only in generated route inventory. No corresponding Next.js handler exists under server/src/app/api/v1/workflows in this worktree. Runtime behavior is middleware-dependent: missing/invalid x-api-key can return 401 before routing; with middleware requirements satisfied, Next.js returns not-found for the absent handler. Existing workflow APIs in this codebase are implemented under /api/workflow-definitions, /api/workflow-runs, and /api/workflow/events rather than /api/v1/workflows paths.",
-    "tags": [
-      "Workflows v1"
-    ],
-    "approvalRequired": false,
-    "parameters": [
-      {
-        "name": "id",
-        "in": "path",
-        "required": true,
-        "description": "Resource identifier.",
-        "schema": {
-          "type": "string",
-          "format": "uuid"
-        }
-      }
-    ]
-  },
-  {
-    "id": "post-_api_v1_workflows_tasks_id_claim",
-    "method": "post",
-    "path": "/api/v1/workflows/tasks/{id}/claim",
-    "displayName": "Claim workflow task (route inventory only)",
-    "summary": "Claim workflow task (route inventory only)",
-    "description": "This operation is currently present only in generated route inventory. No corresponding Next.js handler exists under server/src/app/api/v1/workflows in this worktree. Runtime behavior is middleware-dependent: missing/invalid x-api-key can return 401 before routing; with middleware requirements satisfied, Next.js returns not-found for the absent handler. Existing workflow APIs in this codebase are implemented under /api/workflow-definitions, /api/workflow-runs, and /api/workflow/events rather than /api/v1/workflows paths.",
-    "tags": [
-      "Workflows v1"
-    ],
-    "approvalRequired": false,
-    "parameters": [
-      {
-        "name": "id",
-        "in": "path",
-        "required": true,
-        "description": "Resource identifier.",
-        "schema": {
-          "type": "string",
-          "format": "uuid"
-        }
-      }
-    ]
-  },
-  {
-    "id": "post-_api_v1_workflows_tasks_id_complete",
-    "method": "post",
-    "path": "/api/v1/workflows/tasks/{id}/complete",
-    "displayName": "Complete workflow task (route inventory only)",
-    "summary": "Complete workflow task (route inventory only)",
     "description": "This operation is currently present only in generated route inventory. No corresponding Next.js handler exists under server/src/app/api/v1/workflows in this worktree. Runtime behavior is middleware-dependent: missing/invalid x-api-key can return 401 before routing; with middleware requirements satisfied, Next.js returns not-found for the absent handler. Existing workflow APIs in this codebase are implemented under /api/workflow-definitions, /api/workflow-runs, and /api/workflow/events rather than /api/v1/workflows paths.",
     "tags": [
       "Workflows v1"
@@ -38576,6 +38817,1351 @@ export const chatApiRegistry: ChatApiRegistryEntry[] = [
         }
       }
     ]
+  },
+  {
+    "id": "post-_api_v1_workflows_tasks_id_claim",
+    "method": "post",
+    "path": "/api/v1/workflows/tasks/{id}/claim",
+    "displayName": "Claim workflow task",
+    "summary": "Claim workflow task",
+    "description": "Claims a pending task for the caller. No request body. EE-only — on the Community build this returns 404.",
+    "tags": [
+      "Workflow Tasks v1"
+    ],
+    "approvalRequired": false,
+    "parameters": [
+      {
+        "name": "id",
+        "in": "path",
+        "required": true,
+        "description": "Workflow task identifier (taskId).",
+        "schema": {
+          "type": "string",
+          "description": "Workflow task identifier (taskId)."
+        }
+      }
+    ],
+    "responseBodySchema": {
+      "type": "object",
+      "properties": {
+        "data": {
+          "type": "object",
+          "properties": {
+            "success": {
+              "type": "boolean"
+            }
+          },
+          "required": [
+            "success"
+          ]
+        },
+        "meta": {}
+      },
+      "required": [
+        "data"
+      ]
+    }
+  },
+  {
+    "id": "post-_api_v1_workflows_tasks_id_unclaim",
+    "method": "post",
+    "path": "/api/v1/workflows/tasks/{id}/unclaim",
+    "displayName": "Unclaim workflow task",
+    "summary": "Unclaim workflow task",
+    "description": "Releases a task the caller has claimed, returning it to the pending pool. No request body. EE-only — on the Community build this returns 404.",
+    "tags": [
+      "Workflow Tasks v1"
+    ],
+    "approvalRequired": false,
+    "parameters": [
+      {
+        "name": "id",
+        "in": "path",
+        "required": true,
+        "description": "Workflow task identifier (taskId).",
+        "schema": {
+          "type": "string",
+          "description": "Workflow task identifier (taskId)."
+        }
+      }
+    ],
+    "responseBodySchema": {
+      "type": "object",
+      "properties": {
+        "data": {
+          "type": "object",
+          "properties": {
+            "success": {
+              "type": "boolean"
+            }
+          },
+          "required": [
+            "success"
+          ]
+        },
+        "meta": {}
+      },
+      "required": [
+        "data"
+      ]
+    }
+  },
+  {
+    "id": "post-_api_v1_workflows_tasks_id_complete",
+    "method": "post",
+    "path": "/api/v1/workflows/tasks/{id}/complete",
+    "displayName": "Complete workflow task",
+    "summary": "Complete workflow task",
+    "description": "Submits the task's form payload and completes it. The form data is validated server-side against the task's JSON Schema; validation failures return 400 with the schema errors in `error.details`. EE-only — on the Community build this returns 404.",
+    "tags": [
+      "Workflow Tasks v1"
+    ],
+    "approvalRequired": false,
+    "parameters": [
+      {
+        "name": "id",
+        "in": "path",
+        "required": true,
+        "description": "Workflow task identifier (taskId).",
+        "schema": {
+          "type": "string",
+          "description": "Workflow task identifier (taskId)."
+        }
+      }
+    ],
+    "requestBodySchema": {
+      "type": "object",
+      "properties": {
+        "formData": {
+          "type": "object",
+          "additionalProperties": {},
+          "default": {}
+        },
+        "comments": {
+          "type": "string"
+        }
+      }
+    },
+    "responseBodySchema": {
+      "type": "object",
+      "properties": {
+        "data": {
+          "type": "object",
+          "properties": {
+            "success": {
+              "type": "boolean"
+            }
+          },
+          "required": [
+            "success"
+          ]
+        },
+        "meta": {}
+      },
+      "required": [
+        "data"
+      ]
+    }
+  },
+  {
+    "id": "get-_api_v1_activities",
+    "method": "get",
+    "path": "/api/v1/activities",
+    "displayName": "List My Activities",
+    "summary": "Fetch the authenticated user's unified activity list (the User Activities screen)",
+    "description": "Returns the caller's own work items exactly as the User Activities screen shows them: a unified, paginated fan-out across tickets, project tasks, schedule entries, ad-hoc to-dos, workflow tasks, time entries and notifications. Each activity carries id, type, title, status and priority. Filter with type (comma-separated: ticket, projectTask, schedule, workflowTask, timeEntry, notification, document; ad-hoc to-dos surface as schedule), status (open/closed/all), search, due-date and created-date windows; sort with sortBy/sortDirection. This endpoint is always scoped to the authenticated caller — use it for questions like \"what is on my plate\" or \"my open tickets on my activities screen\". For tenant-wide ticket queries use GET /api/v1/tickets instead.",
+    "tags": [
+      "Activities v1"
+    ],
+    "approvalRequired": false,
+    "parameters": [
+      {
+        "name": "type",
+        "in": "query",
+        "required": false,
+        "description": "Comma-separated ActivityType values (e.g. \"ticket,schedule\"). Omit for all types.",
+        "schema": {
+          "type": "string",
+          "description": "Comma-separated ActivityType values (e.g. \"ticket,schedule\"). Omit for all types."
+        }
+      },
+      {
+        "name": "status",
+        "in": "query",
+        "required": false,
+        "description": "Open/closed filter. `open`→active only, `closed`→closed, `all`→no filter (default).",
+        "schema": {
+          "type": "string",
+          "enum": [
+            "open",
+            "closed",
+            "all"
+          ],
+          "description": "Open/closed filter. `open`→active only, `closed`→closed, `all`→no filter (default)."
+        }
+      },
+      {
+        "name": "search",
+        "in": "query",
+        "required": false,
+        "description": "Free-text search across activity titles/descriptions.",
+        "schema": {
+          "type": "string",
+          "description": "Free-text search across activity titles/descriptions."
+        }
+      },
+      {
+        "name": "dateStart",
+        "in": "query",
+        "required": false,
+        "description": "ISO 8601 lower bound of the schedule/time-entry/notification window.",
+        "schema": {
+          "type": "string",
+          "format": "date-time",
+          "description": "ISO 8601 lower bound of the schedule/time-entry/notification window."
+        }
+      },
+      {
+        "name": "dateEnd",
+        "in": "query",
+        "required": false,
+        "description": "ISO 8601 upper bound of the window.",
+        "schema": {
+          "type": "string",
+          "format": "date-time",
+          "description": "ISO 8601 upper bound of the window."
+        }
+      },
+      {
+        "name": "priority",
+        "in": "query",
+        "required": false,
+        "description": "Comma-separated normalized ActivityPriority buckets (e.g. \"high,medium\"). Lossy for custom schemes; prefer `priorityIds`.",
+        "schema": {
+          "type": "string",
+          "description": "Comma-separated normalized ActivityPriority buckets (e.g. \"high,medium\"). Lossy for custom schemes; prefer `priorityIds`."
+        }
+      },
+      {
+        "name": "priorityIds",
+        "in": "query",
+        "required": false,
+        "description": "Comma-separated exact priority IDs (the tenant's real per-type priorities). Applies to ticket/project-task activities.",
+        "schema": {
+          "type": "string",
+          "description": "Comma-separated exact priority IDs (the tenant's real per-type priorities). Applies to ticket/project-task activities."
+        }
+      },
+      {
+        "name": "dueDateStart",
+        "in": "query",
+        "required": false,
+        "description": "ISO 8601 lower bound of the due-date filter (independent of the schedule window).",
+        "schema": {
+          "type": "string",
+          "format": "date-time",
+          "description": "ISO 8601 lower bound of the due-date filter (independent of the schedule window)."
+        }
+      },
+      {
+        "name": "dueDateEnd",
+        "in": "query",
+        "required": false,
+        "description": "ISO 8601 upper bound of the due-date filter.",
+        "schema": {
+          "type": "string",
+          "format": "date-time",
+          "description": "ISO 8601 upper bound of the due-date filter."
+        }
+      },
+      {
+        "name": "createdAtStart",
+        "in": "query",
+        "required": false,
+        "description": "ISO 8601 lower bound of the created-date (\"date entered\") filter. Applies to every activity type.",
+        "schema": {
+          "type": "string",
+          "format": "date-time",
+          "description": "ISO 8601 lower bound of the created-date (\"date entered\") filter. Applies to every activity type."
+        }
+      },
+      {
+        "name": "createdAtEnd",
+        "in": "query",
+        "required": false,
+        "description": "ISO 8601 upper bound of the created-date (\"date entered\") filter.",
+        "schema": {
+          "type": "string",
+          "format": "date-time",
+          "description": "ISO 8601 upper bound of the created-date (\"date entered\") filter."
+        }
+      },
+      {
+        "name": "sortBy",
+        "in": "query",
+        "required": false,
+        "description": "Sort column. Omit for the default sort (priority high→low, then due date ascending).",
+        "schema": {
+          "type": "string",
+          "enum": [
+            "type",
+            "title",
+            "status",
+            "priority",
+            "dueDate"
+          ],
+          "description": "Sort column. Omit for the default sort (priority high→low, then due date ascending)."
+        }
+      },
+      {
+        "name": "sortDirection",
+        "in": "query",
+        "required": false,
+        "description": "Sort direction for `sortBy` (default asc). Ignored when `sortBy` is omitted.",
+        "schema": {
+          "type": "string",
+          "enum": [
+            "asc",
+            "desc"
+          ],
+          "description": "Sort direction for `sortBy` (default asc). Ignored when `sortBy` is omitted."
+        }
+      },
+      {
+        "name": "groupBy",
+        "in": "query",
+        "required": false,
+        "description": "When set, the response is grouped by this dimension (ActivityGroupedResponseV1) instead of the paginated list; `page`/`pageSize` are ignored. `priority` groups by the real per-tenant priority name (not the normalized bucket), so it is only meaningful when scoped to a single prioritized type.",
+        "schema": {
+          "type": "string",
+          "enum": [
+            "type",
+            "priority",
+            "status",
+            "dueDate"
+          ],
+          "description": "When set, the response is grouped by this dimension (ActivityGroupedResponseV1) instead of the paginated list; `page`/`pageSize` are ignored. `priority` groups by the real per-tenant priority name (not the normalized bucket), so it is only meaningful when scoped to a single prioritized type."
+        }
+      },
+      {
+        "name": "page",
+        "in": "query",
+        "required": false,
+        "description": "1-based page number (default 1). Ignored when `groupBy` is set.",
+        "schema": {
+          "type": "integer",
+          "minimum": 1,
+          "description": "1-based page number (default 1). Ignored when `groupBy` is set."
+        }
+      },
+      {
+        "name": "pageSize",
+        "in": "query",
+        "required": false,
+        "description": "Items per page, max 100 (default 25). Ignored when `groupBy` is set.",
+        "schema": {
+          "type": "integer",
+          "minimum": 1,
+          "maximum": 100,
+          "description": "Items per page, max 100 (default 25). Ignored when `groupBy` is set."
+        }
+      }
+    ],
+    "responseBodySchema": {
+      "type": "object",
+      "properties": {
+        "data": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "id": {
+                "type": "string"
+              },
+              "title": {
+                "type": "string"
+              },
+              "description": {
+                "type": "string"
+              },
+              "type": {
+                "type": "string",
+                "enum": [
+                  "schedule",
+                  "projectTask",
+                  "ticket",
+                  "timeEntry",
+                  "workflowTask",
+                  "notification",
+                  "document"
+                ]
+              },
+              "status": {
+                "type": "string"
+              },
+              "statusColor": {
+                "type": "string"
+              },
+              "priority": {
+                "type": "string",
+                "enum": [
+                  "low",
+                  "medium",
+                  "high"
+                ]
+              },
+              "priorityName": {
+                "type": "string"
+              },
+              "priorityColor": {
+                "type": "string"
+              },
+              "dueDate": {
+                "type": "string"
+              },
+              "startDate": {
+                "type": "string"
+              },
+              "endDate": {
+                "type": "string"
+              },
+              "assignedTo": {
+                "type": "array",
+                "items": {
+                  "type": "string"
+                }
+              },
+              "assignedToNames": {
+                "type": "array",
+                "items": {
+                  "type": "string"
+                }
+              },
+              "sourceId": {
+                "type": "string"
+              },
+              "sourceType": {
+                "type": "string",
+                "enum": [
+                  "schedule",
+                  "projectTask",
+                  "ticket",
+                  "timeEntry",
+                  "workflowTask",
+                  "notification",
+                  "document"
+                ]
+              },
+              "actions": {
+                "type": "array",
+                "items": {
+                  "type": "object",
+                  "properties": {
+                    "id": {
+                      "type": "string"
+                    },
+                    "label": {
+                      "type": "string"
+                    },
+                    "icon": {
+                      "type": "string"
+                    },
+                    "disabled": {
+                      "type": "boolean"
+                    },
+                    "disabledReason": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "id",
+                    "label"
+                  ]
+                }
+              },
+              "isClosed": {
+                "type": "boolean"
+              },
+              "tenant": {
+                "type": "string"
+              },
+              "createdAt": {
+                "type": "string"
+              },
+              "updatedAt": {
+                "type": "string"
+              }
+            },
+            "required": [
+              "id",
+              "title",
+              "type",
+              "status",
+              "priority",
+              "sourceId",
+              "sourceType",
+              "actions",
+              "tenant",
+              "createdAt",
+              "updatedAt"
+            ]
+          }
+        },
+        "pagination": {
+          "type": "object",
+          "properties": {
+            "page": {
+              "type": "number"
+            },
+            "limit": {
+              "type": "number"
+            },
+            "total": {
+              "type": "number"
+            },
+            "totalPages": {
+              "type": "number"
+            },
+            "hasNext": {
+              "type": "boolean"
+            },
+            "hasPrev": {
+              "type": "boolean"
+            }
+          },
+          "required": [
+            "page",
+            "limit",
+            "total",
+            "totalPages",
+            "hasNext",
+            "hasPrev"
+          ]
+        },
+        "meta": {}
+      },
+      "required": [
+        "data",
+        "pagination"
+      ]
+    },
+    "examples": [
+      {
+        "name": "My open ticket activities",
+        "request": {
+          "query": {
+            "type": "ticket",
+            "status": "open",
+            "pageSize": 50
+          }
+        },
+        "notes": "Returns the ticket activities the caller sees on their User Activities screen. Each activity's id is the ticket UUID, usable with GET /api/v1/tickets/{id}."
+      }
+    ]
+  },
+  {
+    "id": "post-_api_v1_activities_adhoc",
+    "method": "post",
+    "path": "/api/v1/activities/ad-hoc",
+    "displayName": "Create ad-hoc activity",
+    "summary": "Create ad-hoc activity",
+    "description": "Creates a personal, self-assigned ad-hoc to-do rendered as a schedule activity. Times are optional; when both are supplied the end must be after the start. Gated by `user_schedule:read`.",
+    "tags": [
+      "Activities v1"
+    ],
+    "approvalRequired": false,
+    "parameters": [],
+    "requestBodySchema": {
+      "type": "object",
+      "properties": {
+        "title": {
+          "type": "string",
+          "minLength": 1
+        },
+        "notes": {
+          "type": "string"
+        },
+        "scheduledStart": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "format": "date-time"
+        },
+        "scheduledEnd": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "format": "date-time"
+        }
+      },
+      "required": [
+        "title"
+      ]
+    },
+    "responseBodySchema": {
+      "type": "object",
+      "properties": {
+        "data": {
+          "type": "object",
+          "properties": {
+            "id": {
+              "type": "string"
+            },
+            "title": {
+              "type": "string"
+            },
+            "description": {
+              "type": "string"
+            },
+            "type": {
+              "type": "string",
+              "enum": [
+                "schedule",
+                "projectTask",
+                "ticket",
+                "timeEntry",
+                "workflowTask",
+                "notification",
+                "document"
+              ]
+            },
+            "status": {
+              "type": "string"
+            },
+            "statusColor": {
+              "type": "string"
+            },
+            "priority": {
+              "type": "string",
+              "enum": [
+                "low",
+                "medium",
+                "high"
+              ]
+            },
+            "priorityName": {
+              "type": "string"
+            },
+            "priorityColor": {
+              "type": "string"
+            },
+            "dueDate": {
+              "type": "string"
+            },
+            "startDate": {
+              "type": "string"
+            },
+            "endDate": {
+              "type": "string"
+            },
+            "assignedTo": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            },
+            "assignedToNames": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            },
+            "sourceId": {
+              "type": "string"
+            },
+            "sourceType": {
+              "type": "string",
+              "enum": [
+                "schedule",
+                "projectTask",
+                "ticket",
+                "timeEntry",
+                "workflowTask",
+                "notification",
+                "document"
+              ]
+            },
+            "actions": {
+              "type": "array",
+              "items": {
+                "type": "object",
+                "properties": {
+                  "id": {
+                    "type": "string"
+                  },
+                  "label": {
+                    "type": "string"
+                  },
+                  "icon": {
+                    "type": "string"
+                  },
+                  "disabled": {
+                    "type": "boolean"
+                  },
+                  "disabledReason": {
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "id",
+                  "label"
+                ]
+              }
+            },
+            "isClosed": {
+              "type": "boolean"
+            },
+            "tenant": {
+              "type": "string"
+            },
+            "createdAt": {
+              "type": "string"
+            },
+            "updatedAt": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "id",
+            "title",
+            "type",
+            "status",
+            "priority",
+            "sourceId",
+            "sourceType",
+            "actions",
+            "tenant",
+            "createdAt",
+            "updatedAt"
+          ]
+        },
+        "meta": {}
+      },
+      "required": [
+        "data"
+      ]
+    }
+  },
+  {
+    "id": "patch-_api_v1_activities_adhoc_id",
+    "method": "patch",
+    "path": "/api/v1/activities/ad-hoc/{id}",
+    "displayName": "Update ad-hoc activity",
+    "summary": "Update ad-hoc activity",
+    "description": "Updates an ad-hoc item's title, notes or optional times. Omitted fields are left unchanged; `notes: null` clears the field. Requires the caller to be an assignee, or hold `user_schedule:update` / `user_schedule:read_all`.",
+    "tags": [
+      "Activities v1"
+    ],
+    "approvalRequired": false,
+    "parameters": [
+      {
+        "name": "id",
+        "in": "path",
+        "required": true,
+        "description": "Ad-hoc activity identifier (the backing schedule entry id).",
+        "schema": {
+          "type": "string",
+          "description": "Ad-hoc activity identifier (the backing schedule entry id)."
+        }
+      }
+    ],
+    "requestBodySchema": {
+      "type": "object",
+      "properties": {
+        "title": {
+          "type": "string",
+          "minLength": 1
+        },
+        "notes": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "scheduledStart": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "format": "date-time"
+        },
+        "scheduledEnd": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "format": "date-time"
+        }
+      }
+    },
+    "responseBodySchema": {
+      "type": "object",
+      "properties": {
+        "data": {
+          "type": "object",
+          "properties": {
+            "id": {
+              "type": "string"
+            },
+            "title": {
+              "type": "string"
+            },
+            "description": {
+              "type": "string"
+            },
+            "type": {
+              "type": "string",
+              "enum": [
+                "schedule",
+                "projectTask",
+                "ticket",
+                "timeEntry",
+                "workflowTask",
+                "notification",
+                "document"
+              ]
+            },
+            "status": {
+              "type": "string"
+            },
+            "statusColor": {
+              "type": "string"
+            },
+            "priority": {
+              "type": "string",
+              "enum": [
+                "low",
+                "medium",
+                "high"
+              ]
+            },
+            "priorityName": {
+              "type": "string"
+            },
+            "priorityColor": {
+              "type": "string"
+            },
+            "dueDate": {
+              "type": "string"
+            },
+            "startDate": {
+              "type": "string"
+            },
+            "endDate": {
+              "type": "string"
+            },
+            "assignedTo": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            },
+            "assignedToNames": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            },
+            "sourceId": {
+              "type": "string"
+            },
+            "sourceType": {
+              "type": "string",
+              "enum": [
+                "schedule",
+                "projectTask",
+                "ticket",
+                "timeEntry",
+                "workflowTask",
+                "notification",
+                "document"
+              ]
+            },
+            "actions": {
+              "type": "array",
+              "items": {
+                "type": "object",
+                "properties": {
+                  "id": {
+                    "type": "string"
+                  },
+                  "label": {
+                    "type": "string"
+                  },
+                  "icon": {
+                    "type": "string"
+                  },
+                  "disabled": {
+                    "type": "boolean"
+                  },
+                  "disabledReason": {
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "id",
+                  "label"
+                ]
+              }
+            },
+            "isClosed": {
+              "type": "boolean"
+            },
+            "tenant": {
+              "type": "string"
+            },
+            "createdAt": {
+              "type": "string"
+            },
+            "updatedAt": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "id",
+            "title",
+            "type",
+            "status",
+            "priority",
+            "sourceId",
+            "sourceType",
+            "actions",
+            "tenant",
+            "createdAt",
+            "updatedAt"
+          ]
+        },
+        "meta": {}
+      },
+      "required": [
+        "data"
+      ]
+    }
+  },
+  {
+    "id": "delete-_api_v1_activities_adhoc_id",
+    "method": "delete",
+    "path": "/api/v1/activities/ad-hoc/{id}",
+    "displayName": "Delete ad-hoc activity",
+    "summary": "Delete ad-hoc activity",
+    "description": "Permanently deletes an ad-hoc item. Requires the caller to be an assignee, or hold `user_schedule:update` / `user_schedule:read_all`.",
+    "tags": [
+      "Activities v1"
+    ],
+    "approvalRequired": false,
+    "parameters": [
+      {
+        "name": "id",
+        "in": "path",
+        "required": true,
+        "description": "Ad-hoc activity identifier (the backing schedule entry id).",
+        "schema": {
+          "type": "string",
+          "description": "Ad-hoc activity identifier (the backing schedule entry id)."
+        }
+      }
+    ]
+  },
+  {
+    "id": "post-_api_v1_activities_adhoc_id_done",
+    "method": "post",
+    "path": "/api/v1/activities/ad-hoc/{id}/done",
+    "displayName": "Toggle ad-hoc activity done",
+    "summary": "Toggle ad-hoc activity done",
+    "description": "Marks an ad-hoc item done/undone. `done: true` sets status to closed; `done: false` reopens it (status scheduled). Requires the caller to be an assignee, or hold `user_schedule:update` / `user_schedule:read_all`.",
+    "tags": [
+      "Activities v1"
+    ],
+    "approvalRequired": false,
+    "parameters": [
+      {
+        "name": "id",
+        "in": "path",
+        "required": true,
+        "description": "Ad-hoc activity identifier (the backing schedule entry id).",
+        "schema": {
+          "type": "string",
+          "description": "Ad-hoc activity identifier (the backing schedule entry id)."
+        }
+      }
+    ],
+    "requestBodySchema": {
+      "type": "object",
+      "properties": {
+        "done": {
+          "type": "boolean"
+        }
+      },
+      "required": [
+        "done"
+      ]
+    },
+    "responseBodySchema": {
+      "type": "object",
+      "properties": {
+        "data": {
+          "type": "object",
+          "properties": {
+            "id": {
+              "type": "string"
+            },
+            "title": {
+              "type": "string"
+            },
+            "description": {
+              "type": "string"
+            },
+            "type": {
+              "type": "string",
+              "enum": [
+                "schedule",
+                "projectTask",
+                "ticket",
+                "timeEntry",
+                "workflowTask",
+                "notification",
+                "document"
+              ]
+            },
+            "status": {
+              "type": "string"
+            },
+            "statusColor": {
+              "type": "string"
+            },
+            "priority": {
+              "type": "string",
+              "enum": [
+                "low",
+                "medium",
+                "high"
+              ]
+            },
+            "priorityName": {
+              "type": "string"
+            },
+            "priorityColor": {
+              "type": "string"
+            },
+            "dueDate": {
+              "type": "string"
+            },
+            "startDate": {
+              "type": "string"
+            },
+            "endDate": {
+              "type": "string"
+            },
+            "assignedTo": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            },
+            "assignedToNames": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            },
+            "sourceId": {
+              "type": "string"
+            },
+            "sourceType": {
+              "type": "string",
+              "enum": [
+                "schedule",
+                "projectTask",
+                "ticket",
+                "timeEntry",
+                "workflowTask",
+                "notification",
+                "document"
+              ]
+            },
+            "actions": {
+              "type": "array",
+              "items": {
+                "type": "object",
+                "properties": {
+                  "id": {
+                    "type": "string"
+                  },
+                  "label": {
+                    "type": "string"
+                  },
+                  "icon": {
+                    "type": "string"
+                  },
+                  "disabled": {
+                    "type": "boolean"
+                  },
+                  "disabledReason": {
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "id",
+                  "label"
+                ]
+              }
+            },
+            "isClosed": {
+              "type": "boolean"
+            },
+            "tenant": {
+              "type": "string"
+            },
+            "createdAt": {
+              "type": "string"
+            },
+            "updatedAt": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "id",
+            "title",
+            "type",
+            "status",
+            "priority",
+            "sourceId",
+            "sourceType",
+            "actions",
+            "tenant",
+            "createdAt",
+            "updatedAt"
+          ]
+        },
+        "meta": {}
+      },
+      "required": [
+        "data"
+      ]
+    }
+  },
+  {
+    "id": "get-_api_v1_activities_groups",
+    "method": "get",
+    "path": "/api/v1/activities/groups",
+    "displayName": "List My Activity Groups",
+    "summary": "Fetch the caller's named custom groups from the User Activities screen",
+    "description": "Returns the personal, user-defined groups the caller created on the User Activities screen (for example a group named \"Basics\"), each with its ordered items. Items are references: { activityId, activityType, sortOrder } — for activityType \"ticket\" the activityId is the ticket UUID. To answer \"what tickets are in my <name> group\": call this endpoint, find the group by groupName (case-insensitive match on what the user said), then resolve each item, e.g. ticket items via GET /api/v1/tickets/{id} or by matching ids against GET /api/v1/activities. Groups are per-user; pass targetUserId only to read another internal user's groups (requires user_schedule:update or user_schedule:read_all).",
+    "tags": [
+      "Activities v1"
+    ],
+    "approvalRequired": false,
+    "parameters": [
+      {
+        "name": "targetUserId",
+        "in": "query",
+        "required": false,
+        "description": "Another internal user whose groups to read (requires elevated schedule permission). Omit for self.",
+        "schema": {
+          "type": "string",
+          "description": "Another internal user whose groups to read (requires elevated schedule permission). Omit for self."
+        }
+      }
+    ],
+    "responseBodySchema": {
+      "type": "object",
+      "properties": {
+        "data": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "groupId": {
+                "type": "string"
+              },
+              "groupName": {
+                "type": "string"
+              },
+              "sortOrder": {
+                "type": "number"
+              },
+              "isCollapsed": {
+                "type": "boolean"
+              },
+              "items": {
+                "type": "array",
+                "items": {
+                  "type": "object",
+                  "properties": {
+                    "itemId": {
+                      "type": "string"
+                    },
+                    "activityId": {
+                      "type": "string"
+                    },
+                    "activityType": {
+                      "type": "string"
+                    },
+                    "sortOrder": {
+                      "type": "number"
+                    }
+                  },
+                  "required": [
+                    "itemId",
+                    "activityId",
+                    "activityType",
+                    "sortOrder"
+                  ]
+                }
+              }
+            },
+            "required": [
+              "groupId",
+              "groupName",
+              "sortOrder",
+              "isCollapsed",
+              "items"
+            ]
+          }
+        },
+        "meta": {}
+      },
+      "required": [
+        "data"
+      ]
+    },
+    "examples": [
+      {
+        "name": "What is in my \"Basics\" group?",
+        "request": {},
+        "notes": "Find the entry whose groupName is \"Basics\" in the response, then look up each item: for activityType \"ticket\" call GET /api/v1/tickets/{activityId} (or filter a GET /api/v1/activities?type=ticket result by the collected ids) to get titles and statuses."
+      }
+    ]
+  },
+  {
+    "id": "post-_api_v1_activities_groups_items",
+    "method": "post",
+    "path": "/api/v1/activities/groups/items",
+    "displayName": "Move Activity Into My Group",
+    "summary": "Put one of the caller's activities into one of their custom groups",
+    "description": "Moves an activity into one of the caller's own User Activities groups at the given sortOrder position, removing it from any other of their groups first (an activity lives in at most one group). Get groupId values from GET /api/v1/activities/groups. Only organizes the caller's own view — it never changes the underlying ticket/task.",
+    "tags": [
+      "Activities v1"
+    ],
+    "approvalRequired": false,
+    "parameters": [],
+    "requestBodySchema": {
+      "type": "object",
+      "properties": {
+        "activityId": {
+          "type": "string",
+          "minLength": 1
+        },
+        "activityType": {
+          "type": "string",
+          "minLength": 1
+        },
+        "groupId": {
+          "type": "string",
+          "minLength": 1
+        },
+        "sortOrder": {
+          "type": "integer",
+          "minimum": 0
+        }
+      },
+      "required": [
+        "activityId",
+        "activityType",
+        "groupId",
+        "sortOrder"
+      ]
+    }
+  },
+  {
+    "id": "delete-_api_v1_activities_groups_items",
+    "method": "delete",
+    "path": "/api/v1/activities/groups/items",
+    "displayName": "Remove Activity From My Groups",
+    "summary": "Make one of the caller's activities ungrouped",
+    "description": "Removes an activity from all of the caller's User Activities groups so it shows as ungrouped. No-op when the activity is not in any group. Only affects the caller's own view.",
+    "tags": [
+      "Activities v1"
+    ],
+    "approvalRequired": false,
+    "parameters": [],
+    "requestBodySchema": {
+      "type": "object",
+      "properties": {
+        "activityId": {
+          "type": "string",
+          "minLength": 1
+        },
+        "activityType": {
+          "type": "string",
+          "minLength": 1
+        }
+      },
+      "required": [
+        "activityId",
+        "activityType"
+      ]
+    }
+  },
+  {
+    "id": "patch-_api_v1_activities_groups_groupid_items",
+    "method": "patch",
+    "path": "/api/v1/activities/groups/{groupId}/items",
+    "displayName": "Reorder My Group's Activities",
+    "summary": "Persist a new ordering of the activities inside one of the caller's groups",
+    "description": "Replaces the ordering of a group's members: pass every item with its new sortOrder (position). Scoped to the caller's own groups from GET /api/v1/activities/groups.",
+    "tags": [
+      "Activities v1"
+    ],
+    "approvalRequired": false,
+    "parameters": [
+      {
+        "name": "groupId",
+        "in": "path",
+        "required": true,
+        "description": "Custom activity group identifier.",
+        "schema": {
+          "type": "string",
+          "description": "Custom activity group identifier."
+        }
+      }
+    ],
+    "requestBodySchema": {
+      "type": "object",
+      "properties": {
+        "items": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "activityId": {
+                "type": "string",
+                "minLength": 1
+              },
+              "activityType": {
+                "type": "string",
+                "minLength": 1
+              },
+              "sortOrder": {
+                "type": "integer",
+                "minimum": 0
+              }
+            },
+            "required": [
+              "activityId",
+              "activityType",
+              "sortOrder"
+            ]
+          },
+          "minItems": 1
+        }
+      },
+      "required": [
+        "items"
+      ]
+    }
   },
   {
     "id": "get-_api_v1_projects_id_taskstatusmappings",
@@ -52704,6 +54290,23 @@ export const chatApiRegistry: ChatApiRegistryEntry[] = [
     }
   },
   {
+    "id": "get-_api_auth_captchaconfig",
+    "method": "get",
+    "path": "/api/auth/captcha-config",
+    "displayName": "GET auth",
+    "summary": "GET auth",
+    "description": "This operation was generated automatically from the route inventory. Replace with canonical OpenAPI metadata.",
+    "tags": [
+      "auth"
+    ],
+    "approvalRequired": false,
+    "parameters": [],
+    "responseBodySchema": {
+      "type": "object",
+      "properties": {}
+    }
+  },
+  {
     "id": "get-_api_auth_e2e_google_authorize",
     "method": "get",
     "path": "/api/auth/e2e/google/authorize",
@@ -52979,6 +54582,111 @@ export const chatApiRegistry: ChatApiRegistryEntry[] = [
     ],
     "approvalRequired": false,
     "parameters": [],
+    "responseBodySchema": {
+      "type": "object",
+      "properties": {}
+    }
+  },
+  {
+    "id": "post-_api_billing_completereactivation",
+    "method": "post",
+    "path": "/api/billing/complete-reactivation",
+    "displayName": "POST billing",
+    "summary": "POST billing",
+    "description": "This operation was generated automatically from the route inventory. Replace with canonical OpenAPI metadata.",
+    "tags": [
+      "billing"
+    ],
+    "approvalRequired": false,
+    "parameters": [],
+    "requestBodySchema": {
+      "type": "object",
+      "properties": {}
+    },
+    "responseBodySchema": {
+      "type": "object",
+      "properties": {}
+    }
+  },
+  {
+    "id": "post-_api_billing_reactivationpasswordreset",
+    "method": "post",
+    "path": "/api/billing/reactivation-password-reset",
+    "displayName": "POST billing",
+    "summary": "POST billing",
+    "description": "This operation was generated automatically from the route inventory. Replace with canonical OpenAPI metadata.",
+    "tags": [
+      "billing"
+    ],
+    "approvalRequired": false,
+    "parameters": [],
+    "requestBodySchema": {
+      "type": "object",
+      "properties": {}
+    },
+    "responseBodySchema": {
+      "type": "object",
+      "properties": {}
+    }
+  },
+  {
+    "id": "post-_api_billing_reactivationtoken",
+    "method": "post",
+    "path": "/api/billing/reactivation-token",
+    "displayName": "POST billing",
+    "summary": "POST billing",
+    "description": "This operation was generated automatically from the route inventory. Replace with canonical OpenAPI metadata.",
+    "tags": [
+      "billing"
+    ],
+    "approvalRequired": false,
+    "parameters": [],
+    "requestBodySchema": {
+      "type": "object",
+      "properties": {}
+    },
+    "responseBodySchema": {
+      "type": "object",
+      "properties": {}
+    }
+  },
+  {
+    "id": "post-_api_billing_reactivationtoken_session",
+    "method": "post",
+    "path": "/api/billing/reactivation-token/session",
+    "displayName": "POST billing",
+    "summary": "POST billing",
+    "description": "This operation was generated automatically from the route inventory. Replace with canonical OpenAPI metadata.",
+    "tags": [
+      "billing"
+    ],
+    "approvalRequired": false,
+    "parameters": [],
+    "requestBodySchema": {
+      "type": "object",
+      "properties": {}
+    },
+    "responseBodySchema": {
+      "type": "object",
+      "properties": {}
+    }
+  },
+  {
+    "id": "post-_api_billing_requestreactivation",
+    "method": "post",
+    "path": "/api/billing/request-reactivation",
+    "displayName": "POST billing",
+    "summary": "POST billing",
+    "description": "This operation was generated automatically from the route inventory. Replace with canonical OpenAPI metadata.",
+    "tags": [
+      "billing"
+    ],
+    "approvalRequired": false,
+    "parameters": [],
+    "requestBodySchema": {
+      "type": "object",
+      "properties": {}
+    },
     "responseBodySchema": {
       "type": "object",
       "properties": {}
@@ -54058,6 +55766,23 @@ export const chatApiRegistry: ChatApiRegistryEntry[] = [
     }
   },
   {
+    "id": "get-_api_integrations_hudu",
+    "method": "get",
+    "path": "/api/integrations/hudu",
+    "displayName": "GET integrations",
+    "summary": "GET integrations",
+    "description": "This operation was generated automatically from the route inventory. Replace with canonical OpenAPI metadata.",
+    "tags": [
+      "integrations"
+    ],
+    "approvalRequired": false,
+    "parameters": [],
+    "responseBodySchema": {
+      "type": "object",
+      "properties": {}
+    }
+  },
+  {
     "id": "get-_api_integrations_ninjaone_callback",
     "method": "get",
     "path": "/api/integrations/ninjaone/callback",
@@ -54317,6 +56042,124 @@ export const chatApiRegistry: ChatApiRegistryEntry[] = [
         }
       }
     ],
+    "requestBodySchema": {
+      "type": "object",
+      "properties": {}
+    },
+    "responseBodySchema": {
+      "type": "object",
+      "properties": {}
+    }
+  },
+  {
+    "id": "get-_api_mcp",
+    "method": "get",
+    "path": "/api/mcp",
+    "displayName": "GET mcp",
+    "summary": "GET mcp",
+    "description": "This operation was generated automatically from the route inventory. Replace with canonical OpenAPI metadata.",
+    "tags": [
+      "mcp"
+    ],
+    "approvalRequired": false,
+    "parameters": [],
+    "responseBodySchema": {
+      "type": "object",
+      "properties": {}
+    }
+  },
+  {
+    "id": "post-_api_mcp",
+    "method": "post",
+    "path": "/api/mcp",
+    "displayName": "POST mcp",
+    "summary": "POST mcp",
+    "description": "This operation was generated automatically from the route inventory. Replace with canonical OpenAPI metadata.",
+    "tags": [
+      "mcp"
+    ],
+    "approvalRequired": false,
+    "parameters": [],
+    "requestBodySchema": {
+      "type": "object",
+      "properties": {}
+    },
+    "responseBodySchema": {
+      "type": "object",
+      "properties": {}
+    }
+  },
+  {
+    "id": "get-_api_mcp_oauth_authorize",
+    "method": "get",
+    "path": "/api/mcp/oauth/authorize",
+    "displayName": "GET mcp",
+    "summary": "GET mcp",
+    "description": "This operation was generated automatically from the route inventory. Replace with canonical OpenAPI metadata.",
+    "tags": [
+      "mcp"
+    ],
+    "approvalRequired": false,
+    "parameters": [],
+    "responseBodySchema": {
+      "type": "object",
+      "properties": {}
+    }
+  },
+  {
+    "id": "post-_api_mcp_oauth_authorize",
+    "method": "post",
+    "path": "/api/mcp/oauth/authorize",
+    "displayName": "POST mcp",
+    "summary": "POST mcp",
+    "description": "This operation was generated automatically from the route inventory. Replace with canonical OpenAPI metadata.",
+    "tags": [
+      "mcp"
+    ],
+    "approvalRequired": false,
+    "parameters": [],
+    "requestBodySchema": {
+      "type": "object",
+      "properties": {}
+    },
+    "responseBodySchema": {
+      "type": "object",
+      "properties": {}
+    }
+  },
+  {
+    "id": "post-_api_mcp_oauth_revoke",
+    "method": "post",
+    "path": "/api/mcp/oauth/revoke",
+    "displayName": "POST mcp",
+    "summary": "POST mcp",
+    "description": "This operation was generated automatically from the route inventory. Replace with canonical OpenAPI metadata.",
+    "tags": [
+      "mcp"
+    ],
+    "approvalRequired": false,
+    "parameters": [],
+    "requestBodySchema": {
+      "type": "object",
+      "properties": {}
+    },
+    "responseBodySchema": {
+      "type": "object",
+      "properties": {}
+    }
+  },
+  {
+    "id": "post-_api_mcp_oauth_token",
+    "method": "post",
+    "path": "/api/mcp/oauth/token",
+    "displayName": "POST mcp",
+    "summary": "POST mcp",
+    "description": "This operation was generated automatically from the route inventory. Replace with canonical OpenAPI metadata.",
+    "tags": [
+      "mcp"
+    ],
+    "approvalRequired": false,
+    "parameters": [],
     "requestBodySchema": {
       "type": "object",
       "properties": {}
@@ -54825,6 +56668,341 @@ export const chatApiRegistry: ChatApiRegistryEntry[] = [
         }
       }
     ],
+    "responseBodySchema": {
+      "type": "object",
+      "properties": {}
+    }
+  },
+  {
+    "id": "get-_api_v1_applianceinstalls",
+    "method": "get",
+    "path": "/api/v1/appliance-installs",
+    "displayName": "GET v1",
+    "summary": "GET v1",
+    "description": "This operation was generated automatically from the route inventory. Replace with canonical OpenAPI metadata.",
+    "tags": [
+      "appliance-installs"
+    ],
+    "approvalRequired": false,
+    "parameters": [],
+    "responseBodySchema": {
+      "type": "object",
+      "properties": {}
+    }
+  },
+  {
+    "id": "post-_api_v1_applianceinstalls_access",
+    "method": "post",
+    "path": "/api/v1/appliance-installs/access",
+    "displayName": "POST v1",
+    "summary": "POST v1",
+    "description": "This operation was generated automatically from the route inventory. Replace with canonical OpenAPI metadata.",
+    "tags": [
+      "appliance-installs"
+    ],
+    "approvalRequired": false,
+    "parameters": [],
+    "requestBodySchema": {
+      "type": "object",
+      "properties": {}
+    },
+    "responseBodySchema": {
+      "type": "object",
+      "properties": {}
+    }
+  },
+  {
+    "id": "get-_api_v1_applianceinstalls_tenantid",
+    "method": "get",
+    "path": "/api/v1/appliance-installs/{tenantId}",
+    "displayName": "GET v1",
+    "summary": "GET v1",
+    "tags": [
+      "appliance-installs"
+    ],
+    "approvalRequired": false,
+    "parameters": [
+      {
+        "name": "tenantId",
+        "in": "path",
+        "required": true,
+        "description": "TenantId path parameter.",
+        "schema": {
+          "type": "string"
+        }
+      }
+    ],
+    "responseBodySchema": {
+      "type": "object",
+      "properties": {}
+    }
+  },
+  {
+    "id": "get-_api_v1_mcp_agents",
+    "method": "get",
+    "path": "/api/v1/mcp/agents",
+    "displayName": "GET v1",
+    "summary": "GET v1",
+    "description": "This operation was generated automatically from the route inventory. Replace with canonical OpenAPI metadata.",
+    "tags": [
+      "mcp"
+    ],
+    "approvalRequired": false,
+    "parameters": [],
+    "responseBodySchema": {
+      "type": "object",
+      "properties": {}
+    }
+  },
+  {
+    "id": "post-_api_v1_mcp_agents",
+    "method": "post",
+    "path": "/api/v1/mcp/agents",
+    "displayName": "POST v1",
+    "summary": "POST v1",
+    "description": "This operation was generated automatically from the route inventory. Replace with canonical OpenAPI metadata.",
+    "tags": [
+      "mcp"
+    ],
+    "approvalRequired": false,
+    "parameters": [],
+    "requestBodySchema": {
+      "type": "object",
+      "properties": {}
+    },
+    "responseBodySchema": {
+      "type": "object",
+      "properties": {}
+    }
+  },
+  {
+    "id": "patch-_api_v1_mcp_agents",
+    "method": "patch",
+    "path": "/api/v1/mcp/agents",
+    "displayName": "PATCH v1",
+    "summary": "PATCH v1",
+    "description": "This operation was generated automatically from the route inventory. Replace with canonical OpenAPI metadata.",
+    "tags": [
+      "mcp"
+    ],
+    "approvalRequired": false,
+    "parameters": [],
+    "requestBodySchema": {
+      "type": "object",
+      "properties": {}
+    },
+    "responseBodySchema": {
+      "type": "object",
+      "properties": {}
+    }
+  },
+  {
+    "id": "delete-_api_v1_mcp_agents",
+    "method": "delete",
+    "path": "/api/v1/mcp/agents",
+    "displayName": "DELETE v1",
+    "summary": "DELETE v1",
+    "description": "This operation was generated automatically from the route inventory. Replace with canonical OpenAPI metadata.",
+    "tags": [
+      "mcp"
+    ],
+    "approvalRequired": false,
+    "parameters": [],
+    "responseBodySchema": {
+      "type": "object",
+      "properties": {}
+    }
+  },
+  {
+    "id": "get-_api_v1_mcp_audit",
+    "method": "get",
+    "path": "/api/v1/mcp/audit",
+    "displayName": "GET v1",
+    "summary": "GET v1",
+    "description": "This operation was generated automatically from the route inventory. Replace with canonical OpenAPI metadata.",
+    "tags": [
+      "mcp"
+    ],
+    "approvalRequired": false,
+    "parameters": [],
+    "responseBodySchema": {
+      "type": "object",
+      "properties": {}
+    }
+  },
+  {
+    "id": "get-_api_v1_mcp_connect_callback",
+    "method": "get",
+    "path": "/api/v1/mcp/connect/callback",
+    "displayName": "GET v1",
+    "summary": "GET v1",
+    "description": "This operation was generated automatically from the route inventory. Replace with canonical OpenAPI metadata.",
+    "tags": [
+      "mcp"
+    ],
+    "approvalRequired": false,
+    "parameters": [],
+    "responseBodySchema": {
+      "type": "object",
+      "properties": {}
+    }
+  },
+  {
+    "id": "post-_api_v1_mcp_connect_start",
+    "method": "post",
+    "path": "/api/v1/mcp/connect/start",
+    "displayName": "POST v1",
+    "summary": "POST v1",
+    "description": "This operation was generated automatically from the route inventory. Replace with canonical OpenAPI metadata.",
+    "tags": [
+      "mcp"
+    ],
+    "approvalRequired": false,
+    "parameters": [],
+    "requestBodySchema": {
+      "type": "object",
+      "properties": {}
+    },
+    "responseBodySchema": {
+      "type": "object",
+      "properties": {}
+    }
+  },
+  {
+    "id": "get-_api_v1_mcp_connections",
+    "method": "get",
+    "path": "/api/v1/mcp/connections",
+    "displayName": "GET v1",
+    "summary": "GET v1",
+    "description": "This operation was generated automatically from the route inventory. Replace with canonical OpenAPI metadata.",
+    "tags": [
+      "mcp"
+    ],
+    "approvalRequired": false,
+    "parameters": [],
+    "responseBodySchema": {
+      "type": "object",
+      "properties": {}
+    }
+  },
+  {
+    "id": "delete-_api_v1_mcp_connections",
+    "method": "delete",
+    "path": "/api/v1/mcp/connections",
+    "displayName": "DELETE v1",
+    "summary": "DELETE v1",
+    "description": "This operation was generated automatically from the route inventory. Replace with canonical OpenAPI metadata.",
+    "tags": [
+      "mcp"
+    ],
+    "approvalRequired": false,
+    "parameters": [],
+    "responseBodySchema": {
+      "type": "object",
+      "properties": {}
+    }
+  },
+  {
+    "id": "get-_api_v1_mcp_idpproviders",
+    "method": "get",
+    "path": "/api/v1/mcp/idp-providers",
+    "displayName": "GET v1",
+    "summary": "GET v1",
+    "description": "This operation was generated automatically from the route inventory. Replace with canonical OpenAPI metadata.",
+    "tags": [
+      "mcp"
+    ],
+    "approvalRequired": false,
+    "parameters": [],
+    "responseBodySchema": {
+      "type": "object",
+      "properties": {}
+    }
+  },
+  {
+    "id": "post-_api_v1_mcp_idpproviders",
+    "method": "post",
+    "path": "/api/v1/mcp/idp-providers",
+    "displayName": "POST v1",
+    "summary": "POST v1",
+    "description": "This operation was generated automatically from the route inventory. Replace with canonical OpenAPI metadata.",
+    "tags": [
+      "mcp"
+    ],
+    "approvalRequired": false,
+    "parameters": [],
+    "requestBodySchema": {
+      "type": "object",
+      "properties": {}
+    },
+    "responseBodySchema": {
+      "type": "object",
+      "properties": {}
+    }
+  },
+  {
+    "id": "get-_api_v1_mcp_idpsuggestions",
+    "method": "get",
+    "path": "/api/v1/mcp/idp-suggestions",
+    "displayName": "GET v1",
+    "summary": "GET v1",
+    "description": "This operation was generated automatically from the route inventory. Replace with canonical OpenAPI metadata.",
+    "tags": [
+      "mcp"
+    ],
+    "approvalRequired": false,
+    "parameters": [],
+    "responseBodySchema": {
+      "type": "object",
+      "properties": {}
+    }
+  },
+  {
+    "id": "get-_api_v1_mcp_platformproviders",
+    "method": "get",
+    "path": "/api/v1/mcp/platform-providers",
+    "displayName": "GET v1",
+    "summary": "GET v1",
+    "description": "This operation was generated automatically from the route inventory. Replace with canonical OpenAPI metadata.",
+    "tags": [
+      "mcp"
+    ],
+    "approvalRequired": false,
+    "parameters": [],
+    "responseBodySchema": {
+      "type": "object",
+      "properties": {}
+    }
+  },
+  {
+    "id": "get-_api_v1_mcp_roles",
+    "method": "get",
+    "path": "/api/v1/mcp/roles",
+    "displayName": "GET v1",
+    "summary": "GET v1",
+    "description": "This operation was generated automatically from the route inventory. Replace with canonical OpenAPI metadata.",
+    "tags": [
+      "mcp"
+    ],
+    "approvalRequired": false,
+    "parameters": [],
+    "responseBodySchema": {
+      "type": "object",
+      "properties": {}
+    }
+  },
+  {
+    "id": "get-_api_v1_meta_mcpregistry",
+    "method": "get",
+    "path": "/api/v1/meta/mcp-registry",
+    "displayName": "GET v1",
+    "summary": "GET v1",
+    "description": "This operation was generated automatically from the route inventory. Replace with canonical OpenAPI metadata.",
+    "tags": [
+      "meta"
+    ],
+    "approvalRequired": false,
+    "parameters": [],
     "responseBodySchema": {
       "type": "object",
       "properties": {}
@@ -56648,6 +58826,65 @@ export const chatApiRegistry: ChatApiRegistryEntry[] = [
         }
       }
     ],
+    "requestBodySchema": {
+      "type": "object",
+      "properties": {}
+    },
+    "responseBodySchema": {
+      "type": "object",
+      "properties": {}
+    }
+  },
+  {
+    "id": "get-_api_webhooks_alternativepayments",
+    "method": "get",
+    "path": "/api/webhooks/alternative-payments",
+    "displayName": "GET webhooks",
+    "summary": "GET webhooks",
+    "description": "This operation was generated automatically from the route inventory. Replace with canonical OpenAPI metadata.",
+    "tags": [
+      "webhooks"
+    ],
+    "approvalRequired": false,
+    "parameters": [],
+    "responseBodySchema": {
+      "type": "object",
+      "properties": {}
+    }
+  },
+  {
+    "id": "post-_api_webhooks_alternativepayments",
+    "method": "post",
+    "path": "/api/webhooks/alternative-payments",
+    "displayName": "POST webhooks",
+    "summary": "POST webhooks",
+    "description": "This operation was generated automatically from the route inventory. Replace with canonical OpenAPI metadata.",
+    "tags": [
+      "webhooks"
+    ],
+    "approvalRequired": false,
+    "parameters": [],
+    "requestBodySchema": {
+      "type": "object",
+      "properties": {}
+    },
+    "responseBodySchema": {
+      "type": "object",
+      "properties": {}
+    }
+  },
+  {
+    "id": "post-_api_webhooks_levelio",
+    "method": "post",
+    "path": "/api/webhooks/levelio",
+    "displayName": "POST webhooks",
+    "summary": "POST webhooks",
+    "description": "This operation was generated automatically from the route inventory. Replace with canonical OpenAPI metadata.",
+    "tags": [
+      "webhooks"
+    ],
+    "approvalRequired": false,
+    "parameters": [],
     "requestBodySchema": {
       "type": "object",
       "properties": {}


### PR DESCRIPTION
## Why

The `/api/v1/activities` endpoints (unified activity list, custom activity groups, group membership mutations) shipped with the mobile User Activities feature, but never appeared in the MCP chat registry — `search_api_registry` couldn't find them, so agents had no way to answer questions like "what tickets are in my *Basics* group on my User Activities screen".

## Root cause

`registerActivitiesV1Routes` put a **live Zod schema object** into `extensions['x-response-when-grouped']`. Extensions are serialized verbatim into the OpenAPI document, and the YAML emitter throws `Tag not resolved for AsyncFunction value` on the schema's internal functions — so `openapi:generate` crashed and **all** generated artifacts (route inventory, OpenAPI specs, CE/EE chat registries) went stale, not just the activities entries.

## Changes

- **Fix** `server/src/lib/api/openapi/routes/activitiesV1.ts`: reference the grouped-response component by `$ref` string instead of embedding the Zod schema (7-line diff — the only hand-written source change).
- **Add** `ee/docs/api-registry/activities.json`: MCP-facing overrides for the 5 activities/groups endpoints — display names, agent-oriented descriptions, and a worked example/playbook for resolving "what is in my named group" (list groups → match `groupName` → resolve ticket items via `GET /api/v1/tickets/{id}`).
- **Regenerate** (per the documented pipeline: `generate_route_inventory.py` → `openapi:generate` (ce+ee) → `mcp:registry:generate`):
  - `docs/openapi/route-inventory.{json,csv}` (777 routes)
  - `sdk/docs/openapi/alga-openapi.{ce,ee}.{json,yaml}` + legacy `alga-openapi.{json,yaml}` (CE 991 / EE 1008 routes)
  - `server/src/lib/mcp/registry.generated.ts` (CE, 936 entries) and `ee/server/src/chat/registry/apiRegistry.generated.ts` (EE, 958 entries); generator validated CE ⊆ EE

The generated-file diff is large because regeneration had been broken for a while — it picks up every route that landed since the last successful run, not just activities.

## Verification

- `openapi:generate` completes for both editions (previously crashed).
- All 9 activities entries present in the CE registry with override metadata applied (`get-_api_v1_activities`, `get-_api_v1_activities_groups`, ad-hoc + group-item mutations).
- `vitest run` green: `ApiMetadataController.docs.test.ts`, `MetadataService.test.ts`, `apiMetadataController.productFiltering.contract.test.ts` (10 tests).

https://claude.ai/code/session_01Lqm22nX6EzDY1pESSoQqH8