### PR TITLE
Add notification suppression to close popup

### DIFF
--- a/docs/plans/2026-07-17-close-popup-blocknote-suppression-plan.md
+++ b/docs/plans/2026-07-17-close-popup-blocknote-suppression-plan.md
@@ -1,0 +1,142 @@
+# Close-popup: BlockNote resolution editor + notification suppression
+
+**Branch:** `feature/notification-suppression-close-popup`
+**Date:** 2026-07-17
+
+## Problem
+
+The "Close ticket" popup added in PR #2963 (`TicketResolutionDialog`, opened from the
+close button on the ticket detail screen in both classic and bento layouts) lags the
+real resolution composer in two ways:
+
+1. The resolution is a plain `TextArea`; the conversation composer uses the BlockNote
+   `TextEditor` with mentions and clipboard-image upload. The popup's text gets wrapped
+   in a single rich-text paragraph on save, losing all formatting ability.
+2. It has no notification-suppression checkboxes. The composer (and the bulk-move flow)
+   offer `TicketNotificationSuppressionControl` ("Don't notify the customer" → "Also
+   don't notify agents and watchers"); a close via the popup always notifies.
+   Additionally, when the popup's close is blocked by close rules, the blocked-close
+   override dialog is opened with `suppression: null` hardcoded
+   (`TicketDetails.tsx:2692`), so even a suppressed close would notify after
+   "Close anyway".
+
+## Settled design (approach A — self-contained dialog)
+
+The dialog owns its editor, upload session, and suppression state, mirroring how the
+conversation composer is built. No backend changes: `updateTicketWithCache` already
+accepts `suppressContactNotifications` / `suppressInternalNotifications`, and the
+resolution comment continues to use the `closesTicket=true` flag for duplicate-email
+dedupe (identical to the conversation path).
+
+Decisions made in the design session:
+
+- Editor parity: mentions + clipboard-image uploads, **no** Hocuspocus `roomName`
+  (a room shared with the main composer would cross-contaminate).
+- Suppression control always active (a close status is mandatory in this dialog),
+  defaults to both-unchecked on every open. No persistence of last choice.
+- Suppression choice carries into the blocked-close override dialog, fixing the
+  hardcoded `null`.
+- The old `TextArea` placeholder string is dropped (BlockNote has no placeholder; the
+  prompt sentence above the fields carries that job).
+
+## Changes
+
+### 1. `packages/tickets/src/components/ticket/TicketResolutionDialog.tsx`
+
+- Replace `TextArea` with the BlockNote editor, same pattern as `TicketConversation`:
+  `dynamic(() => import('@alga-psa/ui/editor').then((m) => m.TextEditor), { loading: () => <RichTextEditorSkeleton height="200px" /> })`
+  wrapped in `Suspense` with the same skeleton. No `roomName`. `autoFocus`.
+- Content state is `PartialBlock[]`, initialized from `DEFAULT_BLOCK` (import the
+  existing export from `./TicketConversation`). Remount the editor on each open
+  (bump an editor key in the existing `isOpen` effect) so content resets.
+- "Has content" check for enabling confirm: `JSON.stringify(content) !== JSON.stringify(DEFAULT_BLOCK)`
+  — the same comparison `handleAddNewComment` uses. Confirm stays disabled without a
+  status or content, and while submitting.
+- Mentions: `searchMentions={searchUsersForMentions}` imported from
+  `@alga-psa/user-composition/actions` (as `TicketConversation` does).
+- Uploads: own `useTicketRichTextUploadSession` instance —
+  `componentLabel: 'TicketResolutionDialog'`, `trackDraftUploads: true`, wired to the
+  upload plumbing props below; `uploadFile={session.uploadFile}` on the editor.
+  - On cancel/close with tracked draft images: `session.requestDiscard()` instead of
+    closing directly; render the same `ConfirmationDialog` the composer has
+    (`clipboardDraftCancelTitle` / `clipboardDraftCancelMessage` keys, delete / keep /
+    continue-editing), then close after resolution. Without drafts, close immediately.
+  - On confirm: `session.resetDraftTracking()` (images become part of the comment).
+- Add `TicketNotificationSuppressionControl` below the editor
+  (`idPrefix={`${id}-notification-suppression`}`), state reset to both-false in the
+  `isOpen` effect, disabled while submitting.
+- Props change:
+  - New: `ticketId: string`, `currentUserId?: string | null`,
+    `onClipboardImageUploaded?: () => Promise<void> | void`, plus the three optional
+    upload plumbing props with the same signatures `TicketConversation` declares:
+    `uploadTicketAttachmentAction`, `deleteDraftTicketAttachmentImagesAction`,
+    `resolveTicketAttachmentViewUrl`.
+  - `onConfirm` becomes
+    `(statusId: string, contentBlocks: PartialBlock[], suppression: TicketNotificationSuppressionValue) => void`.
+- Widen the dialog: `max-w-lg` → `max-w-2xl` so the editor toolbar fits.
+- Drop the `info.closeTicketResolutionPlaceholder` usage.
+
+### 2. `packages/tickets/src/components/ticket/TicketDetails.tsx`
+
+- `addResolutionComment` now takes the stringified BlockNote JSON and passes it to
+  `addTicketCommentWithCache` unchanged (still `isInternal=false`, `isResolution=true`,
+  `closesTicket=true`). Remove the `createTicketRichTextParagraph` wrap and its import
+  (line 126 — this was its only use).
+- `handleResolveAndClose(statusId, contentBlocks, suppression)`:
+  - `addResolutionComment(JSON.stringify(contentBlocks))`.
+  - Blocked-close dialog gets
+    `suppression: suppression.suppressContactNotifications ? suppression : null`
+    instead of `null` (the existing override handler at `TicketDetails.tsx:421` already
+    forwards `closeBlockedDialog.suppression`, so this is the only fix needed).
+  - Status write becomes
+    `updateTicketWithCache(ticket.ticket_id!, { status_id: statusId }, suppression.suppressContactNotifications ? suppression : undefined)`
+    — matching the `options?.suppressContactNotifications ? options : {}` pattern used
+    elsewhere.
+- Pass the new props at the `<TicketResolutionDialog>` render site (~line 3428):
+  `ticketId={ticket.ticket_id!}`, `currentUserId={userId}`,
+  `onClipboardImageUploaded={refreshTicketDocuments}`, and forward
+  `uploadTicketAttachmentAction` / `deleteDraftTicketAttachmentImagesAction` /
+  `resolveTicketAttachmentViewUrl` (already available as `TicketDetails` props).
+
+### 3. Tests — `TicketResolutionDialog.test.tsx`
+
+- Mock `@alga-psa/ui/editor` (and neutralize the `next/dynamic` indirection) with a stub
+  that renders a textarea and calls `onContentChange` with paragraph blocks; mock
+  `@alga-psa/user-composition/actions` (`searchUsersForMentions`) and the upload-session
+  dependencies as needed (simplest: mock `./useTicketRichTextUploadSession`).
+- Update existing cases: confirm disabled until status + non-empty content; submit now
+  yields `(statusId, blocks, suppression)`.
+- New cases:
+  - Suppression defaults: both checkboxes unchecked on open, and reset after reopen.
+  - Checking contact + internal suppression passes
+    `{ suppressContactNotifications: true, suppressInternalNotifications: true }`.
+  - Internal checkbox disabled until contact is checked (control behavior wired in).
+
+### 4. Locales
+
+- Remove the now-unused `info.closeTicketResolutionPlaceholder` key from all 10
+  `server/public/locales/*/features/tickets.json` files. No new keys needed — the
+  suppression control and clipboard-draft dialogs bring their own existing keys.
+
+## Out of scope
+
+- Backend/notification-subscriber changes (none needed).
+- Extracting a shared "resolution composer" from `TicketConversation` (approach C —
+  deliberately rejected as a larger refactor than the feature warrants).
+- The conversation composer and bulk-move suppression flows (already shipped).
+
+## Verification
+
+1. `npx vitest run packages/tickets/src/components/ticket/TicketResolutionDialog.test.tsx`
+   plus the adjacent contract tests
+   (`ticketActions.suppressionMirror.contract.test.ts`,
+   `optimizedTicketActions.liveUpdates.test.ts`) to confirm no regressions.
+2. Manual smoke on the running dev stack (http://localhost:3432): open a ticket → close
+   button → popup shows BlockNote editor + suppression checkboxes; type formatted text,
+   paste an image, @mention a user; confirm → ticket closes, resolution comment renders
+   with formatting and image; reopen popup on another ticket → fields and checkboxes
+   reset. Cancel-with-pasted-image path shows the keep/delete dialog.
+3. Suppression smoke: close a ticket with "Don't notify the customer" checked and
+   verify no contact notification is recorded (internal notification still sent);
+   repeat with both checked and verify neither is sent. Verify the blocked-close
+   "Close anyway" override after a suppressed popup close also suppresses.

--- a/docs/plans/2026-07-17-close-popup-blocknote-suppression-plan.md
+++ b/docs/plans/2026-07-17-close-popup-blocknote-suppression-plan.md
@@ -120,7 +120,8 @@ Decisions made in the design session:
 
 ## Out of scope
 
-- Backend/notification-subscriber changes (none needed).
+- Backend/notification-subscriber changes (initially believed unnecessary; superseded by
+  the review mitigation below).
 - Extracting a shared "resolution composer" from `TicketConversation` (approach C —
   deliberately rejected as a larger refactor than the feature warrants).
 - The conversation composer and bulk-move suppression flows (already shipped).
@@ -140,3 +141,22 @@ Decisions made in the design session:
    verify no contact notification is recorded (internal notification still sent);
    repeat with both checked and verify neither is sent. Verify the blocked-close
    "Close anyway" override after a suppressed popup close also suppresses.
+
+## Review mitigation: resolution-comment event suppression
+
+The close operation writes its resolution comment and status in separate transactions.
+The original implementation applied suppression only to the status write, so the
+resolution comment's `TICKET_COMMENT_ADDED` event remained loud. The mitigation:
+
+- passes the selected suppression value into `addTicketCommentWithCache` when the close
+  popup persists its resolution;
+- publishes both suppression flags on that comment event (defaulting to false for all
+  existing callers and enforcing the existing contact-before-internal invariant);
+- applies contact suppression to contact/portal recipients and external watchers in
+  comment notification subscribers; and
+- classifies mentions by the mentioned user's type, then applies contact or internal
+  suppression as appropriate; assigned/additional agents and internal watchers use
+  internal suppression.
+
+Behavioral coverage verifies both contact-only and full suppression on closing
+resolution comment events and on each subscriber's recipient policy.

--- a/packages/billing/tests/automaticInvoices.groupedParentRows.test.tsx
+++ b/packages/billing/tests/automaticInvoices.groupedParentRows.test.tsx
@@ -677,7 +677,12 @@ describe('AutomaticInvoices grouped parent rows', () => {
     });
     fireEvent.click(parentCheckbox);
 
-    fireEvent.click(screen.getByRole('button', { name: 'Preview Selected' }));
+    const previewButton = screen.getByRole('button', { name: 'Preview Selected' });
+    await waitFor(() => {
+      expect(previewButton).toBeEnabled();
+      expect(screen.getByRole('button', { name: 'Generate Invoices (1)' })).toBeEnabled();
+    });
+    fireEvent.click(previewButton);
     await waitFor(() => {
       expect(screen.getByTestId('preview-invoice-count-summary')).toHaveTextContent(
         'This selection will generate one combined invoice.',

--- a/packages/billing/vitest.setup.ts
+++ b/packages/billing/vitest.setup.ts
@@ -1,6 +1,13 @@
 process.env.NEXTAUTH_SECRET ??= 'billing-vitest-only-secret';
 
 if (typeof window !== 'undefined') {
+  // CI runs the affected nx projects in parallel, so a saturated runner can
+  // stretch renders past testing-library's 1s default async timeout (waitFor,
+  // findBy*) and flake component suites that pass everywhere else. Genuinely
+  // failing waits just take longer to report; passing waits are unaffected.
+  const { configure } = await import('@testing-library/dom');
+  configure({ asyncUtilTimeout: 10_000 });
+
   const storage = new Map<string, string>();
   const localStorageMock: Storage = {
     get length() {

--- a/packages/clients/src/actions/contact-actions/visibilityGroupActions.integration.test.ts
+++ b/packages/clients/src/actions/contact-actions/visibilityGroupActions.integration.test.ts
@@ -177,7 +177,7 @@ describe('contactActions visibility group integration', () => {
     const updatedVisibility = await getClientContactVisibilityContext(trx, 'tenant-1', 'contact-1');
     expect(updatedVisibility.visibilityGroupId).toBe('group-2');
     expect(updatedVisibility.visibleBoardIds).toEqual(['board-2']);
-  });
+  }, 15_000);
 
   it('T001: MSP board loading returns active tenant boards without requiring board client ownership', async () => {
     const boardsSelectMock = vi.fn().mockResolvedValue([

--- a/packages/tickets/src/actions/optimizedTicketActions.liveUpdates.test.ts
+++ b/packages/tickets/src/actions/optimizedTicketActions.liveUpdates.test.ts
@@ -64,6 +64,10 @@ vi.mock('@alga-psa/validation', () => ({
   validateData: (_schema: unknown, value: unknown) => value,
 }));
 
+vi.mock('@alga-psa/formatting/blocknoteUtils', () => ({
+  convertBlockNoteToMarkdown: vi.fn(async () => 'Resolution text'),
+}));
+
 vi.mock('@alga-psa/event-bus/publishers', () => ({
   publishEvent: (...args: any[]) => publishEventMock(...args),
   publishWorkflowEvent: (...args: any[]) => publishWorkflowEventMock(...args),
@@ -117,6 +121,10 @@ vi.mock('../lib/workflowTicketSlaStageEvents', () => ({
 
 vi.mock('../lib/validateTicketClosure', () => ({
   enforceTicketCloseRules: vi.fn(async () => undefined),
+}));
+
+vi.mock('./ticketBundleUtils', () => ({
+  maybeReopenBundleMasterFromChildReply: vi.fn(async () => undefined),
 }));
 
 import {
@@ -180,6 +188,13 @@ function buildTrx(params: {
   const bundleSettings = params.bundleSettings;
 
   const ticketsTable = {
+    select() {
+      return {
+        where: vi.fn(() => ({
+          first: vi.fn(async () => ({ response_state: currentTicket.response_state ?? null })),
+        })),
+      };
+    },
     where(whereArgs: Record<string, unknown>) {
       if ('ticket_id' in whereArgs) {
         return {
@@ -232,7 +247,7 @@ function buildTrx(params: {
     })),
   };
 
-  return ((table: string) => {
+  const trx = ((table: string) => {
     if (table === 'tickets') {
       return ticketsTable;
     }
@@ -263,8 +278,26 @@ function buildTrx(params: {
       };
     }
 
+    if (table === 'comment_threads') {
+      return {
+        insert: vi.fn(async () => undefined),
+      };
+    }
+
+    if (table === 'comments') {
+      return {
+        insert: vi.fn((row: Record<string, unknown>) => ({
+          returning: vi.fn(async () => [{ ...row, comment_id: 'comment-1' }]),
+        })),
+      };
+    }
+
     throw new Error(`Unexpected table: ${table}`);
   }) as any;
+  trx.raw = vi.fn(async () => ({
+    rows: [{ comment_id: 'comment-1', thread_id: 'thread-1' }],
+  }));
+  return trx;
 }
 
 describe('updateTicketWithCache live updates', () => {
@@ -612,6 +645,49 @@ describe('updateTicketWithCache live updates', () => {
         }),
         idempotencyKey: 'sla:ticket-1:resolution:met',
       })
+    );
+  });
+
+  it.each([
+    {
+      label: 'contact notifications',
+      options: { suppressContactNotifications: true },
+      expectedInternalSuppression: false,
+    },
+    {
+      label: 'contact and internal notifications',
+      options: {
+        suppressContactNotifications: true,
+        suppressInternalNotifications: true,
+      },
+      expectedInternalSuppression: true,
+    },
+  ])('publishes selected suppression flags for a closing resolution comment ($label)', async ({
+    options,
+    expectedInternalSuppression,
+  }) => {
+    const { addTicketCommentWithCache } = await import('./optimizedTicketActions');
+
+    await expect(
+      addTicketCommentWithCache(
+        'ticket-1',
+        '[{"type":"paragraph","content":"Resolution text"}]',
+        false,
+        true,
+        true,
+        options,
+      ),
+    ).resolves.toEqual(expect.objectContaining({ comment_id: 'comment-1' }));
+
+    expect(publishEventMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        eventType: 'TICKET_COMMENT_ADDED',
+        payload: expect.objectContaining({
+          ticketId: 'ticket-1',
+          suppressContactNotifications: true,
+          suppressInternalNotifications: expectedInternalSuppression,
+        }),
+      }),
     );
   });
 

--- a/packages/tickets/src/actions/optimizedTicketActions.ts
+++ b/packages/tickets/src/actions/optimizedTicketActions.ts
@@ -3107,9 +3107,19 @@ export const addTicketCommentWithCache = withAuth(async (
   content: string,
   isInternal: boolean,
   isResolution: boolean,
-  closesTicket: boolean = false
+  closesTicket: boolean = false,
+  notificationSuppression?: Pick<
+    UpdateTicketInTransactionOptions,
+    'suppressContactNotifications' | 'suppressInternalNotifications'
+  >,
 ): Promise<IComment | TicketActionError> => {
   const {knex: db} = await createTenantKnex();
+
+  const suppressContactNotifications = notificationSuppression?.suppressContactNotifications === true;
+  const suppressInternalNotifications = notificationSuppression?.suppressInternalNotifications === true;
+  if (suppressInternalNotifications && !suppressContactNotifications) {
+    throw new Error('suppressInternalNotifications requires suppressContactNotifications');
+  }
 
   return withTransaction(db, async (trx): Promise<IComment | TicketActionError> => {
     try {
@@ -3298,7 +3308,9 @@ export const addTicketCommentWithCache = withAuth(async (
             author: `${user.first_name} ${user.last_name}`,
             isInternal,
             authorType,
-          }
+          },
+          suppressContactNotifications,
+          suppressInternalNotifications,
         }
       }),
       `TICKET_COMMENT_ADDED ticket=${ticketId}`
@@ -3405,9 +3417,20 @@ export async function addTicketCommentWithCacheForCurrentUser(
   content: string,
   isInternal: boolean,
   isResolution: boolean,
-  closesTicket: boolean = false
+  closesTicket: boolean = false,
+  notificationSuppression?: Pick<
+    UpdateTicketInTransactionOptions,
+    'suppressContactNotifications' | 'suppressInternalNotifications'
+  >,
 ): Promise<IComment | TicketActionError> {
-  return addTicketCommentWithCache(ticketId, content, isInternal, isResolution, closesTicket);
+  return addTicketCommentWithCache(
+    ticketId,
+    content,
+    isInternal,
+    isResolution,
+    closesTicket,
+    notificationSuppression,
+  );
 }
 
 /**

--- a/packages/tickets/src/components/settings/BoardsSettings.copyStatuses.test.tsx
+++ b/packages/tickets/src/components/settings/BoardsSettings.copyStatuses.test.tsx
@@ -366,6 +366,7 @@ describe('BoardsSettings ticket status copy flow', () => {
     });
     await waitFor(() => {
       expect(getBoardTicketStatusesMock).toHaveBeenCalledWith('board-source');
+      expect(document.getElementById('inline-ticket-status-name-0')).toBeTruthy();
     });
 
     fireEvent.change(document.getElementById('inline-ticket-status-name-0') as HTMLInputElement, {

--- a/packages/tickets/src/components/ticket/TicketDetails.tsx
+++ b/packages/tickets/src/components/ticket/TicketDetails.tsx
@@ -124,6 +124,7 @@ import { hasAdminSettingsViewAccess } from './commentMetadataDebug';
 import type { TicketScreenBootstrap } from '../../lib/ticketScreenBootstrap';
 import { normalizeTicketLiveField, type TicketLiveConflictState } from './ticketLiveFields';
 import TicketResolutionDialog from './TicketResolutionDialog';
+import { persistResolutionComment } from './resolutionCommentPersistence';
 
 interface PendingCommentDelete {
     commentId: string;
@@ -465,30 +466,41 @@ const TicketDetails: React.FC<TicketDetailsProps> = ({
     );
 
     const addResolutionComment = useCallback(async (resolution: string): Promise<boolean> => {
-        if (!ticket.ticket_id) {
+        const ticketId = ticket.ticket_id;
+        if (!ticketId) {
             toast.error(t('messages.closeFailed', 'Failed to close ticket'));
             return false;
         }
 
         try {
-            const result = await addTicketCommentWithCache(
-                ticket.ticket_id,
-                resolution,
-                false,
-                true,
-                true,
-            );
-            if (isReturnedActionError(result)) {
-                throw result;
-            }
-
-            const updatedComments = await findCommentsByTicketId(ticket.ticket_id);
-            if (isReturnedActionError(updatedComments)) {
-                throw updatedComments;
-            }
-            setConversations(updatedComments);
-            setActivityLogRefreshKey((value) => value + 1);
-            return true;
+            return await persistResolutionComment({
+                persistComment: async () => {
+                    const result = await addTicketCommentWithCache(
+                        ticketId,
+                        resolution,
+                        false,
+                        true,
+                        true,
+                    );
+                    if (isReturnedActionError(result)) {
+                        throw result;
+                    }
+                },
+                refreshComments: async () => {
+                    const updatedComments = await findCommentsByTicketId(ticketId);
+                    if (isReturnedActionError(updatedComments)) {
+                        throw updatedComments;
+                    }
+                    return updatedComments;
+                },
+                onCommentsRefreshed: (updatedComments) => {
+                    setConversations(updatedComments);
+                    setActivityLogRefreshKey((value) => value + 1);
+                },
+                onRefreshError: (error) => {
+                    handleTicketActionError(error, t('messages.loadCommentsFailed', 'Failed to load comments'));
+                },
+            });
         } catch (error) {
             handleTicketActionError(error, t('messages.addCommentFailed', 'Failed to add comment'));
             return false;

--- a/packages/tickets/src/components/ticket/TicketDetails.tsx
+++ b/packages/tickets/src/components/ticket/TicketDetails.tsx
@@ -465,7 +465,10 @@ const TicketDetails: React.FC<TicketDetailsProps> = ({
         [statusOptions, ticket.status_id],
     );
 
-    const addResolutionComment = useCallback(async (resolution: string): Promise<boolean> => {
+    const addResolutionComment = useCallback(async (
+        resolution: string,
+        suppression: TicketNotificationSuppressionValue,
+    ): Promise<boolean> => {
         const ticketId = ticket.ticket_id;
         if (!ticketId) {
             toast.error(t('messages.closeFailed', 'Failed to close ticket'));
@@ -481,6 +484,7 @@ const TicketDetails: React.FC<TicketDetailsProps> = ({
                         false,
                         true,
                         true,
+                        suppression,
                     );
                     if (isReturnedActionError(result)) {
                         throw result;
@@ -2686,7 +2690,7 @@ const handleClose = () => {
         setIsSubmittingResolutionClose(true);
         let resolutionSaved = false;
         try {
-            const resolutionAdded = await addResolutionComment(JSON.stringify(contentBlocks));
+            const resolutionAdded = await addResolutionComment(JSON.stringify(contentBlocks), suppression);
             if (!resolutionAdded) {
                 return false;
             }

--- a/packages/tickets/src/components/ticket/TicketDetails.tsx
+++ b/packages/tickets/src/components/ticket/TicketDetails.tsx
@@ -123,7 +123,6 @@ import { isBoardLiveTicketTimerEnabled } from '../../lib/boardLiveTicketTimer';
 import { hasAdminSettingsViewAccess } from './commentMetadataDebug';
 import type { TicketScreenBootstrap } from '../../lib/ticketScreenBootstrap';
 import { normalizeTicketLiveField, type TicketLiveConflictState } from './ticketLiveFields';
-import { createTicketRichTextParagraph } from '../../lib/ticketRichText';
 import TicketResolutionDialog from './TicketResolutionDialog';
 
 interface PendingCommentDelete {
@@ -474,7 +473,7 @@ const TicketDetails: React.FC<TicketDetailsProps> = ({
         try {
             const result = await addTicketCommentWithCache(
                 ticket.ticket_id,
-                JSON.stringify(createTicketRichTextParagraph(resolution)),
+                resolution,
                 false,
                 true,
                 true,
@@ -2662,7 +2661,11 @@ const handleClose = () => {
         ticket.ticket_id,
     ]);
 
-    const handleResolveAndClose = useCallback(async (statusId: string, resolution: string) => {
+    const handleResolveAndClose = useCallback(async (
+        statusId: string,
+        contentBlocks: PartialBlock[],
+        suppression: TicketNotificationSuppressionValue,
+    ) => {
         if (!ticket.ticket_id || !closedStatusOptions.some((option) => option.value === statusId)) {
             toast.error(t('messages.closeFailed', 'Failed to close ticket'));
             return;
@@ -2670,7 +2673,7 @@ const handleClose = () => {
 
         setIsSubmittingResolutionClose(true);
         try {
-            const resolutionAdded = await addResolutionComment(resolution);
+            const resolutionAdded = await addResolutionComment(JSON.stringify(contentBlocks));
             if (!resolutionAdded) {
                 return;
             }
@@ -2689,7 +2692,7 @@ const handleClose = () => {
                         statusId,
                         failures: check.failures,
                         canOverride: check.canOverride,
-                        suppression: null,
+                        suppression: suppression.suppressContactNotifications ? suppression : null,
                     });
                     return;
                 }
@@ -2700,7 +2703,11 @@ const handleClose = () => {
 
             const result = await runWithPendingLiveFields(
                 ['status_id', 'response_state'],
-                () => updateTicketWithCache(ticket.ticket_id!, { status_id: statusId }),
+                () => updateTicketWithCache(
+                    ticket.ticket_id!,
+                    { status_id: statusId },
+                    suppression.suppressContactNotifications ? suppression : undefined,
+                ),
             );
             if (isReturnedActionError(result)) {
                 throw result;
@@ -3428,6 +3435,8 @@ const handleClose = () => {
                 <TicketResolutionDialog
                     id={`${id}-resolution-close`}
                     isOpen={isResolutionCloseDialogOpen}
+                    ticketId={ticket.ticket_id!}
+                    currentUserId={userId}
                     statusOptions={closedStatusOptions}
                     isSubmitting={isSubmittingResolutionClose}
                     onClose={() => {
@@ -3436,6 +3445,10 @@ const handleClose = () => {
                         }
                     }}
                     onConfirm={handleResolveAndClose}
+                    onClipboardImageUploaded={refreshTicketDocuments}
+                    uploadTicketAttachmentAction={uploadTicketAttachmentAction}
+                    deleteDraftTicketAttachmentImagesAction={deleteDraftTicketAttachmentImagesAction}
+                    resolveTicketAttachmentViewUrl={resolveTicketAttachmentViewUrl}
                 />
                 
                 {/* Blocked-close dialog: unmet close rules with quick actions and

--- a/packages/tickets/src/components/ticket/TicketDetails.tsx
+++ b/packages/tickets/src/components/ticket/TicketDetails.tsx
@@ -2668,15 +2668,17 @@ const handleClose = () => {
     ) => {
         if (!ticket.ticket_id || !closedStatusOptions.some((option) => option.value === statusId)) {
             toast.error(t('messages.closeFailed', 'Failed to close ticket'));
-            return;
+            return false;
         }
 
         setIsSubmittingResolutionClose(true);
+        let resolutionSaved = false;
         try {
             const resolutionAdded = await addResolutionComment(JSON.stringify(contentBlocks));
             if (!resolutionAdded) {
-                return;
+                return false;
             }
+            resolutionSaved = true;
 
             // The comment is already durable at this point. Close this dialog
             // so a failed or blocked status write cannot accidentally create a
@@ -2694,7 +2696,7 @@ const handleClose = () => {
                         canOverride: check.canOverride,
                         suppression: suppression.suppressContactNotifications ? suppression : null,
                     });
-                    return;
+                    return true;
                 }
             } catch (checkError) {
                 // Fall through to the write; the server still enforces.
@@ -2721,8 +2723,10 @@ const handleClose = () => {
             }));
             setActivityLogRefreshKey((value) => value + 1);
             toast.success(t('messages.ticketClosed', 'Ticket closed'));
+            return true;
         } catch (error) {
             handleTicketActionError(error, t('messages.closeFailed', 'Failed to close ticket'));
+            return resolutionSaved;
         } finally {
             setIsSubmittingResolutionClose(false);
         }

--- a/packages/tickets/src/components/ticket/TicketResolutionDialog.test.tsx
+++ b/packages/tickets/src/components/ticket/TicketResolutionDialog.test.tsx
@@ -1,19 +1,102 @@
 /* @vitest-environment jsdom */
 /// <reference types="@testing-library/jest-dom/vitest" />
 
-import React from 'react';
-import { fireEvent, render, screen } from '@testing-library/react';
-import { describe, expect, it, vi } from 'vitest';
+import React from "react";
+import { fireEvent, render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
 
-import TicketResolutionDialog from './TicketResolutionDialog';
+import TicketResolutionDialog from "./TicketResolutionDialog";
 
-vi.mock('@alga-psa/ui/lib/i18n/client', () => ({
+const DEFAULT_BLOCK = [
+  {
+    type: "paragraph",
+    props: {
+      textAlignment: "left",
+      backgroundColor: "default",
+      textColor: "default",
+    },
+    content: [{ type: "text", text: "", styles: {} }],
+  },
+];
+
+const uploadSessionMock = vi.hoisted(() => ({
+  deleteTrackedDraftClipboardImages: vi.fn(),
+  isDeletingDraftImages: false,
+  keepDraftClipboardImages: vi.fn(),
+  requestDiscard: vi.fn(),
+  resetDraftTracking: vi.fn(),
+  setShowDraftCancelDialog: vi.fn(),
+  showDraftCancelDialog: false,
+  uploadFile: vi.fn(),
+}));
+
+vi.mock("next/dynamic", () => ({
+  default: () =>
+    function MockTextEditor({
+      initialContent,
+      onContentChange,
+    }: {
+      initialContent: typeof DEFAULT_BLOCK;
+      onContentChange: (blocks: typeof DEFAULT_BLOCK) => void;
+    }) {
+      const [value, setValue] = React.useState(
+        initialContent[0]?.content[0]?.text ?? "",
+      );
+
+      return (
+        <textarea
+          aria-label="Resolution"
+          value={value}
+          onChange={(event) => {
+            const nextValue = event.target.value;
+            setValue(nextValue);
+            onContentChange(
+              nextValue
+                ? [
+                    {
+                      ...DEFAULT_BLOCK[0],
+                      content: [{ type: "text", text: nextValue, styles: {} }],
+                    },
+                  ]
+                : DEFAULT_BLOCK,
+            );
+          }}
+        />
+      );
+    },
+}));
+
+vi.mock("@alga-psa/ui/editor", () => ({ TextEditor: vi.fn() }));
+
+vi.mock("@alga-psa/user-composition/actions", () => ({
+  searchUsersForMentions: vi.fn(),
+}));
+
+vi.mock("./TicketConversation", () => ({
+  DEFAULT_BLOCK: [
+    {
+      type: "paragraph",
+      props: {
+        textAlignment: "left",
+        backgroundColor: "default",
+        textColor: "default",
+      },
+      content: [{ type: "text", text: "", styles: {} }],
+    },
+  ],
+}));
+
+vi.mock("./useTicketRichTextUploadSession", () => ({
+  useTicketRichTextUploadSession: () => uploadSessionMock,
+}));
+
+vi.mock("@alga-psa/ui/lib/i18n/client", () => ({
   useTranslation: () => ({
     t: (_key: string, fallback?: string) => fallback ?? _key,
   }),
 }));
 
-vi.mock('@alga-psa/ui/components/CustomSelect', () => ({
+vi.mock("@alga-psa/ui/components/CustomSelect", () => ({
   default: ({
     id,
     label,
@@ -33,82 +116,164 @@ vi.mock('@alga-psa/ui/components/CustomSelect', () => ({
       {label}
       <select
         id={id}
-        value={value ?? ''}
+        value={value ?? ""}
         onChange={(event) => onValueChange(event.target.value)}
         disabled={disabled}
       >
         <option value="">Select a close status</option>
         {options.map((option) => (
-          <option key={option.value} value={option.value}>{option.label}</option>
+          <option key={option.value} value={option.value}>
+            {option.label}
+          </option>
         ))}
       </select>
     </label>
   ),
 }));
 
-describe('TicketResolutionDialog', () => {
-  it('requires a close status and non-empty resolution, then submits both', () => {
+describe("TicketResolutionDialog", () => {
+  it("requires a close status and non-empty resolution, then submits blocks and suppression", () => {
     const onConfirm = vi.fn();
 
     render(
       <TicketResolutionDialog
         id="ticket-resolution-close"
         isOpen
+        ticketId="ticket-1"
         statusOptions={[
-          { value: 'resolved', label: 'Resolved' },
-          { value: 'closed', label: 'Closed' },
+          { value: "resolved", label: "Resolved" },
+          { value: "closed", label: "Closed" },
         ]}
         onClose={vi.fn()}
         onConfirm={onConfirm}
       />,
     );
 
-    expect(screen.getByText('Choose a close status and add a resolution for this ticket.')).toBeInTheDocument();
-    const confirm = screen.getByRole('button', { name: 'Resolve and close' });
+    expect(
+      screen.getByText(
+        "Choose a close status and add a resolution for this ticket.",
+      ),
+    ).toBeInTheDocument();
+    const confirm = screen.getByRole("button", { name: "Resolve and close" });
     expect(confirm).toBeDisabled();
 
-    fireEvent.change(screen.getByLabelText('Resolution'), { target: { value: '  Replaced the failed switch.  ' } });
+    fireEvent.change(screen.getByLabelText("Resolution"), {
+      target: { value: "  Replaced the failed switch.  " },
+    });
     expect(confirm).toBeDisabled();
 
-    fireEvent.change(screen.getByLabelText('Close status'), { target: { value: 'resolved' } });
+    fireEvent.change(screen.getByLabelText("Close status"), {
+      target: { value: "resolved" },
+    });
     expect(confirm).toBeEnabled();
     fireEvent.click(confirm);
 
-    expect(onConfirm).toHaveBeenCalledWith('resolved', 'Replaced the failed switch.');
+    expect(onConfirm).toHaveBeenCalledWith(
+      "resolved",
+      [
+        {
+          ...DEFAULT_BLOCK[0],
+          content: [
+            {
+              type: "text",
+              text: "  Replaced the failed switch.  ",
+              styles: {},
+            },
+          ],
+        },
+      ],
+      {
+        suppressContactNotifications: false,
+        suppressInternalNotifications: false,
+      },
+    );
   });
 
-  it('resets the draft and status choice whenever the dialog is opened again', () => {
+  it("resets the draft, status choice, and suppression whenever the dialog is opened again", () => {
     const props = {
-      id: 'ticket-resolution-close',
+      id: "ticket-resolution-close",
+      ticketId: "ticket-1",
       statusOptions: [
-        { value: 'resolved', label: 'Resolved' },
-        { value: 'closed', label: 'Closed' },
+        { value: "resolved", label: "Resolved" },
+        { value: "closed", label: "Closed" },
       ],
       onClose: vi.fn(),
       onConfirm: vi.fn(),
     };
     const { rerender } = render(<TicketResolutionDialog {...props} isOpen />);
 
-    fireEvent.change(screen.getByLabelText('Close status'), { target: { value: 'closed' } });
-    fireEvent.change(screen.getByLabelText('Resolution'), { target: { value: 'Temporary draft' } });
+    fireEvent.change(screen.getByLabelText("Close status"), {
+      target: { value: "closed" },
+    });
+    fireEvent.change(screen.getByLabelText("Resolution"), {
+      target: { value: "Temporary draft" },
+    });
+    fireEvent.click(
+      screen.getByRole("checkbox", { name: "Don't notify the customer" }),
+    );
     rerender(<TicketResolutionDialog {...props} isOpen={false} />);
     rerender(<TicketResolutionDialog {...props} isOpen />);
 
-    expect(screen.getByLabelText('Close status')).toHaveValue('');
-    expect(screen.getByLabelText('Resolution')).toHaveValue('');
+    expect(screen.getByLabelText("Close status")).toHaveValue("");
+    expect(screen.getByLabelText("Resolution")).toHaveValue("");
+    expect(
+      screen.getByRole("checkbox", { name: "Don't notify the customer" }),
+    ).not.toBeChecked();
+    expect(
+      screen.getByRole("checkbox", {
+        name: "Also don't notify agents and watchers",
+      }),
+    ).not.toBeChecked();
   });
 
-  it('preselects the only available close status', () => {
+  it("preselects the only available close status", () => {
     render(
       <TicketResolutionDialog
         id="ticket-resolution-close"
         isOpen
-        statusOptions={[{ value: 'closed', label: 'Closed' }]}
+        ticketId="ticket-1"
+        statusOptions={[{ value: "closed", label: "Closed" }]}
         onClose={vi.fn()}
         onConfirm={vi.fn()}
       />,
     );
 
-    expect(screen.getByLabelText('Close status')).toHaveValue('closed');
+    expect(screen.getByLabelText("Close status")).toHaveValue("closed");
+  });
+
+  it("submits contact and internal notification suppression", () => {
+    const onConfirm = vi.fn();
+    render(
+      <TicketResolutionDialog
+        id="ticket-resolution-close"
+        isOpen
+        ticketId="ticket-1"
+        statusOptions={[{ value: "closed", label: "Closed" }]}
+        onClose={vi.fn()}
+        onConfirm={onConfirm}
+      />,
+    );
+
+    const contactSuppression = screen.getByRole("checkbox", {
+      name: "Don't notify the customer",
+    });
+    const internalSuppression = screen.getByRole("checkbox", {
+      name: "Also don't notify agents and watchers",
+    });
+    expect(contactSuppression).not.toBeChecked();
+    expect(internalSuppression).toBeDisabled();
+
+    fireEvent.click(contactSuppression);
+    expect(internalSuppression).toBeEnabled();
+    fireEvent.click(internalSuppression);
+    fireEvent.change(screen.getByLabelText("Resolution"), {
+      target: { value: "Resolved" },
+    });
+    fireEvent.click(screen.getByRole("button", { name: "Resolve and close" }));
+
+    expect(onConfirm).toHaveBeenCalledWith("closed", expect.any(Array), {
+      suppressContactNotifications: true,
+      suppressInternalNotifications: true,
+    });
   });
 });

--- a/packages/tickets/src/components/ticket/TicketResolutionDialog.test.tsx
+++ b/packages/tickets/src/components/ticket/TicketResolutionDialog.test.tsx
@@ -2,7 +2,7 @@
 /// <reference types="@testing-library/jest-dom/vitest" />
 
 import React from "react";
-import { fireEvent, render, screen } from "@testing-library/react";
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
 import { describe, expect, it, vi } from "vitest";
 
 import TicketResolutionDialog from "./TicketResolutionDialog";
@@ -132,8 +132,8 @@ vi.mock("@alga-psa/ui/components/CustomSelect", () => ({
 }));
 
 describe("TicketResolutionDialog", () => {
-  it("requires a close status and non-empty resolution, then submits blocks and suppression", () => {
-    const onConfirm = vi.fn();
+  it("requires a close status and non-empty resolution, then submits blocks and suppression", async () => {
+    const onConfirm = vi.fn().mockResolvedValue(true);
 
     render(
       <TicketResolutionDialog
@@ -148,6 +148,7 @@ describe("TicketResolutionDialog", () => {
         onConfirm={onConfirm}
       />,
     );
+    uploadSessionMock.resetDraftTracking.mockClear();
 
     expect(
       screen.getByText(
@@ -187,6 +188,68 @@ describe("TicketResolutionDialog", () => {
         suppressInternalNotifications: false,
       },
     );
+    await waitFor(() => {
+      expect(uploadSessionMock.resetDraftTracking).toHaveBeenCalledOnce();
+    });
+  });
+
+  it("keeps draft image tracking until the async resolution save succeeds", async () => {
+    let finishSave: ((saved: boolean) => void) | undefined;
+    const onConfirm = vi.fn(
+      () =>
+        new Promise<boolean>((resolve) => {
+          finishSave = resolve;
+        }),
+    );
+
+    render(
+      <TicketResolutionDialog
+        id="ticket-resolution-close"
+        isOpen
+        ticketId="ticket-1"
+        statusOptions={[{ value: "closed", label: "Closed" }]}
+        onClose={vi.fn()}
+        onConfirm={onConfirm}
+      />,
+    );
+    uploadSessionMock.resetDraftTracking.mockClear();
+
+    fireEvent.change(screen.getByLabelText("Resolution"), {
+      target: { value: "Resolved" },
+    });
+    fireEvent.click(screen.getByRole("button", { name: "Resolve and close" }));
+
+    expect(onConfirm).toHaveBeenCalledOnce();
+    expect(uploadSessionMock.resetDraftTracking).not.toHaveBeenCalled();
+
+    finishSave?.(true);
+    await waitFor(() => {
+      expect(uploadSessionMock.resetDraftTracking).toHaveBeenCalledOnce();
+    });
+  });
+
+  it("keeps uploaded images tracked when the resolution save fails", async () => {
+    const onConfirm = vi.fn().mockResolvedValue(false);
+
+    render(
+      <TicketResolutionDialog
+        id="ticket-resolution-close"
+        isOpen
+        ticketId="ticket-1"
+        statusOptions={[{ value: "closed", label: "Closed" }]}
+        onClose={vi.fn()}
+        onConfirm={onConfirm}
+      />,
+    );
+    uploadSessionMock.resetDraftTracking.mockClear();
+
+    fireEvent.change(screen.getByLabelText("Resolution"), {
+      target: { value: "Resolved" },
+    });
+    fireEvent.click(screen.getByRole("button", { name: "Resolve and close" }));
+
+    await waitFor(() => expect(onConfirm).toHaveBeenCalledOnce());
+    expect(uploadSessionMock.resetDraftTracking).not.toHaveBeenCalled();
   });
 
   it("resets the draft, status choice, and suppression whenever the dialog is opened again", () => {
@@ -198,7 +261,7 @@ describe("TicketResolutionDialog", () => {
         { value: "closed", label: "Closed" },
       ],
       onClose: vi.fn(),
-      onConfirm: vi.fn(),
+      onConfirm: vi.fn().mockResolvedValue(true),
     };
     const { rerender } = render(<TicketResolutionDialog {...props} isOpen />);
 
@@ -234,7 +297,7 @@ describe("TicketResolutionDialog", () => {
         ticketId="ticket-1"
         statusOptions={[{ value: "closed", label: "Closed" }]}
         onClose={vi.fn()}
-        onConfirm={vi.fn()}
+        onConfirm={vi.fn().mockResolvedValue(true)}
       />,
     );
 
@@ -242,7 +305,7 @@ describe("TicketResolutionDialog", () => {
   });
 
   it("submits contact and internal notification suppression", () => {
-    const onConfirm = vi.fn();
+    const onConfirm = vi.fn().mockResolvedValue(true);
     render(
       <TicketResolutionDialog
         id="ticket-resolution-close"

--- a/packages/tickets/src/components/ticket/TicketResolutionDialog.tsx
+++ b/packages/tickets/src/components/ticket/TicketResolutionDialog.tsx
@@ -1,47 +1,123 @@
-'use client';
+"use client";
 
-import React, { useEffect, useState } from 'react';
-import { Button } from '@alga-psa/ui/components/Button';
-import CustomSelect from '@alga-psa/ui/components/CustomSelect';
-import { Dialog, DialogContent } from '@alga-psa/ui/components/Dialog';
-import { TextArea } from '@alga-psa/ui/components/TextArea';
-import { useTranslation } from '@alga-psa/ui/lib/i18n/client';
+import React, { Suspense, useCallback, useEffect, useState } from "react";
+import dynamic from "next/dynamic";
+import type { PartialBlock } from "@blocknote/core";
+import { Button } from "@alga-psa/ui/components/Button";
+import CustomSelect from "@alga-psa/ui/components/CustomSelect";
+import { ConfirmationDialog } from "@alga-psa/ui/components/ConfirmationDialog";
+import { Dialog, DialogContent } from "@alga-psa/ui/components/Dialog";
+import RichTextEditorSkeleton from "@alga-psa/ui/components/skeletons/RichTextEditorSkeleton";
+import { useTranslation } from "@alga-psa/ui/lib/i18n/client";
+import { searchUsersForMentions } from "@alga-psa/user-composition/actions";
+import { DEFAULT_BLOCK } from "./TicketConversation";
+import TicketNotificationSuppressionControl, {
+  type TicketNotificationSuppressionValue,
+} from "./TicketNotificationSuppressionControl";
+import { useTicketRichTextUploadSession } from "./useTicketRichTextUploadSession";
+
+const TextEditor = dynamic(
+  () => import("@alga-psa/ui/editor").then((mod) => mod.TextEditor),
+  {
+    loading: () => <RichTextEditorSkeleton height="200px" />,
+    ssr: false,
+  },
+);
+
+const defaultNotificationSuppression =
+  (): TicketNotificationSuppressionValue => ({
+    suppressContactNotifications: false,
+    suppressInternalNotifications: false,
+  });
 
 interface TicketResolutionDialogProps {
   id: string;
   isOpen: boolean;
+  ticketId: string;
+  currentUserId?: string | null;
   statusOptions: { value: string; label: string }[];
   isSubmitting?: boolean;
   onClose: () => void;
-  onConfirm: (statusId: string, resolution: string) => void;
+  onConfirm: (
+    statusId: string,
+    contentBlocks: PartialBlock[],
+    suppression: TicketNotificationSuppressionValue,
+  ) => void;
+  onClipboardImageUploaded?: () => Promise<void> | void;
+  uploadTicketAttachmentAction?: (
+    formData: FormData,
+    params: { userId: string; ticketId: string },
+  ) => Promise<unknown>;
+  deleteDraftTicketAttachmentImagesAction?: (input: {
+    ticketId: string;
+    documentIds: string[];
+  }) => Promise<{
+    deletedDocumentIds: string[];
+    failures: Array<{ documentId: string; reason: string }>;
+  }>;
+  resolveTicketAttachmentViewUrl?: (document: {
+    document_id?: string;
+    file_id?: string;
+  }) => string;
 }
 
 export default function TicketResolutionDialog({
   id,
   isOpen,
+  ticketId,
+  currentUserId,
   statusOptions,
   isSubmitting = false,
   onClose,
   onConfirm,
+  onClipboardImageUploaded,
+  uploadTicketAttachmentAction,
+  deleteDraftTicketAttachmentImagesAction,
+  resolveTicketAttachmentViewUrl,
 }: TicketResolutionDialogProps) {
-  const { t } = useTranslation('features/tickets');
+  const { t } = useTranslation("features/tickets");
   const [statusId, setStatusId] = useState<string | null>(null);
-  const [resolution, setResolution] = useState('');
+  const [content, setContent] = useState<PartialBlock[]>(DEFAULT_BLOCK);
+  const [editorKey, setEditorKey] = useState(0);
+  const [notificationSuppression, setNotificationSuppression] =
+    useState<TicketNotificationSuppressionValue>(
+      defaultNotificationSuppression,
+    );
   const formId = `${id}-form`;
-  const resolutionLabel = t('conversation.resolution', 'Resolution');
+
+  const discardEditor = useCallback(() => {
+    onClose();
+  }, [onClose]);
+
+  const uploadSession = useTicketRichTextUploadSession({
+    componentLabel: "TicketResolutionDialog",
+    ticketId,
+    userId: currentUserId,
+    trackDraftUploads: true,
+    onDocumentsChanged: onClipboardImageUploaded,
+    onDiscard: discardEditor,
+    uploadDocumentAction: uploadTicketAttachmentAction,
+    deleteDraftClipboardImagesAction: deleteDraftTicketAttachmentImagesAction,
+    resolveDocumentViewUrl: resolveTicketAttachmentViewUrl,
+  });
+  const resetDraftTracking = uploadSession.resetDraftTracking;
 
   useEffect(() => {
     if (isOpen) {
       setStatusId(statusOptions.length === 1 ? statusOptions[0].value : null);
-      setResolution('');
+      setContent(DEFAULT_BLOCK);
+      setEditorKey((currentKey) => currentKey + 1);
+      setNotificationSuppression(defaultNotificationSuppression());
+      resetDraftTracking();
     }
-  }, [isOpen, statusOptions]);
+  }, [isOpen, resetDraftTracking, statusOptions]);
 
-  const trimmedResolution = resolution.trim();
+  const hasContent = JSON.stringify(content) !== JSON.stringify(DEFAULT_BLOCK);
   const handleSubmit = (event: React.FormEvent<HTMLFormElement>) => {
     event.preventDefault();
-    if (!statusId || !trimmedResolution || isSubmitting) return;
-    onConfirm(statusId, trimmedResolution);
+    if (!statusId || !hasContent || isSubmitting) return;
+    uploadSession.resetDraftTracking();
+    onConfirm(statusId, content, notificationSuppression);
   };
 
   const footer = (
@@ -50,68 +126,104 @@ export default function TicketResolutionDialog({
         id={`${id}-cancel`}
         type="button"
         variant="ghost"
-        onClick={onClose}
+        onClick={uploadSession.requestDiscard}
         disabled={isSubmitting}
       >
-        {t('actions.cancel', 'Cancel')}
+        {t("actions.cancel", "Cancel")}
       </Button>
       <Button
         id={`${id}-confirm`}
         type="button"
-        disabled={!statusId || !trimmedResolution || isSubmitting}
-        onClick={() => (document.getElementById(formId) as HTMLFormElement | null)?.requestSubmit()}
+        disabled={!statusId || !hasContent || isSubmitting}
+        onClick={() =>
+          (
+            document.getElementById(formId) as HTMLFormElement | null
+          )?.requestSubmit()
+        }
       >
         {isSubmitting
-          ? t('info.closing', 'Closing…')
-          : t('info.resolveAndClose', 'Resolve and close')}
+          ? t("info.closing", "Closing…")
+          : t("info.resolveAndClose", "Resolve and close")}
       </Button>
     </div>
   );
 
   return (
-    <Dialog
-      id={id}
-      isOpen={isOpen}
-      onClose={onClose}
-      title={t('info.closeTicketTitle', 'Close ticket')}
-      className="max-w-lg"
-      footer={footer}
-    >
-      <DialogContent>
-        <form id={formId} className="space-y-4" onSubmit={handleSubmit}>
-          <p className="mb-4 text-sm text-[rgb(var(--color-text-600))]">
-            {t(
-              'info.closeTicketResolutionPrompt',
-              'Choose a close status and add a resolution for this ticket.',
-            )}
-          </p>
-          <CustomSelect
-            id={`${id}-status`}
-            label={t('conversation.closeStatus', 'Close status')}
-            value={statusId}
-            options={statusOptions}
-            onValueChange={setStatusId}
-            placeholder={t('info.selectCloseStatus', 'Select a close status')}
-            required
-            disabled={isSubmitting}
-          />
-          <TextArea
-            id={`${id}-resolution`}
-            label={resolutionLabel}
-            aria-label={resolutionLabel}
-            value={resolution}
-            onChange={(event) => setResolution(event.target.value)}
-            placeholder={t(
-              'info.closeTicketResolutionPlaceholder',
-              'Summarize the resolution for the ticket history and customer.',
-            )}
-            rows={4}
-            required
-            disabled={isSubmitting}
-            wrapperClassName="mb-0"
-          />
-        </form>
-      </DialogContent>
-    </Dialog>
+    <>
+      <Dialog
+        id={id}
+        isOpen={isOpen}
+        onClose={uploadSession.requestDiscard}
+        title={t("info.closeTicketTitle", "Close ticket")}
+        className="max-w-2xl"
+        footer={footer}
+      >
+        <DialogContent>
+          <form id={formId} className="space-y-4" onSubmit={handleSubmit}>
+            <p className="mb-4 text-sm text-[rgb(var(--color-text-600))]">
+              {t(
+                "info.closeTicketResolutionPrompt",
+                "Choose a close status and add a resolution for this ticket.",
+              )}
+            </p>
+            <CustomSelect
+              id={`${id}-status`}
+              label={t("conversation.closeStatus", "Close status")}
+              value={statusId}
+              options={statusOptions}
+              onValueChange={setStatusId}
+              placeholder={t("info.selectCloseStatus", "Select a close status")}
+              required
+              disabled={isSubmitting}
+            />
+            <div>
+              <Suspense
+                fallback={
+                  <RichTextEditorSkeleton
+                    height="200px"
+                    title={t("conversation.commentEditor", "Comment Editor")}
+                  />
+                }
+              >
+                <TextEditor
+                  id={`${id}-resolution`}
+                  key={editorKey}
+                  initialContent={DEFAULT_BLOCK}
+                  onContentChange={setContent}
+                  searchMentions={searchUsersForMentions}
+                  uploadFile={uploadSession.uploadFile}
+                  autoFocus
+                />
+              </Suspense>
+            </div>
+            <TicketNotificationSuppressionControl
+              idPrefix={`${id}-notification-suppression`}
+              value={notificationSuppression}
+              onChange={setNotificationSuppression}
+              disabled={isSubmitting}
+            />
+          </form>
+        </DialogContent>
+      </Dialog>
+      <ConfirmationDialog
+        id={`${id}-clipboard-draft-cancel-dialog`}
+        isOpen={uploadSession.showDraftCancelDialog}
+        onClose={() => uploadSession.setShowDraftCancelDialog(false)}
+        onConfirm={uploadSession.deleteTrackedDraftClipboardImages}
+        onCancel={uploadSession.keepDraftClipboardImages}
+        title={t(
+          "conversation.clipboardDraftCancelTitle",
+          "Pasted Images Detected",
+        )}
+        message={t(
+          "conversation.clipboardDraftCancelMessage",
+          "This draft includes pasted images that were already uploaded as ticket documents. Keep them, or delete them permanently?",
+        )}
+        confirmLabel={t("conversation.deleteUploadedImages", "Delete Images")}
+        thirdButtonLabel={t("conversation.keepUploadedImages", "Keep Images")}
+        cancelLabel={t("common.continueEditing", "Continue Editing")}
+        isConfirming={uploadSession.isDeletingDraftImages}
+      />
+    </>
   );
 }

--- a/packages/tickets/src/components/ticket/TicketResolutionDialog.tsx
+++ b/packages/tickets/src/components/ticket/TicketResolutionDialog.tsx
@@ -42,7 +42,7 @@ interface TicketResolutionDialogProps {
     statusId: string,
     contentBlocks: PartialBlock[],
     suppression: TicketNotificationSuppressionValue,
-  ) => void;
+  ) => Promise<boolean>;
   onClipboardImageUploaded?: () => Promise<void> | void;
   uploadTicketAttachmentAction?: (
     formData: FormData,
@@ -113,11 +113,17 @@ export default function TicketResolutionDialog({
   }, [isOpen, resetDraftTracking, statusOptions]);
 
   const hasContent = JSON.stringify(content) !== JSON.stringify(DEFAULT_BLOCK);
-  const handleSubmit = (event: React.FormEvent<HTMLFormElement>) => {
+  const handleSubmit = async (event: React.FormEvent<HTMLFormElement>) => {
     event.preventDefault();
     if (!statusId || !hasContent || isSubmitting) return;
-    uploadSession.resetDraftTracking();
-    onConfirm(statusId, content, notificationSuppression);
+    const resolutionSaved = await onConfirm(
+      statusId,
+      content,
+      notificationSuppression,
+    );
+    if (resolutionSaved) {
+      uploadSession.resetDraftTracking();
+    }
   };
 
   const footer = (

--- a/packages/tickets/src/components/ticket/TicketResolutionDialog.tsx
+++ b/packages/tickets/src/components/ticket/TicketResolutionDialog.tsx
@@ -10,7 +10,7 @@ import { Dialog, DialogContent } from "@alga-psa/ui/components/Dialog";
 import RichTextEditorSkeleton from "@alga-psa/ui/components/skeletons/RichTextEditorSkeleton";
 import { useTranslation } from "@alga-psa/ui/lib/i18n/client";
 import { searchUsersForMentions } from "@alga-psa/user-composition/actions";
-import { DEFAULT_BLOCK } from "./TicketConversation";
+import { createTicketRichTextParagraph } from "../../lib/ticketRichText";
 import TicketNotificationSuppressionControl, {
   type TicketNotificationSuppressionValue,
 } from "./TicketNotificationSuppressionControl";
@@ -23,6 +23,8 @@ const TextEditor = dynamic(
     ssr: false,
   },
 );
+
+const DEFAULT_RESOLUTION_BLOCK = createTicketRichTextParagraph("");
 
 const defaultNotificationSuppression =
   (): TicketNotificationSuppressionValue => ({
@@ -77,7 +79,9 @@ export default function TicketResolutionDialog({
 }: TicketResolutionDialogProps) {
   const { t } = useTranslation("features/tickets");
   const [statusId, setStatusId] = useState<string | null>(null);
-  const [content, setContent] = useState<PartialBlock[]>(DEFAULT_BLOCK);
+  const [content, setContent] = useState<PartialBlock[]>(
+    DEFAULT_RESOLUTION_BLOCK,
+  );
   const [editorKey, setEditorKey] = useState(0);
   const [notificationSuppression, setNotificationSuppression] =
     useState<TicketNotificationSuppressionValue>(
@@ -105,14 +109,15 @@ export default function TicketResolutionDialog({
   useEffect(() => {
     if (isOpen) {
       setStatusId(statusOptions.length === 1 ? statusOptions[0].value : null);
-      setContent(DEFAULT_BLOCK);
+      setContent(DEFAULT_RESOLUTION_BLOCK);
       setEditorKey((currentKey) => currentKey + 1);
       setNotificationSuppression(defaultNotificationSuppression());
       resetDraftTracking();
     }
   }, [isOpen, resetDraftTracking, statusOptions]);
 
-  const hasContent = JSON.stringify(content) !== JSON.stringify(DEFAULT_BLOCK);
+  const hasContent =
+    JSON.stringify(content) !== JSON.stringify(DEFAULT_RESOLUTION_BLOCK);
   const handleSubmit = async (event: React.FormEvent<HTMLFormElement>) => {
     event.preventDefault();
     if (!statusId || !hasContent || isSubmitting) return;
@@ -194,7 +199,7 @@ export default function TicketResolutionDialog({
                 <TextEditor
                   id={`${id}-resolution`}
                   key={editorKey}
-                  initialContent={DEFAULT_BLOCK}
+                  initialContent={DEFAULT_RESOLUTION_BLOCK}
                   onContentChange={setContent}
                   searchMentions={searchUsersForMentions}
                   uploadFile={uploadSession.uploadFile}

--- a/packages/tickets/src/components/ticket/__tests__/TicketDetails.liveTimerPolicy.test.tsx
+++ b/packages/tickets/src/components/ticket/__tests__/TicketDetails.liveTimerPolicy.test.tsx
@@ -191,6 +191,7 @@ vi.mock('@alga-psa/user-composition/actions', () => ({
   findUserById: vi.fn().mockResolvedValue(null),
   getCurrentUser: vi.fn().mockResolvedValue(null),
   getCurrentUserPermissions: vi.fn().mockResolvedValue([]),
+  searchUsersForMentions: vi.fn().mockResolvedValue([]),
 }));
 
 vi.mock('@alga-psa/reference-data/actions', () => ({

--- a/packages/tickets/src/components/ticket/__tests__/TicketDetails.remoteUpdates.test.tsx
+++ b/packages/tickets/src/components/ticket/__tests__/TicketDetails.remoteUpdates.test.tsx
@@ -195,6 +195,7 @@ vi.mock('@alga-psa/user-composition/actions', () => ({
   findUserById: vi.fn().mockResolvedValue(null),
   getCurrentUser: vi.fn().mockResolvedValue(null),
   getCurrentUserPermissions: vi.fn().mockResolvedValue([]),
+  searchUsersForMentions: vi.fn().mockResolvedValue([]),
 }));
 
 vi.mock('@alga-psa/reference-data/actions', () => ({

--- a/packages/tickets/src/components/ticket/__tests__/TicketDetailsCreateTask.test.tsx
+++ b/packages/tickets/src/components/ticket/__tests__/TicketDetailsCreateTask.test.tsx
@@ -183,6 +183,7 @@ vi.mock('@alga-psa/user-composition/actions', () => ({
   findUserById: vi.fn().mockResolvedValue(null),
   getCurrentUser: vi.fn().mockResolvedValue(null),
   getCurrentUserPermissions: vi.fn().mockResolvedValue([]),
+  searchUsersForMentions: vi.fn().mockResolvedValue([]),
 }));
 
 vi.mock('@alga-psa/tickets/actions', () => ({

--- a/packages/tickets/src/components/ticket/__tests__/TicketInfo.boardChangeStatusReselection.test.tsx
+++ b/packages/tickets/src/components/ticket/__tests__/TicketInfo.boardChangeStatusReselection.test.tsx
@@ -361,8 +361,8 @@ describe('TicketInfo board change status reselection', () => {
 
     await waitFor(() => {
       expect(getTicketStatusesMock).toHaveBeenCalledWith('board-a');
+      expect(statusSelect).toHaveValue('status-a');
     });
-    expect(statusSelect).toHaveValue('status-a');
     expect(saveButton).not.toBeDisabled();
 
     fireEvent.change(boardSelect, { target: { value: 'board-b' } });

--- a/packages/tickets/src/components/ticket/resolutionCommentPersistence.test.ts
+++ b/packages/tickets/src/components/ticket/resolutionCommentPersistence.test.ts
@@ -1,0 +1,38 @@
+import { describe, expect, it, vi } from 'vitest';
+
+import { persistResolutionComment } from './resolutionCommentPersistence';
+
+describe('persistResolutionComment', () => {
+    it('reports durable persistence success when the subsequent comment refresh fails', async () => {
+        const refreshError = new Error('comment refresh failed');
+        const onCommentsRefreshed = vi.fn();
+        const onRefreshError = vi.fn();
+
+        const persisted = await persistResolutionComment({
+            persistComment: vi.fn().mockResolvedValue(undefined),
+            refreshComments: vi.fn().mockRejectedValue(refreshError),
+            onCommentsRefreshed,
+            onRefreshError,
+        });
+
+        expect(persisted).toBe(true);
+        expect(onCommentsRefreshed).not.toHaveBeenCalled();
+        expect(onRefreshError).toHaveBeenCalledWith(refreshError);
+    });
+
+    it('does not report success when comment persistence fails', async () => {
+        const persistenceError = new Error('comment persistence failed');
+        const refreshComments = vi.fn();
+        const onRefreshError = vi.fn();
+
+        await expect(persistResolutionComment({
+            persistComment: vi.fn().mockRejectedValue(persistenceError),
+            refreshComments,
+            onCommentsRefreshed: vi.fn(),
+            onRefreshError,
+        })).rejects.toBe(persistenceError);
+
+        expect(refreshComments).not.toHaveBeenCalled();
+        expect(onRefreshError).not.toHaveBeenCalled();
+    });
+});

--- a/packages/tickets/src/components/ticket/resolutionCommentPersistence.ts
+++ b/packages/tickets/src/components/ticket/resolutionCommentPersistence.ts
@@ -1,0 +1,29 @@
+interface PersistResolutionCommentParams<TComment> {
+    persistComment: () => Promise<void>;
+    refreshComments: () => Promise<TComment[]>;
+    onCommentsRefreshed: (comments: TComment[]) => void;
+    onRefreshError: (error: unknown) => void;
+}
+
+/**
+ * Persists a resolution comment and then refreshes the local comment list.
+ * Once persistence succeeds, a best-effort refresh must not report the save as
+ * failed because callers use this result to release durable draft uploads.
+ */
+export async function persistResolutionComment<TComment>({
+    persistComment,
+    refreshComments,
+    onCommentsRefreshed,
+    onRefreshError,
+}: PersistResolutionCommentParams<TComment>): Promise<boolean> {
+    await persistComment();
+
+    try {
+        const comments = await refreshComments();
+        onCommentsRefreshed(comments);
+    } catch (error) {
+        onRefreshError(error);
+    }
+
+    return true;
+}

--- a/server/public/locales/de/features/tickets.json
+++ b/server/public/locales/de/features/tickets.json
@@ -874,7 +874,6 @@
     "resolveAndClose": "Lösen und schließen",
     "closeTicketResolutionPrompt": "Wählen Sie einen Schließstatus und fügen Sie eine Lösung für dieses Ticket hinzu.",
     "selectCloseStatus": "Schließstatus auswählen",
-    "closeTicketResolutionPlaceholder": "Fassen Sie die Lösung für den Ticketverlauf und den Kunden zusammen.",
     "cannotCloseYet": "Dieses Ticket kann noch nicht geschlossen werden",
     "closeRulesIntro": "Die Schließregeln des Boards erfordern Folgendes, bevor dieses Ticket geschlossen werden kann:",
     "viewChecklist": "Checkliste anzeigen",

--- a/server/public/locales/en/features/tickets.json
+++ b/server/public/locales/en/features/tickets.json
@@ -882,7 +882,6 @@
     "resolveAndClose": "Resolve and close",
     "closeTicketResolutionPrompt": "Choose a close status and add a resolution for this ticket.",
     "selectCloseStatus": "Select a close status",
-    "closeTicketResolutionPlaceholder": "Summarize the resolution for the ticket history and customer.",
     "cannotCloseYet": "This ticket can't be closed yet",
     "closeRulesIntro": "The board's close rules require the following before this ticket can be closed:",
     "viewChecklist": "View checklist",

--- a/server/public/locales/es/features/tickets.json
+++ b/server/public/locales/es/features/tickets.json
@@ -874,7 +874,6 @@
     "resolveAndClose": "Resolver y cerrar",
     "closeTicketResolutionPrompt": "Elige un estado de cierre y añade una resolución para este ticket.",
     "selectCloseStatus": "Selecciona un estado de cierre",
-    "closeTicketResolutionPlaceholder": "Resume la resolución para el historial del ticket y el cliente.",
     "cannotCloseYet": "Este ticket aún no se puede cerrar",
     "closeRulesIntro": "Las reglas de cierre del tablero requieren lo siguiente antes de poder cerrar este ticket:",
     "viewChecklist": "Ver lista de verificación",

--- a/server/public/locales/fr/features/tickets.json
+++ b/server/public/locales/fr/features/tickets.json
@@ -874,7 +874,6 @@
     "resolveAndClose": "Résoudre et fermer",
     "closeTicketResolutionPrompt": "Choisissez un statut de clôture et ajoutez une résolution pour ce ticket.",
     "selectCloseStatus": "Sélectionner un statut de clôture",
-    "closeTicketResolutionPlaceholder": "Résumez la résolution pour l’historique du ticket et le client.",
     "cannotCloseYet": "Ce ticket ne peut pas encore être fermé",
     "closeRulesIntro": "Les règles de fermeture du tableau exigent les éléments suivants avant que ce ticket puisse être fermé :",
     "viewChecklist": "Voir la liste de contrôle",

--- a/server/public/locales/it/features/tickets.json
+++ b/server/public/locales/it/features/tickets.json
@@ -874,7 +874,6 @@
     "resolveAndClose": "Risolvi e chiudi",
     "closeTicketResolutionPrompt": "Scegli uno stato di chiusura e aggiungi una risoluzione per questo ticket.",
     "selectCloseStatus": "Seleziona uno stato di chiusura",
-    "closeTicketResolutionPlaceholder": "Riassumi la risoluzione per la cronologia del ticket e per il cliente.",
     "cannotCloseYet": "Questo ticket non può ancora essere chiuso",
     "closeRulesIntro": "Le regole di chiusura della bacheca richiedono quanto segue prima di poter chiudere questo ticket:",
     "viewChecklist": "Visualizza checklist",

--- a/server/public/locales/nl/features/tickets.json
+++ b/server/public/locales/nl/features/tickets.json
@@ -874,7 +874,6 @@
     "resolveAndClose": "Oplossen en sluiten",
     "closeTicketResolutionPrompt": "Kies een afsluitstatus en voeg een oplossing voor dit ticket toe.",
     "selectCloseStatus": "Selecteer een afsluitstatus",
-    "closeTicketResolutionPlaceholder": "Vat de oplossing samen voor de ticketgeschiedenis en de klant.",
     "cannotCloseYet": "Dit ticket kan nog niet worden gesloten",
     "closeRulesIntro": "De sluitregels van het board vereisen het volgende voordat dit ticket kan worden gesloten:",
     "viewChecklist": "Checklist bekijken",

--- a/server/public/locales/pl/features/tickets.json
+++ b/server/public/locales/pl/features/tickets.json
@@ -984,7 +984,6 @@
     "resolveAndClose": "Rozwiąż i zamknij",
     "closeTicketResolutionPrompt": "Wybierz status zamknięcia i dodaj rozwiązanie tego zgłoszenia.",
     "selectCloseStatus": "Wybierz status zamknięcia",
-    "closeTicketResolutionPlaceholder": "Podsumuj rozwiązanie na potrzeby historii zgłoszenia i klienta.",
     "cannotCloseYet": "Tego zgłoszenia nie można jeszcze zamknąć",
     "closeRulesIntro": "Reguły zamykania tablicy wymagają spełnienia poniższych warunków przed zamknięciem tego zgłoszenia:",
     "viewChecklist": "Zobacz listę kontrolną",

--- a/server/public/locales/pt/features/tickets.json
+++ b/server/public/locales/pt/features/tickets.json
@@ -874,7 +874,6 @@
     "resolveAndClose": "Resolver e fechar",
     "closeTicketResolutionPrompt": "Escolha um status de fechamento e adicione uma resolução para este ticket.",
     "selectCloseStatus": "Selecione um status de fechamento",
-    "closeTicketResolutionPlaceholder": "Resuma a resolução para o histórico do ticket e para o cliente.",
     "cannotCloseYet": "Este ticket ainda não pode ser fechado",
     "closeRulesIntro": "As regras de fechamento do quadro exigem o seguinte antes que este ticket possa ser fechado:",
     "viewChecklist": "Ver checklist",

--- a/server/public/locales/xx/features/tickets.json
+++ b/server/public/locales/xx/features/tickets.json
@@ -882,7 +882,6 @@
     "resolveAndClose": "11111",
     "closeTicketResolutionPrompt": "11111",
     "selectCloseStatus": "11111",
-    "closeTicketResolutionPlaceholder": "11111",
     "cannotCloseYet": "11111",
     "closeRulesIntro": "11111",
     "viewChecklist": "11111",

--- a/server/public/locales/yy/features/tickets.json
+++ b/server/public/locales/yy/features/tickets.json
@@ -882,7 +882,6 @@
     "resolveAndClose": "55555",
     "closeTicketResolutionPrompt": "55555",
     "selectCloseStatus": "55555",
-    "closeTicketResolutionPlaceholder": "55555",
     "cannotCloseYet": "55555",
     "closeRulesIntro": "55555",
     "viewChecklist": "55555",

--- a/server/src/lib/eventBus/subscribers/__tests__/internalNotificationSubscriber.suppression.test.ts
+++ b/server/src/lib/eventBus/subscribers/__tests__/internalNotificationSubscriber.suppression.test.ts
@@ -8,6 +8,7 @@ const {
   resolveTicketNotificationSuppression,
   shouldCreateContactPortalTicketNotification,
   shouldCreateStaffTicketNotification,
+  shouldCreateTicketCommentNotification,
 } = internalNotificationSubscriberTestHarness;
 
 describe('internalNotificationSubscriber ticket suppression policy', () => {
@@ -56,5 +57,20 @@ describe('internalNotificationSubscriber ticket suppression policy', () => {
     expect(shouldCreateContactPortalTicketNotification(contactOnly)).toBe(false);
     expect(shouldCreateStaffTicketNotification(contactOnly)).toBe(true);
     expect(shouldCreateStaffTicketNotification(full)).toBe(false);
+  });
+
+  it('suppresses closing-resolution comment notifications for the selected recipient classes', () => {
+    const contactOnly = resolveTicketNotificationSuppression({
+      suppressContactNotifications: true,
+    });
+    const full = resolveTicketNotificationSuppression({
+      suppressContactNotifications: true,
+      suppressInternalNotifications: true,
+    });
+
+    expect(shouldCreateTicketCommentNotification(contactOnly, 'contact')).toBe(false);
+    expect(shouldCreateTicketCommentNotification(contactOnly, 'internal')).toBe(true);
+    expect(shouldCreateTicketCommentNotification(full, 'contact')).toBe(false);
+    expect(shouldCreateTicketCommentNotification(full, 'internal')).toBe(false);
   });
 });

--- a/server/src/lib/eventBus/subscribers/__tests__/ticketEmailSubscriber.suppression.test.ts
+++ b/server/src/lib/eventBus/subscribers/__tests__/ticketEmailSubscriber.suppression.test.ts
@@ -7,6 +7,7 @@ const {
   resolveAccumulatedTicketNotificationSuppression,
   shouldSendContactFacingTicketEmail,
   shouldSendInternalTicketEmail,
+  shouldSendTicketCommentNotification,
   shouldSendTicketWatcherEmail,
   shouldSendTicketClosedWatcherEmail,
 } = ticketEmailSubscriberTestHarness;
@@ -143,5 +144,20 @@ describe('ticketEmailSubscriber suppression policy', () => {
     expect(shouldSendInternalTicketEmail(contactOnly)).toBe(true);
     expect(shouldSendContactFacingTicketEmail(full)).toBe(false);
     expect(shouldSendInternalTicketEmail(full)).toBe(false);
+  });
+
+  it('suppresses closing-resolution comment emails for the selected recipient classes', () => {
+    const contactOnly = resolveTicketNotificationSuppression({
+      suppressContactNotifications: true,
+    });
+    const full = resolveTicketNotificationSuppression({
+      suppressContactNotifications: true,
+      suppressInternalNotifications: true,
+    });
+
+    expect(shouldSendTicketCommentNotification(contactOnly, 'contact')).toBe(false);
+    expect(shouldSendTicketCommentNotification(contactOnly, 'internal')).toBe(true);
+    expect(shouldSendTicketCommentNotification(full, 'contact')).toBe(false);
+    expect(shouldSendTicketCommentNotification(full, 'internal')).toBe(false);
   });
 });

--- a/server/src/lib/eventBus/subscribers/internalNotificationSubscriber.ts
+++ b/server/src/lib/eventBus/subscribers/internalNotificationSubscriber.ts
@@ -39,6 +39,15 @@ function shouldCreateStaffTicketNotification(suppression: TicketNotificationSupp
   return !suppression.suppressInternalNotifications;
 }
 
+function shouldCreateTicketCommentNotification(
+  suppression: TicketNotificationSuppression,
+  recipientType: 'contact' | 'internal',
+): boolean {
+  return recipientType === 'internal'
+    ? shouldCreateStaffTicketNotification(suppression)
+    : shouldCreateContactPortalTicketNotification(suppression);
+}
+
 /**
  * Handle ticket created events
  */
@@ -1560,6 +1569,7 @@ async function handleTaskCommentUpdated(event: TaskCommentUpdatedEvent): Promise
 async function handleTicketCommentAdded(event: TicketCommentAddedEvent): Promise<void> {
   const { payload } = event;
   const { tenantId, ticketId, userId, comment } = payload;
+  const suppression = resolveTicketNotificationSuppression(payload);
 
   console.log('[InternalNotificationSubscriber] handleTicketCommentAdded START', {
     ticketId,
@@ -1620,10 +1630,20 @@ async function handleTicketCommentAdded(event: TicketCommentAddedEvent): Promise
 
       if (resolvedMentionedUserIds.length > 0) {
         const mentionedUsers = await tenantScopedTable(db, 'users', tenantId)
-          .select('user_id', 'username', db.raw("CONCAT(first_name, ' ', last_name) as display_name"))
+          .select(
+            'user_id',
+            'username',
+            'user_type',
+            db.raw("CONCAT(first_name, ' ', last_name) as display_name"),
+          )
           .whereIn('user_id', resolvedMentionedUserIds);
+        const mentionedUsersToNotify = mentionedUsers.filter((mentionedUser) =>
+          shouldCreateTicketCommentNotification(
+            suppression,
+            mentionedUser.user_type === 'client' ? 'contact' : 'internal',
+          ));
 
-        if (mentionedUsers.length > 0) {
+        if (mentionedUsersToNotify.length > 0) {
           const { internalUrl } = await resolveNotificationLinks(db, tenantId, {
             type: 'ticket',
             ticketId,
@@ -1631,7 +1651,7 @@ async function handleTicketCommentAdded(event: TicketCommentAddedEvent): Promise
             commentId: comment?.id
           });
 
-          await Promise.all(mentionedUsers.map(mentionedUser => {
+          await Promise.all(mentionedUsersToNotify.map(mentionedUser => {
             notifiedUserIds.add(mentionedUser.user_id);
             return createNotificationFromTemplateInternal(db, {
               tenant: tenantId,
@@ -1662,7 +1682,7 @@ async function handleTicketCommentAdded(event: TicketCommentAddedEvent): Promise
 
           logger.info('[InternalNotificationSubscriber] Created mention notifications for ticket comment', {
             ticketId,
-            notifiedCount: mentionedUsers.length,
+            notifiedCount: mentionedUsersToNotify.length,
             tenantId
           });
         }
@@ -1677,7 +1697,10 @@ async function handleTicketCommentAdded(event: TicketCommentAddedEvent): Promise
     });
 
     // Notify all assigned agents (if not internal comment)
-    if (!comment?.isInternal) {
+    if (
+      !comment?.isInternal &&
+      shouldCreateTicketCommentNotification(suppression, 'internal')
+    ) {
       const allAssignees = await getAllTicketAssignees(db, tenantId, ticketId);
 
       for (const assigneeId of allAssignees) {
@@ -1719,7 +1742,12 @@ async function handleTicketCommentAdded(event: TicketCommentAddedEvent): Promise
 
     // Create notification for client contact if they have portal access (and are not the comment author)
     // Skip if comment is internal - internal comments are not visible to client portal users
-    if (ticket.contact_name_id && !comment?.isInternal && ticketPortalUrl) {
+    if (
+      ticket.contact_name_id &&
+      !comment?.isInternal &&
+      ticketPortalUrl &&
+      shouldCreateTicketCommentNotification(suppression, 'contact')
+    ) {
       const contactUser = await tenantScopedTable(db, 'users', tenantId)
         .select('user_id', 'user_type')
         .where({
@@ -2856,6 +2884,7 @@ export const internalNotificationSubscriberTestHarness = {
   resolveTicketNotificationSuppression,
   shouldCreateContactPortalTicketNotification,
   shouldCreateStaffTicketNotification,
+  shouldCreateTicketCommentNotification,
   handleTicketAssigned,
   handleTicketUpdated,
   handleTicketClosed,

--- a/server/src/lib/eventBus/subscribers/ticketEmailSubscriber.ts
+++ b/server/src/lib/eventBus/subscribers/ticketEmailSubscriber.ts
@@ -140,6 +140,15 @@ function shouldSendInternalTicketEmail(suppression: TicketNotificationSuppressio
   return !suppression.suppressInternalNotifications;
 }
 
+function shouldSendTicketCommentNotification(
+  suppression: TicketNotificationSuppression,
+  recipientType: 'contact' | 'internal',
+): boolean {
+  return recipientType === 'internal'
+    ? shouldSendInternalTicketEmail(suppression)
+    : shouldSendContactFacingTicketEmail(suppression);
+}
+
 function shouldSendTicketWatcherEmail(
   suppression: TicketNotificationSuppression,
   isInternalWatcher: boolean
@@ -2425,6 +2434,7 @@ async function handleTicketAssigned(event: TicketAssignedEvent): Promise<void> {
 async function handleTicketCommentAdded(event: TicketCommentAddedEvent): Promise<void> {
   const { payload } = event;
   const { tenantId } = payload;
+  const suppression = resolveTicketNotificationSuppression(payload);
   // Resolve userId from base field, falling back to legacy
   const commentUserId = payload.actorUserId || (payload as any).userId;
 
@@ -2713,7 +2723,13 @@ async function handleTicketCommentAdded(event: TicketCommentAddedEvent): Promise
     );
 
     // Send to primary email if available - external user, no userId
-    if (primaryEmail && isPublicComment && isFromAgent && !isPrimaryContactAuthor) {
+    if (
+      primaryEmail &&
+      isPublicComment &&
+      isFromAgent &&
+      !isPrimaryContactAuthor &&
+      shouldSendTicketCommentNotification(suppression, 'contact')
+    ) {
       // Extract threading info from ticket metadata
       const messageId = emailMetadata.messageId; // Original message ID from inbound email
       
@@ -2754,7 +2770,9 @@ async function handleTicketCommentAdded(event: TicketCommentAddedEvent): Promise
 
     // If this ticket is a bundle master, default behavior is to notify all child requesters for public comments.
     if (isPublicComment && isFromAgent) {
-      const bundleChildren = await fetchBundleChildTicketsForEmail(db, tenantId, payload.ticketId);
+      const bundleChildren = shouldSendTicketCommentNotification(suppression, 'contact')
+        ? await fetchBundleChildTicketsForEmail(db, tenantId, payload.ticketId)
+        : [];
 
       if (bundleChildren.length > 0) {
         const bundlePortalCtx = await resolvePortalLinkContext(db, tenantId);
@@ -2817,7 +2835,20 @@ async function handleTicketCommentAdded(event: TicketCommentAddedEvent): Promise
       await sendOneEmailPerWatcher(
         activeWatcherEmails,
         async (watcherEmail) => {
-          const watcherUrl = internalWatcherEmails.has(normalizeRecipientEmail(watcherEmail)) ? internalUrl : portalUrl;
+          const isInternalWatcher = internalWatcherEmails.has(normalizeRecipientEmail(watcherEmail));
+          if (!shouldSendTicketCommentNotification(
+            suppression,
+            isInternalWatcher ? 'internal' : 'contact',
+          )) {
+            logger.debug('[TicketEmailSubscriber] Skipped ticket comment watcher email due to suppression', {
+              eventId: event.id,
+              ticketId: payload.ticketId,
+              tenantId,
+              watcherType: isInternalWatcher ? 'internal' : 'external',
+            });
+            return;
+          }
+          const watcherUrl = isInternalWatcher ? internalUrl : portalUrl;
           await sendIfUnique({
             tenantId,
             ...emailEntityContext,
@@ -2845,7 +2876,12 @@ async function handleTicketCommentAdded(event: TicketCommentAddedEvent): Promise
       commentAuthorUserId &&
       ticket.assigned_to === commentAuthorUserId
     );
-    if (assignedEmail && assignedEmail !== primaryEmail && !isAssignedUserTheCommentAuthor) {
+    if (
+      assignedEmail &&
+      assignedEmail !== primaryEmail &&
+      !isAssignedUserTheCommentAuthor &&
+      shouldSendTicketCommentNotification(suppression, 'internal')
+    ) {
       await sendIfUnique({
         tenantId,
         ...emailEntityContext,
@@ -2864,7 +2900,10 @@ async function handleTicketCommentAdded(event: TicketCommentAddedEvent): Promise
     }
 
     // Send to all additional resources, excluding the comment author
-    for (const resource of additionalResources) {
+    const resourcesToNotify = shouldSendTicketCommentNotification(suppression, 'internal')
+      ? additionalResources
+      : [];
+    for (const resource of resourcesToNotify) {
       // Skip if this resource is the comment author - they shouldn't be notified about their own comment
       const isResourceTheCommentAuthor = Boolean(
         commentAuthorUserId &&
@@ -3345,6 +3384,7 @@ export const ticketEmailSubscriberTestHarness = {
   resolveAccumulatedTicketNotificationSuppression,
   shouldSendContactFacingTicketEmail,
   shouldSendInternalTicketEmail,
+  shouldSendTicketCommentNotification,
   shouldSendTicketWatcherEmail,
   shouldSendTicketClosedWatcherEmail,
   handleTicketCreated,


### PR DESCRIPTION
## Summary

- Replace the close-ticket resolution textarea with the BlockNote rich-text editor, including mentions, uploads, pasted-image cleanup, and durable draft-image tracking through asynchronous persistence.
- Add contact and internal notification-suppression controls to the close dialog, reset both controls unchecked on every open, and propagate the selected values through normal close and blocked-close override paths.
- Publish suppression flags on close-resolution comment events and gate email and in-app subscribers by contact versus internal recipients.
- Keep a successfully persisted resolution successful even if the subsequent comment-list refresh fails.
- Add focused dialog, persistence, event, and subscriber coverage, plus stabilize affected aggregate-load tests.

## Validation

- 36 focused tests passed.
- Tickets and server typechecks passed; server typecheck used a 12 GB Node heap because lower heap limits exhausted memory in this worktree.
- Full production build passed.

### Live smoke test — PASS

Exercised the real port-3432 product on TIC1001 using PostgreSQL, Redis, notification subscribers, and the configured email service. Verified: close dialog renders the rich-text editor; both suppression controls default/reset unchecked; contact-only suppression emits true/false, saves the resolution, closes the ticket, suppresses Alice while allowing Tin’s notifications; full suppression emits true/true and produced zero ticket emails or in-app notifications; unsuppressed regression emits false/false and delivered Tin’s in-app notifications plus sent emails to Alice and Tin. DB and Redis verified every mutation beyond UI evidence. No mocks or simulators used.

Fidelity compromise: the required card-created alga-dev browser pane was rejected as belonging to another host, and auto-targeting selected an unrelated pane, so UI driving stepped down to a local headless Chrome/Puppeteer harness against the same real product. Shared default Redis streams also had competing worktree consumers; subscriber assertions were rerun with a temporary unique REDIS_PREFIX consumed only by this branch, then port 3432 was restored to its normal prefix and confirmed HTTP 200.

The worktree remains unchanged apart from the pre-existing package files and reasoning.effort=high. TIC1001 was left closed with smoke resolution comments.

Concern: shared default Redis consumers can contaminate cross-worktree notification smoke results; this was recorded as a durable card fact.

Evidence: /tmp/alga-smoke-evidence/notification-suppression-close-popup-20260717-195518