### PR TITLE
Fix Level.io RMM sync failure on fractional RAM

### DIFF
--- a/ee/server/src/__tests__/unit/integrations/levelioDeviceMapper.test.ts
+++ b/ee/server/src/__tests__/unit/integrations/levelioDeviceMapper.test.ts
@@ -158,6 +158,20 @@ describe('mapLevelIoDeviceToSnapshot', () => {
     expect(snapshot.extension?.antivirusProduct).toBe('Defender');
   });
 
+  it('rounds fractional RAM to a whole integer for the integer ram_gb column', () => {
+    // Level reports usable memory, so a "16 GB" machine reports ~15.74 GB.
+    // ram_gb is a Postgres integer column; a decimal fails the insert with
+    // "invalid input syntax for type integer: 15.74".
+    const snapshot = mapLevelIoDeviceToSnapshot({
+      integrationId: 'int-1',
+      device: makeDevice({ total_memory: Math.round(15.74 * 1024 ** 3) }),
+      scopeId: 'g-root',
+    });
+
+    expect(snapshot.extension?.ramGb).toBe(16);
+    expect(Number.isInteger(snapshot.extension?.ramGb)).toBe(true);
+  });
+
   it('marks offline devices offline with no uptime', () => {
     const snapshot = mapLevelIoDeviceToSnapshot({
       integrationId: 'int-1',

--- a/ee/server/src/lib/integrations/levelio/mappers/deviceMapper.ts
+++ b/ee/server/src/lib/integrations/levelio/mappers/deviceMapper.ts
@@ -139,7 +139,9 @@ export function mapLevelIoDeviceToSnapshot(args: {
       pendingOsPatches: args.pendingOsPatches ?? null,
       cpuModel: cpu?.model ?? null,
       cpuCores: device.cpu_cores ?? cpu?.cores ?? null,
-      ramGb: typeof device.total_memory === 'number' ? roundTo2(device.total_memory / BYTES_PER_GB) : null,
+      // ram_gb is an integer column; round to whole GB (matches NinjaOne's getRamGb).
+      // roundTo2 here produced decimals like 15.74 that Postgres rejects for type integer.
+      ramGb: typeof device.total_memory === 'number' ? Math.round(device.total_memory / BYTES_PER_GB) : null,
       diskUsage: mapLevelIoDiskUsage(device),
       systemInfo: {
         manufacturer: device.manufacturer ?? null,


### PR DESCRIPTION
The device mapper computed ram_gb with roundTo2, producing decimals like 15.74 for a "16 GB" machine (Level reports usable memory). The ram_gb column is a Postgres integer, so the asset insert aborted with "invalid input syntax for type integer", which failed the whole sync and blocked alert-webhook provisioning downstream.

Round to whole GB with Math.round to match the integer column and NinjaOne's getRamGb convention. Add a regression test covering the fractional-RAM case, which the existing exact-16-GB test never hit.

And so the Caterpillar's hookah-smoke of 15.74 gigabytes was rounded to a tidy 16, for no sensible integer column will suffer half a puff of memory to pass through its gates. 🐛💨🧮