### PR TITLE
feat(billing): customize fixed invoice line descriptions

### DIFF
--- a/packages/billing/src/components/billing-dashboard/contract-lines/FixedContractLineConfiguration.tsx
+++ b/packages/billing/src/components/billing-dashboard/contract-lines/FixedContractLineConfiguration.tsx
@@ -83,6 +83,7 @@ export function FixedPlanConfiguration({
 
   // Form state
   const [planName, setPlanName] = useState('');
+  const [invoiceLineDescription, setInvoiceLineDescription] = useState('');
   const [planType, setPlanType] = useState<PlanType>('Fixed');
   const [billingFrequency, setBillingFrequency] = useState<string>('monthly');
   const [isCustom, setIsCustom] = useState(false);
@@ -114,6 +115,7 @@ export function FixedPlanConfiguration({
 
         // Populate form fields
         setPlanName(fetchedPlan.contract_line_name);
+        setInvoiceLineDescription(fetchedPlan.invoice_line_description ?? '');
         setBillingFrequency(fetchedPlan.billing_frequency);
         setPlanType(fetchedPlan.contract_line_type as PlanType);
         setIsCustom(fetchedPlan.is_custom ?? false);
@@ -200,6 +202,7 @@ export function FixedPlanConfiguration({
     try {
       const planData: Partial<IContractLine> = {
         contract_line_name: planName,
+        invoice_line_description: invoiceLineDescription.trim() ? invoiceLineDescription.trim() : null,
         billing_frequency: billingFrequency,
         billing_timing: planType === 'Fixed' ? billingTiming : 'arrears',
         is_custom: isCustom,
@@ -332,6 +335,30 @@ export function FixedPlanConfiguration({
                   })}
                   required
                 />
+              </div>
+              <div>
+                <Label htmlFor="invoice-line-description">
+                  {t('configuration.fixed.basics.invoiceLineDescriptionLabel', {
+                    defaultValue: 'Invoice Line Description',
+                  })}
+                </Label>
+                <Input
+                  id="invoice-line-description"
+                  value={invoiceLineDescription}
+                  onChange={(e) => {
+                    setInvoiceLineDescription(e.target.value);
+                    markDirty();
+                  }}
+                  placeholder={t('configuration.fixed.basics.invoiceLineDescriptionPlaceholder', {
+                    defaultValue: 'e.g. Monthly phone system maintenance per 2019 agreement',
+                  })}
+                />
+                <p className="text-sm text-muted-foreground mt-1">
+                  {t('configuration.fixed.basics.invoiceLineDescriptionHelp', {
+                    defaultValue:
+                      'Used verbatim as the invoice line text for this fixed fee. Leave empty to use the contract line name.',
+                  })}
+                </p>
               </div>
               <div>
                 <Label htmlFor="frequency">

--- a/packages/billing/src/services/invoiceService.ts
+++ b/packages/billing/src/services/invoiceService.ts
@@ -820,8 +820,8 @@ async function persistFixedInvoiceCharges(
       ),
     ),
   );
-  // Map: clientContractLineId -> { contract_line_name: string, contract_line_base_rate: number | null }
-  const planInfoMap = new Map<string, { contract_line_name: string; contract_line_base_rate: number | null }>();
+  // Map: clientContractLineId -> { contract_line_name, invoice_line_description, contract_line_base_rate }
+  const planInfoMap = new Map<string, { contract_line_name: string; invoice_line_description?: string | null; contract_line_base_rate: number | null }>();
 
   // Filter out virtual contract-association IDs that start with "contract-" as they're not real UUIDs in the database
   const validDbPlanIds = clientPlanIds.filter(id => !id.startsWith('contract-'));
@@ -843,12 +843,14 @@ async function persistFixedInvoiceCharges(
       .select(
         'cl.contract_line_id as client_contract_line_id',
         'cl.contract_line_name',
+        'cl.invoice_line_description',
         'cl.custom_rate as contract_line_base_rate'
        );
 
     for (const detail of planDetails) {
       planInfoMap.set(detail.client_contract_line_id, {
         contract_line_name: detail.contract_line_name,
+        invoice_line_description: detail.invoice_line_description ?? null,
         contract_line_base_rate: detail.contract_line_base_rate != null
           ? Number(detail.contract_line_base_rate)
           : null
@@ -866,8 +868,11 @@ async function persistFixedInvoiceCharges(
         continue;
     }
 
-    // Update the consolidated item's description and unit_price before insertion
-    planEntry.consolidatedItem.description = `Fixed Plan: ${planInfo.contract_line_name}`;
+    // Update the consolidated item's description and unit_price before insertion.
+    // A hand-crafted per-line override wins over the engine-derived text.
+    planEntry.consolidatedItem.description = planInfo.invoice_line_description
+      ? planInfo.invoice_line_description
+      : `Fixed Plan: ${planInfo.contract_line_name}`;
     // Use the plan-level base rate sourced from the contract line if available.
     // Fallback to the unit_price derived from the first service charge if plan-level rate is missing (shouldn't happen ideally).
     // contract_line_base_rate (from custom_rate) is already stored in cents, no conversion needed
@@ -908,7 +913,7 @@ async function persistFixedInvoiceCharges(
       item_id: parentItemId,
       invoice_id: invoiceId,
       service_id: null,
-      description: planInfo.contract_line_name || 'Fixed Plan Charge',
+      description: planInfo.invoice_line_description || planInfo.contract_line_name || 'Fixed Plan Charge',
       quantity: 1,
       unit_price: planNetTotal,
       net_amount: planNetTotal,

--- a/packages/types/src/interfaces/billing.interfaces.ts
+++ b/packages/types/src/interfaces/billing.interfaces.ts
@@ -250,6 +250,8 @@ export interface IContractLine extends TenantEntity {
   contract_line_id?: string;
   contract_line_name: string;
   description?: string | null;
+  /** Verbatim invoice line text for fixed-fee charges; falls back to the line name when null. */
+  invoice_line_description?: string | null;
   billing_frequency: string;
   contract_id?: string | null;
   service_category?: string;

--- a/server/migrations/20260703140000_add_invoice_line_description_to_contract_lines.cjs
+++ b/server/migrations/20260703140000_add_invoice_line_description_to_contract_lines.cjs
@@ -1,0 +1,26 @@
+/**
+ * Per-contract-line custom invoice description.
+ *
+ * Fixed-fee recurring invoice lines derive their text from the contract line
+ * name ("Fixed Plan: {name}"). Long-standing customer arrangements often need
+ * hand-crafted wording instead ("Monthly phone system maintenance per 2019
+ * agreement"). This nullable override is used verbatim as the invoice line
+ * description when set, removing the need to hand-edit every recurring draft.
+ */
+exports.up = async function up(knex) {
+  const hasColumn = await knex.schema.hasColumn('contract_lines', 'invoice_line_description');
+  if (!hasColumn) {
+    await knex.schema.table('contract_lines', (table) => {
+      table.text('invoice_line_description').nullable();
+    });
+  }
+};
+
+exports.down = async function down(knex) {
+  const hasColumn = await knex.schema.hasColumn('contract_lines', 'invoice_line_description');
+  if (hasColumn) {
+    await knex.schema.table('contract_lines', (table) => {
+      table.dropColumn('invoice_line_description');
+    });
+  }
+};

--- a/server/public/locales/de/msp/contract-lines.json
+++ b/server/public/locales/de/msp/contract-lines.json
@@ -58,6 +58,9 @@
         },
         "description": "Benennen Sie die Vertragsposition und wählen Sie aus, wie sie standardmäßig abgerechnet werden soll.",
         "heading": "Grundlagen der Vertragslinie",
+        "invoiceLineDescriptionHelp": "Wird wörtlich als Text der Rechnungszeile für diese feste Gebühr verwendet. Leer lassen, um den Namen der Vertragszeile zu verwenden.",
+        "invoiceLineDescriptionLabel": "Beschreibung der Rechnungszeile",
+        "invoiceLineDescriptionPlaceholder": "z.B. Monatliche Wartung der Telefonanlage gemäß Vertrag von 2019",
         "nameLabel": "Name der Vertragszeile *",
         "namePlaceholder": "z.B. Verwalteter Support – Gold"
       },

--- a/server/public/locales/en/msp/contract-lines.json
+++ b/server/public/locales/en/msp/contract-lines.json
@@ -58,6 +58,9 @@
         },
         "description": "Name the contract line and choose how it should bill by default.",
         "heading": "Contract Line Basics",
+        "invoiceLineDescriptionHelp": "Used verbatim as the invoice line text for this fixed fee. Leave empty to use the contract line name.",
+        "invoiceLineDescriptionLabel": "Invoice Line Description",
+        "invoiceLineDescriptionPlaceholder": "e.g. Monthly phone system maintenance per 2019 agreement",
         "nameLabel": "Contract Line Name *",
         "namePlaceholder": "e.g. Managed Support - Gold"
       },

--- a/server/public/locales/es/msp/contract-lines.json
+++ b/server/public/locales/es/msp/contract-lines.json
@@ -58,6 +58,9 @@
         },
         "description": "Asigne un nombre a la línea del contrato y elija cómo se debe facturar de forma predeterminada.",
         "heading": "Conceptos básicos de la línea de contrato",
+        "invoiceLineDescriptionHelp": "Se usa literalmente como texto de la línea de factura para esta tarifa fija. Déjelo vacío para usar el nombre de la línea de contrato.",
+        "invoiceLineDescriptionLabel": "Descripción de la línea de factura",
+        "invoiceLineDescriptionPlaceholder": "p.ej. Mantenimiento mensual del sistema telefónico según el acuerdo de 2019",
         "nameLabel": "Nombre de la línea de contrato *",
         "namePlaceholder": "p.ej. Soporte gestionado - Oro"
       },

--- a/server/public/locales/fr/msp/contract-lines.json
+++ b/server/public/locales/fr/msp/contract-lines.json
@@ -58,6 +58,9 @@
         },
         "description": "Nommez la ligne de contrat et choisissez le mode de facturation par défaut.",
         "heading": "Notions de base sur les lignes de contrat",
+        "invoiceLineDescriptionHelp": "Utilisé tel quel comme texte de la ligne de facture pour ces frais fixes. Laissez vide pour utiliser le nom de la ligne de contrat.",
+        "invoiceLineDescriptionLabel": "Description de la ligne de facture",
+        "invoiceLineDescriptionPlaceholder": "par ex. Maintenance mensuelle du système téléphonique selon le contrat de 2019",
         "nameLabel": "Nom de la ligne de contrat *",
         "namePlaceholder": "par ex. Support géré - Or"
       },

--- a/server/public/locales/it/msp/contract-lines.json
+++ b/server/public/locales/it/msp/contract-lines.json
@@ -58,6 +58,9 @@
         },
         "description": "Assegna un nome alla riga del contratto e scegli come fatturare per impostazione predefinita.",
         "heading": "Nozioni di base sulla linea di contratto",
+        "invoiceLineDescriptionHelp": "Utilizzato testualmente come testo della riga di fattura per questa tariffa fissa. Lascia vuoto per usare il nome della linea di contratto.",
+        "invoiceLineDescriptionLabel": "Descrizione della riga di fattura",
+        "invoiceLineDescriptionPlaceholder": "per esempio. Manutenzione mensile del sistema telefonico secondo il contratto del 2019",
         "nameLabel": "Nome della linea di contratto *",
         "namePlaceholder": "per esempio. Supporto gestito - Oro"
       },

--- a/server/public/locales/nl/msp/contract-lines.json
+++ b/server/public/locales/nl/msp/contract-lines.json
@@ -58,6 +58,9 @@
         },
         "description": "Geef de contractregel een naam en kies hoe deze standaard moet worden gefactureerd.",
         "heading": "Basisprincipes van contractregels",
