### PR TITLE
Fix nextjs issue.

### DIFF
--- a/docs/plans/2026-07-16-stale-actions-handling-plan.md
+++ b/docs/plans/2026-07-16-stale-actions-handling-plan.md
@@ -1,0 +1,278 @@
+# Handle stale Next.js server actions after deploy
+
+Branch: `fix/stale-actions-handling`
+
+## Problem
+
+After a production deploy, logs fill with Next.js `Failed to find Server Action`:
+
+- 858 lines over ~30 minutes (~29/min), **steady and not decaying** across the whole window
+- Two dominant action hashes: `7f387937…` 419x, `7f130f7a…` 430x, plus three minor ones
+- Blue had deployed ~6h earlier; green had zero in the same window
+
+The non-decay is the surprising part. A stale-client population drains as people navigate, close
+tabs, and refresh, so the expected shape is a decay curve, not a flat line.
+
+## Diagnosis (confirmed in code)
+
+**The two hashes are two background pollers.** The MSP global header mounts both side by side on
+every authenticated page (`server/src/components/layout/Header.tsx:532-533`):
+
+| Poller | Interval | Rate | Site |
+| --- | --- | --- | --- |
+| `getQueueMetricsAction` | 15s | 4/min | `server/src/components/layout/Header.tsx:290,304` |
+| `getNotificationsAction` | 30s | 2/min | `packages/notifications/src/hooks/useInternalNotifications.ts:149,187` |
+
+**The rate is flat because idle tabs never drain.** A parked tab does not navigate, does not
+refresh, and polls forever. There is no decay curve because there is no population turnover.
+Neither poller distinguishes a permanently-dead action ID from a transient network blip; both
+`catch`, log, and re-fire on the next tick indefinitely.
+
+**Tab arithmetic.** Over the ~30min window: metrics 419 ÷ 30 ÷ 4 ≈ **3.5 tabs**; notifications
+430 ÷ 30 ÷ 2 ≈ **7 tabs**. That 2x gap is expected, not anomalous: `JobActivityIndicator` is
+MSP-only, but `NotificationBell` is mounted on both MSP (`Header.tsx:532`) and client portal
+(`packages/client-portal/src/components/layout/ClientPortalTopBar.tsx:37`). So ~3.5 MSP tabs feed
+both hashes and ~3.5 portal tabs feed only notifications. This is why the fix must cover both
+surfaces.
+
+**Severity reframe.** These 858 errors are ~5-7 parked tabs polling into the void — not 858 broken
+user interactions. The user-facing impact is far smaller than the volume suggests. The real cost is
+that a returning user's tab is silently broken until they refresh.
+
+## Root cause (confirmed in installed Next source + verified empirically)
+
+Server action IDs are **not** derived from the build ID. They are:
+
+```
+action ID = hash(encryption key salt, file path, export name)
+```
+
+The salt is the server actions encryption key — `node_modules/next/dist/build/webpack-config.js:417,443,1921`
+(`serverReferenceHashSalt: encryptionKey`), and turbopack takes the same key at
+`dist/build/turbopack-build/impl.js:63,109`.
+
+`NEXT_SERVER_ACTIONS_ENCRYPTION_KEY` is **not set anywhere in this repo**. When unset, Next
+generates a random AES-256 key per build (`dist/server/app-render/encryption-utils-server.js:92-112`).
+It normally caches that key to `.next/cache/.rscinfo` with a 14-day expiry — **but
+`getStorageDirectory()` returns `undefined` when running under Docker** (`dist/server/cache-dir.js`).
+
+We build in Docker. Therefore:
+
+> **Every build generates a fresh random key → every action ID in the app churns on every deploy →
+> every open tab goes totally stale at the instant of traffic cutover.**
+
+This is why staleness happens on *every* deploy rather than only when an action actually changes.
+`getQueueMetricsAction` has not changed in months; its ID churns anyway.
+
+**Verified empirically** against real turbopack builds of Next 16.2.6 in a scratch app:
+
+| Test | Result |
+| --- | --- |
+| Pinned key, build IDs `build-AAA` vs `build-ZZZ` | **Identical** action IDs |
+| Same build ID, fresh `.next`, no key set | **Completely different** action IDs |
+| Pinned key, changed an action's body | **Identical** action IDs |
+
+**Blue/green is not a factor, but it is the trigger.** `nm-kube-config/alga-psa/workflows/composite/alga-psa-build-migrate-deploy.yaml:92-94`
+builds **once**; `determine-colors` (`:145`) picks whichever color is currently inactive; both
+colors run byte-identical images differing only by a Helm values overlay. So blue and green have
+*identical* action IDs — there is no color skew. But each `istio-promote-traffic` cutover (`:201`)
+swaps in an image built with a fresh random key, so every tab loaded before the cutover is stale
+the moment traffic moves.
+
+## Out of scope / verified safe (do not change)
+
+- **`generateBuildId`** (`server/next.config.mjs:1325`, `'build-' + Date.now()`) — looks like a
+  landmine, is **not one**. Verified: a pinned key with differing build IDs yields identical action
+  IDs. It only drives *navigation* skew, which Next already self-heals via `doMpaNavigation()`
+  (`dist/esm/client/components/router-reducer/fetch-server-response.js:127-130`). **Do not "fix" it
+  as part of this work.**
+- **Hocuspocus reconnect failure** — notification polling is only supposed to run while the
+  websocket is down (`useInternalNotifications.ts:148,186` start it; `:174-177` `onConnect` clears
+  it). Flat polling for ~6h means `onConnect` never fires again after a deploy. That is a separate
+  bug with a separate fix. Filed as **alga0002135** (PSA development board). Not this branch.
+- **`deploymentId` / Next skew protection** — supported (`dist/server/config-schema.js:528`) but
+  useless here: the Next server never reads `x-deployment-id` or `?dpl=` (zero hits across
+  `dist/server/**`; the docs confirm it). It is infra-level routing metadata. Setting it will not
+  make a stale action resolve.
+- **`Dockerfile.build` and `ee/server/Dockerfile.build`** — these contain a real `next build` and
+  `ARG NEXTAUTH_SECRET_BUILD`, and are **completely unused** by the pipeline (zero references in
+  nm-kube-config). They are the abandoned build-in-Docker path. Editing them accomplishes nothing.
+  This is the most likely wrong turn for anyone implementing this plan.
+- **Runtime env for the key** — do **not** add `NEXT_SERVER_ACTIONS_ENCRYPTION_KEY` to
+  `helm/templates/deployment.yaml`. Next reads
+  `process.env.NEXT_SERVER_ACTIONS_ENCRYPTION_KEY || serverActionsManifest.encryptionKey`
+  (`encryption-utils.js:78`), so a runtime value **overrides** the value baked into the build
+  manifest. If the two ever drift, closure-argument decryption breaks. Build-time only is both
+  sufficient (replicas of one image agree) and safer.
+
+## The fix
+
+Two layers. The cheap one does most of the work.
+
+| Layer | Change | Effect |
+| --- | --- | --- |
+| Root cause | Pin `NEXT_SERVER_ACTIONS_ENCRYPTION_KEY` at build time | Unchanged actions survive deploys — kills most staleness, including both observed hashes |
+| Backstop | Catch `UnrecognizedActionError` → halt that poller + show banner | Handles genuinely changed/removed actions, which no key pinning can fix |
+
+### Phase 1 — Pin the key (repo: `~/nm-kube-config`) — **MUST LAND FIRST**
+
+> **Ordering is load-bearing.** Phase 2 hard-fails production builds when the key is unset. If
+> Phase 2 merges before Phase 1 is deployed, **every production build breaks immediately** — EE and
+> CE both. Land and verify Phase 1 first.
+
+`next build` does **not** run in the Dockerfile. It runs in the Argo `build-app-ee` template.
+`ee/server/Dockerfile` is packaging only — it `COPY`s the pre-built `server/.next` (`:67`) and has
+no `ARG` lines. A `--build-arg` there would have zero effect.
+
+1. **Generate the key once**: `openssl rand -base64 32`. This is a real secret (it encrypts closure
+   variables bound into server actions). Never commit it.
+2. **Create a k8s Secret in `namespace: argo`** (the *build* namespace — distinct from the `msp`
+   runtime namespace; only the build one is needed here), e.g. Secret `next-server-actions-key`,
+   key `encryption-key`.
+3. **EE workflow** — `alga-psa/workflows/build/alga-psa-ci-cd-workflow.yaml`:
+   - Add an `env:` block to the `build-app-ee` template at `:959` (between `image:` and `command:`).
+     **This template currently has no `env:` block at all** — this will be the first.
+   - Use `valueFrom.secretKeyRef`, mirroring the house pattern for `GITHUB_TOKEN` at `:1074-1078`.
+   - Thread it onto the `next:build` invocation at `:1003`, alongside the existing
+     `NEXT_PUBLIC_APP_VERSION` (the closest analogue — see `:1000`).
+4. **CE workflow** — mirror the same into
+   `alga-psa/workflows/build/alga-psa-ce-build-workflow.yaml` (CE build command at `:610`, existing
+   `export` block just above it at `:605-608`). Required: the Phase 2 guard will otherwise break CE
+   builds, and CE/self-hosted users have the same bug.
+5. **Do not touch the stale duplicates** under `argo-workflow/alga-psa-dev/templates/build/` —
+   both `alga-psa-ci-cd-workflow.yaml` (diverged: namespace `argo-workflows`, 1216 lines vs 1923)
+   and `alga-psa-ce-build-workflow.yaml` have copies there. The `alga-psa/workflows/build/` copies
+   are the current ones.
+
+### Phase 2 — Guard the invariant (this repo) — **after Phase 1 is live**
+
+In `server/next.config.mjs`, fail **production builds** when `NEXT_SERVER_ACTIONS_ENCRYPTION_KEY`
+is unset. Throw with a message naming the variable and pointing at this plan.
+
+> **Gate on build phase, NOT on `NODE_ENV`.** `next start` evaluates `next.config.mjs` at runtime,
+> the runtime image sets `NODE_ENV=production` (`ee/server/Dockerfile:101`, launched via
+> `server/entrypoint.sh` → `npm start`), and this plan deliberately does **not** set the key at
+> runtime. A `NODE_ENV`-gated throw therefore fires in every production pod at startup and takes
+> the app down. Instead: convert the config export to the function form
+> `export default (phase) => { … return nextConfig }` and throw only when
+> `phase === PHASE_PRODUCTION_BUILD` (import from `next/constants`; verified present at
+> `dist/shared/lib/constants.js:333`). Runtime evaluates under `phase-production-server` and is
+> unaffected.
+
+No escape hatch, and the same rule locally as in CI: a local production build without the key
+produces an image with exactly the same footgun, so failing is the honest outcome. A developer who
+genuinely needs a local production build sets a throwaway key.
+
+Rationale: a pinned key that silently un-pins puts us right back here, and the only signal would be
+a Grafana spike six hours after a deploy. The engine should refuse to produce the footgun rather
+than rely on everyone remembering a pipeline env var forever.
+
+### Phase 3 — App-side backstop (this repo)
+
+Staleness is a property of the **client**, not of an action: if any action ID is gone, the client's
+bundle provably predates the server's build. But halting is **per-poller** — a poller stops when
+*its own* action is provably dead. That rule is correct both today (all IDs churn, so every poller
+halts itself anyway) and after Phase 1 (only changed actions die; a poller calling an unchanged
+action keeps working and should not be broken for no reason). Stop what is provably futile; do not
+break what still works.
+
+**3a. Stale-build store** (`packages/ui`) — a small sticky flag, set once by any dead-action
+detection, never unset. Detection uses `unstable_isUnrecognizedActionError` from `next/navigation`
+(`dist/client/components/navigation.js:57-58`), **with `error.name === 'UnrecognizedActionError'`
+as fallback** — the exported helper is an `instanceof` check, which breaks if duplicate Next client
+copies exist, a real risk in this monorepo. Note: an infra-level 404 *without* the
+`x-nextjs-action-not-found` header falls into Next's generic error path (`E394`) and will not be
+detected; that is acceptable, since the poller then backs off rather than hammering.
+
+**3b. Polling primitive** (`packages/ui`) — the actual leverage. The same shape is currently
+hand-written at least four times: `setInterval` + async call + `try/catch` that logs and swallows +
+re-fire forever.
+
+- `server/src/components/layout/Header.tsx:283-311`
+- `packages/notifications/src/hooks/useInternalNotifications.ts:148,186`
+- `server/src/components/settings/general/ClientPortalSettings.tsx:123` (`getPortalDomainStatusAction`,
+  5s — page-scoped, would appear as a third hash in the tail)
+- EE status pollers (`AccountManagement.tsx:388`, `RunStudioShell.tsx:156`) — state-gated, lower risk
+
+That repetition is the `// LEVERAGE: pattern` signal from `CLAUDE.md` — a missing layer below. The
+primitive owns the failure taxonomy once:
+
+- dead action → mark global stale, **stop permanently**
+- transient error → **exponential backoff**
+- success → reset backoff
+
+Call sites lose their `try/catch` entirely and declare only what to poll and how often.
+
+**3c. Refresh banner** (`packages/ui`) — reads the store, renders the existing `Alert` primitive
+(`@alga-psa/ui/components/Alert`). Non-blocking, persistent, with a Refresh button that reloads.
+
+Never auto-reload: this app is full of unsaved ticket comments and time entries, and silently
+destroying a half-written comment is worse than the stale tab.
+
+Mount in MSP (`server/src/components/layout/DefaultLayout.tsx:22`,
+`server/src/components/layout/AlgaDeskMspShell.tsx:82`) and client portal
+(`packages/client-portal/src/components/layout/ClientPortalTopBar.tsx:37`).
+`server/src/components/layout/PlatformNotificationBanner.tsx` is the right *shape* to copy but the
+wrong *location* to extend — it lives in `server/src` and imports `@enterprise`, so the portal
+cannot use it. The new banner must live in `packages/ui`.
+
+**Important property**: after Phase 1, Phase 3 should almost never fire. It is the backstop for
+genuinely changed actions, not the mechanism keeping the app alive. If the banner starts appearing
+on every deploy, Phase 1 has regressed — which makes Phase 3 a de facto alarm on the real fix.
+
+### Phase 4 — Migrate the call sites
+
+Convert `Header.tsx` and `useInternalNotifications.ts` to the primitive (these two produce the
+observed hashes). Then `ClientPortalSettings.tsx`. Leave the state-gated EE pollers unless trivial.
+
+## Verification
+
+**Phase 1 (the fix that matters):** build twice with the same pinned key and diff the action IDs in
+`.next/server/server-reference-manifest.json` — identical means it works. Build twice *without* the
+key and confirm they differ. This is the experiment that was run empirically during design, so it
+is known to discriminate.
+
+**Phase 2:** production build with the var unset fails with the intended message; with it set,
+succeeds. Dev server (`next dev`) is unaffected. **Also verify the runtime path**: `next start`
+against a built app with the runtime env *not* containing the key must boot cleanly — this is the
+phase-gating property, and it is the failure mode a naive `NODE_ENV` guard would hit in production.
+
+**Phase 3 unit tests** — cheap and deterministic; the error predicate is the only Next-specific
+surface, tested against a synthetic error by `name`:
+- primitive halts permanently on a synthetic `UnrecognizedActionError`
+- primitive backs off exponentially on a generic error, resets backoff on success
+- primitive clears its interval on unmount
+- store is sticky and idempotent
+- banner renders when stale, reloads on click
+
+**What cannot be unit-tested:** proving a genuinely stale client gets the banner requires two builds
+and a live cutover. Manual check against the dev stack (this worktree runs on port 3164): load a
+tab, rebuild with a *different* key to simulate today's behavior, confirm the banner appears and
+the poller stops re-firing.
+
+**Post-deploy:** the real proof is the Grafana `Failed to find Server Action` rate going to ~zero on
+the next promotion. Watch the window after cutover.
+
+## Files touched
+
+**`~/nm-kube-config`** (Phase 1, lands first):
+- `alga-psa/workflows/build/alga-psa-ci-cd-workflow.yaml` — `env:` block on `build-app-ee` (`:959`),
+  thread onto build cmd (`:1003`)
+- `alga-psa-ce-build-workflow.yaml` (`:605-610`) — same
+- new k8s Secret in `namespace: argo`
+
+**This repo:**
+- `server/next.config.mjs` — build guard (Phase 2)
+- `packages/ui/src/…` — stale store, polling primitive, refresh banner (Phase 3)
+- `server/src/components/layout/DefaultLayout.tsx`, `AlgaDeskMspShell.tsx` — mount banner
+- `packages/client-portal/src/components/layout/ClientPortalTopBar.tsx` — mount banner
+- `server/src/components/layout/Header.tsx` — migrate to primitive (Phase 4)
+- `packages/notifications/src/hooks/useInternalNotifications.ts` — migrate to primitive (Phase 4)
+- `server/src/components/settings/general/ClientPortalSettings.tsx` — migrate to primitive (Phase 4)
+
+## Open questions
+
+- Phase 1 lands in a different repo than Phase 2/3. If Draft Implementation can only reach this
+  repo, **Phase 2 must not merge until Phase 1 is deployed** — otherwise all production builds fail.
+- Key rotation is a deliberate act that invalidates every live client (same blast radius as today's
+  every-deploy churn). Worth documenting wherever the secret is recorded.

