### PR TITLE
Record CI test metrics to shared Google Sheet

### DIFF
--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -164,14 +164,14 @@ jobs:
       - name: Run Tier-1 integration subset
         if: github.event_name != 'schedule' && github.event.inputs.suite != 'full'
         working-directory: ./server
-        run: npm run test:integration:tier1
+        run: npm run test:integration:tier1 -- --reporter=default --reporter=json --outputFile.json=./test-results-integration.json
         env:
           NODE_OPTIONS: '--max-old-space-size=8192'
 
       - name: Run full integration suite
         if: github.event_name == 'schedule' || github.event.inputs.suite == 'full'
         working-directory: ./server
-        run: npm run test:integration:ci
+        run: npm run test:integration:ci -- --reporter=default --reporter=json --outputFile.json=./test-results-integration.json
         env:
           NODE_OPTIONS: '--max-old-space-size=8192'
 
@@ -179,11 +179,14 @@ jobs:
       # (invoice generation, tax, credits). It shares this job's Postgres rather
       # than running a parallel workflow. Non-blocking until it has a green
       # baseline; flip continue-on-error off once stable.
+      # `always()` lets the infra suite build its baseline even when the
+      # integration step above fails — without it a red nightly leaves the
+      # infra suite with no data at all.
       # timeout-minutes bounds a hang: continue-on-error ignores a failure but NOT
       # a hung process, so without this a stuck infra run would consume the whole
       # job timeout and cancel the (passing) integration step above.
       - name: Run Tier-1 infrastructure subset (non-blocking)
-        if: github.event_name != 'schedule' && github.event.inputs.suite != 'full'
+        if: always() && github.event_name != 'schedule' && github.event.inputs.suite != 'full'
         continue-on-error: true
         timeout-minutes: 15
         working-directory: ./server
@@ -192,10 +195,44 @@ jobs:
           NODE_OPTIONS: '--max-old-space-size=8192'
 
       - name: Run full infrastructure suite (non-blocking)
-        if: github.event_name == 'schedule' || github.event.inputs.suite == 'full'
+        if: always() && (github.event_name == 'schedule' || github.event.inputs.suite == 'full')
         continue-on-error: true
         timeout-minutes: 60
         working-directory: ./server
-        run: npm run test:infrastructure:ci
+        run: npm run test:infrastructure:ci -- --reporter=default --reporter=json --outputFile.json=./test-results-infrastructure.json
         env:
           NODE_OPTIONS: '--max-old-space-size=8192'
+
+      # Append this run's numbers to the shared metrics sheet
+      # (docs/reference/test-metrics.md). No-op until the Google secrets exist.
+      # Tier-1 rows are recorded on push to main only — PR runs would be noisy
+      # and fork PRs don't get secrets anyway.
+      - name: Record Tier-1 metrics to Google Sheet
+        if: always() && github.event_name == 'push'
+        continue-on-error: true
+        run: node scripts/record-test-metrics.mjs
+        env:
+          TEST_METRICS_SUITE: integration-tier1
+          TEST_METRICS_RESULTS: server/test-results-integration.json
+          GOOGLE_SA_KEY: ${{ secrets.TEST_METRICS_GOOGLE_SA_KEY }}
+          TEST_METRICS_SHEET_ID: ${{ vars.TEST_METRICS_SHEET_ID }}
+
+      - name: Record full-suite metrics to Google Sheet
+        if: always() && (github.event_name == 'schedule' || github.event.inputs.suite == 'full')
+        continue-on-error: true
+        run: node scripts/record-test-metrics.mjs
+        env:
+          TEST_METRICS_SUITE: integration-full
+          TEST_METRICS_RESULTS: server/test-results-integration.json
+          GOOGLE_SA_KEY: ${{ secrets.TEST_METRICS_GOOGLE_SA_KEY }}
+          TEST_METRICS_SHEET_ID: ${{ vars.TEST_METRICS_SHEET_ID }}
+
+      - name: Record infrastructure metrics to Google Sheet
+        if: always() && (github.event_name == 'schedule' || github.event.inputs.suite == 'full')
+        continue-on-error: true
+        run: node scripts/record-test-metrics.mjs
+        env:
+          TEST_METRICS_SUITE: infrastructure-full
+          TEST_METRICS_RESULTS: server/test-results-infrastructure.json
+          GOOGLE_SA_KEY: ${{ secrets.TEST_METRICS_GOOGLE_SA_KEY }}
+          TEST_METRICS_SHEET_ID: ${{ vars.TEST_METRICS_SHEET_ID }}

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -151,16 +151,32 @@ jobs:
         run: sudo apt-get update && sudo apt-get install -y ripgrep
       - name: Run server unit tests with coverage
         working-directory: ./server
