### PR TITLE
Repair the four known-red unit/package tests so the CI unit

### DIFF
--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -97,13 +97,13 @@ jobs:
       # 71 tests fail without them) and its clients reconnect forever, so the
       # vitest process never exits and hangs the job. It has no place in a
       # unit-test gate until its tests stub their connections.
-      # Non-blocking until the runner layer is repaired: the @nx/vite:test
-      # executor is broken under vitest 4 (fails even fully-green suites, and
-      # reports "Unable to load test config from config file undefined" for
-      # the ~20 projects with no vitest.config), so a red step here measures
-      # the executor, not the tests. Past green runs were Nx cache replays.
-      # Restore blocking once the executor is fixed and a real failure
-      # baseline exists.
+      # Non-blocking while the last known-red package suites are burned down.
+      # The runner layer itself is sound again: test targets resolve via
+      # nx:run-script (each package's own `npm run test` -> vitest), not the
+      # @nx/vite:test executor whose vitest-4 breakage ("Unable to load test
+      # config from config file undefined") originally forced these flags —
+      # that error no longer appears, and red steps now report real test
+      # failures. Flip continue-on-error off once the remaining reds are fixed.
       - name: Nx affected tests (libraries, parallel)
         continue-on-error: true
         run: npx nx affected -t test --base=$NX_BASE --head=$NX_HEAD --output-style=static --parallel=3 --exclude=server,sebastian-ee,temporal-workflows

--- a/packages/billing/tests/DraftInvoiceDetailsCard.test.tsx
+++ b/packages/billing/tests/DraftInvoiceDetailsCard.test.tsx
@@ -12,6 +12,26 @@ vi.mock('@alga-psa/billing/actions/invoiceModification', () => ({
   updateDraftInvoiceProperties: (...args: unknown[]) => updateDraftInvoicePropertiesMock(...args),
 }));
 
