### PR TITLE
fix(appliance): reconcile local path storage

### DIFF
--- a/ee/appliance/host-service/setup-engine.mjs
+++ b/ee/appliance/host-service/setup-engine.mjs
@@ -765,6 +765,62 @@ export async function runNetworkChecks(inputs, options = {}) {
   return { ok: true, checkedAt, failure: null, checks: { registryHost, reference: releaseReference, version: resolvedRelease.manifest.version } };
 }
 
+export function installStorage(options = {}) {
+  const stateFile = options.stateFile || DEFAULT_STATE_FILE;
+  const kubeconfigPath = options.kubeconfigPath || DEFAULT_KUBECONFIG;
+  const installerPath = options.storageInstallerPath
+    || path.resolve(import.meta.dirname, '..', 'scripts', 'install-storage.sh');
+  const installCommand = options.storageInstallCommand
+    || `${shellQuote(installerPath)} --kubeconfig ${shellQuote(kubeconfigPath)}`;
+
+  writeInstallState({
+    status: 'storage-install-running',
+    phase: 'storage',
+    lastAction: 'Reconciling the appliance local-path storage provider',
+    updatedAt: nowIso()
+  }, stateFile);
+
+  const result = spawnSync('sh', ['-c', installCommand], {
+    env: process.env,
+    encoding: 'utf8'
+  });
+
+  if (result.status !== 0) {
+    const detail = (result.stderr || result.stdout || `storage installer exited with code ${result.status ?? 1}`).trim();
+    const failure = preflightFailure(
+      'storage',
+      'install-local-path-storage',
+      'Local-path storage reconciliation failed.',
+      detail
+    );
+    writeInstallState({
+      status: 'storage-install-blocked',
+      phase: 'storage',
+      lastAction: failure.message,
+      failure,
+      installerOutput: {
+        stdout: result.stdout || '',
+        stderr: result.stderr || ''
+      },
+      updatedAt: nowIso()
+    }, stateFile);
+    return failure;
+  }
+
+  const success = {
+    ok: true,
+    phase: 'storage',
+    message: 'Local-path storage reconciliation and PVC smoke test completed successfully.'
+  };
+  writeInstallState({
+    status: 'storage-install-complete',
+    phase: 'storage',
+    lastAction: success.message,
+    updatedAt: nowIso()
+  }, stateFile);
+  return success;
+}
+
 export function installFlux(options = {}) {
   const stateFile = options.stateFile || DEFAULT_STATE_FILE;
   const kubeconfigPath = options.kubeconfigPath || DEFAULT_KUBECONFIG;
@@ -1277,10 +1333,15 @@ export async function runSetupWorkflow(inputs, options = {}) {
     return preflight;
   }
 
-  // The k3s substrate and local-path storage are provisioned by the host
-  // bootstrap (bootstrap-control-plane.sh) before this control-plane workflow
-  // ever runs. The setup workflow only layers Flux and the application release
-  // on top of that substrate.
+  // The host bootstrap applies the storage controller early so the setup UI can
+  // start even when registry access is temporarily unavailable. Before Flux is
+  // allowed to create database, Redis, or file-storage PVCs, reconcile storage
+  // to one controller and prove dynamic provisioning with a mounted write.
+  const storageResult = installStorage(options);
+  if (!storageResult.ok) {
+    return storageResult;
+  }
+
   const fluxResult = installFlux(options);
   if (!fluxResult.ok) {
     return fluxResult;

--- a/ee/appliance/host-service/tests/bootstrap-control-plane-script.test.mjs
+++ b/ee/appliance/host-service/tests/bootstrap-control-plane-script.test.mjs
@@ -39,6 +39,8 @@ test('T001 host bootstrap dry-run plans minimal k3s, image import, storage/contr
   assert.equal(result.status, 0, result.stderr || result.stdout);
   const output = result.stdout;
   const expectedInOrder = [
+    'Substrate: reserving local-path storage for the appliance provisioner',
+    'persist --disable local-storage in the k3s service and configuration',
     'Substrate: ensuring k3s is installed and running',
     'ensure k3s service is enabled and running with minimal local substrate options',
     'Substrate: waiting for Kubernetes API',

--- a/ee/appliance/host-service/tests/install-storage.test.mjs
+++ b/ee/appliance/host-service/tests/install-storage.test.mjs
@@ -8,61 +8,274 @@ import test from 'node:test';
 const repoRoot = path.resolve(path.join(import.meta.dirname, '..', '..', '..', '..'));
 const installer = path.join(repoRoot, 'ee', 'appliance', 'scripts', 'install-storage.sh');
 
-test('storage reconciliation preserves existing volumes, removes the bundled controller, and proves a mounted write', () => {
+function createHarness(options = {}) {
   const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'alga-storage-reconcile-'));
   const binDir = path.join(tmp, 'bin');
+  const stateDir = path.join(tmp, 'state');
   const callLog = path.join(tmp, 'kubectl-calls.log');
   const inputLog = path.join(tmp, 'kubectl-input.log');
   const kubeconfig = path.join(tmp, 'k3s.yaml');
   fs.mkdirSync(binDir);
+  fs.mkdirSync(stateDir);
   fs.writeFileSync(kubeconfig, 'apiVersion: v1\n');
+  fs.writeFileSync(callLog, '');
+  fs.writeFileSync(inputLog, '');
+
+  if (options.leakedSmokePv) {
+    fs.writeFileSync(path.join(stateDir, 'pv-leaked.exists'), '');
+    fs.writeFileSync(path.join(stateDir, 'pv-leaked.policy'), 'Retain');
+  }
 
   fs.writeFileSync(path.join(binDir, 'kubectl'), `#!/usr/bin/env bash
 set -euo pipefail
-printf '%s\\n' "$*" >> "$FAKE_KUBE_CALL_LOG"
-case "$*" in
-  *"get storageclass local-path -o jsonpath={.reclaimPolicy}"*)
-    printf 'Delete'
-    ;;
-  *"get persistentvolume -o jsonpath="*|*"get pv -o jsonpath="*)
-    printf 'pv-existing\\n'
-    ;;
+
+args="$*"
+state="$FAKE_KUBE_STATE_DIR"
+printf '%s\\n' "$args" >> "$FAKE_KUBE_CALL_LOG"
+
+next_counter() {
+  local file="$1"
+  local value=0
+  if [ -f "$file" ]; then
+    value="$(cat "$file")"
+  fi
+  value=$((value + 1))
+  printf '%s' "$value" > "$file"
+  printf '%s' "$value"
+}
+
+pv_from_args() {
+  while [ "$#" -gt 0 ]; do
+    if [ "$1" = "persistentvolume" ]; then
+      printf '%s' "$2"
+      return 0
+    fi
+    shift
+  done
+  return 1
+}
+
+if [[ "$args" == *"apply -f -"* ]]; then
+  input="$(cat)"
+  {
+    printf '%s\\n' "--- stdin for: $args"
+    printf '%s\\n' "$input"
+  } >> "$FAKE_KUBE_INPUT_LOG"
+  if [[ "$input" == *"name: storage-smoke-pvc"* ]]; then
+    printf 'pv-storage-smoke' > "$state/current-smoke-pv"
+    printf 'Retain' > "$state/pv-storage-smoke.policy"
+    next_counter "$state/smoke-create-count" >/dev/null
+  fi
+  exit 0
+fi
+
+case "$args" in
   *"create namespace "*" --dry-run=client -o yaml"*)
     printf 'apiVersion: v1\\nkind: Namespace\\nmetadata:\\n  name: fake\\n'
     ;;
-  *"apply -f -"*)
-    {
-      printf '%s\\n' "--- stdin for: $*"
-      cat
-    } >> "$FAKE_KUBE_INPUT_LOG"
+  *"get storageclass local-path -o jsonpath={.reclaimPolicy}"*)
+    printf '%s' "\${FAKE_STORAGE_CLASS_POLICY:-Retain}"
+    ;;
+  *"get storageclass local-path"*)
+    exit 0
+    ;;
+  *"get persistentvolume -o jsonpath="*|*"get pv -o jsonpath="*)
+    printf 'pv-postgresql\\npv-redis\\npv-application\\n'
+    if [ -f "$state/pv-leaked.exists" ]; then
+      printf 'pv-leaked\\n'
+    fi
+    if [ -f "$state/current-smoke-pv" ]; then
+      cat "$state/current-smoke-pv"
+      printf '\\n'
+    fi
+    ;;
+  *"get persistentvolume "*" -o jsonpath={.spec.claimRef.namespace}"*)
+    pv="$(pv_from_args "$@")"
+    case "$pv" in
+      pv-storage-smoke|pv-leaked) printf 'storage-smoke' ;;
+      pv-postgresql|pv-redis|pv-application) printf 'msp' ;;
+      *) exit 1 ;;
+    esac
+    ;;
+  *"get persistentvolume "*" -o jsonpath={.spec.persistentVolumeReclaimPolicy}"*)
+    pv="$(pv_from_args "$@")"
+    if [ -f "$state/$pv.policy" ]; then
+      cat "$state/$pv.policy"
+    else
+      printf 'Retain'
+    fi
+    ;;
+  *"patch persistentvolume "*)
+    pv="$(pv_from_args "$@")"
+    if [[ "$args" == *'"value":"Delete"'* ]]; then
+      printf 'Delete' > "$state/$pv.policy"
+    fi
+    ;;
+  *"delete persistentvolume "*)
+    pv="$(pv_from_args "$@")"
+    case "$pv" in
+      pv-storage-smoke)
+        rm -f "$state/current-smoke-pv" "$state/pv-storage-smoke.policy"
+        ;;
+      pv-leaked)
+        rm -f "$state/pv-leaked.exists" "$state/pv-leaked.policy"
+        ;;
+      *)
+        printf 'refusing fake deletion of application PV %s\\n' "$pv" >&2
+        exit 42
+        ;;
+    esac
+    ;;
+  *"wait --for=delete"*"persistentvolume/"*)
+    pv="\${args##*persistentvolume/}"
+    case "$pv" in
+      pv-storage-smoke) [ ! -f "$state/current-smoke-pv" ] ;;
+      pv-leaked) [ ! -f "$state/pv-leaked.exists" ] ;;
+      *) exit 42 ;;
+    esac
+    ;;
+  *"-n storage-smoke get persistentvolumeclaim storage-smoke-pvc -o jsonpath={.spec.volumeName}"*)
+    [ -f "$state/current-smoke-pv" ]
+    cat "$state/current-smoke-pv"
+    ;;
+  *"-n storage-smoke wait --for=jsonpath={.status.phase}=Bound"*)
+    [ -f "$state/current-smoke-pv" ]
+    ;;
+  *"-n storage-smoke wait --for=condition=complete"*)
+    [ "\${FAKE_SMOKE_JOB_FAIL:-false}" != "true" ]
+    ;;
+  *"-n storage-smoke logs job/storage-smoke"*)
+    printf 'ok\\n'
+    ;;
+  *"delete namespace storage-smoke"*)
+    if [ -f "$state/current-smoke-pv" ] \
+      && [ "$(cat "$state/pv-storage-smoke.policy" 2>/dev/null || true)" = "Delete" ]; then
+      rm -f "$state/current-smoke-pv" "$state/pv-storage-smoke.policy"
+    fi
+    ;;
+  *"-n kube-system delete deployment local-path-provisioner"*)
+    printf 'deleted' > "$state/bundled-deleted"
+    ;;
+  *"-n kube-system get deployment local-path-provisioner"*)
+    count="$(next_counter "$state/bundled-get-count")"
+    reappear_on="\${FAKE_BUNDLED_REAPPEAR_ON_GET:-0}"
+    if [ "$reappear_on" -gt 0 ] && [ "$count" -ge "$reappear_on" ]; then
+      exit 0
+    fi
+    exit 1
+    ;;
+  *"-n local-path-storage rollout status deployment/local-path-provisioner"*)
+    [ "\${FAKE_APPLIANCE_CONTROLLER_AVAILABLE:-true}" = "true" ]
     ;;
 esac
+
 exit 0
 `, { mode: 0o755 });
 
-  const result = spawnSync(installer, ['--kubeconfig', kubeconfig], {
-    cwd: repoRoot,
-    encoding: 'utf8',
+  return {
+    tmp,
+    stateDir,
+    callLog,
+    inputLog,
+    kubeconfig,
     env: {
       ...process.env,
       PATH: `${binDir}:${process.env.PATH}`,
       FAKE_KUBE_CALL_LOG: callLog,
       FAKE_KUBE_INPUT_LOG: inputLog,
-      ALGA_APPLIANCE_STORAGE_LOCK_DIR: path.join(tmp, 'storage-reconcile.lock')
+      FAKE_KUBE_STATE_DIR: stateDir,
+      FAKE_APPLIANCE_CONTROLLER_AVAILABLE: options.applianceControllerAvailable === false ? 'false' : 'true',
+      FAKE_BUNDLED_REAPPEAR_ON_GET: String(options.bundledReappearOnGet || 0),
+      FAKE_SMOKE_JOB_FAIL: options.smokeJobFail ? 'true' : 'false',
+      FAKE_STORAGE_CLASS_POLICY: options.storageClassPolicy || 'Retain',
+      ALGA_APPLIANCE_STORAGE_LOCK_DIR: path.join(tmp, 'storage-reconcile.lock'),
+      ALGA_APPLIANCE_STORAGE_STABILITY_SECONDS: '0'
     }
+  };
+}
+
+function runInstaller(harness) {
+  return spawnSync(installer, ['--kubeconfig', harness.kubeconfig], {
+    cwd: repoRoot,
+    encoding: 'utf8',
+    env: harness.env
   });
+}
+
+function read(file) {
+  return fs.readFileSync(file, 'utf8');
+}
+
+test('storage reconciliation installs the host skip file and converges on only the appliance controller', () => {
+  const harness = createHarness({ storageClassPolicy: 'Delete' });
+  const result = runInstaller(harness);
 
   assert.equal(result.status, 0, result.stderr || result.stdout);
-  const calls = fs.readFileSync(callLog, 'utf8');
-  const appliedInput = fs.readFileSync(inputLog, 'utf8');
+  assert.match(result.stdout, /Storage prerequisites are ready/);
 
-  assert.match(calls, /patch persistentvolume pv-existing .*persistentVolumeReclaimPolicy.*Retain/);
-  assert.match(calls, /delete storageclass local-path/);
-  assert.match(calls, /-n kube-system delete deployment local-path-provisioner --ignore-not-found --wait=true/);
-  assert.match(calls, /-n local-path-storage rollout status deployment\/local-path-provisioner/);
-  assert.match(calls, /-n storage-smoke wait --for=condition=complete/);
-  assert.match(calls, /-n storage-smoke logs job\/storage-smoke/);
+  const calls = read(harness.callLog);
+  const appliedInput = read(harness.inputLog);
+  assert.match(appliedInput, /securityContext:\n\s+privileged: true/);
+  assert.match(appliedInput, /: > "\/host\/var\/lib\/rancher\/k3s\/server\/manifests\/local-storage\.yaml\.skip"/);
   assert.match(appliedInput, /disable\+:\n\s+- local-storage/);
   assert.match(appliedInput, /--disable servicelb --disable local-storage/);
-  assert.match(appliedInput, /persistentVolumeClaim:\n\s+claimName: storage-smoke-pvc/);
+  assert.match(calls, /delete storageclass local-path/);
+  assert.match(calls, /-n kube-system delete deployment local-path-provisioner --ignore-not-found --wait=true/);
+  assert.equal((calls.match(/-n kube-system get deployment local-path-provisioner/g) || []).length, 4);
+  assert.equal((calls.match(/-n local-path-storage rollout status deployment\/local-path-provisioner/g) || []).length >= 4, true);
+});
+
+test('storage reconciliation fails if the bundled controller reappears during the stability check', () => {
+  const harness = createHarness({ bundledReappearOnGet: 2 });
+  const result = runInstaller(harness);
+
+  assert.notEqual(result.status, 0);
+  assert.match(result.stderr, /Bundled kube-system\/local-path-provisioner is still present/);
+  assert.doesNotMatch(result.stdout, /Storage prerequisites are ready/);
+  assert.equal(fs.existsSync(path.join(harness.stateDir, 'current-smoke-pv')), false);
+});
+
+test('storage reconciliation requires the appliance-owned controller to be available', () => {
+  const harness = createHarness({ applianceControllerAvailable: false });
+  const result = runInstaller(harness);
+
+  assert.notEqual(result.status, 0);
+  assert.doesNotMatch(result.stdout, /Storage prerequisites are ready/);
+  assert.equal(fs.existsSync(path.join(harness.stateDir, 'current-smoke-pv')), false);
+});
+
+test('smoke failures still transition and remove only the smoke PV', () => {
+  const harness = createHarness({ leakedSmokePv: true, smokeJobFail: true });
+  const result = runInstaller(harness);
+
+  assert.notEqual(result.status, 0);
+  const calls = read(harness.callLog);
+  assert.match(calls, /patch persistentvolume pv-leaked --type=json .*"value":"Retain".*"value":"Delete"/);
+  assert.match(calls, /delete persistentvolume pv-leaked --wait=false/);
+  assert.match(calls, /patch persistentvolume pv-storage-smoke --type=json .*"value":"Retain".*"value":"Delete"/);
+  assert.match(calls, /wait --for=delete --timeout=5m persistentvolume\/pv-storage-smoke/);
+  assert.equal(fs.existsSync(path.join(harness.stateDir, 'current-smoke-pv')), false);
+  assert.equal(fs.existsSync(path.join(harness.stateDir, 'pv-leaked.exists')), false);
+  assert.doesNotMatch(calls, /delete persistentvolume pv-(?:postgresql|redis|application)/);
+});
+
+test('repeated reconciliation preserves application PVs and leaves no smoke resources or side effects', () => {
+  const harness = createHarness();
+  const first = runInstaller(harness);
+  const second = runInstaller(harness);
+
+  assert.equal(first.status, 0, first.stderr || first.stdout);
+  assert.equal(second.status, 0, second.stderr || second.stdout);
+
+  const calls = read(harness.callLog);
+  for (const pv of ['pv-postgresql', 'pv-redis', 'pv-application']) {
+    assert.equal(
+      (calls.match(new RegExp(`patch persistentvolume ${pv} .*persistentVolumeReclaimPolicy.*Retain`, 'g')) || []).length,
+      2
+    );
+    assert.doesNotMatch(calls, new RegExp(`delete persistentvolume ${pv}`));
+  }
+  assert.equal(read(path.join(harness.stateDir, 'smoke-create-count')), '2');
+  assert.equal(fs.existsSync(path.join(harness.stateDir, 'current-smoke-pv')), false);
+  assert.equal(fs.existsSync(path.join(harness.stateDir, 'pv-storage-smoke.policy')), false);
 });

--- a/ee/appliance/host-service/tests/install-storage.test.mjs
+++ b/ee/appliance/host-service/tests/install-storage.test.mjs
@@ -1,0 +1,68 @@
+import assert from 'node:assert/strict';
+import { spawnSync } from 'node:child_process';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import test from 'node:test';
+
+const repoRoot = path.resolve(path.join(import.meta.dirname, '..', '..', '..', '..'));
+const installer = path.join(repoRoot, 'ee', 'appliance', 'scripts', 'install-storage.sh');
+
+test('storage reconciliation preserves existing volumes, removes the bundled controller, and proves a mounted write', () => {
+  const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'alga-storage-reconcile-'));
+  const binDir = path.join(tmp, 'bin');
+  const callLog = path.join(tmp, 'kubectl-calls.log');
+  const inputLog = path.join(tmp, 'kubectl-input.log');
+  const kubeconfig = path.join(tmp, 'k3s.yaml');
+  fs.mkdirSync(binDir);
+  fs.writeFileSync(kubeconfig, 'apiVersion: v1\n');
+
+  fs.writeFileSync(path.join(binDir, 'kubectl'), `#!/usr/bin/env bash
+set -euo pipefail
+printf '%s\\n' "$*" >> "$FAKE_KUBE_CALL_LOG"
+case "$*" in
+  *"get storageclass local-path -o jsonpath={.reclaimPolicy}"*)
+    printf 'Delete'
+    ;;
+  *"get persistentvolume -o jsonpath="*|*"get pv -o jsonpath="*)
+    printf 'pv-existing\\n'
+    ;;
+  *"create namespace "*" --dry-run=client -o yaml"*)
+    printf 'apiVersion: v1\\nkind: Namespace\\nmetadata:\\n  name: fake\\n'
+    ;;
+  *"apply -f -"*)
+    {
+      printf '%s\\n' "--- stdin for: $*"
+      cat
+    } >> "$FAKE_KUBE_INPUT_LOG"
+    ;;
+esac
+exit 0
+`, { mode: 0o755 });
+
+  const result = spawnSync(installer, ['--kubeconfig', kubeconfig], {
+    cwd: repoRoot,
+    encoding: 'utf8',
+    env: {
+      ...process.env,
+      PATH: `${binDir}:${process.env.PATH}`,
+      FAKE_KUBE_CALL_LOG: callLog,
+      FAKE_KUBE_INPUT_LOG: inputLog,
+      ALGA_APPLIANCE_STORAGE_LOCK_DIR: path.join(tmp, 'storage-reconcile.lock')
+    }
+  });
+
+  assert.equal(result.status, 0, result.stderr || result.stdout);
+  const calls = fs.readFileSync(callLog, 'utf8');
+  const appliedInput = fs.readFileSync(inputLog, 'utf8');
+
+  assert.match(calls, /patch persistentvolume pv-existing .*persistentVolumeReclaimPolicy.*Retain/);
+  assert.match(calls, /delete storageclass local-path/);
+  assert.match(calls, /-n kube-system delete deployment local-path-provisioner --ignore-not-found --wait=true/);
+  assert.match(calls, /-n local-path-storage rollout status deployment\/local-path-provisioner/);
+  assert.match(calls, /-n storage-smoke wait --for=condition=complete/);
+  assert.match(calls, /-n storage-smoke logs job\/storage-smoke/);
+  assert.match(appliedInput, /disable\+:\n\s+- local-storage/);
+  assert.match(appliedInput, /--disable servicelb --disable local-storage/);
+  assert.match(appliedInput, /persistentVolumeClaim:\n\s+claimName: storage-smoke-pvc/);
+});

--- a/ee/appliance/host-service/tests/setup-engine.workflow.test.mjs
+++ b/ee/appliance/host-service/tests/setup-engine.workflow.test.mjs
@@ -3,7 +3,7 @@ import os from 'node:os';
 import path from 'node:path';
 import test from 'node:test';
 import assert from 'node:assert/strict';
-import { applyFluxSource, applyReleaseSelectionConfiguration, applyRuntimeValuesAndReleaseSelection, installFlux, resolveChannelMetadata } from '../setup-engine.mjs';
+import { applyFluxSource, applyReleaseSelectionConfiguration, applyRuntimeValuesAndReleaseSelection, installFlux, installStorage, resolveChannelMetadata } from '../setup-engine.mjs';
 
 const initialTenant = {
   tenantName: 'Acme MSP',
@@ -55,6 +55,42 @@ test('installFlux records success when flux install command exits cleanly', () =
   const persisted = JSON.parse(fs.readFileSync(stateFile, 'utf8'));
   assert.equal(persisted.status, 'flux-install-complete');
   assert.equal(persisted.phase, 'flux');
+});
+
+test('installStorage records the runtime result of the storage reconciliation', () => {
+  const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'alga-appliance-storage-'));
+  const stateFile = path.join(tmp, 'state', 'install-state.json');
+  const marker = path.join(tmp, 'storage-ok.txt');
+
+  const result = installStorage({
+    stateFile,
+    kubeconfigPath: path.join(tmp, 'k3s.yaml'),
+    storageInstallCommand: `printf 'storage-ready' > ${marker}`
+  });
+
+  assert.equal(result.ok, true);
+  assert.equal(result.phase, 'storage');
+  assert.equal(fs.readFileSync(marker, 'utf8'), 'storage-ready');
+
+  const persisted = JSON.parse(fs.readFileSync(stateFile, 'utf8'));
+  assert.equal(persisted.status, 'storage-install-complete');
+  assert.equal(persisted.phase, 'storage');
+});
+
+test('installStorage blocks setup when the reconciliation command fails', () => {
+  const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'alga-appliance-storage-fail-'));
+  const stateFile = path.join(tmp, 'state', 'install-state.json');
+
+  const result = installStorage({
+    stateFile,
+    storageInstallCommand: "printf 'provisioner failed' >&2; exit 7"
+  });
+
+  assert.equal(result.ok, false);
+  assert.equal(result.step, 'install-local-path-storage');
+  const persisted = JSON.parse(fs.readFileSync(stateFile, 'utf8'));
+  assert.equal(persisted.status, 'storage-install-blocked');
+  assert.match(persisted.installerOutput.stderr, /provisioner failed/);
 });
 
 test('resolveChannelMetadata resolves a channel to the registry release manifest', async () => {

--- a/ee/appliance/host-service/tests/update-engine.test.mjs
+++ b/ee/appliance/host-service/tests/update-engine.test.mjs
@@ -56,6 +56,7 @@ test('runAppChannelUpdate applies channel update and persists history without OS
       }
     },
     tokenFile: path.join(tmp, 'setup-token'),
+    storageInstallCommand: 'true',
     fluxSourceApplyCommand: `cat > ${fluxManifestPath}`,
     reconcileSourceCommand: 'true',
     reconcileHelmCommand: 'true',
@@ -125,6 +126,7 @@ function makeUpdateFixture() {
       }
     },
     tokenFile: path.join(tmp, 'setup-token'),
