### PR TITLE
Fix appliance Temporal worker database and Redis config

### DIFF
--- a/ee/appliance/flux/profiles/single-node/values/temporal-worker.single-node.yaml
+++ b/ee/appliance/flux/profiles/single-node/values/temporal-worker.single-node.yaml
@@ -41,6 +41,12 @@ db:
 
 applicationUrl: http://alga-core.msp.svc.cluster.local:3000
 
+extraEnv:
+  - name: REDIS_HOST
+    value: redis.msp.svc.cluster.local
+  - name: REDIS_PORT
+    value: "6379"
+
 autoscaling:
   enabled: true
   minReplicas: 1

--- a/ee/appliance/ubuntu-iso/tests/t001-build-smoke.test.mjs
+++ b/ee/appliance/ubuntu-iso/tests/t001-build-smoke.test.mjs
@@ -198,7 +198,7 @@ test('T004 Temporal chart waits for schema-safe startup and creates the default 
   assert.match(job.spec.template.spec.containers[0].command.join('\n'), /temporal operator namespace create/);
 });
 
-test('T005 temporal-worker profile injects NEXTAUTH_SECRET from alga-core secrets', () => {
+test('T005 temporal-worker profile injects appliance auth and Redis configuration', () => {
   const docs = helmTemplate(temporalWorkerChartPath, temporalWorkerProfileValuesPath);
   const deployment = docs.find((doc) => doc.kind === 'Deployment' && doc.metadata?.name === 'test-release-temporal-worker');
   assert.ok(deployment);
@@ -209,6 +209,8 @@ test('T005 temporal-worker profile injects NEXTAUTH_SECRET from alga-core secret
     name: 'alga-core-sebastian-secrets',
     key: 'NEXTAUTH_SECRET'
   });
+  assert.equal(env.find((entry) => entry.name === 'REDIS_HOST')?.value, 'redis.msp.svc.cluster.local');
+  assert.equal(env.find((entry) => entry.name === 'REDIS_PORT')?.value, '6379');
 });
 
 test('T006 alga-core appliance profile gives the app Deployment a first-install-safe progress deadline', () => {

--- a/packages/db/src/lib/knexfile.test.ts
+++ b/packages/db/src/lib/knexfile.test.ts
@@ -9,6 +9,7 @@ vi.mock('@alga-psa/core', () => ({
 
 describe('knexfile', () => {
   beforeEach(() => {
+    vi.resetModules();
     process.env.DB_HOST = 'db-host';
     process.env.DB_PORT = '5439';
     process.env.DB_USER_SERVER = 'app_user';
@@ -34,6 +35,16 @@ describe('knexfile', () => {
     expect(config.connection.password).toBe('server_pw');
   });
 
+  it('getKnexConfig honors the configured server user in production', async () => {
+    process.env.DB_USER_SERVER = 'app_user_pgbouncer';
+    const { getKnexConfig } = await import('./knexfile');
+
+    const config = await getKnexConfig('production');
+
+    expect(config.connection.user).toBe('app_user_pgbouncer');
+    expect(config.connection.password).toBe('server_pw');
+  });
+
   it('getPostgresConnection uses admin env vars and password', async () => {
     const { getPostgresConnection } = await import('./knexfile');
 
@@ -46,4 +57,3 @@ describe('knexfile', () => {
     expect(connection.password).toBe('admin_pw');
   });
 });
-

--- a/packages/db/src/lib/knexfile.ts
+++ b/packages/db/src/lib/knexfile.ts
@@ -121,7 +121,7 @@ const baseConfig: Record<string, CustomKnexConfig> = {
     connection: {
       host: (typeof process !== 'undefined' && process.env?.DB_HOST) || 'localhost',
       port: Number((typeof process !== 'undefined' && process.env?.DB_PORT) || 5432),
-      user: 'app_user',
+      user: (typeof process !== 'undefined' && process.env?.DB_USER_SERVER) || 'app_user',
       password: getDbPasswordFromEnv(),
       database: (typeof process !== 'undefined' && process.env?.DB_NAME_SERVER) || 'server'
     },


### PR DESCRIPTION
## Summary

Nightly appliance smoke testing of the marketing fan-out worker exposed two appliance-only runtime configuration gaps:

- the shared production Knex config hardcoded `app_user` instead of honoring the chart's `DB_USER_SERVER=app_user_pgbouncer`, causing tenant activities to fail SASL authentication;
- the appliance Temporal worker profile omitted `REDIS_HOST`/`REDIS_PORT`, so the packaged email/event-bus runtime tried localhost.

This change makes the production tenant DB connection honor `DB_USER_SERVER` and configures the appliance worker to use `redis.msp.svc.cluster.local:6379`.

## Validation

- `npm test --workspace=@alga-psa/db -- --run src/lib/knexfile.test.ts` — 3 passed
- `npm run build --workspace=@alga-psa/db` — passed
- `node --test --test-name-pattern='T005' ee/appliance/ubuntu-iso/tests/t001-build-smoke.test.mjs` — passed
- nightly VM evidence before the fix: new worker image ready with zero restarts; three global schedules present; tenant activity reached `runMarketingJobForTenant` but failed with `SASL authentication failed`; worker environment confirmed `DB_USER_SERVER=app_user_pgbouncer` and no Redis host/port.

The broader local Temporal suite was attempted but its environment setup could not run Docker in the sandbox and an unrelated integrations workspace export was not built. PR CI remains the full gate.