+        "invoiceLineDescriptionHelp": "Wordt letterlijk gebruikt als tekst van de factuurregel voor deze vaste vergoeding. Laat leeg om de naam van de contractregel te gebruiken.",
+        "invoiceLineDescriptionLabel": "Omschrijving factuurregel",
+        "invoiceLineDescriptionPlaceholder": "bijv. Maandelijks onderhoud van de telefooncentrale volgens de overeenkomst van 2019",
         "nameLabel": "Naam contractregel *",
         "namePlaceholder": "bijv. Beheerde ondersteuning - Goud"
       },

--- a/server/public/locales/pl/msp/contract-lines.json
+++ b/server/public/locales/pl/msp/contract-lines.json
@@ -58,6 +58,9 @@
         },
         "description": "Nazwij linię umowy i wybierz domyślny sposób rozliczeń.",
         "heading": "Podstawy linii kontraktowej",
+        "invoiceLineDescriptionHelp": "Używany dosłownie jako tekst pozycji faktury dla tej opłaty stałej. Pozostaw puste, aby użyć nazwy linii kontraktu.",
+        "invoiceLineDescriptionLabel": "Opis pozycji faktury",
+        "invoiceLineDescriptionPlaceholder": "np. Miesięczna konserwacja systemu telefonicznego zgodnie z umową z 2019 r.",
         "nameLabel": "Nazwa linii kontraktu *",
         "namePlaceholder": "np. Zarządzane wsparcie — złoto"
       },

