### PR TITLE
Replace native date inputs with shared pickers

### DIFF
--- a/ee/server/src/components/workflow-designer/WorkflowRunList.tsx
+++ b/ee/server/src/components/workflow-designer/WorkflowRunList.tsx
@@ -14,6 +14,9 @@ import { ShareActionsMenu, type ShareAction } from '@alga-psa/ui/components/Shar
 import { PrintableTable } from '@alga-psa/ui/components/PrintableTable';
 import { Card } from '@alga-psa/ui/components/Card';
 import { Input } from '@alga-psa/ui/components/Input';
+import { DatePicker } from '@alga-psa/ui/components/DatePicker';
+import { Label } from '@alga-psa/ui/components/Label';
+import { dateFromString, dateToString } from '@alga-psa/ui/lib/dateInput';
 import { useFormatters, useTranslation } from '@alga-psa/ui/lib/i18n/client';
 import { useRangeSelection } from '@alga-psa/ui/hooks';
 import CustomSelect, { SelectOption } from '@alga-psa/ui/components/CustomSelect';
@@ -792,20 +795,30 @@ const WorkflowRunList: React.FC<WorkflowRunListProps> = ({
               }}
               placeholder={t('runList.filters.versionPlaceholder', { defaultValue: 'Any version' })}
             />
-            <Input
-              id="workflow-runs-from"
-              label={t('runList.filters.fromLabel', { defaultValue: 'From' })}
-              type="date"
-              value={filters.from}
-              onChange={(event) => setFilters((prev) => ({ ...prev, from: event.target.value }))}
-            />
-            <Input
-              id="workflow-runs-to"
-              label={t('runList.filters.toLabel', { defaultValue: 'To' })}
-              type="date"
-              value={filters.to}
-              onChange={(event) => setFilters((prev) => ({ ...prev, to: event.target.value }))}
-            />
+            <div>
+              <Label className="block mb-1" htmlFor="workflow-runs-from">{t('runList.filters.fromLabel', { defaultValue: 'From' })}</Label>
+              <DatePicker
+                id="workflow-runs-from"
+                label={t('runList.filters.fromLabel', { defaultValue: 'From' })}
+                placeholder={t('runList.filters.fromLabel', { defaultValue: 'From' })}
+                clearable
+                className="w-full"
+                value={dateFromString(filters.from)}
+                onChange={(date) => setFilters((prev) => ({ ...prev, from: dateToString(date) }))}
+              />
+            </div>
+            <div>
+              <Label className="block mb-1" htmlFor="workflow-runs-to">{t('runList.filters.toLabel', { defaultValue: 'To' })}</Label>
+              <DatePicker
+                id="workflow-runs-to"
+                label={t('runList.filters.toLabel', { defaultValue: 'To' })}
+                placeholder={t('runList.filters.toLabel', { defaultValue: 'To' })}
+                clearable
+                className="w-full"
+                value={dateFromString(filters.to)}
+                onChange={(date) => setFilters((prev) => ({ ...prev, to: dateToString(date) }))}
+              />
+            </div>
             <CustomSelect
               id="workflow-runs-sort"
               label={t('runList.filters.sortLabel', { defaultValue: 'Sort' })}

--- a/packages/billing/src/components/accounting/QboOnboardingWizard.tsx
+++ b/packages/billing/src/components/accounting/QboOnboardingWizard.tsx
@@ -5,7 +5,8 @@ import { Alert, AlertDescription } from '@alga-psa/ui/components/Alert';
 import { Button } from '@alga-psa/ui/components/Button';
 import { Card, CardContent, CardDescription, CardFooter, CardHeader, CardTitle } from '@alga-psa/ui/components/Card';
 import { Checkbox } from '@alga-psa/ui/components/Checkbox';
-import { Input } from '@alga-psa/ui/components/Input';
+import { DatePicker } from '@alga-psa/ui/components/DatePicker';
+import { dateFromString, dateToString } from '@alga-psa/ui/lib/dateInput';
 import { Label } from '@alga-psa/ui/components/Label';
 import { Switch } from '@alga-psa/ui/components/Switch';
 import { QboCustomerMappingPanel } from './QboCustomerMappingPanel';
