### PR TITLE
docs: align tenant docs with tenantDb facade

### DIFF
--- a/docs/AI_coding_standards.md
+++ b/docs/AI_coding_standards.md
@@ -323,16 +323,17 @@ Lucide icons can (and should) be used from the `lucide` package.
 
 ```typescript
 import { withAuth, hasPermission } from '@alga-psa/auth';
-import { createTenantKnex } from '@alga-psa/db';
+import { createTenantKnex, tenantDb } from '@alga-psa/db';
 
 export const myAction = withAuth(async (user, { tenant }, arg1: string): Promise<Result> => {
   const { knex } = await createTenantKnex();
+  const db = tenantDb(knex, tenant);
 
   if (!await hasPermission(user, 'resource', 'action')) {
     throw new Error('Permission denied');
   }
 
-  return knex('table').where({ tenant }).select('*');
+  return db.table('table').select('*');
 });
 ```
 
@@ -398,30 +399,36 @@ Always use commands like "cd server && npx knex migrate:make <name> --knexfile k
 
 The knexfile is located in the /server/knexfile.cjs file and is used to configure the database connection.
 
-Use createTenantKnex() from the /server/src/lib/db/index.ts file to create a database connection and return the tenant as a string.
+Use createTenantKnex() from `@alga-psa/db` to get the connection and the tenant id, then query through the `tenantDb` facade. The facade applies the tenant predicate to query roots and joins for you; see [Tenant isolation and the tenantDb query facade](architecture/tenant-isolation.md) for the full API.
 
 **Correct Usage Pattern:**
 ```typescript
-// CORRECT: Destructure both knex and tenant
-const { knex, tenant } = await createTenantKnex();
+import { createTenantKnex, tenantDb } from '@alga-psa/db';
 
-// Example query
-const documents = await knex('documents')
-  .where('tenant', tenant)
-  .select('*');
+// CORRECT: Destructure both knex and tenant, then bind the facade
+const { knex, tenant } = await createTenantKnex();
+const db = tenantDb(knex, tenant);
+
+// Example query — tenant scoping is applied by the facade
+const documents = await db.table('documents').select('*');
+
+// Tenant-safe join — adds d.tenant = a.tenant automatically
+const query = db.table('documents as d');
+db.tenantJoin(query, 'document_associations as a', 'a.document_id', 'd.document_id');
 ```
 
 **Transaction Pattern:**
 ```typescript
-import { withTransaction } from '@alga-psa/db';
+import { withTransaction, tenantDb } from '@alga-psa/db';
 
 // CORRECT: Pass knex as first parameter
-const { knex } = await createTenantKnex();
+const { knex, tenant } = await createTenantKnex();
 
 await withTransaction(knex, async (trx) => {
-  // Use trx for all operations within the transaction
-  await trx('documents').insert({...});
-  await trx('document_associations').insert({...});
+  // Bind the facade to the transaction handle
+  const db = tenantDb(trx, tenant);
+  await db.table('documents').insert({...});
+  await db.table('document_associations').insert({...});
 });
 ```
 
