### PR TITLE
Cannot paginate email logs

### DIFF
--- a/docs/plans/2026-07-17-email-log-pagination-plan.md
+++ b/docs/plans/2026-07-17-email-log-pagination-plan.md
@@ -1,0 +1,103 @@
+# Fix email log pagination snap-back
+
+Branch: `fix/email-log-pagination`
+
+## Problem
+
+On `/msp/email-logs` (System Monitoring → Email Logs), clicking page 2 renders page 2
+momentarily, then the table snaps back to page 1. Pagination beyond page 1 is unusable.
+
+## Diagnosis (confirmed in code)
+
+`server/src/app/msp/email-logs/EmailLogsClient.tsx` fetches through a `fetchLogs`
+`useCallback` whose dependency array includes `page` (line 135). Two filter effects list
+`fetchLogs` in their dependencies and both call `fetchLogs({ page: 1 })`:
+
+- debounced text-filter effect (lines 139–150)
+- discrete-filter effect (lines 153–163)
+
+Clicking page 2 runs `setPage(2)` and fetches page 2 — but the state change recreates
+`fetchLogs`, which retriggers both filter effects, which immediately refetch page 1 and
+overwrite the result. The `hasInitialized*` refs only guard each effect's first run, not
+subsequent `fetchLogs` identity changes.
+
+Two adjacent defects on the same screen, in scope:
+
+1. **Default `pageSize` mismatch** — the client seeds `pageSize: 50`
+   (`EmailLogsClient.tsx:45`) while the server action defaults to 25
+   (`packages/email/src/actions/emailLogActions.ts:147`).
+2. **Empty-then-populate flash** — `page.tsx` is `force-dynamic` but never passes
+   `initialLogs`/`initialMetrics` (props the client already supports), so first paint is
+   always an empty table followed by a client fetch.
+
+Out of scope (noted, untouched): `getEmailLogsForTicket` silently caps at 200 rows with no
+pagination — a different UI surface.
+
+## Fix: single state-driven fetch effect
+
+Restructure `EmailLogsClient` so there is exactly one fetch path and handlers only set
+state. The snap-back bug becomes structurally impossible: no `useCallback` identity in any
+dependency array, no competing effects.
+
+### 1. `EmailLogsClient.tsx`
+
+**State.** Keep the existing query state (`page`, `pageSize`, `sortBy`, `sortDirection`,
+`status`, `startDate`, `endDate`, `recipientEmail`, `ticketNumber`). Add
+`debouncedRecipient` and `debouncedTicket`, synced from the raw text values by one 300ms
+debounce effect. Add a `refreshKey` counter.
+
+**Fetch effect.** One `useEffect` calls `getEmailLogs` with the current query state. Its
+dependencies are exactly the real query inputs: `page`, `pageSize`, `sortBy`,
+`sortDirection`, `status`, `startDate`, `endDate`, `debouncedRecipient`,
+`debouncedTicket`, `refreshKey`. Details:
+
+- A request-sequence ref (`const seq = ++seqRef.current`; ignore the result unless
+  `seq === seqRef.current`) so a stale response resolving late cannot overwrite a newer
+  one. Rapid page clicks currently race.
+- Do **not** write `result.page`/`result.pageSize` back into state — client state is the
+  source of truth; only `setLogs(result.data)` and `setTotal(result.total)`. This removes
+  the other half of the feedback loop.
+- Skip the very first run when `initialLogs` was provided (one ref guard — the only ref
+  that remains).
+
+**Handlers become pure setters.**
+
+- `onPageChange` → `setPage(n)`
+- `onItemsPerPageChange` → `setPageSize(n); setPage(1)`
+- `onSortChange` → `setSortBy(...); setSortDirection(...); setPage(1)`
+- discrete filter changes (`status`, `startDate`, `endDate`) → set value; also `setPage(1)`
+- debounce effect, when it commits a text value → also `setPage(1)`
+- Refresh button → `setRefreshKey(k => k + 1); void fetchMetrics()`
+
+React batches setter pairs, so "filter change while on page 3" produces one fetch of
+page 1 with the new filter. Delete `fetchLogs`, both `hasInitialized*` refs, and every
+direct `fetchLogs(...)` call site.
+
+The `LEVERAGE: pattern datatable-filter-paging` marker at line 94 stays — this is still
+the per-table pattern, just a correct instance of it.
+
+### 2. `page.tsx` — SSR seeding
+
+In the server component, call
+`getEmailLogs({ page: 1, pageSize: 50, sortBy: 'sent_at', sortDirection: 'desc' })` and
+`getEmailLogMetrics()`, pass results as `initialLogs`/`initialMetrics`. Wrap in
+try/catch falling back to `undefined` props so a server-side failure degrades to today's
+client-fetch behavior instead of breaking the page.
+
+### 3. `emailLogActions.ts` — default alignment
+
+Change the `getEmailLogs` default `pageSize` from 25 to 50 to match the UI seed.
+
+## Verification
+
+Live against the wired dev stack (`http://localhost:3880/msp/email-logs`, Compose project
+`alga-psa-local-test`, Postgres on 5472). If the local DB has fewer than ~51 email log
+rows, seed enough via SQL for the tenant to produce multiple pages.
+
+1. Click page 2 → page 2 renders **and stays**; page 3 likewise.
+2. On page 3, change the status filter → returns to page 1 showing filtered results.
+3. Type in the recipient filter → single debounced fetch, page resets to 1.
+4. Change page size → table reloads at page 1 with the new size.
+5. Refresh button → logs and metrics refetch, current filters preserved.
+6. Hard-reload the page → first paint shows rows (no empty-table flash).
+7. Rapid-click pages 2→3→4 → final table shows page 4's rows (no stale overwrite).

