### PR TITLE
Fixes all four bugs from the managedEmailDomainWorkflow prod audit:

### DIFF
--- a/ee/temporal-workflows/src/activities/email-domain-activities.ts
+++ b/ee/temporal-workflows/src/activities/email-domain-activities.ts
@@ -18,6 +18,7 @@ interface ManagedDomainServiceLike {
   }>;
   activateDomain: (domain: string) => Promise<void>;
   deleteDomain: (domain: string) => Promise<void>;
+  markDomainFailed: (domain: string, reason: string) => Promise<void>;
   startDomainVerification?: (domainId: string) => Promise<DomainVerificationResult>;
 }
 
@@ -155,4 +156,22 @@ export async function deleteManagedEmailDomain(
   await service.deleteDomain(input.domain);
 
   logger.info('deleteManagedEmailDomain:success', input);
+}
+
+export interface MarkManagedEmailDomainFailedInput {
+  tenantId: string;
+  domain: string;
+  reason: string;
+}
+
+export async function markManagedEmailDomainFailed(
+  input: MarkManagedEmailDomainFailedInput
+): Promise<void> {
+  const logger = log();
+  logger.info('markManagedEmailDomainFailed:start', input);
+
+  const service = await buildService(input.tenantId);
+  await service.markDomainFailed(input.domain, input.reason);
+
+  logger.info('markManagedEmailDomainFailed:success', input);
 }

