### PR TITLE
fix(inventory): drop hardcoded currency symbols from cost/price labels

### DIFF
--- a/docs/features/feature-flags.md
+++ b/docs/features/feature-flags.md
@@ -163,18 +163,6 @@ Controls access to the new service request definition and client portal request-
 - When enabled: The full service request UI is accessible.
 - Backend (tables, actions, provider execution, portal submission processing) remains active regardless of flag state.
 
-### 11. `inventory-enabled`
-Controls access to the Inventory section in the MSP sidebar.
-
-**Affected Areas:**
-- **MSP Portal:**
-  - Inventory sidebar navigation section and all sub-items (Dashboard, Stock, Stock Locations, Stock Units, Vendors, Purchase Orders, Vendor Bills, Sales Orders, Transfers, Cycle Counts, Write-offs, Margin, Ghost Usage, RMA, Loaners, Kits) — hidden when disabled
-
-**Behavior:**
-- When disabled (default): The entire Inventory sidebar section is hidden.
-- When enabled: The full Inventory section is shown.
-- Backend (models, actions, routes) remains available regardless of flag state; this gates the sidebar entry only.
-
 ## Implementation Details
 
 ### User Identification

--- a/server/public/locales/de/features/inventory.json
+++ b/server/public/locales/de/features/inventory.json
@@ -757,7 +757,7 @@
       "product": "Produkt",
       "qty": "Menge",
       "received": "Erfasst",
-      "unitCost": "Stückkosten ($)",
+      "unitCost": "Stückkosten",
       "vendor": "Lieferant"
     },
     "count": "{{count}} Bestellung",
@@ -989,7 +989,7 @@
       "selectService": "Select a service…",
       "service": "Service",
       "serviceId": "Service-ID",
-      "unitPrice": "Stückpreis ($)",
+      "unitPrice": "Stückpreis",
       "unitPriceIn": "Unit price ({{currency}})"
     },
     "fromQuote": "Aus Angebot",
@@ -1091,7 +1091,7 @@
     "fields": {
       "location": "Standort",
       "product": "Produkt",
-      "unitCost": "Stückkosten (USD)"
+      "unitCost": "Stückkosten"
     },
     "filteredCount": "{{shown}} von {{total}} Produkten",
     "levels": {
@@ -1333,7 +1333,7 @@
     "dialogTitle": "Preisliste — {{name}}",
     "emptyState": "Noch keine Angebote — fügen Sie unten die Teilenummern und Vertragskosten des Lieferanten hinzu.",
     "fields": {
-      "cost": "Kosten ($)",
+      "cost": "Kosten",
       "currency": "Währung",
       "leadTime": "Lieferzeit (Tage)",
       "preferred": "Bevorzugter Lieferant für dieses Produkt (steuert Nachbestellvorschläge)",

--- a/server/public/locales/en/features/inventory.json
+++ b/server/public/locales/en/features/inventory.json
@@ -757,7 +757,7 @@
       "product": "Product",
       "qty": "Qty",
       "received": "Received",
-      "unitCost": "Unit cost ($)",
+      "unitCost": "Unit cost",
       "vendor": "Vendor"
     },
     "count": "{{count}} purchase order",
@@ -989,7 +989,7 @@
       "selectService": "Select a service…",
       "service": "Service",
       "serviceId": "Service ID",
-      "unitPrice": "Unit Price ($)",
+      "unitPrice": "Unit Price",
       "unitPriceIn": "Unit price ({{currency}})"
     },
     "fromQuote": "From quote",
@@ -1091,7 +1091,7 @@
     "fields": {
       "location": "Location",
       "product": "Product",
-      "unitCost": "Unit cost (USD)"
+      "unitCost": "Unit cost"
     },
     "filteredCount": "{{shown}} of {{total}} products",
     "levels": {
@@ -1333,7 +1333,7 @@
     "dialogTitle": "Price list — {{name}}",
     "emptyState": "No offers yet — add the vendor's part numbers and contract costs below.",
     "fields": {
-      "cost": "Cost ($)",
+      "cost": "Cost",
       "currency": "Currency",
       "leadTime": "Lead time (days)",
       "preferred": "Preferred vendor for this product (drives reorder suggestions)",

--- a/server/public/locales/es/features/inventory.json
+++ b/server/public/locales/es/features/inventory.json
@@ -757,7 +757,7 @@
       "product": "Producto",
       "qty": "Cant.",
       "received": "Recibido",
-      "unitCost": "Costo unitario ($)",
+      "unitCost": "Costo unitario",
       "vendor": "Proveedor"
     },
     "count": "{{count}} orden de compra",
@@ -989,7 +989,7 @@
       "selectService": "Select a service…",
       "service": "Service",
       "serviceId": "ID de servicio",
-      "unitPrice": "Precio unitario ($)",
+      "unitPrice": "Precio unitario",
       "unitPriceIn": "Unit price ({{currency}})"
     },
     "fromQuote": "Desde cotización",