+    storageInstallCommand: 'true',
     fluxSourceApplyCommand: `cat > ${path.join(tmp, 'flux-source.yaml')}`,
     reconcileSourceCommand: 'true',
     reconcileHelmCommand: 'true',
@@ -179,4 +181,25 @@ test('app update: helm reconcile exits non-zero and HelmRelease is unreadable ->
   const { result, state } = await runWithReconcileOutcome('false'); // kubectl read itself fails
   assert.equal(result.ok, false);
   assert.equal(state.status, 'update-blocked');
+});
+
+test('app update stops before release reconciliation when storage repair fails', async () => {
+  const { stateFile, fakeBin, options } = makeUpdateFixture();
+  const originalPath = process.env.PATH;
+  process.env.PATH = `${fakeBin}:${originalPath}`;
+  try {
+    const result = await runAppChannelUpdate({ channel: 'nightly' }, {
+      ...options,
+      storageInstallCommand: "printf 'storage unavailable' >&2; exit 1"
+    });
+    assert.equal(result.ok, false);
+    assert.equal(result.phase, 'storage');
+    assert.equal(result.step, 'install-local-path-storage');
+
+    const state = JSON.parse(fs.readFileSync(stateFile, 'utf8'));
+    assert.equal(state.status, 'update-blocked');
+    assert.equal(state.phase, 'storage');
+  } finally {
+    process.env.PATH = originalPath;
+  }
 });

