### PR TITLE
docs: add author_type to ticket.comment.added webhook payload

### DIFF
--- a/docs/api/api-rate-limiting-and-webhooks.md
+++ b/docs/api/api-rate-limiting-and-webhooks.md
@@ -278,11 +278,14 @@ Every outbound webhook is delivered as JSON:
       "text": "Scheduled onsite visit for 3 PM.",
       "author": "Pat Lee",
       "timestamp": "2026-05-05T14:25:00.000Z",
-      "is_internal": false
+      "is_internal": false,
+      "author_type": "internal"
     }
   }
 }
 ```
+
+`author_type` identifies whether the comment was posted by an MSP agent or by a client through the client portal. Possible values are `"internal"` (an MSP team member wrote the comment), `"client"` (a contact replied via the client portal), or `null` (the author type is unknown, for example on comments created before this field was tracked). Use `author_type` to distinguish client-initiated replies from agent replies without a separate user-record lookup.
 
 Comment payloads never include attachments.
 


### PR DESCRIPTION
## Source PR

- [#2927 fix: expose comment author_type, map contact_id](https://github.com/Nine-Minds/alga-psa/pull/2927)

## Docs edited

| File | Rationale |
|------|-----------|
| `docs/api/api-rate-limiting-and-webhooks.md` | The `ticket.comment.added` example payload now includes `author_type` (`"internal"` / `"client"` / `null`) so that consumers can distinguish MSP agent comments from client-portal replies without a separate user-record lookup. The JSON example was updated and a prose paragraph was added explaining the field's semantics. |

## Needs human review

- **PR #2929 "Test fixes july 13"** — this PR has no body and was titled as a test-fix batch, but it also adds `nav.opportunities` and `settings.tabs.opportunities` i18n keys across all locales, which implies an Opportunities section is now live (or newly visible) in the nav and settings. Without a description of what the Opportunities feature does, no confident documentation copy could be written. Someone familiar with this feature should determine whether new or updated documentation is needed in `docs/` and whether the nm-store `/documentation/` pages need a corresponding entry.

- **`author_type` value set** — the schema declares `author_type` as `z.string().nullable()`. The values `"internal"` and `"client"` are inferred from `user_type` in the users table; please confirm there are no additional values (e.g., `"system"` for automated comments) before this doc goes live.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Jm9xUr2pVHF2WevoFtLwaz)_