### PR TITLE
fix(billing): approval gate scans one day past the service period

### DIFF
--- a/packages/billing/src/actions/recurringApprovalBlockers.ts
+++ b/packages/billing/src/actions/recurringApprovalBlockers.ts
@@ -46,8 +46,16 @@ function applyNonApprovedStatusFilter(query: Knex.QueryBuilder, column: string) 
   });
 }
 
-function getContractServicePeriodEndExclusive(servicePeriodEndInclusive: ISO8601String): ISO8601String {
-  return toISODate(toPlainDate(servicePeriodEndInclusive).add({ days: 1 }));
+// `service_period_end` is persisted as the EXCLUSIVE end of a half-open service
+// period (e.g. a June period ends 2026-07-01, which is not itself part of June),
+// so it is already the correct upper bound for an `end_time < ...` comparison --
+// matching both the billing engine (`servicePeriodEndExclusive = coveredPeriod.end`)
+// and `countUnresolvedSelectionUnapprovedTimeEntries`, which uses it directly.
+// Previously this added a day, treating the value as inclusive, which pulled the
+// entire first day of the NEXT period into the approval scan and blocked a
+// completed period on unapproved time that belongs to the following one.
+export function getContractServicePeriodEndExclusive(servicePeriodEnd: ISO8601String): ISO8601String {
+  return toISODate(toPlainDate(servicePeriodEnd));
 }
 
 async function getServiceIdsForContractLine(params: {

--- a/packages/billing/tests/recurringApprovalBlockers.servicePeriodBoundary.test.ts
+++ b/packages/billing/tests/recurringApprovalBlockers.servicePeriodBoundary.test.ts
@@ -1,0 +1,24 @@
+import { describe, expect, it } from 'vitest';
+
+import { getContractServicePeriodEndExclusive } from '../src/actions/recurringApprovalBlockers';
+
+describe('getContractServicePeriodEndExclusive', () => {
+  // `service_period_end` is stored as the exclusive end of a half-open period, so
+  // it must be used as-is for `end_time < ...`. Adding a day (the previous bug)
+  // pulled the whole first day of the NEXT period into the approval scan, which
+  // blocked a completed, fully-approved period on the following period's time.
+  it('returns the stored (already-exclusive) end unchanged, without adding a day', () => {
+    // June is [2026-06-01, 2026-07-01); the approval gate must stop before 2026-07-01,
+    // not spill into 2026-07-02 and sweep in July 1 time.
+    expect(getContractServicePeriodEndExclusive('2026-07-01')).toBe('2026-07-01');
+  });
+
+  it('normalizes a timestamp-form boundary to a date-only exclusive bound', () => {
+    expect(getContractServicePeriodEndExclusive('2026-07-01T00:00:00.000Z')).toBe('2026-07-01');
+  });
+
+  it('does not roll a month/year boundary forward by a day', () => {
+    expect(getContractServicePeriodEndExclusive('2026-01-01')).toBe('2026-01-01');
+    expect(getContractServicePeriodEndExclusive('2026-12-01')).toBe('2026-12-01');
+  });
+});


### PR DESCRIPTION
## Summary

A completed, fully-approved billing period could not be invoiced because the approval gate was scanning **one day too far** — into the first day of the *next* period.

`getContractServicePeriodEndExclusive` (in `recurringApprovalBlockers.ts`) added a day to `service_period_end`:

```js
// before
return toISODate(toPlainDate(servicePeriodEndInclusive).add({ days: 1 }));
```

But `recurring_service_periods.service_period_end` is stored as the **exclusive** end of a half-open period (a June period ends `2026-07-01`, which is not itself part of June). Adding a day turned June's bound into `2026-07-02`, so `countContractLineUnapprovedTimeEntries` ran `end_time < 2026-07-02` and swept in unapproved time dated **July 1** — blocking the June invoice on time that belongs to July.

The billing engine (`servicePeriodEndExclusive = coveredPeriod.end`) and the sibling `countUnresolvedSelectionUnapprovedTimeEntries` (which uses `end_time < row.servicePeriodEnd` directly) both treat `service_period_end` as already-exclusive. This aligns the contract-line path with them.

## Impact

Real production case (AI Med Consult, June): selecting June to invoice showed *"Blocked until approval: 6 unapproved entries."* Those 6 entries were July 1 work on a still-draft July timesheet. With the fix, June's contract-line unapproved count goes from **6 → 0** and the period invoices without touching next month's approvals.

Verified directly against production data:
- `end_time < 2026-07-02` (before) → **6** blocked
- `end_time < 2026-07-01` (after) → **0** blocked

## Change

- Remove the erroneous `+1 day`; return `service_period_end` normalized to a date-only exclusive bound.
- Export the helper and add `recurringApprovalBlockers.servicePeriodBoundary.test.ts` locking the boundary behavior (no day added, timestamp normalized, no month/year roll-forward).

Tests: 5 passed (3 new + 2 existing).
