### PR TITLE
Deflake remaining first-queries in Schedules dialog tests

### DIFF
--- a/ee/packages/workflows/src/components/automation-hub/Schedules.test.tsx
+++ b/ee/packages/workflows/src/components/automation-hub/Schedules.test.tsx
@@ -648,8 +648,10 @@ describe('Schedules', () => {
     fireEvent.click(within(row as HTMLTableRowElement).getByText('Edit'));
 
     await screen.findByRole('dialog', { name: 'Edit Schedule' });
-    expect(screen.getByLabelText('Schedule name')).toHaveValue('Weekday billing');
-    expect(screen.getByLabelText('Trigger type')).toHaveValue('recurring');
+    await waitFor(() => {
+      expect(screen.getByLabelText('Schedule name')).toHaveValue('Weekday billing');
+      expect(screen.getByLabelText('Trigger type')).toHaveValue('recurring');
+    });
     expect(screen.getByLabelText('Frequency')).toHaveValue('weekly');
     expect(screen.getByLabelText('Time')).toHaveValue('09:00');
     expect(screen.getByLabelText('Timezone')).toHaveValue('America/New_York');
@@ -695,7 +697,7 @@ describe('Schedules', () => {
 
     fireEvent.click(screen.getByText('New Schedule'));
     await screen.findByRole('dialog', { name: 'Create Schedule' });
-    expect(screen.getByLabelText('Run at')).toBeInTheDocument();
+    expect(await screen.findByLabelText('Run at')).toBeInTheDocument();
     expect(screen.getByText('Create Schedule', { selector: 'button' })).toBeDisabled();
   });
 
@@ -704,7 +706,7 @@ describe('Schedules', () => {
 
     fireEvent.click(screen.getByText('New Schedule'));
     await screen.findByRole('dialog', { name: 'Create Schedule' });
-    expect(screen.getByLabelText('Run at')).toBeInTheDocument();
+    expect(await screen.findByLabelText('Run at')).toBeInTheDocument();
   });
 
   it('shows the recurring schedule builder and timezone input for recurring schedules', async () => {
@@ -762,7 +764,7 @@ describe('Schedules', () => {
     expect(within(calendarSource).getByRole('option', { name: /tenant default business hours \(not configured\)/i })).toBeDisabled();
     expect(screen.getByText('No tenant default business-hours schedule is configured yet. Choose a specific business-hours schedule or set a tenant default first.')).toBeInTheDocument();
 
-    fireEvent.change(screen.getByLabelText('Workflow'), {
+    fireEvent.change(await screen.findByLabelText('Workflow'), {
       target: { value: workflowFixtures[0].workflow_id }
     });
     await screen.findByLabelText('customerId');
@@ -821,7 +823,7 @@ describe('Schedules', () => {
     fireEvent.click(screen.getByText('New Schedule'));
     await screen.findByRole('dialog', { name: 'Create Schedule' });
     fireEvent.change(await screen.findByLabelText('Trigger type'), { target: { value: 'recurring' } });
-    fireEvent.change(screen.getByLabelText('Workflow'), {
+    fireEvent.change(await screen.findByLabelText('Workflow'), {
       target: { value: workflowFixtures[0].workflow_id }
     });
     await screen.findByLabelText('customerId');
@@ -853,7 +855,7 @@ describe('Schedules', () => {
     fireEvent.click(screen.getByText('New Schedule'));
     await screen.findByRole('dialog', { name: 'Create Schedule' });
     fireEvent.change(await screen.findByLabelText('Trigger type'), { target: { value: 'recurring' } });
-    fireEvent.change(screen.getByLabelText('Workflow'), {
+    fireEvent.change(await screen.findByLabelText('Workflow'), {
       target: { value: workflowFixtures[0].workflow_id }
     });
     await screen.findByLabelText('customerId');
@@ -874,7 +876,7 @@ describe('Schedules', () => {
 
     fireEvent.click(screen.getByText('New Schedule'));
     await screen.findByRole('dialog', { name: 'Create Schedule' });
-    fireEvent.change(screen.getByLabelText('Workflow'), {
+    fireEvent.change(await screen.findByLabelText('Workflow'), {
       target: { value: workflowFixtures[0].workflow_id }
     });
 
@@ -887,7 +889,7 @@ describe('Schedules', () => {
 
     fireEvent.click(screen.getByText('New Schedule'));
     await screen.findByRole('dialog', { name: 'Create Schedule' });
-    fireEvent.change(screen.getByLabelText('Workflow'), {
+    fireEvent.change(await screen.findByLabelText('Workflow'), {
       target: { value: workflowFixtures[0].workflow_id }
     });
     await screen.findByLabelText('customerId');
@@ -901,7 +903,7 @@ describe('Schedules', () => {
 
     fireEvent.click(screen.getByText('New Schedule'));
     await screen.findByRole('dialog', { name: 'Create Schedule' });
-    fireEvent.change(screen.getByLabelText('Workflow'), {
+    fireEvent.change(await screen.findByLabelText('Workflow'), {
       target: { value: workflowFixtures[0].workflow_id }
     });
     await screen.findByLabelText('customerId');
@@ -920,7 +922,7 @@ describe('Schedules', () => {
 
     fireEvent.click(screen.getByText('New Schedule'));
     await screen.findByRole('dialog', { name: 'Create Schedule' });
-    fireEvent.change(screen.getByLabelText('Workflow'), {
+    fireEvent.change(await screen.findByLabelText('Workflow'), {
       target: { value: workflowFixtures[0].workflow_id }
     });
     await screen.findByLabelText('customerId');
@@ -943,7 +945,7 @@ describe('Schedules', () => {
 
     fireEvent.click(screen.getByText('New Schedule'));
     await screen.findByRole('dialog', { name: 'Create Schedule' });
-    fireEvent.change(screen.getByLabelText('Workflow'), {
+    fireEvent.change(await screen.findByLabelText('Workflow'), {
       target: { value: workflowFixtures[2].workflow_id }
     });
 
@@ -964,7 +966,7 @@ describe('Schedules', () => {
     fireEvent.click(screen.getByText('New Schedule'));
     await screen.findByRole('dialog', { name: 'Create Schedule' });
     fireEvent.change(await screen.findByLabelText('Trigger type'), { target: { value: 'recurring' } });
-    fireEvent.change(screen.getByLabelText('Workflow'), {
+    fireEvent.change(await screen.findByLabelText('Workflow'), {
       target: { value: workflowFixtures[0].workflow_id }
     });
     await screen.findByLabelText('customerId');

--- a/packages/tickets/src/components/__tests__/ticket-inline-add-prefill.test.tsx
+++ b/packages/tickets/src/components/__tests__/ticket-inline-add-prefill.test.tsx
@@ -712,7 +712,7 @@ describe('QuickAddTicket prefills', () => {
     );
 
     await waitFor(() => expect(getTicketFormDataMock).toHaveBeenCalled());
-    expect(screen.getByTestId('due-date')).toHaveValue('2026-02-05T12:00:00.000Z');
+    expect(await screen.findByTestId('due-date')).toHaveValue('2026-02-05T12:00:00.000Z');
   });
 
   it('navigates to the created ticket when Create + View Ticket is clicked', async () => {
@@ -728,6 +728,7 @@ describe('QuickAddTicket prefills', () => {
 
     await waitFor(() => expect(getTicketFormDataMock).toHaveBeenCalled());
     await waitFor(() => expect(getTicketStatusesMock).toHaveBeenCalledWith('board-1'));
+    await waitForDefaultStatusSelected();
 
     fireEvent.change(screen.getByPlaceholderText('Ticket Title *'), {
       target: { value: 'New ticket from quick add' }


### PR DESCRIPTION
The push-to-main Unit Tests run after merging #2961 failed on `Schedules > renders schema-driven form fields for payload editing` — `Unable to find a label with the text of: Workflow` ([run 29620381984](https://github.com/Nine-Minds/alga-psa/actions/runs/29620381984)).

Same latent race class as the sites already fixed on #2961: a synchronous `getByLabelText` immediately after `findByRole('dialog')` resolves the dialog's accessible name, before its async fields render. On loaded runners the gap is real.

This sweeps the whole file instead of the one failing site:
- all nine `Workflow` select changes now `await screen.findByLabelText('Workflow')`
- both `Run at` presence checks use `findByLabelText`
- the edit-dialog value assertions (`Schedule name`, `Trigger type`) moved inside `waitFor`

Suite green locally: 26/26.