### PR TITLE
refactor(ui): server-render public account pages

### DIFF
--- a/server/src/app/auth/password-reset/confirmation/page.tsx
+++ b/server/src/app/auth/password-reset/confirmation/page.tsx
@@ -1,19 +1,20 @@
-"use client";
-import React from 'react';
-import { useRouter, useSearchParams } from 'next/navigation';
+import Link from 'next/link';
 import Image from 'next/image';
 import { Button } from '@alga-psa/ui/components/Button';
-import { useTranslation } from '@alga-psa/ui/lib/i18n/client';
+import { getServerTranslation } from '@alga-psa/ui/lib/i18n/serverOnly';
 
-const PasswordResetConfirmation: React.FC = () => {
-  const { t } = useTranslation('msp/auth');
-  const router = useRouter();
-  const searchParams = useSearchParams();
-  const portal = searchParams?.get('portal') || 'msp';
+interface PasswordResetConfirmationProps {
+  searchParams?: Promise<{ portal?: string }>;
+}
 
-  const handleContinue = () => {
-    router.push(portal === 'client' ? '/auth/client-portal/signin' : '/auth/msp/signin'); 
-  };
+export default async function PasswordResetConfirmation({
+  searchParams,
+}: PasswordResetConfirmationProps) {
+  const resolvedSearchParams = searchParams ? await searchParams : undefined;
+  const portal = resolvedSearchParams?.portal || 'msp';
+  const signinHref =
+    portal === 'client' ? '/auth/client-portal/signin' : '/auth/msp/signin';
+  const { t } = await getServerTranslation(undefined, 'msp/auth');
 
   return (
     <div className="flex flex-col items-center p-20 min-h-screen bg-[rgb(var(--color-background-50))] dark:bg-[rgb(var(--color-background))]">
@@ -33,17 +34,16 @@ const PasswordResetConfirmation: React.FC = () => {
           <br />
           {t('passwordReset.confirmation.subtitleContinue', 'Click below to sign in with your new password.')}
         </p>
-        <Button
-          id="proceed-to-sign-in-btn"
-          variant="default"
-          onClick={handleContinue}
-          className="w-full px-4 py-2 text-sm font-medium text-white bg-[rgb(var(--color-primary-600))] rounded-md hover:bg-[rgb(var(--color-primary-700))] focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-[rgb(var(--color-primary-500))]"
-        >
-          {t('passwordReset.confirmation.continue', 'Continue')}
-        </Button>
+        <Link href={signinHref} className="block">
+          <Button
+            id="proceed-to-sign-in-btn"
+            variant="default"
+            className="w-full px-4 py-2 text-sm font-medium text-white bg-[rgb(var(--color-primary-600))] rounded-md hover:bg-[rgb(var(--color-primary-700))] focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-[rgb(var(--color-primary-500))]"
+          >
+            {t('passwordReset.confirmation.continue', 'Continue')}
+          </Button>
+        </Link>
       </div>
     </div>
   );
-};
-
-export default PasswordResetConfirmation;
+}

--- a/server/src/app/auth/verify-email/VerifyEmailRedirect.tsx
+++ b/server/src/app/auth/verify-email/VerifyEmailRedirect.tsx
@@ -1,0 +1,45 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import { useRouter } from 'next/navigation';
+import { useTranslation } from '@alga-psa/ui/lib/i18n/client';
+
+const REDIRECT_SECONDS = 5;
+const SIGNIN_HREF = '/auth/msp/signin';
+
+/**
+ * The only interactive part of the verify-email route: a countdown that
+ * redirects to the sign-in page and a manual "Go to sign in" button. Kept as a
+ * client component so the surrounding verification status can render on the
+ * server.
+ */
+export default function VerifyEmailRedirect() {
+  const { t } = useTranslation('msp/auth');
+  const router = useRouter();
+  const [countdown, setCountdown] = useState(REDIRECT_SECONDS);
+
+  useEffect(() => {
+    if (countdown <= 0) {
+      router.push(SIGNIN_HREF);
+      return;
+    }
+    const timer = setInterval(() => {
+      setCountdown((prev) => prev - 1);
+    }, 1000);
+    return () => clearInterval(timer);
+  }, [countdown, router]);
+
+  return (
+    <>
+      <p className="text-[rgb(var(--color-text-500))] mb-4">
+        {t('verifyEmail.redirecting', 'Redirecting in {{count}} seconds...', { count: countdown })}
+      </p>
+      <button
+        onClick={() => router.push(SIGNIN_HREF)}
+        className="mt-4 px-4 py-2 bg-[rgb(var(--color-primary-600))] text-white rounded-md shadow hover:bg-[rgb(var(--color-primary-700))] transition"
+      >
+        {t('verifyEmail.goToSignIn', 'Go to Sign In')}
+      </button>
+    </>
+  );
+}

--- a/server/src/app/auth/verify-email/page.tsx
+++ b/server/src/app/auth/verify-email/page.tsx
@@ -1,102 +1,64 @@
-"use client";
-import { useEffect, useState, useRef, Suspense  } from 'react';
-
-import { useRouter, useSearchParams } from 'next/navigation';
-
+import { getServerTranslation } from '@alga-psa/ui/lib/i18n/serverOnly';
 import { verifyRegisterUser } from '@alga-psa/auth/actions';
-import { useTranslation } from '@alga-psa/ui/lib/i18n/client';
+import VerifyEmailRedirect from './VerifyEmailRedirect';
 
-const VerifyEmailContent = () => {
-    const { t } = useTranslation('msp/auth');
-    const router = useRouter();
-    const searchParams = useSearchParams();
-    const token = searchParams!.get('token');
-    const [countdown, setCountdown] = useState(5);
-    const [verificationSuccess, setVerificationSuccess] = useState(false);
-    const [verificationMessage, setVerificationMessage] = useState('');
-    const hasRun = useRef(false);
+export const dynamic = 'force-dynamic';
 
-    useEffect(() => {
-        const verifyToken = async () => {
-            if (token && !hasRun.current) {
-                hasRun.current = true;
-                try {
-                    const {message, wasSuccess} = await verifyRegisterUser(token);
-                    setVerificationSuccess(wasSuccess);
-                    setVerificationMessage(message);
-                } catch (error) {
-                    console.error("Verification failed:", error);
-                    setVerificationSuccess(false);
-                    setVerificationMessage(t('verifyEmail.unknownErrorMessage', 'Unknow error verifying token'));
-                }
-            }
-        };
+interface VerifyEmailPageProps {
+  searchParams?: Promise<{ token?: string }>;
+}
 
-        verifyToken();
-    }, [token]);
+export default async function VerifyEmailPage({ searchParams }: VerifyEmailPageProps) {
+  const resolvedSearchParams = searchParams ? await searchParams : undefined;
+  const token = resolvedSearchParams?.token;
+  const { t } = await getServerTranslation(undefined, 'msp/auth');
 
-    useEffect(() => {
-        const interval = setInterval(() => {
-        setCountdown((prev) => prev - 1);
-        }, 1000);
+  // The verification runs on the server during render — equivalent to the
+  // previous client effect, but with no loading flash and the result text is
+  // server-rendered. A page refresh re-runs it, matching prior behaviour.
+  let verificationSuccess = false;
+  let verificationMessage = '';
 
-        // Redirect after 10 seconds
-        if (countdown <= 0) {
-        clearInterval(interval);
-        router.push('/auth/msp/signin');
-        }
+  if (token) {
+    try {
+      const { message, wasSuccess } = await verifyRegisterUser(token);
+      verificationSuccess = wasSuccess;
+      verificationMessage = message;
+    } catch {
+      verificationSuccess = false;
+      verificationMessage = t('verifyEmail.unknownErrorMessage', 'Unknow error verifying token');
+    }
+  }
 
-        return () => clearInterval(interval);
-    }, [countdown, router]);
-
-    return (
-        <div className="min-h-screen bg-[rgb(var(--color-background-50))] flex items-center justify-center">
-        <div className="bg-card p-8 rounded-lg shadow-lg max-w-md text-center">
-            
-            {
-                token
-                ?
-                verificationSuccess
-                ?
-                <>
-                    <h1 className="text-3xl font-bold text-[rgb(var(--color-primary-500))] mb-4">{t('verifyEmail.welcomeTitle', 'Welcome!')}</h1>
-                    <p className="text-[rgb(var(--color-text-700))] mb-6">
-                    {t('verifyEmail.welcomeMessage', 'Your email has been successfully verified. You will be redirected to the sign in page shortly.')}
-                    </p>
-                </>
-                :
-                <>
-                    <h1 className="text-3xl font-bold text-[rgb(var(--color-primary-500))] mb-4">{t('verifyEmail.processErrorTitle', 'Process Error!')}</h1>
-                    <p className="text-[rgb(var(--color-text-700))] mb-6">
-                        {verificationMessage}
-                    </p>
-                </>
-                :
-                <>
-                    <h1 className="text-3xl font-bold text-[rgb(var(--color-primary-500))] mb-4">{t('verifyEmail.errorTitle', 'Error!')}</h1>
-                    <p className="text-[rgb(var(--color-text-700))] mb-6">
-                    {t('verifyEmail.tokenRequiredMessage', 'Verification process required a token. Please try again.')}
-                    </p>
-                </>
-            }
-            <p className="text-[rgb(var(--color-text-500))] mb-4">{t('verifyEmail.redirecting', 'Redirecting in {{count}} seconds...', { count: countdown })}</p>
-            <button
-            onClick={() => router.push('/auth/msp/signin')}
-            className="mt-4 px-4 py-2 bg-[rgb(var(--color-primary-600))] text-white rounded-md shadow hover:bg-[rgb(var(--color-primary-700))] transition"
-            >
-            {t('verifyEmail.goToSignIn', 'Go to Sign In')}
-            </button>
-        </div>
-        </div>
-    );
-};
-
-const VerifyEmail: React.FC = () => {
-    return (
-    <Suspense fallback={<div>Loading...</div>}>
-        <VerifyEmailContent />
-    </Suspense>
-    );
-};
-
-export default VerifyEmail;
+  return (
+    <div className="min-h-screen bg-[rgb(var(--color-background-50))] flex items-center justify-center">
+      <div className="bg-card p-8 rounded-lg shadow-lg max-w-md text-center">
+        {token ? (
+          verificationSuccess ? (
+            <>
+              <h1 className="text-3xl font-bold text-[rgb(var(--color-primary-500))] mb-4">{t('verifyEmail.welcomeTitle', 'Welcome!')}</h1>
+              <p className="text-[rgb(var(--color-text-700))] mb-6">
+                {t('verifyEmail.welcomeMessage', 'Your email has been successfully verified. You will be redirected to the sign in page shortly.')}
+              </p>
+            </>
+          ) : (
+            <>
+              <h1 className="text-3xl font-bold text-[rgb(var(--color-primary-500))] mb-4">{t('verifyEmail.processErrorTitle', 'Process Error!')}</h1>
+              <p className="text-[rgb(var(--color-text-700))] mb-6">
+                {verificationMessage}
+              </p>
+            </>
+          )
+        ) : (
+          <>
+            <h1 className="text-3xl font-bold text-[rgb(var(--color-primary-500))] mb-4">{t('verifyEmail.errorTitle', 'Error!')}</h1>
+            <p className="text-[rgb(var(--color-text-700))] mb-6">
+              {t('verifyEmail.tokenRequiredMessage', 'Verification process required a token. Please try again.')}
+            </p>
+          </>
+        )}
+        <VerifyEmailRedirect />
+      </div>
+    </div>
+  );
+}

--- a/server/src/app/auth/verify/page.tsx
+++ b/server/src/app/auth/verify/page.tsx
@@ -1,12 +1,8 @@
-'use client';
-
-import { useRouter } from 'next/navigation';
+import Link from 'next/link';
 import { Button } from '@alga-psa/ui/components/Button';
 import { Alert, AlertDescription } from '@alga-psa/ui/components/Alert';
 
 export default function VerifyPage() {
-  const router = useRouter();
-
   return (
     <div className="flex min-h-screen flex-col items-center justify-center py-12 px-4 sm:px-6 lg:px-8">
       <div className="w-full max-w-md space-y-8">
@@ -27,14 +23,15 @@ export default function VerifyPage() {
           </AlertDescription>
         </Alert>
         <div className="text-center">
-          <Button
-            id="return-to-signin-button"
-            variant="outline"
-            onClick={() => router.push('/auth/msp/signin')}
-            className="mt-4"
-          >
-            Return to Sign In
-          </Button>
+          <Link href="/auth/msp/signin">
+            <Button
+              id="return-to-signin-button"
+              variant="outline"
+              className="mt-4"
+            >
+              Return to Sign In
+            </Button>
+          </Link>
         </div>
       </div>
     </div>

--- a/server/src/app/msp/licenses/purchase/page.tsx
+++ b/server/src/app/msp/licenses/purchase/page.tsx
@@ -1,30 +1,24 @@
-'use client';
-
-import React from 'react';
-import LicensePurchaseForm from '@enterprise/components/licensing/LicensePurchaseForm';
 import { ArrowLeft } from 'lucide-react';
-import { Button } from '@alga-psa/ui/components/Button';
-import { useRouter } from 'next/navigation';
-import { useTranslation } from '@alga-psa/ui/lib/i18n/client';
+import LicensePurchaseForm from '@enterprise/components/licensing/LicensePurchaseForm';
+import BackButton from '@/components/common/BackButton';
+import { getServerTranslation } from '@alga-psa/ui/lib/i18n/serverOnly';
 
-export default function LicensePurchasePage() {
-  const router = useRouter();
-  const { t } = useTranslation('msp/licensing');
-  const { t: tCommon } = useTranslation('common');
+export const dynamic = 'force-dynamic';
+
+export default async function LicensePurchasePage() {
+  const [{ t }, { t: tCommon }] = await Promise.all([
+    getServerTranslation(undefined, 'msp/licensing'),
+    getServerTranslation(undefined, 'common'),
+  ]);
 
   return (
     <div className="container mx-auto p-4 max-w-4xl">
       {/* Back Button */}
       <div className="mb-6">
-        <Button
-          id="back-button"
-          variant="outline"
-          className="gap-2"
-          onClick={() => router.back()}
-        >
+        <BackButton id="back-button" variant="outline" className="gap-2">
           <ArrowLeft className="h-4 w-4" />
           {tCommon('actions.back', { defaultValue: 'Back' })}
-        </Button>
+        </BackButton>
       </div>
 
       {/* Page Header */}

--- a/server/src/app/static/master_terms/page.tsx
+++ b/server/src/app/static/master_terms/page.tsx
@@ -1,13 +1,6 @@
-"use client";
-import { useRouter } from 'next/navigation';
+import BackButton from '@/components/common/BackButton';
 
 export default function MasterTerms() {
-  const router = useRouter();
-
-  const handleBack = () => {
-    router.back();
-  };
-
   return (
     <div className="min-h-screen bg-gray-100 py-12 px-4">
       <div className="bg-white p-8 rounded-lg shadow-lg max-w-4xl mx-auto">
@@ -361,12 +354,12 @@ export default function MasterTerms() {
           </p>
         </div>
 
-        <button
-          onClick={handleBack}
+        <BackButton
+          id="master-terms-back-button"
           className="mt-8 px-4 py-2 bg-gray-600 text-white rounded-md shadow hover:bg-gray-700 transition"
         >
           Go Back
-        </button>
+        </BackButton>
       </div>
     </div>
   );

--- a/server/src/app/static/privacy_policy/page.tsx
+++ b/server/src/app/static/privacy_policy/page.tsx
@@ -1,13 +1,6 @@
-"use client";
-import { useRouter } from 'next/navigation';
+import BackButton from '@/components/common/BackButton';
 
 export default function PrivacyPolicy() {
-  const router = useRouter();
-
-  const handleBack = () => {
-    router.back();
-  };
-
   return (
     <div className="min-h-screen bg-gray-100 py-12 px-4">
       <div className="bg-white p-8 rounded-lg shadow-lg max-w-4xl mx-auto">
@@ -402,12 +395,12 @@ export default function PrivacyPolicy() {
           </p>
         </div>
 
-        <button
-          onClick={handleBack}
+        <BackButton
+          id="privacy-policy-back-button"
           className="mt-8 px-4 py-2 bg-gray-600 text-white rounded-md shadow hover:bg-gray-700 transition"
         >
           Go Back
-        </button>
+        </BackButton>
       </div>
     </div>
   );

--- a/server/src/components/common/BackButton.tsx
+++ b/server/src/components/common/BackButton.tsx
@@ -1,0 +1,31 @@
+'use client';
+
+import * as React from 'react';
+import { useRouter } from 'next/navigation';
+import { Button, type ButtonProps } from '@alga-psa/ui/components/Button';
+
+/**
+ * A thin interactive "back" affordance for otherwise server-rendered pages.
+ *
+ * Most of a page's content renders on the server; only this leaf needs the
+ * client-only `useRouter()` hook, so it is isolated here. Clicking navigates
+ * one entry back through the browser history, matching the previous
+ * `router.back()` behaviour of the pages that adopt it.
+ */
+export default function BackButton({
+  onClick,
+  ...buttonProps
+}: ButtonProps) {
+  const router = useRouter();
+
+  return (
+    <Button
+      {...buttonProps}
+      onClick={(event) => {
+        onClick?.(event);
+        if (event.defaultPrevented) return;
+        router.back();
+      }}
+    />
+  );
+}


### PR DESCRIPTION
## What changed

- Converted password-reset confirmation, email verification, legacy verification, license purchase, master terms, and privacy-policy pages to server-rendered components.
- Moved the verify-email countdown/redirect into a small client leaf.
- Added a reusable client-only back button for otherwise server-rendered pages.
- Moved applicable translations and verification work to server rendering.

## Why

These pages were client components primarily for navigation hooks or a small countdown. That forced the whole page through the client boundary and delayed translated/status content until hydration.

## Impact

Public/account content renders immediately on the server while preserving browser-back and redirect interactions.

## Validation

- Targeted ESLint across all changed TS/TSX files: no errors
- `git diff --check`
- Full `server` typecheck was attempted after refreshing dependencies, but the repository-wide TypeScript process exhausted an 8 GB Node heap before completing.