--- a/packages/client-portal/src/components/layout/ClientPortalTopBar.tsx
+++ b/packages/client-portal/src/components/layout/ClientPortalTopBar.tsx
@@ -3,6 +3,7 @@
 import { ReactNode } from 'react';
 import { NotificationBell } from '@alga-psa/notifications/components';
 import { ThemeToggle } from '@alga-psa/ui/components/ThemeToggle';
+import { StaleActionBanner } from '@alga-psa/ui/components/StaleActionBanner';
 
 interface TopBarProps {
   breadcrumb?: ReactNode;
@@ -40,6 +41,7 @@ export function ClientPortalTopBar({
           {userMenu && <div className="ml-2">{userMenu}</div>}
         </div>
       </div>
+      <StaleActionBanner />
     </header>
   );
 }

--- a/packages/notifications/src/hooks/useInternalNotifications.ts
+++ b/packages/notifications/src/hooks/useInternalNotifications.ts
@@ -6,6 +6,7 @@
 	import { useState, useEffect, useCallback, useRef } from 'react';
 	import * as Y from 'yjs';
 	import { HocuspocusProvider } from '@hocuspocus/provider';
+import { useActionPolling } from '@alga-psa/ui/hooks';
 import type {
   InternalNotification,
   InternalNotificationListResponse,
@@ -73,26 +74,22 @@ export function useInternalNotifications(
 
   const providerRef = useRef<HocuspocusProvider | null>(null);
   const ydocRef = useRef<Y.Doc | null>(null);
-  const pollingIntervalRef = useRef<NodeJS.Timeout | null>(null);
   const reconnectTimeoutRef = useRef<NodeJS.Timeout | null>(null);
   const reconnectDelayRef = useRef<number>(INITIAL_RECONNECT_DELAY);
 
-  const fetchNotificationsRef = useRef<(() => Promise<void>) | undefined>(undefined);
-	  const enablePollingRef = useRef<boolean>(enablePolling);
-	
-	  const fetchNotifications = useCallback(async () => {
-	    if (!tenant || !userId) {
-	      setNotifications([]);
-	      setUnreadCount(0);
-	      setError(null);
-	      setIsLoading(false);
-	      return;
-	    }
-	
-	    try {
-	      const response: InternalNotificationListResponse = await getNotificationsAction({
-	        tenant,
-	        user_id: userId,
+  const fetchNotifications = useCallback(async () => {
+    if (!tenant || !userId) {
+      setNotifications([]);
+      setUnreadCount(0);
+      setError(null);
+      setIsLoading(false);
+      return;
+    }
+
+    try {
+      const response: InternalNotificationListResponse = await getNotificationsAction({
+        tenant,
+        user_id: userId,
         limit,
       });
       setNotifications(response.notifications);
@@ -106,21 +103,10 @@ export function useInternalNotifications(
         notificationsMap.set('data', response.notifications);
         unreadCountMap.set('count', response.unread_count);
       }
-    } catch (err) {
-      console.error('Failed to fetch notifications:', err);
-      setError('Failed to load notifications');
     } finally {
       setIsLoading(false);
     }
-	  }, [tenant, userId, limit]);
-
-  useEffect(() => {
-    fetchNotificationsRef.current = fetchNotifications;
-  }, [fetchNotifications]);
-
-  useEffect(() => {
-    enablePollingRef.current = enablePolling;
-  }, [enablePolling]);
+  }, [tenant, userId, limit]);
 
 	  const fetchUnreadCount = useCallback(async () => {
 	    if (!tenant || !userId) {
@@ -134,30 +120,27 @@ export function useInternalNotifications(
     } catch (err) {
       console.error('Failed to fetch unread count:', err);
     }
-	  }, [tenant, userId]);
-	
-	  const setupWebSocket = useCallback(() => {
+  }, [tenant, userId]);
+
+  const { runNow: pollNotificationsNow } = useActionPolling(fetchNotifications, {
+    intervalMs: POLLING_INTERVAL,
+    enabled: enablePolling && !isConnected && Boolean(tenant && userId),
+    runImmediately: false,
+    onError: () => setError('Failed to load notifications'),
+  });
+
+  const setupWebSocket = useCallback(() => {
 	    if (!tenant || !userId) {
 	      setIsConnected(false);
 	      return () => {};
 	    }
-	
-	    const hocuspocusUrl = getHocuspocusUrl();
-	    if (!hocuspocusUrl) {
-	      setIsConnected(false);
-	      if (enablePollingRef.current && !pollingIntervalRef.current) {
-	        pollingIntervalRef.current = setInterval(() => {
-	          fetchNotificationsRef.current?.();
-	        }, POLLING_INTERVAL);
-	      }
-	      return () => {
-	        if (pollingIntervalRef.current) {
-	          clearInterval(pollingIntervalRef.current);
-	          pollingIntervalRef.current = null;
-	        }
-	      };
-	    }
-	
+
+    const hocuspocusUrl = getHocuspocusUrl();
+    if (!hocuspocusUrl) {
+      setIsConnected(false);
+      return () => {};
+    }
+
 	    const roomName = `notifications:${tenant}:${userId}`;
 	    const ydoc = new Y.Doc();
 	    const provider = new HocuspocusProvider({
@@ -171,23 +154,12 @@ export function useInternalNotifications(
         setError(null);
         reconnectDelayRef.current = INITIAL_RECONNECT_DELAY;
 
-        if (pollingIntervalRef.current) {
-          clearInterval(pollingIntervalRef.current);
-          pollingIntervalRef.current = null;
-        }
-
-        fetchNotificationsRef.current?.();
+        void pollNotificationsNow();
       },
 
       onDisconnect: ({ event }) => {
         console.log('Disconnected from notification stream', event);
         setIsConnected(false);
-
-        if (enablePollingRef.current && !pollingIntervalRef.current) {
-          pollingIntervalRef.current = setInterval(() => {
-            fetchNotificationsRef.current?.();
-          }, POLLING_INTERVAL);
-        }
 
         if (reconnectTimeoutRef.current) {
           clearTimeout(reconnectTimeoutRef.current);
@@ -229,26 +201,22 @@ export function useInternalNotifications(
       provider.destroy();
       ydoc.destroy();
     };
-	  }, [tenant, userId]);
-	
-	  useEffect(() => {
-	    setIsLoading(true);
-	    fetchNotifications();
+  }, [pollNotificationsNow, tenant, userId]);
+
+  useEffect(() => {
+    setIsLoading(true);
+    void pollNotificationsNow();
 
     const cleanup = setupWebSocket();
 
     return () => {
       cleanup();
-      if (pollingIntervalRef.current) {
-        clearInterval(pollingIntervalRef.current);
-        pollingIntervalRef.current = null;
-      }
       if (reconnectTimeoutRef.current) {
         clearTimeout(reconnectTimeoutRef.current);
         reconnectTimeoutRef.current = null;
       }
     };
-  }, [fetchNotifications, setupWebSocket]);
+  }, [pollNotificationsNow, setupWebSocket]);
 
   const markAsRead = useCallback(
     async (notificationId: string) => {

--- a/packages/ui/src/components/StaleActionBanner.test.tsx
+++ b/packages/ui/src/components/StaleActionBanner.test.tsx
@@ -1,0 +1,45 @@
+import { act, fireEvent, render, screen } from '@testing-library/react';
+import '@testing-library/jest-dom/vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { markStaleActionState } from '../lib/staleActionState';
+import { StaleActionBanner } from './StaleActionBanner';
+
+vi.mock('../lib/i18n/client', () => ({
+  useTranslation: () => ({
+    t: (key: string, options?: { defaultValue?: string }) => options?.defaultValue ?? key,
+  }),
+}));
+
+describe('StaleActionBanner', () => {
+  const originalLocation = window.location;
+  const reload = vi.fn();
+
+  beforeEach(() => {
+    reload.mockReset();
+    Object.defineProperty(window, 'location', {
+      configurable: true,
+      value: { reload },
+    });
+  });
+
+  afterEach(() => {
+    Object.defineProperty(window, 'location', {
+      configurable: true,
+      value: originalLocation,
+    });
+  });
+
+  it('appears when an action is stale and refreshes the page on request', () => {
+    render(<StaleActionBanner />);
+    expect(screen.queryByRole('alert')).not.toBeInTheDocument();
+
+    act(() => markStaleActionState());
+
+    expect(screen.getByRole('alert')).toHaveTextContent(
+      'This page is out of date. Refresh to restore live updates and actions.',
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: 'Refresh' }));
+    expect(reload).toHaveBeenCalledTimes(1);
+  });
+});

--- a/packages/ui/src/components/StaleActionBanner.tsx
+++ b/packages/ui/src/components/StaleActionBanner.tsx
@@ -1,0 +1,42 @@
+'use client';
+
+import { RefreshCw } from 'lucide-react';
+import { Alert, AlertDescription } from './Alert';
+import { Button } from './Button';
+import { useStaleActionState } from '../lib/staleActionState';
+import { useTranslation } from '../lib/i18n/client';
+
+export function StaleActionBanner() {
+  const isStale = useStaleActionState();
+  const { t } = useTranslation('common');
+
+  if (!isStale) {
+    return null;
+  }
+
+  return (
+    <Alert
+      id="stale-action-banner"
+      variant="warning"
+      className="rounded-none border-x-0 border-t-0 px-4 py-2 shadow-none [&>svg]:top-2.5"
+    >
+      <AlertDescription className="flex min-h-7 items-center justify-between gap-4">
+        <span>
+          {t('staleAction.message', {
+            defaultValue: 'This page is out of date. Refresh to restore live updates and actions.',
+          })}
+        </span>
+        <Button
+          id="refresh-stale-action-page-button"
+          variant="outline"
+          size="xs"
+          className="shrink-0"
+          onClick={() => window.location.reload()}
+        >
+          <RefreshCw className="mr-1.5 h-3.5 w-3.5" aria-hidden="true" />
+          {t('actions.refresh', { defaultValue: 'Refresh' })}
+        </Button>
+      </AlertDescription>
+    </Alert>
+  );
+}

--- a/packages/ui/src/components/index.ts
+++ b/packages/ui/src/components/index.ts
@@ -1,4 +1,5 @@
 export * from './Alert';
+export * from './StaleActionBanner';
 export * from './LanguageHierarchyTable';
 export type { SelectOption as AsyncSearchableSelectOption } from './AsyncSearchableSelect';
 export { default as AsyncSearchableSelect } from './AsyncSearchableSelect';

--- a/packages/ui/src/hooks/index.ts
+++ b/packages/ui/src/hooks/index.ts
@@ -4,6 +4,7 @@ export * from './use-toast';
 export * from './useCollapsiblePreference';
 export * from './useFeatureFlag';
 export * from './useIntervalTracking';
+export * from './useActionPolling';
 export * from './useIsCompactEvent';
 export * from './useResponsiveColumns';
 export * from './useTicketTimeTracking';

--- a/packages/ui/src/hooks/useActionPolling.test.tsx
+++ b/packages/ui/src/hooks/useActionPolling.test.tsx
@@ -1,0 +1,91 @@
+import { act, renderHook } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { getStaleActionState } from '../lib/staleActionState';
+import { useActionPolling } from './useActionPolling';
+
+async function flushPromises() {
+  await act(async () => {
+    await Promise.resolve();
+  });
+}
+
+describe('useActionPolling', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.spyOn(console, 'error').mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.restoreAllMocks();
+  });
+
+  it('halts permanently and marks the client stale for an unrecognized action', async () => {
+    const staleError = Object.assign(new Error('action missing'), {
+      name: 'UnrecognizedActionError',
+    });
+    const action = vi.fn().mockRejectedValue(staleError);
+
+    renderHook(() => useActionPolling(action, { intervalMs: 1000 }));
+    await flushPromises();
+
+    expect(action).toHaveBeenCalledTimes(1);
+    expect(getStaleActionState()).toBe(true);
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(60000);
+    });
+
+    expect(action).toHaveBeenCalledTimes(1);
+  });
+
+  it('backs off after transient failures and resets after a success', async () => {
+    const action = vi.fn()
+      .mockRejectedValueOnce(new Error('first failure'))
+      .mockRejectedValueOnce(new Error('second failure'))
+      .mockResolvedValue(undefined);
+
+    renderHook(() => useActionPolling(action, {
+      intervalMs: 1000,
+      maxBackoffMs: 8000,
+    }));
+    await flushPromises();
+
+    expect(action).toHaveBeenCalledTimes(1);
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(1000);
+    });
+    expect(action).toHaveBeenCalledTimes(2);
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(1999);
+    });
+    expect(action).toHaveBeenCalledTimes(2);
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(1);
+    });
+    expect(action).toHaveBeenCalledTimes(3);
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(1000);
+    });
+    expect(action).toHaveBeenCalledTimes(4);
+  });
+
+  it('clears a scheduled poll when unmounted', async () => {
+    const action = vi.fn().mockResolvedValue(undefined);
+    const { unmount } = renderHook(() => useActionPolling(action, {
+      intervalMs: 1000,
+      runImmediately: false,
+    }));
+
+    unmount();
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(1000);
+    });
+
+    expect(action).not.toHaveBeenCalled();
+  });
+});

