### PR TITLE
Realign nightly-only integration tests with #2892

### DIFF
--- a/server/src/test/integration/algadeskTicketAttachmentDrafts.integration.test.ts
+++ b/server/src/test/integration/algadeskTicketAttachmentDrafts.integration.test.ts
@@ -259,13 +259,24 @@ describe('AlgaDesk ticket attachment draft integration', () => {
     expect(deletedByAction).toEqual([fixture.deletableDocumentId]);
 
     permissionRef.canDeleteDocument = false;
-    await expect(
-      deleteDraftClipboardImages({
-        ticketId: fixture.ticketId,
-        documentIds: [fixture.deletableDocumentId],
-        deleteDocumentFn: async () => ({ success: true, deleted: true }),
+    let permissionDeleteCalled = false;
+    const permissionResult = await deleteDraftClipboardImages({
+      ticketId: fixture.ticketId,
+      documentIds: [fixture.deletableDocumentId],
+      deleteDocumentFn: async () => {
+        permissionDeleteCalled = true;
+        return { success: true, deleted: true };
+      },
+    });
+    expect(permissionResult.deletedDocumentIds).toEqual([]);
+    expect(permissionResult.failures).toEqual([
+      expect.objectContaining({
+        documentId: fixture.deletableDocumentId,
+        reason: 'permission_denied',
+        detail: 'Permission denied: cannot delete document attachments.',
       }),
-    ).rejects.toThrow('Permission denied: cannot delete document attachments.');
+    ]);
+    expect(permissionDeleteCalled).toBe(false);
 
   }, HOOK_TIMEOUT);
 });

--- a/server/src/test/integration/appointmentRequests.integration.test.ts
+++ b/server/src/test/integration/appointmentRequests.integration.test.ts
@@ -1925,7 +1925,7 @@ describe('Appointment Request Integration Tests', () => {
       });
 
       expect(result.success).toBe(false);
