### PR TITLE
fix(appliance): repair pod exec/port-forward (401 auth + 403 RBAC)

### DIFF
--- a/ee/appliance/control-plane/manifests/rbac.yaml
+++ b/ee/appliance/control-plane/manifests/rbac.yaml
@@ -23,11 +23,13 @@ metadata:
       to Kubernetes cluster-admin. Narrow further once setup-engine moves from
       shell commands to typed in-cluster API operations.
 rules:
-  # Interactive support tools use the Kubernetes streaming subresources. These
-  # exact create grants do not permit pod creation or mutation.
+  # Interactive support tools use the Kubernetes streaming subresources. The
+  # WebSocket streaming protocol opens these with GET (SPDY used POST/create),
+  # so both verbs are required — create alone authorizes the access review but
+  # the actual exec then 403s. Neither grant permits pod creation or mutation.
   - apiGroups: [""]
     resources: ["pods/exec", "pods/portforward"]
-    verbs: ["create"]
+    verbs: ["get", "create"]
   - apiGroups: [""]
     resources: ["namespaces", "configmaps", "secrets", "services", "serviceaccounts", "persistentvolumeclaims", "persistentvolumes", "pods", "pods/log", "events", "resourcequotas", "limitranges"]
     verbs: ["get", "list", "watch", "create", "patch", "update", "delete"]

