### PR TITLE
Portal domain protocol issue

### DIFF
--- a/docs/plans/2026-07-12-portal-domain-protocol-plan.md
+++ b/docs/plans/2026-07-12-portal-domain-protocol-plan.md
@@ -1,0 +1,213 @@
+# Portal domain protocol fix — implementation plan (2026-07-12)
+
+## Problem
+
+On premise/appliance deployments, requests to a vanity portal domain traverse two
+proxy hops (the portal-domain ingress in front of the main ingress). Each hop
+appends to `X-Forwarded-Proto` / `X-Forwarded-Host`, so the headers arrive
+comma-joined (`"https, https"`). The root layout's `generateMetadata`
+(`server/src/app/layout.tsx:45-51`) feeds the raw values into
+`new URL(`${proto}://${host}`)`, which throws:
+
+```
+TypeError: Invalid URL
+  code: 'ERR_INVALID_URL',
+  input: 'https, https://portal.digitalstrength.co.uk'
+```
+
+Because this is the root layout, every page render on the vanity domain 500s,
+while the canonical host (one proxy hop, un-joined header) works fine.
+
+A fourth site, `server/src/app/auth/client-portal/handoff/page.tsx:38`, splits
+raw `x-forwarded-host` on `:` but never on `,` — with a doubled header the
+tenant-locale lookup receives `"portal.x, portal.x"` and silently fails (soft
+failure, wrong/missing locale).
+
+Two sites already parse correctly by hand
+(`server/src/middleware/express/authMiddleware.ts:57-58`,
+`server/src/app/api/client-portal/domain-session/route.ts:232-234`) — the same
+shape written repeatedly, i.e. a missing layer.
+
+## Approach (approved in design session)
+
+Extend the existing edge-safe forwarded-header layer,
+`server/src/lib/deployment/requestHost.ts`, with proto/origin helpers, and
+migrate all four call sites onto it. Two trust decisions were made explicitly:
+
+- **Host is caps-gated.** `X-Forwarded-Host` is honored only when
+  `caps.trustForwardedHost` is true (appliance profile), matching the existing
+  `resolveRequestHost` semantics. This *changes hosted behavior* in the layout:
+  hosted `metadataBase` comes from the `Host` header only — closing a
+  host-injection hole. Hosted ingress preserves `Host`, so real traffic is
+  unaffected.
+- **Proto is parsed in all profiles.** Every deployment terminates TLS at a
+  proxy; a spoofed proto is low-risk (wrong scheme in the requester's own
+  response at worst). First comma-token, trimmed, lowercased, validated.
+
+## Step 1 — helpers in `server/src/lib/deployment/requestHost.ts`
+
+Add two functions (same edge-safe, dependency-free style as the file's existing
+exports, with doc comments matching the file's voice):
+
+```ts
+/** First comma-token of X-Forwarded-Proto, trimmed + lowercased. Returns null
+ *  when the header is absent or the token is not a plausible URL scheme, so
+ *  callers keep their own fallbacks. Parsed in all deployment profiles. */
+export function resolveRequestProto(
+  request: { headers: { get(name: string): string | null } }
+): string | null
+```
+
+- Take `x-forwarded-proto`, `split(',')[0].trim().toLowerCase()`.
+- Validate against `/^[a-z][a-z0-9+.-]*$/` (URL scheme grammar); return `null`
+  on absent header, empty token, or validation failure. This guarantees the
+  value can never make `new URL()` throw.
+
+```ts
+/** Effective request origin as a URL. Host follows resolveRequestHost
+ *  (caps-gated X-Forwarded-Host); proto follows resolveRequestProto with the
+ *  caller-supplied fallback. Never throws on any header input. */
+export function resolveRequestOrigin(
+  request: { headers: { get(name: string): string | null } },
+  caps: DeploymentCapabilities,
+  options: { fallbackProto: string; fallbackHost: string }
+): URL
+```
+
+- Host: `resolveRequestHost(request, caps).hostHeader`, falling back to
+  `options.fallbackHost` when empty (layout needs `localhost:3010`).
+- Proto: `resolveRequestProto(request) ?? options.fallbackProto`.
+- Construct `new URL(`${proto}://${host}`)`. The host header could still in
+  principle contain URL-hostile characters, so wrap the construction in a
+  try/catch that falls back to
+  `new URL(`${options.fallbackProto}://${options.fallbackHost}`)` — the
+  never-throws guarantee is the point of the helper.
+
+## Step 2 — `server/src/app/layout.tsx` (the crash fix)
+
+Replace lines 45–51's raw header parsing:
+
+```ts
+const headersList = await headers();
+const caps = resolveDeploymentCapabilities();
+const rawHost = headersList.get('x-forwarded-host') || headersList.get('host') || '';
+const metadataBase = resolveRequestOrigin(headersList-as-request, caps, {
+  fallbackHost: 'localhost:3010',
+  fallbackProto: rawHost.includes('localhost') ? 'http' : 'https',
+});
+```
+
+Notes:
+- `headers()` returns a `Headers`-like object that already satisfies the
+  `{ headers: { get } }` shape via a tiny inline wrapper:
+  `{ headers: headersList }`.
+- Preserve the existing fallback heuristic (`localhost → http`, else `https`)
+  for the proto fallback. Base the heuristic on the *resolved* host
+  (`resolveRequestHost(...).hostHeader || 'localhost:3010'`) rather than the
+  old unconditional-XFH host, so the heuristic and the URL agree.
+- Import `resolveDeploymentCapabilities` from
+  `@/lib/deployment/deploymentProfile` and the helpers from
+  `@/lib/deployment/requestHost` (check the file's existing import aliasing —
+  layout.tsx uses `@/` for app-local imports).
+
+## Step 3 — `server/src/app/auth/client-portal/handoff/page.tsx`
+
+In `resolveLocale()` (lines 36–48), replace the hand-rolled
+`(xfh || host).split(':')[0]` with:
+
+```ts
+const caps = resolveDeploymentCapabilities();
+const { hostname } = resolveRequestHost({ headers: headersList }, caps);
+```
+
+and pass `hostname` to `getTenantLocaleByDomain`. Keep the existing
+empty-host → `null` early return and the try/catch.
+
+Note this is also a trust-model change on hosted (XFH no longer honored) —
+intended, per the design decision.
+
+## Step 4 — `server/src/app/api/client-portal/domain-session/route.ts`
+
+Lines 232–234: replace the inline proto parsing with
+
+```ts
+const requestScheme =
+  resolveRequestProto(request) ?? requestUrl.protocol.replace(/:$/, '');
+```
+
+Behavior-identical (the route already took the first comma token); this just
+moves it onto the shared layer.
+
+## Step 5 — `server/src/middleware/express/authMiddleware.ts`
+
+`getRequestOrigin` (lines 56–62): Express headers are a plain record, so adapt:
+
+```ts
+const headerAdapter = {
+  headers: {
+    get: (name: string) => {
+      const v = req.headers[name.toLowerCase()];
+      return Array.isArray(v) ? v[0] ?? null : v ?? null;
+    },
+  },
+};
+const caps = resolveDeploymentCapabilities();
+const { hostHeader } = resolveRequestHost(headerAdapter, caps);
+const protocol = resolveRequestProto(headerAdapter) ?? req.protocol ?? 'http';
+const host = hostHeader || 'localhost';
+return `${protocol}://${host}`;
+```
+
+**Deliberate behavior change:** the old code preferred `Host` over XFH; the
+helper prefers XFH when trusted (appliance — where the proxy rewrites `Host`,
+so this is a correction) and ignores XFH when not (hosted — where the old code
+only used XFH as a fallback when `Host` was missing, a case that effectively
+doesn't occur). `NEXTAUTH_URL` still short-circuits callers when set.
+
+If the adapter shape gets reused a third time, extract it — but two sites
+(this file only, today) does not yet earn a layer.
+
+## Step 6 — tests
+
+Extend `server/src/test/unit/resolveRequestHost.test.ts` (or a sibling
+`requestOrigin.test.ts` in the same directory if the existing file's scope
+reads wrong for proto tests):
+
+- `resolveRequestProto`: absent header → null; `"https"` → `https`;
+  `"https, https"` → `https`; `"HTTPS , http"` → `https`; garbage
+  (`"foo bar"`, `""`, `" , https"`) → null.
+- `resolveRequestOrigin`: the exact production repro — caps =
+  appliance, `x-forwarded-proto: "https, https"`,
+  `x-forwarded-host: "portal.digitalstrength.co.uk, portal.digitalstrength.co.uk"`
+  → `https://portal.digitalstrength.co.uk/` and **does not throw**.
+- Caps gating: hosted profile ignores XFH for the origin host; appliance
+  honors it.
+- Fallbacks: no forwarded headers → fallbackProto/fallbackHost used;
+  URL-hostile host header → falls back rather than throwing.
+
+Run the touched suites plus the existing forwarded-host ones:
+
+```
+cd server && npx vitest run src/test/unit/resolveRequestHost.test.ts \
+  src/test/unit/forwardedHostRewrite.test.ts \
+  src/test/unit/middleware.vanityClientPortalRedirect.test.ts \
+  src/test/unit/portalDomainSessionOtt.test.ts
+```
+
+## Step 7 — verification (live)
+
+The wired dev stack for this worktree serves http://localhost:3019.
+
+1. Baseline repro: `curl -sS -o /dev/null -w '%{http_code}' http://localhost:3019/auth/signin -H 'x-forwarded-proto: https, https' -H 'x-forwarded-host: portal.example.test, portal.example.test'` — before the fix this 500s (root layout throws); after the fix it must return the normal status (307/200).
+2. Confirm no regression on plain requests: same curl without the doubled
+   headers.
+3. `cd server && NODE_OPTIONS=--max-old-space-size=24576 npx tsc --noEmit`
+   (full-repo tsc needs the big heap).
+
+## Out of scope
+
+- The `ReadableStream is already closed` exceptions and the
+  "consumer group already exists" log chatter seen alongside the production
+  error — separate symptoms, not touched here.
+- Fixing header duplication at the ingress/proxy layer — the app must be
+  robust to comma-joined forwarded headers regardless.

--- a/server/src/app/api/client-portal/domain-session/route.ts
+++ b/server/src/app/api/client-portal/domain-session/route.ts
@@ -8,6 +8,7 @@ import { analytics } from 'server/src/lib/analytics/posthog';
 import { buildSessionCookie, encodePortalSessionToken } from '@alga-psa/auth';
 import { consumePortalDomainOtt } from '@alga-psa/auth';
 import { getPortalDomainByHostname, normalizeHostname } from 'server/src/models/PortalDomainModel';
+import { resolveRequestProto } from '@/lib/deployment/requestHost';
 
 function sanitizeReturnPath(returnPath: unknown, fallback: string): string {
   if (typeof returnPath !== 'string' || returnPath.length === 0) {
@@ -229,9 +230,8 @@ export async function POST(request: Request): Promise<Response> {
     const userSnapshot = ottRecord.metadata.userSnapshot;
     const sessionToken = await encodePortalSessionToken(userSnapshot);
     const sessionCookie = buildSessionCookie(sessionToken);
-    const forwardedProto = request.headers.get('x-forwarded-proto');
     const requestUrl = new URL(request.url);
-    const requestScheme = forwardedProto?.split(',')[0]?.trim().toLowerCase() ?? requestUrl.protocol.replace(/:$/, '');
+    const requestScheme = resolveRequestProto(request) ?? requestUrl.protocol.replace(/:$/, '');
     const redirectTo = sanitizeReturnPath(
       requestedReturnPath ?? ottRecord.metadata.returnPath,
       '/client-portal/dashboard',

--- a/server/src/app/auth/client-portal/handoff/page.tsx
+++ b/server/src/app/auth/client-portal/handoff/page.tsx
@@ -3,6 +3,8 @@ import { PortalSessionHandoff } from '@alga-psa/auth/client';
 import { I18nWrapper } from '@alga-psa/tenancy/components';
 import { getTenantLocaleByDomain } from '@alga-psa/tenancy/actions';
 import type { Metadata } from 'next';
+import { resolveDeploymentCapabilities } from '@/lib/deployment/deploymentProfile';
+import { resolveRequestHost } from '@/lib/deployment/requestHost';
 
 export const metadata: Metadata = {
   title: 'Signing In',
@@ -35,12 +37,12 @@ async function resolveLocale() {
   // which double-fires the single-use OTT exchange.
   try {
     const headersList = await headers();
-    const host = (headersList.get('x-forwarded-host') || headersList.get('host') || '')
-      .split(':')[0];
-    if (!host) {
+    const caps = resolveDeploymentCapabilities();
+    const { hostname } = resolveRequestHost({ headers: headersList }, caps);
+    if (!hostname) {
       return null;
     }
-    return await getTenantLocaleByDomain(host);
+    return await getTenantLocaleByDomain(hostname);
   } catch (error) {
     console.warn('Failed to resolve locale for client portal handoff', error);
     return null;

--- a/server/src/app/layout.tsx
+++ b/server/src/app/layout.tsx
@@ -16,6 +16,8 @@ import { ClientUIStateProvider } from '@alga-psa/ui/ui-reflection/ClientUIStateP
 import { getServerLocale } from "@alga-psa/ui/lib/i18n/serverOnly";
 import { cookies, headers } from 'next/headers.js';
 import { generateBrandingStyles } from "@alga-psa/tenancy";
+import { resolveDeploymentCapabilities } from '@/lib/deployment/deploymentProfile';
+import { resolveRequestHost, resolveRequestOrigin } from '@/lib/deployment/requestHost';
 import '@mantine/core/styles.css';
 import 'reactflow/dist/style.css';
 // Loaded last so the Inter font-token overrides win over Mantine/Radix defaults.
@@ -44,11 +46,13 @@ export const dynamic = 'force-dynamic';
 
 export async function generateMetadata(): Promise<Metadata> {
   const headersList = await headers();
-  const host = headersList.get('x-forwarded-host') || headersList.get('host') || 'localhost:3010';
-  const proto =
-    headersList.get('x-forwarded-proto') ||
-    (host.includes('localhost') ? 'http' : 'https');
-  const metadataBase = new URL(`${proto}://${host}`);
+  const request = { headers: headersList };
+  const caps = resolveDeploymentCapabilities();
+  const host = resolveRequestHost(request, caps).hostHeader || 'localhost:3010';
+  const metadataBase = resolveRequestOrigin(request, caps, {
+    fallbackHost: 'localhost:3010',
+    fallbackProto: host.includes('localhost') ? 'http' : 'https',
+  });
 
   return {
     metadataBase,

--- a/server/src/lib/deployment/requestHost.ts
+++ b/server/src/lib/deployment/requestHost.ts
@@ -38,6 +38,45 @@ export function resolveRequestHost(
 }
 
 /**
+ * Resolve the effective request protocol from the first X-Forwarded-Proto
+ * entry. Unlike forwarded host handling, protocol parsing applies in every
+ * deployment profile because every supported deployment terminates TLS at a
+ * proxy. Returns null when the header is absent or its first entry is not a
+ * plausible URL scheme, allowing callers to retain their own fallback.
+ *
+ * Edge-safe: pure header reads, no I/O.
+ */
+export function resolveRequestProto(
+  request: { headers: { get(name: string): string | null } }
+): string | null {
+  const proto = request.headers.get('x-forwarded-proto')?.split(',')[0].trim().toLowerCase();
+  return proto && /^[a-z][a-z0-9+.-]*$/.test(proto) ? proto : null;
+}
+
+/**
+ * Resolve the effective request origin. Host trust follows resolveRequestHost;
+ * protocol parsing follows resolveRequestProto. Invalid header input falls back
+ * to the caller-supplied origin instead of throwing.
+ *
+ * Edge-safe: pure header reads and URL parsing, no I/O.
+ */
+export function resolveRequestOrigin(
+  request: { headers: { get(name: string): string | null } },
+  caps: DeploymentCapabilities,
+  options: { fallbackProto: string; fallbackHost: string }
+): URL {
+  const { hostHeader } = resolveRequestHost(request, caps);
+  const host = hostHeader || options.fallbackHost;
+  const proto = resolveRequestProto(request) ?? options.fallbackProto;
+
+  try {
+    return new URL(`${proto}://${host}`);
+  } catch {
+    return new URL(`${options.fallbackProto}://${options.fallbackHost}`);
+  }
+}
+
+/**
  * Best-effort detection of a reverse proxy that rewrites `Host` to the canonical
  * app host while still passing the original host in `X-Forwarded-Host`. We can
  * recover from this (resolveRequestHost prefers XFH), but it's worth surfacing: if

--- a/server/src/middleware/express/authMiddleware.ts
+++ b/server/src/middleware/express/authMiddleware.ts
@@ -4,6 +4,8 @@ import { getToken, decode } from 'next-auth/jwt';
 import { ApiKeyServiceForApi } from '../../lib/services/apiKeyServiceForApi';
 import { getSecretProviderInstance } from '@alga-psa/core/secrets';
 import { getSessionCookieName } from 'server/src/lib/auth/sessionCookies';
+import { resolveDeploymentCapabilities } from '../../lib/deployment/deploymentProfile';
+import { resolveRequestHost, resolveRequestProto } from '../../lib/deployment/requestHost';
 
 /**
  * Constant-time comparison for privileged bypass keys. Using `===` leaks the
@@ -54,10 +56,18 @@ interface AuthenticatedRequest extends Request {
 }
 
 function getRequestOrigin(req: Request): string {
-  const forwardedProto = (req.headers['x-forwarded-proto'] as string)?.split(',')[0]?.trim();
-  const forwardedHost = (req.headers['x-forwarded-host'] as string)?.split(',')[0]?.trim();
-  const protocol = forwardedProto || req.protocol || 'http';
-  const host = req.get('host') || forwardedHost || 'localhost';
+  const headerAdapter = {
+    headers: {
+      get: (name: string) => {
+        const value = req.headers[name.toLowerCase()];
+        return Array.isArray(value) ? value[0] ?? null : value ?? null;
+      },
+    },
+  };
+  const caps = resolveDeploymentCapabilities();
+  const { hostHeader } = resolveRequestHost(headerAdapter, caps);
+  const protocol = resolveRequestProto(headerAdapter) ?? req.protocol ?? 'http';
+  const host = hostHeader || 'localhost';
   return `${protocol}://${host}`;
 }
 

--- a/server/src/test/unit/resolveRequestHost.test.ts
+++ b/server/src/test/unit/resolveRequestHost.test.ts
@@ -1,5 +1,9 @@
 import { describe, it, expect } from 'vitest';
-import { resolveRequestHost } from '@/lib/deployment/requestHost';
+import {
+  resolveRequestHost,
+  resolveRequestOrigin,
+  resolveRequestProto,
+} from '@/lib/deployment/requestHost';
 import type { DeploymentCapabilities } from '@/lib/deployment/deploymentProfile';
 
 const HOSTED: DeploymentCapabilities = { portalDomain: { provisioner: 'temporal' }, trustForwardedHost: false };
@@ -36,5 +40,63 @@ describe('resolveRequestHost', () => {
   it('falls back to Host when trust is on but no X-Forwarded-Host is present', () => {
     const r = resolveRequestHost(req({ host: 'portal.acme.com' }), APPLIANCE);
     expect(r.hostname).toBe('portal.acme.com');
+  });
+});
+
+describe('resolveRequestProto', () => {
+  it.each([
+    [{}, null],
+    [{ 'x-forwarded-proto': 'https' }, 'https'],
+    [{ 'x-forwarded-proto': 'https, https' }, 'https'],
+    [{ 'x-forwarded-proto': 'HTTPS , http' }, 'https'],
+    [{ 'x-forwarded-proto': 'foo bar' }, null],
+    [{ 'x-forwarded-proto': '' }, null],
+    [{ 'x-forwarded-proto': ' , https' }, null],
+  ])('parses %o as %s', (headers, expected) => {
+    expect(resolveRequestProto(req(headers))).toBe(expected);
+  });
+});
+
+describe('resolveRequestOrigin', () => {
+  const fallbacks = { fallbackProto: 'http', fallbackHost: 'localhost:3010' };
+
+  it('handles comma-joined appliance proxy headers without throwing', () => {
+    const origin = resolveRequestOrigin(req({
+      host: 'alga.internal',
+      'x-forwarded-proto': 'https, https',
+      'x-forwarded-host': 'portal.digitalstrength.co.uk, portal.digitalstrength.co.uk',
+    }), APPLIANCE, fallbacks);
+
+    expect(origin.toString()).toBe('https://portal.digitalstrength.co.uk/');
+  });
+
+  it('ignores X-Forwarded-Host for hosted deployments', () => {
+    const origin = resolveRequestOrigin(req({
+      host: 'app.algapsa.com',
+      'x-forwarded-proto': 'https',
+      'x-forwarded-host': 'portal.acme.com',
+    }), HOSTED, fallbacks);
+
+    expect(origin.toString()).toBe('https://app.algapsa.com/');
+  });
+
+  it('honors X-Forwarded-Host for appliance deployments', () => {
+    const origin = resolveRequestOrigin(req({
+      host: 'alga.internal',
+      'x-forwarded-proto': 'https',
+      'x-forwarded-host': 'portal.acme.com',
+    }), APPLIANCE, fallbacks);
+
+    expect(origin.toString()).toBe('https://portal.acme.com/');
+  });
+
+  it('uses caller fallbacks when forwarded headers and Host are absent', () => {
+    expect(resolveRequestOrigin(req({}), HOSTED, fallbacks).toString())
+      .toBe('http://localhost:3010/');
+  });
+
+  it('falls back rather than throwing for a URL-hostile Host header', () => {
+    expect(resolveRequestOrigin(req({ host: 'bad host' }), HOSTED, fallbacks).toString())
+      .toBe('http://localhost:3010/');
   });
 });


### PR DESCRIPTION
## Summary

- Parse comma-joined X-Forwarded-Proto values through shared never-throwing request protocol and origin helpers.
- Keep forwarded-host trust deployment-aware: hosted requests use Host, while appliance requests may prefer X-Forwarded-Host.
- Migrate root metadata, client-portal handoff, domain-session, and Express authentication origin handling to the shared helpers.
- Add focused coverage for doubled, malformed, absent, and deployment-specific forwarded headers.

## Smoke test

PASS — changed root-layout behavior was exercised against the real Next dev server from this worktree on port 3019, with the alga-psa-local-test Postgres, Redis, Hocuspocus, and IMAP containers running. Logged in through the real UI as Glinda Good and reached the MSP Home dashboard.

- Doubled X-Forwarded-Proto: https, https: real sign-in UI rendered, accepted input, SSO discovery returned 200, and the scoped browser window had zero 5xx responses.
- Malformed proto foo bar: sign-in UI rendered through fallback, accepted input, SSO discovery returned 200, and had zero scoped 5xx responses.
- Plain-header regression: sign-in rendered, credential login succeeded, and /msp/dashboard loaded.
- HTTP corroboration: doubled redirect/render returned 307/200; malformed render returned 200; plain redirect/render returned 307/200. Server history contained zero Invalid URL crash signatures.

Evidence: /tmp/alga-smoke-evidence/portal-domain-protocol-20260713-144143

## Fidelity notes

- Used a temporary level-(c) reverse-proxy simulator to inject forwarded-header chains while forwarding everything to the real app. No mocks were used; the simulator was removed afterward and is preserved only with the evidence.
- The database has zero portal_domains rows, so a configured vanity-domain handoff/domain-session/OTT flow was unavailable. Those migrated call sites and appliance-only forwarded-host trust behavior were not validated end-to-end here.
- Creating a new alga-dev browser tab failed with Failed to add tab; the existing browser pane was reused.
- An initial fake-host/origin mismatch correctly triggered Next Server Action CSRF 500s. Retesting with portal.localhost aligned Origin and forwarded host; final scoped flows had zero 5xx events. This was a simulator artifact, not a product regression.
- The worktree was clean after smoke testing, and port 3019 remained live.