@@ -1091,7 +1091,7 @@
     "fields": {
       "location": "Ubicación",
       "product": "Producto",
-      "unitCost": "Costo unitario (USD)"
+      "unitCost": "Costo unitario"
     },
     "filteredCount": "{{shown}} de {{total}} productos",
     "levels": {
@@ -1333,7 +1333,7 @@
     "dialogTitle": "Lista de precios — {{name}}",
     "emptyState": "Aún no hay ofertas — añada abajo los números de pieza y los costos contractuales del proveedor.",
     "fields": {
-      "cost": "Costo ($)",
+      "cost": "Costo",
       "currency": "Moneda",
       "leadTime": "Plazo de entrega (días)",
       "preferred": "Proveedor preferido para este producto (impulsa las sugerencias de reposición)",

--- a/server/public/locales/fr/features/inventory.json
+++ b/server/public/locales/fr/features/inventory.json
@@ -757,7 +757,7 @@
       "product": "Produit",
       "qty": "Qté",
       "received": "Réceptionné",
-      "unitCost": "Coût unitaire ($)",
+      "unitCost": "Coût unitaire",
       "vendor": "Fournisseur"
     },
     "count": "{{count}} bon de commande",
@@ -989,7 +989,7 @@
       "selectService": "Select a service…",
       "service": "Service",
       "serviceId": "ID de service",
-      "unitPrice": "Prix unitaire ($)",
+      "unitPrice": "Prix unitaire",
       "unitPriceIn": "Unit price ({{currency}})"
     },
     "fromQuote": "Depuis le devis",
@@ -1091,7 +1091,7 @@
     "fields": {
       "location": "Emplacement",
       "product": "Produit",
-      "unitCost": "Coût unitaire (USD)"
+      "unitCost": "Coût unitaire"
     },
     "filteredCount": "{{shown}} sur {{total}} produits",
     "levels": {
@@ -1333,7 +1333,7 @@
     "dialogTitle": "Liste de prix — {{name}}",
     "emptyState": "Aucune offre pour l'instant — ajoutez ci-dessous les références du fournisseur et les coûts contractuels.",
     "fields": {
-      "cost": "Coût ($)",
+      "cost": "Coût",
       "currency": "Devise",
       "leadTime": "Délai de livraison (jours)",
       "preferred": "Fournisseur préféré pour ce produit (détermine les suggestions de réapprovisionnement)",

--- a/server/public/locales/it/features/inventory.json
+++ b/server/public/locales/it/features/inventory.json
@@ -757,7 +757,7 @@
       "product": "Prodotto",
       "qty": "Qtà",
       "received": "Ricevuto",
-      "unitCost": "Costo unitario ($)",
+      "unitCost": "Costo unitario",
       "vendor": "Fornitore"
     },
     "count": "{{count}} ordine di acquisto",
@@ -989,7 +989,7 @@
       "selectService": "Select a service…",
       "service": "Service",
       "serviceId": "ID servizio",
-      "unitPrice": "Prezzo unitario ($)",
+      "unitPrice": "Prezzo unitario",
       "unitPriceIn": "Unit price ({{currency}})"
     },
     "fromQuote": "Da preventivo",
@@ -1091,7 +1091,7 @@
     "fields": {
       "location": "Ubicazione",
       "product": "Prodotto",
-      "unitCost": "Costo unitario (USD)"
+      "unitCost": "Costo unitario"
     },
     "filteredCount": "{{shown}} di {{total}} prodotti",
     "levels": {
@@ -1333,7 +1333,7 @@
     "dialogTitle": "Listino prezzi — {{name}}",
     "emptyState": "Ancora nessuna offerta — aggiungi qui sotto i codici articolo del fornitore e i costi contrattuali.",
     "fields": {
-      "cost": "Costo ($)",
+      "cost": "Costo",
       "currency": "Valuta",
       "leadTime": "Tempo di consegna (giorni)",
       "preferred": "Fornitore preferito per questo prodotto (guida i suggerimenti di riordino)",

--- a/server/public/locales/nl/features/inventory.json
+++ b/server/public/locales/nl/features/inventory.json
@@ -757,7 +757,7 @@
       "product": "Product",
       "qty": "Aantal",
       "received": "Ontvangen",
-      "unitCost": "Kostprijs per eenheid ($)",
+      "unitCost": "Kostprijs per eenheid",
       "vendor": "Leverancier"
     },
     "count": "{{count}} inkooporder",
@@ -989,7 +989,7 @@
       "selectService": "Select a service…",
       "service": "Service",
       "serviceId": "Service-ID",
-      "unitPrice": "Stukprijs ($)",
+      "unitPrice": "Stukprijs",
       "unitPriceIn": "Unit price ({{currency}})"
     },
     "fromQuote": "Uit offerte",
