### PR TITLE
Appliance custom portal domain redirect issue

### DIFF
--- a/docs/plans/2026-07-22-custom-portal-domain-redirect-plan.md
+++ b/docs/plans/2026-07-22-custom-portal-domain-redirect-plan.md
@@ -1,0 +1,132 @@
+# Custom Portal Domain — Root Path Redirects to Client Portal
+
+- Date: 2026-07-22
+- Branch: `fix/appliance-custom-portal-domain-redirect`
+- Worktree: `/home/robert/alga-psa.worktrees/fix-appliance-custom-portal-domain-redirect`
+  (recreated here after the original `alga-cow-copies` checkout was lost to btrfs image
+  corruption on 2026-07-22; original base `252e607866`, recreated off `origin/main`
+  `3fd91b8652`)
+- Reporter: Peet McKinney (Artichoke Consulting) — `https://portal.artichoke.tech/` (a
+  registered, active, correctly-proxied portal domain) redirected to the MSP sign-in
+  instead of the client portal; only `/client-portal` worked.
+
+## Objective
+
+The bare root of a registered portal domain (`https://portal.example.com/`) redirects to
+`/client-portal` on the same host, letting the existing vanity middleware chain take over
+(canonical sign-in with `portalDomain` branding + callback, or straight into the portal for
+authenticated clients). Behavior on the canonical host and on unknown hosts is unchanged.
+
+## Root cause
+
+`server/src/app/route.tsx` — the handler for `/` — unconditionally does
+`redirect('/msp/dashboard')`. The middleware's vanity-host logic
+(`server/src/middleware.ts`) only covers `/client-portal/*` and
+`/auth/client-portal/signin`, so `/` on a portal domain never consults the request host.
+
+## Settled design decisions (from the design session)
+
+1. **Target:** root → `redirect('/client-portal')` (relative; browser stays on the vanity
+   host). Downstream auth/branding/callback handling is already implemented in middleware —
+   do not duplicate it.
+2. **Which hosts:** DB-checked via `getPortalDomainByHostname` (the same unscoped
+   tenant-discovery lookup the domain-session exchange uses). A row in **any status**
+   (`active`, `pending_dns`, `disabled`, …) redirects to the portal — the row's existence
+   means "this host is a portal domain"; `active` gates the session exchange downstream,
+   not the intent of the root URL. Unknown/stray hosts keep today's MSP behavior.
+3. **Scope:** root path only. `/msp/*` and MSP auth pages on a portal-domain host are out
+   of scope (possible future hardening, separate design).
+4. **No UI/docs changes** in this branch — the redirect makes the `/client-portal` path an
+   implementation detail, which was the reporter's primary suggestion.
+5. **Approach:** fix in the Node-runtime root route handler (it can reach the DB). Edge
+   middleware and `next.config.js` host redirects were ruled out (no DB access / static
+   config respectively).
+
+## Implementation
+
+### 1. Decision helper (new, unit-testable)
+
+Add `resolveRootRedirect` to a new module `server/src/lib/deployment/rootRedirect.ts`:
+
+```ts
+export type RootRedirectTarget = '/client-portal' | '/msp/dashboard';
+
+export async function resolveRootRedirect(args: {
+  hostname: string;            // from resolveRequestHost (port stripped)
+  hostHeader: string;          // as received, may include port
+  canonicalHostname: string | null;  // null when NEXTAUTH_URL unset/unparseable
+  lookupPortalDomain: (candidate: string) => Promise<unknown | null>;
+}): Promise<RootRedirectTarget>
+```
+
+Decision table, in order:
+
+1. `canonicalHostname` set and `hostname === canonicalHostname` → `/msp/dashboard`
+   (fast path — no DB touched; the overwhelming majority of traffic).
+2. Otherwise build host candidates mirroring
+   `server/src/app/api/client-portal/domain-session/route.ts` (`hostCandidates`): if
+   `hostHeader` carries a non-80/443 port, try `host:port` first, then bare `hostname`.
+   First candidate with a `lookupPortalDomain` hit → `/client-portal`.
+3. No match → `/msp/dashboard`.
+4. `lookupPortalDomain` throws → log a warning (with hostname), return `/msp/dashboard`
+   (fail toward today: an outage never locks MSP users out or behaves worse than status quo).
+
+Empty/missing host falls out naturally: matches neither canonical nor any row → MSP.
+
+### 2. Route handler (`server/src/app/route.tsx`)
+
+Rewrite `GET` to:
+
+- Build a `Request`-shaped header reader from `await headers()` (next/headers).
+- `caps = resolveDeploymentCapabilities()`; `resolveRequestHost(request, caps)` for
+  `{ hostname, hostHeader }` — appliance `X-Forwarded-Host` trust applies as elsewhere.
+- `canonicalHostname` from `NEXTAUTH_URL` (try/catch → `null`), mirroring middleware's
+  `getCanonicalUrl()`.
+- Inject `lookupPortalDomain` as `(candidate) => getPortalDomainByHostname(knex, candidate)`
+  with `knex = await getAdminConnection()` — created lazily, only after the canonical fast
+  path fails.
+- `redirect(await resolveRootRedirect(...))`.
+
+Query strings on `/` are dropped (nothing meaningful lives at root-with-query).
+
+### 3. Tests
+
+Per `docs/AI_coding_standards.md`, tests live centralized under `server/src/test/unit/`,
+mirroring source structure.
+
+- **`server/src/test/unit/rootRedirect.test.ts`** — decision table with an injected fake
+  lookup: canonical host → MSP and lookup not called; lookup hit → `/client-portal`
+  (helper is status-agnostic — any row qualifies); unknown host → MSP; lookup throws → MSP
+  (and warning logged); `canonicalHostname: null` → lookup still consulted; ported host
+  tries `host:port` candidate before bare hostname.
+- **Handler-level test** (same file or `server/src/test/unit/app/route.test.ts`,
+  mocking the helper, `getAdminConnection`, and `next/headers`): redirect `Location` for
+  portal vs non-portal outcomes; assert `getAdminConnection` is **not** called on the
+  canonical fast path (guards the hot path against regression).
+- **No e2e** — the downstream chain (vanity `/client-portal` → canonical sign-in → OTT
+  exchange) is already covered by `middleware.vanityClientPortalRedirect.test.ts` and the
+  domain-session tests.
+
+### 4. Manual verification (requires dev-stack wire-up in this worktree)
+
+The previously running dev stack (port 3553, compose project `alga-psa-local-test`:
+pgbouncer `localhost:6472`, redis `6380`) still serves from the old read-only copy. Before
+manual verification, re-wire this worktree (per the lane's Wire Up conventions: dev port
+3553, same compose project, secrets copied from the previous lane's `secrets/`):
+
+- `curl -sI http://localhost:3553/` → `/msp/dashboard` (canonical host unchanged).
+- Simulate a vanity host: insert/point a `portal_domains` row at a test hostname, then
+  `curl -sI -H 'Host: <test-host>' http://localhost:3553/` → `Location: /client-portal`.
+- With `DEPLOYMENT_PROFILE=appliance`, `curl -sI -H 'X-Forwarded-Host: <test-host>'`
+  (Host = canonical) → `Location: /client-portal` (XFH trust honored).
+- `curl -sI -H 'Host: unknown.example.com' http://localhost:3553/` → `/msp/dashboard`.
+
+## Out of scope
+
+- Portal-domain hosts serving `/msp/*` or MSP auth pages (host-wide "portal-only" hardening).
+- Settings UI / docs copy about the portal URL.
+- Caching the domain lookup (low-QPS path; status changes must take effect immediately).
+
+## Commit plan
+
+Single commit: helper + handler + unit tests. (This plan doc was committed separately first.)

--- a/server/src/app/route.tsx
+++ b/server/src/app/route.tsx
@@ -1,5 +1,33 @@
+import { getAdminConnection } from '@alga-psa/db/admin';
+import { headers } from 'next/headers';
 import { redirect } from 'next/navigation';
+import { resolveDeploymentCapabilities } from '@/lib/deployment/deploymentProfile';
+import { resolveRequestHost } from '@/lib/deployment/requestHost';
+import { resolveRootRedirect } from '@/lib/deployment/rootRedirect';
+import { getPortalDomainByHostname } from 'server/src/models/PortalDomainModel';
 
 export async function GET() {
-  redirect('/msp/dashboard');
+  const request = { headers: await headers() };
+  const capabilities = resolveDeploymentCapabilities();
+  const { hostname, hostHeader } = resolveRequestHost(request, capabilities);
+  const canonicalHostname = (() => {
+    try {
+      return process.env.NEXTAUTH_URL ? new URL(process.env.NEXTAUTH_URL).hostname : null;
+    } catch {
+      return null;
+    }
+  })();
+  let adminConnection: Awaited<ReturnType<typeof getAdminConnection>> | null = null;
+
+  const target = await resolveRootRedirect({
+    hostname,
+    hostHeader,
+    canonicalHostname,
+    lookupPortalDomain: async (candidate) => {
+      adminConnection ??= await getAdminConnection();
+      return getPortalDomainByHostname(adminConnection, candidate);
+    },
+  });
+
+  redirect(target);
 }

--- a/server/src/lib/deployment/rootRedirect.ts
+++ b/server/src/lib/deployment/rootRedirect.ts
@@ -1,0 +1,37 @@
+import logger from '@alga-psa/core/logger';
+
+export type RootRedirectTarget = '/client-portal' | '/msp/dashboard';
+
+export async function resolveRootRedirect(args: {
+  hostname: string;
+  hostHeader: string;
+  canonicalHostname: string | null;
+  lookupPortalDomain: (candidate: string) => Promise<unknown | null>;
+}): Promise<RootRedirectTarget> {
+  const { hostname, hostHeader, canonicalHostname, lookupPortalDomain } = args;
+
+  if (canonicalHostname && hostname === canonicalHostname) {
+    return '/msp/dashboard';
+  }
+
+  const [, port] = hostHeader.split(':');
+  const hostCandidates = [hostname];
+  if (port && port !== '80' && port !== '443') {
+    hostCandidates.unshift(hostHeader);
+  }
+
+  try {
+    for (const candidate of hostCandidates) {
+      if (await lookupPortalDomain(candidate)) {
+        return '/client-portal';
+      }
+    }
+  } catch (error) {
+    logger.warn('Failed to resolve root redirect for request host', {
+      hostname,
+      error,
+    });
+  }
+
+  return '/msp/dashboard';
+}

--- a/server/src/test/unit/app/rootRoute.test.ts
+++ b/server/src/test/unit/app/rootRoute.test.ts
@@ -1,0 +1,75 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const redirectMock = vi.fn();
+const headersMock = vi.fn();
+const getAdminConnectionMock = vi.fn();
+const getPortalDomainByHostnameMock = vi.fn();
+
+function requestHeaders(host: string) {
+  return {
+    get: (name: string) => name.toLowerCase() === 'host' ? host : null,
+  };
+}
+
+vi.mock('next/navigation', () => ({
+  redirect: redirectMock,
+}));
+
+vi.mock('next/headers', () => ({
+  headers: headersMock,
+}));
+
+vi.mock('@alga-psa/db/admin', () => ({
+  getAdminConnection: getAdminConnectionMock,
+}));
+
+vi.mock('server/src/models/PortalDomainModel', () => ({
+  getPortalDomainByHostname: getPortalDomainByHostnameMock,
+}));
+
+const { GET } = await import('../../../app/route');
+
+describe('root route', () => {
+  beforeEach(() => {
+    redirectMock.mockReset();
+    headersMock.mockReset();
+    getAdminConnectionMock.mockReset();
+    getPortalDomainByHostnameMock.mockReset();
+    process.env.NEXTAUTH_URL = 'https://app.example.com';
+    delete process.env.DEPLOYMENT_PROFILE;
+    headersMock.mockResolvedValue(requestHeaders('portal.example.com'));
+    getAdminConnectionMock.mockResolvedValue({ connection: 'admin' });
+  });
+
+  it('redirects a registered portal-domain host to the client portal', async () => {
+    getPortalDomainByHostnameMock.mockResolvedValue({ id: 'portal-domain-1' });
+
+    await GET();
+
+    expect(redirectMock).toHaveBeenCalledWith('/client-portal');
+    expect(getAdminConnectionMock).toHaveBeenCalledOnce();
+    expect(getPortalDomainByHostnameMock).toHaveBeenCalledWith(
+      { connection: 'admin' },
+      'portal.example.com',
+    );
+  });
+
+  it('keeps an unknown host on the MSP redirect', async () => {
+    getPortalDomainByHostnameMock.mockResolvedValue(null);
+
+    await GET();
+
+    expect(redirectMock).toHaveBeenCalledWith('/msp/dashboard');
+    expect(getAdminConnectionMock).toHaveBeenCalledOnce();
+  });
+
+  it('keeps the canonical host on the MSP redirect without opening an admin connection', async () => {
+    headersMock.mockResolvedValue(requestHeaders('app.example.com'));
+
+    await GET();
+
+    expect(redirectMock).toHaveBeenCalledWith('/msp/dashboard');
+    expect(getAdminConnectionMock).not.toHaveBeenCalled();
+    expect(getPortalDomainByHostnameMock).not.toHaveBeenCalled();
+  });
+});

--- a/server/src/test/unit/rootRedirect.test.ts
+++ b/server/src/test/unit/rootRedirect.test.ts
@@ -1,0 +1,85 @@
+import logger from '@alga-psa/core/logger';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { resolveRootRedirect } from '../../lib/deployment/rootRedirect';
+
+describe('resolveRootRedirect', () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('returns the MSP dashboard for the canonical host without a lookup', async () => {
+    const lookupPortalDomain = vi.fn();
+
+    await expect(resolveRootRedirect({
+      hostname: 'app.example.com',
+      hostHeader: 'app.example.com',
+      canonicalHostname: 'app.example.com',
+      lookupPortalDomain,
+    })).resolves.toBe('/msp/dashboard');
+    expect(lookupPortalDomain).not.toHaveBeenCalled();
+  });
+
+  it('returns the client portal for any matching portal-domain row', async () => {
+    const lookupPortalDomain = vi.fn().mockResolvedValue({ status: 'disabled' });
+
+    await expect(resolveRootRedirect({
+      hostname: 'portal.example.com',
+      hostHeader: 'portal.example.com',
+      canonicalHostname: 'app.example.com',
+      lookupPortalDomain,
+    })).resolves.toBe('/client-portal');
+  });
+
+  it('returns the MSP dashboard for an unknown host', async () => {
+    await expect(resolveRootRedirect({
+      hostname: 'unknown.example.com',
+      hostHeader: 'unknown.example.com',
+      canonicalHostname: 'app.example.com',
+      lookupPortalDomain: vi.fn().mockResolvedValue(null),
+    })).resolves.toBe('/msp/dashboard');
+  });
+
+  it('fails toward the MSP dashboard and logs when lookup throws', async () => {
+    const warn = vi.spyOn(logger, 'warn').mockImplementation(() => undefined);
+
+    await expect(resolveRootRedirect({
+      hostname: 'portal.example.com',
+      hostHeader: 'portal.example.com',
+      canonicalHostname: 'app.example.com',
+      lookupPortalDomain: vi.fn().mockRejectedValue(new Error('database unavailable')),
+    })).resolves.toBe('/msp/dashboard');
+    expect(warn).toHaveBeenCalledWith(
+      'Failed to resolve root redirect for request host',
+      expect.objectContaining({ hostname: 'portal.example.com' }),
+    );
+  });
+
+  it('still performs a lookup when the canonical hostname is unavailable', async () => {
+    const lookupPortalDomain = vi.fn().mockResolvedValue({ id: 'domain-1' });
+
+    await expect(resolveRootRedirect({
+      hostname: 'portal.example.com',
+      hostHeader: 'portal.example.com',
+      canonicalHostname: null,
+      lookupPortalDomain,
+    })).resolves.toBe('/client-portal');
+    expect(lookupPortalDomain).toHaveBeenCalledWith('portal.example.com');
+  });
+
+  it('tries a non-standard port before the bare hostname', async () => {
+    const lookupPortalDomain = vi.fn()
+      .mockResolvedValueOnce(null)
+      .mockResolvedValueOnce({ id: 'domain-1' });
+
+    await expect(resolveRootRedirect({
+      hostname: 'portal.example.com',
+      hostHeader: 'portal.example.com:3553',
+      canonicalHostname: 'app.example.com',
+      lookupPortalDomain,
+    })).resolves.toBe('/client-portal');
+    expect(lookupPortalDomain.mock.calls).toEqual([
+      ['portal.example.com:3553'],
+      ['portal.example.com'],
+    ]);
+  });
+});


