### PR TITLE
Ship @alga-psa/db dist in temporal-worker image

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -15,6 +15,13 @@ build
 !shared/dist/**
 !ee/packages/workflows/dist/**
 !packages/workflow-streams/dist/**
+# Runtime-resolved @alga-psa packages: their dist/ must ship in images whose
+# code resolves them from node_modules at runtime — the onboarding seeds
+# dynamic-import '@alga-psa/db', and db's dist imports @alga-psa/core. Missing
+# db/dist broke tenant provisioning (temporal-worker) and the appliance
+# install (server image).
+!packages/core/dist/**
+!packages/db/dist/**
 !packages/event-schemas/dist/**
 
 # Environment variables

--- a/ee/temporal-workflows/Dockerfile
+++ b/ee/temporal-workflows/Dockerfile
@@ -73,6 +73,22 @@ RUN npx tsup
 WORKDIR /app/packages/jobs
 RUN npx tsup
 
+# Build @alga-psa/core and @alga-psa/db. The worker's own TS compiles to
+# self-contained relative imports (tsc-alias), but the onboarding seeds
+# dynamic-import '@alga-psa/db' per seed file, resolving it through the
+# node_modules symlink -> /app/packages/db — so its dist/ must exist (missing
+# db/dist broke tenant provisioning in prod: run_onboarding_seeds
+# ERR_MODULE_NOT_FOUND). core builds first: db's dist imports
+# @alga-psa/core/secrets and /logger at runtime.
+# Known-latent, deliberately NOT built here (never hit in prod traffic): the
+# shared/dist and @alga-psa/workflows runtime bundles also carry lazy bare
+# imports of @alga-psa/{event-bus,authorization,types,storage}. If one of
+# those paths ever fires ERR_MODULE_NOT_FOUND, add the same two lines for it.
+WORKDIR /app/packages/core
+RUN npm install --ignore-scripts && npm run build
+WORKDIR /app/packages/db
+RUN npm install --ignore-scripts && npm run build
+
 WORKDIR /app/ee/temporal-workflows
 RUN npm run build
 
@@ -107,6 +123,11 @@ RUN mkdir -p /app/node_modules/@alga-psa \
 
 RUN ls -la /app/ee/temporal-workflows/dist/seeds/onboarding || echo "Seeds directory not found in prebuilt production stage"
 
+# Same runtime-resolution guard as the production stage: the prebuilt path
+# relies on packages/*/dist arriving via the build context (.dockerignore
+# whitelist) — fail the build here rather than in prod if they didn't.
+RUN cd /app/ee/temporal-workflows && node --input-type=module -e "const m = await import('@alga-psa/db'); if (typeof m.tenantDb !== 'function') throw new Error('@alga-psa/db loaded but tenantDb missing')"
+
 RUN groupadd -r temporal && useradd -r -g temporal temporal
 RUN chown -R temporal:temporal /app
 USER temporal
@@ -132,6 +153,10 @@ COPY --from=development /app/ee/temporal-workflows/node_modules /app/ee/temporal
 COPY --from=development /app/ee/packages/workflows /app/ee/packages/workflows
 # Copy event-schemas dist (runtime dependency of shared/workflow/streams)
 COPY --from=development /app/packages/event-schemas/dist /app/packages/event-schemas/dist
+# Copy the runtime-resolved @alga-psa package dists built above (base-stage
+# packages/ came from the build context, where .dockerignore strips **/dist)
+COPY --from=development /app/packages/core/dist /app/packages/core/dist
+COPY --from=development /app/packages/db/dist /app/packages/db/dist
 # Copy integrations node_modules to both locations for module resolution
 COPY --from=development /app/packages/integrations/node_modules /app/packages/integrations/node_modules
 COPY --from=development /app/packages/integrations/node_modules /app/ee/temporal-workflows/dist/packages/integrations/node_modules
@@ -147,6 +172,11 @@ RUN mkdir -p /app/node_modules/@alga-psa /app/ee/temporal-workflows/node_modules
 
 # Verify seeds are present in production stage
 RUN ls -la /app/ee/temporal-workflows/dist/seeds/onboarding || echo "Seeds directory not found in production stage"
+
+# Fail the build if the runtime-resolved db package can't load the way the
+# onboarding seeds load it (dynamic import from node_modules). Missing
+# packages/db/dist shipped silently and broke prod tenant provisioning.
+RUN cd /app/ee/temporal-workflows && node --input-type=module -e "const m = await import('@alga-psa/db'); if (typeof m.tenantDb !== 'function') throw new Error('@alga-psa/db loaded but tenantDb missing')"
 
 # Create non-root user
 RUN groupadd -r temporal && useradd -r -g temporal temporal

--- a/server/src/middleware.ts
+++ b/server/src/middleware.ts
@@ -70,6 +70,7 @@ const apiKeySkipPaths = [
   '/api/teams/message-extension/',
   '/api/teams/webhooks/',  // Microsoft Graph change notifications; authenticated via clientState secret in the route
   '/api/teams/package/download',
+  '/api/online-meetings/recordings/',
   '/api/client-portal/domain-session',
   // Mobile auth endpoints use OTT/refresh tokens (no x-api-key)
   '/api/v1/mobile/auth/',
@@ -132,7 +133,9 @@ const apiKeySkipPaths = [
 export function shouldSkipApiKeyAuth(pathname: string): boolean {
   return apiKeySkipPaths.some((path) => pathname.startsWith(path)) ||
     (pathname.startsWith('/api/tickets/') && pathname.endsWith('/live-token')) ||
-    (pathname.startsWith('/api/documents/') && (pathname.endsWith('/thumbnail') || pathname.endsWith('/preview'))) ||
+    (pathname.startsWith('/api/documents/') &&
+      (pathname.endsWith('/thumbnail') || pathname.endsWith('/preview') ||
+        pathname.endsWith('/download') || pathname.endsWith('/content'))) ||
     // Session-authenticated inventory SO document endpoints (auth enforced in-handler via withAuth).
     (pathname.startsWith('/api/inventory/sales-orders/') &&
       (pathname.endsWith('/document') || pathname.endsWith('/email-confirmation')));

--- a/server/src/test/unit/middleware.apiKeyAuth.test.ts
+++ b/server/src/test/unit/middleware.apiKeyAuth.test.ts
@@ -16,6 +16,15 @@ describe('shouldSkipApiKeyAuth', () => {
     expect(shouldSkipApiKeyAuth('/api/documents/123/thumbnail')).toBe(true);
   });
 
+  it('allows document download/content routes to use session auth (e.g. meeting transcripts)', () => {
+    expect(shouldSkipApiKeyAuth('/api/documents/123/download')).toBe(true);
+    expect(shouldSkipApiKeyAuth('/api/documents/123/content')).toBe(true);
+  });
+
+  it('allows the Teams online-meeting recording proxy to use session auth', () => {
+    expect(shouldSkipApiKeyAuth('/api/online-meetings/recordings/artifact-123')).toBe(true);
+  });
+
   it('allows public appointment calendar downloads from email links', () => {
     expect(shouldSkipApiKeyAuth('/api/calendar/appointment/2187d639-b796-4b0e-b760-8a2576bb435f.ics')).toBe(true);
   });


### PR DESCRIPTION
The tenant-facade migration made the onboarding seeds dynamic-import @alga-psa/db at runtime, but the worker image never built that package's dist/ (root .dockerignore strips **/dist), so tenantCreationWorkflow failed at run_onboarding_seeds in prod. Build core + db in the builder stage, copy their dist into both production stages, and add a build-time import guard so a missing dist fails the image build instead of a customer checkout. Whitelist the two dists in .dockerignore so the server/appliance image (knex seed:run path) gets them too.

Also: let document /download + /content routes and the Teams online-meeting recording proxy use session auth (skip x-api-key), with middleware tests.

Glinda smiled and said, "You've always had the dist, my dear — the seeds just had to click their symlinks three times and repeat: there's no place like /app/packages/db/dist." 🌪️👠🌱