### PR TITLE
Template issue with quotes

### DIFF
--- a/docs/plans/2026-07-17-quote-template-bindings-plan.md
+++ b/docs/plans/2026-07-17-quote-template-bindings-plan.md
@@ -1,0 +1,146 @@
+# Fix quote document template bindings (client/tenant/date placeholders)
+
+**Branch:** `fix/template-issue-quotes`
+**Date:** 2026-07-17
+
+## Problem
+
+Quote document templates render fallbacks or blanks for `{{client.name}}`,
+`{{client.address}}`, `{{tenant.name}}`, `{{tenant.address}}`,
+`{{quote.quoteDate}}`, and `{{quote.validUntil}}` — even in the standard
+templates — while the equivalent invoice placeholders interpolate correctly.
+A rendered quote shows "Your Company", "Client", and empty Date / Valid Until
+values although the underlying data exists.
+
+## Root causes (confirmed in code)
+
+1. **Invoice-only binding aliases applied to quote renders.**
+   `packages/billing/src/lib/invoice-template-ast/evaluator.ts` resolves every
+   binding path through `resolveInvoiceTemplateBindingAlias`
+   (`packages/billing/src/lib/invoice-template-ast/bindingAliases.ts`), which
+   rewrites `client.name → customer.name`, `client.address → customer.address`,
+   `tenant.name → tenantClient.name`, `tenant.address → tenantClient.address`.
+   The invoice and sales-order view models expose `customer` / `tenantClient`,
+   but the quote view model (`mapDbQuoteToViewModel` in
+   `packages/billing/src/lib/adapters/quoteAdapters.ts`) exposes `client` /
+   `tenant` natively. The rewritten paths resolve to `undefined`, so the
+   bindings' fallbacks ("Client", "Your Company", "") render instead of data.
+
+2. **Raw `Date` objects defeat the field formatter.**
+   `quotes.quote_date` / `valid_until` are `timestamptz` columns; the pg type
+   parsers (`packages/db/src/lib/knexfile.ts`) return JS `Date` objects.
+   `mapDbQuoteToViewModel` passes them through unconverted (violating the
+   declared `ISO8601String | null` type on `QuoteViewModel` in
+   `packages/types/src/interfaces/quote.interfaces.ts`), and
+   `formatPrimitiveValue` in
+   `packages/billing/src/lib/invoice-template-ast/fieldFormatting.ts` returns
+   `{ text: null }` for any value that is not string/number/boolean — so date
+   fields render blank. The invoice adapter stringifies its dates
+   (`formatDateValueToString` in `invoiceAdapters.ts`), which is why invoices
+   work.
+
+## Design decisions (approved)
+
+- **Kind-scoped aliases:** `evaluateTemplateAst` takes an optional alias map;
+  the default is **no aliasing**. Callers whose view models are
+  customer-shaped (invoice, sales-order family) pass the invoice alias map
+  explicitly. Quote callers pass nothing.
+- **Dates fixed at both layers:** the quote adapter normalizes its date fields
+  to ISO strings (matching its type contract and the other adapters), and the
+  field formatter additionally learns to format `Date` instances so no future
+  adapter can reproduce the silent-blank failure.
+
+## Implementation steps
+
+### 1. Make binding aliasing an explicit evaluator option
+
+`packages/billing/src/lib/invoice-template-ast/bindingAliases.ts`:
+- Export the alias map itself (e.g. `INVOICE_TEMPLATE_BINDING_ALIASES:
+  Record<string, string>`) alongside the existing
+  `resolveInvoiceTemplateBindingAlias` helper (still used by
+  `invoice-designer/preview/previewBindings.ts`, which is invoice-only and
+  stays as-is).
+
+`packages/billing/src/lib/invoice-template-ast/evaluator.ts`:
+- Add an options parameter:
+  `evaluateTemplateAst(ast, data, options?: { bindingAliases?: Record<string, string> })`.
+- Thread the option down to the three places that currently call
+  `resolveInvoiceTemplateBindingAlias` (value binding, collection binding, and
+  bare-bindingId resolution in `resolveBindingValue`, plus the bindings loop
+  around line 432). With no option supplied, paths resolve verbatim — no
+  aliasing.
+- Remove the unconditional import/application of the invoice alias resolver.
+
+### 2. Update evaluator call sites
+
+Pass `{ bindingAliases: INVOICE_TEMPLATE_BINDING_ALIASES }`:
+- `packages/billing/src/services/pdfGenerationService.ts` — invoice HTML
+  (~line 229), invoice PDF (~line 353), sales-order render (~line 460).
+- `packages/billing/src/actions/invoiceTemplatePreview.ts` (~line 147).
+- `packages/billing/src/actions/invoiceTemplates.ts` (~line 432).
+- `packages/billing/src/actions/documentTemplateActions.ts` (~line 198) —
+  sales-order-family document previews (verify during implementation that this
+  path only serves sales-order/packing-slip/pick-list samples; if it can carry
+  quote ASTs, select the map by document kind as in the designer below).
+
+Pass no aliases (quote paths):
+- `packages/billing/src/services/pdfGenerationService.ts` — quote preview
+  (~line 258) and quote PDF (~line 423).
+- `packages/billing/src/actions/quoteTemplatePreview.ts` (~line 119).
+
+Select by document kind:
+- `packages/billing/src/components/invoice-designer/transforms/TransformsWorkspace.tsx`
+  (~line 420): use the existing `detectDocumentKind` helper
+  (`invoice-designer/utils/documentKind.ts`) on the validated AST — `quote` →
+  no aliases; `invoice` / `sales-order` → invoice aliases.
+
+### 3. Normalize quote view-model dates
+
+`packages/billing/src/lib/adapters/quoteAdapters.ts`:
+- Add a small exported helper (e.g. `toIsoDateString(value: unknown): string | null`):
+  `Date` → `toISOString()` (guarding invalid dates), non-empty string →
+  trimmed string, anything else → `null`.
+- Apply it to `quote_date`, `valid_until`, and `accepted_at` in
+  `buildQuoteViewModel`.
+
+### 4. Harden the field formatter against `Date` values
+
+`packages/billing/src/lib/invoice-template-ast/fieldFormatting.ts`:
+- In `formatPrimitiveValue`, handle `value instanceof Date` before the
+  catch-all: invalid `Date` → `{ text: null }`; valid `Date` → convert to ISO
+  string and fall through to the existing string branch (so `format: 'date'`
+  produces the locale-formatted date and other formats degrade sensibly).
+
+### 5. Tests
+
+- `packages/billing/src/lib/invoice-template-ast/evaluator.test.ts`:
+  - Quote-shaped data (`client` / `tenant` objects) resolves `client.name`,
+    `tenant.name`, `tenant.address` **without** aliases (no fallback leak).
+  - Invoice-shaped data (`customer` / `tenantClient`) still resolves when the
+    invoice alias map is passed.
+- New `fieldFormatting.test.ts`: `Date` value with `format: 'date'` renders a
+  formatted date; invalid `Date` renders null; existing primitive behavior
+  unchanged.
+- Quote adapter: unit-test `toIsoDateString` (Date, ISO string, null,
+  invalid-date inputs).
+- `packages/billing/tests/quote/quoteTemplateAst.test.ts` (or sibling):
+  regression test rendering a standard quote template against a hand-built
+  `QuoteViewModel` asserting client name, tenant name, quote date, and valid
+  until all appear in the evaluated output.
+
+### 6. Manual verification (dev stack on port 3593)
+
+- Open the quote used in the bug report (Q-0003 equivalent) and render the
+  standard-template preview/PDF: all six placeholders populate (client
+  name/address, tenant name/address, formatted Date and Valid Until).
+- Render an invoice preview/PDF: customer and tenant fields unchanged
+  (alias regression check).
+- Render a sales-order document preview: customer/tenant fields unchanged.
+
+## Out of scope
+
+- Quote **email** templates (`quote-email-templates.ts`) — unaffected, they
+  read quote rows directly.
+- Renaming the invoice/sales-order view-model shapes (`customer` /
+  `tenantClient`) to match the quote shape — larger unification, not needed
+  for this fix.