-        run: npx vitest run src/test/unit --coverage.enabled=true --coverage.reporter=text-summary --coverage.reporter=lcov
+        run: npx vitest run src/test/unit --coverage.enabled=true --coverage.reporter=text-summary --coverage.reporter=lcov --coverage.reporter=json-summary --reporter=default --reporter=json --outputFile.json=./test-results.json
         env:
           NODE_OPTIONS: '--max-old-space-size=14336'
           VITEST_SEED: '20260610'
+      # `if: always()`: a red run is exactly the data point the coverage
+      # artifact and metrics sheet exist to capture.
       - name: Upload lcov artifact
+        if: always()
         uses: actions/upload-artifact@v4
         with:
           name: server-unit-coverage
           path: server/coverage/lcov.info
           retention-days: 30
+      # Appends pass/coverage numbers to the shared metrics sheet
+      # (docs/reference/test-metrics.md). No-op until the Google secrets exist.
+      - name: Record metrics to Google Sheet
+        if: always()
+        continue-on-error: true
+        run: node scripts/record-test-metrics.mjs
+        env:
+          TEST_METRICS_SUITE: unit-coverage
+          TEST_METRICS_RESULTS: server/test-results.json
+          TEST_METRICS_COVERAGE: server/coverage/coverage-summary.json
+          TEST_METRICS_DETAIL: '1'
+          GOOGLE_SA_KEY: ${{ secrets.TEST_METRICS_GOOGLE_SA_KEY }}
+          TEST_METRICS_SHEET_ID: ${{ vars.TEST_METRICS_SHEET_ID }}
 
   # DB-backed infrastructure tests run inside integration-tests.yml (sharing its
   # Postgres job): Tier-1 subset on PRs, full suite nightly — both non-blocking.

--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,8 @@ node_modules/
 # testing
 /coverage
 test-results/
+test-results-*.json
+server/test-results.json
 playwright-test-results/
 playwright-report/
 screenshots/

