### PR TITLE
docs: documentation drift audit 2026-07-10

### DIFF
--- a/docs/architecture/job_scheduler.md
+++ b/docs/architecture/job_scheduler.md
@@ -141,7 +141,7 @@ await scheduler.scheduleRecurringJob('daily-report', '0 0 * * *', {});
 ## Registered Job Handlers
 
 | Job Name | Description | Timeout |
-|----------|-------------|---------|
+|----------|-------------|--------|
 | `generate-invoice` | Generate invoices for billing cycles | 5 min |
 | `invoice_zip` | Create ZIP archives of invoices | 10 min |
 | `invoice_email` | Send invoice emails | default |
@@ -237,6 +237,20 @@ A recurring Temporal schedule bakes one `jobId` into its workflow action args at
 4. Logs a `WARN`-level entry in the Temporal worker log so the repair is visible.
 
 Without this self-healing, every subsequent schedule fire would fail at bookkeeping before the handler ran, generating orphan `pending` rows (~13k rows/day in a busy installation) while appearing COMPLETED in Temporal.
+
+### Schedule teardown on tenant deletion
+
+When a tenant is deleted via `tenantDeletionWorkflow`, the workflow executes a `deleteTenantSchedules` activity as **step 10a, before** `deleteTenantData` drops the `jobs` table. The activity:
+
+1. Lists every schedule in the Temporal namespace.
+2. Describes each schedule and inspects `args[0]` of its workflow action. Schedules whose first argument carries a `tenantId` matching the deleted tenant are deleted; global maintenance schedules (such as `maintenanceJobWorkflow` schedules, which carry no per-tenant `tenantId`) are left untouched.
+3. Logs a summary of the deleted schedule IDs on completion.
+
+**Why this ordering matters:** without explicit teardown, a recurring Temporal schedule keeps firing `genericJobWorkflow` against parent rows that no longer exist. Each fire fails its FK bookkeeping on every invocation, generating error log noise indefinitely. Running schedule teardown before data deletion closes this window.
+
+The step is **non-blocking**: if `deleteTenantSchedules` throws unexpectedly, the error is logged and `tenantDeletionWorkflow` proceeds to data deletion. A lingering schedule is recoverable via a manual sweep in the Temporal UI; a cleanup failure must not strand the tenant deletion. The activity is **idempotent**: a retry re-lists all schedules and silently skips any that were already deleted or have since disappeared.
+
+> **Note on schedule ID matching:** `TemporalJobRunner`-created schedules often use IDs of the form `workflow-schedule:<workflowId>:<scheduleId>` that carry no embedded tenant identifier. Matching is therefore done by inspecting the `tenantId` baked into `args[0]` of each schedule's workflow action — not by parsing the schedule ID string.
 
 ### Job handler failures surface as FAILED in Temporal
 


### PR DESCRIPTION
## Source PRs (alga-psa, merged 2026-07-09 → 2026-07-10)

| # | Title | Merged |
|---|-------|--------|
| [#2891](https://github.com/Nine-Minds/alga-psa/pull/2891) | Delete tenant Temporal schedules on deletion | 2026-07-09T15:24Z |
| [#2894](https://github.com/Nine-Minds/alga-psa/pull/2894) | Ship @alga-psa/db dist in temporal-worker image | 2026-07-09T23:29Z |
| [#2893](https://github.com/Nine-Minds/alga-psa/pull/2893) | Provision appliance tenant via Temporal workflow | 2026-07-09T20:44Z |
| [#2897](https://github.com/Nine-Minds/alga-psa/pull/2897) | Fix vitest auth-mock deadlock; repair test suites | 2026-07-10T02:52Z |
| [#2899](https://github.com/Nine-Minds/alga-psa/pull/2899) | Record billing_cycle_alignment inventory removal | 2026-07-10T03:50Z |

## Files edited

### `docs/architecture/job_scheduler.md`

**Rationale (PR #2891):** The "Recurring Job Lifecycle (Temporal EE)" section described tracker row semantics and self-healing but said nothing about what happens to recurring Temporal schedules when a tenant is deleted. Before #2891, deleted tenants left orphaned schedules firing `genericJobWorkflow` against non-existent rows indefinitely. After #2891, `tenantDeletionWorkflow` runs `deleteTenantSchedules` as step 10a (before `deleteTenantData`), which lists all Temporal schedules, matches each by the `tenantId` baked into `args[0]`, and deletes every matched schedule. The new subsection "Schedule teardown on tenant deletion" explains the ordering rationale, matching approach (args-based, not ID-substring), non-blocking behaviour (failure is logged; deletion proceeds), and idempotency.

## Needs human review

**PR #2894 — Session auth for document routes** (`docs/api/api_overview.md`, nm-store `reference/authentication/page.tsx`)

The PR exempts `/api/documents/<id>/download`, `/api/documents/<id>/content`, and `/api/online-meetings/recordings/*` from API key auth, allowing browser session auth on those routes. `api_overview.md` currently states "API key-based authentication for all API endpoints." This is now technically imprecise — however, the affected routes are browser-facing (binary file serving, recording proxies), not part of the external `/api/v1/` REST surface that `api_overview.md` and the nm-store authentication reference are written for. A confident edit is not warranted without human judgement on whether to expose this distinction in the developer-facing auth docs.

**PR #2893 — Temporal-based appliance bootstrap** (`docs/getting-started/appliance_install.md`)

The internal provisioning mechanism changed from `npx tsx create-tenant.ts` to `node appliance-create-tenant.mjs` (which triggers the same Temporal `tenantCreationWorkflow` used in hosted). `appliance_install.md` is accurate at the wizard/UX level and does not mention the internal script. No user-visible behaviour changed. The `ee/appliance/docs/registration-install-flow.md` internal doc was already updated in the PR itself (out of the in-scope `/docs/**` path). No confident edit for in-scope docs, but a human should verify whether `docs/getting-started/appliance_install.md` or `docs/getting-started/enterprise_edition_architecture.md` warrants a note about the Temporal-based bootstrap for operator awareness.

**PR #2897 / #2899** — Test infrastructure / inventory bookkeeping only. No doc surface affected.

---
_Generated by [Claude Code](https://claude.ai/code/session_01JY5CKxJELpr3AtZQ6JTWwe)_