--- a/ee/appliance/host-service/kubernetes-client-adapter.mjs
+++ b/ee/appliance/host-service/kubernetes-client-adapter.mjs
@@ -85,7 +85,10 @@ export function createNativeKubernetesAdapter({
       return rbac.replaceClusterRole({ name, body });
     },
 
-    async canCreatePodSubresource(subresource) {
+    // Probe the verb the WebSocket streaming protocol actually issues (GET).
+    // Reviewing 'create' (the old SPDY verb) reported the feature available on
+    // roles that then 403'd the real stream.
+    async canUsePodSubresource(subresource, verb = 'get') {
       const { authorization } = await clients();
       const review = await authorization.createSelfSubjectAccessReview({
         body: {
@@ -96,7 +99,7 @@ export function createNativeKubernetesAdapter({
               group: '',
               resource: 'pods',
               subresource,
-              verb: 'create',
+              verb,
             },
           },
         },

--- a/ee/appliance/host-service/kubernetes-client-adapter.mjs
+++ b/ee/appliance/host-service/kubernetes-client-adapter.mjs
@@ -1,4 +1,7 @@
+import { existsSync } from 'node:fs';
 import { PassThrough, Writable } from 'node:stream';
+
+const SERVICE_ACCOUNT_TOKEN_PATH = '/var/run/secrets/kubernetes.io/serviceaccount/token';
 
 class ResizableOutput extends Writable {
   constructor({ columns, rows, onData }) {
@@ -33,6 +36,7 @@ function closeWebSocket(candidate) {
 export function createNativeKubernetesAdapter({
   kubeconfigPath,
   moduleLoader = () => import('@kubernetes/client-node'),
+  serviceAccountTokenPath = SERVICE_ACCOUNT_TOKEN_PATH,
 } = {}) {
   let clientsPromise;
 
@@ -40,7 +44,18 @@ export function createNativeKubernetesAdapter({
     if (!clientsPromise) {
       clientsPromise = moduleLoader().then((k8s) => {
         const config = new k8s.KubeConfig();
-        config.loadFromFile(kubeconfigPath);
+        // In-cluster (the control-plane pod), use the library's own
+        // service-account flow instead of the entrypoint's kubeconfig file.
+        // client-node's kubeconfig parser only understands `token`/`token-file`
+        // — it silently ignores kubectl's `tokenFile:` spelling, so loading
+        // that file authenticated NOTHING and every exec/port-forward/access
+        // probe got a 401. loadFromCluster() also re-reads the projected token
+        // as it rotates (~hourly), which a one-shot file read would not.
+        if (process.env.KUBERNETES_SERVICE_HOST && existsSync(serviceAccountTokenPath)) {
+          config.loadFromCluster();
+        } else {
+          config.loadFromFile(kubeconfigPath);
+        }
         return {
           config,
           core: config.makeApiClient(k8s.CoreV1Api),

--- a/ee/appliance/host-service/pod-access-rbac.mjs
+++ b/ee/appliance/host-service/pod-access-rbac.mjs
@@ -1,15 +1,24 @@
 const ROLE_NAME = 'appliance-control-plane-setup-admin';
 const REQUIRED_SUBRESOURCES = ['pods/exec', 'pods/portforward'];
+// The WebSocket streaming protocol opens exec/port-forward with GET; the older
+// SPDY protocol used POST (create). A role holding only 'create' passes the
+// access review and then 403s on the actual stream ("cannot get resource
+// pods/exec"), so both verbs are required — and roles migrated by earlier
+// builds hold create only, which is why this migration must add 'get' to them.
+const REQUIRED_VERBS = ['get', 'create'];
 
-function ruleAllowsCreate(rule, resource) {
+function ruleGrants(rule, resource, verb) {
   return (rule?.apiGroups || []).includes('')
     && (rule?.resources || []).includes(resource)
-    && ((rule?.verbs || []).includes('create') || (rule?.verbs || []).includes('*'));
+    && ((rule?.verbs || []).includes(verb) || (rule?.verbs || []).includes('*'));
 }
 
+/** Subresources missing at least one required verb. */
 export function missingPodAccessResources(role) {
   const rules = role?.rules || [];
-  return REQUIRED_SUBRESOURCES.filter((resource) => !rules.some((rule) => ruleAllowsCreate(rule, resource)));
+  return REQUIRED_SUBRESOURCES.filter((resource) => !REQUIRED_VERBS.every(
+    (verb) => rules.some((rule) => ruleGrants(rule, resource, verb)),
+  ));
 }
 
 export function addPodAccessRules(role) {
@@ -20,7 +29,7 @@ export function addPodAccessRules(role) {
       ...role,
       rules: [
         ...(role?.rules || []),
-        { apiGroups: [''], resources: missing, verbs: ['create'] },
+        { apiGroups: [''], resources: missing, verbs: [...REQUIRED_VERBS] },
       ],
     },
     changed: true,
@@ -42,8 +51,8 @@ export async function ensurePodAccessRbac(adapter, { roleName = ROLE_NAME, logge
       }));
     }
     const [execAllowed, forwardAllowed] = await Promise.all([
-      adapter.canCreatePodSubresource('exec'),
-      adapter.canCreatePodSubresource('portforward'),
+      adapter.canUsePodSubresource('exec'),
+      adapter.canUsePodSubresource('portforward'),
     ]);
     if (!execAllowed || !forwardAllowed) {
       throw new Error('Kubernetes did not authorize pod exec and port-forward after the RBAC migration.');

--- a/ee/appliance/host-service/tests/control-plane-manifests.test.mjs
+++ b/ee/appliance/host-service/tests/control-plane-manifests.test.mjs
@@ -33,7 +33,8 @@ test('T002 control-plane manifests define isolated namespace, workload, exposure
   assert.match(rbac, /clusterrolebindings/);
   assert.match(rbac, /storageclasses/);
   assert.match(rbac, /resources: \["pods\/exec", "pods\/portforward"\]/);
-  assert.match(rbac, /verbs: \["create"\]/);
+  // WebSocket streaming opens exec/port-forward with GET; create alone 403s.
+  assert.match(rbac, /verbs: \["get", "create"\]/);
   assert.doesNotMatch(rbac, /resources: \["\*"\]/);
   assert.doesNotMatch(rbac, /verbs: \["\*"\]/);
   assert.doesNotMatch(rbac, /host kubeconfig/);

--- a/ee/appliance/host-service/tests/kubernetes-client-adapter.test.mjs
+++ b/ee/appliance/host-service/tests/kubernetes-client-adapter.test.mjs
@@ -1,0 +1,62 @@
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { createNativeKubernetesAdapter } from '../kubernetes-client-adapter.mjs';
+
+// The adapter must pick the library's in-cluster service-account flow when it
+// runs inside the control-plane pod. client-node's kubeconfig parser ignores
+// kubectl's `tokenFile:` spelling, so loading the entrypoint-written
+// kubeconfig authenticated nothing: every exec/port-forward/access-review hit
+// the apiserver as anonymous and 401ed, while kubectl-driven features kept
+// working. loadFromCluster() also tracks the projected token as it rotates.
+
+function fakeK8sModule(calls) {
+  class KubeConfig {
+    loadFromCluster() { calls.push({ method: 'loadFromCluster' }); }
+    loadFromFile(file) { calls.push({ method: 'loadFromFile', file }); }
+    makeApiClient() { return {}; }
+  }
+  return { KubeConfig, Exec: class {}, PortForward: class {} };
+}
+
+async function detectLoad({ env, tokenExists }) {
+  const calls = [];
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'kca-test-'));
+  const tokenPath = path.join(dir, 'token');
+  if (tokenExists) fs.writeFileSync(tokenPath, 'tok');
+
+  const previous = process.env.KUBERNETES_SERVICE_HOST;
+  if (env) process.env.KUBERNETES_SERVICE_HOST = '10.43.0.1';
+  else delete process.env.KUBERNETES_SERVICE_HOST;
+  try {
+    const adapter = createNativeKubernetesAdapter({
+      kubeconfigPath: '/etc/rancher/k3s/k3s.yaml',
+      moduleLoader: async () => fakeK8sModule(calls),
+      serviceAccountTokenPath: tokenPath,
+    });
+    // Any adapter call forces the lazy client construction.
+    await adapter.readPod('msp', 'some-pod').catch(() => {});
+  } finally {
+    if (previous === undefined) delete process.env.KUBERNETES_SERVICE_HOST;
+    else process.env.KUBERNETES_SERVICE_HOST = previous;
+    fs.rmSync(dir, { recursive: true, force: true });
+  }
+  return calls;
+}
+
+test('in-cluster (env + projected token present) uses loadFromCluster', async () => {
+  const calls = await detectLoad({ env: true, tokenExists: true });
+  assert.deepEqual(calls, [{ method: 'loadFromCluster' }]);
+});
+
+test('on the host (no KUBERNETES_SERVICE_HOST) loads the kubeconfig file', async () => {
+  const calls = await detectLoad({ env: false, tokenExists: true });
+  assert.deepEqual(calls, [{ method: 'loadFromFile', file: '/etc/rancher/k3s/k3s.yaml' }]);
+});
+
+test('env set but no projected token falls back to the kubeconfig file', async () => {
+  const calls = await detectLoad({ env: true, tokenExists: false });
+  assert.deepEqual(calls, [{ method: 'loadFromFile', file: '/etc/rancher/k3s/k3s.yaml' }]);
+});

--- a/ee/appliance/host-service/tests/pod-access.test.mjs
+++ b/ee/appliance/host-service/tests/pod-access.test.mjs
@@ -182,14 +182,14 @@ test('T004 RBAC migration adds only missing streaming subresources and verifies 
   const patched = addPodAccessRules(initial);
   assert.equal(patched.changed, true);
   assert.deepEqual(patched.role.rules.at(-1), {
-    apiGroups: [''], resources: ['pods/exec', 'pods/portforward'], verbs: ['create'],
+    apiGroups: [''], resources: ['pods/exec', 'pods/portforward'], verbs: ['get', 'create'],
   });
 
   let replaced = null;
   const result = await ensurePodAccessRbac({
     async readClusterRole() { return initial; },
     async replaceClusterRole(_name, role) { replaced = role; },
-    async canCreatePodSubresource() { return true; },
+    async canUsePodSubresource() { return true; },
   }, { logger: quietLogger() });
   assert.equal(result.available, true);
   assert.equal(result.migrated, true);
@@ -200,4 +200,36 @@ test('T004 RBAC migration adds only missing streaming subresources and verifies 
   }, { logger: quietLogger() });
   assert.equal(unavailable.available, false);
   assert.match(unavailable.message, /forbidden/);
+});
+
+test('T004b a create-only role (shipped by earlier builds) is migrated to add get', async () => {
+  // WebSocket exec issues GET; create-only roles passed the access review and
+  // then 403'd the real stream ("cannot get resource pods/exec").
+  const createOnly = {
+    metadata: { name: 'appliance-control-plane-setup-admin', resourceVersion: '2' },
+    rules: [{ apiGroups: [''], resources: ['pods/exec', 'pods/portforward'], verbs: ['create'] }],
+  };
+  assert.deepEqual(missingPodAccessResources(createOnly), ['pods/exec', 'pods/portforward']);
+
+  let replaced = null;
+  const result = await ensurePodAccessRbac({
+    async readClusterRole() { return createOnly; },
+    async replaceClusterRole(_name, role) { replaced = role; },
+    async canUsePodSubresource(_subresource, verb = 'get') {
+      // Model the apiserver: only what the migrated role actually grants.
+      return (replaced?.rules || []).some((rule) => (rule.verbs || []).includes(verb));
+    },
+  }, { logger: quietLogger() });
+  assert.equal(result.migrated, true);
+  assert.equal(result.available, true);
+  assert.deepEqual(missingPodAccessResources(replaced), []);
+});
+
+test('T004c a role already granting get+create is left alone', async () => {
+  const complete = {
+    metadata: { name: 'appliance-control-plane-setup-admin', resourceVersion: '3' },
+    rules: [{ apiGroups: [''], resources: ['pods/exec', 'pods/portforward'], verbs: ['get', 'create'] }],
+  };
+  assert.deepEqual(missingPodAccessResources(complete), []);
+  assert.equal(addPodAccessRules(complete).changed, false);
 });


### PR DESCRIPTION
## Problem
The appliance console's **Inspect a running container** shows UNAVAILABLE and the terminal fails with a raw kube-apiserver **401 Unauthorized**, while the pod dropdowns populate fine.

Smoke-tested on the local appliance VM, this turned out to be **two independent bugs stacked**:

### 1. Authentication (the 401)
The control-plane entrypoint writes an in-cluster kubeconfig authenticating via `tokenFile:` — kubectl's spelling. `@kubernetes/client-node` only parses `token` / `token-file` and **silently ignores** `tokenFile`, so the native adapter built a client with **no credential**: every exec, port-forward, and SelfSubjectAccessReview hit the apiserver anonymously → 401. kubectl-driven features read the same file correctly, which is why pod listing worked.

**Fix:** in-cluster, use the library's own `loadFromCluster()`. Its `FileAuth` provider also re-reads the projected SA token as it rotates (~hourly) — a latent second failure even with the right spelling. Host-side (`k3s.yaml`) behavior unchanged.

### 2. Authorization (a 403 hiding behind the 401)
With auth restored, exec still failed: `cannot **get** resource "pods/exec" in the namespace "msp"`. The ClusterRole (and the host-service self-migration) grants only **create** on `pods/exec` / `pods/portforward` — the verb the old **SPDY** protocol used. client-node's **WebSocket** streaming opens them with **GET**.

Worse, the availability probe reviewed `create` too — so it would report the feature *available* while every session 403'd.

**Fix:** grant `get` + `create` in the shipped ClusterRole; migrate create-only roles from earlier builds to add `get`; probe the verb the stream actually issues (`canUsePodSubresource`, default `get`).

## Verification (local appliance VM, 192.168.122.143)
Built the control-plane image with both fixes, imported into the VM's k3s, rolled `appliance-control-plane`:
- ClusterRole self-migrated: `["pods/exec","pods/portforward"]=["get","create"]`, log `event: "migrated"`.
- Access probe: `exec=true portforward=true` (was 401).
- **Real exec into `alga-core-sebastian` returned a live `/app #` shell** and ran commands inside the container.

Host-service suite: 109/109 (new adapter in-cluster/host/fallback cases + RBAC get-migration cases).