### PR TITLE
Exclude compare view from tenant deletion

### DIFF
--- a/cli/cleanup-tenant.nu
+++ b/cli/cleanup-tenant.nu
@@ -420,7 +420,7 @@ def "main cleanup" [
         "contract_line_preset_fixed_config" "contract_line_preset_services" "contract_line_presets"
 
         # Contract templates (must be deleted before contracts)
-        "contract_template_compare_view" "contract_template_line_defaults"
+        "contract_template_line_defaults"
         "contract_template_line_fixed_config" "contract_template_line_service_bucket_config"
         "contract_template_line_service_configuration" "contract_template_line_service_hourly_config"
         "contract_template_line_service_usage_config" "contract_template_line_services"
@@ -643,11 +643,15 @@ def "main cleanup" [
     for table in $tables {
         # Check if table has tenant column
         let check_query = (
-            "SELECT column_name " +
-            "FROM information_schema.columns " +
-            "WHERE table_name = '" + $table + "' " +
-            "AND column_name IN ('tenant', 'tenant_id') " +
-            "AND table_schema = 'public' " +
+            "SELECT c.column_name " +
+            "FROM information_schema.columns c " +
+            "JOIN information_schema.tables t " +
+            "ON t.table_schema = c.table_schema AND t.table_name = c.table_name " +
+            "WHERE c.table_name = '" + $table + "' " +
+            "AND c.column_name IN ('tenant', 'tenant_id') " +
+            "AND c.table_schema = 'public' " +
+            "AND t.table_type = 'BASE TABLE' " +
+            "ORDER BY CASE c.column_name WHEN 'tenant' THEN 1 WHEN 'tenant_id' THEN 2 END " +
             "LIMIT 1"
         )
         

--- a/ee/temporal-workflows/src/activities/tenant-deletion-activities.ts
+++ b/ee/temporal-workflows/src/activities/tenant-deletion-activities.ts
@@ -267,7 +267,7 @@ const TENANT_TABLES_DELETION_ORDER: string[] = [
   // Contract templates (must be deleted before contracts)
   // Hourly/usage configs reference contract_template_line_service_configuration
   // with NO ACTION and must be deleted before it.
-  'contract_template_compare_view', 'contract_template_line_defaults',
+  'contract_template_line_defaults',
   'contract_template_line_fixed_config', 'contract_template_line_service_bucket_config',
   'contract_template_line_service_hourly_config',
   'contract_template_line_service_usage_config',
@@ -1268,12 +1268,15 @@ async function getTableTenantColumn(
 ): Promise<TenantColumnName | null> {
   try {
     const result = await knex.raw(`
-      SELECT column_name
-      FROM information_schema.columns
-      WHERE table_name = ?
-        AND column_name IN ('tenant', 'tenant_id')
-        AND table_schema = 'public'
-      ORDER BY CASE column_name WHEN 'tenant' THEN 1 WHEN 'tenant_id' THEN 2 END
+      SELECT c.column_name
+      FROM information_schema.columns c
+      JOIN information_schema.tables t
+        ON t.table_schema = c.table_schema AND t.table_name = c.table_name
+      WHERE c.table_name = ?
+        AND c.column_name IN ('tenant', 'tenant_id')
+        AND c.table_schema = 'public'
+        AND t.table_type = 'BASE TABLE'
+      ORDER BY CASE c.column_name WHEN 'tenant' THEN 1 WHEN 'tenant_id' THEN 2 END
       LIMIT 1
     `, [tableName]);
 

--- a/server/migrations/20260720120000_drop_contract_template_compare_view.cjs
+++ b/server/migrations/20260720120000_drop_contract_template_compare_view.cjs
@@ -1,0 +1,94 @@
+/**
+ * Migration: Drop contract_template_compare_view
+ *
+ * This view was a diagnostic helper for the contract-template hard cutover,
+ * comparing legacy templates stored in contracts against the new
+ * contract_templates rows. The cutover is complete, nothing in application
+ * code queries it, and its sibling contract_template_lines_compare_view was
+ * already dropped in 20251207130000. It also broke tenant deletion: the
+ * deletion worker detected its tenant column and attempted a DELETE, which
+ * fails on a UNION ALL view.
+ */
+
+exports.up = async function up(knex) {
+  await knex.raw('DROP VIEW IF EXISTS contract_template_compare_view');
+};
+
+exports.down = async function down(knex) {
+  const hasCompareView = await knex.raw(`
+    SELECT EXISTS (
+      SELECT FROM pg_views
+      WHERE viewname = 'contract_template_compare_view'
+    ) AS exists
+  `);
+  if (hasCompareView.rows[0].exists) {
+    return;
+  }
+
+  const contractsTableExists = await knex.schema.hasTable('contracts');
+  const hasLegacyTemplateFlag = contractsTableExists
+    ? await knex.schema.hasColumn('contracts', 'is_template')
+    : false;
+
+  const legacyContractsSelect = contractsTableExists
+    ? (hasLegacyTemplateFlag
+        ? `
+    SELECT
+      'legacy'::text AS source,
+      c.tenant,
+      c.contract_id AS template_identifier,
+      c.contract_name AS template_name,
+      c.contract_description AS template_description,
+      c.billing_frequency AS cadence,
+      CASE WHEN c.is_active = true THEN 'active' ELSE 'inactive' END AS status,
+      NULL::jsonb AS template_metadata,
+      c.created_at,
+      c.updated_at
+    FROM contracts c
+    WHERE c.is_template = true`
+        : `
+    SELECT
+      'legacy'::text AS source,
+      c.tenant,
+      c.contract_id AS template_identifier,
+      c.contract_name AS template_name,
+      c.contract_description AS template_description,
+      c.billing_frequency AS cadence,
+      CASE WHEN c.is_active = true THEN 'active' ELSE 'inactive' END AS status,
+      NULL::jsonb AS template_metadata,
+      c.created_at,
+      c.updated_at
+    FROM contracts c
+    WHERE 1 = 0`)
+    : `
+    SELECT
+      'legacy'::text AS source,
+      NULL::uuid AS tenant,
+      NULL::uuid AS template_identifier,
+      NULL::text AS template_name,
+      NULL::text AS template_description,
+      NULL::text AS cadence,
+      NULL::text AS status,
+      NULL::jsonb AS template_metadata,
+      NULL::timestamptz AS created_at,
+      NULL::timestamptz AS updated_at
+    WHERE false`;
+
+  await knex.raw(`
+    CREATE VIEW contract_template_compare_view AS
+    ${legacyContractsSelect}
+    UNION ALL
+    SELECT
+      'new'::text AS source,
+      t.tenant,
+      t.template_id AS template_identifier,
+      t.template_name,
+      t.template_description,
+      t.default_billing_frequency AS cadence,
+      t.template_status AS status,
+      t.template_metadata,
+      t.created_at,
+      t.updated_at
+    FROM contract_templates t
+  `);
+};

--- a/server/src/lib/initializeApp.ts
+++ b/server/src/lib/initializeApp.ts
@@ -512,8 +512,22 @@ async function initializeJobScheduler(storageService: StorageService) {
     }
 
     let jobRecordId: string | null = null;
+    let tenantExists = true;
 
     try {
+      // A deleted tenant must end the chain here, before the finally block
+      // re-enqueues and before a jobs row is written for it.
+      const tenantCheckKnex = await getConnection(tenantId);
+      const tenantRow = await tenantCheckKnex('tenants').where({ tenant: tenantId }).first();
+      if (!tenantRow) {
+        tenantExists = false;
+        logger.warn('createNextTimePeriods: tenant no longer exists, ending job chain', {
+          tenantId,
+          jobId: job.id
+        });
+        return;
+      }
+
       jobRecordId = await jobService.createJob('createNextTimePeriods', {
         tenantId,
         metadata: {
@@ -575,36 +589,38 @@ async function initializeJobScheduler(storageService: StorageService) {
 
       throw error;
     } finally {
-      // Always enqueue the next run so the job continues daily even after archives are cleaned
-      // Use UTC to avoid DST drift issues
-      try {
-        const nextRunInstant = Temporal.Now.instant().add({ hours: 24 });
-        const nextRun = new Date(nextRunInstant.epochMilliseconds);
-        const singletonKey = `createNextTimePeriods:${tenantId}`;
+      // Always enqueue the next run so the job continues daily even after archives are cleaned,
+      // unless the tenant is gone. Use UTC to avoid DST drift issues
+      if (tenantExists) {
+        try {
+          const nextRunInstant = Temporal.Now.instant().add({ hours: 24 });
+          const nextRun = new Date(nextRunInstant.epochMilliseconds);
+          const singletonKey = `createNextTimePeriods:${tenantId}`;
 
-        // Use scheduleRecurringJob which has singleton deduplication built-in
-        // This prevents duplicate jobs from stacking up on retries
-        const nextJobId = await jobScheduler.scheduleRecurringJob(
-          'createNextTimePeriods',
-          '24 hours',
-          { tenantId }
-        );
+          // Use scheduleRecurringJob which has singleton deduplication built-in
+          // This prevents duplicate jobs from stacking up on retries
+          const nextJobId = await jobScheduler.scheduleRecurringJob(
+            'createNextTimePeriods',
+            '24 hours',
+            { tenantId }
+          );
 
-        if (nextJobId) {
-          logger.debug('Queued next createNextTimePeriods job', {
-            tenantId,
-            jobId: nextJobId,
-            nextRun: nextRun.toISOString(),
-            singletonKey
-          });
-        } else {
-          logger.debug('createNextTimePeriods job already queued (singleton active)', {
-            tenantId,
-            singletonKey
-          });
+          if (nextJobId) {
+            logger.debug('Queued next createNextTimePeriods job', {
+              tenantId,
+              jobId: nextJobId,
+              nextRun: nextRun.toISOString(),
+              singletonKey
+            });
+          } else {
+            logger.debug('createNextTimePeriods job already queued (singleton active)', {
+              tenantId,
+              singletonKey
+            });
+          }
+        } catch (scheduleError) {
+          logger.error('Failed to enqueue next createNextTimePeriods job', { tenantId, scheduleError });
         }
-      } catch (scheduleError) {
-        logger.error('Failed to enqueue next createNextTimePeriods job', { tenantId, scheduleError });
       }
     }
   });

--- a/server/src/test/unit/billing/automaticInvoices.recurringDueWork.ui.test.tsx
+++ b/server/src/test/unit/billing/automaticInvoices.recurringDueWork.ui.test.tsx
@@ -661,8 +661,8 @@ describe('AutomaticInvoices recurring due-work UI', () => {
       });
     });
 
+    expect(await screen.findByText('Zenith Health')).toBeInTheDocument();
     expect(getAvailableBillingPeriodsMock).not.toHaveBeenCalled();
-    expect(screen.getByText('Zenith Health')).toBeInTheDocument();
   });
 
   it('handles an empty recurring due-work and history page', async () => {


### PR DESCRIPTION
Tenant deletion failed on DELETE against
contract_template_compare_view, a non-updatable UNION ALL diagnostic view left over from the contract-template cutover.

- Remove the view from TENANT_TABLES_DELETION_ORDER in the Temporal worker and from cleanup-tenant.nu
- Restrict tenant-column detection to BASE TABLE so views can never resolve a deletion boundary again
- Add migration dropping the unused view (down recreates it)

"Off with its head!" cried the Queen of Deletions — but the contract_template_compare_view was only a looking-glass, and no axe of DELETE may fall upon a reflection. So the Cheshire view was dropped from the schema entirely, grinning to the last, while information_schema now admits only BASE TABLEs through the little door. 🐇🪞⚔️