### PR TITLE
Onboarding resilience

### DIFF
--- a/packages/onboarding/src/actions/onboarding-actions/onboardingActions.ts
+++ b/packages/onboarding/src/actions/onboarding-actions/onboardingActions.ts
@@ -1068,6 +1068,24 @@ export const validateOnboardingDefaults = withAuth(async (
   }
 });
 
+export const saveOnboardingStepPosition = withAuth(async (
+  _user: IUserWithRoles,
+  _ctx: AuthContext,
+  step: number
+): Promise<OnboardingActionResult> => {
+  try {
+    if (!Number.isInteger(step) || step < 0) {
+      return { success: false, error: 'Invalid step position' };
+    }
+
+    await saveTenantOnboardingProgress({ currentStep: step });
+    return { success: true };
+  } catch (error) {
+    console.error('Error saving onboarding step position:', error);
+    return { success: false, error: onboardingActionErrorMessage(error, 'Failed to save onboarding step position') };
+  }
+});
+
 export const completeOnboarding = withAuth(async (
   _user: IUserWithRoles,
   _ctx: AuthContext

--- a/packages/onboarding/src/components/OnboardingWizard.tsx
+++ b/packages/onboarding/src/components/OnboardingWizard.tsx
@@ -23,7 +23,8 @@ import {
   setupBilling,
   configureTicketing,
   completeOnboarding,
-  validateOnboardingDefaults
+  validateOnboardingDefaults,
+  saveOnboardingStepPosition
 } from '../actions';
 import { useTranslation } from '@alga-psa/ui/lib/i18n/client';
 import { updateTenantDefaultLocaleAction } from '@alga-psa/tenancy/actions';
@@ -57,13 +58,25 @@ export function OnboardingWizard({
   productCode = 'psa',
 }: OnboardingWizardProps) {
   const { t } = useTranslation('msp/onboarding');
-  const [currentStep, setCurrentStep] = useState(0);
-  const [isLoading, setIsLoading] = useState(false);
-  const [errors, setErrors] = useState<Record<number, string>>({});
-  const [completedSteps, setCompletedSteps] = useState<Set<number>>(new Set());
-  const [attemptedSteps, setAttemptedSteps] = useState<Set<number>>(new Set());
   const activeStepIndexes = getOnboardingWizardStepIndexes(productCode);
   const requiredStepPositions = getOnboardingWizardRequiredStepPositions(productCode);
+
+  // Resume where the user left off: the last persisted step is restored (clamped to
+  // the valid range) and every step before it is treated as completed so the progress
+  // bar and step-click navigation reflect the restored position.
+  const restoredStep = (() => {
+    const saved = initialData.currentStep;
+    if (typeof saved !== 'number' || !Number.isInteger(saved)) return 0;
+    return Math.min(Math.max(saved, 0), activeStepIndexes.length - 1);
+  })();
+
+  const [currentStep, setCurrentStep] = useState(restoredStep);
+  const [isLoading, setIsLoading] = useState(false);
+  const [errors, setErrors] = useState<Record<number, string>>({});
+  const [completedSteps, setCompletedSteps] = useState<Set<number>>(
+    () => new Set(Array.from({ length: restoredStep }, (_, i) => i))
+  );
+  const [attemptedSteps, setAttemptedSteps] = useState<Set<number>>(new Set());
   const currentOriginalStepIndex = activeStepIndexes[currentStep] ?? activeStepIndexes[0] ?? 0;
   const isAlgaDesk = productCode === 'algadesk';
 
@@ -113,6 +126,16 @@ export function OnboardingWizard({
       console.log('Wizard State:', { currentStep, wizardData });
     }
   }, [currentStep, wizardData, debugMode]);
+
+  // Persist the step position on every change so a forced refresh resumes on the
+  // same step instead of restarting the wizard. Fire-and-forget: a failed write only
+  // means the next refresh resumes one step earlier.
+  useEffect(() => {
+    if (testMode) return;
+    saveOnboardingStepPosition(currentStep).catch((error) => {
+      console.error('Failed to persist onboarding step position:', error);
+    });
+  }, [currentStep, testMode]);
 
   const updateData = (data: Partial<WizardData>) => {
     setWizardData((prev) => ({ ...prev, ...data }));

--- a/packages/types/src/lib/onboardingWizard.ts
+++ b/packages/types/src/lib/onboardingWizard.ts
@@ -58,6 +58,9 @@ export interface WizardData {
   // ITIL Configuration
   is_itil_compliant?: boolean;
   importBoardItilSettings?: Record<string, boolean>;
+
+  // Wizard progress (persisted so a refresh resumes on the same step)
+  currentStep?: number;
 }
 
 export interface TeamMember {

--- a/server/src/test/unit/onboarding/onboardingWizardStepRestore.test.tsx
+++ b/server/src/test/unit/onboarding/onboardingWizardStepRestore.test.tsx
@@ -1,0 +1,149 @@
+/**
+ * @vitest-environment jsdom
+ */
+import React from 'react';
+import { cleanup, render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import '@testing-library/jest-dom';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { OnboardingWizard } from '../../../../../packages/onboarding/src/components/OnboardingWizard';
+import type { WizardData } from '@alga-psa/types';
+
+const mocks = vi.hoisted(() => ({
+  saveOnboardingStepPosition: vi.fn(() => Promise.resolve({ success: true })),
+  createClient: vi.fn(() => Promise.resolve({ success: true, data: { clientId: 'client-1' } })),
+}));
+
+vi.mock('../../../../../packages/onboarding/src/actions', () => ({
+  saveClientInfo: vi.fn(),
+  addTeamMembers: vi.fn(),
+  createClient: mocks.createClient,
+  addClientContact: vi.fn(),
+  setupBilling: vi.fn(),
+  configureTicketing: vi.fn(),
+  completeOnboarding: vi.fn(),
+  validateOnboardingDefaults: vi.fn(),
+  saveOnboardingStepPosition: mocks.saveOnboardingStepPosition,
+}));
+
+vi.mock('@alga-psa/tenancy/actions', () => ({
+  updateTenantDefaultLocaleAction: vi.fn(),
+}));
+
+vi.mock('@alga-psa/core/i18n/config', () => ({
+  isSupportedLocale: () => true,
+}));
+
+vi.mock('@alga-psa/ui/lib/i18n/client', () => ({
+  useTranslation: () => ({
+    t: (key: string, options?: Record<string, unknown>) =>
+      String(options?.defaultValue ?? key),
+  }),
+  useI18n: () => ({
+    locale: 'en',
+    setLocale: vi.fn(),
+  }),
+}));
+
+vi.mock('@alga-psa/ui/components/Dialog', () => ({
+  Dialog: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+}));
+
+vi.mock('@alga-psa/ui/components/onboarding/WizardProgress', () => ({
+  WizardProgress: ({ currentStep, completedSteps }: { currentStep: number; completedSteps: Set<number> }) => (
+    <div>
+      <span data-testid="current-step">{currentStep}</span>
+      <span data-testid="completed-steps">{[...completedSteps].sort().join(',')}</span>
+    </div>
+  ),
+}));
+
+vi.mock('@alga-psa/ui/components/onboarding/WizardNavigation', () => ({
+  WizardNavigation: ({ onNext, isNextDisabled }: { onNext: () => void; isNextDisabled: boolean }) => (
+    <button data-testid="next-button" disabled={isNextDisabled} onClick={onNext}>
+      Next
+    </button>
+  ),
+}));
+
+vi.mock('@alga-psa/ui/components/Alert', () => ({
+  Alert: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+  AlertDescription: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+}));
+
+vi.mock('../../../../../packages/onboarding/src/components/steps/ClientInfoStep', () => ({
+  ClientInfoStep: () => <div>ClientInfoStep</div>,
+}));
+vi.mock('../../../../../packages/onboarding/src/components/steps/TeamMembersStep', () => ({
+  TeamMembersStep: () => <div>TeamMembersStep</div>,
+}));
+vi.mock('../../../../../packages/onboarding/src/components/steps/AddClientStep', () => ({
+  AddClientStep: () => <div>AddClientStep</div>,
+}));
+vi.mock('../../../../../packages/onboarding/src/components/steps/ClientContactStep', () => ({
+  ClientContactStep: () => <div>ClientContactStep</div>,
+}));
+vi.mock('../../../../../packages/onboarding/src/components/steps/BillingSetupStep', () => ({
+  BillingSetupStep: () => <div>BillingSetupStep</div>,
+}));
+vi.mock('../../../../../packages/onboarding/src/components/steps/TicketingConfigStep', () => ({
+  TicketingConfigStep: () => <div>TicketingConfigStep</div>,
+}));
+
+afterEach(cleanup);
+beforeEach(() => {
+  mocks.saveOnboardingStepPosition.mockClear();
+  mocks.createClient.mockClear();
+});
+
+const renderWizard = (initialData: Partial<WizardData> = {}) =>
+  render(<OnboardingWizard fullPage initialData={initialData} onComplete={vi.fn()} />);
+
+describe('OnboardingWizard step restore (refresh resilience)', () => {
+  it('starts on step 0 when no step position was saved', () => {
+    renderWizard();
+
+    expect(screen.getByText('ClientInfoStep')).toBeInTheDocument();
+    expect(screen.getByTestId('current-step')).toHaveTextContent('0');
+    expect(screen.getByTestId('completed-steps')).toHaveTextContent('');
+  });
+
+  it('resumes on the saved step and marks earlier steps completed', () => {
+    renderWizard({ currentStep: 2 });
+
+    expect(screen.getByText('AddClientStep')).toBeInTheDocument();
+    expect(screen.getByTestId('current-step')).toHaveTextContent('2');
+    expect(screen.getByTestId('completed-steps')).toHaveTextContent('0,1');
+  });
+
+  it('clamps an out-of-range saved step to the last step', () => {
+    renderWizard({ currentStep: 99 });
+
+    expect(screen.getByText('TicketingConfigStep')).toBeInTheDocument();
+    expect(screen.getByTestId('current-step')).toHaveTextContent('5');
+  });
+
+  it('ignores a non-numeric saved step', () => {
+    renderWizard({ currentStep: 'billing' as unknown as number });
+
+    expect(screen.getByText('ClientInfoStep')).toBeInTheDocument();
+    expect(screen.getByTestId('current-step')).toHaveTextContent('0');
+  });
+
+  it('persists the step position on mount and after advancing', async () => {
+    const user = userEvent.setup();
+    renderWizard({ currentStep: 2, clientName: 'Acme Corp' });
+
+    await waitFor(() => {
+      expect(mocks.saveOnboardingStepPosition).toHaveBeenCalledWith(2);
+    });
+
+    await user.click(screen.getByTestId('next-button'));
+
+    await waitFor(() => {
+      expect(mocks.saveOnboardingStepPosition).toHaveBeenCalledWith(3);
+    });
+    expect(screen.getByText('ClientContactStep')).toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
## Summary

- Persist the onboarding wizard `currentStep` in `tenant_settings.onboarding_data` whenever the active step changes.
- Restore and clamp the saved step when the wizard mounts.
- Backfill earlier steps as completed so restored progress navigation remains usable.
- Cover default, restored, invalid, clamped, and advancing-step behavior with unit tests.

## Validation

PASS. Exercised the real onboarding wizard at `localhost:3256`: dev login; Client Info → Team Members; confirmed `tenant_settings.onboarding_data.currentStep=1` in PostgreSQL; forced reload resumed Team Members; confirmed restored progress navigation remained usable; Back persisted `currentStep=0` and reload resumed Client Info. No browser console errors or failed requests occurred. Temporary password and onboarding test state were restored afterward. No simulator or product mock was used.

The 63 onboarding unit tests pass, and TypeScript compilation is clean.

Evidence: `/tmp/alga-smoke-evidence/onboarding-resilience-20260722-211756`

## Test environment notes

- Fidelity compromise: alga-dev created card-scoped tabs but rejected them as belonging to another host, so Playwright with system Chrome controlled the same real app instead.
- Environment repairs required: recovered host-run config used Docker-only hostnames for PgBouncer, Redis, and Hocuspocus; these were corrected to `localhost`.
- A corrupt Turbopack cache was preserved under `/tmp` and rebuilt.
- App and infrastructure remain healthy; sign-in returns HTTP 200.
- Pre-existing `package-lock.json` and `server/package.json` worktree changes were untouched.