--- a/packages/ui/src/hooks/useActionPolling.ts
+++ b/packages/ui/src/hooks/useActionPolling.ts
@@ -1,0 +1,155 @@
+'use client';
+
+import { useCallback, useEffect, useRef } from 'react';
+import {
+  isStaleServerActionError,
+  markStaleActionState,
+} from '../lib/staleActionState';
+
+interface ActionPollingOptions {
+  intervalMs: number;
+  enabled?: boolean;
+  runImmediately?: boolean;
+  maxBackoffMs?: number;
+  onError?: (error: unknown, retryDelayMs: number) => void;
+}
+
+interface ActionPollingResult {
+  runNow: () => Promise<void>;
+}
+
+type PollAttemptResult =
+  | { outcome: 'success' }
+  | { outcome: 'retry'; retryDelayMs: number }
+  | { outcome: 'halted' };
+
+export function useActionPolling(
+  action: () => Promise<unknown> | unknown,
+  {
+    intervalMs,
+    enabled = true,
+    runImmediately = true,
+    maxBackoffMs = intervalMs * 16,
+    onError,
+  }: ActionPollingOptions,
+): ActionPollingResult {
+  const actionRef = useRef(action);
+  const onErrorRef = useRef(onError);
+  const intervalMsRef = useRef(intervalMs);
+  const maxBackoffMsRef = useRef(maxBackoffMs);
+  const timerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const inFlightRef = useRef<Promise<PollAttemptResult> | null>(null);
+  const failureCountRef = useRef(0);
+  const haltedRef = useRef(false);
+
+  actionRef.current = action;
+  onErrorRef.current = onError;
+  intervalMsRef.current = intervalMs;
+  maxBackoffMsRef.current = maxBackoffMs;
+
+  const clearTimer = useCallback(() => {
+    if (timerRef.current !== null) {
+      clearTimeout(timerRef.current);
+      timerRef.current = null;
+    }
+  }, []);
+
+  const executeAction = useCallback((): Promise<PollAttemptResult> => {
+    if (haltedRef.current) {
+      return Promise.resolve({ outcome: 'halted' });
+    }
+
+    if (inFlightRef.current) {
+      return inFlightRef.current;
+    }
+
+    const attempt = (async (): Promise<PollAttemptResult> => {
+      try {
+        await actionRef.current();
+        failureCountRef.current = 0;
+        return { outcome: 'success' };
+      } catch (error) {
+        if (isStaleServerActionError(error)) {
+          haltedRef.current = true;
+          clearTimer();
+          markStaleActionState();
+          return { outcome: 'halted' };
+        }
+
+        failureCountRef.current += 1;
+        const backoffExponent = Math.min(failureCountRef.current - 1, 30);
+        const retryDelayMs = Math.min(
+          intervalMsRef.current * (2 ** backoffExponent),
+          maxBackoffMsRef.current,
+        );
+
+        console.error(
+          `[useActionPolling] Action failed; retrying in ${retryDelayMs}ms`,
+          error,
+        );
+        onErrorRef.current?.(error, retryDelayMs);
+
+        return { outcome: 'retry', retryDelayMs };
+      }
+    })();
+
+    inFlightRef.current = attempt;
+    void attempt.finally(() => {
+      if (inFlightRef.current === attempt) {
+        inFlightRef.current = null;
+      }
+    });
+
+    return attempt;
+  }, [clearTimer]);
+
+  const runNow = useCallback(async () => {
+    await executeAction();
+  }, [executeAction]);
+
+  useEffect(() => {
+    clearTimer();
+
+    if (!enabled || haltedRef.current) {
+      return undefined;
+    }
+
+    let cancelled = false;
+
+    const schedule = (delayMs: number) => {
+      if (cancelled || haltedRef.current) {
+        return;
+      }
+
+      timerRef.current = setTimeout(() => {
+        void poll();
+      }, delayMs);
+    };
+
+    const poll = async () => {
+      const result = await executeAction();
+      if (cancelled || result.outcome === 'halted') {
+        return;
+      }
+
+      schedule(
+        result.outcome === 'retry'
+          ? result.retryDelayMs
+          : intervalMsRef.current,
+      );
+    };
+
+    if (runImmediately) {
+      void poll();
+    } else {
+      schedule(intervalMs);
+    }
+
+    return () => {
+      cancelled = true;
+      clearTimer();
+    };
+  }, [clearTimer, enabled, executeAction, intervalMs, maxBackoffMs, runImmediately]);
+
+  return { runNow };
+}

