### PR TITLE
Marketing workflow fanout fix

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -36,6 +36,8 @@ build
 !packages/core/dist/**
 !packages/db/dist/**
 !packages/event-schemas/dist/**
+!packages/event-bus/dist/**
+!packages/types/dist/**
 
 # Environment variables
 .env

--- a/.dockerignore
+++ b/.dockerignore
@@ -19,6 +19,8 @@ build
 !packages/db/dist/**
 !packages/email/dist
 !packages/email/dist/**
+!packages/marketing/dist
+!packages/marketing/dist/**
 !ee/packages/workflows/dist/**
 !packages/workflow-streams/dist/**
 # temporal-worker parity build (Dockerfile prebuilt stage) COPYs the locally

--- a/docs/plans/2026-07-23-marketing-temporal-fanout-routing-plan.md
+++ b/docs/plans/2026-07-23-marketing-temporal-fanout-routing-plan.md
@@ -1,0 +1,400 @@
+# Marketing Temporal Fan-out Routing
+
+- Date: 2026-07-23
+- Branch: `fix/marketing-workflow-fanout-routing`
+- Status: Approved design; implementation pending
+
+## Objective
+
+Replace the three per-tenant Enterprise marketing schedules with three global
+Temporal schedules. Each scheduled workflow discovers every tenant, runs the
+selected marketing operation as tenant-scoped Temporal activities with bounded
+parallelism, waits for every tenant, and reports a truthful aggregate result.
+
+Community Edition keeps its existing pg-boss scheduling.
+
+## Production finding
+
+Production Loki logs on 2026-07-23 prove the current failure path:
+
+1. Startup creates a Temporal Schedule for every tenant and each of these three
+   jobs:
+   - `marketing:flip-due-posts`
+   - `marketing:expire-stale-targets`
+   - `marketing:send-sequence-steps`
+2. Each schedule starts `genericJobWorkflow` on the `alga-jobs` task queue.
+3. The workflow reaches `temporal-worker`.
+4. `temporal-worker` rejects the activity with
+   `No handler registered for job type: marketing:<job>`.
+5. Its advertised handler registry contains no marketing handlers.
+
+The workflow IDs in the same log window contain different tenant IDs for the
+same five-minute fire, confirming the current per-tenant workflow fan-out.
+
+## Settled design
+
+1. Create one global schedule per marketing job, not one combined schedule.
+2. Preserve the existing cadences:
+   - flip due posts: every five minutes;
+   - send sequence steps: every five minutes;
+   - expire stale targets: hourly at minute 11.
+3. Run the global workflows on the existing `tenant-workflows` queue owned by
+   `temporal-worker`.
+4. Temporal owns the tenant loop. There is one visible activity execution per
+   tenant, with at most ten tenant activities running concurrently.
+5. Activities execute `@alga-psa/marketing` domain operations directly inside
+   `temporal-worker`. Do not route through `genericJobWorkflow`, the server, or
+   the event bus.
+6. Marketing PostHog flags are UI-only. Background activities run for every
+   tenant; tenants with empty marketing tables are successful no-ops.
+7. A thrown tenant activity error receives up to three attempts with
+   exponential backoff. Exhausted tenant failures are recorded without
+   preventing later tenants from running.
+8. The workflow waits for every tenant. It completes when all tenant activities
+   succeed and fails after fan-out when one or more tenants exhausted retries.
+   The full aggregate summary is returned or attached to the failure.
+9. `sendDueSequenceStepsInternal` may report handled enrollment failures after
+   applying its 30-minute domain backoff. That is a successful activity result,
+   not a reason for an immediate Temporal retry.
+10. Use schedule overlap `SKIP` and a short catch-up window so slow runs and
+    downtime do not create replay storms.
+11. Upsert the three global schedules before deleting the legacy per-tenant
+    schedules.
+12. Use Pareto testing: focused unit and contract coverage for the high-risk
+    boundaries, with full end-to-end behavior verified by smoke testing.
+
+## Implementation
+
+### 1. Define a worker-safe marketing job contract
+
+Add a small worker-safe module under `packages/marketing/src/lib/` that owns:
+
+- the three canonical marketing job-name constants;
+- a `MarketingJobName` union;
+- input and operation-result types shared by activities, workflows, schedules,
+  and the existing server handlers;
+- a runtime guard for rejecting unknown job names.
+
+Update `server/src/lib/jobs/handlers/marketingJobs.ts` to import the canonical
+constants instead of declaring its own copies. Preserve the current CE handler
+behavior; the EE fan-out will bypass these server handlers.
+
+Avoid importing the marketing package root from the worker. Import the narrow
+Node-safe library subpaths needed for posts, sequences, and the shared job
+contract.
+
+### 2. Add direct marketing activities
+
+Create
+`ee/temporal-workflows/src/activities/marketing-activities.ts` with two
+activities.
+
+#### `listMarketingTenantIds`
+
+- Open the admin database connection.
+- Enumerate `tenants.tenant` through an explicitly unscoped `tenantDb` query.
+- Return stable string tenant IDs in deterministic order.
+- Do not query PostHog or filter tenants by the UI feature flag.
+
+#### `runMarketingJobForTenant`
+
+Accept `{ jobName, tenantId }`, establish the tenant execution context, and
+dispatch through an exhaustive switch:
+
+- `marketing:flip-due-posts` ->
+  `flipDuePostsInternal(knex, tenantId)`;
+- `marketing:expire-stale-targets` ->
+  `expireStaleTargetsInternal(knex, tenantId, 48)`;
+- `marketing:send-sequence-steps` ->
+  `sendDueSequenceStepsInternal(knex, tenantId, executionConfig)`.
+
+For sequence sends:
+
+- build the canonical public base URL from the worker's deployment URL
+  configuration using the same precedence as the current server handler;
+- obtain the existing `NEXTAUTH_SECRET` already injected into
+  `temporal-worker`;
+- fail before sending when the signing secret is absent;
+- return the sequence operation's domain summary unchanged, including handled
+  enrollment failures.
+
+Return a discriminated result containing the job name, tenant ID, operation
+summary, and completion timestamp. Log structured start, success, and thrown
+failure events without logging secrets or message content.
+
+Export the new activities from both activity index entry points used by the
+production worker.
+
+### 3. Add the global fan-out workflow
+
+Create
+`ee/temporal-workflows/src/workflows/marketing-fanout-workflow.ts`.
+
+The workflow accepts `{ jobName }` and produces:
+
+```ts
+{
+  jobName,
+  total,
+  succeeded,
+  failed,
+  results
+}
+```
+
+Implementation behavior:
+
+1. Call `listMarketingTenantIds`.
+2. Process the returned IDs with a deterministic worker pool capped at ten
+   concurrent promises.
+3. Invoke `runMarketingJobForTenant` once per tenant.
+4. Configure tenant activity retries for three attempts with exponential
+   backoff and a timeout compatible with the existing five-minute sequence job
+   handler.
+5. Catch an exhausted activity failure inside the pool, add
+   `{ tenantId, status: 'failed', error }`, and continue.
+6. Preserve successful domain summaries in the result list.
+7. After all workers settle, log the aggregate counts.
+8. If `failed > 0`, throw a non-retryable `ApplicationFailure` whose details
+   contain the complete summary. Otherwise return the summary.
+
+Tenant-discovery failure is a workflow-level failure because there is no safe
+fan-out set to process. It should use the activity retry policy and then fail
+normally if retries are exhausted.
+
+Export the workflow from both workflow index entry points loaded by the
+production worker.
+
+### 4. Converge three global schedules
+
+Extend `ee/temporal-workflows/src/schedules/setupSchedules.ts` with three
+schedule definitions:
+
+| Schedule ID | Job | Cadence |
+| --- | --- | --- |
+| `marketing-fanout:flip-due-posts` | `marketing:flip-due-posts` | `*/5 * * * *` |
+| `marketing-fanout:send-sequence-steps` | `marketing:send-sequence-steps` | `*/5 * * * *` |
+| `marketing-fanout:expire-stale-targets` | `marketing:expire-stale-targets` | `11 * * * *` |
+
+Each schedule:
+
+- starts `marketingFanoutWorkflow`;
+- targets `tenant-workflows`;
+- uses `ScheduleOverlapPolicy.SKIP`;
+- uses the existing short catch-up policy;
+- has a one-hour workflow execution timeout.
+
+Use the existing schedule upsert helper so repeated setup refreshes the
+configuration without creating duplicates.
+
+### 5. Remove legacy schedules safely
+
+After all three global upserts succeed:
+
+1. List Temporal schedules.
+2. Select only IDs beginning with one of:
+   - `marketing:flip-due-posts:`;
+   - `marketing:expire-stale-targets:`;
+   - `marketing:send-sequence-steps:`.
+3. Delete each matching schedule through the existing not-found-tolerant
+   deletion helper.
+4. Log scanned, matched, deleted, and failed counts.
+
+The cleanup must be idempotent and safe when several `temporal-worker` replicas
+run schedule setup concurrently. A schedule disappearing between list and
+delete is success, not an error. Never match the new `marketing-fanout:*`
+schedule IDs or unrelated schedules.
+
+Do not delete historical `jobs` or `job_details` rows in this change. Removing
+tracker records is not required to stop execution and would destroy useful
+history.
+
+### 6. Stop EE from recreating tenant schedules
+
+Update `server/src/lib/jobs/initializeScheduledJobs.ts` so the three per-tenant
+marketing scheduling blocks run only outside the Enterprise workflow edition.
+
+- EE/appliance: the Temporal worker's three global schedules are authoritative.
+- CE: keep the current per-tenant pg-boss jobs and handlers unchanged.
+
+Keep the edition decision next to the three marketing blocks so future
+maintainers do not accidentally reintroduce dual scheduling.
+
+### 7. Package the marketing runtime in `temporal-worker`
+
+Update the Temporal worker build and package metadata so direct activity imports
+work in the production image:
+
+- add `@alga-psa/marketing` as an explicit Temporal worker dependency;
+- build `packages/marketing` before compiling `ee/temporal-workflows`;
+- copy `packages/marketing/dist` into production and prebuilt images;
+- preserve the existing `@alga-psa/*` runtime symlink layout;
+- add a Docker/runtime guard that imports the exact marketing subpaths and
+  asserts the three required domain functions exist.
+
+The current worktree already requires `@alga-psa/marketing` to be built before
+the wired dev server starts. Do not rely on that incidental local artifact;
+make the Temporal image build deterministic.
+
+## Pareto test plan
+
+### Workflow orchestration
+
+Add focused tests under
+`ee/temporal-workflows/src/workflows/__tests__/`:
+
+- all discovered tenants are invoked exactly once;
+- observed tenant activity concurrency never exceeds ten;
+- one exhausted tenant failure does not prevent later tenants from running;
+- zero failures returns the expected aggregate;
+- one or more exhausted failures throws only after all tenants were attempted
+  and attaches the aggregate summary.
+
+Mock activities directly. Do not add a full Temporal test-environment suite for
+this change.
+
+### Activity routing
+
+Add focused tests under
+`ee/temporal-workflows/src/activities/__tests__/`:
+
+- each canonical job name calls the corresponding marketing operation with the
+  tenant;
+- tenant discovery uses the explicit unscoped tenant enumeration;
+- unknown job names are rejected;
+- absent `NEXTAUTH_SECRET` prevents sequence sending;
+- a returned sequence summary with handled enrollment failures resolves
+  successfully;
+- a thrown operation error is rethrown for Temporal to retry.
+
+### Schedule cutover and edition boundary
+
+Extend schedule tests or add
+`setupSchedules.marketing-fanout.test.ts`:
+
+- the three global IDs, cron expressions, workflow type, queue, overlap policy,
+  and arguments are exact;
+- global schedules are upserted before legacy deletion begins;
+- only the three legacy prefixes are deleted;
+- not-found races are tolerated;
+- repeated setup remains idempotent.
+
+Add a small server scheduling test proving:
+
+- EE does not call the three per-tenant marketing scheduling functions;
+- CE still calls them with the existing cadences.
+
+### Registration and artifact contracts
+
+Extend `ee/temporal-workflows/src/__tests__/worker-registration.test.ts` to
+assert the workflow and activities are exported.
+
+Extend the production runtime-import validation to assert the built marketing
+subpaths load and expose:
+
+- `flipDuePostsInternal`;
+- `expireStaleTargetsInternal`;
+- `sendDueSequenceStepsInternal`.
+
+### Suggested verification commands
+
+Run the narrow suites first, then the affected package builds:
+
+```bash
+npm run test --workspace=temporal-workflows -- --run \
+  src/workflows/__tests__/marketing-fanout-workflow.test.ts \
+  src/activities/__tests__/marketing-activities.test.ts \
+  src/schedules/__tests__/setupSchedules.marketing-fanout.test.ts \
+  src/__tests__/worker-registration.test.ts
+
+npm run test --workspace=server -- --run \
+  src/test/unit/initializeScheduledJobs.marketing.test.ts
+
+npm run build --workspace=@alga-psa/marketing
+npm run build --workspace=temporal-workflows
+```
+
+Adjust only the command syntax if the repository's current Vitest workspace
+wrapper requires it; do not broaden this task into unrelated failing suites.
+
+## Smoke testing
+
+Use the already wired development stack after implementation:
+
+1. Run schedule setup twice and confirm it remains idempotent.
+2. List schedules and confirm exactly the three `marketing-fanout:*` schedules
+   exist and no legacy marketing tenant schedule remains.
+3. Trigger the safe flip-due-posts global schedule.
+4. Confirm Temporal shows one workflow with tenant activities, never more than
+   ten concurrently.
+5. Confirm the workflow returns aggregate counts and empty-data tenants are
+   successful no-ops.
+6. Confirm worker logs contain no missing-handler errors.
+
+After deployment, verify from Temporal and Loki:
+
+- only three marketing schedules remain;
+- each fire creates one workflow per job rather than one per tenant;
+- per-tenant activity outcomes and final counts are visible;
+- `No handler registered for job type: marketing:*` no longer appears;
+- real handler completion logs appear.
+
+Do not force a production tenant failure as part of acceptance.
+
+## Acceptance criteria
+
+1. EE/appliance has exactly three global marketing schedules and no legacy
+   per-tenant marketing schedules.
+2. CE keeps its existing pg-boss marketing schedules.
+3. Each global run discovers all tenants, executes no more than ten tenant
+   activities concurrently, waits for all tenants, and exposes the aggregate.
+4. One exhausted tenant activity does not prevent later tenants from running.
+5. A partially failed fan-out ends as failed with the full summary; a clean
+   fan-out completes.
+6. Direct worker activities execute all three marketing operations without
+   PostHog gating or server/event-bus routing.
+7. Sequence-email tracking remains signed and sending fails closed without the
+   signing secret.
+8. Handled sequence enrollment failures retain their existing 30-minute domain
+   backoff and do not cause an immediate Temporal retry.
+9. The production worker artifact loads the marketing runtime exports.
+10. The production missing-handler error storm stops.
+
+## Risks and mitigations
+
+- **Worker runtime dependency drift:** direct marketing imports add a new package
+  boundary to a worker image with a history of missing runtime exports.
+  Explicit build/copy steps and an import guard make this a build-time failure.
+- **Multi-replica schedule convergence:** many workers may upsert and clean up
+  simultaneously. Existing already-exists handling plus not-found-tolerant
+  deletion keeps the operation idempotent.
+- **Database and email load:** ten-way concurrency matches the existing
+  maintenance fan-out limit. Schedule overlap `SKIP` prevents stacking.
+- **At-least-once activity execution:** the post transitions and sequence-send
+  claims are already idempotent. Preserve those domain operations rather than
+  reproducing them in the activity.
+- **All-tenant execution:** the previous handler used a UI feature flag as a
+  background gate. The approved behavior removes that gate; tenants without
+  marketing data perform no writes or sends.
+- **Legacy tracker rows:** deleting schedules leaves old tracking rows in the
+  database. They are inert and retained as history.
+
+## Out of scope
+
+- Redesigning the generic Temporal job runner or its handler registry.
+- Moving unrelated per-tenant jobs to global fan-out.
+- Changing marketing domain behavior, email content, sequence limits, or the
+  48-hour stale-target grace period.
+- PostHog feature-flag behavior in the UI.
+- Deleting historical job tracking records.
+- Building a full Temporal integration test suite.
+
+## Commit plan
+
+The implementation agent should use small, reviewable commits:
+
+1. Shared contract, direct activities, workflow, and focused tests.
+2. Global schedule convergence, EE/CE cutover, legacy cleanup, and tests.
+3. Temporal worker packaging/runtime guards and final smoke-test adjustments.
+
+This plan document is committed separately before implementation begins.

--- a/docs/plans/2026-07-23-temporal-worker-nodemailer-packaging-design.md
+++ b/docs/plans/2026-07-23-temporal-worker-nodemailer-packaging-design.md
@@ -1,0 +1,37 @@
+# Temporal Worker Nodemailer Packaging Design
+
+## Problem
+
+The Temporal worker image build for the marketing fan-out change reaches its runtime
+import guard, then fails because `@alga-psa/marketing/lib/sequences` imports the
+`@alga-psa/email` package root. That root eagerly loads SMTP support, which imports
+`nodemailer`, but the Temporal worker's own runtime dependency graph does not install
+`nodemailer`.
+
+## Decision
+
+Declare `nodemailer@^9.0.3` as a direct runtime dependency of
+`ee/temporal-workflows` and update that workspace's lockfile. This is the narrowest
+fix that matches the final image's existing module-resolution path.
+
+Do not copy another package's complete `node_modules` tree into the final image and
+do not refactor marketing or email package exports as part of this deployment fix.
+
+## Validation
+
+1. Run the focused Temporal marketing workflow and registration tests.
+2. Build the Temporal worker's production Docker target. Its existing marketing
+   runtime import guard must pass.
+3. Deploy the resulting image and verify:
+   - all 10 worker replicas become ready without restarts;
+   - the image contains the compiled marketing workflow and activities;
+   - exactly three `marketing-fanout:*` schedules exist;
+   - all legacy per-tenant marketing schedules are removed;
+   - fan-out executions start and tenant activities complete without the old
+     missing-handler error.
+
+## Scope Protection
+
+Commit only the Temporal worker manifest, its local lockfile, this design note, and
+any directly necessary focused test. Preserve unrelated root `package.json` and
+`package-lock.json` worktree changes.

--- a/docs/plans/2026-07-23-temporal-worker-nodemailer-packaging-design.md
+++ b/docs/plans/2026-07-23-temporal-worker-nodemailer-packaging-design.md
@@ -11,8 +11,10 @@ import guard, then fails because `@alga-psa/marketing/lib/sequences` imports the
 ## Decision
 
 Declare `nodemailer@^9.0.3` as a direct runtime dependency of
-`ee/temporal-workflows` and update that workspace's lockfile. This is the narrowest
-fix that matches the final image's existing module-resolution path.
+`ee/temporal-workflows` and update that workspace's lockfile. Build and copy the
+already-declared `@alga-psa/types` and `@alga-psa/event-bus` package exports that the
+email root bundle loads at runtime. This closes the same narrow dependency graph
+using the final image's existing module-resolution path.
 
 Do not copy another package's complete `node_modules` tree into the final image and
 do not refactor marketing or email package exports as part of this deployment fix.

--- a/ee/temporal-workflows/Dockerfile
+++ b/ee/temporal-workflows/Dockerfile
@@ -102,6 +102,9 @@ RUN npm install --ignore-scripts && npm run build
 WORKDIR /app/packages/email
 RUN npm install --ignore-scripts && npm run build
 
+WORKDIR /app/packages/marketing
+RUN npm install --ignore-scripts && npm run build
+
 WORKDIR /app/ee/temporal-workflows
 RUN npm run build
 
@@ -123,6 +126,7 @@ RUN ls -la /app/ee/temporal-workflows/dist/seeds/onboarding || echo "Seeds direc
 FROM base AS production-prebuilt
 
 COPY --from=prebuilt /app/ee/temporal-workflows/dist /app/ee/temporal-workflows/dist
+COPY --from=prebuilt /app/packages/marketing/dist /app/packages/marketing/dist
 # Copy integrations node_modules to both locations for module resolution
 COPY --from=base /app/packages/integrations/node_modules /app/packages/integrations/node_modules
 COPY --from=base /app/packages/integrations/node_modules /app/ee/temporal-workflows/dist/packages/integrations/node_modules
@@ -142,6 +146,8 @@ RUN ls -la /app/ee/temporal-workflows/dist/seeds/onboarding || echo "Seeds direc
 RUN cd /app/ee/temporal-workflows && node --input-type=module -e "const m = await import('@alga-psa/db'); if (typeof m.tenantDb !== 'function') throw new Error('@alga-psa/db loaded but tenantDb missing')"
 
 RUN cd /app/ee/temporal-workflows && node --input-type=module -e "const m = await import('@alga-psa/email/providerConfig'); if (typeof m.createDefaultProviderConfig !== 'function') throw new Error('@alga-psa/email/providerConfig loaded but createDefaultProviderConfig missing')"
+
+RUN cd /app/ee/temporal-workflows && node --input-type=module -e "const posts = await import('@alga-psa/marketing/lib/posts'); const sequences = await import('@alga-psa/marketing/lib/sequences'); if (typeof posts.flipDuePostsInternal !== 'function' || typeof posts.expireStaleTargetsInternal !== 'function' || typeof sequences.sendDueSequenceStepsInternal !== 'function') throw new Error('@alga-psa/marketing runtime exports are incomplete')"
 
 # packages/licensing source is compiled INTO this dist tree, so every import
 # reachable from its root must be resolvable from here at runtime. file: deps
@@ -178,6 +184,7 @@ COPY --from=development /app/ee/packages/workflows /app/ee/packages/workflows
 COPY --from=development /app/packages/core/dist /app/packages/core/dist
 COPY --from=development /app/packages/db/dist /app/packages/db/dist
 COPY --from=development /app/packages/email/dist /app/packages/email/dist
+COPY --from=development /app/packages/marketing/dist /app/packages/marketing/dist
 # Copy event-schemas dist (runtime dependency of shared/workflow/streams)
 COPY --from=development /app/packages/event-schemas/dist /app/packages/event-schemas/dist
 # Copy the runtime-resolved @alga-psa package dists built above (base-stage
@@ -206,6 +213,8 @@ RUN ls -la /app/ee/temporal-workflows/dist/seeds/onboarding || echo "Seeds direc
 RUN cd /app/ee/temporal-workflows && node --input-type=module -e "const m = await import('@alga-psa/db'); if (typeof m.tenantDb !== 'function') throw new Error('@alga-psa/db loaded but tenantDb missing')"
 
 RUN cd /app/ee/temporal-workflows && node --input-type=module -e "const m = await import('@alga-psa/email/providerConfig'); if (typeof m.createDefaultProviderConfig !== 'function') throw new Error('@alga-psa/email/providerConfig loaded but createDefaultProviderConfig missing')"
+
+RUN cd /app/ee/temporal-workflows && node --input-type=module -e "const posts = await import('@alga-psa/marketing/lib/posts'); const sequences = await import('@alga-psa/marketing/lib/sequences'); if (typeof posts.flipDuePostsInternal !== 'function' || typeof posts.expireStaleTargetsInternal !== 'function' || typeof sequences.sendDueSequenceStepsInternal !== 'function') throw new Error('@alga-psa/marketing runtime exports are incomplete')"
 
 # packages/licensing source is compiled INTO this dist tree, so every import
 # reachable from its root must be resolvable from here at runtime. file: deps

--- a/ee/temporal-workflows/Dockerfile
+++ b/ee/temporal-workflows/Dockerfile
@@ -74,6 +74,15 @@ WORKDIR /app/packages/event-schemas
 
 RUN npx tsup
 
+# Build the remaining runtime packages imported by @alga-psa/email's root
+# bundle. Marketing sequence activities load TenantEmailService from that
+# bundle, so these package exports must exist in the final worker image.
+WORKDIR /app/packages/types
+RUN npx tsup
+
+WORKDIR /app/packages/event-bus
+RUN npx tsup
+
 # Build @alga-psa/workflows (dist/lib/*.mjs required at runtime)
 WORKDIR /app/ee/packages/workflows
 RUN npx tsup
@@ -187,6 +196,9 @@ COPY --from=development /app/packages/email/dist /app/packages/email/dist
 COPY --from=development /app/packages/marketing/dist /app/packages/marketing/dist
 # Copy event-schemas dist (runtime dependency of shared/workflow/streams)
 COPY --from=development /app/packages/event-schemas/dist /app/packages/event-schemas/dist
+# Copy the runtime package exports loaded by @alga-psa/email.
+COPY --from=development /app/packages/types/dist /app/packages/types/dist
+COPY --from=development /app/packages/event-bus/dist /app/packages/event-bus/dist
 # Copy the runtime-resolved @alga-psa package dists built above (base-stage
 # packages/ came from the build context, where .dockerignore strips **/dist)
 COPY --from=development /app/packages/core/dist /app/packages/core/dist

