### PR TITLE
Allow appointments in portal to be disabled

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -46250,6 +46250,7 @@
         "@alga-psa/event-bus": "*",
         "@alga-psa/integrations": "*",
         "@alga-psa/inventory": "*",
+        "@alga-psa/notifications": "*",
         "@alga-psa/opportunities": "*",
         "@alga-psa/shared": "*",
         "@alga-psa/storage": "*",
@@ -46355,7 +46356,7 @@
     },
     "packages/core": {
       "name": "@alga-psa/core",
-      "version": "1.3.8",
+      "version": "1.3.9",
       "dependencies": {
         "dotenv": "^16.4.5",
         "node-vault": "^0.10.2",
@@ -49644,7 +49645,7 @@
       }
     },
     "server": {
-      "version": "1.3.8",
+      "version": "1.3.9",
       "license": "ISC",
       "dependencies": {
         "@alga-psa/authorization": "*",

--- a/packages/tickets/src/components/settings/BoardsSettings.copyStatuses.test.tsx
+++ b/packages/tickets/src/components/settings/BoardsSettings.copyStatuses.test.tsx
@@ -533,6 +533,7 @@ describe('BoardsSettings ticket status copy flow', () => {
     });
     await waitFor(() => {
       expect(getBoardTicketStatusesMock).toHaveBeenCalledWith('board-source');
+      expect(screen.getByDisplayValue('Support Open')).toBeInTheDocument();
     });
 
     fireEvent.click(screen.getByTestId('save-board-button'));


### PR DESCRIPTION
## Summary

- Deploy-mitigation follow-up to merged PR #3047, rebased onto current main.
- Synchronizes package-lock workspace metadata with the product manifests: `packages/core` and `server` are recorded at 1.3.9, and the server workspace records its existing `@alga-psa/notifications` dependency.
- Stabilizes the BoardsSettings timer-policy test by waiting for copied ticket statuses to render before clicking Save; the first CI run exposed the state-commit race under full-suite load.
- The underlying feature allows MSP admins to disable client-portal appointments through `tenant_settings.settings.clientPortal.appointmentsEnabled`. Missing values remain enabled for backward compatibility; disabling hides portal appointment UI, redirects direct appointment routes, and rejects appointment creation on the server.

The appointment implementation and its feature tests were merged in #3047. This follow-up contains lockfile metadata synchronization plus the CI-discovered ticket-test race fix.

## Validation

- Overall PASS using real-product evidence at branch head `f08837acf5`. The current rerun was partial for client-facing views.
- Current run: the real MSP UI toggle changed Appointments from enabled to disabled; the live DOM showed unchecked; PostgreSQL persisted `appointmentsEnabled=false`; appointment request count remained 0; and real client credentials authenticated through NextAuth.
- Supplemental same-head evidence proves the enabled dashboard and route, disabled navigation and dashboard, direct-route redirect, server-action rejection, and re-enable regression recovery.
- No simulator or mock was used.
- Lockfile validation: `npm install --package-lock-only --ignore-scripts --no-audit --no-fund` completed cleanly and a second run produced no diff.
- Ticket validation: focused BoardsSettings suite passed 5 consecutive seeded runs (12/12 each); the full seeded tickets suite passed 110 files and 489 tests.

## Smoke-test fidelity and limitations

A temporary socat transport bridged the viewer-host browser to the real server, and CSRF-backed NextAuth login was used when controlled inputs resisted automation.

Fresh client-portal compilation expanded `server/.next` to 2.3 GB and failed in `FlightClientEntryPlugin` with `RangeError: Invalid string length`, preventing fresh client screenshots. Supplemental files are clearly labeled. The failed generated cache was removed from the worktree and is regenerable.

Final state: appointments disabled, real Compose services running, and app signin returns HTTP 200. The client fixture password was reset using the product PBKDF2 format.

Evidence: `/tmp/alga-smoke-evidence/disable-portal-appointments-20260729-143252`
