### PR TITLE
Backfill missing Portuguese (and other locale) email/notification templates

### DIFF
--- a/server/migrations/20260730093000_add_missing_locale_email_and_internal_templates.cjs
+++ b/server/migrations/20260730093000_add_missing_locale_email_and_internal_templates.cjs
@@ -1,247 +1,32 @@
 'use strict';
 
 /**
- * Ship the newly added translations for the locale-gapped templates and the
- * missing pt/pl rows for the inline-defined ones.
+ * Ship the newly added translations for the locale-gapped templates.
  *
- * The opportunity email digest and the internal opportunity templates only had
- * English copy; they now carry every supported locale. The RMM alert and the
- * two inventory internal templates were defined inline in their own migrations
- * missing pt (and the RMM templates were English-only, so fr/es/de/nl/it/pl
- * are missing there too). This migration upserts all of those rows, merging on
+ * The opportunity digest templates only had English copy, and the RMM alert /
+ * inventory templates were defined inline in their own migrations without pt
+ * (the RMM ones were English-only). All of them now live in
+ * utils/templates as the single source of truth and carry every supported
+ * locale. This migration re-upserts them from those modules, merging on
  * (name, language_code), so it is idempotent and a no-op once every row
  * matches the source of truth.
  */
 
-const { upsertEmailTemplate } = require('./utils/templates/_shared/upsertEmailTemplates.cjs');
+const { upsertEmailTemplates } = require('./utils/templates/_shared/upsertEmailTemplates.cjs');
 const { upsertInternalTemplates } = require('./utils/templates/_shared/upsertInternalTemplates.cjs');
 const { getTemplate: opportunityWeeklyDigest } = require('./utils/templates/email/opportunities/opportunityWeeklyDigest.cjs');
+const { getTemplate: rmmAlertTriggered } = require('./utils/templates/email/rmm/rmmAlertTriggered.cjs');
 const { TEMPLATES: opportunityInternalTemplates } = require('./utils/templates/internal/opportunities.cjs');
-
-const RMM_ALERT_EMAIL_TRANSLATIONS = [
-  {
-    language: 'fr',
-    subject: 'Alerte RMM ({{severity}}) : {{deviceName}}',
-    htmlContent: `
-      <h2>Alerte RMM</h2>
-      <p>Une alerte de {{provider}} correspond à une règle qui vous notifie.</p>
-      <div class="details">
-        <p><strong>Gravité :</strong> {{severity}}</p>
-        <p><strong>Appareil :</strong> {{deviceName}}</p>
-        <p><strong>Message :</strong> {{message}}</p>
-        <p><strong>Ticket :</strong> {{ticketNumber}}</p>
-      </div>
-      <p><a href="{{url}}">Voir dans Alga PSA</a></p>
-    `,
-    textContent: 'Alerte RMM ({{severity}}) sur {{deviceName}} : {{message}}\nTicket : {{ticketNumber}}\n{{url}}',
-  },
-  {
-    language: 'es',
-    subject: 'Alerta de RMM ({{severity}}): {{deviceName}}',
-    htmlContent: `
-      <h2>Alerta de RMM</h2>
-      <p>Una alerta de {{provider}} coincide con una regla que te notifica.</p>
-      <div class="details">
-        <p><strong>Severidad:</strong> {{severity}}</p>
-        <p><strong>Dispositivo:</strong> {{deviceName}}</p>
-        <p><strong>Mensaje:</strong> {{message}}</p>
-        <p><strong>Ticket:</strong> {{ticketNumber}}</p>
-      </div>
-      <p><a href="{{url}}">Ver en Alga PSA</a></p>
-    `,
-    textContent: 'Alerta de RMM ({{severity}}) en {{deviceName}}: {{message}}\nTicket: {{ticketNumber}}\n{{url}}',
-  },
-  {
-    language: 'de',
-    subject: 'RMM-Warnung ({{severity}}): {{deviceName}}',
-    htmlContent: `
-      <h2>RMM-Warnung</h2>
-      <p>Eine Warnung von {{provider}} entspricht einer Regel, die Sie benachrichtigt.</p>
-      <div class="details">
-        <p><strong>Schweregrad:</strong> {{severity}}</p>
-        <p><strong>Gerät:</strong> {{deviceName}}</p>
-        <p><strong>Nachricht:</strong> {{message}}</p>
-        <p><strong>Ticket:</strong> {{ticketNumber}}</p>
-      </div>
-      <p><a href="{{url}}">In Alga PSA ansehen</a></p>
-    `,
-    textContent: 'RMM-Warnung ({{severity}}) auf {{deviceName}}: {{message}}\nTicket: {{ticketNumber}}\n{{url}}',
-  },
-  {
-    language: 'nl',
-    subject: 'RMM-melding ({{severity}}): {{deviceName}}',
-    htmlContent: `
-      <h2>RMM-melding</h2>
-      <p>Een melding van {{provider}} komt overeen met een regel die jou waarschuwt.</p>
-      <div class="details">
-        <p><strong>Ernst:</strong> {{severity}}</p>
-        <p><strong>Apparaat:</strong> {{deviceName}}</p>
-        <p><strong>Bericht:</strong> {{message}}</p>
-        <p><strong>Ticket:</strong> {{ticketNumber}}</p>
-      </div>
-      <p><a href="{{url}}">Bekijk in Alga PSA</a></p>
-    `,
-    textContent: 'RMM-melding ({{severity}}) op {{deviceName}}: {{message}}\nTicket: {{ticketNumber}}\n{{url}}',
-  },
-  {
-    language: 'it',
-    subject: 'Avviso RMM ({{severity}}): {{deviceName}}',
-    htmlContent: `
-      <h2>Avviso RMM</h2>
-      <p>Un avviso da {{provider}} corrisponde a una regola che ti avvisa.</p>
-      <div class="details">
-        <p><strong>Gravità:</strong> {{severity}}</p>
-        <p><strong>Dispositivo:</strong> {{deviceName}}</p>
-        <p><strong>Messaggio:</strong> {{message}}</p>
-        <p><strong>Ticket:</strong> {{ticketNumber}}</p>
-      </div>
-      <p><a href="{{url}}">Visualizza in Alga PSA</a></p>
-    `,
-    textContent: 'Avviso RMM ({{severity}}) su {{deviceName}}: {{message}}\nTicket: {{ticketNumber}}\n{{url}}',
-  },
-  {
-    language: 'pl',
-    subject: 'Alert RMM ({{severity}}): {{deviceName}}',
-    htmlContent: `
-      <h2>Alert RMM</h2>
-      <p>Alert z {{provider}} pasuje do reguły, która Cię powiadamia.</p>
-      <div class="details">
-        <p><strong>Ważność:</strong> {{severity}}</p>
-        <p><strong>Urządzenie:</strong> {{deviceName}}</p>
-        <p><strong>Wiadomość:</strong> {{message}}</p>
-        <p><strong>Zgłoszenie:</strong> {{ticketNumber}}</p>
-      </div>
-      <p><a href="{{url}}">Zobacz w Alga PSA</a></p>
-    `,
-    textContent: 'Alert RMM ({{severity}}) na {{deviceName}}: {{message}}\nZgłoszenie: {{ticketNumber}}\n{{url}}',
-  },
-  {
-    language: 'pt',
-    subject: 'Alerta de RMM ({{severity}}): {{deviceName}}',
-    htmlContent: `
-      <h2>Alerta de RMM</h2>
-      <p>Um alerta de {{provider}} correspondeu a uma regra que o notifica.</p>
-      <div class="details">
-        <p><strong>Severidade:</strong> {{severity}}</p>
-        <p><strong>Dispositivo:</strong> {{deviceName}}</p>
-        <p><strong>Mensagem:</strong> {{message}}</p>
-        <p><strong>Ticket:</strong> {{ticketNumber}}</p>
-      </div>
-      <p><a href="{{url}}">Ver no Alga PSA</a></p>
-    `,
-    textContent: 'Alerta de RMM ({{severity}}) em {{deviceName}}: {{message}}\nTicket: {{ticketNumber}}\n{{url}}',
-  },
-];
-
-const INVENTORY_INTERNAL_TRANSLATIONS = {
-  'inventory-low-stock': {
-    pl: {
-      title: 'Niski stan magazynowy w {{locationName}}',
-      message: '{{productCount}} produkt(ów) w {{locationName}} osiągnęło lub spadło poniżej punktu zamawiania: {{summary}}',
-    },
-    pt: {
-      title: 'Estoque baixo em {{locationName}}',
-      message: '{{productCount}} produto(s) em {{locationName}} estão no ponto de reposição ou abaixo dele: {{summary}}',
-    },
-  },
-  'inventory-po-received': {
-    pl: {
-      title: 'Zamówienie zakupu {{poNumber}} odebrane',
-      message: 'Odebrano {{receivedLineCount}} pozycję(i) od {{vendorName}}.',
-    },
-    pt: {
-      title: 'Pedido de compra {{poNumber}} recebido',
-      message: '{{receivedLineCount}} linha(s) recebida(s) de {{vendorName}}.',
-    },
-  },
-};
-
-const RMM_ALERT_INTERNAL_TRANSLATIONS = {
-  fr: {
-    title: 'Alerte RMM ({{severity}}) : {{deviceName}}',
-    message: '{{message}}',
-  },
-  es: {
-    title: 'Alerta de RMM ({{severity}}): {{deviceName}}',
-    message: '{{message}}',
-  },
-  de: {
-    title: 'RMM-Warnung ({{severity}}): {{deviceName}}',
-    message: '{{message}}',
-  },
-  nl: {
-    title: 'RMM-melding ({{severity}}): {{deviceName}}',
-    message: '{{message}}',
-  },
-  it: {
-    title: 'Avviso RMM ({{severity}}): {{deviceName}}',
-    message: '{{message}}',
-  },
-  pl: {
-    title: 'Alert RMM ({{severity}}): {{deviceName}}',
-    message: '{{message}}',
-  },
-  pt: {
-    title: 'Alerta de RMM ({{severity}}): {{deviceName}}',
-    message: '{{message}}',
-  },
-};
-
-async function upsertRmmAlertEmailTranslations(knex) {
-  const subtype = await knex('notification_subtypes').where({ name: 'RMM Alert Triggered' }).first();
-  if (!subtype) {
-    throw new Error("Notification subtype 'RMM Alert Triggered' not found for template 'rmm-alert-triggered'");
-  }
-  const now = new Date();
-  const rows = RMM_ALERT_EMAIL_TRANSLATIONS.map((t) => ({
-    name: 'rmm-alert-triggered',
-    language_code: t.language,
-    subject: t.subject,
-    html_content: t.htmlContent,
-    text_content: t.textContent,
-    notification_subtype_id: subtype.id,
-    updated_at: now,
-  }));
-  await knex('system_email_templates')
-    .insert(rows)
-    .onConflict(['name', 'language_code'])
-    .merge(['subject', 'html_content', 'text_content', 'notification_subtype_id', 'updated_at']);
-}
-
-async function upsertInlineInternalTranslations(knex) {
-  const now = new Date();
-  const specs = [
-    { name: 'inventory-low-stock', subtypeName: 'inventory-low-stock', translations: INVENTORY_INTERNAL_TRANSLATIONS['inventory-low-stock'] },
-    { name: 'inventory-po-received', subtypeName: 'inventory-po-received', translations: INVENTORY_INTERNAL_TRANSLATIONS['inventory-po-received'] },
-    { name: 'rmm-alert-triggered', subtypeName: 'RMM Alert Triggered', translations: RMM_ALERT_INTERNAL_TRANSLATIONS },
-  ];
-  for (const spec of specs) {
-    const subtype = await knex('internal_notification_subtypes').where({ name: spec.subtypeName }).first();
-    if (!subtype) {
-      throw new Error(`Internal notification subtype '${spec.subtypeName}' not found for template '${spec.name}'`);
-    }
-    const rows = Object.entries(spec.translations).map(([language_code, t]) => ({
-      name: spec.name,
-      language_code,
-      title: t.title,
-      message: t.message,
-      subtype_id: subtype.internal_notification_subtype_id,
-    }));
-    await knex('internal_notification_templates')
-      .insert(rows)
-      .onConflict(['name', 'language_code'])
-      .merge({ title: knex.raw('excluded.title'), message: knex.raw('excluded.message'), subtype_id: knex.raw('excluded.subtype_id') });
-  }
-}
+const { TEMPLATES: rmmInternalTemplates } = require('./utils/templates/internal/rmm.cjs');
+const { TEMPLATES: inventoryInternalTemplates } = require('./utils/templates/internal/inventory.cjs');
 
 exports.up = async function up(knex) {
-  // Module-defined templates now carry every supported locale; re-upsert them.
-  await upsertEmailTemplate(knex, opportunityWeeklyDigest());
-  await upsertInternalTemplates(knex, opportunityInternalTemplates);
-
-  // Inline-defined templates: add the missing pt/pl rows.
-  await upsertRmmAlertEmailTranslations(knex);
-  await upsertInlineInternalTranslations(knex);
+  await upsertEmailTemplates(knex, [opportunityWeeklyDigest(), rmmAlertTriggered()]);
+  await upsertInternalTemplates(knex, [
+    ...opportunityInternalTemplates,
+    ...rmmInternalTemplates,
+    ...inventoryInternalTemplates,
+  ]);
 
   console.log('Added missing locale rows for opportunity, RMM alert, and inventory templates.');
 };

