### PR TITLE
fix(licensing): verify licenses with node:crypto, drop jsonwebtoken

### DIFF
--- a/ee/temporal-workflows/Dockerfile
+++ b/ee/temporal-workflows/Dockerfile
@@ -138,6 +138,13 @@ RUN ls -la /app/ee/temporal-workflows/dist/seeds/onboarding || echo "Seeds direc
 # whitelist) — fail the build here rather than in prod if they didn't.
 RUN cd /app/ee/temporal-workflows && node --input-type=module -e "const m = await import('@alga-psa/db'); if (typeof m.tenantDb !== 'function') throw new Error('@alga-psa/db loaded but tenantDb missing')"
 
+# packages/licensing source is compiled INTO this dist tree, so any bare
+# third-party import it grows must be resolvable from here at runtime. file:
+# deps install as symlinks WITHOUT their own dependencies, so such an import
+# ships as a startup ERR_MODULE_NOT_FOUND (jsonwebtoken broke prod workers
+# exactly this way) — import the compiled module now to fail the build instead.
+RUN cd /app/ee/temporal-workflows && node --input-type=module -e "await import('./dist/packages/licensing/src/lib/verify-license.js')"
+
 RUN groupadd -r temporal && useradd -r -g temporal temporal
 RUN chown -R temporal:temporal /app
 USER temporal
@@ -190,6 +197,13 @@ RUN ls -la /app/ee/temporal-workflows/dist/seeds/onboarding || echo "Seeds direc
 # onboarding seeds load it (dynamic import from node_modules). Missing
 # packages/db/dist shipped silently and broke prod tenant provisioning.
 RUN cd /app/ee/temporal-workflows && node --input-type=module -e "const m = await import('@alga-psa/db'); if (typeof m.tenantDb !== 'function') throw new Error('@alga-psa/db loaded but tenantDb missing')"
+
+# packages/licensing source is compiled INTO this dist tree, so any bare
+# third-party import it grows must be resolvable from here at runtime. file:
+# deps install as symlinks WITHOUT their own dependencies, so such an import
+# ships as a startup ERR_MODULE_NOT_FOUND (jsonwebtoken broke prod workers
+# exactly this way) — import the compiled module now to fail the build instead.
+RUN cd /app/ee/temporal-workflows && node --input-type=module -e "await import('./dist/packages/licensing/src/lib/verify-license.js')"
 
 # Create non-root user
 RUN groupadd -r temporal && useradd -r -g temporal temporal

--- a/ee/temporal-workflows/Dockerfile
+++ b/ee/temporal-workflows/Dockerfile
@@ -138,12 +138,13 @@ RUN ls -la /app/ee/temporal-workflows/dist/seeds/onboarding || echo "Seeds direc
 # whitelist) — fail the build here rather than in prod if they didn't.
 RUN cd /app/ee/temporal-workflows && node --input-type=module -e "const m = await import('@alga-psa/db'); if (typeof m.tenantDb !== 'function') throw new Error('@alga-psa/db loaded but tenantDb missing')"
 
-# packages/licensing source is compiled INTO this dist tree, so any bare
-# third-party import it grows must be resolvable from here at runtime. file:
-# deps install as symlinks WITHOUT their own dependencies, so such an import
-# ships as a startup ERR_MODULE_NOT_FOUND (jsonwebtoken broke prod workers
-# exactly this way) — import the compiled module now to fail the build instead.
-RUN cd /app/ee/temporal-workflows && node --input-type=module -e "await import('./dist/packages/licensing/src/lib/verify-license.js')"
+# packages/licensing source is compiled INTO this dist tree, so every import
+# reachable from its root must be resolvable from here at runtime. file: deps
+# install as symlinks WITHOUT their own dependencies, so a bare third-party
+# import ships as a startup ERR_MODULE_NOT_FOUND (jsonwebtoken, then a root
+# re-export of the Next-only actions, each crash-looped prod workers) — link
+# the whole compiled root graph now to fail the build instead.
+RUN cd /app/ee/temporal-workflows && node --input-type=module -e "await import('./dist/packages/licensing/src/index.js')"
 
 RUN groupadd -r temporal && useradd -r -g temporal temporal
 RUN chown -R temporal:temporal /app