--- a/packages/ui/src/lib/index.ts
+++ b/packages/ui/src/lib/index.ts
@@ -3,6 +3,7 @@ export * from './colorUtils';
 export * from './dateFnsLocale';
 export * from './dateInput';
 export * from './errorHandling';
+export * from './staleActionState';
 export * from './cookies';
 export * from './i18n/client';
 export * from './i18n/config';

--- a/packages/ui/src/lib/staleActionState.test.ts
+++ b/packages/ui/src/lib/staleActionState.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, it, vi } from 'vitest';
+import {
+  getStaleActionState,
+  isStaleServerActionError,
+  markStaleActionState,
+  subscribeToStaleActionState,
+} from './staleActionState';
+
+describe('staleActionState', () => {
+  it('recognizes a stale action by name when the Next.js instanceof check cannot', () => {
+    const errorFromAnotherBundle = { name: 'UnrecognizedActionError' };
+
+    expect(isStaleServerActionError(errorFromAnotherBundle)).toBe(true);
+    expect(isStaleServerActionError(new Error('network unavailable'))).toBe(false);
+  });
+
+  it('sets the shared stale state once and keeps it sticky', () => {
+    const listener = vi.fn();
+    const unsubscribe = subscribeToStaleActionState(listener);
+
+    expect(getStaleActionState()).toBe(false);
+
+    markStaleActionState();
+    markStaleActionState();
+
+    expect(getStaleActionState()).toBe(true);
+    expect(listener).toHaveBeenCalledTimes(1);
+
+    unsubscribe();
+  });
+});