--- a/server/migrations/20260730093000_add_missing_locale_email_and_internal_templates.cjs
+++ b/server/migrations/20260730093000_add_missing_locale_email_and_internal_templates.cjs
@@ -1,0 +1,251 @@
+'use strict';
+
+/**
+ * Ship the newly added translations for the locale-gapped templates and the
+ * missing pt/pl rows for the inline-defined ones.
+ *
+ * The opportunity email digest and the internal opportunity templates only had
+ * English copy; they now carry every supported locale. The RMM alert and the
+ * two inventory internal templates were defined inline in their own migrations
+ * missing pt (and the RMM templates were English-only, so fr/es/de/nl/it/pl
+ * are missing there too). This migration upserts all of those rows, merging on
+ * (name, language_code), so it is idempotent and a no-op once every row
+ * matches the source of truth.
+ */
+
+const { upsertEmailTemplate } = require('./utils/templates/_shared/upsertEmailTemplates.cjs');
+const { upsertInternalTemplates } = require('./utils/templates/_shared/upsertInternalTemplates.cjs');
+const { getTemplate: opportunityWeeklyDigest } = require('./utils/templates/email/opportunities/opportunityWeeklyDigest.cjs');
+const { TEMPLATES: opportunityInternalTemplates } = require('./utils/templates/internal/opportunities.cjs');
+
+const RMM_ALERT_EMAIL_TRANSLATIONS = [
+  {
+    language: 'fr',
+    subject: 'Alerte RMM ({{severity}}) : {{deviceName}}',
+    htmlContent: `
+      <h2>Alerte RMM</h2>
+      <p>Une alerte de {{provider}} correspond à une règle qui vous notifie.</p>
+      <div class="details">
+        <p><strong>Gravité :</strong> {{severity}}</p>
+        <p><strong>Appareil :</strong> {{deviceName}}</p>
+        <p><strong>Message :</strong> {{message}}</p>
+        <p><strong>Ticket :</strong> {{ticketNumber}}</p>
+      </div>
+      <p><a href="{{url}}">Voir dans Alga PSA</a></p>
+    `,
+    textContent: 'Alerte RMM ({{severity}}) sur {{deviceName}} : {{message}}\nTicket : {{ticketNumber}}\n{{url}}',
+  },
+  {
+    language: 'es',
+    subject: 'Alerta de RMM ({{severity}}): {{deviceName}}',
+    htmlContent: `
+      <h2>Alerta de RMM</h2>
+      <p>Una alerta de {{provider}} coincide con una regla que te notifica.</p>
+      <div class="details">
+        <p><strong>Severidad:</strong> {{severity}}</p>
+        <p><strong>Dispositivo:</strong> {{deviceName}}</p>
+        <p><strong>Mensaje:</strong> {{message}}</p>
+        <p><strong>Ticket:</strong> {{ticketNumber}}</p>
+      </div>
+      <p><a href="{{url}}">Ver en Alga PSA</a></p>
+    `,
+    textContent: 'Alerta de RMM ({{severity}}) en {{deviceName}}: {{message}}\nTicket: {{ticketNumber}}\n{{url}}',
+  },
+  {
+    language: 'de',
+    subject: 'RMM-Warnung ({{severity}}): {{deviceName}}',
+    htmlContent: `
+      <h2>RMM-Warnung</h2>
+      <p>Eine Warnung von {{provider}} entspricht einer Regel, die Sie benachrichtigt.</p>
+      <div class="details">
+        <p><strong>Schweregrad:</strong> {{severity}}</p>
+        <p><strong>Gerät:</strong> {{deviceName}}</p>
+        <p><strong>Nachricht:</strong> {{message}}</p>
+        <p><strong>Ticket:</strong> {{ticketNumber}}</p>
+      </div>
+      <p><a href="{{url}}">In Alga PSA ansehen</a></p>
+    `,
+    textContent: 'RMM-Warnung ({{severity}}) auf {{deviceName}}: {{message}}\nTicket: {{ticketNumber}}\n{{url}}',
+  },
+  {
+    language: 'nl',
+    subject: 'RMM-melding ({{severity}}): {{deviceName}}',
+    htmlContent: `
+      <h2>RMM-melding</h2>
+      <p>Een melding van {{provider}} komt overeen met een regel die jou waarschuwt.</p>
+      <div class="details">
+        <p><strong>Ernst:</strong> {{severity}}</p>
+        <p><strong>Apparaat:</strong> {{deviceName}}</p>
+        <p><strong>Bericht:</strong> {{message}}</p>
+        <p><strong>Ticket:</strong> {{ticketNumber}}</p>
+      </div>
+      <p><a href="{{url}}">Bekijk in Alga PSA</a></p>
+    `,
+    textContent: 'RMM-melding ({{severity}}) op {{deviceName}}: {{message}}\nTicket: {{ticketNumber}}\n{{url}}',
+  },
+  {
+    language: 'it',
+    subject: 'Avviso RMM ({{severity}}): {{deviceName}}',
+    htmlContent: `
+      <h2>Avviso RMM</h2>
+      <p>Un avviso da {{provider}} corrisponde a una regola che ti avvisa.</p>
+      <div class="details">
+        <p><strong>Gravità:</strong> {{severity}}</p>
+        <p><strong>Dispositivo:</strong> {{deviceName}}</p>
+        <p><strong>Messaggio:</strong> {{message}}</p>
+        <p><strong>Ticket:</strong> {{ticketNumber}}</p>
+      </div>
+      <p><a href="{{url}}">Visualizza in Alga PSA</a></p>
+    `,
+    textContent: 'Avviso RMM ({{severity}}) su {{deviceName}}: {{message}}\nTicket: {{ticketNumber}}\n{{url}}',
+  },
+  {
+    language: 'pl',
+    subject: 'Alert RMM ({{severity}}): {{deviceName}}',
+    htmlContent: `
+      <h2>Alert RMM</h2>
+      <p>Alert z {{provider}} pasuje do reguły, która Cię powiadamia.</p>
+      <div class="details">
+        <p><strong>Ważność:</strong> {{severity}}</p>
+        <p><strong>Urządzenie:</strong> {{deviceName}}</p>
+        <p><strong>Wiadomość:</strong> {{message}}</p>
+        <p><strong>Zgłoszenie:</strong> {{ticketNumber}}</p>
+      </div>
+      <p><a href="{{url}}">Zobacz w Alga PSA</a></p>
+    `,
+    textContent: 'Alert RMM ({{severity}}) na {{deviceName}}: {{message}}\nZgłoszenie: {{ticketNumber}}\n{{url}}',
+  },
+  {
+    language: 'pt',
+    subject: 'Alerta de RMM ({{severity}}): {{deviceName}}',
+    htmlContent: `
+      <h2>Alerta de RMM</h2>
+      <p>Um alerta de {{provider}} correspondeu a uma regra que o notifica.</p>
+      <div class="details">
+        <p><strong>Severidade:</strong> {{severity}}</p>
+        <p><strong>Dispositivo:</strong> {{deviceName}}</p>
+        <p><strong>Mensagem:</strong> {{message}}</p>
+        <p><strong>Ticket:</strong> {{ticketNumber}}</p>
+      </div>
+      <p><a href="{{url}}">Ver no Alga PSA</a></p>
+    `,
+    textContent: 'Alerta de RMM ({{severity}}) em {{deviceName}}: {{message}}\nTicket: {{ticketNumber}}\n{{url}}',
+  },
+];
+
+const INVENTORY_INTERNAL_TRANSLATIONS = {
+  'inventory-low-stock': {
+    pl: {
+      title: 'Niski stan magazynowy w {{locationName}}',
+      message: '{{productCount}} produkt(ów) w {{locationName}} osiągnęło lub spadło poniżej punktu zamawiania: {{summary}}',
+    },
+    pt: {
+      title: 'Estoque baixo em {{locationName}}',
+      message: '{{productCount}} produto(s) em {{locationName}} estão no ponto de reposição ou abaixo dele: {{summary}}',
+    },
+  },
+  'inventory-po-received': {
+    pl: {
+      title: 'Zamówienie zakupu {{poNumber}} odebrane',
+      message: 'Odebrano {{receivedLineCount}} pozycję(i) od {{vendorName}}.',
+    },
+    pt: {
+      title: 'Pedido de compra {{poNumber}} recebido',
+      message: '{{receivedLineCount}} linha(s) recebida(s) de {{vendorName}}.',
+    },
+  },
+};
+
+const RMM_ALERT_INTERNAL_TRANSLATIONS = {
+  fr: {
+    title: 'Alerte RMM ({{severity}}) : {{deviceName}}',
+    message: '{{message}}',
+  },
+  es: {
+    title: 'Alerta de RMM ({{severity}}): {{deviceName}}',
+    message: '{{message}}',
+  },
+  de: {
+    title: 'RMM-Warnung ({{severity}}): {{deviceName}}',
+    message: '{{message}}',
+  },
+  nl: {
+    title: 'RMM-melding ({{severity}}): {{deviceName}}',
+    message: '{{message}}',
+  },
+  it: {
+    title: 'Avviso RMM ({{severity}}): {{deviceName}}',
+    message: '{{message}}',
+  },
+  pl: {
+    title: 'Alert RMM ({{severity}}): {{deviceName}}',
+    message: '{{message}}',
+  },
+  pt: {
+    title: 'Alerta de RMM ({{severity}}): {{deviceName}}',
+    message: '{{message}}',
+  },
+};
+
+async function upsertRmmAlertEmailTranslations(knex) {
+  const subtype = await knex('notification_subtypes').where({ name: 'RMM Alert Triggered' }).first();
+  if (!subtype) {
+    throw new Error("Notification subtype 'RMM Alert Triggered' not found for template 'rmm-alert-triggered'");
+  }
+  const now = new Date();
+  const rows = RMM_ALERT_EMAIL_TRANSLATIONS.map((t) => ({
+    name: 'rmm-alert-triggered',
+    language_code: t.language,
+    subject: t.subject,
+    html_content: t.htmlContent,
+    text_content: t.textContent,
+    notification_subtype_id: subtype.id,
+    updated_at: now,
+  }));
+  await knex('system_email_templates')
+    .insert(rows)
+    .onConflict(['name', 'language_code'])
+    .merge(['subject', 'html_content', 'text_content', 'notification_subtype_id', 'updated_at']);
+}
+
+async function upsertInlineInternalTranslations(knex) {
+  const now = new Date();
+  const specs = [
+    { name: 'inventory-low-stock', subtypeName: 'inventory-low-stock', translations: INVENTORY_INTERNAL_TRANSLATIONS['inventory-low-stock'] },
+    { name: 'inventory-po-received', subtypeName: 'inventory-po-received', translations: INVENTORY_INTERNAL_TRANSLATIONS['inventory-po-received'] },
+    { name: 'rmm-alert-triggered', subtypeName: 'RMM Alert Triggered', translations: RMM_ALERT_INTERNAL_TRANSLATIONS },
+  ];
+  for (const spec of specs) {
+    const subtype = await knex('internal_notification_subtypes').where({ name: spec.subtypeName }).first();
+    if (!subtype) {
+      throw new Error(`Internal notification subtype '${spec.subtypeName}' not found for template '${spec.name}'`);
+    }
+    const rows = Object.entries(spec.translations).map(([language_code, t]) => ({
+      name: spec.name,
+      language_code,
+      title: t.title,
+      message: t.message,
+      subtype_id: subtype.internal_notification_subtype_id,
+    }));
+    await knex('internal_notification_templates')
+      .insert(rows)
+      .onConflict(['name', 'language_code'])
+      .merge({ title: knex.raw('excluded.title'), message: knex.raw('excluded.message'), subtype_id: knex.raw('excluded.subtype_id') });
+  }
+}
+
+exports.up = async function up(knex) {
+  // Module-defined templates now carry every supported locale; re-upsert them.
+  await upsertEmailTemplate(knex, opportunityWeeklyDigest());
+  await upsertInternalTemplates(knex, opportunityInternalTemplates);
+
+  // Inline-defined templates: add the missing pt/pl rows.
+  await upsertRmmAlertEmailTranslations(knex);
+  await upsertInlineInternalTranslations(knex);
+
+  console.log('Added missing locale rows for opportunity, RMM alert, and inventory templates.');
+};
+
+exports.down = async function down() {
+  // No-op: template migrations are forward-only content corrections.
+};