--- a/docs/reference/test-metrics.md
+++ b/docs/reference/test-metrics.md
@@ -1,0 +1,102 @@
+# Test Metrics Sheet
+
+CI appends one row per test run to a shared Google Sheet, so you can watch
+pass rates and coverage move over time instead of opening individual Actions
+runs. `scripts/record-test-metrics.mjs` does the recording. It never fails a
+build: the step runs with `continue-on-error` and exits quietly when the
+Google credentials are not configured.
+
+## Which runs record
+
+| Suite label | Workflow | When |
+|---|---|---|
+| `unit-coverage` | `unit-tests.yml` (coverage job) | every push to main |
+| `integration-tier1` | `integration-tests.yml` | push to main |
+| `integration-full` | `integration-tests.yml` | nightly cron, manual `suite: full` dispatch |
+| `infrastructure-full` | `integration-tests.yml` | nightly cron, manual `suite: full` dispatch |
+
+PR runs are not recorded. They would flood the sheet, and fork PRs cannot read
+the secret anyway.
+
+Red runs still record. The metrics steps use `if: always()`, because a drop in
+pass rate is the signal the sheet exists to show.
+
+## Column schema
+
+Rows land on the `metrics` tab. The script writes the header row on first use.
+
+| Column | Meaning |
+|---|---|
+| `timestamp_utc` | ISO timestamp when the row was recorded |
+| `suite` | label from the table above |
+| `branch`, `commit` | ref name and short SHA of the tested commit |
+| `passed`, `failed`, `skipped`, `todo`, `total` | test counts from the vitest JSON report |
+| `pass_pct` | `passed / (passed + failed)` × 100; skipped tests do not count against it |
+| `lines_pct`, `statements_pct`, `branches_pct`, `functions_pct` | coverage totals; blank for suites that run without coverage |
+| `duration_s` | wall-clock test time |
+| `run_url` | link back to the Actions run |
+
+For charts, add a second tab with `=QUERY(metrics!A:P, "select A, J where B = 'unit-coverage'")`
+style pulls and chart those ranges. Native Sheets charts update as rows arrive.
+
+Coverage percentages are only comparable while `coverage.include` in
+`server/vitest.config.ts` stays the same; widening or narrowing it changes
+the denominator and steps the totals on that day.
+
+## Per-directory coverage
+
+The `unit-coverage` run also writes a breakdown to the `coverage_by_dir` tab:
+one row per source directory per run, with covered/total line counts alongside
+the percentages. Directories group at four path segments under
+`server/src/lib` (each subtree there is a whole subsystem), three elsewhere
+under `server/src`, and two for everything else — so `packages/billing`,
+`shared/workflow`, and `server/src/lib/actions` are each one row.
+
+Coverage measures `server/src/**`, `packages/*/src/**`, and `shared/**`
+(`coverage.include` in `server/vitest.config.ts`; the patterns are absolute
+because `allowExternal` switches matching to absolute paths). Read the rows
+with two caveats:
+
+- **Check `files_measured` against `files_total`.** The v8 provider's
+  untested-file discovery never leaves `server/`, so package and shared files
+  the suite never loads are missing from the report and their percentages read
+  optimistic. `files_total` counts the directory's source files on disk;
+  a gap between the two columns is unmeasured code, and a `0/N` row is a
+  directory the suite never touches. `server/src` rows always measure
+  completely.
+- Directory percentages come from the server unit suite alone. A directory
+  covered mainly by integration tests will read low here.
+
+## One-time setup
+
+1. In Google Cloud Console, create a service account (any project) and enable
+   the **Google Sheets API** for that project. Create a JSON key for the
+   account.
+2. Create the spreadsheet and share it with the service account's
+   `client_email` as an Editor.
+3. In the GitHub repo, add:
+   - secret `TEST_METRICS_GOOGLE_SA_KEY`: the key file's JSON content (raw or
+     base64, both work)
+   - repository variable `TEST_METRICS_SHEET_ID`: the id from the sheet URL
+     (`docs.google.com/spreadsheets/d/<this part>/edit`)
+
+Nothing else. The next recorded run creates the `metrics` tab and header row
+if they are missing.
+
+## Running it by hand
+
+The script reads a vitest JSON report and an optional coverage summary:
+
+```bash
+cd server && npx vitest run src/test/unit \
+  --coverage.enabled=true --coverage.reporter=json-summary \
+  --reporter=default --reporter=json --outputFile.json=./test-results.json
+
+TEST_METRICS_SUITE=unit-coverage \
+TEST_METRICS_RESULTS=server/test-results.json \
+TEST_METRICS_COVERAGE=server/coverage/coverage-summary.json \
+node scripts/record-test-metrics.mjs --dry-run
+```
+
+`--dry-run` prints the row instead of sending it. To send for real, also set
+`GOOGLE_SA_KEY` and `TEST_METRICS_SHEET_ID`.

--- a/docs/reference/testing-standards.md
+++ b/docs/reference/testing-standards.md
@@ -364,6 +364,8 @@ Notes:
   budget when you fix skips; raising it requires editing the budget file in your PR.
 - New workflows start as non-required checks; they are promoted to required in
   branch protection after a green shakeout period.
+- Main-branch and nightly runs append pass/coverage numbers to a shared Google
+  Sheet so trends are visible over time — see [test-metrics.md](test-metrics.md).
 
 ## Coverage Roadmap (priority order)
 

