### PR TITLE
inventory menu update

### DIFF
--- a/packages/billing/src/actions/recurringApprovalBlockers.ts
+++ b/packages/billing/src/actions/recurringApprovalBlockers.ts
@@ -2,7 +2,6 @@ import type { Knex } from 'knex';
 import { tenantDb } from '@alga-psa/db';
 import { toISODate, toPlainDate } from '@alga-psa/core';
 import type { ISO8601String } from '@alga-psa/types';
-import { toPlainDate, toISODate } from '@alga-psa/core';
 
 export type RecurringApprovalBlockerRow = {
   executionIdentityKey: string;

--- a/server/public/locales/de/msp/core.json
+++ b/server/public/locales/de/msp/core.json
@@ -14,7 +14,16 @@
     "documentsAll": "Alle Dokumente",
     "knowledgeBase": "Wissensdatenbank",
     "assets": "Assets",
-    "inventory": "Lagerbestand",
+    "inventory": {
+      "label": "Lagerbestand",
+      "sections": {
+        "overview": "Übersicht",
+        "stock": "Bestand",
+        "purchasing": "Einkauf",
+        "salesFulfillment": "Vertrieb und Abwicklung",
+        "analytics": "Analysen"
+      }
+    },
     "inventoryDashboard": "Dashboard",
     "inventoryStock": "Bestand",
     "inventoryLocations": "Bestandsstandorte",

--- a/server/public/locales/en/msp/core.json
+++ b/server/public/locales/en/msp/core.json
@@ -14,7 +14,16 @@
     "documentsAll": "All Documents",
     "knowledgeBase": "Knowledge Base",
     "assets": "Assets",
-    "inventory": "Inventory",
+    "inventory": {
+      "label": "Inventory",
+      "sections": {
+        "overview": "Overview",
+        "stock": "Stock",
+        "purchasing": "Purchasing",
+        "salesFulfillment": "Sales & Fulfillment",
+        "analytics": "Analytics"
+      }
+    },
     "inventoryDashboard": "Dashboard",
     "inventoryStock": "Stock",
     "inventoryLocations": "Stock Locations",

--- a/server/public/locales/es/msp/core.json
+++ b/server/public/locales/es/msp/core.json
@@ -14,7 +14,16 @@
     "documentsAll": "Todos los documentos",
     "knowledgeBase": "Base de conocimientos",
     "assets": "Activos",
-    "inventory": "Inventario",
+    "inventory": {
+      "label": "Inventario",
+      "sections": {
+        "overview": "Resumen",
+        "stock": "Existencias",
+        "purchasing": "Compras",
+        "salesFulfillment": "Ventas y cumplimiento",
+        "analytics": "Análisis"
+      }
+    },
     "inventoryDashboard": "Panel",
     "inventoryStock": "Existencias",
     "inventoryLocations": "Ubicaciones de existencias",

--- a/server/public/locales/fr/msp/core.json
+++ b/server/public/locales/fr/msp/core.json
@@ -14,7 +14,16 @@
     "documentsAll": "Tous les documents",
     "knowledgeBase": "Base de connaissances",
     "assets": "Actifs",
-    "inventory": "Inventaire",
+    "inventory": {
+      "label": "Inventaire",
+      "sections": {
+        "overview": "Vue d’ensemble",
+        "stock": "Stock",
+        "purchasing": "Achats",
+        "salesFulfillment": "Ventes et exécution",
+        "analytics": "Analyses"
+      }
+    },
     "inventoryDashboard": "Tableau de bord",
     "inventoryStock": "Stock",
     "inventoryLocations": "Emplacements de stock",

--- a/server/public/locales/it/msp/core.json
+++ b/server/public/locales/it/msp/core.json
@@ -14,7 +14,16 @@
     "documentsAll": "Tutti i documenti",
     "knowledgeBase": "Base di conoscenza",
     "assets": "Asset",
-    "inventory": "Inventario",
+    "inventory": {
+      "label": "Inventario",
+      "sections": {
+        "overview": "Panoramica",
+        "stock": "Giacenza",
+        "purchasing": "Acquisti",
+        "salesFulfillment": "Vendite ed evasione",
+        "analytics": "Analisi"
+      }
+    },
     "inventoryDashboard": "Dashboard",
     "inventoryStock": "Giacenza",
     "inventoryLocations": "Ubicazioni di giacenza",

--- a/server/public/locales/nl/msp/core.json
+++ b/server/public/locales/nl/msp/core.json
@@ -14,7 +14,16 @@
     "documentsAll": "Alle documenten",
     "knowledgeBase": "Kennisbank",
     "assets": "Assets",
-    "inventory": "Inventaris",
+    "inventory": {
+      "label": "Inventaris",
+      "sections": {
+        "overview": "Overzicht",
+        "stock": "Voorraad",
+        "purchasing": "Inkoop",
+        "salesFulfillment": "Verkoop en uitvoering",
+        "analytics": "Analyse"
+      }
+    },
     "inventoryDashboard": "Dashboard",
     "inventoryStock": "Voorraad",
     "inventoryLocations": "Voorraadlocaties",

--- a/server/public/locales/pl/msp/core.json
+++ b/server/public/locales/pl/msp/core.json
@@ -14,7 +14,16 @@
     "documentsAll": "Wszystkie dokumenty",
     "knowledgeBase": "Baza wiedzy",
     "assets": "Zasoby",
-    "inventory": "Zapasy",
+    "inventory": {
+      "label": "Zapasy",
+      "sections": {
+        "overview": "Przegląd",
+        "stock": "Zapas",
+        "purchasing": "Zakupy",
+        "salesFulfillment": "Sprzedaż i realizacja",
+        "analytics": "Analityka"
+      }
+    },
     "inventoryDashboard": "Pulpit",
     "inventoryStock": "Zapas",
     "inventoryLocations": "Lokalizacje magazynowe",

--- a/server/public/locales/pt/msp/core.json
+++ b/server/public/locales/pt/msp/core.json
@@ -14,7 +14,16 @@
     "documentsAll": "Todos os documentos",
     "knowledgeBase": "Base de conhecimento",
     "assets": "Ativos",
-    "inventory": "Inventário",
+    "inventory": {
+      "label": "Inventário",
+      "sections": {
+        "overview": "Visão geral",
+        "stock": "Estoque",
+        "purchasing": "Compras",
+        "salesFulfillment": "Vendas e atendimento",
+        "analytics": "Análises"
+      }
+    },
     "inventoryDashboard": "Painel",
     "inventoryStock": "Estoque",
     "inventoryLocations": "Localizações de Estoque",

--- a/server/public/locales/xx/msp/core.json
+++ b/server/public/locales/xx/msp/core.json
@@ -14,7 +14,16 @@
     "documentsAll": "11111",
     "knowledgeBase": "11111",
     "assets": "11111",
-    "inventory": "11111",
+    "inventory": {
+      "label": "11111",
+      "sections": {
+        "overview": "11111",
+        "stock": "11111",
+        "purchasing": "11111",
+        "salesFulfillment": "11111",
+        "analytics": "11111"
+      }
+    },
     "inventoryDashboard": "11111",
     "inventoryStock": "11111",
     "inventoryLocations": "11111",

--- a/server/public/locales/yy/msp/core.json
+++ b/server/public/locales/yy/msp/core.json
@@ -14,7 +14,16 @@
     "documentsAll": "55555",
     "knowledgeBase": "55555",
     "assets": "55555",
-    "inventory": "55555",
+    "inventory": {
+      "label": "55555",
+      "sections": {
+        "overview": "55555",
+        "stock": "55555",
+        "purchasing": "55555",
+        "salesFulfillment": "55555",
+        "analytics": "55555"
+      }
+    },
     "inventoryDashboard": "55555",
     "inventoryStock": "55555",
     "inventoryLocations": "55555",

--- a/server/src/components/layout/DefaultLayout.tsx
+++ b/server/src/components/layout/DefaultLayout.tsx
@@ -52,6 +52,7 @@ export default function DefaultLayout({ children, initialSidebarCollapsed = fals
     if (path.startsWith('/msp/settings')) return 'settings';
     if (path.startsWith('/msp/billing')) return 'billing';
     if (path.startsWith('/msp/extensions')) return 'extensions';
+    if (path.startsWith('/msp/inventory')) return 'inventory';
     return 'main';
   };
 

--- a/server/src/components/layout/Sidebar.tsx
+++ b/server/src/components/layout/Sidebar.tsx
@@ -14,6 +14,7 @@ import {
   settingsNavigationSections,
   billingNavigationSections,
   extensionsNavigationSections,
+  inventoryNavigationSections,
   type NavigationSection,
   type NavMode,
 } from '@/config/menuConfig';
@@ -93,7 +94,8 @@ const Sidebar: React.FC<SidebarProps> = ({
   const isSettingsMode = mode === 'settings';
   const isBillingMode = mode === 'billing';
   const isExtensionsMode = mode === 'extensions';
-  const isSubMode = isSettingsMode || isBillingMode || isExtensionsMode;
+  const isInventoryMode = mode === 'inventory';
+  const isSubMode = isSettingsMode || isBillingMode || isExtensionsMode || isInventoryMode;
 
   const isActive = (path: string) => {
     if (!path) {
@@ -240,7 +242,9 @@ const Sidebar: React.FC<SidebarProps> = ({
       ? billingSections
       : isExtensionsMode
         ? extensionsNavigationSections
-        : (menuSections ?? defaultNavigationSections);
+        : isInventoryMode
+          ? inventoryNavigationSections
+          : (menuSections ?? defaultNavigationSections);
 
   const sectionsToRender = rawSectionsToRender.map(translateSection);
   const translatedBottomMenuItems = bottomMenuItems.map(translateMenuItem);
@@ -253,7 +257,9 @@ const Sidebar: React.FC<SidebarProps> = ({
       ? 'billing-sidebar'
       : isExtensionsMode
         ? 'extensions-sidebar'
-        : 'main-sidebar';
+        : isInventoryMode
+          ? 'inventory-sidebar'
+          : 'main-sidebar';
 
   return (
     <aside

--- a/server/src/config/menuConfig.ts
+++ b/server/src/config/menuConfig.ts
@@ -55,7 +55,7 @@ import {
 } from 'lucide-react';
 
 // Navigation modes for the unified sidebar
-export type NavMode = 'main' | 'settings' | 'billing' | 'extensions';
+export type NavMode = 'main' | 'settings' | 'billing' | 'extensions' | 'inventory';
 
 export interface MenuItem {
   name: string;
@@ -145,26 +145,9 @@ export const navigationSections: NavigationSection[] = [
       },
       {
         name: 'Inventory',
-        translationKey: 'nav.inventory',
+        translationKey: 'nav.inventory.label',
         icon: Package,
-        subItems: [
-          { name: 'Dashboard', translationKey: 'nav.inventoryDashboard', icon: Gauge, href: '/msp/inventory' },
-          { name: 'Stock', translationKey: 'nav.inventoryStock', icon: Package, href: '/msp/inventory/stock' },
-          { name: 'Stock Locations', translationKey: 'nav.inventoryLocations', icon: MapPin, href: '/msp/inventory/locations' },
-          { name: 'Stock Units', translationKey: 'nav.inventoryUnits', icon: Layers3, href: '/msp/inventory/units' },
-          { name: 'Vendors', translationKey: 'nav.inventoryVendors', icon: Handshake, href: '/msp/inventory/vendors' },
-          { name: 'Purchase Orders', translationKey: 'nav.inventoryPurchaseOrders', icon: Receipt, href: '/msp/inventory/purchase-orders' },
-          { name: 'Vendor Bills', translationKey: 'nav.inventoryVendorBills', icon: Receipt, href: '/msp/inventory/vendor-bills' },
-          { name: 'Sales Orders', translationKey: 'nav.inventorySalesOrders', icon: ReceiptText, href: '/msp/inventory/sales-orders' },
-          { name: 'Transfers', translationKey: 'nav.inventoryTransfers', icon: FileOutput, href: '/msp/inventory/transfers' },
-          { name: 'Cycle Counts', translationKey: 'nav.inventoryCounts', icon: ListChecks, href: '/msp/inventory/counts' },
-          { name: 'Write-offs', translationKey: 'nav.inventoryWriteOffs', icon: FileOutput, href: '/msp/inventory/write-offs' },
-          { name: 'Margin', translationKey: 'nav.inventoryMargin', icon: Percent, href: '/msp/inventory/margin' },
-          { name: 'Ghost Usage', translationKey: 'nav.inventoryGhostUsage', icon: Ghost, href: '/msp/inventory/ghost-usage' },
-          { name: 'RMA', translationKey: 'nav.inventoryRma', icon: ListTree, href: '/msp/inventory/rma' },
-          { name: 'Loaners', translationKey: 'nav.inventoryLoaners', icon: Timer, href: '/msp/inventory/loaners' },
-          { name: 'Kits', translationKey: 'nav.inventoryKits', icon: Package, href: '/msp/inventory/kits' }
-        ]
+        href: '/msp/inventory'
       },
       {
         name: 'Reports',
@@ -305,6 +288,56 @@ export const settingsNavigationSections: NavigationSection[] = [
     translationKey: 'settings.sections.experimental',
     items: [
       { name: 'Experimental Features', translationKey: 'settings.tabs.experimentalFeatures', icon: FlaskConical, href: '/msp/settings?tab=experimental-features' },
+    ]
+  },
+];
+
+// Inventory navigation sections - used when sidebar is in 'inventory' mode
+export const inventoryNavigationSections: NavigationSection[] = [
+  {
+    title: 'Overview',
+    translationKey: 'nav.inventory.sections.overview',
+    items: [
+      { name: 'Dashboard', translationKey: 'nav.inventoryDashboard', icon: Gauge, href: '/msp/inventory' },
+    ]
+  },
+  {
+    title: 'Stock',
+    translationKey: 'nav.inventory.sections.stock',
+    items: [
+      { name: 'Stock', translationKey: 'nav.inventoryStock', icon: Package, href: '/msp/inventory/stock' },
+      { name: 'Stock Locations', translationKey: 'nav.inventoryLocations', icon: MapPin, href: '/msp/inventory/locations' },
+      { name: 'Stock Units', translationKey: 'nav.inventoryUnits', icon: Layers3, href: '/msp/inventory/units' },
+      { name: 'Transfers', translationKey: 'nav.inventoryTransfers', icon: FileOutput, href: '/msp/inventory/transfers' },
+      { name: 'Cycle Counts', translationKey: 'nav.inventoryCounts', icon: ListChecks, href: '/msp/inventory/counts' },
+      { name: 'Write-offs', translationKey: 'nav.inventoryWriteOffs', icon: FileOutput, href: '/msp/inventory/write-offs' },
+    ]
+  },
+  {
+    title: 'Purchasing',
+    translationKey: 'nav.inventory.sections.purchasing',
+    items: [
+      { name: 'Vendors', translationKey: 'nav.inventoryVendors', icon: Handshake, href: '/msp/inventory/vendors' },
+      { name: 'Purchase Orders', translationKey: 'nav.inventoryPurchaseOrders', icon: Receipt, href: '/msp/inventory/purchase-orders' },
+      { name: 'Vendor Bills', translationKey: 'nav.inventoryVendorBills', icon: Receipt, href: '/msp/inventory/vendor-bills' },
+    ]
+  },
+  {
+    title: 'Sales & Fulfillment',
+    translationKey: 'nav.inventory.sections.salesFulfillment',
+    items: [
+      { name: 'Sales Orders', translationKey: 'nav.inventorySalesOrders', icon: ReceiptText, href: '/msp/inventory/sales-orders' },
+      { name: 'RMA', translationKey: 'nav.inventoryRma', icon: ListTree, href: '/msp/inventory/rma' },
+      { name: 'Loaners', translationKey: 'nav.inventoryLoaners', icon: Timer, href: '/msp/inventory/loaners' },
+      { name: 'Kits', translationKey: 'nav.inventoryKits', icon: Package, href: '/msp/inventory/kits' },
+    ]
+  },
+  {
+    title: 'Analytics',
+    translationKey: 'nav.inventory.sections.analytics',
+    items: [
+      { name: 'Margin', translationKey: 'nav.inventoryMargin', icon: Percent, href: '/msp/inventory/margin' },
+      { name: 'Ghost Usage', translationKey: 'nav.inventoryGhostUsage', icon: Ghost, href: '/msp/inventory/ghost-usage' },
     ]
   },
 ];

--- a/server/src/test/unit/layout/menuConfig.i18n.test.ts
+++ b/server/src/test/unit/layout/menuConfig.i18n.test.ts
@@ -4,6 +4,7 @@ import {
   billingNavigationSections,
   bottomMenuItems,
   extensionsNavigationSections,
+  inventoryNavigationSections,
   navigationSections,
   settingsNavigationSections,
 } from '../../../config/menuConfig';
@@ -49,7 +50,7 @@ describe('menuConfig i18n metadata', () => {
       'nav.contacts',
       'nav.documents',
       'nav.assets',
-      'nav.inventory',
+      'nav.inventory.label',
       'nav.billing.reports',
       'nav.timeManagement',
       'nav.billing.label',
@@ -74,22 +75,6 @@ describe('menuConfig i18n metadata', () => {
       'nav.projectsTemplates',
       'nav.documentsAll',
       'nav.knowledgeBase',
-      'nav.inventoryDashboard',
-      'nav.inventoryStock',
-      'nav.inventoryLocations',
-      'nav.inventoryUnits',
-      'nav.inventoryVendors',
-      'nav.inventoryPurchaseOrders',
-      'nav.inventoryVendorBills',
-      'nav.inventorySalesOrders',
-      'nav.inventoryTransfers',
-      'nav.inventoryCounts',
-      'nav.inventoryWriteOffs',
-      'nav.inventoryMargin',
-      'nav.inventoryGhostUsage',
-      'nav.inventoryRma',
-      'nav.inventoryLoaners',
-      'nav.inventoryKits',
       'nav.timeEntry',
       'nav.approvals',
       'nav.controlPanel',
@@ -178,6 +163,37 @@ describe('menuConfig i18n metadata', () => {
   it('F006 wiring: extensions navigation item exposes sidebar settings translation key', () => {
     expect(extensionsNavigationSections[0].items.map((item) => item.translationKey)).toEqual([
       'sidebar.settings',
+    ]);
+  });
+
+  it('T010: inventory navigation section titles use nav.inventory.sections.* translation keys', () => {
+    expect(inventoryNavigationSections.map((section) => section.translationKey)).toEqual([
+      'nav.inventory.sections.overview',
+      'nav.inventory.sections.stock',
+      'nav.inventory.sections.purchasing',
+      'nav.inventory.sections.salesFulfillment',
+      'nav.inventory.sections.analytics',
+    ]);
+  });
+
+  it('T011: inventory navigation items use nav.inventory* translation keys', () => {
+    expect(collectSectionItems(inventoryNavigationSections).map((item) => item.translationKey)).toEqual([
+      'nav.inventoryDashboard',
+      'nav.inventoryStock',
+      'nav.inventoryLocations',
+      'nav.inventoryUnits',
+      'nav.inventoryTransfers',
+      'nav.inventoryCounts',
+      'nav.inventoryWriteOffs',
+      'nav.inventoryVendors',
+      'nav.inventoryPurchaseOrders',
+      'nav.inventoryVendorBills',
+      'nav.inventorySalesOrders',
+      'nav.inventoryRma',
+      'nav.inventoryLoaners',
+      'nav.inventoryKits',
+      'nav.inventoryMargin',
+      'nav.inventoryGhostUsage',
     ]);
   });
 });


### PR DESCRIPTION
## Summary
- Converts the main sidebar Inventory entry from an expandable group into a single `/msp/inventory` anchor.
- Adds a dedicated inventory sidebar mode for `/msp/inventory*`, using five grouped sections: Overview, Stock, Purchasing, Sales & Fulfillment, and Analytics.
- Wires `DefaultLayout` and `Sidebar` to render `data-automation-id="inventory-sidebar"` for inventory routes, and updates i18n metadata/tests plus locale keys for the new grouped section labels.
- Removes a duplicate `toISODate`/`toPlainDate` billing helper import that blocked required server and EE typechecks on this branch.

## Smoke Test
PASS: inventory menu update.

Environment: tested the real dev server at `http://localhost:3530` from `/home/robert/alga-copies/feature-inventory-menu-update`. The port is served by the worktree Next dev process with `PORT=3530`. PgBouncer on `6472` and Hocuspocus TCP on `1235` were reachable. Docker container inspection was not available from this shell: direct Docker access was permission-denied and `sudo docker` required interactive auth, so container status could not be proven via Docker.

Flows exercised:
- Logged into the real UI as the dev Glinda user.
- Verified the dashboard main sidebar shows Inventory as a single anchor to `/msp/inventory`, not an expandable group.
- Clicked Inventory and verified `/msp/inventory` renders `data-automation-id="inventory-sidebar"` with Back to Main and the expected groups: Overview, Stock, Purchasing, Sales & Fulfillment, Analytics.
- Clicked representative links from multiple groups: Stock, Purchase Orders, Sales Orders, and Ghost Usage. Each landed on the expected `/msp/inventory/*` URL, kept `inventory-sidebar` active, and highlighted the clicked link.
- Adjacent regression check passed: Back to Main returned to `main-sidebar`, then Billing switched to `billing-sidebar` with Client Contracts active.

Evidence: `/tmp/alga-smoke-evidence/inventory-menu-update-20260707-151133`

## Verification
- PASS: `NODE_OPTIONS=--max-old-space-size=16384 npm --workspace server run typecheck`
- PASS: `NODE_OPTIONS=--max-old-space-size=16384 npm --workspace sebastian-ee run typecheck`

## Notes
- Stacking/base: PR remains open against `main` from `feature/inventory-menu-update`.
- Fidelity compromises: alga-dev could not create a fresh browser tab, so an existing browser pane was reused and targeted explicitly. No simulators or mocks were used. URL wait helpers sometimes timed out even after navigation succeeded, so assertions used live URL/title, DOM eval, active link classes, and screenshots.
- Concerns: Glinda lacks some inventory read permissions in this wired DB, so inventory pages emitted permission-related 500/action errors while still rendering the navigation shell. Inventory data behavior was not validated, only the menu/sidebar navigation change. The browser also logged repeated Hocuspocus websocket handshake resets on localhost:1235; unrelated to this menu change. The pre-existing uncommitted `package-lock.json` change remains untouched.