--- a/packages/ui/src/lib/staleActionState.ts
+++ b/packages/ui/src/lib/staleActionState.ts
@@ -1,0 +1,50 @@
+'use client';
+
+import { useSyncExternalStore } from 'react';
+import { unstable_isUnrecognizedActionError } from 'next/navigation';
+
+type StaleActionListener = () => void;
+
+let isStale = false;
+const listeners = new Set<StaleActionListener>();
+
+const getServerSnapshot = () => false;
+
+export function isStaleServerActionError(error: unknown): boolean {
+  if (unstable_isUnrecognizedActionError(error)) {
+    return true;
+  }
+
+  return (
+    typeof error === 'object'
+    && error !== null
+    && 'name' in error
+    && error.name === 'UnrecognizedActionError'
+  );
+}
+
+export function markStaleActionState(): void {
+  if (isStale) {
+    return;
+  }
+
+  isStale = true;
+  listeners.forEach((listener) => listener());
+}
+
+export function getStaleActionState(): boolean {
+  return isStale;
+}
+
+export function subscribeToStaleActionState(listener: StaleActionListener): () => void {
+  listeners.add(listener);
+  return () => listeners.delete(listener);
+}
+
+export function useStaleActionState(): boolean {
+  return useSyncExternalStore(
+    subscribeToStaleActionState,
+    getStaleActionState,
+    getServerSnapshot,
+  );
+}

