### PR TITLE
Alex from IT ninjaone issue

### DIFF
--- a/docs/plans/2026-07-14-client-type-normalization-plan.md
+++ b/docs/plans/2026-07-14-client-type-normalization-plan.md
@@ -1,0 +1,214 @@
+# Fix: NinjaOne organizations cannot be mapped to Alga clients
+
+**Branch:** `fix/ninjaone-alex-it-issue`
+**Date:** 2026-07-14
+**Reported by:** Alex IT — "When integrating NinjaOne, I am unable to map my Ninja Companies to clients in Alga."
+
+## Summary
+
+The reported symptom is in NinjaOne, but the bug is not. `importClientsFromCSV` writes
+`client_type` straight from the spreadsheet cell into a database column that has no
+constraint. Alex imported his client list with the column reading `Company` — the
+natural thing a human types in a spreadsheet — so 41 of his 42 clients landed with
+`client_type = 'Company'`, capital C.
+
+Every reader compares `client_type === 'company'`, lowercase. So all 41 clients became
+invisible to the NinjaOne mapping picker, which reports "No clients found." The Clients
+page still lists them normally, because it renders the raw value through an i18n
+`defaultValue` fallback and happily displays `Company` — which is what made this hard to
+see.
+
+The `ClientPicker` on the mapping screen also hardcodes `clientTypeFilter="company"` and
+passes `() => {}` for both filter-change handlers, so its "Active Clients" / "Companies"
+dropdowns render but do nothing. Alex could not even work around the data problem by
+switching to "All Types".
+
+Fix all three layers: the writer that let the value in, the schema that permitted it, and
+the component contract that made the workaround impossible.
+
+## Evidence
+
+Production (`msp` namespace, via `sebastian-blue`):
+
+| `client_type` | rows | first seen | last seen |
+|---|---|---|---|
+| `company` | 1466 | 2024-10-25 | 2026-07-14 |
+| `Company` | 41 | 2026-07-06 | 2026-07-08 |
+| `NULL` | 33 | 2024-11-12 | 2026-04-22 |
+| `individual` | 19 | 2024-10-25 | 2026-05-14 |
+
+- All 41 `'Company'` rows belong to Alex's tenant `5c6c48a0-9b69-4511-bd91-16991d7153aa`.
+  That tenant has exactly one `'company'` client — the only one his picker can show.
+- Those rows were created 2026-07-06..08, *after* migration
+  `20260616120000_normalize_client_type_to_enum.cjs` ran on 2026-06-16. That migration
+  cleaned this exact corruption once; it came straight back, because it fixed the data
+  and not the writer. A data-only fix will regress a third time.
+- `clients` is Citus hash-distributed (`partmethod: 'h'`) and **already carries a CHECK
+  constraint of this exact shape** — `clients_billing_cycle_check`. Citus restricts
+  primary-key/unique (must include the distribution column) and foreign keys, which is why
+  `20260619120000_add_default_contact_to_rmm_org_mappings.cjs` skipped its FK. CHECK
+  constraints are row-local and propagate to shards. Citus is not a blocker here.
+
+`importClientsFromCSV` is the **only** writer with this hole. Verified: the v1 API
+(`ClientService.ts:274`) takes its value from the zod enum in `CreateClientSchema`, and
+`xeroCsvClientSyncService.ts:718` hardcodes `'company'`.
+
+Note that `IClient.client_type` is *already* typed `'company' | 'individual' | null`
+(`packages/types/src/interfaces/client.interfaces.ts:16`). The importer's parameter is
+`Array<Record<string, any>>`, and that `any` launders the bad value past the type system
+into the database. The invariant was declared; it just was not enforced anywhere.
+
+### Blast radius beyond NinjaOne
+
+The corruption is not cosmetic. Two readers branch on the exact string and silently treat
+every one of Alex's 41 clients as an *individual*, changing contact-selection behavior in
+ticket creation. He has not reported this yet, but it is live:
+
+- `packages/tickets/src/components/QuickAddTicket.tsx:609`
+- `packages/tickets/src/actions/ticketFormActions.ts:56`
+
+And eight `ClientPicker` call sites pass no-op filter handlers, so their filter dropdowns
+are dead controls. Alex would hit the identical wall on Huntress, Tanium, or Level.io:
+
+- `ee/.../integrations/ninjaone/OrganizationMappingManager.tsx`
+- `ee/.../integrations/huntress/OrganizationMappingManager.tsx`
+- `ee/.../integrations/{TaniumIntegrationSettings,LevelIoIntegrationSettings,HuntressIntegrationSettings}.tsx`
+- `ee/.../workflow-designer/WorkflowActionInputFixedPicker.tsx`
+- `packages/projects/src/components/ProjectDetailsEdit.tsx`
+- `packages/tickets/src/components/TicketImportDialog.tsx`
+
+## Decisions
+
+| Decision | Choice | Why |
+|---|---|---|
+| Enforcement | DB CHECK constraint + normalize on write | Convention alone already failed once. `clients_billing_cycle_check` proves Citus allows it. |
+| Bad CSV values | Case-fold what we recognize, reject true junk | `Company` → `company` silently; `Vendor` fails that row loudly rather than importing a client that is invisible forever. |
+| NULL rows | Eliminate them | `NOT NULL DEFAULT 'company'`. Two legal values, no null branch in any reader. |
+| Picker contract | Make filter props optional / uncontrolled | Fixes all eight call sites and removes the trap for future callers, rather than patching NinjaOne alone. |
+| NinjaOne type filter | Unrestrict | A NinjaOne org may map to any client. An individual-type client is still a client. |
+
+`DEFAULT 'company'` is deliberate and load-bearing: the 33 NULL rows exist *because* some
+writer inserts a client without the column. A bare `NOT NULL` would convert that silent
+gap into a hard insert failure. The default keeps every existing writer working while
+still guaranteeing the invariant.
+
+Ticket alga0002129 was opened to research NULL semantics and then resolved — we decided
+inline to eliminate NULL rather than defer.
+
+## Implementation
+
+### 1. Shared normalizer
+
+Add `normalizeClientType(value: unknown): 'company' | 'individual'` in
+`packages/clients/src/lib/normalizeClientType.ts` (co-located with the client schemas;
+export from the package index).
+
+Rules:
+
+| Input | Result |
+|---|---|
+| `'company'`, `'Company'`, `'COMPANY'` (any case, trimmed) | `'company'` |
+| `'individual'`, `'Individual'` (any case, trimmed) | `'individual'` |
+| `''`, `null`, `undefined` | `'company'` (preserves today's default) |
+| anything else (`'Vendor'`, `'Customer'`) | throws `InvalidClientTypeError` |
+
+### 2. Migration — `server/migrations/<ts>_enforce_client_type_enum.cjs`
+
+In one transaction:
+
+1. Case-fold off-enum values (idempotent; re-runs the June normalization):
+   - `lower(client_type) = 'individual'` → `'individual'`
+   - any other non-null, off-enum value → `'company'`
+2. `UPDATE clients SET client_type = 'company' WHERE client_type IS NULL;` (33 rows)
+3. `ALTER TABLE clients ALTER COLUMN client_type SET DEFAULT 'company';`
+4. `ALTER TABLE clients ALTER COLUMN client_type SET NOT NULL;`
+5. `ALTER TABLE clients ADD CONSTRAINT clients_client_type_check CHECK (client_type IN ('company','individual'));`
+
+Steps 1–2 must fully precede 3–5 or the constraint will not validate. Model the DDL on
+`clients_billing_cycle_check`.
+
+`down`: drop the constraint, drop NOT NULL, drop the default. Do not attempt to restore
+the original free-text values — they are not recoverable, same as the June migration.
+
+### 3. Writer — `packages/clients/src/actions/clientActions.ts`
+
+Apply `normalizeClientType` in `importClientsFromCSV` on **both** paths — the update path
+(`:1619`) has the same hole as the create path (`:1694`):
+
+```ts
+// create (:1694)
+client_type: normalizeClientType(clientData.client_type),
+
+// update (:1619)
+if (clientData.client_type !== undefined) {
+  updateData.client_type = normalizeClientType(clientData.client_type);
+}
+```
+
+Catch `InvalidClientTypeError` per row and surface it through the importer's existing
+`ImportClientResult` error channel, so one bad row fails that row with a clear message
+(`client_type must be 'company' or 'individual'`) without failing the whole import.
+
+### 4. Picker contract — `packages/ui/src/components/ClientPicker.tsx`
+
+Make the four filter props optional:
+
+```ts
+filterState?: 'all' | 'active' | 'inactive';
+onFilterStateChange?: (state: 'all' | 'active' | 'inactive') => void;
+clientTypeFilter?: 'all' | 'company' | 'individual';
+onClientTypeFilterChange?: (type: 'all' | 'company' | 'individual') => void;
+```
+
+When a prop is omitted, `ClientPicker` owns that filter in internal state so its dropdown
+works. When provided, it stays controlled — existing controlled callers are unaffected.
+Defaults when uncontrolled: `filterState: 'active'`, `clientTypeFilter: 'all'`.
+
+Implement as the standard controlled/uncontrolled pattern (internal `useState` seeded from
+the prop; the prop wins when defined; call the handler when present).
+
+### 5. NinjaOne mapping screen
+
+`ee/server/src/components/settings/integrations/ninjaone/OrganizationMappingManager.tsx:252-255`
+— delete all four filter props. The picker then defaults to active clients, all types, with
+working dropdowns.
+
+The other seven no-op call sites get working filters for free. Do not otherwise change
+them in this branch.
+
+## Verification
+
+Unit:
+- `normalizeClientType` — the table in §1, including the throw on `'Vendor'`.
+- `importClientsFromCSV` — a CSV row with `client_type: 'Company'` persists as `'company'`;
+  a row with `'Vendor'` comes back as a failed `ImportClientResult` with a clear message
+  and does not abort sibling rows.
+- `ClientPicker` — uncontrolled: changing the type dropdown re-filters the list;
+  controlled: the parent's value still wins.
+
+Migration:
+- Against a DB seeded with `'Company'`, `NULL`, `'individual'` and `'Vendor'` rows: all
+  land on the enum, column is `NOT NULL`, and a subsequent `INSERT` of `'Bogus'` is
+  rejected by the constraint.
+- Migration is idempotent (run twice).
+
+Live (dev stack on port 3021):
+- Settings → Integrations → NinjaOne → organization mapping: the client dropdown lists
+  clients and a mapping can be saved.
+- Regression: QuickAddTicket contact behavior for a `company` client is unchanged.
+
+## Production remediation
+
+The migration fixes Alex's 41 rows on deploy — no manual data surgery. After deploy,
+confirm:
+
+```sql
+select client_type, count(*) from clients group by 1;
+-- expect only 'company' and 'individual'
+```
+
+## Out of scope
+
+- Whether `client_type` should be a Postgres enum type rather than text + CHECK.
+- The `rmm_organization_mappings` stale-row behavior when a NinjaOne org is deleted or
+  merged (noted during investigation; unrelated to this report).

--- a/ee/server/src/components/settings/integrations/ninjaone/OrganizationMappingManager.tsx
+++ b/ee/server/src/components/settings/integrations/ninjaone/OrganizationMappingManager.tsx
@@ -249,10 +249,6 @@ const OrganizationMappingManager: React.FC<OrganizationMappingManagerProps> = ({
                 if (isSaving) return;
                 handleCompanyChange(mapping.mapping_id, clientId);
               }}
-              filterState="active"
-              onFilterStateChange={() => {}}
-              clientTypeFilter="company"
-              onClientTypeFilterChange={() => {}}
               placeholder={t('integrations.rmm.ninjaone.selectCompany', { defaultValue: 'Select company' })}
               fitContent={true}
               className="w-full"

--- a/packages/clients/src/actions/clientActions.importCsv.test.ts
+++ b/packages/clients/src/actions/clientActions.importCsv.test.ts
@@ -77,7 +77,7 @@ vi.mock('@alga-psa/storage', () => ({
   deleteEntityImage: vi.fn(),
 }));
 
-vi.mock('@alga-psa/tags/actions', () => ({
+vi.mock('@alga-psa/tags/actions/tagActions', () => ({
   createTag: createTagMock,
   findTagsByEntityId: findTagsByEntityIdMock,
 }));
@@ -374,6 +374,38 @@ describe('importClientsFromCSV', () => {
       address_line1: '1201 Alaskan Way',
       is_default: true,
     });
+  });
+
+  it('normalizes case-variant client types on create and update', async () => {
+    const createResults = await importClients([
+      csvRow({ client_name: 'Case Folded Co', client_type: ' Company ' }),
+    ]);
+
+    expect(createResults[0]).toMatchObject({ success: true, message: 'Client created' });
+    expect(state.clients[0].client_type).toBe('company');
+
+    const updateResults = await importClients([
+      csvRow({ client_name: 'Case Folded Co', client_type: 'INDIVIDUAL' }),
+    ], true);
+
+    expect(updateResults[0]).toMatchObject({ success: true, message: 'Client updated' });
+    expect(state.clients[0].client_type).toBe('individual');
+  });
+
+  it('rejects an unsupported client type without aborting sibling rows', async () => {
+    const results = await importClients([
+      csvRow({ client_name: 'Valid Before Co', client_type: 'Company' }),
+      csvRow({ client_name: 'Invalid Vendor Co', client_type: 'Vendor' }),
+      csvRow({ client_name: 'Valid After Person', client_type: 'Individual' }),
+    ]);
+
+    expect(results.map((result) => result.success)).toEqual([true, false, true]);
+    expect(results[1].message).toContain("client_type must be 'company' or 'individual'");
+    expect(state.clients.map((client) => client.client_name)).toEqual([
+      'Valid Before Co',
+      'Valid After Person',
+    ]);
+    expect(state.clients.map((client) => client.client_type)).toEqual(['company', 'individual']);
   });
 
   it('updates the existing default location instead of inserting a second one', async () => {

--- a/packages/clients/src/actions/clientActions.ts
+++ b/packages/clients/src/actions/clientActions.ts
@@ -38,6 +38,7 @@ import {
   type ActionPermissionError,
 } from '@alga-psa/ui/lib/errorHandling';
 import { applyClientListIndexedSearchFilter } from '../lib/listSearchSql';
+import { normalizeClientType } from '../lib/normalizeClientType';
 
 const CLIENT_PORTAL_MUTABLE_CLIENT_PROPERTIES = new Set([
   'website',
@@ -1617,7 +1618,7 @@ export const importClientsFromCSV = withAuth(async (
             updateData.url = clientData.website || clientData.url || '';
           }
           if (clientData.client_type !== undefined) {
-            updateData.client_type = clientData.client_type || 'company';
+            updateData.client_type = normalizeClientType(clientData.client_type);
           }
           if (clientData.is_inactive !== undefined) {
             updateData.is_inactive = parseCsvBoolean(clientData.is_inactive);
@@ -1691,7 +1692,7 @@ export const importClientsFromCSV = withAuth(async (
             url: clientData.website || clientData.url || '',
             is_inactive: parseCsvBoolean(clientData.is_inactive),
             is_tax_exempt: clientData.is_tax_exempt || false,
-            client_type: clientData.client_type || 'company',
+            client_type: normalizeClientType(clientData.client_type),
             tenant: tenant,
             properties: properties,
             account_manager_id: clientData.account_manager_id === '' ? null : clientData.account_manager_id,

--- a/packages/clients/src/index.ts
+++ b/packages/clients/src/index.ts
@@ -26,6 +26,13 @@ export type {
 // Re-export types from @alga-psa/types for convenience
 export type { IClient, CreateClientInput as ICreateClientInput, UpdateClientInput as IUpdateClientInput } from '@alga-psa/types';
 
+// Client data normalization
+export {
+  InvalidClientTypeError,
+  normalizeClientType,
+} from './lib/normalizeClientType';
+export type { NormalizedClientType } from './lib/normalizeClientType';
+
 // Components
 export * from './components';
 

--- a/packages/clients/src/lib/normalizeClientType.test.ts
+++ b/packages/clients/src/lib/normalizeClientType.test.ts
@@ -1,0 +1,25 @@
+import { describe, expect, it } from 'vitest';
+
+import { InvalidClientTypeError, normalizeClientType } from './normalizeClientType';
+
+describe('normalizeClientType', () => {
+  it.each([
+    ['company', 'company'],
+    ['Company', 'company'],
+    [' COMPANY ', 'company'],
+    ['individual', 'individual'],
+    ['Individual', 'individual'],
+    [' INDIVIDUAL ', 'individual'],
+  ] as const)('normalizes %j to %j', (input, expected) => {
+    expect(normalizeClientType(input)).toBe(expected);
+  });
+
+  it.each(['', '   ', null, undefined])('defaults %j to company', (input) => {
+    expect(normalizeClientType(input)).toBe('company');
+  });
+
+  it.each(['Vendor', 'Customer', 42, true, {}])('rejects unsupported value %j', (input) => {
+    expect(() => normalizeClientType(input)).toThrow(InvalidClientTypeError);
+    expect(() => normalizeClientType(input)).toThrow("client_type must be 'company' or 'individual'");
+  });
+});

--- a/packages/clients/src/lib/normalizeClientType.ts
+++ b/packages/clients/src/lib/normalizeClientType.ts
@@ -1,0 +1,26 @@
+export type NormalizedClientType = 'company' | 'individual';
+
+export class InvalidClientTypeError extends Error {
+  constructor(value: unknown) {
+    super(`client_type must be 'company' or 'individual' (received ${String(value)})`);
+    this.name = 'InvalidClientTypeError';
+  }
+}
+
+export function normalizeClientType(value: unknown): NormalizedClientType {
+  if (value === null || value === undefined) {
+    return 'company';
+  }
+
+  if (typeof value === 'string') {
+    const normalized = value.trim().toLowerCase();
+    if (normalized === '') {
+      return 'company';
+    }
+    if (normalized === 'company' || normalized === 'individual') {
+      return normalized;
+    }
+  }
+
+  throw new InvalidClientTypeError(value);
+}

--- a/packages/ui/src/components/ClientPicker.tsx
+++ b/packages/ui/src/components/ClientPicker.tsx
@@ -24,16 +24,18 @@ import { CommonActions } from '../ui-reflection/actionBuilders';
 
 type ButtonVariant = VariantProps<typeof buttonVariants>['variant'];
 type ButtonSize = VariantProps<typeof buttonVariants>['size'];
+type ClientFilterState = 'all' | 'active' | 'inactive';
+type ClientTypeFilter = 'all' | 'company' | 'individual';
 
 interface ClientPickerProps {
   id?: string;
   clients?: IClient[];
   onSelect: (clientId: string | null) => void;
   selectedClientId: string | null;
-  filterState: 'all' | 'active' | 'inactive';
-  onFilterStateChange: (state: 'all' | 'active' | 'inactive') => void;
-  clientTypeFilter: 'all' | 'company' | 'individual';
-  onClientTypeFilterChange: (type: 'all' | 'company' | 'individual') => void;
+  filterState?: ClientFilterState;
+  onFilterStateChange?: (state: ClientFilterState) => void;
+  clientTypeFilter?: ClientTypeFilter;
+  onClientTypeFilterChange?: (type: ClientTypeFilter) => void;
   disabledClientIds?: Set<string>;
   disabledTooltip?: string;
   fitContent?: boolean;
@@ -120,6 +122,8 @@ export const ClientPicker: React.FC<ClientPickerProps & AutomationProps> = ({
   const { fetchClientTags } = useClientTags();
   const [isOpen, setIsOpen] = useState(false);
   const [searchTerm, setSearchTerm] = useState('');
+  const [internalFilterState, setInternalFilterState] = useState<ClientFilterState>(filterState ?? 'active');
+  const [internalClientTypeFilter, setInternalClientTypeFilter] = useState<ClientTypeFilter>(clientTypeFilter ?? 'all');
   const [clientTags, setClientTags] = useState<ITag[]>([]);
   const [selectedTagFilters, setSelectedTagFilters] = useState<string[]>([]);
   const containerRef = useRef<HTMLDivElement>(null);
@@ -174,25 +178,41 @@ export const ClientPicker: React.FC<ClientPickerProps & AutomationProps> = ({
   }, [clientTags]);
 
   const showTagFilter = uniqueFilterTags.length > 0;
+  const resolvedFilterState = filterState ?? internalFilterState;
+  const resolvedClientTypeFilter = clientTypeFilter ?? internalClientTypeFilter;
+
+  const handleFilterStateChange = (state: ClientFilterState) => {
+    if (filterState === undefined) {
+      setInternalFilterState(state);
+    }
+    onFilterStateChange?.(state);
+  };
+
+  const handleClientTypeFilterChange = (type: ClientTypeFilter) => {
+    if (clientTypeFilter === undefined) {
+      setInternalClientTypeFilter(type);
+    }
+    onClientTypeFilterChange?.(type);
+  };
 
   const filteredClients = useMemo(() => {
     return clients
       .filter((client) => {
         const matchesSearch = client.client_name.toLowerCase().includes(searchTerm.toLowerCase());
         const matchesState =
-          filterState === 'all'
+          resolvedFilterState === 'all'
             ? true
-            : filterState === 'active'
+            : resolvedFilterState === 'active'
               ? !client.is_inactive
-              : filterState === 'inactive'
+              : resolvedFilterState === 'inactive'
                 ? client.is_inactive
                 : true;
         const matchesClientType =
-          clientTypeFilter === 'all'
+          resolvedClientTypeFilter === 'all'
             ? true
-            : clientTypeFilter === 'company'
+            : resolvedClientTypeFilter === 'company'
               ? client.client_type === 'company'
-              : clientTypeFilter === 'individual'
+              : resolvedClientTypeFilter === 'individual'
                 ? client.client_type === 'individual'
                 : true;
         const matchesTags =
@@ -210,7 +230,7 @@ export const ClientPicker: React.FC<ClientPickerProps & AutomationProps> = ({
         if (aDisabled !== bDisabled) return aDisabled ? 1 : -1;
         return a.client_name.localeCompare(b.client_name);
       });
-  }, [clients, filterState, clientTypeFilter, searchTerm, disabledClientIds, selectedTagFilters, tagTextsByClientId]);
+  }, [clients, resolvedFilterState, resolvedClientTypeFilter, searchTerm, disabledClientIds, selectedTagFilters, tagTextsByClientId]);
 
   useEffect(() => {
     if (!isOpen) return;
@@ -444,15 +464,17 @@ export const ClientPicker: React.FC<ClientPickerProps & AutomationProps> = ({
           </div>
           <div className="flex items-center gap-2 mt-2">
             <CustomSelect
-              value={filterState}
-              onValueChange={(value) => onFilterStateChange(value as any)}
+              id={`${id}-state-filter`}
+              value={resolvedFilterState}
+              onValueChange={(value) => handleFilterStateChange(value as ClientFilterState)}
               options={opts}
               placeholder="Filter"
               className="flex-1 min-w-0"
             />
             <CustomSelect
-              value={clientTypeFilter}
-              onValueChange={(value) => onClientTypeFilterChange(value as any)}
+              id={`${id}-type-filter`}
+              value={resolvedClientTypeFilter}
+              onValueChange={(value) => handleClientTypeFilterChange(value as ClientTypeFilter)}
               options={clientTypes}
               placeholder="Type"
               className="flex-1 min-w-0"

--- a/packages/ui/src/components/client-picker-inline-add.test.tsx
+++ b/packages/ui/src/components/client-picker-inline-add.test.tsx
@@ -22,11 +22,38 @@ vi.mock('./ClientAvatar', () => ({
   default: () => <div data-testid="client-avatar" />,
 }));
 
+vi.mock('./CustomSelect', () => ({
+  default: ({ id, value, onValueChange, options, placeholder }: {
+    id?: string;
+    value?: string | null;
+    onValueChange: (value: string) => void;
+    options: Array<{ value: string; label: React.ReactNode }>;
+    placeholder?: string;
+  }) => (
+    <select
+      id={id}
+      aria-label={placeholder}
+      value={value ?? ''}
+      onChange={(event) => onValueChange(event.target.value)}
+    >
+      {options.map((option) => (
+        <option key={option.value} value={option.value}>{option.label}</option>
+      ))}
+    </select>
+  ),
+}));
+
 const clients: IClient[] = [
   {
     client_id: 'client-1',
     client_name: 'Acme Corp',
     client_type: 'company',
+    is_inactive: false,
+  } as IClient,
+  {
+    client_id: 'client-2',
+    client_name: 'Jane Smith',
+    client_type: 'individual',
     is_inactive: false,
   } as IClient,
 ];
@@ -135,5 +162,46 @@ describe('ClientPicker', () => {
 
     expect(onSelect).toHaveBeenCalledWith('client-1');
     expect(screen.queryByRole('listbox', { name: /select client/i })).toBeNull();
+  });
+
+  it('owns omitted filter props and re-filters when the type changes', async () => {
+    const user = userEvent.setup();
+    render(
+      <ClientPicker
+        id="uncontrolled-client-picker"
+        clients={clients}
+        onSelect={vi.fn()}
+        selectedClientId={null}
+        placeholder="Select Client"
+      />,
+    );
+
+    await user.click(screen.getByRole('button', { name: /select client/i }));
+    expect(screen.getByRole('option', { name: /acme corp/i })).toBeTruthy();
+    expect(screen.getByRole('option', { name: /jane smith/i })).toBeTruthy();
+
+    await user.selectOptions(screen.getByRole('combobox', { name: /type/i }), 'company');
+
+    expect(screen.getByRole('option', { name: /acme corp/i })).toBeTruthy();
+    expect(screen.queryByRole('option', { name: /jane smith/i })).toBeNull();
+  });
+
+  it('keeps a provided filter controlled while reporting requested changes', async () => {
+    const user = userEvent.setup();
+    const onClientTypeFilterChange = vi.fn();
+    renderPicker({
+      clientTypeFilter: 'company',
+      onClientTypeFilterChange,
+    });
+
+    await user.click(screen.getByRole('button', { name: /select client/i }));
+    expect(screen.getByRole('option', { name: /acme corp/i })).toBeTruthy();
+    expect(screen.queryByRole('option', { name: /jane smith/i })).toBeNull();
+
+    await user.selectOptions(screen.getByRole('combobox', { name: /type/i }), 'individual');
+
+    expect(onClientTypeFilterChange).toHaveBeenCalledWith('individual');
+    expect(screen.getByRole('option', { name: /acme corp/i })).toBeTruthy();
+    expect(screen.queryByRole('option', { name: /jane smith/i })).toBeNull();
   });
 });

--- a/server/migrations/20260714200000_enforce_client_type_enum.cjs
+++ b/server/migrations/20260714200000_enforce_client_type_enum.cjs
@@ -31,11 +31,68 @@ async function constraintExists(knex) {
   return result.rows.length > 0;
 }
 
+async function isCitusDistributedTable(knex) {
+  try {
+    const result = await knex.raw(`
+      SELECT EXISTS (
+        SELECT 1
+        FROM pg_dist_partition
+        WHERE logicalrelid = 'clients'::regclass
+      ) AS is_distributed
+    `);
+    return Boolean(result.rows?.[0]?.is_distributed);
+  } catch (_error) {
+    return false;
+  }
+}
+
+async function setNotNull(knex) {
+  if (await isCitusDistributedTable(knex)) {
+    await knex.raw(`
+      SELECT * FROM run_command_on_shards(
+        'clients',
+        $$ALTER TABLE %s ALTER COLUMN client_type SET NOT NULL$$
+      )
+    `);
+    await knex.raw(`
+      UPDATE pg_attribute
+      SET attnotnull = true
+      WHERE attrelid = 'clients'::regclass
+        AND attname = 'client_type'
+        AND attnotnull = false
+    `);
+    return;
+  }
+
+  await knex.raw('ALTER TABLE clients ALTER COLUMN client_type SET NOT NULL');
+}
+
+async function dropNotNull(knex) {
+  if (await isCitusDistributedTable(knex)) {
+    await knex.raw(`
+      SELECT * FROM run_command_on_shards(
+        'clients',
+        $$ALTER TABLE %s ALTER COLUMN client_type DROP NOT NULL$$
+      )
+    `);
+    await knex.raw(`
+      UPDATE pg_attribute
+      SET attnotnull = false
+      WHERE attrelid = 'clients'::regclass
+        AND attname = 'client_type'
+        AND attnotnull = true
+    `);
+    return;
+  }
+
+  await knex.raw('ALTER TABLE clients ALTER COLUMN client_type DROP NOT NULL');
+}
+
 exports.up = async function up(knex) {
   await normalizeExistingClientTypes(knex);
 
   await knex.raw("ALTER TABLE clients ALTER COLUMN client_type SET DEFAULT 'company'");
-  await knex.raw('ALTER TABLE clients ALTER COLUMN client_type SET NOT NULL');
+  await setNotNull(knex);
 
   if (!await constraintExists(knex)) {
     await knex.raw(`
@@ -48,6 +105,9 @@ exports.up = async function up(knex) {
 
 exports.down = async function down(knex) {
   await knex.raw(`ALTER TABLE clients DROP CONSTRAINT IF EXISTS ${CLIENT_TYPE_CONSTRAINT}`);
-  await knex.raw('ALTER TABLE clients ALTER COLUMN client_type DROP NOT NULL');
+  await dropNotNull(knex);
   await knex.raw('ALTER TABLE clients ALTER COLUMN client_type DROP DEFAULT');
 };
+
+// ALTER COLUMN ... SET/DROP NOT NULL on Citus shards cannot run inside Knex's transaction.
+exports.config = { transaction: false };

--- a/server/migrations/20260714200000_enforce_client_type_enum.cjs
+++ b/server/migrations/20260714200000_enforce_client_type_enum.cjs
@@ -1,0 +1,53 @@
+const CLIENT_TYPE_CONSTRAINT = 'clients_client_type_check';
+const VALID_CLIENT_TYPES = ['company', 'individual'];
+
+async function normalizeExistingClientTypes(knex) {
+  const rows = await knex('clients')
+    .select('tenant', 'client_id', 'client_type')
+    .where((query) => {
+      query.whereNull('client_type').orWhereNotIn('client_type', VALID_CLIENT_TYPES);
+    });
+
+  for (const row of rows) {
+    const normalized =
+      typeof row.client_type === 'string' && row.client_type.trim().toLowerCase() === 'individual'
+        ? 'individual'
+        : 'company';
+
+    await knex('clients')
+      .where({ tenant: row.tenant, client_id: row.client_id })
+      .update({ client_type: normalized });
+  }
+}
+
+async function constraintExists(knex) {
+  const result = await knex.raw(
+    `SELECT 1
+       FROM pg_constraint
+      WHERE conname = ?
+        AND conrelid = 'clients'::regclass`,
+    [CLIENT_TYPE_CONSTRAINT]
+  );
+  return result.rows.length > 0;
+}
+
+exports.up = async function up(knex) {
+  await normalizeExistingClientTypes(knex);
+
+  await knex.raw("ALTER TABLE clients ALTER COLUMN client_type SET DEFAULT 'company'");
+  await knex.raw('ALTER TABLE clients ALTER COLUMN client_type SET NOT NULL');
+
+  if (!await constraintExists(knex)) {
+    await knex.raw(`
+      ALTER TABLE clients
+      ADD CONSTRAINT ${CLIENT_TYPE_CONSTRAINT}
+      CHECK (client_type IN ('company', 'individual'))
+    `);
+  }
+};
+
+exports.down = async function down(knex) {
+  await knex.raw(`ALTER TABLE clients DROP CONSTRAINT IF EXISTS ${CLIENT_TYPE_CONSTRAINT}`);
+  await knex.raw('ALTER TABLE clients ALTER COLUMN client_type DROP NOT NULL');
+  await knex.raw('ALTER TABLE clients ALTER COLUMN client_type DROP DEFAULT');
+};

--- a/server/src/test/integration/clientTypeEnumMigration.integration.test.ts
+++ b/server/src/test/integration/clientTypeEnumMigration.integration.test.ts
@@ -1,0 +1,111 @@
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+import type { Knex } from 'knex';
+import { createRequire } from 'node:module';
+import { v4 as uuidv4 } from 'uuid';
+
+import { createTestDbConnection } from '../../../test-utils/dbConfig';
+
+const require = createRequire(import.meta.url);
+const migration = require('../../../migrations/20260714200000_enforce_client_type_enum.cjs') as {
+  up: (knex: Knex | Knex.Transaction) => Promise<void>;
+  down: (knex: Knex | Knex.Transaction) => Promise<void>;
+};
+
+describe('client type enum migration (integration)', () => {
+  let knex: Knex;
+
+  beforeAll(async () => {
+    knex = await createTestDbConnection({ runSeeds: true });
+  });
+
+  afterAll(async () => {
+    await knex?.destroy();
+  });
+
+  it('normalizes legacy rows and enforces the default, NOT NULL, and enum constraint idempotently', async () => {
+    const trx = await knex.transaction();
+    let testError: unknown;
+
+    try {
+      await migration.down(trx);
+
+      const tenantRow = await trx('tenants').select('tenant').first();
+      if (!tenantRow?.tenant) {
+        throw new Error('Expected the integration database to contain a seeded tenant');
+      }
+
+      const fixtureRows = [
+        { client_type: 'Company', expected: 'company' },
+        { client_type: null, expected: 'company' },
+        { client_type: 'individual', expected: 'individual' },
+        { client_type: 'Vendor', expected: 'company' },
+      ];
+      const fixtureIds = fixtureRows.map(() => uuidv4());
+
+      await trx('clients').insert(fixtureRows.map((fixture, index) => ({
+        tenant: tenantRow.tenant,
+        client_id: fixtureIds[index],
+        client_name: `Client type migration fixture ${fixtureIds[index]}`,
+        client_type: fixture.client_type,
+      })));
+
+      await migration.up(trx);
+      await migration.up(trx);
+
+      const normalizedRows = await trx('clients')
+        .where({ tenant: tenantRow.tenant })
+        .whereIn('client_id', fixtureIds)
+        .select('client_id', 'client_type');
+      const typeById = new Map(normalizedRows.map((row) => [row.client_id, row.client_type]));
+
+      fixtureRows.forEach((fixture, index) => {
+        expect(typeById.get(fixtureIds[index])).toBe(fixture.expected);
+      });
+
+      const column = await trx('information_schema.columns')
+        .where({
+          table_schema: 'public',
+          table_name: 'clients',
+          column_name: 'client_type',
+        })
+        .select('is_nullable', 'column_default')
+        .first();
+      expect(column?.is_nullable).toBe('NO');
+      expect(column?.column_default).toContain('company');
+
+      const defaultedClientId = uuidv4();
+      const [defaultedClient] = await trx('clients')
+        .insert({
+          tenant: tenantRow.tenant,
+          client_id: defaultedClientId,
+          client_name: `Defaulted client type fixture ${defaultedClientId}`,
+        })
+        .returning(['client_type']);
+      expect(defaultedClient.client_type).toBe('company');
+
+      let invalidInsertError: unknown;
+      try {
+        await trx.transaction(async (savepoint) => {
+          const invalidClientId = uuidv4();
+          await savepoint('clients').insert({
+            tenant: tenantRow.tenant,
+            client_id: invalidClientId,
+            client_name: `Invalid client type fixture ${invalidClientId}`,
+            client_type: 'Bogus',
+          });
+        });
+      } catch (error) {
+        invalidInsertError = error;
+      }
+      expect(invalidInsertError).toMatchObject({ code: '23514' });
+    } catch (error) {
+      testError = error;
+    } finally {
+      await trx.rollback();
+    }
+
+    if (testError) {
+      throw testError;
+    }
+  });
+});


### PR DESCRIPTION
## Summary

- Normalize CSV client types through a shared `normalizeClientType()` path on both create and update: trimmed/case-insensitive `company` and `individual` values are accepted, while invalid values fail only their row.
- Repair existing invalid and NULL client types, then enforce `DEFAULT 'company'`, `NOT NULL`, and a `company|individual` CHECK constraint. Distributed installs use the shard-level Citus `SET NOT NULL` pattern and update coordinator metadata; plain Postgres uses normal DDL.
- Make `ClientPicker` filters work in uncontrolled mode and let NinjaOne organization mapping default to All Types so both companies and individuals are available.
- Add focused unit, component, CSV import, and migration integration coverage, plus the implementation plan.

## Root cause and impact

CSV import wrote `client_type` directly from the CSV cell without normalization or enum validation. Values such as `Company` therefore survived as invalid data and disappeared from NinjaOne's company-only mapping picker. The same data also caused ticket creation to treat affected companies as individuals. NinjaOne's picker additionally hardcoded company/active filters with no-op callbacks, so users could not work around the bad data.

## Verification

- 28 focused client normalization/CSV tests passed.
- 7 focused `ClientPicker` component tests passed.
- The real-Postgres migration integration test passed, including normalization, default, NOT NULL, CHECK rejection, and idempotency.

## Smoke test

**PASS with one fidelity limitation: production-environment fidelity.**

Exercised through the running product:

- Applied the migration to real Postgres: five NULL types were backfilled; DEFAULT `company`, NOT NULL, and CHECK constraints are active. Invalid direct writes are rejected.
- CSV create: ` Company ` and `INDIVIDUAL` normalized successfully; `Vendor` produced the expected row error without preventing the following valid row from importing. UI and DB confirmed results.
- CSV update-existing: uppercase input normalized and persisted correctly.
- NinjaOne mapping: picker defaulted to All Types, displayed company and individual clients, and its uncontrolled type filter changed to Individuals. Mapping persisted and was confirmed in DB.
- Ticket regression: the normalized company rendered Quick Add Ticket's company-only contact control and location control.

Fidelity compromises:

- No real NinjaOne account was available. A temporary local integration/mapping fixture and fake credential marker rendered the real mapping UI; no remote sync was invoked. All fixtures were removed.
- `alga-dev space-new-tab` created card-scoped tabs, but browser commands failed with “belongs to a different host.” The real UI was driven through the same alga-dev agent Chromium using Playwright/CDP. Nested picker interactions that hung under native automation used their real React handlers; persistence was independently verified.
- The local database does not have Citus installed, so production Citus behavior—especially `SET NOT NULL`—was not exercised directly. The migration now follows the repository's established shard-level Citus pattern and CI's Citus migration smoke check passed.

Evidence: `/tmp/alga-smoke-evidence/alex-it-ninjaone-issue-20260714-194047`

The standard `PORT=3021 npm run dev` service was restored and returns HTTP 200; dependency containers are running. The only worktree modification remains the pre-existing `package-lock.json` edit, which is not included in this PR.

