### PR TITLE
fix(appliance): set ALGA_LICENSE_SERVICE_URL in the single-node profile

### DIFF
--- a/ee/appliance/flux/profiles/single-node/values/alga-core.single-node.yaml
+++ b/ee/appliance/flux/profiles/single-node/values/alga-core.single-node.yaml
@@ -59,6 +59,14 @@ temporal:
   address: temporal-frontend.msp.svc.cluster.local:7233
   namespace: default
 
+# Nine Minds license service (alga-license). Appliances reach it through the
+# public gateway; the License screen's claim-code redemption (connectAppliance
+# -> POST /register) fails with "License service URL not configured" without it.
+# Claim-code and check-in routes are claim/credential-authed — no service
+# secret is needed or set on appliances.
+licenseService:
+  url: "https://license.nineminds.com"
+
 db:
   enabled: true
   persistence:


### PR DESCRIPTION
## Problem
On a fully upgraded appliance, the License screen shows **"License service URL not configured"** when redeeming a claim code.

`connectAppliance` (server action behind the License screen) reads `process.env.ALGA_LICENSE_SERVICE_URL` and errors when unset. The alga-core chart only injects that env when `licenseService.url` is set (`helm/templates/deployment.yaml:857`), and the appliance Flux profile (`ee/appliance/flux/profiles/single-node/values/alga-core.single-node.yaml`) never set it — so **every real appliance** hits this. Dev smoke tests passed only because the URL was set in a local `.env.local`.

## Fix
Set `licenseService.url: https://license.nineminds.com` in the single-node profile — the public Istio gateway that fronts alga-license's claim/check-in routes for on-prem appliances (`nm-kube-config/alga-license/istio-gateway.yaml`). No service secret is set: appliance-facing routes are claim-code/credential-authed; `ALGA_LICENSE_SERVICE_SECRET` remains a hosted-console-only concern.

## Rollout
Ships to appliances via `alga-appliance-config-publish` (profileValues are applied to the `appliance-values-alga-core` ConfigMap on channel update). Existing boxes can be hot-fixed by adding the same block to that ConfigMap and reconciling the `alga-core` HelmRelease.