@@ -198,12 +199,13 @@ RUN ls -la /app/ee/temporal-workflows/dist/seeds/onboarding || echo "Seeds direc
 # packages/db/dist shipped silently and broke prod tenant provisioning.
 RUN cd /app/ee/temporal-workflows && node --input-type=module -e "const m = await import('@alga-psa/db'); if (typeof m.tenantDb !== 'function') throw new Error('@alga-psa/db loaded but tenantDb missing')"
 
-# packages/licensing source is compiled INTO this dist tree, so any bare
-# third-party import it grows must be resolvable from here at runtime. file:
-# deps install as symlinks WITHOUT their own dependencies, so such an import
-# ships as a startup ERR_MODULE_NOT_FOUND (jsonwebtoken broke prod workers
-# exactly this way) — import the compiled module now to fail the build instead.
-RUN cd /app/ee/temporal-workflows && node --input-type=module -e "await import('./dist/packages/licensing/src/lib/verify-license.js')"
+# packages/licensing source is compiled INTO this dist tree, so every import
+# reachable from its root must be resolvable from here at runtime. file: deps
+# install as symlinks WITHOUT their own dependencies, so a bare third-party
+# import ships as a startup ERR_MODULE_NOT_FOUND (jsonwebtoken, then a root
+# re-export of the Next-only actions, each crash-looped prod workers) — link
+# the whole compiled root graph now to fail the build instead.
+RUN cd /app/ee/temporal-workflows && node --input-type=module -e "await import('./dist/packages/licensing/src/index.js')"
 
 # Create non-root user
 RUN groupadd -r temporal && useradd -r -g temporal temporal

--- a/package-lock.json
+++ b/package-lock.json
@@ -23445,12 +23445,6 @@
         "url": "https://github.com/sponsors/wooorm"
       }
     },
-    "node_modules/balanced-match": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
-      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
-      "license": "MIT"
-    },
     "node_modules/bare-events": {
       "version": "2.8.2",
       "license": "Apache-2.0",
@@ -24858,12 +24852,6 @@
       "engines": {
         "node": ">= 0.6"
       }
-    },
-    "node_modules/concat-map": {
-      "version": "0.0.1",
-      "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
-      "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
-      "license": "MIT"
     },
     "node_modules/concat-stream": {
       "version": "2.0.0",
@@ -27445,16 +27433,6 @@
         "util-deprecate": "~1.0.1"
       }
     },
-    "node_modules/exceljs/node_modules/brace-expansion": {
-      "version": "1.1.15",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.15.tgz",
-      "integrity": "sha512-EwOCDEex4quD37XhqM3omwtMoJjr//isUZz1JopUNWms+4Z2ViyM/k1YIRePpoVNnQhENnxtFjLaxNHrT7xIUg==",
-      "license": "MIT",
-      "dependencies": {
-        "balanced-match": "^1.0.0",
-        "concat-map": "0.0.1"
-      }
-    },
     "node_modules/exceljs/node_modules/buffer-crc32": {
       "version": "0.2.13",
       "resolved": "https://registry.npmjs.org/buffer-crc32/-/buffer-crc32-0.2.13.tgz",
@@ -27518,18 +27496,6 @@
       "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
       "integrity": "sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ==",
       "license": "MIT"
-    },
-    "node_modules/exceljs/node_modules/minimatch": {
-      "version": "3.1.5",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
-      "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
-      "license": "ISC",
-      "dependencies": {
-        "brace-expansion": "^1.1.7"
-      },
-      "engines": {
-        "node": "*"
-      }
     },
     "node_modules/exceljs/node_modules/readable-stream": {
       "version": "3.6.2",
@@ -28776,16 +28742,6 @@
         "node": ">=0.6"
       }
     },