--- a/server/migrations/20260730120000_refresh_portuguese_email_templates.cjs
+++ b/server/migrations/20260730120000_refresh_portuguese_email_templates.cjs
@@ -1,0 +1,28 @@
+/**
+ * Re-upsert every Brazilian Portuguese email template from the source-of-truth
+ * modules.
+ *
+ * Translation edits landed in the template modules after
+ * 20260625120000_add_portuguese_email_templates.cjs had already run, so those
+ * rows still carry the pre-review copy in any environment migrated before the
+ * edits. Replaying the same upsert brings every `pt` row back in sync and is a
+ * no-op for rows that already match.
+ */
+
+const { upsertEmailCategoriesAndSubtypes } = require('./utils/templates/_shared/emailCategoriesAndSubtypes.cjs');
+const {
+  buildPortugueseRows,
+  upsertPortugueseEmailRows,
+} = require('./20260625120000_add_portuguese_email_templates.cjs');
+
+exports.up = async function up(knex) {
+  await upsertEmailCategoriesAndSubtypes(knex);
+  const subtypes = await knex('notification_subtypes').select('id', 'name');
+  const rows = buildPortugueseRows(subtypes);
+  await upsertPortugueseEmailRows(knex, rows);
+  console.log(`Refreshed ${rows.length} Brazilian Portuguese email templates.`);
+};
+
+exports.down = async function down() {
+  // No-op: email template migrations are forward-only content corrections.
+};

--- a/server/migrations/20260730121000_refresh_portuguese_internal_notification_templates.cjs
+++ b/server/migrations/20260730121000_refresh_portuguese_internal_notification_templates.cjs
@@ -1,0 +1,28 @@
+/**
+ * Re-upsert every Brazilian Portuguese internal notification template from the
+ * source-of-truth modules.
+ *
+ * Same drift as the email templates: copy edits landed after
+ * 20260625121000_add_portuguese_internal_notification_templates.cjs had run, so
+ * rows kept the pre-review wording. Replaying the upsert resyncs them and is a
+ * no-op for rows that already match.
+ */
+
+const { upsertCategoriesAndSubtypes } = require('./utils/templates/internal/categoriesAndSubtypes.cjs');
+const {
+  buildPortugueseRows,
+  upsertPortugueseInternalRows,
+} = require('./20260625121000_add_portuguese_internal_notification_templates.cjs');
+
+exports.up = async function up(knex) {
+  await upsertCategoriesAndSubtypes(knex);
+  const subtypes = await knex('internal_notification_subtypes')
+    .select('internal_notification_subtype_id', 'name');
+  const rows = buildPortugueseRows(subtypes);
+  await upsertPortugueseInternalRows(knex, rows);
+  console.log(`Refreshed ${rows.length} Brazilian Portuguese internal notification templates.`);
+};
+
+exports.down = async function down() {
+  // No-op: notification template migrations are forward-only content corrections.
+};

--- a/server/migrations/utils/templates/README.md
+++ b/server/migrations/utils/templates/README.md
@@ -1,0 +1,15 @@
+# Notification template sources
+
+Every system email and internal notification template is defined here, never
+inline in a migration. Migrations only `require` a module and call
+`upsertEmailTemplates` / `upsertInternalTemplates`.
+
+Rules:
+
+- A template ships copy for every locale in `_shared/constants.cjs`
+  (`SUPPORTED_LANGUAGES`), which mirrors `packages/email/src/lib/localeConfig.ts`.
+  `src/test/unit/migrations/templateLocaleParity.test.ts` fails otherwise.
+- Editing copy in a module changes nothing in a deployed database on its own —
+  always ship a migration that re-upserts the affected templates.
+- Never merge a migration meant to be "parked" for later: merged means it runs
+  on the next deploy.

