### PR TITLE
Allow appointments in portal to be disabled

### DIFF
--- a/packages/client-portal/src/actions/client-portal-actions/appointmentRequestActions.ts
+++ b/packages/client-portal/src/actions/client-portal-actions/appointmentRequestActions.ts
@@ -37,6 +37,7 @@ import { isEnterprise } from '@alga-psa/core/features';
 import { format, type Locale } from 'date-fns';
 import { de, es, fr, it, nl, enUS } from 'date-fns/locale';
 import { fromZonedTime, formatInTimeZone } from 'date-fns-tz';
+import { getClientPortalFeatureSettingsForTenant } from '../../lib/clientPortalFeatureSettingsDb';
 
 export interface IAppointmentRequest {
   appointment_request_id: string;
@@ -336,6 +337,14 @@ export const createAppointmentRequest = withAuth(async (
     const validatedData = createAppointmentRequestSchema.parse(data);
 
     const { knex: db } = await createTenantKnex();
+
+    const portalFeatures = await getClientPortalFeatureSettingsForTenant(db, tenant);
+    if (!portalFeatures.appointmentsEnabled) {
+      return {
+        success: false,
+        error: 'Appointment requests are not available in the client portal',
+      };
+    }
 
     // Get client_id from contact
     const contact = await withTransaction(db, async (trx: Knex.Transaction) => {

--- a/packages/client-portal/src/actions/client-portal-actions/clientPortalFeatureSettingsActions.test.ts
+++ b/packages/client-portal/src/actions/client-portal-actions/clientPortalFeatureSettingsActions.test.ts
@@ -1,0 +1,94 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+let currentUser: any;
+let storedSettings: unknown;
+
+const hasPermissionMock = vi.fn();
+const mergeMock = vi.fn();
+
+vi.mock('@alga-psa/auth', () => ({
+  withAuth: (action: any) => async (...args: any[]) =>
+    action(currentUser, { tenant: currentUser.tenant }, ...args),
+  hasPermission: (...args: any[]) => hasPermissionMock(...args),
+}));
+
+vi.mock('@alga-psa/db', () => ({
+  createTenantKnex: vi.fn().mockResolvedValue({ knex: {} }),
+  tenantDb: vi.fn(() => ({
+    table: vi.fn(() => ({
+      select: vi.fn(() => ({
+        first: vi.fn().mockImplementation(async () => ({ settings: storedSettings })),
+      })),
+      insert: vi.fn((value: { settings: string }) => ({
+        onConflict: vi.fn(() => ({
+          merge: vi.fn(async (merged: { settings: string }) => {
+            storedSettings = JSON.parse(merged.settings);
+            mergeMock(value, merged);
+          }),
+        })),
+      })),
+    })),
+  })),
+}));
+
+describe('client portal feature settings actions', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    currentUser = {
+      user_id: 'internal-user-1',
+      user_type: 'internal',
+      tenant: 'tenant-1',
+    };
+    storedSettings = {};
+    hasPermissionMock.mockResolvedValue(true);
+  });
+
+  it('defaults appointments to enabled for existing tenants', async () => {
+    const { getClientPortalFeatureSettings } = await import(
+      './clientPortalFeatureSettingsActions'
+    );
+
+    await expect(getClientPortalFeatureSettings()).resolves.toEqual({
+      appointmentsEnabled: true,
+    });
+  });
+
+  it('updates the appointment flag without replacing other tenant settings', async () => {
+    storedSettings = {
+      branding: { clientName: 'Example MSP' },
+      clientPortal: { defaultLocale: 'en' },
+    };
+    const { updateClientPortalFeatureSettings } = await import(
+      './clientPortalFeatureSettingsActions'
+    );
+
+    await expect(updateClientPortalFeatureSettings({
+      appointmentsEnabled: false,
+    })).resolves.toEqual({
+      appointmentsEnabled: false,
+    });
+
+    expect(storedSettings).toEqual({
+      branding: { clientName: 'Example MSP' },
+      clientPortal: {
+        defaultLocale: 'en',
+        appointmentsEnabled: false,
+      },
+    });
+    expect(mergeMock).toHaveBeenCalledOnce();
+  });
+
+  it('requires settings:update permission', async () => {
+    hasPermissionMock.mockResolvedValue(false);
+    const { updateClientPortalFeatureSettings } = await import(
+      './clientPortalFeatureSettingsActions'
+    );
+
+    await expect(updateClientPortalFeatureSettings({
+      appointmentsEnabled: false,
+    })).resolves.toEqual({
+      permissionError: 'Permission denied: settings:update required',
+    });
+    expect(mergeMock).not.toHaveBeenCalled();
+  });
+});

--- a/packages/client-portal/src/actions/client-portal-actions/clientPortalFeatureSettingsActions.ts
+++ b/packages/client-portal/src/actions/client-portal-actions/clientPortalFeatureSettingsActions.ts
@@ -1,0 +1,68 @@
+'use server';
+
+import { hasPermission, withAuth } from '@alga-psa/auth';
+import { createTenantKnex, tenantDb } from '@alga-psa/db';
+import {
+  permissionError,
+  type ActionPermissionError,
+} from '@alga-psa/ui/lib/errorHandling';
+import {
+  normalizeTenantSettings,
+  resolveClientPortalFeatureSettings,
+  type ClientPortalFeatureSettings,
+} from '../../lib/clientPortalFeatureSettings';
+import { getClientPortalFeatureSettingsForTenant } from '../../lib/clientPortalFeatureSettingsDb';
+
+export const getClientPortalFeatureSettings = withAuth(async (
+  _user,
+  { tenant },
+): Promise<ClientPortalFeatureSettings> => {
+  const { knex } = await createTenantKnex();
+  return getClientPortalFeatureSettingsForTenant(knex, tenant);
+});
+
+export const updateClientPortalFeatureSettings = withAuth(async (
+  user,
+  { tenant },
+  updated: Partial<ClientPortalFeatureSettings>,
+): Promise<ClientPortalFeatureSettings | ActionPermissionError> => {
+  const { knex } = await createTenantKnex();
+
+  if (!(await hasPermission(user, 'settings', 'update', knex))) {
+    return permissionError('Permission denied: settings:update required');
+  }
+
+  const scopedDb = tenantDb(knex, tenant);
+  const existing = await scopedDb
+    .table('tenant_settings')
+    .select('settings')
+    .first();
+  const settings = normalizeTenantSettings(existing?.settings);
+  const currentClientPortal = normalizeTenantSettings(settings.clientPortal);
+  const nextClientPortal = {
+    ...currentClientPortal,
+    ...(updated.appointmentsEnabled === undefined
+      ? {}
+      : { appointmentsEnabled: updated.appointmentsEnabled }),
+  };
+  const nextSettings = {
+    ...settings,
+    clientPortal: nextClientPortal,
+  };
+  const now = new Date();
+
+  await scopedDb
+    .table('tenant_settings')
+    .insert({
+      tenant,
+      settings: JSON.stringify(nextSettings),
+      updated_at: now,
+    })
+    .onConflict('tenant')
+    .merge({
+      settings: JSON.stringify(nextSettings),
+      updated_at: now,
+    });
+
+  return resolveClientPortalFeatureSettings(nextSettings);
+});

--- a/packages/client-portal/src/actions/client-portal-actions/index.ts
+++ b/packages/client-portal/src/actions/client-portal-actions/index.ts
@@ -13,3 +13,4 @@ export * from './visibilityGroupActions';
 export * from './dashboard';
 export * from './notificationActivities';
 export * from './client-assets';
+export * from './clientPortalFeatureSettingsActions';

--- a/packages/client-portal/src/components/dashboard/ClientDashboard.tsx
+++ b/packages/client-portal/src/components/dashboard/ClientDashboard.tsx
@@ -205,7 +205,13 @@ function timeAgo(value: string | Date | null | undefined, t: TranslateFn, locale
 const DASHBOARD_PREVIEW_DEVICES = 4;
 const DASHBOARD_PREVIEW_APPOINTMENTS = 3;
 
-export function ClientDashboard({ productCode = 'psa' }: { productCode?: ProductCode } = {}) {
+export function ClientDashboard({
+  productCode = 'psa',
+  appointmentsEnabled = true,
+}: {
+  productCode?: ProductCode;
+  appointmentsEnabled?: boolean;
+} = {}) {
   const { t, i18n } = useTranslation('client-portal');
   const { branding } = useBranding();
   const portalHeroGradient = branding?.portalHeroGradient ?? 'primary-shades';
@@ -254,7 +260,9 @@ export function ClientDashboard({ productCode = 'psa' }: { productCode?: Product
       const [user, metricsData, appointmentsResult, activityData, devicesData] = await Promise.all([
         getCurrentUser(),
         getDashboardMetrics(),
-        getMyAppointmentRequests({ status: 'approved' }),
+        appointmentsEnabled
+          ? getMyAppointmentRequests({ status: 'approved' })
+          : Promise.resolve({ success: true, data: [] }),
         getRecentActivity().catch(() => [] as RecentActivity[]),
         getClientAssets().catch(() => [] as Asset[]),
       ]);
@@ -281,7 +289,7 @@ export function ClientDashboard({ productCode = 'psa' }: { productCode?: Product
       setErrorMessage(null);
       setError(true);
     }
-  }, [isAlgaDeskPortal]);
+  }, [appointmentsEnabled, isAlgaDeskPortal]);
 
   useEffect(() => {
     fetchDashboardData();
@@ -391,25 +399,27 @@ export function ClientDashboard({ productCode = 'psa' }: { productCode?: Product
               'Structured requests you have submitted from the catalog.',
             ),
           },
-          {
-            id: 'upcoming-visits',
-            label: t('dashboard.metrics.upcomingVisits', 'Upcoming visits'),
-            value: upcomingAppointments.length,
-            icon: Calendar,
-            href: '/client-portal/appointments',
-            hint: nextAppointmentLabel
-              ? t('dashboard.metrics.nextLabel', { defaultValue: 'Next: {{when}}', when: nextAppointmentLabel })
-              : t('dashboard.metrics.noneScheduled', 'None scheduled'),
-            description: t(
-              'dashboard.metrics.upcomingVisitsDescription',
-              'Scheduled appointments with our technicians.',
-            ),
-            action: {
-              id: 'kpi-upcoming-visits-request',
-              label: t('dashboard.quickActions.requestAppointment', 'Request appointment'),
-              onClick: () => setIsAppointmentModalOpen(true),
-            },
-          },
+          ...(appointmentsEnabled
+            ? [{
+                id: 'upcoming-visits',
+                label: t('dashboard.metrics.upcomingVisits', 'Upcoming visits'),
+                value: upcomingAppointments.length,
+                icon: Calendar,
+                href: '/client-portal/appointments',
+                hint: nextAppointmentLabel
+                  ? t('dashboard.metrics.nextLabel', { defaultValue: 'Next: {{when}}', when: nextAppointmentLabel })
+                  : t('dashboard.metrics.noneScheduled', 'None scheduled'),
+                description: t(
+                  'dashboard.metrics.upcomingVisitsDescription',
+                  'Scheduled appointments with our technicians.',
+                ),
+                action: {
+                  id: 'kpi-upcoming-visits-request',
+                  label: t('dashboard.quickActions.requestAppointment', 'Request appointment'),
+                  onClick: () => setIsAppointmentModalOpen(true),
+                },
+              }]
+            : []),
           {
             id: 'active-devices',
             label: t('dashboard.metrics.activeDevices', 'Active devices'),
@@ -451,7 +461,13 @@ export function ClientDashboard({ productCode = 'psa' }: { productCode?: Product
       </div>
 
       {/* KPI Cards */}
-      <div className={isAlgaDeskPortal ? 'grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-3' : 'grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-5'}>
+      <div className={
+        isAlgaDeskPortal
+          ? 'grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-3'
+          : appointmentsEnabled
+            ? 'grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-5'
+            : 'grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-4'
+      }>
         {kpiCards.map((card) => {
           const Icon = card.icon;
           return (
@@ -573,6 +589,7 @@ export function ClientDashboard({ productCode = 'psa' }: { productCode?: Product
         {/* Side rail: Schedule + Devices stacked */}
         {!isAlgaDeskPortal && (
         <div className="lg:col-span-1 space-y-4">
+        {appointmentsEnabled && (
         <Card className="bg-[rgb(var(--color-card))]">
           <CardHeader>
             <div className="flex items-center gap-2">
@@ -644,6 +661,7 @@ export function ClientDashboard({ productCode = 'psa' }: { productCode?: Product
             )}
           </CardContent>
         </Card>
+        )}
 
         {/* Devices preview */}
         <Card className="bg-[rgb(var(--color-card))]">
@@ -715,7 +733,7 @@ export function ClientDashboard({ productCode = 'psa' }: { productCode?: Product
         )}
       </div>
 
-      {!isAlgaDeskPortal && (
+      {!isAlgaDeskPortal && appointmentsEnabled && (
       <RequestAppointmentModal
         open={isAppointmentModalOpen}
         onOpenChange={setIsAppointmentModalOpen}

--- a/packages/client-portal/src/components/layout/ClientPortalLayout.tsx
+++ b/packages/client-portal/src/components/layout/ClientPortalLayout.tsx
@@ -26,16 +26,19 @@ import { resolveClientPortalTitleKey } from './clientPortalRouteTitles';
 interface ClientPortalLayoutProps {
   children: ReactNode;
   productCode?: ProductCode;
+  appointmentsEnabled?: boolean;
   initialSidebarCollapsed?: boolean;
 }
 
 function LayoutShell({
   children,
   productCode,
+  appointmentsEnabled,
   initialSidebarCollapsed,
 }: {
   children: ReactNode;
   productCode: ProductCode;
+  appointmentsEnabled: boolean;
   initialSidebarCollapsed: boolean;
 }) {
   const [userData, setUserData] = useState<IUserWithRoles | null>(null);
@@ -112,6 +115,7 @@ function LayoutShell({
           isLicenseDistributor: permissions.isLicenseDistributor,
         }}
         permissionsLoaded={permissionsLoaded}
+        appointmentsEnabled={appointmentsEnabled}
         initialCollapsed={initialSidebarCollapsed}
       />
 
@@ -140,6 +144,7 @@ function LayoutShell({
 export default function ClientPortalLayout({
   children,
   productCode = 'psa',
+  appointmentsEnabled = true,
   initialSidebarCollapsed = false,
 }: ClientPortalLayoutProps) {
   return (
@@ -147,6 +152,7 @@ export default function ClientPortalLayout({
       <ClientPortalPageProvider>
         <LayoutShell
           productCode={productCode}
+          appointmentsEnabled={appointmentsEnabled}
           initialSidebarCollapsed={initialSidebarCollapsed}
         >
           {children}

--- a/packages/client-portal/src/components/layout/ClientPortalSidebar.tsx
+++ b/packages/client-portal/src/components/layout/ClientPortalSidebar.tsx
@@ -42,6 +42,7 @@ interface SidebarProps {
   productCode?: ProductCode;
   permissions: SidebarPermissions;
   permissionsLoaded: boolean;
+  appointmentsEnabled?: boolean;
   initialCollapsed?: boolean;
 }
 
@@ -62,6 +63,7 @@ export function ClientPortalSidebar({
   productCode = 'psa',
   permissions,
   permissionsLoaded,
+  appointmentsEnabled = true,
   initialCollapsed = false,
 }: SidebarProps) {
   const pathname = usePathname();
@@ -108,7 +110,9 @@ export function ClientPortalSidebar({
         { key: 'tickets', href: '/client-portal/tickets', label: t('nav.tickets', 'Tickets'), icon: Ticket },
         { key: 'request-services', href: '/client-portal/request-services', label: t('nav.requestServices', 'Request Services'), icon: LayoutTemplate },
         { key: 'projects', href: '/client-portal/projects', label: t('nav.projects', 'Projects'), icon: ListTodo },
-        { key: 'appointments', href: '/client-portal/appointments', label: t('nav.appointments', 'Appointments'), icon: Calendar },
+        ...(appointmentsEnabled
+          ? [{ key: 'appointments', href: '/client-portal/appointments', label: t('nav.appointments', 'Appointments'), icon: Calendar }]
+          : []),
         { key: 'devices', href: '/client-portal/devices', label: t('nav.myDevices', 'My devices'), icon: Monitor },
       ];
 

--- a/packages/client-portal/src/lib/clientPortalFeatureSettings.test.ts
+++ b/packages/client-portal/src/lib/clientPortalFeatureSettings.test.ts
@@ -1,0 +1,33 @@
+import { describe, expect, it } from 'vitest';
+import {
+  DEFAULT_CLIENT_PORTAL_FEATURE_SETTINGS,
+  normalizeTenantSettings,
+  resolveClientPortalFeatureSettings,
+} from './clientPortalFeatureSettings';
+
+describe('client portal feature settings', () => {
+  it('keeps appointments enabled when the setting has not been configured', () => {
+    expect(resolveClientPortalFeatureSettings(undefined)).toEqual(
+      DEFAULT_CLIENT_PORTAL_FEATURE_SETTINGS,
+    );
+    expect(resolveClientPortalFeatureSettings({ clientPortal: {} })).toEqual(
+      DEFAULT_CLIENT_PORTAL_FEATURE_SETTINGS,
+    );
+  });
+
+  it('disables appointments only when explicitly configured as false', () => {
+    expect(resolveClientPortalFeatureSettings({
+      clientPortal: { appointmentsEnabled: false },
+    })).toEqual({ appointmentsEnabled: false });
+    expect(resolveClientPortalFeatureSettings({
+      clientPortal: { appointmentsEnabled: true },
+    })).toEqual({ appointmentsEnabled: true });
+  });
+
+  it('normalizes JSON strings and ignores malformed settings', () => {
+    expect(resolveClientPortalFeatureSettings(
+      JSON.stringify({ clientPortal: { appointmentsEnabled: false } }),
+    )).toEqual({ appointmentsEnabled: false });
+    expect(normalizeTenantSettings('{not-json')).toEqual({});
+  });
+});

--- a/packages/client-portal/src/lib/clientPortalFeatureSettings.ts
+++ b/packages/client-portal/src/lib/clientPortalFeatureSettings.ts
@@ -1,0 +1,37 @@
+export interface ClientPortalFeatureSettings {
+  appointmentsEnabled: boolean;
+}
+
+export const DEFAULT_CLIENT_PORTAL_FEATURE_SETTINGS: ClientPortalFeatureSettings = {
+  appointmentsEnabled: true,
+};
+
+function asRecord(value: unknown): Record<string, unknown> {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) {
+    return {};
+  }
+
+  return value as Record<string, unknown>;
+}
+
+export function normalizeTenantSettings(value: unknown): Record<string, unknown> {
+  if (typeof value === 'string') {
+    try {
+      return asRecord(JSON.parse(value));
+    } catch {
+      return {};
+    }
+  }
+
+  return asRecord(value);
+}
+
+export function resolveClientPortalFeatureSettings(value: unknown): ClientPortalFeatureSettings {
+  const settings = normalizeTenantSettings(value);
+  const clientPortal = asRecord(settings.clientPortal);
+
+  return {
+    appointmentsEnabled:
+      clientPortal.appointmentsEnabled !== false,
+  };
+}

--- a/packages/client-portal/src/lib/clientPortalFeatureSettingsDb.ts
+++ b/packages/client-portal/src/lib/clientPortalFeatureSettingsDb.ts
@@ -1,0 +1,18 @@
+import { tenantDb } from '@alga-psa/db';
+import type { Knex } from 'knex';
+import {
+  resolveClientPortalFeatureSettings,
+  type ClientPortalFeatureSettings,
+} from './clientPortalFeatureSettings';
+
+export async function getClientPortalFeatureSettingsForTenant(
+  knex: Knex,
+  tenant: string,
+): Promise<ClientPortalFeatureSettings> {
+  const row = await tenantDb(knex, tenant)
+    .table('tenant_settings')
+    .select('settings')
+    .first();
+
+  return resolveClientPortalFeatureSettings(row?.settings);
+}

--- a/server/public/locales/de/msp/settings.json
+++ b/server/public/locales/de/msp/settings.json
@@ -1056,6 +1056,15 @@
     "openMenu": "Menü öffnen"
   },
   "clientPortal": {
+    "features": {
+      "title": "Portal-Funktionen",
+      "description": "Wählen Sie aus, auf welche Self-Service-Funktionen Kunden zugreifen können.",
+      "appointmentsLabel": "Termine",
+      "appointmentsHelp": "Erlauben Sie Kunden, Termine im Kundenportal anzuzeigen und anzufragen.",
+      "appointmentsEnabled": "Termine sind jetzt im Kundenportal verfügbar",
+      "appointmentsDisabled": "Termine sind jetzt im Kundenportal ausgeblendet",
+      "updateFailed": "Die Funktionen des Kundenportals konnten nicht aktualisiert werden"
+    },
     "branding": {
       "title": "Branding & Erscheinungsbild",
       "description": "Passen Sie das Erscheinungsbild Ihres Kundenportals mit Ihrem Unternehmensbranding an.",

--- a/server/public/locales/en/msp/settings.json
+++ b/server/public/locales/en/msp/settings.json
@@ -1056,6 +1056,15 @@
     "openMenu": "Open menu"
   },
   "clientPortal": {
+    "features": {
+      "title": "Portal Features",
+      "description": "Choose which self-service features clients can access.",
+      "appointmentsLabel": "Appointments",
+      "appointmentsHelp": "Allow clients to view and request appointments from the client portal.",
+      "appointmentsEnabled": "Appointments are now available in the client portal",
+      "appointmentsDisabled": "Appointments are now hidden from the client portal",
+      "updateFailed": "Failed to update client portal features"
+    },
     "branding": {
       "title": "Branding & Appearance",
       "description": "Customize the look and feel of your client portal with your company branding.",

--- a/server/public/locales/es/msp/settings.json
+++ b/server/public/locales/es/msp/settings.json
@@ -1056,6 +1056,15 @@
     "openMenu": "Abrir menú"
   },
   "clientPortal": {
+    "features": {
+      "title": "Funciones del portal",
+      "description": "Elija a qué funciones de autoservicio pueden acceder los clientes.",
+      "appointmentsLabel": "Citas",
+      "appointmentsHelp": "Permita que los clientes vean y soliciten citas desde el portal del cliente.",
+      "appointmentsEnabled": "Las citas ya están disponibles en el portal del cliente",
+      "appointmentsDisabled": "Las citas ahora están ocultas en el portal del cliente",
+      "updateFailed": "No se pudieron actualizar las funciones del portal del cliente"
+    },
     "branding": {
       "title": "Marca y apariencia",
       "description": "Personalice la apariencia de su portal del cliente con la marca de su empresa.",

--- a/server/public/locales/fr/msp/settings.json
+++ b/server/public/locales/fr/msp/settings.json
@@ -1056,6 +1056,15 @@
     "openMenu": "Ouvrir le menu"
   },
   "clientPortal": {
+    "features": {
+      "title": "Fonctionnalités du portail",
+      "description": "Choisissez les fonctionnalités en libre-service auxquelles les clients peuvent accéder.",
+      "appointmentsLabel": "Rendez-vous",
+      "appointmentsHelp": "Permettez aux clients de consulter et de demander des rendez-vous depuis le portail client.",
+      "appointmentsEnabled": "Les rendez-vous sont désormais disponibles dans le portail client",
+      "appointmentsDisabled": "Les rendez-vous sont désormais masqués dans le portail client",
+      "updateFailed": "Impossible de mettre à jour les fonctionnalités du portail client"
+    },
     "branding": {
       "title": "Image de marque et apparence",
       "description": "Personnalisez l'apparence de votre portail client avec l'image de marque de votre entreprise.",

--- a/server/public/locales/it/msp/settings.json
+++ b/server/public/locales/it/msp/settings.json
@@ -1056,6 +1056,15 @@
     "openMenu": "Apri menu"
   },
   "clientPortal": {
+    "features": {
+      "title": "Funzionalità del portale",
+      "description": "Scelga a quali funzionalità self-service possono accedere i clienti.",
+      "appointmentsLabel": "Appuntamenti",
+      "appointmentsHelp": "Consenta ai clienti di visualizzare e richiedere appuntamenti dal portale clienti.",
+      "appointmentsEnabled": "Gli appuntamenti sono ora disponibili nel portale clienti",
+      "appointmentsDisabled": "Gli appuntamenti sono ora nascosti nel portale clienti",
+      "updateFailed": "Impossibile aggiornare le funzionalità del portale clienti"
+    },
     "branding": {
       "title": "Branding e aspetto",
       "description": "Personalizzi l'aspetto del Suo portale clienti con il marchio della Sua azienda.",

--- a/server/public/locales/nl/msp/settings.json
+++ b/server/public/locales/nl/msp/settings.json
@@ -1056,6 +1056,15 @@
     "openMenu": "Menu openen"
   },
   "clientPortal": {
+    "features": {
+      "title": "Portaalfuncties",
+      "description": "Kies tot welke selfservicefuncties klanten toegang hebben.",
+      "appointmentsLabel": "Afspraken",
+      "appointmentsHelp": "Sta klanten toe om afspraken in het klantenportaal te bekijken en aan te vragen.",
+      "appointmentsEnabled": "Afspraken zijn nu beschikbaar in het klantenportaal",
+      "appointmentsDisabled": "Afspraken zijn nu verborgen in het klantenportaal",
+      "updateFailed": "De functies van het klantenportaal konden niet worden bijgewerkt"
+    },
     "branding": {
       "title": "Huisstijl en uiterlijk",
       "description": "Pas het uiterlijk van uw klantenportaal aan met uw bedrijfshuisstijl.",

--- a/server/public/locales/pl/msp/settings.json
+++ b/server/public/locales/pl/msp/settings.json
@@ -1062,6 +1062,15 @@
     "openMenu": "Otwórz menu"
   },
   "clientPortal": {
+    "features": {
+      "title": "Funkcje portalu",
+      "description": "Wybierz funkcje samoobsługowe, do których klienci mają dostęp.",
+      "appointmentsLabel": "Spotkania",
+      "appointmentsHelp": "Zezwól klientom na wyświetlanie spotkań i wysyłanie próśb o spotkanie w portalu klienta.",
+      "appointmentsEnabled": "Spotkania są teraz dostępne w portalu klienta",
+      "appointmentsDisabled": "Spotkania są teraz ukryte w portalu klienta",
+      "updateFailed": "Nie udało się zaktualizować funkcji portalu klienta"
+    },
     "branding": {
       "title": "Branding i wygląd",
       "description": "Dostosuj wygląd portalu klienta za pomocą identyfikacji wizualnej Państwa firmy.",

--- a/server/public/locales/pt/msp/settings.json
+++ b/server/public/locales/pt/msp/settings.json
@@ -1056,6 +1056,15 @@
     "openMenu": "Abrir menu"
   },
   "clientPortal": {
+    "features": {
+      "title": "Funcionalidades do portal",
+      "description": "Escolha as funcionalidades de autoatendimento a que os clientes podem aceder.",
+      "appointmentsLabel": "Agendamentos",
+      "appointmentsHelp": "Permita que os clientes vejam e solicitem agendamentos no portal do cliente.",
+      "appointmentsEnabled": "Os agendamentos estão agora disponíveis no portal do cliente",
+      "appointmentsDisabled": "Os agendamentos estão agora ocultos no portal do cliente",
+      "updateFailed": "Não foi possível atualizar as funcionalidades do portal do cliente"
+    },
     "branding": {
       "title": "Marca e aparência",
       "description": "Personalize a aparência do portal do seu cliente com a marca da sua empresa.",

--- a/server/public/locales/xx/msp/settings.json
+++ b/server/public/locales/xx/msp/settings.json
@@ -1056,6 +1056,15 @@
     "openMenu": "11111"
   },
   "clientPortal": {
+    "features": {
+      "title": "11111",
+      "description": "11111",
+      "appointmentsLabel": "11111",
+      "appointmentsHelp": "11111",
+      "appointmentsEnabled": "11111",
+      "appointmentsDisabled": "11111",
+      "updateFailed": "11111"
+    },
     "branding": {
       "title": "11111",
       "description": "11111",

--- a/server/public/locales/yy/msp/settings.json
+++ b/server/public/locales/yy/msp/settings.json
@@ -1056,6 +1056,15 @@
     "openMenu": "55555"
   },
   "clientPortal": {
+    "features": {
+      "title": "55555",
+      "description": "55555",
+      "appointmentsLabel": "55555",
+      "appointmentsHelp": "55555",
+      "appointmentsEnabled": "55555",
+      "appointmentsDisabled": "55555",
+      "updateFailed": "55555"
+    },
     "branding": {
       "title": "55555",
       "description": "55555",

--- a/server/src/app/client-portal/ClientPortalLayoutClient.tsx
+++ b/server/src/app/client-portal/ClientPortalLayoutClient.tsx
@@ -20,6 +20,7 @@ interface Props {
   session: Session | null;
   branding: TenantBranding | null;
   productCode: ProductCode;
+  appointmentsEnabled?: boolean;
   /** Tenant default currency (default_billing_settings) for CurrencyFormatProvider. */
   currencyCode?: string;
   initialLocale?: SupportedLocale | null;
@@ -31,6 +32,7 @@ export function ClientPortalLayoutClient({
   session,
   branding,
   productCode,
+  appointmentsEnabled = true,
   currencyCode,
   initialLocale,
   initialSidebarCollapsed = false,
@@ -47,6 +49,7 @@ export function ClientPortalLayoutClient({
           <ClientPortalDocumentsProvider>
             <ClientPortalLayout
               productCode={productCode}
+              appointmentsEnabled={appointmentsEnabled}
               initialSidebarCollapsed={initialSidebarCollapsed}
             >
               {productCode === 'algadesk' && routeBehavior !== 'allowed'

--- a/server/src/app/client-portal/appointments/[appointmentRequestId]/page.tsx
+++ b/server/src/app/client-portal/appointments/[appointmentRequestId]/page.tsx
@@ -1,10 +1,15 @@
-'use client';
-
 import { Suspense } from 'react';
 import { AppointmentRequestDetailsPage } from '@alga-psa/client-portal/components';
+import { getClientPortalFeatureSettings } from '@alga-psa/client-portal/actions/client-portal-actions/clientPortalFeatureSettingsActions';
 import { Skeleton } from '@alga-psa/ui/components/Skeleton';
+import { redirect } from 'next/navigation';
 
-export default function AppointmentRequestPage() {
+export default async function AppointmentRequestPage() {
+  const portalFeatureSettings = await getClientPortalFeatureSettings();
+  if (!portalFeatureSettings.appointmentsEnabled) {
+    redirect('/client-portal/dashboard');
+  }
+
   return (
     <div className="w-full">
       <Suspense fallback={<Skeleton className="h-96" />}>

--- a/server/src/app/client-portal/appointments/page.tsx
+++ b/server/src/app/client-portal/appointments/page.tsx
@@ -1,8 +1,12 @@
-'use client';
-
 import { AppointmentsPage as ClientPortalAppointmentsPage } from '@alga-psa/client-portal/components';
+import { getClientPortalFeatureSettings } from '@alga-psa/client-portal/actions/client-portal-actions/clientPortalFeatureSettingsActions';
+import { redirect } from 'next/navigation';
 
-export default function AppointmentsPage() {
+export default async function AppointmentsPage() {
+  const portalFeatureSettings = await getClientPortalFeatureSettings();
+  if (!portalFeatureSettings.appointmentsEnabled) {
+    redirect('/client-portal/dashboard');
+  }
+
   return <ClientPortalAppointmentsPage />;
 }
-

--- a/server/src/app/client-portal/dashboard/page.tsx
+++ b/server/src/app/client-portal/dashboard/page.tsx
@@ -1,12 +1,21 @@
 import { ClientDashboard } from '@alga-psa/client-portal/components';
 import { getCurrentTenantProduct } from '@/lib/productAccess';
 import type { Metadata } from 'next';
+import { getClientPortalFeatureSettings } from '@alga-psa/client-portal/actions/client-portal-actions/clientPortalFeatureSettingsActions';
 
 export const metadata: Metadata = {
   title: 'Dashboard',
 };
 
 export default async function DashboardPage() {
-  const productCode = await getCurrentTenantProduct();
-  return <ClientDashboard productCode={productCode} />;
+  const [productCode, portalFeatureSettings] = await Promise.all([
+    getCurrentTenantProduct(),
+    getClientPortalFeatureSettings(),
+  ]);
+  return (
+    <ClientDashboard
+      productCode={productCode}
+      appointmentsEnabled={portalFeatureSettings.appointmentsEnabled}
+    />
+  );
 }

--- a/server/src/app/client-portal/layout.tsx
+++ b/server/src/app/client-portal/layout.tsx
@@ -7,6 +7,7 @@ import { getHierarchicalLocaleAction } from "@alga-psa/tenancy/actions";
 import { getCurrentTenantProduct } from "@/lib/productAccess";
 import { getTenantDefaultCurrencyCode } from "@alga-psa/billing/actions/billingCurrencyActions";
 import type { Metadata } from 'next';
+import { getClientPortalFeatureSettings } from '@alga-psa/client-portal/actions/client-portal-actions/clientPortalFeatureSettingsActions';
 
 const CLIENT_SIDEBAR_COOKIE = 'client_portal_sidebar_collapsed';
 
@@ -57,12 +58,14 @@ export default async function Layout({
     cookieStore.get(CLIENT_SIDEBAR_COOKIE)?.value === 'true';
   const productCode = await getCurrentTenantProduct();
   const currencyCode = await getTenantDefaultCurrencyCode().catch(() => 'USD');
+  const portalFeatureSettings = await getClientPortalFeatureSettings();
 
   return (
     <ClientPortalLayoutClient
       session={session}
       branding={branding}
       productCode={productCode}
+      appointmentsEnabled={portalFeatureSettings.appointmentsEnabled}
       currencyCode={currencyCode}
       initialLocale={locale}
       initialSidebarCollapsed={initialSidebarCollapsed}

--- a/server/src/components/settings/general/ClientPortalSettings.tsx
+++ b/server/src/components/settings/general/ClientPortalSettings.tsx
@@ -3,7 +3,7 @@
 
 import React, { useCallback, useState, useEffect, useMemo } from 'react';
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@alga-psa/ui/components/Card";
-import { Globe, Palette } from 'lucide-react';
+import { Calendar, Globe, Palette } from 'lucide-react';
 import { LanguageHierarchyTable } from '@alga-psa/ui/components/LanguageHierarchyTable';
 import { LOCALE_CONFIG, filterPseudoLocales, type SupportedLocale } from '@alga-psa/core/i18n/config';
 import CustomSelect, { SelectOption } from '@alga-psa/ui/components/CustomSelect';
@@ -20,7 +20,7 @@ import {
   updateTenantClientPortalLocaleAction,
 } from '@alga-psa/tenancy/actions/tenant-actions/tenantClientPortalLocaleActions';
 import { toast } from 'react-hot-toast';
-import { handleError } from '@alga-psa/ui/lib/errorHandling';
+import { handleError, isActionPermissionError } from '@alga-psa/ui/lib/errorHandling';
 import { Button } from '@alga-psa/ui/components/Button';
 import { Input } from '@alga-psa/ui/components/Input';
 import EntityImageUpload from '@alga-psa/ui/components/EntityImageUpload';
@@ -35,6 +35,10 @@ import { getPortalDomainStatusAction } from '@alga-psa/tenancy/actions/tenant-ac
 import { Switch } from '@alga-psa/ui/components/Switch';
 import { useTranslation } from '@alga-psa/ui/lib/i18n/client';
 import { useActionPolling } from '@alga-psa/ui/hooks';
+import {
+  getClientPortalFeatureSettings,
+  updateClientPortalFeatureSettings,
+} from '@alga-psa/client-portal/actions/client-portal-actions/clientPortalFeatureSettingsActions';
 
 const UNSET_LOCALE_VALUE = '__inherit__';
 const DEFAULT_PORTAL_HERO_GRADIENT: PortalHeroGradient = 'primary-shades';
@@ -83,6 +87,9 @@ const ClientPortalSettings = () => {
   );
   const [localeLoading, setLocaleLoading] = useState<boolean>(true);
   const [localeSaving, setLocaleSaving] = useState<boolean>(false);
+  const [appointmentsEnabled, setAppointmentsEnabled] = useState(true);
+  const [portalFeaturesLoading, setPortalFeaturesLoading] = useState(true);
+  const [portalFeaturesSaving, setPortalFeaturesSaving] = useState(false);
   const { refreshBranding } = useBranding();
 
   const visibleLocales = useMemo(
@@ -115,11 +122,18 @@ const ClientPortalSettings = () => {
   useEffect(() => {
     const loadTenantSettings = async () => {
       try {
-        const [user, brandingSettings, orgLocaleSettings, clientPortalLocaleSettings] = await Promise.all([
+        const [
+          user,
+          brandingSettings,
+          orgLocaleSettings,
+          clientPortalLocaleSettings,
+          portalFeatureSettings,
+        ] = await Promise.all([
           getCurrentUser(),
           getTenantBrandingAction(),
           getTenantLocaleSettingsAction(),
           getTenantClientPortalLocaleAction(),
+          getClientPortalFeatureSettings(),
         ]);
 
         if (user) {
@@ -141,11 +155,13 @@ const ClientPortalSettings = () => {
         }
 
         setClientPortalLocale(clientPortalLocaleSettings?.defaultLocale ?? null);
+        setAppointmentsEnabled(portalFeatureSettings.appointmentsEnabled);
       } catch (error) {
         console.error('Failed to load tenant settings:', error);
       } finally {
         setBrandingLoading(false);
         setLocaleLoading(false);
+        setPortalFeaturesLoading(false);
       }
     };
 
@@ -181,6 +197,44 @@ const ClientPortalSettings = () => {
       handleError(error, 'Failed to update client portal default language');
     } finally {
       setLocaleSaving(false);
+    }
+  };
+
+  const handleAppointmentsEnabledChange = async (enabled: boolean) => {
+    const previous = appointmentsEnabled;
+    setAppointmentsEnabled(enabled);
+    setPortalFeaturesSaving(true);
+
+    try {
+      const result = await updateClientPortalFeatureSettings({
+        appointmentsEnabled: enabled,
+      });
+      if (isActionPermissionError(result)) {
+        setAppointmentsEnabled(previous);
+        handleError(result);
+        return;
+      }
+
+      setAppointmentsEnabled(result.appointmentsEnabled);
+      toast.success(
+        result.appointmentsEnabled
+          ? t('clientPortal.features.appointmentsEnabled', {
+              defaultValue: 'Appointments are now available in the client portal',
+            })
+          : t('clientPortal.features.appointmentsDisabled', {
+              defaultValue: 'Appointments are now hidden from the client portal',
+            }),
+      );
+    } catch (error) {
+      setAppointmentsEnabled(previous);
+      handleError(
+        error,
+        t('clientPortal.features.updateFailed', {
+          defaultValue: 'Failed to update client portal features',
+        }),
+      );
+    } finally {
+      setPortalFeaturesSaving(false);
     }
   };
 
@@ -257,6 +311,47 @@ const ClientPortalSettings = () => {
   return (
     <div className="space-y-6">
       <ClientPortalDomainSettings />
+
+      <Card>
+        <CardHeader>
+          <CardTitle>
+            <div className="flex items-center gap-2">
+              <Calendar className="h-5 w-5" />
+              {t('clientPortal.features.title', { defaultValue: 'Portal Features' })}
+            </div>
+          </CardTitle>
+          <CardDescription>
+            {t('clientPortal.features.description', {
+              defaultValue: 'Choose which self-service features clients can access.',
+            })}
+          </CardDescription>
+        </CardHeader>
+        <CardContent>
+          <div className="flex items-start justify-between gap-6">
+            <div>
+              <div className="text-sm font-medium text-[rgb(var(--color-text-900))]">
+                {t('clientPortal.features.appointmentsLabel', {
+                  defaultValue: 'Appointments',
+                })}
+              </div>
+              <p className="mt-1 text-sm text-[rgb(var(--color-text-600))]">
+                {t('clientPortal.features.appointmentsHelp', {
+                  defaultValue: 'Allow clients to view and request appointments from the client portal.',
+                })}
+              </p>
+            </div>
+            <Switch
+              id="client-portal-appointments-enabled"
+              checked={appointmentsEnabled}
+              onCheckedChange={handleAppointmentsEnabledChange}
+              disabled={portalFeaturesLoading || portalFeaturesSaving}
+              aria-label={t('clientPortal.features.appointmentsLabel', {
+                defaultValue: 'Appointments',
+              })}
+            />
+          </div>
+        </CardContent>
+      </Card>
 
       {/* Client Portal Language Card */}
       <Card>
@@ -607,7 +702,9 @@ const ClientPortalSettings = () => {
                             { label: t('clientPortal.dashboardPreview.navTickets', { defaultValue: 'Tickets' }), active: false },
                             { label: t('clientPortal.dashboardPreview.navServiceRequests', { defaultValue: 'Service Requests' }), active: false },
                             { label: t('clientPortal.dashboardPreview.navProjects', { defaultValue: 'Projects' }), active: false },
-                            { label: t('clientPortal.dashboardPreview.navAppointments', { defaultValue: 'Appointments' }), active: false },
+                            ...(appointmentsEnabled
+                              ? [{ label: t('clientPortal.dashboardPreview.navAppointments', { defaultValue: 'Appointments' }), active: false }]
+                              : []),
                             { label: t('clientPortal.dashboardPreview.navDevices', { defaultValue: 'My devices' }), active: false },
                           ].map((item, idx) => (
                             <li key={idx}>

--- a/server/src/test/unit/client-portal/algadeskPortalTicketing.contract.test.ts
+++ b/server/src/test/unit/client-portal/algadeskPortalTicketing.contract.test.ts
@@ -12,7 +12,11 @@ describe('AlgaDesk client portal ticketing contracts', () => {
     const ticketsPage = read('src/app/client-portal/tickets/page.tsx');
     const ticketDetailPage = read('src/app/client-portal/tickets/[ticketId]/page.tsx');
 
-    expect(dashboardPage).toContain('return <ClientDashboard productCode={productCode} />');
+    expect(dashboardPage).toContain('<ClientDashboard');
+    expect(dashboardPage).toContain('productCode={productCode}');
+    expect(dashboardPage).toContain(
+      'appointmentsEnabled={portalFeatureSettings.appointmentsEnabled}',
+    );
     expect(ticketsPage).toContain('<TicketList />');
     expect(ticketDetailPage).toContain('<TicketDetailsContainer');
   });


### PR DESCRIPTION
## Summary

- Adds an MSP admin switch for client-portal appointments, persisted at `tenant_settings.settings.clientPortal.appointmentsEnabled` while preserving unrelated tenant settings.
- Treats a missing value as enabled for backward compatibility.
- When disabled, removes appointment navigation, dashboard KPI/request controls, the appointment panel, modal, preview entry, and appointment pages while leaving the rest of the portal available.
- Redirects direct appointment listing/detail route visits to the portal dashboard and rejects authenticated appointment creation on the server.
- Adds localized admin copy across the supported MSP locale files plus unit coverage for defaults, persistence, setting preservation, permissions, and dashboard feature propagation.

## Validation

- PASS — full client-portal unit suite: 41 files, 178 tests.
- PASS — AlgaDesk client-portal contract suite: 1 file, 6 tests.
- PASS — core smoke test. Verified the admin setting renders disabled, can be enabled through the real UI, shows its success toast, and persists in PostgreSQL.
- With appointments enabled, the client portal showed appointment navigation, KPI/request controls, panel, and appointments page.
- With appointments disabled, all appointment UI disappeared while tickets, projects, service requests, and devices remained functional. Direct appointment-route navigation redirected to the dashboard.
- An authenticated real Next server-action request was rejected with `Appointment requests are not available in the client portal`; PostgreSQL confirmed no row was created.

No feature mocks or simulators were used.

## Smoke-test fidelity and limitations

The disabled transition was applied directly in PostgreSQL after the UI persistence path was proven. The existing smoke-user password hash was repaired directly after the admin drawer failed to retain typed React state. Later authentication used the real NextAuth credentials endpoint with its session cookie injected into the browser. Modal submission was replaced by the same authenticated server-action transport. Because card-created browser tabs were viewer-host-local, browser control used an explicitly targeted card-owned pane.

The detail-route variant was inconclusive: compiling it repeatedly inflated `server/.next` to 1.7–2.2 GB and crashed Next's `FlightClientEntryPlugin` with `Invalid string length`. Clearing the generated cache restored service. This appears to be a webpack development-environment problem; the listing route itself passed. Two recoverable generated-cache backups remain under `/tmp/alga-next-cache-invalid-string.*`.

Final smoke state: appointments disabled, the app answering with the expected HTTP 307 redirect, infrastructure containers running, and only the pre-existing `package-lock.json` modification present.

Evidence: `/tmp/alga-smoke-evidence/disable-portal-appointments-20260729-003414`