--- a/ee/temporal-workflows/package-lock.json
+++ b/ee/temporal-workflows/package-lock.json
@@ -12,6 +12,7 @@
         "@alga-psa/db": "file:../../packages/db",
         "@alga-psa/event-bus": "file:../../packages/event-bus",
         "@alga-psa/jobs": "file:../../packages/jobs",
+        "@alga-psa/marketing": "file:../../packages/marketing",
         "@alga-psa/search": "file:../../packages/search",
         "@alga-psa/shared": "file:../../shared",
         "@alga-psa/sla": "file:../../packages/sla",
@@ -163,6 +164,34 @@
       "devDependencies": {
         "tsup": "^8.0.0",
         "typescript": "^5.4.0"
+      }
+    },
+    "../../packages/marketing": {
+      "name": "@alga-psa/marketing",
+      "version": "0.1.0",
+      "dependencies": {
+        "@alga-psa/auth": "*",
+        "@alga-psa/core": "*",
+        "@alga-psa/db": "*",
+        "@alga-psa/email": "*",
+        "@alga-psa/opportunities": "*",
+        "@alga-psa/shared": "*",
+        "@alga-psa/types": "*",
+        "@alga-psa/ui": "*",
+        "@alga-psa/validation": "*",
+        "knex": "^3.1.0",
+        "lucide-react": "^0.428.0",
+        "react-hot-toast": "^2.5.1",
+        "zod": "^3.22.4"
+      },
+      "devDependencies": {
+        "tsup": "^8.0.0",
+        "typescript": "^5.3.0",
+        "vitest": "^4.1.9"
+      },
+      "peerDependencies": {
+        "react": "^18.0.0 || ^19.0.0",
+        "react-dom": "^18.0.0 || ^19.0.0"
       }
     },
     "../../packages/search": {
@@ -325,6 +354,10 @@
     },
     "node_modules/@alga-psa/jobs": {
       "resolved": "../../packages/jobs",
+      "link": true
+    },
+    "node_modules/@alga-psa/marketing": {
+      "resolved": "../../packages/marketing",
       "link": true
     },
     "node_modules/@alga-psa/search": {

--- a/ee/temporal-workflows/package-lock.json
+++ b/ee/temporal-workflows/package-lock.json
@@ -10,8 +10,10 @@
       "dependencies": {
         "@alga-psa/core": "file:../../packages/core",
         "@alga-psa/db": "file:../../packages/db",
+        "@alga-psa/email": "file:../../packages/email",
         "@alga-psa/event-bus": "file:../../packages/event-bus",
         "@alga-psa/jobs": "file:../../packages/jobs",
+        "@alga-psa/licensing": "file:../../packages/licensing",
         "@alga-psa/marketing": "file:../../packages/marketing",
         "@alga-psa/search": "file:../../packages/search",
         "@alga-psa/shared": "file:../../shared",
@@ -43,6 +45,7 @@
         "jsonata": "^2.1.0",
         "knex": "^3.0.0",
         "node-vault": "^0.10.9",
+        "nodemailer": "^9.0.3",
         "openai": "^4.104.0",
         "parsimmon": "^1.18.1",
         "pg": "^8.12.0",
@@ -81,7 +84,7 @@
     },
     "../../packages/core": {
       "name": "@alga-psa/core",
-      "version": "1.2.15",
+      "version": "1.3.6",
       "dependencies": {
         "dotenv": "^16.4.5",
         "node-vault": "^0.10.2",
@@ -112,6 +115,22 @@
       "devDependencies": {
         "@types/node": "^20.0.0",
         "tsc-alias": "^1.8.16",
+        "typescript": "^5.7.3"
+      }
+    },
+    "../../packages/email": {
+      "name": "@alga-psa/email",
+      "version": "0.0.1",
+      "dependencies": {
+        "@alga-psa/core": "*",
+        "@alga-psa/db": "*",
+        "@alga-psa/event-bus": "*",
+        "@alga-psa/types": "*",
+        "axios": "^1.16.0",
+        "nodemailer": "^9.0.3"
+      },
+      "devDependencies": {
+        "tsup": "^8.0.0",
         "typescript": "^5.7.3"
       }
     },
@@ -160,6 +179,20 @@
         "lucide-react": "^0.428.0",
         "pg-boss": "^10.1.5",
         "uuid": "^11.1.1"
+      },
+      "devDependencies": {
+        "tsup": "^8.0.0",
+        "typescript": "^5.4.0"
+      }
+    },
+    "../../packages/licensing": {
+      "name": "@alga-psa/licensing",
+      "version": "0.1.0",
+      "dependencies": {
+        "@alga-psa/core": "*",
+        "@alga-psa/db": "*",
+        "@alga-psa/types": "*",
+        "@alga-psa/validation": "*"
       },
       "devDependencies": {
         "tsup": "^8.0.0",
@@ -348,12 +381,20 @@
       "resolved": "../../packages/db",
       "link": true
     },
+    "node_modules/@alga-psa/email": {
+      "resolved": "../../packages/email",
+      "link": true
+    },
     "node_modules/@alga-psa/event-bus": {
       "resolved": "../../packages/event-bus",
       "link": true
     },
     "node_modules/@alga-psa/jobs": {
       "resolved": "../../packages/jobs",
+      "link": true
+    },
+    "node_modules/@alga-psa/licensing": {
+      "resolved": "../../packages/licensing",
       "link": true
     },
     "node_modules/@alga-psa/marketing": {
@@ -2144,9 +2185,6 @@
       "cpu": [
         "arm"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -2162,9 +2200,6 @@
       "integrity": "sha512-excjX8DfsIcJ10x1Kzr4RcWe1edC9PquDRRPx3YVCvQv+U5p7Yin2s32ftzikXojb1PIFc/9Mt28/y+iRklkrw==",
       "cpu": [
         "arm64"
-      ],
-      "libc": [
-        "glibc"
       ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
@@ -2182,9 +2217,6 @@
       "cpu": [
         "ppc64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -2200,9 +2232,6 @@
       "integrity": "sha512-oVDbcR4zUC0ce82teubSm+x6ETixtKZBh/qbREIOcI3cULzDyb18Sr/Wcyx7NRQeQzOiHTNbZFF1UwPS2scyGA==",
       "cpu": [
         "riscv64"
-      ],
-      "libc": [
-        "glibc"
       ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
@@ -2220,9 +2249,6 @@
       "cpu": [
         "s390x"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -2238,9 +2264,6 @@
       "integrity": "sha512-tJxiiLsmHc9Ax1bz3oaOYBURTXGIRDODBqhveVHonrHJ9/+k89qbLl0bcJns+e4t4rvaNBxaEZsFtSfAdquPrw==",
       "cpu": [
         "x64"
-      ],
-      "libc": [
-        "glibc"
       ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
@@ -2258,9 +2281,6 @@
       "cpu": [
         "arm64"
       ],
-      "libc": [
-        "musl"
-      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -2277,9 +2297,6 @@
       "cpu": [
         "x64"
       ],
-      "libc": [
-        "musl"
-      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -2295,9 +2312,6 @@
       "integrity": "sha512-9dLqsvwtg1uuXBGZKsxem9595+ujv0sJ6Vi8wcTANSFpwV/GONat5eCkzQo/1O6zRIkh0m/8+5BjrRr7jDUSZw==",
       "cpu": [
         "arm"
-      ],
-      "libc": [
-        "glibc"
       ],
       "license": "Apache-2.0",
       "optional": true,
@@ -2321,9 +2335,6 @@
       "cpu": [
         "arm64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -2345,9 +2356,6 @@
       "integrity": "sha512-7zznwNaqW6YtsfrGGDA6BRkISKAAE1Jo0QdpNYXNMHu2+0dTrPflTLNkpc8l7MUP5M16ZJcUvysVWWrMefZquA==",
       "cpu": [
         "ppc64"
-      ],
-      "libc": [
-        "glibc"
       ],
       "license": "Apache-2.0",
       "optional": true,
@@ -2371,9 +2379,6 @@
       "cpu": [
         "riscv64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -2395,9 +2400,6 @@
       "integrity": "sha512-nQtCk0PdKfho3eC5MrbQoigJ2gd1CgddUMkabUj+rBevs8tZ2cULOx46E7oyX+04WGfABgIwmMC0VqieTiR4jg==",
       "cpu": [
         "s390x"
-      ],
-      "libc": [
-        "glibc"
       ],
       "license": "Apache-2.0",
       "optional": true,
@@ -2421,9 +2423,6 @@
       "cpu": [
         "x64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -2446,9 +2445,6 @@
       "cpu": [
         "arm64"
       ],
-      "libc": [
-        "musl"
-      ],
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -2470,9 +2466,6 @@
       "integrity": "sha512-Jg8wNT1MUzIvhBFxViqrEhWDGzqymo3sV7z7ZsaWbZNDLXRJZoRGrjulp60YYtV4wfY8VIKcWidjojlLcWrd8Q==",
       "cpu": [
         "x64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "Apache-2.0",
       "optional": true,
@@ -3428,9 +3421,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3448,9 +3438,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3468,9 +3455,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3488,9 +3472,6 @@
         "s390x"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3508,9 +3489,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3528,9 +3506,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -9925,6 +9900,15 @@
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
       "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
       "license": "MIT"
+    },
+    "node_modules/nodemailer": {
+      "version": "9.0.3",
+      "resolved": "https://registry.npmjs.org/nodemailer/-/nodemailer-9.0.3.tgz",
+      "integrity": "sha512-n+YP+NKwR5zRWa60k3GiQ6Q3B4KXCoAw40dAKeCtYn020iNN74aWK2liXIC3ZEATeGql7we3tE3t8QwhY0eskw==",
+      "license": "MIT-0",
+      "engines": {
+        "node": ">=6.0.0"
+      }
     },
     "node_modules/normalize-path": {
       "version": "3.0.0",

--- a/ee/temporal-workflows/package.json
+++ b/ee/temporal-workflows/package.json
@@ -74,6 +74,7 @@
     "fractional-indexing": "^3.2.0",
     "google-auth-library": "^10.5.0",
     "jsonata": "^2.1.0",
+    "nodemailer": "^9.0.3",
     "openai": "^4.104.0",
     "posthog-node": "^4.18.0",
     "rrule": "^2.8.1",

--- a/ee/temporal-workflows/package.json
+++ b/ee/temporal-workflows/package.json
@@ -31,6 +31,7 @@
     "@alga-psa/event-bus": "file:../../packages/event-bus",
     "@alga-psa/jobs": "file:../../packages/jobs",
     "@alga-psa/licensing": "file:../../packages/licensing",
+    "@alga-psa/marketing": "file:../../packages/marketing",
     "@alga-psa/search": "file:../../packages/search",
     "@alga-psa/shared": "file:../../shared",
     "@alga-psa/sla": "file:../../packages/sla",

--- a/ee/temporal-workflows/src/__tests__/marketing-worker-registration.test.ts
+++ b/ee/temporal-workflows/src/__tests__/marketing-worker-registration.test.ts
@@ -1,0 +1,33 @@
+import { readFileSync } from 'node:fs';
+import { describe, expect, it } from 'vitest';
+
+function source(relativeUrl: string): string {
+  return readFileSync(new URL(relativeUrl, import.meta.url), 'utf8');
+}
+
+describe('marketing worker registration contract', () => {
+  it('exports the fan-out workflow from both production workflow indexes', () => {
+    expect(source('../workflows/index.ts')).toContain(
+      "export * from './marketing-fanout-workflow.js';",
+    );
+    expect(source('../workflows/non-authored-index.ts')).toContain(
+      "export * from './marketing-fanout-workflow.js';",
+    );
+    expect(source('../workflows/marketing-fanout-workflow.ts')).toContain(
+      'export async function marketingFanoutWorkflow',
+    );
+  });
+
+  it('exports both marketing activities from both production activity indexes', () => {
+    expect(source('../activities/index.ts')).toContain(
+      'export * from "./marketing-activities";',
+    );
+    expect(source('../activities/non-authored-index.ts')).toContain(
+      "export * from './marketing-activities';",
+    );
+
+    const activitySource = source('../activities/marketing-activities.ts');
+    expect(activitySource).toContain('export async function listMarketingTenantIds');
+    expect(activitySource).toContain('export async function runMarketingJobForTenant');
+  });
+});

--- a/ee/temporal-workflows/src/activities/__tests__/marketing-activities.test.ts
+++ b/ee/temporal-workflows/src/activities/__tests__/marketing-activities.test.ts
@@ -1,0 +1,167 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import {
+  MARKETING_EXPIRE_STALE_TARGETS_JOB,
+  MARKETING_FLIP_DUE_POSTS_JOB,
+  MARKETING_SEND_SEQUENCE_STEPS_JOB,
+} from '@alga-psa/marketing/lib/marketingJobContract';
+
+const getAdminConnectionMock = vi.fn();
+const createTenantKnexMock = vi.fn();
+const runWithTenantMock = vi.fn();
+const tenantDbMock = vi.fn();
+const flipDuePostsInternalMock = vi.fn();
+const expireStaleTargetsInternalMock = vi.fn();
+const sendDueSequenceStepsInternalMock = vi.fn();
+const logInfoMock = vi.fn();
+const logErrorMock = vi.fn();
+
+vi.mock('@temporalio/activity', () => ({
+  Context: {
+    current: () => ({
+      log: {
+        info: logInfoMock,
+        error: logErrorMock,
+      },
+    }),
+  },
+}));
+
+vi.mock('@alga-psa/db/admin.js', () => ({
+  getAdminConnection: getAdminConnectionMock,
+}));
+
+vi.mock('@alga-psa/db/tenant.js', () => ({
+  createTenantKnex: createTenantKnexMock,
+  runWithTenant: runWithTenantMock,
+}));
+
+vi.mock('@alga-psa/db', () => ({
+  tenantDb: tenantDbMock,
+}));
+
+vi.mock('@alga-psa/marketing/lib/posts', () => ({
+  flipDuePostsInternal: flipDuePostsInternalMock,
+  expireStaleTargetsInternal: expireStaleTargetsInternalMock,
+}));
+
+vi.mock('@alga-psa/marketing/lib/sequences', () => ({
+  sendDueSequenceStepsInternal: sendDueSequenceStepsInternalMock,
+}));
+
+describe('marketing activities', () => {
+  const originalNextAuthSecret = process.env.NEXTAUTH_SECRET;
+  const originalNextAuthUrl = process.env.NEXTAUTH_URL;
+  const originalPublicAppUrl = process.env.NEXT_PUBLIC_APP_URL;
+  const knex = { name: 'tenant-knex' };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    createTenantKnexMock.mockResolvedValue({ knex, tenant: 'tenant-1' });
+    runWithTenantMock.mockImplementation(async (_tenantId, callback) => callback());
+    process.env.NEXTAUTH_SECRET = 'test-signing-secret';
+    process.env.NEXTAUTH_URL = 'https://app.example.test/';
+    delete process.env.NEXT_PUBLIC_APP_URL;
+  });
+
+  afterEach(() => {
+    if (originalNextAuthSecret === undefined) delete process.env.NEXTAUTH_SECRET;
+    else process.env.NEXTAUTH_SECRET = originalNextAuthSecret;
+    if (originalNextAuthUrl === undefined) delete process.env.NEXTAUTH_URL;
+    else process.env.NEXTAUTH_URL = originalNextAuthUrl;
+    if (originalPublicAppUrl === undefined) delete process.env.NEXT_PUBLIC_APP_URL;
+    else process.env.NEXT_PUBLIC_APP_URL = originalPublicAppUrl;
+  });
+
+  it('enumerates every tenant with an explicit unscoped query in deterministic order', async () => {
+    const select = vi.fn().mockResolvedValue([
+      { tenant: 'tenant-a' },
+      { tenant: 'tenant-b' },
+    ]);
+    const orderBy = vi.fn(() => ({ select }));
+    const unscoped = vi.fn(() => ({ orderBy }));
+    getAdminConnectionMock.mockResolvedValue({ name: 'admin-knex' });
+    tenantDbMock.mockReturnValue({ unscoped });
+    const { listMarketingTenantIds } = await import('../marketing-activities');
+
+    await expect(listMarketingTenantIds()).resolves.toEqual(['tenant-a', 'tenant-b']);
+    expect(unscoped).toHaveBeenCalledWith(
+      'tenants',
+      expect.stringContaining('enumerates every tenant'),
+    );
+    expect(orderBy).toHaveBeenCalledWith('tenant', 'asc');
+  });
+
+  it.each([
+    [MARKETING_FLIP_DUE_POSTS_JOB, flipDuePostsInternalMock, { flipped: 2 }, [knex, 'tenant-1']],
+    [
+      MARKETING_EXPIRE_STALE_TARGETS_JOB,
+      expireStaleTargetsInternalMock,
+      { expired: 3 },
+      [knex, 'tenant-1', 48],
+    ],
+  ])('routes %s to its tenant domain operation', async (jobName, operation, summary, expectedArgs) => {
+    operation.mockResolvedValue(summary);
+    const { runMarketingJobForTenant } = await import('../marketing-activities');
+
+    const result = await runMarketingJobForTenant({ jobName, tenantId: 'tenant-1' });
+
+    expect(runWithTenantMock).toHaveBeenCalledWith('tenant-1', expect.any(Function));
+    expect(operation).toHaveBeenCalledWith(...expectedArgs);
+    expect(result).toMatchObject({
+      jobName,
+      tenantId: 'tenant-1',
+      operation: summary,
+    });
+  });
+
+  it('passes canonical URL and signing secret to sequence sending', async () => {
+    const summary = { sent: 1, completed: 0, stopped: 0, failed: 1, skipped: 0 };
+    sendDueSequenceStepsInternalMock.mockResolvedValue(summary);
+    const { runMarketingJobForTenant } = await import('../marketing-activities');
+
+    const result = await runMarketingJobForTenant({
+      jobName: MARKETING_SEND_SEQUENCE_STEPS_JOB,
+      tenantId: 'tenant-1',
+    });
+
+    expect(sendDueSequenceStepsInternalMock).toHaveBeenCalledWith(knex, 'tenant-1', {
+      baseUrl: 'https://app.example.test',
+      signingSecret: 'test-signing-secret',
+    });
+    expect(result.operation).toEqual(summary);
+  });
+
+  it('fails closed before sequence sending when NEXTAUTH_SECRET is absent', async () => {
+    delete process.env.NEXTAUTH_SECRET;
+    const { runMarketingJobForTenant } = await import('../marketing-activities');
+
+    await expect(runMarketingJobForTenant({
+      jobName: MARKETING_SEND_SEQUENCE_STEPS_JOB,
+      tenantId: 'tenant-1',
+    })).rejects.toThrow('No marketing signing secret available');
+    expect(sendDueSequenceStepsInternalMock).not.toHaveBeenCalled();
+  });
+
+  it('rejects an unknown job name at runtime', async () => {
+    const { runMarketingJobForTenant } = await import('../marketing-activities');
+
+    await expect(runMarketingJobForTenant({
+      jobName: 'marketing:unknown',
+      tenantId: 'tenant-1',
+    } as never)).rejects.toThrow('Unknown marketing job name');
+  });
+
+  it('rethows domain operation failures so Temporal can retry them', async () => {
+    flipDuePostsInternalMock.mockRejectedValue(new Error('transient database failure'));
+    const { runMarketingJobForTenant } = await import('../marketing-activities');
+
+    await expect(runMarketingJobForTenant({
+      jobName: MARKETING_FLIP_DUE_POSTS_JOB,
+      tenantId: 'tenant-1',
+    })).rejects.toThrow('transient database failure');
+    expect(logErrorMock).toHaveBeenCalledWith(
+      'Marketing tenant activity failed',
+      expect.objectContaining({ error: 'transient database failure' }),
+    );
+  });
+});

--- a/ee/temporal-workflows/src/activities/__tests__/marketing-activities.test.ts
+++ b/ee/temporal-workflows/src/activities/__tests__/marketing-activities.test.ts
@@ -50,6 +50,7 @@ vi.mock('@alga-psa/marketing/lib/sequences', () => ({
 
 describe('marketing activities', () => {
   const originalNextAuthSecret = process.env.NEXTAUTH_SECRET;
+  const originalApplicationUrl = process.env.APPLICATION_URL;
   const originalNextAuthUrl = process.env.NEXTAUTH_URL;
   const originalPublicAppUrl = process.env.NEXT_PUBLIC_APP_URL;
   const knex = { name: 'tenant-knex' };
@@ -59,13 +60,16 @@ describe('marketing activities', () => {
     createTenantKnexMock.mockResolvedValue({ knex, tenant: 'tenant-1' });
     runWithTenantMock.mockImplementation(async (_tenantId, callback) => callback());
     process.env.NEXTAUTH_SECRET = 'test-signing-secret';
-    process.env.NEXTAUTH_URL = 'https://app.example.test/';
+    process.env.APPLICATION_URL = 'https://deployment.example.test/';
+    process.env.NEXTAUTH_URL = 'https://auth.example.test/';
     delete process.env.NEXT_PUBLIC_APP_URL;
   });
 
   afterEach(() => {
     if (originalNextAuthSecret === undefined) delete process.env.NEXTAUTH_SECRET;
     else process.env.NEXTAUTH_SECRET = originalNextAuthSecret;
+    if (originalApplicationUrl === undefined) delete process.env.APPLICATION_URL;
+    else process.env.APPLICATION_URL = originalApplicationUrl;
     if (originalNextAuthUrl === undefined) delete process.env.NEXTAUTH_URL;
     else process.env.NEXTAUTH_URL = originalNextAuthUrl;
     if (originalPublicAppUrl === undefined) delete process.env.NEXT_PUBLIC_APP_URL;
@@ -125,7 +129,7 @@ describe('marketing activities', () => {
     });
 
     expect(sendDueSequenceStepsInternalMock).toHaveBeenCalledWith(knex, 'tenant-1', {
-      baseUrl: 'https://app.example.test',
+      baseUrl: 'https://deployment.example.test',
       signingSecret: 'test-signing-secret',
     });
     expect(result.operation).toEqual(summary);

--- a/ee/temporal-workflows/src/activities/index.ts
+++ b/ee/temporal-workflows/src/activities/index.ts
@@ -11,6 +11,7 @@ export * from "./portal-domain-activities";
 export * from "./email-domain-activities";
 export * from "./job-activities";
 export * from "./maintenance-fanout-activities";
+export * from "./marketing-activities";
 export * from "./email-webhook-maintenance-activities";
 export * from "./calendar-webhook-maintenance-activities";
 export * from "./ninjaone-sync-activities";

--- a/ee/temporal-workflows/src/activities/marketing-activities.ts
+++ b/ee/temporal-workflows/src/activities/marketing-activities.ts
@@ -1,0 +1,113 @@
+import { Context } from '@temporalio/activity';
+import { tenantDb } from '@alga-psa/db';
+import { getAdminConnection } from '@alga-psa/db/admin.js';
+import { createTenantKnex, runWithTenant } from '@alga-psa/db/tenant.js';
+import { expireStaleTargetsInternal, flipDuePostsInternal } from '@alga-psa/marketing/lib/posts';
+import { sendDueSequenceStepsInternal } from '@alga-psa/marketing/lib/sequences';
+import {
+  MARKETING_EXPIRE_STALE_TARGETS_JOB,
+  MARKETING_FLIP_DUE_POSTS_JOB,
+  MARKETING_SEND_SEQUENCE_STEPS_JOB,
+  assertMarketingJobName,
+  type MarketingJobInput,
+  type MarketingTenantJobResult,
+} from '@alga-psa/marketing/lib/marketingJobContract';
+
+const MARKETING_TENANT_DISCOVERY_CONTEXT = '__marketing_fanout_tenant_discovery__';
+const STALE_TARGET_GRACE_HOURS = 48;
+
+function activityLogger() {
+  return Context.current().log;
+}
+
+function getPublicBaseUrl(): string {
+  const raw =
+    process.env.NEXTAUTH_URL
+    || process.env.NEXT_PUBLIC_APP_URL
+    || 'http://localhost:3000';
+  return raw.endsWith('/') ? raw.slice(0, -1) : raw;
+}
+
+export async function listMarketingTenantIds(): Promise<string[]> {
+  const knex = await getAdminConnection();
+  const rows = await tenantDb(knex, MARKETING_TENANT_DISCOVERY_CONTEXT)
+    .unscoped('tenants', 'marketing fan-out enumerates every tenant before tenant context is known')
+    .orderBy('tenant', 'asc')
+    .select('tenant') as Array<{ tenant: string }>;
+
+  return rows.map(({ tenant }) => String(tenant));
+}
+
+export async function runMarketingJobForTenant(
+  input: MarketingJobInput,
+): Promise<MarketingTenantJobResult> {
+  assertMarketingJobName(input.jobName);
+  if (!input.tenantId) {
+    throw new Error('Tenant ID is required for a marketing fan-out activity');
+  }
+
+  const log = activityLogger();
+  log.info('Starting marketing tenant activity', {
+    jobName: input.jobName,
+    tenantId: input.tenantId,
+  });
+
+  try {
+    const result = await runWithTenant(input.tenantId, async () => {
+      const { knex } = await createTenantKnex(input.tenantId);
+
+      switch (input.jobName) {
+        case MARKETING_FLIP_DUE_POSTS_JOB:
+          return {
+            jobName: input.jobName,
+            tenantId: input.tenantId,
+            operation: await flipDuePostsInternal(knex, input.tenantId),
+            completedAt: new Date().toISOString(),
+          };
+        case MARKETING_EXPIRE_STALE_TARGETS_JOB:
+          return {
+            jobName: input.jobName,
+            tenantId: input.tenantId,
+            operation: await expireStaleTargetsInternal(
+              knex,
+              input.tenantId,
+              STALE_TARGET_GRACE_HOURS,
+            ),
+            completedAt: new Date().toISOString(),
+          };
+        case MARKETING_SEND_SEQUENCE_STEPS_JOB: {
+          const signingSecret = process.env.NEXTAUTH_SECRET;
+          if (!signingSecret) {
+            throw new Error(
+              'No marketing signing secret available (NEXTAUTH_SECRET); refusing to send sequence steps',
+            );
+          }
+          return {
+            jobName: input.jobName,
+            tenantId: input.tenantId,
+            operation: await sendDueSequenceStepsInternal(knex, input.tenantId, {
+              baseUrl: getPublicBaseUrl(),
+              signingSecret,
+            }),
+            completedAt: new Date().toISOString(),
+          };
+        }
+      }
+    });
+
+    log.info('Completed marketing tenant activity', {
+      jobName: result.jobName,
+      tenantId: result.tenantId,
+      completedAt: result.completedAt,
+      operation: result.operation,
+    });
+    return result;
+  } catch (error) {
+    log.error('Marketing tenant activity failed', {
+      jobName: input.jobName,
+      tenantId: input.tenantId,
+      error: error instanceof Error ? error.message : String(error),
+    });
+    throw error;
+  }
+}

--- a/ee/temporal-workflows/src/activities/marketing-activities.ts
+++ b/ee/temporal-workflows/src/activities/marketing-activities.ts
@@ -22,7 +22,8 @@ function activityLogger() {
 
 function getPublicBaseUrl(): string {
   const raw =
-    process.env.NEXTAUTH_URL
+    process.env.APPLICATION_URL
+    || process.env.NEXTAUTH_URL
     || process.env.NEXT_PUBLIC_APP_URL
     || 'http://localhost:3000';
   return raw.endsWith('/') ? raw.slice(0, -1) : raw;

--- a/ee/temporal-workflows/src/activities/non-authored-index.ts
+++ b/ee/temporal-workflows/src/activities/non-authored-index.ts
@@ -12,6 +12,7 @@ export * from './portal-domain-activities';
 export * from './email-domain-activities';
 export * from './job-activities';
 export * from './maintenance-fanout-activities';
+export * from './marketing-activities';
 export * from './email-webhook-maintenance-activities';
 export * from './calendar-webhook-maintenance-activities';
 export * from './ninjaone-sync-activities';

--- a/ee/temporal-workflows/src/schedules/__tests__/setupSchedules.marketing-fanout.test.ts
+++ b/ee/temporal-workflows/src/schedules/__tests__/setupSchedules.marketing-fanout.test.ts
@@ -1,0 +1,176 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import {
+  MARKETING_EXPIRE_STALE_TARGETS_JOB,
+  MARKETING_FLIP_DUE_POSTS_JOB,
+  MARKETING_SEND_SEQUENCE_STEPS_JOB,
+} from '@alga-psa/marketing/lib/marketingJobContract';
+
+const scheduleCreateMock = vi.fn();
+const scheduleUpdateMock = vi.fn();
+const scheduleDeleteMock = vi.fn();
+const scheduleTriggerMock = vi.fn();
+const scheduleListMock = vi.fn();
+const connectMock = vi.fn(async () => ({}));
+const events: string[] = [];
+const knownScheduleIds = new Set<string>();
+
+const listedScheduleIds = [
+  `${MARKETING_FLIP_DUE_POSTS_JOB}:tenant-1`,
+  `${MARKETING_EXPIRE_STALE_TARGETS_JOB}:tenant-2`,
+  `${MARKETING_SEND_SEQUENCE_STEPS_JOB}:tenant-missing`,
+  'marketing-fanout:flip-due-posts',
+  'unrelated:schedule',
+];
+
+vi.mock('@temporalio/client', () => ({
+  Connection: {
+    connect: connectMock,
+  },
+  Client: vi.fn(() => ({
+    schedule: {
+      create: scheduleCreateMock,
+      getHandle: vi.fn((scheduleId: string) => ({
+        update: (updater: (previous: Record<string, unknown>) => unknown) => {
+          scheduleUpdateMock(scheduleId, updater({}));
+          events.push(`update:${scheduleId}`);
+        },
+        delete: () => scheduleDeleteMock(scheduleId),
+        trigger: scheduleTriggerMock,
+      })),
+      list: scheduleListMock,
+    },
+  })),
+  ScheduleOverlapPolicy: {
+    SKIP: 'SKIP',
+  },
+}));
+
+vi.mock('@ee/lib/integrations/ninjaone/proactiveRefresh', () => ({
+  seedNinjaOneProactiveRefreshFromStoredCredentials: vi.fn(),
+}));
+
+vi.mock('@alga-psa/db/admin.js', () => ({
+  getAdminConnection: vi.fn(async () => ({})),
+}));
+
+vi.mock('@alga-psa/db', () => ({
+  tenantDb: vi.fn((_knex: unknown, context: string) => {
+    const rows = context.includes('entra') ? [] : [];
+    const query = {
+      where: vi.fn(() => query),
+      select: vi.fn(async () => rows),
+    };
+    return {
+      unscoped: vi.fn(() => query),
+      tenantJoin: vi.fn(),
+    };
+  }),
+}));
+
+describe('setupSchedules marketing fan-out cutover', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    events.length = 0;
+    knownScheduleIds.clear();
+
+    scheduleCreateMock.mockImplementation(async ({ scheduleId }) => {
+      events.push(`upsert:${scheduleId}`);
+      if (knownScheduleIds.has(scheduleId)) {
+        throw { code: 6 };
+      }
+      knownScheduleIds.add(scheduleId);
+    });
+    scheduleDeleteMock.mockImplementation(async (scheduleId: string) => {
+      events.push(`delete:${scheduleId}`);
+      if (scheduleId.endsWith('tenant-missing')) {
+        throw { code: 5 };
+      }
+    });
+    scheduleListMock.mockImplementation(() => ({
+      async *[Symbol.asyncIterator]() {
+        events.push('list');
+        for (const scheduleId of listedScheduleIds) {
+          yield { scheduleId };
+        }
+      },
+    }));
+  });
+
+  it('upserts the exact global schedules before deleting only legacy tenant schedules', async () => {
+    const { setupSchedules } = await import('../setupSchedules');
+
+    await setupSchedules();
+
+    const marketingCreates = scheduleCreateMock.mock.calls
+      .map(([input]) => input)
+      .filter(({ scheduleId }) => scheduleId.startsWith('marketing-fanout:'));
+    expect(marketingCreates).toEqual([
+      expect.objectContaining({
+        scheduleId: 'marketing-fanout:flip-due-posts',
+        spec: { cronExpressions: ['*/5 * * * *'] },
+        action: expect.objectContaining({
+          workflowType: expect.any(Function),
+          args: [{ jobName: MARKETING_FLIP_DUE_POSTS_JOB }],
+          taskQueue: 'tenant-workflows',
+          workflowExecutionTimeout: '1h',
+        }),
+        policies: { overlap: 'SKIP', catchupWindow: '1m' },
+      }),
+      expect.objectContaining({
+        scheduleId: 'marketing-fanout:send-sequence-steps',
+        spec: { cronExpressions: ['*/5 * * * *'] },
+        action: expect.objectContaining({
+          workflowType: expect.any(Function),
+          args: [{ jobName: MARKETING_SEND_SEQUENCE_STEPS_JOB }],
+          taskQueue: 'tenant-workflows',
+          workflowExecutionTimeout: '1h',
+        }),
+        policies: { overlap: 'SKIP', catchupWindow: '1m' },
+      }),
+      expect.objectContaining({
+        scheduleId: 'marketing-fanout:expire-stale-targets',
+        spec: { cronExpressions: ['11 * * * *'] },
+        action: expect.objectContaining({
+          workflowType: expect.any(Function),
+          args: [{ jobName: MARKETING_EXPIRE_STALE_TARGETS_JOB }],
+          taskQueue: 'tenant-workflows',
+          workflowExecutionTimeout: '1h',
+        }),
+        policies: { overlap: 'SKIP', catchupWindow: '1m' },
+      }),
+    ]);
+
+    const firstDelete = events.findIndex((event) => event.startsWith('delete:marketing:'));
+    for (const scheduleId of [
+      'marketing-fanout:flip-due-posts',
+      'marketing-fanout:send-sequence-steps',
+      'marketing-fanout:expire-stale-targets',
+    ]) {
+      expect(events.indexOf(`upsert:${scheduleId}`)).toBeLessThan(firstDelete);
+    }
+    expect(scheduleDeleteMock.mock.calls.map(([scheduleId]) => scheduleId)).toEqual([
+      `${MARKETING_FLIP_DUE_POSTS_JOB}:tenant-1`,
+      `${MARKETING_EXPIRE_STALE_TARGETS_JOB}:tenant-2`,
+      `${MARKETING_SEND_SEQUENCE_STEPS_JOB}:tenant-missing`,
+    ]);
+  });
+
+  it('updates the same global IDs on repeat setup and tolerates not-found cleanup races', async () => {
+    const { setupSchedules } = await import('../setupSchedules');
+
+    await expect(setupSchedules()).resolves.toBeUndefined();
+    await expect(setupSchedules()).resolves.toBeUndefined();
+
+    expect(scheduleUpdateMock.mock.calls
+      .map(([scheduleId]) => scheduleId)
+      .filter((scheduleId) => scheduleId.startsWith('marketing-fanout:')))
+      .toEqual([
+        'marketing-fanout:flip-due-posts',
+        'marketing-fanout:send-sequence-steps',
+        'marketing-fanout:expire-stale-targets',
+      ]);
+    expect(scheduleDeleteMock).toHaveBeenCalledWith(
+      `${MARKETING_SEND_SEQUENCE_STEPS_JOB}:tenant-missing`,
+    );
+  });
+});

--- a/ee/temporal-workflows/src/schedules/setupSchedules.ts
+++ b/ee/temporal-workflows/src/schedules/setupSchedules.ts
@@ -11,8 +11,15 @@ import {
   emailPollingReconcileWorkflow,
   entraAllTenantsSyncWorkflow,
   maintenanceJobWorkflow,
+  marketingFanoutWorkflow,
   premiumTrialExpiryWorkflow,
 } from '../workflows';
+import {
+  MARKETING_EXPIRE_STALE_TARGETS_JOB,
+  MARKETING_FLIP_DUE_POSTS_JOB,
+  MARKETING_SEND_SEQUENCE_STEPS_JOB,
+  type MarketingJobName,
+} from '@alga-psa/marketing/lib/marketingJobContract';
 import * as dotenv from 'dotenv';
 
 dotenv.config();
@@ -35,6 +42,33 @@ const EMAIL_WORKFLOW_TASK_QUEUE = 'email-domain-workflows';
 const ENTRA_WORKFLOW_TASK_QUEUE = 'tenant-workflows';
 const ENTRA_SCHEDULE_ID_PREFIX = 'entra-all-tenants-sync-schedule';
 const ENTRA_SCHEDULE_DISCOVERY_TENANT = '__entra_schedule_config_discovery__';
+const MARKETING_WORKFLOW_TASK_QUEUE = 'tenant-workflows';
+const LEGACY_MARKETING_SCHEDULE_PREFIXES = [
+  `${MARKETING_FLIP_DUE_POSTS_JOB}:`,
+  `${MARKETING_EXPIRE_STALE_TARGETS_JOB}:`,
+  `${MARKETING_SEND_SEQUENCE_STEPS_JOB}:`,
+] as const;
+const MARKETING_FANOUT_SCHEDULES: Array<{
+  scheduleId: string;
+  jobName: MarketingJobName;
+  cron: string;
+}> = [
+  {
+    scheduleId: 'marketing-fanout:flip-due-posts',
+    jobName: MARKETING_FLIP_DUE_POSTS_JOB,
+    cron: '*/5 * * * *',
+  },
+  {
+    scheduleId: 'marketing-fanout:send-sequence-steps',
+    jobName: MARKETING_SEND_SEQUENCE_STEPS_JOB,
+    cron: '*/5 * * * *',
+  },
+  {
+    scheduleId: 'marketing-fanout:expire-stale-targets',
+    jobName: MARKETING_EXPIRE_STALE_TARGETS_JOB,
+    cron: '11 * * * *',
+  },
+];
 // Note: RMM alert reconciliation and Huntress incident polling are NOT set up
 // here. They run as per-integration recurring jobs on the job-runner
 // abstraction (Temporal Schedules in EE via TemporalJobRunner), converged by
@@ -200,17 +234,48 @@ async function upsertSchedule(client: Client, scheduleId: string, input: any): P
   }
 }
 
-async function deleteScheduleIfExists(client: Client, scheduleId: string): Promise<void> {
+async function deleteScheduleIfExists(client: Client, scheduleId: string): Promise<boolean> {
   try {
     const handle = client.schedule.getHandle(scheduleId);
     await handle.delete();
     logger.info(`Deleted schedule: ${scheduleId}`);
+    return true;
   } catch (error: any) {
     if (isNotFoundError(error)) {
-      return;
+      return true;
     }
     logger.warn(`Failed to delete schedule ${scheduleId}: ${error?.message || 'Unknown error'}`);
+    return false;
   }
+}
+
+async function deleteLegacyMarketingSchedules(client: Client): Promise<void> {
+  let scanned = 0;
+  let matched = 0;
+  let deleted = 0;
+  let failed = 0;
+
+  for await (const schedule of client.schedule.list()) {
+    scanned++;
+    const scheduleId = schedule.scheduleId;
+    if (!LEGACY_MARKETING_SCHEDULE_PREFIXES.some((prefix) => scheduleId.startsWith(prefix))) {
+      continue;
+    }
+
+    matched++;
+    if (await deleteScheduleIfExists(client, scheduleId)) {
+      deleted++;
+    } else {
+      failed++;
+    }
+  }
+
+  logger.info('Legacy marketing schedule cleanup completed', {
+    scanned,
+    matched,
+    deleted,
+    failed,
+  });
 }
 
 async function loadEntraScheduleConfigs(): Promise<EntraScheduleConfigRow[]> {
@@ -446,6 +511,29 @@ export async function setupSchedules() {
         },
       });
     }
+
+    for (const { scheduleId: marketingScheduleId, jobName, cron } of MARKETING_FANOUT_SCHEDULES) {
+      await upsertSchedule(client, marketingScheduleId, {
+        spec: {
+          cronExpressions: [cron],
+        },
+        action: {
+          type: 'startWorkflow',
+          workflowType: marketingFanoutWorkflow,
+          args: [{ jobName }],
+          taskQueue: MARKETING_WORKFLOW_TASK_QUEUE,
+          workflowExecutionTimeout: '1h',
+        },
+        policies: {
+          overlap: ScheduleOverlapPolicy.SKIP,
+          catchupWindow: '1m',
+        },
+      });
+    }
+
+    // Cut over only after all global schedules converge. Listing by exact
+    // legacy prefixes cannot match the new marketing-fanout:* IDs.
+    await deleteLegacyMarketingSchedules(client);
 
   } catch (error) {
     logger.error('Failed to connect to Temporal for schedule setup', error);

--- a/ee/temporal-workflows/src/workflows/__tests__/marketing-fanout-workflow.test.ts
+++ b/ee/temporal-workflows/src/workflows/__tests__/marketing-fanout-workflow.test.ts
@@ -1,0 +1,120 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { MARKETING_FLIP_DUE_POSTS_JOB } from '@alga-psa/marketing/lib/marketingJobContract';
+
+const listMarketingTenantIdsMock = vi.fn();
+const runMarketingJobForTenantMock = vi.fn();
+const logInfoMock = vi.fn();
+
+class MockApplicationFailure extends Error {
+  type: string;
+  nonRetryable: boolean;
+  details: unknown[];
+
+  constructor(message: string, type: string, details: unknown[]) {
+    super(message);
+    this.type = type;
+    this.nonRetryable = true;
+    this.details = details;
+  }
+}
+
+vi.mock('@temporalio/workflow', () => ({
+  proxyActivities: vi.fn((options: { startToCloseTimeout: string }) => (
+    options.startToCloseTimeout === '1m'
+      ? { listMarketingTenantIds: listMarketingTenantIdsMock }
+      : { runMarketingJobForTenant: runMarketingJobForTenantMock }
+  )),
+  log: {
+    info: logInfoMock,
+  },
+  ApplicationFailure: {
+    nonRetryable: (message: string, type: string, ...details: unknown[]) =>
+      new MockApplicationFailure(message, type, details),
+  },
+}));
+
+function successfulResult(tenantId: string) {
+  return {
+    jobName: MARKETING_FLIP_DUE_POSTS_JOB,
+    tenantId,
+    operation: { flipped: 1 },
+    completedAt: '2026-07-23T12:00:00.000Z',
+  };
+}
+
+describe('marketingFanoutWorkflow', () => {
+  beforeEach(() => {
+    listMarketingTenantIdsMock.mockReset();
+    runMarketingJobForTenantMock.mockReset();
+    logInfoMock.mockReset();
+  });
+
+  it('invokes every discovered tenant exactly once and returns aggregate counts', async () => {
+    listMarketingTenantIdsMock.mockResolvedValue(['tenant-1', 'tenant-2', 'tenant-3']);
+    runMarketingJobForTenantMock.mockImplementation(async ({ tenantId }) => successfulResult(tenantId));
+    const { marketingFanoutWorkflow } = await import('../marketing-fanout-workflow');
+
+    const summary = await marketingFanoutWorkflow({
+      jobName: MARKETING_FLIP_DUE_POSTS_JOB,
+    });
+
+    expect(runMarketingJobForTenantMock).toHaveBeenCalledTimes(3);
+    expect(runMarketingJobForTenantMock.mock.calls.map(([input]) => input.tenantId).sort())
+      .toEqual(['tenant-1', 'tenant-2', 'tenant-3']);
+    expect(summary).toMatchObject({
+      jobName: MARKETING_FLIP_DUE_POSTS_JOB,
+      total: 3,
+      succeeded: 3,
+      failed: 0,
+    });
+  });
+
+  it('never runs more than ten tenant activities concurrently', async () => {
+    const tenantIds = Array.from({ length: 24 }, (_, index) => `tenant-${index + 1}`);
+    listMarketingTenantIdsMock.mockResolvedValue(tenantIds);
+    let active = 0;
+    let peak = 0;
+    runMarketingJobForTenantMock.mockImplementation(async ({ tenantId }) => {
+      active++;
+      peak = Math.max(peak, active);
+      await new Promise((resolve) => setTimeout(resolve, 2));
+      active--;
+      return successfulResult(tenantId);
+    });
+    const { marketingFanoutWorkflow } = await import('../marketing-fanout-workflow');
+
+    await marketingFanoutWorkflow({ jobName: MARKETING_FLIP_DUE_POSTS_JOB });
+
+    expect(peak).toBe(10);
+  });
+
+  it('attempts later tenants and throws with the full summary after a tenant exhausts retries', async () => {
+    listMarketingTenantIdsMock.mockResolvedValue(['tenant-1', 'tenant-2', 'tenant-3']);
+    runMarketingJobForTenantMock.mockImplementation(async ({ tenantId }) => {
+      if (tenantId === 'tenant-1') {
+        throw new Error('database unavailable');
+      }
+      return successfulResult(tenantId);
+    });
+    const { marketingFanoutWorkflow } = await import('../marketing-fanout-workflow');
+
+    await expect(marketingFanoutWorkflow({
+      jobName: MARKETING_FLIP_DUE_POSTS_JOB,
+    })).rejects.toMatchObject({
+      type: 'MarketingFanoutFailure',
+      nonRetryable: true,
+      details: [{
+        jobName: MARKETING_FLIP_DUE_POSTS_JOB,
+        total: 3,
+        succeeded: 2,
+        failed: 1,
+        results: [
+          { tenantId: 'tenant-1', status: 'failed', error: 'database unavailable' },
+          { tenantId: 'tenant-2', status: 'succeeded' },
+          { tenantId: 'tenant-3', status: 'succeeded' },
+        ],
+      }],
+    });
+    expect(runMarketingJobForTenantMock).toHaveBeenCalledTimes(3);
+  });
+});

--- a/ee/temporal-workflows/src/workflows/index.ts
+++ b/ee/temporal-workflows/src/workflows/index.ts
@@ -7,6 +7,7 @@ export * from './managed-email-domain-workflow.js';
 export * from './generic-job-workflow.js';
 export * from './readiness-workflow.js';
 export * from './maintenance-fanout-workflow.js';
+export * from './marketing-fanout-workflow.js';
 export * from './email-webhook-maintenance-workflow.js';
 export * from './email-polling-reconcile-workflow.js';
 export * from './calendar-webhook-maintenance-workflow.js';

--- a/ee/temporal-workflows/src/workflows/marketing-fanout-workflow.ts
+++ b/ee/temporal-workflows/src/workflows/marketing-fanout-workflow.ts
@@ -1,0 +1,109 @@
+import {
+  ApplicationFailure,
+  log,
+  proxyActivities,
+} from '@temporalio/workflow';
+import type {
+  MarketingFanoutSummary,
+  MarketingFanoutTenantResult,
+  MarketingJobName,
+} from '@alga-psa/marketing/lib/marketingJobContract';
+import type * as marketingActivities from '../activities/marketing-activities.js';
+
+const MAX_TENANT_CONCURRENCY = 10;
+
+const discoveryActivities = proxyActivities<Pick<
+  typeof marketingActivities,
+  'listMarketingTenantIds'
+>>({
+  startToCloseTimeout: '1m',
+  retry: {
+    maximumAttempts: 3,
+    backoffCoefficient: 2,
+    initialInterval: '5s',
+    maximumInterval: '30s',
+  },
+});
+
+const tenantActivities = proxyActivities<Pick<
+  typeof marketingActivities,
+  'runMarketingJobForTenant'
+>>({
+  startToCloseTimeout: '5m',
+  retry: {
+    maximumAttempts: 3,
+    backoffCoefficient: 2,
+    initialInterval: '10s',
+    maximumInterval: '1m',
+  },
+});
+
+export interface MarketingFanoutWorkflowInput {
+  jobName: MarketingJobName;
+}
+
+function errorMessage(error: unknown): string {
+  return error instanceof Error ? error.message : String(error);
+}
+
+export async function marketingFanoutWorkflow(
+  input: MarketingFanoutWorkflowInput,
+): Promise<MarketingFanoutSummary> {
+  const tenantIds = await discoveryActivities.listMarketingTenantIds();
+  const results = new Array<MarketingFanoutTenantResult>(tenantIds.length);
+  let nextTenantIndex = 0;
+
+  const processTenants = async (): Promise<void> => {
+    while (nextTenantIndex < tenantIds.length) {
+      const tenantIndex = nextTenantIndex++;
+      const tenantId = tenantIds[tenantIndex];
+
+      try {
+        const result = await tenantActivities.runMarketingJobForTenant({
+          jobName: input.jobName,
+          tenantId,
+        });
+        results[tenantIndex] = {
+          tenantId,
+          status: 'succeeded',
+          result,
+        };
+      } catch (error) {
+        results[tenantIndex] = {
+          tenantId,
+          status: 'failed',
+          error: errorMessage(error),
+        };
+      }
+    }
+  };
+
+  const workerCount = Math.min(MAX_TENANT_CONCURRENCY, tenantIds.length);
+  await Promise.all(Array.from({ length: workerCount }, processTenants));
+
+  const failed = results.filter((result) => result.status === 'failed').length;
+  const summary: MarketingFanoutSummary = {
+    jobName: input.jobName,
+    total: tenantIds.length,
+    succeeded: tenantIds.length - failed,
+    failed,
+    results,
+  };
+
+  log.info('Marketing fan-out completed', {
+    jobName: summary.jobName,
+    total: summary.total,
+    succeeded: summary.succeeded,
+    failed: summary.failed,
+  });
+
+  if (failed > 0) {
+    throw ApplicationFailure.nonRetryable(
+      `Marketing fan-out failed for ${failed} of ${summary.total} tenants`,
+      'MarketingFanoutFailure',
+      summary,
+    );
+  }
+
+  return summary;
+}

--- a/ee/temporal-workflows/src/workflows/non-authored-index.ts
+++ b/ee/temporal-workflows/src/workflows/non-authored-index.ts
@@ -7,6 +7,7 @@ export * from './managed-email-domain-workflow.js';
 export * from './generic-job-workflow.js';
 export * from './readiness-workflow.js';
 export * from './maintenance-fanout-workflow.js';
+export * from './marketing-fanout-workflow.js';
 export * from './email-webhook-maintenance-workflow.js';
 export * from './email-polling-reconcile-workflow.js';
 export * from './calendar-webhook-maintenance-workflow.js';

--- a/ee/temporal-workflows/vitest.config.ts
+++ b/ee/temporal-workflows/vitest.config.ts
@@ -60,6 +60,8 @@ export default defineConfig({
       { find: /^@alga-psa\/core\/logger$/, replacement: path.resolve(__dirname, '../../packages/core/src/lib/logger.ts') },
       { find: /^@alga-psa\/core\/encryption$/, replacement: path.resolve(__dirname, '../../packages/core/src/lib/encryption.ts') },
       { find: /^@alga-psa\/core\/(.*)$/, replacement: `${path.resolve(__dirname, '../../packages/core/src')}/$1` },
+      { find: /^@alga-psa\/marketing$/, replacement: path.resolve(__dirname, '../../packages/marketing/src/index.ts') },
+      { find: /^@alga-psa\/marketing\/(.*)$/, replacement: `${path.resolve(__dirname, '../../packages/marketing/src')}/$1` },
     ],
   },
 });

--- a/ee/temporal-workflows/vitest.config.ts
+++ b/ee/temporal-workflows/vitest.config.ts
@@ -62,6 +62,8 @@ export default defineConfig({
       { find: /^@alga-psa\/core\/(.*)$/, replacement: `${path.resolve(__dirname, '../../packages/core/src')}/$1` },
       { find: /^@alga-psa\/marketing$/, replacement: path.resolve(__dirname, '../../packages/marketing/src/index.ts') },
       { find: /^@alga-psa\/marketing\/(.*)$/, replacement: `${path.resolve(__dirname, '../../packages/marketing/src')}/$1` },
+      { find: /^@alga-psa\/types$/, replacement: path.resolve(__dirname, '../../packages/types/src/index.ts') },
+      { find: /^@alga-psa\/types\/(.*)$/, replacement: `${path.resolve(__dirname, '../../packages/types/src')}/$1` },
     ],
   },
 });

--- a/package-lock.json
+++ b/package-lock.json
@@ -533,6 +533,7 @@
         "@alga-psa/event-bus": "file:../../packages/event-bus",
         "@alga-psa/jobs": "file:../../packages/jobs",
         "@alga-psa/licensing": "file:../../packages/licensing",
+        "@alga-psa/marketing": "file:../../packages/marketing",
         "@alga-psa/search": "file:../../packages/search",
         "@alga-psa/shared": "file:../../shared",
         "@alga-psa/sla": "file:../../packages/sla",

--- a/packages/marketing/src/lib/index.ts
+++ b/packages/marketing/src/lib/index.ts
@@ -13,3 +13,4 @@ export * from './posts';
 export * from './sequences';
 export * from './signing';
 export * from './tracking';
+export * from './marketingJobContract';

--- a/packages/marketing/src/lib/marketingJobContract.ts
+++ b/packages/marketing/src/lib/marketingJobContract.ts
@@ -1,0 +1,86 @@
+export const MARKETING_FLIP_DUE_POSTS_JOB = 'marketing:flip-due-posts' as const;
+export const MARKETING_EXPIRE_STALE_TARGETS_JOB = 'marketing:expire-stale-targets' as const;
+export const MARKETING_SEND_SEQUENCE_STEPS_JOB = 'marketing:send-sequence-steps' as const;
+
+export const MARKETING_JOB_NAMES = [
+  MARKETING_FLIP_DUE_POSTS_JOB,
+  MARKETING_EXPIRE_STALE_TARGETS_JOB,
+  MARKETING_SEND_SEQUENCE_STEPS_JOB,
+] as const;
+
+export type MarketingJobName = (typeof MARKETING_JOB_NAMES)[number];
+
+export interface MarketingJobData extends Record<string, unknown> {
+  tenantId: string;
+}
+
+export interface MarketingJobInput {
+  jobName: MarketingJobName;
+  tenantId: string;
+}
+
+export interface MarketingFlipDuePostsSummary {
+  flipped: number;
+}
+
+export interface MarketingExpireStaleTargetsSummary {
+  expired: number;
+}
+
+export interface MarketingSequenceSendSummary {
+  sent: number;
+  completed: number;
+  stopped: number;
+  failed: number;
+  skipped: number;
+}
+
+export interface MarketingJobOperationSummaryMap {
+  [MARKETING_FLIP_DUE_POSTS_JOB]: MarketingFlipDuePostsSummary;
+  [MARKETING_EXPIRE_STALE_TARGETS_JOB]: MarketingExpireStaleTargetsSummary;
+  [MARKETING_SEND_SEQUENCE_STEPS_JOB]: MarketingSequenceSendSummary;
+}
+
+export type MarketingTenantJobResult = {
+  [JobName in MarketingJobName]: {
+    jobName: JobName;
+    tenantId: string;
+    operation: MarketingJobOperationSummaryMap[JobName];
+    completedAt: string;
+  };
+}[MarketingJobName];
+
+export interface MarketingFanoutSuccess {
+  tenantId: string;
+  status: 'succeeded';
+  result: MarketingTenantJobResult;
+}
+
+export interface MarketingFanoutFailure {
+  tenantId: string;
+  status: 'failed';
+  error: string;
+}
+
+export type MarketingFanoutTenantResult =
+  | MarketingFanoutSuccess
+  | MarketingFanoutFailure;
+
+export interface MarketingFanoutSummary {
+  jobName: MarketingJobName;
+  total: number;
+  succeeded: number;
+  failed: number;
+  results: MarketingFanoutTenantResult[];
+}
+
+export function isMarketingJobName(value: unknown): value is MarketingJobName {
+  return typeof value === 'string'
+    && MARKETING_JOB_NAMES.includes(value as MarketingJobName);
+}
+
+export function assertMarketingJobName(value: unknown): asserts value is MarketingJobName {
+  if (!isMarketingJobName(value)) {
+    throw new Error(`Unknown marketing job name: ${String(value)}`);
+  }
+}

--- a/packages/marketing/src/lib/posts.ts
+++ b/packages/marketing/src/lib/posts.ts
@@ -1,6 +1,10 @@
 import type { Knex } from 'knex';
 import { tenantDb, withTransaction } from '@alga-psa/db';
 import type {
+  MarketingExpireStaleTargetsSummary,
+  MarketingFlipDuePostsSummary,
+} from './marketingJobContract';
+import type {
   ISocialPost,
   ISocialPostQueueItem,
   ISocialPostTarget,
@@ -133,7 +137,7 @@ export async function flipDuePostsInternal(
   knex: Knex,
   tenant: string,
   now: Date = new Date(),
-): Promise<{ flipped: number }> {
+): Promise<MarketingFlipDuePostsSummary> {
   return withTransaction(knex, async (trx) => {
     const db = tenantDb(trx, tenant);
     const dueTargets = await db.table('social_post_targets as t')
@@ -166,7 +170,7 @@ export async function expireStaleTargetsInternal(
   tenant: string,
   graceHours: number,
   now: Date = new Date(),
-): Promise<{ expired: number }> {
+): Promise<MarketingExpireStaleTargetsSummary> {
   const cutoff = new Date(now.getTime() - graceHours * 3_600_000).toISOString();
   return withTransaction(knex, async (trx) => {
     const db = tenantDb(trx, tenant);

--- a/packages/marketing/src/lib/sequences.ts
+++ b/packages/marketing/src/lib/sequences.ts
@@ -13,6 +13,7 @@ import { recordMarketingEngagement } from './engagements';
 import { signTrackingDestination } from './signing';
 import { addSuppression, isSuppressed, normalizeEmail } from './suppression';
 import type { SequenceInput } from '../schemas/marketingSchemas';
+import type { MarketingSequenceSendSummary } from './marketingJobContract';
 
 // ---------------------------------------------------------------------------
 // CRUD
@@ -241,14 +242,7 @@ function trackableLinks(html: string, clickBase: string, sign: (url: string) => 
     `href="${clickBase}?u=${encodeURIComponent(url)}&s=${sign(url)}"`);
 }
 
-export interface SequenceSendSummary {
-  sent: number;
-  completed: number;
-  stopped: number;
-  failed: number;
-  /** Steps another runner had already claimed or delivered (idempotent replay). */
-  skipped: number;
-}
+export type SequenceSendSummary = MarketingSequenceSendSummary;
 
 /**
  * Sends every due sequence step for the tenant. Each (enrollment, step) pair

--- a/scripts/temporal-worker-dist-import-smoke.mjs
+++ b/scripts/temporal-worker-dist-import-smoke.mjs
@@ -51,6 +51,22 @@ async function importModule(absPath) {
   await import(pathToFileURL(absPath).href);
 }
 
+async function assertMarketingRuntimeExports() {
+  const posts = await import('@alga-psa/marketing/lib/posts');
+  const sequences = await import('@alga-psa/marketing/lib/sequences');
+  const requiredExports = [
+    ['flipDuePostsInternal', posts.flipDuePostsInternal],
+    ['expireStaleTargetsInternal', posts.expireStaleTargetsInternal],
+    ['sendDueSequenceStepsInternal', sequences.sendDueSequenceStepsInternal],
+  ];
+
+  for (const [name, value] of requiredExports) {
+    if (typeof value !== 'function') {
+      throw new Error(`@alga-psa/marketing runtime export ${name} is missing`);
+    }
+  }
+}
+
 async function main() {
   // The Temporal worker statically references the job handlers in @alga-psa/jobs,
   // which fan out across the vertical domain packages (billing/tickets/integrations/
@@ -126,6 +142,7 @@ async function main() {
   await importModule(workerEntry);
   await importModule(activitiesEntry);
   await importModule(workflowsEntry);
+  await assertMarketingRuntimeExports();
   console.log('Temporal worker dist import smoke check passed.');
 }
 

--- a/server/src/lib/jobs/handlers/marketingJobs.ts
+++ b/server/src/lib/jobs/handlers/marketingJobs.ts
@@ -6,17 +6,22 @@ import {
   expireStaleTargetsInternal,
   sendDueSequenceStepsInternal,
 } from '@alga-psa/marketing/lib';
+import {
+  MARKETING_EXPIRE_STALE_TARGETS_JOB,
+  MARKETING_FLIP_DUE_POSTS_JOB,
+  MARKETING_SEND_SEQUENCE_STEPS_JOB,
+  type MarketingJobData,
+} from '@alga-psa/marketing/lib/marketingJobContract';
 import { runWithTenant } from 'server/src/lib/db';
 import { getConnection } from 'server/src/lib/db/db';
 import { getMarketingSigningSecret } from 'server/src/lib/marketing/signingSecret';
 
-export const MARKETING_FLIP_DUE_POSTS_JOB = 'marketing:flip-due-posts';
-export const MARKETING_EXPIRE_STALE_TARGETS_JOB = 'marketing:expire-stale-targets';
-export const MARKETING_SEND_SEQUENCE_STEPS_JOB = 'marketing:send-sequence-steps';
-
-export interface MarketingJobData extends Record<string, unknown> {
-  tenantId: string;
-}
+export {
+  MARKETING_EXPIRE_STALE_TARGETS_JOB,
+  MARKETING_FLIP_DUE_POSTS_JOB,
+  MARKETING_SEND_SEQUENCE_STEPS_JOB,
+};
+export type { MarketingJobData };
 
 /** Grace period before an awaiting-manual-publish target auto-expires (F027). */
 const STALE_TARGET_GRACE_HOURS = 48;

--- a/server/src/lib/jobs/initializeScheduledJobs.ts
+++ b/server/src/lib/jobs/initializeScheduledJobs.ts
@@ -4,6 +4,7 @@ import { scheduleHuduAutoSyncJob } from './handlers/huduAutoSyncHandler';
 import logger from '@alga-psa/core/logger';
 import { getConnection } from 'server/src/lib/db/db';
 import { tenantDb } from '@alga-psa/db';
+import { scheduleMarketingJobsForTenant } from './marketingScheduleCutover';
 
 const isEnterpriseWorkflowEdition = (): boolean =>
   process.env.EDITION === 'enterprise'
@@ -107,27 +108,18 @@ export async function initializeScheduledJobs(): Promise<void> {
         logger.error(`Failed to schedule opportunity weekly digest job for tenant ${tenantId}`, error);
       }
 
-      // Marketing module jobs (flag-gated no-ops when the module is off)
-      try {
-        const flipJobId = await scheduleMarketingFlipDuePostsJob(tenantId, '*/5 * * * *');
-        logger.info('Marketing flip-due-posts schedule converged', { tenantId, flipJobId });
-      } catch (error) {
-        logger.error(`Failed to schedule marketing flip-due-posts job for tenant ${tenantId}`, error);
-      }
-
-      try {
-        const expireJobId = await scheduleMarketingExpireStaleTargetsJob(tenantId, '11 * * * *');
-        logger.info('Marketing expire-stale-targets schedule converged', { tenantId, expireJobId });
-      } catch (error) {
-        logger.error(`Failed to schedule marketing expire-stale-targets job for tenant ${tenantId}`, error);
-      }
-
-      try {
-        const sendJobId = await scheduleMarketingSendSequenceStepsJob(tenantId, '*/5 * * * *');
-        logger.info('Marketing send-sequence-steps schedule converged', { tenantId, sendJobId });
-      } catch (error) {
-        logger.error(`Failed to schedule marketing send-sequence-steps job for tenant ${tenantId}`, error);
-      }
+      // CE keeps the existing per-tenant pg-boss jobs. In EE/appliance the
+      // Temporal worker's three global fan-out schedules are authoritative.
+      await scheduleMarketingJobsForTenant({
+        tenantId,
+        enterpriseWorkflowEdition: isEnterpriseWorkflowEdition(),
+        dependencies: {
+          logger,
+          scheduleFlipDuePosts: scheduleMarketingFlipDuePostsJob,
+          scheduleExpireStaleTargets: scheduleMarketingExpireStaleTargetsJob,
+          scheduleSendSequenceSteps: scheduleMarketingSendSequenceStepsJob,
+        },
+      });
 
       // Schedule daily job to run credit reconciliation (runs at 2:00 AM)
       try {

--- a/server/src/lib/jobs/marketingScheduleCutover.ts
+++ b/server/src/lib/jobs/marketingScheduleCutover.ts
@@ -1,0 +1,70 @@
+interface MarketingScheduleLogger {
+  info(message: string, metadata?: Record<string, unknown>): void;
+  error(message: string, error: unknown): void;
+}
+
+interface MarketingScheduleDependencies {
+  logger: MarketingScheduleLogger;
+  scheduleFlipDuePosts(tenantId: string, cron: string): Promise<string | null>;
+  scheduleExpireStaleTargets(tenantId: string, cron: string): Promise<string | null>;
+  scheduleSendSequenceSteps(tenantId: string, cron: string): Promise<string | null>;
+}
+
+interface ScheduleMarketingJobsInput {
+  tenantId: string;
+  enterpriseWorkflowEdition: boolean;
+  dependencies: MarketingScheduleDependencies;
+}
+
+export async function scheduleMarketingJobsForTenant({
+  tenantId,
+  enterpriseWorkflowEdition,
+  dependencies,
+}: ScheduleMarketingJobsInput): Promise<void> {
+  if (enterpriseWorkflowEdition) {
+    dependencies.logger.info(
+      'Skipping per-tenant marketing schedules because EE uses Temporal fan-out',
+      { tenantId },
+    );
+    return;
+  }
+
+  try {
+    const flipJobId = await dependencies.scheduleFlipDuePosts(tenantId, '*/5 * * * *');
+    dependencies.logger.info('Marketing flip-due-posts schedule converged', {
+      tenantId,
+      flipJobId,
+    });
+  } catch (error) {
+    dependencies.logger.error(
+      `Failed to schedule marketing flip-due-posts job for tenant ${tenantId}`,
+      error,
+    );
+  }
+
+  try {
+    const expireJobId = await dependencies.scheduleExpireStaleTargets(tenantId, '11 * * * *');
+    dependencies.logger.info('Marketing expire-stale-targets schedule converged', {
+      tenantId,
+      expireJobId,
+    });
+  } catch (error) {
+    dependencies.logger.error(
+      `Failed to schedule marketing expire-stale-targets job for tenant ${tenantId}`,
+      error,
+    );
+  }
+
+  try {
+    const sendJobId = await dependencies.scheduleSendSequenceSteps(tenantId, '*/5 * * * *');
+    dependencies.logger.info('Marketing send-sequence-steps schedule converged', {
+      tenantId,
+      sendJobId,
+    });
+  } catch (error) {
+    dependencies.logger.error(
+      `Failed to schedule marketing send-sequence-steps job for tenant ${tenantId}`,
+      error,
+    );
+  }
+}

--- a/server/src/test/unit/billing/automaticInvoices.recurringDueWork.ui.test.tsx
+++ b/server/src/test/unit/billing/automaticInvoices.recurringDueWork.ui.test.tsx
@@ -203,6 +203,7 @@ vi.mock('@alga-psa/auth/rbac', () => ({
 vi.mock('@alga-psa/db', () => ({
   createTenantKnex: dbMocks.createTenantKnex,
   withTransaction: dbMocks.withTransaction,
+  getTenantContext: () => 'tenant-1',
   runWithTenant: async (_tenant: string, callback: () => Promise<unknown> | unknown) => callback(),
   tenantDb: (conn: any, tenant: string) => ({
     table: (t: string) => conn(t).where({ tenant }),

--- a/server/src/test/unit/initializeScheduledJobs.marketing.test.ts
+++ b/server/src/test/unit/initializeScheduledJobs.marketing.test.ts
@@ -1,0 +1,53 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { scheduleMarketingJobsForTenant } from '../../lib/jobs/marketingScheduleCutover';
+
+describe('marketing scheduled-job edition boundary', () => {
+  const logger = {
+    info: vi.fn(),
+    error: vi.fn(),
+  };
+  const scheduleFlipDuePosts = vi.fn();
+  const scheduleExpireStaleTargets = vi.fn();
+  const scheduleSendSequenceSteps = vi.fn();
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    scheduleFlipDuePosts.mockResolvedValue('flip-job');
+    scheduleExpireStaleTargets.mockResolvedValue('expire-job');
+    scheduleSendSequenceSteps.mockResolvedValue('send-job');
+  });
+
+  it('does not create per-tenant marketing schedules in EE', async () => {
+    await scheduleMarketingJobsForTenant({
+      tenantId: 'tenant-1',
+      enterpriseWorkflowEdition: true,
+      dependencies: {
+        logger,
+        scheduleFlipDuePosts,
+        scheduleExpireStaleTargets,
+        scheduleSendSequenceSteps,
+      },
+    });
+
+    expect(scheduleFlipDuePosts).not.toHaveBeenCalled();
+    expect(scheduleExpireStaleTargets).not.toHaveBeenCalled();
+    expect(scheduleSendSequenceSteps).not.toHaveBeenCalled();
+  });
+
+  it('keeps the existing per-tenant marketing cadences in CE', async () => {
+    await scheduleMarketingJobsForTenant({
+      tenantId: 'tenant-1',
+      enterpriseWorkflowEdition: false,
+      dependencies: {
+        logger,
+        scheduleFlipDuePosts,
+        scheduleExpireStaleTargets,
+        scheduleSendSequenceSteps,
+      },
+    });
+
+    expect(scheduleFlipDuePosts).toHaveBeenCalledWith('tenant-1', '*/5 * * * *');
+    expect(scheduleExpireStaleTargets).toHaveBeenCalledWith('tenant-1', '11 * * * *');
+    expect(scheduleSendSequenceSteps).toHaveBeenCalledWith('tenant-1', '*/5 * * * *');
+  });
+});

--- a/services/workflow-worker/Dockerfile
+++ b/services/workflow-worker/Dockerfile
@@ -31,6 +31,7 @@ COPY packages/db/package.json ./packages/db/
 COPY packages/event-bus/package.json ./packages/event-bus/
 COPY packages/event-schemas/package.json ./packages/event-schemas/
 COPY packages/formatting/package.json ./packages/formatting/
+COPY packages/marketing/package.json ./packages/marketing/
 COPY packages/portal-shared/package.json ./packages/portal-shared/
 COPY packages/storage/package.json ./packages/storage/
 COPY packages/types/package.json ./packages/types/
@@ -51,6 +52,7 @@ RUN npm config set legacy-peer-deps true && PUPPETEER_SKIP_DOWNLOAD=true npm ins
   --workspace=@alga-psa/event-bus \
   --workspace=@alga-psa/event-schemas \
   --workspace=@alga-psa/formatting \
+  --workspace=@alga-psa/marketing \
   --workspace=@alga-psa/portal-shared \
   --workspace=@alga-psa/storage \
   --workspace=@alga-psa/types \
@@ -100,6 +102,9 @@ RUN npm run build
 
 # Build event bus (required by shared)
 WORKDIR /app/packages/event-bus
+RUN npm run build
+
+WORKDIR /app/packages/marketing
 RUN npm run build
 
 # Build shared workspace first (server is only referenced for type imports)


### PR DESCRIPTION
## Summary

- Replace EE per-tenant marketing schedules with three global Temporal schedules on `tenant-workflows`, while leaving CE pg-boss scheduling intact.
- Add a deterministic marketing fan-out workflow that discovers every tenant, invokes the selected marketing domain operation directly in independently retryable tenant activities, caps concurrency at 10, and reports `total`, `succeeded`, and `failed` after every tenant is attempted. Any tenants that exhaust retries are included in the full failure summary.
- Converge the global schedules before deleting legacy per-tenant Temporal schedules, preserving the existing 5-minute send/flip and minute-11 hourly expiry cadences with overlap skipping.
- Build and ship the marketing runtime with the compiled Temporal worker, verify its runtime exports, and prefer `APPLICATION_URL` when generating normalized unsubscribe and tracking links.
- Stabilize the existing recurring-invoice UI unit test's `@alga-psa/db` mock after the full server suite exposed delayed `getTenantContext` calls as unhandled rejections.

## Verification

PASS. Focused orchestration, activity, schedule-cutover, routing, worker-registration, and CE scheduling tests passed. Server typechecking passed with `NODE_OPTIONS=--max-old-space-size=16384`, and the compiled temporal-worker distribution import smoke passed. After the CI follow-up, the full server unit suite with the CI shuffle seed and coverage also passed locally: 919 files passed, 1 skipped; 4,446 tests passed, 22 todo.

The real app remains running on port 3016 with its PostgreSQL, PgBouncer, Redis, Hocuspocus, and GreenMail services up.

Exercised through the authenticated UI: enrolled Dorothy Gale into the active Welcome Drip sequence and let the scheduled Temporal workflow process it. The workflow completed with `total=1`, `succeeded=1`, `failed=0`; the UI advanced the enrollment to step 1/4 and the database recorded a sent delivery.

The real GreenMail message proved the URL fix: unsubscribe, click-tracking, and open-tracking URLs all used `http://localhost:3016`, normalized without a double slash, while a deliberately conflicting `NEXTAUTH_URL=http://wrong.invalid` was absent.

Schedule convergence produced exactly the three global marketing schedules, deleted three injected legacy per-tenant schedules, preserved an unrelated control schedule, and remained correct on a second setup run. Flip and expiry workflows also completed successfully as no-ops. A 12-tenant fanout completed with `total=12`, `succeeded=12`, `failed=0`; Temporal history showed ten tenant activities scheduled initially and two only after capacity freed, demonstrating the concurrency cap. CE pg-boss marketing schedules remained intact.

## Fidelity compromise

The repository's existing Compose Temporal service was unhealthy due to Cassandra connection failures. Testing stepped down to the repository's existing `@temporalio/testing` local Temporal server, while retaining the compiled branch worker, real application database, real scheduled executions, real UI, and real SMTP delivery. No mocks or custom simulator were used.

## Not exercised

A deliberately exhausted three-retry tenant failure while other tenants continue was not exercised because inducing it safely would require invasive fault injection into the shared database/runtime.

## Concerns and cleanup

Schedule setup also attempted an unrelated appliance-license check-in against unavailable `localhost:3199`; Temporal Web emitted CodeMirror rendering errors on the large workflow result. Neither affected marketing execution.

Temporary tenants, enrollment, send, and interaction rows were removed. The disposable GreenMail message remains because its delete endpoint returned 405. Pre-existing `package.json` and `package-lock.json` working-tree changes were untouched and are not included in this PR.

Smoke evidence: `/tmp/alga-smoke-evidence/marketing-workflow-fanout-fix-20260723T172735Z`
