### PR TITLE
Internal note adjacent text confusion

### DIFF
--- a/docs/plans/2026-07-14-internal-note-adjacent-text-plan.md
+++ b/docs/plans/2026-07-14-internal-note-adjacent-text-plan.md
@@ -1,0 +1,80 @@
+# Internal notes must not claim the contact will be notified
+
+Ticket: alga0002120
+Branch: `fix/internal-note-adjacent-text`
+
+## Problem
+
+In the bento ticket view, the Timeline tile's composer shows a heading directly above the
+editor that reads "Reply to Andrew" (the contact's first name). The heading renders
+unconditionally, so it stays in place when the agent switches the lane toggle to **Internal**
+— telling them they are addressing the contact while they write a note the contact will never
+receive. The Resolution lane has the same heading, where it is redundant with the close-status
+and notification-suppression controls the lane already reveals.
+
+Only the text is wrong. `composerLane` already drives `isInternal` on send, so internal notes
+have always been *saved* correctly and no contact has ever been notified about one. This is a
+UI-copy defect, not a notification defect.
+
+## Change
+
+Single component: `packages/tickets/src/components/ticket/bento/BentoTimelineTile.tsx`, the
+`composer` block (currently lines 665–675).
+
+Make the heading a function of `composerLane`:
+
+- **Client lane** — unchanged. Renders `bento.timeline.replyTo` ("Reply to {{name}}") when
+  `contactFirstName` is present, and falls back to `bento.timeline.writeReply` ("Write a
+  reply") when the ticket has no contact.
+- **Internal lane** — render no heading at all.
+- **Resolution lane** — render no heading at all.
+
+The `<p>` (and its `mb-1.5`) is omitted rather than blanked, so the editor collapses upward in
+the two lanes that have no heading. The lane toggle sits immediately below the editor and is
+always visible, so the composer's mode stays legible without the heading; the Resolution lane
+additionally surfaces its own close-status selector and "Don't notify the customer" controls,
+which state the notification consequences more precisely than a heading could.
+
+No behavior changes, no new copy, and therefore no new i18n keys — `bento.timeline.replyTo`
+and `bento.timeline.writeReply` keep their current meaning and remain in use in the client
+lane, so the ten locale files under `server/public/locales/*/features/tickets.json` are
+untouched.
+
+## Test
+
+Add `packages/tickets/src/components/ticket/bento/BentoTimelineTile.composerHeading.test.tsx`,
+following the conventions already used in that directory (`BentoHero.unsavedChanges.test.tsx`,
+`TicketActivityTimeline.silentAnnotation.test.tsx`): `/* @vitest-environment jsdom */`,
+Testing Library, and `vi.mock` for `@alga-psa/ui/lib/i18n/client` so `t` returns its fallback
+string.
+
+Render `BentoTimelineTile` with `contactFirstName="Andrew"` and assert:
+
+1. On first render (client lane is the default), the heading "Reply to Andrew" is present.
+2. After clicking the **Internal** lane button (`#<id>-composer-lane-internal`), the heading is
+   gone.
+3. After clicking the **Resolution** lane button (`#<id>-composer-lane-resolution`), the
+   heading is gone.
+4. Returning to the **Client** lane brings the heading back.
+
+A fifth case covers the no-contact ticket: with `contactFirstName` null or absent, the client
+lane shows "Write a reply" and the other two lanes still show nothing.
+
+Mock the tile's data dependencies (timeline entries, reactions, `TextEditor`) as the
+neighbouring bento tests do, so the test exercises the composer chrome without booting the
+editor.
+
+## Verification
+
+Run the tickets package unit tests, then confirm in the running dev stack (port 3919): open a
+ticket with a contact in the bento view, click **Internal** in the composer, and see the "Reply
+to <contact>" line disappear; click back to **Client** and see it return.
+
+## Out of scope
+
+- The internal-note save path, the ticket email/notification subscribers, and the
+  notification-suppression controls — all correct today.
+- `InlineReplyComposer` (threaded replies, both bento and classic views) — it has no
+  person-named heading and inherits its parent comment's internal flag.
+- The classic `TicketConversation` composer — it uses lane tabs, with no copy addressing the
+  contact by name.

--- a/packages/tickets/src/components/ticket/bento/BentoTimelineTile.composerHeading.test.tsx
+++ b/packages/tickets/src/components/ticket/bento/BentoTimelineTile.composerHeading.test.tsx
@@ -1,0 +1,170 @@
+/* @vitest-environment jsdom */
+/// <reference types="@testing-library/jest-dom/vitest" />
+
+import React from 'react';
+import { fireEvent, render, screen } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { BentoTimelineTile } from './BentoTimelineTile';
+
+type BentoTimelineTileProps = React.ComponentProps<typeof BentoTimelineTile>;
+
+vi.mock('next/dynamic', () => ({
+  default: () => () => <div data-testid="composer-editor" />,
+}));
+
+vi.mock('@alga-psa/ui/lib/i18n/client', () => ({
+  useTranslation: () => ({
+    t: (_key: string, fallback?: string, values?: Record<string, unknown>) => {
+      let result = fallback ?? _key;
+      for (const [name, value] of Object.entries(values ?? {})) {
+        result = result.replace(`{{${name}}}`, String(value));
+      }
+      return result;
+    },
+  }),
+}));
+
+vi.mock('@alga-psa/ui/components/Button', () => ({
+  Button: ({
+    children,
+    id,
+    onClick,
+    disabled,
+  }: {
+    children: React.ReactNode;
+    id: string;
+    onClick: () => void;
+    disabled?: boolean;
+  }) => (
+    <button id={id} type="button" onClick={onClick} disabled={disabled}>
+      {children}
+    </button>
+  ),
+}));
+
+vi.mock('@alga-psa/ui/components/CustomSelect', () => ({
+  default: () => null,
+}));
+
+vi.mock('@alga-psa/ui/components/Label', () => ({
+  Label: ({ children }: { children: React.ReactNode }) => <span>{children}</span>,
+}));
+
+vi.mock('@alga-psa/ui/components/bento/BentoTile', () => ({
+  BentoTile: ({ children }: { children: React.ReactNode }) => <section>{children}</section>,
+  BentoTileEmpty: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+}));
+
+vi.mock('@alga-psa/ui/components', () => ({
+  buildCommentThreadGroups: () => [],
+  HybridThreadNode: () => null,
+}));
+
+vi.mock('@alga-psa/ui/components/InlineReplyComposer', () => ({
+  default: () => null,
+}));
+
+vi.mock('@alga-psa/ui/keyboard-shortcuts', () => ({
+  useDialogSubmitShortcut: () => undefined,
+  usePageCreateShortcut: () => undefined,
+}));
+
+vi.mock('@alga-psa/ui/ui-reflection/withDataAutomationId', () => ({
+  withDataAutomationId: ({ id }: { id: string }) => ({ 'data-testid': id }),
+}));
+
+vi.mock('@alga-psa/core/context/DocumentsCrossFeatureContext', () => ({
+  useDocumentsCrossFeature: () => ({ deleteDocument: vi.fn() }),
+}));
+
+vi.mock('@alga-psa/user-composition/actions', () => ({
+  searchUsersForMentions: vi.fn(),
+}));
+
+vi.mock('../../../actions/ticketActivityActions', () => ({
+  getTicketTimelineEntries: vi.fn().mockResolvedValue([]),
+}));
+
+vi.mock('../../../actions/ticketLayoutPreference', () => ({
+  setTicketLayoutPreference: vi.fn().mockResolvedValue(undefined),
+}));
+
+vi.mock('../../../actions/comment-actions/commentReactionActions', () => ({
+  getCommentsReactionsBatch: vi.fn().mockResolvedValue({ reactions: {}, userNames: {} }),
+  toggleCommentReaction: vi.fn(),
+}));
+
+vi.mock('../CommentItem', () => ({
+  default: () => null,
+}));
+
+vi.mock('../TicketConversation', () => ({
+  DEFAULT_BLOCK: [],
+}));
+
+vi.mock('../TicketNotificationSuppressionControl', () => ({
+  default: () => null,
+}));
+
+vi.mock('../useTicketRichTextUploadSession', () => ({
+  useTicketRichTextUploadSession: () => ({
+    uploadFile: vi.fn(),
+    resetDraftTracking: vi.fn(),
+  }),
+}));
+
+const defaultProps: BentoTimelineTileProps = {
+  id: 'ticket-timeline',
+  ticketId: 'ticket-1',
+  conversations: [],
+  userMap: {},
+  contactMap: {},
+  contactFirstName: 'Andrew',
+  editorKey: 1,
+  onNewCommentContentChange: vi.fn(),
+  onAddNewComment: vi.fn().mockResolvedValue(true),
+  isEditing: false,
+  currentComment: null,
+  onContentChange: vi.fn(),
+  onSaveComment: vi.fn(),
+  onCloseEdit: vi.fn(),
+  onEditComment: vi.fn(),
+  onDeleteComment: vi.fn(),
+};
+
+function renderTimeline(overrides: Partial<BentoTimelineTileProps> = {}) {
+  return render(<BentoTimelineTile {...defaultProps} {...overrides} />);
+}
+
+describe('BentoTimelineTile composer heading', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('shows the contact heading only in the client lane', () => {
+    renderTimeline();
+
+    expect(screen.getByText('Reply to Andrew')).toBeInTheDocument();
+
+    fireEvent.click(document.getElementById('ticket-timeline-composer-lane-internal')!);
+    expect(screen.queryByText('Reply to Andrew')).not.toBeInTheDocument();
+
+    fireEvent.click(document.getElementById('ticket-timeline-composer-lane-resolution')!);
+    expect(screen.queryByText('Reply to Andrew')).not.toBeInTheDocument();
+
+    fireEvent.click(document.getElementById('ticket-timeline-composer-lane-client')!);
+    expect(screen.getByText('Reply to Andrew')).toBeInTheDocument();
+  });
+
+  it('shows the no-contact fallback only in the client lane', () => {
+    renderTimeline({ contactFirstName: null });
+
+    expect(screen.getByText('Write a reply')).toBeInTheDocument();
+
+    fireEvent.click(document.getElementById('ticket-timeline-composer-lane-internal')!);
+    expect(screen.queryByText('Write a reply')).not.toBeInTheDocument();
+
+    fireEvent.click(document.getElementById('ticket-timeline-composer-lane-resolution')!);
+    expect(screen.queryByText('Write a reply')).not.toBeInTheDocument();
+  });
+});

--- a/packages/tickets/src/components/ticket/bento/BentoTimelineTile.tsx
+++ b/packages/tickets/src/components/ticket/bento/BentoTimelineTile.tsx
@@ -668,11 +668,13 @@ export function BentoTimelineTile({
       ref={composerRef}
       className="mt-3 rounded-lg border border-[rgb(var(--color-border-200))] bg-[rgb(var(--color-card))] p-3"
     >
-      <p className="text-xs font-medium text-[rgb(var(--color-text-500))] mb-1.5">
-        {contactFirstName
-          ? t('bento.timeline.replyTo', 'Reply to {{name}}', { name: contactFirstName })
-          : t('bento.timeline.writeReply', 'Write a reply')}
-      </p>
+      {composerLane === 'client' ? (
+        <p className="text-xs font-medium text-[rgb(var(--color-text-500))] mb-1.5">
+          {contactFirstName
+            ? t('bento.timeline.replyTo', 'Reply to {{name}}', { name: contactFirstName })
+            : t('bento.timeline.writeReply', 'Write a reply')}
+        </p>
+      ) : null}
       <TextEditor
         {...withDataAutomationId({ id: `${id}-composer-editor` })}
         key={editorKey}


### PR DESCRIPTION
## Summary

- Show the “Reply to {contact}” / “Write a reply” composer heading only in the Client lane.
- Remove the misleading heading—and its adjacent spacing—from Internal and Resolution lanes while restoring it whenever the user returns to Client.
- Add focused coverage for lane switching with both a named contact and the no-contact fallback.

## Verification

- Focused composer-heading tests: PASS (2/2).
- Tickets typecheck: PASS.
- Root production build: PASS.
- Full tickets suite: 94 files passed and 13 failed from unrelated, pre-existing branch failures.

## Real-product smoke test

PASS. Tested the real product on port 3919 against compose project `alga-psa-local-test` and restored the board-owned dev server before handoff.

Flows exercised:

- TIC1001 with contact Alice: Client showed “Reply to Alice”; Internal and Resolution removed the heading and collapsed the spacing; returning to Client restored it.
- TIC001015 without a primary contact: Client showed “Write a reply”; Internal and Resolution hid it; returning to Client restored it.
- Nearby regression: created an internal note through the real editor and Send flow. Database comment `99636aac-208b-4e3b-839e-8640cdcad8a9` persisted with `is_internal=true` and `is_resolution=false`.

No simulators or mocks were used. Lane changes, typing, and submission used real browser interactions. JavaScript was used only to position the nested scroll container for screenshots after browser-scroll could not target it.

Evidence: `/tmp/alga-smoke-evidence/internal-note-adjacent-text-20260714-092903`

## Known limitations

Hocuspocus collaboration attempted `ws://localhost:1234` while the wired container is exposed on port 1274, producing WebSocket errors. Multi-user editor collaboration was therefore not validated, although ordinary note submission and database persistence succeeded. Restart-related HMR errors were also observed; no failed HTTP requests occurred after the final restart.

Pre-existing `package.json` and `package-lock.json` worktree changes remain untouched and are not part of this PR.
