### PR TITLE
docs: update quoting-system email section to reflect customizable Estimates templates

### DIFF
--- a/docs/billing/quoting-system.md
+++ b/docs/billing/quoting-system.md
@@ -174,7 +174,7 @@ Audit trail for all quote state changes.
 ### Document Template Tables
 
 | Table | Purpose |
-|-------|---------|
+|-------|--------|
 | `quote_document_templates` | Tenant-specific PDF rendering templates (AST JSON) |
 | `standard_quote_document_templates` | System-wide default templates |
 | `quote_document_template_assignments` | Tenant-to-template mapping |
@@ -313,24 +313,49 @@ In-browser preview renders the template without Puppeteer, using the same AST ev
 ### Send Quote Action
 
 1. Validates quote is in sendable state (draft or approved)
-2. Generates PDF
-3. Sends email to one or more addresses (defaults to primary contact, supports additional recipients)
-4. Updates `sent_at` timestamp, status → `sent`
-5. Logs activity
+2. Generates PDF (attached as `Estimate_<number>.pdf`, e.g. `Estimate_QUO-0042.pdf`)
+3. Resolves outbound email subject, HTML, and plain-text body from the tenant's configured Estimates template (see [Template Resolution](#template-resolution) below)
+4. Sends email to one or more addresses (defaults to primary contact, supports additional recipients); sender name is derived from the tenant's billing party via `fetchTenantParty`
+5. Updates `sent_at` timestamp, status → `sent`
+6. Logs activity
 
 ### Email Templates
 
-| Template | Trigger |
-|----------|---------|
-| Quote Sent | When MSP sends quote to client |
-| Quote Reminder | For quotes approaching `valid_until` |
-| Quote Accepted | Sent to MSP when client accepts |
+Quote email templates are customizable per tenant through **Settings > Notifications & Email > Email Templates** under the **Estimates** category. Two templates cover client-facing sends:
+
+| Template key | Trigger |
+|---|---|
+| `estimate-email` | When MSP sends or resends a quote to the client |
+| `estimate-reminder-email` | For quotes approaching their `valid_until` date (expiry reminder) |
+
+The "Quote Accepted" event is delivered to the MSP through the standard in-app notification system, not the Email Templates engine.
+
+### Template Resolution
+
+Each send, resend, and reminder action resolves its email content through a three-step fallback chain:
+
+1. **Tenant custom template** — if the tenant has customized the Estimates template in Email Templates settings, that version is used.
+2. **System template** — the default Estimates system template seeded at deployment (`estimate-email` / `estimate-reminder-email`).
+3. **In-code fallback** — hard-coded subjects and body copy in `packages/billing/src/lib/quote-email-templates.ts`, used only when no template record exists (e.g. fresh installations before migration runs).
+
+Source files for the system templates: `packages/billing/src/lib/email/estimates/estimateEmail.cjs`, `estimateReminder.cjs`.
+
+### Template Variables
+
+The following variables are available inside Estimates email templates:
+
+| Variable | Description |
+|---|---|
+| `{{estimate.number}}` | The quote's human-readable number (e.g. `QUO-0042`) |
+| `{{estimate.amount}}` | The quote's formatted total amount |
+| `{{estimate.validUntil}}` | The quote's expiration date |
+| `{{company.name}}` | The MSP's company/trading name (from tenant billing party) |
+| `{{portalLink}}` | Client portal deep-link to the quote detail page |
+| `{{customMessage}}` | The optional personal note entered by the MSP when sending |
 
 ### Email Logging
 
 All sent emails are logged in `email_sending_logs` with `entity_type = 'quote'`, including delivery metadata.
-
-Templates: `packages/billing/src/lib/quote-email-templates.ts`
 
 ---
 
@@ -523,14 +548,14 @@ Runtime flag: defined in `packages/core/src/lib/featureFlagRuntime.ts`
 ### Types and Schemas
 
 | File | Purpose |
-|------|---------|
+|------|--------|
 | `packages/types/src/interfaces/quote.interfaces.ts` | Core TypeScript interfaces (`IQuote`, `IQuoteItem`, `IQuoteActivity`, `QuoteStatus`) |
 | `packages/billing/src/schemas/quoteSchemas.ts` | Zod validation schemas and status transition rules |
 
 ### Models (Data Access)
 
 | File | Purpose |
-|------|---------|
+|------|--------|
 | `packages/billing/src/models/quote.ts` | Quote CRUD, listing, auto-expiration |
 | `packages/billing/src/models/quoteItem.ts` | Line item CRUD, reorder, service catalog lookup |
 | `packages/billing/src/models/quoteActivity.ts` | Audit trail entries |
@@ -539,7 +564,7 @@ Runtime flag: defined in `packages/core/src/lib/featureFlagRuntime.ts`
 ### Server Actions
 
 | File | Purpose |
-|------|---------|
+|------|--------|
 | `packages/billing/src/actions/quoteActions.ts` | All quote server actions (CRUD, send, convert, approve, duplicate) |
 | `packages/billing/src/actions/quoteDocumentTemplates.ts` | Document template actions |
 | `packages/billing/src/actions/quoteTemplatePreview.ts` | Template preview actions |
@@ -547,7 +572,7 @@ Runtime flag: defined in `packages/core/src/lib/featureFlagRuntime.ts`
 ### Services
 
 | File | Purpose |
