### PR TITLE
Xero permission breakage

### DIFF
--- a/docs/plans/2026-07-22-xero-permission-breakage-plan.md
+++ b/docs/plans/2026-07-22-xero-permission-breakage-plan.md
@@ -1,0 +1,111 @@
+# Plan: Replace retired Xero `accounting.transactions` scope with granular scopes
+
+**Date:** 2026-07-22
+**Branch:** `fix/xero-permission-breakage`
+
+## Problem
+
+The Xero integration's OAuth authorization request includes the retired
+`accounting.transactions` scope. Xero apps created after 2026-03-02 reject that
+scope with `invalid_scope` before organization selection, so new integrations
+cannot connect. Existing apps hit the same wall at Xero's legacy-scope cutoff in
+September 2027.
+
+## Approach
+
+Single-constant change. `DEFAULT_XERO_SCOPES` in
+`packages/integrations/src/lib/xero/xeroClientService.ts` is the one source of
+truth for the integration's requested scopes; every authorization request
+(server actions `xeroActions.ts:159,361`, connect route
+`routes/api/integrations/xero/connect.ts:107`) and the settings UI scope display
+derive from it via `getXeroOAuthScopes()` / `getXeroOAuthScopesString()`. The
+`XERO_OAUTH_SCOPES` env override takes precedence verbatim and stays untouched.
+
+Alternatives rejected:
+
+- **Per-tenant/app scope configuration** — over-engineering; the env override
+  already covers outliers (YAGNI).
+- **Compatibility shim requesting old + new scopes** — harmful; new Xero apps
+  reject the whole request with `invalid_scope` when the retired scope is
+  present.
+
+## Change
+
+`packages/integrations/src/lib/xero/xeroClientService.ts:19-24` — replace
+`'accounting.transactions'` in `DEFAULT_XERO_SCOPES` with the granular
+replacements:
+
+```ts
+const DEFAULT_XERO_SCOPES = [
+  'offline_access',
+  'accounting.settings',
+  'accounting.invoices',
+  'accounting.banktransactions',
+  'accounting.payments',
+  'accounting.contacts'
+];
+```
+
+Retained: `offline_access`, `accounting.settings`, `accounting.contacts`.
+Added: `accounting.invoices`, `accounting.banktransactions`,
+`accounting.payments`.
+
+Scope-to-endpoint rationale: the integration currently calls `/Invoices`,
+`/Contacts`, `/Accounts`, `/Items`, `/TaxRates`, `/TrackingCategories`
+(covered by `accounting.invoices` + `accounting.settings` +
+`accounting.contacts`); `accounting.banktransactions` and
+`accounting.payments` are forward-cover for the integration's banking and
+payment operations, included now so future support doesn't force re-auth.
+
+No other production code changes: the callback
+(`routes/api/integrations/xero/callback.ts:184-223`) stores whatever scope Xero
+grants back and performs no validation against the requested set.
+
+## Test updates (assertions only)
+
+1. **`packages/integrations/src/actions/integrations/xeroActions.test.ts`**
+   - Update the two expected-scope arrays (lines ~23-26, ~106-109) to the new
+     default set.
+   - Replace the `expect(result.scopes).toContain('accounting.transactions')`
+     assertion (line ~145) with expectations that the granular scopes are
+     present, and add a guard:
+     `expect(result.scopes).not.toContain('accounting.transactions')`.
+2. **`packages/integrations/src/components/settings/integrations/XeroIntegrationSettings.contract.test.tsx`**
+   - Update the mocked scope arrays (lines ~41-44, ~121-124, ~151, ~197, ~238)
+     and the `getByText('accounting.transactions')` display assertions
+     (line ~69) to match the new default set.
+3. **`server/src/test/unit/api/xeroOAuthRoutes.test.ts`**
+   - Update the exact auth-URL scope-string assertions (lines ~105, ~114) to the
+     new space-joined string:
+     `offline_access accounting.settings accounting.invoices accounting.banktransactions accounting.payments accounting.contacts`.
+
+## Explicitly out of scope
+
+- **Existing connections/tokens.** Tokens granted with the retired scope remain
+  valid until Xero's September 2027 legacy cutoff. No migration, re-auth nudge,
+  or banner. (Confirmed with user.)
+- **Legacy fixture sweep.** `server/src/test/unit/accounting/xeroClientService.spec.ts`
+  and `server/src/test/unit/xeroOauthCallbackCsrf.test.ts` use
+  `accounting.transactions` purely as stored-token/callback fixture data, not as
+  assertions about the default scope set. They realistically represent legacy
+  stored tokens and are left as-is. (Confirmed with user.)
+- **Docs/config.** No references to the retired scope exist in `docs/`, helm, or
+  compose files.
+
+## Verification
+
+1. Targeted vitest runs of the updated suites:
+   - `packages/integrations/src/actions/integrations/xeroActions.test.ts`
+   - `packages/integrations/src/components/settings/integrations/XeroIntegrationSettings.contract.test.tsx`
+   - `server/src/test/unit/api/xeroOAuthRoutes.test.ts`
+   - plus the untouched xero specs (`xeroClientService.spec.ts`,
+     `xeroOauthCallbackCsrf.test.ts`) to confirm no collateral damage.
+2. `grep -rn "accounting.transactions"` — remaining hits must be only the
+   intentionally-retained legacy fixtures listed above.
+3. Override-path check: existing tests covering `XERO_OAUTH_SCOPES` override
+   (in `xeroActions.test.ts` / `xeroClientService` specs) must still pass
+   unchanged, confirming configured scope overrides are respected.
+4. Optional manual sanity via the running dev stack (port 3081): Settings →
+   Integrations → Xero displays the granular scopes; Connect builds an
+   authorization URL containing the granular scopes and not
+   `accounting.transactions`.

