### PR TITLE
docs: keyboard shortcuts — document panel.submit and GlobalShortcutLayer (2026-07-12)

### DIFF
--- a/docs/features/keyboard-shortcuts.md
+++ b/docs/features/keyboard-shortcuts.md
@@ -73,11 +73,27 @@ focused, and reset on route change.
 `C` and `N` are suppressed while any editable target is focused and while a
 dialog or drawer owns scope.
 
-### Panel / dialog scope
+### Panel / drawer scope (when a drawer is open)
 
-When a drawer or modal dialog is open it captures `Escape` (close/cancel) and
-`[`/`]` (previous/next record within the panel). Global and page shortcuts do
-not fire while a panel-scope owner is active.
+When a side drawer is open (for example, the **All fields** view on a ticket,
+the **Client quick view**, or the contact editor), the page scope is suspended
+and the drawer captures keyboard input. Use these shortcuts while a drawer is
+active:
+
+| Action | macOS | Windows / Linux |
+|--------|-------|-----------------|
+| Save the form in the drawer | ⌘S / ⌘↩ | Ctrl+S / Ctrl+Enter |
+| Close the drawer | Escape | Escape |
+| Navigate to previous record | `[` | `[` |
+| Navigate to next record | `]` | `]` |
+
+`⌘S` / `Ctrl+S` on a regular page triggers `page.save` (saves the page). The
+same keys inside a drawer trigger `panel.submit` instead — the drawer-scoped
+save action. Opening a drawer suspends the page scope so the two do not
+conflict.
+
+Modal dialogs behave similarly: `⌘S` / `Ctrl+S` submits the active dialog
+(`dialog.submit`) rather than saving the page behind it.
 
 ## Customizing Shortcuts
 
@@ -118,7 +134,8 @@ profile's baseline (not the factory default).
 The dispatcher picks the highest-priority registered action that matches the
 event's active scope set:
 
-1. **Dialog / panel** — highest priority; owns `Escape` and record-nav keys.
+1. **Dialog / panel** — highest priority; owns `Escape`, `mod+s` / `mod+Enter`
+   (save / submit), and record-nav keys.
 2. **Editor** — `editor`-scoped shortcuts (invoice designer, workflow designer,
    rich-text) override page shortcuts.
 3. **Page** — page-scoped shortcuts fire when the registered page is active.
@@ -147,6 +164,7 @@ and `eslint-plugin-custom-rules`).
 | `packages/ui/src/keyboard-shortcuts/preferences.ts` | `ShortcutStorage` adapter interface + preference resolution (`user override → profile delta → platform default`) |
 | `packages/ui/src/keyboard-shortcuts/ShortcutHintHud.tsx` | `<Kbd>` / `ShortcutHint` component rendering OS-native glyphs |
 | `packages/ui/src/keyboard-shortcuts/command-palette-query.ts` | Command palette query parser (TeamCity-style field scopes + operators) |
+| `server/src/components/layout/GlobalShortcutLayer.tsx` | Shared keyboard layer mounted in both MSP shells (`DefaultLayout` and `AlgaDeskMspShell`); registers global / navigation actions, vim navigation, help dialog, and hint HUD |
 | `server/src/components/settings/general/KeyboardShortcutsPanel.tsx` | Profile → Keyboard Shortcuts settings UI |
 
 The provider is mounted in `MspLayoutClient.tsx` (wraps `DefaultLayout` and


### PR DESCRIPTION
## Source PR

- Nine-Minds/alga-psa #2914 — **Expand keyboard shortcuts coverage** (merged 2026-07-11)
  https://github.com/Nine-Minds/alga-psa/pull/2914

## What changed in the product

PR #2914 introduced a new `panel.submit` shortcut action (`mod+s` / `mod+Enter`) that fires inside drawers and panels. Before this change, pressing Ctrl+S / Cmd+S while a side drawer was open (e.g. the "All fields" ticket view, the Client quick view, or the contact editor) did nothing — the `page.save` action is intentionally suppressed inside the panel scope. After this change, the same key combination saves the form via `panel.submit`. The PR also extended `page.create` ("C") and `dialog.submit` (Ctrl+S in dialogs) coverage to all inventory manager surfaces, and extracted global/navigation shortcuts into a shared `GlobalShortcutLayer` component mounted in both MSP shells.

## Files edited

### `docs/features/keyboard-shortcuts.md`

1. **Added "Panel / drawer scope" subsection** under Default Shortcut Reference — explains that Ctrl+S / Cmd+S inside a drawer saves the open form (via `panel.submit`) rather than the page, and that modal dialogs work similarly with `dialog.submit`. This is a net-new capability that users would not discover from the previous doc.

2. **Updated Scope and Priority Rules item 1** — added `mod+s` / `mod+Enter` to the list of keys owned by the dialog / panel scope, alongside `Escape` and record-nav keys.

3. **Added `GlobalShortcutLayer.tsx` to the Architecture Overview table** — this new file is now the central place where global and navigation shortcut actions are registered; missing it from the table would leave the architecture section incomplete for contributors.

## Needs human review

- **Inventory page `page.create` and `dialog.submit` coverage**: PR #2914 wired the "C" key and Ctrl+S-in-dialog to all inventory manager pages (Purchase Orders, Sales Orders, RMA, Kits, Cycle Counts, Stock Locations, Loaners, Stock Overview, Transfers, Vendors, Vendor Bills). The existing doc describes `page.create` generically ("Open current page's create dialog: C") without enumerating surfaces. The generic description remains accurate; I did not add a surface inventory list because the doc does not enumerate surfaces elsewhere and doing so would create a maintenance burden. If you prefer an explicit list, please add it.
- **`dialog.submit` reference table**: The Default Shortcut Reference currently has no panel/dialog table listing `dialog.submit`. PR #2914 did not introduce `dialog.submit` (it predates this PR); the new "Panel / drawer scope" subsection now mentions it for context alongside `panel.submit`. A dedicated "Dialog scope" table could be added if desired.


---
_Generated by [Claude Code](https://claude.ai/code/session_01XPMowz5mRyPKXwgkFodTvg)_