### PR TITLE
Add configurable client portal hero gradient

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -344,6 +344,7 @@
       "name": "sebastian-ee",
       "dependencies": {
         "@alga-psa/authorization": "*",
+        "@alga-psa/email": "*",
         "@alga-psa/workflow-streams": "*",
         "@alga-psa/workflows": "*",
         "@huggingface/inference": "^3.3.3",
@@ -46667,6 +46668,7 @@
         "@alga-psa/db": "*",
         "@alga-psa/event-bus": "*",
         "@alga-psa/notifications": "*",
+        "@alga-psa/projects": "*",
         "@alga-psa/shared": "*",
         "@alga-psa/types": "*",
         "@alga-psa/ui": "*",
@@ -47424,7 +47426,11 @@
         "typescript": "^5.3.0"
       }
     },
-    "sdk": {},
+    "sdk": {
+      "dev": true,
+      "optional": true,
+      "peer": true
+    },
     "sdk/alga-cli": {
       "name": "@alga-psa/cli",
       "version": "0.2.0",

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "test:local": "cd server && dotenv -e ../.env.localtest -- vitest \"$@\"",
     "generate:proto": "mkdir -p ee/server/src/generated && protoc --plugin=./node_modules/.bin/protoc-gen-ts_proto --ts_proto_out=ee/server/src/generated --ts_proto_opt=esModuleInterop=true,outputServices=false,useExactTypes=false --proto_path=ee/server/protos workflow.proto",
     "mcp:registry:generate": "node ee/scripts/generate-chat-registry.mjs",
-    "dev": "PORT=3019 NX_LOAD_DOT_ENV_FILES=false NODE_ENV=development NX_TUI=false npx nx next:dev server",
+    "dev": "NX_LOAD_DOT_ENV_FILES=false NODE_ENV=development NX_TUI=false npx nx next:dev server",
     "dev:turbo": "NX_LOAD_DOT_ENV_FILES=false NODE_ENV=development NX_TUI=false npx nx next:dev server -- --turbo",
     "build": "npm run build:assemblyscript && npx nx build-deps server && cd server && USE_PREBUILT=true EDITION=community NEXT_PUBLIC_EDITION=community npm run build:turbo",
     "build:source": "npm run build:assemblyscript && cd server && EDITION=community NEXT_PUBLIC_EDITION=community npm run build:turbo",

--- a/packages/client-portal/src/components/dashboard/ClientDashboard.contract.test.ts
+++ b/packages/client-portal/src/components/dashboard/ClientDashboard.contract.test.ts
@@ -8,6 +8,19 @@ const source = fs.readFileSync(
 );
 
 describe('ClientDashboard quick-action distribution contract', () => {
+  it('preserves the established hero gradient unless the tenant opts into both brand colors', () => {
+    expect(source).toContain("branding?.portalHeroGradient ?? 'primary-shades'");
+    expect(source).toContain("portalHeroGradient === 'primary-secondary'");
+    expect(source).toContain("? '--color-secondary-500'");
+    expect(source).toContain(": '--color-primary-700'");
+    expect(source).toContain('linear-gradient(90deg');
+  });
+
+  it('uses the selected gradient endpoint when computing readable hero text', () => {
+    expect(source).toContain("? '--color-secondary-500'");
+    expect(source).toContain(": '--color-primary-700'");
+  });
+
   it('does NOT put the quick-action buttons in the hero block', () => {
     // Hero quick-action IDs were removed; presence of any of these would mean we regressed.
     expect(source).not.toContain('dashboard-quick-create-ticket');

--- a/packages/client-portal/src/components/dashboard/ClientDashboard.tsx
+++ b/packages/client-portal/src/components/dashboard/ClientDashboard.tsx
@@ -40,6 +40,8 @@ import { getCurrentUser } from '@alga-psa/user-composition/actions';
 import { toBrowserDate } from '../appointments/dateUtils';
 import type { AppointmentSummary } from '../appointments/types';
 import { getErrorMessage, isActionMessageError, isActionPermissionError } from '@alga-psa/ui/lib/errorHandling';
+import { useBranding } from '@alga-psa/tenancy/components';
+import type { PortalHeroGradient } from '@alga-psa/tenancy/actions';
 
 type TranslateFn = ReturnType<typeof useTranslation>['t'];
 
@@ -142,10 +144,9 @@ function deviceIcon(type: Asset['asset_type']): React.ComponentType<{ className?
   }
 }
 
-// Pick black or white text based on the average luminance of the hero
-// gradient (read from --color-primary-500 / --color-primary-700, which can be
-// rebranded per tenant or flipped by theme).
-function useHeroTextColor(): 'black' | 'white' {
+// Pick black or white text based on the average luminance of the selected hero
+// gradient. The endpoint is either primary-700 (legacy) or secondary-500.
+function useHeroTextColor(gradientMode: PortalHeroGradient): 'black' | 'white' {
   const [color, setColor] = useState<'black' | 'white'>('white');
 
   useEffect(() => {
@@ -161,7 +162,11 @@ function useHeroTextColor(): 'black' | 'white' {
         return 0.2126 * lin(r) + 0.7152 * lin(g) + 0.0722 * lin(b);
       };
       const start = parse('--color-primary-500');
-      const end = parse('--color-primary-700');
+      const end = parse(
+        gradientMode === 'primary-secondary'
+          ? '--color-secondary-500'
+          : '--color-primary-700',
+      );
       if (start.length !== 3 || end.length !== 3 || [...start, ...end].some(Number.isNaN)) return;
       const avg = (relLum(start) + relLum(end)) / 2;
       setColor(avg > 0.5 ? 'black' : 'white');
@@ -170,7 +175,7 @@ function useHeroTextColor(): 'black' | 'white' {
     const observer = new MutationObserver(compute);
     observer.observe(document.documentElement, { attributes: true, attributeFilter: ['class'] });
     return () => observer.disconnect();
-  }, []);
+  }, [gradientMode]);
 
   return color;
 }
@@ -202,9 +207,14 @@ const DASHBOARD_PREVIEW_APPOINTMENTS = 3;
 
 export function ClientDashboard({ productCode = 'psa' }: { productCode?: ProductCode } = {}) {
   const { t, i18n } = useTranslation('client-portal');
+  const { branding } = useBranding();
+  const portalHeroGradient = branding?.portalHeroGradient ?? 'primary-shades';
+  const heroGradientEnd = portalHeroGradient === 'primary-secondary'
+    ? '--color-secondary-500'
+    : '--color-primary-700';
   const isAlgaDeskPortal = productCode === 'algadesk';
   const locale = i18n.language || undefined;
-  const heroTextColor = useHeroTextColor();
+  const heroTextColor = useHeroTextColor(portalHeroGradient);
   const heroTextClass = heroTextColor === 'black' ? 'text-black' : 'text-white';
   const heroTextMutedClass = heroTextColor === 'black' ? 'text-black/70' : 'text-white/80';
   const heroTextSubtleClass = heroTextColor === 'black' ? 'text-black/75' : 'text-white/85';
@@ -421,7 +431,12 @@ export function ClientDashboard({ productCode = 'psa' }: { productCode?: Product
       {/* Welcome Hero */}
       {/* Text color is computed from the gradient's luminance (see
           useHeroTextColor) so it tracks the actual background, not the theme. */}
-      <div className="relative overflow-hidden rounded-2xl bg-gradient-to-br from-[rgb(var(--color-primary-500))] to-[rgb(var(--color-primary-700))] px-8 py-7 shadow-sm">
+      <div
+        className="relative overflow-hidden rounded-2xl px-8 py-7 shadow-sm"
+        style={{
+          background: `linear-gradient(90deg, rgb(var(--color-primary-500)), rgb(var(${heroGradientEnd})))`,
+        }}
+      >
         <div className="max-w-2xl">
           <div className={`text-xs font-medium uppercase tracking-wider ${heroTextMutedClass}`}>
             {t('dashboard.welcomeBack', 'Welcome back')}

--- a/packages/tenancy/src/actions/tenant-actions/tenantBrandingActions.ts
+++ b/packages/tenancy/src/actions/tenant-actions/tenantBrandingActions.ts
@@ -7,11 +7,18 @@ import { withAuth, withOptionalAuth, type AuthContext } from '@alga-psa/auth';
 import type { IUserWithRoles } from '@alga-psa/types';
 import type { Knex } from 'knex';
 
+export type PortalHeroGradient = 'primary-shades' | 'primary-secondary';
+
 export interface TenantBranding {
   logoUrl: string;
   primaryColor: string;
   secondaryColor: string;
   clientName: string;
+  /**
+   * Controls the client dashboard welcome gradient. Missing values retain the
+   * original primary-500 -> primary-700 behavior for existing tenants.
+   */
+  portalHeroGradient?: PortalHeroGradient;
   supportEmail?: string;
   supportPhone?: string;
   computedStyles?: string; // Cached CSS styles
@@ -57,6 +64,7 @@ export const updateTenantBrandingAction = withAuth(async (user: IUserWithRoles, 
       primaryColor: branding.primaryColor,
       secondaryColor: branding.secondaryColor,
       clientName: branding.clientName,
+      portalHeroGradient: branding.portalHeroGradient,
       computedStyles, // Store precomputed CSS
     }
   };

--- a/packages/tenancy/src/actions/tenant-actions/tenantBrandingTenantScoped.contract.test.ts
+++ b/packages/tenancy/src/actions/tenant-actions/tenantBrandingTenantScoped.contract.test.ts
@@ -9,6 +9,12 @@ const files = [
 ];
 
 describe('tenant branding actions tenant-scoped query contract', () => {
+  it('persists the optional client portal hero gradient mode with branding', () => {
+    const source = readFileSync(resolve(__dirname, 'tenantBrandingActions.ts'), 'utf8');
+    expect(source).toContain("export type PortalHeroGradient = 'primary-shades' | 'primary-secondary'");
+    expect(source).toContain('portalHeroGradient: branding.portalHeroGradient');
+  });
+
   it('uses structural tenant scoping for tenant settings branding roots', () => {
     for (const file of files) {
       const source = readFileSync(resolve(__dirname, file), 'utf8');

--- a/server/public/locales/de/msp/settings.json
+++ b/server/public/locales/de/msp/settings.json
@@ -1052,7 +1052,8 @@
         "primaryColor": "Primärfarbe",
         "secondaryColor": "Sekundärfarbe",
         "supportEmail": "Support-E-Mail",
-        "supportPhone": "Support-Telefon"
+        "supportPhone": "Support-Telefon",
+        "heroGradient": "Dashboard-Hintergrundverlauf"
       },
       "help": {
         "companyName": "Dies wird in der Kopfzeile des Kundenportals angezeigt",
@@ -1060,7 +1061,12 @@
         "primaryColor": "Wird für Schaltflächen, Links und Hervorhebungen verwendet",
         "secondaryColor": "Wird für Akzente und sekundäre Aktionen verwendet",
         "supportEmail": "Wird Kunden in Terminbestätigungen und anderen ausgehenden E-Mails als Kontaktadresse für den Support angezeigt.",
-        "supportPhone": "Optional. Wird neben der Support-E-Mail in E-Mails an Kunden angezeigt."
+        "supportPhone": "Optional. Wird neben der Support-E-Mail in E-Mails an Kunden angezeigt.",
+        "heroGradient": "Steuert den Verlauf des Willkommensbanners im Kunden-Dashboard."
+      },
+      "heroGradient": {
+        "primaryShades": "Primärfarbe zu Primärfarbton",
+        "primarySecondary": "Primärfarbe zu Sekundärfarbe"
       },
       "preview": "Vorschau",
       "previewDarkMode": "Dunkelmodus-Vorschau",

--- a/server/public/locales/en/msp/settings.json
+++ b/server/public/locales/en/msp/settings.json
@@ -1052,7 +1052,8 @@
         "primaryColor": "Primary Color",
         "secondaryColor": "Secondary Color",
         "supportEmail": "Support Email",
-        "supportPhone": "Support Phone"
+        "supportPhone": "Support Phone",
+        "heroGradient": "Dashboard hero gradient"
       },
       "help": {
         "companyName": "This will be displayed in the client portal header",
@@ -1060,7 +1061,12 @@
         "primaryColor": "Used for buttons, links, and highlights",
         "secondaryColor": "Used for accents and secondary actions",
         "supportEmail": "Shown to clients in appointment confirmations and other outbound emails as the address to contact for help.",
-        "supportPhone": "Optional. Shown alongside the support email in client-facing emails."
+        "supportPhone": "Optional. Shown alongside the support email in client-facing emails.",
+        "heroGradient": "Controls the welcome banner gradient on the client dashboard."
+      },
+      "heroGradient": {
+        "primaryShades": "Primary color to primary shade",
+        "primarySecondary": "Primary color to secondary color"
       },
       "preview": "Preview",
       "previewDarkMode": "Preview dark mode",

--- a/server/public/locales/es/msp/settings.json
+++ b/server/public/locales/es/msp/settings.json
@@ -1052,7 +1052,8 @@
         "primaryColor": "Color primario",
         "secondaryColor": "Color secundario",
         "supportEmail": "Correo de soporte",
-        "supportPhone": "Teléfono de soporte"
+        "supportPhone": "Teléfono de soporte",
+        "heroGradient": "Degradado del encabezado del panel"
       },
       "help": {
         "companyName": "Esto se mostrará en el encabezado del portal del cliente",
@@ -1060,7 +1061,12 @@
         "primaryColor": "Se utiliza para botones, enlaces y elementos destacados",
         "secondaryColor": "Se utiliza para acentos y acciones secundarias",
         "supportEmail": "Se muestra a los clientes en las confirmaciones de citas y otros correos salientes como dirección de contacto para obtener ayuda.",
-        "supportPhone": "Opcional. Se muestra junto al correo de soporte en los correos enviados a los clientes."
+        "supportPhone": "Opcional. Se muestra junto al correo de soporte en los correos enviados a los clientes.",
+        "heroGradient": "Controla el degradado del banner de bienvenida del panel del cliente."
+      },
+      "heroGradient": {
+        "primaryShades": "Color primario a tono primario",
+        "primarySecondary": "Color primario a color secundario"
       },
       "preview": "Vista previa",
       "previewDarkMode": "Vista previa en modo oscuro",

--- a/server/public/locales/fr/msp/settings.json
+++ b/server/public/locales/fr/msp/settings.json
@@ -1052,7 +1052,8 @@
         "primaryColor": "Couleur principale",
         "secondaryColor": "Couleur secondaire",
         "supportEmail": "E-mail du support",
-        "supportPhone": "Téléphone du support"
+        "supportPhone": "Téléphone du support",
+        "heroGradient": "Dégradé de l’en-tête du tableau de bord"
       },
       "help": {
         "companyName": "Ce nom sera affiché dans l'en-tête du portail client",
@@ -1060,7 +1061,12 @@
         "primaryColor": "Utilisée pour les boutons, les liens et les éléments mis en avant",
         "secondaryColor": "Utilisée pour les accents et les actions secondaires",
         "supportEmail": "Affiché aux clients dans les confirmations de rendez-vous et autres e-mails sortants comme adresse de contact pour obtenir de l'aide.",
-        "supportPhone": "Facultatif. Affiché à côté de l'e-mail du support dans les e-mails destinés aux clients."
+        "supportPhone": "Facultatif. Affiché à côté de l'e-mail du support dans les e-mails destinés aux clients.",
+        "heroGradient": "Contrôle le dégradé de la bannière d’accueil du tableau de bord client."
+      },
+      "heroGradient": {
+        "primaryShades": "Couleur principale vers une nuance principale",
+        "primarySecondary": "Couleur principale vers couleur secondaire"
       },
       "preview": "Aperçu",
       "previewDarkMode": "Aperçu en mode sombre",

--- a/server/public/locales/it/msp/settings.json
+++ b/server/public/locales/it/msp/settings.json
@@ -1052,7 +1052,8 @@
         "primaryColor": "Colore primario",
         "secondaryColor": "Colore secondario",
         "supportEmail": "E-mail di supporto",
-        "supportPhone": "Telefono di supporto"
+        "supportPhone": "Telefono di supporto",
+        "heroGradient": "Gradiente dell’intestazione della dashboard"
       },
       "help": {
         "companyName": "Verra visualizzato nell'intestazione del portale clienti",
@@ -1060,7 +1061,12 @@
         "primaryColor": "Utilizzato per pulsanti, link e evidenziazioni",
         "secondaryColor": "Utilizzato per accenti e azioni secondarie",
         "supportEmail": "Viene mostrata ai clienti nelle conferme degli appuntamenti e in altre e-mail in uscita come indirizzo di contatto per ricevere assistenza.",
-        "supportPhone": "Facoltativo. Viene mostrato accanto all'e-mail di supporto nelle e-mail rivolte ai clienti."
+        "supportPhone": "Facoltativo. Viene mostrato accanto all'e-mail di supporto nelle e-mail rivolte ai clienti.",
+        "heroGradient": "Controlla il gradiente del banner di benvenuto nella dashboard cliente."
+      },
+      "heroGradient": {
+        "primaryShades": "Dal colore primario a una tonalità primaria",
+        "primarySecondary": "Dal colore primario al colore secondario"
       },
       "preview": "Anteprima",
       "previewDarkMode": "Anteprima modalita scura",

--- a/server/public/locales/nl/msp/settings.json
+++ b/server/public/locales/nl/msp/settings.json
@@ -1052,7 +1052,8 @@
         "primaryColor": "Primaire kleur",
         "secondaryColor": "Secundaire kleur",
         "supportEmail": "Support-e-mail",
-        "supportPhone": "Support-telefoonnummer"
+        "supportPhone": "Support-telefoonnummer",
+        "heroGradient": "Verloop van dashboardkop"
       },
       "help": {
         "companyName": "Dit wordt weergegeven in de koptekst van het klantenportaal",
@@ -1060,7 +1061,12 @@
         "primaryColor": "Wordt gebruikt voor knoppen, links en accenten",
         "secondaryColor": "Wordt gebruikt voor accenten en secundaire acties",
         "supportEmail": "Wordt aan klanten getoond in afspraakbevestigingen en andere uitgaande e-mails als contactadres voor hulp.",
-        "supportPhone": "Optioneel. Wordt naast het support-e-mailadres weergegeven in e-mails aan klanten."
+        "supportPhone": "Optioneel. Wordt naast het support-e-mailadres weergegeven in e-mails aan klanten.",
+        "heroGradient": "Bepaalt het verloop van de welkomstbanner op het klantendashboard."
+      },
+      "heroGradient": {
+        "primaryShades": "Primaire kleur naar primaire tint",
+        "primarySecondary": "Primaire kleur naar secundaire kleur"
       },
       "preview": "Voorbeeld",
       "previewDarkMode": "Voorbeeld donkere modus",

--- a/server/public/locales/pl/msp/settings.json
+++ b/server/public/locales/pl/msp/settings.json
@@ -1058,7 +1058,8 @@
         "primaryColor": "Kolor główny",
         "secondaryColor": "Kolor dodatkowy",
         "supportEmail": "E-mail wsparcia",
-        "supportPhone": "Telefon wsparcia"
+        "supportPhone": "Telefon wsparcia",
+        "heroGradient": "Gradient nagłówka pulpitu"
       },
       "help": {
         "companyName": "Będzie wyświetlana w nagłówku portalu klienta",
@@ -1066,7 +1067,12 @@
         "primaryColor": "Używany dla przycisków, linków i wyróżnień",
         "secondaryColor": "Używany dla akcentów i akcji dodatkowych",
         "supportEmail": "Wyświetlany klientom w potwierdzeniach wizyt i innych wychodzących wiadomościach e-mail jako adres kontaktowy do uzyskania pomocy.",
-        "supportPhone": "Opcjonalnie. Wyświetlany obok e-maila wsparcia w wiadomościach wysyłanych do klientów."
+        "supportPhone": "Opcjonalnie. Wyświetlany obok e-maila wsparcia w wiadomościach wysyłanych do klientów.",
+        "heroGradient": "Steruje gradientem banera powitalnego na pulpicie klienta."
+      },
+      "heroGradient": {
+        "primaryShades": "Kolor główny do odcienia głównego",
+        "primarySecondary": "Kolor główny do koloru dodatkowego"
       },
       "preview": "Podgląd",
       "previewDarkMode": "Podgląd trybu ciemnego",

--- a/server/public/locales/pt/msp/settings.json
+++ b/server/public/locales/pt/msp/settings.json
@@ -1052,7 +1052,8 @@
         "primaryColor": "Cor Primária",
         "secondaryColor": "Cor Secundária",
         "supportEmail": "E-mail de suporte",
-        "supportPhone": "Telefone de suporte"
+        "supportPhone": "Telefone de suporte",
+        "heroGradient": "Gradiente do cabeçalho do painel"
       },
       "help": {
         "companyName": "Isso será exibido no cabeçalho do portal do cliente",
@@ -1060,7 +1061,12 @@
         "primaryColor": "Usado para botões, links e destaques",
         "secondaryColor": "Usado para acentos e ações secundárias",
         "supportEmail": "Mostrado aos clientes em confirmações de compromissos e outros e-mails enviados como o endereço de contato para obter ajuda.",
-        "supportPhone": "Opcional. Exibido ao lado do e-mail de suporte em e-mails direcionados ao cliente."
+        "supportPhone": "Opcional. Exibido ao lado do e-mail de suporte em e-mails direcionados ao cliente.",
+        "heroGradient": "Controla o gradiente do banner de boas-vindas no painel do cliente."
+      },
+      "heroGradient": {
+        "primaryShades": "Cor primária para tom primário",
+        "primarySecondary": "Cor primária para cor secundária"
       },
       "preview": "Visualização",
       "previewDarkMode": "Visualizar modo escuro",

--- a/server/public/locales/xx/msp/settings.json
+++ b/server/public/locales/xx/msp/settings.json
@@ -1052,7 +1052,8 @@
         "primaryColor": "11111",
         "secondaryColor": "11111",
         "supportEmail": "11111",
-        "supportPhone": "11111"
+        "supportPhone": "11111",
+        "heroGradient": "11111"
       },
       "help": {
         "companyName": "11111",
@@ -1060,7 +1061,12 @@
         "primaryColor": "11111",
         "secondaryColor": "11111",
         "supportEmail": "11111",
-        "supportPhone": "11111"
+        "supportPhone": "11111",
+        "heroGradient": "11111"
+      },
+      "heroGradient": {
+        "primaryShades": "11111",
+        "primarySecondary": "11111"
       },
       "preview": "11111",
       "previewDarkMode": "11111",

--- a/server/public/locales/yy/msp/settings.json
+++ b/server/public/locales/yy/msp/settings.json
@@ -1052,7 +1052,8 @@
         "primaryColor": "55555",
         "secondaryColor": "55555",
         "supportEmail": "55555",
-        "supportPhone": "55555"
+        "supportPhone": "55555",
+        "heroGradient": "55555"
       },
       "help": {
         "companyName": "55555",
@@ -1060,7 +1061,12 @@
         "primaryColor": "55555",
         "secondaryColor": "55555",
         "supportEmail": "55555",
-        "supportPhone": "55555"
+        "supportPhone": "55555",
+        "heroGradient": "55555"
+      },
+      "heroGradient": {
+        "primaryShades": "55555",
+        "primarySecondary": "55555"
       },
       "preview": "55555",
       "previewDarkMode": "55555",

--- a/server/src/components/settings/general/ClientPortalSettings.tsx
+++ b/server/src/components/settings/general/ClientPortalSettings.tsx
@@ -10,6 +10,7 @@ import CustomSelect, { SelectOption } from '@alga-psa/ui/components/CustomSelect
 import {
   getTenantBrandingAction,
   updateTenantBrandingAction,
+  type PortalHeroGradient,
 } from '@alga-psa/tenancy/actions/tenant-actions/tenantBrandingActions';
 import {
   getTenantLocaleSettingsAction,
@@ -35,6 +36,28 @@ import { Switch } from '@alga-psa/ui/components/Switch';
 import { useTranslation } from '@alga-psa/ui/lib/i18n/client';
 
 const UNSET_LOCALE_VALUE = '__inherit__';
+const DEFAULT_PORTAL_HERO_GRADIENT: PortalHeroGradient = 'primary-shades';
+
+const hexToRgb = (hex: string): [number, number, number] | null => {
+  const match = /^#?([a-f\d]{2})([a-f\d]{2})([a-f\d]{2})$/i.exec(hex);
+  return match
+    ? [parseInt(match[1], 16), parseInt(match[2], 16), parseInt(match[3], 16)]
+    : null;
+};
+
+const rgbToCss = (rgb: [number, number, number]): string => `rgb(${rgb.join(', ')})`;
+
+/** Mirror the live portal's generated primary-700 shade in the dashboard preview. */
+const getPrimaryShadeEnd = (primary: string, isDark: boolean): string => {
+  const rgb = hexToRgb(primary);
+  if (!rgb) return primary;
+
+  return rgbToCss(rgb.map((channel) => (
+    isDark
+      ? Math.min(255, Math.round(channel + (255 - channel) * 0.75))
+      : Math.max(0, Math.round(channel * 0.7))
+  )) as [number, number, number]);
+};
 
 const ClientPortalSettings = () => {
   const { t } = useTranslation('msp/settings');
@@ -43,6 +66,9 @@ const ClientPortalSettings = () => {
   const [logoUrl, setLogoUrl] = useState<string>('');
   const [primaryColor, setPrimaryColor] = useState<string>('');
   const [secondaryColor, setSecondaryColor] = useState<string>('');
+  const [portalHeroGradient, setPortalHeroGradient] = useState<PortalHeroGradient>(
+    DEFAULT_PORTAL_HERO_GRADIENT,
+  );
   const [clientName, setClientName] = useState<string>('');
   const [supportEmail, setSupportEmail] = useState<string>('');
   const [supportPhone, setSupportPhone] = useState<string>('');
@@ -117,6 +143,7 @@ const ClientPortalSettings = () => {
           setLogoUrl(brandingSettings.logoUrl || '');
           setPrimaryColor(brandingSettings.primaryColor || '');
           setSecondaryColor(brandingSettings.secondaryColor || '');
+          setPortalHeroGradient(brandingSettings.portalHeroGradient ?? DEFAULT_PORTAL_HERO_GRADIENT);
           setClientName(brandingSettings.clientName || '');
           setSupportEmail(brandingSettings.supportEmail || '');
           setSupportPhone(brandingSettings.supportPhone || '');
@@ -173,6 +200,7 @@ const ClientPortalSettings = () => {
   const saveBrandingSettings = async (updates: Partial<{
     primaryColor: string;
     secondaryColor: string;
+    portalHeroGradient: PortalHeroGradient;
     clientName: string;
     supportEmail: string;
     supportPhone: string;
@@ -181,6 +209,7 @@ const ClientPortalSettings = () => {
       logoUrl: logoUrl, // Keep existing logo URL
       primaryColor: updates.primaryColor || primaryColor,
       secondaryColor: updates.secondaryColor || secondaryColor,
+      portalHeroGradient: updates.portalHeroGradient ?? portalHeroGradient,
       clientName: updates.clientName !== undefined ? updates.clientName : clientName,
       supportEmail: updates.supportEmail !== undefined ? updates.supportEmail : supportEmail,
       supportPhone: updates.supportPhone !== undefined ? updates.supportPhone : supportPhone,
@@ -196,6 +225,7 @@ const ClientPortalSettings = () => {
       await saveBrandingSettings({
         primaryColor,
         secondaryColor,
+        portalHeroGradient,
         clientName,
         supportEmail,
         supportPhone,
@@ -447,6 +477,37 @@ const ClientPortalSettings = () => {
                   </p>
                 </div>
               </div>
+
+              <div>
+                <CustomSelect
+                  id="client-portal-hero-gradient"
+                  label={t('clientPortal.branding.fields.heroGradient', { defaultValue: 'Dashboard hero gradient' })}
+                  options={[
+                    {
+                      value: 'primary-shades',
+                      label: t('clientPortal.branding.heroGradient.primaryShades', {
+                        defaultValue: 'Primary color to primary shade',
+                      }),
+                    },
+                    {
+                      value: 'primary-secondary',
+                      label: t('clientPortal.branding.heroGradient.primarySecondary', {
+                        defaultValue: 'Primary color to secondary color',
+                      }),
+                    },
+                  ]}
+                  value={portalHeroGradient}
+                  onValueChange={(value) => setPortalHeroGradient(value as PortalHeroGradient)}
+                  className="!w-fit"
+                  disabled={brandingLoading || brandingSaving}
+                  data-automation-id="client-portal-hero-gradient-select"
+                />
+                <p className="text-xs text-gray-500 mt-1">
+                  {t('clientPortal.branding.help.heroGradient', {
+                    defaultValue: 'Controls the welcome banner gradient on the client dashboard.',
+                  })}
+                </p>
+              </div>
             </div>
 
             {/* Preview Selection Buttons */}
@@ -522,6 +583,15 @@ const ClientPortalSettings = () => {
                 const text = isDark ? 'text-slate-300' : 'text-gray-700';
                 const subtext = isDark ? 'text-slate-400' : 'text-gray-500';
                 const sidebarInactiveText = isDark ? '#94a3b8' : '#cbd5e1';
+                const previewPrimary = primaryColor || (isDark ? '#9855EE' : '#8A4DEA');
+                const previewSecondary = secondaryColor || (isDark ? '#53D7FA' : '#40CFF9');
+                const heroGradientEnd = portalHeroGradient === 'primary-secondary'
+                  ? previewSecondary
+                  : primaryColor
+                    ? getPrimaryShadeEnd(previewPrimary, isDark)
+                    : isDark
+                      ? '#B891F5'
+                      : '#6E3DBB';
 
                 return (
                   <div className={`border ${borderCls} rounded-lg overflow-hidden ${pageBg} max-h-[560px] overflow-y-auto`}>
@@ -594,7 +664,7 @@ const ClientPortalSettings = () => {
                           <div
                             className="rounded-lg p-3 text-white"
                             style={{
-                              background: `linear-gradient(135deg, ${primaryColor || '#8B5CF6'}, ${secondaryColor || '#6366F1'})`,
+                              background: `linear-gradient(90deg, ${previewPrimary}, ${heroGradientEnd})`,
                             }}
                           >
                             <div className="text-[10px] uppercase tracking-wider text-white/80">

--- a/server/src/test/unit/components/settings/ClientPortalSettings.heroGradient.contract.test.ts
+++ b/server/src/test/unit/components/settings/ClientPortalSettings.heroGradient.contract.test.ts
@@ -1,0 +1,42 @@
+import fs from 'node:fs';
+import path from 'node:path';
+import { describe, expect, it } from 'vitest';
+
+const settingsSource = fs.readFileSync(
+  path.resolve(process.cwd(), 'src/components/settings/general/ClientPortalSettings.tsx'),
+  'utf8',
+);
+
+describe('ClientPortalSettings dashboard hero gradient contract', () => {
+  it('defaults existing tenants to the established primary-shades gradient', () => {
+    expect(settingsSource).toContain(
+      "const DEFAULT_PORTAL_HERO_GRADIENT: PortalHeroGradient = 'primary-shades'",
+    );
+    expect(settingsSource).toContain(
+      'brandingSettings.portalHeroGradient ?? DEFAULT_PORTAL_HERO_GRADIENT',
+    );
+  });
+
+  it('previews and persists the explicit primary-to-secondary option', () => {
+    expect(settingsSource).toContain("value: 'primary-secondary'");
+    expect(settingsSource).toContain("portalHeroGradient === 'primary-secondary'");
+    expect(settingsSource).toContain('portalHeroGradient: updates.portalHeroGradient ?? portalHeroGradient');
+    expect(settingsSource).toContain('className="!w-fit"');
+    expect(settingsSource).toContain('linear-gradient(90deg');
+  });
+
+  it('provides the gradient setting translations in every MSP locale', () => {
+    const localeRoot = path.resolve(process.cwd(), 'public/locales');
+    const locales = fs.readdirSync(localeRoot);
+
+    for (const locale of locales) {
+      const localeFile = path.join(localeRoot, locale, 'msp/settings.json');
+      if (!fs.existsSync(localeFile)) continue;
+      const settings = JSON.parse(fs.readFileSync(localeFile, 'utf8'));
+      expect(settings.clientPortal.branding.fields.heroGradient, locale).toBeTruthy();
+      expect(settings.clientPortal.branding.help.heroGradient, locale).toBeTruthy();
+      expect(settings.clientPortal.branding.heroGradient.primaryShades, locale).toBeTruthy();
+      expect(settings.clientPortal.branding.heroGradient.primarySecondary, locale).toBeTruthy();
+    }
+  });
+});


### PR DESCRIPTION
Tenants can now choose how the client dashboard welcome banner is painted: the established primary-500 -> primary-700 shade ramp (default, so existing portals are untouched) or primary -> secondary. The choice is stored on tenant branding as portalHeroGradient and surfaced in Client Portal settings with a matching live preview that mirrors the generated primary-700 shade.

useHeroTextColor now samples whichever endpoint is actually in play, so black/white hero text keeps tracking the real background luminance. Also drops a stray PORT=3019 pin from the root dev script.

And lo, the Horse of a Different Color came trotting out of primary-500 and, midway through the ninetieth degree, thought better of it and turned secondary — whereupon a small gnome named useHeroTextColor followed behind with a lantern, measuring the relative luminance of the poor beast and repainting every word of the greeting black or white as the arithmetic demanded. "That's just how we do things in the Emerald Portal," he said. 🐴🌈🏰