### PR TITLE
Project fixup round 3

### DIFF
--- a/docs/plans/2026-07-30-project-fixup-round-3-plan.md
+++ b/docs/plans/2026-07-30-project-fixup-round-3-plan.md
@@ -1,0 +1,154 @@
+# Project Fixup Round 3 — Implementation Plan
+
+**Date:** 2026-07-30
+**Branch:** `fix/project-fixup-round-3`
+**Status:** Approved design — ready for implementation
+**Predecessor:** `docs/plans/2026-07-29-project-fixup-round-2-plan.md`
+
+## Context
+
+Field testing after round 2 produced a third handwritten page of project-billing and project-UI issues. This round is a batch of targeted fixes: input and dialog polish, dark-mode and warning-text presentation, invoice line-amount display, accounting-integration gating, per-view phase-list controls, an overdue-phase signal, closing the standalone-approve dead-end, and making the `project-billing-ui` feature flag deterministic.
+
+Design-session research established root causes for every item; each workstream below cites its anchors. Two workstreams (A and B) already have substantial uncommitted WIP in this worktree from a prior session; for those the task is to verify, finish, and test rather than build from scratch.
+
+**Pre-existing worktree changes.** `package.json`'s `dev` script was modified by environment wire-up to read `PORT` from the git-ignored `server/.env.local` (fallback 3000). The board-owned dev service depends on it; commit it as a standalone `chore:` commit, separate from the fix commits.
+
+## Goals
+
+1. Standalone-mode schedule entries can never be approved into an uninvoiceable state, and any already-approved backlog has an invoice path.
+2. The `project-billing-ui` flag renders deterministically — no flicker, no intermittently missing Billing view — across all seven consuming components.
+3. Invoice line amounts read as net, summing visibly to the Subtotal row, with tax only in the totals section.
+4. QuickBooks sync affordances appear only when an accounting integration is actually connected.
+5. Project billing status pills, dialogs, number inputs, and warning text look and behave correctly (dark mode, spacing, wheel-scroll, emphasis).
+6. The phase list adapts its controls to the active view, and past-dated phases with pending billing surface an overdue signal instead of sitting silent.
+
+## Non-goals
+
+- Auto-advancing billing status from phase dates (decided against: Mark Complete remains the sole trigger for phase-triggered entries).
+- App-wide wheel-scroll behavior changes on number inputs (scoped to the two Total price fields).
+- Removing the ~20 hand-rolled dialog-footer wrappers made redundant by the Dialog engine fix (no churn; they remain valid).
+- Any change to `generateProjectInvoice`, the schedule-entry lifecycle, or approval semantics for recurring mode.
+- Unifying the vestigial `project_phases.status` column with `completed_at` (edit UI never exposes it; out of scope).
+- The `evaluatePhaseReadiness` / `markPhaseComplete` duplicated-invariant cleanup (mark with `// LEVERAGE: friction` only).
+
+## Workstream A — Standalone approve dead-end (WIP exists: verify & finish)
+
+**Decision:** hide plain Approve for standalone-mode rows everywhere it's offered, and give standalone fixed-price projects the "Generate project invoice" button so already-approved entries have an exit. Recurring-mode Approve is correct and unchanged. No server changes: `generateProjectInvoice(projectId)` with no `entryIds` already bills the approved backlog (`packages/billing/src/actions/invoiceGeneration.ts:2113`).
+
+Already implemented in the uncommitted WIP:
+
+- `ProjectBillingReviewTab.tsx` — per-row plain Approve now renders only when `invoice_mode === 'recurring'`; "Approve & invoice now" remains the standalone path; bulk "Approve selected" renders only when every selected row is recurring (`canBulkApproveSelection`), and `handleBulkApprove` filters to recurring ids.
+- `ProjectBillingView.tsx` — the "Generate project invoice" button (`id="billing-generate-project-invoice"`) is hoisted out of the T&M-only branch and renders for any `invoice_mode === 'standalone' && canManage` config, fixed-price included.
+- New source-contract test `packages/billing/tests/projectBillingStandaloneUi.contract.test.ts` pins both behaviors.
+
+Remaining work:
+
+1. **A1.** Review the WIP diff for correctness and idiom; run the new contract test and the existing project-billing suites.
+2. **A2.** The moved button reuses `billing.tm.generateInvoice` / `billing.tm.generatingInvoice` i18n keys. Rename to mode-neutral keys (e.g. `billing.generateProjectInvoice`, `billing.generatingProjectInvoice`) across all locale files, keeping i18n-parity tests green — the `tm.` namespace is now wrong for a button that also serves fixed-price.
+3. **A3.** Manual smoke (dev server on port 3511): standalone fixed-price project — verify plain Approve is absent in the review tab, "Approve & invoice now" works, and a deliberately pre-approved entry is billed by "Generate project invoice". Recurring project — verify plain Approve and bulk approve still work.
+
+## Workstream B — Deterministic feature flag (WIP exists: verify & finish)
+
+**Root cause:** `useFeatureFlag` (`packages/ui/src/hooks/useFeatureFlag.tsx`) did a one-shot read 200 ms after mount with no `onFeatureFlags` subscription, racing the identify-then-reload in `PostHogUserIdentifier`; `PostHogProvider` bootstrapped `featureFlags: {}` so every flag read disabled until the network responded.
+
+**Decision:** both layers — server-evaluated bootstrap plus client subscription.
+
+Already implemented in the uncommitted WIP:
+
+- `useFeatureFlag.tsx` — subscribes to `posthog.onFeatureFlags()` and re-checks on every flag delivery; unsubscribes on cleanup.
+- `server/src/app/layout.tsx` — root layout evaluates `project-billing-ui` via the cached `checkFeatureFlag` helper (`server/src/lib/feature-flags/serverFeatureFlags.tsx:10`, first production use) and passes it to the provider. Root-layout placement covers all routes, including `InvoicingHub` and the client portal.
+- `PostHogProvider.tsx` — accepts `initialFeatureFlags` and seeds `bootstrap.featureFlags` with it.
+- `packages/billing/tests/projectBillingUiFeatureFlag.contract.test.ts` — updated for the new source shapes.
+
+Remaining work:
+
+1. **B1.** Review the WIP; run the flag contract test and typecheck. Verify the `initialFeatureFlags` object identity doesn't re-trigger the init effect each render (it's in the effect dep array; the layout passes a fresh object literal — confirm the `isInitialized` guard makes this benign, otherwise stabilize).
+2. **B2.** Fix the dead "not ready" guard at `useFeatureFlag.tsx:111-115`: it checks `posthog.isFeatureEnabled === undefined`, which is always false on the posthog-js singleton. With the subscription in place the guard is vestigial — either remove it or check `posthog.__loaded` (the signal `PostHogUserIdentifier.tsx:23` uses).
+3. **B3.** Server-side evaluation sends `groups: { tenant }` (`packages/core/src/lib/featureFlagRuntime.ts:131-133`) while the client identify sets tenant only as a person property (existing `// LEVERAGE: friction` at `PostHogUserIdentifier.tsx:91`). Confirm the PostHog flag definition for `project-billing-ui` matches at least one of the two paths; document in the PR which targeting the flag uses. No code change unless verification shows the bootstrap path evaluating false for a tenant that should be on.
+4. **B4.** Manual smoke on 3511: hard-reload the project detail page repeatedly (cold cache) — Billing view option must be present on first paint every time when the flag is on; toggle the flag off in PostHog and confirm it disappears without a stale-true flicker.
+
+## Workstream C — Invoice lines show net amounts (per-line tax)
+
+**Root cause:** every generated `invoice_charges` row stores `total_price = net + tax` (`invoiceGeneration.ts:440`, `invoiceService.ts:794/916/1063`), and the view-model adapter maps each line's displayed `total` from `total_price` (`packages/billing/src/lib/adapters/invoiceAdapters.ts:371`). Lines therefore show tax-inclusive amounts while the Subtotal row is net and tax has its own totals row — lines visibly don't sum to the subtotal. Most conspicuous on project invoices, where every milestone line carries tax.
+
+Changes:
+
+1. **C1.** In `invoiceAdapters.ts`, map line `total` (and the grouped-subtotal accumulation at `:245` / `:322` if it feeds displayed group sums) from `net_amount` instead of `total_price`. Verify the fallback totals math at `:388-418` — with net lines, `computedSubtotal + tax` is the correct grand total; today the fallback double-counts tax.
+2. **C2.** Audit the other line renderers for the same semantic: client portal `InvoiceDetailsDialog.tsx:276-308` (`renderChargeRow`) and the automatic-invoice preview `AutomaticInvoices.tsx:3037-3090` — wherever a per-line amount is sourced from `total_price`, switch to `net_amount`. Column headers already read "Amount"/"Total" — no label change needed; the Tax totals/breakdown rows stay as-is.
+3. **C3.** Do **not** touch accounting-export adapters (`quickBooksOnlineAdapter.ts`, `xeroAdapter.ts`) — they intentionally consume per-line tax.
+4. **C4.** Tests: unit-test the adapter mapping (line total = net; invoice total = subtotal + tax); regression-check an invoice with a discount line (`net_amount === total_price` there) and a zero-tax invoice (display unchanged).
+
+## Workstream D — Gate QuickBooks sync UI on a connected integration
+
+**Root cause:** `useInvoiceSyncStatuses` (`packages/billing/src/components/invoices/useInvoiceSyncStatuses.ts:24`) hides sync UI only when `getInvoiceSyncStatuses` returns an empty map (CE, missing permission). In EE with `billing:read` and **no** QBO connection, invoices still get `not_synced` statuses, so "Sync to QuickBooks" renders for tenants who never connected QuickBooks.
+
+Changes:
+
+1. **D1.** Expose connection state to the UI: extend `getInvoiceSyncStatuses` (`packages/billing/src/actions/accountingSyncActions.ts`) to short-circuit to an empty result when no accounting integration is connected (reusing the resolution logic behind `getAccountingSyncHealth`, `:328`), or have the hook consult `connected` explicitly. Prefer the action-side short-circuit: `syncHidden` then does the right thing at all three consuming sites with no component changes.
+2. **D2.** Verify all sync affordances disappear when unconnected: sync button + drift controls + "View in QuickBooks" (`InvoicePreviewPanel.tsx:458-546`), and the QuickBooks columns in `FinalizedTab.tsx:399-406` and `DraftsTab.tsx:487-494`.
+3. **D3.** Ensure the connected-tenant path is unchanged (statuses, drift, sync action). Add a unit/contract test for the unconnected short-circuit.
+
+## Workstream E — Dark-mode status pills
+
+**Root cause:** the pill classes in `packages/core/src/lib/projectBillingStatus.ts:26-57` already include `dark:` variants, but `server/tailwind.config.ts` content globs scan only `.jsx/.tsx/.mdx` in a package list that excludes `packages/core` — the dark utilities are never compiled. Light classes work only because other scanned files happen to emit them.
+
+Changes:
+
+1. **E1.** Add `../packages/core/src/lib/projectBillingStatus.ts` to the explicit `.ts` content entries in `server/tailwind.config.ts` (the existing convention at lines 17-19).
+2. **E2.** While there, bump the `canceled` dark pairing (`dark:bg-gray-500/10` + `dark:text-gray-500`) to readable contrast (e.g. `dark:text-gray-400`).
+3. **E3.** Visual check on 3511 in dark mode: billing tab status chips (Pending/Ready/Approved/Invoiced/Held/Canceled) and the phase-badge money icon, which shares `phaseBadgeClasses` (`projectBillingStatus.ts:110-112`).
+
+## Workstream F — Total price wheel-scroll
+
+Scope decision: just the Total price field (it appears in two dialogs), not app-wide.
+
+1. **F1.** Add `onWheel={(e) => (e.target as HTMLInputElement).blur()}` — the repo's existing idiom (`DesignerSchemaInspector.tsx:395`) — to the two fields: `BillingSetupWizard.tsx:184-192` (`billing-setup-total`) and `ProjectBillingView.tsx:301-308` (`billing-terms-total`). The shared `Input` spreads props to the native input, so no component change is needed.
+2. **F2.** Drop a `// LEVERAGE: pattern number-input-wheel-guard` marker at one site noting the same hazard exists on `billing-setup-cap`, `CapPanel.tsx:96`, `ScheduleEntryDialog.tsx:246/:278`, and `PhaseRateOverridesEditor.tsx:224` — candidates for an `Input`-level fix later, deliberately not taken now.
+
+## Workstream G — Dialog footer spacing (engine fix)
+
+**Root cause:** the shared `Dialog` footer container (`packages/ui/src/components/Dialog.tsx:431-435` and the duplicate branch at `:560-564`) is a padded div with no flex/gap; callers passing bare fragments get touching buttons. Two offenders: the "Enable project billing" wizard footer (`BillingSetupWizard.tsx:154-163` — the reported Cancel abutment) and the Hold dialog (`ScheduleTable.tsx:537-545`).
+
+Per the layering rule, fix the engine, not the call sites:
+
+1. **G1.** Give both footer container branches `flex justify-end gap-2` (preserving existing padding). Callers that already wrap their buttons in their own flex div render that div as the single flex child — layout unchanged.
+2. **G2.** Visually verify the two offenders plus a sample of already-wrapped dialogs (`ScheduleEntryDialog`, `ProjectDetailsEdit`, `PhaseTaskImportDialog`, `DuplicateTaskDialog`) in both themes to confirm no regressions from the new default.
+
+## Workstream H — Payment warning emphasis
+
+Both payment-warning surfaces already bold their title; the task is to bold the key clause of the body.
+
+1. **H1.** `ProjectPaymentWarningBanner.tsx` (`packages/billing/src/components/project-billing/`): bold the leading imperative of each message variant — "Payment is required …" through the first sentence boundary — and the interpolated invoice number. Since the strings are i18n keys, split each message into emphasized/rest keys (or wrap with `<Trans>`-style component interpolation per repo i18n idiom) across all locales; keep i18n-parity tests green. Variants: `billing.paymentWarning.generic/preparation/replacement/outstanding` (`:46-71`).
+2. **H2.** Apply the same emphasis to the duplicated banner in `TimeEntryDialog.tsx:326-345` (`workItemPicker.paymentWarningTitle/paymentWarning`). Drop a `// LEVERAGE: pattern payment-warning-banner` marker there — it hand-copies the billing banner instead of reusing it (cross-package reuse blocked today; candidate for extraction).
+
+## Workstream I — Phase list controls per view
+
+**Decision:** billing view = money icon, read-only phases; kanban = editable phases, no money icon. (The phases panel never renders in list view — `ProjectDetail.tsx:4218` gates it to kanban/billing.)
+
+1. **I1.** Thread the existing `viewMode` (`ProjectDetail.tsx:256` type, live value at `:280`, already in scope at the `<ProjectPhases>` call site `:4237`) as a prop through `ProjectPhases.tsx:12-54` into `PhaseListItem.tsx:18-54`.
+2. **I2.** In `PhaseListItem`, when `viewMode === 'billing'`: keep the money icon (`:398-407`); hide the hover action buttons — reopen/mark-complete/edit/delete (`:446-487`), the drag handle (`:389-392`, and don't set `draggable` at `:264`), and the status-settings button (`:339`). When `viewMode === 'kanban'`: hide the money icon; keep all editing controls (current behavior otherwise).
+3. **I3.** In `ProjectPhases`, hide the header add-phase / import controls (header block ending ~`:195-200`) in billing view.
+4. **I4.** Keep phase *selection* (clicking to filter the schedule) working in both views. Update `phaseAwareProjectDetail.contract.test.ts` if it pins the old markup.
+
+## Workstream J — Overdue-phase signal
+
+**Decision:** no auto-advance; surface staleness. A phase is *overdue for billing* when `end_date < today` **and** it has at least one phase-triggered schedule entry still `pending`.
+
+1. **J1.** Data: ensure the billing tab's entry list exposes the linked phase's `end_date` (extend the list query/model join in `packages/billing/src/models/projectBillingScheduleEntry.ts` if absent) and that `PhaseListItem`'s `billingBadge` derivation (`derivePhaseBillingBadges`, `packages/core/src/lib/projectBillingStatus.ts` ~`:85`) can carry an `overdue` flag — computed where phase dates are in scope.
+2. **J2.** `ScheduleTable` row: for such entries, render a warning affordance next to the status chip (`:435`) — amber clock/alert icon with tooltip "Phase end date has passed — mark the phase complete to make this entry ready" (i18n'd, all locales).
+3. **J3.** `PhaseListItem` badge (`:398-407`): overdue accent (amber ring or icon) with equivalent tooltip.
+4. **J4.** Timezone rule: compare dates in the tenant/user timezone per repo convention (match how phase due-ness is displayed elsewhere); treat `end_date` null as never overdue. Unit-test the predicate (past/today/future/null end dates × pending/ready/invoiced entries).
+
+## Testing & verification
+
+- **Contract tests:** run/extend `projectBillingStandaloneUi.contract.test.ts`, `projectBillingUiFeatureFlag.contract.test.ts`, `phaseAwareProjectDetail.contract.test.ts`; new contract or unit tests per C4, D3, J4.
+- **i18n parity:** A2, H1, H2, J2 add or rename keys — every locale file must be updated (parity test enforces).
+- **Manual smoke on the wired dev server (port 3511):** the per-workstream checks A3, B4, E3, G2, plus: wheel-scroll over both Total price fields no longer changes values; project invoice preview lines sum to Subtotal with tax only in totals; unconnected-QBO tenant sees no sync affordances; billing vs kanban phase-list controls; overdue badge appears for a back-dated pending phase.
+- **Suggested commit shape:** the `chore:` dev-script commit first; then one commit per workstream (A and B absorb the existing WIP into properly-messaged commits).
+
+## Out of scope / follow-ups noted
+
+- `Input`-level wheel guard for all number inputs (LEVERAGE marker, F2).
+- Extracting a shared payment-warning banner across packages (LEVERAGE marker, H2).
+- `evaluatePhaseReadiness` dead code / duplicated readiness invariant across `billing` and `projects` packages (existing friction; add `// LEVERAGE: friction phase-readiness-invariant` at `projectActions.ts` markPhaseComplete if not already present).
+- Tenant group-vs-person-property flag targeting mismatch (tracked by existing LEVERAGE marker; B3 only verifies and documents).

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "test:local": "cd server && dotenv -e ../.env.localtest -- vitest \"$@\"",
     "generate:proto": "mkdir -p ee/server/src/generated && protoc --plugin=./node_modules/.bin/protoc-gen-ts_proto --ts_proto_out=ee/server/src/generated --ts_proto_opt=esModuleInterop=true,outputServices=false,useExactTypes=false --proto_path=ee/server/protos workflow.proto",
     "mcp:registry:generate": "node ee/scripts/generate-chat-registry.mjs",
-    "dev": "NX_LOAD_DOT_ENV_FILES=false NODE_ENV=development NX_TUI=false npx nx next:dev server",
+    "dev": "WIRE_PORT=\"$(sed -n 's/^PORT=//p' server/.env.local 2>/dev/null | tail -n 1)\"; PORT=\"${WIRE_PORT:-3000}\" NX_LOAD_DOT_ENV_FILES=false NODE_ENV=development NX_TUI=false npx nx next:dev server",
     "dev:turbo": "NX_LOAD_DOT_ENV_FILES=false NODE_ENV=development NX_TUI=false npx nx next:dev server -- --turbo",
     "build": "npm run build:assemblyscript && npx nx build-deps server && cd server && USE_PREBUILT=true EDITION=community NEXT_PUBLIC_EDITION=community npm run build:turbo",
     "build:source": "npm run build:assemblyscript && cd server && EDITION=community NEXT_PUBLIC_EDITION=community npm run build:turbo",

--- a/packages/billing/src/actions/accountingSyncActions.ts
+++ b/packages/billing/src/actions/accountingSyncActions.ts
@@ -239,6 +239,11 @@ export const getInvoiceSyncStatuses = withAuth(async (
     return {};
   }
 
+  const realm = await resolveDefaultRealm(knex, tenant).catch(() => null);
+  if (!realm) {
+    return {};
+  }
+
   const [mappings, ops] = await Promise.all([
     tenantDb(knex, tenant).table('tenant_external_entity_mappings')
       .where({ integration_type: SYNC_ADAPTER_TYPE, alga_entity_type: 'invoice' })

--- a/packages/billing/src/actions/projectBillingConfigActions.ts
+++ b/packages/billing/src/actions/projectBillingConfigActions.ts
@@ -197,15 +197,22 @@ async function listScheduleEntryViews(
       ? []
       : tenantDb(connection, tenant).table('project_phases')
         .whereIn('phase_id', phaseIds)
-        .select<{ phase_id: string; phase_name: string }[]>('phase_id', 'phase_name'),
+        .select<{ phase_id: string; phase_name: string; end_date: Date | string | null }[]>(
+          'phase_id',
+          'phase_name',
+          'end_date',
+        ),
     invoiceIds.length === 0
       ? []
       : tenantDb(connection, tenant).table('invoices')
         .whereIn('invoice_id', invoiceIds)
         .select<{ invoice_id: string; invoice_number: string }[]>('invoice_id', 'invoice_number'),
   ]);
-  const phaseNames = new Map<string, string>(
-    phaseRows.map((row): [string, string] => [row.phase_id, row.phase_name]),
+  const phasesById = new Map<string, { name: string; endDate: Date | string | null }>(
+    phaseRows.map((row): [string, { name: string; endDate: Date | string | null }] => [
+      row.phase_id,
+      { name: row.phase_name, endDate: row.end_date },
+    ]),
   );
   const invoiceNumbers = new Map<string, string>(
     invoiceRows.map((row): [string, string] => [row.invoice_id, row.invoice_number]),
@@ -214,12 +221,14 @@ async function listScheduleEntryViews(
 
   return entries.map((entry, index) => {
     const phaseDeleted = entry.trigger_type === 'phase'
-      && (entry.phase_id === null || !phaseNames.has(entry.phase_id));
+      && (entry.phase_id === null || !phasesById.has(entry.phase_id));
+    const phase = entry.phase_id ? phasesById.get(entry.phase_id) : undefined;
     return {
       ...entry,
       trigger_type: phaseDeleted ? 'manual' : entry.trigger_type,
       computed_amount: computedAmounts[index],
-      phase_name: entry.phase_id ? phaseNames.get(entry.phase_id) ?? null : null,
+      phase_name: phase?.name ?? null,
+      phase_end_date: phase?.endDate ?? null,
       invoice_number: entry.invoice_id ? invoiceNumbers.get(entry.invoice_id) ?? null : null,
       phase_deleted: phaseDeleted,
     };
@@ -623,6 +632,7 @@ export const recalculateProjectTotalFromSchedule = withAuth(withProjectBillingAc
         ...entry,
         computed_amount: amounts[index],
         phase_name: null,
+        phase_end_date: null,
         invoice_number: null,
         phase_deleted: false,
       })),

--- a/packages/billing/src/actions/projectBillingScheduleActions.ts
+++ b/packages/billing/src/actions/projectBillingScheduleActions.ts
@@ -183,8 +183,8 @@ async function scheduleEntryView(
     context.entry.phase_id
       ? tenantDb(connection, tenant).table('project_phases')
         .where({ phase_id: context.entry.phase_id })
-        .select('phase_name')
-        .first<{ phase_name: string }>()
+        .select('phase_name', 'end_date')
+        .first<{ phase_name: string; end_date: Date | string | null }>()
       : null,
     context.entry.invoice_id
       ? tenantDb(connection, tenant).table('invoices')
@@ -200,6 +200,7 @@ async function scheduleEntryView(
     trigger_type: phaseDeleted ? 'manual' : context.entry.trigger_type,
     computed_amount: amounts[entryIndex],
     phase_name: phase?.phase_name ?? null,
+    phase_end_date: phase?.end_date ?? null,
     invoice_number: invoice?.invoice_number ?? null,
     phase_deleted: phaseDeleted,
   };

--- a/packages/billing/src/components/billing-dashboard/invoicing/ProjectBillingReviewTab.tsx
+++ b/packages/billing/src/components/billing-dashboard/invoicing/ProjectBillingReviewTab.tsx
@@ -116,6 +116,11 @@ const ProjectBillingReviewTab: React.FC<ProjectBillingReviewTabProps> = ({
     onSelectedIdsChange: setSelected,
   });
 
+  const selectedRows = rows.filter((row) => selected.has(row.entry.schedule_entry_id));
+  const canBulkApproveSelection = selected.size > 0
+    && selectedRows.length === selected.size
+    && selectedRows.every((row) => row.invoice_mode === 'recurring');
+
   const handleSelectAll = (checked: boolean) => {
     setSelected(checked ? new Set(rows.map((row) => row.entry.schedule_entry_id)) : new Set());
   };
@@ -184,7 +189,9 @@ const ProjectBillingReviewTab: React.FC<ProjectBillingReviewTabProps> = ({
   };
 
   const handleBulkApprove = async () => {
-    const ids = Array.from(selected);
+    const ids = selectedRows
+      .filter((row) => row.invoice_mode === 'recurring')
+      .map((row) => row.entry.schedule_entry_id);
     if (ids.length === 0) return;
     setIsBusy(true);
     try {
@@ -385,14 +392,16 @@ const ProjectBillingReviewTab: React.FC<ProjectBillingReviewTabProps> = ({
               </Button>
             </DropdownMenuTrigger>
             <DropdownMenuContent align="end">
-              <DropdownMenuItem
-                id={`project-billing-approve-${record.entry.schedule_entry_id}`}
-                onClick={() => handleApprove(record.entry.schedule_entry_id)}
-                className="flex items-center gap-2"
-              >
-                <CheckCircle className="h-4 w-4" />
-                {t('projectBilling.actions.approve', { defaultValue: 'Approve' })}
-              </DropdownMenuItem>
+              {record.invoice_mode === 'recurring' && (
+                <DropdownMenuItem
+                  id={`project-billing-approve-${record.entry.schedule_entry_id}`}
+                  onClick={() => handleApprove(record.entry.schedule_entry_id)}
+                  className="flex items-center gap-2"
+                >
+                  <CheckCircle className="h-4 w-4" />
+                  {t('projectBilling.actions.approve', { defaultValue: 'Approve' })}
+                </DropdownMenuItem>
+              )}
               {record.invoice_mode === 'standalone' && (
                 <DropdownMenuItem
                   id={`project-billing-approve-invoice-${record.entry.schedule_entry_id}`}
@@ -450,14 +459,16 @@ const ProjectBillingReviewTab: React.FC<ProjectBillingReviewTabProps> = ({
             </Button>
           </DropdownMenuTrigger>
           <DropdownMenuContent align="end">
-            <DropdownMenuItem
-              id="project-billing-bulk-approve"
-              onClick={handleBulkApprove}
-              className="flex items-center gap-2"
-            >
-              <CheckCircle className="h-4 w-4" />
-              {t('projectBilling.actions.approveSelected', { defaultValue: 'Approve selected' })}
-            </DropdownMenuItem>
+            {canBulkApproveSelection && (
+              <DropdownMenuItem
+                id="project-billing-bulk-approve"
+                onClick={handleBulkApprove}
+                className="flex items-center gap-2"
+              >
+                <CheckCircle className="h-4 w-4" />
+                {t('projectBilling.actions.approveSelected', { defaultValue: 'Approve selected' })}
+              </DropdownMenuItem>
+            )}
             <DropdownMenuItem
               id="project-billing-bulk-hold"
               onClick={() => openHoldDialog(Array.from(selected))}

--- a/packages/billing/src/components/project-billing/BillingSetupWizard.tsx
+++ b/packages/billing/src/components/project-billing/BillingSetupWizard.tsx
@@ -188,6 +188,8 @@ export default function BillingSetupWizard({ projectId, clientId, canManage, onE
                       step="0.01"
                       value={totalText}
                       onChange={(e) => setTotalText(e.target.value)}
+                      // LEVERAGE: pattern number-input-wheel-guard — number inputs can change accidentally while scrolling; the same hazard exists on billing-setup-cap, CapPanel, ScheduleEntryDialog, and PhaseRateOverridesEditor. Consider an Input-level opt-in after the UX rule is settled.
+                      onWheel={(e) => (e.target as HTMLInputElement).blur()}
                       placeholder="0.00"
                     />
                   </div>

--- a/packages/billing/src/components/project-billing/ProjectBillingView.tsx
+++ b/packages/billing/src/components/project-billing/ProjectBillingView.tsx
@@ -102,7 +102,7 @@ export default function ProjectBillingView({
     );
   };
 
-  const handleGenerateTmInvoice = async () => {
+  const handleGenerateProjectInvoice = async () => {
     setGeneratingInvoice(true);
     try {
       const result = await generateProjectInvoice(projectId);
@@ -123,6 +123,20 @@ export default function ProjectBillingView({
 
   return (
     <div className="flex flex-col gap-3.5 pb-4">
+      {config.invoice_mode === 'standalone' && canManage && (
+        <div className="flex justify-end">
+          <Button
+            id="billing-generate-project-invoice"
+            onClick={handleGenerateProjectInvoice}
+            disabled={generatingInvoice}
+          >
+            {generatingInvoice && <Loader2 className="mr-1.5 h-4 w-4 animate-spin" />}
+            {generatingInvoice
+              ? t('billing.generatingProjectInvoice', 'Generating invoice...')
+              : t('billing.generateProjectInvoice', 'Generate project invoice')}
+          </Button>
+        </div>
+      )}
       {isFixed ? (
         <>
           <div className="flex items-center justify-between">
@@ -154,20 +168,6 @@ export default function ProjectBillingView({
         </>
       ) : (
         <>
-          {config.invoice_mode === 'standalone' && canManage && (
-            <div className="flex justify-end">
-              <Button
-                id="billing-generate-tm-invoice"
-                onClick={handleGenerateTmInvoice}
-                disabled={generatingInvoice}
-              >
-                {generatingInvoice && <Loader2 className="mr-1.5 h-4 w-4 animate-spin" />}
-                {generatingInvoice
-                  ? t('billing.tm.generatingInvoice', 'Generating invoice...')
-                  : t('billing.tm.generateInvoice', 'Generate project invoice')}
-              </Button>
-            </div>
-          )}
           <CapPanel config={config} canManage={canManage} onChanged={onChanged} />
           <PhaseRateOverridesEditor
             overrides={overrides}
@@ -305,6 +305,7 @@ function TermsDialog({
               step="0.01"
               value={totalText}
               onChange={(e) => setTotalText(e.target.value)}
+              onWheel={(e) => (e.target as HTMLInputElement).blur()}
             />
           </div>
           {frozenEntryCount > 0 && (

--- a/packages/billing/src/components/project-billing/ProjectPaymentWarningBanner.tsx
+++ b/packages/billing/src/components/project-billing/ProjectPaymentWarningBanner.tsx
@@ -15,6 +15,35 @@ interface ProjectPaymentWarningBannerProps {
   className?: string;
 }
 
+function splitFirstSentence(message: string): [string, string] {
+  const match = message.match(/^(.+?[.!?])(?:\s+|$)(.*)$/s);
+  return match ? [match[1], match[2]] : [message, ''];
+}
+
+function EmphasizedWarningMessage({
+  message,
+  invoiceNumber,
+}: {
+  message: string;
+  invoiceNumber?: string;
+}) {
+  const [imperative, remainder] = splitFirstSentence(message);
+  const invoiceParts = invoiceNumber ? remainder.split(invoiceNumber) : [remainder];
+
+  return (
+    <>
+      <strong>{imperative}</strong>
+      {remainder && ' '}
+      {invoiceParts.map((part, index) => (
+        <span key={`${part}-${index}`}>
+          {index > 0 && <strong>{invoiceNumber}</strong>}
+          {part}
+        </span>
+      ))}
+    </>
+  );
+}
+
 export default function ProjectPaymentWarningBanner({
   projectId,
   className,
@@ -49,8 +78,10 @@ export default function ProjectPaymentWarningBanner({
   );
 
   let message = genericMessage;
+  let emphasizedInvoiceNumber: string | undefined;
   if (warning.has_billing_details) {
     const invoiceNumber = warning.invoice_number ?? t('billing.paymentWarning.invoiceFallback', 'the linked invoice');
+    emphasizedInvoiceNumber = invoiceNumber;
     if (warning.kind === 'invoice_preparation') {
       message = t(
         'billing.paymentWarning.preparation',
@@ -78,7 +109,7 @@ export default function ProjectPaymentWarningBanner({
         <span className="font-medium">
           {t('billing.paymentWarning.title', 'Payment prerequisite warning')}
         </span>{' '}
-        {message}
+        <EmphasizedWarningMessage message={message} invoiceNumber={emphasizedInvoiceNumber} />
       </AlertDescription>
     </Alert>
   );

--- a/packages/billing/src/components/project-billing/ScheduleTable.tsx
+++ b/packages/billing/src/components/project-billing/ScheduleTable.tsx
@@ -1,12 +1,12 @@
 'use client';
 
-import { useMemo, useState } from 'react';
+import { useEffect, useMemo, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { Button } from '@alga-psa/ui/components/Button';
 import { Dialog, DialogContent } from '@alga-psa/ui/components/Dialog';
 import { Input } from '@alga-psa/ui/components/Input';
 import { Label } from '@alga-psa/ui/components/Label';
-import { LockKeyhole, Plus, Pencil, Trash2 } from 'lucide-react';
+import { AlertTriangle, LockKeyhole, Plus, Pencil, Trash2 } from 'lucide-react';
 import { toast } from 'react-hot-toast';
 import type { IProjectBillingConfig, IProjectPhase } from '@alga-psa/types';
 import type {
@@ -35,6 +35,7 @@ import { useCurrencyFormat } from '@alga-psa/ui/lib';
 import { Tooltip } from '@alga-psa/ui/components/Tooltip';
 import { getEntryDisplayPercentage } from './billingViewHelpers';
 import { recalculateProjectTotalFromSchedule } from '../../actions/projectBillingConfigActions';
+import { getCurrentDateInUserTimeZone, isPhaseBillingOverdue } from '@alga-psa/core';
 
 interface ScheduleTableProps {
   config: IProjectBillingConfig;
@@ -87,6 +88,11 @@ export default function ScheduleTable({
   const [holdReason, setHoldReason] = useState('');
   const [recalculateOpen, setRecalculateOpen] = useState(false);
   const [recalculating, setRecalculating] = useState(false);
+  const [today, setToday] = useState<string | null>(null);
+
+  useEffect(() => {
+    setToday(getCurrentDateInUserTimeZone());
+  }, []);
 
   const allocation = useMemo(() => {
     const total = config.total_price ?? 0;
@@ -432,7 +438,25 @@ export default function ScheduleTable({
                   <td className="px-3.5 py-3 text-right font-semibold tabular-nums text-[rgb(var(--color-text-900))]">
                     {money(entry.computed_amount, currency ?? undefined)}
                   </td>
-                  <td className="px-3.5 py-3"><StatusChip status={entry.status} /></td>
+                  <td className="px-3.5 py-3">
+                    <span className="inline-flex items-center gap-1.5">
+                      <StatusChip status={entry.status} />
+                      {isPhaseBillingOverdue(entry, today) && (
+                        <Tooltip content={t(
+                          'billing.schedule.phaseOverdue',
+                          'Phase end date has passed — mark the phase complete to make this entry ready',
+                        )}>
+                          <AlertTriangle
+                            className="h-3.5 w-3.5 text-amber-600 dark:text-amber-400"
+                            aria-label={t(
+                              'billing.schedule.phaseOverdue',
+                              'Phase end date has passed — mark the phase complete to make this entry ready',
+                            )}
+                          />
+                        </Tooltip>
+                      )}
+                    </span>
+                  </td>
                   <td className="px-3.5 py-3">
                     {entry.invoice_number && entry.invoice_id ? (
                       <button

--- a/packages/billing/src/lib/adapters/invoiceAdapters.test.ts
+++ b/packages/billing/src/lib/adapters/invoiceAdapters.test.ts
@@ -146,6 +146,72 @@ describe('mapDbInvoiceToWasmViewModel', () => {
     expect(mapped?.total).toBe(94830);
   });
 
+  it('maps tax-bearing line totals from net amounts while keeping tax in invoice totals', () => {
+    const mapped = mapDbInvoiceToWasmViewModel({
+      invoice_number: 'INV-TAXED',
+      invoice_date: '2026-07-30',
+      due_date: '2026-08-15',
+      currency_code: 'USD',
+      client: { name: 'Taxed Client', address: '1 Main St' },
+      invoice_charges: [
+        {
+          item_id: 'milestone-1',
+          description: 'Project milestone',
+          quantity: 1,
+          unit_price: 10_000,
+          net_amount: 10_000,
+          tax_amount: 800,
+          total_price: 10_800,
+        },
+      ],
+      subtotal: 10_000,
+      tax: 800,
+      total: null,
+    });
+
+    expect(mapped?.items[0]).toMatchObject({ total: 10_000, taxAmount: 800 });
+    expect(mapped?.subtotal).toBe(10_000);
+    expect(mapped?.tax).toBe(800);
+    expect(mapped?.total).toBe(10_800);
+  });
+
+  it('leaves discount and zero-tax line displays unchanged', () => {
+    const mapped = mapDbInvoiceToWasmViewModel({
+      invoice_number: 'INV-NO-TAX',
+      invoice_date: '2026-07-30',
+      due_date: '2026-08-15',
+      currency_code: 'USD',
+      client: { name: 'No Tax Client', address: '2 Main St' },
+      invoice_charges: [
+        {
+          item_id: 'service-1',
+          description: 'Service',
+          quantity: 1,
+          unit_price: 10_000,
+          net_amount: 10_000,
+          tax_amount: 0,
+          total_price: 10_000,
+        },
+        {
+          item_id: 'discount-1',
+          description: 'Discount',
+          quantity: 1,
+          unit_price: -1_000,
+          net_amount: -1_000,
+          tax_amount: 0,
+          total_price: -1_000,
+        },
+      ],
+      subtotal: 9_000,
+      tax: 0,
+      total: 9_000,
+    });
+
+    expect(mapped?.items.map((item) => item.total)).toEqual([10_000, -1_000]);
+    expect(mapped?.subtotal).toBe(9_000);
+    expect(mapped?.total).toBe(9_000);
+  });
+
   it('maps tenant snapshot details when provided by the invoice query payload', () => {
     const mapped = mapDbInvoiceToWasmViewModel({
       invoice_number: 'INV-601',

--- a/packages/billing/src/lib/adapters/invoiceAdapters.ts
+++ b/packages/billing/src/lib/adapters/invoiceAdapters.ts
@@ -319,7 +319,7 @@ export function mapDbInvoiceToWasmViewModel(inputData: DbInvoiceViewModel | Wasm
       const rawTax = toFiniteNumber((dbData as any).tax);
       const rawTotal = toFiniteNumber((dbData as any).total ?? (dbData as any).total_amount);
       const rawItemTotalsSum = (dbData.invoice_charges ?? []).reduce(
-        (sum: number, item: IInvoiceCharge) => sum + toFiniteNumber(item.total_price),
+        (sum: number, item: IInvoiceCharge) => sum + toFiniteNumber(item.net_amount ?? item.total_price),
         0
       );
       const useLegacyMajorUnits = looksLikeLegacyMajorUnitPayload({
@@ -368,7 +368,7 @@ export function mapDbInvoiceToWasmViewModel(inputData: DbInvoiceViewModel | Wasm
           description: String(item.description ?? ''),
           quantity: toFiniteNumber(item.quantity),
           unitPrice: toMinorUnits(item.unit_price),
-          total: toMinorUnits(item.total_price),
+          total: toMinorUnits(item.net_amount ?? item.total_price),
           taxAmount: toMinorUnits(item.tax_amount),
           servicePeriodStart: summaryStart,
           servicePeriodEnd: summaryEnd,

--- a/packages/billing/src/models/projectBillingScheduleEntry.ts
+++ b/packages/billing/src/models/projectBillingScheduleEntry.ts
@@ -50,6 +50,7 @@ export type ProjectBillingStatusTransitionExtra = Partial<Omit<
 export interface ScheduleEntryView extends IProjectBillingScheduleEntry {
   computed_amount: number;
   phase_name: string | null;
+  phase_end_date: Date | string | null;
   invoice_number: string | null;
   phase_deleted: boolean;
 }
@@ -265,6 +266,7 @@ const ProjectBillingScheduleEntry = {
         'p.client_id',
         'client.client_name',
         'phase.phase_name',
+        'phase.end_date as phase_end_date',
         'invoice.invoice_number'
       )
       .orderBy('e.ready_at', 'asc')
@@ -328,6 +330,7 @@ const ProjectBillingScheduleEntry = {
         client_id,
         client_name,
         phase_name,
+        phase_end_date,
         invoice_number,
         ...entryData
       } = row as Record<string, unknown>;
@@ -338,6 +341,9 @@ const ProjectBillingScheduleEntry = {
           ...entry,
           computed_amount: computedByEntryId.get(entry.schedule_entry_id) ?? 0,
           phase_name: typeof phase_name === 'string' ? phase_name : null,
+          phase_end_date: phase_end_date instanceof Date || typeof phase_end_date === 'string'
+            ? phase_end_date
+            : null,
           invoice_number: typeof invoice_number === 'string' ? invoice_number : null,
           phase_deleted: entry.phase_id !== null && !phase_name
         },

--- a/packages/billing/tests/accountingSyncActions.ce.contract.test.ts
+++ b/packages/billing/tests/accountingSyncActions.ce.contract.test.ts
@@ -27,4 +27,15 @@ describe('CE invoice sync-status capability probe', () => {
     expect(hookSource).toContain('invoiceIds.length > 0 && Object.keys(result).length === 0');
     expect(hookSource).toContain('setHidden(true)');
   });
+
+  it('returns no statuses when QuickBooks is not connected', () => {
+    const statusAction = actionSource.slice(
+      actionSource.indexOf('export const getInvoiceSyncStatuses'),
+      actionSource.indexOf('export interface AccountingSyncRealmInfo'),
+    );
+
+    expect(statusAction).toContain('const realm = await resolveDefaultRealm(knex, tenant).catch(() => null);');
+    expect(statusAction).toContain('if (!realm)');
+    expect(statusAction.indexOf('if (!realm)')).toBeLessThan(statusAction.indexOf("table('tenant_external_entity_mappings')"));
+  });
 });

--- a/packages/billing/tests/projectBillingStandaloneUi.contract.test.ts
+++ b/packages/billing/tests/projectBillingStandaloneUi.contract.test.ts
@@ -1,0 +1,34 @@
+// @vitest-environment node
+
+import { readFileSync } from 'node:fs';
+import path from 'node:path';
+import { describe, expect, it } from 'vitest';
+
+const repoRoot = path.resolve(__dirname, '../../..');
+const readRepo = (relativePath: string) => readFileSync(path.join(repoRoot, relativePath), 'utf8');
+
+const reviewTab = readRepo(
+  'packages/billing/src/components/billing-dashboard/invoicing/ProjectBillingReviewTab.tsx',
+);
+const projectBillingView = readRepo(
+  'packages/billing/src/components/project-billing/ProjectBillingView.tsx',
+);
+
+describe('standalone project billing UI contract', () => {
+  it('offers standalone review rows only the approve-and-invoice path', () => {
+    expect(reviewTab).toContain("record.invoice_mode === 'recurring' && (");
+    expect(reviewTab).toContain("record.invoice_mode === 'standalone' && (");
+    expect(reviewTab).toContain("selectedRows.every((row) => row.invoice_mode === 'recurring')");
+    expect(reviewTab).toContain('{canBulkApproveSelection && (');
+  });
+
+  it('offers invoice generation for every manageable standalone project', () => {
+    const generateAction = "config.invoice_mode === 'standalone' && canManage";
+    expect(projectBillingView).toContain(generateAction);
+    expect(projectBillingView.indexOf(generateAction)).toBeLessThan(
+      projectBillingView.indexOf('{isFixed ? ('),
+    );
+    expect(projectBillingView).toContain('id="billing-generate-project-invoice"');
+    expect(projectBillingView).toContain('onClick={handleGenerateProjectInvoice}');
+  });
+});

--- a/packages/billing/tests/projectBillingUiFeatureFlag.contract.test.ts
+++ b/packages/billing/tests/projectBillingUiFeatureFlag.contract.test.ts
@@ -24,6 +24,7 @@ function sourceFiles(root: string): string[] {
   return readdirSync(root, { withFileTypes: true }).flatMap((entry) => {
     const absolutePath = path.join(root, entry.name);
     if (entry.isDirectory()) return sourceFiles(absolutePath);
+    if (/\.(test|spec)\.(ts|tsx)$/.test(entry.name)) return [];
     return /\.(ts|tsx)$/.test(entry.name) ? [absolutePath] : [];
   });
 }
@@ -65,6 +66,11 @@ describe('project-billing UI-only feature flag contract', () => {
     expect(rootLayout).toContain("checkFeatureFlag('project-billing-ui')");
     expect(rootLayout).toContain("<PostHogProvider initialFeatureFlags={{ 'project-billing-ui': projectBillingUiEnabled }}>");
     expect(postHogProvider).toContain('featureFlags: initialFeatureFlagsRef.current');
+    expect(postHogProvider).toContain(
+      '<FeatureFlagBootstrapProvider initialFeatureFlags={initialFeatureFlagsRef.current}>'
+    );
+    expect(featureFlagHook).toContain('const bootstrappedValue = useBootstrappedFeatureFlag(flagKey);');
+    expect(featureFlagHook).toContain('if (bootstrappedValue !== undefined) return Boolean(bootstrappedValue);');
     expect(featureFlagHook).toContain('posthog.onFeatureFlags(() => {');
     expect(featureFlagHook).toContain('unsubscribeFromFeatureFlags();');
     expect(featureFlagHook).not.toContain('posthog.isFeatureEnabled === undefined');

--- a/packages/billing/tests/projectBillingUiFeatureFlag.contract.test.ts
+++ b/packages/billing/tests/projectBillingUiFeatureFlag.contract.test.ts
@@ -15,6 +15,9 @@ const clientConfig = readRepo('packages/projects/src/components/ClientPortalConf
 const clientSummary = readRepo('packages/client-portal/src/components/projects/ProjectBillingSummarySection.tsx');
 const invoicingHub = readRepo('packages/billing/src/components/billing-dashboard/InvoicingHub.tsx');
 const customTabs = readRepo('packages/ui/src/components/CustomTabs.tsx');
+const featureFlagHook = readRepo('packages/ui/src/hooks/useFeatureFlag.tsx');
+const rootLayout = readRepo('server/src/app/layout.tsx');
+const postHogProvider = readRepo('server/src/components/providers/PostHogProvider.tsx');
 const flagDocs = readRepo('docs/features/feature-flags.md');
 
 function sourceFiles(root: string): string[] {
@@ -58,7 +61,16 @@ describe('project-billing UI-only feature flag contract', () => {
     expect(clientSummary).toContain('if (!projectBillingUiEnabled || !summary || !summary.enabled)');
   });
 
-  it('documents the flag and keeps its runtime key out of backend code', () => {
+  it('bootstraps the flag on the server and subscribes clients to flag changes', () => {
+    expect(rootLayout).toContain("checkFeatureFlag('project-billing-ui')");
+    expect(rootLayout).toContain("<PostHogProvider initialFeatureFlags={{ 'project-billing-ui': projectBillingUiEnabled }}>");
+    expect(postHogProvider).toContain('featureFlags: initialFeatureFlagsRef.current');
+    expect(featureFlagHook).toContain('posthog.onFeatureFlags(() => {');
+    expect(featureFlagHook).toContain('unsubscribeFromFeatureFlags();');
+    expect(featureFlagHook).not.toContain('posthog.isFeatureEnabled === undefined');
+  });
+
+  it('documents the flag and keeps its runtime key out of backend behavior', () => {
     expect(flagDocs).toContain('### 11. `project-billing-ui`');
     expect(flagDocs).toContain('Backend actions, APIs, services, events, jobs, invoice behavior, database logic, and authorization are always available');
 
@@ -84,6 +96,7 @@ describe('project-billing UI-only feature flag contract', () => {
       'packages/projects/src/components/ProjectInfo.tsx',
       'packages/projects/src/components/TaskForm.tsx',
       'packages/scheduling/src/components/time-management/time-entry/time-sheet/TimeEntryDialog.tsx',
+      'server/src/app/layout.tsx',
     ]);
   });
 });

--- a/packages/client-portal/src/components/billing/InvoiceDetailsDialog.tsx
+++ b/packages/client-portal/src/components/billing/InvoiceDetailsDialog.tsx
@@ -304,7 +304,7 @@ const InvoiceDetailsDialog: React.FC<InvoiceDetailsDialogProps> = React.memo(({
         </td>
         <td className="px-3 py-2">{item.quantity}</td>
         <td className="px-3 py-2">{formatCurrency(item.unit_price, invoice.currencyCode)}</td>
-        <td className="px-3 py-2">{formatCurrency(item.total_price, invoice.currencyCode)}</td>
+        <td className="px-3 py-2">{formatCurrency(item.net_amount ?? item.total_price, invoice.currencyCode)}</td>
       </tr>
     );
 
@@ -376,7 +376,7 @@ const InvoiceDetailsDialog: React.FC<InvoiceDetailsDialogProps> = React.memo(({
               <div className="space-y-4 mt-2" id="client-invoice-items-by-location">
                 {locationGroups.map((group) => {
                   const subtotal = group.items.reduce(
-                    (sum, item) => sum + (Number(item.total_price) || 0),
+                    (sum, item) => sum + (Number(item.net_amount ?? item.total_price) || 0),
                     0,
                   );
                   return (

--- a/packages/core/src/lib/dateTimeUtils.ts
+++ b/packages/core/src/lib/dateTimeUtils.ts
@@ -104,6 +104,11 @@ export function getCurrentDate(): Temporal.PlainDate {
   return Temporal.Now.plainDateISO();
 }
 
+/** Current calendar date in the viewer's resolved IANA timezone. */
+export function getCurrentDateInUserTimeZone(): string {
+  return Temporal.Now.zonedDateTimeISO(getUserTimeZone()).toPlainDate().toString();
+}
+
 export function parseDateSafe(dateStr: string | null | undefined): Temporal.PlainDate | null {
   if (!dateStr) return null;
   try {
@@ -158,4 +163,3 @@ export function formatMinutesAsHoursAndMinutes(
   }
   return `${hours} ${hourText} ${remainingMinutes} ${minLabel}`;
 }
-

--- a/packages/core/src/lib/projectBillingStatus.test.ts
+++ b/packages/core/src/lib/projectBillingStatus.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, it } from 'vitest';
+import { isPhaseBillingOverdue } from './projectBillingStatus';
+
+describe('isPhaseBillingOverdue', () => {
+  const today = '2026-07-30';
+
+  it.each([
+    ['past pending phase entry', '2026-07-29', 'pending', 'phase', true],
+    ['past timestamp-shaped phase entry', '2026-07-29T00:00:00.000Z', 'pending', 'phase', true],
+    ['today pending phase entry', '2026-07-30', 'pending', 'phase', false],
+    ['future pending phase entry', '2026-07-31', 'pending', 'phase', false],
+    ['missing phase end date', null, 'pending', 'phase', false],
+    ['past ready phase entry', '2026-07-29', 'ready', 'phase', false],
+    ['past invoiced phase entry', '2026-07-29', 'invoiced', 'phase', false],
+    ['past pending manual entry', '2026-07-29', 'pending', 'manual', false],
+  ] as const)('%s', (_label, phaseEndDate, status, triggerType, expected) => {
+    expect(isPhaseBillingOverdue({
+      phase_end_date: phaseEndDate,
+      status,
+      trigger_type: triggerType,
+    }, today)).toBe(expected);
+  });
+
+  it('treats database Date values as UTC calendar dates', () => {
+    expect(isPhaseBillingOverdue({
+      phase_end_date: new Date('2026-07-30T00:00:00.000Z'),
+      status: 'pending',
+      trigger_type: 'phase',
+    }, today)).toBe(false);
+  });
+});

--- a/packages/core/src/lib/projectBillingStatus.ts
+++ b/packages/core/src/lib/projectBillingStatus.ts
@@ -1,4 +1,6 @@
 import type { ProjectBillingScheduleStatus, ScheduleEntryView } from '@alga-psa/types';
+import { Temporal } from '@js-temporal/polyfill';
+import { toPlainDate } from './dateTimeUtils';
 
 /**
  * Shared project-billing status presentation + phase badge derivation.
@@ -50,7 +52,7 @@ const STATUS_VISUALS: Record<ProjectBillingScheduleStatus, StatusVisual> = {
     labelKey: 'pending',
   },
   canceled: {
-    chip: 'bg-gray-100 text-gray-400 line-through dark:bg-gray-500/10 dark:text-gray-500',
+    chip: 'bg-gray-100 text-gray-400 line-through dark:bg-gray-500/10 dark:text-gray-400',
     dot: 'bg-gray-300',
     labelKey: 'canceled',
   },
@@ -75,6 +77,32 @@ export interface PhaseBillingBadge {
   /** Summed computed amount of the phase's non-canceled linked entries, in cents. */
   amountCents: number;
   currency: string | null;
+  /** A past-dated phase still has a pending phase-triggered billing entry. */
+  overdue: boolean;
+}
+
+function calendarDate(value: Date | string | null): Temporal.PlainDate | null {
+  if (!value) return null;
+  try {
+    return toPlainDate(value);
+  } catch {
+    return null;
+  }
+}
+
+export function isPhaseBillingOverdue(
+  entry: Pick<ScheduleEntryView, 'phase_end_date' | 'status' | 'trigger_type'>,
+  today: string | null,
+): boolean {
+  const endDate = calendarDate(entry.phase_end_date);
+  const currentDate = calendarDate(today);
+  return Boolean(
+    endDate
+    && currentDate
+    && entry.trigger_type === 'phase'
+    && entry.status === 'pending'
+    && Temporal.PlainDate.compare(endDate, currentDate) < 0,
+  );
 }
 
 /**
@@ -85,6 +113,7 @@ export interface PhaseBillingBadge {
 export function derivePhaseBillingBadges(
   entries: ScheduleEntryView[],
   currency: string | null,
+  today: string | null = null,
 ): Record<string, PhaseBillingBadge> {
   const badges: Record<string, PhaseBillingBadge> = {};
   for (const entry of entries) {
@@ -95,10 +124,12 @@ export function derivePhaseBillingBadges(
         status: entry.status,
         amountCents: entry.computed_amount,
         currency,
+        overdue: isPhaseBillingOverdue(entry, today),
       };
       continue;
     }
     existing.amountCents += entry.computed_amount;
+    existing.overdue ||= isPhaseBillingOverdue(entry, today);
     if (STATUS_RANK[entry.status] > STATUS_RANK[existing.status]) {
       existing.status = entry.status;
     }

--- a/packages/projects/src/actions/phaseCustomStatuses.contract.test.ts
+++ b/packages/projects/src/actions/phaseCustomStatuses.contract.test.ts
@@ -192,7 +192,7 @@ describe('per-phase custom status scenarios', () => {
 
     it('refreshes status count after dialog closes', () => {
       // The useEffect depends on showStatusDialog, so closing the dialog triggers a re-fetch
-      expect(phaseListItemSource).toContain('[isEditing, showStatusDialog, projectId, phase.phase_id]');
+      expect(phaseListItemSource).toContain('[effectiveIsEditing, showStatusDialog, projectId, phase.phase_id]');
     });
   });
 

--- a/packages/projects/src/actions/projectActions.ts
+++ b/packages/projects/src/actions/projectActions.ts
@@ -985,6 +985,7 @@ export const markPhaseComplete = withAuth(async (
         const phase = updatedPhase ?? await ProjectModel.getPhaseById(trx, tenant, phaseId);
         if (!phase) throw new Error('Project phase not found');
 
+        // LEVERAGE: friction phase-readiness-invariant — projects duplicates the billing readiness transition because feature packages cannot depend on each other; move this invariant behind a horizontal project-billing boundary when that layer exists.
         // projects cannot depend on @alga-psa/billing without introducing a
         // feature-package dependency cycle, so readiness is evaluated here
         // with the same optimistic pending predicate as the billing service.

--- a/packages/projects/src/components/PhaseListItem.tsx
+++ b/packages/projects/src/components/PhaseListItem.tsx
@@ -3,7 +3,7 @@
 import { useState, useRef, useEffect } from 'react';
 import { useTranslation } from 'react-i18next';
 import { IProjectPhase } from '@alga-psa/types';
-import { Pencil, Trash2, GripVertical, Columns3, CheckCircle2, RotateCcw } from 'lucide-react';
+import { AlertTriangle, Pencil, Trash2, GripVertical, Columns3, CheckCircle2, RotateCcw } from 'lucide-react';
 import { Button } from '@alga-psa/ui/components/Button';
 import { TextArea } from '@alga-psa/ui/components/TextArea';
 import { DatePicker } from '@alga-psa/ui/components/DatePicker';
@@ -16,6 +16,7 @@ import { useCurrencyFormat } from '@alga-psa/ui/lib';
 import styles from './ProjectDetail.module.css';
 
 interface PhaseListItemProps {
+  viewMode: 'kanban' | 'list' | 'billing';
   phase: IProjectPhase;
   projectId: string;
   isSelected: boolean;
@@ -54,6 +55,7 @@ interface PhaseListItemProps {
 }
 
 export const PhaseListItem: React.FC<PhaseListItemProps> = ({
+  viewMode,
   phase,
   projectId,
   isSelected,
@@ -89,8 +91,10 @@ export const PhaseListItem: React.FC<PhaseListItemProps> = ({
 }) => {
   const { t } = useTranslation('features/projects');
   const { money, symbol } = useCurrencyFormat();
+  const isBillingView = viewMode === 'billing';
+  const effectiveIsEditing = isEditing && !isBillingView;
   const isCompleted = Boolean(phase.completed_at);
-  const showCompletionNudge = !isCompleted && Boolean(allTasksClosed) && (taskCount ?? 0) > 0;
+  const showCompletionNudge = !isBillingView && !isCompleted && Boolean(allTasksClosed) && (taskCount ?? 0) > 0;
   const [isDragging, setIsDragging] = useState(false);
   const [showStatusDialog, setShowStatusDialog] = useState(false);
   const [customStatusCount, setCustomStatusCount] = useState<number | null>(null);
@@ -100,17 +104,17 @@ export const PhaseListItem: React.FC<PhaseListItemProps> = ({
 
   // Load phase custom status count when entering edit mode or after dialog closes
   useEffect(() => {
-    if (!isEditing && !showStatusDialog) return;
+    if (!effectiveIsEditing && !showStatusDialog) return;
     let cancelled = false;
     getProjectStatusMappings(projectId, phase.phase_id)
       .then((mappings) => { if (!cancelled) setCustomStatusCount(mappings.length); })
       .catch(() => { if (!cancelled) setCustomStatusCount(null); });
     return () => { cancelled = true; };
-  }, [isEditing, showStatusDialog, projectId, phase.phase_id]);
+  }, [effectiveIsEditing, showStatusDialog, projectId, phase.phase_id]);
 
   // Auto-scroll the editing form into view when editing starts
   useEffect(() => {
-    if (isEditing && itemRef.current) {
+    if (effectiveIsEditing && itemRef.current) {
       const prefersReducedMotion = window.matchMedia('(prefers-reduced-motion: reduce)').matches;
       requestAnimationFrame(() => {
         const target = actionsRef.current ?? itemRef.current;
@@ -120,7 +124,7 @@ export const PhaseListItem: React.FC<PhaseListItemProps> = ({
         catch { nameInputRef.current?.focus(); }
       });
     }
-  }, [isEditing]);
+  }, [effectiveIsEditing]);
 
   const handleDragStart = (e: React.DragEvent) => {
     setIsDragging(true);
@@ -261,7 +265,7 @@ export const PhaseListItem: React.FC<PhaseListItemProps> = ({
   return (
     <li
       ref={itemRef}
-      draggable={!isEditing}
+      draggable={!isBillingView && !effectiveIsEditing}
       onDragStart={handleDragStart}
       onDragEnd={handleDragEnd}
       className={`relative flex items-center justify-between px-3 py-2.5 rounded-md cursor-pointer group
@@ -272,7 +276,7 @@ export const PhaseListItem: React.FC<PhaseListItemProps> = ({
         ${styles.phaseItem}
       `}
       onClick={() => {
-        if (!isEditing) {
+        if (!effectiveIsEditing) {
           onSelect(phase);
         }
       }}
@@ -280,7 +284,7 @@ export const PhaseListItem: React.FC<PhaseListItemProps> = ({
       onDragLeave={handleDragLeave}
       onDrop={handleDrop}
     >
-      {isEditing ? (
+      {effectiveIsEditing ? (
         <div className="flex flex-col w-full gap-3">
           <div className="flex-1 min-w-0">
             {/* Phase Name Input */}
@@ -387,21 +391,32 @@ export const PhaseListItem: React.FC<PhaseListItemProps> = ({
       ) : (
         <>
           {/* Drag Handle — absolutely positioned so it doesn't consume layout space */}
-          <div className="absolute -left-3 top-1/2 -translate-y-1/2 opacity-0 group-hover:opacity-100 transition-opacity cursor-grab">
-            <GripVertical className="w-4 h-4 text-gray-400 dark:text-gray-500" />
-          </div>
+          {!isBillingView && (
+            <div className="absolute -left-3 top-1/2 -translate-y-1/2 opacity-0 group-hover:opacity-100 transition-opacity cursor-grab">
+              <GripVertical className="w-4 h-4 text-gray-400 dark:text-gray-500" />
+            </div>
+          )}
           {/* Display View */}
           <div className="flex flex-col w-full min-w-0">
             <div className="flex items-start justify-between gap-2">
               <span className="text-lg font-bold text-gray-900 dark:text-gray-100 min-w-0 break-words">{phase.phase_name}</span>
               <div className="flex shrink-0 items-center gap-1.5">
-                {billingBadge && (
-                  <Tooltip content={money(billingBadge.amountCents, billingBadge.currency ?? undefined)}>
+                {isBillingView && billingBadge && (
+                  <Tooltip content={billingBadge.overdue ? (
+                    <div className="space-y-1">
+                      <div>{money(billingBadge.amountCents, billingBadge.currency ?? undefined)}</div>
+                      <div>{t(
+                        'billing.schedule.phaseOverdue',
+                        'Phase end date has passed — mark the phase complete to make this entry ready',
+                      )}</div>
+                    </div>
+                  ) : money(billingBadge.amountCents, billingBadge.currency ?? undefined)}>
                     <span
-                      className={`inline-flex items-center rounded px-1.5 py-0.5 text-[10px] font-bold ${phaseBadgeClasses(billingBadge.status)}`}
+                      className={`inline-flex items-center gap-1 rounded px-1.5 py-0.5 text-[10px] font-bold ${phaseBadgeClasses(billingBadge.status)} ${billingBadge.overdue ? 'ring-2 ring-amber-500/70 dark:ring-amber-400/70' : ''}`}
                       aria-label={t('billing.phaseBadge.label', 'Billing milestone')}
                     >
                       {symbol(billingBadge.currency ?? undefined)}
+                      {billingBadge.overdue && <AlertTriangle className="h-3 w-3" />}
                     </span>
                   </Tooltip>
                 )}
@@ -444,51 +459,53 @@ export const PhaseListItem: React.FC<PhaseListItemProps> = ({
             </div>
           </div>
           {/* Hover Action Buttons — absolutely positioned so they don't consume layout space */}
-          <div className="absolute right-2 bottom-2 flex gap-1 opacity-0 group-hover:opacity-100 bg-inherit rounded">
-            {canCompletePhase && (isCompleted ? (
+          {!isBillingView && (
+            <div className="absolute right-2 bottom-2 flex gap-1 opacity-0 group-hover:opacity-100 bg-inherit rounded">
+              {canCompletePhase && (isCompleted ? (
+                <button
+                  id={`reopen-phase-${phase.phase_id}`}
+                  onClick={(e) => { e.stopPropagation(); onReopen?.(phase); }}
+                  className="p-1 rounded hover:bg-gray-200 dark:hover:bg-[rgb(var(--color-border-200))]"
+                  title={t('phases.reopenPhase', 'Reopen phase')}
+                >
+                  <RotateCcw className="w-3 h-3" />
+                </button>
+              ) : (
+                <button
+                  id={`complete-phase-${phase.phase_id}`}
+                  onClick={(e) => { e.stopPropagation(); onMarkComplete?.(phase); }}
+                  className="p-1 rounded text-green-600 hover:bg-green-50 dark:hover:bg-green-500/10"
+                  title={t('phases.markComplete', 'Mark phase complete')}
+                >
+                  <CheckCircle2 className="w-3 h-3" />
+                </button>
+              ))}
               <button
-                id={`reopen-phase-${phase.phase_id}`}
-                onClick={(e) => { e.stopPropagation(); onReopen?.(phase); }}
+                onClick={(e) => {
+                  e.stopPropagation();
+                  onEdit(phase);
+                }}
                 className="p-1 rounded hover:bg-gray-200 dark:hover:bg-[rgb(var(--color-border-200))]"
-                title={t('phases.reopenPhase', 'Reopen phase')}
+                title={t('phases.editPhase')}
               >
-                <RotateCcw className="w-3 h-3" />
+                <Pencil className="w-3 h-3" />
               </button>
-            ) : (
               <button
-                id={`complete-phase-${phase.phase_id}`}
-                onClick={(e) => { e.stopPropagation(); onMarkComplete?.(phase); }}
-                className="p-1 rounded text-green-600 hover:bg-green-50 dark:hover:bg-green-500/10"
-                title={t('phases.markComplete', 'Mark phase complete')}
+                onClick={(e) => {
+                  e.stopPropagation();
+                  onDelete(phase);
+                }}
+                className="p-1 rounded hover:bg-destructive/15 text-destructive"
+                title={t('phases.deletePhase')}
               >
-                <CheckCircle2 className="w-3 h-3" />
+                <Trash2 className="w-3 h-3" />
               </button>
-            ))}
-            <button
-              onClick={(e) => {
-                e.stopPropagation();
-                onEdit(phase);
-              }}
-              className="p-1 rounded hover:bg-gray-200 dark:hover:bg-[rgb(var(--color-border-200))]"
-              title={t('phases.editPhase')}
-            >
-              <Pencil className="w-3 h-3" />
-            </button>
-            <button
-              onClick={(e) => {
-                e.stopPropagation();
-                onDelete(phase);
-              }}
-              className="p-1 rounded hover:bg-destructive/15 text-destructive"
-              title={t('phases.deletePhase')}
-            >
-              <Trash2 className="w-3 h-3" />
-            </button>
-          </div>
+            </div>
+          )}
         </>
       )}
 
-      {showStatusDialog && (
+      {!isBillingView && showStatusDialog && (
         <Dialog
           isOpen
           onClose={() => { setShowStatusDialog(false); onStatusesChanged?.(); }}

--- a/packages/projects/src/components/ProjectDetail.tsx
+++ b/packages/projects/src/components/ProjectDetail.tsx
@@ -36,7 +36,11 @@ import { getProjectTaskStatuses, getProjectStatusesByPhase, updatePhase, deleteP
 import { checkCurrentUserPermissions } from '@alga-psa/auth/actions';
 import type { ProjectBillingOverview } from '@alga-psa/types';
 import { useProjectBillingIntegration } from '../context/ProjectBillingIntegrationContext';
-import { derivePhaseBillingBadges, formatCurrencyFromMinorUnits } from '@alga-psa/core';
+import {
+  derivePhaseBillingBadges,
+  formatCurrencyFromMinorUnits,
+  getCurrentDateInUserTimeZone,
+} from '@alga-psa/core';
 import { updateTaskStatus, reorderTask, reorderTasksInStatus, moveTaskToPhase, updateTaskWithChecklist, getTaskChecklistItems, getTaskResourcesAction, getTaskTicketLinksAction, duplicateTaskToPhase, deleteTask as deleteTaskAction, getTasksForPhase, getTaskById, getProjectTaskData, assignTeamToProjectTask, removeTeamFromProjectTask, bulkAddTagsToTasks } from '../actions/projectTaskActions';
 import styles from './ProjectDetail.module.css';
 import { toast } from 'react-hot-toast';
@@ -360,6 +364,11 @@ export default function ProjectDetail({
   const [billingOverview, setBillingOverview] = useState<ProjectBillingOverview | null>(null);
   const [billingLoading, setBillingLoading] = useState(false);
   const [billingHighlightEntryId, setBillingHighlightEntryId] = useState<string | null>(null);
+  const [billingToday, setBillingToday] = useState<string | null>(null);
+
+  useEffect(() => {
+    setBillingToday(getCurrentDateInUserTimeZone());
+  }, []);
 
   // State for the Move Task Dialog
   const [isMoveTaskDialogOpen, setIsMoveTaskDialogOpen] = useState(false);
@@ -665,9 +674,9 @@ export default function ProjectDetail({
   // Phase → billing badge (F136) and phase → "all tasks closed" (F138) maps.
   const phaseBillingBadges = useMemo(() => (
     projectBillingUiEnabled && billingOverview?.config
-      ? derivePhaseBillingBadges(billingOverview.entries, billingOverview.config.currency)
+      ? derivePhaseBillingBadges(billingOverview.entries, billingOverview.config.currency, billingToday)
       : {}
-  ), [billingOverview, projectBillingUiEnabled]);
+  ), [billingOverview, billingToday, projectBillingUiEnabled]);
 
   const phaseAllTasksClosed = useMemo(() => {
     const result: Record<string, boolean> = {};
@@ -4235,6 +4244,7 @@ export default function ProjectDetail({
               {/* Phases panel content */}
               <div className={`${styles.phasesList} ${isPhasesPanelVisible ? styles.phasesListVisible : styles.phasesListHidden}`}>
                 <ProjectPhases
+                  viewMode={viewMode}
                   phases={projectPhases}
                   projectId={project.project_id}
                   selectedPhase={selectedPhase}

--- a/packages/projects/src/components/ProjectPhases.tsx
+++ b/packages/projects/src/components/ProjectPhases.tsx
@@ -10,6 +10,7 @@ import styles from './ProjectDetail.module.css';
 import { useTranslation } from 'react-i18next';
 
 interface ProjectPhasesProps {
+  viewMode: 'kanban' | 'list' | 'billing';
   phases: IProjectPhase[];
   projectId: string;
   selectedPhase: IProjectPhase | null;
@@ -55,6 +56,7 @@ interface ProjectPhasesProps {
 }
 
 export const ProjectPhases: React.FC<ProjectPhasesProps> = ({
+  viewMode,
   phases,
   projectId,
   selectedPhase,
@@ -178,14 +180,16 @@ export const ProjectPhases: React.FC<ProjectPhasesProps> = ({
           >
             {isAddingTask ? t('projectPhases.adding', 'Adding...') : t('projectPhases.addTask', '+ Add Task')}
           </Button>
-          <Button
-            id="add-phase-button"
-            onClick={onAddPhase}
-            size="sm"
-          >
-            {t('projectPhases.addPhase', '+ Add Phase')}
-          </Button>
-          {onImport && (
+          {viewMode !== 'billing' && (
+            <Button
+              id="add-phase-button"
+              onClick={onAddPhase}
+              size="sm"
+            >
+              {t('projectPhases.addPhase', '+ Add Phase')}
+            </Button>
+          )}
+          {viewMode !== 'billing' && onImport && (
             <Button
               id="import-phases-tasks-button"
               onClick={onImport}
@@ -246,6 +250,7 @@ export const ProjectPhases: React.FC<ProjectPhasesProps> = ({
               />
             )}
             <PhaseListItem
+              viewMode={viewMode}
               phase={phase}
               projectId={projectId}
               phases={phases}

--- a/packages/projects/src/components/phaseAwareProjectDetail.contract.test.ts
+++ b/packages/projects/src/components/phaseAwareProjectDetail.contract.test.ts
@@ -11,6 +11,8 @@ describe('phase-aware MSP project UI contracts', () => {
   const taskStatusSelectSource = readComponent('TaskStatusSelect.tsx');
   const taskEditSource = readComponent('TaskEdit.tsx');
   const taskQuickAddSource = readComponent('TaskQuickAdd.tsx');
+  const projectPhasesSource = readComponent('ProjectPhases.tsx');
+  const phaseListItemSource = readComponent('PhaseListItem.tsx');
 
   it('T034/T035/T036: ProjectDetail refetches phase-effective statuses and derives counts from them', () => {
     expect(projectDetailSource).toContain('const [projectStatuses, setProjectStatuses] = useState<ProjectStatus[]>(initialStatuses);');
@@ -54,5 +56,16 @@ describe('phase-aware MSP project UI contracts', () => {
     );
     expect(taskEditSource).toContain('projectStatuses={selectedPhaseStatuses}');
     expect(taskQuickAddSource).toContain('projectStatuses={projectStatuses}');
+  });
+
+  it('keeps billing-view phases selectable but read-only and reserves billing badges for that view', () => {
+    expect(projectDetailSource).toContain('viewMode={viewMode}');
+    expect(projectPhasesSource).toContain("viewMode !== 'billing'");
+    expect(projectPhasesSource).toContain('viewMode={viewMode}');
+    expect(phaseListItemSource).toContain("const isBillingView = viewMode === 'billing';");
+    expect(phaseListItemSource).toContain('draggable={!isBillingView && !effectiveIsEditing}');
+    expect(phaseListItemSource).toContain('{isBillingView && billingBadge && (');
+    expect(phaseListItemSource).toContain('{!isBillingView && (');
+    expect(phaseListItemSource).toContain('onSelect(phase);');
   });
 });

--- a/packages/scheduling/src/components/time-management/time-entry/time-sheet/TimeEntryDialog.tsx
+++ b/packages/scheduling/src/components/time-management/time-entry/time-sheet/TimeEntryDialog.tsx
@@ -52,6 +52,11 @@ interface TimeEntryDialogProps {
   inDrawer?: boolean;
 }
 
+function splitPaymentWarning(message: string): [string, string] {
+  const match = message.match(/^(.+?[.!?])(?:\s+|$)(.*)$/s);
+  return match ? [match[1], match[2]] : [message, ''];
+}
+
 // Main dialog content component
 const TimeEntryDialogContent = memo(function TimeEntryDialogContent(props: TimeEntryDialogProps): React.JSX.Element {
   const {
@@ -302,6 +307,13 @@ const TimeEntryDialogContent = memo(function TimeEntryDialogContent(props: TimeE
   const title = hasExistingEntry
     ? `${isEditable ? 'Edit' : 'View'} Time Entry for ${workItem.name}`
     : `Add New Time Entry for ${workItem.name}`;
+  // LEVERAGE: pattern payment-warning-banner — this duplicates the project-billing warning presentation because scheduling cannot import billing UI; extract through the cross-feature composition layer if another consumer appears.
+  const [paymentWarningEmphasis, paymentWarningRest] = splitPaymentWarning(t(
+    'workItemPicker.paymentWarning',
+    {
+      defaultValue: 'Payment is required for a flagged project billing milestone and has not been confirmed. Confirm payment before continuing work.',
+    },
+  ));
   const footerActions = (
     <div className="flex justify-end space-x-2">
       <Button
@@ -338,9 +350,8 @@ const TimeEntryDialogContent = memo(function TimeEntryDialogContent(props: TimeE
                 defaultValue: 'Payment prerequisite warning',
               })}
             </span>{' '}
-            {t('workItemPicker.paymentWarning', {
-              defaultValue: 'Payment is required for a flagged project billing milestone and has not been confirmed. Confirm payment before continuing work.',
-            })}
+            <strong>{paymentWarningEmphasis}</strong>
+            {paymentWarningRest && <> {paymentWarningRest}</>}
           </AlertDescription>
         </Alert>
       )}

--- a/packages/types/src/interfaces/projectBilling.interfaces.ts
+++ b/packages/types/src/interfaces/projectBilling.interfaces.ts
@@ -95,6 +95,7 @@ export interface ProjectBillingEconomics {
 export interface ScheduleEntryView extends IProjectBillingScheduleEntry {
   computed_amount: number;
   phase_name: string | null;
+  phase_end_date: Date | string | null;
   invoice_number: string | null;
   phase_deleted: boolean;
 }

--- a/packages/ui/src/components/Dialog.tsx
+++ b/packages/ui/src/components/Dialog.tsx
@@ -430,7 +430,7 @@ export function Dialog({
           </div>
           {/* Sticky footer — rendered outside the scrollable body */}
           {footer && (
-            <div className="flex-shrink-0 border-t border-[rgb(var(--color-border-100))] px-6 py-4 bg-[rgb(var(--color-card))] rounded-b-lg">
+            <div className="flex flex-shrink-0 justify-end gap-2 border-t border-[rgb(var(--color-border-100))] bg-[rgb(var(--color-card))] px-6 py-4 rounded-b-lg">
               {footer}
             </div>
           )}
@@ -559,7 +559,7 @@ export function Dialog({
           </div>
           {/* Sticky footer — rendered outside the scrollable body */}
           {footer && (
-            <div className="flex-shrink-0 border-t border-[rgb(var(--color-border-100))] px-6 py-4 bg-[rgb(var(--color-card))] rounded-b-lg">
+            <div className="flex flex-shrink-0 justify-end gap-2 border-t border-[rgb(var(--color-border-100))] bg-[rgb(var(--color-card))] px-6 py-4 rounded-b-lg">
               {footer}
             </div>
           )}

--- a/packages/ui/src/hooks/useFeatureFlag.test.tsx
+++ b/packages/ui/src/hooks/useFeatureFlag.test.tsx
@@ -1,0 +1,79 @@
+import { act, renderHook } from '@testing-library/react';
+import type { ReactNode } from 'react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+const posthog = {
+  isFeatureEnabled: vi.fn(() => false),
+  onFeatureFlags: vi.fn((_callback: () => void) => vi.fn()),
+};
+
+vi.mock('next-auth/react', () => ({
+  useSession: () => ({ data: null }),
+}));
+
+vi.mock('posthog-js/react', () => ({
+  usePostHog: () => posthog,
+}));
+
+import { FeatureFlagBootstrapProvider, useFeatureFlag } from './useFeatureFlag';
+
+describe('useFeatureFlag', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    posthog.isFeatureEnabled.mockClear();
+    posthog.onFeatureFlags.mockClear();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('uses the server-bootstrapped value until PostHog delivers an update', async () => {
+    const wrapper = ({ children }: { children: ReactNode }) => (
+      <FeatureFlagBootstrapProvider initialFeatureFlags={{ 'project-billing-ui': true }}>
+        {children}
+      </FeatureFlagBootstrapProvider>
+    );
+
+    const { result } = renderHook(
+      () => useFeatureFlag('project-billing-ui', { defaultValue: false }),
+      { wrapper }
+    );
+
+    expect(result.current).toMatchObject({ enabled: true, loading: false, error: null });
+    expect(posthog.isFeatureEnabled).not.toHaveBeenCalled();
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(200);
+    });
+
+    expect(result.current.enabled).toBe(true);
+    expect(posthog.isFeatureEnabled).not.toHaveBeenCalled();
+  });
+
+  it('accepts later PostHog flag updates after the bootstrapped render', async () => {
+    let deliverFeatureFlags: (() => void) | undefined;
+    posthog.onFeatureFlags.mockImplementationOnce((callback: () => void) => {
+      deliverFeatureFlags = callback;
+      return vi.fn();
+    });
+
+    const wrapper = ({ children }: { children: ReactNode }) => (
+      <FeatureFlagBootstrapProvider initialFeatureFlags={{ 'project-billing-ui': true }}>
+        {children}
+      </FeatureFlagBootstrapProvider>
+    );
+
+    const { result } = renderHook(
+      () => useFeatureFlag('project-billing-ui', { defaultValue: false }),
+      { wrapper }
+    );
+
+    await act(async () => {
+      deliverFeatureFlags?.();
+    });
+
+    expect(result.current.enabled).toBe(false);
+    expect(posthog.isFeatureEnabled).toHaveBeenCalledWith('project-billing-ui');
+  });
+});

--- a/packages/ui/src/hooks/useFeatureFlag.tsx
+++ b/packages/ui/src/hooks/useFeatureFlag.tsx
@@ -2,9 +2,35 @@
 // TODO: getFeatureFlags vs getFeatureFlag typo in PostHog API
 'use client';
 
-import { useState, useEffect } from 'react';
+import { createContext, useContext, useState, useEffect, type ReactNode } from 'react';
 import { useSession } from 'next-auth/react';
 import { usePostHog } from 'posthog-js/react';
+
+type FeatureFlagValue = boolean | string;
+type FeatureFlagBootstrap = Record<string, FeatureFlagValue>;
+
+const FeatureFlagBootstrapContext = createContext<FeatureFlagBootstrap>({});
+
+export function FeatureFlagBootstrapProvider({
+  children,
+  initialFeatureFlags,
+}: {
+  children: ReactNode;
+  initialFeatureFlags: FeatureFlagBootstrap;
+}) {
+  return (
+    <FeatureFlagBootstrapContext.Provider value={initialFeatureFlags}>
+      {children}
+    </FeatureFlagBootstrapContext.Provider>
+  );
+}
+
+function useBootstrappedFeatureFlag(flagKey: string): FeatureFlagValue | undefined {
+  const initialFeatureFlags = useContext(FeatureFlagBootstrapContext);
+  return Object.prototype.hasOwnProperty.call(initialFeatureFlags, flagKey)
+    ? initialFeatureFlags[flagKey]
+    : undefined;
+}
 
 const FEATURE_FLAG_DISABLE_VALUES = new Set(['true', '1', 'yes', 'on']);
 const featureFlagsDisabled =
@@ -71,12 +97,16 @@ export function useFeatureFlag(
   const { data: session } = useSession();
   const posthog = usePostHog();
   const forcedValue = getForcedFlagValue(flagKey);
+  const bootstrappedValue = useBootstrappedFeatureFlag(flagKey);
   const [enabled, setEnabled] = useState<boolean>(() => {
     if (featureFlagsDisabled) return true;
     if (forcedValue !== undefined) return coerceForcedBoolean(flagKey, forcedValue);
+    if (bootstrappedValue !== undefined) return Boolean(bootstrappedValue);
     return typeof options.defaultValue === 'boolean' ? options.defaultValue : false;
   });
-  const [loading, setLoading] = useState(!featureFlagsDisabled);
+  const [loading, setLoading] = useState(
+    !featureFlagsDisabled && forcedValue === undefined && bootstrappedValue === undefined
+  );
   const [error, setError] = useState<Error | null>(null);
 
   useEffect(() => {
@@ -130,9 +160,11 @@ export function useFeatureFlag(
       }
     };
 
-    const timeoutId = setTimeout(() => {
-      checkFlag();
-    }, 200);
+    const timeoutId = bootstrappedValue === undefined
+      ? setTimeout(() => {
+          void checkFlag();
+        }, 200)
+      : undefined;
 
     const unsubscribeFromFeatureFlags = posthog.onFeatureFlags(() => {
       void checkFlag();
@@ -141,17 +173,17 @@ export function useFeatureFlag(
     if (options.pollInterval && options.pollInterval > 0) {
       const interval = setInterval(checkFlag, options.pollInterval);
       return () => {
-        clearTimeout(timeoutId);
+        if (timeoutId !== undefined) clearTimeout(timeoutId);
         clearInterval(interval);
         unsubscribeFromFeatureFlags();
       };
     }
 
     return () => {
-      clearTimeout(timeoutId);
+      if (timeoutId !== undefined) clearTimeout(timeoutId);
       unsubscribeFromFeatureFlags();
     };
-  }, [posthog, flagKey, session?.user?.id, session?.user?.tenant, options.userId, options.pollInterval, forcedValue]);
+  }, [posthog, flagKey, session?.user?.id, session?.user?.tenant, options.userId, options.pollInterval, forcedValue, bootstrappedValue]);
 
   return { enabled, loading, error };
 }

--- a/packages/ui/src/hooks/useFeatureFlag.tsx
+++ b/packages/ui/src/hooks/useFeatureFlag.tsx
@@ -108,12 +108,6 @@ export function useFeatureFlag(
         const distinctId = userId || 'anonymous';
         void distinctId;
 
-        if (posthog.isFeatureEnabled === undefined) {
-          console.warn(`[FeatureFlag] PostHog not ready yet for ${flagKey}`);
-          setTimeout(() => checkFlag(), 100);
-          return;
-        }
-
         const flagValue = posthog.isFeatureEnabled(flagKey);
 
         if (process.env.NODE_ENV === 'development') {
@@ -140,15 +134,23 @@ export function useFeatureFlag(
       checkFlag();
     }, 200);
 
+    const unsubscribeFromFeatureFlags = posthog.onFeatureFlags(() => {
+      void checkFlag();
+    });
+
     if (options.pollInterval && options.pollInterval > 0) {
       const interval = setInterval(checkFlag, options.pollInterval);
       return () => {
         clearTimeout(timeoutId);
         clearInterval(interval);
+        unsubscribeFromFeatureFlags();
       };
     }
 
-    return () => clearTimeout(timeoutId);
+    return () => {
+      clearTimeout(timeoutId);
+      unsubscribeFromFeatureFlags();
+    };
   }, [posthog, flagKey, session?.user?.id, session?.user?.tenant, options.userId, options.pollInterval, forcedValue]);
 
   return { enabled, loading, error };

--- a/server/public/locales/de/features/projects.json
+++ b/server/public/locales/de/features/projects.json
@@ -1618,6 +1618,7 @@
       "manualSub": "Manueller Auslöser",
       "phaseRemoved": "Manuell · Phase entfernt",
       "phaseTrigger": "Phasenabschluss",
+      "phaseOverdue": "Das Enddatum der Phase ist verstrichen — markieren Sie die Phase als abgeschlossen, damit dieser Eintrag abrechnungsbereit wird",
       "approve": "Genehmigen",
       "approveInvoice": "Genehmigen und abrechnen",
       "hold": "Zurückstellen",
@@ -1690,9 +1691,9 @@
       "saving": "Wird gespeichert...",
       "errorAmount": "Geben Sie eine Obergrenze größer als null ein"
     },
+    "generateProjectInvoice": "Projektrechnung erstellen",
+    "generatingProjectInvoice": "Rechnung wird erstellt...",
     "tm": {
-      "generateInvoice": "Projektrechnung erstellen",
-      "generatingInvoice": "Rechnung wird erstellt...",
       "invoiceGenerated": "Projektrechnung erstellt"
     },
     "overrides": {

--- a/server/public/locales/en/features/projects.json
+++ b/server/public/locales/en/features/projects.json
@@ -1637,6 +1637,7 @@
       "manualSub": "Manual trigger",
       "phaseRemoved": "Manual · phase removed",
       "phaseTrigger": "Phase completion",
+      "phaseOverdue": "Phase end date has passed — mark the phase complete to make this entry ready",
       "approve": "Approve",
       "approveInvoice": "Approve & invoice",
       "hold": "Hold",
@@ -1715,9 +1716,9 @@
       "saving": "Saving...",
       "errorAmount": "Enter a cap greater than zero"
     },
+    "generateProjectInvoice": "Generate project invoice",
+    "generatingProjectInvoice": "Generating invoice...",
     "tm": {
-      "generateInvoice": "Generate project invoice",
-      "generatingInvoice": "Generating invoice...",
       "invoiceGenerated": "Project invoice generated"
     },
     "overrides": {

--- a/server/public/locales/es/features/projects.json
+++ b/server/public/locales/es/features/projects.json
@@ -1618,6 +1618,7 @@
       "manualSub": "Desencadenante manual",
       "phaseRemoved": "Manual · fase eliminada",
       "phaseTrigger": "Finalización de fase",
+      "phaseOverdue": "La fecha de finalización de la fase ya pasó — marque la fase como completada para que esta entrada quede lista",
       "approve": "Aprobar",
       "approveInvoice": "Aprobar y facturar",
       "hold": "Retener",
@@ -1690,9 +1691,9 @@
       "saving": "Guardando...",
       "errorAmount": "Introduzca un límite mayor que cero"
     },
+    "generateProjectInvoice": "Generar factura del proyecto",
+    "generatingProjectInvoice": "Generando factura...",
     "tm": {
-      "generateInvoice": "Generar factura del proyecto",
-      "generatingInvoice": "Generando factura...",
       "invoiceGenerated": "Factura del proyecto generada"
     },
     "overrides": {

--- a/server/public/locales/fr/features/projects.json
+++ b/server/public/locales/fr/features/projects.json
@@ -1618,6 +1618,7 @@
       "manualSub": "Déclencheur manuel",
       "phaseRemoved": "Manuel · phase supprimée",
       "phaseTrigger": "Achèvement de la phase",
+      "phaseOverdue": "La date de fin de la phase est dépassée — marquez la phase comme terminée pour rendre cette entrée prête",
       "approve": "Approuver",
       "approveInvoice": "Approuver et facturer",
       "hold": "Suspendre",
@@ -1690,9 +1691,9 @@
       "saving": "Enregistrement...",
       "errorAmount": "Saisissez un plafond supérieur à zéro"
     },
+    "generateProjectInvoice": "Générer la facture du projet",
+    "generatingProjectInvoice": "Génération de la facture...",
     "tm": {
-      "generateInvoice": "Générer la facture du projet",
-      "generatingInvoice": "Génération de la facture...",
       "invoiceGenerated": "Facture du projet générée"
     },
     "overrides": {

--- a/server/public/locales/it/features/projects.json
+++ b/server/public/locales/it/features/projects.json
@@ -1618,6 +1618,7 @@
       "manualSub": "Attivazione manuale",
       "phaseRemoved": "Manuale · fase rimossa",
       "phaseTrigger": "Completamento fase",
+      "phaseOverdue": "La data di fine della fase è trascorsa — contrassegna la fase come completata per rendere pronta questa voce",
       "approve": "Approva",
       "approveInvoice": "Approva e fattura",
       "hold": "Sospendi",
@@ -1690,9 +1691,9 @@
       "saving": "Salvataggio...",
       "errorAmount": "Inserisci un limite maggiore di zero"
     },
+    "generateProjectInvoice": "Genera fattura progetto",
+    "generatingProjectInvoice": "Generazione fattura...",
     "tm": {
-      "generateInvoice": "Genera fattura progetto",
-      "generatingInvoice": "Generazione fattura...",
       "invoiceGenerated": "Fattura progetto generata"
     },
     "overrides": {

--- a/server/public/locales/nl/features/projects.json
+++ b/server/public/locales/nl/features/projects.json
@@ -1618,6 +1618,7 @@
       "manualSub": "Handmatige activering",
       "phaseRemoved": "Handmatig · fase verwijderd",
       "phaseTrigger": "Voltooiing van fase",
+      "phaseOverdue": "De einddatum van de fase is verstreken — markeer de fase als voltooid om deze post gereed te maken",
       "approve": "Goedkeuren",
       "approveInvoice": "Goedkeuren en factureren",
       "hold": "Aanhouden",
@@ -1690,9 +1691,9 @@
       "saving": "Opslaan...",
       "errorAmount": "Voer een limiet groter dan nul in"
     },
+    "generateProjectInvoice": "Projectfactuur genereren",
+    "generatingProjectInvoice": "Factuur genereren...",
     "tm": {
-      "generateInvoice": "Projectfactuur genereren",
-      "generatingInvoice": "Factuur genereren...",
       "invoiceGenerated": "Projectfactuur gegenereerd"
     },
     "overrides": {

--- a/server/public/locales/pl/features/projects.json
+++ b/server/public/locales/pl/features/projects.json
@@ -1644,6 +1644,7 @@
       "manualSub": "Wyzwalacz ręczny",
       "phaseRemoved": "Ręcznie · faza usunięta",
       "phaseTrigger": "Ukończenie fazy",
+      "phaseOverdue": "Data zakończenia fazy minęła — oznacz fazę jako ukończoną, aby przygotować ten wpis",
       "approve": "Zatwierdź",
       "approveInvoice": "Zatwierdź i zafakturuj",
       "hold": "Wstrzymaj",
@@ -1716,9 +1717,9 @@
       "saving": "Zapisywanie...",
       "errorAmount": "Wprowadź limit większy od zera"
     },
+    "generateProjectInvoice": "Wygeneruj fakturę projektu",
+    "generatingProjectInvoice": "Generowanie faktury...",
     "tm": {
-      "generateInvoice": "Wygeneruj fakturę projektu",
-      "generatingInvoice": "Generowanie faktury...",
       "invoiceGenerated": "Faktura projektu wygenerowana"
     },
     "overrides": {

--- a/server/public/locales/pt/features/projects.json
+++ b/server/public/locales/pt/features/projects.json
@@ -1637,6 +1637,7 @@
       "manualSub": "Acionador manual",
       "phaseRemoved": "Manual · fase removida",
       "phaseTrigger": "Conclusão da fase",
+      "phaseOverdue": "A data de fim da fase já passou — marque a fase como concluída para deixar esta entrada pronta",
       "approve": "Aprovar",
       "approveInvoice": "Aprovar e faturar",
       "hold": "Reter",
@@ -1715,9 +1716,9 @@
       "saving": "A guardar...",
       "errorAmount": "Introduza um limite superior a zero"
     },
+    "generateProjectInvoice": "Gerar fatura do projeto",
+    "generatingProjectInvoice": "A gerar fatura...",
     "tm": {
-      "generateInvoice": "Gerar fatura do projeto",
-      "generatingInvoice": "A gerar fatura...",
       "invoiceGenerated": "Fatura do projeto gerada"
     },
     "overrides": {

--- a/server/public/locales/xx/features/projects.json
+++ b/server/public/locales/xx/features/projects.json
@@ -1637,6 +1637,7 @@
       "manualSub": "11111",
       "phaseRemoved": "11111",
       "phaseTrigger": "11111",
+      "phaseOverdue": "11111",
       "approve": "11111",
       "approveInvoice": "11111",
       "hold": "11111",
@@ -1715,9 +1716,9 @@
       "saving": "11111",
       "errorAmount": "11111"
     },
+    "generateProjectInvoice": "11111",
+    "generatingProjectInvoice": "11111",
     "tm": {
-      "generateInvoice": "11111",
-      "generatingInvoice": "11111",
       "invoiceGenerated": "11111"
     },
     "overrides": {

--- a/server/public/locales/yy/features/projects.json
+++ b/server/public/locales/yy/features/projects.json
@@ -1637,6 +1637,7 @@
       "manualSub": "55555",
       "phaseRemoved": "55555",
       "phaseTrigger": "55555",
+      "phaseOverdue": "55555",
       "approve": "55555",
       "approveInvoice": "55555",
       "hold": "55555",
@@ -1715,9 +1716,9 @@
       "saving": "55555",
       "errorAmount": "55555"
     },
+    "generateProjectInvoice": "55555",
+    "generatingProjectInvoice": "55555",
     "tm": {
-      "generateInvoice": "55555",
-      "generatingInvoice": "55555",
       "invoiceGenerated": "55555"
     },
     "overrides": {

--- a/server/src/app/layout.tsx
+++ b/server/src/app/layout.tsx
@@ -18,6 +18,7 @@ import { cookies, headers } from 'next/headers.js';
 import { generateBrandingStyles } from "@alga-psa/tenancy";
 import { resolveDeploymentCapabilities } from '@/lib/deployment/deploymentProfile';
 import { resolveRequestHost, resolveRequestOrigin } from '@/lib/deployment/requestHost';
+import { checkFeatureFlag } from '@/lib/feature-flags/serverFeatureFlags';
 import '@mantine/core/styles.css';
 import 'reactflow/dist/style.css';
 // Loaded last so the Inter font-token overrides win over Mantine/Radix defaults.
@@ -125,6 +126,8 @@ export default async function RootLayout({
     brandingStyles = branding?.computedStyles || generateBrandingStyles(branding);
   }
 
+  const projectBillingUiEnabled = await checkFeatureFlag('project-billing-ui');
+
   return (
     <html lang="en" className={`${inter.variable} ${jetbrainsMono.variable} ${inter.className}`} suppressHydrationWarning>
       <head>
@@ -139,7 +142,7 @@ export default async function RootLayout({
         )}
       </head>
       <body className={`${inter.className} ${inter.variable}`} suppressHydrationWarning>
-        <PostHogProvider>
+        <PostHogProvider initialFeatureFlags={{ 'project-billing-ui': projectBillingUiEnabled }}>
            <MainContent>{children}</MainContent>
         </PostHogProvider>
       </body>

--- a/server/src/components/providers/PostHogProvider.tsx
+++ b/server/src/components/providers/PostHogProvider.tsx
@@ -5,6 +5,7 @@ import { PostHogProvider as PHProvider, usePostHog } from 'posthog-js/react';
 import { useEffect, useRef, useState } from 'react';
 import { usePathname, useSearchParams } from 'next/navigation';
 import { isPostHogEnabled, posthogConfig } from '@alga-psa/analytics/client';
+import { FeatureFlagBootstrapProvider } from '@alga-psa/ui/hooks';
 
 function SuspendedPostHogPageView() {
   const posthogClient = usePostHog();
@@ -71,8 +72,10 @@ export function PostHogProvider({ children, initialFeatureFlags }: PostHogProvid
 
   return (
     <PHProvider client={posthog}>
-      {isInitialized && <SuspendedPostHogPageView />}
-      {children}
+      <FeatureFlagBootstrapProvider initialFeatureFlags={initialFeatureFlagsRef.current}>
+        {isInitialized && <SuspendedPostHogPageView />}
+        {children}
+      </FeatureFlagBootstrapProvider>
     </PHProvider>
   );
 }

--- a/server/src/components/providers/PostHogProvider.tsx
+++ b/server/src/components/providers/PostHogProvider.tsx
@@ -2,7 +2,7 @@
 
 import posthog from 'posthog-js';
 import { PostHogProvider as PHProvider, usePostHog } from 'posthog-js/react';
-import { useEffect, useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
 import { usePathname, useSearchParams } from 'next/navigation';
 import { isPostHogEnabled, posthogConfig } from '@alga-psa/analytics/client';
 
@@ -21,9 +21,15 @@ function SuspendedPostHogPageView() {
   return null;
 }
 
-export function PostHogProvider({ children }: { children: React.ReactNode }) {
+interface PostHogProviderProps {
+  children: React.ReactNode;
+  initialFeatureFlags: Record<string, boolean | string>;
+}
+
+export function PostHogProvider({ children, initialFeatureFlags }: PostHogProviderProps) {
   const [isInitialized, setIsInitialized] = useState(false);
   const [isHydrated, setIsHydrated] = useState(false);
+  const initialFeatureFlagsRef = useRef(initialFeatureFlags);
 
   useEffect(() => {
     setIsHydrated(true);
@@ -57,7 +63,7 @@ export function PostHogProvider({ children }: { children: React.ReactNode }) {
       bootstrap: {
         distinctID: undefined,
         isIdentifiedID: false,
-        featureFlags: {},
+        featureFlags: initialFeatureFlagsRef.current,
       },
       disable_session_recording: posthogConfig.features.sessionRecording === false,
     });

--- a/server/tailwind.config.ts
+++ b/server/tailwind.config.ts
@@ -17,6 +17,7 @@ const config: Config = {
     // explicitly rather than enabling a broad `**/*.ts` glob.
     "../packages/scheduling/src/components/technician-dispatch/utils.ts",
     "../packages/tickets/src/actions/optimizedTicketActions.ts",
+    "../packages/core/src/lib/projectBillingStatus.ts",
   ],
   theme: {
     extend: {


### PR DESCRIPTION
## Summary

- Close standalone project-billing dead ends: standalone review rows no longer expose plain or bulk approval, while fixed-price standalone projects can generate a project invoice for approved backlog.
- Make `project-billing-ui` deterministic from the first render by seeding the client from server-side evaluation and subscribing the hook to PostHog flag delivery.
- Correct invoice presentation and accounting gating: invoice lines display net amounts, and QuickBooks sync state is hidden when no accounting realm is connected.
- Polish project billing UI behavior: compile dark-mode status pills, prevent wheel changes on total-price inputs, space shared dialog footers, emphasize payment warnings, and make the billing phase list read-only while preserving selection.
- Surface overdue phase-triggered billing entries without changing lifecycle semantics: Mark Complete remains the only billing trigger.
- Include the approved implementation plan and make the wired dev command honor the assigned `PORT`.

## Validation

- Focused project-billing, feature-flag, adapter, status, and contract tests pass.
- `NODE_OPTIONS=--max-old-space-size=16384 npm run typecheck` passes.
- Full CE `npm run build` passes.
- GitHub Actions is green, including affected unit/type checks, lint/guardrails, integration, and fresh-install E2E.

### Live smoke test

**PASS with one adjacent concern.** Tested the live CE product on port 3511 against real database/services, authenticated as the seeded dev user, using **PB Smoke Fixed 0715**.

1. A hard reload rendered Billing on the first project frame (~2.1s).
2. PostHog SDK false/true updates removed and restored Billing (~20ms), proving the subscription path.
3. Fixed-price standalone Billing rendered **Generate project invoice**; no invoice was generated.
4. Billing mode hid Add Phase, Import, drag/edit/delete controls while preserving phase selection; payment-warning emphasis and billing status pills rendered correctly.

**Adjacent concern:** selecting **Discovery Smoke 0715** highlighted it, but schedule rows stayed at 6 before and after, so planned phase-based schedule filtering appears absent.

Evidence: `/tmp/alga-smoke-evidence/project-fixup-round-3-20260730-164113`

## Smoke-test fidelity

The shared PostHog project currently has no project-billing flag, and no control-plane credential was available. To exercise the real path, the smoke test temporarily forced only the server evaluator to `true`, delayed the real PostHog request long enough to capture first paint, and used the real PostHog SDK override API for false/true delivery. No simulator or mock was used.

`space-new-tab` created a hub-local pane for this remote card, so automation required a browser tab attached to the card’s own design-session pane.

All overrides were removed; `server/.env.local` was restored, the worktree is clean, and the board dev server is live on 3511. Console/network errors observed were attributable to intentional server restarts, expired authentication during restart, and the delayed PostHog request—not the stabilized product flow.