### PR TITLE
report /api/v1/clients returns duplicate rows per client location

### DIFF
--- a/docs/plans/2026-07-18-api-clients-duplicate-rows-plan.md
+++ b/docs/plans/2026-07-18-api-clients-duplicate-rows-plan.md
@@ -1,0 +1,192 @@
+# Fix duplicate client rows in `GET /api/v1/clients` (issue #2980)
+
+**Branch:** `fix/api-clients-duplicate-rows`
+**Issue:** https://github.com/Nine-Minds/alga-psa/issues/2980
+**Status:** approved design; ready for implementation
+**Follow:** `docs/AI_coding_standards.md`
+
+## Problem
+
+`ClientService.list` (`server/src/lib/api/services/ClientService.ts:174-214`) left-joins
+`client_locations` filtered to `is_default = true` in both the data query and the count
+query. The join emits one row per matching default-location row, so a client with N
+`is_default = true` rows appears N times in the response and `pagination.total` inflates
+identically.
+
+Proven mechanism (verified against the dev DB): a client with exactly one default
+location returns exactly one row; adding a second `is_default = true` row returns two.
+The bug is *not* one-row-per-location as the issue title suggests — only rows with
+`is_default = true` multiply the output.
+
+Two ways multiple `is_default = true` rows arise today:
+
+1. **Via the REST API.** `ClientService.createLocation` / `updateLocation`
+   (`ClientService.ts:735`, `:770`) accept `is_default: true` and never clear the
+   previous default. No DB constraint forbids the resulting state.
+2. **Via normal UI use.** `updateClientLocation`
+   (`packages/clients/src/actions/clientLocationActions.ts`) deliberately leaves
+   `is_default = true` on rows it deactivates ("preserve historical audit data"), and
+   deactivating the default promotes nothing. The next location created auto-becomes
+   default → one inactive default + one active default → same fan-out.
+
+The invariant logic (first location auto-default, clear-others-on-set,
+promote-on-unset/delete) exists **only** in the UI server actions; the API service
+re-implemented location CRUD without it. `contact_phone_numbers` already has the
+protective partial unique index (`ux_contact_phone_numbers_default_per_contact`);
+`client_locations` never got one.
+
+## Design decisions (approved)
+
+- **Option C — fix all three layers:** fan-out-proof queries, a DB partial unique
+  index, and shared invariant enforcement.
+- **Full parity:** extract the UI's default-management logic into a shared layer used
+  by both the UI actions and the API service. API behavior changes accordingly (see
+  "API behavior changes" below).
+- **Strict single-default invariant:** `is_default = true` implies `is_active = true`,
+  and at most one default exists per `(tenant, client_id)`. Rationale: billing readers
+  (`packages/billing/src/models/invoice.ts:419,431`,
+  `packages/billing/src/lib/adapters/tenantPartyAdapter.ts:65`) join
+  `cl.is_default = true` with no `is_active` filter, so "audit" defaults on inactive
+  rows already corrupt billing address selection. The UI's keep-default-on-inactive
+  behavior is removed; deactivating the default promotes another active location.
+
+## Implementation
+
+### 1. Shared query helper — `packages/db`
+
+Add a helper next to `tenantJoin` / `tenantJoinSubquery` in
+`packages/db/src/lib/tenantDb.ts` (exact name up to implementer, e.g.
+`tenantJoinDefaultRow`) that joins a **derived table** of at-most-one-row-per-parent
+default children instead of the raw child table:
+
+```sql
+LEFT JOIN (
+  SELECT DISTINCT ON (tenant, <parent_fk>) *
+  FROM <child_table>
+  WHERE is_default = true AND is_active = true
+  ORDER BY tenant, <parent_fk>, updated_at DESC
+) AS <alias> ON <parent>.<pk> = <alias>.<parent_fk> AND <alias>.tenant = <parent>.tenant
+```
+
+Build it on the existing `tenantJoinSubquery` so tenant scoping stays in the engine.
+`DISTINCT ON` makes the join structurally incapable of fan-out even if bad data
+reappears; the unique index (step 2) makes bad data unrepresentable. Parameters:
+child table expression + alias, parent join columns, flag column(s) — keep it minimal,
+it has exactly the six call sites below.
+
+Note: `contact_phone_numbers` has no `is_active` column — the helper must take the
+filter predicate (or flag columns) as a parameter rather than hard-coding
+`is_active`.
+
+### 2. Migration — dedupe, backfill, constrain
+
+New migration `server/migrations/<timestamp>_enforce_single_default_client_location.cjs`:
+
+1. **Clear inactive defaults:** `UPDATE client_locations SET is_default = false WHERE is_default = true AND is_active = false`.
+2. **Dedupe active defaults:** for each `(tenant, client_id)` with more than one
+   active `is_default = true` row, keep one winner — latest `updated_at`, then latest
+   `created_at`, then `location_id` as a deterministic tiebreak — and demote the rest.
+3. **Backfill missing defaults (parity):** for each client with at least one active
+   location but no default, promote the earliest-created active location.
+4. **Add the constraint:**
+   `CREATE UNIQUE INDEX ux_client_locations_default_per_client ON client_locations (tenant, client_id) WHERE is_default = true;`
+   (mirrors `ux_contact_phone_numbers_default_per_contact`).
+
+`down`: drop the index only; the data normalization is intentionally not reversed.
+Steps 1-3 must be plain SQL set operations (no per-row JS loops); the whole migration
+runs in one transaction.
+
+### 3. Shared invariant layer — `packages/clients`
+
+Extract the default-management core from
+`packages/clients/src/actions/clientLocationActions.ts` into a new model module
+(`packages/clients/src/models/clientLocation.ts`, alongside the existing models).
+Transaction-taking functions, no auth/revalidate concerns:
+
+- `createLocation(trx, tenant, clientId, data)` — first active location auto-becomes
+  default; `is_default: true` clears the existing default first (within the same
+  transaction, ordered so the partial unique index is never transiently violated).
+- `updateLocation(trx, tenant, clientId, locationId, data)` — setting
+  `is_default: true` clears the previous default; unsetting the current default
+  promotes another active location; **deactivating (`is_active: false`) the current
+  default clears its flag and promotes another active location** (new behavior,
+  required by the strict invariant).
+- `deleteLocation(trx, tenant, clientId, locationId)` — dependency checks (tickets,
+  tax rates) and promote-before-delete, as the UI action does today.
+
+Rewire:
+
+- UI actions in `clientLocationActions.ts` become thin wrappers (auth + transaction +
+  revalidate around the shared functions). Their observable behavior changes only in
+  the deactivation case described above.
+- `ClientService.createLocation` / `updateLocation` / `deleteLocation`
+  (`server/src/lib/api/services/ClientService.ts:735-826`) call the same functions.
+  Map Postgres unique-violation (`23505`) races on the new index to a 409 Conflict
+  API error.
+
+### 4. Convert the fan-out-capable join sites
+
+Use the step-1 helper at:
+
+| Site | File | Child table |
+|---|---|---|
+| Clients list — data query | `server/src/lib/api/services/ClientService.ts:176` | `client_locations` |
+| Clients list — count query | `server/src/lib/api/services/ClientService.ts:184` | `client_locations` |
+| Contacts list — default phone | `server/src/lib/api/services/ContactService.ts:69-82` (`applyDefaultPhoneJoins`) | `contact_phone_numbers` |
+| Contact getById — default location | `server/src/lib/api/services/ContactService.ts:195-199` | `client_locations` |
+| Tickets — default contact phone | `server/src/lib/api/services/TicketService.ts:145-151` | `contact_phone_numbers` |
+
+The sixth site, `TicketService.ts:487-498`, joins `client_locations` with a mixed
+condition (`t.location_id = cl.location_id OR (t.location_id IS NULL AND cl.is_default)`);
+the specific-location branch joins on the PK and cannot fan out, and the default
+branch is protected by the new index. Leave its shape alone; add a code comment
+pointing at the index.
+
+Semantics note: the clients-list `cl` join only feeds `applyClientFilters`
+(email/phone/address search against the default location) — nothing from `cl` is
+selected. The derived-table join preserves those filter semantics exactly.
+
+### 5. Tests
+
+- **Migration test** (pattern: existing migration tests under `server/src/test/`):
+  seed a multi-active-default client, an inactive-default + active-default client, a
+  no-default client with active locations, and a healthy client; run the migration;
+  assert winner selection, inactive-flag clearing, backfill, and index existence.
+- **API integration tests** (issue #2980 regression): create a client; POST two
+  locations with `is_default: true`; `GET /api/v1/clients` returns the client exactly
+  once with correct `pagination.total`; the second location is default and the first
+  was demoted.
+- **Parity tests** for the shared layer via the API: first location auto-default;
+  promote-on-delete; promote-on-unset; promote-on-deactivate; 409 on constraint race
+  is exercised at least at the unit level.
+- **UI action tests**: existing `clientLocationActions` coverage keeps passing with
+  the wrappers; add/adjust a case for promote-on-deactivate.
+- **Sibling regressions**: contacts list and tickets list with a contact that has
+  multiple phone rows (one default) → no duplicate rows.
+
+### 6. Verification (dev stack)
+
+Dev stack for this worktree: server on `http://localhost:3578`, Postgres on
+`localhost:5472` (db `server`). Run the migration, then replay the customer scenario
+end-to-end via the API (create client → confirm one row → add locations with and
+without `is_default` → confirm still one row, total correct). Verify the clients page
+and a contact/ticket list in the running app render normally. Use `/verify` before
+committing implementation work.
+
+## API behavior changes (release-notes material)
+
+- First location created for a client via the API becomes `is_default: true` even if
+  the request omitted the flag (matches long-standing UI behavior).
+- Creating/updating a location with `is_default: true` clears the previous default.
+- Unsetting, deactivating, or deleting the default promotes another active location.
+- Duplicate rows and inflated `pagination.total` in `GET /api/v1/clients` are fixed;
+  a concurrent double-set-default race can now surface as 409 Conflict.
+
+## Out of scope / follow-ups
+
+- Reply on issue #2980 after merge: correct the mechanism (fan-out is per *default*
+  location; their tenant's clients each carried two default rows), point at the fix
+  and migration, and call out the first-location-auto-default behavior change.
+  Their report cites "v1.3.3" — no such tag exists; the query is unchanged since
+  v1.3.0, so the fix applies regardless.
+- No OpenAPI/schema shape changes; response fields are unchanged.

--- a/packages/billing/tests/automaticInvoices.groupedParentRows.test.tsx
+++ b/packages/billing/tests/automaticInvoices.groupedParentRows.test.tsx
@@ -296,10 +296,10 @@ describe('AutomaticInvoices grouped parent rows', () => {
         document.getElementById('select-child-parent-group:client-1:2026-03-01:2026-04-01-exec-1'),
       ).not.toBeNull();
     });
