### PR TITLE
Improve premise microsoft polling

### DIFF
--- a/docs/inbound-email/setup/microsoft.md
+++ b/docs/inbound-email/setup/microsoft.md
@@ -26,7 +26,10 @@ This guide walks an administrator through connecting a Microsoft 365 / Exchange 
   * Delegated Microsoft Graph permissions: `Mail.Read`, `Mail.Read.Shared`, `offline_access` (the OAuth flow requests read-only mail access).
 * The mailbox to connect (a licensed user mailbox or a shared mailbox the authorizing user can read).
 * An Alga PSA user with permission to manage system settings (**Settings → Integrations → Providers** requires `system_settings:update`).
-* The server must be reachable from the public internet at its configured base URL — Microsoft Graph delivers notifications to `https://<your-host>/api/email/webhooks/microsoft`.
+* The appliance needs outbound HTTPS access to `graph.microsoft.com` and
+  `login.microsoftonline.com`. A public inbound URL is optional: when Microsoft
+  cannot validate the notification endpoint, Alga PSA automatically uses
+  outbound-only polling.
 
 ## End-to-End Flow
 
@@ -37,8 +40,11 @@ flowchart TD
     C --> D[Click 'Authorize Access' -> OAuth popup]
     D --> E[User signs in and consents]
     E --> F[/api/auth/microsoft/callback stores tokens/]
-    F --> G[Graph webhook subscription registered automatically]
-    G --> H[Provider connected - new mail becomes tickets]
+    F --> G{Graph webhook endpoint reachable?}
+    G -->|Yes| H[Real-time webhook delivery]
+    G -->|No| I[Outbound-only polling every 3 minutes]
+    H --> J[Provider connected - new mail becomes tickets]
+    I --> J
 ```
 
 ## Step-by-Step
@@ -69,13 +75,16 @@ Provider credentials are entered only here — the email provider form itself no
    * **Folder Filters** — comma-separated folders to watch (defaults to `Inbox`).
    * **Max Emails Per Sync** — 1–1000, defaults to 50.
    * **Redirect URI** — pre-filled; must exactly match the URI registered in Entra.
-4. Click **Authorize Access** and complete the Microsoft consent in the popup. The window closes automatically; the Graph webhook subscription is registered as part of the callback, and the provider shows as connected.
+4. Click **Authorize Access** and complete the Microsoft consent in the popup.
+   The window closes automatically. Alga PSA attempts to register a Graph
+   webhook and falls back to polling when Microsoft cannot reach the configured
+   notification URL; either delivery mode appears as connected.
 
 ## How It Works at Runtime
 
-* The OAuth callback stores the access/refresh tokens and immediately creates a Microsoft Graph **change-notification subscription** (`changeType: created`) on the watched folder(s), pointing at `https://<your-host>/api/email/webhooks/microsoft`.
+* The OAuth callback stores the access/refresh tokens and attempts to create a Microsoft Graph **change-notification subscription** (`changeType: created`) on the watched folder(s), pointing at `https://<your-host>/api/email/webhooks/microsoft`.
 * Graph subscriptions are short-lived (created for roughly 60 hours). A background maintenance job sweeps every 15 minutes with a 24-hour look-ahead, renews subscriptions before expiry, and recreates them if Graph reports them gone.
-* Delivery is webhook-driven — there is no timed polling for Microsoft providers. Each notification enqueues the message pointer; a worker fetches the full message from Graph and runs the standard email-to-ticket workflow.
+* With a reachable endpoint, delivery is webhook-driven and reconciliation remains a 15-minute safety net. If endpoint validation fails, or reconciliation repeatedly finds messages that webhooks missed, the provider switches to outbound-only polling every 3 minutes. Polling providers retry webhook registration daily and whenever **Test Connection** is used.
 * The connector operates read-only against the mailbox: it does not mark messages, move them, or send replies.
 
 If no tenant profile is bound to the Email consumer, hosted deployments fall back to the platform-level Microsoft app credentials (`MICROSOFT_CLIENT_ID` / `MICROSOFT_CLIENT_SECRET` / `MICROSOFT_TENANT_ID`). Self-hosted installs should always configure their own profile.
@@ -98,5 +107,10 @@ To enable outbound on an appliance install:
 * **"Authorize Access" is disabled / alert about provider settings** — no Microsoft profile is bound to the Email consumer. Use the **Open Providers Settings** link (or **Settings → Integrations → Providers**) and create/bind a profile first.
 * **OAuth popup fails** — confirm the redirect URI in the form exactly matches the one registered in the Entra app, and that the app allows multi-tenant sign-in (`/common` authority).
 * **Provider says Ready/connected but customers get no email** — expected: this provider is inbound-only. Configure outbound SMTP (or Resend) as described above.
-* **No new tickets from incoming mail** — check the provider's subscription health (`email_provider_health` / the renewal status in the provider list) and use the retry-renewal action; Graph subscriptions expire if renewal cannot reach Microsoft. Also confirm the server's base URL is publicly reachable, since notifications are pushed to `/api/email/webhooks/microsoft`.
+* **No new tickets from incoming mail** — check the provider's delivery mode and
+  last-ingested time. Webhook mode requires Microsoft to reach
+  `/api/email/webhooks/microsoft`; polling mode requires only outbound HTTPS to
+  `graph.microsoft.com` and `login.microsoftonline.com`. **Test Connection**
+  checks Graph access and immediately retries webhook registration without
+  changing the last-ingested cursor.
 * **Wrong folder being watched** — adjust **Folder Filters** on the provider and re-save; each watched folder needs its own subscription.

--- a/docs/plans/2026-07-20-webhook-optional-inbound-email-plan.md
+++ b/docs/plans/2026-07-20-webhook-optional-inbound-email-plan.md
@@ -1,0 +1,314 @@
+# Implementation Plan: Webhook-Optional Inbound Email (Firewalled Appliance Support)
+
+**Status:** Approved design, ready for implementation
+**Branch:** `improve/premise-microsoft-polling`
+**Origin:** Design discussion 2026-07-20 (Robert + Claude), refined in design session on this branch
+**Depends on:** PR #2981 (`fix/premise-microsoft-email-token-renewal`) — merged to main, must be deployed before/with this work
+
+## Problem
+
+Some appliance customers run behind firewalls with no inbound HTTPS. Microsoft
+Graph change notifications (webhooks) cannot reach them, so the current
+inbound-email design — which treats the Graph subscription as the primary
+transport — either fails at setup (subscription validation cannot complete) or,
+worse, silently degrades later: the subscription exists and renews (Graph
+renewal is an outbound PATCH that is **not** re-validated), but deliveries are
+suspended by Microsoft and nothing notices. The 2026-07-20 lab session
+demonstrated the silent-degradation class directly: a healthy-looking, renewing
+subscription with zero mail flowing and no system signal.
+
+Key architectural fact: post-PR #2981, missed-message reconciliation already
+constitutes a complete, webhook-free ingestion path (outbound-only HTTPS to
+`graph.microsoft.com`). Webhooks are a latency optimization, not the transport.
+This plan makes that stance explicit and operational.
+
+Note: setup on a firewalled box already "succeeds" today — the OAuth callback
+swallows subscription-registration failures with a `console.warn`
+(`server/src/app/api/auth/microsoft/callback/route.ts:382` region). What is
+missing is recording that outcome and acting on it; the maintenance loop then
+re-attempts `recreateSubscription` every 15 minutes forever (the
+`!webhook_subscription_id` branch, `EmailWebhookMaintenanceService.ts:188-201`).
+
+## Scope
+
+- **EE / Temporal only.** The tight polling loop is a Temporal schedule. The
+  appliance runs the EE image with `temporal` + `temporal-worker` deployed via
+  Flux (`ee/appliance/flux/base/releases/temporal-worker.yaml`), so premise is
+  covered. The CE pg-boss path (`email-webhook-maintenance` daily at 4 AM,
+  `server/src/lib/jobs/index.ts:744`, `initializeScheduledJobs.ts`) is
+  **unchanged**. New columns exist for all editions (migrations are shared) but
+  CE behavior does not change. *(Decided 2026-07-20: option (a), leave CE
+  unchanged.)*
+- Microsoft provider only. Google/Gmail (Pub/Sub watch) gets the same concept
+  in a follow-up plan if needed.
+- No global shortening of the 15-minute maintenance cadence.
+- No primary UI knob for delivery mode or polling frequency. A single advanced
+  "Webhooks: Auto / Off" override is deferred until a compliance customer asks.
+- No new ingestion pipeline — reuse reconciliation (`last_sync_at` delta
+  import) as the polling mechanism.
+
+## Design
+
+### Delivery modes (per provider, system-managed)
+
+- `webhook` — subscription active, deliveries observed; reconciliation runs at
+  the existing 15m safety-net cadence.
+- `polling` — no subscription (or subscription culled); reconciliation runs on
+  a tight per-provider cadence (default **3 minutes**, config-backed constant,
+  not UI-exposed). All Graph traffic is outbound.
+
+### Mode transitions (auto-detection)
+
+1. **At provider setup / Test Connection / config change:** attempt
+   subscription creation. Graph validates the notification URL synchronously —
+   unreachable endpoints fail immediately and unambiguously. Validation
+   failure → `polling` mode, setup completes without user-facing error.
+   Success → `webhook` mode.
+2. **Webhook-silence detector:** if reconciliation imports messages the
+   webhook never delivered for **N consecutive runs** (default N=3), webhooks
+   are de facto dead → delete the Graph subscription, enter `polling` mode,
+   record reason in provider health. A quiet mailbox never increments the
+   counter (detector requires imported messages).
+3. **Recovery probe:** in `polling` mode, re-attempt subscription creation
+   **daily** (`next_subscription_probe_at`) and on explicit Test Connection.
+   Success → back to `webhook` mode, counters reset. Failure → stay in
+   `polling`, single info-level log line, provider status stays healthy-green
+   (polling is a fully supported configuration, not an error).
+
+**Guard rail:** only endpoint-validation failures and the silence detector may
+enter polling mode. Auth/permission errors (401/403, `ErrorAccessDenied`) keep
+the existing error surfacing — masking revoked credentials behind "polling
+mode is fine" would hide real breakage.
+
+### Cadence rules
+
+- Global Temporal schedule stays at **15m**
+  (`email-webhook-maintenance-schedule`, `ee/temporal-workflows/src/schedules/setupSchedules.ts:262`).
+- Each 15m tick keeps doing renewal, token refresh, and safety-net
+  reconciliation for `webhook`-mode providers exactly as today. For
+  `polling`-mode providers it does token refresh and probe-due evaluation
+  only — no subscription renewal/recreate attempts, and no reconciliation
+  (the 3m loop owns it; avoids double-running).
+- New Temporal schedule `email-polling-reconcile-schedule` (every 3m, SKIP
+  overlap) reconciles `polling`-mode providers only; no-ops when none exist.
+- Cost basis: one delta query per polling provider per tick
+  (`receivedDateTime > last_sync_at - safety_margin`), far below Graph
+  per-mailbox throttling limits.
+
+### Health / status surfacing (read-only)
+
+- Provider card shows `Real-time delivery: active` (webhook mode) or
+  `Polling every 3 minutes` (polling mode), plus `Last ingested: <timestamp>`.
+- `polling` mode renders as normal/healthy, never warning styling.
+- Silence-detector culling and every mode transition (both directions, with
+  reason) recorded as a provider health/timeline note and an info-level log
+  with provider id + tenant.
+
+## Data Model
+
+New columns on `microsoft_email_provider_config` (recommended placement — all
+mechanics are Microsoft-specific and `webhook_subscription_id` already lives
+there; revisit promotion to `email_providers` if/when the Google plan lands):
+
+- `delivery_mode` text NOT NULL: `webhook` | `polling`. Migration backfills
+  existing rows: `webhook` when `webhook_subscription_id` is set, else
+  `polling`.
+- `last_webhook_delivery_at` timestamptz — stamped by the webhook handler on
+  every accepted (clientState-valid) notification.
+- `webhook_silent_runs` int NOT NULL DEFAULT 0 — consecutive reconciliation
+  runs that imported mail with no interceding webhook delivery; reset on any
+  webhook delivery.
+- `next_subscription_probe_at` timestamptz — recovery-probe scheduling.
+
+Migration follows existing tenant-scoped (Citus) migration patterns in
+`server/migrations/`.
+
+Note: `Last ingested` uses the existing `email_providers.last_sync_at`.
+
+## Implementation Steps
+
+1. **Migration** — add the four columns with backfill defaults as above.
+2. **Typed subscription outcome** — `MicrosoftGraphAdapter`
+   (`shared/services/email/providers/MicrosoftGraphAdapter.ts`,
+   `registerWebhookSubscription` ~line 430): surface a typed outcome
+   distinguishing (a) endpoint-validation failure (`ValidationError` /
+   validation timeout on `POST /subscriptions`), (b) auth/permission errors
+   (401/403 token errors, 403 `ErrorAccessDenied` on resource), (c) other.
+   Only (a) may flip mode.
+3. **Setup flow** — OAuth callback
+   (`server/src/app/api/auth/microsoft/callback/route.ts:382` region): on
+   validation-failure outcome set `delivery_mode='polling'` and complete
+   setup successfully; on success set `delivery_mode='webhook'`; on auth
+   error keep existing error surfacing. Also invoke the same logic on
+   provider mailbox/config changes, and cull any now-orphaned subscription
+   when config changes (lab example: orphan `9f181f67` left by a reconfigure).
+4. **Webhook handler stamping** —
+   `packages/integrations/src/webhooks/email/handlers/microsoftWebhookHandler.ts`
+   (clientState validation ~line 170): stamp `last_webhook_delivery_at` and
+   reset `webhook_silent_runs` on every accepted notification. (Graph never
+   echoes clientState on `GET /subscriptions` — the lab's `clientState: null`
+   observation is expected read behavior; notification payloads do carry it.)
+5. **Maintenance service mode logic** —
+   `shared/services/email/EmailWebhookMaintenanceService.ts`:
+   - Gate BOTH the renewal path and the `!webhook_subscription_id`
+     recreate branch (lines 188–201) on `delivery_mode='webhook'`.
+   - Reconciliation run recording: each run stamps messages-imported count
+     and whether a webhook delivery occurred in the window, feeding
+     `webhook_silent_runs` idempotently.
+   - Silence detector: `webhook_silent_runs >= 3` → delete Graph
+     subscription, clear `webhook_subscription_id`, set
+     `delivery_mode='polling'`, write health note.
+   - Recovery probe: when `now >= next_subscription_probe_at`, re-attempt
+     subscription creation; success → `webhook` mode + reset counters;
+     failure → advance probe ~24h, single info log, health stays green.
+   - New entry point for the polling loop: reconcile `polling`-mode
+     providers only (reuses `reconcileMissedMessages`).
+6. **Temporal schedule** —
+   `ee/temporal-workflows/src/schedules/setupSchedules.ts`: add
+   `email-polling-reconcile-schedule` (interval from env,
+   default 3m; SKIP overlap; sensible execution timeout) + workflow/activity
+   plumbing mirroring `emailWebhookMaintenanceWorkflow`.
+7. **Test Connection** — trigger an immediate recovery probe for
+   polling-mode providers in addition to the existing Graph health check;
+   must not change `last_sync_at`.
+8. **UI (read-only)** — `ee/server/src/components/MicrosoftProviderForm.tsx`
+   / provider status card: show delivery status line + last-ingested
+   timestamp; polling mode styled as normal/healthy.
+9. **Docs** — appliance setup docs note the egress-only requirement:
+   outbound HTTPS to `graph.microsoft.com` and `login.microsoftonline.com`
+   suffices for polling mode (no tunnel, no public DNS, no cert).
+
+### Reconciliation constants (context, on main)
+
+`RECONCILE_WINDOW_CAP_MS=7d`, `RECONCILE_SAFETY_MARGIN_MS=15m`,
+`DEFAULT_RECONCILE_MAX_MESSAGES=50`, `TOKEN_REFRESH_LOOK_AHEAD_MINUTES=30`
+(`EmailWebhookMaintenanceService.ts:26-29`). 50 msgs/run at 3m ticks ≈
+1000/hr ceiling — likely fine; sanity-check against busiest customer
+mailboxes during implementation.
+
+## Feature Checklist
+
+- F001 `delivery_mode` column + backfill migration
+- F002 `last_webhook_delivery_at` stamped by webhook handler on accepted notifications
+- F003 `webhook_silent_runs` counter (increment on missed-import runs, reset on webhook delivery)
+- F004 `next_subscription_probe_at` column
+- F005 typed `createSubscription` outcome (validation vs auth vs other)
+- F006 setup: validation failure → polling mode, setup succeeds
+- F007 setup: success → webhook mode
+- F008 auth/permission errors surface as provider error, never flip mode
+- F009 `email-polling-reconcile-schedule` Temporal schedule (3m, config-backed)
+- F010 polling reconcile = delta import via `last_sync_at` (PR #2981 path)
+- F011 15m tick: no tight reconcile for webhook-mode; no double-run of polling-mode providers
+- F012 silence detector culls subscription at 3 silent runs, flips to polling
+- F013 culling writes provider health/timeline note
+- F014 daily recovery probe flips back to webhook on success
+- F015 probe failure silent-by-design (info log, +24h, health green)
+- F016 Test Connection triggers immediate probe for polling-mode providers
+- F017 renewal AND recreate paths skip polling-mode providers
+- F018 UI: read-only delivery status + last-ingested
+- F019 polling mode renders as normal/healthy
+- F020 appliance docs: egress-only requirement
+- F021 mode transitions logged (info, provider id + tenant, reason)
+- F022 reconciliation run recording feeds silence counter idempotently
+
+## Test Plan
+
+- T001 DB integration: migration adds all four columns with correct backfill
+  (webhook when subscription id present, else polling).
+- T002 unit (Graph emulator): `createSubscription` returns
+  validation-failure outcome on validation POST timeout/refusal; auth-error
+  outcome on 401/403.
+- T003 integration: setup with unreachable notification URL completes with
+  `delivery_mode='polling'`, no error status.
+- T004 integration: setup with reachable URL sets `delivery_mode='webhook'`
+  (existing behavior preserved).
+- T005 integration (guard): 401/403 during subscription creation sets
+  provider error status and does NOT enter polling mode.
+- T006 integration: polling-mode provider with 2 new messages since
+  `last_sync_at` imports both via 3m tick, enqueues inbound processing,
+  advances `last_sync_at`.
+- T007 unit: 15m tick runs no tight reconcile for webhook-mode providers;
+  polling-mode provider not double-processed on schedule overlap.
+- T008 integration: silence detector — 3 consecutive missed-import runs flip
+  mode to polling, delete subscription, clear `webhook_subscription_id`,
+  write health note.
+- T009 unit (guard): quiet mailbox never increments `webhook_silent_runs`; a
+  single webhook delivery resets it to 0.
+- T010 integration: recovery probe — reachable endpoint flips to webhook +
+  resets counters; unreachable stays polling, advances probe ~24h, health
+  stays green.
+- T011 integration: Test Connection on polling-mode provider triggers
+  immediate probe without changing `last_sync_at`.
+- T012 unit: renewal loop issues no Graph renewal/recreate calls for
+  polling-mode providers.
+- T013 UI: provider card renders polling status + last-ingested with normal
+  styling; webhook mode shows real-time active.
+- T014 E2E smoke (appliance profile, Graph emulator): firewalled setup →
+  polling mode → message becomes ticket within 2 polling cycles → endpoint
+  becomes reachable → probe restores webhook mode → webhook-delivered
+  message creates ticket.
+
+## Acceptance Criteria
+
+- Appliance with **zero inbound connectivity**: provider setup completes
+  without error, provider shows polling mode, an email to the watched
+  mailbox becomes a ticket in ≤ 2× polling cadence (≤ 6 min at default).
+- Appliance with working webhooks: behavior unchanged; email → ticket ≤ 30s;
+  reconciliation stays at 15m.
+- Kill inbound path on a webhook-mode provider, send 3+ emails across 3
+  reconciliation windows: subscription deleted, mode flips to polling,
+  health note recorded, no mail lost.
+- Restore inbound path: within 24h (or on Test Connection) provider returns
+  to webhook mode.
+- Auth revocation on a polling-mode provider still surfaces as an error.
+- Hosted tenants: no measurable increase in Graph API call volume for
+  webhook-mode providers.
+- CE (pg-boss) behavior byte-for-byte unchanged apart from inert new columns.
+
+## Risks & Mitigations
+
+- **False-positive silence detection:** detector requires reconciliation to
+  have *found* messages the webhook missed; quiet mailboxes never increment.
+  N=3 consecutive guards flappiness.
+- **Mode flapping:** probe is daily; culling needs 3 consecutive positive
+  misses; hysteresis is inherent.
+- **Error-classification mistakes:** only validation failures and the
+  silence detector may enter polling mode (F005/F008 typed taxonomy).
+- **Partial webhook delivery** (flaky, not dead): recent
+  `last_webhook_delivery_at` resets the counter, so a flaky-but-alive
+  webhook stays in webhook mode — acceptable; the 15m safety-net
+  reconciliation still catches stragglers.
+- **Load on hosted:** polling schedule no-ops for webhook-mode providers;
+  net new cost ≈ zero.
+
+## Implementation Gotchas (from 2026-07-20 lab session)
+
+- **kubectl logs blind spot on the appliance:** Next.js route-handler
+  `console.log` lines (the entire webhook handler) do NOT appear in
+  `kubectl logs`; diagnose webhook traffic with tcpdump on :3000 or
+  `cloudflared --loglevel debug`, never by log absence.
+- `GET /subscriptions` with the provider's stored delegated token works from
+  the appliance — good supportability trick (token never leaves the box).
+- Re-OAuth may issue a narrower-scope token (observed: Mail read-only).
+  Polling only needs read, so fine — but don't assume write scopes.
+- The appliance serves plain HTTP on :3000 hostNetwork; only external
+  TLS-terminating proxies make https notification URLs possible. Polling
+  mode removes that requirement entirely.
+
+## Open Questions (deferred, not blocking)
+
+1. Advanced "Webhooks: Auto / Off" override — deferred until a compliance
+   customer explicitly requires never-advertise-endpoint behavior.
+2. Exact polling cadence (3m default; 2m for SLA-sensitive desks?) —
+   config-backed constant either way.
+3. Should the first silence-detector cull fire a notification to the MSP
+   admin?
+4. Same treatment for the Google provider (Pub/Sub watch) — separate plan.
+
+## Rollout
+
+- Ships with the next appliance release, riding on PR #2981 (merged
+  2026-07-19, not yet deployed anywhere as of 2026-07-20; hosted prod green
+  = `alga-psa-ee:47148b8d`, appliance stable 1.3.6 = same SHA).
+- No feature flag: behavior is additive and self-detecting; migration
+  defaults preserve current behavior for existing providers.