--- a/server/public/locales/pt/msp/contract-lines.json
+++ b/server/public/locales/pt/msp/contract-lines.json
@@ -58,6 +58,9 @@
         },
         "description": "Dê um nome à linha de contrato e escolha como ela deverá ser cobrada por padrão.",
         "heading": "Noções básicas da linha de contrato",
+        "invoiceLineDescriptionHelp": "Usado literalmente como texto da linha da fatura para esta taxa fixa. Deixe em branco para usar o nome da linha de contrato.",
+        "invoiceLineDescriptionLabel": "Descrição da linha da fatura",
+        "invoiceLineDescriptionPlaceholder": "por exemplo Manutenção mensal do sistema telefônico conforme o contrato de 2019",
         "nameLabel": "Nome da linha de contrato *",
         "namePlaceholder": "por exemplo Suporte Gerenciado - Ouro"
       },

--- a/server/public/locales/xx/msp/contract-lines.json
+++ b/server/public/locales/xx/msp/contract-lines.json
@@ -58,6 +58,9 @@
         },
         "description": "11111",
         "heading": "11111",
+        "invoiceLineDescriptionHelp": "11111",
+        "invoiceLineDescriptionLabel": "11111",
+        "invoiceLineDescriptionPlaceholder": "11111",
         "nameLabel": "11111",
         "namePlaceholder": "11111"
       },