--- a/ee/appliance/host-service/update-engine.mjs
+++ b/ee/appliance/host-service/update-engine.mjs
@@ -2,7 +2,7 @@
 import fs from 'node:fs';
 import path from 'node:path';
 import { spawnSync } from 'node:child_process';
-import { applyFluxSource, applyReleaseSelectionConfiguration, applyRuntimeValuesAndReleaseSelection, resolveChannelMetadata, validateSetupInputs } from './setup-engine.mjs';
+import { applyFluxSource, applyReleaseSelectionConfiguration, applyRuntimeValuesAndReleaseSelection, installStorage, resolveChannelMetadata, validateSetupInputs } from './setup-engine.mjs';
 import { persistMaintenanceMetadata } from './metadata-engine.mjs';
 
 const DEFAULT_STATE_FILE = process.env.ALGA_APPLIANCE_STATE_FILE || '/var/lib/alga-appliance/install-state.json';
@@ -203,6 +203,30 @@ export async function runAppChannelUpdate(rawInputs, options = {}) {
       scope: 'application-only'
     }
   }, stateFile);
+
+  // Channel updates are also the delivery path for appliance control-plane
+  // fixes. Reconcile the storage prerequisite first so an appliance affected by
+  // the historical duplicate local-path controllers can recover before Helm is
+  // asked to converge PostgreSQL, Redis, and the application deployment.
+  const storageResult = installStorage({ ...options, stateFile });
+  if (!storageResult.ok) {
+    writeInstallState({
+      status: 'update-blocked',
+      phase: storageResult.phase,
+      lastAction: storageResult.message,
+      failure: storageResult,
+      updatedAt: nowIso(),
+      update: { requestedChannel: validated.channel, scope: 'application-only' }
+    }, stateFile);
+    appendUpdateHistory({
+      at: nowIso(),
+      channel: validated.channel,
+      ok: false,
+      phase: storageResult.phase,
+      message: storageResult.message
+    }, updateHistoryFile);
+    return storageResult;
+  }
 
   const releaseSelection = await resolveChannelMetadata(validated, options);
   if (!releaseSelection.ok) {

--- a/ee/appliance/manifests/local-path-storage.yaml
+++ b/ee/appliance/manifests/local-path-storage.yaml
@@ -156,5 +156,5 @@ data:
           effect: NoSchedule
       containers:
         - name: helper-pod
-          image: busybox
+          image: busybox:1.36
           imagePullPolicy: IfNotPresent

--- a/ee/appliance/scripts/bootstrap-control-plane.sh
+++ b/ee/appliance/scripts/bootstrap-control-plane.sh
@@ -174,7 +174,7 @@ Wants=network-online.target
 
 [Service]
 Type=notify
-ExecStart=$k3s_bin server --disable traefik --disable servicelb --write-kubeconfig-mode 0644
+ExecStart=$k3s_bin server --disable traefik --disable servicelb --disable local-storage --write-kubeconfig-mode 0644
 KillMode=process
 Delegate=yes
 Restart=always
@@ -193,12 +193,36 @@ EOF
     fi
 
     mkdir -p /var/log
-    nohup "$k3s_bin" server --disable traefik --disable servicelb --write-kubeconfig-mode 0644 >/var/log/alga-appliance-k3s.log 2>&1 &
+    nohup "$k3s_bin" server --disable traefik --disable servicelb --disable local-storage --write-kubeconfig-mode 0644 >/var/log/alga-appliance-k3s.log 2>&1 &
     return 0
   fi
 
   echo "k3s is not installed and no bundled k3s binary is available at $BUNDLED_K3S_BINARY. The ISO must stage k3s before this script runs." >&2
   exit 1
+}
+
+configure_k3s_storage_owner() {
+  log "Substrate: reserving local-path storage for the appliance provisioner"
+  if [ "$DRY_RUN" = "true" ]; then
+    plan "persist --disable local-storage in the k3s service and configuration"
+    return 0
+  fi
+
+  mkdir -p /etc/rancher/k3s/config.yaml.d
+  cat > /etc/rancher/k3s/config.yaml.d/20-alga-local-storage.yaml <<'EOF'
+disable+:
+  - local-storage
+EOF
+
+  # Existing appliance units already carry repeatable --disable CLI flags,
+  # which take precedence over the config-file list. Add local-storage beside
+  # the known servicelb flag so upgrades remain fixed after a reboot.
+  if [ -f /etc/systemd/system/k3s.service ] \
+    && grep -q -- '--disable servicelb' /etc/systemd/system/k3s.service \
+    && ! grep -q -- '--disable local-storage' /etc/systemd/system/k3s.service; then
+    sed -i 's/--disable servicelb/--disable servicelb --disable local-storage/' /etc/systemd/system/k3s.service
+    systemctl daemon-reload
+  fi
 }
 
 wait_for_kubernetes_api() {
@@ -439,6 +463,7 @@ if [ "$CONTROL_PLANE_ONLY" = "true" ]; then
   apply_control_plane
   log "control-plane upgrade applied"
 else
+  configure_k3s_storage_owner
   ensure_k3s_started
   wait_for_kubernetes_api
   import_control_plane_images

--- a/ee/appliance/scripts/control-plane-entrypoint.sh
+++ b/ee/appliance/scripts/control-plane-entrypoint.sh
@@ -37,4 +37,17 @@ EOF
   export ALGA_APPLIANCE_KUBECONFIG="$KUBECONFIG_PATH"
 fi
 
+# A control-plane channel update can repair storage without replacing the
+# ISO-baked host scripts. Reconcile in the background only when the historical
+# k3s controller is still present or the appliance controller is unavailable;
+# the setup/update workflows run the same locked installer synchronously before
+# asking Flux to create or converge PVC-backed workloads.
+(
+  sleep "${ALGA_APPLIANCE_STORAGE_REPAIR_DELAY_SECONDS:-5}"
+  if kubectl --kubeconfig "$KUBECONFIG_PATH" -n kube-system get deployment local-path-provisioner >/dev/null 2>&1 \
+    || ! kubectl --kubeconfig "$KUBECONFIG_PATH" -n local-path-storage rollout status deployment/local-path-provisioner --timeout=5s >/dev/null 2>&1; then
+    /opt/alga-appliance/scripts/install-storage.sh --kubeconfig "$KUBECONFIG_PATH"
+  fi
+) >> /var/lib/alga-appliance/storage-reconcile.log 2>&1 &
+
 exec node /opt/alga-appliance/host-service/server.mjs

--- a/ee/appliance/scripts/install-storage.sh
+++ b/ee/appliance/scripts/install-storage.sh
@@ -6,8 +6,10 @@ APPLIANCE_ROOT="$(CDPATH= cd -- "$(dirname -- "$0")/.." && pwd)"
 STORAGE_MANIFEST="$APPLIANCE_ROOT/manifests/local-path-storage.yaml"
 STORAGE_PATH="/var/mnt/alga-data/local-path-provisioner"
 K3S_CONFIG_DROP_IN="/etc/rancher/k3s/config.yaml.d/20-alga-local-storage.yaml"
+K3S_LOCAL_STORAGE_SKIP_FILE="/var/lib/rancher/k3s/server/manifests/local-storage.yaml.skip"
 SMOKE_NAMESPACE="storage-smoke"
 LOCK_DIR="${ALGA_APPLIANCE_STORAGE_LOCK_DIR:-/var/lib/alga-appliance/storage-reconcile.lock}"
+STORAGE_STABILITY_SECONDS="${ALGA_APPLIANCE_STORAGE_STABILITY_SECONDS:-10}"
 DRY_RUN=false
 KUBE_COMMAND=()
 
@@ -127,6 +129,8 @@ spec:
               disable+:
                 - local-storage
               CONFIG
+              mkdir -p "/host$(dirname "${K3S_LOCAL_STORAGE_SKIP_FILE}")"
+              : > "/host${K3S_LOCAL_STORAGE_SKIP_FILE}"
               K3S_SERVICE=/host/etc/systemd/system/k3s.service
               if [ -f "\$K3S_SERVICE" ] \
                 && grep -q -- '--disable servicelb' "\$K3S_SERVICE" \
@@ -191,8 +195,137 @@ remove_k3s_bundled_provisioner() {
   kube -n kube-system delete deployment local-path-provisioner --ignore-not-found --wait=true
 }
 
-run_smoke_test() {
+verify_single_storage_controller() {
+  if $DRY_RUN; then
+    echo "+ prove local-path-storage/local-path-provisioner is available"
+    echo "+ prove kube-system/local-path-provisioner is absent"
+    echo "+ wait ${STORAGE_STABILITY_SECONDS}s and prove controller uniqueness again"
+    return 0
+  fi
+
+  kube -n local-path-storage rollout status deployment/local-path-provisioner --timeout=5m
+  if kube -n kube-system get deployment local-path-provisioner >/dev/null 2>&1; then
+    echo "Bundled kube-system/local-path-provisioner is still present; refusing to report storage success." >&2
+    return 1
+  fi
+}
+
+verify_storage_controller_convergence() {
+  verify_single_storage_controller
+  sleep "$STORAGE_STABILITY_SECONDS"
+  verify_single_storage_controller
+}
+
+list_local_path_pvs() {
+  kube get persistentvolume \
+    -o jsonpath='{range .items[?(@.spec.storageClassName=="local-path")]}{.metadata.name}{"\n"}{end}' \
+    2>/dev/null || true
+}
+
+smoke_pv_claim_namespace() {
+  kube get persistentvolume "$1" -o jsonpath='{.spec.claimRef.namespace}' 2>/dev/null || true
+}
+
+transition_smoke_pv_to_delete() {
+  local pv_name="$1"
+  local claim_namespace
+  local reclaim_policy
+
+  claim_namespace="$(smoke_pv_claim_namespace "$pv_name")"
+  if [ "$claim_namespace" != "$SMOKE_NAMESPACE" ]; then
+    echo "Refusing to clean PV $pv_name: claim namespace is '$claim_namespace', not '$SMOKE_NAMESPACE'." >&2
+    return 1
+  fi
+
+  reclaim_policy="$(kube get persistentvolume "$pv_name" -o jsonpath='{.spec.persistentVolumeReclaimPolicy}' 2>/dev/null || true)"
+  case "$reclaim_policy" in
+    Retain)
+      kube patch persistentvolume "$pv_name" --type=json \
+        -p='[{"op":"test","path":"/spec/persistentVolumeReclaimPolicy","value":"Retain"},{"op":"replace","path":"/spec/persistentVolumeReclaimPolicy","value":"Delete"}]'
+      ;;
+    Delete)
+      # A previous interrupted cleanup may already have completed the safe
+      # Retain -> Delete transition. Continue removing only this smoke PV.
+      ;;
+    *)
+      echo "Refusing to clean PV $pv_name with unexpected reclaim policy '$reclaim_policy'." >&2
+      return 1
+      ;;
+  esac
+}
+
+cleanup_leaked_smoke_pvs() {
+  local pv_name
+  local claim_namespace
+
+  while IFS= read -r pv_name; do
+    [ -n "$pv_name" ] || continue
+    claim_namespace="$(smoke_pv_claim_namespace "$pv_name")"
+    [ "$claim_namespace" = "$SMOKE_NAMESPACE" ] || continue
+
+    echo "Cleaning previously leaked storage smoke PV $pv_name."
+    if ! transition_smoke_pv_to_delete "$pv_name"; then
+      return 1
+    fi
+    if ! kube delete persistentvolume "$pv_name" --wait=false; then
+      return 1
+    fi
+    if ! kube wait --for=delete --timeout=5m "persistentvolume/$pv_name"; then
+      return 1
+    fi
+  done < <(list_local_path_pvs)
+}
+
+cleanup_previous_smoke_resources() {
+  kube delete namespace "$SMOKE_NAMESPACE" --ignore-not-found --wait=true >/dev/null
+  cleanup_leaked_smoke_pvs
+}
+
+run_smoke_test() (
   local manifest
+  local smoke_pv_name=""
+
+  cleanup_current_smoke_test() {
+    local original_status="$?"
+    local cleanup_status=0
+    local resolved_pv_name="$smoke_pv_name"
+    local safe_smoke_pv=false
+
+    trap - EXIT
+    set +e
+
+    if [ -z "$resolved_pv_name" ]; then
+      resolved_pv_name="$(kube -n "$SMOKE_NAMESPACE" get persistentvolumeclaim storage-smoke-pvc \
+        -o jsonpath='{.spec.volumeName}' 2>/dev/null)"
+    fi
+
+    if [ -n "$resolved_pv_name" ]; then
+      if ! transition_smoke_pv_to_delete "$resolved_pv_name"; then
+        cleanup_status=1
+      else
+        safe_smoke_pv=true
+      fi
+    fi
+
+    if ! kube delete namespace "$SMOKE_NAMESPACE" --ignore-not-found --wait=true >/dev/null; then
+      cleanup_status=1
+    fi
+
+    if $safe_smoke_pv; then
+      if ! kube wait --for=delete --timeout=5m "persistentvolume/$resolved_pv_name"; then
+        cleanup_status=1
+      fi
+    fi
+
+    if ! cleanup_leaked_smoke_pvs; then
+      cleanup_status=1
+    fi
+
+    if [ "$original_status" -ne 0 ]; then
+      exit "$original_status"
+    fi
+    exit "$cleanup_status"
+  }
 
   if $DRY_RUN; then
     cat <<EOF
@@ -214,7 +347,9 @@ EOF
     return 0
   fi
 
-  kube delete namespace "$SMOKE_NAMESPACE" --ignore-not-found --wait=true >/dev/null
+  trap cleanup_current_smoke_test EXIT
+
+  cleanup_previous_smoke_resources
   kube create namespace "$SMOKE_NAMESPACE" --dry-run=client -o yaml | kube apply -f -
   kube label namespace "$SMOKE_NAMESPACE" \
     pod-security.kubernetes.io/enforce=privileged \
@@ -264,10 +399,24 @@ EOF
 )"
 
   printf '%s\n' "$manifest" | kube apply -f -
