### PR TITLE
Harden server action and API route authorization

### DIFF
--- a/packages/auth/src/actions/policyActions.ts
+++ b/packages/auth/src/actions/policyActions.ts
@@ -112,6 +112,67 @@ function tenantScopedTable(
   return tenantDb(conn, tenant).table(table);
 }
 
+/**
+ * Client-portal callers may only assign/remove client-flagged roles on client
+ * users of their own company. The role.msp/user_type compatibility checks
+ * alone are not sufficient: the client portal 'Admin' role holds
+ * client-flagged 'user:update'/'client:update' permissions, and without a
+ * caller-type + same-company check a portal admin could re-role MSP staff or
+ * users of other companies. Internal callers are unaffected (RBAC-gated by
+ * the callers). Returns an error to propagate, or null when in scope.
+ */
+async function checkClientPortalRoleScope(
+  currentUser: IUserWithRoles,
+  tenant: string,
+  trx: Knex.Transaction,
+  targetUser: { user_type?: string; contact_id?: string | null } | undefined,
+  role: IRole | undefined
+): Promise<AuthActionError | null> {
+  if (currentUser.user_type !== 'client') {
+    return null;
+  }
+
+  if (!targetUser || !role) {
+    return null; // existence errors are reported by the caller
+  }
+
+  if (!role.client) {
+    return permissionError('Permission denied: Client portal admins may only manage client portal roles.');
+  }
+
+  if (targetUser.user_type !== 'client') {
+    return permissionError('Permission denied: Client portal admins may only manage client portal users.');
+  }
+
+  if (!currentUser.contact_id) {
+    return permissionError('Permission denied: Client portal admin access is required.');
+  }
+
+  const scopedDb = tenantDb(trx, tenant);
+  const [actorContact, targetContact] = await Promise.all([
+    scopedDb.table('contacts')
+      .where({ contact_name_id: currentUser.contact_id })
+      .select('client_id', 'is_client_admin')
+      .first(),
+    targetUser.contact_id
+      ? scopedDb.table('contacts')
+          .where({ contact_name_id: targetUser.contact_id })
+          .select('client_id')
+          .first()
+      : Promise.resolve(undefined),
+  ]);
+
+  if (!actorContact?.is_client_admin || !actorContact.client_id) {
+    return permissionError('Permission denied: Client portal admin access is required.');
+  }
+
+  if (!targetContact?.client_id || targetContact.client_id !== actorContact.client_id) {
+    return permissionError('Permission denied: Cannot manage users for another client.');
+  }
+
+  return null;
+}
+
 // Role actions
 export const createRole = withAuth(async (user, { tenant }, roleName: string, description: string, msp: boolean = true, client: boolean = false): Promise<IRole | AuthActionError> => {
   try {
@@ -323,6 +384,13 @@ export const assignRoleToUser = withAuth(async (currentUser, { tenant }, userId:
             return actionError('Role not found. Refresh the role list and try again.');
         }
 
+        // Client-portal callers: only client-flagged roles on client users of
+        // their own company. Internal callers are unaffected.
+        const clientScopeError = await checkClientPortalRoleScope(currentUser, tenant, trx, user, role);
+        if (clientScopeError) {
+            return clientScopeError;
+        }
+
         // Validate role compatibility based on user type
         if (user.user_type === 'internal' && !role.msp) {
             return actionError('Cannot assign a client portal role to an MSP user.');
@@ -362,6 +430,16 @@ export const removeRoleFromUser = withAuth(async (currentUser, { tenant }, userI
 
         if (!role) {
             return actionError('Role not found. Refresh the role list and try again.');
+        }
+
+        // Client-portal callers: only client-flagged roles on client users of
+        // their own company. Internal callers are unaffected.
+        const targetUser = currentUser.user_type === 'client'
+            ? await tenantScopedTable(trx, 'users', tenant).where({ user_id: userId }).first()
+            : undefined;
+        const clientScopeError = await checkClientPortalRoleScope(currentUser, tenant, trx, targetUser, role);
+        if (clientScopeError) {
+            return clientScopeError;
         }
 
         await tenantScopedTable(trx, 'user_roles', tenant).where({ user_id: userId, role_id: roleId }).del();

--- a/packages/billing/src/actions/billingClientLocationActions.ts
+++ b/packages/billing/src/actions/billingClientLocationActions.ts
@@ -71,6 +71,25 @@ export const getActiveClientLocationsForBilling = withAuth(async (
 
   const { knex } = await createTenantKnex();
 
+  // Client portal users hold client-flagged copies of client:read, so the
+  // permission check alone does not scope results — client callers may only
+  // query their own client's locations.
+  if (user.user_type === 'client') {
+    let portalClientId = typeof user.clientId === 'string' && user.clientId.length > 0
+      ? user.clientId
+      : null;
+    if (!portalClientId && user.contact_id) {
+      const contact = await tenantDb(knex, tenant).table('contacts')
+        .where({ contact_name_id: user.contact_id })
+        .select('client_id')
+        .first<{ client_id: string | null }>();
+      portalClientId = contact?.client_id ?? null;
+    }
+    if (!portalClientId || portalClientId !== clientId) {
+      return permissionError('Permission denied: cannot access locations for another client');
+    }
+  }
+
   return withTransaction(knex, async (trx: Knex.Transaction) => {
     return tenantScopedTable(trx, tenant, 'client_locations')
       .select<BillingLocationSummary[]>(

--- a/packages/billing/src/actions/invoiceQueries.ts
+++ b/packages/billing/src/actions/invoiceQueries.ts
@@ -20,6 +20,65 @@ import {
   type ActionPermissionError,
 } from '@alga-psa/ui/lib/errorHandling';
 
+type InvoiceQueryUser = {
+  user_id: string;
+  user_type?: string | null;
+  contact_id?: string | null;
+  clientId?: string | null;
+};
+
+/**
+ * Resolve the client_id a client-portal caller is scoped to (from the session
+ * user or their contact record). Only call for user_type === 'client'.
+ */
+async function getClientPortalUserClientId(
+  knex: Knex | Knex.Transaction,
+  tenant: string,
+  user: InvoiceQueryUser
+): Promise<string | null> {
+  if (typeof user.clientId === 'string' && user.clientId.length > 0) {
+    return user.clientId;
+  }
+  if (!user.contact_id) {
+    return null;
+  }
+  const contact = await tenantDb(knex, tenant).table('contacts')
+    .where({ contact_name_id: user.contact_id })
+    .select('client_id')
+    .first<{ client_id: string | null }>();
+  return contact?.client_id ?? null;
+}
+
+/**
+ * Client portal users hold client-flagged copies of billing:read, so the
+ * permission check alone does not scope results to their own client. For
+ * client callers, verify the target invoice belongs to their client; drafts
+ * are never exposed to the portal (mirrors validateClientInvoiceAccess in
+ * client-portal's client-billing actions). Internal callers are unaffected.
+ */
+async function assertClientPortalInvoiceAccess(
+  knex: Knex | Knex.Transaction,
+  tenant: string,
+  user: InvoiceQueryUser,
+  invoiceId: string
+): Promise<ActionPermissionError | null> {
+  if (user.user_type !== 'client') {
+    return null;
+  }
+  const portalClientId = await getClientPortalUserClientId(knex, tenant, user);
+  if (!portalClientId) {
+    return permissionError('Permission denied: invoice access denied');
+  }
+  const invoice = await tenantDb(knex, tenant).table('invoices')
+    .where({ invoice_id: invoiceId })
+    .whereNot('status', 'draft')
+    .first('client_id');
+  if (!invoice || invoice.client_id !== portalClientId) {
+    return permissionError('Permission denied: invoice access denied');
+  }
+  return null;
+}
+
 // Types for paginated invoice fetching
 export interface FetchInvoicesOptions {
   page?: number;
@@ -218,6 +277,13 @@ export const getInvoiceRoutingState = withAuth(async (
     return { exists: false, isDraft: false };
   }
   const { knex } = await createTenantKnex();
+  if (user.user_type === 'client') {
+    // Client portal callers must not probe invoices outside their own client.
+    const denied = await assertClientPortalInvoiceAccess(knex, tenant, user, invoiceId);
+    if (denied) {
+      return { exists: false, isDraft: false };
+    }
+  }
   const row = await knex('invoices')
     .where({ tenant, invoice_id: invoiceId })
     .select('status', 'finalized_at')
@@ -236,6 +302,10 @@ export const fetchInvoicesPaginated = withAuth(async (
 ): Promise<PaginatedInvoicesResult | ActionPermissionError> => {
   if (!await hasPermission(user, 'billing', 'read')) {
     return permissionError('Permission denied: billing read required');
+  }
+  // This listing spans all clients; the portal uses fetchInvoicesByClient instead.
+  if (user.user_type === 'client') {
+    return permissionError('Permission denied: operation not available in client portal');
   }
 
   const {
@@ -489,7 +559,16 @@ export const fetchInvoicesByClient = withAuth(async (
     console.log(`Fetching invoices for client: ${clientId}`);
 
     const { knex } = await createTenantKnex();
-    
+
+    // Client portal callers may only fetch their own client's invoices —
+    // never trust the caller-supplied clientId.
+    if (user.user_type === 'client') {
+      const portalClientId = await getClientPortalUserClientId(knex, tenant, user);
+      if (!portalClientId || portalClientId !== clientId) {
+        return permissionError('Permission denied: cannot access invoices for another client');
+      }
+    }
+
     // Get invoices with client info and location data in a single query, filtered by client_id
     const invoices = await withTransaction(knex, async (trx: Knex.Transaction) => {
       const db = tenantDb(trx, tenant);
@@ -598,6 +677,19 @@ export const fetchInvoicesByContract = withAuth(async (
   try {
     const { knex } = await createTenantKnex();
 
+    // Client portal callers may only fetch invoices for their own client's contracts.
+    if (user.user_type === 'client') {
+      const portalClientId = await getClientPortalUserClientId(knex, tenant, user);
+      const contract = portalClientId
+        ? await tenantDb(knex, tenant).table('client_contracts')
+            .where({ client_contract_id: contractId })
+            .first('client_id')
+        : null;
+      if (!portalClientId || !contract || contract.client_id !== portalClientId) {
+        return permissionError('Permission denied: cannot access invoices for another client');
+      }
+    }
+
     const invoices = await withTransaction(knex, async (trx: Knex.Transaction) => {
       const db = tenantDb(trx, tenant);
       const query = db.table('invoices');
@@ -665,6 +757,13 @@ export const getInvoiceForRendering = withAuth(async (
 
     const { knex } = await createTenantKnex();
 
+    // Portal components call this action directly (bypassing the
+    // ownership-checked client-portal wrapper), so scope client callers here.
+    const denied = await assertClientPortalInvoiceAccess(knex, tenant, user, invoiceId);
+    if (denied) {
+      return denied;
+    }
+
     // Existing-invoice preview refresh and rerender must hydrate through the full
     // detail-aware reader so canonical recurring periods survive after persistence.
     const invoice = await Invoice.getFullInvoiceById(knex, tenant, invoiceId);
@@ -690,6 +789,12 @@ export const getEnrichedInvoiceViewModel = withAuth(async (
   }
 
   const { knex } = await createTenantKnex();
+
+  const denied = await assertClientPortalInvoiceAccess(knex, tenant, user, invoiceId);
+  if (denied) {
+    return denied;
+  }
+
   let loadedInvoice: InvoiceViewModel;
   try {
     loadedInvoice = await Invoice.getFullInvoiceById(knex, tenant, invoiceId);
@@ -733,7 +838,18 @@ export const getResolvedInvoiceTemplateId = withAuth(async (
   { tenant },
   invoiceId: string
 ): Promise<string | null> => {
+  if (!await hasPermission(user, 'billing', 'read')) {
+    return null;
+  }
+
   const { knex } = await createTenantKnex();
+
+  // Same client-portal scoping as the other invoice readers: do not let a
+  // portal caller probe invoices outside their own client.
+  const denied = await assertClientPortalInvoiceAccess(knex, tenant, user, invoiceId);
+  if (denied) {
+    return null;
+  }
 
   const db = tenantDb(knex, tenant);
 
@@ -790,6 +906,11 @@ export const getInvoicePurchaseOrderSummary = withAuth(async (
 
   const { knex } = await createTenantKnex();
 
+  const denied = await assertClientPortalInvoiceAccess(knex, tenant, user, invoiceId);
+  if (denied) {
+    return denied;
+  }
+
   const invoice = await tenantDb(knex, tenant).table('invoices')
     .where({ invoice_id: invoiceId })
     .select('invoice_id', 'client_contract_id', 'po_number')
@@ -842,6 +963,10 @@ export const getInvoiceLineItems = withAuth(async (
 
   try {
     const { knex } = await createTenantKnex();
+    const denied = await assertClientPortalInvoiceAccess(knex, tenant, user, invoiceId);
+    if (denied) {
+      return denied;
+    }
     console.log('Fetching line items for invoice:', invoiceId);
     const items = await Invoice.getInvoiceItems(knex, tenant, invoiceId);
     console.log(`Got ${items.length} line items`);

--- a/packages/billing/src/actions/voidInvoiceActions.ts
+++ b/packages/billing/src/actions/voidInvoiceActions.ts
@@ -6,6 +6,7 @@ import { createTenantKnex } from '@alga-psa/db';
 import { Knex } from 'knex';
 import { v4 as uuidv4 } from 'uuid';
 import { withAuth } from '@alga-psa/auth';
+import { hasPermission } from '@alga-psa/auth/rbac';
 import { enqueueInvoiceVoid } from '../services/accountingSync/syncProducers';
 
 // Exported for testing
@@ -80,6 +81,15 @@ export const voidInvoice = withAuth(async (
   invoiceId: string,
   reason: string
 ): Promise<VoidInvoiceResult> => {
+  // Voiding reverses credits and pushes voids to accounting integrations —
+  // internal MSP users with invoice update permission only.
+  if (user.user_type === 'client') {
+    return { success: false, error: 'Permission denied: operation not available in client portal' };
+  }
+  if (!await hasPermission(user, 'invoice', 'update')) {
+    return { success: false, error: 'Permission denied: invoice update required' };
+  }
+
   const trimmedReason = reason?.trim();
   if (!trimmedReason) {
     return { success: false, error: 'A reason is required to void an invoice.' };

--- a/packages/client-portal/src/actions/client-portal-actions/appointmentRequestActions.ts
+++ b/packages/client-portal/src/actions/client-portal-actions/appointmentRequestActions.ts
@@ -853,6 +853,24 @@ export const updateAppointmentRequest = withAuth(async (
       return { success: false, error: 'Service not found' };
     }
 
+    // If ticket_id provided, verify it exists and belongs to the client
+    // (mirrors the create-path validation — the update path previously wrote
+    // the caller-supplied ticket_id without any ownership check).
+    if (validatedData.ticket_id) {
+      const ticket = await withTransaction(db, async (trx: Knex.Transaction) => {
+        return await tenantDb(trx, tenant).table('tickets')
+          .where({
+            ticket_id: validatedData.ticket_id,
+            client_id: clientId
+          })
+          .first();
+      });
+
+      if (!ticket) {
+        return { success: false, error: 'Ticket not found or does not belong to your organization' };
+      }
+    }
+
     // Update the appointment request
     await withTransaction(db, async (trx: Knex.Transaction) => {
       await tenantDb(trx, tenant).table('appointment_requests')

--- a/packages/client-portal/src/actions/client-portal-actions/client-billing.ts
+++ b/packages/client-portal/src/actions/client-portal-actions/client-billing.ts
@@ -615,7 +615,28 @@ export const getClientInvoiceLineItems = withAuth(async (user, { tenant }, invoi
  * Get invoice templates
  */
 export const getClientInvoiceTemplates = withAuth(async (user, { tenant }): Promise<ClientBillingActionResult<IInvoiceTemplate[]>> => {
+  const knex = await getConnection(tenant);
+
   try {
+    // Same client-context + billing read gate as the other client billing actions
+    const accessError = await withTransaction(knex, async (trx: Knex.Transaction) => {
+      const clientId = await getClientIdFromUser(trx, user, tenant);
+      if (!clientId) {
+        return permissionError('Unauthorized');
+      }
+
+      const hasAccess = await hasBillingPermission(trx, user, tenant);
+      if (!hasAccess) {
+        return permissionError('Unauthorized to access invoice data');
+      }
+
+      return null;
+    });
+
+    if (accessError) {
+      return accessError;
+    }
+
     // Get all templates (both standard and tenant-specific)
     const templates = await getInvoiceTemplates();
     if (isClientBillingActionError(templates)) {
@@ -834,8 +855,32 @@ async function pollJobUntilComplete(
  * Get job status for polling - used to check if PDF generation is complete
  */
 export const getClientJobStatus = withAuth(async (user, { tenant }, jobId: string): Promise<ClientBillingActionResult<ClientJobStatus>> => {
+  const knex = await getConnection(tenant);
+
   try {
-    return await getJobStatus(jobId, tenant);
+    return await withTransaction(knex, async (trx: Knex.Transaction) => {
+      const clientId = await getClientIdFromUser(trx, user, tenant);
+      if (!clientId) {
+        return permissionError('Unauthorized');
+      }
+
+      const hasAccess = await hasBillingPermission(trx, user, tenant);
+      if (!hasAccess) {
+        return permissionError('Unauthorized to access invoice data');
+      }
+
+      // Jobs carry no client context — restrict access to jobs the caller
+      // created so a portal user cannot read other users' generated artifact
+      // fileIds. Report foreign/missing jobs identically to avoid an oracle.
+      const job = await tenantDb(trx, tenant).table('jobs')
+        .where({ job_id: jobId })
+        .first('user_id');
+      if (!job || job.user_id !== user.user_id) {
+        return actionError('Job not found');
+      }
+
+      return await getJobStatus(jobId, tenant);
+    });
   } catch (error) {
     const expected = billingActionErrorFrom(error);
     if (expected) {

--- a/packages/client-portal/src/actions/client-portal-actions/client-tickets.responseSource.test.ts
+++ b/packages/client-portal/src/actions/client-portal-actions/client-tickets.responseSource.test.ts
@@ -36,6 +36,11 @@ vi.mock('@alga-psa/documents/lib/blocknoteUtils', () => ({
     convertBlockNoteToMarkdownMock(...args),
 }));
 
+vi.mock('@alga-psa/formatting/blocknoteUtils', () => ({
+  convertBlockNoteToMarkdown: (...args: any[]) =>
+    convertBlockNoteToMarkdownMock(...args),
+}));
+
 vi.mock('@alga-psa/event-bus/publishers', () => ({
   publishEvent: (...args: any[]) => publishEventMock(...args),
 }));
@@ -170,5 +175,210 @@ describe('addClientTicketComment response source metadata', () => {
 
     expect(result).toBe(true);
     expect(metadata.responseSource).toBe('client_portal');
+  });
+
+  it('T019: forces is_internal=false on the comment and thread even when the caller passes true', async () => {
+    const commentThreadsInsertMock = vi.fn().mockResolvedValue(undefined);
+    const commentsInsertMock = vi.fn((payload: any) => ({
+      returning: vi.fn().mockResolvedValue([
+        {
+          comment_id: 'comment-1',
+          ...payload,
+        },
+      ]),
+    }));
+
+    withTransactionMock.mockImplementation(
+      async (_db: any, callback: (trx: any) => Promise<any>) => {
+        const trx = Object.assign(
+          (table: string) => {
+            if (table === 'users') {
+              return {
+                where: () => ({
+                  first: async () => ({
+                    contact_id: 'contact-1',
+                    first_name: 'Client',
+                    last_name: 'User',
+                  }),
+                }),
+              };
+            }
+
+            if (table === 'contacts') {
+              return {
+                where: () => ({
+                  first: async () => ({
+                    contact_name_id: 'contact-1',
+                    client_id: 'client-1',
+                    portal_visibility_group_id: null,
+                  }),
+                }),
+              };
+            }
+
+            if (table === 'tickets as t') {
+              const builder: any = {
+                select: vi.fn(() => builder),
+                where: vi.fn(() => builder),
+                modify: vi.fn((cb: (query: any) => void) => {
+                  cb(builder);
+                  return builder;
+                }),
+                first: vi.fn().mockResolvedValue({
+                  ticket_id: 'ticket-1',
+                  board_id: 'board-1',
+                  client_id: 'client-1',
+                }),
+              };
+              return builder;
+            }
+
+            if (table === 'comment_threads') {
+              return {
+                insert: commentThreadsInsertMock,
+              };
+            }
+
+            if (table === 'comments') {
+              return {
+                insert: commentsInsertMock,
+              };
+            }
+
+            if (table === 'tickets') {
+              return {
+                where: vi.fn().mockReturnValue({
+                  update: vi.fn().mockResolvedValue(1),
+                }),
+              };
+            }
+
+            throw new Error(`Unexpected table: ${table}`);
+          },
+          {
+            raw: vi.fn().mockResolvedValue({
+              rows: [{ comment_id: 'comment-1', thread_id: 'thread-1' }],
+            }),
+          }
+        );
+
+        return callback(trx);
+      }
+    );
+
+    const { addClientTicketComment } = await import('./client-tickets');
+
+    const result = await addClientTicketComment(
+      'ticket-1',
+      '[{"type":"paragraph","content":[{"type":"text","text":"Hello","styles":{}}]}]',
+      true,
+      false
+    );
+
+    expect(result).toBe(true);
+    expect(commentThreadsInsertMock.mock.calls[0][0].is_internal).toBe(false);
+    expect(commentsInsertMock.mock.calls[0][0].is_internal).toBe(false);
+  });
+
+  it('T020: updateClientTicketComment only persists the note body, ignoring caller-supplied fields', async () => {
+    const commentsUpdateMock = vi.fn().mockResolvedValue(1);
+
+    withTransactionMock.mockImplementation(
+      async (_db: any, callback: (trx: any) => Promise<any>) => {
+        const trx = Object.assign(
+          (table: string) => {
+            if (table === 'users') {
+              return {
+                where: () => ({
+                  first: async () => ({
+                    contact_id: 'contact-1',
+                    first_name: 'Client',
+                    last_name: 'User',
+                  }),
+                }),
+              };
+            }
+
+            if (table === 'contacts') {
+              return {
+                where: () => ({
+                  first: async () => ({
+                    contact_name_id: 'contact-1',
+                    client_id: 'client-1',
+                    portal_visibility_group_id: null,
+                  }),
+                }),
+              };
+            }
+
+            if (table === 'tickets as t') {
+              const builder: any = {
+                select: vi.fn(() => builder),
+                where: vi.fn(() => builder),
+                modify: vi.fn((cb: (query: any) => void) => {
+                  cb(builder);
+                  return builder;
+                }),
+                first: vi.fn().mockResolvedValue({
+                  ticket_id: 'ticket-1',
+                  board_id: 'board-1',
+                  client_id: 'client-1',
+                }),
+              };
+              return builder;
+            }
+
+            if (table === 'comments') {
+              return {
+                where: vi.fn((criteria: any) => {
+                  if (criteria && 'user_id' in criteria) {
+                    // Ownership lookup: comment_id + user_id
+                    return {
+                      first: vi.fn().mockResolvedValue({
+                        comment_id: 'comment-1',
+                        ticket_id: 'ticket-1',
+                        user_id: 'user-1',
+                      }),
+                    };
+                  }
+                  return {
+                    update: commentsUpdateMock,
+                  };
+                }),
+              };
+            }
+
+            throw new Error(`Unexpected table: ${table}`);
+          },
+          {
+            raw: vi.fn().mockResolvedValue({ rows: [] }),
+          }
+        );
+
+        return callback(trx);
+      }
+    );
+
+    const { updateClientTicketComment } = await import('./client-tickets');
+
+    const result = await updateClientTicketComment('comment-1', {
+      note: '[{"type":"paragraph","content":[{"type":"text","text":"Edited","styles":{}}]}]',
+      ticket_id: 'ticket-evil',
+      user_id: 'internal-user-1',
+      author_type: 'internal',
+      is_internal: true,
+      is_resolution: true,
+    } as any);
+
+    expect(result).toBeUndefined();
+    const persisted = commentsUpdateMock.mock.calls[0][0];
+    expect(persisted.note).toContain('Edited');
+    expect(persisted.markdown_content).toBe('markdown-content');
+    expect(persisted.updated_at).toEqual(expect.any(String));
+    expect(persisted).not.toHaveProperty('ticket_id');
+    expect(persisted).not.toHaveProperty('user_id');
+    expect(persisted).not.toHaveProperty('author_type');
+    expect(persisted).not.toHaveProperty('is_internal');
+    expect(persisted).not.toHaveProperty('is_resolution');
   });
 });

--- a/packages/client-portal/src/actions/client-portal-actions/client-tickets.ticketOrigin.test.ts
+++ b/packages/client-portal/src/actions/client-portal-actions/client-tickets.ticketOrigin.test.ts
@@ -138,11 +138,9 @@ function buildTrx(params: { ticket: Record<string, unknown> | undefined }) {
       }
 
       if (table === 'comments') {
-        return {
-          where: vi.fn().mockReturnValue({
-            orderBy: vi.fn().mockResolvedValue([]),
-          }),
-        };
+        // The conversations query selects/joins/filters before ordering; the
+        // chainable builder is thenable and resolves to no comments.
+        return makeChainable();
       }
 
       // Additional-agent / comment / assigned / involved-users subqueries plus the

--- a/packages/client-portal/src/actions/client-portal-actions/client-tickets.ts
+++ b/packages/client-portal/src/actions/client-portal-actions/client-tickets.ts
@@ -336,9 +336,14 @@ export const getClientTicketDetails = withAuth(async (user, { tenant }, ticketId
         'd.is_client_visible': true,
       });
 
+      // Only derive involved-user ids from comments the contact can actually
+      // see — internal-only commenters must not be enumerated here. Comment
+      // visibility mirrors the thread root (Comment model enforces replies
+      // match thread visibility), so the comment flag alone is sufficient.
       const commentUserIdsSubquery = scopedDb.table('comments as c')
         .select('c.user_id')
-        .where('c.ticket_id', ticketId);
+        .where('c.ticket_id', ticketId)
+        .where('c.is_internal', false);
       const assignedUserIdSubquery = scopedDb.table('tickets as assigned_ticket')
         .select('assigned_ticket.assigned_to')
         .where('assigned_ticket.ticket_id', ticketId);
@@ -390,15 +395,30 @@ export const getClientTicketDetails = withAuth(async (user, { tenant }, ticketId
           'aa.relationship_type',
         );
 
+      // Portal contacts must never receive MSP-internal notes. A comment is
+      // hidden when its own is_internal flag is set or when it belongs to an
+      // internal thread (comment_threads.is_internal carries the thread root's
+      // flag — the same "internal thread" definition the MSP thread tabs use
+      // in buildTicketThreadTabState).
+      const conversationsQuery = scopedDb.table('comments');
+      scopedDb.tenantJoin(conversationsQuery, 'comment_threads as ct', 'comments.thread_id', 'ct.thread_id', { type: 'left' });
+      conversationsQuery
+        .select('comments.*')
+        .where({
+          'comments.ticket_id': ticketId,
+          'comments.is_internal': false,
+        })
+        .where(function (this: Knex.QueryBuilder) {
+          this.whereNull('ct.is_internal')
+            .orWhere('ct.is_internal', false);
+        })
+        .orderBy('comments.created_at', 'asc');
+
       const [ticket, conversations, documents, users, linkedAssets] = await Promise.all([
         ticketQuery,
 
-        // Get conversations
-        scopedDb.table('comments')
-        .where({
-          ticket_id: ticketId
-        })
-        .orderBy('created_at', 'asc'),
+        // Get conversations (client-visible comments only)
+        conversationsQuery,
 
         // Get client-visible documents only
         documentsQuery,
@@ -519,6 +539,10 @@ export const addClientTicketComment = withAuth(async (
   isInternal: boolean = false,
   isResolution: boolean = false
 ): Promise<ClientTicketActionResult<boolean>> => {
+  // Client portal contacts can never create internal notes/threads. Force the
+  // flag server-side — the portal UI always passes false, but server actions
+  // are directly invocable and the caller-supplied value must not be trusted.
+  isInternal = false;
   try {
     const userId = clientPortalUserIdOrError(user);
     if (typeof userId !== 'string') {
@@ -704,8 +728,13 @@ export const updateClientTicketComment = withAuth(async (
 
       await resolveVisibleTicket(trx, tenant, userRecord.contact_id, comment.ticket_id);
 
-      let updatesWithMarkdown = { ...updates };
+      // Whitelist the editable fields: portal contacts may only revise the
+      // note body. Everything else on IComment (ticket_id, user_id,
+      // author_type, is_internal, is_resolution, ...) is caller-controlled and
+      // must be dropped to prevent mass assignment.
+      const updatesWithMarkdown: { note?: string; markdown_content?: string } = {};
       if (updates.note) {
+        updatesWithMarkdown.note = updates.note;
         try {
           const markdownContent = await convertBlockNoteToMarkdown(updates.note);
           console.log("Converted markdown content for updated client comment:", markdownContent);

--- a/packages/client-portal/src/actions/client-portal-actions/client-tickets.visibility.test.ts
+++ b/packages/client-portal/src/actions/client-portal-actions/client-tickets.visibility.test.ts
@@ -287,11 +287,9 @@ describe('client portal ticket visibility enforcement', () => {
           }
 
           if (table === 'comments') {
-            return {
-              where: vi.fn().mockReturnValue({
-                orderBy: vi.fn().mockResolvedValue([]),
-              }),
-            };
+            // The conversations query now selects/joins/filters before ordering;
+            // the chainable builder is thenable and resolves to no comments.
+            return makeChainable();
           }
 
           if (table === 'documents as d') {
@@ -365,11 +363,7 @@ describe('client portal ticket visibility enforcement', () => {
           }
 
           if (table === 'comments') {
-            return {
-              where: vi.fn().mockReturnValue({
-                orderBy: vi.fn().mockResolvedValue([]),
-              }),
-            };
+            return makeChainable();
           }
 
           if (table === 'documents as d') {
@@ -423,6 +417,99 @@ describe('client portal ticket visibility enforcement', () => {
     await expect(getClientTicketDetails('ticket-hidden')).resolves.toEqual({
       actionError: 'Ticket not found or access denied',
     });
+  });
+
+  it('T018: client portal ticket detail excludes internal comments and internal-only commenters', async () => {
+    const ticketBuilder = makeDetailBuilder({
+      ticket_id: 'ticket-1',
+      ticket_number: 'T-1',
+      title: 'Visible ticket',
+      board_id: 'board-1',
+      client_id: 'client-1',
+      entered_by_user_type: 'internal',
+      entered_at: '2026-03-15T00:00:00.000Z',
+      updated_at: '2026-03-15T00:00:00.000Z',
+      closed_at: null,
+    });
+    const conversationsBuilder = makeChainable();
+    const commentUserIdsBuilder = makeChainable();
+
+    withTransactionMock.mockImplementation(async (_db: any, callback: (trx: any) => Promise<any>) => {
+      const trx = Object.assign(
+        (table: string) => {
+          if (table === 'users') {
+            return makeUserQuery();
+          }
+
+          if (table === 'tickets as t') {
+            return ticketBuilder;
+          }
+
+          if (table === 'comments') {
+            return conversationsBuilder;
+          }
+
+          if (table === 'comments as c') {
+            return commentUserIdsBuilder;
+          }
+
+          if (table === 'documents as d') {
+            return {
+              select: vi.fn().mockReturnThis(),
+              join: vi.fn().mockReturnThis(),
+              where: vi.fn().mockResolvedValue([]),
+            };
+          }
+
+          if (
+            table === 'ticket_resources as tr' ||
+            table === 'ticket_resources as tr2' ||
+            table === 'tickets as assigned_ticket' ||
+            table === 'users as u'
+          ) {
+            return makeChainable();
+          }
+
+          if (table === 'asset_associations as aa') {
+            return {
+              innerJoin: vi.fn().mockReturnThis(),
+              where: vi.fn().mockReturnThis(),
+              select: vi.fn().mockResolvedValue([]),
+            };
+          }
+
+          throw new Error(`Unexpected table: ${table}`);
+        },
+        {
+          raw: vi.fn().mockResolvedValue({ rows: [] }),
+        }
+      );
+
+      return callback(trx);
+    });
+
+    getVisibilityContextMock.mockResolvedValue({
+      contactId: 'contact-1',
+      clientId: 'client-1',
+      visibilityGroupId: 'group-1',
+      visibleBoardIds: ['board-1'],
+    });
+
+    const { getClientTicketDetails } = await import('./client-tickets');
+    await getClientTicketDetails('ticket-1');
+
+    // The serialized conversation list filters out internal comments at the
+    // query (not just in the client component) and joins comment_threads so
+    // internal threads are excluded too.
+    expect(conversationsBuilder.where).toHaveBeenCalledWith({
+      'comments.ticket_id': 'ticket-1',
+      'comments.is_internal': false,
+    });
+    expect(conversationsBuilder.leftJoin).toHaveBeenCalled();
+
+    // Comment-derived involved-user ids are likewise restricted to
+    // client-visible comments so internal-only commenters aren't enumerated.
+    expect(commentUserIdsBuilder.where).toHaveBeenCalledWith('c.is_internal', false);
   });
 
   it('T012: client portal ticket documents reject hidden-board access', async () => {

--- a/packages/client-portal/src/actions/client-portal-actions/clientUserActions.ts
+++ b/packages/client-portal/src/actions/client-portal-actions/clientUserActions.ts
@@ -8,7 +8,7 @@ import { revalidatePath } from 'next/cache';
 // Note: getUserClientId removed - was unused and caused nested withAuth issues
 import { uploadEntityImage, deleteEntityImage } from '@alga-psa/storage';
 import { hasPermission, withAuth, type AuthContext } from '@alga-psa/auth';
-import { getRoles, assignRoleToUser, removeRoleFromUser, getUserRoles } from '@alga-psa/auth/actions/policyActions';
+import { getRoles, assignRoleToUser, removeRoleFromUser } from '@alga-psa/auth/actions/policyActions';
 import {
   createPortalUserInDB,
   getClientPortalRoles as getClientPortalRolesFromDB,
@@ -95,9 +95,17 @@ function clientUserActionErrorMessage(error: unknown, fallback: string): string 
 /**
  * Get available client portal roles
  */
-export const getClientPortalRoles = withAuth(async (_user: IUserWithRoles, { tenant }: AuthContext): Promise<IRole[]> => {
+export const getClientPortalRoles = withAuth(async (user: IUserWithRoles, { tenant }: AuthContext): Promise<IRole[]> => {
   try {
     const { knex } = await createTenantKnex();
+
+    // Listing assignable client roles is part of user management; gate it the
+    // same way the portal gates the User Management tab (`user:read`).
+    const canRead = await hasPermission(user, 'user', 'read', knex);
+    if (!canRead) {
+      return [];
+    }
+
     return await getClientPortalRolesFromDB(knex, tenant);
   } catch (error) {
     console.error('Error fetching client portal roles:', error);
@@ -146,14 +154,36 @@ export async function removeClientUserRole(userId: string, roleId: string): Prom
 /**
  * Get roles for a specific client user
  */
-export async function getClientUserRoles(userId: string): Promise<IRole[]> {
+export const getClientUserRoles = withAuth(async (
+  user: IUserWithRoles,
+  { tenant }: AuthContext,
+  userId: string
+): Promise<IRole[]> => {
   try {
-    return await getUserRoles(userId);
+    const { knex } = await createTenantKnex();
+
+    return await withTransaction(knex, async (trx: Knex.Transaction) => {
+      // A user may always read their own roles; reading someone else's requires
+      // MSP user:update or same-company client admin (see assertCanManageClientUser).
+      if (user.user_id !== userId) {
+        await assertCanManageClientUser(user, tenant, trx, userId);
+      }
+
+      const scopedDb = tenantDb(trx, tenant);
+      const query = scopedDb.table('user_roles');
+      scopedDb.tenantJoin(query, 'roles', 'user_roles.role_id', 'roles.role_id');
+
+      return await query
+        .where({
+          'user_roles.user_id': userId
+        })
+        .select('roles.*');
+    });
   } catch (error) {
     console.error('Error getting client user roles:', error);
     return [];
   }
-}
+});
 
 /**
  * Authorize management of a client-portal user and confirm the target is a
@@ -217,6 +247,68 @@ async function assertCanManageClientUser(
 
   if (!targetContact?.client_id || targetContact.client_id !== actorContact.client_id) {
     throw new Error('Permission denied: Cannot manage users for another client');
+  }
+}
+
+/**
+ * Authorize creation of a client-portal user for a given contact/client.
+ * Mirrors assertCanManageClientUser for the create case (no target user exists
+ * yet, so the target contact is scoped instead):
+ *
+ * - MSP (internal) staff need the standard `user:create` permission.
+ * - Client-portal callers must be a client admin (`is_client_admin`) and the
+ *   target contact must belong to their own client company. The supplied
+ *   `clientId` must match that contact's client, so a portal admin of Company A
+ *   cannot mint a login attached to Company B's contacts.
+ */
+async function assertCanCreateClientUser(
+  user: IUserWithRoles,
+  tenant: string,
+  knex: Knex | Knex.Transaction,
+  contactId: string,
+  clientId: string
+): Promise<void> {
+  // MSP staff: gate on the standard user-management permission.
+  if (user.user_type !== 'client') {
+    const canCreate = await hasPermission(user, 'user', 'create', knex);
+    if (!canCreate) {
+      throw new Error('Permission denied: Cannot create client user');
+    }
+    return;
+  }
+
+  // Client-portal caller: must be a client admin acting within their own company.
+  if (!user.contact_id) {
+    throw new Error('Permission denied: Client portal admin access is required');
+  }
+
+  const scopedDb = tenantDb(knex, tenant);
+
+  const [actorContact, targetContact] = await Promise.all([
+    scopedDb.table('contacts')
+      .where({ contact_name_id: user.contact_id })
+      .select('client_id', 'is_client_admin')
+      .first(),
+    scopedDb.table('contacts')
+      .where({ contact_name_id: contactId })
+      .select('client_id')
+      .first(),
+  ]);
+
+  if (!actorContact?.is_client_admin || !actorContact.client_id) {
+    throw new Error('Permission denied: Client portal admin access is required');
+  }
+
+  if (!targetContact) {
+    throw new Error('Contact not found');
+  }
+
+  if (targetContact.client_id !== actorContact.client_id) {
+    throw new Error('Permission denied: Cannot create users for another client');
+  }
+
+  if (clientId !== targetContact.client_id) {
+    throw new Error('Permission denied: Client does not match the selected contact');
   }
 }
 
@@ -306,20 +398,43 @@ export const resetClientUserPassword = withAuth(async (
  * Get client user by ID
  */
 export const getClientUserById = withAuth(async (
-  _user: IUserWithRoles,
+  user: IUserWithRoles,
   { tenant }: AuthContext,
   userId: string
 ): Promise<IUser | null> => {
   try {
     const { knex } = await createTenantKnex();
 
-    const user = await withTransaction(knex, async (trx: Knex.Transaction) => {
+    const clientUser = await withTransaction(knex, async (trx: Knex.Transaction) => {
+      // A user may always read their own record; reading someone else's requires
+      // MSP user:update or same-company client admin (see assertCanManageClientUser).
+      if (user.user_id !== userId) {
+        await assertCanManageClientUser(user, tenant, trx, userId);
+      }
+
+      // Column whitelist: never return credential material (hashed_password,
+      // two_factor_secret, ...) to the client portal.
       return await tenantDb(trx, tenant).table('users')
-      .where({ user_id: userId, user_type: 'client' })
-      .first();
+        .where({ user_id: userId, user_type: 'client' })
+        .select(
+          'user_id',
+          'username',
+          'first_name',
+          'last_name',
+          'email',
+          'contact_id',
+          'user_type',
+          'is_inactive',
+          'two_factor_enabled',
+          'last_login_at',
+          'created_at',
+          'updated_at',
+          'tenant'
+        )
+        .first();
     });
 
-    return (user as IUser | undefined) || null;
+    return (clientUser as IUser | undefined) || null;
   } catch (error) {
     console.error('Error getting client user:', error);
     throw error;
@@ -353,10 +468,10 @@ export const createClientUser = withAuth(async (
   try {
     const { knex } = await createTenantKnex();
 
-    const allowed = await hasPermission(currentUser, 'user', 'create', knex);
-    if (!allowed) {
-      return { success: false, error: 'Permission denied: Cannot create client user' };
-    }
+    // Authorize: MSP staff need `user:create`; client-portal callers must be a
+    // client admin creating a login for a contact in their own company, with a
+    // clientId consistent with that contact.
+    await assertCanCreateClientUser(currentUser, tenant, knex, contactId, clientId);
 
     // Use the shared model to create the portal user
     const input: CreatePortalUserInput = {

--- a/packages/client-portal/src/actions/client-portal-actions/dashboard.ts
+++ b/packages/client-portal/src/actions/client-portal-actions/dashboard.ts
@@ -304,7 +304,11 @@ export const getRecentActivity = withAuth(async (
       const clientId = contact.client_id;
       const visibility = await getClientContactVisibilityContext(trx, tenant, userContactId);
 
-      // Get recent tickets with their initial descriptions
+      // Get recent tickets with their initial descriptions.
+      // MSP-internal notes (and notes on internal threads) must never surface
+      // as the activity excerpt — exclude them at the query, mirroring the
+      // getClientTicketDetails comment filter. The filters are null-tolerant
+      // so tickets without any comments are kept.
       const ticketsQuery = scopedDb.table('tickets')
         .select([
           'tickets.title',
@@ -312,9 +316,18 @@ export const getRecentActivity = withAuth(async (
           'comments.note as description'
         ]);
       scopedDb.tenantJoin(ticketsQuery, 'comments', 'tickets.ticket_id', 'comments.ticket_id', { type: 'left' });
+      scopedDb.tenantJoin(ticketsQuery, 'comment_threads as ct', 'comments.thread_id', 'ct.thread_id', { type: 'left' });
       const tickets = await ticketsQuery
         .where({
           'tickets.client_id': clientId
+        })
+        .where(function (this: Knex.QueryBuilder) {
+          this.whereNull('comments.is_internal')
+            .orWhere('comments.is_internal', false);
+        })
+        .where(function (this: Knex.QueryBuilder) {
+          this.whereNull('ct.is_internal')
+            .orWhere('ct.is_internal', false);
         })
         .modify((queryBuilder: Knex.QueryBuilder) => {
           applyVisibilityBoardFilter(queryBuilder, visibility.visibleBoardIds, 'tickets.board_id');

--- a/packages/email/src/actions/emailLogActions.ts
+++ b/packages/email/src/actions/emailLogActions.ts
@@ -2,8 +2,17 @@
 
 import { createTenantKnex, tenantDb, withTransaction } from '@alga-psa/db';
 import type { Knex } from 'knex';
-import { withAuth } from '@alga-psa/auth';
-import type { PaginatedResult } from '@alga-psa/types';
+import { withAuth, hasPermission } from '@alga-psa/auth';
+import type { IUserWithRoles, PaginatedResult } from '@alga-psa/types';
+
+// MSP-only: email sending logs expose tenant-wide correspondence (subjects,
+// addresses, ticket numbers, entity ids), so client-portal callers
+// (user_type 'client') are always rejected.
+function assertInternalEmailLogAccess(user: IUserWithRoles): void {
+  if (user.user_type !== 'internal') {
+    throw new Error('Permission denied: email log actions are internal-only');
+  }
+}
 
 export interface EmailSendingLogRecord {
   id: number;
@@ -39,11 +48,16 @@ export interface EmailSendingLogRecord {
 
 export const getEmailLogsForTicket = withAuth(
   async (
-    _user,
+    user,
     { tenant },
     ticketId: string,
     options?: { limit?: number }
   ): Promise<EmailSendingLogRecord[]> => {
+    assertInternalEmailLogAccess(user);
+    // Surfaced from the MSP ticket details UI, so mirror the ticket read check.
+    if (!await hasPermission(user, 'ticket', 'read')) {
+      throw new Error('Permission denied: cannot read ticket');
+    }
     const { knex } = await createTenantKnex();
     const limit = Math.min(Math.max(options?.limit ?? 20, 1), 200);
 
@@ -137,10 +151,13 @@ function parseDateOnlyEndExclusive(input: string): Date | null {
 
 export const getEmailLogs = withAuth(
   async (
-    _user,
+    user,
     { tenant },
     filters: EmailLogFilters = {}
   ): Promise<PaginatedResult<EmailSendingLogListRecord>> => {
+    // No dedicated email-log permission resource exists; the MSP system
+    // monitoring page is the only consumer, so internal-only is the guard.
+    assertInternalEmailLogAccess(user);
     const { knex } = await createTenantKnex();
 
     const page = Math.max(1, filters.page ?? 1);
@@ -258,7 +275,8 @@ export interface EmailLogMetrics {
 }
 
 export const getEmailLogMetrics = withAuth(
-  async (_user, { tenant }): Promise<EmailLogMetrics> => {
+  async (user, { tenant }): Promise<EmailLogMetrics> => {
+    assertInternalEmailLogAccess(user);
     const { knex } = await createTenantKnex();
 
     return withTransaction(knex, async (trx: Knex.Transaction) => {

--- a/packages/notifications/src/actions/internal-notification-actions/internalNotificationActions.ts
+++ b/packages/notifications/src/actions/internal-notification-actions/internalNotificationActions.ts
@@ -2,6 +2,7 @@
 
 import { tenantDb, withTransaction } from '@alga-psa/db';
 import { Knex } from 'knex';
+import { withAuth } from '@alga-psa/auth';
 import { hasPermissionAsync } from '../../lib/authHelpers';
 import {
   InternalNotification,
@@ -173,6 +174,15 @@ export async function createNotificationFromTemplateInternal(
   knex: Knex,
   request: CreateInternalNotificationRequest
 ): Promise<InternalNotification | null> {
+  // This helper lives in a "use server" module, so it is registered as a server
+  // action and is client-reachable. Refuse anything that is not a real
+  // server-side Knex connection/transaction: withTransaction() would otherwise
+  // interpret a caller-supplied tenant id string as a request to open a
+  // connection to that tenant, letting a remote caller forge notifications for
+  // arbitrary users via request.tenant/request.user_id.
+  if (typeof (knex as unknown as { transaction?: unknown } | null)?.transaction !== 'function') {
+    throw new Error('createNotificationFromTemplateInternal requires a server-side database connection');
+  }
   return await withTransaction(knex, async (trx: Knex.Transaction) => {
     // Get user's locale
     const userLocale = await getUserLocale(trx, request.tenant, request.user_id);
@@ -255,21 +265,31 @@ export async function createNotificationFromTemplateInternal(
 
 /**
  * Create a notification from a template (Server Action for UI components)
+ *
+ * Notifications can only be created for the authenticated user — any
+ * tenant/user_id supplied in the request is ignored in favor of the session.
+ * Server-side event subscribers that need to notify other users must use
+ * createNotificationFromTemplateInternal with a real Knex connection instead.
  */
-export async function createNotificationFromTemplateAction(
+export const createNotificationFromTemplateAction = withAuth(async (
+  currentUser,
+  { tenant },
   request: CreateInternalNotificationRequest
-): Promise<InternalNotification | null | NotificationActionError> {
+): Promise<InternalNotification | null | NotificationActionError> => {
   const { knex } = await (await import("@alga-psa/db")).createTenantKnex();
+
+  const targetTenant = tenant;
+  const targetUserId = currentUser.user_id;
 
   try {
     return await withTransaction(knex, async (trx: Knex.Transaction) => {
       // Get user's locale
-      const userLocale = await getUserLocale(trx, request.tenant, request.user_id);
+      const userLocale = await getUserLocale(trx, targetTenant, targetUserId);
 
       // Get template in user's language
       const template = await getNotificationTemplate(
         trx,
-        request.tenant,
+        targetTenant,
         request.template_name,
         userLocale
       );
@@ -280,10 +300,10 @@ export async function createNotificationFromTemplateAction(
 
       // Check if user has this notification type enabled
       const subtypeId = template.subtype_id;
-      const isEnabled = await checkInternalNotificationEnabled(trx, request.tenant, request.user_id, subtypeId);
+      const isEnabled = await checkInternalNotificationEnabled(trx, targetTenant, targetUserId, subtypeId);
 
       if (!isEnabled) {
-        console.log(`Internal notification disabled for user ${request.user_id}, subtype ${subtypeId}`);
+        console.log(`Internal notification disabled for user ${targetUserId}, subtype ${subtypeId}`);
         return null;
       }
 
@@ -292,10 +312,10 @@ export async function createNotificationFromTemplateAction(
       const message = renderTemplate(template.message, request.data);
 
       // Insert notification
-      const [notification] = await tenantDb(trx, request.tenant).table<any>('internal_notifications')
+      const [notification] = await tenantDb(trx, targetTenant).table<any>('internal_notifications')
         .insert({
-          tenant: request.tenant,
-          user_id: request.user_id,
+          tenant: targetTenant,
+          user_id: targetUserId,
           template_name: request.template_name,
           language_code: userLocale,
           title,
@@ -317,12 +337,12 @@ export async function createNotificationFromTemplateAction(
         payload: buildNotificationSentPayload({
           notificationId: notification.internal_notification_id,
           channel: 'in_app',
-          recipientId: request.user_id,
+          recipientId: targetUserId,
           sentAt: createdAt,
           templateId: request.template_name,
         }),
         ctx: {
-          tenantId: request.tenant,
+          tenantId: targetTenant,
           occurredAt: createdAt,
           actor: { actorType: 'SYSTEM' },
           correlationId: notification.internal_notification_id,
@@ -342,7 +362,7 @@ export async function createNotificationFromTemplateAction(
     if (expected) return expected;
     throw error;
   }
-}
+});
 
 /**
  * Internal helper to check if internal notifications are enabled (used within transaction)
@@ -416,15 +436,22 @@ async function checkInternalNotificationEnabled(
 
 /**
  * Get paginated notifications for a user
+ *
+ * Only the authenticated user's own notifications are returned — tenant and
+ * user_id in the request are ignored in favor of the session.
  */
-export async function getNotificationsAction(
+export const getNotificationsAction = withAuth(async (
+  currentUser,
+  { tenant },
   request: GetInternalNotificationsRequest
-): Promise<InternalNotificationListResponse> {
+): Promise<InternalNotificationListResponse> => {
   const { knex } = await (await import("@alga-psa/db")).createTenantKnex();
 
+  const userId = currentUser.user_id;
+
   console.log('[getNotificationsAction] Fetching notifications for:', {
-    tenant: request.tenant,
-    user_id: request.user_id,
+    tenant,
+    user_id: userId,
     limit: request.limit,
     offset: request.offset,
     is_read: request.is_read,
@@ -436,9 +463,9 @@ export async function getNotificationsAction(
     const offset = request.offset || 0;
 
     // Build base query
-    let query = tenantScopedTable(trx, 'internal_notifications', request.tenant)
+    let query = tenantScopedTable(trx, 'internal_notifications', tenant)
       .where({
-        user_id: request.user_id
+        user_id: userId
       })
       .whereNull('deleted_at');
 
@@ -461,9 +488,9 @@ export async function getNotificationsAction(
       .offset(offset);
 
     // Get unread count
-    const [{ count: unreadCount }] = await tenantScopedTable(trx, 'internal_notifications', request.tenant)
+    const [{ count: unreadCount }] = await tenantScopedTable(trx, 'internal_notifications', tenant)
       .where({
-        user_id: request.user_id,
+        user_id: userId,
         is_read: false
       })
       .whereNull('deleted_at')
@@ -476,40 +503,54 @@ export async function getNotificationsAction(
       has_more: Number(totalCount) > offset + limit
     };
   });
-}
+});
 
 /**
  * Get a single notification by internal notification ID
+ *
+ * Only the authenticated user's own notifications are accessible — the
+ * caller-supplied tenant/userId arguments are retained for call-site
+ * compatibility but ignored in favor of the session.
  */
-export async function getNotificationByIdAction(
+export const getNotificationByIdAction = withAuth(async (
+  currentUser,
+  { tenant },
   internalNotificationId: string,
-  tenant: string,
-  userId: string
-): Promise<InternalNotification | null> {
+  _callerTenant?: string,
+  _callerUserId?: string
+): Promise<InternalNotification | null> => {
   const { knex } = await (await import("@alga-psa/db")).createTenantKnex();
 
   return await withTransaction(knex, async (trx: Knex.Transaction) => {
     const notification = await tenantScopedTable(trx, 'internal_notifications', tenant)
       .where({
         internal_notification_id: internalNotificationId,
-        user_id: userId
+        user_id: currentUser.user_id
       })
       .whereNull('deleted_at')
       .first();
 
     return notification || null;
   });
-}
+});
 
 /**
  * Get unread notification count
+ *
+ * Counts only the authenticated user's own notifications — the caller-supplied
+ * tenant/userId arguments are retained for call-site compatibility but ignored
+ * in favor of the session.
  */
-export async function getUnreadCountAction(
-  tenant: string,
-  userId: string,
+export const getUnreadCountAction = withAuth(async (
+  currentUser,
+  { tenant },
+  _callerTenant?: string,
+  _callerUserId?: string,
   byCategory: boolean = false
-): Promise<UnreadCountResponse> {
+): Promise<UnreadCountResponse> => {
   const { knex } = await (await import("@alga-psa/db")).createTenantKnex();
+
+  const userId = currentUser.user_id;
 
   return await withTransaction(knex, async (trx: Knex.Transaction) => {
     // Get total unread count
@@ -546,17 +587,25 @@ export async function getUnreadCountAction(
 
     return response;
   });
-}
+});
 
 /**
  * Mark a single notification as read
+ *
+ * Only the authenticated user's own notifications can be modified — the
+ * caller-supplied tenant/userId arguments are retained for call-site
+ * compatibility but ignored in favor of the session.
  */
-export async function markAsReadAction(
-  tenant: string,
-  userId: string,
+export const markAsReadAction = withAuth(async (
+  currentUser,
+  { tenant },
+  _callerTenant: string,
+  _callerUserId: string,
   notificationId: string
-): Promise<InternalNotification | NotificationActionError> {
+): Promise<InternalNotification | NotificationActionError> => {
   const { knex } = await (await import("@alga-psa/db")).createTenantKnex();
+
+  const userId = currentUser.user_id;
 
   const notification = await (async () => {
     try {
@@ -615,16 +664,24 @@ export async function markAsReadAction(
   });
 
   return notification;
-}
+});
 
 /**
  * Mark all notifications as read for a user
+ *
+ * Only the authenticated user's own notifications can be modified — the
+ * caller-supplied tenant/userId arguments are retained for call-site
+ * compatibility but ignored in favor of the session.
  */
-export async function markAllAsReadAction(
-  tenant: string,
-  userId: string
-): Promise<{ updated_count: number }> {
+export const markAllAsReadAction = withAuth(async (
+  currentUser,
+  { tenant },
+  _callerTenant: string,
+  _callerUserId: string
+): Promise<{ updated_count: number }> => {
   const { knex } = await (await import("@alga-psa/db")).createTenantKnex();
+
+  const userId = currentUser.user_id;
 
   const result = await withTransaction(knex, async (trx: Knex.Transaction) => {
     const updatedCount = await tenantScopedTable(trx, 'internal_notifications', tenant)
@@ -648,35 +705,40 @@ export async function markAllAsReadAction(
   });
 
   return result;
-}
+});
 
 /**
  * Soft delete a notification
+ *
+ * Only the authenticated user's own notifications can be deleted — the
+ * caller-supplied tenant/userId arguments are retained for call-site
+ * compatibility but ignored in favor of the session.
  */
-export async function deleteNotificationAction(
-  tenant: string,
-  userId: string,
+export const deleteNotificationAction = withAuth(async (
+  currentUser,
+  { tenant },
+  _callerTenant: string,
+  _callerUserId: string,
   notificationId: string
-): Promise<void> {
+): Promise<void> => {
   const { knex } = await (await import("@alga-psa/db")).createTenantKnex();
 
   await withTransaction(knex, async (trx: Knex.Transaction) => {
     await tenantScopedTable(trx, 'internal_notifications', tenant)
       .where({
         internal_notification_id: notificationId,
-        user_id: userId
+        user_id: currentUser.user_id
       })
       .update({
         deleted_at: trx.fn.now(),
         updated_at: trx.fn.now()
       });
   });
-}
+});
 
 /**
  * Get all categories
  */
-import { withAuth } from '@alga-psa/auth';
 
 export const getInternalNotificationCategoriesAction = withAuth(async (
   _user,
@@ -777,10 +839,15 @@ export const getSubtypesAction = withAuth(async (
 
 /**
  * Get all templates for a specific template name (all languages)
+ *
+ * Templates are a global (non-tenant-scoped) catalog, so this only requires an
+ * authenticated session.
  */
-export async function getTemplatesForNameAction(
+export const getTemplatesForNameAction = withAuth(async (
+  _user,
+  _ctx,
   templateName: string
-): Promise<InternalNotificationTemplate[]> {
+): Promise<InternalNotificationTemplate[]> => {
   const { knex } = await (await import("@alga-psa/db")).createTenantKnex();
 
   return await withTransaction(knex, async (trx: Knex.Transaction) => {
@@ -789,39 +856,52 @@ export async function getTemplatesForNameAction(
       .where({ name: templateName })
       .orderBy('language_code');
   });
-}
+});
 
 /**
  * Get user's internal notification preferences
+ *
+ * Only the authenticated user's own preferences are returned — the
+ * caller-supplied tenant/userId arguments are retained for call-site
+ * compatibility but ignored in favor of the session.
  */
-export async function getUserInternalNotificationPreferencesAction(
-  tenant: string,
-  userId: string
-): Promise<UserInternalNotificationPreference[]> {
+export const getUserInternalNotificationPreferencesAction = withAuth(async (
+  currentUser,
+  { tenant },
+  _callerTenant?: string,
+  _callerUserId?: string
+): Promise<UserInternalNotificationPreference[]> => {
   const { knex } = await (await import("@alga-psa/db")).createTenantKnex();
 
   return await withTransaction(knex, async (trx: Knex.Transaction) => {
     return await tenantScopedTable(trx, 'user_internal_notification_preferences', tenant)
       .where({
-        user_id: userId
+        user_id: currentUser.user_id
       })
       .orderBy('preference_id');
   });
-}
+});
 
 /**
  * Update or create a user's internal notification preference
+ *
+ * Only the authenticated user's own preferences can be modified — tenant and
+ * user_id in the request are ignored in favor of the session.
  */
-export async function updateUserInternalNotificationPreferenceAction(
+export const updateUserInternalNotificationPreferenceAction = withAuth(async (
+  currentUser,
+  { tenant },
   request: UpdateUserInternalNotificationPreferenceRequest
-): Promise<UserInternalNotificationPreference> {
+): Promise<UserInternalNotificationPreference> => {
   const { knex } = await (await import("@alga-psa/db")).createTenantKnex();
+
+  const userId = currentUser.user_id;
 
   return await withTransaction(knex, async (trx: Knex.Transaction) => {
     // Check if preference exists
-    const existing = await tenantScopedTable(trx, 'user_internal_notification_preferences', request.tenant)
+    const existing = await tenantScopedTable(trx, 'user_internal_notification_preferences', tenant)
       .where({
-        user_id: request.user_id,
+        user_id: userId,
         category_id: request.category_id || null,
         subtype_id: request.subtype_id || null
       })
@@ -829,7 +909,7 @@ export async function updateUserInternalNotificationPreferenceAction(
 
     if (existing) {
       // Update existing preference
-      const [updated] = await tenantScopedTable(trx, 'user_internal_notification_preferences', request.tenant)
+      const [updated] = await tenantScopedTable(trx, 'user_internal_notification_preferences', tenant)
         .where({
           preference_id: existing.preference_id
         })
@@ -841,10 +921,10 @@ export async function updateUserInternalNotificationPreferenceAction(
       return updated;
     } else {
       // Create new preference
-      const [created] = await tenantDb(trx, request.tenant).table<UserInternalNotificationPreference>('user_internal_notification_preferences')
+      const [created] = await tenantDb(trx, tenant).table<UserInternalNotificationPreference>('user_internal_notification_preferences')
         .insert({
-          tenant: request.tenant,
-          user_id: request.user_id,
+          tenant,
+          user_id: userId,
           category_id: request.category_id || null,
           subtype_id: request.subtype_id || null,
           is_enabled: request.is_enabled
@@ -853,17 +933,25 @@ export async function updateUserInternalNotificationPreferenceAction(
       return created;
     }
   });
-}
+});
 
 /**
  * Check if a user has internal notifications enabled for a specific subtype
+ *
+ * Only the authenticated user's own preferences are consulted — the
+ * caller-supplied tenant/userId arguments are retained for call-site
+ * compatibility but ignored in favor of the session.
  */
-export async function isInternalNotificationEnabledAction(
-  tenant: string,
-  userId: string,
+export const isInternalNotificationEnabledAction = withAuth(async (
+  currentUser,
+  { tenant },
+  _callerTenant: string,
+  _callerUserId: string,
   subtypeId: number
-): Promise<boolean> {
+): Promise<boolean> => {
   const { knex } = await (await import("@alga-psa/db")).createTenantKnex();
+
+  const userId = currentUser.user_id;
 
   return await withTransaction(knex, async (trx: Knex.Transaction) => {
     // Check for specific subtype preference
@@ -903,7 +991,7 @@ export async function isInternalNotificationEnabledAction(
     // Default to subtype's default setting
     return subtype.is_default_enabled;
   });
-}
+});
 
 /**
  * Update internal notification category (tenant-specific)

--- a/packages/reporting/src/actions/report-actions/getRecentClientInvoices.ts
+++ b/packages/reporting/src/actions/report-actions/getRecentClientInvoices.ts
@@ -6,6 +6,8 @@ import type { IInvoice } from '@alga-psa/types';
 import { z } from 'zod';
 import { Knex } from 'knex';
 import { withAuth } from '@alga-psa/auth';
+import { tenantDb } from '@alga-psa/db';
+import { permissionError } from '@alga-psa/ui/lib/errorHandling';
 import { reportingActionErrorFrom, type ReportingActionError } from './reportingActionErrors';
 // Removed safe-action import as it's not the standard pattern here
 // Define the schema for the input parameters
@@ -28,7 +30,7 @@ export type RecentInvoice = Pick<IInvoice, 'invoice_id' | 'invoice_number' | 'in
  * @returns A promise that resolves to an array of recent invoices or throws an error.
  */
 export const getRecentClientInvoices = withAuth(async (
-  _user,
+  user,
   { tenant },
   input: { clientId: string; limit?: number }
 ): Promise<RecentInvoice[] | ReportingActionError> => {
@@ -40,6 +42,25 @@ export const getRecentClientInvoices = withAuth(async (
   const { clientId, limit } = validationResult.data;
 
   const { knex } = await createTenantKnex();
+
+  // Client portal users may only see their own client's invoices: the
+  // caller-supplied clientId is never trusted — resolve the client from the
+  // session contact and require it to match.
+  if (user.user_type === 'client') {
+    let portalClientId = typeof user.clientId === 'string' && user.clientId.length > 0
+      ? user.clientId
+      : null;
+    if (!portalClientId && user.contact_id) {
+      const contact = await tenantDb(knex, tenant).table('contacts')
+        .where({ contact_name_id: user.contact_id })
+        .select('client_id')
+        .first<{ client_id: string | null }>();
+      portalClientId = contact?.client_id ?? null;
+    }
+    if (!portalClientId || portalClientId !== clientId) {
+      return permissionError('Permission denied: cannot access invoices for another client');
+    }
+  }
 
   console.log(`Fetching recent invoices for client ${clientId} in tenant ${tenant}, limit ${limit}`);
 

--- a/packages/scheduling/src/actions/appointmentHelpers.ts
+++ b/packages/scheduling/src/actions/appointmentHelpers.ts
@@ -1,6 +1,10 @@
 'use server';
 
 import { createTenantKnex, tenantDb, withTransaction } from '@alga-psa/db';
+import {
+  getAppointmentIcsSigningSecret,
+  signAppointmentIcsToken,
+} from '../lib/appointmentIcsSigning';
 import { format, type Locale } from 'date-fns';
 import { de, es, fr, it, nl, enUS } from 'date-fns/locale';
 
@@ -226,7 +230,17 @@ export async function generateICSLink(
   // For now, return a link to an endpoint that will generate the ICS file
   // The actual ICS generation endpoint would need to be implemented
   const baseUrl = process.env.NEXT_PUBLIC_APP_URL || 'http://localhost:3000';
-  return `${baseUrl}/api/calendar/appointment/${scheduleEntry.entry_id}.ics`;
+  const url = `${baseUrl}/api/calendar/appointment/${scheduleEntry.entry_id}.ics`;
+  const secret = await getAppointmentIcsSigningSecret();
+  if (!secret) {
+    // Fail closed: without a signing secret no valid token can be minted, and
+    // the route will refuse unsigned requests. Return the unsigned URL rather
+    // than breaking the appointment email flow outright.
+    console.error('[ICS Link] No signing secret available; generated ICS link will be rejected');
+    return url;
+  }
+  const token = await signAppointmentIcsToken(secret, scheduleEntry.entry_id);
+  return `${url}?token=${token}`;
 }
 
 /**

--- a/packages/scheduling/src/actions/clientInteractionLookupActions.ts
+++ b/packages/scheduling/src/actions/clientInteractionLookupActions.ts
@@ -1,15 +1,29 @@
 'use server';
 
-import { withAuth } from '@alga-psa/auth';
+import { withAuth, hasPermission } from '@alga-psa/auth';
 import { createTenantKnex, tenantDb, withTransaction } from '@alga-psa/db';
 import type { Knex } from 'knex';
-import type { IClient, IInteraction } from '@alga-psa/types';
+import type { IClient, IInteraction, IUserWithRoles } from '@alga-psa/types';
+
+// MSP-only lookups: these actions back internal scheduling/time-entry UIs
+// and expose tenant-wide client and interaction data, so client-portal
+// callers (user_type 'client') are rejected and the caller must hold the
+// matching read permission.
+async function assertInternalReadAccess(user: IUserWithRoles, resource: 'client' | 'interaction'): Promise<void> {
+  if (user.user_type !== 'internal') {
+    throw new Error('Permission denied: scheduling lookup actions are internal-only');
+  }
+  if (!await hasPermission(user, resource, 'read')) {
+    throw new Error(`Permission denied: cannot read ${resource}`);
+  }
+}
 
 export const getSchedulingClients = withAuth(async (
-  _user,
+  user,
   { tenant },
   includeInactive: boolean = true
 ): Promise<IClient[]> => {
+  await assertInternalReadAccess(user, 'client');
   const { knex } = await createTenantKnex();
 
   return withTransaction(knex, async (trx: Knex.Transaction) => {
@@ -26,10 +40,11 @@ export const getSchedulingClients = withAuth(async (
 });
 
 export const getSchedulingClientById = withAuth(async (
-  _user,
+  user,
   { tenant },
   clientId: string
 ): Promise<IClient | null> => {
+  await assertInternalReadAccess(user, 'client');
   const { knex } = await createTenantKnex();
 
   return withTransaction(knex, async (trx: Knex.Transaction) => {
@@ -43,10 +58,11 @@ export const getSchedulingClientById = withAuth(async (
 });
 
 export const getSchedulingInteractionById = withAuth(async (
-  _user,
+  user,
   { tenant },
   interactionId: string
 ): Promise<IInteraction> => {
+  await assertInternalReadAccess(user, 'interaction');
   const { knex } = await createTenantKnex();
 
   const interaction = await withTransaction(knex, async (trx: Knex.Transaction) => {

--- a/packages/scheduling/src/lib/appointmentIcsSigning.ts
+++ b/packages/scheduling/src/lib/appointmentIcsSigning.ts
@@ -1,0 +1,59 @@
+import { getSecretProviderInstance } from '@alga-psa/core/secrets';
+import { createHmac, timingSafeEqual } from 'node:crypto';
+
+// NOTE: this module must never be marked 'use server' — it handles the
+// signing secret, and every export of a "use server" file becomes a
+// client-reachable server action.
+
+let cachedIcsSigningSecret: string | null = null;
+
+/**
+ * Secret for HMAC-signing appointment ICS download links (minted when the
+ * appointment email is built, verified by the public ICS route). Sourced the
+ * same way the auth/marketing stacks source it: NEXTAUTH_SECRET from env,
+ * then the app secret provider. Returns null when unavailable — link
+ * generation and the route both fail closed.
+ */
+export async function getAppointmentIcsSigningSecret(): Promise<string | null> {
+  if (cachedIcsSigningSecret) return cachedIcsSigningSecret;
+  const fromEnv = process.env.NEXTAUTH_SECRET?.trim();
+  if (fromEnv) {
+    cachedIcsSigningSecret = fromEnv;
+    return cachedIcsSigningSecret;
+  }
+  const secretProvider = await getSecretProviderInstance();
+  const fromAppSecret = (await secretProvider.getAppSecret('NEXTAUTH_SECRET'))?.trim();
+  if (fromAppSecret) {
+    cachedIcsSigningSecret = fromAppSecret;
+    return cachedIcsSigningSecret;
+  }
+  return null;
+}
+
+/**
+ * HMAC signature binding an ICS download link to a specific schedule entry.
+ * The public ICS route resolves the entry cross-tenant, so the token is what
+ * proves the caller was handed the link (via an appointment email) rather
+ * than guessing entry IDs. Follows the marketing click-tracking signing
+ * pattern — pure, the caller supplies the secret.
+ */
+export async function signAppointmentIcsToken(secret: string, entryId: string): Promise<string> {
+  return createHmac('sha256', secret)
+    .update(`appointment-ics\n${entryId}`)
+    .digest('hex');
+}
+
+export async function verifyAppointmentIcsToken(
+  secret: string,
+  entryId: string,
+  token: string,
+): Promise<boolean> {
+  const expected = Buffer.from(await signAppointmentIcsToken(secret, entryId), 'hex');
+  let provided: Buffer;
+  try {
+    provided = Buffer.from(token, 'hex');
+  } catch {
+    return false;
+  }
+  return provided.length === expected.length && timingSafeEqual(expected, provided);
+}

--- a/packages/tickets/src/actions/clientLookupActions.ts
+++ b/packages/tickets/src/actions/clientLookupActions.ts
@@ -11,10 +11,25 @@ import {
   getContactsByClient as getContactsByClientModel,
 } from '@alga-psa/shared/ticketClients/contacts';
 import { getClientLocations as getClientLocationsModel } from '@alga-psa/shared/ticketClients/locations';
-import { withAuth } from '@alga-psa/auth';
+import { withAuth, hasPermission } from '@alga-psa/auth';
+import type { IUserWithRoles } from '@alga-psa/types';
 import { getClientLogoUrl } from '@alga-psa/formatting/avatarUtils';
 
-export const getAllClients = withAuth(async (_user, { tenant }, includeInactive: boolean = true): Promise<IClient[]> => {
+// MSP-only lookups: these actions back internal ticket UIs and expose
+// tenant-wide client/contact data, so client-portal callers (user_type
+// 'client') are rejected and the caller must hold the matching read
+// permission.
+async function assertInternalReadAccess(user: IUserWithRoles, resource: 'client' | 'contact'): Promise<void> {
+  if (user.user_type !== 'internal') {
+    throw new Error('Permission denied: client lookup actions are internal-only');
+  }
+  if (!await hasPermission(user, resource, 'read')) {
+    throw new Error(`Permission denied: cannot read ${resource}`);
+  }
+}
+
+export const getAllClients = withAuth(async (user, { tenant }, includeInactive: boolean = true): Promise<IClient[]> => {
+  await assertInternalReadAccess(user, 'client');
   const { knex } = await createTenantKnex();
 
   return withTransaction(knex, async (trx: Knex.Transaction) => {
@@ -22,7 +37,8 @@ export const getAllClients = withAuth(async (_user, { tenant }, includeInactive:
   });
 });
 
-export const getClientById = withAuth(async (_user, { tenant }, clientId: string): Promise<IClient | null> => {
+export const getClientById = withAuth(async (user, { tenant }, clientId: string): Promise<IClient | null> => {
+  await assertInternalReadAccess(user, 'client');
   const { knex } = await createTenantKnex();
 
   const client = await withTransaction(knex, async (trx: Knex.Transaction) => {
@@ -40,13 +56,14 @@ export const getClientById = withAuth(async (_user, { tenant }, clientId: string
 });
 
 export const getContactsByClient = withAuth(async (
-  _user,
+  user,
   { tenant },
   clientId: string,
   status: ContactFilterStatus = 'active',
   sortBy: 'full_name' | 'created_at' | 'email' | 'phone_number' = 'full_name',
   sortDirection: 'asc' | 'desc' = 'asc'
 ): Promise<IContact[]> => {
+  await assertInternalReadAccess(user, 'contact');
   const { knex } = await createTenantKnex();
 
   return withTransaction(knex, async (trx: Knex.Transaction) => {
@@ -54,7 +71,8 @@ export const getContactsByClient = withAuth(async (
   });
 });
 
-export const getContactByContactNameId = withAuth(async (_user, { tenant }, contactNameId: string): Promise<IContact | null> => {
+export const getContactByContactNameId = withAuth(async (user, { tenant }, contactNameId: string): Promise<IContact | null> => {
+  await assertInternalReadAccess(user, 'contact');
   const { knex } = await createTenantKnex();
 
   return withTransaction(knex, async (trx: Knex.Transaction) => {
@@ -63,10 +81,11 @@ export const getContactByContactNameId = withAuth(async (_user, { tenant }, cont
 });
 
 export const getAllActiveContacts = withAuth(async (
-  _user,
+  user,
   { tenant },
   sortDirection: 'asc' | 'desc' = 'asc'
 ): Promise<IContact[]> => {
+  await assertInternalReadAccess(user, 'contact');
   const { knex } = await createTenantKnex();
 
   return withTransaction(knex, async (trx: Knex.Transaction) => {
@@ -74,7 +93,8 @@ export const getAllActiveContacts = withAuth(async (
   });
 });
 
-export const getClientLocations = withAuth(async (_user, { tenant }, clientId: string): Promise<IClientLocation[]> => {
+export const getClientLocations = withAuth(async (user, { tenant }, clientId: string): Promise<IClientLocation[]> => {
+  await assertInternalReadAccess(user, 'client');
   const { knex } = await createTenantKnex();
 
   return withTransaction(knex, async (trx: Knex.Transaction) => {

--- a/packages/tickets/src/actions/clientLookupActions.watchList.test.ts
+++ b/packages/tickets/src/actions/clientLookupActions.watchList.test.ts
@@ -8,6 +8,7 @@ const getAllActiveContactsModelMock = vi.fn();
 vi.mock('@alga-psa/auth', () => ({
   withAuth: (action: any) => async (...args: any[]) =>
     action(currentUser, { tenant: currentUser.tenant }, ...args),
+  hasPermission: async () => true,
 }));
 
 vi.mock('@alga-psa/db', () => ({

--- a/packages/user-composition/src/actions/userQueryActions.ts
+++ b/packages/user-composition/src/actions/userQueryActions.ts
@@ -26,6 +26,20 @@ function isExpectedUserQueryError(error: unknown): boolean {
   return isPermissionDeniedError(error) || isInvalidUserQueryReference(error);
 }
 
+/**
+ * These query actions return full `users` rows (select '*', including
+ * hashed_password/two_factor_secret). Client-portal roles hold a
+ * client-flagged `user:read` permission, so the RBAC check alone does not
+ * keep portal callers out. No client-portal surface legitimately calls these
+ * actions (the portal uses dedicated actions like getClientUserById /
+ * getClientUsersForClient), so they are restricted to non-client callers.
+ */
+function assertNotClientPortalCaller(currentUser: { user_type?: string }, action: string): void {
+  if (currentUser.user_type === 'client') {
+    throw new Error(`Permission denied: Cannot ${action}`);
+  }
+}
+
 export const findUserById = withAuth(async (
   currentUser,
   _ctx,
@@ -38,6 +52,7 @@ export const findUserById = withAuth(async (
       if (!await hasPermission(currentUser, 'user', 'read', trx)) {
         throw new Error('Permission denied: Cannot read user');
       }
+      assertNotClientPortalCaller(currentUser, 'read user');
 
       const user = await User.getUserWithRoles(trx, id);
       return user || null;
@@ -68,6 +83,7 @@ export const getAllUsersBasic = withAuth(async (
       if (!await hasPermission(currentUser, 'user', 'read', trx)) {
         throw new Error('Permission denied: Cannot read users');
       }
+      assertNotClientPortalCaller(currentUser, 'read users');
 
       const users = await User.getAll(trx, includeInactive);
 
@@ -99,6 +115,7 @@ export const getAllUsers = withAuth(async (
       if (!await hasPermission(currentUser, 'user', 'read', trx)) {
         throw new Error('Permission denied: Cannot read users');
       }
+      assertNotClientPortalCaller(currentUser, 'read users');
 
       const users = await User.getAll(trx, includeInactive);
 
@@ -140,6 +157,7 @@ export const getReportsToSubordinates = withAuth(async (
       if (targetManagerId !== currentUser.user_id && !canReadUsers) {
         throw new Error('Permission denied: Cannot read other users reporting chains');
       }
+      assertNotClientPortalCaller(currentUser, 'read user reporting chains');
 
       const subordinateIds = await User.getReportsToSubordinateIds(trx, targetManagerId);
       if (subordinateIds.length === 0) {
@@ -332,6 +350,7 @@ export const getUserWithRoles = withAuth(async (
       if (!await hasPermission(currentUser, 'user', 'read', trx)) {
         throw new Error('Permission denied: Cannot read user with roles');
       }
+      assertNotClientPortalCaller(currentUser, 'read user with roles');
 
       const user = await User.getUserWithRoles(trx, userId);
       return user || null;
@@ -357,6 +376,7 @@ export const getMultipleUsersWithRoles = withAuth(async (
       if (!await hasPermission(currentUser, 'user', 'read', trx)) {
         throw new Error('Permission denied: Cannot read multiple users with roles');
       }
+      assertNotClientPortalCaller(currentUser, 'read multiple users with roles');
 
       const users = await Promise.all(userIds.map((id: string): Promise<IUserWithRoles | undefined> => User.getUserWithRoles(trx, id)));
       return users.filter((user): user is IUserWithRoles => user !== undefined);
@@ -554,12 +574,45 @@ export const getClientUsersForClient = withAuth(async (
       const usersQuery = db.table<IUser>('users');
       db.tenantJoin(usersQuery, 'contacts', 'users.contact_id', 'contacts.contact_name_id');
 
-      const users = await usersQuery
+      let query = usersQuery
         .where('contacts.client_id', clientId)
-        .where('users.user_type', 'client')
-        .select<IUser[]>('users.*');
+        .where('users.user_type', 'client');
 
-      return users;
+      if (currentUser.user_type === 'client') {
+        // Client-portal callers (the portal user-management screen) may only
+        // list users of their own company, and must never receive credential
+        // columns — the base query would otherwise return `users.*`,
+        // including hashed_password and two_factor_secret.
+        if (!currentUser.contact_id) {
+          throw new Error('Permission denied: Cannot read client users for client');
+        }
+        const actorContact = await db.table('contacts')
+          .where({ contact_name_id: currentUser.contact_id })
+          .select('client_id')
+          .first();
+        if (!actorContact?.client_id || actorContact.client_id !== clientId) {
+          throw new Error('Permission denied: Cannot read client users for another client');
+        }
+        query = query.select<IUser[]>(
+          'users.user_id',
+          'users.tenant',
+          'users.username',
+          'users.email',
+          'users.first_name',
+          'users.last_name',
+          'users.contact_id',
+          'users.user_type',
+          'users.is_inactive',
+          'users.last_login_at',
+          'users.last_login_method',
+          'users.created_at',
+          'users.updated_at'
+        );
+      } else {
+        query = query.select<IUser[]>('users.*');
+      }
+
+      return await query;
     });
   } catch (error) {
     logger.error('Error getting client users:', error);

--- a/packages/users/src/actions/user-actions/userActions.ts
+++ b/packages/users/src/actions/user-actions/userActions.ts
@@ -136,6 +136,63 @@ async function findExistingUserByEmailGlobally(
 }
 
 /**
+ * Client-portal callers may only manage client users of their own company
+ * (mirrors assertCanManageClientUser in
+ * packages/client-portal/src/actions/client-portal-actions/clientUserActions.ts).
+ * `hasPermission(user, 'user', ...)` alone is not sufficient: the client
+ * portal 'Admin' role holds client-flagged user management permissions, and
+ * the MSP middleware user_type gate does not apply to server actions.
+ * Internal callers are unaffected (RBAC-gated by the callers). Throws on
+ * denial.
+ */
+async function assertPortalUserManagementScope(
+  currentUser: IUser,
+  tenant: string,
+  knexOrTrx: Knex | Knex.Transaction,
+  targetUserId: string
+): Promise<void> {
+  if (currentUser.user_type !== 'client') {
+    return;
+  }
+
+  if (!currentUser.contact_id) {
+    throw new Error('Permission denied: Client portal admin access is required');
+  }
+
+  const scopedDb = tenantDb(knexOrTrx, tenant);
+
+  const targetUser = await scopedDb.table('users')
+    .where({ user_id: targetUserId, user_type: 'client' })
+    .select('contact_id')
+    .first();
+
+  if (!targetUser) {
+    throw new Error('User not found');
+  }
+
+  const [actorContact, targetContact] = await Promise.all([
+    scopedDb.table('contacts')
+      .where({ contact_name_id: currentUser.contact_id })
+      .select('client_id', 'is_client_admin')
+      .first(),
+    targetUser.contact_id
+      ? scopedDb.table('contacts')
+          .where({ contact_name_id: targetUser.contact_id })
+          .select('client_id')
+          .first()
+      : Promise.resolve(undefined),
+  ]);
+
+  if (!actorContact?.is_client_admin || !actorContact.client_id) {
+    throw new Error('Permission denied: Client portal admin access is required');
+  }
+
+  if (!targetContact?.client_id || targetContact.client_id !== actorContact.client_id) {
+    throw new Error('Permission denied: Cannot manage users for another client');
+  }
+}
+
+/**
  * Check if an email exists globally across all tenants. Optionally scope the
  * check to a specific user_type — internal/client users with the same email
  * are allowed by design (tenant provisioning creates both).
@@ -406,6 +463,10 @@ export const deleteUser = withAuth(async (
         throwPermissionError('delete user');
       }
 
+      // Client-portal callers may only delete client users of their own
+      // company; internal callers are gated by the RBAC check above.
+      await assertPortalUserManagementScope(user, tenant, trx, userId);
+
       return await tenantDb(trx, tenant).table('clients')
         .where({ account_manager_id: userId })
         .first();
@@ -673,6 +734,15 @@ export const updateUser = withAuth(async (
         logger.debug(`[updateUser] User ${currentUser.user_id} updating their own profile`);
       } else if (!await hasPermission(currentUser, 'user', 'update', trx)) {
         throwPermissionError('update user');
+      }
+
+      // Client-portal callers may only manage client users of their own
+      // company (self-profile updates above are unaffected). Email changes by
+      // portal callers are allowed for in-scope users, matching the
+      // sanctioned portal admin flow (updateClientUser). Internal callers are
+      // gated by the RBAC check above.
+      if (!isOwnProfile) {
+        await assertPortalUserManagementScope(currentUser, tenant, trx, userId);
       }
 
       // Defense-in-depth against mass-assignment: this generic profile-update
@@ -1143,6 +1213,15 @@ export const adminChangeUserPassword = withAuth(async (
     // Verify users are in the same tenant
     if (targetUser.tenant !== currentUser.tenant) {
       return { success: false, error: 'Unauthorized: Cannot modify user from different tenant' };
+    }
+
+    // This flow is for MSP staff only. The 'Admin' role-name check below is
+    // also satisfied by the client portal 'Admin' role, so gating on it alone
+    // would let portal admins reset MSP staff passwords. Portal admins must
+    // use the portal's own flow (resetClientUserPassword), which enforces
+    // same-company scoping.
+    if (currentUser.user_type !== 'internal') {
+      return { success: false, error: 'Unauthorized: Internal staff privileges required' };
     }
 
     const currentUserRoles = await getUserRoles(currentUser.user_id);

--- a/server/src/app/api/calendar/appointment/[id]/route.ts
+++ b/server/src/app/api/calendar/appointment/[id]/route.ts
@@ -3,10 +3,20 @@ import { createTenantKnex } from 'server/src/lib/db';
 import { tenantDb, withTransaction } from '@alga-psa/db';
 import { Knex } from 'knex';
 import { generateICS, type ICSEventData } from '@alga-psa/scheduling';
+import {
+  getAppointmentIcsSigningSecret,
+  verifyAppointmentIcsToken,
+} from '@alga-psa/scheduling/lib/appointmentIcsSigning';
 
 /**
  * GET /api/calendar/appointment/[id].ics
  * Generate and download an ICS file for an approved appointment
+ *
+ * Public by design (emailed to contacts who may have no portal session), so
+ * access is authorized by an HMAC token minted into the link at send time —
+ * see generateICSLink in @alga-psa/scheduling. The cross-tenant entry lookup
+ * below only runs after the token verifies, so entry IDs cannot be enumerated
+ * for other tenants' appointment details.
  */
 export async function GET(
   request: NextRequest,
@@ -19,6 +29,22 @@ export async function GET(
       return NextResponse.json(
         { error: 'Schedule entry ID is required' },
         { status: 400 }
+      );
+    }
+
+    // Fail closed on token problems — a missing secret or a missing/invalid
+    // token both get the same generic refusal, before any tenant data is read.
+    const token = request.nextUrl.searchParams.get('token');
+    const signingSecret = await getAppointmentIcsSigningSecret();
+    const verified = Boolean(signingSecret) && Boolean(token) && await verifyAppointmentIcsToken(
+      signingSecret!,
+      scheduleEntryId,
+      token!,
+    );
+    if (!verified) {
+      return NextResponse.json(
+        { error: 'Invalid or missing token' },
+        { status: 401 }
       );
     }
 

--- a/server/src/app/api/documents/download/[fileId]/route.ts
+++ b/server/src/app/api/documents/download/[fileId]/route.ts
@@ -6,12 +6,17 @@ import { marked } from 'marked';
 import { convertBlockContentToMarkdown } from '@alga-psa/formatting/blocknoteUtils';
 
 import logger from '@alga-psa/core/logger';
-import { downloadDocument } from '@alga-psa/documents/actions/documentActions';
+import {
+  downloadDocument,
+  getAuthorizedDocumentByFileId,
+  getAuthorizedDocumentById,
+} from '@alga-psa/documents/actions/documentActions';
 import { createPDFGenerationService } from '@alga-psa/billing/services';
 import { StorageService } from '@alga-psa/storage/StorageService';
 import { tenantDb, withTransaction, runWithTenant } from '@alga-psa/db';
 import { Knex } from 'knex';
-import { getSession } from '@alga-psa/auth';
+import { getCurrentUser, getSession } from '@alga-psa/auth';
+import { hasPermission } from 'server/src/lib/auth/rbac';
 
 export async function GET(req: NextRequest, { params }: { params: Promise<{ fileId: string }> }) {
   const resolvedParams = await params;
@@ -33,8 +38,22 @@ export async function GET(req: NextRequest, { params }: { params: Promise<{ file
 
   const tenant = session.user.tenant;
 
+  // Resolve the full user (roles, contact/client linkage) so the export
+  // branches can apply the same authorization as downloadDocument().
+  const currentUser = await getCurrentUser();
+  if (!currentUser) {
+    logger.warn(`Unable to resolve session user for document download/export. ID: ${resolvedParams.fileId}`);
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+  }
+
   // Wrap in runWithTenant to ensure tenant context persists across async boundaries
   return await runWithTenant(tenant, async () => {
+    // Mirror downloadDocument()'s permission gate for every export format.
+    if (!(await hasPermission(currentUser, 'document', 'read'))) {
+      logger.warn(`User ${currentUser.user_id} lacks document:read permission. ID: ${lookupId}, Tenant: ${tenant}`);
+      return NextResponse.json({ error: 'Forbidden' }, { status: 403 });
+    }
+
     // --- Markdown Export Logic ---
     if (format === 'markdown' || format === 'md') {
       logger.info(`Markdown export requested for document ID: ${lookupId}`);
@@ -43,13 +62,13 @@ export async function GET(req: NextRequest, { params }: { params: Promise<{ file
         const { knex } = await createTenantKnex();
         const { document, blockRow, textRow } = await withTransaction(knex, async (trx: Knex.Transaction) => {
           const db = tenantDb(trx, tenant);
+          // Authorize through the same path as downloadDocument() (tenant
+          // scoping + relationship/client-visibility rules) before exporting.
           const doc =
-            (await Document.get(trx, lookupId)) ||
-            (await db.table('documents')
-              .where({ file_id: lookupId })
-              .first());
+            (await getAuthorizedDocumentById(trx, tenant, currentUser, lookupId)) ||
+            (await getAuthorizedDocumentByFileId(trx, tenant, currentUser, lookupId));
 
-          if (!doc || doc.tenant !== tenant) {
+          if (!doc) {
             return { document: null, blockRow: null, textRow: null };
           }
 
@@ -68,7 +87,7 @@ export async function GET(req: NextRequest, { params }: { params: Promise<{ file
         });
 
         if (!document) {
-          logger.warn(`Document not found or tenant mismatch for markdown export. ID: ${lookupId}, Tenant: ${tenant}`);
+          logger.warn(`Document not found or access denied for markdown export. ID: ${lookupId}, Tenant: ${tenant}`);
           return NextResponse.json({ error: 'Document not found.' }, { status: 404 });
         }
 
@@ -137,20 +156,18 @@ export async function GET(req: NextRequest, { params }: { params: Promise<{ file
       logger.info(`PDF generation requested for document ID: ${lookupId}`);
 
       try {
-        // Get document to verify it exists and belongs to the user's tenant
+        // Get the document through the same authorization path used by
+        // downloadDocument() (tenant scoping + relationship/client-visibility
+        // rules) before generating the PDF.
         const { knex } = await createTenantKnex();
         const document = await withTransaction(knex, async (trx: Knex.Transaction) => {
-          const db = tenantDb(trx, tenant);
-          // Try by document_id first, then by file_id
-          const doc = await Document.get(trx, lookupId);
-          if (doc) return doc;
-          return await db.table('documents')
-            .where({ file_id: lookupId })
-            .first();
+          const byDocumentId = await getAuthorizedDocumentById(trx, tenant, currentUser, lookupId);
+          if (byDocumentId) return byDocumentId;
+          return getAuthorizedDocumentByFileId(trx, tenant, currentUser, lookupId);
         });
 
-        if (!document || document.tenant !== tenant) {
-          logger.warn(`Document not found or tenant mismatch for PDF generation. ID: ${lookupId}, Tenant: ${tenant}`);
+        if (!document) {
+          logger.warn(`Document not found or access denied for PDF generation. ID: ${lookupId}, Tenant: ${tenant}`);
           return NextResponse.json({ error: 'Document not found.' }, { status: 404 });
         }
 

--- a/server/src/lib/utils/documentPermissionUtils.ts
+++ b/server/src/lib/utils/documentPermissionUtils.ts
@@ -3,7 +3,9 @@ import { IDocument } from '@/interfaces/document.interface';
 import { IDocumentAssociation } from '@/interfaces/document-association.interface';
 import { hasPermission } from '@/lib/auth/rbac';
 import { createTenantKnex } from '@/lib/db';
-import { tenantDb } from '@alga-psa/db';
+import { tenantDb, withTransaction } from '@alga-psa/db';
+import { authorizeAndRedactDocuments } from '@alga-psa/documents/actions/documentActions';
+import { Knex } from 'knex';
 
 /**
  * Entity type to required resource permission mapping
@@ -20,9 +22,49 @@ const ENTITY_TO_PERMISSION_MAP: Record<string, string> = {
 };
 
 /**
+ * Check whether a client-portal contact can access a document using the
+ * canonical client-portal visibility model (the same authorization path as
+ * downloadDocument / getAuthorizedDocumentByFileId): the contact must own the
+ * document or the document must be associated with their client and flagged
+ * is_client_visible.
+ */
+async function canClientAccessDocument(
+  user: IUser,
+  document: IDocument,
+  db: Knex,
+  tenant: string
+): Promise<boolean> {
+  // authorizeAndRedactDocuments resolves same-client visibility from
+  // user.clientId, which session-resolved users may not have populated;
+  // derive it from the contact record the way getUserWithRoles does.
+  let clientId = (user as IUser & { clientId?: string }).clientId;
+  if (!clientId && user.contact_id) {
+    const contact = await tenantDb(db, tenant).table('contacts')
+      .select('client_id')
+      .where({ contact_name_id: user.contact_id })
+      .first();
+    clientId = contact?.client_id ?? undefined;
+  }
+
+  return withTransaction(db, async (trx: Knex.Transaction) => {
+    const [authorizedDocument] = await authorizeAndRedactDocuments(
+      trx,
+      tenant,
+      { ...user, clientId },
+      [document]
+    );
+    return Boolean(authorizedDocument);
+  });
+}
+
+/**
  * Check if a user can access a specific document based on:
  * 1. User has 'document' read permission
- * 2. User has permission for at least one entity the document is associated with
+ * 2. Client-portal contacts: document satisfies the client-portal visibility
+ *    model (owned by the contact, or associated with their client and
+ *    is_client_visible)
+ * 3. Internal users: permission for at least one entity the document is
+ *    associated with
  *
  * @param user - Current user
  * @param document - Document to check access for
@@ -37,23 +79,31 @@ export async function canAccessDocument(
     return false;
   }
 
-  // 2. Get all associations for this document
   const { knex: db, tenant } = await createTenantKnex();
   const effectiveTenant = tenant ?? document.tenant;
   if (!effectiveTenant) {
     throw new Error('Tenant context not found');
   }
 
+  // 2. Client-portal contacts must satisfy the client-portal visibility
+  // model; the entity-type permission checks below are for internal (MSP)
+  // users only and would otherwise grant contacts access to any document
+  // whose associations match an entity type they can read.
+  if (user.user_type === 'client') {
+    return canClientAccessDocument(user, document, db, effectiveTenant);
+  }
+
+  // 3. Get all associations for this document
   const associations: IDocumentAssociation[] = await tenantDb(db, effectiveTenant).table<IDocumentAssociation>('document_associations')
     .select('*')
     .where({ document_id: document.document_id });
 
-  // 3. If no associations, allow access (tenant-level document)
+  // 4. If no associations, allow access (tenant-level document)
   if (!associations || associations.length === 0) {
     return true;
   }
 
-  // 4. Check if user has permission for ANY associated entity
+  // 5. Check if user has permission for ANY associated entity
   for (const assoc of associations) {
     const requiredPermission = ENTITY_TO_PERMISSION_MAP[assoc.entity_type];
 
@@ -68,7 +118,7 @@ export async function canAccessDocument(
     }
   }
 
-  // 5. User doesn't have permission for any associated entity
+  // 6. User doesn't have permission for any associated entity
   return false;
 }
 

--- a/server/src/test/integration/email/emailLogActions.getEmailLogMetrics.integration.test.ts
+++ b/server/src/test/integration/email/emailLogActions.getEmailLogMetrics.integration.test.ts
@@ -6,8 +6,9 @@ import { createTestDbConnection } from '../../../../test-utils/dbConfig';
 let mockTenantId = 'tenant-test';
 
 vi.mock('@alga-psa/auth', () => ({
+  hasPermission: async () => true,
   withAuth: (fn: any) => async (...args: any[]) =>
-    fn({ user_id: 'user-test', tenant: mockTenantId, roles: [] }, { tenant: mockTenantId }, ...args),
+    fn({ user_id: 'user-test', tenant: mockTenantId, user_type: 'internal', roles: [] }, { tenant: mockTenantId }, ...args),
 }));
 
 import { getEmailLogMetrics } from '@alga-psa/email/actions';

--- a/server/src/test/integration/email/emailLogActions.getEmailLogs.integration.test.ts
+++ b/server/src/test/integration/email/emailLogActions.getEmailLogs.integration.test.ts
@@ -7,8 +7,9 @@ import { createTestDbConnection } from '../../../../test-utils/dbConfig';
 let mockTenantId = 'tenant-test';
 
 vi.mock('@alga-psa/auth', () => ({
+  hasPermission: async () => true,
   withAuth: (fn: any) => async (...args: any[]) =>
-    fn({ user_id: 'user-test', tenant: mockTenantId, roles: [] }, { tenant: mockTenantId }, ...args),
+    fn({ user_id: 'user-test', tenant: mockTenantId, user_type: 'internal', roles: [] }, { tenant: mockTenantId }, ...args),
 }));
 
 import { getEmailLogs } from '@alga-psa/email/actions';

--- a/server/src/test/integration/email/emailLogActions.getEmailLogsForTicket.integration.test.ts
+++ b/server/src/test/integration/email/emailLogActions.getEmailLogsForTicket.integration.test.ts
@@ -7,8 +7,9 @@ import { createTestDbConnection } from '../../../../test-utils/dbConfig';
 let mockTenantId = 'tenant-test';
 
 vi.mock('@alga-psa/auth', () => ({
+  hasPermission: async () => true,
   withAuth: (fn: any) => async (...args: any[]) =>
-    fn({ user_id: 'user-test', tenant: mockTenantId, roles: [] }, { tenant: mockTenantId }, ...args),
+    fn({ user_id: 'user-test', tenant: mockTenantId, user_type: 'internal', roles: [] }, { tenant: mockTenantId }, ...args),
 }));
 
 import { getEmailLogsForTicket } from '@alga-psa/email/actions';

--- a/server/src/test/integration/internal-notifications/notificationCrud.integration.test.ts
+++ b/server/src/test/integration/internal-notifications/notificationCrud.integration.test.ts
@@ -31,6 +31,18 @@ const { createTenantKnexMock } = vi.hoisted(() => ({
   createTenantKnexMock: vi.fn(async () => ({ knex: testDb, tenant: testTenantId }))
 }));
 
+// The actions are wrapped in withAuth and derive tenant/user from the
+// session; inject the test user as the authenticated session user.
+vi.mock('@alga-psa/auth', () => ({
+  withAuth: (fn: any) => async (...args: any[]) =>
+    fn(
+      { user_id: testUserId, tenant: testTenantId, user_type: 'internal', roles: [] },
+      { tenant: testTenantId },
+      ...args
+    ),
+  hasPermission: async () => true,
+}));
+
 vi.mock('@alga-psa/db', async (importOriginal) => {
   const actual = await importOriginal<typeof import('@alga-psa/db')>();
   return {

--- a/server/src/test/integration/internal-notifications/notificationPreferences.integration.test.ts
+++ b/server/src/test/integration/internal-notifications/notificationPreferences.integration.test.ts
@@ -37,6 +37,18 @@ vi.mock('@alga-psa/db', async (importOriginal) => {
   };
 });
 
+// The actions are wrapped in withAuth and derive tenant/user from the
+// session; inject the test user as the authenticated session user.
+vi.mock('@alga-psa/auth', () => ({
+  withAuth: (fn: any) => async (...args: any[]) =>
+    fn(
+      { user_id: testUserId, tenant: testTenantId, user_type: 'internal', roles: [] },
+      { tenant: testTenantId },
+      ...args
+    ),
+  hasPermission: async () => true,
+}));
+
 import {
   broadcastNotification
 } from '@alga-psa/notifications/realtime/internalNotificationBroadcaster';

--- a/server/src/test/unit/appointmentHelpers.test.ts
+++ b/server/src/test/unit/appointmentHelpers.test.ts
@@ -13,6 +13,24 @@ import {
 } from '@alga-psa/scheduling/actions/appointmentHelpers';
 import * as sharedDb from '@alga-psa/db';
 import type { Knex } from 'knex';
+import {
+  signAppointmentIcsToken,
+  verifyAppointmentIcsToken,
+} from '@alga-psa/scheduling/lib/appointmentIcsSigning';
+
+// Pin the ICS signing secret so generated links are deterministic; signing
+// and verification themselves use the real implementations.
+const TEST_ICS_SECRET = 'test-ics-secret';
+vi.mock('@alga-psa/scheduling/lib/appointmentIcsSigning', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@alga-psa/scheduling/lib/appointmentIcsSigning')>();
+  return {
+    ...actual,
+    getAppointmentIcsSigningSecret: async () => TEST_ICS_SECRET,
+  };
+});
+
+const signedIcsUrl = async (base: string, entryId: string): Promise<string> =>
+  `${base}/api/calendar/appointment/${entryId}.ics?token=${await signAppointmentIcsToken(TEST_ICS_SECRET, entryId)}`;
 
 // Mock the shared db module (production imports createTenantKnex and withTransaction from @alga-psa/db)
 vi.mock('@alga-psa/db', () => ({
@@ -306,13 +324,13 @@ describe('Appointment Helper Functions', () => {
 
     it('should generate ICS link with default localhost URL', async () => {
       const result = await generateICSLink(mockScheduleEntry);
-      expect(result).toBe('http://localhost:3000/api/calendar/appointment/entry-123.ics');
+      expect(result).toBe(await signedIcsUrl('http://localhost:3000', 'entry-123'));
     });
 
     it('should generate ICS link with custom base URL from environment', async () => {
       process.env.NEXT_PUBLIC_APP_URL = 'https://example.com';
       const result = await generateICSLink(mockScheduleEntry);
-      expect(result).toBe('https://example.com/api/calendar/appointment/entry-123.ics');
+      expect(result).toBe(await signedIcsUrl('https://example.com', 'entry-123'));
     });
 
     it('should handle entry_id with special characters', async () => {
@@ -321,7 +339,7 @@ describe('Appointment Helper Functions', () => {
         entry_id: 'entry-123-abc_def'
       };
       const result = await generateICSLink(entryWithSpecialId);
-      expect(result).toBe('http://localhost:3000/api/calendar/appointment/entry-123-abc_def.ics');
+      expect(result).toBe(await signedIcsUrl('http://localhost:3000', 'entry-123-abc_def'));
     });
 
     it('should handle UUID entry_id', async () => {
@@ -330,20 +348,20 @@ describe('Appointment Helper Functions', () => {
         entry_id: '550e8400-e29b-41d4-a716-446655440000'
       };
       const result = await generateICSLink(entryWithUUID);
-      expect(result).toBe('http://localhost:3000/api/calendar/appointment/550e8400-e29b-41d4-a716-446655440000.ics');
+      expect(result).toBe(await signedIcsUrl('http://localhost:3000', '550e8400-e29b-41d4-a716-446655440000'));
     });
 
     it('should generate link with trailing slash in base URL', async () => {
       process.env.NEXT_PUBLIC_APP_URL = 'https://example.com/';
       const result = await generateICSLink(mockScheduleEntry);
       // Note: This will result in double slashes, which is acceptable for the URL structure
-      expect(result).toBe('https://example.com//api/calendar/appointment/entry-123.ics');
+      expect(result).toBe(await signedIcsUrl('https://example.com/', 'entry-123'));
     });
 
     it('should generate link with production URL', async () => {
       process.env.NEXT_PUBLIC_APP_URL = 'https://app.algapsa.com';
       const result = await generateICSLink(mockScheduleEntry);
-      expect(result).toBe('https://app.algapsa.com/api/calendar/appointment/entry-123.ics');
+      expect(result).toBe(await signedIcsUrl('https://app.algapsa.com', 'entry-123'));
     });
 
     it('should maintain consistent structure regardless of entry times', async () => {
@@ -354,7 +372,22 @@ describe('Appointment Helper Functions', () => {
         scheduled_end: '2026-01-01T17:00:00Z'
       };
       const result = await generateICSLink(differentEntry);
-      expect(result).toBe('http://localhost:3000/api/calendar/appointment/different-123.ics');
+      expect(result).toBe(await signedIcsUrl('http://localhost:3000', 'different-123'));
+    });
+
+    it('should mint a token that verifies for the same entry', async () => {
+      const result = await generateICSLink(mockScheduleEntry);
+      const token = new URL(result).searchParams.get('token');
+      expect(token).toBeTruthy();
+      expect(await verifyAppointmentIcsToken(TEST_ICS_SECRET, 'entry-123', token!)).toBe(true);
+    });
+
+    it('should reject tokens for a different entry or a tampered token', async () => {
+      const result = await generateICSLink(mockScheduleEntry);
+      const token = new URL(result).searchParams.get('token')!;
+      expect(await verifyAppointmentIcsToken(TEST_ICS_SECRET, 'other-entry', token)).toBe(false);
+      expect(await verifyAppointmentIcsToken(TEST_ICS_SECRET, 'entry-123', token.slice(0, -2) + '00')).toBe(false);
+      expect(await verifyAppointmentIcsToken(TEST_ICS_SECRET, 'entry-123', 'not-hex')).toBe(false);
     });
   });
 

--- a/server/src/test/unit/internal-notifications/internalNotificationActions.test.ts
+++ b/server/src/test/unit/internal-notifications/internalNotificationActions.test.ts
@@ -422,6 +422,24 @@ const withTransactionSpy = vi.fn(async (_knex: unknown, callback: (trx: MockTran
 });
 dbHoisted.withTransactionSpy = withTransactionSpy;
 
+// Session identity for the withAuth-wrapped actions: the actions now derive
+// tenant/user from the authenticated session and ignore caller-supplied
+// values, so tests set the session user here when they need a non-default
+// identity.
+const authHoisted = vi.hoisted(() => ({
+  sessionUser: {
+    user_id: 'user-1',
+    user_type: 'internal',
+    tenant: 'tenant-1',
+    roles: [] as any[],
+  },
+}));
+
+vi.mock('@alga-psa/auth', () => ({
+  withAuth: (action: any) => async (...args: any[]) =>
+    action(authHoisted.sessionUser, { tenant: authHoisted.sessionUser.tenant }, ...args),
+}));
+
 vi.mock('@alga-psa/db', () => ({
   withTransaction: (...args: any[]) => dbHoisted.withTransactionSpy(...args),
   createTenantKnex: vi.fn(async () => ({ knex: {}, tenant: 'tenant-1' })),
@@ -488,6 +506,8 @@ beforeAll(async () => {
 beforeEach(() => {
   vi.clearAllMocks();
   currentDb = null;
+  authHoisted.sessionUser.user_id = 'user-1';
+  authHoisted.sessionUser.tenant = 'tenant-1';
   broadcastNotificationMock.mockResolvedValue(undefined);
   broadcastNotificationReadMock.mockResolvedValue(undefined);
   broadcastAllNotificationsReadMock.mockResolvedValue(undefined);
@@ -956,6 +976,7 @@ describe('internalNotificationActions data access', () => {
     it('returns zero counts for users without notifications', async () => {
       currentDb = createMockDb([]);
 
+      authHoisted.sessionUser.user_id = 'missing-user';
       const response = await getUnreadCountAction('tenant-1', 'missing-user');
       expect(response.unread_count).toBe(0);
     });
@@ -999,6 +1020,7 @@ describe('internalNotificationActions data access', () => {
         })
       ]);
 
+      authHoisted.sessionUser.user_id = 'other-user';
       await expect(markAsReadAction('tenant-1', 'other-user', NOTIFICATION_UUID_1)).resolves.toEqual({
         actionError: 'Notification not found. It may have already been updated or deleted.',
       });
@@ -1077,7 +1099,9 @@ describe('internalNotificationActions data access', () => {
         })
       ]);
 
+      authHoisted.sessionUser.user_id = 'another-user';
       await deleteNotificationAction('tenant-1', 'another-user', NOTIFICATION_UUID_1);
+      authHoisted.sessionUser.user_id = 'owner-user';
       await deleteNotificationAction('tenant-1', 'owner-user', NOTIFICATION_UUID_2);
 
       const [firstRow, secondRow] = currentDb.tables.internal_notifications;


### PR DESCRIPTION
## Summary

This PR tightens authorization checks across a set of server actions and API routes, focusing on consistent permission enforcement and on scoping client-portal callers to their own organization.

## Changes

- **User and role administration** — User management actions now distinguish internal staff from client-portal administrators. Portal administrators can manage users within their own organization only. Staff password administration, staff role assignment, and tenant-wide user queries are restricted to internal users.
- **Client portal user administration** — Portal user management is scoped to the caller's organization, and portal-facing user queries no longer include credential-related columns.
- **Billing** — Invoice voiding now requires the invoice update permission and is unavailable to portal callers. Invoice query actions verify that portal callers can only reach invoices belonging to their own organization, and tenant-wide invoice listings reject portal callers. Job status polling is limited to jobs the caller created.
- **Lookup actions** — Client, contact, and interaction lookup actions that back internal UIs now require an internal user with the matching read permission. Email sending log views are limited to internal callers.
- **Ticket conversations** — Portal ticket views and activity feeds no longer include internal-only notes. Portal comment editing is limited to the note body, portal-added comments are always non-internal, and appointment request updates validate that the linked ticket belongs to the caller's organization.
- **Documents** — Document export endpoints (Markdown/PDF) now apply the same authorization as standard downloads, including the client visibility model for portal contacts.
- **Notifications** — Internal notification actions derive the target tenant and user from the authenticated session rather than caller-supplied identifiers.
- **Calendar** — Public appointment calendar (.ics) download links are now signed at send time; unsigned or tampered links are rejected.

## User-facing behavior changes

- Calendar (.ics) links in appointment emails sent **before** this release will no longer download; emails sent after this release include signed links.
- Portal users may see permission errors or narrower results in a few views (for example, user listings limited to their own organization).
- Document export now returns "not found" for documents the caller is not authorized to access, matching standard download behavior.
- Internal users lacking client/contact read permission may see empty dropdowns in ticket forms that use the lookup actions.

## Testing

- Updated affected unit and integration test mocks for the new authorization checks.
- Added coverage for portal comment visibility, response-source attribution, and signed calendar link generation/verification.