### PR TITLE
Import products and services from QBO

### DIFF
--- a/docs/features/feature-flags.md
+++ b/docs/features/feature-flags.md
@@ -215,6 +215,22 @@ Controls discovery of the SCIM user-provisioning administration UI while the fea
 - When enabled: The SCIM user-provisioning tab is available to eligible enterprise-edition tenants; existing tier and permission checks still apply.
 - SCIM API routes, backend actions, authentication, schemas, migrations, and provisioning behavior remain active regardless of flag state.
 
+### 14. `qbo-item-import`
+Gates the QuickBooks Online Products & Services import (tenant-scoped for piloting).
+
+**Affected Areas:**
+- **MSP Portal:**
+  - "Products & Services" step in the QuickBooks Reconciliation Wizard (Settings › Integrations › QuickBooks)
+- **Server actions:** `previewQboItemImport` / `executeQboItemImport`
+
+**Behavior:**
+- When disabled: the wizard step is absent (the wizard renders its original three steps),
+  and the server actions throw a typed "not enabled" error rather than silently succeeding.
+- Ledger mappings written by a past import are never retroactively hidden — imported
+  mappings remain valid and the export adapter keeps using them.
+- Also gated by EE edition and billing/service RBAC (`billing_settings:read` for preview;
+  `billing_settings:update` + `service:create` for execute).
+
 ## Implementation Details
 
 ### User Identification

--- a/docs/plans/2026-07-27-qbo-item-import-plan.md
+++ b/docs/plans/2026-07-27-qbo-item-import-plan.md
@@ -1,0 +1,110 @@
+# QBO Products & Services Import — Implementation Plan
+
+**Branch:** `feature/qbo-import-products-services`
+**Status:** Approved design, ready for implementation
+**Scope:** Flag-gated bulk import of QuickBooks Online Items (services & products) into `service_catalog`, delivered as a new step in the existing QBO onboarding wizard, factored so CDC-based incremental sync can later feed the same resolve/apply pipeline.
+
+---
+
+## 1. Settled design decisions
+
+| Question | Decision |
+|---|---|
+| Item types | Import `Service`, `NonInventory`, **and** `Inventory` (metadata only — no quantity/asset semantics). `Category` items are **not** imported as catalog entries and no category tree is built; item names are flattened (use the leaf name; the fully qualified `Parent:Child` name is kept in mapping metadata). |
+| Update policy for matched items | **QBO wins on QBO-authoritative fields** (`service_name`, `default_rate`, `sku`, `description`, `cost`, `is_active`). Alga-authoritative fields (`billing_method`, `unit_of_measure`, `custom_service_type_id`, category assignment) are never touched by import or future CDC. Preview shows the exact per-row diff. |
+| Inactive items | Imported as `is_active=false`, flagged in preview. "Include inactive" toggle, default **on**. Nothing silently skipped. |
+| Unmapped tax codes | Imported with `tax_rate_id=null`, flagged in preview. |
+| Match precedence | Existing mapping ledger row → SKU (products, exact) → exact name → create new. |
+| UI placement | New **"Products & Services" step in `QboOnboardingWizard`**, flag-gated step visibility. No new settings slot. |
+| Realm scope | Import is realm-scoped; UI states the active realm (consistent with mapping manager copy). |
+| Gating | EE (`assertEnterpriseEdition` server-side + existing `NEXT_PUBLIC_EDITION` client gate, both already applied to the QBO area) + PostHog flag `qbo-item-import` on both UI and actions. |
+
+## 2. Architecture
+
+The one-time import is a bulk run of the same resolve/apply machinery CDC will later feed one change at a time:
+
+```
+QboOnboardingWizard
+  └─ new step: QboItemImportStep (flag-gated)
+       └─ previewQboItemImport / executeQboItemImport (server actions)
+            └─ qboItemImportService
+                 ├─ fetch: paged SELECT * FROM Item (STARTPOSITION/MAXRESULTS, 1000/page,
+                 │         active + inactive via explicit query), pattern from
+                 │         fetchQboInvoicesPaged (packages/billing/src/actions/qboOnboardingActions.ts:317)
+                 ├─ resolve: qboItemResolver — pure matching, no I/O side effects
+                 └─ apply: qboItemApplier — create/update service_catalog rows,
+                       write tenant_external_entity_mappings rows (provenance metadata),
+                       seed sync-cycle cursor on completion
+```
+
+### CDC-readiness commitments (built into Phase 1)
+
+1. **Ledger row for every imported or matched item**: `integration_type='quickbooks_online'`, `alga_entity_type='service'`, `external_entity_id=<QBO Item Id>`, `external_realm_id=<realm>`, `sync_status='synced'`, `last_synced_at=now`.
+2. **Provenance in mapping `metadata`**: `{ syncToken, lastUpdatedTime, incomeAccountId, expenseAccountId, qboType, fullyQualifiedName }`.
+3. **Cursor seeding**: on successful execute, write a successful sync-cycle row with `cursor_after = max(MetaData.LastUpdatedTime seen, import start)` for tenant+`quickbooks_online`+realm, so the first Item CDC cycle continues without gap or re-import (`CURSOR_OVERLAP_MS` guards the boundary — accountingSyncCycleService.ts:57,113-118).
+4. **Shared resolver/applier modules** — import feeds full catalog; CDC later feeds change sets. Adding CDC = add `'Item'` to `CDC_ENTITIES` + `AccountingExternalChangeEntity` union and route into the same applier. Out of scope now.
+5. **Per-field authority policy** encoded as a constant in the resolver module (single source of truth for import updates and future CDC).
+
+### Field mapping (QBO Item → `service_catalog`)
+
+| QBO | Alga | Notes |
+|---|---|---|
+| `Type='Service'` | `item_kind='service'` | |
+| `Type='NonInventory'`/`'Inventory'` | `item_kind='product'` | metadata only |
+| `Type='Category'` | skipped | reason shown in preview |
+| `Name` (leaf) | `service_name` | fully qualified name → mapping metadata |
+| `Sku` | `sku` | partial unique index (tenant, sku) WHERE item_kind='product' AND sku NOT NULL — conflicts surfaced in preview |
+| `UnitPrice` | `default_rate` | dollars → minor units; currency from `getPreferences()` HomeCurrency |
+| `PurchaseCost` | `cost` + `cost_currency` | same conversion |
+| `Description` | `description` | |
+| `Active` | `is_active` | |
+| `SalesTaxCodeRef` | `tax_rate_id` | via existing tax mappings; unresolved → null + flag |
+| `IncomeAccountRef`, `SyncToken`, `MetaData.LastUpdatedTime` | mapping metadata | |
+| — | `custom_service_type_id` (required), `billing_method`, `unit_of_measure` | collected as defaults in the wizard step: service-type picker (required), billing method (`fixed` default for products, choice for services), unit of measure. Alga-authoritative thereafter. |
+
+## 3. Work items
+
+### 3.1 QBO client & types (additive)
+- Extend `QboItem` (packages/integrations/src/lib/qbo/types.ts:163) with `Sku?, Description?, UnitPrice?, PurchaseCost?, Active?, Taxable?, SubItem?, ParentRef?, FullyQualifiedName?, SalesTaxCodeRef?, MetaData?` (it already has `SyncToken?, IncomeAccountRef?, ExpenseAccountRef?, AssetAccountRef?`).
+- New paged fetch (in the new service, following `fetchQboInvoicesPaged`): `SELECT * FROM Item [WHERE Active IN (true,false)] STARTPOSITION n MAXRESULTS 1000`. Do **not** touch `getQboItems` (qboActions.ts:710) or its `itemCache` — the mapping-dropdown path stays as-is, and the import must not read that cache.
+
+### 3.2 Resolver — `packages/billing/src/services/accountingSync/qboItemResolver.ts`
+Pure module: `(qboItems, existingServices, existingMappings, defaults) → ItemResolution[]` where each resolution is `{ qboItem, action: 'create'|'update'|'link'|'skip', matchedServiceId?, fieldChanges?, flags: ('inactive'|'unmapped_tax'|'sku_conflict'|'name_collision'|'category_skipped')[], reason? }`. Exports `QBO_AUTHORITATIVE_FIELDS` / `ALGA_AUTHORITATIVE_FIELDS` constants. Match precedence: ledger mapping → SKU → exact name → create. Name/SKU collisions with an already-mapped-to-different-item row → `skip` with conflict reason (operator resolves manually via mapping manager).
+
+### 3.3 Import service — `packages/billing/src/services/accountingSync/qboItemImportService.ts`
+- `preview(tenant, realm, defaults)`: paged fetch → resolve → summary + rows. No writes.
+- `execute(tenant, realm, defaults)`: re-fetch + re-resolve (don't trust a stale preview), then per-row apply inside a transaction-per-row (per Xero CSV precedent — one bad row doesn't abort the batch; per-row errors captured and reported). Apply = `createService`-equivalent insert or authoritative-field update, plus `SyncMappingLedger.insert`/`update` (no upsert helper exists — check `findByExternalId` first). On completion, seed the sync-cycle cursor row. Returns `{ created, updated, linked, skipped, errors[] }`.
+- Service creation must satisfy `createService` invariants (packages/billing/src/actions/serviceActions.ts:407): required `custom_service_type_id`, publish `SERVICE_CATALOG_CREATED` search events.
+
+### 3.4 Server actions — `packages/billing/src/actions/qboItemImportActions.ts`
+`previewQboItemImport`, `executeQboItemImport`. Guards in order: `assertEnterpriseEdition` → `featureFlags.isEnabled('qbo-item-import', {userId, tenantId})` (typed "feature not enabled" error, not silent success) → permissions (`billing_settings:update` + `service:create` for execute; `billing_settings:read` for preview). Realm passed explicitly.
+
+### 3.5 UI — new wizard step
+- `packages/billing/src/components/accounting/QboItemImportStep.tsx`: defaults form (service type picker, billing method, unit of measure, include-inactive toggle), preview table grouped by action with flags/reasons and per-field diffs for updates, execute button + result summary. Skippable step (import is optional). Playwright override hooks per existing mapping-module convention.
+- Wire into `QboOnboardingWizard.tsx` (packages/billing/src/components/accounting/QboOnboardingWizard.tsx:419) as a step between customer mapping and go-live cutoff; step visibility behind `useFeatureFlag('qbo-item-import')` (or `FeatureFlagWrapper` — note: the component is `FeatureFlagWrapper` in `packages/ui/src/components/feature-flags/FeatureFlagWrapper.tsx`, not `FeatureFlag`). Wizard step list/state (`getOnboardingWizardState`, qboOnboardingActions.ts:634) must tolerate the step being absent when the flag is off — completed wizards are unaffected.
+
+### 3.6 Flag
+- Register `qbo-item-import` in PostHog (tenant-scoped for piloting); document in `docs/features/feature-flags.md`.
+- Flag off ⇒ step invisible, actions return typed error. **Ledger rows written by a past import are never retroactively hidden** — imported mappings are valid mappings and the export adapter should keep using them.
+
+### 3.7 Tests
+- **Unit (resolver):** match matrix (mapping/SKU/name/create), collision → skip, authority-field partitioning, category skip, inactive & tax flags, leaf-name flattening.
+- **Unit (service):** paged fetch assembly, per-row transaction error isolation, ledger insert-vs-update, provenance metadata shape, cursor seeding value, Alga-authoritative fields untouched on update, currency minor-unit conversion.
+- **Contract:** `QboItemImportStep.contract.test.tsx` mirroring `QboCustomerMappingPanel.contract.test.tsx`; wizard renders/omits the step by flag.
+- **Actions:** flag-off typed error, permission denials, EE gate.
+- Emulator suite (`algasim`, commit 2169ea12ec) available for wire-level QBO Item query/pagination testing if convenient.
+
+## 4. Explicitly out of scope
+- CDC incremental sync for Items (Phase 2: add `'Item'` to `CDC_ENTITIES` at qboClientService.ts:543 + type union, route into the Phase 1 applier; make the entity list capability-driven then).
+- Inventory quantity/asset tracking; `service_categories` creation from QBO categories; schema migrations (none needed).
+- Any change to existing `getQboItems`, `QboLiveMappingManager`, settings slots, or the sync engine.
+
+## 5. Key references
+- `packages/integrations/src/lib/qbo/qboClientService.ts` — `query<T>` :598, `fetchChanges`/`CDC_ENTITIES` :542-543, `getPreferences` :658
+- `packages/billing/src/actions/qboOnboardingActions.ts` — paged-fetch pattern :317, wizard state :634
+- `packages/billing/src/components/accounting/QboOnboardingWizard.tsx` — wizard + entry :419/:488
+- `packages/billing/src/services/accountingSync/syncMappingLedger.ts` — ledger (no upsert)
+- `packages/billing/src/services/accountingSync/accountingSyncCycleService.ts` — cursor semantics :57, :113-118
+- `server/migrations/20260101090000_add_products_fields_to_service_catalog.cjs` (+ `20260107190000` cost_currency, `20260716120000` barcode)
+- `packages/billing/src/actions/serviceActions.ts` — `createService` :407
+- `packages/ui/src/components/feature-flags/FeatureFlagWrapper.tsx`, `server/src/lib/feature-flags/featureFlags.ts`, `packages/core/src/lib/featureFlagRuntime.ts:107`

--- a/packages/billing/src/actions/index.ts
+++ b/packages/billing/src/actions/index.ts
@@ -112,6 +112,12 @@ export {
   type HistMatch,
 } from './qboOnboardingActions';
 
