### PR TITLE
Make manual scan reachable and asset provenance visible

### DIFF
--- a/ee/mobile/src/features/inventory/components/ScanView.test.tsx
+++ b/ee/mobile/src/features/inventory/components/ScanView.test.tsx
@@ -81,4 +81,31 @@ describe("ScanView", () => {
       tree.root.findAll((node) => node.props.accessibilityLabel === "inventory-scan-open-settings").length,
     ).toBeGreaterThan(0);
   });
+
+  it("lets you enter a code manually when the camera is unavailable", async () => {
+    permissionGranted = false;
+    canAskAgain = false;
+    const tree = renderView();
+
+    // No camera: the manual-entry escape hatch is still offered on the permission screen.
+    const enterManually = tree.root.find(
+      (node) => node.props.testID === "inventory-scan-enter-manually-permission",
+    );
+    act(() => enterManually.props.onPress());
+
+    const input = tree.root.find((node) => node.props.accessibilityLabel === "inventory-scan-manual-input");
+    act(() => input.props.onChangeText("SN-LIFE-001"));
+    await act(async () => {
+      tree.root.find((node) => node.props.accessibilityLabel === "inventory-scan-manual-submit").props.onPress();
+    });
+
+    expect(mockLookup).toHaveBeenCalledWith(expect.anything(), expect.objectContaining({ code: "SN-LIFE-001" }));
+  });
+
+  it("offers a visible manual-entry button over the live camera", () => {
+    const tree = renderView();
+    expect(
+      tree.root.findAll((node) => node.props.testID === "inventory-scan-enter-manually").length,
+    ).toBeGreaterThan(0);
+  });
 });

--- a/ee/mobile/src/features/inventory/components/ScanView.tsx
+++ b/ee/mobile/src/features/inventory/components/ScanView.tsx
@@ -124,40 +124,14 @@ export function ScanView() {
     return null;
   }
 