--- a/scripts/record-test-metrics.mjs
+++ b/scripts/record-test-metrics.mjs
@@ -1,0 +1,305 @@
+#!/usr/bin/env node
+/**
+ * Append one row of test metrics (pass/fail counts, coverage %) to the shared
+ * Google Sheet after a CI test run. See docs/reference/test-metrics.md for
+ * the sheet setup and column schema.
+ *
+ * Inputs (env):
+ *   TEST_METRICS_SUITE      required — suite label (unit-coverage, integration-full, ...)
+ *   TEST_METRICS_RESULTS    path to a vitest --reporter=json output file
+ *   TEST_METRICS_COVERAGE   path to a coverage-summary.json (optional)
+ *   GOOGLE_SA_KEY           service-account key JSON (raw or base64)
+ *   TEST_METRICS_SHEET_ID   spreadsheet id from the sheet URL
+ *   TEST_METRICS_SHEET_TAB  tab name (default "metrics")
+ *
+ * Exits 0 without recording when the Google credentials are not configured,
+ * so forks and local runs are unaffected. Pass --dry-run to print the row
+ * instead of sending it.
+ */
+import { readFileSync, existsSync, readdirSync } from 'node:fs';
+import { join } from 'node:path';
+import crypto from 'node:crypto';
+
+const HEADER = [
+  'timestamp_utc', 'suite', 'branch', 'commit',
+  'passed', 'failed', 'skipped', 'todo', 'total', 'pass_pct',
+  'lines_pct', 'statements_pct', 'branches_pct', 'functions_pct',
+  'duration_s', 'run_url',
+];
+
+const DETAIL_HEADER = [
+  'timestamp_utc', 'suite', 'commit', 'directory',
+  'lines_pct', 'lines_covered', 'lines_total',
+  'statements_pct', 'branches_pct', 'functions_pct',
+  'files_measured', 'files_total', 'run_url',
+];
+
+function readJson(path) {
+  if (!path || !existsSync(path)) return null;
+  try {
+    return JSON.parse(readFileSync(path, 'utf8'));
+  } catch (err) {
+    console.warn(`test-metrics: could not parse ${path}: ${err.message}`);
+    return null;
+  }
+}
+
+function testCounts(results) {
+  if (!results) return null;
+  const passed = results.numPassedTests ?? 0;
+  const failed = results.numFailedTests ?? 0;
+  const skipped = results.numPendingTests ?? 0;
+  const todo = results.numTodoTests ?? 0;
+  const total = results.numTotalTests ?? passed + failed + skipped + todo;
+  const passPct = passed + failed > 0
+    ? Math.round((passed / (passed + failed)) * 10000) / 100
+    : '';
+  let durationS = '';
+  const files = results.testResults ?? [];
+  const starts = files.map((f) => f.startTime).filter((t) => typeof t === 'number');
+  const ends = files.map((f) => f.endTime).filter((t) => typeof t === 'number');
+  if (starts.length && ends.length) {
+    durationS = Math.round((Math.max(...ends) - Math.min(...starts)) / 1000);
+  }
+  return { passed, failed, skipped, todo, total, passPct, durationS };
+}
+
+function coveragePcts(summary) {
+  const t = summary?.total;
+  const pct = (k) => (typeof t?.[k]?.pct === 'number' ? t[k].pct : '');
+  return { lines: pct('lines'), statements: pct('statements'), branches: pct('branches'), functions: pct('functions') };
+}
+
+// Group per-file coverage into directory buckets: 4 path segments under
+// server/src/lib (its subtrees are whole subsystems), 3 under the rest of
+// server/src, 2 for packages/shared/ee.
+function coverageGroupKey(rel) {
+  const parts = rel.split('/');
+  let depth = 2;
+  if (rel.startsWith('server/src/lib/')) depth = 4;
+  else if (rel.startsWith('server/src/')) depth = 3;
+  return parts.slice(0, Math.min(depth, parts.length - 1)).join('/');
+}
+
+// Count source files on disk per group. The untested-file crawl of the v8
+// provider never leaves server/, so package/shared files the suite doesn't
+// load are missing from the report — files_measured vs files_total makes
+// that visible instead of letting the percentages read complete.
+const SKIP_DIRS = new Set(['node_modules', 'dist', 'coverage', '.next', 'migrations', 'seeds']);
+const SRC_FILE = /\.(js|ts|jsx|tsx)$/;
+const NOT_SRC = /\.d\.ts$|[.-](test|spec)\.[cm]?[jt]sx?$/;
+
+function walkSourceFiles(absDir, relDir, counts) {
+  let entries;
+  try {
+    entries = readdirSync(absDir, { withFileTypes: true });
+  } catch {
+    return;
+  }
+  for (const e of entries) {
+    if (e.isDirectory()) {
+      if (!SKIP_DIRS.has(e.name) && !e.name.startsWith('__')) {
+        walkSourceFiles(join(absDir, e.name), `${relDir}/${e.name}`, counts);
+      }
+    } else if (SRC_FILE.test(e.name) && !NOT_SRC.test(e.name)) {
+      const key = coverageGroupKey(`${relDir}/${e.name}`);
+      counts.set(key, (counts.get(key) ?? 0) + 1);
+    }
+  }
+}
+
+function sourceFileCounts() {
+  const cwd = process.cwd();
+  const counts = new Map();
+  walkSourceFiles(join(cwd, 'server/src'), 'server/src', counts);
+  walkSourceFiles(join(cwd, 'shared'), 'shared', counts);
+  const pkgRoot = join(cwd, 'packages');
+  let pkgs = [];
+  try {
+    pkgs = readdirSync(pkgRoot, { withFileTypes: true }).filter((e) => e.isDirectory());
+  } catch { /* not run from repo root */ }
+  for (const p of pkgs) {
+    walkSourceFiles(join(pkgRoot, p.name, 'src'), `packages/${p.name}/src`, counts);
+  }
+  return counts;
+}
+
+function coverageByDirectory(summary) {
+  if (!summary) return [];
+  const cwd = process.cwd() + '/';
+  const groups = new Map();
+  for (const [file, m] of Object.entries(summary)) {
+    if (file === 'total' || !m?.lines) continue;
+    const rel = file.startsWith(cwd) ? file.slice(cwd.length) : file;
+    const key = coverageGroupKey(rel);
+    const g = groups.get(key) ?? { files: 0 };
+    g.files += 1;
+    for (const metric of ['lines', 'statements', 'branches', 'functions']) {
+      g[metric] = {
+        covered: (g[metric]?.covered ?? 0) + (m[metric]?.covered ?? 0),
+        total: (g[metric]?.total ?? 0) + (m[metric]?.total ?? 0),
+      };
+    }
+    groups.set(key, g);
+  }
+  const onDisk = sourceFileCounts();
+  const pct = (g, k) => (g[k].total ? Math.round((g[k].covered / g[k].total) * 10000) / 100 : '');
+  const rows = [...groups.entries()].map(([dir, g]) => ({
+    dir,
+    lines: pct(g, 'lines'), linesCovered: g.lines.covered, linesTotal: g.lines.total,
+    statements: pct(g, 'statements'), branches: pct(g, 'branches'), functions: pct(g, 'functions'),
+    filesMeasured: g.files, filesTotal: onDisk.get(dir) ?? '',
+  }));
+  // Directories with sources on disk but nothing in the report: the suite
+  // never loaded them. A 0/N row is the honest record; absence would read
+  // as "no such code".
+  for (const [dir, total] of onDisk) {
+    if (!groups.has(dir)) {
+      rows.push({
+        dir, lines: '', linesCovered: '', linesTotal: '',
+        statements: '', branches: '', functions: '',
+        filesMeasured: 0, filesTotal: total,
+      });
+    }
+  }
+  return rows.sort((a, b) => a.dir.localeCompare(b.dir));
+}
+
+function buildRow() {
+  const suite = process.env.TEST_METRICS_SUITE;
+  if (!suite) {
+    console.error('test-metrics: TEST_METRICS_SUITE is required');
+    process.exit(1);
+  }
+  const counts = testCounts(readJson(process.env.TEST_METRICS_RESULTS));
+  const cov = coveragePcts(readJson(process.env.TEST_METRICS_COVERAGE));
+  if (!counts && cov.lines === '') {
+    console.warn('test-metrics: no results or coverage files found, nothing to record');
+    process.exit(0);
+  }
+  const runUrl = process.env.GITHUB_RUN_ID
+    ? `${process.env.GITHUB_SERVER_URL ?? 'https://github.com'}/${process.env.GITHUB_REPOSITORY}/actions/runs/${process.env.GITHUB_RUN_ID}`
+    : '';
+  return [
+    new Date().toISOString(),
+    suite,
+    process.env.GITHUB_REF_NAME ?? '',
+    (process.env.GITHUB_SHA ?? '').slice(0, 10),
+    counts?.passed ?? '', counts?.failed ?? '', counts?.skipped ?? '', counts?.todo ?? '',
+    counts?.total ?? '', counts?.passPct ?? '',
+    cov.lines, cov.statements, cov.branches, cov.functions,
+    counts?.durationS ?? '',
+    runUrl,
+  ];
+}
+
+function parseServiceAccountKey(raw) {
+  try {
+    return JSON.parse(raw);
+  } catch {
+    return JSON.parse(Buffer.from(raw, 'base64').toString('utf8'));
+  }
+}
+
+async function getAccessToken(sa) {
+  const b64url = (obj) => Buffer.from(JSON.stringify(obj)).toString('base64url');
+  const now = Math.floor(Date.now() / 1000);
+  const unsigned = `${b64url({ alg: 'RS256', typ: 'JWT' })}.${b64url({
+    iss: sa.client_email,
+    scope: 'https://www.googleapis.com/auth/spreadsheets',
+    aud: 'https://oauth2.googleapis.com/token',
+    iat: now,
+    exp: now + 3600,
+  })}`;
+  const signature = crypto.createSign('RSA-SHA256').update(unsigned).sign(sa.private_key).toString('base64url');
+  const res = await fetch('https://oauth2.googleapis.com/token', {
+    method: 'POST',
+    headers: { 'content-type': 'application/x-www-form-urlencoded' },
+    body: new URLSearchParams({
+      grant_type: 'urn:ietf:params:oauth:grant-type:jwt-bearer',
+      assertion: `${unsigned}.${signature}`,
+    }),
+  });
+  if (!res.ok) throw new Error(`token exchange failed: ${res.status} ${await res.text()}`);
+  return (await res.json()).access_token;
+}
+
+async function sheetsApi(token, sheetId, pathAndQuery, method = 'GET', body) {
+  const res = await fetch(`https://sheets.googleapis.com/v4/spreadsheets/${sheetId}${pathAndQuery}`, {
+    method,
+    headers: { authorization: `Bearer ${token}`, 'content-type': 'application/json' },
+    body: body ? JSON.stringify(body) : undefined,
+  });
+  const json = await res.json().catch(() => ({}));
+  return { ok: res.ok, status: res.status, json };
+}
+
+async function ensureHeaderRow(token, sheetId, tab, header) {
+  const range = encodeURIComponent(`${tab}!A1:A1`);
+  let head = await sheetsApi(token, sheetId, `/values/${range}`);
+  if (!head.ok && head.status === 400) {
+    // Tab doesn't exist yet — create it, then fall through to write the header.
+    const add = await sheetsApi(token, sheetId, ':batchUpdate', 'POST', {
+      requests: [{ addSheet: { properties: { title: tab } } }],
+    });
+    if (!add.ok) throw new Error(`could not create tab "${tab}": ${JSON.stringify(add.json)}`);
+    head = { ok: true, json: {} };
+  }
+  if (!head.ok) throw new Error(`could not read sheet: ${head.status} ${JSON.stringify(head.json)}`);
+  if (!head.json.values?.length) {
+    const write = await sheetsApi(
+      token, sheetId,
+      `/values/${encodeURIComponent(`${tab}!A1`)}?valueInputOption=RAW`,
+      'PUT',
+      { values: [header] },
+    );
+    if (!write.ok) throw new Error(`could not write header: ${JSON.stringify(write.json)}`);
+  }
+}
+
+async function appendRows(token, sheetId, tab, header, rows) {
+  await ensureHeaderRow(token, sheetId, tab, header);
+  const append = await sheetsApi(
+    token, sheetId,
+    `/values/${encodeURIComponent(`${tab}!A1`)}:append?valueInputOption=RAW`,
+    'POST',
+    { values: rows },
+  );
+  if (!append.ok) throw new Error(`append to "${tab}" failed: ${append.status} ${JSON.stringify(append.json)}`);
+}
+
+const row = buildRow();
+const wantDetail = process.env.TEST_METRICS_DETAIL === '1';
+const detailRows = wantDetail
+  ? coverageByDirectory(readJson(process.env.TEST_METRICS_COVERAGE)).map((d) => [
+      row[0], row[1], row[3], d.dir,
+      d.lines, d.linesCovered, d.linesTotal,
+      d.statements, d.branches, d.functions,
+      d.filesMeasured, d.filesTotal, row[15],
+    ])
+  : [];
+
+if (process.argv.includes('--dry-run')) {
+  console.log('test-metrics dry run:');
+  HEADER.forEach((col, i) => console.log(`  ${col}: ${row[i]}`));
+  if (wantDetail) {
+    console.log(`coverage_by_dir rows (${detailRows.length}):`);
+    for (const d of detailRows) console.log(`  ${d[3]}: ${d[4]}% lines (${d[5]}/${d[6]}), files ${d[10]}/${d[11]}`);
+  }
+  process.exit(0);
+}
+
+const rawKey = process.env.GOOGLE_SA_KEY;
+const sheetId = process.env.TEST_METRICS_SHEET_ID;
+if (!rawKey || !sheetId) {
+  console.log('test-metrics: GOOGLE_SA_KEY / TEST_METRICS_SHEET_ID not configured, skipping');
+  process.exit(0);
+}
+
+const tab = process.env.TEST_METRICS_SHEET_TAB || 'metrics';
+const token = await getAccessToken(parseServiceAccountKey(rawKey));
+await appendRows(token, sheetId, tab, HEADER, [row]);
+if (detailRows.length) {
+  await appendRows(token, sheetId, 'coverage_by_dir', DETAIL_HEADER, detailRows);
+}
+console.log(`test-metrics: recorded ${row[1]} run (${row[4]} passed / ${row[5]} failed)${detailRows.length ? ` + ${detailRows.length} directory rows` : ''} to sheet`);