@@ -430,6 +437,9 @@ await withTransaction(knex, async (trx) => {
 // ❌ WRONG: Missing destructuring
 const knex = await createTenantKnex();
 
+// ❌ WRONG: Hand-written tenant predicates (legacy shape — use tenantDb)
+const documents = await knex('documents').where('tenant', tenant).select('*');
+
 // ❌ WRONG: Missing knex parameter
 await withTransaction(async (trx) => {...});
 
@@ -437,11 +447,13 @@ await withTransaction(async (trx) => {...});
 const knex = await getConnection();
 ```
 
+The facade only accepts tables registered in `packages/db/src/lib/tenantTableMetadata.ts` and throws for unknown ones. When a migration adds a table, register it in the metadata in the same change. Cross-tenant and pre-login paths must use `db.unscoped(table, reason)` with a non-empty reason string.
+
 Migrations should have a .cjs extension and should be located in the /server/migrations folder.
 
 Run migrations with the migration environment (env) flag.
 
-Every query should filter on the tenant column (including joins) to ensure compatibility with citusdb.
+Every query must be tenant-scoped, including joins. Route queries through the `tenantDb` facade so the tenant predicates are applied structurally; raw SQL (`knex.raw`) must still carry tenant predicates by hand.
 
 ## Local EE migrations
 - Do not physically copy EE migrations into `server/migrations/` locally.
@@ -571,9 +583,10 @@ When working with PostgreSQL JSON and JSONB columns in Knex.js, follow these gui
    ```
 
 3. **Tenant Column Requirements**
-    - Always include tenant column in WHERE clauses
-    - Include tenant in JOIN conditions
+    - Always include tenant column in WHERE clauses (in app code, `tenantDb` does this for you)
+    - Include tenant in JOIN conditions (in app code, use `db.tenantJoin`)
     - Add tenant to unique constraints and indexes
+    - Register new tables in `packages/db/src/lib/tenantTableMetadata.ts` so the facade accepts them — full checklist in [architecture/tenant-isolation.md](architecture/tenant-isolation.md)
     Example:
     ```sql
     CREATE UNIQUE INDEX my_unique_index
@@ -609,22 +622,20 @@ When working with PostgreSQL JSON and JSONB columns in Knex.js, follow these gui
     ```
 
 4. **Tenant Context in Distributed Queries**
-    - Connection-specific tenant context (`app.current_tenant`) does not propagate to all shards
-    - Queries without shard key (tenant) are broadcast to all shards
-    - Each shard connection needs its own tenant context
-    - Security policies checking `app.current_tenant` will fail on shards without context
+    - Queries without the shard key (tenant) are broadcast to all shards
+    - Connection-level settings (e.g. the old `app.current_tenant` GUC) do not propagate to shards — never rely on them for isolation. RLS policies that read that GUC were dropped entirely (`20260509120000_disable_remaining_rls_policies.cjs`); isolation is application-enforced.
     Example of potential issues:
     ```typescript
-    // This could fail if broadcast to all shards
+    // Broadcasts to all shards and returns other tenants' rows
     const results = await knex('some_table')
       .select('*')
       .where('some_column', 'value');
-    
-    // Always include tenant to avoid broadcast
-    const results = await knex('some_table')
-      .select('*')
-      .where('tenant', currentTenant)
-      .andWhere('some_column', 'value');
+
+    // Facade applies the tenant predicate, so the query routes to one shard
+    const results = await tenantDb(knex, tenant)
+      .table('some_table')
+      .where('some_column', 'value')
+      .select('*');
     ```
 
 5. **GUID Handling in CitusDB**
@@ -681,7 +692,7 @@ When working with PostgreSQL JSON and JSONB columns in Knex.js, follow these gui
 - `ON DELETE SET NULL` is not supported and should be handled at the application level.
 
 ## Tenants
-We use row level security and store the tenant in the `tenants` table.
+Tenants are stored in the `tenants` table. Isolation is application-enforced: explicit `tenant` columns, Citus distribution, and the `tenantDb` facade. There is no row-level security — RLS policies were dropped for Citus compatibility (see [architecture/tenant-isolation.md](architecture/tenant-isolation.md)); do not copy RLS blocks from old migrations.
 Most tables require the tenant to be specified in the `tenant` column when inserting.
 
 ## Dates and times in the database:

--- a/docs/architecture/citus-migration-best-practices.md
+++ b/docs/architecture/citus-migration-best-practices.md
@@ -129,6 +129,8 @@ if (isCitusDistributed) {
 }
 ```
 
+For new tenant tables, the shared helper `server/migrations/utils/citusDistribution.cjs` wraps this check: `ensureTenantDistribution(knex, 'my_table')` distributes on `tenant` colocated with `tenants`, and is a no-op on plain PostgreSQL or when the table is already distributed. Migrations that distribute must set `exports.config = { transaction: false }`. A new tenant table also needs registration in the query metadata registry — follow the checklist in [tenant-isolation.md](tenant-isolation.md).
+
 ### 2. Use Raw SQL for DDL
 
 Knex's schema builder may not handle Citus correctly. Use raw SQL:

--- a/docs/architecture/overview.md
+++ b/docs/architecture/overview.md
@@ -55,7 +55,7 @@ This document provides a high-level architectural overview of the open-source MS
     - `server/migrations/20241224184511_create_document_block_content.cjs`: Block-based content table
   * Features:
     - 1-to-1 relationship between documents and content
-    - Tenant isolation through RLS policies
+    - Tenant isolation through application-level tenant scoping (see [tenant-isolation.md](tenant-isolation.md))
     - Efficient metadata querying
     - Large text content separation
     - Rich text editing with BlockNote:
@@ -97,7 +97,7 @@ This document provides a high-level architectural overview of the open-source MS
 * **Email Notifications:** Comprehensive notification system with template management and tenant customization, integrated with the event bus system. Core components:
   * Database-driven templates:
     - `system_email_templates`: System-wide default templates (read-only)
-    - `tenant_email_templates`: Tenant-specific customizations with RLS
+    - `tenant_email_templates`: Tenant-specific customizations (tenant-scoped)
     - Template inheritance: Tenant templates can be cloned from system templates
   * Configuration and preferences:
     - Global settings per tenant (enable/disable, rate limits)
@@ -436,7 +436,7 @@ No code has been merged yet – this section serves as an architectural note so 
 
 **III. Key Design Considerations:**
 
-* **Multi-Tenancy:** Enforced through database schema and row-level security.
+* **Multi-Tenancy:** Enforced in the application layer: explicit `tenant` columns, Citus distribution, per-request tenant context, and the `tenantDb` query facade. There is no row-level security. See [tenant-isolation.md](tenant-isolation.md).
 
 * **Modularity:**
   * Achieved through the organization of modules in the `server/src/components` and `server/src/lib` directories.

--- a/docs/architecture/tenant-isolation.md
+++ b/docs/architecture/tenant-isolation.md
@@ -1,0 +1,234 @@
+# Tenant isolation and the tenantDb query facade
+
+How tenant data stays separated, and how application code is expected to query
+it. Read this before writing any query that touches a tenant-owned table.
+
+## The isolation model
+
+Tenant isolation is enforced by three application-level mechanisms working
+together. **The database does not enforce it for you.**
+
+1. **Explicit `tenant` columns.** Every tenant-owned table carries a
+   `tenant uuid NOT NULL` column, included in the primary key.
+2. **Citus distribution.** Tables are distributed by `tenant`, so a query that
+   filters on `tenant` routes to one shard. A query without a tenant predicate
+   broadcasts to all shards.
+3. **Per-request tenant context.** `withAuth` (from `@alga-psa/auth`) resolves
+   the session's tenant and runs the action inside `runWithTenant()`
+   (AsyncLocalStorage). `createTenantKnex()` reads that context.
+
+Row-level security is **not** part of the model. RLS policies were removed for
+Citus compatibility (`20250523152638_remove_rls_policies_for_citusdb.cjs`), and
+a final sweep dropped every remaining policy and disabled RLS on all public
+tables (`20260509120000_disable_remaining_rls_policies.cjs`). The app no longer
+sets `app.current_tenant` on pooled connections, so any surviving policy that
+referenced it would fail at read time rather than protect anything. Older
+migrations that create RLS policies are historical; do not copy them.
+
+Because the database does not filter rows for you, a query that forgets the
+tenant predicate returns other tenants' data. The `tenantDb` facade exists so
+that application code cannot forget.
+
+## The tenantDb facade
+
+`tenantDb` (in `@alga-psa/db`, source `packages/db/src/lib/tenantDb.ts`) binds
+one connection and one tenant id, then scopes every query root and join for
+you. It is the default way to query tenant data in application code —
+handwritten `.where({ tenant })` predicates are the legacy shape.
+
+```typescript
+import { withAuth } from '@alga-psa/auth';
+import { createTenantKnex, tenantDb } from '@alga-psa/db';
+
+export const getOpenTickets = withAuth(async (user, { tenant }) => {
+  const { knex } = await createTenantKnex();
+  const db = tenantDb(knex, tenant);
+
+  return db
+    .table('tickets as t')
+    .where('t.status', 'open')
+    .select('t.*');
+});
+```
+
+`createTenantKnex()` still provides the connection and tenant id;
+`tenantDb(knex, tenant)` provides the query surface. The facade throws
+immediately if the tenant id is missing or blank.
+
+Inside a transaction, bind the facade to the transaction handle:
+
+```typescript
+await withTransaction(knex, async (trx) => {
+  const db = tenantDb(trx, tenant);
+  await db.table('tickets').where('ticket_id', id).update({ status: 'closed' });
+});
+```
+
+### Query roots
+
+- **`db.table(expr)`** — the normal entry point. Returns an ordinary Knex
+  builder with the tenant predicate already applied to the root table.
+  Supports aliases: `db.table('tickets as t')` scopes on `t.tenant`.
+  Global tables (per the metadata registry) pass through unscoped; admin
+  tables throw.
+- **`db.subquery(expr)`** — alias of `table()`; use it where the call site is
+  a nested query, for readability.
+- **`db.scoped(expr)`** — returns the branded `TenantScopedQuery` instead of a
+  raw builder. Use it only where a consumer requires structural proof of
+  tenant scoping (for example the SQL authorization compiler). Check with
+  `isTenantScopedQuery()`.
+
+Rows are untyped by default (deliberately `any`, not `Record<string, any>` —
+knex would otherwise key rows by the alias-qualified select string). Opt into
+typing per call: `db.table<ITicket>('tickets as t')`.
+
+### Joins
+
+- **`db.tenantJoin(builder, expr, left, right, options?)`** — joins a table
+  and adds tenant equality automatically when the joined table is
+  tenant-scoped:
+
+  ```typescript
+  const query = db.table('tickets as t');
+  db.tenantJoin(query, 'statuses as s', 't.status_id', 's.status_id');
+  // ON s.status_id = t.status_id AND s.tenant = t.tenant
+  ```
+
+  Options: `type: 'left'` for a left join; `tenantPredicate: 'literal'` to
+  compare against the bound tenant id instead of the root's tenant column;
+  `rootTenantColumn` when the root side cannot be inferred from the join
+  columns; `on` for extra join conditions. Joining a global table adds only
+  your join condition; joining an admin table throws.
+- **`db.tenantJoinSubquery(builder, subquery, left, right, options)`** — joins
+  a derived table. You must name both tenant columns
+  (`rootTenantColumn`, `joinedTenantColumn`) because a derived table has no
+  metadata.
+- **`db.tenantWhereColumn(builder, leftCol, rightCol)`** — adds a
+  column-to-column tenant equality (`?? = ??`) where a join helper does not
+  fit, for example in a correlated subquery.
+
+### Parent-scoped tables
+
+A few child tables have no `tenant` column and inherit isolation from a parent
+(registered as `tenantViaParent`, e.g. `composite_tax_mappings` via
+`tax_rates`). For those:
+
+- **`db.parentScopedTable(expr)`** — returns a builder guarded by
+  `WHERE EXISTS` against the tenant-scoped parent.
+- **`db.insertParentScoped(table, values, returning?)`** — verifies every
+  referenced parent row exists in the bound tenant, then inserts. Alias
+  expressions are rejected.
+
+`table()` and `scoped()` throw for these tables, so the facade tells you when
+you need this path.
+
+### Escape hatches
+
+Some code legitimately queries without a tenant root: tenant discovery, login
+and provider resolution before the tenant is known, cross-tenant maintenance,
+and truly global tables.
+
+```typescript
+db.unscoped('tenants', 'tenant discovery before login');
+```
+
+The reason string is required and non-empty. It makes every bypass grep-able
+and reviewable: `grep -rn "\.unscoped(" server/src packages ee`. Do not launder
+a normal tenant query through `unscoped()` to dodge a missing metadata entry —
+register the table instead.
+
+For operations that must run outside any tenant context (platform
+administration), use `getAdminConnection()` / `withAdminTransaction()` from
+`@alga-psa/db` rather than a tenant connection with `unscoped()` everywhere.
+
+## The table metadata registry
+
+The facade fails closed: it only builds queries for tables registered in
+`packages/db/src/lib/tenantTableMetadata.ts`. An unregistered table throws
+`No tenant table metadata registered for <table>`.
+
+Scopes:
+
+| Scope | Meaning | Facade behavior |
+| --- | --- | --- |
+| `tenant` | Has a `tenant` column (override with `tenantColumn`) | Root and joins scoped automatically |
+| `tenantViaParent` | No tenant column; isolated through a parent table | `parentScopedTable()` / `insertParentScoped()` only |
+| `global` | Shared across tenants (e.g. `system_email_templates`, `standard_statuses`) | `table()` passes through unscoped |
+| `admin` | Platform-level (e.g. `tenants` beyond self-lookup) | Tenant paths throw; use `unscoped()` or the admin connection |
+
+**When you add a table in a migration, register it in the metadata in the same
+change.** Otherwise every facade query against it throws at runtime. See the
+checklist below for what a new tenant table needs.
+
+## Adding a new tenant table
+
+1. **Migration** (`server/migrations/`). Create the table with
+   `tenant uuid NOT NULL` in the primary key, then distribute it with the
+   shared helper (no-op on plain Postgres and on already-distributed tables):
+
+   ```javascript
+   const { ensureTenantDistribution } = require('./utils/citusDistribution.cjs');
+
+   exports.config = { transaction: false }; // Citus rejects distribution inside a tx
+
+   // after createTable:
+   await ensureTenantDistribution(knex, 'my_table'); // distributes on tenant, colocated with tenants
+   ```
+
+   Wider Citus rules live in
+   [citus-migration-best-practices.md](citus-migration-best-practices.md).
+2. **Query metadata.** Register the table in
+   `packages/db/src/lib/tenantTableMetadata.ts` so the facade accepts it.
+
+CI runs additional per-table schema checks over the migrated database; if the
+`Validate Tenant Management Schema` job flags your table, follow the script's
+output.
+
+## What still uses raw tenant predicates
+
+The migration to the facade is staged and still in progress. New code and
+touched code must use `tenantDb`; remaining direct `.where({ tenant })` roots
+and hand-written `.andOn('a.tenant', 'b.tenant')` joins are legacy that gets
+converted when a file is next worked on. Do not add new ones.
+
+Places that intentionally do not use the facade:
+
+- **Migrations and seeds** must not import `@alga-psa/db`; the migration
+  runtime never builds it. A migration that wants facade-shaped scoping uses
+  the self-contained CJS shim at `server/migrations/utils/tenantDb.cjs`, which
+  ports `table()` / `unscoped()` / `tenantJoin()` over a snapshot of the table
+  metadata.
+- **Model/service layers already inside `@alga-psa/db`** may use the branded
+  `createTenantScopedRootQuery` internals directly.
+- **Test fixtures** may use raw Knex, though shared helpers (`TestContext`,
+  billing utilities) have been moved onto the facade.
+
+## How the shape is enforced
+
+There is no lint rule. Enforcement is contract tests: per-slice unit tests
+read the source file and assert the facade shape, for example
+`server/src/test/unit/inboundEmailTenantScoped.contract.test.ts` asserts that
+`inboundWebhookLookups.ts` imports `tenantDb` and starts each root through
+`db.table(...)`. When you migrate a file to the facade, add or extend the
+matching `*TenantScoped.contract.test.ts` so it cannot silently regress.
+
+## Rules that still apply underneath the facade
+
+The facade removes the need to hand-write tenant predicates; it does not
+change the physical model:
+
+- New tenant tables: column named `tenant` (not `tenant_id`), `uuid`,
+  `NOT NULL`, part of the primary key, and in every unique index.
+- Raw SQL (reports, `knex.raw`) must still carry tenant predicates by hand —
+  the facade cannot see inside a raw string. Keep raw tenant SQL rare and
+  covered by contract tests.
+- Never rely on connection-level settings (`app.current_tenant`) for
+  isolation; they do not propagate to Citus shards.
+- Citus specifics (UPDATE restrictions, reference tables, distribution) are
+  covered in [citus-migration-best-practices.md](citus-migration-best-practices.md).
+
+## Related
+
+- Design and migration history: `docs/plans/2026-06-25-tenant-query-full-facade-design.md`
+- Transaction and after-commit rules: [db-transaction-guardrails.md](db-transaction-guardrails.md)
+- Server action auth (`withAuth`, tenant context): `docs/AI_coding_standards.md`

--- a/docs/features/asset_management.md
+++ b/docs/features/asset_management.md
@@ -297,8 +297,7 @@ CREATE TABLE asset_history (
 - Client portal
 
 ### Security Considerations
-- Row-level security
-- Tenant isolation
+- Tenant isolation (application-enforced via the `tenantDb` facade — see [tenant-isolation.md](../architecture/tenant-isolation.md))
 - Role-based access
 - Audit logging
 

--- a/docs/getting-started/development_guide.md
+++ b/docs/getting-started/development_guide.md
@@ -174,16 +174,17 @@ All server actions that need authentication and database access should use the `
 
 ```typescript
 import { withAuth, hasPermission } from '@alga-psa/auth';
-import { createTenantKnex } from '@alga-psa/db';
+import { createTenantKnex, tenantDb } from '@alga-psa/db';
 
 export const myAction = withAuth(async (user, { tenant }, arg1: string): Promise<Result> => {
   const { knex } = await createTenantKnex();
+  const db = tenantDb(knex, tenant);
 
   if (!await hasPermission(user, 'resource', 'action')) {
     throw new Error('Permission denied');
   }
 
-  return knex('table').where({ tenant }).select('*');
+  return db.table('table').select('*');
 });
 ```
 
@@ -192,6 +193,7 @@ export const myAction = withAuth(async (user, { tenant }, arg1: string): Promise
 - The wrapper provides typed `user` (IUserWithRoles) and `{ tenant }` as first two arguments
 - Additional action arguments follow after the context
 - Always check permissions using `hasPermission(user, resource, action)`
+- Query tenant data through the `tenantDb` facade, which applies tenant scoping for you — see [Tenant isolation and the tenantDb query facade](../architecture/tenant-isolation.md)
 
 ### 3. Testing
 

--- a/docs/security/secrets_management.md
+++ b/docs/security/secrets_management.md
@@ -17,7 +17,7 @@ All secrets are stored in the `secrets/` directory at the project root. Each sec
 
 ### Database Secrets
 - `postgres_password` - PostgreSQL admin password (used by 'postgres' user for administration)
-- `db_password_server` - Application user password (used by 'app_user' for RLS-controlled access)
+- `db_password_server` - Application user password (used by 'app_user' for application database access)
 - `db_password_hocuspocus` - Hocuspocus service password
 
 ### Redis Secrets
@@ -91,11 +91,10 @@ The system uses a two-user database authentication model for security:
    - Password: Stored in db_password_server secret
    - Used for:
      * Application database access
-     * Limited access via RLS policies
      * Regular database operations
    - Security:
-     * Access controlled by Row Level Security (RLS)
-     * Cannot modify schema or bypass RLS
+     * Cannot modify schema
+     * Tenant isolation is application-enforced (see [tenant-isolation.md](../architecture/tenant-isolation.md)); there are no RLS policies
 
 ## Security Considerations
 
@@ -168,4 +167,4 @@ The `.env.example` file indicates which values are managed via Docker secrets. W
 8. Follow the principle of least privilege:
    - Use app_user for normal operations
    - Limit postgres user access to administration
-   - Implement proper RLS policies
+   - Keep application queries tenant-scoped through the `tenantDb` facade


### PR DESCRIPTION
Add docs/architecture/tenant-isolation.md as the canonical guide to application-enforced tenant scoping: the tenantDb query facade, the tenantTableMetadata registry, escape hatches, and the new-tenant-table checklist (ensureTenantDistribution + metadata registration).

Fix stale claims left over from the refactoring: AI_coding_standards, overview, development_guide, secrets_management, and asset_management still taught row-level security and hand-written `.where({ tenant })` predicates â RLS was dropped for Citus, and raw tenant predicates are now the legacy shape. All examples and rules now route through tenantDb, with cross-links to the new doc.

Pay no attention to the RLS behind the curtain â there isn't one, and there hasn't been since migration 20260509 pulled it back. The great and powerful tenantDb now scopes every root and tenantJoin, no table enters the Emerald Schema without its name in tenantTableMetadata, and even the flying monkeys must state a reason at the unscoped() gate. ð§ðªð