### PR TITLE
fix(billing): resolve invoice email sender name from tenant_companies

### DIFF
--- a/packages/billing/src/actions/invoiceJobActions.ts
+++ b/packages/billing/src/actions/invoiceJobActions.ts
@@ -2,6 +2,7 @@
 
 import logger from '@alga-psa/core/logger';
 import { createTenantKnex, tenantDb } from '@alga-psa/db';
+import { fetchTenantParty } from '../lib/adapters/tenantPartyAdapter';
 import { getInvoiceForRendering } from './invoiceQueries';
 import { createPDFGenerationService } from '../services/pdfGenerationService';
 import { StorageService } from '@alga-psa/storage/StorageService';
@@ -244,8 +245,8 @@ export const getInvoiceEmailRecipientAction = withAuth(async (
 
   const fromEmail = process.env.EMAIL_FROM || 'noreply@example.com';
 
-  const tenantRecord = await tenantDb(knex, tenant).table('tenants').first();
-  const companyName = tenantRecord?.company_name || 'Your Company';
+  const tenantParty = await fetchTenantParty(knex, tenant);
+  const companyName = tenantParty?.name || 'Your Company';
 
   for (const invoiceId of invoiceIds) {
     try {
@@ -452,8 +453,8 @@ export const sendInvoiceEmailAction = withAuth(async (
   const pdfService = createPDFGenerationService(tenant);
   const results: SendInvoiceEmailResult[] = [];
 
-  const tenantRecord = await tenantDb(knex, tenant).table('tenants').first();
-  const companyName = tenantRecord?.company_name || 'Your Company';
+  const tenantParty = await fetchTenantParty(knex, tenant);
+  const companyName = tenantParty?.name || 'Your Company';
   const fromEmail = process.env.EMAIL_FROM || 'noreply@example.com';
 
   for (const invoiceId of invoiceIds) {

--- a/packages/notifications/src/lib/templateVariables/seed.ts
+++ b/packages/notifications/src/lib/templateVariables/seed.ts
@@ -1000,7 +1000,7 @@ export const templateVariableSeed: TemplateVariableSeedCategory[] = [
             "description": "The MSP's own company name, shown as the sender in subject, intro, and signature.",
             "example": "Contoso IT Services",
             "availability": "used",
-            "notes": "From tenants.company_name, defaults to 'Your Company'."
+            "notes": "From the tenant's default company in tenant_companies (clients.client_name), falling back to tenants.client_name, then 'Your Company'."
           },
           {
             "path": "customMessage",

--- a/server/src/lib/jobs/handlers/invoiceEmailHandler.ts
+++ b/server/src/lib/jobs/handlers/invoiceEmailHandler.ts
@@ -8,8 +8,8 @@ import { getConnection } from 'server/src/lib/db/db';
 import { JobStatus } from 'server/src/types/job';
 import { getInvoiceForRendering } from '@alga-psa/billing/actions/invoiceQueries';
 import { getInvoicePaymentLinkUrlForEmail } from '@alga-psa/billing/actions/paymentActions';
+import { fetchTenantParty } from '@alga-psa/billing/lib/adapters/tenantPartyAdapter';
 import logger from '@alga-psa/core/logger';
-import { tenantDb } from '@alga-psa/db';
 import { getErrorMessage, isActionMessageError, isActionPermissionError } from '@alga-psa/ui/lib/errorHandling';
 
 /**
@@ -18,9 +18,8 @@ import { getErrorMessage, isActionMessageError, isActionPermissionError } from '
 async function getTenantCompanyName(tenantId: string): Promise<string> {
   try {
     const knex = await getConnection();
-    const tenant = await tenantDb(knex, tenantId).table('tenants')
-      .first();
-    return tenant?.company_name || 'Your Company';
+    const party = await fetchTenantParty(knex, tenantId);
+    return party?.name || 'Your Company';
   } catch {
     return 'Your Company';
   }

--- a/server/src/test/unit/jobs/invoiceEmailHandler.test.ts
+++ b/server/src/test/unit/jobs/invoiceEmailHandler.test.ts
@@ -17,8 +17,10 @@ const mocks = vi.hoisted(() => ({
   // Clients
   getClientById: vi.fn(),
   getContactByContactNameId: vi.fn(),
-  // DB connection (tenant company name lookup)
+  // DB connection (knex passed through to fetchTenantParty)
   getConnection: vi.fn(),
+  // Tenant party (sender company name lookup)
+  fetchTenantParty: vi.fn(),
   // Billing actions
   getInvoiceForRendering: vi.fn(),
   getInvoicePaymentLinkUrlForEmail: vi.fn(),
@@ -68,6 +70,10 @@ vi.mock('@alga-psa/billing/actions/invoiceQueries', () => ({
 
 vi.mock('@alga-psa/billing/actions/paymentActions', () => ({
   getInvoicePaymentLinkUrlForEmail: mocks.getInvoicePaymentLinkUrlForEmail,
+}));
+
+vi.mock('@alga-psa/billing/lib/adapters/tenantPartyAdapter', () => ({
+  fetchTenantParty: mocks.fetchTenantParty,
 }));
 
 vi.mock('@alga-psa/core/logger', () => ({
@@ -150,12 +156,15 @@ describe('InvoiceEmailHandler', () => {
     mocks.getContactByContactNameId.mockResolvedValue(null);
     mocks.getInvoicePaymentLinkUrlForEmail.mockResolvedValue('https://pay.example/invoice-1');
 
-    // Tenant lookup used by getTenantCompanyName
-    const tenantQuery = {
-      where: vi.fn().mockReturnThis(),
-      first: vi.fn().mockResolvedValue({ tenant: TENANT, company_name: 'MSP Co' }),
-    };
-    mocks.getConnection.mockResolvedValue(vi.fn().mockReturnValue(tenantQuery));
+    // Sender company name comes from the tenant party adapter
+    mocks.getConnection.mockResolvedValue(vi.fn());
+    mocks.fetchTenantParty.mockResolvedValue({
+      name: 'MSP Co',
+      address: null,
+      email: null,
+      phone: null,
+      logo_url: null,
+    });
   });
 
   describe('input validation', () => {


### PR DESCRIPTION
## Problem
The invoice email paths read `tenants.company_name`, a column renamed to `client_name` in migration `20251003000001_company_to_client_migration.cjs`. On any migrated DB the value is always `undefined`, so every invoice email shows the fallback **"Your Company"** in subject and body regardless of the configured company name.

## Fix
Resolve the sender name through the canonical **`fetchTenantParty`** adapter (`packages/billing/src/lib/adapters/tenantPartyAdapter.ts`) — the same one invoice PDFs, quotes, and sales orders already use:

1. Tenant's default company in `tenant_companies` → `clients.client_name`
2. Fallback: `tenants.client_name`
3. Fallback: `'Your Company'`

Changed call sites:
- `packages/billing/src/actions/invoiceJobActions.ts` — `getInvoiceEmailRecipientAction` + `sendInvoiceEmailAction`
- `server/src/lib/jobs/handlers/invoiceEmailHandler.ts` — `getTenantCompanyName` (job-based sends)
- `packages/notifications/src/lib/templateVariables/seed.ts` — doc note for the `company.name` template variable