### PR TITLE
fix: client CSV import update-existing path

### DIFF
--- a/packages/clients/src/actions/clientActions.importCsv.test.ts
+++ b/packages/clients/src/actions/clientActions.importCsv.test.ts
@@ -1,0 +1,481 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const createTenantKnexMock = vi.hoisted(() => vi.fn());
+const tenantDbMock = vi.hoisted(() => vi.fn((conn: any) => ({
+  table: (table: string) => conn(table),
+})));
+const withTransactionMock = vi.hoisted(() => vi.fn());
+const hasPermissionAsyncMock = vi.hoisted(() => vi.fn());
+const createTagMock = vi.hoisted(() => vi.fn());
+const findTagsByEntityIdMock = vi.hoisted(() => vi.fn());
+const isEnterpriseRef = vi.hoisted(() => ({ value: false }));
+const authUserRef = vi.hoisted(() => ({
+  value: {
+    user_id: 'user-1',
+    user_type: 'internal' as 'internal' | 'client',
+    clientId: undefined as string | undefined,
+    contact_id: undefined as string | undefined,
+  },
+}));
+
+type ServerAction = (...args: unknown[]) => unknown;
+
+vi.mock('@alga-psa/auth', () => ({
+  preCheckDeletion: vi.fn(),
+  withAuth: (fn: ServerAction) => (...args: unknown[]) =>
+    fn(authUserRef.value, { tenant: 'tenant-1' }, ...args),
+}));
+
+vi.mock('@alga-psa/core', () => ({
+  deleteEntityWithValidation: vi.fn(),
+  unparseCSV: vi.fn(),
+  get isEnterprise() {
+    return isEnterpriseRef.value;
+  },
+}));
+
+vi.mock('@alga-psa/db', () => ({
+  createTenantKnex: createTenantKnexMock,
+  tenantDb: tenantDbMock,
+  withTransaction: withTransactionMock,
+}));
+
+vi.mock('../lib/authHelpers', () => ({
+  hasPermissionAsync: hasPermissionAsyncMock,
+  isClientPortalUser: (user: any) => user?.user_type === 'client',
+  hasMspPermission: async (user: any, resource: string, action: string, db?: any) =>
+    user?.user_type === 'internal' && await hasPermissionAsyncMock(user, resource, action, db),
+  assertMspPermission: async (user: any, resource: string, action: string, message: string, db?: any) => {
+    if (!(user?.user_type === 'internal' && await hasPermissionAsyncMock(user, resource, action, db))) {
+      throw new Error(message);
+    }
+  },
+  hasMspOrClientPortalOwnClientPermission: async (user: any, _tenant: string, clientId: string, resource: string, action: string, db?: any) =>
+    (user?.user_type === 'internal' || (user?.user_type === 'client' && user?.clientId === clientId))
+      && await hasPermissionAsyncMock(user, resource, action, db),
+  assertMspOrClientPortalOwnClientPermission: async (user: any, _tenant: string, clientId: string, resource: string, action: string, message: string, db?: any) => {
+    if (!((user?.user_type === 'internal' || (user?.user_type === 'client' && user?.clientId === clientId))
+      && await hasPermissionAsyncMock(user, resource, action, db))) {
+      throw new Error(message);
+    }
+  },
+}));
+
+vi.mock('../lib/billingHelpers', () => ({
+  createDefaultTaxSettingsAsync: vi.fn(),
+}));
+
+vi.mock('../lib/documentsHelpers', () => ({
+  getClientLogoUrlAsync: vi.fn(),
+  getClientLogoUrlsBatchAsync: vi.fn(),
+}));
+
+vi.mock('@alga-psa/storage', () => ({
+  uploadEntityImage: vi.fn(),
+  deleteEntityImage: vi.fn(),
+}));
+
+vi.mock('@alga-psa/tags/actions', () => ({
+  createTag: createTagMock,
+  findTagsByEntityId: findTagsByEntityIdMock,
+}));
+
+vi.mock('@alga-psa/tags/lib/tagCleanup', () => ({
+  deleteEntityTags: vi.fn(),
+}));
+
+vi.mock('@alga-psa/shared/models/clientModel', () => ({
+  ClientModel: {},
+}));
+
+vi.mock('@alga-psa/event-bus/publishers', () => ({
+  publishWorkflowEvent: vi.fn(),
+}));
+
+vi.mock('@alga-psa/workflow-streams', () => ({
+  buildClientArchivedPayload: vi.fn(),
+  buildClientCreatedPayload: vi.fn(),
+  buildClientOwnerAssignedPayload: vi.fn(),
+  buildClientStatusChangedPayload: vi.fn(),
+  buildClientUpdatedPayload: vi.fn(() => ({ updatedFields: [], changes: {} })),
+  buildContactPrimarySetPayload: vi.fn(),
+}));
+
+vi.mock('@alga-psa/shared/billingClients/defaultContract', () => ({
+  ensureDefaultContractForClientIfBillingConfigured: vi.fn(),
+}));
+
+vi.mock('next/cache', () => ({
+  revalidatePath: vi.fn(),
+}));
+
+// Real column lists (from the production schema). The fake DB rejects unknown
+// columns exactly like Postgres so schema drift in the import fails these tests.
+const TABLE_COLUMNS: Record<string, Set<string>> = {
+  clients: new Set([
+    'tenant', 'client_id', 'client_name', 'url', 'properties', 'billing_type',
+    'payment_terms', 'credit_limit', 'preferred_payment_method', 'auto_invoice',
+    'invoice_delivery_method', 'created_at', 'updated_at', 'is_inactive',
+    'client_type', 'is_tax_exempt', 'tax_exemption_certificate', 'tax_id_number',
+    'notes', 'credit_balance', 'billing_cycle', 'timezone', 'notes_document_id',
+    'invoice_template_id', 'billing_contact_id', 'billing_email', 'region_code',
+    'account_manager_id', 'default_currency_code', 'sla_policy_id',
+    'entra_tenant_id', 'entra_primary_domain', 'inbound_ticket_defaults_id',
+  ]),
+  client_locations: new Set([
+    'location_id', 'tenant', 'client_id', 'location_name', 'address_line1',
+    'address_line2', 'address_line3', 'city', 'state_province', 'postal_code',
+    'country_code', 'country_name', 'region_code', 'is_billing_address',
+    'is_shipping_address', 'is_default', 'phone', 'fax', 'email', 'notes',
+    'is_active', 'created_at', 'updated_at',
+  ]),
+  default_billing_settings: new Set(['tenant', 'default_currency_code']),
+};
+
+interface FakeState {
+  clients: Record<string, any>[];
+  client_locations: Record<string, any>[];
+  default_billing_settings: Record<string, any>[];
+  updates: Array<{ table: string; data: Record<string, any> }>;
+  failClientInsertNamed: string | null;
+}
+
+let state: FakeState;
+let idCounter: number;
+
+function assertRealColumns(table: string, data: Record<string, any>) {
+  for (const key of Object.keys(data)) {
+    if (!TABLE_COLUMNS[table].has(key)) {
+      throw new Error(`column "${key}" of relation "${table}" does not exist`);
+    }
+  }
+}
+
+function resolveRow(table: string, data: Record<string, any>): Record<string, any> {
+  const row = { ...data };
+  for (const [key, value] of Object.entries(row)) {
+    if (value && typeof value === 'object' && '__raw' in value) {
+      row[key] = `${table}-generated-${++idCounter}`;
+    }
+  }
+  return row;
+}
+
+function fakeConn(table: string) {
+  if (!TABLE_COLUMNS[table]) {
+    throw new Error(`Unexpected table ${table}`);
+  }
+  const rows = () => state[table as 'clients' | 'client_locations' | 'default_billing_settings'];
+  const matching = (criteria: Record<string, any>) =>
+    rows().filter(row => Object.entries(criteria).every(([key, value]) => row[key] === value));
+
+  return {
+    where(criteria: Record<string, any>) {
+      return {
+        first: async () => {
+          const match = matching(criteria)[0];
+          return match ? { ...match } : undefined;
+        },
+        update(data: Record<string, any>) {
+          assertRealColumns(table, data);
+          state.updates.push({ table, data: { ...data } });
+          const updated: Record<string, any>[] = [];
+          for (const row of matching(criteria)) {
+            Object.assign(row, resolveRow(table, data));
+            updated.push({ ...row });
+          }
+          return Object.assign(Promise.resolve(updated.length), {
+            returning: async () => updated,
+          });
+        },
+      };
+    },
+    insert(data: Record<string, any>) {
+      assertRealColumns(table, data);
+      if (table === 'clients' && data.client_name === state.failClientInsertNamed) {
+        throw new Error('simulated insert failure');
+      }
+      const row = resolveRow(table, data);
+      if (table === 'clients' && !row.client_id) {
+        row.client_id = `client-generated-${++idCounter}`;
+      }
+      rows().push(row);
+      return Object.assign(Promise.resolve([{ ...row }]), {
+        returning: async () => [{ ...row }],
+      });
+    },
+    select(..._columns: string[]) {
+      return {
+        first: async () => {
+          const row = rows()[0];
+          return row ? { ...row } : undefined;
+        },
+      };
+    },
+  };
+}
+
+const trxFn = Object.assign((table: string) => fakeConn(table), {
+  raw: (sql: string) => ({ __raw: sql }),
+});
+
+function csvRow(overrides: Record<string, any> = {}): Record<string, any> {
+  // Shape produced by ClientsImportDialog for a template CSV: every mappable
+  // field present, location data included.
+  return {
+    client_name: 'Harborview Dental Group',
+    website: 'https://harborviewdental.com',
+    client_type: 'company',
+    is_inactive: false,
+    is_tax_exempt: false,
+    auto_invoice: false,
+    credit_limit: undefined,
+    notes: 'Imported from CSV',
+    tags: '',
+    location_name: 'Main Office',
+    email: 'frontdesk@harborviewdental.com',
+    phone_number: '(206) 555-0177',
+    address_line1: '1201 Alaskan Way',
+    address_line2: '',
+    city: 'Seattle',
+    state_province: 'Washington',
+    postal_code: '98101',
+    country: 'United States',
+    ...overrides,
+  };
+}
+
+async function importClients(rows: Record<string, any>[], updateExisting = false) {
+  const { importClientsFromCSV } = await import('./clientActions');
+  return importClientsFromCSV(rows, updateExisting) as Promise<Array<{
+    success: boolean;
+    message: string;
+    client?: Record<string, any>;
+    originalData: Record<string, any>;
+    skipped?: boolean;
+  }>>;
+}
+
+describe('importClientsFromCSV', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    idCounter = 0;
+    state = {
+      clients: [],
+      client_locations: [],
+      default_billing_settings: [],
+      updates: [],
+      failClientInsertNamed: null,
+    };
+    authUserRef.value = {
+      user_id: 'user-1',
+      user_type: 'internal',
+      clientId: undefined,
+      contact_id: undefined,
+    };
+    hasPermissionAsyncMock.mockResolvedValue(true);
+    findTagsByEntityIdMock.mockResolvedValue([]);
+    createTagMock.mockResolvedValue({});
+    createTenantKnexMock.mockResolvedValue({ knex: trxFn });
+    withTransactionMock.mockImplementation(async (_db: unknown, callback: (trx: any) => Promise<unknown>) => {
+      const snapshotClients = structuredClone(state.clients);
+      const snapshotLocations = structuredClone(state.client_locations);
+      try {
+        return await callback(trxFn);
+      } catch (error) {
+        state.clients = snapshotClients;
+        state.client_locations = snapshotLocations;
+        throw error;
+      }
+    });
+  });
+
+  it('creates clients with url mapped from website and location data in client_locations', async () => {
+    const results = await importClients([csvRow()]);
+
+    expect(results).toHaveLength(1);
+    expect(results[0]).toMatchObject({ success: true, message: 'Client created' });
+    expect(state.clients).toHaveLength(1);
+    expect(state.clients[0]).toMatchObject({
+      client_name: 'Harborview Dental Group',
+      url: 'https://harborviewdental.com',
+      tenant: 'tenant-1',
+    });
+    expect(state.clients[0]).not.toHaveProperty('website');
+    expect(state.client_locations).toHaveLength(1);
+    expect(state.client_locations[0]).toMatchObject({
+      client_id: state.clients[0].client_id,
+      location_name: 'Main Office',
+      address_line1: '1201 Alaskan Way',
+      city: 'Seattle',
+      phone: '(206) 555-0177',
+      email: 'frontdesk@harborviewdental.com',
+      is_default: true,
+    });
+  });
+
+  it('does not create a location when the row has no location data', async () => {
+    const results = await importClients([csvRow({
+      client_name: 'Summit Peak Consulting',
+      website: '',
+      location_name: '',
+      email: '',
+      phone_number: '',
+      address_line1: '',
+      address_line2: '',
+      city: '',
+      state_province: '',
+      postal_code: '',
+      country: '',
+    })]);
+
+    expect(results[0]).toMatchObject({ success: true, message: 'Client created' });
+    expect(state.client_locations).toHaveLength(0);
+  });
+
+  it('updates an existing client from a template-shaped row without touching non-columns (prod regression)', async () => {
+    state.clients.push({
+      tenant: 'tenant-1',
+      client_id: 'client-existing',
+      client_name: 'Harborview Dental Group',
+      url: 'https://old-url.example',
+      is_inactive: false,
+      notes: 'old notes',
+    });
+
+    const results = await importClients([csvRow({ notes: 'refreshed notes' })], true);
+
+    expect(results[0]).toMatchObject({ success: true, message: 'Client updated' });
+    expect(state.clients).toHaveLength(1);
+    expect(state.clients[0]).toMatchObject({
+      client_id: 'client-existing',
+      url: 'https://harborviewdental.com',
+      notes: 'refreshed notes',
+    });
+
+    const clientUpdate = state.updates.find(u => u.table === 'clients');
+    expect(clientUpdate).toBeDefined();
+    expect(clientUpdate!.data).not.toHaveProperty('tenant');
+    expect(clientUpdate!.data).not.toHaveProperty('website');
+    expect(clientUpdate!.data).not.toHaveProperty('location_name');
+    expect(clientUpdate!.data).not.toHaveProperty('address_line1');
+    expect(clientUpdate!.data).not.toHaveProperty('tags');
+
+    expect(state.client_locations).toHaveLength(1);
+    expect(state.client_locations[0]).toMatchObject({
+      client_id: 'client-existing',
+      address_line1: '1201 Alaskan Way',
+      is_default: true,
+    });
+  });
+
+  it('updates the existing default location instead of inserting a second one', async () => {
+    state.clients.push({
+      tenant: 'tenant-1',
+      client_id: 'client-existing',
+      client_name: 'Harborview Dental Group',
+      url: '',
+    });
+    state.client_locations.push({
+      tenant: 'tenant-1',
+      location_id: 'loc-1',
+      client_id: 'client-existing',
+      location_name: 'Old Office',
+      address_line1: '1 Old St',
+      is_default: true,
+    });
+
+    await importClients([csvRow()], true);
+
+    expect(state.client_locations).toHaveLength(1);
+    expect(state.client_locations[0]).toMatchObject({
+      location_id: 'loc-1',
+      location_name: 'Main Office',
+      address_line1: '1201 Alaskan Way',
+    });
+  });
+
+  it('skips existing clients when updateExisting is off and leaves them unchanged', async () => {
+    state.clients.push({
+      tenant: 'tenant-1',
+      client_id: 'client-existing',
+      client_name: 'Harborview Dental Group',
+      url: 'https://old-url.example',
+    });
+
+    const results = await importClients([csvRow()], false);
+
+    expect(results[0]).toMatchObject({
+      success: false,
+      skipped: true,
+      message: 'Client with name Harborview Dental Group already exists',
+    });
+    expect(state.clients[0].url).toBe('https://old-url.example');
+    expect(state.client_locations).toHaveLength(0);
+  });
+
+  it('isolates row failures: one bad row rolls back alone and later rows still import', async () => {
+    state.failClientInsertNamed = 'Poison Pill LLC';
+
+    const results = await importClients([
+      csvRow({ client_name: 'First Fine Co' }),
+      csvRow({ client_name: 'Poison Pill LLC' }),
+      csvRow({ client_name: 'Third Fine Co' }),
+    ]);
+
+    expect(results.map(r => r.success)).toEqual([true, false, true]);
+    expect(results[1].message).toBe('simulated insert failure');
+    expect(state.clients.map(c => c.client_name)).toEqual(['First Fine Co', 'Third Fine Co']);
+    expect(state.client_locations).toHaveLength(2);
+  });
+
+  it('reports rows without a client name as failed without aborting the batch', async () => {
+    const results = await importClients([
+      csvRow({ client_name: '' }),
+      csvRow({ client_name: 'Valid Co' }),
+    ]);
+
+    expect(results[0]).toMatchObject({ success: false, message: 'Client name is required' });
+    expect(results[1]).toMatchObject({ success: true, message: 'Client created' });
+    expect(state.clients).toHaveLength(1);
+  });
+
+  it('creates tags on create and only missing tags on update', async () => {
+    const createResults = await importClients([
+      csvRow({ client_name: 'Tagged Co', tags: 'Legal,VIP' }),
+    ]);
+    expect(createResults[0].success).toBe(true);
+    expect(createTagMock).toHaveBeenCalledTimes(2);
+
+    createTagMock.mockClear();
+    findTagsByEntityIdMock.mockResolvedValue([{ tag_text: 'legal' }]);
+
+    const updateResults = await importClients([
+      csvRow({ client_name: 'Tagged Co', tags: 'Legal,VIP' }),
+    ], true);
+    expect(updateResults[0].success).toBe(true);
+    expect(createTagMock).toHaveBeenCalledTimes(1);
+    expect(createTagMock).toHaveBeenCalledWith(expect.objectContaining({ tag_text: 'VIP' }));
+  });
+
+  it('applies the tenant default currency to created clients', async () => {
+    state.default_billing_settings.push({ tenant: 'tenant-1', default_currency_code: 'EUR' });
+
+    await importClients([csvRow()]);
+
+    expect(state.clients[0].default_currency_code).toBe('EUR');
+  });
+
+  it('rejects without create permission', async () => {
+    hasPermissionAsyncMock.mockResolvedValue(false);
+
+    await expect(importClients([csvRow()])).rejects.toThrow('Permission denied: Cannot create clients');
+    expect(state.clients).toHaveLength(0);
+  });
+
+  it('rejects updateExisting without update permission', async () => {
+    hasPermissionAsyncMock.mockImplementation(async (_user: any, _resource: string, action: string) => action !== 'update');
+
+    await expect(importClients([csvRow()], true)).rejects.toThrow('Permission denied: Cannot update clients');
+  });
+});