--- a/packages/billing/src/actions/documentTemplateActions.ts
+++ b/packages/billing/src/actions/documentTemplateActions.ts
@@ -28,6 +28,7 @@ import {
   type DocumentTemplateListItem,
 } from '../lib/document-templates/storage';
 import { evaluateTemplateAst } from '../lib/invoice-template-ast/evaluator';
+import { INVOICE_TEMPLATE_BINDING_ALIASES } from '../lib/invoice-template-ast/bindingAliases';
 import { renderTemplateAstHtmlDocument } from '../lib/invoice-template-ast/server-render';
 
 /**
@@ -195,7 +196,9 @@ export const runAuthoritativeTemplatePreview = withAuth(
     }
     const sample = getDocumentTypeRegistryEntry(type).buildSampleViewModel();
     const { knex } = await createTenantKnex();
-    const evaluation = evaluateTemplateAst(templateAst, sample);
+    const evaluation = evaluateTemplateAst(templateAst, sample, {
+      bindingAliases: INVOICE_TEMPLATE_BINDING_ALIASES,
+    });
     const html = await renderTemplateAstHtmlDocument(templateAst, evaluation, { title: 'Preview', knex });
     return { html };
   },

--- a/packages/billing/src/actions/invoiceTemplatePreview.ts
+++ b/packages/billing/src/actions/invoiceTemplatePreview.ts
@@ -8,6 +8,7 @@ import type { WasmInvoiceViewModel } from '@alga-psa/types';
 import type { DesignerWorkspaceSnapshot } from '../components/invoice-designer/state/designerStore';
 import { exportWorkspaceToTemplateAst } from '../components/invoice-designer/ast/workspaceAst';
 import { evaluateTemplateAst, TemplateEvaluationError } from '../lib/invoice-template-ast/evaluator';
+import { INVOICE_TEMPLATE_BINDING_ALIASES } from '../lib/invoice-template-ast/bindingAliases';
 import { renderEvaluatedTemplateAst } from '../lib/invoice-template-ast/react-renderer';
 import { validateTemplateAst } from '../lib/invoice-template-ast/schema';
 
@@ -144,7 +145,11 @@ export const runAuthoritativeInvoiceTemplatePreview = withAuth(
     }
 
     try {
-      const evaluation = evaluateTemplateAst(validation.ast, input.invoiceData as unknown as Record<string, unknown>);
+      const evaluation = evaluateTemplateAst(
+        validation.ast,
+        input.invoiceData as unknown as Record<string, unknown>,
+        { bindingAliases: INVOICE_TEMPLATE_BINDING_ALIASES }
+      );
       const rendered = await renderEvaluatedTemplateAst(validation.ast, evaluation);
       return {
         success: true,

--- a/packages/billing/src/actions/invoiceTemplates.ts
+++ b/packages/billing/src/actions/invoiceTemplates.ts
@@ -26,6 +26,7 @@ import {
 } from '@alga-psa/ui/lib/errorHandling';
 
 import { evaluateTemplateAst } from '../lib/invoice-template-ast/evaluator';
+import { INVOICE_TEMPLATE_BINDING_ALIASES } from '../lib/invoice-template-ast/bindingAliases';
 import { renderEvaluatedTemplateAst } from '../lib/invoice-template-ast/react-renderer';
 import { deleteEntityWithValidation } from '@alga-psa/core/server';
 
@@ -431,7 +432,8 @@ export const renderTemplateOnServer = withAuth(async (
 
         const evaluation = evaluateTemplateAst(
           templateAst,
-          invoiceData as unknown as Record<string, unknown>
+          invoiceData as unknown as Record<string, unknown>,
+          { bindingAliases: INVOICE_TEMPLATE_BINDING_ALIASES }
         );
         const { html, css } = await renderEvaluatedTemplateAst(templateAst, evaluation);
 

--- a/packages/billing/src/components/invoice-designer/transforms/TransformsWorkspace.tsx
+++ b/packages/billing/src/components/invoice-designer/transforms/TransformsWorkspace.tsx
@@ -26,7 +26,9 @@ import {
 import type { PreviewSessionState, PreviewSourceKind } from '../preview/previewSessionState';
 import { createEmptyDesignerTransformWorkspace, useInvoiceDesignerStore } from '../state/designerStore';
 import { evaluateTemplateAst, TemplateEvaluationError } from '../../../lib/invoice-template-ast/evaluator';
+import { INVOICE_TEMPLATE_BINDING_ALIASES } from '../../../lib/invoice-template-ast/bindingAliases';
 import { validateTemplateAst } from '../../../lib/invoice-template-ast/schema';
+import { resolveDesignerDocumentKind } from '../utils/documentKind';
 import {
   cloneDesignerTransformWorkspace,
   suggestTransformOutputBindingId,
@@ -417,7 +419,14 @@ const TransformsWorkspace: React.FC<Props> = ({
         };
       }
 
-      const evaluation = evaluateTemplateAst(validationResult.ast, previewData as unknown as Record<string, unknown>);
+      const documentKind = resolveDesignerDocumentKind(nodes);
+      const evaluation = evaluateTemplateAst(
+        validationResult.ast,
+        previewData as unknown as Record<string, unknown>,
+        documentKind === 'quote'
+          ? undefined
+          : { bindingAliases: INVOICE_TEMPLATE_BINDING_ALIASES }
+      );
       const outputRows = Array.isArray(evaluation.output) ? evaluation.output.filter(isRecord) : [];
       return {
         issues: [] as PreviewIssue[],
@@ -465,7 +474,7 @@ const TransformsWorkspace: React.FC<Props> = ({
         rows: [],
       };
     }
-  }, [previewData, workspaceSnapshot]);
+  }, [nodes, previewData, workspaceSnapshot]);
 
   const combinedIssues = useMemo(
     () => [

--- a/packages/billing/src/lib/adapters/quoteAdapters.test.ts
+++ b/packages/billing/src/lib/adapters/quoteAdapters.test.ts
@@ -7,7 +7,7 @@ vi.mock('./tenantPartyAdapter', () => ({
   fetchTenantParty: (...args: unknown[]) => fetchTenantPartyMock(...args),
 }));
 
-import { mapLoadedQuoteToViewModel } from './quoteAdapters';
+import { mapLoadedQuoteToViewModel, toIsoDateString } from './quoteAdapters';
 
 const fakeKnex = {
   schema: {
@@ -44,6 +44,30 @@ describe('quoteAdapters', () => {
       phone: '555-0100',
       logo_url: null,
     });
+  });
+
+  it('normalizes Date values and preserves trimmed ISO date strings', () => {
+    expect(toIsoDateString(new Date('2026-07-17T12:30:00.000Z'))).toBe('2026-07-17T12:30:00.000Z');
+    expect(toIsoDateString(' 2026-07-31T00:00:00.000Z ')).toBe('2026-07-31T00:00:00.000Z');
+    expect(toIsoDateString(null)).toBeNull();
+    expect(toIsoDateString(new Date('invalid'))).toBeNull();
+    expect(toIsoDateString('   ')).toBeNull();
+  });
+
+  it('normalizes quote view-model dates to ISO strings', async () => {
+    const viewModel = await mapLoadedQuoteToViewModel(
+      fakeKnex,
+      'tenant-1',
+      buildQuote({
+        quote_date: new Date('2026-07-17T12:30:00.000Z') as unknown as string,
+        valid_until: new Date('2026-08-17T12:30:00.000Z') as unknown as string,
+        accepted_at: new Date('2026-07-18T12:30:00.000Z') as unknown as string,
+      })
+    );
+
+    expect(viewModel.quote_date).toBe('2026-07-17T12:30:00.000Z');
+    expect(viewModel.valid_until).toBe('2026-08-17T12:30:00.000Z');
+    expect(viewModel.accepted_at).toBe('2026-07-18T12:30:00.000Z');
   });
 
   it('builds recurring, one-time, service, and product filtered collections from quote line items', async () => {

--- a/packages/billing/src/lib/adapters/quoteAdapters.test.ts
+++ b/packages/billing/src/lib/adapters/quoteAdapters.test.ts
@@ -7,7 +7,7 @@ vi.mock('./tenantPartyAdapter', () => ({
   fetchTenantParty: (...args: unknown[]) => fetchTenantPartyMock(...args),
 }));
 
-import { mapLoadedQuoteToViewModel, toIsoDateString } from './quoteAdapters';
+import { mapLoadedQuoteToViewModel, toDateOnlyString, toIsoDateString } from './quoteAdapters';
 
 const fakeKnex = {
   schema: {
@@ -54,7 +54,14 @@ describe('quoteAdapters', () => {
     expect(toIsoDateString('   ')).toBeNull();
   });
 
-  it('normalizes quote view-model dates to ISO strings', async () => {
+  it('normalizes quote calendar dates without retaining a timezone-bearing time', () => {
+    expect(toDateOnlyString(new Date('2026-07-13T00:00:00.000Z'))).toBe('2026-07-13');
+    expect(toDateOnlyString(' 2026-08-12T00:00:00.000Z ')).toBe('2026-08-12');
+    expect(toDateOnlyString('2026-08-12')).toBe('2026-08-12');
+    expect(toDateOnlyString(null)).toBeNull();
+  });
+
+  it('normalizes quote calendar dates separately from acceptance timestamps', async () => {
     const viewModel = await mapLoadedQuoteToViewModel(
       fakeKnex,
       'tenant-1',
@@ -65,8 +72,8 @@ describe('quoteAdapters', () => {
       })
     );
 
-    expect(viewModel.quote_date).toBe('2026-07-17T12:30:00.000Z');
-    expect(viewModel.valid_until).toBe('2026-08-17T12:30:00.000Z');
+    expect(viewModel.quote_date).toBe('2026-07-17');
+    expect(viewModel.valid_until).toBe('2026-08-17');
     expect(viewModel.accepted_at).toBe('2026-07-18T12:30:00.000Z');
   });
 

--- a/packages/billing/src/lib/adapters/quoteAdapters.ts
+++ b/packages/billing/src/lib/adapters/quoteAdapters.ts
@@ -26,6 +26,16 @@ export const toIsoDateString = (value: unknown): string | null => {
   return null;
 };
 
+export const toDateOnlyString = (value: unknown): string | null => {
+  const normalized = toIsoDateString(value);
+  if (!normalized) {
+    return null;
+  }
+
+  const dateOnlyMatch = normalized.match(/^(\d{4}-\d{2}-\d{2})(?:$|T)/);
+  return dateOnlyMatch?.[1] ?? normalized;
+};
+
 const toFiniteNumber = (value: unknown): number => {
   const parsed = Number(value);
   return Number.isFinite(parsed) ? parsed : 0;
@@ -389,8 +399,8 @@ export async function mapLoadedQuoteToViewModel(
     title: quote.title,
     description: quote.description ?? null,
     scope_of_work: quote.description ?? null,
-    quote_date: toIsoDateString(quote.quote_date),
-    valid_until: toIsoDateString(quote.valid_until),
+    quote_date: toDateOnlyString(quote.quote_date),
+    valid_until: toDateOnlyString(quote.valid_until),
     status: quote.status ?? null,
     version: Number(quote.version ?? 1),
     po_number: quote.po_number ?? null,

--- a/packages/billing/src/lib/adapters/quoteAdapters.ts
+++ b/packages/billing/src/lib/adapters/quoteAdapters.ts
@@ -15,6 +15,17 @@ type QuoteItemGroupSummary = {
 
 const asTrimmedString = (value: unknown): string => (typeof value === 'string' ? value.trim() : '');
 
+export const toIsoDateString = (value: unknown): string | null => {
+  if (value instanceof Date) {
+    return Number.isNaN(value.getTime()) ? null : value.toISOString();
+  }
+  if (typeof value === 'string') {
+    const trimmed = value.trim();
+    return trimmed.length > 0 ? trimmed : null;
+  }
+  return null;
+};
+
 const toFiniteNumber = (value: unknown): number => {
   const parsed = Number(value);
   return Number.isFinite(parsed) ? parsed : 0;
@@ -378,8 +389,8 @@ export async function mapLoadedQuoteToViewModel(
     title: quote.title,
     description: quote.description ?? null,
     scope_of_work: quote.description ?? null,
-    quote_date: quote.quote_date ?? null,
-    valid_until: quote.valid_until ?? null,
+    quote_date: toIsoDateString(quote.quote_date),
+    valid_until: toIsoDateString(quote.valid_until),
     status: quote.status ?? null,
     version: Number(quote.version ?? 1),
     po_number: quote.po_number ?? null,
@@ -416,7 +427,7 @@ export async function mapLoadedQuoteToViewModel(
     groups_by_location: buildLocationGroups(lineItems),
     has_multiple_locations: locationsById.size >= 2,
     accepted_by_name: acceptedByName,
-    accepted_at: quote.accepted_at ?? null,
+    accepted_at: toIsoDateString(quote.accepted_at),
   };
 }
 

--- a/packages/billing/src/lib/invoice-template-ast/bindingAliases.ts
+++ b/packages/billing/src/lib/invoice-template-ast/bindingAliases.ts
@@ -1,4 +1,4 @@
-const BINDING_ALIASES: Record<string, string> = {
+export const INVOICE_TEMPLATE_BINDING_ALIASES: Record<string, string> = {
   'client.name': 'customer.name',
   'client.address': 'customer.address',
   'tenant.name': 'tenantClient.name',
@@ -10,5 +10,5 @@ export const resolveInvoiceTemplateBindingAlias = (bindingPath: string): string 
   if (!normalized) {
     return normalized;
   }
-  return BINDING_ALIASES[normalized] ?? normalized;
+  return INVOICE_TEMPLATE_BINDING_ALIASES[normalized] ?? normalized;
 };

--- a/packages/billing/src/lib/invoice-template-ast/evaluator.test.ts
+++ b/packages/billing/src/lib/invoice-template-ast/evaluator.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it, vi } from 'vitest';
 import type { TemplateAst, TemplateTransformOperation } from '@alga-psa/types';
 import { TEMPLATE_AST_VERSION } from '@alga-psa/types';
 import * as strategiesModule from './strategies';
+import { INVOICE_TEMPLATE_BINDING_ALIASES } from './bindingAliases';
 import { evaluateTemplateAst, TemplateEvaluationError } from './evaluator';
 
 const invoiceFixture = {
@@ -42,6 +43,56 @@ const buildAst = (operations: TemplateTransformOperation[]): TemplateAst => ({
 });
 
 describe('evaluateTemplateAst', () => {
+  it('resolves quote party bindings verbatim when aliases are not provided', () => {
+    const ast: TemplateAst = {
+      kind: 'invoice-template-ast',
+      version: TEMPLATE_AST_VERSION,
+      bindings: {
+        values: {
+          clientName: { id: 'clientName', kind: 'value', path: 'client.name', fallback: 'Client' },
+          tenantName: { id: 'tenantName', kind: 'value', path: 'tenant.name', fallback: 'Your Company' },
+          tenantAddress: { id: 'tenantAddress', kind: 'value', path: 'tenant.address', fallback: '' },
+        },
+      },
+      layout: { id: 'root', type: 'document', children: [] },
+    };
+
+    const result = evaluateTemplateAst(ast, {
+      client: { name: 'Acme Corp' },
+      tenant: { name: 'Northwind MSP', address: '400 SW Main' },
+    });
+
+    expect(result.bindings.clientName).toBe('Acme Corp');
+    expect(result.bindings.tenantName).toBe('Northwind MSP');
+    expect(result.bindings.tenantAddress).toBe('400 SW Main');
+  });
+
+  it('resolves invoice party bindings through explicitly provided aliases', () => {
+    const ast: TemplateAst = {
+      kind: 'invoice-template-ast',
+      version: TEMPLATE_AST_VERSION,
+      bindings: {
+        values: {
+          clientName: { id: 'clientName', kind: 'value', path: 'client.name', fallback: 'Client' },
+          tenantName: { id: 'tenantName', kind: 'value', path: 'tenant.name', fallback: 'Your Company' },
+        },
+      },
+      layout: { id: 'root', type: 'document', children: [] },
+    };
+
+    const result = evaluateTemplateAst(
+      ast,
+      {
+        customer: { name: 'Acme Corp' },
+        tenantClient: { name: 'Northwind MSP' },
+      },
+      { bindingAliases: INVOICE_TEMPLATE_BINDING_ALIASES }
+    );
+
+    expect(result.bindings.clientName).toBe('Acme Corp');
+    expect(result.bindings.tenantName).toBe('Northwind MSP');
+  });
+
   it('applies filter transforms to invoice items', () => {
     const ast = buildAst([
       {

--- a/packages/billing/src/lib/invoice-template-ast/evaluator.ts
+++ b/packages/billing/src/lib/invoice-template-ast/evaluator.ts
@@ -13,9 +13,12 @@ import {
   resolveTemplateStrategy,
 } from './strategies';
 import { validateTemplateAst } from './schema';
-import { resolveInvoiceTemplateBindingAlias } from './bindingAliases';
 
 type UnknownRecord = Record<string, unknown>;
+
+export interface TemplateEvaluationOptions {
+  bindingAliases?: Record<string, string>;
+}
 
 export interface TemplateEvaluatedGroup {
   key: string;
@@ -97,6 +100,14 @@ const getPathValue = (target: unknown, path: string): unknown => {
   }, target);
 };
 
+const resolveBindingPath = (path: string, bindingAliases?: Record<string, string>): string => {
+  const normalized = path.trim();
+  if (!normalized) {
+    return normalized;
+  }
+  return bindingAliases?.[normalized] ?? normalized;
+};
+
 const safeNumber = (value: unknown): number => {
   if (typeof value === 'number' && Number.isFinite(value)) {
     return value;
@@ -132,20 +143,21 @@ const compareValues = (left: unknown, right: unknown): number => {
 const resolveBindingValue = (
   ast: TemplateAst,
   bindingId: string,
-  invoiceData: UnknownRecord
+  invoiceData: UnknownRecord,
+  bindingAliases?: Record<string, string>
 ): unknown => {
   const valueBinding = ast.bindings?.values?.[bindingId];
   if (valueBinding) {
-    const resolved = getPathValue(invoiceData, resolveInvoiceTemplateBindingAlias(valueBinding.path));
+    const resolved = getPathValue(invoiceData, resolveBindingPath(valueBinding.path, bindingAliases));
     return resolved === undefined ? valueBinding.fallback : resolved;
   }
 
   const collectionBinding = ast.bindings?.collections?.[bindingId];
   if (collectionBinding) {
-    return getPathValue(invoiceData, resolveInvoiceTemplateBindingAlias(collectionBinding.path));
+    return getPathValue(invoiceData, resolveBindingPath(collectionBinding.path, bindingAliases));
   }
 
-  return getPathValue(invoiceData, resolveInvoiceTemplateBindingAlias(bindingId));
+  return getPathValue(invoiceData, resolveBindingPath(bindingId, bindingAliases));
 };
 
 const hasBindingReference = (ast: TemplateAst, bindingId: string): boolean =>
@@ -404,7 +416,8 @@ const deepSortObjectKeys = (value: unknown): unknown => {
 
 export const evaluateTemplateAst = (
   ast: TemplateAst,
-  invoiceDataInput: UnknownRecord
+  invoiceDataInput: UnknownRecord,
+  options?: TemplateEvaluationOptions
 ): TemplateEvaluationResult => {
   const astValidation = validateTemplateAst(ast);
   if (!astValidation.success) {
@@ -430,12 +443,12 @@ export const evaluateTemplateAst = (
   };
 
   for (const [bindingId, binding] of Object.entries(ast.bindings?.values ?? {})) {
-    const resolved = getPathValue(invoiceData, resolveInvoiceTemplateBindingAlias(binding.path));
+    const resolved = getPathValue(invoiceData, resolveBindingPath(binding.path, options?.bindingAliases));
     bindings[bindingId] = resolved === undefined ? binding.fallback : resolved;
   }
   for (const [bindingId, binding] of Object.entries(ast.bindings?.collections ?? {})) {
     bindings[bindingId] = cloneRecordArray(
-      getPathValue(invoiceData, resolveInvoiceTemplateBindingAlias(binding.path))
+      getPathValue(invoiceData, resolveBindingPath(binding.path, options?.bindingAliases))
     );
   }
 
@@ -450,14 +463,25 @@ export const evaluateTemplateAst = (
     };
   }
 
-  if (!hasBindingReference(ast, ast.transforms.sourceBindingId) && getPathValue(invoiceData, ast.transforms.sourceBindingId) === undefined) {
+  if (
+    !hasBindingReference(ast, ast.transforms.sourceBindingId) &&
+    getPathValue(
+      invoiceData,
+      resolveBindingPath(ast.transforms.sourceBindingId, options?.bindingAliases)
+    ) === undefined
+  ) {
     throw new TemplateEvaluationError(
       'MISSING_BINDING',
       `Transform source binding "${ast.transforms.sourceBindingId}" is not defined in bindings and did not resolve from invoice data.`
     );
   }
 
-  const sourceValue = resolveBindingValue(ast, ast.transforms.sourceBindingId, invoiceData);
+  const sourceValue = resolveBindingValue(
+    ast,
+    ast.transforms.sourceBindingId,
+    invoiceData,
+    options?.bindingAliases
+  );
   if (!Array.isArray(sourceValue)) {
     throw new TemplateEvaluationError(
       'INVALID_SOURCE_COLLECTION',

--- a/packages/billing/src/lib/invoice-template-ast/fieldFormatting.test.ts
+++ b/packages/billing/src/lib/invoice-template-ast/fieldFormatting.test.ts
@@ -3,6 +3,34 @@ import { describe, expect, it } from 'vitest';
 import { formatTemplateFieldValue } from './fieldFormatting';
 
 describe('formatTemplateFieldValue', () => {
+  it('preserves date-only calendar values in negative-offset timezones', () => {
+    const previousTimeZone = process.env.TZ;
+    process.env.TZ = 'America/New_York';
+
+    try {
+      expect(
+        formatTemplateFieldValue({
+          value: '2026-07-13',
+          format: 'date',
+          currencyCode: 'USD',
+        })
+      ).toEqual({ text: '7/13/2026', multiline: false });
+      expect(
+        formatTemplateFieldValue({
+          value: '2026-08-12',
+          format: 'date',
+          currencyCode: 'USD',
+        })
+      ).toEqual({ text: '8/12/2026', multiline: false });
+    } finally {
+      if (previousTimeZone === undefined) {
+        delete process.env.TZ;
+      } else {
+        process.env.TZ = previousTimeZone;
+      }
+    }
+  });
+
   it('formats Date instances with the existing date formatter', () => {
     expect(
       formatTemplateFieldValue({

--- a/packages/billing/src/lib/invoice-template-ast/fieldFormatting.test.ts
+++ b/packages/billing/src/lib/invoice-template-ast/fieldFormatting.test.ts
@@ -1,0 +1,36 @@
+import { describe, expect, it } from 'vitest';
+
+import { formatTemplateFieldValue } from './fieldFormatting';
+
+describe('formatTemplateFieldValue', () => {
+  it('formats Date instances with the existing date formatter', () => {
+    expect(
+      formatTemplateFieldValue({
+        value: new Date('2026-07-17T12:30:00.000Z'),
+        format: 'date',
+        currencyCode: 'USD',
+      })
+    ).toEqual({ text: '7/17/2026', multiline: false });
+  });
+
+  it('returns null text for invalid Date instances', () => {
+    expect(
+      formatTemplateFieldValue({
+        value: new Date('invalid'),
+        format: 'date',
+        currencyCode: 'USD',
+      })
+    ).toEqual({ text: null, multiline: false });
+  });
+
+  it('preserves existing primitive formatting behavior', () => {
+    expect(formatTemplateFieldValue({ value: true, format: 'text', currencyCode: 'USD' })).toEqual({
+      text: 'Yes',
+      multiline: false,
+    });
+    expect(formatTemplateFieldValue({ value: 1250, format: 'currency', currencyCode: 'USD' })).toEqual({
+      text: '$12.50',
+      multiline: false,
+    });
+  });
+});

--- a/packages/billing/src/lib/invoice-template-ast/fieldFormatting.ts
+++ b/packages/billing/src/lib/invoice-template-ast/fieldFormatting.ts
@@ -23,6 +23,19 @@ const formatCurrency = (value: number, currencyCode: string) => {
 };
 
 const formatDate = (value: string) => {
+  const dateOnlyMatch = value.match(/^(\d{4})-(\d{2})-(\d{2})$/);
+  if (dateOnlyMatch) {
+    const [, year, month, day] = dateOnlyMatch;
+    const parsedDateOnly = new Date(Date.UTC(Number(year), Number(month) - 1, Number(day)));
+    const isValidDateOnly =
+      parsedDateOnly.getUTCFullYear() === Number(year) &&
+      parsedDateOnly.getUTCMonth() === Number(month) - 1 &&
+      parsedDateOnly.getUTCDate() === Number(day);
+    if (isValidDateOnly) {
+      return parsedDateOnly.toLocaleDateString('en-US', { timeZone: 'UTC' });
+    }
+  }
+
   const parsed = new Date(value);
   if (Number.isNaN(parsed.getTime())) {
     return value;

--- a/packages/billing/src/lib/invoice-template-ast/fieldFormatting.ts
+++ b/packages/billing/src/lib/invoice-template-ast/fieldFormatting.ts
@@ -124,6 +124,12 @@ const formatPrimitiveValue = (
   if (isNullish(value)) {
     return { text: null, multiline: false };
   }
+  if (value instanceof Date) {
+    if (Number.isNaN(value.getTime())) {
+      return { text: null, multiline: false };
+    }
+    return formatPrimitiveValue(value.toISOString(), format, currencyCode);
+  }
   if (typeof value === 'string') {
     if (value.length === 0) {
       return { text: null, multiline: false };

--- a/packages/billing/src/services/pdfGenerationService.ts
+++ b/packages/billing/src/services/pdfGenerationService.ts
@@ -16,6 +16,7 @@ import { mapDbQuoteToViewModel } from '../lib/adapters/quoteAdapters';
 import { mapDbSalesOrderToViewModel } from '../lib/adapters/salesOrderAdapters';
 import { fetchTenantParty } from '../lib/adapters/tenantPartyAdapter';
 import { evaluateTemplateAst } from '../lib/invoice-template-ast/evaluator';
+import { INVOICE_TEMPLATE_BINDING_ALIASES } from '../lib/invoice-template-ast/bindingAliases';
 import { resolvePdfPrintOptionsFromAst } from '../lib/invoice-template-ast/printSettings';
 import { renderEvaluatedTemplateAst } from '../lib/invoice-template-ast/react-renderer';
 import { renderTemplateAstHtmlDocument } from '../lib/invoice-template-ast/server-render';
@@ -228,7 +229,8 @@ export class PDFGenerationService {
 
       const evaluation = evaluateTemplateAst(
         templateAst,
-        invoiceViewModel as unknown as Record<string, unknown>
+        invoiceViewModel as unknown as Record<string, unknown>,
+        { bindingAliases: INVOICE_TEMPLATE_BINDING_ALIASES }
       );
       const rendered = await renderEvaluatedTemplateAst(templateAst, evaluation);
       return { html: rendered.html, css: rendered.css, templateAst };
@@ -352,7 +354,8 @@ export class PDFGenerationService {
 
       const evaluation = evaluateTemplateAst(
         templateAst,
-        invoiceViewModel as unknown as Record<string, unknown>
+        invoiceViewModel as unknown as Record<string, unknown>,
+        { bindingAliases: INVOICE_TEMPLATE_BINDING_ALIASES }
       );
 
       const htmlContent = await renderTemplateAstHtmlDocument(templateAst, evaluation, {
@@ -459,7 +462,8 @@ export class PDFGenerationService {
 
       const evaluation = evaluateTemplateAst(
         templateAst,
-        viewModel as unknown as Record<string, unknown>
+        viewModel as unknown as Record<string, unknown>,
+        { bindingAliases: INVOICE_TEMPLATE_BINDING_ALIASES }
       );
 
       const htmlContent = await renderTemplateAstHtmlDocument(templateAst, evaluation, {

--- a/packages/billing/tests/quote/quoteTemplateAst.test.ts
+++ b/packages/billing/tests/quote/quoteTemplateAst.test.ts
@@ -132,8 +132,8 @@ describe('quote-template-ast – standardTemplates', () => {
 
     const evaluation = evaluateTemplateAst(ast, {
       quote_number: 'Q-0003',
-      quote_date: '2026-07-17T12:30:00.000Z',
-      valid_until: '2026-08-17T12:30:00.000Z',
+      quote_date: '2026-07-13',
+      valid_until: '2026-08-12',
       title: 'Managed Services Proposal',
       currency_code: 'USD',
       subtotal: 0,
@@ -150,8 +150,8 @@ describe('quote-template-ast – standardTemplates', () => {
     expect(html).toContain('123 Main St');
     expect(html).toContain('Northwind MSP');
     expect(html).toContain('400 SW Main');
-    expect(html).toContain('7/17/2026');
-    expect(html).toContain('8/17/2026');
+    expect(html).toContain('7/13/2026');
+    expect(html).toContain('8/12/2026');
     expect(html).not.toContain('Your Company');
   });
 });

--- a/packages/billing/tests/quote/quoteTemplateAst.test.ts
+++ b/packages/billing/tests/quote/quoteTemplateAst.test.ts
@@ -11,6 +11,8 @@ import {
   STANDARD_QUOTE_TEMPLATE_ASTS,
   getStandardQuoteTemplateAstByCode,
 } from '../../src/lib/quote-template-ast/standardTemplates';
+import { evaluateTemplateAst } from '../../src/lib/invoice-template-ast/evaluator';
+import { renderTemplateAstHtmlDocument } from '../../src/lib/invoice-template-ast/server-render';
 
 // ── bindings ─────────────────────────────────────────────────────────
 describe('quote-template-ast – bindings', () => {
@@ -119,6 +121,38 @@ describe('quote-template-ast – standardTemplates', () => {
       expect(bindings.values?.subtotal).toBeDefined();
       expect(bindings.collections?.lineItems).toBeDefined();
     }
+  });
+
+  it('renders native quote party and date bindings without invoice aliases', async () => {
+    const ast = getStandardQuoteTemplateAstByCode('standard-quote-default');
+    expect(ast).not.toBeNull();
+    if (!ast) {
+      throw new Error('Expected the standard quote template to exist.');
+    }
+
+    const evaluation = evaluateTemplateAst(ast, {
+      quote_number: 'Q-0003',
+      quote_date: '2026-07-17T12:30:00.000Z',
+      valid_until: '2026-08-17T12:30:00.000Z',
+      title: 'Managed Services Proposal',
+      currency_code: 'USD',
+      subtotal: 0,
+      discount_total: 0,
+      tax: 0,
+      total_amount: 0,
+      line_items: [],
+      client: { name: 'Acme Corp', address: '123 Main St' },
+      tenant: { name: 'Northwind MSP', address: '400 SW Main' },
+    });
+    const html = await renderTemplateAstHtmlDocument(ast, evaluation, { title: 'Quote Q-0003' });
+
+    expect(html).toContain('Acme Corp');
+    expect(html).toContain('123 Main St');
+    expect(html).toContain('Northwind MSP');
+    expect(html).toContain('400 SW Main');
+    expect(html).toContain('7/17/2026');
+    expect(html).toContain('8/17/2026');
+    expect(html).not.toContain('Your Company');
   });
 });
 


### PR DESCRIPTION
## Summary

- make invoice template binding aliases opt-in so quote templates resolve their native `client.*` and `tenant.*` bindings while invoice and sales-order rendering explicitly retain the existing alias map
- normalize quote calendar dates as date-only values and harden primitive date formatting so quote dates render without timezone drift
- select aliases by document kind in the template designer and add regression coverage for evaluator bindings, quote adapters, date formatting, and quote AST rendering

## Smoke test

PASS. Real stack `alga-psa-local-test` was healthy; port 3593 was served from this worktree. Live QUO-0002 preview showed tenant “Oz,” the real client/address, and exact DB-backed dates 7/13/2026 and 8/12/2026. The real Download PDF action returned a fresh 50,867-byte PDF; rendered and extracted PDF content matched those bindings and dates. INV-000002 preview confirmed invoice alias bindings still resolve correctly. No simulator or mock used.

Fidelity compromise: the newly created card tab was cross-host and uncontrollable, so testing used the existing authenticated card browser pane. The PDF Blob was captured from the real UI response for extraction.

Suspicious: two unrelated background POSTs returned 500 on the invoice route, although invoice list/details/preview rendered successfully. Quote requests returned 200.

Evidence: `/tmp/alga-smoke-evidence/template-issue-quotes-20260717-230428`

## Tests

- focused evaluator, field-formatting, quote-adapter, and quote-template AST regression tests
- live quote preview and PDF download against the real local stack
- live invoice preview regression check

