### PR TITLE
Manual inventory error

### DIFF
--- a/docs/plans/2026-07-14-manual-invoice-error-surfacing-plan.md
+++ b/docs/plans/2026-07-14-manual-invoice-error-surfacing-plan.md
@@ -1,0 +1,203 @@
+# Manual Invoice Error Surfacing — Implementation Plan
+
+**Date:** 2026-07-14
+**Branch:** `fix/manual-inventory-error-handling`
+**Ticket:** alga0002092 (Talaria Works — "Saving quotes causes an error", phase 2: manual invoice generation errors)
+
+## Problem
+
+Andrew (Talaria Works, prod tenant `d8ec1212-4487-4eba-83bb-4b6046816408`) cannot generate a
+manual invoice and only ever sees **"Error generating invoice"**. His tenant has zero invoices
+all-time. Investigation (2026-07-14, prod Loki + DB) found the direct cause plus a masking bug
+that hides *every* failure mode behind the same string:
+
+1. **i18n masking (the bug this card fixes).** `translateManualInvoiceError` in
+   `packages/billing/src/components/billing-dashboard/ManualInvoices.tsx:235` falls back to
+   `t('manualInvoices.errors.generateFailed', { defaultValue: message })`. That key **exists**
+   in `server/public/locales/*/msp/invoicing.json` ("Error generating invoice"), so i18next
+   resolves it and the real server message never renders. Andrew's client "Omni Energy
+   Partners" has no billing-location email; the server correctly returns *"Cannot generate
+   invoice: No billing email address for …"* (`invoiceService.ts:331`) and the UI throws that
+   text away.
+2. **Handled failures are invisible in prod logs.** `generateManualInvoice` returns
+   `{success:false, error}` without logging anything, which is why Loki had no trace of any of
+   Andrew's attempts.
+3. Two systemic error sources feed the same generic message and are **ticketed separately,
+   out of scope here**: deploy-skew "Failed to find Server Action" (alga0002126), session
+   expiry `AuthenticationError` (alga0002127). Invoice-number seeding (`TIC001000` for tenants
+   with no `next_number` INVOICE row) is alga0002128.
+
+## Settled design (approved 2026-07-14)
+
+**Approach B — structured error codes.** Handled errors travel as *data* (immune to Next's
+production error masking), the UI translates per code, and every failure is logged
+server-side with context.
+
+- New typed error carrying `code` + `params`; known failure points in the manual-invoice
+  flow produce it.
+- `generateManualInvoice` and `updateInvoiceManualItems` return
+  `{ success: false, code, params, message }` for handled failures; unexpected throws are
+  caught at the action boundary, logged with a short **reference ID** + stack, and returned
+  as `{ success: false, code: 'UNEXPECTED', ref }`.
+- UI maps `code → manualInvoices.errors.<code>` (params interpolated) in **all locales**;
+  unknown code → show server `message` verbatim; `UNEXPECTED` → generic message that includes
+  the ref ID.
+- Pre-submit guard: selecting a client with no billing-location email shows an inline warning
+  immediately.
+- Edit-path atomicity: `recalculateInvoice` moves inside the item-mutation transaction.
+
+## Work items
+
+### W1 — Typed manual-invoice errors
+
+New module `packages/billing/src/errors/manualInvoiceErrors.ts`:
+
+```ts
+export type ManualInvoiceErrorCode =
+  | 'NO_BILLING_EMAIL'          // params: { clientName }
+  | 'CLIENT_NOT_FOUND'
+  | 'SERVICE_NOT_FOUND'         // params: { serviceId }
+  | 'INVALID_QUANTITY'
+  | 'NO_TAX_RATE'               // params: { region, date }
+  | 'DISCOUNT_TARGET_NOT_FOUND' // params: { serviceId }
+  | 'INVOICE_NUMBER_CONFLICT'
+  | 'PERMISSION_DENIED'
+  | 'UNEXPECTED';               // params: { ref }
+
+export class ManualInvoiceError extends Error {
+  constructor(
+    public readonly code: Exclude<ManualInvoiceErrorCode, 'UNEXPECTED'>,
+    message: string,                       // human-readable fallback, English
+    public readonly params: Record<string, string> = {}
+  ) { super(message); this.name = 'ManualInvoiceError'; }
+}
+```
+
+Result envelope (extend the existing `ManualInvoiceResult` union in
+`packages/billing/src/actions/manualInvoiceActions.ts`):
+
+```ts
+{ success: false; code: ManualInvoiceErrorCode; params?: Record<string,string>; message: string; ref?: string }
+```
+
+Keep `error: string` populated alongside `message` for one release so any other consumer of
+the old shape keeps working (grep for callers; the only UI consumer is `ManualInvoices.tsx`).
+
+### W2 — Produce typed errors at the known failure points
+
+All in `packages/billing/src`:
+
+- `services/invoiceService.ts`
+  - `validateClientBillingEmail` (line ~331): return the code + params
+    (`NO_BILLING_EMAIL`, `{clientName}`) alongside the existing message.
+  - `persistManualInvoiceCharges` (line ~454): `Service not found: <id>` (~477) →
+    `ManualInvoiceError('SERVICE_NOT_FOUND', …, {serviceId})`; `Quantity must be greater
+    than 0` (~518) → `INVALID_QUANTITY`; discount-target throw (~571) →
+    `DISCOUNT_TARGET_NOT_FOUND`.
+  - `getClientDetails`: not-found → `CLIENT_NOT_FOUND`.
+- `services/taxService.ts` (~116): `No active tax rate(s) found for region <X> on date <Y>`
+  → `ManualInvoiceError('NO_TAX_RATE', <same message>, {region, date})`. **Keep the message
+  text byte-identical** — other consumers (recurring invoice generation, existing UI
+  string-matching) sniff it. `ManualInvoiceError extends Error`, so existing
+  `catch (e) { e.message }` call sites are unaffected.
+- `actions/manualInvoiceActions.ts` — `generateManualInvoice` (line ~53):
+  - permission failure → `{success:false, code:'PERMISSION_DENIED', …}`.
+  - Wrap the body in try/catch: `ManualInvoiceError` → envelope with its code/params/message.
+  - Postgres unique violation on `unique_invoice_number_per_tenant` (error code `23505`) →
+    `INVOICE_NUMBER_CONFLICT`.
+  - Anything else → generate `ref` (e.g. `crypto.randomUUID().slice(0, 8)`), `log.error`
+    with stack + tenant/client/user + ref, return `{success:false, code:'UNEXPECTED', ref, …}`.
+- `actions/invoiceModification.ts` — `updateInvoiceManualItems` (line ~739): same envelope
+  treatment (it currently throws to the UI). Update the UI edit branch
+  (`ManualInvoices.tsx:586`) to consume the envelope.
+
+### W3 — Server-side logging for handled failures
+
+In both actions, every handled `{success:false}` return logs before returning:
+
+```
+log.warn('[generateManualInvoice] <CODE>', { tenant, clientId, userId, ...params })
+```
+
+Unexpected errors use `log.error` with the ref ID and stack (W2). Acceptance: a failed
+generation attempt is findable in Loki by tenant ID or code string.
+
+### W4 — UI code mapping + locales
+
+`packages/billing/src/components/billing-dashboard/ManualInvoices.tsx`:
+
+- Replace the message-sniffing in `translateManualInvoiceError` (~235) with:
+  1. `result.code` present and key `manualInvoices.errors.<code>` exists → translated string
+     with `result.params` interpolated.
+  2. Unknown/missing code → `result.message` verbatim.
+  3. `UNEXPECTED` → translated generic including `{{ref}}`.
+  4. Thrown (non-envelope) errors in the `catch` (~698): keep today's generic
+     translation path — the codes for those flows arrive with alga0002126/0002127.
+- Sales-order branch keeps its existing `salesOrder*` translations.
+- Add keys to `server/public/locales/<lang>/msp/invoicing.json` for **every** locale
+  directory present (en, de, es, fr, it, nl, pl, pt, xx, yy — follow the repo's locale-parity
+  convention; see commit 89b1d22f50 for the pattern):
+  `manualInvoices.errors.NO_BILLING_EMAIL` ("{{clientName}} has no billing email. Set an
+  email address on the client's billing location, then try again."),
+  `…SERVICE_NOT_FOUND`, `…INVALID_QUANTITY`, `…NO_TAX_RATE`, `…DISCOUNT_TARGET_NOT_FOUND`,
+  `…CLIENT_NOT_FOUND`, `…INVOICE_NUMBER_CONFLICT` (reuse existing text), `…PERMISSION_DENIED`,
+  `…UNEXPECTED` ("Something went wrong generating the invoice. Quote reference {{ref}} when
+  contacting support."), plus `manualInvoices.warnings.noBillingEmail` for W5.
+
+### W5 — Pre-submit billing-email guard
+
+- New action in `manualInvoiceActions.ts`: `getClientBillingEmailStatus(clientId)` →
+  `{ hasBillingEmail: boolean }`, delegating to `invoiceService.getClientBillingEmail`
+  (`invoiceService.ts:307`).
+- In the manual-invoice dialog, when the selected client changes, fetch status; if absent,
+  render a persistent inline warning `Alert` (`manualInvoices.warnings.noBillingEmail`) —
+  non-blocking (server still validates), submit stays enabled.
+
+### W6 — Edit-path atomicity
+
+`updateInvoiceManualItemsInternal` (`invoiceModification.ts:799`) commits item mutations,
+then calls `billingEngine.recalculateInvoice(invoiceId)` (line ~1011) in a **separate**
+transaction — a tax failure there leaves committed items with stale totals.
+
+- Thread the open transaction: give `recalculateInvoice` (billingEngine.ts ~4873) an
+  optional `trx?: Knex.Transaction` parameter, used instead of opening its own; call it
+  inside the `withTransaction` block from `updateInvoiceManualItemsInternal`.
+- **Verify during implementation** that nothing inside `recalculateInvoice` opens its own
+  nested transaction/connection; if threading is not cleanly possible, leave the order as-is,
+  return a dedicated handled error telling the user totals were not refreshed, and drop a
+  `// LEVERAGE: friction billing-engine-trx — recalculateInvoice cannot join an open transaction`
+  marker instead of forcing it.
+
+### W7 — Tests
+
+- Unit tests for the action error mapping (pattern precedent: commit bbbdf16150,
+  "unit-test loaner/restock error mapping"):
+  - each known failure → its code + params (billing email missing, unknown service, zero
+    quantity, missing tax rate, duplicate invoice number, permission denied);
+  - unexpected throw → `UNEXPECTED` + ref present + `log.error` called;
+  - handled failures emit `log.warn` with tenant/client context.
+- UI-level test: envelope with `NO_BILLING_EMAIL` renders the specific translated message,
+  not "Error generating invoice"; `UNEXPECTED` renders the ref.
+- Locale parity check passes (all locale files contain the new keys).
+
+### W8 — Live verification (dev stack, port 3954)
+
+1. Create/choose a client whose billing location has no email.
+2. Open Billing → Invoicing → Generate: selecting the client shows the inline warning (W5).
+3. Submit anyway → specific billing-email message with client name (W4), and the dev-server
+   log shows the `[generateManualInvoice] NO_BILLING_EMAIL` warn line (W3).
+4. Set the billing-location email → invoice generates successfully.
+5. Edit the invoice, force a recalc failure (e.g. temporarily remove the tenant's tax rate)
+   → error surfaces with code and **no stale partial state** (W6).
+
+## Out of scope (ticketed)
+
+- alga0002126 — deploy-skew stale-tab detection ("Failed to find Server Action").
+- alga0002127 — session-expiry UX (`AuthenticationError` → sign-in redirect).
+- alga0002128 — `next_number` INVOICE seeding (TIC001000 first-invoice numbers).
+
+## Support follow-up (not code)
+
+Andrew's concrete unblock: set a billing email on Omni Energy Partners' billing location.
+Worth replying on alga0002092 once this ships — until then the product genuinely cannot tell
+him what was wrong.

--- a/packages/billing/src/actions/invoiceModification.ts
+++ b/packages/billing/src/actions/invoiceModification.ts
@@ -38,6 +38,12 @@ import {
   type ActionMessageError,
   type ActionPermissionError,
 } from '@alga-psa/ui/lib/errorHandling';
+import logger from '@alga-psa/core/logger';
+import {
+  ManualInvoiceError,
+  type ManualInvoiceErrorCode,
+  type ManualInvoiceFailure,
+} from '../errors/manualInvoiceErrors';
 
 function tenantScopedTable<Row extends object = Record<string, unknown>>(
   conn: Knex | Knex.Transaction,
@@ -161,7 +167,7 @@ export type DraftInvoicePropertiesUpdateActionResult =
   | InvoiceActionError;
 
 export type InvoiceMutationActionResult = InvoiceActionSuccess | InvoiceActionError;
-export type InvoiceManualItemsUpdateActionResult = InvoiceViewModel | InvoiceActionError;
+export type InvoiceManualItemsUpdateActionResult = InvoiceViewModel | InvoiceActionError | ManualInvoiceFailure;
 
 function expectedInvoiceActionError(message: string): ExpectedInvoiceActionError {
   return new ExpectedInvoiceActionError(message);
@@ -173,6 +179,59 @@ function toInvoiceActionError(error: unknown): InvoiceActionError | null {
   }
 
   return null;
+}
+
+function manualInvoiceUpdateFailure(
+  code: Exclude<ManualInvoiceErrorCode, 'UNEXPECTED'>,
+  message: string,
+  context: Record<string, string>,
+  params: Record<string, string> = {},
+): ManualInvoiceFailure {
+  logger.warn(`[updateInvoiceManualItems] ${code}`, {
+    ...context,
+    ...params,
+  });
+
+  return {
+    success: false,
+    code,
+    params,
+    message,
+    error: message,
+  };
+}
+
+function unexpectedManualInvoiceUpdateFailure(
+  error: unknown,
+  context: Record<string, string>,
+): ManualInvoiceFailure {
+  const ref = crypto.randomUUID().slice(0, 8);
+  const message = 'Unexpected error updating invoice';
+  logger.error('[updateInvoiceManualItems] UNEXPECTED', {
+    ...context,
+    ref,
+    error: error instanceof Error ? error.message : String(error),
+    stack: error instanceof Error ? error.stack : undefined,
+  });
+
+  return {
+    success: false,
+    code: 'UNEXPECTED',
+    params: { ref },
+    message,
+    error: message,
+    ref,
+  };
+}
+
+function isManualInvoiceNumberConflict(error: unknown): boolean {
+  if (!error || typeof error !== 'object') {
+    return false;
+  }
+
+  const databaseError = error as { code?: string; constraint?: string };
+  return databaseError.code === '23505' &&
+    databaseError.constraint === 'unique_invoice_number_per_tenant';
 }
 
 export const updateDraftInvoiceProperties = withAuth(async (
@@ -742,57 +801,89 @@ export const updateInvoiceManualItems = withAuth(async (
   invoiceId: string,
   changes: ManualItemsUpdate
 ): Promise<InvoiceManualItemsUpdateActionResult> => {
+  const context = {
+    tenant,
+    invoiceId,
+    clientId: '',
+    userId: user.user_id,
+  };
+
   if (!await hasPermission(user, 'invoice', 'update')) {
-    return permissionError('Permission denied: invoice update required');
+    return manualInvoiceUpdateFailure(
+      'PERMISSION_DENIED',
+      'Permission denied: invoice update required',
+      context,
+    );
   }
-  const session = await getSession();
-  const billingEngine = new BillingEngine();
-
-  console.log('[updateInvoiceManualItems] session:', session);
-
-  if (!session?.user?.id) {
-    return permissionError('Unauthorized: No authenticated user found');
-  }
-
-  const { knex } = await createTenantKnex();
-
-  // Load and validate invoice
-  const invoice = await withTransaction(knex, async (trx: Knex.Transaction) => {
-    return await tenantScopedTable(trx, tenant, 'invoices')
-      .where({ invoice_id: invoiceId })
-      .first();
-  });
-
-  if (!invoice) {
-    return actionError('Invoice not found');
-  }
-
-  if (['paid', 'cancelled'].includes(invoice.status)) {
-    return actionError('Cannot modify a paid or cancelled invoice');
-  }
-
-  const client = await withTransaction(knex, async (trx: Knex.Transaction) => {
-    return await tenantScopedTable(trx, tenant, 'clients')
-      .where({ client_id: invoice.client_id })
-      .first();
-  });
-
-  if (!client) {
-    return actionError('Client not found');
-  }
-
-  const currentDate = Temporal.Now.plainDateISO().toString();
 
   try {
+    const session = await getSession();
+    if (!session?.user?.id) {
+      return manualInvoiceUpdateFailure(
+        'PERMISSION_DENIED',
+        'Unauthorized: No authenticated user found',
+        context,
+      );
+    }
+    context.userId = session.user.id;
+
+    const { knex } = await createTenantKnex();
+    const invoice = await withTransaction(knex, async (trx: Knex.Transaction) => {
+      return await tenantScopedTable(trx, tenant, 'invoices')
+        .where({ invoice_id: invoiceId })
+        .first();
+    });
+
+    if (!invoice) {
+      return actionError('Invoice not found');
+    }
+    context.clientId = invoice.client_id;
+
+    if (['paid', 'cancelled'].includes(invoice.status)) {
+      return actionError('Cannot modify a paid or cancelled invoice');
+    }
+
+    const client = await withTransaction(knex, async (trx: Knex.Transaction) => {
+      return await tenantScopedTable(trx, tenant, 'clients')
+        .where({ client_id: invoice.client_id })
+        .first();
+    });
+
+    if (!client) {
+      return manualInvoiceUpdateFailure(
+        'CLIENT_NOT_FOUND',
+        'Client not found',
+        context,
+      );
+    }
+
     await updateManualInvoiceItemsInternal(invoiceId, changes, session!, tenant); // Renamed internal call
+    return await Invoice.getFullInvoiceById(knex, tenant, invoiceId);
   } catch (error) {
+    if (error instanceof ManualInvoiceError) {
+      return manualInvoiceUpdateFailure(
+        error.code,
+        error.message,
+        context,
+        error.params,
+      );
+    }
+
+    if (isManualInvoiceNumberConflict(error)) {
+      return manualInvoiceUpdateFailure(
+        'INVOICE_NUMBER_CONFLICT',
+        'Invoice number must be unique',
+        context,
+      );
+    }
+
     const expectedError = toInvoiceActionError(error);
     if (expectedError) {
       return expectedError;
     }
-    throw error;
+
+    return unexpectedManualInvoiceUpdateFailure(error, context);
   }
-  return await Invoice.getFullInvoiceById(knex, tenant, invoiceId);
 });
 
 // Internal helper function to avoid recursive export/import loop
@@ -995,7 +1086,10 @@ async function updateManualInvoiceItemsInternal(
           error.code === '23505' &&
           'constraint' in error &&
               error.constraint === 'unique_invoice_number_per_tenant') {
-          throw expectedInvoiceActionError('Invoice number must be unique');
+          throw new ManualInvoiceError(
+            'INVOICE_NUMBER_CONFLICT',
+            'Invoice number must be unique',
+          );
         }
         throw error;
       }
@@ -1005,10 +1099,10 @@ async function updateManualInvoiceItemsInternal(
           .where({ invoice_id: invoiceId })
           .update({ updated_at: currentDate });
     }
-  });
 
-  // Recalculate totals after modifications
-  await billingEngine.recalculateInvoice(invoiceId);
+    // Recalculate before commit so tax/totals failures roll back item mutations.
+    await billingEngine.recalculateInvoice(invoiceId, trx, tenant);
+  });
 
 }
 

