### PR TITLE
test(unit): defuse the dice-roll and wait-for-render flakes

### DIFF
--- a/server/src/lib/mobileAuth/mobileAuthService.ts
+++ b/server/src/lib/mobileAuth/mobileAuthService.ts
@@ -443,9 +443,13 @@ export async function refreshMobileSession(input: z.infer<typeof refreshSessionS
   // Probabilistic stale-key cleanup: run on ~5% of refreshes to avoid
   // unnecessary DB work on every token rotation.
   if (Math.random() < 0.05) {
-    ApiKeyService.cleanupStaleKeys(result.existing.user_id, result.existing.tenant).catch((err) => {
-      console.warn('[mobileAuth] stale key cleanup failed', { error: err });
-    });
+    // Fire-and-forget: route through a promise so even a synchronous throw
+    // cannot fail the (already successful) rotation.
+    Promise.resolve()
+      .then(() => ApiKeyService.cleanupStaleKeys(result.existing.user_id, result.existing.tenant))
+      .catch((err) => {
+        console.warn('[mobileAuth] stale key cleanup failed', { error: err });
+      });
   }
 
   return {

--- a/server/src/test/unit/billing/contractPurchaseOrderSupport.ui.test.tsx
+++ b/server/src/test/unit/billing/contractPurchaseOrderSupport.ui.test.tsx
@@ -342,7 +342,7 @@ describe('Contract PO UI flows', () => {
       expect(getAvailableRecurringDueWorkMock).toHaveBeenCalled();
     });
 
-    const readyTable = screen.getAllByTestId('automatic-invoices-table').at(-1)!
+    const readyTable = (await screen.findAllByTestId('automatic-invoices-table')).at(-1)!
     const checkboxes = within(readyTable).getAllByRole('checkbox');
     expect(checkboxes.length).toBeGreaterThanOrEqual(2);
     fireEvent.click(checkboxes[0]!);
@@ -400,7 +400,7 @@ describe('Contract PO UI flows', () => {
       expect(getAvailableRecurringDueWorkMock).toHaveBeenCalled();
     });
 
-    const readyTable = screen.getAllByTestId('automatic-invoices-table').at(-1)!
+    const readyTable = (await screen.findAllByTestId('automatic-invoices-table')).at(-1)!
     const checkboxes = within(readyTable).getAllByRole('checkbox');
     expect(checkboxes.length).toBeGreaterThanOrEqual(2);
     fireEvent.click(checkboxes[0]!);
@@ -485,7 +485,7 @@ describe('Contract PO UI flows', () => {
       expect(getAvailableRecurringDueWorkMock).toHaveBeenCalled();
     });
 
-    const readyTable = screen.getAllByTestId('automatic-invoices-table').at(-1)!
+    const readyTable = (await screen.findAllByTestId('automatic-invoices-table')).at(-1)!
     const checkbox = within(readyTable).getAllByRole('checkbox')[0];
     fireEvent.click(checkbox!);
 
@@ -552,7 +552,7 @@ describe('Contract PO UI flows', () => {
       expect(screen.getByText('Zenith Health')).toBeInTheDocument();
     });
 
-    const readyTable = screen.getAllByTestId('automatic-invoices-table').at(-1)!;
+    const readyTable = (await screen.findAllByTestId('automatic-invoices-table')).at(-1)!;
     const checkbox = within(readyTable).getAllByRole('checkbox')[0];
     fireEvent.click(checkbox!);
     fireEvent.click(
@@ -587,7 +587,7 @@ describe('Contract PO UI flows', () => {
       expect(screen.getByText('Alpha Co')).toBeInTheDocument();
     });
 
-    const readyTable = screen.getAllByTestId('automatic-invoices-table').at(-1)!;
+    const readyTable = (await screen.findAllByTestId('automatic-invoices-table')).at(-1)!;
     fireEvent.click(within(readyTable).getAllByRole('checkbox')[0]!);
     fireEvent.click(
       screen.getByRole('button', { name: /Generate Invoices \(1\)/i }),
@@ -664,7 +664,7 @@ describe('Contract PO UI flows', () => {
       expect(screen.getByText('Zenith Health')).toBeInTheDocument();
     });
 
-    const readyTable = screen.getAllByTestId('automatic-invoices-table').at(-1)!;
+    const readyTable = (await screen.findAllByTestId('automatic-invoices-table')).at(-1)!;
     const checkbox = within(readyTable).getAllByRole('checkbox')[0];
     fireEvent.click(checkbox!);
     fireEvent.click(screen.getByRole('button', { name: /Preview Selected/i }));

--- a/server/src/test/unit/mobileAuth.test.ts
+++ b/server/src/test/unit/mobileAuth.test.ts
@@ -18,10 +18,13 @@ vi.mock('@alga-psa/auth', async (importOriginal) => {
   const mod = await importOriginal<typeof import('@alga-psa/auth')>();
   return {
     ...mod,
+    // ApiKeyService is a class: spreading it copies no statics, so every
+    // method the service calls must be listed here explicitly.
     ApiKeyService: {
       ...mod.ApiKeyService,
       createApiKey: vi.fn(),
       deactivateApiKey: vi.fn(),
+      cleanupStaleKeys: vi.fn(async () => undefined),
     },
   };
 });


### PR DESCRIPTION
Two probabilistic failures from the post-merge coverage run. The mobile-auth refresh path runs stale-key cleanup behind Math.random() < 0.05, and the test mock — built by spreading the ApiKeyService class, which copies no statics — lacked cleanupStaleKeys, so one run in twenty threw a synchronous TypeError that .catch cannot intercept; the mock now defines it, and production routes the fire-and-forget through Promise.resolve() so a sync throw can never fail a successful rotation. The contract-PO UI tests waited only for the due-work fetch to be CALLED and then grabbed the ready table synchronously — under coverage-slowed timing the resolved rows had not rendered yet; all six sites now findAllByTestId the rendered table.

"There is no use trying," said Alice, "one can never win against a d20 sewn into the refresh path." "I daresay you haven not listed its statics," said the Queen. "Why, sometimes the cleanup rolls a five before breakfast — and the table you reach for has not yet been laid. Wait for the plates, child, not for the sound of the dinner bell." 🎲🍽️🐇