@@ -1091,7 +1091,7 @@
     "fields": {
       "location": "Locatie",
       "product": "Product",
-      "unitCost": "Kostprijs per eenheid (USD)"
+      "unitCost": "Kostprijs per eenheid"
     },
     "filteredCount": "{{shown}} van {{total}} producten",
     "levels": {
@@ -1333,7 +1333,7 @@
     "dialogTitle": "Prijslijst — {{name}}",
     "emptyState": "Nog geen aanbiedingen — voeg hieronder de artikelnummers en contractkosten van de leverancier toe.",
     "fields": {
-      "cost": "Kostprijs ($)",
+      "cost": "Kostprijs",
       "currency": "Valuta",
       "leadTime": "Levertijd (dagen)",
       "preferred": "Voorkeursleverancier voor dit product (bepaalt bestelsuggesties)",

--- a/server/public/locales/pl/features/inventory.json
+++ b/server/public/locales/pl/features/inventory.json
@@ -757,7 +757,7 @@
       "product": "Produkt",
       "qty": "Ilość",
       "received": "Przyjęto",
-      "unitCost": "Koszt jednostkowy ($)",
+      "unitCost": "Koszt jednostkowy",
       "vendor": "Dostawca"
     },
     "count": "{{count}} zamówienie zakupu",
@@ -989,7 +989,7 @@
       "selectService": "Select a service…",
       "service": "Service",
       "serviceId": "ID usługi",
-      "unitPrice": "Cena jednostkowa ($)",
+      "unitPrice": "Cena jednostkowa",
       "unitPriceIn": "Unit price ({{currency}})"
     },
     "fromQuote": "Z oferty",
@@ -1091,7 +1091,7 @@
     "fields": {
       "location": "Lokalizacja",
       "product": "Produkt",
-      "unitCost": "Koszt jednostkowy (USD)"
+      "unitCost": "Koszt jednostkowy"
     },
     "filteredCount": "{{shown}} z {{total}} produktów",
     "levels": {
@@ -1333,7 +1333,7 @@
     "dialogTitle": "Cennik — {{name}}",
     "emptyState": "Brak ofert — dodaj poniżej numery katalogowe i koszty kontraktowe dostawcy.",
     "fields": {
-      "cost": "Koszt ($)",
+      "cost": "Koszt",
       "currency": "Waluta",
       "leadTime": "Czas realizacji (dni)",
       "preferred": "Preferowany dostawca dla tego produktu (wpływa na sugestie ponownego zamawiania)",

--- a/server/public/locales/pt/features/inventory.json
+++ b/server/public/locales/pt/features/inventory.json
@@ -757,7 +757,7 @@
       "product": "Produto",
       "qty": "Qtd",
       "received": "Recebido",
-      "unitCost": "Custo unitário ($)",
+      "unitCost": "Custo unitário",
       "vendor": "Fornecedor"
     },
     "count": "{{count}} pedido de compra",
@@ -989,7 +989,7 @@
       "selectService": "Select a service…",
       "service": "Service",
       "serviceId": "ID do serviço",
-      "unitPrice": "Preço Unitário ($)",
+      "unitPrice": "Preço Unitário",
       "unitPriceIn": "Unit price ({{currency}})"
     },
     "fromQuote": "A partir de cotação",