--- a/server/migrations/utils/templates/_shared/constants.cjs
+++ b/server/migrations/utils/templates/_shared/constants.cjs
@@ -26,7 +26,7 @@ const COMMENT_LABEL_COLOR = '#1e40af';
 const FONT_STACK = "Inter,system-ui,-apple-system,BlinkMacSystemFont,'Segoe UI',sans-serif";
 const HEADING_FONT = "Poppins,system-ui,sans-serif";
 
-const SUPPORTED_LANGUAGES = ['en', 'fr', 'es', 'de', 'nl', 'it', 'pl'];
+const SUPPORTED_LANGUAGES = ['en', 'fr', 'es', 'de', 'nl', 'it', 'pl', 'pt'];
 
 module.exports = {
   BRAND_GRADIENT,

--- a/server/migrations/utils/templates/email/opportunities/opportunityWeeklyDigest.cjs
+++ b/server/migrations/utils/templates/email/opportunities/opportunityWeeklyDigest.cjs
@@ -5,41 +5,155 @@ const { wrapEmailLayout } = require('../../_shared/emailLayout.cjs');
 const TEMPLATE_NAME = 'opportunity-weekly-digest';
 const SUBTYPE_NAME = 'Opportunity Weekly Digest';
 
-function getTemplate() {
-  const body = `
-    <h1 style="margin:0 0 16px;font-size:24px;line-height:32px;">Your weekly opportunity brief</h1>
-    <p style="margin:0 0 16px;">Here is what needs your attention this week.</p>
-    <table role="presentation" width="100%" cellspacing="0" cellpadding="8" style="border-collapse:collapse;">
-      <tr><td>Actions due this week</td><td align="right"><strong>{{digest.actionsDue}}</strong></td></tr>
-      <tr><td>Stalled deals</td><td align="right"><strong>{{digest.stalledDeals}}</strong></td></tr>
-      <tr><td>New suggestions</td><td align="right"><strong>{{digest.newSuggestions}}</strong></td></tr>
-      <tr><td>Wins last week</td><td align="right"><strong>{{digest.winsLastWeek}}</strong></td></tr>
-    </table>
-    <p style="margin:20px 0 0;"><a href="{{digest.url}}">Open your opportunity queue</a></p>
-  `;
+const COPY = {
+  en: {
+    subject: 'Your weekly opportunity brief',
+    headerLabel: 'Weekly opportunity brief',
+    heading: 'Your weekly opportunity brief',
+    intro: 'Here is what needs your attention this week.',
+    actionsDue: 'Actions due this week',
+    stalledDeals: 'Stalled deals',
+    newSuggestions: 'New suggestions',
+    winsLastWeek: 'Wins last week',
+    cta: 'Open your opportunity queue',
+    footer: 'Powered by Alga PSA &middot; Keep the next action moving',
+    textOpenQueue: 'Open your queue',
+  },
+  fr: {
+    subject: 'Votre résumé hebdomadaire des opportunités',
+    headerLabel: 'Résumé hebdomadaire des opportunités',
+    heading: 'Votre résumé hebdomadaire des opportunités',
+    intro: 'Voici ce qui demande votre attention cette semaine.',
+    actionsDue: 'Actions dues cette semaine',
+    stalledDeals: 'Affaires en retard',
+    newSuggestions: 'Nouvelles suggestions',
+    winsLastWeek: 'Gains la semaine dernière',
+    cta: 'Ouvrez votre file d\'opportunités',
+    footer: 'Powered by Alga PSA &middot; Faites avancer la prochaine action',
+    textOpenQueue: 'Ouvrez votre file',
+  },
+  es: {
+    subject: 'Tu resumen semanal de oportunidades',
+    headerLabel: 'Resumen semanal de oportunidades',
+    heading: 'Tu resumen semanal de oportunidades',
+    intro: 'Esto es lo que necesita tu atención esta semana.',
+    actionsDue: 'Acciones pendientes esta semana',
+    stalledDeals: 'Tratos estancados',
+    newSuggestions: 'Nuevas sugerencias',
+    winsLastWeek: 'Ganados la semana pasada',
+    cta: 'Abre tu cola de oportunidades',
+    footer: 'Powered by Alga PSA &middot; Mantén la próxima acción en marcha',
+    textOpenQueue: 'Abre tu cola',
+  },
+  de: {
+    subject: 'Ihre wöchentliche Opportunity-Übersicht',
+    headerLabel: 'Wöchentliche Opportunity-Übersicht',
+    heading: 'Ihre wöchentliche Opportunity-Übersicht',
+    intro: 'Das erfordert diese Woche Ihre Aufmerksamkeit.',
+    actionsDue: 'Diese Woche fällige Aktionen',
+    stalledDeals: 'Ins Stocken geratene Abschlüsse',
+    newSuggestions: 'Neue Vorschläge',
+    winsLastWeek: 'Gewinne letzte Woche',
+    cta: 'Öffnen Sie Ihre Opportunity-Warteschlange',
+    footer: 'Powered by Alga PSA &middot; Halten Sie die nächste Aktion in Gang',
+    textOpenQueue: 'Öffnen Sie Ihre Warteschlange',
+  },
+  nl: {
+    subject: 'Je wekelijkse opportunity-overzicht',
+    headerLabel: 'Wekelijks opportunity-overzicht',
+    heading: 'Je wekelijkse opportunity-overzicht',
+    intro: 'Dit vraagt deze week je aandacht.',
+    actionsDue: 'Acties deze week vervallen',
+    stalledDeals: 'Vastgelopen deals',
+    newSuggestions: 'Nieuwe suggesties',
+    winsLastWeek: 'Winsten vorige week',
+    cta: 'Open je opportunity-wachtrij',
+    footer: 'Powered by Alga PSA &middot; Houd de volgende actie in beweging',
+    textOpenQueue: 'Open je wachtrij',
+  },
+  it: {
+    subject: 'Il tuo riepilogo settimanale delle opportunità',
+    headerLabel: 'Riepilogo settimanale delle opportunità',
+    heading: 'Il tuo riepilogo settimanale delle opportunità',
+    intro: 'Ecco cosa richiede la tua attenzione questa settimana.',
+    actionsDue: 'Azioni in scadenza questa settimana',
+    stalledDeals: 'Affari bloccati',
+    newSuggestions: 'Nuovi suggerimenti',
+    winsLastWeek: 'Vittorie la settimana scorsa',
+    cta: 'Apri la tua coda di opportunità',
+    footer: 'Powered by Alga PSA &middot; Mantieni in movimento la prossima azione',
+    textOpenQueue: 'Apri la tua coda',
+  },
+  pl: {
+    subject: 'Twoje tygodniowe podsumowanie szans',
+    headerLabel: 'Tygodniowe podsumowanie szans',
+    heading: 'Twoje tygodniowe podsumowanie szans',
+    intro: 'Oto, co wymaga Twojej uwagi w tym tygodniu.',
+    actionsDue: 'Działania do wykonania w tym tygodniu',
+    stalledDeals: 'Zatrzymane transakcje',
+    newSuggestions: 'Nowe sugestie',
+    winsLastWeek: 'Wygrane w zeszłym tygodniu',
+    cta: 'Otwórz swoją kolejkę szans',
+    footer: 'Powered by Alga PSA &middot; Utrzymuj następną akcję w ruchu',
+    textOpenQueue: 'Otwórz swoją kolejkę',
+  },
+  pt: {
+    subject: 'Seu resumo semanal de oportunidades',
+    headerLabel: 'Resumo semanal de oportunidades',
+    heading: 'Seu resumo semanal de oportunidades',
+    intro: 'Aqui está o que precisa da sua atenção esta semana.',
+    actionsDue: 'Ações vencendo esta semana',
+    stalledDeals: 'Negócios parados',
+    newSuggestions: 'Novas sugestões',
+    winsLastWeek: 'Vitórias na semana passada',
+    cta: 'Abra sua fila de oportunidades',
+    footer: 'Powered by Alga PSA &middot; Mantenha a próxima ação em movimento',
+    textOpenQueue: 'Abra sua fila',
+  },
+};
 
+function buildBodyHtml(c) {
+  return `
+    <h1 style="margin:0 0 16px;font-size:24px;line-height:32px;">${c.heading}</h1>
+    <p style="margin:0 0 16px;">${c.intro}</p>
+    <table role="presentation" width="100%" cellspacing="0" cellpadding="8" style="border-collapse:collapse;">
+      <tr><td>${c.actionsDue}</td><td align="right"><strong>{{digest.actionsDue}}</strong></td></tr>
+      <tr><td>${c.stalledDeals}</td><td align="right"><strong>{{digest.stalledDeals}}</strong></td></tr>
+      <tr><td>${c.newSuggestions}</td><td align="right"><strong>{{digest.newSuggestions}}</strong></td></tr>
+      <tr><td>${c.winsLastWeek}</td><td align="right"><strong>{{digest.winsLastWeek}}</strong></td></tr>
+    </table>
+    <p style="margin:20px 0 0;"><a href="{{digest.url}}">${c.cta}</a></p>
+  `;
+}
+
+function buildText(c) {
+  return [
+    c.heading,
+    '',
+    `${c.actionsDue}: {{digest.actionsDue}}`,
+    `${c.stalledDeals}: {{digest.stalledDeals}}`,
+    `${c.newSuggestions}: {{digest.newSuggestions}}`,
+    `${c.winsLastWeek}: {{digest.winsLastWeek}}`,
+    '',
+    `${c.textOpenQueue}: {{digest.url}}`,
+  ].join('\n');
+}
+
+function getTemplate() {
   return {
     templateName: TEMPLATE_NAME,
     subtypeName: SUBTYPE_NAME,
-    translations: [{
-      language: 'en',
-      subject: 'Your weekly opportunity brief',
+    translations: Object.entries(COPY).map(([lang, copy]) => ({
+      language: lang,
+      subject: copy.subject,
       htmlContent: wrapEmailLayout({
-        headerLabel: 'Weekly opportunity brief',
-        bodyHtml: body,
-        footerText: 'Powered by Alga PSA &middot; Keep the next action moving',
+        language: lang,
+        headerLabel: copy.headerLabel,
+        bodyHtml: buildBodyHtml(copy),
+        footerText: copy.footer,
       }),
-      textContent: [
-        'Your weekly opportunity brief',
-        '',
-        'Actions due this week: {{digest.actionsDue}}',
-        'Stalled deals: {{digest.stalledDeals}}',
-        'New suggestions: {{digest.newSuggestions}}',
-        'Wins last week: {{digest.winsLastWeek}}',
-        '',
-        'Open your queue: {{digest.url}}',
-      ].join('\n'),
-    }],
+      textContent: buildText(copy),
+    })),
   };
 }
 

--- a/server/migrations/utils/templates/email/rmm/rmmAlertTriggered.cjs
+++ b/server/migrations/utils/templates/email/rmm/rmmAlertTriggered.cjs
@@ -1,0 +1,136 @@
+'use strict';
+
+/**
+ * Source of truth: 'rmm-alert-triggered' system email template.
+ *
+ * The English copy and markup match the original inline definition in
+ * 20260612090200_add_rmm_alert_notifications.cjs; the other locales were added
+ * when the template was folded into this module.
+ */
+
+const TEMPLATE_NAME = 'rmm-alert-triggered';
+const SUBTYPE_NAME = 'RMM Alert Triggered';
+
+const COPY = {
+  en: {
+    subject: 'RMM Alert ({{severity}}): {{deviceName}}',
+    heading: 'RMM Alert',
+    intro: 'An alert from {{provider}} matched a rule that notifies you.',
+    severity: 'Severity',
+    device: 'Device',
+    message: 'Message',
+    ticket: 'Ticket',
+    cta: 'View in Alga PSA',
+    textIntro: 'RMM Alert ({{severity}}) on {{deviceName}}: {{message}}',
+  },
+  fr: {
+    subject: 'Alerte RMM ({{severity}}) : {{deviceName}}',
+    heading: 'Alerte RMM',
+    intro: 'Une alerte de {{provider}} correspond à une règle qui vous notifie.',
+    severity: 'Gravité',
+    device: 'Appareil',
+    message: 'Message',
+    ticket: 'Ticket',
+    cta: 'Voir dans Alga PSA',
+    textIntro: 'Alerte RMM ({{severity}}) sur {{deviceName}} : {{message}}',
+  },
+  es: {
+    subject: 'Alerta de RMM ({{severity}}): {{deviceName}}',
+    heading: 'Alerta de RMM',
+    intro: 'Una alerta de {{provider}} coincide con una regla que te notifica.',
+    severity: 'Severidad',
+    device: 'Dispositivo',
+    message: 'Mensaje',
+    ticket: 'Ticket',
+    cta: 'Ver en Alga PSA',
+    textIntro: 'Alerta de RMM ({{severity}}) en {{deviceName}}: {{message}}',
+  },
+  de: {
+    subject: 'RMM-Warnung ({{severity}}): {{deviceName}}',
+    heading: 'RMM-Warnung',
+    intro: 'Eine Warnung von {{provider}} entspricht einer Regel, die Sie benachrichtigt.',
+    severity: 'Schweregrad',
+    device: 'Gerät',
+    message: 'Nachricht',
+    ticket: 'Ticket',
+    cta: 'In Alga PSA ansehen',
+    textIntro: 'RMM-Warnung ({{severity}}) auf {{deviceName}}: {{message}}',
+  },
+  nl: {
+    subject: 'RMM-melding ({{severity}}): {{deviceName}}',
+    heading: 'RMM-melding',
+    intro: 'Een melding van {{provider}} komt overeen met een regel die jou waarschuwt.',
+    severity: 'Ernst',
+    device: 'Apparaat',
+    message: 'Bericht',
+    ticket: 'Ticket',
+    cta: 'Bekijk in Alga PSA',
+    textIntro: 'RMM-melding ({{severity}}) op {{deviceName}}: {{message}}',
+  },
+  it: {
+    subject: 'Avviso RMM ({{severity}}): {{deviceName}}',
+    heading: 'Avviso RMM',
+    intro: 'Un avviso da {{provider}} corrisponde a una regola che ti avvisa.',
+    severity: 'Gravità',
+    device: 'Dispositivo',
+    message: 'Messaggio',
+    ticket: 'Ticket',
+    cta: 'Visualizza in Alga PSA',
+    textIntro: 'Avviso RMM ({{severity}}) su {{deviceName}}: {{message}}',
+  },
+  pl: {
+    subject: 'Alert RMM ({{severity}}): {{deviceName}}',
+    heading: 'Alert RMM',
+    intro: 'Alert z {{provider}} pasuje do reguły, która Cię powiadamia.',
+    severity: 'Ważność',
+    device: 'Urządzenie',
+    message: 'Wiadomość',
+    ticket: 'Zgłoszenie',
+    cta: 'Zobacz w Alga PSA',
+    textIntro: 'Alert RMM ({{severity}}) na {{deviceName}}: {{message}}',
+  },
+  pt: {
+    subject: 'Alerta de RMM ({{severity}}): {{deviceName}}',
+    heading: 'Alerta de RMM',
+    intro: 'Um alerta de {{provider}} correspondeu a uma regra que o notifica.',
+    severity: 'Severidade',
+    device: 'Dispositivo',
+    message: 'Mensagem',
+    ticket: 'Ticket',
+    cta: 'Ver no Alga PSA',
+    textIntro: 'Alerta de RMM ({{severity}}) em {{deviceName}}: {{message}}',
+  },
+};
+
+function buildHtml(copy) {
+  return `
+      <h2>${copy.heading}</h2>
+      <p>${copy.intro}</p>
+      <div class="details">
+        <p><strong>${copy.severity}:</strong> {{severity}}</p>
+        <p><strong>${copy.device}:</strong> {{deviceName}}</p>
+        <p><strong>${copy.message}:</strong> {{message}}</p>
+        <p><strong>${copy.ticket}:</strong> {{ticketNumber}}</p>
+      </div>
+      <p><a href="{{url}}">${copy.cta}</a></p>
+    `;
+}
+
+function buildText(copy) {
+  return `${copy.textIntro}\n${copy.ticket}: {{ticketNumber}}\n{{url}}`;
+}
+
+function getTemplate() {
+  return {
+    templateName: TEMPLATE_NAME,
+    subtypeName: SUBTYPE_NAME,
+    translations: Object.entries(COPY).map(([lang, copy]) => ({
+      language: lang,
+      subject: copy.subject,
+      htmlContent: buildHtml(copy),
+      textContent: buildText(copy),
+    })),
+  };
+}
+
+module.exports = { TEMPLATE_NAME, SUBTYPE_NAME, getTemplate };

--- a/server/migrations/utils/templates/internal/inventory.cjs
+++ b/server/migrations/utils/templates/internal/inventory.cjs
@@ -1,0 +1,83 @@
+/**
+ * Source of truth: inventory internal notification templates.
+ */
+const TEMPLATES = [
+  {
+    templateName: 'inventory-low-stock',
+    subtypeName: 'inventory-low-stock',
+    translations: {
+      en: {
+        title: 'Low stock at {{locationName}}',
+        message: '{{productCount}} product(s) at {{locationName}} are at or below their reorder point: {{summary}}',
+      },
+      fr: {
+        title: 'Stock bas à {{locationName}}',
+        message: '{{productCount}} produit(s) à {{locationName}} sont au niveau ou en dessous de leur seuil de réapprovisionnement : {{summary}}',
+      },
+      es: {
+        title: 'Stock bajo en {{locationName}}',
+        message: '{{productCount}} producto(s) en {{locationName}} están en o por debajo de su punto de pedido: {{summary}}',
+      },
+      de: {
+        title: 'Niedriger Bestand bei {{locationName}}',
+        message: '{{productCount}} Produkt(e) bei {{locationName}} liegen auf oder unter dem Meldebestand: {{summary}}',
+      },
+      nl: {
+        title: 'Lage voorraad bij {{locationName}}',
+        message: '{{productCount}} product(en) bij {{locationName}} zitten op of onder het bestelpunt: {{summary}}',
+      },
+      it: {
+        title: 'Scorte basse presso {{locationName}}',
+        message: '{{productCount}} prodotto/i presso {{locationName}} sono al livello di riordino o al di sotto: {{summary}}',
+      },
+      pl: {
+        title: 'Niski stan magazynowy w {{locationName}}',
+        message: '{{productCount}} produkt(ów) w {{locationName}} osiągnęło lub spadło poniżej punktu zamawiania: {{summary}}',
+      },
+      pt: {
+        title: 'Estoque baixo em {{locationName}}',
+        message: '{{productCount}} produto(s) em {{locationName}} estão no ponto de reposição ou abaixo dele: {{summary}}',
+      },
+    },
+  },
+  {
+    templateName: 'inventory-po-received',
+    subtypeName: 'inventory-po-received',
+    translations: {
+      en: {
+        title: 'Purchase order {{poNumber}} received',
+        message: '{{receivedLineCount}} line(s) received from {{vendorName}}.',
+      },
+      fr: {
+        title: 'Bon de commande {{poNumber}} recu',
+        message: '{{receivedLineCount}} ligne(s) recue(s) de {{vendorName}}.',
+      },
+      es: {
+        title: 'Orden de compra {{poNumber}} recibida',
+        message: '{{receivedLineCount}} linea(s) recibida(s) de {{vendorName}}.',
+      },
+      de: {
+        title: 'Bestellung {{poNumber}} erhalten',
+        message: '{{receivedLineCount}} Position(en) von {{vendorName}} erhalten.',
+      },
+      nl: {
+        title: 'Inkooporder {{poNumber}} ontvangen',
+        message: '{{receivedLineCount}} regel(s) ontvangen van {{vendorName}}.',
+      },
+      it: {
+        title: "Ordine d'acquisto {{poNumber}} ricevuto",
+        message: '{{receivedLineCount}} riga/righe ricevute da {{vendorName}}.',
+      },
+      pl: {
+        title: 'Zamówienie zakupu {{poNumber}} odebrane',
+        message: 'Odebrano {{receivedLineCount}} pozycję(i) od {{vendorName}}.',
+      },
+      pt: {
+        title: 'Pedido de compra {{poNumber}} recebido',
+        message: '{{receivedLineCount}} linha(s) recebida(s) de {{vendorName}}.',
+      },
+    },
+  },
+];
+
+module.exports = { TEMPLATES };

--- a/server/migrations/utils/templates/internal/opportunities.cjs
+++ b/server/migrations/utils/templates/internal/opportunities.cjs
@@ -9,6 +9,34 @@ const TEMPLATES = [
         title: 'Opportunity going quiet: {{opportunityTitle}}',
         message: '{{why}} Next action: {{nextAction}}',
       },
+      fr: {
+        title: 'Opportunité en perte de vitesse : {{opportunityTitle}}',
+        message: '{{why}} Prochaine action : {{nextAction}}',
+      },
+      es: {
+        title: 'Oportunidad enfriándose: {{opportunityTitle}}',
+        message: '{{why}} Próxima acción: {{nextAction}}',
+      },
+      de: {
+        title: 'Opportunity wird ruhig: {{opportunityTitle}}',
+        message: '{{why}} Nächste Aktion: {{nextAction}}',
+      },
+      nl: {
+        title: 'Opportunity wordt stil: {{opportunityTitle}}',
+        message: '{{why}} Volgende actie: {{nextAction}}',
+      },
+      it: {
+        title: 'Opportunità in calo: {{opportunityTitle}}',
+        message: '{{why}} Prossima azione: {{nextAction}}',
+      },
+      pl: {
+        title: 'Szansa przygasa: {{opportunityTitle}}',
+        message: '{{why}} Następna akcja: {{nextAction}}',
+      },
+      pt: {
+        title: 'Oportunidade esfriando: {{opportunityTitle}}',
+        message: '{{why}} Próxima ação: {{nextAction}}',
+      },
     },
   },
   {
@@ -19,6 +47,34 @@ const TEMPLATES = [
         title: 'Opportunity needs intervention: {{opportunityTitle}}',
         message: '{{ownerName}}\'s opportunity with {{clientName}} has been quiet for {{daysSinceActivity}} days.',
       },
+      fr: {
+        title: 'L\'opportunité nécessite une intervention : {{opportunityTitle}}',
+        message: 'L\'opportunité de {{ownerName}} avec {{clientName}} est inactive depuis {{daysSinceActivity}} jours.',
+      },
+      es: {
+        title: 'La oportunidad necesita intervención: {{opportunityTitle}}',
+        message: 'La oportunidad de {{ownerName}} con {{clientName}} lleva {{daysSinceActivity}} días sin actividad.',
+      },
+      de: {
+        title: 'Opportunity erfordert Eingreifen: {{opportunityTitle}}',
+        message: 'Die Opportunity von {{ownerName}} mit {{clientName}} ist seit {{daysSinceActivity}} Tagen inaktiv.',
+      },
+      nl: {
+        title: 'Opportunity vereist interventie: {{opportunityTitle}}',
+        message: 'De opportunity van {{ownerName}} met {{clientName}} is al {{daysSinceActivity}} dagen inactief.',
+      },
+      it: {
+        title: 'L\'opportunità richiede intervento: {{opportunityTitle}}',
+        message: 'L\'opportunità di {{ownerName}} con {{clientName}} è inattiva da {{daysSinceActivity}} giorni.',
+      },
+      pl: {
+        title: 'Szansa wymaga interwencji: {{opportunityTitle}}',
+        message: 'Szansa użytkownika {{ownerName}} z klientem {{clientName}} jest nieaktywna od {{daysSinceActivity}} dni.',
+      },
+      pt: {
+        title: 'A oportunidade precisa de intervenção: {{opportunityTitle}}',
+        message: 'A oportunidade de {{ownerName}} com {{clientName}} está parada há {{daysSinceActivity}} dias.',
+      },
     },
   },
   {
@@ -28,6 +84,34 @@ const TEMPLATES = [
       en: {
         title: 'Your weekly opportunity brief',
         message: '{{actionsDue}} actions due this week, {{stalledDeals}} stalled deals, {{newSuggestions}} new suggestions, and {{winsLastWeek}} wins last week.',
+      },
+      fr: {
+        title: 'Votre résumé hebdomadaire des opportunités',
+        message: '{{actionsDue}} actions dues cette semaine, {{stalledDeals}} affaires en retard, {{newSuggestions}} nouvelles suggestions et {{winsLastWeek}} gains la semaine dernière.',
+      },
+      es: {
+        title: 'Tu resumen semanal de oportunidades',
+        message: '{{actionsDue}} acciones pendientes esta semana, {{stalledDeals}} tratos estancados, {{newSuggestions}} nuevas sugerencias y {{winsLastWeek}} ganados la semana pasada.',
+      },
+      de: {
+        title: 'Ihre wöchentliche Opportunity-Übersicht',
+        message: '{{actionsDue}} diese Woche fällige Aktionen, {{stalledDeals}} ins Stocken geratene Abschlüsse, {{newSuggestions}} neue Vorschläge und {{winsLastWeek}} Gewinne letzte Woche.',
+      },
+      nl: {
+        title: 'Je wekelijkse opportunity-overzicht',
+        message: '{{actionsDue}} acties deze week vervallen, {{stalledDeals}} vastgelopen deals, {{newSuggestions}} nieuwe suggesties en {{winsLastWeek}} winsten vorige week.',
+      },
+      it: {
+        title: 'Il tuo riepilogo settimanale delle opportunità',
+        message: '{{actionsDue}} azioni in scadenza questa settimana, {{stalledDeals}} affari bloccati, {{newSuggestions}} nuovi suggerimenti e {{winsLastWeek}} vittorie la settimana scorsa.',
+      },
+      pl: {
+        title: 'Twoje tygodniowe podsumowanie szans',
+        message: '{{actionsDue}} działania do wykonania w tym tygodniu, {{stalledDeals}} zatrzymane transakcje, {{newSuggestions}} nowe sugestie i {{winsLastWeek}} wygrane w zeszłym tygodniu.',
+      },
+      pt: {
+        title: 'Seu resumo semanal de oportunidades',
+        message: '{{actionsDue}} ações vencendo esta semana, {{stalledDeals}} negócios parados, {{newSuggestions}} novas sugestões e {{winsLastWeek}} vitórias na semana passada.',
       },
     },
   },