--- a/server/vitest.config.ts
+++ b/server/vitest.config.ts
@@ -1,4 +1,4 @@
-import { defineConfig } from 'vitest/config';
+import { coverageConfigDefaults, defineConfig } from 'vitest/config';
 import fs from 'node:fs';
 import path from 'path';
 
@@ -55,8 +55,26 @@ export default defineConfig({
       // instrumentation cost. CI enables it where reports are collected.
       enabled: false,
       provider: 'v8',
+      // The suite loads @alga-psa/* code through the src aliases below, so
+      // package and shared sources are measured alongside server/src.
+      // allowExternal admits files outside server/ into the report — and it
+      // switches include/exclude matching to absolute paths, so these
+      // patterns must be absolute. Two limits of the v8 provider here:
+      // untested-file discovery never leaves the vitest root, so package and
+      // shared files the suite never loads are absent from the report (their
+      // percentages read optimistic), while server/src gets true 0% entries.
+      allowExternal: true,
       include: [
-        'src/**/*.{js,ts,jsx,tsx}',
+        path.resolve(__dirname, './src') + '/**/*.{js,ts,jsx,tsx}',
+        path.resolve(__dirname, '../packages') + '/*/src/**/*.{js,ts,jsx,tsx}',
+        path.resolve(__dirname, '../shared') + '/**/*.{js,ts,jsx,tsx}',
+      ],
+      exclude: [
+        ...coverageConfigDefaults.exclude,
+        '**/dist/**',
+        '**/node_modules/**',
+        '**/migrations/**',
+        '**/seeds/**',
       ],
       reportsDirectory: path.resolve(__dirname, './coverage'),
       reporter: ['text', 'html', 'lcov'],


### PR DESCRIPTION
Append pass/fail counts and coverage percentages to a Google Sheet after main-branch and nightly test runs, so trends are visible over time instead of buried in individual Actions logs.

- scripts/record-test-metrics.mjs: zero-dependency recorder (service account JWT via node:crypto); writes per-run rows to the metrics tab and per-directory coverage to coverage_by_dir, with files_measured vs files_total exposing code the suite never loads. No-ops when the Google secrets are absent; never fails a build.
- unit-tests.yml / integration-tests.yml: emit vitest JSON reports and record unit-coverage, integration-tier1/full, and infrastructure-full runs; infrastructure steps now run via `if: always()` so the suite builds a baseline even on red nights.
- server/vitest.config.ts: widen coverage to packages/*/src and shared/ via allowExternal (include patterns must be absolute there).
- docs/reference/test-metrics.md: sheet setup and column schema.

"Why, sometimes I've measured as many as six impossible branches before breakfast," said the White Queen, peering into coverage_by_dir. "But mind the files the looking-glass never loads â the Cheshire Cat's 0/419 grin shows precisely the code that isn't there." 📊🐇☕