### PR TITLE
fix(seeds): opportunity workflow seed falls back to first tenant

### DIFF
--- a/ee/server/seeds/onboarding/psa/10_opportunity_workflows.cjs
+++ b/ee/server/seeds/onboarding/psa/10_opportunity_workflows.cjs
@@ -173,7 +173,18 @@ async function seedWorkflow(knex, tenantId, workflow) {
 }
 
 exports.seed = async function seed(knex, tenantId) {
-  if (!tenantId) throw new Error('tenantId is required for opportunity workflow seeding');
+  // Use provided tenantId or fall back to first tenant. The onboarding Temporal
+  // workflow (runOnboardingSeeds) calls seed(trx, tenantId), but the standard
+  // knex seed runner invokes seed(knex) with no tenantId — mirror the sibling
+  // onboarding seeds (e.g. 09_asset_type_registry.cjs) rather than throwing.
+  if (!tenantId) {
+    const tenant = await knex('tenants').select('tenant').first();
+    if (!tenant) {
+      console.log('No tenant found, skipping opportunity workflow seed');
+      return;
+    }
+    tenantId = tenant.tenant;
+  }
   for (const workflow of WORKFLOWS) await seedWorkflow(knex, tenantId, workflow);
 };
 

--- a/ee/server/seeds/onboarding/psa/10_opportunity_workflows.cjs
+++ b/ee/server/seeds/onboarding/psa/10_opportunity_workflows.cjs
@@ -177,6 +177,10 @@ exports.seed = async function seed(knex, tenantId) {
   // workflow (runOnboardingSeeds) calls seed(trx, tenantId), but the standard
   // knex seed runner invokes seed(knex) with no tenantId — mirror the sibling
   // onboarding seeds (e.g. 09_asset_type_registry.cjs) rather than throwing.
+  // LEVERAGE: friction builtin-content-distribution — this fallback is an unwritten
+  // contract every onboarding seed must hand-copy (the appliance replays seeds via
+  // knex seed:run with no tenantId on every upgrade); omitting it broke appliance
+  // upgrades (#2989). The runner should inject tenant resolution once, centrally.
   if (!tenantId) {
     const tenant = await knex('tenants').select('tenant').first();
     if (!tenant) {

--- a/ee/temporal-workflows/src/db/onboarding-seeds-operations.ts
+++ b/ee/temporal-workflows/src/db/onboarding-seeds-operations.ts
@@ -20,6 +20,12 @@ export interface SeedRunLog {
 /**
  * Runs the onboarding seed files for a specific tenant
  */
+// LEVERAGE: friction builtin-content-distribution — this is the third invocation style
+// for the same seed files: here seed(trx, tenantId) per tenant; the appliance bootstrap
+// replays them ungated via knex seed:run with NO tenantId on every upgrade (relying on
+// each seed's first-tenant fallback); hosted gates seed:run off and uses readd_*
+// migrations for existing tenants. Every seed must silently satisfy all three contracts
+// and nothing enforces that (#2989). Wants one versioned per-tenant system-content sync.
 export async function runOnboardingSeeds(
   tenantId: string,
   productCode?: ProductCode | string | null,

--- a/helm/templates/appliance-bootstrap-configmap.yaml
+++ b/helm/templates/appliance-bootstrap-configmap.yaml
@@ -369,10 +369,11 @@ data:
       log "license_state seeded (edition_choice=${edition_choice})"
     }
 
-    # LEVERAGE: friction builtin-content-distribution — this seed:run is UNGATED and this
-    # Job is a post-install,post-upgrade hook, so the appliance replays ALL onboarding
-    # seeds via plain knex (seed(knex), no tenantId → first-tenant fallback) on every
-    # upgrade, and a second time on fresh install (ensure_initial_tenant already ran them
+    # LEVERAGE: friction builtin-content-distribution — this seed:run is UNGATED, and the
+    # appliance bootstrap Job is re-created on every helm upgrade (regular Job +
+    # ttlSecondsAfterFinished; the post-upgrade hook is SaaS-only), so the appliance
+    # replays ALL onboarding seeds via plain knex (seed(knex), no tenantId → first-tenant
+    # fallback) on every upgrade, and a second time on fresh install (ensure_initial_tenant already ran them
     # via Temporal runOnboardingSeeds with tenantId). Hosted gates this off (jobs.yaml)
     # and ships built-in content to existing tenants via readd_* migrations instead: two
     # divergent mechanisms + an unenforced seed contract that #2989 showed is easy to

--- a/helm/templates/appliance-bootstrap-configmap.yaml
+++ b/helm/templates/appliance-bootstrap-configmap.yaml
@@ -369,6 +369,15 @@ data:
       log "license_state seeded (edition_choice=${edition_choice})"
     }
 
+    # LEVERAGE: friction builtin-content-distribution — this seed:run is UNGATED and this
+    # Job is a post-install,post-upgrade hook, so the appliance replays ALL onboarding
+    # seeds via plain knex (seed(knex), no tenantId → first-tenant fallback) on every
+    # upgrade, and a second time on fresh install (ensure_initial_tenant already ran them
+    # via Temporal runOnboardingSeeds with tenantId). Hosted gates this off (jobs.yaml)
+    # and ships built-in content to existing tenants via readd_* migrations instead: two
+    # divergent mechanisms + an unenforced seed contract that #2989 showed is easy to
+    # break. Wants one versioned per-tenant system-content sync on both platforms; seeds
+    # only for initial tenant creation.
     if is_enabled "${SETUP_RUN_SEEDS:-true}"; then
       ensure_initial_tenant
       resolve_seeds_dir

--- a/helm/templates/jobs.yaml
+++ b/helm/templates/jobs.yaml
@@ -192,6 +192,11 @@ spec:
                 log "SETUP_RUN_MIGRATIONS is disabled; skipping migrations"
               fi
 
+              # LEVERAGE: friction builtin-content-distribution — hosted gates seeds off after
+              # first run, so new built-in content only reaches existing tenants via
+              # hand-written readd_* migrations; the appliance variant
+              # (appliance-bootstrap-configmap.yaml) instead replays seeds ungated on every
+              # upgrade. Same divergence, see the marker there.
               if is_enabled "${SETUP_RUN_SEEDS:-true}"; then
                 if check_seeds_status; then
                   log "Seeds already exist; skipping"


### PR DESCRIPTION
## Problem
`ee/server/seeds/onboarding/psa/10_opportunity_workflows.cjs` throws `tenantId is required for opportunity workflow seeding` when run via the standard knex seed runner (which calls `seed(knex)` with no `tenantId`). This breaks `seed:run`-based onboarding / base-image / CI seeding.

Observed failure:
```
Error while executing ".../10_opportunity_workflows.cjs" seed: tenantId is required for opportunity workflow seeding
    at Object.seed (.../10_opportunity_workflows.cjs:176:24)
    at Seeder._waterfallBatch (knex/lib/migrations/seed/Seeder.js:115:20)
```

## Root cause
Every sibling onboarding seed (e.g. `09_asset_type_registry.cjs`, `08_document_folder_templates.cjs`) falls back to the first tenant when no `tenantId` is passed. This seed hard-throws instead. The Temporal onboarding path (`runOnboardingSeeds`) passes `tenantId` explicitly and is unaffected.

## Fix
Mirror the sibling convention: fall back to the first tenant (and no-op if there are no tenants) instead of throwing.

Bug predates the current appliance stable release; present since the sales opportunity module (#2926, 2026-07-13). Appliance tenant onboarding uses the Temporal path, so fresh appliance installs are not affected — this fixes the plain seed-runner path.