--- a/server/migrations/utils/templates/internal/rmm.cjs
+++ b/server/migrations/utils/templates/internal/rmm.cjs
@@ -1,0 +1,21 @@
+/**
+ * Source of truth: RMM internal notification templates.
+ */
+const TEMPLATES = [
+  {
+    templateName: 'rmm-alert-triggered',
+    subtypeName: 'RMM Alert Triggered',
+    translations: {
+      en: { title: 'RMM Alert ({{severity}}): {{deviceName}}', message: '{{message}}' },
+      fr: { title: 'Alerte RMM ({{severity}}) : {{deviceName}}', message: '{{message}}' },
+      es: { title: 'Alerta de RMM ({{severity}}): {{deviceName}}', message: '{{message}}' },
+      de: { title: 'RMM-Warnung ({{severity}}): {{deviceName}}', message: '{{message}}' },
+      nl: { title: 'RMM-melding ({{severity}}): {{deviceName}}', message: '{{message}}' },
+      it: { title: 'Avviso RMM ({{severity}}): {{deviceName}}', message: '{{message}}' },
+      pl: { title: 'Alert RMM ({{severity}}): {{deviceName}}', message: '{{message}}' },
+      pt: { title: 'Alerta de RMM ({{severity}}): {{deviceName}}', message: '{{message}}' },
+    },
+  },
+];
+
+module.exports = { TEMPLATES };

