### PR TITLE
Inventory current pass

### DIFF
--- a/docs/plans/2026-07-08-inventory-currency-issues-plan.md
+++ b/docs/plans/2026-07-08-inventory-currency-issues-plan.md
@@ -1,0 +1,282 @@
+# Inventory Currency Issues — Implementation Plan
+
+**Branch:** `fix/inventory-currency-issues`
+**Date:** 2026-07-08
+**Scope:** Full sweep of the inventory-module currency audit (79 findings / 21 files).
+
+---
+
+## 1. Problem
+
+The inventory module re-invents currency handling instead of using the shared
+utilities the codebase already provides. The audit found **79 issues across 21
+files** (28 high, 34 medium, 17 low). The symptoms cluster into three product
+surfaces plus two genuine data bugs:
+
+- **Entry screens** use raw `<input type="number" step="0.01">` for money and
+  either a free-typed currency text field (`VendorPriceList`) or a local 4-item
+  currency list (`PurchaseOrdersManager`) instead of the shared picker.
+- **Displays** hardcode `$`, re-implement `Intl.NumberFormat`, and use ~11 local
+  `money()` / `dollars()` / `fmtCents()` one-liners that all bake in
+  `/100 + toFixed(2)`.
+- **Defaults** hardcode `'USD'` in ~30 write paths, mislabeling every non-USD
+  tenant, and several report/query payloads drop `currency_code` entirely so
+  the UI has nothing correct to format with.
+
+Two of these are real bugs, not cosmetics:
+
+1. **Non-2-decimal corruption on write.** Money is stored as `bigInteger` **minor
+   units** (cents) everywhere, but writes use `Math.round(x * 100)` and displays
+   use `/100`, hardcoding a 2-decimal exponent. A JPY (exponent 0) or BHD
+   (exponent 3) amount is persisted at the wrong magnitude.
+2. **Hardcoded `'USD'` write-defaults** land on persisted rows and report
+   payloads, not just function parameters.
+
+### Root cause — two missing layers
+
+The same private one-liner appears ~11 times because nothing binds the shared
+core formatters to *(a record's `currency_code`, the current user's locale)*.
+And the tenant-default-currency lookup exists only as a **private local helper**
+in billing (`getTenantDefaultCurrency` in
+`packages/billing/src/actions/profitabilityReportActions.ts:305`), so inventory
+would be re-inventing a third copy. Both are classic missing-layer signals.
+
+---
+
+## 2. What already exists (reuse, do not re-create)
+
+- **Core primitives** — `packages/core/src/lib/formatters.ts`:
+  `formatCurrencyFromMinorUnits(minorUnits, locale, currency)`,
+  `formatCurrency`, `currencyFractionDigits(currency, locale)`,
+  `toMinorUnits(value, locale, currency)`. These derive the exponent from
+  `Intl.NumberFormat`, so they are correct for JPY/BHD. Exported from
+  `@alga-psa/core`. `SalesOrdersManager.tsx:25` already imports them.
+- **Shared currency list** — `packages/core/src/constants/currency.ts`:
+  `CURRENCY_OPTIONS`, `getCurrencySymbol(code)`.
+- **Locale-aware money input** — `packages/ui/src/components/CurrencyInput.tsx`
+  (reads locale from `useOptionalI18n()`).
+- **Locale source** — `useOptionalI18n()` (`packages/ui/src/lib/i18n/client.tsx:278`),
+  fallback `LOCALE_CONFIG.defaultLocale`.
+- **Tenant default currency** — `default_billing_settings.default_currency_code`
+  (the column billing already reads).
+- **A dashboard-local `useCurrencyFormat` + `CurrencyFormatProvider`** already
+  exists in `packages/inventory/src/components/dashboard/shared.tsx:40-81` (from
+  PR #2883). It is the right *shape* (context-seeded currency+locale, call sites
+  pass only `cents`) but re-implements `Intl.NumberFormat` and hardcodes `/100`.
+  This plan **promotes and rebases it**, it does not start from scratch.
+
+---
+
+## 3. Design decisions (settled)
+
+- **Two general shared layers, inventory-only adoption this branch.** Billing is
+  left untouched except a `// LEVERAGE: friction` marker on its private resolver.
+- **Storage convention is minor-units (cents).** Display takes minor units;
+  writes convert major→minor via `toMinorUnits`. **Forward-correctness only — no
+  backfill migration** (these tables are weeks old; assume no non-USD data).
+- **No FX.** There is no general "convert amount X→Y" service. We do not convert,
+  sum across, or group mixed currencies.
+- **Mixing is prevented, not summed.** It is only structurally possible at two
+  sites (see §5). Elsewhere currency is header-level and lines inherit it.
+- **Cross-*document* rollups** (dashboard tiles, PO `openTotal`) format in the
+  tenant default currency and make no cross-currency claim.
+
+---
+
+## 4. Layer 1 — `useCurrencyFormat` (display), promoted to `packages/ui`
+
+**Goal:** one hook every inventory display site calls; deletes all ~11 local
+money helpers and every `/100 + toFixed(2)`.
+
+**Create** `packages/ui/src/lib/currency/useCurrencyFormat.tsx` (client module):
+
+- `CurrencyFormatProvider({ currencyCode, locale?, children })` — context that
+  seeds the document/page currency. `locale` defaults to `useOptionalI18n()`.
+- `useCurrencyFormat()` returns:
+  - `money(minorUnits: number, currencyOverride?: string): string` — wraps
+    `formatCurrencyFromMinorUnits(minorUnits, locale, currencyOverride ?? contextCurrency)`.
+    The **`currencyOverride`** argument is what makes list screens correct, where
+    each row carries its own `currency_code` (PO list, vendor bills list).
+  - `moneySigned(minorUnits, currencyOverride?)` — preserve the existing
+    explicit `+/−` behavior from `dashboard/shared.tsx`.
+  - `fractionDigits(currencyOverride?)` — exposes `currencyFractionDigits` for
+    input components.
+- Backed **entirely** by `@alga-psa/core` formatters — no local `Intl.NumberFormat`,
+  no `/100`, no `dp` default that assumes 2 decimals.
+
+**Rebase the dashboard module** `packages/inventory/src/components/dashboard/shared.tsx`:
+
+- Delete `buildCurrencyFormat`, the local `CurrencyFormatContext`,
+  `CurrencyFormatProvider`, and `useCurrencyFormat` (lines ~24-81).
+- Re-export `CurrencyFormatProvider` / `useCurrencyFormat` / `CurrencyFormat`
+  from the new `@alga-psa/ui` module so the ~9 existing dashboard call sites
+  (`RailTiles`, `MoneyBand`, `FooterStrip`, `AttentionStream`, `InventoryDashboard`,
+  `MarginReport`) keep working unchanged.
+- **Intended behavior change:** dashboard money currently renders whole-number
+  (`dp=0`); under the core formatter it renders the currency's natural fraction
+  digits (e.g. USD `$1,234.00`, JPY `¥1,234`). This is the desired result — do
+  **not** reintroduce a hardcoded exponent or a whole-number override.
+
+**Delete these local helpers** and route them through the hook (or, for
+non-component code, `formatCurrencyFromMinorUnits` directly):
+
+| File | Local helper (line) |
+|---|---|
+| `PurchaseOrdersManager.tsx` | `money` (82) |
+| `PoLandedCostDialog.tsx` | `money` (14) |
+| `VendorBillsManager.tsx` | `money` (34) — also called with NO currency at 432/447 |
+| `ImportOpeningBalances.tsx` | `dollars` (30) |
+| `StockOverview.tsx` | `dollars` (48) |
+| `WriteOffsReport.tsx` | `money` (19) |
+| `SalesOrderDetail.tsx` | `dollars` (71) |
+| `CycleCountsManager.tsx` | `dollars` (29) |
+| `StockUnitsManager.tsx` | `fmtCents` (36) |
+| `MarginReport.tsx` | (already on hook; ensure no residual `$`) |
+| `SalesOrdersManager.tsx` | already imports core formatters — finish migration to hook where inside a provider |
+
+Each call site must pass the correct `currency_code` — from the record for list
+rows, or from the provider for single-currency pages (§6 supplies the codes).
+
+---
+
+## 5. Layer 2 — `resolveTenantCurrency` (server default resolver)
+
+**Create** a shared server helper (co-located with the inventory server libs, or a
+shared server util module):
+
+```ts
+async function resolveTenantCurrency(knex: Knex, tenant: string): Promise<string> {
+  const row = await tenantDb(knex, tenant)
+    .table('default_billing_settings')
+    .select('default_currency_code')
+    .first();
+  return row?.default_currency_code || 'USD';
+}
+```
+
+- Replace the ~30 hardcoded `'USD'` **write-defaults** and payload defaults in
+  inventory actions/lib with a call to this resolver (only where a currency is
+  not already known from the record). Target files:
+  `vendorProductActions.ts:84`, `vendorBillActions.ts:178`, `reorderActions.ts:163`,
+  `dropShipActions.ts:55`, `rmaActions.ts:137`,
+  `productInventorySettingsActions.ts:133`, `landedCostActions.ts:69`,
+  `cycleCountActions.ts`, `inventoryDashboardActions.ts`,
+  `lib/materials.ts:156`, `lib/openingBalanceCsv.ts:624`, `lib/dashboardQueries.ts:8`.
+- **Leave billing untouched.** Drop one marker at
+  `packages/billing/src/actions/profitabilityReportActions.ts:305`:
+  `// LEVERAGE: friction tenant-default-currency — duplicate of inventory resolveTenantCurrency; consolidate into a shared server util.`
+
+> Note: `'USD'` also appears in ~15 inventory **test** files — those are fixtures,
+> leave them. Only production write/display paths change.
+
+---
+
+## 6. Consuming sweep — the three surfaces
+
+### 6a. Entry screens
+- Money fields → shared `CurrencyInput` (removes `step="0.01"` raw inputs at
+  `LoanersManager.tsx:305`, `StockOverview.tsx:428`, `PurchaseOrdersManager.tsx:697`,
+  `SalesOrdersManager.tsx:650`, `PoLandedCostDialog`).
+- Currency pickers → shared `CURRENCY_OPTIONS` dropdown:
+  - `VendorPriceList.tsx:218` — **replace the free-typed currency text field**
+    with the dropdown (stops persisting invalid codes).
+  - `PurchaseOrdersManager.tsx:135` — delete the local 4-item `CURRENCY_OPTIONS`,
+    use the shared one.
+- Writes convert major→minor via `toMinorUnits(value, locale, currency)`,
+  replacing `Math.round(x * 100)` (`PurchaseOrdersManager.tsx:267`,
+  `PoLandedCostDialog`, `openingBalanceCsv.ts` parse) and any `* 100`.
+- Form defaults: seed `currency_code` from `resolveTenantCurrency` (server) or the
+  provider (client), not `'USD'` (`PurchaseOrdersManager.tsx:60`, `VendorPriceList`,
+  `PoLandedCostDialog`).
+
+### 6b. Displays
+- All money via `useCurrencyFormat()` / core formatter (§4).
+- Fix hardcoded-symbol column headers, e.g. `PurchaseOrdersManager.tsx:667`
+  `Unit cost ($)` → neutral `Unit cost` (currency shown in the value).
+
+### 6c. Defaults / payloads
+- Thread `currency_code` onto report and query payloads that currently drop it,
+  so display sites have a real code:
+  - `inventoryReportingActions.ts:48` — `InventoryValueReport`, `MarginReport`,
+    `WriteOffReportData`.
+  - `salesOrderLinkActions.ts:74`.
+  - `lib/dashboardQueries.ts:8`.
+  Where a report spans a single tenant currency, carry
+  `resolveTenantCurrency(...)`; where rows carry their own code, include it
+  per-row and format with the override argument.
+
+---
+
+## 7. Mixing enforcement (exactly two sites)
+
+Currency lives on document **headers**; most lines inherit it, so mixing is
+usually impossible. `sales_order_lines` and `vendor_bill_lines` have **no**
+currency column — single-currency by construction, nothing to enforce. The two
+real sites:
+
+1. **Purchase order lines** — `purchase_order_lines.cost_currency` can diverge
+   from `purchase_orders.currency_code`.
+   - UI: PO header has the single currency selector; **remove any per-line
+     currency choice**; lines inherit the header currency.
+   - Server (PO create/update in `PurchaseOrdersManager` action path): write every
+     line's `cost_currency = header currency_code`; **validate equal on save** and
+     reject a divergent mix with a clear error.
+2. **Landed costs** — `po_landed_costs.currency_code` can diverge from its parent
+   PO.
+   - UI (`PoLandedCostDialog`): default and **lock** the currency to the parent
+     PO's `currency_code` (display it, don't offer a different pick).
+   - Server (`landedCostActions.ts`): validate the landed cost currency equals the
+     parent PO currency; reject otherwise.
+
+Cross-*document* rollups (`PurchaseOrdersManager.tsx:514-515` `openTotal`,
+dashboard `MoneyBand`/tiles) simply format in the tenant default currency and
+make no cross-currency arithmetic claim — no grouping UI, no conversion.
+
+---
+
+## 8. Reference implementation order
+
+Do PO end-to-end first as the worked example, then sweep outward.
+
+1. **Layer 1** — build/promote `useCurrencyFormat` in `packages/ui`; rebase
+   `dashboard/shared.tsx` onto it; verify dashboard still renders correctly.
+2. **Layer 2** — build `resolveTenantCurrency`; add the billing `LEVERAGE` marker.
+3. **Purchase Order** end-to-end (`PurchaseOrdersManager` + `PoLandedCostDialog` +
+   `landedCostActions`) using both layers + `CurrencyInput` + shared
+   `CURRENCY_OPTIONS` + mixing enforcement. This is the pattern every other file
+   copies.
+4. **Persisted `'USD'` write-defaults** in actions/lib (highest data risk).
+5. **Payload `currency_code` threading** (unblocks downstream displays).
+6. **Remaining display helpers + form inputs** onto the hook / `CurrencyInput` /
+   `CURRENCY_OPTIONS`.
+
+Files confirmed **already clean** (do not touch): dashboard `RailTiles` /
+`AttentionStream` / `FooterStrip` / `MoneyBand`, `VendorsManager`,
+`GhostUsageReport`, `RmaManager`, `TransfersManager`, `StockLocationsManager`,
+`KitManager`, the `msp/inventory` pages, and both inventory API routes.
+
+---
+
+## 9. Testing / verification
+
+- **Unit:** `toMinorUnits` / `formatCurrencyFromMinorUnits` round-trip for USD (2),
+  JPY (0), BHD (3) — assert no `×100` corruption for JPY.
+- **Component:** a display site formats a non-USD `currency_code` with the correct
+  symbol and fraction digits; PO list rows in different currencies each render
+  their own code via the `money(minor, override)` path.
+- **Enforcement:** PO save rejects a line whose `cost_currency` ≠ header; landed
+  cost save rejects a currency ≠ parent PO.
+- **Resolver:** `resolveTenantCurrency` returns the tenant's
+  `default_currency_code`, falls back to `'USD'` when unset.
+- **Manual (`/verify`-style):** create a PO in a non-USD currency, add a line and a
+  landed cost, confirm entry (locale-aware input), storage (correct minor units),
+  and display (correct symbol/decimals) end-to-end. Confirm the dashboard tiles
+  and margin/write-off reports still render after the `shared.tsx` rebase.
+- **Assumption check:** query distinct `currency_code` / `cost_currency` across
+  inventory tables to confirm the forward-only (no-backfill) assumption holds.
+
+## 10. Out of scope
+
+Exchange rates / FX conversion, mixed-currency grouping UI, data backfill
+migrations, billing-side adoption (marker only), and the inventory `*.test.ts`
+`'USD'` fixtures.

--- a/packages/billing/src/actions/profitabilityReportActions.ts
+++ b/packages/billing/src/actions/profitabilityReportActions.ts
@@ -303,6 +303,7 @@ function normalizeDateInput(input: ProfitabilityDateInput): { startDate: string;
   return { startDate, endDate };
 }
 
+// LEVERAGE: friction tenant-default-currency - duplicate of inventory resolveTenantCurrency; consolidate into a shared server util.
 async function getTenantDefaultCurrency(knex: Knex, tenant: string): Promise<string> {
   const row = await tenantDb(knex, tenant).table('default_billing_settings')
     .select('default_currency_code')

--- a/packages/core/src/lib/formatters.test.ts
+++ b/packages/core/src/lib/formatters.test.ts
@@ -1,0 +1,22 @@
+import { describe, expect, it } from 'vitest';
+import {
+  currencyFractionDigits,
+  formatCurrencyFromMinorUnits,
+  toMinorUnits,
+} from './formatters';
+
+describe('currency minor-unit formatters', () => {
+  it('round-trips currencies with different minor-unit exponents', () => {
+    expect(currencyFractionDigits('USD', 'en-US')).toBe(2);
+    expect(toMinorUnits(12.34, 'en-US', 'USD')).toBe(1234);
+    expect(formatCurrencyFromMinorUnits(1234, 'en-US', 'USD')).toBe('$12.34');
+
+    expect(currencyFractionDigits('JPY', 'en-US')).toBe(0);
+    expect(toMinorUnits(1234, 'en-US', 'JPY')).toBe(1234);
+    expect(formatCurrencyFromMinorUnits(1234, 'en-US', 'JPY')).toBe('¥1,234');
+
+    expect(currencyFractionDigits('BHD', 'en-US')).toBe(3);
+    expect(toMinorUnits(12.345, 'en-US', 'BHD')).toBe(12345);
+    expect(formatCurrencyFromMinorUnits(12345, 'en-US', 'BHD').replace(/\u00a0/g, ' ')).toBe('BHD 12.345');
+  });
+});

--- a/packages/inventory/src/actions/currencyActions.ts
+++ b/packages/inventory/src/actions/currencyActions.ts
@@ -1,0 +1,17 @@
+'use server';
+
+import { createTenantKnex } from '@alga-psa/db';
+import { withAuth } from '@alga-psa/auth';
+import { hasPermission } from '@alga-psa/auth/rbac';
+import { resolveTenantCurrency } from '../lib';
+
+export const getInventoryTenantCurrency = withAuth(
+  async (user, { tenant }): Promise<string> => {
+    if (!(await hasPermission(user, 'inventory', 'read'))) {
+      throw new Error('Permission denied: inventory read required');
+    }
+
+    const { knex } = await createTenantKnex();
+    return resolveTenantCurrency(knex, tenant);
+  },
+);

--- a/packages/inventory/src/actions/cycleCountActions.ts
+++ b/packages/inventory/src/actions/cycleCountActions.ts
@@ -5,7 +5,7 @@ import { withTransaction, createTenantKnex } from '@alga-psa/db';
 import { withAuth } from '@alga-psa/auth';
 import { hasPermission } from '@alga-psa/auth/rbac';
 import { ICountSession, ICountLine, IStockUnit } from '@alga-psa/types';
-import { recordStockMovement, recomputeSerializedOnHand, assertLocationWritable, ensureStockLevel } from '../lib';
+import { recordStockMovement, recomputeSerializedOnHand, assertLocationWritable, ensureStockLevel, resolveTenantCurrency } from '../lib';
 
 // NOTE: 'use server' file — export ONLY async functions (+ erased types).
 
@@ -72,6 +72,8 @@ export interface CountLineView extends ICountLine {
   variance?: number | null;
   /** Variance valued at the product's average cost, cents (approvers only). */
   variance_value_cents?: number | null;
+  /** Currency for the average cost used to value variance. */
+  cost_currency?: string | null;
 }
 
 export interface CountSessionView extends ICountSession {
@@ -216,6 +218,7 @@ export const getCountSession = withAuth(
           'sc.sku',
           trx.raw('COALESCE(pis.is_serialized, false) as is_serialized'),
           'pis.average_cost',
+          'pis.cost_currency',
         )) as any[];
 
       const out: CountLineView[] = [];
@@ -422,6 +425,7 @@ export const approveCountSession = withAuth(
         })
         .where({ 'cl.tenant': tenant, 'cl.session_id': sessionId })
         .select('cl.*', trx.raw('COALESCE(pis.is_serialized, false) as is_serialized'), 'pis.average_cost', 'pis.cost_currency')) as any[];