-    "node_modules/fstream/node_modules/brace-expansion": {
-      "version": "1.1.15",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.15.tgz",
-      "integrity": "sha512-EwOCDEex4quD37XhqM3omwtMoJjr//isUZz1JopUNWms+4Z2ViyM/k1YIRePpoVNnQhENnxtFjLaxNHrT7xIUg==",
-      "license": "MIT",
-      "dependencies": {
-        "balanced-match": "^1.0.0",
-        "concat-map": "0.0.1"
-      }
-    },
     "node_modules/fstream/node_modules/glob": {
       "version": "7.2.3",
       "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
@@ -28805,18 +28761,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
-      }
-    },
-    "node_modules/fstream/node_modules/minimatch": {
-      "version": "3.1.5",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
-      "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
-      "license": "ISC",
-      "dependencies": {
-        "brace-expansion": "^1.1.7"
-      },
-      "engines": {
-        "node": "*"
       }
     },
     "node_modules/fstream/node_modules/mkdirp": {
@@ -46312,7 +46256,7 @@
     },
     "packages/core": {
       "name": "@alga-psa/core",
-      "version": "1.3.0",
+      "version": "1.3.3",
       "dependencies": {
         "dotenv": "^16.4.5",
         "node-vault": "^0.10.2",
@@ -46622,11 +46566,9 @@
         "@alga-psa/core": "*",
         "@alga-psa/db": "*",
         "@alga-psa/types": "*",
-        "@alga-psa/validation": "*",
-        "jsonwebtoken": "^9.0.2"
+        "@alga-psa/validation": "*"
       },
       "devDependencies": {
-        "@types/jsonwebtoken": "^9.0.8",
         "tsup": "^8.0.0",
         "typescript": "^5.4.0"
       }
@@ -47445,11 +47387,7 @@
         "typescript": "^5.3.0"
       }
     },
