### PR TITLE
fix: no error toast when managing portal for a clientless contact

### DIFF
--- a/packages/clients/src/actions/contact-actions/contactActions.tsx
+++ b/packages/clients/src/actions/contact-actions/contactActions.tsx
@@ -135,6 +135,9 @@ function contactUpdateActionErrorFrom(error: unknown): ContactUpdateActionError 
     if (message === 'Contact not found') {
       return actionError('Contact not found');
     }
+    if (message === 'Contact is not associated with a client') {
+      return actionError('Contact is not associated with a client');
+    }
     if (
       message.startsWith('VALIDATION_ERROR:') ||
       message.startsWith('EMAIL_EXISTS:') ||
@@ -1670,6 +1673,7 @@ function visibilityGroupActionErrorFrom(error: unknown): VisibilityGroupActionEr
     }
     if (
       message === 'Contact not found' ||
+      message === 'Contact is not associated with a client' ||
       message === 'Assigned visibility group is invalid for this contact' ||
       message === 'Visibility group not found' ||
       message === 'One or more boards are invalid for this tenant' ||
@@ -1705,8 +1709,12 @@ async function resolveContactClientId(
     .where({ contact_name_id: contactId })
     .first('contact_name_id', 'client_id');
 
-  if (!contact?.client_id) {
+  if (!contact) {
     throw new Error('Contact not found');
+  }
+
+  if (!contact.client_id) {
+    throw new Error('Contact is not associated with a client');
   }
 
   return contact.client_id;

--- a/packages/clients/src/components/contacts/ContactPortalTab.tsx
+++ b/packages/clients/src/components/contacts/ContactPortalTab.tsx
@@ -164,6 +164,17 @@ export function ContactPortalTab({ contact, currentUserPermissions }: ContactPor
   const loadData = async () => {
     setIsLoading(true);
     try {
+      if (!contact.client_id) {
+        setExistingUser(null);
+        setUserRoles([]);
+        setClientRoles([]);
+        setVisibilityGroups([]);
+        setVisibilityBoards([]);
+        setSelectedVisibilityGroupId(null);
+        setInvitationHistory([]);
+        return;
+      }
+
       // Check for existing user
       const { user, error } = await getUserByContactId(contact.contact_name_id);
       if (!error && user) {
@@ -661,6 +672,34 @@ export function ContactPortalTab({ contact, currentUserPermissions }: ContactPor
         showTable={false}
         noCard={false}
       />
+    );
+  }
+
+  if (!contact.client_id) {
+    return (
+      <div className="space-y-6">
+        <Card>
+          <CardHeader>
+            <CardTitle className="flex items-center gap-2">
+              <Shield className="h-5 w-5" />
+              {t('contactPortalTab.title', { defaultValue: 'Client Portal Access' })}
+            </CardTitle>
+            <CardDescription>
+              {t('contactPortalTab.description', { defaultValue: 'Manage client portal access and permissions for this contact' })}
+            </CardDescription>
+          </CardHeader>
+          <CardContent>
+            <Alert>
+              <Info className="h-4 w-4" />
+              <AlertDescription>
+                {t('contactPortalTab.noClient.description', {
+                  defaultValue: 'Assign this contact to a client to manage portal access.'
+                })}
+              </AlertDescription>
+            </Alert>
+          </CardContent>
+        </Card>
+      </div>
     );
   }
 

--- a/packages/clients/src/components/contacts/ContactPortalTab.visibilityGroups.test.tsx
+++ b/packages/clients/src/components/contacts/ContactPortalTab.visibilityGroups.test.tsx
@@ -162,6 +162,7 @@ const contact = {
   contact_name_id: 'contact-1',
   full_name: 'Taylor Client',
   email: 'taylor@example.com',
+  client_id: 'client-1',
   is_client_admin: false,
   portal_visibility_group_id: 'group-1',
 } as any;
@@ -285,5 +286,28 @@ describe('ContactPortalTab visibility groups', () => {
         }
       );
     });
+  });
+
+  it('shows an informational state for a contact with no assigned client, without erroring', async () => {
+    const clientlessContact = { ...contact, client_id: null };
+
+    render(
+      <ContactPortalTab
+        contact={clientlessContact}
+        currentUserPermissions={{ canInvite: true, canUpdateRoles: true, canRead: true }}
+      />
+    );
+
+    await waitFor(() => {
+      expect(
+        screen.getByText('Assign this contact to a client to manage portal access.')
+      ).toBeInTheDocument();
+    });
+
+    expect(toastMock).not.toHaveBeenCalled();
+    expect(getUserByContactIdMock).not.toHaveBeenCalled();
+    expect(getClientPortalVisibilityGroupsForContactMock).not.toHaveBeenCalled();
+    expect(getClientPortalVisibilityBoardsByClientMock).not.toHaveBeenCalled();
+    expect(getPortalInvitationsMock).not.toHaveBeenCalled();
   });
 });