-|------|---------|
+|------|--------|
 | `packages/billing/src/services/quoteCalculationService.ts` | Totals recalculation |
 | `packages/billing/src/services/quoteConversionService.ts` | Quote to contract/invoice conversion |
 | `packages/billing/src/services/pdfGenerationService.ts` | PDF generation (invoices, quotes, documents) |
@@ -555,7 +580,7 @@ Runtime flag: defined in `packages/core/src/lib/featureFlagRuntime.ts`
 ### UI Components (MSP)
 
 | File | Purpose |
-|------|---------|
+|------|--------|
 | `packages/billing/src/components/billing-dashboard/quotes/QuotesTab.tsx` | Quote list with filters |
 | `packages/billing/src/components/billing-dashboard/quotes/QuoteForm.tsx` | Create/edit form |
 | `packages/billing/src/components/billing-dashboard/quotes/QuoteDetail.tsx` | Read-only detail view with actions |
@@ -569,7 +594,7 @@ Runtime flag: defined in `packages/core/src/lib/featureFlagRuntime.ts`
 ### UI Components (Client Portal)
 
 | File | Purpose |
-|------|---------|
+|------|--------|
 | `packages/client-portal/src/components/billing/QuotesTab.tsx` | Client quote list |
 | `packages/client-portal/src/components/billing/QuoteDetailPage.tsx` | Client quote detail with accept/reject |
 | `packages/client-portal/src/client-portal-actions/client-billing.ts` | Portal server actions |
@@ -577,7 +602,7 @@ Runtime flag: defined in `packages/core/src/lib/featureFlagRuntime.ts`
 ### Template AST
 
 | File | Purpose |
-|------|---------|
+|------|--------|
 | `packages/billing/src/lib/quote-template-ast/bindings.ts` | Quote-specific AST bindings |
 | `packages/billing/src/lib/quote-template-ast/standardTemplates.ts` | Default and detailed template ASTs |
 | `packages/billing/src/lib/quote-template-ast/templateSelection.ts` | Template resolution logic |
@@ -586,7 +611,7 @@ Runtime flag: defined in `packages/core/src/lib/featureFlagRuntime.ts`
 ### Database
 
 | File | Purpose |
-|------|---------|
+|------|--------|
 | `server/migrations/20260320100000_create_quotes_tables.cjs` | Core tables migration |
 | `server/migrations/20260320101000_add_tax_source_to_quotes.cjs` | Tax source field |
 | `server/migrations/20260320102000_create_quote_document_templates.cjs` | Document template tables |
@@ -604,7 +629,7 @@ Runtime flag: defined in `packages/core/src/lib/featureFlagRuntime.ts`
 ### Routes
 
 | Route | Purpose |
-|-------|---------|
+|-------|--------|
 | `/msp/billing?tab=quotes` | Billing dashboard quotes tab (quote detail rendered in-page, not via a dedicated route) |
 | `/msp/quote-approvals` | Approval dashboard |
 | `/msp/quote-document-templates` | Document template editor |


### PR DESCRIPTION
## Source PR

- [#3036 Add quote email templates](https://github.com/Nine-Minds/alga-psa/pull/3036) — introduced customizable Estimates email templates (tenant override → system template → in-code fallback), renamed the email notification category and PDF attachment from Quote to Estimate, and registered new template variables.

## Files edited

### `docs/billing/quoting-system.md`

**Email Sending section rewritten** to convey the new behavior introduced by #3036:

- **PDF naming**: step 2 in the Send Quote Action now notes the attachment is `Estimate_<number>.pdf` (was `Quote_<number>.pdf`), which is what clients see in their inbox.
- **Template resolution**: new prose explains the three-step chain — tenant custom template → system template (`estimate-email` / `estimate-reminder-email`) → in-code fallback in `quote-email-templates.ts`. Previously the doc implied only a hard-coded template existed.
- **Template keys**: the old table listed "Quote Sent / Quote Reminder / Quote Accepted" display names; the new table lists the actual template keys (`estimate-email`, `estimate-reminder-email`) used in the Estimates notification category, with a note that the accepted event goes through in-app notifications, not the template engine.
- **Template variables**: new table documents `{{estimate.number}}`, `{{estimate.amount}}`, `{{estimate.validUntil}}`, `{{company.name}}`, `{{portalLink}}`, `{{customMessage}}` so developers know what variables are available when writing or testing templates.
- **Sender name**: step 4 notes the sender name now comes from `fetchTenantParty` rather than `tenants.client_name`.
- **Source file pointers**: updated to reference `email/estimates/estimateEmail.cjs` and `estimateReminder.cjs`.

## Needs human review

- **alga-psa OpenAPI** may be stale if #3036 added any new API endpoints or changed request/response shapes for the quote send/resend/reminder actions. Please regen via `cd sdk && npm run openapi:generate` and re-sync the result to `nm-store/packages/nm-store/public/openapi/alga.json` if needed.
- **PR #3041 (Employee Utilization report)**: added a new report with no existing documentation in `docs/`. A new doc page covering the report's purpose, filters, and output columns should be created.
- **PR #3039 (Assets UI)**: restructured the asset detail into a bento-style layout. No PR body was present to describe what changed for users. `docs/features/asset_management.md` may need updating — needs human triage.

---
_Generated by [Claude Code](https://claude.ai/code/session_01CUYv949wNnEnHRCNdebcVf)_