### PR TITLE
Gate Inventory sidebar behind feature flag, revert version

### DIFF
--- a/docs/features/feature-flags.md
+++ b/docs/features/feature-flags.md
@@ -163,6 +163,18 @@ Controls access to the new service request definition and client portal request-
 - When enabled: The full service request UI is accessible.
 - Backend (tables, actions, provider execution, portal submission processing) remains active regardless of flag state.
 
+### 11. `inventory-enabled`
+Controls access to the Inventory section in the MSP sidebar.
+
+**Affected Areas:**
+- **MSP Portal:**
+  - Inventory sidebar navigation section and all sub-items (Dashboard, Stock, Stock Locations, Stock Units, Vendors, Purchase Orders, Vendor Bills, Sales Orders, Transfers, Cycle Counts, Write-offs, Margin, Ghost Usage, RMA, Loaners, Kits) — hidden when disabled
+
+**Behavior:**
+- When disabled (default): The entire Inventory sidebar section is hidden.
+- When enabled: The full Inventory section is shown.
+- Backend (models, actions, routes) remains available regardless of flag state; this gates the sidebar entry only.
+
 ## Implementation Details
 
 ### User Identification

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@alga-psa/core",
-  "version": "1.3.0",
+  "version": "1.2.15",
   "private": true,
   "type": "module",
   "main": "./dist/index.js",

--- a/server/package.json
+++ b/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "server",
-  "version": "1.3.0",
+  "version": "1.2.15",
   "private": true,
   "type": "module",
   "engines": {

--- a/server/src/components/layout/SidebarWithFeatureFlags.tsx
+++ b/server/src/components/layout/SidebarWithFeatureFlags.tsx
@@ -56,6 +56,9 @@ export default function SidebarWithFeatureFlags(props: SidebarWithFeatureFlagsPr
   const navigationFlag = useFeatureFlag('ui-navigation-v2', { defaultValue: true });
   const useNavigationSections =
     typeof navigationFlag === 'boolean' ? navigationFlag : navigationFlag?.enabled ?? false;
+  const inventoryFlag = useFeatureFlag('inventory-enabled');
+  const isInventoryEnabled =
+    typeof inventoryFlag === 'boolean' ? inventoryFlag : inventoryFlag?.enabled ?? false;
   const [userPermissions, setUserPermissions] = useState<string[]>([]);
   const { hasFeature } = useTier();
   const { productCode } = useProduct();
@@ -102,6 +105,10 @@ export default function SidebarWithFeatureFlags(props: SidebarWithFeatureFlagsPr
     const filteredSections = baseSections.map((section) => ({
       ...section,
       items: section.items.map((item) => {
+        if (item.name === 'Inventory' && !isInventoryEnabled) {
+          return null;
+        }
+
         if (item.name === 'Workflows') {
           const filteredSubItems = item.subItems?.filter((subItem) => {
             if (subItem.name !== 'Dead Letter') return true;
@@ -118,7 +125,7 @@ export default function SidebarWithFeatureFlags(props: SidebarWithFeatureFlagsPr
       productCode,
       filterNavigationSectionsByFeatureAccess(filteredSections, hasFeature),
     );
-  }, [canWorkflowAdmin, useNavigationSections, hasFeature, productCode]);
+  }, [canWorkflowAdmin, useNavigationSections, hasFeature, productCode, isInventoryEnabled]);
 
   const settingsSections = useMemo<NavigationSection[]>(() => {
     return filterMenuSectionsByProduct(productCode, settingsNavigationSections);


### PR DESCRIPTION
Add the `inventory-enabled` PostHog flag so the entire Inventory sidebar section (and its sub-items) is hidden unless enabled; default off. Roll the app version back from 1.3.0 to 1.2.15 in server and @alga-psa/core, and document the new flag.

"And what is the use of an Inventory," thought Alice, "without Stock or Kits or Loaners to be seen?"—so the whole section vanished down the rabbit hole with a wave of `inventory-enabled`, while the clocks all ticked politely backward from 1.3.0 to 1.2.15. 🐇📦🕰️