### PR TITLE
Project template fixup

### DIFF
--- a/packages/projects/src/actions/projectTemplateActions.ts
+++ b/packages/projects/src/actions/projectTemplateActions.ts
@@ -876,6 +876,12 @@ export const getTemplateCategories = withAuth(async (
 
 /**
  * Add a dependency to a template task
+ *
+ * Mirrors addTaskDependency for project tasks: 'blocked_by' is normalized by
+ * swapping the tasks and storing 'blocks' ("A blocked_by B" becomes
+ * "B blocks A"), so stored rows only ever use 'blocks'/'related_to' — the
+ * same set project_task_dependencies enforces via CHECK constraint, which
+ * template application copies into.
  */
 export const addTemplateDependency = withAuth(async (
   user,
@@ -890,27 +896,43 @@ export const addTemplateDependency = withAuth(async (
   try {
     const { knex: db } = await createTenantKnex();
 
+    // LEVERAGE: pattern blocked-by-normalization — same swap lives in
+    // projectTaskActions.addTaskDependency and applyProjectTemplate.
+    let actualPredecessorId = predecessorTaskId;
+    let actualSuccessorId = successorTaskId;
+    let actualDependencyType = dependencyType;
+    if (dependencyType === 'blocked_by') {
+      actualPredecessorId = successorTaskId;
+      actualSuccessorId = predecessorTaskId;
+      actualDependencyType = 'blocks';
+    }
+
     return await withTransaction(db, async (trx) => {
     await checkPermission(user, 'project', 'update', trx);
 
     // Validate that both tasks belong to the template
     const tasks = await tenantScopedTable(trx, 'project_template_tasks', tenant)
-      .whereIn('template_task_id', [predecessorTaskId, successorTaskId]);
+      .whereIn('template_task_id', [actualPredecessorId, actualSuccessorId]);
 
     if (tasks.length !== 2) {
       throw new Error('Invalid task IDs');
     }
 
     // Check for self-reference
-    if (predecessorTaskId === successorTaskId) {
+    if (actualPredecessorId === actualSuccessorId) {
       throw new Error('A task cannot depend on itself');
     }
 
-    // Check for existing dependency
+    // Check for existing dependency (either direction)
     const existing = await tenantScopedTable(trx, 'project_template_dependencies', tenant)
-      .where({
-        predecessor_task_id: predecessorTaskId,
-        successor_task_id: successorTaskId
+      .where(function() {
+        this.where({
+          predecessor_task_id: actualPredecessorId,
+          successor_task_id: actualSuccessorId
+        }).orWhere({
+          predecessor_task_id: actualSuccessorId,
+          successor_task_id: actualPredecessorId
+        });
       })
       .first();
 
@@ -923,9 +945,9 @@ export const addTemplateDependency = withAuth(async (
       .insert({
         tenant,
         template_id: templateId,
-        predecessor_task_id: predecessorTaskId,
-        successor_task_id: successorTaskId,
-        dependency_type: dependencyType,
+        predecessor_task_id: actualPredecessorId,
+        successor_task_id: actualSuccessorId,
+        dependency_type: actualDependencyType,
         lead_lag_days: leadLagDays,
         notes
       })
@@ -957,9 +979,29 @@ export const updateTemplateDependency = withAuth(async (
     return await withTransaction(db, async (trx) => {
     await checkPermission(user, 'project', 'update', trx);
 
+    // Normalize 'blocked_by' the same way addTemplateDependency does:
+    // flip the stored direction and keep the type as 'blocks'.
+    let updateData: Record<string, unknown> = { ...data };
+    if (data.dependency_type === 'blocked_by') {
+      const current = await tenantScopedTable(trx, 'project_template_dependencies', tenant)
+        .where({ template_dependency_id: dependencyId })
+        .first();
+
+      if (!current) {
+        throw new Error('Dependency not found');
+      }
+
+      updateData = {
+        ...updateData,
+        dependency_type: 'blocks',
+        predecessor_task_id: current.successor_task_id,
+        successor_task_id: current.predecessor_task_id
+      };
+    }
+
     const [dependency] = await tenantScopedTable(trx, 'project_template_dependencies', tenant)
       .where({ template_dependency_id: dependencyId })
-      .update(data)
+      .update(updateData)
       .returning('*');
 
     if (!dependency) {

--- a/packages/projects/src/actions/projectTemplateDependencyNormalization.contract.test.ts
+++ b/packages/projects/src/actions/projectTemplateDependencyNormalization.contract.test.ts
@@ -1,0 +1,68 @@
+import { describe, expect, it } from 'vitest';
+import { readFileSync } from 'fs';
+import { resolve } from 'path';
+
+const actionsSource = readFileSync(resolve(__dirname, 'projectTemplateActions.ts'), 'utf8');
+const applyTemplateSource = readFileSync(
+  resolve(__dirname, '../services/applyProjectTemplate.ts'),
+  'utf8'
+);
+
+function section(source: string, start: string, end: string): string {
+  const startIndex = source.indexOf(start);
+  const endIndex = source.indexOf(end, startIndex);
+  expect(startIndex).toBeGreaterThanOrEqual(0);
+  expect(endIndex).toBeGreaterThan(startIndex);
+  return source.slice(startIndex, endIndex);
+}
+
+/**
+ * Template dependency rows must only ever store 'blocks'/'related_to' —
+ * the same set project_task_dependencies enforces via CHECK constraint —
+ * because applying a template copies rows straight across. 'blocked_by'
+ * input is normalized by flipping direction ("A blocked_by B" becomes
+ * "B blocks A"), mirroring projectTaskActions.addTaskDependency.
+ */
+describe('project template dependency normalization contract', () => {
+  it('addTemplateDependency flips blocked_by input to a blocks row', () => {
+    const source = section(
+      actionsSource,
+      'export const addTemplateDependency',
+      '/**\n * Update a template dependency'
+    );
+
+    expect(source).toContain("if (dependencyType === 'blocked_by')");
+    expect(source).toContain('actualPredecessorId = successorTaskId');
+    expect(source).toContain('actualSuccessorId = predecessorTaskId');
+    expect(source).toContain("actualDependencyType = 'blocks'");
+    // The stored row must use the normalized values, not the raw input.
+    expect(source).toContain('dependency_type: actualDependencyType');
+    expect(source).not.toContain('dependency_type: dependencyType');
+  });
+
+  it('updateTemplateDependency flips blocked_by input to a blocks row', () => {
+    const source = section(
+      actionsSource,
+      'export const updateTemplateDependency',
+      '/**\n * Remove a template dependency'
+    );
+
+    expect(source).toContain("data.dependency_type === 'blocked_by'");
+    expect(source).toContain("dependency_type: 'blocks'");
+    expect(source).toContain('predecessor_task_id: current.successor_task_id');
+    expect(source).toContain('successor_task_id: current.predecessor_task_id');
+  });
+
+  it('applyProjectTemplate flips legacy blocked_by template rows when copying', () => {
+    const source = section(
+      applyTemplateSource,
+      '// 7. Create dependencies',
+      '// 8. Create checklists'
+    );
+
+    expect(source).toContain("templateDep.dependency_type === 'blocked_by'");
+    expect(source).toContain("isLegacyBlockedBy ? 'blocks' : templateDep.dependency_type");
+    // Never insert the raw template type without the legacy guard.
+    expect(source).not.toContain('dependency_type: templateDep.dependency_type,');
+  });
+});

--- a/packages/projects/src/components/project-templates/ApplyTemplateDialog.tsx
+++ b/packages/projects/src/components/project-templates/ApplyTemplateDialog.tsx
@@ -65,6 +65,7 @@ export function ApplyTemplateDialog({ open, onClose, onSuccess, initialTemplateI
     copyPhases: true,
     copyStatuses: true,
     copyTasks: true,
+    copyDependencies: true,
     copyChecklists: true,
     copyServices: true,
     assignmentOption: 'primary' as AssignmentOption
@@ -100,6 +101,7 @@ export function ApplyTemplateDialog({ open, onClose, onSuccess, initialTemplateI
         copyPhases: true,
         copyStatuses: true,
         copyTasks: true,
+        copyDependencies: true,
         copyChecklists: true,
         copyServices: true,
         assignmentOption: 'primary'
@@ -170,6 +172,7 @@ export function ApplyTemplateDialog({ open, onClose, onSuccess, initialTemplateI
           copyPhases: options.copyPhases,
           copyStatuses: options.copyStatuses,
           copyTasks: options.copyTasks,
+          copyDependencies: options.copyDependencies,
           copyChecklists: options.copyChecklists,
           copyServices: options.copyServices,
           assignmentOption: options.assignmentOption
@@ -368,11 +371,20 @@ export function ApplyTemplateDialog({ open, onClose, onSuccess, initialTemplateI
                       setOptions({
                         ...options,
                         copyTasks: e.target.checked,
-                        // Disable checklists and services if tasks are disabled
+                        // Disable dependencies, checklists, and services if tasks are disabled
+                        copyDependencies: e.target.checked ? options.copyDependencies : false,
                         copyChecklists: e.target.checked ? options.copyChecklists : false,
                         copyServices: e.target.checked ? options.copyServices : false
                       });
                     }}
+                    containerClassName="mb-2"
+                  />
+                  <Checkbox
+                    id="copy-dependencies-checkbox"
+                    label={t('templates.apply.copyDependencies', 'Copy Dependencies')}
+                    checked={options.copyDependencies}
+                    disabled={!options.copyTasks}
+                    onChange={(e) => setOptions({ ...options, copyDependencies: e.target.checked })}
                     containerClassName="mb-2"
                   />
                   <Checkbox

--- a/packages/projects/src/components/project-templates/TemplateEditor.tsx
+++ b/packages/projects/src/components/project-templates/TemplateEditor.tsx
@@ -711,7 +711,7 @@ export default function TemplateEditor({ template: initialTemplate, onTemplateUp
     additionalAgents?: string[],
     localChecklistItems?: Array<{ id: string; item_name: string; description?: string; completed: boolean; order_number: number; isNew?: boolean }>,
     dependencyChanges?: {
-      added: Array<{ predecessorTaskId: string; dependencyType: DependencyType }>;
+      added: Array<{ relatedTaskId: string; dependencyType: DependencyType }>;
       removed: string[];
     }
   ) => {
@@ -787,12 +787,14 @@ export default function TemplateEditor({ template: initialTemplate, onTemplateUp
           setDependencies((prev) => prev.filter((d) => d.template_dependency_id !== depId));
         }
 
-        // Add new dependencies (current task is the successor)
+        // Add new dependencies. Args follow the project-task convention:
+        // (current task, related task, type) — the action normalizes
+        // 'blocked_by' by swapping direction and storing 'blocks'.
         for (const dep of dependencyChanges.added) {
           const newDep = unwrapTemplateActionResult(await addTemplateDependency(
             template.template_id,
-            dep.predecessorTaskId,
             taskId,
+            dep.relatedTaskId,
             dep.dependencyType
           ));
           setDependencies((prev) => [...prev, newDep]);
@@ -1084,7 +1086,7 @@ export default function TemplateEditor({ template: initialTemplate, onTemplateUp
           initialStatusMappingId={newTaskStatusMappingId}
           checklistItems={editingTask ? checklistItems.filter(c => c.template_task_id === editingTask.template_task_id) : []}
           allTasks={tasks}
-          dependencies={editingTask ? dependencies.filter(d => d.successor_task_id === editingTask.template_task_id) : []}
+          dependencies={editingTask ? dependencies.filter(d => d.successor_task_id === editingTask.template_task_id || d.predecessor_task_id === editingTask.template_task_id) : []}
           tenant={template.tenant}
         />
       )}

--- a/packages/projects/src/components/project-templates/TemplateTaskForm.tsx
+++ b/packages/projects/src/components/project-templates/TemplateTaskForm.tsx
@@ -64,11 +64,13 @@ export interface LocalChecklistItem {
   isNew?: boolean;
 }
 
-/** Local dependency for tracking changes before save */
+/** Local dependency for tracking changes before save.
+ * Modeled from the edited task's perspective: `relatedTaskId` is the other
+ * task, and `dependencyType` reads as "this task <type> related task". */
 interface LocalDependency {
   id: string;
-  predecessorTaskId: string;
-  predecessorTaskName: string;
+  relatedTaskId: string;
+  relatedTaskName: string;
   dependencyType: DependencyType;
   isNew: boolean;
 }
@@ -81,7 +83,7 @@ interface TemplateTaskFormProps {
     additionalAgents?: string[],
     checklistItems?: LocalChecklistItem[],
     dependencyChanges?: {
-      added: Array<{ predecessorTaskId: string; dependencyType: DependencyType }>;
+      added: Array<{ relatedTaskId: string; dependencyType: DependencyType }>;
       removed: string[];
     }
   ) => void;
@@ -97,7 +99,7 @@ interface TemplateTaskFormProps {
   checklistItems?: IProjectTemplateChecklistItem[];
   /** All tasks in the template (for dependency selection) */
   allTasks?: IProjectTemplateTask[];
-  /** Current dependencies where this task is the successor */
+  /** Current dependencies involving this task (either direction) */
   dependencies?: IProjectTemplateDependency[];
   /** Tenant for fetching avatar URLs */
   tenant?: string;
@@ -263,13 +265,21 @@ export function TemplateTaskForm({
           order_number: item.order_number,
           isNew: false,
         }));
+        // Present each dependency from the edited task's perspective. Stored
+        // rows are normalized to 'blocks'/'related_to' with predecessor →
+        // successor direction, so when this task is the successor a 'blocks'
+        // row reads back as "Blocked by <predecessor>".
         const dependenciesVal = dependencies.map(dep => {
-          const predTask = allTasks.find(t => t.template_task_id === dep.predecessor_task_id);
+          const isSuccessor = dep.successor_task_id === task.template_task_id;
+          const relatedTaskId = isSuccessor ? dep.predecessor_task_id : dep.successor_task_id;
+          const relatedTask = allTasks.find(t => t.template_task_id === relatedTaskId);
+          const dependencyType: DependencyType =
+            isSuccessor && dep.dependency_type === 'blocks' ? 'blocked_by' : dep.dependency_type;
           return {
             id: dep.template_dependency_id,
-            predecessorTaskId: dep.predecessor_task_id,
-            predecessorTaskName: predTask?.task_name || t('templates.editor.unknownTask', 'Unknown task'),
-            dependencyType: dep.dependency_type,
+            relatedTaskId,
+            relatedTaskName: relatedTask?.task_name || t('templates.editor.unknownTask', 'Unknown task'),
+            dependencyType,
             isNew: false,
           };
         });
@@ -401,7 +411,7 @@ export function TemplateTaskForm({
       const addedDependencies = localDependencies
         .filter(d => d.isNew)
         .map(d => ({
-          predecessorTaskId: d.predecessorTaskId,
+          relatedTaskId: d.relatedTaskId,
           dependencyType: d.dependencyType,
         }));
 
@@ -555,17 +565,17 @@ export function TemplateTaskForm({
     if (!newDependencyTask) return;
 
     // Check for duplicates
-    if (localDependencies.some(d => d.predecessorTaskId === newDependencyTask)) {
+    if (localDependencies.some(d => d.relatedTaskId === newDependencyTask)) {
       return;
     }
 
-    const predTask = allTasks.find(t => t.template_task_id === newDependencyTask);
-    if (!predTask) return;
+    const relatedTask = allTasks.find(t => t.template_task_id === newDependencyTask);
+    if (!relatedTask) return;
 
     const newDep: LocalDependency = {
       id: `temp_${Date.now()}`,
-      predecessorTaskId: newDependencyTask,
-      predecessorTaskName: predTask.task_name,
+      relatedTaskId: newDependencyTask,
+      relatedTaskName: relatedTask.task_name,
       dependencyType: newDependencyType,
       isNew: true,
     };
@@ -599,7 +609,7 @@ export function TemplateTaskForm({
   // Filter available tasks (exclude current task and already selected)
   const availableTasksForDependency = allTasks.filter(
     t => t.template_task_id !== task?.template_task_id &&
-         !localDependencies.some(d => d.predecessorTaskId === t.template_task_id)
+         !localDependencies.some(d => d.relatedTaskId === t.template_task_id)
   );
 
   // Check if any changes have been made
@@ -1160,7 +1170,7 @@ export function TemplateTaskForm({
                           <div className="flex items-center gap-2">
                             {typeInfo.icon}
                             <span className="text-sm text-gray-600">{typeInfo.label}</span>
-                            <span className="text-sm font-medium">{dep.predecessorTaskName}</span>
+                            <span className="text-sm font-medium">{dep.relatedTaskName}</span>
                             {dep.isNew && (
                               <Badge variant="success" size="sm">
                                 New

--- a/packages/projects/src/services/applyProjectTemplate.ts
+++ b/packages/projects/src/services/applyProjectTemplate.ts
@@ -450,8 +450,16 @@ export async function applyProjectTemplate(
         .where({ template_id: templateId });
 
       for (const templateDep of templateDeps) {
-      const newPredecessorId = taskMap.get(templateDep.predecessor_task_id);
-      const newSuccessorId = taskMap.get(templateDep.successor_task_id);
+      // Template rows are normalized to 'blocks'/'related_to', but legacy
+      // rows may still carry 'blocked_by', which project_task_dependencies'
+      // CHECK constraint rejects — flip those to the equivalent 'blocks'.
+      const isLegacyBlockedBy = templateDep.dependency_type === 'blocked_by';
+      const newPredecessorId = taskMap.get(
+        isLegacyBlockedBy ? templateDep.successor_task_id : templateDep.predecessor_task_id
+      );
+      const newSuccessorId = taskMap.get(
+        isLegacyBlockedBy ? templateDep.predecessor_task_id : templateDep.successor_task_id
+      );
 
       if (newPredecessorId && newSuccessorId) {
         await tenantScopedTable(trx, 'project_task_dependencies', tenant)
@@ -459,7 +467,7 @@ export async function applyProjectTemplate(
             tenant,
             predecessor_task_id: newPredecessorId,
             successor_task_id: newSuccessorId,
-            dependency_type: templateDep.dependency_type,
+            dependency_type: isLegacyBlockedBy ? 'blocks' : templateDep.dependency_type,
             lead_lag_days: templateDep.lead_lag_days || 0,
             notes: templateDep.notes
           });

--- a/server/migrations/20260728120000_normalize_template_dependency_types.cjs
+++ b/server/migrations/20260728120000_normalize_template_dependency_types.cjs
@@ -1,0 +1,56 @@
+/**
+ * Normalize project template dependency types to match project task
+ * dependencies. The template editor used to store the UI-selected type
+ * verbatim, including 'blocked_by' (its default), while
+ * project_task_dependencies only permits 'blocks'/'related_to' via CHECK
+ * constraint — so applying a template with a 'blocked_by' dependency failed
+ * outright. Template rows are rewritten the same way addTaskDependency
+ * normalizes input ("A blocked_by B" becomes "B blocks A"), and the same
+ * CHECK constraint is added so the two tables can never diverge again.
+ *
+ * @param { import('knex').Knex } knex
+ */
+exports.up = async function up(knex) {
+  // Drop 'blocked_by' rows whose flipped equivalent already exists — the
+  // flip below would otherwise create a duplicate pair.
+  await knex.raw(`
+    DELETE FROM project_template_dependencies d1
+    WHERE d1.dependency_type = 'blocked_by'
+      AND EXISTS (
+        SELECT 1 FROM project_template_dependencies d2
+        WHERE d2.tenant = d1.tenant
+          AND d2.template_dependency_id <> d1.template_dependency_id
+          AND d2.predecessor_task_id = d1.successor_task_id
+          AND d2.successor_task_id = d1.predecessor_task_id
+      )
+  `);
+
+  // "A blocked_by B" becomes "B blocks A" (RHS reads the pre-update values,
+  // so the single-statement swap is safe).
+  await knex.raw(`
+    UPDATE project_template_dependencies
+    SET predecessor_task_id = successor_task_id,
+        successor_task_id = predecessor_task_id,
+        dependency_type = 'blocks'
+    WHERE dependency_type = 'blocked_by'
+  `);
+
+  await knex.raw(`
+    ALTER TABLE project_template_dependencies
+    DROP CONSTRAINT IF EXISTS project_template_dependencies_dependency_type_check
+  `);
+
+  await knex.raw(`
+    ALTER TABLE project_template_dependencies
+    ADD CONSTRAINT project_template_dependencies_dependency_type_check
+    CHECK (dependency_type IN ('blocks', 'related_to'))
+  `);
+};
+
+/** @param { import('knex').Knex } knex */
+exports.down = async function down(knex) {
+  await knex.raw(`
+    ALTER TABLE project_template_dependencies
+    DROP CONSTRAINT IF EXISTS project_template_dependencies_dependency_type_check
+  `);
+};

--- a/server/public/locales/de/features/projects.json
+++ b/server/public/locales/de/features/projects.json
@@ -999,6 +999,7 @@
       "copyPhases": "Phasen kopieren",
       "copyStatuses": "Status kopieren",
       "copyTasks": "Aufgaben kopieren",
+      "copyDependencies": "Abhängigkeiten kopieren",
       "copyChecklists": "Checklisten kopieren",
       "copyTaskServices": "Aufgaben-Services kopieren",
       "taskAssignments": "Aufgabenzuweisungen",

--- a/server/public/locales/en/features/projects.json
+++ b/server/public/locales/en/features/projects.json
@@ -999,6 +999,7 @@
       "copyPhases": "Copy Phases",
       "copyStatuses": "Copy Statuses",
       "copyTasks": "Copy Tasks",
+      "copyDependencies": "Copy Dependencies",
       "copyChecklists": "Copy Checklists",
       "copyTaskServices": "Copy Task Services",
       "taskAssignments": "Task Assignments",

--- a/server/public/locales/es/features/projects.json
+++ b/server/public/locales/es/features/projects.json
@@ -999,6 +999,7 @@
       "copyPhases": "Copiar fases",
       "copyStatuses": "Copiar estados",
       "copyTasks": "Copiar tareas",
+      "copyDependencies": "Copiar dependencias",
       "copyChecklists": "Copiar listas",
       "copyTaskServices": "Copiar servicios de tareas",
       "taskAssignments": "Asignaciones de tareas",

--- a/server/public/locales/fr/features/projects.json
+++ b/server/public/locales/fr/features/projects.json
@@ -999,6 +999,7 @@
       "copyPhases": "Copier les phases",
       "copyStatuses": "Copier les statuts",
       "copyTasks": "Copier les tâches",
+      "copyDependencies": "Copier les dépendances",
       "copyChecklists": "Copier les checklists",
       "copyTaskServices": "Copier les services de tâche",
       "taskAssignments": "Affectations des tâches",

--- a/server/public/locales/it/features/projects.json
+++ b/server/public/locales/it/features/projects.json
@@ -999,6 +999,7 @@
       "copyPhases": "Copia fasi",
       "copyStatuses": "Copia stati",
       "copyTasks": "Copia attività",
+      "copyDependencies": "Copia dipendenze",
       "copyChecklists": "Copia checklist",
       "copyTaskServices": "Copia servizi attività",
       "taskAssignments": "Assegnazioni attività",

--- a/server/public/locales/nl/features/projects.json
+++ b/server/public/locales/nl/features/projects.json
@@ -999,6 +999,7 @@
       "copyPhases": "Kopieer fasen",
       "copyStatuses": "Kopieer statussen",
       "copyTasks": "Kopieer taken",
+      "copyDependencies": "Kopieer afhankelijkheden",
       "copyChecklists": "Kopieer checklists",
       "copyTaskServices": "Taakservices kopiëren",
       "taskAssignments": "Taaktoewijzingen",

--- a/server/public/locales/pl/features/projects.json
+++ b/server/public/locales/pl/features/projects.json
@@ -1021,6 +1021,7 @@
       "copyPhases": "Kopiuj fazy",
       "copyStatuses": "Kopiuj statusy",
       "copyTasks": "Kopiuj zadania",
+      "copyDependencies": "Kopiuj zależności",
       "copyChecklists": "Kopiuj listy kontrolne",
       "copyTaskServices": "Kopiuj usługi zadań",
       "taskAssignments": "Przydziały zadań",

--- a/server/public/locales/pt/features/projects.json
+++ b/server/public/locales/pt/features/projects.json
@@ -999,6 +999,7 @@
       "copyPhases": "Copiar fases",
       "copyStatuses": "Copiar status",
       "copyTasks": "Copiar tarefas",
+      "copyDependencies": "Copiar dependências",
       "copyChecklists": "Copiar listas de verificação",
       "copyTaskServices": "Copiar serviços de tarefas",
       "taskAssignments": "Atribuições de tarefas",

--- a/server/public/locales/xx/features/projects.json
+++ b/server/public/locales/xx/features/projects.json
@@ -999,6 +999,7 @@
       "copyPhases": "11111",
       "copyStatuses": "11111",
       "copyTasks": "11111",
+      "copyDependencies": "11111",
       "copyChecklists": "11111",
       "copyTaskServices": "11111",
       "taskAssignments": "11111",

--- a/server/public/locales/yy/features/projects.json
+++ b/server/public/locales/yy/features/projects.json
@@ -999,6 +999,7 @@
       "copyPhases": "55555",
       "copyStatuses": "55555",
       "copyTasks": "55555",
+      "copyDependencies": "55555",
       "copyChecklists": "55555",
       "copyTaskServices": "55555",
       "taskAssignments": "55555",


### PR DESCRIPTION
## Summary

Fix project-template dependencies so the editor, persisted template rows, and applied project-task dependencies share one canonical direction and type model.

- Normalize user-facing `blocked_by` input by swapping task direction and storing canonical `blocks` rows in add and update actions.
- Correct the template editor argument convention and show dependencies from both tasks, rendering successor-side rows as “Blocked by” and predecessor-side rows as “Blocks.”
- Normalize legacy `blocked_by` rows while applying templates, and add an idempotent migration that rewrites existing rows, removes flipped duplicates, and enforces `blocks` / `related_to` with a database CHECK constraint.
- Add the missing “Copy Dependencies” option to the apply-template dialog, including localized labels and task-selection behavior.
- Add focused contract coverage for add, update, and apply normalization behavior.

## Smoke test

PASS. Exercised the real product on port 3070 with the compose infrastructure running.

- Added a user-facing “Blocked by” dependency. PostgreSQL correctly stored the canonical inverse `blocks` row.
- Verified two-way presentation: the successor displayed “Blocked by,” while the predecessor displayed “Blocks,” alongside its existing incoming dependency.
- Applied with Copy Dependencies enabled: created 21 tasks and all 4 canonical dependencies.
- Regression-tested with Copy Dependencies disabled: created the same 21 tasks and 0 dependencies.
- Browser console errors: 0. Failed network requests: 0. Both apply actions returned HTTP 200.
- Removed the temporary template dependency through the UI; the original 3 dependencies remain.
- No product simulators or mocks were used. A transport-only socat forward was needed because alga-dev created the browser on the Mac hub while the real server ran on Linux.
- Fidelity compromise: alga-dev screenshot capture consistently timed out while dialogs were open, so evidence includes result-page screenshots, UI assertion text, PostgreSQL results, and server logs instead of modal screenshots.
- The already-applied migration was verified through canonical live rows and its database CHECK constraint, but legacy-row migration was not destructively replayed against a fresh fixture.
- No task-specific product concerns found. Existing setup-only `.npmrc` and `package-lock.json` changes remain untouched.

Focused validation also passed: the 3-test dependency-normalization contract suite and `@alga-psa/projects` TypeScript checking with `tsc --noEmit`.

Evidence: `/tmp/alga-smoke-evidence/project-template-fixup-20260728-194040`
