### PR TITLE
feat(qbo-sync): reconciliation safety, export readiness, and credit/payment appliers

### DIFF
--- a/docs/AI_coding_standards.md
+++ b/docs/AI_coding_standards.md
@@ -890,6 +890,16 @@ All tests should follow the conventions outlined in [docs/testing-standards.md](
 
 See the full [Testing Standards](./reference/testing-standards.md) document for complete guidelines, templates, and the decision tree for test placement.
 
+## Testing the QuickBooks Online sync
+
+Do not hand-mock `QboClientService` for multi-step accounting-sync tests. A
+stateful in-memory QBO simulator (SyncTokens, duplicate-name rules, balances,
+CDC replay, the auto-apply-credits race) lives at
+`packages/billing/src/services/accountingSync/testing/qboSimulator.ts` — its
+README covers wiring and the scenario pattern, and
+`qboSimulator.scenarios.test.ts` next to it shows real appliers driven
+end-to-end. Canned `vi.fn()` mocks remain fine for single-call unit tests.
+
 # Time Entry Work Item Types
 They can be:
 - Ticket

--- a/packages/billing/src/actions/accountingSyncActions.ts
+++ b/packages/billing/src/actions/accountingSyncActions.ts
@@ -71,6 +71,7 @@ export const updateAccountingSyncSettingsAction = withAuth(async (
   return updateAccountingSyncSettings(knex, tenant, {
     ...(patch.autoSyncEnabled !== undefined ? { autoSyncEnabled: Boolean(patch.autoSyncEnabled) } : {}),
     ...(patch.autoSyncStartDate !== undefined ? { autoSyncStartDate: patch.autoSyncStartDate } : {}),
+    ...(patch.autoProvisionCustomers !== undefined ? { autoProvisionCustomers: Boolean(patch.autoProvisionCustomers) } : {}),
     ...(patch.depositAccountRef !== undefined ? { depositAccountRef: patch.depositAccountRef } : {}),
     ...(patch.defaultClassRef !== undefined ? { defaultClassRef: patch.defaultClassRef } : {}),
     ...(patch.defaultDepartmentRef !== undefined ? { defaultDepartmentRef: patch.defaultDepartmentRef } : {}),

--- a/packages/billing/src/actions/invoiceModification.ts
+++ b/packages/billing/src/actions/invoiceModification.ts
@@ -24,6 +24,8 @@ import {
 
 import { validateInvoiceFinalization } from './taxSourceActions';
 import { enqueueInvoiceAutoExport } from '../services/accountingSync/syncProducers';
+import { assertInvoiceNotExported } from '../services/accountingSync/invoiceExportGuards';
+import { assertInvoiceExportReady, InvoiceExportReadinessError } from '../services/accountingSync/exportReadiness';
 import { withAuth } from '@alga-psa/auth';
 import { getSession } from '@alga-psa/auth';
 import { hasPermission } from '@alga-psa/auth/rbac';
@@ -341,6 +343,18 @@ export async function finalizeInvoiceWithKnex(
     throw expectedInvoiceActionError(taxValidation.error || 'Invoice cannot be finalized');
   }
 
+  // When this invoice will auto-export to QBO, block finalize on deterministic
+  // export failures (line without a service, unmapped service) so the fix
+  // happens here rather than in the sync exception inbox.
+  try {
+    await assertInvoiceExportReady(knex, tenant, invoiceId);
+  } catch (error) {
+    if (error instanceof InvoiceExportReadinessError) {
+      throw expectedInvoiceActionError(error.message);
+    }
+    throw error;
+  }
+
   // First transaction to update invoice status
   await withTransaction(knex, async (trx: Knex.Transaction) => {
     // Check if invoice exists and is not already finalized
@@ -651,6 +665,14 @@ export const unfinalizeInvoice = withAuth(async (
     return permissionError('Permission denied: invoice update required');
   }
   const { knex } = await createTenantKnex();
+
+  // Guard: a document posted to an accounting system must stay posted. Reopening
+  // it here would let a later re-finalize export into reconciled books.
+  try {
+    await assertInvoiceNotExported(knex, tenant, invoiceId, 'unfinalize');
+  } catch (error) {
+    return actionError(getErrorMessage(error));
+  }
 
   let expectedError: InvoiceActionError | null = null;
 

--- a/packages/billing/src/adapters/accounting/quickBooksOnlineAdapter.ts
+++ b/packages/billing/src/adapters/accounting/quickBooksOnlineAdapter.ts
@@ -172,6 +172,12 @@ function resolveQboServiceDate(line: AccountingExportAdapterContext['lines'][num
   return line.service_period_start ?? line.service_period_end ?? null;
 }
 
+/**
+ * Testing note: transform/deliver behavior against real QBO semantics
+ * (SyncTokens, duplicate customer names, recomputed totals) can be exercised
+ * with the stateful in-memory simulator at
+ * ../../services/accountingSync/testing/qboSimulator.ts — see its README.
+ */
 export class QuickBooksOnlineAdapter implements AccountingExportAdapter {
   static readonly TYPE = 'quickbooks_online';
 
@@ -255,6 +261,15 @@ export class QuickBooksOnlineAdapter implements AccountingExportAdapter {
 
       let clientMapping = clientData.mappings.get(clientId);
       if (!clientMapping) {
+        // Defense in depth behind the batch-validation check: without explicit
+        // opt-in, the delivery path never creates or links QBO customers —
+        // that decision belongs to a human in the mapping wizard.
+        if (!syncSettings?.autoProvisionCustomers) {
+          throw new Error(
+            `QuickBooks adapter: customer "${clientRow.client_name ?? clientId}" has no QuickBooks mapping and automatic customer creation is disabled — link the customer from the QuickBooks customer mapping screen`
+          );
+        }
+
         if (!context.batch.target_realm) {
           throw new Error('QuickBooks adapter requires batch target realm to sync customers');
         }

--- a/packages/billing/src/components/accounting/QboSyncHealthPanel.contract.test.tsx
+++ b/packages/billing/src/components/accounting/QboSyncHealthPanel.contract.test.tsx
@@ -63,7 +63,7 @@ const healthConnected = {
   settings: {
     autoSyncEnabled: true,
     autoSyncStartDate: null,
-    depositAccountRef: null,
+    autoProvisionCustomers: false, depositAccountRef: null,
     defaultClassRef: null,
     defaultDepartmentRef: null,
     defaultRealm: null
@@ -112,7 +112,7 @@ describe('QboSyncHealthPanel contracts', () => {
     updateAccountingSyncSettingsActionMock.mockResolvedValue({
       autoSyncEnabled: false,
       autoSyncStartDate: null,
-      depositAccountRef: null,
+      autoProvisionCustomers: false, depositAccountRef: null,
       defaultClassRef: null,
       defaultDepartmentRef: null,
       defaultRealm: null
@@ -348,5 +348,58 @@ describe('QboSyncHealthPanel contracts', () => {
     });
 
     expect(document.getElementById('qbo-realm-list')).not.toBeInTheDocument();
+  });
+
+  // Customer contract: we tell customers Alga warns them when QBO's
+  // "Automatically apply credits" automation is on (it races Alga-driven
+  // credit application). Removing or hiding this warning changes advice
+  // customers have been given — see customerContracts.qboCredits.test.ts.
+  it('contract: auto-apply-credits warning renders when the QBO preference is on', async () => {
+    getAccountingSyncHealthMock.mockImplementation(async () => ({
+      ...healthConnected,
+      autoApplyCreditsEnabled: true
+    }));
+
+    const { default: QboSyncHealthPanel } = await import('./QboSyncHealthPanel');
+    render(<QboSyncHealthPanel />);
+
+    await waitFor(() => {
+      expect(document.getElementById('qbo-auto-apply-credits-warning')).toBeInTheDocument();
+    });
+    expect(document.getElementById('qbo-auto-apply-credits-warning')?.textContent)
+      .toMatch(/automatically apply credits/i);
+  });
+
+  it('contract: auto-apply-credits warning is hidden when the preference is off', async () => {
+    getAccountingSyncHealthMock.mockImplementation(async () => ({
+      ...healthConnected,
+      autoApplyCreditsEnabled: false
+    }));
+
+    const { default: QboSyncHealthPanel } = await import('./QboSyncHealthPanel');
+    render(<QboSyncHealthPanel />);
+
+    await waitFor(() => {
+      expect(document.getElementById('qbo-integration-sync-health-card')).toBeInTheDocument();
+    });
+
+    expect(document.getElementById('qbo-auto-apply-credits-warning')).not.toBeInTheDocument();
+  });
+
+  // Customer contract: customer auto-provisioning is opt-in. The toggle must
+  // exist so tenants CAN opt in, and it must persist through the settings
+  // action — see customerContracts.qboExportSafety.test.ts for the default.
+  it('contract: customer auto-provisioning toggle renders and persists the opt-in', async () => {
+    const { default: QboSyncHealthPanel } = await import('./QboSyncHealthPanel');
+    render(<QboSyncHealthPanel />);
+
+    await waitFor(() => {
+      expect(document.getElementById('qbo-sync-auto-provision-toggle')).toBeInTheDocument();
+    });
+
+    fireEvent.click(document.getElementById('qbo-sync-auto-provision-toggle')!);
+    await waitFor(() => {
+      expect(updateAccountingSyncSettingsActionMock).toHaveBeenCalledWith({ autoProvisionCustomers: true });
+    });
   });
 });

--- a/packages/billing/src/components/accounting/QboSyncHealthPanel.tsx
+++ b/packages/billing/src/components/accounting/QboSyncHealthPanel.tsx
@@ -34,6 +34,7 @@ export default function QboSyncHealthPanel() {
   const [syncNowRunning, setSyncNowRunning] = React.useState(false);
   const [syncNowFeedback, setSyncNowFeedback] = React.useState<{ type: 'success' | 'error'; message: string } | null>(null);
   const [autoSyncToggling, setAutoSyncToggling] = React.useState(false);
+  const [autoProvisionToggling, setAutoProvisionToggling] = React.useState(false);
 
   // Sync config catalog data
   const [accounts, setAccounts] = React.useState<QboAccount[]>([]);
@@ -359,6 +360,39 @@ export default function QboSyncHealthPanel() {
                   // Silently ignore — badge state stays as-is
                 } finally {
                   setAutoSyncToggling(false);
+                }
+              }}
+            />
+          </div>
+
+          {/* Customer auto-provisioning toggle */}
+          <div className="flex items-center justify-between">
+            <div className="pr-4">
+              <span className="text-sm font-medium">
+                {t('integrations.qbo.sync.autoProvisionCustomersLabel', {
+                  defaultValue: 'Create QuickBooks customers automatically'
+                })}
+              </span>
+              <p className="text-xs text-muted-foreground">
+                {t('integrations.qbo.sync.autoProvisionCustomersHint', {
+                  defaultValue:
+                    'Off: exports for unmapped customers pause with an exception until you link them in the customer mapping screen.'
+                })}
+              </p>
+            </div>
+            <Switch
+              id="qbo-sync-auto-provision-toggle"
+              checked={Boolean(health.settings.autoProvisionCustomers)}
+              disabled={autoProvisionToggling}
+              onCheckedChange={async (checked) => {
+                setAutoProvisionToggling(true);
+                try {
+                  const updated = await updateAccountingSyncSettingsAction({ autoProvisionCustomers: checked });
+                  setHealth((prev) => prev ? { ...prev, settings: updated } : prev);
+                } catch {
+                  // Silently ignore — badge state stays as-is
+                } finally {
+                  setAutoProvisionToggling(false);
                 }
               }}
             />

--- a/packages/billing/src/services/accountingExportValidation.ts
+++ b/packages/billing/src/services/accountingExportValidation.ts
@@ -37,6 +37,7 @@ type InvoiceProjection = {
 type ClientProjection = {
   tenant: string;
   client_id: string;
+  client_name?: string | null;
   payment_terms?: string | null;
 };
 
@@ -228,10 +229,61 @@ export class AccountingExportValidation {
     const clients =
       clientIds.size > 0
         ? await db.table<ClientProjection>('clients')
-            .select('client_id', 'payment_terms')
+            .select('client_id', 'client_name', 'payment_terms')
             .whereIn('client_id', Array.from(clientIds))
         : [];
     const clientsById = new Map(clients.map((row) => [row.client_id, row]));
+
+    // With customer auto-provisioning off (the default), an unmapped customer
+    // is a validation failure, not a license for the delivery path to write
+    // to the QBO customer list from a background job.
+    if (adapterType === 'quickbooks_online' && clientIds.size > 0 && tenant) {
+      const syncSettings = await getAccountingSyncSettings(knex, tenant);
+      if (!syncSettings.autoProvisionCustomers) {
+        const mappedRows = await knex('tenant_external_entity_mappings')
+          .where({
+            tenant,
+            integration_type: 'quickbooks_online',
+            alga_entity_type: 'client'
+          })
+          .whereIn('alga_entity_id', Array.from(clientIds))
+          .modify((builder) => {
+            const targetRealm = batch.target_realm;
+            if (targetRealm) {
+              builder.andWhere((realmClause) =>
+                realmClause.where('external_realm_id', targetRealm).orWhereNull('external_realm_id')
+              );
+            } else {
+              builder.whereNull('external_realm_id');
+            }
+          })
+          .select('alga_entity_id');
+        const mappedClientIds = new Set(mappedRows.map((row: any) => row.alga_entity_id));
+        const flaggedClients = new Set<string>();
+
+        for (const invoice of invoices) {
+          if (!invoice.client_id || mappedClientIds.has(invoice.client_id) || flaggedClients.has(invoice.client_id)) {
+            continue;
+          }
+          const lineId = firstLineByInvoice.get(invoice.invoice_id);
+          const line = lineId ? lineById.get(lineId) : null;
+          if (lineId) {
+            const clientName = clientsById.get(invoice.client_id)?.client_name ?? invoice.client_id;
+            await repo.addError({
+              batch_id: batchId,
+              line_id: lineId,
+              code: 'missing_customer_mapping',
+              message: `Customer "${clientName}" is not mapped to a QuickBooks customer. Link or create it from the QuickBooks customer mapping screen, or enable automatic customer creation in sync settings.`,
+              metadata: mergeErrorMetadata(line, {
+                client_id: invoice.client_id,
+                client_name: clientName
+              })
+            });
+            flaggedClients.add(invoice.client_id);
+          }
+        }
+      }
+    }
 
     const checkedTaxRegions = new Set<string>();
     const missingTaxRegions = new Set<string>();

--- a/packages/billing/src/services/accountingSync/accountingSyncCycleService.test.ts
+++ b/packages/billing/src/services/accountingSync/accountingSyncCycleService.test.ts
@@ -1,5 +1,10 @@
 import { describe, expect, it, vi, beforeEach } from 'vitest';
 
+// These tests verify cycle WIRING (ordering, cursor rules, drain error
+// handling) with all appliers mocked out. To test applier BEHAVIOR against
+// stateful QBO semantics, use the simulator in ./testing/qboSimulator.ts —
+// see ./testing/README.md.
+
 // ── Module mocks ────────────────────────────────────────────────────────────
 // tenantDb is only used by the vendor-bill drain to read bill rows; everything
 // else on @alga-psa/db stays real.
@@ -55,7 +60,7 @@ vi.mock('./accountingSyncSettings', () => ({
   getAccountingSyncSettings: vi.fn(async () => ({
     autoSyncEnabled: true,
     autoSyncStartDate: null,
-    depositAccountRef: null,
+    autoProvisionCustomers: false, depositAccountRef: null,
     defaultClassRef: null,
     defaultDepartmentRef: null,
     defaultRealm: null
@@ -172,7 +177,7 @@ describe('runAccountingSyncCycle', () => {
   beforeEach(() => {
     vi.clearAllMocks();
     // Reset all module-level mocks to defaults
-    vi.mocked(getAccountingSyncSettings).mockResolvedValue({ autoSyncEnabled: true, autoSyncStartDate: null, depositAccountRef: null, defaultClassRef: null, defaultDepartmentRef: null, defaultRealm: null });
+    vi.mocked(getAccountingSyncSettings).mockResolvedValue({ autoSyncEnabled: true, autoSyncStartDate: null, autoProvisionCustomers: false, depositAccountRef: null, defaultClassRef: null, defaultDepartmentRef: null, defaultRealm: null });
     vi.mocked(resolveTokenThresholdToAnnounce).mockResolvedValue(null);
     tenantDbMock.mockImplementation(() => makeVendorBillDb([]));
   });
@@ -192,7 +197,7 @@ describe('runAccountingSyncCycle', () => {
   });
 
   it('skips when autoSyncEnabled=false and force not set', async () => {
-    vi.mocked(getAccountingSyncSettings).mockResolvedValue({ autoSyncEnabled: false, autoSyncStartDate: null, depositAccountRef: null, defaultClassRef: null, defaultDepartmentRef: null, defaultRealm: null });
+    vi.mocked(getAccountingSyncSettings).mockResolvedValue({ autoSyncEnabled: false, autoSyncStartDate: null, autoProvisionCustomers: false, depositAccountRef: null, defaultClassRef: null, defaultDepartmentRef: null, defaultRealm: null });
 
     const result = await runAccountingSyncCycle({
       knex: {} as any,
@@ -207,7 +212,7 @@ describe('runAccountingSyncCycle', () => {
   });
 
   it('runs when autoSyncEnabled=false but force=true', async () => {
-    vi.mocked(getAccountingSyncSettings).mockResolvedValue({ autoSyncEnabled: false, autoSyncStartDate: null, depositAccountRef: null, defaultClassRef: null, defaultDepartmentRef: null, defaultRealm: null });
+    vi.mocked(getAccountingSyncSettings).mockResolvedValue({ autoSyncEnabled: false, autoSyncStartDate: null, autoProvisionCustomers: false, depositAccountRef: null, defaultClassRef: null, defaultDepartmentRef: null, defaultRealm: null });
 
     const result = await runAccountingSyncCycle({
       knex: {} as any,

--- a/packages/billing/src/services/accountingSync/accountingSyncCycleService.ts
+++ b/packages/billing/src/services/accountingSync/accountingSyncCycleService.ts
@@ -46,6 +46,11 @@ import { ADAPTER_EXPORT_CAPABILITIES } from '../../adapters/accounting/registry'
  * failures retry per-op with capped attempts and never block the cursor.
  * All appliers are idempotent against the mapping ledger, which is what makes
  * the deliberate cursor overlap (and our own outbound echoes) safe.
+ *
+ * Testing: for multi-step sequences against stateful QBO behavior (balances,
+ * SyncTokens, CDC replay, auto-apply races), drive the appliers with the
+ * in-memory simulator in ./testing/qboSimulator.ts instead of canned mocks —
+ * see ./testing/README.md.
  */
 
 /** Overlap subtracted from the stored cursor to absorb clock skew. */

--- a/packages/billing/src/services/accountingSync/accountingSyncSettings.ts
+++ b/packages/billing/src/services/accountingSync/accountingSyncSettings.ts
@@ -12,8 +12,16 @@ export type QboAccountRef = QboRef;
 
 export interface AccountingSyncSettings {
   autoSyncEnabled: boolean;
-  /** Invoices finalized before this ISO date are never auto-enqueued (set by the onboarding wizard). */
+  /** Invoices dated before this ISO date are never auto-enqueued (set by the onboarding wizard). */
   autoSyncStartDate: string | null;
+  /**
+   * Allow the export pipeline to create or link QBO customers outside the
+   * onboarding wizard. Off (the default) means an unmapped customer fails
+   * batch validation with an actionable exception instead of writing to the
+   * QBO customer list from a background job — the safe behavior for
+   * established company files.
+   */
+  autoProvisionCustomers: boolean;
   /** QBO account to deposit payments into (Bank or Other Current Asset). Null = Undeposited Funds. */
   depositAccountRef: QboRef | null;
   /** Default QBO class applied to invoice lines when the item mapping has no classId. */
@@ -29,6 +37,7 @@ export interface AccountingSyncSettings {
 const DEFAULT_SETTINGS: AccountingSyncSettings = {
   autoSyncEnabled: false,
   autoSyncStartDate: null,
+  autoProvisionCustomers: false,
   depositAccountRef: null,
   defaultClassRef: null,
   defaultDepartmentRef: null,
@@ -58,6 +67,7 @@ function normalize(raw: unknown): AccountingSyncSettings {
   return {
     autoSyncEnabled: Boolean(record.autoSyncEnabled),
     autoSyncStartDate: typeof record.autoSyncStartDate === 'string' ? record.autoSyncStartDate : null,
+    autoProvisionCustomers: Boolean(record.autoProvisionCustomers),
     depositAccountRef: normalizeQboRef(record.depositAccountRef),
     defaultClassRef: normalizeQboRef(record.defaultClassRef),
     defaultDepartmentRef: normalizeQboRef(record.defaultDepartmentRef),

--- a/packages/billing/src/services/accountingSync/creditApplicationApplier.test.ts
+++ b/packages/billing/src/services/accountingSync/creditApplicationApplier.test.ts
@@ -1,5 +1,9 @@
 import { describe, expect, it, vi, beforeEach } from 'vitest';
 
+// These are single-call unit tests, so canned QBO mocks suffice. For stateful
+// sequences (the auto-apply race against real balances, idempotent replay),
+// see the simulator-driven suite in ./testing/qboSimulator.scenarios.test.ts.
+
 // ── Module mocks (hoisted) ──────────────────────────────────────────────────
 const qboCreateMock = vi.hoisted(() => vi.fn());
 const qboReadMock = vi.hoisted(() => vi.fn());
@@ -184,6 +188,102 @@ describe('drainApplyCreditOps', () => {
 
     expect(ops.markDone).toHaveBeenCalledWith(TENANT, 'op-apply-1');
     expect(stats.opsProcessed).toBe(1);
+  });
+
+  it('prepayment-sourced credit (mapping can never arrive) → loud exception + failed op, not silent pending', async () => {
+    const op = makePendingOp();
+    const markFailed = vi.fn(async () => 'pending');
+    const ops = makeOps({ listPending: vi.fn(async () => [op]), markFailed });
+
+    // No mapping for the credit source; target invoice is mapped.
+    const ledger = makeLedger({
+      findByAlgaId: vi.fn(async (entityType: string, entityId: string) => {
+        if (entityType === 'credit_application') return undefined;
+        if (entityId === 'inv-target-1') {
+          return { id: 'map-inv', external_entity_id: 'qbo-inv-99', metadata: { customerId: 'customer-77' } };
+        }
+        return undefined;
+      })
+    });
+
+    // knex resolves the credit source as a prepayment invoice.
+    const first = vi.fn(async () => ({ invoice_type: 'prepayment', is_prepayment: true }));
+    const select = vi.fn(() => ({ first }));
+    const where = vi.fn(() => ({ select }));
+    const knex: any = vi.fn(() => ({ where }));
+
+    const exceptions = makeExceptions();
+    const stats = makeStats();
+
+    await drainApplyCreditOps({
+      knex,
+      tenantId: TENANT,
+      adapterType: ADAPTER,
+      targetRealm: REALM,
+      ops,
+      ledger,
+      exceptions,
+      stats
+    });
+
+    expect(exceptions.createOrUpdate).toHaveBeenCalledWith(
+      expect.objectContaining({
+        entityType: 'credit_allocation',
+        entityId: 'alloc-1',
+        context: expect.objectContaining({ reason: 'prepayment_credit_not_syncable' })
+      })
+    );
+    expect(markFailed).toHaveBeenCalled();
+    expect(qboCreateMock).not.toHaveBeenCalled();
+    expect(stats.exceptionsCreated).toBe(1);
+  });
+
+  it('op stalled past the wait window → exception surfaced, op still left pending', async () => {
+    const eightDaysAgo = new Date(Date.now() - 8 * 24 * 60 * 60 * 1000).toISOString();
+    const op = makePendingOp({ created_at: eightDaysAgo });
+    const markFailed = vi.fn(async () => 'pending');
+    const ops = makeOps({ listPending: vi.fn(async () => [op]), markFailed });
+
+    // Credit source unmapped but NOT a prepayment (export just hasn't happened).
+    const ledger = makeLedger({
+      findByAlgaId: vi.fn(async (entityType: string, entityId: string) => {
+        if (entityType === 'credit_application') return undefined;
+        if (entityId === 'inv-target-1') {
+          return { id: 'map-inv', external_entity_id: 'qbo-inv-99', metadata: { customerId: 'customer-77' } };
+        }
+        return undefined;
+      })
+    });
+
+    const first = vi.fn(async () => ({ invoice_type: 'credit_note', is_prepayment: false }));
+    const select = vi.fn(() => ({ first }));
+    const where = vi.fn(() => ({ select }));
+    const knex: any = vi.fn(() => ({ where }));
+
+    const exceptions = makeExceptions();
+    const stats = makeStats();
+
+    await drainApplyCreditOps({
+      knex,
+      tenantId: TENANT,
+      adapterType: ADAPTER,
+      targetRealm: REALM,
+      ops,
+      ledger,
+      exceptions,
+      stats
+    });
+
+    expect(exceptions.createOrUpdate).toHaveBeenCalledWith(
+      expect.objectContaining({
+        entityType: 'credit_allocation',
+        entityId: 'alloc-1',
+        context: expect.objectContaining({ reason: 'apply_credit_stalled' })
+      })
+    );
+    // Still pending: attempts untouched, no terminal failure.
+    expect(markFailed).not.toHaveBeenCalled();
+    expect(qboCreateMock).not.toHaveBeenCalled();
   });
 
   it('missing CreditMemo mapping → leaves op pending without incrementing attempts', async () => {

--- a/packages/billing/src/services/accountingSync/creditApplicationApplier.ts
+++ b/packages/billing/src/services/accountingSync/creditApplicationApplier.ts
@@ -24,6 +24,24 @@ interface ApplyCreditPayload {
   amountCents: number;
 }
 
+/** How long an apply_credit op may wait on missing mappings before we surface it. */
+export const STALLED_APPLY_CREDIT_AGE_MS = 7 * 24 * 60 * 60 * 1000;
+
+/** True when the credit's source document is a prepayment (which never exports). */
+async function isPrepaymentSourced(deps: DrainDeps, creditNoteInvoiceId: string): Promise<boolean> {
+  try {
+    const sourceInvoice = await deps.knex('invoices')
+      .where({ invoice_id: creditNoteInvoiceId, tenant: deps.tenantId })
+      .select('invoice_type', 'is_prepayment')
+      .first();
+    return Boolean(sourceInvoice && (sourceInvoice.invoice_type === 'prepayment' || sourceInvoice.is_prepayment));
+  } catch {
+    // Infra failure: treat as not-prepayment so the op stays pending rather
+    // than terminally failing on a lookup error.
+    return false;
+  }
+}
+
 /**
  * Drain pending apply_credit ops.
  *
@@ -92,8 +110,71 @@ export async function drainApplyCreditOps(deps: DrainDeps): Promise<void> {
     const invoiceMapping = await deps.ledger.findByAlgaId('invoice', payload.targetInvoiceId);
 
     if (!creditMemoMapping || !invoiceMapping) {
-      // One or both documents are not yet exported — leave pending without
-      // incrementing attempt count so the op retries without burning retries.
+      // Doomed op check: credit drawn from a PREPAYMENT invoice can never map,
+      // because prepayments are not exported to QBO. Without this, the op
+      // pends silently forever while the QBO invoice shows an open balance
+      // Alga believes is settled.
+      if (!creditMemoMapping && (await isPrepaymentSourced(deps, payload.creditNoteInvoiceId))) {
+        const message =
+          'Credit drawn from a prepayment cannot sync: prepayment invoices are not exported to QuickBooks, ' +
+          'so the QuickBooks invoice balance will not reflect this application.';
+        const result = await deps.exceptions.createOrUpdate({
+          type: 'accounting_sync_export_error',
+          entityType: 'credit_allocation',
+          entityId: op.alga_entity_id,
+          title: 'Prepayment credit applied to a synced invoice — QuickBooks not updated',
+          context: {
+            reason: 'prepayment_credit_not_syncable',
+            alga_entity_id: op.alga_entity_id,
+            alga_credit_note_invoice_id: payload.creditNoteInvoiceId,
+            alga_target_invoice_id: payload.targetInvoiceId,
+            requested_amount_cents: payload.amountCents,
+            message,
+            details:
+              `${message} Settle the invoice inside QuickBooks (apply the customer's credit or record the ` +
+              'payment there) so both systems agree, then resolve this exception.',
+            realm: deps.targetRealm
+          }
+        });
+        if (result.created) {
+          deps.stats.exceptionsCreated += 1;
+        }
+        await deps.ops.markFailed(deps.tenantId, op.op_id, message);
+        deps.stats.opsFailed += 1;
+        continue;
+      }
+
+      // Otherwise an export simply hasn't drained yet — leave pending without
+      // burning attempts. But waiting is only healthy for so long: past the
+      // stall window, surface an exception instead of hiding behind the
+      // pending-ops counter (it auto-resolves when the application lands).
+      const ageMs = Date.now() - Date.parse(String(op.created_at));
+      if (Number.isFinite(ageMs) && ageMs > STALLED_APPLY_CREDIT_AGE_MS) {
+        const result = await deps.exceptions.createOrUpdate({
+          type: 'accounting_sync_export_error',
+          entityType: 'credit_allocation',
+          entityId: op.alga_entity_id,
+          title: 'Credit application has been waiting on an invoice export for over a week',
+          context: {
+            reason: 'apply_credit_stalled',
+            alga_entity_id: op.alga_entity_id,
+            alga_credit_note_invoice_id: payload.creditNoteInvoiceId,
+            alga_target_invoice_id: payload.targetInvoiceId,
+            has_credit_memo_mapping: Boolean(creditMemoMapping),
+            has_invoice_mapping: Boolean(invoiceMapping),
+            op_created_at: op.created_at,
+            details:
+              'This credit application is waiting for a document that has not exported to QuickBooks. ' +
+              'Check why the credit note or target invoice has not synced (export exceptions, go-live cutoff, ' +
+              'auto-sync toggle); the application pushes automatically once both documents are mapped.',
+            realm: deps.targetRealm
+          }
+        });
+        if (result.created) {
+          deps.stats.exceptionsCreated += 1;
+        }
+      }
+
       logger.debug('[creditApplicationApplier] Mappings not yet available; leaving apply_credit op pending', {
         opId: op.op_id,
         hasCreditMemoMapping: Boolean(creditMemoMapping),

--- a/packages/billing/src/services/accountingSync/customerContracts.qboCredits.test.ts
+++ b/packages/billing/src/services/accountingSync/customerContracts.qboCredits.test.ts
@@ -1,0 +1,435 @@
+import { describe, expect, it, vi, beforeEach, afterEach } from 'vitest';
+
+/**
+ * Customer-communicated contracts for QBO credit behavior.
+ *
+ * Each test encodes behavior we have described to customers as how the QBO
+ * integration handles credits, and that MSPs have built billing processes
+ * around:
+ *
+ *   1. Credits that already live in QBO are never imported into Alga.
+ *   2. Applying a QBO-side credit to a synced invoice inside QBO flows into
+ *      Alga through the payment sync; the invoice balance drops to match.
+ *   3. Credit notes issued in Alga export to QBO as CreditMemos.
+ *   4. Applying an Alga credit in Alga reconciles QBO via a zero-dollar
+ *      Payment linking CreditMemo → Invoice.
+ *   5. That linking Payment echoing back through CDC is never double-counted.
+ *   6. Prepayment credits stay Alga-only — they are not exported.
+ *   7. If QBO's "Automatically apply credits" consumes a credit first, Alga
+ *      files an exception instead of double-applying.
+ *
+ * A failure here is a change to externally-communicated behavior, not just a
+ * regression. Updating a test to match new code is only correct once the
+ * customer-facing rollout is decided (release notes at minimum). Contract 6
+ * in particular is current behavior we have told customers may change: per
+ * docs/plans/2026-06-11-qbo-phase2-closed-loop/design.md ("Credit memo
+ * export"), prepayment export must ship opt-in and forward-only from a
+ * cutoff — never retroactively exporting existing prepayments.
+ *
+ * These contracts use canned mocks because each asserts a single interaction.
+ * For stateful multi-step versions of these flows, see
+ * ./testing/qboSimulator.scenarios.test.ts (simulator wiring in
+ * ./testing/README.md).
+ */
+
+// ── Module mocks (hoisted) ──────────────────────────────────────────────────
+const qboCreateMock = vi.hoisted(() => vi.fn());
+const qboReadMock = vi.hoisted(() => vi.fn());
+
+vi.mock('@alga-psa/integrations/lib/qbo/qboClientService', () => ({
+  QboClientService: {
+    create: vi.fn(async () => ({ create: qboCreateMock, read: qboReadMock }))
+  },
+  getDefaultQboRealmId: vi.fn(async () => 'realm-1')
+}));
+
+vi.mock('./recordExternalPayment', () => ({
+  recordExternalPayment: vi.fn(async () => ({ success: true, paymentId: 'pay-1', paymentRecorded: true })),
+  reverseExternalPayment: vi.fn(async () => ({ success: true, paymentId: 'rev-1', paymentRecorded: true })),
+  isNonPayableInvoiceStatus: (status: string | null | undefined) =>
+    status === 'cancelled' || status === 'draft' || status === 'void',
+  computeBalanceDue: vi.fn(
+    ({ totalAmount, creditApplied, totalPaid }: { totalAmount: number; creditApplied: number; totalPaid: number }) =>
+      totalAmount - creditApplied - totalPaid
+  )
+}));
+
+vi.mock('./accountingSyncSettings', () => ({
+  getAccountingSyncSettings: vi.fn(async () => ({
+    autoSyncEnabled: true,
+    autoSyncStartDate: null,
+    autoProvisionCustomers: false, depositAccountRef: null,
+    defaultClassRef: null,
+    defaultDepartmentRef: null,
+    defaultRealm: null
+  })),
+  resolveDefaultRealm: vi.fn(async () => 'realm-1')
+}));
+
+vi.mock('./syncOperationsRepository', () => ({
+  SyncOperationsRepository: vi.fn().mockImplementation(function () { return ({
+    enqueue: vi.fn(async () => ({})),
+    satisfyPending: vi.fn(async () => 1)
+  }); })
+}));
+
+import { applyExternalPaymentChange } from './paymentApplier';
+import { applyExternalDocumentChange } from './driftDetector';
+import { drainApplyCreditOps } from './creditApplicationApplier';
+import { enqueueInvoiceAutoExport } from './syncProducers';
+import { emptyCycleStats } from './accountingSync.types';
+import { recordExternalPayment } from './recordExternalPayment';
+import { SyncOperationsRepository } from './syncOperationsRepository';
+import type { AccountingExternalChange } from '@alga-psa/types';
+
+const TENANT = 't1';
+const REALM = 'realm-1';
+const ADAPTER = 'quickbooks_online';
+
+function makeFakeLedger() {
+  const ledger: any = {
+    findByExternalId: vi.fn(async () => null),
+    findByAlgaId: vi.fn(async () => undefined),
+    insert: vi.fn(async () => ({})),
+    update: vi.fn(async () => undefined),
+    withKnex: vi.fn()
+  };
+  ledger.withKnex.mockImplementation(() => ledger);
+  return ledger;
+}
+
+function makeFakeExceptions() {
+  return {
+    createOrUpdate: vi.fn(async () => ({ created: true })),
+    resolve: vi.fn(async () => undefined)
+  };
+}
+
+/** knex whose invoice lookups return an open invoice and whose transaction
+ *  immediately runs the callback against itself. */
+function makeFakeKnex(invoiceRow: any = { status: 'sent', total_amount: 30000, credit_applied: 0 }) {
+  // Self-referential builder so any chain length works, including
+  // tenantDb(...).table(name).where(...) which injects a tenant clause before
+  // the applier's own .where(...).
+  const query: any = {
+    where: vi.fn(() => query),
+    select: vi.fn(() => query),
+    first: vi.fn(async () => invoiceRow)
+  };
+  const trx: any = Object.assign(vi.fn(() => query), {
+    transaction: vi.fn(async (cb: any) => cb(trx)),
+    fn: { now: vi.fn() }
+  });
+  return trx;
+}
+
+/** knex used by the auto-export producer: answers the invoice_type/date lookup. */
+function makeProducerKnex(invoiceType: string, invoiceDate: string | null = null): any {
+  const query: any = {
+    where: vi.fn(() => query),
+    select: vi.fn(() => query),
+    first: vi.fn(async () => ({ invoice_type: invoiceType, invoice_date: invoiceDate }))
+  };
+  return Object.assign(vi.fn(() => query), { fn: { now: vi.fn() } });
+}
+
+function lastEnqueueFn(): ReturnType<typeof vi.fn> | undefined {
+  const results = vi.mocked(SyncOperationsRepository).mock.results;
+  return (results[results.length - 1]?.value as any)?.enqueue;
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  vi.stubEnv('EDITION', 'ee');
+  vi.mocked(recordExternalPayment).mockResolvedValue({
+    success: true,
+    paymentId: 'pay-1',
+    paymentRecorded: true
+  } as any);
+});
+
+afterEach(() => {
+  vi.unstubAllEnvs();
+});
+
+// ── Contract 1 ──────────────────────────────────────────────────────────────
+describe('Contract 1 — credits that already live in QBO are not imported', () => {
+  it('a CreditMemo created directly in QBO (no mapping) is ignored: no writes, no exception', async () => {
+    const ledger = makeFakeLedger();
+    const exceptions = makeFakeExceptions();
+    const stats = emptyCycleStats();
+
+    const legacyCredit: AccountingExternalChange = {
+      entityType: 'CreditMemo',
+      externalId: 'qbo-cm-legacy',
+      syncToken: '0',
+      deleted: false,
+      payload: { TotalAmt: 250.0, DocNumber: 'CM-QBO-1' }
+    };
+
+    await applyExternalDocumentChange(
+      { tenantId: TENANT, targetRealm: REALM, ledger: ledger as any, exceptions, stats },
+      legacyCredit
+    );
+
+    expect(stats.unmappedIgnored).toBe(1);
+    expect(ledger.insert).not.toHaveBeenCalled();
+    expect(ledger.update).not.toHaveBeenCalled();
+    expect(exceptions.createOrUpdate).not.toHaveBeenCalled();
+  });
+});
+
+// ── Contract 2 ──────────────────────────────────────────────────────────────
+describe('Contract 2 — applying a QBO credit to a synced invoice in QBO lands in Alga', () => {
+  // QBO records a credit-memo application as a zero-total Payment whose lines
+  // link the CreditMemo and the Invoice. Only the Invoice line is an AR
+  // allocation; the CreditMemo line must be ignored, not treated as unmapped.
+  it('zero-total Payment with CreditMemo + Invoice lines applies the invoice allocation only', async () => {
+    const invoiceMapping = {
+      id: 'imap-1',
+      alga_entity_id: 'alga-inv-1',
+      external_entity_id: 'qbo-inv-99',
+      sync_status: 'synced',
+      metadata: {}
+    };
+
+    const ledger = makeFakeLedger();
+    ledger.findByExternalId
+      .mockResolvedValueOnce(null)            // credit_application echo probe: not ours
+      .mockResolvedValueOnce(null)            // payment mapping: new
+      .mockResolvedValueOnce(invoiceMapping); // invoice line resolves
+
+    const exceptions = makeFakeExceptions();
+    const stats = emptyCycleStats();
+
+    const qboSideApplication: AccountingExternalChange = {
+      entityType: 'Payment',
+      externalId: 'qbo-pay-credit-app',
+      syncToken: '0',
+      deleted: false,
+      payload: {
+        TotalAmt: 0,
+        UnappliedAmt: 0,
+        Line: [
+          { Amount: 150.0, LinkedTxn: [{ TxnType: 'Invoice', TxnId: 'qbo-inv-99' }] },
+          { Amount: 150.0, LinkedTxn: [{ TxnType: 'CreditMemo', TxnId: 'qbo-cm-legacy' }] }
+        ]
+      }
+    };
+
+    await applyExternalPaymentChange(
+      {
+        knex: makeFakeKnex(),
+        tenantId: TENANT,
+        adapterType: ADAPTER,
+        targetRealm: REALM,
+        ledger: ledger as any,
+        exceptions,
+        stats
+      },
+      qboSideApplication
+    );
+
+    // Exactly one allocation — the invoice line; the CreditMemo line is not AR.
+    expect(recordExternalPayment).toHaveBeenCalledTimes(1);
+    expect(recordExternalPayment).toHaveBeenCalledWith(
+      expect.anything(),
+      TENANT,
+      expect.objectContaining({ invoiceId: 'alga-inv-1', amount: 15000, provider: 'quickbooks' })
+    );
+
+    const inserted = ledger.insert.mock.calls[0][0];
+    expect(inserted.algaEntityType).toBe('invoice_payment');
+    expect(inserted.metadata.allocations).toHaveLength(1);
+
+    expect(exceptions.createOrUpdate).not.toHaveBeenCalled();
+    expect(stats.paymentsApplied).toBe(1);
+  });
+});
+
+// ── Contract 3 ──────────────────────────────────────────────────────────────
+describe('Contract 3 — credit notes issued in Alga export to QBO', () => {
+  it('finalizing a credit note enqueues export_credit_memo', async () => {
+    await enqueueInvoiceAutoExport(makeProducerKnex('credit_note'), TENANT, 'inv-cn-1');
+
+    const enqueueFn = lastEnqueueFn();
+    expect(enqueueFn).toBeDefined();
+    expect(enqueueFn).toHaveBeenCalledWith(
+      expect.objectContaining({
+        algaEntityId: 'inv-cn-1',
+        operation: 'export_credit_memo',
+        adapterType: ADAPTER
+      })
+    );
+  });
+});
+
+// ── Contracts 4 & 7 ─────────────────────────────────────────────────────────
+describe('Contract 4 — applying Alga credit in Alga reconciles QBO', () => {
+  function makeApplyDeps(cmBalance: number) {
+    const op = {
+      op_id: 'op-apply-1',
+      tenant: TENANT,
+      adapter_type: ADAPTER,
+      target_realm: REALM,
+      operation: 'apply_credit',
+      alga_entity_type: 'credit_allocation',
+      alga_entity_id: 'alloc-1',
+      status: 'pending',
+      attempts: 0,
+      last_error: null,
+      payload: { creditNoteInvoiceId: 'inv-cn-1', targetInvoiceId: 'inv-target-1', amountCents: 10000 },
+      created_at: new Date().toISOString(),
+      processed_at: null
+    };
+    const ops = {
+      listPending: vi.fn(async () => [op]),
+      markInProgress: vi.fn(async () => undefined),
+      markDone: vi.fn(async () => undefined),
+      markFailed: vi.fn(async () => 'pending'),
+      enqueue: vi.fn(async () => ({}))
+    };
+    const ledger = makeFakeLedger();
+    ledger.findByAlgaId.mockImplementation(async (entityType: string, entityId: string) => {
+      if (entityType === 'credit_application') return undefined;
+      if (entityId === 'inv-cn-1') return { id: 'map-cn', external_entity_id: 'qbo-cm-42', metadata: null };
+      if (entityId === 'inv-target-1') {
+        return { id: 'map-inv', external_entity_id: 'qbo-inv-99', metadata: { customerId: 'customer-77' } };
+      }
+      return undefined;
+    });
+    qboReadMock.mockResolvedValueOnce({ Id: 'qbo-cm-42', Balance: cmBalance });
+    return { ops, ledger };
+  }
+
+  it('pushes a zero-dollar QBO Payment linking CreditMemo → Invoice, keyed to the allocation', async () => {
+    const { ops, ledger } = makeApplyDeps(100);
+    qboCreateMock.mockResolvedValueOnce({ Id: 'qbo-payment-1' });
+    const stats = emptyCycleStats();
+
+    await drainApplyCreditOps({
+      knex: {} as any,
+      tenantId: TENANT,
+      adapterType: ADAPTER,
+      targetRealm: REALM,
+      ops: ops as any,
+      ledger: ledger as any,
+      exceptions: makeFakeExceptions(),
+      stats
+    });
+
+    expect(qboCreateMock).toHaveBeenCalledWith(
+      'Payment',
+      expect.objectContaining({
+        TotalAmt: 0,
+        Line: expect.arrayContaining([
+          expect.objectContaining({ LinkedTxn: [{ TxnId: 'qbo-inv-99', TxnType: 'Invoice' }] }),
+          expect.objectContaining({ LinkedTxn: [{ TxnId: 'qbo-cm-42', TxnType: 'CreditMemo' }] })
+        ])
+      })
+    );
+    expect(ledger.insert).toHaveBeenCalledWith(
+      expect.objectContaining({
+        algaEntityType: 'credit_application',
+        algaEntityId: 'alloc-1',
+        externalEntityId: 'qbo-payment-1'
+      })
+    );
+    expect(ops.markDone).toHaveBeenCalledWith(TENANT, 'op-apply-1');
+  });
+
+  // Contract 7: customers are advised to turn off QBO's "Automatically apply
+  // credits"; when QBO wins the race anyway, we must surface it, never
+  // double-apply the credit.
+  it('QBO already consumed the credit → exception filed, no Payment pushed', async () => {
+    const { ops, ledger } = makeApplyDeps(0);
+    const exceptions = makeFakeExceptions();
+    const stats = emptyCycleStats();
+
+    await drainApplyCreditOps({
+      knex: {} as any,
+      tenantId: TENANT,
+      adapterType: ADAPTER,
+      targetRealm: REALM,
+      ops: ops as any,
+      ledger: ledger as any,
+      exceptions,
+      stats
+    });
+
+    expect(qboCreateMock).not.toHaveBeenCalled();
+    expect(exceptions.createOrUpdate).toHaveBeenCalledWith(
+      expect.objectContaining({
+        entityType: 'credit_allocation',
+        entityId: 'alloc-1',
+        context: expect.objectContaining({ reason: 'qbo_credit_already_consumed' })
+      })
+    );
+  });
+});
+
+// ── Contract 5 ──────────────────────────────────────────────────────────────
+describe('Contract 5 — our own credit-application Payment echoing back is not double-counted', () => {
+  it('a Payment mapped as a credit_application is skipped by the payment applier', async () => {
+    const ledger = makeFakeLedger();
+    // The echo probe finds the mapping drainApplyCreditOps wrote for this Payment.
+    ledger.findByExternalId.mockResolvedValueOnce({
+      id: 'map-ca',
+      alga_entity_id: 'alloc-1',
+      external_entity_id: 'qbo-payment-1'
+    });
+
+    const exceptions = makeFakeExceptions();
+    const stats = emptyCycleStats();
+
+    const echo: AccountingExternalChange = {
+      entityType: 'Payment',
+      externalId: 'qbo-payment-1',
+      syncToken: '0',
+      deleted: false,
+      payload: {
+        TotalAmt: 0,
+        Line: [
+          { Amount: 100.0, LinkedTxn: [{ TxnType: 'Invoice', TxnId: 'qbo-inv-99' }] },
+          { Amount: 100.0, LinkedTxn: [{ TxnType: 'CreditMemo', TxnId: 'qbo-cm-42' }] }
+        ]
+      }
+    };
+
+    await applyExternalPaymentChange(
+      {
+        knex: makeFakeKnex(),
+        tenantId: TENANT,
+        adapterType: ADAPTER,
+        targetRealm: REALM,
+        ledger: ledger as any,
+        exceptions,
+        stats
+      },
+      echo
+    );
+
+    expect(recordExternalPayment).not.toHaveBeenCalled();
+    expect(ledger.insert).not.toHaveBeenCalled();
+    expect(exceptions.createOrUpdate).not.toHaveBeenCalled();
+    expect(stats.paymentsSkipped).toBe(1);
+    expect(stats.paymentsApplied).toBe(0);
+  });
+});
+
+// ── Contract 6 ──────────────────────────────────────────────────────────────
+describe('Contract 6 — prepayment credits stay Alga-only', () => {
+  // Communicated to customers as current behavior. Shipping prepayment export
+  // later is expected — but it must be opt-in and forward-only from a cutoff,
+  // and this test must only change together with that rollout.
+  it('finalizing a prepayment invoice enqueues nothing', async () => {
+    await enqueueInvoiceAutoExport(makeProducerKnex('prepayment'), TENANT, 'inv-pp-1');
+
+    for (const result of vi.mocked(SyncOperationsRepository).mock.results) {
+      const enqueueFn = (result.value as any)?.enqueue;
+      if (enqueueFn) {
+        expect(enqueueFn).not.toHaveBeenCalled();
+      }
+    }
+  });
+});

--- a/packages/billing/src/services/accountingSync/customerContracts.qboExportSafety.test.ts
+++ b/packages/billing/src/services/accountingSync/customerContracts.qboExportSafety.test.ts
@@ -1,0 +1,160 @@
+import { describe, expect, it, vi, beforeEach, afterEach } from 'vitest';
+
+/**
+ * Customer-communicated contracts for QBO export safety.
+ *
+ * These came out of the July 2026 adversarial onboarding review with an
+ * established-company-file customer profile, and are commitments about how
+ * Alga treats books that were reconciled outside Alga:
+ *
+ *   1. A document posted to QBO stays posted: exported invoices can be voided
+ *      (which propagates) but never unfinalized or hard-deleted from Alga.
+ *   2. The go-live cutoff fences by the invoice's own date. Re-finalizing a
+ *      pre-go-live invoice after the cutoff must NOT export it — neither as a
+ *      duplicate of a hand-entered QBO document nor as an update to
+ *      reconciled history.
+ *   3. By default, nothing outside the onboarding wizard writes to the QBO
+ *      customer list: customer auto-provisioning is opt-in
+ *      (autoProvisionCustomers, default false), and with it off an unmapped
+ *      customer fails export validation with an actionable exception.
+ *
+ * A failure here means a change to safety behavior customers were told they
+ * can rely on — decide the rollout and comms before updating the test.
+ */
+
+// ── Module mocks (hoisted) ──────────────────────────────────────────────────
+vi.mock('@alga-psa/integrations/lib/qbo/qboClientService', () => ({
+  QboClientService: { create: vi.fn(async () => ({})) },
+  getDefaultQboRealmId: vi.fn(async () => 'realm-1'),
+  getStoredQboCredentialsMap: vi.fn(async () => ({ 'realm-1': {} }))
+}));
+
+vi.mock('./syncOperationsRepository', () => ({
+  SyncOperationsRepository: vi.fn().mockImplementation(function () { return ({
+    enqueue: vi.fn(async () => ({})),
+    satisfyPending: vi.fn(async () => 1)
+  }); })
+}));
+
+import { assertInvoiceNotExported } from './invoiceExportGuards';
+import { enqueueInvoiceAutoExport } from './syncProducers';
+import { getAccountingSyncSettings } from './accountingSyncSettings';
+import { SyncOperationsRepository } from './syncOperationsRepository';
+
+/** Multi-table fake knex so the producer runs through the REAL settings code. */
+function makeKnex(tables: Record<string, any>) {
+  const knex: any = vi.fn((table: string) => {
+    if (!(table in tables)) {
+      throw new Error(`unexpected table ${table}`);
+    }
+    const row = tables[table];
+    // Self-referential builder so tenantDb(...).table(name).where(...) can
+    // chain a second .where(...) (the applier's own filter) after the
+    // auto-injected tenant clause.
+    const query: any = {
+      where: vi.fn(() => query),
+      select: vi.fn(() => query),
+      first: vi.fn(async () => row)
+    };
+    return query;
+  });
+  knex.fn = { now: vi.fn() };
+  return knex;
+}
+
+function settingsRow(accountingSync: Record<string, unknown>) {
+  return { settings: { accountingSync } };
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  vi.stubEnv('EDITION', 'ee');
+});
+
+afterEach(() => {
+  vi.unstubAllEnvs();
+});
+
+// ── Contract 1 ──────────────────────────────────────────────────────────────
+describe('Contract 1 — a document posted to QBO stays posted', () => {
+  it('unfinalize is blocked on an exported invoice, directing to void or credit note', async () => {
+    const knex = makeKnex({ tenant_external_entity_mappings: { id: 'map-1' } });
+
+    await expect(assertInvoiceNotExported(knex, 't1', 'inv-exported', 'unfinalize')).rejects.toThrow(
+      /cannot be reopened/i
+    );
+  });
+
+  it('hard delete is blocked on an exported invoice, directing to void', async () => {
+    const knex = makeKnex({ tenant_external_entity_mappings: { id: 'map-1' } });
+
+    await expect(assertInvoiceNotExported(knex, 't1', 'inv-exported', 'delete')).rejects.toThrow(
+      /void it instead of deleting/i
+    );
+  });
+
+  it('unexported invoices are unaffected', async () => {
+    const knex = makeKnex({ tenant_external_entity_mappings: undefined });
+
+    await expect(assertInvoiceNotExported(knex, 't1', 'inv-local', 'unfinalize')).resolves.toBeUndefined();
+  });
+});
+
+// ── Contract 2 ──────────────────────────────────────────────────────────────
+describe('Contract 2 — go-live cutoff fences by invoice date, not the wall clock', () => {
+  it('a pre-go-live invoice re-finalized today does not enqueue an export', async () => {
+    const cutoff = new Date(Date.now() - 30 * 24 * 60 * 60 * 1000).toISOString().slice(0, 10);
+    const historicalDate = new Date(Date.now() - 2 * 365 * 24 * 60 * 60 * 1000).toISOString().slice(0, 10);
+    const knex = makeKnex({
+      tenant_settings: settingsRow({ autoSyncEnabled: true, autoSyncStartDate: cutoff }),
+      invoices: { invoice_type: 'standard', invoice_date: historicalDate }
+    });
+
+    await enqueueInvoiceAutoExport(knex, 't1', 'inv-2024-history');
+
+    for (const result of vi.mocked(SyncOperationsRepository).mock.results) {
+      const enqueueFn = (result.value as any)?.enqueue;
+      if (enqueueFn) {
+        expect(enqueueFn).not.toHaveBeenCalled();
+      }
+    }
+  });
+
+  it('an invoice dated after the cutoff enqueues normally', async () => {
+    const cutoff = new Date(Date.now() - 30 * 24 * 60 * 60 * 1000).toISOString().slice(0, 10);
+    const recentDate = new Date(Date.now() - 3 * 24 * 60 * 60 * 1000).toISOString().slice(0, 10);
+    const knex = makeKnex({
+      tenant_settings: settingsRow({ autoSyncEnabled: true, autoSyncStartDate: cutoff }),
+      invoices: { invoice_type: 'standard', invoice_date: recentDate }
+    });
+
+    await enqueueInvoiceAutoExport(knex, 't1', 'inv-current');
+
+    const results = vi.mocked(SyncOperationsRepository).mock.results;
+    expect(results.length).toBeGreaterThan(0);
+    const enqueueFn = (results[results.length - 1].value as any)?.enqueue as ReturnType<typeof vi.fn>;
+    expect(enqueueFn).toHaveBeenCalledWith(expect.objectContaining({ algaEntityId: 'inv-current' }));
+  });
+});
+
+// ── Contract 3 ──────────────────────────────────────────────────────────────
+describe('Contract 3 — customer auto-provisioning is opt-in', () => {
+  it('autoProvisionCustomers defaults to FALSE for tenants that never set it', async () => {
+    // Empty settings row: whatever a tenant had before this setting existed.
+    const knex = makeKnex({ tenant_settings: undefined });
+
+    const settings = await getAccountingSyncSettings(knex, 't1');
+
+    expect(settings.autoProvisionCustomers).toBe(false);
+  });
+
+  it('legacy settings blobs without the field normalize to FALSE, not undefined', async () => {
+    const knex = makeKnex({
+      tenant_settings: settingsRow({ autoSyncEnabled: true, autoSyncStartDate: null })
+    });
+
+    const settings = await getAccountingSyncSettings(knex, 't1');
+
+    expect(settings.autoProvisionCustomers).toBe(false);
+  });
+});

--- a/packages/billing/src/services/accountingSync/driftDetector.test.ts
+++ b/packages/billing/src/services/accountingSync/driftDetector.test.ts
@@ -1,4 +1,7 @@
 import { describe, expect, it, vi } from 'vitest';
+// Hand-built change payloads keep these unit tests small. To verify against
+// changes a real QBO would emit (voids, balance movement), generate them with
+// the simulator in ./testing/qboSimulator.ts — see ./testing/README.md.
 import { applyExternalDocumentChange } from './driftDetector';
 import { emptyCycleStats, MAPPING_SYNC_STATUS } from './accountingSync.types';
 import type { AccountingExternalChange } from '@alga-psa/types';

--- a/packages/billing/src/services/accountingSync/exportReadiness.test.ts
+++ b/packages/billing/src/services/accountingSync/exportReadiness.test.ts
@@ -1,0 +1,197 @@
+import { describe, expect, it, vi, beforeEach, afterEach } from 'vitest';
+
+const resolveServiceMappingMock = vi.hoisted(() => vi.fn());
+
+vi.mock('./accountingSyncSettings', () => ({
+  getAccountingSyncSettings: vi.fn(async () => ({
+    autoSyncEnabled: true,
+    autoSyncStartDate: null,
+    autoProvisionCustomers: false,
+    depositAccountRef: null,
+    defaultClassRef: null,
+    defaultDepartmentRef: null,
+    defaultRealm: null
+  })),
+  resolveDefaultRealm: vi.fn(async () => 'realm-1')
+}));
+
+vi.mock('../accountingMappingResolver', () => ({
+  AccountingMappingResolver: vi.fn().mockImplementation(function () {
+    return { resolveServiceMapping: resolveServiceMappingMock };
+  })
+}));
+
+import { assertInvoiceExportReady, InvoiceExportReadinessError } from './exportReadiness';
+import { getAccountingSyncSettings, resolveDefaultRealm } from './accountingSyncSettings';
+
+const TENANT = 't1';
+const INVOICE = 'inv-1';
+
+interface KnexFixture {
+  invoice?: any;
+  charges?: any[];
+  services?: any[];
+  /** item_ids that have invoice_charge_details children (consolidated fixed parents). */
+  detailBackedChargeIds?: string[];
+}
+
+/** Multi-table fake knex covering invoices, invoice_charges, details, and service_catalog. */
+function makeKnex(fixture: KnexFixture): any {
+  const knex: any = vi.fn((table: string) => {
+    if (table === 'invoices') {
+      return { where: () => ({ select: () => ({ first: async () => fixture.invoice }) }) };
+    }
+    if (table === 'invoice_charges') {
+      return { where: () => ({ select: async () => fixture.charges ?? [] }) };
+    }
+    if (table === 'invoice_charge_details') {
+      return {
+        whereIn: () => ({
+          andWhere: () => ({
+            select: async () => (fixture.detailBackedChargeIds ?? []).map((id) => ({ item_id: id }))
+          })
+        })
+      };
+    }
+    if (table === 'service_catalog') {
+      return { whereIn: () => ({ andWhere: () => ({ select: async () => fixture.services ?? [] }) }) };
+    }
+    throw new Error(`unexpected table ${table}`);
+  });
+  return knex;
+}
+
+const standardInvoice = { invoice_type: 'standard', is_prepayment: false, invoice_date: '2026-06-20' };
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  vi.stubEnv('EDITION', 'ee');
+  vi.mocked(getAccountingSyncSettings).mockResolvedValue({
+    autoSyncEnabled: true,
+    autoSyncStartDate: null,
+    autoProvisionCustomers: false,
+    depositAccountRef: null,
+    defaultClassRef: null,
+    defaultDepartmentRef: null,
+    defaultRealm: null
+  });
+  vi.mocked(resolveDefaultRealm).mockResolvedValue('realm-1');
+  resolveServiceMappingMock.mockResolvedValue({ external_entity_id: 'item-1', metadata: {} });
+});
+
+afterEach(() => {
+  vi.unstubAllEnvs();
+});
+
+describe('assertInvoiceExportReady', () => {
+  it('passes when every line has a mapped service', async () => {
+    const knex = makeKnex({
+      invoice: standardInvoice,
+      charges: [{ item_id: 'c1', service_id: 'svc-1', description: 'Managed services' }]
+    });
+
+    await expect(assertInvoiceExportReady(knex, TENANT, INVOICE)).resolves.toBeUndefined();
+  });
+
+  it('blocks finalize when a line has no service, naming the line', async () => {
+    const knex = makeKnex({
+      invoice: standardInvoice,
+      charges: [
+        { item_id: 'c1', service_id: 'svc-1', description: 'Managed services' },
+        { item_id: 'c2', service_id: null, description: 'Freight for handset shipment' }
+      ]
+    });
+
+    await expect(assertInvoiceExportReady(knex, TENANT, INVOICE)).rejects.toThrow(
+      /no service assigned.*Freight for handset shipment/s
+    );
+  });
+
+  it('blocks finalize when a service has no QBO item mapping, naming the service', async () => {
+    resolveServiceMappingMock.mockResolvedValue(null);
+    const knex = makeKnex({
+      invoice: standardInvoice,
+      charges: [{ item_id: 'c1', service_id: 'svc-1', description: 'Managed services' }],
+      services: [{ service_id: 'svc-1', service_name: 'PBX Maintenance' }]
+    });
+
+    await expect(assertInvoiceExportReady(knex, TENANT, INVOICE)).rejects.toThrow(
+      /no QuickBooks item mapping.*PBX Maintenance/s
+    );
+    await expect(assertInvoiceExportReady(knex, TENANT, INVOICE)).rejects.toBeInstanceOf(
+      InvoiceExportReadinessError
+    );
+  });
+
+  it('does not flag consolidated fixed-plan parent charges (their services live in detail rows)', async () => {
+    const knex = makeKnex({
+      invoice: standardInvoice,
+      charges: [{ item_id: 'parent-1', service_id: null, description: 'Fixed Plan: Monthly Support' }],
+      detailBackedChargeIds: ['parent-1']
+    });
+
+    await expect(assertInvoiceExportReady(knex, TENANT, INVOICE)).resolves.toBeUndefined();
+  });
+
+  it('does not gate invoices that will not export: auto-sync off', async () => {
+    vi.mocked(getAccountingSyncSettings).mockResolvedValue({
+      autoSyncEnabled: false,
+      autoSyncStartDate: null,
+      autoProvisionCustomers: false,
+      depositAccountRef: null,
+      defaultClassRef: null,
+      defaultDepartmentRef: null,
+      defaultRealm: null
+    });
+    const knex = makeKnex({
+      invoice: standardInvoice,
+      charges: [{ item_id: 'c1', service_id: null, description: 'anything' }]
+    });
+
+    await expect(assertInvoiceExportReady(knex, TENANT, INVOICE)).resolves.toBeUndefined();
+  });
+
+  it('does not gate prepayment invoices (they never export)', async () => {
+    const knex = makeKnex({
+      invoice: { invoice_type: 'standard', is_prepayment: true, invoice_date: '2026-06-20' },
+      charges: [{ item_id: 'c1', service_id: null, description: 'deposit' }]
+    });
+
+    await expect(assertInvoiceExportReady(knex, TENANT, INVOICE)).resolves.toBeUndefined();
+  });
+
+  it('does not gate invoices dated before the go-live cutoff', async () => {
+    vi.mocked(getAccountingSyncSettings).mockResolvedValue({
+      autoSyncEnabled: true,
+      autoSyncStartDate: '2026-06-01',
+      autoProvisionCustomers: false,
+      depositAccountRef: null,
+      defaultClassRef: null,
+      defaultDepartmentRef: null,
+      defaultRealm: null
+    });
+    const knex = makeKnex({
+      invoice: { invoice_type: 'standard', is_prepayment: false, invoice_date: '2024-03-15' },
+      charges: [{ item_id: 'c1', service_id: null, description: 'historical line' }]
+    });
+
+    await expect(assertInvoiceExportReady(knex, TENANT, INVOICE)).resolves.toBeUndefined();
+  });
+
+  it('does not gate when no realm is connected', async () => {
+    vi.mocked(resolveDefaultRealm).mockResolvedValue(null);
+    const knex = makeKnex({
+      invoice: standardInvoice,
+      charges: [{ item_id: 'c1', service_id: null, description: 'anything' }]
+    });
+
+    await expect(assertInvoiceExportReady(knex, TENANT, INVOICE)).resolves.toBeUndefined();
+  });
+
+  it('fails OPEN on infrastructure errors — a broken check must not brick finalize', async () => {
+    vi.mocked(getAccountingSyncSettings).mockRejectedValue(new Error('settings table unavailable'));
+    const knex = makeKnex({});
+
+    await expect(assertInvoiceExportReady(knex, TENANT, INVOICE)).resolves.toBeUndefined();
+  });
+});

--- a/packages/billing/src/services/accountingSync/exportReadiness.ts
+++ b/packages/billing/src/services/accountingSync/exportReadiness.ts
@@ -1,0 +1,170 @@
+import { Knex } from 'knex';
+import logger from '@alga-psa/core/logger';
+import { getAccountingSyncSettings, resolveDefaultRealm } from './accountingSyncSettings';
+import { AccountingMappingResolver } from '../accountingMappingResolver';
+
+/**
+ * Finalize-time export readiness: when an invoice WILL auto-export to QBO,
+ * refuse to finalize it if the export would deterministically fail validation
+ * (a line without a service, or a service without a QBO item mapping).
+ * Failing here — in the screen the user is looking at, with the lines named —
+ * beats failing an hour later in the sync exception inbox and teaching staff
+ * that "finalized" doesn't mean "exported".
+ *
+ * Only deterministic validation findings block; infrastructure errors during
+ * the check fail OPEN (finalize proceeds, batch validation remains the net).
+ */
+
+const SYNC_ADAPTER_TYPE = 'quickbooks_online';
+
+// LEVERAGE: pattern edition-gate — same local isEnterpriseEdition as syncProducers.ts
+function isEnterpriseEdition(): boolean {
+  return (
+    (process.env.EDITION ?? '').toLowerCase() === 'ee' ||
+    (process.env.NEXT_PUBLIC_EDITION ?? '').toLowerCase() === 'enterprise'
+  );
+}
+
+// LEVERAGE: pattern date-only-normalization — same helper as syncProducers.ts
+function toDateOnly(value: unknown): string | null {
+  if (value === null || value === undefined) {
+    return null;
+  }
+  const date = value instanceof Date ? value : new Date(String(value));
+  if (Number.isNaN(date.getTime())) {
+    return null;
+  }
+  return date.toISOString().slice(0, 10);
+}
+
+function truncateDescription(value: unknown): string {
+  const text = typeof value === 'string' && value.trim() ? value.trim() : '(no description)';
+  return text.length > 40 ? `${text.slice(0, 37)}...` : text;
+}
+
+export class InvoiceExportReadinessError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = 'InvoiceExportReadinessError';
+  }
+}
+
+export async function assertInvoiceExportReady(
+  knex: Knex,
+  tenant: string,
+  invoiceId: string
+): Promise<void> {
+  let blockers: string[];
+  try {
+    blockers = await collectExportBlockers(knex, tenant, invoiceId);
+  } catch (error) {
+    logger.warn('[accountingSync] Export readiness check errored; allowing finalize', {
+      tenant,
+      invoiceId,
+      error: error instanceof Error ? error.message : error
+    });
+    return;
+  }
+
+  if (blockers.length > 0) {
+    throw new InvoiceExportReadinessError(
+      `This invoice can't be finalized because it would fail QuickBooks export: ${blockers.join('; ')}. ` +
+        'Assign services and QuickBooks item mappings to these lines, or turn off auto-sync, then finalize again.'
+    );
+  }
+}
+
+async function collectExportBlockers(knex: Knex, tenant: string, invoiceId: string): Promise<string[]> {
+  if (!isEnterpriseEdition()) {
+    return [];
+  }
+
+  const settings = await getAccountingSyncSettings(knex, tenant);
+  if (!settings.autoSyncEnabled) {
+    return [];
+  }
+
+  const invoice = await knex('invoices')
+    .where({ invoice_id: invoiceId, tenant })
+    .select('invoice_type', 'is_prepayment', 'invoice_date')
+    .first();
+  if (!invoice) {
+    return [];
+  }
+
+  // Prepayments never export; invoices dated before the go-live cutoff never
+  // auto-enqueue. Neither can fail an export they will not attempt.
+  if (invoice.invoice_type === 'prepayment' || invoice.is_prepayment) {
+    return [];
+  }
+  if (settings.autoSyncStartDate) {
+    const invoiceDate = toDateOnly(invoice.invoice_date);
+    if (invoiceDate && invoiceDate < settings.autoSyncStartDate.slice(0, 10)) {
+      return [];
+    }
+  }
+
+  const realm = await resolveDefaultRealm(knex, tenant);
+  if (!realm) {
+    return [];
+  }
+
+  const charges: Array<{ item_id: string; service_id: string | null; description: string | null }> =
+    await knex('invoice_charges')
+      .where({ invoice_id: invoiceId, tenant })
+      .select('item_id', 'service_id', 'description');
+
+  // Consolidated fixed-plan parent charges intentionally carry no service_id —
+  // their services live in invoice_charge_details children. Only a serviceless
+  // charge with no children is a user-fixable gap (a manual/discount line
+  // someone forgot to classify).
+  const chargeIdsForDetailLookup = charges.filter((c) => !c.service_id).map((c) => c.item_id);
+  const consolidatedParents = new Set<string>(
+    chargeIdsForDetailLookup.length > 0
+      ? (
+          await knex('invoice_charge_details')
+            .whereIn('item_id', chargeIdsForDetailLookup)
+            .andWhere({ tenant })
+            .select('item_id')
+        ).map((row: { item_id: string }) => row.item_id)
+      : []
+  );
+
+  const blockers: string[] = [];
+
+  const serviceless = charges.filter((charge) => !charge.service_id && !consolidatedParents.has(charge.item_id));
+  if (serviceless.length > 0) {
+    const samples = serviceless.slice(0, 3).map((charge) => `"${truncateDescription(charge.description)}"`);
+    blockers.push(
+      `${serviceless.length} line${serviceless.length === 1 ? ' has' : 's have'} no service assigned (${samples.join(', ')})`
+    );
+  }
+
+  const resolver = new AccountingMappingResolver(knex);
+  const serviceIds = [...new Set(charges.map((charge) => charge.service_id).filter((id): id is string => Boolean(id)))];
+  const unmappedServiceIds: string[] = [];
+  for (const serviceId of serviceIds) {
+    const mapping = await resolver.resolveServiceMapping({
+      adapterType: SYNC_ADAPTER_TYPE,
+      serviceId,
+      targetRealm: realm
+    });
+    if (!mapping) {
+      unmappedServiceIds.push(serviceId);
+    }
+  }
+
+  if (unmappedServiceIds.length > 0) {
+    const serviceRows: Array<{ service_id: string; service_name: string | null }> = await knex('service_catalog')
+      .whereIn('service_id', unmappedServiceIds)
+      .andWhere({ tenant })
+      .select('service_id', 'service_name');
+    const nameById = new Map(serviceRows.map((row) => [row.service_id, row.service_name]));
+    const names = unmappedServiceIds.map((id) => `"${nameById.get(id) ?? id}"`);
+    blockers.push(
+      `${unmappedServiceIds.length} service${unmappedServiceIds.length === 1 ? ' has' : 's have'} no QuickBooks item mapping (${names.join(', ')})`
+    );
+  }
+
+  return blockers;
+}

--- a/packages/billing/src/services/accountingSync/invoiceExportGuards.test.ts
+++ b/packages/billing/src/services/accountingSync/invoiceExportGuards.test.ts
@@ -1,0 +1,49 @@
+import { describe, expect, it, vi } from 'vitest';
+import { assertInvoiceNotExported, findInvoiceAccountingMapping } from './invoiceExportGuards';
+
+function makeKnex(mappingRow: { id: string } | undefined) {
+  const first = vi.fn(async () => mappingRow);
+  const where = vi.fn(() => ({ first }));
+  const knex: any = vi.fn(() => ({ where }));
+  knex.__where = where;
+  return knex;
+}
+
+describe('invoiceExportGuards', () => {
+  it('looks up the invoice mapping by tenant, integration type, and entity', async () => {
+    const knex = makeKnex(undefined);
+
+    await findInvoiceAccountingMapping(knex, 't1', 'inv-1');
+
+    expect(knex).toHaveBeenCalledWith('tenant_external_entity_mappings');
+    expect(knex.__where).toHaveBeenCalledWith({
+      tenant: 't1',
+      integration_type: 'quickbooks_online',
+      alga_entity_type: 'invoice',
+      alga_entity_id: 'inv-1'
+    });
+  });
+
+  it('unfinalize: throws when the invoice has an accounting mapping', async () => {
+    const knex = makeKnex({ id: 'map-1' });
+
+    await expect(assertInvoiceNotExported(knex, 't1', 'inv-1', 'unfinalize')).rejects.toThrow(
+      /cannot be reopened/i
+    );
+  });
+
+  it('delete: throws with the void-instead message when mapped', async () => {
+    const knex = makeKnex({ id: 'map-1' });
+
+    await expect(assertInvoiceNotExported(knex, 't1', 'inv-1', 'delete')).rejects.toThrow(
+      /void it instead of deleting/i
+    );
+  });
+
+  it('resolves silently when the invoice has no mapping', async () => {
+    const knex = makeKnex(undefined);
+
+    await expect(assertInvoiceNotExported(knex, 't1', 'inv-1', 'unfinalize')).resolves.toBeUndefined();
+    await expect(assertInvoiceNotExported(knex, 't1', 'inv-1', 'delete')).resolves.toBeUndefined();
+  });
+});

--- a/packages/billing/src/services/accountingSync/invoiceExportGuards.ts
+++ b/packages/billing/src/services/accountingSync/invoiceExportGuards.ts
@@ -1,0 +1,46 @@
+import { Knex } from 'knex';
+
+const ACCOUNTING_INTEGRATION_TYPE = 'quickbooks_online';
+
+export type ExportedInvoiceAction = 'unfinalize' | 'delete';
+
+const BLOCK_MESSAGES: Record<ExportedInvoiceAction, string> = {
+  unfinalize:
+    'This invoice is synced to an accounting system — it cannot be reopened. Void it and reissue, or issue a credit note for the difference.',
+  delete: 'This invoice is synced to an accounting system — void it instead of deleting.'
+};
+
+export async function findInvoiceAccountingMapping(
+  knex: Knex,
+  tenant: string,
+  invoiceId: string
+): Promise<{ id: string } | undefined> {
+  return knex('tenant_external_entity_mappings')
+    .where({
+      tenant,
+      integration_type: ACCOUNTING_INTEGRATION_TYPE,
+      alga_entity_type: 'invoice',
+      alga_entity_id: invoiceId
+    })
+    .first('id');
+}
+
+/**
+ * Guard for actions that would desynchronize an exported document. An invoice
+ * with an accounting mapping is posted in the external system's books;
+ * unfinalizing or deleting it in Alga leaves the two systems disagreeing about
+ * a posted document (and a later re-finalize would export into reconciled
+ * history). The supported flows are void (which propagates) or a credit note
+ * for the difference.
+ */
+export async function assertInvoiceNotExported(
+  knex: Knex,
+  tenant: string,
+  invoiceId: string,
+  action: ExportedInvoiceAction
+): Promise<void> {
+  const mapping = await findInvoiceAccountingMapping(knex, tenant, invoiceId);
+  if (mapping) {
+    throw new Error(BLOCK_MESSAGES[action]);
+  }
+}

--- a/packages/billing/src/services/accountingSync/paymentApplier.test.ts
+++ b/packages/billing/src/services/accountingSync/paymentApplier.test.ts
@@ -1,5 +1,9 @@
 import { describe, expect, it, vi, beforeEach } from 'vitest';
 
+// These are single-call unit tests, so canned mocks suffice. For multi-step
+// sequences against stateful QBO behavior (CDC replay, balances, races), use
+// the simulator in ./testing/qboSimulator.ts — see ./testing/README.md.
+
 // Mock recordExternalPayment/reverseExternalPayment before importing the module under test
 vi.mock('./recordExternalPayment', () => ({
   recordExternalPayment: vi.fn(async () => ({ success: true, paymentId: 'pay-1', paymentRecorded: true })),
@@ -341,6 +345,114 @@ describe('paymentApplier', () => {
     expect(insertCall.metadata.allocations).toHaveLength(2);
     expect(insertCall.metadata.sync_token).toBe('3');
     expect(stats.paymentsApplied).toBe(1);
+  });
+
+  it('passes QBO TxnDate through as the payment date (month-boundary correctness)', async () => {
+    const invMap = { id: 'imap-1', alga_entity_id: 'alga-inv-1', external_entity_id: 'inv-ext-001', sync_status: 'synced', metadata: {} };
+    const ledger = makeFakeLedger(null);
+    ledger.findByExternalId
+      .mockResolvedValueOnce(null)
+      .mockResolvedValueOnce(null)
+      .mockResolvedValueOnce(invMap);
+
+    await applyExternalPaymentChange(
+      {
+        knex: makeFakeKnex(),
+        tenantId: 't1',
+        adapterType: 'quickbooks_online',
+        targetRealm: 'r1',
+        ledger: ledger as any,
+        exceptions: makeFakeExceptions(),
+        stats: emptyCycleStats()
+      },
+      makeInvoiceChange({
+        payload: {
+          PaymentRefNum: 'REF-EOM',
+          TotalAmt: 200.0,
+          TxnDate: '2026-07-31',
+          Line: [{ Amount: 200.0, LinkedTxn: [{ TxnType: 'Invoice', TxnId: 'inv-ext-001' }] }]
+        }
+      })
+    );
+
+    expect(recordExternalPayment).toHaveBeenCalledWith(
+      expect.anything(),
+      't1',
+      expect.objectContaining({
+        paymentDate: new Date('2026-07-31'),
+        transactionMetadata: expect.objectContaining({ qbo_txn_date: '2026-07-31' })
+      })
+    );
+  });
+
+  it('labels credit-application payments distinctly from cash payments', async () => {
+    const invMap = { id: 'imap-1', alga_entity_id: 'alga-inv-1', external_entity_id: 'inv-ext-001', sync_status: 'synced', metadata: {} };
+    const ledger = makeFakeLedger(null);
+    ledger.findByExternalId
+      .mockResolvedValueOnce(null)
+      .mockResolvedValueOnce(null)
+      .mockResolvedValueOnce(invMap);
+
+    await applyExternalPaymentChange(
+      {
+        knex: makeFakeKnex(),
+        tenantId: 't1',
+        adapterType: 'quickbooks_online',
+        targetRealm: 'r1',
+        ledger: ledger as any,
+        exceptions: makeFakeExceptions(),
+        stats: emptyCycleStats()
+      },
+      makeInvoiceChange({
+        payload: {
+          TotalAmt: 0,
+          Line: [
+            { Amount: 150.0, LinkedTxn: [{ TxnType: 'Invoice', TxnId: 'inv-ext-001' }] },
+            { Amount: 150.0, LinkedTxn: [{ TxnType: 'CreditMemo', TxnId: 'cm-ext-9' }] }
+          ]
+        }
+      })
+    );
+
+    expect(recordExternalPayment).toHaveBeenCalledWith(
+      expect.anything(),
+      't1',
+      expect.objectContaining({
+        notes: expect.stringMatching(/^QuickBooks credit applied /),
+        transactionMetadata: expect.objectContaining({ qbo_payment_kind: 'credit_application' })
+      })
+    );
+  });
+
+  it('cash payments keep the plain payment label', async () => {
+    const invMap = { id: 'imap-1', alga_entity_id: 'alga-inv-1', external_entity_id: 'inv-ext-001', sync_status: 'synced', metadata: {} };
+    const ledger = makeFakeLedger(null);
+    ledger.findByExternalId
+      .mockResolvedValueOnce(null)
+      .mockResolvedValueOnce(null)
+      .mockResolvedValueOnce(invMap);
+
+    await applyExternalPaymentChange(
+      {
+        knex: makeFakeKnex(),
+        tenantId: 't1',
+        adapterType: 'quickbooks_online',
+        targetRealm: 'r1',
+        ledger: ledger as any,
+        exceptions: makeFakeExceptions(),
+        stats: emptyCycleStats()
+      },
+      makeInvoiceChange()
+    );
+
+    expect(recordExternalPayment).toHaveBeenCalledWith(
+      expect.anything(),
+      't1',
+      expect.objectContaining({
+        notes: expect.stringMatching(/^QuickBooks payment /),
+        transactionMetadata: expect.objectContaining({ qbo_payment_kind: 'payment' })
+      })
+    );
   });
 
   it('inserted mapping metadata includes sync_token and allocations', async () => {

--- a/packages/billing/src/services/accountingSync/paymentApplier.ts
+++ b/packages/billing/src/services/accountingSync/paymentApplier.ts
@@ -65,6 +65,27 @@ function paymentReference(payload: Record<string, any> | undefined, externalId: 
   return typeof ref === 'string' && ref.trim().length > 0 ? ref.trim() : externalId;
 }
 
+/** QBO's TxnDate is the bookkeeping date. Stamping "now" instead shifts every
+ *  payment that syncs across a month boundary into the wrong period. */
+function paymentTxnDate(payload: Record<string, any> | undefined): Date | undefined {
+  const raw = payload?.TxnDate;
+  if (typeof raw !== 'string' || !raw) {
+    return undefined;
+  }
+  const date = new Date(raw);
+  return Number.isNaN(date.getTime()) ? undefined : date;
+}
+
+/** A Payment carrying CreditMemo-linked lines is a credit application, not
+ *  cash — label it honestly so AR readers can tell the two apart. */
+function isCreditApplicationPayment(payload: Record<string, any> | undefined): boolean {
+  const lines = Array.isArray(payload?.Line) ? payload!.Line : [];
+  return lines.some(
+    (line: any) =>
+      Array.isArray(line?.LinkedTxn) && line.LinkedTxn.some((txn: any) => txn?.TxnType === 'CreditMemo')
+  );
+}
+
 async function resolveAllocations(
   deps: PaymentApplierDeps,
   change: AccountingExternalChange
@@ -141,6 +162,8 @@ async function applyAllocations(
     typeof (change.payload as any)?.CurrencyRef?.value === 'string'
       ? String((change.payload as any).CurrencyRef.value)
       : undefined;
+  const txnDate = paymentTxnDate(change.payload);
+  const creditApplication = isCreditApplicationPayment(change.payload);
 
   const recorded: RecordedAllocation[] = [];
   for (const allocation of allocations) {
@@ -150,9 +173,14 @@ async function applyAllocations(
       provider,
       referenceNumber: reference,
       currency,
-      notes: `QuickBooks payment ${reference}`,
+      paymentDate: txnDate,
+      notes: creditApplication
+        ? `QuickBooks credit applied ${reference}`
+        : `QuickBooks payment ${reference}`,
       transactionMetadata: {
         external_payment_id: change.externalId,
+        qbo_payment_kind: creditApplication ? 'credit_application' : 'payment',
+        ...(txnDate ? { qbo_txn_date: txnDate.toISOString().slice(0, 10) } : {}),
         realm: deps.targetRealm
       }
     });

--- a/packages/billing/src/services/accountingSync/recordExternalPayment.ts
+++ b/packages/billing/src/services/accountingSync/recordExternalPayment.ts
@@ -266,6 +266,9 @@ export async function reverseExternalPayment(
         invoice_id: input.invoiceId,
         amount: -Math.abs(input.amount),
         payment_method: input.provider,
+        // Deliberately "now", not the original TxnDate: a reversal is a new
+        // bookkeeping event recognized when the sync observes it; backdating
+        // it would rewrite a period that may already be reconciled.
         payment_date: new Date(),
         reference_number: input.referenceNumber,
         notes: input.notes ?? null,

--- a/packages/billing/src/services/accountingSync/syncProducers.test.ts
+++ b/packages/billing/src/services/accountingSync/syncProducers.test.ts
@@ -15,7 +15,7 @@ vi.mock('./accountingSyncSettings', () => ({
   getAccountingSyncSettings: vi.fn(async () => ({
     autoSyncEnabled: true,
     autoSyncStartDate: null,
-    depositAccountRef: null,
+    autoProvisionCustomers: false, depositAccountRef: null,
     defaultClassRef: null,
     defaultDepartmentRef: null,
     defaultRealm: null
@@ -45,12 +45,13 @@ import { SyncOperationsRepository } from './syncOperationsRepository';
 const mockGetRealm = vi.mocked(resolveDefaultRealm);
 const mockGetSettings = vi.mocked(getAccountingSyncSettings);
 
-/** Build a fake knex that returns the given invoice_type for any invoice lookup. */
-function makeKnex(invoiceType: string | null = 'standard'): any {
+/** Build a fake knex that returns the given invoice_type/invoice_date for any invoice lookup. */
+function makeKnex(invoiceType: string | null = 'standard', invoiceDate: string | null = null): any {
   const query: any = {
     where: vi.fn(() => query),
     select: vi.fn(() => query),
-    first: vi.fn(async () => invoiceType !== null ? { invoice_type: invoiceType } : null)
+    first: vi.fn(async () =>
+      invoiceType !== null ? { invoice_type: invoiceType, invoice_date: invoiceDate } : null)
   };
   const table = vi.fn(() => query);
   const fn = Object.assign(table, { fn: { now: vi.fn() } });
@@ -78,7 +79,7 @@ describe('enqueueInvoiceAutoExport', () => {
     // Reset to default happy-path mocks
     mockGetRealm.mockResolvedValue('realm-1');
     getStoredXeroConnectionsMock.mockResolvedValue({});
-    mockGetSettings.mockResolvedValue({ autoSyncEnabled: true, autoSyncStartDate: null, depositAccountRef: null, defaultClassRef: null, defaultDepartmentRef: null, defaultRealm: null });
+    mockGetSettings.mockResolvedValue({ autoSyncEnabled: true, autoSyncStartDate: null, autoProvisionCustomers: false, depositAccountRef: null, defaultClassRef: null, defaultDepartmentRef: null, defaultRealm: null });
   });
 
   afterEach(() => {
@@ -97,7 +98,7 @@ describe('enqueueInvoiceAutoExport', () => {
 
   it('does nothing when autoSyncEnabled=false', async () => {
     vi.stubEnv('EDITION', 'ee');
-    mockGetSettings.mockResolvedValue({ autoSyncEnabled: false, autoSyncStartDate: null, depositAccountRef: null, defaultClassRef: null, defaultDepartmentRef: null, defaultRealm: null });
+    mockGetSettings.mockResolvedValue({ autoSyncEnabled: false, autoSyncStartDate: null, autoProvisionCustomers: false, depositAccountRef: null, defaultClassRef: null, defaultDepartmentRef: null, defaultRealm: null });
 
     await enqueueInvoiceAutoExport(makeKnex(), 't1', 'inv-1');
 
@@ -107,7 +108,7 @@ describe('enqueueInvoiceAutoExport', () => {
   it('does nothing when today is before autoSyncStartDate cutoff', async () => {
     vi.stubEnv('EDITION', 'ee');
     const futureDate = new Date(Date.now() + 7 * 24 * 60 * 60 * 1000).toISOString().slice(0, 10);
-    mockGetSettings.mockResolvedValue({ autoSyncEnabled: true, autoSyncStartDate: futureDate, depositAccountRef: null, defaultClassRef: null, defaultDepartmentRef: null, defaultRealm: null });
+    mockGetSettings.mockResolvedValue({ autoSyncEnabled: true, autoSyncStartDate: futureDate, autoProvisionCustomers: false, depositAccountRef: null, defaultClassRef: null, defaultDepartmentRef: null, defaultRealm: null });
 
     await enqueueInvoiceAutoExport(makeKnex(), 't1', 'inv-1');
 
@@ -134,7 +135,7 @@ describe('enqueueInvoiceAutoExport', () => {
   it('enqueues the invoice when all gates pass (EE + autoSync + past cutoff + realm found)', async () => {
     vi.stubEnv('EDITION', 'ee');
     const pastDate = new Date(Date.now() - 7 * 24 * 60 * 60 * 1000).toISOString().slice(0, 10);
-    mockGetSettings.mockResolvedValue({ autoSyncEnabled: true, autoSyncStartDate: pastDate, depositAccountRef: null, defaultClassRef: null, defaultDepartmentRef: null, defaultRealm: null });
+    mockGetSettings.mockResolvedValue({ autoSyncEnabled: true, autoSyncStartDate: pastDate, autoProvisionCustomers: false, depositAccountRef: null, defaultClassRef: null, defaultDepartmentRef: null, defaultRealm: null });
 
     await enqueueInvoiceAutoExport(makeKnex(), 't1', 'inv-42');
 
@@ -190,6 +191,43 @@ describe('enqueueInvoiceAutoExport', () => {
       }
     }
   });
+
+  it('cutoff fences by the invoice DATE: a pre-cutoff invoice re-finalized after the cutoff never enqueues', async () => {
+    vi.stubEnv('EDITION', 'ee');
+    // Cutoff already passed on the wall clock, but the invoice is dated before
+    // it — the unfinalize → re-finalize scenario. Time passing the cutoff must
+    // not export history.
+    const pastCutoff = new Date(Date.now() - 30 * 24 * 60 * 60 * 1000).toISOString().slice(0, 10);
+    const preGoLiveDate = new Date(Date.now() - 400 * 24 * 60 * 60 * 1000).toISOString().slice(0, 10);
+    mockGetSettings.mockResolvedValue({ autoSyncEnabled: true, autoSyncStartDate: pastCutoff, autoProvisionCustomers: false, depositAccountRef: null, defaultClassRef: null, defaultDepartmentRef: null, defaultRealm: null });
+
+    await enqueueInvoiceAutoExport(makeKnex('standard', preGoLiveDate), 't1', 'inv-history-1');
+
+    expect(mockGetRealm).not.toHaveBeenCalled();
+    const results = vi.mocked(SyncOperationsRepository).mock.results;
+    for (const result of results) {
+      const enqueueFn = (result.value as any)?.enqueue;
+      if (enqueueFn) {
+        expect(enqueueFn).not.toHaveBeenCalled();
+      }
+    }
+  });
+
+  it('cutoff fence: an invoice dated on/after the cutoff enqueues normally', async () => {
+    vi.stubEnv('EDITION', 'ee');
+    const pastCutoff = new Date(Date.now() - 30 * 24 * 60 * 60 * 1000).toISOString().slice(0, 10);
+    const recentDate = new Date(Date.now() - 5 * 24 * 60 * 60 * 1000).toISOString().slice(0, 10);
+    mockGetSettings.mockResolvedValue({ autoSyncEnabled: true, autoSyncStartDate: pastCutoff, autoProvisionCustomers: false, depositAccountRef: null, defaultClassRef: null, defaultDepartmentRef: null, defaultRealm: null });
+
+    await enqueueInvoiceAutoExport(makeKnex('standard', recentDate), 't1', 'inv-recent-1');
+
+    const results = vi.mocked(SyncOperationsRepository).mock.results;
+    expect(results.length).toBeGreaterThan(0);
+    const enqueueFn = (results[results.length - 1].value as any)?.enqueue as ReturnType<typeof vi.fn>;
+    expect(enqueueFn).toHaveBeenCalledWith(
+      expect.objectContaining({ algaEntityId: 'inv-recent-1', operation: 'export_invoice' })
+    );
+  });
 });
 
 describe('enqueueVendorBillAutoExport', () => {
@@ -197,7 +235,7 @@ describe('enqueueVendorBillAutoExport', () => {
     vi.clearAllMocks();
     mockGetRealm.mockResolvedValue('realm-1');
     getStoredXeroConnectionsMock.mockResolvedValue({});
-    mockGetSettings.mockResolvedValue({ autoSyncEnabled: true, autoSyncStartDate: null, depositAccountRef: null, defaultClassRef: null, defaultDepartmentRef: null, defaultRealm: null });
+    mockGetSettings.mockResolvedValue({ autoSyncEnabled: true, autoSyncStartDate: null, autoProvisionCustomers: false, depositAccountRef: null, defaultClassRef: null, defaultDepartmentRef: null, defaultRealm: null });
   });
 
   afterEach(() => {
@@ -226,7 +264,7 @@ describe('enqueueVendorBillAutoExport', () => {
 
   it('skips auto-export when autoSyncEnabled=false', async () => {
     vi.stubEnv('EDITION', 'ee');
-    mockGetSettings.mockResolvedValue({ autoSyncEnabled: false, autoSyncStartDate: null, depositAccountRef: null, defaultClassRef: null, defaultDepartmentRef: null, defaultRealm: null });
+    mockGetSettings.mockResolvedValue({ autoSyncEnabled: false, autoSyncStartDate: null, autoProvisionCustomers: false, depositAccountRef: null, defaultClassRef: null, defaultDepartmentRef: null, defaultRealm: null });
 
     await enqueueVendorBillAutoExport(makeKnex(), 't1', 'bill-2');
 
@@ -241,7 +279,7 @@ describe('enqueueVendorBillAutoExport', () => {
 
   it('retry bypasses autoSyncEnabled=false', async () => {
     vi.stubEnv('EDITION', 'ee');
-    mockGetSettings.mockResolvedValue({ autoSyncEnabled: false, autoSyncStartDate: null, depositAccountRef: null, defaultClassRef: null, defaultDepartmentRef: null, defaultRealm: null });
+    mockGetSettings.mockResolvedValue({ autoSyncEnabled: false, autoSyncStartDate: null, autoProvisionCustomers: false, depositAccountRef: null, defaultClassRef: null, defaultDepartmentRef: null, defaultRealm: null });
 
     await expect(enqueueVendorBillExportRetry(makeKnex(), 't1', 'bill-3')).resolves.toBe(true);
 
@@ -277,7 +315,7 @@ describe('enqueueCreditApplication', () => {
   beforeEach(() => {
     vi.clearAllMocks();
     mockGetRealm.mockResolvedValue('realm-1');
-    mockGetSettings.mockResolvedValue({ autoSyncEnabled: true, autoSyncStartDate: null, depositAccountRef: null, defaultClassRef: null, defaultDepartmentRef: null, defaultRealm: null });
+    mockGetSettings.mockResolvedValue({ autoSyncEnabled: true, autoSyncStartDate: null, autoProvisionCustomers: false, depositAccountRef: null, defaultClassRef: null, defaultDepartmentRef: null, defaultRealm: null });
   });
 
   afterEach(() => {
@@ -419,7 +457,7 @@ describe('enqueueInvoiceVoid', () => {
   it('does NOT check autoSyncEnabled (always enqueues regardless of toggle)', async () => {
     vi.stubEnv('EDITION', 'ee');
     // autoSyncEnabled=false should NOT stop void from enqueuing
-    mockGetSettings.mockResolvedValue({ autoSyncEnabled: false, autoSyncStartDate: null, depositAccountRef: null, defaultClassRef: null, defaultDepartmentRef: null, defaultRealm: null });
+    mockGetSettings.mockResolvedValue({ autoSyncEnabled: false, autoSyncStartDate: null, autoProvisionCustomers: false, depositAccountRef: null, defaultClassRef: null, defaultDepartmentRef: null, defaultRealm: null });
 
     await enqueueInvoiceVoid(makeVoidKnex(true), 't1', 'inv-void-5');
 

--- a/packages/billing/src/services/accountingSync/syncProducers.ts
+++ b/packages/billing/src/services/accountingSync/syncProducers.ts
@@ -14,6 +14,7 @@ import { resolveConnectedAccountingIntegration } from './connectedAccountingInte
  * action (finalize, payment, ...), so everything is caught and logged.
  */
 
+// LEVERAGE: pattern edition-gate — same local isEnterpriseEdition as exportReadiness.ts
 function isEnterpriseEdition(): boolean {
   return (
     (process.env.EDITION ?? '').toLowerCase() === 'ee' ||
@@ -26,6 +27,19 @@ const QBO_ADAPTER_TYPE = 'quickbooks_online';
 function adapterSupportsExportType(adapterType: string, exportType: string): boolean {
   const capabilities = ADAPTER_EXPORT_CAPABILITIES as Record<string, readonly string[] | undefined>;
   return Boolean(capabilities[adapterType]?.includes(exportType));
+}
+
+/** Normalize a date-ish column value (Date | ISO string | date string) to YYYY-MM-DD. */
+// LEVERAGE: pattern date-only-normalization — same helper as exportReadiness.ts
+function toDateOnly(value: unknown): string | null {
+  if (value === null || value === undefined) {
+    return null;
+  }
+  const date = value instanceof Date ? value : new Date(String(value));
+  if (Number.isNaN(date.getTime())) {
+    return null;
+  }
+  return date.toISOString().slice(0, 10);
 }
 
 /**
@@ -53,23 +67,12 @@ export async function enqueueInvoiceAutoExport(
       return;
     }
 
-    if (settings.autoSyncStartDate) {
-      // Finalization happens "now"; the cutoff fences out re-finalized history.
-      const today = new Date().toISOString().slice(0, 10);
-      if (today < settings.autoSyncStartDate.slice(0, 10)) {
-        return;
-      }
-    }
-
-    const integration = await resolveConnectedAccountingIntegration(knex, tenantId);
-    if (!integration) {
-      return;
-    }
-
-    // Look up invoice_type to route the operation correctly.
+    // Look up invoice_type (operation routing) and invoice_date (cutoff fence).
+    // Done before resolving the connected integration so a prepayment or a
+    // pre-cutoff document short-circuits without any realm work.
     const invoiceRow = await tenantDb(knex, tenantId).table('invoices')
       .where({ invoice_id: invoiceId })
-      .select('invoice_type')
+      .select('invoice_type', 'invoice_date')
       .first();
 
     const invoiceType: string | null | undefined = invoiceRow?.invoice_type;
@@ -77,6 +80,29 @@ export async function enqueueInvoiceAutoExport(
     // Prepayments are excluded from QBO export entirely.
     if (invoiceType === 'prepayment') {
       logger.debug('[accountingSync] Skipping prepayment invoice auto-export', { tenantId, invoiceId });
+      return;
+    }
+
+    if (settings.autoSyncStartDate) {
+      // Fence by the invoice's own document date, not the wall clock:
+      // finalization can happen long after the document's era (unfinalize →
+      // re-finalize), and pre-go-live documents must never auto-export into
+      // books that were reconciled before the connection existed.
+      const cutoff = settings.autoSyncStartDate.slice(0, 10);
+      const invoiceDate = toDateOnly(invoiceRow?.invoice_date) ?? new Date().toISOString().slice(0, 10);
+      if (invoiceDate < cutoff) {
+        logger.debug('[accountingSync] Skipping auto-export of pre-cutoff invoice', {
+          tenantId,
+          invoiceId,
+          invoiceDate,
+          cutoff
+        });
+        return;
+      }
+    }
+
+    const integration = await resolveConnectedAccountingIntegration(knex, tenantId);
+    if (!integration) {
       return;
     }
 

--- a/packages/billing/src/services/accountingSync/testing/README.md
+++ b/packages/billing/src/services/accountingSync/testing/README.md
@@ -1,0 +1,101 @@
+# QBO simulator for sync-engine tests
+
+`qboSimulator.ts` is a stateful, in-memory QuickBooks Online. It implements
+the public surface of `QboClientService` (`create`, `read`, `update`, `query`,
+`fetchChanges`, `getPreferences`, `voidInvoice`, `deleteCreditMemo`,
+`findCustomerByDisplayName`, `createOrUpdateCustomer`) with real QBO
+semantics, so a test can drive the actual sync code through a multi-step
+sequence — export, edit, CDC poll, apply — and assert both sides: what Alga
+recorded *and* what QBO now contains.
+
+## When to use it
+
+Use the simulator whenever a test spans more than one QBO interaction or
+depends on QBO state changing between steps:
+
+- anything involving SyncTokens, balances, CDC ordering, or idempotent replay
+- race conditions (QBO consumed a credit first; a document changed under us)
+- shape-fidelity checks (does the payload our applier receives from real CDC
+  actually look like what our canned mocks claim?)
+
+Keep using plain `vi.fn()` mocks for single-call unit tests where the QBO
+response is incidental — the simulator adds nothing there.
+
+## Wiring
+
+The appliers and adapter reach QBO through
+`@alga-psa/integrations/lib/qbo/qboClientService`. Point that seam at a
+simulator instance:
+
+```ts
+const simRef = vi.hoisted(() => ({ current: null as any }));
+
+vi.mock('@alga-psa/integrations/lib/qbo/qboClientService', () => ({
+  QboClientService: { create: vi.fn(async () => simRef.current.client) },
+  getDefaultQboRealmId: vi.fn(async () => 'realm-sim')
+}));
+
+// in each test:
+const sim = new QboSimulator();
+simRef.current = sim;
+```
+
+## The scenario pattern
+
+```ts
+// 1. Seed QBO state
+const customer = sim.seedCustomer({ name: 'Acme Corp' });
+const invoice = sim.seedInvoice({ customerId: customer.Id, amountCents: 15000 });
+
+// 2. Take a CDC cursor, then act "inside QBO"
+const cursor = sim.now();
+sim.receivePaymentInQbo({ invoiceId: invoice.Id, amountCents: 15000 });
+
+// 3. Poll changes the way the cycle service does, run the real applier
+const changeSet = await sim.client.fetchChanges(cursor);
+for (const change of changeSet.changes.filter((c) => c.entityType === 'Payment')) {
+  await applyExternalPaymentChange(deps, change as any);
+}
+
+// 4. Assert both sides
+expect(recordExternalPayment).toHaveBeenCalledWith(/* Alga side */);
+expect((await sim.client.read('Invoice', invoice.Id))!.Balance).toBe(0); // QBO side
+```
+
+Seeding helpers: `seedCustomer` (supports `active: false`), `seedInvoice`,
+`seedCreditMemo`, `applyCreditInQbo` (a bookkeeper applying credit),
+`receivePaymentInQbo` (a check arriving). Inspect state with
+`sim.entities('Payment')` or `sim.client.read(...)`.
+
+## What it models
+
+| Behavior | Detail |
+| --- | --- |
+| Ids & SyncTokens | Tokens start at `"0"`, increment on every mutation; stale-token updates throw error code `5010` |
+| Customer names | Uniqueness enforced across active **and inactive** customers (`6240`); name queries return **active only**, like QBO's default query filter |
+| Document totals | Computed from `Line` amounts — the caller's `TotalAmt` is ignored, like QBO. `taxAdjustmentCents` option models Automated Sales Tax changing the total at create time |
+| Payments | `Line[].LinkedTxn` allocations reduce Invoice/CreditMemo balances; over-application throws `6210`; balance movement bumps the target's token and journals a CDC change |
+| Credit application | A zero-dollar Payment linking CreditMemo → Invoice, same shape the real integration pushes and receives |
+| Auto-apply credits | `new QboSimulator({ autoApplyCredits: true })` consumes open customer credit the moment an invoice is created — QBO's `SalesFormsPrefs.AutoApplyCredit` race |
+| Voids | `voidInvoice` zeroes amounts and stamps a `Voided` private note — the exact shape the drift detector's heuristic matches |
+| CDC | Every mutation journals against a deterministic logical clock; `fetchChanges(since)` replays latest entity state with `deleted` flags. Use `sim.now()` as the cursor between phases |
+| Preferences | `getPreferences()` reports `AutoApplyCredit` from the option |
+
+## What it refuses to fake
+
+Unsupported entity types and unmodeled SQL queries throw
+`SIM_UNSUPPORTED` instead of returning something plausible. If the
+integration starts issuing a new query shape, model it in `runQuery`
+deliberately — with the semantics real QBO has, not the semantics that make
+the test pass.
+
+## Examples
+
+- `qboSimulator.test.ts` — pins the simulator's own QBO semantics
+- `qboSimulator.scenarios.test.ts` — real appliers driven end-to-end:
+  credit-application push + idempotent replay, the auto-apply race, a legacy
+  credit applied by the bookkeeper arriving through CDC, the
+  inactive-customer duplicate-name failure, a QBO-side void tripping drift
+- `../customerContracts.qboCredits.test.ts` and
+  `../customerContracts.qboExportSafety.test.ts` — customer-communicated
+  behavior these flows must preserve

--- a/packages/billing/src/services/accountingSync/testing/qboSimulator.scenarios.test.ts
+++ b/packages/billing/src/services/accountingSync/testing/qboSimulator.scenarios.test.ts
@@ -1,0 +1,358 @@
+import { describe, expect, it, vi, beforeEach } from 'vitest';
+import { QboSimulator } from './qboSimulator';
+
+/**
+ * Sync-engine scenarios run against the stateful QBO simulator instead of
+ * canned mocks: each test drives real applier code through a realistic QBO
+ * sequence (documents exist, balances move, CDC replays state) and asserts
+ * both sides — what Alga recorded AND what QBO now contains.
+ */
+
+// ── Hoisted wiring: the appliers reach QBO through this seam ────────────────
+const simRef = vi.hoisted(() => ({ current: null as any }));
+
+vi.mock('@alga-psa/integrations/lib/qbo/qboClientService', () => ({
+  QboClientService: { create: vi.fn(async () => simRef.current.client) },
+  getDefaultQboRealmId: vi.fn(async () => 'realm-sim')
+}));
+
+vi.mock('../recordExternalPayment', () => ({
+  recordExternalPayment: vi.fn(async () => ({ success: true, paymentId: 'pay-1', paymentRecorded: true })),
+  reverseExternalPayment: vi.fn(async () => ({ success: true, paymentId: 'rev-1', paymentRecorded: true })),
+  isNonPayableInvoiceStatus: (status: string | null | undefined) =>
+    status === 'cancelled' || status === 'draft' || status === 'void',
+  computeBalanceDue: vi.fn(
+    ({ totalAmount, creditApplied, totalPaid }: { totalAmount: number; creditApplied: number; totalPaid: number }) =>
+      totalAmount - creditApplied - totalPaid
+  )
+}));
+
+import { drainApplyCreditOps } from '../creditApplicationApplier';
+import { applyExternalPaymentChange } from '../paymentApplier';
+import { applyExternalDocumentChange } from '../driftDetector';
+import { emptyCycleStats, MAPPING_SYNC_STATUS } from '../accountingSync.types';
+import { recordExternalPayment } from '../recordExternalPayment';
+
+const TENANT = 'tenant-sim';
+const ADAPTER = 'quickbooks_online';
+const REALM = 'realm-sim';
+
+/** Stateful in-memory mapping ledger: inserts are visible to later lookups. */
+function makeStatefulLedger() {
+  const rows: any[] = [];
+  const ledger: any = {
+    rows,
+    findByAlgaId: vi.fn(async (entityType: string, entityId: string) =>
+      rows.find((r) => r.alga_entity_type === entityType && r.alga_entity_id === entityId)
+    ),
+    findByExternalId: vi.fn(async (entityType: string, externalId: string) =>
+      rows.find((r) => r.alga_entity_type === entityType && r.external_entity_id === externalId) ?? null
+    ),
+    insert: vi.fn(async (record: any) => {
+      const row = {
+        id: `map-${rows.length + 1}`,
+        alga_entity_type: record.algaEntityType,
+        alga_entity_id: record.algaEntityId,
+        external_entity_id: record.externalEntityId,
+        sync_status: record.syncStatus ?? 'synced',
+        metadata: record.metadata ?? null
+      };
+      rows.push(row);
+      return row;
+    }),
+    update: vi.fn(async (id: string, patch: any) => {
+      const row = rows.find((r) => r.id === id);
+      if (row) {
+        if (patch.syncStatus) row.sync_status = patch.syncStatus;
+        if (patch.metadata) row.metadata = patch.metadata;
+      }
+    }),
+    withKnex: vi.fn()
+  };
+  ledger.withKnex.mockImplementation(() => ledger);
+  return ledger;
+}
+
+function seedMapping(ledger: any, entityType: string, algaId: string, externalId: string, metadata: any = null) {
+  ledger.rows.push({
+    id: `map-seed-${ledger.rows.length + 1}`,
+    alga_entity_type: entityType,
+    alga_entity_id: algaId,
+    external_entity_id: externalId,
+    sync_status: MAPPING_SYNC_STATUS.synced,
+    metadata
+  });
+}
+
+function makeExceptions() {
+  return {
+    createOrUpdate: vi.fn(async () => ({ created: true })),
+    resolve: vi.fn(async () => undefined)
+  };
+}
+
+function makeOps(pending: any[]) {
+  return {
+    listPending: vi.fn(async () => pending),
+    markInProgress: vi.fn(async () => undefined),
+    markDone: vi.fn(async () => undefined),
+    markFailed: vi.fn(async () => 'pending'),
+    enqueue: vi.fn(async () => ({}))
+  };
+}
+
+function makeApplyCreditOp(amountCents: number) {
+  return {
+    op_id: 'op-apply-sim',
+    tenant: TENANT,
+    adapter_type: ADAPTER,
+    target_realm: REALM,
+    operation: 'apply_credit',
+    alga_entity_type: 'credit_allocation',
+    alga_entity_id: 'alloc-sim-1',
+    status: 'pending',
+    attempts: 0,
+    last_error: null,
+    payload: { creditNoteInvoiceId: 'inv-cn-1', targetInvoiceId: 'inv-target-1', amountCents },
+    created_at: new Date().toISOString(),
+    processed_at: null
+  };
+}
+
+function makeFakeKnex(invoiceRow: any = { status: 'sent', total_amount: 30000, credit_applied: 0 }) {
+  // Self-referential builder: where()/select() return the same query so any
+  // chain length works, including tenantDb(...).table(name).where(...) which
+  // auto-injects a tenant clause before the applier's own .where(...).
+  const query: any = {
+    where: vi.fn(() => query),
+    select: vi.fn(() => query),
+    first: vi.fn(async () => invoiceRow)
+  };
+  const trx: any = Object.assign(vi.fn(() => query), {
+    transaction: vi.fn(async (cb: any) => cb(trx)),
+    fn: { now: vi.fn() }
+  });
+  return trx;
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  vi.mocked(recordExternalPayment).mockResolvedValue({
+    success: true,
+    paymentId: 'pay-1',
+    paymentRecorded: true
+  } as any);
+});
+
+describe('Scenario: Alga applies credit → QBO reconciles', () => {
+  it('pushes a real zero-dollar Payment; CreditMemo and Invoice balances drop in QBO; re-run is idempotent', async () => {
+    const sim = new QboSimulator();
+    simRef.current = sim;
+
+    const customer = sim.seedCustomer({ name: 'Acme Corp' });
+    const qboCm = sim.seedCreditMemo({ customerId: customer.Id, amountCents: 10000 });
+    const qboInvoice = sim.seedInvoice({ customerId: customer.Id, amountCents: 15000 });
+
+    const ledger = makeStatefulLedger();
+    seedMapping(ledger, 'invoice', 'inv-cn-1', qboCm.Id);
+    seedMapping(ledger, 'invoice', 'inv-target-1', qboInvoice.Id, { customerId: customer.Id });
+
+    const ops = makeOps([makeApplyCreditOp(10000)]);
+    const stats = emptyCycleStats();
+
+    await drainApplyCreditOps({
+      knex: {} as any,
+      tenantId: TENANT,
+      adapterType: ADAPTER,
+      targetRealm: REALM,
+      ops: ops as any,
+      ledger: ledger as any,
+      exceptions: makeExceptions(),
+      stats
+    });
+
+    // QBO side: one zero-dollar payment linking the two documents, balances moved.
+    const payments = sim.entities('Payment');
+    expect(payments).toHaveLength(1);
+    expect(payments[0].TotalAmt).toBe(0);
+    expect((await sim.client.read('CreditMemo', qboCm.Id))!.Balance).toBe(0);
+    expect((await sim.client.read('Invoice', qboInvoice.Id))!.Balance).toBe(50);
+    expect(ops.markDone).toHaveBeenCalled();
+
+    // Re-run the same op (crash-recovery replay): the mapping written by the
+    // first run makes it a no-op — still exactly one payment in QBO.
+    await drainApplyCreditOps({
+      knex: {} as any,
+      tenantId: TENANT,
+      adapterType: ADAPTER,
+      targetRealm: REALM,
+      ops: makeOps([makeApplyCreditOp(10000)]) as any,
+      ledger: ledger as any,
+      exceptions: makeExceptions(),
+      stats: emptyCycleStats()
+    });
+    expect(sim.entities('Payment')).toHaveLength(1);
+  });
+});
+
+describe('Scenario: QBO auto-apply wins the race', () => {
+  it('QBO consumed the credit before the cycle ran → exception filed, nothing double-applied', async () => {
+    const sim = new QboSimulator({ autoApplyCredits: true });
+    simRef.current = sim;
+
+    const customer = sim.seedCustomer({ name: 'Acme Corp' });
+    const qboCm = sim.seedCreditMemo({ customerId: customer.Id, amountCents: 10000 });
+    // Invoice creation triggers QBO's auto-apply: credit is consumed instantly.
+    const qboInvoice = sim.seedInvoice({ customerId: customer.Id, amountCents: 15000 });
+    expect((await sim.client.read('CreditMemo', qboCm.Id))!.Balance).toBe(0);
+    const paymentsBefore = sim.entities('Payment').length;
+
+    const ledger = makeStatefulLedger();
+    seedMapping(ledger, 'invoice', 'inv-cn-1', qboCm.Id);
+    seedMapping(ledger, 'invoice', 'inv-target-1', qboInvoice.Id, { customerId: customer.Id });
+
+    const exceptions = makeExceptions();
+    await drainApplyCreditOps({
+      knex: {} as any,
+      tenantId: TENANT,
+      adapterType: ADAPTER,
+      targetRealm: REALM,
+      ops: makeOps([makeApplyCreditOp(10000)]) as any,
+      ledger: ledger as any,
+      exceptions,
+      stats: emptyCycleStats()
+    });
+
+    expect(exceptions.createOrUpdate).toHaveBeenCalledWith(
+      expect.objectContaining({
+        context: expect.objectContaining({ reason: 'qbo_credit_already_consumed' })
+      })
+    );
+    expect(sim.entities('Payment')).toHaveLength(paymentsBefore);
+  });
+});
+
+describe('Scenario: bookkeeper applies a legacy QBO credit to a synced invoice', () => {
+  it('the CDC payment lands in Alga as the applied amount; balance-only document changes are not drift', async () => {
+    const sim = new QboSimulator();
+    simRef.current = sim;
+
+    const customer = sim.seedCustomer({ name: 'Loyal Customer LLC' });
+    const legacyCm = sim.seedCreditMemo({ customerId: customer.Id, amountCents: 60000 });
+    const qboInvoice = sim.seedInvoice({ customerId: customer.Id, amountCents: 15000, docNumber: 'INV-31501' });
+
+    // Alga knows the invoice (it was exported); the legacy credit is QBO-only.
+    const ledger = makeStatefulLedger();
+    seedMapping(ledger, 'invoice', 'alga-inv-1', qboInvoice.Id, {
+      exported_total: 150,
+      doc_number: 'INV-31501',
+      sync_token: qboInvoice.SyncToken
+    });
+
+    const cursor = sim.now();
+    sim.applyCreditInQbo({ creditMemoId: legacyCm.Id, invoiceId: qboInvoice.Id, amountCents: 15000 });
+
+    const changeSet = await sim.client.fetchChanges(cursor);
+    const stats = emptyCycleStats();
+    const exceptions = makeExceptions();
+
+    // Route changes the way the cycle service does: Payments, then documents.
+    for (const change of changeSet.changes.filter((c) => c.entityType === 'Payment')) {
+      await applyExternalPaymentChange(
+        {
+          knex: makeFakeKnex(),
+          tenantId: TENANT,
+          adapterType: ADAPTER,
+          targetRealm: REALM,
+          ledger: ledger as any,
+          exceptions,
+          stats
+        },
+        change as any
+      );
+    }
+    for (const change of changeSet.changes.filter((c) => c.entityType === 'Invoice' || c.entityType === 'CreditMemo')) {
+      await applyExternalDocumentChange(
+        { tenantId: TENANT, targetRealm: REALM, ledger: ledger as any, exceptions, stats },
+        change as any
+      );
+    }
+
+    // The credit application arrived as exactly one invoice allocation,
+    // labeled as a credit application and dated with QBO's TxnDate.
+    expect(recordExternalPayment).toHaveBeenCalledTimes(1);
+    expect(recordExternalPayment).toHaveBeenCalledWith(
+      expect.anything(),
+      TENANT,
+      expect.objectContaining({
+        invoiceId: 'alga-inv-1',
+        amount: 15000,
+        provider: 'quickbooks',
+        paymentDate: expect.any(Date),
+        notes: expect.stringMatching(/^QuickBooks credit applied /)
+      })
+    );
+    // Balance moved in QBO but the total did not: no drift, no exceptions.
+    expect(stats.driftFound).toBe(0);
+    expect(exceptions.createOrUpdate).not.toHaveBeenCalled();
+    // The legacy CreditMemo change was ignored (unmapped by design).
+    expect(stats.unmappedIgnored).toBeGreaterThanOrEqual(1);
+  });
+});
+
+describe('Scenario: auto-provisioning against an established company file', () => {
+  it('an inactive customer is invisible to name lookups but blocks the create — the exact 26-year-file failure mode', async () => {
+    const sim = new QboSimulator();
+    simRef.current = sim;
+    sim.seedCustomer({ name: 'Smith & Sons, Inc.', active: false });
+
+    // The background path's exact-name probe finds nothing...
+    expect(await sim.client.findCustomerByDisplayName('Smith & Sons, Inc.')).toBeNull();
+    // ...so it proceeds to create, and QBO rejects with a duplicate-name error.
+    await expect(sim.client.createOrUpdateCustomer({ name: 'Smith & Sons, Inc.' })).rejects.toMatchObject({
+      code: '6240'
+    });
+    // And a near-miss spelling sails through as a brand-new duplicate customer.
+    const nearMiss = await sim.client.createOrUpdateCustomer({ name: 'Smith and Sons Inc' });
+    expect(nearMiss.externalId).toBeDefined();
+    expect(sim.entities('Customer')).toHaveLength(2);
+  });
+});
+
+describe('Scenario: QBO-side void arrives through CDC', () => {
+  it('the void shape from the simulator trips the drift detector into externalVoided + exception', async () => {
+    const sim = new QboSimulator();
+    simRef.current = sim;
+
+    const customer = sim.seedCustomer({ name: 'Acme Corp' });
+    const qboInvoice = sim.seedInvoice({ customerId: customer.Id, amountCents: 15000, docNumber: 'INV-9' });
+
+    const ledger = makeStatefulLedger();
+    seedMapping(ledger, 'invoice', 'alga-inv-9', qboInvoice.Id, {
+      exported_total: 150,
+      doc_number: 'INV-9',
+      sync_token: qboInvoice.SyncToken
+    });
+
+    const cursor = sim.now();
+    await sim.client.voidInvoice(qboInvoice.Id, qboInvoice.SyncToken);
+
+    const changeSet = await sim.client.fetchChanges(cursor);
+    const stats = emptyCycleStats();
+    const exceptions = makeExceptions();
+
+    for (const change of changeSet.changes.filter((c) => c.entityType === 'Invoice')) {
+      await applyExternalDocumentChange(
+        { tenantId: TENANT, targetRealm: REALM, ledger: ledger as any, exceptions, stats },
+        change as any
+      );
+    }
+
+    expect(stats.driftFound).toBe(1);
+    expect(exceptions.createOrUpdate).toHaveBeenCalledWith(
+      expect.objectContaining({ type: 'accounting_sync_drift' })
+    );
+    const mapping = ledger.rows.find((r: any) => r.external_entity_id === qboInvoice.Id);
+    expect(mapping.sync_status).toBe(MAPPING_SYNC_STATUS.externalVoided);
+  });
+});

--- a/packages/billing/src/services/accountingSync/testing/qboSimulator.test.ts
+++ b/packages/billing/src/services/accountingSync/testing/qboSimulator.test.ts
@@ -1,0 +1,134 @@
+import { describe, expect, it } from 'vitest';
+import { QboSimulator, QboSimError } from './qboSimulator';
+
+describe('QboSimulator — QBO semantics the sync engine depends on', () => {
+  it('computes document totals from lines, ignoring the caller-supplied TotalAmt', async () => {
+    const sim = new QboSimulator();
+    const invoice = await sim.client.create('Invoice', {
+      CustomerRef: { value: 'c-1' },
+      TotalAmt: 999.99, // lies — QBO recomputes
+      Line: [
+        { DetailType: 'SalesItemLineDetail', Amount: 100.0 },
+        { DetailType: 'SalesItemLineDetail', Amount: 50.5 }
+      ]
+    });
+
+    expect(invoice.TotalAmt).toBe(150.5);
+    expect(invoice.Balance).toBe(150.5);
+    expect(invoice.SyncToken).toBe('0');
+  });
+
+  it('taxAdjustmentCents models AST changing the total at create time', async () => {
+    const sim = new QboSimulator({ taxAdjustmentCents: 825 });
+    const invoice = await sim.client.create('Invoice', {
+      CustomerRef: { value: 'c-1' },
+      Line: [{ DetailType: 'SalesItemLineDetail', Amount: 100.0 }]
+    });
+
+    // What Alga transformed is not what QBO stored — the drift-baseline trap.
+    expect(invoice.TotalAmt).toBe(108.25);
+  });
+
+  it('rejects updates carrying a stale SyncToken (5010) and increments on success', async () => {
+    const sim = new QboSimulator();
+    const invoice = await sim.client.create('Invoice', {
+      CustomerRef: { value: 'c-1' },
+      Line: [{ DetailType: 'SalesItemLineDetail', Amount: 10 }]
+    });
+
+    const updated = await sim.client.update('Invoice', { Id: invoice.Id, SyncToken: '0', DocNumber: 'INV-2' });
+    expect(updated.SyncToken).toBe('1');
+
+    await expect(
+      sim.client.update('Invoice', { Id: invoice.Id, SyncToken: '0', DocNumber: 'INV-3' })
+    ).rejects.toMatchObject({ code: '5010' });
+  });
+
+  it('enforces DisplayName uniqueness across ACTIVE AND INACTIVE customers (6240)', async () => {
+    const sim = new QboSimulator();
+    sim.seedCustomer({ name: 'Smith & Sons, Inc.', active: false });
+
+    await expect(
+      sim.client.create('Customer', { DisplayName: 'Smith & Sons, Inc.' })
+    ).rejects.toMatchObject({ code: '6240' });
+  });
+
+  it('name queries return ACTIVE customers only — the auto-provision blind spot', async () => {
+    const sim = new QboSimulator();
+    sim.seedCustomer({ name: 'Dormant LLC', active: false });
+
+    const byQuery = await sim.client.query("SELECT Id FROM Customer WHERE DisplayName = 'Dormant LLC'");
+    const byHelper = await sim.client.findCustomerByDisplayName('Dormant LLC');
+
+    expect(byQuery).toHaveLength(0);
+    expect(byHelper).toBeNull();
+    // ...so createOrUpdateCustomer walks straight into the duplicate-name wall.
+    await expect(sim.client.createOrUpdateCustomer({ name: 'Dormant LLC' })).rejects.toBeInstanceOf(QboSimError);
+  });
+
+  it('payments reduce linked document balances and reject over-application', async () => {
+    const sim = new QboSimulator();
+    const customer = sim.seedCustomer({ name: 'Acme' });
+    const invoice = sim.seedInvoice({ customerId: customer.Id, amountCents: 20000 });
+
+    sim.receivePaymentInQbo({ invoiceId: invoice.Id, amountCents: 15000 });
+    expect((await sim.client.read('Invoice', invoice.Id))!.Balance).toBe(50);
+
+    expect(() => sim.receivePaymentInQbo({ invoiceId: invoice.Id, amountCents: 10000 })).toThrow(/exceeds open balance/);
+  });
+
+  it('CDC returns only changes after the cursor, with latest state and deleted flags', async () => {
+    const sim = new QboSimulator();
+    const customer = sim.seedCustomer({ name: 'Acme' });
+    const cm = sim.seedCreditMemo({ customerId: customer.Id, amountCents: 5000 });
+
+    const cursor = sim.now();
+    const invoice = sim.seedInvoice({ customerId: customer.Id, amountCents: 10000 });
+    await sim.client.deleteCreditMemo(cm.Id, cm.SyncToken);
+
+    const changeSet = await sim.client.fetchChanges(cursor);
+    const types = changeSet.changes.map((c) => `${c.entityType}:${c.deleted}`);
+
+    expect(types).toContain('Invoice:false');
+    expect(types).toContain('CreditMemo:true');
+    // The customer predates the cursor and did not change.
+    expect(changeSet.changes.find((c) => c.entityType === 'Customer')).toBeUndefined();
+    expect(changeSet.changes.find((c) => c.externalId === invoice.Id)!.payload.TotalAmt).toBe(100);
+  });
+
+  it('voidInvoice zeroes amounts and stamps a Voided note (the drift-detector heuristic shape)', async () => {
+    const sim = new QboSimulator();
+    const customer = sim.seedCustomer({ name: 'Acme' });
+    const invoice = sim.seedInvoice({ customerId: customer.Id, amountCents: 10000 });
+
+    await sim.client.voidInvoice(invoice.Id, invoice.SyncToken);
+    const voided = (await sim.client.read('Invoice', invoice.Id))!;
+
+    expect(voided.TotalAmt).toBe(0);
+    expect(voided.Balance).toBe(0);
+    expect(String(voided.PrivateNote)).toMatch(/voided/i);
+  });
+
+  it('autoApplyCredits consumes open customer credit the moment an invoice is created', async () => {
+    const sim = new QboSimulator({ autoApplyCredits: true });
+    const customer = sim.seedCustomer({ name: 'Acme' });
+    const cm = sim.seedCreditMemo({ customerId: customer.Id, amountCents: 10000 });
+
+    const invoice = sim.seedInvoice({ customerId: customer.Id, amountCents: 15000 });
+
+    expect((sim.entities('Payment'))).toHaveLength(1);
+    expect((sim.entities('Payment'))[0].TotalAmt).toBe(0);
+    expect((sim.entities('CreditMemo'))[0].Balance).toBe(0);
+    expect((sim.entities('Invoice'))[0].Balance).toBe(50);
+    expect(cm.Id).toBeDefined();
+    expect(invoice.Id).toBeDefined();
+  });
+
+  it('getPreferences reports the AutoApplyCredit preference', async () => {
+    const on = new QboSimulator({ autoApplyCredits: true });
+    const off = new QboSimulator();
+
+    expect((await on.client.getPreferences()).SalesFormsPrefs.AutoApplyCredit).toBe(true);
+    expect((await off.client.getPreferences()).SalesFormsPrefs.AutoApplyCredit).toBe(false);
+  });
+});

--- a/packages/billing/src/services/accountingSync/testing/qboSimulator.ts
+++ b/packages/billing/src/services/accountingSync/testing/qboSimulator.ts
@@ -1,0 +1,500 @@
+/**
+ * In-memory QuickBooks Online simulator for sync-engine tests.
+ *
+ * Implements the subset of QBO behavior our integration actually depends on,
+ * at the QboClientService seam, so tests can exercise real sequences (export →
+ * edit → CDC poll → apply) against stateful QBO semantics instead of canned
+ * one-shot mocks. Wire it in with:
+ *
+ *   vi.mock('@alga-psa/integrations/lib/qbo/qboClientService', () => ({
+ *     QboClientService: { create: async () => sim.client },
+ *     getDefaultQboRealmId: async () => 'realm-sim'
+ *   }));
+ *
+ * Modeled semantics (each is something a test has caught or could catch):
+ * - Ids and SyncTokens: tokens start at "0" and increment on every update;
+ *   updates with a stale token are rejected (QBO error 5010).
+ * - Customer DisplayName uniqueness across ACTIVE AND INACTIVE customers
+ *   (QBO error 6240) — while name queries return active customers only,
+ *   mirroring QBO's default query filter. This asymmetry is exactly what makes
+ *   auto-provisioning against a 26-year-old company file dangerous.
+ * - Invoice/CreditMemo totals are computed by "QBO" from the lines — the
+ *   caller's header TotalAmt is ignored, like QBO itself does. An optional
+ *   taxAdjustmentCents models Automated Sales Tax changing the total at
+ *   create time.
+ * - Payments carry Line[].LinkedTxn allocations and reduce Invoice/CreditMemo
+ *   balances; a zero-dollar payment linking CreditMemo → Invoice is the
+ *   canonical credit application.
+ * - autoApplyCredits models QBO's SalesFormsPrefs.AutoApplyCredit: when on,
+ *   creating an invoice immediately consumes any open customer credit via an
+ *   auto-created Payment (the race our credit applier must survive).
+ * - Change Data Capture: every mutation is journaled with a deterministic
+ *   logical clock; fetchChanges(since) replays entity state like QBO CDC.
+ */
+
+export interface QboSimEntity {
+  Id: string;
+  SyncToken: string;
+  [key: string]: any;
+}
+
+export interface QboSimulatorOptions {
+  /** Model QBO's "Automatically apply credits" company preference. */
+  autoApplyCredits?: boolean;
+  /** Cents "QBO" adds to each created invoice total (models AST recalculating tax). */
+  taxAdjustmentCents?: number;
+  /** Realm id reported in change sets. */
+  realmId?: string;
+}
+
+interface ChangeJournalEntry {
+  entityType: string;
+  externalId: string;
+  deleted: boolean;
+  at: string;
+}
+
+export class QboSimError extends Error {
+  constructor(public readonly code: string, message: string) {
+    super(message);
+    this.name = 'QboSimError';
+  }
+}
+
+const SUPPORTED_ENTITIES = ['Customer', 'Invoice', 'CreditMemo', 'Payment'] as const;
+type SimEntityType = (typeof SUPPORTED_ENTITIES)[number];
+
+function toCents(amount: unknown): number {
+  const value = Number(amount);
+  return Number.isFinite(value) ? Math.round(value * 100) : 0;
+}
+
+function toAmount(cents: number): number {
+  return Math.round(cents) / 100;
+}
+
+export class QboSimulator {
+  private readonly stores: Record<SimEntityType, Map<string, QboSimEntity>> = {
+    Customer: new Map(),
+    Invoice: new Map(),
+    CreditMemo: new Map(),
+    Payment: new Map()
+  };
+
+  private journal: ChangeJournalEntry[] = [];
+  private nextId = 1;
+  /** Deterministic logical clock: every mutation advances one second. */
+  private clockMs = Date.parse('2026-01-01T00:00:00.000Z');
+
+  readonly options: QboSimulatorOptions;
+
+  /** Drop-in facade matching QboClientService's public surface. */
+  readonly client: {
+    create: <T = any>(entityType: string, data: any) => Promise<T>;
+    read: <T = any>(entityType: string, id: string) => Promise<T | null>;
+    update: <T = any>(entityType: string, data: { Id: string; SyncToken: string; [key: string]: any }) => Promise<T>;
+    query: <T = any>(selectQuery: string) => Promise<T[]>;
+    fetchChanges: (since: string) => Promise<{
+      changes: Array<{ entityType: string; externalId: string; syncToken?: string; deleted: boolean; payload: any }>;
+      truncated: boolean;
+      fetchedAt: string;
+    }>;
+    getPreferences: <T = any>() => Promise<T>;
+    findCustomerByDisplayName: (displayName: string) => Promise<{ externalId: string; name: string; syncToken: string } | null>;
+    createOrUpdateCustomer: (payload: { name: string; primaryEmail?: string | null }) => Promise<{ externalId: string; name: string }>;
+    voidInvoice: (id: string, syncToken: string) => Promise<any>;
+    deleteCreditMemo: (id: string, syncToken: string) => Promise<any>;
+  };
+
+  constructor(options: QboSimulatorOptions = {}) {
+    this.options = { realmId: 'realm-sim', ...options };
+
+    this.client = {
+      create: async (entityType, data) => this.createEntity(entityType, data) as any,
+      read: async (entityType, id) => (this.getStore(entityType).get(id) as any) ?? null,
+      update: async (entityType, data) => this.updateEntity(entityType, data) as any,
+      query: async (selectQuery) => this.runQuery(selectQuery) as any,
+      fetchChanges: async (since) => this.fetchChanges(since),
+      getPreferences: async () =>
+        ({
+          SalesFormsPrefs: {
+            AutoApplyCredit: Boolean(this.options.autoApplyCredits),
+            CustomTxnNumbers: true
+          }
+        }) as any,
+      findCustomerByDisplayName: async (displayName) => {
+        const found = this.findActiveCustomerByName(displayName);
+        return found ? { externalId: found.Id, name: found.DisplayName, syncToken: found.SyncToken } : null;
+      },
+      createOrUpdateCustomer: async (payload) => {
+        const existing = this.findActiveCustomerByName(payload.name);
+        if (existing) {
+          return { externalId: existing.Id, name: existing.DisplayName };
+        }
+        const created = this.createEntity('Customer', {
+          DisplayName: payload.name,
+          PrimaryEmailAddr: payload.primaryEmail ? { Address: payload.primaryEmail } : undefined
+        });
+        return { externalId: created.Id, name: created.DisplayName };
+      },
+      voidInvoice: async (id, syncToken) => this.voidInvoice(id, syncToken),
+      deleteCreditMemo: async (id, syncToken) => this.deleteEntity('CreditMemo', id, syncToken)
+    };
+  }
+
+  // ── Time & journal ────────────────────────────────────────────────────────
+
+  /** Current simulator time; use as the `since` cursor between test phases. */
+  now(): string {
+    return new Date(this.clockMs).toISOString();
+  }
+
+  private tick(): string {
+    this.clockMs += 1000;
+    return this.now();
+  }
+
+  private journalChange(entityType: string, externalId: string, deleted = false): void {
+    this.journal.push({ entityType, externalId, deleted, at: this.tick() });
+  }
+
+  // ── Entity CRUD with QBO semantics ────────────────────────────────────────
+
+  private getStore(entityType: string): Map<string, QboSimEntity> {
+    const store = this.stores[entityType as SimEntityType];
+    if (!store) {
+      throw new QboSimError('SIM_UNSUPPORTED', `QboSimulator does not model entity type ${entityType}`);
+    }
+    return store;
+  }
+
+  private allocateId(entityType: SimEntityType): string {
+    return `${entityType.toLowerCase()}-${this.nextId++}`;
+  }
+
+  private assertFreshToken(entity: QboSimEntity, syncToken: string): void {
+    if (entity.SyncToken !== String(syncToken)) {
+      throw new QboSimError(
+        '5010',
+        `Stale Object Error: You and ${entity.Id} were working on this at the same time — supplied SyncToken ${syncToken}, current ${entity.SyncToken}`
+      );
+    }
+  }
+
+  private createEntity(entityType: string, data: any): QboSimEntity {
+    const type = entityType as SimEntityType;
+    switch (type) {
+      case 'Customer':
+        return this.createCustomer(data);
+      case 'Invoice':
+        return this.createTransactionDocument('Invoice', data);
+      case 'CreditMemo':
+        return this.createTransactionDocument('CreditMemo', data);
+      case 'Payment':
+        return this.createPayment(data);
+      default:
+        throw new QboSimError('SIM_UNSUPPORTED', `QboSimulator cannot create entity type ${entityType}`);
+    }
+  }
+
+  private createCustomer(data: any): QboSimEntity {
+    const displayName = String(data.DisplayName ?? '').trim();
+    if (!displayName) {
+      throw new QboSimError('2020', 'Required parameter DisplayName is missing');
+    }
+    // QBO enforces name uniqueness across active AND inactive customers.
+    for (const customer of this.stores.Customer.values()) {
+      if (customer.DisplayName === displayName) {
+        throw new QboSimError(
+          '6240',
+          `Duplicate Name Exists Error: The name supplied (${displayName}) already exists`
+        );
+      }
+    }
+    const entity: QboSimEntity = {
+      Id: this.allocateId('Customer'),
+      SyncToken: '0',
+      DisplayName: displayName,
+      Active: data.Active !== false,
+      ...(data.PrimaryEmailAddr ? { PrimaryEmailAddr: data.PrimaryEmailAddr } : {})
+    };
+    this.stores.Customer.set(entity.Id, entity);
+    this.journalChange('Customer', entity.Id);
+    return entity;
+  }
+
+  private sumSalesLines(lines: any[]): number {
+    return (Array.isArray(lines) ? lines : [])
+      .filter((line) => line?.DetailType !== 'SubTotalLineDetail')
+      .reduce((sum, line) => sum + toCents(line?.Amount), 0);
+  }
+
+  private createTransactionDocument(type: 'Invoice' | 'CreditMemo', data: any): QboSimEntity {
+    const lines = Array.isArray(data.Line) ? data.Line : [];
+    // QBO computes the total from lines; the caller's TotalAmt is not trusted.
+    const totalCents = this.sumSalesLines(lines) + (type === 'Invoice' ? (this.options.taxAdjustmentCents ?? 0) : 0);
+    const entity: QboSimEntity = {
+      Id: this.allocateId(type),
+      SyncToken: '0',
+      ...data,
+      Line: lines,
+      TotalAmt: toAmount(totalCents),
+      Balance: toAmount(totalCents),
+      TxnDate: data.TxnDate ?? this.now().slice(0, 10)
+    };
+    this.getStore(type).set(entity.Id, entity);
+    this.journalChange(type, entity.Id);
+
+    if (type === 'Invoice' && this.options.autoApplyCredits) {
+      this.autoApplyOpenCredits(entity);
+    }
+    return entity;
+  }
+
+  private createPayment(data: any): QboSimEntity {
+    const lines = Array.isArray(data.Line) ? data.Line : [];
+    for (const line of lines) {
+      const linked = Array.isArray(line?.LinkedTxn) ? line.LinkedTxn : [];
+      for (const txn of linked) {
+        this.applyPaymentAllocation(String(txn?.TxnType), String(txn?.TxnId), toCents(line?.Amount));
+      }
+    }
+    const entity: QboSimEntity = {
+      Id: this.allocateId('Payment'),
+      SyncToken: '0',
+      ...data,
+      Line: lines,
+      TotalAmt: Number(data.TotalAmt ?? 0),
+      TxnDate: data.TxnDate ?? this.now().slice(0, 10)
+    };
+    this.stores.Payment.set(entity.Id, entity);
+    this.journalChange('Payment', entity.Id);
+    return entity;
+  }
+
+  private applyPaymentAllocation(txnType: string, txnId: string, amountCents: number): void {
+    if (txnType !== 'Invoice' && txnType !== 'CreditMemo') {
+      return;
+    }
+    const target = this.getStore(txnType).get(txnId);
+    if (!target) {
+      throw new QboSimError('610', `Object Not Found: ${txnType} ${txnId}`);
+    }
+    const remaining = toCents(target.Balance) - amountCents;
+    if (remaining < 0) {
+      throw new QboSimError(
+        '6210',
+        `Amount received (${toAmount(amountCents)}) exceeds open balance on ${txnType} ${txnId}`
+      );
+    }
+    target.Balance = toAmount(remaining);
+    // Balance movement bumps the token and journals a change, like real QBO.
+    target.SyncToken = String(Number(target.SyncToken) + 1);
+    this.journalChange(txnType, target.Id);
+  }
+
+  /** QBO's AutoApplyCredit: consume open customer credit against a new invoice. */
+  private autoApplyOpenCredits(invoice: QboSimEntity): void {
+    const customerId = invoice.CustomerRef?.value;
+    if (!customerId) {
+      return;
+    }
+    for (const cm of this.stores.CreditMemo.values()) {
+      if (cm.deleted || cm.CustomerRef?.value !== customerId) {
+        continue;
+      }
+      const cmBalance = toCents(cm.Balance);
+      const invoiceBalance = toCents(invoice.Balance);
+      if (cmBalance <= 0 || invoiceBalance <= 0) {
+        continue;
+      }
+      const applied = Math.min(cmBalance, invoiceBalance);
+      this.createPayment({
+        CustomerRef: { value: customerId },
+        TotalAmt: 0,
+        PrivateNote: 'Automatically applied credit',
+        Line: [
+          { Amount: toAmount(applied), LinkedTxn: [{ TxnType: 'Invoice', TxnId: invoice.Id }] },
+          { Amount: toAmount(applied), LinkedTxn: [{ TxnType: 'CreditMemo', TxnId: cm.Id }] }
+        ]
+      });
+    }
+  }
+
+  private updateEntity(entityType: string, data: { Id: string; SyncToken: string; [key: string]: any }): QboSimEntity {
+    const store = this.getStore(entityType);
+    const entity = store.get(String(data.Id));
+    if (!entity || entity.deleted) {
+      throw new QboSimError('610', `Object Not Found: ${entityType} ${data.Id}`);
+    }
+    this.assertFreshToken(entity, data.SyncToken);
+
+    const { Id: _id, SyncToken: _token, ...sparse } = data;
+    Object.assign(entity, sparse);
+    if (sparse.Line && (entityType === 'Invoice' || entityType === 'CreditMemo')) {
+      const totalCents = this.sumSalesLines(sparse.Line);
+      entity.TotalAmt = toAmount(totalCents);
+      // Sparse updates reset the open balance like QBO recalculating the doc.
+      entity.Balance = toAmount(totalCents);
+    }
+    entity.SyncToken = String(Number(entity.SyncToken) + 1);
+    this.journalChange(entityType, entity.Id);
+    return entity;
+  }
+
+  private voidInvoice(id: string, syncToken: string): QboSimEntity {
+    const entity = this.stores.Invoice.get(id);
+    if (!entity || entity.deleted) {
+      throw new QboSimError('610', `Object Not Found: Invoice ${id}`);
+    }
+    this.assertFreshToken(entity, syncToken);
+    // QBO voids keep the document with zeroed amounts and a "Voided" note.
+    entity.TotalAmt = 0;
+    entity.Balance = 0;
+    entity.PrivateNote = entity.PrivateNote ? `${entity.PrivateNote} Voided` : 'Voided';
+    entity.SyncToken = String(Number(entity.SyncToken) + 1);
+    this.journalChange('Invoice', entity.Id);
+    return entity;
+  }
+
+  private deleteEntity(entityType: string, id: string, syncToken: string): { Id: string; status: string } {
+    const store = this.getStore(entityType);
+    const entity = store.get(id);
+    if (!entity || entity.deleted) {
+      throw new QboSimError('610', `Object Not Found: ${entityType} ${id}`);
+    }
+    this.assertFreshToken(entity, syncToken);
+    entity.deleted = true;
+    this.journalChange(entityType, entity.Id, true);
+    return { Id: id, status: 'Deleted' };
+  }
+
+  // ── Query & CDC ───────────────────────────────────────────────────────────
+
+  private findActiveCustomerByName(displayName: string): QboSimEntity | null {
+    for (const customer of this.stores.Customer.values()) {
+      if (customer.Active && customer.DisplayName === displayName) {
+        return customer;
+      }
+    }
+    return null;
+  }
+
+  private runQuery(selectQuery: string): any[] {
+    // Support the one query shape the integration issues. Anything else is a
+    // loud failure so a new query gets modeled deliberately, not silently.
+    const customerByName = selectQuery.match(/FROM\s+Customer\s+WHERE\s+DisplayName\s*=\s*'((?:[^']|'')*)'/i);
+    if (customerByName) {
+      const name = customerByName[1].replace(/''/g, "'");
+      // QBO queries return ACTIVE rows only unless Active is filtered explicitly.
+      const found = this.findActiveCustomerByName(name);
+      return found ? [{ ...found }] : [];
+    }
+    throw new QboSimError('SIM_UNSUPPORTED', `QboSimulator does not model query: ${selectQuery}`);
+  }
+
+  private fetchChanges(since: string) {
+    const sinceMs = Date.parse(since);
+    // Latest journal entry per entity wins, replayed in change order.
+    const latest = new Map<string, ChangeJournalEntry>();
+    for (const entry of this.journal) {
+      if (Date.parse(entry.at) > sinceMs) {
+        latest.set(`${entry.entityType}:${entry.externalId}`, entry);
+      }
+    }
+    const changes = Array.from(latest.values())
+      .sort((a, b) => a.at.localeCompare(b.at))
+      .map((entry) => {
+        const entity = this.getStore(entry.entityType).get(entry.externalId);
+        return {
+          entityType: entry.entityType,
+          externalId: entry.externalId,
+          syncToken: entity?.SyncToken,
+          deleted: entry.deleted,
+          payload: entry.deleted ? {} : { ...entity }
+        };
+      });
+    return { changes, truncated: false, fetchedAt: this.tick() };
+  }
+
+  // ── Test seeding helpers ──────────────────────────────────────────────────
+
+  seedCustomer(params: { name: string; active?: boolean }): QboSimEntity {
+    const entity = this.createCustomer({ DisplayName: params.name, Active: params.active !== false });
+    if (params.active === false) {
+      entity.Active = false;
+    }
+    return entity;
+  }
+
+  seedInvoice(params: { customerId: string; amountCents: number; docNumber?: string }): QboSimEntity {
+    return this.createEntity('Invoice', {
+      CustomerRef: { value: params.customerId },
+      DocNumber: params.docNumber,
+      Line: [
+        {
+          DetailType: 'SalesItemLineDetail',
+          Amount: toAmount(params.amountCents),
+          SalesItemLineDetail: { ItemRef: { value: 'item-sim' } }
+        }
+      ]
+    });
+  }
+
+  seedCreditMemo(params: { customerId: string; amountCents: number; docNumber?: string }): QboSimEntity {
+    return this.createEntity('CreditMemo', {
+      CustomerRef: { value: params.customerId },
+      DocNumber: params.docNumber,
+      Line: [
+        {
+          DetailType: 'SalesItemLineDetail',
+          Amount: toAmount(params.amountCents),
+          SalesItemLineDetail: { ItemRef: { value: 'item-sim' } }
+        }
+      ]
+    });
+  }
+
+  /** A bookkeeper (or QBO auto-apply) applying credit to an invoice inside QBO. */
+  applyCreditInQbo(params: { creditMemoId: string; invoiceId: string; amountCents: number }): QboSimEntity {
+    const cm = this.stores.CreditMemo.get(params.creditMemoId);
+    const invoice = this.stores.Invoice.get(params.invoiceId);
+    if (!cm || !invoice) {
+      throw new QboSimError('610', 'Object Not Found: credit application target');
+    }
+    return this.createPayment({
+      CustomerRef: invoice.CustomerRef,
+      TotalAmt: 0,
+      Line: [
+        { Amount: toAmount(params.amountCents), LinkedTxn: [{ TxnType: 'Invoice', TxnId: params.invoiceId }] },
+        { Amount: toAmount(params.amountCents), LinkedTxn: [{ TxnType: 'CreditMemo', TxnId: params.creditMemoId }] }
+      ]
+    });
+  }
+
+  /** A customer payment (check, card) received against an invoice inside QBO. */
+  receivePaymentInQbo(params: {
+    invoiceId: string;
+    amountCents: number;
+    referenceNumber?: string;
+    txnDate?: string;
+  }): QboSimEntity {
+    const invoice = this.stores.Invoice.get(params.invoiceId);
+    if (!invoice) {
+      throw new QboSimError('610', `Object Not Found: Invoice ${params.invoiceId}`);
+    }
+    return this.createPayment({
+      CustomerRef: invoice.CustomerRef,
+      TotalAmt: toAmount(params.amountCents),
+      PaymentRefNum: params.referenceNumber,
+      TxnDate: params.txnDate,
+      Line: [
+        { Amount: toAmount(params.amountCents), LinkedTxn: [{ TxnType: 'Invoice', TxnId: params.invoiceId }] }
+      ]
+    });
+  }
+
+  entities(entityType: string): QboSimEntity[] {
+    return Array.from(this.getStore(entityType).values());
+  }
+}

--- a/packages/integrations/src/lib/qbo/qboClientService.ts
+++ b/packages/integrations/src/lib/qbo/qboClientService.ts
@@ -302,6 +302,13 @@ export async function upsertStoredQboCredentials(tenantId: string, credentials: 
   await notifyQboConnectionChanged(tenantId);
 }
 
+/**
+ * Testing note: don't mock this class method-by-method for multi-step tests.
+ * A stateful in-memory QBO implementing this surface (SyncTokens, duplicate
+ * names, balances, CDC replay) lives at
+ * packages/billing/src/services/accountingSync/testing/qboSimulator.ts —
+ * see the README next to it for wiring.
+ */
 export class QboClientService {
   private tenantId: string;
   private realmId: string;

--- a/server/public/locales/de/msp/integrations.json
+++ b/server/public/locales/de/msp/integrations.json
@@ -1348,6 +1348,8 @@
         "refreshTokenExpiry": "QuickBooks-Token läuft am {{date}} ab",
         "refreshTokenExpired": "QuickBooks-Token abgelaufen — erneut verbinden, um die Synchronisierung fortzusetzen.",
         "autoSyncLabel": "Automatische Synchronisierung aktiviert",
+        "autoProvisionCustomersLabel": "Create QuickBooks customers automatically",
+        "autoProvisionCustomersHint": "Off: exports for unmapped customers pause with an exception until you link them in the customer mapping screen.",
         "syncNowButton": "Jetzt synchronisieren",
         "syncNowRunning": "Synchronisierung läuft…",
         "syncNowSuccess": "Synchronisierung erfolgreich abgeschlossen.",

--- a/server/public/locales/en/msp/integrations.json
+++ b/server/public/locales/en/msp/integrations.json
@@ -1371,6 +1371,8 @@
         "refreshTokenExpiry": "QuickBooks token expires {{date}}",
         "refreshTokenExpired": "QuickBooks token expired — reconnect to resume syncing.",
         "autoSyncLabel": "Auto-sync enabled",
+        "autoProvisionCustomersLabel": "Create QuickBooks customers automatically",
+        "autoProvisionCustomersHint": "Off: exports for unmapped customers pause with an exception until you link them in the customer mapping screen.",
         "syncNowButton": "Sync Now",
         "syncNowRunning": "Syncing…",
         "syncNowSuccess": "Sync completed successfully.",

--- a/server/public/locales/es/msp/integrations.json
+++ b/server/public/locales/es/msp/integrations.json
@@ -1348,6 +1348,8 @@
         "refreshTokenExpiry": "El token de QuickBooks caduca el {{date}}",
         "refreshTokenExpired": "El token de QuickBooks ha caducado: vuelva a conectarse para reanudar la sincronización.",
         "autoSyncLabel": "Sincronización automática activada",
+        "autoProvisionCustomersLabel": "Create QuickBooks customers automatically",
+        "autoProvisionCustomersHint": "Off: exports for unmapped customers pause with an exception until you link them in the customer mapping screen.",
         "syncNowButton": "Sincronizar ahora",
         "syncNowRunning": "Sincronizando…",
         "syncNowSuccess": "Sincronización completada correctamente.",

--- a/server/public/locales/fr/msp/integrations.json
+++ b/server/public/locales/fr/msp/integrations.json
@@ -1348,6 +1348,8 @@
         "refreshTokenExpiry": "Le jeton QuickBooks expire le {{date}}",
         "refreshTokenExpired": "Jeton QuickBooks expiré — reconnectez-vous pour reprendre la synchronisation.",
         "autoSyncLabel": "Synchronisation automatique activée",
+        "autoProvisionCustomersLabel": "Create QuickBooks customers automatically",
+        "autoProvisionCustomersHint": "Off: exports for unmapped customers pause with an exception until you link them in the customer mapping screen.",
         "syncNowButton": "Synchroniser maintenant",
         "syncNowRunning": "Synchronisation…",
         "syncNowSuccess": "Synchronisation terminée avec succès.",

--- a/server/public/locales/it/msp/integrations.json
+++ b/server/public/locales/it/msp/integrations.json
@@ -1348,6 +1348,8 @@
         "refreshTokenExpiry": "Il token QuickBooks scade il {{date}}",
         "refreshTokenExpired": "Token QuickBooks scaduto: riconnettersi per riprendere la sincronizzazione.",
         "autoSyncLabel": "Sincronizzazione automatica attiva",
+        "autoProvisionCustomersLabel": "Create QuickBooks customers automatically",
+        "autoProvisionCustomersHint": "Off: exports for unmapped customers pause with an exception until you link them in the customer mapping screen.",
         "syncNowButton": "Sincronizza ora",
         "syncNowRunning": "Sincronizzazione in corso…",
         "syncNowSuccess": "Sincronizzazione completata correttamente.",

--- a/server/public/locales/nl/msp/integrations.json
+++ b/server/public/locales/nl/msp/integrations.json
@@ -1348,6 +1348,8 @@
         "refreshTokenExpiry": "QuickBooks-token verloopt op {{date}}",
         "refreshTokenExpired": "QuickBooks-token verlopen — maak opnieuw verbinding om de synchronisatie te hervatten.",
         "autoSyncLabel": "Automatische synchronisatie ingeschakeld",
+        "autoProvisionCustomersLabel": "Create QuickBooks customers automatically",
+        "autoProvisionCustomersHint": "Off: exports for unmapped customers pause with an exception until you link them in the customer mapping screen.",
         "syncNowButton": "Nu synchroniseren",
         "syncNowRunning": "Synchroniseren…",
         "syncNowSuccess": "Synchronisatie voltooid.",

--- a/server/public/locales/pl/msp/integrations.json
+++ b/server/public/locales/pl/msp/integrations.json
@@ -1348,6 +1348,8 @@
         "refreshTokenExpiry": "Token QuickBooks wygasa {{date}}",
         "refreshTokenExpired": "Token QuickBooks wygasł — połącz ponownie, aby wznowić synchronizację.",
         "autoSyncLabel": "Automatyczna synchronizacja włączona",
+        "autoProvisionCustomersLabel": "Create QuickBooks customers automatically",
+        "autoProvisionCustomersHint": "Off: exports for unmapped customers pause with an exception until you link them in the customer mapping screen.",
         "syncNowButton": "Synchronizuj teraz",
         "syncNowRunning": "Synchronizowanie…",
         "syncNowSuccess": "Synchronizacja zakończona pomyślnie.",

--- a/server/public/locales/pt/msp/integrations.json
+++ b/server/public/locales/pt/msp/integrations.json
@@ -1348,6 +1348,8 @@
         "refreshTokenExpiry": "O token QuickBooks expira {{date}}",
         "refreshTokenExpired": "O token QuickBooks expirou – reconecte para retomar a sincronização.",
         "autoSyncLabel": "Sincronização automática ativada",
+        "autoProvisionCustomersLabel": "Create QuickBooks customers automatically",
+        "autoProvisionCustomersHint": "Off: exports for unmapped customers pause with an exception until you link them in the customer mapping screen.",
         "syncNowButton": "Sincronizar agora",
         "syncNowRunning": "Sincronizando…",
         "syncNowSuccess": "Sincronização concluída com sucesso.",

--- a/server/public/locales/xx/msp/integrations.json
+++ b/server/public/locales/xx/msp/integrations.json
@@ -1371,6 +1371,8 @@
         "refreshTokenExpiry": "11111 {{date}} 11111",
         "refreshTokenExpired": "11111",
         "autoSyncLabel": "11111",
+        "autoProvisionCustomersLabel": "11111",
+        "autoProvisionCustomersHint": "11111",
         "syncNowButton": "11111",
         "syncNowRunning": "11111",
         "syncNowSuccess": "11111",

--- a/server/public/locales/yy/msp/integrations.json
+++ b/server/public/locales/yy/msp/integrations.json
@@ -1371,6 +1371,8 @@
         "refreshTokenExpiry": "55555 {{date}} 55555",
         "refreshTokenExpired": "55555",
         "autoSyncLabel": "55555",
+        "autoProvisionCustomersLabel": "55555",
+        "autoProvisionCustomersHint": "55555",
         "syncNowButton": "55555",
         "syncNowRunning": "55555",
         "syncNowSuccess": "55555",

--- a/server/src/test/integration/accounting/auditTrail.integration.test.ts
+++ b/server/src/test/integration/accounting/auditTrail.integration.test.ts
@@ -84,6 +84,7 @@ describe('Accounting export audit trail integration', () => {
     await ctx.db('accounting_export_errors').where({ tenant: ctx.tenantId }).del();
     await ctx.db('accounting_export_lines').where({ tenant: ctx.tenantId }).del();
     await ctx.db('accounting_export_batches').where({ tenant: ctx.tenantId }).del();
+    await ctx.db('tenant_external_entity_mappings').where({ tenant: ctx.tenantId }).del();
     await ctx.db('transactions').where({ tenant: ctx.tenantId }).del();
     await ctx.db('invoice_charges').where({ tenant: ctx.tenantId }).del();
     await ctx.db('invoices').where({ tenant: ctx.tenantId }).del();
@@ -188,6 +189,20 @@ describe('Accounting export audit trail integration', () => {
       alga_entity_type: 'service',
       alga_entity_id: serviceId,
       external_entity_id: 'QB-ITEM-DEFAULT',
+      sync_status: 'synced',
+      created_at: new Date().toISOString(),
+      updated_at: new Date().toISOString()
+    });
+
+    // Map the customer so batch validation passes; this suite exercises the
+    // audit trail, not the customer-provisioning gate.
+    await ctx.db('tenant_external_entity_mappings').insert({
+      id: uuidv4(),
+      tenant: ctx.tenantId,
+      integration_type: 'quickbooks_online',
+      alga_entity_type: 'client',
+      alga_entity_id: ctx.clientId,
+      external_entity_id: 'QB-CUST-DEFAULT',
       sync_status: 'synced',
       created_at: new Date().toISOString(),
       updated_at: new Date().toISOString()

--- a/server/src/test/integration/accounting/batchLifecycle.integration.test.ts
+++ b/server/src/test/integration/accounting/batchLifecycle.integration.test.ts
@@ -157,6 +157,25 @@ describe('Accounting export batch lifecycle integration', () => {
       updated_at: now
     });
 
+    // Map the customer too, so the batch clears validation and reaches
+    // "ready" — this suite exercises the batch lifecycle, not the
+    // customer-provisioning gate. Idempotent: tests may seed several
+    // invoices for the same test client.
+    await ctx.db('tenant_external_entity_mappings')
+      .insert({
+        id: uuidv4(),
+        tenant: ctx.tenantId,
+        integration_type: 'quickbooks_online',
+        alga_entity_type: 'client',
+        alga_entity_id: ctx.clientId,
+        external_entity_id: `QBO-CUST-${uuidv4()}`,
+        sync_status: 'synced',
+        created_at: now,
+        updated_at: now
+      })
+      .onConflict()
+      .ignore();
+
     const invoiceId = uuidv4();
 
     await ctx.db('invoices').insert({

--- a/server/src/test/integration/accounting/validationUnmapped.integration.test.ts
+++ b/server/src/test/integration/accounting/validationUnmapped.integration.test.ts
@@ -93,6 +93,22 @@ describe('Accounting export validation – unmapped services', () => {
       updated_at: new Date().toISOString()
     });
 
+    // Map the customer so batch validation doesn't additionally flag
+    // missing_customer_mapping — this suite exercises service/tax/term/realm
+    // gaps, not the customer-provisioning gate.
+    await ctx.db('tenant_external_entity_mappings').insert({
+      id: uuidv4(),
+      tenant: ctx.tenantId,
+      integration_type: 'quickbooks_online',
+      alga_entity_type: 'client',
+      alga_entity_id: ctx.clientId,
+      external_entity_id: 'QB-CUST-1',
+      external_realm_id: null,
+      sync_status: 'synced',
+      created_at: new Date().toISOString(),
+      updated_at: new Date().toISOString()
+    });
+
     return { serviceId, invoiceId, chargeId };
   }
 

--- a/server/src/test/unit/accounting/quickBooksOnlineAdapter.spec.ts
+++ b/server/src/test/unit/accounting/quickBooksOnlineAdapter.spec.ts
@@ -1065,3 +1065,147 @@ describe('QuickBooksOnlineAdapter class/department transform', () => {
     expect(invoiceHeader.DepartmentRef).toEqual({ value: 'dept-east' });
   });
 });
+
+describe('QuickBooksOnlineAdapter customer auto-provisioning gate', () => {
+  const mockResolver = {
+    resolveServiceMapping: vi.fn(),
+    resolveTaxCodeMapping: vi.fn(),
+    ensureCompanyMapping: vi.fn()
+  };
+
+  const gateLine: MinimalLine = {
+    line_id: 'line-gate-1',
+    batch_id: 'batch-qbo-spec',
+    document_id: INVOICE_ID,
+    document_line_id: 'charge-gate-1',
+    client_id: CLIENT_ID,
+    amount_cents: 10_000,
+    currency_code: 'USD',
+    status: 'ready',
+    payload: null,
+    mapping_resolution: null,
+    service_period_start: null,
+    service_period_end: null,
+    created_at: new Date().toISOString(),
+    updated_at: new Date().toISOString()
+  };
+
+  function spyLoadersWithUnmappedClient(adapter: QuickBooksOnlineAdapter) {
+    vi.spyOn(adapter as any, 'loadInvoices').mockResolvedValue(
+      new Map([
+        [
+          INVOICE_ID,
+          {
+            invoice_id: INVOICE_ID,
+            invoice_number: 'INV-GATE-1',
+            invoice_date: '2026-06-05',
+            due_date: '2026-06-20',
+            total_amount: 10_000,
+            client_id: CLIENT_ID,
+            currency_code: 'USD'
+          }
+        ]
+      ])
+    );
+    vi.spyOn(adapter as any, 'loadCharges').mockResolvedValue(
+      new Map([
+        [
+          'charge-gate-1',
+          {
+            item_id: 'charge-gate-1',
+            invoice_id: INVOICE_ID,
+            service_id: 'svc-gate-1',
+            description: 'Managed services',
+            quantity: 1,
+            unit_price: 10_000,
+            net_amount: 10_000,
+            total_price: 10_000,
+            tax_amount: 0,
+            tax_region: null
+          }
+        ]
+      ])
+    );
+    vi.spyOn(adapter as any, 'loadClients').mockResolvedValue({
+      clients: new Map([
+        [
+          CLIENT_ID,
+          {
+            client_id: CLIENT_ID,
+            client_name: 'Unmapped Newco LLC',
+            billing_email: 'billing@example.com',
+            payment_terms: null
+          }
+        ]
+      ]),
+      // No mapping: this client has never been through the wizard.
+      mappings: new Map()
+    });
+  }
+
+  beforeEach(() => {
+    mockResolver.resolveServiceMapping.mockReset();
+    mockResolver.resolveTaxCodeMapping.mockReset();
+    mockResolver.ensureCompanyMapping.mockReset();
+    getAccountingSyncSettingsMock.mockReset();
+    vi.spyOn(dbModule, 'createTenantKnex').mockResolvedValue({ knex: {} as any, tenant: TENANT_ID });
+    vi.spyOn(AccountingMappingResolver, 'create').mockResolvedValue(
+      mockResolver as unknown as AccountingMappingResolver
+    );
+    mockResolver.resolveServiceMapping.mockResolvedValue({
+      external_entity_id: 'ITEM-QBO-1',
+      metadata: {}
+    });
+    mockResolver.resolveTaxCodeMapping.mockResolvedValue(null);
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('unmapped client with auto-provisioning off (default) → transform refuses to touch the QBO customer list', async () => {
+    getAccountingSyncSettingsMock.mockResolvedValue({
+      autoSyncEnabled: true,
+      autoSyncStartDate: null,
+      autoProvisionCustomers: false,
+      depositAccountRef: null,
+      defaultClassRef: null,
+      defaultDepartmentRef: null,
+      defaultRealm: null
+    });
+
+    const adapter = new QuickBooksOnlineAdapter();
+    spyLoadersWithUnmappedClient(adapter);
+
+    await expect(adapter.transform(buildContext([gateLine]))).rejects.toThrow(
+      /automatic customer creation is disabled/i
+    );
+    expect(mockResolver.ensureCompanyMapping).not.toHaveBeenCalled();
+  });
+
+  it('unmapped client with auto-provisioning explicitly enabled → transform provisions through the resolver', async () => {
+    getAccountingSyncSettingsMock.mockResolvedValue({
+      autoSyncEnabled: true,
+      autoSyncStartDate: null,
+      autoProvisionCustomers: true,
+      depositAccountRef: null,
+      defaultClassRef: null,
+      defaultDepartmentRef: null,
+      defaultRealm: null
+    });
+    mockResolver.ensureCompanyMapping.mockResolvedValue({
+      external_entity_id: 'qb-customer-new',
+      metadata: {}
+    });
+
+    const adapter = new QuickBooksOnlineAdapter();
+    spyLoadersWithUnmappedClient(adapter);
+
+    const result = await adapter.transform(buildContext([gateLine]));
+
+    expect(mockResolver.ensureCompanyMapping).toHaveBeenCalledWith(
+      expect.objectContaining({ companyId: CLIENT_ID })
+    );
+    expect((result.documents[0].payload as any).invoice.CustomerRef).toEqual({ value: 'qb-customer-new' });
+  });
+});


### PR DESCRIPTION
Tracking ticket: **alga0002097** (PSA development board).

Forward-port of the QuickBooks Online accounting-sync safety work onto current `main`. Reimplemented rather than rebased: the source branch was ~1,200 commits behind and `main` had independently rewritten the same hot files, so this applies only the genuinely-new behavior on top of main's current code (deduped against what main already evolved).

## Behavior
- **Finalize-time export-readiness gate** (`exportReadiness.ts`): block finalize when an invoice would deterministically fail QBO export (serviceless line, unmapped service), failing in-screen instead of the sync exception inbox.
- **Document-date cutoff**: auto-export fences by the invoice's document date, not wall-clock, so unfinalize → re-finalize can't export pre-go-live history.
- **Unfinalize guard** (`invoiceExportGuards.ts`): a document posted to accounting stays posted.
- **Credit application applier**: surface prepayment-sourced (can-never-map) and week-stalled ops as exceptions instead of pending silently.
- **Payment applier**: pass QBO `TxnDate` through as the payment date (month-boundary correctness); label credit-memo-linked payments honestly.
- **Customer auto-provisioning off by default**: unmapped customers fail batch validation; the delivery path refuses to write to the QBO customer list from a background job (settings + validation + adapter defense-in-depth).

## Testing
- Stateful in-memory QBO simulator (SyncTokens, duplicate names, balances, CDC replay, auto-apply races) plus scenario/contract suites.
- Full billing package typecheck clean; all affected vitest suites green locally.