### PR TITLE
Restyle document-type tabs to standard underline

### DIFF
--- a/packages/billing/src/components/billing-dashboard/documents/DocumentTemplatesPage.tsx
+++ b/packages/billing/src/components/billing-dashboard/documents/DocumentTemplatesPage.tsx
@@ -306,13 +306,12 @@ const DocumentTemplatesPage: React.FC<DocumentTemplatesPageProps> = ({ documentT
             onValueChange={handleDocumentTypeChange}
             className="w-auto"
           >
-            <TabsList className="rounded-md border border-[rgb(var(--color-border-200))] bg-[rgb(var(--color-card))] p-1">
+            <TabsList>
               {documentTypeOptions.map((option) => (
                 <TabsTrigger
                   key={option.type}
                   id={`document-template-type-${option.type}`}
                   value={option.type}
-                  className="rounded px-3 py-1.5 text-sm aria-selected:bg-[rgb(var(--color-primary-100))] dark:aria-selected:bg-[rgb(var(--color-primary-400)/0.30)]"
                 >
                   {option.label}
                 </TabsTrigger>

--- a/packages/ui/src/components/CustomTabs.tsx
+++ b/packages/ui/src/components/CustomTabs.tsx
@@ -5,6 +5,8 @@ import * as Tabs from '@radix-ui/react-tabs';
 import { AutomationProps } from '../ui-reflection/types';
 import { type LucideIcon, ChevronDown } from 'lucide-react';
 
+// LEVERAGE: pattern duplicate-tabs-components — Radix-based twin of Tabs.tsx (hand-rolled) with the same default underline look but a data-driven API; ~32 vs ~21 consumers split along package-extraction lines. Consolidate to a single tabs layer.
+
 export interface TabContent {
   id: string;
   label: string;

--- a/packages/ui/src/components/Tabs.tsx
+++ b/packages/ui/src/components/Tabs.tsx
@@ -3,6 +3,7 @@
 import * as React from 'react';
 import { cn } from '../lib/utils';
 
+// LEVERAGE: pattern duplicate-tabs-components — hand-rolled twin of CustomTabs.tsx (Radix-based) with the same default underline look but a compositional API; ~21 vs ~32 consumers split along package-extraction lines. Consolidate to a single tabs layer.
 interface TabsContextValue {
   value: string;
   onValueChange: (value: string) => void;


### PR DESCRIPTION
Remove the page-local boxed/pill className overrides from the Document Layouts type switcher (Sales Order / Packing Slip / Pick List) so it renders with the same default underline style as tabs everywhere else in the app. Add LEVERAGE markers (duplicate-tabs-components) to Tabs.tsx and CustomTabs.tsx â two shared tab components with identical default looks â flagging them for consolidation into a single tabs layer.

"Pay no attention to the component behind the curtain!" boomed the great and powerful Tabs â but when the boxed-and-pilled disguise slipped from DocumentTemplatesPage, all of Oz could see there had been two identical underlines the whole time, and two LEVERAGE markers now light the yellow brick road toward a single tabs layer. ð­ðð