### PR TITLE
Marketing workflow fanout fix

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -176,6 +176,8 @@ CRYPTO_ALGORITHM=aes-256-gcm
 
 # Authentication Settings
 NEXTAUTH_URL=http://localhost:3000  # Required: Valid URL
+# Required by prebuilt Compose. Use the public origin that recipients can open.
+NEXT_PUBLIC_BASE_URL=http://localhost:3000
 NEXTAUTH_SESSION_EXPIRES=86400  # Required: Number greater than 0
 
 # OAuth fallback for MSP SSO (CE + EE):

--- a/docker-compose.prod.yaml
+++ b/docker-compose.prod.yaml
@@ -3,6 +3,8 @@ services:
     environment:
       NODE_ENV: production
       APP_ENV: production
+      APPLICATION_URL: ${NEXT_PUBLIC_BASE_URL:?Set NEXT_PUBLIC_BASE_URL to the public application URL}
+      NEXT_PUBLIC_BASE_URL: ${NEXT_PUBLIC_BASE_URL:?Set NEXT_PUBLIC_BASE_URL to the public application URL}
       # Production secret provider configuration
       # Override defaults for production vault integration
       SECRET_READ_CHAIN: ${SECRET_READ_CHAIN:-env,filesystem,vault}

--- a/docs/getting-started/configuration_guide.md
+++ b/docs/getting-started/configuration_guide.md
@@ -78,16 +78,18 @@ EMAIL_USERNAME=noreply@example.com  # Required: Valid email address
 # EMAIL_PASSWORD managed via Docker secrets
 ```
 
-#### Authentication Settings (NEXTAUTH_*)
+#### Application URL and authentication settings
 ```
 NEXTAUTH_URL=http://localhost:3000  # Required: Valid URL - for production, must match your public domain
+NEXT_PUBLIC_BASE_URL=http://localhost:3000  # Required by prebuilt Compose; use the same public origin
 NEXTAUTH_SESSION_EXPIRES=86400  # Required: Number greater than 0
 # NEXTAUTH_SECRET managed via Docker secrets
 ```
 
-**Important**: For production deployments, `NEXTAUTH_URL` must match your actual public domain:
-- Development: `http://localhost:3000`
-- Production: `https://your-domain.com`
+**Important**: For production deployments, `NEXTAUTH_URL` and
+`NEXT_PUBLIC_BASE_URL` must match your actual public domain:
+- Development: both use `http://localhost:3000`
+- Production: both use `https://your-domain.com`
 
 #### Crypto Settings (CRYPTO_*)
 ```

--- a/docs/getting-started/setup_guide.md
+++ b/docs/getting-started/setup_guide.md
@@ -114,6 +114,7 @@ cp .env.example server/.env
    - `EMAIL_PORT=587`
    - `EMAIL_USERNAME=noreply@example.com`
    - `NEXTAUTH_URL=http://localhost:3000`
+   - `NEXT_PUBLIC_BASE_URL=http://localhost:3000` (required; use your public URL in production)
    - `NEXTAUTH_SESSION_EXPIRES=86400`
 
    Optional: enable collaborative editing by setting `REQUIRE_HOCUSPOCUS=true`.
@@ -347,14 +348,19 @@ NEXTAUTH_URL=http://localhost:3000
 For production deployment:
 ```bash
 NEXTAUTH_URL=https://your-domain.com
+NEXT_PUBLIC_BASE_URL=https://your-domain.com
 HOST=https://your-domain.com
 ```
+
+`NEXT_PUBLIC_BASE_URL` is required by the prebuilt Compose stack. Marketing
+emails use it for recipient-facing unsubscribe, click-tracking, and open-tracking
+links. Set it to an origin that email recipients can reach.
 
 ### SSL/TLS Configuration
 For production deployments:
 1. Ensure your domain has valid SSL certificates
 2. Configure your reverse proxy (nginx, Apache, etc.) for HTTPS
-3. Update `NEXTAUTH_URL` to use `https://` protocol
+3. Update `NEXTAUTH_URL` and `NEXT_PUBLIC_BASE_URL` to use the same public `https://` origin
 4. Verify OAuth providers (if used) allow your production domain
 
 ### Reverse Proxy Configuration

--- a/docs/getting-started/setup_guide_windows.md
+++ b/docs/getting-started/setup_guide_windows.md
@@ -112,6 +112,7 @@ This guide provides step-by-step instructions for setting up the PSA system on W
    - `EMAIL_PORT=587`
    - `EMAIL_USERNAME=noreply@example.com`
    - `NEXTAUTH_URL=http://localhost:3000`
+   - `NEXT_PUBLIC_BASE_URL=http://localhost:3000` (required; use your public URL in production)
    - `NEXTAUTH_SESSION_EXPIRES=86400`
 
    Optional: enable collaborative editing by setting `REQUIRE_HOCUSPOCUS=true`.
