### PR TITLE
Xero two way sync test

### DIFF
--- a/docs/plans/2026-07-13-xero-two-way-sync-plan.md
+++ b/docs/plans/2026-07-13-xero-two-way-sync-plan.md
@@ -1,0 +1,101 @@
+# Xero Two-Way Sync — Fix Plan
+
+**Date:** 2026-07-13 (repro executed live in the design session; plan finalized 2026-07-14)
+**Branch:** `test/xero-two-way-sync`
+**Ticket:** alga0002119 — "Xero 2-Way sync investigation" (Augment Technologies / Matt Green)
+
+## Background
+
+Customer report, verbatim: *"How did things go with the Xero 2-way? I've poked the version i can see but not able to get it to pass the Xero 500, not sure if it's actually live yet though."*
+
+The design session **reproduced the journey end-to-end** against a live Xero demo org (Demo Company US) on this worktree's dev stack and catalogued every break. The outbound loop was ultimately driven to **Delivered** — invoices verified inside Xero — but only after clearing six product bugs and several data traps by hand. This plan turns that catalogue into fixes. The customer-facing answer to "is 2-way live?": **outbound invoice export is live (EE); the inbound leg does not exist yet** (Track B scopes it — document only, no inbound code on this branch).
+
+### What the repro proved (all verified live, 2026-07-13/14)
+
+The environment: EE edition, OAuth connect → Demo Company (US) succeeded (tenant-owned credentials via the settings UI), connection `c9c2bbc4-9ad4-43cc-bb9e-0dc14a8233e2`. Batch `70995e4c` (13 lines) reached **Delivered**; invoices INV-001026/23/22/21/19, INV-000951/816/815/814 confirmed in Xero as DRAFT with auto-created contacts and correct totals.
+
+## The Bug Catalogue (fix all of these — Track A)
+
+### Bug 1 — Live Xero mapping UI is dead (tabs render empty, unclickable)
+`XeroLiveMappingManager.tsx:34` passes `defaultTabId="Items / Services"` (a display **label**) but the module ids are `xero-live-service-mappings` / `xero-live-tax-code-mappings`. `CustomTabs` (packages/ui/src/components/CustomTabs.tsx:188) always passes its internal value to `Tabs.Root value=…`, so Radix has no matching trigger → no panel renders, silently. Clicking a tab cannot stick because `AccountingMappingManager`'s effect (AccountingMappingManager.tsx:42-47) recomputes the active tab from the URL param — which `updateURL` writes via raw `history.pushState`, invisible to `useSearchParams` — and snaps state back to the bogus id, which CustomTabs' `defaultTab` effect re-forces into Radix.
+
+**Fix:** pass the real module id as `defaultTabId` (or drop the prop); AND fix the manager/CustomTabs feedback loop so a user-selected tab survives (either make the manager fully controlled via CustomTabs' `value` prop with URL sync through the router, or stop reverting state when the URL param is absent). Add a regression test that renders the manager with a stale/unknown `defaultTabId` and asserts the first tab's panel still renders.
+
+### Bug 2 — Live `xero` missing from the export dialog's adapter list
+`DEFAULT_ADAPTERS` (packages/billing/src/components/billing-dashboard/accounting/AccountingExportsTab.tsx:79-84) offers quickbooks_csv, xero_csv, quickbooks_online, quickbooks_desktop — no `xero`. A connected Xero tenant cannot create a live export batch from the UI at all (the repro had to invoke the React handler directly).
+
+**Fix:** add `{ id: 'xero', label: 'Xero' }`. Consider gating both OAuth adapters on connection state (only show `xero`/`quickbooks_online` when a connection exists), but do not block on that.
+
+### Bug 3 — AppErrors leak as raw 500s throughout the export flow ("the Xero 500")
+Reproduced four distinct raw 500s the customer can hit with ordinary clicks:
+- Create with filters matching an existing batch → `AppError: An export batch already exists for this filter selection` → 500.
+- Execute a 0-line batch → `AppError: ACCOUNTING_EXPORT_EMPTY_BATCH` → 500.
+- Execute a `needs_attention` batch after validation fails → `AppError: … not ready for delivery` → 500.
+- (Pre-migration) schema drift surfaced a raw knex `insert into accounting_export_lines … column "document_id" does not exist` SQL error to the browser.
+
+**Fix:** the export server actions (batch create/execute — wherever `AccountingExportInvoiceSelector.createBatchFromFilters` and `AccountingExportService.executeBatch` are invoked from the UI) must catch `AppError` and return a structured `{ success:false, code, message }` the dialog renders as a friendly inline message/toast — matching the pattern `xeroActions.ts` already uses (lines ~77-100). Sweep the remaining Xero surface (routes under `server/src/app/api/integrations/xero/*`, all `xeroActions.ts` exports, adapter-invoking paths incl. `fetchExternalInvoice`/`onTaxDelegationExport` and `XeroClientService.create`'s `XERO_NOT_CONFIGURED`) for the same guarantee: **no raw 500 reachable from any Xero UI action**. Regression tests per entry point with broken preconditions (no creds, dup filters, empty batch, not-ready state).
+
+### Bug 4 — Live-Xero batches can never resolve realm-scoped mappings
+`createBatchFromFilters` defaults `targetRealm` **only** for `quickbooks_online` (accountingExportInvoiceSelector.ts:299-304); a `xero` batch gets `target_realm=null`. The resolver (accountingMappingResolver.ts `lookupMapping`) then does `whereNull('external_realm_id')` — but the mapping UI writes `external_realm_id = xeroTenantId` (xeroLiveMappingModules.ts `createMapping`). Empirically confirmed: with 7 correct realm-scoped service mappings present, validation still reported `missing_service_mapping` for every service; nulling the realms made it pass.
+
+**Fix:** default a `xero` batch's `target_realm` to the default connected organisation's `xeroTenantId` (mirror the QBO branch; the connection is available via the stored-connections helper used by `XeroIntegrationSettings`). With a realm set, `lookupMapping`'s `realm OR NULL` branch also keeps any legacy null-realm mappings working. `XeroAdapter.deliver` already passes `connectionId = batch.target_realm ?? null` with a first-connection fallback, so delivery keeps working. Add a test: xero batch + realm-scoped mapping resolves.
+
+### Bug 5 — Timezone bug in the service-period readiness check blocks charges with detail periods forever
+`service_period_projection_mismatch` (accountingExportValidation.ts:361): canonical periods come from `invoice_charge_details` timestamptz values (e.g. `2026-05-01T04:00:00Z` — midnight America/New_York) while the export-line snapshot normalizes to UTC date midnight (`2026-05-01T00:00:00Z`). The comparison uses exact ISO strings, so any charge with recurring detail periods fails validation on **every** batch, permanently (reproduced on a fresh batch; introduced with the QBO closed-loop readiness work in `d2baa61e8e`). This affects QBO exports too, not just Xero.
+
+**Fix:** normalize both sides to calendar dates (or a common timezone-stable representation) before comparing, in one shared helper used by both the snapshot writer and the validator. Unit test with a timestamptz fixture at a non-UTC offset.
+
+### Bug 6 — Invoice generation still writes charges with null `net_amount`; one bad charge fails the whole batch
+Charges created 2026-06-11 — months after backfill migration `20260416120000_backfill_invoice_charges_net_amount.cjs` — had `net_amount = NULL` (6 of 17 in the test tenant). `XeroAdapter.transform` throws `XERO_CHARGE_MISSING_NET_AMOUNT` (xeroAdapter.ts:333) which fails the **entire batch** at deliver time (status Failed), after validation had passed.
+
+**Fix (two parts):** (a) find the invoice-generation path that writes charges without `net_amount` and set it at write time (the backfill formula is `total_price - COALESCE(tax_amount,0)`); (b) in the adapter/validation, surface missing `net_amount` as a **per-line validation error** during the readiness pass (like `missing_service_mapping`) instead of a whole-batch hard failure at transform time.
+
+### Bug 7 — Remediation UX traps (lower severity, fix what's cheap)
+- **Fix-data-then-retry is impossible on the same batch:** lines are creation-time snapshots; after repairing data the projection check (rightly) rejects stale snapshots, but the only recovery is cancel + recreate, which nothing tells the user. Either re-snapshot lines on execute of a `needs_attention` batch, or surface "cancel and recreate this batch" guidance in the error UI.
+- **Stale status in the batch list:** after Execute, the table row kept showing `Pending` while the DB said `needs_attention`; the detail dialog also needed manual Refresh. Refetch after execute completes.
+- **Stale Notes:** batch `70995e4c` reached Delivered but still displays the old failure note ("…missing net_amount; run the backfill migration"). Clear/replace notes on successful delivery.
+- **Draft leakage into filtered exports:** with `statuses=sent,paid`, a `draft` invoice with `tax_source=pending_external` is still selected (deliberate tax-delegation branch, accountingExportInvoiceSelector.ts:148-153). If intended, label these lines in the preview/errors so operators aren't confused about "where did this draft come from".
+
+## Environment / ops findings (not code, but record them)
+
+- The original dev-DB 500 was **migration skew**: code inserting `document_id`/`document_line_id` (renamed 2026-07-10) against a DB 42 migrations behind. The same class of skew in hosted would produce exactly Matt's 500 — worth checking the hosted deploy pipeline orders migrations before code for the July 10 release.
+- Dev DB was reconciled during the session (5 inventory migrations ledger-stamped after verifying tables existed; 36 applied). Repro data repairs made to the test tenant: 7 xero service mappings (realms nulled as the Bug 4 workaround — **revert to realm-scoped once Bug 4 is fixed**), smoke-draft `tax_source→internal`, charge `24007c16` assigned a service, 6 `net_amount` backfills.
+
+## Track A execution order
+
+1. Bug 2 (adapter option) + Bug 1 (mapping UI) — restores the customer-visible path.
+2. Bug 4 (realm defaulting) — makes UI-created mappings actually work; revert the test tenant's nulled realms to realm-scoped and re-verify.
+3. Bug 5 (timezone) + Bug 6 (net_amount) — makes real-world data exportable.
+4. Bug 3 (no-raw-500 sweep) — kills the "Xero 500" class entirely.
+5. Bug 7 items as cheap wins alongside the above.
+
+Each fix: smallest correct change + regression test (per `docs/reference/testing-standards.md`), then re-run the live loop below.
+
+## Verification (must demonstrate, not just tests)
+
+Re-run the full journey on this stack (EE dev server on 3708; Xero app `33e0fa01-…` creds in `server/.env.local`, redirect URI for 3708 saved; Demo Company (US) connected):
+1. Mapping UI: open Settings → Accounting → Xero; both tabs render tables; create a service mapping through the dialog (realm-scoped) — no fiber tricks.
+2. Export dialog offers **Xero**; create a batch (sent,paid, 2026 H1) through the UI only.
+3. Execute → batch reaches Delivered with per-line statuses; invoices visible in the Xero demo org.
+4. Negative paths return friendly errors, zero raw 500s: duplicate-filter create, execute empty batch, execute needs_attention batch, missing mapping, missing creds (temporarily rename tenant secret), missing net_amount (unbackfilled charge fixture).
+5. `npm run lint`, typecheck, targeted vitest suites pass.
+6. Record durable discoveries: `alga-dev workflow-add-fact --projectId=13587540-298b-4f3a-9740-05afa2608b70 --step='Draft Implementation' --text='<truth>'`.
+
+## Track B — inbound sync plan (document only)
+
+Write `docs/plans/2026-07-14-xero-inbound-sync-plan.md` (draft, not executed) scoping the true two-way leg:
+- `supportsChangePolling` + `fetchChanges` on `XeroAdapter` (Xero If-Modified-Since paging over Payments, CreditNotes, Invoices).
+- De-QBO the driver: `SYNC_ADAPTER_TYPE` hard-coding in `packages/billing/src/actions/accountingSyncActions.ts:24` and `syncProducers.ts:25`; route through `resolveConnectedAccountingIntegration` (already returns `adapterType:'xero'`); generalize applier metadata (`qbo_payment_kind`, `qbo_txn_date`, paymentApplier's `'quickbooks'` provider default, driftDetector assumptions).
+- Trigger: the existing `accountingSyncCycleHandler` job (server/src/lib/jobs/handlers/) vs Xero webhooks; note QBO's cadence choice and match it.
+- Out of scope for Track B doc: implementing any of it on this branch.
+
+## Findings writeup (final step)
+
+Draft a ticket reply for Matt answering: (1) the "Xero 500" class — unhandled errors in the export flow (schema-skew + AppError leaks), all being fixed; (2) live status — outbound invoice export is live for Enterprise (demonstrated end-to-end against a Xero demo org), inbound 2-way is scoped and planned. Tone per `alga-tech-doc-writing`.
+
+## Out of scope
+
+- Xero card copy (explicit decision: leave "Sync: 2-way / Delivery: Live").
+- Implementing inbound sync (Track B is a document).
+- QBO refactors beyond what a Track A fix strictly requires.
+- Production log forensics (window expired).

--- a/docs/plans/2026-07-14-xero-inbound-sync-plan.md
+++ b/docs/plans/2026-07-14-xero-inbound-sync-plan.md
@@ -1,0 +1,136 @@
+# Xero Inbound Accounting Sync Plan
+
+**Date:** 2026-07-14
+**Ticket:** alga0002119
+**Status:** Draft. This document does not authorize implementation on the Xero outbound-fix branch.
+
+## Problem
+
+AlgaPSA can deliver invoices to a connected Xero organisation, but it does not read accounting changes back from Xero. The Xero adapter does not advertise change polling or implement `fetchChanges`. The accounting sync driver and several downstream appliers still assume QuickBooks Online.
+
+The first inbound milestone should reconcile payments, credit notes, and invoice changes from Xero without creating a second sync engine.
+
+## Goals
+
+- Poll the connected Xero organisation for changed invoices, payments, and credit notes.
+- Feed normalized changes through the existing accounting sync cycle.
+- Apply Xero payments and credits idempotently to the mapped AlgaPSA invoice.
+- Detect material invoice drift without overwriting AlgaPSA invoice data automatically.
+- Preserve adapter and provider identity in mappings, transactions, exceptions, and operator-facing status.
+- Use the existing scheduled accounting sync job and the same operational controls as QuickBooks Online.
+
+## Non-goals
+
+- Xero webhooks in the first milestone.
+- Importing contacts, catalog items, or arbitrary historical transactions.
+- Bi-directional editing of invoice lines.
+- Replacing the existing outbound batch flow.
+- General accounting-platform UI redesign.
+
+## Existing seams
+
+- `packages/types/src/interfaces/accountingExportAdapter.interfaces.ts` already defines `supportsChangePolling` and `fetchChanges`.
+- `packages/billing/src/services/accountingSync/accountingSyncCycleService.ts` owns the pull/apply cycle.
+- `packages/billing/src/services/accountingSync/connectedAccountingIntegration.ts` already resolves either a QBO or Xero connection.
+- `server/src/lib/jobs/handlers/accountingSyncCycleHandler.ts` provides the scheduled trigger.
+- `packages/billing/src/actions/accountingSyncActions.ts` still sets `SYNC_ADAPTER_TYPE` to `quickbooks_online` and loads QBO credentials directly.
+- `packages/billing/src/services/accountingSync/paymentApplier.ts` defaults the provider to `quickbooks` and writes `qbo_payment_kind` and `qbo_txn_date` metadata.
+
+## Adapter contract
+
+Add `supportsChangePolling: true` to `XeroAdapter.capabilities()` and implement:
+
+```ts
+fetchChanges(
+  tenantId: string,
+  since: string,
+  targetRealm?: string | null
+): Promise<AccountingChangeSet>
+```
+
+`targetRealm` is the Xero organisation tenant ID used by mappings. Resolve it to the stored Xero connection before calling the API.
+
+The adapter should request changed records with Xero's `If-Modified-Since` support and follow pagination independently for:
+
+1. Invoices
+2. Payments
+3. Credit notes
+
+Normalize provider records into the existing accounting change types. Provider payloads and pagination details must stay inside the adapter.
+
+## Cursor and replay rules
+
+- Use the sync cycle's last successful completion timestamp as the next lower bound.
+- Subtract a small overlap window from each request to tolerate provider clock skew and records committed near a page boundary.
+- Deduplicate by Xero entity ID plus its provider update timestamp before applying changes.
+- Advance the stored cursor only after every page has been fetched and the cycle completes successfully.
+- Keep payment and credit application idempotency keyed by provider, external transaction ID, target realm, and AlgaPSA invoice ID.
+
+## Driver changes
+
+Replace QBO-specific connection resolution in `accountingSyncActions.ts` with `resolveConnectedAccountingIntegration`:
+
+1. Resolve `{ adapterType, targetRealm }` for the tenant.
+2. Load the matching adapter from `AccountingAdapterRegistry`.
+3. Require `supportsChangePolling` and `fetchChanges` before starting an inbound cycle.
+4. Obtain refresh-token health through an adapter-neutral connection-health contract. Do not import QBO credential storage from the action.
+5. Pass the resolved adapter type and realm through sync operations, cycle rows, mappings, exceptions, and health queries.
+
+Apply the same resolution to any remaining producer or scheduled path that still chooses `quickbooks_online` directly. `syncProducers.ts` already uses the connected-integration resolver and should remain the model.
+
+## Applier changes
+
+Generalize provider-specific metadata before enabling Xero polling:
+
+- Replace `qbo_payment_kind` with `external_payment_kind`.
+- Replace `qbo_txn_date` with `external_transaction_date`.
+- Store `provider: 'xero' | 'quickbooks'` explicitly instead of defaulting to QuickBooks.
+- Keep compatibility reads for existing QBO metadata until historical records have been migrated or aged out.
+- Audit `driftDetector.ts`, `creditApplicationApplier.ts`, and payment-push logic for QBO field names, SyncToken assumptions, and QuickBooks-only operator copy.
+
+Xero invoice changes should update observed external snapshots. A total or document-number difference should create the existing accounting drift exception. Status-only changes that reflect settlement should flow through payment and credit application rather than rewrite the invoice.
+
+## Trigger
+
+Use `accountingSyncCycleHandler` for the first release. Match the existing QBO cadence and concurrency controls so one tenant/realm cannot run overlapping cycles. A later webhook design can enqueue the same cycle with a shorter delay; it should not introduce a separate apply path.
+
+## Error handling
+
+- Treat expired or revoked Xero refresh tokens as reconnect-required and stop the cycle without advancing its cursor.
+- Retry rate limits and transient Xero failures with bounded backoff.
+- Persist a safe operator message and provider correlation ID. Do not persist tokens or raw authorization headers.
+- Isolate malformed provider records as sync exceptions when the rest of the page can be processed safely.
+- Fail the cycle when pagination is incomplete. Partial fetches must not move the cursor.
+
+## Delivery stages
+
+1. **Adapter polling:** normalize paged Xero invoice, payment, and credit-note changes behind fixture-driven adapter tests.
+2. **Adapter-neutral driver:** remove the hard-coded QBO selection and introduce adapter-neutral connection health.
+3. **Provider-neutral appliers:** generalize payment, credit, drift, and transaction metadata while retaining QBO compatibility.
+4. **Scheduled execution:** enable Xero in the existing job with tenant/realm locking and cursor overlap.
+5. **Operator experience:** label Xero sync health, reconnect states, drift, and exceptions accurately.
+
+## Test plan
+
+- Unit tests for Xero pagination, `If-Modified-Since`, normalization, token expiry, and rate-limit retry.
+- Contract tests that run the same normalized change set through QBO and Xero adapters.
+- DB-backed integration tests for payment apply, credit apply, duplicate replay, unknown invoice mapping, and material drift.
+- A cycle test proving the cursor does not advance after a failed page.
+- A scheduler test proving overlapping runs for one tenant/realm are rejected.
+- Live sandbox verification: export an invoice, record a payment and credit in Xero, run Sync Now, and confirm AlgaPSA applies each once.
+
+## Acceptance criteria
+
+- A connected Xero tenant can run the existing accounting sync cycle without a QBO connection.
+- Xero payments and credits update mapped AlgaPSA invoices once, including after an overlapped replay.
+- Xero invoice drift creates an operator-visible exception and does not silently overwrite AlgaPSA.
+- Expired credentials produce reconnect guidance without a raw server error.
+- A failed or partial provider fetch leaves the last-success cursor unchanged.
+- Existing QBO sync tests continue to pass with legacy metadata compatibility.
+
+## Open decisions
+
+- Confirm the overlap duration after measuring Xero update timestamp behavior in the demo organisation.
+- Decide whether the first release imports Xero overpayments or records them as unsupported exceptions.
+- Decide when to migrate existing QBO transaction metadata to provider-neutral keys.
+- Revisit webhooks only after polling correctness and idempotency are proven.

--- a/docs/plans/2026-07-14-xero-two-way-sync-customer-reply.md
+++ b/docs/plans/2026-07-14-xero-two-way-sync-customer-reply.md
@@ -1,0 +1,11 @@
+# Customer Reply Draft: Xero Sync
+
+Hi Matt,
+
+We reproduced the Xero 500 and found several error paths in the accounting export flow that were reaching the browser as server errors. One case was a database migration mismatch. Other expected validation failures were also being returned as raw errors. We have fixes in progress so these cases give clear, actionable messages instead.
+
+Live Xero invoice export is available in Enterprise. We verified the complete outbound flow against a Xero demo organisation, including creating the export in AlgaPSA and confirming the draft invoices in Xero.
+
+The inbound half of two-way sync is not live yet. We have now scoped that work around Xero invoice, payment, and credit-note changes using the existing accounting sync engine.
+
+We will let you know when the export fixes are available for you to retest.

--- a/packages/billing/src/actions/accountingExportActions.test.ts
+++ b/packages/billing/src/actions/accountingExportActions.test.ts
@@ -1,0 +1,97 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const createBatchFromFiltersMock = vi.hoisted(() => vi.fn());
+const executeBatchMock = vi.hoisted(() => vi.fn());
+const cancelBatchMock = vi.hoisted(() => vi.fn());
+const loggerErrorMock = vi.hoisted(() => vi.fn());
+
+vi.mock('@alga-psa/auth', () => ({
+  withAuth:
+    (action: (...args: any[]) => Promise<unknown>) =>
+    (...args: any[]) =>
+      action(
+        { user_id: 'user-1', user_type: 'internal' },
+        { tenant: 'tenant-1' },
+        ...args
+      )
+}));
+
+vi.mock('@alga-psa/auth/rbac', () => ({
+  hasPermission: vi.fn(async () => true)
+}));
+
+vi.mock('@alga-psa/core/logger', () => ({
+  default: { error: loggerErrorMock }
+}));
+
+vi.mock('../services/accountingExportInvoiceSelector', () => ({
+  AccountingExportInvoiceSelector: {
+    create: vi.fn(async () => ({ createBatchFromFilters: createBatchFromFiltersMock }))
+  }
+}));
+
+vi.mock('../services/accountingExportService', () => ({
+  AccountingExportService: {
+    create: vi.fn(async () => ({
+      executeBatch: executeBatchMock,
+      cancelBatch: cancelBatchMock
+    }))
+  }
+}));
+
+import { AppError } from '@alga-psa/core';
+import {
+  createAccountingExportBatch,
+  executeAccountingExportBatch
+} from './accountingExportActions';
+
+describe('accounting export action error boundaries', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('returns a structured duplicate-filter error instead of throwing across the server-action boundary', async () => {
+    createBatchFromFiltersMock.mockRejectedValue(new AppError(
+      'ACCOUNTING_EXPORT_DUPLICATE',
+      'An export batch already exists for this filter selection'
+    ));
+
+    await expect(createAccountingExportBatch({
+      adapter_type: 'xero',
+      export_type: 'invoice',
+      filters: { invoice_statuses: ['sent'] }
+    })).resolves.toEqual({
+      success: false,
+      code: 'ACCOUNTING_EXPORT_DUPLICATE',
+      message: 'An export batch already exists for this filter selection'
+    });
+  });
+
+  it.each([
+    ['ACCOUNTING_EXPORT_EMPTY_BATCH', 'No invoices match the selected filters.'],
+    ['ACCOUNTING_EXPORT_VALIDATION_FAILED', 'Export batch batch-1 is not ready for delivery.']
+  ])('returns structured %s execution failures', async (code, message) => {
+    executeBatchMock.mockRejectedValue(new AppError(code, message));
+
+    const result = await executeAccountingExportBatch('batch-1');
+
+    expect(result).toMatchObject({ success: false, code });
+    expect((result as { message: string }).message).toContain(message);
+  });
+
+  it('does not expose unexpected database details to the browser', async () => {
+    executeBatchMock.mockRejectedValue(new Error(
+      'insert into accounting_export_lines: column document_id does not exist'
+    ));
+
+    const result = await executeAccountingExportBatch('batch-1');
+
+    expect(result).toEqual({
+      success: false,
+      code: 'ACCOUNTING_EXPORT_UNEXPECTED',
+      message: 'Unable to execute the accounting export. Please try again or contact support.'
+    });
+    expect(JSON.stringify(result)).not.toContain('document_id');
+    expect(loggerErrorMock).toHaveBeenCalledOnce();
+  });
+});

--- a/packages/billing/src/actions/accountingExportActions.ts
+++ b/packages/billing/src/actions/accountingExportActions.ts
@@ -26,6 +26,8 @@ import { withAuth } from '@alga-psa/auth';
 import { hasPermission } from '@alga-psa/auth/rbac';
 import { permissionError } from '@alga-psa/ui/lib/errorHandling';
 import type { ActionPermissionError } from '@alga-psa/ui/lib/errorHandling';
+import { AppError } from '@alga-psa/core';
+import logger from '@alga-psa/core/logger';
 
 type AccountingExportPermission = 'create' | 'read' | 'update' | 'execute';
 
@@ -37,6 +39,46 @@ const ACTION_DESCRIPTIONS: Record<AccountingExportPermission, string> = {
 };
 
 const PREVIEW_LINE_LIMIT = 50;
+
+export interface AccountingExportActionError {
+  success: false;
+  code: string;
+  message: string;
+}
+
+function toAccountingExportActionError(
+  error: unknown,
+  operation: 'create' | 'execute' | 'cancel'
+): AccountingExportActionError {
+  if (error instanceof AppError) {
+    if (error.code === 'XERO_NOT_CONFIGURED') {
+      return {
+        success: false,
+        code: error.code,
+        message: 'Connect Xero before executing this export.'
+      };
+    }
+
+    const recreateGuidance = error.code === 'ACCOUNTING_EXPORT_VALIDATION_FAILED'
+      ? ' Review the batch errors, then cancel and recreate the batch after repairing the source data.'
+      : '';
+    return {
+      success: false,
+      code: error.code,
+      message: `${error.message}${recreateGuidance}`
+    };
+  }
+
+  logger.error('[accountingExportActions] Unexpected accounting export failure', {
+    operation,
+    error
+  });
+  return {
+    success: false,
+    code: 'ACCOUNTING_EXPORT_UNEXPECTED',
+    message: `Unable to ${operation} the accounting export. Please try again or contact support.`
+  };
+}
 
 export interface AccountingExportPreviewFilters {
   startDate?: string;
@@ -103,19 +145,23 @@ export const createAccountingExportBatch = withAuth(async (
   user,
   { tenant },
   input: CreateExportBatchInput
-): Promise<AccountingExportBatch | ActionPermissionError> => {
+): Promise<AccountingExportBatch | ActionPermissionError | AccountingExportActionError> => {
   const denied = await checkAccountingExportPermission(user, 'create');
   if (denied) return denied;
-  const selector = await AccountingExportInvoiceSelector.create();
-  const filters = normalizeCreateBatchFilters(input.filters);
-  const { batch } = await selector.createBatchFromFilters({
-    adapterType: input.adapter_type,
-    targetRealm: input.target_realm ?? null,
-    notes: input.notes ?? null,
-    createdBy: input.created_by ?? user.user_id,
-    filters
-  });
-  return batch;
+  try {
+    const selector = await AccountingExportInvoiceSelector.create();
+    const filters = normalizeCreateBatchFilters(input.filters);
+    const { batch } = await selector.createBatchFromFilters({
+      adapterType: input.adapter_type,
+      targetRealm: input.target_realm ?? null,
+      notes: input.notes ?? null,
+      createdBy: input.created_by ?? user.user_id,
+      filters
+    });
+    return batch;
+  } catch (error) {
+    return toAccountingExportActionError(error, 'create');
+  }
 });
 
 export const appendAccountingExportLines = withAuth(async (
@@ -162,14 +208,18 @@ export const cancelAccountingExportBatch = withAuth(async (
   { tenant },
   batchId: string,
   reason?: string
-): Promise<AccountingExportBatch | ActionPermissionError> => {
+): Promise<AccountingExportBatch | ActionPermissionError | AccountingExportActionError> => {
   const denied = await checkAccountingExportPermission(user, 'update');
   if (denied) return denied;
-  const service = await AccountingExportService.create();
-  return service.cancelBatch(batchId, {
-    cancelledBy: user.user_id,
-    reason: reason ?? null
-  });
+  try {
+    const service = await AccountingExportService.create();
+    return await service.cancelBatch(batchId, {
+      cancelledBy: user.user_id,
+      reason: reason ?? null
+    });
+  } catch (error) {
+    return toAccountingExportActionError(error, 'cancel');
+  }
 });
 
 export const getAccountingExportBatch = withAuth(async (
@@ -202,11 +252,15 @@ export const executeAccountingExportBatch = withAuth(async (
   user,
   { tenant },
   batchId: string
-): Promise<AccountingExportDeliveryResult | ActionPermissionError> => {
+): Promise<AccountingExportDeliveryResult | ActionPermissionError | AccountingExportActionError> => {
   const denied = await checkAccountingExportPermission(user, 'execute');
   if (denied) return denied;
-  const service = await AccountingExportService.create();
-  return service.executeBatch(batchId);
+  try {
+    const service = await AccountingExportService.create();
+    return await service.executeBatch(batchId);
+  } catch (error) {
+    return toAccountingExportActionError(error, 'execute');
+  }
 });
 
 export const previewAccountingExport = withAuth(async (

--- a/packages/billing/src/components/billing-dashboard/accounting/AccountingExportsTab.tsx
+++ b/packages/billing/src/components/billing-dashboard/accounting/AccountingExportsTab.tsx
@@ -12,6 +12,7 @@ import toast from 'react-hot-toast';
 import { handleError, isActionPermissionError } from '@alga-psa/ui/lib/errorHandling';
 import { useTranslation } from '@alga-psa/ui/lib/i18n/client';
 import { cancelAccountingExportBatch, createAccountingExportBatch, executeAccountingExportBatch, getAccountingExportBatch, listAccountingExportBatches } from '@alga-psa/billing/actions/accountingExportActions';
+import type { AccountingExportActionError } from '@alga-psa/billing/actions/accountingExportActions';
 import { getAccountingSyncHealth } from '@alga-psa/billing/actions/accountingSyncActions';
 
 type AccountingExportStatus =
@@ -69,6 +70,16 @@ type BatchDetail = {
   errors: AccountingExportError[];
 };
 
+function isAccountingExportActionError(value: unknown): value is AccountingExportActionError {
+  const candidate = value as Partial<AccountingExportActionError> | null;
+  return Boolean(
+    candidate &&
+    candidate.success === false &&
+    typeof candidate.code === 'string' &&
+    typeof candidate.message === 'string'
+  );
+}
+
 function formatIso(iso: string | null | undefined): string {
   if (!iso) return '-';
   const dt = new Date(iso);
@@ -79,6 +90,7 @@ function formatIso(iso: string | null | undefined): string {
 const DEFAULT_ADAPTERS = [
   { id: 'quickbooks_csv', label: 'QuickBooks CSV' },
   { id: 'xero_csv', label: 'Xero CSV' },
+  { id: 'xero', label: 'Xero' },
   { id: 'quickbooks_online', label: 'QuickBooks Online' },
   { id: 'quickbooks_desktop', label: 'QuickBooks Desktop' }
 ] as const;
@@ -226,6 +238,10 @@ export default function AccountingExportsTab(): React.JSX.Element {
         handleError(batchResult.permissionError);
         return;
       }
+      if (isAccountingExportActionError(batchResult)) {
+        handleError(batchResult.message);
+        return;
+      }
       const batch = batchResult as unknown as AccountingExportBatch;
       toast.success(t('accountingExports.toast.created', {
         defaultValue: 'Accounting export batch created',
@@ -249,6 +265,12 @@ export default function AccountingExportsTab(): React.JSX.Element {
         handleError(result.permissionError);
         return;
       }
+      if (isAccountingExportActionError(result)) {
+        await loadBatches();
+        await loadBatchDetail(batchId);
+        handleError(result.message);
+        return;
+      }
       toast.success(t('accountingExports.toast.executing', {
         defaultValue: 'Batch execution started',
       }));
@@ -266,6 +288,10 @@ export default function AccountingExportsTab(): React.JSX.Element {
       const result = await cancelAccountingExportBatch(batchId);
       if (isActionPermissionError(result)) {
         handleError(result.permissionError);
+        return;
+      }
+      if (isAccountingExportActionError(result)) {
+        handleError(result.message);
         return;
       }
       toast.success(t('accountingExports.toast.cancelled', {

--- a/packages/billing/src/repositories/accountingExportRepository.ts
+++ b/packages/billing/src/repositories/accountingExportRepository.ts
@@ -10,6 +10,7 @@ import {
   AccountingExportServicePeriodSource,
   AccountingExportStatus
 } from '@alga-psa/types';
+import { normalizeAccountingExportCalendarDate } from '../services/accountingExportDateUtils';
 
 type Nullable<T> = T | null | undefined;
 
@@ -72,56 +73,7 @@ function normalizeRecurringDetailPeriods(
 }
 
 function normalizeIsoDateField(value: unknown): string | null | undefined {
-  if (value === undefined) {
-    return undefined;
-  }
-
-  if (value === null) {
-    return null;
-  }
-
-  if (value instanceof Date) {
-    const isLocalMidnight =
-      value.getHours() === 0 &&
-      value.getMinutes() === 0 &&
-      value.getSeconds() === 0 &&
-      value.getMilliseconds() === 0;
-    const isUtcMidnight =
-      value.getUTCHours() === 0 &&
-      value.getUTCMinutes() === 0 &&
-      value.getUTCSeconds() === 0 &&
-      value.getUTCMilliseconds() === 0;
-
-    const year = isLocalMidnight ? value.getFullYear() : value.getUTCFullYear();
-    const month = isLocalMidnight ? value.getMonth() + 1 : value.getUTCMonth() + 1;
-    const day = isLocalMidnight ? value.getDate() : value.getUTCDate();
-
-    if (isLocalMidnight || isUtcMidnight) {
-      return `${year}-${String(month).padStart(2, '0')}-${String(day).padStart(2, '0')}T00:00:00.000Z`;
-    }
-
-    return value.toISOString();
-  }
-
-  if (typeof value === 'string') {
-    const trimmed = value.trim();
-    if (!trimmed) {
-      return null;
-    }
-
-    if (/^\d{4}-\d{2}-\d{2}$/.test(trimmed)) {
-      return `${trimmed}T00:00:00.000Z`;
-    }
-
-    return trimmed;
-  }
-
-  const date = new Date(String(value));
-  if (Number.isNaN(date.getTime())) {
-    return undefined;
-  }
-
-  return date.toISOString();
+  return normalizeAccountingExportCalendarDate(value);
 }
 
 function normalizeLinePayload(payload: unknown): AccountingExportLinePayload | null {

--- a/packages/billing/src/services/accountingExportDateUtils.ts
+++ b/packages/billing/src/services/accountingExportDateUtils.ts
@@ -1,0 +1,33 @@
+/**
+ * Accounting service periods are calendar dates, even though legacy columns
+ * store them as timestamptz. Normalize every representation to UTC midnight so
+ * tenant-local midnight offsets do not create false projection drift.
+ */
+export function normalizeAccountingExportCalendarDate(
+  value: unknown
+): string | null | undefined {
+  if (value === undefined) {
+    return undefined;
+  }
+  if (value === null) {
+    return null;
+  }
+
+  if (typeof value === 'string') {
+    const trimmed = value.trim();
+    if (!trimmed) {
+      return null;
+    }
+    const datePrefix = trimmed.match(/^(\d{4}-\d{2}-\d{2})(?:$|T)/)?.[1];
+    if (datePrefix) {
+      return `${datePrefix}T00:00:00.000Z`;
+    }
+  }
+
+  const date = value instanceof Date ? value : new Date(String(value));
+  if (Number.isNaN(date.getTime())) {
+    return undefined;
+  }
+
+  return `${date.toISOString().slice(0, 10)}T00:00:00.000Z`;
+}

--- a/packages/billing/src/services/accountingExportInvoiceSelector.ts
+++ b/packages/billing/src/services/accountingExportInvoiceSelector.ts
@@ -4,9 +4,12 @@ import { createTenantKnex, tenantDb } from '@alga-psa/db';
 import { AccountingExportService } from './accountingExportService';
 import { AccountingExportBatch, AccountingExportServicePeriodSource } from '@alga-psa/types';
 import { AppError } from '@alga-psa/core';
-// eslint-disable-next-line custom-rules/no-feature-to-feature-imports -- batch creation stamps the default QBO realm so realm-scoped mappings resolve
+// eslint-disable-next-line custom-rules/no-feature-to-feature-imports -- batch creation stamps live-accounting realms so realm-scoped mappings resolve
 import { getDefaultQboRealmId } from '@alga-psa/integrations/lib/qbo/qboClientService';
+// eslint-disable-next-line custom-rules/no-feature-to-feature-imports -- batch creation stamps live-accounting realms so realm-scoped mappings resolve
+import { getDefaultXeroTenantId } from '@alga-psa/integrations/lib/xero/xeroClientService';
 import { satisfyExportOpsForManualBatch } from './accountingSync/syncProducers';
+import { normalizeAccountingExportCalendarDate } from './accountingExportDateUtils';
 
 type Nullable<T> = T | null | undefined;
 
@@ -301,6 +304,9 @@ export class AccountingExportInvoiceSelector {
       // Live QBO mappings are realm-scoped, so a batch without a realm cannot
       // resolve them; default to the tenant's connected company.
       targetRealm = await getDefaultQboRealmId(this.tenantId).catch(() => null);
+    } else if (!targetRealm && options.adapterType === 'xero') {
+      // Live Xero mappings use the Xero organisation tenant id as their realm.
+      targetRealm = await getDefaultXeroTenantId(this.tenantId).catch(() => null);
     }
 
     const preview = await this.previewInvoiceLines({
@@ -441,50 +447,7 @@ function toInteger(value: unknown): number {
 }
 
 function toIsoString(value: unknown): string | null {
-  if (value === null || value === undefined) {
-    return null;
-  }
-
-  if (value instanceof Date) {
-    const isLocalMidnight =
-      value.getHours() === 0 &&
-      value.getMinutes() === 0 &&
-      value.getSeconds() === 0 &&
-      value.getMilliseconds() === 0;
-    const isUtcMidnight =
-      value.getUTCHours() === 0 &&
-      value.getUTCMinutes() === 0 &&
-      value.getUTCSeconds() === 0 &&
-      value.getUTCMilliseconds() === 0;
-
-    const year = isLocalMidnight ? value.getFullYear() : value.getUTCFullYear();
-    const month = isLocalMidnight ? value.getMonth() + 1 : value.getUTCMonth() + 1;
-    const day = isLocalMidnight ? value.getDate() : value.getUTCDate();
-
-    if (isLocalMidnight || isUtcMidnight) {
-      return `${year}-${String(month).padStart(2, '0')}-${String(day).padStart(2, '0')}T00:00:00.000Z`;
-    }
-
-    return value.toISOString();
-  }
-
-  if (typeof value === 'string') {
-    const trimmed = value.trim();
-    if (!trimmed) {
-      return null;
-    }
-
-    if (/^\d{4}-\d{2}-\d{2}$/.test(trimmed)) {
-      return `${trimmed}T00:00:00.000Z`;
-    }
-  }
-
-  const date = new Date(value as string);
-  if (Number.isNaN(date.getTime())) {
-    return null;
-  }
-
-  return date.toISOString();
+  return normalizeAccountingExportCalendarDate(value) ?? null;
 }
 
 function expandInvoiceStatuses(input?: string[]): string[] | undefined {

--- a/packages/billing/src/services/accountingExportService.ts
+++ b/packages/billing/src/services/accountingExportService.ts
@@ -335,7 +335,8 @@ export class AccountingExportService {
       if (failedDocuments.length === 0) {
         await this.repository.updateBatchStatus(batchId, {
           status: 'delivered',
-          delivered_at: new Date().toISOString()
+          delivered_at: new Date().toISOString(),
+          notes: null
         });
       } else {
         await this.repository.updateBatchStatus(batchId, {

--- a/packages/billing/src/services/accountingExportValidation.ts
+++ b/packages/billing/src/services/accountingExportValidation.ts
@@ -3,6 +3,7 @@ import { AccountingExportRepository } from '../repositories/accountingExportRepo
 import { AccountingMappingResolver } from './accountingMappingResolver';
 import { getAccountingSyncSettings } from './accountingSync/accountingSyncSettings';
 import type { AccountingExportLine, AccountingExportServicePeriodSource } from '@alga-psa/types';
+import { normalizeAccountingExportCalendarDate } from './accountingExportDateUtils';
 
 type ChargeProjection = {
   tenant: string;
@@ -10,6 +11,7 @@ type ChargeProjection = {
   invoice_id?: string | null;
   service_id?: string | null;
   tax_region?: string | null;
+  net_amount?: number | string | null;
 };
 
 type ChargeDetailProjection = {
@@ -168,7 +170,7 @@ export class AccountingExportValidation {
     const charges =
       chargeIds.size > 0
         ? await db.table<ChargeProjection>('invoice_charges')
-            .select('item_id', 'invoice_id', 'service_id', 'tax_region')
+            .select('item_id', 'invoice_id', 'service_id', 'tax_region', 'net_amount')
             .whereIn('item_id', Array.from(chargeIds))
         : [];
     const chargesById = new Map(charges.map((charge) => [charge.item_id, charge]));
@@ -323,6 +325,16 @@ export class AccountingExportValidation {
       }
 
       const charge = chargesById.get(line.document_line_id);
+      if (adapterType === 'xero' && (charge?.net_amount === null || charge?.net_amount === undefined)) {
+        await repo.addError({
+          batch_id: batchId,
+          line_id: line.line_id,
+          code: 'missing_net_amount',
+          message: `Charge ${line.document_line_id} is missing its net amount. Repair the invoice, then cancel and recreate this export batch.`,
+          metadata: mergeErrorMetadata(line, { invoice_charge_id: line.document_line_id })
+        });
+        continue;
+      }
       if (!charge?.service_id) {
         await repo.addError({
           batch_id: batchId,
@@ -536,16 +548,7 @@ export class AccountingExportValidation {
 }
 
 function normalizeIsoString(value: unknown): string | null {
-  if (value === null || value === undefined) {
-    return null;
-  }
-
-  const date = value instanceof Date ? value : new Date(String(value));
-  if (Number.isNaN(date.getTime())) {
-    return null;
-  }
-
-  return date.toISOString();
+  return normalizeAccountingExportCalendarDate(value) ?? null;
 }
 
 function normalizeRecurringPeriod(input: {

--- a/packages/integrations/src/actions/integrations/xeroActions.ts
+++ b/packages/integrations/src/actions/integrations/xeroActions.ts
@@ -150,7 +150,7 @@ export interface XeroConnectionStatus {
 
 function xeroConnectionStatusError(
   error: string,
-  errorCode: NonNullable<XeroConnectionStatus['errorCode']>
+  errorCode?: NonNullable<XeroConnectionStatus['errorCode']>
 ): XeroConnectionStatus {
   return {
     connections: [],
@@ -316,58 +316,64 @@ export const getXeroConnectionStatus = withAuth(async (
 
   try {
     await checkBillingReadAccess(user);
+
+    const secretProvider = await getSecretProviderInstance();
+    const [storedClientId, storedClientSecret, redirectUri, resolvedCredentials] = await Promise.all([
+      secretProvider.getTenantSecret(tenant, XERO_CLIENT_ID_SECRET_NAME),
+      secretProvider.getTenantSecret(tenant, XERO_CLIENT_SECRET_SECRET_NAME),
+      getXeroRedirectUri(secretProvider),
+      resolveXeroOAuthCredentials(tenant, secretProvider).catch(() => null)
+    ]);
+    const clientId = typeof storedClientId === 'string' ? storedClientId.trim() : '';
+    const clientSecret = typeof storedClientSecret === 'string' ? storedClientSecret.trim() : '';
+    const summaries = await getXeroConnectionSummaries(tenant);
+    const defaultConnection = summaries[0];
+    const credentials = {
+      clientIdConfigured: Boolean(clientId),
+      clientSecretConfigured: Boolean(clientSecret),
+      ready: Boolean(resolvedCredentials),
+      clientIdMasked: clientId ? maskSecret(clientId) : undefined,
+      clientSecretMasked: clientSecret ? maskSecret(clientSecret) : undefined
+    };
+
+    let connected = false;
+    let error: string | undefined;
+
+    if (!credentials.ready) {
+      error = 'Add a Xero client ID and client secret before connecting live Xero.';
+    } else if (!defaultConnection) {
+      error = 'No live Xero organisation is connected yet. Save credentials, then click Connect Xero.';
+    } else {
+      try {
+        await XeroClientService.create(tenant, defaultConnection.connectionId);
+        connected = true;
+      } catch (err) {
+        error = formatXeroStatusError(err);
+      }
+    }
+
+    return {
+      connections: summaries,
+      connected,
+      defaultConnectionId: defaultConnection?.connectionId,
+      defaultConnection,
+      redirectUri,
+      scopes: getXeroOAuthScopes(),
+      credentials,
+      error
+    };
   } catch (error) {
     if (error instanceof Error && error.message.startsWith('Forbidden')) {
       return xeroConnectionStatusError(error.message, 'FORBIDDEN');
     }
-    throw error;
+    logger.error('[xeroActions] Failed to load Xero connection status', {
+      tenantId: tenant,
+      error
+    });
+    return xeroConnectionStatusError(
+      'Failed to load Xero connection status. Please refresh and try again.'
+    );
   }
-
-  const secretProvider = await getSecretProviderInstance();
-  const [storedClientId, storedClientSecret, redirectUri, resolvedCredentials] = await Promise.all([
-    secretProvider.getTenantSecret(tenant, XERO_CLIENT_ID_SECRET_NAME),
-    secretProvider.getTenantSecret(tenant, XERO_CLIENT_SECRET_SECRET_NAME),
-    getXeroRedirectUri(secretProvider),
-    resolveXeroOAuthCredentials(tenant, secretProvider).catch(() => null)
-  ]);
-  const clientId = typeof storedClientId === 'string' ? storedClientId.trim() : '';
-  const clientSecret = typeof storedClientSecret === 'string' ? storedClientSecret.trim() : '';
-  const summaries = await getXeroConnectionSummaries(tenant);
-  const defaultConnection = summaries[0];
-  const credentials = {
-    clientIdConfigured: Boolean(clientId),
-    clientSecretConfigured: Boolean(clientSecret),
-    ready: Boolean(resolvedCredentials),
-    clientIdMasked: clientId ? maskSecret(clientId) : undefined,
-    clientSecretMasked: clientSecret ? maskSecret(clientSecret) : undefined
-  };
-
-  let connected = false;
-  let error: string | undefined;
-
-  if (!credentials.ready) {
-    error = 'Add a Xero client ID and client secret before connecting live Xero.';
-  } else if (!defaultConnection) {
-    error = 'No live Xero organisation is connected yet. Save credentials, then click Connect Xero.';
-  } else {
-    try {
-      await XeroClientService.create(tenant, defaultConnection.connectionId);
-      connected = true;
-    } catch (err) {
-      error = formatXeroStatusError(err);
-    }
-  }
-
-  return {
-    connections: summaries,
-    connected,
-    defaultConnectionId: defaultConnection?.connectionId,
-    defaultConnection,
-    redirectUri,
-    scopes: getXeroOAuthScopes(),
-    credentials,
-    error
-  };
 });
 
 // Backwards-compatible alias used by older callers.

--- a/packages/integrations/src/components/accounting-mappings/AccountingMappingManager.test.tsx
+++ b/packages/integrations/src/components/accounting-mappings/AccountingMappingManager.test.tsx
@@ -1,0 +1,69 @@
+/**
+ * @vitest-environment jsdom
+ */
+import React from 'react';
+import { cleanup, fireEvent, render, screen } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+const routerReplaceMock = vi.hoisted(() => vi.fn());
+const useSearchParamsMock = vi.hoisted(() => vi.fn(() => new URLSearchParams()));
+
+vi.mock('next/navigation', () => ({
+  useRouter: () => ({ replace: routerReplaceMock }),
+  useSearchParams: useSearchParamsMock
+}));
+
+vi.mock('./AccountingMappingModuleView', () => ({
+  AccountingMappingModuleView: ({ module }: { module: { id: string } }) => (
+    <div>{`Panel ${module.id}`}</div>
+  )
+}));
+
+import { AccountingMappingManager } from './AccountingMappingManager';
+import type { AccountingMappingModule } from './types';
+
+const modules = [
+  { id: 'service-mappings', labels: { tab: 'Items / Services' } },
+  { id: 'tax-mappings', labels: { tab: 'Tax Codes' } }
+] as unknown as AccountingMappingModule[];
+
+describe('AccountingMappingManager tab selection', () => {
+  afterEach(() => {
+    cleanup();
+    vi.clearAllMocks();
+    window.history.replaceState({}, '', '/');
+  });
+
+  it('falls back to the first module when defaultTabId is a stale label', () => {
+    render(
+      <AccountingMappingManager
+        modules={modules}
+        context={{}}
+        defaultTabId="Items / Services"
+        urlParamKey="mappingTab"
+      />
+    );
+
+    expect(screen.getByText('Panel service-mappings')).toBeVisible();
+    expect(screen.queryByText('Panel tax-mappings')).not.toBeInTheDocument();
+  });
+
+  it('keeps a user-selected tab active and synchronizes it through the router', () => {
+    render(
+      <AccountingMappingManager
+        modules={modules}
+        context={{}}
+        defaultTabId="service-mappings"
+        urlParamKey="mappingTab"
+      />
+    );
+
+    const taxTab = screen.getByRole('tab', { name: 'Tax Codes' });
+    fireEvent.mouseDown(taxTab, { button: 0, ctrlKey: false });
+    fireEvent.click(taxTab);
+
+    expect(screen.getByText('Panel tax-mappings')).toBeVisible();
+    expect(routerReplaceMock).toHaveBeenCalledWith('/?mappingTab=tax-mappings', { scroll: false });
+  });
+});

--- a/packages/integrations/src/components/accounting-mappings/AccountingMappingManager.tsx
+++ b/packages/integrations/src/components/accounting-mappings/AccountingMappingManager.tsx
@@ -1,7 +1,7 @@
 'use client';
 
-import React, { useEffect, useState } from 'react';
-import { useSearchParams } from 'next/navigation';
+import React, { useEffect, useMemo, useState } from 'react';
+import { useRouter, useSearchParams } from 'next/navigation';
 
 import CustomTabs, { TabContent } from '@alga-psa/ui/components/CustomTabs';
 import { useTranslation } from '@alga-psa/ui/lib/i18n/client';
@@ -29,22 +29,22 @@ export function AccountingMappingManager({
   urlParamKey
 }: AccountingMappingManagerProps) {
   const { t } = useTranslation('msp/integrations');
+  const router = useRouter();
   const searchParams = useSearchParams();
   const paramKey = urlParamKey ?? 'tab';
   const tabParam = searchParams?.get(paramKey);
-
-  const defaultTab = defaultTabId ?? modules[0]?.id ?? '';
+  const moduleIds = useMemo(() => modules.map((module) => module.id), [modules]);
+  const requestedDefaultTab = defaultTabId ?? modules[0]?.id ?? '';
+  const defaultTab = moduleIds.includes(requestedDefaultTab) ? requestedDefaultTab : modules[0]?.id ?? '';
+  const urlTab = tabParam?.toLowerCase() ?? '';
 
   const [activeTab, setActiveTab] = useState<string>(() => {
-    return tabParam?.toLowerCase() || defaultTab;
+    return moduleIds.includes(urlTab) ? urlTab : defaultTab;
   });
 
   useEffect(() => {
-    const targetTab = tabParam?.toLowerCase() || defaultTab;
-    if (targetTab !== activeTab) {
-      setActiveTab(targetTab);
-    }
-  }, [tabParam, activeTab, defaultTab]);
+    setActiveTab(moduleIds.includes(urlTab) ? urlTab : defaultTab);
+  }, [defaultTab, urlTab, moduleIds]);
 
   const updateURL = (tabId: string) => {
     // Build new URL with tab parameter
@@ -60,7 +60,7 @@ export function AccountingMappingManager({
       ? `${window.location.pathname}?${currentSearchParams.toString()}`
       : window.location.pathname;
 
-    window.history.pushState({}, '', newUrl);
+    router.replace(newUrl, { scroll: false });
   };
 
   if (!modules.length) {
@@ -83,7 +83,7 @@ export function AccountingMappingManager({
   return (
     <CustomTabs
       tabs={tabs}
-      defaultTab={activeTab}
+      value={activeTab}
       tabStyles={tabStyles}
       onTabChange={(tabId) => {
         setActiveTab(tabId);

--- a/packages/integrations/src/components/settings/integrations/XeroIntegrationSettings.contract.test.tsx
+++ b/packages/integrations/src/components/settings/integrations/XeroIntegrationSettings.contract.test.tsx
@@ -21,7 +21,7 @@ vi.mock('../../xero/XeroLiveMappingManager', () => ({
   )
 }));
 
-vi.mock('@alga-psa/integrations/actions', () => ({
+vi.mock('../../../actions/integrations/xeroActions', () => ({
   getXeroConnectionStatus: (...args: unknown[]) => getXeroConnectionStatusMock(...args),
   saveXeroCredentials: (...args: unknown[]) => saveXeroCredentialsMock(...args),
   disconnectXero: (...args: unknown[]) => disconnectXeroMock(...args)

--- a/packages/integrations/src/components/xero/XeroLiveMappingManager.tsx
+++ b/packages/integrations/src/components/xero/XeroLiveMappingManager.tsx
@@ -31,7 +31,7 @@ export function XeroLiveMappingManager({ defaultConnection }: XeroLiveMappingMan
       context={context}
       realmLabel={t('integrations.xero.live.defaultOrganisation', { defaultValue: 'Default Xero Organisation' })}
       tabStyles={tabStyles}
-      defaultTabId="Items / Services"
+      defaultTabId="xero-live-service-mappings"
       urlParamKey="xeroMappingTab"
     />
   );

--- a/packages/integrations/src/lib/xero/xeroClientService.credentials.test.ts
+++ b/packages/integrations/src/lib/xero/xeroClientService.credentials.test.ts
@@ -2,6 +2,7 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 const tenantSecrets = new Map<string, string>();
 const appSecrets = new Map<string, string>();
+const axiosRequestMock = vi.hoisted(() => vi.fn());
 
 const getTenantSecretMock = vi.fn(async (tenant: string, key: string) => {
   return tenantSecrets.get(`${tenant}:${key}`) || null;
@@ -15,7 +16,20 @@ vi.mock('@alga-psa/core/secrets', () => ({
   })
 }));
 
-import { getDefaultXeroTenantId, resolveXeroOAuthCredentials } from './xeroClientService';
+vi.mock('axios', () => {
+  const axios = {
+    request: (...args: unknown[]) => axiosRequestMock(...args),
+    post: vi.fn(),
+    isAxiosError: (error: unknown) => Boolean((error as { isAxiosError?: boolean })?.isAxiosError)
+  };
+  return { default: axios, ...axios };
+});
+
+import {
+  getDefaultXeroTenantId,
+  resolveXeroOAuthCredentials,
+  XeroClientService
+} from './xeroClientService';
 
 describe('Xero OAuth credential resolution', () => {
   beforeEach(() => {
@@ -82,5 +96,57 @@ describe('getDefaultXeroTenantId', () => {
 
   it('returns null when no Xero connection is stored', async () => {
     await expect(getDefaultXeroTenantId('tenant-1')).resolves.toBeNull();
+  });
+
+  it('selects a stored connection by its Xero organisation tenant id', async () => {
+    const future = new Date(Date.now() + 60 * 60 * 1000).toISOString();
+    tenantSecrets.set('tenant-1:xero_client_id', 'tenant-client-id');
+    tenantSecrets.set('tenant-1:xero_client_secret', 'tenant-client-secret');
+    tenantSecrets.set('tenant-1:xero_credentials', JSON.stringify({
+      'connection-default': {
+        connectionId: 'connection-default',
+        xeroTenantId: 'xero-tenant-default',
+        accessToken: 'default-access-token',
+        refreshToken: 'default-refresh-token',
+        accessTokenExpiresAt: future
+      },
+      'connection-selected': {
+        connectionId: 'connection-selected',
+        xeroTenantId: 'xero-tenant-selected',
+        accessToken: 'selected-access-token',
+        refreshToken: 'selected-refresh-token',
+        accessTokenExpiresAt: future
+      }
+    }));
+    axiosRequestMock.mockResolvedValueOnce({ data: { Items: [] } });
+
+    const client = await XeroClientService.create('tenant-1', 'xero-tenant-selected');
+    await client.listItems();
+
+    expect(axiosRequestMock).toHaveBeenCalledWith(expect.objectContaining({
+      headers: expect.objectContaining({
+        Authorization: 'Bearer selected-access-token',
+        'Xero-tenant-id': 'xero-tenant-selected'
+      })
+    }));
+  });
+
+  it('does not silently fall back to the default organisation for an unknown realm', async () => {
+    const future = new Date(Date.now() + 60 * 60 * 1000).toISOString();
+    tenantSecrets.set('tenant-1:xero_client_id', 'tenant-client-id');
+    tenantSecrets.set('tenant-1:xero_client_secret', 'tenant-client-secret');
+    tenantSecrets.set('tenant-1:xero_credentials', JSON.stringify({
+      'connection-default': {
+        connectionId: 'connection-default',
+        xeroTenantId: 'xero-tenant-default',
+        accessToken: 'default-access-token',
+        refreshToken: 'default-refresh-token',
+        accessTokenExpiresAt: future
+      }
+    }));
+
+    await expect(XeroClientService.create('tenant-1', 'unknown-realm')).rejects.toMatchObject({
+      code: 'XERO_CONNECTION_NOT_FOUND'
+    });
   });
 });

--- a/packages/integrations/src/lib/xero/xeroClientService.credentials.test.ts
+++ b/packages/integrations/src/lib/xero/xeroClientService.credentials.test.ts
@@ -15,7 +15,7 @@ vi.mock('@alga-psa/core/secrets', () => ({
   })
 }));
 
-import { resolveXeroOAuthCredentials } from './xeroClientService';
+import { getDefaultXeroTenantId, resolveXeroOAuthCredentials } from './xeroClientService';
 
 describe('Xero OAuth credential resolution', () => {
   beforeEach(() => {
@@ -56,5 +56,31 @@ describe('Xero OAuth credential resolution', () => {
     await expect(resolveXeroOAuthCredentials('tenant-1')).rejects.toThrow(
       'Xero client ID and client secret must both be configured for this tenant before connecting.'
     );
+  });
+});
+
+describe('getDefaultXeroTenantId', () => {
+  beforeEach(() => {
+    tenantSecrets.clear();
+    appSecrets.clear();
+    vi.clearAllMocks();
+  });
+
+  it('returns the Xero organisation tenant id from the first stored connection', async () => {
+    tenantSecrets.set('tenant-1:xero_credentials', JSON.stringify({
+      'connection-1': {
+        connectionId: 'connection-1',
+        xeroTenantId: 'xero-tenant-1',
+        accessToken: 'access-token',
+        refreshToken: 'refresh-token',
+        accessTokenExpiresAt: new Date(Date.now() + 60_000).toISOString()
+      }
+    }));
+
+    await expect(getDefaultXeroTenantId('tenant-1')).resolves.toBe('xero-tenant-1');
+  });
+
+  it('returns null when no Xero connection is stored', async () => {
+    await expect(getDefaultXeroTenantId('tenant-1')).resolves.toBeNull();
   });
 });

--- a/packages/integrations/src/lib/xero/xeroClientService.ts
+++ b/packages/integrations/src/lib/xero/xeroClientService.ts
@@ -347,9 +347,10 @@ export class XeroClientService {
       throw new AppError('XERO_NOT_CONFIGURED', `No Xero connections configured for tenant ${tenantId}`);
     }
 
-    const selectedConnection =
-      (connectionId ? connections[connectionId] : undefined) ??
-      connections[Object.keys(connections)[0]];
+    const selectedConnection = connectionId
+      ? connections[connectionId] ??
+        Object.values(connections).find((connection) => connection.xeroTenantId === connectionId)
+      : connections[Object.keys(connections)[0]];
 
     if (!selectedConnection) {
       throw new AppError('XERO_CONNECTION_NOT_FOUND', `Xero connection ${connectionId ?? 'default'} not found`, {

--- a/packages/integrations/src/lib/xero/xeroClientService.ts
+++ b/packages/integrations/src/lib/xero/xeroClientService.ts
@@ -850,6 +850,12 @@ export async function getXeroConnectionSummaries(tenantId: string): Promise<Xero
   return summaries;
 }
 
+export async function getDefaultXeroTenantId(tenantId: string): Promise<string | null> {
+  const connections = await getTenantConnections(tenantId);
+  const defaultConnection = Object.values(connections)[0];
+  return defaultConnection?.xeroTenantId ?? null;
+}
+
 async function getTenantConnections(tenantId: string): Promise<XeroConnectionsStore> {
   const secretProvider = await getSecretProviderInstance();
   const secret = await secretProvider.getTenantSecret(tenantId, XERO_CREDENTIALS_SECRET);

--- a/packages/integrations/src/routes/api/integrations/xero/callback.ts
+++ b/packages/integrations/src/routes/api/integrations/xero/callback.ts
@@ -58,6 +58,15 @@ function createRedirect(path: string, params?: Record<string, string | undefined
 }
 
 export async function GET(request: NextRequest): Promise<NextResponse> {
+  try {
+    return await handleCallbackRequest(request);
+  } catch (error) {
+    logger.error('[xeroOAuth] Unexpected Xero OAuth callback failure', { error });
+    return createRedirect(FAILURE_PATH, { xero_error: 'unexpected_failure' });
+  }
+}
+
+async function handleCallbackRequest(request: NextRequest): Promise<NextResponse> {
   if (!isEnterpriseEdition()) {
     return NextResponse.json(
       { error: 'Xero integration is only available in Enterprise Edition.' },

--- a/packages/integrations/src/routes/api/integrations/xero/connect.ts
+++ b/packages/integrations/src/routes/api/integrations/xero/connect.ts
@@ -42,6 +42,18 @@ function createPkcePair(): { verifier: string; challenge: string } {
 }
 
 export async function GET(): Promise<NextResponse> {
+  try {
+    return await handleConnectRequest();
+  } catch (error) {
+    logger.error('[xeroOAuth] Unexpected failure while starting Xero OAuth', { error });
+    return NextResponse.json(
+      { error: 'Unable to start the Xero connection. Please refresh and try again.' },
+      { status: 503 }
+    );
+  }
+}
+
+async function handleConnectRequest(): Promise<NextResponse> {
   if (!isEnterpriseEdition()) {
     return NextResponse.json(
       { error: 'Xero integration is only available in Enterprise Edition.' },

--- a/server/seeds/dev/31_invoice_charges.cjs
+++ b/server/seeds/dev/31_invoice_charges.cjs
@@ -18,7 +18,9 @@ exports.seed = async function (knex) {
                     description: 'Advanced Rabbit Tracking Services',
                     quantity: 40,
                     unit_price: 100.00,
-                    total_price: 4000.00
+                    total_price: 4000.00,
+                    net_amount: 4000.00,
+                    tax_amount: 0
                 },
                 {
                     tenant: tenantId,
@@ -31,7 +33,9 @@ exports.seed = async function (knex) {
                     description: 'Emergency Looking Glass Repair',
                     quantity: 1,
                     unit_price: 1000.00,
-                    total_price: 1000.00
+                    total_price: 1000.00,
+                    net_amount: 1000.00,
+                    tax_amount: 0
                 },
                 {
                     tenant: tenantId,
@@ -44,7 +48,9 @@ exports.seed = async function (knex) {
                     description: 'Major Yellow Brick Road Overhaul',
                     quantity: 1,
                     unit_price: 10000.00,
-                    total_price: 10000.00
+                    total_price: 10000.00,
+                    net_amount: 10000.00,
+                    tax_amount: 0
                 },
                 {
                     tenant: tenantId,
@@ -57,7 +63,9 @@ exports.seed = async function (knex) {
                     description: 'Enhanced Security Package',
                     quantity: 1,
                     unit_price: 2000.00,
-                    total_price: 2000.00
+                    total_price: 2000.00,
+                    net_amount: 2000.00,
+                    tax_amount: 0
                 },
                 {
                     tenant: tenantId,
@@ -70,7 +78,9 @@ exports.seed = async function (knex) {
                     description: 'Premium Rabbit Tracking Services',
                     quantity: 50,
                     unit_price: 125.00,
-                    total_price: 6250.00
+                    total_price: 6250.00,
+                    net_amount: 6250.00,
+                    tax_amount: 0
                 },
                 {
                     tenant: tenantId,
@@ -83,7 +93,9 @@ exports.seed = async function (knex) {
                     description: 'Monthly Looking Glass Maintenance',
                     quantity: 1,
                     unit_price: 1250.00,
-                    total_price: 1250.00
+                    total_price: 1250.00,
+                    net_amount: 1250.00,
+                    tax_amount: 0
                 }
             ]);
 };

--- a/server/src/lib/api/controllers/ApiAccountingExportController.ts
+++ b/server/src/lib/api/controllers/ApiAccountingExportController.ts
@@ -36,6 +36,16 @@ const PREVIEW_LINE_LIMIT = 50;
 
 type AccountingExportPermission = 'create' | 'read' | 'update' | 'execute';
 
+function isAccountingExportActionFailure(
+  value: unknown
+): value is { success: false; code: string; message: string } {
+  if (!value || typeof value !== 'object') return false;
+  const candidate = value as { success?: unknown; code?: unknown; message?: unknown };
+  return candidate.success === false &&
+    typeof candidate.code === 'string' &&
+    typeof candidate.message === 'string';
+}
+
 const noopService: BaseService = {
   async list(_options: ListOptions): Promise<{ data: any[]; total: number }> {
     throw new NotImplementedError('Accounting export controller does not support base list operations');
@@ -481,6 +491,21 @@ export class ApiAccountingExportController extends ApiBaseController {
         try {
           const result = await executeAccountingExportBatch(params.batchId);
 
+          if (isActionPermissionError(result)) {
+            return NextResponse.json({ error: 'forbidden', message: result.permissionError }, { status: 403 });
+          }
+          if (isAccountingExportActionFailure(result)) {
+            const status = result.code === 'ACCOUNTING_EXPORT_INVALID_STATE'
+              ? 409
+              : result.code === 'ACCOUNTING_EXPORT_UNEXPECTED'
+                ? 500
+                : 400;
+            return NextResponse.json(
+              { error: result.code, message: result.message },
+              { status }
+            );
+          }
+
           return NextResponse.json(result);
         } catch (error) {
           if (error instanceof AppError && error.code === 'ACCOUNTING_EXPORT_INVALID_STATE') {
@@ -523,6 +548,12 @@ export class ApiAccountingExportController extends ApiBaseController {
 
           if (isActionPermissionError(result)) {
             return NextResponse.json({ error: 'forbidden', message: result.permissionError }, { status: 403 });
+          }
+          if (isAccountingExportActionFailure(result)) {
+            return NextResponse.json(
+              { error: result.code, message: result.message },
+              { status: result.code === 'ACCOUNTING_EXPORT_UNEXPECTED' ? 500 : 400 }
+            );
           }
 
           const files = (result.metadata as any)?.files ?? [];

--- a/server/src/lib/api/controllers/ApiAccountingExportController.ts
+++ b/server/src/lib/api/controllers/ApiAccountingExportController.ts
@@ -121,6 +121,26 @@ export class ApiAccountingExportController extends ApiBaseController {
             ...body,
             created_by: body.created_by ?? apiRequest.context.userId
           });
+
+          if (isActionPermissionError(batch)) {
+            return NextResponse.json(
+              { error: 'forbidden', message: batch.permissionError },
+              { status: 403 }
+            );
+          }
+          if (isAccountingExportActionFailure(batch)) {
+            const status = batch.code === 'ACCOUNTING_EXPORT_DUPLICATE' ||
+              batch.code === 'ACCOUNTING_EXPORT_EMPTY_BATCH'
+              ? 409
+              : batch.code === 'ACCOUNTING_EXPORT_UNEXPECTED'
+                ? 500
+                : 400;
+            return NextResponse.json(
+              { error: batch.code, message: batch.message },
+              { status }
+            );
+          }
+
           return NextResponse.json(batch, { status: 201 });
         } catch (error) {
           if (error instanceof AppError && error.code === 'ACCOUNTING_EXPORT_DUPLICATE') {

--- a/server/src/test/integration/accounting/xeroLiveExport.integration.test.ts
+++ b/server/src/test/integration/accounting/xeroLiveExport.integration.test.ts
@@ -121,7 +121,12 @@ describe('Live Xero export integration', () => {
     });
   }
 
-  async function seedLiveXeroBatch(): Promise<{ batchId: string; lineId: string }> {
+  async function seedLiveXeroBatch(options: {
+    targetRealm?: string | null;
+    netAmount?: number | null;
+  } = {}): Promise<{ batchId: string; lineId: string }> {
+    const targetRealm = options.targetRealm ?? null;
+    const netAmount = options.netAmount === undefined ? 5000 : options.netAmount;
     const serviceId = await createTestService(ctx, {
       service_name: 'Managed Endpoint',
       billing_method: 'fixed',
@@ -144,7 +149,7 @@ describe('Live Xero export integration', () => {
         alga_entity_type: 'service',
         alga_entity_id: serviceId,
         external_entity_id: 'ITEM-001',
-        external_realm_id: null,
+        external_realm_id: targetRealm,
         metadata: { accountCode: '200' },
         sync_status: 'synced',
         created_at: now,
@@ -157,7 +162,7 @@ describe('Live Xero export integration', () => {
         alga_entity_type: 'client',
         alga_entity_id: ctx.clientId,
         external_entity_id: 'CONTACT-001',
-        external_realm_id: null,
+        external_realm_id: targetRealm,
         sync_status: 'synced',
         created_at: now,
         updated_at: now
@@ -188,7 +193,7 @@ describe('Live Xero export integration', () => {
       description: 'Endpoint subscription',
       quantity: 1,
       unit_price: 5000,
-      net_amount: 5000,
+      net_amount: netAmount,
       total_price: 5000,
       tax_amount: 0,
       is_manual: false,
@@ -199,7 +204,7 @@ describe('Live Xero export integration', () => {
     const batch = await service.createBatch({
       adapter_type: 'xero',
       export_type: 'invoice',
-      target_realm: null,
+      target_realm: targetRealm,
       filters: { start_date: '2025-01-01', end_date: '2025-01-31' },
       created_by: ctx.user.user_id
     });
@@ -285,5 +290,38 @@ describe('Live Xero export integration', () => {
     expect(line.line_id).toBe(lineId);
     expect(line.status).not.toBe('delivered');
     expect(line.external_document_ref).toBeNull();
+  }, HOOK_TIMEOUT);
+
+  it('T019: realm-scoped Xero service and client mappings resolve for a realm-targeted batch', async () => {
+    const { batchId, lineId } = await seedLiveXeroBatch({ targetRealm: 'xero-tenant-1' });
+
+    xeroCreateMock.mockResolvedValue({
+      createInvoices: vi.fn(async (payloads: Array<Record<string, any>>) => [{
+        status: 'success',
+        invoiceId: 'xero-invoice-realm-1',
+        documentId: payloads[0].invoiceId
+      }])
+    });
+
+    await expect(service.executeBatch(batchId)).resolves.toEqual({
+      deliveredLines: [{ lineId, externalDocumentRef: 'xero-invoice-realm-1' }],
+      metadata: { adapter: 'xero', deliveredInvoices: 1 }
+    });
+    expect(xeroCreateMock).toHaveBeenCalledWith(ctx.tenantId, 'xero-tenant-1');
+  }, HOOK_TIMEOUT);
+
+  it('T020: missing net_amount is a per-line readiness error and never reaches the Xero adapter', async () => {
+    const { batchId, lineId } = await seedLiveXeroBatch({ netAmount: null });
+
+    await expect(service.executeBatch(batchId)).rejects.toMatchObject({
+      code: 'ACCOUNTING_EXPORT_VALIDATION_FAILED'
+    });
+    expect(xeroCreateMock).not.toHaveBeenCalled();
+
+    const errors = await repository.listErrors(batchId);
+    expect(errors).toContainEqual(expect.objectContaining({
+      line_id: lineId,
+      code: 'missing_net_amount'
+    }));
   }, HOOK_TIMEOUT);
 });

--- a/server/src/test/unit/accounting/accountingExportValidation.servicePeriodProjection.test.ts
+++ b/server/src/test/unit/accounting/accountingExportValidation.servicePeriodProjection.test.ts
@@ -55,6 +55,29 @@ describe('AccountingExportValidation service-period projection', () => {
         },
         resolution_state: 'open',
       },
+      {
+        line_id: 'line-2',
+        batch_id: 'batch-1',
+        tenant: 'tenant-1',
+        document_id: 'invoice-2',
+        document_line_id: 'charge-2',
+        client_id: 'client-1',
+        amount_cents: 5000,
+        currency_code: 'USD',
+        service_period_start: '2026-05-01T00:00:00.000Z',
+        service_period_end: '2026-06-01T00:00:00.000Z',
+        payload: {
+          service_period_source: 'canonical_detail_periods',
+          recurring_detail_periods: [
+            {
+              service_period_start: '2026-05-01T00:00:00.000Z',
+              service_period_end: '2026-06-01T00:00:00.000Z',
+              billing_timing: 'advance',
+            },
+          ],
+        },
+        resolution_state: 'open',
+      },
     ];
 
     const persistedErrors: Array<Record<string, unknown>> = [];
@@ -77,6 +100,14 @@ describe('AccountingExportValidation service-period projection', () => {
             invoice_id: 'invoice-1',
             service_id: 'service-1',
             tax_region: null,
+            net_amount: 10000,
+          },
+          {
+            item_id: 'charge-2',
+            invoice_id: 'invoice-2',
+            service_id: 'service-1',
+            tax_region: null,
+            net_amount: 5000,
           },
         ]);
       }
@@ -94,12 +125,23 @@ describe('AccountingExportValidation service-period projection', () => {
             service_period_end: '2026-03-01T00:00:00.000Z',
             billing_timing: 'advance',
           },
+          {
+            item_id: 'charge-2',
+            service_period_start: new Date('2026-05-01T04:00:00.000Z'),
+            service_period_end: new Date('2026-06-01T04:00:00.000Z'),
+            billing_timing: 'advance',
+          },
         ]);
       }
       if (table === 'invoices') {
         return buildThenableQuery([
           {
             invoice_id: 'invoice-1',
+            client_id: 'client-1',
+            tax_source: 'internal',
+          },
+          {
+            invoice_id: 'invoice-2',
             client_id: 'client-1',
             tax_source: 'internal',
           },
@@ -137,7 +179,7 @@ describe('AccountingExportValidation service-period projection', () => {
     } as unknown as AccountingExportRepository);
 
     const resolver = {
-      resolveServiceMapping: vi.fn(),
+      resolveServiceMapping: vi.fn().mockResolvedValue({ externalEntityId: 'ITEM-1' }),
       resolveTaxCodeMapping: vi.fn(),
       resolvePaymentTermMapping: vi.fn(),
       resolveClientMapping: vi.fn(),
@@ -171,6 +213,7 @@ describe('AccountingExportValidation service-period projection', () => {
     });
     expect(updateBatchStatus).toHaveBeenCalledWith('batch-1', { status: 'needs_attention' });
     expect(batch.status).toBe('needs_attention');
-    expect(resolver.resolveServiceMapping).not.toHaveBeenCalled();
+    expect(resolver.resolveServiceMapping).toHaveBeenCalledOnce();
+    expect(persistedErrors).not.toContainEqual(expect.objectContaining({ line_id: 'line-2' }));
   });
 });

--- a/server/src/test/unit/api/apiAccountingExportController.test.ts
+++ b/server/src/test/unit/api/apiAccountingExportController.test.ts
@@ -1,0 +1,63 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { NextRequest } from 'next/server';
+
+const createAccountingExportBatchMock = vi.hoisted(() => vi.fn());
+
+vi.mock('@alga-psa/billing/actions', () => ({
+  createAccountingExportBatch: createAccountingExportBatchMock,
+  appendAccountingExportLines: vi.fn(),
+  appendAccountingExportErrors: vi.fn(),
+  updateAccountingExportBatchStatus: vi.fn(),
+  getAccountingExportBatch: vi.fn(),
+  listAccountingExportBatches: vi.fn(),
+  executeAccountingExportBatch: vi.fn()
+}));
+
+import { ApiAccountingExportController } from '../../../lib/api/controllers/ApiAccountingExportController';
+
+describe('ApiAccountingExportController.createBatch', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('returns a conflict response when the server action reports a duplicate export', async () => {
+    createAccountingExportBatchMock.mockResolvedValue({
+      success: false,
+      code: 'ACCOUNTING_EXPORT_DUPLICATE',
+      message: 'An export batch already exists for this filter selection'
+    });
+
+    const controller = new ApiAccountingExportController();
+    const controllerInternals = controller as unknown as {
+      authenticate: (request: NextRequest) => Promise<NextRequest>;
+      authorize: () => Promise<void>;
+    };
+    vi.spyOn(controllerInternals, 'authenticate').mockImplementation(async (request: NextRequest) => {
+      const authenticatedRequest = request as NextRequest & {
+        context: { tenant: string; userId: string; user: { user_type: string } };
+      };
+      authenticatedRequest.context = {
+        tenant: 'tenant-1',
+        userId: 'user-1',
+        user: { user_type: 'internal' }
+      };
+      return authenticatedRequest;
+    });
+    vi.spyOn(controllerInternals, 'authorize').mockResolvedValue(undefined);
+
+    const response = await controller.createBatch(new NextRequest(
+      'http://localhost/api/accounting/exports',
+      {
+        method: 'POST',
+        body: JSON.stringify({ adapter_type: 'xero', export_type: 'invoice' }),
+        headers: { 'content-type': 'application/json' }
+      }
+    ));
+
+    expect(response.status).toBe(409);
+    await expect(response.json()).resolves.toEqual({
+      error: 'ACCOUNTING_EXPORT_DUPLICATE',
+      message: 'An export batch already exists for this filter selection'
+    });
+  });
+});


### PR DESCRIPTION
## Summary

- Restores the live Xero mapping experience: Items / Services and Tax Codes render, switch correctly, and keep `xeroMappingTab` synchronized with the URL.
- Adds the live Xero adapter to Accounting Export and stamps new Xero batches with the connected organisation's `xeroTenantId`, allowing realm-scoped mappings to resolve.
- Resolves stored Xero credentials by either connection ID or Xero tenant ID without falling back to an unknown explicit realm.
- Normalizes recurring service-period comparisons by calendar date, repairs the development invoice-charge seed amounts, clears stale notes after a successful delivery, and refreshes batch state after execution.
- Converts expected accounting-export and Xero failures into structured, operator-friendly responses across the UI and REST seams.
- Records the live-repro fix plan, customer reply, and a separate implementation plan for inbound Xero synchronization.

## Smoke-test status

**PASS:** the implemented outbound Xero remediation passed live smoke testing. Inbound/two-way synchronization remains follow-up work and is not implemented in this branch.

Environment: the exact worktree Next.js process was verified on port 3708 with the `alga-psa-local-test` infrastructure running.

Live flows passed:

- Xero Items / Services and Tax Codes mapping tabs render, switch, and synchronize `xeroMappingTab` in the URL. The existing realm-scoped Cat6 Patch 1ft → GB1-White mapping was visible.
- New Accounting Export offers the live Xero adapter.
- A no-match Xero export shows a friendly error with no browser 5xx response.
- Finalized existing Cool Cars invoice `INV-000001` through the UI and created batch `3b6f971e-1851-42f0-8f95-cd422e3dc81f`. Database verification confirmed `target_realm = da4345b3-451a-4b0a-bb8a-c17c619f5fbb` rather than null.
- Executed the batch against the real Xero Demo Company (US). It became Delivered with one delivered line, zero open errors, refreshed immediately in the list, and cleared its notes to `NULL`.
- Independently reread external invoice `c7d35fb3-ff3a-416c-911c-a1eca73c689d` from the real Xero API: `INV-000001`, DRAFT, USD 1.00, one line.
- Re-executing the delivered batch showed “Cannot execute batch in status delivered,” retained the refreshed Delivered state, and produced no 5xx response.

Fidelity: the real Alga UI, shared development database, and live Xero API were used. No simulator or mock was used.

## Limitations and concerns

- Direct Xero web UI evidence was blocked by an expired browser login. Xero-side verification used the authenticated API instead.
- The REST create endpoint's non-201 failure behavior could not be exercised past authentication. Session requests are blocked by API-key middleware, and no plaintext development API key was available. The focused handler test remains the proof for that seam.
- Missing-net-amount and recurring service-period failure branches were not freshly recreated because doing so required corrupting or re-exporting existing source data.
- Historical delivered batch `70995e4c` still retains its pre-fix error note. Cleanup occurs on a new successful delivery and is not retroactive.
- The pre-existing `package-lock.json` modification remains untouched and is not part of this pull request.

## Evidence

`/tmp/alga-smoke-evidence/xero-two-way-sync-20260714-093153`
