### PR TITLE
Fix recurring approval blocker window boundary

### DIFF
--- a/packages/billing/src/actions/recurringApprovalBlockers.ts
+++ b/packages/billing/src/actions/recurringApprovalBlockers.ts
@@ -1,7 +1,6 @@
 import type { Knex } from 'knex';
 import { tenantDb } from '@alga-psa/db';
 import type { ISO8601String } from '@alga-psa/types';
-import { toPlainDate, toISODate } from '@alga-psa/core';
 
 export type RecurringApprovalBlockerRow = {
   executionIdentityKey: string;
@@ -44,10 +43,6 @@ function applyNonApprovedStatusFilter(query: Knex.QueryBuilder, column: string) 
   query.where(function applyApprovalStatusGuard(this: Knex.QueryBuilder) {
     this.whereNull(column).orWhere(column, '<>', APPROVED_TIME_STATUS);
   });
-}
-
-function getContractServicePeriodEndExclusive(servicePeriodEndInclusive: ISO8601String): ISO8601String {
-  return toISODate(toPlainDate(servicePeriodEndInclusive).add({ days: 1 }));
 }
 
 async function getServiceIdsForContractLine(params: {
@@ -137,9 +132,7 @@ async function countContractLineUnapprovedTimeEntries(params: {
   }
 
   const servicePeriodStartExclusive = row.servicePeriodStart;
-  const servicePeriodEndExclusive = getContractServicePeriodEndExclusive(
-    row.servicePeriodEnd,
-  );
+  const servicePeriodEndExclusive = row.servicePeriodEnd;
   const uniquelyAssignableServiceIds = await getUniquelyAssignableServiceIdsForLine({
     knex,
     tenant,

--- a/server/src/test/integration/billingInvoiceTiming.integration.test.ts
+++ b/server/src/test/integration/billingInvoiceTiming.integration.test.ts
@@ -1395,7 +1395,7 @@ it('T001/T004: recurring due-work marks a contract-hourly window as approval-blo
   expect(blockedCandidate?.members[0]?.approvalBlockedEntryCount).toBe(1);
 }, HOOK_TIMEOUT);
 
-it('parity: recurring due-work blocks uniquely assignable unassigned hourly time on the persisted service-period end date and treats null approval status as non-approved', async () => {
+it('parity: recurring due-work blocks uniquely assignable unassigned hourly time inside the half-open service period and ignores the exclusive end date', async () => {
   setupCommonMocks({ tenantId, userId: 'approval-unique-unassigned-user', permissionCheck: () => true });
 
   const { contextLike } = await createClientWithRecurringCycles({
@@ -1442,6 +1442,14 @@ it('parity: recurring due-work blocks uniquely assignable unassigned hourly time
     startTime: '2025-03-07T10:00:00.000Z',
     endTime: '2025-03-07T11:00:00.000Z',
     approvalStatus: null,
+  });
+  await createApprovedTimeEntryForContractLine({
+    clientId: contextLike.clientId,
+    serviceId: hourlyLine.serviceId,
+    contractLineId: null,
+    startTime: '2025-03-08T10:00:00.000Z',
+    endTime: '2025-03-08T11:00:00.000Z',
+    approvalStatus: 'SUBMITTED',
   });
 
   const dueWork = await getAvailableRecurringDueWorkAction({


### PR DESCRIPTION
## Summary
- Treat persisted recurring service-period ends as half-open boundaries in approval blocker detection.
- Keep the blocker aligned with the billing engine's approved-time selection window.
- Add DB-backed integration coverage so a non-approved entry exactly on the exclusive end date does not inflate the blocker count.

## Root cause
Recurring approval blockers were adding one day to `servicePeriodEnd` before filtering `time_entries.end_time`. Persisted recurring service periods already use `[start, end)` semantics, so the blocker could include the next calendar day and block invoices for time the invoice calculation would not include.

## Validation
- `npx vitest run ../packages/billing/tests/recurringApprovalBlockers.rolloverRemoval.test.ts --coverage.enabled=false` from `server/` passed.
- Attempted focused DB-backed integration run for `billingInvoiceTiming.integration.test.ts`; local setup could not connect to Postgres on `localhost:5472`, so CI should provide the full integration validation.