@@ -1091,7 +1091,7 @@
     "fields": {
       "location": "Localização",
       "product": "Produto",
-      "unitCost": "Custo unitário (USD)"
+      "unitCost": "Custo unitário"
     },
     "filteredCount": "{{shown}} de {{total}} produtos",
     "levels": {
@@ -1333,7 +1333,7 @@
     "dialogTitle": "Lista de preços — {{name}}",
     "emptyState": "Ainda não há ofertas — adicione os números de peça e os custos contratuais do fornecedor abaixo.",
     "fields": {
-      "cost": "Custo ($)",
+      "cost": "Custo",
       "currency": "Moeda",
       "leadTime": "Prazo de entrega (dias)",
       "preferred": "Fornecedor preferencial para este produto (orienta sugestões de reposição)",

--- a/server/src/components/layout/SidebarWithFeatureFlags.tsx
+++ b/server/src/components/layout/SidebarWithFeatureFlags.tsx
@@ -56,9 +56,6 @@ export default function SidebarWithFeatureFlags(props: SidebarWithFeatureFlagsPr
   const navigationFlag = useFeatureFlag('ui-navigation-v2', { defaultValue: true });
   const useNavigationSections =
     typeof navigationFlag === 'boolean' ? navigationFlag : navigationFlag?.enabled ?? false;
-  const inventoryFlag = useFeatureFlag('inventory-enabled');
-  const isInventoryEnabled =
-    typeof inventoryFlag === 'boolean' ? inventoryFlag : inventoryFlag?.enabled ?? false;
   const [userPermissions, setUserPermissions] = useState<string[]>([]);
   const { hasFeature } = useTier();
   const { productCode } = useProduct();
@@ -105,10 +102,6 @@ export default function SidebarWithFeatureFlags(props: SidebarWithFeatureFlagsPr
     const filteredSections = baseSections.map((section) => ({
       ...section,
       items: section.items.map((item) => {
-        if (item.name === 'Inventory' && !isInventoryEnabled) {
-          return null;
-        }
-
         if (item.name === 'Workflows') {
           const filteredSubItems = item.subItems?.filter((subItem) => {
             if (subItem.name !== 'Dead Letter') return true;
@@ -118,14 +111,14 @@ export default function SidebarWithFeatureFlags(props: SidebarWithFeatureFlagsPr
         }
 
         return item;
-      }).filter((item): item is MenuItem => item !== null)
+      })
     }));
 
     return filterMenuSectionsByProduct(
       productCode,
       filterNavigationSectionsByFeatureAccess(filteredSections, hasFeature),
     );
-  }, [canWorkflowAdmin, useNavigationSections, hasFeature, productCode, isInventoryEnabled]);
+  }, [canWorkflowAdmin, useNavigationSections, hasFeature, productCode]);
 
   const settingsSections = useMemo<NavigationSection[]>(() => {
     return filterMenuSectionsByProduct(productCode, settingsNavigationSections);


### PR DESCRIPTION
## Summary

Four inventory label keys hardcoded a US currency symbol while the fields they label render in a **per-record currency**. The amounts themselves were always formatted correctly through `money()` / `formatCurrencyFromMinorUnits` — only the static labels lied.

| Key | Was (en) | Now |
|---|---|---|
| `vendorPriceList.fields.cost` | `Cost ($)` | `Cost` |
| `purchaseOrders.columns.unitCost` | `Unit cost ($)` | `Unit cost` |
| `salesOrders.fields.unitPrice` | `Unit Price ($)` | `Unit Price` |
| `stock.fields.unitCost` | `Unit cost (USD)` | `Unit cost` |

Each sits next to a genuine currency:

- **Price list** — the cost input has its own Currency dropdown directly beside it (`VendorPriceList.tsx:226`, `:233`).
- **Purchase orders** — a `currency_code` is required (`PurchaseOrdersManager.tsx:247`); `:414` even carries a comment noting amounts render "in the PO's own currency."
- **Sales orders** — lines resolve currency from the client (`SalesOrdersManager.tsx:267`).
- **Receive stock** — the input is handed `selectedProduct?.cost_currency` (`StockOverview.tsx:431`).

In every case the component's inline `t()` fallback was **already** currency-neutral (e.g. `t('stock.fields.unitCost', 'Unit cost')`); the locale string was overriding it. So this is a locale-JSON-only change — no component edits needed.

Corrected across all 8 real locales (en, de, es, fr, it, nl, pl, pt). The pseudo-locales `xx`/`yy` hold placeholder digit strings (`11111`, `55555`) and are untouched.

## Also in this PR

Removes the `inventory-enabled` feature flag (second commit). The Inventory sidebar section is now always visible, subject to the existing tier and product filters. Drops the `useFeatureFlag` call, the Inventory null-out branch, the now-dead null filter, the memo dependency, and the flag's docs section. It was the last flag in the doc, so no renumbering was needed; nothing else in the repo referenced it.

## Out of scope

- **`msp/contract-lines.json`** has the same defect class in three billing labels (`Hourly Rate ($)`, `Overtime Rate ($/hr)`, `Rate ($/hr)`). Filed as **alga0002089**. That one is *not* locale-only — the inline `defaultValue` fallbacks in `ServiceHourlyConfigForm.tsx:219`/`:366` also hardcode the symbol, and the `($/hr)` labels carry a per-hour unit that must survive the fix.
- **`client-portal.json`** marketing prices (`Starting at $299/mo`) are static prose, not currency-formatted values — translators treated them as such (`fr`: `299 $/mois`). Left alone deliberately.

## Testing

Text-only changes to locale JSON. Verified all 8 files still parse as valid JSON and that zero `($)` / `(USD)` occurrences remain in the inventory namespace, with the `purchaseOrders.currency.usd` picker option (`USD — US Dollar`) correctly left intact. Not exercised in a running app.