### PR TITLE
fix(billing): resolve bucket config by configuration_type

### DIFF
--- a/docs/plans/2026-07-25-contract-bucket-usage-error-plan.md
+++ b/docs/plans/2026-07-25-contract-bucket-usage-error-plan.md
@@ -1,0 +1,276 @@
+# Contract bucket usage error — implementation plan
+
+Ticket: **alga0002175** — "Error when allocating time to bucket".
+Branch: `fix/contract-bucket-usage-error`.
+Date: 2026-07-25.
+
+## Problem
+
+A contract is configured with 7 hours included at one rate and overage above
+that at a higher rate. Saving a manual time entry against that service fails
+with:
+
+> Unable to update bucket usage for this time entry. Please refresh and try again.
+
+Time entry against a service with no bucket works. Recreating the contract from
+scratch reproduces the same error.
+
+## Root cause
+
+Confirmed against production data.
+
+`findOrCreateCurrentBucketUsageRecord` resolves the bucket configuration in two
+steps. First it finds the configuration row
+(`shared/billingClients/bucketUsageService.ts:356`):
+
+```js
+const planServiceConfig = await db.table('contract_line_service_configuration')
+    .where({ contract_line_id: planId, service_id: serviceCatalogId })
+    .first<{ config_id: string }>();
+```
+
+Then it loads the bucket detail row for that `config_id` (line 367), and throws
+if there isn't one (line 375).
+
+The first query omits `configuration_type` and has no `ORDER BY`. The data model
+deliberately allows **several configuration rows per (contract line, service)**,
+one per `configuration_type`, each with its own detail table — see
+`packages/billing/src/repositories/contractLineRepository.ts:363-410`, which
+loops over configurations for a single service and clones a
+`..._bucket_config` or `..._hourly_config` row per configuration. So the query
+selects an arbitrary row from a set that legitimately holds more than one, and
+when it returns a non-bucket row the detail lookup finds nothing and throws.
+
+The reproducing shape is a contract line holding two configuration rows for one
+service:
+
+| configuration_type | bucket detail row |
+| --- | --- |
+| Bucket | yes |
+| Hourly | no |
+
+An Hourly line with a Bucket overlay — "7 hours included, overage above that" —
+*is* two configurations on one line. A service with no bucket has one
+configuration and the caller's guard skips the block entirely, which is why that
+case works. In the reporting tenant no `time_entries` row had ever been written:
+every attempt had failed.
+
+Everything else on the path was healthy and was ruled out by inspection:
+
+- Assignment resolution succeeds: the client contract is active, starts before
+  the entry date, and has no end date.
+- `billing_frequency` is `monthly`; `total_minutes` is 420 (= 7 hours), and an
+  overage rate is set.
+- A `recurring_service_periods` row covers the entry date, so period calculation
+  succeeds.
+- Only one active assignment matches, so the ambiguity guard at line 183 does
+  not fire.
+
+Production logs (Loki, incident window) confirm the mechanism directly: every
+failed save threw `Bucket configuration not found`, and the named `config_id`
+was a **non-Bucket** configuration row — the Hourly row on the live line for the
+final attempts, and a Usage row on an earlier attempt, proving the defect is
+wrong-type selection generally rather than anything Hourly-specific. The
+earliest failures show one further variant: a Bucket configuration row whose
+detail row did not exist yet (a half-saved configuration, completed by a later
+re-save). That variant produces the same user message and maps to
+`MISSING_BUCKET_CONFIG` in the new error taxonomy, whose "re-save the bucket
+configuration" guidance is exactly the action that cures it.
+
+### Why the report was undiagnosable
+
+`timeEntryCrudActions.ts:742-746` catches any bucket failure and rewraps it as a
+generic `Bucket usage update failed …`. `timeSheetActionErrors.ts:47` then
+matches that string and returns one fixed sentence. Four distinct causes —
+no active line, ambiguous assignment, missing bucket config, unsupported
+frequency — reach the user as the same words. Identifying this one needed a
+production database session.
+
+### Blast radius
+
+The defect is not tenant-specific. Fleet-wide, **18 (contract line, service)
+pairs across roughly 10 tenants** carry a Bucket configuration alongside another
+type, and every one can fail the same way. Which row Postgres returns is not
+guaranteed stable across plans, statistics or row churn, so a tenant that works
+today can start failing without any change on their side.
+
+Two smaller findings in the reporting tenant, neither a cause of the error:
+
+- **2 detached contract lines** with `contract_id = NULL` and
+  `is_template = false`. Initially read as damage from the recreate attempts;
+  investigation showed they are the deliberate output of removing a line from a
+  contract. See "Detached contract lines" under follow-ups. Note that
+  `contract_id = NULL` is also legitimate for template lines — 53 exist
+  fleet-wide — so any detection must filter on `is_template = false`. Twelve
+  detached lines exist across five tenants.
+- **Duplicate Bucket configurations** on one line (two Bucket rows for one
+  service). This is the only such duplicate fleet-wide, and it sits on one of
+  the detached lines.
+
+Neither blocks the reporter once the lookup is fixed; the live line is clean.
+
+## Scope
+
+In scope: the lookup fix, distinguishable errors on the bucket path, regression
+coverage, and a post-deploy fleet audit.
+
+Out of scope, recorded as follow-ups below: the `weekly` billing-frequency gap,
+a uniqueness constraint on configurations, and cleanup of detached contract
+lines.
+
+**The detached-line repair script was dropped after investigation** — see
+"Detached contract lines" under follow-ups. The rows are not corruption and are
+harmless; the code fix alone resolves the ticket.
+
+## Work items
+
+### 1. Qualify the bucket configuration lookup
+
+`shared/billingClients/bucketUsageService.ts:356`
+
+Add `configuration_type: 'Bucket'` to the `where` clause, and order by
+`created_at` ascending so the choice is deterministic if two Bucket rows ever
+coexist. The type filter is the fix; the ordering removes the residual
+nondeterminism.
+
+Update the header comment (lines 1-18), which already warns against re-deriving
+contract-line ownership, to also state that any lookup of
+`contract_line_service_configuration` on this path must qualify by
+`configuration_type` — a line and service can carry several.
+
+### 2. Qualify the sibling joins
+
+`updateBucketUsageMinutes` (line 534) and `reconcileBucketUsageRecord`
+(line 603) join `contract_line_service_configuration` on the same key without
+the type qualifier. Both are currently safe by accident: their inner join to
+`contract_line_service_bucket_config` discards non-bucket rows.
+
+Add the explicit `configuration_type = 'Bucket'` condition to both joins. No
+behavior change today; it removes a trap for the next edit and makes all three
+call sites read consistently.
+
+### 3. Make bucket failures distinguishable
+
+New module `shared/billingClients/bucketUsageErrors.ts`:
+
+- `BucketUsageError extends Error`, carrying a `code` and a `details` bag of
+  identifiers (tenant, client, contract line, service, date).
+- Codes: `NO_ACTIVE_CONTRACT_LINE`, `AMBIGUOUS_ASSIGNMENT`,
+  `MISSING_BUCKET_CONFIG`, `MISSING_PLAN_SERVICE_CONFIG`,
+  `UNSUPPORTED_BILLING_FREQUENCY`.
+- `isBucketUsageError(value): value is BucketUsageError`.
+
+Throw it in place of the bare `Error`s at `bucketUsageService.ts` lines 184
+(ambiguous), 276 and 441 (unsupported frequency), 329 (no active line), 364
+(missing plan service config) and 375 (missing bucket config). Messages keep
+their current detail for the server log.
+
+The two call sites that rewrap — `timeEntryCrudActions.ts:745` and `:1104`, and
+`usageActions.ts:138`, `:260`, `:332` — must preserve the code. Rethrow the
+`BucketUsageError` unchanged, or wrap with `{ cause }` and have the guard
+unwrap; do not flatten it into a string.
+
+In `timeSheetActionErrors.ts` and `usageActions.ts:38`, check
+`isBucketUsageError` **before** the existing string matches and map each code to
+an actionable sentence:
+
+| Code | User-facing message |
+| --- | --- |
+| `NO_ACTIVE_CONTRACT_LINE` | No active contract covers this date for this client and service. Check the contract's start date and that it is active. |
+| `AMBIGUOUS_ASSIGNMENT` | More than one active contract gives this client a bucket for this service. End-date or deactivate the duplicate. |
+| `MISSING_BUCKET_CONFIG` / `MISSING_PLAN_SERVICE_CONFIG` | This contract line's bucket settings are incomplete. Re-save the bucket configuration on the contract line. |
+| `UNSUPPORTED_BILLING_FREQUENCY` | Bucket billing does not support this contract line's billing frequency. |
+
+Keep the existing string-matching fallback so any unconverted throw still maps
+to the current generic message. This follows the repo's failure-handling
+philosophy — fail fast with actionable, descriptive messages
+(`docs/AI_coding_standards.md:10-14`).
+
+### 4. Tests
+
+**Unit** — `server/src/test/unit/bucketUsageService.test.ts` already mocks the
+transaction and records `whereCalls`, which is exactly the hook needed. Add:
+
+- A configuration set containing both a Bucket row and an Hourly row for one
+  (line, service), asserting the returned `config_id` is the Bucket one. This
+  test fails before the fix.
+- An assertion that the `contract_line_service_configuration` query includes
+  `configuration_type: 'Bucket'`.
+- One test per `BucketUsageError` code, asserting the code rather than the
+  message text.
+
+**Integration** — `server/src/test/integration/bucketUsageIntegration.test.ts`:
+build an Hourly contract line with a Bucket overlay on the same service, save a
+billable time entry, and assert it persists and `bucket_usage.minutes_used`
+increments by the entry's billable minutes. This is the reported shape and no
+existing test covers it.
+
+**Mapper** — assert each code maps to its distinct message and that an unknown
+error still falls through to the generic text.
+
+## Verification
+
+1. Unit and integration suites above pass; the new unit test is confirmed to
+   fail against the unfixed lookup.
+2. On the local stack, rebuild the reported configuration — Hourly line, 7-hour
+   bucket overlay, higher overage rate — and save a manual time entry on a
+   ticket. It saves, and `bucket_usage` shows the minutes.
+3. Log a second entry that crosses the 420-minute threshold and confirm
+   `overage_minutes` is the excess.
+4. Post-deploy, re-run the fleet audit query (Bucket plus another type per line
+   and service) and confirm a time entry succeeds for at least one previously
+   affected tenant besides the reporter's.
+5. Confirm the live contract line and its Bucket config are untouched
+   throughout.
+
+## Follow-ups (not in this branch)
+
+- **`weekly` billing frequency**: the UI offers it
+  (`packages/billing/src/constants/billing.ts:15`) but `calculatePeriod`'s
+  switch handles only monthly, quarterly and annually and throws on anything
+  else (`bucketUsageService.ts:276`). A weekly bucket line can never record
+  time. Worth its own ticket.
+- **Uniqueness**: no constraint stops duplicate configurations per
+  `(tenant, contract_line_id, service_id, configuration_type)`. Exactly one
+  violation exists fleet-wide, so the data is clean enough to add one.
+- **Detached contract lines** (investigated 2026-07-25; no action taken).
+  Removing a line from a contract is implemented as an *unlink*:
+  `ContractLineMapping.removeContractLine`
+  (`packages/billing/src/models/contractLineMapping.ts:226-235`) sets
+  `contract_id = NULL`, clears `custom_rate`, and leaves the line, its
+  configurations, services and schedules in place. This is deliberate, not a
+  stranding bug. No code anywhere filters `contract_id IS NULL` on
+  `contract_lines`, so detached lines are never listed or offered for re-attach
+  — they are unreachable dead rows that accrue on every line removal (12 across
+  5 tenants, accumulating steadily since 2025-12).
+
+  A cleanup script was planned and then dropped: nothing billable is attached to
+  any of them (zero `bucket_usage`, `usage_tracking`, `time_entries` and
+  `contract_line_discounts` rows), and users cannot see them, so they are
+  harmless. Two things a future cleanup must get right, both discovered while
+  scoping it:
+  - `bucket_usage` and `usage_tracking` are **`ON DELETE CASCADE`** from
+    `contract_lines`. A naive delete silently destroys usage and billing
+    records. Seven tables reference `contract_lines`; six reference
+    `contract_line_service_configuration` (bucket, fixed, hourly, hourlys,
+    rate_tiers, usage) — not the two a first pass assumes.
+  - `recurring_service_periods` has **no foreign key** — `obligation_id` is
+    loose — so it never cascades and must be cleaned explicitly. 99 such rows
+    currently point at detached lines across 3 tenants; these are the only
+    residue with a plausible ongoing effect.
+
+  The better fix is probably at the source: have line removal clean up after
+  itself, or mark the line inactive so it stops generating service periods.
+  That is a product decision about contract editing and belongs in its own
+  ticket.
+- **Bad template values**: one template line in the reporting tenant has
+  `total_minutes = 7`, i.e. 7 minutes where 7 hours (420) was meant. It will
+  propagate to any contract created from it. Customer data, but worth flagging
+  in the ticket reply.
+
+## Notes for the ticket reply
+
+The reported configuration was correct throughout; recreating the contract was
+never going to help, because the failure is in how the application resolves a
+bucket overlay, not in what was configured. A 420-minute bucket with a higher
+overage rate is exactly right.

