### PR TITLE
test(setup): restore window.location after every test

### DIFF
--- a/server/src/test/setup.ts
+++ b/server/src/test/setup.ts
@@ -14,6 +14,27 @@ afterEach(async () => {
   cleanup();
 });
 
+// Same reused-jsdom hazard for window.location: several suites replace it with
+// a plain stub (to swallow jsdom's not-implemented navigation), and an
+// unrestored stub has no .search/.pathname and detaches from
+// history.replaceState — whichever URL-reading test the shuffle seats behind
+// it fails (roving per-seed failures: AutomaticInvoices client filter,
+// DefaultLayout interrupt guard). Put the real Location back after every test.
+const realLocation = typeof window === 'undefined' ? undefined : window.location;
+afterEach(() => {
+  if (!realLocation || window.location === realLocation) return;
+  try {
+    Object.defineProperty(window, 'location', {
+      value: realLocation,
+      writable: true,
+      configurable: true,
+    });
+  } catch {
+    // Property left non-configurable by a stub: a value swap is still allowed.
+    Object.defineProperty(window, 'location', { value: realLocation });
+  }
+});
+
 process.env.NEXTAUTH_SECRET ??= 'localtest-nextauth-secret';
 
 // Vitest coverage (v8) uses a temp directory under the reports directory.

--- a/server/src/test/unit/components/GmailProviderForm.test.tsx
+++ b/server/src/test/unit/components/GmailProviderForm.test.tsx
@@ -44,6 +44,7 @@ describe('GmailProviderForm', () => {
     vi.clearAllMocks();
     // Mock window.location
     Object.defineProperty(window, 'location', {
+      configurable: true,
       value: {
         origin: 'http://localhost:3000',
         href: 'http://localhost:3000',

--- a/server/src/test/unit/components/MicrosoftProviderForm.test.tsx
+++ b/server/src/test/unit/components/MicrosoftProviderForm.test.tsx
@@ -36,6 +36,7 @@ describe('MicrosoftProviderForm', () => {
     vi.clearAllMocks();
     // Mock window.location
     Object.defineProperty(window, 'location', {
+      configurable: true,
       value: {
         origin: 'http://localhost:3000',
         href: 'http://localhost:3000',


### PR DESCRIPTION
The provider-form suites replace window.location with a plain stub to swallow jsdom navigation, and never put it back. The jsdom environment is reused across files in this single-fork suite, so the stub — which has no .search and is detached from history.replaceState — poisons whichever URL-reading test the shuffle seats behind it: the CI merge run lost the AutomaticInvoices client-filter test, a local run lost the DefaultLayout interrupt guard. setup.ts now swaps the real Location back in after every test (mirroring the existing RTL-cleanup guard for the same reused-jsdom hazard), and the stubs are marked configurable so the property never gets locked.

The Walrus wept: "The URL you seek was here before you rendered — but a paper moon hung where the window used to be, and no ?search= shone through it." Now the Carpenter rehangs the true Location after every tea, and whichever test sits down next finds the sea, the shore, and the query string exactly where jsdom left them. 🌊🪟🔍