### PR TITLE
Marketing workflow fanout fix

### DIFF
--- a/docker-compose.ee.yaml
+++ b/docker-compose.ee.yaml
@@ -457,6 +457,7 @@ services:
       - SECRET_READ_CHAIN=filesystem,env
       - APPLICATION_URL=${APPLICATION_URL:-http://localhost:3000}
       - NEXTAUTH_URL=${NEXTAUTH_URL:-http://localhost:3000}
+      - NEXT_PUBLIC_BASE_URL=${NEXT_PUBLIC_BASE_URL:-http://localhost:3000}
       - NEXTAUTH_SECRET=${NEXTAUTH_SECRET:-local-nextauth-secret}
       - ALGA_AUTH_KEY=${ALGA_AUTH_KEY:-local-alga-auth-key}
       - DB_HOST=${DB_HOST:-pgbouncer}

--- a/ee/appliance/flux/profiles/single-node/values/temporal-worker.single-node.yaml
+++ b/ee/appliance/flux/profiles/single-node/values/temporal-worker.single-node.yaml
@@ -40,6 +40,7 @@ db:
     key: DB_PASSWORD_SUPERUSER
 
 applicationUrl: http://alga-core.msp.svc.cluster.local:3000
+publicBaseUrl: https://alga.local
 
 extraEnv:
   - name: REDIS_HOST

--- a/ee/appliance/host-service/manage-engine.mjs
+++ b/ee/appliance/host-service/manage-engine.mjs
@@ -197,7 +197,9 @@ export async function applyAppUrl(deps) {
     releaseSelectionFile,
     valuesNamespace = 'alga-system',
     valuesConfigMapName = 'appliance-values-alga-core',
+    temporalWorkerValuesConfigMapName = 'appliance-values-temporal-worker',
     helmReleaseName = 'alga-core',
+    temporalWorkerHelmReleaseName = 'temporal-worker',
     timestamp
   } = deps;
 
@@ -210,35 +212,69 @@ export async function applyAppUrl(deps) {
   }
   const host = hostFromAppUrl(appUrl);
 
-  // 1. Read the current alga-core values configmap, rewrite the URL scalars.
-  const cm = await kube.json(`get configmap ${valuesConfigMapName} -n ${valuesNamespace}`);
-  if (!cm || !cm.ok || !cm.value || !cm.value.data) {
-    return { ok: false, status: 412, error: `Could not read ${valuesConfigMapName} in ${valuesNamespace}.` };
-  }
-  const dataKeys = Object.keys(cm.value.data);
-  const valuesKey = dataKeys.find((k) => k.startsWith('alga-core.')) || dataKeys[0];
-  if (!valuesKey) {
-    return { ok: false, status: 412, error: `${valuesConfigMapName} has no values data key.` };
-  }
-  let yaml = cm.value.data[valuesKey];
-  try {
-    yaml = setYamlScalar(yaml, ['appUrl'], JSON.stringify(appUrl));
-    yaml = setYamlScalar(yaml, ['host'], JSON.stringify(host));
-    yaml = setYamlScalar(yaml, ['domainSuffix'], '""');
-  } catch (error) {
-    return { ok: false, status: 412, error: `Could not rewrite app URL in values: ${error instanceof Error ? error.message : String(error)}` };
+  // 1. Read and rewrite both values ConfigMaps before applying either one.
+  //    The app keeps its internal service URL, while recipient-facing links
+  //    from temporal-worker follow the operator's public hostname.
+  const valuesTargets = [
+    {
+      configMapName: valuesConfigMapName,
+      valuesKeyPrefix: 'alga-core.',
+      rewrite(yaml) {
+        let updated = setYamlScalar(yaml, ['appUrl'], JSON.stringify(appUrl));
+        updated = setYamlScalar(updated, ['host'], JSON.stringify(host));
+        return setYamlScalar(updated, ['domainSuffix'], '""');
+      }
+    },
+    {
+      configMapName: temporalWorkerValuesConfigMapName,
+      valuesKeyPrefix: 'temporal-worker.',
+      rewrite(yaml) {
+        return setYamlScalar(yaml, ['publicBaseUrl'], JSON.stringify(appUrl));
+      }
+    }
+  ];
+  const manifests = [];
+
+  for (const target of valuesTargets) {
+    const cm = await kube.json(`get configmap ${target.configMapName} -n ${valuesNamespace}`);
+    if (!cm || !cm.ok || !cm.value || !cm.value.data) {
+      return { ok: false, status: 412, error: `Could not read ${target.configMapName} in ${valuesNamespace}.` };
+    }
+    const dataKeys = Object.keys(cm.value.data);
+    const valuesKey = dataKeys.find((key) => key.startsWith(target.valuesKeyPrefix)) || dataKeys[0];
+    if (!valuesKey) {
+      return { ok: false, status: 412, error: `${target.configMapName} has no values data key.` };
+    }
+
+    let yaml = cm.value.data[valuesKey];
+    try {
+      yaml = target.rewrite(yaml);
+    } catch (error) {
+      return {
+        ok: false,
+        status: 412,
+        error: `Could not rewrite app URL in ${target.configMapName}: ${error instanceof Error ? error.message : String(error)}`
+      };
+    }
+
+    manifests.push({
+      apiVersion: 'v1',
+      kind: 'ConfigMap',
+      metadata: { name: target.configMapName, namespace: valuesNamespace },
+      data: { [valuesKey]: yaml.endsWith('\n') ? yaml : `${yaml}\n` }
+    });
   }
 
-  // 2. Apply the updated configmap (full object so the data key is preserved).
-  const manifest = {
-    apiVersion: 'v1',
-    kind: 'ConfigMap',
-    metadata: { name: valuesConfigMapName, namespace: valuesNamespace },
-    data: { [valuesKey]: yaml.endsWith('\n') ? yaml : `${yaml}\n` }
-  };
-  const applied = await kube.apply(manifest);
-  if (!applied.ok) {
-    return { ok: false, status: 412, error: `Could not apply updated values: ${(applied.stderr || applied.stdout || '').trim()}` };
+  // 2. Apply the updated ConfigMaps with their existing data keys preserved.
+  for (const manifest of manifests) {
+    const applied = await kube.apply(manifest);
+    if (!applied.ok) {
+      return {
+        ok: false,
+        status: 412,
+        error: `Could not apply updated ${manifest.metadata.name} values: ${(applied.stderr || applied.stdout || '').trim()}`
+      };
+    }
   }
 
   // 3. Persist the operator intent in release-selection.json so the next update
@@ -259,11 +295,17 @@ export async function applyAppUrl(deps) {
     }
   }
 
-  // 4. Reconcile the HelmRelease so NEXTAUTH_URL re-renders from the new values.
+  // 4. Reconcile both HelmReleases so the public URL reaches the app and worker.
   const ts = timestamp || String(Math.floor(nowMs() / 1000));
-  const reconciled = await kube.run(`annotate helmrelease ${helmReleaseName} -n ${valuesNamespace} reconcile.fluxcd.io/requestedAt=${ts} --overwrite`);
-  if (!reconciled.ok) {
-    return { ok: false, status: 412, error: `Values applied but HelmRelease reconcile failed: ${(reconciled.stderr || reconciled.stdout || '').trim()}` };
+  for (const releaseName of [helmReleaseName, temporalWorkerHelmReleaseName]) {
+    const reconciled = await kube.run(`annotate helmrelease ${releaseName} -n ${valuesNamespace} reconcile.fluxcd.io/requestedAt=${ts} --overwrite`);
+    if (!reconciled.ok) {
+      return {
+        ok: false,
+        status: 412,
+        error: `Values applied but ${releaseName} HelmRelease reconcile failed: ${(reconciled.stderr || reconciled.stdout || '').trim()}`
+      };
+    }
   }
   return { ok: true, appUrl, host };
 }

--- a/ee/appliance/host-service/setup-engine.mjs
+++ b/ee/appliance/host-service/setup-engine.mjs
@@ -970,6 +970,11 @@ export async function applyRuntimeValuesAndReleaseSelection(inputs, releaseSelec
       values[`alga-core.${profile}.yaml`] = setYamlScalar(values[`alga-core.${profile}.yaml`], ['appUrl'], yamlString(appUrl));
       values[`alga-core.${profile}.yaml`] = setYamlScalar(values[`alga-core.${profile}.yaml`], ['host'], yamlString(hostFromAppUrl(appUrl)));
       values[`alga-core.${profile}.yaml`] = setYamlScalar(values[`alga-core.${profile}.yaml`], ['domainSuffix'], '""');
+      values[`temporal-worker.${profile}.yaml`] = setYamlScalar(
+        values[`temporal-worker.${profile}.yaml`],
+        ['publicBaseUrl'],
+        yamlString(appUrl)
+      );
     }
     if (images.algaCore) {
       values[`alga-core.${profile}.yaml`] = setYamlScalar(values[`alga-core.${profile}.yaml`], ['setup', 'image', 'tag'], yamlString(images.algaCore));

--- a/ee/appliance/host-service/tests/control-plane-workflow.test.mjs
+++ b/ee/appliance/host-service/tests/control-plane-workflow.test.mjs
@@ -59,7 +59,7 @@ test('T004 control-plane workflow persists setup, release/runtime selection, ini
         'temporal.single-node.yaml': 'temporal: packaged\n',
         'workflow-worker.single-node.yaml': 'image:\n  tag: old\n',
         'email-service.single-node.yaml': 'image:\n  tag: old\n',
-        'temporal-worker.single-node.yaml': 'image:\n  tag: old\n'
+        'temporal-worker.single-node.yaml': 'applicationUrl: http://alga-core.msp.svc.cluster.local:3000\npublicBaseUrl: https://alga.local\nimage:\n  tag: old\n'
       }
     };
     const releaseSelection = {

--- a/ee/appliance/host-service/tests/manage-engine.test.mjs
+++ b/ee/appliance/host-service/tests/manage-engine.test.mjs
@@ -126,18 +126,25 @@ test('applyLicense surfaces structured workflow errors despite a nonzero exit', 
   assert.match(res.error, /different account/);
 });
 
-test('applyAppUrl rewrites values, persists runtime, reconciles helm', async () => {
+test('applyAppUrl rewrites app and temporal-worker values, persists runtime, and reconciles both releases', async () => {
   const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'alga-manage-'));
   const releaseSelectionFile = path.join(tmp, 'release-selection.json');
   fs.writeFileSync(releaseSelectionFile, JSON.stringify({ selectedChannel: 'stable', runtime: { appHostname: 'https://alga.local' } }));
 
   const coreYaml = 'appUrl: https://alga.local\nhost: alga.local\ndomainSuffix: alga.local\nserver:\n  image:\n    tag: latest\n';
-  let appliedManifest = null;
+  const temporalWorkerYaml = 'applicationUrl: http://alga-core.msp.svc.cluster.local:3000\npublicBaseUrl: https://alga.local\nimage:\n  tag: latest\n';
+  const appliedManifests = [];
   const kube = fakeKube({
-    json: (args) => args.includes('configmap appliance-values-alga-core')
-      ? { ok: true, value: { data: { 'alga-core.single-node.yaml': coreYaml } } }
-      : { ok: true, value: {} },
-    apply: (manifest) => { appliedManifest = manifest; return { ok: true }; }
+    json: (args) => {
+      if (args.includes('configmap appliance-values-alga-core')) {
+        return { ok: true, value: { data: { 'alga-core.single-node.yaml': coreYaml } } };
+      }
+      if (args.includes('configmap appliance-values-temporal-worker')) {
+        return { ok: true, value: { data: { 'temporal-worker.single-node.yaml': temporalWorkerYaml } } };
+      }
+      return { ok: true, value: {} };
+    },
+    apply: (manifest) => { appliedManifests.push(manifest); return { ok: true }; }
   });
 
   const res = await applyAppUrl({
@@ -148,18 +155,27 @@ test('applyAppUrl rewrites values, persists runtime, reconciles helm', async () 
   });
   assert.equal(res.ok, true);
 
-  // Configmap was rewritten with the new URL.
-  const newYaml = appliedManifest.data['alga-core.single-node.yaml'];
-  assert.match(newYaml, /appUrl: "http:\/\/192\.168\.1\.50:3000"/);
-  assert.match(newYaml, /host: "192\.168\.1\.50"/);
-  assert.match(newYaml, /domainSuffix: ""/);
+  // Both ConfigMaps were rewritten with the new public URL.
+  const newCoreYaml = appliedManifests
+    .find((manifest) => manifest.metadata.name === 'appliance-values-alga-core')
+    .data['alga-core.single-node.yaml'];
+  assert.match(newCoreYaml, /appUrl: "http:\/\/192\.168\.1\.50:3000"/);
+  assert.match(newCoreYaml, /host: "192\.168\.1\.50"/);
+  assert.match(newCoreYaml, /domainSuffix: ""/);
+
+  const newTemporalWorkerYaml = appliedManifests
+    .find((manifest) => manifest.metadata.name === 'appliance-values-temporal-worker')
+    .data['temporal-worker.single-node.yaml'];
+  assert.match(newTemporalWorkerYaml, /applicationUrl: http:\/\/alga-core\.msp\.svc\.cluster\.local:3000/);
+  assert.match(newTemporalWorkerYaml, /publicBaseUrl: "http:\/\/192\.168\.1\.50:3000"/);
 
   // Operator intent persisted.
   const persisted = JSON.parse(fs.readFileSync(releaseSelectionFile, 'utf8'));
   assert.equal(persisted.runtime.appHostname, 'http://192.168.1.50:3000');
 
-  // HelmRelease reconcile requested.
+  // Both HelmRelease reconciles were requested.
   assert.ok(kube.calls.some((c) => c[0] === 'run' && c[1].includes('annotate helmrelease alga-core')), 'expected a helmrelease reconcile');
+  assert.ok(kube.calls.some((c) => c[0] === 'run' && c[1].includes('annotate helmrelease temporal-worker')), 'expected a temporal-worker reconcile');
 });
 
 test('applyAppUrl requires a hostname', async () => {

--- a/ee/appliance/host-service/tests/setup-engine.workflow.test.mjs
+++ b/ee/appliance/host-service/tests/setup-engine.workflow.test.mjs
@@ -31,7 +31,7 @@ function makeReleaseManifest(overrides = {}) {
       'temporal.single-node.yaml': 'temporal: packaged\n',
       'workflow-worker.single-node.yaml': 'workflow-worker: packaged\nimage:\n  tag: old\nextraEnv:\n  - name: TEMPORAL_ADDRESS\n    value: temporal-frontend.msp.svc.cluster.local:7233\n',
       'email-service.single-node.yaml': 'email-service: packaged\nimage:\n  tag: old\n',
-      'temporal-worker.single-node.yaml': 'temporal-worker: packaged\nimage:\n  tag: old\n'
+      'temporal-worker.single-node.yaml': 'temporal-worker: packaged\napplicationUrl: http://alga-core.msp.svc.cluster.local:3000\npublicBaseUrl: https://alga.local\nimage:\n  tag: old\n'
     },
     ...overrides
   };
@@ -153,6 +153,9 @@ test('applyRuntimeValuesAndReleaseSelection renders runtime values from the mani
     // image tag from the manifest is injected into the alga-core values
     const renderedCoreValues = fs.readFileSync(path.join(runtimeValuesDir, 'values', 'alga-core.single-node.yaml'), 'utf8');
     assert.match(renderedCoreValues, /tag: "coretag"/);
+    const renderedTemporalWorkerValues = fs.readFileSync(path.join(runtimeValuesDir, 'values', 'temporal-worker.single-node.yaml'), 'utf8');
+    assert.match(renderedTemporalWorkerValues, /applicationUrl: http:\/\/alga-core\.msp\.svc\.cluster\.local:3000/);
+    assert.match(renderedTemporalWorkerValues, /publicBaseUrl: "https:\/\/psa\.example\.test"/);
     const initialTenantSecret = fs.readFileSync(path.join(runtimeValuesDir, 'initial-tenant-secret.yaml'), 'utf8');
     assert.match(initialTenantSecret, /name: appliance-initial-tenant/);
     assert.match(initialTenantSecret, /INITIAL_ADMIN_EMAIL: "ava@example.com"/);

--- a/ee/appliance/host-service/tests/update-engine.test.mjs
+++ b/ee/appliance/host-service/tests/update-engine.test.mjs
@@ -25,6 +25,7 @@ test('runAppChannelUpdate applies channel update and persists history without OS
   }));
 
   const valueYaml = `image:\n  tag: latest\n`;
+  const temporalWorkerYaml = `applicationUrl: http://alga-core.msp.svc.cluster.local:3000\npublicBaseUrl: https://alga.local\nimage:\n  tag: latest\n`;
   const coreYaml = `appUrl: https://alga.local\nhost: alga.local\ndomainSuffix: alga.local\nbootstrap:\n  mode: recover\nsetup:\n  image:\n    tag: latest\nserver:\n  image:\n    tag: latest\n`;
   const originalPath = process.env.PATH;
   process.env.PATH = `${fakeBin}:${originalPath}`;
@@ -52,7 +53,7 @@ test('runAppChannelUpdate applies channel update and persists history without OS
         'temporal.test-profile.yaml': valueYaml,
         'workflow-worker.test-profile.yaml': valueYaml,
         'email-service.test-profile.yaml': valueYaml,
-        'temporal-worker.test-profile.yaml': valueYaml
+        'temporal-worker.test-profile.yaml': temporalWorkerYaml
       }
     },
     tokenFile: path.join(tmp, 'setup-token'),
@@ -102,6 +103,7 @@ function makeUpdateFixture() {
     runtime: { appHostname: 'psa.example.com', dnsMode: 'system', dnsServers: '' }
   }));
   const valueYaml = `image:\n  tag: latest\n`;
+  const temporalWorkerYaml = `applicationUrl: http://alga-core.msp.svc.cluster.local:3000\npublicBaseUrl: https://alga.local\nimage:\n  tag: latest\n`;
   const coreYaml = `appUrl: https://alga.local\nhost: alga.local\ndomainSuffix: alga.local\nbootstrap:\n  mode: recover\nsetup:\n  image:\n    tag: latest\nserver:\n  image:\n    tag: latest\n`;
   const options = {
     stateFile,
@@ -121,7 +123,7 @@ function makeUpdateFixture() {
         'temporal.test-profile.yaml': valueYaml,
         'workflow-worker.test-profile.yaml': valueYaml,
         'email-service.test-profile.yaml': valueYaml,
-        'temporal-worker.test-profile.yaml': valueYaml
+        'temporal-worker.test-profile.yaml': temporalWorkerYaml
       }
     },
     tokenFile: path.join(tmp, 'setup-token'),

--- a/ee/appliance/ubuntu-iso/tests/t001-build-smoke.test.mjs
+++ b/ee/appliance/ubuntu-iso/tests/t001-build-smoke.test.mjs
@@ -198,7 +198,7 @@ test('T004 Temporal chart waits for schema-safe startup and creates the default 
   assert.match(job.spec.template.spec.containers[0].command.join('\n'), /temporal operator namespace create/);
 });
 
-test('T005 temporal-worker profile injects appliance auth and Redis configuration', () => {
+test('T005 temporal-worker profile injects appliance auth, public URL, and Redis configuration', () => {
   const docs = helmTemplate(temporalWorkerChartPath, temporalWorkerProfileValuesPath);
   const deployment = docs.find((doc) => doc.kind === 'Deployment' && doc.metadata?.name === 'test-release-temporal-worker');
   assert.ok(deployment);
@@ -209,6 +209,8 @@ test('T005 temporal-worker profile injects appliance auth and Redis configuratio
     name: 'alga-core-sebastian-secrets',
     key: 'NEXTAUTH_SECRET'
   });
+  assert.equal(env.find((entry) => entry.name === 'APPLICATION_URL')?.value, 'http://alga-core.msp.svc.cluster.local:3000');
+  assert.equal(env.find((entry) => entry.name === 'NEXT_PUBLIC_BASE_URL')?.value, 'https://alga.local');
   assert.equal(env.find((entry) => entry.name === 'REDIS_HOST')?.value, 'redis.msp.svc.cluster.local');
   assert.equal(env.find((entry) => entry.name === 'REDIS_PORT')?.value, '6379');
 });

--- a/ee/helm/temporal-worker/README.md
+++ b/ee/helm/temporal-worker/README.md
@@ -46,6 +46,8 @@ The following table lists the configurable parameters and their default values.
 | `image.tag` | Container image tag | `latest` |
 | `image.pullPolicy` | Image pull policy | `Always` |
 | `logLevel` | Logging level (debug, info, warn, error) | `info` |
+| `applicationUrl` | Worker application URL; may be an internal service endpoint | `""` |
+| `publicBaseUrl` | Public application URL used in recipient-facing links | `""` |
 
 ### Temporal Configuration
 
@@ -170,6 +172,7 @@ temporal-worker:
       name: alga-psa-db-secrets
       key: server-password
   applicationUrl: https://app.algapsa.com
+  publicBaseUrl: https://app.algapsa.com
 EOF
 
 helm install alga-psa helm/ -f alga-values.yaml

--- a/ee/helm/temporal-worker/examples/development-values.yaml
+++ b/ee/helm/temporal-worker/examples/development-values.yaml
@@ -58,6 +58,7 @@ podDisruptionBudget:
 
 # Development application URL
 applicationUrl: "http://localhost:3000"
+publicBaseUrl: "http://localhost:3000"
 
 # Additional development environment variables
 extraEnv:

--- a/ee/helm/temporal-worker/templates/deployment.yaml
+++ b/ee/helm/temporal-worker/templates/deployment.yaml
@@ -135,6 +135,8 @@ spec:
               value: "{{ .Values.logLevel }}"
             - name: APPLICATION_URL
               value: "{{ .Values.applicationUrl }}"
+            - name: NEXT_PUBLIC_BASE_URL
+              value: "{{ .Values.publicBaseUrl }}"
             - name: NM_STORE_URL
               value: "{{ .Values.nm_store.baseUrl }}"
             

--- a/ee/helm/temporal-worker/test-values.yaml
+++ b/ee/helm/temporal-worker/test-values.yaml
@@ -22,6 +22,7 @@ email:
 
 # Application URL
 applicationUrl: "https://test.algapsa.com"
+publicBaseUrl: "https://public.test.algapsa.com"
 
 # Test with local secrets (not Vault)
 vault:

--- a/ee/helm/temporal-worker/values.yaml
+++ b/ee/helm/temporal-worker/values.yaml
@@ -222,6 +222,7 @@ stripe:
 
 # Application configuration
 applicationUrl: ""  # Set to your application URL (e.g., https://example.com)
+publicBaseUrl: ""  # Public URL used in recipient-facing links (e.g., https://example.com)
 
 # Namespace override (optional)
 namespace: ""

--- a/ee/temporal-workflows/src/activities/__tests__/marketing-activities.test.ts
+++ b/ee/temporal-workflows/src/activities/__tests__/marketing-activities.test.ts
@@ -52,6 +52,7 @@ describe('marketing activities', () => {
   const originalNextAuthSecret = process.env.NEXTAUTH_SECRET;
   const originalApplicationUrl = process.env.APPLICATION_URL;
   const originalNextAuthUrl = process.env.NEXTAUTH_URL;
+  const originalPublicBaseUrl = process.env.NEXT_PUBLIC_BASE_URL;
   const originalPublicAppUrl = process.env.NEXT_PUBLIC_APP_URL;
   const knex = { name: 'tenant-knex' };
 
@@ -60,9 +61,10 @@ describe('marketing activities', () => {
     createTenantKnexMock.mockResolvedValue({ knex, tenant: 'tenant-1' });
     runWithTenantMock.mockImplementation(async (_tenantId, callback) => callback());
     process.env.NEXTAUTH_SECRET = 'test-signing-secret';
-    process.env.APPLICATION_URL = 'https://deployment.example.test/';
-    process.env.NEXTAUTH_URL = 'https://auth.example.test/';
-    delete process.env.NEXT_PUBLIC_APP_URL;
+    process.env.APPLICATION_URL = 'http://alga-core.msp.svc.cluster.local:3000';
+    process.env.NEXTAUTH_URL = 'http://auth.msp.svc.cluster.local:3000';
+    process.env.NEXT_PUBLIC_BASE_URL = 'https://public.example.test/';
+    process.env.NEXT_PUBLIC_APP_URL = 'https://fallback.example.test/';
   });
 
   afterEach(() => {
@@ -72,6 +74,8 @@ describe('marketing activities', () => {
     else process.env.APPLICATION_URL = originalApplicationUrl;
     if (originalNextAuthUrl === undefined) delete process.env.NEXTAUTH_URL;
     else process.env.NEXTAUTH_URL = originalNextAuthUrl;
+    if (originalPublicBaseUrl === undefined) delete process.env.NEXT_PUBLIC_BASE_URL;
+    else process.env.NEXT_PUBLIC_BASE_URL = originalPublicBaseUrl;
     if (originalPublicAppUrl === undefined) delete process.env.NEXT_PUBLIC_APP_URL;
     else process.env.NEXT_PUBLIC_APP_URL = originalPublicAppUrl;
   });
@@ -118,7 +122,7 @@ describe('marketing activities', () => {
     });
   });
 
-  it('passes canonical URL and signing secret to sequence sending', async () => {
+  it('passes the public URL and signing secret to sequence sending', async () => {
     const summary = { sent: 1, completed: 0, stopped: 0, failed: 1, skipped: 0 };
     sendDueSequenceStepsInternalMock.mockResolvedValue(summary);
     const { runMarketingJobForTenant } = await import('../marketing-activities');
@@ -129,10 +133,45 @@ describe('marketing activities', () => {
     });
 
     expect(sendDueSequenceStepsInternalMock).toHaveBeenCalledWith(knex, 'tenant-1', {
-      baseUrl: 'https://deployment.example.test',
+      baseUrl: 'https://public.example.test',
       signingSecret: 'test-signing-secret',
     });
     expect(result.operation).toEqual(summary);
+  });
+
+  it('falls back to NEXT_PUBLIC_APP_URL without using internal worker hosts', async () => {
+    delete process.env.NEXT_PUBLIC_BASE_URL;
+    sendDueSequenceStepsInternalMock.mockResolvedValue({
+      sent: 0,
+      completed: 0,
+      stopped: 0,
+      failed: 0,
+      skipped: 0,
+    });
+    const { runMarketingJobForTenant } = await import('../marketing-activities');
+
+    await runMarketingJobForTenant({
+      jobName: MARKETING_SEND_SEQUENCE_STEPS_JOB,
+      tenantId: 'tenant-1',
+    });
+
+    expect(sendDueSequenceStepsInternalMock).toHaveBeenCalledWith(
+      knex,
+      'tenant-1',
+      expect.objectContaining({ baseUrl: 'https://fallback.example.test' }),
+    );
+  });
+
+  it('fails closed when only internal worker URLs are configured', async () => {
+    delete process.env.NEXT_PUBLIC_BASE_URL;
+    delete process.env.NEXT_PUBLIC_APP_URL;
+    const { runMarketingJobForTenant } = await import('../marketing-activities');
+
+    await expect(runMarketingJobForTenant({
+      jobName: MARKETING_SEND_SEQUENCE_STEPS_JOB,
+      tenantId: 'tenant-1',
+    })).rejects.toThrow('No public marketing base URL available');
+    expect(sendDueSequenceStepsInternalMock).not.toHaveBeenCalled();
   });
 
   it('fails closed before sequence sending when NEXTAUTH_SECRET is absent', async () => {

--- a/ee/temporal-workflows/src/activities/marketing-activities.ts
+++ b/ee/temporal-workflows/src/activities/marketing-activities.ts
@@ -22,10 +22,14 @@ function activityLogger() {
 
 function getPublicBaseUrl(): string {
   const raw =
-    process.env.APPLICATION_URL
-    || process.env.NEXTAUTH_URL
+    process.env.NEXT_PUBLIC_BASE_URL
     || process.env.NEXT_PUBLIC_APP_URL
-    || 'http://localhost:3000';
+    || '';
+  if (!raw) {
+    throw new Error(
+      'No public marketing base URL available (NEXT_PUBLIC_BASE_URL or NEXT_PUBLIC_APP_URL); refusing to send sequence steps',
+    );
+  }
   return raw.endsWith('/') ? raw.slice(0, -1) : raw;
 }
 

--- a/server/docker-compose.prebuilt.yaml
+++ b/server/docker-compose.prebuilt.yaml
@@ -58,6 +58,7 @@ x-common-config: &common-config
 
     # ---- AUTH ----
     NEXTAUTH_URL: ${NEXTAUTH_URL}
+    NEXT_PUBLIC_BASE_URL: ${NEXT_PUBLIC_BASE_URL:-http://localhost:3000}
     NEXTAUTH_SESSION_EXPIRES: ${NEXTAUTH_SESSION_EXPIRES}
 
     # ---- DEPLOY INFO  ----

--- a/server/docker-compose.yaml
+++ b/server/docker-compose.yaml
@@ -58,6 +58,7 @@ x-common-config: &common-config
 
     # ---- AUTH ----
     NEXTAUTH_URL: ${NEXTAUTH_URL}
+    NEXT_PUBLIC_BASE_URL: ${NEXT_PUBLIC_BASE_URL:-http://localhost:3000}
     NEXTAUTH_SESSION_EXPIRES: ${NEXTAUTH_SESSION_EXPIRES}
 
     # ---- DEPLOY INFO  ----

--- a/server/src/lib/jobs/handlers/marketingJobs.ts
+++ b/server/src/lib/jobs/handlers/marketingJobs.ts
@@ -28,16 +28,20 @@ const STALE_TARGET_GRACE_HOURS = 48;
 
 /**
  * Canonical public base URL for absolute links in outbound marketing email
- * (unsubscribe link, tracking pixel, click redirect). NEXTAUTH_URL is the
- * repo's canonical public-base-url env var — notificationLinkResolver and
- * auth both build absolute URLs from it. NEXT_PUBLIC_APP_URL is accepted as
- * a fallback for deployments that only set the public var.
+ * (unsubscribe link, tracking pixel, click redirect). Internal service and
+ * authentication URLs are deliberately not eligible because recipients must
+ * be able to reach every generated link.
  */
 function getPublicBaseUrl(): string {
   const raw =
-    process.env.NEXTAUTH_URL
+    process.env.NEXT_PUBLIC_BASE_URL
     || process.env.NEXT_PUBLIC_APP_URL
-    || 'http://localhost:3000';
+    || '';
+  if (!raw) {
+    throw new Error(
+      'No public marketing base URL available (NEXT_PUBLIC_BASE_URL or NEXT_PUBLIC_APP_URL); refusing to send sequence steps',
+    );
+  }
   return raw.endsWith('/') ? raw.slice(0, -1) : raw;
 }
 

--- a/server/src/test/unit/jobs/marketingJobs.publicUrl.test.ts
+++ b/server/src/test/unit/jobs/marketingJobs.publicUrl.test.ts
@@ -1,0 +1,100 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+const isFeatureFlagEnabledMock = vi.fn();
+const sendDueSequenceStepsInternalMock = vi.fn();
+const runWithTenantMock = vi.fn();
+const getConnectionMock = vi.fn();
+const getMarketingSigningSecretMock = vi.fn();
+
+vi.mock('@alga-psa/core/logger', () => ({
+  default: {
+    info: vi.fn(),
+    warn: vi.fn(),
+  },
+}));
+
+vi.mock('@alga-psa/core', () => ({
+  isFeatureFlagEnabled: isFeatureFlagEnabledMock,
+}));
+
+vi.mock('@alga-psa/marketing/lib', () => ({
+  MARKETING_MODULE_FLAG: 'marketing-module',
+  flipDuePostsInternal: vi.fn(),
+  expireStaleTargetsInternal: vi.fn(),
+  sendDueSequenceStepsInternal: sendDueSequenceStepsInternalMock,
+}));
+
+vi.mock('server/src/lib/db', () => ({
+  runWithTenant: runWithTenantMock,
+}));
+
+vi.mock('server/src/lib/db/db', () => ({
+  getConnection: getConnectionMock,
+}));
+
+vi.mock('server/src/lib/marketing/signingSecret', () => ({
+  getMarketingSigningSecret: getMarketingSigningSecretMock,
+}));
+
+describe('marketing sequence job public URL', () => {
+  const originalApplicationUrl = process.env.APPLICATION_URL;
+  const originalNextAuthUrl = process.env.NEXTAUTH_URL;
+  const originalPublicBaseUrl = process.env.NEXT_PUBLIC_BASE_URL;
+  const originalPublicAppUrl = process.env.NEXT_PUBLIC_APP_URL;
+  const knex = { name: 'tenant-knex' };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    isFeatureFlagEnabledMock.mockResolvedValue(true);
+    getMarketingSigningSecretMock.mockResolvedValue('test-signing-secret');
+    getConnectionMock.mockResolvedValue(knex);
+    runWithTenantMock.mockImplementation(async (_tenantId, callback) => callback());
+    sendDueSequenceStepsInternalMock.mockResolvedValue({
+      sent: 1,
+      completed: 0,
+      stopped: 0,
+      failed: 0,
+      skipped: 0,
+    });
+    process.env.APPLICATION_URL = 'http://alga-core.msp.svc.cluster.local:3000';
+    process.env.NEXTAUTH_URL = 'http://auth.msp.svc.cluster.local:3000';
+    process.env.NEXT_PUBLIC_BASE_URL = 'https://public.example.test/';
+    process.env.NEXT_PUBLIC_APP_URL = 'https://fallback.example.test/';
+  });
+
+  afterEach(() => {
+    if (originalApplicationUrl === undefined) delete process.env.APPLICATION_URL;
+    else process.env.APPLICATION_URL = originalApplicationUrl;
+    if (originalNextAuthUrl === undefined) delete process.env.NEXTAUTH_URL;
+    else process.env.NEXTAUTH_URL = originalNextAuthUrl;
+    if (originalPublicBaseUrl === undefined) delete process.env.NEXT_PUBLIC_BASE_URL;
+    else process.env.NEXT_PUBLIC_BASE_URL = originalPublicBaseUrl;
+    if (originalPublicAppUrl === undefined) delete process.env.NEXT_PUBLIC_APP_URL;
+    else process.env.NEXT_PUBLIC_APP_URL = originalPublicAppUrl;
+  });
+
+  it('uses the explicit public URL instead of internal application and auth hosts', async () => {
+    const { marketingSendSequenceStepsHandler } = await import(
+      'server/src/lib/jobs/handlers/marketingJobs'
+    );
+
+    await marketingSendSequenceStepsHandler({ tenantId: 'tenant-1' });
+
+    expect(sendDueSequenceStepsInternalMock).toHaveBeenCalledWith(knex, 'tenant-1', {
+      baseUrl: 'https://public.example.test',
+      signingSecret: 'test-signing-secret',
+    });
+  });
+
+  it('fails closed when only internal application and auth hosts are configured', async () => {
+    delete process.env.NEXT_PUBLIC_BASE_URL;
+    delete process.env.NEXT_PUBLIC_APP_URL;
+    const { marketingSendSequenceStepsHandler } = await import(
+      'server/src/lib/jobs/handlers/marketingJobs'
+    );
+
+    await expect(marketingSendSequenceStepsHandler({ tenantId: 'tenant-1' }))
+      .rejects.toThrow('No public marketing base URL available');
+    expect(sendDueSequenceStepsInternalMock).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Summary

- Require an explicit public base URL for recipient-facing marketing links in both pg-boss and Temporal execution, rather than falling back to internal application or authentication URLs.
- Propagate `NEXT_PUBLIC_BASE_URL` through CE/EE Compose and the temporal-worker Helm chart.
- Update appliance setup and `applyAppUrl` reconciliation so temporal-worker keeps its internal `applicationUrl`, follows operator intent through `publicBaseUrl`, and reconciles alongside alga-core.
- Add focused coverage for public-URL selection, fail-closed behavior, Helm/appliance rendering, setup, updates, and reconciliation.

## Smoke test

**PASS, with one resilience concern.**

The real UI flow navigated Marketing → Sequences, created the active zero-delay sequence **Smoke Public URL 2236**, enrolled the GreenMail contact, and let the real pg-boss/SMTP job run. The UI showed 1 sent/completed; database state confirmed `send_status=sent` and engagement was recorded.

The delivered MIME proved List-Unsubscribe, click tracking, open tracking, and HTML unsubscribe URLs all use `http://localhost:3016`, not the internal application URL. The public unsubscribe GET caused no mutation; submitting the confirmation form persisted an unsubscribe/link suppression.

Appliance-only coverage stepped down to a minimal Kubernetes simulator because no live Flux appliance or usable Temporal service exists locally. Production `applyAppUrl` preserved temporal-worker `applicationUrl`, updated `publicBaseUrl`, persisted intent, and reconciled both releases. Read/rewrite failures occur before writes, but apply/reconcile are non-atomic: failure applying the second ConfigMap leaves alga-core updated while temporal-worker and persisted intent remain old; failure reconciling temporal-worker leaves both ConfigMaps and intent updated but only alga-core reconciled. Both return 412 and an identical retry converged. This temporary inconsistency is the main concern.

Focused verification also passed: 24 appliance tests, 9 Temporal public-URL tests, and 2 server public-URL tests. No email/DB mocks were used; only Kubernetes operations were simulated. Multi-tenant Temporal fanout itself was not exercised end-to-end. The branch is clean and the correct worktree server remains running on port 3016. Test data and the suppression record remain in the shared dev database. Initial cold-start browser requests briefly saw connection refusals; no console errors remained after the primary flow.

Evidence: `/tmp/alga-smoke-evidence/marketing-workflow-fanout-fix-20260723-223614`