--- a/packages/billing/src/actions/manualInvoiceActions.ts
+++ b/packages/billing/src/actions/manualInvoiceActions.ts
@@ -17,6 +17,12 @@ import { tenantDb } from '@alga-psa/db';
 import { getInitialInvoiceTaxSource } from './taxSourceActions';
 import { getDueDate } from './billingAndTax';
 import { getErrorMessage, isActionMessageError, isActionPermissionError } from '@alga-psa/ui/lib/errorHandling';
+import logger from '@alga-psa/core/logger';
+import {
+  ManualInvoiceError,
+  type ManualInvoiceErrorCode,
+  type ManualInvoiceFailure,
+} from '../errors/manualInvoiceErrors';
 
 export interface ManualInvoiceItem { // Add export
   service_id: string;
@@ -44,135 +50,226 @@ interface ManualInvoiceRequest {
 
 export type ManualInvoiceResult =
   | { success: true; invoice: InvoiceViewModel }
-  | { success: false; error: string };
+  | ManualInvoiceFailure;
 
 export type ManualInvoiceUpdateResult =
   | { success: true; invoice: InvoiceViewModel }
   | { success: false; error: string };
+
+interface ManualInvoiceLogContext {
+  tenant: string;
+  clientId: string;
+  userId: string;
+}
+
+function handledManualInvoiceFailure(
+  code: Exclude<ManualInvoiceErrorCode, 'UNEXPECTED'>,
+  message: string,
+  context: ManualInvoiceLogContext,
+  params: Record<string, string> = {},
+): ManualInvoiceFailure {
+  logger.warn(`[generateManualInvoice] ${code}`, {
+    ...context,
+    ...params,
+  });
+
+  return {
+    success: false,
+    code,
+    params,
+    message,
+    error: message,
+  };
+}
+
+function unexpectedManualInvoiceFailure(
+  error: unknown,
+  context: ManualInvoiceLogContext,
+): ManualInvoiceFailure {
+  const ref = crypto.randomUUID().slice(0, 8);
+  const message = 'Unexpected error generating invoice';
+  logger.error('[generateManualInvoice] UNEXPECTED', {
+    ...context,
+    ref,
+    error: error instanceof Error ? error.message : String(error),
+    stack: error instanceof Error ? error.stack : undefined,
+  });
+
+  return {
+    success: false,
+    code: 'UNEXPECTED',
+    params: { ref },
+    message,
+    error: message,
+    ref,
+  };
+}
+
+function isInvoiceNumberConflict(error: unknown): boolean {
+  if (!error || typeof error !== 'object') {
+    return false;
+  }
+
+  const databaseError = error as { code?: string; constraint?: string };
+  return databaseError.code === '23505' &&
+    databaseError.constraint === 'unique_invoice_number_per_tenant';
+}
+
+export const getClientBillingEmailStatus = withAuth(async (
+  _user,
+  { tenant },
+  clientId: string,
+): Promise<{ hasBillingEmail: boolean }> => {
+  const { knex } = await invoiceService.validateSessionAndTenant();
+  const billingEmail = await invoiceService.getClientBillingEmail(knex, tenant, clientId);
+  return { hasBillingEmail: Boolean(billingEmail) };
+});
 
 export const generateManualInvoice = withAuth(async (
   user,
   { tenant },
   request: ManualInvoiceRequest
 ): Promise<ManualInvoiceResult> => {
-  if (!await hasPermission(user, 'billing', 'create')) {
-    return { success: false, error: 'Permission denied: billing create required' };
-  }
-
-  // Validate session and tenant context
-  const { session, knex } = await invoiceService.validateSessionAndTenant();
   const { clientId, items, expirationDate, isPrepayment } = request;
-
-  // Get client details
-  const client = await invoiceService.getClientDetails(knex, tenant, clientId);
-
-  // Validate that the client has a billing email (required for online payments)
-  const emailValidation = await invoiceService.validateClientBillingEmail(knex, tenant, clientId, client.client_name);
-  if (!emailValidation.valid) {
-    return { success: false, error: emailValidation.error! };
-  }
-
-  // Resolve the currency: explicit request value, then the client's configured currency,
-  // then the tenant's default billing currency (default_billing_settings), with 'USD' only
-  // as the absolute final fallback.
-  let currencyCode = request.currency_code || client.default_currency_code;
-  if (!currencyCode) {
-    const billingSettings = await tenantDb(knex, tenant).table('default_billing_settings')
-      .select('default_currency_code')
-      .first();
-    currencyCode = billingSettings?.default_currency_code || 'USD';
-  }
-
-  const currentDate = Temporal.Now.plainDateISO().toString();
-  const dueDate = await getDueDate(clientId, currentDate);
-  if (isActionMessageError(dueDate) || isActionPermissionError(dueDate)) {
-    return { success: false, error: getErrorMessage(dueDate) };
-  }
-
-  // Generate invoice number and create invoice record
-  const invoiceNumber = await generateInvoiceNumber();
-  const invoiceId = uuidv4();
-
-  // Determine tax source based on client settings
-  const taxSource = await getInitialInvoiceTaxSource(clientId);
-  if (isActionMessageError(taxSource) || isActionPermissionError(taxSource)) {
-    return { success: false, error: getErrorMessage(taxSource) };
-  }
-
-  // Set invoice type based on isPrepayment flag
-  const invoice = {
-    invoice_id: invoiceId,
+  const context: ManualInvoiceLogContext = {
     tenant,
-    client_id: clientId,
-    invoice_date: currentDate,
-    due_date: dueDate,
-    invoice_number: invoiceNumber,
-    status: 'draft',
-    currency_code: currencyCode,
-    subtotal: 0,
-    tax: 0,
-    total_amount: 0,
-    credit_applied: 0,
-    is_manual: true,
-    is_prepayment: isPrepayment || false,
-    tax_source: taxSource
+    clientId,
+    userId: user.user_id,
   };
 
-  return await knex.transaction(async (trx) => {
-    // Insert invoice
-    await tenantDb(trx, tenant).table('invoices').insert(invoice);
+  try {
+    if (!await hasPermission(user, 'billing', 'create')) {
+      return handledManualInvoiceFailure(
+        'PERMISSION_DENIED',
+        'Permission denied: billing create required',
+        context,
+      );
+    }
 
-    // Persist manual invoice items using the dedicated service function
-    await invoiceService.persistManualInvoiceCharges(
-      trx,
-      invoiceId,
-      items, // Assuming items match ManualInvoiceItemInput structure
-      client,
-      session,
-      tenant
-    );
-
-    // Calculate and distribute tax
-    const taxService = new TaxService();
-    await invoiceService.calculateAndDistributeTax(
-      trx,
-      invoiceId,
-      client,
-      taxService,
-      tenant // Removed subtotal argument
-    );
-
-    // Update invoice totals and record transaction (subtotal/tax recalculated internally)
-    await invoiceService.updateInvoiceTotalsAndRecordTransaction(
-      trx,
-      invoiceId,
-      client,
+    const { session, knex } = await invoiceService.validateSessionAndTenant();
+    context.userId = session.user.id;
+    const client = await invoiceService.getClientDetails(knex, tenant, clientId);
+    const emailValidation = await invoiceService.validateClientBillingEmail(
+      knex,
       tenant,
-      invoiceNumber,
-      isPrepayment ? expirationDate : undefined
+      clientId,
+      client.client_name,
     );
+    if (!emailValidation.valid) {
+      return handledManualInvoiceFailure(
+        emailValidation.code ?? 'NO_BILLING_EMAIL',
+        emailValidation.error ?? 'Client billing email is required',
+        context,
+        emailValidation.params ?? { clientName: client.client_name },
+      );
+    }
 
-    const createdInvoice = await Invoice.getFullInvoiceById(trx, tenant, invoiceId);
+    let currencyCode = request.currency_code || client.default_currency_code;
+    if (!currencyCode) {
+      const billingSettings = await tenantDb(knex, tenant).table('default_billing_settings')
+        .select('default_currency_code')
+        .first();
+      currencyCode = billingSettings?.default_currency_code || 'USD';
+    }
 
-    // Track analytics
-    const { analytics, AnalyticsEvents } = await getAnalyticsAsync();
-    analytics.capture(AnalyticsEvents.INVOICE_GENERATED, {
+    const currentDate = Temporal.Now.plainDateISO().toString();
+    const dueDate = await getDueDate(clientId, currentDate);
+    if (isActionMessageError(dueDate) || isActionPermissionError(dueDate)) {
+      throw new Error(getErrorMessage(dueDate));
+    }
+
+    const invoiceNumber = await generateInvoiceNumber();
+    const invoiceId = uuidv4();
+    const taxSource = await getInitialInvoiceTaxSource(clientId);
+    if (isActionMessageError(taxSource) || isActionPermissionError(taxSource)) {
+      throw new Error(getErrorMessage(taxSource));
+    }
+
+    const invoice = {
       invoice_id: invoiceId,
-      invoice_number: invoiceNumber,
+      tenant,
       client_id: clientId,
-      subtotal: createdInvoice.subtotal,
-      tax: createdInvoice.tax,
-      total_amount: createdInvoice.total_amount,
-      item_count: createdInvoice.invoice_charges.length,
+      invoice_date: currentDate,
+      due_date: dueDate,
+      invoice_number: invoiceNumber,
+      status: 'draft',
+      currency_code: currencyCode,
+      subtotal: 0,
+      tax: 0,
+      total_amount: 0,
+      credit_applied: 0,
       is_manual: true,
-      is_prepayment: isPrepayment || false
-    }, session.user.id);
-
-    return {
-      success: true as const,
-      invoice: createdInvoice
+      is_prepayment: isPrepayment || false,
+      tax_source: taxSource,
     };
-  });
+
+    return await knex.transaction(async (trx) => {
+      await tenantDb(trx, tenant).table('invoices').insert(invoice);
+      await invoiceService.persistManualInvoiceCharges(
+        trx,
+        invoiceId,
+        items,
+        client,
+        session,
+        tenant,
+      );
+
+      const taxService = new TaxService();
+      await invoiceService.calculateAndDistributeTax(
+        trx,
+        invoiceId,
+        client,
+        taxService,
+        tenant,
+      );
+      await invoiceService.updateInvoiceTotalsAndRecordTransaction(
+        trx,
+        invoiceId,
+        client,
+        tenant,
+        invoiceNumber,
+        isPrepayment ? expirationDate : undefined,
+      );
+
+      const createdInvoice = await Invoice.getFullInvoiceById(trx, tenant, invoiceId);
+      const { analytics, AnalyticsEvents } = await getAnalyticsAsync();
+      analytics.capture(AnalyticsEvents.INVOICE_GENERATED, {
+        invoice_id: invoiceId,
+        invoice_number: invoiceNumber,
+        client_id: clientId,
+        subtotal: createdInvoice.subtotal,
+        tax: createdInvoice.tax,
+        total_amount: createdInvoice.total_amount,
+        item_count: createdInvoice.invoice_charges.length,
+        is_manual: true,
+        is_prepayment: isPrepayment || false,
+      }, session.user.id);
+
+      return {
+        success: true as const,
+        invoice: createdInvoice,
+      };
+    });
+  } catch (error) {
+    if (error instanceof ManualInvoiceError) {
+      return handledManualInvoiceFailure(
+        error.code,
+        error.message,
+        context,
+        error.params,
+      );
+    }
+
+    if (isInvoiceNumberConflict(error)) {
+      return handledManualInvoiceFailure(
+        'INVOICE_NUMBER_CONFLICT',
+        'Invoice number must be unique',
+        context,
+      );
+    }
+
+    return unexpectedManualInvoiceFailure(error, context);
+  }
 });
 
 export const updateManualInvoice = withAuth(async (

--- a/packages/billing/src/components/billing-dashboard/ManualInvoices.tsx
+++ b/packages/billing/src/components/billing-dashboard/ManualInvoices.tsx
@@ -1,7 +1,10 @@
 'use client'
 
 import React, { useState, useEffect, useMemo } from 'react';
-import { generateManualInvoice } from '@alga-psa/billing/actions/manualInvoiceActions';
+import {
+  generateManualInvoice,
+  getClientBillingEmailStatus,
+} from '@alga-psa/billing/actions/manualInvoiceActions';
 import { generateInvoiceForSalesOrder, type InvoiceableSalesOrderForBilling } from '@alga-psa/billing/actions/salesOrderInvoicingActions';
 import {
   updateInvoiceManualItems,
@@ -10,6 +13,10 @@ import {
 import { getInvoiceLineItems } from '@alga-psa/billing/actions/invoiceQueries';
 import type { ManualInvoiceUpdate } from '@alga-psa/billing/actions/invoiceActions'; // Import the specific type
 import type { ManualInvoiceItem as ManualInvoiceItemForAction } from '@alga-psa/billing/actions/manualInvoiceActions'; // Import and alias
+import type {
+  ManualInvoiceFailure,
+} from '../../errors/manualInvoiceErrors';
+import { translateManualInvoiceFailure } from './manualInvoiceErrorTranslation';
 import { Button } from '@alga-psa/ui/components/Button';
 import { Checkbox } from '@alga-psa/ui/components/Checkbox';
 import { DatePicker } from '@alga-psa/ui/components/DatePicker';
@@ -52,10 +59,17 @@ interface ManualInvoicesProps {
   sourceSalesOrderId?: string | null;
 }
 
-const isManualItemsUpdateError = (
+const isLegacyManualItemsUpdateError = (
   result: InvoiceManualItemsUpdateActionResult,
-): result is Exclude<InvoiceManualItemsUpdateActionResult, InvoiceViewModel> => (
+): result is Exclude<InvoiceManualItemsUpdateActionResult, InvoiceViewModel | ManualInvoiceFailure> => (
   isActionMessageError(result) || isActionPermissionError(result)
+);
+
+const isManualInvoiceFailure = (result: unknown): result is ManualInvoiceFailure => (
+  Boolean(result) &&
+  typeof result === 'object' &&
+  (result as Partial<ManualInvoiceFailure>).success === false &&
+  typeof (result as Partial<ManualInvoiceFailure>).code === 'string'
 );
 
 // This is the primary state type for manual items within this component
@@ -232,7 +246,11 @@ const ManualInvoicesContent: React.FC<ManualInvoicesProps> = ({
   const [isPrepayment, setIsPrepayment] = useState(false);
   const [expirationDate, setExpirationDate] = useState<string>('');
   const [isQuickAddClientOpen, setIsQuickAddClientOpen] = useState(false);
-  const translateManualInvoiceError = (message: string, mode: 'update' | 'generate'): string => {
+  const [hasSelectedClientBillingEmail, setHasSelectedClientBillingEmail] = useState<boolean | null>(null);
+  const translateManualInvoiceError = (result: ManualInvoiceFailure): string => (
+    translateManualInvoiceFailure(t, result)
+  );
+  const translateLegacyManualInvoiceError = (message: string, mode: 'update' | 'generate'): string => {
     if (message === 'Invoice number must be unique') {
       return t('manualInvoices.errors.invoiceNumberUnique', {
         defaultValue: 'This invoice number is already in use.',
@@ -294,6 +312,31 @@ const ManualInvoicesContent: React.FC<ManualInvoicesProps> = ({
       setSelectedClient(selectedSalesOrder.client_id);
     }
   }, [selectedSalesOrder]);
+
+  useEffect(() => {
+    if (currentInvoiceData || selectedSalesOrder || !selectedClient) {
+      setHasSelectedClientBillingEmail(null);
+      return;
+    }
+
+    let active = true;
+    setHasSelectedClientBillingEmail(null);
+    void getClientBillingEmailStatus(selectedClient)
+      .then(({ hasBillingEmail }) => {
+        if (active) {
+          setHasSelectedClientBillingEmail(hasBillingEmail);
+        }
+      })
+      .catch((statusError: unknown) => {
+        if (IS_DEVELOPMENT) {
+          console.error('Unable to check client billing email status:', statusError);
+        }
+      });
+
+    return () => {
+      active = false;
+    };
+  }, [currentInvoiceData, selectedClient, selectedSalesOrder]);
 
   const salesOrderOptions = useMemo(
     () =>
@@ -590,8 +633,13 @@ const ManualInvoicesContent: React.FC<ManualInvoicesProps> = ({
           removedItemIds
         });
 
-        if (isManualItemsUpdateError(updateResult)) {
-          setError(translateManualInvoiceError(getErrorMessage(updateResult), 'update'));
+        if (isManualInvoiceFailure(updateResult)) {
+          setError(translateManualInvoiceError(updateResult));
+          return;
+        }
+
+        if (isLegacyManualItemsUpdateError(updateResult)) {
+          setError(translateLegacyManualInvoiceError(getErrorMessage(updateResult), 'update'));
           return;
         }
 
@@ -683,12 +731,7 @@ const ManualInvoicesContent: React.FC<ManualInvoicesProps> = ({
         });
 
         if (!result.success) {
-          setError(
-            translateManualInvoiceError(
-              (result as { success: false; error: string }).error,
-              'generate',
-            ),
-          );
+          setError(translateManualInvoiceError(result));
           return;
         }
 
@@ -702,7 +745,7 @@ const ManualInvoicesContent: React.FC<ManualInvoicesProps> = ({
          defaultValue: `Error ${errorMode === 'update' ? 'updating' : 'generating'} invoice`,
        });
        if (err instanceof Error) {
-         errorMessage = translateManualInvoiceError(err.message, errorMode);
+         errorMessage = translateLegacyManualInvoiceError(err.message, errorMode);
        }
        setError(errorMessage);
     } finally {
@@ -991,6 +1034,16 @@ const ManualInvoicesContent: React.FC<ManualInvoicesProps> = ({
                     </>
                   )}
                 </div>
+              )}
+
+              {!invoice && !currentInvoiceData && !hasSalesOrderSource && hasSelectedClientBillingEmail === false && (
+                <Alert id="manual-invoice-no-billing-email-warning" variant="warning">
+                  <AlertDescription>
+                    {t('manualInvoices.warnings.noBillingEmail', {
+                      defaultValue: 'This client has no billing email. Set an email address on the client\'s billing location before generating the invoice.',
+                    })}
+                  </AlertDescription>
+                </Alert>
               )}
 
               {!invoice && !currentInvoiceData && !hasSalesOrderSource && (

--- a/packages/billing/src/components/billing-dashboard/manualInvoiceErrorTranslation.ts
+++ b/packages/billing/src/components/billing-dashboard/manualInvoiceErrorTranslation.ts
@@ -1,0 +1,44 @@
+import type {
+  ManualInvoiceErrorCode,
+  ManualInvoiceFailure,
+} from '../../errors/manualInvoiceErrors';
+
+const translatedManualInvoiceErrorCodes = new Set<ManualInvoiceErrorCode>([
+  'NO_BILLING_EMAIL',
+  'CLIENT_NOT_FOUND',
+  'SERVICE_NOT_FOUND',
+  'INVALID_QUANTITY',
+  'NO_TAX_RATE',
+  'DISCOUNT_TARGET_NOT_FOUND',
+  'INVOICE_NUMBER_CONFLICT',
+  'PERMISSION_DENIED',
+  'UNEXPECTED',
+]);
+
+export type ManualInvoiceTranslation = (
+  key: string,
+  options?: Record<string, unknown>,
+) => string;
+
+export function translateManualInvoiceFailure(
+  t: ManualInvoiceTranslation,
+  result: Partial<ManualInvoiceFailure>,
+): string {
+  const message = result.message ?? result.error ?? 'Error generating invoice';
+  if (!result.code || !translatedManualInvoiceErrorCodes.has(result.code)) {
+    return message;
+  }
+
+  if (result.code === 'UNEXPECTED') {
+    const ref = result.ref ?? result.params?.ref ?? 'unknown';
+    return t('manualInvoices.errors.UNEXPECTED', {
+      ref,
+      defaultValue: `Something went wrong generating the invoice. Quote reference ${ref} when contacting support.`,
+    });
+  }
+
+  return t(`manualInvoices.errors.${result.code}`, {
+    ...result.params,
+    defaultValue: message,
+  });
+}

--- a/packages/billing/src/errors/manualInvoiceErrors.ts
+++ b/packages/billing/src/errors/manualInvoiceErrors.ts
@@ -1,0 +1,33 @@
+export type ManualInvoiceErrorCode =
+  | 'NO_BILLING_EMAIL'
+  | 'CLIENT_NOT_FOUND'
+  | 'SERVICE_NOT_FOUND'
+  | 'INVALID_QUANTITY'
+  | 'NO_TAX_RATE'
+  | 'DISCOUNT_TARGET_NOT_FOUND'
+  | 'INVOICE_NUMBER_CONFLICT'
+  | 'PERMISSION_DENIED'
+  | 'UNEXPECTED';
+
+export type HandledManualInvoiceErrorCode = Exclude<ManualInvoiceErrorCode, 'UNEXPECTED'>;
+
+export interface ManualInvoiceFailure {
+  success: false;
+  code: ManualInvoiceErrorCode;
+  params?: Record<string, string>;
+  message: string;
+  /** @deprecated Kept for one release for consumers of the previous result shape. */
+  error: string;
+  ref?: string;
+}
+
+export class ManualInvoiceError extends Error {
+  constructor(
+    public readonly code: HandledManualInvoiceErrorCode,
+    message: string,
+    public readonly params: Record<string, string> = {},
+  ) {
+    super(message);
+    this.name = 'ManualInvoiceError';
+  }
+}

--- a/packages/billing/src/lib/billing/billingEngine.ts
+++ b/packages/billing/src/lib/billing/billingEngine.ts
@@ -4813,44 +4813,48 @@ export class BillingEngine {
    * Recalculates an entire invoice, including tax amounts and totals.
    * This is used when updating manual items to ensure all calculations are consistent.
    */
-  async recalculateInvoice(invoiceId: string): Promise<void> {
-    await this.initKnex();
-    if (!this.tenant) {
+  async recalculateInvoice(
+    invoiceId: string,
+    existingTransaction?: Knex.Transaction,
+    existingTenant?: string,
+  ): Promise<void> {
+    if (!existingTransaction || (!this.tenant && !existingTenant)) {
+      await this.initKnex();
+    }
+
+    const tenant = existingTenant ?? this.tenant;
+    if (!tenant) {
       throw new Error("tenant context not found");
     }
 
-    let tenant = this.tenant;
-    const db = tenantDb(this.knex, tenant);
+    const connection = existingTransaction ?? this.knex;
+    const db = tenantDb(connection, tenant);
 
     console.log(`Recalculating invoice ${invoiceId}`);
-
-    if (!this.tenant) {
-      throw new Error("tenant context not found");
-    }
 
     const invoice = await db.table("invoices")
       .where({
         invoice_id: invoiceId,
-        tenant: this.tenant,
+        tenant,
       })
       .first();
 
     if (!invoice) {
       throw new Error(
-        `Invoice ${invoiceId} not found in tenant ${this.tenant}`,
+        `Invoice ${invoiceId} not found in tenant ${tenant}`,
       );
     }
 
     const client = await db.table("clients")
       .where({
         client_id: invoice.client_id,
-        tenant: this.tenant,
+        tenant,
       })
       .first();
 
     if (!client) {
       throw new Error(
-        `Client ${invoice.client_id} not found in tenant ${this.tenant}`,
+        `Client ${invoice.client_id} not found in tenant ${tenant}`,
       );
     }
 
@@ -4870,7 +4874,7 @@ export class BillingEngine {
     // Recalculation is intentionally financial-only. Canonical recurring
     // invoice_charge_details rows remain the persisted source of service-period
     // truth after invoice creation; this path should only update tax and totals.
-    await this.knex.transaction(async (trx) => {
+    const recalculate = async (trx: Knex.Transaction) => {
       // Step 1: Recalculate and distribute tax across all items using the service function
       console.log(
         `[recalculateInvoice] Calling calculateAndDistributeTax for invoice ${invoiceId}`,
@@ -4913,7 +4917,13 @@ export class BillingEngine {
       // If discount amounts need recalculation based on the new subtotal *before* tax distribution,
       // that logic would need to be added back here or integrated into calculateAndDistributeTax.
       // For now, we follow the instruction to delegate fully.
-    });
+    };
+
+    if (existingTransaction) {
+      await recalculate(existingTransaction);
+    } else {
+      await withTransaction(this.knex, recalculate);
+    }
 
     // Removed console log referencing deleted variables subtotal/totalTax
 

--- a/packages/billing/src/services/invoiceService.ts
+++ b/packages/billing/src/services/invoiceService.ts
@@ -1,4 +1,5 @@
 import { Temporal } from '@js-temporal/polyfill';
+import { ManualInvoiceError, type HandledManualInvoiceErrorCode } from '../errors/manualInvoiceErrors';
 import { createTenantKnex, tenantDb } from '@alga-psa/db';
 import { v4 as uuidv4 } from 'uuid';
 import { TaxService } from './taxService';
@@ -294,7 +295,10 @@ export async function getClientDetails(knex: Knex, tenant: string, clientId: str
   });
   const client = (await clientQuery.first()) as unknown as IClientWithLocation | undefined;
   if (!client) {
-    throw new Error(`Client not found for tenant ${tenant}`);
+    throw new ManualInvoiceError(
+      'CLIENT_NOT_FOUND',
+      `Client not found for tenant ${tenant}`,
+    );
   }
   return client;
 }
@@ -321,6 +325,8 @@ export async function getClientBillingEmail(knex: Knex, tenant: string, clientId
 export interface ValidationResult {
   valid: boolean;
   error?: string;
+  code?: HandledManualInvoiceErrorCode;
+  params?: Record<string, string>;
 }
 
 /**
@@ -333,6 +339,8 @@ export async function validateClientBillingEmail(knex: Knex, tenant: string, cli
   if (!billingEmail) {
     return {
       valid: false,
+      code: 'NO_BILLING_EMAIL',
+      params: { clientName },
       error: `Cannot generate invoice: No billing email address for "${clientName}". ` +
         `Please set an email address on the client's billing location before generating invoices.`
     };
@@ -474,7 +482,11 @@ export async function persistManualInvoiceCharges(
         .first();
       if (!service) {
         console.warn(`Service ID ${requestItem.service_id} provided for manual item but not found.`);
-        throw new Error(`Service not found: ${requestItem.service_id}`);
+        throw new ManualInvoiceError(
+          'SERVICE_NOT_FOUND',
+          `Service not found: ${requestItem.service_id}`,
+          { serviceId: requestItem.service_id },
+        );
       }
     }
     // --- Determine Tax Info based on the item's (or service's) Tax Rate ID ---
@@ -515,7 +527,7 @@ export async function persistManualInvoiceCharges(
     // --- End Determine Tax Info ---
 
     if ((requestItem.quantity ?? 0) <= 0) {
-      throw new Error('Quantity must be greater than 0');
+      throw new ManualInvoiceError('INVALID_QUANTITY', 'Quantity must be greater than 0');
     }
 
     const netAmount = calculateNetAmount(requestItem, subtotal); // No applicable amount needed here
@@ -568,7 +580,11 @@ export async function persistManualInvoiceCharges(
     if (requestItem.applies_to_service_id && !applicableItemId) {
       applicableItemId = serviceToItemMap.get(requestItem.applies_to_service_id);
       if (!applicableItemId) {
-        throw new Error(`Could not find invoice item for service: ${requestItem.applies_to_service_id} to apply discount.`);
+        throw new ManualInvoiceError(
+          'DISCOUNT_TARGET_NOT_FOUND',
+          `Could not find invoice item for service: ${requestItem.applies_to_service_id} to apply discount.`,
+          { serviceId: requestItem.applies_to_service_id },
+        );
       }
     }
 

--- a/packages/billing/src/services/taxService.ts
+++ b/packages/billing/src/services/taxService.ts
@@ -10,6 +10,7 @@ import type {
 import ClientTaxSettings from '../models/clientTaxSettings';
 import { createTenantKnex, tenantDb } from '@alga-psa/db';
 import { v4 as uuid4 } from 'uuid';
+import { ManualInvoiceError } from '../errors/manualInvoiceErrors';
 
 export class TaxService {
   constructor() {
@@ -113,7 +114,11 @@ export class TaxService {
         // Optional: Log all rates for debugging
         // Debug option: inspect all tenant tax rates through the tenantDb facade.
         // console.log('All tax rates:', allTaxRates);
-        throw new Error(`No active tax rate(s) found for region ${regionCode} on date ${date}`);
+        throw new ManualInvoiceError(
+          'NO_TAX_RATE',
+          `No active tax rate(s) found for region ${regionCode} on date ${date}`,
+          { region: regionCode, date },
+        );
       }
 
       console.log('Applicable rates:', applicableRates);

--- a/packages/billing/tests/ManualInvoices.i18n.test.ts
+++ b/packages/billing/tests/ManualInvoices.i18n.test.ts
@@ -91,12 +91,27 @@ describe('ManualInvoices i18n wiring contract', () => {
       'manualInvoices.errors.salesOrderGenerateFailed',
       'manualInvoices.errors.salesOrderNothingToInvoice',
       'manualInvoices.errors.salesOrderNotInvoiceable',
+      'manualInvoices.warnings.noBillingEmail',
       'manualInvoices.automatedItems.unknownService',
     ];
     const dynamicLocaleChecks = [
       'manualInvoices.errors.updateFailed',
       'manualInvoices.errors.generateFailed',
     ];
+    const structuredErrorKeys = [
+      'NO_BILLING_EMAIL',
+      'CLIENT_NOT_FOUND',
+      'SERVICE_NOT_FOUND',
+      'INVALID_QUANTITY',
+      'NO_TAX_RATE',
+      'DISCOUNT_TARGET_NOT_FOUND',
+      'INVOICE_NUMBER_CONFLICT',
+      'PERMISSION_DENIED',
+      'UNEXPECTED',
+    ];
+    const translationSource = read(
+      '../src/components/billing-dashboard/manualInvoiceErrorTranslation.ts',
+    );
 
     expect(source).toContain('translateManualInvoiceError');
     expect(source).toContain("mode === 'update' ? 'updateFailed' : 'generateFailed'");
@@ -110,6 +125,11 @@ describe('ManualInvoices i18n wiring contract', () => {
 
     for (const key of dynamicLocaleChecks) {
       expect(getLeaf(en, key)).toBeDefined();
+    }
+
+    for (const code of structuredErrorKeys) {
+      expect(translationSource).toContain(`'${code}'`);
+      expect(getLeaf(en, `manualInvoices.errors.${code}`)).toBeDefined();
     }
   });
 

--- a/packages/billing/tests/invoiceModification.manualRecurringGuard.test.ts
+++ b/packages/billing/tests/invoiceModification.manualRecurringGuard.test.ts
@@ -153,4 +153,18 @@ describe('manual invoice edits preserve recurring provenance', () => {
     expect(state.queriedTables).toContain('invoice_charges as ic');
     expect(recalculateInvoiceMock).not.toHaveBeenCalled();
   });
+
+  it('T208: recalculates manual edits on the open mutation transaction', async () => {
+    state.nonManualTargets = [];
+    const { updateInvoiceManualItems } = await import('../src/actions/invoiceModification.ts');
+
+    await updateInvoiceManualItems('invoice-1', {
+      updatedItems: [],
+      newItems: [],
+      removedItemIds: [],
+    } as any);
+
+    expect(recalculateInvoiceMock).toHaveBeenCalledTimes(1);
+    expect(recalculateInvoiceMock).toHaveBeenCalledWith('invoice-1', expect.any(Function), 'tenant-1');
+  });
 });

--- a/packages/billing/tests/tax/taxService.calculateTax.test.ts
+++ b/packages/billing/tests/tax/taxService.calculateTax.test.ts
@@ -221,7 +221,11 @@ describe('TaxService.calculateTax', () => {
 
       await expect(
         new TaxService().calculateTax('client-1', 10000, DATE, 'XX-ZZ')
-      ).rejects.toThrow(`No active tax rate(s) found for region XX-ZZ on date ${DATE}`);
+      ).rejects.toMatchObject({
+        code: 'NO_TAX_RATE',
+        params: { region: 'XX-ZZ', date: DATE },
+        message: `No active tax rate(s) found for region XX-ZZ on date ${DATE}`,
+      });
     });
   });
 

--- a/server/public/locales/de/msp/invoicing.json
+++ b/server/public/locales/de/msp/invoicing.json
@@ -339,9 +339,21 @@
       "refresh": "Beim Aktualisieren der Rechnungsdaten ist ein Fehler aufgetreten.",
       "updateFailed": "Fehler beim Aktualisieren der Rechnung",
       "generateFailed": "Fehler beim Generieren der Rechnung",
+      "NO_BILLING_EMAIL": "Für {{clientName}} ist keine Rechnungs-E-Mail-Adresse hinterlegt. Lege eine E-Mail-Adresse am Rechnungsstandort des Kunden fest und versuche es erneut.",
+      "CLIENT_NOT_FOUND": "Der ausgewählte Kunde wurde nicht gefunden. Aktualisiere die Seite und versuche es erneut.",
+      "SERVICE_NOT_FOUND": "Der Dienst {{serviceId}} wurde nicht gefunden. Aktualisiere die Seite und versuche es erneut.",
+      "INVALID_QUANTITY": "Die Menge muss größer als null sein.",
+      "NO_TAX_RATE": "Für {{region}} wurde am {{date}} kein aktiver Steuersatz gefunden.",
+      "DISCOUNT_TARGET_NOT_FOUND": "Der Dienst {{serviceId}} für diesen Rabatt wurde nicht gefunden.",
+      "INVOICE_NUMBER_CONFLICT": "Diese Rechnungsnummer wird bereits verwendet.",
+      "PERMISSION_DENIED": "Du hast keine Berechtigung, diese Rechnung zu erstellen oder zu aktualisieren.",
+      "UNEXPECTED": "Beim Generieren der Rechnung ist ein Fehler aufgetreten. Gib bei der Kontaktaufnahme mit dem Support die Referenz {{ref}} an.",
       "salesOrderGenerateFailed": "Could not generate the sales order invoice.",
       "salesOrderNothingToInvoice": "Nothing remains to invoice for this sales order.",
       "salesOrderNotInvoiceable": "That sales order is no longer available to invoice."
+    },
+    "warnings": {
+      "noBillingEmail": "Für diesen Kunden ist keine Rechnungs-E-Mail-Adresse hinterlegt. Lege vor dem Generieren der Rechnung eine E-Mail-Adresse am Rechnungsstandort fest."
     },
     "errorFallback": {
       "title": "Etwas ist schief gelaufen",

--- a/server/public/locales/en/msp/invoicing.json
+++ b/server/public/locales/en/msp/invoicing.json
@@ -339,9 +339,21 @@
       "refresh": "An error occurred while refreshing invoice data.",
       "updateFailed": "Error updating invoice",
       "generateFailed": "Error generating invoice",
+      "NO_BILLING_EMAIL": "{{clientName}} has no billing email. Set an email address on the client's billing location, then try again.",
+      "CLIENT_NOT_FOUND": "The selected client could not be found. Refresh and try again.",
+      "SERVICE_NOT_FOUND": "Service {{serviceId}} could not be found. Refresh and try again.",
+      "INVALID_QUANTITY": "Quantity must be greater than zero.",
+      "NO_TAX_RATE": "No active tax rate was found for {{region}} on {{date}}.",
+      "DISCOUNT_TARGET_NOT_FOUND": "Service {{serviceId}} could not be found for this discount.",
+      "INVOICE_NUMBER_CONFLICT": "This invoice number is already in use.",
+      "PERMISSION_DENIED": "You do not have permission to create or update this invoice.",
+      "UNEXPECTED": "Something went wrong generating the invoice. Quote reference {{ref}} when contacting support.",
       "salesOrderGenerateFailed": "Could not generate the sales order invoice.",
       "salesOrderNothingToInvoice": "Nothing remains to invoice for this sales order.",
       "salesOrderNotInvoiceable": "That sales order is no longer available to invoice."
+    },
+    "warnings": {
+      "noBillingEmail": "This client has no billing email. Set an email address on the client's billing location before generating the invoice."
     },
     "errorFallback": {
       "title": "Something went wrong",

--- a/server/public/locales/es/msp/invoicing.json
+++ b/server/public/locales/es/msp/invoicing.json
@@ -339,9 +339,21 @@
       "refresh": "Se produjo un error al actualizar los datos de la factura.",
       "updateFailed": "Error al actualizar la factura",
       "generateFailed": "Error al generar factura",
+      "NO_BILLING_EMAIL": "{{clientName}} no tiene correo electrónico de facturación. Añada una dirección de correo en la ubicación de facturación del cliente e inténtelo de nuevo.",
+      "CLIENT_NOT_FOUND": "No se encontró el cliente seleccionado. Actualice la página e inténtelo de nuevo.",
+      "SERVICE_NOT_FOUND": "No se encontró el servicio {{serviceId}}. Actualice la página e inténtelo de nuevo.",
+      "INVALID_QUANTITY": "La cantidad debe ser mayor que cero.",
+      "NO_TAX_RATE": "No se encontró una tasa impositiva activa para {{region}} el {{date}}.",
+      "DISCOUNT_TARGET_NOT_FOUND": "No se encontró el servicio {{serviceId}} para este descuento.",
+      "INVOICE_NUMBER_CONFLICT": "Este número de factura ya está en uso.",
+      "PERMISSION_DENIED": "No tiene permiso para crear o actualizar esta factura.",
+      "UNEXPECTED": "Se produjo un error al generar la factura. Indique la referencia {{ref}} al contactar con soporte.",
       "salesOrderGenerateFailed": "Could not generate the sales order invoice.",
       "salesOrderNothingToInvoice": "Nothing remains to invoice for this sales order.",
       "salesOrderNotInvoiceable": "That sales order is no longer available to invoice."
+    },
+    "warnings": {
+      "noBillingEmail": "Este cliente no tiene correo electrónico de facturación. Añada una dirección de correo en la ubicación de facturación antes de generar la factura."
     },
     "errorFallback": {
       "title": "algo salió mal",

--- a/server/public/locales/fr/msp/invoicing.json
+++ b/server/public/locales/fr/msp/invoicing.json
@@ -339,9 +339,21 @@
       "refresh": "Une erreur s'est produite lors de l'actualisation des données de facture.",
       "updateFailed": "Erreur lors de la mise à jour de la facture",
       "generateFailed": "Erreur lors de la génération de la facture",
+      "NO_BILLING_EMAIL": "{{clientName}} n'a pas d'adresse e-mail de facturation. Ajoutez une adresse e-mail à l'emplacement de facturation du client, puis réessayez.",
+      "CLIENT_NOT_FOUND": "Le client sélectionné est introuvable. Actualisez la page et réessayez.",
+      "SERVICE_NOT_FOUND": "Le service {{serviceId}} est introuvable. Actualisez la page et réessayez.",
+      "INVALID_QUANTITY": "La quantité doit être supérieure à zéro.",
+      "NO_TAX_RATE": "Aucun taux de taxe actif n'a été trouvé pour {{region}} à la date du {{date}}.",
+      "DISCOUNT_TARGET_NOT_FOUND": "Le service {{serviceId}} associé à cette remise est introuvable.",
+      "INVOICE_NUMBER_CONFLICT": "Ce numéro de facture est déjà utilisé.",
+      "PERMISSION_DENIED": "Vous n'êtes pas autorisé à créer ou à mettre à jour cette facture.",
+      "UNEXPECTED": "Une erreur s'est produite lors de la génération de la facture. Indiquez la référence {{ref}} lorsque vous contactez le support.",
       "salesOrderGenerateFailed": "Could not generate the sales order invoice.",
       "salesOrderNothingToInvoice": "Nothing remains to invoice for this sales order.",
       "salesOrderNotInvoiceable": "That sales order is no longer available to invoice."
+    },
+    "warnings": {
+      "noBillingEmail": "Ce client n'a pas d'adresse e-mail de facturation. Ajoutez une adresse e-mail à son emplacement de facturation avant de générer la facture."
     },
     "errorFallback": {
       "title": "Quelque chose s'est mal passé",

--- a/server/public/locales/it/msp/invoicing.json
+++ b/server/public/locales/it/msp/invoicing.json
@@ -339,9 +339,21 @@
       "refresh": "Si è verificato un errore durante l'aggiornamento dei dati della fattura.",
       "updateFailed": "Errore durante l'aggiornamento della fattura",
       "generateFailed": "Errore nella generazione della fattura",
+      "NO_BILLING_EMAIL": "{{clientName}} non ha un indirizzo e-mail di fatturazione. Imposta un indirizzo e-mail nella sede di fatturazione del cliente e riprova.",
+      "CLIENT_NOT_FOUND": "Il cliente selezionato non è stato trovato. Aggiorna la pagina e riprova.",
+      "SERVICE_NOT_FOUND": "Il servizio {{serviceId}} non è stato trovato. Aggiorna la pagina e riprova.",
+      "INVALID_QUANTITY": "La quantità deve essere maggiore di zero.",
+      "NO_TAX_RATE": "Non è stata trovata un'aliquota fiscale attiva per {{region}} alla data {{date}}.",
+      "DISCOUNT_TARGET_NOT_FOUND": "Il servizio {{serviceId}} per questo sconto non è stato trovato.",
+      "INVOICE_NUMBER_CONFLICT": "Questo numero di fattura è già in uso.",
+      "PERMISSION_DENIED": "Non disponi dell'autorizzazione per creare o aggiornare questa fattura.",
+      "UNEXPECTED": "Si è verificato un errore durante la generazione della fattura. Indica il riferimento {{ref}} quando contatti l'assistenza.",
       "salesOrderGenerateFailed": "Could not generate the sales order invoice.",
       "salesOrderNothingToInvoice": "Nothing remains to invoice for this sales order.",
       "salesOrderNotInvoiceable": "That sales order is no longer available to invoice."
+    },
+    "warnings": {
+      "noBillingEmail": "Questo cliente non ha un indirizzo e-mail di fatturazione. Imposta un indirizzo e-mail nella sede di fatturazione prima di generare la fattura."
     },
     "errorFallback": {
       "title": "Qualcosa è andato storto",

--- a/server/public/locales/nl/msp/invoicing.json
+++ b/server/public/locales/nl/msp/invoicing.json
@@ -339,9 +339,21 @@
       "refresh": "Er is een fout opgetreden bij het vernieuwen van de factuurgegevens.",
       "updateFailed": "Fout bij bijwerken factuur",
       "generateFailed": "Fout bij genereren factuur",
+      "NO_BILLING_EMAIL": "{{clientName}} heeft geen facturatie-e-mailadres. Stel een e-mailadres in op de facturatielocatie van de klant en probeer het opnieuw.",
+      "CLIENT_NOT_FOUND": "De geselecteerde klant is niet gevonden. Vernieuw de pagina en probeer het opnieuw.",
+      "SERVICE_NOT_FOUND": "Service {{serviceId}} is niet gevonden. Vernieuw de pagina en probeer het opnieuw.",
+      "INVALID_QUANTITY": "De hoeveelheid moet groter zijn dan nul.",
+      "NO_TAX_RATE": "Er is geen actief belastingtarief gevonden voor {{region}} op {{date}}.",
+      "DISCOUNT_TARGET_NOT_FOUND": "Service {{serviceId}} voor deze korting is niet gevonden.",
+      "INVOICE_NUMBER_CONFLICT": "Dit factuurnummer is al in gebruik.",
+      "PERMISSION_DENIED": "U bent niet gemachtigd om deze factuur te maken of bij te werken.",
+      "UNEXPECTED": "Er is iets misgegaan bij het genereren van de factuur. Vermeld referentie {{ref}} wanneer u contact opneemt met ondersteuning.",
       "salesOrderGenerateFailed": "Could not generate the sales order invoice.",
       "salesOrderNothingToInvoice": "Nothing remains to invoice for this sales order.",
       "salesOrderNotInvoiceable": "That sales order is no longer available to invoice."
+    },
+    "warnings": {
+      "noBillingEmail": "Deze klant heeft geen facturatie-e-mailadres. Stel een e-mailadres in op de facturatielocatie voordat u de factuur genereert."
     },
     "errorFallback": {
       "title": "Er is iets misgegaan",

--- a/server/public/locales/pl/msp/invoicing.json
+++ b/server/public/locales/pl/msp/invoicing.json
@@ -357,9 +357,21 @@
       "refresh": "Wystąpił błąd podczas odświeżania danych faktury.",
       "updateFailed": "Błąd podczas aktualizowania faktury",
       "generateFailed": "Błąd podczas generowania faktury",
+      "NO_BILLING_EMAIL": "Klient {{clientName}} nie ma adresu e-mail do rozliczeń. Ustaw adres e-mail w lokalizacji rozliczeniowej klienta i spróbuj ponownie.",
+      "CLIENT_NOT_FOUND": "Nie znaleziono wybranego klienta. Odśwież stronę i spróbuj ponownie.",
+      "SERVICE_NOT_FOUND": "Nie znaleziono usługi {{serviceId}}. Odśwież stronę i spróbuj ponownie.",
+      "INVALID_QUANTITY": "Ilość musi być większa od zera.",
+      "NO_TAX_RATE": "Nie znaleziono aktywnej stawki podatku dla regionu {{region}} w dniu {{date}}.",
+      "DISCOUNT_TARGET_NOT_FOUND": "Nie znaleziono usługi {{serviceId}} dla tego rabatu.",
+      "INVOICE_NUMBER_CONFLICT": "Ten numer faktury jest już używany.",
+      "PERMISSION_DENIED": "Nie masz uprawnień do tworzenia ani aktualizowania tej faktury.",
+      "UNEXPECTED": "Wystąpił błąd podczas generowania faktury. Kontaktując się z pomocą techniczną, podaj numer referencyjny {{ref}}.",
       "salesOrderGenerateFailed": "Could not generate the sales order invoice.",
       "salesOrderNothingToInvoice": "Nothing remains to invoice for this sales order.",
       "salesOrderNotInvoiceable": "That sales order is no longer available to invoice."
+    },
+    "warnings": {
+      "noBillingEmail": "Ten klient nie ma adresu e-mail do rozliczeń. Ustaw adres e-mail w lokalizacji rozliczeniowej przed wygenerowaniem faktury."
     },
     "errorFallback": {
       "title": "Coś poszło nie tak",

--- a/server/public/locales/pt/msp/invoicing.json
+++ b/server/public/locales/pt/msp/invoicing.json
@@ -339,9 +339,21 @@
       "refresh": "Ocorreu um erro ao atualizar os dados da fatura.",
       "updateFailed": "Erro ao atualizar fatura",
       "generateFailed": "Erro ao gerar fatura",
+      "NO_BILLING_EMAIL": "{{clientName}} não tem um e-mail de faturação. Defina um endereço de e-mail na localização de faturação do cliente e tente novamente.",
+      "CLIENT_NOT_FOUND": "O cliente selecionado não foi encontrado. Atualize a página e tente novamente.",
+      "SERVICE_NOT_FOUND": "O serviço {{serviceId}} não foi encontrado. Atualize a página e tente novamente.",
+      "INVALID_QUANTITY": "A quantidade deve ser maior que zero.",
+      "NO_TAX_RATE": "Não foi encontrada uma taxa de imposto ativa para {{region}} em {{date}}.",
+      "DISCOUNT_TARGET_NOT_FOUND": "O serviço {{serviceId}} para este desconto não foi encontrado.",
+      "INVOICE_NUMBER_CONFLICT": "Este número de fatura já está em uso.",
+      "PERMISSION_DENIED": "Não tem permissão para criar ou atualizar esta fatura.",
+      "UNEXPECTED": "Ocorreu um erro ao gerar a fatura. Indique a referência {{ref}} ao contactar o suporte.",
       "salesOrderGenerateFailed": "Could not generate the sales order invoice.",
       "salesOrderNothingToInvoice": "Nothing remains to invoice for this sales order.",
       "salesOrderNotInvoiceable": "That sales order is no longer available to invoice."
+    },
+    "warnings": {
+      "noBillingEmail": "Este cliente não tem um e-mail de faturação. Defina um endereço de e-mail na localização de faturação antes de gerar a fatura."
     },
     "errorFallback": {
       "title": "Algo deu errado",

--- a/server/public/locales/xx/msp/invoicing.json
+++ b/server/public/locales/xx/msp/invoicing.json
@@ -339,9 +339,21 @@
       "refresh": "11111",
       "updateFailed": "11111",
       "generateFailed": "11111",
+      "NO_BILLING_EMAIL": "11111 {{clientName}} 11111",
+      "CLIENT_NOT_FOUND": "11111",
+      "SERVICE_NOT_FOUND": "11111 {{serviceId}} 11111",
+      "INVALID_QUANTITY": "11111",
+      "NO_TAX_RATE": "11111 {{region}} 11111 {{date}} 11111",
+      "DISCOUNT_TARGET_NOT_FOUND": "11111 {{serviceId}} 11111",
+      "INVOICE_NUMBER_CONFLICT": "11111",
+      "PERMISSION_DENIED": "11111",
+      "UNEXPECTED": "11111 {{ref}} 11111",
       "salesOrderGenerateFailed": "11111",
       "salesOrderNothingToInvoice": "11111",
       "salesOrderNotInvoiceable": "11111"
+    },
+    "warnings": {
+      "noBillingEmail": "11111"
     },
     "errorFallback": {
       "title": "11111",

--- a/server/public/locales/yy/msp/invoicing.json
+++ b/server/public/locales/yy/msp/invoicing.json
@@ -339,9 +339,21 @@
       "refresh": "55555",
       "updateFailed": "55555",
       "generateFailed": "55555",
+      "NO_BILLING_EMAIL": "55555 {{clientName}} 55555",
+      "CLIENT_NOT_FOUND": "55555",
+      "SERVICE_NOT_FOUND": "55555 {{serviceId}} 55555",
+      "INVALID_QUANTITY": "55555",
+      "NO_TAX_RATE": "55555 {{region}} 55555 {{date}} 55555",
+      "DISCOUNT_TARGET_NOT_FOUND": "55555 {{serviceId}} 55555",
+      "INVOICE_NUMBER_CONFLICT": "55555",
+      "PERMISSION_DENIED": "55555",
+      "UNEXPECTED": "55555 {{ref}} 55555",
       "salesOrderGenerateFailed": "55555",
       "salesOrderNothingToInvoice": "55555",
       "salesOrderNotInvoiceable": "55555"
+    },
+    "warnings": {
+      "noBillingEmail": "55555"
     },
     "errorFallback": {
       "title": "55555",

--- a/server/src/test/unit/billing/billingEngine.recalculateInvoice.detailPeriods.test.ts
+++ b/server/src/test/unit/billing/billingEngine.recalculateInvoice.detailPeriods.test.ts
@@ -83,4 +83,53 @@ describe('BillingEngine recalculation recurring detail preservation', () => {
     expect(queriedTables).not.toContain('invoice_charge_details');
     expect(queriedTables).not.toContain('trx:invoice_charge_details');
   });
+
+  it('joins an existing transaction instead of opening a nested transaction', async () => {
+    const queriedTables: string[] = [];
+    const trx = vi.fn((table: string) => {
+      queriedTables.push(`trx:${table}`);
+      if (table === 'invoices') {
+        return createBuilder({
+          invoice_id: 'invoice-1',
+          client_id: 'client-1',
+          invoice_number: 'INV-1001',
+          tenant: 'tenant-1',
+        });
+      }
+
+      if (table === 'clients') {
+        return createBuilder({
+          client_id: 'client-1',
+          client_name: 'Acme Co',
+          is_tax_exempt: false,
+        });
+      }
+
+      return createBuilder(null);
+    }) as any;
+
+    const knex = vi.fn(() => {
+      throw new Error('root connection should not be queried');
+    }) as any;
+    knex.transaction = vi.fn();
+
+    const engine = new BillingEngine();
+    (engine as any).tenant = 'tenant-1';
+    (engine as any).knex = knex;
+    (engine as any).initKnex = vi.fn(async () => undefined);
+
+    await engine.recalculateInvoice('invoice-1', trx, 'tenant-1');
+
+    expect(knex).not.toHaveBeenCalled();
+    expect(knex.transaction).not.toHaveBeenCalled();
+    expect((engine as any).initKnex).not.toHaveBeenCalled();
+    expect(queriedTables).toEqual(['trx:invoices', 'trx:clients']);
+    expect(calculateAndDistributeTax).toHaveBeenLastCalledWith(
+      trx,
+      'invoice-1',
+      expect.objectContaining({ client_id: 'client-1' }),
+      expect.any(Object),
+      'tenant-1',
+    );
+  });
 });

--- a/server/src/test/unit/billing/invoiceService.manualPeriodPolicy.test.ts
+++ b/server/src/test/unit/billing/invoiceService.manualPeriodPolicy.test.ts
@@ -1,6 +1,9 @@
 import { describe, expect, it } from 'vitest';
 
-import { persistManualInvoiceCharges } from '../../../../../packages/billing/src/services/invoiceService';
+import {
+  persistManualInvoiceCharges,
+  validateClientBillingEmail,
+} from '../../../../../packages/billing/src/services/invoiceService';
 
 function normalizeColumnName(columnName: string) {
   const [, unqualifiedName] = columnName.match(/^(?:[^.]+)\.(.+)$/) ?? [];
@@ -41,6 +44,9 @@ function createMockTx(existingInvoiceCharges: Array<Record<string, any>> = []) {
       select() {
         return builder;
       },
+      orderByRaw() {
+        return builder;
+      },
       async first() {
         return filteredRows[0] ?? null;
       },
@@ -59,6 +65,73 @@ function createMockTx(existingInvoiceCharges: Array<Record<string, any>> = []) {
 }
 
 describe('manual invoice service-period policy', () => {
+  it('returns NO_BILLING_EMAIL with the client name when no billing location email exists', async () => {
+    const { tx } = createMockTx();
+
+    await expect(validateClientBillingEmail(
+      tx,
+      'tenant-1',
+      'client-1',
+      'Omni Energy Partners',
+    )).resolves.toMatchObject({
+      valid: false,
+      code: 'NO_BILLING_EMAIL',
+      params: { clientName: 'Omni Energy Partners' },
+    });
+  });
+
+  it('returns SERVICE_NOT_FOUND with the missing service identifier', async () => {
+    const { tx } = createMockTx();
+
+    await expect(persistManualInvoiceCharges(
+      tx,
+      'invoice-1',
+      [{ service_id: 'service-404', description: 'Missing service', quantity: 1, rate: 2500 }] as any,
+      { client_id: 'client-1', region_code: 'US-WA' },
+      { user: { id: 'user-1' } } as any,
+      'tenant-1',
+    )).rejects.toMatchObject({
+      code: 'SERVICE_NOT_FOUND',
+      params: { serviceId: 'service-404' },
+    });
+  });
+
+  it('returns INVALID_QUANTITY before persisting a non-positive line', async () => {
+    const { tx, inserts } = createMockTx();
+
+    await expect(persistManualInvoiceCharges(
+      tx,
+      'invoice-1',
+      [{ description: 'Invalid quantity', quantity: 0, rate: 2500 }] as any,
+      { client_id: 'client-1', region_code: 'US-WA' },
+      { user: { id: 'user-1' } } as any,
+      'tenant-1',
+    )).rejects.toMatchObject({ code: 'INVALID_QUANTITY' });
+    expect(inserts.invoice_charges).toHaveLength(0);
+  });
+
+  it('returns DISCOUNT_TARGET_NOT_FOUND with the missing service identifier', async () => {
+    const { tx } = createMockTx();
+
+    await expect(persistManualInvoiceCharges(
+      tx,
+      'invoice-1',
+      [{
+        description: 'Orphan discount',
+        quantity: 1,
+        rate: 100,
+        is_discount: true,
+        applies_to_service_id: 'service-404',
+      }] as any,
+      { client_id: 'client-1', region_code: 'US-WA' },
+      { user: { id: 'user-1' } } as any,
+      'tenant-1',
+    )).rejects.toMatchObject({
+      code: 'DISCOUNT_TARGET_NOT_FOUND',
+      params: { serviceId: 'service-404' },
+    });
+  });
+
   it('manual invoice charges do not create time-entry source links', async () => {
     const { tx, inserts } = createMockTx();
 

--- a/server/src/test/unit/billing/manualInvoiceActions.errors.test.ts
+++ b/server/src/test/unit/billing/manualInvoiceActions.errors.test.ts
@@ -1,0 +1,237 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { ManualInvoiceError } from '../../../../../packages/billing/src/errors/manualInvoiceErrors';
+
+const mocks = vi.hoisted(() => {
+  const warn = vi.fn();
+  const error = vi.fn();
+  const hasPermission = vi.fn(async () => true);
+  const insert = vi.fn(async () => undefined);
+  const trx = vi.fn(() => {
+    const builder = {
+      where: vi.fn(() => builder),
+      insert,
+    };
+    return builder;
+  });
+  const transaction = vi.fn(async (callback: (transaction: typeof trx) => Promise<unknown>) => callback(trx));
+  const validateSessionAndTenant = vi.fn(async () => ({
+    session: { user: { id: 'session-user-1' } },
+    knex: { transaction },
+  }));
+  const getClientDetails = vi.fn(async () => ({
+    client_id: 'client-1',
+    client_name: 'Omni Energy Partners',
+    default_currency_code: 'USD',
+  }));
+  const validateClientBillingEmail = vi.fn(async () => ({ valid: true }));
+  const persistManualInvoiceCharges = vi.fn(async () => undefined);
+  const calculateAndDistributeTax = vi.fn(async () => undefined);
+  const updateInvoiceTotalsAndRecordTransaction = vi.fn(async () => undefined);
+  const getFullInvoiceById = vi.fn(async () => ({
+    invoice_id: 'invoice-1',
+    subtotal: 1000,
+    tax: 0,
+    total_amount: 1000,
+    invoice_charges: [],
+  }));
+
+  return {
+    warn,
+    error,
+    hasPermission,
+    insert,
+    trx,
+    transaction,
+    validateSessionAndTenant,
+    getClientDetails,
+    validateClientBillingEmail,
+    persistManualInvoiceCharges,
+    calculateAndDistributeTax,
+    updateInvoiceTotalsAndRecordTransaction,
+    getFullInvoiceById,
+  };
+});
+
+vi.mock('@alga-psa/core/logger', () => ({
+  default: {
+    warn: mocks.warn,
+    error: mocks.error,
+  },
+}));
+
+vi.mock('@alga-psa/auth', () => ({
+  withAuth: (action: (...args: any[]) => Promise<unknown>) =>
+    (...args: any[]) => action({ user_id: 'auth-user-1' }, { tenant: 'tenant-1' }, ...args),
+  getSession: vi.fn(async () => ({ user: { id: 'session-user-1' } })),
+}));
+
+vi.mock('@alga-psa/auth/rbac', () => ({
+  hasPermission: mocks.hasPermission,
+}));
+
+vi.mock('../../../../../packages/billing/src/services/invoiceService', () => ({
+  validateSessionAndTenant: mocks.validateSessionAndTenant,
+  getClientDetails: mocks.getClientDetails,
+  getClientBillingEmail: vi.fn(async () => null),
+  validateClientBillingEmail: mocks.validateClientBillingEmail,
+  persistManualInvoiceCharges: mocks.persistManualInvoiceCharges,
+  calculateAndDistributeTax: mocks.calculateAndDistributeTax,
+  updateInvoiceTotalsAndRecordTransaction: mocks.updateInvoiceTotalsAndRecordTransaction,
+}));
+
+vi.mock('../../../../../packages/billing/src/models/invoice', () => ({
+  default: { getFullInvoiceById: mocks.getFullInvoiceById },
+}));
+
+vi.mock('../../../../../packages/billing/src/actions/invoiceGeneration', () => ({
+  generateInvoiceNumber: vi.fn(async () => 'INV-001'),
+}));
+
+vi.mock('../../../../../packages/billing/src/actions/taxSourceActions', () => ({
+  getInitialInvoiceTaxSource: vi.fn(async () => 'internal'),
+}));
+
+vi.mock('../../../../../packages/billing/src/actions/billingAndTax', () => ({
+  getDueDate: vi.fn(async () => '2026-08-13'),
+}));
+
+vi.mock('../../../../../packages/billing/src/lib/authHelpers', () => ({
+  getAnalyticsAsync: vi.fn(async () => ({
+    analytics: { capture: vi.fn() },
+    AnalyticsEvents: { INVOICE_GENERATED: 'INVOICE_GENERATED' },
+  })),
+}));
+
+vi.mock('../../../../../packages/billing/src/services/taxService', () => ({
+  TaxService: class {},
+}));
+
+const { generateManualInvoice } = await import(
+  '../../../../../packages/billing/src/actions/manualInvoiceActions'
+);
+
+const request = {
+  clientId: 'client-1',
+  items: [{ service_id: 'service-1', quantity: 1, description: 'Setup', rate: 1000 }],
+};
+
+describe('generateManualInvoice structured errors', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.hasPermission.mockResolvedValue(true);
+    mocks.validateClientBillingEmail.mockResolvedValue({ valid: true });
+  });
+
+  it('returns the billing-email code and client name and logs tenant/client/user context', async () => {
+    mocks.validateClientBillingEmail.mockResolvedValueOnce({
+      valid: false,
+      code: 'NO_BILLING_EMAIL',
+      params: { clientName: 'Omni Energy Partners' },
+      error: 'Cannot generate invoice: No billing email address for "Omni Energy Partners".',
+    });
+
+    const result = await generateManualInvoice(request);
+
+    expect(result).toMatchObject({
+      success: false,
+      code: 'NO_BILLING_EMAIL',
+      params: { clientName: 'Omni Energy Partners' },
+      error: expect.stringContaining('No billing email address'),
+      message: expect.stringContaining('No billing email address'),
+    });
+    expect(mocks.warn).toHaveBeenCalledWith('[generateManualInvoice] NO_BILLING_EMAIL', {
+      tenant: 'tenant-1',
+      clientId: 'client-1',
+      userId: 'session-user-1',
+      clientName: 'Omni Energy Partners',
+    });
+  });
+
+  it.each([
+    ['CLIENT_NOT_FOUND', 'Client not found', {}],
+    ['SERVICE_NOT_FOUND', 'Service not found: service-404', { serviceId: 'service-404' }],
+    ['INVALID_QUANTITY', 'Quantity must be greater than 0', {}],
+    ['DISCOUNT_TARGET_NOT_FOUND', 'Discount target not found', { serviceId: 'service-404' }],
+  ] as const)('maps a %s domain error into the structured envelope', async (code, message, params) => {
+    const domainError = new ManualInvoiceError(code, message, params);
+    if (code === 'CLIENT_NOT_FOUND') {
+      mocks.getClientDetails.mockRejectedValueOnce(domainError);
+    } else {
+      mocks.persistManualInvoiceCharges.mockRejectedValueOnce(domainError);
+    }
+
+    const result = await generateManualInvoice(request);
+
+    expect(result).toMatchObject({ success: false, code, params, message, error: message });
+    expect(mocks.warn).toHaveBeenCalledWith(
+      `[generateManualInvoice] ${code}`,
+      expect.objectContaining({ tenant: 'tenant-1', clientId: 'client-1' }),
+    );
+  });
+
+  it('maps missing tax rates with region and date parameters', async () => {
+    mocks.calculateAndDistributeTax.mockRejectedValueOnce(new ManualInvoiceError(
+      'NO_TAX_RATE',
+      'No active tax rate(s) found for region US-PA on date 2026-07-14',
+      { region: 'US-PA', date: '2026-07-14' },
+    ));
+
+    const result = await generateManualInvoice(request);
+
+    expect(result).toMatchObject({
+      success: false,
+      code: 'NO_TAX_RATE',
+      params: { region: 'US-PA', date: '2026-07-14' },
+    });
+  });
+
+  it('maps the invoice-number unique constraint to INVOICE_NUMBER_CONFLICT', async () => {
+    mocks.insert.mockRejectedValueOnce(Object.assign(new Error('duplicate key'), {
+      code: '23505',
+      constraint: 'unique_invoice_number_per_tenant',
+    }));
+
+    const result = await generateManualInvoice(request);
+
+    expect(result).toMatchObject({
+      success: false,
+      code: 'INVOICE_NUMBER_CONFLICT',
+      message: 'Invoice number must be unique',
+    });
+  });
+
+  it('returns and logs PERMISSION_DENIED without starting invoice work', async () => {
+    mocks.hasPermission.mockResolvedValueOnce(false);
+
+    const result = await generateManualInvoice(request);
+
+    expect(result).toMatchObject({ success: false, code: 'PERMISSION_DENIED' });
+    expect(mocks.validateSessionAndTenant).not.toHaveBeenCalled();
+    expect(mocks.warn).toHaveBeenCalledWith(
+      '[generateManualInvoice] PERMISSION_DENIED',
+      expect.objectContaining({ tenant: 'tenant-1', clientId: 'client-1' }),
+    );
+  });
+
+  it('returns a support reference and logs unexpected errors with the stack', async () => {
+    mocks.persistManualInvoiceCharges.mockRejectedValueOnce(new Error('database unavailable'));
+
+    const result = await generateManualInvoice(request);
+
+    expect(result).toMatchObject({
+      success: false,
+      code: 'UNEXPECTED',
+      ref: expect.stringMatching(/^[0-9a-f-]{8}$/),
+    });
+    expect(mocks.error).toHaveBeenCalledWith(
+      '[generateManualInvoice] UNEXPECTED',
+      expect.objectContaining({
+        tenant: 'tenant-1',
+        clientId: 'client-1',
+        ref: expect.any(String),
+        error: 'database unavailable',
+        stack: expect.any(String),
+      }),
+    );
+  });
+});

--- a/server/src/test/unit/billing/manualInvoiceErrorTranslation.test.ts
+++ b/server/src/test/unit/billing/manualInvoiceErrorTranslation.test.ts
@@ -1,0 +1,55 @@
+import { describe, expect, it, vi } from 'vitest';
+import { translateManualInvoiceFailure } from '../../../../../packages/billing/src/components/billing-dashboard/manualInvoiceErrorTranslation';
+
+describe('manual invoice error translation', () => {
+  it('renders the specific billing-email message instead of the generic generation error', () => {
+    const t = vi.fn((key: string, options?: Record<string, unknown>) => {
+      if (key === 'manualInvoices.errors.NO_BILLING_EMAIL') {
+        return `${options?.clientName} has no billing email. Set an email address on the client's billing location, then try again.`;
+      }
+      return 'Error generating invoice';
+    });
+
+    const message = translateManualInvoiceFailure(t, {
+      success: false,
+      code: 'NO_BILLING_EMAIL',
+      params: { clientName: 'Omni Energy Partners' },
+      message: 'server fallback',
+      error: 'server fallback',
+    });
+
+    expect(message).toContain('Omni Energy Partners has no billing email');
+    expect(message).not.toBe('Error generating invoice');
+  });
+
+  it('renders the support reference for unexpected failures', () => {
+    const t = vi.fn((_key: string, options?: Record<string, unknown>) => (
+      `Something went wrong generating the invoice. Quote reference ${options?.ref} when contacting support.`
+    ));
+
+    const message = translateManualInvoiceFailure(t, {
+      success: false,
+      code: 'UNEXPECTED',
+      params: { ref: 'a1b2c3d4' },
+      message: 'Unexpected error generating invoice',
+      error: 'Unexpected error generating invoice',
+      ref: 'a1b2c3d4',
+    });
+
+    expect(message).toContain('a1b2c3d4');
+  });
+
+  it('shows the server fallback verbatim for unknown codes', () => {
+    const t = vi.fn(() => 'Error generating invoice');
+
+    const message = translateManualInvoiceFailure(t, {
+      success: false,
+      code: 'FUTURE_CODE' as never,
+      message: 'A newer server supplied this exact message',
+      error: 'A newer server supplied this exact message',
+    });
+
+    expect(message).toBe('A newer server supplied this exact message');
+    expect(t).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Summary

- replace generic manual-invoice failures with a nine-code structured error envelope, localized per-code messages, and contextual server logging (including support references for unexpected errors)
- warn before submission when the selected client has no billing email while preserving server-side validation and client-specific error handling
- propagate structured failures through manual-invoice edits and run invoice recalculation inside the same database transaction as item changes
- add focused coverage for action error mapping, translation behavior, locale parity, transaction propagation, and recurring/manual period policy regressions

Related ticket: alga0002092.

## Smoke test

PASS with one coverage limitation. Exercised through the real product on port 3954 using the live `alga-psa-local-test` services:

1. Missing billing email: Bills Windsurf Shop showed the new pre-submit warning. Submission returned the specific client-localized error instead of the generic failure. Server logs contained the contextual `NO_BILLING_EMAIL` warning, and the client’s invoice count remained zero.
2. Successful generation: created a real $150 manual invoice for Amys Bird Sanctuary. The success dialog appeared, and Drafts displayed `INV-000002` with the correct client, description, quantity 2, $75 rate, and $150 total. PostgreSQL confirmed a draft manual invoice and one matching $150 charge.
3. Validation/rollback regression: quantity 0 produced the localized “Quantity must be greater than zero.” error. Invoice count did not change and no charge with the test description persisted.

The action error-envelope mapping and edit transaction propagation were reviewed. Live edit-path testing was not possible because `ManualInvoices` is currently mounted only in create mode; no reachable product screen supplies its `invoice` prop. The recalculation call is inside the same transaction in code, but that behavior remains UI-unproven.

Fidelity: real UI, server actions, seeded data, and PostgreSQL were used. No simulator or mock was used. One real draft invoice was intentionally left in the environment as evidence.

Evidence: `/tmp/alga-smoke-evidence/manual-invoice-error-20260714-113644`

## Notes

The Drafts page issued background accounting-sync requests that returned 500 because the CE stack rejects them as Enterprise-only. Invoice/template requests returned 200 and the draft rendered correctly; this is unrelated to this change. Minor automation hydration and restart-related HMR console noise was also observed.

The app remained healthy after testing; the redirected sign-in endpoint returned HTTP 200. Pre-existing `package.json` and `package-lock.json` changes were untouched.