+      const defaultCurrency = await resolveTenantCurrency(trx, tenant);
 
       const result: ApproveCountResult = {
         session,
@@ -502,7 +506,7 @@ export const approveCountSession = withAuth(
                 status: 'in_stock',
                 location_id: locationId,
                 unit_cost: line.average_cost ?? null,
-                cost_currency: line.cost_currency ?? 'USD',
+                cost_currency: line.cost_currency ?? defaultCurrency,
                 received_at: trx.fn.now(),
                 notes: `Found via ${reason}`,
               })

--- a/packages/inventory/src/actions/dropShipActions.ts
+++ b/packages/inventory/src/actions/dropShipActions.ts
@@ -15,6 +15,7 @@ import {
   PurchaseOrderStatus,
 } from '@alga-psa/types';
 import { publishInventoryEvent, recordStockMovement, timestampPayload } from '../lib';
+import { resolveTenantCurrency } from '../lib';
 
 /**
  * Drop-ship: vendor ships straight to the client, the stock never touches one of
@@ -42,6 +43,7 @@ async function resolveCost(
   serviceId: string,
   fallbackCurrency: string,
 ): Promise<{ unitCost: number; costCurrency: string }> {
+  const defaultCurrency = fallbackCurrency || await resolveTenantCurrency(trx, tenant);
   const pis = await trx('product_inventory_settings')
     .where({ tenant, service_id: serviceId })
     .select('average_cost', 'cost_currency')
@@ -52,7 +54,7 @@ async function resolveCost(
     .first();
   return {
     unitCost: Number(pis?.average_cost ?? sc?.cost ?? 0),
-    costCurrency: pis?.cost_currency ?? sc?.cost_currency ?? fallbackCurrency ?? 'USD',
+    costCurrency: pis?.cost_currency ?? sc?.cost_currency ?? defaultCurrency,
   };
 }
 
@@ -98,7 +100,7 @@ export const createDropShipForSoLine = withAuth(
       const vendor = await trx('vendors').where({ tenant, vendor_id: input.vendor_id }).first();
       if (!vendor) throw new Error('Vendor not found');
 
-      const currencyCode = so.currency_code ?? 'USD';
+      const currencyCode = so.currency_code || await resolveTenantCurrency(trx, tenant);
       const numRes = await trx.raw('SELECT generate_next_number(?::uuid, ?) as number', [tenant, 'PURCHASE_ORDER']);
       const poNumber = numRes.rows[0].number;
 
@@ -253,7 +255,7 @@ export const confirmDropShipShipment = withAuth(
         trx,
         tenant,
         soLine.service_id,
-        po.currency_code ?? 'USD',
+        po.currency_code || await resolveTenantCurrency(trx, tenant),
       );
 
       const serials = input?.serials ?? [];

--- a/packages/inventory/src/actions/index.ts
+++ b/packages/inventory/src/actions/index.ts
@@ -26,3 +26,4 @@ export * from './landedCostActions';
 export * from './vendorBillActions';
 export * from './openingBalanceActions';
 export * from './ghostUsageActions';
+export * from './currencyActions';

--- a/packages/inventory/src/actions/inventoryDashboardActions.ts
+++ b/packages/inventory/src/actions/inventoryDashboardActions.ts
@@ -24,6 +24,7 @@ import {
   type RmaReceivables,
   type UnbilledSoRow,
 } from '../lib/dashboardQueries';
+import { resolveTenantCurrency } from '../lib/tenantCurrency';
 
 /**
  * Consolidated data feed for the Inventory dashboard ("money before lunch").
@@ -205,11 +206,7 @@ export const getInventoryDashboardData = withAuth(async (user, { tenant }): Prom
     const tech_count = Number(techRow?.c ?? 0);
 
     /* ---- tenant default billing currency (money formatting) ---- */
-    const billingSettingsRow = await trx('default_billing_settings')
-      .where({ tenant })
-      .select<{ default_currency_code: string | null }>('default_currency_code')
-      .first();
-    const currency_code = billingSettingsRow?.default_currency_code || 'USD';
+    const currency_code = await resolveTenantCurrency(trx, tenant);
 
     /* ---- on-hand value + units (footer) ---- */
     const nonSerValueRow = await trx('stock_levels as sl')

--- a/packages/inventory/src/actions/inventoryDashboardActions.ts
+++ b/packages/inventory/src/actions/inventoryDashboardActions.ts
@@ -15,14 +15,16 @@ import {
   queryPriceCreep,
   queryRmaReceivables,
   queryUnbilled,
-  queryValueWowDelta,
+  queryValueWowDeltaByCurrency,
   queryVanContext,
   queryWarrantyExpiring,
   type DeadStock,
   type DeploymentRow,
+  type MoneyByCurrency,
   type Pipeline,
   type RmaReceivables,
   type UnbilledSoRow,
+  totalMoneyByCurrency,
 } from '../lib/dashboardQueries';
 import { resolveTenantCurrency } from '../lib/tenantCurrency';
 