--- a/server/public/locales/yy/msp/contract-lines.json
+++ b/server/public/locales/yy/msp/contract-lines.json
@@ -58,6 +58,9 @@
         },
         "description": "55555",
         "heading": "55555",
+        "invoiceLineDescriptionHelp": "55555",
+        "invoiceLineDescriptionLabel": "55555",
+        "invoiceLineDescriptionPlaceholder": "55555",
         "nameLabel": "55555",
         "namePlaceholder": "55555"
       },

--- a/server/src/test/unit/app/msp/collab-test/CollabTestPageClient.test.tsx
+++ b/server/src/test/unit/app/msp/collab-test/CollabTestPageClient.test.tsx
@@ -135,7 +135,14 @@ describe('CollabTestPageClient', () => {
       expect(getBlockContentMock).toHaveBeenCalledWith('doc-789');
     });
 
-    fireEvent.click(getByText('Snapshot to DB'));
+    // The button stays disabled until the document finishes loading; clicking
+    // before then is a no-op the component never replays.
+    const snapshotButton = getByText('Snapshot to DB') as HTMLButtonElement;
+    await waitFor(() => {
+      expect(snapshotButton.disabled).toBe(false);
+    });
+
+    fireEvent.click(snapshotButton);
 
     expect(await findByText('Snapshot saved to document_block_content.')).toBeTruthy();
     expect(syncCollabSnapshot).toHaveBeenCalledWith('doc-789');


### PR DESCRIPTION
## What changed

- Added an optional invoice-line description to fixed contract lines.
- Added the authoring field to fixed-line configuration and persisted it through the contract-line model.
- Used the override verbatim when generating fixed invoice charges, with the existing contract-line name as fallback.
- Added the nullable `contract_lines.invoice_line_description` migration.

## Why

Long-standing fixed-fee agreements often require stable customer-facing wording that differs from the internal contract-line name. Without an override, staff must edit every recurring draft manually.

## Impact

Fixed recurring invoices can carry agreement-specific wording automatically while existing lines retain their current descriptions.

## Validation

- `npm run typecheck` in `packages/billing`
- Targeted ESLint: no errors
- `node --check server/migrations/20260703140000_add_invoice_line_description_to_contract_lines.cjs`
- `git diff --check`