### PR TITLE
Release 1.3.0

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@alga-psa/core",
-  "version": "1.2.16",
+  "version": "1.3.0",
   "private": true,
   "type": "module",
   "main": "./dist/index.js",

--- a/server/package.json
+++ b/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "server",
-  "version": "1.2.16",
+  "version": "1.3.0",
   "private": true,
   "type": "module",
   "engines": {


### PR DESCRIPTION
Version bump 1.2.16 → 1.3.0 (server, packages/core) on top of current main.

Includes everything on main up to #2908, notably the silent ticket close/update feature (#2909).