### PR TITLE
Contract user reported error

### DIFF
--- a/docs/plans/2026-07-16-contract-recurring-period-bounds-plan.md
+++ b/docs/plans/2026-07-16-contract-recurring-period-bounds-plan.md
@@ -1,0 +1,283 @@
+# Contract recurring-period bounds & draft status — implementation plan
+
+**Branch:** `fix/contract-user-reported-error`
+**Date:** 2026-07-16
+**Status:** Approved design, ready for implementation
+
+## User report
+
+A premise user (docker/appliance, also reproduced on cloud) reported:
+
+> "I populate a contract with sample data, but I am unable to create it
+> successfully. I can save it as a draft, but then I can never restore it."
+
+Server logs show a bulk insert into `recurring_service_periods` failing with
+check constraint `recurring_service_periods_activity_window_check`
+(code 23514). The failing row has `activity_window_start = 2026-10-01`,
+`activity_window_end = 2026-09-16` — end before start — for a service period
+`2026-10-01 → 2026-11-01` on a contract that ends `2026-09-16`. In the UI the
+user sees the opaque production RSC error ("An error occurred in the Server
+Components render… digest…"), and their draft contract displays a
+**Terminated** badge whose only recovery affordance is **Restore**, which
+fails with the same error.
+
+Reproduced end-to-end in this worktree's dev stack (contract Jul 18 → Sep 16
+2026, monthly client cadence, one fixed-fee line): saving a draft produces a
+row presenting as Terminated; clicking Restore throws the exact constraint
+violation from the report.
+
+## Root cause — one report, three defects
+
+### Defect 1 — client-cadence regeneration materializes periods past the contract end
+
+`computeClientCadenceRegeneration`
+(`shared/billingClients/clientCadenceScheduleRegeneration.ts`) calls
+`materializeClientCadenceServicePeriods` with only `asOf`; the materializer
+generates candidate periods out to a coverage horizon (~6–7 months) with no
+knowledge of the obligation's end date. The only end-awareness is
+`clipRecordActivityWindowToObligationBounds`
+(`clientCadenceScheduleRegeneration.ts:391`), which clips each candidate's
+activity window to `[obligationStart, obligationEnd)`. For a period **wholly
+after** the contract end this produces
+`activityWindow = { start: period.start, end: obligationEnd }` with
+`end < start`, which the DB check constraint
+(`server/migrations/20260318120000_create_recurring_service_periods.cjs`,
+requires `activity_window_start < activity_window_end` strictly) correctly
+rejects. The whole transaction rolls back.
+
+This fires on **every** path that syncs periods for a client-cadence line on
+an end-dated contract whose horizon extends past the end:
+
+- Wizard finalize → `createClientContractFromWizard` →
+  `syncRecurringServicePeriodsForContract`
+  (`packages/billing/src/actions/contractWizardActions.ts:1476`) — "unable to
+  create it successfully".
+- Restore / Set to Active / any assignment update →
+  `updateClientContractForBilling`
+  (`packages/billing/src/actions/billingClientsActions.ts:263`) → same sync —
+  "can never restore it".
+- `applyClientCadenceChange` callers (billing schedule/cycle/anchor actions),
+  `previewClientCadenceScheduleChange`,
+  `repairAllClientCadenceServicePeriodsForTenant` — all funnel through the
+  same `computeClientCadenceRegeneration`.
+
+The sibling **contract-cadence** path already has the missing guard:
+`packages/billing/src/actions/contractCadenceServicePeriodMaterialization.ts:466`
+filters out candidates with `servicePeriod.start >= assignmentEnd` before
+backfilling. It has the mirror-image gap, though: it **never clips** activity
+windows, so a contract-cadence line ending mid-period keeps a full final
+period with no activity window — the invoice engine derives coverage and
+proration from the persisted activity window (see the clip function's
+docstring and `shared/billingClients/recurringTiming.ts`), so the final
+partial period bills as a full period.
+
+No data repair is needed: the check constraint rolled back every affected
+transaction, so no tenant has inverted rows persisted.
+
+### Defect 2 — draft assignments present as "Terminated"
+
+`deriveClientContractStatus` (`shared/billingClients/clientContractStatus.ts`)
+normalizes dates with a string-only `normalizeDateOnly`; knex hydrates `date`
+columns as JS `Date` objects, which normalize to `null`. The future-start →
+`'draft'` branch therefore never fires and every inactive assignment derives
+`'terminated'`. List surfaces (`Contracts.tsx`, `ClientContractsTab.tsx`) and
+the contract detail badges all read this derivation, so a fresh draft shows
+**Terminated** and offers **Restore** (activate assignment, bypassing wizard
+finalize) instead of **Resume** (reopen wizard) — steering users directly
+into defect 1.
+
+Additionally, the derivation never consults the contract header's
+`status = 'draft'`, so even with the `Date` bug fixed, a draft with a
+today-or-past start date would still derive `terminated`.
+
+**Settled ruling:** an assignment belonging to a `draft` contract always
+presents as **Draft** — Resume / Set to Active affordances, never Restore.
+"Terminated" is reserved for contracts that were once active.
+
+### Defect 3 — known validation failures surface as raw 500s
+
+`createClientContractFromWizard` throws raw `Error`s for known validation
+failures — e.g. the currency-pricing check
+(`packages/billing/src/actions/contractWizardActions.ts:1136`, "Cannot create
+contract in USD. The following services do not have USD pricing…") — which
+`contractWizardActionErrorFrom` (`contractWizardActions.ts:50`) does not
+convert, so they escape as HTTP 500s. In production Next.js masks the message
+into the digest error the user screenshotted. This fires even on **draft**
+save. The typed-error plumbing (allowlist converter + `isActionMessageError`
+handling in `ContractWizard.tsx`) already exists on both sides; the message
+is just missing from the allowlist.
+
+Deliberate non-change: DB constraint violations (23514) stay **unmapped** and
+loud — they indicate bugs, not user errors, and must not be dressed up as
+friendly validation messages.
+
+## Design
+
+### 1. Shared obligation-bounds helper (Option A — approved)
+
+New pure function in `shared/billingClients/` (new file
+`clipRecurringCandidatesToObligationBounds.ts`, exported from the package
+barrel alongside the other billing clients):
+
+```ts
+export function clipRecurringCandidatesToObligationBounds(
+  records: IRecurringServicePeriodRecord[],
+  obligationStart: ISO8601String,
+  obligationEnd: ISO8601String | null,
+): IRecurringServicePeriodRecord[]
+```
+
+Semantics (all comparisons date-only, half-open ranges):
+
+- **Drop** a candidate when `obligationEnd != null && servicePeriod.start >= obligationEnd`
+  (wholly after — the reported bug; also covers `start == obligationEnd`).
+- **Drop** a candidate when `servicePeriod.end <= obligationStart`
+  (wholly before — symmetry/defensive).
+- **Clip** a straddling candidate:
+  `clipStart = obligationStart > period.start ? obligationStart : null`;
+  `clipEnd = obligationEnd && obligationEnd < period.end ? obligationEnd : null`;
+  if either is set, `activityWindow = { start: clipStart ?? period.start,
+  end: clipEnd ?? period.end, semantics: period.semantics }`, else return the
+  record unchanged (`activityWindow` stays `null` — preserves the existing
+  "window only when it differs" convention).
+- Invariant: never emits `activityWindow.start >= activityWindow.end`
+  (guaranteed by the drop rules). Both materializers emit records with no
+  activity window, so no intersect logic is needed.
+
+Call-site changes:
+
+- **Client cadence** — `clientCadenceScheduleRegeneration.ts`
+  `computeClientCadenceRegeneration` (~line 494): replace the
+  `materialized.records.map(clipRecordActivityWindowToObligationBounds(...))`
+  with the helper (passing `obligationStart`, `obligationEnd`). Delete
+  `clipRecordActivityWindowToObligationBounds`; move its docstring rationale
+  onto the helper. `candidateCoverageEnd` stays
+  `materialized.generationRangeEnd` (the unbounded horizon) so regeneration
+  still supersedes stale rows beyond a shrunk end date.
+- **Contract cadence** —
+  `contractCadenceServicePeriodMaterialization.ts:466`: replace the inline
+  `.filter(...)` with the helper (passing `assignmentStart`,
+  `assignmentEnd`). This is a deliberate behavior change: the final
+  straddling period now persists a clipped activity window, so mid-period
+  contract ends prorate instead of billing the full period. (Start-clip is a
+  no-op on this path since periods anchor at `assignmentStart`.)
+
+### 2. Status derivation
+
+`shared/billingClients/clientContractStatus.ts`:
+
+- `normalizeDateOnly` accepts `Date` (`value.toISOString().slice(0, 10)`) in
+  addition to strings; widen the param types to
+  `string | Date | null | undefined`.
+- Add optional `contractStatus?: string` to the params. When
+  `contractStatus === 'draft'`, return `'draft'` immediately — before any
+  date/is_active logic.
+
+Call sites — pass the contract header status wherever the contract row is in
+scope (add the select/join where it is cheap; leave call sites that only ever
+see active contracts unchanged):
+
+- `packages/billing/src/models/contract.ts:291` (`getAllWithClients`) — pass
+  `row.contract_header_status` (already selected). This feeds both list
+  tables.
+- `packages/billing/src/actions/contractActions.ts:908` — pass the contract's
+  status (the surrounding query joins `contracts`; select `co.status` if not
+  already).
+- `packages/billing/src/actions/contractActions.ts:786` (active-assignment
+  count for a known `contractId`) — the contract row is available in the
+  enclosing function; pass its status.
+- `packages/billing/src/actions/contractReportActions.ts:259,370` — audit; if
+  the queries join `contracts`, pass status; drafts should not report as
+  terminated in reports either.
+- `packages/clients/src/models/clientContract.ts:286` (row normalizer) — pass
+  the contract status if present on the row; audit callers and add the select
+  where the query joins `contracts`.
+- Leave unchanged: `shared/billingClients/clientContracts.ts:84` (queries
+  filter `c.is_active = true`, drafts excluded) and
+  `packages/clients/src/lib/clientContractWorkflowEvents.ts:22` (already
+  string-normalizes; no header status in scope; not a display surface).
+
+No UI changes required: with the derivation fixed, `Contracts.tsx` and
+`ClientContractsTab.tsx` row menus already render Resume + Set to Active for
+`draft` and reserve Restore for `terminated`.
+
+### 3. Error allowlist
+
+`contractWizardActionErrorFrom` (`contractWizardActions.ts:50`): add
+`error.message.startsWith('Cannot create contract in')` to the
+`actionError` allowlist. Audit the other raw `throw new Error(...)` sites in
+`createClientContractFromWizard` for user-actionable validation messages and
+add any equivalents (the catalog-item messages are already covered by the
+`'Catalog item "'` prefix). The draft-save currency validation itself is
+retained as-is — only its error shape changes (500 → friendly toast).
+
+## Implementation steps
+
+1. **Shared helper + client-cadence adoption.**
+   Add `shared/billingClients/clipRecurringCandidatesToObligationBounds.ts`
+   (+ barrel export). Rewire `computeClientCadenceRegeneration`, delete
+   `clipRecordActivityWindowToObligationBounds`.
+   Domain test `server/src/test/unit/billing/clipRecurringCandidatesToObligationBounds.domain.test.ts`
+   covering: wholly-after dropped (the bug); `start == obligationEnd`
+   dropped; wholly-before dropped; straddling end clipped; straddling start
+   clipped; both clipped; no `obligationEnd` → only start rules apply;
+   untouched records keep `activityWindow: null`; invariant `start < end` on
+   every emitted window.
+
+2. **Contract-cadence adoption.**
+   Replace the inline filter at
+   `contractCadenceServicePeriodMaterialization.ts:466` with the helper.
+   Extend the relevant wiring/domain coverage
+   (`packages/billing/tests/cadenceResyncWiring.test.ts` or a new domain
+   test) to assert the final straddling period now carries a clipped
+   activity window and that periods at/after the assignment end are still
+   excluded.
+
+3. **Status derivation.**
+   Update `clientContractStatus.ts` (Date support + `contractStatus`
+   short-circuit). Update call sites per the design list. Extend
+   `packages/billing/tests/clientContractStatus.shared.test.ts`: `Date`
+   inputs for start/end/now paths; `contractStatus: 'draft'` wins over
+   inactive + past dates; non-draft `contractStatus` changes nothing.
+
+4. **Error allowlist.**
+   Update `contractWizardActionErrorFrom` + a focused unit test (the file's
+   existing test conventions) asserting the currency message converts to an
+   `actionError` and unknown errors still rethrow.
+
+5. **Integration verification.**
+   Add or extend an integration test (per `integration-testing` skill
+   conventions) that: creates a client-cadence contract with an end date
+   inside the generation horizon, activates it, and asserts (a) the insert
+   succeeds, (b) no persisted period starts at/after the contract end,
+   (c) the straddling period's activity window ends at the contract end.
+
+6. **Manual smoke in the dev stack** (mirrors the user's repro):
+   - Create contract (client billing schedule, monthly, start Jul 18 2026,
+     end Sep 16 2026, one fixed-fee service with base rate) → **Create**
+     succeeds; `recurring_service_periods` rows bounded by Sep 16.
+   - Save an equivalent contract as **draft** → list shows **Draft** badge
+     with **Resume** and **Set to Active**; Resume reopens the wizard;
+     Set to Active succeeds.
+   - Terminate an active contract → **Restore** succeeds.
+   - Draft-save with a service lacking USD pricing → friendly toast, no 500.
+
+## Out of scope (noted, not addressed)
+
+- `contractCadenceServicePeriodMaterialization.ts` duplicates
+  `clientCadenceScheduleRegeneration.ts` wholesale (row type, normalizers,
+  serializer, persist helper). Drop a
+  `// LEVERAGE: pattern recurring-period-row-mapping` marker at both sites
+  during implementation; extraction is a separate effort.
+- "Set to Active" on a draft activates without wizard finalize validation
+  (currency checks). Existing affordance; unchanged.
+- Whether draft saves should run finalize-grade validation at all — kept
+  as-is (only the error shape changes).
+
+## Verification commands
+
+- Unit/domain: `npx vitest run` scoped to the touched test files in
+  `server/` and `packages/billing/`.
+- Type check: `npx tsc --noEmit` in the affected packages (or the repo's
+  standard `nx` targets).
+- Manual smoke: dev stack on port 3646, flow above.

--- a/packages/billing/src/actions/contractActions.ts
+++ b/packages/billing/src/actions/contractActions.ts
@@ -763,17 +763,25 @@ export const getContractSummary = withAuth(async (user, { tenant }, contractId: 
     }
 
     const assignmentColumns = [
-      'client_contract_id',
-      'client_id',
-      'is_active',
-      'start_date',
-      'end_date',
-      'po_required',
-      'po_number'
+      'cc.client_contract_id',
+      'cc.client_id',
+      'cc.is_active',
+      'cc.start_date',
+      'cc.end_date',
+      'cc.po_required',
+      'cc.po_number',
+      'co.status as contract_status',
     ];
 
-    const assignmentsRaw = await tenantScopedTable(knex, tenant, 'client_contracts')
-      .where({ contract_id: contractId })
+    const assignmentsQuery = tenantDb(knex, tenant).table('client_contracts as cc');
+    tenantDb(knex, tenant).tenantJoin(
+      assignmentsQuery,
+      'contracts as co',
+      'cc.contract_id',
+      'co.contract_id',
+    );
+    const assignmentsRaw = await assignmentsQuery
+      .where({ 'cc.contract_id': contractId })
       .select(assignmentColumns);
 
     const assignments = (assignmentsRaw as any[]).map((assignment: any) => ({
@@ -787,6 +795,7 @@ export const getContractSummary = withAuth(async (user, { tenant }, contractId: 
         isActive: Boolean(assignment.is_active),
         startDate: assignment.start_date,
         endDate: assignment.end_date,
+        contractStatus: assignment.contract_status,
       }) === 'active'
     ).length;
     const poRequiredAssignments = assignments.filter((assignment) => assignment.po_required).length;
@@ -852,13 +861,15 @@ export const getContractAssignments = withAuth(async (user, { tenant }, contract
       'cc.po_number',
       'cc.po_amount',
       'cc.renewal_ticket_board_id',
-      'cc.renewal_ticket_status_id'
+      'cc.renewal_ticket_status_id',
+      'co.status as contract_status',
     ];
 
     const facade = tenantDb(knex, tenant);
     const query = facade.table('client_contracts as cc');
     facade.tenantJoin(query, 'clients as c', 'cc.client_id', 'c.client_id', { type: 'left' });
     facade.tenantJoin(query, 'default_billing_settings as dbs', 'cc.tenant', 'dbs.tenant', { type: 'left' });
+    facade.tenantJoin(query, 'contracts as co', 'cc.contract_id', 'co.contract_id');
 
     const rows = await query
       .where({ 'cc.contract_id': contractId })
@@ -909,6 +920,7 @@ export const getContractAssignments = withAuth(async (user, { tenant }, contract
           isActive: Boolean(row.is_active),
           startDate: row.start_date,
           endDate: row.end_date,
+          contractStatus: row.contract_status,
         }),
         start_date: row.start_date ?? null,
         end_date: row.end_date ?? null,

--- a/packages/billing/src/actions/contractCadenceServicePeriodMaterialization.ts
+++ b/packages/billing/src/actions/contractCadenceServicePeriodMaterialization.ts
@@ -10,6 +10,7 @@ import type {
 import { ensureUtcMidnightIsoDate } from '../lib/billing/billingCycleAnchors';
 import { materializeContractCadenceServicePeriods } from '@shared/billingClients/materializeContractCadenceServicePeriods';
 import { backfillRecurringServicePeriods } from '@shared/billingClients/backfillRecurringServicePeriods';
+import { clipRecurringCandidatesToObligationBounds } from '@shared/billingClients/clipRecurringCandidatesToObligationBounds';
 
 type ContractCadenceBillingCycle = 'monthly' | 'quarterly' | 'semi-annually' | 'annually';
 
@@ -25,6 +26,7 @@ type ContractCadenceObligationRow = {
   assignment_end_date: unknown;
 };
 
+// LEVERAGE: pattern recurring-period-row-mapping
 type RecurringServicePeriodDbRow = {
   record_id: string;
   tenant: string;
@@ -448,7 +450,7 @@ async function syncContractCadenceObligation(
     ? maxIsoDateOnly(assignmentStart, billedBoundaryEnd)
     : assignmentStart;
 
-  const candidateRecords = materializeContractCadenceServicePeriods({
+  const materialized = materializeContractCadenceServicePeriods({
     asOf: regenerationStart,
     materializedAt,
     billingCycle: frequency,
@@ -463,12 +465,12 @@ async function syncContractCadenceObligation(
     sourceRuleVersion,
     sourceRunKey,
     recordIdFactory: recurringServicePeriodRecordIdFactory,
-  }).records.filter((record) => {
-    if (!assignmentEnd) {
-      return true;
-    }
-    return compareIsoDateOnly(record.servicePeriod.start, assignmentEnd) < 0;
   });
+  const candidateRecords = clipRecurringCandidatesToObligationBounds(
+    materialized.records,
+    assignmentStart,
+    assignmentEnd,
+  );
 
   const regenerationPlan = backfillRecurringServicePeriods({
     candidateRecords,

--- a/packages/billing/src/actions/contractReportActions.ts
+++ b/packages/billing/src/actions/contractReportActions.ts
@@ -74,6 +74,7 @@ type ContractRevenueAssignmentRow = {
   end_date: string | Date | null;
   contract_id: string;
   contract_name: string;
+  contract_status: string | null;
   client_name: string | null;
 };
 
@@ -86,6 +87,7 @@ type ContractExpirationRow = {
   client_contract_id: string;
   contract_id: string;
   contract_name: string;
+  contract_status: string | null;
   client_id: string;
   client_name: string | null;
   is_active: boolean | null;
@@ -247,6 +249,7 @@ export const getContractRevenueReport = withAuth(async (user, { tenant }): Promi
         'cc.end_date',
         'c.contract_id',
         'c.contract_name',
+        'c.status as contract_status',
         'cl.client_name'
       );
     db.tenantJoin(dataQuery, 'contracts as c', 'cc.contract_id', 'c.contract_id');
@@ -260,6 +263,7 @@ export const getContractRevenueReport = withAuth(async (user, { tenant }): Promi
         isActive: Boolean(row.is_active),
         startDate: normalizeDateOnly(row.start_date),
         endDate: normalizeDateOnly(row.end_date),
+        contractStatus: row.contract_status ?? undefined,
         now: today,
       });
       const status = mapAssignmentStatusToRevenueStatus(assignmentStatus);
@@ -339,6 +343,7 @@ export const getContractExpirationReport = withAuth(async (user, { tenant }): Pr
         'cc.client_contract_id',
         'c.contract_id',
         'c.contract_name',
+        'c.status as contract_status',
         'cc.client_id',
         'cl.client_name',
         'cc.is_active',
@@ -371,6 +376,7 @@ export const getContractExpirationReport = withAuth(async (user, { tenant }): Pr
         isActive: Boolean(row.is_active),
         startDate: normalizeDateOnly(row.start_date),
         endDate: normalizeDateOnly(row.end_date),
+        contractStatus: row.contract_status ?? undefined,
         now: today,
       });
       if (assignmentStatus !== 'active') {

--- a/packages/billing/src/actions/contractWizardActionErrors.ts
+++ b/packages/billing/src/actions/contractWizardActionErrors.ts
@@ -1,0 +1,38 @@
+import { actionError, permissionError } from '@alga-psa/ui/lib/errorHandling';
+import type { ActionMessageError, ActionPermissionError } from '@alga-psa/ui/lib/errorHandling';
+
+export type ContractWizardActionError = ActionMessageError | ActionPermissionError;
+
+export function contractWizardActionErrorFrom(error: unknown): ContractWizardActionError | null {
+  if (!(error instanceof Error)) return null;
+
+  if (error.message.startsWith('Permission denied') || error.message === 'user is not logged in') {
+    return permissionError(error.message);
+  }
+
+  if (
+    error.message.startsWith('Catalog item "') ||
+    error.message.startsWith('Product "') ||
+    error.message.startsWith('Cannot create contract in') ||
+    error.message === 'Contract start date is required' ||
+    error.message === 'Draft contract not found' ||
+    error.message === 'Only draft contracts can be updated via the wizard' ||
+    error.message === 'Template not found' ||
+    error.message === 'Contract not found' ||
+    error.message === 'Contract is not a draft' ||
+    error.message === 'Draft contract is missing client assignment' ||
+    error.message === 'Draft contract has an invalid start date'
+  ) {
+    return actionError(error.message);
+  }
+
+  const dbError = error as { code?: string };
+  if (dbError?.code === '23503') {
+    return actionError('One of the selected contract wizard records is no longer valid. Please refresh and try again.');
+  }
+  if (dbError?.code === '23505') {
+    return actionError('A matching contract wizard record already exists.');
+  }
+
+  return null;
+}

--- a/packages/billing/src/actions/contractWizardActions.ts
+++ b/packages/billing/src/actions/contractWizardActions.ts
@@ -8,7 +8,6 @@ import { createTenantKnex } from '@alga-psa/db';
 import { withAuth } from '@alga-psa/auth/withAuth';
 import { hasPermission } from '@alga-psa/auth/rbac';
 import { actionError, permissionError } from '@alga-psa/ui/lib/errorHandling';
-import type { ActionMessageError, ActionPermissionError } from '@alga-psa/ui/lib/errorHandling';
 import { publishWorkflowEvent } from '@alga-psa/event-bus/publishers';
 import {
   buildContractCreatedPayload,
@@ -44,41 +43,12 @@ import {
   upsertBucketOverlayInTransaction
 } from './bucketOverlayActions';
 import { syncRecurringServicePeriodsForContract } from './recurringServicePeriodSync';
+import {
+  contractWizardActionErrorFrom,
+  type ContractWizardActionError,
+} from './contractWizardActionErrors';
 
-export type ContractWizardActionError = ActionMessageError | ActionPermissionError;
-
-function contractWizardActionErrorFrom(error: unknown): ContractWizardActionError | null {
-  if (!(error instanceof Error)) return null;
-
-  if (error.message.startsWith('Permission denied') || error.message === 'user is not logged in') {
-    return permissionError(error.message);
-  }
-
-  if (
-    error.message.startsWith('Catalog item "') ||
-    error.message.startsWith('Product "') ||
-    error.message === 'Contract start date is required' ||
-    error.message === 'Draft contract not found' ||
-    error.message === 'Only draft contracts can be updated via the wizard' ||
-    error.message === 'Template not found' ||
-    error.message === 'Contract not found' ||
-    error.message === 'Contract is not a draft' ||
-    error.message === 'Draft contract is missing client assignment' ||
-    error.message === 'Draft contract has an invalid start date'
-  ) {
-    return actionError(error.message);
-  }
-
-  const dbError = error as { code?: string };
-  if (dbError?.code === '23503') {
-    return actionError('One of the selected contract wizard records is no longer valid. Please refresh and try again.');
-  }
-  if (dbError?.code === '23505') {
-    return actionError('A matching contract wizard record already exists.');
-  }
-
-  return null;
-}
+export type { ContractWizardActionError } from './contractWizardActionErrors';
 
 // ---------------------- Template wizard types ----------------------
 

--- a/packages/billing/src/models/contract.ts
+++ b/packages/billing/src/models/contract.ts
@@ -292,6 +292,7 @@ const Contract = {
           isActive: Boolean(row.assignment_is_active),
           startDate: row.start_date,
           endDate: row.end_date,
+          contractStatus: row.contract_header_status,
         });
 
         return {

--- a/packages/billing/tests/cadenceResyncWiring.test.ts
+++ b/packages/billing/tests/cadenceResyncWiring.test.ts
@@ -9,6 +9,7 @@ const cycleActions = read('../src/actions/billingCycleActions.ts');
 const scheduleActions = read('../src/actions/billingScheduleActions.ts');
 const anchorActions = read('../src/actions/billingCycleAnchorActions.ts');
 const regeneration = read('../../../shared/billingClients/clientCadenceScheduleRegeneration.ts');
+const contractCadenceMaterialization = read('../src/actions/contractCadenceServicePeriodMaterialization.ts');
 const rspActions = read('../src/actions/recurringServicePeriodActions.ts');
 const automaticInvoices = read('../src/components/billing-dashboard/AutomaticInvoices.tsx');
 // The real cadence editor saves through the clients package helper.
@@ -41,6 +42,13 @@ describe('Cadence-change resync wiring', () => {
   it('T004/T005: regeneration preserves billed periods', () => {
     expect(regeneration).toContain('legacyBilledThroughEnd: billedBoundaryEnd');
     expect(regeneration).toContain("regenerationReasonCode: 'billing_schedule_changed'");
+  });
+
+  it('bounds candidate periods in both client- and contract-cadence persistence paths', () => {
+    expect(regeneration).toContain('clipRecurringCandidatesToObligationBounds(');
+    expect(contractCadenceMaterialization).toContain(
+      'clipRecurringCandidatesToObligationBounds(',
+    );
   });
 
   it('T003/T010: preview computes impact without persisting', () => {

--- a/packages/billing/tests/clientContractEffectiveRenewalSettings.test.ts
+++ b/packages/billing/tests/clientContractEffectiveRenewalSettings.test.ts
@@ -52,6 +52,21 @@ describe('client contract effective renewal settings normalization', () => {
     expect(normalized.effective_notice_period_days).toBe(60);
   });
 
+  it('preserves draft contract header status when normalizing an inactive assignment', () => {
+    const normalized = normalizeClientContract({
+      contract_id: 'contract-draft',
+      client_contract_id: 'cc-draft',
+      client_id: 'client-draft',
+      tenant: 'tenant-1',
+      start_date: '2026-01-01',
+      end_date: null,
+      is_active: false,
+      contract_status: 'draft',
+    });
+
+    expect(normalized.assignment_status).toBe('draft');
+  });
+
   it('falls back deterministically when explicit override values are partially missing', () => {
     const normalized = normalizeClientContract({
       contract_id: 'contract-3',

--- a/packages/billing/tests/clientContractStatus.shared.test.ts
+++ b/packages/billing/tests/clientContractStatus.shared.test.ts
@@ -48,4 +48,48 @@ describe('deriveClientContractStatus', () => {
       })
     ).toBe('terminated');
   });
+
+  it('normalizes knex Date values for assignment start, end, and current dates', () => {
+    expect(
+      deriveClientContractStatus({
+        isActive: true,
+        startDate: new Date('2026-04-01T00:00:00.000Z'),
+        endDate: null,
+        now: new Date('2026-03-16T12:00:00.000Z'),
+      })
+    ).toBe('draft');
+
+    expect(
+      deriveClientContractStatus({
+        isActive: true,
+        startDate: new Date('2026-01-01T00:00:00.000Z'),
+        endDate: new Date('2026-03-15T00:00:00.000Z'),
+        now: new Date('2026-03-16T12:00:00.000Z'),
+      })
+    ).toBe('expired');
+  });
+
+  it('always presents assignments belonging to draft contract headers as draft', () => {
+    expect(
+      deriveClientContractStatus({
+        isActive: false,
+        startDate: '2026-01-01',
+        endDate: '2026-02-01',
+        contractStatus: 'draft',
+        now: '2026-03-16',
+      })
+    ).toBe('draft');
+  });
+
+  it('leaves lifecycle derivation unchanged for non-draft contract headers', () => {
+    expect(
+      deriveClientContractStatus({
+        isActive: false,
+        startDate: '2026-01-01',
+        endDate: null,
+        contractStatus: 'active',
+        now: '2026-03-16',
+      })
+    ).toBe('terminated');
+  });
 });

--- a/packages/billing/tests/contract.assignmentFirst.wiring.test.ts
+++ b/packages/billing/tests/contract.assignmentFirst.wiring.test.ts
@@ -17,6 +17,7 @@ describe('Contract.getAllWithClients assignment-first wiring', () => {
   it('T024: derives list status from assignment lifecycle and preserves header status separately', () => {
     expect(source).toContain('deriveClientContractStatus({');
     expect(source).toContain('const assignmentStatus = deriveClientContractStatus({');
+    expect(source).toContain('contractStatus: row.contract_header_status,');
     expect(source).toContain('status: assignmentStatus,');
     expect(source).toContain('assignment_status: assignmentStatus,');
     expect(source).toContain('contract_header_status: row.contract_header_status ?? row.status,');

--- a/packages/billing/tests/contractReportActions.expiration.wiring.test.ts
+++ b/packages/billing/tests/contractReportActions.expiration.wiring.test.ts
@@ -34,6 +34,8 @@ describe('contractReportActions expiration report wiring', () => {
   it('derives expiration rows from assignment lifecycle and groups them by client assignment id', () => {
     expect(source).toContain("'cc.is_active',");
     expect(source).toContain('const assignmentStatus = deriveClientContractStatus({');
+    expect(source).toContain("'c.status as contract_status',");
+    expect(source).toContain('contractStatus: row.contract_status ?? undefined,');
     expect(source).toContain("if (assignmentStatus !== 'active') {");
     expect(source).toContain('const key = row.client_contract_id;');
     expect(source).toContain('const expirationMap = new Map<string, ContractExpiration>();');

--- a/packages/billing/tests/contractReportActions.revenue.assignmentFact.test.ts
+++ b/packages/billing/tests/contractReportActions.revenue.assignmentFact.test.ts
@@ -13,6 +13,8 @@ describe('contractReportActions revenue wiring', () => {
     expect(revenueSource).toContain("db.tenantJoin(dataQuery, 'contracts as c', 'cc.contract_id', 'c.contract_id');");
     expect(revenueSource).toContain(".whereNotNull('c.owner_client_id')");
     expect(revenueSource).toContain('deriveClientContractStatus({');
+    expect(revenueSource).toContain("'c.status as contract_status',");
+    expect(revenueSource).toContain('contractStatus: row.contract_status ?? undefined,');
     expect(revenueSource).toContain('const status = mapAssignmentStatusToRevenueStatus(assignmentStatus);');
     expect(revenueSource).not.toContain("const data = await knex('contracts as c')");
     expect(revenueSource).not.toContain("row.is_active ? 'active' : 'expired'");

--- a/packages/billing/tests/contractWizardActionErrors.test.ts
+++ b/packages/billing/tests/contractWizardActionErrors.test.ts
@@ -1,0 +1,25 @@
+import { describe, expect, it } from 'vitest';
+
+import { contractWizardActionErrorFrom } from '../src/actions/contractWizardActionErrors';
+
+describe('contractWizardActionErrorFrom', () => {
+  it('converts missing currency pricing validation into a user-facing action error', () => {
+    const message =
+      'Cannot create contract in USD. The following services do not have USD pricing and no custom rate was entered: "Managed Service".';
+
+    expect(contractWizardActionErrorFrom(new Error(message))).toEqual({
+      actionError: message,
+    });
+  });
+
+  it('leaves unknown errors unmapped so action callers rethrow them', () => {
+    const unknown = new Error('Unexpected recurring period failure');
+    const convertOrThrow = (error: unknown) => {
+      const expected = contractWizardActionErrorFrom(error);
+      if (expected) return expected;
+      throw error;
+    };
+
+    expect(() => convertOrThrow(unknown)).toThrow(unknown);
+  });
+});

--- a/packages/clients/src/models/clientContract.ts
+++ b/packages/clients/src/models/clientContract.ts
@@ -287,6 +287,9 @@ export const normalizeClientContract = (row: any): IClientContract => {
     isActive: normalized.is_active === true,
     startDate: normalizedStartDate ?? null,
     endDate: normalizedEndDate ?? null,
+    contractStatus: typeof normalized.contract_status === 'string'
+      ? normalized.contract_status
+      : undefined,
   });
 
   delete normalized.tenant_default_renewal_mode;

--- a/server/src/test/integration/contractWizard.integration.test.ts
+++ b/server/src/test/integration/contractWizard.integration.test.ts
@@ -41,6 +41,16 @@ async function hasSchemaTable(connection: Knex, tableName: string): Promise<bool
   return Boolean(row);
 }
 
+function dateOnly(value: unknown): string | null {
+  if (value instanceof Date) {
+    return value.toISOString().slice(0, 10);
+  }
+  if (typeof value === 'string') {
+    return value.slice(0, 10);
+  }
+  return null;
+}
+
 vi.mock('server/src/lib/db', async () => {
   const actual = await vi.importActual<typeof import('server/src/lib/db')>('server/src/lib/db');
   return {
@@ -216,6 +226,83 @@ describe('createClientContractFromWizard', () => {
     expect(fixedConfig).toBeTruthy();
     expect(Number(fixedConfig?.base_rate ?? 0)).toBe(10000);
 
+  });
+
+  it('bounds client-cadence service periods to an end-dated contract assignment', async () => {
+    createdIds = {};
+    const serviceTypeId = await insertServiceType(db, tenantId, 'fixed');
+    createdIds.serviceTypeId = serviceTypeId;
+
+    const serviceId = await insertCatalogItem(db, tenantId, {
+      serviceTypeId,
+      serviceName: 'Bounded Client Cadence Service',
+      billingMethod: 'fixed',
+      itemKind: 'service',
+      defaultRate: 10000,
+      unitOfMeasure: 'month',
+    });
+    createdIds.serviceId = serviceId;
+
+    const clientId = await insertClient(db, tenantId, 'Bounded Cadence Client');
+    createdIds.clientId = clientId;
+
+    const contractEnd = '2026-09-16';
+    const result = await createClientContractFromWizard({
+      contract_name: 'Bounded Client Cadence Contract',
+      description: 'regression coverage for end-dated recurring periods',
+      client_id: clientId,
+      start_date: '2026-07-18',
+      end_date: contractEnd,
+      billing_frequency: 'monthly',
+      cadence_owner: 'client',
+      enable_proration: true,
+      fixed_base_rate: 10000,
+      fixed_services: [{ service_id: serviceId, quantity: 1 }],
+      hourly_services: [],
+      usage_services: [],
+      po_required: false,
+    });
+
+    expect(result).not.toHaveProperty('actionError');
+    if ('actionError' in result) {
+      throw new Error(result.actionError);
+    }
+
+    createdIds.contractId = result.contract_id;
+    createdIds.contractLineId = result.contract_line_id ?? undefined;
+    const clientContract = await tenantTable(db, tenantId, 'client_contracts')
+      .where({ tenant: tenantId, contract_id: result.contract_id, client_id: clientId })
+      .first('client_contract_id');
+    createdIds.clientContractId = clientContract?.client_contract_id;
+
+    const periods = await tenantTable(db, tenantId, 'recurring_service_periods')
+      .where({
+        tenant: tenantId,
+        obligation_id: result.contract_line_id,
+        cadence_owner: 'client',
+      })
+      .whereNot('lifecycle_state', 'superseded')
+      .orderBy('service_period_start', 'asc');
+
+    expect(periods.length).toBeGreaterThan(0);
+    expect(
+      periods.every((period) => {
+        const start = dateOnly(period.service_period_start);
+        return start !== null && start < contractEnd;
+      }),
+    ).toBe(true);
+
+    const straddlingPeriod = periods.find((period) => {
+      const start = dateOnly(period.service_period_start);
+      const end = dateOnly(period.service_period_end);
+      return start !== null && end !== null && start < contractEnd && end > contractEnd;
+    });
+    expect(straddlingPeriod).toBeDefined();
+    expect(dateOnly(straddlingPeriod?.activity_window_end)).toBe(contractEnd);
+    expect(
+      dateOnly(straddlingPeriod?.activity_window_start)! <
+        dateOnly(straddlingPeriod?.activity_window_end)!,
+    ).toBe(true);
   });
 
   it('T013: accepts fixed services even when catalog billing_method is non-fixed', async () => {
@@ -854,6 +941,10 @@ async function cleanupCreatedRecords(db: Knex, tenantId: string, ids: CreatedIds
   }
 
   if (ids.contractLineId) {
+    await safeDelete('recurring_service_periods', {
+      tenant: tenantId,
+      obligation_id: ids.contractLineId,
+    });
     await safeDelete('contract_line_service_bucket_config', {
       tenant: tenantId,
       contract_line_id: ids.contractLineId

--- a/server/src/test/unit/billing/clipRecurringCandidatesToObligationBounds.domain.test.ts
+++ b/server/src/test/unit/billing/clipRecurringCandidatesToObligationBounds.domain.test.ts
@@ -1,0 +1,111 @@
+import { describe, expect, it } from 'vitest';
+
+import { clipRecurringCandidatesToObligationBounds } from '@alga-psa/shared/billingClients/clipRecurringCandidatesToObligationBounds';
+import { buildRecurringServicePeriodRecord } from '../../test-utils/recurringTimingFixtures';
+
+const buildRecord = (start: string, end: string, recordId = `${start}:${end}`) =>
+  buildRecurringServicePeriodRecord({
+    recordId,
+    periodKey: `period:${start}:${end}`,
+    servicePeriod: {
+      start,
+      end,
+      semantics: 'half_open',
+    },
+    invoiceWindow: {
+      start,
+      end,
+      semantics: 'half_open',
+    },
+    activityWindow: null,
+  });
+
+describe('clip recurring candidates to obligation bounds', () => {
+  it('drops candidates wholly outside the half-open obligation range', () => {
+    const before = buildRecord('2026-01-01', '2026-02-01', 'before');
+    const overlapping = buildRecord('2026-02-01', '2026-03-01', 'overlapping');
+    const startsAtEnd = buildRecord('2026-04-01', '2026-05-01', 'starts-at-end');
+    const after = buildRecord('2026-05-01', '2026-06-01', 'after');
+
+    const result = clipRecurringCandidatesToObligationBounds(
+      [before, overlapping, startsAtEnd, after],
+      '2026-02-01',
+      '2026-04-01',
+    );
+
+    expect(result.map((record) => record.recordId)).toEqual(['overlapping']);
+  });
+
+  it('clips candidates that straddle the start, end, or both obligation bounds', () => {
+    const startResult = clipRecurringCandidatesToObligationBounds(
+      [buildRecord('2026-02-01', '2026-03-01')],
+      '2026-02-10',
+      null,
+    );
+    expect(startResult[0]?.activityWindow).toEqual({
+      start: '2026-02-10',
+      end: '2026-03-01',
+      semantics: 'half_open',
+    });
+
+    const endResult = clipRecurringCandidatesToObligationBounds(
+      [buildRecord('2026-02-01', '2026-03-01')],
+      '2026-01-01',
+      '2026-02-20',
+    );
+    expect(endResult[0]?.activityWindow).toEqual({
+      start: '2026-02-01',
+      end: '2026-02-20',
+      semantics: 'half_open',
+    });
+
+    const bothResult = clipRecurringCandidatesToObligationBounds(
+      [buildRecord('2026-02-01', '2026-03-01')],
+      '2026-02-10',
+      '2026-02-20',
+    );
+    expect(bothResult[0]?.activityWindow).toEqual({
+      start: '2026-02-10',
+      end: '2026-02-20',
+      semantics: 'half_open',
+    });
+  });
+
+  it('applies only the start bound when the obligation has no end', () => {
+    const before = buildRecord('2026-01-01', '2026-02-01', 'before');
+    const straddling = buildRecord('2026-02-01', '2026-03-01', 'straddling');
+    const after = buildRecord('2026-03-01', '2026-04-01', 'after');
+
+    const result = clipRecurringCandidatesToObligationBounds(
+      [before, straddling, after],
+      '2026-02-10',
+      null,
+    );
+
+    expect(result.map((record) => record.recordId)).toEqual(['straddling', 'after']);
+    expect(result[0]?.activityWindow?.start).toBe('2026-02-10');
+    expect(result[1]).toBe(after);
+    expect(result[1]?.activityWindow).toBeNull();
+  });
+
+  it('preserves untouched records and never emits an inverted activity window', () => {
+    const untouched = buildRecord('2026-03-01', '2026-04-01', 'untouched');
+    const straddlingEnd = buildRecord('2026-04-01', '2026-05-01', 'straddling-end');
+    const whollyAfter = buildRecord('2026-05-01', '2026-06-01', 'wholly-after');
+
+    const result = clipRecurringCandidatesToObligationBounds(
+      [untouched, straddlingEnd, whollyAfter],
+      '2026-02-01',
+      '2026-04-15',
+    );
+
+    expect(result[0]).toBe(untouched);
+    expect(result[0]?.activityWindow).toBeNull();
+    expect(result).toHaveLength(2);
+    for (const record of result) {
+      if (record.activityWindow) {
+        expect(record.activityWindow.start < record.activityWindow.end).toBe(true);
+      }
+    }
+  });
+});

--- a/shared/billingClients/clientCadenceScheduleRegeneration.ts
+++ b/shared/billingClients/clientCadenceScheduleRegeneration.ts
@@ -13,6 +13,7 @@ import {
   type NormalizedBillingCycleAnchorSettings,
 } from './billingCycleAnchors';
 import { materializeClientCadenceServicePeriods } from './materializeClientCadenceServicePeriods';
+import { clipRecurringCandidatesToObligationBounds } from './clipRecurringCandidatesToObligationBounds';
 import { getClientBillingCycleAnchor } from './billingSchedule';
 import {
   backfillRecurringServicePeriods,
@@ -33,6 +34,7 @@ type ClientCadenceRecurringObligationRow = {
 
 const recurringServicePeriodRecordIdFactory = () => uuidv4();
 
+// LEVERAGE: pattern recurring-period-row-mapping
 type RecurringServicePeriodDbRow = {
   record_id: string;
   tenant: string;
@@ -381,41 +383,6 @@ async function persistRecurringServicePeriodRegeneration(
   }
 }
 
-/**
- * A client-cadence obligation that starts or ends inside a schedule period is
- * only active for part of that period. The invoice engine derives coverage
- * (and proration / canonical detail periods) from the persisted activity
- * window, so regeneration must clip the first/last periods to the assignment
- * bounds; otherwise mid-period contract starts are billed for the full period.
- */
-function clipRecordActivityWindowToObligationBounds(
-  record: IRecurringServicePeriodRecord,
-  obligationStart: ISO8601String,
-  obligationEnd: ISO8601String | null,
-): IRecurringServicePeriodRecord {
-  const clipStart =
-    compareIsoDateOnly(obligationStart, record.servicePeriod.start) > 0
-      ? obligationStart
-      : null;
-  const clipEnd =
-    obligationEnd && compareIsoDateOnly(obligationEnd, record.servicePeriod.end) < 0
-      ? obligationEnd
-      : null;
-
-  if (!clipStart && !clipEnd) {
-    return record;
-  }
-
-  return {
-    ...record,
-    activityWindow: {
-      start: clipStart ?? record.servicePeriod.start,
-      end: clipEnd ?? record.servicePeriod.end,
-      semantics: record.servicePeriod.semantics,
-    },
-  };
-}
-
 type ClientCadenceScheduleChangeParams = {
   tenant: string;
   clientId: string;
@@ -491,8 +458,10 @@ async function computeClientCadenceRegeneration(
       recordIdFactory: recurringServicePeriodRecordIdFactory,
     });
 
-    const candidateRecords = materialized.records.map((record) =>
-      clipRecordActivityWindowToObligationBounds(record, obligationStart, obligationEnd),
+    const candidateRecords = clipRecurringCandidatesToObligationBounds(
+      materialized.records,
+      obligationStart,
+      obligationEnd,
     );
 
     const plan = backfillRecurringServicePeriods({

--- a/shared/billingClients/clientContractStatus.ts
+++ b/shared/billingClients/clientContractStatus.ts
@@ -7,12 +7,17 @@ export type ClientAssignmentStatus = Extract<
 
 type DeriveClientContractStatusParams = {
   isActive: boolean;
-  startDate: string | null | undefined;
-  endDate: string | null | undefined;
+  startDate: string | Date | null | undefined;
+  endDate: string | Date | null | undefined;
+  contractStatus?: string;
   now?: string | Date;
 };
 
-const normalizeDateOnly = (value: string | null | undefined): string | null => {
+const normalizeDateOnly = (value: string | Date | null | undefined): string | null => {
+  if (value instanceof Date) {
+    return value.toISOString().slice(0, 10);
+  }
+
   if (typeof value !== 'string') {
     return null;
   }
@@ -45,6 +50,10 @@ const normalizeNowDateOnly = (value?: string | Date): string => {
 export function deriveClientContractStatus(
   params: DeriveClientContractStatusParams
 ): ClientAssignmentStatus {
+  if (params.contractStatus === 'draft') {
+    return 'draft';
+  }
+
   const startDate = normalizeDateOnly(params.startDate);
   const endDate = normalizeDateOnly(params.endDate);
   const nowDate = normalizeNowDateOnly(params.now);

--- a/shared/billingClients/clientContracts.ts
+++ b/shared/billingClients/clientContracts.ts
@@ -306,6 +306,9 @@ export const normalizeClientContract = (row: any): IClientContract => {
     isActive: normalized.is_active === true,
     startDate: normalizedStartDate ?? null,
     endDate: normalizedEndDate ?? null,
+    contractStatus: typeof normalized.contract_status === 'string'
+      ? normalized.contract_status
+      : undefined,
   });
 
   delete normalized.tenant_default_renewal_mode;

--- a/shared/billingClients/clipRecurringCandidatesToObligationBounds.ts
+++ b/shared/billingClients/clipRecurringCandidatesToObligationBounds.ts
@@ -1,0 +1,54 @@
+import type { IRecurringServicePeriodRecord, ISO8601String } from '@alga-psa/types';
+
+function compareIsoDateOnly(left: ISO8601String, right: ISO8601String): number {
+  return left.slice(0, 10).localeCompare(right.slice(0, 10));
+}
+
+/**
+ * A recurring obligation that starts or ends inside a schedule period is only
+ * active for part of that period. The invoice engine derives coverage (and
+ * proration / canonical detail periods) from the persisted activity window,
+ * so candidates must be bounded before they are persisted. Candidates wholly
+ * outside the obligation are removed so this helper never creates an inverted
+ * activity window.
+ */
+export function clipRecurringCandidatesToObligationBounds(
+  records: IRecurringServicePeriodRecord[],
+  obligationStart: ISO8601String,
+  obligationEnd: ISO8601String | null,
+): IRecurringServicePeriodRecord[] {
+  return records.flatMap((record) => {
+    if (
+      obligationEnd
+      && compareIsoDateOnly(record.servicePeriod.start, obligationEnd) >= 0
+    ) {
+      return [];
+    }
+
+    if (compareIsoDateOnly(record.servicePeriod.end, obligationStart) <= 0) {
+      return [];
+    }
+
+    const clipStart =
+      compareIsoDateOnly(obligationStart, record.servicePeriod.start) > 0
+        ? obligationStart
+        : null;
+    const clipEnd =
+      obligationEnd && compareIsoDateOnly(obligationEnd, record.servicePeriod.end) < 0
+        ? obligationEnd
+        : null;
+
+    if (!clipStart && !clipEnd) {
+      return [record];
+    }
+
+    return [{
+      ...record,
+      activityWindow: {
+        start: clipStart ?? record.servicePeriod.start,
+        end: clipEnd ?? record.servicePeriod.end,
+        semantics: record.servicePeriod.semantics,
+      },
+    }];
+  });
+}

--- a/shared/billingClients/index.ts
+++ b/shared/billingClients/index.ts
@@ -25,3 +25,4 @@ export * from './postDropRecurringObligationIdentity';
 export * from './bucketUsageService';
 export * from './clientCadenceScheduleRegeneration';
 export * from './applyClientCadenceChange';
+export * from './clipRecurringCandidatesToObligationBounds';


### PR DESCRIPTION
## Summary

- Bound recurring service-period candidates to contract obligation dates in both client-cadence and contract-anniversary materialization, dropping wholly out-of-bounds periods and clipping partial activity windows before persistence.
- Made client-contract status derivation accept database `Date` values and honor a draft contract header across assignment, summary, and report surfaces.
- Converted known missing-currency-pricing wizard validation into a friendly actionable error while preserving unknown-error rethrows.
- Added domain, unit, wiring, and integration regression coverage plus the implementation plan.

## Validation

- Focused/unit/integration tests passed.
- Affected package typechecks passed.
- Full CE production build passed.

## Smoke test

**PARTIAL PASS.** Real authenticated UI testing passed the core fixes: client cadence created 3 bounded periods; contract-anniversary cadence created 2 periods with the final activity window clipped to 2026-09-16; both had zero post-end starts and zero inverted windows. The exact draft repro displayed Draft with Resume/Set to Active, and Resume restored its fields. Currency validation produced a friendly actionable message, no contract row, and no failed/5xx request. Terminate/restore also passed and returned the regression contract to Active with 7 valid periods.

**Finding:** Set to Active generates the bounded periods and sets `client_contracts.is_active=true`, but leaves `contracts.status=draft`. Consequently the UI remains Draft and continues offering Set to Active. This activation-state inconsistency needs follow-up.

No simulators or mocks were used. The only console error was automation-induced hydration noise referencing `data-cli-uid` attributes; server logs and browser network contained no product errors. The stack remained healthy on port 3646. The pre-existing `package-lock.json` modification was untouched.

Evidence: `/tmp/alga-smoke-evidence/contract-user-reported-error-20260716-230033`