@@ -339,14 +340,19 @@ NEXTAUTH_URL=http://localhost:3000
 For production deployment:
 ```bash
 NEXTAUTH_URL=https://your-domain.com
+NEXT_PUBLIC_BASE_URL=https://your-domain.com
 HOST=https://your-domain.com
 ```
+
+`NEXT_PUBLIC_BASE_URL` is required by the prebuilt Compose stack. Marketing
+emails use it for recipient-facing unsubscribe, click-tracking, and open-tracking
+links. Set it to an origin that email recipients can reach.
 
 ### SSL/TLS Configuration
 For production deployments:
 1. Ensure your domain has valid SSL certificates
 2. Configure your reverse proxy (nginx, Apache, etc.) for HTTPS
-3. Update `NEXTAUTH_URL` to use `https://` protocol
+3. Update `NEXTAUTH_URL` and `NEXT_PUBLIC_BASE_URL` to use the same public `https://` origin
 4. Verify OAuth providers (if used) allow your production domain
 
 ### Email Configuration for Production

--- a/helm/templates/deployment.yaml
+++ b/helm/templates/deployment.yaml
@@ -583,6 +583,9 @@ spec:
           {{- $publicAppUrl := hasPrefix "http" $rawAppUrl | ternary $rawAppUrl (printf "https://%s" $rawAppUrl) }}
           - name: NEXTAUTH_URL
             value: "{{ $publicAppUrl }}"
+          # Runtime-only public URL for server-side jobs and outbound links
+          - name: APPLICATION_URL
+            value: "{{ $publicAppUrl }}"
           # Public base URL for links in emails and client-side code
           - name: NEXT_PUBLIC_BASE_URL
             value: "{{ $publicAppUrl }}"

--- a/server/docker-compose.prebuilt.yaml
+++ b/server/docker-compose.prebuilt.yaml
@@ -58,7 +58,8 @@ x-common-config: &common-config
 
     # ---- AUTH ----
     NEXTAUTH_URL: ${NEXTAUTH_URL}
