### PR TITLE
fix(service-requests): return expected action failures

### DIFF
--- a/server/src/app/msp/service-requests/ServiceRequestsManagementPage.tsx
+++ b/server/src/app/msp/service-requests/ServiceRequestsManagementPage.tsx
@@ -156,7 +156,11 @@ export default function ServiceRequestsManagementPage() {
                 onClick={() =>
                   startTransition(async () => {
                     try {
-                      await duplicateServiceRequestDefinitionAction(row.definition_id);
+                      const result = await duplicateServiceRequestDefinitionAction(row.definition_id);
+                      if (!result.success) {
+                        toast.error(result.message);
+                        return;
+                      }
                       await reload();
                       toast.success(t('messages.success.definitionDuplicated'));
                     } catch (error) {
@@ -174,7 +178,11 @@ export default function ServiceRequestsManagementPage() {
                   onClick={() =>
                     startTransition(async () => {
                       try {
-                        await unarchiveServiceRequestDefinitionAction(row.definition_id);
+                        const result = await unarchiveServiceRequestDefinitionAction(row.definition_id);
+                        if (!result.success) {
+                          toast.error(result.message);
+                          return;
+                        }
                         await reload();
                         toast.success(t('messages.success.definitionUnarchived'));
                       } catch (error) {
@@ -192,7 +200,11 @@ export default function ServiceRequestsManagementPage() {
                   onClick={() =>
                     startTransition(async () => {
                       try {
-                        await archiveServiceRequestDefinitionAction(row.definition_id);
+                        const result = await archiveServiceRequestDefinitionAction(row.definition_id);
+                        if (!result.success) {
+                          toast.error(result.message);
+                          return;
+                        }
                         await reload();
                         toast.success(t('messages.success.definitionArchived'));
                       } catch (error) {
@@ -272,16 +284,20 @@ export default function ServiceRequestsManagementPage() {
                   onClick={() =>
                     startTransition(async () => {
                       try {
-                        const created = await createServiceRequestDefinitionFromTemplateAction(
+                        const result = await createServiceRequestDefinitionFromTemplateAction(
                           template.providerKey,
                           template.templateId
                         );
+                        if (!result.success) {
+                          toast.error(result.message);
+                          return;
+                        }
                         toast.success(
                           t('messages.success.draftCreatedFromExample', {
                             name: template.templateName,
                           })
                         );
-                        router.push(`/msp/service-requests/${created.definition_id}`);
+                        router.push(`/msp/service-requests/${result.data.definition_id}`);
                       } catch (error) {
                         console.error('Failed to create draft from template', error);
                         toast.error(t('messages.error.createFromExampleFailed'));

--- a/server/src/app/msp/service-requests/actions.ts
+++ b/server/src/app/msp/service-requests/actions.ts
@@ -39,10 +39,28 @@ import {
   type ServiceRequestPublishValidationResult,
   type ServiceRequestTemplateOption,
   type ServiceRequestDefinitionEditorData,
+  ServiceRequestDefinitionBusinessError,
+  type ServiceRequestDefinitionErrorCode,
 } from '../../../lib/service-requests';
 import type { IBoard, IPriority, ITicketCategory, ITicketStatus, IUser } from '@alga-psa/types';
 
 type AuthUser = Parameters<Parameters<typeof withAuth>[0]>[0];
+
+export type ServiceRequestDefinitionActionResult<T = void> =
+  | { success: true; data: T }
+  | { success: false; code: ServiceRequestDefinitionErrorCode; message: string };
+
+function serviceRequestSuccess<T>(data: T): ServiceRequestDefinitionActionResult<T> {
+  return { success: true, data };
+}
+
+function mapServiceRequestDefinitionError<T>(error: unknown): ServiceRequestDefinitionActionResult<T> {
+  if (error instanceof ServiceRequestDefinitionBusinessError) {
+    return { success: false, code: error.code, message: error.message };
+  }
+
+  throw error;
+}
 
 function getActorId(user: unknown): string | null {
   const candidate = user as { user_id?: string; id?: string } | undefined;
@@ -194,31 +212,41 @@ export const createServiceRequestDefinitionFromTemplateAction = withAuth(async (
   { tenant },
   templateProviderKey: string,
   templateId: string
-): Promise<ServiceRequestDefinitionManagementRow> => {
+): Promise<ServiceRequestDefinitionActionResult<ServiceRequestDefinitionManagementRow>> => {
   const { knex } = await createTenantKnex();
   await requireServiceRequestPermission(user, 'create', knex);
-  return createServiceRequestDefinitionFromTemplate({
-    knex,
-    tenant,
-    templateProviderKey,
-    templateId,
-    createdBy: getActorId(user),
-  });
+  try {
+    const created = await createServiceRequestDefinitionFromTemplate({
+      knex,
+      tenant,
+      templateProviderKey,
+      templateId,
+      createdBy: getActorId(user),
+    });
+    return serviceRequestSuccess(created);
+  } catch (error) {
+    return mapServiceRequestDefinitionError(error);
+  }
 });
 
 export const duplicateServiceRequestDefinitionAction = withAuth(async (
   user,
   { tenant },
   definitionId: string
-): Promise<ServiceRequestDefinitionManagementRow> => {
+): Promise<ServiceRequestDefinitionActionResult<ServiceRequestDefinitionManagementRow>> => {
   const { knex } = await createTenantKnex();
   await requireServiceRequestPermission(user, 'create', knex);
-  return duplicateServiceRequestDefinition({
-    knex,
-    tenant,
-    sourceDefinitionId: definitionId,
-    createdBy: getActorId(user),
-  });
+  try {
+    const created = await duplicateServiceRequestDefinition({
+      knex,
+      tenant,
+      sourceDefinitionId: definitionId,
+      createdBy: getActorId(user),
+    });
+    return serviceRequestSuccess(created);
+  } catch (error) {
+    return mapServiceRequestDefinitionError(error);
+  }
 });
 
 export const saveServiceRequestDefinitionDraftAction = withAuth(async (
@@ -538,18 +566,28 @@ export const archiveServiceRequestDefinitionAction = withAuth(async (
   user,
   { tenant },
   definitionId: string
-): Promise<void> => {
+): Promise<ServiceRequestDefinitionActionResult> => {
   const { knex } = await createTenantKnex();
   await requireServiceRequestPermission(user, 'delete', knex);
-  await archiveServiceRequestDefinitionFromManagement(knex, tenant, definitionId, getActorId(user));
+  try {
+    await archiveServiceRequestDefinitionFromManagement(knex, tenant, definitionId, getActorId(user));
+    return serviceRequestSuccess(undefined);
+  } catch (error) {
+    return mapServiceRequestDefinitionError(error);
+  }
 });
 
 export const unarchiveServiceRequestDefinitionAction = withAuth(async (
   user,
   { tenant },
   definitionId: string
-): Promise<void> => {
+): Promise<ServiceRequestDefinitionActionResult> => {
   const { knex } = await createTenantKnex();
   await requireServiceRequestPermission(user, 'update', knex);
-  await unarchiveServiceRequestDefinitionFromManagement(knex, tenant, definitionId, getActorId(user));
+  try {
+    await unarchiveServiceRequestDefinitionFromManagement(knex, tenant, definitionId, getActorId(user));
+    return serviceRequestSuccess(undefined);
+  } catch (error) {
+    return mapServiceRequestDefinitionError(error);
+  }
 });

--- a/server/src/lib/service-requests/definitionErrors.ts
+++ b/server/src/lib/service-requests/definitionErrors.ts
@@ -1,0 +1,14 @@
+export type ServiceRequestDefinitionErrorCode =
+  | 'TEMPLATE_UNAVAILABLE'
+  | 'SOURCE_DEFINITION_NOT_FOUND'
+  | 'DEFINITION_NOT_FOUND';
+
+export class ServiceRequestDefinitionBusinessError extends Error {
+  constructor(
+    public readonly code: ServiceRequestDefinitionErrorCode,
+    message: string
+  ) {
+    super(message);
+    this.name = 'ServiceRequestDefinitionBusinessError';
+  }
+}

--- a/server/src/lib/service-requests/definitionLifecycle.ts
+++ b/server/src/lib/service-requests/definitionLifecycle.ts
@@ -1,5 +1,6 @@
 import type { Knex } from 'knex';
 import { tenantDb } from '@alga-psa/db';
+import { ServiceRequestDefinitionBusinessError } from './definitionErrors';
 
 export interface ServiceRequestDefinitionListItem {
   tenant: string;
@@ -21,11 +22,18 @@ export async function archiveServiceRequestDefinition(
   definitionId: string,
   archivedBy?: string | null
 ): Promise<void> {
-  await tenantDb(knex, tenant).table('service_request_definitions').where({ definition_id: definitionId }).update({
+  const updated = await tenantDb(knex, tenant).table('service_request_definitions').where({ definition_id: definitionId }).update({
     lifecycle_state: 'archived',
     updated_by: archivedBy ?? null,
     updated_at: knex.fn.now(),
   });
+
+  if (updated === 0) {
+    throw new ServiceRequestDefinitionBusinessError(
+      'DEFINITION_NOT_FOUND',
+      'Service request definition was not found or is no longer available.'
+    );
+  }
 }
 
 export async function unarchiveServiceRequestDefinition(
@@ -34,13 +42,20 @@ export async function unarchiveServiceRequestDefinition(
   definitionId: string,
   updatedBy?: string | null
 ): Promise<void> {
-  await tenantDb(knex, tenant).table('service_request_definitions').where({ definition_id: definitionId }).update({
+  const updated = await tenantDb(knex, tenant).table('service_request_definitions').where({ definition_id: definitionId }).update({
     lifecycle_state: 'draft',
     published_by: null,
     published_at: null,
     updated_by: updatedBy ?? null,
     updated_at: knex.fn.now(),
   });
+
+  if (updated === 0) {
+    throw new ServiceRequestDefinitionBusinessError(
+      'DEFINITION_NOT_FOUND',
+      'Service request definition was not found or is no longer available.'
+    );
+  }
 }
 
 export async function listPublishedServiceRequestDefinitions(

--- a/server/src/lib/service-requests/definitionManagement.ts
+++ b/server/src/lib/service-requests/definitionManagement.ts
@@ -8,6 +8,7 @@ import {
 import { listServiceRequestTemplateProviders } from './providers/registry';
 import type { ServiceRequestTemplateDefinition } from './providers/contracts';
 import { isLicenseDistributionTenant } from '@alga-psa/licensing';
+import { ServiceRequestDefinitionBusinessError } from './definitionErrors';
 
 /**
  * Template provider whose templates author the in-app appliance-license purchase
@@ -273,7 +274,10 @@ export async function createServiceRequestDefinitionFromTemplate({
     templateProviderKey === DISTRIBUTION_ONLY_TEMPLATE_PROVIDER_KEY &&
     !isLicenseDistributionTenant(tenant)
   ) {
-    throw new Error('This template is not available for this tenant');
+    throw new ServiceRequestDefinitionBusinessError(
+      'TEMPLATE_UNAVAILABLE',
+      'This template is not available for this tenant'
+    );
   }
 
   const template = findTemplateDefinition(templateProviderKey, templateId);
@@ -329,7 +333,10 @@ export async function duplicateServiceRequestDefinition({
     .first()) as ServiceRequestDefinitionSourceRow | undefined;
 
   if (!source) {
-    throw new Error('Source service request definition not found');
+    throw new ServiceRequestDefinitionBusinessError(
+      'SOURCE_DEFINITION_NOT_FOUND',
+      'Source service request definition not found'
+    );
   }
 
   const [created] = (await db.table('service_request_definitions')

--- a/server/src/lib/service-requests/index.ts
+++ b/server/src/lib/service-requests/index.ts
@@ -1,4 +1,5 @@
 export * from './domain';
+export * from './definitionErrors';
 export * from './definitionPublishing';
 export * from './definitionValidation';
 export * from './definitionLifecycle';

--- a/server/src/test/unit/app/msp/service-requests/ServiceRequestsManagementPage.test.tsx
+++ b/server/src/test/unit/app/msp/service-requests/ServiceRequestsManagementPage.test.tsx
@@ -131,7 +131,8 @@ describe('ServiceRequestsManagementPage', () => {
       },
     ]);
     createServiceRequestDefinitionFromTemplateActionMock.mockResolvedValue({
-      definition_id: 'definition-123',
+      success: true,
+      data: { definition_id: 'definition-123' },
     });
   });
 
@@ -157,6 +158,27 @@ describe('ServiceRequestsManagementPage', () => {
     expect(pushMock).toHaveBeenCalledWith('/msp/service-requests/definition-123');
     expect(listServiceRequestDefinitionsActionMock).toHaveBeenCalledTimes(1);
     expect(listServiceRequestTemplatesActionMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('shows an expected template failure without navigating', async () => {
+    createServiceRequestDefinitionFromTemplateActionMock.mockResolvedValue({
+      success: false,
+      code: 'TEMPLATE_UNAVAILABLE',
+      message: 'This template is not available for this tenant',
+    });
+
+    render(<ServiceRequestsManagementPage />);
+
+    await screen.findByText('New Hire Onboarding');
+    fireEvent.click(screen.getByText(/New Hire Onboarding/));
+
+    await waitFor(() => {
+      expect(toastErrorMock).toHaveBeenCalledWith(
+        'This template is not available for this tenant'
+      );
+    });
+    expect(toastSuccessMock).not.toHaveBeenCalled();
+    expect(pushMock).not.toHaveBeenCalled();
   });
 
   it('hides archived service requests by default and reveals them when toggled on', async () => {


### PR DESCRIPTION
## What changed

- Added typed business-error codes for unavailable templates and missing definitions.
- Returned discriminated success/failure results from template creation, duplication, archive, and unarchive actions.
- Surfaced expected failure messages in the management UI instead of falling through to generic toasts.
- Detected archive/unarchive updates that matched no definition.
- Updated the management-page behavioral tests for the new result contract and added failure-path coverage.

## Root cause

Expected domain failures were thrown as generic exceptions across the server-action boundary. The client could not distinguish a known business rejection from an unexpected failure, so it discarded the useful message.

## Impact

Admins now receive the specific actionable failure while unexpected exceptions still propagate for server-side capture.

## Validation

- `npx vitest run src/test/unit/app/msp/service-requests/ServiceRequestsManagementPage.test.tsx src/test/unit/serviceRequestManagementActions.permissions.test.ts --coverage.enabled=false` — 5/5 tests passed
- Targeted ESLint: no errors (one pre-existing hook-dependency warning)
- `git diff --check`
- Full `server` typecheck was attempted after refreshing dependencies, but the repository-wide TypeScript process exhausted an 8 GB Node heap before completing.