--- a/docs/plans/2026-07-20-webhook-optional-inbound-email-plan.md
+++ b/docs/plans/2026-07-20-webhook-optional-inbound-email-plan.md
@@ -119,11 +119,18 @@ there; revisit promotion to `email_providers` if/when the Google plan lands):
   runs that imported mail with no interceding webhook delivery; reset on any
   webhook delivery.
 - `next_subscription_probe_at` timestamptz — recovery-probe scheduling.
+- `last_reconciliation_at` timestamptz — Graph reconciliation window and
+  overlap-claim cursor. This is deliberately separate from
+  `email_providers.last_sync_at`, which unified queue consumers advance after
+  successful ingestion.
 
 Migration follows existing tenant-scoped (Citus) migration patterns in
 `server/migrations/`.
 
 Note: `Last ingested` uses the existing `email_providers.last_sync_at`.
+Reconciliation must never use that ingestion timestamp to decide that a Graph
+polling window was claimed; webhook/queue ingestion can advance it while a
+polling runner is in flight.
 
 ## Implementation Steps
 
@@ -163,6 +170,9 @@ Note: `Last ingested` uses the existing `email_providers.last_sync_at`.
      failure → advance probe ~24h, single info log, health stays green.
    - New entry point for the polling loop: reconcile `polling`-mode
      providers only (reuses `reconcileMissedMessages`).
