### PR TITLE
Migrate some CIPP functionality to Pro

### DIFF
--- a/docs/plans/2026-07-22-cipp-pro-migration-plan.md
+++ b/docs/plans/2026-07-22-cipp-pro-migration-plan.md
@@ -1,0 +1,101 @@
+# CIPP → Pro Tier Migration — Implementation Plan
+
+**Date:** 2026-07-22
+**Branch:** `feature/cipp-pro-migration`
+**Status:** Approved design, ready for implementation
+
+## Intent
+
+Move the entire Microsoft 365 / Entra integration baseline — connect (Direct **and** CIPP), tenant discovery, client mapping, user→contact sync, field sync, reconciliation queue — from Premium / Enterprise-add-on down to the **Pro tier**. Reinstate the CIPP connection option in the UI, gated by **PostHog flag + tier** for a soft launch. Leave all add-on machinery **dormant but intact** for the future per-client-tenant metered product (strategy: `nineminds-vault/Inbox/2026-07-22-m365-per-tenant-metering-strategy.md`).
+
+**Explicitly out of scope:** per-tenant metering, license reconciliation, contract-change drafts, CIPP Pro API endpoints/auth modernization, grandfathering/refunds of existing Enterprise add-on subscriptions (billing ops), Teams add-on changes, CE edition changes.
+
+## Key discovery that shapes the diff
+
+The server-side gate for all Entra routes is **not** `TIER_FEATURES.ENTRA_SYNC` — it is `assertAddOnAccess(ADD_ONS.ENTERPRISE)` in `ee/server/src/app/api/integrations/entra/_guards.ts`. `ENTRA_SYNC`/`CIPP` tier features currently only drive UI display. The migration is therefore: one guard swap server-side, constant changes in the tier map, and re-wiring two UI gates that already receive the right inputs but ignore them.
+
+## Changes
+
+### 1. Tier model — `packages/types/src/constants/tierFeatures.ts`
+
+- `FEATURE_MINIMUM_TIER[ENTRA_SYNC]`: `'premium'` → `'pro'`
+- `FEATURE_MINIMUM_TIER[CIPP]`: `'premium'` → `'pro'`
+- Remove `TIER_FEATURES.ENTRA_SYNC` from `ADD_ON_ONLY_FEATURES` (it becomes a normal Pro tier feature, included in `TIER_FEATURE_MAP` for pro/premium).
+- **Do not touch:** `TEAMS_INTEGRATION` (stays add-on-only), the `ADD_ON_ONLY_FEATURES` mechanism itself, `assertAddOnAccess`, `ADD_ONS.ENTERPRISE`, `tenantHasAddOn`, the tenant add-ons table, Stripe price mappings in `ee/server/src/lib/stripe/StripeService.ts`. All dormant plumbing for the future metered product.
+
+### 2. Server route guard — `ee/server/src/app/api/integrations/entra/_guards.ts`
+
+- In `requireEntraUiFlagEnabled`, replace `await assertAddOnAccess(ADD_ONS.ENTERPRISE)` with `await assertTierAccess(TIER_FEATURES.ENTRA_SYNC)`.
+- Keep the existing try/catch shape: `TierAccessError` → 403 "Microsoft Entra integration is not available for this workspace." `AddOnAccessError` import/handling may be dropped from this file only if it becomes unused; unexpected errors must still rethrow (existing behavior, locked by test).
+- This single swap opens every Entra route (connect, validate, discovery, mappings, sync, reconciliation queue) to Pro+ tenants. The `entra-integration-ui` PostHog master flag and EE edition gating are unchanged.
+
+### 3. Integrations settings body — `server/src/app/msp/settings/integrations/IntegrationsSettingsBody.tsx`
+
+- Replace `const canUseEntraSync = hasAddOn(ADD_ONS.ENTERPRISE)` with `const canUseEntraSync = useTierFeature(TIER_FEATURES.ENTRA_SYNC)`.
+- `canUseCipp = useTierFeature(TIER_FEATURES.CIPP)` is already correct (line 13) — after change #1 it yields true for Pro+.
+- `canUseTeams` stays on `hasAddOn(ADD_ONS.TEAMS)`.
+
+### 4. CIPP UI reinstatement — `ee/server/src/components/settings/integrations/entraIntegrationSettingsGates.ts`
+
+- `buildEntraConnectionOptions(isCippEnabled)` honors its parameter again: return `[DIRECT_CONNECTION_OPTION, CIPP_CONNECTION_OPTION]` when true, `[DIRECT_CONNECTION_OPTION]` when false. Replace the descope comment with a note that CIPP is gated by `entra-integration-cipp` flag + `TIER_FEATURES.CIPP` tier.
+- **No other UI change needed.** `EntraIntegrationSettings.tsx:239` already computes `buildEntraConnectionOptions(cippFlag.enabled && canUseCippTier)`; the connect dialog, CIPP status display, discovery/mapping/sync flows are all CIPP-aware and live in EE only.
+- PostHog flag `entra-integration-cipp` stays default-off; soft launch is an ops action (flip per-tenant, then globally).
+
+### 5. Account Management add-ons — `ee/server/src/components/settings/account/AccountManagement.tsx`
+
+- The `ADD_ONS.ENTERPRISE` card (line ~887) offers purchase of an add-on that after this migration grants nothing extra. Change the card list so the Enterprise card is shown **only when the add-on is already active** for the tenant (existing subscribers keep their "active" state and cancel path); do not offer it for new purchase.
+- Keep the `ADD_ONS.ENTERPRISE` enum, labels, descriptions, Stripe price config, and i18n keys in place (dormant). The tier-feature display entries (`features.entraSync`, `features.cipp`, lines 72–73) now naturally show as included for Pro+ — verify the labels read correctly in that context.
+
+### 6. Tests — update what locked the old behavior
+
+| File | Change |
+|---|---|
+| `packages/types/src/constants/tierFeatures.test.ts` | Min tiers now `pro` for `ENTRA_SYNC`/`CIPP`; `tierHasFeature('pro', …)` → true for both; `TIER_FEATURE_MAP` pro/premium include both; `ENTRA_SYNC` no longer excluded as add-on-only. |
+| `server/src/test/unit/integrations/entraAddOnGuard.test.ts` | Semantics invert. T103 becomes: guard passes for a tenant whose **tier** assertion passes, with **no** add-on assertion made; solo/tier-failure → 403 with the same error body; unexpected errors still rethrow. T104 becomes: premium tier alone still does **not** unlock `TEAMS_INTEGRATION` (control), and `ENTRA_SYNC` is now tier-unlocked. Rename the file/describes if the add-on framing no longer fits (e.g. `entraTierGuard.test.ts`). |
+| `ee/server/src/__tests__/unit/entraIntegrationSettingsGates.test.ts` | Invert: CIPP option appears when `isCippEnabled` is true, hidden when false. |
+| `server/src/test/unit/context/TierContext.test.tsx` | Audit line ~129 (`hasFeature(TIER_FEATURES.ENTRA_SYNC)`) — update fixture expectations for the new tier mapping. |
+| `packages/types/src/constants/tierExports.test.ts` | Audit for ENTRA_SYNC assumptions. |
+
+Unaffected: `cippProviderAdapter.normalization.test.ts`, `entraValidateCippRoute.test.ts`, `entraProviderFactory.test.ts`, `entraSecretKeys.test.ts`, `entraActions.directConnect.test.ts`, all addOns constants tests, Teams guard tests.
+
+**New test worth adding:** a guard test asserting a **Pro tier tenant with no add-ons** passes `requireEntraUiFlagEnabled` — this is the behavior the branch exists to create.
+
+### 7. Docs
+
+- `docs/tier-gating-guide.md` — move `CIPP`/`ENTRA_SYNC` rows to Pro; add a short "Dormant add-on plumbing" note: `ADD_ONS.ENTERPRISE`, `assertAddOnAccess`, and the Stripe price config are retained intentionally for the future per-client-tenant metered product (see vault strategy note); do not delete them as "dead code."
+- `ee/docs/guides/entra-integration-phase-1.md` — the CIPP section is stale (documents classic CIPP setup, PRD descoped it). Update to describe: CIPP available at Pro tier, behind `entra-integration-cipp` flag; connection via base URL + API token; classic CIPP API.
+
+## Audit step (first task for the implementer)
+
+Before editing, run a fresh sweep to confirm no enforcement point was missed:
+
+```
+grep -rn "ADD_ONS.ENTERPRISE\|TIER_FEATURES.ENTRA_SYNC\|TIER_FEATURES.CIPP" \
+  ee/server/src server/src packages --include="*.ts" --include="*.tsx" | grep -v node_modules
+```
+
+Every hit must be either (a) changed per this plan, (b) verified UI-display-only, or (c) deliberately dormant add-on machinery. As of 2026-07-22 the known non-test hits are exactly the files listed above.
+
+## Verification
+
+1. `npm run test` (or targeted vitest runs) for all touched test files; full tier-gating + integrations suites green.
+2. Typecheck EE + CE (`@enterprise` resolves to `ee/server` in EE, `packages/ee` stubs in CE — CE is untouched and must stay green).
+3. i18n parity check (no keys added or removed; the Enterprise card keys stay).
+4. Manual smoke on the dev server (port 3164): with a Pro-tier tenant and `entra-integration-ui` on —
+   a. flag `entra-integration-cipp` off → only "Direct Microsoft Partner" offered;
+   b. flag on → CIPP option appears; connect dialog accepts base URL + token; validation runs; status shows `cippBaseUrl`.
+5. Confirm a Solo-tier tenant still gets 403 from Entra routes and no Entra UI.
+
+## Rollout
+
+1. Merge with `entra-integration-cipp` default-off everywhere (Pro tier access to Direct path goes live immediately — intended).
+2. Ops: enable flag for internal/early tenants, validate CIPP connect → discover → map → sync end-to-end against a real CIPP instance.
+3. Enable flag globally.
+4. Billing ops (separate): handle existing Enterprise add-on subscriptions (the add-on becomes inert; subscribers keep active state/cancel path in the UI).
+
+## Risks / notes
+
+- **Direct path becomes Pro on merge** (no flag on it). That's the intent ("everything into Pro"), but it is a packaging change that takes effect at deploy, not at flag flip.
+- **Grandfathering is unresolved by design** — existing Enterprise add-on subscribers see no functional change; billing treatment is an ops decision tracked in the vault note.
+- The `entra-integration-cipp` flag must exist in PostHog bootstrap (it is already read in `EntraIntegrationSettings.tsx`); confirm it's registered for the environments before smoke testing.
+- Do not "clean up" the dormant add-on machinery — it is the substrate for the metered follow-up. If a future agent is tempted, the tier-gating guide note (change #7) is the guardrail.

--- a/docs/plans/2026-07-22-cipp-pro-migration-plan.md
+++ b/docs/plans/2026-07-22-cipp-pro-migration-plan.md
@@ -2,7 +2,7 @@
 
 **Date:** 2026-07-22
 **Branch:** `feature/cipp-pro-migration`
-**Status:** Approved design, ready for implementation
+**Status:** Draft implemented
 
 ## Intent
 
@@ -85,6 +85,28 @@ Every hit must be either (a) changed per this plan, (b) verified UI-display-only
    a. flag `entra-integration-cipp` off → only "Direct Microsoft Partner" offered;
    b. flag on → CIPP option appears; connect dialog accepts base URL + token; validation runs; status shows `cippBaseUrl`.
 5. Confirm a Solo-tier tenant still gets 403 from Entra routes and no Entra UI.
+
+### CIPP emulator follow-up
+
+Build later CIPP smoke and integration automation around a small, deterministic CIPP
+API emulator rather than requiring a live CIPP deployment for every run. Follow the
+same test-double approach used by the QuickBooks harnesses and the checked-in
+`test-harness/graph-emulator/`:
+
+- Add a growable `test-harness/cipp-emulator/` with a standalone server, Compose
+  entry point, seeded fixtures, README, and self-contained smoke test.
+- Start with the classic CIPP endpoints the current adapter calls for managed
+  tenants and tenant users. Emulate static-token authorization, representative
+  response shapes, pagination if the live API requires it, and deterministic
+  authentication/rate-limit/server failures.
+- Point the existing configurable CIPP base URL at the emulator; do not add a
+  production-only bypass or weaken token validation for tests.
+- Use emulator-backed automation for connect/validate, discovery, mapping, and
+  sync flows. Keep one opt-in live-CIPP smoke as a fidelity check before rollout.
+
+The emulator itself is not required for this tier-gating draft, but it is the
+preferred prerequisite for expanding CIPP smoke coverage beyond the focused unit
+tests in this branch.
 
 ## Rollout
 

--- a/docs/tier-gating-guide.md
+++ b/docs/tier-gating-guide.md
@@ -32,7 +32,10 @@ Map which tiers get the feature:
 ```ts
 // packages/types/src/constants/tierFeatures.ts
 export const TIER_FEATURE_MAP: Record<TenantTier, TIER_FEATURES[]> = {
-  pro: [],
+  pro: [
+    TIER_FEATURES.ENTRA_SYNC,
+    TIER_FEATURES.CIPP,
+  ],
   premium: [
     TIER_FEATURES.ENTRA_SYNC,
     TIER_FEATURES.CIPP,
@@ -46,8 +49,8 @@ export const TIER_FEATURE_MAP: Record<TenantTier, TIER_FEATURES[]> = {
 ```ts
 // packages/types/src/constants/tierFeatures.ts
 export const FEATURE_MINIMUM_TIER: Record<TIER_FEATURES, TenantTier> = {
-  [TIER_FEATURES.ENTRA_SYNC]: 'premium',
-  [TIER_FEATURES.CIPP]: 'premium',
+  [TIER_FEATURES.ENTRA_SYNC]: 'pro',
+  [TIER_FEATURES.CIPP]: 'pro',
   [TIER_FEATURES.YOUR_NEW_FEATURE]: 'premium',  // ← add here
 };
 ```
@@ -164,8 +167,12 @@ This means CE users get all features regardless of `tenants.plan`.
 
 ## Existing Gated Features (for reference)
 
-| Feature | Enum | Gated Where |
-|---------|------|-------------|
-| Visual Invoice Designer | `INVOICE_DESIGNER` | InvoiceTemplateEditor visual tab, BillingPageClient |
-| Entra Sync | `ENTRA_SYNC` | IntegrationsSettingsPage, SettingsPage |
-| CIPP | `CIPP` | EntraIntegrationSettings connection options |
+| Feature | Enum | Minimum tier | Gated Where |
+|---------|------|--------------|-------------|
+| Visual Invoice Designer | `INVOICE_DESIGNER` | Premium | InvoiceTemplateEditor visual tab, BillingPageClient |
+| Entra Sync | `ENTRA_SYNC` | Pro | IntegrationsSettingsPage, SettingsPage, Entra API routes |
+| CIPP | `CIPP` | Pro | EntraIntegrationSettings connection options |
+
+## Dormant Enterprise Add-on Plumbing
+
+`ADD_ONS.ENTERPRISE`, `assertAddOnAccess`, and the Enterprise Stripe price configuration are retained intentionally for a future per-client-tenant metered product. Entra Sync and CIPP no longer depend on this add-on; do not remove the dormant plumbing as dead code. The product strategy is recorded in `nineminds-vault/Inbox/2026-07-22-m365-per-tenant-metering-strategy.md`.

--- a/ee/docs/guides/entra-integration-phase-1.md
+++ b/ee/docs/guides/entra-integration-phase-1.md
@@ -14,6 +14,7 @@ All user-visible Entra surfaces are feature-flag gated.
 ## Prerequisites
 
 - Edition: `NEXT_PUBLIC_EDITION=enterprise`
+- Subscription tier: Pro or Premium
 - Internal MSP user account (client portal users are denied)
 - RBAC:
   - View endpoints/actions: `system_settings.read`
@@ -29,8 +30,9 @@ Choose one connection type per tenant:
 - Best when you control OAuth app registration and consent flow.
 
 2. `cipp` (CIPP API)
-- Use this when CIPP is your operational control plane for managed tenant/user enumeration.
-- Requires CIPP base URL and API token.
+- Available on Pro and Premium when the `entra-integration-cipp` flag is enabled for the tenant.
+- Uses the classic CIPP API for managed tenant and user enumeration.
+- Requires the CIPP base URL and a static API token.
 - Best when your MSP already uses CIPP and wants to reuse that API boundary.
 
 Switching connection types automatically clears stale credentials for the previous type.

--- a/ee/server/src/app/api/integrations/entra/_guards.ts
+++ b/ee/server/src/app/api/integrations/entra/_guards.ts
@@ -1,9 +1,8 @@
 import { NextResponse } from 'next/server';
-import { ADD_ONS, TIER_FEATURES } from '@alga-psa/types';
+import { TIER_FEATURES } from '@alga-psa/types';
 import { getCurrentUser } from '@alga-psa/user-composition/actions';
 import { hasPermission } from '@alga-psa/auth/rbac';
 import { featureFlags } from 'server/src/lib/feature-flags/featureFlags';
-import { AddOnAccessError, assertAddOnAccess } from 'server/src/lib/tier-gating/assertAddOnAccess';
 import { TierAccessError, assertTierAccess } from 'server/src/lib/tier-gating/assertTierAccess';
 
 type EntraGuardPermission = 'read' | 'update';
@@ -46,9 +45,9 @@ export async function requireEntraUiFlagEnabled(
 
   try {
     await assertTierAccess(TIER_FEATURES.INTEGRATIONS);
-    await assertAddOnAccess(ADD_ONS.ENTERPRISE);
+    await assertTierAccess(TIER_FEATURES.ENTRA_SYNC);
   } catch (error) {
-    if (error instanceof TierAccessError || error instanceof AddOnAccessError) {
+    if (error instanceof TierAccessError) {
       return NextResponse.json(
         {
           success: false,

--- a/ee/server/src/components/settings/account/AccountManagement.tsx
+++ b/ee/server/src/components/settings/account/AccountManagement.tsx
@@ -891,7 +891,7 @@ export default function AccountManagement() {
       activeTitle: 'Enterprise add-on active',
       activeBody: 'Microsoft Entra Sync is available for this tenant.',
     },
-  ];
+  ].filter((card) => card.addOn !== ADD_ONS.ENTERPRISE || hasAddOn(ADD_ONS.ENTERPRISE));
 
   return (
     <div className="space-y-6">

--- a/ee/server/src/components/settings/integrations/EntraIntegrationSettings.tsx
+++ b/ee/server/src/components/settings/integrations/EntraIntegrationSettings.tsx
@@ -732,7 +732,7 @@ export default function EntraIntegrationSettings({ canUseCipp: canUseCippTier = 
         <CardHeader>
           <div className="flex items-center justify-between gap-2">
             <CardTitle>{t('integrations.entra.settings.title')}</CardTitle>
-            <Badge variant="secondary">{t('integrations.entra.settings.badges.enterprise')}</Badge>
+            <Badge variant="secondary">{t('integrations.entra.settings.badges.pro')}</Badge>
           </div>
           <CardDescription>
             {t('integrations.entra.settings.description')}

--- a/ee/server/src/components/settings/integrations/entraIntegrationSettingsGates.ts
+++ b/ee/server/src/components/settings/integrations/entraIntegrationSettingsGates.ts
@@ -16,11 +16,11 @@ const CIPP_CONNECTION_OPTION: EntraConnectionOption = {
   description: 'Use a CIPP endpoint/token as the Entra data source for discovery and sync.',
 };
 
-export const buildEntraConnectionOptions = (_isCippEnabled: boolean): EntraConnectionOption[] => {
-  // CIPP entry point intentionally disabled in the UI. Server plumbing and the
-  // CIPP_CONNECTION_OPTION constant are retained so the path can be reinstated
-  // without a schema or API change.
-  return [DIRECT_CONNECTION_OPTION];
+export const buildEntraConnectionOptions = (isCippEnabled: boolean): EntraConnectionOption[] => {
+  // The caller combines the entra-integration-cipp flag with TIER_FEATURES.CIPP.
+  return isCippEnabled
+    ? [DIRECT_CONNECTION_OPTION, CIPP_CONNECTION_OPTION]
+    : [DIRECT_CONNECTION_OPTION];
 };
 
 export const shouldShowFieldSyncControls = (isFieldSyncEnabled: boolean): boolean => isFieldSyncEnabled;

--- a/packages/scheduling/tests/timeSheetApproval.test.ts
+++ b/packages/scheduling/tests/timeSheetApproval.test.ts
@@ -225,10 +225,11 @@ describe('TimeSheetApproval', () => {
     toggleButton.dispatchEvent(new MouseEvent('click', { bubbles: true }));
     await flushUi();
 
-    const suggestionInput = container.querySelector('textarea');
-    if (!suggestionInput) {
-      throw new Error('Suggestion input not found');
-    }
+    const suggestionInput = await waitFor(() => {
+      const input = container.querySelector('textarea');
+      expect(input).not.toBeNull();
+      return input as HTMLTextAreaElement;
+    }, { timeout: 5_000 });
 
     const valueSetter = Object.getOwnPropertyDescriptor(
       HTMLTextAreaElement.prototype,
@@ -240,12 +241,13 @@ describe('TimeSheetApproval', () => {
     suggestionInput.dispatchEvent(new Event('change', { bubbles: true }));
     await flushUi();
 
-    let requestChangesButton = Array.from(container.querySelectorAll('button')).find(
-      node => node.textContent?.includes('Request Changes'),
-    );
-    if (!requestChangesButton) {
-      throw new Error('Request Changes button not found');
-    }
+    let requestChangesButton = await waitFor(() => {
+      const button = Array.from(container.querySelectorAll('button')).find(
+        node => node.textContent?.includes('Request Changes'),
+      );
+      expect(button).toBeDefined();
+      return button as HTMLButtonElement;
+    }, { timeout: 5_000 });
     requestChangesButton.dispatchEvent(new MouseEvent('click', { bubbles: true }));
     await flushUi();
 
@@ -268,19 +270,21 @@ describe('TimeSheetApproval', () => {
     renderApprovalDrawer();
     await flushUi();
 
-    const freshToggleButton = container.querySelector('button[title="Show Details"]');
-    if (!freshToggleButton) {
-      throw new Error('Show Details button not found');
-    }
+    const freshToggleButton = await waitFor(() => {
+      const button = container.querySelector('button[title="Show Details"]');
+      expect(button).not.toBeNull();
+      return button as HTMLButtonElement;
+    }, { timeout: 5_000 });
     freshToggleButton.dispatchEvent(new MouseEvent('click', { bubbles: true }));
     await flushUi();
 
-    requestChangesButton = Array.from(container.querySelectorAll('button')).find(
-      node => node.textContent?.includes('Request Changes'),
-    );
-    if (!requestChangesButton) {
-      throw new Error('Request Changes button not found');
-    }
+    requestChangesButton = await waitFor(() => {
+      const button = Array.from(container.querySelectorAll('button')).find(
+        node => node.textContent?.includes('Request Changes'),
+      );
+      expect(button).toBeDefined();
+      return button as HTMLButtonElement;
+    }, { timeout: 5_000 });
     requestChangesButton.dispatchEvent(new MouseEvent('click', { bubbles: true }));
     await flushUi();
 

--- a/packages/scheduling/tests/timeSheetApproval.test.ts
+++ b/packages/scheduling/tests/timeSheetApproval.test.ts
@@ -217,10 +217,11 @@ describe('TimeSheetApproval', () => {
 
     await flushUi();
 
-    const toggleButton = container.querySelector('button[title="Show Details"]');
-    if (!toggleButton) {
-      throw new Error('Show Details button not found');
-    }
+    const toggleButton = await waitFor(() => {
+      const button = container.querySelector('button[title="Show Details"]');
+      expect(button).not.toBeNull();
+      return button as HTMLButtonElement;
+    }, { timeout: 5_000 });
     toggleButton.dispatchEvent(new MouseEvent('click', { bubbles: true }));
     await flushUi();
 
@@ -376,7 +377,9 @@ describe('TimeSheetApproval', () => {
     requestChangesButton.dispatchEvent(new MouseEvent('click', { bubbles: true }));
     await flushUi();
 
-    expect(container.textContent).toContain('Please correct the service classification.');
-    expect(container.querySelector('[data-feedback-state="unresolved"]')).not.toBeNull();
+    await waitFor(() => {
+      expect(container.textContent).toContain('Please correct the service classification.');
+      expect(container.querySelector('[data-feedback-state="unresolved"]')).not.toBeNull();
+    }, { timeout: 5_000 });
   });
 });

--- a/packages/types/src/constants/tierFeatures.test.ts
+++ b/packages/types/src/constants/tierFeatures.test.ts
@@ -36,7 +36,7 @@ describe('tierFeatures', () => {
       ]);
     });
 
-    it('pro tier includes solo features without add-on-only Teams integration', () => {
+    it('pro tier includes Entra Sync and CIPP without add-on-only Teams integration', () => {
       expect(TIER_FEATURE_MAP.pro).toEqual([
         TIER_FEATURES.INTEGRATIONS,
         TIER_FEATURES.EXTENSIONS,
@@ -45,10 +45,12 @@ describe('tierFeatures', () => {
         TIER_FEATURES.CLIENT_PORTAL_ADMIN,
         TIER_FEATURES.WORKFLOW_DESIGNER,
         TIER_FEATURES.MOBILE_ACCESS,
+        TIER_FEATURES.ENTRA_SYNC,
+        TIER_FEATURES.CIPP,
       ]);
     });
 
-    it('premium tier excludes add-on-only Teams and Entra Sync features', () => {
+    it('premium tier includes Entra Sync and CIPP but excludes add-on-only Teams integration', () => {
       expect(TIER_FEATURE_MAP.premium).toEqual([
         TIER_FEATURES.INTEGRATIONS,
         TIER_FEATURES.EXTENSIONS,
@@ -57,6 +59,7 @@ describe('tierFeatures', () => {
         TIER_FEATURES.CLIENT_PORTAL_ADMIN,
         TIER_FEATURES.WORKFLOW_DESIGNER,
         TIER_FEATURES.MOBILE_ACCESS,
+        TIER_FEATURES.ENTRA_SYNC,
         TIER_FEATURES.CIPP,
         TIER_FEATURES.ADVANCED_AUTHORIZATION_BUNDLES,
         TIER_FEATURES.OPPORTUNITY_MANAGEMENT,
@@ -83,18 +86,18 @@ describe('tierFeatures', () => {
       expect(tierHasFeature('pro', TIER_FEATURES.TEAMS_INTEGRATION)).toBe(false);
     });
 
-    it('pro cannot access premium or add-on-only features', () => {
-      expect(tierHasFeature('pro', TIER_FEATURES.ENTRA_SYNC)).toBe(false);
-      expect(tierHasFeature('pro', TIER_FEATURES.CIPP)).toBe(false);
+    it('pro can access Entra Sync and CIPP but not premium features', () => {
+      expect(tierHasFeature('pro', TIER_FEATURES.ENTRA_SYNC)).toBe(true);
+      expect(tierHasFeature('pro', TIER_FEATURES.CIPP)).toBe(true);
       expect(tierHasFeature('pro', TIER_FEATURES.ADVANCED_AUTHORIZATION_BUNDLES)).toBe(false);
       expect(tierHasFeature('pro', TIER_FEATURES.OPPORTUNITY_MANAGEMENT)).toBe(false);
     });
 
-    it('premium has access to premium tier features but not add-on-only features', () => {
+    it('premium has access to Entra and premium tier features but not add-on-only features', () => {
       expect(tierHasFeature('premium', TIER_FEATURES.INTEGRATIONS)).toBe(true);
       expect(tierHasFeature('premium', TIER_FEATURES.WORKFLOW_DESIGNER)).toBe(true);
       expect(tierHasFeature('premium', TIER_FEATURES.TEAMS_INTEGRATION)).toBe(false);
-      expect(tierHasFeature('premium', TIER_FEATURES.ENTRA_SYNC)).toBe(false);
+      expect(tierHasFeature('premium', TIER_FEATURES.ENTRA_SYNC)).toBe(true);
       expect(tierHasFeature('premium', TIER_FEATURES.CIPP)).toBe(true);
       expect(tierHasFeature('premium', TIER_FEATURES.ADVANCED_AUTHORIZATION_BUNDLES)).toBe(true);
       expect(tierHasFeature('premium', TIER_FEATURES.OPPORTUNITY_MANAGEMENT)).toBe(true);
@@ -116,9 +119,9 @@ describe('tierFeatures', () => {
       expect(FEATURE_MINIMUM_TIER[TIER_FEATURES.TEAMS_INTEGRATION]).toBe('pro');
     });
 
-    it('keeps historical minimum tier metadata for Entra/CIPP premium features', () => {
-      expect(FEATURE_MINIMUM_TIER[TIER_FEATURES.ENTRA_SYNC]).toBe('premium');
-      expect(FEATURE_MINIMUM_TIER[TIER_FEATURES.CIPP]).toBe('premium');
+    it('maps Entra Sync and CIPP to Pro while retaining other Premium features', () => {
+      expect(FEATURE_MINIMUM_TIER[TIER_FEATURES.ENTRA_SYNC]).toBe('pro');
+      expect(FEATURE_MINIMUM_TIER[TIER_FEATURES.CIPP]).toBe('pro');
       expect(FEATURE_MINIMUM_TIER[TIER_FEATURES.ADVANCED_AUTHORIZATION_BUNDLES]).toBe('premium');
       expect(FEATURE_MINIMUM_TIER[TIER_FEATURES.OPPORTUNITY_MANAGEMENT]).toBe('premium');
     });

--- a/packages/types/src/constants/tierFeatures.ts
+++ b/packages/types/src/constants/tierFeatures.ts
@@ -48,15 +48,14 @@ export const FEATURE_MINIMUM_TIER: Record<TIER_FEATURES, TenantTier> = {
   // Available to all tiers; a usage cap (planned: 150 workflow steps) will be enforced separately rather than tier-gated.
   [TIER_FEATURES.WORKFLOW_DESIGNER]: 'solo',
   [TIER_FEATURES.MOBILE_ACCESS]: 'solo',
-  [TIER_FEATURES.ENTRA_SYNC]: 'premium',
-  [TIER_FEATURES.CIPP]: 'premium',
+  [TIER_FEATURES.ENTRA_SYNC]: 'pro',
+  [TIER_FEATURES.CIPP]: 'pro',
   [TIER_FEATURES.TEAMS_INTEGRATION]: 'pro',
   [TIER_FEATURES.ADVANCED_AUTHORIZATION_BUNDLES]: 'premium',
   [TIER_FEATURES.OPPORTUNITY_MANAGEMENT]: 'premium',
 } as const;
 
 const ADD_ON_ONLY_FEATURES = new Set<TIER_FEATURES>([
-  TIER_FEATURES.ENTRA_SYNC,
   TIER_FEATURES.TEAMS_INTEGRATION,
 ]);
 

--- a/server/public/locales/de/msp/integrations.json
+++ b/server/public/locales/de/msp/integrations.json
@@ -367,7 +367,7 @@
           "syncAllStarting": "Wird gestartet…"
         },
         "badges": {
-          "enterprise": "Enterprise",
+          "pro": "Pro",
           "reviewBeforeInitialSync": "Vor initialer Synchronisation prüfen"
         },
         "connection": {

--- a/server/public/locales/en/msp/integrations.json
+++ b/server/public/locales/en/msp/integrations.json
@@ -367,7 +367,7 @@
           "syncAllStarting": "Starting…"
         },
         "badges": {
-          "enterprise": "Enterprise",
+          "pro": "Pro",
           "reviewBeforeInitialSync": "Review Before Initial Sync"
         },
         "connection": {

--- a/server/public/locales/es/msp/integrations.json
+++ b/server/public/locales/es/msp/integrations.json
@@ -367,7 +367,7 @@
           "syncAllStarting": "Iniciando…"
         },
         "badges": {
-          "enterprise": "Enterprise",
+          "pro": "Pro",
           "reviewBeforeInitialSync": "Revisar antes de la sincronización inicial"
         },
         "connection": {

--- a/server/public/locales/fr/msp/integrations.json
+++ b/server/public/locales/fr/msp/integrations.json
@@ -367,7 +367,7 @@
           "syncAllStarting": "Démarrage…"
         },
         "badges": {
-          "enterprise": "Enterprise",
+          "pro": "Pro",
           "reviewBeforeInitialSync": "Vérifier avant la synchronisation initiale"
         },
         "connection": {

--- a/server/public/locales/it/msp/integrations.json
+++ b/server/public/locales/it/msp/integrations.json
@@ -367,7 +367,7 @@
           "syncAllStarting": "Avvio in corso…"
         },
         "badges": {
-          "enterprise": "Enterprise",
+          "pro": "Pro",
           "reviewBeforeInitialSync": "Rivedi prima della sincronizzazione iniziale"
         },
         "connection": {

--- a/server/public/locales/nl/msp/integrations.json
+++ b/server/public/locales/nl/msp/integrations.json
@@ -367,7 +367,7 @@
           "syncAllStarting": "Starten…"
         },
         "badges": {
-          "enterprise": "Enterprise",
+          "pro": "Pro",
           "reviewBeforeInitialSync": "Controleer voor initiële synchronisatie"
         },
         "connection": {

--- a/server/public/locales/pl/msp/integrations.json
+++ b/server/public/locales/pl/msp/integrations.json
@@ -367,7 +367,7 @@
           "syncAllStarting": "Uruchamianie…"
         },
         "badges": {
-          "enterprise": "Enterprise",
+          "pro": "Pro",
           "reviewBeforeInitialSync": "Przejrzyj przed początkową synchronizacją"
         },
         "connection": {

--- a/server/public/locales/pt/msp/integrations.json
+++ b/server/public/locales/pt/msp/integrations.json
@@ -367,7 +367,7 @@
           "syncAllStarting": "Começando…"
         },
         "badges": {
-          "enterprise": "Empresa",
+          "pro": "Pro",
           "reviewBeforeInitialSync": "Revise antes da sincronização inicial"
         },
         "connection": {

--- a/server/public/locales/xx/msp/integrations.json
+++ b/server/public/locales/xx/msp/integrations.json
@@ -367,7 +367,7 @@
           "syncAllStarting": "11111"
         },
         "badges": {
-          "enterprise": "11111",
+          "pro": "11111",
           "reviewBeforeInitialSync": "11111"
         },
         "connection": {

--- a/server/public/locales/yy/msp/integrations.json
+++ b/server/public/locales/yy/msp/integrations.json
@@ -367,7 +367,7 @@
           "syncAllStarting": "55555"
         },
         "badges": {
-          "enterprise": "55555",
+          "pro": "55555",
           "reviewBeforeInitialSync": "55555"
         },
         "connection": {

--- a/server/src/app/msp/settings/integrations/IntegrationsSettingsBody.tsx
+++ b/server/src/app/msp/settings/integrations/IntegrationsSettingsBody.tsx
@@ -11,7 +11,7 @@ import { ADD_ONS, TIER_FEATURES } from '@alga-psa/types';
 export default function IntegrationsSettingsBody(): React.JSX.Element {
   const { hasAddOn } = useTier();
   const canUseCipp = useTierFeature(TIER_FEATURES.CIPP);
-  const canUseEntraSync = hasAddOn(ADD_ONS.ENTERPRISE);
+  const canUseEntraSync = useTierFeature(TIER_FEATURES.ENTRA_SYNC);
   const canUseTeams = hasAddOn(ADD_ONS.TEAMS);
 
   return (

--- a/server/src/lib/tier-gating/assertTierAccess.test.ts
+++ b/server/src/lib/tier-gating/assertTierAccess.test.ts
@@ -21,35 +21,42 @@ describe('assertTierAccess', () => {
 
   describe('TierAccessError', () => {
     it('creates error with correct properties', () => {
-      const error = new TierAccessError(TIER_FEATURES.ENTRA_SYNC, 'premium', 'pro');
+      const error = new TierAccessError(TIER_FEATURES.ENTRA_SYNC, 'pro', 'solo');
       expect(error.name).toBe('TierAccessError');
       expect(error.feature).toBe(TIER_FEATURES.ENTRA_SYNC);
-      expect(error.requiredTier).toBe('premium');
-      expect(error.currentTier).toBe('pro');
-      expect(error.message).toContain('Premium');
+      expect(error.requiredTier).toBe('pro');
+      expect(error.currentTier).toBe('solo');
+      expect(error.message).toContain('Pro');
     });
   });
 
   describe('assertTierAccess function', () => {
-    it('throws TierAccessError for pro tenant accessing ENTRA_SYNC', async () => {
+    it('allows a Pro tenant to access ENTRA_SYNC', async () => {
       vi.mocked(getSession).mockResolvedValue({
         user: { plan: 'pro' },
       } as any);
 
-      await expect(assertTierAccess(TIER_FEATURES.ENTRA_SYNC)).rejects.toThrow(TierAccessError);
-      await expect(assertTierAccess(TIER_FEATURES.ENTRA_SYNC)).rejects.toMatchObject({
-        feature: TIER_FEATURES.ENTRA_SYNC,
-        requiredTier: 'premium',
-        currentTier: 'pro',
-      });
+      await expect(assertTierAccess(TIER_FEATURES.ENTRA_SYNC)).resolves.toBeUndefined();
     });
 
-    it('throws for premium tenant accessing add-on-only ENTRA_SYNC by tier', async () => {
+    it('allows a Premium tenant to access ENTRA_SYNC', async () => {
       vi.mocked(getSession).mockResolvedValue({
         user: { plan: 'premium' },
       } as any);
 
-      await expect(assertTierAccess(TIER_FEATURES.ENTRA_SYNC)).rejects.toThrow(TierAccessError);
+      await expect(assertTierAccess(TIER_FEATURES.ENTRA_SYNC)).resolves.toBeUndefined();
+    });
+
+    it('throws TierAccessError for a Solo tenant accessing ENTRA_SYNC', async () => {
+      vi.mocked(getSession).mockResolvedValue({
+        user: { plan: 'solo' },
+      } as any);
+
+      await expect(assertTierAccess(TIER_FEATURES.ENTRA_SYNC)).rejects.toMatchObject({
+        feature: TIER_FEATURES.ENTRA_SYNC,
+        requiredTier: 'pro',
+        currentTier: 'solo',
+      });
     });
 
     it('does not throw for solo tenant accessing INTEGRATIONS (now unlocked at solo)', async () => {
@@ -108,15 +115,12 @@ describe('assertTierAccess', () => {
       await expect(assertTierAccess(TIER_FEATURES.TEAMS_INTEGRATION)).rejects.toThrow(TierAccessError);
     });
 
-    it('throws for NULL plan tenant (misconfigured → pro)', async () => {
+    it('allows a NULL plan tenant because the legacy fallback resolves to Pro', async () => {
       vi.mocked(getSession).mockResolvedValue({
         user: { plan: null },
       } as any);
 
-      await expect(assertTierAccess(TIER_FEATURES.ENTRA_SYNC)).rejects.toThrow(TierAccessError);
-      await expect(assertTierAccess(TIER_FEATURES.ENTRA_SYNC)).rejects.toMatchObject({
-        currentTier: 'pro',
-      });
+      await expect(assertTierAccess(TIER_FEATURES.ENTRA_SYNC)).resolves.toBeUndefined();
     });
 
     it('reverts expired Solo -> Pro trials back to solo access', async () => {

--- a/server/src/test/unit/components/integrations/entraIntegrationSettingsGates.test.ts
+++ b/server/src/test/unit/components/integrations/entraIntegrationSettingsGates.test.ts
@@ -14,13 +14,11 @@ describe('buildEntraConnectionOptions', () => {
     expect(options.find((option) => option.id === 'cipp')).toBeUndefined();
   });
 
-  it('ignores the CIPP flag and never surfaces CIPP in the UI', () => {
-    // CIPP entry point is intentionally removed from the UI. Server plumbing
-    // remains, but buildEntraConnectionOptions must not re-expose it.
+  it('returns Direct and CIPP options when CIPP is enabled', () => {
     const options = buildEntraConnectionOptions(true);
 
-    expect(options.map((option) => option.id)).toEqual(['direct']);
-    expect(options.find((option) => option.id === 'cipp')).toBeUndefined();
+    expect(options.map((option) => option.id)).toEqual(['direct', 'cipp']);
+    expect(options.find((option) => option.id === 'cipp')).toBeDefined();
   });
 
   it('hides field-sync controls and ambiguous queue when their flags are disabled', () => {

--- a/server/src/test/unit/context/TierContext.test.tsx
+++ b/server/src/test/unit/context/TierContext.test.tsx
@@ -55,6 +55,13 @@ describe('TierContext', () => {
     expect(result.current.tier).toBe('pro');
   });
 
+  it('grants Pro tenants access to Entra Sync and CIPP by tier', () => {
+    const { result } = renderHook(() => useTier(), { wrapper });
+
+    expect(result.current.hasFeature(TIER_FEATURES.ENTRA_SYNC)).toBe(true);
+    expect(result.current.hasFeature(TIER_FEATURES.CIPP)).toBe(true);
+  });
+
   it('defaults to hosted when no self-host licensing prop is supplied', () => {
     const { result } = renderHook(() => useTier(), { wrapper });
 

--- a/server/src/test/unit/integrations/entraAddOnGuard.test.ts
+++ b/server/src/test/unit/integrations/entraAddOnGuard.test.ts
@@ -1,9 +1,8 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 /**
- * T103/T104 (closing the 2026-05-12 teams-enterprise-addons plan debt):
- * Entra API guard returns 403 without the enterprise add-on, and tier alone
- * (premium, no add-on) never unlocks the add-on-only Teams/Entra features.
+ * T103/T104: Entra API access follows the tenant tier while Teams remains
+ * add-on-only.
  */
 
 const hoisted = vi.hoisted(() => {
@@ -25,7 +24,7 @@ const hoisted = vi.hoisted(() => {
     getCurrentUserMock: vi.fn(),
     hasPermissionMock: vi.fn(async () => true),
     assertAddOnAccessMock: vi.fn(async () => undefined),
-    assertTierAccessMock: vi.fn(async () => undefined),
+    assertTierAccessMock: vi.fn(async (_feature: string) => undefined),
     isEnabledMock: vi.fn(async () => true),
   };
 });
@@ -55,7 +54,7 @@ vi.mock('server/src/lib/tier-gating/assertTierAccess', () => ({
 import { requireEntraUiFlagEnabled } from '@ee/app/api/integrations/entra/_guards';
 import { TIER_FEATURES, TIER_FEATURE_MAP, tierHasFeature } from '@alga-psa/types';
 
-describe('Entra add-on guard (T103)', () => {
+describe('Entra tier guard (T103)', () => {
   beforeEach(() => {
     vi.clearAllMocks();
     hoisted.getCurrentUserMock.mockResolvedValue({
@@ -69,10 +68,12 @@ describe('Entra add-on guard (T103)', () => {
     hoisted.isEnabledMock.mockResolvedValue(true);
   });
 
-  it('T103: returns 403 when the enterprise add-on is missing — even for a tenant whose tier passes', async () => {
-    // Tier assertion passes (premium tier), add-on assertion fails: the guard
-    // must still refuse — tier alone never unlocks add-on-only features.
-    hoisted.assertAddOnAccessMock.mockRejectedValue(new hoisted.AddOnAccessError('Enterprise'));
+  it('T103: returns 403 when the tenant tier does not include Entra Sync', async () => {
+    hoisted.assertTierAccessMock.mockImplementation(async (feature: TIER_FEATURES) => {
+      if (feature === TIER_FEATURES.ENTRA_SYNC) {
+        throw new hoisted.TierAccessError(feature);
+      }
+    });
 
     const result = await requireEntraUiFlagEnabled('read');
 
@@ -84,29 +85,33 @@ describe('Entra add-on guard (T103)', () => {
     });
   });
 
-  it('T103: passes with the enterprise add-on active and returns tenant/user context', async () => {
+  it('T103: passes for a Pro tenant with no add-ons and returns tenant/user context', async () => {
     const result = await requireEntraUiFlagEnabled('read');
 
     expect(result).toEqual({ tenantId: 'tenant-1', userId: 'user-1' });
-    expect(hoisted.assertAddOnAccessMock).toHaveBeenCalled();
+    expect(hoisted.assertTierAccessMock).toHaveBeenNthCalledWith(1, TIER_FEATURES.INTEGRATIONS);
+    expect(hoisted.assertTierAccessMock).toHaveBeenNthCalledWith(2, TIER_FEATURES.ENTRA_SYNC);
+    expect(hoisted.assertAddOnAccessMock).not.toHaveBeenCalled();
   });
 
   it('rethrows unexpected assertion failures instead of masking them as 403', async () => {
-    hoisted.assertAddOnAccessMock.mockRejectedValue(new Error('database down'));
+    hoisted.assertTierAccessMock.mockRejectedValue(new Error('database down'));
 
     await expect(requireEntraUiFlagEnabled('read')).rejects.toThrow('database down');
   });
 });
 
 describe('tier-vs-addon separation (T104)', () => {
-  it('T104: premium tier alone does not unlock Teams or Entra features', () => {
+  it('T104: premium tier unlocks Entra Sync while Teams stays add-on-only', () => {
     expect(tierHasFeature('premium', TIER_FEATURES.TEAMS_INTEGRATION)).toBe(false);
-    expect(tierHasFeature('premium', TIER_FEATURES.ENTRA_SYNC)).toBe(false);
+    expect(tierHasFeature('premium', TIER_FEATURES.ENTRA_SYNC)).toBe(true);
 
     for (const tier of Object.keys(TIER_FEATURE_MAP) as Array<keyof typeof TIER_FEATURE_MAP>) {
       expect(TIER_FEATURE_MAP[tier]).not.toContain(TIER_FEATURES.TEAMS_INTEGRATION);
-      expect(TIER_FEATURE_MAP[tier]).not.toContain(TIER_FEATURES.ENTRA_SYNC);
     }
+
+    expect(TIER_FEATURE_MAP.pro).toContain(TIER_FEATURES.ENTRA_SYNC);
+    expect(TIER_FEATURE_MAP.premium).toContain(TIER_FEATURES.ENTRA_SYNC);
   });
 
   it('T104: non-add-on features remain tier-unlocked (control)', () => {


### PR DESCRIPTION
## Summary

- Move Microsoft Entra Sync and CIPP from Premium/Enterprise-add-on access to normal Pro-tier features.
- Gate shared Entra API routes with the Entra Sync tier feature, and restore the CIPP connection option when its feature flag and tier gate are enabled.
- Label the Entra integration as Pro across locales and stop offering new Enterprise add-on purchases while preserving the active-subscriber card and cancel path.
- Update tier-gating tests and documentation, including a follow-up plan for a deterministic CIPP emulator while retaining dormant add-on plumbing for future metering.
- Harden two existing timesheet approval UI-test waits after affected CI exposed asynchronous rendering races under parallel runner load.

## Smoke test

PASS with one blocked adjacent check.

Verified the seeded Oz workspace is Pro with only the AI Assistant add-on and no Enterprise add-on. In the real production EE build, Identity/Entra rendered with a “Pro” badge; both Direct Microsoft Partner and CIPP options were present; clicking CIPP opened the real URL/token dialog.

Using the documented `DISABLE_FEATURE_FLAGS` server override and a temporary minimal CIPP simulator, CIPP connected and validated successfully, advanced onboarding to Discover, and persisted two discovered tenants with correct names, domains, counts, and timestamps. No mocks were used. The simulator, credentials, connection, and discovered rows were removed afterward; the worktree is clean.

The EE artifact rebuilt successfully with the required 16 GB heap, and the app remains healthy on port 3164 with only the client Entra/CIPP flags forced.

Adjacent blocked check: Account Management could not be reverified because another active localhost card repeatedly replaced the shared browser cookie and navigated the available pane to port 3263; the previously reported React #310 crash therefore remains a concern.

Evidence includes the Pro badge, CIPP dialog, and post-validation Step 2 readiness at `/tmp/alga-smoke-evidence/cipp-pro-migration-20260722-183855`.

## Automated verification

- Focused CIPP/tier tests: 47/47 passed.
- Server and EE typechecks passed with `NODE_OPTIONS=--max-old-space-size=16384`.
- EE production build passed with `NODE_OPTIONS=--max-old-space-size=16384`.
- Focused timesheet approval suite: 5/5 passed after the CI-load wait hardening.