### PR TITLE
docs: reflect numbering consolidation — fix quote number format example

### DIFF
--- a/docs/billing/quoting-system.md
+++ b/docs/billing/quoting-system.md
@@ -30,7 +30,7 @@ Quotes are pre-sale pricing proposals that MSPs create for clients. A quote cont
 
 Key capabilities:
 - Full CRUD with tenant isolation
-- Sequential numbering (Q-0001, Q-0002, ...) via `SharedNumberingService`
+- Sequential numbering (`QUO-0001`, `QUO-0002`, …) via `SharedNumberingService`; configure prefix and format under **Settings > Billing > Numbering**
 - Status-driven lifecycle with enforced transitions
 - Reusable business templates (predefined line item configurations)
 - Professional PDF generation using the shared AST template engine
@@ -89,7 +89,7 @@ Primary entity table with Citus-compatible composite keys.
 |--------|------|-------------|
 | `tenant` | UUID | Tenant isolation key |
 | `quote_id` | UUID | Primary identifier |
-| `quote_number` | TEXT | Human-readable number (Q-0001) |
+| `quote_number` | TEXT | Human-readable number (QUO-0001) |
 | `client_id` | UUID | Associated client |
 | `contact_id` | UUID | Primary contact |
 | `title` | TEXT | Quote title |
@@ -265,7 +265,7 @@ When a sent or rejected quote needs changes, a **revision** is created rather th
 2. `parent_quote_id` links to the original quote (first version)
 3. All `quote_items` are cloned to the new version
 4. The old version's status is set to `superseded`
-5. The same `quote_number` is reused across versions (displayed as "Q-0042 v2")
+5. The same `quote_number` is reused across versions (displayed as "QUO-0042 v2")
 
 The version history chain can be queried via `parent_quote_id` to display all versions with navigation in the UI.
 


### PR DESCRIPTION
## Source PRs

| # | Title | Link |
|---|---|---|
| #2952 | Test metrics dashboard, numbering consolidation, and infra suite burn-down start | https://github.com/Nine-Minds/alga-psa/pull/2952 |
| #2955 | Fix/numbering service test selfinit | https://github.com/Nine-Minds/alga-psa/pull/2955 |

## Files edited

### `docs/billing/quoting-system.md`

**Rationale:** The Overview section gave `Q-0001, Q-0002, …` as the quote number format example. The canonical default prefix established by `NUMBERING_DEFAULTS` (introduced/consolidated in #2952) is `QUO-` with 4-digit padding, producing `QUO-0001`. The example and the revision-history note (`Q-0042 v2` → `QUO-0042 v2`) have been updated to match the actual service output. A cross-reference to **Settings > Billing > Numbering** (the tab renamed from "Quoting" in #2955) is added so developers know where tenants configure this.

## Needs human review

- **PR #2955: Opportunity numbering settings** — PR #2955 adds a new "Opportunity Numbering" section to the Opportunities settings page (default prefix `OPP-`). No existing doc in `docs/` explicitly covers the Opportunities settings UI, so it is unclear whether a new doc section is warranted or whether there is an out-of-scope doc to update. Flagged for human judgement.
- **PR #2955: Credit Note numbering** — The new `Numbering` tab includes a Credit Note Numbering card (default prefix `CM-`). The existing `docs/billing/credits_and_reconciliation.md` may benefit from a note that credit note number format is now configurable under **Settings > Billing > Numbering**, but the change is additive rather than corrective; left for human review.
- **Search index entries** in `nm-store` — `packages/nm-store/src/lib/developer-portal/search/` may contain entries for billing settings or quoting that reference the old "Quoting" tab name. These were not evaluated in this run.

---
_Generated by [Claude Code](https://claude.ai/code/session_01BttjzWTQSZwWh3QhSoohq9)_