@@ -151,8 +153,12 @@ export interface InventoryDashboardData {
     techs: Array<{ name: string; count: number; est: number | null }>;
   };
   footer: {
+    /** Legacy total; use value_by_currency for display so non-2-decimal currencies keep their scale. */
     value: number;
+    value_by_currency: MoneyByCurrency[];
+    /** Legacy total; use wow_delta_by_currency for display. */
     wow_delta: number;
+    wow_delta_by_currency: MoneyByCurrency[];
     on_hand_units: number;
     serialized_units: number;
     dead_stock: DeadStock | null;
@@ -176,6 +182,18 @@ const ROUTES = {
   quotes: '/msp/billing?tab=quotes',
   client: (id: string) => `/msp/clients/${id}`,
 } as const;
+
+function mergeMoneyBuckets(rows: Array<{ currency_code: string | null; amount: unknown }>, fallbackCurrency: string): MoneyByCurrency[] {
+  const byCurrency = new Map<string, number>();
+  for (const row of rows) {
+    const currency = row.currency_code?.trim() || fallbackCurrency;
+    byCurrency.set(currency, (byCurrency.get(currency) ?? 0) + Math.round(Number(row.amount ?? 0)));
+  }
+  return [...byCurrency.entries()]
+    .map(([currency_code, amount]) => ({ currency_code, amount }))
+    .filter((row) => row.amount !== 0)
+    .sort((a, b) => Math.abs(b.amount) - Math.abs(a.amount) || a.currency_code.localeCompare(b.currency_code));
+}
 
 function sameLocalDay(a: Date, b: Date): boolean {
   return a.getFullYear() === b.getFullYear() && a.getMonth() === b.getMonth() && a.getDate() === b.getDate();
@@ -209,20 +227,40 @@ export const getInventoryDashboardData = withAuth(async (user, { tenant }): Prom
     const currency_code = await resolveTenantCurrency(trx, tenant);
 
     /* ---- on-hand value + units (footer) ---- */
-    const nonSerValueRow = await trx('stock_levels as sl')
+    const settingsCurrency = trx.raw("COALESCE(NULLIF(pis.cost_currency, ''), ?) as currency_code", [currency_code]);
+    const settingsCurrencyGroup = trx.raw("COALESCE(NULLIF(pis.cost_currency, ''), ?)", [currency_code]);
+    const nonSerValueRows = await trx('stock_levels as sl')
       .join('product_inventory_settings as pis', function () {
         this.on('sl.service_id', '=', 'pis.service_id').andOn('sl.tenant', '=', 'pis.tenant');
       })
       .where({ 'sl.tenant': tenant, 'pis.is_serialized': false })
       .andWhere('sl.quantity_on_hand', '>', 0)
-      .select<{ value: string }[]>(trx.raw('COALESCE(SUM(sl.quantity_on_hand * COALESCE(pis.average_cost, 0)),0) as value'))
-      .first();
-    const serValueRow = await trx('stock_units')
-      .where({ tenant, status: 'in_stock' })
-      .whereNotNull('location_id')
-      .select<{ value: string }[]>(trx.raw('COALESCE(SUM(COALESCE(unit_cost,0)),0) as value'))
-      .first();
-    const footerValue = Math.round(Number(nonSerValueRow?.value ?? 0)) + Math.round(Number(serValueRow?.value ?? 0));
+      .groupBy(settingsCurrencyGroup)
+      .select<{ currency_code: string | null; value: string }[]>(
+        settingsCurrency,
+        trx.raw('COALESCE(SUM(sl.quantity_on_hand * COALESCE(pis.average_cost, 0)),0) as value'),
+      );
+    const unitCurrency = trx.raw("COALESCE(NULLIF(su.cost_currency, ''), NULLIF(pis.cost_currency, ''), ?) as currency_code", [currency_code]);
+    const unitCurrencyGroup = trx.raw("COALESCE(NULLIF(su.cost_currency, ''), NULLIF(pis.cost_currency, ''), ?)", [currency_code]);
+    const serValueRows = await trx('stock_units as su')
+      .leftJoin('product_inventory_settings as pis', function () {
+        this.on('su.service_id', '=', 'pis.service_id').andOn('su.tenant', '=', 'pis.tenant');
+      })
+      .where({ 'su.tenant': tenant, 'su.status': 'in_stock' })
+      .whereNotNull('su.location_id')
+      .groupBy(unitCurrencyGroup)
+      .select<{ currency_code: string | null; value: string }[]>(
+        unitCurrency,
+        trx.raw('COALESCE(SUM(COALESCE(su.unit_cost,0)),0) as value'),
+      );
+    const footerValueByCurrency = mergeMoneyBuckets(
+      [
+        ...nonSerValueRows.map((row) => ({ currency_code: row.currency_code, amount: row.value })),
+        ...serValueRows.map((row) => ({ currency_code: row.currency_code, amount: row.value })),
+      ],
+      currency_code,
+    );
+    const footerValue = totalMoneyByCurrency(footerValueByCurrency);
 
     const onHandRow = await trx('stock_levels').where({ tenant }).sum<{ s: string }>('quantity_on_hand as s').first();
     const serCountRow = await trx('stock_units').where({ tenant, status: 'in_stock' }).count<{ c: string }>('* as c').first();
@@ -318,8 +356,9 @@ export const getInventoryDashboardData = withAuth(async (user, { tenant }): Prom
     const rma_receivables = await queryRmaReceivables(trx, tenant);
     const deployments = await queryDeployments(trx, tenant);
     const pipeline = await queryPipeline(trx, tenant);
-    const deadStock = await queryDeadStock(trx, tenant);
-    const wowDelta = await queryValueWowDelta(trx, tenant);
+    const deadStock = await queryDeadStock(trx, tenant, currency_code);
+    const wowDeltaByCurrency = await queryValueWowDeltaByCurrency(trx, tenant, currency_code);
+    const wowDelta = totalMoneyByCurrency(wowDeltaByCurrency);
     const overdueLoaners = await queryOverdueLoaners(trx, tenant);
     const countApprovals = await queryCountApprovals(trx, tenant);
     const billCreep = await queryBillCreep(trx, tenant);
@@ -822,7 +861,9 @@ export const getInventoryDashboardData = withAuth(async (user, { tenant }): Prom
       ghost_week: { count: ghost_week.count, est_total: ghost_week.est_total, techs: ghost_week.techs },
       footer: {
         value: footerValue,
+        value_by_currency: footerValueByCurrency,
         wow_delta: wowDelta,
+        wow_delta_by_currency: wowDeltaByCurrency,
         on_hand_units: Number(onHandRow?.s ?? 0),
         serialized_units: Number(serCountRow?.c ?? 0),
         dead_stock: deadStock,

--- a/packages/inventory/src/actions/inventoryDashboardActions.ts
+++ b/packages/inventory/src/actions/inventoryDashboardActions.ts
@@ -228,27 +228,25 @@ export const getInventoryDashboardData = withAuth(async (user, { tenant }): Prom
 
     /* ---- on-hand value + units (footer) ---- */
     const settingsCurrency = trx.raw("COALESCE(NULLIF(pis.cost_currency, ''), ?) as currency_code", [currency_code]);
-    const settingsCurrencyGroup = trx.raw("COALESCE(NULLIF(pis.cost_currency, ''), ?)", [currency_code]);
     const nonSerValueRows = await trx('stock_levels as sl')
       .join('product_inventory_settings as pis', function () {
         this.on('sl.service_id', '=', 'pis.service_id').andOn('sl.tenant', '=', 'pis.tenant');
       })
       .where({ 'sl.tenant': tenant, 'pis.is_serialized': false })
       .andWhere('sl.quantity_on_hand', '>', 0)
-      .groupBy(settingsCurrencyGroup)
+      .groupBy('currency_code')
       .select<{ currency_code: string | null; value: string }[]>(
         settingsCurrency,
         trx.raw('COALESCE(SUM(sl.quantity_on_hand * COALESCE(pis.average_cost, 0)),0) as value'),
       );
     const unitCurrency = trx.raw("COALESCE(NULLIF(su.cost_currency, ''), NULLIF(pis.cost_currency, ''), ?) as currency_code", [currency_code]);
-    const unitCurrencyGroup = trx.raw("COALESCE(NULLIF(su.cost_currency, ''), NULLIF(pis.cost_currency, ''), ?)", [currency_code]);
     const serValueRows = await trx('stock_units as su')
       .leftJoin('product_inventory_settings as pis', function () {
         this.on('su.service_id', '=', 'pis.service_id').andOn('su.tenant', '=', 'pis.tenant');
       })
       .where({ 'su.tenant': tenant, 'su.status': 'in_stock' })
       .whereNotNull('su.location_id')
-      .groupBy(unitCurrencyGroup)
+      .groupBy('currency_code')
       .select<{ currency_code: string | null; value: string }[]>(
         unitCurrency,
         trx.raw('COALESCE(SUM(COALESCE(su.unit_cost,0)),0) as value'),

--- a/packages/inventory/src/actions/inventoryReportingActions.ts
+++ b/packages/inventory/src/actions/inventoryReportingActions.ts
@@ -5,6 +5,7 @@ import { withTransaction, createTenantKnex, tenantDb } from '@alga-psa/db';
 import { withAuth } from '@alga-psa/auth';
 import { hasPermission } from '@alga-psa/auth/rbac';
 import { IPurchaseOrder, ISalesOrder } from '@alga-psa/types';
+import { resolveTenantCurrency } from '../lib/tenantCurrency';
 
 /**
  * Read-only inventory reporting + dashboard widgets. See design doc §10 / §11.
@@ -48,6 +49,7 @@ export interface InventoryValueLocationRow {
 export interface InventoryValueReport {
   by_location: InventoryValueLocationRow[];
   grand_total: number;
+  currency_code: string;
 }
 
 /**
@@ -60,6 +62,7 @@ export const inventoryValueReport = withAuth(async (user, { tenant }): Promise<I
   const { knex: db } = await createTenantKnex();
   return withTransaction(db, async (trx: Knex.Transaction) => {
     const scopedDb = tenantDb(trx, tenant);
+    const currency_code = await resolveTenantCurrency(trx, tenant);
     const valueByLocation = new Map<string, number>();
 
     // Non-serialized: on-hand × average_cost from stock_levels joined to settings.
@@ -103,7 +106,7 @@ export const inventoryValueReport = withAuth(async (user, { tenant }): Promise<I
       .sort((a, b) => a.location_name.localeCompare(b.location_name));
 
     const grand_total = by_location.reduce((sum, r) => sum + r.total_value, 0);
-    return { by_location, grand_total };
+    return { by_location, grand_total, currency_code };
   });
 });
 
@@ -204,11 +207,7 @@ export const marginReport = withAuth(
       const total_revenue_cents = rows.reduce((s, r) => s + r.revenue_cents, 0);
       const total_cogs_cents = rows.reduce((s, r) => s + r.cogs_cents, 0);
       const total_margin_cents = total_revenue_cents - total_cogs_cents;
-      const billingSettingsRow = await trx('default_billing_settings')
-        .where({ tenant })
-        .select<{ default_currency_code: string | null }>('default_currency_code')
-        .first();
-      const currency_code = billingSettingsRow?.default_currency_code || 'USD';
+      const currency_code = await resolveTenantCurrency(trx, tenant);
       return {
         rows,
         total_revenue_cents,
@@ -341,6 +340,7 @@ export interface WriteOffByUser {
 export interface WriteOffReportData {
   from: string;
   to: string;
+  currency_code: string;
   rows: WriteOffRow[];
   /** True when more events exist than the row cap; totals below still cover the FULL range. */
   truncated: boolean;
@@ -369,6 +369,7 @@ export const writeOffReport = withAuth(
     const { knex: db } = await createTenantKnex();
     return withTransaction(db, async (trx: Knex.Transaction) => {
       const scopedDb = tenantDb(trx, tenant);
+      const currency_code = await resolveTenantCurrency(trx, tenant);
       const to = opts?.to ? new Date(opts.to) : new Date();
       const from = opts?.from ? new Date(opts.from) : new Date(to.getTime() - 90 * 86_400_000);
       // End of the 'to' day, so a date-only input includes that whole day.
@@ -466,6 +467,7 @@ export const writeOffReport = withAuth(
       return {
         from: from.toISOString(),
         to: toEnd.toISOString(),
+        currency_code,
         rows,
         truncated,
         by_user,

--- a/packages/inventory/src/actions/landedCostActions.ts
+++ b/packages/inventory/src/actions/landedCostActions.ts
@@ -6,6 +6,7 @@ import { withAuth } from '@alga-psa/auth';
 import { hasPermission } from '@alga-psa/auth/rbac';
 import { IPoLandedCost, IPurchaseOrderLine } from '@alga-psa/types';
 import { recordStockMovement } from '../lib';
+import { resolveTenantCurrency } from '../lib';
 
 // NOTE: 'use server' file — export ONLY async functions (+ erased types).
 
@@ -47,6 +48,7 @@ export const addPoLandedCost = withAuth(
     input: {
       cost_type: 'freight' | 'duty' | 'other';
       amount: number; // cents
+      currency_code?: string | null;
       allocation_method?: 'value' | 'quantity';
       description?: string | null;
     },
@@ -60,13 +62,18 @@ export const addPoLandedCost = withAuth(
       const po = await trx('purchase_orders').where({ tenant, po_id: poId }).first();
       if (!po) throw new Error('Purchase order not found');
       if (po.status === 'cancelled') throw new Error('Cannot add landed cost to a cancelled purchase order');
+      const poCurrency = po.currency_code || await resolveTenantCurrency(trx, tenant);
+      const inputCurrency = input.currency_code?.trim();
+      if (inputCurrency && inputCurrency !== poCurrency) {
+        throw new Error(`Landed cost currency_code (${inputCurrency}) must match PO currency_code (${poCurrency})`);
+      }
       const [row] = await trx('po_landed_costs')
         .insert({
           tenant,
           po_id: poId,
           cost_type: input.cost_type,
           amount: input.amount,
-          currency_code: po.currency_code ?? 'USD', // landed costs share the PO currency
+          currency_code: poCurrency,
           allocation_method: input.allocation_method ?? 'value',
           description: input.description ?? null,
         })
@@ -112,11 +119,16 @@ export const applyPoLandedCosts = withAuth(
       // whole operation idempotent (F071).
       const po = await trx('purchase_orders').where({ tenant, po_id: poId }).forUpdate().first();
       if (!po) throw new Error('Purchase order not found');
+      const poCurrency = po.currency_code || await resolveTenantCurrency(trx, tenant);
 
       const entries = (await trx('po_landed_costs')
         .where({ tenant, po_id: poId, applied: false })
         .forUpdate()) as IPoLandedCost[];
       if (entries.length === 0) return { applied_entries: 0, total_applied_cents: 0, allocations: [] };
+      const mixedEntry = entries.find((entry) => entry.currency_code !== poCurrency);
+      if (mixedEntry) {
+        throw new Error(`Landed cost currency_code (${mixedEntry.currency_code}) must match PO currency_code (${poCurrency})`);
+      }
 
       const lines = (await trx('purchase_order_lines')
         .where({ tenant, po_id: poId })
@@ -189,7 +201,7 @@ export const applyPoLandedCosts = withAuth(
           service_id: l.service_id,
           quantity: 0,
           unit_cost: allocated,
-          cost_currency: po.currency_code ?? 'USD',
+          cost_currency: poCurrency,
           reason: `landed_cost: PO ${po.po_number} — ${allocated} cents allocated (${perUnit}/unit)`,
           source_doc_type: 'purchase_order',
           source_doc_id: poId,

--- a/packages/inventory/src/actions/productInventorySettingsActions.ts
+++ b/packages/inventory/src/actions/productInventorySettingsActions.ts
@@ -5,6 +5,7 @@ import { withTransaction, createTenantKnex } from '@alga-psa/db';
 import { withAuth } from '@alga-psa/auth';
 import { hasPermission } from '@alga-psa/auth/rbac';
 import { IProductInventorySettings, KitPricingMode } from '@alga-psa/types';
+import { resolveTenantCurrency } from '../lib';
 
 async function requireInvPerm(user: any, action: 'create' | 'read' | 'update' | 'delete'): Promise<void> {
   if (!(await hasPermission(user, 'inventory', action))) {
@@ -108,6 +109,7 @@ export const enableInventory = withAuth(
     const { knex: db } = await createTenantKnex();
     return withTransaction(db, async (trx: Knex.Transaction) => {
       const { cost_currency } = await assertProduct(trx, tenant, serviceId);
+      const defaultCurrency = await resolveTenantCurrency(trx, tenant);
 
       // Default preferred vendor from the legacy freeform service_catalog.vendor, if it maps to a vendor.
       const svc = await trx('service_catalog').where({ tenant, service_id: serviceId }).select('vendor').first();
@@ -130,7 +132,7 @@ export const enableInventory = withAuth(
           creates_asset_on_delivery: input?.creates_asset_on_delivery ?? false,
           reorder_point: input?.reorder_point ?? null,
           reorder_quantity: input?.reorder_quantity ?? null,
-          cost_currency: cost_currency ?? 'USD',
+          cost_currency: cost_currency ?? defaultCurrency,
           default_location_id: input?.default_location_id ?? null,
           preferred_vendor_id: preferredVendorId,
         })

--- a/packages/inventory/src/actions/purchaseOrderActions.ts
+++ b/packages/inventory/src/actions/purchaseOrderActions.ts
@@ -396,6 +396,13 @@ export const submitPurchaseOrder = withAuth(
       if (po.status !== 'draft') throw new Error(`Only draft purchase orders can be submitted (current: ${po.status})`);
       const lineCount = await trx('purchase_order_lines').where({ tenant, po_id: poId }).count<{ c: string }>('* as c').first();
       if (Number(lineCount?.c ?? 0) === 0) throw new Error('Cannot submit a purchase order with no lines');
+      const mixedLine = await trx('purchase_order_lines')
+        .where({ tenant, po_id: poId })
+        .andWhere('cost_currency', '<>', po.currency_code)
+        .first();
+      if (mixedLine) {
+        throw new Error(`Line cost_currency (${mixedLine.cost_currency}) must match PO currency_code (${po.currency_code})`);
+      }
 
       const [row] = await trx('purchase_orders')
         .where({ tenant, po_id: poId })

--- a/packages/inventory/src/actions/reorderActions.ts
+++ b/packages/inventory/src/actions/reorderActions.ts
@@ -5,7 +5,7 @@ import { withTransaction, createTenantKnex } from '@alga-psa/db';
 import { withAuth } from '@alga-psa/auth';
 import { hasPermission } from '@alga-psa/auth/rbac';
 import { IPurchaseOrder } from '@alga-psa/types';
-import { availableQuantity } from '../lib';
+import { availableQuantity, resolveTenantCurrency } from '../lib';
 
 async function requireInvPerm(user: any, action: 'create' | 'read' | 'update' | 'delete'): Promise<void> {
   if (!(await hasPermission(user, 'inventory', action))) {
@@ -150,6 +150,7 @@ export const createPoFromLowStock = withAuth(async (user, { tenant }): Promise<C
   const { knex: db } = await createTenantKnex();
   return withTransaction(db, async (trx: Knex.Transaction) => {
     const skipped: LowStockRow[] = [];
+    const defaultCurrency = await resolveTenantCurrency(trx, tenant);
 
     /**
      * Cost basis for a suggested line: the preferred vendor's price-list offer
@@ -160,7 +161,7 @@ export const createPoFromLowStock = withAuth(async (user, { tenant }): Promise<C
         .where({ tenant, service_id: serviceId, is_preferred: true })
         .first();
       if (offer?.unit_cost != null) {
-        return { unitCost: Number(offer.unit_cost), currency: offer.cost_currency ?? 'USD' };
+        return { unitCost: Number(offer.unit_cost), currency: offer.cost_currency ?? defaultCurrency };
       }
       const pis = await trx('product_inventory_settings')
         .where({ tenant, service_id: serviceId })
@@ -172,7 +173,7 @@ export const createPoFromLowStock = withAuth(async (user, { tenant }): Promise<C
         .first();
       return {
         unitCost: Number(pis?.average_cost ?? sc?.cost ?? 0),
-        currency: pis?.cost_currency ?? sc?.cost_currency ?? 'USD',
+        currency: pis?.cost_currency ?? sc?.cost_currency ?? defaultCurrency,
       };
     };
 

--- a/packages/inventory/src/actions/rmaActions.ts
+++ b/packages/inventory/src/actions/rmaActions.ts
@@ -6,6 +6,7 @@ import { withAuth } from '@alga-psa/auth';
 import { hasPermission } from '@alga-psa/auth/rbac';
 import { IRmaCase, IStockUnit, RmaStatus } from '@alga-psa/types';
 import { publishInventoryEvent, recordStockMovement, timestampPayload } from '../lib';
+import { resolveTenantCurrency } from '../lib';
 
 /**
  * RMA / return-path lifecycle (design §6.G).
@@ -124,6 +125,7 @@ async function createInStockUnit(
     .where({ tenant, service_id: serviceId })
     .select('cost_currency')
     .first();
+  const defaultCurrency = await resolveTenantCurrency(trx, tenant);
 
   const [row] = await trx('stock_units')
     .insert({
@@ -134,7 +136,7 @@ async function createInStockUnit(
       status: 'in_stock',
       location_id: input.location_id,
       unit_cost: input.unit_cost ?? null,
-      cost_currency: input.cost_currency ?? settings?.cost_currency ?? 'USD',
+      cost_currency: input.cost_currency ?? settings?.cost_currency ?? defaultCurrency,
       warranty_expires_at: input.warranty_expires_at ?? null,
       warranty_term: input.warranty_term ?? null,
       received_at: trx.fn.now(),

--- a/packages/inventory/src/actions/salesOrderLinkActions.ts
+++ b/packages/inventory/src/actions/salesOrderLinkActions.ts
@@ -10,6 +10,7 @@ export interface SalesOrderInvoiceLink {
   invoice_number: string | null;
   status: string | null;
   total_amount: number; // cents
+  currency_code: string | null;
   created_at: string; // ISO
 }
 
@@ -59,6 +60,7 @@ export const listSalesOrderInvoices = withAuth(async (
         'i.status',
         'i.finalized_at',
         'i.total_amount',
+        'i.currency_code',
         'i.created_at'
       )
       .orderBy('i.created_at', 'desc');
@@ -72,6 +74,7 @@ export const listSalesOrderInvoices = withAuth(async (
         ? 'finalized'
         : ((row.status as string | null) ?? null),
       total_amount: Number(row.total_amount ?? 0),
+      currency_code: (row.currency_code as string | null) ?? null,
       created_at: toIsoString(row.created_at),
     }));
   });

--- a/packages/inventory/src/actions/vendorBillActions.ts
+++ b/packages/inventory/src/actions/vendorBillActions.ts
@@ -5,6 +5,7 @@ import { withTransaction, createTenantKnex } from '@alga-psa/db';
 import { withAuth } from '@alga-psa/auth';
 import { hasPermission } from '@alga-psa/auth/rbac';
 import { IVendorBill, IVendorBillLine, VendorBillStatus } from '@alga-psa/types';
+import { resolveTenantCurrency } from '../lib';
 
 // NOTE: 'use server' file — export ONLY async functions (+ erased types).
 
@@ -173,9 +174,11 @@ export const createVendorBill = withAuth(
         ? new Date(input.due_date)
         : new Date(billDate.getTime() + termsToDays(vendor.payment_terms) * 24 * 60 * 60 * 1000);
 
-      const currency = (await (input.po_id
-        ? trx('purchase_orders').where({ tenant, po_id: input.po_id }).first()
-        : Promise.resolve(null)))?.currency_code ?? 'USD';
+      const po = input.po_id
+        ? await trx('purchase_orders').where({ tenant, po_id: input.po_id }).first()
+        : null;
+      if (input.po_id && !po) throw new Error('Purchase order not found');
+      const currency = po?.currency_code ?? await resolveTenantCurrency(trx, tenant);
 
       const lines = (input.lines ?? []).map((l) => {
         const quantity = Number(l.quantity);

--- a/packages/inventory/src/actions/vendorProductActions.ts
+++ b/packages/inventory/src/actions/vendorProductActions.ts
@@ -5,6 +5,7 @@ import { withTransaction, createTenantKnex } from '@alga-psa/db';
 import { withAuth } from '@alga-psa/auth';
 import { hasPermission } from '@alga-psa/auth/rbac';
 import { IVendorProduct } from '@alga-psa/types';
+import { resolveTenantCurrency } from '../lib';
 
 // NOTE: 'use server' file — export ONLY async functions (+ erased types).
 
@@ -67,6 +68,7 @@ export const upsertVendorProduct = withAuth(
     }
     const { knex: db } = await createTenantKnex();
     return withTransaction(db, async (trx: Knex.Transaction) => {
+      const costCurrency = input.cost_currency?.trim() || await resolveTenantCurrency(trx, tenant);
       if (input.is_preferred) {
         // Single preferred offer per product (backed by the partial unique index).
         await trx('vendor_products')
@@ -81,7 +83,7 @@ export const upsertVendorProduct = withAuth(
           service_id: input.service_id,
           vendor_sku: input.vendor_sku?.trim() || null,
           unit_cost: input.unit_cost ?? null,
-          cost_currency: (input.cost_currency ?? 'USD').trim() || 'USD',
+          cost_currency: costCurrency,
           lead_time_days: input.lead_time_days ?? null,
           is_preferred: input.is_preferred ?? false,
         })
@@ -89,7 +91,7 @@ export const upsertVendorProduct = withAuth(
         .merge({
           vendor_sku: input.vendor_sku?.trim() || null,
           unit_cost: input.unit_cost ?? null,
-          cost_currency: (input.cost_currency ?? 'USD').trim() || 'USD',
+          cost_currency: costCurrency,
           lead_time_days: input.lead_time_days ?? null,
           is_preferred: input.is_preferred ?? false,
           updated_at: trx.fn.now(),

--- a/packages/inventory/src/components/CycleCountsManager.tsx
+++ b/packages/inventory/src/components/CycleCountsManager.tsx
@@ -8,6 +8,7 @@ import { TextArea } from '@alga-psa/ui/components/TextArea';
 import { Badge, type BadgeVariant } from '@alga-psa/ui/components/Badge';
 import CustomSelect from '@alga-psa/ui/components/CustomSelect';
 import { Dialog } from '@alga-psa/ui/components/Dialog';
+import { useCurrencyFormat } from '@alga-psa/ui/lib';
 import { useTranslation } from '@alga-psa/ui/lib/i18n/client';
 import { toast } from 'react-hot-toast';
 import type { ColumnDefinition, ICountSession, IStockLocation } from '@alga-psa/types';
@@ -26,16 +27,17 @@ import {
 
 type SessionRow = ICountSession & { location_name: string | null; line_count: number; counted_count: number };
 
-const dollars = (cents: number): string => `$${(cents / 100).toFixed(2)}`;
-
 export function CycleCountsManager({
   initialSessions,
   locations,
+  defaultCurrencyCode = 'USD',
 }: {
   initialSessions: SessionRow[];
   locations: IStockLocation[];
+  defaultCurrencyCode?: string;
 }) {
   const { t } = useTranslation('features/inventory');
+  const { money } = useCurrencyFormat();
   const [sessions, setSessions] = useState<SessionRow[]>(initialSessions || []);
   const [startOpen, setStartOpen] = useState(false);
   const [startLocation, setStartLocation] = useState('');
@@ -340,7 +342,7 @@ export function CycleCountsManager({
                               <span className={line.variance === 0 ? 'text-gray-500' : line.variance > 0 ? 'text-green-700' : 'text-red-700'}>
                                 {' '}{t('counts.varianceLabel', '· variance')} {line.variance > 0 ? '+' : ''}
                                 {line.variance}
-                                {line.variance_value_cents != null && line.variance !== 0 && ` (${dollars(line.variance_value_cents)})`}
+                                {line.variance_value_cents != null && line.variance !== 0 && ` (${money(line.variance_value_cents, line.cost_currency ?? defaultCurrencyCode)})`}
                               </span>
                             )}
                           </span>

--- a/packages/inventory/src/components/ImportOpeningBalances.tsx
+++ b/packages/inventory/src/components/ImportOpeningBalances.tsx
@@ -6,6 +6,7 @@ import { Input } from '@alga-psa/ui/components/Input';
 import { Checkbox } from '@alga-psa/ui/components/Checkbox';
 import { Dialog } from '@alga-psa/ui/components/Dialog';
 import { useTranslation } from '@alga-psa/ui/lib/i18n/client';
+import { useCurrencyFormat } from '@alga-psa/ui/lib';
 import { toast } from 'react-hot-toast';
 import {
   validateOpeningBalanceImport,
@@ -27,14 +28,18 @@ const TEMPLATE_CSV = [
   'YLNK-T46U,,Dmitri Van,4,,805EC0AABBCC,155.00',
 ].join('\n');
 
-const dollars = (cents: number): string =>
-  `$${(cents / 100).toLocaleString(undefined, { minimumFractionDigits: 2, maximumFractionDigits: 2 })}`;
-
 const MAX_LISTED_ISSUES = 20;
 const MAX_SAMPLE_ROWS = 8;
 
-export function ImportOpeningBalances({ onApplied }: { onApplied?: () => void | Promise<void> }) {
+export function ImportOpeningBalances({
+  onApplied,
+  defaultCurrencyCode = 'USD',
+}: {
+  onApplied?: () => void | Promise<void>;
+  defaultCurrencyCode?: string;
+}) {
   const { t } = useTranslation('features/inventory');
+  const { money } = useCurrencyFormat();
   const [open, setOpen] = useState(false);
   const [csvText, setCsvText] = useState('');
   const [fileName, setFileName] = useState('');
@@ -122,7 +127,7 @@ export function ImportOpeningBalances({ onApplied }: { onApplied?: () => void | 
         t('import_.apply.success', 'Imported {{receipts}} ({{units}}, {{value}}) as "{{label}}".', {
           receipts: receiptsText,
           units: unitsText,
-          value: dollars(result.total_value_cents),
+          value: money(result.total_value_cents, defaultCurrencyCode),
           label: result.batch_label,
         }),
       );
@@ -222,7 +227,7 @@ export function ImportOpeningBalances({ onApplied }: { onApplied?: () => void | 
                   <span className="text-gray-500">{t('import_.summary.bulkQuantity', 'Bulk quantity:')}</span> <b>{preview.summary.bulk_quantity}</b>
                 </span>
                 <span>
-                  <span className="text-gray-500">{t('import_.summary.value', 'Value:')}</span> <b>{dollars(preview.summary.total_value_cents)}</b>
+                  <span className="text-gray-500">{t('import_.summary.value', 'Value:')}</span> <b>{money(preview.summary.total_value_cents, defaultCurrencyCode)}</b>
                 </span>
                 {preview.summary.settings_to_create > 0 && (
                   <span className="text-amber-700">
@@ -288,7 +293,7 @@ export function ImportOpeningBalances({ onApplied }: { onApplied?: () => void | 
                         <td className="py-1 px-2 text-right tabular-nums">{r.quantity}</td>
                         <td className="py-1 px-2 font-mono text-xs">{r.serial_number || t('common.emptyValue', '—')}</td>
                         <td className="py-1 pl-2 text-right tabular-nums">
-                          {r.unit_cost_cents != null ? dollars(r.unit_cost_cents) : t('common.emptyValue', '—')}
+                          {r.unit_cost_cents != null ? money(r.unit_cost_cents, defaultCurrencyCode) : t('common.emptyValue', '—')}
                         </td>
                       </tr>
                     ))}

--- a/packages/inventory/src/components/InventoryDashboard.tsx
+++ b/packages/inventory/src/components/InventoryDashboard.tsx
@@ -54,7 +54,9 @@ const EMPTY: InventoryDashboardData = {
   ghost_week: { count: 0, est_total: null, techs: [] },
   footer: {
     value: 0,
+    value_by_currency: [],
     wow_delta: 0,
+    wow_delta_by_currency: [],
     on_hand_units: 0,
     serialized_units: 0,
     dead_stock: null,

--- a/packages/inventory/src/components/LoanersManager.tsx
+++ b/packages/inventory/src/components/LoanersManager.tsx
@@ -4,10 +4,12 @@ import React, { useState, useCallback, useEffect } from 'react';
 import { DataTable } from '@alga-psa/ui/components/DataTable';
 import { Button } from '@alga-psa/ui/components/Button';
 import { Input } from '@alga-psa/ui/components/Input';
+import { CurrencyInput } from '@alga-psa/ui/components/CurrencyInput';
 import CustomSelect from '@alga-psa/ui/components/CustomSelect';
 import { Dialog } from '@alga-psa/ui/components/Dialog';
 import { useTranslation } from '@alga-psa/ui/lib/i18n/client';
 import { toast } from 'react-hot-toast';
+import { toMinorUnits } from '@alga-psa/core';
 import type { ColumnDefinition, IStockLocation } from '@alga-psa/types';
 import {
   loanOut,
@@ -24,7 +26,13 @@ function formatDue(value: string | Date | null): string {
   return Number.isNaN(d.getTime()) ? String(value) : d.toLocaleDateString();
 }
 
-export function LoanersManager({ initialLoaners }: { initialLoaners: LoanerOutRow[] }) {
+export function LoanersManager({
+  initialLoaners,
+  defaultCurrencyCode = 'USD',
+}: {
+  initialLoaners: LoanerOutRow[];
+  defaultCurrencyCode?: string;
+}) {
   const { t } = useTranslation('features/inventory');
   const [rows, setRows] = useState<LoanerOutRow[]>(initialLoaners || []);
   const [locations, setLocations] = useState<IStockLocation[]>([]);
@@ -147,7 +155,7 @@ export function LoanersManager({ initialLoaners }: { initialLoaners: LoanerOutRo
         toast.error(t('loaners.restockFeeInvalid', 'Restocking fee must be a non-negative amount'));
         return;
       }
-      restocking_fee_cents = Math.round(parsed * 100);
+      restocking_fee_cents = toMinorUnits(parsed, undefined, defaultCurrencyCode);
     }
     setSaving(true);
     try {
@@ -297,14 +305,12 @@ export function LoanersManager({ initialLoaners }: { initialLoaners: LoanerOutRo
             ]}
             onValueChange={(v: string) => setRestockForm({ ...restockForm, location_id: v })}
           />
-          <Input
+          <CurrencyInput
             id="loaner-restock-fee"
             label={t('loaners.fields.restockingFee', 'Restocking fee (optional)')}
-            type="number"
-            min="0"
-            step="0.01"
-            value={restockForm.restocking_fee}
-            onChange={(e) => setRestockForm({ ...restockForm, restocking_fee: e.target.value })}
+            currencyCode={defaultCurrencyCode}
+            value={restockForm.restocking_fee ? Number(restockForm.restocking_fee) : undefined}
+            onChange={(value) => setRestockForm({ ...restockForm, restocking_fee: value == null ? '' : String(value) })}
           />
           <div className="flex justify-end gap-2 pt-2">
             <Button id="loaner-restock-cancel" variant="outline" onClick={() => setRestockOpen(false)}>

--- a/packages/inventory/src/components/MarginReport.tsx
+++ b/packages/inventory/src/components/MarginReport.tsx
@@ -42,9 +42,9 @@ function MarginReportBody({
       ),
     },
     { title: t('margin.columns.qtySold', 'Qty sold'), dataIndex: 'qty_sold', render: (v: any) => <span className="tabular-nums">{Number(v ?? 0)}</span> },
-    { title: t('margin.columns.revenue', 'Revenue'), dataIndex: 'revenue_cents', render: (v: any) => <span className="tabular-nums">{money(v, 2)}</span> },
-    { title: t('margin.columns.cogs', 'COGS'), dataIndex: 'cogs_cents', render: (v: any) => <span className="tabular-nums">{money(v, 2)}</span> },
-    { title: t('margin.columns.margin', 'Margin'), dataIndex: 'margin_cents', render: (v: any) => <span className="tabular-nums">{money(v, 2)}</span> },
+    { title: t('margin.columns.revenue', 'Revenue'), dataIndex: 'revenue_cents', render: (v: any) => <span className="tabular-nums">{money(v)}</span> },
+    { title: t('margin.columns.cogs', 'COGS'), dataIndex: 'cogs_cents', render: (v: any) => <span className="tabular-nums">{money(v)}</span> },
+    { title: t('margin.columns.margin', 'Margin'), dataIndex: 'margin_cents', render: (v: any) => <span className="tabular-nums">{money(v)}</span> },
     { title: t('margin.columns.marginPct', 'Margin %'), dataIndex: 'margin_pct', render: (v: any) => <span className="tabular-nums">{pct(t, v)}</span> },
   ];
 
@@ -53,15 +53,15 @@ function MarginReportBody({
       <div className="grid grid-cols-2 gap-3 md:grid-cols-4" id="margin-report-totals">
         <div className="rounded border p-3">
           <div className="text-xs text-gray-500">{t('margin.metrics.revenue', 'Revenue')}</div>
-          <div className="text-xl font-semibold tabular-nums">{money(report.total_revenue_cents, 2)}</div>
+          <div className="text-xl font-semibold tabular-nums">{money(report.total_revenue_cents)}</div>
         </div>
         <div className="rounded border p-3">
           <div className="text-xs text-gray-500">{t('margin.metrics.cogs', 'COGS')}</div>
-          <div className="text-xl font-semibold tabular-nums">{money(report.total_cogs_cents, 2)}</div>
+          <div className="text-xl font-semibold tabular-nums">{money(report.total_cogs_cents)}</div>
         </div>
         <div className="rounded border p-3">
           <div className="text-xs text-gray-500">{t('margin.metrics.margin', 'Margin')}</div>
-          <div className="text-xl font-semibold tabular-nums">{money(report.total_margin_cents, 2)}</div>
+          <div className="text-xl font-semibold tabular-nums">{money(report.total_margin_cents)}</div>
         </div>
         <div className="rounded border p-3">
           <div className="text-xs text-gray-500">{t('margin.metrics.marginPct', 'Margin %')}</div>

--- a/packages/inventory/src/components/PoLandedCostDialog.tsx
+++ b/packages/inventory/src/components/PoLandedCostDialog.tsx
@@ -4,18 +4,19 @@ import React, { useState, useEffect, useCallback, useMemo } from 'react';
 import { Dialog } from '@alga-psa/ui/components/Dialog';
 import { Button } from '@alga-psa/ui/components/Button';
 import { Input } from '@alga-psa/ui/components/Input';
+import { CurrencyInput } from '@alga-psa/ui/components/CurrencyInput';
 import { Badge } from '@alga-psa/ui/components/Badge';
 import CustomSelect from '@alga-psa/ui/components/CustomSelect';
+import { toMinorUnits } from '@alga-psa/core';
+import { useCurrencyFormat } from '@alga-psa/ui/lib';
 import { useTranslation } from '@alga-psa/ui/lib/i18n/client';
 import { toast } from 'react-hot-toast';
 import type { IPurchaseOrder, IPurchaseOrderLine, IPoLandedCost } from '@alga-psa/types';
 import { listPoLandedCosts, addPoLandedCost, removePoLandedCost, applyPoLandedCosts, getPurchaseOrder } from '../actions';
 
-const money = (cents: number, currency: string): string => `$${(cents / 100).toFixed(2)} ${currency}`;
-
 interface EntryForm {
   cost_type: 'freight' | 'duty' | 'other';
-  amount: string; // dollars
+  amount: string; // major units, converted to integer minor units on save
   allocation_method: 'value' | 'quantity';
   description: string;
 }
@@ -39,6 +40,7 @@ export function PoLandedCostDialog({
   productName: (serviceId: string) => string;
 }) {
   const { t } = useTranslation('features/inventory');
+  const { money } = useCurrencyFormat();
   // Localized display labels for the entry enums. The stored values ('freight'/'value'/…)
   // stay raw in state and requests; only the table text is translated. Unknown values fall
   // back to the raw value so behavior never regresses.
@@ -90,6 +92,7 @@ export function PoLandedCostDialog({
   const unapplied = entries.filter((e) => !e.applied);
   const appliedTotal = entries.filter((e) => e.applied).reduce((s, e) => s + Number(e.amount), 0);
   const unappliedTotal = unapplied.reduce((s, e) => s + Number(e.amount), 0);
+  const currency = po?.currency_code ?? 'USD';
 
   // Estimated allocation preview for the unapplied entries — same weights the server uses.
   const preview = useMemo(() => {
@@ -123,8 +126,9 @@ export function PoLandedCostDialog({
     try {
       await addPoLandedCost(po.po_id, {
         cost_type: form.cost_type,
-        amount: Math.round(dollars * 100),
+        amount: toMinorUnits(dollars, undefined, currency),
         allocation_method: form.allocation_method,
+        currency_code: currency,
         description: form.description.trim() || null,
       });
       toast.success(t('poLandedCost.entryAdded', 'Landed-cost entry added.'));
@@ -172,8 +176,6 @@ export function PoLandedCostDialog({
       setBusy(null);
     }
   };
-
-  const currency = po?.currency_code ?? 'USD';
 
   return (
     <Dialog
@@ -250,12 +252,12 @@ export function PoLandedCostDialog({
                 { value: 'other', label: t('poLandedCost.costType.other', 'Other') },
               ]}
             />
-            <Input
+            <CurrencyInput
               id="landed-cost-amount"
-              label={t('poLandedCost.fields.amount', 'Amount ($ {{currency}})', { currency })}
-              type="number"
-              value={form.amount}
-              onChange={(e) => setForm({ ...form, amount: e.target.value })}
+              label={t('poLandedCost.fields.amount', 'Amount ({{currency}})', { currency })}
+              currencyCode={currency}
+              value={form.amount ? Number(form.amount) : undefined}
+              onChange={(value) => setForm({ ...form, amount: value == null ? '' : String(value) })}
             />
             <CustomSelect
               id="landed-cost-method"

--- a/packages/inventory/src/components/PurchaseOrdersManager.tsx
+++ b/packages/inventory/src/components/PurchaseOrdersManager.tsx
@@ -7,10 +7,13 @@ import { Input } from '@alga-psa/ui/components/Input';
 import { SearchInput } from '@alga-psa/ui/components/SearchInput';
 import { TextArea } from '@alga-psa/ui/components/TextArea';
 import { Dialog } from '@alga-psa/ui/components/Dialog';
+import { CurrencyInput } from '@alga-psa/ui/components/CurrencyInput';
 import CustomSelect from '@alga-psa/ui/components/CustomSelect';
 import { Badge } from '@alga-psa/ui/components/Badge';
 import { EmptyState } from '@alga-psa/ui/components/EmptyState';
 import { ConfirmationDialog } from '@alga-psa/ui/components/ConfirmationDialog';
+import { CURRENCY_OPTIONS, toMinorUnits } from '@alga-psa/core';
+import { useCurrencyFormat } from '@alga-psa/ui/lib';
 import { useTranslation } from '@alga-psa/ui/lib/i18n/client';
 import { toast } from 'react-hot-toast';
 import { PoLandedCostDialog } from './PoLandedCostDialog';
@@ -56,9 +59,9 @@ interface FormState {
 
 const emptyLine = (): LineForm => ({ service_id: '', quantity_ordered: '1', unit_cost: '0' });
 
-const emptyForm = (): FormState => ({
+const emptyForm = (currencyCode: string): FormState => ({
   vendor_id: '',
-  currency_code: 'USD',
+  currency_code: currencyCode,
   expected_date: '',
   lines: [emptyLine()],
 });
@@ -76,15 +79,6 @@ function formatDate(value?: string | Date | null): string {
   if (!value) return '';
   const d = new Date(value);
   return Number.isNaN(d.getTime()) ? String(value) : d.toLocaleDateString();
-}
-
-/** Integer cents → a localized currency string in the PO's currency. */
-function money(cents: number, currency = 'USD'): string {
-  try {
-    return (cents / 100).toLocaleString('en-US', { style: 'currency', currency });
-  } catch {
-    return `$${(cents / 100).toFixed(2)}`;
-  }
 }
 
 const NUM_HEADER = 'text-right';
@@ -126,18 +120,14 @@ const OUTSTANDING_STATUSES = new Set(['open', 'partially_received']);
 export function PurchaseOrdersManager({
   initialPos,
   loadError = false,
+  defaultCurrencyCode = 'USD',
 }: {
   initialPos: PurchaseOrderListRow[];
   loadError?: boolean;
+  defaultCurrencyCode?: string;
 }) {
   const { t } = useTranslation('features/inventory');
-  // Closed currency set — the create form picks from these instead of free-typing a code.
-  const CURRENCY_OPTIONS = [
-    { value: 'USD', label: t('purchaseOrders.currency.usd', 'USD — US Dollar') },
-    { value: 'CAD', label: t('purchaseOrders.currency.cad', 'CAD — Canadian Dollar') },
-    { value: 'EUR', label: t('purchaseOrders.currency.eur', 'EUR — Euro') },
-    { value: 'GBP', label: t('purchaseOrders.currency.gbp', 'GBP — British Pound') },
-  ];
+  const { money } = useCurrencyFormat();
   const STATUS_FILTER_OPTIONS = [
     { value: '', label: t('purchaseOrders.status.allStatuses', 'All statuses') },
     { value: 'draft', label: t('purchaseOrders.status.draft', 'Draft') },
@@ -166,7 +156,7 @@ export function PurchaseOrdersManager({
   const [statusFilter, setStatusFilter] = useState('');
   const [vendorFilter, setVendorFilter] = useState('');
   const [dialogOpen, setDialogOpen] = useState(false);
-  const [form, setForm] = useState<FormState>(emptyForm());
+  const [form, setForm] = useState<FormState>(emptyForm(defaultCurrencyCode));
   const [saving, setSaving] = useState(false);
   const [pendingCancel, setPendingCancel] = useState<IPurchaseOrder | null>(null);
   const [landedCostPo, setLandedCostPo] = useState<IPurchaseOrder | null>(null);
@@ -233,7 +223,7 @@ export function PurchaseOrdersManager({
   }));
 
   const openCreate = () => {
-    setForm(emptyForm());
+    setForm(emptyForm(defaultCurrencyCode));
     setDialogOpen(true);
   };
 
@@ -263,8 +253,7 @@ export function PurchaseOrdersManager({
       .map((l) => ({
         service_id: l.service_id.trim(),
         quantity_ordered: Number(l.quantity_ordered),
-        // Money is integer cents: convert the dollar input to cents.
-        unit_cost: Math.round(Number(l.unit_cost) * 100),
+        unit_cost: toMinorUnits(Number(l.unit_cost || 0), undefined, form.currency_code),
       }));
     for (const l of lines) {
       if (!(l.quantity_ordered > 0)) {
@@ -511,8 +500,12 @@ export function PurchaseOrdersManager({
 
   // Money currently on order — the at-a-glance number for "what's outstanding".
   const outstanding = pos.filter((p) => OUTSTANDING_STATUSES.has(p.status));
-  const openTotal = outstanding.reduce((sum, p) => sum + Number(p.total_amount ?? 0), 0);
-  const openCurrency = outstanding[0]?.currency_code ?? 'USD';
+  const outstandingCurrencies = new Set(outstanding.map((p) => p.currency_code || defaultCurrencyCode));
+  const canShowOpenTotal = outstandingCurrencies.size <= 1;
+  const openCurrency = outstanding[0]?.currency_code ?? defaultCurrencyCode;
+  const openTotal = canShowOpenTotal
+    ? outstanding.reduce((sum, p) => sum + Number(p.total_amount ?? 0), 0)
+    : 0;
   const filtersActive = Boolean(q || statusFilter || vendorFilter);
 
   const vendorFilterOptions = [
@@ -537,7 +530,12 @@ export function PurchaseOrdersManager({
                 ? t('purchaseOrders.count', '{{count}} purchase order', { count: pos.length })
                 : t('purchaseOrders.countPlural', '{{count}} purchase orders', { count: pos.length })}
               {outstanding.length > 0 && (
-                <span className="font-medium text-gray-700"> · {t('purchaseOrders.amountOnOrder', '{{amount}} on order', { amount: money(openTotal, openCurrency) })}</span>
+                <span className="font-medium text-gray-700">
+                  {' '}
+                  · {canShowOpenTotal
+                    ? t('purchaseOrders.amountOnOrder', '{{amount}} on order', { amount: money(openTotal, openCurrency) })
+                    : t('purchaseOrders.mixedCurrencyOnOrder', '{{count}} purchase orders on order across multiple currencies', { count: outstanding.length })}
+                </span>
               )}
             </p>
           )}
@@ -641,7 +639,7 @@ export function PurchaseOrdersManager({
               required
               value={form.currency_code}
               onValueChange={(value) => setForm({ ...form, currency_code: value })}
-              options={CURRENCY_OPTIONS}
+              options={CURRENCY_OPTIONS.map((option) => ({ value: option.value, label: option.label }))}
             />
             <Input
               id="purchase-order-expected-date"
@@ -664,7 +662,7 @@ export function PurchaseOrdersManager({
             <div className="flex gap-2 items-center text-xs font-medium text-gray-600">
               <div className="flex-1">{t('purchaseOrders.columns.product', 'Product')}</div>
               <div className="w-24 text-right">{t('purchaseOrders.columns.qty', 'Qty')}</div>
-              <div className="w-32 text-right">{t('purchaseOrders.columns.unitCost', 'Unit cost ($)')}</div>
+              <div className="w-32 text-right">{t('purchaseOrders.columns.unitCost', 'Unit cost')}</div>
               <div className="w-20" />
             </div>
             {form.lines.map((line, idx) => (
@@ -690,14 +688,12 @@ export function PurchaseOrdersManager({
                   />
                 </div>
                 <div className="w-32">
-                  <Input
+                  <CurrencyInput
                     id={`purchase-order-line-cost-${idx}`}
-                    type="number"
-                    min="0"
-                    step="0.01"
+                    currencyCode={form.currency_code}
                     className="text-right tabular-nums"
-                    value={line.unit_cost}
-                    onChange={(e) => updateLine(idx, { unit_cost: e.target.value })}
+                    value={Number(line.unit_cost || 0)}
+                    onChange={(value) => updateLine(idx, { unit_cost: value == null ? '' : String(value) })}
                   />
                 </div>
                 <Button

--- a/packages/inventory/src/components/SalesOrderDetail.tsx
+++ b/packages/inventory/src/components/SalesOrderDetail.tsx
@@ -7,6 +7,7 @@ import { Input } from '@alga-psa/ui/components/Input';
 import { Badge, type BadgeVariant } from '@alga-psa/ui/components/Badge';
 import CustomSelect from '@alga-psa/ui/components/CustomSelect';
 import { Checkbox } from '@alga-psa/ui/components/Checkbox';
+import { useCurrencyFormat } from '@alga-psa/ui/lib';
 import { useTranslation } from '@alga-psa/ui/lib/i18n/client';
 import { toast } from 'react-hot-toast';
 import type { ISalesOrder, IStockLocation, IVendor } from '@alga-psa/types';
@@ -68,9 +69,6 @@ const STATUS_VARIANTS: Record<string, BadgeVariant> = {
   cancelled: 'error',
 };
 
-const dollars = (cents?: number | null): string =>
-  cents == null ? '—' : `$${(Number(cents) / 100).toFixed(2)}`;
-
 const remainingOf = (l: SalesOrderLineDetail): number =>
   Math.max(0, Number(l.quantity_ordered) - Number(l.quantity_fulfilled ?? 0));
 
@@ -100,6 +98,7 @@ export function SalesOrderDetail({
   confirmDropShip,
 }: SalesOrderDetailProps) {
   const { t } = useTranslation('features/inventory');
+  const { money } = useCurrencyFormat();
   const statusLabel = (status: string): string => {
     switch (status) {
       case 'draft':
@@ -575,7 +574,9 @@ export function SalesOrderDetail({
                       <td className="py-2 px-2 text-right tabular-nums">{Number(line.quantity_ordered)}</td>
                       <td className="py-2 px-2 text-right tabular-nums">{Number(line.quantity_fulfilled ?? 0)}</td>
                       <td className="py-2 px-2 text-right tabular-nums">{Number(line.quantity_invoiced ?? 0)}</td>
-                      <td className="py-2 px-2 text-right tabular-nums">{dollars(line.unit_price)}</td>
+                      <td className="py-2 px-2 text-right tabular-nums">
+                        {line.unit_price == null ? t('common.emptyValue', '—') : money(line.unit_price, so.currency_code)}
+                      </td>
                       <td className="py-2 px-2">
                         {bo?.backordered ? (
                           <Badge variant="error" size="sm">
@@ -657,7 +658,9 @@ export function SalesOrderDetail({
                           </a>
                         </td>
                         <td className="py-2 px-2">{inv.status || t('common.emptyValue', '—')}</td>
-                        <td className="py-2 px-2 text-right tabular-nums">{dollars(inv.total_amount)}</td>
+                        <td className="py-2 px-2 text-right tabular-nums">
+                          {inv.total_amount == null ? t('common.emptyValue', '—') : money(inv.total_amount, inv.currency_code || so.currency_code)}
+                        </td>
                         <td className="py-2 pl-2 text-gray-500">
                           {inv.created_at ? new Date(inv.created_at).toLocaleDateString() : t('common.emptyValue', '—')}
                         </td>

--- a/packages/inventory/src/components/SalesOrdersManager.tsx
+++ b/packages/inventory/src/components/SalesOrdersManager.tsx
@@ -5,6 +5,7 @@ import { useRouter } from 'next/navigation';
 import { DataTable } from '@alga-psa/ui/components/DataTable';
 import { Button } from '@alga-psa/ui/components/Button';
 import { Input } from '@alga-psa/ui/components/Input';
+import { CurrencyInput } from '@alga-psa/ui/components/CurrencyInput';
 import { TextArea } from '@alga-psa/ui/components/TextArea';
 import { Dialog } from '@alga-psa/ui/components/Dialog';
 import CustomSelect from '@alga-psa/ui/components/CustomSelect';
@@ -166,6 +167,7 @@ export interface SalesOrdersManagerProps {
   fulfillAndInvoice: FulfillAndInvoiceFn;
   generateInvoice: GenerateInvoiceFn;
   confirmDropShip: ConfirmDropShipFn;
+  defaultCurrencyCode?: string;
 }
 
 export function SalesOrdersManager({
@@ -176,6 +178,7 @@ export function SalesOrdersManager({
   fulfillAndInvoice,
   generateInvoice,
   confirmDropShip,
+  defaultCurrencyCode = 'USD',
 }: SalesOrdersManagerProps) {
   const router = useRouter();
   const { t } = useTranslation('features/inventory');
@@ -255,13 +258,13 @@ export function SalesOrdersManager({
   };
 
   // Currency is a property of who you bill, not a per-order choice: derive it from the picked
-  // client and render it read-only (falling back to USD only when the client has none).
+  // client and render it read-only (falling back to the tenant default when the client has none).
   const onClientSelect = (clientId: string | null) => {
     const picked = clientId ? clients.find((c) => c.client_id === clientId) : undefined;
     setForm((f) => ({
       ...f,
       client_id: clientId ?? '',
-      currency_code: picked?.default_currency_code || (clientId ? 'USD' : ''),
+      currency_code: picked?.default_currency_code || (clientId ? defaultCurrencyCode : ''),
     }));
   };
 
@@ -276,7 +279,7 @@ export function SalesOrdersManager({
   // seeds the editable unit price from its catalog default_rate (stored in minor units).
   const onServicePicked = (idx: number, serviceId: string) => {
     const svc = serviceById.get(serviceId);
-    const currency = form.currency_code || 'USD';
+    const currency = form.currency_code || defaultCurrencyCode;
     const seededPrice =
       svc?.default_rate != null
         ? String(svc.default_rate / Math.pow(10, currencyFractionDigits(currency)))
@@ -288,7 +291,7 @@ export function SalesOrdersManager({
   const removeLine = (idx: number) =>
     setForm((f) => ({ ...f, lines: f.lines.filter((_, i) => i !== idx) }));
 
-  const currency = form.currency_code || 'USD';
+  const currency = form.currency_code || defaultCurrencyCode;
   // Running total: Σ quantity × unit price, in the resolved currency's minor units. Lines without
   // a picked service or a positive quantity don't contribute.
   const totalMinor = form.lines.reduce((sum, l) => {
@@ -643,14 +646,12 @@ export function SalesOrdersManager({
                       )}
                     </div>
                     <div className="w-32">
-                      <Input
+                      <CurrencyInput
                         id={`sales-order-line-price-${idx}`}
-                        type="number"
-                        min="0"
-                        step="0.01"
+                        currencyCode={currency}
                         className="text-right tabular-nums"
-                        value={line.unit_price}
-                        onChange={(e) => setLine(idx, { unit_price: e.target.value })}
+                        value={line.unit_price ? Number(line.unit_price) : undefined}
+                        onChange={(value) => setLine(idx, { unit_price: value == null ? '' : String(value) })}
                       />
                     </div>
                     <div className="w-8 flex justify-center pt-2">

--- a/packages/inventory/src/components/StockOverview.tsx
+++ b/packages/inventory/src/components/StockOverview.tsx
@@ -4,12 +4,14 @@ import React, { useState, useCallback, useEffect } from 'react';
 import { DataTable } from '@alga-psa/ui/components/DataTable';
 import { Button } from '@alga-psa/ui/components/Button';
 import { Input } from '@alga-psa/ui/components/Input';
+import { CurrencyInput } from '@alga-psa/ui/components/CurrencyInput';
 import { Badge } from '@alga-psa/ui/components/Badge';
 import { EmptyState } from '@alga-psa/ui/components/EmptyState';
 import CustomSelect from '@alga-psa/ui/components/CustomSelect';
 import { Dialog } from '@alga-psa/ui/components/Dialog';
 import { useTranslation } from '@alga-psa/ui/lib/i18n/client';
 import { toast } from 'react-hot-toast';
+import { toMinorUnits } from '@alga-psa/core';
 import type { ColumnDefinition, IProductInventorySettings, IStockLocation } from '@alga-psa/types';
 import {
   listInventoryProducts,
@@ -45,9 +47,6 @@ interface StockLevelRow {
   available: number;
 }
 
-const dollars = (cents?: number | null): string =>
-  cents == null ? '—' : `$${(cents / 100).toFixed(2)}`;
-
 interface ReceiveForm {
   service_id: string;
   location_id: string;
@@ -60,7 +59,13 @@ const EMPTY_RECEIVE: ReceiveForm = { service_id: '', location_id: '', quantity: 
 const NUM_HEADER = 'text-right';
 const NUM_CELL = 'text-right tabular-nums';
 
-export function StockOverview({ initialProducts }: { initialProducts: InventoryProduct[] }) {
+export function StockOverview({
+  initialProducts,
+  defaultCurrencyCode = 'USD',
+}: {
+  initialProducts: InventoryProduct[];
+  defaultCurrencyCode?: string;
+}) {
   const { t } = useTranslation('features/inventory');
 
   /** "Out · 1 site" / "Low · 2 sites" — per-location scope so a summed total never
@@ -145,6 +150,8 @@ export function StockOverview({ initialProducts }: { initialProducts: InventoryP
     setReceiveOpen(true);
   };
 
+  const selectedProduct = products.find((p) => p.service_id === receiveForm.service_id) || null;
+
   const saveReceive = async () => {
     if (!receiveForm.service_id) {
       toast.error(t('stock.receive.pickProduct', 'Pick a product.'));
@@ -170,7 +177,7 @@ export function StockOverview({ initialProducts }: { initialProducts: InventoryP
         service_id: receiveForm.service_id,
         location_id: receiveForm.location_id,
         quantity,
-        unit_cost: Math.round(unitDollars * 100),
+        unit_cost: toMinorUnits(unitDollars, undefined, selectedProduct?.cost_currency ?? defaultCurrencyCode),
       });
       toast.success(t('stock.receive.success', 'Stock received.'));
       if (result?.warnings?.length) {
@@ -203,8 +210,6 @@ export function StockOverview({ initialProducts }: { initialProducts: InventoryP
     setLevelsOpen(true);
     await loadLevels(product);
   };
-
-  const selectedProduct = products.find((p) => p.service_id === receiveForm.service_id) || null;
 
   const columns: ColumnDefinition<InventoryProduct>[] = [
     {
@@ -312,7 +317,7 @@ export function StockOverview({ initialProducts }: { initialProducts: InventoryP
         </div>
         <div className="flex items-center gap-2">
           {/* Day-one migration path (Sam review P1): opening balances from CSV as real receipts. */}
-          <ImportOpeningBalances onApplied={reload} />
+          <ImportOpeningBalances onApplied={reload} defaultCurrencyCode={defaultCurrencyCode} />
           {/* Repair path for cache drift (F028): recompute on-hand + reserved/held from
               the ledger, unit statuses, and open SO reservations. */}
           <Button
@@ -420,14 +425,12 @@ export function StockOverview({ initialProducts }: { initialProducts: InventoryP
             value={receiveForm.quantity}
             onChange={(e) => setReceiveForm({ ...receiveForm, quantity: e.target.value })}
           />
-          <Input
+          <CurrencyInput
             id="receive-stock-unit-cost"
-            label={t('stock.fields.unitCost', 'Unit cost (USD)')}
-            type="number"
-            min="0"
-            step="0.01"
-            value={receiveForm.unit_cost}
-            onChange={(e) => setReceiveForm({ ...receiveForm, unit_cost: e.target.value })}
+            label={t('stock.fields.unitCost', 'Unit cost')}
+            currencyCode={selectedProduct?.cost_currency ?? defaultCurrencyCode}
+            value={receiveForm.unit_cost ? Number(receiveForm.unit_cost) : undefined}
+            onChange={(value) => setReceiveForm({ ...receiveForm, unit_cost: value == null ? '' : String(value) })}
           />
           {selectedProduct?.is_serialized && (
             <p className="text-xs text-[rgb(var(--color-text-500))]">

--- a/packages/inventory/src/components/StockUnitsManager.tsx
+++ b/packages/inventory/src/components/StockUnitsManager.tsx
@@ -7,6 +7,7 @@ import { Input } from '@alga-psa/ui/components/Input';
 import { Badge } from '@alga-psa/ui/components/Badge';
 import { Dialog } from '@alga-psa/ui/components/Dialog';
 import CustomSelect from '@alga-psa/ui/components/CustomSelect';
+import { useCurrencyFormat } from '@alga-psa/ui/lib';
 import { useTranslation } from '@alga-psa/ui/lib/i18n/client';
 import { toast } from 'react-hot-toast';
 import type { ColumnDefinition, IStockLocation, IStockMovement, IStockUnit } from '@alga-psa/types';
@@ -31,12 +32,6 @@ function fmtDateTime(v?: string | Date | null): string {
   if (!v) return '';
   const d = new Date(v);
   return isNaN(d.getTime()) ? '' : d.toLocaleString();
-}
-
-function fmtCents(v?: number | string | null): string {
-  if (v === null || v === undefined || v === '') return '';
-  const n = Number(v); // pg returns bigint columns as strings
-  return Number.isFinite(n) ? `$${(n / 100).toFixed(2)}` : '';
 }
 
 function csvValue(v: unknown): string {
@@ -67,6 +62,7 @@ function statusVariant(v?: string | null) {
 
 export function StockUnitsManager({ initialUnits }: { initialUnits: IStockUnit[] }) {
   const { t } = useTranslation('features/inventory');
+  const { money } = useCurrencyFormat();
 
   const SEARCH_MODE_OPTIONS = [
     { value: 'serial', label: t('stockUnits.searchMode.serial', 'Serial number') },
@@ -325,7 +321,11 @@ export function StockUnitsManager({ initialUnits }: { initialUnits: IStockUnit[]
                 </div>
                 <div>
                   <div className="text-xs text-gray-500">{t('stockUnits.detail.unitCost', 'Unit cost')}</div>
-                  <div className="font-mono">{fmtCents(historyDetail.unit.unit_cost) || t('common.emptyValue', '—')}</div>
+                  <div className="font-mono">
+                    {historyDetail.unit.unit_cost == null
+                      ? t('common.emptyValue', '—')
+                      : money(Number(historyDetail.unit.unit_cost), historyDetail.unit.cost_currency ?? undefined)}
+                  </div>
                 </div>
                 {historyDetail.unit.received_at && (
                   <div>

--- a/packages/inventory/src/components/VendorBillsManager.tsx
+++ b/packages/inventory/src/components/VendorBillsManager.tsx
@@ -8,6 +8,7 @@ import { Badge, type BadgeVariant } from '@alga-psa/ui/components/Badge';
 import CustomSelect from '@alga-psa/ui/components/CustomSelect';
 import { Dialog } from '@alga-psa/ui/components/Dialog';
 import { useTranslation } from '@alga-psa/ui/lib/i18n/client';
+import { useCurrencyFormat } from '@alga-psa/ui/lib';
 import { toast } from 'react-hot-toast';
 import type { ColumnDefinition, IVendorBill, IVendor, VendorBillStatus } from '@alga-psa/types';
 import {
@@ -31,9 +32,6 @@ interface VendorBillExportProps {
   getExportStatuses?: (billIds: string[]) => Promise<VendorBillExportStatus[]>;
 }
 
-const money = (cents: number, currency?: string): string =>
-  `$${(Number(cents || 0) / 100).toFixed(2)}${currency ? ` ${currency}` : ''}`;
-
 interface CreateForm {
   vendor_id: string;
   bill_number: string;
@@ -48,6 +46,7 @@ export function VendorBillsManager({
   getExportStatuses,
 }: { initialBills: BillRow[] } & VendorBillExportProps) {
   const { t } = useTranslation('features/inventory');
+  const { money } = useCurrencyFormat();
   const [bills, setBills] = useState<BillRow[]>(initialBills || []);
   const [statusFilter, setStatusFilter] = useState('');
   const [vendors, setVendors] = useState<IVendor[]>([]);
@@ -429,8 +428,8 @@ export function VendorBillsManager({
                     <tr key={l.bill_line_id} className="border-b last:border-0">
                       <td className="py-1 pr-2">{l.service_name || l.description || t('common.emptyValue', '—')}</td>
                       <td className="py-1 px-2 text-right tabular-nums">{l.quantity}</td>
-                      <td className="py-1 px-2 text-right tabular-nums">{money(l.unit_cost)}</td>
-                      <td className="py-1 px-2 text-right tabular-nums">{money(l.amount)}</td>
+                      <td className="py-1 px-2 text-right tabular-nums">{money(l.unit_cost, detail.currency_code)}</td>
+                      <td className="py-1 px-2 text-right tabular-nums">{money(l.amount, detail.currency_code)}</td>
                       <td className="py-1 pl-2 text-right">
                         {l.line_variance_cents == null ? (
                           <span className="text-gray-400">{t('common.emptyValue', '—')}</span>
@@ -444,7 +443,7 @@ export function VendorBillsManager({
                             }`}
                           >
                             {l.line_variance_cents > 0 ? '+' : ''}
-                            {money(l.line_variance_cents)}
+                            {money(l.line_variance_cents, detail.currency_code)}
                           </span>
                         )}
                       </td>

--- a/packages/inventory/src/components/VendorPriceList.tsx
+++ b/packages/inventory/src/components/VendorPriceList.tsx
@@ -4,9 +4,12 @@ import React, { useState, useEffect, useCallback } from 'react';
 import { Dialog } from '@alga-psa/ui/components/Dialog';
 import { Button } from '@alga-psa/ui/components/Button';
 import { Input } from '@alga-psa/ui/components/Input';
+import { CurrencyInput } from '@alga-psa/ui/components/CurrencyInput';
 import { Badge } from '@alga-psa/ui/components/Badge';
 import CustomSelect from '@alga-psa/ui/components/CustomSelect';
 import { Checkbox } from '@alga-psa/ui/components/Checkbox';
+import { CURRENCY_OPTIONS, toMinorUnits } from '@alga-psa/core';
+import { useCurrencyFormat } from '@alga-psa/ui/lib';
 import { useTranslation } from '@alga-psa/ui/lib/i18n/client';
 import { toast } from 'react-hot-toast';
 import type { IVendor, IVendorProduct } from '@alga-psa/types';
@@ -17,17 +20,17 @@ type OfferRow = IVendorProduct & { service_name: string | null; sku: string | nu
 interface OfferForm {
   service_id: string;
   vendor_sku: string;
-  unit_cost: string; // dollars
+  unit_cost: string; // major units, converted to integer minor units on save
   cost_currency: string;
   lead_time_days: string;
   is_preferred: boolean;
 }
 
-const emptyOffer = (): OfferForm => ({
+const emptyOffer = (currencyCode: string): OfferForm => ({
   service_id: '',
   vendor_sku: '',
   unit_cost: '',
-  cost_currency: 'USD',
+  cost_currency: currencyCode,
   lead_time_days: '',
   is_preferred: false,
 });
@@ -37,11 +40,20 @@ const emptyOffer = (): OfferForm => ({
  * PO lines and reorder suggestions price from these rows; the preferred offer also
  * drives which vendor auto-suggested POs group under.
  */
-export function VendorPriceList({ vendor, onClose }: { vendor: IVendor | null; onClose: () => void }) {
+export function VendorPriceList({
+  vendor,
+  onClose,
+  defaultCurrencyCode = 'USD',
+}: {
+  vendor: IVendor | null;
+  onClose: () => void;
+  defaultCurrencyCode?: string;
+}) {
   const { t } = useTranslation('features/inventory');
+  const { money, fractionDigits } = useCurrencyFormat();
   const [offers, setOffers] = useState<OfferRow[]>([]);
   const [products, setProducts] = useState<Array<{ service_id: string; service_name: string | null; sku: string | null }>>([]);
-  const [form, setForm] = useState<OfferForm>(emptyOffer());
+  const [form, setForm] = useState<OfferForm>(emptyOffer(defaultCurrencyCode));
   const [saving, setSaving] = useState(false);
 
   const load = useCallback(async () => {
@@ -54,7 +66,7 @@ export function VendorPriceList({ vendor, onClose }: { vendor: IVendor | null; o
   }, [vendor, t]);
 
   useEffect(() => {
-    setForm(emptyOffer());
+    setForm(emptyOffer(defaultCurrencyCode));
     setOffers([]);
     load();
     if (vendor) {
@@ -62,7 +74,7 @@ export function VendorPriceList({ vendor, onClose }: { vendor: IVendor | null; o
         .then((rows: any[]) => setProducts(rows.map((r) => ({ service_id: r.service_id, service_name: r.service_name, sku: r.sku }))))
         .catch(() => setProducts([]));
     }
-  }, [vendor, load]);
+  }, [defaultCurrencyCode, vendor, load]);
 
   const save = async () => {
     if (!vendor) return;
@@ -82,13 +94,13 @@ export function VendorPriceList({ vendor, onClose }: { vendor: IVendor | null; o
         vendor_id: vendor.vendor_id,
         service_id: form.service_id,
         vendor_sku: form.vendor_sku.trim() || null,
-        unit_cost: dollars == null ? null : Math.round(dollars * 100),
-        cost_currency: form.cost_currency.trim() || 'USD',
+        unit_cost: dollars == null ? null : toMinorUnits(dollars, undefined, form.cost_currency),
+        cost_currency: form.cost_currency || defaultCurrencyCode,
         lead_time_days: leadDays,
         is_preferred: form.is_preferred,
       });
       toast.success(t('vendorPriceList.offerSaved', 'Offer saved.'));
-      setForm(emptyOffer());
+      setForm(emptyOffer(defaultCurrencyCode));
       await load();
     } catch (e: any) {
       toast.error(e?.message || t('vendorPriceList.saveError', "Couldn't save the offer."));
@@ -109,11 +121,13 @@ export function VendorPriceList({ vendor, onClose }: { vendor: IVendor | null; o
   };
 
   const startEdit = (offer: OfferRow) => {
+    const currency = offer.cost_currency ?? defaultCurrencyCode;
+    const digits = fractionDigits(currency);
     setForm({
       service_id: offer.service_id,
       vendor_sku: offer.vendor_sku ?? '',
-      unit_cost: offer.unit_cost != null ? (Number(offer.unit_cost) / 100).toFixed(2) : '',
-      cost_currency: offer.cost_currency ?? 'USD',
+      unit_cost: offer.unit_cost != null ? (Number(offer.unit_cost) / Math.pow(10, digits)).toFixed(digits) : '',
+      cost_currency: currency,
       lead_time_days: offer.lead_time_days != null ? String(offer.lead_time_days) : '',
       is_preferred: Boolean(offer.is_preferred),
     });
@@ -151,7 +165,7 @@ export function VendorPriceList({ vendor, onClose }: { vendor: IVendor | null; o
                   </td>
                   <td className="py-2 px-2 font-mono text-xs">{o.vendor_sku || t('common.emptyValue', '—')}</td>
                   <td className="py-2 px-2 text-right tabular-nums">
-                    {o.unit_cost != null ? `$${(Number(o.unit_cost) / 100).toFixed(2)} ${o.cost_currency}` : t('common.emptyValue', '—')}
+                    {o.unit_cost != null ? money(Number(o.unit_cost), o.cost_currency ?? defaultCurrencyCode) : t('common.emptyValue', '—')}
                   </td>
                   <td className="py-2 px-2 text-right tabular-nums">
                     {o.lead_time_days != null ? t('vendorPriceList.leadTimeDays', '{{days}}d', { days: o.lead_time_days }) : t('common.emptyValue', '—')}
@@ -206,18 +220,19 @@ export function VendorPriceList({ vendor, onClose }: { vendor: IVendor | null; o
               value={form.vendor_sku}
               onChange={(e) => setForm({ ...form, vendor_sku: e.target.value })}
             />
-            <Input
+            <CurrencyInput
               id="vendor-offer-cost"
-              label={t('vendorPriceList.fields.cost', 'Cost ($)')}
-              type="number"
-              value={form.unit_cost}
-              onChange={(e) => setForm({ ...form, unit_cost: e.target.value })}
+              label={t('vendorPriceList.fields.cost', 'Cost')}
+              currencyCode={form.cost_currency}
+              value={form.unit_cost ? Number(form.unit_cost) : undefined}
+              onChange={(value) => setForm({ ...form, unit_cost: value == null ? '' : String(value) })}
             />
-            <Input
+            <CustomSelect
               id="vendor-offer-currency"
               label={t('vendorPriceList.fields.currency', 'Currency')}
               value={form.cost_currency}
-              onChange={(e) => setForm({ ...form, cost_currency: e.target.value.toUpperCase() })}
+              onValueChange={(value) => setForm({ ...form, cost_currency: value })}
+              options={CURRENCY_OPTIONS.map((option) => ({ value: option.value, label: option.label }))}
             />
             <Input
               id="vendor-offer-lead-time"

--- a/packages/inventory/src/components/VendorsManager.tsx
+++ b/packages/inventory/src/components/VendorsManager.tsx
@@ -31,7 +31,13 @@ const EMPTY_FORM: FormState = {
   account_number: '',
 };
 
-export function VendorsManager({ initialVendors }: { initialVendors: IVendor[] }) {
+export function VendorsManager({
+  initialVendors,
+  defaultCurrencyCode = 'USD',
+}: {
+  initialVendors: IVendor[];
+  defaultCurrencyCode?: string;
+}) {
   const { t } = useTranslation('features/inventory');
   const [priceListVendor, setPriceListVendor] = useState<IVendor | null>(null);
   const [vendors, setVendors] = useState<IVendor[]>(initialVendors || []);
@@ -167,7 +173,11 @@ export function VendorsManager({ initialVendors }: { initialVendors: IVendor[] }
 
       <DataTable id="vendors-table" data={vendors} columns={columns} onRowClick={openEdit} />
 
-      <VendorPriceList vendor={priceListVendor} onClose={() => setPriceListVendor(null)} />
+      <VendorPriceList
+        vendor={priceListVendor}
+        onClose={() => setPriceListVendor(null)}
+        defaultCurrencyCode={defaultCurrencyCode}
+      />
 
       <Dialog
         isOpen={dialogOpen}

--- a/packages/inventory/src/components/WriteOffsReport.tsx
+++ b/packages/inventory/src/components/WriteOffsReport.tsx
@@ -8,6 +8,7 @@ import { Badge } from '@alga-psa/ui/components/Badge';
 import { toast } from 'react-hot-toast';
 import type { ColumnDefinition } from '@alga-psa/types';
 import { useTranslation } from '@alga-psa/ui/lib/i18n/client';
+import { useCurrencyFormat } from '@alga-psa/ui/lib';
 import { writeOffReport, type WriteOffReportData, type WriteOffRow, type WriteOffByUser } from '../actions';
 
 /**
@@ -16,20 +17,16 @@ import { writeOffReport, type WriteOffReportData, type WriteOffRow, type WriteOf
  * person who HOLDS the approve button. Signs follow stock: negative = written down.
  */
 
-const money = (cents: number): string => {
-  const v = cents / 100;
-  const s = `$${Math.abs(v).toLocaleString(undefined, { minimumFractionDigits: 2, maximumFractionDigits: 2 })}`;
-  return v < 0 ? `-${s}` : s;
-};
-
 const dateInputValue = (iso: string): string => iso.slice(0, 10);
 
 export function WriteOffsReport({ initialData }: { initialData: WriteOffReportData | null }) {
   const { t } = useTranslation('features/inventory');
+  const { money } = useCurrencyFormat();
   const [data, setData] = useState<WriteOffReportData | null>(initialData);
   const [from, setFrom] = useState(initialData ? dateInputValue(initialData.from) : '');
   const [to, setTo] = useState(initialData ? dateInputValue(initialData.to) : '');
   const [loading, setLoading] = useState(false);
+  const currencyCode = data?.currency_code ?? initialData?.currency_code ?? 'USD';
 
   const run = useCallback(async () => {
     setLoading(true);
@@ -48,18 +45,18 @@ export function WriteOffsReport({ initialData }: { initialData: WriteOffReportDa
     {
       title: t('writeOffs.columns.writtenOff', 'Written off'),
       dataIndex: 'losses_cents',
-      render: (v: any) => <span className="text-red-700 tabular-nums">{money(Number(v))}</span>,
+      render: (v: any) => <span className="text-red-700 tabular-nums">{money(Number(v), currencyCode)}</span>,
     },
     {
       title: t('writeOffs.columns.foundAdded', 'Found / added'),
       dataIndex: 'gains_cents',
-      render: (v: any) => <span className="text-green-700 tabular-nums">{money(Number(v))}</span>,
+      render: (v: any) => <span className="text-green-700 tabular-nums">{money(Number(v), currencyCode)}</span>,
     },
     {
       title: t('writeOffs.columns.net', 'Net'),
       dataIndex: 'net_cents',
       render: (v: any) => (
-        <span className={`tabular-nums ${Number(v) < 0 ? 'text-red-700' : 'text-gray-700'}`}>{money(Number(v))}</span>
+        <span className={`tabular-nums ${Number(v) < 0 ? 'text-red-700' : 'text-gray-700'}`}>{money(Number(v), currencyCode)}</span>
       ),
     },
   ];
@@ -106,7 +103,7 @@ export function WriteOffsReport({ initialData }: { initialData: WriteOffReportDa
       title: t('writeOffs.columns.value', 'Value'),
       dataIndex: 'value_cents',
       render: (v: any) => (
-        <span className={`tabular-nums ${Number(v) < 0 ? 'text-red-700' : 'text-green-700'}`}>{money(Number(v))}</span>
+        <span className={`tabular-nums ${Number(v) < 0 ? 'text-red-700' : 'text-green-700'}`}>{money(Number(v), currencyCode)}</span>
       ),
     },
     { title: t('writeOffs.columns.reason', 'Reason'), dataIndex: 'reason', render: (v: any) => <span className="text-xs">{v || t('common.emptyValue', '—')}</span> },
@@ -136,16 +133,16 @@ export function WriteOffsReport({ initialData }: { initialData: WriteOffReportDa
           <div className="flex gap-6 text-sm" id="write-offs-totals">
             <div>
               <span className="text-gray-500">{t('writeOffs.totals.writtenOff', 'Written off: ')}</span>
-              <span className="font-semibold text-red-700 tabular-nums">{money(data.total_losses_cents)}</span>
+              <span className="font-semibold text-red-700 tabular-nums">{money(data.total_losses_cents, currencyCode)}</span>
             </div>
             <div>
               <span className="text-gray-500">{t('writeOffs.totals.foundAdded', 'Found / added: ')}</span>
-              <span className="font-semibold text-green-700 tabular-nums">{money(data.total_gains_cents)}</span>
+              <span className="font-semibold text-green-700 tabular-nums">{money(data.total_gains_cents, currencyCode)}</span>
             </div>
             <div>
               <span className="text-gray-500">{t('writeOffs.totals.net', 'Net: ')}</span>
               <span className={`font-semibold tabular-nums ${data.net_cents < 0 ? 'text-red-700' : 'text-gray-800'}`}>
-                {money(data.net_cents)}
+                {money(data.net_cents, currencyCode)}
               </span>
             </div>
           </div>

--- a/packages/inventory/src/components/dashboard/FooterStrip.tsx
+++ b/packages/inventory/src/components/dashboard/FooterStrip.tsx
@@ -10,8 +10,22 @@ interface FooterStripProps {
   footer: InventoryDashboardData['footer'];
 }
 
+type MoneyBucket = InventoryDashboardData['footer']['value_by_currency'][number];
+
 function Divider() {
   return <span className="hidden h-5 w-px flex-shrink-0 bg-[rgb(var(--color-border-200))] md:block" />;
+}
+
+function formatMoneyBuckets(
+  buckets: MoneyBucket[] | undefined,
+  fallbackAmount: number,
+  money: ReturnType<typeof useCurrencyFormat>['money'],
+  absolute = false,
+): string {
+  const rows = buckets && buckets.length > 0 ? buckets : [{ amount: fallbackAmount, currency_code: undefined }];
+  return rows
+    .map((row) => money(absolute ? Math.abs(row.amount) : row.amount, row.currency_code))
+    .join(' + ');
 }
 
 function Stat({
@@ -35,7 +49,8 @@ function Stat({
 export function FooterStrip({ footer }: FooterStripProps) {
   const { t } = useTranslation('features/inventory');
   const { money } = useCurrencyFormat();
-  const deltaPositive = footer.wow_delta >= 0;
+  const deltaPositive =
+    footer.wow_delta_by_currency.length === 1 ? footer.wow_delta_by_currency[0].amount >= 0 : footer.wow_delta >= 0;
   return (
     <section
       id="inventory-dashboard-health-footer"
@@ -43,7 +58,7 @@ export function FooterStrip({ footer }: FooterStripProps) {
     >
       <Stat
         label={t('dashboard.footer.title', 'Inventory health')}
-        value={money(footer.value)}
+        value={formatMoneyBuckets(footer.value_by_currency, footer.value, money)}
         detail={
           <span
             className={
@@ -53,7 +68,7 @@ export function FooterStrip({ footer }: FooterStripProps) {
             }
           >
             {deltaPositive ? <ArrowUp className="h-3 w-3" /> : <ArrowDown className="h-3 w-3" />}
-            {money(Math.abs(footer.wow_delta))} {t('dashboard.footer.weekAbbrev', 'wk')}
+            {formatMoneyBuckets(footer.wow_delta_by_currency, footer.wow_delta, money, true)} {t('dashboard.footer.weekAbbrev', 'wk')}
           </span>
         }
       />
@@ -68,7 +83,7 @@ export function FooterStrip({ footer }: FooterStripProps) {
           <Divider />
           <Stat
             label={t('dashboard.footer.deadStock', 'Dead stock')}
-            value={money(footer.dead_stock.amount)}
+            value={formatMoneyBuckets(footer.dead_stock.amount_by_currency, footer.dead_stock.amount, money)}
             detail={
               <span className="font-semibold text-amber-700 dark:text-amber-300">
                 {t('dashboard.footer.deadStockDetail', '{{location}} · 90d', {

--- a/packages/inventory/src/components/dashboard/shared.tsx
+++ b/packages/inventory/src/components/dashboard/shared.tsx
@@ -4,6 +4,11 @@ import React from 'react';
 import { ArrowRight } from 'lucide-react';
 import { cn } from '@alga-psa/ui/lib/utils';
 import { useTranslation } from '@alga-psa/ui/lib/i18n/client';
+export {
+  CurrencyFormatProvider,
+  useCurrencyFormat,
+  type CurrencyFormat,
+} from '@alga-psa/ui/lib';
 
 /**
  * Shared primitives for the inventory dashboard bento tiles
@@ -20,65 +25,6 @@ export function pct(value: number, dp = 0): string {
 
 export function clientHref(clientId: string | null | undefined): string {
   return clientId ? `/msp/clients/${clientId}` : '/msp/inventory/sales-orders';
-}
-
-/**
- * Locale/currency-aware money formatting for the dashboard. The provider is
- * seeded once at the root from the tenant's default billing currency and the
- * active i18n locale; tiles read the formatters through the hook so every
- * amount renders with the correct symbol and grouping instead of a hardcoded $.
- */
-const DEFAULT_LOCALE = 'en';
-const DEFAULT_CURRENCY = 'USD';
-
-export interface CurrencyFormat {
-  /** Whole-number by default (dp=0), preserving the prior display. */
-  money: (cents: number, dp?: number) => string;
-  /** Explicit +/− prefix on the absolute value (−$340 / +$40). */
-  moneySigned: (cents: number) => string;
-}
-
-function buildCurrencyFormat(locale: string, currencyCode: string): CurrencyFormat {
-  const format = (cents: number, dp = 0) =>
-    new Intl.NumberFormat(locale, {
-      style: 'currency',
-      currency: currencyCode,
-      minimumFractionDigits: dp,
-      maximumFractionDigits: dp,
-    }).format(Number(cents || 0) / 100);
-  return {
-    money: format,
-    moneySigned: (cents: number) => {
-      const abs = format(Math.abs(cents));
-      if (cents < 0) return `−${abs}`;
-      if (cents > 0) return `+${abs}`;
-      return abs;
-    },
-  };
-}
-
-const CurrencyFormatContext = React.createContext<CurrencyFormat>(
-  buildCurrencyFormat(DEFAULT_LOCALE, DEFAULT_CURRENCY),
-);
-
-export function CurrencyFormatProvider({
-  currencyCode,
-  locale,
-  children,
-}: {
-  currencyCode: string;
-  locale: string;
-  children: React.ReactNode;
-}) {
-  const value = React.useMemo(
-    () => buildCurrencyFormat(locale || DEFAULT_LOCALE, currencyCode || DEFAULT_CURRENCY),
-    [locale, currencyCode],
-  );
-  return <CurrencyFormatContext.Provider value={value}>{children}</CurrencyFormatContext.Provider>;
-}
-
-export function useCurrencyFormat(): CurrencyFormat {
-  return React.useContext(CurrencyFormatContext);
 }
 
 export function shortDate(iso: string): string {

--- a/packages/inventory/src/lib/dashboardQueries.ts
+++ b/packages/inventory/src/lib/dashboardQueries.ts
@@ -365,6 +365,7 @@ export interface UnbilledSoRow {
   so_number: string;
   client_id: string | null;
   client_name: string | null;
+  currency_code: string | null;
   amount: number;
   /** Days since the last consume movement for this SO (null when untracked, e.g. drop-ship). */
   shipped_days_ago: number | null;
@@ -397,13 +398,14 @@ export async function queryUnbilled(db: Db, tenant: string, ghost: GhostWeek): P
       .where({ 'so.tenant': tenant })
       .whereNot('so.status', 'cancelled')
       .andWhere('l.fulfillment_type', dropShip ? 'drop_ship' : 'from_stock')
-      .groupBy('so.so_id', 'so.so_number', 'so.status', 'so.order_date', 'so.client_id', 'c.client_name')
+      .groupBy('so.so_id', 'so.so_number', 'so.status', 'so.order_date', 'so.client_id', 'so.currency_code', 'c.client_name')
       .havingRaw('COALESCE(SUM(GREATEST(l.quantity_fulfilled - l.quantity_invoiced, 0)),0) > 0')
       .select<any[]>(
         'so.so_id as so_id',
         'so.so_number as so_number',
         'so.status as so_status',
         'so.client_id as client_id',
+        'so.currency_code as currency_code',
         'c.client_name as client_name',
         db.raw('COUNT(*) FILTER (WHERE l.quantity_fulfilled > l.quantity_invoiced) as line_count'),
         db.raw('COALESCE(SUM(GREATEST(l.quantity_fulfilled - l.quantity_invoiced, 0) * l.unit_price),0) as amount'),
@@ -432,6 +434,7 @@ export async function queryUnbilled(db: Db, tenant: string, ghost: GhostWeek): P
     so_number: r.so_number,
     client_id: r.client_id ?? null,
     client_name: r.client_name ?? null,
+    currency_code: r.currency_code ?? null,
     amount: num(r.amount),
     shipped_days_ago: shipAges.get(r.so_id) ?? null,
     line_count: Number(r.line_count ?? 0),

--- a/packages/inventory/src/lib/dashboardQueries.ts
+++ b/packages/inventory/src/lib/dashboardQueries.ts
@@ -631,7 +631,6 @@ export interface DeadStock {
  */
 export async function queryDeadStock(db: Db, tenant: string, fallbackCurrency: string): Promise<DeadStock | null> {
   const settingsCurrency = db.raw("COALESCE(NULLIF(pis.cost_currency, ''), ?) as currency_code", [fallbackCurrency]);
-  const settingsCurrencyGroup = db.raw("COALESCE(NULLIF(pis.cost_currency, ''), ?)", [fallbackCurrency]);
   const nonSer = await db('stock_levels as sl')
     .join('product_inventory_settings as pis', function () {
       this.on('sl.service_id', '=', 'pis.service_id').andOn('sl.tenant', '=', 'pis.tenant');
@@ -646,7 +645,7 @@ export async function queryDeadStock(db: Db, tenant: string, fallbackCurrency: s
         .whereRaw('(sm.from_location_id = sl.location_id OR sm.to_location_id = sl.location_id)')
         .whereRaw("sm.created_at >= now() - interval '90 days'");
     })
-    .groupBy('sl.location_id', settingsCurrencyGroup)
+    .groupBy('sl.location_id', 'currency_code')
     .select<any[]>(
       'sl.location_id as location_id',
       settingsCurrency,
@@ -654,7 +653,6 @@ export async function queryDeadStock(db: Db, tenant: string, fallbackCurrency: s
     );
 
   const unitCurrency = db.raw("COALESCE(NULLIF(su.cost_currency, ''), NULLIF(pis.cost_currency, ''), ?) as currency_code", [fallbackCurrency]);
-  const unitCurrencyGroup = db.raw("COALESCE(NULLIF(su.cost_currency, ''), NULLIF(pis.cost_currency, ''), ?)", [fallbackCurrency]);
   const ser = await db('stock_units as su')
     .leftJoin('product_inventory_settings as pis', function () {
       this.on('su.service_id', '=', 'pis.service_id').andOn('su.tenant', '=', 'pis.tenant');
@@ -669,7 +667,7 @@ export async function queryDeadStock(db: Db, tenant: string, fallbackCurrency: s
         .whereRaw('sm.unit_id = su.unit_id')
         .whereRaw("sm.created_at >= now() - interval '90 days'");
     })
-    .groupBy('su.location_id', unitCurrencyGroup)
+    .groupBy('su.location_id', 'currency_code')
     .select<any[]>(
       'su.location_id as location_id',
       unitCurrency,
@@ -868,10 +866,6 @@ export async function queryValueWowDeltaByCurrency(
     "COALESCE(NULLIF(sm.cost_currency, ''), NULLIF(su.cost_currency, ''), NULLIF(pis.cost_currency, ''), ?) as currency_code",
     [fallbackCurrency],
   );
-  const currencyGroup = db.raw(
-    "COALESCE(NULLIF(sm.cost_currency, ''), NULLIF(su.cost_currency, ''), NULLIF(pis.cost_currency, ''), ?)",
-    [fallbackCurrency],
-  );
   const row = await db('stock_movements as sm')
     .leftJoin('stock_units as su', function () {
       this.on('sm.unit_id', '=', 'su.unit_id').andOn('sm.tenant', '=', 'su.tenant');
@@ -881,7 +875,7 @@ export async function queryValueWowDeltaByCurrency(
     })
     .where('sm.tenant', tenant)
     .andWhereRaw("sm.created_at >= now() - interval '7 days'")
-    .groupBy(currencyGroup)
+    .groupBy('currency_code')
     .select<{ currency_code: string | null; delta: string }[]>(
       currencyExpr,
       db.raw(`COALESCE(SUM(

--- a/packages/inventory/src/lib/dashboardQueries.ts
+++ b/packages/inventory/src/lib/dashboardQueries.ts
@@ -21,6 +21,34 @@ function num(v: unknown): number {
   return Math.round(Number(v ?? 0));
 }
 
+export interface MoneyByCurrency {
+  currency_code: string;
+  amount: number;
+}
+
+function normalizeCurrency(currency: string | null | undefined, fallbackCurrency: string): string {
+  return currency?.trim() || fallbackCurrency;
+}
+
+function mergeMoneyByCurrency(
+  rows: Array<{ currency_code: string | null; amount: unknown }>,
+  fallbackCurrency: string,
+): MoneyByCurrency[] {
+  const byCurrency = new Map<string, number>();
+  for (const row of rows) {
+    const currency = normalizeCurrency(row.currency_code, fallbackCurrency);
+    byCurrency.set(currency, (byCurrency.get(currency) ?? 0) + num(row.amount));
+  }
+  return [...byCurrency.entries()]
+    .map(([currency_code, amount]) => ({ currency_code, amount }))
+    .filter((row) => row.amount !== 0)
+    .sort((a, b) => Math.abs(b.amount) - Math.abs(a.amount) || a.currency_code.localeCompare(b.currency_code));
+}
+
+export function totalMoneyByCurrency(rows: MoneyByCurrency[]): number {
+  return rows.reduce((sum, row) => sum + row.amount, 0);
+}
+
 /* ------------------------------ D1 deployments ------------------------------ */
 
 export type DeploymentStatus = 'at_risk' | 'ready' | 'staging';
@@ -587,8 +615,10 @@ export async function queryBillCreep(db: Db, tenant: string): Promise<BillCreepR
 export interface DeadStock {
   location_id: string;
   location_name: string | null;
-  /** Cents tied up at the worst location. */
+  /** Legacy ranking total for the worst location; use amount_by_currency for display. */
   amount: number;
+  /** Minor units tied up at the worst location, grouped by stock cost currency. */
+  amount_by_currency: MoneyByCurrency[];
   /** Number of locations with dead stock (worst is surfaced; rest rolled up). */
   location_count: number;
 }
@@ -599,7 +629,9 @@ export interface DeadStock {
  * that location) plus in_stock serialized units received >90d ago with no
  * unit movement since.
  */
-export async function queryDeadStock(db: Db, tenant: string): Promise<DeadStock | null> {
+export async function queryDeadStock(db: Db, tenant: string, fallbackCurrency: string): Promise<DeadStock | null> {
+  const settingsCurrency = db.raw("COALESCE(NULLIF(pis.cost_currency, ''), ?) as currency_code", [fallbackCurrency]);
+  const settingsCurrencyGroup = db.raw("COALESCE(NULLIF(pis.cost_currency, ''), ?)", [fallbackCurrency]);
   const nonSer = await db('stock_levels as sl')
     .join('product_inventory_settings as pis', function () {
       this.on('sl.service_id', '=', 'pis.service_id').andOn('sl.tenant', '=', 'pis.tenant');
@@ -614,10 +646,19 @@ export async function queryDeadStock(db: Db, tenant: string): Promise<DeadStock 
         .whereRaw('(sm.from_location_id = sl.location_id OR sm.to_location_id = sl.location_id)')
         .whereRaw("sm.created_at >= now() - interval '90 days'");
     })
-    .groupBy('sl.location_id')
-    .select<any[]>('sl.location_id as location_id', db.raw('SUM(sl.quantity_on_hand * COALESCE(pis.average_cost, 0)) as value'));
+    .groupBy('sl.location_id', settingsCurrencyGroup)
+    .select<any[]>(
+      'sl.location_id as location_id',
+      settingsCurrency,
+      db.raw('SUM(sl.quantity_on_hand * COALESCE(pis.average_cost, 0)) as value'),
+    );
 
+  const unitCurrency = db.raw("COALESCE(NULLIF(su.cost_currency, ''), NULLIF(pis.cost_currency, ''), ?) as currency_code", [fallbackCurrency]);
+  const unitCurrencyGroup = db.raw("COALESCE(NULLIF(su.cost_currency, ''), NULLIF(pis.cost_currency, ''), ?)", [fallbackCurrency]);
   const ser = await db('stock_units as su')
+    .leftJoin('product_inventory_settings as pis', function () {
+      this.on('su.service_id', '=', 'pis.service_id').andOn('su.tenant', '=', 'pis.tenant');
+    })
     .where({ 'su.tenant': tenant, 'su.status': 'in_stock' })
     .whereNotNull('su.location_id')
     .andWhereRaw("COALESCE(su.received_at, su.created_at) < now() - interval '90 days'")
@@ -628,18 +669,30 @@ export async function queryDeadStock(db: Db, tenant: string): Promise<DeadStock 
         .whereRaw('sm.unit_id = su.unit_id')
         .whereRaw("sm.created_at >= now() - interval '90 days'");
     })
-    .groupBy('su.location_id')
-    .select<any[]>('su.location_id as location_id', db.raw('SUM(COALESCE(su.unit_cost, 0)) as value'));
+    .groupBy('su.location_id', unitCurrencyGroup)
+    .select<any[]>(
+      'su.location_id as location_id',
+      unitCurrency,
+      db.raw('SUM(COALESCE(su.unit_cost, 0)) as value'),
+    );
 
-  const byLocation = new Map<string, number>();
+  const byLocation = new Map<string, MoneyByCurrency[]>();
   for (const r of [...nonSer, ...ser]) {
-    byLocation.set(r.location_id, (byLocation.get(r.location_id) ?? 0) + num(r.value));
+    const rows = byLocation.get(r.location_id) ?? [];
+    rows.push({ currency_code: normalizeCurrency(r.currency_code, fallbackCurrency), amount: num(r.value) });
+    byLocation.set(r.location_id, rows);
   }
-  const entries = [...byLocation.entries()].filter(([, v]) => v > 0).sort((a, b) => b[1] - a[1]);
+  const entries = [...byLocation.entries()]
+    .map(([locationId, rows]) => {
+      const amount_by_currency = mergeMoneyByCurrency(rows, fallbackCurrency);
+      return { locationId, amount_by_currency, amount: totalMoneyByCurrency(amount_by_currency) };
+    })
+    .filter((entry) => entry.amount_by_currency.length > 0)
+    .sort((a, b) => Math.abs(b.amount) - Math.abs(a.amount) || a.locationId.localeCompare(b.locationId));
   if (entries.length === 0) return null;
-  const [locationId, amount] = entries[0];
+  const { locationId, amount, amount_by_currency } = entries[0];
   const loc = await db('stock_locations').where({ tenant, location_id: locationId }).first<{ name: string }>('name');
-  return { location_id: locationId, location_name: loc?.name ?? null, amount, location_count: entries.length };
+  return { location_id: locationId, location_name: loc?.name ?? null, amount, amount_by_currency, location_count: entries.length };
 }
 
 /* --------------------------- D8 van context --------------------------- */
@@ -802,6 +855,23 @@ export async function queryPipeline(db: Db, tenant: string): Promise<Pipeline> {
  * drift over the week is accepted as part of the approximation.
  */
 export async function queryValueWowDelta(db: Db, tenant: string): Promise<number> {
+  const rows = await queryValueWowDeltaByCurrency(db, tenant, 'USD');
+  return totalMoneyByCurrency(rows);
+}
+
+export async function queryValueWowDeltaByCurrency(
+  db: Db,
+  tenant: string,
+  fallbackCurrency: string,
+): Promise<MoneyByCurrency[]> {
+  const currencyExpr = db.raw(
+    "COALESCE(NULLIF(sm.cost_currency, ''), NULLIF(su.cost_currency, ''), NULLIF(pis.cost_currency, ''), ?) as currency_code",
+    [fallbackCurrency],
+  );
+  const currencyGroup = db.raw(
+    "COALESCE(NULLIF(sm.cost_currency, ''), NULLIF(su.cost_currency, ''), NULLIF(pis.cost_currency, ''), ?)",
+    [fallbackCurrency],
+  );
   const row = await db('stock_movements as sm')
     .leftJoin('stock_units as su', function () {
       this.on('sm.unit_id', '=', 'su.unit_id').andOn('sm.tenant', '=', 'su.tenant');
@@ -811,7 +881,9 @@ export async function queryValueWowDelta(db: Db, tenant: string): Promise<number
     })
     .where('sm.tenant', tenant)
     .andWhereRaw("sm.created_at >= now() - interval '7 days'")
-    .select<{ delta: string }[]>(
+    .groupBy(currencyGroup)
+    .select<{ currency_code: string | null; delta: string }[]>(
+      currencyExpr,
       db.raw(`COALESCE(SUM(
         (CASE
           WHEN sm.movement_type = 'retire' THEN -1
@@ -821,9 +893,11 @@ export async function queryValueWowDelta(db: Db, tenant: string): Promise<number
           ELSE 0
         END) * sm.quantity * COALESCE(sm.unit_cost, su.unit_cost, pis.average_cost, 0)
       ), 0) as delta`),
-    )
-    .first();
-  return num(row?.delta);
+    );
+  return mergeMoneyByCurrency(
+    row.map((r) => ({ currency_code: r.currency_code, amount: r.delta })),
+    fallbackCurrency,
+  );
 }
 
 /* --------------------------- RMA receivables --------------------------- */

--- a/packages/inventory/src/lib/index.ts
+++ b/packages/inventory/src/lib/index.ts
@@ -16,3 +16,4 @@ export * from './availability';
 export * from './inventoryEvents';
 export * from './stockLowSignal';
 export * from './dashboardQueries';
+export * from './tenantCurrency';

--- a/packages/inventory/src/lib/materials.ts
+++ b/packages/inventory/src/lib/materials.ts
@@ -3,6 +3,7 @@ import { IProjectMaterial, IServicePrice, IStockUnit, ITicketMaterial } from '@a
 import { recordStockConsumption, reverseStockConsumption } from './consume';
 import { publishInventoryEvent } from './inventoryEvents';
 import { collectDefaultLocationStockLowSignalAfterConsume } from './stockLowSignal';
+import { resolveTenantCurrency } from './tenantCurrency';
 
 /**
  * Lib-layer transaction helper (this file must stay importable without the
@@ -153,7 +154,7 @@ export async function addMaterial(
         service_id: input.service_id,
         quantity,
         rate,
-        currency_code: input.currency_code || 'USD',
+        currency_code: input.currency_code || await resolveTenantCurrency(trx, tenant),
         description: input.description ?? null,
         is_billed: false,
       })

--- a/packages/inventory/src/lib/openingBalanceCsv.ts
+++ b/packages/inventory/src/lib/openingBalanceCsv.ts
@@ -1,5 +1,7 @@
 import type { Knex } from 'knex';
+import { toMinorUnits } from '@alga-psa/core';
 import { recordStockMovement } from './movements';
+import { resolveTenantCurrency } from './tenantCurrency';
 
 export interface CsvParseResult {
   header: string[];
@@ -119,15 +121,15 @@ function parsePositiveInteger(value: string): number | null {
   return parsed;
 }
 
-function parseCostCents(value: string): number | null {
+function parseCostMinorUnits(value: string, currencyCode: string): number | null {
   if (!/^-?(?:\d+(?:\.\d*)?|\.\d+)$/.test(value)) return null;
   const parsed = Number(value);
   if (!Number.isFinite(parsed) || parsed < 0) return null;
-  const cents = Math.round(parsed * 100);
-  return Number.isSafeInteger(cents) ? cents : null;
+  const minorUnits = toMinorUnits(parsed, undefined, currencyCode);
+  return Number.isSafeInteger(minorUnits) ? minorUnits : null;
 }
 
-export function shapeOpeningBalanceRows(parsed: CsvParseResult): CsvShapeResult {
+export function shapeOpeningBalanceRows(parsed: CsvParseResult, currencyCode: string = 'USD'): CsvShapeResult {
   const errors: Array<{ row: number; message: string }> = [];
   const rows: OpeningBalanceCsvRow[] = [];
 
@@ -191,9 +193,9 @@ export function shapeOpeningBalanceRows(parsed: CsvParseResult): CsvShapeResult 
 
     let unitCostCents: number | null = null;
     if (unitCostText) {
-      unitCostCents = parseCostCents(unitCostText);
+      unitCostCents = parseCostMinorUnits(unitCostText, currencyCode);
       if (unitCostCents === null) {
-        errors.push({ row: rowNumber, message: 'unit_cost must be a non-negative dollar amount' });
+        errors.push({ row: rowNumber, message: 'unit_cost must be a non-negative amount' });
       }
     }
 
@@ -296,6 +298,7 @@ interface OpeningBalancePreparation {
   validation: OpeningBalanceValidation;
   settingsByService: Map<string, SettingsLookupRow>;
   missingSettingsSerialized: Map<string, boolean>;
+  defaultCurrency: string;
 }
 
 function normalizedKey(value: string | null | undefined): string {
@@ -353,7 +356,8 @@ async function prepareOpeningBalance(
   opts?: OpeningBalanceOptions,
 ): Promise<OpeningBalancePreparation> {
   const parsed = parseCsv(csvText);
-  const shaped = shapeOpeningBalanceRows(parsed);
+  const defaultCurrency = await resolveTenantCurrency(trx, tenant);
+  const shaped = shapeOpeningBalanceRows(parsed, defaultCurrency);
   const errors: OpeningBalanceRowError[] = [...shaped.errors];
   const warnings: OpeningBalanceWarning[] = [];
   const errorRows = new Set<number>();
@@ -377,7 +381,7 @@ async function prepareOpeningBalance(
       warnings,
       summary: emptySummary(parsed.rows.length),
     };
-    return { validation, settingsByService, missingSettingsSerialized };
+    return { validation, settingsByService, missingSettingsSerialized, defaultCurrency };
   }
 
   const candidates = shaped.rows.filter((row) => !errorRows.has(row.row));
@@ -569,7 +573,7 @@ async function prepareOpeningBalance(
     warnings,
     summary: summarize(parsed.rows.length, previewRows, missingSettingsSerialized),
   };
-  return { validation, settingsByService, missingSettingsSerialized };
+  return { validation, settingsByService, missingSettingsSerialized, defaultCurrency };
 }
 
 export async function validateOpeningBalance(
@@ -610,6 +614,7 @@ export async function applyOpeningBalance(
   const reason = `opening_balance_import: ${batchLabel}`;
   const rows = validation.rows;
   const serviceIds = Array.from(new Set(rows.map((row) => row.service_id)));
+  const defaultCurrency = prepared.defaultCurrency;
 
   let settingsCreated = 0;
   for (const [serviceId, isSerialized] of prepared.missingSettingsSerialized) {
@@ -620,7 +625,7 @@ export async function applyOpeningBalance(
         service_id: serviceId,
         track_stock: true,
         is_serialized: isSerialized,
-        cost_currency: 'USD',
+        cost_currency: defaultCurrency,
       })
       .onConflict(['tenant', 'service_id'])
       .ignore()
@@ -642,7 +647,7 @@ export async function applyOpeningBalance(
     oldBulkBasis.set(serviceId, {
       quantity: await totalOnHand(trx, tenant, serviceId),
       average_cost: Number(settings.average_cost ?? 0),
-      cost_currency: settings.cost_currency ?? 'USD',
+      cost_currency: settings.cost_currency ?? defaultCurrency,
     });
   }
 
@@ -653,7 +658,7 @@ export async function applyOpeningBalance(
 
   for (const row of rows) {
     const settings = settingsByService.get(row.service_id);
-    const costCurrency = settings?.cost_currency ?? 'USD';
+    const costCurrency = settings?.cost_currency ?? defaultCurrency;
     totalValueCents += row.quantity * (row.unit_cost_cents ?? 0);
 
     if (row.is_serialized) {

--- a/packages/inventory/src/lib/tenantCurrency.ts
+++ b/packages/inventory/src/lib/tenantCurrency.ts
@@ -1,0 +1,14 @@
+import type { Knex } from 'knex';
+import { tenantDb } from '@alga-psa/db';
+
+export async function resolveTenantCurrency(
+  knex: Knex | Knex.Transaction,
+  tenant: string,
+): Promise<string> {
+  const row = await tenantDb(knex, tenant)
+    .table('default_billing_settings')
+    .select<{ default_currency_code: string | null }>('default_currency_code')
+    .first();
+
+  return row?.default_currency_code?.trim() || 'USD';
+}

--- a/packages/ui/src/components/CurrencyInput.tsx
+++ b/packages/ui/src/components/CurrencyInput.tsx
@@ -4,14 +4,19 @@ import React, { useState, useEffect } from 'react';
 import { Input } from './Input';
 import { useOptionalI18n } from '../lib/i18n/client';
 import { LOCALE_CONFIG } from '../lib/i18n/config';
+import { currencyFractionDigits } from '@alga-psa/core';
 
 interface CurrencyInputProps {
   id?: string;
+  label?: string;
   value?: number;
   onChange?: (value: number | undefined) => void;
+  currencyCode?: string;
   disabled?: boolean;
+  required?: boolean;
   placeholder?: string;
   className?: string;
+  containerClassName?: string;
 }
 
 export function getNumberSeparators(locale: string): { group: string; decimal: string } {
@@ -22,10 +27,11 @@ export function getNumberSeparators(locale: string): { group: string; decimal: s
   };
 }
 
-export function formatCurrencyValue(value: number, locale: string): string {
+export function formatCurrencyValue(value: number, locale: string, currencyCode: string = 'USD'): string {
+  const fractionDigits = currencyFractionDigits(currencyCode, locale);
   return new Intl.NumberFormat(locale, {
-    minimumFractionDigits: 2,
-    maximumFractionDigits: 2,
+    minimumFractionDigits: fractionDigits,
+    maximumFractionDigits: fractionDigits,
   }).format(value);
 }
 
@@ -50,11 +56,15 @@ export function parseCurrencyValue(raw: string, locale: string): number {
 
 export function CurrencyInput({
   id,
+  label,
   value,
   onChange,
+  currencyCode = 'USD',
   disabled = false,
+  required,
   placeholder,
   className = '',
+  containerClassName,
 }: CurrencyInputProps) {
   const i18n = useOptionalI18n();
   const locale = i18n?.locale ?? LOCALE_CONFIG.defaultLocale;
@@ -64,9 +74,9 @@ export function CurrencyInput({
     if (value === undefined || value === null || isNaN(value)) {
       setDisplayValue('');
     } else {
-      setDisplayValue(formatCurrencyValue(value, locale));
+      setDisplayValue(formatCurrencyValue(value, locale, currencyCode));
     }
-  }, [value, locale]);
+  }, [currencyCode, value, locale]);
 
   const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     const raw = e.target.value;
@@ -83,7 +93,7 @@ export function CurrencyInput({
   const handleBlur = () => {
     const numeric = parseCurrencyValue(displayValue, locale);
     if (!isNaN(numeric)) {
-      setDisplayValue(formatCurrencyValue(numeric, locale));
+      setDisplayValue(formatCurrencyValue(numeric, locale, currencyCode));
     } else {
       setDisplayValue('');
     }
@@ -92,13 +102,16 @@ export function CurrencyInput({
   return (
     <Input
       id={id}
+      label={label}
       type="text"
       value={displayValue}
       onChange={handleChange}
       onBlur={handleBlur}
-      placeholder={placeholder ?? formatCurrencyValue(0, locale)}
+      placeholder={placeholder ?? formatCurrencyValue(0, locale, currencyCode)}
       disabled={disabled}
+      required={required}
       className={className}
+      containerClassName={containerClassName}
     />
   );
 }

--- a/packages/ui/src/lib/currency/useCurrencyFormat.tsx
+++ b/packages/ui/src/lib/currency/useCurrencyFormat.tsx
@@ -1,0 +1,73 @@
+'use client';
+
+import React from 'react';
+import {
+  currencyFractionDigits,
+  formatCurrencyFromMinorUnits,
+} from '@alga-psa/core';
+import { useOptionalI18n } from '../i18n/client';
+import { LOCALE_CONFIG } from '../i18n/config';
+
+const DEFAULT_CURRENCY = 'USD';
+
+interface CurrencyFormatContextValue {
+  currencyCode: string;
+  locale?: string;
+}
+
+export interface CurrencyFormat {
+  money: (minorUnits: number, currencyOverride?: string) => string;
+  moneySigned: (minorUnits: number, currencyOverride?: string) => string;
+  fractionDigits: (currencyOverride?: string) => number;
+}
+
+const CurrencyFormatContext = React.createContext<CurrencyFormatContextValue>({
+  currencyCode: DEFAULT_CURRENCY,
+});
+
+export function CurrencyFormatProvider({
+  currencyCode,
+  locale,
+  children,
+}: {
+  currencyCode: string;
+  locale?: string;
+  children: React.ReactNode;
+}) {
+  const i18n = useOptionalI18n();
+  const value = React.useMemo(
+    () => ({
+      currencyCode: currencyCode || DEFAULT_CURRENCY,
+      locale: locale || i18n?.locale || LOCALE_CONFIG.defaultLocale,
+    }),
+    [currencyCode, i18n?.locale, locale],
+  );
+
+  return <CurrencyFormatContext.Provider value={value}>{children}</CurrencyFormatContext.Provider>;
+}
+
+export function useCurrencyFormat(): CurrencyFormat {
+  const context = React.useContext(CurrencyFormatContext);
+  const i18n = useOptionalI18n();
+  const locale = context.locale || i18n?.locale || LOCALE_CONFIG.defaultLocale;
+  const currencyCode = context.currencyCode || DEFAULT_CURRENCY;
+
+  return React.useMemo(() => {
+    const resolveCurrency = (currencyOverride?: string) => currencyOverride || currencyCode || DEFAULT_CURRENCY;
+    const money = (minorUnits: number, currencyOverride?: string) =>
+      formatCurrencyFromMinorUnits(Number(minorUnits || 0), locale, resolveCurrency(currencyOverride));
+
+    return {
+      money,
+      moneySigned: (minorUnits: number, currencyOverride?: string) => {
+        const amount = Number(minorUnits || 0);
+        const formatted = money(Math.abs(amount), currencyOverride);
+        if (amount < 0) return `-${formatted}`;
+        if (amount > 0) return `+${formatted}`;
+        return formatted;
+      },
+      fractionDigits: (currencyOverride?: string) =>
+        currencyFractionDigits(resolveCurrency(currencyOverride), locale),
+    };
+  }, [currencyCode, locale]);
+}

--- a/packages/ui/src/lib/index.ts
+++ b/packages/ui/src/lib/index.ts
@@ -6,3 +6,4 @@ export * from './cookies';
 export * from './i18n/client';
 export * from './i18n/config';
 export * from './i18n/interpolateFallback';
+export * from './currency/useCurrencyFormat';

--- a/server/public/locales/de/features/inventory.json
+++ b/server/public/locales/de/features/inventory.json
@@ -744,6 +744,7 @@
     "addPurchaseOrder": "Bestellung hinzufügen",
     "allVendors": "Alle Lieferanten",
     "amountOnOrder": "{{amount}} bestellt",
+    "mixedCurrencyOnOrder": "{{count}} Bestellungen über mehrere Währungen hinweg bestellt",
     "cancelConfirm": "Möchten Sie die Bestellung {{poNumber}} wirklich stornieren? Dies kann nicht rückgängig gemacht werden.",
     "cancelFailed": "Die Bestellung konnte nicht storniert werden.",
     "cancelTitle": "Bestellung stornieren",

--- a/server/public/locales/en/features/inventory.json
+++ b/server/public/locales/en/features/inventory.json
@@ -744,6 +744,7 @@
     "addPurchaseOrder": "Add Purchase Order",
     "allVendors": "All vendors",
     "amountOnOrder": "{{amount}} on order",
+    "mixedCurrencyOnOrder": "{{count}} purchase orders on order across multiple currencies",
     "cancelConfirm": "Are you sure you want to cancel purchase order {{poNumber}}? This cannot be undone.",
     "cancelFailed": "Couldn't cancel the purchase order.",
     "cancelTitle": "Cancel purchase order",

--- a/server/public/locales/en/features/inventory.json
+++ b/server/public/locales/en/features/inventory.json
@@ -717,7 +717,7 @@
     },
     "entryAdded": "Landed-cost entry added.",
     "fields": {
-      "amount": "Amount ($ {{currency}})"
+      "amount": "Amount ({{currency}})"
     },
     "loadError": "Couldn't load landed costs.",
     "nothingReceived": "Nothing received yet — receive the PO first, then apply.",

--- a/server/public/locales/es/features/inventory.json
+++ b/server/public/locales/es/features/inventory.json
@@ -744,6 +744,7 @@
     "addPurchaseOrder": "Añadir orden de compra",
     "allVendors": "Todos los proveedores",
     "amountOnOrder": "{{amount}} en pedido",
+    "mixedCurrencyOnOrder": "{{count}} órdenes de compra en pedido en varias monedas",
     "cancelConfirm": "¿Está seguro de que desea cancelar la orden de compra {{poNumber}}? Esta acción no se puede deshacer.",
     "cancelFailed": "No se pudo cancelar la orden de compra.",
     "cancelTitle": "Cancelar orden de compra",

--- a/server/public/locales/fr/features/inventory.json
+++ b/server/public/locales/fr/features/inventory.json
@@ -744,6 +744,7 @@
     "addPurchaseOrder": "Ajouter un bon de commande",
     "allVendors": "Tous les fournisseurs",
     "amountOnOrder": "{{amount}} en commande",
+    "mixedCurrencyOnOrder": "{{count}} bons de commande en cours dans plusieurs devises",
     "cancelConfirm": "Êtes-vous sûr de vouloir annuler le bon de commande {{poNumber}} ? Cette action est irréversible.",
     "cancelFailed": "Impossible d'annuler le bon de commande.",
     "cancelTitle": "Annuler le bon de commande",

--- a/server/public/locales/it/features/inventory.json
+++ b/server/public/locales/it/features/inventory.json
@@ -744,6 +744,7 @@
     "addPurchaseOrder": "Aggiungi ordine di acquisto",
     "allVendors": "Tutti i fornitori",
     "amountOnOrder": "{{amount}} in ordine",
+    "mixedCurrencyOnOrder": "{{count}} ordini di acquisto in ordine in più valute",
     "cancelConfirm": "Sei sicuro di voler annullare l'ordine di acquisto {{poNumber}}? L'operazione non può essere annullata.",
     "cancelFailed": "Impossibile annullare l'ordine di acquisto.",
     "cancelTitle": "Annulla ordine di acquisto",

--- a/server/public/locales/nl/features/inventory.json
+++ b/server/public/locales/nl/features/inventory.json
@@ -744,6 +744,7 @@
     "addPurchaseOrder": "Inkooporder toevoegen",
     "allVendors": "Alle leveranciers",
     "amountOnOrder": "{{amount}} besteld",
+    "mixedCurrencyOnOrder": "{{count}} inkooporders in bestelling in meerdere valuta",
     "cancelConfirm": "Weet u zeker dat u inkooporder {{poNumber}} wilt annuleren? Dit kan niet ongedaan worden gemaakt.",
     "cancelFailed": "Kon de inkooporder niet annuleren.",
     "cancelTitle": "Inkooporder annuleren",

--- a/server/public/locales/pl/features/inventory.json
+++ b/server/public/locales/pl/features/inventory.json
@@ -744,6 +744,7 @@
     "addPurchaseOrder": "Dodaj zamówienie zakupu",
     "allVendors": "Wszyscy dostawcy",
     "amountOnOrder": "{{amount}} zamówione",
+    "mixedCurrencyOnOrder": "{{count}} zamówień zakupu w toku w wielu walutach",
     "cancelConfirm": "Czy na pewno chcesz anulować zamówienie zakupu {{poNumber}}? Tej operacji nie można cofnąć.",
     "cancelFailed": "Nie udało się anulować zamówienia zakupu.",
     "cancelTitle": "Anuluj zamówienie zakupu",

--- a/server/public/locales/pt/features/inventory.json
+++ b/server/public/locales/pt/features/inventory.json
@@ -744,6 +744,7 @@
     "addPurchaseOrder": "Adicionar Pedido de Compra",
     "allVendors": "Todos os fornecedores",
     "amountOnOrder": "{{amount}} em pedido",
+    "mixedCurrencyOnOrder": "{{count}} pedidos de compra em aberto em várias moedas",
     "cancelConfirm": "Tem certeza de que deseja cancelar o pedido de compra {{poNumber}}? Isso não pode ser desfeito.",
     "cancelFailed": "Não foi possível cancelar o pedido de compra.",
     "cancelTitle": "Cancelar pedido de compra",

--- a/server/public/locales/xx/features/inventory.json
+++ b/server/public/locales/xx/features/inventory.json
@@ -744,6 +744,7 @@
     "addPurchaseOrder": "11111",
     "allVendors": "11111",
     "amountOnOrder": "11111 {{amount}} 11111",
+    "mixedCurrencyOnOrder": "11111 {{count}} 11111",
     "cancelConfirm": "11111 {{poNumber}} 11111",
     "cancelFailed": "11111",
     "cancelTitle": "11111",

--- a/server/public/locales/yy/features/inventory.json
+++ b/server/public/locales/yy/features/inventory.json
@@ -744,6 +744,7 @@
     "addPurchaseOrder": "55555",
     "allVendors": "55555",
     "amountOnOrder": "55555 {{amount}} 55555",
+    "mixedCurrencyOnOrder": "55555 {{count}} 55555",
     "cancelConfirm": "55555 {{poNumber}} 55555",
     "cancelFailed": "55555",
     "cancelTitle": "55555",

--- a/server/src/app/msp/inventory/counts/page.tsx
+++ b/server/src/app/msp/inventory/counts/page.tsx
@@ -1,4 +1,4 @@
-import { listCountSessions, listStockLocations } from '@alga-psa/inventory/actions';
+import { getInventoryTenantCurrency, listCountSessions, listStockLocations } from '@alga-psa/inventory/actions';
 import { CycleCountsManager } from '@alga-psa/inventory/components';
 import { getSession } from '@alga-psa/auth';
 import { redirect } from 'next/navigation';
@@ -29,13 +29,25 @@ export default async function CycleCountsPage() {
   }
 
   let locations: IStockLocation[] = [];
+  let defaultCurrencyCode = 'USD';
   try {
     locations = await listStockLocations();
   } catch (error) {
     console.error('Failed to load stock locations:', error);
   }
+  try {
+    defaultCurrencyCode = await getInventoryTenantCurrency();
+  } catch (error) {
+    console.error('Failed to load inventory default currency:', error);
+  }
 
-  return <CycleCountsManager initialSessions={initialSessions} locations={locations} />;
+  return (
+    <CycleCountsManager
+      initialSessions={initialSessions}
+      locations={locations}
+      defaultCurrencyCode={defaultCurrencyCode}
+    />
+  );
 }
 
 export const dynamic = 'force-dynamic';

--- a/server/src/app/msp/inventory/loaners/page.tsx
+++ b/server/src/app/msp/inventory/loaners/page.tsx
@@ -1,4 +1,4 @@
-import { loanersOutReport } from '@alga-psa/inventory/actions';
+import { getInventoryTenantCurrency, loanersOutReport } from '@alga-psa/inventory/actions';
 import { LoanersManager } from '@alga-psa/inventory/components';
 import { getSession } from '@alga-psa/auth';
 import { redirect } from 'next/navigation';
@@ -22,13 +22,19 @@ export default async function LoanersPage() {
   }
 
   let initialLoaners: LoanerOutRow[] = [];
+  let defaultCurrencyCode = 'USD';
   try {
     initialLoaners = await loanersOutReport();
   } catch (error) {
     console.error('Failed to load loaners:', error);
   }
+  try {
+    defaultCurrencyCode = await getInventoryTenantCurrency();
+  } catch (error) {
+    console.error('Failed to load inventory default currency:', error);
+  }
 
-  return <LoanersManager initialLoaners={initialLoaners} />;
+  return <LoanersManager initialLoaners={initialLoaners} defaultCurrencyCode={defaultCurrencyCode} />;
 }
 
 export const dynamic = 'force-dynamic';

--- a/server/src/app/msp/inventory/page.tsx
+++ b/server/src/app/msp/inventory/page.tsx
@@ -48,7 +48,9 @@ const EMPTY: InventoryDashboardData = {
   ghost_week: { count: 0, est_total: null, techs: [] },
   footer: {
     value: 0,
+    value_by_currency: [],
     wow_delta: 0,
+    wow_delta_by_currency: [],
     on_hand_units: 0,
     serialized_units: 0,
     dead_stock: null,

--- a/server/src/app/msp/inventory/purchase-orders/page.tsx
+++ b/server/src/app/msp/inventory/purchase-orders/page.tsx
@@ -1,4 +1,4 @@
-import { listPurchaseOrders } from '@alga-psa/inventory/actions';
+import { getInventoryTenantCurrency, listPurchaseOrders } from '@alga-psa/inventory/actions';
 import type { PurchaseOrderListRow } from '@alga-psa/inventory/actions';
 import { PurchaseOrdersManager } from '@alga-psa/inventory/components';
 import { getSession } from '@alga-psa/auth';
@@ -23,14 +23,26 @@ export default async function PurchaseOrdersPage() {
 
   let initialPos: PurchaseOrderListRow[] = [];
   let loadError = false;
+  let defaultCurrencyCode = 'USD';
   try {
     initialPos = await listPurchaseOrders({});
   } catch (error) {
     console.error('Failed to load purchase orders:', error);
     loadError = true;
   }
+  try {
+    defaultCurrencyCode = await getInventoryTenantCurrency();
+  } catch (error) {
+    console.error('Failed to load inventory default currency:', error);
+  }
 
-  return <PurchaseOrdersManager initialPos={initialPos} loadError={loadError} />;
+  return (
+    <PurchaseOrdersManager
+      initialPos={initialPos}
+      loadError={loadError}
+      defaultCurrencyCode={defaultCurrencyCode}
+    />
+  );
 }
 
 export const dynamic = 'force-dynamic';

--- a/server/src/app/msp/inventory/sales-orders/page.tsx
+++ b/server/src/app/msp/inventory/sales-orders/page.tsx
@@ -1,4 +1,4 @@
-import { listSalesOrders, listStockLocations } from '@alga-psa/inventory/actions';
+import { getInventoryTenantCurrency, listSalesOrders, listStockLocations } from '@alga-psa/inventory/actions';
 import { SalesOrdersManager } from '@alga-psa/inventory/components';
 // Billing owns SO invoicing (billing → inventory dependency direction); the server
 // action references are passed down to the client component as props (F008).
@@ -68,6 +68,13 @@ export default async function SalesOrdersPage() {
     console.error('Failed to load services:', error);
   }
 
+  let defaultCurrencyCode = 'USD';
+  try {
+    defaultCurrencyCode = await getInventoryTenantCurrency();
+  } catch (error) {
+    console.error('Failed to load inventory default currency:', error);
+  }
+
   return (
     <SalesOrdersManager
       initialSos={initialSos}
@@ -77,6 +84,7 @@ export default async function SalesOrdersPage() {
       fulfillAndInvoice={fulfillAndInvoiceSoLine}
       generateInvoice={generateInvoiceForSalesOrder}
       confirmDropShip={confirmDropShipAndInvoice}
+      defaultCurrencyCode={defaultCurrencyCode}
     />
   );
 }

--- a/server/src/app/msp/inventory/stock/page.tsx
+++ b/server/src/app/msp/inventory/stock/page.tsx
@@ -1,6 +1,6 @@
 // Stock screen: lists inventory-tracked products with summed availability and
 // per-location reorder status. See StockOverview for the grid/dialogs.
-import { listInventoryProducts } from '@alga-psa/inventory/actions';
+import { getInventoryTenantCurrency, listInventoryProducts } from '@alga-psa/inventory/actions';
 import { StockOverview } from '@alga-psa/inventory/components';
 import { getSession } from '@alga-psa/auth';
 import { redirect } from 'next/navigation';
@@ -23,13 +23,19 @@ export default async function StockOverviewPage() {
   }
 
   let initialProducts: any[] = [];
+  let defaultCurrencyCode = 'USD';
   try {
     initialProducts = await listInventoryProducts();
   } catch (error) {
     console.error('Failed to load inventory products:', error);
   }
+  try {
+    defaultCurrencyCode = await getInventoryTenantCurrency();
+  } catch (error) {
+    console.error('Failed to load inventory default currency:', error);
+  }
 
-  return <StockOverview initialProducts={initialProducts} />;
+  return <StockOverview initialProducts={initialProducts} defaultCurrencyCode={defaultCurrencyCode} />;
 }
 
 export const dynamic = 'force-dynamic';

--- a/server/src/app/msp/inventory/vendors/page.tsx
+++ b/server/src/app/msp/inventory/vendors/page.tsx
@@ -1,4 +1,4 @@
-import { listVendors } from '@alga-psa/inventory/actions';
+import { getInventoryTenantCurrency, listVendors } from '@alga-psa/inventory/actions';
 import { VendorsManager } from '@alga-psa/inventory/components';
 import { getSession } from '@alga-psa/auth';
 import { redirect } from 'next/navigation';
@@ -22,13 +22,19 @@ export default async function VendorsPage() {
   }
 
   let initialVendors: IVendor[] = [];
+  let defaultCurrencyCode = 'USD';
   try {
     initialVendors = await listVendors({});
   } catch (error) {
     console.error('Failed to load vendors:', error);
   }
+  try {
+    defaultCurrencyCode = await getInventoryTenantCurrency();
+  } catch (error) {
+    console.error('Failed to load inventory default currency:', error);
+  }
 
-  return <VendorsManager initialVendors={initialVendors} />;
+  return <VendorsManager initialVendors={initialVendors} defaultCurrencyCode={defaultCurrencyCode} />;
 }
 
 export const dynamic = 'force-dynamic';


### PR DESCRIPTION
## Summary

- Promotes inventory money formatting onto the shared UI currency hook backed by the core minor-unit formatters, with per-call currency overrides for row/list displays.
- Adds an inventory tenant currency resolver that reads `default_billing_settings.default_currency_code`, then wires inventory pages and dashboard providers to use tenant default currency instead of hardcoded USD formatting.
- Keeps inventory amounts as integer minor units across displays and inputs, including zero-decimal currencies like JPY and three-decimal currencies like BHD.
- Enforces header-driven currency for purchase orders and landed costs so PO lines and landed-cost entries cannot silently diverge from the PO currency.
- Splits dashboard footer valuation, WoW delta, and dead-stock valuation into currency buckets instead of summing unlike currencies into a single displayed amount.
- Adds and syncs the mixed-currency purchase-order summary locale key across English, translated locales, and pseudo-locales surfaced by CI.
- Rebases this branch onto current `origin/main` before opening the PR; `package-lock.json` remains the only local dirty file and is not part of this PR.

## Smoke Test Results

Exercised the real `localhost:3011` app and real PostgreSQL/PgBouncer data for tenant `dd8cb218-d46d-47f3-be27-8aa50aad5fce`. No simulators or mocks used.

Plan covered:

1. Inventory dashboard no longer falls back to the load-error/zero state.
2. Multi-currency footer valuation renders separate USD/JPY buckets.
3. Nearby inventory analytics navigation still loads.

Results: PASS.

- `/msp/inventory` rendered `#inventory-dashboard-page` with no `#inventory-dashboard-load-error`.
- Footer showed Inventory health `$370.35 + ¥3,880` and week delta `$370.35 + ¥3,380 wk`.
- DB verification matched valuation buckets: JPY `3880` and USD `37035` minor units.
- DB verification matched WoW delta buckets: JPY `3380` and USD `37035` minor units.
- Dashboard Valuation report link opened `/msp/inventory/margin` with Margin Report and no page alert.
- Browser failed-network check returned zero failed requests.

Evidence directory: `/tmp/alga-smoke-evidence/inventory-current-pass-20260709-011754`

Fidelity step-down: `alga-dev` could not create a fresh browser tab this run, so the smoke used the existing controllable `localhost:3011` browser pane `4af70e54-ed29-4a1b-9f2d-748e0711f61e`. It was authenticated as Glinda Good via credentials login; the dev-login banner was confirmed in terminal history, but the password was not retyped because fresh pane creation failed.

Suspicious but unrelated existing env noise: repeated Hocuspocus `ws://localhost:1274` connection refused console errors and TemporalJobRunner unavailable messages in server history.

## Verification

- `npm -w @alga-psa/inventory run typecheck`
- `NODE_OPTIONS=--max-old-space-size=16384 npm -w server run typecheck`
- `NODE_OPTIONS=--max-old-space-size=16384 npm run build`
- `node scripts/find-missing-i18n-keys.cjs`
- `node scripts/validate-translations.cjs`