### PR TITLE
Fix support contact in portal invitation emails

### DIFF
--- a/packages/email/src/sendPortalInvitationEmail.ts
+++ b/packages/email/src/sendPortalInvitationEmail.ts
@@ -10,12 +10,13 @@ import logger from '@alga-psa/core/logger';
 interface SendPortalInvitationEmailParams {
   email: string;
   contactName: string;
-  clientName: string;
+  clientName: string;      // Recipient's own client company
+  tenantName?: string;     // MSP sending the invitation
   portalLink: string;
   expirationTime: string;
   tenant: string;
-  clientLocationEmail?: string;
-  clientLocationPhone?: string;
+  supportEmail?: string;   // MSP support contact shown to the recipient
+  supportPhone?: string;
   fromName?: string;
   recipientUserId?: string;
   clientId?: string;  // Client ID (from contact.company_id) for locale resolution when user doesn't exist yet
@@ -25,11 +26,12 @@ export async function sendPortalInvitationEmail({
   email,
   contactName,
   clientName,
+  tenantName,
   portalLink,
   expirationTime,
   tenant,
-  clientLocationEmail,
-  clientLocationPhone,
+  supportEmail,
+  supportPhone,
   fromName: _fromName,
   recipientUserId,
   clientId
@@ -64,15 +66,22 @@ export async function sendPortalInvitationEmail({
         clientId: recipientInfo.clientId
       });
 
-      // Prepare template data
+      // Prepare template data. clientLocationEmail/clientLocationPhone are kept
+      // as aliases of the support contact so template rows that predate the
+      // supportEmail/supportPhone rename still render the right values.
+      const resolvedSupportEmail = supportEmail || 'Not provided';
+      const resolvedSupportPhone = supportPhone || 'Not provided';
       const templateData = {
         contactName,
         clientName,
+        tenantName: tenantName || clientName,
         portalLink,
         expirationTime,
         currentYear: new Date().getFullYear(),
-        clientLocationEmail: clientLocationEmail || 'Not provided',
-        clientLocationPhone: clientLocationPhone || 'Not provided'
+        supportEmail: resolvedSupportEmail,
+        supportPhone: resolvedSupportPhone,
+        clientLocationEmail: resolvedSupportEmail,
+        clientLocationPhone: resolvedSupportPhone
       };
 
       // Create database template processor with locale support
@@ -84,7 +93,7 @@ export async function sendPortalInvitationEmail({
         templateProcessor,
         templateData,
         locale: recipientLocale,
-        replyTo: clientLocationEmail // Client email as reply-to
+        replyTo: supportEmail // MSP support email as reply-to
       };
 
       let result = await tenantEmailService.sendEmail({

--- a/packages/notifications/src/lib/templateVariables/seed.ts
+++ b/packages/notifications/src/lib/templateVariables/seed.ts
@@ -732,10 +732,18 @@ export const templateVariableSeed: TemplateVariableSeedCategory[] = [
           {
             "path": "clientName",
             "type": "string",
-            "description": "The client/company whose customer portal the recipient is being invited to.",
+            "description": "The recipient's own client company, named in the invitation intro.",
             "example": "Acme Corporation",
             "availability": "used",
-            "notes": "Used in subject, intro, and footer copyright. Also an {{#if clientName}} condition in the Polish subject."
+            "notes": "Used only in the intro sentence ('invited to access the customer portal for <clientName>'). Falls back to tenantName when the contact has no client."
+          },
+          {
+            "path": "tenantName",
+            "type": "string",
+            "description": "The MSP sending the invitation, shown in the subject and footer copyright.",
+            "example": "Northwind Managed Services",
+            "availability": "used",
+            "notes": "Assembled from the tenant's default client name. Used in subject, footer copyright, and the {{#if tenantName}} condition in the Polish subject."
           },
           {
             "path": "portalLink",
@@ -754,20 +762,36 @@ export const templateVariableSeed: TemplateVariableSeedCategory[] = [
             "notes": "Used in the time-sensitive warning box and its text equivalent."
           },
           {
+            "path": "supportEmail",
+            "type": "string",
+            "description": "The MSP's support email, shown in the Need Assistance box and footer (also the email Reply-To).",
+            "example": "support@northwind.example",
+            "availability": "used",
+            "notes": "Assembled from tenant_settings.settings.supportEmail, falling back to the default client's location email. Defaults to 'Not provided' when neither is set. Used in contact-info Email, footerUnexpected, and text. Also passed as replyTo."
+          },
+          {
+            "path": "supportPhone",
+            "type": "string",
+            "description": "The MSP's support phone number, shown in the Need Assistance box.",
+            "example": "+1 (555) 010-1234",
+            "availability": "used",
+            "notes": "Assembled from tenant_settings.settings.supportPhone, falling back to the default client's location phone. Defaults to 'Not provided' when neither is set. Used in contact-info Phone and text."
+          },
+          {
             "path": "clientLocationEmail",
             "type": "string",
-            "description": "The client location's contact email, shown in the Need Assistance box and footer (also the email Reply-To).",
-            "example": "support@acme.com",
-            "availability": "used",
-            "notes": "Defaults to 'Not provided' when the caller omits it. Used in contact-info Email, footerUnexpected, and text. Also passed as replyTo."
+            "description": "Legacy alias of supportEmail, kept for template rows that predate the rename.",
+            "example": "support@northwind.example",
+            "availability": "available-unused",
+            "notes": "Still supplied with the same value as supportEmail so un-migrated template rows keep rendering, but no current template references it."
           },
           {
             "path": "clientLocationPhone",
             "type": "string",
-            "description": "The client location's contact phone number, shown in the Need Assistance box.",
+            "description": "Legacy alias of supportPhone, kept for template rows that predate the rename.",
             "example": "+1 (555) 010-1234",
-            "availability": "used",
-            "notes": "Defaults to 'Not provided' when the caller omits it. Used in contact-info Phone and text."
+            "availability": "available-unused",
+            "notes": "Still supplied with the same value as supportPhone so un-migrated template rows keep rendering, but no current template references it."
           },
           {
             "path": "currentYear",
@@ -4261,7 +4285,7 @@ export const sharedBlockSeed: SharedVariableBlockSeed[] = [
         "description": "Name shown as the sending organization in the footer / header.",
         "example": "Wolf River IT",
         "availability": "used",
-        "notes": "VARIANTS for the same slot: tenantClientName (auth email-verification, from tenants.client_name), clientName (auth password-reset footer, from the passed org), tenant_name (surveys, tenant.client_name||tenant.name, default 'Your Team'), company.name (invoices/billing MSP sender). These are NOT interchangeable across categories - see client block for the client-vs-MSP-company collision."
+        "notes": "VARIANTS for the same slot: tenantClientName (auth email-verification, from tenants.client_name), clientName (auth password-reset footer, from the passed org), tenantName (auth portal-invitation subject + footer, from the tenant's default client), tenant_name (surveys, tenant.client_name||tenant.name, default 'Your Team'), company.name (invoices/billing MSP sender). These are NOT interchangeable across categories - see client block for the client-vs-MSP-company collision."
       },
       {
         "path": "platformName",
@@ -4287,7 +4311,7 @@ export const sharedBlockSeed: SharedVariableBlockSeed[] = [
         "description": "Support email address the recipient can reach out to (often also set as Reply-To).",
         "example": "support@acme-it.com",
         "availability": "used",
-        "notes": "VARIANTS: supportEmail (auth password-reset, also replyTo), clientLocationEmail (auth portal-invitation, defaults 'Not provided', also replyTo). Assembled-but-unused in new-appointment-request (staff template)."
+        "notes": "VARIANT: supportEmail (auth password-reset and auth portal-invitation, defaults 'Not provided', also replyTo). Assembled-but-unused in new-appointment-request (staff template)."
       },
       {
         "path": "contactPhone",
@@ -4295,7 +4319,7 @@ export const sharedBlockSeed: SharedVariableBlockSeed[] = [
         "description": "Support phone number, shown only when provided.",
         "example": "+1 (555) 010-1234",
         "availability": "used",
-        "notes": "Optional; every appointment template guards it with {{#if contactPhone}}. VARIANT: clientLocationPhone (auth portal-invitation, defaults 'Not provided')."
+        "notes": "Optional; every appointment template guards it with {{#if contactPhone}}. VARIANT: supportPhone (auth portal-invitation, defaults 'Not provided')."
       }
     ]
   },

--- a/packages/portal-shared/src/actions/portalInvitationActions.ts
+++ b/packages/portal-shared/src/actions/portalInvitationActions.ts
@@ -603,13 +603,21 @@ export const sendPortalInvitation = withAuth(async (
         );
       }
 
-      if (!mspLocation.email) {
+      // Support contact shown in the invitation is the tenant's own support
+      // desk (Settings -> Client Portal -> Branding), falling back to the
+      // default client's location contact.
+      const tenantSettingsRow = await scopedDb.table('tenant_settings').first() as any;
+      const tenantSettings = tenantSettingsRow?.settings || {};
+      const supportEmail: string = tenantSettings.supportEmail || mspLocation.email;
+      const supportPhone: string = tenantSettings.supportPhone || mspLocation.phone || '';
+
+      if (!supportEmail) {
         throw new PortalInvitationError(
-          'Default client\'s location must have a contact email configured',
+          'A support email must be configured in Client Portal settings, or on the default client\'s location',
           'NO_LOCATION_EMAIL'
         );
       }
-      
+
       // Get the client's client info for the email template
       const clientClient = contact.client_id ? await scopedDb.table('clients')
         .where({ client_id: contact.client_id })
@@ -658,12 +666,13 @@ export const sendPortalInvitation = withAuth(async (
       await sendPortalInvitationEmail({
         email: contact.email,
         contactName: contact.full_name,
-        clientName: clientClient?.client_name || tenantDefaultClient.client_name,  // Client's client name or MSP name
+        clientName: clientClient?.client_name || tenantDefaultClient.client_name,  // Recipient's own client name
+        tenantName: tenantDefaultClient.client_name,  // MSP name (sender of the invitation)
         portalLink: portalSetupUrl,
         expirationTime: expirationTime,
         tenant: tenant,
-        clientLocationEmail: mspLocation.email,  // MSP's email for reply-to
-        clientLocationPhone: mspLocation.phone || 'Not provided',  // MSP's phone
+        supportEmail,  // MSP's support email for reply-to
+        supportPhone,  // MSP's support phone
         fromName: `${tenantDefaultClient.client_name} Portal`,  // MSP's name for the portal
         clientId: contact.client_id  // Pass client ID (stored in company_id field) for locale resolution
       });

--- a/server/migrations/20260729120000_portal_invitation_support_contact.cjs
+++ b/server/migrations/20260729120000_portal_invitation_support_contact.cjs
@@ -1,0 +1,18 @@
+/**
+ * Re-upsert the portal-invitation email template so the subject, footer and
+ * "Need Assistance?" box reference the MSP (tenantName / supportEmail /
+ * supportPhone) instead of the recipient's own client company and contact
+ * details. Picks up the latest content from the source-of-truth file.
+ */
+
+const { upsertEmailTemplate } = require('./utils/templates/_shared/upsertEmailTemplates.cjs');
+
+const { getTemplate: authPortalInvitation } = require('./utils/templates/email/auth/portalInvitation.cjs');
+
+exports.up = async function (knex) {
+  await upsertEmailTemplate(knex, authPortalInvitation());
+};
+
+exports.down = async function () {
+  // No-op: prior content is reproducible by running the consolidation migration.
+};

--- a/server/migrations/utils/templates/email/auth/portalInvitation.cjs
+++ b/server/migrations/utils/templates/email/auth/portalInvitation.cjs
@@ -193,7 +193,7 @@ const PORTAL_INVITATION_CSS = `
 /* ------------------------------------------------------------------ */
 const COPY = {
   en: {
-    subject: 'Portal Invitation - {{clientName}}',
+    subject: 'Portal Invitation - {{tenantName}}',
     title: 'Portal Access Invitation',
     headerTitle: 'Welcome to Your Customer Portal',
     headerSubtitle: "You're invited to access your account",
@@ -212,11 +212,11 @@ const COPY = {
     phoneLabel: 'Phone',
     contactHelp: 'Our support team is ready to help you get started.',
     footerSent: 'This email was sent to {{contactName}} as part of your portal access setup.',
-    footerUnexpected: "If you didn't expect this invitation, please contact us at {{clientLocationEmail}}.",
-    footerCopyright: '\u00a9 {{currentYear}} {{clientName}}. All rights reserved.',
+    footerUnexpected: "If you didn't expect this invitation, please contact us at {{supportEmail}}.",
+    footerCopyright: '\u00a9 {{currentYear}} {{tenantName}}. All rights reserved.',
   },
   fr: {
-    subject: 'Invitation au portail client - {{clientName}}',
+    subject: 'Invitation au portail client - {{tenantName}}',
     title: 'Invitation au portail',
     headerTitle: 'Bienvenue sur votre portail client',
     headerSubtitle: 'Vous \u00eates invit\u00e9 \u00e0 acc\u00e9der \u00e0 votre compte',
@@ -235,11 +235,11 @@ const COPY = {
     phoneLabel: 'T\u00e9l\u00e9phone',
     contactHelp: "Notre \u00e9quipe support est pr\u00eate \u00e0 vous aider \u00e0 d\u00e9marrer.",
     footerSent: 'Cet e-mail a \u00e9t\u00e9 envoy\u00e9 \u00e0 {{contactName}} dans le cadre de la configuration de votre acc\u00e8s au portail.',
-    footerUnexpected: "Si vous n\u2019attendiez pas cette invitation, veuillez nous contacter \u00e0 {{clientLocationEmail}}.",
-    footerCopyright: '\u00a9 {{currentYear}} {{clientName}}. Tous droits r\u00e9serv\u00e9s.',
+    footerUnexpected: "Si vous n\u2019attendiez pas cette invitation, veuillez nous contacter \u00e0 {{supportEmail}}.",
+    footerCopyright: '\u00a9 {{currentYear}} {{tenantName}}. Tous droits r\u00e9serv\u00e9s.',
   },
   es: {
-    subject: 'Invitaci\u00f3n al portal del cliente - {{clientName}}',
+    subject: 'Invitaci\u00f3n al portal del cliente - {{tenantName}}',
     title: 'Invitaci\u00f3n al portal',
     headerTitle: 'Bienvenido a tu portal de cliente',
     headerSubtitle: 'Has sido invitado a acceder a tu cuenta',
@@ -258,11 +258,11 @@ const COPY = {
     phoneLabel: 'Tel\u00e9fono',
     contactHelp: 'Nuestro equipo de soporte est\u00e1 listo para ayudarte a comenzar.',
     footerSent: 'Este correo fue enviado a {{contactName}} como parte de la configuraci\u00f3n de tu acceso al portal.',
-    footerUnexpected: 'Si no esperabas esta invitaci\u00f3n, cont\u00e1ctanos en {{clientLocationEmail}}.',
-    footerCopyright: '\u00a9 {{currentYear}} {{clientName}}. Todos los derechos reservados.',
+    footerUnexpected: 'Si no esperabas esta invitaci\u00f3n, cont\u00e1ctanos en {{supportEmail}}.',
+    footerCopyright: '\u00a9 {{currentYear}} {{tenantName}}. Todos los derechos reservados.',
   },
   de: {
-    subject: 'Kundenportal-Einladung - {{clientName}}',
+    subject: 'Kundenportal-Einladung - {{tenantName}}',
     title: 'Portal-Einladung',
     headerTitle: 'Willkommen in Ihrem Kundenportal',
     headerSubtitle: 'Sie sind eingeladen, auf Ihr Konto zuzugreifen',
@@ -281,11 +281,11 @@ const COPY = {
     phoneLabel: 'Telefon',
     contactHelp: 'Unser Support-Team steht bereit, um Ihnen den Einstieg zu erleichtern.',
     footerSent: 'Diese E-Mail wurde an {{contactName}} im Rahmen der Einrichtung Ihres Portal-Zugangs gesendet.',
-    footerUnexpected: 'Wenn Sie diese Einladung nicht erwartet haben, kontaktieren Sie uns bitte unter {{clientLocationEmail}}.',
-    footerCopyright: '\u00a9 {{currentYear}} {{clientName}}. Alle Rechte vorbehalten.',
+    footerUnexpected: 'Wenn Sie diese Einladung nicht erwartet haben, kontaktieren Sie uns bitte unter {{supportEmail}}.',
+    footerCopyright: '\u00a9 {{currentYear}} {{tenantName}}. Alle Rechte vorbehalten.',
   },
   nl: {
-    subject: 'Uitnodiging voor klantenportaal - {{clientName}}',
+    subject: 'Uitnodiging voor klantenportaal - {{tenantName}}',
     title: 'Portaaluitnodiging',
     headerTitle: 'Welkom bij uw klantenportaal',
     headerSubtitle: 'U bent uitgenodigd om toegang te krijgen tot uw account',
@@ -304,11 +304,11 @@ const COPY = {
     phoneLabel: 'Telefoon',
     contactHelp: 'Ons supportteam staat klaar om u op weg te helpen.',
     footerSent: 'Deze e-mail is verzonden naar {{contactName}} als onderdeel van uw portaaltoegang.',
-    footerUnexpected: 'Als u deze uitnodiging niet verwachtte, neem dan contact met ons op via {{clientLocationEmail}}.',
-    footerCopyright: '\u00a9 {{currentYear}} {{clientName}}. Alle rechten voorbehouden.',
+    footerUnexpected: 'Als u deze uitnodiging niet verwachtte, neem dan contact met ons op via {{supportEmail}}.',
+    footerCopyright: '\u00a9 {{currentYear}} {{tenantName}}. Alle rechten voorbehouden.',
   },
   it: {
-    subject: 'Invito al portale clienti - {{clientName}}',
+    subject: 'Invito al portale clienti - {{tenantName}}',
     title: 'Invito al portale',
     headerTitle: 'Benvenuto nel tuo portale clienti',
     headerSubtitle: 'Sei stato invitato ad accedere al tuo account',
@@ -327,11 +327,11 @@ const COPY = {
     phoneLabel: 'Telefono',
     contactHelp: 'Il nostro team di supporto \u00e8 pronto ad aiutarti a iniziare.',
     footerSent: "Questa e-mail \u00e8 stata inviata a {{contactName}} nell'ambito della configurazione dell'accesso al portale.",
-    footerUnexpected: 'Se non ti aspettavi questo invito, contattaci all\'indirizzo {{clientLocationEmail}}.',
-    footerCopyright: '\u00a9 {{currentYear}} {{clientName}}. Tutti i diritti riservati.',
+    footerUnexpected: 'Se non ti aspettavi questo invito, contattaci all\'indirizzo {{supportEmail}}.',
+    footerCopyright: '\u00a9 {{currentYear}} {{tenantName}}. Tutti i diritti riservati.',
   },
   pl: {
-    subject: 'Zaproszenie do portalu klienta{{#if clientName}} - {{clientName}}{{/if}}',
+    subject: 'Zaproszenie do portalu klienta{{#if tenantName}} - {{tenantName}}{{/if}}',
     title: 'Zaproszenie do portalu',
     headerTitle: 'Witamy w portalu klienta',
     headerSubtitle: 'Tw\u00f3j dost\u0119p do zarz\u0105dzania us\u0142ugami jest gotowy',
@@ -350,12 +350,12 @@ const COPY = {
     phoneLabel: 'Telefon',
     contactHelp: 'Nasz zesp\u00f3\u0142 wsparcia jest gotowy, aby pom\u00f3c Ci rozpocz\u0105\u0107.',
     footerSent: 'Ta wiadomo\u015b\u0107 zosta\u0142a wys\u0142ana do {{contactName}} w ramach konfiguracji dost\u0119pu do portalu.',
-    footerUnexpected: 'Je\u015bli nie spodziewale\u015b(a\u015b) si\u0119 tego zaproszenia, skontaktuj si\u0119 z nami pod adresem {{clientLocationEmail}}.',
-    footerCopyright: '\u00a9 {{currentYear}} {{clientName}}. Wszelkie prawa zastrze\u017cone.',
+    footerUnexpected: 'Je\u015bli nie spodziewale\u015b(a\u015b) si\u0119 tego zaproszenia, skontaktuj si\u0119 z nami pod adresem {{supportEmail}}.',
+    footerCopyright: '\u00a9 {{currentYear}} {{tenantName}}. Wszelkie prawa zastrze\u017cone.',
   },
 };
 COPY.pt = {
-  subject: 'Convite para o portal - {{clientName}}',
+  subject: 'Convite para o portal - {{tenantName}}',
   title: 'Convite de acesso ao portal',
   headerTitle: 'Boas-vindas ao seu portal do cliente',
   headerSubtitle: 'Você foi convidado(a) a acessar sua conta',
@@ -374,8 +374,8 @@ COPY.pt = {
   phoneLabel: 'Telefone',
   contactHelp: 'Nossa equipe de suporte está pronta para ajudar você a começar.',
   footerSent: 'Este email foi enviado para {{contactName}} como parte da configuração do seu acesso ao portal.',
-  footerUnexpected: 'Se você não esperava este convite, entre em contato conosco em {{clientLocationEmail}}.',
-  footerCopyright: '© {{currentYear}} {{clientName}}. Todos os direitos reservados.',
+  footerUnexpected: 'Se você não esperava este convite, entre em contato conosco em {{supportEmail}}.',
+  footerCopyright: '© {{currentYear}} {{tenantName}}. Todos os direitos reservados.',
 };
 
 /* eslint-enable max-len */
@@ -433,8 +433,8 @@ ${c.tagline ? `
 
     <div class="contact-info">
       <h4>${c.contactTitle}</h4>
-      <p><strong>Email:</strong> {{clientLocationEmail}}</p>
-      <p><strong>${c.phoneLabel}:</strong> {{clientLocationPhone}}</p>
+      <p><strong>Email:</strong> {{supportEmail}}</p>
+      <p><strong>${c.phoneLabel}:</strong> {{supportPhone}}</p>
       <p style="margin-top: 12px; font-size: 13px; color: #64748b;">${c.contactHelp}</p>
     </div>
   </div>
@@ -465,8 +465,8 @@ ${c.warningTitle}
 ${c.warningText.replace(/<[^>]+>/g, '')}
 
 ${c.contactTitle}
-Email: {{clientLocationEmail}}
-${c.phoneLabel}: {{clientLocationPhone}}
+Email: {{supportEmail}}
+${c.phoneLabel}: {{supportPhone}}
 ${c.contactHelp}
 
 ---

--- a/server/src/test/unit/notifications/templateSampleData.test.ts
+++ b/server/src/test/unit/notifications/templateSampleData.test.ts
@@ -28,11 +28,14 @@ const TEMPLATE_SAMPLE_DATA: Record<string, Record<string, string>> = {
     expirationTime: '48 hours',
   },
   'portal-invitation': {
-    invitedEmail: 'jane.smith@client.com',
-    inviterName: 'John Doe',
+    contactName: 'Jane Smith',
     clientName: 'Acme Corporation',
-    invitationLink: 'https://app.example.com/auth/accept-invite?token=sample-token',
+    tenantName: 'Northwind Managed Services',
+    portalLink: 'https://app.example.com/auth/accept-invite?token=sample-token',
     expirationTime: '7 days',
+    supportEmail: 'support@northwind.example',
+    supportPhone: '+1 (555) 010-1234',
+    currentYear: String(new Date().getFullYear()),
   },
   'credit-expiration': {
     'client.name': 'Acme Corporation',
@@ -120,9 +123,12 @@ describe('templateSampleData', () => {
 
     it('should return sample data for known template "portal-invitation"', () => {
       const data = getTemplateSampleData('portal-invitation');
-      expect(data.invitedEmail).toBeDefined();
-      expect(data.inviterName).toBeDefined();
+      expect(data.contactName).toBeDefined();
       expect(data.clientName).toBeDefined();
+      // The MSP identity and support contact are distinct from the recipient's client
+      expect(data.tenantName).toBeDefined();
+      expect(data.supportEmail).toBeDefined();
+      expect(data.supportPhone).toBeDefined();
     });
 
     it('should return sample data for known template "sla-breach"', () => {


### PR DESCRIPTION
## Summary
Portal invitation emails were pointing recipients back to their own client contact instead of the MSP's support desk. The "Need Assistance?" box and reply-to address now use the tenant's own support email/phone (configured under Client Portal → Branding), with a fallback to the default client's location contact, and the invitation copy now correctly distinguishes the recipient's client name from the sending MSP's name.

## Changes
- **Email send logic** (`sendPortalInvitationEmail.ts`): renamed `clientLocationEmail`/`clientLocationPhone` params to `supportEmail`/`supportPhone`, added a `tenantName` param for the MSP identity, and switched Reply-To to the support email. Legacy `clientLocationEmail`/`clientLocationPhone` template keys are still populated (aliased to the support contact) so un-migrated template rows keep rendering.
- **Invitation action** (`portalInvitationActions.ts`): resolves `supportEmail`/`supportPhone` from `tenant_settings.settings`, falling back to the default client's location contact; updated the missing-contact error message accordingly; passes `tenantName` (MSP name) alongside the recipient's `clientName`.
- **Email template** (`portalInvitation.cjs`): updated all eight language variants so the subject and footer copyright use `{{tenantName}}` instead of `{{clientName}}`, and the assistance box / "didn't expect this" footer use `{{supportEmail}}`/`{{supportPhone}}` instead of the client location fields. The intro still uses `{{clientName}}` for the recipient's own company.
- **Migration**: adds `20260729120000_portal_invitation_support_contact.cjs` to re-upsert the portal-invitation template from the updated source file.
- **Template variable registry** (`seed.ts`): registers `tenantName`, `supportEmail`, and `supportPhone` as used variables for portal-invitation; demotes `clientLocationEmail`/`clientLocationPhone` to available-unused legacy aliases; corrects the `clientName` description/notes; refreshes related shared block notes for the branding/contact variable variants.

## Testing
- Updated `templateSampleData.test.ts` sample data and assertions for `portal-invitation` to match the new variable shape (`contactName`, `tenantName`, `supportEmail`, `supportPhone`) and ran the notifications unit test suite.
