### PR TITLE
Fix kanban panning by targeting real vertical scroll owner

### DIFF
--- a/packages/projects/src/components/useKanbanPan.ts
+++ b/packages/projects/src/components/useKanbanPan.ts
@@ -3,22 +3,37 @@
 import { useEffect, useRef, type RefObject } from 'react';
 
 const PAN_THRESHOLD = 5;
-// Vertical rubber-band limit (px) for the translateY fallback used when the
-// board has no native scroll overflow. Bounding it — and always snapping back
-// to 0 on mouseup — is what stops repeated drags from drifting the board
-// off-screen.
-const RUBBER_BAND_LIMIT = 64;
 const INTERACTIVE_SELECTOR =
   '[draggable="true"], button, a, input, select, textarea, [role="scrollbar"], [data-kanban-scrollbar-thumb]';
+
+/**
+ * Walks up from `el` to find the element that actually owns vertical scroll
+ * (overflow-y auto/scroll with real overflow), e.g. a column's task list or
+ * the kanban container itself. Falls back to the document's scrolling
+ * element so a drag still pans the page when nothing in between scrolls.
+ */
+function findVerticalScrollParent(el: HTMLElement): HTMLElement {
+  let node: HTMLElement | null = el;
+  while (node) {
+    const style = getComputedStyle(node);
+    const canScroll =
+      node.scrollHeight > node.clientHeight && /(auto|scroll)/.test(style.overflowY);
+    if (canScroll) return node;
+    node = node.parentElement;
+  }
+  return (document.scrollingElement as HTMLElement | null) ?? document.documentElement;
+}
 
 /**
  * Attaches Figma/Miro-style click-and-drag panning to a Kanban scroll container.
  *
  * Horizontal panning uses the container's native scrollLeft.
- * Vertical panning uses scrollTop when the board overflows, otherwise applies
- * a bounded, rubber-banded CSS translateY on the board so dragging still
- * feels responsive. The translateY always snaps back to 0 on mouseup, so
- * offsets can never accumulate across drags.
+ * Vertical panning targets whichever ancestor of the mousedown point
+ * actually owns the vertical overflow (a column's task list, the container,
+ * or the page itself), so a single drag can always reach the real top/bottom
+ * of the content. All scroll assignments are native, so the browser clamps
+ * them to the real content bounds and dragging can never drift anything
+ * off-screen.
  *
  * Interactive elements (draggable cards, buttons, inputs, the custom scrollbar thumb)
  * are excluded so native HTML5 drag-and-drop and clicks keep working.
@@ -31,8 +46,7 @@ export function useKanbanPan(containerRef: RefObject<HTMLDivElement | null>, ena
     startY: 0,
     startScrollLeft: 0,
     startScrollTop: 0,
-    useTranslateY: false,
-    board: null as HTMLElement | null,
+    verticalTarget: null as HTMLElement | null,
   });
 
   useEffect(() => {
@@ -40,16 +54,6 @@ export function useKanbanPan(containerRef: RefObject<HTMLDivElement | null>, ena
     if (!container || !enabled) return;
 
     const state = stateRef.current;
-
-    const getBoard = (): HTMLElement | null =>
-      container.querySelector('[data-kanban-board]') as HTMLElement | null;
-
-    const applyTranslateY = (offset: number, animate = false) => {
-      const board = state.board ?? getBoard();
-      if (!board) return;
-      board.style.transition = animate ? 'transform 0.15s ease-out' : '';
-      board.style.transform = offset === 0 ? '' : `translateY(${offset}px)`;
-    };
 
     const setPanningCursor = (panning: boolean) => {
       if (panning) {
@@ -85,27 +89,17 @@ export function useKanbanPan(containerRef: RefObject<HTMLDivElement | null>, ena
 
       event.preventDefault();
 
-      // Horizontal: native scroll
+      // Horizontal: native scroll on the board container.
       container.scrollLeft = state.startScrollLeft - deltaX;
 
-      // Vertical: native scroll when possible, otherwise a bounded rubber-band
-      // translateY so dragging still feels responsive when the board has no
-      // overflow of its own.
-      if (state.useTranslateY) {
-        const raw = deltaY;
-        const clamped = Math.max(-RUBBER_BAND_LIMIT, Math.min(RUBBER_BAND_LIMIT, raw));
-        applyTranslateY(clamped);
-      } else {
-        container.scrollTop = state.startScrollTop - deltaY;
+      // Vertical: native scroll on whichever element actually owns the
+      // overflow under the cursor.
+      if (state.verticalTarget) {
+        state.verticalTarget.scrollTop = state.startScrollTop - deltaY;
       }
     };
 
     const handleMouseUp = () => {
-      // Always snap the translateY offset back to 0 so it can never persist
-      // (and accumulate) across drags.
-      if (state.useTranslateY) {
-        applyTranslateY(0, true);
-      }
       cleanupPanning();
       if (state.hasMoved) {
         setTimeout(() => { state.hasMoved = false; }, 0);
@@ -119,16 +113,15 @@ export function useKanbanPan(containerRef: RefObject<HTMLDivElement | null>, ena
       if (!target) return;
       if (target.closest(INTERACTIVE_SELECTOR)) return;
 
-      const canScrollVertically = container.scrollHeight > container.clientHeight;
+      const verticalTarget = findVerticalScrollParent(target);
 
       state.active = false;
       state.hasMoved = false;
       state.startX = event.clientX;
       state.startY = event.clientY;
       state.startScrollLeft = container.scrollLeft;
-      state.startScrollTop = container.scrollTop;
-      state.useTranslateY = !canScrollVertically;
-      state.board = state.useTranslateY ? getBoard() : null;
+      state.startScrollTop = verticalTarget.scrollTop;
+      state.verticalTarget = verticalTarget;
 
       window.addEventListener('mousemove', handleMouseMove);
       window.addEventListener('mouseup', handleMouseUp);
@@ -148,7 +141,6 @@ export function useKanbanPan(containerRef: RefObject<HTMLDivElement | null>, ena
     return () => {
       container.removeEventListener('mousedown', handleMouseDown);
       container.removeEventListener('click', handleClickCapture, true);
-      applyTranslateY(0);
       cleanupPanning();
     };
   }, [containerRef, enabled]);

--- a/packages/projects/src/components/useKanbanPan.ts
+++ b/packages/projects/src/components/useKanbanPan.ts
@@ -3,6 +3,11 @@
 import { useEffect, useRef, type RefObject } from 'react';
 
 const PAN_THRESHOLD = 5;
+// Vertical rubber-band limit (px) for the translateY fallback used when the
+// board has no native scroll overflow. Bounding it — and always snapping back
+// to 0 on mouseup — is what stops repeated drags from drifting the board
+// off-screen.
+const RUBBER_BAND_LIMIT = 64;
 const INTERACTIVE_SELECTOR =
   '[draggable="true"], button, a, input, select, textarea, [role="scrollbar"], [data-kanban-scrollbar-thumb]';
 
@@ -10,8 +15,10 @@ const INTERACTIVE_SELECTOR =
  * Attaches Figma/Miro-style click-and-drag panning to a Kanban scroll container.
  *
  * Horizontal panning uses the container's native scrollLeft.
- * Vertical panning uses the container's native scrollTop, which is naturally
- * clamped by the browser so panning can never drift past the content edges.
+ * Vertical panning uses scrollTop when the board overflows, otherwise applies
+ * a bounded, rubber-banded CSS translateY on the board so dragging still
+ * feels responsive. The translateY always snaps back to 0 on mouseup, so
+ * offsets can never accumulate across drags.
  *
  * Interactive elements (draggable cards, buttons, inputs, the custom scrollbar thumb)
  * are excluded so native HTML5 drag-and-drop and clicks keep working.
@@ -24,6 +31,8 @@ export function useKanbanPan(containerRef: RefObject<HTMLDivElement | null>, ena
     startY: 0,
     startScrollLeft: 0,
     startScrollTop: 0,
+    useTranslateY: false,
+    board: null as HTMLElement | null,
   });
 
   useEffect(() => {
@@ -31,6 +40,16 @@ export function useKanbanPan(containerRef: RefObject<HTMLDivElement | null>, ena
     if (!container || !enabled) return;
 
     const state = stateRef.current;
+
+    const getBoard = (): HTMLElement | null =>
+      container.querySelector('[data-kanban-board]') as HTMLElement | null;
+
+    const applyTranslateY = (offset: number, animate = false) => {
+      const board = state.board ?? getBoard();
+      if (!board) return;
+      board.style.transition = animate ? 'transform 0.15s ease-out' : '';
+      board.style.transform = offset === 0 ? '' : `translateY(${offset}px)`;
+    };
 
     const setPanningCursor = (panning: boolean) => {
       if (panning) {
@@ -69,11 +88,24 @@ export function useKanbanPan(containerRef: RefObject<HTMLDivElement | null>, ena
       // Horizontal: native scroll
       container.scrollLeft = state.startScrollLeft - deltaX;
 
-      // Vertical: native scroll, naturally clamped to the content bounds
-      container.scrollTop = state.startScrollTop - deltaY;
+      // Vertical: native scroll when possible, otherwise a bounded rubber-band
+      // translateY so dragging still feels responsive when the board has no
+      // overflow of its own.
+      if (state.useTranslateY) {
+        const raw = deltaY;
+        const clamped = Math.max(-RUBBER_BAND_LIMIT, Math.min(RUBBER_BAND_LIMIT, raw));
+        applyTranslateY(clamped);
+      } else {
+        container.scrollTop = state.startScrollTop - deltaY;
+      }
     };
 
     const handleMouseUp = () => {
+      // Always snap the translateY offset back to 0 so it can never persist
+      // (and accumulate) across drags.
+      if (state.useTranslateY) {
+        applyTranslateY(0, true);
+      }
       cleanupPanning();
       if (state.hasMoved) {
         setTimeout(() => { state.hasMoved = false; }, 0);
@@ -87,12 +119,16 @@ export function useKanbanPan(containerRef: RefObject<HTMLDivElement | null>, ena
       if (!target) return;
       if (target.closest(INTERACTIVE_SELECTOR)) return;
 
+      const canScrollVertically = container.scrollHeight > container.clientHeight;
+
       state.active = false;
       state.hasMoved = false;
       state.startX = event.clientX;
       state.startY = event.clientY;
       state.startScrollLeft = container.scrollLeft;
       state.startScrollTop = container.scrollTop;
+      state.useTranslateY = !canScrollVertically;
+      state.board = state.useTranslateY ? getBoard() : null;
 
       window.addEventListener('mousemove', handleMouseMove);
       window.addEventListener('mouseup', handleMouseUp);
@@ -112,6 +148,7 @@ export function useKanbanPan(containerRef: RefObject<HTMLDivElement | null>, ena
     return () => {
       container.removeEventListener('mousedown', handleMouseDown);
       container.removeEventListener('click', handleClickCapture, true);
+      applyTranslateY(0);
       cleanupPanning();
     };
   }, [containerRef, enabled]);

--- a/packages/projects/src/components/useKanbanPan.ts
+++ b/packages/projects/src/components/useKanbanPan.ts
@@ -10,8 +10,8 @@ const INTERACTIVE_SELECTOR =
  * Attaches Figma/Miro-style click-and-drag panning to a Kanban scroll container.
  *
  * Horizontal panning uses the container's native scrollLeft.
- * Vertical panning uses scrollTop when the board overflows, otherwise
- * applies a CSS translateY on the board so panning always feels responsive.
+ * Vertical panning uses the container's native scrollTop, which is naturally
+ * clamped by the browser so panning can never drift past the content edges.
  *
  * Interactive elements (draggable cards, buttons, inputs, the custom scrollbar thumb)
  * are excluded so native HTML5 drag-and-drop and clicks keep working.
@@ -24,9 +24,6 @@ export function useKanbanPan(containerRef: RefObject<HTMLDivElement | null>, ena
     startY: 0,
     startScrollLeft: 0,
     startScrollTop: 0,
-    startTranslateY: 0,
-    useTranslateY: false,
-    board: null as HTMLElement | null,
   });
 
   useEffect(() => {
@@ -34,19 +31,6 @@ export function useKanbanPan(containerRef: RefObject<HTMLDivElement | null>, ena
     if (!container || !enabled) return;
 
     const state = stateRef.current;
-
-    /** Current translateY offset persisted across drags. */
-    let translateY = 0;
-
-    const getBoard = (): HTMLElement | null =>
-      container.querySelector('[data-kanban-board]') as HTMLElement | null;
-
-    const applyTranslateY = (offset: number) => {
-      const board = state.board ?? getBoard();
-      if (!board) return;
-      translateY = offset;
-      board.style.transform = offset === 0 ? '' : `translateY(${offset}px)`;
-    };
 
     const setPanningCursor = (panning: boolean) => {
       if (panning) {
@@ -85,15 +69,8 @@ export function useKanbanPan(containerRef: RefObject<HTMLDivElement | null>, ena
       // Horizontal: native scroll
       container.scrollLeft = state.startScrollLeft - deltaX;
 
-      // Vertical: native scroll when possible, otherwise translateY
-      if (state.useTranslateY) {
-        const raw = state.startTranslateY + deltaY;
-        // Clamp: can only pull board upward (reveal lower content), min 0 means no
-        // downward shift past origin.
-        applyTranslateY(Math.min(0, raw));
-      } else {
-        container.scrollTop = state.startScrollTop - deltaY;
-      }
+      // Vertical: native scroll, naturally clamped to the content bounds
+      container.scrollTop = state.startScrollTop - deltaY;
     };
 
     const handleMouseUp = () => {
@@ -110,17 +87,12 @@ export function useKanbanPan(containerRef: RefObject<HTMLDivElement | null>, ena
       if (!target) return;
       if (target.closest(INTERACTIVE_SELECTOR)) return;
 
-      const canScrollVertically = container.scrollHeight > container.clientHeight;
-
       state.active = false;
       state.hasMoved = false;
       state.startX = event.clientX;
       state.startY = event.clientY;
       state.startScrollLeft = container.scrollLeft;
       state.startScrollTop = container.scrollTop;
-      state.useTranslateY = !canScrollVertically;
-      state.startTranslateY = translateY;
-      state.board = getBoard();
 
       window.addEventListener('mousemove', handleMouseMove);
       window.addEventListener('mouseup', handleMouseUp);
@@ -134,22 +106,12 @@ export function useKanbanPan(containerRef: RefObject<HTMLDivElement | null>, ena
       }
     };
 
-    /** Reset translateY on native scroll / wheel so the two don't fight. */
-    const handleScroll = () => {
-      if (translateY !== 0 && container.scrollHeight > container.clientHeight) {
-        applyTranslateY(0);
-      }
-    };
-
     container.addEventListener('mousedown', handleMouseDown);
     container.addEventListener('click', handleClickCapture, true);
-    container.addEventListener('scroll', handleScroll, { passive: true });
 
     return () => {
       container.removeEventListener('mousedown', handleMouseDown);
       container.removeEventListener('click', handleClickCapture, true);
-      container.removeEventListener('scroll', handleScroll);
-      applyTranslateY(0);
       cleanupPanning();
     };
   }, [containerRef, enabled]);


### PR DESCRIPTION
## Summary
Replaces CSS transform-based vertical panning with proper native scroll targeting. The original approach applied `translateY` transforms to the kanban board as a fallback when the container didn't overflow, which could drift content off-screen and conflicted with inner scroll areas (column task lists). The fix identifies which DOM ancestor actually owns vertical overflow—a column's task list, the container, or the page itself—and applies native scroll to that element. Browser scroll clamping ensures content never drifts and panning works smoothly across all layout configurations.

## Changes
- **Scroll target discovery**: Added `findVerticalScrollParent()` to walk up the DOM and locate the element with real vertical overflow (scrollHeight > clientHeight and overflow-y auto/scroll)
- **Removed CSS transform fallback**: Eliminated `applyTranslateY()`, `translateY` accumulator, `useTranslateY` flag, and related state (`startTranslateY`, `board` ref)
- **Simplified state**: Replaced multiple transform-tracking properties with a single `verticalTarget` reference to the scroll owner
- **Native scroll on target**: Vertical panning now applies `scrollTop` changes to the discovered target element instead of the container or transforms
- **Removed scroll listener**: Deleted `handleScroll()` that was mediating conflicts between transforms and native scrolling

## Testing
Manual verification on local kanban boards:
- Single-column layout (vertical scroll on task list) — panning within column boundaries works smoothly
- Multi-column layout with container-level scroll — panning reaches top/bottom without off-screen drift
- Compact content (page-level scroll) — panning falls through to document scroll when no container overflow exists