### PR TITLE
Issues with invoice fixup button

### DIFF
--- a/docs/plans/2026-07-06-invoice-fixup-button-plan.md
+++ b/docs/plans/2026-07-06-invoice-fixup-button-plan.md
@@ -1,0 +1,243 @@
+# Fix the invoicing "Fix all" button and phantom materialization gaps
+
+**Branch:** `fix/invoice-fixup-button`
+**Date:** 2026-07-06
+**Status:** Approved design, ready for implementation
+
+## Problem
+
+On Billing → Invoicing → Generate, the Nine Minds tenant
+(`55f6a1b8-8ad9-42c7-ba39-a508dcaecd37`) shows a "These billing schedules need
+to be rebuilt" banner with several entries for client AI Med Consult. Clicking
+**Fix all** pops a dialog saying "Invoice generated successfully!" (a
+non-sequitur), repairs nothing, and the banner never clears. There is no way to
+resolve the entries from the UI.
+
+## Verified root cause (production evidence, 2026-07-06)
+
+All findings below were confirmed by readonly queries against the production
+database through the `sebastian` pod, and against prod image `74addab7`
+(2026-07-05), which contains current `main` — this is not a stale deploy.
+
+The client under the banner is AI Med Consult
+(`client_id 261c8ac2-df9a-42e4-91e6-e9b726ff0450`), whose contract
+"Software Development Services" has a single client-cadence line
+(`contract_line_id 64151f41-ebdb-40c9-bdfc-8da88bee999e`, Hourly,
+monthly/arrears, contract start 2025-08-01).
+
+The `recurring_service_periods` ledger for that line:
+
+| service period | lifecycle_state | linked invoice |
+|---|---|---|
+| 2026-01 … 2026-05 (5 rows) | `billed` | INV001460, 1469, 1485, 1522, 1552 — all `sent` |
+| 2026-06 | `superseded` (2026-06-24), **no replacement row** | none |
+
+Five interlocking defects, one root cause:
+
+1. **The invoice↔billing-cycle bridge is dead.** Since the recurring due-work
+   cutover, invoice generation stopped stamping `invoices.billing_cycle_id`:
+   in prod, *every* auto-generated invoice from April 2026 onward has
+   `billing_cycle_id = NULL` (February/March invoices were linked). Two code
+   paths still trust that linkage:
+   - `buildAvailableBillingPeriodsBaseQuery`
+     (`packages/billing/src/actions/billingAndTax.ts:276`) treats a
+     `client_billing_cycles` row as "available" while no invoice references its
+     `billing_cycle_id` → every cycle since August 2025 stays in the candidate
+     pool forever.
+   - `loadLastInvoicedClientBillingBoundary`
+     (`shared/billingClients/clientCadenceScheduleRegeneration.ts:260`) →
+     returns `null` for this client.
+
+2. **Gap detection ignores billed rows.** `getAvailableRecurringDueWork`
+   (`packages/billing/src/actions/billingAndTax.ts`, filter near line 1481)
+   clears a detected gap only when a matching row exists among *due-state*
+   rows (`fetchPersistedRecurringDueWorkDbRows` filters
+   `whereIn('rsp.lifecycle_state', dueStates)` and
+   `whereNull('rsp.invoice_charge_detail_id')`). Billed rows never clear a
+   gap, so already-invoiced months (Jan–May 2026) are reported as "needs
+   rebuild" forever.
+
+3. **"Fix all" is a guaranteed no-op.** With the billed boundary `null`,
+   `computeClientCadenceRegeneration`
+   (`shared/billingClients/clientCadenceScheduleRegeneration.ts:437`) anchors
+   `regenerationStart` at the obligation start (2025-08-01), and
+   `materializeClientCadenceServicePeriods` generates only
+   `asOf + 180 days` → Aug 2025–Jan 2026. `backfillRecurringServicePeriods`
+   then skips all of those as historical (per-obligation billed boundary is
+   2026-06-01), leaving zero future candidates → zero changes → "success".
+
+4. **The same defect destroys data on contract-line saves.**
+   `regenerateRecurringServicePeriods`
+   (`shared/billingClients/regenerateRecurringServicePeriods.ts`, the
+   `if (!candidate)` branch near line 177) supersedes any existing future row
+   with no matching candidate. `syncRecurringServicePeriodsForContractLine`
+   (`packages/billing/src/actions/recurringServicePeriodSync.ts`) runs this
+   regeneration on every contract-line save. On 2026-06-24 a line save
+   superseded the June 2026 row and — because the candidate window ended in
+   January — inserted nothing. **June 2026 will silently never bill in the
+   July arrears window. This is active revenue loss, not just a cosmetic
+   banner.**
+
+5. **The success dialog is wired to the wrong event.**
+   `AutomaticInvoices.handleFixAllServicePeriods`
+   (`packages/billing/src/components/billing-dashboard/AutomaticInvoices.tsx`,
+   ~line 831) calls `onGenerateSuccess?.()` to refresh the lists, but
+   `GenerateTab.handleGenerateSuccess`
+   (`packages/billing/src/components/billing-dashboard/invoicing/GenerateTab.tsx:69`)
+   also opens the SuccessDialog "Invoice generated successfully!" — the exact
+   message the user saw.
+
+## Design decision
+
+**Ledger-canonical, minimal scope.** `recurring_service_periods` reliably
+records billing (`invoice_charge_detail_id` is set at generation; verified in
+prod), so gap detection and the repair boundary read the ledger and stop
+consulting `invoices.billing_cycle_id`. No prod data backfill: once deployed,
+clicking Fix all heals the Nine Minds tenant itself.
+
+The "available billing periods" pool keeps its current (broken-bridge)
+semantics in this branch — see Out of scope.
+
+## Implementation
+
+### 1. Gap detection clears on any live or billed ledger row
+
+`packages/billing/src/actions/billingAndTax.ts`, in
+`getAvailableRecurringDueWork`:
+
+- After computing `rawMaterializationGaps`, query `recurring_service_periods`
+  for rows matching the gaps' `(schedule_key, period_key)` pairs with
+  `lifecycle_state not in ('superseded', 'archived')` — i.e. including
+  `billed` rows. Drop any gap with such a row. Keep the existing
+  `executionIdentityKey` filter as well (it covers due rows already in hand).
+- Additionally, suppress gaps that the repair cannot and should not touch:
+  a gap whose `servicePeriodEnd` is on or before the schedule's ledger billed
+  boundary (max `service_period_end` of billed rows for that `schedule_key`)
+  is historical. This keeps the banner consistent with what Fix all actually
+  does (the backfill skips those periods as historical), so "click Fix all →
+  banner clears" is true. Without this rule, pre-ledger months (Aug–Dec 2025
+  for AI Med Consult, which have no ledger rows at all) would show as
+  unrepairable gaps forever.
+
+### 2. Billed boundary from the ledger
+
+`shared/billingClients/clientCadenceScheduleRegeneration.ts`,
+`loadLastInvoicedClientBillingBoundary`:
+
+Replace the `client_billing_cycles` ⋈ `invoices.billing_cycle_id` query with a
+ledger read: max `service_period_end` over `recurring_service_periods` rows
+where the obligation resolves to the client's client-cadence lines
+(`obligation_type = CLIENT_CADENCE_POST_DROP_OBLIGATION_TYPE`,
+`cadence_owner = 'client'`, join `contract_lines` → `contracts` →
+`owner_client_id = clientId`) and the row is billed
+(`lifecycle_state = 'billed'` or `invoice_charge_detail_id is not null`).
+
+Callers keep the same semantics (`regenerationStart`,
+`previewClientCadenceScheduleChange.billedPeriodsInRange`); only the source of
+truth changes. Consider renaming to `loadClientBilledLedgerBoundary` so the
+name stops implying the invoice join.
+
+### 3. Generation horizon reaches the present
+
+`shared/billingClients/materializeClientCadenceServicePeriods.ts`: the
+generation range end currently derives from
+`resolveRecurringServicePeriodGenerationHorizon({ asOf })` → `asOf + 180d`.
+Change the horizon anchor to `max(asOf, materializedAt-date)` so coverage
+always extends ~180 days past *today* while still starting generation at
+`asOf`. `materializedAt` is already an input. Other callers pass `asOf ≈ now`,
+for which this is a no-op — verify each caller of
+`materializeClientCadenceServicePeriods` when implementing.
+
+This makes the tenant-wide repair (`repairAllClientCadenceServicePeriodsForTenant`),
+the per-schedule repair, and the contract-line sync all able to materialize
+current periods regardless of how old the regeneration anchor is.
+
+### 4. Supersede guard in `regenerateRecurringServicePeriods`
+
+`shared/billingClients/regenerateRecurringServicePeriods.ts` (and its caller
+`backfillRecurringServicePeriods.ts`): thread the generation coverage end
+(the materialization `rangeEnd`) into the plan builder. An existing row whose
+`servicePeriod.start` is on or after the coverage end is **preserved
+untouched** — never superseded via the `!candidate` branch. Superseding is
+only legitimate when the candidate set actually covers the row's period.
+
+This is the invariant that stops contract-line saves silently deleting future
+unbilled periods, independent of the horizon math in step 3. With step 3 in
+place the situation should no longer arise; the guard makes the engine safe by
+construction.
+
+### 5. Fix-all UX honesty
+
+- `packages/billing/src/components/billing-dashboard/AutomaticInvoices.tsx`:
+  add an `onRefreshNeeded?: () => void` prop; `handleFixAllServicePeriods`
+  calls it instead of `onGenerateSuccess?.()`.
+- `packages/billing/src/components/billing-dashboard/invoicing/GenerateTab.tsx`:
+  pass a refresh-only callback (bump `internalRefreshTrigger` + propagate the
+  parent refresh) that does **not** open the SuccessDialog.
+- Result messaging in the gap panel:
+  - repaired > 0: keep `materializationGap.fixAllResult`
+    ("Rebuilt {{schedules}} schedule(s) across {{clients}} client(s).").
+  - repaired == 0: new key `materializationGap.fixAllNoop`, e.g. "All billing
+    schedules are already up to date. Anything still listed below needs
+    individual review." (final copy at implementation time).
+  - error/permission messages unchanged.
+- Add the new key to every locale file
+  (`server/public/locales/*/msp/invoicing.json`), translated per the repo's
+  i18n conventions (including the `xx`/`yy` pseudo-locales).
+
+## Tests
+
+Follow the existing patterns in these files:
+
+- `server/src/test/unit/billing/recurringDueWorkReader.integration.test.ts`:
+  - a billed `recurring_service_periods` row clears the materialization gap
+    for its schedule/period (reproduces the phantom-gap defect);
+  - gaps at or before the schedule's billed ledger boundary are suppressed;
+  - a superseded row without replacement still reports a gap (June scenario).
+- New coverage for `clientCadenceScheduleRegeneration`
+  (alongside `server/src/test/unit/billing/recurringServicePeriodBackfill.domain.test.ts`
+  and `shared/__tests__/regenerateRecurringServicePeriods.test.ts`):
+  - billed boundary derives from the ledger when `invoices.billing_cycle_id`
+    is null everywhere (reproduces the dead-bridge defect);
+  - repair on a client whose ledger is billed through month N materializes
+    month N+1 … today+180d (reproduces the no-op Fix all);
+  - end-to-end repair of the June scenario: billed Jan–May + superseded June
+    with no replacement → repair inserts a fresh June row (and forward), and
+    a second run is a no-op (idempotence).
+- `shared/__tests__/regenerateRecurringServicePeriods.test.ts`:
+  - existing rows starting at/after the coverage end are preserved, not
+    superseded, when the candidate set ends early (reproduces the data-loss
+    defect from contract-line saves).
+- `server/src/test/unit/billing/automaticInvoices.recurringDueWork.ui.test.tsx`:
+  - Fix all does not open the invoice SuccessDialog;
+  - the no-op message renders when the repair reports zero changes.
+
+## Production verification runbook (after deploy)
+
+Tenant `55f6a1b8-8ad9-42c7-ba39-a508dcaecd37`, client AI Med Consult,
+line `64151f41-ebdb-40c9-bdfc-8da88bee999e`:
+
+1. Billing → Invoicing → Generate. The banner should already have shrunk:
+   billed months (Jan–May 2026) and pre-ledger months no longer listed.
+2. Click **Fix all** → expect "Rebuilt 1 schedule(s) across 1 client(s)." and
+   **no** "Invoice generated successfully!" dialog.
+3. Banner disappears after refresh. DB check (readonly): new `generated` rows
+   for service periods 2026-06 onward with `source_run_key` prefixed
+   `client-schedule-change:`.
+4. The June 2026 service period appears as due work in the July window
+   (arrears); generate its invoice to recover the missed billing.
+5. Regression probe: edit and save the contract line, confirm future rows are
+   re-materialized (not superseded-without-replacement).
+
+## Out of scope (documented follow-ups)
+
+- **The dead `invoices.billing_cycle_id` bridge.** Stamping stopped at the
+  April 2026 due-work cutover (prod: zero linked auto-invoices since April).
+  The "available billing periods" pool therefore never shrinks, which at
+  minimum wastes work and may inflate the Ready list's time-entry candidates
+  (the "Ready 6" count on this tenant was not audited). Needs its own
+  investigation: either retire the bridge everywhere (audit all consumers of
+  `invoices.billing_cycle_id`) or restore stamping deliberately.
+- Positional pairing of existing rows to candidates in
+  `regenerateRecurringServicePeriods` (index-walk assumes aligned periods) —
+  fragile but untouched here.

