### PR TITLE
Avoid runtime steps in EE image packaging

### DIFF
--- a/ee/server/Dockerfile
+++ b/ee/server/Dockerfile
@@ -89,13 +89,9 @@ COPY ./ee/server/seeds/ /app/ee/server/seeds/
 # Copy core package.json for version info
 COPY packages/core/package.json /app/packages/core/package.json
 
-# Copy entrypoint
-COPY server/entrypoint.sh /app/entrypoint.sh
-RUN chmod +x /app/entrypoint.sh
-
-# Create build timestamp for verification
-RUN echo "BUILD_TIME=$(date)" > /app/build-info.txt && \
-    echo "BUILD_EPOCH=$(date +%s)" >> /app/build-info.txt
+# Copy the entrypoint with its runtime mode already set. Keeping this as image
+# metadata avoids starting a throwaway build container solely to run chmod.
+COPY --chmod=0755 server/entrypoint.sh /app/entrypoint.sh
 
 EXPOSE 3000
 ENV NODE_ENV=production


### PR DESCRIPTION
## Summary
- set the EE entrypoint executable bit with `COPY --chmod=0755`
- remove the unused build-info timestamp `RUN` step
- avoid spawning throwaway build containers for image metadata-only work

## Why
The coordinated appliance release repeatedly exhausted Docker retries on a runner-level `runc` failure while masking `/proc/acpi` at the uncached `RUN chmod` step. The image contents had already built successfully and included the marketing migrations.

## Validation
- `git diff --check`
- confirmed `build-info.txt` is not consumed elsewhere
- coordinated nightly release will be retried after merge to validate packaging and the appliance migration path