-    NEXT_PUBLIC_BASE_URL: ${NEXT_PUBLIC_BASE_URL:-http://localhost:3000}
+    APPLICATION_URL: ${NEXT_PUBLIC_BASE_URL:?Set NEXT_PUBLIC_BASE_URL to the public application URL}
+    NEXT_PUBLIC_BASE_URL: ${NEXT_PUBLIC_BASE_URL:?Set NEXT_PUBLIC_BASE_URL to the public application URL}
     NEXTAUTH_SESSION_EXPIRES: ${NEXTAUTH_SESSION_EXPIRES}
 
     # ---- DEPLOY INFO  ----

--- a/server/docker-compose.yaml
+++ b/server/docker-compose.yaml
@@ -58,6 +58,7 @@ x-common-config: &common-config
 
     # ---- AUTH ----
     NEXTAUTH_URL: ${NEXTAUTH_URL}
+    APPLICATION_URL: ${APPLICATION_URL:-${NEXT_PUBLIC_BASE_URL:-http://localhost:3000}}
     NEXT_PUBLIC_BASE_URL: ${NEXT_PUBLIC_BASE_URL:-http://localhost:3000}
     NEXTAUTH_SESSION_EXPIRES: ${NEXTAUTH_SESSION_EXPIRES}
 

--- a/server/src/lib/jobs/handlers/marketingJobs.ts
+++ b/server/src/lib/jobs/handlers/marketingJobs.ts
@@ -28,18 +28,18 @@ const STALE_TARGET_GRACE_HOURS = 48;
 
 /**
  * Canonical public base URL for absolute links in outbound marketing email
- * (unsubscribe link, tracking pixel, click redirect). Internal service and
- * authentication URLs are deliberately not eligible because recipients must
- * be able to reach every generated link.
+ * (unsubscribe link, tracking pixel, click redirect). These server-only
+ * variables are resolved when the job runs, unlike NEXT_PUBLIC_* variables
+ * that Next.js can freeze into the image during compilation.
  */
 function getPublicBaseUrl(): string {
   const raw =
-    process.env.NEXT_PUBLIC_BASE_URL
-    || process.env.NEXT_PUBLIC_APP_URL
+    process.env.APPLICATION_URL
+    || process.env.NEXTAUTH_URL
     || '';
   if (!raw) {
     throw new Error(
-      'No public marketing base URL available (NEXT_PUBLIC_BASE_URL or NEXT_PUBLIC_APP_URL); refusing to send sequence steps',
+      'No runtime public marketing base URL available (APPLICATION_URL or NEXTAUTH_URL); refusing to send sequence steps',
     );
   }
   return raw.endsWith('/') ? raw.slice(0, -1) : raw;

--- a/server/src/test/unit/jobs/marketingJobs.publicUrl.test.ts
+++ b/server/src/test/unit/jobs/marketingJobs.publicUrl.test.ts
@@ -56,10 +56,10 @@ describe('marketing sequence job public URL', () => {
       failed: 0,
       skipped: 0,
     });
-    process.env.APPLICATION_URL = 'http://alga-core.msp.svc.cluster.local:3000';
-    process.env.NEXTAUTH_URL = 'http://auth.msp.svc.cluster.local:3000';
-    process.env.NEXT_PUBLIC_BASE_URL = 'https://public.example.test/';
-    process.env.NEXT_PUBLIC_APP_URL = 'https://fallback.example.test/';
+    process.env.APPLICATION_URL = 'https://runtime-public.example.test/';
+    process.env.NEXTAUTH_URL = 'https://auth-fallback.example.test/';
+    process.env.NEXT_PUBLIC_BASE_URL = 'https://image-build.example.test/';
+    process.env.NEXT_PUBLIC_APP_URL = 'https://image-build-fallback.example.test/';
   });
 
   afterEach(() => {
@@ -73,7 +73,7 @@ describe('marketing sequence job public URL', () => {
     else process.env.NEXT_PUBLIC_APP_URL = originalPublicAppUrl;
   });
 
-  it('uses the explicit public URL instead of internal application and auth hosts', async () => {
+  it('uses the runtime application URL instead of NEXT_PUBLIC values from the image build', async () => {
     const { marketingSendSequenceStepsHandler } = await import(
       'server/src/lib/jobs/handlers/marketingJobs'
     );
@@ -81,20 +81,34 @@ describe('marketing sequence job public URL', () => {
     await marketingSendSequenceStepsHandler({ tenantId: 'tenant-1' });
 
     expect(sendDueSequenceStepsInternalMock).toHaveBeenCalledWith(knex, 'tenant-1', {
-      baseUrl: 'https://public.example.test',
+      baseUrl: 'https://runtime-public.example.test',
       signingSecret: 'test-signing-secret',
     });
   });
 
-  it('fails closed when only internal application and auth hosts are configured', async () => {
-    delete process.env.NEXT_PUBLIC_BASE_URL;
-    delete process.env.NEXT_PUBLIC_APP_URL;
+  it('falls back to the runtime authentication URL for non-Compose local launches', async () => {
+    delete process.env.APPLICATION_URL;
+    const { marketingSendSequenceStepsHandler } = await import(
+      'server/src/lib/jobs/handlers/marketingJobs'
+    );
+
+    await marketingSendSequenceStepsHandler({ tenantId: 'tenant-1' });
+
+    expect(sendDueSequenceStepsInternalMock).toHaveBeenCalledWith(knex, 'tenant-1', {
+      baseUrl: 'https://auth-fallback.example.test',
+      signingSecret: 'test-signing-secret',
+    });
+  });
+
+  it('fails closed when runtime-only public URLs are absent', async () => {
+    delete process.env.APPLICATION_URL;
+    delete process.env.NEXTAUTH_URL;
     const { marketingSendSequenceStepsHandler } = await import(
       'server/src/lib/jobs/handlers/marketingJobs'
     );
 
     await expect(marketingSendSequenceStepsHandler({ tenantId: 'tenant-1' }))
-      .rejects.toThrow('No public marketing base URL available');
+      .rejects.toThrow('No runtime public marketing base URL available');
     expect(sendDueSequenceStepsInternalMock).not.toHaveBeenCalled();
   });
 });

--- a/server/src/test/unit/jobs/marketingPublicUrlDeployment.contract.test.ts
+++ b/server/src/test/unit/jobs/marketingPublicUrlDeployment.contract.test.ts
@@ -1,0 +1,72 @@
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+
+import { describe, expect, it } from 'vitest';
+
+const repoRoot = resolve(process.cwd(), '..');
+
+function readRepoFile(path: string): string {
+  return readFileSync(resolve(repoRoot, path), 'utf8');
+}
+
+describe('marketing public URL deployment contract', () => {
+  it('requires an explicit recipient-facing URL in prebuilt Compose', () => {
+    const prebuiltCompose = readRepoFile('server/docker-compose.prebuilt.yaml');
+    const productionCompose = readRepoFile('docker-compose.prod.yaml');
+
+    expect(prebuiltCompose).toContain(
+      'APPLICATION_URL: ${NEXT_PUBLIC_BASE_URL:?Set NEXT_PUBLIC_BASE_URL to the public application URL}',
+    );
+    expect(prebuiltCompose).toContain(
+      'NEXT_PUBLIC_BASE_URL: ${NEXT_PUBLIC_BASE_URL:?Set NEXT_PUBLIC_BASE_URL to the public application URL}',
+    );
+    expect(prebuiltCompose).not.toContain(
+      'NEXT_PUBLIC_BASE_URL: ${NEXT_PUBLIC_BASE_URL:-http://localhost:3000}',
+    );
+    expect(productionCompose).toContain(
+      'APPLICATION_URL: ${NEXT_PUBLIC_BASE_URL:?Set NEXT_PUBLIC_BASE_URL to the public application URL}',
+    );
+    expect(productionCompose).toContain(
+      'NEXT_PUBLIC_BASE_URL: ${NEXT_PUBLIC_BASE_URL:?Set NEXT_PUBLIC_BASE_URL to the public application URL}',
+    );
+  });
+
+  it('keeps explicit localhost values in the local env example and source Compose', () => {
+    const envExample = readRepoFile('.env.example');
+    const sourceCompose = readRepoFile('server/docker-compose.yaml');
+
+    expect(envExample).toContain('NEXT_PUBLIC_BASE_URL=http://localhost:3000');
+    expect(sourceCompose).toContain(
+      'APPLICATION_URL: ${APPLICATION_URL:-${NEXT_PUBLIC_BASE_URL:-http://localhost:3000}}',
+    );
+    expect(sourceCompose).toContain(
+      'NEXT_PUBLIC_BASE_URL: ${NEXT_PUBLIC_BASE_URL:-http://localhost:3000}',
+    );
+  });
+
+  it('documents the required public URL for production operators', () => {
+    const configurationGuide = readRepoFile('docs/getting-started/configuration_guide.md');
+    const setupGuides = [
+      readRepoFile('docs/getting-started/setup_guide.md'),
+      readRepoFile('docs/getting-started/setup_guide_windows.md'),
+    ];
+
+    expect(configurationGuide).toContain(
+      'NEXT_PUBLIC_BASE_URL=http://localhost:3000  # Required by prebuilt Compose',
+    );
+    for (const setupGuide of setupGuides) {
+      expect(setupGuide).toContain('NEXT_PUBLIC_BASE_URL=https://your-domain.com');
+      expect(setupGuide).toContain(
+        '`NEXT_PUBLIC_BASE_URL` is required by the prebuilt Compose stack.',
+      );
+    }
+  });
+
+  it('injects the public Helm URL into server-only runtime configuration', () => {
+    const deployment = readRepoFile('helm/templates/deployment.yaml');
+
+    expect(deployment).toMatch(
+      /- name: APPLICATION_URL\s+value: "\{\{ \$publicAppUrl \}\}"/,
+    );
+  });
+});


### PR DESCRIPTION
## Summary

- Resolve recipient-facing marketing URLs from server runtime configuration (`APPLICATION_URL`, with `NEXTAUTH_URL` as the local-launch fallback) so jobs do not consume `NEXT_PUBLIC_*` values frozen into an image at build time.
- Require `NEXT_PUBLIC_BASE_URL` in prebuilt and production Compose, propagate it into both `APPLICATION_URL` and `NEXT_PUBLIC_BASE_URL`, and preserve explicit localhost defaults in source-development Compose.
- Inject the public application URL into the Helm server runtime, document the required production setting, and add focused job and deployment-contract coverage.
- Restack the post-merge mitigation commit onto current `main` after PR #3010 merged.

## Smoke test

**PASS — one coverage limit disclosed.**

- Created a contact and enrolled it in an active marketing sequence through the real UI.
- Allowed the natural pg-boss schedule to deliver through the repository's existing GreenMail simulator.
- Verified the delivered MIME used `http://localhost:3016` for unsubscribe, click-tracking, and open-tracking URLs.
- Submitted the public unsubscribe form and confirmed suppression in PostgreSQL.
- Exercised signed click/open endpoints; confirmed redirect/pixel responses, persisted interactions, and 50% open/click metrics in the UI.
- Confirmed suppressed re-enrollment was blocked and no additional enrollment was created.
- Verified prebuilt CE/EE Compose rejects a missing `NEXT_PUBLIC_BASE_URL` and propagates a configured public URL.
- Verified production EE preserves temporal-worker `APPLICATION_URL=http://server:3000` while supplying public `NEXT_PUBLIC_BASE_URL`.

Fidelity: real UI, Next.js server, PostgreSQL, Redis, pg-boss, and SMTP were used. GreenMail was the repository's existing email simulator; no new simulator or mock was created.

Coverage limit: live multi-tenant Temporal fanout was not executable because this wired CE stack has no healthy Temporal service, so its deployment URL separation was verified by rendering the real production Compose configuration.

Concern: the test SMTP sender `sales@localhost` caused a queued-event email-validation warning, although SMTP delivery and the sent event succeeded. This appears to be fixture configuration, not a regression in the change.

Final state: port 3016 answers, GreenMail is ready, supporting containers are running, and the worktree is clean.

Evidence: `/tmp/alga-smoke-evidence/marketing-workflow-fanout-fix-20260725T032804Z`