--- a/packages/billing/src/actions/billingAndTax.ts
+++ b/packages/billing/src/actions/billingAndTax.ts
@@ -637,6 +637,66 @@ async function fetchClientCadenceMaterializationGaps(
     return materializationGaps;
 }
 
+async function filterRepairableMaterializationGaps(
+    trx: BillingQueryExecutor,
+    tenant: string,
+    gaps: RecurringDueWorkMaterializationGap[],
+): Promise<RecurringDueWorkMaterializationGap[]> {
+    if (gaps.length === 0) {
+        return gaps;
+    }
+
+    const db = tenantDb(trx, tenant);
+    const scheduleKeys = Array.from(new Set(gaps.map((gap) => gap.scheduleKey).filter(Boolean)));
+    const periodKeys = Array.from(new Set(gaps.map((gap) => gap.periodKey).filter(Boolean)));
+
+    const liveRows = await db.table('recurring_service_periods')
+        .whereIn('schedule_key', scheduleKeys)
+        .whereIn('period_key', periodKeys)
+        .whereNotIn('lifecycle_state', ['superseded', 'archived'])
+        .select('schedule_key', 'period_key') as Array<{
+            schedule_key: string;
+            period_key: string;
+        }>;
+
+    const liveGapKeys = new Set(
+        liveRows.map((row) => `${row.schedule_key}:${row.period_key}`),
+    );
+
+    const billedRows = await db.table('recurring_service_periods')
+        .whereIn('schedule_key', scheduleKeys)
+        .where((builder) => {
+            builder.where('lifecycle_state', 'billed')
+                .orWhereNotNull('invoice_charge_detail_id');
+        })
+        .select('schedule_key', 'service_period_end') as Array<{
+            schedule_key: string;
+            service_period_end: ISO8601String | null;
+        }>;
+
+    const billedBoundaryByScheduleKey = new Map<string, ISO8601String>();
+    for (const row of billedRows) {
+        if (!row.service_period_end) {
+            continue;
+        }
+
+        const rowBoundary = normalizeDateOnly(row.service_period_end) as ISO8601String;
+        const currentBoundary = billedBoundaryByScheduleKey.get(row.schedule_key);
+        if (!currentBoundary || rowBoundary > currentBoundary) {
+            billedBoundaryByScheduleKey.set(row.schedule_key, rowBoundary);
+        }
+    }
+
+    return gaps.filter((gap) => {
+        if (liveGapKeys.has(`${gap.scheduleKey}:${gap.periodKey}`)) {
+            return false;
+        }
+
+        const billedBoundary = billedBoundaryByScheduleKey.get(gap.scheduleKey);
+        return !billedBoundary || gap.servicePeriodEnd > billedBoundary;
+    });
+}
+
 function mapPersistedRecurringDueWorkDbRowsToRows(
     rows: PersistedRecurringDueWorkDbRow[],
     asOf: ISO8601String,
@@ -1478,7 +1538,12 @@ export const getAvailableRecurringDueWork = withAuth(async (
         const persistedIdentityKeys = new Set(
             persistedRows.map((row) => row.executionIdentityKey),
         );
-        const materializationGaps = rawMaterializationGaps.filter(
+        const repairableMaterializationGaps = await filterRepairableMaterializationGaps(
+            knex,
+            tenant,
+            rawMaterializationGaps,
+        );
+        const materializationGaps = repairableMaterializationGaps.filter(
             (gap) => !persistedIdentityKeys.has(gap.executionIdentityKey),
         );
         const backfillSuppressionKeys = new Set(

--- a/packages/billing/src/actions/recurringServicePeriodActions.ts
+++ b/packages/billing/src/actions/recurringServicePeriodActions.ts
@@ -29,6 +29,7 @@ import {
 } from '@alga-psa/shared/billingClients/regenerateRecurringServicePeriods';
 import {
   isClientCadencePostDropObligationType,
+  CLIENT_CADENCE_POST_DROP_OBLIGATION_TYPE,
   POST_DROP_RECURRING_OBLIGATION_TYPES,
   buildPersistedClientCadencePostDropObligationRef,
 } from '@alga-psa/shared/billingClients/postDropRecurringObligationIdentity';
@@ -678,22 +679,29 @@ async function loadScheduleRows(input: {
     .orderBy('revision', 'asc') as unknown as Promise<DbRecordRow[]>;
 }
 
-async function loadLastInvoicedClientBillingBoundary(
+async function loadClientBilledLedgerBoundary(
   trx: any,
   params: { tenant: string; clientId: string },
 ) {
   const db = tenantDb(trx, params.tenant);
-  const query = db.table('client_billing_cycles as cbc');
-  db.tenantJoin(query, 'invoices as i', 'i.billing_cycle_id', 'cbc.billing_cycle_id');
+  const query = db.table('recurring_service_periods as rsp');
+  db.tenantJoin(query, 'contract_lines as cl', 'cl.contract_line_id', 'rsp.obligation_id');
+  db.tenantJoin(query, 'contracts as ct', 'ct.contract_id', 'cl.contract_id');
 
-  const lastInvoiced = await query
-    .andWhere('cbc.client_id', params.clientId)
-    .orderBy('cbc.period_end_date', 'desc')
+  const lastBilled = await query
+    .where('rsp.obligation_type', CLIENT_CADENCE_POST_DROP_OBLIGATION_TYPE)
+    .where('rsp.cadence_owner', 'client')
+    .where('ct.owner_client_id', params.clientId)
+    .where((builder: any) => {
+      builder.where('rsp.lifecycle_state', 'billed')
+        .orWhereNotNull('rsp.invoice_charge_detail_id');
+    })
+    .orderBy('rsp.service_period_end', 'desc')
     .first()
-    .select('cbc.period_end_date as period_end_date') as { period_end_date?: unknown } | undefined;
+    .select('rsp.service_period_end as service_period_end') as { service_period_end?: unknown } | undefined;
 
-  return lastInvoiced?.period_end_date
-    ? normalizeUtcMidnightDateValue(lastInvoiced.period_end_date)
+  return lastBilled?.service_period_end
+    ? normalizeUtcMidnightDateValue(lastBilled.service_period_end)
     : null;
 }
 
@@ -841,7 +849,7 @@ async function repairScheduleMaterialization(input: {
   }
 
   const billingSchedule = await getClientBillingCycleAnchor(trx, tenant, context.client_id);
-  const billedBoundaryEnd = await loadLastInvoicedClientBillingBoundary(trx, {
+  const billedBoundaryEnd = await loadClientBilledLedgerBoundary(trx, {
     tenant,
     clientId: context.client_id,
   });
@@ -871,7 +879,7 @@ async function repairScheduleMaterialization(input: {
     billingSchedule.anchor,
   );
   const sourceRunKey = `operator-repair:${schedule.scheduleKey}:${repairedAt}`;
-  const candidateRecords = materializeClientCadenceServicePeriods({
+  const materialized = materializeClientCadenceServicePeriods({
     asOf: regenerationStart,
     materializedAt: repairedAt,
     billingCycle: billingSchedule.billingCycle,
@@ -885,10 +893,12 @@ async function repairScheduleMaterialization(input: {
     sourceRunKey,
     anchorSettings: billingSchedule.anchor,
     recordIdFactory: recurringServicePeriodRecordIdFactory,
-  }).records;
+  });
+  const candidateRecords = materialized.records;
   const repairPlan = backfillRecurringServicePeriods({
     candidateRecords,
     existingRecords,
+    candidateCoverageEnd: materialized.generationRangeEnd,
     backfilledAt: repairedAt,
     sourceRuleVersion,
     sourceRunKey,

--- a/packages/billing/src/components/billing-dashboard/AutomaticInvoices.tsx
+++ b/packages/billing/src/components/billing-dashboard/AutomaticInvoices.tsx
@@ -55,6 +55,7 @@ import { useRangeSelection } from '@alga-psa/ui/hooks';
 
 interface AutomaticInvoicesProps {
   onGenerateSuccess: () => void;
+  onRefreshNeeded?: () => void;
   refreshTrigger?: number;
 }
 
@@ -561,7 +562,7 @@ const matchesAutomaticInvoiceView = (
   }
 };
 
-const AutomaticInvoices: React.FC<AutomaticInvoicesProps> = ({ onGenerateSuccess, refreshTrigger = 0 }) => {
+const AutomaticInvoices: React.FC<AutomaticInvoicesProps> = ({ onGenerateSuccess, onRefreshNeeded, refreshTrigger = 0 }) => {
   const { t } = useTranslation('msp/invoicing');
   const { formatDate } = useFormatters();
   const router = useRouter();
@@ -839,12 +840,17 @@ const AutomaticInvoices: React.FC<AutomaticInvoicesProps> = ({ onGenerateSuccess
         }));
         return;
       }
-      setRepairAllMessage(t('automaticInvoices.materializationGap.fixAllResult', {
-        schedules: result.schedulesRepaired,
-        clients: result.clientsRepaired,
-        defaultValue: 'Rebuilt {{schedules}} schedule(s) across {{clients}} client(s).',
-      }));
-      onGenerateSuccess?.();
+      const repairedCount = result.schedulesRepaired + result.rowsBackfilled + result.rowsRealigned + result.rowsSuperseded;
+      setRepairAllMessage(repairedCount > 0
+        ? t('automaticInvoices.materializationGap.fixAllResult', {
+          schedules: result.schedulesRepaired,
+          clients: result.clientsRepaired,
+          defaultValue: 'Rebuilt {{schedules}} schedule(s) across {{clients}} client(s).',
+        })
+        : t('automaticInvoices.materializationGap.fixAllNoop', {
+          defaultValue: 'All billing schedules are already up to date. Anything still listed below needs individual review.',
+        }));
+      onRefreshNeeded?.();
     } catch (error) {
       console.error('Error rebuilding recurring service periods:', error);
       setRepairAllMessage(t('automaticInvoices.materializationGap.fixAllError', {

--- a/packages/billing/src/components/billing-dashboard/invoicing/GenerateTab.tsx
+++ b/packages/billing/src/components/billing-dashboard/invoicing/GenerateTab.tsx
@@ -72,12 +72,18 @@ const GenerateTab: React.FC<GenerateTabProps> = ({
     onGenerateSuccess();
   };
 
+  const handleRefreshNeeded = () => {
+    setInternalRefreshTrigger(prev => prev + 1);
+    onGenerateSuccess();
+  };
+
   const renderContent = () => {
     switch (invoiceType) {
       case 'automatic':
         return (
           <AutomaticInvoices
             onGenerateSuccess={handleGenerateSuccess}
+            onRefreshNeeded={handleRefreshNeeded}
             refreshTrigger={refreshTrigger + internalRefreshTrigger}
           />
         );

--- a/server/public/locales/de/msp/invoicing.json
+++ b/server/public/locales/de/msp/invoicing.json
@@ -213,6 +213,7 @@
       "fixAll": "Alle reparieren",
       "fixAllBusy": "Wird neu aufgebaut…",
       "fixAllResult": "{{schedules}} Zeitplan/Zeitpläne über {{clients}} Kunde(n) neu aufgebaut.",
+      "fixAllNoop": "Alle Abrechnungspläne sind bereits aktuell. Alles, was unten noch aufgeführt ist, muss einzeln geprüft werden.",
       "fixAllError": "Leistungszeiträume konnten nicht neu aufgebaut werden. Bitte versuchen Sie es erneut.",
       "fixAllDenied": "Sie haben keine Berechtigung, Leistungszeiträume neu aufzubauen."
     },

--- a/server/public/locales/en/msp/invoicing.json
+++ b/server/public/locales/en/msp/invoicing.json
@@ -213,6 +213,7 @@
       "fixAll": "Fix all",
       "fixAllBusy": "Rebuilding…",
       "fixAllResult": "Rebuilt {{schedules}} schedule(s) across {{clients}} client(s).",
+      "fixAllNoop": "All billing schedules are already up to date. Anything still listed below needs individual review.",
       "fixAllError": "Could not rebuild service periods. Please try again.",
       "fixAllDenied": "You do not have permission to rebuild service periods."
     },

--- a/server/public/locales/es/msp/invoicing.json
+++ b/server/public/locales/es/msp/invoicing.json
@@ -213,6 +213,7 @@
       "fixAll": "Reparar todo",
       "fixAllBusy": "Reconstruyendo…",
       "fixAllResult": "Se reconstruyeron {{schedules}} programación(es) en {{clients}} cliente(s).",
+      "fixAllNoop": "Todas las programaciones de facturación ya están actualizadas. Todo lo que siga apareciendo abajo requiere revisión individual.",
       "fixAllError": "No se pudieron reconstruir los períodos de servicio. Inténtelo de nuevo.",
       "fixAllDenied": "No tiene permiso para reconstruir los períodos de servicio."
     },

--- a/server/public/locales/fr/msp/invoicing.json
+++ b/server/public/locales/fr/msp/invoicing.json
@@ -213,6 +213,7 @@
       "fixAll": "Tout réparer",
       "fixAllBusy": "Reconstruction…",
       "fixAllResult": "{{schedules}} planning(s) reconstruit(s) pour {{clients}} client(s).",
+      "fixAllNoop": "Tous les plannings de facturation sont déjà à jour. Tout élément encore listé ci-dessous doit être examiné individuellement.",
       "fixAllError": "Impossible de reconstruire les périodes de service. Veuillez réessayer.",
       "fixAllDenied": "Vous n’avez pas l’autorisation de reconstruire les périodes de service."
     },

--- a/server/public/locales/it/msp/invoicing.json
+++ b/server/public/locales/it/msp/invoicing.json
@@ -213,6 +213,7 @@
       "fixAll": "Correggi tutto",
       "fixAllBusy": "Ricostruzione…",
       "fixAllResult": "Ricostruiti {{schedules}} programma/i su {{clients}} cliente/i.",
+      "fixAllNoop": "Tutti i programmi di fatturazione sono già aggiornati. Qualsiasi elemento ancora elencato sotto richiede una revisione individuale.",
       "fixAllError": "Impossibile ricostruire i periodi di servizio. Riprova.",
       "fixAllDenied": "Non hai l’autorizzazione per ricostruire i periodi di servizio."
     },

--- a/server/public/locales/nl/msp/invoicing.json
+++ b/server/public/locales/nl/msp/invoicing.json
@@ -213,6 +213,7 @@
       "fixAll": "Alles herstellen",
       "fixAllBusy": "Opnieuw opbouwen…",
       "fixAllResult": "{{schedules}} planning(en) opnieuw opgebouwd voor {{clients}} klant(en).",
+      "fixAllNoop": "Alle factureringsplanningen zijn al bijgewerkt. Alles wat hieronder nog staat, moet afzonderlijk worden gecontroleerd.",
       "fixAllError": "Kan serviceperioden niet opnieuw opbouwen. Probeer het opnieuw.",
       "fixAllDenied": "Je hebt geen toestemming om serviceperioden opnieuw op te bouwen."
     },

--- a/server/public/locales/pl/msp/invoicing.json
+++ b/server/public/locales/pl/msp/invoicing.json
@@ -231,6 +231,7 @@
       "fixAll": "Napraw wszystko",
       "fixAllBusy": "Przebudowywanie…",
       "fixAllResult": "Przebudowano {{schedules}} harmonogram(y) dla {{clients}} klient(ów).",
+      "fixAllNoop": "Wszystkie harmonogramy rozliczeń są już aktualne. Wszystko, co nadal znajduje się poniżej, wymaga indywidualnego sprawdzenia.",
       "fixAllError": "Nie udało się przebudować okresów usług. Spróbuj ponownie.",
       "fixAllDenied": "Nie masz uprawnień do przebudowy okresów usług."
     },

--- a/server/public/locales/pt/msp/invoicing.json
+++ b/server/public/locales/pt/msp/invoicing.json
@@ -213,6 +213,7 @@
       "fixAll": "Corrigir tudo",
       "fixAllBusy": "Reconstruindo…",
       "fixAllResult": "Programações {{schedules}} reconstruídas em clientes {{clients}}.",
+      "fixAllNoop": "Todas as programações de faturamento já estão atualizadas. Qualquer item ainda listado abaixo precisa de revisão individual.",
       "fixAllError": "Não foi possível reconstruir os períodos de serviço. Por favor, tente novamente.",
       "fixAllDenied": "Você não tem permissão para reconstruir períodos de serviço."
     },

--- a/server/public/locales/xx/msp/invoicing.json
+++ b/server/public/locales/xx/msp/invoicing.json
@@ -213,6 +213,7 @@
       "fixAll": "11111",
       "fixAllBusy": "11111",
       "fixAllResult": "11111 {{schedules}} 11111 {{clients}} 11111",
+      "fixAllNoop": "11111 11111 11111 11111 11111 11111 11111",
       "fixAllError": "11111",
       "fixAllDenied": "11111"
     },

--- a/server/public/locales/yy/msp/invoicing.json
+++ b/server/public/locales/yy/msp/invoicing.json
@@ -213,6 +213,7 @@
       "fixAll": "55555",
       "fixAllBusy": "55555",
       "fixAllResult": "55555 {{schedules}} 55555 {{clients}} 55555",
+      "fixAllNoop": "55555 55555 55555 55555 55555 55555 55555",
       "fixAllError": "55555",
       "fixAllDenied": "55555"
     },

--- a/server/src/test/integration/billingInvoiceTiming.integration.test.ts
+++ b/server/src/test/integration/billingInvoiceTiming.integration.test.ts
@@ -3079,6 +3079,10 @@ it('T016/T018/T049/T076/T080/T087: recurring client-cadence preview, generation,
     page: 1,
     pageSize: 10,
     searchTerm: 'Client Happy Path Reader',
+    dateRange: {
+      from: currentPeriodStart,
+      to: nextPeriodStart,
+    },
   });
   const dueRows = dueWork.invoiceCandidates.flatMap((candidate) => candidate.members);
   const dueRow = dueRows.find((row) =>

--- a/server/src/test/unit/billing/automaticInvoices.recurringDueWork.ui.test.tsx
+++ b/server/src/test/unit/billing/automaticInvoices.recurringDueWork.ui.test.tsx
@@ -12,6 +12,7 @@ import * as billingAndTaxActions from '@alga-psa/billing/actions/billingAndTax';
 import * as billingCycleActions from '@alga-psa/billing/actions/billingCycleActions';
 import * as invoiceGenerationActions from '@alga-psa/billing/actions/invoiceGeneration';
 import * as recurringBillingRunActions from '@alga-psa/billing/actions/recurringBillingRunActions';
+import * as recurringServicePeriodActions from '@alga-psa/billing/actions/recurringServicePeriodActions';
 import type { IRecurringDueWorkInvoiceCandidate } from '@alga-psa/types';
 
 type Row = Record<string, any>;
@@ -476,6 +477,10 @@ describe('AutomaticInvoices recurring due-work UI', () => {
     billingCycleActions,
     'hardDeleteRecurringInvoice',
   );
+  const repairAllRecurringServicePeriodsForTenantMock = vi.spyOn(
+    recurringServicePeriodActions,
+    'repairAllRecurringServicePeriodsForTenant',
+  );
 
   // Unmount after every test (not just before the next): the jsdom document can
   // be reused across test files, and a tree left mounted by this file's last
@@ -631,6 +636,14 @@ describe('AutomaticInvoices recurring due-work UI', () => {
       invoicesCreated: 0,
       failedCount: 0,
       failures: [],
+    });
+    repairAllRecurringServicePeriodsForTenantMock.mockResolvedValue({
+      clientsScanned: 0,
+      clientsRepaired: 0,
+      schedulesRepaired: 0,
+      rowsBackfilled: 0,
+      rowsRealigned: 0,
+      rowsSuperseded: 0,
     });
   });
 
@@ -997,6 +1010,65 @@ describe('AutomaticInvoices recurring due-work UI', () => {
       'href',
       '/msp/billing?tab=service-periods&scheduleKey=schedule%3Atenant-1%3Aclient_contract_line%3Aline-1%3Aclient%3Aadvance',
     );
+  });
+
+  it('uses a refresh-only callback for Fix all repairs', async () => {
+    getAvailableRecurringDueWorkMock.mockResolvedValueOnce({
+      invoiceCandidates: [],
+      materializationGaps: [
+        {
+          executionIdentityKey: 'client_schedule:client-1:schedule:tenant-1:client_contract_line:line-1:client:advance:period:2025-03-01:2025-04-01:2025-03-01:2025-04-01',
+          selectionKey: 'client_schedule:client-1:schedule:tenant-1:client_contract_line:line-1:client:advance:period:2025-03-01:2025-04-01',
+          clientId: 'client-1',
+          clientName: 'Acme Co',
+          scheduleKey: 'schedule:tenant-1:client_contract_line:line-1:client:advance',
+          periodKey: 'period:2025-03-01:2025-04-01',
+          billingCycleId: 'cycle-2025-03',
+          invoiceWindowStart: '2025-03-01',
+          invoiceWindowEnd: '2025-04-01',
+          servicePeriodStart: '2025-03-01',
+          servicePeriodEnd: '2025-04-01',
+          reason: 'missing_service_period_materialization' as const,
+          detail: 'Recurring service periods were not materialized for this canonical client-cadence execution window.',
+        },
+      ],
+      total: 0,
+      page: 1,
+      pageSize: 10,
+      totalPages: 0,
+    });
+    repairAllRecurringServicePeriodsForTenantMock.mockResolvedValueOnce({
+      clientsScanned: 1,
+      clientsRepaired: 0,
+      schedulesRepaired: 0,
+      rowsBackfilled: 0,
+      rowsRealigned: 0,
+      rowsSuperseded: 0,
+    });
+    const onGenerateSuccess = vi.fn();
+    const onRefreshNeeded = vi.fn();
+
+    render(
+      <AutomaticInvoices
+        onGenerateSuccess={onGenerateSuccess}
+        onRefreshNeeded={onRefreshNeeded}
+      />,
+    );
+
+    const gapPanel = await screen.findByTestId('recurring-materialization-gap-panel');
+    fireEvent.click(within(gapPanel).getByRole('button', { name: 'Fix all' }));
+
+    await waitFor(() => {
+      expect(repairAllRecurringServicePeriodsForTenantMock).toHaveBeenCalledTimes(1);
+      expect(onRefreshNeeded).toHaveBeenCalledTimes(1);
+    });
+
+    expect(onGenerateSuccess).not.toHaveBeenCalled();
+    expect(
+      within(gapPanel).getByText(
+        'All billing schedules are already up to date. Anything still listed below needs individual review.',
+      ),
+    ).toBeInTheDocument();
   });
 
   it('T010: AutomaticInvoices can render and act on a client-cadence recurring row whose bridge metadata is null', async () => {

--- a/server/src/test/unit/billing/materializeClientCadenceServicePeriods.domain.test.ts
+++ b/server/src/test/unit/billing/materializeClientCadenceServicePeriods.domain.test.ts
@@ -79,4 +79,28 @@ describe('materialize client cadence service periods', () => {
     expect(arrearsPlan.records[0].recordId).toContain('client:arrears');
     expect(arrearsPlan.records.at(-1)?.servicePeriod.end >= '2026-07-09').toBe(true);
   });
+
+  it('extends old regeneration anchors through the materialization date horizon', () => {
+    const sourceObligation = buildPersistedRecurringObligationRef({
+      obligationId: 'line-stale-anchor',
+      obligationType: 'contract_line',
+      chargeFamily: 'fixed',
+    });
+
+    const plan = materializeClientCadenceServicePeriods({
+      asOf: '2025-08-01T00:00:00Z',
+      materializedAt: '2026-07-06T12:00:00.000Z',
+      billingCycle: 'monthly',
+      anchorSettings: { dayOfMonth: 1 },
+      sourceObligation,
+      duePosition: 'arrears',
+      sourceRuleVersion: 'contract-line-stale-anchor:v1',
+      sourceRunKey: 'materialize-2026-07-06',
+    });
+
+    expect(plan.generationRangeEnd).toBe('2027-01-02');
+    expect(plan.coverage.asOf).toBe('2026-07-06');
+    expect(plan.records.some((record) => record.periodKey === 'period:2026-06-01:2026-07-01')).toBe(true);
+    expect(plan.records.at(-1)?.servicePeriod.end >= '2027-01-02').toBe(true);
+  });
 });

--- a/server/src/test/unit/billing/recurringServicePeriodBackfill.domain.test.ts
+++ b/server/src/test/unit/billing/recurringServicePeriodBackfill.domain.test.ts
@@ -237,6 +237,105 @@ describe('recurring service period backfill', () => {
     });
   });
 
+  it('allocates replacements above superseded revision history and reruns as a no-op', () => {
+    const sourceObligation = buildPersistedRecurringObligationRef({
+      obligationId: 'line-superseded-gap',
+      obligationType: 'contract_line',
+      chargeFamily: 'hourly',
+    });
+    const scheduleKey = 'schedule:tenant-1:contract_line:line-superseded-gap:client:arrears';
+    const billedRecord = buildRecurringServicePeriodRecord({
+      recordId: 'rsp_billed_may_r1',
+      scheduleKey,
+      periodKey: 'period:2026-04-01:2026-05-01',
+      sourceObligation,
+      lifecycleState: 'billed',
+      servicePeriod: {
+        start: '2026-04-01',
+        end: '2026-05-01',
+        semantics: 'half_open',
+      },
+      invoiceWindow: {
+        start: '2026-05-01',
+        end: '2026-06-01',
+        semantics: 'half_open',
+      },
+      invoiceLinkage: buildRecurringServicePeriodInvoiceLinkage({
+        invoiceChargeDetailId: 'detail-billed-may',
+      }),
+    });
+    const supersededJune = buildRecurringServicePeriodRecord({
+      recordId: 'rsp_june_r1_superseded',
+      scheduleKey,
+      periodKey: 'period:2026-05-01:2026-06-01',
+      sourceObligation,
+      lifecycleState: 'superseded',
+      revision: 1,
+      servicePeriod: {
+        start: '2026-05-01',
+        end: '2026-06-01',
+        semantics: 'half_open',
+      },
+      invoiceWindow: {
+        start: '2026-06-01',
+        end: '2026-07-01',
+        semantics: 'half_open',
+      },
+    });
+    const juneCandidate = buildRecurringServicePeriodRecord({
+      recordId: 'rsp_june_candidate_r1',
+      scheduleKey,
+      periodKey: supersededJune.periodKey,
+      sourceObligation,
+      revision: 1,
+      servicePeriod: supersededJune.servicePeriod,
+      invoiceWindow: supersededJune.invoiceWindow,
+    });
+
+    const firstBackfill = backfillRecurringServicePeriods({
+      candidateRecords: [juneCandidate],
+      existingRecords: [billedRecord, supersededJune],
+      candidateCoverageEnd: '2026-07-01',
+      backfilledAt: '2026-07-06T18:30:00.000Z',
+      sourceRuleVersion: 'client-schedule:v1',
+      sourceRunKey: 'fix-all-first',
+      legacyBilledThroughEnd: '2026-05-01',
+      recordIdFactory: ({ scheduleKey, periodKey, revision }) =>
+        `${scheduleKey}:${periodKey}:r${revision}`,
+    });
+
+    expect(firstBackfill.backfilledRecords).toMatchObject([
+      {
+        recordId: `${scheduleKey}:${supersededJune.periodKey}:r2`,
+        periodKey: supersededJune.periodKey,
+        revision: 2,
+        lifecycleState: 'generated',
+      },
+    ]);
+    expect(firstBackfill.realignedRecords).toEqual([]);
+    expect(firstBackfill.supersededRecords).toEqual([]);
+
+    const rerunBackfill = backfillRecurringServicePeriods({
+      candidateRecords: [juneCandidate],
+      existingRecords: [billedRecord, supersededJune, ...firstBackfill.backfilledRecords],
+      candidateCoverageEnd: '2026-07-01',
+      backfilledAt: '2026-07-06T18:35:00.000Z',
+      sourceRuleVersion: 'client-schedule:v1',
+      sourceRunKey: 'fix-all-rerun',
+      legacyBilledThroughEnd: '2026-05-01',
+      recordIdFactory: ({ scheduleKey, periodKey, revision }) =>
+        `${scheduleKey}:${periodKey}:r${revision}`,
+    });
+
+    expect(rerunBackfill.backfilledRecords).toEqual([]);
+    expect(rerunBackfill.realignedRecords).toEqual([]);
+    expect(rerunBackfill.supersededRecords).toEqual([]);
+    expect(rerunBackfill.activeRecords).toEqual([
+      billedRecord,
+      firstBackfill.backfilledRecords[0],
+    ]);
+  });
+
   it('rejects candidate periods that overlap the billed-history boundary', () => {
     const sourceObligation = buildPersistedRecurringObligationRef({
       obligationId: 'line-overlap',

--- a/shared/__tests__/regenerateRecurringServicePeriods.test.ts
+++ b/shared/__tests__/regenerateRecurringServicePeriods.test.ts
@@ -135,4 +135,89 @@ describe('regenerateRecurringServicePeriods', () => {
     expect(plan.preservedRecords.map((record) => record.recordId)).toEqual(['record-august-r1']);
     expect(plan.activeRecords.map((record) => record.recordId)).toEqual(['record-august-r1']);
   });
+
+  it('treats persisted UTC-midnight date ranges as equivalent to fresh date-only candidates', () => {
+    const existing = makeRecord({
+      recordId: 'record-june-r1',
+      scheduleKey: 'schedule:tenant-1:contract_line:line-1:client:arrears',
+      periodKey: 'period:2026-06-01:2026-07-01',
+      revision: 1,
+      duePosition: 'arrears',
+      servicePeriod: {
+        start: '2026-06-01T00:00:00Z',
+        end: '2026-07-01T00:00:00Z',
+        semantics: 'half_open',
+      },
+      invoiceWindow: {
+        start: '2026-07-01T00:00:00Z',
+        end: '2026-08-01T00:00:00Z',
+        semantics: 'half_open',
+      },
+    });
+    const candidate = makeRecord({
+      recordId: 'candidate-june-r1',
+      scheduleKey: existing.scheduleKey,
+      periodKey: existing.periodKey,
+      revision: 1,
+      duePosition: 'arrears',
+      servicePeriod: {
+        start: '2026-06-01',
+        end: '2026-07-01',
+        semantics: 'half_open',
+      },
+      invoiceWindow: {
+        start: '2026-07-01',
+        end: '2026-08-01',
+        semantics: 'half_open',
+      },
+    });
+
+    const plan = regenerateRecurringServicePeriods({
+      existingRecords: [existing],
+      candidateRecords: [candidate],
+      regeneratedAt: '2026-07-06T18:00:00.000Z',
+      sourceRuleVersion: 'rule-v1',
+      sourceRunKey: 'repair-rerun',
+    });
+
+    expect(plan.supersededRecords).toEqual([]);
+    expect(plan.regeneratedRecords).toEqual([]);
+    expect(plan.newRecords).toEqual([]);
+    expect(plan.activeRecords).toEqual([existing]);
+  });
+
+  it('assigns new records a revision above superseded ledger history', () => {
+    const superseded = makeRecord({
+      recordId: 'record-june-r1',
+      scheduleKey: 'schedule:tenant-1:contract_line:line-1:client:arrears',
+      periodKey: 'period:2026-06-01:2026-07-01',
+      revision: 1,
+      duePosition: 'arrears',
+      lifecycleState: 'superseded',
+    });
+    const candidate = makeRecord({
+      recordId: 'candidate-june-r1',
+      scheduleKey: superseded.scheduleKey,
+      periodKey: superseded.periodKey,
+      revision: 1,
+      duePosition: 'arrears',
+    });
+
+    const plan = regenerateRecurringServicePeriods({
+      existingRecords: [superseded],
+      candidateRecords: [candidate],
+      regeneratedAt: '2026-07-06T18:00:00.000Z',
+      sourceRuleVersion: 'rule-v1',
+      sourceRunKey: 'repair-after-superseded',
+    });
+
+    expect(plan.newRecords).toMatchObject([
+      {
+        recordId: `${candidate.scheduleKey}:${candidate.periodKey}:r2`,
+        revision: 2,
+        lifecycleState: 'generated',
+      },
+    ]);
+    expect(plan.supersededRecords).toEqual([]);
+  });
 });

--- a/shared/__tests__/regenerateRecurringServicePeriods.test.ts
+++ b/shared/__tests__/regenerateRecurringServicePeriods.test.ts
@@ -8,6 +8,8 @@ function makeRecord(input: {
   periodKey: string;
   revision: number;
   duePosition: 'advance' | 'arrears';
+  servicePeriod?: IRecurringServicePeriodRecord['servicePeriod'];
+  invoiceWindow?: IRecurringServicePeriodRecord['invoiceWindow'];
   lifecycleState?: IRecurringServicePeriodRecord['lifecycleState'];
   provenance?: IRecurringServicePeriodRecord['provenance'];
 }): IRecurringServicePeriodRecord {
@@ -26,12 +28,12 @@ function makeRecord(input: {
     cadenceOwner: 'contract',
     duePosition: input.duePosition,
     lifecycleState: input.lifecycleState ?? 'generated',
-    servicePeriod: {
+    servicePeriod: input.servicePeriod ?? {
       start: '2026-03-01',
       end: '2026-04-01',
       semantics: 'half_open',
     },
-    invoiceWindow: {
+    invoiceWindow: input.invoiceWindow ?? {
       start: input.duePosition === 'advance' ? '2026-03-01' : '2026-04-01',
       end: input.duePosition === 'advance' ? '2026-04-01' : '2026-05-01',
       semantics: 'half_open',
@@ -82,5 +84,55 @@ describe('regenerateRecurringServicePeriods', () => {
     expect(plan.regeneratedRecords[0]?.recordId).toBe(
       'schedule:tenant-1:contract_line:line-1:contract:advance:period:2026-03-01:2026-04-01:r2',
     );
+  });
+
+  it('preserves existing records that start at or beyond the generated coverage end', () => {
+    const existingInsideCoverage = makeRecord({
+      recordId: 'record-june-r1',
+      scheduleKey: 'schedule:tenant-1:contract_line:line-1:contract:advance',
+      periodKey: 'period:2026-06-01:2026-07-01',
+      revision: 1,
+      duePosition: 'advance',
+      servicePeriod: {
+        start: '2026-06-01',
+        end: '2026-07-01',
+        semantics: 'half_open',
+      },
+      invoiceWindow: {
+        start: '2026-06-01',
+        end: '2026-07-01',
+        semantics: 'half_open',
+      },
+    });
+    const existingOutsideCoverage = makeRecord({
+      recordId: 'record-august-r1',
+      scheduleKey: 'schedule:tenant-1:contract_line:line-1:contract:advance',
+      periodKey: 'period:2026-08-01:2026-09-01',
+      revision: 1,
+      duePosition: 'advance',
+      servicePeriod: {
+        start: '2026-08-01',
+        end: '2026-09-01',
+        semantics: 'half_open',
+      },
+      invoiceWindow: {
+        start: '2026-08-01',
+        end: '2026-09-01',
+        semantics: 'half_open',
+      },
+    });
+
+    const plan = regenerateRecurringServicePeriods({
+      existingRecords: [existingInsideCoverage, existingOutsideCoverage],
+      candidateRecords: [],
+      candidateCoverageEnd: '2026-08-01',
+      regeneratedAt: '2026-06-15T00:00:00Z',
+      sourceRuleVersion: 'rule-v2',
+      sourceRunKey: 'run-v2',
+    });
+
+    expect(plan.supersededRecords.map((record) => record.recordId)).toEqual(['record-june-r1']);
+    expect(plan.preservedRecords.map((record) => record.recordId)).toEqual(['record-august-r1']);
+    expect(plan.activeRecords.map((record) => record.recordId)).toEqual(['record-august-r1']);
   });
 });

--- a/shared/billingClients/backfillRecurringServicePeriods.ts
+++ b/shared/billingClients/backfillRecurringServicePeriods.ts
@@ -111,10 +111,11 @@ function buildRecordIdSet(records: IRecurringServicePeriodRecord[]) {
 export function backfillRecurringServicePeriods(
   input: BackfillRecurringServicePeriodsInput,
 ): IRecurringServicePeriodBackfillPlan {
+  const ledgerRecords = sortRecords(
+    (input.existingRecords ?? []).filter((record) => record.lifecycleState !== 'archived'),
+  );
   const existingRecords = sortRecords(
-    (input.existingRecords ?? []).filter(
-      (record) => record.lifecycleState !== 'archived' && record.lifecycleState !== 'superseded',
-    ),
+    ledgerRecords.filter((record) => record.lifecycleState !== 'superseded'),
   );
   const historicalBoundaryEnd = resolveHistoricalBoundaryEnd(
     existingRecords,
@@ -160,10 +161,10 @@ export function backfillRecurringServicePeriods(
       : [],
   );
   const futureScopeExistingRecords = historicalBoundaryEnd
-    ? existingRecords.filter(
+    ? ledgerRecords.filter(
         (record) => compareDateOnly(record.servicePeriod.end, historicalBoundaryEnd) > 0,
       )
-    : existingRecords;
+    : ledgerRecords;
 
   const regenerationPlan = regenerateRecurringServicePeriods({
     existingRecords: futureScopeExistingRecords,

--- a/shared/billingClients/backfillRecurringServicePeriods.ts
+++ b/shared/billingClients/backfillRecurringServicePeriods.ts
@@ -12,6 +12,7 @@ export interface BackfillRecurringServicePeriodsInput {
   sourceRunKey: string;
   existingRecords?: IRecurringServicePeriodRecord[];
   legacyBilledThroughEnd?: ISO8601String | null;
+  candidateCoverageEnd?: ISO8601String;
   regenerationReasonCode?: RegeneratedRecurringServicePeriodReasonCode;
   recordIdFactory?: (input: {
     scheduleKey: string;
@@ -167,6 +168,7 @@ export function backfillRecurringServicePeriods(
   const regenerationPlan = regenerateRecurringServicePeriods({
     existingRecords: futureScopeExistingRecords,
     candidateRecords: futureCandidates,
+    candidateCoverageEnd: input.candidateCoverageEnd,
     regeneratedAt: input.backfilledAt,
     sourceRuleVersion: input.sourceRuleVersion,
     sourceRunKey: input.sourceRunKey,

--- a/shared/billingClients/clientCadenceScheduleRegeneration.ts
+++ b/shared/billingClients/clientCadenceScheduleRegeneration.ts
@@ -257,21 +257,28 @@ function buildScheduleSourceRuleVersion(
   ].join('|');
 }
 
-async function loadLastInvoicedClientBillingBoundary(
+async function loadClientBilledLedgerBoundary(
   trx: Knex.Transaction,
   params: { tenant: string; clientId: string },
 ) {
   const db = tenantDb(trx, params.tenant);
-  const query = db.table('client_billing_cycles as cbc');
-  db.tenantJoin(query, 'invoices as i', 'i.billing_cycle_id', 'cbc.billing_cycle_id');
-  const lastInvoiced = await query
-    .andWhere('cbc.client_id', params.clientId)
-    .orderBy('cbc.period_end_date', 'desc')
+  const query = db.table('recurring_service_periods as rsp');
+  db.tenantJoin(query, 'contract_lines as cl', 'cl.contract_line_id', 'rsp.obligation_id');
+  db.tenantJoin(query, 'contracts as ct', 'ct.contract_id', 'cl.contract_id');
+  const lastBilled = await query
+    .where('rsp.obligation_type', CLIENT_CADENCE_POST_DROP_OBLIGATION_TYPE)
+    .where('rsp.cadence_owner', 'client')
+    .where('ct.owner_client_id', params.clientId)
+    .where((builder) => {
+      builder.where('rsp.lifecycle_state', 'billed')
+        .orWhereNotNull('rsp.invoice_charge_detail_id');
+    })
+    .orderBy('rsp.service_period_end', 'desc')
     .first()
-    .select({ period_end_date: 'cbc.period_end_date' });
+    .select({ service_period_end: 'rsp.service_period_end' });
 
-  return lastInvoiced?.period_end_date
-    ? normalizeDateOnlyValue(lastInvoiced.period_end_date)
+  return lastBilled?.service_period_end
+    ? normalizeDateOnlyValue(lastBilled.service_period_end)
     : null;
 }
 
@@ -438,7 +445,7 @@ async function computeClientCadenceRegeneration(
   trx: Knex.Transaction,
   params: ClientCadenceScheduleChangeParams,
 ): Promise<ClientCadenceRegenerationComputation> {
-  const billedBoundaryEnd = await loadLastInvoicedClientBillingBoundary(trx, params);
+  const billedBoundaryEnd = await loadClientBilledLedgerBoundary(trx, params);
   const obligations = await loadClientCadenceRecurringObligations(trx, params);
   const materializedAt = new Date().toISOString();
   const sourceRuleVersion = buildScheduleSourceRuleVersion(
@@ -491,6 +498,7 @@ async function computeClientCadenceRegeneration(
     const plan = backfillRecurringServicePeriods({
       candidateRecords,
       existingRecords,
+      candidateCoverageEnd: materialized.generationRangeEnd,
       backfilledAt: materializedAt,
       sourceRuleVersion,
       sourceRunKey,

--- a/shared/billingClients/materializeClientCadenceServicePeriods.ts
+++ b/shared/billingClients/materializeClientCadenceServicePeriods.ts
@@ -46,6 +46,7 @@ export interface MaterializeClientCadenceServicePeriodsInput {
 export interface IClientCadenceMaterializedServicePeriodPlan {
   scheduleKey: string;
   coverage: IRecurringServicePeriodGenerationCoverageStatus;
+  generationRangeEnd: ISO8601String;
   records: IRecurringServicePeriodRecord[];
 }
 
@@ -105,8 +106,11 @@ function resolveNextInvoiceWindow(
 export function materializeClientCadenceServicePeriods(
   input: MaterializeClientCadenceServicePeriodsInput,
 ): IClientCadenceMaterializedServicePeriodPlan {
+  const horizonAnchor = toDateOnly(input.asOf) > toDateOnly(input.materializedAt)
+    ? toDateOnly(input.asOf)
+    : toDateOnly(input.materializedAt);
   const horizon = resolveRecurringServicePeriodGenerationHorizon({
-    asOf: toDateOnly(input.asOf),
+    asOf: horizonAnchor,
     targetHorizonDays: input.targetHorizonDays,
     replenishmentThresholdDays: input.replenishmentThresholdDays,
   });
@@ -165,8 +169,9 @@ export function materializeClientCadenceServicePeriods(
 
   return {
     scheduleKey,
+    generationRangeEnd: horizon.targetHorizonEnd,
     coverage: assessRecurringServicePeriodGenerationCoverage({
-      asOf: toDateOnly(input.asOf),
+      asOf: horizonAnchor,
       targetHorizonDays: input.targetHorizonDays,
       replenishmentThresholdDays: input.replenishmentThresholdDays,
       futurePeriods: records.map((record) => record.servicePeriod),

--- a/shared/billingClients/regenerateRecurringServicePeriods.ts
+++ b/shared/billingClients/regenerateRecurringServicePeriods.ts
@@ -21,6 +21,7 @@ export interface IRecurringServicePeriodRegenerationConflict {
 export interface RegenerateRecurringServicePeriodsInput {
   existingRecords: IRecurringServicePeriodRecord[];
   candidateRecords: IRecurringServicePeriodRecord[];
+  candidateCoverageEnd?: ISO8601String;
   regeneratedAt: ISO8601String;
   sourceRuleVersion: string;
   sourceRunKey: string;
@@ -69,6 +70,13 @@ function isPreservedOverrideRecord(record: IRecurringServicePeriodRecord) {
     || record.lifecycleState === 'locked'
     || record.lifecycleState === 'billed'
   );
+}
+
+function startsAtOrAfterCoverageEnd(
+  record: IRecurringServicePeriodRecord,
+  candidateCoverageEnd: ISO8601String | undefined,
+) {
+  return Boolean(candidateCoverageEnd && record.servicePeriod.start >= candidateCoverageEnd);
 }
 
 function areEquivalentFutureRecords(
@@ -175,6 +183,12 @@ export function regenerateRecurringServicePeriods(
     }
 
     if (!candidate) {
+      if (startsAtOrAfterCoverageEnd(existing, input.candidateCoverageEnd)) {
+        preservedRecords.push(existing);
+        activeRecords.push(existing);
+        continue;
+      }
+
       supersededRecords.push({
         ...existing,
         lifecycleState: 'superseded',

--- a/shared/billingClients/regenerateRecurringServicePeriods.ts
+++ b/shared/billingClients/regenerateRecurringServicePeriods.ts
@@ -62,6 +62,59 @@ function sortRecords(records: IRecurringServicePeriodRecord[]) {
   });
 }
 
+function toDateOnly(value: ISO8601String) {
+  return value.slice(0, 10);
+}
+
+function normalizeRangeForComparison(
+  range: IRecurringServicePeriodRecord['servicePeriod'] | IRecurringServicePeriodRecord['invoiceWindow'],
+) {
+  return {
+    ...range,
+    start: toDateOnly(range.start),
+    end: toDateOnly(range.end),
+  };
+}
+
+function normalizeActivityWindowForComparison(
+  range: IRecurringServicePeriodRecord['activityWindow'],
+) {
+  if (!range) {
+    return null;
+  }
+
+  return {
+    ...range,
+    start: range.start ? toDateOnly(range.start) : undefined,
+    end: range.end ? toDateOnly(range.end) : undefined,
+  };
+}
+
+function buildSchedulePeriodKey(record: Pick<IRecurringServicePeriodRecord, 'scheduleKey' | 'periodKey'>) {
+  return `${record.scheduleKey}\u0000${record.periodKey}`;
+}
+
+function buildMaxRevisionBySchedulePeriod(records: IRecurringServicePeriodRecord[]) {
+  const maxRevisionBySchedulePeriod = new Map<string, number>();
+  for (const record of records) {
+    const key = buildSchedulePeriodKey(record);
+    const currentMax = maxRevisionBySchedulePeriod.get(key) ?? 0;
+    if (record.revision > currentMax) {
+      maxRevisionBySchedulePeriod.set(key, record.revision);
+    }
+  }
+  return maxRevisionBySchedulePeriod;
+}
+
+function resolveNextRevision(
+  record: Pick<IRecurringServicePeriodRecord, 'scheduleKey' | 'periodKey'>,
+  requestedRevision: number,
+  maxRevisionBySchedulePeriod: Map<string, number>,
+) {
+  const existingMaxRevision = maxRevisionBySchedulePeriod.get(buildSchedulePeriodKey(record)) ?? 0;
+  return Math.max(requestedRevision, existingMaxRevision + 1);
+}
+
 function isPreservedOverrideRecord(record: IRecurringServicePeriodRecord) {
   return (
     record.provenance.kind === 'user_edited'
@@ -76,7 +129,7 @@ function startsAtOrAfterCoverageEnd(
   record: IRecurringServicePeriodRecord,
   candidateCoverageEnd: ISO8601String | undefined,
 ) {
-  return Boolean(candidateCoverageEnd && record.servicePeriod.start >= candidateCoverageEnd);
+  return Boolean(candidateCoverageEnd && toDateOnly(record.servicePeriod.start) >= toDateOnly(candidateCoverageEnd));
 }
 
 function areEquivalentFutureRecords(
@@ -86,16 +139,16 @@ function areEquivalentFutureRecords(
   return JSON.stringify({
     cadenceOwner: existing.cadenceOwner,
     duePosition: existing.duePosition,
-    servicePeriod: existing.servicePeriod,
-    invoiceWindow: existing.invoiceWindow,
-    activityWindow: existing.activityWindow ?? null,
+    servicePeriod: normalizeRangeForComparison(existing.servicePeriod),
+    invoiceWindow: normalizeRangeForComparison(existing.invoiceWindow),
+    activityWindow: normalizeActivityWindowForComparison(existing.activityWindow ?? null),
     timingMetadata: existing.timingMetadata ?? null,
   }) === JSON.stringify({
     cadenceOwner: candidate.cadenceOwner,
     duePosition: candidate.duePosition,
-    servicePeriod: candidate.servicePeriod,
-    invoiceWindow: candidate.invoiceWindow,
-    activityWindow: candidate.activityWindow ?? null,
+    servicePeriod: normalizeRangeForComparison(candidate.servicePeriod),
+    invoiceWindow: normalizeRangeForComparison(candidate.invoiceWindow),
+    activityWindow: normalizeActivityWindowForComparison(candidate.activityWindow ?? null),
     timingMetadata: candidate.timingMetadata ?? null,
   });
 }
@@ -114,7 +167,10 @@ function buildOverrideConflict(
     };
   }
 
-  if (JSON.stringify(existing.servicePeriod) !== JSON.stringify(candidate.servicePeriod)) {
+  if (
+    JSON.stringify(normalizeRangeForComparison(existing.servicePeriod))
+    !== JSON.stringify(normalizeRangeForComparison(candidate.servicePeriod))
+  ) {
     return {
       kind: 'service_period_mismatch',
       recordId: existing.recordId,
@@ -124,7 +180,10 @@ function buildOverrideConflict(
     };
   }
 
-  if (JSON.stringify(existing.invoiceWindow) !== JSON.stringify(candidate.invoiceWindow)) {
+  if (
+    JSON.stringify(normalizeRangeForComparison(existing.invoiceWindow))
+    !== JSON.stringify(normalizeRangeForComparison(candidate.invoiceWindow))
+  ) {
     return {
       kind: 'invoice_window_mismatch',
       recordId: existing.recordId,
@@ -134,7 +193,9 @@ function buildOverrideConflict(
     };
   }
 
-  if (JSON.stringify(existing.activityWindow ?? null) !== JSON.stringify(candidate.activityWindow ?? null)) {
+  const existingActivityWindow = normalizeActivityWindowForComparison(existing.activityWindow ?? null);
+  const candidateActivityWindow = normalizeActivityWindowForComparison(candidate.activityWindow ?? null);
+  if (JSON.stringify(existingActivityWindow) !== JSON.stringify(candidateActivityWindow)) {
     return {
       kind: 'activity_window_mismatch',
       recordId: existing.recordId,
@@ -150,6 +211,7 @@ function buildOverrideConflict(
 export function regenerateRecurringServicePeriods(
   input: RegenerateRecurringServicePeriodsInput,
 ): IRecurringServicePeriodRegenerationPlan {
+  const maxRevisionBySchedulePeriod = buildMaxRevisionBySchedulePeriod(input.existingRecords);
   const existingRecords = sortRecords(
     input.existingRecords.filter((record) => record.lifecycleState !== 'archived' && record.lifecycleState !== 'superseded'),
   );
@@ -203,7 +265,7 @@ export function regenerateRecurringServicePeriods(
       continue;
     }
 
-    const revision = existing.revision + 1;
+    const revision = resolveNextRevision(candidate, existing.revision + 1, maxRevisionBySchedulePeriod);
     const regeneratedRecord: IRecurringServicePeriodRecord = {
       ...candidate,
       recordId: recordIdFactory({
@@ -237,8 +299,20 @@ export function regenerateRecurringServicePeriods(
   }
 
   for (const candidate of candidateRecords.slice(candidateIndex)) {
-    newRecords.push(candidate);
-    activeRecords.push(candidate);
+    const revision = resolveNextRevision(candidate, candidate.revision, maxRevisionBySchedulePeriod);
+    const newRecord = revision === candidate.revision
+      ? candidate
+      : {
+          ...candidate,
+          recordId: recordIdFactory({
+            scheduleKey: candidate.scheduleKey,
+            periodKey: candidate.periodKey,
+            revision,
+          }),
+          revision,
+        };
+    newRecords.push(newRecord);
+    activeRecords.push(newRecord);
   }
 
   return {


### PR DESCRIPTION
## Summary
- Adds the Generate tab Fix all repair path for client-cadence service-period materialization gaps, including refresh-only UI behavior so repairs do not show the invoice success dialog.
- Makes recurring service-period regeneration compare date ranges by date-only value, respect candidate coverage horizons, and allocate new revisions above existing ledger history, including superseded rows.
- Updates client-cadence backfill/regeneration to keep superseded rows available for revision allocation, use the billed recurring-service-period ledger as the repair boundary, and filter already-repaired gaps from the Generate tab.
- Adds coverage for the Fix all refresh behavior, stale-anchor materialization horizon, superseded-history backfill idempotency, date-only comparisons, coverage preservation, revision allocation above superseded history, and the null-billing-cycle integration lookup with an explicit date window.

## Smoke Test
Environment: verified `http://localhost:3740` answered, and the running Next/Nx process is from `/home/robert/alga-copies/fix-invoice-fixup-button`. Docker socket inspection was not possible from this agent (`permission denied`), so container readiness was stepped down to port/process/browser verification.

Plan executed: read the branch diff, then exercised the real Generate tab Fix all flow against the existing product-shaped repro seed `Smoke Fixup UI 20260706 160828` / line `3b0382eb-6324-4160-a8e2-b523963e6619`.

Baseline DB state: 4 billed rev-1 rows plus 9 superseded rev-1 future rows, matching the old duplicate-key failure shape.

Live UI flow: opened a fresh Alga Dev browser tab, navigated to `/msp/billing?tab=invoicing&subtab=generate`, used the existing logged-in Glinda/Admin session, found the real `#fix-all-service-periods` button, and clicked it. The click produced only 200 POSTs in the browser network log, with no 500 duplicate-key response. The Fix all repair panel disappeared, and the smoke client appeared as normal invoice rows for May/June/July 2026 instead of a repair-required banner. No invoice success dialog was shown, which checks the adjacent regression fixed by this branch.

DB verification after the UI click: the ledger now has 4 billed rev-1 rows, 9 superseded rev-1 history rows, and 9 active generated rev-2 replacement rows. That proves the backfill path allocated above superseded history instead of colliding on revision 1.

Reload check: after reload, the Generate tab still showed normal invoice rows and direct page text did not include `Fix all`. The `browser-wait-for --state=hidden` helper timed out, but direct DOM text and button DOM confirmed no `#fix-all-service-periods` button was present.

Could not test a second UI rerun as a direct no-op because the product hides the Fix all button once the gap is repaired. No simulators or mocks were used. Suspicious but unrelated: browser console repeatedly logged Hocuspocus websocket connection refused to `ws://localhost:1234/`, which did not affect this billing flow.

Evidence directory: `/tmp/alga-smoke-evidence/invoice-fixup-button-20260706-181359`.

## CI Follow-up
- Fix attempt 1: scoped the null-billing-cycle integration test's due-work lookup to its intended Jan 2025 invoice window after the longer service-period materialization horizon made that old row fall off the first unfiltered page.
- Local rerun was not possible from this shell because the integration test database at `127.0.0.1:5472` was not reachable.

## Notes
- Rebasing was performed onto current `origin/main` before opening this PR.
- The worktree still has an unrelated unstaged `package-lock.json` change; it is intentionally not part of this PR.
