### PR TITLE
Hoist MspClientTagsProvider to the MSP shell

### DIFF
--- a/server/src/components/layout/DefaultLayout.tsx
+++ b/server/src/components/layout/DefaultLayout.tsx
@@ -14,6 +14,11 @@ import { useTranslation } from '@alga-psa/ui/lib/i18n/client';
 import { savePreference } from '@alga-psa/ui/lib';
 import QuickAskOverlay from 'server/src/components/chat/QuickAskOverlay';
 import { QuickAskProvider } from './QuickAskContext';
+// Mounted at the shell so the ClientPicker tag filter is ambient across every MSP
+// route (AlgaDeskMspShell mounts it for the AlgaDesk shell). The per-route-group
+// workspace provider stack is opt-in and left ~26 groups (inventory, opportunities,
+// surveys…) without it; this lightweight, fetch-on-demand provider fills that gap.
+import { MspClientTagsProvider } from '@alga-psa/msp-composition/clients/MspClientTagsProvider';
 import { PlatformNotificationBanner } from './PlatformNotificationBanner';
 import GlobalShortcutLayer from './GlobalShortcutLayer';
 import { isExperimentalFeatureEnabled } from '@alga-psa/tenancy/actions/tenant-settings-actions/tenantSettingsActions';
@@ -410,6 +415,7 @@ export default function DefaultLayout({ children, initialSidebarCollapsed = fals
 
 
   return (
+    <MspClientTagsProvider>
     <DrawerProvider>
       <div className="flex h-screen overflow-hidden bg-gray-100">
         <SidebarWithFeatureFlags
@@ -512,5 +518,6 @@ export default function DefaultLayout({ children, initialSidebarCollapsed = fals
         />
       )}
     </DrawerProvider>
+    </MspClientTagsProvider>
   );
 }

--- a/server/src/components/layout/WorkspaceProviders.tsx
+++ b/server/src/components/layout/WorkspaceProviders.tsx
@@ -12,7 +12,8 @@ import { MspClientIntegrationProvider } from '@alga-psa/msp-composition/projects
 import { MspClientDrawerProvider } from '@alga-psa/msp-composition/clients/MspClientDrawerProvider';
 import { MspClientCrossFeatureProvider } from '@alga-psa/msp-composition/clients/MspClientCrossFeatureProvider';
 import { QuickAddClientProviderWithCallbacks } from '@alga-psa/clients/providers/QuickAddClientProviderWithCallbacks';
-import { MspClientTagsProvider } from '@alga-psa/msp-composition/clients/MspClientTagsProvider';
+// MspClientTagsProvider is now mounted at the shell (DefaultLayout / AlgaDeskMspShell),
+// which is always an ancestor of this component — so it no longer needs to be re-mounted here.
 import { MspAssetCrossFeatureProvider } from '@alga-psa/msp-composition/assets/MspAssetCrossFeatureProvider';
 import { MspDocumentsCrossFeatureProvider } from '@alga-psa/msp-composition/documents/MspDocumentsCrossFeatureProvider';
 import { MspSchedulingCrossFeatureProvider } from '@alga-psa/msp-composition/scheduling/MspSchedulingCrossFeatureProvider';
@@ -46,10 +47,8 @@ export default function WorkspaceProviders({ children }: WorkspaceProvidersProps
                     <MspSchedulingCrossFeatureProvider>
                       <MspActivityCrossFeatureProvider>
                         <QuickAddClientProviderWithCallbacks>
-                          <MspClientTagsProvider>
-                            {children}
-                            <DrawerOutlet />
-                          </MspClientTagsProvider>
+                          {children}
+                          <DrawerOutlet />
                         </QuickAddClientProviderWithCallbacks>
                       </MspActivityCrossFeatureProvider>
                     </MspSchedulingCrossFeatureProvider>

--- a/server/src/test/unit/layout/WorkspaceProviders.static.test.ts
+++ b/server/src/test/unit/layout/WorkspaceProviders.static.test.ts
@@ -43,4 +43,12 @@ describe('WorkspaceProviders static structure', () => {
       expect(defaultLayoutSource).not.toContain(`import { ${provider} }`);
     }
   });
+
+  it('mounts MspClientTagsProvider at the shell, not in WorkspaceProviders', () => {
+    // Hoisted to DefaultLayout so the ClientPicker tag filter is ambient on every MSP
+    // route (AlgaDeskMspShell mounts it for AlgaDesk). WorkspaceProviders is always a
+    // descendant of the shell, so it must not re-mount the provider.
+    expect(defaultLayoutSource).toContain('<MspClientTagsProvider>');
+    expect(workspaceSource).not.toContain('<MspClientTagsProvider>');
+  });
 });


### PR DESCRIPTION
Mount the ClientPicker tag-filter provider once in DefaultLayout (matching AlgaDeskMspShell) instead of per-route in WorkspaceProviders, which left ~26 route groups (inventory, opportunities, surveysâ¦) without it. The tag filter is now ambient on every MSP client picker. Remove the now-redundant mount from WorkspaceProviders, since it always renders beneath a shell that already provides the context, and lock the single-owner placement into the layout static test.

"Would you tell me, please, which way I ought to go from here?" asked the ClientPicker. "That depends a good deal on where your Provider is mounted," said the DefaultLayout â and so it hoisted the little fetchClientTags up into the shell, and every picker in Wonderland could sort its tags at last. ðð·ï¸ð©