### PR TITLE
feat(credits): direct credit-grant path for Add Credit

### DIFF
--- a/packages/billing/src/actions/creditActions.ts
+++ b/packages/billing/src/actions/creditActions.ts
@@ -555,6 +555,178 @@ export const scheduledCreditBalanceValidation = withAuth(async (
     });
 });
 
+/**
+ * Resolve the expiration date for a newly issued credit: an explicit date wins;
+ * otherwise the client's billing settings (falling back to tenant defaults)
+ * decide whether and when the credit expires.
+ */
+async function resolveCreditExpirationDate(
+    trx: Knex.Transaction,
+    tenant: string,
+    clientId: string,
+    manualExpirationDate?: string
+): Promise<string | undefined> {
+    const clientSettings = await tenantScopedTable(trx, tenant, 'client_billing_settings')
+        .where({ client_id: clientId, tenant })
+        .first();
+
+    const defaultSettings = await tenantScopedTable(trx, tenant, 'default_billing_settings')
+        .first();
+
+    let isCreditExpirationEnabled = true;
+    if (typeof clientSettings?.enable_credit_expiration === 'boolean') {
+        isCreditExpirationEnabled = clientSettings.enable_credit_expiration;
+    } else if (typeof defaultSettings?.enable_credit_expiration === 'boolean') {
+        isCreditExpirationEnabled = defaultSettings.enable_credit_expiration;
+    }
+
+    if (!isCreditExpirationEnabled) {
+        return undefined;
+    }
+
+    if (manualExpirationDate) {
+        return manualExpirationDate;
+    }
+
+    let expirationDays: number | undefined;
+    if (typeof clientSettings?.credit_expiration_days === 'number') {
+        expirationDays = clientSettings.credit_expiration_days;
+    } else if (typeof defaultSettings?.credit_expiration_days === 'number') {
+        expirationDays = defaultSettings.credit_expiration_days;
+    }
+
+    if (expirationDays && expirationDays > 0) {
+        const expDate = new Date();
+        expDate.setDate(expDate.getDate() + expirationDays);
+        return expDate.toISOString();
+    }
+
+    return undefined;
+}
+
+/**
+ * Grant credit to a client directly — no invoice is created. Writes the
+ * credit_issuance transaction, the credit_tracking entry, and the client's
+ * credit_balance atomically, so the credit is spendable immediately.
+ */
+export const grantCredit = withAuth(async (
+    user,
+    { tenant },
+    clientId: string,
+    amount: number,
+    manualExpirationDate?: string,
+    description?: string
+): Promise<ICreditTracking | CreditActionError> => {
+    return withCreditActionErrors(async () => {
+    if (!await hasPermission(user, 'credit', 'create')) {
+        throw new Error('Permission denied: Cannot issue credits');
+    }
+
+    if (!clientId) {
+        throw new Error('Client ID is required');
+    }
+    if (!Number.isFinite(amount) || amount <= 0) {
+        throw new Error('Credit amount must be greater than zero');
+    }
+
+    const { knex } = await createTenantKnex();
+
+    const createdCredit = await withTransaction(knex, async (trx: Knex.Transaction) => {
+        const client = await tenantScopedTable(trx, tenant, 'clients')
+            .where({ client_id: clientId, tenant })
+            .first();
+        if (!client) {
+            throw new Error('Client not found');
+        }
+
+        const clientCurrency = client.default_currency_code || 'USD';
+        const expirationDate = await resolveCreditExpirationDate(trx, tenant, clientId, manualExpirationDate);
+
+        const currentBalance = await tenantScopedTable(trx, tenant, 'transactions')
+            .where({ client_id: clientId, tenant })
+            .orderBy('created_at', 'desc')
+            .first()
+            .then(lastTx => lastTx?.balance_after || 0);
+
+        const now = new Date().toISOString();
+        const transactionId = uuidv4();
+        await tenantScopedTable(trx, tenant, 'transactions').insert({
+            transaction_id: transactionId,
+            client_id: clientId,
+            amount,
+            type: 'credit_issuance',
+            status: 'completed',
+            description: description?.trim() || 'Credit granted',
+            created_at: now,
+            balance_after: currentBalance + amount,
+            tenant,
+            expiration_date: expirationDate,
+            currency_code: clientCurrency
+        });
+
+        const creditId = uuidv4();
+        const [creditTracking] = await tenantScopedTable(trx, tenant, 'credit_tracking')
+            .insert({
+                credit_id: creditId,
+                tenant,
+                client_id: clientId,
+                transaction_id: transactionId,
+                amount,
+                remaining_amount: amount,
+                created_at: now,
+                expiration_date: expirationDate,
+                is_expired: false,
+                updated_at: now,
+                currency_code: clientCurrency
+            })
+            .returning('*');
+
+        // Unlike prepayments, there is no finalize step: the balance moves now,
+        // in the same transaction as the ledger entries.
+        await tenantScopedTable(trx, tenant, 'clients')
+            .where({ client_id: clientId, tenant })
+            .increment('credit_balance', amount);
+
+        return {
+            creditTracking: {
+                ...creditTracking,
+                expiration_date: creditTracking.expiration_date ?? undefined,
+            },
+            currency: clientCurrency,
+            createdAt: now,
+        };
+    });
+
+    await publishWorkflowEvent({
+        eventType: 'CREDIT_NOTE_CREATED',
+        payload: buildCreditNoteCreatedPayload({
+            creditNoteId: createdCredit.creditTracking.credit_id,
+            clientId,
+            createdByUserId: user.user_id,
+            createdAt: createdCredit.createdAt,
+            amount,
+            currency: createdCredit.currency,
+            status: 'issued',
+            sourceDocumentKind: 'direct_grant',
+            sourceInvoiceId: null,
+            sourceInvoiceNumber: null,
+            sourceInvoiceStatus: null,
+            sourceInvoiceDateBasis: 'financial_document_date',
+            sourceServicePeriodStart: null,
+            sourceServicePeriodEnd: null,
+        }),
+        ctx: {
+            tenantId: tenant,
+            occurredAt: createdCredit.createdAt,
+            actor: { actorType: 'USER', actorUserId: user.user_id },
+        },
+        idempotencyKey: `credit_note_created:${createdCredit.creditTracking.credit_id}`,
+    });
+
+    return createdCredit.creditTracking;
+    });
+});
+
 export const createPrepaymentInvoice = withAuth(async (
     user,
     { tenant },
@@ -599,50 +771,7 @@ export const createPrepaymentInvoice = withAuth(async (
     } | null = null;
 
     const createdInvoice = await withTransaction(knex, async (trx: Knex.Transaction) => {
-        // Get client's credit expiration settings or default settings
-        const clientSettings = await tenantScopedTable(trx, tenant, 'client_billing_settings')
-            .where({
-                client_id: clientId,
-                tenant
-            })
-            .first();
-        
-        const defaultSettings = await tenantScopedTable(trx, tenant, 'default_billing_settings')
-            .first();
-        
-        // Determine if credit expiration is enabled
-        // Client setting overrides default, if not specified use default
-        let isCreditExpirationEnabled = true; // Default to true if no settings found
-        if (typeof clientSettings?.enable_credit_expiration === 'boolean') {
-            isCreditExpirationEnabled = clientSettings.enable_credit_expiration;
-        } else if (typeof defaultSettings?.enable_credit_expiration === 'boolean') {
-            isCreditExpirationEnabled = defaultSettings.enable_credit_expiration;
-        }
-        
-        // Determine expiration days - use client setting if available, otherwise use default
-        let expirationDays: number | undefined;
-        if (typeof clientSettings?.credit_expiration_days === 'number') {
-            expirationDays = clientSettings.credit_expiration_days;
-        } else if (typeof defaultSettings?.credit_expiration_days === 'number') {
-            expirationDays = defaultSettings.credit_expiration_days;
-        }
-        
-        // Calculate expiration date if applicable and if expiration is enabled
-        let expirationDate: string | undefined = manualExpirationDate;
-        console.log('createPrepaymentInvoice: Manual expiration date provided:', manualExpirationDate);
-        
-        if (isCreditExpirationEnabled && !expirationDate && expirationDays && expirationDays > 0) {
-            const today = new Date();
-            const expDate = new Date(today);
-            expDate.setDate(today.getDate() + expirationDays);
-            expirationDate = expDate.toISOString();
-            console.log('createPrepaymentInvoice: Calculated expiration date from settings:', expirationDate);
-        } else if (!isCreditExpirationEnabled) {
-            // If credit expiration is disabled, don't set an expiration date
-            expirationDate = undefined;
-            console.log('createPrepaymentInvoice: Credit expiration disabled, no expiration date set');
-        }
-        
+        const expirationDate = await resolveCreditExpirationDate(trx, tenant, clientId, manualExpirationDate);
         console.log('createPrepaymentInvoice: Final expiration date to use:', expirationDate);
 
         // Get client's currency

--- a/packages/billing/src/components/credits/AddCreditButton.tsx
+++ b/packages/billing/src/components/credits/AddCreditButton.tsx
@@ -5,6 +5,7 @@ import { useRouter } from 'next/navigation';
 import { Button } from '@alga-psa/ui/components/Button';
 import { Dialog, DialogContent, DialogFooter } from '@alga-psa/ui/components/Dialog';
 import { CurrencyInput } from '@alga-psa/ui/components/CurrencyInput';
+import { Input } from '@alga-psa/ui/components/Input';
 import { Label } from '@alga-psa/ui/components/Label';
 import { DatePicker } from '@alga-psa/ui/components/DatePicker';
 import { ClientPicker } from '@alga-psa/ui/components/ClientPicker';
@@ -14,8 +15,7 @@ import { isActionMessageError, isActionPermissionError, getErrorMessage } from '
 import { toast } from 'react-hot-toast';
 import { toMinorUnits } from '@alga-psa/core';
 import type { IClient } from '@alga-psa/types';
-import { createPrepaymentInvoice } from '@alga-psa/billing/actions/creditActions';
-import { finalizeInvoice } from '@alga-psa/billing/actions/invoiceModification';
+import { grantCredit } from '@alga-psa/billing/actions/creditActions';
 import { getAllClientsForBilling } from '@alga-psa/billing/actions/billingClientsActions';
 
 export default function AddCreditButton() {
@@ -27,6 +27,7 @@ export default function AddCreditButton() {
   const [selectedClient, setSelectedClient] = useState<string | null>(null);
   const [amount, setAmount] = useState<number | undefined>(undefined);
   const [expirationDate, setExpirationDate] = useState<Date | undefined>(undefined);
+  const [description, setDescription] = useState('');
   const [filterState, setFilterState] = useState<'all' | 'active' | 'inactive'>('active');
   const [clientTypeFilter, setClientTypeFilter] = useState<'all' | 'company' | 'individual'>('all');
   const [isSubmitting, setIsSubmitting] = useState(false);
@@ -62,6 +63,7 @@ export default function AddCreditButton() {
     setSelectedClient(null);
     setAmount(undefined);
     setExpirationDate(undefined);
+    setDescription('');
     setError(null);
   };
 
@@ -90,20 +92,14 @@ export default function AddCreditButton() {
       // The ledger stores minor units (cents); the form takes major units.
       const amountInCents = toMinorUnits(amount, i18n.language);
 
-      const invoice = await createPrepaymentInvoice(
+      const result = await grantCredit(
         selectedClient,
         amountInCents,
         expirationDate ? expirationDate.toISOString() : undefined,
+        description.trim() || undefined,
       );
-      if (isActionMessageError(invoice) || isActionPermissionError(invoice)) {
-        setError(getErrorMessage(invoice));
-        return;
-      }
-
-      // Credit only becomes available once the prepayment invoice is finalized.
-      const finalizeResult = await finalizeInvoice(invoice.invoice_id);
-      if (isActionMessageError(finalizeResult) || isActionPermissionError(finalizeResult)) {
-        setError(getErrorMessage(finalizeResult));
+      if (isActionMessageError(result) || isActionPermissionError(result)) {
+        setError(getErrorMessage(result));
         return;
       }
 
@@ -176,6 +172,18 @@ export default function AddCreditButton() {
                 value={amount}
                 onChange={setAmount}
                 placeholder={t('addCredit.placeholders.amount', { defaultValue: 'Enter amount' })}
+              />
+            </div>
+
+            <div>
+              <Input
+                id="add-credit-description"
+                label={t('addCredit.fields.description', { defaultValue: 'Description (optional)' })}
+                value={description}
+                onChange={(e) => setDescription(e.target.value)}
+                placeholder={t('addCredit.placeholders.description', {
+                  defaultValue: 'Reason for the credit',
+                })}
               />
             </div>
 

--- a/server/public/locales/en/msp/credits.json
+++ b/server/public/locales/en/msp/credits.json
@@ -193,10 +193,12 @@
     "fields": {
       "client": "Client",
       "amount": "Amount",
+      "description": "Description (optional)",
       "expirationDate": "Expiration Date (optional)"
     },
     "placeholders": {
       "amount": "Enter amount",
+      "description": "Reason for the credit",
       "expirationDate": "Select expiration date"
     },
     "hints": {

--- a/shared/workflow/streams/domainEventBuilders/creditNoteEventBuilders.ts
+++ b/shared/workflow/streams/domainEventBuilders/creditNoteEventBuilders.ts
@@ -11,7 +11,7 @@ export function buildCreditNoteCreatedPayload(params: {
   amount: number;
   currency: string;
   status: string;
-  sourceDocumentKind?: 'prepayment_invoice' | 'negative_invoice';
+  sourceDocumentKind?: 'prepayment_invoice' | 'negative_invoice' | 'direct_grant';
   sourceInvoiceId?: string | null;
   sourceInvoiceNumber?: string | null;
   sourceInvoiceStatus?: string | null;


### PR DESCRIPTION
Stacked on #3034.

## What

`Add Credit` on the credit management page previously created **and finalized a prepayment invoice** to grant a credit — an invoice the user never asked for and never saw mentioned in the dialog.

This adds a first-class direct grant path:

- **`grantCredit(clientId, amount, expirationDate?, description?)`** in `creditActions.ts`: atomically writes the `credit_issuance` transaction (no `invoice_id`), the `credit_tracking` row, and the `clients.credit_balance` increment in one DB transaction — no invoice, no finalize step, and no window where the ledger and balance disagree.
- **AddCreditButton** now calls `grantCredit` (dropping `createPrepaymentInvoice` + `finalizeInvoice`) and gains an optional description field, surfaced in the credits table.
- **`CREDIT_NOTE_CREATED` event** gains a `sourceDocumentKind: 'direct_grant'` (no source invoice fields).
- **`resolveCreditExpirationDate()`** extracts the client/default billing-settings expiration logic, shared by `grantCredit` and `createPrepaymentInvoice` (behavior unchanged, console noise removed).

Reconciliation already computes expected balance from `credit_issuance` transactions, so direct grants reconcile cleanly by construction.

`createPrepaymentInvoice` remains for genuine prepayment workflows (API route unchanged).

## Testing

- `tsc --noEmit` in `packages/billing` passes.
- Not yet exercised against a running stack.