--- a/server/src/test/unit/migrations/templateLocaleParity.test.ts
+++ b/server/src/test/unit/migrations/templateLocaleParity.test.ts
@@ -188,15 +188,31 @@ function makeKnex() {
 function emailTemplateDefs() {
   const { TEMPLATE_GETTERS } = require(path.join(migrationsDir, '20260625120000_add_portuguese_email_templates.cjs'));
   const defs = TEMPLATE_GETTERS.map((getter: any) => getter());
-  // Locale-gapped modules not yet folded into the pt migration's getter list.
+  // Modules not yet folded into the pt migration's getter list.
   defs.push(require(path.join(migrationsDir, 'utils/templates/email/opportunities/opportunityWeeklyDigest.cjs')).getTemplate());
+  defs.push(require(path.join(migrationsDir, 'utils/templates/email/rmm/rmmAlertTriggered.cjs')).getTemplate());
   return defs;
 }
 
 function internalTemplateDefs() {
   const { ALL_TEMPLATES } = require(path.join(migrationsDir, '20260625121000_add_portuguese_internal_notification_templates.cjs'));
-  const { TEMPLATES: opportunityTemplates } = require(path.join(migrationsDir, 'utils/templates/internal/opportunities.cjs'));
-  return [...ALL_TEMPLATES, ...opportunityTemplates];
+  const load = (module: string) => require(path.join(migrationsDir, `utils/templates/internal/${module}.cjs`)).TEMPLATES;
+  return [...ALL_TEMPLATES, ...load('opportunities'), ...load('rmm'), ...load('inventory')];
+}
+
+/**
+ * Categories/subtypes these templates hang off are created by their own
+ * feature migrations rather than the shared category seeders.
+ */
+async function seedFeatureSubtypes(knex: any) {
+  for (const migration of [
+    '20260712105300_add_opportunity_notification_templates.cjs',
+    '20260612090200_add_rmm_alert_notifications.cjs',
+    '20260701091000_inventory_low_stock_notification.cjs',
+    '20260702151000_inventory_po_received_notification.cjs',
+  ]) {
+    await require(path.join(migrationsDir, migration)).up(knex);
+  }
 }
 
 function rowsByTemplate(rows: Row[]): Map<string, Set<string>> {
@@ -212,8 +228,8 @@ describe('template locale parity', () => {
   it('ships every supported locale for every module-defined system email template', async () => {
     const knex = makeKnex();
     await upsertEmailCategoriesAndSubtypes(knex);
-    // Creates the 'Opportunities' category + 'Opportunity Weekly Digest' subtype.
-    await require(path.join(migrationsDir, '20260712105300_add_opportunity_notification_templates.cjs')).up(knex);
+    await upsertCategoriesAndSubtypes(knex);
+    await seedFeatureSubtypes(knex);
     const defs = emailTemplateDefs();
     for (const def of defs) {
       await upsertEmailTemplate(knex, def);
@@ -234,9 +250,9 @@ describe('template locale parity', () => {
 
   it('ships every supported locale for every module-defined internal notification template', async () => {
     const knex = makeKnex();
+    await upsertEmailCategoriesAndSubtypes(knex);
     await upsertCategoriesAndSubtypes(knex);
-    // The opportunity category/subtypes are created by their own migration.
-    await require(path.join(migrationsDir, '20260712105300_add_opportunity_notification_templates.cjs')).up(knex);
+    await seedFeatureSubtypes(knex);
     const defs = internalTemplateDefs();
     await upsertInternalTemplates(knex, defs);
     const rows = await knex('internal_notification_templates').select('name', 'language_code');
@@ -261,36 +277,23 @@ describe('template locale parity', () => {
     expect([...SUPPORTED_LANGUAGES].sort()).toEqual([...LOCALE_CONFIG.supportedLocales].sort());
   });
 
-  it('ships every supported locale for the inline-defined templates', async () => {
-    // These templates are defined inline in their own migrations rather than
-    // in a shared template module, so they drifted without a shared def to
-    // check. Run their migrations plus the locale-fill migration and assert
-    // full coverage.
+  it('covers every template the migrations write through a shared module', async () => {
+    // Guards the split the reviewer flagged: a template whose copy is only
+    // defined inline in its own migration escapes the parity checks above.
     const knex = makeKnex();
     await upsertEmailCategoriesAndSubtypes(knex);
     await upsertCategoriesAndSubtypes(knex);
-    // The fill migration also re-upserts the opportunity templates.
-    await require(path.join(migrationsDir, '20260712105300_add_opportunity_notification_templates.cjs')).up(knex);
-    await require(path.join(migrationsDir, '20260612090200_add_rmm_alert_notifications.cjs')).up(knex);
-    await require(path.join(migrationsDir, '20260701091000_inventory_low_stock_notification.cjs')).up(knex);
-    await require(path.join(migrationsDir, '20260702151000_inventory_po_received_notification.cjs')).up(knex);
+    await seedFeatureSubtypes(knex);
     await require(path.join(migrationsDir, '20260730093000_add_missing_locale_email_and_internal_templates.cjs')).up(knex);
 
-    const expectations: Array<[string, string[]]> = [
-      ['system_email_templates', ['rmm-alert-triggered']],
-      ['internal_notification_templates', ['rmm-alert-triggered', 'inventory-low-stock', 'inventory-po-received']],
-    ];
-    const missing: string[] = [];
-    for (const [table, names] of expectations) {
-      const rows = await knex(table).select('name', 'language_code');
-      const byTemplate = rowsByTemplate(rows);
-      for (const name of names) {
-        const shipped = byTemplate.get(name) || new Set();
-        for (const locale of SUPPORTED_LANGUAGES) {
-          if (!shipped.has(locale)) missing.push(`${name}:${locale}`);
-        }
-      }
+    const moduleNames = new Set<string>([
+      ...emailTemplateDefs().map((def: any) => def.templateName),
+      ...internalTemplateDefs().map((def: any) => def.templateName),
+    ]);
+    const written = new Set<string>();
+    for (const table of ['system_email_templates', 'internal_notification_templates']) {
+      for (const row of await knex(table).select('name')) written.add(row.name);
     }
-    expect(missing).toEqual([]);
+    expect([...written].filter((name) => !moduleNames.has(name))).toEqual([]);
   });
 });

--- a/server/src/test/unit/migrations/templateLocaleParity.test.ts
+++ b/server/src/test/unit/migrations/templateLocaleParity.test.ts
@@ -10,6 +10,7 @@
 import { describe, expect, it } from 'vitest';
 import path from 'node:path';
 import { createRequire } from 'node:module';
+import { LOCALE_CONFIG } from '../../../../../packages/email/src/lib/localeConfig';
 
 const require = createRequire(import.meta.url);
 const migrationsDir = path.resolve(__dirname, '../../../../migrations');
@@ -270,10 +271,6 @@ describe('template locale parity', () => {
   });
 
   it('keeps the migration locale list aligned with the runtime locale config', () => {
-    const { LOCALE_CONFIG } = require(path.resolve(
-      __dirname,
-      '../../../../../packages/email/src/lib/localeConfig.ts',
-    ));
     expect([...SUPPORTED_LANGUAGES].sort()).toEqual([...LOCALE_CONFIG.supportedLocales].sort());
   });
 

--- a/server/src/test/unit/migrations/templateLocaleParity.test.ts
+++ b/server/src/test/unit/migrations/templateLocaleParity.test.ts
@@ -1,0 +1,296 @@
+/**
+ * Template locale parity guard.
+ *
+ * Builds every module-defined system email / internal notification template
+ * through the same upsert helpers the migrations use, against an in-memory
+ * knex stub, and asserts each shipped template carries every supported locale.
+ * This stops a new template from being merged without its pt (or any other)
+ * variant — the drift that left many production templates without Portuguese.
+ */
+import { describe, expect, it } from 'vitest';
+import path from 'node:path';
+import { createRequire } from 'node:module';
+
+const require = createRequire(import.meta.url);
+const migrationsDir = path.resolve(__dirname, '../../../../migrations');
+
+const { SUPPORTED_LANGUAGES } = require(path.join(
+  migrationsDir,
+  'utils/templates/_shared/constants.cjs',
+));
+const { upsertEmailCategoriesAndSubtypes } = require(path.join(
+  migrationsDir,
+  'utils/templates/_shared/emailCategoriesAndSubtypes.cjs',
+));
+const { upsertEmailTemplate } = require(path.join(
+  migrationsDir,
+  'utils/templates/_shared/upsertEmailTemplates.cjs',
+));
+const { upsertCategoriesAndSubtypes } = require(path.join(
+  migrationsDir,
+  'utils/templates/internal/categoriesAndSubtypes.cjs',
+));
+const { upsertInternalTemplates } = require(path.join(
+  migrationsDir,
+  'utils/templates/_shared/upsertInternalTemplates.cjs',
+));
+
+// ---------------------------------------------------------------------------
+// In-memory knex stub (insert / onConflict / merge / select)
+// ---------------------------------------------------------------------------
+
+type Row = Record<string, any>;
+
+const TABLE_PRIMARY_KEYS: Record<string, string> = {
+  notification_categories: 'id',
+  notification_subtypes: 'id',
+  internal_notification_categories: 'internal_notification_category_id',
+  internal_notification_subtypes: 'internal_notification_subtype_id',
+};
+
+function resolveTemplateValue(template: any, stored: Row): any {
+  if (template && template.__raw && typeof template.column === 'string') {
+    return stored[template.column];
+  }
+  return template;
+}
+
+function makeKnex() {
+  const state = new Map<string, Row[]>();
+  const sequences = new Map<string, number>();
+
+  const rowsFor = (name: string): Row[] => {
+    if (!state.has(name)) state.set(name, []);
+    return state.get(name)!;
+  };
+
+  const knex: any = (name: string) => {
+    const assignPrimaryKey = (row: Row): void => {
+      const pk = TABLE_PRIMARY_KEYS[name];
+      if (pk && row[pk] === undefined) {
+        const next = (sequences.get(name) || 0) + 1;
+        sequences.set(name, next);
+        row[pk] = next;
+      }
+    };
+
+    const execute = (rows: Row[], conflictColumns: string[], mergeSpec: any, columns: any): Row[] => {
+      const list = rowsFor(name);
+      const cols: string[] | null = columns === '*' || columns == null ? null : Array.isArray(columns) ? columns : [columns];
+      const result: Row[] = [];
+      for (const row of rows) {
+        assignPrimaryKey(row);
+        // The real schema defaults language_code to 'en' (NOT NULL); knex
+        // omits undefined keys, so apply the DB default here.
+        if ((name === 'system_email_templates' || name === 'internal_notification_templates') && row.language_code === undefined) {
+          row.language_code = 'en';
+        }
+        const existing =
+          conflictColumns.length > 0
+            ? list.find((candidate) => conflictColumns.every((column) => candidate[column] === row[column]))
+            : undefined;
+        let stored: Row;
+        if (existing) {
+          if (mergeSpec == null) {
+            stored = existing;
+          } else if (Array.isArray(mergeSpec)) {
+            for (const column of mergeSpec) existing[column] = row[column];
+            stored = existing;
+          } else {
+            Object.assign(existing, row);
+            for (const [column, template] of Object.entries(mergeSpec)) {
+              existing[column] = resolveTemplateValue(template, existing);
+            }
+            stored = existing;
+          }
+        } else {
+          stored = { ...row };
+          list.push(stored);
+        }
+        if (cols) {
+          const picked: Row = {};
+          for (const column of cols) picked[column] = stored[column];
+          result.push(picked);
+        } else {
+          result.push({ ...stored });
+        }
+      }
+      return result;
+    };
+
+    return {
+      where(criteria: Row) {
+        return {
+          async first() {
+            return rowsFor(name).find((row) =>
+              Object.entries(criteria).every(([key, value]) => row[key] === value),
+            );
+          },
+        };
+      },
+      whereIn(column: string, values: any[]) {
+        return {
+          async del() {
+            const list = rowsFor(name);
+            const remaining = list.filter((row) => !values.includes(row[column]));
+            state.set(name, remaining);
+            return list.length - remaining.length;
+          },
+        };
+      },
+      select(...columns: string[]) {
+        return Promise.resolve(
+          rowsFor(name).map((row) => {
+            const picked: Row = {};
+            for (const column of columns) picked[column] = row[column];
+            return picked;
+          }),
+        );
+      },
+      insert(input: Row | Row[]) {
+        const rows = Array.isArray(input) ? input : [input];
+        const api: any = {
+          conflictColumns: [] as string[],
+          mergeSpec: null as any,
+          onConflict(columns: any) {
+            api.conflictColumns = Array.isArray(columns) ? columns : [columns];
+            return api;
+          },
+          merge(spec: any) {
+            api.mergeSpec = spec;
+            const merged: any = Promise.resolve(execute(rows, api.conflictColumns, api.mergeSpec, null));
+            merged.returning = (columns: any) => Promise.resolve(execute(rows, api.conflictColumns, api.mergeSpec, columns));
+            return merged;
+          },
+          returning(columns: any) {
+            return Promise.resolve(execute(rows, api.conflictColumns, api.mergeSpec, columns));
+          },
+          then(onFulfilled: any, onRejected: any) {
+            return Promise.resolve(execute(rows, api.conflictColumns, api.mergeSpec, null)).then(onFulfilled, onRejected);
+          },
+        };
+        return api;
+      },
+    };
+  };
+
+  knex.raw = (sql: string) => {
+    const match = /excluded\.([A-Za-z0-9_]+)/.exec(sql);
+    return { __raw: sql, column: match ? match[1] : undefined };
+  };
+  return knex;
+}
+
+// ---------------------------------------------------------------------------
+// Module-defined template defs
+// ---------------------------------------------------------------------------
+
+function emailTemplateDefs() {
+  const { TEMPLATE_GETTERS } = require(path.join(migrationsDir, '20260625120000_add_portuguese_email_templates.cjs'));
+  const defs = TEMPLATE_GETTERS.map((getter: any) => getter());
+  // Locale-gapped modules not yet folded into the pt migration's getter list.
+  defs.push(require(path.join(migrationsDir, 'utils/templates/email/opportunities/opportunityWeeklyDigest.cjs')).getTemplate());
+  return defs;
+}
+
+function internalTemplateDefs() {
+  const { ALL_TEMPLATES } = require(path.join(migrationsDir, '20260625121000_add_portuguese_internal_notification_templates.cjs'));
+  const { TEMPLATES: opportunityTemplates } = require(path.join(migrationsDir, 'utils/templates/internal/opportunities.cjs'));
+  return [...ALL_TEMPLATES, ...opportunityTemplates];
+}
+
+function rowsByTemplate(rows: Row[]): Map<string, Set<string>> {
+  const map = new Map<string, Set<string>>();
+  for (const row of rows) {
+    if (!map.has(row.name)) map.set(row.name, new Set());
+    map.get(row.name)!.add(row.language_code);
+  }
+  return map;
+}
+
+describe('template locale parity', () => {
+  it('ships every supported locale for every module-defined system email template', async () => {
+    const knex = makeKnex();
+    await upsertEmailCategoriesAndSubtypes(knex);
+    // Creates the 'Opportunities' category + 'Opportunity Weekly Digest' subtype.
+    await require(path.join(migrationsDir, '20260712105300_add_opportunity_notification_templates.cjs')).up(knex);
+    const defs = emailTemplateDefs();
+    for (const def of defs) {
+      await upsertEmailTemplate(knex, def);
+    }
+    const rows = await knex('system_email_templates').select('name', 'language_code');
+    const byTemplate = rowsByTemplate(rows);
+
+    const missing: string[] = [];
+    for (const def of defs) {
+      const shipped = byTemplate.get(def.templateName) || new Set();
+      for (const locale of SUPPORTED_LANGUAGES) {
+        if (!shipped.has(locale)) missing.push(`${def.templateName}:${locale}`);
+      }
+    }
+    expect(missing).toEqual([]);
+    expect(defs.length).toBeGreaterThanOrEqual(42);
+  });
+
+  it('ships every supported locale for every module-defined internal notification template', async () => {
+    const knex = makeKnex();
+    await upsertCategoriesAndSubtypes(knex);
+    // The opportunity category/subtypes are created by their own migration.
+    await require(path.join(migrationsDir, '20260712105300_add_opportunity_notification_templates.cjs')).up(knex);
+    const defs = internalTemplateDefs();
+    await upsertInternalTemplates(knex, defs);
+    const rows = await knex('internal_notification_templates').select('name', 'language_code');
+    const byTemplate = rowsByTemplate(rows);
+
+    const missing: string[] = [];
+    for (const def of defs) {
+      const shipped = byTemplate.get(def.templateName) || new Set();
+      for (const locale of SUPPORTED_LANGUAGES) {
+        if (!shipped.has(locale)) missing.push(`${def.templateName}:${locale}`);
+      }
+    }
+    expect(missing).toEqual([]);
+    expect(defs.length).toBeGreaterThanOrEqual(51);
+  });
+
+  it('keeps the migration locale list aligned with the runtime locale config', () => {
+    const { LOCALE_CONFIG } = require(path.resolve(
+      __dirname,
+      '../../../../../packages/email/src/lib/localeConfig.ts',
+    ));
+    expect([...SUPPORTED_LANGUAGES].sort()).toEqual([...LOCALE_CONFIG.supportedLocales].sort());
+  });
+
+  it('ships every supported locale for the inline-defined templates', async () => {
+    // These templates are defined inline in their own migrations rather than
+    // in a shared template module, so they drifted without a shared def to
+    // check. Run their migrations plus the locale-fill migration and assert
+    // full coverage.
+    const knex = makeKnex();
+    await upsertEmailCategoriesAndSubtypes(knex);
+    await upsertCategoriesAndSubtypes(knex);
+    // The fill migration also re-upserts the opportunity templates.
+    await require(path.join(migrationsDir, '20260712105300_add_opportunity_notification_templates.cjs')).up(knex);
+    await require(path.join(migrationsDir, '20260612090200_add_rmm_alert_notifications.cjs')).up(knex);
+    await require(path.join(migrationsDir, '20260701091000_inventory_low_stock_notification.cjs')).up(knex);
+    await require(path.join(migrationsDir, '20260702151000_inventory_po_received_notification.cjs')).up(knex);
+    await require(path.join(migrationsDir, '20260730093000_add_missing_locale_email_and_internal_templates.cjs')).up(knex);
+
+    const expectations: Array<[string, string[]]> = [
+      ['system_email_templates', ['rmm-alert-triggered']],
+      ['internal_notification_templates', ['rmm-alert-triggered', 'inventory-low-stock', 'inventory-po-received']],
+    ];
+    const missing: string[] = [];
+    for (const [table, names] of expectations) {
+      const rows = await knex(table).select('name', 'language_code');
+      const byTemplate = rowsByTemplate(rows);
+      for (const name of names) {
+        const shipped = byTemplate.get(name) || new Set();
+        for (const locale of SUPPORTED_LANGUAGES) {
+          if (!shipped.has(locale)) missing.push(`${name}:${locale}`);
+        }
+      }
+    }
+    expect(missing).toEqual([]);
+  });
+});


### PR DESCRIPTION
## Summary
Several system email and internal notification templates were missing Brazilian Portuguese (and in some cases other locale) copy, and two migrations that had already shipped `pt` rows drifted from the source-of-truth modules after review edits landed. This PR adds `pt` to the list of supported languages, backfills every locale-gapped template, resyncs the stale Portuguese rows, moves the last inline template definitions into the shared `utils/templates` source-of-truth structure, and adds a regression test that fails the build if a template ever ships without full locale parity again.

## Changes
- **Locale support**: Add `pt` to `SUPPORTED_LANGUAGES` in `_shared/constants.cjs`.
- **Template refactor**: Move the `opportunity-weekly-digest` and RMM alert email templates, and the inventory/opportunities internal notification templates, out of inline migration code and into per-locale copy modules under `utils/templates/email/` and `utils/templates/internal/`, matching the existing source-of-truth pattern.
- **New/expanded template content**: Add full `en/fr/es/de/nl/it/pl/pt` translations for `opportunity-weekly-digest` (email), `rmm-alert-triggered` (email + internal), `inventory-low-stock` / `inventory-po-received` (internal), and the remaining opportunity internal notification templates that previously only had English copy.
- **Migrations**:
  - `20260730093000_add_missing_locale_email_and_internal_templates.cjs` re-upserts the newly-translated templates so every environment gets the missing locale rows.
  - `20260730120000_refresh_portuguese_email_templates.cjs` and `20260730121000_refresh_portuguese_internal_notification_templates.cjs` replay the original Portuguese upserts against the current source modules to resync rows left with pre-review wording after `20260625120000`/`20260625121000` had already run.
  - All three migrations are idempotent (merge on name/language) and forward-only (`down()` is a no-op).
- **Docs**: Add `utils/templates/README.md` documenting the rule that templates live in source modules (never inline in migrations), must cover every `SUPPORTED_LANGUAGES` entry, and require a migration to actually ship copy edits.
- **Tests**: Add `templateLocaleParity.test.ts`, which builds every module-defined template through an in-memory knex stub and the real upsert helpers, asserting full locale coverage and that `SUPPORTED_LANGUAGES` stays aligned with `packages/email/src/lib/localeConfig.ts`. Fixed the test's import of that TS module to a normal ESM import instead of `createRequire`, which choked on untransformed TypeScript.

## Testing
- Added unit test `server/src/test/unit/migrations/templateLocaleParity.test.ts`, run via the server unit suite (`vitest`), covering locale parity for all email/internal templates and alignment with `LOCALE_CONFIG.supportedLocales`.