+  kube -n "$SMOKE_NAMESPACE" wait \
+    --for=jsonpath='{.status.phase}'=Bound \
+    --timeout=5m \
+    persistentvolumeclaim/storage-smoke-pvc
+  smoke_pv_name="$(kube -n "$SMOKE_NAMESPACE" get persistentvolumeclaim storage-smoke-pvc \
+    -o jsonpath='{.spec.volumeName}')"
+  if [ -z "$smoke_pv_name" ]; then
+    echo "Storage smoke PVC did not bind to a PV." >&2
+    return 1
+  fi
+  if [ "$(smoke_pv_claim_namespace "$smoke_pv_name")" != "$SMOKE_NAMESPACE" ]; then
+    echo "Storage smoke PVC bound to a PV outside namespace $SMOKE_NAMESPACE." >&2
+    return 1
+  fi
+
   kube -n "$SMOKE_NAMESPACE" wait --for=condition=complete --timeout=5m job/storage-smoke
   kube -n "$SMOKE_NAMESPACE" logs job/storage-smoke >/dev/null
-  kube delete namespace "$SMOKE_NAMESPACE" --ignore-not-found >/dev/null
-}
+)
 
 while [ "$#" -gt 0 ]; do
   case "$1" in
@@ -334,6 +483,8 @@ kubectl_cmd label namespace msp \
   --overwrite
 
 wait_for_rollout
