### PR TITLE
Make SSO premise setup clear

### DIFF
--- a/docs/plans/2026-07-08-sso-provider-setup-easy-path-plan.md
+++ b/docs/plans/2026-07-08-sso-provider-setup-easy-path-plan.md
@@ -1,0 +1,188 @@
+# SSO Provider Setup — Easy Path
+
+**Branch:** `feature/sso-provider-setup-easy-path`
+**Date:** 2026-07-08
+**Type:** Discoverability / settings-IA consolidation (one new read-only server action; no schema changes)
+
+## Background
+
+There are two doors labeled "SSO", and hosted MSP admins keep walking through the wrong one.
+
+- **The right door — Settings → Security → Single Sign-On** renders `SsoBulkAssignment`
+  (`ee/server/src/components/settings/security/SsoBulkAssignment.tsx`, mounted via the
+  `single-sign-on` tab in `server/src/components/settings/security/SecuritySettingsPage.tsx`).
+  It holds the **auto-link** toggle and the **bulk user → provider assignment** form. Provider
+  availability comes from app-level OAuth secrets (`ee/server/src/lib/auth/providerConfig.ts`),
+  which on hosted are Nine Minds' own Google/Microsoft OAuth apps — already configured. This
+  tab is *all* a hosted tenant needs, but its content reads as "bulk assignment", not "set up SSO".
+  On CE the tab shows an enterprise-upgrade stub (`packages/ee/src/components/settings/security/SsoBulkAssignment.tsx`).
+
+- **The wrong door — Settings → General → Providers** stacks `MspSsoLoginDomainsSettings`
+  (`packages/integrations/src/components/settings/integrations/MspSsoLoginDomainsSettings.tsx`)
+  under the "Google Cloud" integration item in
+  `packages/integrations/src/components/settings/integrations/IntegrationsSettingsPage.tsx` (~line 295).
+  That panel manages **login-domain claims** (EE: DNS-TXT-verified; CE: advisory) which steer
+  MSP login SSO toward **tenant-level** IdP credentials — credentials read via
+  `getTenantSecret(tenant, 'google_client_id')` etc. in
+  `packages/auth/src/lib/sso/mspSsoResolution.ts`, and **settable by no UI anywhere**. They are
+  wired out-of-band on appliance/custom installs only.
+
+**Net effect on hosted:** an admin searching for "SSO" finds "MSP SSO Login Domains", claims
+domains, adds DNS records, verifies — and the resolver still falls back to app-level providers
+(`resolveMspSsoCredentialSource`), because no tenant credentials exist. A ritual with zero
+effect, while the effective path sits one section over with an unhelpful name.
+
+## Goal
+
+One obvious SSO home. Settings → Security → Single Sign-On becomes the single destination:
+the easy hosted path front and center, the advanced tenant-credential routing tucked behind a
+clearly-labeled collapsed section that *says so* when it is inert. The old location signposts
+the move.
+
+## Design decisions (settled in design session)
+
+1. **Move, not signpost-only** — the domain panel relocates to Security → SSO.
+2. **Collapsed "Advanced" section** — always present (both editions), collapsed by default,
+   with an explicit inert-state notice when no tenant IdP credentials exist. CE keeps its
+   advisory-mode panel here (below the upgrade card).
+3. **Status header included** — provider-availability chips at the top of the SSO tab (EE),
+   so the tab reads as the setup page.
+4. **Pointer card at the old location** — slim "this moved" card with a deep link to
+   `/msp/security-settings?tab=single-sign-on`; droppable in a later release.
+
+## Implementation
+
+### Change 1 — New server action: tenant IdP credential status
+
+**File:** `packages/integrations/src/actions/integrations/mspSsoDomainActions.ts` (sibling of
+the existing `listMspSsoDomainClaims` / `saveMspSsoLoginDomains` actions; export through the
+existing barrels `packages/integrations/src/actions/index.ts`).
+
+```ts
+export async function getMspSsoTenantCredentialStatus(): Promise<{
+  success: boolean;
+  google: boolean;
+  microsoft: boolean;
+}>
+```
+
+- Resolve the current tenant the same way the sibling actions do (`createTenantKnex` /
+  current-user context) and enforce the same settings permission the sibling actions enforce.
+- Call `hasTenantProviderCredentials(tenant, 'google')` and
+  `hasTenantProviderCredentials(tenant, 'azure-ad')` from
+  `@alga-psa/auth` (`packages/auth/src/lib/sso/mspSsoResolution.ts:235`). Export it from the
+  auth package barrel if not already exported.
+- Read-only; failures return `{ success: false, google: false, microsoft: false }` and log a
+  warning — the UI treats a failure as "unknown" and shows no inert notice rather than a wrong one.
+
+### Change 2 — Advanced section in Security → Single Sign-On
+
+**File:** `server/src/components/settings/security/SecuritySettingsPage.tsx`
+
+The `single-sign-on` tab content becomes a stack:
+
+```tsx
+<Suspense fallback={<SsoLoading />}>
+  <SsoBulkAssignment />          {/* unchanged EE/CE resolution via @enterprise alias */}
+</Suspense>
+<MspSsoAdvancedSection />        {/* new, below — both editions */}
+```
+
+**New component:** `server/src/components/settings/security/MspSsoAdvancedSection.tsx`
+(client component):
+
+- A `Card` whose header is a toggle — title "Advanced: custom identity provider routing",
+  chevron, `aria-expanded`, collapsed by default (local `useState`; no persisted state). No
+  Collapsible primitive exists in `@alga-psa/ui` — use Card + button header, matching house
+  style (cf. `CollapseToggleButton.tsx` for iconography).
+- Body (rendered only when expanded, so the panel's data loads lazily):
+  1. **Inert-state notice** — on mount of the expanded body, call
+     `getMspSsoTenantCredentialStatus()`. When `success && !google && !microsoft`, render an
+     info `Alert`: *"No tenant identity provider credentials are configured — domain claims
+     currently have no effect. Users sign in with the hosted Google / Microsoft providers.
+     Tenant credentials are provisioned on custom and on-premise installations."* When either
+     credential exists, or on failure, render nothing extra.
+  2. `<MspSsoLoginDomainsSettings />` imported from `@alga-psa/integrations/components`
+     (already exported via `packages/integrations/src/components/settings/integrations/index.ts`;
+     `server/src` already imports from this entry point in `SettingsPage.tsx`).
+- Both editions render this section; `MspSsoLoginDomainsSettings` already branches CE
+  (advisory domains) vs EE (claims) internally via `NEXT_PUBLIC_EDITION`.
+- i18n namespace: `msp/profile` (the namespace `SecuritySettingsPage` already uses), keys under
+  `security.sso.advanced.*`.
+
+### Change 3 — Provider status header in the SSO tab (EE)
+
+**File:** `ee/server/src/components/settings/security/SsoBulkAssignment.tsx`
+
+The component already fetches `getSsoProviderOptionsAction({ scope: "settings" })`. Add a
+status strip above the auto-link card:
+
+- One row per option in `providerOptions`: provider name + `Badge` — success "Available" when
+  `option.configured`, secondary "Not configured" otherwise.
+- Short caption: *"These providers are managed by the platform — no client IDs or DNS setup is
+  required. Enable auto-link or assign users below."*
+- Renders only when `providerOptions` is non-empty (the existing no-provider fallback stays).
+- i18n: `msp/settings` namespace, keys under `ssoBulk.status.*`.
+- The CE stub (`packages/ee/src/.../SsoBulkAssignment.tsx`) is unchanged.
+
+### Change 4 — Pointer card at the old location
+
+**File:** `packages/integrations/src/components/settings/integrations/IntegrationsSettingsPage.tsx`
+
+Replace `<MspSsoLoginDomainsSettings />` (~line 295) with a slim inline card:
+
+- Title: "MSP SSO Login Domains" (so admins scanning for the old name find the pointer).
+- Body: *"Single sign-on settings, including login-domain claims, have moved to
+  Security → Single Sign-On."*
+- Button (`id="msp-sso-moved-link"`): "Open Single Sign-On settings" → navigates to
+  `/msp/security-settings?tab=single-sign-on` (plain `Link`/router push; the Security page
+  already deep-links via its `tab` query param, `SecuritySettingsPage.tsx:102-128`).
+- Remove the now-unused `MspSsoLoginDomainsSettings` import here; the component itself stays
+  where it lives and stays exported (the Security page now consumes it).
+- i18n: `msp/integrations` namespace, keys under `integrations.sso.msp.moved.*`.
+
+### Change 5 — i18n
+
+Add new keys (with `defaultValue`s in code, as house style) to `server/public/locales/en/msp/`:
+
+| Namespace file | Keys |
+|---|---|
+| `profile.json` | `security.sso.advanced.title`, `.description`, `.inertNotice` |
+| `settings.json` | `ssoBulk.status.title`, `.caption`, `.available`, `.notConfigured` |
+| `integrations.json` | `integrations.sso.msp.moved.title`, `.body`, `.cta` |
+
+Mirror the keys into the non-English locale dirs (`de`, `es`, `fr`, `it`, `nl`, `pl`, `pt`,
+`xx`, `yy`) following the repo's existing translation pattern for sibling keys.
+
+## Tests
+
+1. **`getMspSsoTenantCredentialStatus`** — new unit coverage in
+   `packages/integrations/src/actions/integrations/mspSsoDomainActions.test.ts`: permission
+   enforcement, both-false / one-true matrices (mock secret provider), failure → safe default.
+2. **`MspSsoAdvancedSection`** — new unit test (pattern of
+   `server/src/test/unit/components/integrations/MspSsoLoginDomainsSettings.test.tsx`):
+   renders collapsed; expanding mounts `MspSsoLoginDomainsSettings`; inert notice shows only
+   for `{google:false, microsoft:false, success:true}`.
+3. **`SsoBulkAssignment` status header** — extend existing EE component coverage: chips render
+   per option with correct configured/not-configured badge; absent when options empty.
+4. **`IntegrationsSettingsPage`** — update
+   `server/src/test/unit/components/integrations/IntegrationsSettingsPage.*.test.tsx`: the
+   Providers stack no longer renders the domain panel; pointer card + deep-link present.
+5. **Security page integration** — the `single-sign-on` tab renders both the bulk-assignment
+   block and the advanced section (both editions' expectations).
+
+## Manual smoke (dev stack on :3144)
+
+1. Settings → Security → Single Sign-On: status chips (EE), auto-link + bulk assignment,
+   collapsed Advanced section at bottom.
+2. Expand Advanced: inert notice appears (local stack has no tenant IdP credentials); domain
+   panel functions (add claim → DNS challenge shown).
+3. Settings → General → Providers: pointer card in place of the old panel; button lands on the
+   Security SSO tab.
+
+## Out of scope (explicitly unchanged)
+
+- Any UI for *setting* tenant-level IdP credentials (stays out-of-band for appliances).
+- Login-page provider resolution (`mspSsoResolution.ts`, resolve/discover routes) — untouched.
+- Removing the pointer card (future release).
+- Tier gating changes (`assertTierAccess(TIER_FEATURES.SSO)` stays as-is).

--- a/ee/server/src/components/settings/security/SsoBulkAssignment.tsx
+++ b/ee/server/src/components/settings/security/SsoBulkAssignment.tsx
@@ -3,6 +3,7 @@
 import { useEffect, useState } from "react";
 import { Card, CardHeader, CardTitle, CardDescription, CardContent } from "@alga-psa/ui/components/Card";
 import { Alert, AlertDescription } from "@alga-psa/ui/components/Alert";
+import { Badge } from "@alga-psa/ui/components/Badge";
 import { Switch } from "@alga-psa/ui/components/Switch";
 import SettingsTabSkeleton from "@alga-psa/ui/components/skeletons/SettingsTabSkeleton";
 import type { SsoProviderOption } from "@ee/lib/auth/providerConfig";
@@ -79,6 +80,30 @@ export default function SsoBulkAssignment() {
 
   return (
     <div className="space-y-6">
+      {!shouldShowFallback && (
+        <Card>
+          <CardHeader>
+            <CardTitle>{t("ssoBulk.status.title")}</CardTitle>
+            <CardDescription>{t("ssoBulk.status.caption")}</CardDescription>
+          </CardHeader>
+          <CardContent className="space-y-2">
+            {providerOptions!.map((option) => (
+              <div
+                key={option.id}
+                className="flex items-center justify-between rounded-lg border border-muted-foreground/20 p-3"
+              >
+                <span className="text-sm font-medium">{option.name}</span>
+                <Badge variant={option.configured ? "success" : "secondary"}>
+                  {option.configured
+                    ? t("ssoBulk.status.available")
+                    : t("ssoBulk.status.notConfigured")}
+                </Badge>
+              </div>
+            ))}
+          </CardContent>
+        </Card>
+      )}
+
       <Card>
         <CardHeader>
           <CardTitle>{t("ssoBulk.autoLink.title")}</CardTitle>

--- a/packages/integrations/src/actions/index.ts
+++ b/packages/integrations/src/actions/index.ts
@@ -133,6 +133,8 @@ export {
   refreshMspSsoDomainClaimChallenge,
   verifyMspSsoDomainClaimOwnership,
   revokeMspSsoDomainClaim,
+  getMspSsoTenantCredentialStatus,
+  type MspSsoTenantCredentialStatusResult,
 } from './integrations/mspSsoDomainActions';
 export {
   getTeamsIntegrationStatus,

--- a/packages/integrations/src/actions/integrations/mspSsoDomainActions.test.ts
+++ b/packages/integrations/src/actions/integrations/mspSsoDomainActions.test.ts
@@ -46,6 +46,10 @@ const resolveTxtMock = vi.hoisted(() =>
   vi.fn(async (_hostname: string): Promise<string[][]> => [])
 );
 
+const hasTenantProviderCredentialsMock = vi.hoisted(() =>
+  vi.fn(async (_tenant: string, _provider: string): Promise<boolean> => false)
+);
+
 function normalize(value: string): string {
   const trimmed = value.trim().toLowerCase();
   return trimmed.startsWith('@') ? trimmed.slice(1) : trimmed;
@@ -237,7 +241,15 @@ vi.mock('node:dns/promises', () => ({
   resolveTxt: resolveTxtMock,
 }));
 
+// Preserve the real resolution helpers (normalize/validate) the action file relies on; only
+// swap the credential probe, which otherwise reaches the secret provider / Microsoft resolver.
+vi.mock('@alga-psa/auth/lib/sso/mspSsoResolution', async (importActual) => {
+  const actual = await importActual<typeof import('@alga-psa/auth/lib/sso/mspSsoResolution')>();
+  return { ...actual, hasTenantProviderCredentials: hasTenantProviderCredentialsMock };
+});
+
 import {
+  getMspSsoTenantCredentialStatus,
   listMspSsoDomainClaims,
   listMspSsoLoginDomains,
   refreshMspSsoDomainClaimChallenge,
@@ -257,6 +269,8 @@ describe('msp sso domain actions', () => {
     hasChallengeTable = true;
     resolveTxtMock.mockReset();
     resolveTxtMock.mockResolvedValue([]);
+    hasTenantProviderCredentialsMock.mockReset();
+    hasTenantProviderCredentialsMock.mockResolvedValue(false);
   });
 
   it('T004: list action denies unauthorized users and client users', async () => {
@@ -642,5 +656,52 @@ describe('msp sso domain actions', () => {
     expect(revokeResult.success).toBe(true);
     expect(revokeResult.claim?.claim_status).toBe('revoked');
     expect(challengeRows.find((row) => row.id === 'challenge-1')?.is_active).toBe(false);
+  });
+
+  describe('getMspSsoTenantCredentialStatus', () => {
+    it('denies client users and users without settings permission (safe default)', async () => {
+      mockUser = { user_id: 'client-1', user_type: 'client' };
+      await expect(getMspSsoTenantCredentialStatus()).resolves.toEqual({
+        success: false,
+        google: false,
+        microsoft: false,
+      });
+
+      mockUser = { user_id: 'user-1', user_type: 'internal' };
+      hasPermissionValue = false;
+      await expect(getMspSsoTenantCredentialStatus()).resolves.toEqual({
+        success: false,
+        google: false,
+        microsoft: false,
+      });
+      expect(hasTenantProviderCredentialsMock).not.toHaveBeenCalled();
+    });
+
+    it('reports both providers absent when no tenant credentials exist', async () => {
+      hasTenantProviderCredentialsMock.mockResolvedValue(false);
+      await expect(getMspSsoTenantCredentialStatus()).resolves.toEqual({
+        success: true,
+        google: false,
+        microsoft: false,
+      });
+    });
+
+    it('reports each provider independently', async () => {
+      hasTenantProviderCredentialsMock.mockImplementation(async (_tenant, provider) => provider === 'google');
+      await expect(getMspSsoTenantCredentialStatus()).resolves.toEqual({
+        success: true,
+        google: true,
+        microsoft: false,
+      });
+    });
+
+    it('returns a safe default when the credential probe throws', async () => {
+      hasTenantProviderCredentialsMock.mockRejectedValue(new Error('secret provider unavailable'));
+      await expect(getMspSsoTenantCredentialStatus()).resolves.toEqual({
+        success: false,
+        google: false,
+        microsoft: false,
+      });
+    });
   });
 });

--- a/packages/integrations/src/actions/integrations/mspSsoDomainActions.ts
+++ b/packages/integrations/src/actions/integrations/mspSsoDomainActions.ts
@@ -7,11 +7,13 @@ import { createTenantKnex, tenantDb } from '@alga-psa/db';
 import { withAuth } from '@alga-psa/auth/withAuth';
 import { hasPermission } from '@alga-psa/auth/rbac';
 import {
+  hasTenantProviderCredentials,
   normalizeMspSsoDomain,
   normalizeMspSsoDomainClaimStatus,
   validateMspSsoDomain,
   type MspSsoDomainClaimStatus,
 } from '@alga-psa/auth/lib/sso/mspSsoResolution';
+import logger from '@alga-psa/core/logger';
 import type { Knex } from 'knex';
 
 const MSP_SSO_LOGIN_DOMAIN_TABLE = 'msp_sso_tenant_login_domains';
@@ -98,6 +100,12 @@ export interface RevokeMspSsoDomainClaimResult {
   success: boolean;
   claim?: MspSsoDomainClaim;
   error?: string;
+}
+
+export interface MspSsoTenantCredentialStatusResult {
+  success: boolean;
+  google: boolean;
+  microsoft: boolean;
 }
 
 function normalizeDomain(value: string): string {
@@ -918,5 +926,35 @@ export const saveMspSsoLoginDomains = withAuth(async (
       success: false,
       error: error instanceof Error ? error.message : 'Failed to save MSP SSO login domains',
     };
+  }
+});
+
+/**
+ * Read-only status of tenant-scoped IdP credentials, used by the Security → Single Sign-On
+ * "Advanced" section to explain when login-domain claims are inert (no tenant credentials
+ * configured, so login SSO uses the hosted app-level providers). On any failure it reports
+ * `success: false` and both providers `false` — the UI treats that as "unknown" and shows no
+ * inert-state notice rather than a wrong one.
+ */
+export const getMspSsoTenantCredentialStatus = withAuth(async (
+  user,
+  { tenant }
+): Promise<MspSsoTenantCredentialStatusResult> => {
+  try {
+    if (!(await canManageDomains(user))) {
+      return { success: false, google: false, microsoft: false };
+    }
+
+    const [google, microsoft] = await Promise.all([
+      hasTenantProviderCredentials(tenant, 'google'),
+      hasTenantProviderCredentials(tenant, 'azure-ad'),
+    ]);
+
+    return { success: true, google, microsoft };
+  } catch (error: unknown) {
+    logger.warn('Failed to resolve MSP SSO tenant credential status', {
+      error: error instanceof Error ? error.message : String(error),
+    });
+    return { success: false, google: false, microsoft: false };
   }
 });

--- a/packages/integrations/src/components/settings/integrations/IntegrationsSettingsPage.providers.test.ts
+++ b/packages/integrations/src/components/settings/integrations/IntegrationsSettingsPage.providers.test.ts
@@ -17,10 +17,15 @@ describe('IntegrationsSettingsPage providers tab', () => {
     expect(source).toContain("import { GoogleIntegrationSettings } from './GoogleIntegrationSettings'");
     expect(source).toContain("import { MicrosoftIntegrationSettings } from './MicrosoftIntegrationSettings'");
     expect(source).toContain("import { TeamsEnterpriseIntegrationSettings } from './TeamsEnterpriseIntegrationSettings'");
-    expect(source).toContain("import { MspSsoLoginDomainsSettings } from './MspSsoLoginDomainsSettings'");
+    // MSP SSO login domains moved to Security → Single Sign-On; the Providers tab now shows a
+    // pointer card that deep-links there instead of rendering the domain panel inline.
+    expect(source).not.toContain("import { MspSsoLoginDomainsSettings } from './MspSsoLoginDomainsSettings'");
+    expect(source).not.toContain('<MspSsoLoginDomainsSettings />');
+    expect(source).toContain('id="msp-sso-moved-link"');
+    expect(source).toContain("router.push('/msp/security-settings?tab=single-sign-on')");
+    expect(source).toContain("tIntegrations('integrations.sso.msp.moved.title'");
     expect(source).toContain('<GoogleIntegrationSettings />');
     expect(source).toContain('<MicrosoftIntegrationSettings canUseTeams={canUseTeams} />');
-    expect(source).toContain('<MspSsoLoginDomainsSettings />');
     expect(source).not.toContain('<TeamsIntegrationSettings />');
     expect(source).toContain("id: 'communication'");
     expect(source).toContain("id: 'teams'");

--- a/packages/integrations/src/components/settings/integrations/IntegrationsSettingsPage.tsx
+++ b/packages/integrations/src/components/settings/integrations/IntegrationsSettingsPage.tsx
@@ -8,8 +8,9 @@
  */
 
 import React, { useState, useMemo, useEffect } from 'react';
-import { useSearchParams } from 'next/navigation';
+import { useRouter, useSearchParams } from 'next/navigation';
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@alga-psa/ui/components/Card';
+import { Button } from '@alga-psa/ui/components/Button';
 import CustomTabs, { TabContent } from '@alga-psa/ui/components/CustomTabs';
 import {
   Building2,
@@ -27,7 +28,6 @@ import RmmIntegrationsSetup from './RmmIntegrationsSetup';
 import { EmailProviderConfiguration } from '@alga-psa/integrations/components';
 import { GoogleIntegrationSettings } from './GoogleIntegrationSettings';
 import { MicrosoftIntegrationSettings } from './MicrosoftIntegrationSettings';
-import { MspSsoLoginDomainsSettings } from './MspSsoLoginDomainsSettings';
 import { CalendarEnterpriseIntegrationSettings } from './CalendarEnterpriseIntegrationSettings';
 import { TeamsEnterpriseIntegrationSettings } from './TeamsEnterpriseIntegrationSettings';
 import dynamic from 'next/dynamic';
@@ -144,6 +144,8 @@ const IntegrationsSettingsPage: React.FC<IntegrationsSettingsPageProps> = ({
   qboOnboardingSlot,
 }) => {
   const { t } = useTranslation('msp/settings');
+  const { t: tIntegrations } = useTranslation('msp/integrations');
+  const router = useRouter();
   const isEEAvailable = isCalendarEnterpriseEdition();
   const entraUiFlag = useFeatureFlag('entra-integration-ui', { defaultValue: false });
   const isEntraUiEnabled = isEEAvailable && entraUiFlag.enabled;
@@ -292,7 +294,29 @@ const IntegrationsSettingsPage: React.FC<IntegrationsSettingsPageProps> = ({
               </Card>
               <GoogleIntegrationSettings />
               <MicrosoftIntegrationSettings canUseTeams={canUseTeams} />
-              <MspSsoLoginDomainsSettings />
+              <Card>
+                <CardHeader>
+                  <CardTitle>
+                    {tIntegrations('integrations.sso.msp.moved.title', { defaultValue: 'MSP SSO Login Domains' })}
+                  </CardTitle>
+                  <CardDescription>
+                    {tIntegrations('integrations.sso.msp.moved.body', {
+                      defaultValue:
+                        'Single sign-on settings, including login-domain claims, have moved to Security → Single Sign-On.',
+                    })}
+                  </CardDescription>
+                </CardHeader>
+                <CardContent>
+                  <Button
+                    id="msp-sso-moved-link"
+                    type="button"
+                    variant="outline"
+                    onClick={() => router.push('/msp/security-settings?tab=single-sign-on')}
+                  >
+                    {tIntegrations('integrations.sso.msp.moved.cta', { defaultValue: 'Open Single Sign-On settings' })}
+                  </Button>
+                </CardContent>
+              </Card>
             </div>
           ),
         },

--- a/packages/integrations/src/components/settings/integrations/IntegrationsSettingsPage.tsx
+++ b/packages/integrations/src/components/settings/integrations/IntegrationsSettingsPage.tsx
@@ -282,6 +282,33 @@ const IntegrationsSettingsPage: React.FC<IntegrationsSettingsPageProps> = ({
             : t('integrations.items.google.description.oss'),
           component: () => (
             <div className="space-y-6">
+              {/* Conspicuous, above-the-fold pointer: admins mistake this Providers tab for the
+                  SSO setup path, so the redirect must be the first thing they see — not a card
+                  buried under the Google/Microsoft panels. */}
+              <div className="flex flex-col gap-3 rounded-lg border-2 border-primary-500 bg-alert-info-bg p-4 shadow-sm sm:flex-row sm:items-center sm:justify-between">
+                <div className="flex items-start gap-3">
+                  <Shield className="mt-0.5 h-6 w-6 shrink-0 text-primary-500" />
+                  <div className="space-y-0.5">
+                    <div className="text-base font-semibold text-[rgb(var(--color-text-900))]">
+                      {tIntegrations('integrations.sso.msp.moved.title', { defaultValue: 'MSP SSO Login Domains' })}
+                    </div>
+                    <div className="text-sm text-[rgb(var(--color-text-700))]">
+                      {tIntegrations('integrations.sso.msp.moved.body', {
+                        defaultValue:
+                          'Single sign-on settings, including login-domain claims, have moved to Security → Single Sign-On.',
+                      })}
+                    </div>
+                  </div>
+                </div>
+                <Button
+                  id="msp-sso-moved-link"
+                  type="button"
+                  onClick={() => router.push('/msp/security-settings?tab=single-sign-on')}
+                  className="shrink-0"
+                >
+                  {tIntegrations('integrations.sso.msp.moved.cta', { defaultValue: 'Open Single Sign-On settings' })}
+                </Button>
+              </div>
               <Card>
                 <CardHeader>
                   <CardTitle>{t('integrations.items.google.cardTitle')}</CardTitle>
@@ -294,29 +321,6 @@ const IntegrationsSettingsPage: React.FC<IntegrationsSettingsPageProps> = ({
               </Card>
               <GoogleIntegrationSettings />
               <MicrosoftIntegrationSettings canUseTeams={canUseTeams} />
-              <Card>
-                <CardHeader>
-                  <CardTitle>
-                    {tIntegrations('integrations.sso.msp.moved.title', { defaultValue: 'MSP SSO Login Domains' })}
-                  </CardTitle>
-                  <CardDescription>
-                    {tIntegrations('integrations.sso.msp.moved.body', {
-                      defaultValue:
-                        'Single sign-on settings, including login-domain claims, have moved to Security → Single Sign-On.',
-                    })}
-                  </CardDescription>
-                </CardHeader>
-                <CardContent>
-                  <Button
-                    id="msp-sso-moved-link"
-                    type="button"
-                    variant="outline"
-                    onClick={() => router.push('/msp/security-settings?tab=single-sign-on')}
-                  >
-                    {tIntegrations('integrations.sso.msp.moved.cta', { defaultValue: 'Open Single Sign-On settings' })}
-                  </Button>
-                </CardContent>
-              </Card>
             </div>
           ),
         },

--- a/server/public/locales/de/msp/integrations.json
+++ b/server/public/locales/de/msp/integrations.json
@@ -1864,6 +1864,11 @@
         },
         "descriptionCe": "Registrieren Sie Hinweisdomänen für die MSP-Login-SSO-Erkennung. Besitznachweise werden in der Community Edition nicht erzwungen, und nicht verwaltete Domänen greifen auf Nine-Minds-App-Provider zurück.",
         "descriptionEe": "Verwalten Sie den Lebenszyklus von Domänenansprüchen für die Provider-Erkennung beim MSP-Login-SSO. Nicht beanspruchte oder nicht zulässige Domänen greifen auf Nine-Minds-App-Provider zurück.",
+        "moved": {
+          "title": "MSP SSO Login Domains",
+          "body": "Single sign-on settings, including login-domain claims, have moved to Security → Single Sign-On.",
+          "cta": "Open Single Sign-On settings"
+        },
         "dnsHost": "Host:",
         "dnsInstructions": "DNS-TXT-Eintrag hinzufügen und anschließend auf „Verifizieren“ klicken:",
         "dnsValue": "Wert:",

--- a/server/public/locales/de/msp/profile.json
+++ b/server/public/locales/de/msp/profile.json
@@ -103,6 +103,13 @@
       "sso": "SSO-Verwaltungswerkzeuge werden geladen...",
       "sessions": "Aktive Sitzungen werden geladen..."
     },
+    "sso": {
+      "advanced": {
+        "title": "Advanced: custom identity provider routing",
+        "description": "Route MSP login SSO to your own identity provider using verified login domains. Only needed on custom or on-premise installations.",
+        "inertNotice": "No tenant identity provider credentials are configured, so domain claims currently have no effect. Users sign in with the hosted Google / Microsoft providers. Tenant credentials are provisioned on custom and on-premise installations."
+      }
+    },
     "userRoles": {
       "title": "Rollen an Benutzer zuweisen",
       "description": {

--- a/server/public/locales/de/msp/settings.json
+++ b/server/public/locales/de/msp/settings.json
@@ -1792,6 +1792,12 @@
       "title": "Single Sign-On",
       "description": "SSO-Massenzuweisungs-Werkzeuge werden geladen..."
     },
+    "status": {
+      "title": "Sign-in providers",
+      "caption": "These providers are managed by the platform — no client IDs or DNS setup is required. Enable auto-link or assign users below.",
+      "available": "Available",
+      "notConfigured": "Not configured"
+    },
     "autoLink": {
       "title": "SSO für neue interne Benutzer automatisch einrichten",
       "description": "Aktivieren Sie diese Option, um jedem neuen Mitarbeiterkonto sofort Ihren Unternehmens-SSO-Anbieter zuzuweisen, sodass eine passwortbasierte Anmeldung nicht erforderlich ist.",

--- a/server/public/locales/en/msp/integrations.json
+++ b/server/public/locales/en/msp/integrations.json
@@ -1864,6 +1864,11 @@
         },
         "descriptionCe": "Register advisory domains for MSP login SSO discovery. Ownership verification is not enforced in Community Edition, and unmanaged domains fall back to Nine Minds app-level providers.",
         "descriptionEe": "Manage domain claim lifecycle for MSP login SSO provider discovery. Unclaimed or ineligible domains fall back to Nine Minds app-level providers.",
+        "moved": {
+          "title": "MSP SSO Login Domains",
+          "body": "Single sign-on settings, including login-domain claims, have moved to Security → Single Sign-On.",
+          "cta": "Open Single Sign-On settings"
+        },
         "dnsHost": "Host:",
         "dnsInstructions": "Add DNS TXT record, then click Verify:",
         "dnsValue": "Value:",

--- a/server/public/locales/en/msp/profile.json
+++ b/server/public/locales/en/msp/profile.json
@@ -103,6 +103,13 @@
       "sso": "Loading SSO management tools...",
       "sessions": "Loading active sessions..."
     },
+    "sso": {
+      "advanced": {
+        "title": "Advanced: custom identity provider routing",
+        "description": "Route MSP login SSO to your own identity provider using verified login domains. Only needed on custom or on-premise installations.",
+        "inertNotice": "No tenant identity provider credentials are configured, so domain claims currently have no effect. Users sign in with the hosted Google / Microsoft providers. Tenant credentials are provisioned on custom and on-premise installations."
+      }
+    },
     "userRoles": {
       "title": "Assign Roles to Users",
       "description": {

--- a/server/public/locales/en/msp/settings.json
+++ b/server/public/locales/en/msp/settings.json
@@ -1792,6 +1792,12 @@
       "title": "Single Sign-On",
       "description": "Loading SSO bulk assignment tools..."
     },
+    "status": {
+      "title": "Sign-in providers",
+      "caption": "These providers are managed by the platform — no client IDs or DNS setup is required. Enable auto-link or assign users below.",
+      "available": "Available",
+      "notConfigured": "Not configured"
+    },
     "autoLink": {
       "title": "Automatically set up SSO for new internal users",
       "description": "Turn this on to provision every new staff account with your corporate SSO provider right away, so they never need a password-based sign-in.",

--- a/server/public/locales/es/msp/integrations.json
+++ b/server/public/locales/es/msp/integrations.json
@@ -1864,6 +1864,11 @@
         },
         "descriptionCe": "Registre dominios consultivos para el descubrimiento de SSO de inicio de sesión de MSP. La verificación de propiedad no se aplica en Community Edition, y los dominios no gestionados recurren a los proveedores de aplicación de Nine Minds.",
         "descriptionEe": "Gestione el ciclo de vida de las reclamaciones de dominio para el descubrimiento de proveedores de SSO de inicio de sesión de MSP. Los dominios no reclamados o no elegibles recurren a los proveedores de aplicación de Nine Minds.",
+        "moved": {
+          "title": "MSP SSO Login Domains",
+          "body": "Single sign-on settings, including login-domain claims, have moved to Security → Single Sign-On.",
+          "cta": "Open Single Sign-On settings"
+        },
         "dnsHost": "Host:",
         "dnsInstructions": "Añada el registro DNS TXT y luego haga clic en Verificar:",
         "dnsValue": "Valor:",

--- a/server/public/locales/es/msp/profile.json
+++ b/server/public/locales/es/msp/profile.json
@@ -103,6 +103,13 @@
       "sso": "Cargando herramientas de gestión de SSO...",
       "sessions": "Cargando sesiones activas..."
     },
+    "sso": {
+      "advanced": {
+        "title": "Advanced: custom identity provider routing",
+        "description": "Route MSP login SSO to your own identity provider using verified login domains. Only needed on custom or on-premise installations.",
+        "inertNotice": "No tenant identity provider credentials are configured, so domain claims currently have no effect. Users sign in with the hosted Google / Microsoft providers. Tenant credentials are provisioned on custom and on-premise installations."
+      }
+    },
     "userRoles": {
       "title": "Asignar roles a usuarios",
       "description": {

--- a/server/public/locales/es/msp/settings.json
+++ b/server/public/locales/es/msp/settings.json
@@ -1792,6 +1792,12 @@
       "title": "Inicio de sesión único",
       "description": "Cargando herramientas de asignación masiva de SSO..."
     },
+    "status": {
+      "title": "Sign-in providers",
+      "caption": "These providers are managed by the platform — no client IDs or DNS setup is required. Enable auto-link or assign users below.",
+      "available": "Available",
+      "notConfigured": "Not configured"
+    },
     "autoLink": {
       "title": "Configurar SSO automáticamente para nuevos usuarios internos",
       "description": "Active esta opción para aprovisionar cada nueva cuenta de personal con su proveedor SSO corporativo de inmediato, de modo que nunca necesiten un inicio de sesión basado en contraseña.",

--- a/server/public/locales/fr/msp/integrations.json
+++ b/server/public/locales/fr/msp/integrations.json
@@ -1864,6 +1864,11 @@
         },
         "descriptionCe": "Enregistrez des domaines consultatifs pour la découverte du SSO de connexion MSP. La vérification de propriété n'est pas imposée dans l'édition Community, et les domaines non gérés basculent vers les fournisseurs au niveau application de Nine Minds.",
         "descriptionEe": "Gérez le cycle de vie des revendications de domaine pour la découverte des fournisseurs SSO de connexion MSP. Les domaines non revendiqués ou non éligibles basculent vers les fournisseurs au niveau application de Nine Minds.",
+        "moved": {
+          "title": "MSP SSO Login Domains",
+          "body": "Single sign-on settings, including login-domain claims, have moved to Security → Single Sign-On.",
+          "cta": "Open Single Sign-On settings"
+        },
         "dnsHost": "Hôte :",
         "dnsInstructions": "Ajoutez l'enregistrement DNS TXT, puis cliquez sur Vérifier :",
         "dnsValue": "Valeur :",

--- a/server/public/locales/fr/msp/profile.json
+++ b/server/public/locales/fr/msp/profile.json
@@ -103,6 +103,13 @@
       "sso": "Chargement des outils de gestion SSO...",
       "sessions": "Chargement des sessions actives..."
     },
+    "sso": {
+      "advanced": {
+        "title": "Advanced: custom identity provider routing",
+        "description": "Route MSP login SSO to your own identity provider using verified login domains. Only needed on custom or on-premise installations.",
+        "inertNotice": "No tenant identity provider credentials are configured, so domain claims currently have no effect. Users sign in with the hosted Google / Microsoft providers. Tenant credentials are provisioned on custom and on-premise installations."
+      }
+    },
     "userRoles": {
       "title": "Attribuer des rôles aux utilisateurs",
       "description": {

--- a/server/public/locales/fr/msp/settings.json
+++ b/server/public/locales/fr/msp/settings.json
@@ -1792,6 +1792,12 @@
       "title": "SSO",
       "description": "Chargement des outils d'attribution SSO en masse..."
     },
+    "status": {
+      "title": "Sign-in providers",
+      "caption": "These providers are managed by the platform — no client IDs or DNS setup is required. Enable auto-link or assign users below.",
+      "available": "Available",
+      "notConfigured": "Not configured"
+    },
     "autoLink": {
       "title": "Configurer automatiquement le SSO pour les nouveaux utilisateurs internes",
       "description": "Activez cette option pour provisionner immédiatement chaque nouveau compte du personnel avec votre fournisseur SSO d'entreprise, afin qu'ils n'aient jamais besoin d'une connexion par mot de passe.",

--- a/server/public/locales/it/msp/integrations.json
+++ b/server/public/locales/it/msp/integrations.json
@@ -1864,6 +1864,11 @@
         },
         "descriptionCe": "Registra domini consultivi per la discovery dell'SSO di accesso MSP. La verifica della proprietà non è imposta nella Community Edition, e i domini non gestiti ricorrono ai provider a livello di applicazione di Nine Minds.",
         "descriptionEe": "Gestisci il ciclo di vita dei reclami di dominio per la discovery dei provider SSO di accesso MSP. I domini non reclamati o non idonei ricorrono ai provider a livello di applicazione di Nine Minds.",
+        "moved": {
+          "title": "MSP SSO Login Domains",
+          "body": "Single sign-on settings, including login-domain claims, have moved to Security → Single Sign-On.",
+          "cta": "Open Single Sign-On settings"
+        },
         "dnsHost": "Host:",
         "dnsInstructions": "Aggiungi il record DNS TXT, poi clicca su Verifica:",
         "dnsValue": "Valore:",

--- a/server/public/locales/it/msp/profile.json
+++ b/server/public/locales/it/msp/profile.json
@@ -103,6 +103,13 @@
       "sso": "Caricamento strumenti di gestione SSO...",
       "sessions": "Caricamento sessioni attive..."
     },
+    "sso": {
+      "advanced": {
+        "title": "Advanced: custom identity provider routing",
+        "description": "Route MSP login SSO to your own identity provider using verified login domains. Only needed on custom or on-premise installations.",
+        "inertNotice": "No tenant identity provider credentials are configured, so domain claims currently have no effect. Users sign in with the hosted Google / Microsoft providers. Tenant credentials are provisioned on custom and on-premise installations."
+      }
+    },
     "userRoles": {
       "title": "Assegna ruoli agli utenti",
       "description": {

--- a/server/public/locales/it/msp/settings.json
+++ b/server/public/locales/it/msp/settings.json
@@ -1792,6 +1792,12 @@
       "title": "SSO",
       "description": "Caricamento degli strumenti di assegnazione SSO in blocco..."
     },
+    "status": {
+      "title": "Sign-in providers",
+      "caption": "These providers are managed by the platform — no client IDs or DNS setup is required. Enable auto-link or assign users below.",
+      "available": "Available",
+      "notConfigured": "Not configured"
+    },
     "autoLink": {
       "title": "Configuri automaticamente l'SSO per i nuovi utenti interni",
       "description": "Attivi questa opzione per provisionare immediatamente ogni nuovo account del personale con il Suo provider SSO aziendale, in modo che non sia mai necessario un accesso basato su password.",

--- a/server/public/locales/nl/msp/integrations.json
+++ b/server/public/locales/nl/msp/integrations.json
@@ -1864,6 +1864,11 @@
         },
         "descriptionCe": "Registreer adviesdomeinen voor de detectie van MSP-aanmeldings-SSO. Eigendomsverificatie wordt niet afgedwongen in Community Edition, en onbeheerde domeinen vallen terug op providers op applicatieniveau van Nine Minds.",
         "descriptionEe": "Beheer de levenscyclus van domeinclaims voor de detectie van MSP-aanmeldings-SSO-providers. Niet-geclaimde of niet-geschikte domeinen vallen terug op providers op applicatieniveau van Nine Minds.",
+        "moved": {
+          "title": "MSP SSO Login Domains",
+          "body": "Single sign-on settings, including login-domain claims, have moved to Security → Single Sign-On.",
+          "cta": "Open Single Sign-On settings"
+        },
         "dnsHost": "Host:",
         "dnsInstructions": "Voeg het DNS TXT-record toe en klik vervolgens op Verifiëren:",
         "dnsValue": "Waarde:",

--- a/server/public/locales/nl/msp/profile.json
+++ b/server/public/locales/nl/msp/profile.json
@@ -103,6 +103,13 @@
       "sso": "SSO-beheertools laden...",
       "sessions": "Actieve sessies laden..."
     },
+    "sso": {
+      "advanced": {
+        "title": "Advanced: custom identity provider routing",
+        "description": "Route MSP login SSO to your own identity provider using verified login domains. Only needed on custom or on-premise installations.",
+        "inertNotice": "No tenant identity provider credentials are configured, so domain claims currently have no effect. Users sign in with the hosted Google / Microsoft providers. Tenant credentials are provisioned on custom and on-premise installations."
+      }
+    },
     "userRoles": {
       "title": "Rollen toewijzen aan gebruikers",
       "description": {

--- a/server/public/locales/nl/msp/settings.json
+++ b/server/public/locales/nl/msp/settings.json
@@ -1792,6 +1792,12 @@
       "title": "Single sign-on",
       "description": "SSO-tools voor bulktoewijzing laden..."
     },
+    "status": {
+      "title": "Sign-in providers",
+      "caption": "These providers are managed by the platform — no client IDs or DNS setup is required. Enable auto-link or assign users below.",
+      "available": "Available",
+      "notConfigured": "Not configured"
+    },
     "autoLink": {
       "title": "SSO automatisch instellen voor nieuwe interne gebruikers",
       "description": "Schakel dit in om elk nieuw personeelsaccount direct te voorzien van uw zakelijke SSO-provider, zodat ze nooit een wachtwoordgebaseerde aanmelding nodig hebben.",

--- a/server/public/locales/pl/msp/integrations.json
+++ b/server/public/locales/pl/msp/integrations.json
@@ -1864,6 +1864,11 @@
         },
         "descriptionCe": "Zarejestruj domeny doradcze dla wykrywania SSO logowania MSP. Weryfikacja własności nie jest wymuszana w edycji Community, a niezarządzane domeny korzystają z dostawców Nine Minds na poziomie aplikacji.",
         "descriptionEe": "Zarządzaj cyklem życia zgłoszeń domen dla wykrywania dostawców SSO logowania MSP. Niezgłoszone lub niekwalifikujące się domeny korzystają z dostawców Nine Minds na poziomie aplikacji.",
+        "moved": {
+          "title": "MSP SSO Login Domains",
+          "body": "Single sign-on settings, including login-domain claims, have moved to Security → Single Sign-On.",
+          "cta": "Open Single Sign-On settings"
+        },
         "dnsHost": "Host:",
         "dnsInstructions": "Dodaj rekord DNS TXT, a następnie kliknij Zweryfikuj:",
         "dnsValue": "Wartość:",

--- a/server/public/locales/pl/msp/profile.json
+++ b/server/public/locales/pl/msp/profile.json
@@ -103,6 +103,13 @@
       "sso": "Ładowanie narzędzi zarządzania SSO...",
       "sessions": "Ładowanie aktywnych sesji..."
     },
+    "sso": {
+      "advanced": {
+        "title": "Advanced: custom identity provider routing",
+        "description": "Route MSP login SSO to your own identity provider using verified login domains. Only needed on custom or on-premise installations.",
+        "inertNotice": "No tenant identity provider credentials are configured, so domain claims currently have no effect. Users sign in with the hosted Google / Microsoft providers. Tenant credentials are provisioned on custom and on-premise installations."
+      }
+    },
     "userRoles": {
       "title": "Przypisywanie ról użytkownikom",
       "description": {

--- a/server/public/locales/pl/msp/settings.json
+++ b/server/public/locales/pl/msp/settings.json
@@ -1800,6 +1800,12 @@
       "title": "Single Sign-On",
       "description": "Ładowanie narzędzi do masowego przypisywania SSO..."
     },
+    "status": {
+      "title": "Sign-in providers",
+      "caption": "These providers are managed by the platform — no client IDs or DNS setup is required. Enable auto-link or assign users below.",
+      "available": "Available",
+      "notConfigured": "Not configured"
+    },
     "autoLink": {
       "title": "Automatyczne konfigurowanie SSO dla nowych użytkowników wewnętrznych",
       "description": "Włącz tę opcję, aby każde nowe konto pracownika było natychmiast udostępniane Państwa korporacyjnemu dostawcy SSO, dzięki czemu nigdy nie będzie wymagane logowanie hasłem.",

--- a/server/public/locales/pt/msp/integrations.json
+++ b/server/public/locales/pt/msp/integrations.json
@@ -1864,6 +1864,11 @@
         },
         "descriptionCe": "Registre domínios de consultoria para descoberta de SSO de login do MSP. A verificação de propriedade não é aplicada no Community Edition e os domínios não gerenciados voltam para os provedores de nível de aplicativo Nine Minds.",
         "descriptionEe": "Gerencie o ciclo de vida de reivindicação de domínio para descoberta de provedor de SSO de login MSP. Domínios não reivindicados ou inelegíveis recorrem aos provedores de nível de aplicativo Nine Minds.",
+        "moved": {
+          "title": "MSP SSO Login Domains",
+          "body": "Single sign-on settings, including login-domain claims, have moved to Security → Single Sign-On.",
+          "cta": "Open Single Sign-On settings"
+        },
         "dnsHost": "Hospedar:",
         "dnsInstructions": "Adicione o registro DNS TXT e clique em Verificar:",
         "dnsValue": "Valor:",

--- a/server/public/locales/pt/msp/profile.json
+++ b/server/public/locales/pt/msp/profile.json
@@ -103,6 +103,13 @@
       "sso": "Carregando ferramentas de gerenciamento de SSO...",
       "sessions": "Carregando sessões ativas..."
     },
+    "sso": {
+      "advanced": {
+        "title": "Advanced: custom identity provider routing",
+        "description": "Route MSP login SSO to your own identity provider using verified login domains. Only needed on custom or on-premise installations.",
+        "inertNotice": "No tenant identity provider credentials are configured, so domain claims currently have no effect. Users sign in with the hosted Google / Microsoft providers. Tenant credentials are provisioned on custom and on-premise installations."
+      }
+    },
     "userRoles": {
       "title": "Atribuir funções aos usuários",
       "description": {

--- a/server/public/locales/pt/msp/settings.json
+++ b/server/public/locales/pt/msp/settings.json
@@ -1792,6 +1792,12 @@
       "title": "Logon único",
       "description": "Carregando ferramentas de atribuição em massa de SSO..."
     },
+    "status": {
+      "title": "Sign-in providers",
+      "caption": "These providers are managed by the platform — no client IDs or DNS setup is required. Enable auto-link or assign users below.",
+      "available": "Available",
+      "notConfigured": "Not configured"
+    },
     "autoLink": {
       "title": "Configure automaticamente o SSO para novos usuários internos",
       "description": "Ative esta opção para provisionar imediatamente cada nova conta de equipe com seu provedor de SSO corporativo, para que eles nunca precisem de um login baseado em senha.",

--- a/server/public/locales/xx/msp/integrations.json
+++ b/server/public/locales/xx/msp/integrations.json
@@ -1864,6 +1864,11 @@
         },
         "descriptionCe": "11111",
         "descriptionEe": "11111",
+        "moved": {
+          "title": "MSP SSO Login Domains",
+          "body": "Single sign-on settings, including login-domain claims, have moved to Security → Single Sign-On.",
+          "cta": "Open Single Sign-On settings"
+        },
         "dnsHost": "11111",
         "dnsInstructions": "11111",
         "dnsValue": "11111",

--- a/server/public/locales/xx/msp/profile.json
+++ b/server/public/locales/xx/msp/profile.json
@@ -103,6 +103,13 @@
       "sso": "11111",
       "sessions": "11111"
     },
+    "sso": {
+      "advanced": {
+        "title": "Advanced: custom identity provider routing",
+        "description": "Route MSP login SSO to your own identity provider using verified login domains. Only needed on custom or on-premise installations.",
+        "inertNotice": "No tenant identity provider credentials are configured, so domain claims currently have no effect. Users sign in with the hosted Google / Microsoft providers. Tenant credentials are provisioned on custom and on-premise installations."
+      }
+    },
     "userRoles": {
       "title": "11111",
       "description": {

--- a/server/public/locales/xx/msp/settings.json
+++ b/server/public/locales/xx/msp/settings.json
@@ -1792,6 +1792,12 @@
       "title": "11111",
       "description": "11111"
     },
+    "status": {
+      "title": "Sign-in providers",
+      "caption": "These providers are managed by the platform — no client IDs or DNS setup is required. Enable auto-link or assign users below.",
+      "available": "Available",
+      "notConfigured": "Not configured"
+    },
     "autoLink": {
       "title": "11111",
       "description": "11111",

--- a/server/public/locales/yy/msp/integrations.json
+++ b/server/public/locales/yy/msp/integrations.json
@@ -1864,6 +1864,11 @@
         },
         "descriptionCe": "55555",
         "descriptionEe": "55555",
+        "moved": {
+          "title": "MSP SSO Login Domains",
+          "body": "Single sign-on settings, including login-domain claims, have moved to Security → Single Sign-On.",
+          "cta": "Open Single Sign-On settings"
+        },
         "dnsHost": "55555",
         "dnsInstructions": "55555",
         "dnsValue": "55555",

--- a/server/public/locales/yy/msp/profile.json
+++ b/server/public/locales/yy/msp/profile.json
@@ -103,6 +103,13 @@
       "sso": "55555",
       "sessions": "55555"
     },
+    "sso": {
+      "advanced": {
+        "title": "Advanced: custom identity provider routing",
+        "description": "Route MSP login SSO to your own identity provider using verified login domains. Only needed on custom or on-premise installations.",
+        "inertNotice": "No tenant identity provider credentials are configured, so domain claims currently have no effect. Users sign in with the hosted Google / Microsoft providers. Tenant credentials are provisioned on custom and on-premise installations."
+      }
+    },
     "userRoles": {
       "title": "55555",
       "description": {

--- a/server/public/locales/yy/msp/settings.json
+++ b/server/public/locales/yy/msp/settings.json
@@ -1792,6 +1792,12 @@
       "title": "55555",
       "description": "55555"
     },
+    "status": {
+      "title": "Sign-in providers",
+      "caption": "These providers are managed by the platform — no client IDs or DNS setup is required. Enable auto-link or assign users below.",
+      "available": "Available",
+      "notConfigured": "Not configured"
+    },
     "autoLink": {
       "title": "55555",
       "description": "55555",

--- a/server/src/components/settings/security/MspSsoAdvancedSection.tsx
+++ b/server/src/components/settings/security/MspSsoAdvancedSection.tsx
@@ -1,0 +1,86 @@
+'use client';
+
+import React from 'react';
+import { Card, CardContent } from '@alga-psa/ui/components/Card';
+import { Alert, AlertDescription } from '@alga-psa/ui/components/Alert';
+import { ChevronRight } from 'lucide-react';
+import { cn } from '@alga-psa/ui/lib/utils';
+import { useTranslation } from '@alga-psa/ui/lib/i18n/client';
+import { MspSsoLoginDomainsSettings } from '@alga-psa/integrations/components';
+import {
+  getMspSsoTenantCredentialStatus,
+  type MspSsoTenantCredentialStatusResult,
+} from '@alga-psa/integrations/actions';
+
+/**
+ * Advanced, collapsed-by-default section under Security → Single Sign-On that hosts the
+ * tenant-level login-domain routing panel (the "custom identity provider" path). On hosted
+ * installs no tenant IdP credentials exist, so the panel is inert — we say so explicitly with
+ * an info notice rather than leaving admins to discover it has no effect.
+ */
+export function MspSsoAdvancedSection(): React.JSX.Element {
+  const { t } = useTranslation('msp/profile');
+  const [expanded, setExpanded] = React.useState(false);
+  const [status, setStatus] = React.useState<MspSsoTenantCredentialStatusResult | null>(null);
+
+  // Load credential status lazily, the first time the section is expanded.
+  React.useEffect(() => {
+    if (!expanded || status) return;
+    let cancelled = false;
+    (async () => {
+      const result = await getMspSsoTenantCredentialStatus();
+      if (!cancelled) setStatus(result);
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, [expanded, status]);
+
+  const showInertNotice = Boolean(status?.success && !status.google && !status.microsoft);
+
+  return (
+    <Card className="mt-6">
+      <button
+        id="msp-sso-advanced-toggle"
+        type="button"
+        onClick={() => setExpanded((prev) => !prev)}
+        aria-expanded={expanded}
+        aria-controls="msp-sso-advanced-body"
+        className="flex w-full items-center gap-2 px-6 py-4 text-left"
+      >
+        <ChevronRight
+          className={cn('h-4 w-4 shrink-0 transition-transform duration-300', expanded && 'rotate-90')}
+        />
+        <span className="flex flex-col">
+          <span className="font-medium">
+            {t('security.sso.advanced.title', { defaultValue: 'Advanced: custom identity provider routing' })}
+          </span>
+          <span className="text-sm text-muted-foreground">
+            {t('security.sso.advanced.description', {
+              defaultValue:
+                'Route MSP login SSO to your own identity provider using verified login domains. Only needed on custom or on-premise installations.',
+            })}
+          </span>
+        </span>
+      </button>
+
+      {expanded && (
+        <CardContent id="msp-sso-advanced-body" className="space-y-4 pt-0">
+          {showInertNotice && (
+            <Alert variant="info">
+              <AlertDescription>
+                {t('security.sso.advanced.inertNotice', {
+                  defaultValue:
+                    'No tenant identity provider credentials are configured, so domain claims currently have no effect. Users sign in with the hosted Google / Microsoft providers. Tenant credentials are provisioned on custom and on-premise installations.',
+                })}
+              </AlertDescription>
+            </Alert>
+          )}
+          <MspSsoLoginDomainsSettings />
+        </CardContent>
+      )}
+    </Card>
+  );
+}
+
+export default MspSsoAdvancedSection;

--- a/server/src/components/settings/security/SecuritySettingsPage.tsx
+++ b/server/src/components/settings/security/SecuritySettingsPage.tsx
@@ -89,6 +89,11 @@ const SsoBulkAssignment = dynamic(
   },
 );
 
+const MspSsoAdvancedSection = dynamic(
+  () => import('./MspSsoAdvancedSection'),
+  { ssr: false },
+);
+
 function SessionsLoading() {
   const { t } = useTranslation('msp/profile');
   return <SettingsTabSkeleton title={t('security.tabs.sessions', { defaultValue: 'Sessions' })} description={t('security.loading.sessions', { defaultValue: 'Loading active sessions...' })} showTable={true} />;
@@ -150,9 +155,12 @@ const SecuritySettingsPage = (): React.JSX.Element => {
       id: 'single-sign-on',
       label: t('security.tabs.sso', { defaultValue: 'Single Sign-On' }),
       content: (
-        <Suspense fallback={<SsoLoading />}>
-          <SsoBulkAssignment />
-        </Suspense>
+        <>
+          <Suspense fallback={<SsoLoading />}>
+            <SsoBulkAssignment />
+          </Suspense>
+          <MspSsoAdvancedSection />
+        </>
       ),
     },
     {

--- a/server/src/test/unit/components/integrations/IntegrationsSettingsPage.calendar.test.tsx
+++ b/server/src/test/unit/components/integrations/IntegrationsSettingsPage.calendar.test.tsx
@@ -11,6 +11,7 @@ const useFeatureFlagMock = vi.hoisted(() => vi.fn());
 
 vi.mock('next/navigation', () => ({
   useSearchParams: useSearchParamsMock,
+  useRouter: () => ({ push: vi.fn(), replace: vi.fn(), prefetch: vi.fn() }),
 }));
 
 // Resolve integration category labels/descriptions against the real msp/settings

--- a/server/src/test/unit/components/integrations/IntegrationsSettingsPage.entra.test.tsx
+++ b/server/src/test/unit/components/integrations/IntegrationsSettingsPage.entra.test.tsx
@@ -11,6 +11,7 @@ const useFeatureFlagMock = vi.hoisted(() => vi.fn());
 
 vi.mock('next/navigation', () => ({
   useSearchParams: useSearchParamsMock,
+  useRouter: () => ({ push: vi.fn(), replace: vi.fn(), prefetch: vi.fn() }),
 }));
 
 // Resolve integration category labels/descriptions against the real msp/settings

--- a/server/src/test/unit/components/integrations/IntegrationsSettingsPage.teams.test.tsx
+++ b/server/src/test/unit/components/integrations/IntegrationsSettingsPage.teams.test.tsx
@@ -11,6 +11,7 @@ const useFeatureFlagMock = vi.hoisted(() => vi.fn());
 
 vi.mock('next/navigation', () => ({
   useSearchParams: useSearchParamsMock,
+  useRouter: () => ({ push: vi.fn(), replace: vi.fn(), prefetch: vi.fn() }),
 }));
 
 // Resolve integration category labels/descriptions against the real msp/settings


### PR DESCRIPTION
## Make SSO premise setup clear

MSP admins were treating **Settings → General → Providers** as the place to configure single sign-on, and the tenant login-domain panel that lived there had no visible effect on hosted installs (no tenant IdP credentials exist, so domain claims are inert). This branch consolidates SSO under **Security → Single Sign-On**, makes the "easy path" (platform-managed providers) obvious, and demotes the on-prem/custom routing to a clearly-labelled advanced section.

### What changed

**Security → Single Sign-On (the easy path, front and center)**
- The EE `SsoBulkAssignment` panel gained a **provider-status strip** ("Sign-in providers") at the top, showing Google Workspace and Microsoft 365 (Azure AD) with **Available** badges and the clarifying caption: *"These providers are managed by the platform — no client IDs or DNS setup is required. Enable auto-link or assign users below."*
- New **collapsed-by-default "Advanced: custom identity provider routing" section** (`MspSsoAdvancedSection.tsx`) hosts the tenant login-domain panel. Subtitle: *"Only needed on custom or on-premise installations."*
- When no tenant IdP credentials are configured, the advanced section shows an **inert-state notice** explaining that domain claims currently have no effect and users sign in with the hosted providers — instead of leaving admins to discover the panel does nothing.

**New read-only action**
- `getMspSsoTenantCredentialStatus` (in `packages/integrations` `mspSsoDomainActions.ts`) wraps `hasTenantProviderCredentials` from `packages/auth` `mspSsoResolution.ts` for Google + Azure AD. Permission-gated; on any failure it reports `success:false` so the UI shows *no* notice rather than a wrong one. Loaded lazily the first time the advanced section is expanded.

**Providers tab (the old spot)**
- The inline login-domain panel is removed and replaced with a conspicuous **above-the-fold pointer banner** (`id=msp-sso-moved-link`, Shield icon, solid deep-link button) reading *"MSP SSO Login Domains — Single sign-on settings, including login-domain claims, have moved to Security → Single Sign-On."* The button deep-links to `/msp/security-settings?tab=single-sign-on`. The Google/Microsoft integration cards and Provider Credentials section are untouched.

**Supporting**
- i18n defaults added across all locales (`msp/settings`, `msp/profile`, `msp/integrations`).
- Unit tests: `mspSsoDomainActions.test.ts` (new action) and updated `IntegrationsSettingsPage.providers.test.ts`.
- Plan: `docs/plans/2026-07-08-sso-provider-setup-easy-path-plan.md`.

### Smoke-test results

Smoke-tested against the real running product (compose project `alga-psa-local-test`, host-run dev server on `http://localhost:3144`, edition=enterprise), authenticated as `glinda@emeraldcity.oz` (MSP admin) and driving the real UI via alga-dev browser automation. All four flows **PASS**, 0 console errors:

1. **Provider-status strip** — Security → Single Sign-On renders the "Sign-in providers" card with the clarifying caption; Google Workspace and Microsoft 365 both show green **Available** badges; auto-link toggle + Bulk SSO Assignment render below. *(screenshot 01)*
2. **Advanced section + inert notice** — collapsed by default (`aria-expanded=false`, body not in DOM); expanding lazily loads `getMspSsoTenantCredentialStatus` → `success:true/google:false/microsoft:false`, proving out via the inert notice appearing above the login-domains panel. *(screenshots 02 collapsed, 03 expanded)*
3. **Providers pointer deep-link** — the above-the-fold banner (Shield icon, `id=msp-sso-moved-link`) navigates `/msp/settings...providers` → `/msp/security-settings?tab=single-sign-on` on the same origin; destination renders the strip + advanced toggle. *(screenshots 04 banner, 05 landed)*
4. **Regression** — the old inline domain panel is gone; Google/Microsoft integration cards and Provider Credentials section still render intact.

**Env note:** a prior wire-up set app-level OAuth *placeholders* in `server/.env.local` to simulate hosted mode (fidelity-ladder config-level simulator): placeholders make Google/Microsoft report `configured` (Available) while no tenant IdP credentials exist, so `hasTenantProviderCredentials()=false` and the Advanced section shows its inert notice — the intended hosted-mode state. A real Google/Microsoft login would **not** complete with placeholders and was not exercised (no real hosted IdP available); acceptable since this change is about UI clarity, not the OAuth handshake.

Evidence directory: `/tmp/alga-smoke-evidence/sso-provider-setup-easy-path-20260708-155651`