+   - Lock, compare, and advance `last_reconciliation_at` to serialize Graph
+     windows. Commit it only after queue writes succeed; leave `last_sync_at`
+     to the unified queue consumer.
 6. **Temporal schedule** —
    `ee/temporal-workflows/src/schedules/setupSchedules.ts`: add
    `email-polling-reconcile-schedule` (interval from env,
@@ -210,6 +220,7 @@ mailboxes during implementation.
 - F020 appliance docs: egress-only requirement
 - F021 mode transitions logged (info, provider id + tenant, reason)
 - F022 reconciliation run recording feeds silence counter idempotently
+- F023 dedicated reconciliation cursor cannot be advanced by queue ingestion
 
 ## Test Plan
 
@@ -247,6 +258,9 @@ mailboxes during implementation.
   polling mode → message becomes ticket within 2 polling cycles → endpoint
   becomes reachable → probe restores webhook mode → webhook-delivered
   message creates ticket.
+- T015 unit/concurrency: a queue consumer advances `last_sync_at` while
+  reconciliation is deciding whether to enqueue/commit; the Graph window is
+  still enqueued and the dedicated cursor advances.
 
 ## Acceptance Criteria
 

--- a/docs/plans/2026-07-20-webhook-optional-inbound-email-verification.md
+++ b/docs/plans/2026-07-20-webhook-optional-inbound-email-verification.md
@@ -1,0 +1,80 @@
+# Webhook-Optional Inbound Email Verification
+
+Verified on 2026-07-21 in the `improve/premise-microsoft-polling`
+worktree. These results cover the initial implementation plus the silence
+detection concurrency/idempotency mitigation.
+
+## Focused automated tests
+
+Command (run from `server/`):
+
+```sh
+npx vitest run \
+  src/test/unit/email/EmailWebhookMaintenanceService.test.ts \
+  src/test/unit/email/MicrosoftGraphAdapter.subscription.test.ts \
+  src/test/unit/email/microsoftPollingWiring.contract.test.ts \
+  src/test/unit/components/EmailProviderCard.test.tsx \
+  src/test/integration/microsoftWebhookUnifiedQueue.integration.test.ts \
+  --coverage.enabled=false --silent=passed-only
+```
+
+Result: **5 files passed, 22 tests passed**.
+
+Coverage includes Graph validation-versus-auth classification, healthy polling
+fallback, polling reconciliation, daily recovery, Test Connection recovery
+wiring, Temporal schedule wiring, webhook delivery stamping/queue ingress,
+healthy UI status, and the following silence-detector guards:
+
+- an overlapping run that loses the `last_sync_at` compare-and-set does not
+  enqueue or increment;
+- a safety-margin retry can be re-enqueued but is not counted as a new silent
+  run;
+- a webhook counter reset that wins the conditional mode-transition update
+  prevents subscription deletion.
+
+## Typechecks and builds
+
+Commands (run from the repository root unless noted):
+
+```sh
+NODE_OPTIONS=--max-old-space-size=8192 \
+  npx nx run @alga-psa/shared:typecheck --output-style=static
+
+npx nx run @alga-psa/integrations:typecheck --output-style=static
+
+NODE_OPTIONS=--max-old-space-size=12288 \
+  npx nx run server:typecheck --output-style=static
+
+cd ee/temporal-workflows && npm run build
+
+cd server && \
+  NODE_OPTIONS=--max-old-space-size=12288 \
+  EDITION=enterprise NEXT_PUBLIC_EDITION=enterprise \
+  npm run build:enterprise
+```
+
+Result: **all passed**. The EE Next.js build completed with the repository's
+existing webpack warnings. Server typechecking exhausted the 4 GB and 8 GB
+Node heaps in earlier attempts and passed at 12 GB; this branch already had the
+same documented memory requirement for the EE production build.
+
+## Isolated migration exercise
+
+The migration was executed against a disposable PostgreSQL database created on
+the wired stack's direct PostgreSQL port (5472), not against the ahead-of-branch
+shared application database. The exercise:
+
+1. created a minimal pre-migration `microsoft_email_provider_config` table;
+2. inserted one row with a subscription and one without;
+3. ran migration `up`;
+4. verified all four columns, the `webhook`/`polling` backfill, the zero counter
+   default, and the delivery-mode check constraint;
+5. ran migration `down` and verified all four columns were removed;
+6. dropped the disposable database and confirmed no `alga_ms_poll_verify_%`
+   databases remained.
+
+Result: **PASS isolated migration up/backfill/constraint/down**.
+
+The full branch migration directory still cannot be validated against the
+wired `alga-psa-local-test` application database because that database contains
+migrations from newer branches that are absent from this checkout.

--- a/docs/plans/2026-07-20-webhook-optional-inbound-email-verification.md
+++ b/docs/plans/2026-07-20-webhook-optional-inbound-email-verification.md
@@ -2,7 +2,8 @@
 
 Verified on 2026-07-21 in the `improve/premise-microsoft-polling`
 worktree. These results cover the initial implementation plus the silence
-detection concurrency/idempotency mitigation and enqueue-failure follow-up.
+detection concurrency/idempotency mitigation, enqueue-failure follow-up, and
+the dedicated reconciliation-cursor mitigation.
 
 ## Focused automated tests
 
@@ -18,17 +19,21 @@ npx vitest run \
   --coverage.enabled=false --silent=passed-only
 ```
 
-Result: **5 files passed, 23 tests passed**.
+Result: **5 files passed, 25 tests passed**.
 
 Coverage includes Graph validation-versus-auth classification, healthy polling
 fallback, polling reconciliation, daily recovery, Test Connection recovery
 wiring, Temporal schedule wiring, webhook delivery stamping/queue ingress,
 healthy UI status, and the following silence-detector guards:
 
-- polling runners lock and compare the provider cursor before enqueueing, so
+- polling runners lock and compare the dedicated Microsoft reconciliation
+  cursor before enqueueing, so
   an overlapping run that observes a committed cursor does not enqueue or
   increment;
-- a failed Redis enqueue occurs before the transactional `last_sync_at` update,
+- a unified queue consumer advancing `last_sync_at` while reconciliation is
+  in flight cannot make the Graph window appear claimed or skipped;
+- a failed Redis enqueue occurs before the transactional
+  `last_reconciliation_at` update,
   leaving the polling window retryable;
 - a safety-margin retry can be re-enqueued but is not counted as a new silent
   run;
@@ -61,7 +66,7 @@ existing webpack warnings. Server typechecking exhausted the 4 GB and 8 GB
 Node heaps in earlier attempts and passed at 12 GB; this branch already had the
 same documented memory requirement for the EE production build.
 
-## Isolated migration exercise
+## Isolated migration exercises
 
 The migration was executed against a disposable PostgreSQL database created on
 the wired stack's direct PostgreSQL port (5472), not against the ahead-of-branch
@@ -77,6 +82,14 @@ shared application database. The exercise:
    databases remained.
 
 Result: **PASS isolated migration up/backfill/constraint/down**.
+
+The follow-up reconciliation-cursor migration was also exercised against a
+disposable PostgreSQL database on port 5472. It added
+`last_reconciliation_at`, backfilled a non-null `email_providers.last_sync_at`
+through the tenant-co-located join while preserving null, and removed the
+column on `down`.
+
+Result: **PASS isolated cursor migration up/backfill/down**.
 
 The full branch migration directory still cannot be validated against the
 wired `alga-psa-local-test` application database because that database contains

--- a/docs/plans/2026-07-20-webhook-optional-inbound-email-verification.md
+++ b/docs/plans/2026-07-20-webhook-optional-inbound-email-verification.md
@@ -2,7 +2,7 @@
 
 Verified on 2026-07-21 in the `improve/premise-microsoft-polling`
 worktree. These results cover the initial implementation plus the silence
-detection concurrency/idempotency mitigation.
+detection concurrency/idempotency mitigation and enqueue-failure follow-up.
 
 ## Focused automated tests
 
@@ -18,15 +18,18 @@ npx vitest run \
   --coverage.enabled=false --silent=passed-only
 ```
 
-Result: **5 files passed, 22 tests passed**.
+Result: **5 files passed, 23 tests passed**.
 
 Coverage includes Graph validation-versus-auth classification, healthy polling
 fallback, polling reconciliation, daily recovery, Test Connection recovery
 wiring, Temporal schedule wiring, webhook delivery stamping/queue ingress,
 healthy UI status, and the following silence-detector guards:
 
-- an overlapping run that loses the `last_sync_at` compare-and-set does not
-  enqueue or increment;
+- polling runners lock and compare the provider cursor before enqueueing, so
+  an overlapping run that observes a committed cursor does not enqueue or
+  increment;
+- a failed Redis enqueue occurs before the transactional `last_sync_at` update,
+  leaving the polling window retryable;
 - a safety-margin retry can be re-enqueued but is not counted as a new silent
   run;
 - a webhook counter reset that wins the conditional mode-transition update

--- a/docs/plans/2026-07-20-webhook-optional-inbound-email-verification.md
+++ b/docs/plans/2026-07-20-webhook-optional-inbound-email-verification.md
@@ -3,7 +3,7 @@
 Verified on 2026-07-21 in the `improve/premise-microsoft-polling`
 worktree. These results cover the initial implementation plus the silence
 detection concurrency/idempotency mitigation, enqueue-failure follow-up, and
-the dedicated reconciliation-cursor mitigation.
+the dedicated reconciliation-cursor and capped-batch overflow mitigations.
 
 ## Focused automated tests
 
@@ -19,7 +19,7 @@ npx vitest run \
   --coverage.enabled=false --silent=passed-only
 ```
 
-Result: **5 files passed, 25 tests passed**.
+Result: **5 files passed, 26 tests passed**.
 
 Coverage includes Graph validation-versus-auth classification, healthy polling
 fallback, polling reconciliation, daily recovery, Test Connection recovery
@@ -37,6 +37,10 @@ healthy UI status, and the following silence-detector guards:
   leaving the polling window retryable;
 - a safety-margin retry can be re-enqueued but is not counted as a new silent
   run;
+- a capped oldest-first Graph batch commits an effective boundary cursor
+  instead of wall-clock completion time, and the next run expands past
+  processed overlap rows to enqueue same-timestamp overflow already older than
+  the 15-minute safety margin;
 - a webhook counter reset that wins the conditional mode-transition update
   prevents subscription deletion.
 

--- a/ee/temporal-workflows/src/activities/email-webhook-maintenance-activities.ts
+++ b/ee/temporal-workflows/src/activities/email-webhook-maintenance-activities.ts
@@ -5,3 +5,10 @@ export async function renewMicrosoftWebhooksActivity(options: { tenantId?: strin
   return service.renewMicrosoftWebhooks(options);
 }
 
+export async function reconcilePollingMicrosoftProvidersActivity(options: {
+  tenantId?: string;
+  providerId?: string;
+}): Promise<any[]> {
+  const service = new EmailWebhookMaintenanceService();
+  return service.reconcilePollingProviders(options);
+}

--- a/ee/temporal-workflows/src/schedules/setupSchedules.ts
+++ b/ee/temporal-workflows/src/schedules/setupSchedules.ts
@@ -8,6 +8,7 @@ import {
   applianceCheckInWorkflow,
   calendarWebhookMaintenanceWorkflow,
   emailWebhookMaintenanceWorkflow,
+  emailPollingReconcileWorkflow,
   entraAllTenantsSyncWorkflow,
   maintenanceJobWorkflow,
   premiumTrialExpiryWorkflow,
@@ -70,6 +71,11 @@ function normalizeIntervalMinutes(rawValue: unknown): number {
   }
 
   return Math.max(5, Math.floor(parsed));
+}
+
+function microsoftEmailPollingIntervalMinutes(): number {
+  const parsed = Number(process.env.MICROSOFT_EMAIL_POLLING_INTERVAL_MINUTES || 3);
+  return Number.isFinite(parsed) && parsed >= 1 ? Math.floor(parsed) : 3;
 }
 
 function parseSettings(value: unknown): Record<string, unknown> {
@@ -269,6 +275,24 @@ export async function setupSchedules() {
         type: 'startWorkflow',
         workflowType: emailWebhookMaintenanceWorkflow,
         args: [{ lookAheadMinutes: 1440 }],
+        taskQueue: EMAIL_WORKFLOW_TASK_QUEUE,
+        workflowExecutionTimeout: '10m',
+      },
+      policies: {
+        overlap: ScheduleOverlapPolicy.SKIP,
+        catchupWindow: '1m',
+      },
+    });
+
+    const pollingScheduleId = 'email-polling-reconcile-schedule';
+    await upsertSchedule(client, pollingScheduleId, {
+      spec: {
+        intervals: [{ every: `${microsoftEmailPollingIntervalMinutes()}m` }],
+      },
+      action: {
+        type: 'startWorkflow',
+        workflowType: emailPollingReconcileWorkflow,
+        args: [{}],
         taskQueue: EMAIL_WORKFLOW_TASK_QUEUE,
         workflowExecutionTimeout: '10m',
       },

--- a/ee/temporal-workflows/src/workflows/email-polling-reconcile-workflow.ts
+++ b/ee/temporal-workflows/src/workflows/email-polling-reconcile-workflow.ts
@@ -1,0 +1,12 @@
+import { proxyActivities } from '@temporalio/workflow';
+import type * as activities from '../activities';
+
+const { reconcilePollingMicrosoftProvidersActivity } = proxyActivities<typeof activities>({
+  startToCloseTimeout: '5m',
+});
+
+export async function emailPollingReconcileWorkflow(
+  options: { tenantId?: string; providerId?: string } = {}
+): Promise<void> {
+  await reconcilePollingMicrosoftProvidersActivity(options);
+}

--- a/ee/temporal-workflows/src/workflows/index.ts
+++ b/ee/temporal-workflows/src/workflows/index.ts
@@ -8,6 +8,7 @@ export * from './generic-job-workflow.js';
 export * from './readiness-workflow.js';
 export * from './maintenance-fanout-workflow.js';
 export * from './email-webhook-maintenance-workflow.js';
+export * from './email-polling-reconcile-workflow.js';
 export * from './calendar-webhook-maintenance-workflow.js';
 export * from './ninjaone-sync-workflow.js';
 export * from './ninjaone-token-refresh-workflow.js';

--- a/ee/temporal-workflows/src/workflows/non-authored-index.ts
+++ b/ee/temporal-workflows/src/workflows/non-authored-index.ts
@@ -8,6 +8,7 @@ export * from './generic-job-workflow.js';
 export * from './readiness-workflow.js';
 export * from './maintenance-fanout-workflow.js';
 export * from './email-webhook-maintenance-workflow.js';
+export * from './email-polling-reconcile-workflow.js';
 export * from './calendar-webhook-maintenance-workflow.js';
 export * from './ninjaone-sync-workflow.js';
 export * from './ninjaone-token-refresh-workflow.js';

--- a/packages/integrations/src/actions/email-actions/emailProviderActions.ts
+++ b/packages/integrations/src/actions/email-actions/emailProviderActions.ts
@@ -387,6 +387,9 @@ async function persistMicrosoftConfig(
       webhook_subscription_id: null,
       webhook_expires_at: null,
       webhook_verification_token: null,
+      delivery_mode: 'polling',
+      webhook_silent_runs: 0,
+      next_subscription_probe_at: null,
       created_at: now,
       updated_at: now,
     })
@@ -698,6 +701,11 @@ export const getEmailProviders = withAuth(async (
             'webhook_subscription_id',
             'webhook_expires_at',
             'webhook_verification_token',
+            'last_subscription_renewal',
+            'delivery_mode',
+            'last_webhook_delivery_at',
+            'webhook_silent_runs',
+            'next_subscription_probe_at',
             'created_at',
             'updated_at'
           )
@@ -1277,6 +1285,20 @@ export const testEmailProviderConnection = withAuth(async (
           'Microsoft 365 authentication failed. Reconnect the mailbox and try again.',
           'connection_failed'
         );
+      }
+
+      if (vendorConfig.delivery_mode === 'polling') {
+        const [probeResult] = await new EmailWebhookMaintenanceService().renewMicrosoftWebhooks({
+          tenantId: tenant,
+          providerId,
+          lookAheadMinutes: 0,
+        });
+        if (probeResult && !probeResult.success) {
+          return emailProviderOperationError(
+            probeResult.error || 'Microsoft webhook recovery probe failed.',
+            'connection_failed'
+          );
+        }
       }
     }
 

--- a/packages/integrations/src/components/email/EmailProviderCard.tsx
+++ b/packages/integrations/src/components/email/EmailProviderCard.tsx
@@ -235,7 +235,7 @@ export function EmailProviderCard({
       </CardHeader>
 
       <CardContent className="pt-0">
-        <div className="grid grid-cols-3 gap-4 text-sm">
+        <div className="grid grid-cols-2 gap-4 text-sm lg:grid-cols-4">
           <div>
             <div className="flex items-center space-x-1 text-muted-foreground mb-1">
               {getStatusIcon(provider.status)}
@@ -253,9 +253,26 @@ export function EmailProviderCard({
           </div>
 
           <div>
-            <div className="text-muted-foreground mb-1">{t('providerCard.fields.lastSync', { defaultValue: 'Last Sync' })}</div>
+            <div className="text-muted-foreground mb-1">
+              {provider.providerType === 'microsoft'
+                ? t('providerCard.fields.lastIngested', { defaultValue: 'Last ingested' })
+                : t('providerCard.fields.lastSync', { defaultValue: 'Last Sync' })}
+            </div>
             <div className="font-medium">{formatLastSync(provider.lastSyncAt)}</div>
           </div>
+
+          {provider.providerType === 'microsoft' && provider.microsoftConfig && (
+            <div>
+              <div className="text-muted-foreground mb-1">
+                {t('providerCard.fields.delivery', { defaultValue: 'Delivery' })}
+              </div>
+              <div className="font-medium">
+                {provider.microsoftConfig.delivery_mode === 'polling'
+                  ? t('providerCard.delivery.polling', { defaultValue: 'Polling every 3 minutes' })
+                  : t('providerCard.delivery.webhook', { defaultValue: 'Real-time delivery: active' })}
+              </div>
+            </div>
+          )}
 
           <div>
             <div className="text-muted-foreground mb-1">{t('providerCard.fields.created', { defaultValue: 'Created' })}</div>

--- a/packages/integrations/src/components/email/types.ts
+++ b/packages/integrations/src/components/email/types.ts
@@ -42,6 +42,10 @@ export interface MicrosoftEmailProviderConfig {
   webhook_verification_token?: string; // Added to match database
   webhook_expires_at?: string;
   last_subscription_renewal?: string; // Added to match database
+  delivery_mode?: 'webhook' | 'polling';
+  last_webhook_delivery_at?: string;
+  webhook_silent_runs?: number;
+  next_subscription_probe_at?: string;
   created_at: string;
   updated_at: string;
 }

--- a/packages/integrations/src/services/email/EmailProviderService.ts
+++ b/packages/integrations/src/services/email/EmailProviderService.ts
@@ -7,6 +7,7 @@ import { createTenantKnex, tenantDb } from '@alga-psa/db';
 import { EmailProviderConfig } from '@alga-psa/shared/interfaces/inbound-email.interfaces';
 import { MicrosoftGraphAdapter } from '@alga-psa/shared/services/email/providers/MicrosoftGraphAdapter';
 import { buildMicrosoftEmailProviderConfig } from '@alga-psa/shared/services/email/microsoftEmailProviderConfig';
+import { EmailWebhookMaintenanceService } from '@alga-psa/shared/services/email/EmailWebhookMaintenanceService';
 import { GmailAdapter } from './providers/GmailAdapter';
 import { GmailWebhookService } from './GmailWebhookService';
 import { getWebhookBaseUrl } from '../../utils/email/webhookHelpers';
@@ -415,8 +416,22 @@ export class EmailProviderService {
         const result = await adapter.initializeWebhook(webhookUrl);
         
         if (!result.success) {
+          if (result.errorKind === 'validation') {
+            await new EmailWebhookMaintenanceService().usePollingDelivery({
+              providerId,
+              tenant,
+              reason: result.error || 'Microsoft webhook endpoint validation failed',
+            });
+            return;
+          }
           throw new Error(result.error);
         }
+
+        await new EmailWebhookMaintenanceService().recordWebhookDeliveryMode({
+          providerId,
+          tenant,
+          reason: 'provider configuration subscription succeeded',
+        });
 
         // Update provider with webhook subscription ID
         await this.updateProvider(providerId, tenant, {
@@ -543,6 +558,11 @@ export class EmailProviderService {
       webhook_verification_token: vendorConfig?.webhook_verification_token || null,
       webhook_expires_at: vendorConfig?.webhook_expires_at || null,
       last_subscription_renewal: vendorConfig?.last_subscription_renewal || null,
+      delivery_mode: vendorConfig?.delivery_mode ||
+        (vendorConfig?.webhook_subscription_id ? 'webhook' : 'polling'),
+      last_webhook_delivery_at: vendorConfig?.last_webhook_delivery_at || null,
+      webhook_silent_runs: vendorConfig?.webhook_silent_runs || 0,
+      next_subscription_probe_at: vendorConfig?.next_subscription_probe_at || null,
       connection_status: row.status || 'configuring',
       last_connection_test: row.last_sync_at || null,
       connection_error_message: row.error_message || null,

--- a/packages/integrations/src/webhooks/email/handlers/microsoftWebhookHandler.ts
+++ b/packages/integrations/src/webhooks/email/handlers/microsoftWebhookHandler.ts
@@ -138,6 +138,11 @@ export async function handleMicrosoftWebhookPost(request: NextRequest) {
           const row: any = await providerQuery
             .where('mc.webhook_subscription_id', providerId)
             .andWhere('ep.provider_type', 'microsoft')
+            // Serialize accepted-delivery stamping with the silence detector's
+            // conditional counter/mode updates. Without this lock, a handler
+            // could validate the old subscription, pause, and reset the counter
+            // only after reconciliation had already culled it.
+            .forUpdate('mc')
             .first(
               'ep.*',
               trx.raw('mc.client_id as mc_client_id'),

--- a/packages/integrations/src/webhooks/email/handlers/microsoftWebhookHandler.ts
+++ b/packages/integrations/src/webhooks/email/handlers/microsoftWebhookHandler.ts
@@ -186,6 +186,22 @@ export async function handleMicrosoftWebhookPost(request: NextRequest) {
             console.warn(`⚠️ No stored verification token for provider ${row.id} - skipping client state validation`);
           }
 
+          const acceptedAt = new Date().toISOString();
+          const providerDb = tenantDb(trx, row.tenant);
+          await providerDb.table('microsoft_email_provider_config')
+            .where({ email_provider_id: row.id })
+            .update({
+              last_webhook_delivery_at: acceptedAt,
+              webhook_silent_runs: 0,
+              updated_at: acceptedAt,
+            });
+          await providerDb.table('email_provider_health')
+            .where({ provider_id: row.id })
+            .update({
+              last_notification_received_at: acceptedAt,
+              updated_at: acceptedAt,
+            });
+
           // Extract message ID from resource
           const messageId = notification.resourceData?.id || extractMessageId(notification.resource);
           if (!messageId) {

--- a/server/migrations/20260720210000_add_microsoft_email_delivery_mode.cjs
+++ b/server/migrations/20260720210000_add_microsoft_email_delivery_mode.cjs
@@ -1,0 +1,42 @@
+/**
+ * Track whether Microsoft inbound email uses Graph change notifications or
+ * outbound-only reconciliation polling.
+ *
+ * @param { import('knex').Knex } knex
+ */
+exports.up = async function up(knex) {
+  await knex.schema.alterTable('microsoft_email_provider_config', (table) => {
+    table.text('delivery_mode').notNullable().defaultTo('polling');
+    table.timestamp('last_webhook_delivery_at', { useTz: true }).nullable();
+    table.integer('webhook_silent_runs').notNullable().defaultTo(0);
+    table.timestamp('next_subscription_probe_at', { useTz: true }).nullable();
+  });
+
+  const tenants = await knex('microsoft_email_provider_config').distinct('tenant');
+  for (const { tenant } of tenants) {
+    await knex('microsoft_email_provider_config')
+      .where({ tenant })
+      .whereNotNull('webhook_subscription_id')
+      .update({ delivery_mode: 'webhook' });
+  }
+
+  await knex.raw(`
+    ALTER TABLE microsoft_email_provider_config
+    ADD CONSTRAINT microsoft_email_provider_config_delivery_mode_check
+    CHECK (delivery_mode IN ('webhook', 'polling'))
+  `);
+};
+
+/** @param { import('knex').Knex } knex */
+exports.down = async function down(knex) {
+  await knex.raw(`
+    ALTER TABLE microsoft_email_provider_config
+    DROP CONSTRAINT IF EXISTS microsoft_email_provider_config_delivery_mode_check
+  `);
+  await knex.schema.alterTable('microsoft_email_provider_config', (table) => {
+    table.dropColumn('next_subscription_probe_at');
+    table.dropColumn('webhook_silent_runs');
+    table.dropColumn('last_webhook_delivery_at');
+    table.dropColumn('delivery_mode');
+  });
+};

--- a/server/migrations/20260721120000_add_microsoft_email_reconciliation_cursor.cjs
+++ b/server/migrations/20260721120000_add_microsoft_email_reconciliation_cursor.cjs
@@ -1,0 +1,30 @@
+/**
+ * Keep the Microsoft Graph reconciliation cursor separate from last_sync_at.
+ * Unified queue consumers advance last_sync_at after successful ingestion, so
+ * it cannot also identify whether a polling window has been claimed.
+ *
+ * @param { import('knex').Knex } knex
+ */
+exports.up = async function up(knex) {
+  await knex.schema.alterTable('microsoft_email_provider_config', (table) => {
+    table.timestamp('last_reconciliation_at', { useTz: true }).nullable();
+  });
+
+  // Both tables are tenant-distributed. Include the co-location key in the
+  // UPDATE ... FROM join so this remains valid for Citus installations.
+  await knex.raw(`
+    UPDATE microsoft_email_provider_config mpc
+    SET last_reconciliation_at = ep.last_sync_at
+    FROM email_providers ep
+    WHERE mpc.tenant = ep.tenant
+      AND mpc.email_provider_id = ep.id
+      AND ep.last_sync_at IS NOT NULL
+  `);
+};
+
+/** @param { import('knex').Knex } knex */
+exports.down = async function down(knex) {
+  await knex.schema.alterTable('microsoft_email_provider_config', (table) => {
+    table.dropColumn('last_reconciliation_at');
+  });
+};

--- a/server/public/locales/de/msp/email-providers.json
+++ b/server/public/locales/de/msp/email-providers.json
@@ -172,10 +172,16 @@
     "fields": {
       "status": "Status",
       "lastSync": "Letzte Synchronisierung",
+      "lastIngested": "Zuletzt eingelesen",
+      "delivery": "Zustellung",
       "created": "Erstellt",
       "subscription": "Abonnement",
       "defaults": "Ticket-Standardeinstellungen",
       "error": "Fehler:"
+    },
+    "delivery": {
+      "polling": "Abruf alle 3 Minuten",
+      "webhook": "Echtzeit-Zustellung: aktiv"
     },
     "values": {
       "active": "Aktiv",

--- a/server/public/locales/en/msp/email-providers.json
+++ b/server/public/locales/en/msp/email-providers.json
@@ -172,10 +172,16 @@
     "fields": {
       "status": "Status",
       "lastSync": "Last Sync",
+      "lastIngested": "Last ingested",
+      "delivery": "Delivery",
       "created": "Created",
       "subscription": "Subscription",
       "defaults": "Ticket Defaults",
       "error": "Error:"
+    },
+    "delivery": {
+      "polling": "Polling every 3 minutes",
+      "webhook": "Real-time delivery: active"
     },
     "values": {
       "active": "Active",

--- a/server/public/locales/es/msp/email-providers.json
+++ b/server/public/locales/es/msp/email-providers.json
@@ -172,10 +172,16 @@
     "fields": {
       "status": "Estado",
       "lastSync": "Última sincronización",
+      "lastIngested": "Última ingesta",
+      "delivery": "Entrega",
       "created": "Creado",
       "subscription": "Suscripción",
       "defaults": "Valores predeterminados del ticket",
       "error": "Error:"
+    },
+    "delivery": {
+      "polling": "Sondeo cada 3 minutos",
+      "webhook": "Entrega en tiempo real: activa"
     },
     "values": {
       "active": "Activo",

--- a/server/public/locales/fr/msp/email-providers.json
+++ b/server/public/locales/fr/msp/email-providers.json
@@ -172,10 +172,16 @@
     "fields": {
       "status": "Statut",
       "lastSync": "Dernière synchronisation",
+      "lastIngested": "Dernière ingestion",
+      "delivery": "Livraison",
       "created": "Créé",
       "subscription": "Abonnement",
       "defaults": "Valeurs par défaut des tickets",
       "error": "Erreur:"
+    },
+    "delivery": {
+      "polling": "Interrogation toutes les 3 minutes",
+      "webhook": "Livraison en temps réel : active"
     },
     "values": {
       "active": "Actif",

--- a/server/public/locales/it/msp/email-providers.json
+++ b/server/public/locales/it/msp/email-providers.json
@@ -172,10 +172,16 @@
     "fields": {
       "status": "Stato",
       "lastSync": "Ultima sincronizzazione",
+      "lastIngested": "Ultima acquisizione",
+      "delivery": "Consegna",
       "created": "Creato",
       "subscription": "Sottoscrizione",
       "defaults": "Impostazioni predefinite dei ticket",
       "error": "Errore:"
+    },
+    "delivery": {
+      "polling": "Polling ogni 3 minuti",
+      "webhook": "Consegna in tempo reale: attiva"
     },
     "values": {
       "active": "Attivo",

--- a/server/public/locales/nl/msp/email-providers.json
+++ b/server/public/locales/nl/msp/email-providers.json
@@ -172,10 +172,16 @@
     "fields": {
       "status": "Status",
       "lastSync": "Laatste synchronisatie",
+      "lastIngested": "Laatst ingelezen",
+      "delivery": "Levering",
       "created": "Gemaakt",
       "subscription": "Abonnement",
       "defaults": "Ticketstandaarden",
       "error": "Fout:"
+    },
+    "delivery": {
+      "polling": "Polling elke 3 minuten",
+      "webhook": "Realtime levering: actief"
     },
     "values": {
       "active": "Actief",

--- a/server/public/locales/pl/msp/email-providers.json
+++ b/server/public/locales/pl/msp/email-providers.json
@@ -172,10 +172,16 @@
     "fields": {
       "status": "Status",
       "lastSync": "Ostatnia synchronizacja",
+      "lastIngested": "Ostatnio pobrano",
+      "delivery": "Dostarczanie",
       "created": "Utworzono",
       "subscription": "Subskrypcja",
       "defaults": "Domyślne ustawienia zgłoszeń",
       "error": "Błąd:"
+    },
+    "delivery": {
+      "polling": "Odpytywanie co 3 minuty",
+      "webhook": "Dostarczanie w czasie rzeczywistym: aktywne"
     },
     "values": {
       "active": "Aktywny",

--- a/server/public/locales/pt/msp/email-providers.json
+++ b/server/public/locales/pt/msp/email-providers.json
@@ -172,10 +172,16 @@
     "fields": {
       "status": "Status",
       "lastSync": "Última sincronização",
+      "lastIngested": "Última ingestão",
+      "delivery": "Entrega",
       "created": "Criado",
       "subscription": "Subscrição",
       "defaults": "Padrões de ticket",
       "error": "Erro:"
+    },
+    "delivery": {
+      "polling": "Consulta a cada 3 minutos",
+      "webhook": "Entrega em tempo real: ativa"
     },
     "values": {
       "active": "Ativo",

--- a/server/public/locales/xx/msp/email-providers.json
+++ b/server/public/locales/xx/msp/email-providers.json
@@ -172,10 +172,16 @@
     "fields": {
       "status": "11111",
       "lastSync": "11111",
+      "lastIngested": "11111",
+      "delivery": "11111",
       "created": "11111",
       "subscription": "11111",
       "defaults": "11111",
       "error": "11111"
+    },
+    "delivery": {
+      "polling": "11111",
+      "webhook": "11111"
     },
     "values": {
       "active": "11111",

--- a/server/public/locales/yy/msp/email-providers.json
+++ b/server/public/locales/yy/msp/email-providers.json
@@ -172,10 +172,16 @@
     "fields": {
       "status": "55555",
       "lastSync": "55555",
+      "lastIngested": "55555",
+      "delivery": "55555",
       "created": "55555",
       "subscription": "55555",
       "defaults": "55555",
       "error": "55555"
+    },
+    "delivery": {
+      "polling": "55555",
+      "webhook": "55555"
     },
     "values": {
       "active": "55555",

--- a/server/src/app/api/auth/microsoft/callback/route.ts
+++ b/server/src/app/api/auth/microsoft/callback/route.ts
@@ -3,12 +3,16 @@ import { headers } from 'next/headers.js';
 import { getSecretProviderInstance } from '@alga-psa/core/secrets';
 import { tenantDb } from '@alga-psa/db';
 import { createTenantKnex, runWithTenant } from '../../../../../lib/db';
-import { MicrosoftGraphAdapter } from '@alga-psa/shared/services/email/providers/MicrosoftGraphAdapter';
+import {
+  MicrosoftGraphAdapter,
+  MicrosoftSubscriptionError,
+} from '@alga-psa/shared/services/email/providers/MicrosoftGraphAdapter';
 import { resolveMicrosoftConsumerProfileConfig } from '@alga-psa/integrations/lib/microsoftConsumerProfileResolution';
 import { getWebhookBaseUrl } from '../../../../../utils/email/webhookHelpers';
 import { getCurrentUser } from '@alga-psa/user-composition/actions';
 import axios from 'axios';
 import { getMicrosoftTokenUrl } from '@alga-psa/shared/services/email/microsoftGraphEndpoints';
+import { EmailWebhookMaintenanceService } from '@alga-psa/shared/services/email/EmailWebhookMaintenanceService';
 
 export const dynamic = 'force-dynamic';
 
@@ -380,19 +384,39 @@ export async function GET(request: NextRequest) {
                   });
 
                   await adapter.registerWebhookSubscription();
+                  await new EmailWebhookMaintenanceService().recordWebhookDeliveryMode({
+                    providerId: provider.id,
+                    tenant: provider.tenant,
+                    reason: 'OAuth setup subscription succeeded',
+                  });
 
                   console.log('[MS OAuth Callback] Webhook subscription registration attempted');
                 } catch (subErr: any) {
+                  if (subErr instanceof MicrosoftSubscriptionError && subErr.kind === 'validation') {
+                    const nextProbeAt = await new EmailWebhookMaintenanceService().usePollingDelivery({
+                      providerId: provider.id,
+                      tenant: provider.tenant,
+                      reason: subErr.message,
+                    });
+                    console.info('[MS OAuth Callback] Webhook endpoint validation failed; using polling delivery', {
+                      tenant: provider.tenant,
+                      providerId: provider.id,
+                      nextProbeAt,
+                    });
+                    return;
+                  }
                   console.warn('⚠️ Failed to register Microsoft webhook subscription in callback:', {
                     message: subErr?.message || String(subErr),
                     status: subErr?.status,
                     code: subErr?.code,
                     requestId: subErr?.requestId,
                   });
+                  throw subErr;
                 }
               }
             } catch (e) {
-              console.warn('⚠️ Skipped webhook initialization after OAuth due to setup error:', (e as any)?.message || e);
+              console.warn('⚠️ Microsoft webhook initialization failed after OAuth:', (e as any)?.message || e);
+              throw e;
             }
           });
         } catch (persistErr: any) {

--- a/server/src/test/integration/microsoftWebhookUnifiedQueue.integration.test.ts
+++ b/server/src/test/integration/microsoftWebhookUnifiedQueue.integration.test.ts
@@ -17,6 +17,9 @@ const providerQueryMock = {
   andWhere: vi.fn(function andWhere() {
     return this;
   }),
+  forUpdate: vi.fn(function forUpdate() {
+    return this;
+  }),
   first: vi.fn(),
 };
 // tenantDb(trx, tenant).table('tenants') → conn('tenants').where(tenant).first(...)
@@ -61,6 +64,7 @@ describe('Microsoft unified inbound pointer queue ingress', () => {
     providerQueryMock.join.mockClear();
     providerQueryMock.where.mockClear();
     providerQueryMock.andWhere.mockClear();
+    providerQueryMock.forUpdate.mockClear();
     providerQueryMock.first.mockReset();
 
     enqueueUnifiedInboundEmailQueueJobMock.mockResolvedValue({
@@ -143,6 +147,7 @@ describe('Microsoft unified inbound pointer queue ingress', () => {
 
     // Provider lookup stays tenant-scoped through the facade join.
     expect(providerQueryMock.join).toHaveBeenCalledWith('email_providers as ep', expect.any(Function));
+    expect(providerQueryMock.forUpdate).toHaveBeenCalledWith('mc');
 
     expect(enqueueUnifiedInboundEmailQueueJobMock).toHaveBeenCalledTimes(1);
     const enqueuePayload = enqueueUnifiedInboundEmailQueueJobMock.mock.calls[0][0];

--- a/server/src/test/integration/microsoftWebhookUnifiedQueue.integration.test.ts
+++ b/server/src/test/integration/microsoftWebhookUnifiedQueue.integration.test.ts
@@ -26,6 +26,12 @@ const tenantsQueryMock = {
   }),
   first: vi.fn(async () => ({ product_code: 'psa' })),
 };
+const updateQueryMock = {
+  where: vi.fn(function where() {
+    return this;
+  }),
+  update: vi.fn().mockResolvedValue(1),
+};
 
 vi.mock('@alga-psa/shared/services/email/unifiedInboundEmailQueue', () => ({
   enqueueUnifiedInboundEmailQueueJob: (...args: any[]) => enqueueUnifiedInboundEmailQueueJobMock(...args),
@@ -72,6 +78,8 @@ describe('Microsoft unified inbound pointer queue ingress', () => {
 
     tenantsQueryMock.where.mockClear();
     tenantsQueryMock.first.mockClear();
+    updateQueryMock.where.mockClear();
+    updateQueryMock.update.mockClear();
 
     trxMock.mockImplementation((table: string) => {
       if (table === 'microsoft_email_provider_config as mc') {
@@ -79,6 +87,9 @@ describe('Microsoft unified inbound pointer queue ingress', () => {
       }
       if (table === 'tenants') {
         return tenantsQueryMock;
+      }
+      if (table === 'microsoft_email_provider_config' || table === 'email_provider_health') {
+        return updateQueryMock;
       }
       throw new Error(`Unexpected table in test transaction: ${table}`);
     });
@@ -149,6 +160,10 @@ describe('Microsoft unified inbound pointer queue ingress', () => {
     expect(enqueuePayload).not.toHaveProperty('emailData');
     expect(enqueuePayload).not.toHaveProperty('attachments');
     expect(enqueuePayload).not.toHaveProperty('rawMimeBase64');
+    expect(updateQueryMock.update).toHaveBeenCalledWith(expect.objectContaining({
+      last_webhook_delivery_at: expect.any(String),
+      webhook_silent_runs: 0,
+    }));
   });
 
   it('T004: Microsoft callback success waits for durable enqueue completion', async () => {

--- a/server/src/test/unit/components/EmailProviderCard.test.tsx
+++ b/server/src/test/unit/components/EmailProviderCard.test.tsx
@@ -1,0 +1,73 @@
+/**
+ * @vitest-environment jsdom
+ */
+import React from 'react';
+import { describe, expect, it, vi } from 'vitest';
+import { screen } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import { renderWithProviders } from '../../utils/testWrapper';
+import { EmailProviderCard } from '@alga-psa/integrations/components/email/EmailProviderCard';
+import type { EmailProvider } from '@alga-psa/integrations/components/email/types';
+
+function microsoftProvider(deliveryMode: 'webhook' | 'polling'): EmailProvider {
+  const now = new Date().toISOString();
+  return {
+    id: '11111111-1111-4111-8111-111111111111',
+    tenant: '22222222-2222-4222-8222-222222222222',
+    providerType: 'microsoft',
+    providerName: 'Support mailbox',
+    mailbox: 'support@example.test',
+    isActive: true,
+    status: 'connected',
+    lastSyncAt: now,
+    createdAt: now,
+    updatedAt: now,
+    microsoftConfig: {
+      email_provider_id: '11111111-1111-4111-8111-111111111111',
+      tenant: '22222222-2222-4222-8222-222222222222',
+      client_id: null,
+      client_secret: null,
+      tenant_id: 'common',
+      redirect_uri: 'https://example.test/api/auth/microsoft/callback',
+      auto_process_emails: true,
+      max_emails_per_sync: 50,
+      folder_filters: ['Inbox'],
+      delivery_mode: deliveryMode,
+      created_at: now,
+      updated_at: now,
+    },
+  };
+}
+
+function renderCard(provider: EmailProvider) {
+  renderWithProviders(
+    <EmailProviderCard
+      provider={provider}
+      defaultsOptions={[]}
+      updatingProviderId={null}
+      onEdit={vi.fn()}
+      onDelete={vi.fn()}
+      onTestConnection={vi.fn()}
+      onRefreshWatchSubscription={vi.fn()}
+      onRetryRenewal={vi.fn()}
+      onRunDiagnostics={vi.fn()}
+      onChangeDefaults={vi.fn()}
+    />
+  );
+}
+
+describe('EmailProviderCard Microsoft delivery status', () => {
+  it('renders polling as a normal connected delivery mode', () => {
+    renderCard(microsoftProvider('polling'));
+
+    expect(screen.getByText('Connected')).toBeInTheDocument();
+    expect(screen.getByText('Polling every 3 minutes')).toBeInTheDocument();
+    expect(screen.getByText('Last ingested')).toBeInTheDocument();
+  });
+
+  it('renders active webhook delivery', () => {
+    renderCard(microsoftProvider('webhook'));
+
+    expect(screen.getByText('Real-time delivery: active')).toBeInTheDocument();
+  });
+});

--- a/server/src/test/unit/email/EmailWebhookMaintenanceService.test.ts
+++ b/server/src/test/unit/email/EmailWebhookMaintenanceService.test.ts
@@ -63,28 +63,43 @@ describe('EmailWebhookMaintenanceService Microsoft recovery sweep', () => {
       join: vi.fn().mockReturnThis(),
       where: vi.fn().mockReturnThis(),
       andWhere: vi.fn().mockReturnThis(),
+      andWhereRaw: vi.fn().mockReturnThis(),
+      whereNull: vi.fn().mockReturnThis(),
+      orWhere: vi.fn().mockReturnThis(),
       whereIn: vi.fn().mockReturnThis(),
       first: vi.fn().mockImplementation((...columns: string[]) => {
-        if (columns.includes('last_webhook_delivery_at')) {
+        if (columns.includes('webhook_silent_runs')) {
           return Promise.resolve({
             last_webhook_delivery_at: provider.last_webhook_delivery_at || null,
             webhook_silent_runs: provider.webhook_silent_runs || 0,
           });
         }
-        return Promise.resolve({ last_sync_at: provider.last_sync_at });
+        return Promise.resolve({
+          last_sync_at: provider.last_sync_at,
+          last_sync_cursor: provider.last_sync_at,
+        });
       }),
       select: vi.fn()
         .mockResolvedValueOnce([provider])
         .mockResolvedValueOnce([]),
-      update: vi.fn().mockResolvedValue(1),
+      update: vi.fn().mockImplementation(async (values: Record<string, unknown>) => {
+        if (values.webhook_silent_runs === 'webhook_silent_runs + 1') {
+          provider.webhook_silent_runs = Number(provider.webhook_silent_runs || 0) + 1;
+        }
+        return 1;
+      }),
       insert: vi.fn().mockResolvedValue([1]),
     };
     const knex: any = vi.fn(() => query);
     knex.fn = { now: vi.fn(() => new Date()) };
+    knex.raw = vi.fn((sql: string) => sql);
     mocks.getAdminConnection.mockResolvedValue(knex);
     mocks.adapter.ensureTokenHealthy.mockResolvedValue(undefined);
     mocks.adapter.cleanupOrphanedSubscriptions.mockResolvedValue(1);
-    mocks.adapter.listMessagesReceivedSince.mockResolvedValue([{ id: 'missed-message' }]);
+    mocks.adapter.listMessagesReceivedSince.mockResolvedValue([{
+      id: 'missed-message',
+      receivedDateTime: new Date().toISOString(),
+    }]);
     mocks.enqueue.mockResolvedValue({ queueDepth: 1 });
   });
 
@@ -134,6 +149,65 @@ describe('EmailWebhookMaintenanceService Microsoft recovery sweep', () => {
     expect(results[0]).toMatchObject({ success: true, action: 'skipped' });
   });
 
+  it('falls back to healthy polling mode on endpoint validation failure', async () => {
+    provider.delivery_mode = 'webhook';
+    provider.webhook_subscription_id = null;
+    provider.webhook_expires_at = null;
+    mocks.adapter.initializeWebhook.mockResolvedValueOnce({
+      success: false,
+      errorKind: 'validation',
+      error: 'Notification URL validation failed',
+    });
+
+    const results = await new EmailWebhookMaintenanceService().renewMicrosoftWebhooks({
+      tenantId: provider.tenant,
+      lookAheadMinutes: 60,
+    });
+
+    const knex = await mocks.getAdminConnection();
+    const query = knex();
+    expect(query.update).toHaveBeenCalledWith(expect.objectContaining({
+      delivery_mode: 'polling',
+      webhook_subscription_id: null,
+      webhook_silent_runs: 0,
+    }));
+    expect(results[0]).toMatchObject({ success: true, action: 'skipped' });
+  });
+
+  it('restores webhook mode when a due polling recovery probe succeeds', async () => {
+    provider.delivery_mode = 'polling';
+    provider.next_subscription_probe_at = new Date(Date.now() - 1_000).toISOString();
+    mocks.adapter.initializeWebhook.mockResolvedValueOnce({ success: true });
+    mocks.adapter.getConfig.mockReturnValueOnce({
+      webhook_expires_at: new Date(Date.now() + 60 * 60 * 1000).toISOString(),
+    });
+
+    const results = await new EmailWebhookMaintenanceService().renewMicrosoftWebhooks({
+      tenantId: provider.tenant,
+    });
+
+    const knex = await mocks.getAdminConnection();
+    const query = knex();
+    expect(query.update).toHaveBeenCalledWith(expect.objectContaining({
+      delivery_mode: 'webhook',
+      webhook_silent_runs: 0,
+      next_subscription_probe_at: null,
+    }));
+    expect(results[0]).toMatchObject({ success: true, action: 'recreated' });
+  });
+
+  it('polling reconciliation imports missed messages without silence detection', async () => {
+    provider.delivery_mode = 'polling';
+
+    const results = await new EmailWebhookMaintenanceService().reconcilePollingProviders({
+      tenantId: provider.tenant,
+    });
+
+    expect(mocks.enqueue).toHaveBeenCalledOnce();
+    expect(mocks.adapter.deleteWebhookSubscription).not.toHaveBeenCalled();
+    expect(results[0]).toMatchObject({ success: true, action: 'skipped' });
+  });
+
   it('culls a webhook after the third reconciliation run that imports missed mail', async () => {
     provider.delivery_mode = 'webhook';
     provider.webhook_silent_runs = 2;
@@ -146,5 +220,74 @@ describe('EmailWebhookMaintenanceService Microsoft recovery sweep', () => {
 
     expect(mocks.adapter.deleteWebhookSubscription).toHaveBeenCalledOnce();
     expect(results[0]).toMatchObject({ success: true, action: 'skipped' });
+  });
+
+  it('does not enqueue or count a reconciliation window already claimed by an overlapping run', async () => {
+    provider.delivery_mode = 'webhook';
+    provider.webhook_silent_runs = 2;
+    const knex = await mocks.getAdminConnection();
+    const query = knex();
+    query.update.mockImplementationOnce(async () => 1) // connected status
+      .mockImplementationOnce(async () => 0); // last_sync_at compare-and-set loses
+
+    const results = await new EmailWebhookMaintenanceService().renewMicrosoftWebhooks({
+      tenantId: provider.tenant,
+      lookAheadMinutes: 60,
+    });
+
+    expect(mocks.enqueue).not.toHaveBeenCalled();
+    expect(mocks.adapter.deleteWebhookSubscription).not.toHaveBeenCalled();
+    expect(provider.webhook_silent_runs).toBe(2);
+    expect(query.andWhereRaw).toHaveBeenCalledWith(
+      'last_sync_at = ?::timestamptz',
+      [provider.last_sync_at]
+    );
+    expect(results[0]).toMatchObject({ success: true, action: 'skipped' });
+  });
+
+  it('does not count safety-margin retries as a second silent run', async () => {
+    provider.delivery_mode = 'webhook';
+    provider.webhook_silent_runs = 2;
+    mocks.adapter.listMessagesReceivedSince.mockResolvedValueOnce([{
+      id: 'retried-message',
+      receivedDateTime: new Date(new Date(provider.last_sync_at).getTime() - 1_000).toISOString(),
+    }]);
+
+    await new EmailWebhookMaintenanceService().renewMicrosoftWebhooks({
+      tenantId: provider.tenant,
+      lookAheadMinutes: 60,
+    });
+
+    expect(mocks.enqueue).toHaveBeenCalledOnce();
+    expect(provider.webhook_silent_runs).toBe(2);
+    expect(mocks.adapter.deleteWebhookSubscription).not.toHaveBeenCalled();
+  });
+
+  it('does not delete a webhook when its reset wins the polling-transition compare-and-set', async () => {
+    provider.delivery_mode = 'webhook';
+    provider.webhook_silent_runs = 2;
+    const knex = await mocks.getAdminConnection();
+    const query = knex();
+    const defaultUpdate = query.update.getMockImplementation();
+    query.update.mockImplementation(async (values: Record<string, unknown>) => {
+      if (values.delivery_mode === 'polling') {
+        provider.webhook_silent_runs = 0;
+        provider.last_webhook_delivery_at = new Date().toISOString();
+        return 0;
+      }
+      return defaultUpdate?.(values);
+    });
+
+    await new EmailWebhookMaintenanceService().renewMicrosoftWebhooks({
+      tenantId: provider.tenant,
+      lookAheadMinutes: 60,
+    });
+
+    expect(provider.webhook_silent_runs).toBe(0);
+    expect(query.update).toHaveBeenCalledWith(expect.objectContaining({
+      delivery_mode: 'polling',
+      webhook_subscription_id: null,
+    }));
+    expect(mocks.adapter.deleteWebhookSubscription).not.toHaveBeenCalled();
   });
 });

--- a/server/src/test/unit/email/EmailWebhookMaintenanceService.test.ts
+++ b/server/src/test/unit/email/EmailWebhookMaintenanceService.test.ts
@@ -7,6 +7,7 @@ const mocks = vi.hoisted(() => ({
     listMessagesReceivedSince: vi.fn(),
     renewWebhookSubscription: vi.fn(),
     initializeWebhook: vi.fn(),
+    deleteWebhookSubscription: vi.fn(),
     getConfig: vi.fn(),
   },
   enqueue: vi.fn(),
@@ -32,9 +33,11 @@ vi.mock('@alga-psa/core/logger', () => ({
 import { EmailWebhookMaintenanceService } from '@alga-psa/shared/services/email/EmailWebhookMaintenanceService';
 
 describe('EmailWebhookMaintenanceService Microsoft recovery sweep', () => {
+  let provider: any;
+
   beforeEach(() => {
     vi.clearAllMocks();
-    const provider = {
+    provider = {
       id: '11111111-1111-4111-8111-111111111111',
       tenant: '22222222-2222-4222-8222-222222222222',
       provider_name: 'Support',
@@ -61,7 +64,15 @@ describe('EmailWebhookMaintenanceService Microsoft recovery sweep', () => {
       where: vi.fn().mockReturnThis(),
       andWhere: vi.fn().mockReturnThis(),
       whereIn: vi.fn().mockReturnThis(),
-      first: vi.fn().mockResolvedValue({ last_sync_at: provider.last_sync_at }),
+      first: vi.fn().mockImplementation((...columns: string[]) => {
+        if (columns.includes('last_webhook_delivery_at')) {
+          return Promise.resolve({
+            last_webhook_delivery_at: provider.last_webhook_delivery_at || null,
+            webhook_silent_runs: provider.webhook_silent_runs || 0,
+          });
+        }
+        return Promise.resolve({ last_sync_at: provider.last_sync_at });
+      }),
       select: vi.fn()
         .mockResolvedValueOnce([provider])
         .mockResolvedValueOnce([]),
@@ -105,5 +116,35 @@ describe('EmailWebhookMaintenanceService Microsoft recovery sweep', () => {
       action: 'failed',
       error: 'invalid_grant',
     });
+  });
+
+  it('does not renew, recreate, or reconcile polling providers before their probe is due', async () => {
+    provider.delivery_mode = 'polling';
+    provider.next_subscription_probe_at = new Date(Date.now() + 60 * 60 * 1000).toISOString();
+
+    const results = await new EmailWebhookMaintenanceService().renewMicrosoftWebhooks({
+      tenantId: '22222222-2222-4222-8222-222222222222',
+      lookAheadMinutes: 60,
+    });
+
+    expect(mocks.adapter.cleanupOrphanedSubscriptions).not.toHaveBeenCalled();
+    expect(mocks.adapter.listMessagesReceivedSince).not.toHaveBeenCalled();
+    expect(mocks.adapter.renewWebhookSubscription).not.toHaveBeenCalled();
+    expect(mocks.adapter.initializeWebhook).not.toHaveBeenCalled();
+    expect(results[0]).toMatchObject({ success: true, action: 'skipped' });
+  });
+
+  it('culls a webhook after the third reconciliation run that imports missed mail', async () => {
+    provider.delivery_mode = 'webhook';
+    provider.webhook_silent_runs = 2;
+    provider.last_webhook_delivery_at = null;
+
+    const results = await new EmailWebhookMaintenanceService().renewMicrosoftWebhooks({
+      tenantId: '22222222-2222-4222-8222-222222222222',
+      lookAheadMinutes: 60,
+    });
+
+    expect(mocks.adapter.deleteWebhookSubscription).toHaveBeenCalledOnce();
+    expect(results[0]).toMatchObject({ success: true, action: 'skipped' });
   });
 });

--- a/server/src/test/unit/email/EmailWebhookMaintenanceService.test.ts
+++ b/server/src/test/unit/email/EmailWebhookMaintenanceService.test.ts
@@ -67,6 +67,7 @@ describe('EmailWebhookMaintenanceService Microsoft recovery sweep', () => {
       whereNull: vi.fn().mockReturnThis(),
       orWhere: vi.fn().mockReturnThis(),
       whereIn: vi.fn().mockReturnThis(),
+      forUpdate: vi.fn().mockReturnThis(),
       first: vi.fn().mockImplementation((...columns: string[]) => {
         if (columns.includes('webhook_silent_runs')) {
           return Promise.resolve({
@@ -93,6 +94,7 @@ describe('EmailWebhookMaintenanceService Microsoft recovery sweep', () => {
     const knex: any = vi.fn(() => query);
     knex.fn = { now: vi.fn(() => new Date()) };
     knex.raw = vi.fn((sql: string) => sql);
+    knex.transaction = vi.fn(async (callback: (trx: any) => Promise<unknown>) => callback(knex));
     mocks.getAdminConnection.mockResolvedValue(knex);
     mocks.adapter.ensureTokenHealthy.mockResolvedValue(undefined);
     mocks.adapter.cleanupOrphanedSubscriptions.mockResolvedValue(1);
@@ -222,13 +224,19 @@ describe('EmailWebhookMaintenanceService Microsoft recovery sweep', () => {
     expect(results[0]).toMatchObject({ success: true, action: 'skipped' });
   });
 
-  it('does not enqueue or count a reconciliation window already claimed by an overlapping run', async () => {
+  it('does not enqueue or count a reconciliation window locked and committed by an overlapping run', async () => {
     provider.delivery_mode = 'webhook';
     provider.webhook_silent_runs = 2;
     const knex = await mocks.getAdminConnection();
     const query = knex();
-    query.update.mockImplementationOnce(async () => 1) // connected status
-      .mockImplementationOnce(async () => 0); // last_sync_at compare-and-set loses
+    query.first
+      .mockResolvedValueOnce({
+        last_sync_at: provider.last_sync_at,
+        last_sync_cursor: provider.last_sync_at,
+      })
+      .mockResolvedValueOnce({
+        last_sync_cursor: new Date().toISOString(),
+      });
 
     const results = await new EmailWebhookMaintenanceService().renewMicrosoftWebhooks({
       tenantId: provider.tenant,
@@ -238,11 +246,29 @@ describe('EmailWebhookMaintenanceService Microsoft recovery sweep', () => {
     expect(mocks.enqueue).not.toHaveBeenCalled();
     expect(mocks.adapter.deleteWebhookSubscription).not.toHaveBeenCalled();
     expect(provider.webhook_silent_runs).toBe(2);
-    expect(query.andWhereRaw).toHaveBeenCalledWith(
-      'last_sync_at = ?::timestamptz',
-      [provider.last_sync_at]
-    );
+    expect(query.forUpdate).toHaveBeenCalledOnce();
     expect(results[0]).toMatchObject({ success: true, action: 'skipped' });
+  });
+
+  it('does not commit the polling cursor when enqueue fails', async () => {
+    provider.delivery_mode = 'polling';
+    mocks.enqueue.mockRejectedValueOnce(new Error('Redis unavailable'));
+    const knex = await mocks.getAdminConnection();
+    const query = knex();
+
+    const results = await new EmailWebhookMaintenanceService().reconcilePollingProviders({
+      tenantId: provider.tenant,
+    });
+
+    expect(query.forUpdate).toHaveBeenCalledOnce();
+    expect(query.update).not.toHaveBeenCalledWith(expect.objectContaining({
+      last_sync_at: expect.any(String),
+    }));
+    expect(results[0]).toMatchObject({
+      success: false,
+      action: 'failed',
+      error: 'Redis unavailable',
+    });
   });
 
   it('does not count safety-margin retries as a second silent run', async () => {

--- a/server/src/test/unit/email/EmailWebhookMaintenanceService.test.ts
+++ b/server/src/test/unit/email/EmailWebhookMaintenanceService.test.ts
@@ -88,6 +88,9 @@ describe('EmailWebhookMaintenanceService Microsoft recovery sweep', () => {
         if (values.webhook_silent_runs === 'webhook_silent_runs + 1') {
           provider.webhook_silent_runs = Number(provider.webhook_silent_runs || 0) + 1;
         }
+        if (typeof values.last_reconciliation_at === 'string') {
+          provider.last_reconciliation_at = values.last_reconciliation_at;
+        }
         return 1;
       }),
       insert: vi.fn().mockResolvedValue([1]),
@@ -303,6 +306,61 @@ describe('EmailWebhookMaintenanceService Microsoft recovery sweep', () => {
       action: 'failed',
       error: 'Redis unavailable',
     });
+  });
+
+  it('keeps capped oldest-first overflow older than the safety margin retryable', async () => {
+    provider.delivery_mode = 'polling';
+    provider.max_emails_per_sync = 2;
+    const originalCursorMs = Date.now() - 3 * 60 * 60 * 1000;
+    provider.last_reconciliation_at = new Date(originalCursorMs).toISOString();
+    const firstMessage = {
+      id: 'oldest-message',
+      receivedDateTime: new Date(originalCursorMs + 20 * 60 * 1000).toISOString(),
+    };
+    const boundaryMessage = {
+      id: 'boundary-message',
+      receivedDateTime: new Date(originalCursorMs + 30 * 60 * 1000).toISOString(),
+    };
+    const overflowMessage = {
+      id: 'overflow-older-than-margin',
+      // Graph only promises oldest-first ordering by receivedDateTime, so an
+      // overflow message may share the boundary message's timestamp.
+      receivedDateTime: boundaryMessage.receivedDateTime,
+    };
+    mocks.adapter.listMessagesReceivedSince
+      .mockResolvedValueOnce([firstMessage, boundaryMessage])
+      .mockResolvedValueOnce([firstMessage, boundaryMessage])
+      .mockResolvedValueOnce([firstMessage, boundaryMessage, overflowMessage]);
+    const knex = await mocks.getAdminConnection();
+    const query = knex();
+
+    await new EmailWebhookMaintenanceService().reconcilePollingProviders({
+      tenantId: provider.tenant,
+    });
+
+    expect(provider.last_reconciliation_at).toBe(boundaryMessage.receivedDateTime);
+    query.select
+      .mockResolvedValueOnce([provider])
+      .mockResolvedValueOnce([
+        { message_id: firstMessage.id },
+        { message_id: boundaryMessage.id },
+      ])
+      .mockResolvedValueOnce([]);
+
+    await new EmailWebhookMaintenanceService().reconcilePollingProviders({
+      tenantId: provider.tenant,
+    });
+
+    expect(mocks.adapter.listMessagesReceivedSince).toHaveBeenNthCalledWith(
+      2,
+      new Date(new Date(boundaryMessage.receivedDateTime).getTime() - 15 * 60 * 1000),
+      2
+    );
+    expect(mocks.enqueue).toHaveBeenCalledWith(expect.objectContaining({
+      pointer: expect.objectContaining({ messageId: overflowMessage.id }),
+    }));
+    expect(Date.now() - new Date(overflowMessage.receivedDateTime).getTime())
+      .toBeGreaterThan(15 * 60 * 1000);
   });
 
   it('does not count safety-margin retries as a second silent run', async () => {

--- a/server/src/test/unit/email/EmailWebhookMaintenanceService.test.ts
+++ b/server/src/test/unit/email/EmailWebhookMaintenanceService.test.ts
@@ -46,6 +46,7 @@ describe('EmailWebhookMaintenanceService Microsoft recovery sweep', () => {
       is_active: true,
       status: 'error',
       last_sync_at: new Date(Date.now() - 60 * 60 * 1000).toISOString(),
+      last_reconciliation_at: new Date(Date.now() - 60 * 60 * 1000).toISOString(),
       webhook_subscription_id: 'current-subscription',
       webhook_expires_at: new Date(Date.now() + 48 * 60 * 60 * 1000).toISOString(),
       client_id: 'premise-app',
@@ -76,8 +77,8 @@ describe('EmailWebhookMaintenanceService Microsoft recovery sweep', () => {
           });
         }
         return Promise.resolve({
-          last_sync_at: provider.last_sync_at,
-          last_sync_cursor: provider.last_sync_at,
+          last_reconciliation_at: provider.last_reconciliation_at,
+          last_reconciliation_cursor: provider.last_reconciliation_at,
         });
       }),
       select: vi.fn()
@@ -231,11 +232,11 @@ describe('EmailWebhookMaintenanceService Microsoft recovery sweep', () => {
     const query = knex();
     query.first
       .mockResolvedValueOnce({
-        last_sync_at: provider.last_sync_at,
-        last_sync_cursor: provider.last_sync_at,
+        last_reconciliation_at: provider.last_reconciliation_at,
+        last_reconciliation_cursor: provider.last_reconciliation_at,
       })
       .mockResolvedValueOnce({
-        last_sync_cursor: new Date().toISOString(),
+        last_reconciliation_cursor: new Date().toISOString(),
       });
 
     const results = await new EmailWebhookMaintenanceService().renewMicrosoftWebhooks({
@@ -247,6 +248,39 @@ describe('EmailWebhookMaintenanceService Microsoft recovery sweep', () => {
     expect(mocks.adapter.deleteWebhookSubscription).not.toHaveBeenCalled();
     expect(provider.webhook_silent_runs).toBe(2);
     expect(query.forUpdate).toHaveBeenCalledOnce();
+    expect(results[0]).toMatchObject({ success: true, action: 'skipped' });
+  });
+
+  it('does not treat a queue consumer last_sync_at update as a claimed polling window', async () => {
+    provider.delivery_mode = 'polling';
+    provider.last_reconciliation_at = new Date(Date.now() - 2 * 60 * 60 * 1000).toISOString();
+    const expectedWindowStart = new Date(
+      new Date(provider.last_reconciliation_at).getTime() - 15 * 60 * 1000
+    );
+    const consumerSyncAt = new Date().toISOString();
+    mocks.adapter.listMessagesReceivedSince.mockImplementationOnce(async () => {
+      // A unified queue consumer finishes webhook ingestion while Graph
+      // reconciliation is deciding whether to enqueue and commit its window.
+      provider.last_sync_at = consumerSyncAt;
+      return [{ id: 'polling-window-message', receivedDateTime: new Date().toISOString() }];
+    });
+    const knex = await mocks.getAdminConnection();
+    const query = knex();
+
+    const results = await new EmailWebhookMaintenanceService().reconcilePollingProviders({
+      tenantId: provider.tenant,
+    });
+
+    expect(mocks.adapter.listMessagesReceivedSince).toHaveBeenCalledWith(expectedWindowStart, 50);
+    expect(mocks.enqueue).toHaveBeenCalledWith(expect.objectContaining({
+      pointer: expect.objectContaining({ messageId: 'polling-window-message' }),
+    }));
+    expect(query.update).toHaveBeenCalledWith(expect.objectContaining({
+      last_reconciliation_at: expect.any(String),
+    }));
+    expect(query.update).not.toHaveBeenCalledWith(expect.objectContaining({
+      last_sync_at: expect.any(String),
+    }));
     expect(results[0]).toMatchObject({ success: true, action: 'skipped' });
   });
 
@@ -262,7 +296,7 @@ describe('EmailWebhookMaintenanceService Microsoft recovery sweep', () => {
 
     expect(query.forUpdate).toHaveBeenCalledOnce();
     expect(query.update).not.toHaveBeenCalledWith(expect.objectContaining({
-      last_sync_at: expect.any(String),
+      last_reconciliation_at: expect.any(String),
     }));
     expect(results[0]).toMatchObject({
       success: false,
@@ -276,7 +310,7 @@ describe('EmailWebhookMaintenanceService Microsoft recovery sweep', () => {
     provider.webhook_silent_runs = 2;
     mocks.adapter.listMessagesReceivedSince.mockResolvedValueOnce([{
       id: 'retried-message',
-      receivedDateTime: new Date(new Date(provider.last_sync_at).getTime() - 1_000).toISOString(),
+      receivedDateTime: new Date(new Date(provider.last_reconciliation_at).getTime() - 1_000).toISOString(),
     }]);
 
     await new EmailWebhookMaintenanceService().renewMicrosoftWebhooks({

--- a/server/src/test/unit/email/MicrosoftGraphAdapter.subscription.test.ts
+++ b/server/src/test/unit/email/MicrosoftGraphAdapter.subscription.test.ts
@@ -29,7 +29,10 @@ vi.mock('@alga-psa/shared/db/admin', () => ({
   }),
 }));
 
-import { MicrosoftGraphAdapter } from '@alga-psa/shared/services/email/providers/MicrosoftGraphAdapter';
+import {
+  MicrosoftGraphAdapter,
+  MicrosoftSubscriptionError,
+} from '@alga-psa/shared/services/email/providers/MicrosoftGraphAdapter';
 
 function config() {
   return {
@@ -88,5 +91,31 @@ describe('MicrosoftGraphAdapter subscription hygiene', () => {
     await expect(adapter.cleanupOrphanedSubscriptions()).resolves.toBe(1);
     expect(mocks.client.delete).toHaveBeenCalledTimes(1);
     expect(mocks.client.delete).toHaveBeenCalledWith('/subscriptions/orphan');
+  });
+
+  it('classifies endpoint validation failures separately from authentication failures', async () => {
+    mocks.client.post.mockRejectedValueOnce({
+      message: 'Request failed with status code 400',
+      response: {
+        status: 400,
+        data: { error: { code: 'ValidationError', message: 'Notification URL validation failed' } },
+        headers: {},
+      },
+    });
+
+    await expect(new MicrosoftGraphAdapter(config()).registerWebhookSubscription())
+      .rejects.toMatchObject<Partial<MicrosoftSubscriptionError>>({ kind: 'validation', status: 400 });
+
+    mocks.client.post.mockRejectedValueOnce({
+      message: 'Request failed with status code 403',
+      response: {
+        status: 403,
+        data: { error: { code: 'ErrorAccessDenied', message: 'Access denied' } },
+        headers: {},
+      },
+    });
+
+    await expect(new MicrosoftGraphAdapter(config()).registerWebhookSubscription())
+      .rejects.toMatchObject<Partial<MicrosoftSubscriptionError>>({ kind: 'authentication', status: 403 });
   });
 });

--- a/server/src/test/unit/email/microsoftPollingWiring.contract.test.ts
+++ b/server/src/test/unit/email/microsoftPollingWiring.contract.test.ts
@@ -39,6 +39,17 @@ describe('Microsoft polling delivery wiring', () => {
     expect(testConnection).not.toContain('last_sync_at');
   });
 
+  it('adds a dedicated reconciliation cursor and backfills it from the legacy ingestion timestamp', () => {
+    const migration = readRepoFile(
+      'server/migrations/20260721120000_add_microsoft_email_reconciliation_cursor.cjs'
+    );
+
+    expect(migration).toContain("table.timestamp('last_reconciliation_at', { useTz: true }).nullable()");
+    expect(migration).toContain('SET last_reconciliation_at = ep.last_sync_at');
+    expect(migration).toContain('mpc.tenant = ep.tenant');
+    expect(migration).toContain("table.dropColumn('last_reconciliation_at')");
+  });
+
   it('registers a config-backed three-minute non-overlapping Temporal schedule', () => {
     const schedules = readRepoFile(
       'ee/temporal-workflows/src/schedules/setupSchedules.ts'

--- a/server/src/test/unit/email/microsoftPollingWiring.contract.test.ts
+++ b/server/src/test/unit/email/microsoftPollingWiring.contract.test.ts
@@ -1,0 +1,51 @@
+import fs from 'node:fs';
+import path from 'node:path';
+import { describe, expect, it } from 'vitest';
+
+const repoRoot = path.resolve(__dirname, '../../../../..');
+
+function readRepoFile(relativePath: string): string {
+  return fs.readFileSync(path.join(repoRoot, relativePath), 'utf8');
+}
+
+describe('Microsoft polling delivery wiring', () => {
+  it('adds, backfills, constrains, and rolls back the delivery-mode columns', () => {
+    const migration = readRepoFile(
+      'server/migrations/20260720210000_add_microsoft_email_delivery_mode.cjs'
+    );
+
+    expect(migration).toContain("table.text('delivery_mode').notNullable().defaultTo('polling')");
+    expect(migration).toContain("table.timestamp('last_webhook_delivery_at', { useTz: true }).nullable()");
+    expect(migration).toContain("table.integer('webhook_silent_runs').notNullable().defaultTo(0)");
+    expect(migration).toContain("table.timestamp('next_subscription_probe_at', { useTz: true }).nullable()");
+    expect(migration).toContain(".whereNotNull('webhook_subscription_id')");
+    expect(migration).toContain(".update({ delivery_mode: 'webhook' })");
+    expect(migration).toContain("CHECK (delivery_mode IN ('webhook', 'polling'))");
+    expect(migration).toContain("table.dropColumn('delivery_mode')");
+  });
+
+  it('Test Connection forces a polling recovery probe without writing the ingestion cursor', () => {
+    const actions = readRepoFile(
+      'packages/integrations/src/actions/email-actions/emailProviderActions.ts'
+    );
+    const testConnectionStart = actions.indexOf('export const testEmailProviderConnection');
+    const retryActionStart = actions.indexOf('export const retryMicrosoftSubscriptionRenewal');
+    const testConnection = actions.slice(testConnectionStart, retryActionStart);
+
+    expect(testConnection).toContain("vendorConfig.delivery_mode === 'polling'");
+    expect(testConnection).toContain('new EmailWebhookMaintenanceService().renewMicrosoftWebhooks({');
+    expect(testConnection).toContain('providerId,');
+    expect(testConnection).toContain('lookAheadMinutes: 0');
+    expect(testConnection).not.toContain('last_sync_at');
+  });
+
+  it('registers a config-backed three-minute non-overlapping Temporal schedule', () => {
+    const schedules = readRepoFile(
+      'ee/temporal-workflows/src/schedules/setupSchedules.ts'
+    );
+
+    expect(schedules).toContain("const pollingScheduleId = 'email-polling-reconcile-schedule'");
+    expect(schedules).toContain('process.env.MICROSOFT_EMAIL_POLLING_INTERVAL_MINUTES || 3');
+    expect(schedules).toContain('ScheduleOverlapPolicy.SKIP');
+  });
+});

--- a/shared/interfaces/inbound-email.interfaces.ts
+++ b/shared/interfaces/inbound-email.interfaces.ts
@@ -14,6 +14,10 @@ export interface EmailProviderConfig {
   webhook_verification_token?: string;
   webhook_expires_at?: string; // ISO date
   last_subscription_renewal?: string; // ISO date
+  delivery_mode?: 'webhook' | 'polling';
+  last_webhook_delivery_at?: string;
+  webhook_silent_runs?: number;
+  next_subscription_probe_at?: string;
   // Connection status fields
   connection_status: 'connected' | 'disconnected' | 'error';
   last_connection_test?: string; // ISO date

--- a/shared/services/email/EmailWebhookMaintenanceService.ts
+++ b/shared/services/email/EmailWebhookMaintenanceService.ts
@@ -511,16 +511,16 @@ export class EmailWebhookMaintenanceService {
   ): Promise<ReconciliationResult> {
     const knex = await getAdminConnection();
     const db = tenantDb(knex, config.tenant);
-    const provider = await db.table('email_providers')
-      .where({ id: config.id })
+    const reconciliationState = await db.table('microsoft_email_provider_config')
+      .where({ email_provider_id: config.id })
       .first(
-        'last_sync_at',
-        knex.raw('last_sync_at::text as last_sync_cursor')
+        'last_reconciliation_at',
+        knex.raw('last_reconciliation_at::text as last_reconciliation_cursor')
       );
-    const lastSyncMs = provider?.last_sync_at
-      ? new Date(provider.last_sync_at).getTime() - RECONCILE_SAFETY_MARGIN_MS
+    const lastReconciliationMs = reconciliationState?.last_reconciliation_at
+      ? new Date(reconciliationState.last_reconciliation_at).getTime() - RECONCILE_SAFETY_MARGIN_MS
       : Date.now() - RECONCILE_WINDOW_CAP_MS;
-    const since = new Date(Math.max(lastSyncMs, Date.now() - RECONCILE_WINDOW_CAP_MS));
+    const since = new Date(Math.max(lastReconciliationMs, Date.now() - RECONCILE_WINDOW_CAP_MS));
     const maxCount = Math.max(
       1,
       Number(config.provider_config?.max_emails_per_sync || DEFAULT_RECONCILE_MAX_MESSAGES)
@@ -537,23 +537,24 @@ export class EmailWebhookMaintenanceService {
       unprocessedMessages = messages.filter((message) => !processed.has(message.id));
     }
 
-    const previousSyncMs = provider?.last_sync_at
-      ? new Date(provider.last_sync_at).getTime()
+    const previousReconciliationMs = reconciliationState?.last_reconciliation_at
+      ? new Date(reconciliationState.last_reconciliation_at).getTime()
       : null;
     const completedAt = new Date().toISOString();
     const completedAtMs = new Date(completedAt).getTime();
     const enqueueResult = await knex.transaction(async (trx) => {
       const transactionDb = tenantDb(trx, config.tenant);
-      const lockedProvider = await transactionDb.table('email_providers')
-        .where({ id: config.id })
+      const lockedState = await transactionDb.table('microsoft_email_provider_config')
+        .where({ email_provider_id: config.id })
         .forUpdate()
-        .first(trx.raw('last_sync_at::text as last_sync_cursor'));
-      const observedCursor = provider?.last_sync_cursor || null;
-      const lockedCursor = lockedProvider?.last_sync_cursor || null;
+        .first(trx.raw('last_reconciliation_at::text as last_reconciliation_cursor'));
+      const observedCursor = reconciliationState?.last_reconciliation_cursor || null;
+      const lockedCursor = lockedState?.last_reconciliation_cursor || null;
 
-      // Serialize runners that observed the same window, but do not commit the
-      // cursor claim until every queue write succeeds. An enqueue exception
-      // rolls this transaction back so the same window remains retryable.
+      // This cursor belongs only to Graph reconciliation. Queue consumers also
+      // advance email_providers.last_sync_at after ingestion, so that timestamp
+      // cannot safely claim a polling window. Commit this dedicated cursor only
+      // after every queue write succeeds so enqueue failures remain retryable.
       if (lockedCursor !== observedCursor) {
         return { claimed: false as const, queuedMessages: 0, silenceEvidenceCount: 0 };
       }
@@ -580,16 +581,16 @@ export class EmailWebhookMaintenanceService {
         if (
           Number.isFinite(receivedAtMs) &&
           receivedAtMs <= completedAtMs &&
-          (previousSyncMs === null || receivedAtMs > previousSyncMs)
+          (previousReconciliationMs === null || receivedAtMs > previousReconciliationMs)
         ) {
           silenceEvidenceMessageIds.add(message.id);
         }
       }
 
-      await transactionDb.table('email_providers')
-        .where({ id: config.id })
+      await transactionDb.table('microsoft_email_provider_config')
+        .where({ email_provider_id: config.id })
         .update({
-          last_sync_at: completedAt,
+          last_reconciliation_at: completedAt,
           updated_at: completedAt,
         });
 
@@ -604,7 +605,7 @@ export class EmailWebhookMaintenanceService {
       logger.info('Skipped an already-claimed Microsoft reconciliation window', {
         providerId: config.id,
         tenant: config.tenant,
-        observedLastSyncAt: provider?.last_sync_at || null,
+        observedLastReconciliationAt: reconciliationState?.last_reconciliation_at || null,
       });
       return { queuedMessages: 0, switchedToPolling: false };
     }
@@ -618,10 +619,10 @@ export class EmailWebhookMaintenanceService {
     const silenceUpdate = db.table('microsoft_email_provider_config')
       .where({ email_provider_id: config.id })
       .andWhere('delivery_mode', 'webhook');
-    if (provider?.last_sync_at) {
+    if (reconciliationState?.last_reconciliation_at) {
       silenceUpdate.andWhere((query: any) => {
         query.whereNull('last_webhook_delivery_at')
-          .orWhere('last_webhook_delivery_at', '<=', provider.last_sync_at);
+          .orWhere('last_webhook_delivery_at', '<=', reconciliationState.last_reconciliation_at);
       });
     } else {
       silenceUpdate.whereNull('last_webhook_delivery_at');
@@ -649,10 +650,10 @@ export class EmailWebhookMaintenanceService {
       .where({ email_provider_id: config.id })
       .andWhere('delivery_mode', 'webhook')
       .andWhere('webhook_silent_runs', silentRuns);
-    if (provider?.last_sync_at) {
+    if (reconciliationState?.last_reconciliation_at) {
       pollingTransition.andWhere((query: any) => {
         query.whereNull('last_webhook_delivery_at')
-          .orWhere('last_webhook_delivery_at', '<=', provider.last_sync_at);
+          .orWhere('last_webhook_delivery_at', '<=', reconciliationState.last_reconciliation_at);
       });
     } else {
       pollingTransition.whereNull('last_webhook_delivery_at');

--- a/shared/services/email/EmailWebhookMaintenanceService.ts
+++ b/shared/services/email/EmailWebhookMaintenanceService.ts
@@ -23,10 +23,17 @@ interface RenewalResult {
   error?: string;
 }
 
+interface ReconciliationResult {
+  queuedMessages: number;
+  switchedToPolling: boolean;
+}
+
 const TOKEN_REFRESH_LOOK_AHEAD_MINUTES = 30;
 const RECONCILE_WINDOW_CAP_MS = 7 * 24 * 60 * 60 * 1000;
 const RECONCILE_SAFETY_MARGIN_MS = 15 * 60 * 1000;
 const DEFAULT_RECONCILE_MAX_MESSAGES = 50;
+const WEBHOOK_SILENT_RUN_THRESHOLD = 3;
+const SUBSCRIPTION_PROBE_INTERVAL_MS = 24 * 60 * 60 * 1000;
 
 export class EmailWebhookMaintenanceService {
   
@@ -70,12 +77,114 @@ export class EmailWebhookMaintenanceService {
     }
   }
 
+  /** Reconcile only providers explicitly operating without webhooks. */
+  async reconcilePollingProviders(options: Pick<RenewalOptions, 'tenantId' | 'providerId'> = {}): Promise<RenewalResult[]> {
+    const candidates = await this.findActiveMicrosoftProviders(
+      options.tenantId,
+      options.providerId,
+      'polling'
+    );
+    const results: RenewalResult[] = [];
+
+    for (const candidate of candidates) {
+      try {
+        const resolvedConfig = await buildMicrosoftEmailProviderConfig(candidate);
+        const adapter = new MicrosoftGraphAdapter(resolvedConfig);
+        await adapter.ensureTokenHealthy(TOKEN_REFRESH_LOOK_AHEAD_MINUTES);
+        await this.updateProviderConnectionStatus(candidate.id, candidate.tenant, 'connected', null);
+        await this.reconcileMissedMessages(adapter, resolvedConfig, false);
+        results.push({
+          providerId: candidate.id,
+          tenant: candidate.tenant,
+          success: true,
+          action: 'skipped',
+        });
+      } catch (error: any) {
+        const message = error?.message || 'Microsoft polling reconciliation failed';
+        await this.updateProviderConnectionStatus(candidate.id, candidate.tenant, 'error', message);
+        logger.error('Microsoft polling reconciliation failed', {
+          providerId: candidate.id,
+          tenant: candidate.tenant,
+          error: message,
+        });
+        results.push({
+          providerId: candidate.id,
+          tenant: candidate.tenant,
+          success: false,
+          action: 'failed',
+          error: message,
+        });
+      }
+    }
+
+    return results;
+  }
+
+  async usePollingDelivery(params: {
+    providerId: string;
+    tenant: string;
+    reason: string;
+    probeFailure?: boolean;
+  }): Promise<string> {
+    const knex = await getAdminConnection();
+    const nextProbeAt = new Date(Date.now() + SUBSCRIPTION_PROBE_INTERVAL_MS).toISOString();
+    await tenantDb(knex, params.tenant).table('microsoft_email_provider_config')
+      .where({ email_provider_id: params.providerId })
+      .update({
+        delivery_mode: 'polling',
+        webhook_subscription_id: null,
+        webhook_expires_at: null,
+        webhook_silent_runs: 0,
+        next_subscription_probe_at: nextProbeAt,
+        updated_at: new Date().toISOString(),
+      });
+    await this.updateProviderConnectionStatus(params.providerId, params.tenant, 'connected', null);
+    await this.updateHealthStatus(params.providerId, params.tenant, {
+      subscription_status: 'polling',
+      last_renewal_result: params.probeFailure ? 'probe_validation_failed' : 'polling_enabled',
+      failure_reason: params.reason,
+      is_healthy: true,
+    });
+    logger.info('Microsoft email delivery mode is polling', {
+      providerId: params.providerId,
+      tenant: params.tenant,
+      reason: params.reason,
+      nextProbeAt,
+    });
+    return nextProbeAt;
+  }
+
+  async recordWebhookDeliveryMode(params: {
+    providerId: string;
+    tenant: string;
+    reason: string;
+  }): Promise<void> {
+    const knex = await getAdminConnection();
+    await tenantDb(knex, params.tenant).table('microsoft_email_provider_config')
+      .where({ email_provider_id: params.providerId })
+      .update({
+        delivery_mode: 'webhook',
+        webhook_silent_runs: 0,
+        next_subscription_probe_at: null,
+        updated_at: new Date().toISOString(),
+      });
+    await this.updateProviderConnectionStatus(params.providerId, params.tenant, 'connected', null);
+    await this.updateHealthStatus(params.providerId, params.tenant, {
+      subscription_status: 'healthy',
+      last_renewal_result: 'webhook_enabled',
+      failure_reason: null,
+      is_healthy: true,
+    });
+    logger.info('Microsoft email delivery mode changed to webhook', params);
+  }
+
   /**
    * Find providers that need renewal
    */
   private async findActiveMicrosoftProviders(
     tenantId?: string,
-    providerId?: string
+    providerId?: string,
+    deliveryMode?: 'webhook' | 'polling'
   ): Promise<EmailProviderConfig[]> {
     const knex = await getAdminConnection();
 
@@ -113,6 +222,9 @@ export class EmailWebhookMaintenanceService {
     if (providerId) {
       query = query.andWhere('ep.id', providerId);
     }
+    if (deliveryMode) {
+      query = query.andWhere('mpc.delivery_mode', deliveryMode);
+    }
 
     // Select all columns needed to construct EmailProviderConfig
     const rows = await query.select(
@@ -131,6 +243,10 @@ export class EmailWebhookMaintenanceService {
       'mpc.webhook_verification_token',
       'mpc.webhook_expires_at',
       'mpc.last_subscription_renewal',
+      'mpc.delivery_mode',
+      'mpc.last_webhook_delivery_at',
+      'mpc.webhook_silent_runs',
+      'mpc.next_subscription_probe_at',
       // Select all vendor config columns as an object if possible, or spread them
       // For simplicity, we'll select the raw columns and map them manually as needed by the adapter
       'mpc.client_id',
@@ -175,12 +291,38 @@ export class EmailWebhookMaintenanceService {
           subscription_status: 'error',
           last_renewal_result: 'failure',
           failure_reason: message,
+          is_healthy: false,
         });
         throw error;
       }
 
+      const deliveryMode = config.delivery_mode ||
+        (config.webhook_subscription_id ? 'webhook' : 'polling');
+      if (deliveryMode === 'polling') {
+        const probeAt = config.next_subscription_probe_at
+          ? new Date(config.next_subscription_probe_at).getTime()
+          : 0;
+        if (forceRenewal || probeAt <= Date.now()) {
+          return await this.probeSubscription(adapter, config);
+        }
+        return {
+          providerId: config.id,
+          tenant: config.tenant,
+          success: true,
+          action: 'skipped',
+        };
+      }
+
       await adapter.cleanupOrphanedSubscriptions();
-      await this.reconcileMissedMessages(adapter, resolvedConfig);
+      const reconciliation = await this.reconcileMissedMessages(adapter, resolvedConfig, true);
+      if (reconciliation.switchedToPolling) {
+        return {
+          providerId: config.id,
+          tenant: config.tenant,
+          success: true,
+          action: 'skipped',
+        };
+      }
 
       const expiryMs = config.webhook_expires_at
         ? new Date(config.webhook_expires_at).getTime()
@@ -210,7 +352,8 @@ export class EmailWebhookMaintenanceService {
         await this.updateHealthStatus(config.id, config.tenant, {
           subscription_status: 'healthy',
           last_renewal_result: 'success',
-          failure_reason: null
+          failure_reason: null,
+          is_healthy: true,
         });
 
         return {
@@ -241,7 +384,8 @@ export class EmailWebhookMaintenanceService {
       await this.updateHealthStatus(config.id, config.tenant, {
         subscription_status: 'error',
         last_renewal_result: 'failure',
-        failure_reason: error.message
+        failure_reason: error.message,
+        is_healthy: false,
       });
 
       return {
@@ -268,7 +412,7 @@ export class EmailWebhookMaintenanceService {
     if (config.webhook_notification_url.includes('localhost') || !config.webhook_notification_url.startsWith('https://')) {
       const msg = `Invalid webhook URL detected: ${config.webhook_notification_url}. Microsoft requires a public HTTPS endpoint. Check APPLICATION_URL env var.`;
       logger.error(msg, { providerId: config.id, tenant: config.tenant });
-      throw new Error(msg);
+      return this.enterPollingMode(config, msg);
     }
 
     logger.info(`Attempting to recreate subscription with URL: ${config.webhook_notification_url}`, { 
@@ -279,13 +423,17 @@ export class EmailWebhookMaintenanceService {
     const result = await adapter.initializeWebhook(config.webhook_notification_url);
     
     if (!result.success) {
+      if (result.errorKind === 'validation') {
+        return this.enterPollingMode(config, result.error || 'Microsoft webhook endpoint validation failed');
+      }
       throw new Error(result.error || 'Failed to initialize webhook');
     }
 
     await this.updateHealthStatus(config.id, config.tenant, {
       subscription_status: 'healthy',
       last_renewal_result: 'success',
-      failure_reason: null
+      failure_reason: null,
+      is_healthy: true,
     });
 
     return {
@@ -297,10 +445,70 @@ export class EmailWebhookMaintenanceService {
     };
   }
 
-  private async reconcileMissedMessages(
+  private async probeSubscription(
     adapter: MicrosoftGraphAdapter,
     config: EmailProviderConfig
-  ): Promise<void> {
+  ): Promise<RenewalResult> {
+    if (!config.webhook_notification_url ||
+        config.webhook_notification_url.includes('localhost') ||
+        !config.webhook_notification_url.startsWith('https://')) {
+      return this.enterPollingMode(
+        config,
+        'Microsoft webhook endpoint is not a public HTTPS URL',
+        true
+      );
+    }
+
+    const result = await adapter.initializeWebhook(config.webhook_notification_url);
+    if (result.success) {
+      await this.recordWebhookDeliveryMode({
+        providerId: config.id,
+        tenant: config.tenant,
+        reason: 'subscription probe succeeded',
+      });
+      return {
+        providerId: config.id,
+        tenant: config.tenant,
+        success: true,
+        action: 'recreated',
+        newExpiration: adapter.getConfig().webhook_expires_at,
+      };
+    }
+
+    if (result.errorKind === 'validation') {
+      return this.enterPollingMode(
+        config,
+        result.error || 'Microsoft webhook endpoint validation failed',
+        true
+      );
+    }
+    throw new Error(result.error || 'Microsoft subscription recovery probe failed');
+  }
+
+  private async enterPollingMode(
+    config: EmailProviderConfig,
+    reason: string,
+    probeFailure = false
+  ): Promise<RenewalResult> {
+    await this.usePollingDelivery({
+      providerId: config.id,
+      tenant: config.tenant,
+      reason,
+      probeFailure,
+    });
+    return {
+      providerId: config.id,
+      tenant: config.tenant,
+      success: true,
+      action: 'skipped',
+    };
+  }
+
+  private async reconcileMissedMessages(
+    adapter: MicrosoftGraphAdapter,
+    config: EmailProviderConfig,
+    detectWebhookSilence: boolean
+  ): Promise<ReconciliationResult> {
     const knex = await getAdminConnection();
     const db = tenantDb(knex, config.tenant);
     const provider = await db.table('email_providers')
@@ -315,6 +523,7 @@ export class EmailWebhookMaintenanceService {
       Number(config.provider_config?.max_emails_per_sync || DEFAULT_RECONCILE_MAX_MESSAGES)
     );
     const messages = await adapter.listMessagesReceivedSince(since, maxCount);
+    let queuedMessages = 0;
 
     if (messages.length > 0) {
       const processedRows = await db.table('email_processed_messages')
@@ -335,13 +544,46 @@ export class EmailWebhookMaintenanceService {
             changeType: 'created',
           },
         });
+        queuedMessages += 1;
       }
     }
 
+    const completedAt = new Date().toISOString();
     await db.table('email_providers').where({ id: config.id }).update({
-      last_sync_at: new Date().toISOString(),
-      updated_at: new Date().toISOString(),
+      last_sync_at: completedAt,
+      updated_at: completedAt,
     });
+
+    if (!detectWebhookSilence || queuedMessages === 0) {
+      return { queuedMessages, switchedToPolling: false };
+    }
+
+    const latestMicrosoftConfig = await db.table('microsoft_email_provider_config')
+      .where({ email_provider_id: config.id })
+      .first('last_webhook_delivery_at', 'webhook_silent_runs');
+    const previousSyncAt = provider?.last_sync_at ? new Date(provider.last_sync_at).getTime() : 0;
+    const webhookDeliveryAt = latestMicrosoftConfig?.last_webhook_delivery_at
+      ? new Date(latestMicrosoftConfig.last_webhook_delivery_at).getTime()
+      : 0;
+    if (webhookDeliveryAt > previousSyncAt) {
+      await db.table('microsoft_email_provider_config')
+        .where({ email_provider_id: config.id })
+        .update({ webhook_silent_runs: 0, updated_at: completedAt });
+      return { queuedMessages, switchedToPolling: false };
+    }
+
+    const silentRuns = Number(latestMicrosoftConfig?.webhook_silent_runs || 0) + 1;
+    await db.table('microsoft_email_provider_config')
+      .where({ email_provider_id: config.id })
+      .update({ webhook_silent_runs: silentRuns, updated_at: completedAt });
+    if (silentRuns < WEBHOOK_SILENT_RUN_THRESHOLD) {
+      return { queuedMessages, switchedToPolling: false };
+    }
+
+    await adapter.deleteWebhookSubscription();
+    const reason = `${silentRuns} reconciliation runs imported messages without a webhook delivery`;
+    await this.enterPollingMode(config, reason);
+    return { queuedMessages, switchedToPolling: true };
   }
 
   private async updateProviderConnectionStatus(
@@ -373,6 +615,7 @@ export class EmailWebhookMaintenanceService {
     subscription_status: string;
     last_renewal_result: string;
     failure_reason: string | null;
+    is_healthy?: boolean;
   }): Promise<void> {
     try {
       const knex = await getAdminConnection();
@@ -445,6 +688,10 @@ export class EmailWebhookMaintenanceService {
       webhook_verification_token: row.webhook_verification_token,
       webhook_expires_at: row.webhook_expires_at,
       last_subscription_renewal: row.last_subscription_renewal,
+      delivery_mode: row.delivery_mode,
+      last_webhook_delivery_at: row.last_webhook_delivery_at,
+      webhook_silent_runs: row.webhook_silent_runs,
+      next_subscription_probe_at: row.next_subscription_probe_at,
       connection_status: row.status || 'connected',
       last_connection_test: row.last_sync_at,
       connection_error_message: row.error_message,

--- a/shared/services/email/EmailWebhookMaintenanceService.ts
+++ b/shared/services/email/EmailWebhookMaintenanceService.ts
@@ -537,25 +537,70 @@ export class EmailWebhookMaintenanceService {
       unprocessedMessages = messages.filter((message) => !processed.has(message.id));
     }
 
+    const previousSyncMs = provider?.last_sync_at
+      ? new Date(provider.last_sync_at).getTime()
+      : null;
     const completedAt = new Date().toISOString();
-    const cursorClaim = db.table('email_providers').where({ id: config.id });
-    if (provider?.last_sync_cursor) {
-      // Compare the exact PostgreSQL text value. The pg driver's Date parser
-      // truncates sub-millisecond precision, which would make a Date equality
-      // compare lose every claim for cursors written with microseconds.
-      cursorClaim.andWhereRaw('last_sync_at = ?::timestamptz', [provider.last_sync_cursor]);
-    } else {
-      cursorClaim.whereNull('last_sync_at');
-    }
-    const claimedRows = await cursorClaim.update({
-      last_sync_at: completedAt,
-      updated_at: completedAt,
+    const completedAtMs = new Date(completedAt).getTime();
+    const enqueueResult = await knex.transaction(async (trx) => {
+      const transactionDb = tenantDb(trx, config.tenant);
+      const lockedProvider = await transactionDb.table('email_providers')
+        .where({ id: config.id })
+        .forUpdate()
+        .first(trx.raw('last_sync_at::text as last_sync_cursor'));
+      const observedCursor = provider?.last_sync_cursor || null;
+      const lockedCursor = lockedProvider?.last_sync_cursor || null;
+
+      // Serialize runners that observed the same window, but do not commit the
+      // cursor claim until every queue write succeeds. An enqueue exception
+      // rolls this transaction back so the same window remains retryable.
+      if (lockedCursor !== observedCursor) {
+        return { claimed: false as const, queuedMessages: 0, silenceEvidenceCount: 0 };
+      }
+
+      let queuedMessages = 0;
+      const silenceEvidenceMessageIds = new Set<string>();
+      for (const message of unprocessedMessages) {
+        await enqueueUnifiedInboundEmailQueueJob({
+          tenantId: config.tenant,
+          providerId: config.id,
+          provider: 'microsoft',
+          pointer: {
+            subscriptionId: config.webhook_subscription_id || 'reconcile',
+            messageId: message.id,
+            resource: 'maintenance-reconcile',
+            changeType: 'created',
+          },
+        });
+        queuedMessages += 1;
+
+        const receivedAtMs = message.receivedDateTime
+          ? new Date(message.receivedDateTime).getTime()
+          : NaN;
+        if (
+          Number.isFinite(receivedAtMs) &&
+          receivedAtMs <= completedAtMs &&
+          (previousSyncMs === null || receivedAtMs > previousSyncMs)
+        ) {
+          silenceEvidenceMessageIds.add(message.id);
+        }
+      }
+
+      await transactionDb.table('email_providers')
+        .where({ id: config.id })
+        .update({
+          last_sync_at: completedAt,
+          updated_at: completedAt,
+        });
+
+      return {
+        claimed: true as const,
+        queuedMessages,
+        silenceEvidenceCount: silenceEvidenceMessageIds.size,
+      };
     });
 
-    // last_sync_at is the reconciliation-window claim. A retry or overlapping
-    // workflow that observed the same cursor loses this compare-and-set and
-    // must not enqueue the same window or count it as another silent run.
-    if (Number(claimedRows) !== 1) {
+    if (!enqueueResult.claimed) {
       logger.info('Skipped an already-claimed Microsoft reconciliation window', {
         providerId: config.id,
         tenant: config.tenant,
@@ -564,39 +609,9 @@ export class EmailWebhookMaintenanceService {
       return { queuedMessages: 0, switchedToPolling: false };
     }
 
-    let queuedMessages = 0;
-    const silenceEvidenceMessageIds = new Set<string>();
-    const previousSyncMs = provider?.last_sync_at
-      ? new Date(provider.last_sync_at).getTime()
-      : null;
-    const completedAtMs = new Date(completedAt).getTime();
-    for (const message of unprocessedMessages) {
-      await enqueueUnifiedInboundEmailQueueJob({
-        tenantId: config.tenant,
-        providerId: config.id,
-        provider: 'microsoft',
-        pointer: {
-          subscriptionId: config.webhook_subscription_id || 'reconcile',
-          messageId: message.id,
-          resource: 'maintenance-reconcile',
-          changeType: 'created',
-        },
-      });
-      queuedMessages += 1;
+    const { queuedMessages, silenceEvidenceCount } = enqueueResult;
 
-      const receivedAtMs = message.receivedDateTime
-        ? new Date(message.receivedDateTime).getTime()
-        : NaN;
-      if (
-        Number.isFinite(receivedAtMs) &&
-        receivedAtMs <= completedAtMs &&
-        (previousSyncMs === null || receivedAtMs > previousSyncMs)
-      ) {
-        silenceEvidenceMessageIds.add(message.id);
-      }
-    }
-
-    if (!detectWebhookSilence || silenceEvidenceMessageIds.size === 0) {
+    if (!detectWebhookSilence || silenceEvidenceCount === 0) {
       return { queuedMessages, switchedToPolling: false };
     }
 

--- a/shared/services/email/EmailWebhookMaintenanceService.ts
+++ b/shared/services/email/EmailWebhookMaintenanceService.ts
@@ -513,7 +513,10 @@ export class EmailWebhookMaintenanceService {
     const db = tenantDb(knex, config.tenant);
     const provider = await db.table('email_providers')
       .where({ id: config.id })
-      .first('last_sync_at');
+      .first(
+        'last_sync_at',
+        knex.raw('last_sync_at::text as last_sync_cursor')
+      );
     const lastSyncMs = provider?.last_sync_at
       ? new Date(provider.last_sync_at).getTime() - RECONCILE_SAFETY_MARGIN_MS
       : Date.now() - RECONCILE_WINDOW_CAP_MS;
@@ -523,7 +526,7 @@ export class EmailWebhookMaintenanceService {
       Number(config.provider_config?.max_emails_per_sync || DEFAULT_RECONCILE_MAX_MESSAGES)
     );
     const messages = await adapter.listMessagesReceivedSince(since, maxCount);
-    let queuedMessages = 0;
+    let unprocessedMessages = messages;
 
     if (messages.length > 0) {
       const processedRows = await db.table('email_processed_messages')
@@ -531,58 +534,154 @@ export class EmailWebhookMaintenanceService {
         .whereIn('message_id', messages.map((message) => message.id))
         .select('message_id');
       const processed = new Set(processedRows.map((row: any) => String(row.message_id)));
-      for (const message of messages) {
-        if (processed.has(message.id)) continue;
-        await enqueueUnifiedInboundEmailQueueJob({
-          tenantId: config.tenant,
-          providerId: config.id,
-          provider: 'microsoft',
-          pointer: {
-            subscriptionId: config.webhook_subscription_id || 'reconcile',
-            messageId: message.id,
-            resource: 'maintenance-reconcile',
-            changeType: 'created',
-          },
-        });
-        queuedMessages += 1;
-      }
+      unprocessedMessages = messages.filter((message) => !processed.has(message.id));
     }
 
     const completedAt = new Date().toISOString();
-    await db.table('email_providers').where({ id: config.id }).update({
+    const cursorClaim = db.table('email_providers').where({ id: config.id });
+    if (provider?.last_sync_cursor) {
+      // Compare the exact PostgreSQL text value. The pg driver's Date parser
+      // truncates sub-millisecond precision, which would make a Date equality
+      // compare lose every claim for cursors written with microseconds.
+      cursorClaim.andWhereRaw('last_sync_at = ?::timestamptz', [provider.last_sync_cursor]);
+    } else {
+      cursorClaim.whereNull('last_sync_at');
+    }
+    const claimedRows = await cursorClaim.update({
       last_sync_at: completedAt,
       updated_at: completedAt,
     });
 
-    if (!detectWebhookSilence || queuedMessages === 0) {
+    // last_sync_at is the reconciliation-window claim. A retry or overlapping
+    // workflow that observed the same cursor loses this compare-and-set and
+    // must not enqueue the same window or count it as another silent run.
+    if (Number(claimedRows) !== 1) {
+      logger.info('Skipped an already-claimed Microsoft reconciliation window', {
+        providerId: config.id,
+        tenant: config.tenant,
+        observedLastSyncAt: provider?.last_sync_at || null,
+      });
+      return { queuedMessages: 0, switchedToPolling: false };
+    }
+
+    let queuedMessages = 0;
+    const silenceEvidenceMessageIds = new Set<string>();
+    const previousSyncMs = provider?.last_sync_at
+      ? new Date(provider.last_sync_at).getTime()
+      : null;
+    const completedAtMs = new Date(completedAt).getTime();
+    for (const message of unprocessedMessages) {
+      await enqueueUnifiedInboundEmailQueueJob({
+        tenantId: config.tenant,
+        providerId: config.id,
+        provider: 'microsoft',
+        pointer: {
+          subscriptionId: config.webhook_subscription_id || 'reconcile',
+          messageId: message.id,
+          resource: 'maintenance-reconcile',
+          changeType: 'created',
+        },
+      });
+      queuedMessages += 1;
+
+      const receivedAtMs = message.receivedDateTime
+        ? new Date(message.receivedDateTime).getTime()
+        : NaN;
+      if (
+        Number.isFinite(receivedAtMs) &&
+        receivedAtMs <= completedAtMs &&
+        (previousSyncMs === null || receivedAtMs > previousSyncMs)
+      ) {
+        silenceEvidenceMessageIds.add(message.id);
+      }
+    }
+
+    if (!detectWebhookSilence || silenceEvidenceMessageIds.size === 0) {
       return { queuedMessages, switchedToPolling: false };
     }
 
-    const latestMicrosoftConfig = await db.table('microsoft_email_provider_config')
+    const silenceUpdate = db.table('microsoft_email_provider_config')
       .where({ email_provider_id: config.id })
-      .first('last_webhook_delivery_at', 'webhook_silent_runs');
-    const previousSyncAt = provider?.last_sync_at ? new Date(provider.last_sync_at).getTime() : 0;
-    const webhookDeliveryAt = latestMicrosoftConfig?.last_webhook_delivery_at
-      ? new Date(latestMicrosoftConfig.last_webhook_delivery_at).getTime()
-      : 0;
-    if (webhookDeliveryAt > previousSyncAt) {
-      await db.table('microsoft_email_provider_config')
-        .where({ email_provider_id: config.id })
-        .update({ webhook_silent_runs: 0, updated_at: completedAt });
-      return { queuedMessages, switchedToPolling: false };
+      .andWhere('delivery_mode', 'webhook');
+    if (provider?.last_sync_at) {
+      silenceUpdate.andWhere((query: any) => {
+        query.whereNull('last_webhook_delivery_at')
+          .orWhere('last_webhook_delivery_at', '<=', provider.last_sync_at);
+      });
+    } else {
+      silenceUpdate.whereNull('last_webhook_delivery_at');
     }
 
-    const silentRuns = Number(latestMicrosoftConfig?.webhook_silent_runs || 0) + 1;
-    await db.table('microsoft_email_provider_config')
+    // Increment in SQL so a webhook's atomic reset cannot be overwritten by a
+    // stale read. The timestamp predicate makes an interceding delivery win.
+    const updatedSilenceRows = await silenceUpdate.update({
+      webhook_silent_runs: knex.raw('webhook_silent_runs + 1'),
+      updated_at: completedAt,
+    });
+    if (Number(updatedSilenceRows) !== 1) {
+      return { queuedMessages, switchedToPolling: false };
+    }
+    const latestSilenceState = await db.table('microsoft_email_provider_config')
       .where({ email_provider_id: config.id })
-      .update({ webhook_silent_runs: silentRuns, updated_at: completedAt });
+      .first('webhook_silent_runs');
+    const silentRuns = Number(latestSilenceState?.webhook_silent_runs || 0);
     if (silentRuns < WEBHOOK_SILENT_RUN_THRESHOLD) {
       return { queuedMessages, switchedToPolling: false };
     }
 
-    await adapter.deleteWebhookSubscription();
+    const nextProbeAt = new Date(Date.now() + SUBSCRIPTION_PROBE_INTERVAL_MS).toISOString();
+    const pollingTransition = db.table('microsoft_email_provider_config')
+      .where({ email_provider_id: config.id })
+      .andWhere('delivery_mode', 'webhook')
+      .andWhere('webhook_silent_runs', silentRuns);
+    if (provider?.last_sync_at) {
+      pollingTransition.andWhere((query: any) => {
+        query.whereNull('last_webhook_delivery_at')
+          .orWhere('last_webhook_delivery_at', '<=', provider.last_sync_at);
+      });
+    } else {
+      pollingTransition.whereNull('last_webhook_delivery_at');
+    }
+    const transitionedRows = await pollingTransition.update({
+      delivery_mode: 'polling',
+      webhook_subscription_id: null,
+      webhook_expires_at: null,
+      webhook_silent_runs: 0,
+      next_subscription_probe_at: nextProbeAt,
+      updated_at: completedAt,
+    });
+    if (Number(transitionedRows) !== 1) {
+      // A webhook reset or another mode transition won the race after the
+      // increment. Never delete the subscription from stale state.
+      return { queuedMessages, switchedToPolling: false };
+    }
+
     const reason = `${silentRuns} reconciliation runs imported messages without a webhook delivery`;
-    await this.enterPollingMode(config, reason);
+    try {
+      await adapter.deleteWebhookSubscription();
+    } catch (error: any) {
+      // The local subscription id is already cleared, so Graph can no longer
+      // route accepted notifications to this provider. Its remote expiry is a
+      // cleanup concern and must not make supported polling mode unhealthy.
+      logger.warn('Failed to delete silent Microsoft webhook subscription', {
+        providerId: config.id,
+        tenant: config.tenant,
+        error: error?.message || String(error),
+      });
+    }
+    await this.updateProviderConnectionStatus(config.id, config.tenant, 'connected', null);
+    await this.updateHealthStatus(config.id, config.tenant, {
+      subscription_status: 'polling',
+      last_renewal_result: 'polling_enabled',
+      failure_reason: reason,
+      is_healthy: true,
+    });
+    logger.info('Microsoft email delivery mode is polling', {
+      providerId: config.id,
+      tenant: config.tenant,
+      reason,
+      nextProbeAt,
+    });
     return { queuedMessages, switchedToPolling: true };
   }
 

--- a/shared/services/email/EmailWebhookMaintenanceService.ts
+++ b/shared/services/email/EmailWebhookMaintenanceService.ts
@@ -525,16 +525,36 @@ export class EmailWebhookMaintenanceService {
       1,
       Number(config.provider_config?.max_emails_per_sync || DEFAULT_RECONCILE_MAX_MESSAGES)
     );
-    const messages = await adapter.listMessagesReceivedSince(since, maxCount);
-    let unprocessedMessages = messages;
+    let fetchLimit = maxCount;
+    let messages: Array<{ id: string; receivedDateTime?: string }> = [];
+    let unprocessedMessages: Array<{ id: string; receivedDateTime?: string }> = [];
+    const processedMessageIds = new Set<string>();
+    const checkedMessageIds = new Set<string>();
 
-    if (messages.length > 0) {
-      const processedRows = await db.table('email_processed_messages')
-        .where({ provider_id: config.id })
-        .whereIn('message_id', messages.map((message) => message.id))
-        .select('message_id');
-      const processed = new Set(processedRows.map((row: any) => String(row.message_id)));
-      unprocessedMessages = messages.filter((message) => !processed.has(message.id));
+    // A capped oldest-first query can initially contain only messages from the
+    // safety-margin overlap. Expand the read until either maxCount unprocessed
+    // messages are visible or Graph is exhausted; otherwise the same processed
+    // boundary batch could permanently hide newer overflow messages.
+    while (true) {
+      messages = await adapter.listMessagesReceivedSince(since, fetchLimit);
+      const uncheckedMessageIds = messages
+        .map((message) => message.id)
+        .filter((messageId) => !checkedMessageIds.has(messageId));
+
+      if (uncheckedMessageIds.length > 0) {
+        const processedRows = await db.table('email_processed_messages')
+          .where({ provider_id: config.id })
+          .whereIn('message_id', uncheckedMessageIds)
+          .select('message_id');
+        for (const messageId of uncheckedMessageIds) checkedMessageIds.add(messageId);
+        for (const row of processedRows) processedMessageIds.add(String(row.message_id));
+      }
+
+      unprocessedMessages = messages
+        .filter((message) => !processedMessageIds.has(message.id))
+        .slice(0, maxCount);
+      if (unprocessedMessages.length >= maxCount || messages.length < fetchLimit) break;
+      fetchLimit *= 2;
     }
 
     const previousReconciliationMs = reconciliationState?.last_reconciliation_at
@@ -542,6 +562,24 @@ export class EmailWebhookMaintenanceService {
       : null;
     const completedAt = new Date().toISOString();
     const completedAtMs = new Date(completedAt).getTime();
+    const graphBatchMayHaveOverflow = unprocessedMessages.length >= maxCount && messages.length >= fetchLimit;
+    let nextReconciliationAt = completedAt;
+    if (graphBatchMayHaveOverflow) {
+      const newestQueuedAtMs = Math.max(...unprocessedMessages.map((message) => {
+        const receivedAtMs = message.receivedDateTime
+          ? new Date(message.receivedDateTime).getTime()
+          : NaN;
+        return receivedAtMs;
+      }));
+      if (!Number.isFinite(newestQueuedAtMs)) {
+        throw new Error('Cannot safely advance a capped Microsoft reconciliation batch without receivedDateTime');
+      }
+
+      // Keep the cursor at the newest queued message. The next query's safety
+      // margin may replay this batch, but the processed-message expansion above
+      // lets it reach overflow without ever advancing past unfetched mail.
+      nextReconciliationAt = new Date(newestQueuedAtMs).toISOString();
+    }
     const enqueueResult = await knex.transaction(async (trx) => {
       const transactionDb = tenantDb(trx, config.tenant);
       const lockedState = await transactionDb.table('microsoft_email_provider_config')
@@ -590,7 +628,7 @@ export class EmailWebhookMaintenanceService {
       await transactionDb.table('microsoft_email_provider_config')
         .where({ email_provider_id: config.id })
         .update({
-          last_reconciliation_at: completedAt,
+          last_reconciliation_at: nextReconciliationAt,
           updated_at: completedAt,
         });
 

--- a/shared/services/email/providers/MicrosoftGraphAdapter.ts
+++ b/shared/services/email/providers/MicrosoftGraphAdapter.ts
@@ -13,6 +13,54 @@ import { getAdminConnection } from '../../../db/admin';
 import { tenantDb } from '@alga-psa/db';
 import { getMicrosoftGraphBaseUrl, getMicrosoftTokenUrl } from '../microsoftGraphEndpoints';
 
+export type MicrosoftSubscriptionErrorKind = 'validation' | 'authentication' | 'other';
+
+export class MicrosoftSubscriptionError extends Error {
+  constructor(
+    message: string,
+    public readonly kind: MicrosoftSubscriptionErrorKind,
+    public readonly status?: number,
+    public readonly code?: string,
+    options?: { cause?: unknown }
+  ) {
+    super(message, options);
+    this.name = 'MicrosoftSubscriptionError';
+  }
+}
+
+export interface MicrosoftWebhookInitializationResult {
+  success: boolean;
+  subscriptionId?: string;
+  error?: string;
+  errorKind?: MicrosoftSubscriptionErrorKind;
+}
+
+function classifySubscriptionError(error: any): MicrosoftSubscriptionErrorKind {
+  const status = error?.response?.status ?? error?.status;
+  const code = String(error?.response?.data?.error?.code ?? error?.code ?? '');
+  const message = String(
+    error?.response?.data?.error?.message ?? error?.message ?? error ?? ''
+  ).toLowerCase();
+
+  if (status === 401 || status === 403 || code === 'ErrorAccessDenied') {
+    return 'authentication';
+  }
+
+  if (
+    code === 'ValidationError' ||
+    code === 'ECONNABORTED' ||
+    message.includes('validation') ||
+    message.includes('notification url') ||
+    message.includes('notificationurl') ||
+    message.includes('validation token') ||
+    message.includes('endpoint') && message.includes('respond')
+  ) {
+    return 'validation';
+  }
+
+  return 'other';
+}
+
 /**
  * Microsoft Graph API adapter for email processing
  * Handles OAuth authentication, webhook subscriptions, and message retrieval
@@ -479,6 +527,9 @@ export class MicrosoftGraphAdapter extends BaseEmailAdapter {
             webhook_subscription_id: response.data.id,
             webhook_expires_at: response.data.expirationDateTime,
             webhook_verification_token: this.config.webhook_verification_token || null,
+            delivery_mode: 'webhook',
+            webhook_silent_runs: 0,
+            next_subscription_probe_at: null,
             updated_at: new Date().toISOString(),
           });
       } catch (dbErr: any) {
@@ -497,7 +548,13 @@ export class MicrosoftGraphAdapter extends BaseEmailAdapter {
         requestId: (enriched as any).requestId,
         responseBody: (enriched as any).responseBody,
       });
-      throw enriched;
+      throw new MicrosoftSubscriptionError(
+        enriched.message,
+        classifySubscriptionError(error),
+        (enriched as any).status,
+        String((enriched as any).code || ''),
+        { cause: error }
+      );
     }
   }
 
@@ -1314,10 +1371,23 @@ export class MicrosoftGraphAdapter extends BaseEmailAdapter {
     }
   }
 
+  async deleteWebhookSubscription(): Promise<void> {
+    const subscriptionId = this.config.webhook_subscription_id;
+    if (!subscriptionId) return;
+
+    try {
+      await this.httpClient.delete(`/subscriptions/${encodeURIComponent(subscriptionId)}`);
+    } catch (error: any) {
+      if (error?.response?.status !== 404) {
+        throw this.handleError(error, 'deleteWebhookSubscription');
+      }
+    }
+  }
+
   /**
    * Initialize webhook subscription for email notifications
    */
-  async initializeWebhook(webhookUrl: string): Promise<{ success: boolean; subscriptionId?: string; error?: string }> {
+  async initializeWebhook(webhookUrl: string): Promise<MicrosoftWebhookInitializationResult> {
     try {
       this.log('info', `Initializing webhook subscription to ${webhookUrl}`);
       this.config.webhook_notification_url = webhookUrl;
@@ -1325,7 +1395,9 @@ export class MicrosoftGraphAdapter extends BaseEmailAdapter {
       return { success: true, subscriptionId: this.config.webhook_subscription_id };
     } catch (error) {
       // Enrich/log details (status, request-id, body) before throwing
-      const enriched = this.handleError(error, 'initializeWebhook');
+      const enriched = error instanceof MicrosoftSubscriptionError
+        ? error
+        : this.handleError(error, 'initializeWebhook');
       this.log('error', 'Subscription creation failed (initializeWebhook)', {
         message: enriched.message,
         context: 'initializeWebhook',
@@ -1335,7 +1407,11 @@ export class MicrosoftGraphAdapter extends BaseEmailAdapter {
         responseBody: (enriched as any).responseBody,
       });
       // Return error info instead of throwing to satisfy return type
-      return { success: false, error: enriched.message };
+      return {
+        success: false,
+        error: enriched.message,
+        errorKind: error instanceof MicrosoftSubscriptionError ? error.kind : 'other',
+      };
     }
   }
 


### PR DESCRIPTION
## Summary

- Allow enterprise Microsoft inbound email providers to fall back to a dedicated 3-minute polling schedule when Graph cannot validate a public webhook, while continuing to probe for webhook recovery.
- Persist delivery-mode, webhook-health, and reconciliation-cursor state; surface the current mode and health in the provider UI; and keep unified queue consumers exclusively responsible for advancing `email_providers.last_sync_at` after ingestion.
- Make reconciliation concurrency- and retry-safe by row-locking and rechecking the observed cursor, enqueueing before committing it, and leaving failed windows retryable.
- Preserve capped oldest-first Graph overflow: when a fetch reaches the configured cap, hold the cursor at the newest queued message, expand subsequent reads past already-processed overlap rows, and enqueue equal-timestamp overflow without duplicating processed mail.
- Add focused unit, integration, contract, migration, localization, documentation, and verification coverage.

## Smoke test

**PASS.** Verified the enterprise product on port 3264 with wired PostgreSQL and Redis. The repo's Graph emulator supplied three oldest-first messages with a two-message cap. Cycle 1 queued the oldest and boundary messages and held the reconciliation cursor at the boundary. After marking those processed, cycle 2 expanded the fetch and queued the equal-timestamp overflow exactly once despite it being 150 minutes old; processed overlap was not re-enqueued. The authenticated UI showed the provider as Connected, Active, and “Polling every 3 minutes.” The adjacent Microsoft 365 provider setup dialog also opened correctly.

### Fidelity compromises

Microsoft Graph was replaced by the existing repository emulator, and reconciliation was invoked directly because Temporal is unavailable in this stack. The required alga-dev card browser was attempted first but rejected due to the known cross-host pane restriction, so system Chrome via Playwright drove the same real application instead. Backend overflow assertions are recorded as DB/Redis text evidence because the cursor and queue are not exposed in the UI.

### Concern

Extremely large processed-overlap windows were not load-tested; they can intentionally cause additional doubling Graph reads.

Test data, Redis queue, emulator process, and temporary harness files were cleaned up. The application still returns HTTP 200 and infrastructure containers remain healthy. The pre-existing `package.json` modification remains untouched.

Evidence: `/tmp/alga-smoke-evidence/improve-premise-microsoft-polling-20260722-085516`