+verify_storage_controller_convergence
 run_smoke_test
+verify_storage_controller_convergence
 
 echo "Storage prerequisites are ready."

--- a/ee/appliance/scripts/install-storage.sh
+++ b/ee/appliance/scripts/install-storage.sh
@@ -5,8 +5,11 @@ KUBECONFIG_PATH="${KUBECONFIG:-}"
 APPLIANCE_ROOT="$(CDPATH= cd -- "$(dirname -- "$0")/.." && pwd)"
 STORAGE_MANIFEST="$APPLIANCE_ROOT/manifests/local-path-storage.yaml"
 STORAGE_PATH="/var/mnt/alga-data/local-path-provisioner"
+K3S_CONFIG_DROP_IN="/etc/rancher/k3s/config.yaml.d/20-alga-local-storage.yaml"
 SMOKE_NAMESPACE="storage-smoke"
+LOCK_DIR="${ALGA_APPLIANCE_STORAGE_LOCK_DIR:-/var/lib/alga-appliance/storage-reconcile.lock}"
 DRY_RUN=false
+KUBE_COMMAND=()
 
 usage() {
   cat <<'EOF'
@@ -18,13 +21,6 @@ Options:
   --dry-run                  Print the commands without mutating the cluster
   --help                     Show this help
 EOF
-}
-
-require_command() {
-  if ! command -v "$1" >/dev/null 2>&1; then
-    echo "Required command not found: $1" >&2
-    exit 1
-  fi
 }
 
 run_cmd() {
@@ -40,8 +36,43 @@ run_cmd() {
   "$@"
 }
 
+acquire_lock() {
+  if $DRY_RUN; then
+    return 0
+  fi
+
+  local attempts=0
+  mkdir -p "$(dirname "$LOCK_DIR")"
+  until mkdir "$LOCK_DIR" 2>/dev/null; do
+    attempts=$((attempts + 1))
+    if [ "$attempts" -ge 150 ]; then
+      echo "Timed out waiting for another storage reconciliation to finish." >&2
+      exit 1
+    fi
+    sleep 2
+  done
+  trap 'rmdir "$LOCK_DIR" 2>/dev/null || true' EXIT INT TERM
+}
+
+configure_kube_command() {
+  if command -v kubectl >/dev/null 2>&1; then
+    KUBE_COMMAND=(kubectl)
+  elif [ -x "$APPLIANCE_ROOT/bin/k3s" ]; then
+    KUBE_COMMAND=("$APPLIANCE_ROOT/bin/k3s" kubectl)
+  elif command -v k3s >/dev/null 2>&1; then
+    KUBE_COMMAND=(k3s kubectl)
+  else
+    echo "kubectl or k3s is required" >&2
+    exit 1
+  fi
+}
+
+kube() {
+  "${KUBE_COMMAND[@]}" --kubeconfig "$KUBECONFIG_PATH" "$@"
+}
+
 kubectl_cmd() {
-  run_cmd kubectl --kubeconfig "$KUBECONFIG_PATH" "$@"
+  run_cmd "${KUBE_COMMAND[@]}" --kubeconfig "$KUBECONFIG_PATH" "$@"
 }
 
 wait_for_rollout() {
@@ -50,7 +81,7 @@ wait_for_rollout() {
     return 0
   fi
 
-  kubectl --kubeconfig "$KUBECONFIG_PATH" -n local-path-storage rollout status deployment/local-path-provisioner --timeout=5m
+  kube -n local-path-storage rollout status deployment/local-path-provisioner --timeout=5m
 }
 
 prepare_storage_path() {
@@ -91,6 +122,17 @@ spec:
             - |
               mkdir -p /host${STORAGE_PATH}
               chmod 0777 /host${STORAGE_PATH}
+              mkdir -p "/host$(dirname "${K3S_CONFIG_DROP_IN}")"
+              cat > "/host${K3S_CONFIG_DROP_IN}" <<'CONFIG'
+              disable+:
+                - local-storage
+              CONFIG
+              K3S_SERVICE=/host/etc/systemd/system/k3s.service
+              if [ -f "\$K3S_SERVICE" ] \
+                && grep -q -- '--disable servicelb' "\$K3S_SERVICE" \
+                && ! grep -q -- '--disable local-storage' "\$K3S_SERVICE"; then
+                sed -i 's/--disable servicelb/--disable servicelb --disable local-storage/' "\$K3S_SERVICE"
+              fi
           volumeMounts:
             - name: host-root
               mountPath: /host
@@ -102,36 +144,51 @@ spec:
 EOF
 )"
 
-  printf '%s\n' "$manifest" | kubectl --kubeconfig "$KUBECONFIG_PATH" apply -f -
-  kubectl --kubeconfig "$KUBECONFIG_PATH" -n local-path-storage wait --for=condition=complete --timeout=5m job/local-path-storage-prepare
+  kube -n local-path-storage delete job local-path-storage-prepare --ignore-not-found --wait=true >/dev/null
+  printf '%s\n' "$manifest" | kube apply -f -
+  kube -n local-path-storage wait --for=condition=complete --timeout=5m job/local-path-storage-prepare
 }
 
 reconcile_existing_storage_class() {
   if $DRY_RUN; then
-    echo "+ inspect existing local-path StorageClass and delete it only when it is incompatible and unused"
+    echo "+ preserve existing local-path PVs and replace an incompatible StorageClass"
     return 0
   fi
 
-  if ! kubectl --kubeconfig "$KUBECONFIG_PATH" get storageclass local-path >/dev/null 2>&1; then
+  local pv_name
+  while IFS= read -r pv_name; do
+    [ -n "$pv_name" ] || continue
+    echo "Protecting existing local-path PV $pv_name with Retain policy."
+    kube patch persistentvolume "$pv_name" --type=merge -p '{"spec":{"persistentVolumeReclaimPolicy":"Retain"}}'
+  done < <(kube get pv -o jsonpath='{range .items[?(@.spec.storageClassName=="local-path")]}{.metadata.name}{"\n"}{end}' 2>/dev/null || true)
+
+  if ! kube get storageclass local-path >/dev/null 2>&1; then
     return 0
   fi
 
   local reclaim_policy=""
-  reclaim_policy="$(kubectl --kubeconfig "$KUBECONFIG_PATH" get storageclass local-path -o jsonpath='{.reclaimPolicy}' 2>/dev/null || true)"
+  reclaim_policy="$(kube get storageclass local-path -o jsonpath='{.reclaimPolicy}' 2>/dev/null || true)"
   if [ "$reclaim_policy" = "Retain" ]; then
     return 0
   fi
 
-  local pv_count pvc_count
-  pv_count="$(kubectl --kubeconfig "$KUBECONFIG_PATH" get pv -o jsonpath='{range .items[?(@.spec.storageClassName=="local-path")]}x{end}' 2>/dev/null | wc -c | tr -d ' ')"
-  pvc_count="$(kubectl --kubeconfig "$KUBECONFIG_PATH" get pvc -A -o jsonpath='{range .items[?(@.spec.storageClassName=="local-path")]}x{end}' 2>/dev/null | wc -c | tr -d ' ')"
-  if [ "${pv_count:-0}" != "0" ] || [ "${pvc_count:-0}" != "0" ]; then
-    echo "Existing local-path StorageClass has reclaimPolicy=$reclaim_policy and is already in use; refusing to replace it automatically." >&2
-    exit 1
+  echo "Replacing local-path StorageClass with appliance Retain policy."
+  kube delete storageclass local-path
+}
+
+remove_k3s_bundled_provisioner() {
+  if $DRY_RUN; then
+    echo "+ remove kube-system/local-path-provisioner after preserving existing local-path volumes"
+    return 0
   fi
 
-  echo "Replacing unused local-path StorageClass with appliance Retain policy."
-  kubectl --kubeconfig "$KUBECONFIG_PATH" delete storageclass local-path
+  # k3s normally installs this controller automatically. The appliance owns a
+  # separately configured controller using the same provisioner name, so
+  # leaving both active lets two controllers race for every local-path claim.
+  # The prepare job persists the disable flag in both k3s configuration and the
+  # appliance's existing systemd unit so the bundled controller stays disabled
+  # after the next host restart.
+  kube -n kube-system delete deployment local-path-provisioner --ignore-not-found --wait=true
 }
 
 run_smoke_test() {
@@ -157,8 +214,9 @@ EOF
     return 0
   fi
 
-  kubectl --kubeconfig "$KUBECONFIG_PATH" create namespace "$SMOKE_NAMESPACE" --dry-run=client -o yaml | kubectl --kubeconfig "$KUBECONFIG_PATH" apply -f -
-  kubectl --kubeconfig "$KUBECONFIG_PATH" label namespace "$SMOKE_NAMESPACE" \
+  kube delete namespace "$SMOKE_NAMESPACE" --ignore-not-found --wait=true >/dev/null
+  kube create namespace "$SMOKE_NAMESPACE" --dry-run=client -o yaml | kube apply -f -
+  kube label namespace "$SMOKE_NAMESPACE" \
     pod-security.kubernetes.io/enforce=privileged \
     pod-security.kubernetes.io/audit=privileged \
     pod-security.kubernetes.io/warn=privileged \
@@ -205,10 +263,10 @@ spec:
 EOF
 )"
 
-  printf '%s\n' "$manifest" | kubectl --kubeconfig "$KUBECONFIG_PATH" apply -f -
-  kubectl --kubeconfig "$KUBECONFIG_PATH" -n "$SMOKE_NAMESPACE" wait --for=condition=complete --timeout=5m job/storage-smoke
-  kubectl --kubeconfig "$KUBECONFIG_PATH" -n "$SMOKE_NAMESPACE" logs job/storage-smoke >/dev/null
-  kubectl --kubeconfig "$KUBECONFIG_PATH" delete namespace "$SMOKE_NAMESPACE" --ignore-not-found >/dev/null
+  printf '%s\n' "$manifest" | kube apply -f -
+  kube -n "$SMOKE_NAMESPACE" wait --for=condition=complete --timeout=5m job/storage-smoke
+  kube -n "$SMOKE_NAMESPACE" logs job/storage-smoke >/dev/null
+  kube delete namespace "$SMOKE_NAMESPACE" --ignore-not-found >/dev/null
 }
 
 while [ "$#" -gt 0 ]; do
