### PR TITLE
fix(i18n): correct pt-BR "Citar" → "Cotação" for the quote noun

### DIFF
--- a/server/public/locales/pt/features/billing.json
+++ b/server/public/locales/pt/features/billing.json
@@ -151,7 +151,7 @@
     }
   },
   "quoteForm": {
-    "noticeTitle": "Citar",
+    "noticeTitle": "Cotação",
     "readOnlyNotice": "Esta orçamento é somente leitura. Para fazer alterações, crie uma nova revisão.",
     "breadcrumb": {
       "billing": "Faturamento",

--- a/server/public/locales/pt/msp/invoicing.json
+++ b/server/public/locales/pt/msp/invoicing.json
@@ -1133,7 +1133,7 @@
           "client": "Cliente",
           "contact": "Contato",
           "line-item": "Item de linha",
-          "quote": "Citar",
+          "quote": "Cotação",
           "quote-totals": "Totais de cotação",
           "invoice": "Fatura",
           "customer": "Cliente",

--- a/server/public/locales/pt/msp/quotes.json
+++ b/server/public/locales/pt/msp/quotes.json
@@ -42,7 +42,7 @@
       "items": "Unid",
       "name": "Nome",
       "quoteDate": "Data da cotação",
-      "quoteNumber": "Citar #",
+      "quoteNumber": "Cotação #",
       "source": "Fonte",
       "status": "Status",
       "title": "Título",
@@ -158,7 +158,7 @@
       "editTemplate": "Editar modelo de cotação",
       "newQuote": "Nova cotação",
       "newTemplate": "Novo modelo de cotação",
-      "quote": "Citar",
+      "quote": "Cotação",
       "quoteWithNumber": "orçamento {{quoteNumber}}",
       "quoteWithNumberAndVersion": "orçamento {{quoteNumber}} v{{version}}",
       "templateQuoteFallback": "orçamento de modelo"
@@ -184,7 +184,7 @@
       "accepted": "Orçamento aceito",
       "converted": "Cotação convertida",
       "convertedDescription": "Esta cotação foi convertida em um contrato e/ou fatura.",
-      "quote": "Citar",
+      "quote": "Cotação",
       "rejected": "orçamento rejeitada"
     },
     "dialogs": {
@@ -278,7 +278,7 @@
       "convertedTitle": "Cotação convertida",
       "convertedDescription": "Esta cotação foi convertida em um contrato e/ou fatura."
     },
-    "noticeTitle": "Citar",
+    "noticeTitle": "Cotação",
     "essentials": {
       "title": "Fundamentos",
       "subtitle": "Mostrado ao cliente no documento de cotação.",

--- a/server/public/locales/pt/msp/workflows.json
+++ b/server/public/locales/pt/msp/workflows.json
@@ -2077,7 +2077,7 @@
       "client": "Cliente",
       "project": "Projeto",
       "appointment": "Encontro",
-      "quote": "Citar"
+      "quote": "Cotação"
     },
     "workflowLinkRelation": {
       "related": "Relacionado",


### PR DESCRIPTION
## Problem

In the pt-BR interface, the quote **noun** was rendered as **"Citar"** — the verb *"to cite/quote a text"* — instead of **"Cotação"** (a business quote/quotation). Reported by Rafael Pereira (Talos Defense): the toast/notice title showed "Citar" when working with a "Cotação".

## Fix

Corrects all **7** occurrences of the mistranslation across the pt-BR locale files:

| file | key(s) |
|---|---|
| `msp/quotes.json` | `quoteNumber` ("Citar #"), `labels.quote`, `alerts.quote`, `noticeTitle` |
| `features/billing.json` | `quoteForm.noticeTitle` |
| `msp/invoicing.json` | template-designer field category `quote` |
| `msp/workflows.json` | entity-type label `quote` |

Each was the noun (label / title / column header), so `"Citar"` → `"Cotação"` is unambiguous. JSON validated.

> Note: the files also mix `"Cotação"` and `"orçamento"` for quote in places — left as-is here; that broader glossary consistency pass is tracked separately by the localization team.

https://claude.ai/code/session_015h5M19noPH57Vo1uE241z5