+vi.mock('@alga-psa/ui/components/DatePicker', () => ({
+  // The real DatePicker is a Radix popover + calendar, which getByDisplayValue /
+  // fireEvent.change cannot drive. Render it as a native date input while
+  // preserving the Date-based onChange contract: (date: Date | undefined) => void.
+  DatePicker: ({ value, onChange, id, placeholder, label, clearable, displayFormat, minDate, maxDate, collapsible, ...props }: any) => {
+    const toDateString = (d: Date) =>
+      `${d.getFullYear()}-${String(d.getMonth() + 1).padStart(2, '0')}-${String(d.getDate()).padStart(2, '0')}`;
+    return (
+      <input
+        id={id}
+        type="date"
+        placeholder={placeholder}
+        value={value instanceof Date ? toDateString(value) : ''}
+        onChange={(e) => onChange?.(e.target.value ? new Date(`${e.target.value}T00:00:00`) : undefined)}
+        {...props}
+      />
+    );
+  },
+}));
+
 const draftInvoice = {
   invoice_id: 'inv-1',
   invoice_number: 'INV-1001',

--- a/packages/tickets/src/components/settings/BoardsSettings.copyStatuses.test.tsx
+++ b/packages/tickets/src/components/settings/BoardsSettings.copyStatuses.test.tsx
@@ -348,6 +348,13 @@ describe('BoardsSettings ticket status copy flow', () => {
     await waitFor(() => {
       expect(getAllBoardsMock).toHaveBeenCalledWith(true);
     });
+    // Also wait for the fetched boards to render before interacting: the add
+    // handler reads the committed `boards` state (falling back to create_inline
+    // seeding when boards.length === 0), so clicking while the resolved boards
+    // are still uncommitted races away the copy-statuses select on slow runners.
+    await waitFor(() => {
+      expect(document.querySelector('[id^="board-row-"]')).toBeTruthy();
+    });
 
     fireEvent.click(screen.getByTestId('add-board-button'));
 
@@ -415,6 +422,13 @@ describe('BoardsSettings ticket status copy flow', () => {
     await waitFor(() => {
       expect(getAllBoardsMock).toHaveBeenCalledWith(true);
     });
+    // Also wait for the fetched boards to render before interacting: the add
+    // handler reads the committed `boards` state (falling back to create_inline
+    // seeding when boards.length === 0), so clicking while the resolved boards
+    // are still uncommitted races away the copy-statuses select on slow runners.
+    await waitFor(() => {
+      expect(document.querySelector('[id^="board-row-"]')).toBeTruthy();
+    });
 
     fireEvent.click(screen.getByTestId('add-board-button'));
     fireEvent.change(screen.getByTestId('copy-ticket-statuses-select'), {
@@ -445,6 +459,13 @@ describe('BoardsSettings ticket status copy flow', () => {
 
     await waitFor(() => {
       expect(getAllBoardsMock).toHaveBeenCalledWith(true);
+    });
+    // Also wait for the fetched boards to render before interacting: the add
+    // handler reads the committed `boards` state (falling back to create_inline
+    // seeding when boards.length === 0), so clicking while the resolved boards
+    // are still uncommitted races away the copy-statuses select on slow runners.
+    await waitFor(() => {
+      expect(document.querySelector('[id^="board-row-"]')).toBeTruthy();
     });
 
     fireEvent.click(screen.getByTestId('add-board-button'));
@@ -490,6 +511,13 @@ describe('BoardsSettings ticket status copy flow', () => {
 
     await waitFor(() => {
       expect(getAllBoardsMock).toHaveBeenCalledWith(true);
+    });
+    // Also wait for the fetched boards to render before interacting: the add
+    // handler reads the committed `boards` state (falling back to create_inline
+    // seeding when boards.length === 0), so clicking while the resolved boards
+    // are still uncommitted races away the copy-statuses select on slow runners.
+    await waitFor(() => {
+      expect(document.querySelector('[id^="board-row-"]')).toBeTruthy();
     });
 
     fireEvent.click(screen.getByTestId('add-board-button'));
@@ -544,6 +572,13 @@ describe('BoardsSettings ticket status copy flow', () => {
 
     await waitFor(() => {
       expect(getAllBoardsMock).toHaveBeenCalledWith(true);
+    });
+    // Also wait for the fetched boards to render before interacting: the add
+    // handler reads the committed `boards` state (falling back to create_inline
+    // seeding when boards.length === 0), so clicking while the resolved boards
+    // are still uncommitted races away the copy-statuses select on slow runners.
+    await waitFor(() => {
+      expect(document.querySelector('[id^="board-row-"]')).toBeTruthy();
     });
 
     fireEvent.click(screen.getByTestId('add-board-button'));
@@ -600,6 +635,13 @@ describe('BoardsSettings ticket status copy flow', () => {
     await waitFor(() => {
       expect(getAllBoardsMock).toHaveBeenCalledWith(true);
     });
+    // Also wait for the fetched boards to render before interacting: the add
+    // handler reads the committed `boards` state (falling back to create_inline
+    // seeding when boards.length === 0), so clicking while the resolved boards
+    // are still uncommitted races away the copy-statuses select on slow runners.
+    await waitFor(() => {
+      expect(document.querySelector('[id^="board-row-"]')).toBeTruthy();
+    });
 
     fireEvent.click(screen.getAllByText('ticketing.boards.actions.edit')[0]);
 
@@ -618,6 +660,13 @@ describe('BoardsSettings ticket status copy flow', () => {
 
     await waitFor(() => {
       expect(getAllBoardsMock).toHaveBeenCalledWith(true);
+    });
+    // Also wait for the fetched boards to render before interacting: the add
+    // handler reads the committed `boards` state (falling back to create_inline
+    // seeding when boards.length === 0), so clicking while the resolved boards
+    // are still uncommitted races away the copy-statuses select on slow runners.
+    await waitFor(() => {
+      expect(document.querySelector('[id^="board-row-"]')).toBeTruthy();
     });
 
     fireEvent.click(screen.getByTestId('add-board-button'));
@@ -647,6 +696,13 @@ describe('BoardsSettings ticket status copy flow', () => {
     await waitFor(() => {
       expect(getAllBoardsMock).toHaveBeenCalledWith(true);
     });
+    // Also wait for the fetched boards to render before interacting: the add
+    // handler reads the committed `boards` state (falling back to create_inline
+    // seeding when boards.length === 0), so clicking while the resolved boards
+    // are still uncommitted races away the copy-statuses select on slow runners.
+    await waitFor(() => {
+      expect(document.querySelector('[id^="board-row-"]')).toBeTruthy();
+    });
 
     fireEvent.click(document.getElementById('board-row-board-source') as HTMLElement);
 
@@ -673,6 +729,13 @@ describe('BoardsSettings ticket status copy flow', () => {
 
     await waitFor(() => {
       expect(getAllBoardsMock).toHaveBeenCalledWith(true);
+    });
+    // Also wait for the fetched boards to render before interacting: the add
+    // handler reads the committed `boards` state (falling back to create_inline
+    // seeding when boards.length === 0), so clicking while the resolved boards
+    // are still uncommitted races away the copy-statuses select on slow runners.
+    await waitFor(() => {
+      expect(document.querySelector('[id^="board-row-"]')).toBeTruthy();
     });
 
     fireEvent.click(document.getElementById('board-row-board-source') as HTMLElement);
@@ -715,6 +778,13 @@ describe('BoardsSettings ticket status copy flow', () => {
     await waitFor(() => {
       expect(getAllBoardsMock).toHaveBeenCalledWith(true);
     });
+    // Also wait for the fetched boards to render before interacting: the add
+    // handler reads the committed `boards` state (falling back to create_inline
+    // seeding when boards.length === 0), so clicking while the resolved boards
+    // are still uncommitted races away the copy-statuses select on slow runners.
+    await waitFor(() => {
+      expect(document.querySelector('[id^="board-row-"]')).toBeTruthy();
+    });
 
     fireEvent.click(document.getElementById('board-row-board-source') as HTMLElement);
 
@@ -750,6 +820,13 @@ describe('BoardsSettings ticket status copy flow', () => {
     await waitFor(() => {
       expect(getAllBoardsMock).toHaveBeenCalledWith(true);
     });
+    // Also wait for the fetched boards to render before interacting: the add
+    // handler reads the committed `boards` state (falling back to create_inline
+    // seeding when boards.length === 0), so clicking while the resolved boards
+    // are still uncommitted races away the copy-statuses select on slow runners.
+    await waitFor(() => {
+      expect(document.querySelector('[id^="board-row-"]')).toBeTruthy();
+    });
 
     // Page 1 shows the first 10 boards only.
     await waitFor(() => {
@@ -778,6 +855,13 @@ describe('BoardsSettings ticket status copy flow', () => {
 
     await waitFor(() => {
       expect(getAllBoardsMock).toHaveBeenCalledWith(true);
+    });
+    // Also wait for the fetched boards to render before interacting: the add
+    // handler reads the committed `boards` state (falling back to create_inline
+    // seeding when boards.length === 0), so clicking while the resolved boards
+    // are still uncommitted races away the copy-statuses select on slow runners.
+    await waitFor(() => {
+      expect(document.querySelector('[id^="board-row-"]')).toBeTruthy();
     });
 
     // Default 10 per page: the 11th board is on page 2.

--- a/packages/ui/src/components/contact-picker-inline-add.test.tsx
+++ b/packages/ui/src/components/contact-picker-inline-add.test.tsx
@@ -173,7 +173,11 @@ describe('ContactPicker', () => {
     option.focus();
     expect(document.activeElement).toBe(option);
 
-    await user.keyboard('{Enter}');
+    // Dispatch Enter to the option directly rather than via user.keyboard():
+    // the picker's open-dropdown rAF (ContactPicker focus-search effect) can
+    // fire during user-event's internal await on a slow runner and steal
+    // focus back to the search input, sending the keydown to the wrong node.
+    fireEvent.keyDown(option, { key: 'Enter' });
 
     expect(onValueChange).toHaveBeenCalledWith('contact-1');
     expect(screen.queryByRole('listbox', { name: /contacts/i })).toBeNull();

--- a/server/src/test/unit/email/EmailLogsClient.ui.test.tsx
+++ b/server/src/test/unit/email/EmailLogsClient.ui.test.tsx
@@ -27,6 +27,26 @@ vi.mock('@alga-psa/ui/components/Button', () => ({
   ),
 }));
 
+vi.mock('@alga-psa/ui/components/DatePicker', () => ({
+  // The real DatePicker is a Radix popover + calendar, which fireEvent.change
+  // cannot drive. Render it as a native date input while preserving the
+  // Date-based onChange contract: (date: Date | undefined) => void.
+  DatePicker: ({ value, onChange, id, placeholder, label, clearable, displayFormat, minDate, maxDate, collapsible, ...props }: any) => {
+    const toDateString = (d: Date) =>
+      `${d.getFullYear()}-${String(d.getMonth() + 1).padStart(2, '0')}-${String(d.getDate()).padStart(2, '0')}`;
+    return (
+      <input
+        id={id}
+        type="date"
+        placeholder={placeholder}
+        value={value instanceof Date ? toDateString(value) : ''}
+        onChange={(e) => onChange?.(e.target.value ? new Date(`${e.target.value}T00:00:00`) : undefined)}
+        {...props}
+      />
+    );
+  },
+}));
+
 vi.mock('@alga-psa/ui/components/Dialog', () => ({
   Dialog: ({ isOpen, children }: any) => (isOpen ? <div data-testid="dialog">{children}</div> : null),
   DialogHeader: ({ children }: any) => <div>{children}</div>,


### PR DESCRIPTION
gate can be re-armed:

- EmailLogsClient + DraftInvoiceDetailsCard: mock the shared DatePicker as a native date input — the date_picker_sweep replaced raw <input type="date"> with a Radix popover that fireEvent/getByDisplayValue cannot drive
- contact-picker-inline-add: dispatch Enter via fireEvent.keyDown on the option; the picker's open-dropdown rAF steals focus back to the search input mid-user.keyboard() on slow runners
- BoardsSettings.copyStatuses: wait for board rows to render before clicking add — the handler falls back to create_inline seeding while the fetched boards are still uncommitted
- unit-tests.yml: retire the stale @nx/vite:test executor note; non-blocking status now reflects the red-suite burn-down only

"Off with its rAF!" cried the Queen of Hearts, as the focus thief was caught red-handed fleeing to the search input. "In THIS wonderland, an Enter key lands where it is aimed, a DatePicker tells the truth in plain yyyy-MM-dd, and no board seeds itself before the boards have bloomed." 🃏⏰🌹