+// QBO products & services import (EE only, flag-gated)
+export {
+  previewQboItemImport,
+  executeQboItemImport,
+} from './qboItemImportActions';
+
 // Accounting sync actions (EE only)
 export {
   getAccountingSyncSettingsAction,

--- a/packages/billing/src/actions/qboItemImportActions.test.ts
+++ b/packages/billing/src/actions/qboItemImportActions.test.ts
@@ -1,0 +1,150 @@
+/**
+ * Mock-based unit tests for qboItemImportActions.
+ *
+ * Covers the guard chain for both server actions:
+ *  - EE edition gate (assertEnterpriseEdition)
+ *  - PostHog flag gate (`qbo-item-import`) — typed "not enabled" error, never silent success
+ *  - RBAC permissions (billing_settings:read for preview; billing_settings:update + service:create for execute)
+ *  - Realm resolution (connected company required)
+ *  - Delegation to the import service on the happy path
+ */
+
+// EE edition must be set before any module reads it at import time.
+process.env.EDITION = 'ee';
+
+/* eslint-disable custom-rules/no-feature-to-feature-imports -- mocks the QuickBooks client the import actions bridge to */
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+// ─── Module mocks (hoisted) ─────────────────────────────────────────────────
+
+vi.mock('@alga-psa/auth', () => ({
+  withAuth: (fn: any) => (input?: any) =>
+    fn({ user_id: 'user-1' }, { tenant: 'tenant-test' }, input)
+}));
+
+vi.mock('@alga-psa/auth/rbac', () => ({
+  hasPermission: vi.fn(async () => true)
+}));
+
+vi.mock('@alga-psa/core/logger', () => ({
+  default: { info: vi.fn(), warn: vi.fn(), debug: vi.fn(), error: vi.fn() }
+}));
+
+vi.mock('@alga-psa/core/server', () => ({
+  featureFlags: { isEnabled: vi.fn(async () => true) }
+}));
+
+vi.mock('@alga-psa/integrations/lib/qbo/qboClientService', () => ({
+  getDefaultQboRealmId: vi.fn(async () => 'realm-1'),
+  QboClientService: { create: vi.fn() }
+}));
+
+const previewForTenant = vi.fn();
+const executeForTenant = vi.fn();
+
+vi.mock('../services/accountingSync/qboItemImportService', () => ({
+  previewQboItemImportForTenant: (...args: any[]) => previewForTenant(...args),
+  executeQboItemImportForTenant: (...args: any[]) => executeForTenant(...args)
+}));
+
+import { previewQboItemImport, executeQboItemImport } from './qboItemImportActions';
+import { hasPermission } from '@alga-psa/auth/rbac';
+import { featureFlags } from '@alga-psa/core/server';
+import { getDefaultQboRealmId } from '@alga-psa/integrations/lib/qbo/qboClientService';
+
+const OPTIONS = {
+  includeInactive: true,
+  defaults: {
+    serviceTypeId: 'st-1',
+    serviceBillingMethod: 'hourly',
+    productBillingMethod: 'fixed',
+    unitOfMeasure: 'ea'
+  }
+};
+
+describe('qboItemImportActions', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    process.env.EDITION = 'ee';
+    (hasPermission as any).mockResolvedValue(true);
+    (featureFlags.isEnabled as any).mockResolvedValue(true);
+    (getDefaultQboRealmId as any).mockResolvedValue('realm-1');
+  });
+
+  it('preview: returns the service preview on the happy path', async () => {
+    previewForTenant.mockResolvedValue({ realm: 'realm-1', summary: { create: 1, update: 0, link: 0, skip: 0 }, rows: [] });
+    const result = await previewQboItemImport(OPTIONS as any);
+    expect(result.realm).toBe('realm-1');
+    expect(previewForTenant).toHaveBeenCalledWith({ tenant: 'tenant-test', realm: 'realm-1', options: OPTIONS });
+  });
+
+  it('execute: returns the service result on the happy path', async () => {
+    executeForTenant.mockResolvedValue({ created: 1, updated: 0, linked: 0, skipped: 0, errors: [] });
+    const result = await executeQboItemImport(OPTIONS as any);
+    expect(result.created).toBe(1);
+    expect(executeForTenant).toHaveBeenCalledWith({
+      tenant: 'tenant-test', realm: 'realm-1', options: OPTIONS, userId: 'user-1'
+    });
+  });
+
+  it('throws the typed "not enabled" error when the flag is off (never silent success)', async () => {
+    (featureFlags.isEnabled as any).mockResolvedValue(false);
+    await expect(previewQboItemImport(OPTIONS as any)).rejects.toThrow(/not enabled/i);
+    await expect(executeQboItemImport(OPTIONS as any)).rejects.toThrow(/not enabled/i);
+    expect(previewForTenant).not.toHaveBeenCalled();
+    expect(executeForTenant).not.toHaveBeenCalled();
+  });
+
+  it('scopes the flag check to the user and tenant', async () => {
+    previewForTenant.mockResolvedValue({ realm: 'realm-1', summary: { create: 0, update: 0, link: 0, skip: 0 }, rows: [] });
+    await previewQboItemImport(OPTIONS as any);
+    expect(featureFlags.isEnabled).toHaveBeenCalledWith('qbo-item-import', { userId: 'user-1', tenantId: 'tenant-test' });
+  });
+
+  it('rejects non-EE editions before any other work', async () => {
+    process.env.EDITION = 'community';
+    await expect(previewQboItemImport(OPTIONS as any)).rejects.toThrow(/Enterprise Edition/i);
+    await expect(executeQboItemImport(OPTIONS as any)).rejects.toThrow(/Enterprise Edition/i);
+    expect(featureFlags.isEnabled).not.toHaveBeenCalled();
+    expect(previewForTenant).not.toHaveBeenCalled();
+  });
+
+  it('preview requires billing_settings:read and nothing more', async () => {
+    (hasPermission as any).mockImplementation(async (_u: any, resource: string, action: string) =>
+      !(resource === 'billing_settings' && action === 'read')
+    );
+    await expect(previewQboItemImport(OPTIONS as any)).rejects.toThrow('Forbidden');
+    expect(previewForTenant).not.toHaveBeenCalled();
+  });
+
+  it('execute requires both billing_settings:update and service:create', async () => {
+    // Deny service:create only.
+    (hasPermission as any).mockImplementation(async (_u: any, resource: string, action: string) =>
+      !(resource === 'service' && action === 'create')
+    );
+    await expect(executeQboItemImport(OPTIONS as any)).rejects.toThrow('Forbidden');
+    expect(executeForTenant).not.toHaveBeenCalled();
+
+    // Deny billing_settings:update only.
+    (hasPermission as any).mockImplementation(async (_u: any, resource: string, action: string) =>
+      !(resource === 'billing_settings' && action === 'update')
+    );
+    await expect(executeQboItemImport(OPTIONS as any)).rejects.toThrow('Forbidden');
+    expect(executeForTenant).not.toHaveBeenCalled();
+  });
+
+  it('fails cleanly when no QuickBooks company is connected', async () => {
+    (getDefaultQboRealmId as any).mockResolvedValue(null);
+    await expect(previewQboItemImport(OPTIONS as any)).rejects.toThrow(/No QuickBooks company is connected/i);
+    await expect(executeQboItemImport(OPTIONS as any)).rejects.toThrow(/No QuickBooks company is connected/i);
+    expect(previewForTenant).not.toHaveBeenCalled();
+    expect(executeForTenant).not.toHaveBeenCalled();
+  });
+
+  it('wraps service failures in a friendly message (and logs, not leaks)', async () => {
+    previewForTenant.mockRejectedValue(new Error('qbo api 429'));
+    await expect(previewQboItemImport(OPTIONS as any)).rejects.toThrow(/Failed to load QuickBooks/i);
+    executeForTenant.mockRejectedValue(new Error('db boom'));
+    await expect(executeQboItemImport(OPTIONS as any)).rejects.toThrow(/import failed/i);
+  });
+});

--- a/packages/billing/src/actions/qboItemImportActions.ts
+++ b/packages/billing/src/actions/qboItemImportActions.ts
@@ -1,5 +1,6 @@
 'use server';
 
+/* eslint-disable custom-rules/no-feature-to-feature-imports -- import actions resolve the connected QuickBooks realm */
 import { withAuth } from '@alga-psa/auth';
 import { hasPermission } from '@alga-psa/auth/rbac';
 import { featureFlags } from '@alga-psa/core/server';

--- a/packages/billing/src/actions/qboItemImportActions.ts
+++ b/packages/billing/src/actions/qboItemImportActions.ts
@@ -1,0 +1,101 @@
+'use server';
+
+import { withAuth } from '@alga-psa/auth';
+import { hasPermission } from '@alga-psa/auth/rbac';
+import { featureFlags } from '@alga-psa/core/server';
+import type { IUserWithRoles } from '@alga-psa/types';
+import { getDefaultQboRealmId } from '@alga-psa/integrations/lib/qbo/qboClientService';
+import logger from '@alga-psa/core/logger';
+
+import {
+  previewQboItemImportForTenant,
+  executeQboItemImportForTenant,
+  type QboItemImportOptions,
+  type QboItemImportPreview,
+  type QboItemImportResult
+} from '../services/accountingSync/qboItemImportService';
+
+const FEATURE_FLAG_KEY = 'qbo-item-import';
+
+// ─── EE + flag + permission guards ───────────────────────────────────────────
+
+function isEnterpriseEdition(): boolean {
+  return (
+    (process.env.EDITION ?? '').toLowerCase() === 'ee' ||
+    (process.env.NEXT_PUBLIC_EDITION ?? '').toLowerCase() === 'enterprise'
+  );
+}
+
+function assertEnterpriseEdition(): void {
+  if (!isEnterpriseEdition()) {
+    throw new Error('QuickBooks Online item import is only available in Enterprise Edition.');
+  }
+}
+
+async function assertFeatureEnabled(user: IUserWithRoles, tenant: string): Promise<void> {
+  const enabled = await featureFlags.isEnabled(FEATURE_FLAG_KEY, {
+    userId: user.user_id,
+    tenantId: tenant
+  });
+  if (!enabled) {
+    // Typed error, never silent success: a flagged-off tenant calling the
+    // action directly must hear "not enabled", not get an empty import.
+    throw new Error('The QuickBooks products & services import is not enabled for this account.');
+  }
+}
+
+async function requirePermission(user: IUserWithRoles, resource: string, action: string): Promise<void> {
+  const allowed = await hasPermission(user, resource, action);
+  if (!allowed) throw new Error('Forbidden');
+}
+
+async function requireDefaultRealm(tenantId: string): Promise<string> {
+  const realm = await getDefaultQboRealmId(tenantId);
+  if (!realm) throw new Error('No QuickBooks company is connected.');
+  return realm;
+}
+
+// ─── Actions ─────────────────────────────────────────────────────────────────
+
+export const previewQboItemImport = withAuth(async (
+  user,
+  { tenant },
+  options: QboItemImportOptions
+): Promise<QboItemImportPreview> => {
+  assertEnterpriseEdition();
+  await assertFeatureEnabled(user, tenant);
+  await requirePermission(user, 'billing_settings', 'read');
+
+  const realm = await requireDefaultRealm(tenant);
+
+  try {
+    return await previewQboItemImportForTenant({ tenant, realm, options });
+  } catch (error) {
+    logger.error('[qboItemImport] Preview failed', {
+      tenant, realm, error: error instanceof Error ? error.message : error
+    });
+    throw new Error('Failed to load QuickBooks products & services. Please check the QuickBooks connection and try again.');
+  }
+});
+
+export const executeQboItemImport = withAuth(async (
+  user,
+  { tenant },
+  options: QboItemImportOptions
+): Promise<QboItemImportResult> => {
+  assertEnterpriseEdition();
+  await assertFeatureEnabled(user, tenant);
+  await requirePermission(user, 'billing_settings', 'update');
+  await requirePermission(user, 'service', 'create');
+
+  const realm = await requireDefaultRealm(tenant);
+
+  try {
+    return await executeQboItemImportForTenant({ tenant, realm, options, userId: user.user_id });
+  } catch (error) {
+    logger.error('[qboItemImport] Execute failed', {
+      tenant, realm, error: error instanceof Error ? error.message : error
+    });
+    throw new Error('The QuickBooks products & services import failed. No further rows were processed.');
+  }
+});

--- a/packages/billing/src/components/accounting/QboItemImportStep.contract.test.tsx
+++ b/packages/billing/src/components/accounting/QboItemImportStep.contract.test.tsx
@@ -1,0 +1,226 @@
+/**
+ * @vitest-environment jsdom
+ */
+import React from 'react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { cleanup, render, screen, fireEvent, waitFor } from '@testing-library/react';
+import '@testing-library/jest-dom';
+
+// ──────────────────────────────────────────────────────────────────────────────
+// Hoisted mocks
+// ──────────────────────────────────────────────────────────────────────────────
+const previewQboItemImportMock = vi.hoisted(() => vi.fn());
+const executeQboItemImportMock = vi.hoisted(() => vi.fn());
+const getServiceTypesForSelectionMock = vi.hoisted(() => vi.fn());
+const useFeatureFlagMock = vi.hoisted(() => vi.fn(() => true));
+
+vi.mock('../../actions/qboItemImportActions', () => ({
+  previewQboItemImport: async (...args: unknown[]) => previewQboItemImportMock(...args),
+  executeQboItemImport: async (...args: unknown[]) => executeQboItemImportMock(...args),
+}));
+
+vi.mock('../../actions/serviceActions', () => ({
+  getServiceTypesForSelection: async (...args: unknown[]) => getServiceTypesForSelectionMock(...args),
+}));
+
+vi.mock('../../actions/qboOnboardingActions', () => ({
+  getCustomerMatchCandidates: async () => ({ rows: [] }),
+  linkClientToQboCustomer: async () => ({ linked: true }),
+  bulkLinkExactCustomerMatches: async () => ({ linked: 0 }),
+  createQboCustomerForClient: async () => ({ created: true }),
+  getHistoricalInvoiceMatches: async () => ({ confident: [], review: [] }),
+  bulkLinkHistoricalInvoices: async () => ({ linked: 0 }),
+  backfillPaymentsForLinkedInvoices: async () => ({ processed: 0 }),
+  getOnboardingWizardState: async () => ({ completedAt: null, lastRunAt: null, connected: true }),
+  completeOnboardingWizard: async () => ({ done: true }),
+}));
+
+vi.mock('@alga-psa/integrations/actions', () => ({
+  getQboCustomers: async () => [],
+}));
+
+vi.mock('@alga-psa/ui/hooks', async (importOriginal) => ({
+  ...(await importOriginal<Record<string, unknown>>()),
+  useFeatureFlag: (...args: unknown[]) => useFeatureFlagMock(...(args as [])),
+}));
+
+import { QboItemImportStep } from './QboItemImportStep';
+import { QboOnboardingWizard } from './QboOnboardingWizard';
+
+// ──────────────────────────────────────────────────────────────────────────────
+// Fixtures
+// ──────────────────────────────────────────────────────────────────────────────
+
+const serviceTypes = [
+  { id: 'type-1', name: 'Managed Services', is_standard: false },
+  { id: 'type-2', name: 'Hardware', is_standard: false },
+];
+
+const previewFixture = {
+  realm: 'realm-1',
+  currencyCode: 'USD',
+  totalQboItems: 3,
+  summary: { create: 1, update: 1, link: 0, skip: 1 },
+  rows: [
+    {
+      qboItemId: 'q1',
+      qboName: 'Consulting',
+      qboFullyQualifiedName: null,
+      qboType: 'Service',
+      action: 'create',
+      matchedServiceId: null,
+      fields: {
+        service_name: 'Consulting', item_kind: 'service', sku: null, description: null,
+        default_rate: 15000, cost: null, is_active: true, tax_rate_id: null,
+      },
+      fieldChanges: null,
+      flags: [],
+      reason: null,
+    },
+    {
+      qboItemId: 'q2',
+      qboName: 'Widget',
+      qboFullyQualifiedName: null,
+      qboType: 'NonInventory',
+      action: 'update',
+      matchedServiceId: 's-1',
+      fields: {
+        service_name: 'Widget', item_kind: 'product', sku: 'W-1', description: null,
+        default_rate: 1999, cost: 750, is_active: false, tax_rate_id: null,
+      },
+      fieldChanges: [{ field: 'default_rate', from: 1500, to: 1999 }],
+      flags: ['inactive'],
+      reason: null,
+    },
+    {
+      qboItemId: 'q3',
+      qboName: 'Design',
+      qboFullyQualifiedName: null,
+      qboType: 'Category',
+      action: 'skip',
+      matchedServiceId: null,
+      fields: null,
+      fieldChanges: null,
+      flags: ['category_skipped'],
+      reason: 'QBO categories are not imported; item names are flattened to their leaf name.',
+    },
+  ],
+};
+
+// Radix Select needs these DOM APIs, which jsdom lacks.
+beforeEach(() => {
+  Object.defineProperty(Element.prototype, 'scrollIntoView', {
+    value: vi.fn(),
+    writable: true,
+  });
+  Object.defineProperty(HTMLElement.prototype, 'hasPointerCapture', {
+    value: vi.fn(() => false),
+    writable: true,
+  });
+});
+
+async function selectServiceType() {
+  fireEvent.click(document.querySelector('#qbo-item-import-service-type')!);
+  const option = await screen.findByText('Managed Services');
+  fireEvent.click(option);
+}
+
+describe('QboItemImportStep contracts', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    useFeatureFlagMock.mockReturnValue(true);
+    getServiceTypesForSelectionMock.mockResolvedValue(serviceTypes);
+    previewQboItemImportMock.mockResolvedValue(previewFixture);
+    executeQboItemImportMock.mockResolvedValue({
+      created: 1, updated: 1, linked: 0, skipped: 1, errors: [],
+    });
+  });
+
+  afterEach(() => {
+    cleanup();
+  });
+
+  it('preview is disabled until a service type is chosen', async () => {
+    render(<QboItemImportStep />);
+    const previewButton = await screen.findByRole('button', { name: /preview import/i });
+    expect(previewButton).toBeDisabled();
+
+    await selectServiceType();
+    await waitFor(() => expect(previewButton).not.toBeDisabled());
+  });
+
+  it('preview shows summary, grouped rows, flags, per-field diffs, and skip reasons — without writing', async () => {
+    render(<QboItemImportStep />);
+    await screen.findByRole('button', { name: /preview import/i });
+    await selectServiceType();
+    fireEvent.click(screen.getByRole('button', { name: /preview import/i }));
+
+    await screen.findByText(/1 to create/);
+    expect(previewQboItemImportMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        includeInactive: true,
+        defaults: expect.objectContaining({ serviceTypeId: 'type-1' }),
+      })
+    );
+    expect(executeQboItemImportMock).not.toHaveBeenCalled();
+
+    expect(screen.getByText('Consulting')).toBeInTheDocument();
+    expect(screen.getByText('Inactive in QuickBooks')).toBeInTheDocument();
+    expect(screen.getByText(/default_rate: 15\.00 → 19\.99/)).toBeInTheDocument();
+    expect(screen.getByText(/categories are not imported/i)).toBeInTheDocument();
+  });
+
+  it('execute runs only from an explicit click and reports the result summary', async () => {
+    render(<QboItemImportStep />);
+    await screen.findByRole('button', { name: /preview import/i });
+    await selectServiceType();
+    fireEvent.click(screen.getByRole('button', { name: /preview import/i }));
+    await screen.findByText(/1 to create/);
+
+    fireEvent.click(screen.getByRole('button', { name: /run import/i }));
+    await screen.findByText(/Import complete: 1 created, 1 updated, 0 linked, 1 skipped/);
+    expect(executeQboItemImportMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('surfaces per-row errors from execute', async () => {
+    executeQboItemImportMock.mockResolvedValue({
+      created: 0, updated: 0, linked: 0, skipped: 0,
+      errors: [{ qboItemId: 'q1', qboName: 'Consulting', message: 'boom' }],
+    });
+
+    render(<QboItemImportStep />);
+    await screen.findByRole('button', { name: /preview import/i });
+    await selectServiceType();
+    fireEvent.click(screen.getByRole('button', { name: /preview import/i }));
+    await screen.findByText(/1 to create/);
+    fireEvent.click(screen.getByRole('button', { name: /run import/i }));
+
+    await screen.findByText(/1 failed/);
+    expect(screen.getByText(/Consulting: boom/)).toBeInTheDocument();
+  });
+});
+
+describe('QboOnboardingWizard flag gating', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    getServiceTypesForSelectionMock.mockResolvedValue(serviceTypes);
+  });
+
+  afterEach(() => {
+    cleanup();
+  });
+
+  it('renders the Products & Services step when qbo-item-import is on', () => {
+    useFeatureFlagMock.mockReturnValue(true);
+    render(<QboOnboardingWizard />);
+    expect(useFeatureFlagMock).toHaveBeenCalledWith('qbo-item-import');
+    expect(screen.getByText('Products & Services')).toBeInTheDocument();
+  });
+
+  it('omits the step when the flag is off', () => {
+    useFeatureFlagMock.mockReturnValue(false);
+    render(<QboOnboardingWizard />);
+    expect(screen.queryByText('Products & Services')).not.toBeInTheDocument();
+    expect(screen.getByText('Go-live')).toBeInTheDocument();
+  });
+});

