### PR TITLE
Confirm before changing the default client company in settings

### DIFF
--- a/packages/tenancy/src/actions/coreTenantActions.ts
+++ b/packages/tenancy/src/actions/coreTenantActions.ts
@@ -51,12 +51,17 @@ export const updateTenantName = withAuth(async (_user, { tenant }, name: string)
 export const addClientToTenant = withAuth(async (_user, { tenant }, clientId: string): Promise<void> => {
   const { knex: db } = await createTenantKnex();
   return withTransaction(db, async (trx: Knex.Transaction) => {
+    // Re-adding a client that was previously removed hits the (tenant, client_id)
+    // primary key, so revive the soft-deleted row instead of failing.
     await tenantScopedTable(trx, 'tenant_companies', tenant)
       .insert({
         tenant,
         client_id: clientId,
-        is_default: false
-      });
+        is_default: false,
+        deleted_at: null
+      })
+      .onConflict(['tenant', 'client_id'])
+      .merge(['deleted_at']);
   });
 });
 

--- a/server/public/locales/de/msp/settings.json
+++ b/server/public/locales/de/msp/settings.json
@@ -86,6 +86,7 @@
         "updateTimezone": "Zeitzone konnte nicht aktualisiert werden",
         "selectClient": "Bitte wählen Sie einen Kunden aus",
         "clientNotFound": "Kunde nicht gefunden",
+        "clientAlreadyAdded": "Dieser Kunde ist hier bereits aufgeführt",
         "addClient": "Kunde konnte nicht hinzugefügt werden",
         "removeClient": "Kunde konnte nicht entfernt werden",
         "setDefaultClient": "Standardkunde konnte nicht festgelegt werden",