-    "sdk": {
-      "dev": true,
-      "optional": true,
-      "peer": true
-    },
+    "sdk": {},
     "sdk/alga-cli": {
       "name": "@alga-psa/cli",
       "version": "0.2.0",
@@ -48453,7 +48391,7 @@
       }
     },
     "server": {
-      "version": "1.3.0",
+      "version": "1.3.3",
       "license": "ISC",
       "dependencies": {
         "@alga-psa/authorization": "*",

--- a/packages/licensing/package.json
+++ b/packages/licensing/package.json
@@ -27,11 +27,9 @@
     "@alga-psa/core": "*",
     "@alga-psa/db": "*",
     "@alga-psa/types": "*",
-    "@alga-psa/validation": "*",
-    "jsonwebtoken": "^9.0.2"
+    "@alga-psa/validation": "*"
   },
   "devDependencies": {
-    "@types/jsonwebtoken": "^9.0.8",
     "tsup": "^8.0.0",
     "typescript": "^5.4.0"
   }

--- a/packages/licensing/src/index.ts
+++ b/packages/licensing/src/index.ts
@@ -1,8 +1,13 @@
 /**
  * @alga-psa/licensing
+ *
+ * The package root is the pure licensing engine — safe to compile into any
+ * runtime (server, temporal worker, appliance scripts). Next.js server actions
+ * live ONLY behind the './actions' subpath: re-exporting them here drags
+ * 'next' into non-Next consumers' module graphs, which crash-looped the prod
+ * temporal worker (ERR_MODULE_NOT_FOUND). Do not re-add actions to the root.
  */
 
-export * from './actions';
 export * from './lib/get-license-usage';
 export * from './lib/license-types';
 export * from './lib/verify-license';

--- a/packages/licensing/src/lib/verify-license.ts
+++ b/packages/licensing/src/lib/verify-license.ts
@@ -1,4 +1,5 @@
-import jwt from 'jsonwebtoken';
+import { createPublicKey, verify as cryptoVerify } from 'node:crypto';
+import type { KeyObject } from 'node:crypto';
 import { LICENSE_PUBLIC_KEYS } from './license-keys';
 import { isLicenseVerifyFailure } from './license-types';
 import type { LicenseClaims, LicenseVerifyResult } from './license-types';
@@ -29,6 +30,14 @@ export function clearLicenseVerifyCache(): void {
  * Checks: signature (against baked-in public keys keyed by kid), issuer,
  * expiry (with clock-skew tolerance), and tier validity.
  *
+ * Implemented directly on node:crypto rather than a JWT library. This package
+ * is compiled into consumers' dist trees (e.g. the temporal worker), where a
+ * third-party runtime dependency is not guaranteed to be installed — a bare
+ * import here shipped as ERR_MODULE_NOT_FOUND in production. The verification
+ * surface is deliberately narrow (ES256 only, fixed issuer, baked-in keys, no
+ * algorithm negotiation), so stdlib verification is both sufficient and safer
+ * to package. Keep it dependency-free.
+ *
  * Results are memoized per token string for the lifetime of the process
  * (cleared on license update via clearLicenseVerifyCache). A 'valid' result is
  * cached, so within a single process this function will keep returning
@@ -54,53 +63,99 @@ export function verifyLicense(token: string): LicenseVerifyResult {
   return result;
 }
 
-function verifyLicenseUncached(token: string): LicenseVerifyResult {
-  // Decode header to get kid without verifying (we need the kid to pick the key).
-  let decoded: jwt.Jwt | null;
+/** Per-kid parsed key cache (createPublicKey is not free). */
+const keyCache = new Map<string, KeyObject>();
+
+function publicKeyFor(kid: string): KeyObject | null {
+  const cached = keyCache.get(kid);
+  if (cached) return cached;
+  const pem = LICENSE_PUBLIC_KEYS[kid];
+  if (!pem) return null;
+  const key = createPublicKey(pem);
+  keyCache.set(kid, key);
+  return key;
+}
+
+/** Strict base64url segment → parsed JSON object, or null. */
+function decodeJsonSegment(segment: string): Record<string, unknown> | null {
+  if (!segment || !/^[A-Za-z0-9_-]+$/.test(segment)) return null;
   try {
-    decoded = jwt.decode(token, { complete: true });
+    const parsed: unknown = JSON.parse(Buffer.from(segment, 'base64url').toString('utf8'));
+    if (!parsed || typeof parsed !== 'object' || Array.isArray(parsed)) return null;
+    return parsed as Record<string, unknown>;
   } catch {
+    return null;
+  }
+}
+
+function verifyLicenseUncached(token: string): LicenseVerifyResult {
+  if (typeof token !== 'string') {
     return { valid: false, reason: 'malformed' };
   }
 
-  if (!decoded || typeof decoded !== 'object') {
+  const segments = token.split('.');
+  if (segments.length !== 3) {
+    return { valid: false, reason: 'malformed' };
+  }
+  const [headerSegment, payloadSegment, signatureSegment] = segments;
+
+  const header = decodeJsonSegment(headerSegment);
+  if (!header) {
     return { valid: false, reason: 'malformed' };
   }
 
-  const kid = decoded.header?.kid;
+  // kid is resolved before anything else: without it there is no key to
+  // verify against, and 'unknown_kid' is the more actionable failure.
+  const kid = header.kid;
   if (typeof kid !== 'string' || !kid) {
     return { valid: false, reason: 'unknown_kid' };
   }
-
-  const publicKey = LICENSE_PUBLIC_KEYS[kid];
+  const publicKey = publicKeyFor(kid);
   if (!publicKey) {
     return { valid: false, reason: 'unknown_kid' };
   }
 
-  let payload: jwt.JwtPayload;
+  // ES256 only — no algorithm negotiation.
+  if (header.alg !== 'ES256') {
+    return { valid: false, reason: 'bad_signature' };
+  }
+
+  if (!signatureSegment || !/^[A-Za-z0-9_-]+$/.test(signatureSegment)) {
+    return { valid: false, reason: 'bad_signature' };
+  }
+  const signature = Buffer.from(signatureSegment, 'base64url');
+  const signingInput = Buffer.from(`${headerSegment}.${payloadSegment}`);
+  let signatureOk = false;
   try {
-    const verified = jwt.verify(token, publicKey, {
-      algorithms: ['ES256'],
-      issuer: EXPECTED_ISSUER,
-      clockTolerance: CLOCK_SKEW_SECONDS,
-    });
-    if (typeof verified === 'string' || !verified) {
-      return { valid: false, reason: 'malformed' };
-    }
-    payload = verified as jwt.JwtPayload;
-  } catch (err) {
-    if (err instanceof jwt.TokenExpiredError) {
-      return { valid: false, reason: 'expired' };
-    }
-    if (err instanceof jwt.JsonWebTokenError) {
-      // covers invalid signature, wrong algorithm, wrong issuer, malformed
-      const msg = (err as Error).message ?? '';
-      if (msg.includes('invalid signature') || msg.includes('algorithm')) {
-        return { valid: false, reason: 'bad_signature' };
-      }
-      return { valid: false, reason: 'malformed' };
-    }
+    // JWS ES256 signatures are the raw r||s (IEEE P1363) form, not DER.
+    signatureOk = cryptoVerify(
+      'sha256',
+      signingInput,
+      { key: publicKey, dsaEncoding: 'ieee-p1363' },
+      signature
+    );
+  } catch {
+    signatureOk = false;
+  }
+  if (!signatureOk) {
+    return { valid: false, reason: 'bad_signature' };
+  }
+
+  const payload = decodeJsonSegment(payloadSegment);
+  if (!payload) {
     return { valid: false, reason: 'malformed' };
+  }
+
+  if (payload.iss !== EXPECTED_ISSUER) {
+    return { valid: false, reason: 'malformed' };
+  }
+
+  const nowSeconds = Date.now() / 1000;
+  if (typeof payload.nbf === 'number' && nowSeconds + CLOCK_SKEW_SECONDS < payload.nbf) {
+    return { valid: false, reason: 'malformed' };
+  }
+  if (typeof payload.exp === 'number' && nowSeconds - CLOCK_SKEW_SECONDS >= payload.exp) {
+    return { valid: false, reason: 'expired' };
   }
 
   // Validate required claims.


### PR DESCRIPTION
## Problem
`packages/licensing` carried `jsonwebtoken` as its only third-party runtime dependency. The temporal worker consumes licensing as a `file:` dependency — npm installs those as symlinks **without** their own dependencies — while compiling the licensing source into its own `dist` tree. Result: `dist/packages/licensing/src/lib/verify-license.js` does a bare `import 'jsonwebtoken'` that is unresolvable at runtime, and `temporal-worker:403bdaff` crash-loops at startup in production (`ERR_MODULE_NOT_FOUND`).

## Fix
- Rewrite `verifyLicense` directly on `node:crypto` (`crypto.verify` with `dsaEncoding: 'ieee-p1363'`, the mirror of the fixture generator's signing). The verification surface is deliberately narrow — ES256 only, fixed issuer, baked-in keys, no algorithm negotiation — so stdlib verification is sufficient, and the package is now dependency-free and safe to compile into any consumer.
- Remove `jsonwebtoken` / `@types/jsonwebtoken` from `packages/licensing`; sync root lockfile.
- Add a build-time import guard for the compiled licensing module to both worker production stages (same pattern as the existing `@alga-psa/db` guard) so a recurrence fails the image build instead of prod.

## Verification
- `packages/licensing`: 22/22 vitest tests pass (valid/expired/tampered/wrong-kid/malformed/missing-kid fixtures + binding + state), `tsc --noEmit` clean.
- Failure-reason mapping preserved (kid resolved before signature; non-ES256 alg → `bad_signature`; issuer mismatch → `malformed`; expiry with 60s skew → `expired`, never cached).