### PR TITLE
Gate Opportunities settings menu with feature flag

### DIFF
--- a/server/src/components/layout/SidebarWithFeatureFlags.tsx
+++ b/server/src/components/layout/SidebarWithFeatureFlags.tsx
@@ -153,11 +153,17 @@ export default function SidebarWithFeatureFlags(props: SidebarWithFeatureFlagsPr
   }, [canWorkflowAdmin, useNavigationSections, hasFeature, productCode, opportunitiesEnabled]);
 
   const settingsSections = useMemo<NavigationSection[]>(() => {
+    const productSections = filterMenuSectionsByProduct(productCode, settingsNavigationSections);
+    const opportunitiesFilteredSections = productSections.map((section) => ({
+      ...section,
+      items: section.items.filter((item) => item.name !== 'Opportunities' || opportunitiesEnabled),
+    }));
+
     return filterNavigationSectionsBySelfHost(
-      filterMenuSectionsByProduct(productCode, settingsNavigationSections),
+      opportunitiesFilteredSections,
       selfHostMode,
     );
-  }, [productCode, selfHostMode]);
+  }, [opportunitiesEnabled, productCode, selfHostMode]);
 
   return (
     <Sidebar

--- a/server/src/test/unit/layout/SidebarWithFeatureFlags.productShell.test.tsx
+++ b/server/src/test/unit/layout/SidebarWithFeatureFlags.productShell.test.tsx
@@ -78,6 +78,23 @@ describe('SidebarWithFeatureFlags product shell composition', () => {
     expect(names).not.toContain('License');
   });
 
+  it('hides Opportunities from settings navigation when its feature flag is disabled', async () => {
+    useFeatureFlag.mockImplementation((flagKey: string) => flagKey !== 'opportunities-module');
+
+    render(<SidebarWithFeatureFlags sidebarOpen={true} setSidebarOpen={vi.fn()} />);
+
+    await waitFor(() => expect(sidebarPropsSpy).toHaveBeenCalled());
+
+    const latestProps = sidebarPropsSpy.mock.calls.at(-1)?.[0] as {
+      settingsSectionsOverride: Array<{ items: Array<{ name: string }> }>;
+    };
+    const settingsNames = latestProps.settingsSectionsOverride.flatMap((section) =>
+      section.items.map((item) => item.name),
+    );
+
+    expect(settingsNames).not.toContain('Opportunities');
+  });
+
   it('T005: AlgaDesk shell keeps only allowed nav and uses AlgaDesk branding labels', async () => {
     useProduct.mockReturnValue({ productCode: 'algadesk' });
 


### PR DESCRIPTION
## What changed

- Filter the Opportunities entry from Settings navigation when `opportunities-module` is disabled.
- Reuse the flag value already loaded for the main navigation.
- Add a behavioral test covering the disabled Settings-menu state.

## Why

The main Opportunities navigation item already respected the feature flag, but the Opportunities setup entry under Settings did not. Users without the flag could therefore still see that setup menu item.

## Impact

Users without `opportunities-module` no longer see Opportunities in Settings navigation. Direct URL behavior is unchanged.

## Validation

- `npx vitest run src/test/unit/layout/SidebarWithFeatureFlags.productShell.test.tsx --coverage.enabled=false`
- `npm run typecheck`