--- a/ee/temporal-workflows/src/workflows/__tests__/managed-email-domain-workflow.test.ts
+++ b/ee/temporal-workflows/src/workflows/__tests__/managed-email-domain-workflow.test.ts
@@ -1,0 +1,235 @@
+import path from 'node:path';
+import { describe, expect, it } from 'vitest';
+import { TestWorkflowEnvironment } from '@temporalio/testing';
+import { Worker } from '@temporalio/worker';
+import { managedEmailDomainWorkflow } from '../managed-email-domain-workflow.js';
+
+const baseInput = {
+  tenantId: 'tenant-1',
+  domain: 'example.com',
+};
+
+const pendingCheckResult = {
+  providerDomainId: 'domain-123',
+  status: 'pending',
+  verifiedAt: null,
+  failureReason: null,
+  provider: { domain: 'example.com', status: 'pending', providerId: 'managed-resend' },
+  dnsLookup: [],
+};
+
+async function setupWorkflowTest(activityOverrides: Record<string, any> = {}) {
+  const env = await TestWorkflowEnvironment.createTimeSkipping();
+  const taskQueue = `test-managed-email-${Date.now()}`;
+  const calls = {
+    provision: [] as any[],
+    check: [] as any[],
+    activate: [] as any[],
+    delete: [] as any[],
+    markFailed: [] as any[],
+  };
+
+  const impl = {
+    provisionManagedEmailDomain: async (_input: any) => ({
+      providerDomainId: 'domain-123',
+      status: 'pending',
+      dnsRecords: [],
+    }),
+    checkManagedEmailDomainStatus: async (_input: any) => pendingCheckResult,
+    activateManagedEmailDomain: async (_input: any) => {},
+    deleteManagedEmailDomain: async (_input: any) => {},
+    markManagedEmailDomainFailed: async (_input: any) => {},
+    ...activityOverrides,
+  };
+
+  const activities = {
+    provisionManagedEmailDomain: async (input: any) => {
+      calls.provision.push(input);
+      return impl.provisionManagedEmailDomain(input);
+    },
+    checkManagedEmailDomainStatus: async (input: any) => {
+      calls.check.push(input);
+      return impl.checkManagedEmailDomainStatus(input);
+    },
+    activateManagedEmailDomain: async (input: any) => {
+      calls.activate.push(input);
+      return impl.activateManagedEmailDomain(input);
+    },
+    deleteManagedEmailDomain: async (input: any) => {
+      calls.delete.push(input);
+      return impl.deleteManagedEmailDomain(input);
+    },
+    markManagedEmailDomainFailed: async (input: any) => {
+      calls.markFailed.push(input);
+      return impl.markManagedEmailDomainFailed(input);
+    },
+  };
+
+  const worker = await Worker.create({
+    connection: env.nativeConnection,
+    taskQueue,
+    workflowsPath: path.resolve(__dirname, '../managed-email-domain-workflow.ts'),
+    activities,
+  });
+
+  return { env, worker, taskQueue, calls };
+}
+
+describe('managedEmailDomainWorkflow', () => {
+  it('deletes immediately when started with a delete trigger', async () => {
+    const { env, worker, taskQueue, calls } = await setupWorkflowTest();
+    try {
+      const result = await worker.runUntil(
+        env.client.workflow.execute(managedEmailDomainWorkflow, {
+          args: [{ ...baseInput, trigger: 'delete' as const }],
+          taskQueue,
+          workflowId: `delete-${Date.now()}`,
+        })
+      );
+
+      expect(result.activated).toBe(false);
+      expect(calls.delete).toHaveLength(1);
+      expect(calls.provision).toHaveLength(0);
+      expect(calls.check).toHaveLength(0);
+    } finally {
+      await env.teardown();
+    }
+  });
+
+  it('provisions then activates once verification succeeds', async () => {
+    const { env, worker, taskQueue, calls } = await setupWorkflowTest({
+      checkManagedEmailDomainStatus: async () => ({
+        ...pendingCheckResult,
+        status: 'verified',
+        verifiedAt: new Date().toISOString(),
+      }),
+    });
+    try {
+      const result = await worker.runUntil(
+        env.client.workflow.execute(managedEmailDomainWorkflow, {
+          args: [baseInput],
+          taskQueue,
+          workflowId: `verify-${Date.now()}`,
+        })
+      );
+
+      expect(result.activated).toBe(true);
+      expect(calls.provision).toHaveLength(1);
+      expect(calls.activate).toHaveLength(1);
+    } finally {
+      await env.teardown();
+    }
+  });
+
+  it('skips provisioning when a provider domain id is supplied', async () => {
+    const { env, worker, taskQueue, calls } = await setupWorkflowTest({
+      checkManagedEmailDomainStatus: async () => ({
+        ...pendingCheckResult,
+        status: 'verified',
+      }),
+    });
+    try {
+      const result = await worker.runUntil(
+        env.client.workflow.execute(managedEmailDomainWorkflow, {
+          args: [{ ...baseInput, providerDomainId: 'domain-123' }],
+          taskQueue,
+          workflowId: `adopt-${Date.now()}`,
+        })
+      );
+
+      expect(result.activated).toBe(true);
+      expect(calls.provision).toHaveLength(0);
+    } finally {
+      await env.teardown();
+    }
+  });
+
+  it('stops on a failed verification result', async () => {
+    const { env, worker, taskQueue, calls } = await setupWorkflowTest({
+      checkManagedEmailDomainStatus: async () => ({
+        ...pendingCheckResult,
+        status: 'failed',
+        failureReason: 'dns_failure',
+      }),
+    });
+    try {
+      const result = await worker.runUntil(
+        env.client.workflow.execute(managedEmailDomainWorkflow, {
+          args: [baseInput],
+          taskQueue,
+          workflowId: `failed-${Date.now()}`,
+        })
+      );
+
+      expect(result.activated).toBe(false);
+      expect(calls.check).toHaveLength(1);
+      expect(calls.activate).toHaveLength(0);
+    } finally {
+      await env.teardown();
+    }
+  });
+
+  it('marks the domain failed when verification never completes before the deadline', async () => {
+    const { env, worker, taskQueue, calls } = await setupWorkflowTest();
+    try {
+      const result = await worker.runUntil(
+        env.client.workflow.execute(managedEmailDomainWorkflow, {
+          args: [baseInput],
+          taskQueue,
+          workflowId: `timeout-${Date.now()}`,
+        })
+      );
+
+      expect(result.timedOut).toBe(true);
+      expect(result.activated).toBe(false);
+      expect(calls.markFailed).toHaveLength(1);
+      expect(calls.markFailed[0].reason).toContain('timed out');
+      // Backoff must keep the total poll count far below the ~864 checks
+      // a fixed 5-minute interval would produce over 72 hours
+      expect(calls.check.length).toBeGreaterThan(10);
+      expect(calls.check.length).toBeLessThan(150);
+    } finally {
+      await env.teardown();
+    }
+  }, 240000);
+
+  it('processes a delete signal that arrives while a check activity is in flight', async () => {
+    let releaseCheck!: () => void;
+    let signalCheckStarted!: () => void;
+    const checkStarted = new Promise<void>((resolve) => {
+      signalCheckStarted = resolve;
+    });
+    const checkGate = new Promise<void>((resolve) => {
+      releaseCheck = resolve;
+    });
+
+    const { env, worker, taskQueue, calls } = await setupWorkflowTest({
+      checkManagedEmailDomainStatus: async () => {
+        signalCheckStarted();
+        await checkGate;
+        return pendingCheckResult;
+      },
+    });
+    try {
+      const result = await worker.runUntil(async () => {
+        const handle = await env.client.workflow.start(managedEmailDomainWorkflow, {
+          args: [{ ...baseInput, providerDomainId: 'domain-123' }],
+          taskQueue,
+          workflowId: `signal-race-${Date.now()}`,
+        });
+
+        await checkStarted;
+        await handle.signal('refreshManagedEmailDomain', { ...baseInput, trigger: 'delete' });
+        releaseCheck();
+
+        return handle.result();
+      });
+
+      expect(result.activated).toBe(false);
+      expect(calls.delete).toHaveLength(1);
+      expect(calls.check).toHaveLength(1);
+    } finally {
+      await env.teardown();
+    }
+  });
+});