--- a/server/public/locales/de/common.json
+++ b/server/public/locales/de/common.json
@@ -14,6 +14,9 @@
     "expiringForClient_one": "{{count}} Guthaben für {{clientName}} läuft bald ab",
     "expiringForClient_other": "{{count}} Guthaben für {{clientName}} laufen bald ab"
   },
+  "staleAction": {
+    "message": "Diese Seite ist nicht mehr aktuell. Aktualisieren Sie sie, um Live-Updates und Aktionen wiederherzustellen."
+  },
   "licenseBanner": {
     "trialExpiresIn_one": "Die Pro-Testphase läuft in {{count}} Tag ab. Geben Sie einen Lizenzschlüssel ein, um die Pro-Funktionen zu behalten.",
     "trialExpiresIn_other": "Die Pro-Testphase läuft in {{count}} Tagen ab. Geben Sie einen Lizenzschlüssel ein, um die Pro-Funktionen zu behalten.",

--- a/server/public/locales/en/common.json
+++ b/server/public/locales/en/common.json
@@ -14,6 +14,9 @@
     "expiringForClient_one": "{{count}} credit for {{clientName}} will expire soon",
     "expiringForClient_other": "{{count}} credits for {{clientName}} will expire soon"
   },
+  "staleAction": {
+    "message": "This page is out of date. Refresh to restore live updates and actions."
+  },
   "licenseBanner": {
     "trialExpiresIn_one": "Pro trial expires in {{count}} day. Enter a license key to keep Pro features.",
     "trialExpiresIn_other": "Pro trial expires in {{count}} days. Enter a license key to keep Pro features.",

--- a/server/public/locales/es/common.json
+++ b/server/public/locales/es/common.json
@@ -14,6 +14,9 @@
     "expiringForClient_one": "{{count}} crédito de {{clientName}} vencerá pronto",
     "expiringForClient_other": "{{count}} créditos de {{clientName}} vencerán pronto"
   },
+  "staleAction": {
+    "message": "Esta página está desactualizada. Actualízala para restaurar las actualizaciones y las acciones."
+  },
   "licenseBanner": {
     "trialExpiresIn_one": "La prueba Pro vence en {{count}} día. Introduzca una clave de licencia para conservar las funciones Pro.",
     "trialExpiresIn_other": "La prueba Pro vence en {{count}} días. Introduzca una clave de licencia para conservar las funciones Pro.",

--- a/server/public/locales/fr/common.json
+++ b/server/public/locales/fr/common.json
@@ -14,6 +14,9 @@
     "expiringForClient_one": "{{count}} crédit pour {{clientName}} expirera bientôt",
     "expiringForClient_other": "{{count}} crédits pour {{clientName}} expireront bientôt"
   },
+  "staleAction": {
+    "message": "Cette page n’est plus à jour. Actualisez-la pour rétablir les mises à jour et les actions."
+  },
   "licenseBanner": {
     "trialExpiresIn_one": "L'essai Pro expire dans {{count}} jour. Saisissez une clé de licence pour conserver les fonctionnalités Pro.",
     "trialExpiresIn_other": "L'essai Pro expire dans {{count}} jours. Saisissez une clé de licence pour conserver les fonctionnalités Pro.",

--- a/server/public/locales/it/common.json
+++ b/server/public/locales/it/common.json
@@ -14,6 +14,9 @@
     "expiringForClient_one": "{{count}} credito di {{clientName}} scadrà presto",
     "expiringForClient_other": "{{count}} crediti di {{clientName}} scadranno presto"
   },
