### PR TITLE
Sales order inventory adversarial design

### DIFF
--- a/docs/plans/2026-07-07-sales-order-add-dialog-plan.md
+++ b/docs/plans/2026-07-07-sales-order-add-dialog-plan.md
@@ -1,0 +1,172 @@
+# Add Sales Order dialog — adversarial redesign plan
+
+**Date:** 2026-07-07
+**Branch:** `feature/sales-order-inventory-design`
+**Screen:** "Add Sales Order" dialog — the create form inside
+`packages/inventory/src/components/SalesOrdersManager.tsx`
+**Backing action:** `createSalesOrder` in `packages/inventory/src/actions/salesOrderActions.ts`
+
+## Why
+
+An adversarial design pass (six critic lenses: voice, pixel, concept/IA, intent, gap,
+low-effort) found the dialog was built in isolation from machinery Alga already ships. It is
+simultaneously **too careless** (product chosen by hand-typed UUID, currency free-typed and
+hardcoded `USD`, a `×100` cents assumption that is wrong for JPY) and **too thin** (it hides
+capability the `createSalesOrder` action already accepts: expected ship date, client PO number,
+notes, and — most costly — per-line `fulfillment_type`, whose omission makes the entire
+downstream drop-ship workflow unreachable).
+
+Every change below is **backed** — it adopts an existing component, action, or field, not new
+backend. The mandate is two-sided: nothing unearned stays, nothing essential is missing.
+
+## The screen's job
+
+Create a sales order: pick the client, add priced line items (services/products), set how it
+invoices and allocates stock, save. One task.
+
+## Reuse artifacts (all confirmed to exist)
+
+- **`ServicePicker`** — `packages/billing/src/components/billing-dashboard/contracts/ServicePicker.tsx`.
+  Searchable `SearchableSelect` over `{value,label}`. Already used by contracts/quotes.
+- **`getServices`** — `packages/billing/src/actions/serviceActions.ts:198` → `PaginatedServicesResponse`.
+  Each service carries `service_id`, `service_name`, `sku`, `item_kind` (`'service' | 'product' | …`),
+  `default_rate` (**stored in cents**), `billing_method`. Reference auto-fill pattern:
+  `ServiceSelectionDialog.tsx:297` and `ManualInvoices.tsx:680` (`rate ?? service.default_rate`, ÷100).
+- **Client-derived currency** — the dominant billing-UI pattern is `selectedClient?.default_currency_code
+  || 'USD'` read client-side (`ContractDialog.tsx:384`, `ManualInvoices.tsx:670`, `ContractWizard.tsx:322`).
+  `IClient.default_currency_code` is already present on the `clients` prop.
+  (`resolveClientBillingCurrency` in `packages/billing/src/actions/billingCurrencyActions.ts` is the
+  more-authoritative server resolver — it also inspects active contracts — but the UI convention here
+  is the client-side read; use that for consistency.)
+- **Currency-aware money** — `formatCurrency(minorUnits, currencyCode)` in
+  `packages/core/src/lib/formatters.ts` derives fraction digits from the currency via
+  `Intl.NumberFormat`. Use the same `Intl` approach for both display and the dollars→minor-units
+  conversion, replacing the hardcoded `×100`.
+
+## Scope (approved)
+
+Full three tiers. Include the per-line drop-ship control. Keep invoice + allocation modes with
+helper text, grouped. Add client PO number, notes, and expected ship date.
+
+---
+
+## Tier 1 — Wire into existing machinery (correctness)
+
+### T1.1 Service picker replaces the UUID text box
+- **File:** `SalesOrdersManager.tsx` (line-item Service cell, ~`:485-491`) and the page server
+  component `server/src/app/msp/inventory/sales-orders/page.tsx`.
+- The page already fetches `getAllClients()` + `listStockLocations()` and passes them as props.
+  Add `getServices(1, 999, { item_kind: 'any' })` beside them (products **and** services can be
+  sold), pass a `services` prop down, guarded in its own try/catch like the others.
+- In the component, map services to `{ value: service_id, label: sku ? `${service_name} (${sku})`
+  : service_name }` and render `<ServicePicker options={serviceOptions} value={line.service_id}
+  onChange={(v) => onServicePicked(idx, v)} />`.
+- This alone eliminates the "line pointing at nothing" hazard: a picker can only yield real
+  `service_id`s. No separate existence check needed once the free-text box is gone.
+
+### T1.2 Auto-fill unit price from the picked service
+- On service pick (`onServicePicked`), set that line's `unit_price` from the service's
+  `default_rate` (cents → dollars: `default_rate / 100`), leaving it editable for negotiated
+  overrides. Mirrors `ServiceSelectionDialog` / `ManualInvoices`.
+- Removes the `unit_price: '0'` default's ambiguity ("forgot to price" vs "genuinely free").
+
+### T1.3 Currency derived from client, rendered read-only (never free text)
+- Remove the free-text `<Input id="sales-order-currency-code">` (~`:450-456`) and the
+  `currency_code: 'USD'` seed in `emptyForm()`.
+- On client select (extend `ClientPicker.onSelect`, currently only sets `client_id`), set
+  `currency_code = pickedClient?.default_currency_code || 'USD'` from the `clients` prop.
+- Render currency as a **read-only** derived display (label "Currency", value = resolved code),
+  grouped with the client. Currency is a property of who you bill, not a per-order choice.
+- Keep the server guard as-is; the UI now always sends a real client-derived code.
+
+### T1.4 Currency-aware money math (fixes JPY correctness bug)
+- Replace `Math.round(Number(unit_price) * 100)` in `save()` (~`:235`) with an `Intl`-derived
+  minor-unit conversion keyed to `form.currency_code` (fraction digits from
+  `Intl.NumberFormat(undefined,{style:'currency',currency}).resolvedOptions().maximumFractionDigits`,
+  matching `formatCurrency`). For JPY (0 digits) the multiplier is ×1, for 3-decimal currencies ×1000.
+- Replace the hardcoded `'Unit Price ($)'` label (~`:503`); show the resolved currency (code or
+  symbol) instead of a literal `$`.
+
+---
+
+## Tier 2 — Surface backed capability the dialog hides (gaps)
+
+### T2.1 Per-line fulfillment type — unlocks the dead drop-ship workflow
+- The action accepts per-line `fulfillment_type` (`'from_stock' | 'drop_ship'`, defaults
+  `from_stock`). No line can currently be *born* drop-ship (create omits it; `SalesOrderDetail`
+  has no line add/edit), so the shipped drop-ship apparatus (badge, vendor-shipment dialog with
+  serial/MAC capture, `confirmDropShipAndInvoice`) is unreachable.
+- Add a compact per-line `<CustomSelect>` `From stock | Drop-ship` (mirror the existing
+  invoice/allocation select pattern), sent as each line's `fulfillment_type`.
+
+### T2.2 Header fields — client PO number, notes, expected ship date
+- All three are already accepted by `createSalesOrder`. Add and wire into the create payload:
+  - `client_po_number` — one `<Input>` ("Client PO number").
+  - `notes` — one `<TextArea>` ("Notes").
+  - `expected_ship_date` — one date field ("Expected ship date"); optional.
+- `order_date` stays server-defaulted (`now()`); not surfaced.
+
+### T2.3 Running order total
+- Show a right-aligned "Total" above the Cancel/Save row: `Σ quantity × unit_price`, formatted
+  with `formatCurrency` in the resolved currency. Pure client-side arithmetic.
+
+### T2.4 Inline validation instead of vanishing toasts
+- Disable Save until: a client is selected **and** ≥1 line has a picked service with quantity > 0.
+- Mark the specific invalid field/line inline (empty service, qty ≤ 0) rather than only firing a
+  transient `toast.error` on click. The predicates already exist in `save()`; render them as state.
+
+---
+
+## Tier 3 — Layout & voice craft
+
+### T3.1 Line-items table hygiene
+- Render column headers (**Service / Fulfillment / Qty / Unit price**) **once** above the list,
+  not repeated per line.
+- Make Remove an **icon-only** button (trash icon, `aria-label`), freeing its column width.
+- Right-align and currency-format the price cell.
+- Wrap the line list in a max-height scroll region so the footer (Cancel/Save) stays reachable at
+  ~15 lines.
+- Rebalance the column split so Service gets the most room and Qty is not over-wide.
+
+### T3.2 Grouping, ordering, and voice
+- Reorder the dialog to **Client (+ derived Currency) → Items → "Billing & allocation"**.
+- Group invoice mode + allocation mode in a "Billing & allocation" section beneath the items
+  (kept per approval, not hidden), with **helper text** under allocation explaining the
+  consequence (e.g. "Soft = reserve stock, still visible to other orders; Hard = hold stock
+  exclusively"). Relabel "…mode" wording to operator-plain.
+- Relabel schema-speak: "Service ID" → "Service", "Currency code" → "Currency", "Lines" → "Items".
+- All new/changed strings go through `t('key', 'Default English')` in the `features/inventory`
+  namespace, with matching keys added to `server/public/locales/en/features/inventory.json` (and
+  the other locale files as the repo convention requires).
+
+---
+
+## Deliberate declines (not in this pass)
+
+- **`ship_to`** — a free-form address object with no client-address picker to reuse. Real gap for
+  physical shipments, but wiring it well needs an address source out of scope. Propose separately.
+- **Per-line `tax_rate_id`** — accepted by the action but no tax-rate list is passed to this
+  component, and tax is plausibly resolved at invoice generation. Defer.
+- **`order_date`** — server defaults to `now()`; back-dating is an edge case. Leave out.
+- **Per-line `currency_code`** — the action models it but validates it must equal the header
+  currency (a fake degree of freedom). Keep it **out of the UI permanently**. Optional follow-up:
+  drop it from the create contract so the model stops implying a choice the domain forbids.
+
+## Testing / verification
+
+- Type check the touched packages (`inventory`, and `server` for the page).
+- Update the nearest contract/unit tests that assert the create payload or dialog shape (search
+  `SalesOrdersManager`, `createSalesOrder`, and inventory i18n key tests — the i18n key test will
+  fail if new default strings lack locale entries).
+- Verify live (SSR/server-driven — reload, not hot-reload): open the dialog, pick a client and
+  confirm currency auto-derives read-only; pick a service and confirm price auto-fills; set a line
+  to Drop-ship; confirm the running total; confirm Save is disabled until valid; save and confirm
+  the SO persists with PO number, notes, ship date, and the drop-ship line reaching its downstream
+  vendor-shipment flow.
+- Each change lands as its own verified, individually-committed iteration.
+
+## Out of scope / structural proposals (surface, don't build here)
+
+- `SalesOrderDetail` gaining line add/edit (a second path to born-drop-ship lines).
+- A shared client-address picker to make `ship_to` fillable.
+- Dropping per-line `currency_code` from the `createSalesOrder` contract.

--- a/ee/server/seeds/onboarding/psa/02_permissions.cjs
+++ b/ee/server/seeds/onboarding/psa/02_permissions.cjs
@@ -47,6 +47,35 @@ exports.seed = async function(knex, tenantId) {
         { resource: 'interaction', action: 'update', msp: true, client: false, description: 'Update interactions' },
         { resource: 'interaction', action: 'delete', msp: true, client: false, description: 'Delete interactions' },
 
+        // Inventory module permissions (MSP-only; granted to the MSP Admin role,
+        // mirrors migration 20260626100600_add_inventory_permissions). Without these
+        // the Add Sales Order / stock-location / inventory server actions fail the
+        // RBAC check even for Admin (e.g. "Permission denied: sales_order create required").
+        { resource: 'inventory', action: 'create', msp: true, client: false, description: 'Create inventory records' },
+        { resource: 'inventory', action: 'read', msp: true, client: false, description: 'View inventory records' },
+        { resource: 'inventory', action: 'update', msp: true, client: false, description: 'Update inventory records' },
+        { resource: 'inventory', action: 'delete', msp: true, client: false, description: 'Delete inventory records' },
+        { resource: 'vendor', action: 'create', msp: true, client: false, description: 'Create vendors' },
+        { resource: 'vendor', action: 'read', msp: true, client: false, description: 'View vendors' },
+        { resource: 'vendor', action: 'update', msp: true, client: false, description: 'Update vendors' },
+        { resource: 'vendor', action: 'delete', msp: true, client: false, description: 'Delete vendors' },
+        { resource: 'purchase_order', action: 'create', msp: true, client: false, description: 'Create purchase orders' },
+        { resource: 'purchase_order', action: 'read', msp: true, client: false, description: 'View purchase orders' },
+        { resource: 'purchase_order', action: 'update', msp: true, client: false, description: 'Update purchase orders' },
+        { resource: 'purchase_order', action: 'delete', msp: true, client: false, description: 'Delete purchase orders' },
+        { resource: 'sales_order', action: 'create', msp: true, client: false, description: 'Create sales orders' },
+        { resource: 'sales_order', action: 'read', msp: true, client: false, description: 'View sales orders' },
+        { resource: 'sales_order', action: 'update', msp: true, client: false, description: 'Update sales orders' },
+        { resource: 'sales_order', action: 'delete', msp: true, client: false, description: 'Delete sales orders' },
+        { resource: 'stock_transfer', action: 'create', msp: true, client: false, description: 'Create stock transfers' },
+        { resource: 'stock_transfer', action: 'read', msp: true, client: false, description: 'View stock transfers' },
+        { resource: 'stock_transfer', action: 'update', msp: true, client: false, description: 'Update stock transfers' },
+        { resource: 'stock_transfer', action: 'delete', msp: true, client: false, description: 'Delete stock transfers' },
+        { resource: 'stock_location', action: 'create', msp: true, client: false, description: 'Create stock locations' },
+        { resource: 'stock_location', action: 'read', msp: true, client: false, description: 'View stock locations' },
+        { resource: 'stock_location', action: 'update', msp: true, client: false, description: 'Update stock locations' },
+        { resource: 'stock_location', action: 'delete', msp: true, client: false, description: 'Delete stock locations' },
+
         // Credit permissions
         { resource: 'credit', action: 'create', msp: true, client: false, description: 'Create credits' },
         { resource: 'credit', action: 'read', msp: true, client: false, description: 'View credits' },

--- a/packages/core/src/lib/formatters.ts
+++ b/packages/core/src/lib/formatters.ts
@@ -39,6 +39,24 @@ export function formatCurrencyFromMinorUnits(
 }
 
 /**
+ * The number of minor-unit fraction digits a currency uses (USD=2, JPY=0, some=3),
+ * derived from `Intl.NumberFormat` so it stays correct without a hand-kept table.
+ */
+export function currencyFractionDigits(currency: string = 'USD', locale: string = 'en-US'): number {
+  const resolved = new Intl.NumberFormat(locale, { style: 'currency', currency }).resolvedOptions();
+  return resolved.maximumFractionDigits ?? 2;
+}
+
+/**
+ * Convert a major-unit amount (e.g. dollars) to the currency's integer minor units
+ * (e.g. cents), using the currency's own exponent — so JPY multiplies by 1, not 100.
+ * The inverse of {@link formatCurrencyFromMinorUnits}; replaces hardcoded `× 100`.
+ */
+export function toMinorUnits(value: number, locale: string = 'en-US', currency: string = 'USD'): number {
+  return Math.round(value * Math.pow(10, currencyFractionDigits(currency, locale)));
+}
+
+/**
  * Format a date as a string
  * @param date The date to format
  * @param locale The locale to use (default: 'en-US')

--- a/packages/inventory/src/components/SalesOrdersManager.tsx
+++ b/packages/inventory/src/components/SalesOrdersManager.tsx
@@ -4,8 +4,10 @@ import React, { useState, useCallback } from 'react';
 import { DataTable } from '@alga-psa/ui/components/DataTable';
 import { Button } from '@alga-psa/ui/components/Button';
 import { Input } from '@alga-psa/ui/components/Input';
+import { TextArea } from '@alga-psa/ui/components/TextArea';
 import { Dialog } from '@alga-psa/ui/components/Dialog';
 import CustomSelect from '@alga-psa/ui/components/CustomSelect';
+import SearchableSelect from '@alga-psa/ui/components/SearchableSelect';
 import { ClientPicker } from '@alga-psa/ui/components/ClientPicker';
 import { Badge, type BadgeVariant } from '@alga-psa/ui/components/Badge';
 import { ConfirmationDialog } from '@alga-psa/ui/components/ConfirmationDialog';
@@ -16,9 +18,10 @@ import {
   DropdownMenuSeparator,
   DropdownMenuTrigger,
 } from '@alga-psa/ui/components/DropdownMenu';
-import { ChevronDown } from 'lucide-react';
+import { ChevronDown, Trash2 } from 'lucide-react';
 import { useTranslation } from '@alga-psa/ui/lib/i18n/client';
 import { toast } from 'react-hot-toast';
+import { formatCurrencyFromMinorUnits, toMinorUnits, currencyFractionDigits } from '@alga-psa/core';
 import type {
   ColumnDefinition,
   IClient,
@@ -26,6 +29,7 @@ import type {
   IStockLocation,
   SalesOrderInvoiceMode,
   SalesOrderAllocationMode,
+  SalesOrderLineFulfillmentType,
 } from '@alga-psa/types';
 import {
   listSalesOrders,
@@ -103,24 +107,49 @@ const STATUS_VARIANTS: Record<string, BadgeVariant> = {
 interface LineForm {
   service_id: string;
   quantity_ordered: string;
-  unit_price: string; // dollars
+  unit_price: string; // major units (e.g. dollars), converted to minor units on save
+  fulfillment_type: SalesOrderLineFulfillmentType;
 }
 
 interface FormState {
   client_id: string;
+  /** Derived from the picked client, never free-typed. */
   currency_code: string;
   invoice_mode: SalesOrderInvoiceMode;
   allocation_mode: SalesOrderAllocationMode;
+  client_po_number: string;
+  expected_ship_date: string; // yyyy-mm-dd, optional
+  notes: string;
   lines: LineForm[];
 }
 
-const emptyLine = (): LineForm => ({ service_id: '', quantity_ordered: '1', unit_price: '0' });
+/**
+ * A sellable catalog entry for the line-item picker. Fetched by the page via billing's
+ * `getServices` and passed down (inventory can't import billing directly). `default_rate` is in
+ * the currency's minor units (e.g. cents) and seeds the editable unit price.
+ */
+export interface SalesOrderServiceOption {
+  service_id: string;
+  service_name: string | null;
+  sku: string | null;
+  default_rate: number | null;
+}
+
+const emptyLine = (): LineForm => ({
+  service_id: '',
+  quantity_ordered: '1',
+  unit_price: '',
+  fulfillment_type: 'from_stock',
+});
 
 const emptyForm = (): FormState => ({
   client_id: '',
-  currency_code: 'USD',
+  currency_code: '',
   invoice_mode: 'on_fulfillment',
   allocation_mode: 'soft',
+  client_po_number: '',
+  expected_ship_date: '',
+  notes: '',
   lines: [emptyLine()],
 });
 
@@ -130,6 +159,8 @@ export interface SalesOrdersManagerProps {
   locations?: IStockLocation[];
   /** Clients for the create-SO client picker. */
   clients?: IClient[];
+  /** Sellable services/products for the line-item picker (fetched by the page from billing). */
+  services?: SalesOrderServiceOption[];
   /** Billing-owned actions passed from the page (billing → inventory dependency). */
   fulfillAndInvoice: FulfillAndInvoiceFn;
   generateInvoice: GenerateInvoiceFn;
@@ -140,6 +171,7 @@ export function SalesOrdersManager({
   initialSos,
   locations = [],
   clients = [],
+  services = [],
   fulfillAndInvoice,
   generateInvoice,
   confirmDropShip,
@@ -153,6 +185,20 @@ export function SalesOrdersManager({
     { value: 'soft', label: t('salesOrders.allocationMode.soft', 'Soft') },
     { value: 'hard', label: t('salesOrders.allocationMode.hard', 'Hard') },
   ];
+  const FULFILLMENT_OPTIONS: { value: SalesOrderLineFulfillmentType; label: string }[] = [
+    { value: 'from_stock', label: t('salesOrders.fulfillment.fromStock', 'From stock') },
+    { value: 'drop_ship', label: t('salesOrders.fulfillment.dropShip', 'Drop-ship') },
+  ];
+  const serviceOptions = services.map((s) => ({
+    value: s.service_id,
+    label: s.sku
+      ? `${s.service_name ?? t('salesOrders.unnamedService', 'Unnamed')} (${s.sku})`
+      : s.service_name ?? t('salesOrders.unnamedService', 'Unnamed'),
+  }));
+  const serviceById = React.useMemo(
+    () => new Map(services.map((s) => [s.service_id, s])),
+    [services],
+  );
   const documentLabels: Record<string, string> = {
     'sales-order': t('salesOrders.documents.salesOrder', 'Order Confirmation'),
     'packing-slip': t('salesOrders.documents.packingSlip', 'Packing Slip'),
@@ -206,6 +252,17 @@ export function SalesOrdersManager({
     setDialogOpen(true);
   };
 
+  // Currency is a property of who you bill, not a per-order choice: derive it from the picked
+  // client and render it read-only (falling back to USD only when the client has none).
+  const onClientSelect = (clientId: string | null) => {
+    const picked = clientId ? clients.find((c) => c.client_id === clientId) : undefined;
+    setForm((f) => ({
+      ...f,
+      client_id: clientId ?? '',
+      currency_code: picked?.default_currency_code || (clientId ? 'USD' : ''),
+    }));
+  };
+
   const setLine = (idx: number, patch: Partial<LineForm>) => {
     setForm((f) => ({
       ...f,
@@ -213,9 +270,35 @@ export function SalesOrdersManager({
     }));
   };
 
+  // Picking a service both binds a real service_id (a picker can't yield a non-existent one) and
+  // seeds the editable unit price from its catalog default_rate (stored in minor units).
+  const onServicePicked = (idx: number, serviceId: string) => {
+    const svc = serviceById.get(serviceId);
+    const currency = form.currency_code || 'USD';
+    const seededPrice =
+      svc?.default_rate != null
+        ? String(svc.default_rate / Math.pow(10, currencyFractionDigits(currency)))
+        : undefined;
+    setLine(idx, { service_id: serviceId, ...(seededPrice !== undefined ? { unit_price: seededPrice } : {}) });
+  };
+
   const addLine = () => setForm((f) => ({ ...f, lines: [...f.lines, emptyLine()] }));
   const removeLine = (idx: number) =>
     setForm((f) => ({ ...f, lines: f.lines.filter((_, i) => i !== idx) }));
+
+  const currency = form.currency_code || 'USD';
+  // Running total: Σ quantity × unit price, in the resolved currency's minor units. Lines without
+  // a picked service or a positive quantity don't contribute.
+  const totalMinor = form.lines.reduce((sum, l) => {
+    const qty = Number(l.quantity_ordered);
+    const price = Number(l.unit_price);
+    if (!l.service_id || !(qty > 0) || !Number.isFinite(price)) return sum;
+    return sum + toMinorUnits(price, undefined, currency) * qty;
+  }, 0);
+  // A line is "priced" once a service is picked with a positive quantity. Save needs a client and
+  // at least one such line; individual invalid lines are marked inline rather than via a toast.
+  const lineIsValid = (l: LineForm) => Boolean(l.service_id) && Number(l.quantity_ordered) > 0;
+  const canSave = Boolean(form.client_id) && form.lines.some(lineIsValid) && !saving;
 
   const save = async () => {
     if (!form.client_id.trim()) {
@@ -231,8 +314,9 @@ export function SalesOrdersManager({
       .map((l) => ({
         service_id: l.service_id.trim(),
         quantity_ordered: Number(l.quantity_ordered),
-        // Money is integer cents — convert dollars to cents.
-        unit_price: Math.round(Number(l.unit_price) * 100),
+        // Convert the major-unit price to the currency's integer minor units (JPY ×1, USD ×100).
+        unit_price: toMinorUnits(Number(l.unit_price || 0), undefined, form.currency_code),
+        fulfillment_type: l.fulfillment_type,
       }));
     for (const l of lines) {
       if (!(l.quantity_ordered > 0)) {
@@ -247,6 +331,9 @@ export function SalesOrdersManager({
         currency_code: form.currency_code.trim(),
         invoice_mode: form.invoice_mode,
         allocation_mode: form.allocation_mode,
+        client_po_number: form.client_po_number.trim() || null,
+        expected_ship_date: form.expected_ship_date || null,
+        notes: form.notes.trim() || null,
         lines,
       });
       toast.success(t('salesOrders.created', 'Sales order created'));
@@ -434,100 +521,210 @@ export function SalesOrdersManager({
         id="sales-order-dialog"
       >
         <div className="space-y-4 p-1">
-          <div className="space-y-1">
-            <label className="block text-sm font-medium">{t('salesOrders.columns.client', 'Client')}</label>
-            <ClientPicker
-              id="sales-order-client"
-              clients={clients}
-              selectedClientId={form.client_id || null}
-              onSelect={(clientId) => setForm({ ...form, client_id: clientId ?? '' })}
-              filterState={clientFilterState}
-              onFilterStateChange={setClientFilterState}
-              clientTypeFilter={clientTypeFilter}
-              onClientTypeFilterChange={setClientTypeFilter}
+          {/* Order details — who it's for (currency follows from that) and their reference. */}
+          <div className="grid grid-cols-2 gap-3 items-start">
+            <div className="space-y-1">
+              <label className="block text-sm font-medium">{t('salesOrders.columns.client', 'Client')}</label>
+              <ClientPicker
+                id="sales-order-client"
+                clients={clients}
+                selectedClientId={form.client_id || null}
+                onSelect={onClientSelect}
+                filterState={clientFilterState}
+                onFilterStateChange={setClientFilterState}
+                clientTypeFilter={clientTypeFilter}
+                onClientTypeFilterChange={setClientTypeFilter}
+              />
+            </div>
+            <div className="space-y-1">
+              <label className="block text-sm font-medium">{t('salesOrders.columns.currency', 'Currency')}</label>
+              {/* Read-only: currency is a property of who you bill, derived on client select. */}
+              <div
+                id="sales-order-currency"
+                className="h-10 flex items-center rounded-md border border-[rgb(var(--color-border-200))] bg-[rgb(var(--color-border-50))] px-3 text-sm text-[rgb(var(--color-text-700))]"
+              >
+                {form.currency_code || t('salesOrders.currencyFromClient', 'Set from client')}
+              </div>
+            </div>
+          </div>
+
+          <div className="grid grid-cols-2 gap-3">
+            <Input
+              id="sales-order-client-po"
+              label={t('salesOrders.fields.clientPoNumber', 'Client PO number')}
+              value={form.client_po_number}
+              onChange={(e) => setForm({ ...form, client_po_number: e.target.value })}
+            />
+            <Input
+              id="sales-order-expected-ship-date"
+              label={t('salesOrders.fields.expectedShipDate', 'Expected ship date')}
+              type="date"
+              value={form.expected_ship_date}
+              onChange={(e) => setForm({ ...form, expected_ship_date: e.target.value })}
             />
           </div>
-          <Input
-            id="sales-order-currency-code"
-            label={t('salesOrders.fields.currencyCode', 'Currency code')}
-            required
-            value={form.currency_code}
-            onChange={(e) => setForm({ ...form, currency_code: e.target.value })}
-          />
-          <CustomSelect
-            id="sales-order-invoice-mode"
-            label={t('salesOrders.fields.invoiceMode', 'Invoice mode')}
-            options={INVOICE_MODE_OPTIONS}
-            value={form.invoice_mode}
-            onValueChange={(value) =>
-              setForm({ ...form, invoice_mode: value as SalesOrderInvoiceMode })
-            }
-          />
-          <CustomSelect
-            id="sales-order-allocation-mode"
-            label={t('salesOrders.fields.allocationMode', 'Allocation mode')}
-            options={ALLOCATION_MODE_OPTIONS}
-            value={form.allocation_mode}
-            onValueChange={(value) =>
-              setForm({ ...form, allocation_mode: value as SalesOrderAllocationMode })
-            }
-          />
 
+          {/* Items */}
           <div className="space-y-2">
             <div className="flex items-center justify-between">
-              <label className="block text-sm font-medium">{t('salesOrders.fields.lines', 'Lines')}</label>
+              <label className="block text-sm font-medium">{t('salesOrders.fields.items', 'Items')}</label>
               <Button id="sales-order-add-line" variant="outline" size="sm" onClick={addLine}>
                 {t('salesOrders.actions.addLine', 'Add Line')}
               </Button>
             </div>
-            {form.lines.map((line, idx) => (
-              <div key={idx} className="grid grid-cols-12 gap-2 items-end">
-                <div className="col-span-5">
-                  <label className="block text-xs mb-1">{t('salesOrders.fields.serviceId', 'Service ID')}</label>
-                  <Input
-                    id={`sales-order-line-service-${idx}`}
-                    value={line.service_id}
-                    onChange={(e) => setLine(idx, { service_id: e.target.value })}
-                  />
-                </div>
-                <div className="col-span-3">
-                  <label className="block text-xs mb-1">{t('salesOrders.fields.qty', 'Qty')}</label>
-                  <Input
-                    id={`sales-order-line-qty-${idx}`}
-                    type="number"
-                    value={line.quantity_ordered}
-                    onChange={(e) => setLine(idx, { quantity_ordered: e.target.value })}
-                  />
-                </div>
-                <div className="col-span-3">
-                  <label className="block text-xs mb-1">{t('salesOrders.fields.unitPrice', 'Unit Price ($)')}</label>
-                  <Input
-                    id={`sales-order-line-price-${idx}`}
-                    type="number"
-                    value={line.unit_price}
-                    onChange={(e) => setLine(idx, { unit_price: e.target.value })}
-                  />
-                </div>
-                <div className="col-span-1">
-                  <Button
-                    id={`sales-order-line-remove-${idx}`}
-                    variant="ghost"
-                    size="sm"
-                    onClick={() => removeLine(idx)}
-                    disabled={form.lines.length <= 1}
-                  >
-                    {t('common.remove', 'Remove')}
-                  </Button>
-                </div>
+            {/* Column headers once, so each row carries inputs only. */}
+            <div className="flex gap-2 items-center text-xs font-medium text-gray-600">
+              <div className="flex-1">{t('salesOrders.fields.service', 'Service')}</div>
+              <div className="w-32">{t('salesOrders.fields.fulfillment', 'Fulfillment')}</div>
+              <div className="w-20 text-right">{t('salesOrders.fields.qty', 'Qty')}</div>
+              <div className="w-32 text-right">
+                {t('salesOrders.fields.unitPriceIn', 'Unit price ({{currency}})', { currency })}
               </div>
-            ))}
+              <div className="w-8" />
+            </div>
+            {/* Keep the footer reachable when a large order pushes past the fold. */}
+            <div className="max-h-[22rem] overflow-y-auto space-y-2 pr-1">
+              {form.lines.map((line, idx) => {
+                const missingService = !line.service_id && Number(line.quantity_ordered) > 0;
+                const badQty = Boolean(line.service_id) && !(Number(line.quantity_ordered) > 0);
+                return (
+                  <div key={idx} className="flex gap-2 items-start" id={`sales-order-line-${idx}`}>
+                    <div className="flex-1">
+                      <SearchableSelect
+                        id={`sales-order-line-service-${idx}`}
+                        options={serviceOptions}
+                        value={line.service_id}
+                        onChange={(value) => onServicePicked(idx, value)}
+                        placeholder={t('salesOrders.fields.selectService', 'Select a service…')}
+                        searchPlaceholder={t('salesOrders.fields.searchService', 'Search services…')}
+                        emptyMessage={t('salesOrders.fields.noService', 'No service found.')}
+                        dropdownMode="overlay"
+                        maxListHeight="250px"
+                      />
+                      {missingService && (
+                        <p className="mt-1 text-xs text-[rgb(var(--color-accent-500))]">
+                          {t('salesOrders.pickServiceForLine', 'Pick a service for this line.')}
+                        </p>
+                      )}
+                    </div>
+                    <div className="w-32">
+                      <CustomSelect
+                        id={`sales-order-line-fulfillment-${idx}`}
+                        options={FULFILLMENT_OPTIONS}
+                        value={line.fulfillment_type}
+                        onValueChange={(value) =>
+                          setLine(idx, { fulfillment_type: value as SalesOrderLineFulfillmentType })
+                        }
+                      />
+                    </div>
+                    <div className="w-20">
+                      <Input
+                        id={`sales-order-line-qty-${idx}`}
+                        type="number"
+                        min="1"
+                        step="1"
+                        className="text-right tabular-nums"
+                        value={line.quantity_ordered}
+                        onChange={(e) => setLine(idx, { quantity_ordered: e.target.value })}
+                      />
+                      {badQty && (
+                        <p className="mt-1 text-xs text-[rgb(var(--color-accent-500))]">
+                          {t('salesOrders.qtyPositive', 'Must be > 0.')}
+                        </p>
+                      )}
+                    </div>
+                    <div className="w-32">
+                      <Input
+                        id={`sales-order-line-price-${idx}`}
+                        type="number"
+                        min="0"
+                        step="0.01"
+                        className="text-right tabular-nums"
+                        value={line.unit_price}
+                        onChange={(e) => setLine(idx, { unit_price: e.target.value })}
+                      />
+                    </div>
+                    <div className="w-8 flex justify-center pt-2">
+                      <Button
+                        id={`sales-order-line-remove-${idx}`}
+                        variant="ghost"
+                        size="sm"
+                        aria-label={t('common.remove', 'Remove')}
+                        onClick={() => removeLine(idx)}
+                        disabled={form.lines.length <= 1}
+                      >
+                        <Trash2 className="h-4 w-4" />
+                      </Button>
+                    </div>
+                  </div>
+                );
+              })}
+            </div>
           </div>
 
-          <div className="flex justify-end gap-2 pt-2">
+          {/* Billing & allocation — kept visible; helper text spells out the consequence. */}
+          <div className="space-y-3 rounded-md border border-[rgb(var(--color-border-200))] p-3">
+            <label className="block text-sm font-medium">
+              {t('salesOrders.billingAllocation', 'Billing & allocation')}
+            </label>
+            <div className="grid grid-cols-2 gap-3">
+              <div className="space-y-1">
+                <CustomSelect
+                  id="sales-order-invoice-mode"
+                  label={t('salesOrders.fields.invoiceMode', 'When to invoice')}
+                  options={INVOICE_MODE_OPTIONS}
+                  value={form.invoice_mode}
+                  onValueChange={(value) =>
+                    setForm({ ...form, invoice_mode: value as SalesOrderInvoiceMode })
+                  }
+                />
+                <p className="text-xs text-gray-500">
+                  {t(
+                    'salesOrders.invoiceModeHelp',
+                    'On fulfillment bills as items ship; Manual leaves invoicing to you.',
+                  )}
+                </p>
+              </div>
+              <div className="space-y-1">
+                <CustomSelect
+                  id="sales-order-allocation-mode"
+                  label={t('salesOrders.fields.allocationMode', 'How to allocate stock')}
+                  options={ALLOCATION_MODE_OPTIONS}
+                  value={form.allocation_mode}
+                  onValueChange={(value) =>
+                    setForm({ ...form, allocation_mode: value as SalesOrderAllocationMode })
+                  }
+                />
+                <p className="text-xs text-gray-500">
+                  {t(
+                    'salesOrders.allocationModeHelp',
+                    'Soft reserves stock but leaves it visible to other orders; Hard holds it exclusively.',
+                  )}
+                </p>
+              </div>
+            </div>
+          </div>
+
+          <TextArea
+            id="sales-order-notes"
+            label={t('salesOrders.fields.notes', 'Notes')}
+            rows={2}
+            value={form.notes}
+            onChange={(e) => setForm({ ...form, notes: e.target.value })}
+          />
+
+          <div className="flex items-center justify-between border-t border-[rgb(var(--color-border-200))] pt-3">
+            <span className="text-sm text-gray-600">{t('salesOrders.total', 'Total')}</span>
+            <span id="sales-order-total" className="text-base font-semibold tabular-nums">
+              {formatCurrencyFromMinorUnits(totalMinor, undefined, currency)}
+            </span>
+          </div>
+
+          <div className="flex justify-end gap-2 pt-1">
             <Button id="sales-order-cancel" variant="outline" onClick={() => setDialogOpen(false)}>
               {t('common.cancel', 'Cancel')}
             </Button>
-            <Button id="sales-order-save" onClick={save} disabled={saving}>
+            <Button id="sales-order-save" onClick={save} disabled={!canSave}>
               {saving ? t('common.saving', 'Saving…') : t('common.save', 'Save')}
             </Button>
           </div>

--- a/server/migrations/20260707120000_readd_inventory_permissions_for_seeded_tenants.cjs
+++ b/server/migrations/20260707120000_readd_inventory_permissions_for_seeded_tenants.cjs
@@ -1,0 +1,96 @@
+/**
+ * Re-run the inventory permission backfill for tenants that were provisioned
+ * AFTER migration 20260626100600_add_inventory_permissions ran.
+ *
+ * That migration backfills inventory permission rows (and the MSP Admin grants)
+ * for every tenant that exists at migration time. On appliance/on-prem (CE) and
+ * fresh hosted installs the bootstrap order is: run all migrations against an
+ * EMPTY database, then create the first tenant via the onboarding seeds
+ * (ee/server/seeds/onboarding/psa). So 20260626100600 was recorded as applied
+ * without inserting anything (its `if (!tenants.length) return` short-circuits),
+ * and the onboarding/dev permission seeds had no inventory permission defs —
+ * leaving the default Admin (and every other role) with no sales_order /
+ * stock_location / inventory / vendor / purchase_order / stock_transfer grants.
+ * Every inventory server action then failed the RBAC check, e.g. Add Sales Order
+ * Save returned HTTP 200 but persisted no row ("Permission denied: sales_order
+ * create required") and the Sales Orders list rendered empty.
+ * The same gap applies to any tenant created between 20260626100600 and the
+ * onboarding/dev seed fix that ships alongside this migration.
+ *
+ * The permission seeds now include the inventory defs, so tenants created from
+ * this build onward are correct; this migration repairs tenants that were
+ * already provisioned. Same idempotent logic as 20260626100600: safe to re-run
+ * and a no-op for tenants that already have the rows.
+ *
+ * Uses raw knex (every query passes `tenant` explicitly) so the migration runner
+ * does not load the @alga-psa/db ESM package.
+ */
+
+const RESOURCES = ['inventory', 'vendor', 'purchase_order', 'sales_order', 'stock_transfer', 'stock_location'];
+const ACTIONS = ['create', 'read', 'update', 'delete'];
+
+function buildPermissions() {
+  const perms = [];
+  for (const resource of RESOURCES) {
+    for (const action of ACTIONS) {
+      perms.push({ resource, action, msp: true, client: false, description: `${action} ${resource}` });
+    }
+  }
+  return perms;
+}
+
+exports.up = async function up(knex) {
+  const tenants = await knex('tenants').select('tenant');
+  if (!tenants.length) return;
+
+  const newPermissions = buildPermissions();
+
+  for (const { tenant } of tenants) {
+    const existingPerms = await knex('permissions').where({ tenant }).select('resource', 'action');
+    const existingMap = new Set(existingPerms.map((p) => `${p.resource}:${p.action}`));
+
+    const permissionsToAdd = newPermissions
+      .filter((p) => !existingMap.has(`${p.resource}:${p.action}`))
+      .map((p) => ({
+        tenant,
+        permission_id: knex.raw('gen_random_uuid()'),
+        ...p,
+        created_at: new Date(),
+      }));
+
+    if (permissionsToAdd.length > 0) {
+      await knex('permissions').insert(permissionsToAdd);
+    }
+
+    const adminRole = await knex('roles')
+      .where({ tenant, msp: true, client: false })
+      .whereRaw("LOWER(role_name) = 'admin'")
+      .first();
+
+    if (adminRole) {
+      const invPerms = await knex('permissions')
+        .where({ tenant, msp: true })
+        .whereIn('resource', RESOURCES)
+        .select('permission_id');
+
+      const existingRolePerms = await knex('role_permissions')
+        .where({ tenant, role_id: adminRole.role_id })
+        .select('permission_id');
+      const existingRolePermIds = new Set(existingRolePerms.map((rp) => rp.permission_id));
+
+      const rolePermissionsToAdd = invPerms
+        .filter((p) => !existingRolePermIds.has(p.permission_id))
+        .map((p) => ({ tenant, role_id: adminRole.role_id, permission_id: p.permission_id }));
+
+      if (rolePermissionsToAdd.length > 0) {
+        await knex('role_permissions').insert(rolePermissionsToAdd);
+      }
+    }
+  }
+};
+
+exports.down = async function down() {
+  // Intentionally a no-op: the inventory permission rows may predate this
+  // migration (created by 20260626100600 or the permission seeds), so deleting
+  // them here could strip grants this migration did not create.
+};

--- a/server/public/locales/de/features/inventory.json
+++ b/server/public/locales/de/features/inventory.json
@@ -686,8 +686,10 @@
       "hard": "Fest",
       "soft": "Weich"
     },
+    "allocationModeHelp": "Soft reserves stock but leaves it visible to other orders; Hard holds it exclusively.",
     "availabilityOk": "OK",
     "backorderBadge": "Rückstand {{shortfall}}",
+    "billingAllocation": "Billing & allocation",
     "billsOnFulfillment": "Abrechnung bei Auslieferung",
     "cancelDialog": {
       "confirm": "Kundenauftrag stornieren",
@@ -716,6 +718,7 @@
       "vendorPlaceholder": "Lieferant auswählen…"
     },
     "created": "Kundenauftrag erstellt",
+    "currencyFromClient": "Set from client",
     "currencyRequired": "Währungscode ist erforderlich",
     "detailTitle": "Kundenauftrag {{number}}",
     "detailTitleFallback": "Kundenauftrag",
@@ -747,12 +750,22 @@
     "enterSerial": "Geben Sie mindestens eine Seriennummer ein.",
     "fields": {
       "allocationMode": "Zuordnungsmodus",
+      "clientPoNumber": "Client PO number",
       "currencyCode": "Währungscode",
+      "expectedShipDate": "Expected ship date",
+      "fulfillment": "Fulfillment",
       "invoiceMode": "Rechnungsmodus",
+      "items": "Items",
       "lines": "Positionen",
+      "noService": "No service found.",
+      "notes": "Notes",
       "qty": "Menge",
+      "searchService": "Search services…",
+      "selectService": "Select a service…",
+      "service": "Service",
       "serviceId": "Service-ID",
-      "unitPrice": "Stückpreis ($)"
+      "unitPrice": "Stückpreis ($)",
+      "unitPriceIn": "Unit price ({{currency}})"
     },
     "fromQuote": "Aus Angebot",
     "fulfillDialog": {
@@ -771,6 +784,10 @@
       "title": "Ausliefern — {{name}}"
     },
     "fulfilledUnits": "{{count}} Einheit(en) ausgeliefert.",
+    "fulfillment": {
+      "dropShip": "Drop-ship",
+      "fromStock": "From stock"
+    },
     "fulfillmentFailed": "Auslieferung fehlgeschlagen.",
     "invoiceColumns": {
       "amount": "Betrag",
@@ -782,6 +799,7 @@
       "manual": "Manuell",
       "onFulfillment": "Bei Auslieferung"
     },
+    "invoiceModeHelp": "On fulfillment bills as items ship; Manual leaves invoicing to you.",
     "invoicedItems": "{{count}} Artikel abgerechnet.",
     "invoices": "Rechnungen",
     "invoicingFailed": "Abrechnung fehlgeschlagen: {{error}}. Verwenden Sie \"Rechnung erstellen\", um es erneut zu versuchen.",
@@ -802,8 +820,10 @@
     "nothingBackordered": "Nichts ist im Rückstand.",
     "nothingToInvoice": "Nichts mehr abzurechnen.",
     "onlyRemaining": "Nur noch {{remaining}} für diese Position verbleibend.",
+    "pickServiceForLine": "Pick a service for this line.",
     "pickVendor": "Wählen Sie den Lieferanten, der diese Position versendet.",
     "productDefaultLocation": "Standardstandort des Produkts",
+    "qtyPositive": "Must be > 0.",
     "qtyPositiveInteger": "Die Menge muss eine positive ganze Zahl sein.",
     "reopenError": "Der Kundenauftrag konnte nicht wieder geöffnet werden.",
     "reopened": "Kundenauftrag wieder geöffnet — er ist wieder ein Entwurf.",
@@ -819,7 +839,9 @@
       "partiallyFulfilled": "Teilweise ausgeliefert"
     },
     "title": "Kundenaufträge",
-    "unassignedBackorder": "{{count}} rückständige Position(en) haben keinen bevorzugten Lieferanten — erstellen Sie diese POs manuell."
+    "total": "Total",
+    "unassignedBackorder": "{{count}} rückständige Position(en) haben keinen bevorzugten Lieferanten — erstellen Sie diese POs manuell.",
+    "unnamedService": "Unnamed"
   },
   "stock": {
     "actions": {

--- a/server/public/locales/en/features/inventory.json
+++ b/server/public/locales/en/features/inventory.json
@@ -686,8 +686,10 @@
       "hard": "Hard",
       "soft": "Soft"
     },
+    "allocationModeHelp": "Soft reserves stock but leaves it visible to other orders; Hard holds it exclusively.",
     "availabilityOk": "OK",
     "backorderBadge": "Backorder {{shortfall}}",
+    "billingAllocation": "Billing & allocation",
     "billsOnFulfillment": "Bills on fulfillment",
     "cancelDialog": {
       "confirm": "Cancel sales order",
@@ -716,6 +718,7 @@
       "vendorPlaceholder": "Select a vendor…"
     },
     "created": "Sales order created",
+    "currencyFromClient": "Set from client",
     "currencyRequired": "Currency code is required",
     "detailTitle": "Sales Order {{number}}",
     "detailTitleFallback": "Sales Order",
@@ -746,13 +749,23 @@
     "emailSuccess": "Confirmation emailed to {{recipients}}",
     "enterSerial": "Enter at least one serial number.",
     "fields": {
-      "allocationMode": "Allocation mode",
+      "allocationMode": "How to allocate stock",
+      "clientPoNumber": "Client PO number",
       "currencyCode": "Currency code",
-      "invoiceMode": "Invoice mode",
+      "expectedShipDate": "Expected ship date",
+      "fulfillment": "Fulfillment",
+      "invoiceMode": "When to invoice",
+      "items": "Items",
       "lines": "Lines",
+      "noService": "No service found.",
+      "notes": "Notes",
       "qty": "Qty",
+      "searchService": "Search services…",
+      "selectService": "Select a service…",
+      "service": "Service",
       "serviceId": "Service ID",
-      "unitPrice": "Unit Price ($)"
+      "unitPrice": "Unit Price ($)",
+      "unitPriceIn": "Unit price ({{currency}})"
     },
     "fromQuote": "From quote",
     "fulfillDialog": {
@@ -771,6 +784,10 @@
       "title": "Fulfill — {{name}}"
     },
     "fulfilledUnits": "Fulfilled {{count}} unit(s).",
+    "fulfillment": {
+      "dropShip": "Drop-ship",
+      "fromStock": "From stock"
+    },
     "fulfillmentFailed": "Fulfillment failed.",
     "invoiceColumns": {
       "amount": "Amount",
@@ -782,6 +799,7 @@
       "manual": "Manual",
       "onFulfillment": "On fulfillment"
     },
+    "invoiceModeHelp": "On fulfillment bills as items ship; Manual leaves invoicing to you.",
     "invoicedItems": "Invoiced {{count}} item(s).",
     "invoices": "Invoices",
     "invoicingFailed": "Invoicing failed: {{error}}. Use \"Generate invoice\" to retry.",
@@ -802,8 +820,10 @@
     "nothingBackordered": "Nothing is backordered.",
     "nothingToInvoice": "Nothing left to invoice.",
     "onlyRemaining": "Only {{remaining}} remaining on this line.",
+    "pickServiceForLine": "Pick a service for this line.",
     "pickVendor": "Pick the vendor that will ship this line.",
     "productDefaultLocation": "Product default location",
+    "qtyPositive": "Must be > 0.",
     "qtyPositiveInteger": "Quantity must be a positive whole number.",
     "reopenError": "Couldn't reopen the sales order.",
     "reopened": "Sales order reopened — it is a draft again.",
@@ -819,7 +839,9 @@
       "partiallyFulfilled": "Partially fulfilled"
     },
     "title": "Sales Orders",
-    "unassignedBackorder": "{{count}} backordered line(s) have no preferred vendor — create those POs manually."
+    "total": "Total",
+    "unassignedBackorder": "{{count}} backordered line(s) have no preferred vendor — create those POs manually.",
+    "unnamedService": "Unnamed"
   },
   "stock": {
     "actions": {

--- a/server/public/locales/es/features/inventory.json
+++ b/server/public/locales/es/features/inventory.json
@@ -686,8 +686,10 @@
       "hard": "Firme",
       "soft": "Flexible"
     },
+    "allocationModeHelp": "Soft reserves stock but leaves it visible to other orders; Hard holds it exclusively.",
     "availabilityOk": "Correcto",
     "backorderBadge": "Pedido pendiente {{shortfall}}",
+    "billingAllocation": "Billing & allocation",
     "billsOnFulfillment": "Factura al cumplirse",
     "cancelDialog": {
       "confirm": "Cancelar orden de venta",
@@ -716,6 +718,7 @@
       "vendorPlaceholder": "Seleccione un proveedor…"
     },
     "created": "Orden de venta creada",
+    "currencyFromClient": "Set from client",
     "currencyRequired": "El código de moneda es obligatorio",
     "detailTitle": "Orden de venta {{number}}",
     "detailTitleFallback": "Orden de venta",
@@ -747,12 +750,22 @@
     "enterSerial": "Introduzca al menos un número de serie.",
     "fields": {
       "allocationMode": "Modo de asignación",
+      "clientPoNumber": "Client PO number",
       "currencyCode": "Código de moneda",
+      "expectedShipDate": "Expected ship date",
+      "fulfillment": "Fulfillment",
       "invoiceMode": "Modo de facturación",
+      "items": "Items",
       "lines": "Líneas",
+      "noService": "No service found.",
+      "notes": "Notes",
       "qty": "Cant.",
+      "searchService": "Search services…",
+      "selectService": "Select a service…",
+      "service": "Service",
       "serviceId": "ID de servicio",
-      "unitPrice": "Precio unitario ($)"
+      "unitPrice": "Precio unitario ($)",
+      "unitPriceIn": "Unit price ({{currency}})"
     },
     "fromQuote": "Desde cotización",
     "fulfillDialog": {
@@ -771,6 +784,10 @@
       "title": "Cumplir — {{name}}"
     },
     "fulfilledUnits": "Se cumplieron {{count}} unidad(es).",
+    "fulfillment": {
+      "dropShip": "Drop-ship",
+      "fromStock": "From stock"
+    },
     "fulfillmentFailed": "El cumplimiento falló.",
     "invoiceColumns": {
       "amount": "Importe",
@@ -782,6 +799,7 @@
       "manual": "Manual",
       "onFulfillment": "Al cumplirse"
     },
+    "invoiceModeHelp": "On fulfillment bills as items ship; Manual leaves invoicing to you.",
     "invoicedItems": "Se facturaron {{count}} artículo(s).",
     "invoices": "Facturas",
     "invoicingFailed": "La facturación falló: {{error}}. Use «Generar factura» para reintentar.",
@@ -802,8 +820,10 @@
     "nothingBackordered": "No hay nada en pedido pendiente.",
     "nothingToInvoice": "No queda nada por facturar.",
     "onlyRemaining": "Solo quedan {{remaining}} en esta línea.",
+    "pickServiceForLine": "Pick a service for this line.",
     "pickVendor": "Elija el proveedor que enviará esta línea.",
     "productDefaultLocation": "Ubicación predeterminada del producto",
+    "qtyPositive": "Must be > 0.",
     "qtyPositiveInteger": "La cantidad debe ser un número entero positivo.",
     "reopenError": "No se pudo reabrir la orden de venta.",
     "reopened": "Orden de venta reabierta — vuelve a ser un borrador.",
@@ -819,7 +839,9 @@
       "partiallyFulfilled": "Parcialmente cumplida"
     },
     "title": "Órdenes de venta",
-    "unassignedBackorder": "{{count}} línea(s) en pedido pendiente no tienen proveedor preferido — cree esas órdenes de compra manualmente."
+    "total": "Total",
+    "unassignedBackorder": "{{count}} línea(s) en pedido pendiente no tienen proveedor preferido — cree esas órdenes de compra manualmente.",
+    "unnamedService": "Unnamed"
   },
   "stock": {
     "actions": {

--- a/server/public/locales/fr/features/inventory.json
+++ b/server/public/locales/fr/features/inventory.json
@@ -686,8 +686,10 @@
       "hard": "Ferme",
       "soft": "Souple"
     },
+    "allocationModeHelp": "Soft reserves stock but leaves it visible to other orders; Hard holds it exclusively.",
     "availabilityOk": "OK",
     "backorderBadge": "Reliquat {{shortfall}}",
+    "billingAllocation": "Billing & allocation",
     "billsOnFulfillment": "Facturé à la livraison",
     "cancelDialog": {
       "confirm": "Annuler la commande client",
@@ -716,6 +718,7 @@
       "vendorPlaceholder": "Sélectionnez un fournisseur…"
     },
     "created": "Commande client créée",
+    "currencyFromClient": "Set from client",
     "currencyRequired": "Le code de devise est requis",
     "detailTitle": "Commande client {{number}}",
     "detailTitleFallback": "Commande client",
@@ -747,12 +750,22 @@
     "enterSerial": "Saisissez au moins un numéro de série.",
     "fields": {
       "allocationMode": "Mode d'allocation",
+      "clientPoNumber": "Client PO number",
       "currencyCode": "Code de devise",
+      "expectedShipDate": "Expected ship date",
+      "fulfillment": "Fulfillment",
       "invoiceMode": "Mode de facturation",
+      "items": "Items",
       "lines": "Lignes",
+      "noService": "No service found.",
+      "notes": "Notes",
       "qty": "Qté",
+      "searchService": "Search services…",
+      "selectService": "Select a service…",
+      "service": "Service",
       "serviceId": "ID de service",
-      "unitPrice": "Prix unitaire ($)"
+      "unitPrice": "Prix unitaire ($)",
+      "unitPriceIn": "Unit price ({{currency}})"
     },
     "fromQuote": "Depuis le devis",
     "fulfillDialog": {
@@ -771,6 +784,10 @@
       "title": "Livrer — {{name}}"
     },
     "fulfilledUnits": "{{count}} unité(s) livrée(s).",
+    "fulfillment": {
+      "dropShip": "Drop-ship",
+      "fromStock": "From stock"
+    },
     "fulfillmentFailed": "Échec de la livraison.",
     "invoiceColumns": {
       "amount": "Montant",
@@ -782,6 +799,7 @@
       "manual": "Manuel",
       "onFulfillment": "À la livraison"
     },
+    "invoiceModeHelp": "On fulfillment bills as items ship; Manual leaves invoicing to you.",
     "invoicedItems": "{{count}} article(s) facturé(s).",
     "invoices": "Factures",
     "invoicingFailed": "Échec de la facturation : {{error}}. Utilisez « Générer la facture » pour réessayer.",
@@ -802,8 +820,10 @@
     "nothingBackordered": "Aucun reliquat.",
     "nothingToInvoice": "Plus rien à facturer.",
     "onlyRemaining": "Il ne reste que {{remaining}} sur cette ligne.",
+    "pickServiceForLine": "Pick a service for this line.",
     "pickVendor": "Choisissez le fournisseur qui expédiera cette ligne.",
     "productDefaultLocation": "Emplacement par défaut du produit",
+    "qtyPositive": "Must be > 0.",
     "qtyPositiveInteger": "La quantité doit être un nombre entier positif.",
     "reopenError": "Impossible de rouvrir la commande client.",
     "reopened": "Commande client rouverte — elle est de nouveau à l'état de brouillon.",
@@ -819,7 +839,9 @@
       "partiallyFulfilled": "Partiellement livrée"
     },
     "title": "Commandes client",
-    "unassignedBackorder": "{{count}} ligne(s) en reliquat n'ont pas de fournisseur préféré — créez ces PO manuellement."
+    "total": "Total",
+    "unassignedBackorder": "{{count}} ligne(s) en reliquat n'ont pas de fournisseur préféré — créez ces PO manuellement.",
+    "unnamedService": "Unnamed"
   },
   "stock": {
     "actions": {

--- a/server/public/locales/it/features/inventory.json
+++ b/server/public/locales/it/features/inventory.json
@@ -686,8 +686,10 @@
       "hard": "Rigida",
       "soft": "Flessibile"
     },
+    "allocationModeHelp": "Soft reserves stock but leaves it visible to other orders; Hard holds it exclusively.",
     "availabilityOk": "OK",
     "backorderBadge": "Arretrato {{shortfall}}",
+    "billingAllocation": "Billing & allocation",
     "billsOnFulfillment": "Fattura all'evasione",
     "cancelDialog": {
       "confirm": "Annulla ordine di vendita",
@@ -716,6 +718,7 @@
       "vendorPlaceholder": "Seleziona un fornitore…"
     },
     "created": "Ordine di vendita creato",
+    "currencyFromClient": "Set from client",
     "currencyRequired": "Il codice valuta è obbligatorio",
     "detailTitle": "Ordine di vendita {{number}}",
     "detailTitleFallback": "Ordine di vendita",
@@ -747,12 +750,22 @@
     "enterSerial": "Inserisci almeno un numero di serie.",
     "fields": {
       "allocationMode": "Modalità di allocazione",
+      "clientPoNumber": "Client PO number",
       "currencyCode": "Codice valuta",
+      "expectedShipDate": "Expected ship date",
+      "fulfillment": "Fulfillment",
       "invoiceMode": "Modalità fattura",
+      "items": "Items",
       "lines": "Righe",
+      "noService": "No service found.",
+      "notes": "Notes",
       "qty": "Qtà",
+      "searchService": "Search services…",
+      "selectService": "Select a service…",
+      "service": "Service",
       "serviceId": "ID servizio",
-      "unitPrice": "Prezzo unitario ($)"
+      "unitPrice": "Prezzo unitario ($)",
+      "unitPriceIn": "Unit price ({{currency}})"
     },
     "fromQuote": "Da preventivo",
     "fulfillDialog": {
@@ -771,6 +784,10 @@
       "title": "Evadi — {{name}}"
     },
     "fulfilledUnits": "Evase {{count}} unità.",
+    "fulfillment": {
+      "dropShip": "Drop-ship",
+      "fromStock": "From stock"
+    },
     "fulfillmentFailed": "Evasione non riuscita.",
     "invoiceColumns": {
       "amount": "Importo",
@@ -782,6 +799,7 @@
       "manual": "Manuale",
       "onFulfillment": "All'evasione"
     },
+    "invoiceModeHelp": "On fulfillment bills as items ship; Manual leaves invoicing to you.",
     "invoicedItems": "Fatturati {{count}} articoli.",
     "invoices": "Fatture",
     "invoicingFailed": "Fatturazione non riuscita: {{error}}. Usa \"Genera fattura\" per riprovare.",
@@ -802,8 +820,10 @@
     "nothingBackordered": "Non c'è nulla in arretrato.",
     "nothingToInvoice": "Non c'è più nulla da fatturare.",
     "onlyRemaining": "Rimangono solo {{remaining}} su questa riga.",
+    "pickServiceForLine": "Pick a service for this line.",
     "pickVendor": "Scegli il fornitore che spedirà questa riga.",
     "productDefaultLocation": "Ubicazione predefinita del prodotto",
+    "qtyPositive": "Must be > 0.",
     "qtyPositiveInteger": "La quantità deve essere un numero intero positivo.",
     "reopenError": "Impossibile riaprire l'ordine di vendita.",
     "reopened": "Ordine di vendita riaperto — è di nuovo una bozza.",
@@ -819,7 +839,9 @@
       "partiallyFulfilled": "Evaso parzialmente"
     },
     "title": "Ordini di vendita",
-    "unassignedBackorder": "{{count}} riga/righe in arretrato non hanno un fornitore preferito — crea quei PO manualmente."
+    "total": "Total",
+    "unassignedBackorder": "{{count}} riga/righe in arretrato non hanno un fornitore preferito — crea quei PO manualmente.",
+    "unnamedService": "Unnamed"
   },
   "stock": {
     "actions": {

--- a/server/public/locales/nl/features/inventory.json
+++ b/server/public/locales/nl/features/inventory.json
@@ -686,8 +686,10 @@
       "hard": "Hard",
       "soft": "Zacht"
     },
+    "allocationModeHelp": "Soft reserves stock but leaves it visible to other orders; Hard holds it exclusively.",
     "availabilityOk": "OK",
     "backorderBadge": "Backorder {{shortfall}}",
+    "billingAllocation": "Billing & allocation",
     "billsOnFulfillment": "Factureert bij uitvoering",
     "cancelDialog": {
       "confirm": "Verkooporder annuleren",
@@ -716,6 +718,7 @@
       "vendorPlaceholder": "Selecteer een leverancier…"
     },
     "created": "Verkooporder aangemaakt",
+    "currencyFromClient": "Set from client",
     "currencyRequired": "Valutacode is verplicht",
     "detailTitle": "Verkooporder {{number}}",
     "detailTitleFallback": "Verkooporder",
@@ -747,12 +750,22 @@
     "enterSerial": "Voer minstens één serienummer in.",
     "fields": {
       "allocationMode": "Toewijzingsmodus",
+      "clientPoNumber": "Client PO number",
       "currencyCode": "Valutacode",
+      "expectedShipDate": "Expected ship date",
+      "fulfillment": "Fulfillment",
       "invoiceMode": "Factuurmodus",
+      "items": "Items",
       "lines": "Regels",
+      "noService": "No service found.",
+      "notes": "Notes",
       "qty": "Aantal",
+      "searchService": "Search services…",
+      "selectService": "Select a service…",
+      "service": "Service",
       "serviceId": "Service-ID",
-      "unitPrice": "Stukprijs ($)"
+      "unitPrice": "Stukprijs ($)",
+      "unitPriceIn": "Unit price ({{currency}})"
     },
     "fromQuote": "Uit offerte",
     "fulfillDialog": {
@@ -771,6 +784,10 @@
       "title": "Uitvoeren — {{name}}"
     },
     "fulfilledUnits": "{{count}} eenhe(i)d(en) uitgevoerd.",
+    "fulfillment": {
+      "dropShip": "Drop-ship",
+      "fromStock": "From stock"
+    },
     "fulfillmentFailed": "Uitvoering mislukt.",
     "invoiceColumns": {
       "amount": "Bedrag",
@@ -782,6 +799,7 @@
       "manual": "Handmatig",
       "onFulfillment": "Bij uitvoering"
     },
+    "invoiceModeHelp": "On fulfillment bills as items ship; Manual leaves invoicing to you.",
     "invoicedItems": "{{count}} item(s) gefactureerd.",
     "invoices": "Facturen",
     "invoicingFailed": "Facturatie mislukt: {{error}}. Gebruik \"Factuur genereren\" om het opnieuw te proberen.",
@@ -802,8 +820,10 @@
     "nothingBackordered": "Er staat niets in backorder.",
     "nothingToInvoice": "Er is niets meer te factureren.",
     "onlyRemaining": "Nog maar {{remaining}} resterend op deze regel.",
+    "pickServiceForLine": "Pick a service for this line.",
     "pickVendor": "Kies de leverancier die deze regel gaat verzenden.",
     "productDefaultLocation": "Standaardlocatie product",
+    "qtyPositive": "Must be > 0.",
     "qtyPositiveInteger": "Aantal moet een positief geheel getal zijn.",
     "reopenError": "Kon de verkooporder niet heropenen.",
     "reopened": "Verkooporder heropend — het is weer een concept.",
@@ -819,7 +839,9 @@
       "partiallyFulfilled": "Gedeeltelijk uitgevoerd"
     },
     "title": "Verkooporders",
-    "unassignedBackorder": "{{count}} backorderregel(s) hebben geen voorkeursleverancier — maak die inkooporders handmatig aan."
+    "total": "Total",
+    "unassignedBackorder": "{{count}} backorderregel(s) hebben geen voorkeursleverancier — maak die inkooporders handmatig aan.",
+    "unnamedService": "Unnamed"
   },
   "stock": {
     "actions": {

--- a/server/public/locales/pl/features/inventory.json
+++ b/server/public/locales/pl/features/inventory.json
@@ -686,8 +686,10 @@
       "hard": "Twarda",
       "soft": "Miękka"
     },
+    "allocationModeHelp": "Soft reserves stock but leaves it visible to other orders; Hard holds it exclusively.",
     "availabilityOk": "OK",
     "backorderBadge": "Zamówienie zaległe {{shortfall}}",
+    "billingAllocation": "Billing & allocation",
     "billsOnFulfillment": "Rozliczenie przy realizacji",
     "cancelDialog": {
       "confirm": "Anuluj zamówienie sprzedaży",
@@ -716,6 +718,7 @@
       "vendorPlaceholder": "Wybierz dostawcę…"
     },
     "created": "Zamówienie sprzedaży utworzone",
+    "currencyFromClient": "Set from client",
     "currencyRequired": "Kod waluty jest wymagany",
     "detailTitle": "Zamówienie sprzedaży {{number}}",
     "detailTitleFallback": "Zamówienie sprzedaży",
@@ -747,12 +750,22 @@
     "enterSerial": "Wprowadź co najmniej jeden numer seryjny.",
     "fields": {
       "allocationMode": "Tryb alokacji",
+      "clientPoNumber": "Client PO number",
       "currencyCode": "Kod waluty",
+      "expectedShipDate": "Expected ship date",
+      "fulfillment": "Fulfillment",
       "invoiceMode": "Tryb fakturowania",
+      "items": "Items",
       "lines": "Linie",
+      "noService": "No service found.",
+      "notes": "Notes",
       "qty": "Ilość",
+      "searchService": "Search services…",
+      "selectService": "Select a service…",
+      "service": "Service",
       "serviceId": "ID usługi",
-      "unitPrice": "Cena jednostkowa ($)"
+      "unitPrice": "Cena jednostkowa ($)",
+      "unitPriceIn": "Unit price ({{currency}})"
     },
     "fromQuote": "Z oferty",
     "fulfillDialog": {
@@ -771,6 +784,10 @@
       "title": "Zrealizuj — {{name}}"
     },
     "fulfilledUnits": "Zrealizowano {{count}} jednostek.",
+    "fulfillment": {
+      "dropShip": "Drop-ship",
+      "fromStock": "From stock"
+    },
     "fulfillmentFailed": "Realizacja nie powiodła się.",
     "invoiceColumns": {
       "amount": "Kwota",
@@ -782,6 +799,7 @@
       "manual": "Ręczny",
       "onFulfillment": "Przy realizacji"
     },
+    "invoiceModeHelp": "On fulfillment bills as items ship; Manual leaves invoicing to you.",
     "invoicedItems": "Zafakturowano {{count}} pozycji.",
     "invoices": "Faktury",
     "invoicingFailed": "Fakturowanie nie powiodło się: {{error}}. Użyj „Wygeneruj fakturę”, aby spróbować ponownie.",
@@ -802,8 +820,10 @@
     "nothingBackordered": "Nic nie jest zaległe.",
     "nothingToInvoice": "Nic nie pozostało do zafakturowania.",
     "onlyRemaining": "Na tej linii pozostało tylko {{remaining}}.",
+    "pickServiceForLine": "Pick a service for this line.",
     "pickVendor": "Wybierz dostawcę, który wyśle tę linię.",
     "productDefaultLocation": "Domyślna lokalizacja produktu",
+    "qtyPositive": "Must be > 0.",
     "qtyPositiveInteger": "Ilość musi być dodatnią liczbą całkowitą.",
     "reopenError": "Nie udało się otworzyć ponownie zamówienia sprzedaży.",
     "reopened": "Zamówienie sprzedaży otwarte ponownie — jest znowu szkicem.",
@@ -819,7 +839,9 @@
       "partiallyFulfilled": "Częściowo zrealizowane"
     },
     "title": "Zamówienia sprzedaży",
-    "unassignedBackorder": "{{count}} zaległych linii nie ma preferowanego dostawcy — utwórz te PO ręcznie."
+    "total": "Total",
+    "unassignedBackorder": "{{count}} zaległych linii nie ma preferowanego dostawcy — utwórz te PO ręcznie.",
+    "unnamedService": "Unnamed"
   },
   "stock": {
     "actions": {

--- a/server/public/locales/pt/features/inventory.json
+++ b/server/public/locales/pt/features/inventory.json
@@ -686,8 +686,10 @@
       "hard": "Rígida",
       "soft": "Flexível"
     },
+    "allocationModeHelp": "Soft reserves stock but leaves it visible to other orders; Hard holds it exclusively.",
     "availabilityOk": "OK",
     "backorderBadge": "Pendência {{shortfall}}",
+    "billingAllocation": "Billing & allocation",
     "billsOnFulfillment": "Fatura no atendimento",
     "cancelDialog": {
       "confirm": "Cancelar pedido de venda",
@@ -716,6 +718,7 @@
       "vendorPlaceholder": "Selecione um fornecedor…"
     },
     "created": "Pedido de venda criado",
+    "currencyFromClient": "Set from client",
     "currencyRequired": "O código da moeda é obrigatório",
     "detailTitle": "Pedido de Venda {{number}}",
     "detailTitleFallback": "Pedido de Venda",
@@ -747,12 +750,22 @@
     "enterSerial": "Insira pelo menos um número de série.",
     "fields": {
       "allocationMode": "Modo de alocação",
+      "clientPoNumber": "Client PO number",
       "currencyCode": "Código da moeda",
+      "expectedShipDate": "Expected ship date",
+      "fulfillment": "Fulfillment",
       "invoiceMode": "Modo de faturamento",
+      "items": "Items",
       "lines": "Linhas",
+      "noService": "No service found.",
+      "notes": "Notes",
       "qty": "Qtd",
+      "searchService": "Search services…",
+      "selectService": "Select a service…",
+      "service": "Service",
       "serviceId": "ID do serviço",
-      "unitPrice": "Preço Unitário ($)"
+      "unitPrice": "Preço Unitário ($)",
+      "unitPriceIn": "Unit price ({{currency}})"
     },
     "fromQuote": "A partir de cotação",
     "fulfillDialog": {
@@ -771,6 +784,10 @@
       "title": "Atender — {{name}}"
     },
     "fulfilledUnits": "Atendidas {{count}} unidade(s).",
+    "fulfillment": {
+      "dropShip": "Drop-ship",
+      "fromStock": "From stock"
+    },
     "fulfillmentFailed": "Falha no atendimento.",
     "invoiceColumns": {
       "amount": "Valor",
@@ -782,6 +799,7 @@
       "manual": "Manual",
       "onFulfillment": "No atendimento"
     },
+    "invoiceModeHelp": "On fulfillment bills as items ship; Manual leaves invoicing to you.",
     "invoicedItems": "Faturados {{count}} item(ns).",
     "invoices": "Faturas",
     "invoicingFailed": "Falha no faturamento: {{error}}. Use \"Gerar fatura\" para tentar novamente.",
@@ -802,8 +820,10 @@
     "nothingBackordered": "Nada em pendência.",
     "nothingToInvoice": "Nada mais a faturar.",
     "onlyRemaining": "Apenas {{remaining}} restantes nesta linha.",
+    "pickServiceForLine": "Pick a service for this line.",
     "pickVendor": "Escolha o fornecedor que enviará esta linha.",
     "productDefaultLocation": "Localização padrão do produto",
+    "qtyPositive": "Must be > 0.",
     "qtyPositiveInteger": "A quantidade deve ser um número inteiro positivo.",
     "reopenError": "Não foi possível reabrir o pedido de venda.",
     "reopened": "Pedido de venda reaberto — voltou a ser um rascunho.",
@@ -819,7 +839,9 @@
       "partiallyFulfilled": "Parcialmente atendido"
     },
     "title": "Pedidos de Venda",
-    "unassignedBackorder": "{{count}} linha(s) em pendência não têm fornecedor preferencial — crie esses POs manualmente."
+    "total": "Total",
+    "unassignedBackorder": "{{count}} linha(s) em pendência não têm fornecedor preferencial — crie esses POs manualmente.",
+    "unnamedService": "Unnamed"
   },
   "stock": {
     "actions": {

--- a/server/public/locales/xx/features/inventory.json
+++ b/server/public/locales/xx/features/inventory.json
@@ -686,8 +686,10 @@
       "hard": "11111",
       "soft": "11111"
     },
+    "allocationModeHelp": "Soft reserves stock but leaves it visible to other orders; Hard holds it exclusively.",
     "availabilityOk": "11111",
     "backorderBadge": "11111 {{shortfall}} 11111",
+    "billingAllocation": "Billing & allocation",
     "billsOnFulfillment": "11111",
     "cancelDialog": {
       "confirm": "11111",
@@ -716,6 +718,7 @@
       "vendorPlaceholder": "11111"
     },
     "created": "11111",
+    "currencyFromClient": "Set from client",
     "currencyRequired": "11111",
     "detailTitle": "11111 {{number}} 11111",
     "detailTitleFallback": "11111",
@@ -747,12 +750,22 @@
     "enterSerial": "11111",
     "fields": {
       "allocationMode": "11111",
+      "clientPoNumber": "Client PO number",
       "currencyCode": "11111",
+      "expectedShipDate": "Expected ship date",
+      "fulfillment": "Fulfillment",
       "invoiceMode": "11111",
+      "items": "Items",
       "lines": "11111",
+      "noService": "No service found.",
+      "notes": "Notes",
       "qty": "11111",
+      "searchService": "Search services…",
+      "selectService": "Select a service…",
+      "service": "Service",
       "serviceId": "11111",
-      "unitPrice": "11111"
+      "unitPrice": "11111",
+      "unitPriceIn": "Unit price ({{currency}})"
     },
     "fromQuote": "11111",
     "fulfillDialog": {
@@ -771,6 +784,10 @@
       "title": "11111 {{name}} 11111"
     },
     "fulfilledUnits": "11111 {{count}} 11111",
+    "fulfillment": {
+      "dropShip": "Drop-ship",
+      "fromStock": "From stock"
+    },
     "fulfillmentFailed": "11111",
     "invoiceColumns": {
       "amount": "11111",
@@ -782,6 +799,7 @@
       "manual": "11111",
       "onFulfillment": "11111"
     },
+    "invoiceModeHelp": "On fulfillment bills as items ship; Manual leaves invoicing to you.",
     "invoicedItems": "11111 {{count}} 11111",
     "invoices": "11111",
     "invoicingFailed": "11111 {{error}} 11111",
@@ -802,8 +820,10 @@
     "nothingBackordered": "11111",
     "nothingToInvoice": "11111",
     "onlyRemaining": "11111 {{remaining}} 11111",
+    "pickServiceForLine": "Pick a service for this line.",
     "pickVendor": "11111",
     "productDefaultLocation": "11111",
+    "qtyPositive": "Must be > 0.",
     "qtyPositiveInteger": "11111",
     "reopenError": "11111",
     "reopened": "11111",
@@ -819,7 +839,9 @@
       "partiallyFulfilled": "11111"
     },
     "title": "11111",
-    "unassignedBackorder": "11111 {{count}} 11111"
+    "total": "Total",
+    "unassignedBackorder": "11111 {{count}} 11111",
+    "unnamedService": "Unnamed"
   },
   "stock": {
     "actions": {

--- a/server/public/locales/yy/features/inventory.json
+++ b/server/public/locales/yy/features/inventory.json
@@ -686,8 +686,10 @@
       "hard": "55555",
       "soft": "55555"
     },
+    "allocationModeHelp": "Soft reserves stock but leaves it visible to other orders; Hard holds it exclusively.",
     "availabilityOk": "55555",
     "backorderBadge": "55555 {{shortfall}} 55555",
+    "billingAllocation": "Billing & allocation",
     "billsOnFulfillment": "55555",
     "cancelDialog": {
       "confirm": "55555",
@@ -716,6 +718,7 @@
       "vendorPlaceholder": "55555"
     },
     "created": "55555",
+    "currencyFromClient": "Set from client",
     "currencyRequired": "55555",
     "detailTitle": "55555 {{number}} 55555",
     "detailTitleFallback": "55555",
@@ -747,12 +750,22 @@
     "enterSerial": "55555",
     "fields": {
       "allocationMode": "55555",
+      "clientPoNumber": "Client PO number",
       "currencyCode": "55555",
+      "expectedShipDate": "Expected ship date",
+      "fulfillment": "Fulfillment",
       "invoiceMode": "55555",
+      "items": "Items",
       "lines": "55555",
+      "noService": "No service found.",
+      "notes": "Notes",
       "qty": "55555",
+      "searchService": "Search services…",
+      "selectService": "Select a service…",
+      "service": "Service",
       "serviceId": "55555",
-      "unitPrice": "55555"
+      "unitPrice": "55555",
+      "unitPriceIn": "Unit price ({{currency}})"
     },
     "fromQuote": "55555",
     "fulfillDialog": {
@@ -771,6 +784,10 @@
       "title": "55555 {{name}} 55555"
     },
     "fulfilledUnits": "55555 {{count}} 55555",
+    "fulfillment": {
+      "dropShip": "Drop-ship",
+      "fromStock": "From stock"
+    },
     "fulfillmentFailed": "55555",
     "invoiceColumns": {
       "amount": "55555",
@@ -782,6 +799,7 @@
       "manual": "55555",
       "onFulfillment": "55555"
     },
+    "invoiceModeHelp": "On fulfillment bills as items ship; Manual leaves invoicing to you.",
     "invoicedItems": "55555 {{count}} 55555",
     "invoices": "55555",
     "invoicingFailed": "55555 {{error}} 55555",
@@ -802,8 +820,10 @@
     "nothingBackordered": "55555",
     "nothingToInvoice": "55555",
     "onlyRemaining": "55555 {{remaining}} 55555",
+    "pickServiceForLine": "Pick a service for this line.",
     "pickVendor": "55555",
     "productDefaultLocation": "55555",
+    "qtyPositive": "Must be > 0.",
     "qtyPositiveInteger": "55555",
     "reopenError": "55555",
     "reopened": "55555",
@@ -819,7 +839,9 @@
       "partiallyFulfilled": "55555"
     },
     "title": "55555",
-    "unassignedBackorder": "55555 {{count}} 55555"
+    "total": "Total",
+    "unassignedBackorder": "55555 {{count}} 55555",
+    "unnamedService": "Unnamed"
   },
   "stock": {
     "actions": {

--- a/server/seeds/dev/47_permissions.cjs
+++ b/server/seeds/dev/47_permissions.cjs
@@ -256,7 +256,36 @@ exports.seed = async function(knex) {
         { resource: 'service', action: 'delete', msp: true, client: false, description: 'Archive/delete services/products in the service catalog' },
 
         // Job monitoring
-        { resource: 'job', action: 'delete', msp: true, client: false, description: 'Clear job monitoring history' }
+        { resource: 'job', action: 'delete', msp: true, client: false, description: 'Clear job monitoring history' },
+
+        // Inventory module permissions (MSP-only; the MSP Admin role receives all
+        // msp permissions below. Mirrors migration 20260626100600_add_inventory_permissions.
+        // Without these the Add Sales Order / stock-location / inventory server actions
+        // fail the RBAC check even for Admin, e.g. "Permission denied: sales_order create required".)
+        { resource: 'inventory', action: 'create', msp: true, client: false, description: 'Create inventory records' },
+        { resource: 'inventory', action: 'read', msp: true, client: false, description: 'View inventory records' },
+        { resource: 'inventory', action: 'update', msp: true, client: false, description: 'Update inventory records' },
+        { resource: 'inventory', action: 'delete', msp: true, client: false, description: 'Delete inventory records' },
+        { resource: 'vendor', action: 'create', msp: true, client: false, description: 'Create vendors' },
+        { resource: 'vendor', action: 'read', msp: true, client: false, description: 'View vendors' },
+        { resource: 'vendor', action: 'update', msp: true, client: false, description: 'Update vendors' },
+        { resource: 'vendor', action: 'delete', msp: true, client: false, description: 'Delete vendors' },
+        { resource: 'purchase_order', action: 'create', msp: true, client: false, description: 'Create purchase orders' },
+        { resource: 'purchase_order', action: 'read', msp: true, client: false, description: 'View purchase orders' },
+        { resource: 'purchase_order', action: 'update', msp: true, client: false, description: 'Update purchase orders' },
+        { resource: 'purchase_order', action: 'delete', msp: true, client: false, description: 'Delete purchase orders' },
+        { resource: 'sales_order', action: 'create', msp: true, client: false, description: 'Create sales orders' },
+        { resource: 'sales_order', action: 'read', msp: true, client: false, description: 'View sales orders' },
+        { resource: 'sales_order', action: 'update', msp: true, client: false, description: 'Update sales orders' },
+        { resource: 'sales_order', action: 'delete', msp: true, client: false, description: 'Delete sales orders' },
+        { resource: 'stock_transfer', action: 'create', msp: true, client: false, description: 'Create stock transfers' },
+        { resource: 'stock_transfer', action: 'read', msp: true, client: false, description: 'View stock transfers' },
+        { resource: 'stock_transfer', action: 'update', msp: true, client: false, description: 'Update stock transfers' },
+        { resource: 'stock_transfer', action: 'delete', msp: true, client: false, description: 'Delete stock transfers' },
+        { resource: 'stock_location', action: 'create', msp: true, client: false, description: 'Create stock locations' },
+        { resource: 'stock_location', action: 'read', msp: true, client: false, description: 'View stock locations' },
+        { resource: 'stock_location', action: 'update', msp: true, client: false, description: 'Update stock locations' },
+        { resource: 'stock_location', action: 'delete', msp: true, client: false, description: 'Delete stock locations' }
     ];
 
     // Process each tenant

--- a/server/src/app/msp/inventory/sales-orders/page.tsx
+++ b/server/src/app/msp/inventory/sales-orders/page.tsx
@@ -6,11 +6,13 @@ import {
   confirmDropShipAndInvoice,
   fulfillAndInvoiceSoLine,
   generateInvoiceForSalesOrder,
+  getServices,
 } from '@alga-psa/billing/actions';
 import { getAllClients } from '@alga-psa/clients/actions';
 import { getSession } from '@alga-psa/auth';
 import { redirect } from 'next/navigation';
 import type { IClient, ISalesOrder, IStockLocation } from '@alga-psa/types';
+import type { SalesOrderServiceOption } from '@alga-psa/inventory/components';
 import type { Metadata } from 'next';
 import { enforceServerProductRoute } from '@/lib/serverProductRouteGuard';
 
@@ -50,11 +52,28 @@ export default async function SalesOrdersPage() {
     console.error('Failed to load clients:', error);
   }
 
+  // Products *and* services can be sold on a sales order (item_kind: 'any'). The picker and
+  // price auto-fill live in the inventory client component, but the fetch belongs on the server
+  // beside the other prop loads — inventory can't import billing's getServices directly.
+  let services: SalesOrderServiceOption[] = [];
+  try {
+    const paginated = await getServices(1, 999, { item_kind: 'any' });
+    services = paginated.services.map((s) => ({
+      service_id: s.service_id,
+      service_name: s.service_name,
+      sku: s.sku ?? null,
+      default_rate: s.default_rate ?? null,
+    }));
+  } catch (error) {
+    console.error('Failed to load services:', error);
+  }
+
   return (
     <SalesOrdersManager
       initialSos={initialSos}
       locations={locations}
       clients={clients}
+      services={services}
       fulfillAndInvoice={fulfillAndInvoiceSoLine}
       generateInvoice={generateInvoiceForSalesOrder}
       confirmDropShip={confirmDropShipAndInvoice}

--- a/server/src/test/unit/migrations/inventoryPermissionsSeedGap.test.ts
+++ b/server/src/test/unit/migrations/inventoryPermissionsSeedGap.test.ts
@@ -1,0 +1,70 @@
+import fs from 'node:fs';
+import path from 'node:path';
+import { describe, expect, it } from 'vitest';
+
+const repoRoot = path.resolve(__dirname, '../../../../..');
+
+function readRepoFile(...segments: string[]): string {
+  return fs.readFileSync(path.join(repoRoot, ...segments), 'utf8');
+}
+
+// Regression guard for the inventory RBAC seed gap: migration 20260626100600
+// backfills inventory permissions for tenants that exist at migration time, but
+// on fresh installs (migrations run against an empty DB, then a tenant is created
+// from the seeds) that backfill is a no-op and the permission seeds carried no
+// inventory defs — so even the MSP Admin failed every inventory RBAC check
+// ("Permission denied: sales_order create required"). The seeds now define the
+// inventory permissions and a readd migration repairs already-provisioned tenants.
+describe('inventory permissions seed gap', () => {
+  const INVENTORY_RESOURCES = [
+    'inventory',
+    'vendor',
+    'purchase_order',
+    'sales_order',
+    'stock_transfer',
+    'stock_location',
+  ];
+
+  const readdMigration = readRepoFile(
+    'server',
+    'migrations',
+    '20260707120000_readd_inventory_permissions_for_seeded_tenants.cjs',
+  );
+  const devPermissionSeed = readRepoFile('server', 'seeds', 'dev', '47_permissions.cjs');
+  const onboardingPermissionSeed = readRepoFile(
+    'ee',
+    'server',
+    'seeds',
+    'onboarding',
+    'psa',
+    '02_permissions.cjs',
+  );
+
+  it('defines every inventory resource/action in both permission seeds', () => {
+    const actions = ['create', 'read', 'update', 'delete'];
+    for (const resource of INVENTORY_RESOURCES) {
+      for (const action of actions) {
+        const def = `{ resource: '${resource}', action: '${action}', msp: true, client: false`;
+        expect(devPermissionSeed).toContain(def);
+        expect(onboardingPermissionSeed).toContain(def);
+      }
+    }
+  });
+
+  it('readd migration grants the inventory resources to the MSP Admin role only', () => {
+    for (const resource of INVENTORY_RESOURCES) {
+      expect(readdMigration).toContain(`'${resource}'`);
+    }
+
+    // Grants flow to the single MSP Admin role, mirroring 20260626100600.
+    expect(readdMigration).toContain("whereRaw(\"LOWER(role_name) = 'admin'\")");
+    expect(readdMigration).toContain('role_id: adminRole.role_id');
+    expect(readdMigration).not.toContain("role_name: 'Manager'");
+    expect(readdMigration).not.toContain("role_name: 'Technician'");
+
+    // Exactly one role_permissions insert (Admin), and it is idempotent.
+    const rolePermissionInsertCount = (readdMigration.match(/role_permissions'\)\n?\s*\.insert/g) ?? []).length;
+    expect(rolePermissionInsertCount).toBe(1);
+    expect(readdMigration).toContain('existingRolePermIds.has');
+  });
+});


### PR DESCRIPTION
## Sales order inventory adversarial design

An adversarial-design pass over the **Add Sales Order** dialog (`packages/inventory/src/components/SalesOrdersManager.tsx`), plus the RBAC seed fix that makes the whole sales-order flow actually reachable for existing tenants.

### What changed

**Add Sales Order dialog redesign** (`SalesOrdersManager.tsx`)
- **Per-line `fulfillment_type` (From-stock | Drop-ship).** This is the headline fix: drop-ship was fully built downstream (vendor-shipment dialog + `confirmDropShipAndInvoice`) but **unreachable** — no line could be *born* drop-ship because the create dialog never emitted `fulfillment_type`. A line can now be created drop-ship, closing that gap.
- **Client-derived, read-only currency.** Selecting a client cascades client → tenant → USD to set the header currency; the field is read-only with a "Set from client" placeholder until a client is chosen.
- **Currency-aware price seeding.** Picking a service/product seeds the unit price from the catalog rate, converting minor-units → major-units using the currency's own exponent (JPY×1, USD×100) instead of a hardcoded `× 100`.
- **New fields:** `client_po_number`, `notes`, `expected_ship_date`, grouped alongside the retained invoice-mode / allocation-mode controls with helper text in a Billing & allocation section.
- **Running order total** recomputed live from line qty × unit price.
- **Save gating:** disabled until a client and at least one valid line are present.
- Deferred by design: ship_to, per-line `tax_rate_id`, `order_date`. Per-line `currency_code` kept out of the UI (must equal header).

**New currency-aware formatters** (`packages/core/src/lib/formatters.ts`)
- `currencyFractionDigits()` and `toMinorUnits()` derive minor-unit exponents from `Intl.NumberFormat` (no hand-kept table). Inventory can't import billing, so services are fetched by the page (`getServices`, `item_kind: 'any'`) and passed as a `SalesOrderServiceOption[]` prop; the line picker uses `SearchableSelect`.

**Inventory RBAC seed fix** (the reason the SO list/flow was empty before)
- Added inventory permission definitions — `sales_order`, `stock_location`, `inventory`, `vendor`, `purchase_order`, `stock_transfer` × CRUD (`msp: true`) — to **both** permission seeds (`server/seeds/dev/47_permissions.cjs`, `ee/server/seeds/onboarding/psa/02_permissions.cjs`). MSP Admin auto-receives all `msp` perms.
- Added an idempotent, Admin-only re-add migration (`server/migrations/20260707120000_readd_inventory_permissions_for_seeded_tenants.cjs`) to repair **already-provisioned** tenants. Root cause: the prior `20260626100600` migration no-ops on fresh installs (migrations run against an empty DB; the tenant is seeded afterward), so seeded tenants had no inventory permission rows and even Admin hit `Permission denied: sales_order`.
- Regression test: `server/src/test/unit/migrations/inventoryPermissionsSeedGap.test.ts`.
- i18n strings for the new dialog fields across all locales.

### Smoke test

**Full-fidelity UI smoke test PASSED** against the live dev stack (localhost:3433, next-server running from this worktree, tenant Oz, logged in as Admin glinda). Drove the redesigned Add Sales Order dialog end-to-end and verified every changed behavior at the database level.

1. Selecting client **Emerald City** auto-derived the read-only currency to **USD**.
2. The `SearchableSelect` service picker (**Rabbit Tracking**, catalog 7500 minor units) seeded unit price to **75** via currency-aware conversion (USD 2 fraction digits).
3. Running total recomputed to **$150.00** (qty 2 × $75).
4. Set the per-line fulfillment to **Drop-ship** — the previously-**unreachable** path.
5. Filled the new fields `client_po_number=PO-SMOKE-9001`, `expected_ship_date=2026-08-15`, notes.
6. Save was enabled and persisted a real row: `sales_orders` count 1→2; DB confirms `currency_code=USD`, `client_po_number=PO-SMOKE-9001`, `expected_ship_date=2026-08-15`, notes present, `invoice_mode=on_fulfillment`, `allocation_mode=soft`, and line = Rabbit Tracking qty 2 unit_price 7500 `fulfillment_type=drop_ship`.

This simultaneously confirms the **RBAC seed fix** (Admin persisted with no permission-denied) and the **dialog redesign** incl. the `drop_ship` capability.

**Regression checks:** the new order renders in the SO list (empty before the RBAC fix), and a fresh dialog has Save disabled with the currency placeholder "Set from client".

**Fidelity:** No mocks/fakes/simulators — real app + real Postgres + real RBAC gate; no fidelity step-downs.

**Suspicious (pre-existing, not from this change):** the created order's `so_number` came out as `TIC001000` (ticket-style) vs a prior `SO-SMOKE-DOC-200126` — the dialog doesn't assign the number (server-side `createSalesOrder` does), so this looks like a pre-existing SO-numbering-sequence quirk worth a separate look.

**Not tested (out of scope):** the downstream drop-ship confirmation/invoice dialog; this run only proves a line can now be *born* drop_ship, which was the gap.

**Evidence directory:** `/tmp/alga-smoke-evidence/sales-order-inventory-20260707-195719`