--- a/packages/integrations/src/actions/integrations/xeroActions.test.ts
+++ b/packages/integrations/src/actions/integrations/xeroActions.test.ts
@@ -22,7 +22,9 @@ const getXeroRedirectUriMock = vi.hoisted(() => vi.fn(async () => 'https://examp
 const getXeroOAuthScopesMock = vi.hoisted(() => vi.fn(() => [
   'offline_access',
   'accounting.settings',
-  'accounting.transactions',
+  'accounting.invoices',
+  'accounting.banktransactions',
+  'accounting.payments',
   'accounting.contacts'
 ]));
 const resolveXeroOAuthCredentialsMock = vi.hoisted(() => vi.fn(async () => ({
@@ -105,7 +107,9 @@ describe('Xero integration actions', () => {
     getXeroOAuthScopesMock.mockReturnValue([
       'offline_access',
       'accounting.settings',
-      'accounting.transactions',
+      'accounting.invoices',
+      'accounting.banktransactions',
+      'accounting.payments',
       'accounting.contacts'
     ]);
     resolveXeroOAuthCredentialsMock.mockResolvedValue({
@@ -142,7 +146,10 @@ describe('Xero integration actions', () => {
     expect(result.credentials.clientSecretMasked).not.toContain('super-secret-value');
     expect(JSON.stringify(result)).not.toContain('super-secret-value');
     expect(result.redirectUri).toBe('https://example.com/api/integrations/xero/callback');
-    expect(result.scopes).toContain('accounting.transactions');
+    expect(result.scopes).toContain('accounting.invoices');
+    expect(result.scopes).toContain('accounting.banktransactions');
+    expect(result.scopes).toContain('accounting.payments');
+    expect(result.scopes).not.toContain('accounting.transactions');
     expect(result.defaultConnectionId).toBe('connection-1');
     expect(result.defaultConnection?.tenantName).toBe('Acme Holdings');
     expect(result.connected).toBe(true);

--- a/packages/integrations/src/components/settings/integrations/XeroIntegrationSettings.contract.test.tsx
+++ b/packages/integrations/src/components/settings/integrations/XeroIntegrationSettings.contract.test.tsx
@@ -40,7 +40,9 @@ describe('XeroIntegrationSettings contracts', () => {
       scopes: [
         'offline_access',
         'accounting.settings',
-        'accounting.transactions',
+        'accounting.invoices',
+        'accounting.banktransactions',
+        'accounting.payments',
         'accounting.contacts'
       ],
       credentials: {
@@ -66,7 +68,9 @@ describe('XeroIntegrationSettings contracts', () => {
     expect(await screen.findByText('https://example.com/api/integrations/xero/callback')).toBeInTheDocument();
     expect(screen.getByText('offline_access')).toBeInTheDocument();
     expect(screen.getByText('accounting.settings')).toBeInTheDocument();
-    expect(screen.getByText('accounting.transactions')).toBeInTheDocument();
+    expect(screen.getByText('accounting.invoices')).toBeInTheDocument();
+    expect(screen.getByText('accounting.banktransactions')).toBeInTheDocument();
+    expect(screen.getByText('accounting.payments')).toBeInTheDocument();
     expect(screen.getByText('accounting.contacts')).toBeInTheDocument();
   });
 
@@ -120,7 +124,9 @@ describe('XeroIntegrationSettings contracts', () => {
       scopes: [
         'offline_access',
         'accounting.settings',
-        'accounting.transactions',
+        'accounting.invoices',
+        'accounting.banktransactions',
+        'accounting.payments',
         'accounting.contacts'
       ],
       credentials: {
@@ -148,7 +154,9 @@ describe('XeroIntegrationSettings contracts', () => {
       scopes: [
         'offline_access',
         'accounting.settings',
-        'accounting.transactions',
+        'accounting.invoices',
+        'accounting.banktransactions',
+        'accounting.payments',
         'accounting.contacts'
       ],
       credentials: {
@@ -194,7 +202,9 @@ describe('XeroIntegrationSettings contracts', () => {
       scopes: [
         'offline_access',
         'accounting.settings',
-        'accounting.transactions',
+        'accounting.invoices',
+        'accounting.banktransactions',
+        'accounting.payments',
         'accounting.contacts'
       ],
       credentials: {
@@ -235,7 +245,9 @@ describe('XeroIntegrationSettings contracts', () => {
       scopes: [
         'offline_access',
         'accounting.settings',
-        'accounting.transactions',
+        'accounting.invoices',
+        'accounting.banktransactions',
+        'accounting.payments',
         'accounting.contacts'
       ],
       credentials: {

--- a/packages/integrations/src/lib/xero/xeroClientService.ts
+++ b/packages/integrations/src/lib/xero/xeroClientService.ts
@@ -19,7 +19,9 @@ const ACCESS_TOKEN_BUFFER_SECONDS = 300;
 const DEFAULT_XERO_SCOPES = [
   'offline_access',
   'accounting.settings',
-  'accounting.transactions',
+  'accounting.invoices',
+  'accounting.banktransactions',
+  'accounting.payments',
   'accounting.contacts'
 ];
 

--- a/server/src/test/unit/api/xeroOAuthRoutes.test.ts
+++ b/server/src/test/unit/api/xeroOAuthRoutes.test.ts
@@ -102,7 +102,7 @@ describe('Xero OAuth routes', () => {
     });
     getXeroRedirectUriMock.mockResolvedValue('https://example.com/api/integrations/xero/callback');
     getXeroOAuthScopesStringMock.mockReturnValue(
-      'offline_access accounting.settings accounting.transactions accounting.contacts'
+      'offline_access accounting.settings accounting.invoices accounting.banktransactions accounting.payments accounting.contacts'
     );
     upsertStoredXeroConnectionsMock.mockResolvedValue({});
     axiosPostMock.mockResolvedValue({
@@ -111,7 +111,7 @@ describe('Xero OAuth routes', () => {
         refresh_token: 'refresh-token',
         expires_in: 1800,
         refresh_token_expires_in: 3600,
-        scope: 'offline_access accounting.transactions'
+        scope: 'offline_access accounting.invoices accounting.banktransactions accounting.payments'
       }
     });
     axiosGetMock.mockResolvedValue({


### PR DESCRIPTION
## Summary

- Replace Xero's retired `accounting.transactions` OAuth scope with `accounting.invoices`, `accounting.banktransactions`, and `accounting.payments` in the shared default scope source.
- Keep `offline_access`, `accounting.settings`, and `accounting.contacts` unchanged.
- Update the Xero action, settings UI contract, and OAuth route regression coverage, including a guard that the retired scope is absent.
- Add the implementation and verification plan; legacy stored-token fixtures and existing-token migration remain out of scope.

## Validation

- **PASS, with the rerun limitations disclosed below.**
- Automated coverage passed: 5 targeted Xero suites (41 tests), integrations and server typechecks, and `npm run build`.
- Same-commit live-product evidence shows the Xero settings UI listing `accounting.invoices`, `accounting.banktransactions`, and `accounting.payments`; `accounting.transactions` is absent.
- Regression coverage confirms unchanged `offline_access`, `accounting.settings`, and `accounting.contacts` scopes.
- **Connect Xero** reached Xero Identity, which rejected the smoke client as `unauthorized_client`—expected without valid Xero credentials and proof that OAuth navigation occurred.
- No Xero simulator or API mock was used.

## Rerun and fidelity limitations

The rerun verified that the `alga-psa-local-test` stack and the port 3014 app are genuinely running; `/auth/signin` returns HTTP 200. However, this repaired wire-in identifies as Community Edition, so `/api/integrations/xero/connect` returns HTTP 501: “Xero integration is only available in Enterprise Edition.”

The card's Mac-hosted browser required a temporary localhost HTTP forwarder and failed to hydrate/screenshot reliably; the forwarder was removed afterward. Screenshots referenced here are therefore from the earlier live Enterprise same-commit smoke pass, not newly captured during this rerun.

The earlier flow stopped at Xero's expected invalid-client response. This rerun authenticated through the real credentials callback after background native typing failed, and the Glinda dev fixture password hash was locally reset for authentication. Existing `package.json` and `package-lock.json` wire-in modifications remain untouched. The dev server was left answering on port 3014.

Evidence: `/tmp/alga-smoke-evidence/xero-permission-breakage-20260722-120310`