@@ -152,12 +153,14 @@ function StepHistory() {
           <Label htmlFor="qbo-history-window-start" className="text-xs">
             History window start (optional)
           </Label>
-          <Input
+          <DatePicker
             id="qbo-history-window-start"
-            type="date"
-            value={windowStart}
-            onChange={(e) => setWindowStart(e.target.value)}
+            label="History window start (optional)"
+            placeholder="History window start (optional)"
+            clearable
             className="w-44"
+            value={dateFromString(windowStart)}
+            onChange={(date) => setWindowStart(dateToString(date))}
           />
         </div>
         <Button id="qbo-history-load" type="button" variant="outline" disabled={fetching} onClick={() => void handleFetch()}>
@@ -346,11 +349,14 @@ function StepGoLive({ onDone }: StepGoLiveProps) {
       <div className="grid gap-4 sm:grid-cols-2">
         <div className="space-y-2">
           <Label htmlFor="qbo-golive-date">Auto-sync start date</Label>
-          <Input
+          <DatePicker
             id="qbo-golive-date"
-            type="date"
-            value={autoSyncStartDate}
-            onChange={(e) => setAutoSyncStartDate(e.target.value)}
+            label="Auto-sync start date"
+            placeholder="Auto-sync start date"
+            clearable
+            className="w-full"
+            value={dateFromString(autoSyncStartDate)}
+            onChange={(date) => setAutoSyncStartDate(dateToString(date))}
           />
           <p className="text-xs text-muted-foreground">
             Only invoices finalized on or after this date will auto-export.

--- a/packages/billing/src/components/billing-dashboard/CreditExpirationModificationDialog.tsx
+++ b/packages/billing/src/components/billing-dashboard/CreditExpirationModificationDialog.tsx
@@ -4,7 +4,8 @@ import React, { useState } from 'react';
 import { Dialog, DialogContent, DialogDescription, DialogFooter } from '@alga-psa/ui/components/Dialog';
 import { Button } from '@alga-psa/ui/components/Button';
 import { Label } from '@alga-psa/ui/components/Label';
-import { Input } from '@alga-psa/ui/components/Input';
+import { DatePicker } from '@alga-psa/ui/components/DatePicker';
+import { dateFromString, dateToString } from '@alga-psa/ui/lib/dateInput';
 import { Switch } from '@alga-psa/ui/components/Switch';
 import { useTranslation } from '@alga-psa/ui/lib/i18n/client';
 import { ICreditTracking } from '@alga-psa/types';
@@ -143,13 +144,15 @@ const CreditExpirationModificationDialog: React.FC<CreditExpirationModificationD
                 <Label htmlFor="expiration-date">
                   {t('expirationDialog.newExpirationDate', { defaultValue: 'New Expiration Date' })}
                 </Label>
-                <Input
+                <DatePicker
                   id="expiration-date"
-                  type="date"
-                  value={expirationDate}
-                  onChange={(e) => setExpirationDate(e.target.value)}
+                  label={t('expirationDialog.newExpirationDate', { defaultValue: 'New Expiration Date' })}
+                  placeholder={t('expirationDialog.newExpirationDate', { defaultValue: 'New Expiration Date' })}
+                  clearable
+                  value={dateFromString(expirationDate)}
+                  onChange={(date) => setExpirationDate(dateToString(date))}
                   disabled={removeExpiration}
-                  min={new Date().toISOString().split('T')[0]} // Prevent past dates
+                  minDate={dateFromString(new Date().toISOString().split('T')[0])} // Prevent past dates
                   className="w-full"
                 />
               </div>

--- a/packages/billing/src/components/billing-dashboard/CreditReconciliation.tsx
+++ b/packages/billing/src/components/billing-dashboard/CreditReconciliation.tsx
@@ -5,6 +5,7 @@ import { useRouter, useSearchParams } from 'next/navigation';
 import { useSession } from 'next-auth/react';
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@alga-psa/ui/components/Card';
 import { DatePicker } from '@alga-psa/ui/components/DatePicker';
+import { dateFromString, dateToString } from '@alga-psa/ui/lib/dateInput';
 import { Button } from '@alga-psa/ui/components/Button';
 import { CustomTabs } from '@alga-psa/ui/components/CustomTabs';
 import { DataTable } from '@alga-psa/ui/components/DataTable';
@@ -377,12 +378,14 @@ const CreditReconciliation: React.FC = () => {
                 <label htmlFor="date-from" className="block text-sm font-medium text-[rgb(var(--color-text-700))] mb-1">
                   {t('reconciliation.fromDate', { defaultValue: 'From Date' })}
                 </label>
-                <input
+                <DatePicker
                   id="date-from"
-                  type="date"
-                  value={dateRange.startDate || ''}
-                  onChange={(e) => setDateRange({...dateRange, startDate: e.target.value || null})}
-                  className="border border-[rgb(var(--color-border-300))] rounded-md px-3 py-2 text-sm text-[rgb(var(--color-text-700))] bg-card"
+                  label={t('reconciliation.fromDate', { defaultValue: 'From Date' })}
+                  placeholder={t('reconciliation.fromDate', { defaultValue: 'From Date' })}
+                  clearable
+                  className="w-full"
+                  value={dateFromString(dateRange.startDate)}
+                  onChange={(date) => setDateRange({ ...dateRange, startDate: dateToString(date) || null })}
                 />
               </div>
               
@@ -390,12 +393,14 @@ const CreditReconciliation: React.FC = () => {
                 <label htmlFor="date-to" className="block text-sm font-medium text-[rgb(var(--color-text-700))] mb-1">
                   {t('reconciliation.toDate', { defaultValue: 'To Date' })}
                 </label>
-                <input
+                <DatePicker
                   id="date-to"
-                  type="date"
-                  value={dateRange.endDate || ''}
-                  onChange={(e) => setDateRange({...dateRange, endDate: e.target.value || null})}
-                  className="border border-[rgb(var(--color-border-300))] rounded-md px-3 py-2 text-sm text-[rgb(var(--color-text-700))] bg-card"
+                  label={t('reconciliation.toDate', { defaultValue: 'To Date' })}
+                  placeholder={t('reconciliation.toDate', { defaultValue: 'To Date' })}
+                  clearable
+                  className="w-full"
+                  value={dateFromString(dateRange.endDate)}
+                  onChange={(date) => setDateRange({ ...dateRange, endDate: dateToString(date) || null })}
                 />
               </div>
               

--- a/packages/billing/src/components/billing-dashboard/ManualInvoices.tsx
+++ b/packages/billing/src/components/billing-dashboard/ManualInvoices.tsx
@@ -20,6 +20,7 @@ import { translateManualInvoiceFailure } from './manualInvoiceErrorTranslation';
 import { Button } from '@alga-psa/ui/components/Button';
 import { Checkbox } from '@alga-psa/ui/components/Checkbox';
 import { DatePicker } from '@alga-psa/ui/components/DatePicker';
+import { dateFromString, dateToString } from '@alga-psa/ui/lib/dateInput';
 import { Card } from '@alga-psa/ui/components/Card';
 import { LineItem, ServiceOption, EditableItem as LineItemEditableItem } from './LineItem'; // Import EditableItem type from LineItem
 import { ClientPicker } from '@alga-psa/ui/components/ClientPicker';
@@ -1109,12 +1110,18 @@ const ManualInvoicesContent: React.FC<ManualInvoicesProps> = ({
                         })}
                       </label>
                       <div className="flex items-center">
-                        <input
+                        <DatePicker
                           id="expiration-date-input"
-                          type="date"
-                          value={expirationDate}
-                          onChange={(e) => setExpirationDate(e.target.value)}
-                          className="border rounded-md px-3 py-2 w-full max-w-xs shadow-sm focus:ring-blue-500 focus:border-blue-500"
+                          label={t('manualInvoices.creditExpiration.label', {
+                            defaultValue: 'Credit Expiration Date',
+                          })}
+                          placeholder={t('manualInvoices.creditExpiration.label', {
+                            defaultValue: 'Credit Expiration Date',
+                          })}
+                          clearable
+                          className="w-full max-w-xs"
+                          value={dateFromString(expirationDate)}
+                          onChange={(date) => setExpirationDate(dateToString(date))}
                         />
                         <div className="ml-2 text-sm text-muted-foreground">
                           {t('manualInvoices.creditExpiration.helpText', {

--- a/packages/billing/src/components/billing-dashboard/TaxRates.tsx
+++ b/packages/billing/src/components/billing-dashboard/TaxRates.tsx
@@ -4,6 +4,8 @@ import React, { useState, useEffect, useCallback, useMemo } from 'react';
 import { Card, CardHeader, CardContent } from '@alga-psa/ui/components/Card';
 import { Button } from '@alga-psa/ui/components/Button';
 import { Input } from '@alga-psa/ui/components/Input';
+import { DatePicker } from '@alga-psa/ui/components/DatePicker';
+import { dateFromString, dateToString } from '@alga-psa/ui/lib/dateInput';
 import { Dialog, DialogContent, DialogDescription } from '@alga-psa/ui/components/Dialog';
 import { Label } from '@alga-psa/ui/components/Label';
 import CustomSelect from '@alga-psa/ui/components/CustomSelect';
@@ -562,16 +564,18 @@ const TaxRates: React.FC = () => {
               <Label htmlFor="tax-rate-start-date-field">
                 {t('taxRates.dialog.fields.startDate', { defaultValue: 'Start Date *' })}
               </Label>
-              <Input
+              <DatePicker
                 id="tax-rate-start-date-field"
-                type="date"
-                value={currentTaxRate.start_date || ''}
-                onChange={(e) => {
-                  setCurrentTaxRate({ ...currentTaxRate, start_date: e.target.value });
+                label={t('taxRates.dialog.fields.startDate', { defaultValue: 'Start Date *' })}
+                placeholder={t('taxRates.dialog.fields.startDate', { defaultValue: 'Start Date *' })}
+                clearable
+                value={dateFromString(currentTaxRate.start_date || '')}
+                onChange={(date) => {
+                  setCurrentTaxRate({ ...currentTaxRate, start_date: dateToString(date) });
                   setError(null);
                   clearErrorIfSubmitted();
                 }}
-                className={hasAttemptedSubmit && !currentTaxRate.start_date ? 'border-red-500' : ''}
+                className={`w-full ${hasAttemptedSubmit && !currentTaxRate.start_date ? 'border-red-500' : ''}`}
               />
             </div>
             <div>
@@ -580,12 +584,15 @@ const TaxRates: React.FC = () => {
                   defaultValue: 'End Date (Optional)',
                 })}
               </Label>
-              <Input
+              <DatePicker
                 id="tax-rate-end-date-field"
-                type="date"
-                value={currentTaxRate.end_date || ''}
-                onChange={(e) => {
-                  setCurrentTaxRate({ ...currentTaxRate, end_date: e.target.value || null });
+                label={t('taxRates.dialog.fields.endDate', { defaultValue: 'End Date (Optional)' })}
+                placeholder={t('taxRates.dialog.fields.endDate', { defaultValue: 'End Date (Optional)' })}
+                clearable
+                className="w-full"
+                value={dateFromString(currentTaxRate.end_date || '')}
+                onChange={(date) => {
+                  setCurrentTaxRate({ ...currentTaxRate, end_date: dateToString(date) || null });
                   setError(null);
                 }}
               />

--- a/packages/billing/src/components/billing-dashboard/UsageTracking.tsx
+++ b/packages/billing/src/components/billing-dashboard/UsageTracking.tsx
@@ -7,6 +7,7 @@ import { Card, CardContent, CardHeader } from '@alga-psa/ui/components/Card';
 import { Dialog, DialogContent } from '@alga-psa/ui/components/Dialog';
 import { Input } from '@alga-psa/ui/components/Input';
 import { DatePicker } from '@alga-psa/ui/components/DatePicker';
+import { dateFromString, dateToString } from '@alga-psa/ui/lib/dateInput';
 import { Label } from '@alga-psa/ui/components/Label';
 import CustomSelect from '@alga-psa/ui/components/CustomSelect';
 import { Plus, AlertTriangle, Info, MoreVertical, Package } from 'lucide-react';
@@ -652,13 +653,19 @@ const UsageTracking: React.FC<UsageTrackingProps> = ({ initialServices }) => {
             </div>
             <div>
               <Label htmlFor="usage-date-input">{t('usage.dialog.fields.usageDate', { defaultValue: 'Usage Date' })}</Label>
-              <Input
+              <DatePicker
                 id="usage-date-input"
-                type="date"
-                value={newUsage.usage_date
+                label={t('usage.dialog.fields.usageDate', { defaultValue: 'Usage Date' })}
+                placeholder={t('usage.dialog.fields.usageDate', { defaultValue: 'Usage Date' })}
+                clearable
+                className="w-full"
+                value={dateFromString(newUsage.usage_date
                   ? new Date(newUsage.usage_date).toISOString().split('T')[0]
-                  : ''}
-                onChange={(e) => setNewUsage({ ...newUsage, usage_date: new Date(e.target.value).toISOString() })}
+                  : '')}
+                onChange={(date) => setNewUsage({
+                  ...newUsage,
+                  usage_date: date ? new Date(dateToString(date)).toISOString() : '',
+                })}
               />
             </div>
             <div>

--- a/packages/billing/src/components/billing-dashboard/accounting/AccountingExportsTab.tsx
+++ b/packages/billing/src/components/billing-dashboard/accounting/AccountingExportsTab.tsx
@@ -5,6 +5,8 @@ import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@alga
 import { Button } from '@alga-psa/ui/components/Button';
 import { Dialog, DialogContent, DialogHeader, DialogTitle } from '@alga-psa/ui/components/Dialog';
 import { Input } from '@alga-psa/ui/components/Input';
+import { DatePicker } from '@alga-psa/ui/components/DatePicker';
+import { dateFromString, dateToString } from '@alga-psa/ui/lib/dateInput';
 import { Label } from '@alga-psa/ui/components/Label';
 import CustomSelect from '@alga-psa/ui/components/CustomSelect';
 import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from '@alga-psa/ui/components/Table';
@@ -469,22 +471,28 @@ export default function AccountingExportsTab(): React.JSX.Element {
                 <Label htmlFor="accounting-export-start-date">
                   {t('accountingExports.createDialog.fields.startDate', { defaultValue: 'Start Date' })}
                 </Label>
-                <Input
+                <DatePicker
                   id="accounting-export-start-date"
-                  type="date"
-                  value={startDate}
-                  onChange={(e) => setStartDate(e.target.value)}
+                  label={t('accountingExports.createDialog.fields.startDate', { defaultValue: 'Start Date' })}
+                  placeholder={t('accountingExports.createDialog.fields.startDate', { defaultValue: 'Start Date' })}
+                  clearable
+                  className="w-full"
+                  value={dateFromString(startDate)}
+                  onChange={(date) => setStartDate(dateToString(date))}
                 />
               </div>
               <div className="space-y-2">
                 <Label htmlFor="accounting-export-end-date">
                   {t('accountingExports.createDialog.fields.endDate', { defaultValue: 'End Date' })}
                 </Label>
-                <Input
+                <DatePicker
                   id="accounting-export-end-date"
-                  type="date"
-                  value={endDate}
-                  onChange={(e) => setEndDate(e.target.value)}
+                  label={t('accountingExports.createDialog.fields.endDate', { defaultValue: 'End Date' })}
+                  placeholder={t('accountingExports.createDialog.fields.endDate', { defaultValue: 'End Date' })}
+                  clearable
+                  className="w-full"
+                  value={dateFromString(endDate)}
+                  onChange={(date) => setEndDate(dateToString(date))}
                 />
               </div>
             </div>

--- a/packages/billing/src/components/billing-dashboard/invoicing/DraftInvoiceDetailsCard.tsx
+++ b/packages/billing/src/components/billing-dashboard/invoicing/DraftInvoiceDetailsCard.tsx
@@ -12,6 +12,9 @@ import {
   CardTitle,
 } from '@alga-psa/ui/components/Card';
 import { Input } from '@alga-psa/ui/components/Input';
+import { DatePicker } from '@alga-psa/ui/components/DatePicker';
+import { dateFromString, dateToString } from '@alga-psa/ui/lib/dateInput';
+import { Label } from '@alga-psa/ui/components/Label';
 import { Alert, AlertDescription } from '@alga-psa/ui/components/Alert';
 import { formatCurrencyFromMinorUnits, toPlainDate } from '@alga-psa/core';
 import type { DateValue, InvoiceViewModel as DbInvoiceViewModel } from '@alga-psa/types';
@@ -231,24 +234,34 @@ const DraftInvoiceDetailsCard: React.FC<DraftInvoiceDetailsCardProps> = ({
             </div>
           </div>
 
-          <Input
-            id="draft-invoice-date-input"
-            label="Invoice Date"
-            type="date"
-            value={formState.invoiceDate}
-            onChange={(event) => setFormState((current) => ({ ...current, invoiceDate: event.target.value }))}
-            disabled={isSaving}
-            required
-          />
+          <div className="space-y-1">
+            <Label className="block mb-1" htmlFor="draft-invoice-date-input">Invoice Date</Label>
+            <DatePicker
+              id="draft-invoice-date-input"
+              label="Invoice Date"
+              placeholder="Invoice Date"
+              clearable
+              className="w-full"
+              value={dateFromString(formState.invoiceDate)}
+              onChange={(date) => setFormState((current) => ({ ...current, invoiceDate: dateToString(date) }))}
+              disabled={isSaving}
+              required
+            />
+          </div>
 
-          <Input
-            id="draft-due-date-input"
-            label="Due Date"
-            type="date"
-            value={formState.dueDate}
-            onChange={(event) => setFormState((current) => ({ ...current, dueDate: event.target.value }))}
-            disabled={isSaving}
-          />
+          <div className="space-y-1">
+            <Label className="block mb-1" htmlFor="draft-due-date-input">Due Date</Label>
+            <DatePicker
+              id="draft-due-date-input"
+              label="Due Date"
+              placeholder="Due Date"
+              clearable
+              className="w-full"
+              value={dateFromString(formState.dueDate)}
+              onChange={(date) => setFormState((current) => ({ ...current, dueDate: dateToString(date) }))}
+              disabled={isSaving}
+            />
+          </div>
         </div>
 
         <div className="grid gap-4 md:grid-cols-2">

--- a/packages/billing/src/components/billing-dashboard/reports/ProfitabilityReport.tsx
+++ b/packages/billing/src/components/billing-dashboard/reports/ProfitabilityReport.tsx
@@ -8,7 +8,8 @@ import { Badge } from '@alga-psa/ui/components/Badge';
 import { Button } from '@alga-psa/ui/components/Button';
 import { Card } from '@alga-psa/ui/components/Card';
 import { DataTable } from '@alga-psa/ui/components/DataTable';
-import { Input } from '@alga-psa/ui/components/Input';
+import { DatePicker } from '@alga-psa/ui/components/DatePicker';
+import { dateFromString, dateToString } from '@alga-psa/ui/lib/dateInput';
 import { Label } from '@alga-psa/ui/components/Label';
 import { Skeleton } from '@alga-psa/ui/components/Skeleton';
 import { useFormatters, useTranslation } from '@alga-psa/ui/lib/i18n/client';
@@ -409,20 +410,26 @@ const ProfitabilityReport: React.FC = () => {
         <form className="flex flex-wrap items-end gap-2" onSubmit={applyDateRange}>
           <div className="space-y-1">
             <Label htmlFor="profitability-start-date">{t('contractReports.profitability.filters.startDate', { defaultValue: 'Start Date' })}</Label>
-            <Input
+            <DatePicker
               id="profitability-start-date"
-              type="date"
-              value={draftRange.startDate}
-              onChange={(event) => setDraftRange((current) => ({ ...current, startDate: event.target.value }))}
+              label={t('contractReports.profitability.filters.startDate', { defaultValue: 'Start Date' })}
+              placeholder={t('contractReports.profitability.filters.startDate', { defaultValue: 'Start Date' })}
+              clearable
+              className="w-full"
+              value={dateFromString(draftRange.startDate)}
+              onChange={(date) => setDraftRange((current) => ({ ...current, startDate: dateToString(date) }))}
             />
           </div>
           <div className="space-y-1">
             <Label htmlFor="profitability-end-date">{t('contractReports.profitability.filters.endDate', { defaultValue: 'End Date' })}</Label>
-            <Input
+            <DatePicker
               id="profitability-end-date"
-              type="date"
-              value={draftRange.endDate}
-              onChange={(event) => setDraftRange((current) => ({ ...current, endDate: event.target.value }))}
+              label={t('contractReports.profitability.filters.endDate', { defaultValue: 'End Date' })}
+              placeholder={t('contractReports.profitability.filters.endDate', { defaultValue: 'End Date' })}
+              clearable
+              className="w-full"
+              value={dateFromString(draftRange.endDate)}
+              onChange={(date) => setDraftRange((current) => ({ ...current, endDate: dateToString(date) }))}
             />
           </div>
           <Button id="profitability-apply-date-range" type="submit">

--- a/packages/billing/src/components/settings/billing/CostRatesSettings.tsx
+++ b/packages/billing/src/components/settings/billing/CostRatesSettings.tsx
@@ -12,6 +12,7 @@ import CustomSelect from '@alga-psa/ui/components/CustomSelect';
 import { Label } from '@alga-psa/ui/components/Label';
 import Spinner from '@alga-psa/ui/components/Spinner';
 import { handleError } from '@alga-psa/ui/lib/errorHandling';
+import { dateFromString, dateToString } from '@alga-psa/ui/lib/dateInput';
 import { useTranslation, useFormatters } from '@alga-psa/ui/lib/i18n/client';
 import {
   checkCostRateWorkedTimeImpact,
@@ -72,17 +73,6 @@ function rateStatus(rate: IUserCostRate, today: string): RateStatus {
   return 'current';
 }
 
-function dateFromString(value: string): Date | undefined {
-  return value ? new Date(`${value}T00:00:00`) : undefined;
-}
-
-function dateToString(date: Date | null | undefined): string {
-  if (!date) {
-    return '';
-  }
-
-  return `${date.getFullYear()}-${String(date.getMonth() + 1).padStart(2, '0')}-${String(date.getDate()).padStart(2, '0')}`;
-}
 
 function userLabel(user: Pick<CostRateUserRow, 'first_name' | 'last_name' | 'username'>): string {
   const fullName = [user.first_name, user.last_name].filter(Boolean).join(' ').trim();

--- a/packages/billing/src/components/settings/tax/TaxComponentEditor.tsx
+++ b/packages/billing/src/components/settings/tax/TaxComponentEditor.tsx
@@ -17,6 +17,8 @@ import { MoreVertical, PlusCircle, Info } from 'lucide-react';
 import { Button } from '@alga-psa/ui/components/Button';
 import { DataTable } from '@alga-psa/ui/components/DataTable';
 import { Input } from '@alga-psa/ui/components/Input';
+import { DatePicker } from '@alga-psa/ui/components/DatePicker';
+import { dateFromString, dateToString } from '@alga-psa/ui/lib/dateInput';
 import { Label } from '@alga-psa/ui/components/Label';
 import { Switch } from '@alga-psa/ui/components/Switch';
 import { Badge } from '@alga-psa/ui/components/Badge';
@@ -558,11 +560,21 @@ export function TaxComponentEditor({ taxRateId, isReadOnly = false }: TaxCompone
               <Label htmlFor="tax-component-start-date-field">
                 {t('tax.components.fields.startDate.label', { defaultValue: 'Start Date (Optional)' })}
               </Label>
-              <Input
-                id="tax-component-start-date-field"
-                type="date"
-                {...form.register('start_date')}
-                disabled={isSubmitting}
+              <Controller
+                control={form.control}
+                name="start_date"
+                render={({ field }) => (
+                  <DatePicker
+                    id="tax-component-start-date-field"
+                    label={t('tax.components.fields.startDate.label', { defaultValue: 'Start Date (Optional)' })}
+                    placeholder={t('tax.components.fields.startDate.label', { defaultValue: 'Start Date (Optional)' })}
+                    clearable
+                    className="w-full"
+                    disabled={isSubmitting}
+                    value={dateFromString(field.value)}
+                    onChange={(date) => field.onChange(dateToString(date))}
+                  />
+                )}
               />
             </div>
 
@@ -570,11 +582,21 @@ export function TaxComponentEditor({ taxRateId, isReadOnly = false }: TaxCompone
               <Label htmlFor="tax-component-end-date-field">
                 {t('tax.components.fields.endDate.label', { defaultValue: 'End Date (Optional)' })}
               </Label>
-              <Input
-                id="tax-component-end-date-field"
-                type="date"
-                {...form.register('end_date')}
-                disabled={isSubmitting}
+              <Controller
+                control={form.control}
+                name="end_date"
+                render={({ field }) => (
+                  <DatePicker
+                    id="tax-component-end-date-field"
+                    label={t('tax.components.fields.endDate.label', { defaultValue: 'End Date (Optional)' })}
+                    placeholder={t('tax.components.fields.endDate.label', { defaultValue: 'End Date (Optional)' })}
+                    clearable
+                    className="w-full"
+                    disabled={isSubmitting}
+                    value={dateFromString(field.value)}
+                    onChange={(date) => field.onChange(dateToString(date))}
+                  />
+                )}
               />
             </div>
           </div>

--- a/packages/billing/src/components/settings/tax/TaxHolidayManager.tsx
+++ b/packages/billing/src/components/settings/tax/TaxHolidayManager.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import React, { useState, useEffect, useCallback, useMemo } from 'react';
-import { useForm } from 'react-hook-form';
+import { useForm, Controller } from 'react-hook-form';
 import { zodResolver } from '@hookform/resolvers/zod';
 import * as z from 'zod';
 import toast from 'react-hot-toast';
@@ -17,6 +17,8 @@ import { MoreVertical, PlusCircle, Info, Calendar, CalendarDays } from 'lucide-r
 import { Button } from '@alga-psa/ui/components/Button';
 import { DataTable } from '@alga-psa/ui/components/DataTable';
 import { Input } from '@alga-psa/ui/components/Input';
+import { DatePicker } from '@alga-psa/ui/components/DatePicker';
+import { dateFromString, dateToString } from '@alga-psa/ui/lib/dateInput';
 import { Label } from '@alga-psa/ui/components/Label';
 import { Badge } from '@alga-psa/ui/components/Badge';
 import GenericDialog from '@alga-psa/ui/components/GenericDialog';
@@ -435,12 +437,21 @@ export function TaxHolidayManager({ taxRateId, taxRateName, isReadOnly = false }
               <Label htmlFor="tax-holiday-start-date-field">
                 {t('tax.holidays.fields.startDate.label', { defaultValue: 'Start Date *' })}
               </Label>
-              <Input
-                id="tax-holiday-start-date-field"
-                type="date"
-                {...form.register('start_date')}
-                disabled={isSubmitting}
-                aria-invalid={form.formState.errors.start_date ? "true" : "false"}
+              <Controller
+                control={form.control}
+                name="start_date"
+                render={({ field }) => (
+                  <DatePicker
+                    id="tax-holiday-start-date-field"
+                    label={t('tax.holidays.fields.startDate.label', { defaultValue: 'Start Date *' })}
+                    placeholder={t('tax.holidays.fields.startDate.label', { defaultValue: 'Start Date *' })}
+                    clearable
+                    className="w-full"
+                    disabled={isSubmitting}
+                    value={dateFromString(field.value)}
+                    onChange={(date) => field.onChange(dateToString(date))}
+                  />
+                )}
               />
               {form.formState.errors.start_date && (
                 <p className="text-sm text-red-600" role="alert">
@@ -453,12 +464,21 @@ export function TaxHolidayManager({ taxRateId, taxRateName, isReadOnly = false }
               <Label htmlFor="tax-holiday-end-date-field">
                 {t('tax.holidays.fields.endDate.label', { defaultValue: 'End Date *' })}
               </Label>
-              <Input
-                id="tax-holiday-end-date-field"
-                type="date"
-                {...form.register('end_date')}
-                disabled={isSubmitting}
-                aria-invalid={form.formState.errors.end_date ? "true" : "false"}
+              <Controller
+                control={form.control}
+                name="end_date"
+                render={({ field }) => (
+                  <DatePicker
+                    id="tax-holiday-end-date-field"
+                    label={t('tax.holidays.fields.endDate.label', { defaultValue: 'End Date *' })}
+                    placeholder={t('tax.holidays.fields.endDate.label', { defaultValue: 'End Date *' })}
+                    clearable
+                    className="w-full"
+                    disabled={isSubmitting}
+                    value={dateFromString(field.value)}
+                    onChange={(date) => field.onChange(dateToString(date))}
+                  />
+                )}
               />
               {form.formState.errors.end_date && (
                 <p className="text-sm text-red-600" role="alert">

--- a/packages/client-portal/src/components/billing/HoursByServiceTab.tsx
+++ b/packages/client-portal/src/components/billing/HoursByServiceTab.tsx
@@ -3,6 +3,7 @@
 import React, { useMemo, useState } from 'react';
 import { Button } from '@alga-psa/ui/components/Button';
 import { DatePicker } from '@alga-psa/ui/components/DatePicker';
+import { dateFromString, dateToString } from '@alga-psa/ui/lib/dateInput';
 import { Card, CardHeader, CardTitle, CardContent } from '@alga-psa/ui/components/Card';
 import { DataTable } from '@alga-psa/ui/components/DataTable';
 import { Clock } from 'lucide-react';
@@ -60,24 +61,38 @@ const HoursByServiceTab: React.FC<HoursByServiceTabProps> = React.memo(({
             <label htmlFor="hours-start-date" className="text-sm font-medium text-gray-500 mb-1">
               Start Date
             </label>
-            <input
+            <DatePicker
               id="hours-start-date"
-              type="date"
-              className="border border-gray-300 rounded-md px-3 py-2"
-              value={dateRange.startDate}
-              onChange={(e) => handleDateRangeChange(e, 'startDate')}
+              label="Start Date"
+              placeholder="Start Date"
+              clearable
+              className="w-full"
+              value={dateFromString(dateRange.startDate)}
+              onChange={(date) =>
+                handleDateRangeChange(
+                  { target: { value: dateToString(date) } } as React.ChangeEvent<HTMLInputElement>,
+                  'startDate'
+                )
+              }
             />
           </div>
           <div className="flex flex-col">
             <label htmlFor="hours-end-date" className="text-sm font-medium text-gray-500 mb-1">
               End Date
             </label>
-            <input
+            <DatePicker
               id="hours-end-date"
-              type="date"
-              className="border border-gray-300 rounded-md px-3 py-2"
-              value={dateRange.endDate}
-              onChange={(e) => handleDateRangeChange(e, 'endDate')}
+              label="End Date"
+              placeholder="End Date"
+              clearable
+              className="w-full"
+              value={dateFromString(dateRange.endDate)}
+              onChange={(date) =>
+                handleDateRangeChange(
+                  { target: { value: dateToString(date) } } as React.ChangeEvent<HTMLInputElement>,
+                  'endDate'
+                )
+              }
             />
           </div>
           <div className="flex items-end">

--- a/packages/client-portal/src/components/billing/UsageMetricsTab.tsx
+++ b/packages/client-portal/src/components/billing/UsageMetricsTab.tsx
@@ -3,6 +3,7 @@
 import React, { useMemo, useState } from 'react';
 import { Button } from '@alga-psa/ui/components/Button';
 import { DatePicker } from '@alga-psa/ui/components/DatePicker';
+import { dateFromString, dateToString } from '@alga-psa/ui/lib/dateInput';
 import { Card, CardHeader, CardTitle, CardContent } from '@alga-psa/ui/components/Card';
 import { DataTable } from '@alga-psa/ui/components/DataTable';
 import { BarChart, Clock } from 'lucide-react';
@@ -75,24 +76,38 @@ const UsageMetricsTab: React.FC<UsageMetricsTabProps> = React.memo(({
             <label htmlFor="usage-start-date" className="text-sm font-medium text-gray-500 mb-1">
               Start Date
             </label>
-            <input
+            <DatePicker
               id="usage-start-date"
-              type="date"
-              className="border border-gray-300 rounded-md px-3 py-2"
-              value={dateRange.startDate}
-              onChange={(e) => handleDateRangeChange(e, 'startDate')}
+              label="Start Date"
+              placeholder="Start Date"
+              clearable
+              className="w-full"
+              value={dateFromString(dateRange.startDate)}
+              onChange={(date) =>
+                handleDateRangeChange(
+                  { target: { value: dateToString(date) } } as React.ChangeEvent<HTMLInputElement>,
+                  'startDate'
+                )
+              }
             />
           </div>
           <div className="flex flex-col">
             <label htmlFor="usage-end-date" className="text-sm font-medium text-gray-500 mb-1">
               End Date
             </label>
-            <input
+            <DatePicker
               id="usage-end-date"
-              type="date"
-              className="border border-gray-300 rounded-md px-3 py-2"
-              value={dateRange.endDate}
-              onChange={(e) => handleDateRangeChange(e, 'endDate')}
+              label="End Date"
+              placeholder="End Date"
+              clearable
+              className="w-full"
+              value={dateFromString(dateRange.endDate)}
+              onChange={(date) =>
+                handleDateRangeChange(
+                  { target: { value: dateToString(date) } } as React.ChangeEvent<HTMLInputElement>,
+                  'endDate'
+                )
+              }
             />
           </div>
           <div className="flex items-end">

--- a/packages/clients/src/components/clients/ClientBillingSchedule.tsx
+++ b/packages/clients/src/components/clients/ClientBillingSchedule.tsx
@@ -4,7 +4,8 @@ import React, { useEffect, useMemo, useRef, useState } from 'react';
 import { Button } from '@alga-psa/ui/components/Button';
 import CustomSelect from '@alga-psa/ui/components/CustomSelect';
 import { Dialog } from '@alga-psa/ui/components/Dialog';
-import { Input } from '@alga-psa/ui/components/Input';
+import { DatePicker } from '@alga-psa/ui/components/DatePicker';
+import { dateFromString, dateToString } from '@alga-psa/ui/lib/dateInput';
 import { Tooltip } from '@alga-psa/ui/components/Tooltip';
 import { Info } from 'lucide-react';
 import { toast } from 'react-hot-toast';
@@ -546,11 +547,14 @@ export function ClientBillingSchedule(props: { clientId: string }): React.JSX.El
           {(billingCycle === 'bi-weekly') && (
             <div className="space-y-2">
               <div className="text-sm font-medium">{t('clientBillingSchedule.firstCycleStartDate', { defaultValue: 'First cycle start date (UTC)' })}</div>
-              <Input
+              <DatePicker
                 id="client-billing-anchor-reference-date"
-                type="date"
-                value={anchorDraft.referenceDate ?? ''}
-                onChange={(e) => setAnchorDraft(d => ({ ...d, referenceDate: e.target.value || null }))}
+                label={t('clientBillingSchedule.firstCycleStartDate', { defaultValue: 'First cycle start date (UTC)' })}
+                placeholder={t('clientBillingSchedule.firstCycleStartDate', { defaultValue: 'First cycle start date (UTC)' })}
+                clearable
+                className="w-full"
+                value={dateFromString(anchorDraft.referenceDate ?? '')}
+                onChange={(date) => setAnchorDraft(d => ({ ...d, referenceDate: dateToString(date) || null }))}
               />
               <div className="text-xs text-gray-500">{t('clientBillingSchedule.firstCycleStartHelp', { defaultValue: 'Used to establish stable parity; leave blank for rolling bi-weekly cycles.' })}</div>
             </div>
@@ -583,11 +587,14 @@ export function ClientBillingSchedule(props: { clientId: string }): React.JSX.El
 
           <div className="space-y-2 border-t pt-3">
             <div className="text-sm font-medium">{t('clientBillingSchedule.historyStartDate', { defaultValue: 'Billing History Start Date (optional)' })}</div>
-            <Input
+            <DatePicker
               id="client-billing-history-start-date"
-              type="date"
-              value={billingHistoryStartDate ?? ''}
-              onChange={(e) => setBillingHistoryStartDate(e.target.value || null)}
+              label={t('clientBillingSchedule.historyStartDate', { defaultValue: 'Billing History Start Date (optional)' })}
+              placeholder={t('clientBillingSchedule.historyStartDate', { defaultValue: 'Billing History Start Date (optional)' })}
+              clearable
+              className="w-full"
+              value={dateFromString(billingHistoryStartDate ?? '')}
+              onChange={(date) => setBillingHistoryStartDate(dateToString(date) || null)}
             />
             <div className="text-xs text-gray-500">
               {t('clientBillingSchedule.historyStartHelp', { defaultValue: 'If set, historical client billing cycles are generated from the containing billing-cycle boundary through today.' })}

--- a/packages/clients/src/components/clients/ClientContractDialog.tsx
+++ b/packages/clients/src/components/clients/ClientContractDialog.tsx
@@ -5,6 +5,8 @@ import { Dialog, DialogContent } from '@alga-psa/ui/components/Dialog';
 import { Button } from '@alga-psa/ui/components/Button';
 import { Label } from '@alga-psa/ui/components/Label';
 import { Input } from '@alga-psa/ui/components/Input';
+import { DatePicker } from '@alga-psa/ui/components/DatePicker';
+import { dateFromString, dateToString } from '@alga-psa/ui/lib/dateInput';
 import { SwitchWithLabel } from '@alga-psa/ui/components/SwitchWithLabel'; // Import SwitchWithLabel
 import { Alert, AlertDescription } from '@alga-psa/ui/components/Alert';
 import CustomSelect from '@alga-psa/ui/components/CustomSelect';
@@ -247,12 +249,14 @@ export function ClientContractDialog({
             
             <div>
               <Label htmlFor="start-date">{t('clientContractDialog.startDate', { defaultValue: 'Start Date' })}</Label>
-              <Input
+              <DatePicker
                 id="start-date"
-                type="date"
-                value={startDate}
-                onChange={(e) => setStartDate(e.target.value)}
-                required
+                label={t('clientContractDialog.startDate', { defaultValue: 'Start Date' })}
+                placeholder={t('clientContractDialog.startDate', { defaultValue: 'Start Date' })}
+                clearable
+                className="w-full"
+                value={dateFromString(startDate)}
+                onChange={(date) => setStartDate(dateToString(date))}
               />
             </div>
             
@@ -271,13 +275,15 @@ export function ClientContractDialog({
               <>
                 <div>
                   <Label htmlFor="end-date">{t('clientContractDialog.endDate', { defaultValue: 'End Date' })}</Label>
-                  <Input
+                  <DatePicker
                     id="end-date"
-                    type="date"
-                    value={endDate || ''}
-                    onChange={(e) => setEndDate(e.target.value)}
-                    required={!isOngoing}
-                    min={startDate}
+                    label={t('clientContractDialog.endDate', { defaultValue: 'End Date' })}
+                    placeholder={t('clientContractDialog.endDate', { defaultValue: 'End Date' })}
+                    clearable
+                    className="w-full"
+                    value={dateFromString(endDate || '')}
+                    onChange={(date) => setEndDate(dateToString(date))}
+                    minDate={dateFromString(startDate)}
                   />
                 </div>
 

--- a/packages/clients/src/components/clients/TaxRateCreateForm.tsx
+++ b/packages/clients/src/components/clients/TaxRateCreateForm.tsx
@@ -2,6 +2,7 @@ import React, { useState, useEffect } from 'react';
 import { Button } from '@alga-psa/ui/components/Button';
 import { Input } from '@alga-psa/ui/components/Input';
 import { DatePicker } from '@alga-psa/ui/components/DatePicker';
+import { dateFromString, dateToString } from '@alga-psa/ui/lib/dateInput';
 import { Label } from '@alga-psa/ui/components/Label';
 import CustomSelect from '@alga-psa/ui/components/CustomSelect';
 import { Alert, AlertDescription } from '@alga-psa/ui/components/Alert';
@@ -218,26 +219,30 @@ const TaxRateCreateForm: React.FC<TaxRateCreateFormProps> = ({ onSuccess, onErro
             </div>
             <div>
                 <Label htmlFor="tax-rate-start-date">{t('taxRateCreateForm.startDateLabel', { defaultValue: 'Start Date *' })}</Label>
-                <Input
+                <DatePicker
                     id="tax-rate-start-date"
-                    type="date"
-                    value={startDate}
-                    onChange={(e) => {
-                        setStartDate(e.target.value);
+                    label={t('taxRateCreateForm.startDateLabel', { defaultValue: 'Start Date *' })}
+                    placeholder={t('taxRateCreateForm.startDateLabel', { defaultValue: 'Start Date *' })}
+                    clearable
+                    value={dateFromString(startDate)}
+                    onChange={(date) => {
+                        setStartDate(dateToString(date));
                         clearErrorIfSubmitted();
                     }}
                     disabled={isSubmitting}
-                    required
-                    className={hasAttemptedSubmit && !startDate ? 'border-red-500' : ''}
+                    className={hasAttemptedSubmit && !startDate ? 'w-full border-red-500' : 'w-full'}
                 />
             </div>
             <div>
                 <Label htmlFor="tax-rate-end-date">{t('taxRateCreateForm.endDateLabel', { defaultValue: 'End Date (Optional)' })}</Label>
-                <Input
+                <DatePicker
                     id="tax-rate-end-date"
-                    type="date"
-                    value={endDate}
-                    onChange={(e) => setEndDate(e.target.value)}
+                    label={t('taxRateCreateForm.endDateLabel', { defaultValue: 'End Date (Optional)' })}
+                    placeholder={t('taxRateCreateForm.endDateLabel', { defaultValue: 'End Date (Optional)' })}
+                    clearable
+                    className="w-full"
+                    value={dateFromString(endDate)}
+                    onChange={(date) => setEndDate(dateToString(date))}
                     disabled={isSubmitting}
                 />
             </div>

--- a/packages/clients/src/components/interactions/InteractionsFeed.tsx
+++ b/packages/clients/src/components/interactions/InteractionsFeed.tsx
@@ -13,6 +13,7 @@ import InteractionDetails from './InteractionDetails';
 import CustomSelect from '@alga-psa/ui/components/CustomSelect';
 import { Input } from '@alga-psa/ui/components/Input';
 import { DatePicker } from '@alga-psa/ui/components/DatePicker';
+import { dateFromString, dateToString } from '@alga-psa/ui/lib/dateInput';
 import { Button } from '@alga-psa/ui/components/Button';
 import { Dialog, DialogContent } from '@alga-psa/ui/components/Dialog';
 import { useAutomationIdAndRegister } from '@alga-psa/ui/ui-reflection/useAutomationIdAndRegister';
@@ -99,22 +100,6 @@ const InteractionsFeed: React.FC<InteractionsFeedProps> = ({
     fieldType: 'select',
     label: 'Filter by Type',
     helperText: 'Filter interactions by their type'
-  });
-
-  const { automationIdProps: startDateProps } = useAutomationIdAndRegister<FormFieldComponent>({
-    id: `${id}-start-date`,
-    type: 'formField',
-    fieldType: 'textField',
-    label: 'Start Date Filter',
-    helperText: 'Filter interactions from this date'
-  });
-
-  const { automationIdProps: endDateProps } = useAutomationIdAndRegister<FormFieldComponent>({
-    id: `${id}-end-date`,
-    type: 'formField',
-    fieldType: 'textField',
-    label: 'End Date Filter',
-    helperText: 'Filter interactions until this date'
   });
 
   const { automationIdProps: resetButtonProps } = useAutomationIdAndRegister<ButtonComponent>({
@@ -374,19 +359,23 @@ const InteractionsFeed: React.FC<InteractionsFeedProps> = ({
               onValueChange={setSelectedType}
               placeholder={t('interactions.feed.typePlaceholder', { defaultValue: 'Interaction Type' })}
             />
-            <Input
-              {...startDateProps}
-              type="date"
-              value={startDate}
-              onChange={(e) => setStartDate(e.target.value)}
+            <DatePicker
+              id={`${id}-start-date`}
+              label={t('interactions.feed.startDate', { defaultValue: 'Start Date' })}
               placeholder={t('interactions.feed.startDate', { defaultValue: 'Start Date' })}
+              clearable
+              className="w-full"
+              value={dateFromString(startDate)}
+              onChange={(date) => setStartDate(dateToString(date))}
             />
-            <Input
-              {...endDateProps}
-              type="date"
-              value={endDate}
-              onChange={(e) => setEndDate(e.target.value)}
+            <DatePicker
+              id={`${id}-end-date`}
+              label={t('interactions.feed.endDate', { defaultValue: 'End Date' })}
               placeholder={t('interactions.feed.endDate', { defaultValue: 'End Date' })}
+              clearable
+              className="w-full"
+              value={dateFromString(endDate)}
+              onChange={(date) => setEndDate(dateToString(date))}
             />
           </div>
         </DialogContent>

--- a/packages/integrations/src/components/settings/integrations/RmmAlertAutomationSettings.tsx
+++ b/packages/integrations/src/components/settings/integrations/RmmAlertAutomationSettings.tsx
@@ -5,6 +5,8 @@ import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@alga
 import { Alert, AlertDescription } from '@alga-psa/ui/components/Alert';
 import { Button } from '@alga-psa/ui/components/Button';
 import { Input } from '@alga-psa/ui/components/Input';
+import { DateTimePicker } from '@alga-psa/ui/components/DateTimePicker';
+import { dateTimeFromString, dateTimeToString } from '@alga-psa/ui/lib/dateInput';
 import { Label } from '@alga-psa/ui/components/Label';
 import CustomSelect from '@alga-psa/ui/components/CustomSelect';
 import { ClientPicker } from '@alga-psa/ui/components/ClientPicker';
@@ -969,21 +971,27 @@ function WindowEditorDialog({
           <div className="grid grid-cols-1 sm:grid-cols-2 gap-3">
             <div className="space-y-1">
               <Label htmlFor="win-starts-at">Starts at</Label>
-              <Input
+              <DateTimePicker
                 id="win-starts-at"
-                type="datetime-local"
-                value={f.startsAt}
-                onChange={(e) => setF((p) => ({ ...p, startsAt: e.target.value }))}
+                label="Starts at"
+                placeholder="Starts at"
+                clearable
+                className="w-full"
+                value={dateTimeFromString(f.startsAt)}
+                onChange={(date) => setF((p) => ({ ...p, startsAt: dateTimeToString(date) }))}
                 disabled={saving}
               />
             </div>
             <div className="space-y-1">
               <Label htmlFor="win-ends-at">Ends at</Label>
-              <Input
+              <DateTimePicker
                 id="win-ends-at"
-                type="datetime-local"
-                value={f.endsAt}
-                onChange={(e) => setF((p) => ({ ...p, endsAt: e.target.value }))}
+                label="Ends at"
+                placeholder="Ends at"
+                clearable
+                className="w-full"
+                value={dateTimeFromString(f.endsAt)}
+                onChange={(date) => setF((p) => ({ ...p, endsAt: dateTimeToString(date) }))}
                 disabled={saving}
               />
             </div>

--- a/packages/inventory/src/components/GhostUsageReport.tsx
+++ b/packages/inventory/src/components/GhostUsageReport.tsx
@@ -3,7 +3,8 @@
 import React, { useEffect, useState } from 'react';
 import { DataTable } from '@alga-psa/ui/components/DataTable';
 import { Button } from '@alga-psa/ui/components/Button';
-import { Input } from '@alga-psa/ui/components/Input';
+import { DatePicker } from '@alga-psa/ui/components/DatePicker';
+import { Label } from '@alga-psa/ui/components/Label';
 import { Badge } from '@alga-psa/ui/components/Badge';
 import { Switch } from '@alga-psa/ui/components/Switch';
 import CustomSelect from '@alga-psa/ui/components/CustomSelect';
@@ -27,6 +28,7 @@ import {
   type GhostRunResult,
   type GhostDisposition,
 } from '../actions';
+import { dateFromString, dateToString } from '@alga-psa/ui/lib/dateInput';
 
 /**
  * Ghost-usage report (PRD §16/§17): the tickets a hardware shop closed with no part
@@ -391,8 +393,14 @@ export function GhostUsageReport({
             onValueChange={(v) => setCategoryId(v)}
           />
         </div>
-        <Input id="ghost-usage-from" label={t('common.from', 'From')} type="date" value={from} onChange={(e) => setFrom(e.target.value)} />
-        <Input id="ghost-usage-to" label={t('common.to', 'To')} type="date" value={to} onChange={(e) => setTo(e.target.value)} />
+        <div>
+          <Label className="block mb-1" htmlFor="ghost-usage-from">{t('common.from', 'From')}</Label>
+          <DatePicker id="ghost-usage-from" label={t('common.from', 'From')} placeholder={t('common.from', 'From')} clearable className="w-40" value={dateFromString(from)} onChange={(date) => setFrom(dateToString(date))} />
+        </div>
+        <div>
+          <Label className="block mb-1" htmlFor="ghost-usage-to">{t('common.to', 'To')}</Label>
+          <DatePicker id="ghost-usage-to" label={t('common.to', 'To')} placeholder={t('common.to', 'To')} clearable className="w-40" value={dateFromString(to)} onChange={(date) => setTo(dateToString(date))} />
+        </div>
         <Button id="ghost-usage-run" onClick={run} disabled={loading}>
           {loading ? t('common.running', 'Running…') : t('common.runReport', 'Run report')}
         </Button>

--- a/packages/inventory/src/components/LoanersManager.tsx
+++ b/packages/inventory/src/components/LoanersManager.tsx
@@ -3,7 +3,8 @@
 import React, { useCallback, useEffect, useMemo, useState } from 'react';
 import { DataTable } from '@alga-psa/ui/components/DataTable';
 import { Button } from '@alga-psa/ui/components/Button';
-import { Input } from '@alga-psa/ui/components/Input';
+import { DatePicker } from '@alga-psa/ui/components/DatePicker';
+import { Label } from '@alga-psa/ui/components/Label';
 import { SearchInput } from '@alga-psa/ui/components/SearchInput';
 import CustomSelect from '@alga-psa/ui/components/CustomSelect';
 import { Dialog } from '@alga-psa/ui/components/Dialog';
@@ -27,6 +28,7 @@ import {
   updateLoanDueDate,
   type LoanerOutRow,
 } from '../actions';
+import { dateFromString, dateToString } from '@alga-psa/ui/lib/dateInput';
 import { UnitHistoryDialog, type UnitDetail } from './UnitHistoryDialog';
 
 const isReturnedActionError = (value: unknown) => isActionMessageError(value) || isActionPermissionError(value);
@@ -549,13 +551,20 @@ export function LoanersManager({
               onClientTypeFilterChange={setLoanClientType}
             />
           </div>
-          <Input
-            id="loaner-loan-due-at"
-            label={t('loaners.fields.dueDate', 'Due date')}
-            type="date"
-            value={loanDueAt}
-            onChange={(e) => setLoanDueAt(e.target.value)}
-          />
+          <div>
+            <Label className="block mb-1" htmlFor="loaner-loan-due-at">
+              {t('loaners.fields.dueDate', 'Due date')}
+            </Label>
+            <DatePicker
+              id="loaner-loan-due-at"
+              label={t('loaners.fields.dueDate', 'Due date')}
+              placeholder={t('loaners.fields.dueDate', 'Due date')}
+              clearable
+              className="w-full"
+              value={dateFromString(loanDueAt)}
+              onChange={(date) => setLoanDueAt(dateToString(date))}
+            />
+          </div>
           <div className="flex justify-end gap-2 pt-2">
             <Button id="loaner-loan-cancel" variant="outline" onClick={() => setLoanOpen(false)}>
               {t('common.cancel', 'Cancel')}
@@ -601,13 +610,20 @@ export function LoanersManager({
               due: fmtDueDate(extendUnit?.loan_due_at) ?? t('loaners.noDueDate', 'No due date'),
             })}
           </p>
-          <Input
-            id="loaner-extend-due-at"
-            label={t('loaners.fields.dueDate', 'Due date')}
-            type="date"
-            value={extendDueAt}
-            onChange={(e) => setExtendDueAt(e.target.value)}
-          />
+          <div>
+            <Label className="block mb-1" htmlFor="loaner-extend-due-at">
+              {t('loaners.fields.dueDate', 'Due date')}
+            </Label>
+            <DatePicker
+              id="loaner-extend-due-at"
+              label={t('loaners.fields.dueDate', 'Due date')}
+              placeholder={t('loaners.fields.dueDate', 'Due date')}
+              clearable
+              className="w-full"
+              value={dateFromString(extendDueAt)}
+              onChange={(date) => setExtendDueAt(dateToString(date))}
+            />
+          </div>
           <div className="flex justify-end gap-2 pt-2">
             <Button id="loaner-extend-cancel" variant="outline" onClick={() => setExtendUnit(null)}>
               {t('common.cancel', 'Cancel')}

--- a/packages/inventory/src/components/MarginReport.tsx
+++ b/packages/inventory/src/components/MarginReport.tsx
@@ -3,11 +3,13 @@
 import React, { useEffect, useState } from 'react';
 import { DataTable } from '@alga-psa/ui/components/DataTable';
 import { Button } from '@alga-psa/ui/components/Button';
-import { Input } from '@alga-psa/ui/components/Input';
+import { DatePicker } from '@alga-psa/ui/components/DatePicker';
+import { Label } from '@alga-psa/ui/components/Label';
 import { toast } from 'react-hot-toast';
 import type { ColumnDefinition } from '@alga-psa/types';
 import { useTranslation } from '@alga-psa/ui/lib/i18n/client';
 import { getErrorMessage, isActionMessageError, isActionPermissionError } from '@alga-psa/ui/lib/errorHandling';
+import { dateFromString, dateToString } from '@alga-psa/ui/lib/dateInput';
 import { marginReport, type MarginReport as MarginReportData, type MarginReportRow } from '../actions';
 import { CurrencyFormatProvider, useCurrencyFormat } from './dashboard/shared';
 
@@ -123,8 +125,14 @@ export function MarginReport() {
       </div>
 
       <div className="flex items-end gap-3 flex-wrap">
-        <Input id="margin-report-from" label={t('common.from', 'From')} type="date" value={from} onChange={(e) => setFrom(e.target.value)} />
-        <Input id="margin-report-to" label={t('common.to', 'To')} type="date" value={to} onChange={(e) => setTo(e.target.value)} />
+        <div>
+          <Label className="block mb-1" htmlFor="margin-report-from">{t('common.from', 'From')}</Label>
+          <DatePicker id="margin-report-from" label={t('common.from', 'From')} placeholder={t('common.from', 'From')} clearable className="w-40" value={dateFromString(from)} onChange={(date) => setFrom(dateToString(date))} />
+        </div>
+        <div>
+          <Label className="block mb-1" htmlFor="margin-report-to">{t('common.to', 'To')}</Label>
+          <DatePicker id="margin-report-to" label={t('common.to', 'To')} placeholder={t('common.to', 'To')} clearable className="w-40" value={dateFromString(to)} onChange={(date) => setTo(dateToString(date))} />
+        </div>
         <Button id="margin-report-run" onClick={run} disabled={loading}>
           {loading ? t('common.running', 'Running…') : t('common.runReport', 'Run report')}
         </Button>

--- a/packages/inventory/src/components/PurchaseOrdersManager.tsx
+++ b/packages/inventory/src/components/PurchaseOrdersManager.tsx
@@ -5,6 +5,8 @@ import { useRouter, useSearchParams } from 'next/navigation';
 import { DataTable } from '@alga-psa/ui/components/DataTable';
 import { Button } from '@alga-psa/ui/components/Button';
 import { Input } from '@alga-psa/ui/components/Input';
+import { DatePicker } from '@alga-psa/ui/components/DatePicker';
+import { Label } from '@alga-psa/ui/components/Label';
 import { SearchInput } from '@alga-psa/ui/components/SearchInput';
 import { TextArea } from '@alga-psa/ui/components/TextArea';
 import { Dialog } from '@alga-psa/ui/components/Dialog';
@@ -45,6 +47,7 @@ import {
   listInventoryProducts,
   type PurchaseOrderListRow,
 } from '../actions';
+import { dateFromString, dateToString } from '@alga-psa/ui/lib/dateInput';
 
 type ProductOption = {
   service_id: string;
@@ -728,13 +731,20 @@ export function PurchaseOrdersManager({
               onValueChange={(value) => setForm({ ...form, currency_code: value })}
               options={CURRENCY_OPTIONS.map((option) => ({ value: option.value, label: option.label }))}
             />
-            <Input
-              id="purchase-order-expected-date"
-              label={t('purchaseOrders.fields.expectedDate', 'Expected date')}
-              type="date"
-              value={form.expected_date}
-              onChange={(e) => setForm({ ...form, expected_date: e.target.value })}
-            />
+            <div>
+              <Label className="block mb-1" htmlFor="purchase-order-expected-date">
+                {t('purchaseOrders.fields.expectedDate', 'Expected date')}
+              </Label>
+              <DatePicker
+                id="purchase-order-expected-date"
+                label={t('purchaseOrders.fields.expectedDate', 'Expected date')}
+                placeholder={t('purchaseOrders.fields.expectedDate', 'Expected date')}
+                clearable
+                className="w-full"
+                value={dateFromString(form.expected_date)}
+                onChange={(date) => setForm({ ...form, expected_date: dateToString(date) })}
+              />
+            </div>
           </div>
 
           <div className="space-y-2">

--- a/packages/inventory/src/components/SalesOrdersManager.tsx
+++ b/packages/inventory/src/components/SalesOrdersManager.tsx
@@ -5,6 +5,8 @@ import { useRouter, useSearchParams } from 'next/navigation';
 import { DataTable } from '@alga-psa/ui/components/DataTable';
 import { Button } from '@alga-psa/ui/components/Button';
 import { Input } from '@alga-psa/ui/components/Input';
+import { DatePicker } from '@alga-psa/ui/components/DatePicker';
+import { Label } from '@alga-psa/ui/components/Label';
 import { CurrencyInput } from '@alga-psa/ui/components/CurrencyInput';
 import { TextArea } from '@alga-psa/ui/components/TextArea';
 import { Dialog } from '@alga-psa/ui/components/Dialog';
@@ -47,6 +49,7 @@ import {
   confirmSalesOrder,
   cancelSalesOrder,
 } from '../actions';
+import { dateFromString, dateToString } from '@alga-psa/ui/lib/dateInput';
 import {
   SalesOrderDetail,
   type ConfirmDropShipFn,
@@ -789,13 +792,20 @@ export function SalesOrdersManager({
               value={form.client_po_number}
               onChange={(e) => setForm({ ...form, client_po_number: e.target.value })}
             />
-            <Input
-              id="sales-order-expected-ship-date"
-              label={t('salesOrders.fields.expectedShipDate', 'Expected ship date')}
-              type="date"
-              value={form.expected_ship_date}
-              onChange={(e) => setForm({ ...form, expected_ship_date: e.target.value })}
-            />
+            <div>
+              <Label className="block mb-1" htmlFor="sales-order-expected-ship-date">
+                {t('salesOrders.fields.expectedShipDate', 'Expected ship date')}
+              </Label>
+              <DatePicker
+                id="sales-order-expected-ship-date"
+                label={t('salesOrders.fields.expectedShipDate', 'Expected ship date')}
+                placeholder={t('salesOrders.fields.expectedShipDate', 'Expected ship date')}
+                clearable
+                className="w-full"
+                value={dateFromString(form.expected_ship_date)}
+                onChange={(date) => setForm({ ...form, expected_ship_date: dateToString(date) })}
+              />
+            </div>
           </div>
 
           {/* Items */}

--- a/packages/inventory/src/components/WriteOffsReport.tsx
+++ b/packages/inventory/src/components/WriteOffsReport.tsx
@@ -3,13 +3,15 @@
 import React, { useState, useCallback } from 'react';
 import { DataTable } from '@alga-psa/ui/components/DataTable';
 import { Button } from '@alga-psa/ui/components/Button';
-import { Input } from '@alga-psa/ui/components/Input';
+import { DatePicker } from '@alga-psa/ui/components/DatePicker';
+import { Label } from '@alga-psa/ui/components/Label';
 import { Badge } from '@alga-psa/ui/components/Badge';
 import { toast } from 'react-hot-toast';
 import type { ColumnDefinition } from '@alga-psa/types';
 import { useTranslation } from '@alga-psa/ui/lib/i18n/client';
 import { getErrorMessage, isActionMessageError, isActionPermissionError } from '@alga-psa/ui/lib/errorHandling';
 import { useCurrencyFormat } from '@alga-psa/ui/lib';
+import { dateFromString, dateToString } from '@alga-psa/ui/lib/dateInput';
 import { writeOffReport, type WriteOffReportData, type WriteOffRow, type WriteOffByUser } from '../actions';
 
 /**
@@ -127,8 +129,14 @@ export function WriteOffsReport({ initialData }: { initialData: WriteOffReportDa
           </p>
         </div>
         <div className="flex items-end gap-2">
-          <Input id="write-offs-from" label={t('common.from', 'From')} type="date" value={from} onChange={(e) => setFrom(e.target.value)} />
-          <Input id="write-offs-to" label={t('common.to', 'To')} type="date" value={to} onChange={(e) => setTo(e.target.value)} />
+          <div>
+            <Label className="block mb-1" htmlFor="write-offs-from">{t('common.from', 'From')}</Label>
+            <DatePicker id="write-offs-from" label={t('common.from', 'From')} placeholder={t('common.from', 'From')} clearable className="w-40" value={dateFromString(from)} onChange={(date) => setFrom(dateToString(date))} />
+          </div>
+          <div>
+            <Label className="block mb-1" htmlFor="write-offs-to">{t('common.to', 'To')}</Label>
+            <DatePicker id="write-offs-to" label={t('common.to', 'To')} placeholder={t('common.to', 'To')} clearable className="w-40" value={dateFromString(to)} onChange={(date) => setTo(dateToString(date))} />
+          </div>
           <Button id="write-offs-run" onClick={run} disabled={loading}>
             {loading ? t('common.running', 'Running…') : t('common.run', 'Run')}
           </Button>

--- a/packages/opportunities/src/components/detail/OpportunityDetailHost.tsx
+++ b/packages/opportunities/src/components/detail/OpportunityDetailHost.tsx
@@ -6,6 +6,8 @@ import { toast } from 'react-hot-toast';
 import { Dialog } from '@alga-psa/ui/components/Dialog';
 import { Button } from '@alga-psa/ui/components/Button';
 import { Input } from '@alga-psa/ui/components/Input';
+import { DatePicker } from '@alga-psa/ui/components/DatePicker';
+import { dateFromString, dateToString } from '@alga-psa/ui/lib/dateInput';
 import { Label } from '@alga-psa/ui/components/Label';
 import CustomSelect from '@alga-psa/ui/components/CustomSelect';
 import { formatCurrencyFromMinorUnits } from '@alga-psa/core';
@@ -397,11 +399,14 @@ export function OpportunityDetailHost({
                   <Label htmlFor="opportunity-win-project-start">
                     {t('opportunities.winDialog.projectStart', 'Start date')}
                   </Label>
-                  <Input
+                  <DatePicker
                     id="opportunity-win-project-start"
-                    type="date"
-                    value={winProjectStartDate}
-                    onChange={(event) => setWinProjectStartDate(event.target.value)}
+                    label={t('opportunities.winDialog.projectStart', 'Start date')}
+                    placeholder={t('opportunities.winDialog.projectStart', 'Start date')}
+                    clearable
+                    className="w-full"
+                    value={dateFromString(winProjectStartDate)}
+                    onChange={(date) => setWinProjectStartDate(dateToString(date))}
                   />
                 </div>
               </div>

--- a/packages/ui/src/lib/dateInput.ts
+++ b/packages/ui/src/lib/dateInput.ts
@@ -1,0 +1,36 @@
+// Bridges between the string values that <input type="date"|"datetime-local"> used to hold
+// and the Date values the shared DatePicker / DateTimePicker components work with.
+// All parse/format is local-time, avoiding the UTC day-shift footgun of `new Date('yyyy-MM-dd')`
+// (date-only strings parse as UTC per the ES spec, so re-serializing can jump a day).
+
+/** Parse a `yyyy-MM-dd` string into a local-time Date for DatePicker. */
+export function dateFromString(value: string | null | undefined): Date | undefined {
+  return value ? new Date(`${value}T00:00:00`) : undefined;
+}
+
+/** Format a Date back into the `yyyy-MM-dd` string a date-only field expects. */
+export function dateToString(date: Date | null | undefined): string {
+  if (!date) return '';
+  const y = date.getFullYear();
+  const m = String(date.getMonth() + 1).padStart(2, '0');
+  const d = String(date.getDate()).padStart(2, '0');
+  return `${y}-${m}-${d}`;
+}
+
+/** Parse a `yyyy-MM-ddTHH:mm` string into a local-time Date for DateTimePicker. */
+export function dateTimeFromString(value: string | null | undefined): Date | undefined {
+  if (!value) return undefined;
+  const parsed = new Date(value);
+  return Number.isNaN(parsed.getTime()) ? undefined : parsed;
+}
+
+/** Format a Date back into the `yyyy-MM-ddTHH:mm` string a datetime-local field expects. */
+export function dateTimeToString(date: Date | null | undefined): string {
+  if (!date) return '';
+  const y = date.getFullYear();
+  const m = String(date.getMonth() + 1).padStart(2, '0');
+  const d = String(date.getDate()).padStart(2, '0');
+  const hh = String(date.getHours()).padStart(2, '0');
+  const mm = String(date.getMinutes()).padStart(2, '0');
+  return `${y}-${m}-${d}T${hh}:${mm}`;
+}

--- a/packages/ui/src/lib/index.ts
+++ b/packages/ui/src/lib/index.ts
@@ -1,6 +1,7 @@
 export * from './utils';
 export * from './colorUtils';
 export * from './dateFnsLocale';
+export * from './dateInput';
 export * from './errorHandling';
 export * from './cookies';
 export * from './i18n/client';

--- a/server/src/app/msp/email-logs/EmailLogsClient.tsx
+++ b/server/src/app/msp/email-logs/EmailLogsClient.tsx
@@ -4,6 +4,9 @@ import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import { Card } from '@alga-psa/ui/components/Card';
 import { DataTable } from '@alga-psa/ui/components/DataTable';
 import { Input } from '@alga-psa/ui/components/Input';
+import { DatePicker } from '@alga-psa/ui/components/DatePicker';
+import { Label } from '@alga-psa/ui/components/Label';
+import { dateFromString, dateToString } from '@alga-psa/ui/lib/dateInput';
 import { Button } from '@alga-psa/ui/components/Button';
 import { Dialog, DialogContent, DialogHeader } from '@alga-psa/ui/components/Dialog';
 import { useTranslation } from '@alga-psa/ui/lib/i18n/client';
@@ -232,20 +235,30 @@ export default function EmailLogsClient({ initialMetrics, initialLogs }: EmailLo
       <Card className="p-6">
         <div className="mb-4 flex flex-col gap-3">
           <div className="grid grid-cols-1 md:grid-cols-5 gap-3">
-            <Input
-              id="email-logs-filter-start-date"
-              type="date"
-              label={t('emailLogs.filters.startDate')}
-              value={startDate}
-              onChange={(e) => setStartDate(e.target.value)}
-            />
-            <Input
-              id="email-logs-filter-end-date"
-              type="date"
-              label={t('emailLogs.filters.endDate')}
-              value={endDate}
-              onChange={(e) => setEndDate(e.target.value)}
-            />
+            <div>
+              <Label className="block mb-1" htmlFor="email-logs-filter-start-date">{t('emailLogs.filters.startDate')}</Label>
+              <DatePicker
+                id="email-logs-filter-start-date"
+                label={t('emailLogs.filters.startDate')}
+                placeholder={t('emailLogs.filters.startDate')}
+                clearable
+                className="w-full"
+                value={dateFromString(startDate)}
+                onChange={(date) => setStartDate(dateToString(date))}
+              />
+            </div>
+            <div>
+              <Label className="block mb-1" htmlFor="email-logs-filter-end-date">{t('emailLogs.filters.endDate')}</Label>
+              <DatePicker
+                id="email-logs-filter-end-date"
+                label={t('emailLogs.filters.endDate')}
+                placeholder={t('emailLogs.filters.endDate')}
+                clearable
+                className="w-full"
+                value={dateFromString(endDate)}
+                onChange={(date) => setEndDate(dateToString(date))}
+              />
+            </div>
             <div>
               <label className="block text-sm font-medium text-[rgb(var(--color-text-700))] mb-1">{t('emailLogs.filters.status')}</label>
               <select

--- a/server/src/components/settings/profile/ApiKeysSetup.tsx
+++ b/server/src/components/settings/profile/ApiKeysSetup.tsx
@@ -12,6 +12,8 @@ import { Dialog, DialogContent } from '@alga-psa/ui/components/Dialog';
 import { DataTable } from '@alga-psa/ui/components/DataTable';
 import CustomSelect from '@alga-psa/ui/components/CustomSelect';
 import { DatePicker } from '@alga-psa/ui/components/DatePicker';
+import { DateTimePicker } from '@alga-psa/ui/components/DateTimePicker';
+import { dateTimeFromString, dateTimeToString } from '@alga-psa/ui/lib/dateInput';
 import type { ColumnDefinition } from '@alga-psa/types';
 import { createApiKey, deactivateApiKey, listApiKeys } from '@/lib/actions/apiKeyActions';
 import { useRouter } from 'next/navigation';
@@ -269,12 +271,14 @@ export default function ApiKeysSetup() {
           </div>
           <div>
             <Label htmlFor="api-key-expiration">{t('security.apiKeys.generate.expiration', 'Expiration Date (Optional)')}</Label>
-            <Input
+            <DateTimePicker
               id="api-key-expiration"
-              type="datetime-local"
-              value={expirationDate}
-              onChange={(e) => setExpirationDate(e.target.value)}
+              label={t('security.apiKeys.generate.expiration', 'Expiration Date (Optional)')}
+              placeholder={t('security.apiKeys.generate.expiration', 'Expiration Date (Optional)')}
+              clearable
               className="mt-1"
+              value={dateTimeFromString(expirationDate)}
+              onChange={(date) => setExpirationDate(dateTimeToString(date))}
             />
           </div>
           <Button


### PR DESCRIPTION
Swap every raw <input type="date"|"datetime-local"> across inventory, billing, clients, client-portal, opportunities, integrations, server, and ee for the canonical DatePicker / DateTimePicker components â consistent theming, locale-aware display, and UI-reflection registration. Promote the string bridges (dateFromString/dateToString, dateTimeFromString/ dateTimeToString) into @alga-psa/ui/lib/dateInput and drop the duplicated copies in inventory and CostRatesSettings. RHF-bound tax fields converted via Controller.

"Why, a native date input is like the Mad Hatter's watch," said the Cat, grinning at the calendar popover, "it tells the day but never the same one twice â until dateFromString pinned midnight to the local hour and the day stopped hopping like a March hare."