### PR TITLE
DEE SMTP issue

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -17,6 +17,8 @@ build
 !packages/core/dist/**
 !packages/db/dist
 !packages/db/dist/**
+!packages/email/dist
+!packages/email/dist/**
 !ee/packages/workflows/dist/**
 !packages/workflow-streams/dist/**
 # Runtime-resolved @alga-psa packages: their dist/ must ship in images whose

--- a/docs/plans/2026-07-14-smtp-settings-uneditable-plan.md
+++ b/docs/plans/2026-07-14-smtp-settings-uneditable-plan.md
@@ -1,0 +1,273 @@
+# Outbound SMTP settings fields are uneditable on appliance installs
+
+**Branch:** `fix/dee-smtp-issue`
+**Date:** 2026-07-14
+
+## Problem
+
+A customer on a current appliance build reports that the Outbound Email → SMTP
+Configuration fields will not accept typed input. The fields focus, and the
+browser's own autofill history drops down, but no characters ever appear.
+
+The screen is not merely hard to type into — it is entirely inert. Save and Test
+Connection are dead on the same screen, for the same reason.
+
+This is not an email-delivery bug. Nothing is wrong with SMTP, the network, or
+the credentials. The screen has no data object to write into.
+
+## Root cause
+
+`tenant_email_settings.provider_configs` is an empty array, so the screen cannot
+find an SMTP provider config, and its change handler silently discards every
+keystroke.
+
+The chain:
+
+1. Tenant creation inserts a settings row with **no providers**.
+   `ee/temporal-workflows/src/db/tenant-operations.ts:425` inserts
+   `email_provider: 'resend'` and omits `provider_configs` entirely, so it takes
+   the column default `'[]'::json`
+   (`server/migrations/20250601000000_create_email_system_tables.cjs:13`).
+   The appliance runs this **same** Temporal workflow — `appliance-bootstrap-configmap.yaml:194`
+   shells out to `server/scripts/appliance-create-tenant.mjs`, which starts
+   `tenantCreationWorkflow`. There is no on-prem-specific seed path.
+
+2. The existing row defeats the only fallback. `getEmailSettings`
+   (`packages/integrations/src/actions/email-actions/emailSettingsActions.ts:79-108`)
+   fabricates a default SMTP entry from env vars **only when no row exists at
+   all**. A row does exist, so it returns `providerConfigs: []` untouched.
+
+3. The screen finds nothing. `getSmtpConfig()`
+   (`ee/server/src/components/settings/email/ManagedEmailSettings.tsx:443`)
+   does `providerConfigs.find(c => c.providerType === 'smtp')` → `undefined`.
+
+4. **The inputs render anyway and eat the typing.** They read through optional
+   chaining — `value={smtpConfig?.config.host || ''}` (`:748`) — so they render
+   as normal, enabled, focusable inputs. But `updateSmtpField` opens with
+   `if (!smtpConfig) return;` (`:450`). Every keystroke is discarded and React
+   re-renders the value back to `''`. `persistSmtpSettings` early-returns the
+   same way (`:462`), so Save and Test Connection no-op too.
+
+5. **There is no escape hatch.** The only code that creates a missing SMTP entry
+   is `handleProviderSwitch` (`:412-421`), reachable solely through the provider
+   selector, which is gated behind `canUseManagedEmail` (`:650`). On an appliance
+   that entitlement is off — which is why the customer's screenshot shows "SMTP"
+   as static text with no dropdown. The user can never reach the code that would
+   create the entry.
+
+### Why appliances specifically
+
+With `canUseManagedEmail: false` the screen forces `outboundProvider = 'smtp'`
+(`:131`, `:201`) regardless of the stored `email_provider`. So the SMTP card
+renders (`:731`) even though the row says `resend` with an empty provider list.
+On managed/hosted EE, `emailProvider` stays `resend`, the SMTP card never
+renders, and the defect stays invisible.
+
+### Two further defects found on the way
+
+- **`persistSmtpSettings` never enables the provider it saves.** It sends
+  `emailProvider: 'smtp'` but passes `providerConfigs` through unchanged
+  (`:460-466`), never setting `isEnabled: true` on the SMTP entry. A config saved
+  while disabled leaves `EmailProviderManager` with no enabled provider, which
+  makes it **silently fall back to the system env relay**
+  (`packages/email/src/providers/EmailProviderManager.ts:60-63`). Mail appears to
+  send, from the wrong server.
+
+- **CE has a milder form of the same disease.** `getCurrentProviderConfig`
+  (`packages/integrations/src/components/email/admin/EmailSettings.tsx:248`)
+  requires `providerType === selectedProvider && config.isEnabled`, and
+  `selectedProvider` is initialized to `'smtp'` (`:67`) but never synced from the
+  loaded settings. With an empty provider list the SMTP form simply does not
+  render; and since the dropdown already reads "SMTP", re-selecting SMTP fires no
+  change event, so the user escapes only by toggling to Resend and back.
+
+### A second writer of the same bad row
+
+`ManagedDomainService.activateDomain`
+(`packages/integrations/src/email/domains/services/ManagedDomainService.ts:323-332`)
+also inserts `email_provider: 'resend'`, `provider_configs: '[]'` when no row
+exists. Writers of this bad shape will keep appearing, which is why the durable
+fix belongs at the read/write boundary rather than in a hunt for every writer.
+
+### Explicitly NOT the cause
+
+Two claims in the circulating troubleshooting notes are stale and should not
+drive this work:
+
+- The `***`-masked-password clobber **is already fixed** by `mergeProviderSecrets`
+  (`emailSettingsActions.ts:28-51`, commit `0eb87e167a`, 2026-07-01). Both CE and
+  EE send the `***` sentinel and both go through that same protected action,
+  which restores the stored secret before writing. Re-entering the password on
+  every save is no longer necessary.
+- Test Connection buttons and TLS controls **already exist** in both screens —
+  visible in the customer's own screenshot.
+
+## Design
+
+One invariant, enforced at the boundaries rather than in each screen:
+
+> **A settings screen never renders an input without a backing config object, and
+> the provider named by `email_provider` always has an enabled config entry.**
+
+Three layers:
+
+1. **Read boundary** (`getEmailSettings`) — guarantee the returned
+   `providerConfigs` contains a well-formed entry for every provider type the
+   settings UI can edit, whether or not a row exists. Existing entries are
+   preserved untouched; only missing ones are materialized. Nothing is written to
+   the database on read.
+
+2. **Write boundary** (`updateEmailSettings`) — when the caller supplies
+   `emailProvider`, enforce enablement consistency: the entry matching that
+   provider type is enabled, the others are not. No client can persist the
+   "configured but disabled" state that silently reroutes mail to the system
+   relay.
+
+3. **Clients** — never gate an input on the presence of data the handler could
+   create. `updateSmtpField` creates the entry on write instead of returning.
+
+Because `persistSmtpSettings` already sends `emailProvider: 'smtp'` plus the full
+provider array, **the bad row repairs itself on the first successful save.** No
+backfill migration is required. Existing broken tenants (including the customer's)
+are fixed the moment they use the now-working screen.
+
+Separately, fix the seed so new appliance tenants never start in the bad shape.
+
+### Seed decisions (agreed)
+
+- **Provider selection is an explicit workflow input, not inferred from ambient
+  env.** `appliance-create-tenant.mjs` passes `emailProvider: 'smtp'`; hosted
+  callers keep today's `'resend'` default. The appliance declares its own intent
+  rather than having the seed guess from `EMAIL_HOST`.
+- **Do not pre-fill SMTP details from `EMAIL_*` env.** Seed a blank but
+  well-formed SMTP entry. The admin fills the form.
+- **Seed the entry as `isEnabled: false`.** An empty config must not be
+  "enabled" — enabling an unconfigured provider would make `EmailProviderManager`
+  select it and fail every send. Left disabled, the manager keeps today's
+  behavior (system-relay fallback) until the admin saves real settings, at which
+  point the write boundary enables it. This keeps a fresh appliance's behavior
+  identical to today's, so the seed change carries no regression risk for
+  out-of-the-box sending.
+
+## Changes
+
+### 1. Shared default-config factory (new)
+
+The default shape for a provider config is currently written out three times
+(`emailSettingsActions.ts:82-92`, CE `EmailSettings.tsx:211-222`, EE
+`ManagedEmailSettings.tsx:415-421`). Extract one factory and use it everywhere:
+
+- **New:** `createDefaultProviderConfig(providerType, { isEnabled })` in
+  `packages/email` (exported for use by both the actions and the UI packages).
+  Returns `{ providerId: '<type>-provider', providerType, isEnabled, config }`
+  with the per-type empty config (`{ host: '', port: 587, username: '',
+  password: '', from: '' }` for smtp; `{ apiKey: '', from: '' }` for resend).
+- Replace all three inline copies with calls to it.
+
+### 2. Read boundary — `packages/integrations/src/actions/email-actions/emailSettingsActions.ts`
+
+- Add `withEditableProviderConfigs(settings)`: returns settings whose
+  `providerConfigs` contains an entry for each UI-editable provider type
+  (`smtp`, `resend`). Existing entries pass through unchanged; missing ones are
+  materialized via the factory with `isEnabled: providerType === emailProvider`.
+- Apply it to the existing-row path in `getEmailSettings` (after the `***`
+  masking at `:112-124`), and rebuild the no-row default path on top of it so the
+  two paths share one shape. Preserve the current env-derived host/port/username/
+  from behavior for the no-row case, and keep not exposing `EMAIL_PASSWORD`.
+
+### 3. Write boundary — same file, `updateEmailSettings`
+
+- After `mergeProviderSecrets` (`:155-164`), when `updates.emailProvider` is
+  present, normalize enablement: `isEnabled = (config.providerType === emailProvider)`
+  across the merged array.
+- `mergeProviderSecrets` itself is unchanged — it is correct.
+
+### 4. EE screen — `ee/server/src/components/settings/email/ManagedEmailSettings.tsx`
+
+- `updateSmtpField` (`:447`): replace `if (!smtpConfig) return;` with
+  create-on-write — if no SMTP entry exists, append one from the factory and
+  apply the field to it.
+- `persistSmtpSettings` (`:460`): create the entry if absent rather than
+  returning `null`, and mark the SMTP config enabled (others disabled) in the
+  payload so the UI's local state matches what the write boundary will persist.
+- Replace the inline default in `handleProviderSwitch` (`:415`) with the factory.
+
+### 5. CE screen — `packages/integrations/src/components/email/admin/EmailSettings.tsx`
+
+- Sync `selectedProvider` from `settings.emailProvider` when settings load
+  (`:87`); today it stays stuck on its `'smtp'` initial value.
+- `getCurrentProviderConfig` (`:248`): match on `providerType === selectedProvider`
+  only. Drop the `isEnabled` requirement — enablement is a save-time concern and
+  must not decide whether a form renders.
+- Replace the inline default in `handleProviderChange` (`:211`) with the factory.
+
+### 6. Seed — appliance defaults to SMTP
+
+- `ee/temporal-workflows/src/db/tenant-operations.ts:425`: take `emailProvider`
+  from the activity input (default `'resend'`, preserving hosted behavior), and
+  seed `provider_configs` with a well-formed, **disabled**, empty entry for that
+  provider type via the factory. Plumb the optional `emailProvider` field through
+  the workflow input → `SetupTenantDataActivityInput` type chain.
+- `server/scripts/appliance-create-tenant.mjs:90-116`: pass `emailProvider: 'smtp'`
+  in the workflow input.
+- Leave the `try/catch` non-blocking behavior as is, but ensure the failure log
+  stays accurate.
+
+## Testing
+
+Unit:
+
+- `getEmailSettings` returns a well-formed SMTP entry when the row exists with
+  `provider_configs: []` (the customer's exact state), and when the row has only
+  a `resend` entry. Existing configured entries are returned untouched, and
+  secret masking still applies.
+- `updateEmailSettings` enables exactly the config named by `emailProvider` and
+  disables the others; a payload with a configured-but-disabled SMTP entry
+  persists it enabled.
+- `mergeProviderSecrets` still preserves a `***` password across the new
+  enablement normalization (regression guard on the July 1 fix).
+- `setupTenantDataInDB` seeds `email_provider: 'smtp'` with a blank disabled SMTP
+  entry when given `emailProvider: 'smtp'`, and keeps `'resend'` by default.
+
+Component (EE screen, jsdom):
+
+- With `providerConfigs: []` and `canUseManagedEmail: false`, typing into SMTP
+  Host updates state — the direct regression test for the reported bug.
+- Saving from that state sends an SMTP entry marked enabled.
+
+Manual verification (the reproduction we deliberately did not run during design):
+
+1. Set a local tenant's `provider_configs` to `[]` and `email_provider` to
+   `'resend'` to reproduce the customer's exact row.
+2. Load `/msp/settings/email` → Outbound Email with the managed-email entitlement
+   off. Confirm fields are typable, Save persists, and Test Connection runs.
+3. Confirm the DB row afterwards has a populated, **enabled** SMTP entry and
+   `email_provider: 'smtp'`.
+4. Restore the original row.
+
+## Out of scope
+
+- Rows already corrupted by a pre-July-1 build storing a literal `***` password.
+  Those cannot self-heal; the admin must retype the password. Worth a support
+  note, not code.
+- The generic error string returned by `TenantEmailService.testConnection`
+  (`:411`), which hides the real nodemailer failure (EAUTH vs ECONNREFUSED vs
+  self-signed cert) behind one message. Real diagnosability problem, separate
+  change.
+- The silent system-relay fallback in `EmailProviderManager` (`:60-63`) as a
+  design question. This plan stops the *new* way of falling into it; it does not
+  remove the fallback.
+- The orphaned duplicate `server/src/services/email/providers/SMTPEmailProvider.ts`
+  (zero importers).
+
+## Risks
+
+- **Enablement normalization** assumes a single active outbound provider. That
+  matches the data model (`emailProvider: 'smtp' | 'resend'`) and
+  `EmailProviderManager`, which selects the first enabled config. Low risk.
+- **The read boundary materializes a blank `resend` entry** for SMTP tenants,
+  which a subsequent save will persist. It is inert while disabled, and it makes
+  provider switching robust. Acceptable.
+- **No migration**, so existing broken tenants stay broken in the database until
+  an admin opens the screen and saves. That is the intended self-healing design
+  and it is what unblocks the customer.

--- a/ee/appliance/host-service/tests/appliance-temporal-tenant-bootstrap.test.mjs
+++ b/ee/appliance/host-service/tests/appliance-temporal-tenant-bootstrap.test.mjs
@@ -50,12 +50,14 @@ test('appliance Temporal client uses an idempotent fixed workflow execution', ()
   assert.match(client, /taskQueue/);
   assert.match(client, /skipCustomerTracking: true/);
   assert.match(client, /skipWelcomeEmail: true/);
+  assert.match(client, /emailProvider: 'smtp'/);
   assert.match(client, /tenantId/);
   assert.match(client, /password/);
 });
 
-test('Temporal worker image includes database exports required by onboarding seeds', () => {
+test('Temporal worker image includes package exports required by tenant setup', () => {
   const dockerfile = read('ee/temporal-workflows/Dockerfile');
+  const dockerignore = read('.dockerignore');
 
   assert.match(dockerfile, /WORKDIR \/app\/packages\/core\s+RUN npm run build/);
   assert.match(dockerfile, /WORKDIR \/app\/packages\/db\s+RUN npm run build/);
@@ -67,6 +69,13 @@ test('Temporal worker image includes database exports required by onboarding see
     dockerfile,
     /COPY --from=development \/app\/packages\/db\/dist \/app\/packages\/db\/dist/
   );
+  assert.match(dockerfile, /WORKDIR \/app\/packages\/email\s+RUN npm install --ignore-scripts && npm run build/);
+  assert.match(
+    dockerfile,
+    /COPY --from=development \/app\/packages\/email\/dist \/app\/packages\/email\/dist/
+  );
+  assert.match(dockerfile, /import\('@alga-psa\/email\/providerConfig'\)/);
+  assert.match(dockerignore, /!packages\/email\/dist\/\*\*/);
 });
 
 test('EE application image requires onboarding seed runtime package exports', () => {

--- a/ee/server/src/__tests__/unit/ManagedEmailSettings.actions.test.tsx
+++ b/ee/server/src/__tests__/unit/ManagedEmailSettings.actions.test.tsx
@@ -46,6 +46,20 @@ vi.mock('@alga-psa/integrations/actions', () => ({
   testOutboundEmail: testOutboundEmailMock,
 }));
 
+vi.mock('@alga-psa/email/providerConfig', () => ({
+  createDefaultProviderConfig: (
+    providerType: 'smtp' | 'resend',
+    { isEnabled }: { isEnabled: boolean }
+  ) => ({
+    providerId: `${providerType}-provider`,
+    providerType,
+    isEnabled,
+    config: providerType === 'smtp'
+      ? { host: '', port: 587, username: '', password: '', from: '' }
+      : { apiKey: '', from: '' },
+  }),
+}));
+
 vi.mock('server/src/context/TierContext', () => ({
   useTier: () => ({ hasFeature: () => true, isHosted: tierContextState.isHosted }),
 }));
@@ -431,5 +445,51 @@ describe('ManagedEmailSettings outbound SMTP test and TLS controls', () => {
     expect(
       screen.queryByText(/Managed email domains are not available on your current plan/i)
     ).not.toBeInTheDocument();
+  });
+
+  it('accepts SMTP host input on self-host when provider configs are empty', async () => {
+    tierContextState.isHosted = false;
+    getEmailSettingsMock.mockResolvedValue(baseSettings);
+
+    render(<ManagedEmailSettings />);
+
+    const hostInput = await screen.findByLabelText(/smtp host/i);
+    fireEvent.change(hostInput, { target: { value: 'relay.appliance.lan' } });
+
+    expect(hostInput).toHaveValue('relay.appliance.lan');
+  });
+
+  it('creates and enables the SMTP config when saving from an empty provider list', async () => {
+    tierContextState.isHosted = false;
+    getEmailSettingsMock.mockResolvedValue(baseSettings);
+    updateEmailSettingsMock.mockResolvedValue(smtpSettings);
+
+    render(<ManagedEmailSettings />);
+
+    fireEvent.change(await screen.findByLabelText(/smtp host/i), {
+      target: { value: 'relay.appliance.lan' },
+    });
+    fireEvent.change(document.getElementById('smtp-from') as HTMLInputElement, {
+      target: { value: 'support@acme.test' },
+    });
+    fireEvent.click(screen.getByRole('button', { name: /save smtp settings/i }));
+
+    await waitFor(() => {
+      expect(updateEmailSettingsMock).toHaveBeenCalledWith(
+        expect.objectContaining({
+          emailProvider: 'smtp',
+          providerConfigs: [
+            expect.objectContaining({
+              providerType: 'smtp',
+              isEnabled: true,
+              config: expect.objectContaining({
+                host: 'relay.appliance.lan',
+                from: 'support@acme.test',
+              }),
+            }),
+          ],
+        })
+      );
+    });
   });
 });