@@ -233,8 +291,6 @@ while [ "$#" -gt 0 ]; do
   esac
 done
 
-require_command kubectl
-
 if [ -z "$KUBECONFIG_PATH" ]; then
   echo "Kubeconfig path is required via --kubeconfig or KUBECONFIG." >&2
   exit 1
@@ -250,12 +306,26 @@ if [ ! -f "$STORAGE_MANIFEST" ]; then
   exit 1
 fi
 
+configure_kube_command
+acquire_lock
+if $DRY_RUN; then
+  echo "+ kubectl --kubeconfig $KUBECONFIG_PATH create namespace local-path-storage --dry-run=client -o yaml | kubectl --kubeconfig $KUBECONFIG_PATH apply -f -"
+else
+  kube create namespace local-path-storage --dry-run=client -o yaml | kube apply -f -
+fi
+kubectl_cmd label namespace local-path-storage \
+  pod-security.kubernetes.io/enforce=privileged \
+  pod-security.kubernetes.io/audit=privileged \
+  pod-security.kubernetes.io/warn=privileged \
+  --overwrite
+prepare_storage_path
 reconcile_existing_storage_class
+remove_k3s_bundled_provisioner
 kubectl_cmd apply -f "$STORAGE_MANIFEST"
 if $DRY_RUN; then
   echo "+ kubectl --kubeconfig $KUBECONFIG_PATH create namespace msp --dry-run=client -o yaml | kubectl --kubeconfig $KUBECONFIG_PATH apply -f -"
 else
