### PR TITLE
Move ticket description into bento hero

### DIFF
--- a/packages/tickets/src/components/ticket/TicketDetails.tsx
+++ b/packages/tickets/src/components/ticket/TicketDetails.tsx
@@ -3647,6 +3647,7 @@ const handleClose = () => {
                     agentOptions={agentOptions}
                     onSelectChange={handleSelectChange}
                     onBatchSelectChange={(changes, options) => handleBatchSaveChanges(changes, options)}
+                    onUpdateDescription={handleUpdateDescription}
                     responseStateTrackingEnabled={responseStateTrackingEnabled}
                     hideSlaStatus={hideSlaStatus}
                     hideBilling={hideBilling}

--- a/packages/tickets/src/components/ticket/bento/BentoHero.tsx
+++ b/packages/tickets/src/components/ticket/bento/BentoHero.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import type { PartialBlock } from '@blocknote/core';
 import { Pencil, SlidersHorizontal, Flame, Save, CheckCircle } from 'lucide-react';
 import { Button } from '@alga-psa/ui/components/Button';
 import { Input } from '@alga-psa/ui/components/Input';
@@ -15,13 +16,18 @@ import UserAvatar from '@alga-psa/ui/components/UserAvatar';
 import { Badge } from '@alga-psa/ui/components/Badge';
 import { Tooltip } from '@alga-psa/ui/components/Tooltip';
 import { TagManager } from '@alga-psa/tags/components';
-import type { ITag, ITicket, ITeam, ITicketResource, IUserWithRoles } from '@alga-psa/types';
+import type { ITag, ITicket, ITeam, ITicketResource, IUser, IUserWithRoles } from '@alga-psa/types';
 import { useTranslation } from '@alga-psa/ui/lib/i18n/client';
-import { BentoTile } from '@alga-psa/ui/components/bento/BentoTile';
+import { BentoTile, BentoTileEmpty } from '@alga-psa/ui/components/bento/BentoTile';
+import { RichTextViewer, TextEditor } from '@alga-psa/ui/editor';
 import { FieldConflictBanner } from '@alga-psa/ui/presence/FieldConflictBanner';
+import { searchUsersForMentions } from '@alga-psa/user-composition/actions';
+import { useDocumentsCrossFeature } from '@alga-psa/core/context/DocumentsCrossFeatureContext';
 import { computeSlaClocks, formatSlaLabel, type TicketSlaFields } from './slaClocks';
 import { useTeamAvatarUrl } from './useTeamAvatarUrl';
 import type { TicketLiveConflictState } from '../ticketLiveFields';
+import { parseTicketRichTextContent, serializeTicketRichTextContent } from '../../../lib/ticketRichText';
+import { useTicketRichTextUploadSession } from '../useTicketRichTextUploadSession';
 import { getTicketStatuses } from '@alga-psa/reference-data/actions';
 import { getTicketCategoriesByBoard, type BoardCategoryData } from '../../../actions/ticketCategoryActions';
 import { useRegisterUnsavedChanges } from '@alga-psa/ui/context';
@@ -61,7 +67,7 @@ interface BentoHeroProps {
   id: string;
   /** Observed by TicketDetails' sticky header to float the title on scroll. */
   titleRef?: React.Ref<HTMLHeadingElement>;
-  ticket: ITicket & TicketSlaFields & { escalated?: boolean; escalation_level?: number | null };
+  ticket: ITicket & TicketSlaFields & { source?: string | null; escalated?: boolean; escalation_level?: number | null };
   statusOptions: HeroSelectOption[];
   priorityOptions: HeroSelectOption[];
   boardOptions: HeroSelectOption[];
@@ -87,9 +93,11 @@ interface BentoHeroProps {
    * onSelectChange when absent.
    */
   onBatchSelectChange?: (
-    changes: Record<string, string | null>,
+    changes: Record<string, unknown>,
     options?: TicketNotificationSuppressionValue
   ) => Promise<boolean | void> | boolean | void;
+  /** Persists the description on its own; used only when no batch handler exists. */
+  onUpdateDescription?: (content: string) => Promise<boolean>;
   responseStateTrackingEnabled?: boolean;
   hideSlaStatus?: boolean;
   /** Locks workflow fields when the ticket is a bundle child. */
@@ -119,6 +127,21 @@ interface BentoHeroProps {
   onLiveEditingFieldChange?: (field: string | null) => void;
   /** Reports locally dirty hero fields for live update conflict/highlight filtering. */
   onLiveDirtyFieldsChange?: (fields: string[]) => void;
+  // Description editing (same pipeline TicketInfo uses for pasted images).
+  /** Who opened the ticket; rendered as the description caption. */
+  createdByUser?: IUser | null;
+  /** Current user id; required for clipboard-image uploads. */
+  userId?: string;
+  onClipboardImageUploaded?: () => void;
+  uploadTicketAttachmentAction?: (
+    formData: FormData,
+    params: { userId: string; ticketId: string }
+  ) => Promise<any>;
+  deleteDraftTicketAttachmentImagesAction?: (input: {
+    ticketId: string;
+    documentIds: string[];
+  }) => Promise<{ deletedDocumentIds: string[]; failures: Array<{ documentId: string; reason: string }> }>;
+  resolveTicketAttachmentViewUrl?: (document: { document_id?: string; file_id?: string }) => string;
 }
 
 function HeroField({ label, children }: { label: string; children: React.ReactNode }) {
@@ -155,6 +178,7 @@ export function BentoHero({
   onAgentClick,
   onSelectChange,
   onBatchSelectChange,
+  onUpdateDescription,
   responseStateTrackingEnabled,
   hideSlaStatus,
   workflowLocked,
@@ -172,6 +196,12 @@ export function BentoHero({
   liveEditingUsers,
   onLiveEditingFieldChange,
   onLiveDirtyFieldsChange,
+  createdByUser,
+  userId,
+  onClipboardImageUploaded,
+  uploadTicketAttachmentAction,
+  deleteDraftTicketAttachmentImagesAction,
+  resolveTicketAttachmentViewUrl,
 }: BentoHeroProps) {
   const { t } = useTranslation('features/tickets');
   const [isEditingTitle, setIsEditingTitle] = useState(false);
@@ -197,7 +227,9 @@ export function BentoHero({
 
   const [originalTicketValues, setOriginalTicketValues] = useState<HeroPendingChanges>(() => buildOriginalTicketValues());
   const [pendingChanges, setPendingChanges] = useState<HeroPendingChanges>({});
-  const hasUnsavedChanges = Object.keys(pendingChanges).length > 0;
+  const [isEditingDescription, setIsEditingDescription] = useState(false);
+  const [hasDescriptionContentChanged, setHasDescriptionContentChanged] = useState(false);
+  const hasUnsavedChanges = Object.keys(pendingChanges).length > 0 || hasDescriptionContentChanged;
   const hasActiveLiveConflict = Boolean(liveFieldConflicts && Object.keys(liveFieldConflicts).length > 0);
 
   useRegisterUnsavedChanges(`ticket-bento-hero-${id}`, hasUnsavedChanges);
@@ -266,6 +298,66 @@ export function BentoHero({
   }, [liveFieldConflicts]);
 
   const [titleDraft, setTitleDraft] = useState(ticket.title ?? '');
+
+  // --- Description (entry-view parity: same editor + clipboard pipeline) ---
+  const { deleteDocument } = useDocumentsCrossFeature();
+  const originalDescriptionRef = useRef<PartialBlock[] | null>(null);
+  const [descriptionContent, setDescriptionContent] = useState<PartialBlock[]>(() =>
+    parseTicketRichTextContent(ticket.attributes?.description as string | object | undefined),
+  );
+  const [descriptionExpanded, setDescriptionExpanded] = useState(false);
+  const [descriptionOverflows, setDescriptionOverflows] = useState(false);
+  const descriptionBodyRef = useRef<HTMLDivElement>(null);
+
+  const discardDescriptionEdit = useCallback(() => {
+    const originalDescription =
+      originalDescriptionRef.current ??
+      parseTicketRichTextContent(ticket.attributes?.description as string | object | undefined);
+    setDescriptionContent(originalDescription);
+    setHasDescriptionContentChanged(false);
+    setIsEditingDescription(false);
+  }, [ticket.attributes?.description]);
+
+  const descriptionUploadSession = useTicketRichTextUploadSession({
+    componentLabel: 'BentoHero',
+    ticketId: ticket.ticket_id,
+    userId,
+    trackDraftUploads: true,
+    onDocumentsChanged: onClipboardImageUploaded,
+    onDiscard: discardDescriptionEdit,
+    uploadDocumentAction: uploadTicketAttachmentAction,
+    deleteDraftClipboardImagesAction: deleteDraftTicketAttachmentImagesAction,
+    resolveDocumentViewUrl: resolveTicketAttachmentViewUrl,
+    deleteDocumentFn: deleteDocument,
+  });
+
+  // The persisted description wins whenever this user isn't editing it, so live
+  // updates from other sessions land without clobbering an in-flight draft.
+  useEffect(() => {
+    if (isEditingDescription) return;
+    const parsedDescription = parseTicketRichTextContent(
+      ticket.attributes?.description as string | object | undefined,
+    );
+    setDescriptionContent(parsedDescription);
+    originalDescriptionRef.current = parsedDescription;
+    setHasDescriptionContentChanged(false);
+  }, [ticket.attributes?.description, isEditingDescription]);
+
+  const hasDescription = useMemo(
+    () =>
+      descriptionContent.some((block) =>
+        Array.isArray((block as { content?: unknown }).content)
+          ? ((block as { content: unknown[] }).content.length > 0)
+          : Boolean((block as { content?: unknown }).content),
+      ),
+    [descriptionContent],
+  );
+
+  useEffect(() => {
+    const el = descriptionBodyRef.current;
+    if (!el || descriptionExpanded) return;
+    setDescriptionOverflows(el.scrollHeight > el.clientHeight + 4);
+  }, [descriptionContent, descriptionExpanded, hasDescription]);
 
   const responseStateOptions = useMemo<SelectOption[]>(
     () => [
@@ -553,7 +645,15 @@ export function BentoHero({
 
     setIsSaving(true);
     try {
-      const changes = { ...pendingChanges };
+      const changes: Record<string, unknown> = { ...pendingChanges };
+      // attributes also carries the watch list, so merge onto the LATEST
+      // persisted attributes rather than a buffered copy.
+      if (hasDescriptionContentChanged) {
+        changes.attributes = {
+          ...(ticket.attributes ?? {}),
+          description: serializeTicketRichTextContent(descriptionContent),
+        };
+      }
       const saveOptions = notificationSuppression.suppressContactNotifications
         ? notificationSuppression
         : undefined;
@@ -566,13 +666,25 @@ export function BentoHero({
           return;
         }
       } else {
-        for (const [field, value] of Object.entries(changes)) {
+        for (const [field, value] of Object.entries(pendingChanges)) {
           await onSelectChange(field as keyof ITicket, value);
+        }
+        if (hasDescriptionContentChanged && onUpdateDescription) {
+          const descriptionSaved = await onUpdateDescription(
+            serializeTicketRichTextContent(descriptionContent),
+          );
+          if (descriptionSaved === false) {
+            return;
+          }
         }
       }
 
-      setOriginalTicketValues((prev) => ({ ...prev, ...changes }));
+      setOriginalTicketValues((prev) => ({ ...prev, ...pendingChanges }));
       setPendingChanges({});
+      originalDescriptionRef.current = descriptionContent;
+      descriptionUploadSession.resetDraftTracking();
+      setHasDescriptionContentChanged(false);
+      setIsEditingDescription(false);
       setNotificationSuppression(defaultNotificationSuppression());
       setIsEditingTitle(false);
       setSaveSuccess(true);
@@ -586,13 +698,18 @@ export function BentoHero({
       setIsSaving(false);
     }
   }, [
+    descriptionContent,
+    descriptionUploadSession,
     hasActiveLiveConflict,
+    hasDescriptionContentChanged,
     hasUnsavedChanges,
     notificationSuppression,
     onBatchSelectChange,
     onSelectChange,
+    onUpdateDescription,
     pendingChanges,
     requiresDestinationStatusSelection,
+    ticket.attributes,
   ]);
 
   usePageSaveShortcut(handleSaveChanges, {
@@ -605,7 +722,12 @@ export function BentoHero({
     setIsEditingTitle(false);
     setNotificationSuppression(defaultNotificationSuppression());
     setShowCancelConfirm(false);
-  }, [ticket.title]);
+    // Routes through the upload session so pasted images get the keep/delete
+    // prompt before the draft is thrown away.
+    if (isEditingDescription) {
+      descriptionUploadSession.requestDiscard();
+    }
+  }, [descriptionUploadSession, isEditingDescription, ticket.title]);
 
   const handleCancelClick = useCallback(() => {
     if (hasUnsavedChanges) {
@@ -1020,7 +1142,81 @@ export function BentoHero({
           </div>
         ) : null}
 
-        {hasUnsavedChanges ? (
+        <div id={`${id}-description-section`} className="mt-3 border-t border-[rgb(var(--color-border-200))] pt-3">
+          <div className="flex items-center gap-2 mb-1">
+            <span className="text-[10px] font-semibold uppercase tracking-wider text-[rgb(var(--color-text-400))]">
+              {t('fields.description', 'Description')}
+            </span>
+            {!isEditingDescription ? (
+              <button
+                id={`${id}-description-edit`}
+                type="button"
+                aria-label={t('bento.tiles.editDescription', 'Edit description')}
+                className="text-[rgb(var(--color-text-400))] hover:text-[rgb(var(--color-text-700))]"
+                onClick={() => {
+                  originalDescriptionRef.current = descriptionContent;
+                  setHasDescriptionContentChanged(false);
+                  setIsEditingDescription(true);
+                }}
+              >
+                <Pencil className="h-3.5 w-3.5" />
+              </button>
+            ) : null}
+          </div>
+
+          {isEditingDescription ? (
+            <div className="min-w-0 w-full">
+              <TextEditor
+                id={`${id}-description-editor`}
+                initialContent={descriptionContent}
+                searchMentions={searchUsersForMentions}
+                uploadFile={descriptionUploadSession.uploadFile}
+                onContentChange={(content: PartialBlock[]) => {
+                  setDescriptionContent(content);
+                  if (originalDescriptionRef.current) {
+                    const originalStr = serializeTicketRichTextContent(originalDescriptionRef.current);
+                    const currentStr = serializeTicketRichTextContent(content);
+                    setHasDescriptionContentChanged(originalStr !== currentStr);
+                  }
+                }}
+              />
+            </div>
+          ) : hasDescription ? (
+            <>
+              <div
+                ref={descriptionBodyRef}
+                className={`text-sm ${descriptionExpanded ? '' : 'max-h-40 overflow-hidden'}`}
+              >
+                <RichTextViewer id={`${id}-description-view`} content={descriptionContent} />
+              </div>
+              {descriptionOverflows || descriptionExpanded ? (
+                <button
+                  id={`${id}-description-expand`}
+                  type="button"
+                  className="text-xs font-medium text-[rgb(var(--color-primary-600))] hover:underline mt-1"
+                  onClick={() => setDescriptionExpanded((value) => !value)}
+                >
+                  {descriptionExpanded ? t('bento.tiles.showLess', 'Show less') : t('bento.tiles.showMore', 'Show more')}
+                </button>
+              ) : null}
+            </>
+          ) : (
+            <BentoTileEmpty id={`${id}-description-empty`}>
+              {t('bento.tiles.noDescriptionYet', 'No description yet')}
+            </BentoTileEmpty>
+          )}
+
+          <p className="text-xs text-[rgb(var(--color-text-400))] mt-2">
+            {createdByUser
+              ? t('bento.tiles.openedBy', 'Opened by {{name}}', { name: `${createdByUser.first_name} ${createdByUser.last_name}` })
+              : t('bento.tiles.opened', 'Opened')}
+            {ticket.source ? ` · ${t('bento.tiles.viaSource', 'via {{source}}', { source: String(ticket.source).replace(/_/g, ' ') })}` : ''}
+          </p>
+        </div>
+
+        {/* The bar is also the only exit from an open description editor, so it
+            shows while editing even before anything is typed. */}
+        {hasUnsavedChanges || isEditingDescription ? (
           <div
             id={`${id}-save-bar`}
             className="mt-4 flex flex-wrap items-center gap-3 border-t border-[rgb(var(--color-border-200))] pt-3"
@@ -1049,7 +1245,7 @@ export function BentoHero({
               id={`${id}-save-changes-btn`}
               type="button"
               onClick={handleSaveChanges}
-              disabled={isSaving || requiresDestinationStatusSelection || hasActiveLiveConflict}
+              disabled={isSaving || !hasUnsavedChanges || requiresDestinationStatusSelection || hasActiveLiveConflict}
             >
               <span className="font-bold">
                 {isSaving
@@ -1075,6 +1271,19 @@ export function BentoHero({
         message={t('info.discardChangesMessage', 'Are you sure you want to discard your unsaved changes?')}
         confirmLabel={t('info.discardChanges', 'Discard Changes')}
         cancelLabel={t('actions.cancel', 'Cancel')}
+      />
+      <ConfirmationDialog
+        id={`${id}-description-clipboard-draft-cancel-dialog`}
+        isOpen={descriptionUploadSession.showDraftCancelDialog}
+        onClose={() => descriptionUploadSession.setShowDraftCancelDialog(false)}
+        onConfirm={descriptionUploadSession.deleteTrackedDraftClipboardImages}
+        onCancel={descriptionUploadSession.keepDraftClipboardImages}
+        title={t('conversation.clipboardDraftCancelTitle', 'Pasted Images Detected')}
+        message={t('info.clipboardDraftMessage', 'This description includes pasted images that were already uploaded as ticket documents. Keep them, or delete them permanently?')}
+        confirmLabel={t('conversation.deleteUploadedImages', 'Delete Images')}
+        thirdButtonLabel={t('conversation.keepUploadedImages', 'Keep Images')}
+        cancelLabel={t('quickAdd.continueEditing', 'Continue Editing')}
+        isConfirming={descriptionUploadSession.isDeletingDraftImages}
       />
     </BentoTile>
   );

--- a/packages/tickets/src/components/ticket/bento/BentoHero.tsx
+++ b/packages/tickets/src/components/ticket/bento/BentoHero.tsx
@@ -1142,7 +1142,7 @@ export function BentoHero({
           </div>
         ) : null}
 
-        <div id={`${id}-description-section`} className="mt-3 border-t border-[rgb(var(--color-border-200))] pt-3">
+        <div id={`${id}-description-section`} className="mt-4">
           <div className="flex items-center gap-2 mb-1">
             <span className="text-[10px] font-semibold uppercase tracking-wider text-[rgb(var(--color-text-400))]">
               {t('fields.description', 'Description')}

--- a/packages/tickets/src/components/ticket/bento/BentoHero.unsavedChanges.test.tsx
+++ b/packages/tickets/src/components/ticket/bento/BentoHero.unsavedChanges.test.tsx
@@ -10,6 +10,8 @@ const getTicketStatusesMock = vi.fn();
 const getTicketCategoriesByBoardMock = vi.fn();
 const useRegisterUnsavedChangesMock = vi.fn();
 const usePageSaveShortcutMock = vi.fn();
+const requestDiscardMock = vi.fn();
+const resetDraftTrackingMock = vi.fn();
 
 vi.mock('@alga-psa/ui/lib/i18n/client', () => ({
   useTranslation: () => ({
@@ -106,6 +108,55 @@ vi.mock('@alga-psa/ui/components/Tooltip', () => ({
 
 vi.mock('@alga-psa/ui/components/bento/BentoTile', () => ({
   BentoTile: ({ children, id }: { children: React.ReactNode; id: string }) => <section id={id}>{children}</section>,
+  BentoTileEmpty: ({ children, id }: { children: React.ReactNode; id: string }) => <p id={id}>{children}</p>,
+}));
+
+vi.mock('@alga-psa/ui/editor', () => ({
+  RichTextViewer: ({ id, content }: { id?: string; content: unknown }) => (
+    <div data-testid={id ?? 'rich-text-viewer'}>{JSON.stringify(content)}</div>
+  ),
+  TextEditor: ({
+    id,
+    initialContent,
+    onContentChange,
+  }: {
+    id: string;
+    initialContent: unknown;
+    onContentChange: (content: unknown) => void;
+  }) => (
+    <textarea
+      data-testid={id}
+      defaultValue={JSON.stringify(initialContent)}
+      onChange={(event) => onContentChange(JSON.parse(event.target.value))}
+    />
+  ),
+}));
+
+vi.mock('@alga-psa/user-composition/actions', () => ({
+  searchUsersForMentions: vi.fn(),
+}));
+
+vi.mock('@alga-psa/core/context/DocumentsCrossFeatureContext', () => ({
+  useDocumentsCrossFeature: () => ({ deleteDocument: vi.fn() }),
+}));
+
+// Stand-in for the clipboard-upload session: discarding routes straight to the
+// component's onDiscard (no pasted images tracked in these tests).
+vi.mock('../useTicketRichTextUploadSession', () => ({
+  useTicketRichTextUploadSession: (options: { onDiscard: () => void }) => ({
+    draftClipboardImages: [],
+    isDeletingDraftImages: false,
+    keepDraftClipboardImages: vi.fn(),
+    requestDiscard: () => {
+      requestDiscardMock();
+      options.onDiscard();
+    },
+    resetDraftTracking: resetDraftTrackingMock,
+    showDraftCancelDialog: false,
+    setShowDraftCancelDialog: vi.fn(),
+    uploadFile: vi.fn(),
+    deleteTrackedDraftClipboardImages: vi.fn(),
+  }),
 }));
 
 vi.mock('@alga-psa/ui/components/Alert', () => ({
@@ -163,10 +214,24 @@ vi.mock('../TicketNotificationSuppressionControl', () => ({
   ),
 }));
 
+const descriptionBlocks = (text: string) => [
+  {
+    type: 'paragraph',
+    props: { textAlignment: 'left', backgroundColor: 'default', textColor: 'default' },
+    content: [{ type: 'text', text, styles: {} }],
+  },
+];
+
+const watchList = [{ type: 'contact', id: 'contact-1', email: 'watcher@example.com' }];
+
 const baseTicket = {
   ticket_id: 'ticket-1',
   tenant: 'tenant-1',
   title: 'Printer offline',
+  attributes: {
+    description: JSON.stringify(descriptionBlocks('Printer will not come online')),
+    watch_list: watchList,
+  },
   status_id: 'status-a',
   priority_id: 'priority-high',
   board_id: 'board-a',
@@ -386,6 +451,118 @@ describe('BentoHero unsaved change model', () => {
       expect(screen.queryByRole('button', { name: /Save Changes/i })).not.toBeInTheDocument();
       expect(screen.getByTestId('bento-hero-priority-select')).toHaveValue('priority-high');
     });
+  });
+
+  it('renders the ticket description inline with the opened-by caption', () => {
+    renderHero({
+      createdByUser: { first_name: 'Ada', last_name: 'Lovelace' } as any,
+      ticket: { ...baseTicket, source: 'email' } as any,
+    });
+
+    expect(screen.getByTestId('bento-hero-description-view')).toHaveTextContent(
+      'Printer will not come online',
+    );
+    // The caption replaces what the old Request tile carried.
+    expect(screen.getByText(/Opened by/)).toBeInTheDocument();
+  });
+
+  it('flags the description edit as unsaved and flushes it inside the hero batch', async () => {
+    const onBatchSelectChange = vi.fn().mockResolvedValue(true);
+    renderHero({ onBatchSelectChange });
+
+    fireEvent.click(screen.getByRole('button', { name: 'Edit description' }));
+    fireEvent.change(screen.getByTestId('bento-hero-description-editor'), {
+      target: { value: JSON.stringify(descriptionBlocks('Toner cartridge replaced')) },
+    });
+
+    expect(useRegisterUnsavedChangesMock).toHaveBeenLastCalledWith('ticket-bento-hero-bento-hero', true);
+    expect(
+      screen.getByText('You have unsaved changes. Click "Save Changes" to apply them.'),
+    ).toBeInTheDocument();
+
+    fireEvent.change(screen.getByTestId('bento-hero-priority-select'), {
+      target: { value: 'priority-low' },
+    });
+    fireEvent.click(screen.getByLabelText("Don't notify the customer"));
+    fireEvent.click(screen.getByRole('button', { name: /Save Changes/i }));
+
+    await waitFor(() => {
+      // ONE batch: the pending field plus the merged attributes, and the
+      // pre-existing watch list must survive the description write.
+      expect(onBatchSelectChange).toHaveBeenCalledWith(
+        {
+          priority_id: 'priority-low',
+          attributes: {
+            watch_list: watchList,
+            description: JSON.stringify(descriptionBlocks('Toner cartridge replaced')),
+          },
+        },
+        { suppressContactNotifications: true, suppressInternalNotifications: false },
+      );
+    });
+    expect(onBatchSelectChange).toHaveBeenCalledTimes(1);
+
+    await waitFor(() => {
+      expect(screen.queryByRole('button', { name: /Save Changes/i })).not.toBeInTheDocument();
+    });
+    expect(screen.queryByTestId('bento-hero-description-editor')).not.toBeInTheDocument();
+    expect(resetDraftTrackingMock).toHaveBeenCalled();
+  });
+
+  it('falls back to onUpdateDescription when no batch handler is wired', async () => {
+    const onUpdateDescription = vi.fn().mockResolvedValue(true);
+    renderHero({ onBatchSelectChange: undefined, onUpdateDescription });
+
+    fireEvent.click(screen.getByRole('button', { name: 'Edit description' }));
+    fireEvent.change(screen.getByTestId('bento-hero-description-editor'), {
+      target: { value: JSON.stringify(descriptionBlocks('Escalated to vendor')) },
+    });
+    fireEvent.click(screen.getByRole('button', { name: /Save Changes/i }));
+
+    await waitFor(() => {
+      expect(onUpdateDescription).toHaveBeenCalledWith(
+        JSON.stringify(descriptionBlocks('Escalated to vendor')),
+      );
+    });
+  });
+
+  it('opening the description editor offers a cancel exit with Save still gated', async () => {
+    renderHero();
+
+    fireEvent.click(screen.getByRole('button', { name: 'Edit description' }));
+
+    expect(screen.getByRole('button', { name: /Save Changes/i })).toBeDisabled();
+    expect(
+      screen.queryByText('You have unsaved changes. Click "Save Changes" to apply them.'),
+    ).not.toBeInTheDocument();
+
+    // No pending diff, so Cancel closes the editor without a confirmation.
+    fireEvent.click(screen.getByRole('button', { name: 'Cancel' }));
+
+    await waitFor(() => {
+      expect(screen.queryByTestId('bento-hero-description-editor')).not.toBeInTheDocument();
+    });
+  });
+
+  it('cancel discards the description draft through the upload session', async () => {
+    renderHero();
+
+    fireEvent.click(screen.getByRole('button', { name: 'Edit description' }));
+    fireEvent.change(screen.getByTestId('bento-hero-description-editor'), {
+      target: { value: JSON.stringify(descriptionBlocks('Draft never saved')) },
+    });
+
+    expect(screen.getByRole('button', { name: /Save Changes/i })).toBeInTheDocument();
+    fireEvent.click(screen.getByRole('button', { name: 'Cancel' }));
+    fireEvent.click(screen.getByRole('button', { name: 'Discard Changes' }));
+
+    await waitFor(() => {
+      expect(requestDiscardMock).toHaveBeenCalled();
+      expect(screen.queryByRole('button', { name: /Save Changes/i })).not.toBeInTheDocument();
+    });
+    expect(screen.getByTestId('bento-hero-description-view')).toHaveTextContent(
+      'Printer will not come online',
+    );
   });
 
   it('T067: taking a remote board conflict clears coupled pending fields', async () => {

--- a/packages/tickets/src/components/ticket/bento/TicketBentoLayout.tsx
+++ b/packages/tickets/src/components/ticket/bento/TicketBentoLayout.tsx
@@ -520,8 +520,14 @@ export function TicketBentoLayout(props: TicketBentoLayoutProps) {
         selectedClientId: effectiveClientId ?? null,
       })}
 
+      {props.surveySummaryCard ? props.surveySummaryCard : null}
+
       {props.associatedAssets ? (
         <div id={`${id}-assets-container`}>{props.associatedAssets}</div>
+      ) : null}
+
+      {!props.hideMaterials ? (
+        <TicketMaterialsCard id={`${id}-materials`} ticketId={ticketId} clientId={ticket.client_id} initialMaterials={props.bentoStreams?.materials} />
       ) : null}
 
       {!props.hideScheduling ? (
@@ -794,12 +800,6 @@ export function TicketBentoLayout(props: TicketBentoLayoutProps) {
         getUserAvatarUrlsBatch={getUserAvatarUrlsBatchAction}
         getTeamAvatarUrlsBatch={getTeamAvatarUrlsBatchAction}
       />
-
-      {!props.hideMaterials ? (
-        <TicketMaterialsCard id={`${id}-materials`} ticketId={ticketId} clientId={ticket.client_id} initialMaterials={props.bentoStreams?.materials} />
-      ) : null}
-
-      {props.surveySummaryCard ? props.surveySummaryCard : null}
 
       <DocumentsTile
         id={`${id}-documents-section`}

--- a/packages/tickets/src/components/ticket/bento/TicketBentoLayout.tsx
+++ b/packages/tickets/src/components/ticket/bento/TicketBentoLayout.tsx
@@ -2,7 +2,7 @@
 
 import React, { Suspense, useRef } from 'react';
 import type { PartialBlock } from '@blocknote/core';
-import { FileText, User, Play, Pause, StopCircle, Clock, Users, Pencil } from 'lucide-react';
+import { User, Play, Pause, StopCircle, Clock, Users, Pencil } from 'lucide-react';
 import { Button } from '@alga-psa/ui/components/Button';
 import { Input } from '@alga-psa/ui/components/Input';
 import { Label } from '@alga-psa/ui/components/Label';
@@ -12,7 +12,6 @@ import ContactAvatar from '@alga-psa/ui/components/ContactAvatar';
 import ClientAvatar from '@alga-psa/ui/components/ClientAvatar';
 import TeamAvatar from '@alga-psa/ui/components/TeamAvatar';
 import MultiUserAndTeamPicker from '@alga-psa/ui/components/MultiUserAndTeamPicker';
-import { RichTextViewer } from '@alga-psa/ui/editor';
 import { ContentCardVariantProvider } from '@alga-psa/ui/components';
 import { withDataAutomationId } from '@alga-psa/ui/ui-reflection/withDataAutomationId';
 import type {
@@ -25,7 +24,6 @@ import type {
   IUserWithRoles,
   ITeam,
 } from '@alga-psa/types';
-import { parseTicketRichTextContent } from '../../../lib/ticketRichText';
 import type { CommentUserAuthor, CommentContactAuthor } from '../../../lib/commentAuthorResolution';
 import TicketChecklistSection from './../TicketChecklistSection';
 import { DocumentsTile } from './DocumentsTile';
@@ -75,9 +73,11 @@ export interface TicketBentoLayoutProps {
   onSelectChange: (field: keyof ITicket, newValue: string | null) => Promise<void> | void;
   /** Coalesced multi-field hero save; forwarded to BentoHero. */
   onBatchSelectChange?: (
-    changes: Record<string, string | null>,
+    changes: Record<string, unknown>,
     options?: TicketNotificationSuppressionValue
   ) => Promise<boolean | void> | boolean | void;
+  /** Persists the hero description when no batch handler is wired. */
+  onUpdateDescription?: (content: string) => Promise<boolean>;
   responseStateTrackingEnabled?: boolean;
   hideSlaStatus?: boolean;
   /** Hides the billing rollup tile (AlgaDesk has no billing surface). */
@@ -151,7 +151,7 @@ export interface TicketBentoLayoutProps {
    * React use() behind <Suspense> skeletons — zero fetch-on-mount requests.
    */
   bentoStreams?: NonNullable<TicketScreenBootstrap['streams']>;
-  // Request / contact
+  // Description caption / contact
   createdByUser?: IUser | null;
   contactInfo?: IContact | null;
   client?: IClient | null;
@@ -224,7 +224,6 @@ export function TicketBentoLayout(props: TicketBentoLayoutProps) {
   const { id, ticket } = props;
   const { t } = useTranslation('features/tickets');
   const ticketId = ticket.ticket_id ?? '';
-  const [requestExpanded, setRequestExpanded] = React.useState(false);
   // Guards against re-entrant add/remove churn on rapid multi-select changes.
   const isProcessingAgentsRef = useRef(false);
 
@@ -288,74 +287,8 @@ export function TicketBentoLayout(props: TicketBentoLayoutProps) {
     setContactEditOpen(true);
   }, [props.contactInfo?.contact_name_id]);
 
-  const requestBodyRef = React.useRef<HTMLDivElement>(null);
-  const [requestOverflows, setRequestOverflows] = React.useState(false);
-
-  const descriptionBlocks = React.useMemo(
-    () => parseTicketRichTextContent(ticket.attributes?.description as string | object | undefined),
-    [ticket.attributes?.description],
-  );
-  const hasDescription = React.useMemo(
-    () =>
-      descriptionBlocks.some((block) =>
-        Array.isArray((block as { content?: unknown }).content)
-          ? ((block as { content: unknown[] }).content.length > 0)
-          : Boolean((block as { content?: unknown }).content),
-      ),
-    [descriptionBlocks],
-  );
-
-  React.useEffect(() => {
-    const el = requestBodyRef.current;
-    if (!el || requestExpanded) return;
-    setRequestOverflows(el.scrollHeight > el.clientHeight + 4);
-  }, [descriptionBlocks, requestExpanded, hasDescription]);
-
   const leftRail = (
     <div className="space-y-4 min-w-0">
-      <BentoTile
-        id={`${id}-request-tile`}
-        title={t('bento.tiles.request', 'Request')}
-        icon={<FileText className="h-4 w-4" />}
-        action={
-          <button
-            id={`${id}-request-edit`}
-            type="button"
-            aria-label={t('bento.tiles.editDescription', 'Edit description')}
-            className="text-[rgb(var(--color-text-400))] hover:text-[rgb(var(--color-text-700))]"
-            onClick={props.onOpenAllFields}
-          >
-            <Pencil className="h-3.5 w-3.5" />
-          </button>
-        }
-      >
-        {hasDescription ? (
-          <>
-            <div ref={requestBodyRef} className={`text-sm ${requestExpanded ? '' : 'max-h-40 overflow-hidden'}`}>
-              <RichTextViewer id={`${id}-request-description`} content={descriptionBlocks} />
-            </div>
-            {requestOverflows || requestExpanded ? (
-              <button
-                id={`${id}-request-expand`}
-                type="button"
-                className="text-xs font-medium text-[rgb(var(--color-primary-600))] hover:underline mt-1 self-start"
-                onClick={() => setRequestExpanded((value) => !value)}
-              >
-                {requestExpanded ? t('bento.tiles.showLess', 'Show less') : t('bento.tiles.showMore', 'Show more')}
-              </button>
-            ) : null}
-          </>
-        ) : (
-          <BentoTileEmpty id={`${id}-request-empty`}>{t('bento.tiles.noDescriptionYet', 'No description yet')}</BentoTileEmpty>
-        )}
-        <p className="text-xs text-[rgb(var(--color-text-400))] mt-2">
-          {props.createdByUser
-            ? t('bento.tiles.openedBy', 'Opened by {{name}}', { name: `${props.createdByUser.first_name} ${props.createdByUser.last_name}` })
-            : t('bento.tiles.opened', 'Opened')}
-          {ticket.source ? ` · ${t('bento.tiles.viaSource', 'via {{source}}', { source: String(ticket.source).replace(/_/g, ' ') })}` : ''}
-        </p>
-      </BentoTile>
-
       <BentoTile
         id={`${id}-contact-tile`}
         title={t('bento.tiles.contact', 'Contact')}
@@ -906,6 +839,7 @@ export function TicketBentoLayout(props: TicketBentoLayoutProps) {
           onAgentClick={props.onAgentClick}
           onSelectChange={props.onSelectChange}
           onBatchSelectChange={props.onBatchSelectChange}
+          onUpdateDescription={props.onUpdateDescription}
           responseStateTrackingEnabled={props.responseStateTrackingEnabled}
           hideSlaStatus={props.hideSlaStatus}
           workflowLocked={props.workflowLocked}
@@ -923,6 +857,12 @@ export function TicketBentoLayout(props: TicketBentoLayoutProps) {
           liveEditingUsers={props.liveEditingUsers}
           onLiveEditingFieldChange={props.onLiveEditingFieldChange}
           onLiveDirtyFieldsChange={props.onLiveDirtyFieldsChange}
+          createdByUser={props.createdByUser}
+          userId={props.userId}
+          onClipboardImageUploaded={props.onClipboardImageUploaded}
+          uploadTicketAttachmentAction={props.uploadTicketAttachmentAction}
+          deleteDraftTicketAttachmentImagesAction={props.deleteDraftTicketAttachmentImagesAction}
+          resolveTicketAttachmentViewUrl={props.resolveTicketAttachmentViewUrl}
         />
       </div>
       {/* Mobile: timeline first, then state tiles (SLA/checklist lead the right

--- a/server/public/locales/de/features/tickets.json
+++ b/server/public/locales/de/features/tickets.json
@@ -1489,7 +1489,6 @@
       "pausedHint": "Die Uhr ist pausiert, während das Ticket in einem pausierten Status wartet."
     },
     "tiles": {
-      "request": "Anfrage",
       "openedBy": "Geöffnet von {{name}}",
       "showMore": "Mehr anzeigen",
       "showLess": "Weniger anzeigen",

--- a/server/public/locales/en/features/tickets.json
+++ b/server/public/locales/en/features/tickets.json
@@ -1497,7 +1497,6 @@
       "pausedHint": "The clock is paused while the ticket waits in a paused status."
     },
     "tiles": {
-      "request": "Request",
       "openedBy": "Opened by {{name}}",
       "showMore": "Show more",
       "showLess": "Show less",

--- a/server/public/locales/es/features/tickets.json
+++ b/server/public/locales/es/features/tickets.json
@@ -1489,7 +1489,6 @@
       "pausedHint": "El reloj está en pausa mientras el ticket permanece en un estado pausado."
     },
     "tiles": {
-      "request": "Solicitud",
       "openedBy": "Abierto por {{name}}",
       "showMore": "Mostrar más",
       "showLess": "Mostrar menos",

--- a/server/public/locales/fr/features/tickets.json
+++ b/server/public/locales/fr/features/tickets.json
@@ -1489,7 +1489,6 @@
       "pausedHint": "L'horloge est en pause tant que le ticket est dans un statut en pause."
     },
     "tiles": {
-      "request": "Demande",
       "openedBy": "Ouvert par {{name}}",
       "showMore": "Afficher plus",
       "showLess": "Afficher moins",

--- a/server/public/locales/it/features/tickets.json
+++ b/server/public/locales/it/features/tickets.json
@@ -1489,7 +1489,6 @@
       "pausedHint": "Il contatore è in pausa mentre il ticket resta in uno stato sospeso."
     },
     "tiles": {
-      "request": "Richiesta",
       "openedBy": "Aperto da {{name}}",
       "showMore": "Mostra altro",
       "showLess": "Mostra meno",

--- a/server/public/locales/nl/features/tickets.json
+++ b/server/public/locales/nl/features/tickets.json
@@ -1489,7 +1489,6 @@
       "pausedHint": "De klok is gepauzeerd terwijl het ticket in een gepauzeerde status wacht."
     },
     "tiles": {
-      "request": "Verzoek",
       "openedBy": "Geopend door {{name}}",
       "showMore": "Meer weergeven",
       "showLess": "Minder weergeven",

--- a/server/public/locales/pl/features/tickets.json
+++ b/server/public/locales/pl/features/tickets.json
@@ -1629,7 +1629,6 @@
       "pausedHint": "Licznik jest wstrzymany, gdy zgłoszenie oczekuje w statusie wstrzymanym."
     },
     "tiles": {
-      "request": "Zgłoszenie",
       "openedBy": "Otwarte przez {{name}}",
       "showMore": "Pokaż więcej",
       "showLess": "Pokaż mniej",

--- a/server/public/locales/pt/features/tickets.json
+++ b/server/public/locales/pt/features/tickets.json
@@ -1489,7 +1489,6 @@
       "pausedHint": "O relógio está pausado enquanto o ticket aguarda em um status pausado."
     },
     "tiles": {
-      "request": "Solicitação",
       "openedBy": "Aberto por {{name}}",
       "showMore": "Mostrar mais",
       "showLess": "Mostrar menos",

--- a/server/public/locales/xx/features/tickets.json
+++ b/server/public/locales/xx/features/tickets.json
@@ -1497,7 +1497,6 @@
       "pausedHint": "11111"
     },
     "tiles": {
-      "request": "11111",
       "openedBy": "11111 {{name}} 11111",
       "showMore": "11111",
       "showLess": "11111",

--- a/server/public/locales/yy/features/tickets.json
+++ b/server/public/locales/yy/features/tickets.json
@@ -1497,7 +1497,6 @@
       "pausedHint": "55555"
     },
     "tiles": {
-      "request": "55555",
       "openedBy": "55555 {{name}} 55555",
       "showMore": "55555",
       "showLess": "55555",


### PR DESCRIPTION
## Summary
Moves the ticket description editor out of the standalone "Request" tile and into the bento hero, right below the tags row. Editing, viewing, and saving the description now go through the same inline pipeline as the rest of the hero fields (title, status, priority, etc.), including the shared unsaved-changes/save-bar model and the clipboard-image upload/discard flow previously only wired up for `TicketInfo`. The "Request" tile and its translation key are removed, and the left/right bento rails are rebalanced to fill the resulting gap.

## Changes
- **BentoHero**: adds an inline description section (view/edit toggle, expand/collapse, "opened by / via source" caption, empty state) using `TextEditor`/`RichTextViewer` and the existing rich-text parse/serialize helpers; wires up the clipboard-image upload session (`useTicketRichTextUploadSession`) with its own discard/keep confirmation dialog; description edits now participate in `hasUnsavedChanges` and are flushed either via `onBatchSelectChange` (merged into the existing `attributes` payload alongside e.g. `watch_list`) or, when no batch handler is wired, via a new `onUpdateDescription` prop; Save is now disabled when there are no pending changes.
- **TicketBentoLayout**: removes the old "Request" `BentoTile` (description rendering, overflow tracking, edit button) and forwards the new description-related props (`createdByUser`, `userId`, `onClipboardImageUploaded`, `onUpdateDescription`, attachment upload/delete/view-url actions) down to `BentoHero`; reorders `surveySummaryCard`/`TicketMaterialsCard`/`DocumentsTile` placement in the left rail to rebalance the two columns now that the Request tile is gone; drops the now-unused `FileText` icon import and `RichTextViewer`/`parseTicketRichTextContent` imports.
- **TicketDetails**: passes `onUpdateDescription={handleUpdateDescription}` through to the bento layout.
- **i18n**: removes the orphaned `bento.tiles.request` key from all locale files (de, en, es, fr, it, nl, pl, pt, xx, yy).
- **Styling**: removes the divider rule that previously separated the hero tags row from the description section.

## Testing
- Added `BentoHero.unsavedChanges.test.tsx` coverage for: inline description rendering with the "opened by" caption, editing + saving a description change merged into a single `onBatchSelectChange` call (preserving unrelated `attributes` like `watch_list`), the `onUpdateDescription` fallback path when no batch handler exists, opening the editor with no diff (Save stays disabled, Cancel closes without confirmation), and cancel-with-discard routing through the upload session's `requestDiscard`/draft-cancel dialog.
