### PR TITLE
Add print support to every report surface

### DIFF
--- a/packages/billing/src/actions/profitabilityReportActions.static.test.ts
+++ b/packages/billing/src/actions/profitabilityReportActions.static.test.ts
@@ -24,7 +24,8 @@ describe('profitability report action SQL contracts', () => {
   it('normalizes invoice currency and flags unconverted foreign revenue with null exchange rates', () => {
     expect(source).toContain('exchange_rate_basis_points');
     expect(source).toContain('ROUND((cd.amount_cents::numeric * cd.exchange_rate_basis_points::numeric) / 10000)');
-    expect(source).toContain('cd.exchange_rate_basis_points IS NULL) AS unconverted');
+    // Whitespace-tolerant: the flag spans several lines, so assert the contract, not the formatting.
+    expect(source).toMatch(/cd\.exchange_rate_basis_points IS NULL\s*\)\s*AS unconverted/);
   });
 
   it('costs labor by work_date, actual duration, resolved cost rate, and approval warning minutes', () => {

--- a/packages/billing/src/components/billing-dashboard/reports/ContractReports.tsx
+++ b/packages/billing/src/components/billing-dashboard/reports/ContractReports.tsx
@@ -26,6 +26,10 @@ import {
   BucketUsage,
   ContractReportSummary
 } from '@alga-psa/billing/actions/contractReportActions';
+import { PrintButton } from '@alga-psa/ui/components/PrintButton';
+import { PrintableDetailHeader } from '@alga-psa/ui/components/PrintableDetailHeader';
+import { PrintableSummary } from '@alga-psa/ui/components/PrintableSummary';
+import { PrintableTable, type PrintableTableColumn } from '@alga-psa/ui/components/PrintableTable';
 import { Skeleton } from '@alga-psa/ui/components/Skeleton';
 import { useFormatters, useTranslation } from '@alga-psa/ui/lib/i18n/client';
 import ProfitabilityReport from './ProfitabilityReport';
@@ -37,6 +41,22 @@ import {
 
 const isReturnedActionError = (value: unknown) =>
   isActionMessageError(value) || isActionPermissionError(value);
+
+type Translator = ReturnType<typeof useTranslation>['t'];
+
+const statusLabel = (value: string, t: Translator): string => (
+  value === 'active'
+    ? t('contractReports.statusValues.active', { defaultValue: 'Active' })
+    : value === 'upcoming'
+      ? t('contractReports.statusValues.upcoming', { defaultValue: 'Upcoming' })
+      : value.charAt(0).toUpperCase() + value.slice(1)
+);
+
+const yesNoLabel = (value: boolean, t: Translator): string => (
+  value
+    ? t('contractReports.statusValues.yes', { defaultValue: 'Yes' })
+    : t('contractReports.statusValues.no', { defaultValue: 'No' })
+);
 
 const ContractReports: React.FC = () => {
   const { t } = useTranslation('msp/reports');
@@ -135,11 +155,7 @@ const ContractReports: React.FC = () => {
             'default-muted'
           }
         >
-          {value === 'active'
-            ? t('contractReports.statusValues.active', { defaultValue: 'Active' })
-            : value === 'upcoming'
-              ? t('contractReports.statusValues.upcoming', { defaultValue: 'Upcoming' })
-              : value.charAt(0).toUpperCase() + value.slice(1)}
+          {statusLabel(value, t)}
         </Badge>
       )
     }
@@ -181,9 +197,7 @@ const ContractReports: React.FC = () => {
       dataIndex: 'auto_renew',
       render: (value: boolean) => (
         <Badge variant="secondary" className={value ? 'border-green-300 text-green-800' : 'border-[rgb(var(--color-border-300))] text-muted-foreground'}>
-          {value
-            ? t('contractReports.statusValues.yes', { defaultValue: 'Yes' })
-            : t('contractReports.statusValues.no', { defaultValue: 'No' })}
+          {yesNoLabel(value, t)}
         </Badge>
       )
     }
@@ -249,6 +263,61 @@ const ContractReports: React.FC = () => {
       )
     }
   ];
+
+  // Print columns mirror the on-screen tables but drop badges/bars and render every
+  // row — the screen tables paginate.
+  const revenuePrintColumns: PrintableTableColumn<ContractRevenue>[] = [
+    { key: 'contract', header: t('contractReports.table.contract', { defaultValue: 'Contract' }), render: (row) => row.contract_name },
+    { key: 'client', header: t('contractReports.table.client', { defaultValue: 'Client' }), render: (row) => row.client_name },
+    { key: 'mrr', header: t('contractReports.table.monthlyRecurring', { defaultValue: 'Monthly Recurring' }), render: (row) => formatCents(row.monthly_recurring) },
+    { key: 'ytd', header: t('contractReports.table.totalBilledYtd', { defaultValue: 'Total Billed (YTD)' }), render: (row) => formatCents(row.total_billed_ytd) },
+    { key: 'status', header: t('contractReports.table.status', { defaultValue: 'Status' }), render: (row) => statusLabel(row.status, t) },
+  ];
+
+  const expirationPrintColumns: PrintableTableColumn<ContractExpiration>[] = [
+    { key: 'contract', header: t('contractReports.table.contract', { defaultValue: 'Contract' }), render: (row) => row.contract_name },
+    { key: 'client', header: t('contractReports.table.client', { defaultValue: 'Client' }), render: (row) => row.client_name },
+    { key: 'endDate', header: t('contractReports.table.endDate', { defaultValue: 'End Date' }), render: (row) => formatDate(row.end_date) },
+    {
+      key: 'daysUntil',
+      header: t('contractReports.table.daysUntilExpiration', { defaultValue: 'Days Until Expiration' }),
+      render: (row) => `${row.days_until_expiration} ${t('units.days', { defaultValue: 'days' })}`,
+    },
+    { key: 'monthlyValue', header: t('contractReports.table.monthlyValue', { defaultValue: 'Monthly Value' }), render: (row) => formatCents(row.monthly_value) },
+    { key: 'autoRenew', header: t('contractReports.table.autoRenew', { defaultValue: 'Auto-Renew' }), render: (row) => yesNoLabel(row.auto_renew, t) },
+  ];
+
+  const bucketUsagePrintColumns: PrintableTableColumn<BucketUsage>[] = [
+    { key: 'contract', header: t('contractReports.table.contract', { defaultValue: 'Contract' }), render: (row) => row.contract_name },
+    { key: 'client', header: t('contractReports.table.client', { defaultValue: 'Client' }), render: (row) => row.client_name },
+    { key: 'totalHours', header: t('contractReports.table.totalHours', { defaultValue: 'Total Hours' }), render: (row) => `${row.total_hours} ${t('units.hoursShort', { defaultValue: 'hrs' })}` },
+    { key: 'usedHours', header: t('contractReports.table.usedHours', { defaultValue: 'Used Hours' }), render: (row) => `${row.used_hours} ${t('units.hoursShort', { defaultValue: 'hrs' })}` },
+    { key: 'remaining', header: t('contractReports.table.remaining', { defaultValue: 'Remaining' }), render: (row) => `${row.remaining_hours} ${t('units.hoursShort', { defaultValue: 'hrs' })}` },
+    { key: 'utilization', header: t('contractReports.table.utilization', { defaultValue: 'Utilization' }), render: (row) => `${row.utilization_percentage}${t('units.percent', { defaultValue: '%' })}` },
+    {
+      key: 'overage',
+      header: t('contractReports.table.overage', { defaultValue: 'Overage' }),
+      render: (row) => (row.overage_hours > 0
+        ? `+${row.overage_hours} ${t('units.hoursShort', { defaultValue: 'hrs' })}`
+        : t('units.dash', { defaultValue: '—' })),
+    },
+  ];
+
+  const printSummaryMetrics = [
+    { label: t('contractReports.summary.totalMRR.title', { defaultValue: 'Total MRR' }), value: formatCents(summary?.totalMRR ?? 0) },
+    { label: t('contractReports.summary.ytdRevenue.title', { defaultValue: 'YTD Revenue' }), value: formatCents(summary?.totalYTD ?? 0) },
+    { label: t('contractReports.summary.activeContracts.title', { defaultValue: 'Active Contracts' }), value: summary?.activeContractCount ?? 0 },
+    { label: t('contractReports.summary.renewalDecisions.title', { defaultValue: 'Renewal Decisions Due' }), value: summary?.atRiskDecisionCount ?? 0 },
+  ];
+
+  // Plain function, not a component: keeps the print markup out of the render tree's identity.
+  const printRoot = (id: string, title: string, subtitle: string, table: React.ReactNode) => (
+    <div className="app-print-root app-print-only" id={id}>
+      <PrintableDetailHeader title={title} subtitle={subtitle} />
+      <PrintableSummary metrics={printSummaryMetrics} />
+      {table}
+    </div>
+  );
 
   // Show loading state
   if (isLoading) {
@@ -326,15 +395,21 @@ const ContractReports: React.FC = () => {
 
   return (
     <div className="space-y-6">
-      <div>
-        <h2 className="text-2xl font-bold mb-2">
-          {t('contractReports.title', { defaultValue: 'Contract Reports' })}
-        </h2>
-        <p className="text-muted-foreground text-sm">
-          {t('contractReports.description', {
-            defaultValue: 'Analyze contract performance, revenue, and utilization metrics',
-          })}
-        </p>
+      <div className="flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
+        <div>
+          <h2 className="text-2xl font-bold mb-2">
+            {t('contractReports.title', { defaultValue: 'Contract Reports' })}
+          </h2>
+          <p className="text-muted-foreground text-sm">
+            {t('contractReports.description', {
+              defaultValue: 'Analyze contract performance, revenue, and utilization metrics',
+            })}
+          </p>
+        </div>
+        {/* Profitability carries its own print button — it owns its date filters and load state. */}
+        {activeReport !== 'profitability' && (
+          <PrintButton id="contract-reports-print" size="sm" variant="outline" />
+        )}
       </div>
 
       {/* Summary Cards */}
@@ -431,6 +506,19 @@ const ContractReports: React.FC = () => {
               />
             )}
           </Card>
+          {printRoot(
+            'contract-revenue-print',
+            t('contractReports.sections.revenue.title', { defaultValue: 'Contract Revenue Report' }),
+            t('contractReports.sections.revenue.description', {
+              defaultValue: 'Overview of monthly recurring revenue and year-to-date billed service periods by contract.',
+            }),
+            <PrintableTable
+              rows={revenueData}
+              columns={revenuePrintColumns}
+              getRowKey={(row) => `${row.contract_name}-${row.client_id ?? ''}`}
+              emptyMessage={t('contractReports.sections.revenue.empty', { defaultValue: 'No contract revenue data available' })}
+            />
+          )}
         </TabsContent>
 
         <TabsContent value="expiration" className="mt-4">
@@ -467,6 +555,21 @@ const ContractReports: React.FC = () => {
               />
             )}
           </Card>
+          {printRoot(
+            'contract-expiration-print',
+            t('contractReports.sections.expiration.title', { defaultValue: 'Contract Expiration and Renewal Decisions' }),
+            t('contractReports.sections.expiration.description', {
+              defaultValue: 'Track upcoming contract expirations and renewal decision due dates.',
+            }),
+            <PrintableTable
+              rows={expirationData}
+              columns={expirationPrintColumns}
+              getRowKey={(row) => `${row.contract_name}-${row.client_id ?? ''}-${row.end_date}`}
+              emptyMessage={t('contractReports.sections.expiration.empty', {
+                defaultValue: 'No upcoming contract expirations or renewal decisions in the near term',
+              })}
+            />
+          )}
         </TabsContent>
 
         <TabsContent value="bucket-usage" className="mt-4">
@@ -499,6 +602,19 @@ const ContractReports: React.FC = () => {
               />
             )}
           </Card>
+          {printRoot(
+            'bucket-usage-print',
+            t('contractReports.sections.bucketUsage.title', { defaultValue: 'Bucket Hours Utilization' }),
+            t('contractReports.sections.bucketUsage.description', {
+              defaultValue: 'Monitor bucket hours usage and identify overage situations',
+            }),
+            <PrintableTable
+              rows={bucketUsageData}
+              columns={bucketUsagePrintColumns}
+              getRowKey={(row) => `${row.contract_name}-${row.client_id ?? ''}`}
+              emptyMessage={t('contractReports.sections.bucketUsage.empty', { defaultValue: 'No bucket-based contracts found' })}
+            />
+          )}
         </TabsContent>
 
         <TabsContent value="profitability" className="mt-4">

--- a/packages/billing/src/components/billing-dashboard/reports/ProfitabilityReport.test.tsx
+++ b/packages/billing/src/components/billing-dashboard/reports/ProfitabilityReport.test.tsx
@@ -2,10 +2,11 @@
  * @vitest-environment jsdom
  */
 import React from 'react';
-import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { cleanup, configure, fireEvent, render, screen, waitFor, within } from '@testing-library/react';
 import '@testing-library/jest-dom';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import type { ColumnDefinition } from '@alga-psa/types';
+import { dateFromString, dateToString } from '@alga-psa/ui/lib/dateInput';
 
 const getProfitabilitySummaryMock = vi.hoisted(() => vi.fn());
 const getClientProfitabilityMock = vi.hoisted(() => vi.fn());
@@ -27,10 +28,11 @@ vi.mock('@alga-psa/ui/lib/i18n/client', () => ({
   useTranslation: () => ({ t: tMock }),
   useFormatters: () => ({
     formatCurrency: (value: number, currency: string = 'USD') => `${currency} ${value.toFixed(2)}`,
+    formatDate: (value: string) => value,
   }),
 }));
 
-vi.mock('@alga-psa/billing/actions', () => ({
+vi.mock('@alga-psa/billing/actions/profitabilityReportActions', () => ({
   getProfitabilitySummary: (...args: unknown[]) => getProfitabilitySummaryMock(...args),
   getClientProfitability: (...args: unknown[]) => getClientProfitabilityMock(...args),
   getAgreementProfitability: (...args: unknown[]) => getAgreementProfitabilityMock(...args),
@@ -94,6 +96,24 @@ vi.mock('@alga-psa/ui/components/Input', () => ({
   Input: (props: React.InputHTMLAttributes<HTMLInputElement>) => <input {...props} />,
 }));
 
+// Stands in for the real DatePicker (popover + calendar) with a plain date input,
+// speaking the same Date-in/Date-out API so the component's dateFromString/dateToString
+// bridge is still exercised.
+vi.mock('@alga-psa/ui/components/DatePicker', () => ({
+  DatePicker: ({ id, value, onChange }: {
+    id: string;
+    value?: Date;
+    onChange: (date: Date | undefined) => void;
+  }) => (
+    <input
+      id={id}
+      type="date"
+      value={value ? dateToString(value) : ''}
+      onChange={(event) => onChange(dateFromString(event.target.value))}
+    />
+  ),
+}));
+
 vi.mock('@alga-psa/ui/components/Label', () => ({
   Label: ({ children, htmlFor }: React.PropsWithChildren<{ htmlFor?: string }>) => <label htmlFor={htmlFor}>{children}</label>,
 }));
@@ -105,6 +125,10 @@ vi.mock('@alga-psa/ui/components/Skeleton', () => ({
 vi.mock('next/link', () => ({
   default: ({ children, href }: React.PropsWithChildren<{ href: string }>) => <a href={href}>{children}</a>,
 }));
+
+// The print region mirrors the report's content into the DOM (hidden by @media print
+// CSS that jsdom never applies), so keep text queries scoped to the on-screen view.
+configure({ defaultIgnore: 'script, style, .app-print-only, .app-print-only *' });
 
 const metricFields = {
   revenue: 100000,
@@ -283,13 +307,48 @@ describe('ProfitabilityReport', () => {
     expect(screen.getByText(/4 material currency mismatches/)).toBeInTheDocument();
   });
 
-  it('renders an error state when an action fails', async () => {
+  it('mirrors the report into a print region scoped to the current selection', async () => {
+    await renderReport();
+    fireEvent.click(screen.getByText('Acme Corp'));
+    await screen.findByText('Agreements for Acme Corp');
+
+    const printRegion = document.getElementById('profitability-report-print') as HTMLElement;
+    expect(printRegion).toBeInTheDocument();
+    expect(printRegion.className).toContain('app-print-root');
+
+    // This suite ignores the print region by default; opt back in to inspect it.
+    const print = (text: string) => within(printRegion).getAllByText(text, { ignore: 'script, style' });
+
+    // Header states the window and what the numbers are scoped to.
+    expect(print('2026-06-01 to 2026-06-30').length).toBe(1);
+    expect(print('Acme Corp').length).toBeGreaterThan(0);
+    expect(print('EUR').length).toBe(1);
+
+    // Drill-down levels all reach the page, not just the top table.
+    expect(print('Managed Services').length).toBeGreaterThan(0);
+    expect(print('#123 Server issue').length).toBe(1);
+    expect(print('Exact (uncosted)').length).toBe(1);
+  });
+
+  it('renders a generic error state when an action throws', async () => {
     getProfitabilitySummaryMock.mockRejectedValue(new Error('boom'));
 
     const { default: ProfitabilityReport } = await import('./ProfitabilityReport');
     render(<ProfitabilityReport />);
 
     expect(await screen.findByText('Error Loading Profitability')).toBeInTheDocument();
-    expect(screen.getByText('boom')).toBeInTheDocument();
+    // Raw exception text stays out of the UI; only the safe copy is shown.
+    expect(screen.getByText('Failed to load profitability data')).toBeInTheDocument();
+    expect(screen.queryByText('boom')).not.toBeInTheDocument();
+  });
+
+  it('surfaces the message when an action returns a user-safe error', async () => {
+    getProfitabilitySummaryMock.mockResolvedValue({ actionError: 'Cost rates are locked' });
+
+    const { default: ProfitabilityReport } = await import('./ProfitabilityReport');
+    render(<ProfitabilityReport />);
+
+    expect(await screen.findByText('Error Loading Profitability')).toBeInTheDocument();
+    expect(screen.getByText('Cost rates are locked')).toBeInTheDocument();
   });
 });

--- a/packages/billing/src/components/billing-dashboard/reports/ProfitabilityReport.tsx
+++ b/packages/billing/src/components/billing-dashboard/reports/ProfitabilityReport.tsx
@@ -11,6 +11,10 @@ import { DataTable } from '@alga-psa/ui/components/DataTable';
 import { DatePicker } from '@alga-psa/ui/components/DatePicker';
 import { dateFromString, dateToString } from '@alga-psa/ui/lib/dateInput';
 import { Label } from '@alga-psa/ui/components/Label';
+import { PrintButton } from '@alga-psa/ui/components/PrintButton';
+import { PrintableDetailHeader } from '@alga-psa/ui/components/PrintableDetailHeader';
+import { PrintableSummary } from '@alga-psa/ui/components/PrintableSummary';
+import { PrintableTable, type PrintableTableColumn } from '@alga-psa/ui/components/PrintableTable';
 import { Skeleton } from '@alga-psa/ui/components/Skeleton';
 import { useFormatters, useTranslation } from '@alga-psa/ui/lib/i18n/client';
 import type { ColumnDefinition } from '@alga-psa/types';
@@ -101,9 +105,28 @@ function rowName(row: AgreementProfitabilityRow): string {
   return row.contractName;
 }
 
+type Translator = ReturnType<typeof useTranslation>['t'];
+
+function ticketLabel(row: TicketProfitabilityRow, t: Translator): string {
+  const title = row.title || t('contractReports.profitability.fallbacks.untitledTicket', { defaultValue: 'Untitled ticket' });
+  return row.ticketNumber
+    ? t('contractReports.profitability.formats.ticketWithNumber', {
+      defaultValue: '#{{number}} {{title}}',
+      number: row.ticketNumber,
+      title,
+    })
+    : title;
+}
+
+function attributionLabel(value: TicketProfitabilityRow['attribution'], t: Translator): string {
+  if (value === 'exact') return t('contractReports.profitability.attribution.exact', { defaultValue: 'Exact' });
+  if (value === 'allocated') return t('contractReports.profitability.attribution.allocated', { defaultValue: 'Allocated' });
+  return t('contractReports.profitability.attribution.none', { defaultValue: 'None' });
+}
+
 const ProfitabilityReport: React.FC = () => {
   const { t } = useTranslation('msp/reports');
-  const { formatCurrency } = useFormatters();
+  const { formatCurrency, formatDate } = useFormatters();
   const defaultRange = useMemo(() => getLastCompleteMonthRange(), []);
   const [dateRange, setDateRange] = useState<DateRange>(defaultRange);
   const [draftRange, setDraftRange] = useState<DateRange>(defaultRange);
@@ -300,15 +323,7 @@ const ProfitabilityReport: React.FC = () => {
     dataIndex: 'title',
     render: (_value: string | null, record: TicketProfitabilityRow) => (
       <div className="flex flex-col">
-        <span className="font-medium">
-          {record.ticketNumber
-            ? t('contractReports.profitability.formats.ticketWithNumber', {
-              defaultValue: '#{{number}} {{title}}',
-              number: record.ticketNumber,
-              title: record.title || t('contractReports.profitability.fallbacks.untitledTicket', { defaultValue: 'Untitled ticket' }),
-            })
-            : record.title || t('contractReports.profitability.fallbacks.untitledTicket', { defaultValue: 'Untitled ticket' })}
-        </span>
+        <span className="font-medium">{ticketLabel(record, t)}</span>
         <span className="text-xs text-muted-foreground">
           {t('contractReports.profitability.formats.billableHours', {
             defaultValue: '{{value}} billable hrs',
@@ -327,11 +342,7 @@ const ProfitabilityReport: React.FC = () => {
       render: (value: TicketProfitabilityRow['attribution'], record: TicketProfitabilityRow) => (
         <div className="flex items-center gap-2">
           <Badge variant={value === 'exact' ? 'success' : value === 'allocated' ? 'warning' : 'secondary'}>
-            {value === 'exact'
-              ? t('contractReports.profitability.attribution.exact', { defaultValue: 'Exact' })
-              : value === 'allocated'
-                ? t('contractReports.profitability.attribution.allocated', { defaultValue: 'Allocated' })
-                : t('contractReports.profitability.attribution.none', { defaultValue: 'None' })}
+            {attributionLabel(value, t)}
           </Badge>
           {record.uncosted && (
             <Badge variant="error">
@@ -343,12 +354,131 @@ const ProfitabilityReport: React.FC = () => {
     },
   ];
 
+  // Print mirrors the on-screen drill-down, but renders every row — the screen tables paginate at 10.
+  const printMetricColumns = <T extends ProfitabilityMetricFields>(
+    nameColumn: PrintableTableColumn<T>
+  ): PrintableTableColumn<T>[] => [
+    nameColumn,
+    {
+      key: 'revenue',
+      header: t('contractReports.profitability.table.revenue', { defaultValue: 'Revenue' }),
+      render: (row) => formatCents(row.revenue),
+    },
+    {
+      key: 'laborCost',
+      header: t('contractReports.profitability.table.laborCost', { defaultValue: 'Labor Cost' }),
+      render: (row) => formatCents(row.laborCost),
+    },
+    {
+      key: 'materialCost',
+      header: t('contractReports.profitability.table.materialCost', { defaultValue: 'Material Cost' }),
+      render: (row) => formatCents(row.materialCost),
+    },
+    {
+      key: 'margin',
+      header: t('contractReports.profitability.table.margin', { defaultValue: 'Margin' }),
+      render: (row) => formatCents(row.margin),
+    },
+    {
+      key: 'marginPct',
+      header: t('contractReports.profitability.table.marginPct', { defaultValue: 'Margin %' }),
+      render: (row) => formatPercent(row.marginPct),
+    },
+    {
+      key: 'hours',
+      header: t('contractReports.profitability.table.hours', { defaultValue: 'Hours' }),
+      render: (row) => formatHours(row.totalMinutes),
+    },
+    {
+      key: 'ehr',
+      header: t('contractReports.profitability.table.ehr', { defaultValue: 'EHR' }),
+      render: (row) => formatRate(row.effectiveHourlyRate),
+    },
+  ];
+
+  const printClientColumns = printMetricColumns<ClientProfitabilityRow>({
+    key: 'client',
+    header: t('contractReports.profitability.table.client', { defaultValue: 'Client' }),
+    render: (row) => row.clientName,
+  });
+
+  const printAgreementColumns = printMetricColumns<AgreementProfitabilityRow>({
+    key: 'agreement',
+    header: t('contractReports.profitability.table.agreement', { defaultValue: 'Agreement' }),
+    render: (row) => rowName(row),
+  });
+
+  const printTicketColumns: PrintableTableColumn<TicketProfitabilityRow>[] = [
+    ...printMetricColumns<TicketProfitabilityRow>({
+      key: 'ticket',
+      header: t('contractReports.profitability.table.ticket', { defaultValue: 'Ticket' }),
+      render: (row) => ticketLabel(row, t),
+    }),
+    {
+      key: 'attribution',
+      header: t('contractReports.profitability.table.attribution', { defaultValue: 'Attribution' }),
+      render: (row) => (
+        row.uncosted
+          ? t('contractReports.profitability.formats.attributionUncosted', {
+            defaultValue: '{{attribution}} (uncosted)',
+            attribution: attributionLabel(row.attribution, t),
+          })
+          : attributionLabel(row.attribution, t)
+      ),
+    },
+  ];
+
+  const printLineColumns: PrintableTableColumn<ContractLineProfitabilityRow>[] = [
+    {
+      key: 'line',
+      header: t('contractReports.profitability.table.contractLine', { defaultValue: 'Line' }),
+      render: (row) => (
+        row.rowType === 'unassigned'
+          ? t('contractReports.profitability.formats.unassignedLine', {
+            defaultValue: '{{line}} (unassigned)',
+            line: row.contractLineName,
+          })
+          : row.contractLineName
+      ),
+    },
+    {
+      key: 'revenue',
+      header: t('contractReports.profitability.table.revenue', { defaultValue: 'Revenue' }),
+      render: (row) => formatCents(row.revenue),
+    },
+    {
+      key: 'cost',
+      header: t('contractReports.profitability.table.cost', { defaultValue: 'Cost' }),
+      render: (row) => formatCents(row.laborCost + row.materialCost),
+    },
+    {
+      key: 'margin',
+      header: t('contractReports.profitability.table.margin', { defaultValue: 'Margin' }),
+      render: (row) => formatCents(row.margin),
+    },
+    {
+      key: 'hours',
+      header: t('contractReports.profitability.table.hours', { defaultValue: 'Hours' }),
+      render: (row) => formatHours(row.totalMinutes),
+    },
+  ];
+
   const selectedAgreementKey = selectedAgreement?.clientContractId ?? null;
   const visibleTickets = tickets.filter((ticket) => (
     !selectedAgreementKey || ticket.clientContractId === selectedAgreementKey
   ));
 
   const summaryWarnings = summary ? warningItems(summary, t) : [];
+
+  const expandedAgreementRows = agreements.filter(
+    (agreement) => expandedAgreements.has(agreement.clientContractId ?? agreement.rowType)
+  );
+
+  const printDateRange = t('contractReports.profitability.print.dateRange', {
+    defaultValue: '{{start}} to {{end}}',
+    start: formatDate(dateRange.startDate),
+    end: formatDate(dateRange.endDate),
+  });
 
   const applyDateRange = (event: React.FormEvent) => {
     event.preventDefault();
@@ -436,6 +566,7 @@ const ProfitabilityReport: React.FC = () => {
             <RefreshCw className="h-4 w-4" aria-hidden="true" />
             {t('contractReports.profitability.actions.apply', { defaultValue: 'Apply' })}
           </Button>
+          <PrintButton id="profitability-print" type="button" variant="outline" />
         </form>
       </div>
 
@@ -647,6 +778,116 @@ const ProfitabilityReport: React.FC = () => {
           )}
         </Card>
       )}
+
+      <div className="app-print-root app-print-only" id="profitability-report-print">
+        <PrintableDetailHeader
+          title={t('contractReports.sections.profitability.title', { defaultValue: 'Profitability Report' })}
+          subtitle={printDateRange}
+          fields={[
+            {
+              label: t('contractReports.profitability.print.client', { defaultValue: 'Client' }),
+              value: selectedClient
+                ? selectedClient.clientName
+                : t('contractReports.profitability.print.allClients', { defaultValue: 'All clients' }),
+            },
+            {
+              label: t('contractReports.profitability.print.agreement', { defaultValue: 'Agreement' }),
+              value: selectedAgreement
+                ? rowName(selectedAgreement)
+                : t('contractReports.profitability.print.allAgreements', { defaultValue: 'All agreements' }),
+            },
+            {
+              label: t('contractReports.profitability.print.currency', { defaultValue: 'Currency' }),
+              value: currencyCode,
+            },
+          ]}
+        />
+
+        {summary && (
+          <PrintableSummary
+            metrics={[
+              { label: t('contractReports.profitability.summary.revenue', { defaultValue: 'Revenue' }), value: formatCents(summary.revenue) },
+              { label: t('contractReports.profitability.summary.laborCost', { defaultValue: 'Labor Cost' }), value: formatCents(summary.laborCost) },
+              { label: t('contractReports.profitability.summary.materialCost', { defaultValue: 'Material Cost' }), value: formatCents(summary.materialCost) },
+              { label: t('contractReports.profitability.summary.margin', { defaultValue: 'Margin' }), value: formatCents(summary.margin) },
+              { label: t('contractReports.profitability.summary.marginPct', { defaultValue: 'Margin %' }), value: formatPercent(summary.marginPct) },
+              { label: t('contractReports.profitability.summary.ehr', { defaultValue: 'Effective Hourly Rate' }), value: formatRate(summary.effectiveHourlyRate) },
+            ]}
+          />
+        )}
+
+        {summaryWarnings.length > 0 && (
+          <section className="app-print-table-section" style={{ marginBottom: '10pt' }}>
+            <header className="app-print-table-header">
+              <h2>{t('contractReports.profitability.warnings.title', { defaultValue: 'Report warnings' })}</h2>
+            </header>
+            <p>{summaryWarnings.join(t('contractReports.profitability.formats.listSeparator', { defaultValue: ', ' }))}</p>
+          </section>
+        )}
+
+        {summary && !summary.costRatesConfigured && (
+          <section className="app-print-table-section" style={{ marginBottom: '10pt' }}>
+            <p>
+              {t('contractReports.profitability.empty.costRates', {
+                defaultValue: 'Cost rates are not configured. Labor hours are shown as uncosted until a tenant default or user rate exists.',
+              })}
+            </p>
+          </section>
+        )}
+
+        <PrintableTable
+          title={t('contractReports.profitability.sections.clients', { defaultValue: 'Clients' })}
+          rows={clients}
+          columns={printClientColumns}
+          getRowKey={(row) => row.clientId ?? row.clientName}
+          emptyMessage={t('contractReports.profitability.empty.clients', {
+            defaultValue: 'No client profitability data available for this range.',
+          })}
+        />
+
+        {selectedClient && (
+          <>
+            <PrintableTable
+              title={t('contractReports.profitability.sections.agreements', {
+                defaultValue: 'Agreements for {{client}}',
+                client: selectedClient.clientName,
+              })}
+              rows={agreements}
+              columns={printAgreementColumns}
+              getRowKey={(row) => row.clientContractId ?? row.rowType}
+              emptyMessage={t('contractReports.profitability.empty.agreements', {
+                defaultValue: 'No agreement profitability data available for this selection.',
+              })}
+            />
+
+            {expandedAgreementRows.map((agreement) => (
+              <PrintableTable
+                key={`print-lines-${agreement.clientContractId ?? agreement.rowType}`}
+                title={t('contractReports.profitability.sections.linesForAgreement', {
+                  defaultValue: 'Contract lines for {{agreement}}',
+                  agreement: rowName(agreement),
+                })}
+                rows={agreement.lines}
+                columns={printLineColumns}
+                getRowKey={(row) => row.contractLineId ?? row.rowType}
+                emptyMessage={t('contractReports.profitability.empty.lines', {
+                  defaultValue: 'No line-level detail for this row.',
+                })}
+              />
+            ))}
+
+            <PrintableTable
+              title={t('contractReports.profitability.sections.tickets', { defaultValue: 'Tickets' })}
+              rows={visibleTickets}
+              columns={printTicketColumns}
+              getRowKey={(row) => row.ticketId}
+              emptyMessage={t('contractReports.profitability.empty.tickets', {
+                defaultValue: 'No ticket profitability data available for this selection.',
+              })}
+            />
+          </>
+        )}
+      </div>
     </div>
   );
 };

--- a/packages/inventory/src/components/GhostUsageReport.tsx
+++ b/packages/inventory/src/components/GhostUsageReport.tsx
@@ -7,6 +7,10 @@ import { DatePicker } from '@alga-psa/ui/components/DatePicker';
 import { Label } from '@alga-psa/ui/components/Label';
 import { Badge } from '@alga-psa/ui/components/Badge';
 import { Switch } from '@alga-psa/ui/components/Switch';
+import { PrintButton } from '@alga-psa/ui/components/PrintButton';
+import { PrintableDetailHeader } from '@alga-psa/ui/components/PrintableDetailHeader';
+import { PrintableSummary } from '@alga-psa/ui/components/PrintableSummary';
+import { PrintableTable, type PrintableTableColumn } from '@alga-psa/ui/components/PrintableTable';
 import CustomSelect from '@alga-psa/ui/components/CustomSelect';
 import { useTranslation } from '@alga-psa/ui/lib/i18n/client';
 import { toast } from 'react-hot-toast';
@@ -349,6 +353,35 @@ export function GhostUsageReport({
     { title: t('common.actions', 'Actions'), dataIndex: 'ticket_id', render: (_v: any, rec) => worklistActions(rec) },
   ];
 
+  // Print drops the links/badges/action buttons and keeps the evidence columns.
+  const verdictLabel = (rec: GhostUsageCandidateRow): string => {
+    if (!rec.ai_classification) return t('common.emptyValue', '—');
+    const pct = rec.ai_confidence != null ? ` ${Math.round(rec.ai_confidence * 100)}%` : '';
+    const verdict =
+      rec.ai_classification === 'hardware_missing'
+        ? t('ghostUsage.verdict.hardwareMissing', 'Hardware missing')
+        : rec.ai_classification === 'no_hardware'
+          ? t('ghostUsage.verdict.noHardware', 'No hardware')
+          : t('ghostUsage.verdict.unclear', 'Unclear');
+    return `${verdict}${pct}`;
+  };
+
+  const printBaseColumns: PrintableTableColumn<GhostUsageCandidateRow>[] = [
+    { key: 'ticketNumber', header: t('ghostUsage.columns.ticketNumber', 'Ticket #'), render: (row) => row.ticket_number },
+    { key: 'title', header: t('ghostUsage.columns.title', 'Title'), render: (row) => row.title || t('common.emptyValue', '—') },
+    { key: 'board', header: t('ghostUsage.columns.board', 'Board'), render: (row) => row.board_name || t('common.emptyValue', '—') },
+    { key: 'category', header: t('ghostUsage.columns.category', 'Category'), render: (row) => row.category_name || t('common.emptyValue', '—') },
+    { key: 'client', header: t('ghostUsage.columns.client', 'Client'), render: (row) => row.client_name || t('common.emptyValue', '—') },
+    { key: 'closed', header: t('ghostUsage.columns.closed', 'Closed'), render: (row) => shortDate(row.closed_at) },
+    { key: 'closedBy', header: t('ghostUsage.columns.closedBy', 'Closed by'), render: (row) => row.closed_by_name || t('common.emptyValue', '—') },
+    { key: 'assignedTo', header: t('ghostUsage.columns.assignedTo', 'Assigned to'), render: (row) => row.assigned_to_name || t('common.emptyValue', '—') },
+  ];
+
+  const printCandidateColumns: PrintableTableColumn<GhostUsageCandidateRow>[] = [
+    ...printBaseColumns,
+    { key: 'aiVerdict', header: t('ghostUsage.columns.aiVerdict', 'AI verdict'), render: (row) => verdictLabel(row) },
+  ];
+
   const funnel = report?.funnel;
   const funnelDenom = Math.max(funnel?.closed_in_scope ?? 0, 1);
   const funnelStages = funnel
@@ -369,9 +402,12 @@ export function GhostUsageReport({
             {t('ghostUsage.subtitle', 'Closed hardware tickets with no recorded parts — work the shop may have eaten.')}
           </p>
         </div>
-        <Button id="ghost-usage-refresh" variant="outline" onClick={refresh} disabled={loading}>
-          {loading ? t('common.refreshing', 'Refreshing…') : t('common.refresh', 'Refresh')}
-        </Button>
+        <div className="flex items-center gap-2">
+          <PrintButton id="ghost-usage-print" variant="outline" disabled={!report || loading} />
+          <Button id="ghost-usage-refresh" variant="outline" onClick={refresh} disabled={loading}>
+            {loading ? t('common.refreshing', 'Refreshing…') : t('common.refresh', 'Refresh')}
+          </Button>
+        </div>
       </div>
 
       <div className="flex items-end gap-3 flex-wrap">
@@ -486,6 +522,39 @@ export function GhostUsageReport({
               <DataTable id="ghost-usage-worklist-table" data={report.worklist} columns={worklistColumns} />
             </div>
           )}
+
+          <div className="app-print-root app-print-only" id="ghost-usage-print-region">
+            <PrintableDetailHeader
+              title={t('ghostUsage.title', 'Ghost Usage')}
+              subtitle={t('ghostUsage.subtitle', 'Closed hardware tickets with no recorded parts — work the shop may have eaten.')}
+              fields={[
+                { label: t('common.from', 'From'), value: from || t('common.allTime', 'All time') },
+                { label: t('common.to', 'To'), value: to || t('common.today', 'Today') },
+                { label: t('ghostUsage.filters.board', 'Board'), value: boardOptions.find((o) => o.value === boardId)?.label },
+                { label: t('ghostUsage.filters.category', 'Category'), value: categoryOptions.find((o) => o.value === categoryId)?.label },
+              ]}
+            />
+            <PrintableSummary metrics={funnelStages.map((s) => ({ label: s.label, value: s.value }))} />
+            <PrintableTable
+              title={t('ghostUsage.candidatesTitle', 'Ghost candidates')}
+              subtitle={report.candidates.length >= report.candidate_cap
+                ? t('ghostUsage.candidateCapNote', ' (showing first {{cap}})', { cap: report.candidate_cap })
+                : undefined}
+              rows={report.candidates}
+              columns={printCandidateColumns}
+              getRowKey={(row) => row.ticket_id}
+              emptyMessage={t('ghostUsage.noCandidates', 'No ghost candidates — nothing looks eaten.')}
+            />
+            {report.worklist.length > 0 && (
+              <PrintableTable
+                title={t('ghostUsage.worklistTitle', 'Confirmed — record the material')}
+                rows={report.worklist}
+                columns={printBaseColumns}
+                getRowKey={(row) => row.ticket_id}
+                emptyMessage={t('common.emptyValue', '—')}
+              />
+            )}
+          </div>
         </>
       )}
     </div>

--- a/packages/inventory/src/components/MarginReport.tsx
+++ b/packages/inventory/src/components/MarginReport.tsx
@@ -5,6 +5,10 @@ import { DataTable } from '@alga-psa/ui/components/DataTable';
 import { Button } from '@alga-psa/ui/components/Button';
 import { DatePicker } from '@alga-psa/ui/components/DatePicker';
 import { Label } from '@alga-psa/ui/components/Label';
+import { PrintButton } from '@alga-psa/ui/components/PrintButton';
+import { PrintableDetailHeader } from '@alga-psa/ui/components/PrintableDetailHeader';
+import { PrintableSummary } from '@alga-psa/ui/components/PrintableSummary';
+import { PrintableTable, type PrintableTableColumn } from '@alga-psa/ui/components/PrintableTable';
 import { toast } from 'react-hot-toast';
 import type { ColumnDefinition } from '@alga-psa/types';
 import { useTranslation } from '@alga-psa/ui/lib/i18n/client';
@@ -23,12 +27,20 @@ type InventoryTranslator = ReturnType<typeof useTranslation>['t'];
 const pct = (t: InventoryTranslator, value: number | null | undefined): string =>
   value == null ? t('common.emptyValue', '—') : `${value.toFixed(1)}%`;
 
+/** "From — To", or "All time" when the window is open-ended. */
+const rangeLabel = (t: InventoryTranslator, from: string, to: string): string => {
+  if (!from && !to) return t('common.allTime', 'All time');
+  return `${from || t('common.allTime', 'All time')} — ${to || t('common.today', 'Today')}`;
+};
+
 function MarginReportBody({
   report,
   t,
+  rangeSubtitle,
 }: {
   report: MarginReportData;
   t: InventoryTranslator;
+  rangeSubtitle: string;
 }) {
   const { money } = useCurrencyFormat();
   const rows: MarginReportRow[] = report.rows ?? [];
@@ -49,6 +61,19 @@ function MarginReportBody({
     { title: t('margin.columns.cogs', 'COGS'), dataIndex: 'cogs_cents', render: (v: any) => <span className="tabular-nums">{money(v)}</span> },
     { title: t('margin.columns.margin', 'Margin'), dataIndex: 'margin_cents', render: (v: any) => <span className="tabular-nums">{money(v)}</span> },
     { title: t('margin.columns.marginPct', 'Margin %'), dataIndex: 'margin_pct', render: (v: any) => <span className="tabular-nums">{pct(t, v)}</span> },
+  ];
+
+  const printColumns: PrintableTableColumn<MarginReportRow>[] = [
+    {
+      key: 'product',
+      header: t('margin.columns.product', 'Product'),
+      render: (row) => [row.service_name || t('common.emptyValue', '—'), row.sku].filter(Boolean).join(' · '),
+    },
+    { key: 'qtySold', header: t('margin.columns.qtySold', 'Qty sold'), render: (row) => Number(row.qty_sold ?? 0) },
+    { key: 'revenue', header: t('margin.columns.revenue', 'Revenue'), render: (row) => money(row.revenue_cents) },
+    { key: 'cogs', header: t('margin.columns.cogs', 'COGS'), render: (row) => money(row.cogs_cents) },
+    { key: 'margin', header: t('margin.columns.margin', 'Margin'), render: (row) => money(row.margin_cents) },
+    { key: 'marginPct', header: t('margin.columns.marginPct', 'Margin %'), render: (row) => pct(t, row.margin_pct) },
   ];
 
   return (
@@ -77,6 +102,28 @@ function MarginReportBody({
       ) : (
         <DataTable id="margin-report-table" data={rows} columns={columns} />
       )}
+
+      <div className="app-print-root app-print-only" id="margin-report-print">
+        <PrintableDetailHeader
+          title={t('margin.title', 'Margin Report')}
+          subtitle={t('margin.subtitle', 'Revenue, cost of goods sold, and margin per product from fulfilled sales orders.')}
+          fields={[{ label: t('common.period', 'Period'), value: rangeSubtitle }]}
+        />
+        <PrintableSummary
+          metrics={[
+            { label: t('margin.metrics.revenue', 'Revenue'), value: money(report.total_revenue_cents) },
+            { label: t('margin.metrics.cogs', 'COGS'), value: money(report.total_cogs_cents) },
+            { label: t('margin.metrics.margin', 'Margin'), value: money(report.total_margin_cents) },
+            { label: t('margin.metrics.marginPct', 'Margin %'), value: pct(t, report.total_margin_pct) },
+          ]}
+        />
+        <PrintableTable
+          rows={rows}
+          columns={printColumns}
+          getRowKey={(row) => row.service_id ?? row.sku ?? row.service_name}
+          emptyMessage={t('margin.empty', 'No sales-driven margin in this window.')}
+        />
+      </div>
     </>
   );
 }
@@ -119,9 +166,12 @@ export function MarginReport() {
             {t('margin.subtitle', 'Revenue, cost of goods sold, and margin per product from fulfilled sales orders.')}
           </p>
         </div>
-        <Button id="margin-report-refresh" variant="outline" onClick={run} disabled={loading}>
-          {loading ? t('common.refreshing', 'Refreshing…') : t('common.refresh', 'Refresh')}
-        </Button>
+        <div className="flex items-center gap-2">
+          <PrintButton id="margin-report-print" variant="outline" disabled={!report || loading} />
+          <Button id="margin-report-refresh" variant="outline" onClick={run} disabled={loading}>
+            {loading ? t('common.refreshing', 'Refreshing…') : t('common.refresh', 'Refresh')}
+          </Button>
+        </div>
       </div>
 
       <div className="flex items-end gap-3 flex-wrap">
@@ -143,7 +193,7 @@ export function MarginReport() {
           currencyCode={report.currency_code || 'USD'}
           locale={i18n.language || 'en'}
         >
-          <MarginReportBody report={report} t={t} />
+          <MarginReportBody report={report} t={t} rangeSubtitle={rangeLabel(t, from, to)} />
         </CurrencyFormatProvider>
       ) : loading ? (
         <p className="text-sm text-gray-500">{t('margin.loading', 'Loading margin…')}</p>

--- a/packages/inventory/src/components/WriteOffsReport.tsx
+++ b/packages/inventory/src/components/WriteOffsReport.tsx
@@ -6,6 +6,10 @@ import { Button } from '@alga-psa/ui/components/Button';
 import { DatePicker } from '@alga-psa/ui/components/DatePicker';
 import { Label } from '@alga-psa/ui/components/Label';
 import { Badge } from '@alga-psa/ui/components/Badge';
+import { PrintButton } from '@alga-psa/ui/components/PrintButton';
+import { PrintableDetailHeader } from '@alga-psa/ui/components/PrintableDetailHeader';
+import { PrintableSummary } from '@alga-psa/ui/components/PrintableSummary';
+import { PrintableTable, type PrintableTableColumn } from '@alga-psa/ui/components/PrintableTable';
 import { toast } from 'react-hot-toast';
 import type { ColumnDefinition } from '@alga-psa/types';
 import { useTranslation } from '@alga-psa/ui/lib/i18n/client';
@@ -70,6 +74,13 @@ export function WriteOffsReport({ initialData }: { initialData: WriteOffReportDa
     },
   ];
 
+  const movementLabel = (rec: WriteOffRow): string =>
+    rec.count_session_id
+      ? t('writeOffs.badges.countCorrection', 'Count correction')
+      : rec.movement_type === 'retire'
+        ? t('writeOffs.badges.retired', 'Retired')
+        : t('writeOffs.badges.adjustment', 'Adjustment');
+
   const rowColumns: ColumnDefinition<WriteOffRow>[] = [
     {
       title: t('writeOffs.columns.when', 'When'),
@@ -90,14 +101,14 @@ export function WriteOffsReport({ initialData }: { initialData: WriteOffReportDa
     {
       title: t('writeOffs.columns.type', 'Type'),
       dataIndex: 'movement_type',
-      render: (v: any, rec) =>
-        rec.count_session_id ? (
-          <Badge variant="warning" size="sm">{t('writeOffs.badges.countCorrection', 'Count correction')}</Badge>
-        ) : v === 'retire' ? (
-          <Badge variant="error" size="sm">{t('writeOffs.badges.retired', 'Retired')}</Badge>
-        ) : (
-          <Badge variant="secondary" size="sm">{t('writeOffs.badges.adjustment', 'Adjustment')}</Badge>
-        ),
+      render: (v: any, rec) => (
+        <Badge
+          variant={rec.count_session_id ? 'warning' : v === 'retire' ? 'error' : 'secondary'}
+          size="sm"
+        >
+          {movementLabel(rec)}
+        </Badge>
+      ),
     },
     {
       title: t('writeOffs.columns.qty', 'Qty'),
@@ -117,6 +128,33 @@ export function WriteOffsReport({ initialData }: { initialData: WriteOffReportDa
     },
     { title: t('writeOffs.columns.reason', 'Reason'), dataIndex: 'reason', render: (v: any) => <span className="text-xs">{v || t('common.emptyValue', '—')}</span> },
     { title: t('writeOffs.columns.by', 'By'), dataIndex: 'performed_by_name', render: (v: any, rec) => v || rec.performed_by || t('common.emptyValue', '—') },
+  ];
+
+  const printUserColumns: PrintableTableColumn<WriteOffByUser>[] = [
+    { key: 'user', header: t('writeOffs.columns.user', 'User'), render: (row) => row.name || row.user_id || t('common.unknown', 'Unknown') },
+    { key: 'events', header: t('writeOffs.columns.events', 'Events'), render: (row) => row.events },
+    { key: 'writtenOff', header: t('writeOffs.columns.writtenOff', 'Written off'), render: (row) => money(Number(row.losses_cents), currencyCode) },
+    { key: 'foundAdded', header: t('writeOffs.columns.foundAdded', 'Found / added'), render: (row) => money(Number(row.gains_cents), currencyCode) },
+    { key: 'net', header: t('writeOffs.columns.net', 'Net'), render: (row) => money(Number(row.net_cents), currencyCode) },
+  ];
+
+  const printRowColumns: PrintableTableColumn<WriteOffRow>[] = [
+    {
+      key: 'when',
+      header: t('writeOffs.columns.when', 'When'),
+      render: (row) => new Date(row.created_at).toLocaleString(undefined, { dateStyle: 'medium', timeStyle: 'short' }),
+    },
+    {
+      key: 'product',
+      header: t('writeOffs.columns.product', 'Product'),
+      render: (row) => [row.service_name || t('common.emptyValue', '—'), row.serial_number].filter(Boolean).join(' · '),
+    },
+    { key: 'location', header: t('writeOffs.columns.location', 'Location'), render: (row) => row.location_name || t('common.emptyValue', '—') },
+    { key: 'type', header: t('writeOffs.columns.type', 'Type'), render: (row) => movementLabel(row) },
+    { key: 'qty', header: t('writeOffs.columns.qty', 'Qty'), render: (row) => (Number(row.quantity_delta) > 0 ? `+${row.quantity_delta}` : String(row.quantity_delta)) },
+    { key: 'value', header: t('writeOffs.columns.value', 'Value'), render: (row) => money(Number(row.value_cents), currencyCode) },
+    { key: 'reason', header: t('writeOffs.columns.reason', 'Reason'), render: (row) => row.reason || t('common.emptyValue', '—') },
+    { key: 'by', header: t('writeOffs.columns.by', 'By'), render: (row) => row.performed_by_name || row.performed_by || t('common.emptyValue', '—') },
   ];
 
   return (
@@ -140,6 +178,7 @@ export function WriteOffsReport({ initialData }: { initialData: WriteOffReportDa
           <Button id="write-offs-run" onClick={run} disabled={loading}>
             {loading ? t('common.running', 'Running…') : t('common.run', 'Run')}
           </Button>
+          <PrintButton id="write-offs-print" variant="outline" disabled={!data || loading} />
         </div>
       </div>
 
@@ -175,6 +214,41 @@ export function WriteOffsReport({ initialData }: { initialData: WriteOffReportDa
               </p>
             )}
             <DataTable id="write-offs-events-table" data={data.rows} columns={rowColumns} />
+          </div>
+
+          <div className="app-print-root app-print-only" id="write-offs-print-region">
+            <PrintableDetailHeader
+              title={t('writeOffs.title', 'Write-offs & adjustments')}
+              subtitle={t('writeOffs.subtitle', 'Every stock write-down, retirement, and count correction — with the name that signed it. Ledger-backed; nothing here can be edited after the fact.')}
+              fields={[
+                { label: t('common.from', 'From'), value: dateInputValue(data.from) },
+                { label: t('common.to', 'To'), value: dateInputValue(data.to) },
+              ]}
+            />
+            <PrintableSummary
+              metrics={[
+                { label: t('writeOffs.columns.writtenOff', 'Written off'), value: money(data.total_losses_cents, currencyCode) },
+                { label: t('writeOffs.columns.foundAdded', 'Found / added'), value: money(data.total_gains_cents, currencyCode) },
+                { label: t('writeOffs.columns.net', 'Net'), value: money(data.net_cents, currencyCode) },
+              ]}
+            />
+            <PrintableTable
+              title={t('writeOffs.byUser', 'By user')}
+              rows={data.by_user}
+              columns={printUserColumns}
+              getRowKey={(row) => row.user_id ?? row.name ?? 'unknown'}
+              emptyMessage={t('common.emptyValue', '—')}
+            />
+            <PrintableTable
+              title={t('writeOffs.eventsTitle', 'Events')}
+              subtitle={data.truncated
+                ? t('writeOffs.truncatedNotice', 'Showing the most recent {{count}} events — the totals above still cover the whole period. Narrow the date range to see everything itemized.', { count: data.rows.length })
+                : undefined}
+              rows={data.rows}
+              columns={printRowColumns}
+              getRowKey={(row) => row.movement_id}
+              emptyMessage={t('common.emptyValue', '—')}
+            />
           </div>
         </>
       )}

--- a/packages/msp-composition/src/tickets/__tests__/MspTicketDetailsContainerClient.contract.test.ts
+++ b/packages/msp-composition/src/tickets/__tests__/MspTicketDetailsContainerClient.contract.test.ts
@@ -3,7 +3,9 @@ import path from 'node:path';
 import { describe, expect, it } from 'vitest';
 
 function readTicketCompositionSource(): string {
-  return fs.readFileSync(path.resolve(process.cwd(), '../packages/msp-composition/src/tickets/MspTicketDetailsContainerClient.tsx'), 'utf8');
+  // Resolve from this file, not cwd, so the suite passes under both the package
+  // and the server vitest configs.
+  return fs.readFileSync(path.resolve(__dirname, '../MspTicketDetailsContainerClient.tsx'), 'utf8');
 }
 
 describe('MspTicketDetailsContainerClient static contracts', () => {

--- a/packages/projects/src/components/__tests__/PrefillFromTicketDialog.test.tsx
+++ b/packages/projects/src/components/__tests__/PrefillFromTicketDialog.test.tsx
@@ -170,9 +170,14 @@ describe('PrefillFromTicketDialog', () => {
       </TicketIntegrationProvider>
     );
 
-    await waitFor(() => expect(mockCtx.getTicketsForList).toHaveBeenCalled());
+    const ticketSelect = screen.getByLabelText('ticket-select');
+    // The list call resolving is not the render: the option must exist
+    // before the change event can select it.
+    await waitFor(() => {
+      expect(ticketSelect.querySelector('option[value="ticket-1"]')).not.toBeNull();
+    });
 
-    fireEvent.change(screen.getByLabelText('ticket-select'), {
+    fireEvent.change(ticketSelect, {
       target: { value: 'ticket-1' }
     });
 

--- a/packages/surveys/src/components/SurveyPrintReport.tsx
+++ b/packages/surveys/src/components/SurveyPrintReport.tsx
@@ -1,0 +1,125 @@
+'use client';
+
+import type {
+  SurveyDashboardData,
+  SurveyDistributionBucket,
+  SurveyIssueSummary,
+  SurveyResponseListItem,
+  SurveyTrendPoint,
+} from '@alga-psa/types';
+import { PrintableDetailHeader } from '@alga-psa/ui/components/PrintableDetailHeader';
+import { PrintableSummary } from '@alga-psa/ui/components/PrintableSummary';
+import { PrintableTable, type PrintableTableColumn } from '@alga-psa/ui/components/PrintableTable';
+import { useTranslation } from '@alga-psa/ui/lib/i18n/client';
+
+export type SurveyPrintSection = 'trend' | 'distribution' | 'topIssues' | 'recentResponses';
+
+type SurveyPrintReportProps = {
+  data: SurveyDashboardData;
+  title: string;
+  subtitle?: string;
+  sections: SurveyPrintSection[];
+};
+
+/**
+ * Print region for the survey report surfaces. The dashboard/analytics pages are
+ * server components, so the column renderers have to live behind this client
+ * boundary rather than being passed down as props.
+ */
+export default function SurveyPrintReport({ data, title, subtitle, sections }: SurveyPrintReportProps) {
+  const { t } = useTranslation('msp/surveys');
+
+  const dash = t('print.emptyValue', { defaultValue: '—' });
+  const formatRating = (value: number | null): string => (value === null ? dash : value.toFixed(2));
+  const formatDate = (value: string): string => new Date(value).toLocaleDateString(undefined, { dateStyle: 'medium' });
+
+  const trendColumns: PrintableTableColumn<SurveyTrendPoint>[] = [
+    { key: 'date', header: t('print.columns.date', { defaultValue: 'Date' }), render: (row) => formatDate(row.date) },
+    { key: 'averageRating', header: t('print.columns.averageRating', { defaultValue: 'Average Rating' }), render: (row) => formatRating(row.averageRating) },
+    { key: 'responseCount', header: t('print.columns.responses', { defaultValue: 'Responses' }), render: (row) => row.responseCount },
+  ];
+
+  const distributionColumns: PrintableTableColumn<SurveyDistributionBucket>[] = [
+    { key: 'rating', header: t('print.columns.rating', { defaultValue: 'Rating' }), render: (row) => row.rating },
+    { key: 'count', header: t('print.columns.responses', { defaultValue: 'Responses' }), render: (row) => row.count },
+    { key: 'percentage', header: t('print.columns.share', { defaultValue: 'Share' }), render: (row) => `${row.percentage.toFixed(1)}%` },
+  ];
+
+  const issueColumns: PrintableTableColumn<SurveyIssueSummary>[] = [
+    { key: 'ticket', header: t('print.columns.ticket', { defaultValue: 'Ticket' }), render: (row) => row.ticketNumber || dash },
+    { key: 'client', header: t('print.columns.client', { defaultValue: 'Client' }), render: (row) => row.clientName || dash },
+    { key: 'rating', header: t('print.columns.rating', { defaultValue: 'Rating' }), render: (row) => row.rating },
+    { key: 'agent', header: t('print.columns.agent', { defaultValue: 'Agent' }), render: (row) => row.assignedAgentName || dash },
+    { key: 'submitted', header: t('print.columns.submitted', { defaultValue: 'Submitted' }), render: (row) => formatDate(row.submittedAt) },
+    { key: 'comment', header: t('print.columns.comment', { defaultValue: 'Comment' }), render: (row) => row.comment || dash },
+  ];
+
+  const responseColumns: PrintableTableColumn<SurveyResponseListItem>[] = [
+    { key: 'ticket', header: t('print.columns.ticket', { defaultValue: 'Ticket' }), render: (row) => row.ticketNumber || dash },
+    { key: 'client', header: t('print.columns.client', { defaultValue: 'Client' }), render: (row) => row.clientName || dash },
+    { key: 'contact', header: t('print.columns.contact', { defaultValue: 'Contact' }), render: (row) => row.contactName || dash },
+    { key: 'rating', header: t('print.columns.rating', { defaultValue: 'Rating' }), render: (row) => row.rating },
+    { key: 'technician', header: t('print.columns.technician', { defaultValue: 'Technician' }), render: (row) => row.technicianName || dash },
+    { key: 'submitted', header: t('print.columns.submitted', { defaultValue: 'Submitted' }), render: (row) => formatDate(row.submittedAt) },
+    { key: 'comment', header: t('print.columns.comment', { defaultValue: 'Comment' }), render: (row) => row.comment || dash },
+  ];
+
+  const includes = (section: SurveyPrintSection): boolean => sections.includes(section);
+
+  return (
+    <div className="app-print-root app-print-only" id="survey-print-region">
+      <PrintableDetailHeader title={title} subtitle={subtitle} />
+
+      <PrintableSummary
+        metrics={[
+          { label: t('print.metrics.invitations', { defaultValue: 'Invitations' }), value: data.metrics.totalInvitations },
+          { label: t('print.metrics.responses', { defaultValue: 'Responses' }), value: data.metrics.totalResponses },
+          { label: t('print.metrics.responseRate', { defaultValue: 'Response Rate' }), value: `${data.metrics.responseRate.toFixed(1)}%` },
+          { label: t('print.metrics.averageRating', { defaultValue: 'Average Rating' }), value: formatRating(data.metrics.averageRating) },
+          { label: t('print.metrics.outstanding', { defaultValue: 'Outstanding' }), value: data.metrics.outstandingInvitations },
+          { label: t('print.metrics.recentNegative', { defaultValue: 'Recent Negative' }), value: data.metrics.recentNegativeResponses },
+        ]}
+      />
+
+      {includes('trend') && (
+        <PrintableTable
+          title={t('print.sections.trend', { defaultValue: 'Response Trend' })}
+          rows={data.trend}
+          columns={trendColumns}
+          getRowKey={(row) => row.date}
+          emptyMessage={t('print.empty.trend', { defaultValue: 'No responses in this period.' })}
+        />
+      )}
+
+      {includes('distribution') && (
+        <PrintableTable
+          title={t('print.sections.distribution', { defaultValue: 'Satisfaction Distribution' })}
+          rows={data.distribution}
+          columns={distributionColumns}
+          getRowKey={(row) => String(row.rating)}
+          emptyMessage={t('print.empty.distribution', { defaultValue: 'No rated responses in this period.' })}
+        />
+      )}
+
+      {includes('topIssues') && (
+        <PrintableTable
+          title={t('print.sections.topIssues', { defaultValue: 'Top Issues' })}
+          rows={data.topIssues}
+          columns={issueColumns}
+          getRowKey={(row) => row.responseId}
+          emptyMessage={t('print.empty.topIssues', { defaultValue: 'No negative responses in this period.' })}
+        />
+      )}
+
+      {includes('recentResponses') && (
+        <PrintableTable
+          title={t('print.sections.recentResponses', { defaultValue: 'Recent Responses' })}
+          rows={data.recentResponses}
+          columns={responseColumns}
+          getRowKey={(row) => row.responseId}
+          emptyMessage={t('print.empty.recentResponses', { defaultValue: 'No responses in this period.' })}
+        />
+      )}
+    </div>
+  );
+}

--- a/packages/surveys/src/components/analytics/SurveyAnalyticsPage.tsx
+++ b/packages/surveys/src/components/analytics/SurveyAnalyticsPage.tsx
@@ -1,9 +1,11 @@
 import { Card, CardContent, CardHeader, CardTitle } from '@alga-psa/ui/components/Card';
 import { getSurveyDashboardData } from '@alga-psa/surveys/actions/survey-actions/surveyDashboardActions';
 import { getServerTranslation } from '@alga-psa/ui/lib/i18n/serverOnly';
+import { PrintButton } from '@alga-psa/ui/components/PrintButton';
 import FilterPanel from './FilterPanel';
 import ResponseAnalyticsChart from './ResponseAnalyticsChart';
 import ExportOptions from './ExportOptions';
+import SurveyPrintReport from '../SurveyPrintReport';
 
 export default async function SurveyAnalyticsPage() {
   const dashboardData = await getSurveyDashboardData();
@@ -40,12 +42,24 @@ export default async function SurveyAnalyticsPage() {
               })}
             </p>
           </div>
-          <ExportOptions />
+          <div className="flex flex-wrap items-center gap-2">
+            <ExportOptions />
+            <PrintButton id="survey-analytics-print" variant="outline" />
+          </div>
         </CardHeader>
         <CardContent>
           <ResponseAnalyticsChart data={chartData} />
         </CardContent>
       </Card>
+
+      <SurveyPrintReport
+        data={dashboardData}
+        title={t('analytics.page.overviewTitle', { defaultValue: 'Satisfaction Overview' })}
+        subtitle={t('analytics.page.overviewDescription', {
+          defaultValue: 'Compare average satisfaction and response rates over time. Additional segmentation will arrive in later iterations.',
+        })}
+        sections={['trend']}
+      />
     </div>
   );
 }

--- a/packages/surveys/src/components/dashboard/SurveyDashboard.tsx
+++ b/packages/surveys/src/components/dashboard/SurveyDashboard.tsx
@@ -9,7 +9,9 @@ import TopIssuesPanel from './TopIssuesPanel';
 import ResponsesList from './ResponsesList';
 import ChartSkeleton from '@alga-psa/ui/components/skeletons/ChartSkeleton';
 import LoadingIndicator from '@alga-psa/ui/components/LoadingIndicator';
+import { PrintButton } from '@alga-psa/ui/components/PrintButton';
 import { getServerTranslation } from '@alga-psa/ui/lib/i18n/serverOnly';
+import SurveyPrintReport from '../SurveyPrintReport';
 
 type SurveyDashboardProps = {
   filters?: SurveyDashboardFilters;
@@ -21,6 +23,10 @@ export default async function SurveyDashboard({ filters }: SurveyDashboardProps)
 
   return (
     <div className="space-y-8">
+      <div className="flex justify-end">
+        <PrintButton id="survey-dashboard-print" size="sm" variant="outline" />
+      </div>
+
       <section className="animate-in fade-in-50 duration-500">
         <ResponseMetrics metrics={data.metrics} />
       </section>
@@ -49,6 +55,12 @@ export default async function SurveyDashboard({ filters }: SurveyDashboardProps)
       <section className="animate-in fade-in-50 duration-1000">
         <ResponsesList responses={data.recentResponses} />
       </section>
+
+      <SurveyPrintReport
+        data={data}
+        title={t('dashboard.printTitle', { defaultValue: 'Survey Dashboard' })}
+        sections={['trend', 'distribution', 'topIssues', 'recentResponses']}
+      />
     </div>
   );
 }

--- a/packages/ui/src/components/PrintableSummary.tsx
+++ b/packages/ui/src/components/PrintableSummary.tsx
@@ -1,0 +1,41 @@
+'use client';
+
+import * as React from 'react';
+import { cn } from '../lib/utils';
+
+export type PrintableSummaryMetric = {
+  label: React.ReactNode;
+  value: React.ReactNode;
+};
+
+export interface PrintableSummaryProps {
+  metrics: PrintableSummaryMetric[];
+  className?: string;
+}
+
+/**
+ * Print-only KPI strip. Laid out as a fixed table row so the metric cards that
+ * reports show on screen survive `@media print` without their grid/flex chrome.
+ */
+export function PrintableSummary({ metrics, className }: PrintableSummaryProps): React.ReactElement | null {
+  if (metrics.length === 0) return null;
+
+  return (
+    <section className={cn('app-print-table-section', className)} style={{ marginBottom: '10pt' }}>
+      <table className="app-print-table" style={{ tableLayout: 'fixed' }}>
+        <tbody>
+          <tr>
+            {metrics.map((metric, idx) => (
+              <td key={idx} style={{ verticalAlign: 'top' }}>
+                <div style={{ fontSize: '8pt', color: '#555', textTransform: 'uppercase', letterSpacing: '0.04em' }}>
+                  {metric.label}
+                </div>
+                <div style={{ fontSize: '15pt', fontWeight: 700, marginTop: '2pt' }}>{metric.value}</div>
+              </td>
+            ))}
+          </tr>
+        </tbody>
+      </table>
+    </section>
+  );
+}

--- a/packages/ui/src/components/index.ts
+++ b/packages/ui/src/components/index.ts
@@ -92,6 +92,7 @@ export * from './PrintButton';
 export * from './PrintOptionsDialog';
 export * from './PrintableDetailHeader';
 export * from './PrintableRegion';
+export * from './PrintableSummary';
 export * from './PrintableTable';
 export * from './ShareActionsMenu';
 export * from './Progress';

--- a/server/public/locales/de/features/inventory.json
+++ b/server/public/locales/de/features/inventory.json
@@ -2,6 +2,7 @@
   "common": {
     "actions": "Aktionen",
     "active": "Aktiv",
+    "allTime": "Gesamter Zeitraum",
     "cancel": "Abbrechen",
     "clear": "Zurücksetzen",
     "close": "Schließen",
@@ -14,6 +15,7 @@
     "inactive": "Inaktiv",
     "loading": "Wird geladen…",
     "name": "Name",
+    "period": "Zeitraum",
     "quantity": "Menge",
     "refresh": "Aktualisieren",
     "refreshing": "Wird aktualisiert…",
@@ -28,6 +30,7 @@
     "search": "Suchen",
     "status": "Status",
     "to": "Bis",
+    "today": "Heute",
     "total": "Gesamt",
     "unknown": "Unbekannt"
   },
@@ -432,6 +435,7 @@
     "candidateCapNote": " (erste {{cap}} werden angezeigt)",
     "candidateCount": "{{count}} Ghost-Kandidat",
     "candidateCountPlural": "{{count}} Ghost-Kandidaten",
+    "candidatesTitle": "Ghost-Kandidaten",
     "columns": {
       "aiVerdict": "AI-Urteil",
       "assignedTo": "Zugewiesen an",

--- a/server/public/locales/de/msp/reports.json
+++ b/server/public/locales/de/msp/reports.json
@@ -258,7 +258,9 @@
         "hourlyRate": "{{value}}/Std.",
         "ticketWithNumber": "#{{number}} {{title}}",
         "billableHours": "{{value}} abrechenbare Std.",
-        "listSeparator": ", "
+        "listSeparator": ", ",
+        "attributionUncosted": "{{attribution}} (ohne Kostensatz)",
+        "unassignedLine": "{{line}} (nicht zugewiesen)"
       },
       "errors": {
         "load": "Rentabilitätsdaten konnten nicht geladen werden",
@@ -308,7 +310,8 @@
         "costRates": "Es sind keine Kostensätze konfiguriert. Arbeitsstunden werden als ohne Kostensatz angezeigt, bis ein Mandantenstandard oder ein Benutzersatz vorhanden ist.",
         "clients": "Für diesen Zeitraum sind keine Kunden-Rentabilitätsdaten verfügbar.",
         "lines": "Keine Details auf Positionsebene für diese Zeile.",
-        "tickets": "Für diese Auswahl sind keine Ticket-Rentabilitätsdaten verfügbar."
+        "tickets": "Für diese Auswahl sind keine Ticket-Rentabilitätsdaten verfügbar.",
+        "agreements": "Für diese Auswahl sind keine Vertrags-Rentabilitätsdaten verfügbar."
       },
       "warnings": {
         "title": "Berichtswarnungen",
@@ -340,6 +343,14 @@
       },
       "fallbacks": {
         "untitledTicket": "Ticket ohne Titel"
+      },
+      "print": {
+        "dateRange": "{{start}} bis {{end}}",
+        "client": "Kunde",
+        "allClients": "Alle Kunden",
+        "agreement": "Vertrag",
+        "allAgreements": "Alle Verträge",
+        "currency": "Währung"
       }
     }
   },

--- a/server/public/locales/de/msp/surveys.json
+++ b/server/public/locales/de/msp/surveys.json
@@ -277,6 +277,7 @@
   },
   "dashboard": {
     "loadingInsights": "Umfrageeinblicke werden geladen...",
+    "printTitle": "Umfrage-Dashboard",
     "responseMetrics": {
       "cards": {
         "sent": "Gesendete Einladungen",
@@ -422,6 +423,43 @@
     },
     "fallbacks": {
       "none": "-"
+    }
+  },
+  "print": {
+    "emptyValue": "—",
+    "columns": {
+      "date": "Datum",
+      "averageRating": "Durchschnittliche Bewertung",
+      "responses": "Antworten",
+      "rating": "Bewertung",
+      "share": "Anteil",
+      "ticket": "Ticket",
+      "client": "Kunde",
+      "contact": "Kontakt",
+      "agent": "Agent",
+      "technician": "Techniker",
+      "submitted": "Eingereicht",
+      "comment": "Kommentar"
+    },
+    "metrics": {
+      "averageRating": "Durchschnittliche Bewertung",
+      "invitations": "Einladungen",
+      "outstanding": "Ausstehend",
+      "recentNegative": "Aktuelle negative",
+      "responseRate": "Antwortquote",
+      "responses": "Antworten"
+    },
+    "sections": {
+      "trend": "Antworttrend",
+      "distribution": "Zufriedenheitsverteilung",
+      "topIssues": "Häufigste Probleme",
+      "recentResponses": "Neueste Antworten"
+    },
+    "empty": {
+      "trend": "Keine Antworten in diesem Zeitraum.",
+      "distribution": "Keine bewerteten Antworten in diesem Zeitraum.",
+      "topIssues": "Keine negativen Antworten in diesem Zeitraum.",
+      "recentResponses": "Keine Antworten in diesem Zeitraum."
     }
   }
 }

--- a/server/public/locales/en/features/inventory.json
+++ b/server/public/locales/en/features/inventory.json
@@ -2,6 +2,7 @@
   "common": {
     "actions": "Actions",
     "active": "Active",
+    "allTime": "All time",
     "cancel": "Cancel",
     "clear": "Clear",
     "close": "Close",
@@ -14,6 +15,7 @@
     "inactive": "Inactive",
     "loading": "Loading…",
     "name": "Name",
+    "period": "Period",
     "quantity": "Quantity",
     "refresh": "Refresh",
     "refreshing": "Refreshing…",
@@ -28,6 +30,7 @@
     "search": "Search",
     "status": "Status",
     "to": "To",
+    "today": "Today",
     "total": "Total",
     "unknown": "Unknown"
   },
@@ -432,6 +435,7 @@
     "candidateCapNote": " (showing first {{cap}})",
     "candidateCount": "{{count}} ghost candidate",
     "candidateCountPlural": "{{count}} ghost candidates",
+    "candidatesTitle": "Ghost candidates",
     "columns": {
       "aiVerdict": "AI verdict",
       "assignedTo": "Assigned to",

--- a/server/public/locales/en/msp/reports.json
+++ b/server/public/locales/en/msp/reports.json
@@ -258,7 +258,9 @@
         "hourlyRate": "{{value}}/hr",
         "ticketWithNumber": "#{{number}} {{title}}",
         "billableHours": "{{value}} billable hrs",
-        "listSeparator": ", "
+        "listSeparator": ", ",
+        "attributionUncosted": "{{attribution}} (uncosted)",
+        "unassignedLine": "{{line}} (unassigned)"
       },
       "errors": {
         "load": "Failed to load profitability data",
@@ -308,7 +310,16 @@
         "costRates": "Cost rates are not configured. Labor hours are shown as uncosted until a tenant default or user rate exists.",
         "clients": "No client profitability data available for this range.",
         "lines": "No line-level detail for this row.",
-        "tickets": "No ticket profitability data available for this selection."
+        "tickets": "No ticket profitability data available for this selection.",
+        "agreements": "No agreement profitability data available for this selection."
+      },
+      "print": {
+        "dateRange": "{{start}} to {{end}}",
+        "client": "Client",
+        "allClients": "All clients",
+        "agreement": "Agreement",
+        "allAgreements": "All agreements",
+        "currency": "Currency"
       },
       "warnings": {
         "title": "Report warnings",

--- a/server/public/locales/en/msp/surveys.json
+++ b/server/public/locales/en/msp/surveys.json
@@ -277,6 +277,7 @@
   },
   "dashboard": {
     "loadingInsights": "Loading survey insights...",
+    "printTitle": "Survey Dashboard",
     "responseMetrics": {
       "cards": {
         "sent": "Invitations Sent",
@@ -422,6 +423,43 @@
     },
     "fallbacks": {
       "none": "-"
+    }
+  },
+  "print": {
+    "emptyValue": "—",
+    "columns": {
+      "date": "Date",
+      "averageRating": "Average Rating",
+      "responses": "Responses",
+      "rating": "Rating",
+      "share": "Share",
+      "ticket": "Ticket",
+      "client": "Client",
+      "contact": "Contact",
+      "agent": "Agent",
+      "technician": "Technician",
+      "submitted": "Submitted",
+      "comment": "Comment"
+    },
+    "metrics": {
+      "invitations": "Invitations",
+      "responses": "Responses",
+      "responseRate": "Response Rate",
+      "averageRating": "Average Rating",
+      "outstanding": "Outstanding",
+      "recentNegative": "Recent Negative"
+    },
+    "sections": {
+      "trend": "Response Trend",
+      "distribution": "Satisfaction Distribution",
+      "topIssues": "Top Issues",
+      "recentResponses": "Recent Responses"
+    },
+    "empty": {
+      "trend": "No responses in this period.",
+      "distribution": "No rated responses in this period.",
+      "topIssues": "No negative responses in this period.",
+      "recentResponses": "No responses in this period."
     }
   }
 }

--- a/server/public/locales/es/features/inventory.json
+++ b/server/public/locales/es/features/inventory.json
@@ -2,6 +2,7 @@
   "common": {
     "actions": "Acciones",
     "active": "Activo",
+    "allTime": "Todo el periodo",
     "cancel": "Cancelar",
     "clear": "Limpiar",
     "close": "Cerrar",
@@ -14,6 +15,7 @@
     "inactive": "Inactivo",
     "loading": "Cargando…",
     "name": "Nombre",
+    "period": "Periodo",
     "quantity": "Cantidad",
     "refresh": "Actualizar",
     "refreshing": "Actualizando…",
@@ -28,6 +30,7 @@
     "search": "Buscar",
     "status": "Estado",
     "to": "Hasta",
+    "today": "Hoy",
     "total": "Total",
     "unknown": "Desconocido"
   },
@@ -432,6 +435,7 @@
     "candidateCapNote": " (mostrando los primeros {{cap}})",
     "candidateCount": "{{count}} candidato fantasma",
     "candidateCountPlural": "{{count}} candidatos fantasma",
+    "candidatesTitle": "Candidatos fantasma",
     "columns": {
       "aiVerdict": "Veredicto de la IA",
       "assignedTo": "Asignado a",

--- a/server/public/locales/es/msp/reports.json
+++ b/server/public/locales/es/msp/reports.json
@@ -258,7 +258,9 @@
         "hourlyRate": "{{value}}/h",
         "ticketWithNumber": "#{{number}} {{title}}",
         "billableHours": "{{value}} h facturables",
-        "listSeparator": ", "
+        "listSeparator": ", ",
+        "attributionUncosted": "{{attribution}} (sin costear)",
+        "unassignedLine": "{{line}} (sin asignar)"
       },
       "errors": {
         "load": "No se pudieron cargar los datos de rentabilidad",
@@ -308,7 +310,8 @@
         "costRates": "Las tarifas de costo no están configuradas. Las horas de mano de obra se muestran sin costear hasta que exista una tarifa predeterminada del tenant o una tarifa por usuario.",
         "clients": "No hay datos de rentabilidad por cliente disponibles para este intervalo.",
         "lines": "No hay detalle por línea para esta fila.",
-        "tickets": "No hay datos de rentabilidad por ticket disponibles para esta selección."
+        "tickets": "No hay datos de rentabilidad por ticket disponibles para esta selección.",
+        "agreements": "No hay datos de rentabilidad por acuerdo disponibles para esta selección."
       },
       "warnings": {
         "title": "Advertencias del informe",
@@ -340,6 +343,14 @@
       },
       "fallbacks": {
         "untitledTicket": "Ticket sin título"
+      },
+      "print": {
+        "dateRange": "{{start}} a {{end}}",
+        "client": "Cliente",
+        "allClients": "Todos los clientes",
+        "agreement": "Acuerdo",
+        "allAgreements": "Todos los acuerdos",
+        "currency": "Moneda"
       }
     }
   },

--- a/server/public/locales/es/msp/surveys.json
+++ b/server/public/locales/es/msp/surveys.json
@@ -277,6 +277,7 @@
   },
   "dashboard": {
     "loadingInsights": "Cargando información de la encuesta...",
+    "printTitle": "Panel de encuestas",
     "responseMetrics": {
       "cards": {
         "sent": "Invitaciones enviadas",
@@ -422,6 +423,43 @@
     },
     "fallbacks": {
       "none": "-"
+    }
+  },
+  "print": {
+    "emptyValue": "—",
+    "columns": {
+      "date": "Fecha",
+      "averageRating": "Valoración media",
+      "responses": "Respuestas",
+      "rating": "Valoración",
+      "share": "Porcentaje",
+      "ticket": "Ticket",
+      "client": "Cliente",
+      "contact": "Contacto",
+      "agent": "Agente",
+      "technician": "Técnico",
+      "submitted": "Enviado",
+      "comment": "Comentario"
+    },
+    "metrics": {
+      "averageRating": "Valoración media",
+      "invitations": "Invitaciones",
+      "outstanding": "Pendientes",
+      "recentNegative": "Negativas recientes",
+      "responseRate": "Tasa de respuesta",
+      "responses": "Respuestas"
+    },
+    "sections": {
+      "trend": "Tendencia de respuestas",
+      "distribution": "Distribución de satisfacción",
+      "topIssues": "Principales incidencias",
+      "recentResponses": "Respuestas recientes"
+    },
+    "empty": {
+      "trend": "No hay respuestas en este periodo.",
+      "distribution": "No hay respuestas valoradas en este periodo.",
+      "topIssues": "No hay respuestas negativas en este periodo.",
+      "recentResponses": "No hay respuestas en este periodo."
     }
   }
 }

--- a/server/public/locales/fr/features/inventory.json
+++ b/server/public/locales/fr/features/inventory.json
@@ -2,6 +2,7 @@
   "common": {
     "actions": "Actions",
     "active": "Actif",
+    "allTime": "Toute la période",
     "cancel": "Annuler",
     "clear": "Effacer",
     "close": "Fermer",
@@ -14,6 +15,7 @@
     "inactive": "Inactif",
     "loading": "Chargement…",
     "name": "Nom",
+    "period": "Période",
     "quantity": "Quantité",
     "refresh": "Actualiser",
     "refreshing": "Actualisation…",
@@ -28,6 +30,7 @@
     "search": "Rechercher",
     "status": "Statut",
     "to": "À",
+    "today": "Aujourd'hui",
     "total": "Total",
     "unknown": "Inconnu"
   },
@@ -432,6 +435,7 @@
     "candidateCapNote": " (affichage des {{cap}} premiers)",
     "candidateCount": "{{count}} candidat fantôme",
     "candidateCountPlural": "{{count}} candidats fantômes",
+    "candidatesTitle": "Candidats fantômes",
     "columns": {
       "aiVerdict": "Verdict AI",
       "assignedTo": "Assigné à",

--- a/server/public/locales/fr/msp/reports.json
+++ b/server/public/locales/fr/msp/reports.json
@@ -258,7 +258,9 @@
         "hourlyRate": "{{value}}/h",
         "ticketWithNumber": "#{{number}} {{title}}",
         "billableHours": "{{value}} h facturables",
-        "listSeparator": ", "
+        "listSeparator": ", ",
+        "attributionUncosted": "{{attribution}} (non valorisé)",
+        "unassignedLine": "{{line}} (non assigné)"
       },
       "errors": {
         "load": "Impossible de charger les données de rentabilité",
@@ -308,7 +310,8 @@
         "costRates": "Les taux de coût ne sont pas configurés. Les heures de main-d'œuvre apparaissent comme non valorisées tant qu'aucun taux par défaut du locataire ou taux utilisateur n'existe.",
         "clients": "Aucune donnée de rentabilité client disponible pour cette période.",
         "lines": "Aucun détail par ligne de contrat pour cette entrée.",
-        "tickets": "Aucune donnée de rentabilité des tickets disponible pour cette sélection."
+        "tickets": "Aucune donnée de rentabilité des tickets disponible pour cette sélection.",
+        "agreements": "Aucune donnée de rentabilité par contrat disponible pour cette sélection."
       },
       "warnings": {
         "title": "Avertissements du rapport",
@@ -340,6 +343,14 @@
       },
       "fallbacks": {
         "untitledTicket": "Ticket sans titre"
+      },
+      "print": {
+        "dateRange": "Du {{start}} au {{end}}",
+        "client": "Client",
+        "allClients": "Tous les clients",
+        "agreement": "Contrat",
+        "allAgreements": "Tous les contrats",
+        "currency": "Devise"
       }
     }
   },

--- a/server/public/locales/fr/msp/surveys.json
+++ b/server/public/locales/fr/msp/surveys.json
@@ -277,6 +277,7 @@
   },
   "dashboard": {
     "loadingInsights": "Chargement des indicateurs d'enquête...",
+    "printTitle": "Tableau de bord des enquêtes",
     "responseMetrics": {
       "cards": {
         "sent": "Invitations envoyées",
@@ -422,6 +423,43 @@
     },
     "fallbacks": {
       "none": "-"
+    }
+  },
+  "print": {
+    "emptyValue": "—",
+    "columns": {
+      "date": "Date",
+      "averageRating": "Note moyenne",
+      "responses": "Réponses",
+      "rating": "Note",
+      "share": "Part",
+      "ticket": "Ticket",
+      "client": "Client",
+      "contact": "Contact",
+      "agent": "Agent",
+      "technician": "Technicien",
+      "submitted": "Soumis le",
+      "comment": "Commentaire"
+    },
+    "metrics": {
+      "averageRating": "Note moyenne",
+      "invitations": "Invitations",
+      "outstanding": "En attente",
+      "recentNegative": "Négatives récentes",
+      "responseRate": "Taux de réponse",
+      "responses": "Réponses"
+    },
+    "sections": {
+      "trend": "Tendance des réponses",
+      "distribution": "Répartition de la satisfaction",
+      "topIssues": "Principaux problèmes",
+      "recentResponses": "Réponses récentes"
+    },
+    "empty": {
+      "trend": "Aucune réponse sur cette période.",
+      "distribution": "Aucune réponse notée sur cette période.",
+      "topIssues": "Aucune réponse négative sur cette période.",
+      "recentResponses": "Aucune réponse sur cette période."
     }
   }
 }

--- a/server/public/locales/it/features/inventory.json
+++ b/server/public/locales/it/features/inventory.json
@@ -2,6 +2,7 @@
   "common": {
     "actions": "Azioni",
     "active": "Attivo",
+    "allTime": "Tutto il periodo",
     "cancel": "Annulla",
     "clear": "Cancella",
     "close": "Chiudi",
@@ -14,6 +15,7 @@
     "inactive": "Inattivo",
     "loading": "Caricamento…",
     "name": "Nome",
+    "period": "Periodo",
     "quantity": "Quantità",
     "refresh": "Aggiorna",
     "refreshing": "Aggiornamento…",
@@ -28,6 +30,7 @@
     "search": "Cerca",
     "status": "Stato",
     "to": "A",
+    "today": "Oggi",
     "total": "Totale",
     "unknown": "Sconosciuto"
   },
@@ -432,6 +435,7 @@
     "candidateCapNote": " (mostrati i primi {{cap}})",
     "candidateCount": "{{count}} candidato fantasma",
     "candidateCountPlural": "{{count}} candidati fantasma",
+    "candidatesTitle": "Candidati fantasma",
     "columns": {
       "aiVerdict": "Verdetto AI",
       "assignedTo": "Assegnato a",

--- a/server/public/locales/it/msp/reports.json
+++ b/server/public/locales/it/msp/reports.json
@@ -258,7 +258,9 @@
         "hourlyRate": "{{value}}/h",
         "ticketWithNumber": "#{{number}} {{title}}",
         "billableHours": "{{value}} h fatturabili",
-        "listSeparator": ", "
+        "listSeparator": ", ",
+        "attributionUncosted": "{{attribution}} (senza costo)",
+        "unassignedLine": "{{line}} (non assegnato)"
       },
       "errors": {
         "load": "Impossibile caricare i dati di redditività",
@@ -308,7 +310,8 @@
         "costRates": "Le tariffe di costo non sono configurate. Le ore di lavoro risultano senza costo finché non esiste una tariffa predefinita del tenant o una tariffa utente.",
         "clients": "Nessun dato di redditività per cliente disponibile in questo intervallo.",
         "lines": "Nessun dettaglio a livello di riga per questa voce.",
-        "tickets": "Nessun dato di redditività dei ticket disponibile per questa selezione."
+        "tickets": "Nessun dato di redditività dei ticket disponibile per questa selezione.",
+        "agreements": "Nessun dato di redditività per contratto disponibile per questa selezione."
       },
       "warnings": {
         "title": "Avvisi del report",
@@ -340,6 +343,14 @@
       },
       "fallbacks": {
         "untitledTicket": "Ticket senza titolo"
+      },
+      "print": {
+        "dateRange": "Dal {{start}} al {{end}}",
+        "client": "Cliente",
+        "allClients": "Tutti i clienti",
+        "agreement": "Contratto",
+        "allAgreements": "Tutti i contratti",
+        "currency": "Valuta"
       }
     }
   },

--- a/server/public/locales/it/msp/surveys.json
+++ b/server/public/locales/it/msp/surveys.json
@@ -277,6 +277,7 @@
   },
   "dashboard": {
     "loadingInsights": "Caricamento analisi del sondaggio...",
+    "printTitle": "Dashboard sondaggi",
     "responseMetrics": {
       "cards": {
         "sent": "Inviti inviati",
@@ -422,6 +423,43 @@
     },
     "fallbacks": {
       "none": "-"
+    }
+  },
+  "print": {
+    "emptyValue": "—",
+    "columns": {
+      "date": "Data",
+      "averageRating": "Valutazione media",
+      "responses": "Risposte",
+      "rating": "Valutazione",
+      "share": "Quota",
+      "ticket": "Ticket",
+      "client": "Cliente",
+      "contact": "Contatto",
+      "agent": "Agente",
+      "technician": "Tecnico",
+      "submitted": "Inviato",
+      "comment": "Commento"
+    },
+    "metrics": {
+      "averageRating": "Valutazione media",
+      "invitations": "Inviti",
+      "outstanding": "In sospeso",
+      "recentNegative": "Negative recenti",
+      "responseRate": "Tasso di risposta",
+      "responses": "Risposte"
+    },
+    "sections": {
+      "trend": "Trend delle risposte",
+      "distribution": "Distribuzione della soddisfazione",
+      "topIssues": "Problemi principali",
+      "recentResponses": "Risposte recenti"
+    },
+    "empty": {
+      "trend": "Nessuna risposta in questo periodo.",
+      "distribution": "Nessuna risposta valutata in questo periodo.",
+      "topIssues": "Nessuna risposta negativa in questo periodo.",
+      "recentResponses": "Nessuna risposta in questo periodo."
     }
   }
 }

--- a/server/public/locales/nl/features/inventory.json
+++ b/server/public/locales/nl/features/inventory.json
@@ -2,6 +2,7 @@
   "common": {
     "actions": "Acties",
     "active": "Actief",
+    "allTime": "Volledige periode",
     "cancel": "Annuleren",
     "clear": "Wissen",
     "close": "Sluiten",
@@ -14,6 +15,7 @@
     "inactive": "Inactief",
     "loading": "Laden…",
     "name": "Naam",
+    "period": "Periode",
     "quantity": "Aantal",
     "refresh": "Vernieuwen",
     "refreshing": "Vernieuwen…",
@@ -28,6 +30,7 @@
     "search": "Zoeken",
     "status": "Status",
     "to": "Naar",
+    "today": "Vandaag",
     "total": "Totaal",
     "unknown": "Onbekend"
   },
@@ -432,6 +435,7 @@
     "candidateCapNote": " (eerste {{cap}} weergegeven)",
     "candidateCount": "{{count}} ghost-kandidaat",
     "candidateCountPlural": "{{count}} ghost-kandidaten",
+    "candidatesTitle": "Ghost-kandidaten",
     "columns": {
       "aiVerdict": "AI-oordeel",
       "assignedTo": "Toegewezen aan",

--- a/server/public/locales/nl/msp/reports.json
+++ b/server/public/locales/nl/msp/reports.json
@@ -258,7 +258,9 @@
         "hourlyRate": "{{value}}/u",
         "ticketWithNumber": "#{{number}} {{title}}",
         "billableHours": "{{value}} factureerbare uren",
-        "listSeparator": ", "
+        "listSeparator": ", ",
+        "attributionUncosted": "{{attribution}} (zonder kostentarief)",
+        "unassignedLine": "{{line}} (niet toegewezen)"
       },
       "errors": {
         "load": "Winstgevendheidsgegevens konden niet worden geladen",
@@ -308,7 +310,8 @@
         "costRates": "Er zijn geen kostentarieven geconfigureerd. Arbeidsuren worden zonder kostentarief weergegeven totdat er een tenantstandaard of gebruikerstarief bestaat.",
         "clients": "Geen winstgevendheidsgegevens per klant beschikbaar voor deze periode.",
         "lines": "Geen detailgegevens op regelniveau voor deze rij.",
-        "tickets": "Geen winstgevendheidsgegevens per ticket beschikbaar voor deze selectie."
+        "tickets": "Geen winstgevendheidsgegevens per ticket beschikbaar voor deze selectie.",
+        "agreements": "Geen winstgevendheidsgegevens per contract beschikbaar voor deze selectie."
       },
       "warnings": {
         "title": "Rapportwaarschuwingen",
@@ -340,6 +343,14 @@
       },
       "fallbacks": {
         "untitledTicket": "Ticket zonder titel"
+      },
+      "print": {
+        "dateRange": "{{start}} tot {{end}}",
+        "client": "Klant",
+        "allClients": "Alle klanten",
+        "agreement": "Contract",
+        "allAgreements": "Alle contracten",
+        "currency": "Valuta"
       }
     }
   },

--- a/server/public/locales/nl/msp/surveys.json
+++ b/server/public/locales/nl/msp/surveys.json
@@ -277,6 +277,7 @@
   },
   "dashboard": {
     "loadingInsights": "Enquête-inzichten laden...",
+    "printTitle": "Enquêtedashboard",
     "responseMetrics": {
       "cards": {
         "sent": "Verzonden uitnodigingen",
@@ -422,6 +423,43 @@
     },
     "fallbacks": {
       "none": "-"
+    }
+  },
+  "print": {
+    "emptyValue": "—",
+    "columns": {
+      "date": "Datum",
+      "averageRating": "Gemiddelde beoordeling",
+      "responses": "Reacties",
+      "rating": "Beoordeling",
+      "share": "Aandeel",
+      "ticket": "Ticket",
+      "client": "Klant",
+      "contact": "Contactpersoon",
+      "agent": "Agent",
+      "technician": "Technicus",
+      "submitted": "Ingediend",
+      "comment": "Opmerking"
+    },
+    "metrics": {
+      "averageRating": "Gemiddelde beoordeling",
+      "invitations": "Uitnodigingen",
+      "outstanding": "Openstaand",
+      "recentNegative": "Recent negatief",
+      "responseRate": "Responspercentage",
+      "responses": "Reacties"
+    },
+    "sections": {
+      "trend": "Reactietrend",
+      "distribution": "Tevredenheidsverdeling",
+      "topIssues": "Belangrijkste problemen",
+      "recentResponses": "Recente reacties"
+    },
+    "empty": {
+      "trend": "Geen reacties in deze periode.",
+      "distribution": "Geen beoordeelde reacties in deze periode.",
+      "topIssues": "Geen negatieve reacties in deze periode.",
+      "recentResponses": "Geen reacties in deze periode."
     }
   }
 }

--- a/server/public/locales/pl/features/inventory.json
+++ b/server/public/locales/pl/features/inventory.json
@@ -2,6 +2,7 @@
   "common": {
     "actions": "Akcje",
     "active": "Aktywny",
+    "allTime": "Cały okres",
     "cancel": "Anuluj",
     "clear": "Wyczyść",
     "close": "Zamknij",
@@ -14,6 +15,7 @@
     "inactive": "Nieaktywny",
     "loading": "Ładowanie…",
     "name": "Nazwa",
+    "period": "Okres",
     "quantity": "Ilość",
     "refresh": "Odśwież",
     "refreshing": "Odświeżanie…",
@@ -28,6 +30,7 @@
     "search": "Szukaj",
     "status": "Status",
     "to": "Do",
+    "today": "Dzisiaj",
     "total": "Razem",
     "unknown": "Nieznany"
   },
@@ -432,6 +435,7 @@
     "candidateCapNote": " (pokazano pierwsze {{cap}})",
     "candidateCount": "{{count}} kandydat widmowy",
     "candidateCountPlural": "{{count}} kandydatów widmowych",
+    "candidatesTitle": "Kandydaci widmowi",
     "columns": {
       "aiVerdict": "Werdykt AI",
       "assignedTo": "Przypisane do",

--- a/server/public/locales/pl/msp/reports.json
+++ b/server/public/locales/pl/msp/reports.json
@@ -258,7 +258,9 @@
         "hourlyRate": "{{value}}/godz.",
         "ticketWithNumber": "#{{number}} {{title}}",
         "billableHours": "{{value}} godz. rozliczalnych",
-        "listSeparator": ", "
+        "listSeparator": ", ",
+        "attributionUncosted": "{{attribution}} (bez wyceny)",
+        "unassignedLine": "{{line}} (nieprzydzielone)"
       },
       "errors": {
         "load": "Nie udało się załadować danych o rentowności",
@@ -308,7 +310,8 @@
         "costRates": "Stawki kosztów nie są skonfigurowane. Godziny pracy są wykazywane jako bez wyceny, dopóki nie istnieje stawka domyślna tenanta lub stawka użytkownika.",
         "clients": "Brak danych o rentowności klientów dla tego zakresu.",
         "lines": "Brak szczegółów na poziomie pozycji dla tego wiersza.",
-        "tickets": "Brak danych o rentowności zgłoszeń dla tego wyboru."
+        "tickets": "Brak danych o rentowności zgłoszeń dla tego wyboru.",
+        "agreements": "Brak danych o rentowności umów dla tego wyboru."
       },
       "warnings": {
         "title": "Ostrzeżenia raportu",
@@ -340,6 +343,14 @@
       },
       "fallbacks": {
         "untitledTicket": "Zgłoszenie bez tytułu"
+      },
+      "print": {
+        "dateRange": "{{start}} do {{end}}",
+        "client": "Klient",
+        "allClients": "Wszyscy klienci",
+        "agreement": "Umowa",
+        "allAgreements": "Wszystkie umowy",
+        "currency": "Waluta"
       }
     }
   },

--- a/server/public/locales/pl/msp/surveys.json
+++ b/server/public/locales/pl/msp/surveys.json
@@ -277,6 +277,7 @@
   },
   "dashboard": {
     "loadingInsights": "Ładowanie analizy ankiet...",
+    "printTitle": "Panel ankiet",
     "responseMetrics": {
       "cards": {
         "sent": "Wysłane zaproszenia",
@@ -422,6 +423,43 @@
     },
     "fallbacks": {
       "none": "-"
+    }
+  },
+  "print": {
+    "emptyValue": "—",
+    "columns": {
+      "date": "Data",
+      "averageRating": "Średnia ocena",
+      "responses": "Odpowiedzi",
+      "rating": "Ocena",
+      "share": "Udział",
+      "ticket": "Zgłoszenie",
+      "client": "Klient",
+      "contact": "Kontakt",
+      "agent": "Agent",
+      "technician": "Technik",
+      "submitted": "Przesłano",
+      "comment": "Komentarz"
+    },
+    "metrics": {
+      "averageRating": "Średnia ocena",
+      "invitations": "Zaproszenia",
+      "outstanding": "Oczekujące",
+      "recentNegative": "Ostatnie negatywne",
+      "responseRate": "Wskaźnik odpowiedzi",
+      "responses": "Odpowiedzi"
+    },
+    "sections": {
+      "trend": "Trend odpowiedzi",
+      "distribution": "Rozkład satysfakcji",
+      "topIssues": "Najczęstsze problemy",
+      "recentResponses": "Najnowsze odpowiedzi"
+    },
+    "empty": {
+      "trend": "Brak odpowiedzi w tym okresie.",
+      "distribution": "Brak ocenionych odpowiedzi w tym okresie.",
+      "topIssues": "Brak negatywnych odpowiedzi w tym okresie.",
+      "recentResponses": "Brak odpowiedzi w tym okresie."
     }
   }
 }

--- a/server/public/locales/pt/features/inventory.json
+++ b/server/public/locales/pt/features/inventory.json
@@ -2,6 +2,7 @@
   "common": {
     "actions": "Ações",
     "active": "Ativo",
+    "allTime": "Todo o período",
     "cancel": "Cancelar",
     "clear": "Limpar",
     "close": "Fechar",
@@ -14,6 +15,7 @@
     "inactive": "Inativo",
     "loading": "Carregando…",
     "name": "Nome",
+    "period": "Período",
     "quantity": "Quantidade",
     "refresh": "Atualizar",
     "refreshing": "Atualizando…",
@@ -28,6 +30,7 @@
     "search": "Buscar",
     "status": "Status",
     "to": "Para",
+    "today": "Hoje",
     "total": "Total",
     "unknown": "Desconhecido"
   },
@@ -432,6 +435,7 @@
     "candidateCapNote": " (exibindo os primeiros {{cap}})",
     "candidateCount": "{{count}} candidato fantasma",
     "candidateCountPlural": "{{count}} candidatos fantasma",
+    "candidatesTitle": "Candidatos fantasma",
     "columns": {
       "aiVerdict": "Veredito da IA",
       "assignedTo": "Atribuído a",

--- a/server/public/locales/pt/msp/reports.json
+++ b/server/public/locales/pt/msp/reports.json
@@ -258,7 +258,9 @@
         "hourlyRate": "{{value}}/h",
         "ticketWithNumber": "#{{number}} {{title}}",
         "billableHours": "{{value}} h faturáveis",
-        "listSeparator": ", "
+        "listSeparator": ", ",
+        "attributionUncosted": "{{attribution}} (sem custo definido)",
+        "unassignedLine": "{{line}} (não atribuído)"
       },
       "errors": {
         "load": "Falha ao carregar dados de rentabilidade",
@@ -308,7 +310,8 @@
         "costRates": "As taxas de custo não estão configuradas. As horas de mão de obra são exibidas sem custo definido até que exista uma taxa padrão do locatário ou por usuário.",
         "clients": "Não há dados de rentabilidade por cliente disponíveis para este período.",
         "lines": "Não há detalhes no nível de linha para este item.",
-        "tickets": "Não há dados de rentabilidade por ticket disponíveis para esta seleção."
+        "tickets": "Não há dados de rentabilidade por ticket disponíveis para esta seleção.",
+        "agreements": "Não há dados de rentabilidade por contrato disponíveis para esta seleção."
       },
       "warnings": {
         "title": "Avisos do relatório",
@@ -340,6 +343,14 @@
       },
       "fallbacks": {
         "untitledTicket": "Ticket sem título"
+      },
+      "print": {
+        "dateRange": "{{start}} a {{end}}",
+        "client": "Cliente",
+        "allClients": "Todos os clientes",
+        "agreement": "Contrato",
+        "allAgreements": "Todos os contratos",
+        "currency": "Moeda"
       }
     }
   },

--- a/server/public/locales/pt/msp/surveys.json
+++ b/server/public/locales/pt/msp/surveys.json
@@ -277,6 +277,7 @@
   },
   "dashboard": {
     "loadingInsights": "Carregando informações da pesquisa...",
+    "printTitle": "Painel de pesquisas",
     "responseMetrics": {
       "cards": {
         "sent": "Convites enviados",
@@ -422,6 +423,43 @@
     },
     "fallbacks": {
       "none": "-"
+    }
+  },
+  "print": {
+    "emptyValue": "—",
+    "columns": {
+      "date": "Data",
+      "averageRating": "Avaliação média",
+      "responses": "Respostas",
+      "rating": "Avaliação",
+      "share": "Percentual",
+      "ticket": "Ticket",
+      "client": "Cliente",
+      "contact": "Contato",
+      "agent": "Agente",
+      "technician": "Técnico",
+      "submitted": "Enviado",
+      "comment": "Comentário"
+    },
+    "metrics": {
+      "averageRating": "Avaliação média",
+      "invitations": "Convites",
+      "outstanding": "Pendentes",
+      "recentNegative": "Negativas recentes",
+      "responseRate": "Taxa de resposta",
+      "responses": "Respostas"
+    },
+    "sections": {
+      "trend": "Tendência de resposta",
+      "distribution": "Distribuição de Satisfação",
+      "topIssues": "Principais problemas",
+      "recentResponses": "Respostas recentes"
+    },
+    "empty": {
+      "trend": "Não há respostas neste período.",
+      "distribution": "Não há respostas avaliadas neste período.",
+      "topIssues": "Não há respostas negativas neste período.",
+      "recentResponses": "Não há respostas neste período."
     }
   }
 }

--- a/server/public/locales/xx/features/inventory.json
+++ b/server/public/locales/xx/features/inventory.json
@@ -2,6 +2,7 @@
   "common": {
     "actions": "11111",
     "active": "11111",
+    "allTime": "11111",
     "cancel": "11111",
     "clear": "11111",
     "close": "11111",
@@ -14,6 +15,7 @@
     "inactive": "11111",
     "loading": "11111",
     "name": "11111",
+    "period": "11111",
     "quantity": "11111",
     "refresh": "11111",
     "refreshing": "11111",
@@ -28,6 +30,7 @@
     "search": "11111",
     "status": "11111",
     "to": "11111",
+    "today": "11111",
     "total": "11111",
     "unknown": "11111"
   },
@@ -432,6 +435,7 @@
     "candidateCapNote": "11111 {{cap}} 11111",
     "candidateCount": "11111 {{count}} 11111",
     "candidateCountPlural": "11111 {{count}} 11111",
+    "candidatesTitle": "11111",
     "columns": {
       "aiVerdict": "11111",
       "assignedTo": "11111",

--- a/server/public/locales/xx/msp/integrations.json
+++ b/server/public/locales/xx/msp/integrations.json
@@ -370,7 +370,7 @@
           "baseUrlPlaceholder": "11111"
         },
         "test": {
-          "passed": "11111",
+          "passed": "11111 {{count}} 11111",
           "required": "11111"
         },
         "title": "11111"
@@ -395,18 +395,18 @@
           "connection": "11111",
           "connectionDetail": "11111",
           "empty": "11111",
-          "failedClients": "11111",
-          "failedClientsDetail": "11111",
-          "failedClientsOne": "11111",
-          "neverSynced": "11111",
-          "neverSyncedDetail": "11111",
-          "neverSyncedOne": "11111",
+          "failedClients": "11111 {{count}} 11111",
+          "failedClientsDetail": "11111 {{clients}} 11111",
+          "failedClientsOne": "11111 {{count}} 11111",
+          "neverSynced": "11111 {{count}} 11111",
+          "neverSyncedDetail": "11111 {{clients}} 11111",
+          "neverSyncedOne": "11111 {{count}} 11111",
           "noClients": "11111",
           "noClientsDetail": "11111",
-          "reviewQueue": "11111",
-          "reviewQueueAtLeast": "11111",
+          "reviewQueue": "11111 {{count}} 11111",
+          "reviewQueueAtLeast": "11111 {{count}} 11111",
           "reviewQueueDetail": "11111",
-          "reviewQueueOne": "11111",
+          "reviewQueueOne": "11111 {{count}} 11111",
           "scheduleNotApplied": "11111",
           "scheduleNotAppliedDetail": "11111",
           "scheduleOff": "11111",
@@ -446,13 +446,13 @@
           "emptyAction": "11111",
           "clearFilters": "11111",
           "unlinkConfirm": {
-            "body": "11111",
-            "title": "11111"
+            "body": "11111 {{client}} 11111",
+            "title": "11111 {{client}} 11111"
           },
-          "unlinked": "11111",
+          "unlinked": "11111 {{client}} 11111",
           "unlinkFailed": "11111",
           "hidePreview": "11111",
-          "previewLoading": "11111",
+          "previewLoading": "11111 {{client}} 11111",
           "previewLoadingHint": "11111"
         },
         "connection": {
@@ -475,8 +475,8 @@
         },
         "health": {
           "checking": "11111",
-          "failingClients": "11111",
-          "failingClientsOne": "11111",
+          "failingClients": "11111 {{count}} 11111",
+          "failingClientsOne": "11111 {{count}} 11111",
           "healthy": "11111",
           "unknown": "11111"
         },
@@ -495,7 +495,7 @@
           "includePreviews": "11111",
           "next": "11111",
           "onlyFailures": "11111",
-          "page": "11111",
+          "page": "11111 {{page}} 11111 {{pages}} 11111",
           "previewBadge": "11111",
           "previous": "11111",
           "triggers": {
@@ -514,15 +514,15 @@
             "updated": "11111"
           },
           "empty": "11111",
-          "progress": "11111",
+          "progress": "11111 {{processed}} 11111 {{total}} 11111",
           "results": {
             "done": "11111",
             "failed": "11111",
             "partlyFailed": "11111",
             "running": "11111",
-            "toReview": "11111"
+            "toReview": "11111 {{count}} 11111"
           },
-          "showAll": "11111",
+          "showAll": "11111 {{count}} 11111",
           "stats": {
             "created": "11111",
             "createdSub": "11111",
@@ -536,16 +536,16 @@
             "updatedSub": "11111"
           },
           "summaries": {
-            "completed": "11111",
-            "failed": "11111",
-            "partial": "11111",
-            "running": "11111",
-            "unknown": "11111"
+            "completed": "11111 {{time}} 11111",
+            "failed": "11111 {{time}} 11111",
+            "partial": "11111 {{time}} 11111",
+            "running": "11111 {{time}} 11111",
+            "unknown": "11111 {{time}} 11111"
           },
           "title": "11111",
           "unavailable": "11111"
         },
-        "lead": "11111",
+        "lead": "11111 {{clients}} 11111 {{method}} 11111",
         "overwrites": {
           "change": "11111",
           "inactivateOff": "11111",
@@ -555,22 +555,22 @@
         },
         "schedule": {
           "cadence": {
-            "10080": "11111",
-            "1440": "11111",
-            "240": "11111",
             "60": "11111",
-            "720": "11111"
+            "240": "11111",
+            "720": "11111",
+            "1440": "11111",
+            "10080": "11111"
           },
           "changeAction": "11111",
           "description": "11111",
           "enablePrompt": "11111",
           "intervalLabel": "11111",
           "intervals": {
-            "10080": "11111",
-            "1440": "11111",
-            "240": "11111",
             "60": "11111",
-            "720": "11111"
+            "240": "11111",
+            "720": "11111",
+            "1440": "11111",
+            "10080": "11111"
           },
           "pause": "11111",
           "pauseHint": "11111",
@@ -584,8 +584,8 @@
           "title": "11111"
         },
         "sideRail": {
-          "runs": "11111",
-          "runsMinutes": "11111",
+          "runs": "11111 {{cadence}} 11111",
+          "runsMinutes": "11111 {{minutes}} 11111",
           "scheduleOff": "11111"
         },
         "syncStarted": "11111",
@@ -604,8 +604,8 @@
           "preview": "11111",
           "previewing": "11111",
           "syncOne": "11111",
-          "syncOneNamed": "11111",
-          "syncRemaining": "11111",
+          "syncOneNamed": "11111 {{client}} 11111",
+          "syncRemaining": "11111 {{count}} 11111",
           "syncingOne": "11111",
           "syncingRemaining": "11111"
         },
@@ -618,8 +618,8 @@
         },
         "gateNote": "11111",
         "previewPrompt": "11111",
-        "remainingStarted": "11111",
-        "started": "11111"
+        "remainingStarted": "11111 {{count}} 11111",
+        "started": "11111 {{client}} 11111"
       },
       "preflight": {
         "buckets": {
@@ -647,11 +647,11 @@
         "checkAgain": "11111",
         "checkedLabel": "11111",
         "hideNames": "11111",
-        "moreNames": "11111",
+        "moreNames": "11111 {{count}} 11111",
         "nothingWritten": "11111",
         "showNames": "11111",
-        "summary": "11111",
-        "summaryNoTime": "11111",
+        "summary": "11111 {{count}} 11111 {{time}} 11111",
+        "summaryNoTime": "11111 {{count}} 11111",
         "title": "11111"
       },
       "reconciliation": {
@@ -680,7 +680,7 @@
         "queuedAt": "11111 {{identity}} 11111 {{time}} 11111",
         "scopedToMappedClient": "11111",
         "success": {
-          "dismissed": "11111",
+          "dismissed": "11111 {{identity}} 11111",
           "resolvedExisting": "11111 {{queueItemId}} 11111 {{contactNameId}} 11111",
           "resolvedNew": "11111 {{queueItemId}} 11111 {{contactNameId}} 11111"
         },
@@ -913,7 +913,7 @@
         }
       },
       "setup": {
-        "backToCurrentStep": "11111",
+        "backToCurrentStep": "11111 {{step}} 11111",
         "chooser": {
           "cipp": {
             "description": "11111",
@@ -944,7 +944,7 @@
           "recommendedBadge": "11111",
           "title": "11111"
         },
-        "connectedVia": "11111",
+        "connectedVia": "11111 {{method}} 11111",
         "description": "11111",
         "directConsent": {
           "adminNote": "11111",
@@ -975,7 +975,7 @@
           "copy": "11111",
           "description": "11111",
           "inactiveNote": "11111",
-          "recordGeneratedAt": "11111",
+          "recordGeneratedAt": "11111 {{time}} 11111",
           "recordHeading": "11111",
           "scopes": {
             "directory": "11111",
@@ -988,7 +988,7 @@
           "scopesTitle": "11111",
           "title": "11111"
         },
-        "stepLabel": "11111",
+        "stepLabel": "11111 {{number}} 11111",
         "steps": {
           "connect": {
             "description": "11111",

--- a/server/public/locales/xx/msp/reports.json
+++ b/server/public/locales/xx/msp/reports.json
@@ -258,7 +258,9 @@
         "hourlyRate": "11111 {{value}} 11111",
         "ticketWithNumber": "11111 {{number}} 11111 {{title}} 11111",
         "billableHours": "11111 {{value}} 11111",
-        "listSeparator": "11111"
+        "listSeparator": "11111",
+        "attributionUncosted": "11111 {{attribution}} 11111",
+        "unassignedLine": "11111 {{line}} 11111"
       },
       "errors": {
         "load": "11111",
@@ -308,7 +310,16 @@
         "costRates": "11111",
         "clients": "11111",
         "lines": "11111",
-        "tickets": "11111"
+        "tickets": "11111",
+        "agreements": "11111"
+      },
+      "print": {
+        "dateRange": "11111 {{start}} 11111 {{end}} 11111",
+        "client": "11111",
+        "allClients": "11111",
+        "agreement": "11111",
+        "allAgreements": "11111",
+        "currency": "11111"
       },
       "warnings": {
         "title": "11111",

--- a/server/public/locales/xx/msp/surveys.json
+++ b/server/public/locales/xx/msp/surveys.json
@@ -277,6 +277,7 @@
   },
   "dashboard": {
     "loadingInsights": "11111",
+    "printTitle": "11111",
     "responseMetrics": {
       "cards": {
         "sent": "11111",
@@ -422,6 +423,43 @@
     },
     "fallbacks": {
       "none": "11111"
+    }
+  },
+  "print": {
+    "emptyValue": "11111",
+    "columns": {
+      "date": "11111",
+      "averageRating": "11111",
+      "responses": "11111",
+      "rating": "11111",
+      "share": "11111",
+      "ticket": "11111",
+      "client": "11111",
+      "contact": "11111",
+      "agent": "11111",
+      "technician": "11111",
+      "submitted": "11111",
+      "comment": "11111"
+    },
+    "metrics": {
+      "invitations": "11111",
+      "responses": "11111",
+      "responseRate": "11111",
+      "averageRating": "11111",
+      "outstanding": "11111",
+      "recentNegative": "11111"
+    },
+    "sections": {
+      "trend": "11111",
+      "distribution": "11111",
+      "topIssues": "11111",
+      "recentResponses": "11111"
+    },
+    "empty": {
+      "trend": "11111",
+      "distribution": "11111",
+      "topIssues": "11111",
+      "recentResponses": "11111"
     }
   }
 }

--- a/server/public/locales/yy/features/inventory.json
+++ b/server/public/locales/yy/features/inventory.json
@@ -2,6 +2,7 @@
   "common": {
     "actions": "55555",
     "active": "55555",
+    "allTime": "55555",
     "cancel": "55555",
     "clear": "55555",
     "close": "55555",
@@ -14,6 +15,7 @@
     "inactive": "55555",
     "loading": "55555",
     "name": "55555",
+    "period": "55555",
     "quantity": "55555",
     "refresh": "55555",
     "refreshing": "55555",
@@ -28,6 +30,7 @@
     "search": "55555",
     "status": "55555",
     "to": "55555",
+    "today": "55555",
     "total": "55555",
     "unknown": "55555"
   },
@@ -432,6 +435,7 @@
     "candidateCapNote": "55555 {{cap}} 55555",
     "candidateCount": "55555 {{count}} 55555",
     "candidateCountPlural": "55555 {{count}} 55555",
+    "candidatesTitle": "55555",
     "columns": {
       "aiVerdict": "55555",
       "assignedTo": "55555",

--- a/server/public/locales/yy/msp/integrations.json
+++ b/server/public/locales/yy/msp/integrations.json
@@ -370,7 +370,7 @@
           "baseUrlPlaceholder": "55555"
         },
         "test": {
-          "passed": "55555",
+          "passed": "55555 {{count}} 55555",
           "required": "55555"
         },
         "title": "55555"
@@ -395,18 +395,18 @@
           "connection": "55555",
           "connectionDetail": "55555",
           "empty": "55555",
-          "failedClients": "55555",
-          "failedClientsDetail": "55555",
-          "failedClientsOne": "55555",
-          "neverSynced": "55555",
-          "neverSyncedDetail": "55555",
-          "neverSyncedOne": "55555",
+          "failedClients": "55555 {{count}} 55555",
+          "failedClientsDetail": "55555 {{clients}} 55555",
+          "failedClientsOne": "55555 {{count}} 55555",
+          "neverSynced": "55555 {{count}} 55555",
+          "neverSyncedDetail": "55555 {{clients}} 55555",
+          "neverSyncedOne": "55555 {{count}} 55555",
           "noClients": "55555",
           "noClientsDetail": "55555",
-          "reviewQueue": "55555",
-          "reviewQueueAtLeast": "55555",
+          "reviewQueue": "55555 {{count}} 55555",
+          "reviewQueueAtLeast": "55555 {{count}} 55555",
           "reviewQueueDetail": "55555",
-          "reviewQueueOne": "55555",
+          "reviewQueueOne": "55555 {{count}} 55555",
           "scheduleNotApplied": "55555",
           "scheduleNotAppliedDetail": "55555",
           "scheduleOff": "55555",
@@ -446,13 +446,13 @@
           "emptyAction": "55555",
           "clearFilters": "55555",
           "unlinkConfirm": {
-            "body": "55555",
-            "title": "55555"
+            "body": "55555 {{client}} 55555",
+            "title": "55555 {{client}} 55555"
           },
-          "unlinked": "55555",
+          "unlinked": "55555 {{client}} 55555",
           "unlinkFailed": "55555",
           "hidePreview": "55555",
-          "previewLoading": "55555",
+          "previewLoading": "55555 {{client}} 55555",
           "previewLoadingHint": "55555"
         },
         "connection": {
@@ -475,8 +475,8 @@
         },
         "health": {
           "checking": "55555",
-          "failingClients": "55555",
-          "failingClientsOne": "55555",
+          "failingClients": "55555 {{count}} 55555",
+          "failingClientsOne": "55555 {{count}} 55555",
           "healthy": "55555",
           "unknown": "55555"
         },
@@ -495,7 +495,7 @@
           "includePreviews": "55555",
           "next": "55555",
           "onlyFailures": "55555",
-          "page": "55555",
+          "page": "55555 {{page}} 55555 {{pages}} 55555",
           "previewBadge": "55555",
           "previous": "55555",
           "triggers": {
@@ -514,15 +514,15 @@
             "updated": "55555"
           },
           "empty": "55555",
-          "progress": "55555",
+          "progress": "55555 {{processed}} 55555 {{total}} 55555",
           "results": {
             "done": "55555",
             "failed": "55555",
             "partlyFailed": "55555",
             "running": "55555",
-            "toReview": "55555"
+            "toReview": "55555 {{count}} 55555"
           },
-          "showAll": "55555",
+          "showAll": "55555 {{count}} 55555",
           "stats": {
             "created": "55555",
             "createdSub": "55555",
@@ -536,16 +536,16 @@
             "updatedSub": "55555"
           },
           "summaries": {
-            "completed": "55555",
-            "failed": "55555",
-            "partial": "55555",
-            "running": "55555",
-            "unknown": "55555"
+            "completed": "55555 {{time}} 55555",
+            "failed": "55555 {{time}} 55555",
+            "partial": "55555 {{time}} 55555",
+            "running": "55555 {{time}} 55555",
+            "unknown": "55555 {{time}} 55555"
           },
           "title": "55555",
           "unavailable": "55555"
         },
-        "lead": "55555",
+        "lead": "55555 {{clients}} 55555 {{method}} 55555",
         "overwrites": {
           "change": "55555",
           "inactivateOff": "55555",
@@ -555,22 +555,22 @@
         },
         "schedule": {
           "cadence": {
-            "10080": "55555",
-            "1440": "55555",
-            "240": "55555",
             "60": "55555",
-            "720": "55555"
+            "240": "55555",
+            "720": "55555",
+            "1440": "55555",
+            "10080": "55555"
           },
           "changeAction": "55555",
           "description": "55555",
           "enablePrompt": "55555",
           "intervalLabel": "55555",
           "intervals": {
-            "10080": "55555",
-            "1440": "55555",
-            "240": "55555",
             "60": "55555",
-            "720": "55555"
+            "240": "55555",
+            "720": "55555",
+            "1440": "55555",
+            "10080": "55555"
           },
           "pause": "55555",
           "pauseHint": "55555",
@@ -584,8 +584,8 @@
           "title": "55555"
         },
         "sideRail": {
-          "runs": "55555",
-          "runsMinutes": "55555",
+          "runs": "55555 {{cadence}} 55555",
+          "runsMinutes": "55555 {{minutes}} 55555",
           "scheduleOff": "55555"
         },
         "syncStarted": "55555",
@@ -604,8 +604,8 @@
           "preview": "55555",
           "previewing": "55555",
           "syncOne": "55555",
-          "syncOneNamed": "55555",
-          "syncRemaining": "55555",
+          "syncOneNamed": "55555 {{client}} 55555",
+          "syncRemaining": "55555 {{count}} 55555",
           "syncingOne": "55555",
           "syncingRemaining": "55555"
         },
@@ -618,8 +618,8 @@
         },
         "gateNote": "55555",
         "previewPrompt": "55555",
-        "remainingStarted": "55555",
-        "started": "55555"
+        "remainingStarted": "55555 {{count}} 55555",
+        "started": "55555 {{client}} 55555"
       },
       "preflight": {
         "buckets": {
@@ -647,11 +647,11 @@
         "checkAgain": "55555",
         "checkedLabel": "55555",
         "hideNames": "55555",
-        "moreNames": "55555",
+        "moreNames": "55555 {{count}} 55555",
         "nothingWritten": "55555",
         "showNames": "55555",
-        "summary": "55555",
-        "summaryNoTime": "55555",
+        "summary": "55555 {{count}} 55555 {{time}} 55555",
+        "summaryNoTime": "55555 {{count}} 55555",
         "title": "55555"
       },
       "reconciliation": {
@@ -680,7 +680,7 @@
         "queuedAt": "55555 {{identity}} 55555 {{time}} 55555",
         "scopedToMappedClient": "55555",
         "success": {
-          "dismissed": "55555",
+          "dismissed": "55555 {{identity}} 55555",
           "resolvedExisting": "55555 {{queueItemId}} 55555 {{contactNameId}} 55555",
           "resolvedNew": "55555 {{queueItemId}} 55555 {{contactNameId}} 55555"
         },
@@ -913,7 +913,7 @@
         }
       },
       "setup": {
-        "backToCurrentStep": "55555",
+        "backToCurrentStep": "55555 {{step}} 55555",
         "chooser": {
           "cipp": {
             "description": "55555",
@@ -944,7 +944,7 @@
           "recommendedBadge": "55555",
           "title": "55555"
         },
-        "connectedVia": "55555",
+        "connectedVia": "55555 {{method}} 55555",
         "description": "55555",
         "directConsent": {
           "adminNote": "55555",
@@ -975,7 +975,7 @@
           "copy": "55555",
           "description": "55555",
           "inactiveNote": "55555",
-          "recordGeneratedAt": "55555",
+          "recordGeneratedAt": "55555 {{time}} 55555",
           "recordHeading": "55555",
           "scopes": {
             "directory": "55555",
@@ -988,7 +988,7 @@
           "scopesTitle": "55555",
           "title": "55555"
         },
-        "stepLabel": "55555",
+        "stepLabel": "55555 {{number}} 55555",
         "steps": {
           "connect": {
             "description": "55555",

--- a/server/public/locales/yy/msp/reports.json
+++ b/server/public/locales/yy/msp/reports.json
@@ -258,7 +258,9 @@
         "hourlyRate": "55555 {{value}} 55555",
         "ticketWithNumber": "55555 {{number}} 55555 {{title}} 55555",
         "billableHours": "55555 {{value}} 55555",
-        "listSeparator": "55555"
+        "listSeparator": "55555",
+        "attributionUncosted": "55555 {{attribution}} 55555",
+        "unassignedLine": "55555 {{line}} 55555"
       },
       "errors": {
         "load": "55555",
@@ -308,7 +310,16 @@
         "costRates": "55555",
         "clients": "55555",
         "lines": "55555",
-        "tickets": "55555"
+        "tickets": "55555",
+        "agreements": "55555"
+      },
+      "print": {
+        "dateRange": "55555 {{start}} 55555 {{end}} 55555",
+        "client": "55555",
+        "allClients": "55555",
+        "agreement": "55555",
+        "allAgreements": "55555",
+        "currency": "55555"
       },
       "warnings": {
         "title": "55555",

--- a/server/public/locales/yy/msp/surveys.json
+++ b/server/public/locales/yy/msp/surveys.json
@@ -277,6 +277,7 @@
   },
   "dashboard": {
     "loadingInsights": "55555",
+    "printTitle": "55555",
     "responseMetrics": {
       "cards": {
         "sent": "55555",
@@ -422,6 +423,43 @@
     },
     "fallbacks": {
       "none": "55555"
+    }
+  },
+  "print": {
+    "emptyValue": "55555",
+    "columns": {
+      "date": "55555",
+      "averageRating": "55555",
+      "responses": "55555",
+      "rating": "55555",
+      "share": "55555",
+      "ticket": "55555",
+      "client": "55555",
+      "contact": "55555",
+      "agent": "55555",
+      "technician": "55555",
+      "submitted": "55555",
+      "comment": "55555"
+    },
+    "metrics": {
+      "invitations": "55555",
+      "responses": "55555",
+      "responseRate": "55555",
+      "averageRating": "55555",
+      "outstanding": "55555",
+      "recentNegative": "55555"
+    },
+    "sections": {
+      "trend": "55555",
+      "distribution": "55555",
+      "topIssues": "55555",
+      "recentResponses": "55555"
+    },
+    "empty": {
+      "trend": "55555",
+      "distribution": "55555",
+      "topIssues": "55555",
+      "recentResponses": "55555"
     }
   }
 }


### PR DESCRIPTION
Only the five reports on /msp/reports could print; every other report surface had no print affordance at all — including Billing Profitability.

Wire the existing print infrastructure (usePrintAction/PrintButton, PrintableTable, PrintableDetailHeader, print.css) into the remaining reports, and add a shared PrintableSummary for the KPI card strips that don't survive @media print:

- Billing Profitability: date window, scope, summary, warnings, and the full clients -> agreements -> contract-lines -> tickets drill-down
- Contract Revenue / Expiration / Bucket Hours: per-tab print regions
- Inventory Margin, Write-offs, Ghost Usage
- Survey Analytics and Dashboard, via a new SurveyPrintReport client component (both pages are async server components, so column render functions cannot cross the RSC boundary)

Print regions render every row; the on-screen tables paginate at 10, so a printed report is no longer silently truncated to page one. Label logic for ticket titles, attribution, contract status, and movement type is now shared between the screen and print paths.

Adds ~43 keys across msp/reports, features/inventory, and msp/surveys, translated into all seven locales; pseudo-locales regenerated.

Also repairs stale tests: ProfitabilityReport.test.tsx mocked the wrong actions path and still stubbed Input instead of DatePicker, so all six tests were silently rendering the error branch. Its error test asserted raw exception text that the component deliberately never shows, so it now covers both the thrown (generic copy) and returned (user-safe message) paths. The msp-composition contract test resolved its target through process.cwd() and only passed under the server config; the profitability SQL contract test broke on reformatting, not behavior.

"But how does one print a Cheshire Cat?" asked Alice, quite reasonably, for the report had faded until nothing remained but its margins. "You mark the ancestors and hide the siblings," said the Hatter, marking ancestors and hiding siblings, "and then it is all grin and no cat, or all cat and no grin, depending entirely on the media query." Alice observed that page one had eaten the other nine. "That," said the Hatter, "is why we no longer paginate at ten." 🎩🖨️🐈