-  kubectl --kubeconfig "$KUBECONFIG_PATH" create namespace msp --dry-run=client -o yaml | kubectl --kubeconfig "$KUBECONFIG_PATH" apply -f -
+  kube create namespace msp --dry-run=client -o yaml | kube apply -f -
 fi
 kubectl_cmd label namespace msp \
   pod-security.kubernetes.io/enforce=privileged \
@@ -263,7 +333,6 @@ kubectl_cmd label namespace msp \
   pod-security.kubernetes.io/warn=privileged \
   --overwrite
 
-prepare_storage_path
 wait_for_rollout
 run_smoke_test
 


### PR DESCRIPTION
## What changed

- Prevent fresh appliance installs from starting k3s's bundled local-path controller alongside the appliance-owned controller.
- Add an upgrade-safe storage reconciler that protects all existing local-path application PVs with `Retain` before any controller changes.
- Persist all three k3s protections: the config drop-in, the systemd `--disable local-storage` flag, and `/var/lib/rancher/k3s/server/manifests/local-storage.yaml.skip` for the already-running manifest deployer.
- Delete the bundled `kube-system/local-path-provisioner`, require the appliance controller to be available, and prove controller uniqueness before and after the smoke test with stability rechecks.
- Capture the smoke PVC's bound PV, atomically transition only that `storage-smoke` PV from `Retain` to `Delete`, and wait for complete namespace/PV cleanup through a failure-safe trap.
- Reconcile previously leaked PVs only when `claimRef.namespace` is exactly `storage-smoke`; application PVCs and PVs are never deleted or recreated.
- Run storage reconciliation before setup Flux installation and application-channel updates, and automatically repair affected existing appliances when the updated control-plane image starts.