+  "staleAction": {
+    "message": "Questa pagina non è aggiornata. Aggiornala per ripristinare gli aggiornamenti e le azioni."
+  },
   "licenseBanner": {
     "trialExpiresIn_one": "La prova Pro scade tra {{count}} giorno. Inserisci una chiave di licenza per mantenere le funzionalità Pro.",
     "trialExpiresIn_other": "La prova Pro scade tra {{count}} giorni. Inserisci una chiave di licenza per mantenere le funzionalità Pro.",

--- a/server/public/locales/nl/common.json
+++ b/server/public/locales/nl/common.json
@@ -14,6 +14,9 @@
     "expiringForClient_one": "{{count}} tegoed van {{clientName}} verloopt binnenkort",
     "expiringForClient_other": "{{count}} tegoeden van {{clientName}} verlopen binnenkort"
   },
+  "staleAction": {
+    "message": "Deze pagina is verouderd. Vernieuw de pagina om live-updates en acties te herstellen."
+  },
   "licenseBanner": {
     "trialExpiresIn_one": "De Pro-proefperiode verloopt over {{count}} dag. Voer een licentiesleutel in om Pro-functies te behouden.",
     "trialExpiresIn_other": "De Pro-proefperiode verloopt over {{count}} dagen. Voer een licentiesleutel in om Pro-functies te behouden.",

--- a/server/public/locales/pl/common.json
+++ b/server/public/locales/pl/common.json
@@ -20,6 +20,9 @@
     "expiringForClient_many": "{{count}} kredytów klienta {{clientName}} wkrótce wygaśnie",
     "expiringForClient_other": "{{count}} kredytów klienta {{clientName}} wkrótce wygaśnie"
   },
+  "staleAction": {
+    "message": "Ta strona jest nieaktualna. Odśwież ją, aby przywrócić aktualizacje i działania."
+  },
   "licenseBanner": {
     "trialExpiresIn_one": "Okres próbny Pro wygasa za {{count}} dzień. Wprowadź klucz licencyjny, aby zachować funkcje Pro.",
     "trialExpiresIn_few": "Okres próbny Pro wygasa za {{count}} dni. Wprowadź klucz licencyjny, aby zachować funkcje Pro.",

--- a/server/public/locales/pt/common.json
+++ b/server/public/locales/pt/common.json
@@ -14,6 +14,9 @@
     "expiringForClient_one": "O crédito {{count}} para {{clientName}} expirará em breve",
     "expiringForClient_other": "Os créditos {{count}} para {{clientName}} expirarão em breve"
   },
+  "staleAction": {
+    "message": "Esta página está desatualizada. Atualize-a para restaurar atualizações e ações."
+  },
   "licenseBanner": {
     "trialExpiresIn_one": "A avaliação Pro expira no dia {{count}}. Insira uma chave de licença para manter os recursos Pro.",
     "trialExpiresIn_other": "A avaliação Pro expira em {{count}} dias. Insira uma chave de licença para manter os recursos Pro.",

--- a/server/public/locales/xx/common.json
+++ b/server/public/locales/xx/common.json
@@ -14,6 +14,9 @@
     "expiringForClient_one": "11111 {{count}} 11111 {{clientName}} 11111",
     "expiringForClient_other": "11111 {{count}} 11111 {{clientName}} 11111"
   },
+  "staleAction": {
+    "message": "11111"
+  },
   "licenseBanner": {
     "trialExpiresIn_one": "11111 {{count}} 11111",
     "trialExpiresIn_other": "11111 {{count}} 11111",

--- a/server/public/locales/yy/common.json
+++ b/server/public/locales/yy/common.json
@@ -14,6 +14,9 @@
     "expiringForClient_one": "55555 {{count}} 55555 {{clientName}} 55555",
     "expiringForClient_other": "55555 {{count}} 55555 {{clientName}} 55555"
   },
