### PR TITLE
Use tenantDb shim in seed migration, document rule

### DIFF
--- a/docs/AI_coding_standards.md
+++ b/docs/AI_coding_standards.md
@@ -455,6 +455,19 @@ Run migrations with the migration environment (env) flag.
 
 Every query must be tenant-scoped, including joins. Route queries through the `tenantDb` facade so the tenant predicates are applied structurally; raw SQL (`knex.raw`) must still carry tenant predicates by hand.
 
+**Inside migration files**, get the facade from the local CJS shim, never from the workspace package:
+
+```javascript
+// ✅ CORRECT: the shim ships with the migration tree
+const { tenantDb } = require('./utils/tenantDb.cjs');
+const db = tenantDb(knex, tenantId);
+
+// ❌ WRONG: fails or resolves to a stale dist in migration runners
+const { tenantDb } = await import('@alga-psa/db');
+```
+
+Several environments that run migrations (CI Citus smoke, the integration harness, the prod migration image, the EE combined temp dir) do not load the `@alga-psa/db` ESM package, so `import('@alga-psa/db')` fails with `ERR_MODULE_NOT_FOUND` — or resolves to a stale `dist/` where the export is `undefined` (`tenantDb is not a function`). The shim at `server/migrations/utils/tenantDb.cjs` mirrors the facade's `table()` / `unscoped()` / `tenantJoin()` API and carries its own table registry; if a migration touches a table the shim doesn't know, register it in the shim's metadata in the same change.
+
 ## Local EE migrations
 - Do not physically copy EE migrations into `server/migrations/` locally.
 - Use the temp-dir overlay runner which points Knex at a merged directory via `MIGRATIONS_DIR`.

--- a/docs/architecture/citus-migration-best-practices.md
+++ b/docs/architecture/citus-migration-best-practices.md
@@ -247,6 +247,7 @@ if (isCitus.rows[0]?.is_distributed) {
 Before deploying a migration:
 
 - [ ] Migration is idempotent (can be run multiple times safely)
+- [ ] Data access goes through `require('./utils/tenantDb.cjs')`, never `import('@alga-psa/db')` — migration runners don't build the workspace package
 - [ ] If it distributes a possibly-non-empty table, it calls `truncate_local_data_after_distributing_table()` right after (see Issue 4)
 - [ ] Tested on both PostgreSQL and CitusDB
 - [ ] Large backfills include delays for propagation

--- a/server/migrations/20260713090000_seed_opportunity_workflows.cjs
+++ b/server/migrations/20260713090000_seed_opportunity_workflows.cjs
@@ -92,7 +92,7 @@ function deterministicUuid(namespace, tenantId) {
 }
 
 async function seedWorkflow(knex, tenantId, workflow) {
-  const { tenantDb } = await import('@alga-psa/db');
+  const { tenantDb } = require('./utils/tenantDb.cjs');
   const db = tenantDb(knex, tenantId);
   const workflowId = deterministicUuid(workflow.baseId, tenantId);
   const definition = { ...workflow.definition, id: workflowId };


### PR DESCRIPTION
The opportunity workflow seed migration imported tenantDb via import('@alga-psa/db'), which resolves to a stale dist (or nothing at all) in migration runners, throwing "tenantDb is not a function". Switch it to the self-contained shim at utils/tenantDb.cjs, matching its own up/down hooks, and record the rule in AI_coding_standards and the Citus migration checklist so the next migration doesn't wander down the same rabbit hole.

"Why, sometimes I've imported six impossible modules before breakfast," said the migration, reaching for '@alga-psa/db' — but the Cheshire dist had faded away entirely, leaving only its grin and an undefined export. "If you want tenantDb to *be* a function," remarked the shim at ./utils/tenantDb.cjs, "you must require it from a package that actually exists here. We're all self-contained down here." 🐇🫖✨