## Root cause

The appliance started k3s without disabling its packaged `local-storage` component and also installed a second `rancher.io/local-path` controller. The first repair persisted future-boot disable settings and deleted the bundled deployment, but k3s's already-running packaged-manifest deployer continued watching `local-storage.yaml` and recreated the bundled controller. K3s documents that a matching `.skip` file is required to make the running deployer ignore the manifest; creating it does not remove resources that already exist, so explicit deletion remains necessary.

## Impact

Nightly appliance control-plane updates now repair existing duplicate-controller installations without rebooting k3s or deleting application storage. Reconciliation refuses to report success if both controllers exist, and repeated runs leave no smoke volumes behind.

## Validation

- 22 focused Node behavioral tests passed, including controller recreation, controller availability, smoke failure cleanup, leaked smoke PV cleanup, application PV safety, and repeated reconciliation.
- `bash ee/appliance/tests/run-plan-tests.sh` passed.
- `bash -n ee/appliance/scripts/install-storage.sh` passed.
- `git diff --check` passed.

### Live nightly acceptance

Published commit `df1ef01831fdc1fc59ca52010266b4ffc18598c7` as nightly release `manual-nightly-controlPlane-53853f7d819e-20260724155705`:

`ghcr.io/nine-minds/alga-appliance-control-plane@sha256:53853f7d819e631ed0c11244b9c7f2c1bdb5b4523f94f8889272496b867b724b`

Updated the affected VM through the host-agent control-plane-only path without rebooting:

- k3s remained PID `1236`, with start time `Sat 2026-07-04 22:40:39 UTC`.
- `kube-system/local-path-provisioner` was absent immediately after repair and remained absent beyond 60 seconds.
- Only `local-path-storage/local-path-provisioner` was available.
- The three original application PVC UIDs, Bound states, and PV bindings were unchanged.
- All three application PVs remained `Retain`; no application PVC/PV was deleted or recreated.
- PostgreSQL retained tenant `Nine Minds Nightly Test` and the existing 470-table public schema.
- Five previously leaked `storage-smoke` PVs were removed; subsequent smoke writes left no namespace or PVs.
- A second reconciliation exited `0`, and the complete k3s/PVC/PV/database/no-leak comparison passed again.

K3s packaged-component behavior: https://docs.k3s.io/installation/packaged-components