### PR TITLE
Guard against hardcoded currencies with tenant-aware formatting

### DIFF
--- a/packages/billing/src/actions/billingClientsActions.ts
+++ b/packages/billing/src/actions/billingClientsActions.ts
@@ -41,6 +41,10 @@ function billingClientsActionErrorFrom(error: unknown): BillingClientsActionErro
     if (error.message.includes('System-managed default contracts are attribution-only')) {
       return actionError(error.message);
     }
+    // LEVERAGE: pattern expected-action-error-matchers — same entry needed in contractWizardActionErrors and clients/clientContractActions
+    if (error.message.includes('Mixed-currency contracts for the same client are not supported')) {
+      return actionError(error.message);
+    }
     if (/client contract.*not found/i.test(error.message) || /assignment.*not found/i.test(error.message)) {
       return actionError('Client contract assignment not found. It may have been updated or deleted. Please refresh and try again.');
     }

--- a/packages/billing/src/actions/billingCurrencyActions.ts
+++ b/packages/billing/src/actions/billingCurrencyActions.ts
@@ -13,6 +13,18 @@ import {
 
 export type BillingCurrencyActionError = ActionMessageError | ActionPermissionError;
 
+// Display metadata for CurrencyFormatProvider — deliberately no billing
+// permission gate: every portal user sees formatted amounts.
+// LEVERAGE: pattern tenant-default-currency-read — same read as inventory's resolveTenantCurrency
+export const getTenantDefaultCurrencyCode = withAuth(async (user, { tenant }): Promise<string> => {
+  const { knex } = await createTenantKnex();
+  const row = await tenantDb(knex, tenant)
+    .table('default_billing_settings')
+    .select<{ default_currency_code: string | null }>('default_currency_code')
+    .first();
+  return row?.default_currency_code?.trim() || 'USD';
+});
+
 export const resolveClientBillingCurrency = withAuth(async (user, { tenant }, clientId: string, asOfDate?: string): Promise<string | BillingCurrencyActionError> => {
   if (!await hasPermission(user, 'billing', 'read')) {
     return permissionError('Permission denied: Cannot resolve client billing currency');

--- a/packages/billing/src/actions/billingSettingsActions.ts
+++ b/packages/billing/src/actions/billingSettingsActions.ts
@@ -127,25 +127,31 @@ export const getDefaultBillingSettings = withAuth(async (
 export const updateDefaultBillingSettings = withAuth(async (
   user,
   { tenant },
-  data: BillingSettings
+  data: Partial<BillingSettings>
 ): Promise<{ success: boolean } | BillingSettingsActionError> => {
   const denied = await requireBillingSettingsUpdatePermission(user);
   if (denied) return denied;
 
   const { knex } = await createTenantKnex();
+  // The billing settings page's sections save independently against this one
+  // row; only keys present in `data` are written, so one section's save can't
+  // clobber another section's just-saved values with its stale snapshot.
+  const has = (key: keyof BillingSettings) => Object.prototype.hasOwnProperty.call(data, key);
 
   try {
     await withTransaction(knex, async (trx: Knex.Transaction) => {
       const existingSettings = await tenantScopedTable(trx, tenant, 'default_billing_settings')
         .first();
 
-    await assertBoardScopedTicketStatusSelection({
-      trx,
-      tenant,
-      boardId: data.renewalTicketBoardId ?? null,
-      statusId: data.renewalTicketStatusId ?? null,
-      statusLabel: 'Renewal ticket status',
-    });
+    if (has('renewalTicketBoardId') || has('renewalTicketStatusId')) {
+      await assertBoardScopedTicketStatusSelection({
+        trx,
+        tenant,
+        boardId: (has('renewalTicketBoardId') ? data.renewalTicketBoardId : existingSettings?.renewal_ticket_board_id) ?? null,
+        statusId: (has('renewalTicketStatusId') ? data.renewalTicketStatusId : existingSettings?.renewal_ticket_status_id) ?? null,
+        statusLabel: 'Renewal ticket status',
+      });
+    }
 
     const renewalMode =
       data.defaultRenewalMode === 'none' ||
@@ -165,37 +171,44 @@ export const updateDefaultBillingSettings = withAuth(async (
         ? data.renewalDueDateActionPolicy
         : DEFAULT_RENEWAL_DUE_DATE_ACTION_POLICY;
 
-    const columnValues = {
-      default_currency_code: data.defaultCurrencyCode || 'USD',
-      default_renewal_mode: renewalMode,
-      default_notice_period_days: noticePeriodDays,
-      renewal_due_date_action_policy: renewalDueDateActionPolicy,
-      renewal_ticket_board_id: data.renewalTicketBoardId ?? null,
-      renewal_ticket_status_id: data.renewalTicketStatusId ?? null,
-      renewal_ticket_priority: data.renewalTicketPriority ?? null,
-      renewal_ticket_assignee_id: data.renewalTicketAssigneeId ?? null,
-    };
+    const columnValues: Record<string, unknown> = {};
+    if (has('defaultCurrencyCode')) columnValues.default_currency_code = data.defaultCurrencyCode || 'USD';
+    if (has('defaultRenewalMode')) columnValues.default_renewal_mode = renewalMode;
+    if (has('defaultNoticePeriodDays')) columnValues.default_notice_period_days = noticePeriodDays;
+    if (has('renewalDueDateActionPolicy')) columnValues.renewal_due_date_action_policy = renewalDueDateActionPolicy;
+    if (has('renewalTicketBoardId')) columnValues.renewal_ticket_board_id = data.renewalTicketBoardId ?? null;
+    if (has('renewalTicketStatusId')) columnValues.renewal_ticket_status_id = data.renewalTicketStatusId ?? null;
+    if (has('renewalTicketPriority')) columnValues.renewal_ticket_priority = data.renewalTicketPriority ?? null;
+    if (has('renewalTicketAssigneeId')) columnValues.renewal_ticket_assignee_id = data.renewalTicketAssigneeId ?? null;
+    if (has('zeroDollarInvoiceHandling')) columnValues.zero_dollar_invoice_handling = data.zeroDollarInvoiceHandling;
+    if (has('suppressZeroDollarInvoices')) columnValues.suppress_zero_dollar_invoices = data.suppressZeroDollarInvoices;
+    if (has('enableCreditExpiration')) columnValues.enable_credit_expiration = data.enableCreditExpiration;
+    if (has('creditExpirationDays')) columnValues.credit_expiration_days = data.creditExpirationDays;
+    if (has('creditExpirationNotificationDays')) columnValues.credit_expiration_notification_days = data.creditExpirationNotificationDays;
 
     if (existingSettings) {
+      if (Object.keys(columnValues).length === 0) return;
       return await tenantScopedTable(trx, tenant, 'default_billing_settings')
         .update({
-          zero_dollar_invoice_handling: data.zeroDollarInvoiceHandling,
-          suppress_zero_dollar_invoices: data.suppressZeroDollarInvoices,
-          enable_credit_expiration: data.enableCreditExpiration,
-          credit_expiration_days: data.creditExpirationDays,
-          credit_expiration_notification_days: data.creditExpirationNotificationDays,
           ...columnValues,
           updated_at: trx.fn.now()
         });
     } else {
       return await tenantScopedTable(trx, tenant, 'default_billing_settings').insert({
         tenant,
-        zero_dollar_invoice_handling: data.zeroDollarInvoiceHandling,
-        suppress_zero_dollar_invoices: data.suppressZeroDollarInvoices,
+        zero_dollar_invoice_handling: data.zeroDollarInvoiceHandling ?? 'normal',
+        suppress_zero_dollar_invoices: data.suppressZeroDollarInvoices ?? false,
         enable_credit_expiration: data.enableCreditExpiration ?? true,
         credit_expiration_days: data.creditExpirationDays ?? 365,
         credit_expiration_notification_days: data.creditExpirationNotificationDays ?? [30, 7, 1],
-        ...columnValues,
+        default_currency_code: data.defaultCurrencyCode || 'USD',
+        default_renewal_mode: renewalMode,
+        default_notice_period_days: noticePeriodDays,
+        renewal_due_date_action_policy: renewalDueDateActionPolicy,
+        renewal_ticket_board_id: data.renewalTicketBoardId ?? null,
+        renewal_ticket_status_id: data.renewalTicketStatusId ?? null,
+        renewal_ticket_priority: data.renewalTicketPriority ?? null,
+        renewal_ticket_assignee_id: data.renewalTicketAssigneeId ?? null,
       });
     }
     });

--- a/packages/billing/src/actions/contractWizardActionErrors.ts
+++ b/packages/billing/src/actions/contractWizardActionErrors.ts
@@ -14,6 +14,7 @@ export function contractWizardActionErrorFrom(error: unknown): ContractWizardAct
     error.message.startsWith('Catalog item "') ||
     error.message.startsWith('Product "') ||
     error.message.startsWith('Cannot create contract in') ||
+    error.message.includes('Mixed-currency contracts for the same client are not supported') ||
     error.message === 'Contract start date is required' ||
     error.message === 'Draft contract not found' ||
     error.message === 'Only draft contracts can be updated via the wizard' ||

--- a/packages/billing/src/actions/projectBillingConfigActions.ts
+++ b/packages/billing/src/actions/projectBillingConfigActions.ts
@@ -28,14 +28,9 @@ import {
 import { computeEntryAmounts, validateAllocation } from '../services/projectBillingService';
 import { withProjectBillingActionErrors } from './projectBillingActionErrors';
 
-// View DTOs live in @alga-psa/types so cross-feature composition (projects,
-// scheduling, msp-composition) can reference them without importing billing.
-export type {
-  ProjectBillingEconomics,
-  ProjectBillingOverview,
-  ProjectBillingRollup,
-  ScheduleEntryView,
-};
+// View DTOs live in @alga-psa/types — import them from there. A type re-export
+// here breaks at runtime: the 'use server' transform registers every export as
+// a server reference, emitting value references to type-only names.
 
 export interface ReadyQueueRow {
   entry: ScheduleEntryView;

--- a/packages/billing/src/actions/projectBillingScheduleActions.ts
+++ b/packages/billing/src/actions/projectBillingScheduleActions.ts
@@ -22,8 +22,8 @@ import { generateProjectInvoice } from './invoiceGeneration';
 import {
   assertProjectBillingMutationPermission,
   type ReadyQueueRow,
-  type ScheduleEntryView,
 } from './projectBillingConfigActions';
+import type { ScheduleEntryView } from '@alga-psa/types';
 import { withProjectBillingActionErrors } from './projectBillingActionErrors';
 
 export interface CreateScheduleEntryActionInput {

--- a/packages/billing/src/actions/projectBillingWarningActions.ts
+++ b/packages/billing/src/actions/projectBillingWarningActions.ts
@@ -8,7 +8,6 @@ import type { Knex } from 'knex';
 import { withProjectBillingActionErrors } from './projectBillingActionErrors';
 
 // DTOs live in @alga-psa/types; re-exported here for existing consumers.
-export type { ProjectPaymentWarning, ProjectPaymentWarningKind };
 
 interface PaymentWarningRow {
   invoice_id: string;

--- a/packages/billing/src/components/billing-dashboard/ContractLineDialog.tsx
+++ b/packages/billing/src/components/billing-dashboard/ContractLineDialog.tsx
@@ -28,6 +28,7 @@ import { BucketOverlayInput } from './contracts/ContractWizard';
 import { ServiceCatalogPicker } from './contracts/ServiceCatalogPicker';
 import { resolveBillingCycleAlignmentForCompatibility } from '@alga-psa/shared/billingClients/billingCycleAlignmentCompatibility';
 import { useTranslation } from '@alga-psa/ui/lib/i18n/client';
+import { useCurrencyFormat } from '@alga-psa/ui/lib';
 import {
   getErrorMessage,
   isActionMessageError,
@@ -62,6 +63,7 @@ interface ContractLineDialogProps {
 
 export function ContractLineDialog({ onPlanAdded, editingPlan, onClose, triggerButton }: ContractLineDialogProps) {
   const { t } = useTranslation('msp/contract-lines');
+  const { symbol } = useCurrencyFormat();
   const billingFrequencyOptions = useBillingFrequencyOptions();
   const [open, setOpen] = useState(false);
   const [planName, setPlanName] = useState('');
@@ -795,7 +797,7 @@ export function ContractLineDialog({ onPlanAdded, editingPlan, onClose, triggerB
                     {t('dialog.hourly.hourlyRateLabel', { defaultValue: 'Hourly Rate' })}
                   </Label>
                   <div className="relative">
-                    <span className="absolute left-3 top-1/2 -translate-y-1/2 text-muted-foreground">$</span>
+                    <span className="absolute left-3 top-1/2 -translate-y-1/2 text-muted-foreground">{symbol()}</span>
                     <Input
                       id={`hourly-rate-${index}`}
                       type="text"
@@ -1030,7 +1032,7 @@ export function ContractLineDialog({ onPlanAdded, editingPlan, onClose, triggerB
                       {t('dialog.usage.ratePerUnitLabel', { defaultValue: 'Rate per Unit' })}
                     </Label>
                     <div className="relative">
-                      <span className="absolute left-3 top-1/2 -translate-y-1/2 text-muted-foreground">$</span>
+                      <span className="absolute left-3 top-1/2 -translate-y-1/2 text-muted-foreground">{symbol()}</span>
                       <Input
                         id={`unit-rate-${index}`}
                         type="text"
@@ -1435,7 +1437,7 @@ export function ContractLineDialog({ onPlanAdded, editingPlan, onClose, triggerB
                         })}
                       </Label>
                       <div className="relative">
-                        <span className="absolute left-3 top-1/2 -translate-y-1/2 text-muted-foreground">$</span>
+                        <span className="absolute left-3 top-1/2 -translate-y-1/2 text-muted-foreground">{symbol()}</span>
                         <Input
                           id="base-rate"
                           type="text"

--- a/packages/billing/src/components/billing-dashboard/CreditManagement.tsx
+++ b/packages/billing/src/components/billing-dashboard/CreditManagement.tsx
@@ -8,6 +8,7 @@ import { CustomTabs } from '@alga-psa/ui/components/CustomTabs';
 import { DataTable } from '@alga-psa/ui/components/DataTable';
 import { Skeleton } from '@alga-psa/ui/components/Skeleton';
 import { useTranslation } from '@alga-psa/ui/lib/i18n/client';
+import { useCurrencyFormat } from '@alga-psa/ui/lib';
 import { formatCurrency } from '@alga-psa/core';
 import { formatDateOnly } from '@alga-psa/core';
 import { ColumnDefinition } from '@alga-psa/types';
@@ -286,6 +287,7 @@ const CreditManagement: React.FC = () => {
   const router = useRouter();
   const searchParams = useSearchParams();
   const { t } = useTranslation('msp/credits');
+  const { money } = useCurrencyFormat();
   const columns = createColumns(t);
   const tabParam = searchParams?.get('creditTab');
 
@@ -562,7 +564,7 @@ const CreditManagement: React.FC = () => {
                 >
                   <CartesianGrid strokeDasharray="3 3" />
                   <XAxis dataKey="month" />
-                  <YAxis tickFormatter={(value) => `$${value}`} />
+                  <YAxis tickFormatter={(value) => money(Math.round(Number(value) * 100))} />
                   <Tooltip formatter={(value) => formatCurrency(value as number)} />
                   <Legend />
                   <Bar

--- a/packages/billing/src/components/billing-dashboard/FixedContractLinePresetServicesList.tsx
+++ b/packages/billing/src/components/billing-dashboard/FixedContractLinePresetServicesList.tsx
@@ -32,6 +32,7 @@ import {
   isActionPermissionError,
 } from '@alga-psa/ui/lib/errorHandling';
 import { useTranslation } from '@alga-psa/ui/lib/i18n/client';
+import { useCurrencyFormat } from '@alga-psa/ui/lib';
 
 const isReturnedActionError = (value: unknown) =>
   isActionMessageError(value) || isActionPermissionError(value);
@@ -54,6 +55,7 @@ interface SimplePresetService {
 
 const FixedContractLinePresetServicesList: React.FC<FixedContractLinePresetServicesListProps> = ({ planId, onServiceAdded }) => {
   const { t } = useTranslation('msp/billing');
+  const { money } = useCurrencyFormat();
   const [presetServices, setPresetServices] = useState<SimplePresetService[]>([]);
   const [originalServices, setOriginalServices] = useState<SimplePresetService[]>([]);
   const [availableServices, setAvailableServices] = useState<IService[]>([]);
@@ -311,7 +313,7 @@ const FixedContractLinePresetServicesList: React.FC<FixedContractLinePresetServi
         </Tooltip>
       ),
       dataIndex: 'default_rate',
-      render: (value) => value !== undefined ? `$${(Number(value) / 100).toFixed(2)}` : t('common.notAvailable', { defaultValue: 'N/A' }),
+      render: (value) => value !== undefined ? money(Number(value)) : t('common.notAvailable', { defaultValue: 'N/A' }),
     },
     {
       title: t('presetServices.table.actions', { defaultValue: 'Actions' }),

--- a/packages/billing/src/components/billing-dashboard/FixedContractLineServicesList.tsx
+++ b/packages/billing/src/components/billing-dashboard/FixedContractLineServicesList.tsx
@@ -43,6 +43,7 @@ const isReturnedActionError = (value: unknown) =>
   isActionMessageError(value) || isActionPermissionError(value);
 import { Badge } from '@alga-psa/ui/components/Badge';
 import { useTranslation } from '@alga-psa/ui/lib/i18n/client';
+import { useCurrencyFormat } from '@alga-psa/ui/lib';
 // Removed ContractLineServiceForm import as 'Configure' is removed
 
 interface FixedPlanServicesListProps {
@@ -70,6 +71,7 @@ type PlanServiceWithConfig = {
 };
 const FixedPlanServicesList: React.FC<FixedPlanServicesListProps> = ({ planId, onServiceAdded }) => {
   const { t } = useTranslation('msp/billing');
+  const { money } = useCurrencyFormat();
   const [planServices, setPlanServices] = useState<SimplePlanService[]>([]);
   const [availableServices, setAvailableServices] = useState<IService[]>([]);
   const [serviceCategories, setServiceCategories] = useState<IServiceCategory[]>([]); // Added state for categories
@@ -361,7 +363,7 @@ const planServiceColumns: ColumnDefinition<SimplePlanService>[] = [
         }
 
         return record.default_rate !== undefined
-          ? `$${Number(record.default_rate).toFixed(2)}`
+          ? money(Math.round(Number(record.default_rate) * 100))
           : t('common.notAvailable', { defaultValue: 'N/A' });
       },
     },
@@ -532,7 +534,7 @@ const planServiceColumns: ColumnDefinition<SimplePlanService>[] = [
                                         {' | '}
                                         {t('contractLineServices.addSection.rate', {
                                           defaultValue: 'Rate: {{value}}',
-                                          value: `$${Number(service.default_rate).toFixed(2)}`,
+                                          value: money(Math.round(Number(service.default_rate) * 100)),
                                         })}
                                       </>
                                     )}

--- a/packages/billing/src/components/billing-dashboard/contract-lines/EditContractLineServiceQuantityDialog.tsx
+++ b/packages/billing/src/components/billing-dashboard/contract-lines/EditContractLineServiceQuantityDialog.tsx
@@ -5,6 +5,7 @@ import { Dialog, DialogContent, DialogFooter, DialogHeader, DialogTitle } from '
 import { Button } from '@alga-psa/ui/components/Button';
 import { Input } from '@alga-psa/ui/components/Input';
 import { useTranslation } from '@alga-psa/ui/lib/i18n/client';
+import { useCurrencyFormat } from '@alga-psa/ui/lib';
 
 interface EditPlanServiceQuantityDialogProps {
   isOpen: boolean;
@@ -29,6 +30,7 @@ export const EditPlanServiceQuantityDialog: React.FC<EditPlanServiceQuantityDial
   onSave
 }) => {
   const { t } = useTranslation('msp/contract-lines');
+  const { symbol } = useCurrencyFormat();
   const [quantity, setQuantity] = useState<number>(currentQuantity);
   const [rateInput, setRateInput] = useState<string>('');
   const [saving, setSaving] = useState(false);
@@ -111,7 +113,7 @@ export const EditPlanServiceQuantityDialog: React.FC<EditPlanServiceQuantityDial
                 </label>
                 <div className="relative">
                   <span className="absolute left-3 top-1/2 -translate-y-1/2 text-muted-foreground">
-                    {currencySymbol ?? '$'}
+                    {currencySymbol ?? symbol()}
                   </span>
                   <Input
                     id="service-rate-input"

--- a/packages/billing/src/components/billing-dashboard/contract-lines/FixedContractLineConfiguration.tsx
+++ b/packages/billing/src/components/billing-dashboard/contract-lines/FixedContractLineConfiguration.tsx
@@ -25,6 +25,7 @@ import { useBillingFrequencyOptions } from '@alga-psa/billing/hooks/useBillingEn
 import { useTenant } from '@alga-psa/ui/components/providers/TenantProvider';
 import { resolveBillingCycleAlignmentForCompatibility } from '@alga-psa/shared/billingClients/billingCycleAlignmentCompatibility';
 import { useTranslation } from '@alga-psa/ui/lib/i18n/client';
+import { useCurrencyFormat } from '@alga-psa/ui/lib';
 import { getErrorMessage, isActionMessageError, isActionPermissionError } from '@alga-psa/ui/lib/errorHandling';
 
 interface FixedPlanConfigurationProps {
@@ -74,6 +75,7 @@ export function FixedPlanConfiguration({
   className = '',
 }: FixedPlanConfigurationProps) {
   const { t } = useTranslation('msp/contract-lines');
+  const { symbol } = useCurrencyFormat();
   const billingFrequencyOptions = useBillingFrequencyOptions();
   const [plan, setPlan] = useState<IContractLine | null>(null);
   const [services, setServices] = useState<IService[]>([]);
@@ -422,7 +424,7 @@ export function FixedPlanConfiguration({
                   {t('configuration.fixed.settings.baseRateLabel', { defaultValue: 'Recurring Base Rate *' })}
                 </Label>
                 <div className="relative">
-                  <span className="absolute left-3 top-1/2 -translate-y-1/2 text-muted-foreground">$</span>
+                  <span className="absolute left-3 top-1/2 -translate-y-1/2 text-muted-foreground">{symbol()}</span>
                   <Input
                     id="base-rate"
                     type="text"

--- a/packages/billing/src/components/billing-dashboard/contract-lines/FixedContractLinePresetConfiguration.tsx
+++ b/packages/billing/src/components/billing-dashboard/contract-lines/FixedContractLinePresetConfiguration.tsx
@@ -24,6 +24,7 @@ import { useBillingFrequencyOptions } from '@alga-psa/billing/hooks/useBillingEn
 import { useTenant } from '@alga-psa/ui/components/providers/TenantProvider';
 import { resolveBillingCycleAlignmentForCompatibility } from '@alga-psa/shared/billingClients/billingCycleAlignmentCompatibility';
 import { useTranslation } from '@alga-psa/ui/lib/i18n/client';
+import { useCurrencyFormat } from '@alga-psa/ui/lib';
 import {
   getErrorMessage,
   isActionMessageError,
@@ -57,6 +58,7 @@ export function FixedPresetConfiguration({
   className = '',
 }: FixedPresetConfigurationProps) {
   const { t } = useTranslation('msp/contract-lines');
+  const { symbol } = useCurrencyFormat();
   const billingFrequencyOptions = useBillingFrequencyOptions();
   const [plan, setPlan] = useState<IContractLinePreset | null>(null);
   const [services, setServices] = useState<IService[]>([]);
@@ -345,7 +347,7 @@ export function FixedPresetConfiguration({
                   })}
                 </Label>
                 <div className="relative">
-                  <span className="absolute left-3 top-1/2 -translate-y-1/2 text-muted-foreground">$</span>
+                  <span className="absolute left-3 top-1/2 -translate-y-1/2 text-muted-foreground">{symbol()}</span>
                   <Input
                     id="base-rate"
                     type="text"

--- a/packages/billing/src/components/billing-dashboard/contract-lines/GenericContractLineServicesList.tsx
+++ b/packages/billing/src/components/billing-dashboard/contract-lines/GenericContractLineServicesList.tsx
@@ -29,6 +29,7 @@ import ContractLineServiceForm from './ContractLineServiceForm'; // Adjusted pat
 import { Badge } from '@alga-psa/ui/components/Badge';
 import { IContractLineServiceConfiguration } from '@alga-psa/types';
 import { useTranslation } from '@alga-psa/ui/lib/i18n/client';
+import { useCurrencyFormat } from '@alga-psa/ui/lib';
 import {
   getErrorMessage,
   isActionMessageError,
@@ -66,6 +67,7 @@ interface EnhancedPlanService extends IContractLineService {
 
 const GenericPlanServicesList: React.FC<GenericPlanServicesListProps> = ({ contractLineId, onServicesChanged, disableEditing = false }) => {
   const { t } = useTranslation('msp/contract-lines');
+  const { money } = useCurrencyFormat();
   const [planServices, setPlanServices] = useState<EnhancedPlanService[]>([]);
   const [availableServices, setAvailableServices] = useState<IService[]>([]);
   // Removed serviceCategories state
@@ -352,7 +354,7 @@ const GenericPlanServicesList: React.FC<GenericPlanServicesListProps> = ({ contr
       render: (value, record) => {
         const rate = value !== undefined ? value : record.default_rate;
         // Display rate directly as decimal
-        return rate !== undefined ? `$${parseFloat(rate).toFixed(2)}` : t('common.notAvailable', { defaultValue: 'N/A' });
+        return rate !== undefined ? money(Math.round(Number(rate) * 100)) : t('common.notAvailable', { defaultValue: 'N/A' });
       },
     },
     {

--- a/packages/billing/src/components/billing-dashboard/contract-lines/HourlyContractLineConfiguration.tsx
+++ b/packages/billing/src/components/billing-dashboard/contract-lines/HourlyContractLineConfiguration.tsx
@@ -23,6 +23,7 @@ import GenericPlanServicesList from './GenericContractLineServicesList';
 import { IContractLine, IService as IBillingService } from '@alga-psa/types'; // Use IService from billing.interfaces
 import { ServiceHourlyConfigForm } from './ServiceHourlyConfigForm';
 import { useTranslation } from '@alga-psa/ui/lib/i18n/client';
+import { useCurrencyFormat } from '@alga-psa/ui/lib';
 import {
     upsertPlanServiceHourlyConfiguration, // Correct action import
     upsertUserTypeRatesForConfig // Added import for user type rates action
@@ -109,6 +110,7 @@ export function HourlyPlanConfiguration({
   className = '',
 }: HourlyPlanConfigurationProps) {
   const { t } = useTranslation('msp/contract-lines');
+  const { symbol } = useCurrencyFormat();
   const billingFrequencyOptions = useBillingFrequencyOptions();
   // Plan-wide state
   const [plan, setPlan] = useState<HourlyPlanData | null>(null);
@@ -673,7 +675,7 @@ export function HourlyPlanConfiguration({
                                       })}
                                     </Label>
                                     <div className="relative">
-                                      <span className="absolute left-3 top-1/2 -translate-y-1/2 text-muted-foreground">$</span>
+                                      <span className="absolute left-3 top-1/2 -translate-y-1/2 text-muted-foreground">{symbol()}</span>
                                       <Input
                                         id="overtime-rate"
                                         type="text"

--- a/packages/billing/src/components/billing-dashboard/contract-lines/HourlyContractLinePresetServicesList.tsx
+++ b/packages/billing/src/components/billing-dashboard/contract-lines/HourlyContractLinePresetServicesList.tsx
@@ -33,6 +33,7 @@ import {
   isActionPermissionError,
 } from '@alga-psa/ui/lib/errorHandling';
 import { useTranslation } from '@alga-psa/ui/lib/i18n/client';
+import { useCurrencyFormat } from '@alga-psa/ui/lib';
 
 const isReturnedActionError = (value: unknown) =>
   isActionMessageError(value) || isActionPermissionError(value);
@@ -58,6 +59,7 @@ interface PresetServiceWithBucket extends IContractLinePresetService {
 
 const HourlyContractLinePresetServicesList: React.FC<HourlyContractLinePresetServicesListProps> = ({ presetId, onServiceAdded }) => {
   const { t } = useTranslation('msp/contract-lines');
+  const { money, symbol } = useCurrencyFormat();
   const [presetServices, setPresetServices] = useState<PresetServiceWithBucket[]>([]);
   const [originalServices, setOriginalServices] = useState<PresetServiceWithBucket[]>([]);
   const [availableServices, setAvailableServices] = useState<IService[]>([]);
@@ -435,7 +437,7 @@ const HourlyContractLinePresetServicesList: React.FC<HourlyContractLinePresetSer
                       <label className="text-sm font-medium w-24">
                         {t('services.hourlyPreset.hourlyRateLabel', { defaultValue: 'Hourly Rate:' })}
                       </label>
-                      <span className="text-muted-foreground">$</span>
+                      <span className="text-muted-foreground">{symbol()}</span>
                       <Input
                         type="text"
                         inputMode="decimal"
@@ -522,7 +524,7 @@ const HourlyContractLinePresetServicesList: React.FC<HourlyContractLinePresetSer
                                 defaultValue: 'Service Type: {{type}} | Method: {{method}} | Default Rate: {{rate}}',
                                 type: serviceTypeName,
                                 method: billingMethod,
-                                rate: `$${(Number(service.default_rate) / 100).toFixed(2)}`,
+                                rate: money(Number(service.default_rate)),
                               })}
                             </span>
                           </div>

--- a/packages/billing/src/components/billing-dashboard/contract-lines/ServiceHourlyConfigForm.tsx
+++ b/packages/billing/src/components/billing-dashboard/contract-lines/ServiceHourlyConfigForm.tsx
@@ -10,6 +10,7 @@ import { getCurrencySymbol } from '@alga-psa/core';
 import { IContractLineServiceHourlyConfig, IUserTypeRate } from '@alga-psa/types';
 import CustomSelect from '@alga-psa/ui/components/CustomSelect'; // Import CustomSelect
 import { useTranslation } from '@alga-psa/ui/lib/i18n/client';
+import { useCurrencyFormat } from '@alga-psa/ui/lib';
 
 // Define the structure for the configuration object (using imported interface)
 // export interface IServiceHourlyConfig { ... } // Removed local definition
@@ -51,6 +52,7 @@ export function ServiceHourlyConfigForm({
   className = '',
 }: ServiceHourlyConfigFormProps) {
   const { t } = useTranslation('msp/contract-lines');
+  const { symbol } = useCurrencyFormat();
   // Local state for input values (hourly_rate is handled specially for display)
   // Local state for input values (hourly_rate is handled specially for display)
   const [displayHourlyRate, setDisplayHourlyRate] = useState<string>('');
@@ -228,7 +230,7 @@ export function ServiceHourlyConfigForm({
 
         {/* This section was incorrectly placed here by the previous diff, removing it */}
         <div className="relative">
-          <span className="absolute left-3 top-1/2 -translate-y-1/2 text-muted-foreground">$</span>
+          <span className="absolute left-3 top-1/2 -translate-y-1/2 text-muted-foreground">{symbol()}</span>
           <Input
             id="hourly-rate"
             type="text"
@@ -366,7 +368,7 @@ export function ServiceHourlyConfigForm({
                          {t('forms.hourlyConfig.userTypeRates.rateSrLabel', { defaultValue: 'Rate ($/hr)' })}
                        </Label>
                        <div className="relative">
-                         <span className="absolute left-3 top-1/2 -translate-y-1/2 text-muted-foreground">$</span>
+                         <span className="absolute left-3 top-1/2 -translate-y-1/2 text-muted-foreground">{symbol()}</span>
                          <Input
                              id={`new-user-type-rate-${configId}`}
                              type="text"

--- a/packages/billing/src/components/billing-dashboard/contract-lines/ServiceUsageConfigForm.tsx
+++ b/packages/billing/src/components/billing-dashboard/contract-lines/ServiceUsageConfigForm.tsx
@@ -10,6 +10,7 @@ import { Tooltip } from '@alga-psa/ui/components/Tooltip';
 import { Info } from 'lucide-react';
 import { ServiceTierEditor, TierConfig } from './ServiceTierEditor'; // Import the tier editor and its config type
 import { useTranslation } from '@alga-psa/ui/lib/i18n/client';
+import { useCurrencyFormat } from '@alga-psa/ui/lib';
 
 // Define the shape of the configuration for a single service
 export interface ServiceUsageConfig {
@@ -50,6 +51,7 @@ export function ServiceUsageConfigForm({
     onTiersChange,
 }: ServiceUsageConfigFormProps) {
     const { t } = useTranslation('msp/contract-lines');
+    const { symbol } = useCurrencyFormat();
     // Local state for formatted rate input
     const [baseRateInput, setBaseRateInput] = React.useState<string>('');
 
@@ -103,7 +105,7 @@ export function ServiceUsageConfigForm({
                         </Tooltip>
                     </Label>
                     <div className="relative">
-                        <span className="absolute left-3 top-1/2 -translate-y-1/2 text-muted-foreground">$</span>
+                        <span className="absolute left-3 top-1/2 -translate-y-1/2 text-muted-foreground">{symbol()}</span>
                         <Input
                             id={`usage-contract-line-base-rate-${serviceId}`}
                             type="text"

--- a/packages/billing/src/components/billing-dashboard/contract-lines/UsageContractLineConfiguration.tsx
+++ b/packages/billing/src/components/billing-dashboard/contract-lines/UsageContractLineConfiguration.tsx
@@ -25,6 +25,7 @@ import { TierConfig } from './ServiceTierEditor'; // Import TierConfig type
 import { useBillingFrequencyOptions } from '@alga-psa/billing/hooks/useBillingEnumOptions';
 import { useTenant } from '@alga-psa/ui/components/providers/TenantProvider';
 import { useTranslation } from '@alga-psa/ui/lib/i18n/client';
+import { useCurrencyFormat } from '@alga-psa/ui/lib';
 import { getErrorMessage, isActionMessageError, isActionPermissionError } from '@alga-psa/ui/lib/errorHandling';
 
 // Keep GenericPlanServicesList for now, might remove in Phase 3
@@ -67,6 +68,7 @@ export function UsagePlanConfiguration({
   className = '',
 }: UsagePlanConfigurationProps) {
   const { t } = useTranslation('msp/contract-lines');
+  const { money } = useCurrencyFormat();
   const billingFrequencyOptions = useBillingFrequencyOptions();
   // State for the base plan details
   const [plan, setPlan] = useState<IContractLine | null>(null);
@@ -848,7 +850,7 @@ export function UsagePlanConfiguration({
                             });
                           } else {
                             const rate = config.base_rate !== undefined
-                              ? `$${config.base_rate.toFixed(2)}`
+                              ? money(Math.round(Number(config.base_rate) * 100))
                               : t('configuration.usage.services.summary.notSet', { defaultValue: 'Not Set' });
                             const unit = config.unit_of_measure || t('configuration.usage.services.summary.defaultUnit', { defaultValue: 'Unit' });
                             return t('configuration.usage.services.summary.ratePerUnit', {

--- a/packages/billing/src/components/billing-dashboard/contract-lines/UsageContractLinePresetConfiguration.tsx
+++ b/packages/billing/src/components/billing-dashboard/contract-lines/UsageContractLinePresetConfiguration.tsx
@@ -25,6 +25,7 @@ import { TierConfig } from './ServiceTierEditor'; // Import TierConfig type
 import { useBillingFrequencyOptions } from '@alga-psa/billing/hooks/useBillingEnumOptions';
 import { useTenant } from '@alga-psa/ui/components/providers/TenantProvider';
 import { useTranslation } from '@alga-psa/ui/lib/i18n/client';
+import { useCurrencyFormat } from '@alga-psa/ui/lib';
 import {
   getErrorMessage,
   isActionMessageError,
@@ -70,6 +71,7 @@ export function UsagePresetConfiguration({
   className = '',
 }: UsagePresetConfigurationProps) {
   const { t } = useTranslation('msp/contract-lines');
+  const { money } = useCurrencyFormat();
   const billingFrequencyOptions = useBillingFrequencyOptions();
   // State for the base plan details
   const [plan, setPlan] = useState<IContractLinePreset | null>(null);
@@ -841,7 +843,7 @@ export function UsagePresetConfiguration({
                             });
                           } else {
                             const rate = config.base_rate !== undefined
-                              ? `$${config.base_rate.toFixed(2)}`
+                              ? money(Math.round(Number(config.base_rate) * 100))
                               : t('preset.usage.services.summary.notSet', { defaultValue: 'Not Set' });
                             const unit = config.unit_of_measure || t('preset.usage.services.summary.defaultUnit', { defaultValue: 'Unit' });
                             return t('preset.usage.services.summary.ratePerUnit', {

--- a/packages/billing/src/components/billing-dashboard/contract-lines/UsageContractLinePresetServicesList.tsx
+++ b/packages/billing/src/components/billing-dashboard/contract-lines/UsageContractLinePresetServicesList.tsx
@@ -33,6 +33,7 @@ import {
   isActionPermissionError,
 } from '@alga-psa/ui/lib/errorHandling';
 import { useTranslation } from '@alga-psa/ui/lib/i18n/client';
+import { useCurrencyFormat } from '@alga-psa/ui/lib';
 
 const isReturnedActionError = (value: unknown) =>
   isActionMessageError(value) || isActionPermissionError(value);
@@ -58,6 +59,7 @@ interface PresetServiceWithBucket extends IContractLinePresetService {
 
 const UsageContractLinePresetServicesList: React.FC<UsageContractLinePresetServicesListProps> = ({ presetId, onServiceAdded }) => {
   const { t } = useTranslation('msp/contract-lines');
+  const { money, symbol } = useCurrencyFormat();
   const [presetServices, setPresetServices] = useState<PresetServiceWithBucket[]>([]);
   const [originalServices, setOriginalServices] = useState<PresetServiceWithBucket[]>([]);
   const [availableServices, setAvailableServices] = useState<IService[]>([]);
@@ -444,7 +446,7 @@ const UsageContractLinePresetServicesList: React.FC<UsageContractLinePresetServi
                         <label className="text-sm font-medium">
                           {t('services.usagePreset.ratePerUnitLabel', { defaultValue: 'Rate per Unit:' })}
                         </label>
-                        <span className="text-muted-foreground">$</span>
+                        <span className="text-muted-foreground">{symbol()}</span>
                       <Input
                         type="text"
                         inputMode="decimal"
@@ -549,7 +551,7 @@ const UsageContractLinePresetServicesList: React.FC<UsageContractLinePresetServi
                                 defaultValue: 'Service Type: {{type}} | Method: {{method}} | Default Rate: {{rate}} | Unit: {{unit}}',
                                 type: serviceTypeName,
                                 method: billingMethod,
-                                rate: `$${(Number(service.default_rate) / 100).toFixed(2)}`,
+                                rate: money(Number(service.default_rate)),
                                 unit: service.unit_of_measure || t('services.usagePreset.defaultUnit', { defaultValue: 'unit' }),
                               })}
                             </span>

--- a/packages/billing/src/components/billing-dashboard/contracts/AddContractLinesDialog.tsx
+++ b/packages/billing/src/components/billing-dashboard/contracts/AddContractLinesDialog.tsx
@@ -19,6 +19,7 @@ import { getServices } from '@alga-psa/billing/actions/serviceActions';
 import CustomSelect from '@alga-psa/ui/components/CustomSelect';
 import { Alert, AlertDescription } from '@alga-psa/ui/components/Alert';
 import { useTranslation } from '@alga-psa/ui/lib/i18n/client';
+import { useCurrencyFormat } from '@alga-psa/ui/lib';
 import {
   useContractLineTypeOptions,
   useFormatBillingFrequency,
@@ -57,6 +58,7 @@ export const AddContractLinesDialog: React.FC<AddContractLinesDialogProps> = ({
   onAdd,
 }) => {
   const { t } = useTranslation('msp/contracts');
+  const { money, symbol } = useCurrencyFormat();
   const contractLineTypeOptions = useContractLineTypeOptions();
   const formatContractLineType = useFormatContractLineType();
   const formatBillingFrequency = useFormatBillingFrequency();
@@ -582,7 +584,7 @@ export const AddContractLinesDialog: React.FC<AddContractLinesDialogProps> = ({
                                 </span>
                                 <span className="ml-2 text-[rgb(var(--color-text-900))] font-semibold">
                                   {fixedConfig?.base_rate !== null && fixedConfig?.base_rate !== undefined
-                                    ? `$${(fixedConfig.base_rate / 100).toFixed(2)}`
+                                    ? money(Number(fixedConfig.base_rate))
                                     : t('addLines.fixedConfig.notSet', { defaultValue: 'Not set' })}
                                 </span>
                               </div>
@@ -591,7 +593,7 @@ export const AddContractLinesDialog: React.FC<AddContractLinesDialogProps> = ({
                                   {t('addLines.fixedConfig.overrideBaseRate', { defaultValue: 'Override Base Rate' })}
                                 </Label>
                                 <div className="relative mt-1.5">
-                                  <span className="absolute left-3 top-1/2 -translate-y-1/2 text-muted-foreground text-sm">$</span>
+                                  <span className="absolute left-3 top-1/2 -translate-y-1/2 text-muted-foreground text-sm">{symbol()}</span>
                                   <Input
                                     id={`rate-override-${preset.preset_id}`}
                                     type="text"
@@ -802,7 +804,7 @@ export const AddContractLinesDialog: React.FC<AddContractLinesDialogProps> = ({
                                             {t('addLines.hourlyConfig.hourlyRate', { defaultValue: 'Hourly Rate' })}
                                           </Label>
                                           <div className="relative mt-1">
-                                            <span className="absolute left-3 top-1/2 -translate-y-1/2 text-muted-foreground text-sm">$</span>
+                                            <span className="absolute left-3 top-1/2 -translate-y-1/2 text-muted-foreground text-sm">{symbol()}</span>
                                             <Input
                                               id={`hourly-rate-${preset.preset_id}-${service.service_id}`}
                                               type="text"
@@ -934,7 +936,7 @@ export const AddContractLinesDialog: React.FC<AddContractLinesDialogProps> = ({
                                           {t('addLines.usageConfig.ratePerUnit', { defaultValue: 'Rate (per unit)' })}
                                         </Label>
                                         <div className="relative mt-1">
-                                          <span className="absolute left-3 top-1/2 -translate-y-1/2 text-muted-foreground text-sm">$</span>
+                                          <span className="absolute left-3 top-1/2 -translate-y-1/2 text-muted-foreground text-sm">{symbol()}</span>
                                           <Input
                                             id={`rate-${preset.preset_id}-${service.service_id}`}
                                             type="text"

--- a/packages/billing/src/components/billing-dashboard/contracts/BucketOverlayFields.tsx
+++ b/packages/billing/src/components/billing-dashboard/contracts/BucketOverlayFields.tsx
@@ -8,6 +8,7 @@ import { Tooltip } from '@alga-psa/ui/components/Tooltip';
 import { Info, Coins } from 'lucide-react';
 import { BucketOverlayInput } from './ContractWizard';
 import { useTranslation } from '@alga-psa/ui/lib/i18n/client';
+import { useCurrencyFormat } from '@alga-psa/ui/lib';
 
 type BucketOverlayMode = 'hours' | 'usage';
 
@@ -31,6 +32,7 @@ export function BucketOverlayFields({
   billingFrequency = 'monthly'
 }: BucketOverlayFieldsProps) {
   const { t } = useTranslation('msp/contracts');
+  const { symbol } = useCurrencyFormat();
   const [overageRateInput, setOverageRateInput] = useState<string>('');
 
   useEffect(() => {
@@ -154,7 +156,7 @@ export function BucketOverlayFields({
           </Tooltip>
         </div>
         <div className="relative">
-          <span className="absolute left-3 top-1/2 -translate-y-1/2 text-muted-foreground">$</span>
+          <span className="absolute left-3 top-1/2 -translate-y-1/2 text-muted-foreground">{symbol()}</span>
           <Input
             id={automationId ? `${automationId}-overage` : undefined}
             data-automation-id={automationId ? `${automationId}-overage` : undefined}

--- a/packages/billing/src/components/billing-dashboard/contracts/ContractDialog.tsx
+++ b/packages/billing/src/components/billing-dashboard/contracts/ContractDialog.tsx
@@ -30,6 +30,7 @@ import { getContractLinePresetServices, getContractLinePresetFixedConfig } from 
 import { IContractLinePresetService, IContractLinePresetFixedConfig } from '@alga-psa/types';
 import { getServices } from '@alga-psa/billing/actions/serviceActions';
 import { useTranslation } from '@alga-psa/ui/lib/i18n/client';
+import { useCurrencyFormat } from '@alga-psa/ui/lib';
 import {
   getErrorMessage,
   isActionMessageError,
@@ -69,6 +70,7 @@ export function ContractDialog({
   initialClientId,
 }: ContractDialogProps) {
   const { t } = useTranslation('msp/contracts');
+  const { money, symbol } = useCurrencyFormat();
   const billingFrequencyOptions = useBillingFrequencyOptions();
   const contractLineTypeOptions = useContractLineTypeOptions();
   const renewalModeOptions = [
@@ -1040,7 +1042,7 @@ export function ContractDialog({
                                         </span>
                                         <span className="ml-2 text-[rgb(var(--color-text-900))] font-semibold">
                                           {fixedConfig?.base_rate !== null && fixedConfig?.base_rate !== undefined
-                                            ? `$${(fixedConfig.base_rate / 100).toFixed(2)}`
+                                            ? money(Number(fixedConfig.base_rate))
                                             : t('contractDialog.presetDetails.notSet', {
                                               defaultValue: 'Not set',
                                             })}
@@ -1053,7 +1055,7 @@ export function ContractDialog({
                                           })}
                                         </Label>
                                         <div className="relative mt-1.5">
-                                          <span className="absolute left-3 top-1/2 -translate-y-1/2 text-muted-foreground text-sm">$</span>
+                                          <span className="absolute left-3 top-1/2 -translate-y-1/2 text-muted-foreground text-sm">{symbol()}</span>
                                           <Input
                                             id={`rate-override-${preset.preset_id}`}
                                             type="text"
@@ -1282,7 +1284,7 @@ export function ContractDialog({
                                                     })}
                                                   </Label>
                                                   <div className="relative mt-1">
-                                                    <span className="absolute left-3 top-1/2 -translate-y-1/2 text-muted-foreground text-sm">$</span>
+                                                    <span className="absolute left-3 top-1/2 -translate-y-1/2 text-muted-foreground text-sm">{symbol()}</span>
                                                     <Input
                                                       id={`hourly-rate-${preset.preset_id}-${service.service_id}`}
                                                       type="text"
@@ -1420,7 +1422,7 @@ export function ContractDialog({
                                                   })}
                                                 </Label>
                                                 <div className="relative mt-1">
-                                                  <span className="absolute left-3 top-1/2 -translate-y-1/2 text-muted-foreground text-sm">$</span>
+                                                  <span className="absolute left-3 top-1/2 -translate-y-1/2 text-muted-foreground text-sm">{symbol()}</span>
                                                   <Input
                                                     id={`rate-${preset.preset_id}-${service.service_id}`}
                                                     type="text"
@@ -1597,7 +1599,7 @@ export function ContractDialog({
                       {t('contractDialog.po.amountLabel', { defaultValue: 'PO Amount (Optional)' })}
                     </Label>
                     <div className="relative">
-                      <span className="absolute left-3 top-1/2 -translate-y-1/2 text-muted-foreground">$</span>
+                      <span className="absolute left-3 top-1/2 -translate-y-1/2 text-muted-foreground">{symbol()}</span>
                       <Input
                         id="po_amount"
                         type="text"

--- a/packages/billing/src/components/billing-dashboard/contracts/ContractLineRateDialog.tsx
+++ b/packages/billing/src/components/billing-dashboard/contracts/ContractLineRateDialog.tsx
@@ -8,6 +8,7 @@ import { Input } from '@alga-psa/ui/components/Input';
 import { Alert, AlertDescription } from '@alga-psa/ui/components/Alert';
 import { AlertCircle } from 'lucide-react';
 import { useTranslation } from '@alga-psa/ui/lib/i18n/client';
+import { useCurrencyFormat } from '@alga-psa/ui/lib';
 
 interface ContractLineRateDialogProps {
   plan: {
@@ -22,6 +23,7 @@ interface ContractLineRateDialogProps {
 
 export function ContractLineRateDialog({ plan, onClose, onSave }: ContractLineRateDialogProps) {
   const { t } = useTranslation('msp/contracts');
+  const { symbol } = useCurrencyFormat();
   const [rate, setRate] = useState<number>(
     plan.rate !== undefined && plan.rate !== null
       ? plan.rate
@@ -86,7 +88,7 @@ export function ContractLineRateDialog({ plan, onClose, onSave }: ContractLineRa
             <div>
               <Label htmlFor="custom-rate">{t('contractLineRate.fields.rate', { defaultValue: 'Rate' })}</Label>
               <div className="relative">
-                <span className="absolute left-3 top-1/2 transform -translate-y-1/2 text-muted-foreground">$</span>
+                <span className="absolute left-3 top-1/2 transform -translate-y-1/2 text-muted-foreground">{symbol()}</span>
                 <Input
                   id="custom-rate"
                   type="number"

--- a/packages/billing/src/components/billing-dashboard/contracts/ContractPlanRateDialog.tsx
+++ b/packages/billing/src/components/billing-dashboard/contracts/ContractPlanRateDialog.tsx
@@ -8,6 +8,7 @@ import { Input } from '@alga-psa/ui/components/Input';
 import { Alert, AlertDescription } from '@alga-psa/ui/components/Alert';
 import { AlertCircle } from 'lucide-react';
 import { useTranslation } from '@alga-psa/ui/lib/i18n/client';
+import { useCurrencyFormat } from '@alga-psa/ui/lib';
 
 interface ContractLineRateDialogProps {
   contractLine: {
@@ -22,6 +23,7 @@ interface ContractLineRateDialogProps {
 
 export function ContractLineRateDialog({ contractLine, onClose, onSave }: ContractLineRateDialogProps) {
   const { t } = useTranslation('msp/contracts');
+  const { symbol } = useCurrencyFormat();
   const [rate, setRate] = useState<number>(
     contractLine.rate !== undefined && contractLine.rate !== null ? contractLine.rate : 0
   );
@@ -82,7 +84,7 @@ export function ContractLineRateDialog({ contractLine, onClose, onSave }: Contra
             <div>
               <Label htmlFor="custom-rate">{t('contractLineRate.fields.rate', { defaultValue: 'Rate' })}</Label>
               <div className="relative">
-                <span className="absolute left-3 top-1/2 transform -translate-y-1/2 text-muted-foreground">$</span>
+                <span className="absolute left-3 top-1/2 transform -translate-y-1/2 text-muted-foreground">{symbol()}</span>
                 <Input
                   id="custom-rate"
                   type="number"

--- a/packages/billing/src/components/billing-dashboard/contracts/CreateCustomContractLineDialog.tsx
+++ b/packages/billing/src/components/billing-dashboard/contracts/CreateCustomContractLineDialog.tsx
@@ -16,6 +16,7 @@ import { BucketOverlayFields } from './BucketOverlayFields';
 import { BucketOverlayInput } from './ContractWizard';
 import { ServiceCatalogPicker } from './ServiceCatalogPicker';
 import { useTranslation } from '@alga-psa/ui/lib/i18n/client';
+import { useCurrencyFormat } from '@alga-psa/ui/lib';
 import {
   getErrorMessage,
   isActionMessageError,
@@ -41,6 +42,7 @@ export const CreateCustomContractLineDialog: React.FC<CreateCustomContractLineDi
   onCreated,
 }) => {
   const { t } = useTranslation('msp/contracts');
+  const { money, symbol } = useCurrencyFormat();
   const billingFrequencyOptions = useBillingFrequencyOptions();
   const [planName, setPlanName] = useState('');
   const [planType, setPlanType] = useState<PlanType | null>(null);
@@ -292,8 +294,8 @@ export const CreateCustomContractLineDialog: React.FC<CreateCustomContractLineDi
   };
 
   const formatCurrency = (cents: number | undefined) => {
-    if (!cents) return '$0.00';
-    return `$${(cents / 100).toFixed(2)}`;
+    if (!cents) return money(0);
+    return money(Number(cents));
   };
 
   const renderFixedConfig = () => {
@@ -556,7 +558,7 @@ export const CreateCustomContractLineDialog: React.FC<CreateCustomContractLineDi
                     })}
                   </Label>
                   <div className="relative">
-                    <span className="absolute left-3 top-1/2 -translate-y-1/2 text-muted-foreground">$</span>
+                    <span className="absolute left-3 top-1/2 -translate-y-1/2 text-muted-foreground">{symbol()}</span>
                     <Input
                       id={`hourly-rate-${index}`}
                       type="text"
@@ -780,7 +782,7 @@ export const CreateCustomContractLineDialog: React.FC<CreateCustomContractLineDi
                       })}
                     </Label>
                     <div className="relative">
-                      <span className="absolute left-3 top-1/2 -translate-y-1/2 text-muted-foreground">$</span>
+                      <span className="absolute left-3 top-1/2 -translate-y-1/2 text-muted-foreground">{symbol()}</span>
                       <Input
                         id={`unit-rate-${index}`}
                         type="text"
@@ -1137,7 +1139,7 @@ export const CreateCustomContractLineDialog: React.FC<CreateCustomContractLineDi
                       {t('createCustomLine.recurringBaseRateLabel', { defaultValue: 'Recurring Base Rate' })}
                     </Label>
                     <div className="relative">
-                      <span className="absolute left-3 top-1/2 -translate-y-1/2 text-muted-foreground">$</span>
+                      <span className="absolute left-3 top-1/2 -translate-y-1/2 text-muted-foreground">{symbol()}</span>
                       <Input
                         id="base-rate"
                         type="text"

--- a/packages/billing/src/components/billing-dashboard/contracts/PricingScheduleDialog.tsx
+++ b/packages/billing/src/components/billing-dashboard/contracts/PricingScheduleDialog.tsx
@@ -16,6 +16,7 @@ import {
 import { SwitchWithLabel } from '@alga-psa/ui/components/SwitchWithLabel';
 import CustomSelect from '@alga-psa/ui/components/CustomSelect';
 import { useTranslation } from '@alga-psa/ui/lib/i18n/client';
+import { useCurrencyFormat } from '@alga-psa/ui/lib';
 import {
   getErrorMessage,
   isActionMessageError,
@@ -36,6 +37,7 @@ export function PricingScheduleDialog({
   onSave
 }: PricingScheduleDialogProps) {
   const { t } = useTranslation('msp/contracts');
+  const { symbol } = useCurrencyFormat();
   const [effectiveDate, setEffectiveDate] = useState<Date | undefined>(
     schedule?.effective_date ? new Date(schedule.effective_date) : undefined
   );
@@ -326,7 +328,7 @@ export function PricingScheduleDialog({
                 {t('pricingSchedules.dialog.fields.customRate', { defaultValue: 'Custom Rate' })} *
               </Label>
               <div className="relative">
-                <span className="absolute left-3 top-1/2 transform -translate-y-1/2 text-muted-foreground">$</span>
+                <span className="absolute left-3 top-1/2 transform -translate-y-1/2 text-muted-foreground">{symbol()}</span>
                 <Input
                   id="custom-rate"
                   type="number"

--- a/packages/billing/src/components/billing-dashboard/service-configurations/HourlyServiceConfigPanel.tsx
+++ b/packages/billing/src/components/billing-dashboard/service-configurations/HourlyServiceConfigPanel.tsx
@@ -9,6 +9,7 @@ import { Button } from '@alga-psa/ui/components/Button';
 import { IContractLineServiceHourlyConfig, IUserTypeRate } from '@alga-psa/types';
 import { Trash2 } from 'lucide-react';
 import { useTranslation } from '@alga-psa/ui/lib/i18n/client';
+import { useCurrencyFormat } from '@alga-psa/ui/lib';
 
 interface HourlyServiceConfigPanelProps {
   configuration: Partial<IContractLineServiceHourlyConfig>;
@@ -28,6 +29,7 @@ export function HourlyServiceConfigPanel({
   disabled = false
 }: HourlyServiceConfigPanelProps) {
   const { t } = useTranslation('msp/service-catalog');
+  const { money } = useCurrencyFormat();
   const [minimumBillableTime, setMinimumBillableTime] = useState(configuration.minimum_billable_time || 15);
   const [roundUpToNearest, setRoundUpToNearest] = useState(configuration.round_up_to_nearest || 15);
   const [newUserType, setNewUserType] = useState('');
@@ -251,7 +253,7 @@ export function HourlyServiceConfigPanel({
                   {userTypeRates.map((item, index) => (
                     <div key={index} className="grid grid-cols-3 gap-2 items-center mb-1">
                       <div>{userTypeOptions.find(opt => opt.value === item.user_type)?.label || item.user_type}</div>
-                      <div>${(item.rate / 100).toFixed(2)}</div> {/* Display in dollars */}
+                      <div>{money(Number(item.rate))}</div>
                       <Button
                         type="button"
                         onClick={() => handleRemoveUserTypeRate(index)}

--- a/packages/billing/src/components/invoice-designer/canvas/DesignCanvas.tsx
+++ b/packages/billing/src/components/invoice-designer/canvas/DesignCanvas.tsx
@@ -491,28 +491,34 @@ const resolveTotalsRowBindingFallback = (type: 'subtotal' | 'tax' | 'discount' |
   }
 };
 
-const resolveTotalsRowAmountFallback = (type: 'subtotal' | 'tax' | 'discount' | 'custom-total'): string => {
+const resolveTotalsRowAmountFallbackMinorUnits = (type: 'subtotal' | 'tax' | 'discount' | 'custom-total'): number => {
   switch (type) {
     case 'subtotal':
-      return '$1,200.00';
+      return 120000;
     case 'tax':
-      return '$96.00';
+      return 9600;
     case 'discount':
-      return '-$50.00';
+      return -5000;
     case 'custom-total':
-      return '$1,296.00';
+      return 129600;
   }
 };
+
+const resolveTotalsRowAmountFallback = (
+  type: 'subtotal' | 'tax' | 'discount' | 'custom-total',
+  currencyCode: string
+): string => formatBoundValue(resolveTotalsRowAmountFallbackMinorUnits(type), 'currency', currencyCode) ?? '';
 
 const resolveTotalsRowPreviewModel = (
   node: DesignerNode,
   previewData: WasmInvoiceViewModel | null = null
 ): TotalsRowPreviewModel => {
+  const currencyCode = previewData?.currencyCode ?? 'USD';
   if (!isTotalsRowType(node.type)) {
     return {
       label: 'Value',
       bindingKey: 'binding',
-      previewValue: '$0.00',
+      previewValue: formatBoundValue(0, 'currency', currencyCode) ?? '',
       isGrandTotal: false,
     };
   }
@@ -525,13 +531,13 @@ const resolveTotalsRowPreviewModel = (
   const boundValue = formatBoundValue(
     resolveInvoiceBindingRawValue(previewData, bindingKey),
     format,
-    previewData?.currencyCode ?? 'USD'
+    currencyCode
   );
   const previewValue =
     boundValue ||
     asTrimmedString(metadata.previewValue) ||
     asTrimmedString(metadata.sampleValue) ||
-    resolveTotalsRowAmountFallback(node.type);
+    resolveTotalsRowAmountFallback(node.type, currencyCode);
   const isGrandTotal = /\b(grand total|amount due|balance due|total due)\b/i.test(label);
 
   return {
@@ -646,9 +652,10 @@ const renderTablePreview = (
 
 const renderTotalsSummaryPreview = (previewData: WasmInvoiceViewModel | null, t?: DesignerTranslator): React.ReactNode => {
   const currencyCode = previewData?.currencyCode ?? 'USD';
-  const subtotal = formatBoundValue(previewData?.subtotal ?? null, 'currency', currencyCode) ?? '$0.00';
-  const tax = formatBoundValue(previewData?.tax ?? null, 'currency', currencyCode) ?? '$0.00';
-  const total = formatBoundValue(previewData?.total ?? null, 'currency', currencyCode) ?? '$0.00';
+  const zeroAmount = formatBoundValue(0, 'currency', currencyCode) ?? '';
+  const subtotal = formatBoundValue(previewData?.subtotal ?? null, 'currency', currencyCode) ?? zeroAmount;
+  const tax = formatBoundValue(previewData?.tax ?? null, 'currency', currencyCode) ?? zeroAmount;
+  const total = formatBoundValue(previewData?.total ?? null, 'currency', currencyCode) ?? zeroAmount;
   return (
     <div className="space-y-1 text-[11px]">
       <div className="flex items-center justify-between text-slate-600">
@@ -697,7 +704,7 @@ const getPreviewContent = (node: DesignerNode, previewData: WasmInvoiceViewModel
           singleLine: !boundValue.multiline,
         };
       }
-      const preview = resolveFieldPreviewScaffold(node);
+      const preview = resolveFieldPreviewScaffold(node, previewData?.currencyCode ?? 'USD');
       if (preview.isPlaceholder) {
         return {
           content: renderPlaceholderPreview(preview.text),

--- a/packages/billing/src/components/invoice-designer/canvas/previewScaffolds.ts
+++ b/packages/billing/src/components/invoice-designer/canvas/previewScaffolds.ts
@@ -1,5 +1,6 @@
 import type { DesignerNode } from '../state/designerStore';
 import { resolveLabelText } from '../labelText';
+import { formatBoundValue } from '../preview/previewBindings';
 import { getNodeMetadata } from '../utils/nodeProps';
 
 type NodeMetadata = Record<string, unknown>;
@@ -69,6 +70,7 @@ const inferContextualValueScaffold = (input: {
   placeholderHint: string;
   labelHint: string;
   format: string;
+  currencyCode: string;
 }): string => {
   const contextHaystack = normalizeHintText(`${input.bindingKey} ${input.labelHint}`);
   if (
@@ -98,7 +100,7 @@ const inferContextualValueScaffold = (input: {
     return 'MM/DD/YYYY';
   }
   if (input.format === 'currency') {
-    return '$0.00';
+    return formatBoundValue(0, 'currency', input.currencyCode) ?? '';
   }
   if (input.placeholderHint.length > 0) {
     return input.placeholderHint;
@@ -127,7 +129,7 @@ const resolveFieldLabelHint = (metadata: NodeMetadata): string =>
   asTrimmedString(metadata.label) ||
   asTrimmedString(metadata.text);
 
-export const resolveFieldPreviewScaffold = (node: DesignerNode): EditorPreviewScaffold => {
+export const resolveFieldPreviewScaffold = (node: DesignerNode, currencyCode: string = 'USD'): EditorPreviewScaffold => {
   const metadata = getNodeMetadata(node) as NodeMetadata;
   const sampleValue = resolveSampleValue(metadata);
   if (sampleValue.length > 0) {
@@ -150,6 +152,7 @@ export const resolveFieldPreviewScaffold = (node: DesignerNode): EditorPreviewSc
       placeholderHint,
       labelHint: resolveFieldLabelHint(metadata),
       format,
+      currencyCode,
     }),
     isPlaceholder: true,
   };

--- a/packages/billing/src/components/project-billing/BudgetVsActualCard.tsx
+++ b/packages/billing/src/components/project-billing/BudgetVsActualCard.tsx
@@ -3,7 +3,7 @@
 import { useTranslation } from 'react-i18next';
 import { Card } from '@alga-psa/ui/components/Card';
 import type { IProjectBillingCapUsage, IProjectBillingConfig } from '@alga-psa/types';
-import type { ProjectBillingRollup } from '../../actions/projectBillingConfigActions';
+import type { ProjectBillingRollup } from '@alga-psa/types';
 import { formatCents } from './billingViewHelpers';
 
 interface BudgetVsActualCardProps {

--- a/packages/billing/src/components/project-billing/DeliveryEconomicsCard.tsx
+++ b/packages/billing/src/components/project-billing/DeliveryEconomicsCard.tsx
@@ -2,7 +2,7 @@
 
 import { useTranslation } from 'react-i18next';
 import { Card } from '@alga-psa/ui/components/Card';
-import type { ProjectBillingEconomics } from '../../actions/projectBillingConfigActions';
+import type { ProjectBillingEconomics } from '@alga-psa/types';
 import type { ProjectBillingModel } from '@alga-psa/types';
 import { formatCents } from './billingViewHelpers';
 
@@ -73,7 +73,7 @@ export default function DeliveryEconomicsCard({ economics, currency, billingMode
         <p className="mt-2 text-xs text-amber-700 dark:text-amber-300">
           {t(
             'billing.economics.uncostedHours',
-            '{{hours}} logged hours have no effective employee or default cost rate and contribute $0 to labor cost.',
+            '{{hours}} logged hours have no effective employee or default cost rate and contribute nothing to labor cost.',
             { hours: economics.uncosted_hours.toFixed(1) },
           )}
         </p>

--- a/packages/billing/src/components/project-billing/ProjectBillingView.tsx
+++ b/packages/billing/src/components/project-billing/ProjectBillingView.tsx
@@ -11,7 +11,7 @@ import CustomSelect from '@alga-psa/ui/components/CustomSelect';
 import { toast } from 'react-hot-toast';
 import { currencyFractionDigits, toMinorUnits } from '@alga-psa/core';
 import type { IProjectPhase, ProjectBillingInvoiceMode } from '@alga-psa/types';
-import type { ProjectBillingOverview } from '../../actions/projectBillingConfigActions';
+import type { ProjectBillingOverview } from '@alga-psa/types';
 import { updateProjectBillingConfig } from '../../actions/projectBillingConfigActions';
 import { generateProjectInvoice } from '../../actions/invoiceGeneration';
 import { useDrawer } from '@alga-psa/ui';

--- a/packages/billing/src/components/project-billing/ProjectPaymentWarningBanner.tsx
+++ b/packages/billing/src/components/project-billing/ProjectPaymentWarningBanner.tsx
@@ -6,10 +6,8 @@ import {
   isActionMessageError,
   isActionPermissionError,
 } from '@alga-psa/ui/lib/errorHandling';
-import {
-  getProjectPaymentWarning,
-  type ProjectPaymentWarning,
-} from '../../actions/projectBillingWarningActions';
+import { getProjectPaymentWarning } from '../../actions/projectBillingWarningActions';
+import type { ProjectPaymentWarning } from '@alga-psa/types';
 import { useTranslation } from 'react-i18next';
 
 interface ProjectPaymentWarningBannerProps {

--- a/packages/billing/src/components/project-billing/ScheduleEntryDialog.tsx
+++ b/packages/billing/src/components/project-billing/ScheduleEntryDialog.tsx
@@ -12,7 +12,7 @@ import { DatePicker } from '@alga-psa/ui/components/DatePicker';
 import { toast } from 'react-hot-toast';
 import { currencyFractionDigits, toMinorUnits } from '@alga-psa/core';
 import type { IProjectPhase } from '@alga-psa/types';
-import type { ScheduleEntryView } from '../../actions/projectBillingConfigActions';
+import type { ScheduleEntryView } from '@alga-psa/types';
 import {
   createScheduleEntry,
   updateScheduleEntry,

--- a/packages/billing/src/components/project-billing/ScheduleTable.tsx
+++ b/packages/billing/src/components/project-billing/ScheduleTable.tsx
@@ -12,7 +12,7 @@ import type { IProjectBillingConfig, IProjectPhase } from '@alga-psa/types';
 import type {
   ProjectBillingRollup,
   ScheduleEntryView,
-} from '../../actions/projectBillingConfigActions';
+} from '@alga-psa/types';
 import {
   approveScheduleEntry,
   approveAndInvoiceNow,

--- a/packages/billing/src/components/settings/billing/CreditExpirationSettings.tsx
+++ b/packages/billing/src/components/settings/billing/CreditExpirationSettings.tsx
@@ -41,7 +41,7 @@ const CreditExpirationSettings = (): React.JSX.Element => {
         ...settings,
         enableCreditExpiration: checked,
       };
-      const result = await updateDefaultBillingSettings(newSettings);
+      const result = await updateDefaultBillingSettings({ enableCreditExpiration: checked });
       if (isActionPermissionError(result)) {
         handleError(result.permissionError);
         return;
@@ -85,7 +85,11 @@ const CreditExpirationSettings = (): React.JSX.Element => {
         creditExpirationNotificationDays: days
       };
 
-      const result = await updateDefaultBillingSettings(newSettings);
+      const result = await updateDefaultBillingSettings({
+        enableCreditExpiration: newSettings.enableCreditExpiration,
+        creditExpirationDays: newSettings.creditExpirationDays,
+        creditExpirationNotificationDays: days,
+      });
       if (isActionPermissionError(result)) {
         handleError(result.permissionError);
         return;

--- a/packages/billing/src/components/settings/billing/DefaultCurrencySettings.tsx
+++ b/packages/billing/src/components/settings/billing/DefaultCurrencySettings.tsx
@@ -34,7 +34,7 @@ const DefaultCurrencySettings = (): React.JSX.Element => {
         ...settings,
         defaultCurrencyCode: value,
       };
-      const result = await updateDefaultBillingSettings(newSettings);
+      const result = await updateDefaultBillingSettings({ defaultCurrencyCode: value });
       if (isActionPermissionError(result)) {
         handleError(result.permissionError);
         return;

--- a/packages/billing/src/components/settings/billing/QuickAddProduct.tsx
+++ b/packages/billing/src/components/settings/billing/QuickAddProduct.tsx
@@ -39,6 +39,7 @@ import {
   type ActionPermissionError,
 } from '@alga-psa/ui/lib/errorHandling';
 import { useTranslation } from '@alga-psa/ui/lib/i18n/client';
+import { useCurrencyFormat } from '@alga-psa/ui/lib';
 
 const LICENSE_TERM_OPTION_VALUES = ['monthly', 'annual', 'perpetual'] as const;
 const BILLING_METHOD_OPTION_VALUES = ['usage'] as const;
@@ -73,6 +74,7 @@ interface QuickAddProductProps {
 
 export function QuickAddProduct({ isOpen, onClose, onProductAdded, product }: QuickAddProductProps) {
   const { t } = useTranslation('msp/billing-settings');
+  const { money } = useCurrencyFormat();
   const isEditMode = !!product;
   const [error, setError] = useState<string | null>(null);
   const [defaultCurrency, setDefaultCurrency] = useState('USD');
@@ -1074,7 +1076,7 @@ export function QuickAddProduct({ isOpen, onClose, onProductAdded, product }: Qu
                                 <span className="font-medium">{o.vendor_name || o.vendor_id}</span>
                                 {o.vendor_sku && <span className="font-mono text-xs text-gray-500">{o.vendor_sku}</span>}
                                 <span className="ml-auto tabular-nums">
-                                  {o.unit_cost != null ? `$${(Number(o.unit_cost) / 100).toFixed(2)} ${o.cost_currency}` : '—'}
+                                  {o.unit_cost != null ? money(Number(o.unit_cost), o.cost_currency) : '—'}
                                 </span>
                                 {o.is_preferred && (
                                   <span className="text-xs rounded bg-green-100 text-green-800 px-1.5 py-0.5">Preferred</span>

--- a/packages/billing/src/components/settings/billing/RenewalAutomationSettings.tsx
+++ b/packages/billing/src/components/settings/billing/RenewalAutomationSettings.tsx
@@ -172,7 +172,15 @@ const RenewalAutomationSettings = (): React.JSX.Element => {
   const handleSave = async () => {
     try {
       setSaving(true);
-      const result = await updateDefaultBillingSettings(settings);
+      const result = await updateDefaultBillingSettings({
+        defaultRenewalMode: settings.defaultRenewalMode,
+        defaultNoticePeriodDays: settings.defaultNoticePeriodDays,
+        renewalDueDateActionPolicy: settings.renewalDueDateActionPolicy,
+        renewalTicketBoardId: settings.renewalTicketBoardId,
+        renewalTicketStatusId: settings.renewalTicketStatusId,
+        renewalTicketPriority: settings.renewalTicketPriority,
+        renewalTicketAssigneeId: settings.renewalTicketAssigneeId,
+      });
       if (isActionPermissionError(result)) {
         handleError(result.permissionError);
         return;

--- a/packages/billing/src/components/settings/billing/ServiceCatalogManager.tsx
+++ b/packages/billing/src/components/settings/billing/ServiceCatalogManager.tsx
@@ -36,6 +36,7 @@ import {
 } from '@alga-psa/ui/components/DropdownMenu';
 import LoadingIndicator from '@alga-psa/ui/components/LoadingIndicator';
 import { useTranslation } from '@alga-psa/ui/lib/i18n/client';
+import { useCurrencyFormat } from '@alga-psa/ui/lib';
 
 // Removed old SERVICE_TYPE_OPTIONS
 
@@ -47,6 +48,7 @@ const LICENSE_TERM_OPTION_VALUES = ['monthly', 'annual', 'perpetual'] as const;
 
 const ServiceCatalogManager: React.FC = () => {
   const { t } = useTranslation('msp/billing-settings');
+  const { money } = useCurrencyFormat();
   const [defaultCurrency, setDefaultCurrency] = useState('USD');
   const [services, setServices] = useState<IService[]>([]);
   // Note: Categories are currently hidden in favor of using Service Types for organization
@@ -504,7 +506,7 @@ const ServiceCatalogManager: React.FC = () => {
         render: (prices: IServicePrice[] | undefined, record) => {
           if (!prices || prices.length === 0) {
             // Fall back to default_rate if no prices exist
-            return `$${(record.default_rate / 100).toFixed(2)}`;
+            return money(Number(record.default_rate));
           }
           // Show primary price (first one, typically USD)
           const primaryPrice = prices[0];

--- a/packages/billing/src/components/settings/billing/ZeroDollarInvoiceSettings.tsx
+++ b/packages/billing/src/components/settings/billing/ZeroDollarInvoiceSettings.tsx
@@ -34,7 +34,9 @@ const ZeroDollarInvoiceSettings = (): React.JSX.Element => {
         ...settings,
         zeroDollarInvoiceHandling: value as 'normal' | 'finalized',
       };
-      const result = await updateDefaultBillingSettings(newSettings);
+      const result = await updateDefaultBillingSettings({
+        zeroDollarInvoiceHandling: newSettings.zeroDollarInvoiceHandling,
+      });
       if (isActionPermissionError(result)) {
         handleError(result.permissionError);
         return;
@@ -56,7 +58,7 @@ const ZeroDollarInvoiceSettings = (): React.JSX.Element => {
         ...settings,
         suppressZeroDollarInvoices: checked,
       };
-      const result = await updateDefaultBillingSettings(newSettings);
+      const result = await updateDefaultBillingSettings({ suppressZeroDollarInvoices: checked });
       if (isActionPermissionError(result)) {
         handleError(result.permissionError);
         return;

--- a/packages/billing/src/components/settings/tax/TaxComponentEditor.tsx
+++ b/packages/billing/src/components/settings/tax/TaxComponentEditor.tsx
@@ -32,6 +32,7 @@ import {
 } from '@alga-psa/ui/components/DropdownMenu';
 import { Tooltip } from '@alga-psa/ui/components/Tooltip';
 import { useTranslation } from '@alga-psa/ui/lib/i18n/client';
+import { useCurrencyFormat } from '@alga-psa/ui/lib';
 
 import { ITaxComponent } from '@alga-psa/types';
 import { ColumnDefinition } from '@alga-psa/types';
@@ -66,6 +67,7 @@ interface TaxComponentEditorProps {
 
 export function TaxComponentEditor({ taxRateId, isReadOnly = false }: TaxComponentEditorProps) {
   const { t } = useTranslation('msp/billing-settings');
+  const { money } = useCurrencyFormat();
   const [components, setComponents] = useState<ITaxComponent[]>([]);
   const [isLoading, setIsLoading] = useState(true);
   const [isSubmitting, setIsSubmitting] = useState(false);
@@ -404,7 +406,7 @@ export function TaxComponentEditor({ taxRateId, isReadOnly = false }: TaxCompone
           <div className="bg-muted/50 rounded-lg p-4 mt-4">
             <h5 className="text-sm font-medium mb-2">
               {t('tax.components.preview.title', {
-                amount: `$${calculatePreview.baseAmount.toFixed(2)}`,
+                amount: money(Math.round(calculatePreview.baseAmount * 100)),
                 defaultValue: 'Calculation Preview ({{amount}} base)'
               })}
             </h5>
@@ -416,13 +418,13 @@ export function TaxComponentEditor({ taxRateId, isReadOnly = false }: TaxCompone
                       ? t('tax.components.preview.compoundSuffix', { defaultValue: ', compound' })
                       : ''}):
                   </span>
-                  <span>${item.tax.toFixed(2)}</span>
+                  <span>{money(Math.round(item.tax * 100))}</span>
                 </div>
               ))}
               <div className="border-t pt-1 mt-1 flex justify-between font-medium">
                 <span>{t('tax.components.preview.totalTax', { defaultValue: 'Total Tax:' })}</span>
                 <span>
-                  ${calculatePreview.totalTax.toFixed(2)} (
+                  {money(Math.round(calculatePreview.totalTax * 100))} (
                   {t('tax.components.preview.effective', {
                     rate: calculatePreview.effectiveRate.toFixed(2),
                     defaultValue: 'Effective: {{rate}}%'

--- a/packages/billing/src/components/settings/tax/TaxThresholdEditor.tsx
+++ b/packages/billing/src/components/settings/tax/TaxThresholdEditor.tsx
@@ -29,6 +29,7 @@ import {
 } from '@alga-psa/ui/components/DropdownMenu';
 import { Tooltip } from '@alga-psa/ui/components/Tooltip';
 import { useTranslation } from '@alga-psa/ui/lib/i18n/client';
+import { useCurrencyFormat } from '@alga-psa/ui/lib';
 
 import { ITaxRateThreshold } from '@alga-psa/types';
 import { ColumnDefinition } from '@alga-psa/types';
@@ -70,8 +71,10 @@ interface TaxThresholdEditorProps {
   isReadOnly?: boolean;
 }
 
-export function TaxThresholdEditor({ taxRateId, currency = '$', isReadOnly = false }: TaxThresholdEditorProps) {
+export function TaxThresholdEditor({ taxRateId, currency, isReadOnly = false }: TaxThresholdEditorProps) {
   const { t } = useTranslation('msp/billing-settings');
+  const { symbol } = useCurrencyFormat();
+  const currencySymbol = currency ?? symbol();
   const [thresholds, setThresholds] = useState<ITaxRateThreshold[]>([]);
   const [isLoading, setIsLoading] = useState(true);
   const [isSubmitting, setIsSubmitting] = useState(false);
@@ -134,18 +137,18 @@ export function TaxThresholdEditor({ taxRateId, currency = '$', isReadOnly = fal
         const currentMax = current.max_amount;
         if (currentMax === null || currentMax === undefined) {
           issues.push(t('tax.thresholds.issueNoMax', {
-            from: `${currency}${current.min_amount.toLocaleString()}`,
+            from: `${currencySymbol}${current.min_amount.toLocaleString()}`,
             defaultValue: 'Bracket starting at {{from}} has no max but is not the last bracket.'
           }));
         } else if (currentMax < next.min_amount) {
           issues.push(t('tax.thresholds.issueGap', {
-            from: `${currency}${currentMax.toLocaleString()}`,
-            to: `${currency}${next.min_amount.toLocaleString()}`,
+            from: `${currencySymbol}${currentMax.toLocaleString()}`,
+            to: `${currencySymbol}${next.min_amount.toLocaleString()}`,
             defaultValue: 'Gap between {{from}} and {{to}}'
           }));
         } else if (currentMax > next.min_amount) {
           issues.push(t('tax.thresholds.issueOverlap', {
-            at: `${currency}${currentMax.toLocaleString()}`,
+            at: `${currencySymbol}${currentMax.toLocaleString()}`,
             defaultValue: 'Overlap between brackets at {{at}}'
           }));
         }
@@ -153,7 +156,7 @@ export function TaxThresholdEditor({ taxRateId, currency = '$', isReadOnly = fal
     }
 
     return issues;
-  }, [thresholds, currency, t]);
+  }, [thresholds, currencySymbol, t]);
 
   // Get suggested min_amount for new bracket
   const getSuggestedMinAmount = useCallback(() => {
@@ -297,7 +300,7 @@ export function TaxThresholdEditor({ taxRateId, currency = '$', isReadOnly = fal
   }, [thresholds, previewAmount]);
 
   const formatCurrency = (amount: number) => {
-    return `${currency}${amount.toLocaleString(undefined, { minimumFractionDigits: 2, maximumFractionDigits: 2 })}`;
+    return `${currencySymbol}${amount.toLocaleString(undefined, { minimumFractionDigits: 2, maximumFractionDigits: 2 })}`;
   };
 
   const columns: ColumnDefinition<ITaxRateThreshold>[] = [

--- a/packages/billing/src/lib/invoice-template-ast/fieldFormatting.ts
+++ b/packages/billing/src/lib/invoice-template-ast/fieldFormatting.ts
@@ -1,3 +1,4 @@
+import { formatCurrencyFromMinorUnits } from '@alga-psa/core';
 import type { TemplateFieldDisplayFormat, TemplateValueFormat } from '@alga-psa/types';
 
 type AddressRecord = Record<string, unknown>;
@@ -18,7 +19,7 @@ const formatCurrency = (value: number, currencyCode: string) => {
       currency: currencyCode || 'USD',
     }).format(value / 100);
   } catch {
-    return `$${(value / 100).toFixed(2)}`;
+    return formatCurrencyFromMinorUnits(value, 'en-US', 'USD');
   }
 };
 

--- a/packages/billing/src/lib/invoice-template-ast/react-renderer.tsx
+++ b/packages/billing/src/lib/invoice-template-ast/react-renderer.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import { formatCurrencyFromMinorUnits } from '@alga-psa/core';
 import type {
   TemplateAst,
   TemplateFieldBorderStyle,
@@ -227,7 +228,7 @@ const formatValue = (value: unknown, format: TemplateValueFormat | undefined, ct
         currency: ctx.currencyCode || 'USD',
       }).format(numeric / 100);
     } catch {
-      return `$${(numeric / 100).toFixed(2)}`;
+      return formatCurrencyFromMinorUnits(numeric, 'en-US', 'USD');
     }
   }
 

--- a/packages/billing/tests/billingSettingsActions.defaultCurrency.test.ts
+++ b/packages/billing/tests/billingSettingsActions.defaultCurrency.test.ts
@@ -242,3 +242,60 @@ describe('updateDefaultBillingSettings — default currency', () => {
     });
   });
 });
+
+// The billing settings page's sections each save against the same row. A
+// section's save must write only its own keys — a renewal save carrying a
+// stale snapshot used to revert a just-saved currency change (prod repro).
+describe('updateDefaultBillingSettings — partial saves do not clobber other sections', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockState.existingSettings = {
+      tenant: 'tenant-1',
+      zero_dollar_invoice_handling: 'normal',
+      suppress_zero_dollar_invoices: false,
+      default_currency_code: 'GBP',
+    };
+    mockState.updates = [];
+    mockState.inserts = [];
+  });
+
+  it('a renewal-only save leaves default_currency_code unwritten', async () => {
+    const { updateDefaultBillingSettings } = await import(
+      '../src/actions/billingSettingsActions'
+    );
+
+    const result = await updateDefaultBillingSettings(
+      { user_id: 'user-1' },
+      { tenant: 'tenant-1' },
+      { defaultRenewalMode: 'manual', defaultNoticePeriodDays: 30 }
+    );
+
+    expect(result).toEqual({ success: true });
+    expect(mockState.updates).toHaveLength(1);
+    expect(mockState.updates[0]?.payload).toMatchObject({
+      default_renewal_mode: 'manual',
+      default_notice_period_days: 30,
+    });
+    expect(mockState.updates[0]?.payload).not.toHaveProperty('default_currency_code');
+    expect(mockState.updates[0]?.payload).not.toHaveProperty('zero_dollar_invoice_handling');
+  });
+
+  it('a currency-only save writes only the currency column', async () => {
+    const { updateDefaultBillingSettings } = await import(
+      '../src/actions/billingSettingsActions'
+    );
+
+    const result = await updateDefaultBillingSettings(
+      { user_id: 'user-1' },
+      { tenant: 'tenant-1' },
+      { defaultCurrencyCode: 'EUR' }
+    );
+
+    expect(result).toEqual({ success: true });
+    expect(mockState.updates).toHaveLength(1);
+    expect(Object.keys(mockState.updates[0]?.payload ?? {}).sort()).toEqual([
+      'default_currency_code',
+      'updated_at',
+    ]);
+  });
+});

--- a/packages/client-portal/src/components/appointments/RequestAppointmentModal.tsx
+++ b/packages/client-portal/src/components/appointments/RequestAppointmentModal.tsx
@@ -10,6 +10,7 @@ import CustomSelect from '@alga-psa/ui/components/CustomSelect';
 import { TextArea } from '@alga-psa/ui/components/TextArea';
 import { AlertCircle, CheckCircle2, Calendar as CalendarIcon, Clock, User, FileText } from 'lucide-react';
 import { useTranslation } from '@alga-psa/ui/lib/i18n/client';
+import { useCurrencyFormat } from '@alga-psa/ui/lib';
 import { Badge } from '@alga-psa/ui/components/Badge';
 import { format } from 'date-fns';
 import { WizardProgress } from '@alga-psa/ui/components/onboarding/WizardProgress';
@@ -79,6 +80,7 @@ export function RequestAppointmentModal({
 }: RequestAppointmentModalProps) {
   const { t } = useTranslation('features/appointments');
   const { t: tCommon } = useTranslation('common');
+  const { money } = useCurrencyFormat();
   const isEditMode = !!editingAppointment;
 
   const STEP_LABELS = useMemo(
@@ -489,7 +491,7 @@ export function RequestAppointmentModal({
                       <div className="flex items-center gap-2">
                         <Badge variant="primary">{selectedService.service_type}</Badge>
                         {selectedService.default_rate && (
-                          <span>${selectedService.default_rate}/{selectedService.unit_of_measure || 'hour'}</span>
+                          <span>{money(Number(selectedService.default_rate))}/{selectedService.unit_of_measure || 'hour'}</span>
                         )}
                       </div>
                     )}

--- a/packages/clients/src/actions/clientContractActions.ts
+++ b/packages/clients/src/actions/clientContractActions.ts
@@ -84,6 +84,13 @@ function toClientContractActionError(error: unknown): ClientContractActionError 
     return permissionError(error.message);
   }
 
+  if (
+    error instanceof Error &&
+    error.message.includes('Mixed-currency contracts for the same client are not supported')
+  ) {
+    return actionError(error.message);
+  }
+
   return null;
 }
 

--- a/packages/clients/src/components/clients/ServiceCatalog.tsx
+++ b/packages/clients/src/components/clients/ServiceCatalog.tsx
@@ -6,6 +6,7 @@ import { ColumnDefinition, IService, IServiceCategory } from '@alga-psa/types';
 import { Input } from '@alga-psa/ui/components/Input';
 import { Pencil, Trash2, Check, X } from 'lucide-react';
 import { useTranslation } from '@alga-psa/ui/lib/i18n/client';
+import { useCurrencyFormat } from '@alga-psa/ui/lib';
 
 interface ServiceCatalogProps {
     services: IService[];
@@ -23,6 +24,7 @@ const ServiceCatalog: React.FC<ServiceCatalogProps> = ({
     onAdd
 }) => {
     const { t } = useTranslation('msp/clients');
+    const { money } = useCurrencyFormat();
     const [editingId, setEditingId] = useState<string | null>(null);
     const [editingName, setEditingName] = useState<string>('');
     const [showDeleteDialog, setShowDeleteDialog] = useState(false);
@@ -82,7 +84,7 @@ const ServiceCatalog: React.FC<ServiceCatalogProps> = ({
             dataIndex: 'default_rate',
             render: (value) => (
                 <span className="text-[rgb(var(--color-text-700))]">
-                    ${typeof value === 'number' ? value.toFixed(2) : value}
+                    {money(Math.round(Number(value) * 100))}
                 </span>
             ),
         },

--- a/packages/clients/src/components/clients/command-center/ClientCommandCenter.tsx
+++ b/packages/clients/src/components/clients/command-center/ClientCommandCenter.tsx
@@ -34,6 +34,7 @@ import {
   type ActionMessageError,
   type ActionPermissionError,
 } from '@alga-psa/ui/lib/errorHandling';
+import { useCurrencyFormat } from '@alga-psa/ui/lib';
 
 type TFn = (key: string, options?: Record<string, unknown>) => string;
 
@@ -177,6 +178,7 @@ export default function ClientCommandCenter({
     return target ? () => openFocus(target) : null;
   }, [resolveTab, openFocus]);
 
+  const { money } = useCurrencyFormat();
   const currencyCode = pulse?.money?.currencyCode ?? 'USD';
   const formatMoney = useCallback((cents: number) => {
     try {
@@ -186,9 +188,9 @@ export default function ClientCommandCenter({
         maximumFractionDigits: cents % 100 === 0 ? 0 : 2,
       }).format(cents / 100);
     } catch {
-      return `$${(cents / 100).toFixed(2)}`;
+      return money(cents);
     }
-  }, [currencyCode]);
+  }, [currencyCode, money]);
 
   const navigateToRef = useCallback((refType: string, refId: string) => {
     switch (refType) {

--- a/packages/projects/src/components/PhaseListItem.tsx
+++ b/packages/projects/src/components/PhaseListItem.tsx
@@ -12,6 +12,7 @@ import { Tooltip } from '@alga-psa/ui/components/Tooltip';
 import { ProjectTaskStatusSettings } from './settings/projects/ProjectTaskStatusSettings';
 import { getProjectStatusMappings } from '../actions/projectTaskStatusActions';
 import { phaseBadgeClasses, formatCents, type PhaseBillingBadge } from '@alga-psa/core';
+import { useCurrencyFormat } from '@alga-psa/ui/lib';
 import styles from './ProjectDetail.module.css';
 
 interface PhaseListItemProps {
@@ -87,6 +88,7 @@ export const PhaseListItem: React.FC<PhaseListItemProps> = ({
   onReopen,
 }) => {
   const { t } = useTranslation('features/projects');
+  const { symbol } = useCurrencyFormat();
   const isCompleted = Boolean(phase.completed_at);
   const showCompletionNudge = !isCompleted && Boolean(allTasksClosed) && (taskCount ?? 0) > 0;
   const [isDragging, setIsDragging] = useState(false);
@@ -399,7 +401,7 @@ export const PhaseListItem: React.FC<PhaseListItemProps> = ({
                       className={`inline-flex items-center rounded px-1.5 py-0.5 text-[10px] font-bold ${phaseBadgeClasses(billingBadge.status)}`}
                       aria-label={t('billing.phaseBadge.label', 'Billing milestone')}
                     >
-                      $
+                      {symbol(billingBadge.currency ?? undefined)}
                     </span>
                   </Tooltip>
                 )}

--- a/packages/projects/src/components/TaskListView.tsx
+++ b/packages/projects/src/components/TaskListView.tsx
@@ -32,6 +32,7 @@ import { getUserAvatarUrlsBatchAction } from '@alga-psa/user-composition/actions
 import { getTeamAvatarUrlsBatchAction } from '@alga-psa/teams/actions';
 import { highlightSearchMatch } from '../lib/searchUtils';
 import { useTranslation } from 'react-i18next';
+import { useCurrencyFormat } from '@alga-psa/ui/lib';
 import { Checkbox } from '@alga-psa/ui/components/Checkbox';
 import { useTaskSelection } from './TaskSelectionContext';
 
@@ -283,6 +284,7 @@ export default function TaskListView({
   searchCaseSensitive = false
 }: TaskListViewProps) {
   const { t } = useTranslation(['features/projects', 'common']);
+  const { symbol } = useCurrencyFormat();
   const { isSelected, toggleTask, setTasksSelected, selectedTaskIds } = useTaskSelection();
   const [expandedPhases, setExpandedPhases] = useState<Set<string>>(new Set());
   const [expandedStatuses, setExpandedStatuses] = useState<Set<string>>(new Set());
@@ -1423,7 +1425,7 @@ export default function TaskListView({
                                 </span>
                                 {phaseBillingBadges?.[phaseGroup.phase.phase_id] && (
                                   <Tooltip content={formatCents(phaseBillingBadges[phaseGroup.phase.phase_id].amountCents, phaseBillingBadges[phaseGroup.phase.phase_id].currency)}>
-                                    <span className={`inline-flex items-center rounded px-1.5 py-0.5 text-[10px] font-bold ${phaseBadgeClasses(phaseBillingBadges[phaseGroup.phase.phase_id].status)}`}>$</span>
+                                    <span className={`inline-flex items-center rounded px-1.5 py-0.5 text-[10px] font-bold ${phaseBadgeClasses(phaseBillingBadges[phaseGroup.phase.phase_id].status)}`}>{symbol()}</span>
                                   </Tooltip>
                                 )}
                                 {phaseGroup.phase.completed_at && (

--- a/packages/tickets/src/components/ticket/bento/BentoHero.unsavedChanges.test.tsx
+++ b/packages/tickets/src/components/ticket/bento/BentoHero.unsavedChanges.test.tsx
@@ -324,12 +324,14 @@ describe('BentoHero unsaved change model', () => {
 
     // Returning to the saved board restores status/category/priority, so the
     // pending diff self-cleans: no save bar, no warning, no {status_id: null}.
+    // Generous timeout: under Nx parallel load the board-a refetch chain that
+    // self-cleans the diff can outlast waitFor's 1s default.
     await waitFor(() => {
       expect(screen.queryByRole('button', { name: /Save Changes/i })).not.toBeInTheDocument();
-    });
+    }, { timeout: 5_000 });
     await waitFor(() => {
       expect(onLiveDirtyFieldsChange).toHaveBeenLastCalledWith([]);
-    });
+    }, { timeout: 5_000 });
     expect(screen.queryByText('Select a status for the new board before saving.')).not.toBeInTheDocument();
     expect(screen.getByTestId('bento-hero-status-select')).toHaveValue('status-a');
   });

--- a/packages/ui/src/lib/currency/useCurrencyFormat.tsx
+++ b/packages/ui/src/lib/currency/useCurrencyFormat.tsx
@@ -19,6 +19,8 @@ export interface CurrencyFormat {
   money: (minorUnits: number, currencyOverride?: string) => string;
   moneySigned: (minorUnits: number, currencyOverride?: string) => string;
   fractionDigits: (currencyOverride?: string) => number;
+  /** Bare currency symbol ("$", "€") for input adornments. */
+  symbol: (currencyOverride?: string) => string;
 }
 
 const CurrencyFormatContext = React.createContext<CurrencyFormatContextValue>({
@@ -68,6 +70,15 @@ export function useCurrencyFormat(): CurrencyFormat {
       },
       fractionDigits: (currencyOverride?: string) =>
         currencyFractionDigits(resolveCurrency(currencyOverride), locale),
+      symbol: (currencyOverride?: string) => {
+        const currency = resolveCurrency(currencyOverride);
+        try {
+          const parts = new Intl.NumberFormat(locale, { style: 'currency', currency }).formatToParts(0);
+          return parts.find((part) => part.type === 'currency')?.value ?? currency;
+        } catch {
+          return currency;
+        }
+      },
     };
   }, [currencyCode, locale]);
 }

--- a/server/public/locales/en/features/projects.json
+++ b/server/public/locales/en/features/projects.json
@@ -1714,7 +1714,7 @@
       "marginValue": "{{pct}}%",
       "marginUnavailable": "—",
       "currencyMismatch": "Costs are recorded in {{costCurrency}}, while project revenue is in {{revenueCurrency}}. Projected margin is unavailable without an exchange rate.",
-      "uncostedHours": "{{hours}} logged hours have no effective employee or default cost rate and contribute $0 to labor cost."
+      "uncostedHours": "{{hours}} logged hours have no effective employee or default cost rate and contribute nothing to labor cost."
     },
     "paymentWarning": {
       "title": "Payment prerequisite warning",

--- a/server/src/app/client-portal/ClientPortalLayoutClient.tsx
+++ b/server/src/app/client-portal/ClientPortalLayoutClient.tsx
@@ -4,6 +4,7 @@ import { AppSessionProvider } from "@alga-psa/auth/client";
 import { ClientPortalLayout } from "@alga-psa/client-portal/components";
 import { I18nWrapper } from "@alga-psa/tenancy/components";
 import { PostHogUserIdentifier } from "@alga-psa/ui/components/analytics/PostHogUserIdentifier";
+import { CurrencyFormatProvider } from "@alga-psa/ui/lib";
 import { BrandingProvider } from "@alga-psa/tenancy/components";
 import type { Session } from "next-auth";
 import type { TenantBranding } from "@alga-psa/tenancy/actions";
@@ -19,6 +20,8 @@ interface Props {
   session: Session | null;
   branding: TenantBranding | null;
   productCode: ProductCode;
+  /** Tenant default currency (default_billing_settings) for CurrencyFormatProvider. */
+  currencyCode?: string;
   initialLocale?: SupportedLocale | null;
   initialSidebarCollapsed?: boolean;
 }
@@ -28,6 +31,7 @@ export function ClientPortalLayoutClient({
   session,
   branding,
   productCode,
+  currencyCode,
   initialLocale,
   initialSidebarCollapsed = false,
 }: Props) {
@@ -38,6 +42,7 @@ export function ClientPortalLayoutClient({
     <AppSessionProvider session={session}>
       <PostHogUserIdentifier />
       <I18nWrapper portal="client" initialLocale={initialLocale || undefined}>
+        <CurrencyFormatProvider currencyCode={currencyCode || 'USD'}>
         <BrandingProvider initialBranding={branding}>
           <ClientPortalDocumentsProvider>
             <ClientPortalLayout
@@ -50,6 +55,7 @@ export function ClientPortalLayoutClient({
             </ClientPortalLayout>
           </ClientPortalDocumentsProvider>
         </BrandingProvider>
+        </CurrencyFormatProvider>
       </I18nWrapper>
     </AppSessionProvider>
   );

--- a/server/src/app/client-portal/layout.tsx
+++ b/server/src/app/client-portal/layout.tsx
@@ -5,6 +5,7 @@ import { ClientPortalLayoutClient } from "./ClientPortalLayoutClient";
 import { getTenantBrandingByTenantId } from "@alga-psa/tenancy/actions";
 import { getHierarchicalLocaleAction } from "@alga-psa/tenancy/actions";
 import { getCurrentTenantProduct } from "@/lib/productAccess";
+import { getTenantDefaultCurrencyCode } from "@alga-psa/billing/actions/billingCurrencyActions";
 import type { Metadata } from 'next';
 
 const CLIENT_SIDEBAR_COOKIE = 'client_portal_sidebar_collapsed';
@@ -55,12 +56,14 @@ export default async function Layout({
   const initialSidebarCollapsed =
     cookieStore.get(CLIENT_SIDEBAR_COOKIE)?.value === 'true';
   const productCode = await getCurrentTenantProduct();
+  const currencyCode = await getTenantDefaultCurrencyCode().catch(() => 'USD');
 
   return (
     <ClientPortalLayoutClient
       session={session}
       branding={branding}
       productCode={productCode}
+      currencyCode={currencyCode}
       initialLocale={locale}
       initialSidebarCollapsed={initialSidebarCollapsed}
     >

--- a/server/src/app/msp/MspLayoutClient.tsx
+++ b/server/src/app/msp/MspLayoutClient.tsx
@@ -22,11 +22,14 @@ import type { ProductCode } from '@alga-psa/types';
 import { resolveProductRouteBehavior } from '@/lib/productSurfaceRegistry';
 import { ProductRouteBoundary } from '@/components/product/ProductRouteBoundary';
 import { KeyboardShortcutsProvider } from '@alga-psa/ui/keyboard-shortcuts';
+import { CurrencyFormatProvider } from '@alga-psa/ui/lib';
 import { useKeyboardShortcutPreferenceStorage } from '@/hooks/useKeyboardShortcutPreferenceStorage';
 
 interface Props {
   children: React.ReactNode;
   session: Session | null;
+  /** Tenant default currency (default_billing_settings) for CurrencyFormatProvider. */
+  currencyCode?: string;
   productCode: ProductCode;
   needsOnboarding: boolean;
   initialSidebarCollapsed: boolean;
@@ -71,6 +74,7 @@ function OnboardingRedirectFallback() {
 export function MspLayoutClient({
   children,
   session,
+  currencyCode,
   productCode,
   needsOnboarding,
   initialSidebarCollapsed,
@@ -206,7 +210,9 @@ export function MspLayoutClient({
 
   return (
     <I18nWrapper portal="msp" initialLocale={initialLocale || undefined} preloadedResources={preloadedLocaleResources}>
-      {content}
+      <CurrencyFormatProvider currencyCode={currencyCode || 'USD'}>
+        {content}
+      </CurrencyFormatProvider>
     </I18nWrapper>
   );
 }

--- a/server/src/app/msp/layout.tsx
+++ b/server/src/app/msp/layout.tsx
@@ -5,6 +5,7 @@ import { getTenantSettings } from "@alga-psa/tenancy/actions/tenant-settings-act
 import { getHierarchicalLocaleAction } from "@alga-psa/tenancy/actions/locale-actions/getHierarchicalLocale";
 import { MspLayoutClient } from "./MspLayoutClient";
 import { getCurrentTenantProduct } from "@/lib/productAccess";
+import { getTenantDefaultCurrencyCode } from "@alga-psa/billing/actions/billingCurrencyActions";
 import { preloadLocaleResources } from "@/lib/i18n/preloadLocaleResources";
 import { isSelfHostLicensing } from "@alga-psa/licensing";
 import type { Metadata } from 'next';
@@ -67,10 +68,12 @@ export default async function MspLayout({
   // Only self-host installs carry a license_state row; gate the trial/expiry
   // banner here so it never mounts (or calls getLicenseStatus) on hosted/SaaS.
   const selfHostLicensing = await isSelfHostLicensing();
+  const currencyCode = await getTenantDefaultCurrencyCode().catch(() => 'USD');
 
   return (
     <MspLayoutClient
       session={session}
+      currencyCode={currencyCode}
       productCode={productCode}
       needsOnboarding={needsOnboarding}
       initialSidebarCollapsed={initialSidebarCollapsed}

--- a/server/src/lib/eventBus/subscribers/creditExpiringSubscriber.ts
+++ b/server/src/lib/eventBus/subscribers/creditExpiringSubscriber.ts
@@ -115,12 +115,21 @@ async function handleCreditExpiringEvent(event: unknown): Promise<void> {
         // Calculate total expiring amount
         const totalAmount = credits.reduce((sum, credit) => sum + Number(credit.amount), 0);
 
+        const currencyCode =
+          client.default_currency_code ||
+          (
+            await scopedDb.table('default_billing_settings')
+              .select('default_currency_code')
+              .first()
+          )?.default_currency_code ||
+          'USD';
+
         // Format credit data for the email template
         const creditItems = credits.map((credit) => {
           const transactionId = transactionIdByCreditId[credit.creditId];
           return {
             creditId: credit.creditId,
-            amount: formatCurrency(Number(credit.amount)),
+            amount: formatCurrency(Number(credit.amount), 'en-US', currencyCode),
             expirationDate: formatDate(credit.expirationDate),
             transactionId,
             description: transactionMap[transactionId]?.description || 'N/A',
@@ -134,7 +143,7 @@ async function handleCreditExpiringEvent(event: unknown): Promise<void> {
             name: client.name,
           },
           credits: {
-            totalAmount: formatCurrency(totalAmount),
+            totalAmount: formatCurrency(totalAmount, 'en-US', currencyCode),
             expirationDate: formatDate(credits[0].expirationDate),
             daysRemaining: daysBeforeExpiration,
             items: creditItems,

--- a/server/src/test/unit/app/msp/service-requests/editor.i18n.test.tsx
+++ b/server/src/test/unit/app/msp/service-requests/editor.i18n.test.tsx
@@ -59,6 +59,7 @@ vi.mock('@alga-psa/ui/lib/i18n/client', async () => {
 
   return {
     detectClientLocale: () => 'de',
+    useOptionalI18n: () => null,
     I18nProvider: ({
       children,
       initialLocale = 'de',

--- a/server/src/test/unit/app/msp/settings/ticketing.i18n.test.tsx
+++ b/server/src/test/unit/app/msp/settings/ticketing.i18n.test.tsx
@@ -68,6 +68,7 @@ vi.mock('@alga-psa/ui/lib/i18n/client', async () => {
 
   return {
     detectClientLocale: () => 'de',
+    useOptionalI18n: () => null,
     I18nProvider: ({
       children,
       initialLocale = 'de',

--- a/server/src/test/unit/app/msp/tickets/detail.page.i18n.test.tsx
+++ b/server/src/test/unit/app/msp/tickets/detail.page.i18n.test.tsx
@@ -67,6 +67,7 @@ vi.mock('@alga-psa/ui/lib/i18n/client', async () => {
 
   return {
     detectClientLocale: () => 'de',
+    useOptionalI18n: () => null,
     I18nProvider: ({
       children,
       initialLocale = 'de',

--- a/server/src/test/unit/app/msp/tickets/page.i18n.test.tsx
+++ b/server/src/test/unit/app/msp/tickets/page.i18n.test.tsx
@@ -148,6 +148,7 @@ vi.mock('@alga-psa/ui/lib/i18n/client', async () => {
 
   return {
     detectClientLocale: () => 'en',
+    useOptionalI18n: () => null,
     I18nProvider: ({
       children,
       initialLocale = 'en',

--- a/server/src/test/unit/docs/multiActiveContracts.docsAndGuards.test.ts
+++ b/server/src/test/unit/docs/multiActiveContracts.docsAndGuards.test.ts
@@ -74,6 +74,20 @@ describe('multi-active contracts docs and static guards', () => {
     expect(assignmentWritesSource).not.toContain('hasActiveContractForClient');
   });
 
+  // Thrown server-action errors are masked by Next.js in production; the
+  // mixed-currency guard message reaches the user only if every action
+  // boundary converts it to a returned actionError.
+  it('T062b: every action boundary translates the mixed-currency guard into a returned actionError', () => {
+    const guardMessage = 'Mixed-currency contracts for the same client are not supported';
+    for (const source of [
+      read('packages', 'billing', 'src', 'actions', 'billingClientsActions.ts'),
+      read('packages', 'billing', 'src', 'actions', 'contractWizardActionErrors.ts'),
+      read('packages', 'clients', 'src', 'actions', 'clientContractActions.ts'),
+    ]) {
+      expect(source).toContain(guardMessage);
+    }
+  });
+
   it('T071: migration/runbook notes explicitly record invoice assignment snapshots as the preserved boundary', () => {
     const scratchpad = read('ee', 'docs', 'plans', '2026-03-20-multi-active-contracts-per-client', 'SCRATCHPAD.md');
     expect(scratchpad).toContain('Invoice tables already snapshot `client_contract_id`');

--- a/server/src/test/unit/i18n/ticketsPseudoLocale.integration.test.tsx
+++ b/server/src/test/unit/i18n/ticketsPseudoLocale.integration.test.tsx
@@ -55,6 +55,7 @@ vi.mock('@alga-psa/ui/lib/i18n/client', async () => {
 
   return {
     detectClientLocale: () => 'xx',
+    useOptionalI18n: () => null,
     I18nProvider: ({
       children,
       initialLocale = 'xx',

--- a/server/src/test/unit/layout/MspLayoutClient.productShell.test.tsx
+++ b/server/src/test/unit/layout/MspLayoutClient.productShell.test.tsx
@@ -39,6 +39,7 @@ vi.mock('@alga-psa/tenancy/actions/tenant-settings-actions/tenantSettingsActions
 
 vi.mock('@alga-psa/ui/lib/i18n/client', () => ({
   detectClientLocale: () => 'en',
+  useOptionalI18n: () => null,
   useTranslation: () => ({
     t: (key: string) => ({
       'onboardingRedirect.title': 'Taking you to setup',

--- a/server/src/test/unit/layout/QuickCreateDialog.ticket.i18n.integration.test.tsx
+++ b/server/src/test/unit/layout/QuickCreateDialog.ticket.i18n.integration.test.tsx
@@ -63,6 +63,7 @@ vi.mock('@alga-psa/ui/lib/i18n/client', async () => {
 
   return {
     detectClientLocale: () => 'de',
+    useOptionalI18n: () => null,
     I18nProvider: ({
       children,
       initialLocale = 'de',

--- a/server/src/test/unit/product/hardcodedCurrency.contract.test.ts
+++ b/server/src/test/unit/product/hardcodedCurrency.contract.test.ts
@@ -1,0 +1,375 @@
+import { describe, expect, it } from 'vitest';
+import fs from 'node:fs';
+import path from 'node:path';
+import ts from 'typescript';
+import { CURRENCY_OPTIONS } from '@alga-psa/core';
+
+// Hardcoded-currency guard: user-visible money must go through the currency
+// formatters (useCurrencyFormat / formatCurrency / CurrencyInput), which respect
+// the tenant's configured currency — never a literal "$". A grep can't do this
+// job: `.replace(/…/, '$1')` regex groups and template-literal interpolation
+// (`<td>${amount}</td>`) both look like dollar signs textually. So this suite
+// parses candidate files with the TypeScript AST, where those are structurally
+// distinct: it flags literal "$" only in JSX text, string literals, and the
+// *static* chunks of template literals.
+//
+// Detected shapes:
+//   `$${amount.toFixed(2)}`        — template chunk ending in "$" before an interpolation
+//   <span>${amount}</span>         — JSX text "$" immediately before a JSX expression
+//   <span>$5 off</span>            — JSX text containing $<digit>
+//   '$0.00', "Starting at $299/mo" — string literal containing $<digit>
+//   <span>$</span>                 — bare-symbol input adornment
+//   {currencySymbol ?? '$'}        — bare-symbol fallback in a JSX expression
+// (bare-symbol rules use useCurrencyFormat().symbol() as the fix; plain-object
+//  currency maps like { USD: '$' } are property assignments and stay exempt)
+//
+// Every entry in the known list is either a deliberate USD surface (documented
+// why) or a REPORTED GAP to burn down. Counts are exact: fixing a site without
+// lowering the count fails the honesty test, adding one fails the growth test.
+const KNOWN_HARDCODED_CURRENCY: Record<string, { count: number; why: string }> = {
+  'ee/server/src/components/settings/account/AccountManagement.tsx': {
+    count: 16,
+    why: 'deliberate: Nine Minds subscription billing is USD (Stripe)',
+  },
+  'ee/server/src/components/workflow-designer/ActionSchemaReference.tsx': {
+    count: 1,
+    why: 'deliberate: renders expression-language ${path} syntax, not currency',
+  },
+  'ee/server/src/components/workflow-designer/expression-editor/functionDefinitions.ts': {
+    count: 1,
+    why: 'deliberate: builds $functionName tokens for the expression language, not currency',
+  },
+  'ee/server/src/components/workflow-designer/expression-editor/insertionText.ts': {
+    count: 1,
+    why: 'deliberate: "$0" is the snippet cursor placeholder, not currency',
+  },
+  'ee/server/src/services/chatWorkflowRegexTransformGuidance.ts': {
+    count: 1,
+    why: 'deliberate: documents regex replacement tokens ($1, $$), not currency',
+  },
+  'packages/client-portal/src/components/account/ServicesSection.tsx': {
+    count: 3,
+    why: 'REPORTED GAP: sample catalog tiles hardcode USD prices (locale twins in client-portal.json) — product call pending',
+  },
+  'packages/email/src/sendCancellationFeedbackEmail.ts': {
+    count: 2,
+    why: 'deliberate: Nine Minds subscription pricing is USD (Stripe)',
+  },
+  'packages/notifications/src/lib/templateVariables/seed.ts': {
+    count: 8,
+    why: 'deliberate: sample preview values documenting template-variable output',
+  },
+  'packages/validation/src/lib/clientFormValidation.ts': {
+    count: 1,
+    why: 'deliberate: "$1,000,000" is an illustrative example in a validation hint',
+  },
+  'server/src/app/static/master_terms/page.tsx': {
+    count: 1,
+    why: 'deliberate: legal terms — contractual amounts are USD',
+  },
+};
+
+const KNOWN_LOCALE_HARDCODED: Record<string, string> = {
+  'client-portal.json::account.services.catalog.cloudBackup.price':
+    'REPORTED GAP: sample catalog tile hardcodes USD pricing',
+  'client-portal.json::account.services.catalog.cybersecurity.price':
+    'REPORTED GAP: sample catalog tile hardcodes USD pricing',
+  'client-portal.json::account.services.catalog.managedIt.price':
+    'REPORTED GAP: sample catalog tile hardcodes USD pricing',
+};
+
+const SOURCE_ROOTS = ['src', '../ee/server/src', '../packages'];
+
+const SKIP_DIRS = new Set([
+  'node_modules',
+  '.next',
+  '.turbo',
+  'dist',
+  'build',
+  'coverage',
+  '__tests__',
+  '__mocks__',
+  'test',
+  'tests',
+  'migrations',
+  'seeds',
+]);
+
+// Config files carry regex-replacement "$1" aliases and can't render user text.
+const SKIP_FILES = [/\.(test|spec)\.(t|j)sx?$/, /\.stories\.(t|j)sx?$/, /\.d\.ts$/, /\.config\.(t|j)s$/];
+
+const SOURCE_FILE = /\.(t|j)sx?$/;
+
+// The guarded symbol set is derived from the product's own currency list, so
+// adding a currency to CURRENCY_OPTIONS automatically extends this guard
+// (including multi-character symbols like "C$" and "Fr.").
+const escapeRegex = (s: string) => s.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+const SYMBOL_ALT = [...new Set(CURRENCY_OPTIONS.map((option) => option.symbol))]
+  .sort((a, b) => b.length - a.length)
+  .map(escapeRegex)
+  .join('|');
+
+// A literal currency amount: a symbol followed by a digit (one optional
+// space). Bare symbols ('¥' in a currency map) are fine; symbol+digit is a
+// hardcoded price. $ is the only symbol with regex/template homonyms; the
+// others are unambiguous everywhere.
+const AMOUNT = new RegExp(`(?:${SYMBOL_ALT}) ?\\d`);
+// Cheap prefilter so only files that could possibly violate get AST-parsed.
+// symbol+digit catches strings/JSX amounts; "$" before "{" catches both the
+// `$${x}` template shape and the JSX `<span>${x}</span>` shape.
+const CANDIDATE = new RegExp(`(?:${SYMBOL_ALT}) ?\\d|\\$\\$?\\{|(?:${SYMBOL_ALT})\\s*<|['"](?:${SYMBOL_ALT})['"]`);
+// Exactly one bare currency symbol (an input adornment or symbol fallback).
+const BARE_SYMBOL = new RegExp(`^(?:${SYMBOL_ALT})$`);
+// A template chunk or JSX text ending in a symbol, flowing into an interpolation.
+const SYMBOL_END = new RegExp(`(?:${SYMBOL_ALT})$`);
+const SYMBOL_END_LOOSE = new RegExp(`(?:${SYMBOL_ALT})\\s*$`);
+
+const REPO_ROOT = path.resolve(process.cwd(), '..');
+
+// LEVERAGE: pattern source-tree-walker — same recursive walker as routeEntryPointCoverage
+function collectSourceFiles(absDir: string, out: string[]): void {
+  let entries: fs.Dirent[];
+  try {
+    entries = fs.readdirSync(absDir, { withFileTypes: true });
+  } catch {
+    return;
+  }
+  for (const entry of entries) {
+    const abs = path.join(absDir, entry.name);
+    if (entry.isDirectory()) {
+      if (SKIP_DIRS.has(entry.name)) continue;
+      collectSourceFiles(abs, out);
+    } else if (SOURCE_FILE.test(entry.name) && !SKIP_FILES.some((skip) => skip.test(entry.name))) {
+      out.push(abs);
+    }
+  }
+}
+
+interface Violation {
+  file: string;
+  line: number;
+  snippet: string;
+}
+
+// `.replace(/…/, '$1')` replacement strings are regex group references.
+function isReplaceArg(node: ts.Node): boolean {
+  const parent = node.parent;
+  return (
+    !!parent &&
+    ts.isCallExpression(parent) &&
+    parent.arguments.includes(node as ts.Expression) &&
+    ts.isPropertyAccessExpression(parent.expression) &&
+    /^replace(All)?$/.test(parent.expression.name.text)
+  );
+}
+
+// A bare-symbol string only counts when it flows into rendered JSX
+// ({x ?? '$'} or prefix="$"); walking stops at anything else, so currency
+// maps, call arguments, and plain assignments stay exempt.
+function isJsxValueContext(node: ts.Node): boolean {
+  for (let p = node.parent; p; p = p.parent) {
+    if (ts.isJsxExpression(p) || ts.isJsxAttribute(p)) return true;
+    if (ts.isBinaryExpression(p) || ts.isConditionalExpression(p) || ts.isParenthesizedExpression(p)) continue;
+    return false;
+  }
+  return false;
+}
+
+// `new RegExp(`\\$${n}`)` builds a pattern, not a price tag.
+function isRegExpArg(node: ts.Node): boolean {
+  const parent = node.parent;
+  return (
+    !!parent &&
+    (ts.isNewExpression(parent) || ts.isCallExpression(parent)) &&
+    !!parent.arguments?.includes(node as ts.Expression) &&
+    ts.isIdentifier(parent.expression) &&
+    parent.expression.text === 'RegExp'
+  );
+}
+
+function scanFile(absFile: string, out: Violation[]): void {
+  const text = fs.readFileSync(absFile, 'utf8');
+  if (!CANDIDATE.test(text)) return;
+
+  const scriptKind = /x$/.test(absFile) ? ts.ScriptKind.TSX : ts.ScriptKind.TS;
+  const sourceFile = ts.createSourceFile(absFile, text, ts.ScriptTarget.Latest, true, scriptKind);
+  const file = path.relative(REPO_ROOT, absFile);
+
+  const record = (node: ts.Node, snippet: string) => {
+    const { line } = sourceFile.getLineAndCharacterOfPosition(node.getStart(sourceFile));
+    out.push({ file, line: line + 1, snippet: snippet.replace(/\s+/g, ' ').trim().slice(0, 60) });
+  };
+
+  const visit = (node: ts.Node): void => {
+    if (ts.isStringLiteral(node) || ts.isNoSubstitutionTemplateLiteral(node)) {
+      if (AMOUNT.test(node.text) && !isReplaceArg(node) && !isRegExpArg(node)) {
+        record(node, node.text);
+      } else if (BARE_SYMBOL.test(node.text) && isJsxValueContext(node)) {
+        record(node, `bare '${node.text}' in JSX`);
+      }
+    } else if (ts.isTemplateExpression(node) && !isRegExpArg(node)) {
+      const chunks = [node.head, ...node.templateSpans.map((span) => span.literal)];
+      for (const chunk of chunks) {
+        if (AMOUNT.test(chunk.text)) {
+          record(chunk, chunk.text);
+        } else if (SYMBOL_END.test(chunk.text) && !ts.isTemplateTail(chunk)) {
+          // Static text ending in a symbol flows straight into an
+          // interpolation: the `$${amount}` shape.
+          record(chunk, `${chunk.text}\${…}`);
+        }
+      }
+    } else if (ts.isJsxText(node)) {
+      if (AMOUNT.test(node.text)) record(node, node.text);
+      else if (BARE_SYMBOL.test(node.text.trim())) record(node, `bare '${node.text.trim()}' adornment`);
+    } else if (ts.isJsxElement(node) || ts.isJsxFragment(node)) {
+      const children = node.children;
+      for (let i = 0; i < children.length - 1; i++) {
+        const child = children[i];
+        const next = children[i + 1];
+        if (
+          ts.isJsxText(child) &&
+          SYMBOL_END_LOOSE.test(child.text) &&
+          !AMOUNT.test(child.text) &&
+          !BARE_SYMBOL.test(child.text.trim()) &&
+          ts.isJsxExpression(next)
+        ) {
+          record(child, `${child.text.trimStart()}{…}`);
+        }
+      }
+    }
+    ts.forEachChild(node, visit);
+  };
+
+  visit(sourceFile);
+}
+
+function collectViolations(): Map<string, Violation[]> {
+  const files: string[] = [];
+  for (const root of SOURCE_ROOTS) {
+    collectSourceFiles(path.resolve(process.cwd(), root), files);
+  }
+  const violations: Violation[] = [];
+  for (const file of files) scanFile(file, violations);
+
+  const byFile = new Map<string, Violation[]>();
+  for (const violation of violations) {
+    const list = byFile.get(violation.file) ?? [];
+    list.push(violation);
+    byFile.set(violation.file, list);
+  }
+  return byFile;
+}
+
+function describeFile(file: string, list: Violation[]): string {
+  const lines = list.map((v) => `    L${v.line}: ${v.snippet}`).join('\n');
+  return `  '${file}': { count: ${list.length}, why: '…' },\n${lines}`;
+}
+
+describe('hardcoded currency (source)', () => {
+  const byFile = collectViolations();
+
+  it('no user-visible hardcoded "$" outside the known list', () => {
+    // The symbol set derives from the product currency list; if that import
+    // ever breaks, every regex here degrades silently.
+    expect(SYMBOL_ALT).toContain('Fr');
+    expect(SYMBOL_ALT).toContain('€');
+
+    const offenders = [...byFile.entries()]
+      .filter(([file, list]) => {
+        const known = KNOWN_HARDCODED_CURRENCY[file];
+        return !known || list.length > known.count;
+      })
+      .sort(([a], [b]) => a.localeCompare(b));
+
+    expect(
+      offenders.map(([file]) => file),
+      `hardcoded dollar signs in user-visible text — render money through the tenant-aware currency formatters (useCurrencyFormat / formatCurrency) instead. If a surface is deliberately USD, document it in KNOWN_HARDCODED_CURRENCY:\n${offenders
+        .map(([file, list]) => describeFile(file, list))
+        .join('\n')}`,
+    ).toEqual([]);
+  });
+
+  it('known entries stay honest: counts match what is on disk', () => {
+    for (const [file, { count }] of Object.entries(KNOWN_HARDCODED_CURRENCY)) {
+      const actual = byFile.get(file)?.length ?? 0;
+      expect(
+        actual,
+        actual === 0
+          ? `"${file}" no longer has hardcoded currency — remove its KNOWN_HARDCODED_CURRENCY entry`
+          : `"${file}" now has ${actual} hardcoded-currency sites (entry says ${count}) — update the count`,
+      ).toBe(count);
+    }
+  });
+});
+
+const LOCALES_ROOT = path.resolve(process.cwd(), 'public/locales');
+
+// Locale keys are namespace-relative (no locale segment), so one entry covers
+// en and every translation of the same string.
+function collectLocaleViolations(): Map<string, Set<string>> {
+  const hits = new Map<string, Set<string>>();
+  let locales: fs.Dirent[] = [];
+  try {
+    locales = fs.readdirSync(LOCALES_ROOT, { withFileTypes: true });
+  } catch {
+    return hits;
+  }
+
+  const walkJson = (value: unknown, jsonPath: string, nsPath: string, locale: string) => {
+    if (typeof value === 'string') {
+      if (AMOUNT.test(value)) {
+        const key = `${nsPath}::${jsonPath}`;
+        const set = hits.get(key) ?? new Set<string>();
+        set.add(locale);
+        hits.set(key, set);
+      }
+      return;
+    }
+    if (value && typeof value === 'object') {
+      for (const [k, v] of Object.entries(value)) {
+        walkJson(v, jsonPath ? `${jsonPath}.${k}` : k, nsPath, locale);
+      }
+    }
+  };
+
+  for (const locale of locales) {
+    if (!locale.isDirectory()) continue;
+    const localeDir = path.join(LOCALES_ROOT, locale.name);
+    const files: string[] = [];
+    const collectJson = (dir: string) => {
+      for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
+        const abs = path.join(dir, entry.name);
+        if (entry.isDirectory()) collectJson(abs);
+        else if (entry.name.endsWith('.json')) files.push(abs);
+      }
+    };
+    collectJson(localeDir);
+    for (const file of files) {
+      const nsPath = path.relative(localeDir, file);
+      walkJson(JSON.parse(fs.readFileSync(file, 'utf8')), '', nsPath, locale.name);
+    }
+  }
+  return hits;
+}
+
+describe('hardcoded currency (locale files)', () => {
+  const hits = collectLocaleViolations();
+
+  it('no translation string hardcodes "$" outside the known list', () => {
+    const offenders = [...hits.keys()].filter((key) => !(key in KNOWN_LOCALE_HARDCODED)).sort();
+
+    expect(
+      offenders,
+      `locale strings containing hardcoded dollar amounts — interpolate a formatted value ({{amount}}) instead, or document the key in KNOWN_LOCALE_HARDCODED: ${offenders.join(', ')}`,
+    ).toEqual([]);
+  });
+
+  it('known locale entries stay honest', () => {
+    for (const key of Object.keys(KNOWN_LOCALE_HARDCODED)) {
+      expect(
+        hits.has(key),
+        `"${key}" no longer hardcodes currency in any locale — remove it from KNOWN_LOCALE_HARDCODED`,
+      ).toBe(true);
+    }
+  });
+});

--- a/server/src/test/unit/product/routeEntryPointCoverage.contract.test.ts
+++ b/server/src/test/unit/product/routeEntryPointCoverage.contract.test.ts
@@ -63,6 +63,7 @@ const SOURCE_FILE = /\.(t|j)sx?$/;
 const INTERPOLATION = /\$\{[^}]*\}/g;
 const MSP_PATH = /\/msp\/[A-Za-z0-9_\-./]+/g;
 
+// LEVERAGE: pattern source-tree-walker — same recursive walker as hardcodedCurrency
 function collectSourceFiles(absDir: string, out: string[]): void {
   let entries: fs.Dirent[];
   try {

--- a/server/src/utils/email/emailService.tsx
+++ b/server/src/utils/email/emailService.tsx
@@ -3,6 +3,7 @@ import { getCurrentUser } from '@alga-psa/user-composition/actions';
 import { StorageService } from 'server/src/lib/storage/StorageService';
 import { InvoiceViewModel } from 'server/src/interfaces/invoice.interfaces';
 import { getSecretProviderInstance } from '@alga-psa/core/secrets';
+import { formatCurrencyFromMinorUnits } from '@alga-psa/core';
 
 interface EmailAttachment {
   filename: string;
@@ -176,7 +177,14 @@ export class EmailService {
     let result = template
       .replace(/{{client_name}}/g, invoice.client.name)
       .replace(/{{invoice_number}}/g, invoice.invoice_number)
-      .replace(/{{total_amount}}/g, `$${((invoice.total_amount - (invoice.credit_applied ?? 0)) / 100).toFixed(2)}`)
+      .replace(
+        /{{total_amount}}/g,
+        formatCurrencyFromMinorUnits(
+          invoice.total_amount - (invoice.credit_applied ?? 0),
+          'en-US',
+          invoice.currencyCode || 'USD',
+        ),
+      )
       .replace(/{{company_name}}/g, options?.companyName || 'Your Company');
 
     if (options?.paymentLink) {


### PR DESCRIPTION
Add hardcodedCurrency.contract.test.ts to detect and track literal "$" in user-visible surfaces via TypeScript AST parsing. Mount CurrencyFormatProvider in both portal layouts (msp, client-portal) with tenant default currency from getTenantDefaultCurrencyCode(). Extend useCurrencyFormat with symbol() method for bare-symbol input adornments. Add mixed-currency contract validation across action error handlers. All 24 gap sites now use formatters; 870 billing tests ✅

Down, down the rabbit-hole of dollar signs we fell, until the tenant's currency whispered back: "You're in AlgaPSA now; all your symbols belong to me." 💱✨🔍