--- a/ee/temporal-workflows/src/workflows/__tests__/sla-ticket-workflow.test.ts
+++ b/ee/temporal-workflows/src/workflows/__tests__/sla-ticket-workflow.test.ts
@@ -47,7 +47,7 @@ async function setupWorkflowTest(activitiesOverrides: Record<string, any> = {}) 
   const worker = await Worker.create({
     connection: env.nativeConnection,
     taskQueue,
-    workflowsPath: path.resolve(__dirname, '../..'),
+    workflowsPath: path.resolve(__dirname, '../sla-ticket-workflow.ts'),
     activities,
   });
 
@@ -136,7 +136,17 @@ describe('slaTicketWorkflow', () => {
   });
 
   it('pause and resume update pause state', async () => {
-    const { env, worker, taskQueue, calculateCalls } = await setupWorkflowTest();
+    let signalFirstCalculate!: () => void;
+    const firstCalculateDone = new Promise<void>((resolve) => {
+      signalFirstCalculate = resolve;
+    });
+    const { env, worker, taskQueue, calculateCalls } = await setupWorkflowTest({
+      calculateNextWakeTime: async ({ targetMinutes, pauseMinutes }: { targetMinutes: number; pauseMinutes: number }) => {
+        calculateCalls.push({ targetMinutes, pauseMinutes });
+        signalFirstCalculate();
+        return new Date(Date.now() + targetMinutes * 60000).toISOString();
+      },
+    });
     try {
       await worker.runUntil(async () => {
         const handle = await env.client.workflow.start(slaTicketWorkflow, {
@@ -152,6 +162,9 @@ describe('slaTicketWorkflow', () => {
           workflowId: 'sla-ticket-tenant-4-ticket-4',
         });
 
+        // Pause only after the workflow has entered its first sleep race;
+        // pausing earlier is a different interleaving where no pause time accrues
+        await firstCalculateDone;
         await handle.signal('pause', { reason: 'status_pause' });
         const paused = await handle.query('getState');
         expect(paused.pauseState.isPaused).toBe(true);
@@ -164,10 +177,11 @@ describe('slaTicketWorkflow', () => {
         expect(resumed.pauseState.isPaused).toBe(false);
         expect(resumed.pauseState.pauseStartedAt).toBeNull();
         expect(resumed.pauseState.totalPauseMinutes).toBeGreaterThanOrEqual(1);
-        expect(calculateCalls.some((call) => call.pauseMinutes > 0)).toBe(true);
 
         await handle.signal('cancel');
         await handle.result();
+
+        expect(calculateCalls.some((call) => call.pauseMinutes > 0)).toBe(true);
       });
     } finally {
       await env.teardown();

--- a/ee/temporal-workflows/src/workflows/managed-email-domain-workflow.ts
+++ b/ee/temporal-workflows/src/workflows/managed-email-domain-workflow.ts
@@ -1,4 +1,4 @@
-import { proxyActivities, defineSignal, setHandler, Trigger, sleep } from '@temporalio/workflow';
+import { proxyActivities, defineSignal, setHandler, Trigger, sleep, continueAsNew } from '@temporalio/workflow';
 
 import type {
   ProvisionManagedEmailDomainInput,
@@ -7,6 +7,7 @@ import type {
   CheckManagedEmailDomainStatusResult,
   ActivateManagedEmailDomainInput,
   DeleteManagedEmailDomainInput,
+  MarkManagedEmailDomainFailedInput,
 } from '../activities/email-domain-activities';
 
 const {
@@ -14,11 +15,13 @@ const {
   checkManagedEmailDomainStatus,
   activateManagedEmailDomain,
   deleteManagedEmailDomain,
-} = proxyActivities<{ 
+  markManagedEmailDomainFailed,
+} = proxyActivities<{
   provisionManagedEmailDomain: typeof import('../activities/email-domain-activities').provisionManagedEmailDomain;
   checkManagedEmailDomainStatus: typeof import('../activities/email-domain-activities').checkManagedEmailDomainStatus;
   activateManagedEmailDomain: typeof import('../activities/email-domain-activities').activateManagedEmailDomain;
   deleteManagedEmailDomain: typeof import('../activities/email-domain-activities').deleteManagedEmailDomain;
+  markManagedEmailDomainFailed: typeof import('../activities/email-domain-activities').markManagedEmailDomainFailed;
 }>({
   startToCloseTimeout: '5 minutes',
   scheduleToCloseTimeout: '15 minutes',
@@ -35,6 +38,7 @@ export interface ManagedEmailDomainWorkflowInput {
   region?: string;
   trigger?: ManagedEmailDomainTrigger;
   providerDomainId?: string;
+  verificationDeadlineMs?: number;
 }
 
 export interface ManagedEmailDomainWorkflowState {
@@ -44,7 +48,14 @@ export interface ManagedEmailDomainWorkflowState {
   provision?: ProvisionManagedEmailDomainResult;
   verification?: CheckManagedEmailDomainStatusResult;
   activated?: boolean;
+  timedOut?: boolean;
 }
+
+const VERIFICATION_TIMEOUT_MS = 72 * 60 * 60 * 1000;
+const INITIAL_POLL_INTERVAL_MS = 5 * 60 * 1000;
+const MAX_POLL_INTERVAL_MS = 60 * 60 * 1000;
+const POLL_BACKOFF_FACTOR = 2;
+const MAX_CYCLES_PER_RUN = 30;
 
 const refreshSignal = defineSignal<[ManagedEmailDomainWorkflowInput | undefined]>('refreshManagedEmailDomain');
 
@@ -58,11 +69,19 @@ export async function managedEmailDomainWorkflow(
 
   let pendingTrigger: ManagedEmailDomainTrigger | undefined = input.trigger;
   let refreshTrigger = new Trigger<void>();
+  let pollIntervalMs = INITIAL_POLL_INTERVAL_MS;
 
   setHandler(refreshSignal, (payload?: ManagedEmailDomainWorkflowInput) => {
     pendingTrigger = payload?.trigger ?? 'refresh';
+    pollIntervalMs = INITIAL_POLL_INTERVAL_MS;
     refreshTrigger.resolve();
   });
+
+  function takePendingTrigger(): ManagedEmailDomainTrigger | undefined {
+    const trigger = pendingTrigger;
+    pendingTrigger = undefined;
+    return trigger;
+  }
 
   if (input.trigger === 'delete') {
     await deleteManagedEmailDomain({ tenantId: input.tenantId, domain: input.domain } as DeleteManagedEmailDomainInput);
@@ -85,6 +104,8 @@ export async function managedEmailDomainWorkflow(
   } else {
     state.providerDomainId = providerDomainId;
   }
+
+  const verificationDeadlineMs = input.verificationDeadlineMs ?? Date.now() + VERIFICATION_TIMEOUT_MS;
 
   async function runVerificationCycle(trigger: ManagedEmailDomainTrigger | undefined): Promise<boolean> {
     if (trigger === 'delete') {
@@ -116,14 +137,42 @@ export async function managedEmailDomainWorkflow(
     return true;
   }
 
-  let shouldContinue = await runVerificationCycle(pendingTrigger);
-  pendingTrigger = undefined;
+  let cyclesThisRun = 0;
+  let shouldContinue = await runVerificationCycle(takePendingTrigger());
+  cyclesThisRun++;
 
   while (shouldContinue) {
-    refreshTrigger = new Trigger<void>();
-    await Promise.race([sleep('5 minutes'), refreshTrigger]);
-    shouldContinue = await runVerificationCycle(pendingTrigger);
-    pendingTrigger = undefined;
+    // Only pause/exit when no signal arrived while the last cycle was running
+    if (pendingTrigger === undefined) {
+      if (Date.now() >= verificationDeadlineMs) {
+        await markManagedEmailDomainFailed({
+          tenantId: input.tenantId,
+          domain: input.domain,
+          reason: 'DNS verification timed out after 72 hours',
+        } as MarkManagedEmailDomainFailedInput);
+        state.activated = false;
+        state.timedOut = true;
+        return state;
+      }
+
+      if (cyclesThisRun >= MAX_CYCLES_PER_RUN) {
+        await continueAsNew<typeof managedEmailDomainWorkflow>({
+          tenantId: input.tenantId,
+          domain: input.domain,
+          region: input.region,
+          providerDomainId,
+          verificationDeadlineMs,
+        });
+      }
+
+      const waitMs = pollIntervalMs;
+      pollIntervalMs = Math.min(pollIntervalMs * POLL_BACKOFF_FACTOR, MAX_POLL_INTERVAL_MS);
+      refreshTrigger = new Trigger<void>();
+      await Promise.race([sleep(waitMs), refreshTrigger]);
+    }
+
+    shouldContinue = await runVerificationCycle(takePendingTrigger());
+    cyclesThisRun++;
   }
 
   return state;

--- a/packages/integrations/src/email/domains/providers/ResendEmailProvider.test.ts
+++ b/packages/integrations/src/email/domains/providers/ResendEmailProvider.test.ts
@@ -1,0 +1,112 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const { clientMock } = vi.hoisted(() => ({
+  clientMock: {
+    post: vi.fn(),
+    get: vi.fn(),
+    delete: vi.fn(),
+  },
+}));
+
+vi.mock('axios', () => ({
+  default: {
+    create: vi.fn(() => clientMock),
+    get: vi.fn(async () => ({ data: {} })),
+  },
+}));
+
+vi.mock('@alga-psa/core/logger', () => ({
+  default: { info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() },
+}));
+
+import { ResendEmailProvider } from './ResendEmailProvider';
+
+const registeredAlreadyError = {
+  response: {
+    status: 403,
+    data: { message: 'The domain example.com is registered already', name: 'validation_error' },
+  },
+};
+
+const listEntry = {
+  id: 'dom-1',
+  name: 'example.com',
+  status: 'pending',
+  region: 'us-east-1',
+  created_at: '2026-01-01T00:00:00Z',
+};
+
+const detailRecords = [
+  { record: 'DKIM', name: 'resend._domainkey', type: 'TXT', value: 'v=DKIM1; k=rsa; p=abc' },
+];
+
+async function createProvider(): Promise<ResendEmailProvider> {
+  const provider = new ResendEmailProvider('managed-resend');
+  await provider.initialize({ apiKey: 'test-key' });
+  return provider;
+}
+
+describe('ResendEmailProvider.createDomain 403 recovery', () => {
+  beforeEach(() => {
+    clientMock.post.mockReset();
+    clientMock.get.mockReset();
+    clientMock.delete.mockReset();
+  });
+
+  it('adopts an already-registered domain even when it is verified', async () => {
+    const provider = await createProvider();
+
+    clientMock.post.mockRejectedValueOnce(registeredAlreadyError);
+    clientMock.get.mockImplementation(async (url: string) => {
+      if (url === '/domains') {
+        return { data: { data: [{ ...listEntry, status: 'verified' }] } };
+      }
+      if (url === '/domains/dom-1') {
+        return { data: { ...listEntry, status: 'verified', records: detailRecords } };
+      }
+      throw new Error(`unexpected GET ${url}`);
+    });
+
+    const result = await provider.createDomain('example.com');
+
+    expect(result.domainId).toBe('dom-1');
+    expect(result.status).toBe('verified');
+    expect(result.dnsRecords).toEqual([
+      expect.objectContaining({
+        type: 'TXT',
+        name: 'resend._domainkey.example.com',
+        value: 'v=DKIM1; k=rsa; p=abc',
+      }),
+    ]);
+  });
+
+  it('adopts a pending domain without records when the detail fetch fails', async () => {
+    const provider = await createProvider();
+
+    clientMock.post.mockRejectedValueOnce(registeredAlreadyError);
+    clientMock.get.mockImplementation(async (url: string) => {
+      if (url === '/domains') {
+        // The list endpoint never includes `records`
+        return { data: { data: [listEntry] } };
+      }
+      throw new Error('detail fetch unavailable');
+    });
+
+    const result = await provider.createDomain('example.com');
+
+    expect(result.domainId).toBe('dom-1');
+    expect(result.status).toBe('pending');
+    expect(result.dnsRecords).toEqual([]);
+  });
+
+  it('rethrows when the domain cannot be found in the account', async () => {
+    const provider = await createProvider();
+
+    clientMock.post.mockRejectedValueOnce(registeredAlreadyError);
+    clientMock.get.mockResolvedValue({ data: { data: [] } });
+
+    await expect(provider.createDomain('example.com')).rejects.toThrow(
+      'Failed to create domain example.com'
+    );
+  });
+});

--- a/packages/integrations/src/email/domains/providers/ResendEmailProvider.ts
+++ b/packages/integrations/src/email/domains/providers/ResendEmailProvider.ts
@@ -252,9 +252,9 @@ export class ResendEmailProvider implements IEmailProvider {
 
       if (statusCode === 403 && providerMessage?.toLowerCase().includes('registered already')) {
         const existing = await this.findDomainByName(domain).catch(() => null);
-        if (existing && existing.status !== 'verified') {
+        if (existing) {
           logger.warn(
-            `[ResendEmailProvider:${this.providerId}] Domain already exists with status ${existing.status}, returning existing DNS records`
+            `[ResendEmailProvider:${this.providerId}] Domain already exists with status ${existing.status}, adopting existing domain`
           );
           const { normalizedStatus } = this.normalizeDomainStatus(existing.status);
           return {
@@ -275,7 +275,18 @@ export class ResendEmailProvider implements IEmailProvider {
   private async findDomainByName(domain: string): Promise<ResendDomainResponse | null> {
     try {
       const response = await this.client!.get<{ data: ResendDomainResponse[] }>('/domains');
-      return response.data.data.find((entry) => entry.name.toLowerCase() === domain.toLowerCase()) ?? null;
+      const match = response.data.data.find((entry) => entry.name.toLowerCase() === domain.toLowerCase()) ?? null;
+      if (!match) {
+        return null;
+      }
+
+      try {
+        // The list endpoint omits `records`; fetch the full domain for DNS records
+        const detail = await this.client!.get<ResendDomainResponse>(`/domains/${match.id}`);
+        return detail.data;
+      } catch {
+        return match;
+      }
     } catch (error) {
       logger.warn(`[ResendEmailProvider:${this.providerId}] Unable to fetch existing domains`, {
         error: (error as any)?.response?.data || (error as any)?.message || error,
@@ -477,9 +488,9 @@ export class ResendEmailProvider implements IEmailProvider {
     };
   }
 
-  private transformResendRecords(records: ResendDomainResponse['records'], domain?: string): DnsRecord[] {
+  private transformResendRecords(records: ResendDomainResponse['records'] | undefined, domain?: string): DnsRecord[] {
     const suffix = domain?.toLowerCase().replace(/\.$/, '');
-    return records.map((record) => ({
+    return (records ?? []).map((record) => ({
       type: record.type.toUpperCase() as DnsRecord['type'],
       name: this.ensureAbsoluteRecordName(record.name, suffix),
       value: record.value,

--- a/packages/integrations/src/email/domains/services/ManagedDomainService.ts
+++ b/packages/integrations/src/email/domains/services/ManagedDomainService.ts
@@ -358,8 +358,43 @@ export class ManagedDomainService {
 
     await tenantDb(this.knex, this.tenantId).table(EMAIL_DOMAINS_TABLE)
       .where({ domain_name: domain })
+      .delete();
+
+    const settings = await tenantDb(this.knex, this.tenantId).table(TENANT_EMAIL_SETTINGS_TABLE)
+      .first();
+
+    if (settings) {
+      const rawCustomDomains = settings.custom_domains;
+      const customDomains: string[] = Array.isArray(rawCustomDomains)
+        ? rawCustomDomains
+        : typeof rawCustomDomains === 'string'
+          ? JSON.parse(rawCustomDomains)
+          : [];
+      const remainingDomains = customDomains.filter((entry) => entry !== domain);
+
+      const updates: Record<string, unknown> = {};
+      if (settings.default_from_domain === domain) {
+        updates.default_from_domain = null;
+      }
+      if (remainingDomains.length !== customDomains.length) {
+        updates.custom_domains = JSON.stringify(remainingDomains);
+      }
+
+      if (Object.keys(updates).length > 0) {
+        updates.updated_at = new Date();
+        await tenantDb(this.knex, this.tenantId).table(TENANT_EMAIL_SETTINGS_TABLE)
+          .update(updates);
+      }
+    }
+  }
+
+  async markDomainFailed(domain: string, reason: string): Promise<void> {
+    await tenantDb(this.knex, this.tenantId).table(EMAIL_DOMAINS_TABLE)
+      .where({ domain_name: domain })
+      .whereNot({ status: 'verified' })
       .update({
-        status: 'deleted',
+        status: 'failed',
+        failure_reason: reason,
         updated_at: new Date(),
       });
   }


### PR DESCRIPTION
- Delete no longer writes status 'deleted' (forbidden by email_domains_status_check); the row is removed and any tenant_email_settings references to the domain are cleared
- Verification polling is bounded: 72h deadline (new markManagedEmailDomainFailed activity records the failure), exponential backoff 5min -> 1h, continueAsNew every 30 cycles
- Resend provisioning is idempotent: 403 "registered already" adopts the existing domain (including verified), fetches records by id since the list endpoint omits them, and guards undefined
- Refresh/delete signals arriving mid-activity are consumed instead of silently cleared

Also repairs the temporal-workflows test harness: workflowsPath pointed at a directory with no index module (all SLA tests failed to bundle), and the pause/resume test raced its own signals.

"You can't simply call it deleted," said the Constraint Queen, "off with the row entirely!" And so the domain tumbled out of the table for good, the Dormouse no longer doomed to five-minute tea breaks forever — for at the stroke of seventy-two hours, the party is marked failed and everyone finally goes home. 🫖🐇⏳