### PR TITLE
docs(migrations): warn against truncate_local_data_after_distributing_table cascade

### DIFF
--- a/ee/server/migrations/20260529130000_distribute_workflow_v2_tables.cjs
+++ b/ee/server/migrations/20260529130000_distribute_workflow_v2_tables.cjs
@@ -278,6 +278,15 @@ exports.up = async function up(knex) {
   // 4. Distribute, then immediately truncate the leftover LOCAL coordinator data —
   //    it otherwise blocks the constraint re-adds below. Cast to ::regclass so the
   //    Citus functions resolve unambiguously.
+  //
+  //    ⚠️ UNSAFE PATTERN — do not copy into new migrations.
+  //    truncate_local_data_after_distributing_table() issues a TRUNCATE that
+  //    CASCADEs across the whole FK graph. Distributed tables in the cascade
+  //    only lose stranded coordinator-local rows, but any NON-distributed table
+  //    in the recursive FK closure loses ALL of its data (a local table's
+  //    coordinator heap is its only copy). Before ever calling this again, walk
+  //    the FK closure (pg_constraint) and abort unless every member is
+  //    distributed (pg_dist_partition). Retained as history, not as an example.
   if (toPrep.length) {
     console.log(`Colocating workflow v2 tables with ${COLOCATE_WITH}`);
   }

--- a/server/migrations/20251211120000_add_tenant_notification_settings.cjs
+++ b/server/migrations/20251211120000_add_tenant_notification_settings.cjs
@@ -81,6 +81,15 @@ exports.up = async function(knex) {
       for (const fk of crossFks) {
         await knex.raw(`ALTER TABLE ${fk.tbl} ADD CONSTRAINT "${fk.conname}" ${fk.def}`);
       }
+      // ⚠️ UNSAFE PATTERN — do not copy into new migrations.
+      // truncate_local_data_after_distributing_table() issues a TRUNCATE that
+      // CASCADEs across the whole FK graph. Distributed tables in the cascade
+      // only lose stranded coordinator-local rows, but any NON-distributed
+      // table in the recursive FK closure loses ALL of its data (a local
+      // table's coordinator heap is its only copy). Before ever calling this
+      // again, walk the FK closure (pg_constraint) and abort unless every
+      // member is distributed (pg_dist_partition). Retained as history, not
+      // as an example.
       for (const t of [...pendingReference, ...pendingDistributed]) {
         await knex.raw('SELECT truncate_local_data_after_distributing_table(?::regclass)', [t]);
       }

--- a/server/migrations/20260513100800_distribute_email_reply_tokens.cjs
+++ b/server/migrations/20260513100800_distribute_email_reply_tokens.cjs
@@ -6,8 +6,18 @@
 // table has an FK to comments. Several do (email_reply_tokens, vectors,
 // ticket_bundle_mirrors, ...). This migration distributes every such local
 // referrer co-located with comments, then runs the official cleanup.
-// Rule: distributing a possibly-non-empty table MUST be followed by
-// truncate_local_data_after_distributing_table().
+//
+// ⚠️ UNSAFE PATTERN — do not copy into new migrations, and do NOT treat the
+// following as a general rule: "distributing a possibly-non-empty table must be
+// followed by truncate_local_data_after_distributing_table()". That function
+// issues a TRUNCATE that CASCADEs across the whole FK graph. Distributed tables
+// in the cascade only lose stranded coordinator-local rows, but any
+// NON-distributed table in the recursive FK closure loses ALL of its data (a
+// local table's coordinator heap is its only copy). This migration only got
+// away with it because it first distributed every local referrer. Before ever
+// calling the function again, walk the FK closure (pg_constraint) and abort
+// unless every member is distributed (pg_dist_partition). Retained as history,
+// not as an example.
 
 exports.up = async function up(knex) {
   const citus = await knex.raw(
@@ -243,6 +253,8 @@ async function isDistributed(knex, table) {
   return Boolean(res.rows?.[0]?.is_distributed);
 }
 
+// ⚠️ See the header warning: the TRUNCATE below cascades over the FK graph and
+// destroys ALL data of any non-distributed table in the closure. Do not reuse.
 async function truncateLocalDataIfNeeded(knex, table) {
   if (!(await isDistributed(knex, table))) {
     return;

--- a/server/migrations/20260513101000_enforce_comment_thread_ids_not_null.cjs
+++ b/server/migrations/20260513101000_enforce_comment_thread_ids_not_null.cjs
@@ -75,6 +75,14 @@ async function truncateLocalDataIfNeeded(knex, table) {
     return;
   }
 
+  // ⚠️ UNSAFE PATTERN — do not copy into new migrations.
+  // truncate_local_data_after_distributing_table() issues a TRUNCATE that
+  // CASCADEs across the whole FK graph. Distributed tables in the cascade only
+  // lose stranded coordinator-local rows, but any NON-distributed table in the
+  // recursive FK closure loses ALL of its data (a local table's coordinator
+  // heap is its only copy). Before ever calling this again, walk the FK
+  // closure (pg_constraint) and abort unless every member is distributed
+  // (pg_dist_partition). Retained as history, not as an example.
   await knex.raw(`SELECT truncate_local_data_after_distributing_table(?::regclass)`, [table]);
 }
 

--- a/server/migrations/20260612120000_create_asset_type_registry.cjs
+++ b/server/migrations/20260612120000_create_asset_type_registry.cjs
@@ -79,9 +79,17 @@ exports.up = async function (knex) {
       await knex.raw("SELECT create_distributed_table('asset_type_registry', 'tenant', colocate_with => 'assets')");
     }
 
-    // Required follow-up whenever the table could already hold rows at
-    // distribution time (idempotent re-runs): clear stranded coordinator-heap
-    // rows. No-op when the parent heap is already empty.
+    // Clear stranded coordinator-heap rows left by create_distributed_table on
+    // idempotent re-runs. No-op when the parent heap is already empty.
+    //
+    // ⚠️ UNSAFE PATTERN — do not copy into new migrations.
+    // truncate_local_data_after_distributing_table() issues a TRUNCATE that
+    // CASCADEs across the whole FK graph. Distributed tables in the cascade
+    // only lose stranded coordinator-local rows, but any NON-distributed table
+    // in the recursive FK closure loses ALL of its data (a local table's
+    // coordinator heap is its only copy). Before ever calling this again, walk
+    // the FK closure (pg_constraint) and abort unless every member is
+    // distributed (pg_dist_partition). Retained as history, not as an example.
     const localSize = await knex.raw("SELECT pg_relation_size('asset_type_registry'::regclass) AS size");
     if (Number(localSize.rows?.[0]?.size ?? 0) > 0) {
       await knex.raw("SELECT truncate_local_data_after_distributing_table('asset_type_registry'::regclass)");

--- a/server/migrations/20260718234058_enforce_single_default_client_location.cjs
+++ b/server/migrations/20260718234058_enforce_single_default_client_location.cjs
@@ -4,8 +4,17 @@ exports.up = async function up(knex) {
   // coordinator's local heap. They are invisible to all Citus-planned queries
   // (including the dedupe UPDATEs below) but CREATE INDEX still scans them, so
   // stale duplicates fail the unique index build. Truncate the leftover local
-  // data first; this cascades to local heaps of FK-referencing tables and never
-  // touches distributed (shard) data.
+  // data first.
+  //
+  // ⚠️ UNSAFE PATTERN — do not copy into new migrations.
+  // truncate_local_data_after_distributing_table() issues a TRUNCATE that
+  // CASCADEs across the whole FK graph. It is NOT harmless: while distributed
+  // tables in the cascade only lose stranded coordinator-local rows (shard
+  // data is untouched), any NON-distributed table in the recursive FK closure
+  // loses ALL of its data — a local table's coordinator heap is its only copy.
+  // Before ever calling this again, walk the FK closure (pg_constraint) and
+  // abort unless every member is distributed (pg_dist_partition). Retained as
+  // history, not as an example.
   const citusInstalled = await knex.raw(
     "SELECT to_regclass('pg_catalog.pg_dist_partition') IS NOT NULL AS has_citus"
   );


### PR DESCRIPTION
Comment-only change annotating all six historical call sites of `truncate_local_data_after_distributing_table()` as an unsafe pattern that must not be copied into new migrations.

The function issues a TRUNCATE that CASCADEs across the entire FK graph. Distributed tables in the cascade only lose stranded coordinator-local rows, but any **non-distributed** table in the recursive FK closure loses **all** of its data — a local table's coordinator heap is its only copy.

Rule for future callers: compute the recursive FK closure of the target (`pg_constraint`) and abort unless every member is distributed (`pg_dist_partition`).

Notes:
- These migrations have already run everywhere they need to; behavior is unchanged.
- On-premise appliances do not use Citus/StackGres, so the guarded code path is inert there.
- Also corrects two comments that previously presented the cascade as harmless (one stated a "Rule" mandating the follow-up; one claimed it "never touches" anything that matters).
- `[skip ci]` — comment-only diff, no build needed.