### PR TITLE
docs: record appliance admin recovery smoke

### DIFF
--- a/ee/docs/plans/2026-07-10-appliance-admin-password-recovery/SCRATCHPAD.md
+++ b/ee/docs/plans/2026-07-10-appliance-admin-password-recovery/SCRATCHPAD.md
@@ -22,7 +22,8 @@
 - (2026-07-10) The existing control-plane ClusterRole already grants the namespaced Secret and Job operations required by recovery, so no RBAC expansion was necessary.
 - (2026-07-10) The recovery Job clones the running Alga container image and environment, then adds only Secret-backed target/password inputs. This makes the application deployment the effective hashing configuration authority.
 - (2026-07-10) Local VM `ubuntu24.04` currently leases `192.168.122.215`, not the older `192.168.122.55` recorded in the appliance skill.
-- (2026-07-10) Live VM deployment is pending explicit authorization to install a temporary SSH key; the automated fresh-install harness, full host-service suite, UI production build, Helm render, runtime import smoke, and migrated-schema DB integration all pass.
+- (2026-07-11) Live appliance smoke passed on `alga-appliance-pro-lab`: Argo workflow `temporal-worker-build-auto-vmfgb` published `ghcr.io/nine-minds/temporal-worker:78b18a50` (digest `sha256:ffb93248de3f9b6d9b80e008f1c3ac8e1f3d19aa4682c7d4c7eb4c59454af8d1`), the appliance rolled out that sole worker with `ITERATIONS=1000`, and `tenantCreationWorkflow` created `temporal-password-smoke-20260711@local.test`. Alga authenticated that user with the exact workflow-supplied password.
+- (2026-07-11) The authenticated management recovery path reset original setup admin `bob@nineminds.com`; the reset returned HTTP 200 and Alga authenticated the original admin with the replacement password. The live Job initially failed while the app still used the pre-change `c18cf795` image because that image lacked the reset script, then passed after deploying the committed script on the same base image.
 
 ## Commands / Runbooks
 

--- a/ee/docs/plans/2026-07-10-appliance-admin-password-recovery/tests.json
+++ b/ee/docs/plans/2026-07-10-appliance-admin-password-recovery/tests.json
@@ -5,5 +5,5 @@
   {"id":"T004","description":"Host-service requests require an authenticated management session and reject invalid passwords, mismatched confirmation, browser-supplied target identity, and concurrent active reset Jobs.","implemented":true,"featureIds":["F006","F007","F008","F011"]},
   {"id":"T005","description":"Generated Kubernetes resources use the current Alga image, correct application configuration, bounded lifetime, and cleanup while containing no plaintext password in names, arguments, labels, logs, status, or responses.","implemented":true,"featureIds":["F009","F010","F012","F013","F014","F018"]},
   {"id":"T006","description":"Status UI displays only the original admin identity and covers validation, confirmation mismatch, busy, success, and generic failure behavior.","implemented":true,"featureIds":["F015","F016","F017","F018"]},
-  {"id":"T007","description":"Appliance smoke test resets the original admin through the authenticated management UI and signs into Alga with the replacement password.","implemented":false,"featureIds":["F001","F006","F010","F015","F017"]}
+  {"id":"T007","description":"Appliance smoke test resets the original admin through the authenticated management UI and signs into Alga with the replacement password.","implemented":true,"featureIds":["F001","F006","F010","F015","F017"]}
 ]


### PR DESCRIPTION
## Summary
- record the successful appliance Temporal worker build and live tenant/admin password verification
- record the authenticated original-admin recovery smoke
- mark the final plan test T007 implemented

## Evidence
- Argo workflow `temporal-worker-build-auto-vmfgb` succeeded
- `ghcr.io/nine-minds/temporal-worker:78b18a50` rolled out as the sole worker with `ITERATIONS=1000`
- the Temporal-created admin authenticated with the exact supplied password
- original admin `bob@nineminds.com` authenticated after the management reset returned HTTP 200

Follow-up to #2908.