--- a/packages/billing/src/actions/usageActions.ts
+++ b/packages/billing/src/actions/usageActions.ts
@@ -6,6 +6,11 @@ import { determineDefaultContractLine } from '@alga-psa/billing/lib/contractLine
 import { ICreateUsageRecord, IUpdateUsageRecord, IUsageFilter, IUsageRecord } from '@alga-psa/types';
 import { revalidatePath } from 'next/cache';
 import { findOrCreateCurrentBucketUsageRecord, updateBucketUsageMinutes } from '../services/bucketUsageService'; // Import bucket service functions
+import {
+  bucketUsageErrorMessage,
+  findBucketUsageError,
+  isBucketUsageError,
+} from '@alga-psa/shared/billingClients/bucketUsageErrors';
 import { withAuth } from '@alga-psa/auth';
 import { hasPermission } from '@alga-psa/auth/rbac';
 import { getAnalyticsAsync } from '../lib/authHelpers';
@@ -27,6 +32,12 @@ function tenantScopedTable(
 }
 
 function usageActionErrorFrom(error: unknown): UsageActionError | null {
+  // Typed bucket failures name their cause; prefer them over the string match.
+  const bucketError = findBucketUsageError(error);
+  if (bucketError) {
+    return actionError(bucketUsageErrorMessage(bucketError));
+  }
+
   if (error instanceof Error) {
     const message = error.message;
     if (message.startsWith('Permission denied:')) {
@@ -135,6 +146,7 @@ export const createUsageRecord = withAuth(async (user, { tenant }, data: ICreate
             console.log(`Successfully updated bucket usage for usage record ${record.usage_id}`);
           } catch (bucketError) {
             console.error(`Error updating bucket usage for usage record ${record.usage_id}:`, bucketError);
+            if (isBucketUsageError(bucketError)) throw bucketError;
             throw new Error(`Bucket usage update failed for usage record ${record.usage_id}: ${bucketError instanceof Error ? bucketError.message : String(bucketError)}`);
           }
         }
@@ -257,6 +269,7 @@ export const updateUsageRecord = withAuth(async (user, { tenant }, data: IUpdate
             console.log(`Successfully updated bucket usage for usage record ${updatedRecord.usage_id}`);
           } catch (bucketError) {
             console.error(`Error updating bucket usage for usage record ${updatedRecord.usage_id}:`, bucketError);
+            if (isBucketUsageError(bucketError)) throw bucketError;
             throw new Error(`Bucket usage update failed for usage record ${updatedRecord.usage_id}: ${bucketError instanceof Error ? bucketError.message : String(bucketError)}`);
           }
         }
@@ -329,6 +342,7 @@ export const deleteUsageRecord = withAuth(async (user, { tenant }, usageId: stri
             console.log(`Successfully updated (decremented) bucket usage for deleted usage record ${usageId}`);
           } catch (bucketError) {
             console.error(`Error updating bucket usage before deleting usage record ${usageId}:`, bucketError);
+            if (isBucketUsageError(bucketError)) throw bucketError;
             throw new Error(`Bucket usage update failed before deleting usage record ${usageId}: ${bucketError instanceof Error ? bucketError.message : String(bucketError)}`);
           }
         }

--- a/packages/scheduling/src/actions/timeEntryCrudActions.ts
+++ b/packages/scheduling/src/actions/timeEntryCrudActions.ts
@@ -8,6 +8,7 @@ import { determineDefaultContractLine } from '../lib/contractLineDisambiguation'
 // the dropped `client_contract_lines` table and caused a prod outage on
 // time-entry save. Don't recreate a local copy.
 import { findOrCreateCurrentBucketUsageRecord, updateBucketUsageMinutes } from '@alga-psa/shared/billingClients/bucketUsageService';
+import { isBucketUsageError } from '@alga-psa/shared/billingClients/bucketUsageErrors';
 import {
   ITimeEntry,
   ITimeEntryWithWorkItem,
@@ -741,7 +742,12 @@ export const saveTimeEntry = withAuth(async (
                 console.log(`Successfully updated bucket usage for entry ${resultingEntry.entry_id}`);
               } catch (bucketError) {
                 console.error(`Error updating bucket usage for time entry ${resultingEntry.entry_id}:`, bucketError);
-                // Re-throwing ensures data consistency.
+                // Re-throwing ensures data consistency. Keep the typed failure
+                // intact — the action guard maps its code to a message the user
+                // can actually act on.
+                if (isBucketUsageError(bucketError)) {
+                  throw bucketError;
+                }
                 throw new Error(`Bucket usage update failed for time entry ${resultingEntry.entry_id}: ${bucketError instanceof Error ? bucketError.message : String(bucketError)}`);
               }
             } else {
@@ -1100,7 +1106,10 @@ export const deleteTimeEntry = withAuth(async (
                 console.log(`Successfully decremented bucket usage for deleted entry ${entryId}`);
               } catch (bucketError) {
                 console.error(`Error updating bucket usage for deleted time entry ${entryId}:`, bucketError);
-                // Re-throwing ensures data consistency.
+                // Re-throwing ensures data consistency; preserve the typed code.
+                if (isBucketUsageError(bucketError)) {
+                  throw bucketError;
+                }
                 throw new Error(`Bucket usage update failed while deleting time entry ${entryId}: ${bucketError instanceof Error ? bucketError.message : String(bucketError)}`);
               }
             }

--- a/packages/scheduling/src/actions/timeSheetActionErrors.test.ts
+++ b/packages/scheduling/src/actions/timeSheetActionErrors.test.ts
@@ -1,5 +1,10 @@
 import { describe, expect, it } from 'vitest';
 import { timeSheetActionErrorFrom } from './timeSheetActionErrors';
+import {
+  BUCKET_USAGE_ERROR_MESSAGES,
+  BucketUsageError,
+  type BucketUsageErrorCode,
+} from '@alga-psa/shared/billingClients/bucketUsageErrors';
 
 describe('timeSheetActionErrorFrom', () => {
   it('maps expected permission, not-found, and workflow-state failures to action results', () => {
@@ -18,5 +23,57 @@ describe('timeSheetActionErrorFrom', () => {
 
   it('leaves unexpected failures unhandled', () => {
     expect(timeSheetActionErrorFrom(new Error('database connection lost'))).toBeNull();
+  });
+
+  describe('bucket usage failures', () => {
+    // Regression: alga0002175. These causes are unrelated and need different
+    // actions from the user, but all used to surface as the single sentence
+    // "Unable to update bucket usage for this time entry."
+    const codes: BucketUsageErrorCode[] = [
+      'NO_ACTIVE_CONTRACT_LINE',
+      'AMBIGUOUS_ASSIGNMENT',
+      'MISSING_PLAN_SERVICE_CONFIG',
+      'MISSING_BUCKET_CONFIG',
+      'UNSUPPORTED_BILLING_FREQUENCY',
+    ];
+
+    it.each(codes)('maps %s to its own message', (code) => {
+      const result = timeSheetActionErrorFrom(
+        new BucketUsageError(code, 'internal detail that must not reach the user'),
+      );
+
+      expect(result).toEqual({ actionError: BUCKET_USAGE_ERROR_MESSAGES[code] });
+    });
+
+    it('gives each code a distinct message', () => {
+      const messages = codes.map((code) => BUCKET_USAGE_ERROR_MESSAGES[code]);
+      expect(new Set(messages).size).toBe(messages.length);
+    });
+
+    it('never leaks the internal message to the user', () => {
+      const result = timeSheetActionErrorFrom(
+        new BucketUsageError('MISSING_BUCKET_CONFIG', 'config_id abc-123 in tenant xyz'),
+      );
+
+      expect(JSON.stringify(result)).not.toContain('abc-123');
+    });
+
+    it('recovers the code when the failure was wrapped on its way up', () => {
+      const wrapped = new Error('Bucket usage update failed for time entry entry-1', {
+        cause: new BucketUsageError('AMBIGUOUS_ASSIGNMENT', 'two assignments matched'),
+      });
+
+      expect(timeSheetActionErrorFrom(wrapped)).toEqual({
+        actionError: BUCKET_USAGE_ERROR_MESSAGES.AMBIGUOUS_ASSIGNMENT,
+      });
+    });
+
+    it('still handles an unconverted bucket failure via the string fallback', () => {
+      expect(
+        timeSheetActionErrorFrom(new Error('Bucket usage update failed for time entry entry-1')),
+      ).toEqual({
+        actionError: 'Unable to update bucket usage for this time entry. Please refresh and try again.',
+      });
+    });
   });
 });

--- a/packages/scheduling/src/actions/timeSheetActionErrors.ts
+++ b/packages/scheduling/src/actions/timeSheetActionErrors.ts
@@ -4,10 +4,22 @@ import {
   type ActionMessageError,
   type ActionPermissionError,
 } from '@alga-psa/ui/lib/errorHandling';
+import {
+  bucketUsageErrorMessage,
+  findBucketUsageError,
+} from '@alga-psa/shared/billingClients/bucketUsageErrors';
 
 export type TimeSheetActionError = ActionMessageError | ActionPermissionError;
 
 export function timeSheetActionErrorFrom(error: unknown): TimeSheetActionError | null {
+  // Check the typed bucket failure first: it carries which of several unrelated
+  // causes fired, so it can say something the user can act on. The string match
+  // further down is the fallback for any throw not yet converted.
+  const bucketError = findBucketUsageError(error);
+  if (bucketError) {
+    return actionError(bucketUsageErrorMessage(bucketError));
+  }
+
   if (error instanceof Error) {
     const message = error.message;
     if (message.includes('Permission denied:')) {

--- a/server/src/test/integration/bucketUsageOverlayIntegration.test.ts
+++ b/server/src/test/integration/bucketUsageOverlayIntegration.test.ts
@@ -1,0 +1,192 @@
+/*
+ * Regression coverage for alga0002175, against a real Postgres.
+ *
+ * The unit suite mocks the transaction, so it proves the resolution logic but
+ * cannot prove the SQL: whether `configuration_type` and `created_at` exist on
+ * `contract_line_service_configuration`, or whether the ordered, filtered query
+ * actually runs. This exercises the shipped
+ * `findOrCreateCurrentBucketUsageRecord` against the live schema with the
+ * failing shape — an Hourly contract line carrying a Bucket overlay on the same
+ * service, i.e. "7 hours included, overage above that".
+ *
+ * Opt-in: needs a reachable database, so it is skipped unless RUN_DB_TESTS=1.
+ * Everything runs inside one transaction that is always rolled back.
+ */
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import knexFactory, { Knex } from 'knex';
+import { randomUUID } from 'node:crypto';
+import {
+  findOrCreateCurrentBucketUsageRecord,
+  updateBucketUsageMinutes,
+} from '@alga-psa/shared/billingClients/bucketUsageService';
+
+const ENABLED = process.env.RUN_DB_TESTS === '1';
+const TOTAL_MINUTES = 420; // 7 hours included
+
+let db: Knex;
+
+describe.skipIf(!ENABLED)('bucket usage with an Hourly + Bucket overlay (real DB)', () => {
+  beforeAll(() => {
+    // The shared vitest setup loads .env.localtest and overwrites DB_*, so read
+    // dedicated BUCKET_TEST_DB_* overrides that nothing else touches.
+    db = knexFactory({
+      client: 'pg',
+      connection: {
+        host: process.env.BUCKET_TEST_DB_HOST || process.env.DB_HOST || '127.0.0.1',
+        port: Number(process.env.BUCKET_TEST_DB_PORT || process.env.DB_PORT || 5432),
+        database: process.env.BUCKET_TEST_DB_NAME || process.env.DB_NAME_SERVER || 'server',
+        user: process.env.BUCKET_TEST_DB_USER || process.env.DB_USER_SERVER || 'app_user',
+        password: process.env.BUCKET_TEST_DB_PASSWORD || process.env.DB_PASSWORD_SERVER,
+      },
+      pool: { min: 0, max: 2 },
+    });
+  });
+
+  afterAll(async () => {
+    if (db) await db.destroy();
+  });
+
+  /**
+   * Seeds the failing shape and hands the caller a transaction that is rolled
+   * back no matter what the body does.
+   */
+  async function withSeededOverlay(
+    body: (ctx: {
+      trx: Knex.Transaction;
+      tenant: string;
+      clientId: string;
+      serviceId: string;
+      contractLineId: string;
+      bucketConfigId: string;
+      hourlyConfigId: string;
+      entryDate: string;
+    }) => Promise<void>,
+  ) {
+    const tenant: string = (await db('tenants').first('tenant')).tenant;
+
+    await db
+      .transaction(async (trx) => {
+        // bucketUsageService reads the tenant off the transaction.
+        (trx as any).client.config.tenant = tenant;
+
+        const serviceTypeId = (
+          await trx('service_types').where({ tenant }).first('id')
+        )?.id ?? (await trx('service_types').first('id'))?.id;
+
+        const clientId = randomUUID();
+        const serviceId = randomUUID();
+        const contractId = randomUUID();
+        const contractLineId = randomUUID();
+        const bucketConfigId = randomUUID();
+        const hourlyConfigId = randomUUID();
+
+        await trx('clients').insert({
+          tenant, client_id: clientId, client_name: `bucket-overlay-${clientId.slice(0, 8)}`,
+        });
+
+        await trx('service_catalog').insert({
+          tenant, service_id: serviceId,
+          service_name: `bucket-overlay-svc-${serviceId.slice(0, 8)}`,
+          billing_method: 'per_unit', custom_service_type_id: serviceTypeId,
+        });
+
+        await trx('contracts').insert({
+          tenant, contract_id: contractId, contract_name: 'Retainer with overage (test)',
+        });
+
+        await trx('contract_lines').insert({
+          tenant, contract_line_id: contractLineId, contract_id: contractId,
+          contract_line_name: 'Retainer with overage (test) - Hourly',
+          contract_line_type: 'Hourly', billing_frequency: 'monthly',
+          cadence_owner: 'client', is_template: false, is_active: true,
+        });
+
+        // Assignment starts before the entry date so period resolution succeeds.
+        await trx('client_contracts').insert({
+          tenant, client_contract_id: randomUUID(), client_id: clientId,
+          contract_id: contractId, start_date: '2026-01-01', end_date: null,
+          is_active: true,
+        });
+
+        // THE SHAPE: two configurations on one (line, service). The Hourly row
+        // is written FIRST so an unqualified `.first()` tends to return it --
+        // that is precisely the alga0002175 failure.
+        await trx('contract_line_service_configuration').insert({
+          tenant, config_id: hourlyConfigId, contract_line_id: contractLineId,
+          service_id: serviceId, configuration_type: 'Hourly',
+          created_at: new Date('2026-01-01T00:00:00Z'),
+        });
+        await trx('contract_line_service_configuration').insert({
+          tenant, config_id: bucketConfigId, contract_line_id: contractLineId,
+          service_id: serviceId, configuration_type: 'Bucket',
+          created_at: new Date('2026-01-01T00:00:01Z'),
+        });
+
+        // Only the Bucket configuration gets a detail row.
+        await trx('contract_line_service_bucket_config').insert({
+          tenant, config_id: bucketConfigId, total_minutes: TOTAL_MINUTES,
+          overage_rate: 18500, allow_rollover: false,
+        });
+
+        await body({
+          trx, tenant, clientId, serviceId, contractLineId,
+          bucketConfigId, hourlyConfigId, entryDate: '2026-03-10T09:00:00Z',
+        });
+
+        throw new Error('__rollback__');
+      })
+      .catch((error: unknown) => {
+        if (error instanceof Error && error.message === '__rollback__') return;
+        throw error;
+      });
+  }
+
+  it('resolves the Bucket configuration and records usage', async () => {
+    await withSeededOverlay(async ({ trx, clientId, serviceId, contractLineId, entryDate }) => {
+      const record = await findOrCreateCurrentBucketUsageRecord(
+        trx, clientId, serviceId, entryDate,
+      );
+
+      expect(record.contract_line_id).toBe(contractLineId);
+      expect(record.service_catalog_id).toBe(serviceId);
+      expect(Number(record.minutes_used)).toBe(0);
+
+      // 60 billable minutes, well inside the 420-minute bucket.
+      await updateBucketUsageMinutes(trx, record.usage_id, 60);
+
+      const after = await trx('bucket_usage').where({ usage_id: record.usage_id }).first();
+      expect(Number(after.minutes_used)).toBe(60);
+      expect(Number(after.overage_minutes)).toBe(0);
+    });
+  });
+
+  it('accrues overage once usage passes the included minutes', async () => {
+    await withSeededOverlay(async ({ trx, clientId, serviceId, entryDate }) => {
+      const record = await findOrCreateCurrentBucketUsageRecord(
+        trx, clientId, serviceId, entryDate,
+      );
+
+      await updateBucketUsageMinutes(trx, record.usage_id, TOTAL_MINUTES + 30);
+
+      const after = await trx('bucket_usage').where({ usage_id: record.usage_id }).first();
+      expect(Number(after.minutes_used)).toBe(TOTAL_MINUTES + 30);
+      expect(Number(after.overage_minutes)).toBe(30);
+    });
+  });
+
+  it('reuses the existing usage record for a second entry in the same period', async () => {
+    await withSeededOverlay(async ({ trx, clientId, serviceId, entryDate }) => {
+      const first = await findOrCreateCurrentBucketUsageRecord(trx, clientId, serviceId, entryDate);
+      await updateBucketUsageMinutes(trx, first.usage_id, 100);
+
+      const second = await findOrCreateCurrentBucketUsageRecord(
+        trx, clientId, serviceId, '2026-03-20T09:00:00Z',
+      );
+      expect(second.usage_id).toBe(first.usage_id);
+
+      await updateBucketUsageMinutes(trx, second.usage_id, 50);
+      const after = await trx('bucket_usage').where({ usage_id: first.usage_id }).first();
+      expect(Number(after.minutes_used)).toBe(150);
+    });
+  });
+});

--- a/server/src/test/unit/bucketUsageService.test.ts
+++ b/server/src/test/unit/bucketUsageService.test.ts
@@ -19,18 +19,36 @@ type BucketUsageRow = {
   rolled_over_minutes: number;
 };
 
+type ServiceConfigurationRow = {
+  config_id: string;
+  configuration_type: string;
+};
+
+/**
+ * A (contract line, service) pair holds one configuration row per
+ * configuration_type. Default to the single-Bucket shape; tests that care about
+ * the multi-configuration case pass their own set.
+ */
+const DEFAULT_SERVICE_CONFIGURATIONS: ServiceConfigurationRow[] = [
+  { config_id: "bucket-config-1", configuration_type: "Bucket" },
+];
+
 function buildBucketUsageTransaction(config: {
   existingUsage?: BucketUsageRow;
   previousUsage?: BucketUsageRow;
   allowRollover?: boolean;
   bucketConfig?: Record<string, unknown> | null;
+  serviceConfigurations?: ServiceConfigurationRow[];
 }) {
+  const serviceConfigurations = config.serviceConfigurations ?? DEFAULT_SERVICE_CONFIGURATIONS;
   const state = {
     bucketUsageFirstCalls: 0,
     clientContractFirstCalls: 0,
     insertedRecord: null as Record<string, unknown> | null,
     tablesCalled: [] as string[],
     whereCalls: [] as Array<{ tableName: string; args: unknown[] }>,
+    /** config_id the service resolved and then looked up a detail row for. */
+    requestedBucketConfigId: null as string | null,
   };
 
   const trx: any = ((tableName: string) => {
@@ -41,8 +59,14 @@ function buildBucketUsageTransaction(config: {
 
     state.tablesCalled.push(tableName);
     const builder: any = {};
+    // Track the filter this builder actually applied, so the fakes can answer
+    // like a real table rather than ignoring the predicate.
+    const appliedWhere: Record<string, unknown> = {};
     builder.where = vi.fn().mockImplementation((...args: unknown[]) => {
       state.whereCalls.push({ tableName, args });
+      if (args.length === 1 && typeof args[0] === "object" && args[0] !== null) {
+        Object.assign(appliedWhere, args[0] as Record<string, unknown>);
+      }
       return builder;
     });
     builder.andWhere = vi.fn().mockImplementation(() => builder);
@@ -84,16 +108,36 @@ function buildBucketUsageTransaction(config: {
       }
 
       if (tableName === "contract_line_service_configuration") {
-        return { config_id: "bucket-config-1" };
+        // Honour configuration_type when the caller pins it. Omitting it is the
+        // alga0002175 defect: the pair can hold an Hourly row too, and picking
+        // that one leaves the bucket detail lookup below with nothing.
+        const matches = "configuration_type" in appliedWhere
+          ? serviceConfigurations.filter(
+              (row) => row.configuration_type === appliedWhere.configuration_type,
+            )
+          : serviceConfigurations;
+
+        return matches.length > 0 ? { config_id: matches[0].config_id } : undefined;
       }
 
       if (tableName === "contract_line_service_bucket_config") {
+        const requestedConfigId = appliedWhere.config_id as string | undefined;
+        state.requestedBucketConfigId = requestedConfigId ?? null;
+
         if (config.bucketConfig === null) {
           return undefined;
         }
 
+        // Only Bucket configurations have a detail row.
+        const owningConfiguration = serviceConfigurations.find(
+          (row) => row.config_id === requestedConfigId,
+        );
+        if (owningConfiguration && owningConfiguration.configuration_type !== "Bucket") {
+          return undefined;
+        }
+
         return config.bucketConfig ?? {
-          config_id: "bucket-config-1",
+          config_id: requestedConfigId ?? "bucket-config-1",
           contract_line_id: "contract-line-1",
           service_catalog_id: "service-1",
           total_minutes: 120,
@@ -299,10 +343,77 @@ describe("BucketUsageService Unit Tests", () => {
           "service-1",
           "2025-02-10T00:00:00Z",
         ),
-      ).rejects.toThrow(
-        "Bucket configuration not found for config_id bucket-config-1 (plan contract-line-1, service service-1) in tenant test-tenant. Cannot create usage record.",
-      );
+      ).rejects.toMatchObject({ code: "MISSING_BUCKET_CONFIG" });
       expect(state.insertedRecord).toBeNull();
+    });
+
+    // Regression: alga0002175. An Hourly contract line carrying a bucket
+    // overlay ("7 hours included, overage above that") has BOTH an 'Hourly' and
+    // a 'Bucket' configuration row for the one service. Resolving on
+    // (contract_line_id, service_id) alone can return the Hourly row, whose
+    // bucket detail lookup finds nothing — so every bucket time entry in the
+    // tenant fails. Ordered Hourly-first here so an unqualified query picks it.
+    it("resolves the Bucket configuration when the line also has an Hourly one", async () => {
+      const { trx, state } = buildBucketUsageTransaction({
+        serviceConfigurations: [
+          { config_id: "hourly-config-1", configuration_type: "Hourly" },
+          { config_id: "bucket-config-1", configuration_type: "Bucket" },
+        ],
+      });
+
+      const record = await findOrCreateCurrentBucketUsageRecord(
+        trx,
+        "client-1",
+        "service-1",
+        "2025-02-10T00:00:00Z",
+      );
+
+      expect(state.requestedBucketConfigId).toBe("bucket-config-1");
+      expect(record).toMatchObject({
+        contract_line_id: "contract-line-1",
+        service_catalog_id: "service-1",
+        minutes_used: 0,
+      });
+    });
+
+    it("pins configuration_type when querying contract_line_service_configuration", async () => {
+      const { trx, state } = buildBucketUsageTransaction({});
+
+      await findOrCreateCurrentBucketUsageRecord(
+        trx,
+        "client-1",
+        "service-1",
+        "2025-02-10T00:00:00Z",
+      );
+
+      const configurationFilters = state.whereCalls
+        .filter((call) => call.tableName === "contract_line_service_configuration")
+        .flatMap((call) => call.args)
+        .filter((arg): arg is Record<string, unknown> =>
+          typeof arg === "object" && arg !== null,
+        );
+
+      expect(
+        configurationFilters.some((filter) => filter.configuration_type === "Bucket"),
+      ).toBe(true);
+    });
+
+    it("reports a missing Bucket configuration distinctly from a missing detail row", async () => {
+      const { trx } = buildBucketUsageTransaction({
+        // Line covers the service, but only with an Hourly configuration.
+        serviceConfigurations: [
+          { config_id: "hourly-config-1", configuration_type: "Hourly" },
+        ],
+      });
+
+      await expect(
+        findOrCreateCurrentBucketUsageRecord(
+          trx,
+          "client-1",
+          "service-1",
+          "2025-02-10T00:00:00Z",
+        ),
+      ).rejects.toMatchObject({ code: "MISSING_PLAN_SERVICE_CONFIG" });
     });
   });
 

--- a/shared/billingClients/bucketUsageErrors.ts
+++ b/shared/billingClients/bucketUsageErrors.ts
@@ -1,0 +1,120 @@
+/*
+ * Typed failures for the bucket-usage path.
+ *
+ * Bucket usage can fail for several unrelated reasons — no active contract line
+ * covers the date, two assignments claim the service, the line's bucket detail
+ * row is missing, the billing frequency is one the period maths cannot express.
+ * These used to reach the user as a single sentence ("Unable to update bucket
+ * usage for this time entry"), because the server-action guards matched on
+ * substrings of a message that had already been flattened by an intermediate
+ * rewrap. Diagnosing alga0002175 needed a production database session purely to
+ * recover which of the four had happened.
+ *
+ * Carry the `code` instead. Server-action guards map code -> actionable
+ * sentence; `details` stays out of the user's face and goes to the log.
+ */
+
+export type BucketUsageErrorCode =
+    /** No active client contract line with a bucket covers the target date. */
+    | 'NO_ACTIVE_CONTRACT_LINE'
+    /** More than one active assignment claims this client/service pair. */
+    | 'AMBIGUOUS_ASSIGNMENT'
+    /** The contract line has no configuration row for this service. */
+    | 'MISSING_PLAN_SERVICE_CONFIG'
+    /** The Bucket configuration row exists but its detail row does not. */
+    | 'MISSING_BUCKET_CONFIG'
+    /** The line's billing frequency has no period calculation. */
+    | 'UNSUPPORTED_BILLING_FREQUENCY';
+
+export interface BucketUsageErrorDetails {
+    tenant?: string;
+    clientId?: string;
+    contractLineId?: string;
+    serviceCatalogId?: string;
+    configId?: string;
+    billingFrequency?: string;
+    date?: string;
+    [key: string]: unknown;
+}
+
+export class BucketUsageError extends Error {
+    readonly code: BucketUsageErrorCode;
+    readonly details: BucketUsageErrorDetails;
+
+    constructor(
+        code: BucketUsageErrorCode,
+        message: string,
+        details: BucketUsageErrorDetails = {},
+        options?: { cause?: unknown },
+    ) {
+        super(message, options as ErrorOptions | undefined);
+        this.name = 'BucketUsageError';
+        this.code = code;
+        this.details = details;
+
+        // Preserve `instanceof` when this file is transpiled to ES5 targets.
+        Object.setPrototypeOf(this, BucketUsageError.prototype);
+    }
+}
+
+/**
+ * User-facing text per failure code. Each one names what is wrong and what to
+ * change; "please refresh and try again" is never the honest answer for these —
+ * none of them resolve by retrying.
+ *
+ * Shared by the time-entry and usage-record action guards so a given failure
+ * reads identically wherever the user meets it.
+ */
+export const BUCKET_USAGE_ERROR_MESSAGES: Record<BucketUsageErrorCode, string> = {
+    NO_ACTIVE_CONTRACT_LINE:
+        'No active contract covers this date for this client and service. Check the contract’s start date and that it is active.',
+    AMBIGUOUS_ASSIGNMENT:
+        'More than one active contract gives this client a bucket for this service. End-date or deactivate the duplicate, then try again.',
+    MISSING_PLAN_SERVICE_CONFIG:
+        'This contract line has no bucket configuration for this service. Re-save the bucket settings on the contract line.',
+    MISSING_BUCKET_CONFIG:
+        'This contract line’s bucket settings are incomplete. Re-save the bucket configuration on the contract line.',
+    UNSUPPORTED_BILLING_FREQUENCY:
+        'Bucket billing does not support this contract line’s billing frequency. Set the line to monthly, quarterly, or annually.',
+};
+
+export function bucketUsageErrorMessage(error: BucketUsageError): string {
+    return (
+        BUCKET_USAGE_ERROR_MESSAGES[error.code]
+        // An unrecognised code is still better served by a generic sentence than
+        // by leaking the internal message.
+        ?? 'Unable to update bucket usage. Check the contract line’s bucket configuration.'
+    );
+}
+
+export function isBucketUsageError(value: unknown): value is BucketUsageError {
+    if (value instanceof BucketUsageError) {
+        return true;
+    }
+
+    // Cross-realm / re-bundled copies of this class (the shared module is
+    // consumed from several packages) fail `instanceof`, so fall back to shape.
+    const candidate = value as { name?: unknown; code?: unknown } | null;
+    return (
+        typeof value === 'object' &&
+        value !== null &&
+        candidate?.name === 'BucketUsageError' &&
+        typeof candidate?.code === 'string'
+    );
+}
+
+/**
+ * Recovers a BucketUsageError from an error that may have been wrapped with
+ * `{ cause }` on its way up through the action layers.
+ */
+export function findBucketUsageError(value: unknown): BucketUsageError | null {
+    let current: unknown = value;
+    // Bounded so a self-referential cause chain cannot spin.
+    for (let depth = 0; current != null && depth < 10; depth += 1) {
+        if (isBucketUsageError(current)) {
+            return current;
+        }
+        current = (current as { cause?: unknown }).cause;
+    }
+    return null;
+}

--- a/shared/billingClients/bucketUsageService.ts
+++ b/shared/billingClients/bucketUsageService.ts
@@ -15,6 +15,15 @@
  * name in a runtime query, you are on the wrong path — use the join above.
  * (The static guard clientContractLineRuntimeSourceGuards.static.test.ts will
  * fail the build if a dropped-table reference slips into packages/ or shared/.)
+ *
+ * ALWAYS qualify `contract_line_service_configuration` by
+ * `configuration_type = 'Bucket'` here. A single (contract_line_id, service_id)
+ * pair legitimately carries ONE ROW PER configuration_type — an Hourly line with
+ * a bucket overlay ("7 hours included, overage above that") has both an 'Hourly'
+ * and a 'Bucket' row, each with its own detail table. Selecting on
+ * (contract_line_id, service_id) alone picks an arbitrary row from that set;
+ * when it lands on the non-bucket one the detail lookup finds nothing and bucket
+ * time entry fails for the whole tenant. That shipped as alga0002175.
  */
 import { Knex } from 'knex';
 import { Temporal } from '@js-temporal/polyfill';
@@ -24,6 +33,14 @@ import { toPlainDate, toISODate } from '@alga-psa/core';
 import {
     buildClientCadencePostDropObligationRef,
 } from './postDropRecurringObligationIdentity';
+import { BucketUsageError } from './bucketUsageErrors';
+
+/**
+ * A (contract_line_id, service_id) pair carries one configuration row per
+ * configuration_type. Every bucket-usage lookup must pin this value; see the
+ * file header.
+ */
+const BUCKET_CONFIGURATION_TYPE = 'Bucket';
 // Import necessary interfaces - adjust paths if needed
 
 // Define IBucketUsage locally for now, aligning with Phase 1 needs.
@@ -181,10 +198,21 @@ async function calculatePeriod(
         .first<{ client_contract_id: string } | undefined>();
 
     if (conflictingClientPlan?.client_contract_id) {
-        throw new Error(
+        throw new BucketUsageError(
+            'AMBIGUOUS_ASSIGNMENT',
             `Ambiguous bucket usage assignment resolution for client ${clientId}, service ${serviceCatalogId}, date ${targetDateISO}. `
             + `Matched assignments: ${clientPlan.client_contract_id}, ${conflictingClientPlan.client_contract_id}. `
             + 'Provide explicit assignment identity before bucket billing.',
+            {
+                tenant,
+                clientId,
+                serviceCatalogId,
+                date: targetDateISO,
+                matchedAssignments: [
+                    clientPlan.client_contract_id,
+                    conflictingClientPlan.client_contract_id,
+                ],
+            },
         );
     }
 
@@ -273,11 +301,25 @@ async function calculatePeriod(
             // TODO: Add other frequencies if supported (e.g., weekly, bi-annually)
             default:
                 // Throw an error for unsupported frequencies
-                throw new Error(`Unsupported billing frequency: ${frequency}`);
+                throw new BucketUsageError(
+                    'UNSUPPORTED_BILLING_FREQUENCY',
+                    `Unsupported billing frequency for bucket period calculation: ${frequency}`,
+                    {
+                        tenant,
+                        clientId,
+                        serviceCatalogId,
+                        contractLineId: clientPlan.contract_line_id,
+                        billingFrequency: frequency,
+                        date: targetDateISO,
+                    },
+                );
         }
     } catch (error) {
         console.error(`[calculatePeriod] Error calculating period dates: ${error}`);
-        throw new Error(`Failed to calculate period dates for frequency ${frequency}.`);
+        // Rethrow untouched. The deliberate throws above are already typed;
+        // stamping an unexpected failure (e.g. bad date data) with a frequency
+        // code would tell the user to change a setting that isn't the problem.
+        throw error;
     }
 
     console.debug(`[calculatePeriod] Calculated period: start=${periodStart.toString()}, end=${periodEnd.toString()}`);
@@ -326,7 +368,11 @@ export async function findOrCreateCurrentBucketUsageRecord(
 
     if (!periodInfo) {
         // If no period info, it means no suitable active plan was found.
-        throw new Error(`Could not determine active contract line/period for client ${clientId}, service ${serviceCatalogId}, date ${date}`);
+        throw new BucketUsageError(
+            'NO_ACTIVE_CONTRACT_LINE',
+            `Could not determine active contract line/period for client ${clientId}, service ${serviceCatalogId}, date ${date}`,
+            { tenant, clientId, serviceCatalogId, date },
+        );
     }
 
     const { periodStart, periodEnd, planId, billingFrequency, source, recurringScheduleKey } = periodInfo;
@@ -353,15 +399,24 @@ export async function findOrCreateCurrentBucketUsageRecord(
     // 3. Create New Record - Fetch Bucket Configuration
 
     // First, get the contract_line_service_configuration to find the config_id
+    // configuration_type is REQUIRED here — this pair can hold an 'Hourly' (or
+    // 'Usage', or 'Fixed') row alongside the 'Bucket' one. Ordering keeps the
+    // choice stable in the event a tenant ends up with two Bucket rows.
     const planServiceConfig = await db.table('contract_line_service_configuration')
         .where({
             contract_line_id: planId,
             service_id: serviceCatalogId,
+            configuration_type: BUCKET_CONFIGURATION_TYPE,
         })
+        .orderBy('created_at', 'asc')
         .first<{ config_id: string }>();
 
     if (!planServiceConfig) {
-        throw new Error(`Plan service configuration not found for plan ${planId}, service ${serviceCatalogId} in tenant ${tenant}. Cannot create usage record.`);
+        throw new BucketUsageError(
+            'MISSING_PLAN_SERVICE_CONFIG',
+            `Bucket service configuration not found for contract line ${planId}, service ${serviceCatalogId} in tenant ${tenant}. Cannot create usage record.`,
+            { tenant, clientId, contractLineId: planId, serviceCatalogId, date },
+        );
     }
 
     const bucketConfig = await db.table('contract_line_service_bucket_config')
@@ -372,7 +427,18 @@ export async function findOrCreateCurrentBucketUsageRecord(
 
     if (!bucketConfig) {
         // A bucket usage record cannot exist without its configuration.
-        throw new Error(`Bucket configuration not found for config_id ${planServiceConfig.config_id} (plan ${planId}, service ${serviceCatalogId}) in tenant ${tenant}. Cannot create usage record.`);
+        throw new BucketUsageError(
+            'MISSING_BUCKET_CONFIG',
+            `Bucket configuration not found for config_id ${planServiceConfig.config_id} (contract line ${planId}, service ${serviceCatalogId}) in tenant ${tenant}. Cannot create usage record.`,
+            {
+                tenant,
+                clientId,
+                contractLineId: planId,
+                serviceCatalogId,
+                configId: planServiceConfig.config_id,
+                date,
+            },
+        );
     }
 
     let rolledOverMinutes = 0;
@@ -419,7 +485,11 @@ export async function findOrCreateCurrentBucketUsageRecord(
                             prevPeriodStart = periodStart.subtract({ years: 1 });
                             break;
                         default:
-                            throw new Error(`Unsupported billing frequency encountered during rollover calculation: ${billingFrequency}`);
+                            throw new BucketUsageError(
+                                'UNSUPPORTED_BILLING_FREQUENCY',
+                                `Unsupported billing frequency encountered during rollover calculation: ${billingFrequency}`,
+                                { tenant, clientId, contractLineId: planId, serviceCatalogId, billingFrequency, date },
+                            );
                     }
                 }
             } else {
@@ -438,12 +508,20 @@ export async function findOrCreateCurrentBucketUsageRecord(
                         break;
                     default:
                         // Should not happen due to check in calculatePeriod, but handle defensively
-                        throw new Error(`Unsupported billing frequency encountered during rollover calculation: ${billingFrequency}`);
+                        throw new BucketUsageError(
+                            'UNSUPPORTED_BILLING_FREQUENCY',
+                            `Unsupported billing frequency encountered during rollover calculation: ${billingFrequency}`,
+                            { tenant, clientId, contractLineId: planId, serviceCatalogId, billingFrequency, date },
+                        );
                 }
             }
         } catch (error) {
              console.error(`Error calculating previous period dates: ${error}`);
-             throw new Error(`Failed to calculate previous period dates for frequency ${billingFrequency}.`);
+             // Rethrow untouched. This try block includes a live DB query, so
+             // an unexpected failure here can be a transient database error —
+             // stamping it with a frequency code would tell the user to change
+             // a setting that isn't the problem.
+             throw error;
         }
 
 
@@ -531,9 +609,13 @@ export async function updateBucketUsageMinutes(
 
     const db = tenantDb(trx, tenant);
     const currentUsageQuery = db.table('bucket_usage as bu');
+    // The inner join to psbc below already excludes non-bucket rows, but pin
+    // configuration_type explicitly so this reads the same as every other
+    // bucket lookup and stays correct if that join is ever loosened.
     db.tenantJoin(currentUsageQuery, 'contract_line_service_configuration as psc', 'psc.contract_line_id', 'bu.contract_line_id', {
         on(join) {
             join.andOn('psc.service_id', '=', 'bu.service_catalog_id');
+            join.andOnVal('psc.configuration_type', '=', BUCKET_CONFIGURATION_TYPE);
         },
     });
     db.tenantJoin(currentUsageQuery, 'contract_line_service_bucket_config as psbc', 'psc.config_id', 'psbc.config_id');
@@ -600,9 +682,11 @@ export async function reconcileBucketUsageRecord(
    // 2. Fetch Bucket Usage Record and Config
    const db = tenantDb(trx, tenant);
    const usageRecordQuery = db.table('bucket_usage as bu');
+   // See updateBucketUsageMinutes — pin configuration_type for consistency.
    db.tenantJoin(usageRecordQuery, 'contract_line_service_configuration as psc', 'psc.contract_line_id', 'bu.contract_line_id', {
        on(join) {
            join.andOn('psc.service_id', '=', 'bu.service_catalog_id');
+           join.andOnVal('psc.configuration_type', '=', BUCKET_CONFIGURATION_TYPE);
        },
    });
    db.tenantJoin(usageRecordQuery, 'contract_line_service_bucket_config as psbc', 'psc.config_id', 'psbc.config_id');

--- a/shared/tsup.config.ts
+++ b/shared/tsup.config.ts
@@ -64,6 +64,7 @@ export default defineConfig({
     'extensions/types': 'extensions/types.ts',
     'billingClients/index': 'billingClients/index.ts',
     'billingClients/bucketUsageService': 'billingClients/bucketUsageService.ts',
+    'billingClients/bucketUsageErrors': 'billingClients/bucketUsageErrors.ts',
     'lib/ticketActivity/index': 'lib/ticketActivity/index.ts',
     'lib/ticketActivity/types': 'lib/ticketActivity/types.ts',
     'lib/ticketActivity/writeTicketActivity': 'lib/ticketActivity/writeTicketActivity.ts',


### PR DESCRIPTION
## Summary

Saving a time entry against a service with a bucket overlay failed with **"Unable to update bucket usage for this time entry. Please refresh and try again."** — reported as **alga0002175**, blocking a customer's onboarding.

`findOrCreateCurrentBucketUsageRecord` resolved the bucket configuration by `(contract_line_id, service_id)` alone, then looked up the bucket detail row for whatever `config_id` came back. But a line/service pair legitimately carries **one configuration row per `configuration_type`**: an Hourly line with a bucket overlay ("7 hours included, overage above that") has both an `Hourly` and a `Bucket` row, each with its own detail table. When the unqualified query returned the non-Bucket row, the detail lookup found nothing and every bucket time entry in the tenant failed. With no `ORDER BY`, the choice wasn't even stable. Fleet-wide, **18 line/service pairs across ~10 tenants** carry the vulnerable shape — this fix silently repairs all of them.

## Changes

- **`shared/billingClients/bucketUsageService.ts`** — pin `configuration_type = 'Bucket'` in the resolution query, with `ORDER BY created_at` for determinism. The sibling joins in `updateBucketUsageMinutes` / `reconcileBucketUsageRecord` were safe only via their inner join to the detail table; pin them too so all three read alike. Header comment documents the invariant.
- **`shared/billingClients/bucketUsageErrors.ts`** (new) — `BucketUsageError` with a typed code (`NO_ACTIVE_CONTRACT_LINE`, `AMBIGUOUS_ASSIGNMENT`, `MISSING_PLAN_SERVICE_CONFIG`, `MISSING_BUCKET_CONFIG`, `UNSUPPORTED_BILLING_FREQUENCY`). Previously four unrelated causes all flattened into the same opaque sentence; each now maps to an actionable message while identifiers stay in the server log. Dependency-free module, safe for any bundle.
- **Action layers** (`timeEntryCrudActions`, `usageActions`, `timeSheetActionErrors`) — rewrap sites preserve the typed error; guards map code → message ahead of the legacy string matching, which remains as fallback.
- **`shared/tsup.config.ts`** — register the new entrypoint (required, or the import resolves in tests but fails at runtime).

## Evidence

- **Root cause confirmed in production data**: the reporting tenant's live line carried exactly the two-config shape; every other failure mode (dates, frequency, ambiguity, missing rows) ruled out by inspection.
- **Confirmed in production logs** (Loki, incident window): every failed save threw `Bucket configuration not found` naming a **non-Bucket** config row — the Hourly row on the live line, a Usage row on an earlier attempt — proving wrong-type selection generally.
- **Reproduced against real Postgres**: the new opt-in integration suite (`RUN_DB_TESTS=1`, fully transaction-rolled-back) seeds the failing shape and drives the shipped function through it. **Verified to fail without the fix** with the exact reported error — real Postgres does return the wrong row.

## Tests

- `server/src/test/unit/bucketUsageService.test.ts` — mock harness now honors the `configuration_type` filter; 3 new regression tests (verified to fail against the unfixed lookup).
- `server/src/test/integration/bucketUsageOverlayIntegration.test.ts` (new) — zero-usage, overage-crossing, and same-period-reuse cases against a live schema.
- `packages/scheduling/src/actions/timeSheetActionErrors.test.ts` — per-code mapping, distinct messages, no identifier leakage, cause-chain recovery, string fallback.
- 47 tests green across the affected suites; `tsc --noEmit` clean on `shared`, `scheduling`, `billing`.

## Out of scope (documented as follow-ups in the plan)

- `weekly` billing frequency: offered by the UI but unsupported by `calculatePeriod` — a weekly bucket line can never record time.
- Uniqueness constraint on `(tenant, line, service, configuration_type)`.
- Detached contract lines (`contract_id IS NULL`): investigated, deliberate output of line removal, harmless — cleanup notes recorded in the plan for whoever picks it up.

Fixes alga0002175