--- a/packages/email/src/actions/emailLogActions.ts
+++ b/packages/email/src/actions/emailLogActions.ts
@@ -144,7 +144,7 @@ export const getEmailLogs = withAuth(
     const { knex } = await createTenantKnex();
 
     const page = Math.max(1, filters.page ?? 1);
-    const pageSize = Math.min(Math.max(filters.pageSize ?? 25, 1), 200);
+    const pageSize = Math.min(Math.max(filters.pageSize ?? 50, 1), 200);
     const sortDirection = filters.sortDirection === 'asc' ? 'asc' : 'desc';
     const offset = (page - 1) * pageSize;
 

--- a/server/src/app/msp/email-logs/EmailLogsClient.tsx
+++ b/server/src/app/msp/email-logs/EmailLogsClient.tsx
@@ -97,19 +97,42 @@ export default function EmailLogsClient({ initialMetrics, initialLogs }: EmailLo
   const [endDate, setEndDate] = useState<string>('');
   const [recipientEmail, setRecipientEmail] = useState<string>('');
   const [ticketNumber, setTicketNumber] = useState<string>('');
+  const [debouncedRecipient, setDebouncedRecipient] = useState<string>('');
+  const [debouncedTicket, setDebouncedTicket] = useState<string>('');
+  const [refreshKey, setRefreshKey] = useState(0);
 
   const [isLoading, setIsLoading] = useState(false);
   const [selected, setSelected] = useState<EmailSendingLogListRecord | null>(null);
-  const hasInitializedTextFilterEffect = useRef(false);
-  const hasInitializedDiscreteFilterEffect = useRef(false);
+  const skipInitialFetchRef = useRef(Boolean(initialLogs));
+  const requestSequenceRef = useRef(0);
 
   const fetchMetrics = useCallback(async () => {
     const result = await getEmailLogMetrics();
     setMetrics(result);
   }, []);
 
-  const fetchLogs = useCallback(
-    async (next: Partial<EmailLogFilters> = {}) => {
+  // Debounce text-based filters to avoid spamming server actions.
+  useEffect(() => {
+    const timer = setTimeout(() => {
+      if (recipientEmail !== debouncedRecipient || ticketNumber !== debouncedTicket) {
+        setDebouncedRecipient(recipientEmail);
+        setDebouncedTicket(ticketNumber);
+        setPage(1);
+      }
+    }, 300);
+
+    return () => clearTimeout(timer);
+  }, [recipientEmail, ticketNumber, debouncedRecipient, debouncedTicket]);
+
+  useEffect(() => {
+    if (skipInitialFetchRef.current) {
+      skipInitialFetchRef.current = false;
+      return;
+    }
+
+    const requestSequence = ++requestSequenceRef.current;
+
+    const fetchLogs = async () => {
       setIsLoading(true);
       try {
         const result = await getEmailLogs({
@@ -120,47 +143,34 @@ export default function EmailLogsClient({ initialMetrics, initialLogs }: EmailLo
           startDate: startDate || undefined,
           endDate: endDate || undefined,
           status: status ? (status as any) : undefined,
-          recipientEmail: recipientEmail || undefined,
-          ticketNumber: ticketNumber || undefined,
-          ...next,
+          recipientEmail: debouncedRecipient || undefined,
+          ticketNumber: debouncedTicket || undefined,
         });
+
+        if (requestSequence !== requestSequenceRef.current) return;
+
         setLogs(result.data);
         setTotal(result.total);
-        setPage(result.page);
-        setPageSize(result.pageSize);
       } finally {
-        setIsLoading(false);
+        if (requestSequence === requestSequenceRef.current) {
+          setIsLoading(false);
+        }
       }
-    },
-    [page, pageSize, sortBy, sortDirection, startDate, endDate, status, recipientEmail, ticketNumber]
-  );
+    };
 
-  // Debounce text-based filters to avoid spamming server actions
-  useEffect(() => {
-    if (!hasInitializedTextFilterEffect.current) {
-      hasInitializedTextFilterEffect.current = true;
-      return;
-    }
-
-    const timer = setTimeout(() => {
-      void fetchLogs({ page: 1 });
-    }, 300);
-
-    return () => clearTimeout(timer);
-  }, [recipientEmail, ticketNumber, fetchLogs]);
-
-  // Immediate refresh for discrete filters
-  useEffect(() => {
-    if (!hasInitializedDiscreteFilterEffect.current) {
-      hasInitializedDiscreteFilterEffect.current = true;
-      if (!initialLogs) {
-        void fetchLogs({ page: 1 });
-      }
-      return;
-    }
-
-    void fetchLogs({ page: 1 });
-  }, [status, startDate, endDate, fetchLogs, initialLogs]);
+    void fetchLogs();
+  }, [
+    page,
+    pageSize,
+    sortBy,
+    sortDirection,
+    status,
+    startDate,
+    endDate,
+    debouncedRecipient,
+    debouncedTicket,
+    refreshKey,
+  ]);
 
   useEffect(() => {
     if (initialMetrics) return;
@@ -244,7 +254,10 @@ export default function EmailLogsClient({ initialMetrics, initialLogs }: EmailLo
                 clearable
                 className="w-full"
                 value={dateFromString(startDate)}
-                onChange={(date) => setStartDate(dateToString(date))}
+                onChange={(date) => {
+                  setStartDate(dateToString(date));
+                  setPage(1);
+                }}
               />
             </div>
             <div>
@@ -256,15 +269,27 @@ export default function EmailLogsClient({ initialMetrics, initialLogs }: EmailLo
                 clearable
                 className="w-full"
                 value={dateFromString(endDate)}
-                onChange={(date) => setEndDate(dateToString(date))}
+                onChange={(date) => {
+                  setEndDate(dateToString(date));
+                  setPage(1);
+                }}
               />
             </div>
             <div>
-              <label className="block text-sm font-medium text-[rgb(var(--color-text-700))] mb-1">{t('emailLogs.filters.status')}</label>
+              <label
+                htmlFor="email-logs-filter-status"
+                className="block text-sm font-medium text-[rgb(var(--color-text-700))] mb-1"
+              >
+                {t('emailLogs.filters.status')}
+              </label>
               <select
+                id="email-logs-filter-status"
                 className="w-full h-10 rounded-md border border-[rgb(var(--color-border-400))] bg-white px-3 text-sm"
                 value={status}
-                onChange={(e) => setStatus(e.target.value)}
+                onChange={(e) => {
+                  setStatus(e.target.value);
+                  setPage(1);
+                }}
               >
                 <option value="">{t('emailLogs.filters.statusOptions.all')}</option>
                 <option value="sent">{t('emailLogs.filters.statusOptions.sent')}</option>
@@ -297,7 +322,7 @@ export default function EmailLogsClient({ initialMetrics, initialLogs }: EmailLo
               id="email-logs-refresh"
               variant="outline"
               onClick={() => {
-                void fetchLogs({ page: 1 });
+                setRefreshKey((key) => key + 1);
                 void fetchMetrics();
               }}
               disabled={isLoading}
@@ -314,14 +339,10 @@ export default function EmailLogsClient({ initialMetrics, initialLogs }: EmailLo
           currentPage={page}
           pageSize={pageSize}
           totalItems={total}
-          onPageChange={(nextPage) => {
-            setPage(nextPage);
-            void fetchLogs({ page: nextPage });
-          }}
+          onPageChange={(nextPage) => setPage(nextPage)}
           onItemsPerPageChange={(nextSize) => {
             setPageSize(nextSize);
             setPage(1);
-            void fetchLogs({ page: 1, pageSize: nextSize });
           }}
           manualSorting
           sortBy={sortBy}
@@ -330,7 +351,6 @@ export default function EmailLogsClient({ initialMetrics, initialLogs }: EmailLo
             setSortBy(nextSortBy as any);
             setSortDirection(nextDirection);
             setPage(1);
-            void fetchLogs({ page: 1, sortBy: nextSortBy as any, sortDirection: nextDirection });
           }}
           onRowClick={(record) => setSelected(record)}
         />

--- a/server/src/app/msp/email-logs/page.tsx
+++ b/server/src/app/msp/email-logs/page.tsx
@@ -1,6 +1,7 @@
 import SystemMonitoringWrapper from '@alga-psa/ui/components/system-monitoring/SystemMonitoringWrapper';
 import EmailLogsClient from './EmailLogsClient';
 import { getServerTranslation } from '@alga-psa/ui/lib/i18n/serverOnly';
+import { getEmailLogMetrics, getEmailLogs } from '@alga-psa/email/actions';
 import type { Metadata } from 'next';
 
 export const metadata: Metadata = {
@@ -11,6 +12,18 @@ export const dynamic = 'force-dynamic';
 
 export default async function EmailLogsPage() {
   const { t } = await getServerTranslation(undefined, 'common');
+  let initialLogs: Awaited<ReturnType<typeof getEmailLogs>> | undefined;
+  let initialMetrics: Awaited<ReturnType<typeof getEmailLogMetrics>> | undefined;
+
+  try {
+    [initialLogs, initialMetrics] = await Promise.all([
+      getEmailLogs({ page: 1, pageSize: 50, sortBy: 'sent_at', sortDirection: 'desc' }),
+      getEmailLogMetrics(),
+    ]);
+  } catch (error) {
+    console.error('Failed to preload email logs:', error);
+  }
+
   return (
     <SystemMonitoringWrapper>
       <div className="space-y-6">
@@ -21,7 +34,7 @@ export default async function EmailLogsPage() {
           </p>
         </div>
 
-        <EmailLogsClient />
+        <EmailLogsClient initialLogs={initialLogs} initialMetrics={initialMetrics} />
       </div>
     </SystemMonitoringWrapper>
   );

--- a/server/src/test/unit/email/EmailLogsClient.ui.test.tsx
+++ b/server/src/test/unit/email/EmailLogsClient.ui.test.tsx
@@ -3,12 +3,13 @@
  */
 import React from 'react';
 import { describe, expect, it, vi, beforeEach, afterEach } from 'vitest';
-import { cleanup, fireEvent, render, screen, waitFor, within } from '@testing-library/react';
+import { act, cleanup, fireEvent, render, screen, waitFor, within } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import EmailLogsClient from 'server/src/app/msp/email-logs/EmailLogsClient';
 
 vi.mock('@alga-psa/email/actions', () => ({
   getEmailLogs: vi.fn(),
+  getEmailLogMetrics: vi.fn(),
 }));
 
 vi.mock('@alga-psa/ui/components/Card', () => ({
@@ -55,20 +56,25 @@ vi.mock('@alga-psa/ui/components/Dialog', () => ({
 }));
 
 vi.mock('@alga-psa/ui/components/DataTable', () => ({
-  DataTable: ({ data, columns, onRowClick }: any) => (
-    <table>
-      <tbody>
-        {data.map((row: any, idx: number) => (
-          <tr key={row.id ?? idx} onClick={() => onRowClick?.(row)}>
-            {columns.map((col: any, colIdx: number) => {
-              const value = row[col.dataIndex];
-              const cell = col.render ? col.render(value, row, idx) : String(value ?? '');
-              return <td key={colIdx}>{cell}</td>;
-            })}
-          </tr>
-        ))}
-      </tbody>
-    </table>
+  DataTable: ({ data, columns, currentPage, onPageChange, onRowClick }: any) => (
+    <div>
+      <div data-testid="current-page">{currentPage}</div>
+      <button onClick={() => onPageChange?.(2)}>Page 2</button>
+      <button onClick={() => onPageChange?.(3)}>Page 3</button>
+      <table>
+        <tbody>
+          {data.map((row: any, idx: number) => (
+            <tr key={row.id ?? idx} onClick={() => onRowClick?.(row)}>
+              {columns.map((col: any, colIdx: number) => {
+                const value = row[col.dataIndex];
+                const cell = col.render ? col.render(value, row, idx) : String(value ?? '');
+                return <td key={colIdx}>{cell}</td>;
+              })}
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
   ),
 }));
 
@@ -126,30 +132,100 @@ describe('EmailLogsClient', () => {
     });
   });
 
-  it('updates results when date range filter changes', async () => {
-    getEmailLogsMock
-      .mockResolvedValueOnce({ data: [], total: 0, page: 1, pageSize: 50, totalPages: 0 } as any)
-      .mockResolvedValueOnce({
-        data: [
-          {
-            id: 1,
-            sent_at: '2026-01-01T00:00:00Z',
-            ticket_number: '123',
-            to_addresses: ['to@example.com'],
-            subject: 'Filtered',
-            status: 'sent',
-            provider_type: 'test',
-            provider_id: 'p',
-            message_id: 'm1',
-            from_address: 'from@example.com',
-            metadata: {},
-          },
-        ],
-        total: 1,
-        page: 1,
+  it('keeps the requested page active without refetching page 1', async () => {
+    const user = userEvent.setup();
+
+    render(
+      <EmailLogsClient
+        initialMetrics={{ total: 0, failed: 0, today: 0, failedRate: 0 }}
+        initialLogs={{ data: [], total: 150, page: 1, pageSize: 50, totalPages: 3 }}
+      />
+    );
+
+    await user.click(screen.getByRole('button', { name: 'Page 2' }));
+
+    await waitFor(() => {
+      expect(getEmailLogsMock).toHaveBeenCalledTimes(1);
+      expect(getEmailLogsMock).toHaveBeenLastCalledWith(expect.objectContaining({ page: 2 }));
+    });
+
+    await new Promise((resolve) => setTimeout(resolve, 350));
+
+    expect(screen.getByTestId('current-page').textContent).toBe('2');
+    expect(getEmailLogsMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('ignores a stale page response that resolves after the latest request', async () => {
+    let resolvePage2: (value: any) => void = () => undefined;
+    let resolvePage3: (value: any) => void = () => undefined;
+    const page2Result = new Promise((resolve) => { resolvePage2 = resolve; });
+    const page3Result = new Promise((resolve) => { resolvePage3 = resolve; });
+
+    getEmailLogsMock.mockImplementation(({ page }: any) => {
+      if (page === 2) return page2Result as any;
+      if (page === 3) return page3Result as any;
+      throw new Error(`Unexpected page ${page}`);
+    });
+
+    render(
+      <EmailLogsClient
+        initialMetrics={{ total: 0, failed: 0, today: 0, failedRate: 0 }}
+        initialLogs={{ data: [], total: 150, page: 1, pageSize: 50, totalPages: 3 }}
+      />
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: 'Page 2' }));
+    await waitFor(() => expect(getEmailLogsMock).toHaveBeenCalledWith(expect.objectContaining({ page: 2 })));
+
+    fireEvent.click(screen.getByRole('button', { name: 'Page 3' }));
+    await waitFor(() => expect(getEmailLogsMock).toHaveBeenCalledWith(expect.objectContaining({ page: 3 })));
+
+    resolvePage3({
+      data: [{ id: 3, subject: 'Newest page', sent_at: '2026-01-03T00:00:00Z', status: 'sent' }],
+      total: 150,
+      page: 3,
+      pageSize: 50,
+      totalPages: 3,
+    });
+    await waitFor(() => expect(screen.getByText('Newest page')).toBeTruthy());
+
+    await act(async () => {
+      resolvePage2({
+        data: [{ id: 2, subject: 'Stale page', sent_at: '2026-01-02T00:00:00Z', status: 'sent' }],
+        total: 150,
+        page: 2,
         pageSize: 50,
-        totalPages: 1,
-      } as any);
+        totalPages: 3,
+      });
+      await page2Result;
+    });
+
+    expect(screen.queryByText('Stale page')).toBeNull();
+    expect(screen.getByText('Newest page')).toBeTruthy();
+  });
+
+  it('updates results when date range filter changes', async () => {
+    getEmailLogsMock.mockResolvedValueOnce({
+      data: [
+        {
+          id: 1,
+          sent_at: '2026-01-01T00:00:00Z',
+          ticket_number: '123',
+          to_addresses: ['to@example.com'],
+          subject: 'Filtered',
+          status: 'sent',
+          provider_type: 'test',
+          provider_id: 'p',
+          message_id: 'm1',
+          from_address: 'from@example.com',
+          metadata: {},
+        },
+      ],
+      total: 1,
+      page: 1,
+      pageSize: 50,
+      totalPages: 1,
+    } as any);
 
     render(
       <EmailLogsClient
@@ -170,29 +246,27 @@ describe('EmailLogsClient', () => {
   });
 
   it('updates results when recipient search changes', async () => {
-    getEmailLogsMock
-      .mockResolvedValueOnce({ data: [], total: 0, page: 1, pageSize: 50, totalPages: 0 } as any)
-      .mockResolvedValueOnce({
-        data: [
-          {
-            id: 1,
-            sent_at: '2026-01-01T00:00:00Z',
-            ticket_number: '123',
-            to_addresses: ['alice@example.com'],
-            subject: 'Recipient filtered',
-            status: 'sent',
-            provider_type: 'test',
-            provider_id: 'p',
-            message_id: 'm1',
-            from_address: 'from@example.com',
-            metadata: {},
-          },
-        ],
-        total: 1,
-        page: 1,
-        pageSize: 50,
-        totalPages: 1,
-      } as any);
+    getEmailLogsMock.mockResolvedValueOnce({
+      data: [
+        {
+          id: 1,
+          sent_at: '2026-01-01T00:00:00Z',
+          ticket_number: '123',
+          to_addresses: ['alice@example.com'],
+          subject: 'Recipient filtered',
+          status: 'sent',
+          provider_type: 'test',
+          provider_id: 'p',
+          message_id: 'm1',
+          from_address: 'from@example.com',
+          metadata: {},
+        },
+      ],
+      total: 1,
+      page: 1,
+      pageSize: 50,
+      totalPages: 1,
+    } as any);
 
     render(
       <EmailLogsClient
@@ -214,29 +288,27 @@ describe('EmailLogsClient', () => {
   });
 
   it('updates results when ticket filter changes', async () => {
-    getEmailLogsMock
-      .mockResolvedValueOnce({ data: [], total: 0, page: 1, pageSize: 50, totalPages: 0 } as any)
-      .mockResolvedValueOnce({
-        data: [
-          {
-            id: 1,
-            sent_at: '2026-01-01T00:00:00Z',
-            ticket_number: '123',
-            to_addresses: ['to@example.com'],
-            subject: 'Ticket filtered',
-            status: 'sent',
-            provider_type: 'test',
-            provider_id: 'p',
-            message_id: 'm1',
-            from_address: 'from@example.com',
-            metadata: {},
-          },
-        ],
-        total: 1,
-        page: 1,
-        pageSize: 50,
-        totalPages: 1,
-      } as any);
+    getEmailLogsMock.mockResolvedValueOnce({
+      data: [
+        {
+          id: 1,
+          sent_at: '2026-01-01T00:00:00Z',
+          ticket_number: '123',
+          to_addresses: ['to@example.com'],
+          subject: 'Ticket filtered',
+          status: 'sent',
+          provider_type: 'test',
+          provider_id: 'p',
+          message_id: 'm1',
+          from_address: 'from@example.com',
+          metadata: {},
+        },
+      ],
+      total: 1,
+      page: 1,
+      pageSize: 50,
+      totalPages: 1,
+    } as any);
 
     render(
       <EmailLogsClient


### PR DESCRIPTION
## Summary

- Replace competing page/filter fetch paths with one state-driven email-log fetch effect so pagination no longer snaps back to page 1.
- Debounce text filters, reset pagination only when a filter actually changes, and ignore stale responses from rapid navigation.
- Seed the first 50 log rows and metrics during SSR, and align the server action's default page size with the UI.
- Extend the EmailLogsClient unit coverage for stable pagination, stale-response protection, and filter behavior.

## Verification

- PASS: `npx vitest run src/test/unit/email/EmailLogsClient.ui.test.tsx` from `server` (8 tests).
- Earlier focused validation on this branch also passed the email-package typecheck, relevant typechecks, and production build. The full server typecheck was not rerun after a prior 8 GB OOM.
- PASS: exercised the real product on port 3880 against the running `alga-psa-local-test` services and Postgres database.
  - Confirmed SSR-loaded page 1 and the 50-items/page default.
  - Navigated to page 2; it remained selected after fetching, showing “51–100 of 130 items” and page-2 records.
  - Issued rapid page 3 → page 2 clicks; the UI settled on page 2 with page-2 rows only.
  - From page 2, entered the debounced recipient filter; results reset to page 1 (“1–50 of 125 items”).
  - From page 2, selected Failed; results reset to page 1 and showed exactly 31 failed records, matching the database.
  - Opened a row’s detail dialog and verified provider, message ID, recipient, error, and metadata.

## Smoke-test setup and cleanup

Only five email logs existed, so the test inserted 125 uniquely tagged fixture rows into the real database; no simulator or mock was used. Database corroboration found 94 sent and 31 failed fixtures. All 125 generated rows were deleted afterward and zero remain. They were disposable test data and can be recreated, but the deleted rows themselves are not recoverable. The worktree remains clean and port 3880 still returns HTTP 200.

Evidence: `/tmp/alga-smoke-evidence/email-log-pagination-20260717-174746`

## Fidelity compromises and concerns

- The required card-scoped browser tab was created, but explicit control failed with “pane belongs to a different host.” Testing used another IDE browser pane against the same real product; its previous `localhost:3339` URL was restored afterward.
- Back-to-back clicks exercised rapid navigation, but the local server was too fast to guarantee deliberately inverted response order without introducing a mock. No mock was introduced for the smoke test; the unit test directly covers an inverted response order.
- No feature-specific console errors or failed requests occurred during the tested flows. Earlier hydration warnings came from alga-dev’s `data-cli-uid` instrumentation, and HMR connection failures corresponded to the intentional server restart used to refresh stale login credentials.

## Scope

`getEmailLogsForTicket` and its existing 200-row cap are intentionally unchanged.
