### PR TITLE
Provision appliance tenant via Temporal workflow

### DIFF
--- a/ee/appliance/docs/registration-install-flow.md
+++ b/ee/appliance/docs/registration-install-flow.md
@@ -30,10 +30,13 @@ license JWT, a per-appliance credential, and the check-in URL. Those flow into t
 Secrets the in-cluster bootstrap consumes:
 
 - `appliance-initial-tenant` gains `INITIAL_TENANT_ID`. The bootstrap
-  (`helm/templates/appliance-bootstrap-configmap.yaml`) runs `create-tenant`, which
-  **adopts that id** instead of generating one, so the appliance's local tenant row
-  *is* the registry tenant. (No install code → `create-tenant` generates a id as
-  before; nothing else changes.)
+  (`helm/templates/appliance-bootstrap-configmap.yaml`) runs
+  `server/scripts/appliance-create-tenant.mjs`, which starts the same Temporal
+  `tenantCreationWorkflow` the hosted environment uses (on the appliance's own
+  Temporal, with the hosted-only customer-tracking/welcome-email steps skipped)
+  and **adopts that id** instead of generating one, so the appliance's local
+  tenant row *is* the registry tenant. (No install code → the workflow generates
+  an id as before; nothing else changes.)
 - `appliance-license-seed` carries the edition + (paid) license token + connected
   credential/check-in URL. The bootstrap seeds `license_state` from it: essentials
   runs at the essentials tier with no token; paid is licensed from first boot and

--- a/ee/server/src/interfaces/tenant.interfaces.ts
+++ b/ee/server/src/interfaces/tenant.interfaces.ts
@@ -27,7 +27,16 @@ export interface TenantCreationInput {
     firstName: string;
     lastName: string;
     email: string;
+    // Pre-set admin password (appliance install). Omitted => generated.
+    password?: string;
   };
+  // Pre-minted tenant id to adopt (appliance install-code redemption).
+  // Omitted => DB-generated.
+  tenantId?: string;
+  // Appliance installs skip the hosted-only steps (no nineminds management
+  // tenant; the operator already knows their password).
+  skipCustomerTracking?: boolean;
+  skipWelcomeEmail?: boolean;
   companyName: string;
   clientName: string;
   licenseCount?: number;

--- a/ee/temporal-workflows/src/db/tenant-operations.ts
+++ b/ee/temporal-workflows/src/db/tenant-operations.ts
@@ -138,6 +138,12 @@ export async function createTenantInDB(
         updated_at: knex.fn.now()
       };
 