### PR DESCRIPTION
## Summary

Fix the appliance custom portal domain root route so registered vanity hosts land on the client portal instead of the MSP dashboard.

- Resolve the request host using deployment-aware forwarded-host handling.
- Keep the canonical host on `/msp/dashboard` without opening a database connection.
- Look up non-canonical hosts against portal domains, trying a non-standard `host:port` before the bare hostname.
- Redirect any registered portal-domain row, including disabled domains, to `/client-portal`.
- Fail safely to `/msp/dashboard` when the host is unknown or the lookup fails.
- Add focused decision-helper and root-route unit coverage.

## Validation

- PASS: 9 focused unit tests covering root-route behavior and redirect decisions.
- PASS: server typecheck with a 16 GB Node heap.
- PASS: root community production build.
- PASS: changed root-route behavior against the real enterprise Next server on port 3553 and the live `alga-psa-local-test` PostgreSQL/PgBouncer/Redis stack:
  - Registered `portal.localhost:3553` → HTTP 307 `/client-portal`.
  - Disabled registered domain → HTTP 307 `/client-portal`.
  - Bare-domain fallback candidate (`portal.localhost` with request port 3553) → HTTP 307 `/client-portal`.
  - Canonical `localhost:3553` → HTTP 307 `/msp/dashboard`.
  - Unknown host → HTTP 307 `/msp/dashboard`.
  - Logged into the real MSP UI as the generated dev user; the canonical root reached the dashboard and the client-portal target rendered the portal-switch UI.

## Smoke-test fidelity and concerns

No appliance ingress/reverse proxy was available. The domain was inserted directly into the real database rather than configured through Settings, then deleted after testing. No simulator or mock was used. Database-failure fallback was not exercised because deliberately stopping the shared database would disrupt other work.

Following the vanity host beyond the correct root redirect looped on a relative `/auth/client-portal/signin` redirect in local dev instead of switching to the canonical host. The canonical client-portal page renders correctly, but appliance ingress behavior remains unverified. The enterprise dev server also logged unavailable Temporal services and briefly returned 500s after a very large hot compilation; restarting it cleared the condition and all redirect checks then passed repeatedly.

The card-owned dev server remains running from this worktree, the smoke fixture was removed, and the worktree is clean.

Evidence: `/tmp/alga-smoke-evidence/appliance-custom-portal-domain-redirect-20260722-164458`

