### PR TITLE
Ability to edit contract lines

### DIFF
--- a/packages/billing/src/actions/contractLineServiceActions.ts
+++ b/packages/billing/src/actions/contractLineServiceActions.ts
@@ -22,6 +22,23 @@ import type { ActionMessageError, ActionPermissionError } from '@alga-psa/ui/lib
 type TenantScopedKnex = Knex | Knex.Transaction;
 export type ContractLineServiceActionError = ActionMessageError | ActionPermissionError;
 
+export interface ContractLineServiceMembershipAddition {
+  serviceId: string;
+  quantity?: number;
+  customRate?: number | null;
+  configurationType: 'Fixed' | 'Hourly' | 'Usage';
+  typeConfig?: Partial<
+    IContractLineServiceFixedConfig |
+    IContractLineServiceHourlyConfig |
+    IContractLineServiceUsageConfig
+  >;
+}
+
+export interface ContractLineServiceMembershipChanges {
+  additions: ContractLineServiceMembershipAddition[];
+  removals: string[];
+}
+
 type ContractLineServiceWithConfiguration = {
   service: IService & { service_type_name?: string };
   configuration: IContractLineServiceConfiguration;
@@ -49,6 +66,7 @@ function contractLineServiceActionErrorFrom(error: unknown): ContractLineService
   if (error instanceof Error) {
     if (
       error.message === 'Service management for template lines currently supports fixed fee lines only.' ||
+      error.message === 'System-managed default contracts are attribution-only; contract-line service configuration authoring is disabled.' ||
       error.message === 'Products can only be added to fixed-fee contract lines.' ||
       error.message.includes('cannot be attached to contract lines') ||
       error.message.includes('does not have') ||
@@ -330,6 +348,272 @@ async function addServiceToTemplateLine(
   return configId;
 }
 
+async function addServiceToLiveContractLine(
+  trx: Knex.Transaction,
+  tenant: string,
+  contractLineId: string,
+  serviceId: string,
+  quantity?: number,
+  customRate?: number | null,
+  configType?: 'Fixed' | 'Hourly' | 'Usage' | 'Bucket',
+  typeConfig?: Partial<
+    IContractLineServiceFixedConfig |
+    IContractLineServiceHourlyConfig |
+    IContractLineServiceUsageConfig |
+    IContractLineServiceBucketConfig
+  >,
+): Promise<string> {
+  const service = await tenantScopedTable(trx, tenant, 'service_catalog')
+    .where({ service_id: serviceId })
+    .first() as IService | undefined;
+  if (!service) {
+    throw new Error(`Service ${serviceId} not found`);
+  }
+
+  const contractLine = await assertLiveContractLineIsAuthorable(trx, tenant, contractLineId);
+  if (service.is_active === false) {
+    throw new Error(`"${service.service_name}" is inactive and cannot be attached to contract lines.`);
+  }
+
+  if (service.item_kind === 'product') {
+    if (contractLine.contract_line_type !== 'Fixed') {
+      throw new Error('Products can only be added to fixed-fee contract lines.');
+    }
+
+    const contract = contractLine.contract_id
+      ? await tenantScopedTable(trx, tenant, 'contracts')
+          .where({ contract_id: contractLine.contract_id })
+          .select('currency_code')
+          .first()
+      : null;
+    const currencyCode = contract?.currency_code ?? 'USD';
+    const hasOverride = customRate !== undefined && customRate !== null;
+    if (!hasOverride) {
+      const priceRow = await tenantScopedTable(trx, tenant, 'service_prices')
+        .where({ service_id: serviceId, currency_code: currencyCode })
+        .select('price_id')
+        .first();
+      if (!priceRow) {
+        throw new Error(
+          `Product "${service.service_name}" does not have ${currencyCode} pricing. Add a price in the catalog or enter a custom rate.`
+        );
+      }
+    }
+  }
+
+  const allowedConfigTypesByLine: Record<
+    'Fixed' | 'Hourly' | 'Usage',
+    Array<'Fixed' | 'Hourly' | 'Usage' | 'Bucket'>
+  > = {
+    Fixed: ['Fixed', 'Bucket'],
+    Hourly: ['Hourly', 'Bucket'],
+    Usage: ['Usage', 'Bucket'],
+  };
+  const configurationType = configType ?? contractLine.contract_line_type;
+  const allowedConfigTypes = allowedConfigTypesByLine[
+    contractLine.contract_line_type as 'Fixed' | 'Hourly' | 'Usage'
+  ] ?? ['Fixed'];
+  if (!allowedConfigTypes.includes(configurationType)) {
+    throw new Error(
+      `Configuration type ${configurationType} is not valid for ${contractLine.contract_line_type} contract lines. Allowed: ${allowedConfigTypes.join(', ')}.`
+    );
+  }
+
+  let resolvedTypeConfig = typeConfig || {};
+  if (configurationType === 'Bucket') {
+    resolvedTypeConfig = {
+      ...resolvedTypeConfig,
+      overage_rate:
+        (resolvedTypeConfig as Partial<IContractLineServiceBucketConfig>).overage_rate
+        ?? service.default_rate,
+    };
+  } else if (configurationType === 'Hourly') {
+    const providedHourly = resolvedTypeConfig as Partial<IContractLineServiceHourlyConfig>;
+    const hourlyRateValue = providedHourly.hourly_rate ?? service.default_rate;
+    if (hourlyRateValue === undefined || hourlyRateValue === null) {
+      throw new Error(`Service ${service.service_name} requires an hourly rate before it can be added to an hourly contract line.`);
+    }
+    const hourlyRate = Number(hourlyRateValue);
+    if (!Number.isFinite(hourlyRate)) {
+      throw new Error(`Hourly rate for service ${service.service_name} must be a numeric value.`);
+    }
+    resolvedTypeConfig = {
+      ...providedHourly,
+      hourly_rate: hourlyRate,
+      minimum_billable_time:
+        Number(providedHourly.minimum_billable_time) > 0
+          ? Number(providedHourly.minimum_billable_time)
+          : 15,
+      round_up_to_nearest:
+        Number(providedHourly.round_up_to_nearest) > 0
+          ? Number(providedHourly.round_up_to_nearest)
+          : 15,
+    };
+  }
+
+  const existingMembership = await tenantScopedTable(trx, tenant, 'contract_line_services')
+    .where({ contract_line_id: contractLineId, service_id: serviceId })
+    .first();
+  if (!existingMembership) {
+    await tenantScopedTable(trx, tenant, 'contract_line_services').insert({
+      tenant,
+      contract_line_id: contractLineId,
+      service_id: serviceId,
+    });
+  }
+
+  const configurationService = new ContractLineServiceConfigurationService(trx, tenant);
+  const existingConfig = await configurationService.getConfigurationForService(contractLineId, serviceId);
+  if (existingConfig) {
+    await configurationService.updateConfiguration(
+      existingConfig.config_id,
+      {
+        configuration_type: configurationType,
+        custom_rate: customRate,
+        quantity: quantity || 1,
+      },
+      resolvedTypeConfig,
+    );
+    return existingConfig.config_id;
+  }
+
+  return configurationService.createConfiguration(
+    {
+      tenant,
+      contract_line_id: contractLineId,
+      service_id: serviceId,
+      configuration_type: configurationType,
+      custom_rate: customRate,
+      quantity: quantity || 1,
+    },
+    resolvedTypeConfig,
+  );
+}
+
+async function assertLiveContractLineIsAuthorable(
+  trx: Knex.Transaction,
+  tenant: string,
+  contractLineId: string,
+) {
+  const contractLine = await tenantScopedTable(trx, tenant, 'contract_lines')
+    .where({ contract_line_id: contractLineId })
+    .first();
+  if (!contractLine) {
+    throw new Error(`Contract line ${contractLineId} not found`);
+  }
+
+  if (contractLine.contract_id) {
+    const contract = await tenantScopedTable(trx, tenant, 'contracts')
+      .where({ contract_id: contractLine.contract_id })
+      .select('is_system_managed_default')
+      .first();
+    if (contract?.is_system_managed_default === true) {
+      throw new Error('System-managed default contracts are attribution-only; contract-line service configuration authoring is disabled.');
+    }
+  }
+  return contractLine;
+}
+
+async function removeServiceFromTemplateLine(
+  trx: Knex.Transaction,
+  tenant: string,
+  contractLineId: string,
+  serviceId: string,
+): Promise<void> {
+  const templateConfigs = await tenantScopedTable(trx, tenant, 'contract_template_line_service_configuration')
+    .where({ template_line_id: contractLineId, service_id: serviceId })
+    .select('config_id');
+  if (templateConfigs.length > 0) {
+    const configIds = (templateConfigs as Array<{ config_id: string }>).map((config) => config.config_id);
+    await tenantScopedTable(trx, tenant, 'contract_template_line_service_hourly_config')
+      .whereIn('config_id', configIds)
+      .delete();
+    await tenantScopedTable(trx, tenant, 'contract_template_line_service_usage_config')
+      .whereIn('config_id', configIds)
+      .delete();
+    await tenantScopedTable(trx, tenant, 'contract_template_line_service_bucket_config')
+      .whereIn('config_id', configIds)
+      .delete();
+    await tenantScopedTable(trx, tenant, 'contract_template_line_service_configuration')
+      .whereIn('config_id', configIds)
+      .delete();
+  }
+  await tenantScopedTable(trx, tenant, 'contract_template_line_services')
+    .where({ template_line_id: contractLineId, service_id: serviceId })
+    .delete();
+}
+
+async function removeServiceFromLiveContractLine(
+  trx: Knex.Transaction,
+  tenant: string,
+  contractLineId: string,
+  serviceId: string,
+): Promise<void> {
+  await assertLiveContractLineIsAuthorable(trx, tenant, contractLineId);
+  const configurationService = new ContractLineServiceConfigurationService(trx, tenant);
+  const configurations = await configurationService.getConfigurationsForPlan(contractLineId);
+  for (const configuration of configurations) {
+    if (configuration.service_id === serviceId) {
+      await configurationService.deleteConfiguration(configuration.config_id);
+    }
+  }
+  await tenantScopedTable(trx, tenant, 'contract_line_services')
+    .where({ contract_line_id: contractLineId, service_id: serviceId })
+    .delete();
+}
+
+async function addServiceToContractLineInTransaction(
+  trx: Knex.Transaction,
+  tenant: string,
+  contractLineId: string,
+  serviceId: string,
+  quantity?: number,
+  customRate?: number | null,
+  configType?: 'Fixed' | 'Hourly' | 'Usage' | 'Bucket',
+  typeConfig?: Partial<
+    IContractLineServiceFixedConfig |
+    IContractLineServiceHourlyConfig |
+    IContractLineServiceUsageConfig |
+    IContractLineServiceBucketConfig
+  >,
+): Promise<string> {
+  const templateLine = await findTemplateLine(trx, tenant, contractLineId);
+  if (templateLine) {
+    return addServiceToTemplateLine(
+      trx,
+      tenant,
+      templateLine,
+      serviceId,
+      quantity,
+      customRate ?? undefined,
+    );
+  }
+  return addServiceToLiveContractLine(
+    trx,
+    tenant,
+    contractLineId,
+    serviceId,
+    quantity,
+    customRate,
+    configType,
+    typeConfig,
+  );
+}
+
+async function removeServiceFromContractLineInTransaction(
+  trx: Knex.Transaction,
+  tenant: string,
+  contractLineId: string,
+  serviceId: string,
+): Promise<void> {
+  const templateLine = await findTemplateLine(trx, tenant, contractLineId);
+  if (templateLine) {
+    await removeServiceFromTemplateLine(trx, tenant, contractLineId, serviceId);
+    return;
+  }
+  await removeServiceFromLiveContractLine(trx, tenant, contractLineId, serviceId);
+}
+
 /**
  * Add a service to a plan with configuration
  */
@@ -351,203 +635,18 @@ export const addServiceToContractLine = withAuth(async (
     if (!tenant) {
       throw new Error('tenant context not found');
     }
-    return withTransaction(db, async (trx: Knex.Transaction) => {
-      const templateLine = await findTemplateLine(trx, tenant, contractLineId);
-      if (templateLine) {
-        return addServiceToTemplateLine(trx, tenant, templateLine, serviceId, quantity, customRate);
-      }
-
-      const service = await tenantScopedTable(trx, tenant, 'service_catalog')
-        .where({
-          service_id: serviceId,
-        })
-        .first() as IService | undefined;
-
-      if (!service) {
-        throw new Error(`Service ${serviceId} not found`);
-      }
-
-      const plan = await tenantScopedTable(trx, tenant, 'contract_lines')
-        .where({
-          contract_line_id: contractLineId,
-        })
-        .first();
-
-      if (!plan) {
-        throw new Error(`Contract line ${contractLineId} not found`);
-      }
-
-      if (service.is_active === false) {
-        throw new Error(`"${service.service_name}" is inactive and cannot be attached to contract lines.`);
-      }
-
-      if (service.item_kind === 'product') {
-        if (plan.contract_line_type !== 'Fixed') {
-          throw new Error(`Products can only be added to fixed-fee contract lines.`);
-        }
-
-        const contract = plan.contract_id
-          ? await tenantScopedTable(trx, tenant, 'contracts').where({ contract_id: plan.contract_id }).select('currency_code').first()
-          : null;
-        const currencyCode = contract?.currency_code ?? 'USD';
-
-        const hasOverride = customRate !== undefined && customRate !== null;
-        if (!hasOverride) {
-          const priceRow = await tenantScopedTable(trx, tenant, 'service_prices')
-            .where({
-              service_id: serviceId,
-              currency_code: currencyCode
-            })
-            .select('price_id')
-            .first();
-
-          if (!priceRow) {
-            throw new Error(
-              `Product "${service.service_name}" does not have ${currencyCode} pricing. Add a price in the catalog or enter a custom rate.`
-            );
-          }
-        }
-      }
-
-      const allowedConfigTypesByPlan: Record<'Fixed' | 'Hourly' | 'Usage', Array<'Fixed' | 'Hourly' | 'Usage' | 'Bucket'>> = {
-        Fixed: ['Fixed', 'Bucket'],
-        Hourly: ['Hourly', 'Bucket'],
-        Usage: ['Usage', 'Bucket'],
-      };
-
-      if (configType) {
-        const allowedConfigTypes = allowedConfigTypesByPlan[plan.contract_line_type as 'Fixed' | 'Hourly' | 'Usage'] ?? ['Fixed'];
-        if (!allowedConfigTypes.includes(configType)) {
-          throw new Error(
-            `Configuration type ${configType} is not valid for ${plan.contract_line_type} contract lines. Allowed: ${allowedConfigTypes.join(', ')}.`
-          );
-        }
-      }
-
-      const determinedConfigType: 'Fixed' | 'Hourly' | 'Usage' | 'Bucket' = configType
-        ?? (
-          plan.contract_line_type === 'Hourly'
-            ? 'Hourly'
-            : plan.contract_line_type === 'Usage'
-              ? 'Usage'
-              : 'Fixed'
-        );
-
-      const configurationType = determinedConfigType;
-      let hourlyConfigPayload: Partial<IContractLineServiceHourlyConfig> | undefined;
-
-      if (configurationType === 'Bucket') {
-        typeConfig = typeConfig || {};
-        if ((typeConfig as Partial<IContractLineServiceBucketConfig>)?.overage_rate === undefined) {
-          (typeConfig as Partial<IContractLineServiceBucketConfig>).overage_rate = service.default_rate;
-        }
-      } else if (configurationType === 'Hourly') {
-        const providedHourly = (typeConfig as Partial<IContractLineServiceHourlyConfig>) || {};
-        const resolvedHourlyRate =
-          typeof providedHourly.hourly_rate !== 'undefined'
-            ? providedHourly.hourly_rate
-            : service.default_rate;
-
-        if (resolvedHourlyRate === undefined || resolvedHourlyRate === null) {
-          throw new Error(`Service ${service.service_name} requires an hourly rate before it can be added to an hourly contract line.`);
-        }
-
-        const normalizedHourlyRate = Number(resolvedHourlyRate);
-        if (Number.isNaN(normalizedHourlyRate)) {
-          throw new Error(`Hourly rate for service ${service.service_name} must be a numeric value.`);
-        }
-
-        const minimumBillableCandidate = Number(
-          typeof providedHourly.minimum_billable_time !== 'undefined'
-            ? providedHourly.minimum_billable_time
-            : 15
-        );
-        const roundUpCandidate = Number(
-          typeof providedHourly.round_up_to_nearest !== 'undefined'
-            ? providedHourly.round_up_to_nearest
-            : 15
-        );
-
-        const minimumBillableTime = Number.isFinite(minimumBillableCandidate) && minimumBillableCandidate > 0
-          ? minimumBillableCandidate
-          : 15;
-        const roundUpToNearest = Number.isFinite(roundUpCandidate) && roundUpCandidate > 0
-          ? roundUpCandidate
-          : 15;
-
-        hourlyConfigPayload = {
-          hourly_rate: normalizedHourlyRate,
-          minimum_billable_time: minimumBillableTime,
-          round_up_to_nearest: roundUpToNearest,
-        };
-
-        typeConfig = hourlyConfigPayload;
-      }
-
-      const existingPlanService = await getContractLineService(contractLineId, serviceId);
-      if (isReturnedActionError(existingPlanService)) {
-        return existingPlanService;
-      }
-
-      if (!existingPlanService) {
-        await tenantScopedTable(trx, tenant, 'contract_line_services').insert({
-          contract_line_id: contractLineId,
-          service_id: serviceId,
-          tenant: tenant
-        });
-      }
-
-      const existingConfig = await planServiceConfigActions.getConfigurationForService(contractLineId, serviceId);
-      if (isReturnedActionError(existingConfig)) {
-        return existingConfig;
-      }
-
-      let configId: string | ContractLineServiceActionError;
-
-      if (existingConfig) {
-        const updateResult = await planServiceConfigActions.updateConfiguration(
-          existingConfig.config_id,
-          {
-            configuration_type: configurationType,
-            custom_rate: customRate,
-            quantity: quantity || 1
-          },
-          typeConfig || {}
-        );
-        if (isReturnedActionError(updateResult)) {
-          return updateResult;
-        }
-        configId = existingConfig.config_id;
-      } else {
-        configId = await planServiceConfigActions.createConfiguration(
-          {
-            contract_line_id: contractLineId,
-            service_id: serviceId,
-            configuration_type: configurationType,
-            custom_rate: customRate,
-            quantity: quantity || 1,
-            tenant: tenant!
-          },
-          typeConfig || {}
-        );
-        if (isReturnedActionError(configId)) {
-          return configId;
-        }
-      }
-
-      if (configurationType === 'Hourly' && hourlyConfigPayload) {
-        const hourlyResult = await planServiceConfigActions.upsertPlanServiceHourlyConfiguration(
-          contractLineId,
-          serviceId,
-          hourlyConfigPayload
-        );
-        if (isReturnedActionError(hourlyResult)) {
-          return hourlyResult;
-        }
-      }
-
-      return configId;
-    });
+    return await withTransaction(db, (trx: Knex.Transaction) =>
+      addServiceToContractLineInTransaction(
+        trx,
+        tenant,
+        contractLineId,
+        serviceId,
+        quantity,
+        customRate,
+        configType,
+        typeConfig,
+      )
+    );
   } catch (error) {
     console.error(`Error adding service ${serviceId} to contract line ${contractLineId}:`, error);
     const expected = contractLineServiceActionErrorFrom(error);
@@ -656,69 +755,74 @@ export const removeServiceFromContractLine = withAuth(async (
     if (!tenant) {
       throw new Error('tenant context not found');
     }
-    return withTransaction(db, async (trx: Knex.Transaction) => {
-      const templateLine = await findTemplateLine(trx, tenant, contractLineId);
-      if (templateLine) {
-        const templateConfigs = await tenantScopedTable(trx, tenant, 'contract_template_line_service_configuration')
-          .where({
-            template_line_id: contractLineId,
-            service_id: serviceId,
-          })
-          .select('config_id');
-
-        if (templateConfigs.length > 0) {
-          const configIds = (templateConfigs as any[]).map((config: any) => config.config_id);
-
-          await tenantScopedTable(trx, tenant, 'contract_template_line_service_hourly_config')
-            .whereIn('config_id', configIds)
-            .delete();
-
-          await tenantScopedTable(trx, tenant, 'contract_template_line_service_usage_config')
-            .whereIn('config_id', configIds)
-            .delete();
-
-          await tenantScopedTable(trx, tenant, 'contract_template_line_service_bucket_config')
-            .whereIn('config_id', configIds)
-            .delete();
-
-          await tenantScopedTable(trx, tenant, 'contract_template_line_service_configuration')
-            .whereIn('config_id', configIds)
-            .delete();
-        }
-
-        await tenantScopedTable(trx, tenant, 'contract_template_line_services')
-          .where({
-            template_line_id: contractLineId,
-            service_id: serviceId,
-          })
-          .delete();
-
-        return true;
-      }
-
-      const config = await planServiceConfigActions.getConfigurationForService(contractLineId, serviceId);
-      if (isReturnedActionError(config)) {
-        return config;
-      }
-
-      if (config) {
-        const deleteResult = await planServiceConfigActions.deleteConfiguration(config.config_id);
-        if (isReturnedActionError(deleteResult)) {
-          return deleteResult;
-        }
-      }
-
-      await tenantScopedTable(trx, tenant, 'contract_line_services')
-        .where({
-          contract_line_id: contractLineId,
-          service_id: serviceId,
-        })
-        .delete();
-
+    return await withTransaction(db, async (trx: Knex.Transaction) => {
+      await removeServiceFromContractLineInTransaction(trx, tenant, contractLineId, serviceId);
       return true;
     });
   } catch (error) {
     console.error(`Error removing service ${serviceId} from contract line ${contractLineId}:`, error);
+    const expected = contractLineServiceActionErrorFrom(error);
+    if (expected) {
+      return expected;
+    }
+    throw error;
+  }
+});
+
+/**
+ * Apply all staged membership changes from the contract-line editor in one
+ * transaction. The editor intentionally calls this only from its outer Save
+ * action; opening the picker or pressing Remove never mutates persisted data.
+ */
+export const applyContractLineServiceMembershipChanges = withAuth(async (
+  user,
+  { tenant },
+  contractLineId: string,
+  changes: ContractLineServiceMembershipChanges,
+): Promise<boolean | ContractLineServiceActionError> => {
+  try {
+    if (changes.additions.length > 0 && !await hasPermission(user, 'billing', 'create')) {
+      return permissionError('Permission denied: billing create required');
+    }
+    if (changes.removals.length > 0 && !await hasPermission(user, 'billing', 'delete')) {
+      return permissionError('Permission denied: billing delete required');
+    }
+    if (!tenant) {
+      throw new Error('tenant context not found');
+    }
+
+    const additionIds = changes.additions.map((addition) => addition.serviceId);
+    if (new Set(additionIds).size !== additionIds.length) {
+      return actionError('A service can only be added once in a contract line edit.');
+    }
+    if (new Set(changes.removals).size !== changes.removals.length) {
+      return actionError('A service can only be removed once in a contract line edit.');
+    }
+    if (changes.removals.some((serviceId) => additionIds.includes(serviceId))) {
+      return actionError('The same service cannot be added and removed in one contract line edit.');
+    }
+
+    const { knex: db } = await createTenantKnex();
+    return await withTransaction(db, async (trx: Knex.Transaction) => {
+      for (const serviceId of changes.removals) {
+        await removeServiceFromContractLineInTransaction(trx, tenant, contractLineId, serviceId);
+      }
+      for (const addition of changes.additions) {
+        await addServiceToContractLineInTransaction(
+          trx,
+          tenant,
+          contractLineId,
+          addition.serviceId,
+          addition.quantity,
+          addition.customRate,
+          addition.configurationType,
+          addition.typeConfig,
+        );
+      }
+      return true;
+    });
+  } catch (error) {
+    console.error(`Error applying service membership changes to contract line ${contractLineId}:`, error);
     const expected = contractLineServiceActionErrorFrom(error);
     if (expected) {
       return expected;

--- a/packages/billing/src/components/billing-dashboard/contracts/ContractLines.tsx
+++ b/packages/billing/src/components/billing-dashboard/contracts/ContractLines.tsx
@@ -16,9 +16,10 @@ import {
 } from '@alga-psa/billing/actions/contractLineMappingActions';
 import { checkContractHasInvoices } from '@alga-psa/billing/actions/contractActions';
 import {
+  applyContractLineServiceMembershipChanges,
   getContractLineServicesWithConfigurations,
   getTemplateLineServicesWithConfigurations,
-  removeServiceFromContractLine,
+  type ContractLineServiceMembershipAddition,
 } from '@alga-psa/billing/actions/contractLineServiceActions';
 import {
   updateConfiguration,
@@ -34,7 +35,10 @@ import LoadingIndicator from '@alga-psa/ui/components/LoadingIndicator';
 import { Badge } from '@alga-psa/ui/components/Badge';
 import { AddContractLinesDialog } from './AddContractLinesDialog';
 import { CreateCustomContractLineDialog } from './CreateCustomContractLineDialog';
-import { ServiceSelectionDialog } from '../service-config/ServiceSelectionDialog';
+import {
+  ServiceSelectionDialog,
+  type ContractLineServiceSelection,
+} from '../service-config/ServiceSelectionDialog';
 import { SwitchWithLabel } from '@alga-psa/ui/components/SwitchWithLabel';
 import { BucketOverlayFields } from './BucketOverlayFields';
 import { BucketOverlayInput } from './ContractWizard';
@@ -118,6 +122,13 @@ interface ServiceConfiguration {
   bucketConfig?: any; // Add bucketConfig property for merged bucket data
 }
 
+interface PendingServiceAddition {
+  selection: ContractLineServiceSelection;
+  draftConfigurationId: string;
+}
+
+const DRAFT_SERVICE_CONFIG_PREFIX = 'draft-service-config:';
+
 const ContractLines: React.FC<ContractLinesProps> = ({ contract, clientId = null, onContractLinesChanged, isReadOnly = false }) => {
   const { t } = useTranslation('msp/contracts');
   const { formatCurrency } = useFormatters();
@@ -158,6 +169,8 @@ const ContractLines: React.FC<ContractLinesProps> = ({ contract, clientId = null
   const [editLineData, setEditLineData] = useState<Partial<DetailedContractLineMapping>>({});
   const [editServiceConfigs, setEditServiceConfigs] = useState<Record<string, any>>({});
   const [editBucketConfigs, setEditBucketConfigs] = useState<Record<string, BucketOverlayInput | null>>({});
+  const [pendingServiceAdditions, setPendingServiceAdditions] = useState<PendingServiceAddition[]>([]);
+  const [pendingServiceRemovalIds, setPendingServiceRemovalIds] = useState<string[]>([]);
 
   // Location grouping state
   const [clientLocations, setClientLocations] = useState<BillingLocationSummary[]>([]);
@@ -396,10 +409,31 @@ const ContractLines: React.FC<ContractLinesProps> = ({ contract, clientId = null
     setEditBucketConfigs(bucketConfigsData);
   };
 
-  const refreshServicesForEditing = async (contractLineId: string) => {
-    const services = await loadServicesForLine(contractLineId, true);
-    initializeServiceConfigEdits(services);
+  const resetServiceMembershipDraft = () => {
+    setPendingServiceAdditions([]);
+    setPendingServiceRemovalIds([]);
   };
+
+  const createDraftServiceConfiguration = (
+    contractLineId: string,
+    pendingAddition: PendingServiceAddition,
+  ): ServiceConfiguration => ({
+    service: {
+      service_id: pendingAddition.selection.service.service_id,
+      service_name: pendingAddition.selection.service.service_name,
+      billing_method: pendingAddition.selection.service.billing_method,
+    },
+    configuration: {
+      config_id: pendingAddition.draftConfigurationId,
+      service_id: pendingAddition.selection.service.service_id,
+      contract_line_id: contractLineId,
+      configuration_type: pendingAddition.selection.configurationType,
+      custom_rate: pendingAddition.selection.customRate,
+      quantity: pendingAddition.selection.quantity,
+    },
+    typeConfig: pendingAddition.selection.typeConfig,
+    bucketConfig: null,
+  });
 
   const handleAddContractLines = async () => {
     if (!contract.contract_id) return;
@@ -470,6 +504,7 @@ const ContractLines: React.FC<ContractLinesProps> = ({ contract, clientId = null
         location_id: line.location_id ?? defaultLocationId ?? null,
       });
       initializeServiceConfigEdits(services);
+      resetServiceMembershipDraft();
     } catch (err) {
       console.error('Error checking contract invoices:', err);
       setError(t('contractLines.errors.failedToCheckEditable', {
@@ -478,35 +513,86 @@ const ContractLines: React.FC<ContractLinesProps> = ({ contract, clientId = null
     }
   };
 
-  const handleRemoveService = async (contractLineId: string, serviceId: string) => {
+  const handleRemoveService = (contractLineId: string, serviceId: string, configId: string) => {
     setError(null);
-    try {
-      const result = await removeServiceFromContractLine(contractLineId, serviceId);
-      if (isReturnedActionError(result)) {
-        setError(getErrorMessage(result));
-        return;
-      }
-
-      await refreshServicesForEditing(contractLineId);
-      onContractLinesChanged?.();
-    } catch (err) {
-      console.error('Error removing service from contract line:', err);
-      setError(t('contractLines.errors.failedToUpdate', {
-        defaultValue: 'Failed to update contract line',
-      }));
+    if (configId.startsWith(DRAFT_SERVICE_CONFIG_PREFIX)) {
+      setPendingServiceAdditions((current) =>
+        current.filter((addition) => addition.selection.service.service_id !== serviceId)
+      );
+      setEditServiceConfigs((current) => {
+        const next = { ...current };
+        delete next[configId];
+        return next;
+      });
+      setEditBucketConfigs((current) => {
+        const next = { ...current };
+        delete next[serviceId];
+        return next;
+      });
+      return;
     }
+
+    if (!lineServices[contractLineId]?.some((service) => service.service.service_id === serviceId)) {
+      return;
+    }
+
+    setPendingServiceRemovalIds((current) =>
+      current.includes(serviceId) ? current : [...current, serviceId]
+    );
   };
 
-  const handleServicesAdded = async (contractLineId: string) => {
-    try {
-      await refreshServicesForEditing(contractLineId);
-      onContractLinesChanged?.();
-    } catch (err) {
-      console.error('Error refreshing services after adding to contract line:', err);
-      setError(t('contractLines.errors.failedToUpdate', {
-        defaultValue: 'Failed to update contract line',
-      }));
-    }
+  const handleServicesSelected = (
+    contractLineId: string,
+    selections: ContractLineServiceSelection[],
+  ) => {
+    const persistedServiceIds = new Set(
+      (lineServices[contractLineId] || []).map((service) => service.service.service_id)
+    );
+    const pendingServiceIds = new Set(
+      pendingServiceAdditions.map((addition) => addition.selection.service.service_id)
+    );
+    const newSelections = selections.filter((selection) => {
+      const serviceId = selection.service.service_id;
+      return !persistedServiceIds.has(serviceId) && !pendingServiceIds.has(serviceId);
+    });
+    const newAdditions = newSelections.map((selection) => ({
+      selection,
+      draftConfigurationId: `${DRAFT_SERVICE_CONFIG_PREFIX}${selection.service.service_id}`,
+    }));
+
+    setPendingServiceRemovalIds((current) =>
+      current.filter((serviceId) => !selections.some(
+        (selection) => selection.service.service_id === serviceId && persistedServiceIds.has(serviceId)
+      ))
+    );
+    setPendingServiceAdditions((current) => [...current, ...newAdditions]);
+    setEditServiceConfigs((configs) => {
+      const next = { ...configs };
+      for (const addition of newAdditions) {
+        const { selection, draftConfigurationId } = addition;
+        next[draftConfigurationId] = {
+          quantity: selection.quantity,
+          custom_rate: selection.customRate,
+          hourly_rate: 'hourly_rate' in selection.typeConfig
+            ? selection.typeConfig.hourly_rate
+            : undefined,
+          base_rate: 'base_rate' in selection.typeConfig
+            ? selection.typeConfig.base_rate
+            : undefined,
+          unit_of_measure: 'unit_of_measure' in selection.typeConfig
+            ? selection.typeConfig.unit_of_measure
+            : undefined,
+        };
+      }
+      return next;
+    });
+    setEditBucketConfigs((configs) => {
+      const next = { ...configs };
+      for (const addition of newAdditions) {
+        next[addition.selection.service.service_id] = null;
+      }
+      return next;
+    });
   };
 
   const handleSaveContractLine = async (contractLineId: string) => {
@@ -533,7 +619,9 @@ const ContractLines: React.FC<ContractLinesProps> = ({ contract, clientId = null
 
       // Update all service configurations based on what was actually edited
       // Use editServiceConfigs keys to ensure we update the correct config_ids
-      const services = lineServices[contractLineId] || [];
+      const services = (lineServices[contractLineId] || []).filter(
+        (service) => !pendingServiceRemovalIds.includes(service.service.service_id)
+      );
 
       // Build a map of service_id to serviceConfig for bucket updates
       const serviceById = new Map();
@@ -578,8 +666,47 @@ const ContractLines: React.FC<ContractLinesProps> = ({ contract, clientId = null
         }
       }
 
-      // Update bucket configurations separately
+      const additions: ContractLineServiceMembershipAddition[] = pendingServiceAdditions.map((addition) => {
+        const editData = editServiceConfigs[addition.draftConfigurationId] || {};
+        const typeConfig = addition.selection.configurationType === 'Hourly'
+          ? { hourly_rate: editData.hourly_rate ?? addition.selection.customRate }
+          : addition.selection.configurationType === 'Usage'
+            ? {
+                base_rate: editData.base_rate ?? addition.selection.customRate,
+                unit_of_measure:
+                  editData.unit_of_measure || addition.selection.service.unit_of_measure || 'unit',
+              }
+            : { base_rate: editData.base_rate ?? addition.selection.customRate };
+
+        return {
+          serviceId: addition.selection.service.service_id,
+          quantity: editData.quantity ?? addition.selection.quantity,
+          customRate: editData.custom_rate ?? addition.selection.customRate,
+          configurationType: addition.selection.configurationType,
+          typeConfig,
+        };
+      });
+
+      if (additions.length > 0 || pendingServiceRemovalIds.length > 0) {
+        const membershipResult = await applyContractLineServiceMembershipChanges(
+          contractLineId,
+          {
+            additions,
+            removals: pendingServiceRemovalIds,
+          }
+        );
+        if (isReturnedActionError(membershipResult)) {
+          setError(getErrorMessage(membershipResult));
+          return;
+        }
+      }
+
+      // Persist memberships before bucket overlays so a newly selected service
+      // has its primary configuration available to the bucket upsert.
       for (const [serviceId, bucketConfig] of Object.entries(editBucketConfigs)) {
+        if (pendingServiceRemovalIds.includes(serviceId)) {
+          continue;
+        }
         if (bucketConfig && bucketConfig.total_minutes !== undefined && bucketConfig.overage_rate !== undefined) {
           const bucketResult = await upsertContractLineServiceBucketConfigurationAction(
             contractLineId,
@@ -612,6 +739,7 @@ const ContractLines: React.FC<ContractLinesProps> = ({ contract, clientId = null
       setEditLineData({});
       setEditServiceConfigs({});
       setEditBucketConfigs({});
+      resetServiceMembershipDraft();
       setShowServiceSelectionDialog(false);
       onContractLinesChanged?.();
     } catch (err) {
@@ -627,6 +755,7 @@ const ContractLines: React.FC<ContractLinesProps> = ({ contract, clientId = null
     setEditLineData({});
     setEditServiceConfigs({});
     setEditBucketConfigs({});
+    resetServiceMembershipDraft();
     setShowServiceSelectionDialog(false);
   };
 
@@ -640,11 +769,18 @@ const ContractLines: React.FC<ContractLinesProps> = ({ contract, clientId = null
   const editingLine = editingLineId
     ? contractLines.find((line) => line.contract_line_id === editingLineId)
     : undefined;
-  const editingLineServiceIds = editingLineId
-    ? (lineServices[editingLineId] || [])
-        .filter((service) => service.configuration.configuration_type !== 'Bucket')
-        .map((service) => service.service.service_id)
-    : [];
+  const editingLineServiceIds = useMemo(() => editingLineId
+    ? [
+        ...(lineServices[editingLineId] || [])
+          .filter(
+            (service) =>
+              service.configuration.configuration_type !== 'Bucket' &&
+              !pendingServiceRemovalIds.includes(service.service.service_id)
+          )
+          .map((service) => service.service.service_id),
+        ...pendingServiceAdditions.map((addition) => addition.selection.service.service_id),
+      ]
+    : [], [editingLineId, lineServices, pendingServiceAdditions, pendingServiceRemovalIds]);
 
   if (isLoading) {
     return (
@@ -822,7 +958,17 @@ const ContractLines: React.FC<ContractLinesProps> = ({ contract, clientId = null
                     <div className="space-y-2">
                       {group.lines.map((line) => {
               const isExpanded = expandedLines[line.contract_line_id];
-              const services = lineServices[line.contract_line_id] || [];
+              const persistedServices = lineServices[line.contract_line_id] || [];
+              const services = editingLineId === line.contract_line_id
+                ? [
+                    ...persistedServices.filter(
+                      (service) => !pendingServiceRemovalIds.includes(service.service.service_id)
+                    ),
+                    ...pendingServiceAdditions.map((addition) =>
+                      createDraftServiceConfiguration(line.contract_line_id, addition)
+                    ),
+                  ]
+                : persistedServices;
               const isLoadingServices = loadingServices[line.contract_line_id];
               const isSavingLine = savingLineId === line.contract_line_id;
 
@@ -1290,9 +1436,10 @@ const ContractLines: React.FC<ContractLinesProps> = ({ contract, clientId = null
                                             type="button"
                                             variant="ghost"
                                             size="sm"
-                                            onClick={() => void handleRemoveService(
+                                            onClick={() => handleRemoveService(
                                               line.contract_line_id,
                                               serviceConfig.service.service_id,
+                                              serviceConfig.configuration.config_id,
                                             )}
                                             className="text-destructive hover:bg-destructive/10 hover:text-destructive"
                                             disabled={isSavingLine}
@@ -1566,11 +1713,12 @@ const ContractLines: React.FC<ContractLinesProps> = ({ contract, clientId = null
             <ServiceSelectionDialog
               isOpen={showServiceSelectionDialog}
               onClose={() => setShowServiceSelectionDialog(false)}
-              contractLineId={editingLine.contract_line_id}
               contractLineType={editingLine.contract_line_type as 'Fixed' | 'Hourly' | 'Usage'}
               currencyCode={contract.currency_code || 'USD'}
               existingServiceIds={editingLineServiceIds}
-              onServiceAdded={() => void handleServicesAdded(editingLine.contract_line_id)}
+              onServicesSelected={(selections) =>
+                handleServicesSelected(editingLine.contract_line_id, selections)
+              }
             />
           )}
         </>

--- a/packages/billing/src/components/billing-dashboard/contracts/ContractLines.tsx
+++ b/packages/billing/src/components/billing-dashboard/contracts/ContractLines.tsx
@@ -18,6 +18,7 @@ import { checkContractHasInvoices } from '@alga-psa/billing/actions/contractActi
 import {
   getContractLineServicesWithConfigurations,
   getTemplateLineServicesWithConfigurations,
+  removeServiceFromContractLine,
 } from '@alga-psa/billing/actions/contractLineServiceActions';
 import {
   updateConfiguration,
@@ -33,6 +34,7 @@ import LoadingIndicator from '@alga-psa/ui/components/LoadingIndicator';
 import { Badge } from '@alga-psa/ui/components/Badge';
 import { AddContractLinesDialog } from './AddContractLinesDialog';
 import { CreateCustomContractLineDialog } from './CreateCustomContractLineDialog';
+import { ServiceSelectionDialog } from '../service-config/ServiceSelectionDialog';
 import { SwitchWithLabel } from '@alga-psa/ui/components/SwitchWithLabel';
 import { BucketOverlayFields } from './BucketOverlayFields';
 import { BucketOverlayInput } from './ContractWizard';
@@ -150,6 +152,7 @@ const ContractLines: React.FC<ContractLinesProps> = ({ contract, clientId = null
   const [loadingServices, setLoadingServices] = useState<Record<string, boolean>>({});
   const [showAddDialog, setShowAddDialog] = useState(false);
   const [showCreateCustomDialog, setShowCreateCustomDialog] = useState(false);
+  const [showServiceSelectionDialog, setShowServiceSelectionDialog] = useState(false);
   const [editingLineId, setEditingLineId] = useState<string | null>(null);
   const [savingLineId, setSavingLineId] = useState<string | null>(null);
   const [editLineData, setEditLineData] = useState<Partial<DetailedContractLineMapping>>({});
@@ -362,6 +365,42 @@ const ContractLines: React.FC<ContractLinesProps> = ({ contract, clientId = null
     }
   };
 
+  const initializeServiceConfigEdits = (services: ServiceConfiguration[]) => {
+    const serviceConfigsData: Record<string, any> = {};
+    const bucketConfigsData: Record<string, BucketOverlayInput | null> = {};
+
+    // Bucket configurations are represented by the bucketConfig property on
+    // their parent service rather than as independently editable services.
+    services.filter(s => s.configuration.configuration_type !== 'Bucket').forEach(serviceConfig => {
+      const serviceId = serviceConfig.service.service_id;
+
+      serviceConfigsData[serviceConfig.configuration.config_id] = {
+        quantity: serviceConfig.configuration.quantity ?? 1,
+        custom_rate: serviceConfig.configuration.custom_rate,
+        hourly_rate: serviceConfig.typeConfig?.hourly_rate,
+        base_rate: serviceConfig.typeConfig?.base_rate,
+        unit_of_measure: serviceConfig.typeConfig?.unit_of_measure,
+      };
+
+      bucketConfigsData[serviceId] = serviceConfig.bucketConfig
+        ? {
+            total_minutes: serviceConfig.bucketConfig.total_minutes,
+            overage_rate: serviceConfig.bucketConfig.overage_rate,
+            allow_rollover: serviceConfig.bucketConfig.allow_rollover,
+            billing_period: serviceConfig.bucketConfig.billing_period,
+          }
+        : null;
+    });
+
+    setEditServiceConfigs(serviceConfigsData);
+    setEditBucketConfigs(bucketConfigsData);
+  };
+
+  const refreshServicesForEditing = async (contractLineId: string) => {
+    const services = await loadServicesForLine(contractLineId, true);
+    initializeServiceConfigEdits(services);
+  };
+
   const handleAddContractLines = async () => {
     if (!contract.contract_id) return;
 
@@ -430,40 +469,42 @@ const ContractLines: React.FC<ContractLinesProps> = ({ contract, clientId = null
         round_up_to_nearest: line.round_up_to_nearest,
         location_id: line.location_id ?? defaultLocationId ?? null,
       });
-      const serviceConfigsData: Record<string, any> = {};
-      const bucketConfigsData: Record<string, BucketOverlayInput | null> = {};
-
-      // Filter out Bucket configurations - they're handled separately via bucketConfig property
-      services.filter(s => s.configuration.configuration_type !== 'Bucket').forEach(serviceConfig => {
-        const serviceId = serviceConfig.service.service_id;
-
-        serviceConfigsData[serviceConfig.configuration.config_id] = {
-          quantity: serviceConfig.configuration.quantity ?? 1,
-          custom_rate: serviceConfig.configuration.custom_rate,
-          hourly_rate: serviceConfig.typeConfig?.hourly_rate,
-          base_rate: serviceConfig.typeConfig?.base_rate,
-          unit_of_measure: serviceConfig.typeConfig?.unit_of_measure,
-        };
-
-        // Load existing bucket configuration from the bucketConfig property
-        if (serviceConfig.bucketConfig) {
-          bucketConfigsData[serviceId] = {
-            total_minutes: serviceConfig.bucketConfig.total_minutes,
-            overage_rate: serviceConfig.bucketConfig.overage_rate,
-            allow_rollover: serviceConfig.bucketConfig.allow_rollover,
-            billing_period: serviceConfig.bucketConfig.billing_period
-          };
-        } else {
-          bucketConfigsData[serviceId] = null;
-        }
-      });
-
-      setEditServiceConfigs(serviceConfigsData);
-      setEditBucketConfigs(bucketConfigsData);
+      initializeServiceConfigEdits(services);
     } catch (err) {
       console.error('Error checking contract invoices:', err);
       setError(t('contractLines.errors.failedToCheckEditable', {
         defaultValue: 'Failed to check if contract can be edited',
+      }));
+    }
+  };
+
+  const handleRemoveService = async (contractLineId: string, serviceId: string) => {
+    setError(null);
+    try {
+      const result = await removeServiceFromContractLine(contractLineId, serviceId);
+      if (isReturnedActionError(result)) {
+        setError(getErrorMessage(result));
+        return;
+      }
+
+      await refreshServicesForEditing(contractLineId);
+      onContractLinesChanged?.();
+    } catch (err) {
+      console.error('Error removing service from contract line:', err);
+      setError(t('contractLines.errors.failedToUpdate', {
+        defaultValue: 'Failed to update contract line',
+      }));
+    }
+  };
+
+  const handleServicesAdded = async (contractLineId: string) => {
+    try {
+      await refreshServicesForEditing(contractLineId);
+      onContractLinesChanged?.();
+    } catch (err) {
+      console.error('Error refreshing services after adding to contract line:', err);
+      setError(t('contractLines.errors.failedToUpdate', {
+        defaultValue: 'Failed to update contract line',
       }));
     }
   };
@@ -571,6 +612,7 @@ const ContractLines: React.FC<ContractLinesProps> = ({ contract, clientId = null
       setEditLineData({});
       setEditServiceConfigs({});
       setEditBucketConfigs({});
+      setShowServiceSelectionDialog(false);
       onContractLinesChanged?.();
     } catch (err) {
       console.error('Error updating contract line:', err);
@@ -585,6 +627,7 @@ const ContractLines: React.FC<ContractLinesProps> = ({ contract, clientId = null
     setEditLineData({});
     setEditServiceConfigs({});
     setEditBucketConfigs({});
+    setShowServiceSelectionDialog(false);
   };
 
   const formatRate = (rate?: number | null) => {
@@ -593,6 +636,15 @@ const ContractLines: React.FC<ContractLinesProps> = ({ contract, clientId = null
     }
     return formatCurrency(rate / 100, contract.currency_code || 'USD');
   };
+
+  const editingLine = editingLineId
+    ? contractLines.find((line) => line.contract_line_id === editingLineId)
+    : undefined;
+  const editingLineServiceIds = editingLineId
+    ? (lineServices[editingLineId] || [])
+        .filter((service) => service.configuration.configuration_type !== 'Bucket')
+        .map((service) => service.service.service_id)
+    : [];
 
   if (isLoading) {
     return (
@@ -1167,12 +1219,27 @@ const ContractLines: React.FC<ContractLinesProps> = ({ contract, clientId = null
 
                           {/* Services List Section */}
                           <div>
-                            <h4 className="text-sm font-medium text-[rgb(var(--color-text-700))] mb-3">
-                              {t('contractLines.services.title', {
-                                count: services.filter(s => s.configuration.configuration_type !== 'Bucket').length,
-                                defaultValue: 'Services ({{count}})',
-                              })}
-                            </h4>
+                            <div className="mb-3 flex flex-wrap items-center justify-between gap-2">
+                              <h4 className="text-sm font-medium text-[rgb(var(--color-text-700))]">
+                                {t('contractLines.services.title', {
+                                  count: services.filter(s => s.configuration.configuration_type !== 'Bucket').length,
+                                  defaultValue: 'Services ({{count}})',
+                                })}
+                              </h4>
+                              {editingLineId === line.contract_line_id && (
+                                <Button
+                                  id={`add-service-${line.contract_line_id}`}
+                                  type="button"
+                                  size="sm"
+                                  variant="outline"
+                                  onClick={() => setShowServiceSelectionDialog(true)}
+                                  disabled={isSavingLine}
+                                >
+                                  <Plus className="mr-1 h-4 w-4" />
+                                  {t('createCustomLine.addItem', { defaultValue: 'Add Item' })}
+                                </Button>
+                              )}
+                            </div>
                             {services.filter(s => s.configuration.configuration_type !== 'Bucket').length === 0 ? (
                               <div className="text-center py-8 text-muted-foreground bg-muted rounded-lg border border-[rgb(var(--color-border-200))]">
                                 <p className="text-sm">
@@ -1217,6 +1284,23 @@ const ContractLines: React.FC<ContractLinesProps> = ({ contract, clientId = null
                                             </Badge>
                                           )}
                                         </div>
+                                        {isEditing && (
+                                          <Button
+                                            id={`remove-service-${serviceConfig.configuration.config_id}`}
+                                            type="button"
+                                            variant="ghost"
+                                            size="sm"
+                                            onClick={() => void handleRemoveService(
+                                              line.contract_line_id,
+                                              serviceConfig.service.service_id,
+                                            )}
+                                            className="text-destructive hover:bg-destructive/10 hover:text-destructive"
+                                            disabled={isSavingLine}
+                                          >
+                                            <Trash2 className="mr-1 h-4 w-4" />
+                                            {t('common.actions.remove', { defaultValue: 'Remove' })}
+                                          </Button>
+                                        )}
                                       </div>
 
                                       <div className="grid gap-4 md:grid-cols-2">
@@ -1477,6 +1561,18 @@ const ContractLines: React.FC<ContractLinesProps> = ({ contract, clientId = null
             contractId={contract.contract_id}
             onCreated={handleAddContractLines}
           />
+
+          {editingLine && (
+            <ServiceSelectionDialog
+              isOpen={showServiceSelectionDialog}
+              onClose={() => setShowServiceSelectionDialog(false)}
+              contractLineId={editingLine.contract_line_id}
+              contractLineType={editingLine.contract_line_type as 'Fixed' | 'Hourly' | 'Usage'}
+              currencyCode={contract.currency_code || 'USD'}
+              existingServiceIds={editingLineServiceIds}
+              onServiceAdded={() => void handleServicesAdded(editingLine.contract_line_id)}
+            />
+          )}
         </>
       ) : null}
     </Card>

--- a/packages/billing/src/components/billing-dashboard/service-config/ServiceSelectionDialog.tsx
+++ b/packages/billing/src/components/billing-dashboard/service-config/ServiceSelectionDialog.tsx
@@ -7,32 +7,46 @@ import { Badge } from '@alga-psa/ui/components/Badge';
 import { Input } from '@alga-psa/ui/components/Input';
 import { Table, TableHeader, TableBody, TableRow, TableHead, TableCell } from '@alga-psa/ui/components/Table';
 import { Search, Plus, Check } from 'lucide-react';
-import { IService } from '@alga-psa/types';
+import {
+  IContractLineServiceFixedConfig,
+  IContractLineServiceHourlyConfig,
+  IContractLineServiceUsageConfig,
+  IService,
+} from '@alga-psa/types';
 import { getServices } from '@alga-psa/billing/actions/serviceActions';
-import { addServiceToContractLine } from '@alga-psa/billing/actions/contractLineServiceActions';
 import { useFormatters, useTranslation } from '@alga-psa/ui/lib/i18n/client';
 import { getErrorMessage, isActionMessageError, isActionPermissionError } from '@alga-psa/ui/lib/errorHandling';
 
 const isReturnedActionError = (value: unknown): boolean =>
   isActionMessageError(value) || isActionPermissionError(value);
 
+export interface ContractLineServiceSelection {
+  service: IService;
+  quantity: number;
+  customRate: number;
+  configurationType: 'Fixed' | 'Hourly' | 'Usage';
+  typeConfig: Partial<
+    IContractLineServiceFixedConfig |
+    IContractLineServiceHourlyConfig |
+    IContractLineServiceUsageConfig
+  >;
+}
+
 interface ServiceSelectionDialogProps {
   isOpen: boolean;
   onClose: () => void;
-  contractLineId: string;
   contractLineType: 'Fixed' | 'Hourly' | 'Usage';
   currencyCode: string;
-  onServiceAdded?: () => void;
+  onServicesSelected: (services: ContractLineServiceSelection[]) => void | Promise<void>;
   existingServiceIds?: string[];
 }
 
 export function ServiceSelectionDialog({ 
   isOpen, 
   onClose, 
-  contractLineId,
   contractLineType,
   currencyCode,
-  onServiceAdded,
+  onServicesSelected,
   existingServiceIds = []
 }: ServiceSelectionDialogProps) {
   const { t } = useTranslation('msp/service-catalog');
@@ -64,7 +78,7 @@ export function ServiceSelectionDialog({
           setError(getErrorMessage(servicesResponse));
           return;
         }
-        
+
         // Extract the services array from the paginated response
         const servicesData = Array.isArray(servicesResponse)
           ? servicesResponse
@@ -133,13 +147,10 @@ export function ServiceSelectionDialog({
       setAdding(true);
       setError(null);
       
-      // Add each selected service with a usable type-specific default so it can
-      // be configured immediately in the contract-line editor after refresh.
-      for (const serviceId of selectedServices) {
+      const selections = selectedServices.map((serviceId): ContractLineServiceSelection => {
         const selectedService = services.find((service) => service.service_id === serviceId);
         if (!selectedService) {
-          setError(t('serviceSelection.errors.add', { defaultValue: 'Failed to add services to contract line' }));
-          return;
+          throw new Error(`Selected service ${serviceId} is no longer available`);
         }
 
         const currencyRate = selectedService.prices?.find(
@@ -155,23 +166,19 @@ export function ServiceSelectionDialog({
               }
             : { base_rate: resolvedRate };
 
-        const result = await addServiceToContractLine(
-          contractLineId,
-          serviceId,
-          1,
-          resolvedRate,
-          contractLineType,
-          typeConfig
-        );
-        if (isReturnedActionError(result)) {
-          setError(getErrorMessage(result));
-          return;
-        }
-      }
-      
-      if (onServiceAdded) {
-        onServiceAdded();
-      }
+        return {
+          service: selectedService,
+          quantity: 1,
+          customRate: resolvedRate,
+          configurationType: contractLineType,
+          typeConfig,
+        };
+      });
+
+      // The parent editor owns persistence. Keeping this callback local makes
+      // the picker part of the contract-line draft, so its outer Cancel action
+      // can discard additions along with every other unsaved edit.
+      await onServicesSelected(selections);
 
       setSelectedServices([]);
       onClose();

--- a/packages/billing/src/components/billing-dashboard/service-config/ServiceSelectionDialog.tsx
+++ b/packages/billing/src/components/billing-dashboard/service-config/ServiceSelectionDialog.tsx
@@ -19,7 +19,9 @@ const isReturnedActionError = (value: unknown): boolean =>
 interface ServiceSelectionDialogProps {
   isOpen: boolean;
   onClose: () => void;
-  planId: string;
+  contractLineId: string;
+  contractLineType: 'Fixed' | 'Hourly' | 'Usage';
+  currencyCode: string;
   onServiceAdded?: () => void;
   existingServiceIds?: string[];
 }
@@ -27,7 +29,9 @@ interface ServiceSelectionDialogProps {
 export function ServiceSelectionDialog({ 
   isOpen, 
   onClose, 
-  planId,
+  contractLineId,
+  contractLineType,
+  currencyCode,
   onServiceAdded,
   existingServiceIds = []
 }: ServiceSelectionDialogProps) {
@@ -51,14 +55,22 @@ export function ServiceSelectionDialog({
         setLoading(true);
         setError(null);
         
-        const servicesResponse = await getServices(1, 999, { item_kind: 'any' });
+        const servicesResponse = await getServices(1, 999, {
+          item_kind: contractLineType === 'Fixed' ? 'any' : 'service',
+          is_active: true,
+        });
+
+        if (isReturnedActionError(servicesResponse)) {
+          setError(getErrorMessage(servicesResponse));
+          return;
+        }
         
         // Extract the services array from the paginated response
         const servicesData = Array.isArray(servicesResponse)
           ? servicesResponse
           : (servicesResponse.services || []);
         
-        // Filter out services that are already in the plan
+        // Filter out services that are already in the contract line.
         const availableServices = servicesData.filter(
           service => !existingServiceIds.includes(service.service_id)
         );
@@ -74,7 +86,7 @@ export function ServiceSelectionDialog({
     };
 
     fetchServices();
-  }, [isOpen, existingServiceIds, t]);
+  }, [contractLineType, existingServiceIds, isOpen, t]);
 
   // Filter services based on search query and selected category
   useEffect(() => {
@@ -90,7 +102,7 @@ export function ServiceSelectionDialog({
     }
     
     if (selectedCategory) {
-      filtered = filtered.filter(service => service.category_id === selectedCategory);
+      filtered = filtered.filter(service => service.service_type_name === selectedCategory);
     }
     
     setFilteredServices(filtered);
@@ -121,11 +133,35 @@ export function ServiceSelectionDialog({
       setAdding(true);
       setError(null);
       
-      // Add each selected service to the plan
+      // Add each selected service with a usable type-specific default so it can
+      // be configured immediately in the contract-line editor after refresh.
       for (const serviceId of selectedServices) {
+        const selectedService = services.find((service) => service.service_id === serviceId);
+        if (!selectedService) {
+          setError(t('serviceSelection.errors.add', { defaultValue: 'Failed to add services to contract line' }));
+          return;
+        }
+
+        const currencyRate = selectedService.prices?.find(
+          (price) => price.currency_code === currencyCode
+        )?.rate;
+        const resolvedRate = Number(currencyRate ?? selectedService.default_rate ?? 0);
+        const typeConfig = contractLineType === 'Hourly'
+          ? { hourly_rate: resolvedRate }
+          : contractLineType === 'Usage'
+            ? {
+                base_rate: resolvedRate,
+                unit_of_measure: selectedService.unit_of_measure || 'unit',
+              }
+            : { base_rate: resolvedRate };
+
         const result = await addServiceToContractLine(
-          planId,
-          serviceId
+          contractLineId,
+          serviceId,
+          1,
+          resolvedRate,
+          contractLineType,
+          typeConfig
         );
         if (isReturnedActionError(result)) {
           setError(getErrorMessage(result));
@@ -136,11 +172,12 @@ export function ServiceSelectionDialog({
       if (onServiceAdded) {
         onServiceAdded();
       }
-      
+
+      setSelectedServices([]);
       onClose();
     } catch (err) {
-      console.error('Error adding services to plan:', err);
-      setError(t('serviceSelection.errors.add', { defaultValue: 'Failed to add services to plan' }));
+      console.error('Error adding services to contract line:', err);
+      setError(t('serviceSelection.errors.add', { defaultValue: 'Failed to add services to contract line' }));
     } finally {
       setAdding(false);
     }
@@ -160,7 +197,8 @@ export function ServiceSelectionDialog({
       isOpen={isOpen}
       onClose={onClose}
       id="service-selection-dialog"
-      title={t('serviceSelection.title', { defaultValue: 'Add Services & Products to Plan' })}
+      title={t('serviceSelection.title', { defaultValue: 'Add Services & Products to Contract Line' })}
+      className="max-w-4xl"
       footer={(
         <div className="flex justify-between w-full">
           <div>
@@ -201,7 +239,7 @@ export function ServiceSelectionDialog({
         </div>
       )}
     >
-      <DialogContent className="max-w-4xl flex flex-col">
+      <DialogContent className="flex flex-col">
 
         <div className="flex flex-col space-y-4 h-full">
           {/* Search and filters */}
@@ -220,10 +258,10 @@ export function ServiceSelectionDialog({
             </div>
             
             <div className="flex flex-wrap gap-2">
-              {serviceTypes.map(type => (
+              {serviceTypes.map((type, index) => (
                 <Button
                   key={type}
-                  id={`filter-${type.toLowerCase()}-button`}
+                  id={`service-type-filter-button-${index}`}
                   variant={selectedCategory === type ? "default" : "outline"}
                   size="sm"
                   onClick={() => handleCategorySelect(type)}
@@ -275,7 +313,9 @@ export function ServiceSelectionDialog({
                   {filteredServices.map(service => (
                     <TableRow 
                       key={service.service_id}
-                      className={selectedServices.includes(service.service_id) ? "bg-blue-50" : ""}
+                      className={selectedServices.includes(service.service_id)
+                        ? 'bg-[rgb(var(--color-primary-50))] dark:bg-[rgb(var(--color-primary-400)/0.20)]'
+                        : ''}
                       onClick={() => toggleServiceSelection(service.service_id)}
                       style={{ cursor: 'pointer' }}
                     >
@@ -302,8 +342,12 @@ export function ServiceSelectionDialog({
                       <TableCell>{service.unit_of_measure}</TableCell>
                       <TableCell>
                         {formatCurrency(
-                          service.default_rate,
-                          service.prices?.[0]?.currency_code || 'USD',
+                          Number(
+                            service.prices?.find((price) => price.currency_code === currencyCode)?.rate
+                              ?? service.default_rate
+                              ?? 0
+                          ) / 100,
+                          currencyCode,
                         )}
                       </TableCell>
                     </TableRow>
@@ -318,10 +362,10 @@ export function ServiceSelectionDialog({
             <span className="text-sm font-medium text-[rgb(var(--color-text-700))] mr-2">
               {t('serviceSelection.quickAdd.label', { defaultValue: 'Quick Add:' })}
             </span>
-            {serviceTypes.map(type => (
+            {serviceTypes.map((type, index) => (
               <Button
                 key={`quick-add-${type}`}
-                id={`quick-add-${type.toLowerCase()}-button`}
+                id={`quick-add-service-type-button-${index}`}
                 variant="soft"
                 size="sm"
                 className="flex items-center gap-1"

--- a/packages/billing/src/services/contractLineServiceConfigurationService.ts
+++ b/packages/billing/src/services/contractLineServiceConfigurationService.ts
@@ -174,7 +174,8 @@ export class ContractLineServiceConfigurationService {
             config_id: configId,
             unit_of_measure: (typeConfig as IContractLineServiceUsageConfig)?.unit_of_measure ?? 'Unit',
             enable_tiered_pricing: (typeConfig as IContractLineServiceUsageConfig)?.enable_tiered_pricing ?? false,
-            minimum_usage: (typeConfig as IContractLineServiceUsageConfig)?.minimum_usage ?? 0
+            minimum_usage: (typeConfig as IContractLineServiceUsageConfig)?.minimum_usage ?? 0,
+            base_rate: (typeConfig as IContractLineServiceUsageConfig)?.base_rate ?? null,
           });
           
           // Add rate tiers if provided

--- a/packages/billing/tests/contractLineServiceMembershipActions.test.ts
+++ b/packages/billing/tests/contractLineServiceMembershipActions.test.ts
@@ -1,0 +1,225 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const mocks = vi.hoisted(() => ({
+  createConfiguration: vi.fn(),
+  createTenantKnex: vi.fn(),
+  deleteConfiguration: vi.fn(),
+  getConfigurationForService: vi.fn(),
+  getConfigurationsForPlan: vi.fn(),
+  hasPermission: vi.fn(),
+  transactionConnections: [] as unknown[],
+  withTransaction: vi.fn(),
+}));
+
+let currentServiceId: string | undefined;
+let systemManagedContract = false;
+
+const makeBuilder = (table: string) => {
+  const builder: any = {};
+  builder.where = vi.fn((criteria: Record<string, unknown>) => {
+    if (typeof criteria.service_id === 'string') {
+      currentServiceId = criteria.service_id;
+    }
+    return builder;
+  });
+  builder.select = vi.fn(() => builder);
+  builder.first = vi.fn(async () => {
+    if (table === 'contract_template_lines') return undefined;
+    if (table === 'contract_lines') {
+      return {
+        contract_line_id: 'line-1',
+        contract_line_type: 'Fixed',
+        contract_id: 'contract-1',
+      };
+    }
+    if (table === 'service_catalog') {
+      return {
+        service_id: currentServiceId,
+        service_name: currentServiceId,
+        is_active: true,
+        item_kind: 'service',
+        default_rate: 10000,
+      };
+    }
+    if (table === 'contracts') {
+      return { is_system_managed_default: systemManagedContract };
+    }
+    if (table === 'contract_line_services') return undefined;
+    throw new Error(`Unexpected first() on ${table}`);
+  });
+  builder.insert = vi.fn(async () => undefined);
+  builder.delete = vi.fn(async () => 1);
+  builder.whereIn = vi.fn(() => builder);
+  return builder;
+};
+
+const trx: any = vi.fn((table: string) => makeBuilder(table));
+trx.fn = { now: vi.fn(() => new Date('2026-07-15T00:00:00Z')) };
+
+vi.mock('@alga-psa/db', () => ({
+  createTenantKnex: (...args: unknown[]) => mocks.createTenantKnex(...args),
+  tenantDb: (connection: any) => ({
+    table: (table: string) => connection(table),
+  }),
+  withTransaction: (...args: unknown[]) => mocks.withTransaction(...args),
+}));
+
+vi.mock('@alga-psa/auth', () => ({
+  withAuth:
+    (fn: any) =>
+    (...args: unknown[]) =>
+      fn({ user_id: 'user-1' }, { tenant: 'tenant-1' }, ...args),
+}));
+
+vi.mock('@alga-psa/auth/rbac', () => ({
+  hasPermission: (...args: unknown[]) => mocks.hasPermission(...args),
+}));
+
+vi.mock('../src/services/contractLineServiceConfigurationService', () => ({
+  ContractLineServiceConfigurationService: class MockContractLineServiceConfigurationService {
+    constructor(connection: unknown) {
+      mocks.transactionConnections.push(connection);
+    }
+
+    getConfigurationForService(...args: unknown[]) {
+      return mocks.getConfigurationForService(...args);
+    }
+
+    getConfigurationsForPlan(...args: unknown[]) {
+      return mocks.getConfigurationsForPlan(...args);
+    }
+
+    createConfiguration(...args: unknown[]) {
+      return mocks.createConfiguration(...args);
+    }
+
+    deleteConfiguration(...args: unknown[]) {
+      return mocks.deleteConfiguration(...args);
+    }
+  },
+}));
+
+vi.mock('../src/actions/contractLineServiceConfigurationActions', () => ({}));
+
+describe('applyContractLineServiceMembershipChanges', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    currentServiceId = undefined;
+    systemManagedContract = false;
+    mocks.transactionConnections.length = 0;
+    mocks.createTenantKnex.mockResolvedValue({ knex: { name: 'root-knex' } });
+    mocks.deleteConfiguration.mockResolvedValue(true);
+    mocks.hasPermission.mockResolvedValue(true);
+    mocks.getConfigurationForService.mockResolvedValue(null);
+    mocks.getConfigurationsForPlan.mockResolvedValue([]);
+    mocks.withTransaction.mockImplementation(async (_db, callback) => callback(trx));
+  });
+
+  it('runs every staged addition in one transaction and propagates a later failure for rollback', async () => {
+    mocks.createConfiguration
+      .mockResolvedValueOnce('config-1')
+      .mockRejectedValueOnce(new Error('second service failed'));
+    const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => undefined);
+
+    const { applyContractLineServiceMembershipChanges } = await import(
+      '../src/actions/contractLineServiceActions'
+    );
+
+    try {
+      await expect(applyContractLineServiceMembershipChanges('line-1', {
+        additions: [
+          {
+            serviceId: 'service-1',
+            quantity: 1,
+            customRate: 10000,
+            configurationType: 'Fixed',
+            typeConfig: { base_rate: 10000 },
+          },
+          {
+            serviceId: 'service-2',
+            quantity: 1,
+            customRate: 20000,
+            configurationType: 'Fixed',
+            typeConfig: { base_rate: 20000 },
+          },
+        ],
+        removals: [],
+      })).rejects.toThrow('second service failed');
+    } finally {
+      errorSpy.mockRestore();
+    }
+
+    expect(mocks.withTransaction).toHaveBeenCalledOnce();
+    expect(mocks.createConfiguration).toHaveBeenCalledTimes(2);
+    expect(mocks.transactionConnections).toEqual([trx, trx]);
+  });
+
+  it('removes every configuration for a service before adding the new membership', async () => {
+    mocks.getConfigurationsForPlan.mockResolvedValue([
+      { config_id: 'existing-main', service_id: 'existing-service' },
+      { config_id: 'existing-bucket', service_id: 'existing-service' },
+      { config_id: 'unrelated-config', service_id: 'unrelated-service' },
+    ]);
+    mocks.createConfiguration.mockResolvedValue('new-config');
+
+    const { applyContractLineServiceMembershipChanges } = await import(
+      '../src/actions/contractLineServiceActions'
+    );
+
+    await expect(applyContractLineServiceMembershipChanges('line-1', {
+      additions: [{
+        serviceId: 'new-service',
+        quantity: 1,
+        customRate: 20000,
+        configurationType: 'Fixed',
+        typeConfig: { base_rate: 20000 },
+      }],
+      removals: ['existing-service'],
+    })).resolves.toBe(true);
+
+    expect(mocks.withTransaction).toHaveBeenCalledOnce();
+    expect(mocks.deleteConfiguration).toHaveBeenNthCalledWith(1, 'existing-main');
+    expect(mocks.deleteConfiguration).toHaveBeenNthCalledWith(2, 'existing-bucket');
+    expect(mocks.deleteConfiguration).toHaveBeenCalledTimes(2);
+    expect(mocks.createConfiguration).toHaveBeenCalledOnce();
+    expect(mocks.transactionConnections).toEqual([trx, trx]);
+  });
+
+  it('rejects contradictory membership input before opening a transaction', async () => {
+    const { applyContractLineServiceMembershipChanges } = await import(
+      '../src/actions/contractLineServiceActions'
+    );
+
+    await expect(applyContractLineServiceMembershipChanges('line-1', {
+      additions: [{
+        serviceId: 'service-1',
+        configurationType: 'Fixed',
+      }],
+      removals: ['service-1'],
+    })).resolves.toMatchObject({
+      actionError: 'The same service cannot be added and removed in one contract line edit.',
+    });
+    expect(mocks.withTransaction).not.toHaveBeenCalled();
+  });
+
+  it('preserves the system-managed contract authoring guard inside the batch transaction', async () => {
+    systemManagedContract = true;
+    const { applyContractLineServiceMembershipChanges } = await import(
+      '../src/actions/contractLineServiceActions'
+    );
+    const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => undefined);
+
+    try {
+      await expect(applyContractLineServiceMembershipChanges('line-1', {
+        additions: [{ serviceId: 'service-1', configurationType: 'Fixed' }],
+        removals: [],
+      })).resolves.toEqual({
+        actionError: 'System-managed default contracts are attribution-only; contract-line service configuration authoring is disabled.',
+      });
+    } finally {
+      errorSpy.mockRestore();
+    }
+
+    expect(mocks.createConfiguration).not.toHaveBeenCalled();
+  });
+});

--- a/packages/billing/tests/contractLineServiceMembershipEditing.test.tsx
+++ b/packages/billing/tests/contractLineServiceMembershipEditing.test.tsx
@@ -1,0 +1,180 @@
+// @vitest-environment jsdom
+
+import React from 'react';
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { ServiceSelectionDialog } from '../src/components/billing-dashboard/service-config/ServiceSelectionDialog';
+
+const actionMocks = vi.hoisted(() => ({
+  addServiceToContractLine: vi.fn(),
+  getServices: vi.fn(),
+}));
+
+vi.mock('@alga-psa/billing/actions/serviceActions', () => ({
+  getServices: actionMocks.getServices,
+}));
+
+vi.mock('@alga-psa/billing/actions/contractLineServiceActions', () => ({
+  addServiceToContractLine: actionMocks.addServiceToContractLine,
+}));
+
+vi.mock('@alga-psa/ui/lib/i18n/client', () => ({
+  useTranslation: () => ({
+    t: (_key: string, options?: { defaultValue?: string }) => options?.defaultValue ?? _key,
+  }),
+  useFormatters: () => ({
+    formatCurrency: (value: number, currency: string) => `${currency} ${value}`,
+  }),
+}));
+
+vi.mock('@alga-psa/ui/lib/errorHandling', () => ({
+  getErrorMessage: () => 'action error',
+  isActionMessageError: () => false,
+  isActionPermissionError: () => false,
+}));
+
+vi.mock('@alga-psa/ui/components/Dialog', () => ({
+  Dialog: ({
+    isOpen,
+    title,
+    children,
+    footer,
+  }: {
+    isOpen: boolean;
+    title: React.ReactNode;
+    children: React.ReactNode;
+    footer: React.ReactNode;
+  }) => isOpen ? (
+    <div role="dialog">
+      <h1>{title}</h1>
+      {children}
+      {footer}
+    </div>
+  ) : null,
+  DialogContent: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+}));
+
+vi.mock('@alga-psa/ui/components/Button', () => ({
+  Button: ({ children, ...props }: React.ButtonHTMLAttributes<HTMLButtonElement>) => (
+    <button {...props}>{children}</button>
+  ),
+}));
+
+vi.mock('@alga-psa/ui/components/Badge', () => ({
+  Badge: ({ children }: { children: React.ReactNode }) => <span>{children}</span>,
+}));
+
+vi.mock('@alga-psa/ui/components/Input', () => ({
+  Input: (props: React.InputHTMLAttributes<HTMLInputElement>) => <input {...props} />,
+}));
+
+vi.mock('@alga-psa/ui/components/Table', () => ({
+  Table: ({ children }: { children: React.ReactNode }) => <table>{children}</table>,
+  TableHeader: ({ children }: { children: React.ReactNode }) => <thead>{children}</thead>,
+  TableBody: ({ children }: { children: React.ReactNode }) => <tbody>{children}</tbody>,
+  TableRow: ({ children, ...props }: React.HTMLAttributes<HTMLTableRowElement>) => (
+    <tr {...props}>{children}</tr>
+  ),
+  TableHead: ({ children }: { children?: React.ReactNode }) => <th>{children}</th>,
+  TableCell: ({ children }: { children: React.ReactNode }) => <td>{children}</td>,
+}));
+
+describe('contract line service membership editing', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    actionMocks.addServiceToContractLine.mockResolvedValue('new-config-id');
+    actionMocks.getServices.mockResolvedValue({
+      services: [
+        {
+          service_id: 'existing-service',
+          service_name: 'Existing service',
+          service_type_name: 'Support',
+          unit_of_measure: 'hour',
+          default_rate: 12000,
+          billing_method: 'hourly',
+          item_kind: 'service',
+          is_active: true,
+          prices: [],
+        },
+        {
+          service_id: 'new-service',
+          service_name: 'New hourly service',
+          service_type_name: 'Support',
+          unit_of_measure: 'hour',
+          default_rate: 18000,
+          billing_method: 'hourly',
+          item_kind: 'service',
+          is_active: true,
+          prices: [{ currency_code: 'USD', rate: 25000 }],
+        },
+      ],
+      totalCount: 2,
+    });
+  });
+
+  it('filters the picker for the line type, excludes existing services, and adds with contract-currency defaults', async () => {
+    const onClose = vi.fn();
+    const onServiceAdded = vi.fn();
+
+    render(
+      <ServiceSelectionDialog
+        isOpen
+        onClose={onClose}
+        contractLineId="line-1"
+        contractLineType="Hourly"
+        currencyCode="USD"
+        existingServiceIds={['existing-service']}
+        onServiceAdded={onServiceAdded}
+      />
+    );
+
+    expect(await screen.findByText('New hourly service')).not.toBeNull();
+    expect(screen.queryByText('Existing service')).toBeNull();
+    expect(screen.getByText('USD 250')).not.toBeNull();
+    expect(actionMocks.getServices).toHaveBeenCalledWith(1, 999, {
+      item_kind: 'service',
+      is_active: true,
+    });
+
+    fireEvent.click(screen.getByText('New hourly service'));
+    fireEvent.click(screen.getByRole('button', { name: 'Add Selected Services' }));
+
+    await waitFor(() => {
+      expect(actionMocks.addServiceToContractLine).toHaveBeenCalledWith(
+        'line-1',
+        'new-service',
+        1,
+        25000,
+        'Hourly',
+        { hourly_rate: 25000 }
+      );
+    });
+    expect(onServiceAdded).toHaveBeenCalledOnce();
+    expect(onClose).toHaveBeenCalledOnce();
+  });
+
+  it('exposes removal only from the active inline editor and refreshes its configuration state', () => {
+    const source = readFileSync(
+      resolve(__dirname, '../src/components/billing-dashboard/contracts/ContractLines.tsx'),
+      'utf8'
+    );
+
+    expect(source).toContain('editingLineId === line.contract_line_id');
+    expect(source).toContain('removeServiceFromContractLine(contractLineId, serviceId)');
+    expect(source).toContain('await refreshServicesForEditing(contractLineId)');
+    expect(source).toContain('id={`remove-service-${serviceConfig.configuration.config_id}`}');
+  });
+
+  it('preserves the selected base rate when creating a usage-service configuration', () => {
+    const source = readFileSync(
+      resolve(__dirname, '../src/services/contractLineServiceConfigurationService.ts'),
+      'utf8'
+    );
+
+    expect(source).toContain(
+      "base_rate: (typeConfig as IContractLineServiceUsageConfig)?.base_rate ?? null"
+    );
+  });
+});

--- a/packages/billing/tests/contractLineServiceMembershipEditing.test.tsx
+++ b/packages/billing/tests/contractLineServiceMembershipEditing.test.tsx
@@ -1,15 +1,24 @@
 // @vitest-environment jsdom
 
 import React from 'react';
-import { readFileSync } from 'node:fs';
-import { resolve } from 'node:path';
-import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { fireEvent, render, screen, waitFor, within } from '@testing-library/react';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
+import ContractLines from '../src/components/billing-dashboard/contracts/ContractLines';
 import { ServiceSelectionDialog } from '../src/components/billing-dashboard/service-config/ServiceSelectionDialog';
 
 const actionMocks = vi.hoisted(() => ({
-  addServiceToContractLine: vi.fn(),
+  applyContractLineServiceMembershipChanges: vi.fn(),
+  checkContractHasInvoices: vi.fn(),
+  getActiveClientLocationsForBilling: vi.fn(),
+  getContractLineServicesWithConfigurations: vi.fn(),
+  getDetailedContractLines: vi.fn(),
   getServices: vi.fn(),
+  getTemplateLineServicesWithConfigurations: vi.fn(),
+  removeContractLine: vi.fn(),
+  updateConfiguration: vi.fn(),
+  updateContractLine: vi.fn(),
+  updateContractLineAssociation: vi.fn(),
+  upsertBucketConfiguration: vi.fn(),
 }));
 
 vi.mock('@alga-psa/billing/actions/serviceActions', () => ({
@@ -17,22 +26,67 @@ vi.mock('@alga-psa/billing/actions/serviceActions', () => ({
 }));
 
 vi.mock('@alga-psa/billing/actions/contractLineServiceActions', () => ({
-  addServiceToContractLine: actionMocks.addServiceToContractLine,
+  applyContractLineServiceMembershipChanges: actionMocks.applyContractLineServiceMembershipChanges,
+  getContractLineServicesWithConfigurations: actionMocks.getContractLineServicesWithConfigurations,
+  getTemplateLineServicesWithConfigurations: actionMocks.getTemplateLineServicesWithConfigurations,
 }));
 
+vi.mock('@alga-psa/billing/actions/contractLineAction', () => ({
+  updateContractLine: actionMocks.updateContractLine,
+}));
+
+vi.mock('@alga-psa/billing/actions/contractLineMappingActions', () => ({
+  getDetailedContractLines: actionMocks.getDetailedContractLines,
+  removeContractLine: actionMocks.removeContractLine,
+  updateContractLineAssociation: actionMocks.updateContractLineAssociation,
+}));
+
+vi.mock('@alga-psa/billing/actions/contractActions', () => ({
+  checkContractHasInvoices: actionMocks.checkContractHasInvoices,
+}));
+
+vi.mock('@alga-psa/billing/actions/contractLineServiceConfigurationActions', () => ({
+  updateConfiguration: actionMocks.updateConfiguration,
+  upsertPlanServiceBucketConfigurationAction: actionMocks.upsertBucketConfiguration,
+}));
+
+vi.mock('@alga-psa/billing/actions/billingClientLocationActions', () => ({
+  getActiveClientLocationsForBilling: actionMocks.getActiveClientLocationsForBilling,
+}));
+
+const translate = (_key: string, options?: Record<string, unknown>) => {
+  let value = String(options?.defaultValue ?? _key);
+  for (const [name, replacement] of Object.entries(options ?? {})) {
+    value = value.replace(`{{${name}}}`, String(replacement));
+  }
+  return value;
+};
+
 vi.mock('@alga-psa/ui/lib/i18n/client', () => ({
-  useTranslation: () => ({
-    t: (_key: string, options?: { defaultValue?: string }) => options?.defaultValue ?? _key,
-  }),
+  useTranslation: () => ({ t: translate }),
   useFormatters: () => ({
     formatCurrency: (value: number, currency: string) => `${currency} ${value}`,
   }),
+}));
+
+vi.mock('@alga-psa/billing/hooks/useBillingEnumOptions', () => ({
+  useFormatBillingFrequency: () => (value: string) => value,
+  useFormatContractLineType: () => (value: string) => value,
 }));
 
 vi.mock('@alga-psa/ui/lib/errorHandling', () => ({
   getErrorMessage: () => 'action error',
   isActionMessageError: () => false,
   isActionPermissionError: () => false,
+}));
+
+vi.mock('@alga-psa/core', () => ({
+  getCurrencySymbol: () => '$',
+}));
+
+vi.mock('@radix-ui/themes', () => ({
+  Card: ({ children }: { children: React.ReactNode }) => <section>{children}</section>,
+  Box: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
 }));
 
 vi.mock('@alga-psa/ui/components/Dialog', () => ({
@@ -57,7 +111,7 @@ vi.mock('@alga-psa/ui/components/Dialog', () => ({
 }));
 
 vi.mock('@alga-psa/ui/components/Button', () => ({
-  Button: ({ children, ...props }: React.ButtonHTMLAttributes<HTMLButtonElement>) => (
+  Button: ({ children, variant: _variant, size: _size, ...props }: any) => (
     <button {...props}>{children}</button>
   ),
 }));
@@ -68,6 +122,29 @@ vi.mock('@alga-psa/ui/components/Badge', () => ({
 
 vi.mock('@alga-psa/ui/components/Input', () => ({
   Input: (props: React.InputHTMLAttributes<HTMLInputElement>) => <input {...props} />,
+}));
+
+vi.mock('@alga-psa/ui/components/Label', () => ({
+  Label: ({ children, ...props }: React.LabelHTMLAttributes<HTMLLabelElement>) => (
+    <label {...props}>{children}</label>
+  ),
+}));
+
+vi.mock('@alga-psa/ui/components/CustomSelect', () => ({
+  default: () => null,
+}));
+
+vi.mock('@alga-psa/ui/components/Alert', () => ({
+  Alert: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+  AlertDescription: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+}));
+
+vi.mock('@alga-psa/ui/components/LoadingIndicator', () => ({
+  default: ({ text }: { text?: React.ReactNode }) => <div>{text}</div>,
+}));
+
+vi.mock('@alga-psa/ui/components/SwitchWithLabel', () => ({
+  SwitchWithLabel: () => null,
 }));
 
 vi.mock('@alga-psa/ui/components/Table', () => ({
@@ -81,100 +158,212 @@ vi.mock('@alga-psa/ui/components/Table', () => ({
   TableCell: ({ children }: { children: React.ReactNode }) => <td>{children}</td>,
 }));
 
+vi.mock('../src/components/billing-dashboard/contracts/AddContractLinesDialog', () => ({
+  AddContractLinesDialog: () => null,
+}));
+
+vi.mock('../src/components/billing-dashboard/contracts/CreateCustomContractLineDialog', () => ({
+  CreateCustomContractLineDialog: () => null,
+}));
+
+vi.mock('../src/components/billing-dashboard/contracts/BucketOverlayFields', () => ({
+  BucketOverlayFields: () => null,
+}));
+
+const existingServiceConfiguration = {
+  service: {
+    service_id: 'existing-service',
+    service_name: 'Existing service',
+    service_type_name: 'Support',
+    unit_of_measure: 'item',
+    default_rate: 12000,
+    billing_method: 'fixed',
+    item_kind: 'service',
+    is_active: true,
+  },
+  configuration: {
+    config_id: 'existing-config',
+    contract_line_id: 'line-1',
+    service_id: 'existing-service',
+    configuration_type: 'Fixed',
+    custom_rate: 12000,
+    quantity: 1,
+  },
+  typeConfig: { base_rate: 12000 },
+  bucketConfig: null,
+};
+
+const availableServices = [
+  existingServiceConfiguration.service,
+  {
+    service_id: 'new-service',
+    service_name: 'New service',
+    service_type_name: 'Support',
+    unit_of_measure: 'item',
+    default_rate: 18000,
+    billing_method: 'fixed',
+    item_kind: 'service',
+    is_active: true,
+    prices: [{ currency_code: 'USD', rate: 25000 }],
+  },
+];
+
+const renderContractLines = () => render(
+  <ContractLines
+    contract={{
+      contract_id: 'contract-1',
+      contract_name: 'Managed Services',
+      currency_code: 'USD',
+      is_template: false,
+    } as any}
+  />
+);
+
 describe('contract line service membership editing', () => {
   beforeEach(() => {
     vi.clearAllMocks();
-    actionMocks.addServiceToContractLine.mockResolvedValue('new-config-id');
+    actionMocks.applyContractLineServiceMembershipChanges.mockResolvedValue(true);
+    actionMocks.checkContractHasInvoices.mockResolvedValue(false);
+    actionMocks.getActiveClientLocationsForBilling.mockResolvedValue([]);
+    actionMocks.getContractLineServicesWithConfigurations.mockResolvedValue([
+      existingServiceConfiguration,
+    ]);
+    actionMocks.getTemplateLineServicesWithConfigurations.mockResolvedValue([]);
+    actionMocks.getDetailedContractLines.mockResolvedValue([{
+      tenant: 'tenant-1',
+      contract_id: 'contract-1',
+      contract_line_id: 'line-1',
+      display_order: 1,
+      created_at: new Date(),
+      contract_line_name: 'Managed Services line',
+      billing_frequency: 'monthly',
+      billing_timing: 'arrears',
+      cadence_owner: 'client',
+      contract_line_type: 'Fixed',
+      default_rate: 10000,
+      location_id: null,
+    }]);
     actionMocks.getServices.mockResolvedValue({
-      services: [
-        {
-          service_id: 'existing-service',
-          service_name: 'Existing service',
-          service_type_name: 'Support',
-          unit_of_measure: 'hour',
-          default_rate: 12000,
-          billing_method: 'hourly',
-          item_kind: 'service',
-          is_active: true,
-          prices: [],
-        },
-        {
-          service_id: 'new-service',
-          service_name: 'New hourly service',
-          service_type_name: 'Support',
-          unit_of_measure: 'hour',
-          default_rate: 18000,
-          billing_method: 'hourly',
-          item_kind: 'service',
-          is_active: true,
-          prices: [{ currency_code: 'USD', rate: 25000 }],
-        },
-      ],
-      totalCount: 2,
+      services: availableServices,
+      totalCount: availableServices.length,
     });
+    actionMocks.updateConfiguration.mockResolvedValue(true);
+    actionMocks.updateContractLine.mockResolvedValue({ contract_line_id: 'line-1' });
+    actionMocks.upsertBucketConfiguration.mockResolvedValue(true);
   });
 
-  it('filters the picker for the line type, excludes existing services, and adds with contract-currency defaults', async () => {
+  it('returns selected services to the editor with contract-currency defaults without persisting them', async () => {
     const onClose = vi.fn();
-    const onServiceAdded = vi.fn();
+    const onServicesSelected = vi.fn();
 
     render(
       <ServiceSelectionDialog
         isOpen
         onClose={onClose}
-        contractLineId="line-1"
-        contractLineType="Hourly"
+        contractLineType="Fixed"
         currencyCode="USD"
         existingServiceIds={['existing-service']}
-        onServiceAdded={onServiceAdded}
+        onServicesSelected={onServicesSelected}
       />
     );
 
-    expect(await screen.findByText('New hourly service')).not.toBeNull();
+    expect(await screen.findByText('New service')).not.toBeNull();
     expect(screen.queryByText('Existing service')).toBeNull();
     expect(screen.getByText('USD 250')).not.toBeNull();
-    expect(actionMocks.getServices).toHaveBeenCalledWith(1, 999, {
-      item_kind: 'service',
-      is_active: true,
-    });
 
-    fireEvent.click(screen.getByText('New hourly service'));
+    fireEvent.click(screen.getByText('New service'));
     fireEvent.click(screen.getByRole('button', { name: 'Add Selected Services' }));
 
-    await waitFor(() => {
-      expect(actionMocks.addServiceToContractLine).toHaveBeenCalledWith(
-        'line-1',
-        'new-service',
-        1,
-        25000,
-        'Hourly',
-        { hourly_rate: 25000 }
-      );
-    });
-    expect(onServiceAdded).toHaveBeenCalledOnce();
+    await waitFor(() => expect(onServicesSelected).toHaveBeenCalledWith([
+      expect.objectContaining({
+        service: expect.objectContaining({ service_id: 'new-service' }),
+        quantity: 1,
+        customRate: 25000,
+        configurationType: 'Fixed',
+        typeConfig: { base_rate: 25000 },
+      }),
+    ]));
+    expect(actionMocks.applyContractLineServiceMembershipChanges).not.toHaveBeenCalled();
     expect(onClose).toHaveBeenCalledOnce();
   });
 
-  it('exposes removal only from the active inline editor and refreshes its configuration state', () => {
-    const source = readFileSync(
-      resolve(__dirname, '../src/components/billing-dashboard/contracts/ContractLines.tsx'),
-      'utf8'
-    );
+  it('stages additions and removals, then restores persisted membership on Cancel', async () => {
+    renderContractLines();
 
-    expect(source).toContain('editingLineId === line.contract_line_id');
-    expect(source).toContain('removeServiceFromContractLine(contractLineId, serviceId)');
-    expect(source).toContain('await refreshServicesForEditing(contractLineId)');
-    expect(source).toContain('id={`remove-service-${serviceConfig.configuration.config_id}`}');
+    fireEvent.click(await screen.findByRole('button', { name: 'Edit' }));
+    expect(await screen.findByText('Existing service')).not.toBeNull();
+
+    fireEvent.click(document.getElementById('remove-service-existing-config')!);
+    expect(screen.queryByText('Existing service')).toBeNull();
+
+    fireEvent.click(screen.getByRole('button', { name: 'Add Item' }));
+    const dialog = await screen.findByRole('dialog');
+    fireEvent.click(within(dialog).getByText('New service'));
+    fireEvent.click(within(dialog).getByRole('button', { name: 'Add Selected Services' }));
+    expect(await screen.findByText('New service')).not.toBeNull();
+    expect(actionMocks.applyContractLineServiceMembershipChanges).not.toHaveBeenCalled();
+
+    fireEvent.click(screen.getByRole('button', { name: 'Cancel' }));
+
+    expect(await screen.findByText('Existing service')).not.toBeNull();
+    expect(screen.queryByText('New service')).toBeNull();
+    expect(actionMocks.applyContractLineServiceMembershipChanges).not.toHaveBeenCalled();
   });
 
-  it('preserves the selected base rate when creating a usage-service configuration', () => {
-    const source = readFileSync(
-      resolve(__dirname, '../src/services/contractLineServiceConfigurationService.ts'),
-      'utf8'
+  it('persists the complete staged membership change only when the outer editor is saved', async () => {
+    renderContractLines();
+
+    fireEvent.click(await screen.findByRole('button', { name: 'Edit' }));
+    expect(await screen.findByText('Existing service')).not.toBeNull();
+    fireEvent.click(document.getElementById('remove-service-existing-config')!);
+
+    fireEvent.click(screen.getByRole('button', { name: 'Add Item' }));
+    const dialog = await screen.findByRole('dialog');
+    fireEvent.click(within(dialog).getByText('New service'));
+    fireEvent.click(within(dialog).getByRole('button', { name: 'Add Selected Services' }));
+    expect(await screen.findByText('New service')).not.toBeNull();
+
+    fireEvent.click(screen.getByRole('button', { name: 'Save' }));
+
+    await waitFor(() => expect(actionMocks.applyContractLineServiceMembershipChanges).toHaveBeenCalledWith(
+      'line-1',
+      {
+        additions: [{
+          serviceId: 'new-service',
+          quantity: 1,
+          customRate: 25000,
+          configurationType: 'Fixed',
+          typeConfig: { base_rate: 25000 },
+        }],
+        removals: ['existing-service'],
+      },
+    ));
+  });
+
+  it('preserves the selected base rate when creating a usage-service configuration', async () => {
+    const onServicesSelected = vi.fn();
+    render(
+      <ServiceSelectionDialog
+        isOpen
+        onClose={vi.fn()}
+        contractLineType="Usage"
+        currencyCode="USD"
+        existingServiceIds={['existing-service']}
+        onServicesSelected={onServicesSelected}
+      />
     );
 
-    expect(source).toContain(
-      "base_rate: (typeConfig as IContractLineServiceUsageConfig)?.base_rate ?? null"
-    );
+    fireEvent.click(await screen.findByText('New service'));
+    fireEvent.click(screen.getByRole('button', { name: 'Add Selected Services' }));
+
+    await waitFor(() => expect(onServicesSelected).toHaveBeenCalledWith([
+      expect.objectContaining({
+        configurationType: 'Usage',
+        typeConfig: {
+          base_rate: 25000,
+          unit_of_measure: 'item',
+        },
+      }),
+    ]));
   });
 });

--- a/packages/billing/tests/contractLineServiceUsageConfiguration.test.ts
+++ b/packages/billing/tests/contractLineServiceUsageConfiguration.test.ts
@@ -1,0 +1,77 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const mocks = vi.hoisted(() => ({
+  baseCreate: vi.fn(),
+  usageCreate: vi.fn(),
+}));
+
+vi.mock('../src/models/contractLineServiceConfiguration', () => ({
+  default: class MockContractLineServiceConfiguration {
+    create(...args: unknown[]) {
+      return mocks.baseCreate(...args);
+    }
+  },
+}));
+
+vi.mock('../src/models/contractLineServiceUsageConfig', () => ({
+  default: class MockContractLineServiceUsageConfig {
+    create(...args: unknown[]) {
+      return mocks.usageCreate(...args);
+    }
+  },
+}));
+
+vi.mock('../src/models/contractLineServiceFixedConfig', () => ({
+  default: class MockContractLineServiceFixedConfig {},
+}));
+
+vi.mock('../src/models/contractLineServiceHourlyConfig', () => ({
+  default: class MockContractLineServiceHourlyConfig {},
+}));
+
+vi.mock('../src/models/contractLineServiceBucketConfig', () => ({
+  default: class MockContractLineServiceBucketConfig {},
+}));
+
+describe('ContractLineServiceConfigurationService usage configuration', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.baseCreate.mockResolvedValue('config-1');
+    mocks.usageCreate.mockResolvedValue(true);
+  });
+
+  it('passes the selected usage base rate to the persisted type configuration', async () => {
+    const trx = {
+      transaction: async (callback: (nestedTrx: unknown) => Promise<unknown>) => callback(trx),
+    } as any;
+    const { ContractLineServiceConfigurationService } = await import(
+      '../src/services/contractLineServiceConfigurationService'
+    );
+    const service = new ContractLineServiceConfigurationService(trx, 'tenant-1');
+
+    await service.createConfiguration(
+      {
+        tenant: 'tenant-1',
+        contract_line_id: 'line-1',
+        service_id: 'usage-service',
+        configuration_type: 'Usage',
+        custom_rate: 25000,
+        quantity: 1,
+      },
+      {
+        unit_of_measure: 'item',
+        enable_tiered_pricing: false,
+        minimum_usage: 0,
+        base_rate: 25000,
+      },
+    );
+
+    expect(mocks.usageCreate).toHaveBeenCalledWith({
+      config_id: 'config-1',
+      unit_of_measure: 'item',
+      enable_tiered_pricing: false,
+      minimum_usage: 0,
+      base_rate: 25000,
+    });
+  });
+});

--- a/server/public/locales/de/msp/service-catalog.json
+++ b/server/public/locales/de/msp/service-catalog.json
@@ -169,11 +169,11 @@
       "addSelected": "Ausgewählte Dienste hinzufügen",
       "adding": "Hinzufügen..."
     },
-    "title": "Fügen Sie Services und Produkte zum Plan hinzu",
+    "title": "Services und Produkte zur Vertragszeile hinzufügen",
     "searchPlaceholder": "Dienstleistungen/Produkte suchen...",
     "errors": {
       "load": "Dienste konnten nicht geladen werden",
-      "add": "Das Hinzufügen von Diensten zum Plan ist fehlgeschlagen"
+      "add": "Das Hinzufügen von Diensten zur Vertragszeile ist fehlgeschlagen"
     },
     "states": {
       "loading": "Dienste werden geladen...",

--- a/server/public/locales/en/msp/service-catalog.json
+++ b/server/public/locales/en/msp/service-catalog.json
@@ -155,11 +155,11 @@
     }
   },
   "serviceSelection": {
-    "title": "Add Services & Products to Plan",
+    "title": "Add Services & Products to Contract Line",
     "searchPlaceholder": "Search services/products...",
     "errors": {
       "load": "Failed to load services",
-      "add": "Failed to add services to plan"
+      "add": "Failed to add services to contract line"
     },
     "states": {
       "loading": "Loading services...",

--- a/server/public/locales/es/msp/service-catalog.json
+++ b/server/public/locales/es/msp/service-catalog.json
@@ -169,11 +169,11 @@
       "addSelected": "Agregar servicios seleccionados",
       "adding": "Añadiendo..."
     },
-    "title": "Agregar servicios y productos al plan",
+    "title": "Agregar servicios y productos a la línea de contrato",
     "searchPlaceholder": "Buscar servicios/productos...",
     "errors": {
       "load": "No se pudieron cargar los servicios",
-      "add": "No se pudieron agregar servicios al plan"
+      "add": "No se pudieron agregar servicios a la línea de contrato"
     },
     "states": {
       "loading": "Cargando servicios...",

--- a/server/public/locales/fr/msp/service-catalog.json
+++ b/server/public/locales/fr/msp/service-catalog.json
@@ -169,11 +169,11 @@
       "addSelected": "Ajouter les services sélectionnés",
       "adding": "Ajout..."
     },
-    "title": "Ajouter des services et des produits au plan",
+    "title": "Ajouter des services et des produits à la ligne de contrat",
     "searchPlaceholder": "Rechercher des services/produits...",
     "errors": {
       "load": "Échec du chargement des services",
-      "add": "Échec de l'ajout de services au plan"
+      "add": "Échec de l'ajout de services à la ligne de contrat"
     },
     "states": {
       "loading": "Chargement des services...",

--- a/server/public/locales/it/msp/service-catalog.json
+++ b/server/public/locales/it/msp/service-catalog.json
@@ -169,11 +169,11 @@
       "addSelected": "Aggiungi servizi selezionati",
       "adding": "Aggiunta..."
     },
-    "title": "Aggiungi servizi e prodotti al piano",
+    "title": "Aggiungi servizi e prodotti alla riga del contratto",
     "searchPlaceholder": "Cerca servizi/prodotti...",
     "errors": {
       "load": "Impossibile caricare i servizi",
-      "add": "Impossibile aggiungere servizi al piano"
+      "add": "Impossibile aggiungere servizi alla riga del contratto"
     },
     "states": {
       "loading": "Caricamento servizi...",

--- a/server/public/locales/nl/msp/service-catalog.json
+++ b/server/public/locales/nl/msp/service-catalog.json
@@ -169,11 +169,11 @@
       "addSelected": "Voeg geselecteerde services toe",
       "adding": "Toevoegen..."
     },
-    "title": "Diensten en producten toevoegen aan plan",
+    "title": "Diensten en producten toevoegen aan contractregel",
     "searchPlaceholder": "Diensten/producten zoeken...",
     "errors": {
       "load": "Kan services niet laden",
-      "add": "Het is niet gelukt om services aan het plan toe te voegen"
+      "add": "Het is niet gelukt om services aan de contractregel toe te voegen"
     },
     "states": {
       "loading": "Diensten laden...",

--- a/server/public/locales/pl/msp/service-catalog.json
+++ b/server/public/locales/pl/msp/service-catalog.json
@@ -169,11 +169,11 @@
       "addSelected": "Dodaj wybrane usługi",
       "adding": "Dodawanie..."
     },
-    "title": "Dodaj usługi i produkty do planu",
+    "title": "Dodaj usługi i produkty do pozycji umowy",
     "searchPlaceholder": "Wyszukaj usługi/produkty...",
     "errors": {
       "load": "Nie udało się załadować usług",
-      "add": "Nie udało się dodać usług do planu"
+      "add": "Nie udało się dodać usług do pozycji umowy"
     },
     "states": {
       "loading": "Ładowanie usług...",

--- a/server/public/locales/pt/msp/service-catalog.json
+++ b/server/public/locales/pt/msp/service-catalog.json
@@ -155,11 +155,11 @@
     }
   },
   "serviceSelection": {
-    "title": "Adicionar serviços e produtos ao plano",
+    "title": "Adicionar serviços e produtos à linha do contrato",
     "searchPlaceholder": "Pesquisar serviços/produtos...",
     "errors": {
       "load": "Falha ao carregar serviços",
-      "add": "Falha ao adicionar serviços ao plano"
+      "add": "Falha ao adicionar serviços à linha do contrato"
     },
     "states": {
       "loading": "Carregando serviços...",


### PR DESCRIPTION
## Summary

- Add contract-line service membership controls to the existing inline editor, with catalog additions and removals staged locally until the outer Save action.
- Make Cancel restore persisted membership, hide Add Item and Remove controls outside edit mode, and keep selected service quantity/rate/type details editable in the draft.
- Apply all staged membership changes in one transaction with permission, duplicate-input, contract-authorability, product-pricing, and line/configuration-type validation.
- Use contract-currency catalog pricing when selecting services, persist Usage base rates, and align service-selection copy with contract-line terminology across supported locales.
- Cover the picker/editor draft lifecycle, transactional replacement and rollback behavior, authoring guards, and Usage configuration persistence with focused tests.

## Validation

- PASS — 9 focused contract-line membership and Usage configuration tests.
- PASS — billing and server TypeScript checks.
- PASS — billing package build and full production build.
- PASS — authenticated HTTP smoke check on port 3774.
- The broader billing Vitest run has one unrelated pre-existing DraftInvoiceDetailsCard date-input assertion failure; 807 tests passed and 2 were skipped.

## Authenticated real-product smoke test

PASS — authenticated real-product smoke testing completed on port 3774 using the live PostgreSQL/PgBouncer/Redis stack.

Exercised:

- Staged a service addition: UI showed 2 services while PostgreSQL remained at 1; Cancel restored the persisted service.
- Staged a simultaneous removal and addition: before Save, PostgreSQL still contained only the original service.
- Saved the replacement: PostgreSQL contained only the new Fixed service with quantity 1 and rate 30000; the original and cancelled services were absent.
- Reloaded the page and confirmed the replacement remained visible.
- Staged removal of the saved service: UI showed Services (0), but PostgreSQL retained it; Cancel restored it.
- Confirmed Add Item/service Remove controls are hidden outside edit mode.
- Final browser console had no errors, failed-network log was empty, sign-in returned HTTP 200, and the worktree remained clean.

Fidelity: no simulator or mock was used. Deterministic test data was seeded directly into the real compose PostgreSQL database. The requested space-new-tab command produced cross-host panes that could not be controlled, so a fresh project-bound browser layout was created on the correct host without grafting onto an existing pane. The card's own dev server was restarted to refresh a stale dev-login credential.

Concern: a line initially showing “No location assigned” automatically selected and persisted Headquarters when Save was used, although no location was intentionally chosen. The relevant fallback predates this task's diff, so this appears adjacent/pre-existing rather than introduced by service editing. The baseline and later screenshots show the change.

Automation notes: one selector-based Save click did not activate; a fresh UID-targeted real click did. A reload text-wait also timed out despite the page loading; DOM, screenshot, and database assertions were used instead.

The reusable fixture remains in the dev database as contract 605dd553-b9ac-449c-99c3-bfdb42081d44.

Evidence files 01–08 cover baseline, staged additions/removals, both Cancel outcomes, Save, and reload persistence:

/tmp/alga-smoke-evidence/edit-contract-line-services-20260716-144154