--- a/packages/clients/src/components/contacts/bento/ContactBentoLayout.tsx
+++ b/packages/clients/src/components/contacts/bento/ContactBentoLayout.tsx
@@ -535,6 +535,7 @@ export function ContactBentoLayout({
   );
 
   const portalStatus = (() => {
+    if (!contact.client_id) return { label: 'No client assigned', positive: false };
     if (!portalSummary) return { label: '—', positive: false };
     if (portalSummary.hasAccount) {
       return portalSummary.accountInactive

--- a/server/public/locales/de/msp/contacts.json
+++ b/server/public/locales/de/msp/contacts.json
@@ -366,6 +366,9 @@
       "title": "Kein Portalzugriff",
       "description": "Dieser Kontakt hat noch keinen Zugriff auf das Kundenportal"
     },
+    "noClient": {
+      "description": "Weisen Sie diesem Kontakt einen Kunden zu, um den Portalzugriff zu verwalten."
+    },
     "portalAdmin": {
       "label": "Portaladministrator",
       "helper": "Wenn aktiviert, wird der Benutzer mit der Rolle Kundenadministrator erstellt. Wenn deaktiviert, erhält er die Rolle Kundenbenutzer."

--- a/server/public/locales/en/msp/contacts.json
+++ b/server/public/locales/en/msp/contacts.json
@@ -366,6 +366,9 @@
       "title": "No Portal Access",
       "description": "This contact does not have client portal access yet"
     },
+    "noClient": {
+      "description": "Assign this contact to a client to manage portal access."
+    },
     "portalAdmin": {
       "label": "Portal Administrator",
       "helper": "When enabled, the user will be created with Client Admin role. When disabled, they'll get Client User role."

--- a/server/public/locales/es/msp/contacts.json
+++ b/server/public/locales/es/msp/contacts.json
@@ -366,6 +366,9 @@
       "title": "Sin acceso al portal",
       "description": "Este contacto aún no tiene acceso al portal del cliente"
     },
+    "noClient": {
+      "description": "Asigne este contacto a un cliente para gestionar el acceso al portal."
+    },
     "portalAdmin": {
       "label": "Administrador del portal",
       "helper": "Cuando está habilitado, el usuario se creará con el rol Administrador del cliente. Cuando está deshabilitado, obtendrá el rol Usuario del cliente."

--- a/server/public/locales/fr/msp/contacts.json
+++ b/server/public/locales/fr/msp/contacts.json
@@ -366,6 +366,9 @@
       "title": "Aucun accès au portail",
       "description": "Ce contact n’a pas encore accès au portail client"
     },
+    "noClient": {
+      "description": "Associez ce contact à un client pour gérer l’accès au portail."
+    },
     "portalAdmin": {
       "label": "Administrateur du portail",
       "helper": "Lorsqu’il est activé, l’utilisateur sera créé avec le rôle Administrateur client. Lorsqu’il est désactivé, il obtiendra le rôle Utilisateur client."

--- a/server/public/locales/it/msp/contacts.json
+++ b/server/public/locales/it/msp/contacts.json
@@ -366,6 +366,9 @@
       "title": "Nessun accesso al portale",
       "description": "Questo contatto non ha ancora accesso al portale clienti"
     },
+    "noClient": {
+      "description": "Assegna questo contatto a un cliente per gestire l'accesso al portale."
+    },
     "portalAdmin": {
       "label": "Amministratore del portale",
       "helper": "Se abilitato, l'utente verrà creato con il ruolo di Amministratore cliente. Se disabilitato, riceverà il ruolo di Utente cliente."

--- a/server/public/locales/nl/msp/contacts.json
+++ b/server/public/locales/nl/msp/contacts.json
@@ -366,6 +366,9 @@
       "title": "Geen portaaltoegang",
       "description": "Dit contact heeft nog geen toegang tot het klantportaal"
     },
+    "noClient": {
+      "description": "Wijs dit contact toe aan een klant om portaaltoegang te beheren."
+    },
     "portalAdmin": {
       "label": "Portaalbeheerder",
       "helper": "Wanneer ingeschakeld, wordt de gebruiker aangemaakt met de rol Klantbeheerder. Wanneer uitgeschakeld, krijgt die de rol Klantgebruiker."

--- a/server/public/locales/pl/msp/contacts.json
+++ b/server/public/locales/pl/msp/contacts.json
@@ -370,6 +370,9 @@
       "title": "Brak dostępu do portalu",
       "description": "Ten kontakt nie ma jeszcze dostępu do portalu klienta"
     },
+    "noClient": {
+      "description": "Przypisz ten kontakt do klienta, aby zarządzać dostępem do portalu."
+    },
     "portalAdmin": {
       "label": "Administrator portalu",
       "helper": "Po włączeniu użytkownik zostanie utworzony z rolą Administratora klienta. Po wyłączeniu otrzyma rolę Użytkownika klienta."

--- a/server/public/locales/pt/msp/contacts.json
+++ b/server/public/locales/pt/msp/contacts.json
@@ -366,6 +366,9 @@
       "title": "Sem acesso ao portal",
       "description": "Este contato ainda não tem acesso ao portal do cliente"
     },
+    "noClient": {
+      "description": "Atribua este contato a um cliente para gerenciar o acesso ao portal."
+    },
     "portalAdmin": {
       "label": "Administrador do Portal",
       "helper": "Quando ativado, o usuário será criado com a função de administrador do cliente. Quando desativados, eles receberão a função de usuário cliente."

--- a/server/public/locales/xx/msp/contacts.json
+++ b/server/public/locales/xx/msp/contacts.json
@@ -366,6 +366,9 @@
       "title": "11111",
       "description": "11111"
     },
+    "noClient": {
+      "description": "11111"
+    },
     "portalAdmin": {
       "label": "11111",
       "helper": "11111"

--- a/server/public/locales/yy/msp/contacts.json
+++ b/server/public/locales/yy/msp/contacts.json
@@ -366,6 +366,9 @@
       "title": "55555",
       "description": "55555"
     },
+    "noClient": {
+      "description": "55555"
+    },
     "portalAdmin": {
       "label": "55555",
       "helper": "55555"


### PR DESCRIPTION
## Summary

Opening Portal → Manage for a contact that has no client assigned showed a generic "Failed to load" error toast. The portal actions assumed every contact carries a `client_id`; for clientless contacts the lookup failed and surfaced as an opaque error. Portal management now recognizes this state explicitly and tells the user what's actually going on.

## Changes

- `packages/clients/src/actions/contact-actions/contactActions.tsx` — portal-management actions distinguish "contact has no client" from a real load failure instead of throwing
- `packages/clients/src/components/contacts/ContactPortalTab.tsx` — renders a clear "no client assigned" state (with guidance to assign one) instead of the error toast; new visibility-group test covers the clientless case
- `packages/clients/src/components/contacts/bento/ContactBentoLayout.tsx` — same handling in the bento contact view
- Locale files (`msp/contacts.json`, all languages) — new strings for the clientless-contact portal state

## Testing

- Targeted vitest: `ContactPortalTab.visibilityGroups.test.tsx` — 3/3 passing, including the new clientless-contact regression test
- Verified live: contact without client → Portal → Manage no longer errors; shows the explanatory state
