### PR TITLE
Add REST endpoints for ticket agent and team assignment management

### DIFF
--- a/ee/server/src/chat/registry/apiRegistry.generated.ts
+++ b/ee/server/src/chat/registry/apiRegistry.generated.ts
@@ -34029,10 +34029,10 @@ export const chatApiRegistry: ChatApiRegistryEntry[] = [
         "name": "types",
         "in": "query",
         "required": false,
-        "description": "Comma-separated list of object types to restrict the search (e.g. \"ticket,project\"). Omit to search every type the API key's user is permitted to read. Allowed values: client, contact, user, ticket, ticket_comment, project, project_phase, project_task, project_task_comment, asset, invoice, invoice_item, invoice_annotation, contract, client_contract, document, kb_article, service_catalog, service_request_submission, service_request_definition, workflow_task, interaction, schedule_entry, time_entry, board, category, tag, status.",
+        "description": "Comma-separated list of object types to restrict the search (e.g. \"ticket,project\"). Omit to search every type the API key's user is permitted to read. Allowed values: client, contact, user, ticket, ticket_comment, project, project_phase, project_task, project_task_comment, asset, sales_order, purchase_order, stock_unit, invoice, invoice_item, invoice_annotation, contract, client_contract, document, kb_article, service_catalog, service_request_submission, service_request_definition, workflow_task, interaction, schedule_entry, time_entry, board, category, tag, status.",
         "schema": {
           "type": "string",
-          "description": "Comma-separated list of object types to restrict the search (e.g. \"ticket,project\"). Omit to search every type the API key's user is permitted to read. Allowed values: client, contact, user, ticket, ticket_comment, project, project_phase, project_task, project_task_comment, asset, invoice, invoice_item, invoice_annotation, contract, client_contract, document, kb_article, service_catalog, service_request_submission, service_request_definition, workflow_task, interaction, schedule_entry, time_entry, board, category, tag, status."
+          "description": "Comma-separated list of object types to restrict the search (e.g. \"ticket,project\"). Omit to search every type the API key's user is permitted to read. Allowed values: client, contact, user, ticket, ticket_comment, project, project_phase, project_task, project_task_comment, asset, sales_order, purchase_order, stock_unit, invoice, invoice_item, invoice_annotation, contract, client_contract, document, kb_article, service_catalog, service_request_submission, service_request_definition, workflow_task, interaction, schedule_entry, time_entry, board, category, tag, status."
         }
       },
       {
@@ -35841,6 +35841,20 @@ export const chatApiRegistry: ChatApiRegistryEntry[] = [
             }
           ]
         },