--- a/ee/server/src/components/settings/email/ManagedEmailSettings.tsx
+++ b/ee/server/src/components/settings/email/ManagedEmailSettings.tsx
@@ -34,7 +34,8 @@ import {
 } from '@ee/lib/actions/email-actions/managedDomainActions';
 import { EmailProviderConfiguration } from '@alga-psa/integrations/components';
 import type { EmailProvider } from '@alga-psa/integrations/components';
-import type { TenantEmailSettings, EmailProviderConfig } from 'server/src/types/email.types';
+import type { TenantEmailSettings } from 'server/src/types/email.types';
+import { createDefaultProviderConfig } from '@alga-psa/email/providerConfig';
 import { getEmailSettings, updateEmailSettings, getEmailProviders, testOutboundEmail } from '@alga-psa/integrations/actions';
 import ManagedDomainList from './ManagedDomainList';
 
@@ -415,12 +416,7 @@ export const ManagedEmailSettings: React.FC<EmailSettingsProps> = () => {
     // Ensure a config entry exists for the selected provider
     const hasProvider = emailSettings.providerConfigs.some(c => c.providerType === provider);
     if (!hasProvider) {
-      const newConfig: EmailProviderConfig = {
-        providerId: `${provider}-provider`,
-        providerType: provider,
-        isEnabled: true,
-        config: provider === 'smtp' ? { host: '', port: 587, username: '', password: '', from: '' } : { apiKey: '', from: '' }
-      };
+      const newConfig = createDefaultProviderConfig(provider, { isEnabled: true });
       updatedSettings.providerConfigs = [...(updatedSettings.providerConfigs || []), newConfig];
     }
 
@@ -447,9 +443,11 @@ export const ManagedEmailSettings: React.FC<EmailSettingsProps> = () => {
   const updateSmtpField = (field: string, value: string | number | boolean) => {
     if (!emailSettings) return;
     const smtpConfig = getSmtpConfig();
-    if (!smtpConfig) return;
+    const providerConfigs = smtpConfig
+      ? emailSettings.providerConfigs
+      : [...emailSettings.providerConfigs, createDefaultProviderConfig('smtp', { isEnabled: true })];
 
-    const updatedConfigs = emailSettings.providerConfigs.map(config =>
+    const updatedConfigs = providerConfigs.map(config =>
       config.providerType === 'smtp'
         ? { ...config, config: { ...config.config, [field]: value } }
         : config
@@ -458,8 +456,10 @@ export const ManagedEmailSettings: React.FC<EmailSettingsProps> = () => {
   };
 
   const persistSmtpSettings = async (): Promise<TenantEmailSettings | null> => {
-    const smtpConfig = getSmtpConfig();
-    if (!smtpConfig || !emailSettings) return null;
+    if (!emailSettings) return null;
+    const existingSmtpConfig = getSmtpConfig();
+    const smtpConfig = existingSmtpConfig
+      ?? createDefaultProviderConfig('smtp', { isEnabled: true });
 
     const { host, from } = smtpConfig.config;
     if (!host?.trim()) {
@@ -471,9 +471,17 @@ export const ManagedEmailSettings: React.FC<EmailSettingsProps> = () => {
       return null;
     }
 
+    const providerConfigs = (existingSmtpConfig
+      ? emailSettings.providerConfigs
+      : [...emailSettings.providerConfigs, smtpConfig]
+    ).map(config => ({
+      ...config,
+      isEnabled: config.providerType === 'smtp',
+    }));
+
     const updatedResult = await updateEmailSettings({
       emailProvider: 'smtp',
-      providerConfigs: emailSettings.providerConfigs,
+      providerConfigs,
       defaultFromDomain: from.trim().split('@').pop() || emailSettings.defaultFromDomain
     });
     const updated = resolveEmailSettingsResult(updatedResult, t('managed.messages.smtpSaveFailed'));

--- a/ee/temporal-workflows/Dockerfile
+++ b/ee/temporal-workflows/Dockerfile
@@ -99,6 +99,9 @@ RUN npm install --ignore-scripts && npm run build
 WORKDIR /app/packages/db
 RUN npm install --ignore-scripts && npm run build
 
+WORKDIR /app/packages/email
+RUN npm install --ignore-scripts && npm run build
+
 WORKDIR /app/ee/temporal-workflows
 RUN npm run build
 
@@ -138,6 +141,8 @@ RUN ls -la /app/ee/temporal-workflows/dist/seeds/onboarding || echo "Seeds direc
 # whitelist) — fail the build here rather than in prod if they didn't.
 RUN cd /app/ee/temporal-workflows && node --input-type=module -e "const m = await import('@alga-psa/db'); if (typeof m.tenantDb !== 'function') throw new Error('@alga-psa/db loaded but tenantDb missing')"
 
+RUN cd /app/ee/temporal-workflows && node --input-type=module -e "const m = await import('@alga-psa/email/providerConfig'); if (typeof m.createDefaultProviderConfig !== 'function') throw new Error('@alga-psa/email/providerConfig loaded but createDefaultProviderConfig missing')"
+
 # packages/licensing source is compiled INTO this dist tree, so every import
 # reachable from its root must be resolvable from here at runtime. file: deps
 # install as symlinks WITHOUT their own dependencies, so a bare third-party
@@ -172,6 +177,7 @@ COPY --from=development /app/ee/packages/workflows /app/ee/packages/workflows
 # Copy package exports used by dynamically loaded onboarding seeds.
 COPY --from=development /app/packages/core/dist /app/packages/core/dist
 COPY --from=development /app/packages/db/dist /app/packages/db/dist
+COPY --from=development /app/packages/email/dist /app/packages/email/dist
 # Copy event-schemas dist (runtime dependency of shared/workflow/streams)
 COPY --from=development /app/packages/event-schemas/dist /app/packages/event-schemas/dist
 # Copy the runtime-resolved @alga-psa package dists built above (base-stage
@@ -198,6 +204,8 @@ RUN ls -la /app/ee/temporal-workflows/dist/seeds/onboarding || echo "Seeds direc
 # onboarding seeds load it (dynamic import from node_modules). Missing
 # packages/db/dist shipped silently and broke prod tenant provisioning.
 RUN cd /app/ee/temporal-workflows && node --input-type=module -e "const m = await import('@alga-psa/db'); if (typeof m.tenantDb !== 'function') throw new Error('@alga-psa/db loaded but tenantDb missing')"
+
+RUN cd /app/ee/temporal-workflows && node --input-type=module -e "const m = await import('@alga-psa/email/providerConfig'); if (typeof m.createDefaultProviderConfig !== 'function') throw new Error('@alga-psa/email/providerConfig loaded but createDefaultProviderConfig missing')"
 
 # packages/licensing source is compiled INTO this dist tree, so every import
 # reachable from its root must be resolvable from here at runtime. file: deps

--- a/ee/temporal-workflows/package.json
+++ b/ee/temporal-workflows/package.json
@@ -27,6 +27,7 @@
   "dependencies": {
     "@alga-psa/core": "file:../../packages/core",
     "@alga-psa/db": "file:../../packages/db",
+    "@alga-psa/email": "file:../../packages/email",
     "@alga-psa/event-bus": "file:../../packages/event-bus",
     "@alga-psa/jobs": "file:../../packages/jobs",
     "@alga-psa/licensing": "file:../../packages/licensing",

--- a/ee/temporal-workflows/src/db/__tests__/tenant-operations.email-settings.test.ts
+++ b/ee/temporal-workflows/src/db/__tests__/tenant-operations.email-settings.test.ts
@@ -1,0 +1,120 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const { inserts, getAdminConnectionMock, withAdminTransactionMock } = vi.hoisted(() => ({
+  inserts: [] as Array<{ table: string; value: Record<string, unknown> }>,
+  getAdminConnectionMock: vi.fn(),
+  withAdminTransactionMock: vi.fn(),
+}));
+
+vi.mock('@temporalio/activity', () => ({
+  ApplicationFailure: class ApplicationFailure extends Error {},
+  Context: {
+    current: () => ({
+      log: {
+        info: vi.fn(),
+        warn: vi.fn(),
+        error: vi.fn(),
+      },
+    }),
+  },
+}));
+
+vi.mock('@alga-psa/db/admin.js', () => ({
+  getAdminConnection: getAdminConnectionMock,
+  withAdminTransactionRetryReadOnly: withAdminTransactionMock,
+}));
+
+vi.mock('@alga-psa/db', () => ({
+  tenantDb: () => ({
+    table: (table: string) => ({
+      insert: async (value: Record<string, unknown>) => {
+        inserts.push({ table, value });
+        return 1;
+      },
+      select: async () => [],
+    }),
+  }),
+}));
+
+vi.mock('@alga-psa/email/providerConfig', () => ({
+  createDefaultProviderConfig: (
+    providerType: 'smtp' | 'resend',
+    { isEnabled }: { isEnabled: boolean }
+  ) => ({
+    providerId: `${providerType}-provider`,
+    providerType,
+    isEnabled,
+    config: providerType === 'smtp'
+      ? { host: '', port: 587, username: '', password: '', from: '' }
+      : { apiKey: '', from: '' },
+  }),
+}));
+
+vi.mock('../../services/stripe-service.js', () => ({
+  updateSubscriptionMetadata: vi.fn(),
+}));
+
+vi.mock('@alga-psa/core/secrets', () => ({
+  getSecret: vi.fn(),
+}));
+
+vi.mock('@ee/lib/stripe/stripeTierMapping.js', () => ({
+  tierFromStripeProduct: vi.fn(),
+}));
+
+describe('setupTenantDataInDB email settings seed', () => {
+  beforeEach(() => {
+    inserts.length = 0;
+    getAdminConnectionMock.mockReset();
+    withAdminTransactionMock.mockReset();
+
+    const knex = { fn: { now: () => new Date('2026-07-14T00:00:00.000Z') } };
+    const trx = { raw: (sql: string) => sql };
+    getAdminConnectionMock.mockResolvedValue(knex);
+    withAdminTransactionMock.mockImplementation(async (callback: (trx: unknown) => unknown) => callback(trx));
+  });
+
+  it('seeds a blank disabled SMTP config when explicitly requested', async () => {
+    const { setupTenantDataInDB } = await import('../tenant-operations');
+
+    await setupTenantDataInDB({
+      tenantId: 'tenant-appliance',
+      adminUserId: 'admin-1',
+      emailProvider: 'smtp',
+    });
+
+    const emailSettings = inserts.find(insert => insert.table === 'tenant_email_settings');
+    expect(emailSettings?.value).toMatchObject({
+      tenant: 'tenant-appliance',
+      email_provider: 'smtp',
+    });
+    expect(JSON.parse(emailSettings?.value.provider_configs as string)).toEqual([
+      {
+        providerId: 'smtp-provider',
+        providerType: 'smtp',
+        isEnabled: false,
+        config: { host: '', port: 587, username: '', password: '', from: '' },
+      },
+    ]);
+  });
+
+  it('keeps Resend as the hosted default and seeds it disabled', async () => {
+    const { setupTenantDataInDB } = await import('../tenant-operations');
+
+    await setupTenantDataInDB({
+      tenantId: 'tenant-hosted',
+      adminUserId: 'admin-2',
+    });
+
+    const emailSettings = inserts.find(insert => insert.table === 'tenant_email_settings');
+    expect(emailSettings?.value.email_provider).toBe('resend');
+    expect(JSON.parse(emailSettings?.value.provider_configs as string)).toEqual([
+      {
+        providerId: 'resend-provider',
+        providerType: 'resend',
+        isEnabled: false,
+        config: { apiKey: '', from: '' },
+      },
+    ]);
+  });
+});

--- a/ee/temporal-workflows/src/db/tenant-operations.ts
+++ b/ee/temporal-workflows/src/db/tenant-operations.ts
@@ -13,6 +13,7 @@ import { getSecret } from '@alga-psa/core/secrets';
 import { tierFromStripeProduct } from '@ee/lib/stripe/stripeTierMapping.js';
 import { normalizeProductCode } from './product-bootstrap-resolver.js';
 import type { SeedRunLog } from './onboarding-seeds-operations.js';
+import { createDefaultProviderConfig } from '@alga-psa/email/providerConfig';
 
 const logger = () => Context.current().log;
 const TENANT_CREATION_SUBSCRIPTION_DISCOVERY_CONTEXT = 'tenant-creation-subscription-discovery';
@@ -423,10 +424,14 @@ export async function setupTenantDataInDB(
       const db = tenantDb(trx, input.tenantId);
       // Set up tenant email settings with defaults (simple insert, no ON CONFLICT to avoid distributed table issues)
       try {
+        const emailProvider = input.emailProvider ?? 'resend';
         await db.table('tenant_email_settings')
           .insert({
             tenant: input.tenantId,
-            email_provider: 'resend',
+            email_provider: emailProvider,
+            provider_configs: JSON.stringify([
+              createDefaultProviderConfig(emailProvider, { isEnabled: false }),
+            ]),
             fallback_enabled: true,
             tracking_enabled: false
           });

--- a/ee/temporal-workflows/src/types/workflow-types.ts
+++ b/ee/temporal-workflows/src/types/workflow-types.ts
@@ -34,6 +34,7 @@ export interface TenantCreationInput {
   companyName?: string;
   clientName?: string;
   contractLine?: string;
+  emailProvider?: 'smtp' | 'resend';
   licenseCount?: number; // Number of licenses for the tenant
   checkoutSessionId?: string; // Stripe checkout session ID for status updates
 
@@ -133,6 +134,7 @@ export interface SetupTenantDataActivityInput {
   adminUserId: string;
   clientId?: string;
   contractLine?: string;
+  emailProvider?: 'smtp' | 'resend';
 }
 
 export interface SetupTenantDataActivityResult {

--- a/ee/temporal-workflows/src/workflows/__tests__/tenant-creation-appliance.test.ts
+++ b/ee/temporal-workflows/src/workflows/__tests__/tenant-creation-appliance.test.ts
@@ -15,6 +15,7 @@ import type { TenantCreationInput } from '../../types/workflow-types.js';
 interface RecordedCalls {
   createTenant: any[];
   createAdminUser: any[];
+  setupTenantData: any[];
   customerTracking: number;
   welcomeEmail: number;
 }
@@ -25,6 +26,7 @@ async function setupWorkflowTest() {
   const calls: RecordedCalls = {
     createTenant: [],
     createAdminUser: [],
+    setupTenantData: [],
     customerTracking: 0,
     welcomeEmail: 0,
   };
@@ -43,7 +45,10 @@ async function setupWorkflowTest() {
         temporaryPassword: input.password ?? 'generated-password',
       };
     },
-    setupTenantData: async () => ({ setupSteps: ['tenant_settings'] }),
+    setupTenantData: async (input: any) => {
+      calls.setupTenantData.push(input);
+      return { setupSteps: ['tenant_settings'] };
+    },
     sendWelcomeEmail: async () => {
       calls.welcomeEmail += 1;
       return { emailSent: true };
@@ -104,6 +109,7 @@ describe('tenantCreationWorkflow appliance mode', () => {
               tenantId: 'pre-minted-tenant-id',
               adminUser: { ...baseInput.adminUser, password: 'operator-chosen-password' },
               billingSource: 'manual',
+              emailProvider: 'smtp',
               skipCustomerTracking: true,
               skipWelcomeEmail: true,
             },
@@ -117,6 +123,7 @@ describe('tenantCreationWorkflow appliance mode', () => {
       expect(result.tenantId).toBe('pre-minted-tenant-id');
       expect(calls.createTenant[0].tenantId).toBe('pre-minted-tenant-id');
       expect(calls.createAdminUser[0].password).toBe('operator-chosen-password');
+      expect(calls.setupTenantData[0].emailProvider).toBe('smtp');
       expect(calls.customerTracking).toBe(0);
       expect(calls.welcomeEmail).toBe(0);
       expect(result.emailSent).toBe(false);
@@ -140,6 +147,7 @@ describe('tenantCreationWorkflow appliance mode', () => {
       expect(result.tenantId).toBe('generated-tenant-id');
       expect(calls.createTenant[0].tenantId).toBeUndefined();
       expect(calls.createAdminUser[0].password).toBeUndefined();
+      expect(calls.setupTenantData[0].emailProvider).toBeUndefined();
       expect(calls.customerTracking).toBe(3);
       expect(calls.welcomeEmail).toBe(1);
       expect(result.emailSent).toBe(true);

--- a/ee/temporal-workflows/src/workflows/shared/tenant-creation-steps.ts
+++ b/ee/temporal-workflows/src/workflows/shared/tenant-creation-steps.ts
@@ -62,6 +62,7 @@ const activities = proxyActivities<{
     adminUserId: string;
     clientId?: string;
     contractLine?: string;
+    emailProvider?: 'smtp' | 'resend';
   }): Promise<SetupTenantDataActivityResult>;
   run_onboarding_seeds(input: {
     tenantId: string;
@@ -309,6 +310,7 @@ export async function runTenantCreationOrchestration(
       adminUserId: userResult.userId,
       clientId: tenantResult.clientId,
       contractLine: input.contractLine,
+      emailProvider: input.emailProvider,
     });
 
     workflowState.progress = 90;

--- a/ee/temporal-workflows/vitest.config.ts
+++ b/ee/temporal-workflows/vitest.config.ts
@@ -38,6 +38,7 @@ export default defineConfig({
       { find: /^@ee\/(.*)$/, replacement: `${path.resolve(__dirname, '../server/src')}/$1` },
       { find: /^@\/(.*)$/, replacement: `${path.resolve(__dirname, './src')}/$1` },
       { find: /^@shared\/(.*)$/, replacement: `${path.resolve(__dirname, '../../shared')}/$1` },
+      { find: /^@ee\/(.*)$/, replacement: `${path.resolve(__dirname, '../server/src')}/$1` },
       { find: /^@alga-psa\/shared$/, replacement: path.resolve(__dirname, '../../shared') },
       { find: /^@alga-psa\/shared\/(.*)$/, replacement: `${path.resolve(__dirname, '../../shared')}/$1` },
       // Workspace packages resolved from source — their package.json entries

--- a/package-lock.json
+++ b/package-lock.json
@@ -529,6 +529,7 @@
       "dependencies": {
         "@alga-psa/core": "file:../../packages/core",
         "@alga-psa/db": "file:../../packages/db",
+        "@alga-psa/email": "file:../../packages/email",
         "@alga-psa/event-bus": "file:../../packages/event-bus",
         "@alga-psa/jobs": "file:../../packages/jobs",
         "@alga-psa/licensing": "file:../../packages/licensing",
@@ -46484,6 +46485,7 @@
       "dependencies": {
         "@alga-psa/core": "file:../core",
         "@alga-psa/db": "file:../db",
+        "@alga-psa/email": "file:../email",
         "@alga-psa/event-bus": "file:../event-bus",
         "@alga-psa/shared": "file:../../shared",
         "@alga-psa/types": "file:../types",

--- a/packages/email/package.json
+++ b/packages/email/package.json
@@ -11,6 +11,11 @@
       "types": "./src/index.ts",
       "import": "./dist/index.js",
       "require": "./dist/index.cjs"
+    },
+    "./providerConfig": {
+      "types": "./src/providerConfig.ts",
+      "import": "./dist/providerConfig.js",
+      "require": "./dist/providerConfig.cjs"
     }
   },
   "scripts": {

--- a/packages/email/src/__tests__/providerConfig.test.ts
+++ b/packages/email/src/__tests__/providerConfig.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, it } from 'vitest';
+import { createDefaultProviderConfig } from '../providerConfig';
+
+describe('createDefaultProviderConfig', () => {
+  it('creates a blank SMTP config with the requested enablement', () => {
+    expect(createDefaultProviderConfig('smtp', { isEnabled: false })).toEqual({
+      providerId: 'smtp-provider',
+      providerType: 'smtp',
+      isEnabled: false,
+      config: {
+        host: '',
+        port: 587,
+        username: '',
+        password: '',
+        from: '',
+      },
+    });
+  });
+
+  it('creates a blank Resend config with the requested enablement', () => {
+    expect(createDefaultProviderConfig('resend', { isEnabled: true })).toEqual({
+      providerId: 'resend-provider',
+      providerType: 'resend',
+      isEnabled: true,
+      config: {
+        apiKey: '',
+        from: '',
+      },
+    });
+  });
+});

--- a/packages/email/src/index.ts
+++ b/packages/email/src/index.ts
@@ -59,3 +59,9 @@ export { SystemEmailProviderFactory } from './system/SystemEmailProviderFactory'
 
 // Tenant email provider manager
 export { EmailProviderManager } from './providers/EmailProviderManager';
+
+// Shared settings defaults
+export {
+  createDefaultProviderConfig,
+  type EditableEmailProviderType,
+} from './providerConfig';

--- a/packages/email/src/providerConfig.ts
+++ b/packages/email/src/providerConfig.ts
@@ -1,0 +1,26 @@
+import type { EmailProviderConfig, TenantEmailSettings } from '@alga-psa/types';
+
+export type EditableEmailProviderType = TenantEmailSettings['emailProvider'];
+
+export function createDefaultProviderConfig(
+  providerType: EditableEmailProviderType,
+  { isEnabled }: { isEnabled: boolean }
+): EmailProviderConfig {
+  return {
+    providerId: `${providerType}-provider`,
+    providerType,
+    isEnabled,
+    config: providerType === 'smtp'
+      ? {
+          host: '',
+          port: 587,
+          username: '',
+          password: '',
+          from: '',
+        }
+      : {
+          apiKey: '',
+          from: '',
+        },
+  };
+}

--- a/packages/email/tsup.config.ts
+++ b/packages/email/tsup.config.ts
@@ -1,7 +1,7 @@
 import { defineConfig } from 'tsup';
 
 export default defineConfig({
-  entry: ['src/index.ts'],
+  entry: ['src/index.ts', 'src/providerConfig.ts'],
   format: ['esm', 'cjs'],
   dts: false,
   bundle: true,

--- a/packages/integrations/package.json
+++ b/packages/integrations/package.json
@@ -39,6 +39,7 @@
   "dependencies": {
     "@alga-psa/core": "file:../core",
     "@alga-psa/db": "file:../db",
+    "@alga-psa/email": "file:../email",
     "@alga-psa/event-bus": "file:../event-bus",
     "@alga-psa/shared": "file:../../shared",
     "@alga-psa/types": "file:../types",

--- a/packages/integrations/src/actions/email-actions/emailSettingsActions.clear.test.ts
+++ b/packages/integrations/src/actions/email-actions/emailSettingsActions.clear.test.ts
@@ -21,6 +21,20 @@ vi.mock('@alga-psa/email', () => ({
   },
 }));
 
+vi.mock('@alga-psa/email/providerConfig', () => ({
+  createDefaultProviderConfig: (
+    providerType: 'smtp' | 'resend',
+    { isEnabled }: { isEnabled: boolean }
+  ) => ({
+    providerId: `${providerType}-provider`,
+    providerType,
+    isEnabled,
+    config: providerType === 'smtp'
+      ? { host: '', port: 587, username: '', password: '', from: '' }
+      : { apiKey: '', from: '' },
+  }),
+}));
+
 describe('updateEmailSettings clear behavior', () => {
   beforeEach(() => {
     createTenantKnexMock.mockReset();

--- a/packages/integrations/src/actions/email-actions/emailSettingsActions.providers.test.ts
+++ b/packages/integrations/src/actions/email-actions/emailSettingsActions.providers.test.ts
@@ -1,0 +1,186 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import type { EmailProviderConfig, TenantEmailSettings } from '@alga-psa/types';
+
+const { createTenantKnexMock, getTenantEmailSettingsMock } = vi.hoisted(() => ({
+  createTenantKnexMock: vi.fn(),
+  getTenantEmailSettingsMock: vi.fn(),
+}));
+
+vi.mock('@alga-psa/db', () => ({
+  createTenantKnex: createTenantKnexMock,
+  tenantDb: (conn: any, tenant: string) => ({
+    table: (table: string) => conn(table).where({ tenant }),
+  }),
+}));
+
+vi.mock('@alga-psa/auth', () => ({
+  withAuth: (fn: any) => async (...args: any[]) =>
+    fn({ id: 'user-1' }, { tenant: 'tenant-123' }, ...args),
+}));
+
+vi.mock('@alga-psa/email', () => ({
+  TenantEmailService: {
+    getTenantEmailSettings: getTenantEmailSettingsMock,
+  },
+}));
+
+vi.mock('@alga-psa/email/providerConfig', () => ({
+  createDefaultProviderConfig: (
+    providerType: 'smtp' | 'resend',
+    { isEnabled }: { isEnabled: boolean }
+  ): EmailProviderConfig => ({
+    providerId: `${providerType}-provider`,
+    providerType,
+    isEnabled,
+    config: providerType === 'smtp'
+      ? { host: '', port: 587, username: '', password: '', from: '' }
+      : { apiKey: '', from: '' },
+  }),
+}));
+
+function buildSettings(
+  emailProvider: TenantEmailSettings['emailProvider'],
+  providerConfigs: EmailProviderConfig[]
+): TenantEmailSettings {
+  return {
+    tenantId: 'tenant-123',
+    customDomains: [],
+    emailProvider,
+    providerConfigs,
+    trackingEnabled: false,
+    createdAt: new Date('2026-07-01T00:00:00.000Z'),
+    updatedAt: new Date('2026-07-01T00:00:00.000Z'),
+  };
+}
+
+describe('email settings provider invariants', () => {
+  beforeEach(() => {
+    createTenantKnexMock.mockReset();
+    getTenantEmailSettingsMock.mockReset();
+    createTenantKnexMock.mockResolvedValue({ knex: vi.fn() });
+  });
+
+  it('materializes editable provider configs for an existing empty settings row', async () => {
+    getTenantEmailSettingsMock.mockResolvedValue(buildSettings('resend', []));
+
+    const { getEmailSettings } = await import('./emailSettingsActions');
+    const result = await getEmailSettings();
+
+    expect(result).toMatchObject({
+      emailProvider: 'resend',
+      providerConfigs: [
+        {
+          providerId: 'smtp-provider',
+          providerType: 'smtp',
+          isEnabled: false,
+          config: { host: '', port: 587, username: '', password: '', from: '' },
+        },
+        {
+          providerId: 'resend-provider',
+          providerType: 'resend',
+          isEnabled: true,
+          config: { apiKey: '', from: '' },
+        },
+      ],
+    });
+  });
+
+  it('preserves an existing provider and only adds the missing editable provider', async () => {
+    const resendConfig: EmailProviderConfig = {
+      providerId: 'custom-resend',
+      providerType: 'resend',
+      isEnabled: true,
+      config: { apiKey: 'secret-key', from: 'support@acme.test' },
+      rateLimits: { perDay: 500 },
+    };
+    getTenantEmailSettingsMock.mockResolvedValue(buildSettings('resend', [resendConfig]));
+
+    const { getEmailSettings } = await import('./emailSettingsActions');
+    const result = await getEmailSettings();
+
+    expect(result).toMatchObject({
+      emailProvider: 'resend',
+      providerConfigs: [
+        {
+          providerId: 'custom-resend',
+          providerType: 'resend',
+          isEnabled: true,
+          config: { apiKey: '***', from: 'support@acme.test' },
+          rateLimits: { perDay: 500 },
+        },
+        {
+          providerId: 'smtp-provider',
+          providerType: 'smtp',
+          isEnabled: false,
+        },
+      ],
+    });
+  });
+
+  it('normalizes enablement and preserves masked secrets when changing provider', async () => {
+    const existingSettings = buildSettings('resend', [
+      {
+        providerId: 'smtp-provider',
+        providerType: 'smtp',
+        isEnabled: false,
+        config: {
+          host: 'relay.acme.test',
+          port: 587,
+          username: 'mailer',
+          password: 'stored-password',
+          from: 'support@acme.test',
+        },
+      },
+      {
+        providerId: 'resend-provider',
+        providerType: 'resend',
+        isEnabled: true,
+        config: { apiKey: 'stored-api-key', from: 'support@acme.test' },
+      },
+    ]);
+    const updateMock = vi.fn(async (_value: Record<string, unknown>) => 1);
+    const whereMock = vi.fn(() => ({
+      first: vi.fn(async () => ({ tenant: 'tenant-123' })),
+      update: updateMock,
+    }));
+    const knexMock = vi.fn(() => ({
+      where: whereMock,
+      insert: vi.fn(async () => 1),
+    })) as any;
+    createTenantKnexMock.mockResolvedValue({ knex: knexMock });
+    getTenantEmailSettingsMock
+      .mockResolvedValueOnce(existingSettings)
+      .mockResolvedValueOnce({ ...existingSettings, emailProvider: 'smtp' });
+
+    const { updateEmailSettings } = await import('./emailSettingsActions');
+    await updateEmailSettings({
+      emailProvider: 'smtp',
+      providerConfigs: existingSettings.providerConfigs.map(config => ({
+        ...config,
+        config: {
+          ...config.config,
+          ...(config.providerType === 'smtp'
+            ? { password: '***' }
+            : { apiKey: '***' }),
+        },
+      })),
+    });
+
+    expect(updateMock).toHaveBeenCalledOnce();
+    const persistedPayload = updateMock.mock.calls[0]?.[0];
+    expect(persistedPayload).toBeDefined();
+    const persisted = JSON.parse(persistedPayload?.provider_configs as string);
+    expect(persisted).toEqual([
+      expect.objectContaining({
+        providerType: 'smtp',
+        isEnabled: true,
+        config: expect.objectContaining({ password: 'stored-password' }),
+      }),
+      expect.objectContaining({
+        providerType: 'resend',
+        isEnabled: false,
+        config: expect.objectContaining({ apiKey: 'stored-api-key' }),
+      }),
+    ]);
+  });
+});

--- a/packages/integrations/src/actions/email-actions/emailSettingsActions.ts
+++ b/packages/integrations/src/actions/email-actions/emailSettingsActions.ts
@@ -8,6 +8,7 @@ import { createTenantKnex, tenantDb } from '@alga-psa/db';
 import { withAuth } from '@alga-psa/auth';
 import type { EmailProviderConfig, TenantEmailSettings } from '@alga-psa/types';
 import { TenantEmailService } from '@alga-psa/email';
+import { createDefaultProviderConfig } from '@alga-psa/email/providerConfig';
 import {
   actionError,
   isActionMessageError,
@@ -24,6 +25,21 @@ type EmailSettingsUpdateInput = Partial<TenantEmailSettings> & {
 // sent to the browser. On save it means "unchanged" — restore the real value.
 const SECRET_MASK = '***';
 const SECRET_FIELDS = ['password', 'apiKey'] as const;
+const EDITABLE_PROVIDER_TYPES = ['smtp', 'resend'] as const;
+
+function withEditableProviderConfigs(settings: TenantEmailSettings): TenantEmailSettings {
+  const providerConfigs = [...(settings.providerConfigs ?? [])];
+
+  for (const providerType of EDITABLE_PROVIDER_TYPES) {
+    if (!providerConfigs.some(config => config.providerType === providerType)) {
+      providerConfigs.push(createDefaultProviderConfig(providerType, {
+        isEnabled: providerType === settings.emailProvider,
+      }));
+    }
+  }
+
+  return { ...settings, providerConfigs };
+}
 
 function mergeProviderSecrets(
   incoming: EmailProviderConfig[],
@@ -81,6 +97,7 @@ export const getEmailSettings = withAuth(async (
 
     if (!settings) {
       // Return default settings if none exist
+      const defaultSmtpConfig = createDefaultProviderConfig('smtp', { isEnabled: true });
       const defaultSettings: TenantEmailSettings = {
         tenantId: tenant || '',
         defaultFromDomain: process.env.EMAIL_FROM ? extractDomain(process.env.EMAIL_FROM) || undefined : undefined,
@@ -88,26 +105,23 @@ export const getEmailSettings = withAuth(async (
         ticketingFromName: null,
         customDomains: [],
         emailProvider: 'smtp',
-        providerConfigs: [
-          {
-            providerId: 'default-smtp',
-            providerType: 'smtp',
-            isEnabled: true,
-            config: {
-              host: process.env.EMAIL_HOST || '',
-              port: parseInt(process.env.EMAIL_PORT || '587'),
-              username: process.env.EMAIL_USERNAME || '',
-              password: '', // Don't expose password
-              from: process.env.EMAIL_FROM || ''
-            }
+        providerConfigs: [{
+          ...defaultSmtpConfig,
+          config: {
+            ...defaultSmtpConfig.config,
+            host: process.env.EMAIL_HOST || '',
+            port: parseInt(process.env.EMAIL_PORT || '587'),
+            username: process.env.EMAIL_USERNAME || '',
+            password: '', // Don't expose password
+            from: process.env.EMAIL_FROM || ''
           }
-        ],
+        }],
         trackingEnabled: false,
         createdAt: new Date(),
         updatedAt: new Date()
       };
       
-      return defaultSettings;
+      return withEditableProviderConfigs(defaultSettings);
     }
 
     // Don't expose sensitive data like passwords and API keys in full
@@ -123,7 +137,7 @@ export const getEmailSettings = withAuth(async (
       }))
     };
 
-    return sanitizedSettings;
+    return withEditableProviderConfigs(sanitizedSettings);
   } catch (error: any) {
     console.error('Error fetching email settings:', error);
     return actionError('Failed to fetch email settings');
@@ -152,6 +166,16 @@ export const updateEmailSettings = withAuth(async (
       ? normalizeOptionalString(updates.ticketingFromName)
       : existingSettings?.ticketingFromName ?? null;
 
+    const mergedProviderConfigs = updates.providerConfigs
+      ? mergeProviderSecrets(updates.providerConfigs, existingSettings?.providerConfigs)
+      : existingSettings?.providerConfigs ?? [];
+    const normalizedProviderConfigs = updates.emailProvider
+      ? mergedProviderConfigs.map(config => ({
+          ...config,
+          isEnabled: config.providerType === updates.emailProvider,
+        }))
+      : mergedProviderConfigs;
+
     const mergedSettings: TenantEmailSettings = {
       tenantId: tenant || '',
       defaultFromDomain: nextDefaultFromDomain,
@@ -159,9 +183,7 @@ export const updateEmailSettings = withAuth(async (
       ticketingFromName: nextTicketingFromName,
       customDomains: updates.customDomains ?? existingSettings?.customDomains ?? [],
       emailProvider: updates.emailProvider ?? existingSettings?.emailProvider ?? 'smtp',
-      providerConfigs: updates.providerConfigs
-        ? mergeProviderSecrets(updates.providerConfigs, existingSettings?.providerConfigs)
-        : existingSettings?.providerConfigs ?? [],
+      providerConfigs: normalizedProviderConfigs,
       trackingEnabled: updates.trackingEnabled ?? existingSettings?.trackingEnabled ?? false,
       maxDailyEmails: updates.maxDailyEmails ?? existingSettings?.maxDailyEmails,
       createdAt: existingSettings?.createdAt ?? now,

--- a/packages/integrations/src/components/email/admin/EmailSettings.tsx
+++ b/packages/integrations/src/components/email/admin/EmailSettings.tsx
@@ -16,10 +16,8 @@ import { Switch } from '@alga-psa/ui/components/Switch';
 import { Badge } from '@alga-psa/ui/components/Badge';
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '@alga-psa/ui/components/Tabs';
 import { Mail, Globe, Settings, CheckCircle, XCircle, Clock, Eye, EyeOff, Send, Inbox } from 'lucide-react';
-import {
-  TenantEmailSettings,
-  EmailProviderConfig
-} from '@alga-psa/types';
+import type { TenantEmailSettings } from '@alga-psa/types';
+import { createDefaultProviderConfig } from '@alga-psa/email/providerConfig';
 import {
   getEmailSettings,
   updateEmailSettings,
@@ -212,21 +210,7 @@ export const EmailSettings: React.FC<EmailSettingsProps> = () => {
     // Ensure we have a config for the selected provider
     const hasProvider = updatedSettings.providerConfigs.some(config => config.providerType === providerType);
     if (!hasProvider) {
-      const newConfig: EmailProviderConfig = {
-        providerId: `${providerType}-provider`,
-        providerType: providerType,
-        isEnabled: true,
-        config: providerType === 'smtp' ? {
-          host: '',
-          port: 587,
-          username: '',
-          password: '',
-          from: ''
-        } : {
-          apiKey: '',
-          from: ''
-        }
-      };
+      const newConfig = createDefaultProviderConfig(providerType, { isEnabled: true });
       updatedSettings.providerConfigs.push(newConfig);
     }
 
@@ -246,9 +230,7 @@ export const EmailSettings: React.FC<EmailSettingsProps> = () => {
   };
 
   const getCurrentProviderConfig = () => {
-    return settings?.providerConfigs.find(config =>
-      config.providerType === selectedProvider && config.isEnabled
-    );
+    return settings?.providerConfigs.find(config => config.providerType === selectedProvider);
   };
 
   const renderSMTPConfig = () => {

--- a/server/scripts/appliance-create-tenant.mjs
+++ b/server/scripts/appliance-create-tenant.mjs
@@ -79,6 +79,7 @@ const input = {
   companyName: tenantName,
   clientName: tenantName,
   productCode: 'psa',
+  emailProvider: 'smtp',
   billingSource: 'manual',
   tenantId,
   skipCustomerTracking: true,


### PR DESCRIPTION
## Summary

- Restore appliance SMTP editing when the persisted tenant row names Resend but has no provider configs by materializing editable SMTP and Resend configs at the read boundary and creating SMTP state on first edit/save.
- Centralize default provider construction, normalize the enabled provider on writes, and make CE provider editing independent of stale `isEnabled` flags.
- Seed appliance-created tenants explicitly for SMTP with a blank disabled config, preserving system-relay fallback, and package the shared email export in the Temporal worker image.
- Add focused coverage for provider materialization, secret preservation, managed SMTP editing, appliance tenant input, Temporal tenant creation, and package export resolution.

## Smoke test

**PASS.** Exercised the real EE appliance-style UI on port 3485 against the exact broken state (`email_provider=resend`, `provider_configs=[]`). The static SMTP form rendered without a provider selector, accepted native typing, saved successfully, and self-healed the DB to SMTP enabled/Resend disabled. Values survived reload. Test Connection sent a real message through the existing Mailpit simulator; both the product success state and received email were captured. Confirmed reads materialize the form without writing to the DB, then restored the tenant’s original row.

No mocks or custom simulators were used. Final app readiness was HTTP 200 with no new browser/network errors. The full Temporal Docker image and appliance tenant-creation workflow were not run; Docker wiring was reviewed and the Temporal package successfully resolved the built email export host-side. The local stack lacks reachable Temporal, so EE startup logged unrelated Temporal job-runner/scheduling failures. The pre-existing uncommitted package-lock change remains untouched.

Evidence: `/tmp/alga-smoke-evidence/dee-smtp-issue-20260714-175703`

## Validation

- Focused email action, CE/EE component, provider factory, appliance bootstrap, and Temporal tenant-creation tests passed.
- Affected typechecks passed.
- Email, Temporal, and Nx integrations builds passed.