-    expect(screen.getAllByText('Assigned work item').length).toBeGreaterThan(0);
+    expect((await screen.findAllByText('Assigned work item')).length).toBeGreaterThan(0);
     // Cadence and billing timing share one compact line in the grouped grid.
-    expect(screen.getAllByText('Contract anniversary · Advance').length).toBeGreaterThan(0);
-    expect(screen.getByText('$125.00')).toBeInTheDocument();
+    expect((await screen.findAllByText('Contract anniversary · Advance')).length).toBeGreaterThan(0);
+    expect(await screen.findByText('$125.00')).toBeInTheDocument();
   });
 
   it('is combinable only when all ready children share client/currency/PO/tax/export scope (T004)', async () => {

--- a/packages/billing/vitest.setup.ts
+++ b/packages/billing/vitest.setup.ts
@@ -5,8 +5,13 @@ if (typeof window !== 'undefined') {
   // stretch renders past testing-library's 1s default async timeout (waitFor,
   // findBy*) and flake component suites that pass everywhere else. Genuinely
   // failing waits just take longer to report; passing waits are unaffected.
+  // @testing-library/react ships its own nested copy of @testing-library/dom,
+  // so configure through the react entry point (which re-exports configure from
+  // the copy it actually uses) as well as the top-level dom package.
   const { configure } = await import('@testing-library/dom');
   configure({ asyncUtilTimeout: 10_000 });
+  const { configure: configureReact } = await import('@testing-library/react');
+  configureReact({ asyncUtilTimeout: 10_000 });
 
   const storage = new Map<string, string>();
   const localStorageMock: Storage = {

--- a/packages/clients/src/actions/clientLocationActions.ts
+++ b/packages/clients/src/actions/clientLocationActions.ts
@@ -2,12 +2,16 @@
 
 import { createTenantKnex, tenantDb } from '@alga-psa/db';
 import type { IClientLocation } from '@alga-psa/types';
-import { v4 as uuidv4 } from 'uuid';
 import { withAuth } from '@alga-psa/auth';
 import { withTransaction } from '@alga-psa/db';
 import { Knex } from 'knex';
 import { revalidatePath } from 'next/cache';
 import { assertMspOrClientPortalOwnClientPermission } from '../lib/authHelpers';
+import {
+  createLocation,
+  deleteLocation,
+  updateLocation,
+} from '../models/clientLocation';
 import {
   actionError,
   permissionError,
@@ -27,6 +31,9 @@ function clientLocationActionErrorFrom(error: unknown): ClientLocationActionErro
     }
     if (error.message === 'Cannot unset default: no other active location available') {
       return actionError('Add another active location or choose a different default before unsetting this location as the default.');
+    }
+    if (error.message === 'A default location must be active') {
+      return actionError(error.message);
     }
     if (error.message.startsWith('Cannot delete location: it has associated ')) {
       return actionError(error.message);
@@ -150,54 +157,7 @@ export const createClientLocation = withAuth(async (
         trx
       );
 
-      const locationId = uuidv4();
-
-      // If this is set as default, clear any existing active defaults first
-      // Only clear active locations to preserve historical audit data on inactive rows
-      if (locationData.is_default) {
-        const db = tenantDb(trx, tenant);
-
-        await db.table<IClientLocation>('client_locations')
-          .where({
-            client_id: clientId,
-            is_default: true,
-            is_active: true
-          })
-          .update({
-            is_default: false,
-            updated_at: trx.fn.now()
-          });
-      } else {
-        // If not setting as default, check if we need to auto-set as default
-        const db = tenantDb(trx, tenant);
-
-        const existingDefault = await db.table<IClientLocation>('client_locations')
-          .where({
-            client_id: clientId,
-            is_default: true,
-            is_active: true
-          })
-          .first();
-
-        // If no active default location exists, make this one default
-        if (!existingDefault) {
-          locationData.is_default = true;
-        }
-      }
-
-      const [location] = await tenantDb(trx, tenant).table<IClientLocation>('client_locations')
-        .insert({
-          location_id: locationId,
-          tenant: tenant,
-          ...locationData,
-          client_id: clientId,
-          is_active: locationData.is_active ?? true,
-          created_at: trx.fn.now(),
-          updated_at: trx.fn.now()
-        })
-        .returning('*');
-
-      return location;
+      return createLocation(trx, tenant, clientId, locationData);
     });
   } catch (error) {
     const expected = clientLocationActionErrorFrom(error);
@@ -224,12 +184,10 @@ export const updateClientLocation = withAuth(async (
   let updatedLocation: IClientLocation;
   try {
     updatedLocation = await withTransaction(knex, async (trx: Knex.Transaction) => {
-      // Get the existing location first to check current state
-      // Filter by is_active for consistency (we filter by is_active everywhere)
       const db = tenantDb(trx, tenant);
 
       const existingLocation = await db.table<IClientLocation>('client_locations')
-        .select('client_id', 'is_default')
+        .select('client_id')
         .where({
           location_id: locationId,
           is_active: true
@@ -250,78 +208,13 @@ export const updateClientLocation = withAuth(async (
         trx
       );
 
-      // If setting is_default to true, first clear other defaults for this client
-      if (locationData.is_default === true) {
-        // Clear is_default from all other active locations for this client
-        // Only clear active locations to preserve historical audit data on inactive rows
-        await db.table<IClientLocation>('client_locations')
-          .where({
-            client_id: existingLocation.client_id,
-            is_default: true,
-            is_active: true
-          })
-          .whereNot('location_id', locationId)
-          .update({
-            is_default: false,
-            updated_at: trx.fn.now()
-          });
-      }
-
-      // If unsetting is_default on the current default, reassign to another active location
-      // (same logic as deleteClientLocation to ensure there's always one default)
-      if (locationData.is_default === false && existingLocation.is_default) {
-        const nextDefault = await db.table<IClientLocation>('client_locations')
-          .where({
-            client_id: existingLocation.client_id,
-            is_active: true
-          })
-          .whereNot('location_id', locationId)
-          .first();
-
-        if (!nextDefault) {
-          throw new Error('Cannot unset default: no other active location available');
-        }
-
-        // Clear current default first, then promote next (avoids unique constraint violation)
-        await db.table<IClientLocation>('client_locations')
-          .where({
-            location_id: locationId,
-          })
-          .update({
-            is_default: false,
-            updated_at: trx.fn.now()
-          });
-
-        await db.table<IClientLocation>('client_locations')
-          .where({
-            location_id: nextDefault.location_id,
-          })
-          .update({
-            is_default: true,
-            updated_at: trx.fn.now()
-          });
-
-        // Remove is_default from locationData since we already handled it
-        delete locationData.is_default;
-      }
-
-      // Filter by is_active for consistency (we filter by is_active everywhere)
-      const [location] = await db.table<IClientLocation>('client_locations')
-        .where({
-          location_id: locationId,
-          is_active: true
-        })
-        .update({
-          ...locationData,
-          updated_at: trx.fn.now()
-        })
-        .returning('*');
-
-      if (!location) {
-        throw new Error('Location not found');
-      }
-
-      return location;
+      return updateLocation(
+        trx,
+        tenant,
+        existingLocation.client_id,
+        locationId,
+        locationData
+      );
     });
   } catch (error) {
     const expected = clientLocationActionErrorFrom(error);
@@ -343,11 +236,10 @@ export const deleteClientLocation = withAuth(async (user, { tenant }, locationId
   let clientId: string;
   try {
     clientId = await withTransaction(knex, async (trx: Knex.Transaction) => {
-      // Check if this is the default location
       const db = tenantDb(trx, tenant);
 
       const location = await db.table<IClientLocation>('client_locations')
-        .select('client_id', 'is_default')
+        .select('client_id')
         .where({
           location_id: locationId,
         })
@@ -367,62 +259,7 @@ export const deleteClientLocation = withAuth(async (user, { tenant }, locationId
         trx
       );
 
-      // Check for dependencies before deletion
-      const dependencies: string[] = [];
-
-      // Check for tickets referencing this location
-      const ticketCount = await db.table('tickets')
-        .where({ location_id: locationId })
-        .count('ticket_id as count')
-        .first();
-
-      if (ticketCount && Number(ticketCount.count) > 0) {
-        dependencies.push(`${ticketCount.count} ticket(s)`);
-      }
-
-      // Check for client tax rates referencing this location
-      const taxRateCount = await db.table('client_tax_rates')
-        .where({ location_id: locationId })
-        .count('tax_rate_id as count')
-        .first();
-
-      if (taxRateCount && Number(taxRateCount.count) > 0) {
-        dependencies.push(`${taxRateCount.count} tax rate(s)`);
-      }
-
-      // If there are dependencies, throw an error
-      if (dependencies.length > 0) {
-        throw new Error(`Cannot delete location: it has associated ${dependencies.join(' and ')}`);
-      }
-
-      // If this was the default location, assign default to another active location first
-      if (location.is_default) {
-        const nextDefault = await db.table<IClientLocation>('client_locations')
-          .where({
-            client_id: location.client_id,
-            is_active: true
-          })
-          .whereNot('location_id', locationId)
-          .first();
-
-        if (nextDefault) {
-          await db.table<IClientLocation>('client_locations')
-            .where({
-              location_id: nextDefault.location_id,
-            })
-            .update({
-              is_default: true,
-              updated_at: trx.fn.now()
-            });
-        }
-      }
-
-      // Hard delete the location
-      await db.table<IClientLocation>('client_locations')
-        .where({
-          location_id: locationId,
-        })
-        .delete();
+      await deleteLocation(trx, tenant, location.client_id, locationId);
 
       return location.client_id;
     });
@@ -470,29 +307,7 @@ export const setDefaultClientLocation = withAuth(async (user, { tenant }, locati
         trx
       );
 
-      // Remove default from all other active locations for this client
-      // Only clear active locations to preserve historical audit data on inactive rows
-      await db.table<IClientLocation>('client_locations')
-        .where({
-          client_id: location.client_id,
-          is_default: true,
-          is_active: true
-        })
-        .whereNot('location_id', locationId)
-        .update({
-          is_default: false,
-          updated_at: trx.fn.now()
-        });
-
-      // Set this location as default
-      await db.table<IClientLocation>('client_locations')
-        .where({
-          location_id: locationId,
-        })
-        .update({
-          is_default: true,
-          updated_at: trx.fn.now()
-        });
+      await updateLocation(trx, tenant, location.client_id, locationId, { is_default: true });
 
       return location.client_id;
     });

--- a/packages/clients/src/components/contacts/ContactPortalTab.visibilityGroups.test.tsx
+++ b/packages/clients/src/components/contacts/ContactPortalTab.visibilityGroups.test.tsx
@@ -256,6 +256,9 @@ describe('ContactPortalTab visibility groups', () => {
       });
     });
 
+    await waitFor(() => {
+      expect(screen.getAllByRole('button', { name: 'Edit' })).toHaveLength(2);
+    }, { timeout: 5_000 });
     fireEvent.click(screen.getAllByRole('button', { name: 'Edit' })[1]);
 
     await waitFor(() => {

--- a/packages/clients/src/models/clientLocation.ts
+++ b/packages/clients/src/models/clientLocation.ts
@@ -1,0 +1,217 @@
+import { tenantDb } from '@alga-psa/db';
+import type { IClientLocation } from '@alga-psa/types';
+import type { Knex } from 'knex';
+
+export type CreateClientLocationInput = Omit<
+  IClientLocation,
+  'location_id' | 'tenant' | 'client_id' | 'created_at' | 'updated_at'
+>;
+
+export type UpdateClientLocationInput = Partial<Omit<
+  IClientLocation,
+  'location_id' | 'tenant' | 'client_id' | 'created_at' | 'updated_at'
+>>;
+
+async function lockClient(trx: Knex.Transaction, tenant: string, clientId: string): Promise<void> {
+  const client = await tenantDb(trx, tenant).table('clients')
+    .select('client_id')
+    .where({ client_id: clientId })
+    .forUpdate()
+    .first();
+
+  if (!client) {
+    throw new Error('Client not found');
+  }
+}
+
+async function findNextActiveLocation(
+  trx: Knex.Transaction,
+  tenant: string,
+  clientId: string,
+  excludedLocationId: string
+): Promise<IClientLocation | undefined> {
+  return tenantDb(trx, tenant).table<IClientLocation>('client_locations')
+    .where({ client_id: clientId, is_active: true })
+    .whereNot('location_id', excludedLocationId)
+    .orderBy('created_at', 'asc')
+    .orderBy('location_id', 'asc')
+    .first();
+}
+
+async function clearDefaults(
+  trx: Knex.Transaction,
+  tenant: string,
+  clientId: string,
+  excludedLocationId?: string
+): Promise<void> {
+  const query = tenantDb(trx, tenant).table<IClientLocation>('client_locations')
+    .where({ client_id: clientId, is_default: true });
+
+  if (excludedLocationId) {
+    query.whereNot('location_id', excludedLocationId);
+  }
+
+  await query.update({ is_default: false, updated_at: trx.fn.now() });
+}
+
+async function promoteLocation(
+  trx: Knex.Transaction,
+  tenant: string,
+  locationId: string
+): Promise<void> {
+  await tenantDb(trx, tenant).table<IClientLocation>('client_locations')
+    .where({ location_id: locationId, is_active: true })
+    .update({ is_default: true, updated_at: trx.fn.now() });
+}
+
+export async function createLocation(
+  trx: Knex.Transaction,
+  tenant: string,
+  clientId: string,
+  data: CreateClientLocationInput
+): Promise<IClientLocation> {
+  await lockClient(trx, tenant, clientId);
+  const db = tenantDb(trx, tenant);
+  const isActive = data.is_active ?? true;
+
+  if (data.is_default && !isActive) {
+    throw new Error('A default location must be active');
+  }
+
+  const existingDefault = await db.table<IClientLocation>('client_locations')
+    .where({ client_id: clientId, is_default: true })
+    .first();
+  const shouldBeDefault = isActive && (data.is_default === true || !existingDefault);
+
+  if (shouldBeDefault) {
+    await clearDefaults(trx, tenant, clientId);
+  }
+
+  const [location] = await db.table<IClientLocation>('client_locations')
+    .insert({
+      ...data,
+      location_id: trx.raw('gen_random_uuid()'),
+      tenant,
+      client_id: clientId,
+      is_active: isActive,
+      is_default: shouldBeDefault,
+      created_at: trx.fn.now(),
+      updated_at: trx.fn.now(),
+    })
+    .returning('*');
+
+  return location;
+}
+
+export async function updateLocation(
+  trx: Knex.Transaction,
+  tenant: string,
+  clientId: string,
+  locationId: string,
+  data: UpdateClientLocationInput
+): Promise<IClientLocation> {
+  await lockClient(trx, tenant, clientId);
+  const db = tenantDb(trx, tenant);
+  const existing = await db.table<IClientLocation>('client_locations')
+    .where({ client_id: clientId, location_id: locationId })
+    .forUpdate()
+    .first();
+
+  if (!existing) {
+    throw new Error('Location not found');
+  }
+
+  const updateData = Object.fromEntries(
+    Object.entries(data).filter(([, value]) => value !== undefined)
+  ) as UpdateClientLocationInput;
+  const willBeActive = updateData.is_active ?? existing.is_active ?? true;
+
+  if (updateData.is_default === true && !willBeActive) {
+    throw new Error('A default location must be active');
+  }
+
+  const removesCurrentDefault = Boolean(existing.is_default) && (
+    updateData.is_default === false || updateData.is_active === false
+  );
+
+  if (updateData.is_default === true) {
+    await clearDefaults(trx, tenant, clientId, locationId);
+  } else if (removesCurrentDefault) {
+    const nextDefault = await findNextActiveLocation(trx, tenant, clientId, locationId);
+    if (!nextDefault && willBeActive) {
+      throw new Error('Cannot unset default: no other active location available');
+    }
+
+    await db.table<IClientLocation>('client_locations')
+      .where({ location_id: locationId })
+      .update({ is_default: false, updated_at: trx.fn.now() });
+    if (nextDefault) {
+      await promoteLocation(trx, tenant, nextDefault.location_id);
+    }
+    delete updateData.is_default;
+  } else if (willBeActive && !existing.is_default) {
+    const currentDefault = await db.table<IClientLocation>('client_locations')
+      .where({ client_id: clientId, is_default: true })
+      .first();
+    if (!currentDefault) {
+      updateData.is_default = true;
+    }
+  }
+
+  const [location] = await db.table<IClientLocation>('client_locations')
+    .where({ client_id: clientId, location_id: locationId })
+    .update({ ...updateData, updated_at: trx.fn.now() })
+    .returning('*');
+
+  if (!location) {
+    throw new Error('Location not found');
+  }
+  return location;
+}
+
+export async function deleteLocation(
+  trx: Knex.Transaction,
+  tenant: string,
+  clientId: string,
+  locationId: string
+): Promise<void> {
+  await lockClient(trx, tenant, clientId);
+  const db = tenantDb(trx, tenant);
+  const location = await db.table<IClientLocation>('client_locations')
+    .where({ client_id: clientId, location_id: locationId })
+    .forUpdate()
+    .first();
+
+  if (!location) {
+    throw new Error('Location not found');
+  }
+
+  const dependencies: string[] = [];
+  const [ticketCount, taxRateCount] = await Promise.all([
+    db.table('tickets').where({ location_id: locationId }).count('ticket_id as count').first(),
+    db.table('client_tax_rates').where({ location_id: locationId }).count('tax_rate_id as count').first(),
+  ]);
+  if (ticketCount && Number(ticketCount.count) > 0) {
+    dependencies.push(`${ticketCount.count} ticket(s)`);
+  }
+  if (taxRateCount && Number(taxRateCount.count) > 0) {
+    dependencies.push(`${taxRateCount.count} tax rate(s)`);
+  }
+  if (dependencies.length > 0) {
+    throw new Error(`Cannot delete location: it has associated ${dependencies.join(' and ')}`);
+  }
+
+  if (location.is_default) {
+    const nextDefault = await findNextActiveLocation(trx, tenant, clientId, locationId);
+    await db.table<IClientLocation>('client_locations')
+      .where({ location_id: locationId })
+      .update({ is_default: false, updated_at: trx.fn.now() });
+    if (nextDefault) {
+      await promoteLocation(trx, tenant, nextDefault.location_id);
+    }
+  }
+
+  await db.table<IClientLocation>('client_locations')
+    .where({ client_id: clientId, location_id: locationId })
+    .delete();
+}

--- a/packages/clients/src/models/index.ts
+++ b/packages/clients/src/models/index.ts
@@ -5,3 +5,12 @@
 export { default as Client } from './client';
 export { default as ClientContract } from './clientContract';
 export { default as OnlineMeetingModel } from './onlineMeeting';
+export {
+  createLocation,
+  updateLocation,
+  deleteLocation,
+} from './clientLocation';
+export type {
+  CreateClientLocationInput,
+  UpdateClientLocationInput,
+} from './clientLocation';

--- a/packages/clients/vitest.config.ts
+++ b/packages/clients/vitest.config.ts
@@ -5,6 +5,7 @@ export default defineConfig({
   plugins: [tsconfigPaths({ ignoreConfigErrors: true })],
   test: {
     environment: 'node',
+    setupFiles: ['./vitest.setup.ts'],
     include: ['src/**/*.test.{ts,tsx}'],
     sequence: { concurrent: false, shuffle: false },
     coverage: { enabled: false },

--- a/packages/clients/vitest.setup.ts
+++ b/packages/clients/vitest.setup.ts
@@ -1,0 +1,12 @@
+if (typeof window !== 'undefined') {
+  // CI runs the affected nx projects in parallel, so a saturated runner can
+  // stretch renders past testing-library's 1s default async timeout (waitFor,
+  // findBy*) and flake component suites that pass everywhere else. Configure
+  // through the react entry point as well: @testing-library/react ships its
+  // own nested copy of @testing-library/dom, so configuring only the top-level
+  // dom package leaves the copy react actually uses at the 1s default.
+  const { configure } = await import('@testing-library/dom');
+  configure({ asyncUtilTimeout: 10_000 });
+  const { configure: configureReact } = await import('@testing-library/react');
+  configureReact({ asyncUtilTimeout: 10_000 });
+}

--- a/packages/db/src/lib/tenantDb.test.ts
+++ b/packages/db/src/lib/tenantDb.test.ts
@@ -222,6 +222,34 @@ describe('tenantDb facade', () => {
     );
   });
 
+  it('joins at most one matching child row per tenant and parent', () => {
+    const db = tenantDb(knex, 'tenant-1');
+    const query = db.table('clients as c').select('c.client_id');
+
+    db.tenantJoinFirstMatching(query, 'client_locations', 'cl', 'c.client_id', 'client_id', {
+      type: 'left',
+      rootTenantColumn: 'c.tenant',
+      where: (childQuery, sourceAlias) => childQuery.where({
+        [`${sourceAlias}.is_default`]: true,
+        [`${sourceAlias}.is_active`]: true,
+      }),
+      orderBy: [
+        { column: 'updated_at', order: 'desc' },
+        { column: 'location_id', order: 'desc' },
+      ],
+    });
+
+    expect(query.toString()).toContain(
+      'left join (select distinct on ("__cl_source"."tenant", "__cl_source"."client_id") "__cl_source".* from "client_locations" as "__cl_source"'
+    );
+    expect(query.toString()).toContain(
+      'order by "__cl_source"."tenant" asc, "__cl_source"."client_id" asc, "__cl_source"."updated_at" desc, "__cl_source"."location_id" desc'
+    );
+    expect(query.toString()).toContain(
+      'on "c"."client_id" = "cl"."client_id" and "cl"."tenant" = "c"."tenant"'
+    );
+  });
+
   it('supports correlated tenant predicates outside joins', () => {
     const db = tenantDb(knex, 'tenant-1');
     const waitSearch = db

--- a/packages/db/src/lib/tenantDb.ts
+++ b/packages/db/src/lib/tenantDb.ts
@@ -21,6 +21,16 @@ export interface TenantSubqueryJoinOptions {
   on?: (join: Knex.JoinClause) => void;
 }
 
+export interface TenantFirstMatchingJoinOptions {
+  type?: 'inner' | 'left';
+  rootTenantColumn: string;
+  where: (query: Knex.QueryBuilder, sourceAlias: string) => void;
+  orderBy: ReadonlyArray<{
+    column: string;
+    order: 'asc' | 'desc';
+  }>;
+}
+
 // Default row type for facade queries. `any` (not `Record<string, any>`) is
 // deliberate: knex narrows `.select('alias.col')` over a Record to
 // `Pick<Record, "alias.col">`, keying the row by the literal alias-qualified
@@ -54,6 +64,14 @@ export interface TenantDb {
     left: string,
     right: string,
     options: TenantSubqueryJoinOptions
+  ): Knex.QueryBuilder;
+  tenantJoinFirstMatching(
+    builder: Knex.QueryBuilder,
+    tableName: string,
+    alias: string,
+    rootParentColumn: string,
+    childParentColumn: string,
+    options: TenantFirstMatchingJoinOptions
   ): Knex.QueryBuilder;
   tenantWhereColumn(
     builder: Knex.QueryBuilder,
@@ -293,6 +311,47 @@ export function tenantDb(conn: Knex | Knex.Transaction, tenantInput: string | nu
     return builder.join(subquery, joinDerivedTenantQuery);
   }
 
+  function tenantJoinFirstMatching(
+    builder: Knex.QueryBuilder,
+    tableName: string,
+    alias: string,
+    rootParentColumn: string,
+    childParentColumn: string,
+    options: TenantFirstMatchingJoinOptions
+  ): Knex.QueryBuilder {
+    const parsed = parseTableExpression(tableName);
+    if (parsed.rootAlias !== parsed.tableName) {
+      throw new Error('tenantDb.tenantJoinFirstMatching requires a table name without an alias');
+    }
+    if (!alias.trim() || !childParentColumn.trim() || options.orderBy.length === 0) {
+      throw new Error('tenantDb.tenantJoinFirstMatching requires an alias, parent column, and ordering');
+    }
+
+    const sourceAlias = `__${alias}_source`;
+    const subquery = table(`${tableName} as ${sourceAlias}`)
+      .distinctOn([`${sourceAlias}.tenant`, `${sourceAlias}.${childParentColumn}`])
+      .select(`${sourceAlias}.*`)
+      .orderBy(`${sourceAlias}.tenant`, 'asc')
+      .orderBy(`${sourceAlias}.${childParentColumn}`, 'asc');
+
+    options.where(subquery, sourceAlias);
+    for (const ordering of options.orderBy) {
+      subquery.orderBy(`${sourceAlias}.${ordering.column}`, ordering.order);
+    }
+
+    return tenantJoinSubquery(
+      builder,
+      subquery.as(alias),
+      rootParentColumn,
+      `${alias}.${childParentColumn}`,
+      {
+        type: options.type,
+        rootTenantColumn: options.rootTenantColumn,
+        joinedTenantColumn: `${alias}.tenant`,
+      }
+    );
+  }
+
   function tenantWhereColumn(
     builder: Knex.QueryBuilder,
     leftTenantColumn: string,
@@ -325,6 +384,7 @@ export function tenantDb(conn: Knex | Knex.Transaction, tenantInput: string | nu
     subquery: table,
     tenantJoin,
     tenantJoinSubquery,
+    tenantJoinFirstMatching,
     tenantWhereColumn,
     unscoped,
   };

--- a/packages/scheduling/tests/timeSheetTable.feedback.test.ts
+++ b/packages/scheduling/tests/timeSheetTable.feedback.test.ts
@@ -1,6 +1,6 @@
 // @vitest-environment jsdom
 import * as React from 'react';
-import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { createRoot, Root } from 'react-dom/client';
 import { flushSync } from 'react-dom';
 
@@ -105,6 +105,15 @@ describe('TimeSheetTable feedback markers', () => {
     Object.defineProperty(container, 'offsetWidth', { value: 900, configurable: true });
     document.body.appendChild(container);
     root = createRoot(container);
+  });
+
+  afterEach(() => {
+    // Unmount before the jsdom environment is torn down; otherwise React's
+    // scheduler fires pending work afterwards ("window is not defined").
+    flushSync(() => {
+      root.unmount();
+    });
+    container.remove();
   });
 
   const commonProps = {

--- a/packages/tickets/src/components/settings/BoardsSettings.copyStatuses.test.tsx
+++ b/packages/tickets/src/components/settings/BoardsSettings.copyStatuses.test.tsx
@@ -752,7 +752,7 @@ describe('BoardsSettings ticket status copy flow', () => {
 
     await waitFor(() => {
       expect(updateBoardMock).toHaveBeenCalled();
-    });
+    }, { timeout: 5_000 });
 
     // The editor stays open (no return to the list) and the header reflects the saved name.
     await waitFor(() => {

--- a/server/migrations/20260718234058_enforce_single_default_client_location.cjs
+++ b/server/migrations/20260718234058_enforce_single_default_client_location.cjs
@@ -1,0 +1,70 @@
+
+exports.up = async function up(knex) {
+  await knex.raw(`
+    UPDATE client_locations
+    SET is_default = false,
+        updated_at = NOW()
+    WHERE is_default = true
+      AND is_active = false
+  `);
+
+  await knex.raw(`
+    WITH ranked_defaults AS (
+      SELECT tenant,
+             location_id,
+             ROW_NUMBER() OVER (
+               PARTITION BY tenant, client_id
+               ORDER BY updated_at DESC, created_at DESC, location_id DESC
+             ) AS default_rank
+      FROM client_locations
+      WHERE is_default = true
+        AND is_active = true
+    )
+    UPDATE client_locations AS location
+    SET is_default = false,
+        updated_at = NOW()
+    FROM ranked_defaults AS ranked
+    WHERE location.tenant = ranked.tenant
+      AND location.location_id = ranked.location_id
+      AND ranked.default_rank > 1
+  `);
+
+  await knex.raw(`
+    WITH ranked_active_locations AS (
+      SELECT location.tenant,
+             location.location_id,
+             ROW_NUMBER() OVER (
+               PARTITION BY location.tenant, location.client_id
+               ORDER BY location.created_at ASC, location.location_id ASC
+             ) AS active_rank
+      FROM client_locations AS location
+      WHERE location.is_active = true
+        AND NOT EXISTS (
+          SELECT 1
+          FROM client_locations AS existing_default
+          WHERE existing_default.tenant = location.tenant
+            AND existing_default.client_id = location.client_id
+            AND existing_default.is_default = true
+        )
+    )
+    UPDATE client_locations AS location
+    SET is_default = true,
+        updated_at = NOW()
+    FROM ranked_active_locations AS ranked
+    WHERE location.tenant = ranked.tenant
+      AND location.location_id = ranked.location_id
+      AND ranked.active_rank = 1
+  `);
+
+  await knex.raw(`
+    CREATE UNIQUE INDEX ux_client_locations_default_per_client
+    ON client_locations (tenant, client_id)
+    WHERE is_default = true
+  `);
+};
+
+exports.down = async function down(knex) {
+  await knex.raw('DROP INDEX IF EXISTS ux_client_locations_default_per_client');
+};
+
+exports.config = { transaction: true };

--- a/server/src/lib/api/services/ClientService.ts
+++ b/server/src/lib/api/services/ClientService.ts
@@ -10,7 +10,12 @@ import { getClientLogoUrl } from '@alga-psa/formatting/avatarUtils';
 import { createDefaultTaxSettingsInternal } from '@alga-psa/billing/actions';
 import { isEnterprise } from '@alga-psa/core';
 import { deleteEntityWithValidation } from '@alga-psa/core/server';
-import { NotFoundError, ValidationError } from '../../api/middleware/apiMiddleware';
+import { ConflictError, NotFoundError, ValidationError } from '../../api/middleware/apiMiddleware';
+import {
+  createLocation as createClientLocation,
+  deleteLocation as deleteClientLocation,
+  updateLocation as updateClientLocation,
+} from '@alga-psa/clients/models';
 import {
   CreateClientData,
   UpdateClientData,
@@ -36,6 +41,34 @@ import {
 function maybeUserActorFromContext(context: ServiceContext) {
   if (typeof context.userId !== 'string' || !context.userId) return undefined;
   return { actorType: 'USER' as const, actorUserId: context.userId };
+}
+
+function throwClientLocationApiError(error: unknown): never {
+  if ((error as { code?: string })?.code === '23505') {
+    throw new ConflictError('Another location is already the default for this client');
+  }
+
+  if (error instanceof Error) {
+    if (error.message === 'Client not found') {
+      throw new NotFoundError('Client not found');
+    }
+    if (error.message === 'Location not found') {
+      throw new NotFoundError('Client location not found');
+    }
+    if (error.message === 'A default location must be active') {
+      throw new ValidationError('Validation failed', [
+        { path: ['is_default'], message: error.message },
+      ]);
+    }
+    if (
+      error.message === 'Cannot unset default: no other active location available' ||
+      error.message.startsWith('Cannot delete location: it has associated ')
+    ) {
+      throw new ConflictError(error.message);
+    }
+  }
+
+  throw error;
 }
 
 function scopedTable<Row extends object = Record<string, any>>(
@@ -173,19 +206,33 @@ export class ClientService extends BaseService<IClient> {
       // Build base query with account manager and location joins
       let dataQuery = db.table('clients as c');
       db.tenantJoin(dataQuery, 'users as u', 'c.account_manager_id', 'u.user_id', { type: 'left' });
-      db.tenantJoin(dataQuery, 'client_locations as cl', 'c.client_id', 'cl.client_id', {
+      db.tenantJoinFirstMatching(dataQuery, 'client_locations', 'cl', 'c.client_id', 'client_id', {
         type: 'left',
-        on(join) {
-          join.andOn('cl.is_default', '=', trx.raw('true'));
-        },
+        rootTenantColumn: 'c.tenant',
+        where: (query, alias) => query.where({
+          [`${alias}.is_default`]: true,
+          [`${alias}.is_active`]: true,
+        }),
+        orderBy: [
+          { column: 'updated_at', order: 'desc' },
+          { column: 'created_at', order: 'desc' },
+          { column: 'location_id', order: 'desc' },
+        ],
       });
 
       let countQuery = db.table('clients as c');
-      db.tenantJoin(countQuery, 'client_locations as cl', 'c.client_id', 'cl.client_id', {
+      db.tenantJoinFirstMatching(countQuery, 'client_locations', 'cl', 'c.client_id', 'client_id', {
         type: 'left',
-        on(join) {
-          join.andOn('cl.is_default', '=', trx.raw('true'));
-        },
+        rootTenantColumn: 'c.tenant',
+        where: (query, alias) => query.where({
+          [`${alias}.is_default`]: true,
+          [`${alias}.is_active`]: true,
+        }),
+        orderBy: [
+          { column: 'updated_at', order: 'desc' },
+          { column: 'created_at', order: 'desc' },
+          { column: 'location_id', order: 'desc' },
+        ],
       });
 
       // Apply filters
@@ -738,31 +785,22 @@ export class ClientService extends BaseService<IClient> {
     context: ServiceContext
   ): Promise<IClientLocation> {
     const { knex } = await this.getKnex();
-    return withTransaction(knex, async (trx) => {
-      // Verify client exists
-      const client = await scopedTable(trx, context.tenant, 'clients')
-        .where({ client_id: clientId })
-        .first();
+    try {
+      return await withTransaction(knex, async (trx) => {
+        // Verify client exists before entering the shared mutation layer.
+        const client = await scopedTable(trx, context.tenant, 'clients')
+          .where({ client_id: clientId })
+          .first();
 
-      if (!client) {
-        throw new NotFoundError('Client not found');
-      }
+        if (!client) {
+          throw new NotFoundError('Client not found');
+        }
 
-      const locationData = {
-        location_id: knex.raw('gen_random_uuid()'),
-        client_id: clientId,
-        ...data,
-        tenant: context.tenant,
-        created_at: knex.raw('now()'),
-        updated_at: knex.raw('now()')
-      };
-
-      const [location] = await tenantDb(trx, context.tenant).table('client_locations')
-        .insert(locationData)
-        .returning('*');
-
-      return location as IClientLocation;
-    });
+        return createClientLocation(trx, context.tenant, clientId, data);
+      });
+    } catch (error) {
+      throwClientLocationApiError(error);
+    }
   }
 
   /**
@@ -774,32 +812,13 @@ export class ClientService extends BaseService<IClient> {
     context: ServiceContext
   ): Promise<IClientLocation> {
     const { knex } = await this.getKnex();
-    return withTransaction(knex, async (trx) => {
-      const db = tenantDb(trx, context.tenant);
-      const updateData: any = {
-        ...data,
-        updated_at: knex.raw('now()')
-      };
-
-      // Remove undefined values
-      Object.keys(updateData).forEach(key => {
-        if (updateData[key] === undefined) {
-          delete updateData[key];
-        }
-      });
-
-      const [location] = await db.table('client_locations')
-        .where('location_id', locationId)
-        .where('client_id', clientId)
-        .update(updateData)
-        .returning('*');
-
-      if (!location) {
-        throw new NotFoundError('Client location not found');
-      }
-
-      return location as IClientLocation;
-    });
+    try {
+      return await withTransaction(knex, (trx) =>
+        updateClientLocation(trx, context.tenant, clientId, locationId, data)
+      );
+    } catch (error) {
+      throwClientLocationApiError(error);
+    }
   }
 
   /**
@@ -810,19 +829,13 @@ export class ClientService extends BaseService<IClient> {
     context: ServiceContext
   ): Promise<void> {
     const { knex } = await this.getKnex();
-    return withTransaction(knex, async (trx) => {
-      const result = await scopedTable(trx, context.tenant, 'client_locations')
-        .where({
-          location_id: locationId,
-          client_id: clientId
-        })
-        .delete();
-
-      if (result === 0) {
-        throw new NotFoundError('Location not found');
-      }
-
-    });
+    try {
+      await withTransaction(knex, (trx) =>
+        deleteClientLocation(trx, context.tenant, clientId, locationId)
+      );
+    } catch (error) {
+      throwClientLocationApiError(error);
+    }
   }
 
   /**

--- a/server/src/lib/api/services/ContactService.ts
+++ b/server/src/lib/api/services/ContactService.ts
@@ -68,11 +68,15 @@ function applyEmailSearchClause(
 
 function applyDefaultPhoneJoins(query: Knex.QueryBuilder, knex: Knex, tenant: string, contactAlias = 'c'): Knex.QueryBuilder {
   const scopedDb = tenantDb(knex, tenant);
-  scopedDb.tenantJoin(query, 'contact_phone_numbers as cpn_default', `${contactAlias}.contact_name_id`, 'cpn_default.contact_name_id', {
+  scopedDb.tenantJoinFirstMatching(query, 'contact_phone_numbers', 'cpn_default', `${contactAlias}.contact_name_id`, 'contact_name_id', {
     type: 'left',
-    on(join) {
-      join.andOn('cpn_default.is_default', '=', knex.raw('true'));
-    },
+    rootTenantColumn: `${contactAlias}.tenant`,
+    where: (childQuery, alias) => childQuery.where(`${alias}.is_default`, true),
+    orderBy: [
+      { column: 'updated_at', order: 'desc' },
+      { column: 'created_at', order: 'desc' },
+      { column: 'contact_phone_number_id', order: 'desc' },
+    ],
   });
   scopedDb.tenantJoin(query, 'contact_phone_type_definitions as cptd_default', 'cpn_default.custom_phone_type_id', 'cptd_default.contact_phone_type_id', {
     type: 'left',
@@ -192,12 +196,18 @@ export class ContactService extends BaseService<IContact> {
       const scopedDb = tenantDb(trx, context.tenant);
       const contactQuery = scopedDb.table('contacts as c');
       scopedDb.tenantJoin(contactQuery, 'clients as comp', 'c.client_id', 'comp.client_id', { type: 'left' });
-      scopedDb.tenantJoin(contactQuery, 'client_locations as cl', 'comp.client_id', 'cl.client_id', {
+      scopedDb.tenantJoinFirstMatching(contactQuery, 'client_locations', 'cl', 'comp.client_id', 'client_id', {
         type: 'left',
         rootTenantColumn: 'comp.tenant',
-        on(join) {
-          join.andOn('cl.is_default', '=', knex.raw('true'));
-        },
+        where: (childQuery, alias) => childQuery.where({
+          [`${alias}.is_default`]: true,
+          [`${alias}.is_active`]: true,
+        }),
+        orderBy: [
+          { column: 'updated_at', order: 'desc' },
+          { column: 'created_at', order: 'desc' },
+          { column: 'location_id', order: 'desc' },
+        ],
       });
       const baseContact = await applyDefaultPhoneJoins(contactQuery, trx, context.tenant)
         .where('c.contact_name_id', id)

--- a/server/src/lib/api/services/TicketService.ts
+++ b/server/src/lib/api/services/TicketService.ts
@@ -142,12 +142,15 @@ function applyDefaultContactPhoneJoin(
 ): Knex.QueryBuilder {
   const scopedDb = tenantDb(knex, tenant);
   scopedDb.tenantJoin(query, `contacts as ${contactAlias}`, `${ticketAlias}.contact_name_id`, `${contactAlias}.contact_name_id`, { type: 'left' });
-  scopedDb.tenantJoin(query, `contact_phone_numbers as ${phoneAlias}`, `${contactAlias}.contact_name_id`, `${phoneAlias}.contact_name_id`, {
+  scopedDb.tenantJoinFirstMatching(query, 'contact_phone_numbers', phoneAlias, `${contactAlias}.contact_name_id`, 'contact_name_id', {
     type: 'left',
     rootTenantColumn: `${contactAlias}.tenant`,
-    on(join) {
-      join.andOn(`${phoneAlias}.is_default`, '=', knex.raw('true'));
-    },
+    where: (childQuery, alias) => childQuery.where(`${alias}.is_default`, true),
+    orderBy: [
+      { column: 'updated_at', order: 'desc' },
+      { column: 'created_at', order: 'desc' },
+      { column: 'contact_phone_number_id', order: 'desc' },
+    ],
   });
   return query;
 }
@@ -487,6 +490,8 @@ export class TicketService extends BaseService<ITicket> {
     scopedDb.tenantJoin(ticketQuery, 'client_locations as cl', 't.client_id', 'cl.client_id', {
       type: 'left',
       on(join) {
+        // The default branch is single-row by ux_client_locations_default_per_client;
+        // the explicit location branch joins the tenant-qualified primary key.
         join.andOn(function() {
           this.on('t.location_id', '=', 'cl.location_id')
               .orOn(function() {

--- a/server/src/test/e2e/api/clients.e2e.test.ts
+++ b/server/src/test/e2e/api/clients.e2e.test.ts
@@ -224,10 +224,12 @@ describe('Clients API E2E Tests', () => {
 
   describe('Client Locations', () => {
     let testClientId: string;
+    let testClientName: string;
 
     beforeEach(async () => {
       // Create a test client for location tests
       const clientData = createClientTestData();
+      testClientName = clientData.client_name;
       const response = await env.apiClient.post('/api/v1/clients', clientData);
       
       if (response.status !== 201) {
@@ -287,6 +289,41 @@ describe('Clients API E2E Tests', () => {
       expect(response.status).toBe(200);
       expect(response.data.data).toBeInstanceOf(Array);
       expect(response.data.data.length).toBeGreaterThan(0);
+    });
+
+    it('keeps one client list row when successive locations are made default', async () => {
+      const firstLocation = createClientLocationTestData({ is_default: true });
+      const secondLocation = createClientLocationTestData({ is_default: true });
+
+      const firstResponse = await env.apiClient.post(
+        `/api/v1/clients/${testClientId}/locations`,
+        firstLocation
+      );
+      const secondResponse = await env.apiClient.post(
+        `/api/v1/clients/${testClientId}/locations`,
+        secondLocation
+      );
+
+      expect(firstResponse.status).toBe(201);
+      expect(secondResponse.status).toBe(201);
+      expect(firstResponse.data.data.is_default).toBe(true);
+      expect(secondResponse.data.data.is_default).toBe(true);
+
+      const locationsResponse = await env.apiClient.get(`/api/v1/clients/${testClientId}/locations`);
+      const defaultLocations = locationsResponse.data.data.filter(
+        (location: { is_default: boolean }) => location.is_default
+      );
+      expect(defaultLocations).toHaveLength(1);
+      expect(defaultLocations[0].location_id).toBe(secondResponse.data.data.location_id);
+
+      const listResponse = await env.apiClient.get(
+        `/api/v1/clients?client_name=${encodeURIComponent(testClientName)}&limit=100&page=1`
+      );
+      expect(listResponse.status).toBe(200);
+      expect(
+        listResponse.data.data.filter((client: { client_id: string }) => client.client_id === testClientId)
+      ).toHaveLength(1);
+      expect(listResponse.data.pagination.total).toBe(1);
     });
   });
 

--- a/server/src/test/integration/clientLocationDefaultMigration.integration.test.ts
+++ b/server/src/test/integration/clientLocationDefaultMigration.integration.test.ts
@@ -1,0 +1,122 @@
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+import type { Knex } from 'knex';
+import { createRequire } from 'node:module';
+import { v4 as uuidv4 } from 'uuid';
+
+import { createTestDbConnection } from '../../../test-utils/dbConfig';
+
+const require = createRequire(import.meta.url);
+const migration = require('../../../migrations/20260718234058_enforce_single_default_client_location.cjs') as {
+  up: (knex: Knex | Knex.Transaction) => Promise<void>;
+  down: (knex: Knex | Knex.Transaction) => Promise<void>;
+};
+
+describe('single default client location migration (integration)', () => {
+  let knex: Knex;
+
+  beforeAll(async () => {
+    knex = await createTestDbConnection({ runSeeds: true });
+  });
+
+  afterAll(async () => {
+    await knex?.destroy();
+  });
+
+  it('normalizes defaults, backfills missing defaults, and enforces uniqueness', async () => {
+    const trx = await knex.transaction();
+    let testError: unknown;
+
+    try {
+      await migration.down(trx);
+      const tenantRow = await trx('tenants').select('tenant').first();
+      if (!tenantRow?.tenant) {
+        throw new Error('Expected the integration database to contain a seeded tenant');
+      }
+
+      const clientIds = {
+        duplicate: uuidv4(),
+        inactive: uuidv4(),
+        missing: uuidv4(),
+        healthy: uuidv4(),
+      };
+      await trx('clients').insert(Object.entries(clientIds).map(([label, clientId]) => ({
+        tenant: tenantRow.tenant,
+        client_id: clientId,
+        client_name: `Default migration ${label} ${clientId}`,
+      })));
+
+      const duplicateOlder = uuidv4();
+      const duplicateWinner = uuidv4();
+      const inactiveDefault = uuidv4();
+      const activeDefault = uuidv4();
+      const missingWinner = uuidv4();
+      const missingLater = uuidv4();
+      const healthyDefault = uuidv4();
+      const baseLocation = {
+        tenant: tenantRow.tenant,
+        location_name: 'Migration fixture',
+        address_line1: '1 Test Way',
+        city: 'Testville',
+        country_code: 'US',
+        country_name: 'United States',
+      };
+
+      await trx('client_locations').insert([
+        { ...baseLocation, location_id: duplicateOlder, client_id: clientIds.duplicate, is_active: true, is_default: true, created_at: '2026-01-01T00:00:00Z', updated_at: '2026-01-01T00:00:00Z' },
+        { ...baseLocation, location_id: duplicateWinner, client_id: clientIds.duplicate, is_active: true, is_default: true, created_at: '2026-01-02T00:00:00Z', updated_at: '2026-02-01T00:00:00Z' },
+        { ...baseLocation, location_id: inactiveDefault, client_id: clientIds.inactive, is_active: false, is_default: true, created_at: '2026-01-01T00:00:00Z', updated_at: '2026-01-01T00:00:00Z' },
+        { ...baseLocation, location_id: activeDefault, client_id: clientIds.inactive, is_active: true, is_default: true, created_at: '2026-01-02T00:00:00Z', updated_at: '2026-01-02T00:00:00Z' },
+        { ...baseLocation, location_id: missingWinner, client_id: clientIds.missing, is_active: true, is_default: false, created_at: '2026-01-01T00:00:00Z', updated_at: '2026-01-01T00:00:00Z' },
+        { ...baseLocation, location_id: missingLater, client_id: clientIds.missing, is_active: true, is_default: false, created_at: '2026-01-02T00:00:00Z', updated_at: '2026-01-02T00:00:00Z' },
+        { ...baseLocation, location_id: healthyDefault, client_id: clientIds.healthy, is_active: true, is_default: true, created_at: '2026-01-01T00:00:00Z', updated_at: '2026-01-01T00:00:00Z' },
+      ]);
+
+      await migration.up(trx);
+
+      const rows = await trx('client_locations')
+        .where({ tenant: tenantRow.tenant })
+        .whereIn('client_id', Object.values(clientIds))
+        .select('location_id', 'is_default');
+      const defaultByLocation = new Map(rows.map((row) => [row.location_id, row.is_default]));
+
+      expect(defaultByLocation.get(duplicateOlder)).toBe(false);
+      expect(defaultByLocation.get(duplicateWinner)).toBe(true);
+      expect(defaultByLocation.get(inactiveDefault)).toBe(false);
+      expect(defaultByLocation.get(activeDefault)).toBe(true);
+      expect(defaultByLocation.get(missingWinner)).toBe(true);
+      expect(defaultByLocation.get(missingLater)).toBe(false);
+      expect(defaultByLocation.get(healthyDefault)).toBe(true);
+
+      const index = await trx('pg_indexes')
+        .where({ schemaname: 'public', tablename: 'client_locations', indexname: 'ux_client_locations_default_per_client' })
+        .select('indexdef')
+        .first();
+      expect(index?.indexdef).toContain('UNIQUE INDEX');
+      expect(index?.indexdef).toContain('WHERE (is_default = true)');
+
+      let duplicateError: unknown;
+      try {
+        await trx.transaction(async (savepoint) => {
+          await savepoint('client_locations').insert({
+            ...baseLocation,
+            location_id: uuidv4(),
+            client_id: clientIds.healthy,
+            is_active: true,
+            is_default: true,
+          });
+        });
+      } catch (error) {
+        duplicateError = error;
+      }
+      expect(duplicateError).toMatchObject({ code: '23505' });
+    } catch (error) {
+      testError = error;
+    } finally {
+      await trx.rollback();
+    }
+
+    if (testError) {
+      throw testError;
+    }
+  });
+});

--- a/server/src/test/integration/clientLocationModel.integration.test.ts
+++ b/server/src/test/integration/clientLocationModel.integration.test.ts
@@ -1,0 +1,91 @@
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+import type { Knex } from 'knex';
+import { v4 as uuidv4 } from 'uuid';
+
+import {
+  createLocation,
+  deleteLocation,
+  updateLocation,
+} from '../../../../packages/clients/src/models/clientLocation';
+import { createTestDbConnection } from '../../../test-utils/dbConfig';
+
+describe('client location default management (integration)', () => {
+  let knex: Knex;
+
+  beforeAll(async () => {
+    knex = await createTestDbConnection({ runSeeds: true });
+  });
+
+  afterAll(async () => {
+    await knex?.destroy();
+  });
+
+  it('keeps UI and API location transitions on the same single-default invariant', async () => {
+    const trx = await knex.transaction();
+    let testError: unknown;
+
+    try {
+      const tenantRow = await trx('tenants').select('tenant').first();
+      if (!tenantRow?.tenant) {
+        throw new Error('Expected the integration database to contain a seeded tenant');
+      }
+
+      const clientId = uuidv4();
+      await trx('clients').insert({
+        tenant: tenantRow.tenant,
+        client_id: clientId,
+        client_name: `Location model fixture ${clientId}`,
+      });
+
+      const locationInput = (name: string) => ({
+        location_name: name,
+        address_line1: `${name} address`,
+        city: 'Testville',
+        country_code: 'US',
+        country_name: 'United States',
+        is_active: true,
+      });
+
+      const first = await createLocation(trx, tenantRow.tenant, clientId, locationInput('First'));
+      expect(first.is_default).toBe(true);
+
+      const second = await createLocation(trx, tenantRow.tenant, clientId, {
+        ...locationInput('Second'),
+        is_default: true,
+      });
+      expect(second.is_default).toBe(true);
+      await expect(trx('client_locations').where({ location_id: first.location_id }).first())
+        .resolves.toMatchObject({ is_default: false });
+
+      await updateLocation(trx, tenantRow.tenant, clientId, second.location_id, { is_default: false });
+      await expect(trx('client_locations').where({ location_id: first.location_id }).first())
+        .resolves.toMatchObject({ is_default: true });
+
+      await updateLocation(trx, tenantRow.tenant, clientId, first.location_id, { is_active: false });
+      await expect(trx('client_locations').where({ location_id: first.location_id }).first())
+        .resolves.toMatchObject({ is_active: false, is_default: false });
+      await expect(trx('client_locations').where({ location_id: second.location_id }).first())
+        .resolves.toMatchObject({ is_default: true });
+
+      const third = await createLocation(trx, tenantRow.tenant, clientId, locationInput('Third'));
+      expect(third.is_default).toBe(false);
+      await deleteLocation(trx, tenantRow.tenant, clientId, second.location_id);
+      await expect(trx('client_locations').where({ location_id: third.location_id }).first())
+        .resolves.toMatchObject({ is_default: true });
+
+      await expect(createLocation(trx, tenantRow.tenant, clientId, {
+        ...locationInput('Inactive default'),
+        is_active: false,
+        is_default: true,
+      })).rejects.toThrow('A default location must be active');
+    } catch (error) {
+      testError = error;
+    } finally {
+      await trx.rollback();
+    }
+
+    if (testError) {
+      throw testError;
+    }
+  });
+});

--- a/server/src/test/integration/contactServicePhoneSearch.integration.test.ts
+++ b/server/src/test/integration/contactServicePhoneSearch.integration.test.ts
@@ -162,5 +162,53 @@ describe('contact service normalized phone search and sort integration', () => {
       '111-0000',
       '999-0000',
     ]);
+    expect(result.total).toBe(2);
+  });
+
+  it('returns one list row for a contact with default and secondary phone rows', async () => {
+    const tenantId = uuidv4();
+    const clientId = uuidv4();
+    const service = new ContactService();
+
+    await createTenant(db, tenantId);
+    await createClient(db, tenantId, clientId);
+    vi.spyOn(service as any, 'getKnex').mockResolvedValue({ knex: db, tenant: tenantId });
+
+    const contact = await db.transaction((trx) => ContactModel.createContact({
+      full_name: 'Sibling Join Contact',
+      email: `sibling-${tenantId}@example.com`,
+      client_id: clientId,
+      phone_numbers: [
+        {
+          phone_number: '555-0100',
+          canonical_type: 'work',
+          is_default: true,
+          display_order: 0,
+        },
+        {
+          phone_number: '555-0101',
+          canonical_type: 'mobile',
+          is_default: false,
+          display_order: 1,
+        },
+      ],
+    }, tenantId, trx));
+
+    const result = await service.list({
+      page: 1,
+      limit: 10,
+      filters: { client_id: clientId },
+    }, {
+      tenant: tenantId,
+      userId: 'test-user',
+    });
+
+    expect(result.total).toBe(1);
+    expect(result.data).toHaveLength(1);
+    expect(result.data[0]).toMatchObject({
+      contact_name_id: contact.contact_name_id,
+      default_phone_number: '555-0100',
+    });
+    expect(result.data[0]?.phone_numbers).toHaveLength(2);
   });
 });

--- a/server/src/test/integration/resolveInboundTicketContext.domainFallback.integration.test.ts
+++ b/server/src/test/integration/resolveInboundTicketContext.domainFallback.integration.test.ts
@@ -104,7 +104,9 @@ describeDb('resolve_inbound_ticket_context (integration)', () => {
       city: 'City',
       country_code: 'US',
       country_name: 'United States',
-      is_default: true,
+      // The defaults row below pins this location by id; the seeded client already
+      // owns the single allowed default (ux_client_locations_default_per_client).
+      is_default: false,
       created_at: db.fn.now(),
       updated_at: db.fn.now(),
     });

--- a/server/src/test/integration/ticketStatusReadSurfaces.integration.test.ts
+++ b/server/src/test/integration/ticketStatusReadSurfaces.integration.test.ts
@@ -4,8 +4,15 @@ import { v4 as uuidv4 } from 'uuid';
 
 import { tenantDb } from '@alga-psa/db';
 import { createTestDbConnection } from '../../../test-utils/dbConfig';
+import { ContactModel } from '@alga-psa/shared/models/contactModel';
 import { TicketModel } from '@shared/models/ticketModel';
 import { TicketService } from '@/lib/api/services/TicketService';
+
+vi.mock('@alga-psa/formatting/avatarUtils', () => ({
+  getClientLogoUrl: vi.fn().mockResolvedValue(null),
+  getContactAvatarUrl: vi.fn().mockResolvedValue(null),
+  getUserAvatarUrl: vi.fn().mockResolvedValue(null),
+}));
 
 const HOOK_TIMEOUT = 180_000;
 
@@ -15,6 +22,7 @@ type ReadSurfaceFixture = {
   tenantId: string;
   userId: string;
   clientId: string;
+  contactId: string;
   boardAId: string;
   boardBId: string;
   boardAStatusId: string;
@@ -51,6 +59,8 @@ function schemaTable(table: string) {
 
 async function cleanupTenant(tenantId: string): Promise<void> {
   await tenantTable(tenantId, 'tickets').del();
+  await tenantTable(tenantId, 'contact_phone_numbers').del();
+  await tenantTable(tenantId, 'contacts').del();
   await tenantTable(tenantId, 'next_number').del();
   await tenantTable(tenantId, 'statuses').del();
   await tenantTable(tenantId, 'priorities').del();
@@ -103,6 +113,26 @@ async function createFixture(): Promise<ReadSurfaceFixture> {
     ...(hasColumn(clientColumns, 'created_at') ? { created_at: db.fn.now() } : {}),
     ...(hasColumn(clientColumns, 'updated_at') ? { updated_at: db.fn.now() } : {}),
   });
+
+  const contact = await db.transaction((trx) => ContactModel.createContact({
+    full_name: 'Ticket Contact',
+    email: `contact-${tenantId.slice(0, 8)}@example.com`,
+    client_id: clientId,
+    phone_numbers: [
+      {
+        phone_number: '555-0200',
+        canonical_type: 'work',
+        is_default: true,
+        display_order: 0,
+      },
+      {
+        phone_number: '555-0201',
+        canonical_type: 'mobile',
+        is_default: false,
+        display_order: 1,
+      },
+    ],
+  }, tenantId, trx));
 
   await tenantTable(tenantId, 'boards').insert([
     {
@@ -187,6 +217,7 @@ async function createFixture(): Promise<ReadSurfaceFixture> {
     tenantId,
     userId,
     clientId,
+    contactId: contact.contact_name_id,
     boardAId,
     boardBId,
     boardAStatusId,
@@ -202,6 +233,7 @@ async function seedTickets(fixture: ReadSurfaceFixture): Promise<void> {
         title: 'Board A Search Ticket',
         description: 'Open board A ticket',
         client_id: fixture.clientId,
+        contact_id: fixture.contactId,
         board_id: fixture.boardAId,
         status_id: fixture.boardAStatusId,
         priority_id: fixture.priorityId,
@@ -344,5 +376,27 @@ describe('Ticket status read surfaces integration', () => {
     expect(Object.keys(stats.tickets_by_status)).toEqual(
       expect.arrayContaining([fixture.boardAStatusId, fixture.boardBStatusId])
     );
+  }, HOOK_TIMEOUT);
+
+  it('returns one ticket with the default phone when its contact has sibling phone rows', async () => {
+    const fixture = await createFixture();
+    await seedTickets(fixture);
+    const service = createService();
+    const ticket = await tenantTable(fixture.tenantId, 'tickets')
+      .where({ title: 'Board A Search Ticket' })
+      .first<{ ticket_id: string }>();
+    if (!ticket) {
+      throw new Error('Expected the ticket sibling-phone fixture to exist');
+    }
+
+    const result = await service.getById(ticket.ticket_id, {
+      tenant: fixture.tenantId,
+    } as any);
+
+    expect(result).toMatchObject({
+      ticket_id: ticket.ticket_id,
+      contact_name: 'Ticket Contact',
+      contact_phone: '555-0200',
+    });
   }, HOOK_TIMEOUT);
 });

--- a/server/src/test/unit/api/clientProjectAssetServicesTenantScoped.contract.test.ts
+++ b/server/src/test/unit/api/clientProjectAssetServicesTenantScoped.contract.test.ts
@@ -34,7 +34,7 @@ describe('client, project, and asset API services tenant-scoped query contract',
 
     expect(clientSource).toContain("let dataQuery = db.table('clients as c')");
     expect(clientSource).toContain("db.tenantJoin(dataQuery, 'users as u'");
-    expect(clientSource).toContain("db.tenantJoin(dataQuery, 'client_locations as cl'");
+    expect(clientSource).toContain("db.tenantJoinFirstMatching(dataQuery, 'client_locations', 'cl'");
     expect(clientSource).toContain('deleteFromTenantTableIfExists');
 
     // row type moved to the method signature; the read keeps the facade root

--- a/server/src/test/unit/api/clientService.locationConflict.test.ts
+++ b/server/src/test/unit/api/clientService.locationConflict.test.ts
@@ -1,0 +1,57 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const updateLocationMock = vi.fn();
+const withTransactionMock = vi.fn((_knex: unknown, callback: (trx: unknown) => Promise<unknown>) =>
+  callback({ transactionId: 'location-conflict-trx' })
+);
+
+vi.mock('@alga-psa/db', async () => {
+  const actual = await vi.importActual<any>('@alga-psa/db');
+  return {
+    ...actual,
+    withTransaction: (...args: any[]) => withTransactionMock(...args),
+  };
+});
+
+vi.mock('@alga-psa/clients/models', () => ({
+  createLocation: vi.fn(),
+  deleteLocation: vi.fn(),
+  updateLocation: (...args: any[]) => updateLocationMock(...args),
+}));
+
+vi.mock('@alga-psa/formatting/avatarUtils', () => ({
+  getClientLogoUrl: vi.fn().mockResolvedValue(null),
+}));
+
+vi.mock('server/src/lib/eventBus/publishers', () => ({
+  publishWorkflowEvent: vi.fn().mockResolvedValue(undefined),
+}));
+
+describe('ClientService location conflict mapping', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('maps a concurrent single-default unique violation to HTTP 409', async () => {
+    updateLocationMock.mockRejectedValue({
+      code: '23505',
+      constraint: 'ux_client_locations_default_per_client',
+    });
+
+    const { ClientService } = await import('../../../lib/api/services/ClientService');
+    const service = new ClientService();
+    vi.spyOn(service as any, 'getKnex').mockResolvedValue({ knex: {} });
+
+    await expect(service.updateLocation(
+      '11111111-1111-4111-8111-111111111111',
+      '22222222-2222-4222-8222-222222222222',
+      { is_default: true },
+      { tenant: '33333333-3333-4333-8333-333333333333' } as any,
+    )).rejects.toMatchObject({
+      name: 'ConflictError',
+      statusCode: 409,
+      code: 'CONFLICT',
+      message: 'Another location is already the default for this client',
+    });
+  });
+});

--- a/server/src/test/unit/api/ticketService.avatarUrls.test.ts
+++ b/server/src/test/unit/api/ticketService.avatarUrls.test.ts
@@ -18,12 +18,15 @@ vi.mock('@alga-psa/formatting/avatarUtils', async () => {
 function createQueryChain(ticket: Record<string, unknown> | null) {
   const chain = {
     leftJoin: vi.fn(() => chain),
+    distinctOn: vi.fn(() => chain),
     modify: vi.fn((callback: (builder: typeof chain) => void) => {
       callback(chain);
       return chain;
     }),
+    orderBy: vi.fn(() => chain),
     select: vi.fn(() => chain),
     where: vi.fn(() => chain),
+    as: vi.fn(() => chain),
     first: vi.fn().mockResolvedValue(ticket),
   };
 


### PR DESCRIPTION
## Summary

- make client listing joins select one deterministic active default location, so legacy clients with duplicate defaults no longer fan out response rows or inflate pagination totals
- centralize client-location mutations for UI actions and REST services, enforcing one active default through create, update, deactivate, unset, and delete flows
- normalize existing location data and add `ux_client_locations_default_per_client` to prevent multiple defaults at the database layer
- map unique-default conflicts to HTTP 409 and harden related contact and ticket child-row joins
- add unit, integration, migration, and API regression coverage for duplicate child rows, invariant recovery, and conflict handling

## Smoke test

PASS. Tested the real Next dev product on port 3578 with all five `alga-psa-local-test` infrastructure containers running.

Flows exercised:

1. Forced the original legacy precondition through direct DB setup: one client with two active default locations. Live `GET /api/v1/clients` returned HTTP 200, exactly one matching client row, and `pagination.total=1`.
2. Created successive default locations through the real REST API. The service cleared sibling defaults; the final state contained exactly one active default.
3. From the forced invalid two-default state, posted another default through the API. The shared mutation layer recovered the client to one default and cleared both siblings.
4. Logged into the real MSP UI as the seeded dev user, navigated through the Clients sidebar, searched for the fixture, and observed one client card. After recovery, the card displayed the new default address, `3 Recovery Road`, and `1 clients total`.

No mocks or service simulators were used. Direct DB setup was used only to create the invalid legacy state that the public API now prevents. The API screenshots are compact browser-rendered summaries generated from live API responses; the unmodified response JSON is included alongside them.

Evidence: `/tmp/alga-smoke-evidence/api-v1-clients-duplicate-rows-20260718-202047`

## Fidelity compromises and limitations

- The requested card-space browser pane was created, but the remote alga-dev CLI rejected it as belonging to the desktop/viewer host. Testing continued in an isolated browser pane controllable from the worktree host.
- The wired DB still lacks `ux_client_locations_default_per_client` because its migration history cannot accept this branch's migration. Therefore, the live PostgreSQL 23505 to HTTP 409 path could not be exercised without modifying the shared schema. Its regression coverage passed in the earlier implementation verification.
- The stale dev-login credential required restarting the board-owned server. It is now live as service generation `:5` using `PORT=3578 npm run dev`; this requirement was recorded as a durable card fact.

The temporary API key was deleted after testing. The smoke client remains in a valid single-default state. The worktree remains clean, and port 3578 is answering.

