### PR TITLE
Wire appliance Temporal worker Redis credentials

### DIFF
--- a/ee/appliance/flux/profiles/single-node/values/temporal-worker.single-node.yaml
+++ b/ee/appliance/flux/profiles/single-node/values/temporal-worker.single-node.yaml
@@ -46,6 +46,11 @@ extraEnv:
     value: redis.msp.svc.cluster.local
   - name: REDIS_PORT
     value: "6379"
+  - name: REDIS_PASSWORD
+    valueFrom:
+      secretKeyRef:
+        name: redis-credentials
+        key: REDIS_PASSWORD
 
 autoscaling:
   enabled: true

--- a/ee/appliance/ubuntu-iso/tests/t001-build-smoke.test.mjs
+++ b/ee/appliance/ubuntu-iso/tests/t001-build-smoke.test.mjs
@@ -211,6 +211,10 @@ test('T005 temporal-worker profile injects appliance auth and Redis configuratio
   });
   assert.equal(env.find((entry) => entry.name === 'REDIS_HOST')?.value, 'redis.msp.svc.cluster.local');
   assert.equal(env.find((entry) => entry.name === 'REDIS_PORT')?.value, '6379');
+  assert.deepEqual(env.find((entry) => entry.name === 'REDIS_PASSWORD')?.valueFrom.secretKeyRef, {
+    name: 'redis-credentials',
+    key: 'REDIS_PASSWORD'
+  });
 });
 
 test('T006 alga-core appliance profile gives the app Deployment a first-install-safe progress deadline', () => {

--- a/ee/helm/temporal-worker/templates/deployment.yaml
+++ b/ee/helm/temporal-worker/templates/deployment.yaml
@@ -217,9 +217,8 @@ spec:
             {{- end }}
             
             # Additional environment variables
-            {{- range .Values.extraEnv }}
-            - name: {{ .name }}
-              value: {{ .value | quote }}
+            {{- with .Values.extraEnv }}
+            {{- toYaml . | nindent 12 }}
             {{- end }}
           
           ports:

--- a/ee/helm/temporal-worker/values.yaml
+++ b/ee/helm/temporal-worker/values.yaml
@@ -159,6 +159,11 @@ affinity: {}
 extraEnv: []
   # - name: EXTRA_VAR
   #   value: "extra-value"
+  # - name: SECRET_VAR
+  #   valueFrom:
+  #     secretKeyRef:
+  #       name: existing-secret
+  #       key: SECRET_KEY
 
 # Auth configuration
 auth:


### PR DESCRIPTION
## Summary
- allow the Temporal worker Helm chart's `extraEnv` entries to render Kubernetes `valueFrom` sources
- inject `REDIS_PASSWORD` from the appliance's existing `redis-credentials` Secret
- extend the appliance render smoke test to verify host, port, and secret-backed password wiring

## Why
Nightly appliance validation of PR #3007 proved the corrected worker reached the in-cluster Redis service, but startup then failed event publication with `NOAUTH Authentication required.` The appliance Redis StatefulSet requires the existing `redis-credentials/REDIS_PASSWORD` value, already used by the email and workflow workers.

## Validation
- `node --test --test-name-pattern='T005' ee/appliance/ubuntu-iso/tests/t001-build-smoke.test.mjs`
- `helm lint ee/helm/temporal-worker -f ee/appliance/flux/profiles/single-node/values/temporal-worker.single-node.yaml`
- `git diff --check`

This is a chart/config-only correction; the already-published Temporal worker image does not change.