### PR TITLE
docs: webhook notification-suppression fields and panel.submit shortcut (2026-07-11)

### DIFF
--- a/docs/api/api-rate-limiting-and-webhooks.md
+++ b/docs/api/api-rate-limiting-and-webhooks.md
@@ -112,6 +112,22 @@ Ticket webhooks support these event types in v1:
 - `ticket.closed`
 - `ticket.comment.added`
 
+### Notification Suppression
+
+`ticket.updated`, `ticket.assigned`, and `ticket.closed` payloads carry two
+boolean flags that reflect whether notifications were suppressed when the
+operation was performed:
+
+| Field | Type | Default | Meaning |
+| --- | --- | --- | --- |
+| `suppress_contact_notifications` | boolean | `false` | `true` when the contact (end-customer) was not notified about this update. |
+| `suppress_internal_notifications` | boolean | `false` | `true` when all notifications were suppressed — neither internal users nor the contact were notified. Implies `suppress_contact_notifications`. |
+
+Both fields are always present in the payload and default to `false`.
+Integrations that forward ticket events to an external system can read these
+flags to avoid double-notifying contacts when the MSP operator already chose
+to suppress the native notification.
+
 ### Delivery Envelope
 
 Every outbound webhook is delivered as JSON:
@@ -148,6 +164,8 @@ Every outbound webhook is delivered as JSON:
     "closed_at": null,
     "due_date": null,
     "tags": ["printer", "onsite"],
+    "suppress_contact_notifications": false,
+    "suppress_internal_notifications": false,
     "url": "https://algapsa.com/msp/tickets/22222222-2222-2222-2222-222222222222"
   }
 }
@@ -191,6 +209,8 @@ Every outbound webhook is delivered as JSON:
     "status_name": "Open",
     "tags": ["printer"],
     "url": "https://algapsa.com/msp/tickets/22222222-2222-2222-2222-222222222222",
+    "suppress_contact_notifications": false,
+    "suppress_internal_notifications": false,
     "changes": {
       "title": {
         "previous": "Printer offline",
@@ -236,6 +256,8 @@ Every outbound webhook is delivered as JSON:
     "assigned_to_name": "Pat Lee",
     "status_name": "In Progress",
     "tags": [],
+    "suppress_contact_notifications": false,
+    "suppress_internal_notifications": false,
     "url": "https://algapsa.com/msp/tickets/22222222-2222-2222-2222-222222222222"
   }
 }
@@ -255,6 +277,8 @@ Every outbound webhook is delivered as JSON:
     "is_closed": true,
     "closed_at": "2026-05-05T16:20:00.000Z",
     "tags": [],
+    "suppress_contact_notifications": false,
+    "suppress_internal_notifications": false,
     "url": "https://algapsa.com/msp/tickets/22222222-2222-2222-2222-222222222222"
   }
 }

--- a/docs/features/keyboard-shortcuts.md
+++ b/docs/features/keyboard-shortcuts.md
@@ -79,6 +79,19 @@ When a drawer or modal dialog is open it captures `Escape` (close/cancel) and
 `[`/`]` (previous/next record within the panel). Global and page shortcuts do
 not fire while a panel-scope owner is active.
 
+| Action | macOS | Windows / Linux |
+|--------|-------|-----------------|
+| Close / cancel | ⎋ | Escape |
+| Previous record in panel | `[` | `[` |
+| Next record in panel | `]` | `]` |
+| Save panel form (`panel.submit`) | ⌘S or ⌘↵ | Ctrl+S or Ctrl+Enter |
+
+`panel.submit` fires when a drawer is the active scope owner and the form
+inside it registers the shortcut. It takes priority over the page-level
+`Save current page` action — pressing ⌘S / Ctrl+S while a drawer is open
+saves the panel form rather than the underlying page. The shortcut is wired up
+in: ticket details panel, client quick-view panel, and contact details panel.
+
 ## Customizing Shortcuts
 
 Navigate to **Profile → Keyboard Shortcuts** to manage personal bindings.


### PR DESCRIPTION
## Summary

Automated documentation-drift audit for PRs merged 2026-07-10 → 2026-07-11. Two in-repo docs were confirmed stale.

### `docs/api/api-rate-limiting-and-webhooks.md` — reflects PR #2909 (Silent close option)

- Added **Notification Suppression** subsection under Ticket Webhooks explaining the two new boolean fields (`suppress_contact_notifications`, `suppress_internal_notifications`) that appear on `ticket.updated`, `ticket.assigned`, and `ticket.closed` payloads.
- Updated the delivery-envelope example (ticket.assigned) and all three affected per-event examples to include the new fields with their default values.

### `docs/features/keyboard-shortcuts.md` — reflects PR #2914 (Expand keyboard shortcuts coverage)

- Expanded the **Panel / dialog scope** section with a shortcut reference table and an explicit entry for `panel.submit` (⌘S / Ctrl+S or ⌘↵ / Ctrl+Enter).
- Added prose clarifying that `panel.submit` takes priority over the page-level Save shortcut when a drawer is open, and noting which panels it is wired up in (ticket details, client quick-view, contact details).

---

## Needs human review

The following PRs from the same window were examined but are **not** covered by this draft:

| PR | Reason |
|----|--------|
| **#2905** Tag filter for client picker | New UI feature in the MSP client picker; no existing doc covers this control. Worth a new docs entry but no current page to update. |
| **#2913** Preserve requested reactivation license count | Internal HMAC token-payload change (`email:licenseCount:timestamp`). No public-facing doc covers the reactivation token contract; existing tokens without `licenseCount` will fail closed. Human judgment needed on whether to document the contract publicly. |
| **#2910** Add licenses mid-trial in place | EE billing internals — trial seat increases no longer charge immediately. The change is server-side; no existing customer-facing billing doc was identified as stale. |

---
_Generated by [Claude Code](https://claude.ai/code/session_01THZ1isxivoULJ2ju9Hb1EQ)_