### PR TITLE
fix(migrations): run project billing notification templates outside batch transaction

### DIFF
--- a/server/migrations/20260715120000_add_project_billing_notification_templates.cjs
+++ b/server/migrations/20260715120000_add_project_billing_notification_templates.cjs
@@ -15,6 +15,14 @@ const INTERNAL_NAMES = [
   'project-budget-exceeded',
 ];
 
+// Upserts into notification_categories/notification_subtypes (Citus reference
+// tables) cannot share a transaction with parallel distributed operations from
+// earlier migrations in the same knex batch — knex wraps the whole batch in one
+// transaction when every migration uses transactions, and Citus rejects
+// reference-table writes after a parallel operation on a distributed table.
+// All statements below are idempotent upserts, so per-statement commit is safe.
+exports.config = { transaction: false };
+
 exports.up = async function up(knex) {
   await upsertEmailCategoriesAndSubtypes(knex);
   await upsertEmailTemplate(knex, getMilestoneReadyTemplate());


### PR DESCRIPTION
## Problem

The migration environment failed on `20260715120000_add_project_billing_notification_templates.cjs` with:

```
insert into "notification_categories" ... on conflict ("name") do update ...
- cannot modify table "notification_categories" because there was a parallel
  operation on a distributed table
```

## Root cause

knex 3.1 wraps an **entire `migrate:latest` batch in a single transaction** when every pending migration uses transactions (`Migrator.js` `transactionForAll`). The deploy batch included the project-billing schema migrations (20260715090000–06), which perform parallel operations on Citus distributed tables. When this migration then ran its first `INSERT ... ON CONFLICT` into `notification_categories` — a Citus **reference** table with FKs from distributed tables — Citus rejected it, since reference-table writes must go over a single connection per node and can't follow a parallel operation in the same transaction.

## Fix

Set `exports.config = { transaction: false }`, the same pattern already used by `20251211120000_add_tenant_notification_settings.cjs` for this exact failure mode. The batch then falls back to per-migration transactions, so the reference-table upserts no longer share a transaction with the schema migrations' parallel distributed operations.

Notes:
- Chose `transaction: false` over `SET citus.multi_shard_modify_mode = 'sequential'` (the other in-repo pattern) because the parallel operation happens in *earlier* migrations of the shared batch transaction, not inside this migration — sequential mode can't retroactively fix that.
- Safe without a wrapping transaction: every statement is an idempotent upsert and `down()` is a plain delete, so re-running after a failure is fine.