--- a/packages/clients/src/actions/clientActions.ts
+++ b/packages/clients/src/actions/clientActions.ts
@@ -18,7 +18,7 @@ import {
 import { getClientLogoUrlAsync, getClientLogoUrlsBatchAsync } from '../lib/documentsHelpers';
 import { uploadEntityImage, deleteEntityImage } from '@alga-psa/storage';
 import { Knex } from 'knex';
-import { createTag } from '@alga-psa/tags/actions';
+import { createTag, findTagsByEntityId } from '@alga-psa/tags/actions';
 import { deleteEntityTags } from '@alga-psa/tags/lib/tagCleanup';
 import { ClientModel } from '@alga-psa/shared/models/clientModel';
 import { publishWorkflowEvent } from '@alga-psa/event-bus/publishers';
@@ -1398,6 +1398,7 @@ export interface ImportClientResult {
   message: string;
   client?: IClient;
   originalData: Record<string, any>;
+  skipped?: boolean;
 }
 
 export const importClientsFromCSV = withAuth(async (
@@ -1422,52 +1423,114 @@ export const importClientsFromCSV = withAuth(async (
     .first();
   const tenantDefaultCurrencyCode = tenantDefaultBillingSettings?.default_currency_code || 'USD';
 
-  // Start a transaction to ensure all operations succeed or fail together
-  await withTransaction(db, async (trx: Knex.Transaction) => {
-    for (const clientData of clientsData) {
-      try {
-        if (!clientData.client_name) {
-          throw new Error('Client name is required');
-        }
+  const parseCsvBoolean = (value: unknown): boolean =>
+    value === true || value === 'true' || value === 'Yes';
 
+  const hasLocationData = (row: Record<string, any>): boolean =>
+    Boolean(row.email || row.phone_number || row.address_line1 || row.city || row.location_name);
+
+  const locationFieldsFromRow = (row: Record<string, any>) => ({
+    location_name: row.location_name || 'Main Office',
+    address_line1: row.address_line1 || '',
+    address_line2: row.address_line2 || '',
+    city: row.city || '',
+    state_province: row.state_province || '',
+    postal_code: row.postal_code || '',
+    country_code: 'US',
+    country_name: row.country || 'United States',
+    phone: row.phone_number || '',
+    email: row.email || ''
+  });
+
+  // Each row gets its own transaction: a failed row rolls back alone instead of
+  // aborting a shared transaction and taking every later row down with it.
+  // LEVERAGE: pattern csv-import-row-isolation — tickets importer solves the same problem with savepoints (ticketImportActions safeInsert); contacts/phase-tasks/xero importers still share one abortable transaction
+  for (const clientData of clientsData) {
+    try {
+      if (!clientData.client_name) {
+        throw new Error('Client name is required');
+      }
+
+      let savedClient: IClient | undefined;
+      let created = false;
+      let skipped = false;
+
+      await withTransaction(db, async (trx: Knex.Transaction) => {
         const existingClient = await tenantScopedTable(trx, 'clients', tenant)
           .where({ client_name: clientData.client_name })
           .first();
 
         if (existingClient && !updateExisting) {
-          results.push({
-            success: false,
-            message: `Client with name ${clientData.client_name} already exists`,
-            originalData: clientData
-          });
-          continue;
+          skipped = true;
+          return;
         }
 
-        let savedClient: IClient;
-
-        if (existingClient && updateExisting) {
-          // Keep the existing tenant when updating
-          const { tenant: _, ...safeClientData } = clientData; // Remove tenant from spread to prevent override
-          const { account_manager_id, ...restOfSafeData } = safeClientData;
-          const updateData = {
-            ...restOfSafeData,
-            account_manager_id: account_manager_id === '' ? null : account_manager_id,
-            tenant: existingClient.tenant, // Explicitly set correct tenant
+        if (existingClient) {
+          // Map CSV fields onto real clients columns only — location data lives
+          // in client_locations, and tenant must never be part of the SET list.
+          const updateData: Record<string, any> = {
             updated_at: new Date().toISOString()
           };
+          if (clientData.website !== undefined || clientData.url !== undefined) {
+            updateData.url = clientData.website || clientData.url || '';
+          }
+          if (clientData.client_type !== undefined) {
+            updateData.client_type = clientData.client_type || 'company';
+          }
+          if (clientData.is_inactive !== undefined) {
+            updateData.is_inactive = parseCsvBoolean(clientData.is_inactive);
+          }
+          if (clientData.is_tax_exempt !== undefined) {
+            updateData.is_tax_exempt = parseCsvBoolean(clientData.is_tax_exempt);
+          }
+          if (clientData.auto_invoice !== undefined) {
+            updateData.auto_invoice = parseCsvBoolean(clientData.auto_invoice);
+          }
+          if (clientData.notes !== undefined) {
+            updateData.notes = clientData.notes || '';
+          }
+          if (clientData.credit_limit !== undefined && clientData.credit_limit !== null && clientData.credit_limit !== '') {
+            updateData.credit_limit = Number(clientData.credit_limit);
+          }
+          if (clientData.account_manager_id !== undefined) {
+            updateData.account_manager_id = clientData.account_manager_id === '' ? null : clientData.account_manager_id;
+          }
 
           [savedClient] = await tenantScopedTable(trx, 'clients', tenant)
             .where({ client_id: existingClient.client_id })
             .update(updateData)
             .returning('*');
 
-          results.push({
-            success: true,
-            message: 'Client updated',
-            client: savedClient,
-            originalData: clientData
-          });
+          if (hasLocationData(clientData)) {
+            const defaultLocation = await tenantScopedTable(trx, 'client_locations', tenant)
+              .where({ client_id: existingClient.client_id, is_default: true })
+              .first();
+
+            if (defaultLocation) {
+              await tenantScopedTable(trx, 'client_locations', tenant)
+                .where({ location_id: defaultLocation.location_id })
+                .update({
+                  ...locationFieldsFromRow(clientData),
+                  updated_at: new Date().toISOString()
+                });
+            } else {
+              await tenantScopedTable(trx, 'client_locations', tenant).insert({
+                location_id: trx.raw('gen_random_uuid()'),
+                client_id: existingClient.client_id,
+                tenant: tenant,
+                ...locationFieldsFromRow(clientData),
+                is_default: true,
+                is_billing_address: true,
+                is_shipping_address: true,
+                is_active: true,
+                created_at: new Date().toISOString(),
+                updated_at: new Date().toISOString()
+              });
+            }
+          }
         } else {
+          created = true;
+
           // Create new client with synchronized website fields
           const properties = clientData.properties ? { ...clientData.properties } : {};
           const url = clientData.url || '';
@@ -1482,9 +1545,9 @@ export const importClientsFromCSV = withAuth(async (
           }
 
           const clientToCreate = {
-            client_name: clientData.client_name || clientData.client_name,
+            client_name: clientData.client_name,
             url: clientData.website || clientData.url || '',
-            is_inactive: clientData.is_inactive === 'Yes' || clientData.is_inactive === true || false,
+            is_inactive: parseCsvBoolean(clientData.is_inactive),
             is_tax_exempt: clientData.is_tax_exempt || false,
             client_type: clientData.client_type || 'company',
             tenant: tenant,
@@ -1509,72 +1572,72 @@ export const importClientsFromCSV = withAuth(async (
             .insert(clientToCreate)
             .returning('*');
 
-          // Create default location if any location data exists in CSV
-          if (clientData.email || clientData.phone_number || clientData.address_line1 ||
-              clientData.city || clientData.location_name) {
-            try {
-              await tenantScopedTable(trx, 'client_locations', tenant).insert({
-                location_id: trx.raw('gen_random_uuid()'),
-                client_id: savedClient.client_id,
-                tenant: tenant,
-                location_name: clientData.location_name || 'Main Office',
-                address_line1: clientData.address_line1 || '',
-                address_line2: clientData.address_line2 || '',
-                city: clientData.city || '',
-                state_province: clientData.state_province || '',
-                postal_code: clientData.postal_code || '',
-                country_code: 'US',
-                country_name: clientData.country || 'United States',
-                phone: clientData.phone_number || '',
-                email: clientData.email || '',
-                is_default: true,
-                is_billing_address: true,
-                is_shipping_address: true,
-                is_active: true,
-                created_at: new Date().toISOString(),
-                updated_at: new Date().toISOString()
-              });
-            } catch (locationError) {
-              console.error('Failed to create location during CSV import:', locationError);
-              // Don't fail the client import if location creation fails
-            }
+          if (hasLocationData(clientData)) {
+            await tenantScopedTable(trx, 'client_locations', tenant).insert({
+              location_id: trx.raw('gen_random_uuid()'),
+              client_id: savedClient!.client_id,
+              tenant: tenant,
+              ...locationFieldsFromRow(clientData),
+              is_default: true,
+              is_billing_address: true,
+              is_shipping_address: true,
+              is_active: true,
+              created_at: new Date().toISOString(),
+              updated_at: new Date().toISOString()
+            });
           }
-
-          // Handle tags if provided
-          if (clientData.tags) {
-            try {
-              const tagTexts = clientData.tags.split(',').map((tag: string) => tag.trim()).filter((tag: string) => tag);
-              for (const tagText of tagTexts) {
-                await createTag({
-                  tag_text: tagText,
-                  tagged_id: savedClient.client_id,
-                  tagged_type: 'client',
-                  created_by: user.user_id
-                });
-              }
-            } catch (tagError) {
-              console.error('Failed to create tags during CSV import:', tagError);
-              // Don't fail the client import if tag creation fails
-            }
-          }
-
-          results.push({
-            success: true,
-            message: 'Client created',
-            client: savedClient,
-            originalData: clientData
-          });
         }
-      } catch (error) {
-        console.error('Error processing client:', clientData, error);
+      });
+
+      if (skipped) {
         results.push({
           success: false,
-          message: error instanceof Error ? error.message : 'Unknown error occurred',
+          skipped: true,
+          message: `Client with name ${clientData.client_name} already exists`,
           originalData: clientData
         });
+        continue;
       }
+
+      // Tags run after the row commits: createTag opens its own connection, so
+      // creating them inside the transaction would leak tags for rolled-back rows.
+      if (savedClient && clientData.tags) {
+        try {
+          const tagTexts = clientData.tags.split(',').map((tag: string) => tag.trim()).filter((tag: string) => tag);
+          const existingTags = created ? [] : await findTagsByEntityId(savedClient.client_id, 'client');
+          const existingTagTexts = new Set(existingTags.map((tag): string => tag.tag_text.toLowerCase()));
+          for (const tagText of tagTexts) {
+            if (existingTagTexts.has(tagText.toLowerCase())) {
+              continue;
+            }
+            await createTag({
+              tag_text: tagText,
+              tagged_id: savedClient.client_id,
+              tagged_type: 'client',
+              created_by: user.user_id
+            });
+          }
+        } catch (tagError) {
+          console.error('Failed to create tags during CSV import:', tagError);
+          // Don't fail the client import if tag creation fails
+        }
+      }
+
+      results.push({
+        success: true,
+        message: created ? 'Client created' : 'Client updated',
+        client: savedClient,
+        originalData: clientData
+      });
+    } catch (error) {
+      console.error('Error processing client:', clientData, error);
+      results.push({
+        success: false,
+        message: error instanceof Error ? error.message : 'Unknown error occurred',
+        originalData: clientData
+      });
     }
-  });
+  }
 
   return results;
 });

--- a/packages/clients/src/components/clients/Clients.tsx
+++ b/packages/clients/src/components/clients/Clients.tsx
@@ -23,7 +23,6 @@ import {
   getAllClientsPaginated,
   deleteClient,
   validateClientDeletion,
-  importClientsFromCSV,
   exportClientsToCSV,
   markClientInactiveWithContacts,
   markClientActiveWithContacts,
@@ -1315,14 +1314,10 @@ const Clients: React.FC = () => {
     onAfterPrint: () => setPrintClients([]),
   });
 
-  const handleImportComplete = async (clients: IClient[], updateExisting: boolean) => {
-    try {
-      await importClientsFromCSV(clients, updateExisting);
-      setIsImportDialogOpen(false);
-      router.refresh();
-    } catch (error) {
-      console.error('Error importing clients:', error);
-    }
+  const handleImportComplete = () => {
+    // The dialog already ran the import and shows per-row results;
+    // just refresh the list behind it.
+    void refreshClients();
   };
 
   if (viewMode === null || areClientPreferencesLoading) {
@@ -1775,7 +1770,7 @@ const Clients: React.FC = () => {
       <ClientsImportDialog
         isOpen={isImportDialogOpen}
         onClose={() => setIsImportDialogOpen(false)}
-        onImportComplete={(clients, updateExisting) => void handleImportComplete(clients, updateExisting)}
+        onImportComplete={handleImportComplete}
       />
       
       {/* Quick View Drawer */}

--- a/packages/clients/src/components/clients/ClientsImportDialog.tsx
+++ b/packages/clients/src/components/clients/ClientsImportDialog.tsx
@@ -13,6 +13,7 @@ import type { IClient } from '@alga-psa/types';
 import { Upload, AlertTriangle, Check } from 'lucide-react';
 import { parseCSV } from '@alga-psa/core';
 import { checkExistingClients, importClientsFromCSV, generateClientCSVTemplate } from '@alga-psa/clients/actions';
+import type { ImportClientResult } from '@alga-psa/clients/actions';
 import { Tooltip } from '@alga-psa/ui/components/Tooltip';
 import { Alert, AlertDescription } from '@alga-psa/ui/components/Alert';
 import { useTranslation } from '@alga-psa/ui/lib/i18n/client';
@@ -20,7 +21,7 @@ import { useTranslation } from '@alga-psa/ui/lib/i18n/client';
 interface ClientsImportDialogProps {
   isOpen: boolean;
   onClose: () => void;
-  onImportComplete: (clients: IClient[], updateExisting: boolean) => void;
+  onImportComplete: (results: ImportClientResult[]) => void;
 }
 
 type MappableClientField = 
@@ -102,6 +103,7 @@ const ClientsImportDialog: React.FC<ClientsImportDialogProps> = ({
   const [existingClientsCount, setExistingClientsCount] = useState(0);
   const [isProcessing, setIsProcessing] = useState(false);
   const [showOptionalFields, setShowOptionalFields] = useState(false);
+  const [importResults, setImportResults] = useState<ImportClientResult[]>([]);
 
   // Pagination state
   const [currentPage, setCurrentPage] = useState(1);
@@ -131,6 +133,7 @@ const ClientsImportDialog: React.FC<ClientsImportDialogProps> = ({
       setExistingClientsCount(0);
       setIsProcessing(false);
       setShowOptionalFields(false);
+      setImportResults([]);
       setCurrentPage(1);
       setPageSize(10);
     }
@@ -188,7 +191,6 @@ const ClientsImportDialog: React.FC<ClientsImportDialogProps> = ({
       data: {
         ...mappedData,
         client_name: mappedData.client_name,
-        tenant: 'default',
         is_inactive: mappedData.is_inactive ? mappedData.is_inactive.toLowerCase() === 'true' : false,
         is_tax_exempt: mappedData.is_tax_exempt ? mappedData.is_tax_exempt.toLowerCase() === 'true' : false,
         auto_invoice: mappedData.auto_invoice ? mappedData.auto_invoice.toLowerCase() === 'true' : false,
@@ -336,8 +338,9 @@ const ClientsImportDialog: React.FC<ClientsImportDialogProps> = ({
         .filter(result => result.isValid || importOptions.skipInvalid)
         .map((result): IClient => result.data as IClient);
 
-      await importClientsFromCSV(validClients, importOptions.updateExisting);
-      await onImportComplete(validClients, importOptions.updateExisting);
+      const results = await importClientsFromCSV(validClients, importOptions.updateExisting);
+      setImportResults(results);
+      onImportComplete(results);
       setStep('complete');
     } catch (error) {
       setErrors([error instanceof Error ? error.message : 'Error importing clients']);
@@ -362,6 +365,7 @@ const ClientsImportDialog: React.FC<ClientsImportDialogProps> = ({
       setShowUpdateConfirmation(false);
       setExistingClientsCount(0);
       setShowOptionalFields(false);
+      setImportResults([]);
       onClose();
     }
   }, [isProcessing, onClose]);
@@ -708,20 +712,74 @@ const ClientsImportDialog: React.FC<ClientsImportDialogProps> = ({
             </div>
           )}
 
-          {step === 'complete' && (
-            <div className="text-center">
-              <Check className="h-12 w-12 text-green-500 mx-auto mb-4" />
-              <h3 className="text-lg font-medium mb-2">
-                {t('clientsImportDialog.importComplete', { defaultValue: 'Import Complete' })}
-              </h3>
-              <p className="text-gray-600 mb-4">
-                {t('clientsImportDialog.importCompleteMessage', {
-                  defaultValue: 'Successfully imported {{count}} clients',
-                  count: validationResults.filter(r => r.isValid).length,
-                })}
-              </p>
-            </div>
-          )}
+          {step === 'complete' && (() => {
+            const createdCount = importResults.filter(r => r.success && r.message === 'Client created').length;
+            const updatedCount = importResults.filter(r => r.success && r.message === 'Client updated').length;
+            const skippedCount = importResults.filter(r => r.skipped).length;
+            const failedResults = importResults.filter(r => !r.success && !r.skipped);
+
+            return (
+              <div>
+                <div className="text-center">
+                  {failedResults.length === 0 ? (
+                    <Check className="h-12 w-12 text-green-500 mx-auto mb-4" />
+                  ) : (
+                    <AlertTriangle className="h-12 w-12 text-yellow-500 mx-auto mb-4" />
+                  )}
+                  <h3 className="text-lg font-medium mb-2">
+                    {failedResults.length === 0
+                      ? t('clientsImportDialog.importComplete', { defaultValue: 'Import Complete' })
+                      : t('clientsImportDialog.importCompleteWithErrors', { defaultValue: 'Import Completed with Errors' })}
+                  </h3>
+                  <p className="text-gray-600 mb-4">
+                    {t('clientsImportDialog.importResultSummary', {
+                      defaultValue: '{{created}} created, {{updated}} updated, {{skipped}} skipped, {{failed}} failed',
+                      created: createdCount,
+                      updated: updatedCount,
+                      skipped: skippedCount,
+                      failed: failedResults.length,
+                    })}
+                  </p>
+                </div>
+                {skippedCount > 0 && (
+                  <Alert variant="info" className="mb-4">
+                    <AlertDescription>
+                      {t('clientsImportDialog.skippedExistingMessage', {
+                        defaultValue: '{{count}} clients were skipped because they already exist. Enable "Update existing clients" to overwrite them.',
+                        count: skippedCount,
+                      })}
+                    </AlertDescription>
+                  </Alert>
+                )}
+                {failedResults.length > 0 && (
+                  <div className="max-h-64 overflow-y-auto">
+                    <DataTable
+                      id="clients-import-failures-table"
+                      pagination={false}
+                      data={failedResults.map((result): Record<string, any> => ({
+                        client_name: result.originalData.client_name || '-',
+                        message: result.message,
+                      }))}
+                      columns={[
+                        {
+                          title: t('clientsImportDialog.clientName', { defaultValue: 'Client Name' }),
+                          dataIndex: 'client_name',
+                          width: '30%',
+                        },
+                        {
+                          title: t('clientsImportDialog.error', { defaultValue: 'Error' }),
+                          dataIndex: 'message',
+                          render: (value: string) => (
+                            <span className="text-red-600 text-sm whitespace-normal break-words">{value}</span>
+                          ),
+                        },
+                      ] as ColumnDefinition<any>[]}
+                    />
+                  </div>
+                )}
+              </div>
+            );
+          })()}
         </DialogContent>
       </Dialog>
 

--- a/server/public/locales/de/msp/clients.json
+++ b/server/public/locales/de/msp/clients.json
@@ -903,6 +903,10 @@
     "email": "E-Mail",
     "clientName": "Kundenname",
     "importCompleteMessage": "{{count}}-Clients wurden erfolgreich importiert",
+    "importCompleteWithErrors": "Import mit Fehlern abgeschlossen",
+    "importResultSummary": "{{created}} erstellt, {{updated}} aktualisiert, {{skipped}} übersprungen, {{failed}} fehlgeschlagen",
+    "skippedExistingMessage": "{{count}} Clients wurden übersprungen, da sie bereits existieren. Aktivieren Sie „Bestehende Clients aktualisieren“, um sie zu überschreiben.",
+    "error": "Fehler",
     "updateExistingTitle": "Bestehende Clients aktualisieren",
     "updateExistingMessage": "{{count}} Clients sind bereits vorhanden. Möchten Sie sie mit den neuen Daten aktualisieren?"
   },

--- a/server/public/locales/en/msp/clients.json
+++ b/server/public/locales/en/msp/clients.json
@@ -903,6 +903,10 @@
     "email": "Email",
     "clientName": "Client Name",
     "importCompleteMessage": "Successfully imported {{count}} clients",
+    "importCompleteWithErrors": "Import Completed with Errors",
+    "importResultSummary": "{{created}} created, {{updated}} updated, {{skipped}} skipped, {{failed}} failed",
+    "skippedExistingMessage": "{{count}} clients were skipped because they already exist. Enable \"Update existing clients\" to overwrite them.",
+    "error": "Error",
     "updateExistingTitle": "Update Existing Clients",
     "updateExistingMessage": "{{count}} clients already exist. Do you want to update them with the new data?"
   },

--- a/server/public/locales/es/msp/clients.json
+++ b/server/public/locales/es/msp/clients.json
@@ -903,6 +903,10 @@
     "email": "Correo electrónico",
     "clientName": "Nombre del cliente",
     "importCompleteMessage": "Clientes {{count}} importados correctamente",
+    "importCompleteWithErrors": "Importación completada con errores",
+    "importResultSummary": "{{created}} creados, {{updated}} actualizados, {{skipped}} omitidos, {{failed}} fallidos",
+    "skippedExistingMessage": "Se omitieron {{count}} clientes porque ya existen. Activa \"Actualizar clientes existentes\" para sobrescribirlos.",
+    "error": "Error",
     "updateExistingTitle": "Actualizar clientes existentes",
     "updateExistingMessage": "{{count}} clientes ya existen. ¿Quieres actualizarlos con los nuevos datos?"
   },

--- a/server/public/locales/fr/msp/clients.json
+++ b/server/public/locales/fr/msp/clients.json
@@ -903,6 +903,10 @@
     "email": "E-mail",
     "clientName": "Nom du client",
     "importCompleteMessage": "Clients {{count}} importés avec succès",
+    "importCompleteWithErrors": "Importation terminée avec des erreurs",
+    "importResultSummary": "{{created}} créés, {{updated}} mis à jour, {{skipped}} ignorés, {{failed}} en échec",
+    "skippedExistingMessage": "{{count}} clients ont été ignorés car ils existent déjà. Activez « Mettre à jour les clients existants » pour les remplacer.",
+    "error": "Erreur",
     "updateExistingTitle": "Mettre à jour les clients existants",
     "updateExistingMessage": "Les clients {{count}} existent déjà. Voulez-vous les mettre à jour avec les nouvelles données ?"
   },

--- a/server/public/locales/it/msp/clients.json
+++ b/server/public/locales/it/msp/clients.json
@@ -903,6 +903,10 @@
     "email": "E-mail",
     "clientName": "Nome del cliente",
     "importCompleteMessage": "Clienti {{count}} importati correttamente",
+    "importCompleteWithErrors": "Importazione completata con errori",
+    "importResultSummary": "{{created}} creati, {{updated}} aggiornati, {{skipped}} saltati, {{failed}} non riusciti",
+    "skippedExistingMessage": "{{count}} client sono stati saltati perché esistono già. Attiva \"Aggiorna i client esistenti\" per sovrascriverli.",
+    "error": "Errore",
     "updateExistingTitle": "Aggiorna i clienti esistenti",
     "updateExistingMessage": "I client {{count}} esistono già. Vuoi aggiornarli con i nuovi dati?"
   },

--- a/server/public/locales/nl/msp/clients.json
+++ b/server/public/locales/nl/msp/clients.json
@@ -903,6 +903,10 @@
     "email": "E-mail",
     "clientName": "Klantnaam",
     "importCompleteMessage": "{{count}}-clients zijn geïmporteerd",
+    "importCompleteWithErrors": "Import voltooid met fouten",
+    "importResultSummary": "{{created}} aangemaakt, {{updated}} bijgewerkt, {{skipped}} overgeslagen, {{failed}} mislukt",
+    "skippedExistingMessage": "{{count}} klanten zijn overgeslagen omdat ze al bestaan. Schakel \"Update bestaande klanten\" in om ze te overschrijven.",
+    "error": "Fout",
     "updateExistingTitle": "Update bestaande klanten",
     "updateExistingMessage": "{{count}}-clients bestaan ​​al. Wilt u ze updaten met de nieuwe gegevens?"
   },

--- a/server/public/locales/pl/msp/clients.json
+++ b/server/public/locales/pl/msp/clients.json
@@ -933,6 +933,10 @@
     "email": "E-mail",
     "clientName": "Nazwa klienta",
     "importCompleteMessage": "Pomyślnie zaimportowano klientów {{count}}",
+    "importCompleteWithErrors": "Import zakończony z błędami",
+    "importResultSummary": "{{created}} utworzono, {{updated}} zaktualizowano, {{skipped}} pominięto, {{failed}} nie powiodło się",
+    "skippedExistingMessage": "Pominięto {{count}} klientów, ponieważ już istnieją. Włącz „Zaktualizuj istniejących klientów”, aby ich nadpisać.",
+    "error": "Błąd",
     "updateExistingTitle": "Zaktualizuj istniejących klientów",
     "updateExistingMessage": "Klienci {{count}} już istnieją. Chcesz je zaktualizować o nowe dane?"
   },

--- a/server/public/locales/pt/msp/clients.json
+++ b/server/public/locales/pt/msp/clients.json
@@ -903,6 +903,10 @@
     "email": "E-mail",
     "clientName": "Nome do cliente",
     "importCompleteMessage": "Clientes {{count}} importados com sucesso",
+    "importCompleteWithErrors": "Importação concluída com erros",
+    "importResultSummary": "{{created}} criados, {{updated}} atualizados, {{skipped}} ignorados, {{failed}} com falha",
+    "skippedExistingMessage": "{{count}} clientes foram ignorados porque já existem. Ative \"Atualizar clientes existentes\" para sobrescrevê-los.",
+    "error": "Erro",
     "updateExistingTitle": "Atualizar clientes existentes",
     "updateExistingMessage": "Os clientes {{count}} já existem. Deseja atualizá-los com os novos dados?"
   },

--- a/server/public/locales/xx/msp/clients.json
+++ b/server/public/locales/xx/msp/clients.json
@@ -903,6 +903,10 @@
     "email": "11111",
     "clientName": "11111",
     "importCompleteMessage": "11111 {{count}} 11111",
+    "importCompleteWithErrors": "11111",
+    "importResultSummary": "{{created}} 11111, {{updated}} 11111, {{skipped}} 11111, {{failed}} 11111",
+    "skippedExistingMessage": "{{count}} 11111",
+    "error": "11111",
     "updateExistingTitle": "11111",
     "updateExistingMessage": "11111 {{count}} 11111"
   },

--- a/server/public/locales/yy/msp/clients.json
+++ b/server/public/locales/yy/msp/clients.json
@@ -903,6 +903,10 @@
     "email": "55555",
     "clientName": "55555",
     "importCompleteMessage": "55555 {{count}} 55555",
+    "importCompleteWithErrors": "55555",
+    "importResultSummary": "{{created}} 55555, {{updated}} 55555, {{skipped}} 55555, {{failed}} 55555",
+    "skippedExistingMessage": "{{count}} 55555",
+    "error": "55555",
     "updateExistingTitle": "55555",
     "updateExistingMessage": "55555 {{count}} 55555"
   },


### PR DESCRIPTION
The update path spread raw CSV fields (website, address_line1, location_name, ...) straight into UPDATE clients, which don't exist as columns (42703). The first existing client aborted the shared transaction and every following row died with it â whole imports silently failed while the dialog reported success.

- map CSV fields onto real clients columns; website -> url, location data upserted into client_locations, tenant never SET
- run each row in its own transaction so one bad row rolls back alone instead of poisoning the batch
- remove the duplicate import call (dialog and Clients.tsx both ran the import, back to back)
- show real per-row results (created/updated/skipped/failed) in the complete step and refresh the list via refreshClients()
- dedupe tags on update; add skipped flag to ImportClientResult
- add schema-enforcing unit tests (fake DB rejects unknown columns like Postgres) that fail against the old code; new i18n keys in all 10 locales

"No room! No room!" cried the clients table as website tried to sit down at the tea party â but the Hatter has rearranged the seating: every column gets only its own chair, and one spilled teacup no longer cancels all sixty-nine unbirthdays. ð©ð«ð