--- a/server/public/locales/de/msp/settings.json
+++ b/server/public/locales/de/msp/settings.json
@@ -53,9 +53,9 @@
       "saveDefaultTimezone": "Standardzeitzone speichern"
     },
     "clients": {
-      "title": "Ihr Unternehmen & Kunden",
+      "title": "Ihr Unternehmen",
       "help": "Der als Ihr Unternehmen markierte Kunde ist Ihre eigene Organisation. Name, Adresse und Logo dieses Kunden erscheinen auf Rechnungen, Angeboten und in der Kundenkommunikation.",
-      "currentDefault": "Aktueller Standard: {{name}}",
+      "currentDefault": "Ihr Unternehmen ist derzeit {{name}}.",
       "yourCompanyBadge": "Ihr Unternehmen",
       "table": {
         "name": "Name",

--- a/server/public/locales/de/msp/settings.json
+++ b/server/public/locales/de/msp/settings.json
@@ -38,7 +38,7 @@
   },
   "general": {
     "title": "Allgemeine Einstellungen",
-    "description": "Verwalten Sie Ihren Organisationsnamen und den Standardkunden. Der Standardkunde wird zu Konfigurationszwecken verwendet und repräsentiert Ihren MSP.",
+    "description": "Verwalten Sie Ihren Organisationsnamen und legen Sie fest, welcher Kundendatensatz Ihr eigenes Unternehmen darstellt. Die Daten dieses Kunden erscheinen auf Rechnungen, Angeboten und in der Kundenkommunikation.",
     "fields": {
       "organizationName": {
         "label": "Organisationsname"
@@ -53,14 +53,24 @@
       "saveDefaultTimezone": "Standardzeitzone speichern"
     },
     "clients": {
-      "title": "Kunden",
+      "title": "Ihr Unternehmen & Kunden",
+      "help": "Der als Ihr Unternehmen markierte Kunde ist Ihre eigene Organisation. Name, Adresse und Logo dieses Kunden erscheinen auf Rechnungen, Angeboten und in der Kundenkommunikation.",
+      "currentDefault": "Aktueller Standard: {{name}}",
+      "yourCompanyBadge": "Ihr Unternehmen",
       "table": {
         "name": "Name",
-        "default": "Standard",
+        "default": "Ihr Unternehmen (Standard)",
         "actions": "Aktionen"
       },
       "placeholder": "Wählen Sie einen Kunden zum Hinzufügen aus",
-      "addClient": "Kunde hinzufügen"
+      "addClient": "Kunde hinzufügen",
+      "confirmDialog": {
+        "title": "Ihr Unternehmen ändern?",
+        "message": "Dadurch wird Ihr Unternehmen von {{current}} auf {{next}} geändert. {{next}} repräsentiert dann Ihre eigene Organisation auf Rechnungen, Angeboten sowie in E-Mails und Einladungen an Kunden.",
+        "messageInitial": "Dadurch wird {{next}} als Ihr Unternehmen festgelegt. {{next}} repräsentiert dann Ihre eigene Organisation auf Rechnungen, Angeboten sowie in E-Mails und Einladungen an Kunden.",
+        "confirm": "Unternehmen ändern",
+        "cancel": "Abbrechen"
+      }
     },
     "messages": {
       "success": {

--- a/server/public/locales/en/msp/settings.json
+++ b/server/public/locales/en/msp/settings.json
@@ -86,6 +86,7 @@
         "updateTimezone": "Failed to update timezone",
         "selectClient": "Please select a client",
         "clientNotFound": "Client not found",
+        "clientAlreadyAdded": "That client is already listed here",
         "addClient": "Failed to add client",
         "removeClient": "Failed to remove client",
         "setDefaultClient": "Failed to set default client",

--- a/server/public/locales/en/msp/settings.json
+++ b/server/public/locales/en/msp/settings.json
@@ -38,7 +38,7 @@
   },
   "general": {
     "title": "General Settings",
-    "description": "Manage your organization name and default client. The default client is used for configuration purposes and represents your MSP.",
+    "description": "Manage your organization name and choose which client record represents your own company. That client's details appear on invoices, quotes, and client-facing communications.",
     "fields": {
       "organizationName": {
         "label": "Organization Name"
@@ -53,14 +53,24 @@
       "saveDefaultTimezone": "Save Default Time Zone"
     },
     "clients": {
-      "title": "Clients",
+      "title": "Your Company & Clients",
+      "help": "The client marked as your company is your own organization. Its name, address, and logo appear on invoices, quotes, and client-facing communications.",
+      "currentDefault": "Current default: {{name}}",
+      "yourCompanyBadge": "Your company",
       "table": {
         "name": "Name",
-        "default": "Default",
+        "default": "Your Company (Default)",
         "actions": "Actions"
       },
       "placeholder": "Select a client to add",
-      "addClient": "Add Client"
+      "addClient": "Add Client",
+      "confirmDialog": {
+        "title": "Change your company?",
+        "message": "This will change your company from {{current}} to {{next}}. {{next}} will represent your own organization on invoices, quotes, and client-facing emails and invitations.",
+        "messageInitial": "This will set {{next}} as your company. {{next}} will represent your own organization on invoices, quotes, and client-facing emails and invitations.",
+        "confirm": "Change Company",
+        "cancel": "Cancel"
+      }
     },
     "messages": {
       "success": {

--- a/server/public/locales/en/msp/settings.json
+++ b/server/public/locales/en/msp/settings.json
@@ -53,9 +53,9 @@
       "saveDefaultTimezone": "Save Default Time Zone"
     },
     "clients": {
-      "title": "Your Company & Clients",
+      "title": "Your Company",
       "help": "The client marked as your company is your own organization. Its name, address, and logo appear on invoices, quotes, and client-facing communications.",
-      "currentDefault": "Current default: {{name}}",
+      "currentDefault": "Your company is currently {{name}}.",
       "yourCompanyBadge": "Your company",
       "table": {
         "name": "Name",

--- a/server/public/locales/es/msp/settings.json
+++ b/server/public/locales/es/msp/settings.json
@@ -53,9 +53,9 @@
       "saveDefaultTimezone": "Guardar zona horaria predeterminada"
     },
     "clients": {
-      "title": "Su empresa y clientes",
+      "title": "Su empresa",
       "help": "El cliente marcado como su empresa es su propia organización. Su nombre, dirección y logotipo aparecen en facturas, presupuestos y comunicaciones con los clientes.",
-      "currentDefault": "Predeterminado actual: {{name}}",
+      "currentDefault": "Actualmente su empresa es {{name}}.",
       "yourCompanyBadge": "Su empresa",
       "table": {
         "name": "Nombre",

--- a/server/public/locales/es/msp/settings.json
+++ b/server/public/locales/es/msp/settings.json
@@ -86,6 +86,7 @@
         "updateTimezone": "Error al actualizar la zona horaria",
         "selectClient": "Seleccione un cliente",
         "clientNotFound": "Cliente no encontrado",
+        "clientAlreadyAdded": "Ese cliente ya está en la lista",
         "addClient": "Error al agregar el cliente",
         "removeClient": "Error al eliminar el cliente",
         "setDefaultClient": "Error al establecer el cliente predeterminado",

--- a/server/public/locales/es/msp/settings.json
+++ b/server/public/locales/es/msp/settings.json
@@ -38,7 +38,7 @@
   },
   "general": {
     "title": "Configuración general",
-    "description": "Administre el nombre de su organización y el cliente predeterminado. El cliente predeterminado se utiliza con fines de configuración y representa a su MSP.",
+    "description": "Administre el nombre de su organización y elija qué registro de cliente representa a su propia empresa. Los datos de ese cliente aparecen en facturas, presupuestos y comunicaciones con los clientes.",
     "fields": {
       "organizationName": {
         "label": "Nombre de la organización"
@@ -53,14 +53,24 @@
       "saveDefaultTimezone": "Guardar zona horaria predeterminada"
     },
     "clients": {
-      "title": "Clientes",
+      "title": "Su empresa y clientes",
+      "help": "El cliente marcado como su empresa es su propia organización. Su nombre, dirección y logotipo aparecen en facturas, presupuestos y comunicaciones con los clientes.",
+      "currentDefault": "Predeterminado actual: {{name}}",
+      "yourCompanyBadge": "Su empresa",
       "table": {
         "name": "Nombre",
-        "default": "Predeterminado",
+        "default": "Su empresa (predeterminado)",
         "actions": "Acciones"
       },
       "placeholder": "Seleccione un cliente para agregar",
-      "addClient": "Agregar cliente"
+      "addClient": "Agregar cliente",
+      "confirmDialog": {
+        "title": "¿Cambiar su empresa?",
+        "message": "Esto cambiará su empresa de {{current}} a {{next}}. {{next}} representará a su propia organización en facturas, presupuestos y en los correos e invitaciones dirigidos a los clientes.",
+        "messageInitial": "Esto establecerá {{next}} como su empresa. {{next}} representará a su propia organización en facturas, presupuestos y en los correos e invitaciones dirigidos a los clientes.",
+        "confirm": "Cambiar empresa",
+        "cancel": "Cancelar"
+      }
     },
     "messages": {
       "success": {

--- a/server/public/locales/fr/msp/settings.json
+++ b/server/public/locales/fr/msp/settings.json
@@ -86,6 +86,7 @@
         "updateTimezone": "Échec de la mise à jour du fuseau horaire",
         "selectClient": "Veuillez sélectionner un client",
         "clientNotFound": "Client introuvable",
+        "clientAlreadyAdded": "Ce client figure déjà dans la liste",
         "addClient": "Échec de l'ajout du client",
         "removeClient": "Échec de la suppression du client",
         "setDefaultClient": "Échec de la définition du client par défaut",

--- a/server/public/locales/fr/msp/settings.json
+++ b/server/public/locales/fr/msp/settings.json
@@ -53,9 +53,9 @@
       "saveDefaultTimezone": "Enregistrer le fuseau horaire par défaut"
     },
     "clients": {
-      "title": "Votre entreprise et clients",
+      "title": "Votre entreprise",
       "help": "Le client marqué comme votre entreprise correspond à votre propre organisation. Son nom, son adresse et son logo apparaissent sur les factures, les devis et les communications adressées aux clients.",
-      "currentDefault": "Valeur par défaut actuelle : {{name}}",
+      "currentDefault": "Votre entreprise est actuellement {{name}}.",
       "yourCompanyBadge": "Votre entreprise",
       "table": {
         "name": "Nom",

--- a/server/public/locales/fr/msp/settings.json
+++ b/server/public/locales/fr/msp/settings.json
@@ -38,7 +38,7 @@
   },
   "general": {
     "title": "Paramètres généraux",
-    "description": "Gérez le nom de votre organisation et le client par défaut. Le client par défaut est utilisé à des fins de configuration et représente votre MSP.",
+    "description": "Gérez le nom de votre organisation et choisissez quelle fiche client représente votre propre entreprise. Les informations de ce client apparaissent sur les factures, les devis et les communications adressées aux clients.",
     "fields": {
       "organizationName": {
         "label": "Nom de l'organisation"
@@ -53,14 +53,24 @@
       "saveDefaultTimezone": "Enregistrer le fuseau horaire par défaut"
     },
     "clients": {
-      "title": "Clients",
+      "title": "Votre entreprise et clients",
+      "help": "Le client marqué comme votre entreprise correspond à votre propre organisation. Son nom, son adresse et son logo apparaissent sur les factures, les devis et les communications adressées aux clients.",
+      "currentDefault": "Valeur par défaut actuelle : {{name}}",
+      "yourCompanyBadge": "Votre entreprise",
       "table": {
         "name": "Nom",
-        "default": "Par défaut",
+        "default": "Votre entreprise (par défaut)",
         "actions": "Actions"
       },
       "placeholder": "Sélectionnez un client à ajouter",
-      "addClient": "Ajouter un client"
+      "addClient": "Ajouter un client",
+      "confirmDialog": {
+        "title": "Changer votre entreprise ?",
+        "message": "Cela remplacera votre entreprise {{current}} par {{next}}. {{next}} représentera votre propre organisation sur les factures, les devis ainsi que dans les e-mails et invitations envoyés aux clients.",
+        "messageInitial": "Cela définira {{next}} comme votre entreprise. {{next}} représentera votre propre organisation sur les factures, les devis ainsi que dans les e-mails et invitations envoyés aux clients.",
+        "confirm": "Changer d'entreprise",
+        "cancel": "Annuler"
+      }
     },
     "messages": {
       "success": {

--- a/server/public/locales/it/msp/settings.json
+++ b/server/public/locales/it/msp/settings.json
@@ -53,9 +53,9 @@
       "saveDefaultTimezone": "Salva fuso orario predefinito"
     },
     "clients": {
-      "title": "La Sua azienda e i clienti",
+      "title": "La Sua azienda",
       "help": "Il cliente contrassegnato come la Sua azienda rappresenta la Sua organizzazione. Nome, indirizzo e logo di questo cliente compaiono su fatture, preventivi e comunicazioni ai clienti.",
-      "currentDefault": "Predefinito attuale: {{name}}",
+      "currentDefault": "Attualmente la Sua azienda è {{name}}.",
       "yourCompanyBadge": "La Sua azienda",
       "table": {
         "name": "Nome",

--- a/server/public/locales/it/msp/settings.json
+++ b/server/public/locales/it/msp/settings.json
@@ -38,7 +38,7 @@
   },
   "general": {
     "title": "Impostazioni generali",
-    "description": "Gestisca il nome dell'organizzazione e il cliente predefinito. Il cliente predefinito viene utilizzato per scopi di configurazione e rappresenta il Suo MSP.",
+    "description": "Gestisca il nome dell'organizzazione e scelga quale scheda cliente rappresenta la Sua azienda. I dati di quel cliente compaiono su fatture, preventivi e comunicazioni ai clienti.",
     "fields": {
       "organizationName": {
         "label": "Nome dell'organizzazione"
@@ -53,14 +53,24 @@
       "saveDefaultTimezone": "Salva fuso orario predefinito"
     },
     "clients": {
-      "title": "Clienti",
+      "title": "La Sua azienda e i clienti",
+      "help": "Il cliente contrassegnato come la Sua azienda rappresenta la Sua organizzazione. Nome, indirizzo e logo di questo cliente compaiono su fatture, preventivi e comunicazioni ai clienti.",
+      "currentDefault": "Predefinito attuale: {{name}}",
+      "yourCompanyBadge": "La Sua azienda",
       "table": {
         "name": "Nome",
-        "default": "Predefinito",
+        "default": "La Sua azienda (predefinito)",
         "actions": "Azioni"
       },
       "placeholder": "Selezioni un cliente da aggiungere",
-      "addClient": "Aggiungi cliente"
+      "addClient": "Aggiungi cliente",
+      "confirmDialog": {
+        "title": "Modificare la Sua azienda?",
+        "message": "Questa operazione cambierà la Sua azienda da {{current}} a {{next}}. {{next}} rappresenterà la Sua organizzazione su fatture, preventivi ed e-mail e inviti destinati ai clienti.",
+        "messageInitial": "Questa operazione imposterà {{next}} come la Sua azienda. {{next}} rappresenterà la Sua organizzazione su fatture, preventivi ed e-mail e inviti destinati ai clienti.",
+        "confirm": "Modifica azienda",
+        "cancel": "Annulla"
+      }
     },
     "messages": {
       "success": {

--- a/server/public/locales/it/msp/settings.json
+++ b/server/public/locales/it/msp/settings.json
@@ -86,6 +86,7 @@
         "updateTimezone": "Impossibile aggiornare il fuso orario",
         "selectClient": "Selezioni un cliente",
         "clientNotFound": "Cliente non trovato",
+        "clientAlreadyAdded": "Questo cliente è già presente nell’elenco",
         "addClient": "Impossibile aggiungere il cliente",
         "removeClient": "Impossibile rimuovere il cliente",
         "setDefaultClient": "Impossibile impostare il cliente predefinito",

--- a/server/public/locales/nl/msp/settings.json
+++ b/server/public/locales/nl/msp/settings.json
@@ -86,6 +86,7 @@
         "updateTimezone": "Kan tijdzone niet bijwerken",
         "selectClient": "Selecteer een klant",
         "clientNotFound": "Klant niet gevonden",
+        "clientAlreadyAdded": "Die klant staat hier al in de lijst",
         "addClient": "Kan klant niet toevoegen",
         "removeClient": "Kan klant niet verwijderen",
         "setDefaultClient": "Kan standaardklant niet instellen",

--- a/server/public/locales/nl/msp/settings.json
+++ b/server/public/locales/nl/msp/settings.json
@@ -53,9 +53,9 @@
       "saveDefaultTimezone": "Standaard tijdzone opslaan"
     },
     "clients": {
-      "title": "Uw bedrijf & klanten",
+      "title": "Uw bedrijf",
       "help": "De klant die als uw bedrijf is gemarkeerd, is uw eigen organisatie. De naam, het adres en het logo van deze klant verschijnen op facturen, offertes en communicatie naar klanten.",
-      "currentDefault": "Huidige standaard: {{name}}",
+      "currentDefault": "Uw bedrijf is momenteel {{name}}.",
       "yourCompanyBadge": "Uw bedrijf",
       "table": {
         "name": "Naam",

--- a/server/public/locales/nl/msp/settings.json
+++ b/server/public/locales/nl/msp/settings.json
@@ -38,7 +38,7 @@
   },
   "general": {
     "title": "Algemene instellingen",
-    "description": "Beheer uw organisatienaam en standaardklant. De standaardklant wordt gebruikt voor configuratiedoeleinden en vertegenwoordigt uw MSP.",
+    "description": "Beheer uw organisatienaam en kies welke klantregistratie uw eigen bedrijf vertegenwoordigt. De gegevens van die klant verschijnen op facturen, offertes en communicatie naar klanten.",
     "fields": {
       "organizationName": {
         "label": "Organisatienaam"
@@ -53,14 +53,24 @@
       "saveDefaultTimezone": "Standaard tijdzone opslaan"
     },
     "clients": {
-      "title": "Klanten",
+      "title": "Uw bedrijf & klanten",
+      "help": "De klant die als uw bedrijf is gemarkeerd, is uw eigen organisatie. De naam, het adres en het logo van deze klant verschijnen op facturen, offertes en communicatie naar klanten.",
+      "currentDefault": "Huidige standaard: {{name}}",
+      "yourCompanyBadge": "Uw bedrijf",
       "table": {
         "name": "Naam",
-        "default": "Standaard",
+        "default": "Uw bedrijf (standaard)",
         "actions": "Acties"
       },
       "placeholder": "Selecteer een klant om toe te voegen",
-      "addClient": "Klant toevoegen"
+      "addClient": "Klant toevoegen",
+      "confirmDialog": {
+        "title": "Uw bedrijf wijzigen?",
+        "message": "Hiermee wijzigt u uw bedrijf van {{current}} naar {{next}}. {{next}} vertegenwoordigt dan uw eigen organisatie op facturen, offertes en in e-mails en uitnodigingen aan klanten.",
+        "messageInitial": "Hiermee stelt u {{next}} in als uw bedrijf. {{next}} vertegenwoordigt dan uw eigen organisatie op facturen, offertes en in e-mails en uitnodigingen aan klanten.",
+        "confirm": "Bedrijf wijzigen",
+        "cancel": "Annuleren"
+      }
     },
     "messages": {
       "success": {

--- a/server/public/locales/pl/msp/settings.json
+++ b/server/public/locales/pl/msp/settings.json
@@ -55,9 +55,9 @@
       "saveDefaultTimezone": "Zapisz domyślną strefę czasową"
     },
     "clients": {
-      "title": "Państwa firma i klienci",
+      "title": "Państwa firma",
       "help": "Klient oznaczony jako Państwa firma reprezentuje Państwa własną organizację. Jego nazwa, adres i logo pojawiają się na fakturach, ofertach oraz w komunikacji z klientami.",
-      "currentDefault": "Bieżący domyślny: {{name}}",
+      "currentDefault": "Państwa firmą jest obecnie {{name}}.",
       "yourCompanyBadge": "Państwa firma",
       "table": {
         "name": "Nazwa",

--- a/server/public/locales/pl/msp/settings.json
+++ b/server/public/locales/pl/msp/settings.json
@@ -88,6 +88,7 @@
         "updateTimezone": "Nie udało się zaktualizować strefy czasowej",
         "selectClient": "Proszę wybrać klienta",
         "clientNotFound": "Nie znaleziono klienta",
+        "clientAlreadyAdded": "Ten klient już znajduje się na liście",
         "addClient": "Nie udało się dodać klienta",
         "removeClient": "Nie udało się usunąć klienta",
         "setDefaultClient": "Nie udało się ustawić domyślnego klienta",

--- a/server/public/locales/pl/msp/settings.json
+++ b/server/public/locales/pl/msp/settings.json
@@ -40,7 +40,7 @@
   },
   "general": {
     "title": "Ustawienia ogólne",
-    "description": "Zarządzanie nazwą organizacji i domyślnym klientem. Domyślny klient jest używany do celów konfiguracyjnych i reprezentuje Państwa MSP.",
+    "description": "Zarządzanie nazwą organizacji i wybór rekordu klienta, który reprezentuje Państwa własną firmę. Dane tego klienta pojawiają się na fakturach, ofertach oraz w komunikacji z klientami.",
     "fields": {
       "organizationName": {
         "label": "Nazwa organizacji"
@@ -55,14 +55,24 @@
       "saveDefaultTimezone": "Zapisz domyślną strefę czasową"
     },
     "clients": {
-      "title": "Klienci",
+      "title": "Państwa firma i klienci",
+      "help": "Klient oznaczony jako Państwa firma reprezentuje Państwa własną organizację. Jego nazwa, adres i logo pojawiają się na fakturach, ofertach oraz w komunikacji z klientami.",
+      "currentDefault": "Bieżący domyślny: {{name}}",
+      "yourCompanyBadge": "Państwa firma",
       "table": {
         "name": "Nazwa",
-        "default": "Domyślny",
+        "default": "Państwa firma (domyślny)",
         "actions": "Akcje"
       },
       "placeholder": "Wybierz klienta do dodania",
-      "addClient": "Dodaj klienta"
+      "addClient": "Dodaj klienta",
+      "confirmDialog": {
+        "title": "Zmienić Państwa firmę?",
+        "message": "Spowoduje to zmianę Państwa firmy z {{current}} na {{next}}. {{next}} będzie reprezentować Państwa własną organizację na fakturach, ofertach oraz w wiadomościach e-mail i zaproszeniach kierowanych do klientów.",
+        "messageInitial": "Spowoduje to ustawienie {{next}} jako Państwa firmy. {{next}} będzie reprezentować Państwa własną organizację na fakturach, ofertach oraz w wiadomościach e-mail i zaproszeniach kierowanych do klientów.",
+        "confirm": "Zmień firmę",
+        "cancel": "Anuluj"
+      }
     },
     "messages": {
       "success": {

--- a/server/public/locales/pt/msp/settings.json
+++ b/server/public/locales/pt/msp/settings.json
@@ -38,7 +38,7 @@
   },
   "general": {
     "title": "Configurações Gerais",
-    "description": "Gerencie o nome da sua organização e o cliente padrão. O cliente padrão é usado para fins de configuração e representa seu MSP.",
+    "description": "Gerencie o nome da sua organização e escolha qual registro de cliente representa sua própria empresa. Os dados desse cliente aparecem em faturas, orçamentos e comunicações com clientes.",
     "fields": {
       "organizationName": {
         "label": "Nome da organização"
@@ -53,14 +53,24 @@
       "saveDefaultTimezone": "Salvar fuso horário padrão"
     },
     "clients": {
-      "title": "Clientes",
+      "title": "Sua empresa e clientes",
+      "help": "O cliente marcado como sua empresa representa sua própria organização. O nome, o endereço e o logotipo desse cliente aparecem em faturas, orçamentos e comunicações com clientes.",
+      "currentDefault": "Padrão atual: {{name}}",
+      "yourCompanyBadge": "Sua empresa",
       "table": {
         "name": "Nome",
-        "default": "Padrão",
+        "default": "Sua empresa (padrão)",
         "actions": "Ações"
       },
       "placeholder": "Selecione um cliente para adicionar",
-      "addClient": "Adicionar cliente"
+      "addClient": "Adicionar cliente",
+      "confirmDialog": {
+        "title": "Alterar sua empresa?",
+        "message": "Isso alterará sua empresa de {{current}} para {{next}}. {{next}} passará a representar sua própria organização em faturas, orçamentos e em e-mails e convites enviados a clientes.",
+        "messageInitial": "Isso definirá {{next}} como sua empresa. {{next}} passará a representar sua própria organização em faturas, orçamentos e em e-mails e convites enviados a clientes.",
+        "confirm": "Alterar empresa",
+        "cancel": "Cancelar"
+      }
     },
     "messages": {
       "success": {

--- a/server/public/locales/pt/msp/settings.json
+++ b/server/public/locales/pt/msp/settings.json
@@ -53,9 +53,9 @@
       "saveDefaultTimezone": "Salvar fuso horário padrão"
     },
     "clients": {
-      "title": "Sua empresa e clientes",
+      "title": "Sua empresa",
       "help": "O cliente marcado como sua empresa representa sua própria organização. O nome, o endereço e o logotipo desse cliente aparecem em faturas, orçamentos e comunicações com clientes.",
-      "currentDefault": "Padrão atual: {{name}}",
+      "currentDefault": "Atualmente, sua empresa é {{name}}.",
       "yourCompanyBadge": "Sua empresa",
       "table": {
         "name": "Nome",

--- a/server/public/locales/pt/msp/settings.json
+++ b/server/public/locales/pt/msp/settings.json
@@ -86,6 +86,7 @@
         "updateTimezone": "Falha ao atualizar o fuso horário",
         "selectClient": "Selecione um cliente",
         "clientNotFound": "Cliente não encontrado",
+        "clientAlreadyAdded": "Esse cliente já está na lista",
         "addClient": "Falha ao adicionar cliente",
         "removeClient": "Falha ao remover cliente",
         "setDefaultClient": "Falha ao definir o cliente padrão",

--- a/server/public/locales/xx/msp/settings.json
+++ b/server/public/locales/xx/msp/settings.json
@@ -54,13 +54,23 @@
     },
     "clients": {
       "title": "11111",
+      "help": "11111",
+      "currentDefault": "11111 {{name}} 11111",
+      "yourCompanyBadge": "11111",
       "table": {
         "name": "11111",
         "default": "11111",
         "actions": "11111"
       },
       "placeholder": "11111",
-      "addClient": "11111"
+      "addClient": "11111",
+      "confirmDialog": {
+        "title": "11111",
+        "message": "11111 {{current}} 11111 {{next}} 11111 {{next}} 11111",
+        "messageInitial": "11111 {{next}} 11111 {{next}} 11111",
+        "confirm": "11111",
+        "cancel": "11111"
+      }
     },
     "messages": {
       "success": {

--- a/server/public/locales/xx/msp/settings.json
+++ b/server/public/locales/xx/msp/settings.json
@@ -86,6 +86,7 @@
         "updateTimezone": "11111",
         "selectClient": "11111",
         "clientNotFound": "11111",
+        "clientAlreadyAdded": "11111",
         "addClient": "11111",
         "removeClient": "11111",
         "setDefaultClient": "11111",

--- a/server/public/locales/yy/msp/settings.json
+++ b/server/public/locales/yy/msp/settings.json
@@ -86,6 +86,7 @@
         "updateTimezone": "55555",
         "selectClient": "55555",
         "clientNotFound": "55555",
+        "clientAlreadyAdded": "55555",
         "addClient": "55555",
         "removeClient": "55555",
         "setDefaultClient": "55555",

--- a/server/public/locales/yy/msp/settings.json
+++ b/server/public/locales/yy/msp/settings.json
@@ -54,13 +54,23 @@
     },
     "clients": {
       "title": "55555",
+      "help": "55555",
+      "currentDefault": "55555 {{name}} 55555",
+      "yourCompanyBadge": "55555",
       "table": {
         "name": "55555",
         "default": "55555",
         "actions": "55555"
       },
       "placeholder": "55555",
-      "addClient": "55555"
+      "addClient": "55555",
+      "confirmDialog": {
+        "title": "55555",
+        "message": "55555 {{current}} 55555 {{next}} 55555 {{next}} 55555",
+        "messageInitial": "55555 {{next}} 55555 {{next}} 55555",
+        "confirm": "55555",
+        "cancel": "55555"
+      }
     },
     "messages": {
       "success": {

--- a/server/src/components/settings/general/GeneralSettings.tsx
+++ b/server/src/components/settings/general/GeneralSettings.tsx
@@ -7,6 +7,8 @@ import { Input } from "@alga-psa/ui/components/Input";
 import { Button } from "@alga-psa/ui/components/Button";
 import { Label } from "@alga-psa/ui/components/Label";
 import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from "@alga-psa/ui/components/Table";
+import { Badge } from "@alga-psa/ui/components/Badge";
+import { ConfirmationDialog } from "@alga-psa/ui/components/ConfirmationDialog";
 import { Plus, Trash } from 'lucide-react';
 import toast from 'react-hot-toast';
 import {
@@ -38,6 +40,9 @@ const GeneralSettings = () => {
   const [allClients, setAllClients] = React.useState<IClient[]>([]);
   const [filterState, setFilterState] = React.useState<'all' | 'active' | 'inactive'>('active');
   const [clientTypeFilter, setClientTypeFilter] = React.useState<'all' | 'company' | 'individual'>('all');
+  const [pendingDefaultClient, setPendingDefaultClient] = React.useState<{ id: string; name: string } | null>(null);
+
+  const defaultClient = clients.find(c => c.isDefault) ?? null;
 
   const loadTenantData = async () => {
     try {
@@ -190,7 +195,15 @@ const GeneralSettings = () => {
           </div>
 
         <div className="space-y-4">
-          <h3 className="text-lg font-semibold">{t('general.clients.title')}</h3>
+          <div className="space-y-1">
+            <h3 className="text-lg font-semibold">{t('general.clients.title')}</h3>
+            <p className="text-sm text-muted-foreground">{t('general.clients.help')}</p>
+          </div>
+          {defaultClient && (
+            <p className="text-sm">
+              {t('general.clients.currentDefault', { name: defaultClient.name })}
+            </p>
+          )}
           <Table>
             <TableHeader>
               <TableRow>
@@ -203,8 +216,11 @@ const GeneralSettings = () => {
               {clients.map((client) => (
                 <TableRow key={client.id}>
                   <TableCell>
-                    <label htmlFor={`default-client-radio-${client.id}`} className="cursor-pointer">
+                    <label htmlFor={`default-client-radio-${client.id}`} className="cursor-pointer inline-flex items-center gap-2">
                       {client.name}
+                      {client.isDefault && (
+                        <Badge variant="success" size="sm">{t('general.clients.yourCompanyBadge')}</Badge>
+                      )}
                     </label>
                   </TableCell>
                   <TableCell>
@@ -213,7 +229,7 @@ const GeneralSettings = () => {
                       name="default-client"
                       id={`default-client-radio-${client.id}`}
                       checked={client.isDefault}
-                      onChange={() => handleSetDefaultClient(client.id)}
+                      onChange={() => setPendingDefaultClient({ id: client.id, name: client.name })}
                       className="h-4 w-4 border-gray-300 text-primary-500 focus:ring-2 focus:ring-primary-500 focus:ring-offset-0 focus-visible:outline-none focus:outline-none cursor-pointer"
                       style={{
                         accentColor: 'rgb(var(--color-primary-500))',
@@ -258,6 +274,28 @@ const GeneralSettings = () => {
             </Button>
           </div>
         </div>
+
+        <ConfirmationDialog
+          id="change-default-client-dialog"
+          isOpen={pendingDefaultClient !== null}
+          onClose={() => setPendingDefaultClient(null)}
+          onConfirm={async () => {
+            if (!pendingDefaultClient) return;
+            await handleSetDefaultClient(pendingDefaultClient.id);
+            setPendingDefaultClient(null);
+          }}
+          title={t('general.clients.confirmDialog.title')}
+          message={defaultClient
+            ? t('general.clients.confirmDialog.message', {
+                current: defaultClient.name,
+                next: pendingDefaultClient?.name ?? ''
+              })
+            : t('general.clients.confirmDialog.messageInitial', {
+                next: pendingDefaultClient?.name ?? ''
+              })}
+          confirmLabel={t('general.clients.confirmDialog.confirm')}
+          cancelLabel={t('general.clients.confirmDialog.cancel')}
+        />
       </CardContent>
     </Card>
   );

--- a/server/src/components/settings/general/GeneralSettings.tsx
+++ b/server/src/components/settings/general/GeneralSettings.tsx
@@ -43,6 +43,7 @@ const GeneralSettings = () => {
   const [pendingDefaultClient, setPendingDefaultClient] = React.useState<{ id: string; name: string } | null>(null);
 
   const defaultClient = clients.find(c => c.isDefault) ?? null;
+  const selectableClients = allClients.filter(c => !clients.some(tc => tc.id === c.client_id));
 
   const loadTenantData = async () => {
     try {
@@ -97,6 +98,12 @@ const GeneralSettings = () => {
       const clientToAdd = allClients.find(c => c.client_id === selectedClientId);
       if (!clientToAdd) {
         throw new Error(t('general.messages.error.clientNotFound'));
+      }
+
+      if (clients.some(c => c.id === selectedClientId)) {
+        toast.error(t('general.messages.error.clientAlreadyAdded'));
+        setSelectedClientId(null);
+        return;
       }
 
       const newClient = {
@@ -254,7 +261,7 @@ const GeneralSettings = () => {
           <div className="space-y-4">
             <ClientPicker
               id="tenant-client-picker"
-              clients={allClients}
+              clients={selectableClients}
               onSelect={setSelectedClientId}
               selectedClientId={selectedClientId}
               filterState={filterState}

--- a/server/src/test/unit/components/settings/GeneralSettings.defaultClientConfirmation.test.tsx
+++ b/server/src/test/unit/components/settings/GeneralSettings.defaultClientConfirmation.test.tsx
@@ -1,0 +1,159 @@
+/**
+ * @vitest-environment jsdom
+ */
+import fs from 'fs';
+import path from 'path';
+import React from 'react';
+import { render, screen, cleanup, waitFor, fireEvent } from '@testing-library/react';
+import { vi, describe, it, expect, beforeEach, afterEach } from 'vitest';
+
+const enSettings = JSON.parse(
+  fs.readFileSync(
+    path.join(process.cwd(), 'public/locales/en/msp/settings.json'),
+    'utf8'
+  )
+);
+
+// Resolve against the real en bundle so the test also proves the keys exist.
+const translate = (key: string, options?: Record<string, unknown>) => {
+  const template = key.split('.').reduce<any>((acc, part) => acc?.[part], enSettings);
+  if (typeof template !== 'string') {
+    throw new Error(`Missing en msp/settings key: ${key}`);
+  }
+  return template.replace(/\{\{(\w+)\}\}/g, (match, name: string) =>
+    options?.[name] === undefined ? match : String(options[name])
+  );
+};
+const stableI18n = { language: 'en' };
+const stableTranslation = { t: translate, i18n: stableI18n };
+
+vi.mock('@alga-psa/ui/lib/i18n/client', () => ({
+  useTranslation: () => stableTranslation,
+  useFormatters: () => ({}),
+  useI18n: () => ({ locale: 'en', ...stableTranslation }),
+  useOptionalI18n: () => ({ locale: 'en', ...stableTranslation }),
+  detectClientLocale: () => 'en',
+  I18nProvider: ({ children }: { children: React.ReactNode }) => children,
+}));
+
+const setDefaultClient = vi.fn().mockResolvedValue(undefined);
+
+vi.mock('@alga-psa/tenancy/actions/coreTenantActions', () => ({
+  getTenantDetails: vi.fn().mockResolvedValue({
+    client_name: 'Acme MSP',
+    clients: [
+      { client_id: 'client-1', client_name: 'Acme MSP', is_default: true },
+      { client_id: 'client-2', client_name: 'Globex', is_default: false },
+    ],
+  }),
+  updateTenantName: vi.fn().mockResolvedValue(undefined),
+  addClientToTenant: vi.fn().mockResolvedValue(undefined),
+  removeClientFromTenant: vi.fn().mockResolvedValue(undefined),
+  setDefaultClient: (...args: unknown[]) => setDefaultClient(...args),
+}));
+
+vi.mock('@alga-psa/tenancy/actions/tenant-settings-actions/tenantSettingsActions', () => ({
+  getTenantTimezoneAuth: vi.fn().mockResolvedValue('UTC'),
+  setTenantTimezone: vi.fn().mockResolvedValue(undefined),
+}));
+
+vi.mock('@alga-psa/clients/actions/queryActions', () => ({
+  getAllClients: vi.fn().mockResolvedValue([]),
+}));
+
+vi.mock('@alga-psa/ui/components/ClientPicker', () => ({
+  ClientPicker: () => <div data-testid="client-picker" />,
+}));
+
+vi.mock('@alga-psa/ui/components/TimezonePicker', () => ({
+  default: () => <div data-testid="timezone-picker" />,
+}));
+
+vi.mock('react-hot-toast', () => {
+  const toast = Object.assign(vi.fn(), {
+    success: vi.fn(),
+    error: vi.fn(),
+    custom: vi.fn(),
+    dismiss: vi.fn(),
+    loading: vi.fn(),
+  });
+  return { default: toast, toast };
+});
+
+import GeneralSettings from '@/components/settings/general/GeneralSettings';
+
+const radioFor = (clientId: string) =>
+  document.getElementById(`default-client-radio-${clientId}`) as HTMLInputElement;
+
+describe('GeneralSettings default client confirmation', () => {
+  beforeEach(() => {
+    setDefaultClient.mockClear();
+  });
+
+  afterEach(() => {
+    cleanup();
+  });
+
+  it('asks for confirmation before changing the default client', async () => {
+    render(<GeneralSettings />);
+
+    await waitFor(() => expect(radioFor('client-2')).toBeTruthy());
+    expect(radioFor('client-1').checked).toBe(true);
+    expect(screen.getByText(enSettings.general.clients.help)).toBeTruthy();
+    expect(screen.getByText(enSettings.general.clients.yourCompanyBadge)).toBeTruthy();
+    expect(
+      screen.getByText(translate('general.clients.currentDefault', { name: 'Acme MSP' }))
+    ).toBeTruthy();
+
+    fireEvent.click(radioFor('client-2'));
+
+    await screen.findByText(enSettings.general.clients.confirmDialog.title);
+    expect(
+      screen.getAllByText(
+        translate('general.clients.confirmDialog.message', {
+          current: 'Acme MSP',
+          next: 'Globex',
+        })
+      ).length
+    ).toBeGreaterThan(0);
+    expect(setDefaultClient).not.toHaveBeenCalled();
+    expect(radioFor('client-1').checked).toBe(true);
+  });
+
+  it('keeps the previous default when the dialog is cancelled', async () => {
+    render(<GeneralSettings />);
+
+    await waitFor(() => expect(radioFor('client-2')).toBeTruthy());
+    fireEvent.click(radioFor('client-2'));
+
+    const cancelButton = await screen.findByText(
+      enSettings.general.clients.confirmDialog.cancel
+    );
+    fireEvent.click(cancelButton);
+
+    await waitFor(() =>
+      expect(
+        screen.queryByText(enSettings.general.clients.confirmDialog.title)
+      ).toBeNull()
+    );
+    expect(setDefaultClient).not.toHaveBeenCalled();
+    expect(radioFor('client-1').checked).toBe(true);
+    expect(radioFor('client-2').checked).toBe(false);
+  });
+
+  it('applies the new default once confirmed', async () => {
+    render(<GeneralSettings />);
+
+    await waitFor(() => expect(radioFor('client-2')).toBeTruthy());
+    fireEvent.click(radioFor('client-2'));
+
+    const confirmButton = await screen.findByText(
+      enSettings.general.clients.confirmDialog.confirm
+    );
+    fireEvent.click(confirmButton);
+
+    await waitFor(() => expect(setDefaultClient).toHaveBeenCalledWith('client-2'));
+    await waitFor(() => expect(radioFor('client-2').checked).toBe(true));
+    expect(radioFor('client-1').checked).toBe(false);
+  });
+});

--- a/server/src/test/unit/components/settings/GeneralSettings.defaultClientConfirmation.test.tsx
+++ b/server/src/test/unit/components/settings/GeneralSettings.defaultClientConfirmation.test.tsx
@@ -58,11 +58,20 @@ vi.mock('@alga-psa/tenancy/actions/tenant-settings-actions/tenantSettingsActions
 }));
 
 vi.mock('@alga-psa/clients/actions/queryActions', () => ({
-  getAllClients: vi.fn().mockResolvedValue([]),
+  getAllClients: vi.fn().mockResolvedValue([
+    { client_id: 'client-1', client_name: 'Acme MSP' },
+    { client_id: 'client-2', client_name: 'Globex' },
+    { client_id: 'client-3', client_name: 'Initech' },
+  ]),
 }));
 
+const clientPickerProps = vi.fn();
+
 vi.mock('@alga-psa/ui/components/ClientPicker', () => ({
-  ClientPicker: () => <div data-testid="client-picker" />,
+  ClientPicker: (props: { clients: { client_id: string }[] }) => {
+    clientPickerProps(props);
+    return <div data-testid="client-picker" />;
+  },
 }));
 
 vi.mock('@alga-psa/ui/components/TimezonePicker', () => ({
@@ -88,6 +97,7 @@ const radioFor = (clientId: string) =>
 describe('GeneralSettings default client confirmation', () => {
   beforeEach(() => {
     setDefaultClient.mockClear();
+    clientPickerProps.mockClear();
   });
 
   afterEach(() => {
@@ -155,5 +165,17 @@ describe('GeneralSettings default client confirmation', () => {
     await waitFor(() => expect(setDefaultClient).toHaveBeenCalledWith('client-2'));
     await waitFor(() => expect(radioFor('client-2').checked).toBe(true));
     expect(radioFor('client-1').checked).toBe(false);
+  });
+
+  it('does not offer clients that are already listed', async () => {
+    render(<GeneralSettings />);
+
+    await waitFor(() => expect(radioFor('client-2')).toBeTruthy());
+    await waitFor(() => {
+      const lastCall = clientPickerProps.mock.calls.at(-1)?.[0];
+      expect(lastCall.clients.map((c: { client_id: string }) => c.client_id)).toEqual([
+        'client-3',
+      ]);
+    });
   });
 });


### PR DESCRIPTION
## Summary
The "General Settings" client list previously let a user switch the tenant's default client with a single unconfirmed radio-button click, and the UI used unexplained "default" jargon that didn't convey what the setting actually controls. This change adds a confirmation dialog before applying the switch, clarifies the copy to explain that this client represents the MSP's own company on invoices/quotes/communications, prevents adding a client that's already in the list, and makes re-adding a previously removed client idempotent at the data layer.

## Changes
- **Settings UI** (`GeneralSettings.tsx`): selecting a different default client now opens a `ConfirmationDialog` summarizing the change (current → new client) before it's applied; the current default is now also shown as a badge/label near the table. Adding a client already present in the tenant's list now shows an error toast instead of silently duplicating it, and the client picker excludes clients already added.
- **Copy/i18n**: reworded the "default client" concept as "Your Company" throughout the General Settings section (title, help text, table header, badge, new confirmation dialog strings, new `clientAlreadyAdded` error) across all locale files (`de`, `en`, `es`, `fr`, `it`, `nl`, `pl`, `pt`, `xx`, `yy`).
- **Tenant actions** (`coreTenantActions.ts`): `addClientToTenant` now upserts on the `(tenant, client_id)` primary key, clearing `deleted_at` on conflict, so re-adding a soft-deleted client succeeds instead of throwing a primary-key violation.

## Testing
- Added `GeneralSettings.defaultClientConfirmation.test.tsx`, covering the confirmation dialog flow for changing the default client (confirm and cancel paths) and the duplicate-add prevention path.
