### PR TITLE
docs: fix developer setup guide after fresh-machine end-to-end test

### DIFF
--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -12,8 +12,8 @@ Thank you for your interest in contributing to Alga PSA! We appreciate contribut
 
 ## Getting Started
 
-1. **Fork the repository** and clone it locally
-2. **Set up your development environment** following the [Setup Guide](getting-started/setup_guide.md)
+1. **Fork the repository** and clone it locally (`git clone https://github.com/nine-minds/alga-psa.git`)
+2. **Set up your development environment** following the [Development Guide](getting-started/development_guide.md). (To run a production-like deployment with prebuilt images instead, see the [Setup Guide](getting-started/setup_guide.md).)
 3. **Create a branch** for your changes:
    ```bash
    git checkout -b feature/your-feature-name

--- a/docs/getting-started/development_guide.md
+++ b/docs/getting-started/development_guide.md
@@ -7,37 +7,86 @@ This guide covers development workflows, best practices, and common tasks when w
 ### Prerequisites
 - Docker Engine 24.0.0+
 - Docker Compose v2.20.0+
-- Node.js 18+
+- Node.js `>=20 <25` (for running tests and tooling on the host)
 - Git
 - VS Code (recommended)
+- ~80 GB of free disk space for Docker images, build cache, and volumes
+  (image builds alone can transiently consume 30–40 GB);
+  16 GB RAM recommended for building the server image
+
+On a fresh Ubuntu 24.04 machine, install the prerequisites with:
+
+```bash
+# Docker Engine + Compose v2 (Ubuntu packages satisfy the version requirements)
+sudo apt-get update
+sudo apt-get install -y docker.io docker-compose-v2 git
+
+# Run docker without sudo (takes effect on next login, or run `newgrp docker`)
+sudo usermod -aG docker $USER
+
+# Node.js 22 LTS via NodeSource (Ubuntu's apt nodejs is too old):
+curl -fsSL https://deb.nodesource.com/setup_22.x | sudo -E bash -
+sudo apt-get install -y nodejs
+```
+
+Verify the versions:
+
+```bash
+docker --version            # 24.0.0 or later
+docker compose version      # v2.20.0 or later
+node --version              # >=20 <25
+```
 
 ### Initial Setup
 
 1. Clone and setup:
 ```bash
-git clone https://github.com/your-org/alga-psa.git
+git clone https://github.com/nine-minds/alga-psa.git
 cd alga-psa
-cp .env.example .env.development
+cp .env.example .env
 ```
 
-2. Create development secrets:
+> Compose reads `.env` in the project root by default. If you name the file
+> something else (e.g. `.env.development`), pass it explicitly with
+> `--env-file .env.development` on every `docker compose` command.
+
+> Compose prints `The "X" variable is not set. Defaulting to a blank string.`
+> warnings for a handful of optional values that `.env.example` does not
+> define (e.g. `VERSION`, `HOST`, `PROJECT_NAME`, `TOKEN_EXPIRES`,
+> `SALT_BYTES`). These are safe to ignore for local development — the server
+> image carries its own baked-in defaults.
+
+2. Create development secrets. The Compose stack requires these 11 secret files:
+
 ```bash
 mkdir -p secrets