+        "barcode": {
+          "anyOf": [
+            {
+              "type": "string",
+              "maxLength": 255
+            },
+            {
+              "type": "null"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
         "cost": {
           "anyOf": [
             {
@@ -36139,6 +36153,20 @@ export const chatApiRegistry: ChatApiRegistryEntry[] = [
             {
               "type": "string",
               "maxLength": 128
+            },
+            {
+              "type": "null"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "barcode": {
+          "anyOf": [
+            {
+              "type": "string",
+              "maxLength": 255
             },
             {
               "type": "null"
@@ -49436,6 +49464,309 @@ export const chatApiRegistry: ChatApiRegistryEntry[] = [
     }
   },
   {
+    "id": "get-_api_v1_tickets_id_agents",
+    "method": "get",
+    "path": "/api/v1/tickets/{id}/agents",
+    "displayName": "List ticket agents",
+    "summary": "List ticket agents",
+    "description": "Returns the ticket primary agent (tickets.assigned_to) and its additional agents (ticket_resources), each with user_id, name and email.",
+    "tags": [
+      "Work Management v1"
+    ],
+    "approvalRequired": false,
+    "parameters": [
+      {
+        "name": "id",
+        "in": "path",
+        "required": true,
+        "description": "UUID path identifier from underlying resource tables.",
+        "schema": {
+          "type": "string",
+          "format": "uuid",
+          "description": "UUID path identifier from underlying resource tables."
+        }
+      }
+    ],
+    "responseBodySchema": {
+      "type": "object",
+      "properties": {
+        "data": {
+          "anyOf": [
+            {
+              "type": "object",
+              "additionalProperties": {}
+            },
+            {
+              "type": "array",
+              "items": {
+                "type": "object",
+                "additionalProperties": {}
+              }
+            }
+          ]
+        },
+        "meta": {
+          "type": "object",
+          "additionalProperties": {}
+        }
+      },
+      "required": [
+        "data"
+      ]
+    }
+  },
+  {
+    "id": "post-_api_v1_tickets_id_agents",
+    "method": "post",
+    "path": "/api/v1/tickets/{id}/agents",
+    "displayName": "Add a ticket additional agent",
+    "summary": "Add a ticket additional agent",
+    "description": "Adds a user as an additional agent on the ticket and publishes TICKET_ADDITIONAL_AGENT_ASSIGNED so notifications fire as they do in the UI. A ticket with no primary agent promotes the user to primary instead (TICKET_ASSIGNED). Returns the updated agent list; a duplicate returns 409.",
+    "tags": [
+      "Work Management v1"
+    ],
+    "approvalRequired": false,
+    "parameters": [
+      {
+        "name": "id",
+        "in": "path",
+        "required": true,
+        "description": "UUID path identifier from underlying resource tables.",
+        "schema": {
+          "type": "string",
+          "format": "uuid",
+          "description": "UUID path identifier from underlying resource tables."
+        }
+      }
+    ],
+    "requestBodySchema": {
+      "type": "object",
+      "properties": {
+        "user_id": {
+          "type": "string",
+          "format": "uuid",
+          "description": "User to add as an additional agent."
+        },
+        "role": {
+          "type": "string",
+          "maxLength": 50,
+          "description": "Resource role recorded on the assignment; defaults to support."
+        }
+      },
+      "required": [
+        "user_id"
+      ]
+    },
+    "responseBodySchema": {
+      "type": "object",
+      "properties": {
+        "data": {
+          "anyOf": [
+            {
+              "type": "object",
+              "additionalProperties": {}
+            },
+            {
+              "type": "array",
+              "items": {
+                "type": "object",
+                "additionalProperties": {}
+              }
+            }
+          ]
+        },
+        "meta": {
+          "type": "object",
+          "additionalProperties": {}
+        }
+      },
+      "required": [
+        "data"
+      ]
+    }
+  },
+  {
+    "id": "delete-_api_v1_tickets_id_agents_userid",
+    "method": "delete",
+    "path": "/api/v1/tickets/{id}/agents/{userId}",
+    "displayName": "Remove a ticket additional agent",
+    "summary": "Remove a ticket additional agent",
+    "description": "Removes the additional-agent assignment for the given user. The primary agent is changed through PUT /api/v1/tickets/{id}/assignment instead.",
+    "tags": [
+      "Work Management v1"
+    ],
+    "approvalRequired": false,
+    "parameters": [
+      {
+        "name": "id",
+        "in": "path",
+        "required": true,
+        "description": "Ticket UUID.",
+        "schema": {
+          "type": "string",
+          "format": "uuid",
+          "description": "Ticket UUID."
+        }
+      },
+      {
+        "name": "userId",
+        "in": "path",
+        "required": true,
+        "description": "User UUID of the additional agent.",
+        "schema": {
+          "type": "string",
+          "format": "uuid",
+          "description": "User UUID of the additional agent."
+        }
+      }
+    ]
+  },
+  {
+    "id": "put-_api_v1_tickets_id_team",
+    "method": "put",
+    "path": "/api/v1/tickets/{id}/team",
+    "displayName": "Assign a team to a ticket",
+    "summary": "Assign a team to a ticket",
+    "description": "Sets assigned_team_id, resolves the primary agent (the existing assignee, else the team lead) and records the team's active members as team_member additional agents. Returns the updated ticket. A team without a lead is rejected with 400.",
+    "tags": [
+      "Work Management v1"
+    ],
+    "approvalRequired": false,
+    "parameters": [
+      {
+        "name": "id",
+        "in": "path",
+        "required": true,
+        "description": "UUID path identifier from underlying resource tables.",
+        "schema": {
+          "type": "string",
+          "format": "uuid",
+          "description": "UUID path identifier from underlying resource tables."
+        }
+      }
+    ],
+    "requestBodySchema": {
+      "type": "object",
+      "properties": {
+        "team_id": {
+          "type": "string",
+          "format": "uuid",
+          "description": "Team to assign to the ticket."
+        },
+        "suppressContactNotifications": {
+          "type": "boolean"
+        },
+        "suppressInternalNotifications": {
+          "type": "boolean"
+        }
+      },
+      "required": [
+        "team_id"
+      ]
+    },
+    "responseBodySchema": {
+      "type": "object",
+      "properties": {
+        "data": {
+          "anyOf": [
+            {
+              "type": "object",
+              "additionalProperties": {}
+            },
+            {
+              "type": "array",
+              "items": {
+                "type": "object",
+                "additionalProperties": {}
+              }
+            }
+          ]
+        },
+        "meta": {
+          "type": "object",
+          "additionalProperties": {}
+        }
+      },
+      "required": [
+        "data"
+      ]
+    }
+  },
+  {
+    "id": "delete-_api_v1_tickets_id_team",
+    "method": "delete",
+    "path": "/api/v1/tickets/{id}/team",
+    "displayName": "Remove a ticket team assignment",
+    "summary": "Remove a ticket team assignment",
+    "description": "Clears assigned_team_id. mode=remove_all (default) drops the team_member additional agents, keep_all leaves them, and selective keeps only keep_user_ids. Returns the updated ticket.",
+    "tags": [
+      "Work Management v1"
+    ],
+    "approvalRequired": false,
+    "parameters": [
+      {
+        "name": "id",
+        "in": "path",
+        "required": true,
+        "description": "UUID path identifier from underlying resource tables.",
+        "schema": {
+          "type": "string",
+          "format": "uuid",
+          "description": "UUID path identifier from underlying resource tables."
+        }
+      }
+    ],
+    "requestBodySchema": {
+      "type": "object",
+      "properties": {
+        "mode": {
+          "type": "string",
+          "enum": [
+            "remove_all",
+            "keep_all",
+            "selective"
+          ],
+          "description": "What to do with the team_member additional agents; defaults to remove_all."
+        },
+        "keep_user_ids": {
+          "type": "array",
+          "items": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "description": "Required with mode=selective: the team members to keep as additional agents."
+        }
+      }
+    },
+    "responseBodySchema": {
+      "type": "object",
+      "properties": {
+        "data": {
+          "anyOf": [
+            {
+              "type": "object",
+              "additionalProperties": {}
+            },
+            {
+              "type": "array",
+              "items": {
+                "type": "object",
+                "additionalProperties": {}
+              }
+            }
+          ]
+        },
+        "meta": {
+          "type": "object",
+          "additionalProperties": {}
+        }
+      },
+      "required": [
+        "data"
+      ]
+    }
+  },
+  {
     "id": "get-_api_v1_tickets_id_materials",
     "method": "get",
     "path": "/api/v1/tickets/{id}/materials",
@@ -51668,6 +51999,31 @@ export const chatApiRegistry: ChatApiRegistryEntry[] = [
     }
   },
   {
+    "id": "get-_api_v1_opportunities_workqueue",
+    "method": "get",
+    "path": "/api/v1/opportunities/work-queue",
+    "displayName": "Get the current user work queue",
+    "summary": "Get the current user work queue",
+    "description": "Returns the shared server-composed opportunity work queue for the authenticated API-key user.",
+    "tags": [
+      "Opportunities v1"
+    ],
+    "approvalRequired": false,
+    "parameters": [],
+    "responseBodySchema": {
+      "type": "object",
+      "properties": {
+        "data": {
+          "type": "object",
+          "additionalProperties": {}
+        }
+      },
+      "required": [
+        "data"
+      ]
+    }
+  },
+  {
     "id": "get-_api_v1_opportunities_id",
     "method": "get",
     "path": "/api/v1/opportunities/{id}",
@@ -51878,6 +52234,73 @@ export const chatApiRegistry: ChatApiRegistryEntry[] = [
         }
       }
     ]
+  },
+  {
+    "id": "get-_api_v1_opportunities_id_timeline",
+    "method": "get",
+    "path": "/api/v1/opportunities/{id}/timeline",
+    "displayName": "List opportunity timeline",
+    "summary": "List opportunity timeline",
+    "description": "Lists interactions linked to the opportunity, newest first.",
+    "tags": [
+      "Opportunities v1"
+    ],
+    "approvalRequired": false,
+    "parameters": [
+      {
+        "name": "id",
+        "in": "path",
+        "required": true,
+        "description": "Opportunity UUID from opportunities.opportunity_id.",
+        "schema": {
+          "type": "string",
+          "format": "uuid",
+          "description": "Opportunity UUID from opportunities.opportunity_id."
+        }
+      }
+    ],
+    "responseBodySchema": {
+      "type": "object",
+      "properties": {
+        "data": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "interaction_id": {
+                "type": "string",
+                "format": "uuid"
+              },
+              "title": {
+                "type": "string"
+              },
+              "notes": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "interaction_date": {
+                "type": "string",
+                "format": "date-time"
+              },
+              "user_name": {
+                "type": "string"
+              }
+            },
+            "required": [
+              "interaction_id",
+              "title",
+              "interaction_date",
+              "user_name"
+            ]
+          }
+        }
+      },
+      "required": [
+        "data"
+      ]
+    }
   },
   {
     "id": "post-_api_v1_opportunities_id_win",
@@ -54405,6 +54828,13 @@ export const chatApiRegistry: ChatApiRegistryEntry[] = [
             "archived"
           ]
         },
+        "campaign_id": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "format": "uuid"
+        },
         "steps": {
           "type": "array",
           "items": {
@@ -54550,6 +54980,13 @@ export const chatApiRegistry: ChatApiRegistryEntry[] = [
             "archived"
           ]
         },
+        "campaign_id": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "format": "uuid"
+        },
         "steps": {
           "type": "array",
           "items": {
@@ -54680,6 +55117,1752 @@ export const chatApiRegistry: ChatApiRegistryEntry[] = [
         }
       }
     ]
+  },
+  {
+    "id": "get-_api_v1_interactions",
+    "method": "get",
+    "path": "/api/v1/interactions",
+    "displayName": "List interactions",
+    "summary": "List interactions",
+    "tags": [
+      "Interactions v1"
+    ],
+    "approvalRequired": false,
+    "parameters": [
+      {
+        "name": "client_id",
+        "in": "query",
+        "required": false,
+        "schema": {
+          "type": "string",
+          "format": "uuid"
+        }
+      },
+      {
+        "name": "contact_id",
+        "in": "query",
+        "required": false,
+        "schema": {
+          "type": "string",
+          "format": "uuid"
+        }
+      },
+      {
+        "name": "opportunity_id",
+        "in": "query",
+        "required": false,
+        "schema": {
+          "type": "string",
+          "format": "uuid"
+        }
+      },
+      {
+        "name": "ticket_id",
+        "in": "query",
+        "required": false,
+        "schema": {
+          "type": "string",
+          "format": "uuid"
+        }
+      },
+      {
+        "name": "project_id",
+        "in": "query",
+        "required": false,
+        "schema": {
+          "type": "string",
+          "format": "uuid"
+        }
+      },
+      {
+        "name": "user_id",
+        "in": "query",
+        "required": false,
+        "schema": {
+          "type": "string",
+          "format": "uuid"
+        }
+      },
+      {
+        "name": "type_id",
+        "in": "query",
+        "required": false,
+        "schema": {
+          "type": "string",
+          "format": "uuid"
+        }
+      },
+      {
+        "name": "date_from",
+        "in": "query",
+        "required": false,
+        "schema": {
+          "type": "string",
+          "format": "date-time"
+        }
+      },
+      {
+        "name": "date_to",
+        "in": "query",
+        "required": false,
+        "schema": {
+          "type": "string",
+          "format": "date-time"
+        }
+      },
+      {
+        "name": "page",
+        "in": "query",
+        "required": false,
+        "schema": {
+          "type": "string",
+          "pattern": "^\\d+$"
+        }
+      },
+      {
+        "name": "page_size",
+        "in": "query",
+        "required": false,
+        "schema": {
+          "type": "string",
+          "pattern": "^\\d+$"
+        }
+      }
+    ],
+    "responseBodySchema": {
+      "type": "object",
+      "properties": {
+        "data": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "tenant": {
+                "type": "string",
+                "format": "uuid"
+              },
+              "interaction_id": {
+                "type": "string",
+                "format": "uuid"
+              },
+              "type_id": {
+                "type": "string",
+                "format": "uuid"
+              },
+              "type_name": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "icon": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "contact_name_id": {
+                "type": [
+                  "string",
+                  "null"
+                ],
+                "format": "uuid"
+              },
+              "contact_name": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "client_id": {
+                "type": [
+                  "string",
+                  "null"
+                ],
+                "format": "uuid"
+              },
+              "client_name": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "user_id": {
+                "type": "string",
+                "format": "uuid"
+              },
+              "user_name": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "ticket_id": {
+                "type": [
+                  "string",
+                  "null"
+                ],
+                "format": "uuid"
+              },
+              "project_id": {
+                "type": [
+                  "string",
+                  "null"
+                ],
+                "format": "uuid"
+              },
+              "opportunity_id": {
+                "type": [
+                  "string",
+                  "null"
+                ],
+                "format": "uuid"
+              },
+              "title": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "notes": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "interaction_date": {
+                "anyOf": [
+                  {
+                    "type": "string",
+                    "format": "date-time"
+                  },
+                  {
+                    "type": "string"
+                  }
+                ]
+              },
+              "start_time": {
+                "anyOf": [
+                  {
+                    "type": "string",
+                    "format": "date-time"
+                  },
+                  {
+                    "type": "string"
+                  },
+                  {
+                    "type": "null"
+                  }
+                ]
+              },
+              "end_time": {
+                "anyOf": [
+                  {
+                    "type": "string",
+                    "format": "date-time"
+                  },
+                  {
+                    "type": "string"
+                  },
+                  {
+                    "type": "null"
+                  }
+                ]
+              },
+              "duration": {
+                "type": [
+                  "integer",
+                  "null"
+                ]
+              },
+              "status_id": {
+                "type": [
+                  "string",
+                  "null"
+                ],
+                "format": "uuid"
+              },
+              "status_name": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "is_status_closed": {
+                "type": [
+                  "boolean",
+                  "null"
+                ]
+              },
+              "visibility": {
+                "type": "string",
+                "enum": [
+                  "internal",
+                  "client_visible"
+                ]
+              }
+            },
+            "required": [
+              "tenant",
+              "interaction_id",
+              "type_id",
+              "type_name",
+              "icon",
+              "contact_name_id",
+              "contact_name",
+              "client_id",
+              "client_name",
+              "user_id",
+              "user_name",
+              "ticket_id",
+              "project_id",
+              "opportunity_id",
+              "title",
+              "notes",
+              "interaction_date",
+              "start_time",
+              "end_time",
+              "duration",
+              "status_id",
+              "status_name",
+              "is_status_closed",
+              "visibility"
+            ]
+          }
+        },
+        "pagination": {
+          "type": "object",
+          "properties": {
+            "page": {
+              "type": "number"
+            },
+            "limit": {
+              "type": "number"
+            },
+            "total": {
+              "type": "number"
+            },
+            "totalPages": {
+              "type": "number"
+            },
+            "hasNext": {
+              "type": "boolean"
+            },
+            "hasPrev": {
+              "type": "boolean"
+            }
+          },
+          "required": [
+            "page",
+            "limit",
+            "total",
+            "totalPages",
+            "hasNext",
+            "hasPrev"
+          ]
+        },
+        "meta": {
+          "type": "object",
+          "properties": {}
+        }
+      },
+      "required": [
+        "data",
+        "pagination"
+      ]
+    }
+  },
+  {
+    "id": "post-_api_v1_interactions",
+    "method": "post",
+    "path": "/api/v1/interactions",
+    "displayName": "Create an interaction",
+    "summary": "Create an interaction",
+    "tags": [
+      "Interactions v1"
+    ],
+    "approvalRequired": false,
+    "parameters": [],
+    "requestBodySchema": {
+      "type": "object",
+      "properties": {
+        "type_id": {
+          "type": "string",
+          "format": "uuid"
+        },
+        "client_id": {
+          "type": "string",
+          "format": "uuid"
+        },
+        "contact_name_id": {
+          "type": "string",
+          "format": "uuid"
+        },
+        "ticket_id": {
+          "type": "string",
+          "format": "uuid"
+        },
+        "project_id": {
+          "type": "string",
+          "format": "uuid"
+        },
+        "opportunity_id": {
+          "type": "string",
+          "format": "uuid"
+        },
+        "title": {
+          "type": "string",
+          "minLength": 1
+        },
+        "notes": {
+          "type": "string"
+        },
+        "duration": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "start_time": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "end_time": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "interaction_date": {
+          "type": "string",
+          "format": "date-time"
+        }
+      },
+      "required": [
+        "type_id"
+      ]
+    },
+    "responseBodySchema": {
+      "type": "object",
+      "properties": {
+        "data": {
+          "type": "object",
+          "properties": {
+            "tenant": {
+              "type": "string",
+              "format": "uuid"
+            },
+            "interaction_id": {
+              "type": "string",
+              "format": "uuid"
+            },
+            "type_id": {
+              "type": "string",
+              "format": "uuid"
+            },
+            "type_name": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "icon": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "contact_name_id": {
+              "type": [
+                "string",
+                "null"
+              ],
+              "format": "uuid"
+            },
+            "contact_name": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "client_id": {
+              "type": [
+                "string",
+                "null"
+              ],
+              "format": "uuid"
+            },
+            "client_name": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "user_id": {
+              "type": "string",
+              "format": "uuid"
+            },
+            "user_name": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "ticket_id": {
+              "type": [
+                "string",
+                "null"
+              ],
+              "format": "uuid"
+            },
+            "project_id": {
+              "type": [
+                "string",
+                "null"
+              ],
+              "format": "uuid"
+            },
+            "opportunity_id": {
+              "type": [
+                "string",
+                "null"
+              ],
+              "format": "uuid"
+            },
+            "title": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "notes": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "interaction_date": {
+              "anyOf": [
+                {
+                  "type": "string",
+                  "format": "date-time"
+                },
+                {
+                  "type": "string"
+                }
+              ]
+            },
+            "start_time": {
+              "anyOf": [
+                {
+                  "type": "string",
+                  "format": "date-time"
+                },
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            },
+            "end_time": {
+              "anyOf": [
+                {
+                  "type": "string",
+                  "format": "date-time"
+                },
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            },
+            "duration": {
+              "type": [
+                "integer",
+                "null"
+              ]
+            },
+            "status_id": {
+              "type": [
+                "string",
+                "null"
+              ],
+              "format": "uuid"
+            },
+            "status_name": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "is_status_closed": {
+              "type": [
+                "boolean",
+                "null"
+              ]
+            },
+            "visibility": {
+              "type": "string",
+              "enum": [
+                "internal",
+                "client_visible"
+              ]
+            }
+          },
+          "required": [
+            "tenant",
+            "interaction_id",
+            "type_id",
+            "type_name",
+            "icon",
+            "contact_name_id",
+            "contact_name",
+            "client_id",
+            "client_name",
+            "user_id",
+            "user_name",
+            "ticket_id",
+            "project_id",
+            "opportunity_id",
+            "title",
+            "notes",
+            "interaction_date",
+            "start_time",
+            "end_time",
+            "duration",
+            "status_id",
+            "status_name",
+            "is_status_closed",
+            "visibility"
+          ]
+        },
+        "meta": {
+          "type": "object",
+          "properties": {}
+        }
+      },
+      "required": [
+        "data"
+      ]
+    }
+  },
+  {
+    "id": "get-_api_v1_interactions_id",
+    "method": "get",
+    "path": "/api/v1/interactions/{id}",
+    "displayName": "Get an interaction",
+    "summary": "Get an interaction",
+    "tags": [
+      "Interactions v1"
+    ],
+    "approvalRequired": false,
+    "parameters": [
+      {
+        "name": "id",
+        "in": "path",
+        "required": true,
+        "schema": {
+          "type": "string",
+          "format": "uuid"
+        }
+      }
+    ],
+    "responseBodySchema": {
+      "type": "object",
+      "properties": {
+        "data": {
+          "type": "object",
+          "properties": {
+            "tenant": {
+              "type": "string",
+              "format": "uuid"
+            },
+            "interaction_id": {
+              "type": "string",
+              "format": "uuid"
+            },
+            "type_id": {
+              "type": "string",
+              "format": "uuid"
+            },
+            "type_name": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "icon": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "contact_name_id": {
+              "type": [
+                "string",
+                "null"
+              ],
+              "format": "uuid"
+            },
+            "contact_name": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "client_id": {
+              "type": [
+                "string",
+                "null"
+              ],
+              "format": "uuid"
+            },
+            "client_name": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "user_id": {
+              "type": "string",
+              "format": "uuid"
+            },
+            "user_name": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "ticket_id": {
+              "type": [
+                "string",
+                "null"
+              ],
+              "format": "uuid"
+            },
+            "project_id": {
+              "type": [
+                "string",
+                "null"
+              ],
+              "format": "uuid"
+            },
+            "opportunity_id": {
+              "type": [
+                "string",
+                "null"
+              ],
+              "format": "uuid"
+            },
+            "title": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "notes": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "interaction_date": {
+              "anyOf": [
+                {
+                  "type": "string",
+                  "format": "date-time"
+                },
+                {
+                  "type": "string"
+                }
+              ]
+            },
+            "start_time": {
+              "anyOf": [
+                {
+                  "type": "string",
+                  "format": "date-time"
+                },
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            },
+            "end_time": {
+              "anyOf": [
+                {
+                  "type": "string",
+                  "format": "date-time"
+                },
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            },
+            "duration": {
+              "type": [
+                "integer",
+                "null"
+              ]
+            },
+            "status_id": {
+              "type": [
+                "string",
+                "null"
+              ],
+              "format": "uuid"
+            },
+            "status_name": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "is_status_closed": {
+              "type": [
+                "boolean",
+                "null"
+              ]
+            },
+            "visibility": {
+              "type": "string",
+              "enum": [
+                "internal",
+                "client_visible"
+              ]
+            }
+          },
+          "required": [
+            "tenant",
+            "interaction_id",
+            "type_id",
+            "type_name",
+            "icon",
+            "contact_name_id",
+            "contact_name",
+            "client_id",
+            "client_name",
+            "user_id",
+            "user_name",
+            "ticket_id",
+            "project_id",
+            "opportunity_id",
+            "title",
+            "notes",
+            "interaction_date",
+            "start_time",
+            "end_time",
+            "duration",
+            "status_id",
+            "status_name",
+            "is_status_closed",
+            "visibility"
+          ]
+        },
+        "meta": {
+          "type": "object",
+          "properties": {}
+        }
+      },
+      "required": [
+        "data"
+      ]
+    }
+  },
+  {
+    "id": "get-_api_v1_interactiontypes",
+    "method": "get",
+    "path": "/api/v1/interaction-types",
+    "displayName": "List interaction types",
+    "summary": "List interaction types",
+    "description": "Returns the union of system and tenant-defined interaction types.",
+    "tags": [
+      "Interactions v1"
+    ],
+    "approvalRequired": false,
+    "parameters": [],
+    "responseBodySchema": {
+      "type": "object",
+      "properties": {
+        "data": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "type_id": {
+                "type": "string",
+                "format": "uuid"
+              },
+              "type_name": {
+                "type": "string"
+              },
+              "icon": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "is_system": {
+                "type": "boolean"
+              }
+            },
+            "required": [
+              "type_id",
+              "type_name",
+              "icon",
+              "is_system"
+            ]
+          }
+        },
+        "meta": {
+          "type": "object",
+          "properties": {}
+        }
+      },
+      "required": [
+        "data"
+      ]
+    }
+  },
+  {
+    "id": "get-_api_v1_inventory_lookup",
+    "method": "get",
+    "path": "/api/v1/inventory/lookup",
+    "displayName": "Look up an inventory barcode or identifier",
+    "summary": "Look up an inventory barcode or identifier",
+    "tags": [
+      "Inventory v1"
+    ],
+    "approvalRequired": false,
+    "parameters": [
+      {
+        "name": "code",
+        "in": "query",
+        "required": true,
+        "schema": {
+          "type": "string",
+          "minLength": 1
+        }
+      }
+    ],
+    "responseBodySchema": {
+      "type": "object",
+      "properties": {
+        "data": {}
+      }
+    }
+  },
+  {
+    "id": "get-_api_v1_inventory_stock",
+    "method": "get",
+    "path": "/api/v1/inventory/stock",
+    "displayName": "List stock levels",
+    "summary": "List stock levels",
+    "tags": [
+      "Inventory v1"
+    ],
+    "approvalRequired": false,
+    "parameters": [
+      {
+        "name": "page",
+        "in": "query",
+        "required": false,
+        "schema": {
+          "type": "integer",
+          "minimum": 1
+        }
+      },
+      {
+        "name": "limit",
+        "in": "query",
+        "required": false,
+        "schema": {
+          "type": "integer",
+          "minimum": 1,
+          "maximum": 100
+        }
+      },
+      {
+        "name": "search",
+        "in": "query",
+        "required": false,
+        "schema": {
+          "type": "string"
+        }
+      },
+      {
+        "name": "status",
+        "in": "query",
+        "required": false,
+        "schema": {
+          "type": "string"
+        }
+      },
+      {
+        "name": "location_id",
+        "in": "query",
+        "required": false,
+        "schema": {
+          "type": "string",
+          "format": "uuid"
+        }
+      },
+      {
+        "name": "service_id",
+        "in": "query",
+        "required": false,
+        "schema": {
+          "type": "string",
+          "format": "uuid"
+        }
+      },
+      {
+        "name": "client_id",
+        "in": "query",
+        "required": false,
+        "schema": {
+          "type": "string",
+          "format": "uuid"
+        }
+      },
+      {
+        "name": "low_stock",
+        "in": "query",
+        "required": false,
+        "schema": {
+          "type": "string",
+          "enum": [
+            "true",
+            "false"
+          ]
+        }
+      }
+    ],
+    "responseBodySchema": {
+      "type": "object",
+      "properties": {
+        "data": {}
+      }
+    }
+  },
+  {
+    "id": "get-_api_v1_inventory_stocklocations",
+    "method": "get",
+    "path": "/api/v1/inventory/stock-locations",
+    "displayName": "List stock locations",
+    "summary": "List stock locations",
+    "tags": [
+      "Inventory v1"
+    ],
+    "approvalRequired": false,
+    "parameters": [],
+    "responseBodySchema": {
+      "type": "object",
+      "properties": {
+        "data": {}
+      }
+    }
+  },
+  {
+    "id": "get-_api_v1_inventory_units",
+    "method": "get",
+    "path": "/api/v1/inventory/units",
+    "displayName": "List serialized stock units",
+    "summary": "List serialized stock units",
+    "tags": [
+      "Inventory v1"
+    ],
+    "approvalRequired": false,
+    "parameters": [
+      {
+        "name": "page",
+        "in": "query",
+        "required": false,
+        "schema": {
+          "type": "integer",
+          "minimum": 1
+        }
+      },
+      {
+        "name": "limit",
+        "in": "query",
+        "required": false,
+        "schema": {
+          "type": "integer",
+          "minimum": 1,
+          "maximum": 100
+        }
+      },
+      {
+        "name": "search",
+        "in": "query",
+        "required": false,
+        "schema": {
+          "type": "string"
+        }
+      },
+      {
+        "name": "status",
+        "in": "query",
+        "required": false,
+        "schema": {
+          "type": "string"
+        }
+      },
+      {
+        "name": "location_id",
+        "in": "query",
+        "required": false,
+        "schema": {
+          "type": "string",
+          "format": "uuid"
+        }
+      },
+      {
+        "name": "service_id",
+        "in": "query",
+        "required": false,
+        "schema": {
+          "type": "string",
+          "format": "uuid"
+        }
+      },
+      {
+        "name": "client_id",
+        "in": "query",
+        "required": false,
+        "schema": {
+          "type": "string",
+          "format": "uuid"
+        }
+      },
+      {
+        "name": "low_stock",
+        "in": "query",
+        "required": false,
+        "schema": {
+          "type": "string",
+          "enum": [
+            "true",
+            "false"
+          ]
+        }
+      }
+    ],
+    "responseBodySchema": {
+      "type": "object",
+      "properties": {
+        "data": {}
+      }
+    }
+  },
+  {
+    "id": "get-_api_v1_inventory_units_unitid",
+    "method": "get",
+    "path": "/api/v1/inventory/units/{unitId}",
+    "displayName": "Get a serialized stock unit",
+    "summary": "Get a serialized stock unit",
+    "tags": [
+      "Inventory v1"
+    ],
+    "approvalRequired": false,
+    "parameters": [
+      {
+        "name": "unitId",
+        "in": "path",
+        "required": true,
+        "schema": {
+          "type": "string",
+          "format": "uuid"
+        }
+      }
+    ],
+    "responseBodySchema": {
+      "type": "object",
+      "properties": {
+        "data": {}
+      }
+    }
+  },
+  {
+    "id": "post-_api_v1_inventory_receipts",
+    "method": "post",
+    "path": "/api/v1/inventory/receipts",
+    "displayName": "Receive stock manually",
+    "summary": "Receive stock manually",
+    "tags": [
+      "Inventory v1"
+    ],
+    "approvalRequired": false,
+    "parameters": [],
+    "requestBodySchema": {
+      "type": "object",
+      "additionalProperties": {}
+    },
+    "responseBodySchema": {
+      "type": "object",
+      "properties": {
+        "data": {}
+      }
+    }
+  },
+  {
+    "id": "post-_api_v1_inventory_adjustments",
+    "method": "post",
+    "path": "/api/v1/inventory/adjustments",
+    "displayName": "Adjust stock",
+    "summary": "Adjust stock",
+    "tags": [
+      "Inventory v1"
+    ],
+    "approvalRequired": false,
+    "parameters": [],
+    "requestBodySchema": {
+      "type": "object",
+      "additionalProperties": {}
+    },
+    "responseBodySchema": {
+      "type": "object",
+      "properties": {
+        "data": {}
+      }
+    }
+  },
+  {
+    "id": "get-_api_v1_inventory_counts",
+    "method": "get",
+    "path": "/api/v1/inventory/counts",
+    "displayName": "List cycle count sessions",
+    "summary": "List cycle count sessions",
+    "tags": [
+      "Inventory v1"
+    ],
+    "approvalRequired": false,
+    "parameters": [
+      {
+        "name": "page",
+        "in": "query",
+        "required": false,
+        "schema": {
+          "type": "integer",
+          "minimum": 1
+        }
+      },
+      {
+        "name": "limit",
+        "in": "query",
+        "required": false,
+        "schema": {
+          "type": "integer",
+          "minimum": 1,
+          "maximum": 100
+        }
+      },
+      {
+        "name": "search",
+        "in": "query",
+        "required": false,
+        "schema": {
+          "type": "string"
+        }
+      },
+      {
+        "name": "status",
+        "in": "query",
+        "required": false,
+        "schema": {
+          "type": "string"
+        }
+      },
+      {
+        "name": "location_id",
+        "in": "query",
+        "required": false,
+        "schema": {
+          "type": "string",
+          "format": "uuid"
+        }
+      },
+      {
+        "name": "service_id",
+        "in": "query",
+        "required": false,
+        "schema": {
+          "type": "string",
+          "format": "uuid"
+        }
+      },
+      {
+        "name": "client_id",
+        "in": "query",
+        "required": false,
+        "schema": {
+          "type": "string",
+          "format": "uuid"
+        }
+      },
+      {
+        "name": "low_stock",
+        "in": "query",
+        "required": false,
+        "schema": {
+          "type": "string",
+          "enum": [
+            "true",
+            "false"
+          ]
+        }
+      }
+    ],
+    "responseBodySchema": {
+      "type": "object",
+      "properties": {
+        "data": {}
+      }
+    }
+  },
+  {
+    "id": "post-_api_v1_inventory_counts",
+    "method": "post",
+    "path": "/api/v1/inventory/counts",
+    "displayName": "Start a cycle count session",
+    "summary": "Start a cycle count session",
+    "tags": [
+      "Inventory v1"
+    ],
+    "approvalRequired": false,
+    "parameters": [],
+    "requestBodySchema": {
+      "type": "object",
+      "additionalProperties": {}
+    },
+    "responseBodySchema": {
+      "type": "object",
+      "properties": {
+        "data": {}
+      }
+    }
+  },
+  {
+    "id": "get-_api_v1_inventory_counts_sessionid",
+    "method": "get",
+    "path": "/api/v1/inventory/counts/{sessionId}",
+    "displayName": "Get a cycle count session",
+    "summary": "Get a cycle count session",
+    "tags": [
+      "Inventory v1"
+    ],
+    "approvalRequired": false,
+    "parameters": [
+      {
+        "name": "sessionId",
+        "in": "path",
+        "required": true,
+        "schema": {
+          "type": "string",
+          "format": "uuid"
+        }
+      }
+    ],
+    "responseBodySchema": {
+      "type": "object",
+      "properties": {
+        "data": {}
+      }
+    }
+  },
+  {
+    "id": "post-_api_v1_inventory_counts_sessionid_records",
+    "method": "post",
+    "path": "/api/v1/inventory/counts/{sessionId}/records",
+    "displayName": "Record a cycle count quantity",
+    "summary": "Record a cycle count quantity",
+    "tags": [
+      "Inventory v1"
+    ],
+    "approvalRequired": false,
+    "parameters": [
+      {
+        "name": "sessionId",
+        "in": "path",
+        "required": true,
+        "schema": {
+          "type": "string",
+          "format": "uuid"
+        }
+      }
+    ],
+    "requestBodySchema": {
+      "type": "object",
+      "additionalProperties": {}
+    },
+    "responseBodySchema": {
+      "type": "object",
+      "properties": {
+        "data": {}
+      }
+    }
+  },
+  {
+    "id": "post-_api_v1_inventory_counts_sessionid_submit",
+    "method": "post",
+    "path": "/api/v1/inventory/counts/{sessionId}/submit",
+    "displayName": "Submit a cycle count session",
+    "summary": "Submit a cycle count session",
+    "tags": [
+      "Inventory v1"
+    ],
+    "approvalRequired": false,
+    "parameters": [
+      {
+        "name": "sessionId",
+        "in": "path",
+        "required": true,
+        "schema": {
+          "type": "string",
+          "format": "uuid"
+        }
+      }
+    ],
+    "responseBodySchema": {
+      "type": "object",
+      "properties": {
+        "data": {}
+      }
+    }
+  },
+  {
+    "id": "get-_api_v1_inventory_purchaseorders",
+    "method": "get",
+    "path": "/api/v1/inventory/purchase-orders",
+    "displayName": "List purchase orders",
+    "summary": "List purchase orders",
+    "tags": [
+      "Inventory v1"
+    ],
+    "approvalRequired": false,
+    "parameters": [
+      {
+        "name": "page",
+        "in": "query",
+        "required": false,
+        "schema": {
+          "type": "integer",
+          "minimum": 1
+        }
+      },
+      {
+        "name": "limit",
+        "in": "query",
+        "required": false,
+        "schema": {
+          "type": "integer",
+          "minimum": 1,
+          "maximum": 100
+        }
+      },
+      {
+        "name": "search",
+        "in": "query",
+        "required": false,
+        "schema": {
+          "type": "string"
+        }
+      },
+      {
+        "name": "status",
+        "in": "query",
+        "required": false,
+        "schema": {
+          "type": "string"
+        }
+      },
+      {
+        "name": "location_id",
+        "in": "query",
+        "required": false,
+        "schema": {
+          "type": "string",
+          "format": "uuid"
+        }
+      },
+      {
+        "name": "service_id",
+        "in": "query",
+        "required": false,
+        "schema": {
+          "type": "string",
+          "format": "uuid"
+        }
+      },
+      {
+        "name": "client_id",
+        "in": "query",
+        "required": false,
+        "schema": {
+          "type": "string",
+          "format": "uuid"
+        }
+      },
+      {
+        "name": "low_stock",
+        "in": "query",
+        "required": false,
+        "schema": {
+          "type": "string",
+          "enum": [
+            "true",
+            "false"
+          ]
+        }
+      }
+    ],
+    "responseBodySchema": {
+      "type": "object",
+      "properties": {
+        "data": {}
+      }
+    }
+  },
+  {
+    "id": "get-_api_v1_inventory_purchaseorders_poid",
+    "method": "get",
+    "path": "/api/v1/inventory/purchase-orders/{poId}",
+    "displayName": "Get a purchase order",
+    "summary": "Get a purchase order",
+    "tags": [
+      "Inventory v1"
+    ],
+    "approvalRequired": false,
+    "parameters": [
+      {
+        "name": "poId",
+        "in": "path",
+        "required": true,
+        "schema": {
+          "type": "string",
+          "format": "uuid"
+        }
+      }
+    ],
+    "responseBodySchema": {
+      "type": "object",
+      "properties": {
+        "data": {}
+      }
+    }
+  },
+  {
+    "id": "post-_api_v1_inventory_purchaseorders_poid_lines_lineid_receive",
+    "method": "post",
+    "path": "/api/v1/inventory/purchase-orders/{poId}/lines/{lineId}/receive",
+    "displayName": "Receive a purchase-order line",
+    "summary": "Receive a purchase-order line",
+    "tags": [
+      "Inventory v1"
+    ],
+    "approvalRequired": false,
+    "parameters": [
+      {
+        "name": "poId",
+        "in": "path",
+        "required": true,
+        "schema": {
+          "type": "string",
+          "format": "uuid"
+        }
+      },
+      {
+        "name": "lineId",
+        "in": "path",
+        "required": true,
+        "schema": {
+          "type": "string",
+          "format": "uuid"
+        }
+      }
+    ],
+    "requestBodySchema": {
+      "type": "object",
+      "additionalProperties": {}
+    },
+    "responseBodySchema": {
+      "type": "object",
+      "properties": {
+        "data": {}
+      }
+    }
+  },
+  {
+    "id": "get-_api_v1_inventory_transfers",
+    "method": "get",
+    "path": "/api/v1/inventory/transfers",
+    "displayName": "List stock transfers",
+    "summary": "List stock transfers",
+    "tags": [
+      "Inventory v1"
+    ],
+    "approvalRequired": false,
+    "parameters": [
+      {
+        "name": "page",
+        "in": "query",
+        "required": false,
+        "schema": {
+          "type": "integer",
+          "minimum": 1
+        }
+      },
+      {
+        "name": "limit",
+        "in": "query",
+        "required": false,
+        "schema": {
+          "type": "integer",
+          "minimum": 1,
+          "maximum": 100
+        }
+      },
+      {
+        "name": "search",
+        "in": "query",
+        "required": false,
+        "schema": {
+          "type": "string"
+        }
+      },
+      {
+        "name": "status",
+        "in": "query",
+        "required": false,
+        "schema": {
+          "type": "string"
+        }
+      },
+      {
+        "name": "location_id",
+        "in": "query",
+        "required": false,
+        "schema": {
+          "type": "string",
+          "format": "uuid"
+        }
+      },
+      {
+        "name": "service_id",
+        "in": "query",
+        "required": false,
+        "schema": {
+          "type": "string",
+          "format": "uuid"
+        }
+      },
+      {
+        "name": "client_id",
+        "in": "query",
+        "required": false,
+        "schema": {
+          "type": "string",
+          "format": "uuid"
+        }
+      },
+      {
+        "name": "low_stock",
+        "in": "query",
+        "required": false,
+        "schema": {
+          "type": "string",
+          "enum": [
+            "true",
+            "false"
+          ]
+        }
+      }
+    ],
+    "responseBodySchema": {
+      "type": "object",
+      "properties": {
+        "data": {}
+      }
+    }
+  },
+  {
+    "id": "post-_api_v1_inventory_transfers_transferid_receive",
+    "method": "post",
+    "path": "/api/v1/inventory/transfers/{transferId}/receive",
+    "displayName": "Receive a stock transfer",
+    "summary": "Receive a stock transfer",
+    "tags": [
+      "Inventory v1"
+    ],
+    "approvalRequired": false,
+    "parameters": [
+      {
+        "name": "transferId",
+        "in": "path",
+        "required": true,
+        "schema": {
+          "type": "string",
+          "format": "uuid"
+        }
+      }
+    ],
+    "responseBodySchema": {
+      "type": "object",
+      "properties": {
+        "data": {}
+      }
+    }
+  },
+  {
+    "id": "get-_api_v1_mobile_me_capabilities",
+    "method": "get",
+    "path": "/api/v1/mobile/me/capabilities",
+    "displayName": "Get current mobile feature capabilities",
+    "summary": "Get current mobile feature capabilities",
+    "description": "Returns tenant-product and RBAC-derived mobile feature availability for the authenticated API-key user.",
+    "tags": [
+      "Mobile v1"
+    ],
+    "approvalRequired": false,
+    "parameters": [],
+    "responseBodySchema": {
+      "type": "object",
+      "properties": {
+        "data": {
+          "type": "object",
+          "properties": {
+            "features": {
+              "type": "object",
+              "properties": {
+                "inventory": {
+                  "type": "boolean"
+                },
+                "opportunities": {
+                  "type": "boolean"
+                }
+              },
+              "required": [
+                "inventory",
+                "opportunities"
+              ]
+            }
+          },
+          "required": [
+            "features"
+          ]
+        }
+      },
+      "required": [
+        "data"
+      ]
+    }
   },
   {
     "id": "post-_api_v1_featureaccess",

--- a/packages/tickets/src/actions/teamAssignmentActions.ts
+++ b/packages/tickets/src/actions/teamAssignmentActions.ts
@@ -1,24 +1,21 @@
 'use server';
 
 import { withAuth, hasPermission } from '@alga-psa/auth';
-import { createTenantKnex, tenantDb, withTransaction } from '@alga-psa/db';
+import { createTenantKnex, withTransaction } from '@alga-psa/db';
 import { publishEvent } from '@alga-psa/event-bus/publishers';
 import { revalidatePath } from 'next/cache';
 import { Knex } from 'knex';
+import {
+  assignTeamToTicketCore,
+  removeTeamFromTicketCore,
+  type RemoveTeamFromTicketOptions,
+} from '../lib/teamAssignmentCore';
 import { ticketActionErrorFrom, type TicketActionError } from './ticketActionErrors';
 
 export type TeamAssignmentNotificationOptions = {
   suppressContactNotifications?: boolean;
   suppressInternalNotifications?: boolean;
 };
-
-function tenantScopedTable(
-  conn: Knex | Knex.Transaction,
-  table: string,
-  tenant: string
-): Knex.QueryBuilder {
-  return tenantDb(conn, tenant).table(table);
-}
 
 export const assignTeamToTicket = withAuth(async (
   user,
@@ -40,78 +37,7 @@ export const assignTeamToTicket = withAuth(async (
         throw new Error('Permission denied: Cannot assign team to ticket');
       }
 
-      const ticket = await tenantScopedTable(trx, 'tickets', tenant)
-        .where({ ticket_id: ticketId })
-        .first();
-
-      if (!ticket) {
-        throw new Error('Ticket not found');
-      }
-
-      const team = await tenantScopedTable(trx, 'teams', tenant)
-        .where({ team_id: teamId })
-        .first();
-
-      if (!team) {
-        throw new Error('Team not found');
-      }
-
-      if (!team.manager_id) {
-        throw new Error('Team lead not found');
-      }
-
-      const teamMembers = await tenantDb(trx, tenant)
-        .tenantJoin(
-          tenantScopedTable(trx, 'team_members', tenant),
-          'users',
-          'team_members.user_id',
-          'users.user_id'
-        )
-        .where({ 'team_members.team_id': teamId })
-        .andWhere('users.is_inactive', false)
-        .select('team_members.user_id') as Array<{ user_id: string }>;
-
-      // assigned_to is guaranteed non-null: either the ticket already has one,
-      // or we fall back to team.manager_id (validated above).
-      const resolvedAssignedTo: string = (ticket.assigned_to as string | null) || team.manager_id;
-
-      await tenantScopedTable(trx, 'tickets', tenant)
-        .where({ ticket_id: ticketId })
-        .update({
-          assigned_team_id: teamId,
-          assigned_to: resolvedAssignedTo,
-          updated_by: user.user_id,
-          updated_at: new Date()
-        });
-
-      const memberIds = teamMembers
-        .map((member: { user_id: string }) => member.user_id)
-        .filter((userId: string) => userId && userId !== resolvedAssignedTo);
-
-      if (memberIds.length > 0) {
-        const existingResources = await tenantScopedTable(trx, 'ticket_resources', tenant)
-          .where({ ticket_id: ticketId })
-          .whereIn('additional_user_id', memberIds)
-          .select('additional_user_id');
-
-        const existingIds = new Set(existingResources.map((row: { additional_user_id: string }) => row.additional_user_id));
-        const toInsert = memberIds.filter((userId) => !existingIds.has(userId));
-
-        if (toInsert.length > 0) {
-          await tenantScopedTable(trx, 'ticket_resources', tenant).insert(
-            toInsert.map((userId) => ({
-              ticket_id: ticketId,
-              assigned_to: resolvedAssignedTo,
-              additional_user_id: userId,
-              role: 'team_member',
-              tenant,
-              assigned_at: new Date()
-            }))
-          );
-        }
-      }
-
-      return resolvedAssignedTo;
+      return await assignTeamToTicketCore(trx, tenant, user.user_id, ticketId, teamId);
     });
 
     // Emit event after transaction commits so subscribers can see the data
@@ -139,13 +65,6 @@ export const assignTeamToTicket = withAuth(async (
   }
 });
 
-export type RemoveTeamFromTicketMode = 'remove_all' | 'keep_all' | 'selective';
-
-export interface RemoveTeamFromTicketOptions {
-  mode: RemoveTeamFromTicketMode;
-  keepUserIds?: string[];
-}
-
 export const removeTeamFromTicket = withAuth(async (
   user,
   { tenant },
@@ -159,36 +78,7 @@ export const removeTeamFromTicket = withAuth(async (
         throw new Error('Permission denied: Cannot remove team from ticket');
       }
 
-      const ticket = await tenantScopedTable(trx, 'tickets', tenant)
-        .where({ ticket_id: ticketId })
-        .first();
-
-      if (!ticket) {
-        throw new Error('Ticket not found');
-      }
-
-      const mode = options.mode;
-      if (mode === 'remove_all') {
-        await tenantScopedTable(trx, 'ticket_resources', tenant)
-          .where({ ticket_id: ticketId, role: 'team_member' })
-          .delete();
-      }
-
-      if (mode === 'selective') {
-        const keepIds = new Set(options.keepUserIds ?? []);
-        await tenantScopedTable(trx, 'ticket_resources', tenant)
-          .where({ ticket_id: ticketId, role: 'team_member' })
-          .whereNotIn('additional_user_id', Array.from(keepIds))
-          .delete();
-      }
-
-      await tenantScopedTable(trx, 'tickets', tenant)
-        .where({ ticket_id: ticketId })
-        .update({
-          assigned_team_id: null,
-          updated_by: user.user_id,
-          updated_at: new Date()
-        });
+      await removeTeamFromTicketCore(trx, tenant, user.user_id, ticketId, options);
     });
 
     // Invalidate ticket list cache so team badge removal is reflected

--- a/packages/tickets/src/actions/ticketActions.ts
+++ b/packages/tickets/src/actions/ticketActions.ts
@@ -54,6 +54,7 @@ import { TicketModelEventPublisher } from '../lib/adapters/TicketModelEventPubli
 import { TicketModelAnalyticsTracker } from '../lib/adapters/TicketModelAnalyticsTracker';
 import { calculateItilPriority } from '@alga-psa/tickets/lib/itilUtils';
 import { enforceTicketCloseRules, TicketCloseValidationError, type CloseRuleFailure } from '../lib/validateTicketClosure';
+import { prepareTicketResourceReassignment } from '../lib/reassignTicketResources';
 import { applyMatchingChecklistTemplates } from '@alga-psa/shared/lib/ticketChecklists';
 import { withAuth } from '@alga-psa/auth';
 import {
@@ -825,71 +826,25 @@ export const updateTicket = withAuth(async (user, { tenant }, id: string, data: 
         }
       }
 
-      let updatedTicket;
+      // Changing assigned_to needs the ticket_resources rows keyed to the old
+      // assignee cleared first, then re-keyed to the new one.
+      const finalizeResourceReassignment = isChangingAssignment
+        ? await prepareTicketResourceReassignment(
+          trx,
+          tenant,
+          id,
+          currentTicket.assigned_to,
+          updateData.assigned_to
+        )
+        : null;
 
-      // If we're changing the assigned_to field, we need to handle the ticket_resources table
-      if (isChangingAssignment) {
-        // Step 1: Delete any ticket_resources where the new assigned_to is an additional_user_id
-        // to avoid constraint violations after the update
-        await tenantScopedTable(trx, 'ticket_resources', tenant)
-          .where({
-            ticket_id: id,
-            additional_user_id: updateData.assigned_to
-          })
-          .delete();
+      const [updatedTicket] = await tenantScopedTable(trx, 'tickets', tenant)
+        .where({ ticket_id: id })
+        .update(updateData)
+        .returning('*');
 
-        // Step 2: Get existing resources with the old assigned_to value
-        const existingResources = await tenantScopedTable(trx, 'ticket_resources', tenant)
-          .where({
-            ticket_id: id,
-            assigned_to: currentTicket.assigned_to
-          })
-          .select('*');
-
-        // Step 3: Store resources for recreation, excluding those that would violate constraints
-        const resourcesToRecreate: any[] = [];
-        for (const resource of existingResources) {
-          // Skip resources where additional_user_id would equal the new assigned_to
-          if (resource.additional_user_id !== updateData.assigned_to) {
-            // Clone the resource but exclude the primary key fields
-            const { assignment_id, ...resourceData } = resource;
-            resourcesToRecreate.push(resourceData);
-          }
-        }
-
-        // Step 4: Delete the existing resources with the old assigned_to
-        if (existingResources.length > 0) {
-          await tenantScopedTable(trx, 'ticket_resources', tenant)
-            .where({
-              ticket_id: id,
-              assigned_to: currentTicket.assigned_to
-            })
-            .delete();
-        }
-
-        // Step 5: Update the ticket with the new assigned_to
-        const [updated] = await tenantScopedTable(trx, 'tickets', tenant)
-          .where({ ticket_id: id })
-          .update(updateData)
-          .returning('*');
-
-        // Step 6: Re-create the resources with the new assigned_to
-        for (const resourceData of resourcesToRecreate) {
-          await tenantScopedTable(trx, 'ticket_resources', tenant).insert({
-            ...resourceData,
-            assigned_to: updateData.assigned_to
-          });
-        }
-
-        updatedTicket = updated;
-      } else {
-        // Regular update without changing assignment
-        const [updated] = await tenantScopedTable(trx, 'tickets', tenant)
-          .where({ ticket_id: id })
-          .update(updateData)
-          .returning('*');
-
-        updatedTicket = updated;
+      if (finalizeResourceReassignment) {
+        await finalizeResourceReassignment();
       }
 
     if (!updatedTicket) {

--- a/packages/tickets/src/actions/ticketResourceActions.ts
+++ b/packages/tickets/src/actions/ticketResourceActions.ts
@@ -6,8 +6,12 @@ import { hasPermission } from '@alga-psa/auth';
 import { tenantDb, withTransaction } from '@alga-psa/db';
 import { createTenantKnex } from '@alga-psa/db';
 import { Knex } from 'knex';
-import { publishEvent } from '@alga-psa/event-bus/publishers';
 import { withAuth } from '@alga-psa/auth';
+import {
+  addTicketResourceCore,
+  getTicketResourcesCore,
+  removeTicketResourceCore,
+} from '../lib/ticketResourceCore';
 import { ticketActionErrorFrom, type TicketActionError } from './ticketActionErrors';
 
 function tenantScopedTable(
@@ -32,86 +36,7 @@ export const addTicketResource = withAuth(async (
       throw new Error('Permission denied: Cannot add ticket resource');
     }
 
-    // First, verify that the ticket exists and has the correct assigned_to
-    const ticket = await tenantScopedTable(trx, 'tickets', tenant)
-      .where({
-        ticket_id: ticketId,
-      })
-      .first();
-
-    if (!ticket) {
-      throw new Error(`Ticket not found in tenant ${tenant}`);
-    }
-
-    // If the ticket has no primary assignment yet, promote this user to primary
-    if (!ticket.assigned_to) {
-      const [updatedTicket] = await tenantScopedTable(trx, 'tickets', tenant)
-        .where({
-          ticket_id: ticketId,
-        })
-        .update({
-          assigned_to: additionalUserId,
-          updated_by: user.user_id,
-          updated_at: new Date()
-        })
-        .returning('*');
-
-      if (!updatedTicket) {
-        throw new Error(`Primary assignment update for ticket ${ticketId} completed without returning the updated ticket.`);
-      }
-
-      await publishEvent({
-        eventType: 'TICKET_ASSIGNED',
-        payload: {
-          tenantId: tenant,
-          ticketId: ticketId,
-          userId: additionalUserId,
-          assignedByUserId: user.user_id
-        }
-      });
-
-      return null;
-    }
-
-    // Check if resource already exists
-    const existingResource = await tenantScopedTable(trx, 'ticket_resources', tenant)
-      .where({
-        ticket_id: ticketId,
-        additional_user_id: additionalUserId,
-      })
-      .first();
-
-    if (existingResource) {
-      throw new Error(`Resource already exists for user ${additionalUserId} in tenant ${tenant}`);
-    }
-
-    // Create the resource with the ticket's assigned_to
-    const [resource] = await tenantScopedTable(trx, 'ticket_resources', tenant)
-      .insert({
-        ticket_id: ticketId,
-        assigned_to: ticket.assigned_to,
-        additional_user_id: additionalUserId,
-        role: role,
-        tenant: tenant,
-        assigned_at: new Date()
-      })
-      .returning('*');
-
-    // Publish TICKET_ADDITIONAL_AGENT_ASSIGNED event
-    const eventPayload = {
-      tenantId: tenant,
-      ticketId: ticketId,
-      primaryAgentId: ticket.assigned_to,
-      additionalAgentId: additionalUserId,
-      assignedByUserId: user.user_id
-    };
-    console.log('[ticketResourceActions] Publishing TICKET_ADDITIONAL_AGENT_ASSIGNED event:', JSON.stringify(eventPayload));
-    await publishEvent({
-      eventType: 'TICKET_ADDITIONAL_AGENT_ASSIGNED',
-      payload: eventPayload
-    });
-
-    return resource;
+    return await addTicketResourceCore(trx, tenant, user.user_id, ticketId, additionalUserId, role);
     });
   } catch (error) {
     const expected = ticketActionErrorFrom(error);
@@ -135,22 +60,7 @@ export const removeTicketResource = withAuth(async (
       throw new Error('Permission denied: Cannot remove ticket resource');
     }
 
-    // Verify the resource exists before attempting to delete
-    const resource = await tenantScopedTable(trx, 'ticket_resources', tenant)
-      .where({
-        assignment_id: assignmentId,
-      })
-      .first();
-
-    if (!resource) {
-      throw new Error(`Ticket resource not found in tenant ${tenant}`);
-    }
-
-    await tenantScopedTable(trx, 'ticket_resources', tenant)
-      .where({
-        assignment_id: assignmentId,
-      })
-      .delete();
+    await removeTicketResourceCore(trx, tenant, assignmentId);
     });
   } catch (error) {
     const expected = ticketActionErrorFrom(error);
@@ -174,25 +84,7 @@ export const getTicketResources = withAuth(async (
       throw new Error('Permission denied: Cannot view ticket resources');
     }
 
-    // First verify the ticket exists
-    const ticket = await tenantScopedTable(trx, 'tickets', tenant)
-      .where({
-        ticket_id: ticketId,
-      })
-      .first();
-
-    if (!ticket) {
-      throw new Error(`Ticket not found in tenant ${tenant}`);
-    }
-
-    const resources = await tenantScopedTable(trx, 'ticket_resources', tenant)
-      .where({
-        ticket_id: ticketId,
-      })
-      .select('*')
-      .orderBy('assigned_at', 'desc');
-
-    return resources;
+    return await getTicketResourcesCore(trx, tenant, ticketId);
     });
   } catch (error) {
     const expected = ticketActionErrorFrom(error);

--- a/packages/tickets/src/actions/ticketSupportFacade.contract.test.ts
+++ b/packages/tickets/src/actions/ticketSupportFacade.contract.test.ts
@@ -12,7 +12,9 @@ function readRepoFile(relativePath: string): string {
 
 const sources = {
   resourceActions: readRepoFile('packages/tickets/src/actions/ticketResourceActions.ts'),
-  teamAssignmentActions: readRepoFile('packages/tickets/src/actions/teamAssignmentActions.ts'),
+  resourceCore: readRepoFile('packages/tickets/src/lib/ticketResourceCore.ts'),
+  reassignTicketResources: readRepoFile('packages/tickets/src/lib/reassignTicketResources.ts'),
+  teamAssignmentCore: readRepoFile('packages/tickets/src/lib/teamAssignmentCore.ts'),
   ticketBundleUtils: readRepoFile('packages/tickets/src/actions/ticketBundleUtils.ts'),
   ticketActivityActions: readRepoFile('packages/tickets/src/actions/ticketActivityActions.ts'),
   ticketNumberActions: readRepoFile('packages/tickets/src/actions/ticket-number-actions/ticketNumberActions.ts'),
@@ -68,9 +70,9 @@ describe('ticket support facade contract', () => {
   });
 
   it('uses facade joins for migrated support joins', () => {
-    expect(sources.teamAssignmentActions).toContain("tenantScopedTable(trx, 'team_members', tenant)");
-    expect(sources.teamAssignmentActions).toContain("tenantJoin(");
-    expect(sources.teamAssignmentActions).toContain("'users'");
+    expect(sources.teamAssignmentCore).toContain("tenantScopedTable(trx, 'team_members', tenant)");
+    expect(sources.teamAssignmentCore).toContain("tenantJoin(");
+    expect(sources.teamAssignmentCore).toContain("'users'");
 
     expect(sources.ticketBundleUtils).toContain("tenantScopedTable(trx, 'tickets as t', tenant)");
     expect(sources.ticketBundleUtils).toContain("tenantJoin(");

--- a/packages/tickets/src/lib/__tests__/fakeTenantTables.ts
+++ b/packages/tickets/src/lib/__tests__/fakeTenantTables.ts
@@ -1,0 +1,108 @@
+/**
+ * Tiny in-memory stand-in for the tenant-scoped knex builder used by the
+ * ticket assignment helpers. Supports only the operations those helpers call.
+ */
+
+export type FakeRow = Record<string, any>;
+export type FakeTables = Record<string, FakeRow[]>;
+
+// Joined queries filter on qualified columns ('users.is_inactive'); the fake
+// stores flat rows, so match on the bare column name.
+function columnName(key: string): string {
+  return key.includes('.') ? key.split('.').pop()! : key;
+}
+
+function createBuilder(tables: FakeTables, table: string) {
+  const criteria: FakeRow[] = [];
+  let inFilter: { column: string; values: any[] } | null = null;
+  let notInFilter: { column: string; values: any[] } | null = null;
+  let orderByColumn: string | null = null;
+  let orderByDirection: 'asc' | 'desc' = 'asc';
+
+  const rows = () => (tables[table] ??= []);
+
+  const matches = (row: FakeRow) => {
+    const matchesCriteria = criteria.every((criterion) =>
+      Object.entries(criterion).every(([key, value]) => row[columnName(key)] === value)
+    );
+    const matchesIn = !inFilter || inFilter.values.includes(row[columnName(inFilter.column)]);
+    const matchesNotIn = !notInFilter || !notInFilter.values.includes(row[columnName(notInFilter.column)]);
+    return matchesCriteria && matchesIn && matchesNotIn;
+  };
+
+  const selected = () => {
+    const result = rows().filter(matches);
+    if (orderByColumn) {
+      result.sort((a, b) => {
+        const left = a[orderByColumn!];
+        const right = b[orderByColumn!];
+        const comparison = left === right ? 0 : left > right ? 1 : -1;
+        return orderByDirection === 'desc' ? -comparison : comparison;
+      });
+    }
+    return result;
+  };
+
+  const builder: any = {
+    where(criterion: FakeRow | string, value?: any) {
+      criteria.push(typeof criterion === 'string' ? { [criterion]: value } : criterion);
+      return builder;
+    },
+    andWhere(criterion: FakeRow | string, value?: any) {
+      return builder.where(criterion, value);
+    },
+    whereIn(column: string, values: any[]) {
+      inFilter = { column, values };
+      return builder;
+    },
+    whereNotIn(column: string, values: any[]) {
+      notInFilter = { column, values };
+      return builder;
+    },
+    orderBy(column: string, direction: 'asc' | 'desc' = 'asc') {
+      orderByColumn = column;
+      orderByDirection = direction;
+      return builder;
+    },
+    select() {
+      return builder;
+    },
+    async first() {
+      return selected()[0];
+    },
+    insert(payload: FakeRow | FakeRow[]) {
+      const inserted = (Array.isArray(payload) ? payload : [payload]).map((row, index) => ({
+        assignment_id: `assignment-${rows().length + index + 1}`,
+        ...row,
+      }));
+      rows().push(...inserted);
+      const result: any = Promise.resolve(inserted);
+      result.returning = async () => inserted;
+      return result;
+    },
+    update(values: FakeRow) {
+      const updated = selected().map((row) => Object.assign(row, values));
+      const result: any = Promise.resolve(updated.length);
+      result.returning = async () => updated;
+      return result;
+    },
+    async delete() {
+      const doomed = new Set(selected());
+      tables[table] = rows().filter((row) => !doomed.has(row));
+      return doomed.size;
+    },
+    then(resolve: (rows: FakeRow[]) => unknown, reject?: (error: unknown) => unknown) {
+      return Promise.resolve(selected()).then(resolve, reject);
+    },
+  };
+
+  return builder;
+}
+
+/** Drop-in replacement for the `tenantDb` export of `@alga-psa/db`. */
+export function createTenantDbMock(getTables: () => FakeTables) {
+  return () => ({
+    table: (table: string) => createBuilder(getTables(), table),
+    tenantJoin: (query: any) => query,
+  });
+}

--- a/packages/tickets/src/lib/__tests__/reassignTicketResources.test.ts
+++ b/packages/tickets/src/lib/__tests__/reassignTicketResources.test.ts
@@ -1,0 +1,78 @@
+// @vitest-environment node
+
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import type { FakeTables } from './fakeTenantTables';
+
+let tables: FakeTables = {};
+
+vi.mock('@alga-psa/db', async () => {
+  const { createTenantDbMock } = await import('./fakeTenantTables');
+  return { tenantDb: createTenantDbMock(() => tables) };
+});
+
+const TENANT = 'tenant-1';
+const TICKET = 'ticket-1';
+
+async function reassign(currentAssignedTo: string | null, newAssignedTo: string | null) {
+  const { prepareTicketResourceReassignment } = await import('../reassignTicketResources');
+  const finalize = await prepareTicketResourceReassignment(
+    {} as any,
+    TENANT,
+    TICKET,
+    currentAssignedTo,
+    newAssignedTo
+  );
+  await finalize();
+  return tables.ticket_resources ?? [];
+}
+
+describe('prepareTicketResourceReassignment', () => {
+  beforeEach(() => {
+    tables = {
+      ticket_resources: [
+        { assignment_id: 'a1', tenant: TENANT, ticket_id: TICKET, assigned_to: 'user-a', additional_user_id: 'user-c', role: 'support' },
+        { assignment_id: 'a2', tenant: TENANT, ticket_id: TICKET, assigned_to: 'user-a', additional_user_id: 'user-d', role: 'team_member' },
+        { assignment_id: 'a3', tenant: TENANT, ticket_id: 'other-ticket', assigned_to: 'user-a', additional_user_id: 'user-e', role: 'support' },
+      ],
+    };
+  });
+
+  it('re-keys the additional agents to the new primary assignee', async () => {
+    const resources = await reassign('user-a', 'user-b');
+
+    const forTicket = resources.filter((row) => row.ticket_id === TICKET);
+    expect(forTicket).toHaveLength(2);
+    expect(forTicket.every((row) => row.assigned_to === 'user-b')).toBe(true);
+    expect(forTicket.map((row) => row.additional_user_id).sort()).toEqual(['user-c', 'user-d']);
+    expect(forTicket.map((row) => row.role).sort()).toEqual(['support', 'team_member']);
+  });
+
+  it('leaves other tickets alone', async () => {
+    const resources = await reassign('user-a', 'user-b');
+
+    expect(resources.find((row) => row.assignment_id === 'a3')).toMatchObject({
+      ticket_id: 'other-ticket',
+      assigned_to: 'user-a',
+    });
+  });
+
+  it('absorbs an additional agent who becomes the primary assignee', async () => {
+    const resources = await reassign('user-a', 'user-c');
+
+    const forTicket = resources.filter((row) => row.ticket_id === TICKET);
+    expect(forTicket).toHaveLength(1);
+    expect(forTicket[0]).toMatchObject({ assigned_to: 'user-c', additional_user_id: 'user-d' });
+  });
+
+  it('drops the additional agents when the ticket is unassigned', async () => {
+    const resources = await reassign('user-a', null);
+
+    expect(resources.filter((row) => row.ticket_id === TICKET)).toHaveLength(0);
+  });
+
+  it('is a no-op when the ticket had no primary assignee', async () => {
+    const resources = await reassign(null, 'user-b');
+
+    expect(resources).toHaveLength(3);
+  });
+});

--- a/packages/tickets/src/lib/__tests__/teamAssignmentCore.test.ts
+++ b/packages/tickets/src/lib/__tests__/teamAssignmentCore.test.ts
@@ -1,0 +1,154 @@
+// @vitest-environment node
+
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import type { FakeTables } from './fakeTenantTables';
+
+let tables: FakeTables = {};
+
+vi.mock('@alga-psa/db', async () => {
+  const { createTenantDbMock } = await import('./fakeTenantTables');
+  return { tenantDb: createTenantDbMock(() => tables) };
+});
+
+const TENANT = 'tenant-1';
+const TICKET = 'ticket-1';
+const TEAM = 'team-1';
+const ACTOR = 'user-actor';
+
+const trx = {} as any;
+
+function seed(overrides: Partial<FakeTables> = {}) {
+  tables = {
+    tickets: [{ tenant: TENANT, ticket_id: TICKET, assigned_to: null, assigned_team_id: null }],
+    teams: [{ tenant: TENANT, team_id: TEAM, manager_id: 'user-lead' }],
+    team_members: [
+      { tenant: TENANT, team_id: TEAM, user_id: 'user-lead', is_inactive: false },
+      { tenant: TENANT, team_id: TEAM, user_id: 'user-b', is_inactive: false },
+      { tenant: TENANT, team_id: TEAM, user_id: 'user-inactive', is_inactive: true },
+    ],
+    ticket_resources: [],
+    ...overrides,
+  };
+}
+
+describe('assignTeamToTicketCore', () => {
+  beforeEach(() => seed());
+
+  it('falls back to the team lead as primary agent and adds the active members', async () => {
+    const { assignTeamToTicketCore } = await import('../teamAssignmentCore');
+
+    const assignedTo = await assignTeamToTicketCore(trx, TENANT, ACTOR, TICKET, TEAM);
+
+    expect(assignedTo).toBe('user-lead');
+    expect(tables.tickets[0]).toMatchObject({
+      assigned_team_id: TEAM,
+      assigned_to: 'user-lead',
+      updated_by: ACTOR,
+    });
+    expect(tables.ticket_resources).toHaveLength(1);
+    expect(tables.ticket_resources[0]).toMatchObject({
+      ticket_id: TICKET,
+      assigned_to: 'user-lead',
+      additional_user_id: 'user-b',
+      role: 'team_member',
+    });
+  });
+
+  it('keeps an existing primary agent and keys the members to them', async () => {
+    tables.tickets[0].assigned_to = 'user-a';
+    const { assignTeamToTicketCore } = await import('../teamAssignmentCore');
+
+    const assignedTo = await assignTeamToTicketCore(trx, TENANT, ACTOR, TICKET, TEAM);
+
+    expect(assignedTo).toBe('user-a');
+    expect(tables.ticket_resources.map((row) => row.additional_user_id).sort()).toEqual([
+      'user-b',
+      'user-lead',
+    ]);
+    expect(tables.ticket_resources.every((row) => row.assigned_to === 'user-a')).toBe(true);
+  });
+
+  it('does not duplicate members who are already additional agents', async () => {
+    tables.tickets[0].assigned_to = 'user-a';
+    tables.ticket_resources.push({
+      assignment_id: 'existing',
+      tenant: TENANT,
+      ticket_id: TICKET,
+      assigned_to: 'user-a',
+      additional_user_id: 'user-b',
+      role: 'support',
+    });
+    const { assignTeamToTicketCore } = await import('../teamAssignmentCore');
+
+    await assignTeamToTicketCore(trx, TENANT, ACTOR, TICKET, TEAM);
+
+    expect(tables.ticket_resources.filter((row) => row.additional_user_id === 'user-b')).toHaveLength(1);
+    expect(tables.ticket_resources.find((row) => row.additional_user_id === 'user-b')?.role).toBe('support');
+  });
+
+  it('rejects a team without a lead', async () => {
+    tables.teams[0].manager_id = null;
+    const { assignTeamToTicketCore } = await import('../teamAssignmentCore');
+
+    await expect(assignTeamToTicketCore(trx, TENANT, ACTOR, TICKET, TEAM)).rejects.toThrow(
+      'Team lead not found'
+    );
+  });
+
+  it('rejects an unknown ticket or team', async () => {
+    const { assignTeamToTicketCore } = await import('../teamAssignmentCore');
+
+    await expect(assignTeamToTicketCore(trx, TENANT, ACTOR, 'missing', TEAM)).rejects.toThrow('Ticket not found');
+    await expect(assignTeamToTicketCore(trx, TENANT, ACTOR, TICKET, 'missing')).rejects.toThrow('Team not found');
+  });
+});
+
+describe('removeTeamFromTicketCore', () => {
+  beforeEach(() => {
+    seed();
+    tables.tickets[0].assigned_team_id = TEAM;
+    tables.tickets[0].assigned_to = 'user-a';
+    tables.ticket_resources = [
+      { assignment_id: 'r1', tenant: TENANT, ticket_id: TICKET, assigned_to: 'user-a', additional_user_id: 'user-b', role: 'team_member' },
+      { assignment_id: 'r2', tenant: TENANT, ticket_id: TICKET, assigned_to: 'user-a', additional_user_id: 'user-c', role: 'team_member' },
+      { assignment_id: 'r3', tenant: TENANT, ticket_id: TICKET, assigned_to: 'user-a', additional_user_id: 'user-d', role: 'support' },
+    ];
+  });
+
+  it('remove_all drops the team members but keeps other additional agents', async () => {
+    const { removeTeamFromTicketCore } = await import('../teamAssignmentCore');
+
+    await removeTeamFromTicketCore(trx, TENANT, ACTOR, TICKET, { mode: 'remove_all' });
+
+    expect(tables.tickets[0].assigned_team_id).toBeNull();
+    expect(tables.ticket_resources.map((row) => row.assignment_id)).toEqual(['r3']);
+  });
+
+  it('keep_all leaves every additional agent in place', async () => {
+    const { removeTeamFromTicketCore } = await import('../teamAssignmentCore');
+
+    await removeTeamFromTicketCore(trx, TENANT, ACTOR, TICKET, { mode: 'keep_all' });
+
+    expect(tables.tickets[0].assigned_team_id).toBeNull();
+    expect(tables.ticket_resources).toHaveLength(3);
+  });
+
+  it('selective keeps only the listed team members', async () => {
+    const { removeTeamFromTicketCore } = await import('../teamAssignmentCore');
+
+    await removeTeamFromTicketCore(trx, TENANT, ACTOR, TICKET, {
+      mode: 'selective',
+      keepUserIds: ['user-c'],
+    });
+
+    expect(tables.ticket_resources.map((row) => row.assignment_id).sort()).toEqual(['r2', 'r3']);
+  });
+
+  it('rejects an unknown ticket', async () => {
+    const { removeTeamFromTicketCore } = await import('../teamAssignmentCore');
+
+    await expect(
+      removeTeamFromTicketCore(trx, TENANT, ACTOR, 'missing', { mode: 'remove_all' })
+    ).rejects.toThrow('Ticket not found');
+  });
+});

--- a/packages/tickets/src/lib/__tests__/ticketResourceCore.test.ts
+++ b/packages/tickets/src/lib/__tests__/ticketResourceCore.test.ts
@@ -1,0 +1,139 @@
+// @vitest-environment node
+
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import type { FakeTables } from './fakeTenantTables';
+
+let tables: FakeTables = {};
+const publishEventMock = vi.fn();
+
+vi.mock('@alga-psa/db', async () => {
+  const { createTenantDbMock } = await import('./fakeTenantTables');
+  return { tenantDb: createTenantDbMock(() => tables) };
+});
+
+vi.mock('@alga-psa/event-bus/publishers', () => ({
+  publishEvent: (...args: any[]) => publishEventMock(...args),
+}));
+
+const TENANT = 'tenant-1';
+const TICKET = 'ticket-1';
+const ACTOR = 'user-actor';
+
+const trx = {} as any;
+
+describe('ticketResourceCore', () => {
+  beforeEach(() => {
+    publishEventMock.mockReset();
+    tables = {
+      tickets: [{ tenant: TENANT, ticket_id: TICKET, assigned_to: 'user-a' }],
+      ticket_resources: [],
+    };
+  });
+
+  describe('addTicketResourceCore', () => {
+    it('adds an additional agent keyed to the current primary assignee', async () => {
+      const { addTicketResourceCore } = await import('../ticketResourceCore');
+
+      const resource = await addTicketResourceCore(trx, TENANT, ACTOR, TICKET, 'user-b', 'support');
+
+      expect(resource).toMatchObject({
+        ticket_id: TICKET,
+        assigned_to: 'user-a',
+        additional_user_id: 'user-b',
+        role: 'support',
+      });
+      expect(publishEventMock).toHaveBeenCalledWith({
+        eventType: 'TICKET_ADDITIONAL_AGENT_ASSIGNED',
+        payload: {
+          tenantId: TENANT,
+          ticketId: TICKET,
+          primaryAgentId: 'user-a',
+          additionalAgentId: 'user-b',
+          assignedByUserId: ACTOR,
+        },
+      });
+    });
+
+    it('promotes the user to primary when the ticket is unassigned', async () => {
+      tables.tickets[0].assigned_to = null;
+      const { addTicketResourceCore } = await import('../ticketResourceCore');
+
+      const resource = await addTicketResourceCore(trx, TENANT, ACTOR, TICKET, 'user-b', 'support');
+
+      expect(resource).toBeNull();
+      expect(tables.tickets[0]).toMatchObject({ assigned_to: 'user-b', updated_by: ACTOR });
+      expect(tables.ticket_resources).toHaveLength(0);
+      expect(publishEventMock).toHaveBeenCalledWith({
+        eventType: 'TICKET_ASSIGNED',
+        payload: {
+          tenantId: TENANT,
+          ticketId: TICKET,
+          userId: 'user-b',
+          assignedByUserId: ACTOR,
+        },
+      });
+    });
+
+    it('rejects a duplicate additional agent as a conflict', async () => {
+      const { addTicketResourceCore, TicketResourceError } = await import('../ticketResourceCore');
+      await addTicketResourceCore(trx, TENANT, ACTOR, TICKET, 'user-b', 'support');
+
+      const error = await addTicketResourceCore(trx, TENANT, ACTOR, TICKET, 'user-b', 'support')
+        .catch((thrown) => thrown);
+
+      expect(error).toBeInstanceOf(TicketResourceError);
+      expect(error.kind).toBe('conflict');
+      expect(tables.ticket_resources).toHaveLength(1);
+    });
+
+    it('reports a missing ticket as not found', async () => {
+      const { addTicketResourceCore } = await import('../ticketResourceCore');
+
+      await expect(
+        addTicketResourceCore(trx, TENANT, ACTOR, 'missing-ticket', 'user-b', 'support')
+      ).rejects.toMatchObject({ kind: 'not_found' });
+    });
+  });
+
+  describe('removeTicketResourceCore', () => {
+    it('removes the assignment row', async () => {
+      const { addTicketResourceCore, removeTicketResourceCore } = await import('../ticketResourceCore');
+      const resource = await addTicketResourceCore(trx, TENANT, ACTOR, TICKET, 'user-b', 'support');
+
+      await removeTicketResourceCore(trx, TENANT, resource!.assignment_id!);
+
+      expect(tables.ticket_resources).toHaveLength(0);
+    });
+
+    it('reports an unknown assignment as not found', async () => {
+      const { removeTicketResourceCore } = await import('../ticketResourceCore');
+
+      await expect(removeTicketResourceCore(trx, TENANT, 'nope')).rejects.toMatchObject({
+        kind: 'not_found',
+      });
+    });
+  });
+
+  describe('getTicketResourcesCore', () => {
+    it('returns the ticket resources newest first', async () => {
+      tables.ticket_resources = [
+        { assignment_id: 'a1', tenant: TENANT, ticket_id: TICKET, assigned_to: 'user-a', additional_user_id: 'user-b', assigned_at: new Date('2026-01-01') },
+        { assignment_id: 'a2', tenant: TENANT, ticket_id: TICKET, assigned_to: 'user-a', additional_user_id: 'user-c', assigned_at: new Date('2026-02-01') },
+        { assignment_id: 'a3', tenant: TENANT, ticket_id: 'other', assigned_to: 'user-a', additional_user_id: 'user-d', assigned_at: new Date('2026-03-01') },
+      ];
+      const { getTicketResourcesCore } = await import('../ticketResourceCore');
+
+      const resources = await getTicketResourcesCore(trx, TENANT, TICKET);
+
+      expect(resources.map((resource) => resource.additional_user_id)).toEqual(['user-c', 'user-b']);
+    });
+
+    it('reports a missing ticket as not found', async () => {
+      const { getTicketResourcesCore } = await import('../ticketResourceCore');
+
+      await expect(getTicketResourcesCore(trx, TENANT, 'missing-ticket')).rejects.toMatchObject({
+        kind: 'not_found',
+      });
+    });
+  });
+});

--- a/packages/tickets/src/lib/reassignTicketResources.ts
+++ b/packages/tickets/src/lib/reassignTicketResources.ts
@@ -1,0 +1,70 @@
+import type { Knex } from 'knex';
+import { tenantDb } from '@alga-psa/db';
+
+function tenantScopedTable(
+  conn: Knex | Knex.Transaction,
+  table: string,
+  tenant: string
+): Knex.QueryBuilder {
+  return tenantDb(conn, tenant).table(table);
+}
+
+/**
+ * Re-keys a ticket's additional agents when the primary assignee changes.
+ *
+ * `ticket_resources` has a foreign key on (tenant, ticket_id, assigned_to) with
+ * NO ACTION semantics, so `tickets.assigned_to` cannot be updated while rows
+ * reference the old assignee. Call this before the update, then invoke the
+ * returned finalizer afterwards to re-insert against the new assignee. Shared by
+ * the server action and the REST API so both paths behave the same.
+ */
+export async function prepareTicketResourceReassignment(
+  trx: Knex.Transaction,
+  tenant: string,
+  ticketId: string,
+  currentAssignedTo: string | null | undefined,
+  newAssignedTo: string | null | undefined
+): Promise<() => Promise<void>> {
+  const noop = async () => {};
+
+  // The incoming primary assignee may already be an additional agent, which the
+  // `assigned_to != additional_user_id` check constraint forbids. Absorb that
+  // row into the promotion rather than failing the update.
+  if (newAssignedTo) {
+    await tenantScopedTable(trx, 'ticket_resources', tenant)
+      .where({ ticket_id: ticketId, additional_user_id: newAssignedTo })
+      .delete();
+  }
+
+  if (!currentAssignedTo) {
+    return noop;
+  }
+
+  const existingResources = await tenantScopedTable(trx, 'ticket_resources', tenant)
+    .where({ ticket_id: ticketId, assigned_to: currentAssignedTo })
+    .select('*');
+
+  if (existingResources.length === 0) {
+    return noop;
+  }
+
+  const resourcesToRecreate: Record<string, unknown>[] = existingResources
+    .filter((resource: Record<string, unknown>) => resource.additional_user_id !== newAssignedTo)
+    .map(({ assignment_id: _assignmentId, ...resource }: Record<string, unknown>) => resource);
+
+  await tenantScopedTable(trx, 'ticket_resources', tenant)
+    .where({ ticket_id: ticketId, assigned_to: currentAssignedTo })
+    .delete();
+
+  return async () => {
+    // Unassigning leaves nothing to key the rows to (`assigned_to` is NOT NULL),
+    // so the additional agents go away with the assignment.
+    if (!newAssignedTo || resourcesToRecreate.length === 0) {
+      return;
+    }
+
+    await tenantScopedTable(trx, 'ticket_resources', tenant).insert(
+      resourcesToRecreate.map((resource) => ({ ...resource, assigned_to: newAssignedTo }))
+    );
+  };
+}

--- a/packages/tickets/src/lib/teamAssignmentCore.ts
+++ b/packages/tickets/src/lib/teamAssignmentCore.ts
@@ -1,0 +1,147 @@
+import type { Knex } from 'knex';
+import { tenantDb } from '@alga-psa/db';
+
+export type RemoveTeamFromTicketMode = 'remove_all' | 'keep_all' | 'selective';
+
+export interface RemoveTeamFromTicketOptions {
+  mode: RemoveTeamFromTicketMode;
+  keepUserIds?: string[];
+}
+
+function tenantScopedTable(
+  conn: Knex | Knex.Transaction,
+  table: string,
+  tenant: string
+): Knex.QueryBuilder {
+  return tenantDb(conn, tenant).table(table);
+}
+
+/**
+ * Assigns a team to a ticket: sets assigned_team_id, resolves the primary
+ * assignee (existing one, else the team lead), and records the team's active
+ * members as `team_member` additional agents. Returns the resolved primary
+ * assignee so the caller can publish TICKET_ASSIGNED after the commit.
+ */
+export async function assignTeamToTicketCore(
+  trx: Knex.Transaction,
+  tenant: string,
+  actorUserId: string,
+  ticketId: string,
+  teamId: string
+): Promise<string> {
+  const ticket = await tenantScopedTable(trx, 'tickets', tenant)
+    .where({ ticket_id: ticketId })
+    .first();
+
+  if (!ticket) {
+    throw new Error('Ticket not found');
+  }
+
+  const team = await tenantScopedTable(trx, 'teams', tenant)
+    .where({ team_id: teamId })
+    .first();
+
+  if (!team) {
+    throw new Error('Team not found');
+  }
+
+  if (!team.manager_id) {
+    throw new Error('Team lead not found');
+  }
+
+  const teamMembers = await tenantDb(trx, tenant)
+    .tenantJoin(
+      tenantScopedTable(trx, 'team_members', tenant),
+      'users',
+      'team_members.user_id',
+      'users.user_id'
+    )
+    .where({ 'team_members.team_id': teamId })
+    .andWhere('users.is_inactive', false)
+    .select('team_members.user_id') as Array<{ user_id: string }>;
+
+  // assigned_to is guaranteed non-null: either the ticket already has one,
+  // or we fall back to team.manager_id (validated above).
+  const resolvedAssignedTo: string = (ticket.assigned_to as string | null) || team.manager_id;
+
+  await tenantScopedTable(trx, 'tickets', tenant)
+    .where({ ticket_id: ticketId })
+    .update({
+      assigned_team_id: teamId,
+      assigned_to: resolvedAssignedTo,
+      updated_by: actorUserId,
+      updated_at: new Date()
+    });
+
+  const memberIds = teamMembers
+    .map((member: { user_id: string }) => member.user_id)
+    .filter((userId: string) => userId && userId !== resolvedAssignedTo);
+
+  if (memberIds.length > 0) {
+    const existingResources = await tenantScopedTable(trx, 'ticket_resources', tenant)
+      .where({ ticket_id: ticketId })
+      .whereIn('additional_user_id', memberIds)
+      .select('additional_user_id');
+
+    const existingIds = new Set(existingResources.map((row: { additional_user_id: string }) => row.additional_user_id));
+    const toInsert = memberIds.filter((userId) => !existingIds.has(userId));
+
+    if (toInsert.length > 0) {
+      await tenantScopedTable(trx, 'ticket_resources', tenant).insert(
+        toInsert.map((userId) => ({
+          ticket_id: ticketId,
+          assigned_to: resolvedAssignedTo,
+          additional_user_id: userId,
+          role: 'team_member',
+          tenant,
+          assigned_at: new Date()
+        }))
+      );
+    }
+  }
+
+  return resolvedAssignedTo;
+}
+
+/**
+ * Clears a ticket's team assignment, optionally pruning the `team_member`
+ * additional agents the team assignment created.
+ */
+export async function removeTeamFromTicketCore(
+  trx: Knex.Transaction,
+  tenant: string,
+  actorUserId: string,
+  ticketId: string,
+  options: RemoveTeamFromTicketOptions
+): Promise<void> {
+  const ticket = await tenantScopedTable(trx, 'tickets', tenant)
+    .where({ ticket_id: ticketId })
+    .first();
+
+  if (!ticket) {
+    throw new Error('Ticket not found');
+  }
+
+  const mode = options.mode;
+  if (mode === 'remove_all') {
+    await tenantScopedTable(trx, 'ticket_resources', tenant)
+      .where({ ticket_id: ticketId, role: 'team_member' })
+      .delete();
+  }
+
+  if (mode === 'selective') {
+    const keepIds = new Set(options.keepUserIds ?? []);
+    await tenantScopedTable(trx, 'ticket_resources', tenant)
+      .where({ ticket_id: ticketId, role: 'team_member' })
+      .whereNotIn('additional_user_id', Array.from(keepIds))
+      .delete();
+  }
+
+  await tenantScopedTable(trx, 'tickets', tenant)
+    .where({ ticket_id: ticketId })
+    .update({
+      assigned_team_id: null,
+      updated_by: actorUserId,
+      updated_at: new Date()
+    });
+}

--- a/packages/tickets/src/lib/ticketResourceCore.ts
+++ b/packages/tickets/src/lib/ticketResourceCore.ts
@@ -1,0 +1,149 @@
+import type { Knex } from 'knex';
+import { tenantDb } from '@alga-psa/db';
+import { publishEvent } from '@alga-psa/event-bus/publishers';
+import type { ITicketResource } from '@alga-psa/types';
+
+function tenantScopedTable(
+  conn: Knex | Knex.Transaction,
+  table: string,
+  tenant: string
+): Knex.QueryBuilder {
+  return tenantDb(conn, tenant).table(table);
+}
+
+export class TicketResourceError extends Error {
+  constructor(
+    message: string,
+    readonly kind: 'not_found' | 'conflict'
+  ) {
+    super(message);
+    this.name = 'TicketResourceError';
+  }
+}
+
+/**
+ * Adds an additional agent to a ticket. Returns null when the ticket had no
+ * primary assignee and the user was promoted to primary instead.
+ *
+ * Shared by the server action (`addTicketResource`) and the REST API so both
+ * paths apply the same promote-to-primary rule, duplicate check, and events.
+ */
+export async function addTicketResourceCore(
+  trx: Knex.Transaction,
+  tenant: string,
+  actorUserId: string,
+  ticketId: string,
+  additionalUserId: string,
+  role: string
+): Promise<ITicketResource | null> {
+  const ticket = await tenantScopedTable(trx, 'tickets', tenant)
+    .where({ ticket_id: ticketId })
+    .first();
+
+  if (!ticket) {
+    throw new TicketResourceError(`Ticket not found in tenant ${tenant}`, 'not_found');
+  }
+
+  // If the ticket has no primary assignment yet, promote this user to primary
+  if (!ticket.assigned_to) {
+    const [updatedTicket] = await tenantScopedTable(trx, 'tickets', tenant)
+      .where({ ticket_id: ticketId })
+      .update({
+        assigned_to: additionalUserId,
+        updated_by: actorUserId,
+        updated_at: new Date()
+      })
+      .returning('*');
+
+    if (!updatedTicket) {
+      throw new Error(`Primary assignment update for ticket ${ticketId} completed without returning the updated ticket.`);
+    }
+
+    await publishEvent({
+      eventType: 'TICKET_ASSIGNED',
+      payload: {
+        tenantId: tenant,
+        ticketId: ticketId,
+        userId: additionalUserId,
+        assignedByUserId: actorUserId
+      }
+    });
+
+    return null;
+  }
+
+  const existingResource = await tenantScopedTable(trx, 'ticket_resources', tenant)
+    .where({
+      ticket_id: ticketId,
+      additional_user_id: additionalUserId,
+    })
+    .first();
+
+  if (existingResource) {
+    throw new TicketResourceError(
+      `Resource already exists for user ${additionalUserId} in tenant ${tenant}`,
+      'conflict'
+    );
+  }
+
+  const [resource] = await tenantScopedTable(trx, 'ticket_resources', tenant)
+    .insert({
+      ticket_id: ticketId,
+      assigned_to: ticket.assigned_to,
+      additional_user_id: additionalUserId,
+      role: role,
+      tenant: tenant,
+      assigned_at: new Date()
+    })
+    .returning('*');
+
+  await publishEvent({
+    eventType: 'TICKET_ADDITIONAL_AGENT_ASSIGNED',
+    payload: {
+      tenantId: tenant,
+      ticketId: ticketId,
+      primaryAgentId: ticket.assigned_to,
+      additionalAgentId: additionalUserId,
+      assignedByUserId: actorUserId
+    }
+  });
+
+  return resource;
+}
+
+export async function removeTicketResourceCore(
+  trx: Knex.Transaction,
+  tenant: string,
+  assignmentId: string
+): Promise<void> {
+  const resource = await tenantScopedTable(trx, 'ticket_resources', tenant)
+    .where({ assignment_id: assignmentId })
+    .first();
+
+  if (!resource) {
+    throw new TicketResourceError(`Ticket resource not found in tenant ${tenant}`, 'not_found');
+  }
+
+  await tenantScopedTable(trx, 'ticket_resources', tenant)
+    .where({ assignment_id: assignmentId })
+    .delete();
+}
+
+export async function getTicketResourcesCore(
+  trx: Knex.Transaction,
+  tenant: string,
+  ticketId: string
+): Promise<ITicketResource[]> {
+  const ticket = await tenantScopedTable(trx, 'tickets', tenant)
+    .where({ ticket_id: ticketId })
+    .first();
+
+  if (!ticket) {
+    throw new TicketResourceError(`Ticket not found in tenant ${tenant}`, 'not_found');
+  }
+
+  return await tenantScopedTable(trx, 'ticket_resources', tenant)
+    .where({ ticket_id: ticketId })
+    .select('*')
+    .orderBy('assigned_at', 'desc');
+}

--- a/sdk/docs/openapi/alga-openapi.ce.json
+++ b/sdk/docs/openapi/alga-openapi.ce.json
@@ -21329,6 +21329,84 @@
           "currency_code"
         ]
       },
+      "WorkV1TicketAgentParams": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string",
+            "format": "uuid",
+            "description": "Ticket UUID."
+          },
+          "userId": {
+            "type": "string",
+            "format": "uuid",
+            "description": "User UUID of the additional agent."
+          }
+        },
+        "required": [
+          "id",
+          "userId"
+        ]
+      },
+      "WorkV1TicketAgentBody": {
+        "type": "object",
+        "properties": {
+          "user_id": {
+            "type": "string",
+            "format": "uuid",
+            "description": "User to add as an additional agent."
+          },
+          "role": {
+            "type": "string",
+            "maxLength": 50,
+            "description": "Resource role recorded on the assignment; defaults to support."
+          }
+        },
+        "required": [
+          "user_id"
+        ]
+      },
+      "WorkV1TicketTeamAssignBody": {
+        "type": "object",
+        "properties": {
+          "team_id": {
+            "type": "string",
+            "format": "uuid",
+            "description": "Team to assign to the ticket."
+          },
+          "suppressContactNotifications": {
+            "type": "boolean"
+          },
+          "suppressInternalNotifications": {
+            "type": "boolean"
+          }
+        },
+        "required": [
+          "team_id"
+        ]
+      },
+      "WorkV1TicketTeamRemoveBody": {
+        "type": "object",
+        "properties": {
+          "mode": {
+            "type": "string",
+            "enum": [
+              "remove_all",
+              "keep_all",
+              "selective"
+            ],
+            "description": "What to do with the team_member additional agents; defaults to remove_all."
+          },
+          "keep_user_ids": {
+            "type": "array",
+            "items": {
+              "type": "string",
+              "format": "uuid"
+            },
+            "description": "Required with mode=selective: the team members to keep as additional agents."
+          }
+        }
+      },
       "QuoteIdParamV1": {
         "type": "object",
         "properties": {
@@ -95530,6 +95608,536 @@
         "responses": {
           "200": {
             "description": "Document removed.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/WorkV1ApiSuccess"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Validation or request parsing failure.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/WorkV1ApiError"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "API key missing/invalid.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/WorkV1ApiError"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "RBAC denied for ticket resource action.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/WorkV1ApiError"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Ticket or sub-resource not found.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/WorkV1ApiError"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Unexpected controller/service failure.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/WorkV1ApiError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/tickets/{id}/agents": {
+      "get": {
+        "summary": "List ticket agents",
+        "description": "Returns the ticket primary agent (tickets.assigned_to) and its additional agents (ticket_resources), each with user_id, name and email.",
+        "tags": [
+          "Work Management v1"
+        ],
+        "security": [
+          {
+            "ApiKeyAuth": []
+          }
+        ],
+        "extensions": {
+          "x-tenant-scoped": true,
+          "x-rbac-resource": "ticket",
+          "x-rbac-action": "read"
+        },
+        "x-alga-products": [
+          "psa",
+          "algadesk"
+        ],
+        "parameters": [
+          {
+            "schema": {
+              "type": "string",
+              "format": "uuid",
+              "description": "UUID path identifier from underlying resource tables."
+            },
+            "required": true,
+            "description": "UUID path identifier from underlying resource tables.",
+            "name": "id",
+            "in": "path"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Ticket primary and additional agents.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/WorkV1ApiSuccess"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Validation or request parsing failure.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/WorkV1ApiError"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "API key missing/invalid.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/WorkV1ApiError"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "RBAC denied for ticket resource action.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/WorkV1ApiError"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Ticket or sub-resource not found.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/WorkV1ApiError"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Unexpected controller/service failure.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/WorkV1ApiError"
+                }
+              }
+            }
+          }
+        }
+      },
+      "post": {
+        "summary": "Add a ticket additional agent",
+        "description": "Adds a user as an additional agent on the ticket and publishes TICKET_ADDITIONAL_AGENT_ASSIGNED so notifications fire as they do in the UI. A ticket with no primary agent promotes the user to primary instead (TICKET_ASSIGNED). Returns the updated agent list; a duplicate returns 409.",
+        "tags": [
+          "Work Management v1"
+        ],
+        "security": [
+          {
+            "ApiKeyAuth": []
+          }
+        ],
+        "extensions": {
+          "x-tenant-scoped": true,
+          "x-rbac-resource": "ticket",
+          "x-rbac-action": "update"
+        },
+        "x-alga-products": [
+          "psa",
+          "algadesk"
+        ],
+        "parameters": [
+          {
+            "schema": {
+              "type": "string",
+              "format": "uuid",
+              "description": "UUID path identifier from underlying resource tables."
+            },
+            "required": true,
+            "description": "UUID path identifier from underlying resource tables.",
+            "name": "id",
+            "in": "path"
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/WorkV1TicketAgentBody"
+              }
+            }
+          }
+        },
+        "responses": {
+          "201": {
+            "description": "Agent added; updated agent list returned.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/WorkV1ApiSuccess"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Validation or request parsing failure.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/WorkV1ApiError"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "API key missing/invalid.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/WorkV1ApiError"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "RBAC denied for ticket resource action.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/WorkV1ApiError"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Ticket or sub-resource not found.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/WorkV1ApiError"
+                }
+              }
+            }
+          },
+          "409": {
+            "description": "User is already an additional agent on this ticket.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/WorkV1ApiError"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Unexpected controller/service failure.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/WorkV1ApiError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/tickets/{id}/agents/{userId}": {
+      "delete": {
+        "summary": "Remove a ticket additional agent",
+        "description": "Removes the additional-agent assignment for the given user. The primary agent is changed through PUT /api/v1/tickets/{id}/assignment instead.",
+        "tags": [
+          "Work Management v1"
+        ],
+        "security": [
+          {
+            "ApiKeyAuth": []
+          }
+        ],
+        "extensions": {
+          "x-tenant-scoped": true,
+          "x-rbac-resource": "ticket",
+          "x-rbac-action": "update"
+        },
+        "x-alga-products": [
+          "psa",
+          "algadesk"
+        ],
+        "parameters": [
+          {
+            "schema": {
+              "type": "string",
+              "format": "uuid",
+              "description": "Ticket UUID."
+            },
+            "required": true,
+            "description": "Ticket UUID.",
+            "name": "id",
+            "in": "path"
+          },
+          {
+            "schema": {
+              "type": "string",
+              "format": "uuid",
+              "description": "User UUID of the additional agent."
+            },
+            "required": true,
+            "description": "User UUID of the additional agent.",
+            "name": "userId",
+            "in": "path"
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "Additional agent removed."
+          },
+          "400": {
+            "description": "Validation or request parsing failure.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/WorkV1ApiError"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "API key missing/invalid.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/WorkV1ApiError"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "RBAC denied for ticket resource action.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/WorkV1ApiError"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Ticket or additional agent not found.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/WorkV1ApiError"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Unexpected controller/service failure.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/WorkV1ApiError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/tickets/{id}/team": {
+      "put": {
+        "summary": "Assign a team to a ticket",
+        "description": "Sets assigned_team_id, resolves the primary agent (the existing assignee, else the team lead) and records the team's active members as team_member additional agents. Returns the updated ticket. A team without a lead is rejected with 400.",
+        "tags": [
+          "Work Management v1"
+        ],
+        "security": [
+          {
+            "ApiKeyAuth": []
+          }
+        ],
+        "extensions": {
+          "x-tenant-scoped": true,
+          "x-rbac-resource": "ticket",
+          "x-rbac-action": "update"
+        },
+        "x-alga-products": [
+          "psa",
+          "algadesk"
+        ],
+        "parameters": [
+          {
+            "schema": {
+              "type": "string",
+              "format": "uuid",
+              "description": "UUID path identifier from underlying resource tables."
+            },
+            "required": true,
+            "description": "UUID path identifier from underlying resource tables.",
+            "name": "id",
+            "in": "path"
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/WorkV1TicketTeamAssignBody"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Team assigned; updated ticket returned.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/WorkV1ApiSuccess"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Validation or request parsing failure.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/WorkV1ApiError"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "API key missing/invalid.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/WorkV1ApiError"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "RBAC denied for ticket resource action.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/WorkV1ApiError"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Ticket or sub-resource not found.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/WorkV1ApiError"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Unexpected controller/service failure.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/WorkV1ApiError"
+                }
+              }
+            }
+          }
+        }
+      },
+      "delete": {
+        "summary": "Remove a ticket team assignment",
+        "description": "Clears assigned_team_id. mode=remove_all (default) drops the team_member additional agents, keep_all leaves them, and selective keeps only keep_user_ids. Returns the updated ticket.",
+        "tags": [
+          "Work Management v1"
+        ],
+        "security": [
+          {
+            "ApiKeyAuth": []
+          }
+        ],
+        "extensions": {
+          "x-tenant-scoped": true,
+          "x-rbac-resource": "ticket",
+          "x-rbac-action": "update"
+        },
+        "x-alga-products": [
+          "psa",
+          "algadesk"
+        ],
+        "parameters": [
+          {
+            "schema": {
+              "type": "string",
+              "format": "uuid",
+              "description": "UUID path identifier from underlying resource tables."
+            },
+            "required": true,
+            "description": "UUID path identifier from underlying resource tables.",
+            "name": "id",
+            "in": "path"
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/WorkV1TicketTeamRemoveBody"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Team assignment removed; updated ticket returned.",
             "content": {
               "application/json": {
                 "schema": {

--- a/sdk/docs/openapi/alga-openapi.ce.yaml
+++ b/sdk/docs/openapi/alga-openapi.ce.yaml
@@ -15135,6 +15135,64 @@ components:
         - quantity
         - rate
         - currency_code
+    WorkV1TicketAgentParams:
+      type: object
+      properties:
+        id:
+          type: string
+          format: uuid
+          description: Ticket UUID.
+        userId:
+          type: string
+          format: uuid
+          description: User UUID of the additional agent.
+      required:
+        - id
+        - userId
+    WorkV1TicketAgentBody:
+      type: object
+      properties:
+        user_id:
+          type: string
+          format: uuid
+          description: User to add as an additional agent.
+        role:
+          type: string
+          maxLength: 50
+          description: Resource role recorded on the assignment; defaults to support.
+      required:
+        - user_id
+    WorkV1TicketTeamAssignBody:
+      type: object
+      properties:
+        team_id:
+          type: string
+          format: uuid
+          description: Team to assign to the ticket.
+        suppressContactNotifications:
+          type: boolean
+        suppressInternalNotifications:
+          type: boolean
+      required:
+        - team_id
+    WorkV1TicketTeamRemoveBody:
+      type: object
+      properties:
+        mode:
+          type: string
+          enum:
+            - remove_all
+            - keep_all
+            - selective
+          description: What to do with the team_member additional agents; defaults to
+            remove_all.
+        keep_user_ids:
+          type: array
+          items:
+            type: string
+            format: uuid
+          description: "Required with mode=selective: the team members to keep as
+            additional agents."
     QuoteIdParamV1:
       type: object
       properties:
@@ -63866,6 +63924,349 @@ paths:
       responses:
         "200":
           description: Document removed.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/WorkV1ApiSuccess"
+        "400":
+          description: Validation or request parsing failure.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/WorkV1ApiError"
+        "401":
+          description: API key missing/invalid.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/WorkV1ApiError"
+        "403":
+          description: RBAC denied for ticket resource action.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/WorkV1ApiError"
+        "404":
+          description: Ticket or sub-resource not found.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/WorkV1ApiError"
+        "500":
+          description: Unexpected controller/service failure.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/WorkV1ApiError"
+  /api/v1/tickets/{id}/agents:
+    get:
+      summary: List ticket agents
+      description: Returns the ticket primary agent (tickets.assigned_to) and its
+        additional agents (ticket_resources), each with user_id, name and email.
+      tags:
+        - Work Management v1
+      security:
+        - ApiKeyAuth: []
+      extensions:
+        x-tenant-scoped: true
+        x-rbac-resource: ticket
+        x-rbac-action: read
+      x-alga-products:
+        - psa
+        - algadesk
+      parameters:
+        - schema:
+            type: string
+            format: uuid
+            description: UUID path identifier from underlying resource tables.
+          required: true
+          description: UUID path identifier from underlying resource tables.
+          name: id
+          in: path
+      responses:
+        "200":
+          description: Ticket primary and additional agents.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/WorkV1ApiSuccess"
+        "400":
+          description: Validation or request parsing failure.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/WorkV1ApiError"
+        "401":
+          description: API key missing/invalid.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/WorkV1ApiError"
+        "403":
+          description: RBAC denied for ticket resource action.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/WorkV1ApiError"
+        "404":
+          description: Ticket or sub-resource not found.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/WorkV1ApiError"
+        "500":
+          description: Unexpected controller/service failure.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/WorkV1ApiError"
+    post:
+      summary: Add a ticket additional agent
+      description: Adds a user as an additional agent on the ticket and publishes
+        TICKET_ADDITIONAL_AGENT_ASSIGNED so notifications fire as they do in the
+        UI. A ticket with no primary agent promotes the user to primary instead
+        (TICKET_ASSIGNED). Returns the updated agent list; a duplicate returns
+        409.
+      tags:
+        - Work Management v1
+      security:
+        - ApiKeyAuth: []
+      extensions:
+        x-tenant-scoped: true
+        x-rbac-resource: ticket
+        x-rbac-action: update
+      x-alga-products:
+        - psa
+        - algadesk
+      parameters:
+        - schema:
+            type: string
+            format: uuid
+            description: UUID path identifier from underlying resource tables.
+          required: true
+          description: UUID path identifier from underlying resource tables.
+          name: id
+          in: path
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/WorkV1TicketAgentBody"
+      responses:
+        "201":
+          description: Agent added; updated agent list returned.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/WorkV1ApiSuccess"
+        "400":
+          description: Validation or request parsing failure.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/WorkV1ApiError"
+        "401":
+          description: API key missing/invalid.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/WorkV1ApiError"
+        "403":
+          description: RBAC denied for ticket resource action.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/WorkV1ApiError"
+        "404":
+          description: Ticket or sub-resource not found.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/WorkV1ApiError"
+        "409":
+          description: User is already an additional agent on this ticket.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/WorkV1ApiError"
+        "500":
+          description: Unexpected controller/service failure.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/WorkV1ApiError"
+  /api/v1/tickets/{id}/agents/{userId}:
+    delete:
+      summary: Remove a ticket additional agent
+      description: Removes the additional-agent assignment for the given user. The
+        primary agent is changed through PUT /api/v1/tickets/{id}/assignment
+        instead.
+      tags:
+        - Work Management v1
+      security:
+        - ApiKeyAuth: []
+      extensions:
+        x-tenant-scoped: true
+        x-rbac-resource: ticket
+        x-rbac-action: update
+      x-alga-products:
+        - psa
+        - algadesk
+      parameters:
+        - schema:
+            type: string
+            format: uuid
+            description: Ticket UUID.
+          required: true
+          description: Ticket UUID.
+          name: id
+          in: path
+        - schema:
+            type: string
+            format: uuid
+            description: User UUID of the additional agent.
+          required: true
+          description: User UUID of the additional agent.
+          name: userId
+          in: path
+      responses:
+        "204":
+          description: Additional agent removed.
+        "400":
+          description: Validation or request parsing failure.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/WorkV1ApiError"
+        "401":
+          description: API key missing/invalid.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/WorkV1ApiError"
+        "403":
+          description: RBAC denied for ticket resource action.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/WorkV1ApiError"
+        "404":
+          description: Ticket or additional agent not found.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/WorkV1ApiError"
+        "500":
+          description: Unexpected controller/service failure.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/WorkV1ApiError"
+  /api/v1/tickets/{id}/team:
+    put:
+      summary: Assign a team to a ticket
+      description: Sets assigned_team_id, resolves the primary agent (the existing
+        assignee, else the team lead) and records the team's active members as
+        team_member additional agents. Returns the updated ticket. A team
+        without a lead is rejected with 400.
+      tags:
+        - Work Management v1
+      security:
+        - ApiKeyAuth: []
+      extensions:
+        x-tenant-scoped: true
+        x-rbac-resource: ticket
+        x-rbac-action: update
+      x-alga-products:
+        - psa
+        - algadesk
+      parameters:
+        - schema:
+            type: string
+            format: uuid
+            description: UUID path identifier from underlying resource tables.
+          required: true
+          description: UUID path identifier from underlying resource tables.
+          name: id
+          in: path
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/WorkV1TicketTeamAssignBody"
+      responses:
+        "200":
+          description: Team assigned; updated ticket returned.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/WorkV1ApiSuccess"
+        "400":
+          description: Validation or request parsing failure.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/WorkV1ApiError"
+        "401":
+          description: API key missing/invalid.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/WorkV1ApiError"
+        "403":
+          description: RBAC denied for ticket resource action.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/WorkV1ApiError"
+        "404":
+          description: Ticket or sub-resource not found.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/WorkV1ApiError"
+        "500":
+          description: Unexpected controller/service failure.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/WorkV1ApiError"
+    delete:
+      summary: Remove a ticket team assignment
+      description: Clears assigned_team_id. mode=remove_all (default) drops the
+        team_member additional agents, keep_all leaves them, and selective keeps
+        only keep_user_ids. Returns the updated ticket.
+      tags:
+        - Work Management v1
+      security:
+        - ApiKeyAuth: []
+      extensions:
+        x-tenant-scoped: true
+        x-rbac-resource: ticket
+        x-rbac-action: update
+      x-alga-products:
+        - psa
+        - algadesk
+      parameters:
+        - schema:
+            type: string
+            format: uuid
+            description: UUID path identifier from underlying resource tables.
+          required: true
+          description: UUID path identifier from underlying resource tables.
+          name: id
+          in: path
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/WorkV1TicketTeamRemoveBody"
+      responses:
+        "200":
+          description: Team assignment removed; updated ticket returned.
           content:
             application/json:
               schema:

--- a/sdk/docs/openapi/alga-openapi.ee.json
+++ b/sdk/docs/openapi/alga-openapi.ee.json
@@ -21332,6 +21332,84 @@
           "currency_code"
         ]
       },
+      "WorkV1TicketAgentParams": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string",
+            "format": "uuid",
+            "description": "Ticket UUID."
+          },
+          "userId": {
+            "type": "string",
+            "format": "uuid",
+            "description": "User UUID of the additional agent."
+          }
+        },
+        "required": [
+          "id",
+          "userId"
+        ]
+      },
+      "WorkV1TicketAgentBody": {
+        "type": "object",
+        "properties": {
+          "user_id": {
+            "type": "string",
+            "format": "uuid",
+            "description": "User to add as an additional agent."
+          },
+          "role": {
+            "type": "string",
+            "maxLength": 50,
+            "description": "Resource role recorded on the assignment; defaults to support."
+          }
+        },
+        "required": [
+          "user_id"
+        ]
+      },
+      "WorkV1TicketTeamAssignBody": {
+        "type": "object",
+        "properties": {
+          "team_id": {
+            "type": "string",
+            "format": "uuid",
+            "description": "Team to assign to the ticket."
+          },
+          "suppressContactNotifications": {
+            "type": "boolean"
+          },
+          "suppressInternalNotifications": {
+            "type": "boolean"
+          }
+        },
+        "required": [
+          "team_id"
+        ]
+      },
+      "WorkV1TicketTeamRemoveBody": {
+        "type": "object",
+        "properties": {
+          "mode": {
+            "type": "string",
+            "enum": [
+              "remove_all",
+              "keep_all",
+              "selective"
+            ],
+            "description": "What to do with the team_member additional agents; defaults to remove_all."
+          },
+          "keep_user_ids": {
+            "type": "array",
+            "items": {
+              "type": "string",
+              "format": "uuid"
+            },
+            "description": "Required with mode=selective: the team members to keep as additional agents."
+          }
+        }
+      },
       "QuoteIdParamV1": {
         "type": "object",
         "properties": {
@@ -95533,6 +95611,536 @@
         "responses": {
           "200": {
             "description": "Document removed.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/WorkV1ApiSuccess"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Validation or request parsing failure.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/WorkV1ApiError"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "API key missing/invalid.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/WorkV1ApiError"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "RBAC denied for ticket resource action.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/WorkV1ApiError"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Ticket or sub-resource not found.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/WorkV1ApiError"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Unexpected controller/service failure.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/WorkV1ApiError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/tickets/{id}/agents": {
+      "get": {
+        "summary": "List ticket agents",
+        "description": "Returns the ticket primary agent (tickets.assigned_to) and its additional agents (ticket_resources), each with user_id, name and email.",
+        "tags": [
+          "Work Management v1"
+        ],
+        "security": [
+          {
+            "ApiKeyAuth": []
+          }
+        ],
+        "extensions": {
+          "x-tenant-scoped": true,
+          "x-rbac-resource": "ticket",
+          "x-rbac-action": "read"
+        },
+        "x-alga-products": [
+          "psa",
+          "algadesk"
+        ],
+        "parameters": [
+          {
+            "schema": {
+              "type": "string",
+              "format": "uuid",
+              "description": "UUID path identifier from underlying resource tables."
+            },
+            "required": true,
+            "description": "UUID path identifier from underlying resource tables.",
+            "name": "id",
+            "in": "path"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Ticket primary and additional agents.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/WorkV1ApiSuccess"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Validation or request parsing failure.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/WorkV1ApiError"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "API key missing/invalid.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/WorkV1ApiError"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "RBAC denied for ticket resource action.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/WorkV1ApiError"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Ticket or sub-resource not found.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/WorkV1ApiError"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Unexpected controller/service failure.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/WorkV1ApiError"
+                }
+              }
+            }
+          }
+        }
+      },
+      "post": {
+        "summary": "Add a ticket additional agent",
+        "description": "Adds a user as an additional agent on the ticket and publishes TICKET_ADDITIONAL_AGENT_ASSIGNED so notifications fire as they do in the UI. A ticket with no primary agent promotes the user to primary instead (TICKET_ASSIGNED). Returns the updated agent list; a duplicate returns 409.",
+        "tags": [
+          "Work Management v1"
+        ],
+        "security": [
+          {
+            "ApiKeyAuth": []
+          }
+        ],
+        "extensions": {
+          "x-tenant-scoped": true,
+          "x-rbac-resource": "ticket",
+          "x-rbac-action": "update"
+        },
+        "x-alga-products": [
+          "psa",
+          "algadesk"
+        ],
+        "parameters": [
+          {
+            "schema": {
+              "type": "string",
+              "format": "uuid",
+              "description": "UUID path identifier from underlying resource tables."
+            },
+            "required": true,
+            "description": "UUID path identifier from underlying resource tables.",
+            "name": "id",
+            "in": "path"
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/WorkV1TicketAgentBody"
+              }
+            }
+          }
+        },
+        "responses": {
+          "201": {
+            "description": "Agent added; updated agent list returned.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/WorkV1ApiSuccess"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Validation or request parsing failure.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/WorkV1ApiError"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "API key missing/invalid.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/WorkV1ApiError"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "RBAC denied for ticket resource action.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/WorkV1ApiError"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Ticket or sub-resource not found.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/WorkV1ApiError"
+                }
+              }
+            }
+          },
+          "409": {
+            "description": "User is already an additional agent on this ticket.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/WorkV1ApiError"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Unexpected controller/service failure.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/WorkV1ApiError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/tickets/{id}/agents/{userId}": {
+      "delete": {
+        "summary": "Remove a ticket additional agent",
+        "description": "Removes the additional-agent assignment for the given user. The primary agent is changed through PUT /api/v1/tickets/{id}/assignment instead.",
+        "tags": [
+          "Work Management v1"
+        ],
+        "security": [
+          {
+            "ApiKeyAuth": []
+          }
+        ],
+        "extensions": {
+          "x-tenant-scoped": true,
+          "x-rbac-resource": "ticket",
+          "x-rbac-action": "update"
+        },
+        "x-alga-products": [
+          "psa",
+          "algadesk"
+        ],
+        "parameters": [
+          {
+            "schema": {
+              "type": "string",
+              "format": "uuid",
+              "description": "Ticket UUID."
+            },
+            "required": true,
+            "description": "Ticket UUID.",
+            "name": "id",
+            "in": "path"
+          },
+          {
+            "schema": {
+              "type": "string",
+              "format": "uuid",
+              "description": "User UUID of the additional agent."
+            },
+            "required": true,
+            "description": "User UUID of the additional agent.",
+            "name": "userId",
+            "in": "path"
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "Additional agent removed."
+          },
+          "400": {
+            "description": "Validation or request parsing failure.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/WorkV1ApiError"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "API key missing/invalid.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/WorkV1ApiError"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "RBAC denied for ticket resource action.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/WorkV1ApiError"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Ticket or additional agent not found.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/WorkV1ApiError"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Unexpected controller/service failure.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/WorkV1ApiError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/tickets/{id}/team": {
+      "put": {
+        "summary": "Assign a team to a ticket",
+        "description": "Sets assigned_team_id, resolves the primary agent (the existing assignee, else the team lead) and records the team's active members as team_member additional agents. Returns the updated ticket. A team without a lead is rejected with 400.",
+        "tags": [
+          "Work Management v1"
+        ],
+        "security": [
+          {
+            "ApiKeyAuth": []
+          }
+        ],
+        "extensions": {
+          "x-tenant-scoped": true,
+          "x-rbac-resource": "ticket",
+          "x-rbac-action": "update"
+        },
+        "x-alga-products": [
+          "psa",
+          "algadesk"
+        ],
+        "parameters": [
+          {
+            "schema": {
+              "type": "string",
+              "format": "uuid",
+              "description": "UUID path identifier from underlying resource tables."
+            },
+            "required": true,
+            "description": "UUID path identifier from underlying resource tables.",
+            "name": "id",
+            "in": "path"
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/WorkV1TicketTeamAssignBody"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Team assigned; updated ticket returned.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/WorkV1ApiSuccess"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Validation or request parsing failure.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/WorkV1ApiError"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "API key missing/invalid.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/WorkV1ApiError"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "RBAC denied for ticket resource action.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/WorkV1ApiError"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Ticket or sub-resource not found.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/WorkV1ApiError"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Unexpected controller/service failure.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/WorkV1ApiError"
+                }
+              }
+            }
+          }
+        }
+      },
+      "delete": {
+        "summary": "Remove a ticket team assignment",
+        "description": "Clears assigned_team_id. mode=remove_all (default) drops the team_member additional agents, keep_all leaves them, and selective keeps only keep_user_ids. Returns the updated ticket.",
+        "tags": [
+          "Work Management v1"
+        ],
+        "security": [
+          {
+            "ApiKeyAuth": []
+          }
+        ],
+        "extensions": {
+          "x-tenant-scoped": true,
+          "x-rbac-resource": "ticket",
+          "x-rbac-action": "update"
+        },
+        "x-alga-products": [
+          "psa",
+          "algadesk"
+        ],
+        "parameters": [
+          {
+            "schema": {
+              "type": "string",
+              "format": "uuid",
+              "description": "UUID path identifier from underlying resource tables."
+            },
+            "required": true,
+            "description": "UUID path identifier from underlying resource tables.",
+            "name": "id",
+            "in": "path"
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/WorkV1TicketTeamRemoveBody"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Team assignment removed; updated ticket returned.",
             "content": {
               "application/json": {
                 "schema": {

--- a/sdk/docs/openapi/alga-openapi.ee.yaml
+++ b/sdk/docs/openapi/alga-openapi.ee.yaml
@@ -15136,6 +15136,64 @@ components:
         - quantity
         - rate
         - currency_code
+    WorkV1TicketAgentParams:
+      type: object
+      properties:
+        id:
+          type: string
+          format: uuid
+          description: Ticket UUID.
+        userId:
+          type: string
+          format: uuid
+          description: User UUID of the additional agent.
+      required:
+        - id
+        - userId
+    WorkV1TicketAgentBody:
+      type: object
+      properties:
+        user_id:
+          type: string
+          format: uuid
+          description: User to add as an additional agent.
+        role:
+          type: string
+          maxLength: 50
+          description: Resource role recorded on the assignment; defaults to support.
+      required:
+        - user_id
+    WorkV1TicketTeamAssignBody:
+      type: object
+      properties:
+        team_id:
+          type: string
+          format: uuid
+          description: Team to assign to the ticket.
+        suppressContactNotifications:
+          type: boolean
+        suppressInternalNotifications:
+          type: boolean
+      required:
+        - team_id
+    WorkV1TicketTeamRemoveBody:
+      type: object
+      properties:
+        mode:
+          type: string
+          enum:
+            - remove_all
+            - keep_all
+            - selective
+          description: What to do with the team_member additional agents; defaults to
+            remove_all.
+        keep_user_ids:
+          type: array
+          items:
+            type: string
+            format: uuid
+          description: "Required with mode=selective: the team members to keep as
+            additional agents."
     QuoteIdParamV1:
       type: object
       properties:
@@ -63867,6 +63925,349 @@ paths:
       responses:
         "200":
           description: Document removed.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/WorkV1ApiSuccess"
+        "400":
+          description: Validation or request parsing failure.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/WorkV1ApiError"
+        "401":
+          description: API key missing/invalid.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/WorkV1ApiError"
+        "403":
+          description: RBAC denied for ticket resource action.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/WorkV1ApiError"
+        "404":
+          description: Ticket or sub-resource not found.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/WorkV1ApiError"
+        "500":
+          description: Unexpected controller/service failure.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/WorkV1ApiError"
+  /api/v1/tickets/{id}/agents:
+    get:
+      summary: List ticket agents
+      description: Returns the ticket primary agent (tickets.assigned_to) and its
+        additional agents (ticket_resources), each with user_id, name and email.
+      tags:
+        - Work Management v1
+      security:
+        - ApiKeyAuth: []
+      extensions:
+        x-tenant-scoped: true
+        x-rbac-resource: ticket
+        x-rbac-action: read
+      x-alga-products:
+        - psa
+        - algadesk
+      parameters:
+        - schema:
+            type: string
+            format: uuid
+            description: UUID path identifier from underlying resource tables.
+          required: true
+          description: UUID path identifier from underlying resource tables.
+          name: id
+          in: path
+      responses:
+        "200":
+          description: Ticket primary and additional agents.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/WorkV1ApiSuccess"
+        "400":
+          description: Validation or request parsing failure.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/WorkV1ApiError"
+        "401":
+          description: API key missing/invalid.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/WorkV1ApiError"
+        "403":
+          description: RBAC denied for ticket resource action.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/WorkV1ApiError"
+        "404":
+          description: Ticket or sub-resource not found.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/WorkV1ApiError"
+        "500":
+          description: Unexpected controller/service failure.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/WorkV1ApiError"
+    post:
+      summary: Add a ticket additional agent
+      description: Adds a user as an additional agent on the ticket and publishes
+        TICKET_ADDITIONAL_AGENT_ASSIGNED so notifications fire as they do in the
+        UI. A ticket with no primary agent promotes the user to primary instead
+        (TICKET_ASSIGNED). Returns the updated agent list; a duplicate returns
+        409.
+      tags:
+        - Work Management v1
+      security:
+        - ApiKeyAuth: []
+      extensions:
+        x-tenant-scoped: true
+        x-rbac-resource: ticket
+        x-rbac-action: update
+      x-alga-products:
+        - psa
+        - algadesk
+      parameters:
+        - schema:
+            type: string
+            format: uuid
+            description: UUID path identifier from underlying resource tables.
+          required: true
+          description: UUID path identifier from underlying resource tables.
+          name: id
+          in: path
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/WorkV1TicketAgentBody"
+      responses:
+        "201":
+          description: Agent added; updated agent list returned.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/WorkV1ApiSuccess"
+        "400":
+          description: Validation or request parsing failure.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/WorkV1ApiError"
+        "401":
+          description: API key missing/invalid.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/WorkV1ApiError"
+        "403":
+          description: RBAC denied for ticket resource action.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/WorkV1ApiError"
+        "404":
+          description: Ticket or sub-resource not found.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/WorkV1ApiError"
+        "409":
+          description: User is already an additional agent on this ticket.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/WorkV1ApiError"
+        "500":
+          description: Unexpected controller/service failure.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/WorkV1ApiError"
+  /api/v1/tickets/{id}/agents/{userId}:
+    delete:
+      summary: Remove a ticket additional agent
+      description: Removes the additional-agent assignment for the given user. The
+        primary agent is changed through PUT /api/v1/tickets/{id}/assignment
+        instead.
+      tags:
+        - Work Management v1
+      security:
+        - ApiKeyAuth: []
+      extensions:
+        x-tenant-scoped: true
+        x-rbac-resource: ticket
+        x-rbac-action: update
+      x-alga-products:
+        - psa
+        - algadesk
+      parameters:
+        - schema:
+            type: string
+            format: uuid
+            description: Ticket UUID.
+          required: true
+          description: Ticket UUID.
+          name: id
+          in: path
+        - schema:
+            type: string
+            format: uuid
+            description: User UUID of the additional agent.
+          required: true
+          description: User UUID of the additional agent.
+          name: userId
+          in: path
+      responses:
+        "204":
+          description: Additional agent removed.
+        "400":
+          description: Validation or request parsing failure.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/WorkV1ApiError"
+        "401":
+          description: API key missing/invalid.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/WorkV1ApiError"
+        "403":
+          description: RBAC denied for ticket resource action.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/WorkV1ApiError"
+        "404":
+          description: Ticket or additional agent not found.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/WorkV1ApiError"
+        "500":
+          description: Unexpected controller/service failure.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/WorkV1ApiError"
+  /api/v1/tickets/{id}/team:
+    put:
+      summary: Assign a team to a ticket
+      description: Sets assigned_team_id, resolves the primary agent (the existing
+        assignee, else the team lead) and records the team's active members as
+        team_member additional agents. Returns the updated ticket. A team
+        without a lead is rejected with 400.
+      tags:
+        - Work Management v1
+      security:
+        - ApiKeyAuth: []
+      extensions:
+        x-tenant-scoped: true
+        x-rbac-resource: ticket
+        x-rbac-action: update
+      x-alga-products:
+        - psa
+        - algadesk
+      parameters:
+        - schema:
+            type: string
+            format: uuid
+            description: UUID path identifier from underlying resource tables.
+          required: true
+          description: UUID path identifier from underlying resource tables.
+          name: id
+          in: path
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/WorkV1TicketTeamAssignBody"
+      responses:
+        "200":
+          description: Team assigned; updated ticket returned.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/WorkV1ApiSuccess"
+        "400":
+          description: Validation or request parsing failure.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/WorkV1ApiError"
+        "401":
+          description: API key missing/invalid.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/WorkV1ApiError"
+        "403":
+          description: RBAC denied for ticket resource action.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/WorkV1ApiError"
+        "404":
+          description: Ticket or sub-resource not found.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/WorkV1ApiError"
+        "500":
+          description: Unexpected controller/service failure.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/WorkV1ApiError"
+    delete:
+      summary: Remove a ticket team assignment
+      description: Clears assigned_team_id. mode=remove_all (default) drops the
+        team_member additional agents, keep_all leaves them, and selective keeps
+        only keep_user_ids. Returns the updated ticket.
+      tags:
+        - Work Management v1
+      security:
+        - ApiKeyAuth: []
+      extensions:
+        x-tenant-scoped: true
+        x-rbac-resource: ticket
+        x-rbac-action: update
+      x-alga-products:
+        - psa
+        - algadesk
+      parameters:
+        - schema:
+            type: string
+            format: uuid
+            description: UUID path identifier from underlying resource tables.
+          required: true
+          description: UUID path identifier from underlying resource tables.
+          name: id
+          in: path
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/WorkV1TicketTeamRemoveBody"
+      responses:
+        "200":
+          description: Team assignment removed; updated ticket returned.
           content:
             application/json:
               schema:

--- a/sdk/docs/openapi/alga-openapi.json
+++ b/sdk/docs/openapi/alga-openapi.json
@@ -21329,6 +21329,84 @@
           "currency_code"
         ]
       },
+      "WorkV1TicketAgentParams": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string",
+            "format": "uuid",
+            "description": "Ticket UUID."
+          },
+          "userId": {
+            "type": "string",
+            "format": "uuid",
+            "description": "User UUID of the additional agent."
+          }
+        },
+        "required": [
+          "id",
+          "userId"
+        ]
+      },
+      "WorkV1TicketAgentBody": {
+        "type": "object",
+        "properties": {
+          "user_id": {
+            "type": "string",
+            "format": "uuid",
+            "description": "User to add as an additional agent."
+          },
+          "role": {
+            "type": "string",
+            "maxLength": 50,
+            "description": "Resource role recorded on the assignment; defaults to support."
+          }
+        },
+        "required": [
+          "user_id"
+        ]
+      },
+      "WorkV1TicketTeamAssignBody": {
+        "type": "object",
+        "properties": {
+          "team_id": {
+            "type": "string",
+            "format": "uuid",
+            "description": "Team to assign to the ticket."
+          },
+          "suppressContactNotifications": {
+            "type": "boolean"
+          },
+          "suppressInternalNotifications": {
+            "type": "boolean"
+          }
+        },
+        "required": [
+          "team_id"
+        ]
+      },
+      "WorkV1TicketTeamRemoveBody": {
+        "type": "object",
+        "properties": {
+          "mode": {
+            "type": "string",
+            "enum": [
+              "remove_all",
+              "keep_all",
+              "selective"
+            ],
+            "description": "What to do with the team_member additional agents; defaults to remove_all."
+          },
+          "keep_user_ids": {
+            "type": "array",
+            "items": {
+              "type": "string",
+              "format": "uuid"
+            },
+            "description": "Required with mode=selective: the team members to keep as additional agents."
+          }
+        }
+      },
       "QuoteIdParamV1": {
         "type": "object",
         "properties": {
@@ -95530,6 +95608,536 @@
         "responses": {
           "200": {
             "description": "Document removed.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/WorkV1ApiSuccess"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Validation or request parsing failure.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/WorkV1ApiError"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "API key missing/invalid.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/WorkV1ApiError"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "RBAC denied for ticket resource action.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/WorkV1ApiError"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Ticket or sub-resource not found.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/WorkV1ApiError"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Unexpected controller/service failure.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/WorkV1ApiError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/tickets/{id}/agents": {
+      "get": {
+        "summary": "List ticket agents",
+        "description": "Returns the ticket primary agent (tickets.assigned_to) and its additional agents (ticket_resources), each with user_id, name and email.",
+        "tags": [
+          "Work Management v1"
+        ],
+        "security": [
+          {
+            "ApiKeyAuth": []
+          }
+        ],
+        "extensions": {
+          "x-tenant-scoped": true,
+          "x-rbac-resource": "ticket",
+          "x-rbac-action": "read"
+        },
+        "x-alga-products": [
+          "psa",
+          "algadesk"
+        ],
+        "parameters": [
+          {
+            "schema": {
+              "type": "string",
+              "format": "uuid",
+              "description": "UUID path identifier from underlying resource tables."
+            },
+            "required": true,
+            "description": "UUID path identifier from underlying resource tables.",
+            "name": "id",
+            "in": "path"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Ticket primary and additional agents.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/WorkV1ApiSuccess"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Validation or request parsing failure.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/WorkV1ApiError"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "API key missing/invalid.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/WorkV1ApiError"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "RBAC denied for ticket resource action.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/WorkV1ApiError"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Ticket or sub-resource not found.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/WorkV1ApiError"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Unexpected controller/service failure.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/WorkV1ApiError"
+                }
+              }
+            }
+          }
+        }
+      },
+      "post": {
+        "summary": "Add a ticket additional agent",
+        "description": "Adds a user as an additional agent on the ticket and publishes TICKET_ADDITIONAL_AGENT_ASSIGNED so notifications fire as they do in the UI. A ticket with no primary agent promotes the user to primary instead (TICKET_ASSIGNED). Returns the updated agent list; a duplicate returns 409.",
+        "tags": [
+          "Work Management v1"
+        ],
+        "security": [
+          {
+            "ApiKeyAuth": []
+          }
+        ],
+        "extensions": {
+          "x-tenant-scoped": true,
+          "x-rbac-resource": "ticket",
+          "x-rbac-action": "update"
+        },
+        "x-alga-products": [
+          "psa",
+          "algadesk"
+        ],
+        "parameters": [
+          {
+            "schema": {
+              "type": "string",
+              "format": "uuid",
+              "description": "UUID path identifier from underlying resource tables."
+            },
+            "required": true,
+            "description": "UUID path identifier from underlying resource tables.",
+            "name": "id",
+            "in": "path"
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/WorkV1TicketAgentBody"
+              }
+            }
+          }
+        },
+        "responses": {
+          "201": {
+            "description": "Agent added; updated agent list returned.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/WorkV1ApiSuccess"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Validation or request parsing failure.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/WorkV1ApiError"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "API key missing/invalid.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/WorkV1ApiError"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "RBAC denied for ticket resource action.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/WorkV1ApiError"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Ticket or sub-resource not found.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/WorkV1ApiError"
+                }
+              }
+            }
+          },
+          "409": {
+            "description": "User is already an additional agent on this ticket.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/WorkV1ApiError"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Unexpected controller/service failure.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/WorkV1ApiError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/tickets/{id}/agents/{userId}": {
+      "delete": {
+        "summary": "Remove a ticket additional agent",
+        "description": "Removes the additional-agent assignment for the given user. The primary agent is changed through PUT /api/v1/tickets/{id}/assignment instead.",
+        "tags": [
+          "Work Management v1"
+        ],
+        "security": [
+          {
+            "ApiKeyAuth": []
+          }
+        ],
+        "extensions": {
+          "x-tenant-scoped": true,
+          "x-rbac-resource": "ticket",
+          "x-rbac-action": "update"
+        },
+        "x-alga-products": [
+          "psa",
+          "algadesk"
+        ],
+        "parameters": [
+          {
+            "schema": {
+              "type": "string",
+              "format": "uuid",
+              "description": "Ticket UUID."
+            },
+            "required": true,
+            "description": "Ticket UUID.",
+            "name": "id",
+            "in": "path"
+          },
+          {
+            "schema": {
+              "type": "string",
+              "format": "uuid",
+              "description": "User UUID of the additional agent."
+            },
+            "required": true,
+            "description": "User UUID of the additional agent.",
+            "name": "userId",
+            "in": "path"
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "Additional agent removed."
+          },
+          "400": {
+            "description": "Validation or request parsing failure.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/WorkV1ApiError"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "API key missing/invalid.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/WorkV1ApiError"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "RBAC denied for ticket resource action.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/WorkV1ApiError"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Ticket or additional agent not found.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/WorkV1ApiError"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Unexpected controller/service failure.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/WorkV1ApiError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/tickets/{id}/team": {
+      "put": {
+        "summary": "Assign a team to a ticket",
+        "description": "Sets assigned_team_id, resolves the primary agent (the existing assignee, else the team lead) and records the team's active members as team_member additional agents. Returns the updated ticket. A team without a lead is rejected with 400.",
+        "tags": [
+          "Work Management v1"
+        ],
+        "security": [
+          {
+            "ApiKeyAuth": []
+          }
+        ],
+        "extensions": {
+          "x-tenant-scoped": true,
+          "x-rbac-resource": "ticket",
+          "x-rbac-action": "update"
+        },
+        "x-alga-products": [
+          "psa",
+          "algadesk"
+        ],
+        "parameters": [
+          {
+            "schema": {
+              "type": "string",
+              "format": "uuid",
+              "description": "UUID path identifier from underlying resource tables."
+            },
+            "required": true,
+            "description": "UUID path identifier from underlying resource tables.",
+            "name": "id",
+            "in": "path"
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/WorkV1TicketTeamAssignBody"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Team assigned; updated ticket returned.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/WorkV1ApiSuccess"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Validation or request parsing failure.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/WorkV1ApiError"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "API key missing/invalid.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/WorkV1ApiError"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "RBAC denied for ticket resource action.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/WorkV1ApiError"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Ticket or sub-resource not found.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/WorkV1ApiError"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Unexpected controller/service failure.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/WorkV1ApiError"
+                }
+              }
+            }
+          }
+        }
+      },
+      "delete": {
+        "summary": "Remove a ticket team assignment",
+        "description": "Clears assigned_team_id. mode=remove_all (default) drops the team_member additional agents, keep_all leaves them, and selective keeps only keep_user_ids. Returns the updated ticket.",
+        "tags": [
+          "Work Management v1"
+        ],
+        "security": [
+          {
+            "ApiKeyAuth": []
+          }
+        ],
+        "extensions": {
+          "x-tenant-scoped": true,
+          "x-rbac-resource": "ticket",
+          "x-rbac-action": "update"
+        },
+        "x-alga-products": [
+          "psa",
+          "algadesk"
+        ],
+        "parameters": [
+          {
+            "schema": {
+              "type": "string",
+              "format": "uuid",
+              "description": "UUID path identifier from underlying resource tables."
+            },
+            "required": true,
+            "description": "UUID path identifier from underlying resource tables.",
+            "name": "id",
+            "in": "path"
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/WorkV1TicketTeamRemoveBody"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Team assignment removed; updated ticket returned.",
             "content": {
               "application/json": {
                 "schema": {

--- a/sdk/docs/openapi/alga-openapi.yaml
+++ b/sdk/docs/openapi/alga-openapi.yaml
@@ -15135,6 +15135,64 @@ components:
         - quantity
         - rate
         - currency_code
+    WorkV1TicketAgentParams:
+      type: object
+      properties:
+        id:
+          type: string
+          format: uuid
+          description: Ticket UUID.
+        userId:
+          type: string
+          format: uuid
+          description: User UUID of the additional agent.
+      required:
+        - id
+        - userId
+    WorkV1TicketAgentBody:
+      type: object
+      properties:
+        user_id:
+          type: string
+          format: uuid
+          description: User to add as an additional agent.
+        role:
+          type: string
+          maxLength: 50
+          description: Resource role recorded on the assignment; defaults to support.
+      required:
+        - user_id
+    WorkV1TicketTeamAssignBody:
+      type: object
+      properties:
+        team_id:
+          type: string
+          format: uuid
+          description: Team to assign to the ticket.
+        suppressContactNotifications:
+          type: boolean
+        suppressInternalNotifications:
+          type: boolean
+      required:
+        - team_id
+    WorkV1TicketTeamRemoveBody:
+      type: object
+      properties:
+        mode:
+          type: string
+          enum:
+            - remove_all
+            - keep_all
+            - selective
+          description: What to do with the team_member additional agents; defaults to
+            remove_all.
+        keep_user_ids:
+          type: array
+          items:
+            type: string
+            format: uuid
+          description: "Required with mode=selective: the team members to keep as
+            additional agents."
     QuoteIdParamV1:
       type: object
       properties:
@@ -63866,6 +63924,349 @@ paths:
       responses:
         "200":
           description: Document removed.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/WorkV1ApiSuccess"
+        "400":
+          description: Validation or request parsing failure.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/WorkV1ApiError"
+        "401":
+          description: API key missing/invalid.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/WorkV1ApiError"
+        "403":
+          description: RBAC denied for ticket resource action.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/WorkV1ApiError"
+        "404":
+          description: Ticket or sub-resource not found.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/WorkV1ApiError"
+        "500":
+          description: Unexpected controller/service failure.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/WorkV1ApiError"
+  /api/v1/tickets/{id}/agents:
+    get:
+      summary: List ticket agents
+      description: Returns the ticket primary agent (tickets.assigned_to) and its
+        additional agents (ticket_resources), each with user_id, name and email.
+      tags:
+        - Work Management v1
+      security:
+        - ApiKeyAuth: []
+      extensions:
+        x-tenant-scoped: true
+        x-rbac-resource: ticket
+        x-rbac-action: read
+      x-alga-products:
+        - psa
+        - algadesk
+      parameters:
+        - schema:
+            type: string
+            format: uuid
+            description: UUID path identifier from underlying resource tables.
+          required: true
+          description: UUID path identifier from underlying resource tables.
+          name: id
+          in: path
+      responses:
+        "200":
+          description: Ticket primary and additional agents.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/WorkV1ApiSuccess"
+        "400":
+          description: Validation or request parsing failure.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/WorkV1ApiError"
+        "401":
+          description: API key missing/invalid.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/WorkV1ApiError"
+        "403":
+          description: RBAC denied for ticket resource action.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/WorkV1ApiError"
+        "404":
+          description: Ticket or sub-resource not found.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/WorkV1ApiError"
+        "500":
+          description: Unexpected controller/service failure.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/WorkV1ApiError"
+    post:
+      summary: Add a ticket additional agent
+      description: Adds a user as an additional agent on the ticket and publishes
+        TICKET_ADDITIONAL_AGENT_ASSIGNED so notifications fire as they do in the
+        UI. A ticket with no primary agent promotes the user to primary instead
+        (TICKET_ASSIGNED). Returns the updated agent list; a duplicate returns
+        409.
+      tags:
+        - Work Management v1
+      security:
+        - ApiKeyAuth: []
+      extensions:
+        x-tenant-scoped: true
+        x-rbac-resource: ticket
+        x-rbac-action: update
+      x-alga-products:
+        - psa
+        - algadesk
+      parameters:
+        - schema:
+            type: string
+            format: uuid
+            description: UUID path identifier from underlying resource tables.
+          required: true
+          description: UUID path identifier from underlying resource tables.
+          name: id
+          in: path
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/WorkV1TicketAgentBody"
+      responses:
+        "201":
+          description: Agent added; updated agent list returned.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/WorkV1ApiSuccess"
+        "400":
+          description: Validation or request parsing failure.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/WorkV1ApiError"
+        "401":
+          description: API key missing/invalid.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/WorkV1ApiError"
+        "403":
+          description: RBAC denied for ticket resource action.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/WorkV1ApiError"
+        "404":
+          description: Ticket or sub-resource not found.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/WorkV1ApiError"
+        "409":
+          description: User is already an additional agent on this ticket.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/WorkV1ApiError"
+        "500":
+          description: Unexpected controller/service failure.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/WorkV1ApiError"
+  /api/v1/tickets/{id}/agents/{userId}:
+    delete:
+      summary: Remove a ticket additional agent
+      description: Removes the additional-agent assignment for the given user. The
+        primary agent is changed through PUT /api/v1/tickets/{id}/assignment
+        instead.
+      tags:
+        - Work Management v1
+      security:
+        - ApiKeyAuth: []
+      extensions:
+        x-tenant-scoped: true
+        x-rbac-resource: ticket
+        x-rbac-action: update
+      x-alga-products:
+        - psa
+        - algadesk
+      parameters:
+        - schema:
+            type: string
+            format: uuid
+            description: Ticket UUID.
+          required: true
+          description: Ticket UUID.
+          name: id
+          in: path
+        - schema:
+            type: string
+            format: uuid
+            description: User UUID of the additional agent.
+          required: true
+          description: User UUID of the additional agent.
+          name: userId
+          in: path
+      responses:
+        "204":
+          description: Additional agent removed.
+        "400":
+          description: Validation or request parsing failure.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/WorkV1ApiError"
+        "401":
+          description: API key missing/invalid.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/WorkV1ApiError"
+        "403":
+          description: RBAC denied for ticket resource action.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/WorkV1ApiError"
+        "404":
+          description: Ticket or additional agent not found.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/WorkV1ApiError"
+        "500":
+          description: Unexpected controller/service failure.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/WorkV1ApiError"
+  /api/v1/tickets/{id}/team:
+    put:
+      summary: Assign a team to a ticket
+      description: Sets assigned_team_id, resolves the primary agent (the existing
+        assignee, else the team lead) and records the team's active members as
+        team_member additional agents. Returns the updated ticket. A team
+        without a lead is rejected with 400.
+      tags:
+        - Work Management v1
+      security:
+        - ApiKeyAuth: []
+      extensions:
+        x-tenant-scoped: true
+        x-rbac-resource: ticket
+        x-rbac-action: update
+      x-alga-products:
+        - psa
+        - algadesk
+      parameters:
+        - schema:
+            type: string
+            format: uuid
+            description: UUID path identifier from underlying resource tables.
+          required: true
+          description: UUID path identifier from underlying resource tables.
+          name: id
+          in: path
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/WorkV1TicketTeamAssignBody"
+      responses:
+        "200":
+          description: Team assigned; updated ticket returned.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/WorkV1ApiSuccess"
+        "400":
+          description: Validation or request parsing failure.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/WorkV1ApiError"
+        "401":
+          description: API key missing/invalid.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/WorkV1ApiError"
+        "403":
+          description: RBAC denied for ticket resource action.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/WorkV1ApiError"
+        "404":
+          description: Ticket or sub-resource not found.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/WorkV1ApiError"
+        "500":
+          description: Unexpected controller/service failure.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/WorkV1ApiError"
+    delete:
+      summary: Remove a ticket team assignment
+      description: Clears assigned_team_id. mode=remove_all (default) drops the
+        team_member additional agents, keep_all leaves them, and selective keeps
+        only keep_user_ids. Returns the updated ticket.
+      tags:
+        - Work Management v1
+      security:
+        - ApiKeyAuth: []
+      extensions:
+        x-tenant-scoped: true
+        x-rbac-resource: ticket
+        x-rbac-action: update
+      x-alga-products:
+        - psa
+        - algadesk
+      parameters:
+        - schema:
+            type: string
+            format: uuid
+            description: UUID path identifier from underlying resource tables.
+          required: true
+          description: UUID path identifier from underlying resource tables.
+          name: id
+          in: path
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/WorkV1TicketTeamRemoveBody"
+      responses:
+        "200":
+          description: Team assignment removed; updated ticket returned.
           content:
             application/json:
               schema:

--- a/server/src/app/api/v1/tickets/[id]/agents/[userId]/route.ts
+++ b/server/src/app/api/v1/tickets/[id]/agents/[userId]/route.ts
@@ -1,0 +1,13 @@
+/**
+ * Ticket Additional Agent API Route
+ * DELETE /api/v1/tickets/{id}/agents/{userId} - Remove an additional agent
+ */
+
+import { ApiTicketController } from 'server/src/lib/api/controllers/ApiTicketController';
+
+const controller = new ApiTicketController();
+
+export const DELETE = controller.removeAgent();
+
+export const runtime = 'nodejs';
+export const dynamic = 'force-dynamic';

--- a/server/src/app/api/v1/tickets/[id]/agents/route.ts
+++ b/server/src/app/api/v1/tickets/[id]/agents/route.ts
@@ -1,0 +1,15 @@
+/**
+ * Ticket Agents API Route
+ * GET  /api/v1/tickets/{id}/agents - List the primary and additional agents
+ * POST /api/v1/tickets/{id}/agents - Add an additional agent
+ */
+
+import { ApiTicketController } from 'server/src/lib/api/controllers/ApiTicketController';
+
+const controller = new ApiTicketController();
+
+export const GET = controller.getAgents();
+export const POST = controller.addAgent();
+
+export const runtime = 'nodejs';
+export const dynamic = 'force-dynamic';

--- a/server/src/app/api/v1/tickets/[id]/team/route.ts
+++ b/server/src/app/api/v1/tickets/[id]/team/route.ts
@@ -1,0 +1,15 @@
+/**
+ * Ticket Team Assignment API Route
+ * PUT    /api/v1/tickets/{id}/team - Assign a team to a ticket
+ * DELETE /api/v1/tickets/{id}/team - Remove the ticket's team assignment
+ */
+
+import { ApiTicketController } from 'server/src/lib/api/controllers/ApiTicketController';
+
+const controller = new ApiTicketController();
+
+export const PUT = controller.assignTeam();
+export const DELETE = controller.removeTeam();
+
+export const runtime = 'nodejs';
+export const dynamic = 'force-dynamic';

--- a/server/src/lib/api/controllers/ApiTicketController.ts
+++ b/server/src/lib/api/controllers/ApiTicketController.ts
@@ -7,7 +7,7 @@ import { NextRequest, NextResponse } from 'next/server';
 import { ApiBaseController, AuthenticatedApiRequest } from './ApiBaseController';
 import { TicketService } from '../services/TicketService';
 import { 
-  createTicketSchema, updateTicketSchema, ticketListQuerySchema, ticketSearchSchema, ticketStatsResponseSchema, createTicketMaterialSchema, createTicketCommentSchema, updateTicketCommentSchema, updateTicketStatusSchema, updateTicketAssignmentSchema, createTicketFromAssetSchema, linkTicketAssetSchema
+  createTicketSchema, updateTicketSchema, ticketListQuerySchema, ticketSearchSchema, ticketStatsResponseSchema, createTicketMaterialSchema, createTicketCommentSchema, updateTicketCommentSchema, updateTicketStatusSchema, updateTicketAssignmentSchema, createTicketFromAssetSchema, linkTicketAssetSchema, addTicketAgentSchema, assignTicketTeamSchema, removeTicketTeamSchema
 } from '../schemas/ticket';
 import { 
   ApiKeyServiceForApi 
@@ -784,6 +784,173 @@ export class ApiTicketController extends ApiBaseController {
           await this.ticketService.unlinkAsset(ticketId, assetId, apiRequest.context!);
 
           return new NextResponse(null, { status: 204 });
+        });
+      } catch (error) {
+        return handleApiError(error);
+      }
+    };
+  }
+
+  /**
+   * List a ticket's primary and additional agents
+   */
+  getAgents() {
+    return async (req: NextRequest): Promise<NextResponse> => {
+      try {
+        const apiRequest = await this.authenticate(req);
+
+        return await runWithTenant(apiRequest.context!.tenant, async () => {
+          await this.checkPermission(apiRequest, this.options.permissions?.read || 'read');
+
+          const ticketId = await this.extractIdFromPath(apiRequest);
+          const knex = await getConnection(apiRequest.context!.tenant);
+          await this.assertTicketReadAllowed(apiRequest, ticketId, knex);
+
+          const agents = await this.ticketService.getTicketAgents(ticketId, apiRequest.context!);
+
+          return createSuccessResponse(agents, 200, undefined, apiRequest);
+        });
+      } catch (error) {
+        return handleApiError(error);
+      }
+    };
+  }
+
+  /**
+   * Add an additional agent to a ticket
+   */
+  addAgent() {
+    return async (req: NextRequest): Promise<NextResponse> => {
+      try {
+        const apiRequest = await this.authenticate(req);
+
+        return await runWithTenant(apiRequest.context!.tenant, async () => {
+          await this.checkPermission(apiRequest, this.options.permissions?.update || 'update');
+
+          const ticketId = await this.extractIdFromPath(apiRequest);
+          const knex = await getConnection(apiRequest.context!.tenant);
+          await this.assertTicketReadAllowed(apiRequest, ticketId, knex);
+
+          const body = await req.json();
+          const validation = addTicketAgentSchema.safeParse(body);
+          if (!validation.success) {
+            throw new ValidationError('Validation failed', validation.error.errors);
+          }
+
+          const agents = await this.ticketService.addTicketAgent(ticketId, validation.data, apiRequest.context!);
+
+          return createSuccessResponse(agents, 201, undefined, apiRequest);
+        });
+      } catch (error) {
+        return handleApiError(error);
+      }
+    };
+  }
+
+  /**
+   * Remove an additional agent from a ticket
+   */
+  removeAgent() {
+    return async (req: NextRequest): Promise<NextResponse> => {
+      try {
+        const apiRequest = await this.authenticate(req);
+
+        return await runWithTenant(apiRequest.context!.tenant, async () => {
+          await this.checkPermission(apiRequest, this.options.permissions?.update || 'update');
+
+          const ticketId = await this.extractIdFromPath(apiRequest);
+          const knex = await getConnection(apiRequest.context!.tenant);
+          await this.assertTicketReadAllowed(apiRequest, ticketId, knex);
+
+          // userId is the path segment after "agents".
+          const url = new URL(apiRequest.url || req.url);
+          const segments = url.pathname.split('/');
+          const agentsIndex = segments.indexOf('agents');
+          const userId = agentsIndex >= 0 ? segments[agentsIndex + 1] : undefined;
+
+          if (!userId) {
+            throw new ValidationError('Validation failed', [
+              { path: ['userId'], message: 'user ID is required' },
+            ]);
+          }
+
+          await this.ticketService.removeTicketAgent(ticketId, userId, apiRequest.context!);
+
+          return new NextResponse(null, { status: 204 });
+        });
+      } catch (error) {
+        return handleApiError(error);
+      }
+    };
+  }
+
+  /**
+   * Assign a team to a ticket
+   */
+  assignTeam() {
+    return async (req: NextRequest): Promise<NextResponse> => {
+      try {
+        const apiRequest = await this.authenticate(req);
+
+        return await runWithTenant(apiRequest.context!.tenant, async () => {
+          await this.checkPermission(apiRequest, this.options.permissions?.update || 'update');
+
+          const ticketId = await this.extractIdFromPath(apiRequest);
+          const knex = await getConnection(apiRequest.context!.tenant);
+          await this.assertTicketReadAllowed(apiRequest, ticketId, knex);
+
+          const body = await req.json();
+          const validation = assignTicketTeamSchema.safeParse(body);
+          if (!validation.success) {
+            throw new ValidationError('Validation failed', validation.error.errors);
+          }
+
+          const ticket = await this.ticketService.assignTeam(ticketId, validation.data, apiRequest.context!);
+
+          return createSuccessResponse(ticket, 200, undefined, apiRequest);
+        });
+      } catch (error) {
+        return handleApiError(error);
+      }
+    };
+  }
+
+  /**
+   * Remove the team assignment from a ticket
+   */
+  removeTeam() {
+    return async (req: NextRequest): Promise<NextResponse> => {
+      try {
+        const apiRequest = await this.authenticate(req);
+
+        return await runWithTenant(apiRequest.context!.tenant, async () => {
+          await this.checkPermission(apiRequest, this.options.permissions?.update || 'update');
+
+          const ticketId = await this.extractIdFromPath(apiRequest);
+          const knex = await getConnection(apiRequest.context!.tenant);
+          await this.assertTicketReadAllowed(apiRequest, ticketId, knex);
+
+          // DELETE bodies are optional; no body means remove_all.
+          let body: unknown = {};
+          try {
+            const raw = await req.text();
+            if (raw.trim()) {
+              body = JSON.parse(raw);
+            }
+          } catch {
+            throw new ValidationError('Validation failed', [
+              { path: [], message: 'Request body must be valid JSON' },
+            ]);
+          }
+
+          const validation = removeTicketTeamSchema.safeParse(body);
+          if (!validation.success) {
+            throw new ValidationError('Validation failed', validation.error.errors);
+          }
+
+          const ticket = await this.ticketService.removeTeam(ticketId, validation.data, apiRequest.context!);
+
+          return createSuccessResponse(ticket, 200, undefined, apiRequest);
         });
       } catch (error) {
         return handleApiError(error);

--- a/server/src/lib/api/openapi/routes/workManagementV1.ts
+++ b/server/src/lib/api/openapi/routes/workManagementV1.ts
@@ -542,6 +542,96 @@ export function registerWorkManagementV1Routes(registry: ApiOpenApiRegistry) {
     extensions: ticketExt('update'), edition: 'both',
   });
 
+  const TicketAgentParams = registry.registerSchema(
+    'WorkV1TicketAgentParams',
+    zOpenApi.object({
+      id: zOpenApi.string().uuid().describe('Ticket UUID.'),
+      userId: zOpenApi.string().uuid().describe('User UUID of the additional agent.'),
+    }),
+  );
+  const TicketAgentBody = registry.registerSchema(
+    'WorkV1TicketAgentBody',
+    zOpenApi.object({
+      user_id: zOpenApi.string().uuid().describe('User to add as an additional agent.'),
+      role: zOpenApi.string().max(50).optional().describe('Resource role recorded on the assignment; defaults to support.'),
+    }),
+  );
+  const TicketTeamAssignBody = registry.registerSchema(
+    'WorkV1TicketTeamAssignBody',
+    zOpenApi.object({
+      team_id: zOpenApi.string().uuid().describe('Team to assign to the ticket.'),
+      suppressContactNotifications: zOpenApi.boolean().optional(),
+      suppressInternalNotifications: zOpenApi.boolean().optional(),
+    }),
+  );
+  const TicketTeamRemoveBody = registry.registerSchema(
+    'WorkV1TicketTeamRemoveBody',
+    zOpenApi.object({
+      mode: zOpenApi.enum(['remove_all', 'keep_all', 'selective']).optional().describe('What to do with the team_member additional agents; defaults to remove_all.'),
+      keep_user_ids: zOpenApi.array(zOpenApi.string().uuid()).optional().describe('Required with mode=selective: the team members to keep as additional agents.'),
+    }),
+  );
+
+  registry.registerRoute({
+    method: 'get', path: '/api/v1/tickets/{id}/agents',
+    summary: 'List ticket agents',
+    description: 'Returns the ticket primary agent (tickets.assigned_to) and its additional agents (ticket_resources), each with user_id, name and email.',
+    tags: [tag], security: [{ ApiKeyAuth: [] }],
+    request: { params: IdParam },
+    responses: ticketStdResponses({ code: 200, description: 'Ticket primary and additional agents.' }),
+    extensions: ticketExt('read'), edition: 'both',
+  });
+
+  registry.registerRoute({
+    method: 'post', path: '/api/v1/tickets/{id}/agents',
+    summary: 'Add a ticket additional agent',
+    description: 'Adds a user as an additional agent on the ticket and publishes TICKET_ADDITIONAL_AGENT_ASSIGNED so notifications fire as they do in the UI. A ticket with no primary agent promotes the user to primary instead (TICKET_ASSIGNED). Returns the updated agent list; a duplicate returns 409.',
+    tags: [tag], security: [{ ApiKeyAuth: [] }],
+    request: { params: IdParam, body: { schema: TicketAgentBody } },
+    responses: {
+      ...ticketStdResponses({ code: 201, description: 'Agent added; updated agent list returned.' }),
+      409: { description: 'User is already an additional agent on this ticket.', schema: ApiError },
+    },
+    extensions: ticketExt('update'), edition: 'both',
+  });
+
+  registry.registerRoute({
+    method: 'delete', path: '/api/v1/tickets/{id}/agents/{userId}',
+    summary: 'Remove a ticket additional agent',
+    description: 'Removes the additional-agent assignment for the given user. The primary agent is changed through PUT /api/v1/tickets/{id}/assignment instead.',
+    tags: [tag], security: [{ ApiKeyAuth: [] }],
+    request: { params: TicketAgentParams },
+    responses: {
+      204: { description: 'Additional agent removed.', emptyBody: true },
+      400: { description: 'Validation or request parsing failure.', schema: ApiError },
+      401: { description: 'API key missing/invalid.', schema: ApiError },
+      403: { description: 'RBAC denied for ticket resource action.', schema: ApiError },
+      404: { description: 'Ticket or additional agent not found.', schema: ApiError },
+      500: { description: 'Unexpected controller/service failure.', schema: ApiError },
+    },
+    extensions: ticketExt('update'), edition: 'both',
+  });
+
+  registry.registerRoute({
+    method: 'put', path: '/api/v1/tickets/{id}/team',
+    summary: 'Assign a team to a ticket',
+    description: 'Sets assigned_team_id, resolves the primary agent (the existing assignee, else the team lead) and records the team\'s active members as team_member additional agents. Returns the updated ticket. A team without a lead is rejected with 400.',
+    tags: [tag], security: [{ ApiKeyAuth: [] }],
+    request: { params: IdParam, body: { schema: TicketTeamAssignBody } },
+    responses: ticketStdResponses({ code: 200, description: 'Team assigned; updated ticket returned.' }),
+    extensions: ticketExt('update'), edition: 'both',
+  });
+
+  registry.registerRoute({
+    method: 'delete', path: '/api/v1/tickets/{id}/team',
+    summary: 'Remove a ticket team assignment',
+    description: 'Clears assigned_team_id. mode=remove_all (default) drops the team_member additional agents, keep_all leaves them, and selective keeps only keep_user_ids. Returns the updated ticket.',
+    tags: [tag], security: [{ ApiKeyAuth: [] }],
+    request: { params: IdParam, body: { schema: TicketTeamRemoveBody } },
+    responses: ticketStdResponses({ code: 200, description: 'Team assignment removed; updated ticket returned.' }),
+    extensions: ticketExt('update'), edition: 'both',
+  });
+
   registry.registerRoute({
     method: 'get', path: '/api/v1/tickets/{id}/materials',
     summary: 'List ticket materials',

--- a/server/src/lib/api/schemas/ticket.ts
+++ b/server/src/lib/api/schemas/ticket.ts
@@ -354,6 +354,46 @@ export const linkTicketAssetSchema = z.object({
   notes: z.string().optional()
 });
 
+// Add an additional agent to a ticket (POST /api/v1/tickets/{id}/agents).
+export const addTicketAgentSchema = z.object({
+  user_id: uuidSchema,
+  role: z.string().trim().min(1).max(50).optional()
+});
+
+const ticketAgentSchema = z.object({
+  user_id: uuidSchema,
+  first_name: z.string().nullable(),
+  last_name: z.string().nullable(),
+  email: z.string().nullable()
+});
+
+// GET /api/v1/tickets/{id}/agents response.
+export const ticketAgentsResponseSchema = z.object({
+  ticket_id: uuidSchema,
+  primary_agent: ticketAgentSchema.nullable(),
+  additional_agents: z.array(ticketAgentSchema.extend({
+    assignment_id: uuidSchema,
+    role: z.string().nullable(),
+    assigned_at: z.union([z.string(), z.date()]).nullable()
+  }))
+});
+
+// Assign a team to a ticket (PUT /api/v1/tickets/{id}/team).
+export const assignTicketTeamSchema = z.object({
+  team_id: uuidSchema,
+  ...ticketNotificationSuppressionSchema
+});
+
+// Remove a ticket's team (DELETE /api/v1/tickets/{id}/team). `mode` decides what
+// happens to the additional agents the team assignment created.
+export const removeTicketTeamSchema = z.object({
+  mode: z.enum(['remove_all', 'keep_all', 'selective']).default('remove_all'),
+  keep_user_ids: z.array(uuidSchema).optional()
+}).refine(
+  (data) => data.mode !== 'selective' || (data.keep_user_ids?.length ?? 0) > 0,
+  { path: ['keep_user_ids'], message: 'keep_user_ids is required when mode is selective' }
+);
+
 // Export types for TypeScript
 export type CreateTicketData = z.infer<typeof createTicketSchema>;
 export type UpdateTicketData = z.infer<typeof updateTicketSchema>;
@@ -367,3 +407,7 @@ export type TicketExportQuery = z.infer<typeof ticketExportQuerySchema>;
 export type TicketMetricsQuery = z.infer<typeof ticketMetricsQuerySchema>;
 export type CreateTicketFromAssetData = z.infer<typeof createTicketFromAssetSchema>;
 export type LinkTicketAssetData = z.infer<typeof linkTicketAssetSchema>;
+export type AddTicketAgentData = z.infer<typeof addTicketAgentSchema>;
+export type TicketAgentsResponse = z.infer<typeof ticketAgentsResponseSchema>;
+export type AssignTicketTeamData = z.infer<typeof assignTicketTeamSchema>;
+export type RemoveTicketTeamData = z.infer<typeof removeTicketTeamSchema>;

--- a/server/src/lib/api/services/TicketService.ts
+++ b/server/src/lib/api/services/TicketService.ts
@@ -13,6 +13,7 @@ import { TICKET_ORIGINS } from '@alga-psa/types';
 import { maybeReopenBundleMasterFromChildReply } from '@alga-psa/tickets/actions/ticketBundleUtils';
 import { deleteTicketChildRecords } from '@alga-psa/tickets/lib/deleteTicketChildRecords';
 import { enforceTicketCloseRules, TicketCloseValidationError } from '@alga-psa/tickets/lib/validateTicketClosure';
+import { prepareTicketResourceReassignment } from '@alga-psa/tickets/lib/reassignTicketResources';
 import { deleteEntityWithValidation } from '@alga-psa/core/server';
 import { publishWorkflowEvent } from 'server/src/lib/eventBus/publishers';
 import { NotFoundError, ValidationError, ConflictError } from '../middleware/apiMiddleware';
@@ -1319,11 +1320,29 @@ export class TicketService extends BaseService<ITicket> {
         updated_at: knex.raw('now()')
       };
 
+      // Changing the primary assignee requires clearing the ticket_resources
+      // rows that reference the old one, then re-keying them afterwards.
+      const isChangingAssignment =
+        'assigned_to' in cleanedData && cleanedData.assigned_to !== currentTicket.assigned_to;
+      const finalizeResourceReassignment = isChangingAssignment
+        ? await prepareTicketResourceReassignment(
+          trx,
+          context.tenant,
+          id,
+          currentTicket.assigned_to,
+          (cleanedData as { assigned_to?: string | null }).assigned_to
+        )
+        : null;
+
       // Update ticket
       const [ticket] = await tenantScopedTable(trx, 'tickets', context.tenant)
         .where({ ticket_id: id })
         .update(updateData)
         .returning('*');
+
+      if (finalizeResourceReassignment) {
+        await finalizeResourceReassignment();
+      }
 
       // Handle tags if provided
       if (data.tags) {

--- a/server/src/lib/api/services/TicketService.ts
+++ b/server/src/lib/api/services/TicketService.ts
@@ -14,6 +14,17 @@ import { maybeReopenBundleMasterFromChildReply } from '@alga-psa/tickets/actions
 import { deleteTicketChildRecords } from '@alga-psa/tickets/lib/deleteTicketChildRecords';
 import { enforceTicketCloseRules, TicketCloseValidationError } from '@alga-psa/tickets/lib/validateTicketClosure';
 import { prepareTicketResourceReassignment } from '@alga-psa/tickets/lib/reassignTicketResources';
+import {
+  TicketResourceError,
+  addTicketResourceCore,
+  getTicketResourcesCore,
+  removeTicketResourceCore,
+} from '@alga-psa/tickets/lib/ticketResourceCore';
+import {
+  assignTeamToTicketCore,
+  removeTeamFromTicketCore,
+  type RemoveTeamFromTicketOptions,
+} from '@alga-psa/tickets/lib/teamAssignmentCore';
 import { deleteEntityWithValidation } from '@alga-psa/core/server';
 import { publishWorkflowEvent } from 'server/src/lib/eventBus/publishers';
 import { NotFoundError, ValidationError, ConflictError } from '../middleware/apiMiddleware';
@@ -37,7 +48,11 @@ import {
   CreateTicketMaterialData,
   UpdateTicketCommentData,
   TicketSearchData,
-  CreateTicketFromAssetData
+  CreateTicketFromAssetData,
+  AddTicketAgentData,
+  TicketAgentsResponse,
+  AssignTicketTeamData,
+  RemoveTicketTeamData
 } from '../schemas/ticket';
 import { ListOptions } from '../controllers/types';
 import { analytics } from '../../analytics/posthog';
@@ -676,6 +691,215 @@ export class TicketService extends BaseService<ITicket> {
     if (!deleted) {
       throw new NotFoundError('Asset-ticket association not found');
     }
+  }
+
+  /**
+   * List a ticket's primary agent (tickets.assigned_to) and its additional
+   * agents (ticket_resources).
+   */
+  async getTicketAgents(ticketId: string, context: ServiceContext): Promise<TicketAgentsResponse> {
+    const { knex } = await this.getKnex();
+    this.assertValidTicketId(ticketId);
+
+    return withTransaction(knex, async (trx) => {
+      const ticket = await tenantScopedTable(trx, 'tickets', context.tenant)
+        .where({ ticket_id: ticketId })
+        .first();
+      if (!ticket) {
+        throw new NotFoundError('Ticket not found');
+      }
+
+      const resources = await getTicketResourcesCore(trx, context.tenant, ticketId);
+      return this.buildTicketAgentsResponse(trx, context, ticket, resources);
+    });
+  }
+
+  /**
+   * Add an additional agent to a ticket. A ticket with no primary agent
+   * promotes the user to primary instead, matching the UI behaviour.
+   */
+  async addTicketAgent(
+    ticketId: string,
+    data: AddTicketAgentData,
+    context: ServiceContext
+  ): Promise<TicketAgentsResponse> {
+    const { knex } = await this.getKnex();
+    this.assertValidTicketId(ticketId);
+
+    return withTransaction(knex, async (trx) => {
+      const agentUser = await tenantScopedTable(trx, 'users', context.tenant)
+        .where({ user_id: data.user_id })
+        .first();
+      if (!agentUser) {
+        throw new NotFoundError('User not found');
+      }
+
+      try {
+        await addTicketResourceCore(
+          trx,
+          context.tenant,
+          context.userId,
+          ticketId,
+          data.user_id,
+          data.role ?? 'support'
+        );
+      } catch (error) {
+        if (error instanceof TicketResourceError) {
+          throw error.kind === 'conflict'
+            ? new ConflictError('User is already an additional agent on this ticket')
+            : new NotFoundError('Ticket not found');
+        }
+        throw error;
+      }
+
+      const ticket = await tenantScopedTable(trx, 'tickets', context.tenant)
+        .where({ ticket_id: ticketId })
+        .first();
+      const resources = await getTicketResourcesCore(trx, context.tenant, ticketId);
+      return this.buildTicketAgentsResponse(trx, context, ticket, resources);
+    });
+  }
+
+  /**
+   * Remove an additional agent from a ticket by user id. The primary agent is
+   * changed through the assignment endpoint, not here.
+   */
+  async removeTicketAgent(ticketId: string, userId: string, context: ServiceContext): Promise<void> {
+    const { knex } = await this.getKnex();
+    this.assertValidTicketId(ticketId);
+
+    await withTransaction(knex, async (trx) => {
+      const resource = await tenantScopedTable(trx, 'ticket_resources', context.tenant)
+        .where({ ticket_id: ticketId, additional_user_id: userId })
+        .first();
+      if (!resource) {
+        throw new NotFoundError('Additional agent not found on this ticket');
+      }
+
+      await removeTicketResourceCore(trx, context.tenant, resource.assignment_id);
+    });
+  }
+
+  /**
+   * Assign a team to a ticket: sets assigned_team_id, resolves the primary
+   * agent (existing one, else the team lead) and adds the team's active members
+   * as additional agents.
+   */
+  async assignTeam(ticketId: string, data: AssignTicketTeamData, context: ServiceContext): Promise<ITicket> {
+    const { knex } = await this.getKnex();
+    this.assertValidTicketId(ticketId);
+
+    const { ticket, assignedTo } = await withTransaction(knex, async (trx) => {
+      let resolvedAssignedTo: string;
+      try {
+        resolvedAssignedTo = await assignTeamToTicketCore(
+          trx,
+          context.tenant,
+          context.userId,
+          ticketId,
+          data.team_id
+        );
+      } catch (error) {
+        throw this.mapTeamAssignmentError(error);
+      }
+
+      const updated = await tenantScopedTable(trx, 'tickets', context.tenant)
+        .where({ ticket_id: ticketId })
+        .first();
+
+      return { ticket: updated as ITicket, assignedTo: resolvedAssignedTo };
+    });
+
+    await this.safePublishEvent('TICKET_ASSIGNED', context, {
+      ticketId,
+      userId: assignedTo,
+      assignedByUserId: context.userId,
+      changes: { assigned_team_id: data.team_id },
+      suppressContactNotifications: data.suppressContactNotifications === true,
+      suppressInternalNotifications: data.suppressInternalNotifications === true,
+    });
+
+    return this.withDescriptionHtml(ticket);
+  }
+
+  /**
+   * Clear a ticket's team assignment, optionally pruning the additional agents
+   * the team assignment created.
+   */
+  async removeTeam(ticketId: string, data: RemoveTicketTeamData, context: ServiceContext): Promise<ITicket> {
+    const { knex } = await this.getKnex();
+    this.assertValidTicketId(ticketId);
+
+    const options: RemoveTeamFromTicketOptions = {
+      mode: data.mode,
+      keepUserIds: data.keep_user_ids,
+    };
+
+    return withTransaction(knex, async (trx) => {
+      try {
+        await removeTeamFromTicketCore(trx, context.tenant, context.userId, ticketId, options);
+      } catch (error) {
+        throw this.mapTeamAssignmentError(error);
+      }
+
+      const updated = await tenantScopedTable(trx, 'tickets', context.tenant)
+        .where({ ticket_id: ticketId })
+        .first();
+
+      return this.withDescriptionHtml(updated as ITicket);
+    });
+  }
+
+  private mapTeamAssignmentError(error: unknown): unknown {
+    if (error instanceof Error) {
+      if (error.message === 'Ticket not found' || error.message === 'Team not found') {
+        return new NotFoundError(error.message);
+      }
+      if (error.message === 'Team lead not found') {
+        return new ValidationError('The selected team does not have a team lead');
+      }
+    }
+    return error;
+  }
+
+  private async buildTicketAgentsResponse(
+    trx: Knex.Transaction,
+    context: ServiceContext,
+    ticket: Record<string, any>,
+    resources: Array<Record<string, any>>
+  ): Promise<TicketAgentsResponse> {
+    const userIds = Array.from(new Set<string>([
+      ...(ticket.assigned_to ? [ticket.assigned_to as string] : []),
+      ...resources.map((resource) => resource.additional_user_id as string).filter(Boolean),
+    ]));
+
+    const users = userIds.length
+      ? await tenantScopedTable(trx, 'users', context.tenant)
+        .whereIn('user_id', userIds)
+        .select('user_id', 'first_name', 'last_name', 'email')
+      : [];
+    const usersById = new Map<string, any>(users.map((user: any) => [user.user_id, user]));
+
+    const toAgent = (userId: string) => {
+      const user = usersById.get(userId);
+      return {
+        user_id: userId,
+        first_name: user?.first_name ?? null,
+        last_name: user?.last_name ?? null,
+        email: user?.email ?? null,
+      };
+    };
+
+    return {
+      ticket_id: ticket.ticket_id as string,
+      primary_agent: ticket.assigned_to ? toAgent(ticket.assigned_to as string) : null,
+      additional_agents: resources.map((resource) => ({
+        ...toAgent(resource.additional_user_id as string),
+        assignment_id: resource.assignment_id as string,
+        role: resource.role ?? null,
+        assigned_at: resource.assigned_at ?? null,
+      })),
+    };
   }
 
   async uploadTicketDocument(ticketId: string, file: File, context: ServiceContext): Promise<IDocument> {

--- a/server/src/lib/mcp/registry.generated.ts
+++ b/server/src/lib/mcp/registry.generated.ts
@@ -34029,10 +34029,10 @@ export const chatApiRegistry: ChatApiRegistryEntry[] = [
         "name": "types",
         "in": "query",
         "required": false,
-        "description": "Comma-separated list of object types to restrict the search (e.g. \"ticket,project\"). Omit to search every type the API key's user is permitted to read. Allowed values: client, contact, user, ticket, ticket_comment, project, project_phase, project_task, project_task_comment, asset, invoice, invoice_item, invoice_annotation, contract, client_contract, document, kb_article, service_catalog, service_request_submission, service_request_definition, workflow_task, interaction, schedule_entry, time_entry, board, category, tag, status.",
+        "description": "Comma-separated list of object types to restrict the search (e.g. \"ticket,project\"). Omit to search every type the API key's user is permitted to read. Allowed values: client, contact, user, ticket, ticket_comment, project, project_phase, project_task, project_task_comment, asset, sales_order, purchase_order, stock_unit, invoice, invoice_item, invoice_annotation, contract, client_contract, document, kb_article, service_catalog, service_request_submission, service_request_definition, workflow_task, interaction, schedule_entry, time_entry, board, category, tag, status.",
         "schema": {
           "type": "string",
-          "description": "Comma-separated list of object types to restrict the search (e.g. \"ticket,project\"). Omit to search every type the API key's user is permitted to read. Allowed values: client, contact, user, ticket, ticket_comment, project, project_phase, project_task, project_task_comment, asset, invoice, invoice_item, invoice_annotation, contract, client_contract, document, kb_article, service_catalog, service_request_submission, service_request_definition, workflow_task, interaction, schedule_entry, time_entry, board, category, tag, status."
+          "description": "Comma-separated list of object types to restrict the search (e.g. \"ticket,project\"). Omit to search every type the API key's user is permitted to read. Allowed values: client, contact, user, ticket, ticket_comment, project, project_phase, project_task, project_task_comment, asset, sales_order, purchase_order, stock_unit, invoice, invoice_item, invoice_annotation, contract, client_contract, document, kb_article, service_catalog, service_request_submission, service_request_definition, workflow_task, interaction, schedule_entry, time_entry, board, category, tag, status."
         }
       },
       {
@@ -35841,6 +35841,20 @@ export const chatApiRegistry: ChatApiRegistryEntry[] = [
             }
           ]
         },
+        "barcode": {
+          "anyOf": [
+            {
+              "type": "string",
+              "maxLength": 255
+            },
+            {
+              "type": "null"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
         "cost": {
           "anyOf": [
             {
@@ -36139,6 +36153,20 @@ export const chatApiRegistry: ChatApiRegistryEntry[] = [
             {
               "type": "string",
               "maxLength": 128
+            },
+            {
+              "type": "null"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "barcode": {
+          "anyOf": [
+            {
+              "type": "string",
+              "maxLength": 255
             },
             {
               "type": "null"
@@ -49436,6 +49464,309 @@ export const chatApiRegistry: ChatApiRegistryEntry[] = [
     }
   },
   {
+    "id": "get-_api_v1_tickets_id_agents",
+    "method": "get",
+    "path": "/api/v1/tickets/{id}/agents",
+    "displayName": "List ticket agents",
+    "summary": "List ticket agents",
+    "description": "Returns the ticket primary agent (tickets.assigned_to) and its additional agents (ticket_resources), each with user_id, name and email.",
+    "tags": [
+      "Work Management v1"
+    ],
+    "approvalRequired": false,
+    "parameters": [
+      {
+        "name": "id",
+        "in": "path",
+        "required": true,
+        "description": "UUID path identifier from underlying resource tables.",
+        "schema": {
+          "type": "string",
+          "format": "uuid",
+          "description": "UUID path identifier from underlying resource tables."
+        }
+      }
+    ],
+    "responseBodySchema": {
+      "type": "object",
+      "properties": {
+        "data": {
+          "anyOf": [
+            {
+              "type": "object",
+              "additionalProperties": {}
+            },
+            {
+              "type": "array",
+              "items": {
+                "type": "object",
+                "additionalProperties": {}
+              }
+            }
+          ]
+        },
+        "meta": {
+          "type": "object",
+          "additionalProperties": {}
+        }
+      },
+      "required": [
+        "data"
+      ]
+    }
+  },
+  {
+    "id": "post-_api_v1_tickets_id_agents",
+    "method": "post",
+    "path": "/api/v1/tickets/{id}/agents",
+    "displayName": "Add a ticket additional agent",
+    "summary": "Add a ticket additional agent",
+    "description": "Adds a user as an additional agent on the ticket and publishes TICKET_ADDITIONAL_AGENT_ASSIGNED so notifications fire as they do in the UI. A ticket with no primary agent promotes the user to primary instead (TICKET_ASSIGNED). Returns the updated agent list; a duplicate returns 409.",
+    "tags": [
+      "Work Management v1"
+    ],
+    "approvalRequired": false,
+    "parameters": [
+      {
+        "name": "id",
+        "in": "path",
+        "required": true,
+        "description": "UUID path identifier from underlying resource tables.",
+        "schema": {
+          "type": "string",
+          "format": "uuid",
+          "description": "UUID path identifier from underlying resource tables."
+        }
+      }
+    ],
+    "requestBodySchema": {
+      "type": "object",
+      "properties": {
+        "user_id": {
+          "type": "string",
+          "format": "uuid",
+          "description": "User to add as an additional agent."
+        },
+        "role": {
+          "type": "string",
+          "maxLength": 50,
+          "description": "Resource role recorded on the assignment; defaults to support."
+        }
+      },
+      "required": [
+        "user_id"
+      ]
+    },
+    "responseBodySchema": {
+      "type": "object",
+      "properties": {
+        "data": {
+          "anyOf": [
+            {
+              "type": "object",
+              "additionalProperties": {}
+            },
+            {
+              "type": "array",
+              "items": {
+                "type": "object",
+                "additionalProperties": {}
+              }
+            }
+          ]
+        },
+        "meta": {
+          "type": "object",
+          "additionalProperties": {}
+        }
+      },
+      "required": [
+        "data"
+      ]
+    }
+  },
+  {
+    "id": "delete-_api_v1_tickets_id_agents_userid",
+    "method": "delete",
+    "path": "/api/v1/tickets/{id}/agents/{userId}",
+    "displayName": "Remove a ticket additional agent",
+    "summary": "Remove a ticket additional agent",
+    "description": "Removes the additional-agent assignment for the given user. The primary agent is changed through PUT /api/v1/tickets/{id}/assignment instead.",
+    "tags": [
+      "Work Management v1"
+    ],
+    "approvalRequired": false,
+    "parameters": [
+      {
+        "name": "id",
+        "in": "path",
+        "required": true,
+        "description": "Ticket UUID.",
+        "schema": {
+          "type": "string",
+          "format": "uuid",
+          "description": "Ticket UUID."
+        }
+      },
+      {
+        "name": "userId",
+        "in": "path",
+        "required": true,
+        "description": "User UUID of the additional agent.",
+        "schema": {
+          "type": "string",
+          "format": "uuid",
+          "description": "User UUID of the additional agent."
+        }
+      }
+    ]
+  },
+  {
+    "id": "put-_api_v1_tickets_id_team",
+    "method": "put",
+    "path": "/api/v1/tickets/{id}/team",
+    "displayName": "Assign a team to a ticket",
+    "summary": "Assign a team to a ticket",
+    "description": "Sets assigned_team_id, resolves the primary agent (the existing assignee, else the team lead) and records the team's active members as team_member additional agents. Returns the updated ticket. A team without a lead is rejected with 400.",
+    "tags": [
+      "Work Management v1"
+    ],
+    "approvalRequired": false,
+    "parameters": [
+      {
+        "name": "id",
+        "in": "path",
+        "required": true,
+        "description": "UUID path identifier from underlying resource tables.",
+        "schema": {
+          "type": "string",
+          "format": "uuid",
+          "description": "UUID path identifier from underlying resource tables."
+        }
+      }
+    ],
+    "requestBodySchema": {
+      "type": "object",
+      "properties": {
+        "team_id": {
+          "type": "string",
+          "format": "uuid",
+          "description": "Team to assign to the ticket."
+        },
+        "suppressContactNotifications": {
+          "type": "boolean"
+        },
+        "suppressInternalNotifications": {
+          "type": "boolean"
+        }
+      },
+      "required": [
+        "team_id"
+      ]
+    },
+    "responseBodySchema": {
+      "type": "object",
+      "properties": {
+        "data": {
+          "anyOf": [
+            {
+              "type": "object",
+              "additionalProperties": {}
+            },
+            {
+              "type": "array",
+              "items": {
+                "type": "object",
+                "additionalProperties": {}
+              }
+            }
+          ]
+        },
+        "meta": {
+          "type": "object",
+          "additionalProperties": {}
+        }
+      },
+      "required": [
+        "data"
+      ]
+    }
+  },
+  {
+    "id": "delete-_api_v1_tickets_id_team",
+    "method": "delete",
+    "path": "/api/v1/tickets/{id}/team",
+    "displayName": "Remove a ticket team assignment",
+    "summary": "Remove a ticket team assignment",
+    "description": "Clears assigned_team_id. mode=remove_all (default) drops the team_member additional agents, keep_all leaves them, and selective keeps only keep_user_ids. Returns the updated ticket.",
+    "tags": [
+      "Work Management v1"
+    ],
+    "approvalRequired": false,
+    "parameters": [
+      {
+        "name": "id",
+        "in": "path",
+        "required": true,
+        "description": "UUID path identifier from underlying resource tables.",
+        "schema": {
+          "type": "string",
+          "format": "uuid",
+          "description": "UUID path identifier from underlying resource tables."
+        }
+      }
+    ],
+    "requestBodySchema": {
+      "type": "object",
+      "properties": {
+        "mode": {
+          "type": "string",
+          "enum": [
+            "remove_all",
+            "keep_all",
+            "selective"
+          ],
+          "description": "What to do with the team_member additional agents; defaults to remove_all."
+        },
+        "keep_user_ids": {
+          "type": "array",
+          "items": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "description": "Required with mode=selective: the team members to keep as additional agents."
+        }
+      }
+    },
+    "responseBodySchema": {
+      "type": "object",
+      "properties": {
+        "data": {
+          "anyOf": [
+            {
+              "type": "object",
+              "additionalProperties": {}
+            },
+            {
+              "type": "array",
+              "items": {
+                "type": "object",
+                "additionalProperties": {}
+              }
+            }
+          ]
+        },
+        "meta": {
+          "type": "object",
+          "additionalProperties": {}
+        }
+      },
+      "required": [
+        "data"
+      ]
+    }
+  },
+  {
     "id": "get-_api_v1_tickets_id_materials",
     "method": "get",
     "path": "/api/v1/tickets/{id}/materials",
@@ -51668,6 +51999,31 @@ export const chatApiRegistry: ChatApiRegistryEntry[] = [
     }
   },
   {
+    "id": "get-_api_v1_opportunities_workqueue",
+    "method": "get",
+    "path": "/api/v1/opportunities/work-queue",
+    "displayName": "Get the current user work queue",
+    "summary": "Get the current user work queue",
+    "description": "Returns the shared server-composed opportunity work queue for the authenticated API-key user.",
+    "tags": [
+      "Opportunities v1"
+    ],
+    "approvalRequired": false,
+    "parameters": [],
+    "responseBodySchema": {
+      "type": "object",
+      "properties": {
+        "data": {
+          "type": "object",
+          "additionalProperties": {}
+        }
+      },
+      "required": [
+        "data"
+      ]
+    }
+  },
+  {
     "id": "get-_api_v1_opportunities_id",
     "method": "get",
     "path": "/api/v1/opportunities/{id}",
@@ -51878,6 +52234,73 @@ export const chatApiRegistry: ChatApiRegistryEntry[] = [
         }
       }
     ]
+  },
+  {
+    "id": "get-_api_v1_opportunities_id_timeline",
+    "method": "get",
+    "path": "/api/v1/opportunities/{id}/timeline",
+    "displayName": "List opportunity timeline",
+    "summary": "List opportunity timeline",
+    "description": "Lists interactions linked to the opportunity, newest first.",
+    "tags": [
+      "Opportunities v1"
+    ],
+    "approvalRequired": false,
+    "parameters": [
+      {
+        "name": "id",
+        "in": "path",
+        "required": true,
+        "description": "Opportunity UUID from opportunities.opportunity_id.",
+        "schema": {
+          "type": "string",
+          "format": "uuid",
+          "description": "Opportunity UUID from opportunities.opportunity_id."
+        }
+      }
+    ],
+    "responseBodySchema": {
+      "type": "object",
+      "properties": {
+        "data": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "interaction_id": {
+                "type": "string",
+                "format": "uuid"
+              },
+              "title": {
+                "type": "string"
+              },
+              "notes": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "interaction_date": {
+                "type": "string",
+                "format": "date-time"
+              },
+              "user_name": {
+                "type": "string"
+              }
+            },
+            "required": [
+              "interaction_id",
+              "title",
+              "interaction_date",
+              "user_name"
+            ]
+          }
+        }
+      },
+      "required": [
+        "data"
+      ]
+    }
   },
   {
     "id": "post-_api_v1_opportunities_id_win",
@@ -53826,6 +54249,13 @@ export const chatApiRegistry: ChatApiRegistryEntry[] = [
             "archived"
           ]
         },
+        "campaign_id": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "format": "uuid"
+        },
         "steps": {
           "type": "array",
           "items": {
@@ -53971,6 +54401,13 @@ export const chatApiRegistry: ChatApiRegistryEntry[] = [
             "archived"
           ]
         },
+        "campaign_id": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "format": "uuid"
+        },
         "steps": {
           "type": "array",
           "items": {
@@ -54101,6 +54538,1752 @@ export const chatApiRegistry: ChatApiRegistryEntry[] = [
         }
       }
     ]
+  },
+  {
+    "id": "get-_api_v1_interactions",
+    "method": "get",
+    "path": "/api/v1/interactions",
+    "displayName": "List interactions",
+    "summary": "List interactions",
+    "tags": [
+      "Interactions v1"
+    ],
+    "approvalRequired": false,
+    "parameters": [
+      {
+        "name": "client_id",
+        "in": "query",
+        "required": false,
+        "schema": {
+          "type": "string",
+          "format": "uuid"
+        }
+      },
+      {
+        "name": "contact_id",
+        "in": "query",
+        "required": false,
+        "schema": {
+          "type": "string",
+          "format": "uuid"
+        }
+      },
+      {
+        "name": "opportunity_id",
+        "in": "query",
+        "required": false,
+        "schema": {
+          "type": "string",
+          "format": "uuid"
+        }
+      },
+      {
+        "name": "ticket_id",
+        "in": "query",
+        "required": false,
+        "schema": {
+          "type": "string",
+          "format": "uuid"
+        }
+      },
+      {
+        "name": "project_id",
+        "in": "query",
+        "required": false,
+        "schema": {
+          "type": "string",
+          "format": "uuid"
+        }
+      },
+      {
+        "name": "user_id",
+        "in": "query",
+        "required": false,
+        "schema": {
+          "type": "string",
+          "format": "uuid"
+        }
+      },
+      {
+        "name": "type_id",
+        "in": "query",
+        "required": false,
+        "schema": {
+          "type": "string",
+          "format": "uuid"
+        }
+      },
+      {
+        "name": "date_from",
+        "in": "query",
+        "required": false,
+        "schema": {
+          "type": "string",
+          "format": "date-time"
+        }
+      },
+      {
+        "name": "date_to",
+        "in": "query",
+        "required": false,
+        "schema": {
+          "type": "string",
+          "format": "date-time"
+        }
+      },
+      {
+        "name": "page",
+        "in": "query",
+        "required": false,
+        "schema": {
+          "type": "string",
+          "pattern": "^\\d+$"
+        }
+      },
+      {
+        "name": "page_size",
+        "in": "query",
+        "required": false,
+        "schema": {
+          "type": "string",
+          "pattern": "^\\d+$"
+        }
+      }
+    ],
+    "responseBodySchema": {
+      "type": "object",
+      "properties": {
+        "data": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "tenant": {
+                "type": "string",
+                "format": "uuid"
+              },
+              "interaction_id": {
+                "type": "string",
+                "format": "uuid"
+              },
+              "type_id": {
+                "type": "string",
+                "format": "uuid"
+              },
+              "type_name": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "icon": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "contact_name_id": {
+                "type": [
+                  "string",
+                  "null"
+                ],
+                "format": "uuid"
+              },
+              "contact_name": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "client_id": {
+                "type": [
+                  "string",
+                  "null"
+                ],
+                "format": "uuid"
+              },
+              "client_name": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "user_id": {
+                "type": "string",
+                "format": "uuid"
+              },
+              "user_name": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "ticket_id": {
+                "type": [
+                  "string",
+                  "null"
+                ],
+                "format": "uuid"
+              },
+              "project_id": {
+                "type": [
+                  "string",
+                  "null"
+                ],
+                "format": "uuid"
+              },
+              "opportunity_id": {
+                "type": [
+                  "string",
+                  "null"
+                ],
+                "format": "uuid"
+              },
+              "title": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "notes": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "interaction_date": {
+                "anyOf": [
+                  {
+                    "type": "string",
+                    "format": "date-time"
+                  },
+                  {
+                    "type": "string"
+                  }
+                ]
+              },
+              "start_time": {
+                "anyOf": [
+                  {
+                    "type": "string",
+                    "format": "date-time"
+                  },
+                  {
+                    "type": "string"
+                  },
+                  {
+                    "type": "null"
+                  }
+                ]
+              },
+              "end_time": {
+                "anyOf": [
+                  {
+                    "type": "string",
+                    "format": "date-time"
+                  },
+                  {
+                    "type": "string"
+                  },
+                  {
+                    "type": "null"
+                  }
+                ]
+              },
+              "duration": {
+                "type": [
+                  "integer",
+                  "null"
+                ]
+              },
+              "status_id": {
+                "type": [
+                  "string",
+                  "null"
+                ],
+                "format": "uuid"
+              },
+              "status_name": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "is_status_closed": {
+                "type": [
+                  "boolean",
+                  "null"
+                ]
+              },
+              "visibility": {
+                "type": "string",
+                "enum": [
+                  "internal",
+                  "client_visible"
+                ]
+              }
+            },
+            "required": [
+              "tenant",
+              "interaction_id",
+              "type_id",
+              "type_name",
+              "icon",
+              "contact_name_id",
+              "contact_name",
+              "client_id",
+              "client_name",
+              "user_id",
+              "user_name",
+              "ticket_id",
+              "project_id",
+              "opportunity_id",
+              "title",
+              "notes",
+              "interaction_date",
+              "start_time",
+              "end_time",
+              "duration",
+              "status_id",
+              "status_name",
+              "is_status_closed",
+              "visibility"
+            ]
+          }
+        },
+        "pagination": {
+          "type": "object",
+          "properties": {
+            "page": {
+              "type": "number"
+            },
+            "limit": {
+              "type": "number"
+            },
+            "total": {
+              "type": "number"
+            },
+            "totalPages": {
+              "type": "number"
+            },
+            "hasNext": {
+              "type": "boolean"
+            },
+            "hasPrev": {
+              "type": "boolean"
+            }
+          },
+          "required": [
+            "page",
+            "limit",
+            "total",
+            "totalPages",
+            "hasNext",
+            "hasPrev"
+          ]
+        },
+        "meta": {
+          "type": "object",
+          "properties": {}
+        }
+      },
+      "required": [
+        "data",
+        "pagination"
+      ]
+    }
+  },
+  {
+    "id": "post-_api_v1_interactions",
+    "method": "post",
+    "path": "/api/v1/interactions",
+    "displayName": "Create an interaction",
+    "summary": "Create an interaction",
+    "tags": [
+      "Interactions v1"
+    ],
+    "approvalRequired": false,
+    "parameters": [],
+    "requestBodySchema": {
+      "type": "object",
+      "properties": {
+        "type_id": {
+          "type": "string",
+          "format": "uuid"
+        },
+        "client_id": {
+          "type": "string",
+          "format": "uuid"
+        },
+        "contact_name_id": {
+          "type": "string",
+          "format": "uuid"
+        },
+        "ticket_id": {
+          "type": "string",
+          "format": "uuid"
+        },
+        "project_id": {
+          "type": "string",
+          "format": "uuid"
+        },
+        "opportunity_id": {
+          "type": "string",
+          "format": "uuid"
+        },
+        "title": {
+          "type": "string",
+          "minLength": 1
+        },
+        "notes": {
+          "type": "string"
+        },
+        "duration": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "start_time": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "end_time": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "interaction_date": {
+          "type": "string",
+          "format": "date-time"
+        }
+      },
+      "required": [
+        "type_id"
+      ]
+    },
+    "responseBodySchema": {
+      "type": "object",
+      "properties": {
+        "data": {
+          "type": "object",
+          "properties": {
+            "tenant": {
+              "type": "string",
+              "format": "uuid"
+            },
+            "interaction_id": {
+              "type": "string",
+              "format": "uuid"
+            },
+            "type_id": {
+              "type": "string",
+              "format": "uuid"
+            },
+            "type_name": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "icon": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "contact_name_id": {
+              "type": [
+                "string",
+                "null"
+              ],
+              "format": "uuid"
+            },
+            "contact_name": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "client_id": {
+              "type": [
+                "string",
+                "null"
+              ],
+              "format": "uuid"
+            },
+            "client_name": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "user_id": {
+              "type": "string",
+              "format": "uuid"
+            },
+            "user_name": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "ticket_id": {
+              "type": [
+                "string",
+                "null"
+              ],
+              "format": "uuid"
+            },
+            "project_id": {
+              "type": [
+                "string",
+                "null"
+              ],
+              "format": "uuid"
+            },
+            "opportunity_id": {
+              "type": [
+                "string",
+                "null"
+              ],
+              "format": "uuid"
+            },
+            "title": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "notes": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "interaction_date": {
+              "anyOf": [
+                {
+                  "type": "string",
+                  "format": "date-time"
+                },
+                {
+                  "type": "string"
+                }
+              ]
+            },
+            "start_time": {
+              "anyOf": [
+                {
+                  "type": "string",
+                  "format": "date-time"
+                },
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            },
+            "end_time": {
+              "anyOf": [
+                {
+                  "type": "string",
+                  "format": "date-time"
+                },
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            },
+            "duration": {
+              "type": [
+                "integer",
+                "null"
+              ]
+            },
+            "status_id": {
+              "type": [
+                "string",
+                "null"
+              ],
+              "format": "uuid"
+            },
+            "status_name": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "is_status_closed": {
+              "type": [
+                "boolean",
+                "null"
+              ]
+            },
+            "visibility": {
+              "type": "string",
+              "enum": [
+                "internal",
+                "client_visible"
+              ]
+            }
+          },
+          "required": [
+            "tenant",
+            "interaction_id",
+            "type_id",
+            "type_name",
+            "icon",
+            "contact_name_id",
+            "contact_name",
+            "client_id",
+            "client_name",
+            "user_id",
+            "user_name",
+            "ticket_id",
+            "project_id",
+            "opportunity_id",
+            "title",
+            "notes",
+            "interaction_date",
+            "start_time",
+            "end_time",
+            "duration",
+            "status_id",
+            "status_name",
+            "is_status_closed",
+            "visibility"
+          ]
+        },
+        "meta": {
+          "type": "object",
+          "properties": {}
+        }
+      },
+      "required": [
+        "data"
+      ]
+    }
+  },
+  {
+    "id": "get-_api_v1_interactions_id",
+    "method": "get",
+    "path": "/api/v1/interactions/{id}",
+    "displayName": "Get an interaction",
+    "summary": "Get an interaction",
+    "tags": [
+      "Interactions v1"
+    ],
+    "approvalRequired": false,
+    "parameters": [
+      {
+        "name": "id",
+        "in": "path",
+        "required": true,
+        "schema": {
+          "type": "string",
+          "format": "uuid"
+        }
+      }
+    ],
+    "responseBodySchema": {
+      "type": "object",
+      "properties": {
+        "data": {
+          "type": "object",
+          "properties": {
+            "tenant": {
+              "type": "string",
+              "format": "uuid"
+            },
+            "interaction_id": {
+              "type": "string",
+              "format": "uuid"
+            },
+            "type_id": {
+              "type": "string",
+              "format": "uuid"
+            },
+            "type_name": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "icon": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "contact_name_id": {
+              "type": [
+                "string",
+                "null"
+              ],
+              "format": "uuid"
+            },
+            "contact_name": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "client_id": {
+              "type": [
+                "string",
+                "null"
+              ],
+              "format": "uuid"
+            },
+            "client_name": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "user_id": {
+              "type": "string",
+              "format": "uuid"
+            },
+            "user_name": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "ticket_id": {
+              "type": [
+                "string",
+                "null"
+              ],
+              "format": "uuid"
+            },
+            "project_id": {
+              "type": [
+                "string",
+                "null"
+              ],
+              "format": "uuid"
+            },
+            "opportunity_id": {
+              "type": [
+                "string",
+                "null"
+              ],
+              "format": "uuid"
+            },
+            "title": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "notes": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "interaction_date": {
+              "anyOf": [
+                {
+                  "type": "string",
+                  "format": "date-time"
+                },
+                {
+                  "type": "string"
+                }
+              ]
+            },
+            "start_time": {
+              "anyOf": [
+                {
+                  "type": "string",
+                  "format": "date-time"
+                },
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            },
+            "end_time": {
+              "anyOf": [
+                {
+                  "type": "string",
+                  "format": "date-time"
+                },
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            },
+            "duration": {
+              "type": [
+                "integer",
+                "null"
+              ]
+            },
+            "status_id": {
+              "type": [
+                "string",
+                "null"
+              ],
+              "format": "uuid"
+            },
+            "status_name": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "is_status_closed": {
+              "type": [
+                "boolean",
+                "null"
+              ]
+            },
+            "visibility": {
+              "type": "string",
+              "enum": [
+                "internal",
+                "client_visible"
+              ]
+            }
+          },
+          "required": [
+            "tenant",
+            "interaction_id",
+            "type_id",
+            "type_name",
+            "icon",
+            "contact_name_id",
+            "contact_name",
+            "client_id",
+            "client_name",
+            "user_id",
+            "user_name",
+            "ticket_id",
+            "project_id",
+            "opportunity_id",
+            "title",
+            "notes",
+            "interaction_date",
+            "start_time",
+            "end_time",
+            "duration",
+            "status_id",
+            "status_name",
+            "is_status_closed",
+            "visibility"
+          ]
+        },
+        "meta": {
+          "type": "object",
+          "properties": {}
+        }
+      },
+      "required": [
+        "data"
+      ]
+    }
+  },
+  {
+    "id": "get-_api_v1_interactiontypes",
+    "method": "get",
+    "path": "/api/v1/interaction-types",
+    "displayName": "List interaction types",
+    "summary": "List interaction types",
+    "description": "Returns the union of system and tenant-defined interaction types.",
+    "tags": [
+      "Interactions v1"
+    ],
+    "approvalRequired": false,
+    "parameters": [],
+    "responseBodySchema": {
+      "type": "object",
+      "properties": {
+        "data": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "type_id": {
+                "type": "string",
+                "format": "uuid"
+              },
+              "type_name": {
+                "type": "string"
+              },
+              "icon": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "is_system": {
+                "type": "boolean"
+              }
+            },
+            "required": [
+              "type_id",
+              "type_name",
+              "icon",
+              "is_system"
+            ]
+          }
+        },
+        "meta": {
+          "type": "object",
+          "properties": {}
+        }
+      },
+      "required": [
+        "data"
+      ]
+    }
+  },
+  {
+    "id": "get-_api_v1_inventory_lookup",
+    "method": "get",
+    "path": "/api/v1/inventory/lookup",
+    "displayName": "Look up an inventory barcode or identifier",
+    "summary": "Look up an inventory barcode or identifier",
+    "tags": [
+      "Inventory v1"
+    ],
+    "approvalRequired": false,
+    "parameters": [
+      {
+        "name": "code",
+        "in": "query",
+        "required": true,
+        "schema": {
+          "type": "string",
+          "minLength": 1
+        }
+      }
+    ],
+    "responseBodySchema": {
+      "type": "object",
+      "properties": {
+        "data": {}
+      }
+    }
+  },
+  {
+    "id": "get-_api_v1_inventory_stock",
+    "method": "get",
+    "path": "/api/v1/inventory/stock",
+    "displayName": "List stock levels",
+    "summary": "List stock levels",
+    "tags": [
+      "Inventory v1"
+    ],
+    "approvalRequired": false,
+    "parameters": [
+      {
+        "name": "page",
+        "in": "query",
+        "required": false,
+        "schema": {
+          "type": "integer",
+          "minimum": 1
+        }
+      },
+      {
+        "name": "limit",
+        "in": "query",
+        "required": false,
+        "schema": {
+          "type": "integer",
+          "minimum": 1,
+          "maximum": 100
+        }
+      },
+      {
+        "name": "search",
+        "in": "query",
+        "required": false,
+        "schema": {
+          "type": "string"
+        }
+      },
+      {
+        "name": "status",
+        "in": "query",
+        "required": false,
+        "schema": {
+          "type": "string"
+        }
+      },
+      {
+        "name": "location_id",
+        "in": "query",
+        "required": false,
+        "schema": {
+          "type": "string",
+          "format": "uuid"
+        }
+      },
+      {
+        "name": "service_id",
+        "in": "query",
+        "required": false,
+        "schema": {
+          "type": "string",
+          "format": "uuid"
+        }
+      },
+      {
+        "name": "client_id",
+        "in": "query",
+        "required": false,
+        "schema": {
+          "type": "string",
+          "format": "uuid"
+        }
+      },
+      {
+        "name": "low_stock",
+        "in": "query",
+        "required": false,
+        "schema": {
+          "type": "string",
+          "enum": [
+            "true",
+            "false"
+          ]
+        }
+      }
+    ],
+    "responseBodySchema": {
+      "type": "object",
+      "properties": {
+        "data": {}
+      }
+    }
+  },
+  {
+    "id": "get-_api_v1_inventory_stocklocations",
+    "method": "get",
+    "path": "/api/v1/inventory/stock-locations",
+    "displayName": "List stock locations",
+    "summary": "List stock locations",
+    "tags": [
+      "Inventory v1"
+    ],
+    "approvalRequired": false,
+    "parameters": [],
+    "responseBodySchema": {
+      "type": "object",
+      "properties": {
+        "data": {}
+      }
+    }
+  },
+  {
+    "id": "get-_api_v1_inventory_units",
+    "method": "get",
+    "path": "/api/v1/inventory/units",
+    "displayName": "List serialized stock units",
+    "summary": "List serialized stock units",
+    "tags": [
+      "Inventory v1"
+    ],
+    "approvalRequired": false,
+    "parameters": [
+      {
+        "name": "page",
+        "in": "query",
+        "required": false,
+        "schema": {
+          "type": "integer",
+          "minimum": 1
+        }
+      },
+      {
+        "name": "limit",
+        "in": "query",
+        "required": false,
+        "schema": {
+          "type": "integer",
+          "minimum": 1,
+          "maximum": 100
+        }
+      },
+      {
+        "name": "search",
+        "in": "query",
+        "required": false,
+        "schema": {
+          "type": "string"
+        }
+      },
+      {
+        "name": "status",
+        "in": "query",
+        "required": false,
+        "schema": {
+          "type": "string"
+        }
+      },
+      {
+        "name": "location_id",
+        "in": "query",
+        "required": false,
+        "schema": {
+          "type": "string",
+          "format": "uuid"
+        }
+      },
+      {
+        "name": "service_id",
+        "in": "query",
+        "required": false,
+        "schema": {
+          "type": "string",
+          "format": "uuid"
+        }
+      },
+      {
+        "name": "client_id",
+        "in": "query",
+        "required": false,
+        "schema": {
+          "type": "string",
+          "format": "uuid"
+        }
+      },
+      {
+        "name": "low_stock",
+        "in": "query",
+        "required": false,
+        "schema": {
+          "type": "string",
+          "enum": [
+            "true",
+            "false"
+          ]
+        }
+      }
+    ],
+    "responseBodySchema": {
+      "type": "object",
+      "properties": {
+        "data": {}
+      }
+    }
+  },
+  {
+    "id": "get-_api_v1_inventory_units_unitid",
+    "method": "get",
+    "path": "/api/v1/inventory/units/{unitId}",
+    "displayName": "Get a serialized stock unit",
+    "summary": "Get a serialized stock unit",
+    "tags": [
+      "Inventory v1"
+    ],
+    "approvalRequired": false,
+    "parameters": [
+      {
+        "name": "unitId",
+        "in": "path",
+        "required": true,
+        "schema": {
+          "type": "string",
+          "format": "uuid"
+        }
+      }
+    ],
+    "responseBodySchema": {
+      "type": "object",
+      "properties": {
+        "data": {}
+      }
+    }
+  },
+  {
+    "id": "post-_api_v1_inventory_receipts",
+    "method": "post",
+    "path": "/api/v1/inventory/receipts",
+    "displayName": "Receive stock manually",
+    "summary": "Receive stock manually",
+    "tags": [
+      "Inventory v1"
+    ],
+    "approvalRequired": false,
+    "parameters": [],
+    "requestBodySchema": {
+      "type": "object",
+      "additionalProperties": {}
+    },
+    "responseBodySchema": {
+      "type": "object",
+      "properties": {
+        "data": {}
+      }
+    }
+  },
+  {
+    "id": "post-_api_v1_inventory_adjustments",
+    "method": "post",
+    "path": "/api/v1/inventory/adjustments",
+    "displayName": "Adjust stock",
+    "summary": "Adjust stock",
+    "tags": [
+      "Inventory v1"
+    ],
+    "approvalRequired": false,
+    "parameters": [],
+    "requestBodySchema": {
+      "type": "object",
+      "additionalProperties": {}
+    },
+    "responseBodySchema": {
+      "type": "object",
+      "properties": {
+        "data": {}
+      }
+    }
+  },
+  {
+    "id": "get-_api_v1_inventory_counts",
+    "method": "get",
+    "path": "/api/v1/inventory/counts",
+    "displayName": "List cycle count sessions",
+    "summary": "List cycle count sessions",
+    "tags": [
+      "Inventory v1"
+    ],
+    "approvalRequired": false,
+    "parameters": [
+      {
+        "name": "page",
+        "in": "query",
+        "required": false,
+        "schema": {
+          "type": "integer",
+          "minimum": 1
+        }
+      },
+      {
+        "name": "limit",
+        "in": "query",
+        "required": false,
+        "schema": {
+          "type": "integer",
+          "minimum": 1,
+          "maximum": 100
+        }
+      },
+      {
+        "name": "search",
+        "in": "query",
+        "required": false,
+        "schema": {
+          "type": "string"
+        }
+      },
+      {
+        "name": "status",
+        "in": "query",
+        "required": false,
+        "schema": {
+          "type": "string"
+        }
+      },
+      {
+        "name": "location_id",
+        "in": "query",
+        "required": false,
+        "schema": {
+          "type": "string",
+          "format": "uuid"
+        }
+      },
+      {
+        "name": "service_id",
+        "in": "query",
+        "required": false,
+        "schema": {
+          "type": "string",
+          "format": "uuid"
+        }
+      },
+      {
+        "name": "client_id",
+        "in": "query",
+        "required": false,
+        "schema": {
+          "type": "string",
+          "format": "uuid"
+        }
+      },
+      {
+        "name": "low_stock",
+        "in": "query",
+        "required": false,
+        "schema": {
+          "type": "string",
+          "enum": [
+            "true",
+            "false"
+          ]
+        }
+      }
+    ],
+    "responseBodySchema": {
+      "type": "object",
+      "properties": {
+        "data": {}
+      }
+    }
+  },
+  {
+    "id": "post-_api_v1_inventory_counts",
+    "method": "post",
+    "path": "/api/v1/inventory/counts",
+    "displayName": "Start a cycle count session",
+    "summary": "Start a cycle count session",
+    "tags": [
+      "Inventory v1"
+    ],
+    "approvalRequired": false,
+    "parameters": [],
+    "requestBodySchema": {
+      "type": "object",
+      "additionalProperties": {}
+    },
+    "responseBodySchema": {
+      "type": "object",
+      "properties": {
+        "data": {}
+      }
+    }
+  },
+  {
+    "id": "get-_api_v1_inventory_counts_sessionid",
+    "method": "get",
+    "path": "/api/v1/inventory/counts/{sessionId}",
+    "displayName": "Get a cycle count session",
+    "summary": "Get a cycle count session",
+    "tags": [
+      "Inventory v1"
+    ],
+    "approvalRequired": false,
+    "parameters": [
+      {
+        "name": "sessionId",
+        "in": "path",
+        "required": true,
+        "schema": {
+          "type": "string",
+          "format": "uuid"
+        }
+      }
+    ],
+    "responseBodySchema": {
+      "type": "object",
+      "properties": {
+        "data": {}
+      }
+    }
+  },
+  {
+    "id": "post-_api_v1_inventory_counts_sessionid_records",
+    "method": "post",
+    "path": "/api/v1/inventory/counts/{sessionId}/records",
+    "displayName": "Record a cycle count quantity",
+    "summary": "Record a cycle count quantity",
+    "tags": [
+      "Inventory v1"
+    ],
+    "approvalRequired": false,
+    "parameters": [
+      {
+        "name": "sessionId",
+        "in": "path",
+        "required": true,
+        "schema": {
+          "type": "string",
+          "format": "uuid"
+        }
+      }
+    ],
+    "requestBodySchema": {
+      "type": "object",
+      "additionalProperties": {}
+    },
+    "responseBodySchema": {
+      "type": "object",
+      "properties": {
+        "data": {}
+      }
+    }
+  },
+  {
+    "id": "post-_api_v1_inventory_counts_sessionid_submit",
+    "method": "post",
+    "path": "/api/v1/inventory/counts/{sessionId}/submit",
+    "displayName": "Submit a cycle count session",
+    "summary": "Submit a cycle count session",
+    "tags": [
+      "Inventory v1"
+    ],
+    "approvalRequired": false,
+    "parameters": [
+      {
+        "name": "sessionId",
+        "in": "path",
+        "required": true,
+        "schema": {
+          "type": "string",
+          "format": "uuid"
+        }
+      }
+    ],
+    "responseBodySchema": {
+      "type": "object",
+      "properties": {
+        "data": {}
+      }
+    }
+  },
+  {
+    "id": "get-_api_v1_inventory_purchaseorders",
+    "method": "get",
+    "path": "/api/v1/inventory/purchase-orders",
+    "displayName": "List purchase orders",
+    "summary": "List purchase orders",
+    "tags": [
+      "Inventory v1"
+    ],
+    "approvalRequired": false,
+    "parameters": [
+      {
+        "name": "page",
+        "in": "query",
+        "required": false,
+        "schema": {
+          "type": "integer",
+          "minimum": 1
+        }
+      },
+      {
+        "name": "limit",
+        "in": "query",
+        "required": false,
+        "schema": {
+          "type": "integer",
+          "minimum": 1,
+          "maximum": 100
+        }
+      },
+      {
+        "name": "search",
+        "in": "query",
+        "required": false,
+        "schema": {
+          "type": "string"
+        }
+      },
+      {
+        "name": "status",
+        "in": "query",
+        "required": false,
+        "schema": {
+          "type": "string"
+        }
+      },
+      {
+        "name": "location_id",
+        "in": "query",
+        "required": false,
+        "schema": {
+          "type": "string",
+          "format": "uuid"
+        }
+      },
+      {
+        "name": "service_id",
+        "in": "query",
+        "required": false,
+        "schema": {
+          "type": "string",
+          "format": "uuid"
+        }
+      },
+      {
+        "name": "client_id",
+        "in": "query",
+        "required": false,
+        "schema": {
+          "type": "string",
+          "format": "uuid"
+        }
+      },
+      {
+        "name": "low_stock",
+        "in": "query",
+        "required": false,
+        "schema": {
+          "type": "string",
+          "enum": [
+            "true",
+            "false"
+          ]
+        }
+      }
+    ],
+    "responseBodySchema": {
+      "type": "object",
+      "properties": {
+        "data": {}
+      }
+    }
+  },
+  {
+    "id": "get-_api_v1_inventory_purchaseorders_poid",
+    "method": "get",
+    "path": "/api/v1/inventory/purchase-orders/{poId}",
+    "displayName": "Get a purchase order",
+    "summary": "Get a purchase order",
+    "tags": [
+      "Inventory v1"
+    ],
+    "approvalRequired": false,
+    "parameters": [
+      {
+        "name": "poId",
+        "in": "path",
+        "required": true,
+        "schema": {
+          "type": "string",
+          "format": "uuid"
+        }
+      }
+    ],
+    "responseBodySchema": {
+      "type": "object",
+      "properties": {
+        "data": {}
+      }
+    }
+  },
+  {
+    "id": "post-_api_v1_inventory_purchaseorders_poid_lines_lineid_receive",
+    "method": "post",
+    "path": "/api/v1/inventory/purchase-orders/{poId}/lines/{lineId}/receive",
+    "displayName": "Receive a purchase-order line",
+    "summary": "Receive a purchase-order line",
+    "tags": [
+      "Inventory v1"
+    ],
+    "approvalRequired": false,
+    "parameters": [
+      {
+        "name": "poId",
+        "in": "path",
+        "required": true,
+        "schema": {
+          "type": "string",
+          "format": "uuid"
+        }
+      },
+      {
+        "name": "lineId",
+        "in": "path",
+        "required": true,
+        "schema": {
+          "type": "string",
+          "format": "uuid"
+        }
+      }
+    ],
+    "requestBodySchema": {
+      "type": "object",
+      "additionalProperties": {}
+    },
+    "responseBodySchema": {
+      "type": "object",
+      "properties": {
+        "data": {}
+      }
+    }
+  },
+  {
+    "id": "get-_api_v1_inventory_transfers",
+    "method": "get",
+    "path": "/api/v1/inventory/transfers",
+    "displayName": "List stock transfers",
+    "summary": "List stock transfers",
+    "tags": [
+      "Inventory v1"
+    ],
+    "approvalRequired": false,
+    "parameters": [
+      {
+        "name": "page",
+        "in": "query",
+        "required": false,
+        "schema": {
+          "type": "integer",
+          "minimum": 1
+        }
+      },
+      {
+        "name": "limit",
+        "in": "query",
+        "required": false,
+        "schema": {
+          "type": "integer",
+          "minimum": 1,
+          "maximum": 100
+        }
+      },
+      {
+        "name": "search",
+        "in": "query",
+        "required": false,
+        "schema": {
+          "type": "string"
+        }
+      },
+      {
+        "name": "status",
+        "in": "query",
+        "required": false,
+        "schema": {
+          "type": "string"
+        }
+      },
+      {
+        "name": "location_id",
+        "in": "query",
+        "required": false,
+        "schema": {
+          "type": "string",
+          "format": "uuid"
+        }
+      },
+      {
+        "name": "service_id",
+        "in": "query",
+        "required": false,
+        "schema": {
+          "type": "string",
+          "format": "uuid"
+        }
+      },
+      {
+        "name": "client_id",
+        "in": "query",
+        "required": false,
+        "schema": {
+          "type": "string",
+          "format": "uuid"
+        }
+      },
+      {
+        "name": "low_stock",
+        "in": "query",
+        "required": false,
+        "schema": {
+          "type": "string",
+          "enum": [
+            "true",
+            "false"
+          ]
+        }
+      }
+    ],
+    "responseBodySchema": {
+      "type": "object",
+      "properties": {
+        "data": {}
+      }
+    }
+  },
+  {
+    "id": "post-_api_v1_inventory_transfers_transferid_receive",
+    "method": "post",
+    "path": "/api/v1/inventory/transfers/{transferId}/receive",
+    "displayName": "Receive a stock transfer",
+    "summary": "Receive a stock transfer",
+    "tags": [
+      "Inventory v1"
+    ],
+    "approvalRequired": false,
+    "parameters": [
+      {
+        "name": "transferId",
+        "in": "path",
+        "required": true,
+        "schema": {
+          "type": "string",
+          "format": "uuid"
+        }
+      }
+    ],
+    "responseBodySchema": {
+      "type": "object",
+      "properties": {
+        "data": {}
+      }
+    }
+  },
+  {
+    "id": "get-_api_v1_mobile_me_capabilities",
+    "method": "get",
+    "path": "/api/v1/mobile/me/capabilities",
+    "displayName": "Get current mobile feature capabilities",
+    "summary": "Get current mobile feature capabilities",
+    "description": "Returns tenant-product and RBAC-derived mobile feature availability for the authenticated API-key user.",
+    "tags": [
+      "Mobile v1"
+    ],
+    "approvalRequired": false,
+    "parameters": [],
+    "responseBodySchema": {
+      "type": "object",
+      "properties": {
+        "data": {
+          "type": "object",
+          "properties": {
+            "features": {
+              "type": "object",
+              "properties": {
+                "inventory": {
+                  "type": "boolean"
+                },
+                "opportunities": {
+                  "type": "boolean"
+                }
+              },
+              "required": [
+                "inventory",
+                "opportunities"
+              ]
+            }
+          },
+          "required": [
+            "features"
+          ]
+        }
+      },
+      "required": [
+        "data"
+      ]
+    }
   },
   {
     "id": "post-_api_v1_featureaccess",

--- a/server/src/test/e2e/api/tickets.e2e.test.ts
+++ b/server/src/test/e2e/api/tickets.e2e.test.ts
@@ -1,8 +1,9 @@
 import { describe, it, expect, beforeEach, afterEach, beforeAll } from 'vitest';
 import { tenantDb } from '@alga-psa/db';
-import { 
-  setupE2ETestEnvironment, 
-  E2ETestEnvironment 
+import {
+  setupE2ETestEnvironment,
+  createTestUserWithPermissions,
+  E2ETestEnvironment
 } from '../utils/e2eTestSetup';
 import { 
   createTestTicket,
@@ -27,6 +28,9 @@ describe('Ticket API E2E Tests', () => {
   let statusIds: { open: string; inProgress: string; closed: string };
   let priorityIds: { low: string; medium: string; high: string };
   let boardId: string;
+  let secondaryUserId: string;
+  let extraAgentId: string;
+  let teamId: string;
 
   function tenantTable(table: string) {
     return tenantDb(env.db, env.tenant).table(table);
@@ -89,13 +93,32 @@ describe('Ticket API E2E Tests', () => {
     };
     
     // Priorities should already be created by setupE2ETestEnvironment
+
+    // Extra internal users + a team for the assignment / agent / team suites.
+    secondaryUserId = await createTestUserWithPermissions(env.db, env.tenant, []);
+    extraAgentId = await createTestUserWithPermissions(env.db, env.tenant, []);
+
+    teamId = uuidv4();
+    await tenantTable('teams').insert({
+      tenant: env.tenant,
+      team_id: teamId,
+      team_name: `Test Team ${teamId}`,
+      manager_id: env.userId
+    });
+    await tenantTable('team_members').insert([
+      { tenant: env.tenant, team_id: teamId, user_id: env.userId },
+      { tenant: env.tenant, team_id: teamId, user_id: secondaryUserId }
+    ]);
   });
 
   afterAll(async () => {
     if (env) {
       // Clean up any remaining test data - delete in order to respect foreign keys
       await tenantTable('comments').delete();
+      await tenantTable('ticket_resources').delete();
       await tenantTable('tickets').delete();
+      await tenantTable('team_members').where({ team_id: teamId }).delete();
+      await tenantTable('teams').where({ team_id: teamId }).delete();
       await env.cleanup();
     }
   });
@@ -737,6 +760,267 @@ describe('Ticket API E2E Tests', () => {
       assertSuccess(response);
 
       expect(response.data.data.assigned_to).toBeNull();
+    });
+
+    // Regression for #3025: ticket_resources holds an FK on
+    // (tenant, ticket_id, assigned_to), so a ticket with additional agents used
+    // to reject every reassignment with 400 "Invalid reference".
+    it('should reassign a ticket that has additional agents', async () => {
+      await env.apiClient.put(
+        `${API_BASE}/${testTicket.ticket_id}/assignment`,
+        { assigned_to: env.userId }
+      );
+      await tenantTable('ticket_resources').insert({
+        tenant: env.tenant,
+        ticket_id: testTicket.ticket_id,
+        assigned_to: env.userId,
+        additional_user_id: extraAgentId,
+        role: 'support',
+        assigned_at: new Date()
+      });
+
+      const response = await env.apiClient.put(
+        `${API_BASE}/${testTicket.ticket_id}/assignment`,
+        { assigned_to: secondaryUserId }
+      );
+      assertSuccess(response);
+
+      expect(response.data.data.assigned_to).toBe(secondaryUserId);
+      const resources = await tenantTable('ticket_resources')
+        .where({ ticket_id: testTicket.ticket_id })
+        .select('*');
+      expect(resources).toHaveLength(1);
+      expect(resources[0].assigned_to).toBe(secondaryUserId);
+      expect(resources[0].additional_user_id).toBe(extraAgentId);
+      expect(resources[0].role).toBe('support');
+    });
+
+    it('should absorb an additional agent who becomes the primary assignee', async () => {
+      await env.apiClient.put(
+        `${API_BASE}/${testTicket.ticket_id}/assignment`,
+        { assigned_to: env.userId }
+      );
+      await tenantTable('ticket_resources').insert({
+        tenant: env.tenant,
+        ticket_id: testTicket.ticket_id,
+        assigned_to: env.userId,
+        additional_user_id: secondaryUserId,
+        role: 'support',
+        assigned_at: new Date()
+      });
+
+      const response = await env.apiClient.put(
+        `${API_BASE}/${testTicket.ticket_id}/assignment`,
+        { assigned_to: secondaryUserId }
+      );
+      assertSuccess(response);
+
+      expect(response.data.data.assigned_to).toBe(secondaryUserId);
+      const resources = await tenantTable('ticket_resources')
+        .where({ ticket_id: testTicket.ticket_id })
+        .select('*');
+      expect(resources).toHaveLength(0);
+    });
+
+    it('should reassign a ticket with additional agents via the generic update', async () => {
+      await env.apiClient.put(
+        `${API_BASE}/${testTicket.ticket_id}/assignment`,
+        { assigned_to: env.userId }
+      );
+      await tenantTable('ticket_resources').insert({
+        tenant: env.tenant,
+        ticket_id: testTicket.ticket_id,
+        assigned_to: env.userId,
+        additional_user_id: extraAgentId,
+        role: 'support',
+        assigned_at: new Date()
+      });
+
+      const response = await env.apiClient.put(
+        `${API_BASE}/${testTicket.ticket_id}`,
+        { assigned_to: secondaryUserId }
+      );
+      assertSuccess(response);
+
+      expect(response.data.data.assigned_to).toBe(secondaryUserId);
+      const resources = await tenantTable('ticket_resources')
+        .where({ ticket_id: testTicket.ticket_id })
+        .select('*');
+      expect(resources).toHaveLength(1);
+      expect(resources[0].assigned_to).toBe(secondaryUserId);
+    });
+  });
+
+  describe('Ticket Agents (/api/v1/tickets/:id/agents)', () => {
+    let testTicket: any;
+
+    beforeEach(async () => {
+      testTicket = await createTestTicket(env.db, env.tenant, {
+        title: 'Ticket for Agents',
+        client_id: env.clientId,
+        board_id: boardId,
+        status_id: statusIds.open,
+        priority_id: priorityIds.medium,
+        assigned_to: env.userId
+      });
+    });
+
+    it('should list the primary and additional agents', async () => {
+      await env.apiClient.post(`${API_BASE}/${testTicket.ticket_id}/agents`, {
+        user_id: extraAgentId
+      });
+
+      const response = await env.apiClient.get(`${API_BASE}/${testTicket.ticket_id}/agents`);
+      assertSuccess(response);
+
+      expect(response.data.data.primary_agent.user_id).toBe(env.userId);
+      expect(response.data.data.additional_agents).toHaveLength(1);
+      expect(response.data.data.additional_agents[0]).toMatchObject({
+        user_id: extraAgentId,
+        role: 'support'
+      });
+    });
+
+    it('should add an additional agent with an explicit role', async () => {
+      const response = await env.apiClient.post(
+        `${API_BASE}/${testTicket.ticket_id}/agents`,
+        { user_id: extraAgentId, role: 'reviewer' }
+      );
+      assertSuccess(response, 201);
+
+      expect(response.data.data.additional_agents[0]).toMatchObject({
+        user_id: extraAgentId,
+        role: 'reviewer'
+      });
+      const resources = await tenantTable('ticket_resources')
+        .where({ ticket_id: testTicket.ticket_id })
+        .select('*');
+      expect(resources).toHaveLength(1);
+      expect(resources[0].assigned_to).toBe(env.userId);
+    });
+
+    it('should reject a duplicate additional agent', async () => {
+      await env.apiClient.post(`${API_BASE}/${testTicket.ticket_id}/agents`, {
+        user_id: extraAgentId
+      });
+
+      const response = await env.apiClient.post(
+        `${API_BASE}/${testTicket.ticket_id}/agents`,
+        { user_id: extraAgentId }
+      );
+      assertError(response, 409);
+    });
+
+    it('should promote the user to primary agent on an unassigned ticket', async () => {
+      const unassigned = await createTestTicket(env.db, env.tenant, {
+        title: 'Unassigned ticket for agents',
+        client_id: env.clientId,
+        board_id: boardId,
+        status_id: statusIds.open,
+        priority_id: priorityIds.medium
+      });
+
+      const response = await env.apiClient.post(
+        `${API_BASE}/${unassigned.ticket_id}/agents`,
+        { user_id: extraAgentId }
+      );
+      assertSuccess(response, 201);
+
+      expect(response.data.data.primary_agent.user_id).toBe(extraAgentId);
+      expect(response.data.data.additional_agents).toHaveLength(0);
+    });
+
+    it('should remove an additional agent by user id', async () => {
+      await env.apiClient.post(`${API_BASE}/${testTicket.ticket_id}/agents`, {
+        user_id: extraAgentId
+      });
+
+      const response = await env.apiClient.delete(
+        `${API_BASE}/${testTicket.ticket_id}/agents/${extraAgentId}`
+      );
+      expect(response.status).toBe(204);
+
+      const list = await env.apiClient.get(`${API_BASE}/${testTicket.ticket_id}/agents`);
+      expect(list.data.data.additional_agents).toHaveLength(0);
+    });
+
+    it('should return 404 when removing a user who is not an additional agent', async () => {
+      const response = await env.apiClient.delete(
+        `${API_BASE}/${testTicket.ticket_id}/agents/${extraAgentId}`
+      );
+      assertError(response, 404);
+    });
+  });
+
+  describe('Ticket Team Assignment (/api/v1/tickets/:id/team)', () => {
+    let testTicket: any;
+
+    beforeEach(async () => {
+      testTicket = await createTestTicket(env.db, env.tenant, {
+        title: 'Ticket for Team Assignment',
+        client_id: env.clientId,
+        board_id: boardId,
+        status_id: statusIds.open,
+        priority_id: priorityIds.medium
+      });
+    });
+
+    it('should assign a team, defaulting the primary agent to the team lead', async () => {
+      const response = await env.apiClient.put(
+        `${API_BASE}/${testTicket.ticket_id}/team`,
+        { team_id: teamId }
+      );
+      assertSuccess(response);
+
+      expect(response.data.data.assigned_team_id).toBe(teamId);
+      expect(response.data.data.assigned_to).toBe(env.userId);
+
+      const resources = await tenantTable('ticket_resources')
+        .where({ ticket_id: testTicket.ticket_id })
+        .select('*');
+      expect(resources).toHaveLength(1);
+      expect(resources[0]).toMatchObject({
+        assigned_to: env.userId,
+        additional_user_id: secondaryUserId,
+        role: 'team_member'
+      });
+    });
+
+    it('should remove the team and its team members by default', async () => {
+      await env.apiClient.put(`${API_BASE}/${testTicket.ticket_id}/team`, { team_id: teamId });
+
+      const response = await env.apiClient.delete(`${API_BASE}/${testTicket.ticket_id}/team`);
+      assertSuccess(response);
+
+      expect(response.data.data.assigned_team_id).toBeNull();
+      const resources = await tenantTable('ticket_resources')
+        .where({ ticket_id: testTicket.ticket_id })
+        .select('*');
+      expect(resources).toHaveLength(0);
+    });
+
+    it('should keep the team members when mode is keep_all', async () => {
+      await env.apiClient.put(`${API_BASE}/${testTicket.ticket_id}/team`, { team_id: teamId });
+
+      const response = await env.apiClient.delete(
+        `${API_BASE}/${testTicket.ticket_id}/team`,
+        { data: { mode: 'keep_all' } }
+      );
+      assertSuccess(response);
+
+      expect(response.data.data.assigned_team_id).toBeNull();
+      const resources = await tenantTable('ticket_resources')
+        .where({ ticket_id: testTicket.ticket_id })
+        .select('*');
+      expect(resources).toHaveLength(1);
+    });
+
+    it('should return 404 for an unknown team', async () => {
+      const response = await env.apiClient.put(
+        `${API_BASE}/${testTicket.ticket_id}/team`,
+        { team_id: uuidv4() }
+      );
+      assertError(response, 404);
     });
   });
 


### PR DESCRIPTION
## Summary

This change enables REST API clients to manage ticket assignments at parity with existing server actions. We extract ticket assignment logic (`addTicketResource`, `assignTeamToTicket`, etc.) into reusable core modules that both server actions and REST endpoints can call, ensuring identical behavior across integration paths. Additionally, we fix a regression where API-driven ticket reassignments would fail with FK constraint violations when a ticket already had additional agents assigned.

## Changes

### Core Modules (Shared by Actions & API)
- **`ticketResourceCore.ts`**: Extracted `addTicketResourceCore`, `removeTicketResourceCore`, and `getTicketResourcesCore` to handle additional agent management—including promote-to-primary logic, duplicate detection, and event publishing
- **`teamAssignmentCore.ts`**: Extracted `assignTeamToTicketCore` and `removeTeamFromTicketCore` to manage team assignments, including team-lead fallback and flexible resource retention modes
- **`reassignTicketResources.ts`**: Extracted resource re-keying logic (`prepareTicketResourceReassignment`) to handle the FK constraint dance when primary assignees change; server actions already used this, now REST paths do too

### REST Endpoints
- **`GET /api/v1/tickets/{id}/agents`**: List the primary agent and all additional agents
- **`POST /api/v1/tickets/{id}/agents`**: Add an additional agent (with optional role override); returns updated agent list
- **`DELETE /api/v1/tickets/{id}/agents/{userId}`**: Remove an additional agent
- **`PUT /api/v1/tickets/{id}/team`**: Assign or change a ticket's team assignment
- **`DELETE /api/v1/tickets/{id}/team`**: Clear team assignment (with optional selective resource retention)

### Refactoring
- **Server actions** (`teamAssignmentActions.ts`, `ticketResourceActions.ts`, `ticketActions.ts`): Now thin permission-checking wrappers that delegate to core modules
- **API controller** (`ApiTicketController.ts`): Implements the five new endpoints, reusing core logic and schemas
- **Schemas**: Added `addTicketAgentSchema`, `assignTicketTeamSchema`, and `removeTicketTeamSchema`

### Bug Fix
Tickets with additional agents can now be reassigned via both REST API and assignment endpoints; `prepareTicketResourceReassignment` is invoked inside the update transaction to clear and re-key resources against the new primary assignee before the FK-constrained update.

### Testing
- **Unit tests** for core modules: `ticketResourceCore.test.ts`, `teamAssignmentCore.test.ts`, `reassignTicketResources.test.ts` cover promote-to-primary, duplicates, resource re-keying, selective team-member retention, and absorption of promotees
- **E2E API tests**: Coverage for ticket reassignment with existing agents, agent list retrieval, adding/removing agents with custom roles, team assignment modes, and edge cases (absorbing additional agents who become primary, generic update paths)

### Documentation
- Regenerated OpenAPI specs and MCP registry to reflect new endpoints

## Testing

Unit test suite for extracted core modules passes all assignment rules, resource re-keying scenarios, and team workflows. E2E API tests validate all five new endpoints plus regression coverage for ticket reassignment with additional agents (regression for #3025).