-  if (!permission.granted) {
-    return (
-      <View style={{ flex: 1, justifyContent: "center", padding: theme.spacing.xl, gap: theme.spacing.md }}>
-        <Text style={{ ...theme.typography.title, color: theme.colors.text, textAlign: "center" }}>
-          {t("scan.permissionTitle", "Camera access needed")}
-        </Text>
-        <Text style={{ ...theme.typography.body, color: theme.colors.textSecondary, textAlign: "center" }}>
-          {t("scan.permissionBody", "Allow camera access to scan barcodes, serial numbers, and MAC labels.")}
-        </Text>
-        {permission.canAskAgain ? (
-          <PrimaryButton onPress={() => void requestPermission()} accessibilityLabel="inventory-scan-request-permission">
-            {t("scan.permissionTitle", "Camera access needed")}
-          </PrimaryButton>
-        ) : (
-          <PrimaryButton onPress={() => void Linking.openSettings()} accessibilityLabel="inventory-scan-open-settings">
-            {t("scan.openSettings", "Open Settings")}
-          </PrimaryButton>
-        )}
-      </View>
-    );
-  }
+  const showCamera = !manualMode && permission.granted && isFocused;
 
   return (
     <View style={{ flex: 1 }}>
       <View style={{ flex: 1 }}>
-        {!manualMode && isFocused ? (
-          <CameraView
-            style={{ flex: 1 }}
-            facing="back"
-            enableTorch={torchOn}
-            barcodeScannerSettings={{ barcodeTypes: [...INVENTORY_BARCODE_TYPES] }}
-            onBarcodeScanned={result ? undefined : onBarcodeScanned}
-          />
-        ) : (
+        {manualMode ? (
+          // Manual entry works without a camera — emulators, denied permission,
+          // a damaged lens, or a code the scanner can't read.
           <View style={{ flex: 1, justifyContent: "center", padding: theme.spacing.xl, gap: theme.spacing.md }}>
             <TextInput
               value={manualCode}
@@ -174,16 +148,51 @@ export function ScanView() {
             >
               {t("segments.scan", "Scan")}
             </PrimaryButton>
+            {permission.granted ? (
+              <Text
+                onPress={() => setManualMode(false)}
+                testID="inventory-scan-back-to-camera"
+                style={{ ...theme.typography.body, color: theme.colors.primary, textAlign: "center" }}
+              >
+                {t("scan.useCamera", "Use the camera instead")}
+              </Text>
+            ) : null}
+          </View>
+        ) : !permission.granted ? (
+          <View style={{ flex: 1, justifyContent: "center", padding: theme.spacing.xl, gap: theme.spacing.md }}>
+            <Text style={{ ...theme.typography.title, color: theme.colors.text, textAlign: "center" }}>
+              {t("scan.permissionTitle", "Camera access needed")}
+            </Text>
+            <Text style={{ ...theme.typography.body, color: theme.colors.textSecondary, textAlign: "center" }}>
+              {t("scan.permissionBody", "Allow camera access to scan barcodes, serial numbers, and MAC labels.")}
+            </Text>
+            {permission.canAskAgain ? (
+              <PrimaryButton onPress={() => void requestPermission()} accessibilityLabel="inventory-scan-request-permission">
+                {t("scan.grantAccess", "Allow camera access")}
+              </PrimaryButton>
+            ) : (
+              <PrimaryButton onPress={() => void Linking.openSettings()} accessibilityLabel="inventory-scan-open-settings">
+                {t("scan.openSettings", "Open Settings")}
+              </PrimaryButton>
+            )}
             <Text
-              onPress={() => setManualMode(false)}
-              testID="inventory-scan-back-to-camera"
-              style={{ ...theme.typography.body, color: theme.colors.primary, textAlign: "center" }}
+              onPress={() => setManualMode(true)}
+              testID="inventory-scan-enter-manually-permission"
+              style={{ ...theme.typography.body, color: theme.colors.primary, textAlign: "center", paddingVertical: theme.spacing.sm }}
             >
-              {t("scan.rescan", "Scan again")}
+              {t("scan.manualEntry", "Enter code manually")}
             </Text>
           </View>
-        )}
-        {!manualMode ? (
+        ) : isFocused ? (
+          <CameraView
+            style={{ flex: 1 }}
+            facing="back"
+            enableTorch={torchOn}
+            barcodeScannerSettings={{ barcodeTypes: [...INVENTORY_BARCODE_TYPES] }}
+            onBarcodeScanned={result ? undefined : onBarcodeScanned}
+          />
+        ) : null}
+        {showCamera ? (
           <>
             <View pointerEvents="none" style={{ position: "absolute", top: 0, left: 0, right: 0, bottom: 0, justifyContent: "center", alignItems: "center" }}>
               <View
@@ -196,11 +205,9 @@ export function ScanView() {
                   opacity: 0.9,
                 }}
               />
-              <Text style={{ ...theme.typography.caption, color: "#ffffff", marginTop: theme.spacing.md, textShadowColor: "#000000", textShadowRadius: 4 }}>
-                {t("scan.instruction", "Point the camera at a barcode")}
-              </Text>
             </View>
-            <View style={{ position: "absolute", top: theme.spacing.md, right: theme.spacing.md, flexDirection: "row", gap: theme.spacing.sm }}>
+            {/* Dark backing so the white icons stay visible on any feed (incl. a blank simulator). */}
+            <View style={{ position: "absolute", top: theme.spacing.md, right: theme.spacing.md, flexDirection: "row", gap: theme.spacing.sm, backgroundColor: "rgba(0,0,0,0.45)", borderRadius: theme.borderRadius.md, paddingHorizontal: theme.spacing.xs }}>
               <IconButton
                 onPress={() => setTorchOn((value) => !value)}
                 accessibilityLabel={torchOn ? t("scan.torchOff", "Turn flashlight off") : t("scan.torchOn", "Turn flashlight on")}
@@ -211,6 +218,24 @@ export function ScanView() {
                 accessibilityLabel={t("scan.manualEntry", "Enter code manually")}
                 icon={<MaterialCommunityIcons name="keyboard-outline" size={22} color="#ffffff" />}
               />
+            </View>
+            {/* Always-visible manual-entry affordance, styled so it reads on any feed. */}
+            <View style={{ position: "absolute", left: 0, right: 0, bottom: theme.spacing.xl, alignItems: "center" }}>
+              <Text
+                onPress={() => setManualMode(true)}
+                testID="inventory-scan-enter-manually"
+                style={{
+                  ...theme.typography.body,
+                  color: "#ffffff",
+                  backgroundColor: "rgba(0,0,0,0.6)",
+                  paddingHorizontal: theme.spacing.lg,
+                  paddingVertical: theme.spacing.sm,
+                  borderRadius: theme.borderRadius.md,
+                  overflow: "hidden",
+                }}
+              >
+                {t("scan.manualEntry", "Enter code manually")}
+              </Text>
             </View>
           </>
         ) : null}

--- a/ee/mobile/src/i18n/locales/en/assets.json
+++ b/ee/mobile/src/i18n/locales/en/assets.json
@@ -91,5 +91,10 @@
     "saved": "Note added",
     "saveFailed": "Couldn't save note",
     "empty": "No notes on this device yet."
+  },
+  "provenance": {
+    "title": "Stock provenance",
+    "body": "This device was deployed from your stock.",
+    "viewHistory": "View stock history"
   }
 }

--- a/ee/mobile/src/i18n/locales/en/inventory.json
+++ b/ee/mobile/src/i18n/locales/en/inventory.json
@@ -32,7 +32,9 @@
     "assetKind": "Asset",
     "viewAsset": "View asset",
     "createProduct": "Create a new product",
-    "registerAsset": "Register as a client's asset"
+    "registerAsset": "Register as a client's asset",
+    "useCamera": "Use the camera instead",
+    "grantAccess": "Allow camera access"
   },
   "stock": {
     "title": "Stock",

--- a/ee/mobile/src/screens/AssetDetailScreen.test.tsx
+++ b/ee/mobile/src/screens/AssetDetailScreen.test.tsx
@@ -112,13 +112,13 @@ function ok<T>(data: T) {
   return { ok: true as const, status: 200, data };
 }
 
-async function renderScreen(): Promise<ReactTestRenderer> {
+async function renderScreen(navigate: ReturnType<typeof vi.fn> = vi.fn()): Promise<ReactTestRenderer> {
   let tree!: ReactTestRenderer;
   await act(async () => {
     tree = create(
       <AssetDetailScreen
         route={{ key: "r", name: "AssetDetail", params: { assetId: "asset-1", assetName: "Device" } } as never}
-        navigation={{ navigate: vi.fn() } as never}
+        navigation={{ navigate } as never}
       />,
     );
   });
@@ -277,6 +277,22 @@ describe("AssetDetailScreen", () => {
         }),
       }),
     );
+  });
+
+  it("links to the stock movement trail for an inventory-sourced asset", async () => {
+    mockGetAsset.mockResolvedValue(ok({ data: { ...asset, stock_unit_id: "unit-7" } }));
+    const navigate = vi.fn();
+    const tree = await renderScreen(navigate);
+
+    const link = hosts(tree, "asset-detail-view-provenance")[0];
+    expect(link).toBeTruthy();
+    act(() => link.props.onPress());
+    expect(navigate).toHaveBeenCalledWith("StockUnitDetail", { unitId: "unit-7" });
+  });
+
+  it("hides stock provenance for a manually created asset", async () => {
+    const tree = await renderScreen();
+    expect(hosts(tree, "asset-detail-view-provenance").length).toBe(0);
   });
 
   it("renders installed software when the RMM reports it", async () => {

--- a/ee/mobile/src/screens/AssetDetailScreen.tsx
+++ b/ee/mobile/src/screens/AssetDetailScreen.tsx
@@ -388,6 +388,25 @@ export function AssetDetailScreen({ route, navigation }: Props) {
           )}
         </Card>
 
+        {/* Stock provenance — only for assets that came from inventory. Links to
+            the originating unit's movement trail (received → transfers → install). */}
+        {asset.stock_unit_id ? (
+          <Card>
+            <SectionTitle theme={theme}>{t("provenance.title", "Stock provenance")}</SectionTitle>
+            <Text style={{ ...theme.typography.body, color: theme.colors.textSecondary, marginTop: theme.spacing.xs }}>
+              {t("provenance.body", "This device was deployed from your stock.")}
+            </Text>
+            <Text
+              onPress={() => navigation.navigate("StockUnitDetail", { unitId: asset.stock_unit_id as string })}
+              testID="asset-detail-view-provenance"
+              accessibilityRole="button"
+              style={{ ...theme.typography.body, color: theme.colors.primary, marginTop: theme.spacing.sm }}
+            >
+              {t("provenance.viewHistory", "View stock history")}
+            </Text>
+          </Card>
+        ) : null}
+
         {/* Service history */}
         <Card>
           <SectionTitle theme={theme}>{t("history.title", "Service history")}</SectionTitle>


### PR DESCRIPTION
Manual code entry no longer hides behind a working camera: add an always-visible Enter-code-manually control over the feed (the white icons vanished on a blank simulator), keep it on the permission screen, and let it work with no camera granted at all.

Give the asset screen a Stock provenance card that links to the originating stock unit's movement trail, shown only for inventory-sourced assets — so the received -> transferred -> installed history is reachable from the asset, not just from a scan.