+      // Adopt a pre-minted tenant id when provided (appliance install-code
+      // redemption mints the id in the registry before the tenant exists).
+      if (input.tenantId) {
+        tenantData.tenant = input.tenantId;
+      }
+
       // Record which system is paying for this tenant. Defaults to 'stripe'
       // at the DB level so existing flows don't need to change.
       if (input.billingSource) {

--- a/ee/temporal-workflows/src/db/user-operations.ts
+++ b/ee/temporal-workflows/src/db/user-operations.ts
@@ -39,9 +39,10 @@ export async function createAdminUserInDB(
         throw new Error(`An internal user with email ${input.email} already exists. Each internal user email must be unique across all tenants.`);
       }
 
-      // Generate temporary password
-      const temporaryPassword = generateSecurePassword();
-      
+      // Use the pre-set password when supplied (appliance install: the
+      // operator chose it during setup); otherwise generate a temporary one.
+      const temporaryPassword = input.password || generateSecurePassword();
+
       // Create user (matching actual Alga schema)
       const userResult = await db.table('users')
         .insert({
@@ -51,7 +52,7 @@ export async function createAdminUserInDB(
           tenant: input.tenantId,
           user_type: 'internal',
           username: input.email.toLowerCase(), // use lowercased email as username
-          hashed_password: await hashPassword(temporaryPassword) // hash the temporary password
+          hashed_password: await hashPassword(temporaryPassword)
         })
         .returning('user_id');
       

--- a/ee/temporal-workflows/src/types/workflow-types.ts
+++ b/ee/temporal-workflows/src/types/workflow-types.ts
@@ -20,7 +20,17 @@ export interface TenantCreationInput {
     firstName: string;
     lastName: string;
     email: string;
+    // Pre-set admin password (appliance install: the operator chose it during
+    // setup). Omitted => a temporary password is generated.
+    password?: string;
   };
+  // Pre-minted tenant id to adopt (appliance install-code redemption mints the
+  // id in the registry before the tenant exists). Omitted => DB-generated.
+  tenantId?: string;
+  // Appliance installs have no nineminds management tenant, no Stripe, and the
+  // operator already knows their password — skip the hosted-only steps.
+  skipCustomerTracking?: boolean;
+  skipWelcomeEmail?: boolean;
   companyName?: string;
   clientName?: string;
   contractLine?: string;
@@ -67,6 +77,8 @@ export interface TenantCreationResult {
 export interface CreateTenantActivityInput {
   tenantName: string;
   email: string;
+  // Pre-minted tenant id to adopt; omitted => DB-generated.
+  tenantId?: string;
   companyName?: string;
   clientName?: string;
   licenseCount?: number; // Number of licenses for the tenant
@@ -106,6 +118,8 @@ export interface CreateAdminUserActivityInput {
   lastName: string;
   email: string;
   clientId?: string;
+  // Pre-set password (appliance install). Omitted => generated.
+  password?: string;
 }
 
 export interface CreateAdminUserActivityResult {

--- a/ee/temporal-workflows/src/workflows/__tests__/tenant-creation-appliance.test.ts
+++ b/ee/temporal-workflows/src/workflows/__tests__/tenant-creation-appliance.test.ts
@@ -1,0 +1,150 @@
+import path from 'node:path';
+import { describe, expect, it } from 'vitest';
+import { TestWorkflowEnvironment } from '@temporalio/testing';
+import { Worker } from '@temporalio/worker';
+import { tenantCreationWorkflow } from '../tenant-creation-workflow.js';
+import type { TenantCreationInput } from '../../types/workflow-types.js';
+
+/**
+ * Appliance-mode contract for tenantCreationWorkflow: the appliance bootstrap
+ * (server/scripts/appliance-create-tenant.mjs) starts this workflow with a
+ * pre-minted tenant id, a pre-set admin password, and the hosted-only steps
+ * (customer tracking in the nineminds tenant, welcome email) skipped.
+ */
+
+interface RecordedCalls {
+  createTenant: any[];
+  createAdminUser: any[];
+  customerTracking: number;
+  welcomeEmail: number;
+}
+
+async function setupWorkflowTest() {
+  const env = await TestWorkflowEnvironment.createTimeSkipping();
+  const taskQueue = `test-tenant-creation-${Date.now()}`;
+  const calls: RecordedCalls = {
+    createTenant: [],
+    createAdminUser: [],
+    customerTracking: 0,
+    welcomeEmail: 0,
+  };
+
+  const activities = {
+    createTenant: async (input: any) => {
+      calls.createTenant.push(input);
+      return { tenantId: input.tenantId ?? 'generated-tenant-id', clientId: 'client-1' };
+    },
+    run_onboarding_seeds: async () => ({ success: true, seedsApplied: ['01_roles.cjs'] }),
+    createAdminUser: async (input: any) => {
+      calls.createAdminUser.push(input);
+      return {
+        userId: 'user-1',
+        roleId: 'role-1',
+        temporaryPassword: input.password ?? 'generated-password',
+      };
+    },
+    setupTenantData: async () => ({ setupSteps: ['tenant_settings'] }),
+    sendWelcomeEmail: async () => {
+      calls.welcomeEmail += 1;
+      return { emailSent: true };
+    },
+    createCustomerClientActivity: async () => {
+      calls.customerTracking += 1;
+      return { customerId: 'customer-1' };
+    },
+    createCustomerContactActivity: async () => {
+      calls.customerTracking += 1;
+      return { contactId: 'contact-1' };
+    },
+    tagCustomerClientActivity: async () => {
+      calls.customerTracking += 1;
+      return { tagId: 'tag-1' };
+    },
+    getManagementTenantId: async () => ({ tenantId: 'nineminds-tenant' }),
+    createPortalUser: async () => ({ userId: 'portal-user-1', roleId: 'portal-role-1' }),
+    fetchStripeDetailsFromCheckout: async () => ({ stripeCustomerId: 'cus_x' }),
+    rollbackTenant: async () => {},
+    rollbackUser: async () => {},
+    rollbackPortalUser: async () => {},
+    deleteCustomerClientActivity: async () => {},
+    deleteCustomerContactActivity: async () => {},
+  };
+
+  const worker = await Worker.create({
+    connection: env.nativeConnection,
+    taskQueue,
+    workflowsPath: path.resolve(__dirname, '../tenant-creation-workflow.ts'),
+    activities,
+  });
+
+  return { env, worker, taskQueue, calls };
+}
+
+const baseInput: TenantCreationInput = {
+  tenantName: 'Acme MSP',
+  adminUser: {
+    firstName: 'Ada',
+    lastName: 'Admin',
+    email: 'ada@acme.test',
+  },
+  companyName: 'Acme MSP',
+  clientName: 'Acme MSP',
+  productCode: 'psa',
+};
+
+describe('tenantCreationWorkflow appliance mode', () => {
+  it('adopts the pre-minted tenant id, uses the supplied password, and skips hosted-only steps', async () => {
+    const { env, worker, taskQueue, calls } = await setupWorkflowTest();
+    try {
+      const result = await worker.runUntil(
+        env.client.workflow.execute(tenantCreationWorkflow, {
+          args: [
+            {
+              ...baseInput,
+              tenantId: 'pre-minted-tenant-id',
+              adminUser: { ...baseInput.adminUser, password: 'operator-chosen-password' },
+              billingSource: 'manual',
+              skipCustomerTracking: true,
+              skipWelcomeEmail: true,
+            },
+          ],
+          taskQueue,
+          workflowId: `appliance-${Date.now()}`,
+        })
+      );
+
+      expect(result.success).toBe(true);
+      expect(result.tenantId).toBe('pre-minted-tenant-id');
+      expect(calls.createTenant[0].tenantId).toBe('pre-minted-tenant-id');
+      expect(calls.createAdminUser[0].password).toBe('operator-chosen-password');
+      expect(calls.customerTracking).toBe(0);
+      expect(calls.welcomeEmail).toBe(0);
+      expect(result.emailSent).toBe(false);
+    } finally {
+      await env.teardown();
+    }
+  });
+
+  it('keeps the hosted flow unchanged when the appliance fields are omitted', async () => {
+    const { env, worker, taskQueue, calls } = await setupWorkflowTest();
+    try {
+      const result = await worker.runUntil(
+        env.client.workflow.execute(tenantCreationWorkflow, {
+          args: [baseInput],
+          taskQueue,
+          workflowId: `hosted-${Date.now()}`,
+        })
+      );
+
+      expect(result.success).toBe(true);
+      expect(result.tenantId).toBe('generated-tenant-id');
+      expect(calls.createTenant[0].tenantId).toBeUndefined();
+      expect(calls.createAdminUser[0].password).toBeUndefined();
+      expect(calls.customerTracking).toBe(3);
+      expect(calls.welcomeEmail).toBe(1);
+      expect(result.emailSent).toBe(true);
+    } finally {
+      await env.teardown();
+    }
+  });
+});

--- a/ee/temporal-workflows/src/workflows/shared/tenant-creation-steps.ts
+++ b/ee/temporal-workflows/src/workflows/shared/tenant-creation-steps.ts
@@ -24,6 +24,7 @@ const activities = proxyActivities<{
   createTenant(input: {
     tenantName: string;
     email: string;
+    tenantId?: string;
     companyName?: string;
     clientName?: string;
     licenseCount?: number;
@@ -54,6 +55,7 @@ const activities = proxyActivities<{
     lastName: string;
     email: string;
     clientId?: string;
+    password?: string;
   }): Promise<CreateAdminUserActivityResult>;
   setupTenantData(input: {
     tenantId: string;
@@ -221,6 +223,7 @@ export async function runTenantCreationOrchestration(
     const tenantResult = await activities.createTenant({
       tenantName: input.tenantName,
       email: input.adminUser.email,
+      tenantId: input.tenantId,
       companyName: tenantCompanyName,
       clientName: tenantDefaultClientName,
       licenseCount: stripeDetails.licenseCount,
@@ -279,6 +282,7 @@ export async function runTenantCreationOrchestration(
       lastName: input.adminUser.lastName,
       email: input.adminUser.email,
       clientId: tenantResult.clientId,
+      password: input.adminUser.password,
     });
 
     userCreated = true;
@@ -311,7 +315,12 @@ export async function runTenantCreationOrchestration(
 
     log.info('Tenant data setup completed', { setupSteps: setupResult.setupSteps });
 
-    // Step 5: Create customer tracking records (optional, non-blocking)
+    // Step 5: Create customer tracking records (optional, non-blocking).
+    // Skipped on appliance installs: there is no nineminds management tenant
+    // to track the customer in.
+    if (input.skipCustomerTracking) {
+      log.info('Skipping customer tracking records (skipCustomerTracking=true)');
+    } else {
     try {
       workflowState.step = 'creating_customer_tracking';
       workflowState.progress = 85;
@@ -388,8 +397,10 @@ export async function runTenantCreationOrchestration(
         tenantName: input.tenantName,
       });
     }
+    }
 
-    // Step 6: Send welcome email
+    // Step 6: Send welcome email. Skipped on appliance installs: the operator
+    // set their own password during setup, so there is no credential to send.
     workflowState.step = 'sending_welcome_email';
     workflowState.progress = 95;
 
@@ -397,23 +408,27 @@ export async function runTenantCreationOrchestration(
       throw new Error(`Workflow cancelled: ${cancelReason}`);
     }
 
-    log.info('Sending welcome email to admin user');
-    const emailResult = await activities.sendWelcomeEmail({
-      tenantId: tenantResult.tenantId,
-      tenantName: input.tenantName,
-      adminUser: {
-        userId: userResult.userId,
-        firstName: input.adminUser.firstName,
-        lastName: input.adminUser.lastName,
-        email: input.adminUser.email,
-      },
-      temporaryPassword,
-      clientName: tenantDefaultClientName,
-      companyName: tenantCompanyName,
-      productCode: input.productCode,
-    });
+    if (input.skipWelcomeEmail) {
+      log.info('Skipping welcome email (skipWelcomeEmail=true)');
+    } else {
+      log.info('Sending welcome email to admin user');
+      const emailResult = await activities.sendWelcomeEmail({
+        tenantId: tenantResult.tenantId,
+        tenantName: input.tenantName,
+        adminUser: {
+          userId: userResult.userId,
+          firstName: input.adminUser.firstName,
+          lastName: input.adminUser.lastName,
+          email: input.adminUser.email,
+        },
+        temporaryPassword,
+        clientName: tenantDefaultClientName,
+        companyName: tenantCompanyName,
+        productCode: input.productCode,
+      });
 
-    emailSent = emailResult.emailSent;
+      emailSent = emailResult.emailSent;
+    }
     workflowState.emailSent = emailSent;
     workflowState.progress = 100;
     workflowState.step = 'completed';

--- a/helm/templates/appliance-bootstrap-configmap.yaml
+++ b/helm/templates/appliance-bootstrap-configmap.yaml
@@ -184,17 +184,14 @@ data:
       require_initial_tenant_value INITIAL_ADMIN_EMAIL
       require_initial_tenant_value INITIAL_ADMIN_PASSWORD
 
-      log "Creating initial appliance tenant and admin user"
-      # INITIAL_TENANT_ID (set when an install code was redeemed) makes
-      # create-tenant adopt the registry-minted tenant id; empty => DB-generated.
-      INITIAL_ADMIN_PASSWORD="${INITIAL_ADMIN_PASSWORD}" INITIAL_TENANT_ID="${INITIAL_TENANT_ID:-}" npx tsx /app/server/scripts/create-tenant.ts \
-        --tenant "${INITIAL_TENANT_NAME}" \
-        --companyName "${INITIAL_TENANT_NAME}" \
-        --clientName "${INITIAL_TENANT_NAME}" \
-        --email "${INITIAL_ADMIN_EMAIL}" \
-        --firstName "${INITIAL_ADMIN_FIRST_NAME}" \
-        --lastName "${INITIAL_ADMIN_LAST_NAME}" \
-        --productCode psa
+      log "Creating initial appliance tenant and admin user (Temporal tenantCreationWorkflow)"
+      # Runs the same Temporal workflow the hosted environment uses for tenant
+      # provisioning. The script reads the INITIAL_* env vars directly
+      # (INITIAL_TENANT_ID, set when an install code was redeemed, makes the
+      # workflow adopt the registry-minted tenant id; empty => DB-generated).
+      # The temporal-worker deploys concurrently with this job; the workflow
+      # queues until the worker polls, and the script waits for the result.
+      node /app/server/scripts/appliance-create-tenant.mjs
       log "Initial appliance tenant and admin user created"
     }
 

--- a/helm/templates/jobs.yaml
+++ b/helm/templates/jobs.yaml
@@ -233,6 +233,14 @@ spec:
             {{- if .Values.setup.applianceBootstrap.enabled }}
             - name: SEEDS_DIR
               value: "/app/ee/server/seeds/onboarding"
+            # Initial tenant creation runs the hosted tenantCreationWorkflow on
+            # the appliance Temporal (deployed concurrently with this job).
+            - name: TEMPORAL_ADDRESS
+              value: {{ .Values.setup.applianceBootstrap.temporal.address | default (printf "temporal-frontend.%s.svc.cluster.local:7233" (include "sebastian.namespace" .)) | quote }}
+            - name: TEMPORAL_NAMESPACE
+              value: {{ .Values.setup.applianceBootstrap.temporal.namespace | default "default" | quote }}
+            - name: TEMPORAL_TASK_QUEUE
+              value: {{ .Values.setup.applianceBootstrap.temporal.taskQueue | default "tenant-workflows" | quote }}
             {{- end }}
 
             # Secret provider configuration for setup jobs
@@ -246,11 +254,12 @@ spec:
             {{- end }}
 
             {{- if .Values.setup.applianceBootstrap.enabled }}
-            # Appliance bootstrap hashes the initial admin password with PBKDF2
-            # peppered by getSecret('nextauth_secret','NEXTAUTH_SECRET'); getSecret
-            # consults the env provider FIRST, which looks up the *lowercase*
-            # secret name. Bind both names to the shared cluster secret so the
-            # bootstrap and the server resolve the identical pepper.
+            # The initial admin password is hashed by the temporal-worker (which
+            # binds the same NEXTAUTH_SECRET pepper from this cluster secret via
+            # auth.nextauthSecretSecret). These bindings remain for the seed/knex
+            # paths this job still runs: getSecret consults the env provider
+            # FIRST, which looks up the *lowercase* secret name, so bind both
+            # names to the shared cluster secret.
             - name: nextauth_secret
               valueFrom:
                 secretKeyRef:

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -57,6 +57,12 @@ setup:
     lockTimeoutSeconds: 1800
     lockStaleSeconds: 120
     lockHeartbeatSeconds: 10
+    # Temporal connection for the initial-tenant workflow (appliance only).
+    # address defaults to temporal-frontend.<release namespace>.svc.cluster.local:7233.
+    temporal:
+      address: ""
+      namespace: "default"
+      taskQueue: "tenant-workflows"
   waitForBootstrap:
     image:
       # Optional lightweight image with psql used by the app initContainer while

--- a/packages/db/src/lib/knexfile.ts
+++ b/packages/db/src/lib/knexfile.ts
@@ -9,13 +9,16 @@ import type { Knex } from 'knex';
 import { setTypeParser } from 'pg-types';
 import { validate as uuidValidate } from 'uuid';
 import { getSecret } from '@alga-psa/core/secrets';
+import * as dotenv from 'dotenv';
 
 type Function = (err: Error | null, connection: Knex.Client) => void;
 
-// Load test environment variables if we're in a test environment
+// Load test environment variables if we're in a test environment.
+// Static dotenv import (not `await import`): top-level await makes this module
+// ESM-only, and the appliance bootstrap loads it through a CJS require chain
+// (tsx create-tenant.ts -> require(tenant-creation) -> @alga-psa/db source).
 if (typeof process !== 'undefined' && process.env?.NODE_ENV === 'test') {
   try {
-    const dotenv = await import('dotenv');
     const result = dotenv.config({ path: '.env.localtest' });
     if (result.parsed?.DB_NAME_SERVER) {
       (process.env as any).DB_NAME_SERVER = result.parsed.DB_NAME_SERVER;

--- a/server/scripts/appliance-create-tenant.mjs
+++ b/server/scripts/appliance-create-tenant.mjs
@@ -1,0 +1,123 @@
+#!/usr/bin/env node
+
+/**
+ * Appliance bootstrap: create the initial tenant + admin user by running the
+ * same Temporal tenantCreationWorkflow the hosted environment uses.
+ *
+ * Plain .mjs on purpose: this runs inside the production image at first boot,
+ * where workspace packages (@alga-psa/*) have no built dist/ and tsx has
+ * repeatedly broken on runtime resolution (three prior incidents in
+ * create-tenant.ts). This script imports ONLY @temporalio/client — a published
+ * npm dependency of ee/server that is always present in node_modules — and
+ * needs no transpilation.
+ *
+ * Inputs (env):
+ *   INITIAL_TENANT_NAME, INITIAL_ADMIN_FIRST_NAME, INITIAL_ADMIN_LAST_NAME,
+ *   INITIAL_ADMIN_EMAIL, INITIAL_ADMIN_PASSWORD  — required
+ *   INITIAL_TENANT_ID   — optional pre-minted tenant id (install-code redeem)
+ *   TEMPORAL_ADDRESS    — default temporal-frontend.msp.svc.cluster.local:7233
+ *   TEMPORAL_NAMESPACE  — default "default"
+ *   TEMPORAL_TASK_QUEUE — default "tenant-workflows"
+ *   BOOTSTRAP_TEMPORAL_WAIT_TIMEOUT_SECONDS — how long to retry connecting to
+ *     the Temporal frontend (default 600; it deploys concurrently with this job)
+ */
+
+import { Client, Connection, WorkflowExecutionAlreadyStartedError } from '@temporalio/client';
+
+const log = (message) => {
+  console.log(`[${new Date().toISOString().replace('T', ' ').slice(0, 19)}] ${message}`);
+};
+
+const requireEnv = (name) => {
+  const value = process.env[name];
+  if (!value) {
+    log(`ERROR: ${name} is required to create the initial appliance tenant`);
+    process.exit(1);
+  }
+  return value;
+};
+
+const tenantName = requireEnv('INITIAL_TENANT_NAME');
+const firstName = requireEnv('INITIAL_ADMIN_FIRST_NAME');
+const lastName = requireEnv('INITIAL_ADMIN_LAST_NAME');
+const email = requireEnv('INITIAL_ADMIN_EMAIL');
+const password = requireEnv('INITIAL_ADMIN_PASSWORD');
+const tenantId = process.env.INITIAL_TENANT_ID || undefined;
+
+const address = process.env.TEMPORAL_ADDRESS || 'temporal-frontend.msp.svc.cluster.local:7233';
+const namespace = process.env.TEMPORAL_NAMESPACE || 'default';
+const taskQueue = process.env.TEMPORAL_TASK_QUEUE || 'tenant-workflows';
+
+// Fixed workflow id so bootstrap-job retries attach to the same execution
+// instead of minting duplicate tenants.
+const workflowId = 'appliance-initial-tenant';
+
+async function connectWithRetry() {
+  const timeoutSeconds = Number(process.env.BOOTSTRAP_TEMPORAL_WAIT_TIMEOUT_SECONDS || 600);
+  const startedAt = Date.now();
+  for (;;) {
+    try {
+      return await Connection.connect({ address });
+    } catch (error) {
+      if (Date.now() - startedAt >= timeoutSeconds * 1000) {
+        log(`ERROR: Temporal frontend did not become reachable within ${timeoutSeconds}s at ${address}`);
+        log(`ERROR: ${error instanceof Error ? error.message : error}`);
+        process.exit(1);
+      }
+      log(`Temporal frontend is not ready yet at ${address} - retrying`);
+      await new Promise((resolve) => setTimeout(resolve, 5000));
+    }
+  }
+}
+
+const connection = await connectWithRetry();
+const client = new Client({ connection, namespace });
+
+const input = {
+  tenantName,
+  adminUser: { firstName, lastName, email, password },
+  companyName: tenantName,
+  clientName: tenantName,
+  productCode: 'psa',
+  billingSource: 'manual',
+  tenantId,
+  skipCustomerTracking: true,
+  skipWelcomeEmail: true,
+};
+
+let handle;
+try {
+  handle = await client.workflow.start('tenantCreationWorkflow', {
+    args: [input],
+    taskQueue,
+    workflowId,
+    // Re-running the bootstrap after a failed attempt starts a fresh run; after
+    // a successful one it attaches to the completed execution instead of
+    // minting a duplicate tenant.
+    workflowIdReusePolicy: 'ALLOW_DUPLICATE_FAILED_ONLY',
+    workflowExecutionTimeout: '1h',
+    workflowRunTimeout: '30m',
+  });
+  log(`Started tenantCreationWorkflow (workflowId=${workflowId}, taskQueue=${taskQueue})`);
+} catch (error) {
+  if (error instanceof WorkflowExecutionAlreadyStartedError) {
+    log(`tenantCreationWorkflow already started (workflowId=${workflowId}); attaching to it`);
+    handle = client.workflow.getHandle(workflowId);
+  } else {
+    throw error;
+  }
+}
+
+try {
+  // The temporal-worker deploys concurrently with this job and may still be
+  // starting; Temporal queues the workflow until a worker polls the task queue.
+  log('Waiting for tenant creation workflow to complete...');
+  const result = await handle.result();
+  log(`Tenant created successfully (tenantId=${result.tenantId}, adminUserId=${result.adminUserId}${tenantId ? ', adopted from INITIAL_TENANT_ID' : ''})`);
+} catch (error) {
+  log(`ERROR: Tenant creation workflow failed: ${error instanceof Error ? error.message : error}`);
+  log(`ERROR: Inspect the execution in Temporal (workflowId=${workflowId}) for details; it can be retried by re-running the bootstrap job.`);
+  process.exit(1);
+} finally {
+  await connection.close().catch(() => {});
+}

--- a/server/scripts/create-tenant.ts
+++ b/server/scripts/create-tenant.ts
@@ -9,7 +9,6 @@ import * as dotenv from 'dotenv';
 import * as path from 'path';
 import { fileURLToPath } from 'url';
 import { createRequire } from 'node:module';
-import { tenantDb } from '@alga-psa/db';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
@@ -147,9 +146,12 @@ async function main() {
     // SaaS provisioning path does, so without this the OnboardingProvider redirect
     // (which requires onboarding_completed=false AND onboarding_skipped=false)
     // never fires. Idempotent + best-effort so it never blocks tenant creation.
+    // Plain knex (not the @alga-psa/db tenantDb facade): that package resolves to
+    // dist/ output absent from the --omit=dev production image, and importing it
+    // crashes this script at load (ERR_MODULE_NOT_FOUND) during appliance install.
     try {
       const now = new Date();
-      await tenantDb(db, result.tenantId).table('tenant_settings')
+      await db('tenant_settings')
         .insert({
           tenant: result.tenantId,
           onboarding_completed: false,


### PR DESCRIPTION
Replace the fragile tsx create-tenant.ts appliance bootstrap (three ERR_MODULE_NOT_FOUND incidents) with the hosted tenantCreationWorkflow:

- TenantCreationInput gains optional tenantId adoption (registry-minted install-code ids), adminUser.password (operator-chosen), and skipCustomerTracking/skipWelcomeEmail flags; hosted flow unchanged when omitted
- New appliance-create-tenant.mjs trigger imports only the published @temporalio/client — no tsx, no workspace dist resolution at boot — with a fixed workflow id + ALLOW_DUPLICATE_FAILED_ONLY so job retries never mint duplicate tenants
- Bootstrap configmap/job wire TEMPORAL_* env; values expose setup.applianceBootstrap.temporal
- create-tenant.ts drops its @alga-psa/db import and knexfile.ts drops top-level await, unbreaking the current installer as a fallback
- Time-skipping workflow tests pin both appliance and hosted behavior

"Pay no attention to the tsx behind the curtain!" boomed the great and powerful Oz, as the appliance clicked its ruby slippers three times — "there's no place like temporal-frontend.msp.svc.cluster.local:7233" — and the tenant it had always been in the registry appeared at last, password in hand, no wizard's welcome email required. 🌪️👠✨