### PR TITLE
Add licenses mid-trial in place, without charging

### DIFF
--- a/ee/server/src/__tests__/unit/stripeService.licenseSubscriptionLifecycle.test.ts
+++ b/ee/server/src/__tests__/unit/stripeService.licenseSubscriptionLifecycle.test.ts
@@ -1,0 +1,393 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { StripeService } from '../../lib/stripe/StripeService';
+
+const getConnectionMock = vi.hoisted(() => vi.fn());
+const startTenantDeletionWorkflowMock = vi.hoisted(() => vi.fn());
+
+vi.mock('@/lib/db/db', () => ({
+  getConnection: getConnectionMock,
+}));
+
+vi.mock('@ee/lib/tenant-management/workflowClient', () => ({
+  startTenantDeletionWorkflow: startTenantDeletionWorkflowMock,
+}));
+
+vi.mock('@alga-psa/db', () => ({
+  tenantDb: (conn: any, tenant: string) => ({
+    table: (table: string) => conn(table).where('tenant', tenant),
+  }),
+}));
+
+const TENANT = 'tenant-1';
+
+type Call = { method: string; args: any[] };
+
+interface FakeDbState {
+  rows: Record<string, Record<string, any>[]>;
+  updates: Array<{ table: string; calls: Call[]; values: Record<string, any> }>;
+}
+
+function applyFilters(rows: Record<string, any>[], calls: Call[]) {
+  let out = [...rows];
+  for (const call of calls) {
+    const [first, second] = call.args;
+    if (call.method === 'where' && typeof first === 'object') {
+      out = out.filter((row) => Object.entries(first).every(([key, value]) => row[key] === value));
+    } else if (call.method === 'where' && typeof first === 'string' && call.args.length === 2) {
+      out = out.filter((row) => row[first] === second);
+    } else if (call.method === 'whereNot' && typeof first === 'string' && call.args.length === 2) {
+      out = out.filter((row) => row[first] !== second);
+    } else if (call.method === 'whereIn') {
+      out = out.filter((row) => (second as any[]).includes(row[first]));
+    } else if (call.method === 'whereRaw' && String(first).includes('addon_key')) {
+      out = out.filter((row) => !row.metadata?.addon_key);
+    } else if (call.method === 'orderByRaw' && String(first).includes("'active'")) {
+      out = [...out].sort(
+        (a, b) => (a.status === 'active' ? 0 : 1) - (b.status === 'active' ? 0 : 1),
+      );
+    }
+  }
+  return out;
+}
+
+function createFakeKnex(state: FakeDbState) {
+  const knex: any = (table: string) => {
+    const calls: Call[] = [];
+    const builder: any = {};
+    for (const method of ['where', 'whereNot', 'whereIn', 'whereRaw', 'orderByRaw', 'orderBy', 'select']) {
+      builder[method] = (...args: any[]) => {
+        calls.push({ method, args });
+        return builder;
+      };
+    }
+    builder.first = async (..._columns: any[]) =>
+      applyFilters(state.rows[table] ?? [], calls)[0] ?? null;
+    builder.update = async (values: Record<string, any>) => {
+      state.updates.push({ table, calls, values });
+      return 1;
+    };
+    return builder;
+  };
+
+  knex.fn = {
+    now: () => new Date('2026-07-10T00:00:00.000Z'),
+  };
+
+  return knex;
+}
+
+function trialSubscription(overrides: Record<string, any> = {}) {
+  return {
+    tenant: TENANT,
+    stripe_subscription_id: 'dbsub_trial',
+    stripe_subscription_external_id: 'sub_ext_trial',
+    stripe_subscription_item_id: 'si_trial',
+    stripe_customer_id: 'cust_db_1',
+    status: 'trialing',
+    quantity: 1,
+    stripe_base_item_id: null,
+    metadata: {},
+    ...overrides,
+  };
+}
+
+function activeSubscription(overrides: Record<string, any> = {}) {
+  return {
+    tenant: TENANT,
+    stripe_subscription_id: 'dbsub_active',
+    stripe_subscription_external_id: 'sub_ext_active',
+    stripe_subscription_item_id: 'si_active',
+    stripe_customer_id: 'cust_db_1',
+    status: 'active',
+    quantity: 2,
+    stripe_base_item_id: null,
+    metadata: {},
+    ...overrides,
+  };
+}
+
+function createService(state: FakeDbState) {
+  const knex = createFakeKnex(state);
+  const service = new StripeService() as any;
+
+  service.initPromise = Promise.resolve();
+  service.config = {
+    soloBasePriceId: 'price_solo_month',
+    soloBaseAnnualPriceId: 'price_solo_year',
+    proPriceId: 'price_pro_seat',
+    proAnnualPriceId: 'price_pro_seat_year',
+    premiumBasePriceId: 'price_premium_base',
+    premiumUserPriceId: 'price_premium_user',
+    premiumBaseAnnualPriceId: 'price_premium_base_year',
+    premiumUserAnnualPriceId: 'price_premium_user_year',
+    aiAddOnPriceId: 'price_ai_addon',
+    aiAddOnAnnualPriceId: 'price_ai_addon_year',
+    teamsAddOnPriceId: 'price_teams_addon',
+    teamsAddOnAnnualPriceId: 'price_teams_addon_year',
+    enterpriseAddOnPriceId: 'price_enterprise_addon',
+    enterpriseAddOnAnnualPriceId: 'price_enterprise_addon_year',
+    earlyAdoptersBasePriceId: null,
+    earlyAdoptersUserPriceId: null,
+    earlyAdoptersBaseAnnualPriceId: null,
+    earlyAdoptersUserAnnualPriceId: null,
+  };
+  service.stripe = {
+    subscriptions: {
+      update: vi.fn().mockResolvedValue({ id: 'sub_ext_updated', status: 'active' }),
+    },
+    checkout: {
+      sessions: {
+        create: vi.fn().mockResolvedValue({ id: 'cs_test_1', client_secret: 'cs_secret_1' }),
+      },
+    },
+  };
+  service.getOrImportCustomer = vi.fn().mockResolvedValue({
+    stripe_customer_id: 'cust_db_1',
+    stripe_customer_external_id: 'cus_ext_1',
+  });
+
+  getConnectionMock.mockResolvedValue(knex);
+
+  return { service, knex };
+}
+
+function createState(subscriptions: Record<string, any>[]): FakeDbState {
+  return {
+    rows: {
+      tenants: [{ tenant: TENANT, plan: 'pro', billing_source: 'stripe' }],
+      stripe_subscriptions: subscriptions,
+    },
+    updates: [],
+  };
+}
+
+describe('StripeService license subscription lifecycle', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    startTenantDeletionWorkflowMock.mockResolvedValue({ available: true, workflowId: 'wf-1' });
+  });
+
+  describe('updateOrCreateLicenseSubscription', () => {
+    it('increases a trialing subscription in place with no charge', async () => {
+      const state = createState([trialSubscription()]);
+      const { service } = createService(state);
+
+      const result = await service.updateOrCreateLicenseSubscription(TENANT, 3);
+
+      expect(result).toEqual(
+        expect.objectContaining({ type: 'updated', scheduledChange: false }),
+      );
+
+      expect(service.stripe.subscriptions.update).toHaveBeenCalledTimes(1);
+      const [subscriptionId, params] = service.stripe.subscriptions.update.mock.calls[0];
+      expect(subscriptionId).toBe('sub_ext_trial');
+      expect(params.items).toEqual([{ id: 'si_trial', quantity: 3 }]);
+      expect(params.proration_behavior).toBe('none');
+      expect(params.payment_behavior).toBeUndefined();
+
+      expect(service.stripe.checkout.sessions.create).not.toHaveBeenCalled();
+
+      const subscriptionUpdate = state.updates.find((u) => u.table === 'stripe_subscriptions');
+      expect(subscriptionUpdate?.values.quantity).toBe(3);
+      const tenantUpdate = state.updates.find((u) => u.table === 'tenants');
+      expect(tenantUpdate?.values.licensed_user_count).toBe(3);
+    });
+
+    it('charges immediately when increasing an active subscription', async () => {
+      const state = createState([activeSubscription()]);
+      const { service } = createService(state);
+
+      const result = await service.updateOrCreateLicenseSubscription(TENANT, 3);
+
+      expect(result).toEqual(
+        expect.objectContaining({ type: 'updated', scheduledChange: false }),
+      );
+
+      expect(service.stripe.subscriptions.update).toHaveBeenCalledTimes(1);
+      const [subscriptionId, params] = service.stripe.subscriptions.update.mock.calls[0];
+      expect(subscriptionId).toBe('sub_ext_active');
+      expect(params.proration_behavior).toBe('always_invoice');
+      expect(params.payment_behavior).toBe('error_if_incomplete');
+      expect(service.stripe.checkout.sessions.create).not.toHaveBeenCalled();
+    });
+
+    it('prefers the active subscription when a leftover trial row exists', async () => {
+      const state = createState([trialSubscription(), activeSubscription()]);
+      const { service } = createService(state);
+
+      await service.updateOrCreateLicenseSubscription(TENANT, 3);
+
+      expect(service.stripe.subscriptions.update).toHaveBeenCalledTimes(1);
+      expect(service.stripe.subscriptions.update.mock.calls[0][0]).toBe('sub_ext_active');
+    });
+
+    it('ignores add-on subscriptions when looking for the license subscription', async () => {
+      const state = createState([
+        activeSubscription({
+          stripe_subscription_id: 'dbsub_addon',
+          stripe_subscription_external_id: 'sub_ext_addon',
+          stripe_subscription_item_id: 'si_addon',
+          metadata: { addon_key: 'ai_assistant' },
+        }),
+      ]);
+      const { service } = createService(state);
+
+      const result = await service.updateOrCreateLicenseSubscription(TENANT, 3);
+
+      // No license subscription found: falls through to a new checkout session
+      expect(result.type).toBe('checkout');
+      expect(service.stripe.subscriptions.update).not.toHaveBeenCalled();
+      expect(service.stripe.checkout.sessions.create).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe('handleSubscriptionUpdated', () => {
+    function subscriptionUpdatedEvent(overrides: Record<string, any> = {}) {
+      return {
+        data: {
+          object: {
+            id: 'sub_ext_trial',
+            status: 'trialing',
+            metadata: {},
+            items: {
+              data: [
+                {
+                  id: 'si_trial',
+                  quantity: 1,
+                  price: { id: 'price_pro_seat', recurring: { interval: 'month' }, product: 'prod_1' },
+                },
+              ],
+            },
+            current_period_start: 1780000000,
+            current_period_end: 1781000000,
+            cancel_at: 1781000000,
+            canceled_at: null,
+            trial_end: 1781000000,
+            ...overrides,
+          },
+        },
+      };
+    }
+
+    function prepareUpdateHandler(service: any) {
+      service.stripe.prices = {
+        retrieve: vi.fn().mockResolvedValue({
+          id: 'price_pro_seat',
+          recurring: { interval: 'month' },
+          product: { name: 'alga-psa-pro' },
+        }),
+      };
+      service.ensureStripePriceRecord = vi.fn().mockResolvedValue(null);
+    }
+
+    it('does not clobber licensed_user_count from a non-canonical trialing subscription', async () => {
+      const state = createState([trialSubscription(), activeSubscription()]);
+      const { service, knex } = createService(state);
+      prepareUpdateHandler(service);
+
+      await service.handleSubscriptionUpdated(subscriptionUpdatedEvent(), TENANT, knex);
+
+      // The trial sub's own row is still synced
+      const subscriptionUpdate = state.updates.find((u) => u.table === 'stripe_subscriptions');
+      expect(subscriptionUpdate?.values.quantity).toBe(1);
+
+      // ...but the tenant seat count is not driven by the non-canonical trial sub
+      expect(state.updates.find((u) => u.table === 'tenants')).toBeUndefined();
+    });
+
+    it('syncs licensed_user_count from the canonical subscription', async () => {
+      const state = createState([trialSubscription(), activeSubscription()]);
+      const { service, knex } = createService(state);
+      prepareUpdateHandler(service);
+
+      await service.handleSubscriptionUpdated(
+        subscriptionUpdatedEvent({
+          id: 'sub_ext_active',
+          status: 'active',
+          items: {
+            data: [
+              {
+                id: 'si_active',
+                quantity: 3,
+                price: { id: 'price_pro_seat', recurring: { interval: 'month' }, product: 'prod_1' },
+              },
+            ],
+          },
+          cancel_at: null,
+          trial_end: null,
+        }),
+        TENANT,
+        knex,
+      );
+
+      const tenantUpdate = state.updates.find((u) => u.table === 'tenants');
+      expect(tenantUpdate?.values.licensed_user_count).toBe(3);
+    });
+
+    it('syncs licensed_user_count normally for a tenant with a single trialing subscription', async () => {
+      const state = createState([trialSubscription()]);
+      const { service, knex } = createService(state);
+      prepareUpdateHandler(service);
+
+      await service.handleSubscriptionUpdated(subscriptionUpdatedEvent(), TENANT, knex);
+
+      const tenantUpdate = state.updates.find((u) => u.table === 'tenants');
+      expect(tenantUpdate?.values.licensed_user_count).toBe(1);
+    });
+  });
+
+  describe('handleSubscriptionDeleted', () => {
+    const deletionEvent = {
+      data: {
+        object: {
+          id: 'sub_ext_trial',
+          status: 'canceled',
+          metadata: {},
+        },
+      },
+    };
+
+    it('skips the tenant deletion workflow when another license subscription survives', async () => {
+      const state = createState([trialSubscription(), activeSubscription()]);
+      const { service, knex } = createService(state);
+
+      await service.handleSubscriptionDeleted(deletionEvent, TENANT, knex);
+
+      const cancelUpdate = state.updates.find((u) => u.table === 'stripe_subscriptions');
+      expect(cancelUpdate?.values.status).toBe('canceled');
+      expect(startTenantDeletionWorkflowMock).not.toHaveBeenCalled();
+    });
+
+    it('starts the tenant deletion workflow when only add-on subscriptions survive', async () => {
+      const state = createState([
+        trialSubscription(),
+        activeSubscription({
+          stripe_subscription_id: 'dbsub_addon',
+          stripe_subscription_external_id: 'sub_ext_addon',
+          metadata: { addon_key: 'ai_assistant' },
+        }),
+      ]);
+      const { service, knex } = createService(state);
+
+      await service.handleSubscriptionDeleted(deletionEvent, TENANT, knex);
+
+      expect(startTenantDeletionWorkflowMock).toHaveBeenCalledTimes(1);
+    });
+
+    it('starts the tenant deletion workflow when no live subscription remains', async () => {
+      const state = createState([trialSubscription()]);
+      const { service, knex } = createService(state);
+
+      await service.handleSubscriptionDeleted(deletionEvent, TENANT, knex);
+
+      expect(startTenantDeletionWorkflowMock).toHaveBeenCalledTimes(1);
+      expect(startTenantDeletionWorkflowMock).toHaveBeenCalledWith(
+        expect.objectContaining({
+          tenantId: TENANT,
+          triggerSource: 'stripe_webhook',
+          subscriptionExternalId: 'sub_ext_trial',
+        }),
+      );
+    });
+  });
+});

--- a/ee/server/src/lib/stripe/StripeService.ts
+++ b/ee/server/src/lib/stripe/StripeService.ts
@@ -244,6 +244,20 @@ function tenantScopedTable<Row extends object = Record<string, any>>(
   return tenantDb(conn, tenant).table<Row>(table);
 }
 
+/**
+ * A tenant's license (seat) subscriptions in the given statuses. Excludes
+ * add-on subscriptions: those carry metadata.addon_key, license rows never do.
+ */
+function licenseSubscriptions(
+  conn: Knex,
+  tenant: string,
+  statuses: readonly string[]
+): Knex.QueryBuilder<Record<string, any>, Record<string, any>[]> {
+  return tenantScopedTable(conn, 'stripe_subscriptions', tenant)
+    .whereIn('status', [...statuses])
+    .whereRaw("COALESCE(metadata->>'addon_key', '') = ''");
+}
+
 export class StripeService {
   private stripe!: Stripe;
   private config!: Awaited<ReturnType<typeof getStripeConfig>>;
@@ -667,12 +681,9 @@ export class StripeService {
     const knex = await getConnection(tenantId);
     const customer = await this.getOrImportCustomer(tenantId);
 
-    // Get existing subscription
-    const existingSubscription = await tenantScopedTable(knex, 'stripe_subscriptions', tenantId)
-      .where({
-        stripe_customer_id: customer.stripe_customer_id,
-        status: 'active',
-      })
+    // Get existing license subscription (add-on subscriptions previewed separately)
+    const existingSubscription = await licenseSubscriptions(knex, tenantId, ['active'])
+      .where({ stripe_customer_id: customer.stripe_customer_id })
       .first();
 
     if (!existingSubscription || !existingSubscription.stripe_subscription_item_id) {
@@ -732,7 +743,9 @@ export class StripeService {
    * Update existing subscription quantity or create checkout for new subscription
    *
    * IMPORTANT: Different behavior for increases vs decreases:
-   * - Increase: Immediate change with prorated charge
+   * - Increase (active): Immediate change with prorated charge
+   * - Increase (trialing): Immediate change, no charge — billing starts at the
+   *   new quantity when the trial converts
    * - Decrease: Scheduled for end of billing period (no immediate credit)
    *
    * Returns either an updated subscription or checkout session details
@@ -761,27 +774,21 @@ export class StripeService {
     // Get or import customer
     const customer = await this.getOrImportCustomer(tenantId);
 
-    // Check for an existing active or trialing subscription for the license price.
-    const existingSubscription = await tenantScopedTable(knex, 'stripe_subscriptions', tenantId)
-      .where({
-        stripe_customer_id: customer.stripe_customer_id,
-      })
-      .whereIn('status', ['active', 'trialing'])
+    // Check for an existing active or trialing license subscription, preferring
+    // active over trialing so a tenant that temporarily carries both rows gets
+    // seat changes on the paid subscription.
+    const existingSubscription = await licenseSubscriptions(knex, tenantId, ['active', 'trialing'])
+      .where({ stripe_customer_id: customer.stripe_customer_id })
+      .orderByRaw("CASE WHEN status = 'active' THEN 0 ELSE 1 END")
       .first();
-
-    // Trials can only be DECREASED here (scheduled at trial end, no charge). A trial
-    // increase falls through to checkout so we never bill mid-trial.
-    const isTrialingIncrease =
-      existingSubscription?.status === 'trialing' &&
-      quantity > existingSubscription.quantity;
 
     if (
       existingSubscription &&
-      existingSubscription.stripe_subscription_item_id &&
-      !isTrialingIncrease
+      existingSubscription.stripe_subscription_item_id
     ) {
       const currentQuantity = existingSubscription.quantity;
       const isIncrease = quantity > currentQuantity;
+      const isTrialing = existingSubscription.status === 'trialing';
 
       logger.info(
         `[StripeService] Found existing subscription ${existingSubscription.stripe_subscription_external_id}, ` +
@@ -789,10 +796,15 @@ export class StripeService {
       );
 
       if (isIncrease) {
-        // INCREASE: Immediate change with prorated charge
+        // INCREASE: Immediate change with prorated charge.
         // IMPORTANT: payment_behavior: 'error_if_incomplete' ensures the API call fails
         // if payment cannot be collected immediately, preventing license count updates
         // when payment fails (e.g., insufficient funds, expired card)
+        //
+        // Trialing subscriptions increase in place with NO invoice: the seats are
+        // usable immediately and billing simply starts at the new quantity when the
+        // trial converts. Paying mid-trial is only for tier upgrades (upgradeTier),
+        // never for adding seats on the current plan.
 
         // `quantity` is the user-facing total. For multi-item subscriptions
         // (platform fee + per-user line), the per-user line only carries the
@@ -815,8 +827,12 @@ export class StripeService {
                 quantity: perUserQuantity,
               },
             ],
-            proration_behavior: 'always_invoice', // Charge prorated amount now
-            payment_behavior: 'error_if_incomplete', // Fail if payment cannot be collected
+            ...(isTrialing
+              ? { proration_behavior: 'none' as const }
+              : {
+                  proration_behavior: 'always_invoice' as const, // Charge prorated amount now
+                  payment_behavior: 'error_if_incomplete' as const, // Fail if payment cannot be collected
+                }),
             metadata: {
               tenant_id: tenantId,
             },
@@ -1455,23 +1471,40 @@ export class StripeService {
       .where('stripe_subscription_external_id', subscription.id)
       .update(subscriptionUpdateData);
 
-    // Update tenant licensed_user_count and plan if subscription is active or trialing
+    // Update tenant licensed_user_count and plan if subscription is active or trialing.
+    // Only the tenant's canonical license subscription may drive the seat count:
+    // when a tenant temporarily carries two live rows (e.g. a leftover trial next
+    // to a paid subscription), events on the non-canonical one must not clobber it.
     if (subscription.status === 'active' || subscription.status === 'trialing') {
-      const updateData: Record<string, any> = {
-        licensed_user_count: quantity,
-        updated_at: knex.fn.now(),
-      };
-      if (plan) {
-        updateData.plan = plan;
-      }
+      const canonicalSubscription = await licenseSubscriptions(knex, tenantId, ['active', 'trialing'])
+        .orderByRaw("CASE WHEN status = 'active' THEN 0 ELSE 1 END")
+        .first();
 
-      await tenantScopedTable(knex, 'tenants', tenantId)
-        .update(updateData);
-
-      if (subscription.status === 'trialing') {
-        logger.info(`[StripeService] Tenant ${tenantId} is trialing${plan ? ` on ${plan}` : ''}, trial ends ${subscription.trial_end ? new Date(subscription.trial_end * 1000).toISOString() : 'unknown'}`);
+      if (
+        canonicalSubscription &&
+        canonicalSubscription.stripe_subscription_external_id !== subscription.id
+      ) {
+        logger.info(
+          `[StripeService] Subscription ${subscription.id} is not tenant ${tenantId}'s canonical license subscription ` +
+          `(${canonicalSubscription.stripe_subscription_external_id}); skipping licensed_user_count sync`
+        );
       } else {
-        logger.info(`[StripeService] Updated tenant ${tenantId} licensed_user_count to ${quantity}${plan ? `, plan to ${plan}` : ''}`);
+        const updateData: Record<string, any> = {
+          licensed_user_count: quantity,
+          updated_at: knex.fn.now(),
+        };
+        if (plan) {
+          updateData.plan = plan;
+        }
+
+        await tenantScopedTable(knex, 'tenants', tenantId)
+          .update(updateData);
+
+        if (subscription.status === 'trialing') {
+          logger.info(`[StripeService] Tenant ${tenantId} is trialing${plan ? ` on ${plan}` : ''}, trial ends ${subscription.trial_end ? new Date(subscription.trial_end * 1000).toISOString() : 'unknown'}`);
+        } else {
+          logger.info(`[StripeService] Updated tenant ${tenantId} licensed_user_count to ${quantity}${plan ? `, plan to ${plan}` : ''}`);
+        }
       }
     }
 
@@ -1532,6 +1565,21 @@ export class StripeService {
       });
 
     logger.warn(`[StripeService] Subscription ${subscription.id} canceled for tenant ${tenantId}`);
+
+    // A tenant with another live license subscription is not churning — this is
+    // cleanup of a superseded subscription (e.g. a leftover trial after a license
+    // purchase). Add-on subscriptions don't count: they can't keep a tenant alive.
+    const survivingSubscription = await licenseSubscriptions(knex, tenantId, ['active', 'trialing', 'past_due', 'unpaid'])
+      .whereNot('stripe_subscription_external_id', subscription.id)
+      .first();
+
+    if (survivingSubscription) {
+      logger.info(
+        `[StripeService] Tenant ${tenantId} still has ${survivingSubscription.status} subscription ` +
+        `${survivingSubscription.stripe_subscription_external_id}; skipping tenant deletion workflow`
+      );
+      return;
+    }
 
     // Start tenant deletion workflow
     // This will:


### PR DESCRIPTION
Trial seat increases previously fell through to a checkout session, charging the customer immediately and leaving a second subscription behind â the pay-first gate belongs to tier upgrades, not seat changes on the current plan. Now:

- updateOrCreateLicenseSubscription increases trialing subs in place with proration_behavior 'none'; billing starts at the new quantity when the trial converts
- handleSubscriptionDeleted skips the tenant deletion workflow while another live license subscription survives
- handleSubscriptionUpdated only syncs licensed_user_count and plan from the tenant's canonical license subscription, so events on a leftover trial row can't clobber seat count
- new licenseSubscriptions() helper excludes add-on rows and prefers active over trialing in all three lookups

"Off with their tenants!" cried the Queen of Webhooks â but handleSubscriptionDeleted counted the surviving subscriptions first, and pardoned every tenant still grinning from the stripe_subscriptions table like a canonical Cheshire Cat. ð±ðð³