-      expect(result.error).toMatch(/past|future|invalid date/i);
+      expect(result.error).toBe('Appointment request contains invalid fields. Review the details and try again.');
     });
 
     it('should reject appointment request with invalid time format', async () => {

--- a/server/src/test/integration/boardContextTicketStatusReferenceRemap.integration.test.ts
+++ b/server/src/test/integration/boardContextTicketStatusReferenceRemap.integration.test.ts
@@ -67,6 +67,7 @@ function schemaTable(table: string) {
 async function cleanupTenant(tenantId: string): Promise<void> {
   if (hasColumn(clientContractsColumns, 'tenant')) {
     await tenantTable(tenantId, 'client_contracts').del();
+    await tenantTable(tenantId, 'contracts').del();
   }
 
   await tenantTable(tenantId, 'clients').del();
@@ -228,11 +229,20 @@ async function createReferenceFixture(): Promise<ReferenceFixture> {
     client_name: `Client ${clientId.slice(0, 8)}`,
   });
 
+  // client_contracts.contract_id has a composite FK to contracts (real since
+  // 20251008000003 was fixed to create it on plain Postgres) — create the row.
+  const contractRowId = uuidv4();
+  await tenantTable(tenantId, 'contracts').insert({
+    tenant: tenantId,
+    contract_id: contractRowId,
+    contract_name: `Contract ${contractRowId.slice(0, 8)}`,
+  });
+
   await tenantTable(tenantId, 'client_contracts').insert({
     tenant: tenantId,
     ...(hasColumn(clientContractsColumns, 'client_contract_id') ? { client_contract_id: contractId } : {}),
     ...(hasColumn(clientContractsColumns, 'client_id') ? { client_id: clientId } : {}),
-    ...(hasColumn(clientContractsColumns, 'contract_id') ? { contract_id: uuidv4() } : {}),
+    ...(hasColumn(clientContractsColumns, 'contract_id') ? { contract_id: contractRowId } : {}),
     ...(hasColumn(clientContractsColumns, 'start_date') ? { start_date: db.fn.now() } : {}),
     ...(hasColumn(clientContractsColumns, 'is_active') ? { is_active: true } : {}),
     ...(hasColumn(clientContractsColumns, 'renewal_ticket_board_id')

--- a/server/src/test/integration/boardSpecificTicketStatusesMigration.integration.test.ts
+++ b/server/src/test/integration/boardSpecificTicketStatusesMigration.integration.test.ts
@@ -101,6 +101,7 @@ async function cleanupTenant(tenantId: string): Promise<void> {
   await tenantTable(tenantId, 'survey_triggers').del();
   await tenantTable(tenantId, 'survey_templates').del();
   await tenantTable(tenantId, 'client_contracts').del();
+  await tenantTable(tenantId, 'contracts').del();
   await tenantTable(tenantId, 'default_billing_settings').del();
   await tenantTable(tenantId, 'inbound_ticket_defaults').del();
   await tenantTable(tenantId, 'statuses').del();
@@ -314,11 +315,20 @@ async function seedBoardContextStatusReferences(fixture: LegacyFixture) {
     ...(hasColumn(defaultBillingSettingsColumns, 'updated_at') ? { updated_at: db.fn.now() } : {}),
   });
 
+  // client_contracts.contract_id has a composite FK to contracts (real since
+  // 20251008000003 was fixed to create it on plain Postgres) — create the row.
+  const contractRowId = uuidv4();
+  await tenantTable(fixture.tenantId, 'contracts').insert({
+    tenant: fixture.tenantId,
+    contract_id: contractRowId,
+    contract_name: `Contract ${contractRowId.slice(0, 8)}`,
+  });
+
   await tenantTable(fixture.tenantId, 'client_contracts').insert({
     tenant: fixture.tenantId,
     client_contract_id: clientContractId,
     client_id: fixture.clientId,
-    contract_id: uuidv4(),
+    contract_id: contractRowId,
     start_date: new Date('2026-03-01T00:00:00.000Z'),
     renewal_ticket_board_id: boardA,
     renewal_ticket_status_id: legacyClosedStatusId,

--- a/server/src/test/integration/commentActionsThreading.integration.test.ts
+++ b/server/src/test/integration/commentActionsThreading.integration.test.ts
@@ -243,14 +243,17 @@ describe('ticket comment threading actions', () => {
         .first();
       threadId = root.thread_id;
 
-      await expect(createComment({
+      const deniedInternalReply = await createComment({
         ticket_id: context.ticket_id,
         user_id: clientUser.user_id,
         note: blockNote('Invalid internal reply from client user'),
         is_internal: true,
         is_resolution: false,
         parent_comment_id: rootCommentId,
-      })).rejects.toThrow('Failed to create comment');
+      });
+      expect(deniedInternalReply).toMatchObject({
+        actionError: 'Only MSP users can create internal comments',
+      });
 
       const invalidReply = await scopedDb(context.tenant).table('comments')
         .select('comment_id')
@@ -391,23 +394,29 @@ describe('ticket comment threading actions', () => {
         parent_comment_id: clientVisibleRootId,
       });
 
-      await expect(createComment({
+      const deniedInternalThreadReply = await createComment({
         ticket_id: context.ticket_id,
         user_id: ids.client_user_id,
         note: blockNote('T078 denied internal-thread reply'),
         is_internal: false,
         is_resolution: false,
         parent_comment_id: internalRootId,
-      })).rejects.toThrow('Failed to create comment');
+      });
+      expect(deniedInternalThreadReply).toMatchObject({
+        actionError: 'Reply visibility must match the thread root visibility',
+      });
 
-      await expect(createComment({
+      const deniedInaccessibleReply = await createComment({
         ticket_id: ids.other_ticket_id,
         user_id: ids.client_user_id,
         note: blockNote('T078 denied inaccessible ticket reply'),
         is_internal: false,
         is_resolution: false,
         parent_comment_id: inaccessibleRootId,
-      })).rejects.toThrow('Failed to create comment');
+      });
+      expect(deniedInaccessibleReply).toMatchObject({
+        actionError: 'Client user cannot access this ticket',
+      });
     } finally {
       userRef.user = originalUser;
       await scopedDb(context.tenant).table('comments')

--- a/server/src/test/integration/contractWizard.integration.test.ts
+++ b/server/src/test/integration/contractWizard.integration.test.ts
@@ -274,22 +274,24 @@ describe('createClientContractFromWizard', () => {
     const clientId = await insertClient(db, tenantId, 'Fixed Rejection Client');
     createdIds.clientId = clientId;
 
-    await expect(
-      createClientContractFromWizard({
-        contract_name: 'Fixed Product Rejection Contract',
-        description: 'reject product in fixed services',
-        client_id: clientId,
-        start_date: '2025-10-01',
-        end_date: null,
-        billing_frequency: 'monthly',
-        enable_proration: true,
-        fixed_base_rate: 4200,
-        fixed_services: [{ service_id: productId, quantity: 1 }],
-        hourly_services: [],
-        usage_services: [],
-        po_required: false,
-      })
-    ).rejects.toThrow('must be a service to be added to fixed fee contract lines');
+    const result = await createClientContractFromWizard({
+      contract_name: 'Fixed Product Rejection Contract',
+      description: 'reject product in fixed services',
+      client_id: clientId,
+      start_date: '2025-10-01',
+      end_date: null,
+      billing_frequency: 'monthly',
+      enable_proration: true,
+      fixed_base_rate: 4200,
+      fixed_services: [{ service_id: productId, quantity: 1 }],
+      hourly_services: [],
+      usage_services: [],
+      po_required: false,
+    });
+
+    expect(result).toMatchObject({
+      actionError: 'Catalog item "Fixed Line Product" must be a service to be added to fixed fee contract lines.',
+    });
   });
 
   it('T015: accepts hourly services even when catalog billing_method is non-hourly', async () => {
@@ -349,23 +351,25 @@ describe('createClientContractFromWizard', () => {
     const clientId = await insertClient(db, tenantId, 'Hourly Rejection Client');
     createdIds.clientId = clientId;
 
-    await expect(
-      createClientContractFromWizard({
-        contract_name: 'Hourly Product Rejection Contract',
-        description: 'reject product in hourly services',
-        client_id: clientId,
-        start_date: '2025-10-01',
-        end_date: null,
-        billing_frequency: 'monthly',
-        enable_proration: false,
-        fixed_services: [],
-        hourly_services: [{ service_id: productId, hourly_rate: 3500 }],
-        usage_services: [],
-        minimum_billable_time: 15,
-        round_up_to_nearest: 15,
-        po_required: false,
-      })
-    ).rejects.toThrow('must be a service to be added to hourly contract lines');
+    const result = await createClientContractFromWizard({
+      contract_name: 'Hourly Product Rejection Contract',
+      description: 'reject product in hourly services',
+      client_id: clientId,
+      start_date: '2025-10-01',
+      end_date: null,
+      billing_frequency: 'monthly',
+      enable_proration: false,
+      fixed_services: [],
+      hourly_services: [{ service_id: productId, hourly_rate: 3500 }],
+      usage_services: [],
+      minimum_billable_time: 15,
+      round_up_to_nearest: 15,
+      po_required: false,
+    });
+
+    expect(result).toMatchObject({
+      actionError: 'Catalog item "Hourly Line Product" must be a service to be added to hourly contract lines.',
+    });
   });
 
   it('T017: accepts usage services even when catalog billing_method is non-usage', async () => {
@@ -423,21 +427,23 @@ describe('createClientContractFromWizard', () => {
     const clientId = await insertClient(db, tenantId, 'Usage Rejection Client');
     createdIds.clientId = clientId;
 
-    await expect(
-      createClientContractFromWizard({
-        contract_name: 'Usage Product Rejection Contract',
-        description: 'reject product in usage services',
-        client_id: clientId,
-        start_date: '2025-10-01',
-        end_date: null,
-        billing_frequency: 'monthly',
-        enable_proration: false,
-        fixed_services: [],
-        hourly_services: [],
-        usage_services: [{ service_id: productId, unit_rate: 1800, unit_of_measure: 'unit' }],
-        po_required: false,
-      })
-    ).rejects.toThrow('must be a service to be added to usage contract lines');
+    const result = await createClientContractFromWizard({
+      contract_name: 'Usage Product Rejection Contract',
+      description: 'reject product in usage services',
+      client_id: clientId,
+      start_date: '2025-10-01',
+      end_date: null,
+      billing_frequency: 'monthly',
+      enable_proration: false,
+      fixed_services: [],
+      hourly_services: [],
+      usage_services: [{ service_id: productId, unit_rate: 1800, unit_of_measure: 'unit' }],
+      po_required: false,
+    });
+
+    expect(result).toMatchObject({
+      actionError: 'Catalog item "Usage Line Product" must be a service to be added to usage contract lines.',
+    });
   });
 
   it('T021: resolves fixed-mode prefill from service+mode+currency defaults when no fixed override is provided', async () => {

--- a/server/src/test/integration/multiCurrencyGaps.integration.test.ts
+++ b/server/src/test/integration/multiCurrencyGaps.integration.test.ts
@@ -266,17 +266,12 @@ describe('Multi-Currency Gap Tests', () => {
       createdIds.invoiceIds.push(eurInvoiceId);
 
       // Action: Try to apply USD credit to EUR invoice
-      // GAP EXPOSED: This should throw an error but currently succeeds
-      let error: Error | null = null;
-      try {
-        await applyCreditToInvoice(clientId, eurInvoiceId, 5000);
-      } catch (e) {
-        error = e as Error;
-      }
+      const result = await applyCreditToInvoice(clientId, eurInvoiceId, 5000);
 
-      // Expected: Should reject with currency mismatch error
-      expect(error).not.toBeNull();
-      expect(error?.message).toContain('currencies');
+      // Expected: Should return currency mismatch error
+      expect(result).toMatchObject({
+        actionError: 'No EUR credits available. Credits exist in other currencies but cannot be applied to EUR invoices.',
+      });
     });
   });
 

--- a/server/src/test/integration/projectTaskCommentThreading.integration.test.ts
+++ b/server/src/test/integration/projectTaskCommentThreading.integration.test.ts
@@ -503,8 +503,10 @@ describe('project task comment threading model', () => {
         .first();
       expect(ownReply).toBeUndefined();
 
-      await expect(deleteTaskComment(generated.other_reply_id))
-        .rejects.toThrow('You can only delete your own comments');
+      const deniedDeleteResult = await deleteTaskComment(generated.other_reply_id);
+      expect(deniedDeleteResult).toMatchObject({
+        actionError: 'You can only delete your own comments',
+      });
 
       const otherReply = await scopedDb(context.tenant).table('project_task_comments')
         .select('task_comment_id')

--- a/server/src/test/integration/sla/slaPauseConfigActions.integration.test.ts
+++ b/server/src/test/integration/sla/slaPauseConfigActions.integration.test.ts
@@ -301,9 +301,10 @@ describe('SLA Pause Config Actions Integration Tests', () => {
         created_by: context.userId
       });
 
-      await expect(setStatusSlaPauseConfig(legacyStatusId, true)).rejects.toThrow(
-        'board-owned ticket status'
-      );
+      const result = await setStatusSlaPauseConfig(legacyStatusId, true);
+      expect(result).toMatchObject({
+        actionError: 'SLA pause configuration requires a board-owned ticket status.',
+      });
     });
 
     it('filters legacy tenant-global ticket configs out of returned config lists', async () => {

--- a/server/src/test/integration/ticketBundling.integration.test.ts
+++ b/server/src/test/integration/ticketBundling.integration.test.ts
@@ -271,19 +271,25 @@ describe('Ticket bundling integration', () => {
 
     mockCurrentUser = noPermUser;
     try {
-      await expect(
-        runWithTenant(tenantId, async () => {
-          await bundleTicketsAction({ masterTicketId: masterId, childTicketIds: [childId], mode: 'link_only' }, noPermUser as any);
-        })
-      ).rejects.toThrow(/permission denied/i);
+      const deniedBundleResult = await runWithTenant(tenantId, async () => {
+        return bundleTicketsAction({ masterTicketId: masterId, childTicketIds: [childId], mode: 'link_only' }, noPermUser as any);
+      });
+      expect(deniedBundleResult).toMatchObject({
+        permissionError: 'Permission denied: Cannot bundle tickets',
+      });
 
       await grantUserPermissions(db, tenantId, noPermUserId, [
         { resource: 'ticket', action: 'update' },
         { resource: 'ticket', action: 'read' },
       ]);
 
-      await runWithTenant(tenantId, async () => {
-        await bundleTicketsAction({ masterTicketId: masterId, childTicketIds: [childId], mode: 'link_only' }, noPermUser as any);
+      const allowedBundleResult = await runWithTenant(tenantId, async () => {
+        return bundleTicketsAction({ masterTicketId: masterId, childTicketIds: [childId], mode: 'link_only' }, noPermUser as any);
+      });
+      expect(allowedBundleResult).toMatchObject({
+        masterTicketId: masterId,
+        childTicketIds: [childId],
+        mode: 'link_only',
       });
     } finally {
       mockCurrentUser = internalUser;
@@ -398,9 +404,10 @@ describe('Ticket bundling integration', () => {
 
     await runWithTenant(tenantId, async () => {
       await bundleTicketsAction({ masterTicketId: oldMasterId, childTicketIds: [child1Id, child2Id], mode: 'sync_updates' }, internalUser as any);
-      await expect(
-        promoteBundleMasterAction({ oldMasterTicketId: oldMasterId, newMasterTicketId: oldMasterId }, internalUser as any)
-      ).rejects.toThrow(/must be different/i);
+      const selfPromoteResult = await promoteBundleMasterAction({ oldMasterTicketId: oldMasterId, newMasterTicketId: oldMasterId }, internalUser as any);
+      expect(selfPromoteResult).toMatchObject({
+        actionError: 'New master ticket must be different from the current master.',
+      });
       await promoteBundleMasterAction({ oldMasterTicketId: oldMasterId, newMasterTicketId: child1Id }, internalUser as any);
     });
 
@@ -442,11 +449,12 @@ describe('Ticket bundling integration', () => {
     expect(childAfter?.status_id).toBe(statusClosedId);
     expect(childAfter?.priority_id).toBe(nextPriorityId);
 
-    await expect(
-      runWithTenant(tenantId, async () => {
-        await updateTicketWithCache(childId, { status_id: statusOpenId }, internalUser as any);
-      })
-    ).rejects.toThrow();
+    const childWorkflowUpdateResult = await runWithTenant(tenantId, async () => {
+      return updateTicketWithCache(childId, { status_id: statusOpenId }, internalUser as any);
+    });
+    expect(childWorkflowUpdateResult).toMatchObject({
+      actionError: 'This ticket is bundled; workflow fields are locked (status_id). Update the master ticket instead.',
+    });
 
     const childAfterLockAttempt = await scopedDb.table('tickets').where({ ticket_id: childId }).first();
     expect(childAfterLockAttempt?.status_id).toBe(statusClosedId);
@@ -487,11 +495,12 @@ describe('Ticket bundling integration', () => {
     expect(mirrored?.is_internal).toBe(false);
 
     const originalNote = mirrored?.note;
-    await expect(
-      runWithTenant(tenantId, async () => {
-        await updateComment(mirrored.comment_id, { note: 'edited' } as any);
-      })
-    ).rejects.toThrow();
+    const mirroredUpdateResult = await runWithTenant(tenantId, async () => {
+      return updateComment(mirrored.comment_id, { note: 'edited' } as any);
+    });
+    expect(mirroredUpdateResult).toMatchObject({
+      actionError: 'This comment is system-generated and cannot be edited.',
+    });
 
     const mirroredAfter = await scopedDb.table('comments').where({ comment_id: mirrored.comment_id }).first();
     expect(mirroredAfter?.note).toBe(originalNote);

--- a/server/src/test/integration/ticketCloseRules.integration.test.ts
+++ b/server/src/test/integration/ticketCloseRules.integration.test.ts
@@ -494,9 +494,10 @@ describe('ticket close rules', () => {
     const ticketId = await insertTicket(db, fixture);
     await setBoardCloseRules(db, fixture, { require_time_entry: true });
 
-    await expect(
-      updateTicket(ticketId, { status_id: fixture.closedStatusId })
-    ).rejects.toThrow(/cannot be closed/i);
+    const closeResult = await updateTicket(ticketId, { status_id: fixture.closedStatusId });
+    expect(closeResult).toMatchObject({
+      actionError: expect.stringContaining('Ticket cannot be closed'),
+    });
 
     let ticket = await scopedDb().table('tickets').where({ ticket_id: ticketId }).first();
     expect(ticket.status_id).toBe(fixture.openStatusId);


### PR DESCRIPTION
PR #2892 converted expected failures from throws to returned { actionError } envelopes and fixed the client_contracts -> contracts FK migration to actually create the composite (tenant, contract_id) constraint on plain Postgres (the old single-column form silently failed against the composite-PK contracts table). The unit and Tier-1 suites were realigned in that PR, but these eleven files only run in the nightly full suite:

- Rewrite rejects-based assertions to check the returned actionError / failures envelopes (attachment drafts, comment threading, contract wizard, multi-currency credits, task comment threading, SLA pause config, ticket bundling, ticket close rules) and update the appointment-request validation copy.
- Board status remap migration tests: back the client_contracts fixture's contract_id with a real contracts row (the now-live FK rejects dangling ids) and clean contracts up before tenant deletion.

All 11 files verified locally against a real Postgres: 166 tests passing.

'I can't go back to yesterday,' said Alice, 'because the actions were a different shape then.' The Queen only smiled: 'Envelopes, my dear — we throw nothing here anymore, and every contract_id must name a real contract, or it's off with its foreign key.' ✉️👑🔗