-# Create development secrets with dummy values
-echo 'dev-password' > secrets/db_password_server
-echo 'dev-password' > secrets/db_password_hocuspocus
-# ... create other required secrets
+for s in postgres_password db_password_server db_password_hocuspocus \
+         redis_password email_password crypto_key token_secret_key \
+         nextauth_secret google_oauth_client_id google_oauth_client_secret \
+         alga_auth_key; do
+  echo "dev-$(openssl rand -hex 24)" > "secrets/$s"
+done
 chmod 600 secrets/*
 ```
 
-3. Start development environment:
+3. Start development environment (the first run builds the server image from
+   source, which can take 15–30 minutes):
 ```bash
 # For Community Edition
-docker compose -f docker-compose.base.yaml -f docker-compose.ce.yaml up
+docker compose -f docker-compose.base.yaml -f docker-compose.ce.yaml up -d
 
 # For Enterprise Edition
-docker compose -f docker-compose.base.yaml -f docker-compose.ee.yaml up
+docker compose -f docker-compose.base.yaml -f docker-compose.ee.yaml up -d
 ```
+
+4. Retrieve the seeded workspace admin credentials. On first boot the server
+   logs print an admin email and generated password:
+```bash
+docker compose -f docker-compose.base.yaml -f docker-compose.ce.yaml logs -f server
+```
+Look for a banner containing `User Email is ->` and `Password is ->`.
+
+5. Open http://localhost:3000 and sign in with those credentials.
 
 ## Development Workflow
 
@@ -225,7 +274,7 @@ export const myAction = withAuth(async (user, { tenant }, arg1: string): Promise
 
 1. Enable debug logs:
 ```bash
-docker compose up -f docker-compose.base.yaml -f docker-compose.ce.yaml -e DEBUG=true
+DEBUG=true docker compose -f docker-compose.base.yaml -f docker-compose.ce.yaml up -d
 ```
 
 2. Use VS Code debugger:
@@ -476,19 +525,15 @@ docker compose exec [service] sh
 
 ### Useful Scripts
 
-1. Development setup:
+1. Build the CE/EE server images locally (also used for prebuilt deployments):
 ```bash
-./scripts/dev-setup.sh
+./scripts/set-image-tag.sh
 ```
 
-2. Test data generation:
+2. Compose wrapper that validates secret files (trailing newlines, presence)
+   before delegating to `docker compose`:
 ```bash
-./scripts/generate-test-data.sh
-```
-
-3. Dependency updates:
-```bash
-./scripts/update-deps.sh
+./scripts/docker-compose-wrapper.sh -f docker-compose.base.yaml -f docker-compose.ce.yaml up -d
 ```
 
 ## Additional Resources

--- a/docs/getting-started/getting-started.md
+++ b/docs/getting-started/getting-started.md
@@ -1,5 +1,18 @@
-First, run:
+# Getting Started with Alga PSA
 
-node setup/create_database.js
-npx knex --knexfile knexfile.cjs migrate:latest --env development
-npx knex seed:run --knexfile knexfile.cjs --env development
+Choose the path that matches what you want to do:
+
+- **Run Alga PSA with prebuilt images** (evaluation or production-like
+  deployment): follow the [Complete Setup Guide](setup_guide.md). It covers
+  release selection, secrets, environment configuration, Docker Compose,
+  initial login credentials, persistence, and backups.
+- **Develop Alga PSA locally** (build from source, run tests, contribute
+  code): follow the [Development Guide](development_guide.md), then the
+  [Contributing Guide](../contributing.md).
+- **Turnkey on-premise install** from a bootable ISO: see the
+  [Appliance Install Guide](appliance_install.md).
+- **Windows-specific setup**: see the [Windows Setup Guide](setup_guide_windows.md).
+
+After the stack is up, use [Verify Setup](verify-setup.md) to confirm
+everything is healthy, and the [Configuration Guide](configuration_guide.md)
+to tune environment variables.


### PR DESCRIPTION
## What

End-to-end tested the documented developer setup process on a **pristine Ubuntu 24.04 VM**, following nothing but the docs. Every snag that blocked or misled a new developer is fixed here; the fixed docs were then validated with a second clean run (VM reverted to a fresh-install snapshot) that brought the CE dev stack up with zero deviations.

## Method

1. Provisioned a fresh Ubuntu 24.04 cloud VM (no docker, no node), snapshot after base install.
2. Followed the docs exactly (README → `docs/contributing.md` → `docs/getting-started/development_guide.md`). Recorded every failure/deviation.
3. Fixed the docs, reverted the VM to the snapshot, and re-ran using only the fixed docs — stack came up cleanly: 10 containers, sign-in page renders at `http://localhost:3000`, seeded admin credentials appear in the server logs as documented.

## Snags found and fixed

| # | Snag | Fix |
|---|------|-----|
| 1 | No instructions for installing prerequisites on Linux (fresh Ubuntu has no docker/node) | Added Ubuntu 24.04 install commands (`docker.io`, `docker-compose-v2`, Node 22 via NodeSource) + version checks |
| 2 | Disk/RAM requirements undocumented — image builds transiently consume 30–40 GB (a 40 GB disk is not enough) | Documented ~80 GB disk / 16 GB RAM recommendation |
| 3 | Clone URL was `github.com/your-org/alga-psa.git` (fails) | `github.com/nine-minds/alga-psa.git` |
| 4 | `cp .env.example .env.development` — but compose reads `.env` by default, so all interpolation variables came up blank | `cp .env.example .env`; documented the `--env-file` alternative and that the unset-variable warnings are harmless |
| 5 | Secrets section showed 2 of the 11 secret files the dev compose stack requires (compose fails fast on the missing ones) | Full 11-file loop with `openssl rand` values |
| 6 | No guidance on first login / verifying the stack is up | Documented retrieving the seeded admin credentials from the server logs and opening `http://localhost:3000` |
| 7 | Node `18+` contradicted README's `>=20 <25` (Ubuntu apt ships 18) | Aligned on `>=20 <25`, NodeSource install |
| 8 | `docker compose up -f ... -e DEBUG=true` is invalid syntax | `DEBUG=true docker compose -f ... up -d` |
| 9 | Referenced scripts don't exist (`dev-setup.sh`, `generate-test-data.sh`, `update-deps.sh`) | Replaced with real scripts (`set-image-tag.sh`, `docker-compose-wrapper.sh`) |
| 10 | `contributing.md` sent developers to the prebuilt-deployment Setup Guide | Points to the Development Guide; Setup Guide kept as the deployment path |
| 11 | `getting-started.md` was a stale stub referencing nonexistent `setup/create_database.js` / `knexfile.cjs` | Rewritten as a landing page routing to the right guide |

## Notes / out of scope

- The CE server image carries multi-GB webpack cache (`server/node_modules/.cache/webpack`) in its runtime layers — worth a separate Dockerfile hygiene pass; it materially contributes to the disk requirement above.
- Verification was done against the CE dev stack (`docker-compose.base.yaml` + `docker-compose.ce.yaml`). The EE path is documented identically but was not exercised in this test.