### PR TITLE
License page: portal purchase/seat CTAs and Refresh license now

### DIFF
--- a/packages/licensing/src/lib/license-types.ts
+++ b/packages/licensing/src/lib/license-types.ts
@@ -16,7 +16,13 @@ export interface LicenseClaims {
   cust: string;
   /** Tier unlocked by this license */
   tier: LicenseTier;
-  /** Optional seat count (informational in v1; not enforced) */
+  /**
+   * Optional seat count. ENFORCED on EE self-host at paid tiers: user creation
+   * is blocked at this many active internal users (see
+   * ee/server/src/lib/license/userSeatGuard.ts). Absent = unlimited. Customers
+   * change it in the licensing portal; the new count arrives via check-in
+   * re-sign (or the License page's "Refresh license now").
+   */
   seats?: number;
   /** Issued-at (seconds since epoch) */
   iat: number;

--- a/packages/users/src/actions/user-actions/userActions.ts
+++ b/packages/users/src/actions/user-actions/userActions.ts
@@ -283,7 +283,7 @@ export const addUser = withAuth(async (
           return {
             success: false,
             code: 'LICENSE_LIMIT_REACHED',
-            error: `You've reached the seat limit (${seatLimit.seats}) of your Alga appliance license.`,
+            error: `You've reached the seat limit (${seatLimit.seats}) of your Alga appliance license. Add seats at nineminds.com/portal, then use "Refresh license now" on the License page.`,
           };
         }
 

--- a/server/src/components/licenses/LicenseManagementPage.tsx
+++ b/server/src/components/licenses/LicenseManagementPage.tsx
@@ -8,6 +8,7 @@ import {
   CheckCircle2,
   ChevronDown,
   Crown,
+  ExternalLink,
   KeyRound,
   RefreshCw,
   ShieldCheck,
@@ -27,10 +28,20 @@ import {
   submitLicense,
   startTrial,
   connectAppliance,
+  refreshLicenseNow,
 } from "@/lib/actions/licenseManagementActions";
 import type { LicenseStatus } from "@/lib/actions/licenseManagementActions";
 
 type Tone = "neutral" | "success" | "warning" | "danger" | "premium";
+
+/**
+ * The Nine Minds customer licensing portal: buying Pro, changing seats, and
+ * reissuing activation codes all happen there (sign-in is a link emailed to the
+ * registered address). Overridable for non-production environments.
+ */
+const PORTAL_URL =
+  process.env.NEXT_PUBLIC_NINEMINDS_PORTAL_URL ||
+  "https://www.nineminds.com/portal";
 
 function formatDate(value: string | null) {
   if (!value) return null;
@@ -250,6 +261,22 @@ export default function LicenseManagementPage() {
     });
   }
 
+  function handleRefreshLicense() {
+    setError(null);
+    setSuccessMsg(null);
+    startTransition(async () => {
+      const result = await refreshLicenseNow();
+      if (result.success && result.status) {
+        await refresh(result.status);
+        setSuccessMsg(
+          "License refreshed. Seat or plan changes from the portal are now active.",
+        );
+      } else {
+        setError(result.error ?? "Failed to refresh the license.");
+      }
+    });
+  }
+
   if (loading) {
     return (
       <div className="mx-auto w-full max-w-5xl p-6 text-[rgb(var(--color-text-700))]">
@@ -453,9 +480,72 @@ export default function LicenseManagementPage() {
                     Last check-in: {lastCheckIn}
                   </p>
                 ) : null}
+                <Button
+                  id="license-refresh-now"
+                  variant="outline"
+                  onClick={handleRefreshLicense}
+                  disabled={isPending}
+                  className="mt-3 gap-2"
+                >
+                  <RefreshCw className="h-4 w-4" aria-hidden="true" />
+                  {isPending ? "Refreshing…" : "Refresh license now"}
+                </Button>
+                <p className="mt-2 text-xs text-emerald-700/80 dark:text-emerald-200/80">
+                  Applies seat or plan changes made in the portal immediately.
+                </p>
               </div>
             ) : null}
           </section>
+
+          {status.state === "licensed" ? (
+            <section className="flex flex-col gap-3 rounded-xl border border-[rgb(var(--color-border-200))] bg-[rgb(var(--color-background))] p-4 sm:flex-row sm:items-center sm:justify-between">
+              <div>
+                <h3 className="font-semibold text-[rgb(var(--color-text-900))]">
+                  Seats, billing, and activation codes
+                </h3>
+                <p className="mt-1 max-w-2xl text-sm text-[rgb(var(--color-text-500))]">
+                  Add or remove seats, update billing, or reissue an activation
+                  code in the licensing portal. Sign in with your registered
+                  email — no password needed.
+                </p>
+              </div>
+              <Button
+                id="license-manage-in-portal"
+                variant="outline"
+                asChild
+                className="w-full gap-2 whitespace-nowrap sm:w-auto"
+              >
+                <a href={PORTAL_URL} target="_blank" rel="noopener noreferrer">
+                  <ExternalLink className="h-4 w-4" aria-hidden="true" />
+                  Manage license in portal
+                </a>
+              </Button>
+            </section>
+          ) : (
+            <section className="flex flex-col gap-3 rounded-xl border border-[rgb(var(--color-border-200))] bg-[rgb(var(--color-background))] p-4 sm:flex-row sm:items-center sm:justify-between">
+              <div>
+                <h3 className="font-semibold text-[rgb(var(--color-text-900))]">
+                  Ready to buy AlgaPSA Pro?
+                </h3>
+                <p className="mt-1 max-w-2xl text-sm text-[rgb(var(--color-text-500))]">
+                  Purchase in the licensing portal — sign in with your
+                  registered email, pick your seat count, and you&apos;ll get a
+                  one-time activation code to enter below. Your appliance
+                  upgrades in place.
+                </p>
+              </div>
+              <Button
+                id="license-buy-pro-in-portal"
+                asChild
+                className="w-full gap-2 whitespace-nowrap sm:w-auto"
+              >
+                <a href={PORTAL_URL} target="_blank" rel="noopener noreferrer">
+                  <ExternalLink className="h-4 w-4" aria-hidden="true" />
+                  Buy Pro in the portal
+                </a>
+              </Button>
+            </section>
+          )}
         </CardContent>
       </Card>
 
@@ -478,8 +568,16 @@ export default function LicenseManagementPage() {
         </summary>
         <div className="space-y-5 border-t border-[rgb(var(--color-border-200))] px-5 pb-5 pt-4">
           <p className="max-w-3xl text-sm text-[rgb(var(--color-text-500))]">
-            Use these options only if Nine Minds sent you a paid-license claim
-            code or a manually issued license key.
+            Enter the activation code or offline key you received from the{" "}
+            <a
+              href={PORTAL_URL}
+              target="_blank"
+              rel="noopener noreferrer"
+              className="font-medium text-[rgb(var(--color-primary-600))] underline underline-offset-2 dark:text-[rgb(var(--color-primary-300))]"
+            >
+              licensing portal
+            </a>{" "}
+            or from Nine Minds support.
           </p>
 
           <div className="grid gap-4 lg:grid-cols-2">
@@ -493,8 +591,9 @@ export default function LicenseManagementPage() {
                     Activate with claim code
                   </h3>
                   <p className="mt-1 text-sm text-[rgb(var(--color-text-500))]">
-                    Use an 8-character claim code from a paid-license email.
-                    This also enables automatic license refresh.
+                    Use the 8-character code from the licensing portal or a
+                    paid-license email. This also enables automatic license
+                    refresh.
                   </p>
                 </div>
               </div>
@@ -530,8 +629,8 @@ export default function LicenseManagementPage() {
                     Paste a license key
                   </h3>
                   <p className="mt-1 text-sm text-[rgb(var(--color-text-500))]">
-                    Use this for manually issued or offline license keys from
-                    support.
+                    Use this for offline keys downloaded from the licensing
+                    portal (air-gapped installs) or issued by support.
                   </p>
                 </div>
               </div>

--- a/server/src/lib/actions/licenseManagementActions.ts
+++ b/server/src/lib/actions/licenseManagementActions.ts
@@ -134,6 +134,58 @@ export async function startTrial(): Promise<{ success: boolean; error?: string; 
 }
 
 /**
+ * Immediately check in with the alga-license service and store any re-signed
+ * license. The daily check-in does this on its own schedule; this action backs
+ * the License page's "Refresh license now" button so a seat or tier change made
+ * in the customer portal takes effect right away (the service re-signs whenever
+ * the held token no longer matches the entitlement).
+ */
+export async function refreshLicenseNow(): Promise<{ success: boolean; error?: string; status?: LicenseStatus }> {
+  await assertAdminPermission();
+
+  const row = await getLicenseStateRow();
+  if (!row) return { success: false, error: 'Not a self-hosted install' };
+  if (!row.appliance_credential || !row.check_in_url) {
+    return { success: false, error: 'This appliance is not connected for automatic refresh. Activate a claim code first.' };
+  }
+
+  let currentLicenseSub: string | undefined;
+  if (row.license_token) {
+    const v = verifyLicense(row.license_token);
+    if (v.valid) currentLicenseSub = v.claims.sub;
+  }
+
+  try {
+    const res = await fetch(row.check_in_url, {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ appliance_credential: row.appliance_credential, current_license_sub: currentLicenseSub }),
+    });
+
+    if (!res.ok) {
+      return { success: false, error: `License service returned HTTP ${res.status}. Try again shortly.` };
+    }
+
+    const body = await res.json() as { status: 'ok' | 'no_change' | 'revoked'; jwt?: string };
+    if (body.status === 'revoked') {
+      // Soft revocation: keep the stored token (it grace-expires on its own exp).
+      await upsertLicenseState({ last_checkin_at: new Date() } as any);
+      return { success: false, error: 'This license has been revoked. Contact support if this is unexpected.' };
+    }
+
+    await upsertLicenseState({
+      ...(body.status === 'ok' && body.jwt ? { license_token: body.jwt } : {}),
+      last_checkin_at: new Date(),
+    } as any);
+
+    const status = await getLicenseStatus();
+    return { success: true, status };
+  } catch (err) {
+    return { success: false, error: err instanceof Error ? err.message : 'License refresh failed' };
+  }
+}
+
+/**
  * Redeems a one-time claim code against the alga-license service.
  * Stores the per-appliance credential and the first JWT in license_state.
  * Called by the in-app License page "Connect this appliance" flow (C5).


### PR DESCRIPTION
## Summary
The customer licensing portal (nineminds.com/portal, overridable via `NEXT_PUBLIC_NINEMINDS_PORTAL_URL`) is now where buying Pro, changing seats, and reissuing activation codes happen. This PR points the appliance at it:

- **License page CTAs**: "Buy Pro in the portal" on unlicensed installs, "Manage license in portal" on licensed ones; claim-code/offline-key copy references the portal
- **"Refresh license now"** button (connected installs): new `refreshLicenseNow` action checks in with the license service immediately and stores the re-signed token, so portal seat/tier changes apply without waiting for the daily cycle (the service re-signs whenever the held token no longer matches the entitlement — requires the alga-license PR)
- **Seat-limit error** now tells users to add seats in the portal and refresh
- Fixes the stale `license-types.ts` comment claiming seats are "not enforced" (userSeatGuard enforces them at user creation)

Part of the licensing-portal release with nine-minds/alga-license and nine-minds/nm-store PRs.