### PR TITLE
Delete tenant Temporal schedules on deletion

### DIFF
--- a/ee/temporal-workflows/src/activities/tenant-deletion-activities.ts
+++ b/ee/temporal-workflows/src/activities/tenant-deletion-activities.ts
@@ -9,6 +9,7 @@
  */
 
 import { Context } from '@temporalio/activity';
+import { Client, Connection } from '@temporalio/client';
 import crypto from 'crypto';
 import { getAdminConnection, refreshAdminConnection } from '@alga-psa/db/admin.js';
 import { getTenantTableScope, retryOnReadOnly, tenantDb, type TenantTableScope } from '@alga-psa/db';
@@ -2215,4 +2216,83 @@ export async function recordReactivationPaymentAlert(
   }
 
   return { success: true };
+}
+
+/**
+ * Delete every recurring Temporal Schedule owned by a tenant.
+ *
+ * Every per-tenant schedule — accounting-sync-cycle, rmm-alert-reconciliation,
+ * huntress-incident-poll, and workflow-v2 `workflow-schedule:*` — is created by
+ * TemporalJobRunner, which bakes `{ tenantId }` into the started workflow's
+ * `args[0]`. We match on that baked tenantId rather than the schedule id: the
+ * `workflow-schedule:<workflowId>:<scheduleId>` ids carry no tenant, so an
+ * id-substring match would silently orphan them. Global maintenance schedules
+ * run `maintenanceJobWorkflow` with no tenantId and are left untouched.
+ *
+ * Must run BEFORE deleteTenantData drops the `jobs` table, otherwise the
+ * schedules keep firing genericJobWorkflow against deleted parent rows and fail
+ * their FK bookkeeping on every fire (the orphaned-schedule bug this closes).
+ * Idempotent: safe to retry — a re-run re-lists and skips anything already gone.
+ */
+export async function deleteTenantSchedules(
+  tenantId: string
+): Promise<{ deletedScheduleIds: string[] }> {
+  const log = logger();
+  const connection = await Connection.connect({
+    address: process.env.TEMPORAL_ADDRESS || 'temporal-frontend.temporal.svc.cluster.local:7233',
+  });
+  const client = new Client({
+    connection,
+    namespace: process.env.TEMPORAL_NAMESPACE || 'default',
+  });
+
+  const deletedScheduleIds: string[] = [];
+  try {
+    for await (const summary of client.schedule.list()) {
+      const { scheduleId } = summary;
+
+      let belongsToTenant = false;
+      try {
+        const description = await client.schedule.getHandle(scheduleId).describe();
+        const action = description.action as { type?: string; args?: unknown[] };
+        const firstArg = action?.type === 'startWorkflow' ? action.args?.[0] : undefined;
+        const bakedTenantId =
+          firstArg && typeof firstArg === 'object'
+            ? (firstArg as { tenantId?: unknown }).tenantId
+            : undefined;
+        belongsToTenant = bakedTenantId === tenantId;
+      } catch (describeError) {
+        // Vanished between list and describe, or not a start-workflow schedule
+        // we can introspect — skip rather than block the deletion.
+        log.warn('Could not describe schedule during tenant teardown', {
+          tenantId,
+          scheduleId,
+          error: describeError instanceof Error ? describeError.message : String(describeError),
+        });
+        continue;
+      }
+
+      if (!belongsToTenant) continue;
+
+      try {
+        await client.schedule.getHandle(scheduleId).delete();
+        deletedScheduleIds.push(scheduleId);
+        log.info('Deleted tenant schedule', { tenantId, scheduleId });
+      } catch (deleteError) {
+        const message = deleteError instanceof Error ? deleteError.message : String(deleteError);
+        // Idempotent: a concurrent delete already removed it.
+        if (/not.?found/i.test(message)) continue;
+        throw deleteError;
+      }
+    }
+
+    log.info('Tenant schedule teardown complete', {
+      tenantId,
+      deletedCount: deletedScheduleIds.length,
+      deletedScheduleIds,
+    });
+    return { deletedScheduleIds };
+  } finally {
+    await connection.close().catch(() => {});
+  }
 }

--- a/ee/temporal-workflows/src/types/tenant-deletion-types.ts
+++ b/ee/temporal-workflows/src/types/tenant-deletion-types.ts
@@ -50,6 +50,7 @@ export type TenantDeletionStep =
   | 'awaiting_confirmation'
   | 'waiting_for_deletion_date'
   | 'rolling_back'
+  | 'deleting_schedules'
   | 'deleting_tenant_data'
   | 'completed'
   | 'failed';

--- a/ee/temporal-workflows/src/workflows/tenant-deletion-workflow.ts
+++ b/ee/temporal-workflows/src/workflows/tenant-deletion-workflow.ts
@@ -40,6 +40,7 @@ const {
   recordPendingDeletion,
   updateDeletionStatus,
   deleteTenantData,
+  deleteTenantSchedules,
   cancelTenantStripeSubscription,
   sendCancellationConfirmationEmail,
   linkSubscriptionToExistingTenant,
@@ -374,6 +375,27 @@ export async function tenantDeletionWorkflow(
     state.step = 'deleting_tenant_data';
     state.status = 'deleting';
     await updateDeletionStatus({ deletionId, status: 'deleting' });
+
+    // Step 10a: Tear down the tenant's recurring Temporal schedules BEFORE
+    // dropping the jobs table. Otherwise every schedule keeps firing
+    // genericJobWorkflow against deleted parent rows and fails forever (the
+    // orphaned-schedule bug). Non-blocking: the activity already retries; if it
+    // still fails we log and proceed so a schedule-cleanup hiccup can't strand
+    // the deletion — the leftover schedule is recoverable via a backfill sweep.
+    state.step = 'deleting_schedules';
+    try {
+      const scheduleTeardown = await deleteTenantSchedules(input.tenantId);
+      log.info('Recurring Temporal schedules torn down', {
+        tenantId: input.tenantId,
+        deletedCount: scheduleTeardown.deletedScheduleIds.length,
+        deletedScheduleIds: scheduleTeardown.deletedScheduleIds,
+      });
+    } catch (scheduleError) {
+      log.error('Failed to tear down tenant schedules (continuing with deletion)', {
+        tenantId: input.tenantId,
+        error: scheduleError instanceof Error ? scheduleError.message : 'Unknown error',
+      });
+    }
 
     log.info('Executing tenant deletion', { tenantId: input.tenantId });
     const deleteResult = await deleteTenantData(input.tenantId, deletionId);


### PR DESCRIPTION
Tenant deletion dropped the jobs table but left recurring Temporal schedules running, so genericJobWorkflow kept firing every interval against deleted parent rows and failed its createJobDetail FK forever.

Add deleteTenantSchedules activity: list all schedules, match on the tenantId baked into args[0] (not the schedule id, which carries no tenant for workflow-v2 workflow-schedule:* ids), and delete matches. Wire it into tenantDeletionWorkflow as step 10a before deleteTenantData, non-blocking and idempotent. Global maintenanceJobWorkflow schedules carry no tenantId and are left untouched.

"But it kept ticking after the White Rabbit was gone!" cried Alice, as the phantom schedule chimed genericJobWorkflow every fifteen minutes to a jobs table that had long since vanished down the hole. So we taught the Gardener to pull every recurring root bearing the tenant's mark — even the workflow-schedule:* ones that hid their name — and left the maintenanceJobWorkflow beds blooming, undisturbed. ⏰🐇🌹