--- a/packages/billing/src/components/accounting/QboItemImportStep.tsx
+++ b/packages/billing/src/components/accounting/QboItemImportStep.tsx
@@ -1,0 +1,322 @@
+'use client';
+
+import React from 'react';
+import { Alert, AlertDescription } from '@alga-psa/ui/components/Alert';
+import { Badge } from '@alga-psa/ui/components/Badge';
+import { Button } from '@alga-psa/ui/components/Button';
+import CustomSelect from '@alga-psa/ui/components/CustomSelect';
+import { Input } from '@alga-psa/ui/components/Input';
+import { Label } from '@alga-psa/ui/components/Label';
+import { Switch } from '@alga-psa/ui/components/Switch';
+import {
+  previewQboItemImport,
+  executeQboItemImport,
+} from '../../actions/qboItemImportActions';
+import type {
+  QboItemImportPreview,
+  QboItemImportPreviewRow,
+  QboItemImportResult,
+} from '../../services/accountingSync/qboItemImportService';
+import { getServiceTypesForSelection } from '../../actions/serviceActions';
+
+/**
+ * Optional wizard step: bulk import of QBO Products & Services into the
+ * service catalog. Preview shows the exact per-row plan (incl. flags and
+ * per-field diffs) before anything is written. Skippable — the wizard's
+ * Next button is always available.
+ */
+
+const BILLING_METHOD_OPTIONS = [
+  { value: 'fixed', label: 'Fixed' },
+  { value: 'hourly', label: 'Hourly' },
+  { value: 'usage', label: 'Usage' },
+] as const;
+
+type BillingMethod = 'fixed' | 'hourly' | 'usage';
+
+const FLAG_LABELS: Record<string, string> = {
+  inactive: 'Inactive in QuickBooks',
+  unmapped_tax: 'Tax code not mapped',
+  sku_conflict: 'SKU conflict',
+  name_collision: 'Name already mapped',
+  category_skipped: 'Category (not imported)',
+};
+
+const ACTION_LABELS: Record<QboItemImportPreviewRow['action'], string> = {
+  create: 'Will create',
+  update: 'Will update',
+  link: 'Will link',
+  skip: 'Skipped',
+};
+
+function centsToDisplay(value: unknown): string {
+  if (typeof value !== 'number') return String(value ?? '—');
+  return (value / 100).toFixed(2);
+}
+
+function formatChangeValue(field: string, value: unknown): string {
+  if (value === null || value === undefined || value === '') return '—';
+  if (field === 'default_rate' || field === 'cost') return centsToDisplay(value);
+  return String(value);
+}
+
+function RowFlags({ flags }: { flags: QboItemImportPreviewRow['flags'] }) {
+  if (flags.length === 0) return null;
+  return (
+    <span className="inline-flex flex-wrap gap-1">
+      {flags.map((flag) => (
+        <Badge key={flag} variant="secondary" className="text-xs">
+          {FLAG_LABELS[flag] ?? flag}
+        </Badge>
+      ))}
+    </span>
+  );
+}
+
+function PreviewGroup({ title, rows }: { title: string; rows: QboItemImportPreviewRow[] }) {
+  if (rows.length === 0) return null;
+  return (
+    <div className="space-y-2">
+      <p className="text-sm font-medium text-foreground">
+        {title} <span className="text-muted-foreground">({rows.length})</span>
+      </p>
+      <div className="rounded-md border divide-y">
+        {rows.map((row) => (
+          <div key={row.qboItemId} className="p-2 text-sm space-y-1">
+            <div className="flex flex-wrap items-center gap-2">
+              <span className="font-medium">{row.qboName}</span>
+              <span className="text-xs text-muted-foreground">{row.qboType}</span>
+              <RowFlags flags={row.flags} />
+            </div>
+            {row.qboFullyQualifiedName && row.qboFullyQualifiedName !== row.qboName && (
+              <p className="text-xs text-muted-foreground">
+                QuickBooks name: {row.qboFullyQualifiedName} (imported as “{row.fields?.service_name ?? row.qboName}”)
+              </p>
+            )}
+            {row.reason && <p className="text-xs text-muted-foreground">{row.reason}</p>}
+            {row.action === 'update' && row.fieldChanges && row.fieldChanges.length > 0 && (
+              <ul className="text-xs text-muted-foreground list-disc pl-4">
+                {row.fieldChanges.map((change) => (
+                  <li key={change.field}>
+                    {change.field}: {formatChangeValue(change.field, change.from)} →{' '}
+                    {formatChangeValue(change.field, change.to)}
+                  </li>
+                ))}
+              </ul>
+            )}
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}
+
+export function QboItemImportStep() {
+  const [serviceTypes, setServiceTypes] = React.useState<Array<{ id: string; name: string }>>([]);
+  const [serviceTypeId, setServiceTypeId] = React.useState('');
+  const [serviceBillingMethod, setServiceBillingMethod] = React.useState<BillingMethod>('fixed');
+  const [productBillingMethod, setProductBillingMethod] = React.useState<BillingMethod>('fixed');
+  const [unitOfMeasure, setUnitOfMeasure] = React.useState('Unit');
+  const [includeInactive, setIncludeInactive] = React.useState(true);
+
+  const [previewing, setPreviewing] = React.useState(false);
+  const [preview, setPreview] = React.useState<QboItemImportPreview | null>(null);
+  const [previewError, setPreviewError] = React.useState<string | null>(null);
+
+  const [executing, setExecuting] = React.useState(false);
+  const [result, setResult] = React.useState<QboItemImportResult | null>(null);
+  const [executeError, setExecuteError] = React.useState<string | null>(null);
+
+  React.useEffect(() => {
+    let cancelled = false;
+    (async () => {
+      try {
+        const types = await getServiceTypesForSelection();
+        if (!cancelled && Array.isArray(types)) {
+          setServiceTypes(types);
+        }
+      } catch {
+        // Preview surfaces a clearer error when a type is required but missing.
+      }
+    })();
+    return () => { cancelled = true; };
+  }, []);
+
+  const options = () => ({
+    includeInactive,
+    defaults: {
+      serviceTypeId,
+      serviceBillingMethod,
+      productBillingMethod,
+      unitOfMeasure: unitOfMeasure.trim() || 'Unit',
+    },
+  });
+
+  const handlePreview = async () => {
+    setPreviewing(true);
+    setPreviewError(null);
+    setPreview(null);
+    setResult(null);
+    setExecuteError(null);
+    try {
+      setPreview(await previewQboItemImport(options()));
+    } catch (err) {
+      setPreviewError(err instanceof Error ? err.message : 'Failed to load the import preview.');
+    } finally {
+      setPreviewing(false);
+    }
+  };
+
+  const handleExecute = async () => {
+    setExecuting(true);
+    setExecuteError(null);
+    try {
+      setResult(await executeQboItemImport(options()));
+      setPreview(null);
+    } catch (err) {
+      setExecuteError(err instanceof Error ? err.message : 'The import failed.');
+    } finally {
+      setExecuting(false);
+    }
+  };
+
+  const rowsByAction = (action: QboItemImportPreviewRow['action']) =>
+    preview?.rows.filter((row) => row.action === action) ?? [];
+
+  return (
+    <div id="qbo-item-import-step" className="space-y-4">
+      <p className="text-sm text-muted-foreground">
+        Import your QuickBooks products and services into the Alga service catalog for the
+        connected QuickBooks company. QuickBooks stays the source of truth for names, rates,
+        SKUs, descriptions, and costs; billing method, unit of measure, and service type are
+        set here and owned by Alga afterwards. This step is optional — skip it with Next.
+      </p>
+
+      {/* Defaults for created items */}
+      <div className="rounded-lg border p-4 space-y-4 text-sm">
+        <p className="font-medium text-foreground">Defaults for imported items</p>
+
+        <div className="grid gap-4 sm:grid-cols-2">
+          <div className="space-y-1">
+            <Label htmlFor="qbo-item-import-service-type">Service type (required)</Label>
+            <CustomSelect
+              id="qbo-item-import-service-type"
+              value={serviceTypeId}
+              onValueChange={setServiceTypeId}
+              placeholder="Select a service type…"
+              options={serviceTypes.map((type) => ({ value: type.id, label: type.name }))}
+            />
+          </div>
+
+          <div className="space-y-1">
+            <Label htmlFor="qbo-item-import-uom">Unit of measure</Label>
+            <Input
+              id="qbo-item-import-uom"
+              value={unitOfMeasure}
+              onChange={(e) => setUnitOfMeasure(e.target.value)}
+            />
+          </div>
+
+          <div className="space-y-1">
+            <Label htmlFor="qbo-item-import-service-billing">Billing method for services</Label>
+            <CustomSelect
+              id="qbo-item-import-service-billing"
+              value={serviceBillingMethod}
+              onValueChange={(value) => setServiceBillingMethod(value as BillingMethod)}
+              options={[...BILLING_METHOD_OPTIONS]}
+            />
+          </div>
+
+          <div className="space-y-1">
+            <Label htmlFor="qbo-item-import-product-billing">Billing method for products</Label>
+            <CustomSelect
+              id="qbo-item-import-product-billing"
+              value={productBillingMethod}
+              onValueChange={(value) => setProductBillingMethod(value as BillingMethod)}
+              options={[...BILLING_METHOD_OPTIONS]}
+            />
+          </div>
+        </div>
+
+        <div className="flex items-center gap-2">
+          <Switch
+            id="qbo-item-import-include-inactive"
+            checked={includeInactive}
+            onCheckedChange={setIncludeInactive}
+          />
+          <Label htmlFor="qbo-item-import-include-inactive">
+            Include inactive QuickBooks items (imported as inactive)
+          </Label>
+        </div>
+
+        <Button
+          id="qbo-item-import-preview"
+          type="button"
+          disabled={previewing || !serviceTypeId}
+          onClick={handlePreview}
+        >
+          {previewing ? 'Loading preview…' : 'Preview import'}
+        </Button>
+        {!serviceTypeId && (
+          <p className="text-xs text-muted-foreground">Choose a service type to enable the preview.</p>
+        )}
+      </div>
+
+      {previewError && (
+        <Alert variant="destructive" id="qbo-item-import-preview-error">
+          <AlertDescription>{previewError}</AlertDescription>
+        </Alert>
+      )}
+
+      {preview && (
+        <div id="qbo-item-import-preview-panel" className="space-y-4">
+          <p className="text-sm">
+            Found <span className="font-medium">{preview.totalQboItems}</span> QuickBooks items for
+            the connected company (realm {preview.realm}): {preview.summary.create} to create,{' '}
+            {preview.summary.update} to update, {preview.summary.link} to link,{' '}
+            {preview.summary.skip} skipped. Nothing has been written yet.
+          </p>
+
+          <PreviewGroup title="Will create" rows={rowsByAction('create')} />
+          <PreviewGroup title="Will update" rows={rowsByAction('update')} />
+          <PreviewGroup title="Will link (already matching)" rows={rowsByAction('link')} />
+          <PreviewGroup title="Skipped" rows={rowsByAction('skip')} />
+
+          <Button
+            id="qbo-item-import-execute"
+            type="button"
+            disabled={executing || preview.summary.create + preview.summary.update + preview.summary.link === 0}
+            onClick={handleExecute}
+          >
+            {executing ? 'Importing…' : 'Run import'}
+          </Button>
+        </div>
+      )}
+
+      {executeError && (
+        <Alert variant="destructive" id="qbo-item-import-execute-error">
+          <AlertDescription>{executeError}</AlertDescription>
+        </Alert>
+      )}
+
+      {result && (
+        <Alert id="qbo-item-import-result">
+          <AlertDescription>
+            Import complete: {result.created} created, {result.updated} updated, {result.linked}{' '}
+            linked, {result.skipped} skipped
+            {result.errors.length > 0 ? `, ${result.errors.length} failed` : ''}.
+            {result.errors.length > 0 && (
+              <ul className="mt-2 list-disc pl-4 text-xs">
+                {result.errors.map((error) => (
+                  <li key={error.qboItemId}>
+                    {error.qboName}: {error.message}
+                  </li>
+                ))}
+              </ul>
+            )}
+          </AlertDescription>
+        </Alert>
+      )}
+    </div>
+  );
+}

--- a/packages/billing/src/components/accounting/QboOnboardingWizard.contract.test.tsx
+++ b/packages/billing/src/components/accounting/QboOnboardingWizard.contract.test.tsx
@@ -33,6 +33,14 @@ vi.mock('@alga-psa/integrations/actions', () => ({
   getQboCustomers: async (...args: unknown[]) => getQboCustomersMock(...args),
 }));
 
+// Flag off by default: these contracts describe the original three-step wizard.
+// The flag-gated Products & Services step has its own contract suite.
+const useFeatureFlagMock = vi.hoisted(() => vi.fn(() => false));
+vi.mock('@alga-psa/ui/hooks', async (importOriginal) => ({
+  ...(await importOriginal<Record<string, unknown>>()),
+  useFeatureFlag: (...args: unknown[]) => useFeatureFlagMock(...(args as [])),
+}));
+
 // ──────────────────────────────────────────────────────────────────────────────
 // Fixtures
 // ──────────────────────────────────────────────────────────────────────────────

--- a/packages/billing/src/components/accounting/QboOnboardingWizard.tsx
+++ b/packages/billing/src/components/accounting/QboOnboardingWizard.tsx
@@ -9,7 +9,9 @@ import { DatePicker } from '@alga-psa/ui/components/DatePicker';
 import { dateFromString, dateToString } from '@alga-psa/ui/lib/dateInput';
 import { Label } from '@alga-psa/ui/components/Label';
 import { Switch } from '@alga-psa/ui/components/Switch';
+import { useFeatureFlag } from '@alga-psa/ui/hooks';
 import { QboCustomerMappingPanel } from './QboCustomerMappingPanel';
+import { QboItemImportStep } from './QboItemImportStep';
 import { useTranslation } from '@alga-psa/ui/lib/i18n/client';
 import {
   getHistoricalInvoiceMatches,
@@ -22,10 +24,34 @@ import {
 
 // ─── Stepper ──────────────────────────────────────────────────────────────────
 
-const STEPS = ['Customers', 'History', 'Go-live'] as const;
-type Step = 0 | 1 | 2;
+// The Products & Services step is flag-gated ('qbo-item-import'); the step
+// list is computed per render so completed wizards are unaffected either way.
+type StepKey = 'customers' | 'history' | 'items' | 'golive';
 
-function StepIndicator({ step, current }: { step: number; current: Step }) {
+interface WizardStepDef {
+  key: StepKey;
+  label: string;
+}
+
+const BASE_STEPS: WizardStepDef[] = [
+  { key: 'customers', label: 'Customers' },
+  { key: 'history', label: 'History' },
+  { key: 'golive', label: 'Go-live' },
+];
+
+const ITEM_IMPORT_STEP: WizardStepDef = { key: 'items', label: 'Products & Services' };
+
+function useWizardSteps(): WizardStepDef[] {
+  const flag = useFeatureFlag('qbo-item-import');
+  const itemImportEnabled = typeof flag === 'boolean' ? flag : Boolean(flag?.enabled);
+  if (!itemImportEnabled) return BASE_STEPS;
+  // Between customer mapping / history and the go-live cutoff.
+  return [BASE_STEPS[0], BASE_STEPS[1], ITEM_IMPORT_STEP, BASE_STEPS[2]];
+}
+
+type Step = number;
+
+function StepIndicator({ step, current, label }: { step: number; current: Step; label: string }) {
   const isCompleted = step < current;
   const isCurrent = step === current;
   return (
@@ -46,7 +72,7 @@ function StepIndicator({ step, current }: { step: number; current: Step }) {
           isCurrent ? 'font-semibold text-foreground' : 'text-muted-foreground',
         ].join(' ')}
       >
-        {STEPS[step]}
+        {label}
       </span>
     </div>
   );
@@ -417,8 +443,14 @@ function WizardDone({ onRerun }: { onRerun: () => void }) {
 // ─── Main wizard ──────────────────────────────────────────────────────────────
 
 export function QboOnboardingWizard() {
+  const steps = useWizardSteps();
   const [step, setStep] = React.useState<Step>(0);
   const [done, setDone] = React.useState(false);
+
+  // If the flag flips mid-session and shrinks the list, stay in bounds.
+  const currentStep = Math.min(step, steps.length - 1);
+  const currentKey = steps[currentStep].key;
+  const lastStep = steps.length - 1;
 
   if (done) {
     return (
@@ -435,17 +467,17 @@ export function QboOnboardingWizard() {
       <CardHeader>
         <CardTitle>QuickBooks Reconciliation Wizard</CardTitle>
         <CardDescription>
-          Map customers, link historical invoices, and set your go-live cutoff in three steps.
+          Map customers, link historical invoices, and set your go-live cutoff.
         </CardDescription>
       </CardHeader>
 
       <CardContent className="space-y-6">
         {/* Stepper */}
         <div className="flex flex-wrap items-center gap-4 border-b pb-4">
-          {STEPS.map((_, i) => (
-            <React.Fragment key={i}>
-              <StepIndicator step={i} current={step} />
-              {i < STEPS.length - 1 && (
+          {steps.map((stepDef, i) => (
+            <React.Fragment key={stepDef.key}>
+              <StepIndicator step={i} current={currentStep} label={stepDef.label} />
+              {i < steps.length - 1 && (
                 <div className="hidden h-px flex-1 bg-border sm:block" />
               )}
             </React.Fragment>
@@ -453,9 +485,10 @@ export function QboOnboardingWizard() {
         </div>
 
         {/* Step content */}
-        {step === 0 && <StepCustomers />}
-        {step === 1 && <StepHistory />}
-        {step === 2 && <StepGoLive onDone={() => setDone(true)} />}
+        {currentKey === 'customers' && <StepCustomers />}
+        {currentKey === 'history' && <StepHistory />}
+        {currentKey === 'items' && <QboItemImportStep />}
+        {currentKey === 'golive' && <StepGoLive onDone={() => setDone(true)} />}
       </CardContent>
 
       <CardFooter className="flex items-center justify-between gap-3">
@@ -463,17 +496,17 @@ export function QboOnboardingWizard() {
           id="qbo-wizard-back"
           type="button"
           variant="outline"
-          disabled={step === 0}
-          onClick={() => setStep((s) => Math.max(0, s - 1) as Step)}
+          disabled={currentStep === 0}
+          onClick={() => setStep(Math.max(0, currentStep - 1))}
         >
           Back
         </Button>
 
-        {step < 2 ? (
+        {currentStep < lastStep ? (
           <Button
             id="qbo-wizard-next"
             type="button"
-            onClick={() => setStep((s) => Math.min(2, s + 1) as Step)}
+            onClick={() => setStep(Math.min(lastStep, currentStep + 1))}
           >
             Next
           </Button>

--- a/packages/billing/src/services/accountingSync/qboItemImportService.test.ts
+++ b/packages/billing/src/services/accountingSync/qboItemImportService.test.ts
@@ -1,0 +1,334 @@
+/**
+ * Mock-based unit tests for qboItemImportService.
+ *
+ * Covers the behaviors the resolver tests can't see:
+ *  - paged QBO fetch assembly (STARTPOSITION/MAXRESULTS, active filter)
+ *  - currency: minor-unit conversion already in the resolver; here the
+ *    home-currency lookup feeding cost_currency
+ *  - per-row transaction error isolation (one bad row reported, batch continues)
+ *  - ledger insert-vs-update with provenance metadata
+ *  - sync-cycle cursor seeding under the item-scoped adapter namespace
+ */
+
+/* eslint-disable custom-rules/no-feature-to-feature-imports -- tests bridge billing catalog and the QuickBooks integration client */
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+// ─── Module mocks (hoisted) ─────────────────────────────────────────────────
+
+vi.mock('@alga-psa/core/logger', () => ({
+  default: { info: vi.fn(), warn: vi.fn(), debug: vi.fn(), error: vi.fn() }
+}));
+
+// In-memory mapping/cursor state shared across mocks.
+const mappingStore: any[] = [];
+const cycleStore: any[] = [];
+
+const qboQuery = vi.fn();
+const qboGetPreferences = vi.fn();
+
+vi.mock('@alga-psa/integrations/lib/qbo/qboClientService', () => ({
+  QboClientService: {
+    create: vi.fn(async () => ({
+      query: qboQuery,
+      getPreferences: qboGetPreferences
+    }))
+  }
+}));
+
+vi.mock('@alga-psa/event-bus/publishers', () => ({
+  publishEvent: vi.fn(async () => undefined)
+}));
+
+const serviceCreate = vi.fn();
+const serviceUpdate = vi.fn();
+
+vi.mock('../../models/service', () => ({
+  default: {
+    create: (...args: any[]) => serviceCreate(...args),
+    update: (...args: any[]) => serviceUpdate(...args)
+  }
+}));
+
+vi.mock('./syncMappingLedger', () => ({
+  SyncMappingLedger: class {
+    constructor() {}
+    async findByExternalId(_type: string, externalId: string) {
+      return mappingStore.find((m) => m.external_entity_id === externalId);
+    }
+    async insert(params: any) {
+      const row = { id: `m-${mappingStore.length + 1}`, ...params };
+      mappingStore.push({
+        id: row.id,
+        alga_entity_id: params.algaEntityId,
+        external_entity_id: params.externalEntityId,
+        external_realm_id: params.targetRealm,
+        sync_status: params.syncStatus,
+        metadata: params.metadata
+      });
+      return row;
+    }
+  }
+}));
+
+vi.mock('./syncCycleRepository', () => ({
+  SyncCycleRepository: class {
+    constructor() {}
+    async startCycle(params: any) {
+      const id = `cycle-${cycleStore.length + 1}`;
+      cycleStore.push({ id, ...params });
+      return id;
+    }
+    async finishCycle(_tenant: string, cycleId: string, patch: any) {
+      const cycle = cycleStore.find((c) => c.id === cycleId);
+      if (cycle) Object.assign(cycle, patch);
+    }
+  }
+}));
+
+// Fake tenant knex: tenantDb(...).table(name) → chainable query. We only need
+// the tables the service reads for resolution; Service/ledger/cycle are mocked.
+const catalogRows: any[] = [];
+const itemMappingRows: any[] = [];
+const taxMappingRows: any[] = [];
+
+function makeKnex() {
+  const knex: any = (table: string) => knex.table(table);
+  knex.table = (table: string) => {
+    const query: any = {
+      _table: table,
+      _whereCriteria: undefined as any,
+      where: vi.fn((criteria: any) => { query._whereCriteria = criteria; return query; }),
+      andWhere: vi.fn(() => query),
+      whereIn: vi.fn(() => query),
+      select: vi.fn(async () => {
+        if (table === 'service_catalog') return catalogRows;
+        if (table === 'tenant_external_entity_mappings') {
+          // loadExistingItemMappings reads service mappings; buildTaxRateMap
+          // reads tax_code mappings. The shared fake keys off the where-clause.
+          const criteria = query._whereCriteria;
+          if (criteria?.alga_entity_type === 'tax_code') return taxMappingRows;
+          if (criteria?.alga_entity_type === 'service') return itemMappingRows;
+          return [...itemMappingRows, ...taxMappingRows];
+        }
+        if (table === 'tax_rates') return [];
+        return [];
+      }),
+      update: vi.fn(async (patch: any) => {
+        if (table === 'tenant_external_entity_mappings') {
+          const criteria = query._whereCriteria;
+          const target = mappingStore.find((m) => m.id === criteria?.id);
+          if (target) Object.assign(target, patch);
+        }
+        return 1;
+      }),
+      insert: vi.fn(async () => [1]),
+      returning: vi.fn(async () => [{}]),
+      first: vi.fn(async () => undefined)
+    };
+    return query;
+  };
+  knex.fn = { now: () => 'NOW()' };
+  knex.transaction = async (fn: any) => fn(knex);
+  return knex;
+}
+
+vi.mock('@alga-psa/db', () => ({
+  createTenantKnex: vi.fn(async () => ({ knex: makeKnex() })),
+  tenantDb: (knex: any) => knex,
+  withTransaction: (knex: any, fn: any) => knex.transaction(fn)
+}));
+
+import {
+  previewQboItemImportForTenant,
+  executeQboItemImportForTenant
+} from './qboItemImportService';
+import type { QboItem } from '@alga-psa/integrations/lib/qbo/types';
+
+function qboItem(overrides: Partial<QboItem> & { Id: string; Name: string }): QboItem {
+  return { Type: 'Service', ...overrides } as QboItem;
+}
+
+const DEFAULTS = {
+  includeInactive: true,
+  defaults: {
+    serviceTypeId: 'st-1',
+    serviceBillingMethod: 'hourly' as const,
+    productBillingMethod: 'fixed' as const,
+    unitOfMeasure: 'ea'
+  }
+};
+
+describe('qboItemImportService', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mappingStore.length = 0;
+    cycleStore.length = 0;
+    catalogRows.length = 0;
+    itemMappingRows.length = 0;
+    taxMappingRows.length = 0;
+    qboQuery.mockResolvedValue([]);
+    qboGetPreferences.mockResolvedValue({ CurrencyPrefs: { HomeCurrency: { value: 'EUR' } } });
+    serviceCreate.mockImplementation(async (_trx: any, data: any) => ({ ...data, service_id: `svc-${data.service_name}` }));
+    serviceUpdate.mockResolvedValue({});
+  });
+
+  it('preview: pages the QBO Item query until a short page and converts to minor units', async () => {
+    // First page full (1000) → forces a second request; second page short → stop.
+    const page1 = Array.from({ length: 1000 }, (_, i) => qboItem({ Id: `a-${i}`, Name: `A${i}`, UnitPrice: 1 }));
+    qboQuery.mockResolvedValueOnce(page1).mockResolvedValueOnce([qboItem({ Id: 'b-1', Name: 'B1', UnitPrice: 19.99 })]);
+
+    const preview = await previewQboItemImportForTenant({ tenant: 't1', realm: 'r1', options: DEFAULTS });
+
+    expect(qboQuery).toHaveBeenCalledTimes(2);
+    expect(qboQuery.mock.calls[0][0]).toMatch(/STARTPOSITION 1 MAXRESULTS 1000/);
+    expect(qboQuery.mock.calls[1][0]).toMatch(/STARTPOSITION 1001 MAXRESULTS 1000/);
+    // Include-inactive asks QBO for both states explicitly.
+    expect(qboQuery.mock.calls[0][0]).toMatch(/Active IN \(true, false\)/);
+    expect(preview.summary.create).toBe(1001);
+    const b1 = preview.rows.find((r) => r.qboItemId === 'b-1');
+    expect(b1?.fields?.default_rate).toBe(1999);
+  });
+
+  it('preview: reads home currency from QBO preferences', async () => {
+    qboQuery.mockResolvedValue([qboItem({ Id: 'c-1', Name: 'C1', UnitPrice: 5 })]);
+    const preview = await previewQboItemImportForTenant({ tenant: 't1', realm: 'r1', options: DEFAULTS });
+    expect(preview.currencyCode).toBe('EUR');
+  });
+
+  it('execute: creates rows, writes ledger with provenance metadata, and seeds the item-scoped cursor', async () => {
+    qboQuery.mockResolvedValue([
+      qboItem({
+        Id: 'q1', Name: 'Consulting', UnitPrice: 150, PurchaseCost: 50,
+        SyncToken: '3', FullyQualifiedName: 'Svc:Consulting',
+        IncomeAccountRef: { value: 'acc-9', name: 'Income' } as any,
+        MetaData: { CreateTime: '2026-01-01', LastUpdatedTime: '2026-06-01T10:00:00Z' } as any
+      })
+    ]);
+
+    const result = await executeQboItemImportForTenant({ tenant: 't1', realm: 'r1', options: DEFAULTS, userId: 'u1' });
+
+    expect(result.created).toBe(1);
+    expect(result.errors).toHaveLength(0);
+
+    // Created with converted minor units and cost currency.
+    expect(serviceCreate).toHaveBeenCalledWith(expect.anything(), expect.objectContaining({
+      service_name: 'Consulting',
+      default_rate: 15000,
+      cost: 5000,
+      cost_currency: 'EUR',
+      custom_service_type_id: 'st-1'
+    }));
+
+    // Ledger row carries provenance metadata.
+    expect(mappingStore).toHaveLength(1);
+    expect(mappingStore[0]).toMatchObject({
+      external_entity_id: 'q1',
+      sync_status: 'synced',
+      metadata: expect.objectContaining({
+        syncToken: '3',
+        lastUpdatedTime: '2026-06-01T10:00:00Z',
+        incomeAccountId: 'acc-9',
+        fullyQualifiedName: 'Svc:Consulting'
+      })
+    });
+
+    // Cursor seeded under the item-scoped adapter namespace (never the shared
+    // 'quickbooks_online' cursor), at max(LastUpdatedTime, import start).
+    expect(cycleStore).toHaveLength(1);
+    expect(cycleStore[0].adapterType).toBe('quickbooks_online_items');
+    expect(cycleStore[0].status).toBe('succeeded');
+    expect(cycleStore[0].cursorAfter >= '2026-06-01T10:00:00Z').toBe(true);
+  });
+
+  it('execute: one bad row is captured and does not abort the batch', async () => {
+    qboQuery.mockResolvedValue([
+      qboItem({ Id: 'ok-1', Name: 'Good', UnitPrice: 10 }),
+      qboItem({ Id: 'bad-1', Name: 'Bad', UnitPrice: 20 })
+    ]);
+    serviceCreate
+      .mockResolvedValueOnce({ service_id: 'svc-good' })
+      .mockRejectedValueOnce(new Error('unique sku violation'));
+
+    const result = await executeQboItemImportForTenant({ tenant: 't1', realm: 'r1', options: DEFAULTS });
+
+    expect(result.created).toBe(1);
+    expect(result.errors).toHaveLength(1);
+    expect(result.errors[0]).toMatchObject({ qboItemId: 'bad-1', message: 'unique sku violation' });
+    // Cursor still seeded despite the row error.
+    expect(cycleStore).toHaveLength(1);
+  });
+
+  it('execute: updates QBO-authoritative fields only on a mapped drift, leaving Alga fields untouched', async () => {
+    catalogRows.push({
+      service_id: 'svc-existing',
+      service_name: 'Old Name',
+      item_kind: 'service',
+      sku: null,
+      description: null,
+      default_rate: 10000,
+      cost: null,
+      is_active: true
+    });
+    const preExisting = {
+      id: 'm-1',
+      alga_entity_id: 'svc-existing',
+      external_entity_id: 'q1',
+      external_realm_id: 'r1',
+      sync_status: 'synced',
+      metadata: {}
+    };
+    mappingStore.push(preExisting);
+    itemMappingRows.push({ id: 'm-1', alga_entity_id: 'svc-existing', external_entity_id: 'q1' });
+
+    qboQuery.mockResolvedValue([
+      qboItem({ Id: 'q1', Name: 'New Name', UnitPrice: 175, SyncToken: '4' })
+    ]);
+
+    const result = await executeQboItemImportForTenant({ tenant: 't1', realm: 'r1', options: DEFAULTS });
+
+    expect(result.updated).toBe(1);
+    // Only QBO-authoritative fields patched; billing_method / unit_of_measure /
+    // service type / category never appear in the update.
+    const patch = serviceUpdate.mock.calls[0][2];
+    expect(patch).toMatchObject({ service_name: 'New Name', default_rate: 17500 });
+    expect(patch).not.toHaveProperty('billing_method');
+    expect(patch).not.toHaveProperty('unit_of_measure');
+    expect(patch).not.toHaveProperty('custom_service_type_id');
+    expect(patch).not.toHaveProperty('category_id');
+
+    // Existing ledger row is updated in place, not duplicated.
+    expect(mappingStore).toHaveLength(1);
+    expect(serviceCreate).not.toHaveBeenCalled();
+  });
+
+  it('execute: re-run links an unchanged mapped item without writing to the catalog', async () => {
+    catalogRows.push({
+      service_id: 'svc-same',
+      service_name: 'Same',
+      item_kind: 'service',
+      sku: null,
+      description: null,
+      default_rate: 5000,
+      cost: null,
+      is_active: true
+    });
+    mappingStore.push({
+      id: 'm-1',
+      alga_entity_id: 'svc-same',
+      external_entity_id: 'q1',
+      external_realm_id: 'r1',
+      sync_status: 'synced',
+      metadata: {}
+    });
+    itemMappingRows.push({ id: 'm-1', alga_entity_id: 'svc-same', external_entity_id: 'q1' });
+
+    qboQuery.mockResolvedValue([qboItem({ Id: 'q1', Name: 'Same', UnitPrice: 50 })]);
+
+    const result = await executeQboItemImportForTenant({ tenant: 't1', realm: 'r1', options: DEFAULTS });
+
+    expect(result.linked).toBe(1);
+    expect(serviceUpdate).not.toHaveBeenCalled();
+    expect(serviceCreate).not.toHaveBeenCalled();
+    expect(mappingStore).toHaveLength(1);
+  });
+});

--- a/packages/billing/src/services/accountingSync/qboItemImportService.ts
+++ b/packages/billing/src/services/accountingSync/qboItemImportService.ts
@@ -1,0 +1,394 @@
+import { Knex } from 'knex';
+import logger from '@alga-psa/core/logger';
+import { createTenantKnex, tenantDb, withTransaction } from '@alga-psa/db';
+import { publishEvent } from '@alga-psa/event-bus/publishers';
+import { QboClientService } from '@alga-psa/integrations/lib/qbo/qboClientService';
+import type { QboItem } from '@alga-psa/integrations/lib/qbo/types';
+import Service from '../../models/service';
+import { SyncMappingLedger } from './syncMappingLedger';
+import { SyncCycleRepository } from './syncCycleRepository';
+import {
+  resolveQboItems,
+  type ExistingItemMappingRow,
+  type ExistingServiceRow,
+  type ItemResolution,
+  type QboItemImportDefaults
+} from './qboItemResolver';
+
+/**
+ * One-time bulk import of QBO Items into service_catalog — a bulk run of the
+ * same resolve/apply machinery Item CDC will later feed one change at a time.
+ * Preview never writes; execute re-fetches and re-resolves (a stale preview
+ * is advisory, not a contract), applies row-by-row in per-row transactions,
+ * and seeds the sync-cycle cursor so a future Item CDC cycle continues
+ * without gap or re-import.
+ */
+
+const SYNC_ADAPTER_TYPE = 'quickbooks_online';
+const IMPORTED_ITEM_TYPES = "('Service', 'NonInventory', 'Inventory', 'Category')";
+
+export interface QboItemImportOptions {
+  includeInactive: boolean;
+  defaults: Omit<QboItemImportDefaults, 'currencyCode'>;
+}
+
+export interface QboItemImportPreviewRow {
+  qboItemId: string;
+  qboName: string;
+  qboFullyQualifiedName: string | null;
+  qboType: QboItem['Type'];
+  action: ItemResolution['action'];
+  matchedServiceId: string | null;
+  fields: ItemResolution['fields'] | null;
+  fieldChanges: ItemResolution['fieldChanges'] | null;
+  flags: ItemResolution['flags'];
+  reason: string | null;
+}
+
+export interface QboItemImportPreview {
+  realm: string;
+  currencyCode: string;
+  totalQboItems: number;
+  summary: { create: number; update: number; link: number; skip: number };
+  rows: QboItemImportPreviewRow[];
+}
+
+export interface QboItemImportResult {
+  created: number;
+  updated: number;
+  linked: number;
+  skipped: number;
+  errors: Array<{ qboItemId: string; qboName: string; message: string }>;
+}
+
+async function fetchQboItemsPaged(
+  qboClient: QboClientService,
+  includeInactive: boolean
+): Promise<QboItem[]> {
+  const PAGE_SIZE = 1000;
+  const results: QboItem[] = [];
+  let startPosition = 1;
+
+  // Without an explicit Active filter QBO only returns active items.
+  const activeFilter = includeInactive ? ' AND Active IN (true, false)' : '';
+
+  while (true) {
+    const query = `SELECT * FROM Item WHERE Type IN ${IMPORTED_ITEM_TYPES}${activeFilter} STARTPOSITION ${startPosition} MAXRESULTS ${PAGE_SIZE}`;
+    const page = await qboClient.query<QboItem>(query);
+    results.push(...page);
+    if (page.length < PAGE_SIZE) break;
+    startPosition += PAGE_SIZE;
+  }
+
+  return results;
+}
+
+async function getHomeCurrency(qboClient: QboClientService): Promise<string> {
+  try {
+    const prefs = await qboClient.getPreferences<any>();
+    return prefs?.CurrencyPrefs?.HomeCurrency?.value ?? 'USD';
+  } catch (error) {
+    logger.warn('[qboItemImport] Failed to read QBO preferences; defaulting currency to USD', {
+      error: error instanceof Error ? error.message : error
+    });
+    return 'USD';
+  }
+}
+
+/** QBO TaxCode id → Alga tax_rate_id, via the tax_code mapping ledger and active tax_rates. */
+async function buildTaxRateMap(knex: Knex, tenant: string, realm: string): Promise<Map<string, string>> {
+  const db = tenantDb(knex, tenant);
+
+  const taxMappings: Array<{ alga_entity_id: string; external_entity_id: string }> =
+    await db.table('tenant_external_entity_mappings')
+      .where({
+        integration_type: SYNC_ADAPTER_TYPE,
+        alga_entity_type: 'tax_code',
+        external_realm_id: realm
+      })
+      .select('alga_entity_id', 'external_entity_id');
+
+  if (taxMappings.length === 0) return new Map();
+
+  const regionCodes = Array.from(new Set(taxMappings.map((m) => m.alga_entity_id)));
+  const rates: Array<{ tax_rate_id: string; region_code: string }> = await db.table('tax_rates')
+    .whereIn('region_code', regionCodes)
+    .where({ is_active: true })
+    .select('tax_rate_id', 'region_code');
+
+  const rateByRegion = new Map(rates.map((r) => [r.region_code, r.tax_rate_id]));
+  const map = new Map<string, string>();
+  for (const mapping of taxMappings) {
+    const rateId = rateByRegion.get(mapping.alga_entity_id);
+    if (rateId) map.set(mapping.external_entity_id, rateId);
+  }
+  return map;
+}
+
+async function loadExistingCatalog(knex: Knex, tenant: string): Promise<ExistingServiceRow[]> {
+  return tenantDb(knex, tenant).table('service_catalog')
+    .select('service_id', 'service_name', 'item_kind', 'sku', 'description', 'default_rate', 'cost', 'is_active');
+}
+
+async function loadExistingItemMappings(
+  knex: Knex,
+  tenant: string,
+  realm: string
+): Promise<ExistingItemMappingRow[]> {
+  return tenantDb(knex, tenant).table('tenant_external_entity_mappings')
+    .where({
+      integration_type: SYNC_ADAPTER_TYPE,
+      alga_entity_type: 'service',
+      external_realm_id: realm
+    })
+    .select('id', 'alga_entity_id', 'external_entity_id');
+}
+
+async function resolveAll(params: {
+  knex: Knex;
+  tenant: string;
+  realm: string;
+  options: QboItemImportOptions;
+}): Promise<{ resolutions: ItemResolution[]; currencyCode: string; qboItems: QboItem[] }> {
+  const { knex, tenant, realm, options } = params;
+
+  const qboClient = await QboClientService.create(tenant, realm);
+  const [qboItems, currencyCode, existingServices, existingMappings, taxRateMap] = await Promise.all([
+    fetchQboItemsPaged(qboClient, options.includeInactive),
+    getHomeCurrency(qboClient),
+    loadExistingCatalog(knex, tenant),
+    loadExistingItemMappings(knex, tenant, realm),
+    buildTaxRateMap(knex, tenant, realm)
+  ]);
+
+  const resolutions = resolveQboItems(qboItems, existingServices, existingMappings, taxRateMap);
+  return { resolutions, currencyCode, qboItems };
+}
+
+export async function previewQboItemImportForTenant(params: {
+  tenant: string;
+  realm: string;
+  options: QboItemImportOptions;
+}): Promise<QboItemImportPreview> {
+  const { knex } = await createTenantKnex();
+  const { resolutions, currencyCode, qboItems } = await resolveAll({ knex, ...params });
+
+  const summary = { create: 0, update: 0, link: 0, skip: 0 };
+  const rows: QboItemImportPreviewRow[] = resolutions.map((resolution) => {
+    summary[resolution.action] += 1;
+    return {
+      qboItemId: resolution.qboItem.Id,
+      qboName: resolution.qboItem.Name,
+      qboFullyQualifiedName: resolution.qboItem.FullyQualifiedName ?? null,
+      qboType: resolution.qboItem.Type,
+      action: resolution.action,
+      matchedServiceId: resolution.matchedServiceId ?? null,
+      fields: resolution.fields ?? null,
+      fieldChanges: resolution.fieldChanges ?? null,
+      flags: resolution.flags,
+      reason: resolution.reason ?? null
+    };
+  });
+
+  return { realm: params.realm, currencyCode, totalQboItems: qboItems.length, summary, rows };
+}
+
+function mappingMetadataFor(item: QboItem): Record<string, unknown> {
+  return {
+    syncToken: item.SyncToken ?? null,
+    lastUpdatedTime: item.MetaData?.LastUpdatedTime ?? null,
+    incomeAccountId: item.IncomeAccountRef?.value ?? null,
+    expenseAccountId: item.ExpenseAccountRef?.value ?? null,
+    qboType: item.Type,
+    fullyQualifiedName: item.FullyQualifiedName ?? null,
+    importedAt: new Date().toISOString()
+  };
+}
+
+async function publishCatalogSearchEvent(
+  eventType: 'SERVICE_CATALOG_CREATED' | 'SERVICE_CATALOG_UPDATED',
+  tenant: string,
+  serviceId: string,
+  itemKind: 'service' | 'product',
+  userId: string | undefined,
+  changedFields: string[]
+): Promise<void> {
+  try {
+    await publishEvent({
+      eventType,
+      payload: {
+        tenantId: tenant,
+        serviceId,
+        userId,
+        itemKind,
+        changedFields,
+        timestamp: new Date().toISOString()
+      }
+    });
+  } catch (eventError) {
+    logger.warn(`[qboItemImport] Failed to publish ${eventType} search event`, {
+      tenant,
+      serviceId,
+      error: eventError instanceof Error ? eventError.message : eventError
+    });
+  }
+}
+
+async function applyResolution(params: {
+  knex: Knex;
+  tenant: string;
+  realm: string;
+  resolution: ItemResolution;
+  defaults: QboItemImportDefaults;
+  userId?: string;
+}): Promise<'created' | 'updated' | 'linked'> {
+  const { knex, tenant, realm, resolution, defaults, userId } = params;
+  const fields = resolution.fields!;
+
+  return withTransaction(knex, async (trx: Knex.Transaction) => {
+    const ledger = new SyncMappingLedger(trx, tenant, SYNC_ADAPTER_TYPE);
+    const metadata = mappingMetadataFor(resolution.qboItem);
+
+    const upsertLedger = async (serviceId: string) => {
+      // No upsert helper on the ledger — re-check inside the transaction so a
+      // re-run of the import updates rather than duplicates.
+      const existing = resolution.existingMappingId
+        ? { id: resolution.existingMappingId }
+        : await ledger.findByExternalId('service', resolution.qboItem.Id, realm);
+      if (existing) {
+        await trx('tenant_external_entity_mappings')
+          .where({ id: existing.id })
+          .update({
+            alga_entity_id: serviceId,
+            sync_status: 'synced',
+            last_synced_at: trx.fn.now(),
+            metadata,
+            updated_at: trx.fn.now()
+          });
+      } else {
+        await ledger.insert({
+          algaEntityType: 'service',
+          algaEntityId: serviceId,
+          externalEntityId: resolution.qboItem.Id,
+          targetRealm: realm,
+          syncStatus: 'synced',
+          metadata
+        });
+      }
+    };
+
+    if (resolution.action === 'create') {
+      const service = await Service.create(trx, {
+        tenant,
+        service_name: fields.service_name,
+        custom_service_type_id: defaults.serviceTypeId,
+        billing_method:
+          fields.item_kind === 'product' ? defaults.productBillingMethod : defaults.serviceBillingMethod,
+        default_rate: fields.default_rate,
+        unit_of_measure: defaults.unitOfMeasure,
+        category_id: null,
+        item_kind: fields.item_kind,
+        is_active: fields.is_active,
+        sku: fields.sku,
+        description: fields.description,
+        cost: fields.cost,
+        cost_currency: fields.cost !== null ? defaults.currencyCode : null,
+        tax_rate_id: fields.tax_rate_id
+      } as any);
+
+      await upsertLedger(service.service_id);
+      await publishCatalogSearchEvent('SERVICE_CATALOG_CREATED', tenant, service.service_id, fields.item_kind, userId, Object.keys(fields));
+      return 'created';
+    }
+
+    const serviceId = resolution.matchedServiceId!;
+
+    if (resolution.action === 'update') {
+      // QBO-authoritative fields only; billing_method / unit_of_measure /
+      // service type / category stay untouched.
+      const patch: Record<string, unknown> = {};
+      for (const change of resolution.fieldChanges ?? []) {
+        patch[change.field] = change.to;
+      }
+      if (fields.cost !== null) {
+        patch.cost_currency = defaults.currencyCode;
+      }
+      await Service.update(trx, serviceId, patch as any);
+      await upsertLedger(serviceId);
+      await publishCatalogSearchEvent('SERVICE_CATALOG_UPDATED', tenant, serviceId, fields.item_kind, userId, Object.keys(patch));
+      return 'updated';
+    }
+
+    await upsertLedger(serviceId);
+    return 'linked';
+  });
+}
+
+export async function executeQboItemImportForTenant(params: {
+  tenant: string;
+  realm: string;
+  options: QboItemImportOptions;
+  userId?: string;
+}): Promise<QboItemImportResult> {
+  const { tenant, realm, options, userId } = params;
+  const { knex } = await createTenantKnex();
+  const importStartedAt = new Date().toISOString();
+
+  const { resolutions, currencyCode } = await resolveAll({ knex, tenant, realm, options });
+  const defaults: QboItemImportDefaults = { ...options.defaults, currencyCode };
+
+  const result: QboItemImportResult = { created: 0, updated: 0, linked: 0, skipped: 0, errors: [] };
+
+  for (const resolution of resolutions) {
+    if (resolution.action === 'skip') {
+      result.skipped += 1;
+      continue;
+    }
+
+    // Transaction per row (Xero CSV precedent): one bad row is reported, not
+    // allowed to abort the batch.
+    try {
+      const outcome = await applyResolution({ knex, tenant, realm, resolution, defaults, userId });
+      if (outcome === 'created') result.created += 1;
+      else if (outcome === 'updated') result.updated += 1;
+      else result.linked += 1;
+    } catch (error) {
+      const message = error instanceof Error ? error.message : 'Failed to apply item';
+      result.errors.push({
+        qboItemId: resolution.qboItem.Id,
+        qboName: resolution.qboItem.Name,
+        message
+      });
+      logger.error('[qboItemImport] Failed to apply QBO item', {
+        tenant, realm, qboItemId: resolution.qboItem.Id, error: message
+      });
+    }
+  }
+
+  // Seed the CDC cursor: the first Item CDC cycle should pick up right after
+  // what this import saw (CURSOR_OVERLAP_MS absorbs the boundary).
+  try {
+    const lastUpdatedTimes = resolutions
+      .map((r) => r.qboItem.MetaData?.LastUpdatedTime)
+      .filter((t): t is string => Boolean(t));
+    const cursorAfter = [importStartedAt, ...lastUpdatedTimes]
+      .sort((a, b) => new Date(a).getTime() - new Date(b).getTime())
+      .pop()!;
+
+    const cycles = new SyncCycleRepository(knex);
+    const cycleId = await cycles.startCycle({
+      tenant,
+      adapterType: SYNC_ADAPTER_TYPE,
+      targetRealm: realm,
+      cursorBefore: null
+    });
+    await cycles.finishCycle(tenant, cycleId, { status: 'succeeded', cursorAfter });
+  } catch (error) {
+    logger.warn('[qboItemImport] Failed to seed sync-cycle cursor after import', {
+      tenant, realm, error: error instanceof Error ? error.message : error
+    });
+  }
+
+  logger.info('[qboItemImport] Import complete', { tenant, realm, ...result, errorCount: result.errors.length });
+  return result;
+}

--- a/packages/billing/src/services/accountingSync/qboItemImportService.ts
+++ b/packages/billing/src/services/accountingSync/qboItemImportService.ts
@@ -20,11 +20,16 @@ import {
  * same resolve/apply machinery Item CDC will later feed one change at a time.
  * Preview never writes; execute re-fetches and re-resolves (a stale preview
  * is advisory, not a contract), applies row-by-row in per-row transactions,
- * and seeds the sync-cycle cursor so a future Item CDC cycle continues
- * without gap or re-import.
+ * and seeds an item-scoped sync-cycle cursor so a future Item CDC cycle
+ * continues without gap or re-import.
  */
 
 const SYNC_ADAPTER_TYPE = 'quickbooks_online';
+// Item CDC gets its own cursor namespace: seeding under 'quickbooks_online'
+// would advance the shared accounting sync cursor and make runAccountingSyncCycle
+// skip unrelated QBO changes (invoices, payments) between its real cursor and
+// the import time.
+const ITEM_SYNC_ADAPTER_TYPE = 'quickbooks_online_items';
 const IMPORTED_ITEM_TYPES = "('Service', 'NonInventory', 'Inventory', 'Category')";
 
 export interface QboItemImportOptions {
@@ -378,7 +383,7 @@ export async function executeQboItemImportForTenant(params: {
     const cycles = new SyncCycleRepository(knex);
     const cycleId = await cycles.startCycle({
       tenant,
-      adapterType: SYNC_ADAPTER_TYPE,
+      adapterType: ITEM_SYNC_ADAPTER_TYPE,
       targetRealm: realm,
       cursorBefore: null
     });

--- a/packages/billing/src/services/accountingSync/qboItemImportService.ts
+++ b/packages/billing/src/services/accountingSync/qboItemImportService.ts
@@ -1,3 +1,4 @@
+/* eslint-disable custom-rules/no-feature-to-feature-imports -- QBO item import intentionally bridges billing catalog and the QuickBooks integration client */
 import { Knex } from 'knex';
 import logger from '@alga-psa/core/logger';
 import { createTenantKnex, tenantDb, withTransaction } from '@alga-psa/db';

--- a/packages/billing/src/services/accountingSync/qboItemResolver.test.ts
+++ b/packages/billing/src/services/accountingSync/qboItemResolver.test.ts
@@ -1,0 +1,206 @@
+import { describe, expect, it } from 'vitest';
+import type { QboItem } from '@alga-psa/integrations/lib/qbo/types';
+import {
+  resolveQboItems,
+  QBO_AUTHORITATIVE_FIELDS,
+  ALGA_AUTHORITATIVE_FIELDS,
+  type ExistingItemMappingRow,
+  type ExistingServiceRow
+} from './qboItemResolver';
+
+function qboItem(overrides: Partial<QboItem> & { Id: string; Name: string }): QboItem {
+  return { Type: 'Service', ...overrides } as QboItem;
+}
+
+function serviceRow(overrides: Partial<ExistingServiceRow> & { service_id: string; service_name: string }): ExistingServiceRow {
+  return {
+    item_kind: 'service',
+    sku: null,
+    description: null,
+    default_rate: 0,
+    cost: null,
+    is_active: true,
+    ...overrides
+  };
+}
+
+const noMappings: ExistingItemMappingRow[] = [];
+const noTax = new Map<string, string>();
+
+describe('qboItemResolver', () => {
+  it('creates new services and products with converted minor units', () => {
+    const items = [
+      qboItem({ Id: '1', Name: 'Consulting', UnitPrice: 150, Description: 'Hourly consulting' }),
+      qboItem({ Id: '2', Name: 'Widget', Type: 'NonInventory', Sku: 'W-1', UnitPrice: 19.99, PurchaseCost: 7.5 }),
+      qboItem({ Id: '3', Name: 'Gadget', Type: 'Inventory', Sku: 'G-1' })
+    ];
+
+    const [consulting, widget, gadget] = resolveQboItems(items, [], noMappings, noTax);
+
+    expect(consulting.action).toBe('create');
+    expect(consulting.fields).toMatchObject({
+      service_name: 'Consulting',
+      item_kind: 'service',
+      default_rate: 15000,
+      description: 'Hourly consulting',
+      cost: null
+    });
+
+    expect(widget.fields).toMatchObject({ item_kind: 'product', sku: 'W-1', default_rate: 1999, cost: 750 });
+    expect(gadget.fields).toMatchObject({ item_kind: 'product', default_rate: 0 });
+  });
+
+  it('skips Category items with a reason', () => {
+    const [resolution] = resolveQboItems(
+      [qboItem({ Id: '9', Name: 'Design', Type: 'Category' })],
+      [], noMappings, noTax
+    );
+    expect(resolution.action).toBe('skip');
+    expect(resolution.flags).toContain('category_skipped');
+    expect(resolution.reason).toBeTruthy();
+  });
+
+  it('uses the leaf Name, keeping FullyQualifiedName out of the catalog name', () => {
+    const [resolution] = resolveQboItems(
+      [qboItem({ Id: '4', Name: 'Child', FullyQualifiedName: 'Parent:Child', SubItem: true })],
+      [], noMappings, noTax
+    );
+    expect(resolution.fields?.service_name).toBe('Child');
+  });
+
+  it('prefers ledger mapping over SKU and name matches', () => {
+    const services = [
+      serviceRow({ service_id: 's-mapped', service_name: 'Old Name' }),
+      serviceRow({ service_id: 's-name', service_name: 'Consulting' })
+    ];
+    const mappings = [{ id: 'm1', alga_entity_id: 's-mapped', external_entity_id: 'q1' }];
+
+    const [resolution] = resolveQboItems(
+      [qboItem({ Id: 'q1', Name: 'Consulting' })],
+      services, mappings, noTax
+    );
+
+    expect(resolution.matchedServiceId).toBe('s-mapped');
+    expect(resolution.action).toBe('update');
+    expect(resolution.fieldChanges).toEqual([
+      { field: 'service_name', from: 'Old Name', to: 'Consulting' }
+    ]);
+  });
+
+  it('matches products by exact SKU before name', () => {
+    const services = [
+      serviceRow({ service_id: 's-sku', service_name: 'Different Name', item_kind: 'product', sku: 'ABC' }),
+      serviceRow({ service_id: 's-name', service_name: 'Widget', item_kind: 'product' })
+    ];
+
+    const [resolution] = resolveQboItems(
+      [qboItem({ Id: 'q1', Name: 'Widget', Type: 'NonInventory', Sku: 'abc' })],
+      services, noMappings, noTax
+    );
+
+    expect(resolution.matchedServiceId).toBe('s-sku');
+  });
+
+  it('links (no update) when all QBO-authoritative fields already agree', () => {
+    const services = [
+      serviceRow({ service_id: 's1', service_name: 'Consulting', default_rate: 15000, description: 'x', is_active: true })
+    ];
+    const [resolution] = resolveQboItems(
+      [qboItem({ Id: 'q1', Name: 'Consulting', UnitPrice: 150, Description: 'x' })],
+      services, noMappings, noTax
+    );
+    expect(resolution.action).toBe('link');
+    expect(resolution.matchedServiceId).toBe('s1');
+  });
+
+  it('skips on SKU conflict when the catalog row is mapped to a different QBO item', () => {
+    const services = [serviceRow({ service_id: 's1', service_name: 'Widget', item_kind: 'product', sku: 'ABC' })];
+    const mappings = [{ id: 'm1', alga_entity_id: 's1', external_entity_id: 'other-qbo-item' }];
+
+    const [resolution] = resolveQboItems(
+      [qboItem({ Id: 'q1', Name: 'Widget 2', Type: 'NonInventory', Sku: 'ABC' })],
+      services, mappings, noTax
+    );
+
+    expect(resolution.action).toBe('skip');
+    expect(resolution.flags).toContain('sku_conflict');
+  });
+
+  it('skips on name collision when the name-matched row is mapped to a different QBO item', () => {
+    const services = [serviceRow({ service_id: 's1', service_name: 'Consulting' })];
+    const mappings = [{ id: 'm1', alga_entity_id: 's1', external_entity_id: 'other-qbo-item' }];
+
+    const [resolution] = resolveQboItems(
+      [qboItem({ Id: 'q1', Name: 'Consulting' })],
+      services, mappings, noTax
+    );
+
+    expect(resolution.action).toBe('skip');
+    expect(resolution.flags).toContain('name_collision');
+  });
+
+  it('skips the second QBO item claiming the same SKU within one import', () => {
+    const items = [
+      qboItem({ Id: 'q1', Name: 'Widget A', Type: 'NonInventory', Sku: 'DUP' }),
+      qboItem({ Id: 'q2', Name: 'Widget B', Type: 'NonInventory', Sku: 'DUP' })
+    ];
+    const [first, second] = resolveQboItems(items, [], noMappings, noTax);
+    expect(first.action).toBe('create');
+    expect(second.action).toBe('skip');
+    expect(second.flags).toContain('sku_conflict');
+  });
+
+  it('flags inactive items and imports them as is_active=false', () => {
+    const [resolution] = resolveQboItems(
+      [qboItem({ Id: 'q1', Name: 'Retired', Active: false })],
+      [], noMappings, noTax
+    );
+    expect(resolution.action).toBe('create');
+    expect(resolution.fields?.is_active).toBe(false);
+    expect(resolution.flags).toContain('inactive');
+  });
+
+  it('resolves mapped tax codes and flags unmapped ones (NON is not a gap)', () => {
+    const taxMap = new Map([['tc-1', 'rate-1']]);
+    const items = [
+      qboItem({ Id: 'q1', Name: 'Taxed', SalesTaxCodeRef: { value: 'tc-1' } }),
+      qboItem({ Id: 'q2', Name: 'Unknown Tax', SalesTaxCodeRef: { value: 'tc-2' } }),
+      qboItem({ Id: 'q3', Name: 'Non Taxable', SalesTaxCodeRef: { value: 'NON' } })
+    ];
+
+    const [taxed, unknown, nonTaxable] = resolveQboItems(items, [], noMappings, taxMap);
+
+    expect(taxed.fields?.tax_rate_id).toBe('rate-1');
+    expect(taxed.flags).not.toContain('unmapped_tax');
+    expect(unknown.fields?.tax_rate_id).toBeNull();
+    expect(unknown.flags).toContain('unmapped_tax');
+    expect(nonTaxable.fields?.tax_rate_id).toBeNull();
+    expect(nonTaxable.flags).not.toContain('unmapped_tax');
+  });
+
+  it('recreates when a mapping points at a deleted catalog row', () => {
+    const mappings = [{ id: 'm1', alga_entity_id: 'gone', external_entity_id: 'q1' }];
+    const [resolution] = resolveQboItems(
+      [qboItem({ Id: 'q1', Name: 'Ghost' })],
+      [], mappings, noTax
+    );
+    expect(resolution.action).toBe('create');
+    expect(resolution.existingMappingId).toBe('m1');
+  });
+
+  it('only ever diffs QBO-authoritative fields', () => {
+    const services = [
+      serviceRow({ service_id: 's1', service_name: 'Consulting', default_rate: 1000, description: 'old', is_active: true })
+    ];
+    const [resolution] = resolveQboItems(
+      [qboItem({ Id: 'q1', Name: 'Consulting', UnitPrice: 20, Description: 'new' })],
+      services, noMappings, noTax
+    );
+
+    for (const change of resolution.fieldChanges ?? []) {
+      expect(QBO_AUTHORITATIVE_FIELDS).toContain(change.field);
+      expect(ALGA_AUTHORITATIVE_FIELDS).not.toContain(change.field as never);
+    }
+    expect(resolution.fieldChanges?.map((c) => c.field).sort()).toEqual(['default_rate', 'description']);
+  });
+});

--- a/packages/billing/src/services/accountingSync/qboItemResolver.test.ts
+++ b/packages/billing/src/services/accountingSync/qboItemResolver.test.ts
@@ -1,3 +1,4 @@
+/* eslint-disable custom-rules/no-feature-to-feature-imports -- tests resolve QBO Items (integrations) against the billing catalog */
 import { describe, expect, it } from 'vitest';
 import type { QboItem } from '@alga-psa/integrations/lib/qbo/types';
 import {

--- a/packages/billing/src/services/accountingSync/qboItemResolver.ts
+++ b/packages/billing/src/services/accountingSync/qboItemResolver.ts
@@ -1,3 +1,4 @@
+/* eslint-disable custom-rules/no-feature-to-feature-imports -- QBO item import resolves QBO Items (integrations) against the billing catalog */
 import type { QboItem } from '@alga-psa/integrations/lib/qbo/types';
 
 /**

--- a/packages/billing/src/services/accountingSync/qboItemResolver.ts
+++ b/packages/billing/src/services/accountingSync/qboItemResolver.ts
@@ -1,0 +1,299 @@
+import type { QboItem } from '@alga-psa/integrations/lib/qbo/types';
+
+/**
+ * Pure matching/diffing for the QBO Products & Services import. No I/O:
+ * the import service fetches QBO items, existing catalog rows, ledger
+ * mappings, and the tax-code map, then asks this module what to do with
+ * each item. The same resolutions later feed Item CDC one change at a time.
+ */
+
+/** Fields the import (and future Item CDC) is allowed to overwrite. */
+export const QBO_AUTHORITATIVE_FIELDS = [
+  'service_name',
+  'default_rate',
+  'sku',
+  'description',
+  'cost',
+  'is_active'
+] as const;
+
+/** Fields owned by Alga — never touched by import or CDC once set. */
+export const ALGA_AUTHORITATIVE_FIELDS = [
+  'billing_method',
+  'unit_of_measure',
+  'custom_service_type_id',
+  'category_id'
+] as const;
+
+export type QboAuthoritativeField = (typeof QBO_AUTHORITATIVE_FIELDS)[number];
+
+export interface QboItemImportDefaults {
+  /** Applied to every created row; existing rows keep theirs. */
+  serviceTypeId: string;
+  serviceBillingMethod: 'fixed' | 'hourly' | 'usage';
+  productBillingMethod: 'fixed' | 'hourly' | 'usage';
+  unitOfMeasure: string;
+  /** Tenant home currency (from QBO Preferences), for cost_currency. */
+  currencyCode: string;
+}
+
+/** The slice of a service_catalog row the resolver needs. */
+export interface ExistingServiceRow {
+  service_id: string;
+  service_name: string;
+  item_kind: 'service' | 'product' | null;
+  sku: string | null;
+  description: string | null;
+  default_rate: number | string | null;
+  cost: number | string | null;
+  is_active: boolean | null;
+}
+
+/** The slice of a ledger row the resolver needs. */
+export interface ExistingItemMappingRow {
+  id: string;
+  alga_entity_id: string;
+  external_entity_id: string;
+}
+
+export type ItemResolutionFlag =
+  | 'inactive'
+  | 'unmapped_tax'
+  | 'sku_conflict'
+  | 'name_collision'
+  | 'category_skipped';
+
+export interface ItemFieldChange {
+  field: QboAuthoritativeField;
+  from: unknown;
+  to: unknown;
+}
+
+export interface ResolvedItemFields {
+  service_name: string;
+  item_kind: 'service' | 'product';
+  sku: string | null;
+  description: string | null;
+  /** Minor units (cents). */
+  default_rate: number;
+  /** Minor units (cents), null when QBO has no PurchaseCost. */
+  cost: number | null;
+  is_active: boolean;
+  tax_rate_id: string | null;
+}
+
+export interface ItemResolution {
+  qboItem: QboItem;
+  action: 'create' | 'update' | 'link' | 'skip';
+  /** Set for update/link, and for create when re-creating a mapped-but-deleted row. */
+  matchedServiceId?: string;
+  /** Existing ledger row id, when one already points at this QBO item. */
+  existingMappingId?: string;
+  /** Desired QBO-authoritative values (absent for skips). */
+  fields?: ResolvedItemFields;
+  /** Per-field diff backing an 'update' (QBO-authoritative fields only). */
+  fieldChanges?: ItemFieldChange[];
+  flags: ItemResolutionFlag[];
+  reason?: string;
+}
+
+/** QBO's US pseudo tax codes — "NON" is an explicit "not taxable", not a gap. */
+const NON_TAXABLE_TAX_CODES = new Set(['NON']);
+
+function toCents(amount: number | undefined | null): number | null {
+  if (amount === undefined || amount === null || Number.isNaN(Number(amount))) return null;
+  return Math.round(Number(amount) * 100);
+}
+
+function normalizedName(name: string): string {
+  return name.trim().toLowerCase();
+}
+
+function normalizedSku(sku: string | null | undefined): string | null {
+  const trimmed = (sku ?? '').trim();
+  return trimmed.length > 0 ? trimmed.toLowerCase() : null;
+}
+
+function itemKindFor(item: QboItem): 'service' | 'product' {
+  return item.Type === 'Service' ? 'service' : 'product';
+}
+
+function desiredFields(
+  item: QboItem,
+  taxRateByQboTaxCodeId: Map<string, string>
+): { fields: ResolvedItemFields; flags: ItemResolutionFlag[] } {
+  const flags: ItemResolutionFlag[] = [];
+
+  const taxCodeId = item.SalesTaxCodeRef?.value?.trim();
+  let taxRateId: string | null = null;
+  if (taxCodeId && !NON_TAXABLE_TAX_CODES.has(taxCodeId.toUpperCase())) {
+    taxRateId = taxRateByQboTaxCodeId.get(taxCodeId) ?? null;
+    if (!taxRateId) flags.push('unmapped_tax');
+  }
+
+  const isActive = item.Active ?? true;
+  if (!isActive) flags.push('inactive');
+
+  const sku = (item.Sku ?? '').trim();
+
+  return {
+    fields: {
+      // QBO's Name is the leaf; FullyQualifiedName ("Parent:Child") goes to
+      // mapping metadata only — no category tree is built.
+      service_name: item.Name.trim(),
+      item_kind: itemKindFor(item),
+      sku: sku.length > 0 ? sku : null,
+      description: item.Description?.trim() || null,
+      default_rate: toCents(item.UnitPrice) ?? 0,
+      cost: toCents(item.PurchaseCost),
+      is_active: isActive,
+      tax_rate_id: taxRateId
+    },
+    flags
+  };
+}
+
+function diffAgainstExisting(
+  fields: ResolvedItemFields,
+  existing: ExistingServiceRow
+): ItemFieldChange[] {
+  const current: Record<QboAuthoritativeField, unknown> = {
+    service_name: existing.service_name,
+    default_rate: existing.default_rate === null ? 0 : Math.round(Number(existing.default_rate)),
+    sku: existing.sku ?? null,
+    description: existing.description ?? null,
+    cost: existing.cost === null || existing.cost === undefined ? null : Math.round(Number(existing.cost)),
+    is_active: existing.is_active ?? true
+  };
+
+  const changes: ItemFieldChange[] = [];
+  for (const field of QBO_AUTHORITATIVE_FIELDS) {
+    const to = fields[field];
+    const from = current[field];
+    if (from !== to) {
+      changes.push({ field, from, to });
+    }
+  }
+  return changes;
+}
+
+export function resolveQboItems(
+  qboItems: QboItem[],
+  existingServices: ExistingServiceRow[],
+  existingMappings: ExistingItemMappingRow[],
+  taxRateByQboTaxCodeId: Map<string, string>
+): ItemResolution[] {
+  const mappingByExternalId = new Map(existingMappings.map((m) => [m.external_entity_id, m]));
+  const mappedServiceToExternal = new Map(existingMappings.map((m) => [m.alga_entity_id, m.external_entity_id]));
+  const serviceById = new Map(existingServices.map((s) => [s.service_id, s]));
+  const serviceByName = new Map(existingServices.map((s) => [normalizedName(s.service_name), s]));
+  const productBySku = new Map(
+    existingServices
+      .filter((s) => s.item_kind === 'product' && normalizedSku(s.sku))
+      .map((s) => [normalizedSku(s.sku) as string, s])
+  );
+
+  // SKUs/names claimed by earlier resolutions this run, so two QBO items
+  // can't both create/update their way into the same unique SKU.
+  const claimedSkus = new Set<string>();
+
+  const resolutions: ItemResolution[] = [];
+
+  for (const item of qboItems) {
+    if (item.Type === 'Category') {
+      resolutions.push({
+        qboItem: item,
+        action: 'skip',
+        flags: ['category_skipped'],
+        reason: 'QBO categories are not imported; item names are flattened to their leaf name.'
+      });
+      continue;
+    }
+
+    const { fields, flags } = desiredFields(item, taxRateByQboTaxCodeId);
+    const skuKey = normalizedSku(fields.sku);
+
+    // 1. Existing ledger mapping wins.
+    const mapping = mappingByExternalId.get(item.Id);
+    if (mapping) {
+      const existing = serviceById.get(mapping.alga_entity_id);
+      if (!existing) {
+        // Mapped catalog row no longer exists — recreate and re-point the ledger.
+        resolutions.push({
+          qboItem: item, action: 'create', existingMappingId: mapping.id, fields, flags,
+          reason: 'Previously mapped catalog item no longer exists; it will be recreated.'
+        });
+      } else {
+        const fieldChanges = diffAgainstExisting(fields, existing);
+        resolutions.push({
+          qboItem: item,
+          action: fieldChanges.length > 0 ? 'update' : 'link',
+          matchedServiceId: existing.service_id,
+          existingMappingId: mapping.id,
+          fields,
+          fieldChanges,
+          flags
+        });
+      }
+      if (skuKey) claimedSkus.add(skuKey);
+      continue;
+    }
+
+    // 2. SKU match (products, exact).
+    let matched: ExistingServiceRow | undefined;
+    if (fields.item_kind === 'product' && skuKey) {
+      const bySku = productBySku.get(skuKey);
+      if (bySku) {
+        const mappedTo = mappedServiceToExternal.get(bySku.service_id);
+        if (mappedTo && mappedTo !== item.Id) {
+          resolutions.push({
+            qboItem: item, action: 'skip', flags: [...flags, 'sku_conflict'],
+            reason: `SKU "${fields.sku}" belongs to "${bySku.service_name}", which is already mapped to a different QBO item. Resolve in the mapping manager.`
+          });
+          continue;
+        }
+        matched = bySku;
+      }
+      if (!matched && claimedSkus.has(skuKey)) {
+        resolutions.push({
+          qboItem: item, action: 'skip', flags: [...flags, 'sku_conflict'],
+          reason: `SKU "${fields.sku}" is claimed by another QBO item in this import.`
+        });
+        continue;
+      }
+    }
+
+    // 3. Exact name match.
+    if (!matched) {
+      const byName = serviceByName.get(normalizedName(fields.service_name));
+      if (byName) {
+        const mappedTo = mappedServiceToExternal.get(byName.service_id);
+        if (mappedTo && mappedTo !== item.Id) {
+          resolutions.push({
+            qboItem: item, action: 'skip', flags: [...flags, 'name_collision'],
+            reason: `"${byName.service_name}" is already mapped to a different QBO item. Resolve in the mapping manager.`
+          });
+          continue;
+        }
+        matched = byName;
+      }
+    }
+
+    if (matched) {
+      const fieldChanges = diffAgainstExisting(fields, matched);
+      resolutions.push({
+        qboItem: item,
+        action: fieldChanges.length > 0 ? 'update' : 'link',
+        matchedServiceId: matched.service_id,
+        fields,
+        fieldChanges,
+        flags
+      });
+    } else {
+      resolutions.push({ qboItem: item, action: 'create', fields, flags });
+    }
+    if (skuKey) claimedSkus.add(skuKey);
+  }
+
+  return resolutions;
+}

--- a/packages/billing/src/services/accountingSync/testing/qboSimulator.ts
+++ b/packages/billing/src/services/accountingSync/testing/qboSimulator.ts
@@ -61,7 +61,7 @@ export class QboSimError extends Error {
   }
 }
 
-const SUPPORTED_ENTITIES = ['Customer', 'Invoice', 'CreditMemo', 'Payment'] as const;
+const SUPPORTED_ENTITIES = ['Customer', 'Invoice', 'CreditMemo', 'Payment', 'Item'] as const;
 type SimEntityType = (typeof SUPPORTED_ENTITIES)[number];
 
 function toCents(amount: unknown): number {
@@ -78,7 +78,8 @@ export class QboSimulator {
     Customer: new Map(),
     Invoice: new Map(),
     CreditMemo: new Map(),
-    Payment: new Map()
+    Payment: new Map(),
+    Item: new Map()
   };
 
   private journal: ChangeJournalEntry[] = [];
@@ -120,6 +121,9 @@ export class QboSimulator {
           SalesFormsPrefs: {
             AutoApplyCredit: Boolean(this.options.autoApplyCredits),
             CustomTxnNumbers: true
+          },
+          CurrencyPrefs: {
+            HomeCurrency: { value: 'USD' }
           }
         }) as any,
       findCustomerByDisplayName: async (displayName) => {
@@ -381,7 +385,7 @@ export class QboSimulator {
   }
 
   private runQuery(selectQuery: string): any[] {
-    // Support the one query shape the integration issues. Anything else is a
+    // Support the query shapes the integration issues. Anything else is a
     // loud failure so a new query gets modeled deliberately, not silently.
     const customerByName = selectQuery.match(/FROM\s+Customer\s+WHERE\s+DisplayName\s*=\s*'((?:[^']|'')*)'/i);
     if (customerByName) {
@@ -389,6 +393,24 @@ export class QboSimulator {
       // QBO queries return ACTIVE rows only unless Active is filtered explicitly.
       const found = this.findActiveCustomerByName(name);
       return found ? [{ ...found }] : [];
+    }
+    // Item paged fetch (products & services import): Type IN (...) with an
+    // optional explicit Active IN (true, false) filter and pagination.
+    const itemByType = selectQuery.match(
+      /FROM\s+Item\s+WHERE\s+Type\s+IN\s+\(([^)]*)\)(\s+AND\s+Active\s+IN\s+\(\s*true\s*,\s*false\s*\))?\s+STARTPOSITION\s+(\d+)\s+MAXRESULTS\s+(\d+)/i
+    );
+    if (itemByType) {
+      const types = new Set(
+        itemByType[1].split(',').map((t) => t.trim().replace(/^'|'$/g, ''))
+      );
+      const includeInactive = Boolean(itemByType[2]);
+      const startPosition = Number(itemByType[3]);
+      const maxResults = Number(itemByType[4]);
+      const rows = Array.from(this.stores.Item.values())
+        .filter((item) => types.has(String(item.Type)))
+        // QBO returns ACTIVE rows only unless Active is filtered explicitly.
+        .filter((item) => includeInactive || item.Active !== false);
+      return rows.slice(startPosition - 1, startPosition - 1 + maxResults).map((item) => ({ ...item }));
     }
     throw new QboSimError('SIM_UNSUPPORTED', `QboSimulator does not model query: ${selectQuery}`);
   }
@@ -439,6 +461,42 @@ export class QboSimulator {
         }
       ]
     });
+  }
+
+  seedItem(params: {
+    name: string;
+    type: 'Service' | 'NonInventory' | 'Inventory' | 'Category';
+    sku?: string;
+    description?: string;
+    /** Dollars, like QBO's UnitPrice. */
+    unitPrice?: number;
+    /** Dollars, like QBO's PurchaseCost. */
+    purchaseCost?: number;
+    active?: boolean;
+    /** QBO SalesTaxCodeRef value (e.g. 'TAX', 'NON', or a TaxCode id). */
+    taxCodeId?: string;
+    /** "Parent:Child" marks a sub-item; Name stays the leaf. */
+    fullyQualifiedName?: string;
+  }): QboSimEntity {
+    const at = this.tick();
+    const entity: QboSimEntity = {
+      Id: this.allocateId('Item'),
+      SyncToken: '0',
+      Name: params.name,
+      Type: params.type,
+      Active: params.active !== false,
+      FullyQualifiedName: params.fullyQualifiedName ?? params.name,
+      SubItem: Boolean(params.fullyQualifiedName && params.fullyQualifiedName.includes(':')),
+      ...(params.sku !== undefined ? { Sku: params.sku } : {}),
+      ...(params.description !== undefined ? { Description: params.description } : {}),
+      ...(params.unitPrice !== undefined ? { UnitPrice: params.unitPrice } : {}),
+      ...(params.purchaseCost !== undefined ? { PurchaseCost: params.purchaseCost } : {}),
+      ...(params.taxCodeId ? { SalesTaxCodeRef: { value: params.taxCodeId } } : {}),
+      MetaData: { CreateTime: at, LastUpdatedTime: at }
+    };
+    this.stores.Item.set(entity.Id, entity);
+    this.journalChange('Item', entity.Id);
+    return entity;
   }
 
   seedCreditMemo(params: { customerId: string; amountCents: number; docNumber?: string }): QboSimEntity {

--- a/packages/emulators/qbo/src/register.ts
+++ b/packages/emulators/qbo/src/register.ts
@@ -21,6 +21,23 @@ export function register(reg: ControlRegistry, core: QboEmulatorCore): void {
   });
 
   reg.seeder({
+    name: 'item',
+    description: 'Create a QBO Item (product/service catalog entry)',
+    params: z.object({
+      name: z.string(),
+      type: z.enum(['Service', 'NonInventory', 'Inventory', 'Category']),
+      sku: z.string().optional(),
+      description: z.string().optional(),
+      unitPrice: z.number().optional(),
+      purchaseCost: z.number().optional(),
+      active: z.boolean().optional(),
+      taxCodeId: z.string().optional(),
+      fullyQualifiedName: z.string().optional(),
+    }),
+    run: (params) => core.sim.seedItem(params),
+  });
+
+  reg.seeder({
     name: 'invoice',
     description: 'Create a QBO invoice with a single sales line',
     params: z.object({
@@ -100,6 +117,7 @@ export function register(reg: ControlRegistry, core: QboEmulatorCore): void {
     ['invoices', 'Invoice'],
     ['credit-memos', 'CreditMemo'],
     ['payments', 'Payment'],
+    ['items', 'Item'],
   ] as const) {
     reg.stateView({
       name: view,

--- a/packages/integrations/src/lib/qbo/types.ts
+++ b/packages/integrations/src/lib/qbo/types.ts
@@ -168,6 +168,17 @@ export interface QboItem {
   IncomeAccountRef?: QboRef;
   ExpenseAccountRef?: QboRef;
   AssetAccountRef?: QboRef;
+  Sku?: string;
+  Description?: string;
+  UnitPrice?: number;
+  PurchaseCost?: number;
+  Active?: boolean;
+  Taxable?: boolean;
+  SubItem?: boolean;
+  ParentRef?: QboRef;
+  FullyQualifiedName?: string;
+  SalesTaxCodeRef?: QboRef;
+  MetaData?: QboMetaData;
   // Add other relevant fields
 }
 

--- a/tools/smoke-sim/qbo-item-import-smoke/common.cjs
+++ b/tools/smoke-sim/qbo-item-import-smoke/common.cjs
@@ -1,0 +1,50 @@
+const path = require('path');
+const fs = require('fs');
+const { chromium } = require('/home/robert/alga-copies/feature-qbo-import-products-services/node_modules/playwright/index.js');
+
+const EVD = '/tmp/alga-smoke-evidence/qbo-item-import-20260729-003734';
+const STATE = path.join(EVD, 'driver-state.json');
+const BASE = 'http://localhost:3642';
+const EMAIL = 'glinda@emeraldcity.oz';
+const PASSWORD = 'VVVbiTMGKYX2UEcM';
+
+async function launch() {
+  const browser = await chromium.launch({
+    executablePath: '/usr/bin/google-chrome',
+    headless: true,
+    args: ['--no-sandbox']
+  });
+  const context = await browser.newContext({
+    viewport: { width: 1512, height: 950 },
+    storageState: fs.existsSync(STATE) ? STATE : undefined
+  });
+  const page = await context.newPage();
+  page.setDefaultTimeout(30000);
+  return { browser, context, page };
+}
+
+async function saveState(context) {
+  await context.storageState({ path: STATE });
+}
+
+async function shot(page, name) {
+  const file = path.join(EVD, name);
+  await page.screenshot({ path: file, fullPage: true });
+  console.log('SHOT', file);
+}
+
+async function login(page) {
+  await page.goto(BASE + '/auth/msp/signin', { waitUntil: 'networkidle' });
+  if (!page.url().includes('signin')) { console.log('already logged in:', page.url()); return; }
+  const email = page.locator('input[type="email"], input[name="email"], #email').first();
+  const pass = page.locator('input[type="password"]').first();
+  await email.fill(EMAIL);
+  await pass.fill(PASSWORD);
+  await Promise.all([
+    page.waitForURL(/msp/, { timeout: 30000 }),
+    page.locator('button[type="submit"], #signin-button, button:has-text("Sign in")').first().click()
+  ]);
+  console.log('logged in, at', page.url());
+}
+
+module.exports = { launch, saveState, shot, login, EVD, BASE };

--- a/tools/smoke-sim/qbo-item-import-smoke/stage2-qbo-settings.cjs
+++ b/tools/smoke-sim/qbo-item-import-smoke/stage2-qbo-settings.cjs
@@ -1,0 +1,26 @@
+const { launch, saveState, shot, BASE } = require('./common.cjs');
+(async () => {
+  const { browser, context, page } = await launch();
+  try {
+    await page.goto(BASE + '/msp/settings?tab=integrations&category=accounting', { waitUntil: 'networkidle' });
+    await page.waitForTimeout(5000);
+    console.log('url:', page.url());
+    for (const id of ['qbo-integration-settings', 'qbo-connect-button', 'qbo-onboarding-wizard', 'qbo-integration-connection-card']) {
+      const el = page.locator('#' + id);
+      const n = await el.count();
+      console.log(id, 'count=', n, n ? 'visible=' + (await el.first().isVisible()) : '');
+    }
+    const btn = page.locator('#qbo-connect-button');
+    if (await btn.count()) {
+      console.log('connect disabled =', await btn.first().isDisabled());
+      console.log('connect text =', (await btn.first().innerText()).trim());
+    }
+    await shot(page, '02-qbo-settings-before-connect.png');
+    await saveState(context);
+  } finally {
+    await browser.close();
+  }
+})().catch((e) => {
+  console.error('FAIL', e.message);
+  process.exit(1);
+});

--- a/tools/smoke-sim/qbo-item-import-smoke/stage3-connect.cjs
+++ b/tools/smoke-sim/qbo-item-import-smoke/stage3-connect.cjs
@@ -1,0 +1,46 @@
+const { launch, saveState, shot, BASE } = require('./common.cjs');
+(async () => {
+  const { browser, context, page } = await launch();
+  try {
+    await page.goto(BASE + '/msp/settings?tab=integrations&category=accounting', { waitUntil: 'networkidle' });
+    await page.waitForTimeout(4000);
+
+    // Select the QuickBooks Online integration card
+    const qboCard = page.locator('div', { has: page.locator('text=QuickBooks Online') }).locator('button:has-text("Configure Integration")').first();
+    // More robust: find the card containing the "QuickBooks Online" heading
+    const card = page.locator('text=Connect your realm to sync').locator('xpath=ancestor::div[contains(@class,"rounded") or contains(@class,"card")][1]');
+    let clicked = false;
+    const buttons = page.locator('button:has-text("Configure Integration")');
+    const n = await buttons.count();
+    for (let i = 0; i < n; i++) {
+      const b = buttons.nth(i);
+      const cardText = await b.evaluate((el) => el.closest('div[class*="border"], div[class*="card"], div[class*="rounded"]')?.innerText || '');
+      if (/QuickBooks Online/.test(cardText) && !/CSV/.test(cardText)) {
+        await b.click();
+        clicked = true;
+        console.log('clicked QuickBooks Online configure card (index', i, ')');
+        break;
+      }
+    }
+    if (!clicked) console.log('WARN: did not find QBO card button; buttons:', n);
+    await page.waitForTimeout(4000);
+    for (const id of ['qbo-integration-settings', 'qbo-connect-button', 'qbo-onboarding-wizard']) {
+      const el = page.locator('#' + id);
+      const c = await el.count();
+      console.log(id, 'count=', c, c ? 'visible=' + (await el.first().isVisible()) : '');
+    }
+    const btn = page.locator('#qbo-connect-button');
+    if (await btn.count()) {
+      await btn.first().scrollIntoViewIfNeeded();
+      console.log('connect disabled =', await btn.first().isDisabled());
+      console.log('connect text =', (await btn.first().innerText()).trim());
+    }
+    await shot(page, '03-qbo-settings-selected.png');
+    await saveState(context);
+  } finally {
+    await browser.close();
+  }
+})().catch((e) => {
+  console.error('FAIL', e.message);
+  process.exit(1);
+});

--- a/tools/smoke-sim/qbo-item-import-smoke/stage4-oauth.cjs
+++ b/tools/smoke-sim/qbo-item-import-smoke/stage4-oauth.cjs
@@ -1,0 +1,42 @@
+const { launch, saveState, shot, BASE } = require('./common.cjs');
+(async () => {
+  const { browser, context, page } = await launch();
+  try {
+    await page.goto(BASE + '/msp/settings?tab=integrations&category=accounting', { waitUntil: 'networkidle' });
+    await page.waitForTimeout(3000);
+    // The QBO integration stays selected? If connect button absent, reselect card.
+    if (!(await page.locator('#qbo-connect-button').count())) {
+      const buttons = page.locator('button:has-text("Configure Integration")');
+      const n = await buttons.count();
+      for (let i = 0; i < n; i++) {
+        const b = buttons.nth(i);
+        const cardText = await b.evaluate((el) => el.closest('div[class*="border"], div[class*="card"], div[class*="rounded"]')?.innerText || '');
+        if (/QuickBooks Online/.test(cardText) && !/CSV/.test(cardText)) { await b.click(); break; }
+      }
+      await page.waitForTimeout(3000);
+    }
+    page.on('request', (r) => {
+      const u = r.url();
+      if (u.includes('4020') || u.includes('/api/integrations/qbo')) console.log('REQ', r.method(), u);
+    });
+    await page.locator('#qbo-connect-button').click();
+    await page.waitForTimeout(8000);
+    console.log('url after connect:', page.url());
+    await shot(page, '04-after-oauth-connect.png');
+    // Check for connected company + wizard
+    for (const id of ['qbo-onboarding-wizard', 'qbo-disconnect-button']) {
+      const el = page.locator('#' + id);
+      const c = await el.count();
+      console.log(id, 'count=', c);
+    }
+    const bodyText = await page.locator('body').innerText();
+    const m = bodyText.match(/Realm ID: [^\n]*/);
+    console.log('realm line:', m ? m[0] : '(none)');
+    await saveState(context);
+  } finally {
+    await browser.close();
+  }
+})().catch((e) => {
+  console.error('FAIL', e.message);
+  process.exit(1);
+});

--- a/tools/smoke-sim/qbo-item-import-smoke/stage5-wizard.cjs
+++ b/tools/smoke-sim/qbo-item-import-smoke/stage5-wizard.cjs
@@ -1,0 +1,38 @@
+const { launch, saveState, shot, BASE } = require('./common.cjs');
+(async () => {
+  const { browser, context, page } = await launch();
+  try {
+    await page.goto(BASE + '/msp/settings?tab=integrations&category=accounting', { waitUntil: 'networkidle' });
+    await page.waitForTimeout(3000);
+    if (!(await page.locator('#qbo-integration-settings').count())) {
+      const buttons = page.locator('button:has-text("Configure Integration")');
+      const n = await buttons.count();
+      for (let i = 0; i < n; i++) {
+        const b = buttons.nth(i);
+        const cardText = await b.evaluate((el) => el.closest('div[class*="border"], div[class*="card"], div[class*="rounded"]')?.innerText || '');
+        if (/QuickBooks Online/.test(cardText) && !/CSV/.test(cardText)) { await b.click(); break; }
+      }
+      await page.waitForTimeout(4000);
+    }
+    const bodyText = await page.locator('body').innerText();
+    console.log('has Reconciliation Wizard:', /Reconciliation Wizard/.test(bodyText));
+    console.log('has Products & Services step label:', /Products & Services/.test(bodyText));
+    console.log('has Customers step:', /Customers/.test(bodyText));
+    console.log('has Go-live:', /Go-live/.test(bodyText));
+    const wiz = page.locator('#qbo-onboarding-wizard');
+    console.log('wizard id count:', await wiz.count());
+    // scroll to wizard area
+    const heading = page.locator('text=QuickBooks Reconciliation Wizard').first();
+    if (await heading.count()) {
+      await heading.scrollIntoViewIfNeeded();
+      await page.waitForTimeout(1000);
+    }
+    await shot(page, '05-wizard-visible.png');
+    await saveState(context);
+  } finally {
+    await browser.close();
+  }
+})().catch((e) => {
+  console.error('FAIL', e.message);
+  process.exit(1);
+});

--- a/tools/smoke-sim/qbo-item-import-smoke/stage6-scan.cjs
+++ b/tools/smoke-sim/qbo-item-import-smoke/stage6-scan.cjs
@@ -1,0 +1,31 @@
+const { launch, saveState, shot, BASE } = require('./common.cjs');
+(async () => {
+  const { browser, context, page } = await launch();
+  try {
+    await page.goto(BASE + '/msp/settings?tab=integrations&category=accounting', { waitUntil: 'networkidle' });
+    await page.waitForTimeout(8000);
+    // scroll progressively to bottom to force lazy renders
+    for (let i = 0; i < 10; i++) {
+      await page.mouse.wheel(0, 1200);
+      await page.waitForTimeout(400);
+    }
+    await page.waitForTimeout(3000);
+    const ids = await page.evaluate(() =>
+      Array.from(document.querySelectorAll('[id]'))
+        .map((e) => e.id)
+        .filter((id) => /qbo|wizard|onboarding/i.test(id))
+    );
+    console.log('qbo-ish ids:', JSON.stringify(ids, null, 1));
+    const bodyText = await page.locator('body').innerText();
+    console.log('has Reconciliation Wizard:', /Reconciliation Wizard/.test(bodyText));
+    console.log('has Connected company:', /Connected company/.test(bodyText));
+    console.log('has realm-sim:', /realm-sim/.test(bodyText));
+    await shot(page, '06-full-scroll.png');
+    await saveState(context);
+  } finally {
+    await browser.close();
+  }
+})().catch((e) => {
+  console.error('FAIL', e.message);
+  process.exit(1);
+});

--- a/tools/smoke-sim/qbo-item-import-smoke/stage7-console.cjs
+++ b/tools/smoke-sim/qbo-item-import-smoke/stage7-console.cjs
@@ -1,0 +1,23 @@
+const { launch, saveState, shot, BASE } = require('./common.cjs');
+(async () => {
+  const { browser, context, page } = await launch();
+  const errors = [];
+  page.on('console', (msg) => {
+    if (msg.type() === 'error' || msg.type() === 'warning') errors.push(msg.type() + ': ' + msg.text().slice(0, 400));
+  });
+  page.on('pageerror', (err) => errors.push('pageerror: ' + String(err).slice(0, 600)));
+  try {
+    await page.goto(BASE + '/msp/settings?tab=integrations&category=accounting', { waitUntil: 'networkidle' });
+    await page.waitForTimeout(10000);
+    const hasSettings = await page.locator('#qbo-integration-settings').count();
+    console.log('qbo-integration-settings count:', hasSettings);
+    console.log('--- console/page errors ---');
+    for (const e of errors.slice(0, 30)) console.log(e);
+    await saveState(context);
+  } finally {
+    await browser.close();
+  }
+})().catch((e) => {
+  console.error('FAIL', e.message);
+  process.exit(1);
+});

--- a/tools/smoke-sim/qbo-item-import-smoke/stage8-wizard-run.cjs
+++ b/tools/smoke-sim/qbo-item-import-smoke/stage8-wizard-run.cjs
@@ -1,0 +1,98 @@
+const { launch, saveState, shot, BASE } = require('./common.cjs');
+(async () => {
+  const { browser, context, page } = await launch();
+  page.on('pageerror', (e) => console.log('PAGEERROR', String(e).slice(0, 300)));
+  try {
+    await page.goto(BASE + '/msp/settings?tab=integrations&category=accounting', { waitUntil: 'networkidle' });
+    await page.waitForTimeout(4000);
+
+    // Select the QuickBooks Online card (fresh selection each page load)
+    const buttons = page.locator('button:has-text("Configure Integration")');
+    const n = await buttons.count();
+    for (let i = 0; i < n; i++) {
+      const b = buttons.nth(i);
+      const cardText = await b.evaluate((el) => el.closest('div[class*="border"], div[class*="card"], div[class*="rounded"]')?.innerText || '');
+      if (/QuickBooks Online/.test(cardText) && !/CSV/.test(cardText)) {
+        await b.click();
+        console.log('selected QuickBooks Online card');
+        break;
+      }
+    }
+    await page.waitForSelector('#qbo-integration-settings', { timeout: 20000 });
+
+    // Wizard entry CTA
+    await page.waitForSelector('#qbo-wizard-entry-run, #qbo-wizard-entry-rerun', { timeout: 20000 });
+    const runBtn = page.locator('#qbo-wizard-entry-run, #qbo-wizard-entry-rerun').first();
+    await runBtn.scrollIntoViewIfNeeded();
+    await shot(page, '10-wizard-entry-rerun.png');
+    await runBtn.click();
+    await page.waitForSelector('#qbo-onboarding-wizard', { timeout: 20000 });
+
+    // Assert stepper labels
+    const wizardText = await page.locator('#qbo-onboarding-wizard').innerText();
+    for (const label of ['Customers', 'History', 'Products & Services', 'Go-live']) {
+      console.log('step label', JSON.stringify(label), wizardText.includes(label) ? 'PRESENT' : 'MISSING');
+    }
+    await page.locator('#qbo-onboarding-wizard').scrollIntoViewIfNeeded();
+    await shot(page, '11-wizard-four-steps-rerun.png');
+
+    // Navigate: Customers -> History -> Products & Services
+    await page.locator('#qbo-wizard-next').click();
+    await page.waitForTimeout(1500);
+    await page.locator('#qbo-wizard-next').click();
+    await page.waitForSelector('#qbo-item-import-step', { timeout: 15000 });
+    console.log('items step reached');
+    await page.locator('#qbo-item-import-step').scrollIntoViewIfNeeded();
+    await shot(page, '12-items-step-rerun.png');
+
+    // Preview should be disabled until service type picked
+    console.log('preview disabled before type =', await page.locator('#qbo-item-import-preview').isDisabled());
+
+    // Pick a service type via CustomSelect
+    await page.locator('#qbo-item-import-service-type').click();
+    await page.waitForTimeout(800);
+    const opts = page.locator('[role="option"]');
+    const oc = await opts.count();
+    const names = [];
+    for (let i = 0; i < Math.min(oc, 10); i++) names.push((await opts.nth(i).innerText()).trim());
+    console.log('service type options:', JSON.stringify(names));
+    await page.locator('[role="option"]:not([aria-disabled="true"])', { hasText: 'Managed Services' }).first().click();
+    await page.waitForTimeout(500);
+    console.log('preview disabled after type =', await page.locator('#qbo-item-import-preview').isDisabled());
+
+    // Preview
+    await page.locator('#qbo-item-import-preview').click();
+    await page.waitForSelector('#qbo-item-import-preview-panel, #qbo-item-import-preview-error', { timeout: 60000 });
+    if (await page.locator('#qbo-item-import-preview-error').count()) {
+      console.log('PREVIEW ERROR:', await page.locator('#qbo-item-import-preview-error').innerText());
+      await shot(page, '13-preview-error-rerun.png');
+      return;
+    }
+    const panelText = await page.locator('#qbo-item-import-preview-panel').innerText();
+    console.log('--- preview panel ---');
+    console.log(panelText.slice(0, 2500));
+    await page.locator('#qbo-item-import-preview-panel').scrollIntoViewIfNeeded();
+    await shot(page, '13-preview-panel-rerun.png');
+
+    // Execute
+    await page.locator('#qbo-item-import-execute').click();
+    await page.waitForSelector('#qbo-item-import-result, #qbo-item-import-execute-error', { timeout: 120000 });
+    if (await page.locator('#qbo-item-import-execute-error').count()) {
+      console.log('EXECUTE ERROR:', await page.locator('#qbo-item-import-execute-error').innerText());
+      await shot(page, '14-execute-error-rerun.png');
+      return;
+    }
+    const resultText = await page.locator('#qbo-item-import-result').innerText();
+    console.log('--- import result ---');
+    console.log(resultText);
+    await page.locator('#qbo-item-import-result').scrollIntoViewIfNeeded();
+    await shot(page, '14-import-result-rerun.png');
+
+    await saveState(context);
+  } finally {
+    await browser.close();
+  }
+})().catch((e) => {
+  console.error('FAIL', e.message);
+  process.exit(1);
+});


### PR DESCRIPTION
## Summary

Adds a flag-gated **Products & Services import** step to the existing QuickBooks Online onboarding/reconciliation wizard, importing QBO Items (Service, NonInventory, Inventory) into the Alga service catalog.

### Behavior
- **New wizard step** (`QboItemImportStep`) in `QboOnboardingWizard`, gated behind the `qbo-item-import` feature flag. Preview shows the full resolution plan (create / update / link / skip) before anything is written; execute runs the import and reports per-row results.
- **Item resolution** (`qboItemResolver`): match precedence is existing mapping → SKU → name → create-new. Category items are skipped and hierarchical names flattened.
- **Field ownership**: QBO wins on name, rate, SKU, description, cost, and is_active; Alga owns billing_method, unit of measure, and service type. Inactive QBO items import as `is_active=false` and unmapped tax codes import as null — both are flagged in the preview.
- **Import service** (`qboItemImportService`): per-row error isolation (a failing row does not abort the batch), dollars→cents conversion, and mapping rows written under `integration_type='quickbooks_online'`.
- **Cursor namespacing** (key mitigation): the import records its sync cycle under `adapter_type='quickbooks_online_items'` — a separate namespace from the shared `quickbooks_online` CDC cursor — so the item import can never advance the accounting-sync cursor used by invoice/customer sync. A future Item CDC consumer reads the new namespace.

### Implementation
- `packages/billing/src/actions/qboItemImportActions.ts` — server actions (preview + execute), paginated Item fetch following the `fetchQboInvoicesPaged` pattern.
- `packages/billing/src/services/accountingSync/qboItemImportService.ts` + `qboItemResolver.ts` — core import/resolution logic.
- `packages/billing/src/components/accounting/QboItemImportStep.tsx` — wizard step UI.
- `packages/integrations/src/lib/qbo/types.ts` — QBO Item types.
- QBO simulator + wire emulator (`qboSimulator.ts`, `packages/emulators/qbo/src/register.ts`) now model Item queries; smoke drivers under `tools/smoke-sim/qbo-item-import-smoke/`.
- Unit/contract tests for the resolver, import service, actions, and wizard step (~900 lines of tests).

## Smoke test

**PASS** — exercised end-to-end through the real running product (dev server + wire-level QBO emulator + real OAuth'd `realm-sim` tenant + shared postgres): logged in via the signin form, drove the flag-gated Products & Services wizard step through preview and execute.

- Preview resolved 11 emulator items: 1 create, 2 update, 7 link, 1 skip (Category), with tax-not-mapped flags and the "Nothing has been written yet" notice.
- Execute: 1 created / 0 updated / 7 linked / 1 skipped / 2 failed — both failures are the two previously documented per-row edge cases (legacy `per_unit` billing_method rejected by the Service.update zod enum; `idx_unique_alga_mapping` cross-realm collision), and the batch continued as designed.
- **Core mitigation verified live**: the import wrote exactly one `accounting_sync_cycles` row under `adapter_type='quickbooks_online_items'` (realm-sim, succeeded), while the shared `quickbooks_online` namespace was untouched (73 rows, latest cursor unchanged, zero rows for realm-sim).
- Also verified: created service present in `service_catalog` (fixed / 15000 cents / active, correct dollars→cents), mapping rows present, service visible in the Service Catalog UI, and `[qboItemImport] Import complete` in server logs.
- Not covered: a visible QBO-wins field update (no emulator action mutates existing items; the two would-be update rows are the known failing edge cases), and the future Item CDC consumer of the new cursor namespace (does not exist yet).
- Pre-existing issues noticed (not this branch): the QBO simulator does not model the wizard's paged Customer query, so wizard step 1 Customers and the legacy Items/Services mapping tab show load errors against the sim.

Evidence: `/tmp/alga-smoke-evidence/qbo-item-import-round3-20260729-012830`
