### PR TITLE
fix(email): require coherent quoted header blocks

### DIFF
--- a/shared/lib/email/__tests__/replyParser.headerHeuristics.test.ts
+++ b/shared/lib/email/__tests__/replyParser.headerHeuristics.test.ts
@@ -1,0 +1,48 @@
+import { describe, expect, it } from 'vitest';
+
+import { parseEmailReply } from '../replyParser';
+
+describe('replyParser provider-header heuristics', () => {
+  it('preserves header-like fields in an authored Ninja support request', () => {
+    const text = `New support request from
+
+First Name: Ada
+Last Name: Example
+Email: nick@example.com
+Phone: 5550100
+Subject: Test
+Problem Description: Test Support ticket after update
+Device: WORKSTATION-01
+Ninja URL: https://example.rmmservice.com/#/deviceDashboard/38/overview
+Device Role: WINDOWS_WORKSTATION
+Organization: Example Office
+
+Environment Variables
+COMPUTERNAME: WORKSTATION-01
+OS: Microsoft Windows 11 Pro Edition`;
+
+    const result = parseEmailReply({ text });
+
+    expect(result.strategy).toBe('fallback');
+    expect(result.sanitizedText).toBe(text);
+    expect(result.sanitizedText).toContain('Problem Description: Test Support ticket after update');
+    expect(result.sanitizedText).toContain('OS: Microsoft Windows 11 Pro Edition');
+  });
+
+  it('trims a coherent Outlook quoted-message header block', () => {
+    const result = parseEmailReply({
+      text: `The restart fixed the issue. Thank you.
+
+From: Alga Support <support@example.com>
+Sent: Sunday, July 26, 2026 9:15 AM
+To: Nick Green <nick@example.com>
+Subject: Server offline
+
+Previous ticket content that should not be copied.`,
+    });
+
+    expect(result.strategy).toBe('provider-header');
+    expect(result.appliedHeuristics).toContain('provider-header');
+    expect(result.sanitizedText).toBe('The restart fixed the issue. Thank you.');
+  });
+});

--- a/shared/lib/email/replyParser.ts
+++ b/shared/lib/email/replyParser.ts
@@ -108,6 +108,54 @@ interface TrimResult {
   heuristic?: string;
 }
 
+type QuotedHeaderField = 'from' | 'sent' | 'to' | 'cc' | 'subject';
+
+/**
+ * Classify fields that commonly appear in a plain-text quoted-message envelope.
+ * A single matching line is not enough evidence: structured email/form bodies
+ * frequently contain legitimate fields such as `Subject:` or `From:`.
+ */
+function classifyQuotedHeaderField(line: string): QuotedHeaderField | null {
+  if (/^(?:from|de)\s*:/i.test(line)) return 'from';
+  if (/^(?:sent|date|envoyé)\s*:/i.test(line)) return 'sent';
+  if (/^(?:to|répondre à)\s*:/i.test(line)) return 'to';
+  if (/^cc\s*:/i.test(line)) return 'cc';
+  if (/^subject\s*:/i.test(line)) return 'subject';
+  return null;
+}
+
+/**
+ * Recognize the coherent envelope emitted by plain-text Outlook-style replies.
+ * Requiring From + Sent/Date + To + Subject avoids truncating authored content
+ * merely because one form field happens to look like an email header.
+ */
+function isCoherentQuotedHeaderBlock(lines: string[], startIndex: number): boolean {
+  if (classifyQuotedHeaderField(lines[startIndex].trim()) !== 'from') {
+    return false;
+  }
+
+  const fields = new Set<QuotedHeaderField>();
+  const endIndex = Math.min(lines.length, startIndex + 10);
+
+  for (let i = startIndex; i < endIndex; i += 1) {
+    const rawLine = lines[i];
+    const line = rawLine.trim();
+    if (!line) break;
+
+    const field = classifyQuotedHeaderField(line);
+    if (field) {
+      fields.add(field);
+      continue;
+    }
+
+    // Permit folded header values, but stop as soon as normal body text begins.
+    if (/^\s/.test(rawLine)) continue;
+    break;
+  }
+
+  return fields.has('from') && fields.has('sent') && fields.has('to') && fields.has('subject');
+}
+
 const blockquoteRegex = /<blockquote[\s\S]*?$/i;
 const htmlCommentTokenRegex = /<!--\s*alga:reply-token:(?<payload>[^-]+)-->?/i;
 const htmlTokenAttributeRegex = /data-alga-reply-token="(?<token>[^"]+)"/i;
@@ -267,6 +315,12 @@ function stripProviderHeaders(text: string, config: ReplyParserConfig): TrimResu
     }
 
     if (config.providerReplyHeaders.some((regex) => regex.test(line))) {
+      const headerField = classifyQuotedHeaderField(line);
+      if (headerField && !isCoherentQuotedHeaderBlock(lines, i)) {
+        kept.push(rawLine);
+        continue;
+      }
+
       matched = line;
       heuristic = 'provider-header';
       break;


### PR DESCRIPTION
Fix inbound plain-text email parsing so standalone form fields such as Subject do not truncate ticket content. Quoted Outlook history is still trimmed when a coherent From, Sent/Date, To, and Subject envelope is present. Validation: focused Vitest regression suite (2 tests) and shared TypeScript typecheck.