+  "staleAction": {
+    "message": "55555"
+  },
   "licenseBanner": {
     "trialExpiresIn_one": "55555 {{count}} 55555",
     "trialExpiresIn_other": "55555 {{count}} 55555",

--- a/server/src/components/layout/AlgaDeskMspShell.tsx
+++ b/server/src/components/layout/AlgaDeskMspShell.tsx
@@ -11,6 +11,7 @@ import GlobalShortcutLayer from './GlobalShortcutLayer';
 import { MspDocumentsCrossFeatureProvider } from '@alga-psa/msp-composition/documents/MspDocumentsCrossFeatureProvider';
 import { AlgaDeskClientCrossFeatureProvider } from '@alga-psa/msp-composition/clients/AlgaDeskClientCrossFeatureProvider';
 import { MspClientTagsProvider } from '@alga-psa/msp-composition/clients/MspClientTagsProvider';
+import { StaleActionBanner } from '@alga-psa/ui/components/StaleActionBanner';
 
 interface AlgaDeskMspShellProps {
   children: React.ReactNode;
@@ -80,6 +81,7 @@ export default function AlgaDeskMspShell({
             setRightSidebarOpen={setRightSidebarOpen}
           />
           <PlatformNotificationBanner />
+          <StaleActionBanner />
           <main className={`flex-1 overflow-hidden flex ${sidebarMode !== 'main' ? 'pt-0 pl-0 pr-3' : 'pt-2 px-3'}`}>
             <Body>{children}</Body>
           </main>

--- a/server/src/components/layout/DefaultLayout.tsx
+++ b/server/src/components/layout/DefaultLayout.tsx
@@ -24,6 +24,7 @@ import GlobalShortcutLayer from './GlobalShortcutLayer';
 import { isExperimentalFeatureEnabled } from '@alga-psa/tenancy/actions/tenant-settings-actions/tenantSettingsActions';
 import { useTier } from 'server/src/context/TierContext';
 import { useCatalogShortcut } from '@alga-psa/ui/keyboard-shortcuts';
+import { StaleActionBanner } from '@alga-psa/ui/components/StaleActionBanner';
 
 interface DefaultLayoutProps {
   children: React.ReactNode;
@@ -435,6 +436,7 @@ export default function DefaultLayout({ children, initialSidebarCollapsed = fals
               setRightSidebarOpen={setRightSidebarOpen}
             />
             <PlatformNotificationBanner />
+            <StaleActionBanner />
             <main className={`flex-1 overflow-hidden flex ${sidebarMode !== 'main' ? 'pt-0 pl-0 pr-3' : 'pt-2 px-3'}`}>
               <Body>{children}</Body>
               {aiAssistantAvailable ? (

--- a/server/src/components/layout/Header.tsx
+++ b/server/src/components/layout/Header.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import React, { useEffect, useMemo, useState } from 'react';
+import React, { useCallback, useEffect, useMemo, useState } from 'react';
 import { signOut } from 'next-auth/react';
 import Link from 'next/link';
 import { usePathname, useRouter } from 'next/navigation';
@@ -43,6 +43,7 @@ import { TrialBanner } from './TrialBanner';
 import { PaymentFailedBanner } from './PaymentFailedBanner';
 import { useQuickAsk } from './QuickAskContext';
 import { useCatalogShortcut, useShortcutScope } from '@alga-psa/ui/keyboard-shortcuts';
+import { useActionPolling } from '@alga-psa/ui/hooks';
 
 export const QUICK_CREATE_OPEN_EVENT = 'alga:quick-create:open';
 
@@ -280,36 +281,17 @@ const JobActivityIndicator: React.FC<{ t: HeaderTranslator }> = ({ t }) => {
   const [metrics, setMetrics] = useState<JobMetrics | null>(null);
   const [loading, setLoading] = useState<boolean>(false);
 
-  useEffect(() => {
-    let isMounted = true;
-    let interval: ReturnType<typeof setInterval> | undefined;
-
-    const fetchMetrics = async () => {
-      setLoading(true);
-      try {
-        const data = await getQueueMetricsAction();
-        if (isMounted) {
-          setMetrics(data);
-        }
-      } catch (error) {
-        console.error('[Header] Failed to fetch job metrics', error);
-      } finally {
-        if (isMounted) {
-          setLoading(false);
-        }
-      }
-    };
-
-    fetchMetrics();
-    interval = setInterval(fetchMetrics, 15000);
-
-    return () => {
-      isMounted = false;
-      if (interval) {
-        clearInterval(interval);
-      }
-    };
+  const fetchMetrics = useCallback(async () => {
+    setLoading(true);
+    try {
+      const data = await getQueueMetricsAction();
+      setMetrics(data);
+    } finally {
+      setLoading(false);
+    }
   }, []);
+
+  useActionPolling(fetchMetrics, { intervalMs: 15000 });
 
   const activeJobs = metrics?.active ?? 0;
   const failedJobs = metrics?.failed ?? 0;

--- a/server/src/components/settings/general/ClientPortalSettings.tsx
+++ b/server/src/components/settings/general/ClientPortalSettings.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 
-import React, { useState, useEffect, useMemo } from 'react';
+import React, { useCallback, useState, useEffect, useMemo } from 'react';
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@alga-psa/ui/components/Card";
 import { Globe, Palette } from 'lucide-react';
 import { LanguageHierarchyTable } from '@alga-psa/ui/components/LanguageHierarchyTable';
@@ -34,6 +34,7 @@ import SignInPagePreview from './SignInPagePreview';
 import { getPortalDomainStatusAction } from '@alga-psa/tenancy/actions/tenant-actions/portalDomainActions';
 import { Switch } from '@alga-psa/ui/components/Switch';
 import { useTranslation } from '@alga-psa/ui/lib/i18n/client';
+import { useActionPolling } from '@alga-psa/ui/hooks';
 
 const UNSET_LOCALE_VALUE = '__inherit__';
 const DEFAULT_PORTAL_HERO_GRADIENT: PortalHeroGradient = 'primary-shades';
@@ -103,27 +104,13 @@ const ClientPortalSettings = () => {
     ];
   }, [visibleLocales, orgDefaultLocale, t]);
 
-  // Check if custom domain is configured
-  useEffect(() => {
-    const checkCustomDomain = async () => {
-      try {
-        const status = await getPortalDomainStatusAction();
-        // Enable preview if there's a domain value (regardless of status)
-        setHasCustomDomain(!!status?.domain);
-      } catch (error) {
-        console.error('Failed to check custom domains:', error);
-        setHasCustomDomain(false);
-      }
-    };
-
-    // Check initially
-    checkCustomDomain();
-
-    // Check periodically every 5 seconds to detect domain changes
-    const interval = setInterval(checkCustomDomain, 5000);
-
-    return () => clearInterval(interval);
+  const checkCustomDomain = useCallback(async () => {
+    const status = await getPortalDomainStatusAction();
+    // Enable preview if there's a domain value (regardless of status)
+    setHasCustomDomain(!!status?.domain);
   }, []);
+
+  useActionPolling(checkCustomDomain, { intervalMs: 5000 });
 
   useEffect(() => {
     const loadTenantSettings = async () => {


### PR DESCRIPTION
## Summary

- Add a shared, sticky stale-server-action detector using Next.js `unstable_isUnrecognizedActionError` with an error-name fallback for cross-bundle cases.
- Add `useActionPolling`, which permanently halts a poller after an unrecognized action, exponentially backs off transient failures, deduplicates in-flight calls, and restores the normal interval after recovery.
- Migrate dashboard queue metrics, notification fallback, and client-portal domain-status polling to the shared primitive.
- Mount a localized, non-blocking refresh banner in the MSP and client-portal shells.
- Document the complete action-key mitigation plan. Phase 1 build-time encryption-key injection and the Phase 2 build guard remain deferred until the external deployment configuration lands.

## Validation

**PASS — implemented app-side mitigation.**

Exercised through the real app and compose services:

- Healthy dashboard polling: queue metrics every 15s and notification fallback every 30s returned HTTP 200 without a stale banner.
- Opened the notification panel and rendered 13 real notifications.
- Client Portal settings: domain-status polling every 5s returned HTTP 200.
- Genuine action-key rotation: the preserved old client received HTTP 404 with `x-nextjs-action-not-found: 1` for all three pollers. Each halted after its first stale response, with no further requests during the remaining 60s observation. The page stayed open and showed the refresh banner.
- Refresh recovery: clicking **Refresh** reloaded the current client, removed the banner, and restored successful action calls.
- Nearby regression: injected two transport failures into the real queue-metrics action. Retries backed off from 15s to 30s, recovered with HTTP 200, returned to 15s cadence, and never showed the stale banner.

Focused tests, UI/notifications/client-portal/server typechecks, and the root CE production build also pass.

## Smoke-test fidelity

- The card-scoped alga-dev tab was created, but browser commands rejected it after the remote browser agent restarted and lost its host mapping. Testing attached directly to the same alga-dev-owned Chrome profile through CDP.
- Next dev HMR normally reloads a client when the dev server restarts. For the stale-client test, only the HMR session identifier was rewritten so the old client remained loaded. The UI, database, server actions, key rotation, 404 responses, and headers remained real; no action result was mocked.
- Transient failures used browser-level request aborts as transport fault injection.

## Remaining scope

Not covered: an authenticated client-portal-user shell, a production two-image deployment, or post-deploy Grafana validation. Phase 1 encryption-key injection and the Phase 2 build guard remain unimplemented, so the underlying production action-ID churn is still unresolved; this smoke validates the app-side backstop only.

The notification WebSocket remained disconnected, so the real 30s fallback path was exercised. That reconnect issue is already tracked out of scope.

Cleanup completed: the standard `PORT=3164 npm run dev` service is live, compose dependencies are up, the temporary encryption key was removed, and the existing uncommitted `package-lock.json` change remains untouched.

Evidence: `/tmp/alga-smoke-evidence/fix-stale-actions-20260716-224026` (screenshots plus network timelines for stale halting, refresh recovery, and exponential backoff).