### PR TITLE
Fix ticket hero field squishing at 1024-1279px and picker overflow

### DIFF
--- a/packages/tickets/src/components/ticket/bento/BentoHero.tsx
+++ b/packages/tickets/src/components/ticket/bento/BentoHero.tsx
@@ -980,7 +980,7 @@ export function BentoHero({
           </Alert>
         ) : null}
 
-        <div className="mt-3 grid grid-cols-2 sm:grid-cols-3 lg:grid-cols-7 gap-3">
+        <div className="mt-3 grid grid-cols-2 sm:grid-cols-3 lg:grid-cols-4 xl:grid-cols-7 gap-3">
           <HeroField label={t('bento.hero.status', 'Status')}>
             {renderLiveField('status_id', '', (
               <CustomSelect
@@ -1105,6 +1105,7 @@ export function BentoHero({
                 onChange={handleDueDateChange}
                 placeholder={t('bento.hero.noDueDate', 'No due date')}
                 disabled={isFrozen('due_date')}
+                collapsible
               />
             ))}
           </HeroField>

--- a/packages/ui/src/components/UserAndTeamPicker.tsx
+++ b/packages/ui/src/components/UserAndTeamPicker.tsx
@@ -503,7 +503,7 @@ const UserAndTeamPicker = ({
 
   return (
     <div
-      className={`relative inline-block ${buttonWidth === 'full' ? 'w-full' : ''} ${className || ''}`}
+      className={`relative inline-block max-w-full ${buttonWidth === 'full' ? 'w-full' : ''} ${className || ''}`}
       ref={containerRef}
     >
       {label && labelStyle !== 'none' && (
@@ -528,10 +528,10 @@ const UserAndTeamPicker = ({
             ? 'p-1 h-7 text-xs min-w-0 gap-1'
             : 'p-2 h-10 text-sm'
         } ${
-          buttonWidth === 'full' ? 'w-full' : size === 'xs' ? 'w-fit' : 'w-fit min-w-[150px]'
+          buttonWidth === 'full' ? 'w-full' : size === 'xs' ? 'w-fit' : 'w-fit min-w-[min(150px,100%)] max-w-full'
         }`}
       >
-        <div className={`flex items-center flex-1 ${size === 'xs' ? 'gap-1' : 'gap-2'}`}>
+        <div className={`flex items-center flex-1 min-w-0 ${size === 'xs' ? 'gap-1' : 'gap-2'}`}>
           {currentUser && (
             <UserAvatar
               userId={currentUser.user_id}
@@ -549,7 +549,7 @@ const UserAndTeamPicker = ({
             />
           )}
           {size !== 'xs' && (
-            <span className={!hasSelection ? 'text-gray-400' : ''}>{selectedLabel}</span>
+            <span className={`truncate ${!hasSelection ? 'text-gray-400' : ''}`}>{selectedLabel}</span>
           )}
         </div>
         <ChevronDown className={size === 'xs' ? 'w-3 h-3 text-gray-500' : 'w-4 h-4 text-gray-500'} />

--- a/server/src/test/unit/userAndTeamPicker.selectedTeamDisplay.test.ts
+++ b/server/src/test/unit/userAndTeamPicker.selectedTeamDisplay.test.ts
@@ -14,7 +14,10 @@ describe('UserAndTeamPicker selected team display', () => {
     expect(picker).toContain("const selectedLabel = currentUser");
     expect(picker).toContain("    : currentTeam");
     expect(picker).toContain("      ? currentTeam.team_name || 'Unnamed Team'");
-    expect(picker).toContain("<span className={!hasSelection ? 'text-gray-400' : ''}>{selectedLabel}</span>");
+    // The trigger label truncates so a long name cannot widen a narrow parent.
+    expect(picker).toContain(
+      "<span className={`truncate ${!hasSelection ? 'text-gray-400' : ''}`}>{selectedLabel}</span>",
+    );
   });
 
   it('renders a TeamAvatar in the trigger for selected teams and fetches that avatar even before the menu opens', () => {


### PR DESCRIPTION
## Summary
The ticket bento hero's field band went 7-across starting at the `lg` breakpoint, which left each cell only ~130px wide between 1024–1279px — clipping the Due date text and letting the Assigned To picker (150px min-width) overflow its cell. This PR holds the 7-column layout until `xl` and adds a roomy 4-column band for the `lg` range, makes the Due date picker collapse to an icon-only trigger when its cell is too narrow, and hardens `UserAndTeamPicker` so it truncates its label and respects its parent's width instead of spilling over.

## Changes
- **Ticket bento hero** (`packages/tickets/src/components/ticket/bento/BentoHero.tsx`): field grid now uses `lg:grid-cols-4 xl:grid-cols-7` instead of jumping straight to 7 columns at `lg`; Due date field gets `collapsible` so a narrow cell renders an icon-only trigger with the date in a tooltip instead of clipped text.
- **UserAndTeamPicker** (`packages/ui/src/components/UserAndTeamPicker.tsx`): container and trigger button now cap at `max-w-full` (with a `min(150px,100%)` min-width), and the selected-label span truncates with `min-w-0` on its flex wrapper, so the picker no longer overflows narrow parent cells.
- **Tests** (`server/src/test/unit/userAndTeamPicker.selectedTeamDisplay.test.ts`): updated the selected-team display contract test to expect the new truncating label markup.

## Testing
- Updated and verified the `userAndTeamPicker.selectedTeamDisplay` unit test against the new truncating trigger markup.
