### PR TITLE
fix: require database runtime in appliance app image

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -13,6 +13,10 @@ build
 **/dist
 !shared/dist
 !shared/dist/**
+!packages/core/dist
+!packages/core/dist/**
+!packages/db/dist
+!packages/db/dist/**
 !ee/packages/workflows/dist/**
 !packages/workflow-streams/dist/**
 # Runtime-resolved @alga-psa packages: their dist/ must ship in images whose

--- a/ee/appliance/host-service/tests/appliance-temporal-tenant-bootstrap.test.mjs
+++ b/ee/appliance/host-service/tests/appliance-temporal-tenant-bootstrap.test.mjs
@@ -68,3 +68,13 @@ test('Temporal worker image includes database exports required by onboarding see
     /COPY --from=development \/app\/packages\/db\/dist \/app\/packages\/db\/dist/
   );
 });
+
+test('EE application image requires onboarding seed runtime package exports', () => {
+  const dockerfile = read('ee/server/Dockerfile');
+  const dockerignore = read('.dockerignore');
+
+  assert.match(dockerfile, /test -f \/app\/packages\/core\/dist\/index\.js/);
+  assert.match(dockerfile, /test -f \/app\/packages\/db\/dist\/index\.js/);
+  assert.match(dockerignore, /!packages\/core\/dist\/\*\*/);
+  assert.match(dockerignore, /!packages\/db\/dist\/\*\*/);
+});

--- a/ee/server/Dockerfile
+++ b/ee/server/Dockerfile
@@ -56,6 +56,12 @@ COPY ./shared/ ./shared/
 # Copy packages directory for webpack aliases
 COPY ./packages/ ./packages/
 
+# Appliance onboarding seeds execute in this image after Temporal creates the
+# tenant. Fail the build if the runtime exports those seeds import were not
+# included by the pre-build pipeline.
+RUN test -f /app/packages/core/dist/index.js \
+    && test -f /app/packages/db/dist/index.js
+
 # Copy pre-built Next.js artifacts (must exist locally with EE features)
 # server/dist is no longer required here; workflow-worker is built/deployed separately
 COPY ./server/.next ./server/.next


### PR DESCRIPTION
## Summary
- unignore the core and database dist directories themselves so Docker includes their contents
- fail the EE image build when onboarding seed runtime exports are absent
- add an appliance image contract regression test

## Validation
- node --test ee/appliance/host-service/tests/appliance-temporal-tenant-bootstrap.test.mjs

## Runtime evidence
A clean appliance on release a611242f completed Temporal tenant creation, then the bootstrap's local onboarding seed step failed because the EE app image lacked /app/node_modules/@alga-psa/db/dist/index.js. This follow-up closes that second image boundary.