### PR TITLE
Fix raw BlockNote JSON showing in Technician Dispatch descriptions

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -48040,6 +48040,7 @@
         "@alga-psa/clients": "*",
         "@alga-psa/core": "*",
         "@alga-psa/db": "*",
+        "@alga-psa/formatting": "*",
         "@alga-psa/shared": "*",
         "@alga-psa/types": "*",
         "@alga-psa/ui": "*",

--- a/packages/scheduling/package.json
+++ b/packages/scheduling/package.json
@@ -65,6 +65,7 @@
     "@alga-psa/clients": "*",
     "@alga-psa/core": "*",
     "@alga-psa/db": "*",
+    "@alga-psa/formatting": "*",
     "@alga-psa/shared": "*",
     "@alga-psa/types": "*",
     "@alga-psa/user-composition": "*",

--- a/packages/scheduling/src/actions/ticketLookupActions.ts
+++ b/packages/scheduling/src/actions/ticketLookupActions.ts
@@ -3,6 +3,7 @@
 import { withAuth } from '@alga-psa/auth';
 import { createTenantKnex, tenantDb, withTransaction } from '@alga-psa/db';
 import type { Knex } from 'knex';
+import { workItemDescriptionParagraphs } from '../lib/workItemDescription';
 
 export interface SchedulingTicketDetailsRecord {
   ticket_id: string;
@@ -68,12 +69,7 @@ export const getSchedulingTicketById = withAuth(async (
   const attributes = (ticket.attributes && typeof ticket.attributes === 'object')
     ? ticket.attributes as Record<string, unknown>
     : null;
-  const rawDescription = attributes?.description;
-  const description = typeof rawDescription === 'string'
-    ? rawDescription
-    : rawDescription == null
-      ? null
-      : JSON.stringify(rawDescription);
+  const description = workItemDescriptionParagraphs(attributes?.description) || null;
 
   return {
     ...(ticket as Omit<SchedulingTicketDetailsRecord, 'description'>),

--- a/packages/scheduling/src/actions/workItemActions.ts
+++ b/packages/scheduling/src/actions/workItemActions.ts
@@ -8,6 +8,7 @@ import { IUser } from '@alga-psa/types';
 import ScheduleEntry from '@alga-psa/shared/models/scheduleEntry';
 import User from '@alga-psa/db/models/user';
 import { parseWorkItemStatusNameFilterValue } from '@alga-psa/reference-data/actions/status-actions/workItemStatusFilter';
+import { workItemDescriptionText } from '../lib/workItemDescription';
 import {
   actionError,
   isActionMessageError,
@@ -295,7 +296,7 @@ export const searchDispatchWorkItems = withAuth(async (
         work_item_id: item.work_item_id,
         type: item.type,
         name: item.name,
-        description: item.description,
+        description: workItemDescriptionText(item.description),
         is_billable: true,
         ticket_number: item.ticket_number,
         title: item.title,
@@ -750,7 +751,7 @@ export const searchPickerWorkItems = withAuth(async (
         work_item_id: item.work_item_id,
         type: item.type,
         name: item.name,
-        description: item.description,
+        description: item.type === 'ticket' ? workItemDescriptionText(item.description) : item.description,
         is_billable: true,
         ticket_number: item.ticket_number,
         master_ticket_id: item.master_ticket_id,

--- a/packages/scheduling/src/components/technician-dispatch/WorkItemCard.tsx
+++ b/packages/scheduling/src/components/technician-dispatch/WorkItemCard.tsx
@@ -44,7 +44,7 @@ const WorkItemCard: React.FC<WorkItemCardProps> = ({
         {title ? (
           <>
             <div className="font-bold truncate">{title}</div>
-            <div className="text-sm text-gray-600 truncate">{description}</div>
+            {description && <div className="text-sm text-gray-600 truncate">{description}</div>}
           </>
         ) : (
           <>

--- a/packages/scheduling/src/lib/workItemDescription.ts
+++ b/packages/scheduling/src/lib/workItemDescription.ts
@@ -1,10 +1,20 @@
 import { formatBlockNoteContent } from '@alga-psa/formatting/blocknoteUtils';
 
 /**
- * Work item descriptions are stored as serialized editor content. Flatten them to
- * plain text for list/card surfaces, and collapse empty documents to ''.
+ * Work item descriptions are stored as serialized editor content. Flatten them to a
+ * single line of plain text for list/card surfaces, and collapse empty documents to ''.
+ * The flattening keeps styling markup (spans, bold, headings) that would render
+ * literally on a truncated card line, so strip it here.
  */
 export function workItemDescriptionText(raw: unknown): string {
   if (raw === null || raw === undefined) return '';
-  return formatBlockNoteContent(raw).text.trim();
+
+  return formatBlockNoteContent(raw).text
+    .replace(/<[^>]+>/g, '')
+    .replace(/^\s*(?:#{1,6}|>|[-*+]|\d+\.)\s+/gm, '')
+    .replace(/(\*\*|__|~~)(.*?)\1/g, '$2')
+    .replace(/(?<!\*)\*([^*\n]+)\*(?!\*)/g, '$1')
+    .replace(/\[([^\]]*)\]\([^)]*\)/g, '$1')
+    .replace(/\s+/g, ' ')
+    .trim();
 }

--- a/packages/scheduling/src/lib/workItemDescription.ts
+++ b/packages/scheduling/src/lib/workItemDescription.ts
@@ -1,20 +1,41 @@
 import { formatBlockNoteContent } from '@alga-psa/formatting/blocknoteUtils';
 
 /**
- * Work item descriptions are stored as serialized editor content. Flatten them to a
- * single line of plain text for list/card surfaces, and collapse empty documents to ''.
  * The flattening keeps styling markup (spans, bold, headings) that would render
- * literally on a truncated card line, so strip it here.
+ * literally wherever the text is shown, so strip it here.
  */
-export function workItemDescriptionText(raw: unknown): string {
-  if (raw === null || raw === undefined) return '';
-
-  return formatBlockNoteContent(raw).text
+function stripMarkup(value: string): string {
+  return value
     .replace(/<[^>]+>/g, '')
     .replace(/^\s*(?:#{1,6}|>|[-*+]|\d+\.)\s+/gm, '')
     .replace(/(\*\*|__|~~)(.*?)\1/g, '$2')
     .replace(/(?<!\*)\*([^*\n]+)\*(?!\*)/g, '$1')
-    .replace(/\[([^\]]*)\]\([^)]*\)/g, '$1')
+    .replace(/\[([^\]]*)\]\([^)]*\)/g, '$1');
+}
+
+/**
+ * Work item descriptions are stored as serialized editor content. Flatten them to a
+ * single line of plain text for list/card surfaces, and collapse empty documents to ''.
+ */
+export function workItemDescriptionText(raw: unknown): string {
+  if (raw === null || raw === undefined) return '';
+
+  return stripMarkup(formatBlockNoteContent(raw).text)
     .replace(/\s+/g, ' ')
+    .trim();
+}
+
+/**
+ * Same flattening for detail surfaces that render with whitespace-pre-wrap: keep the
+ * block structure as blank-line-separated paragraphs instead of one long line.
+ */
+export function workItemDescriptionParagraphs(raw: unknown): string {
+  if (raw === null || raw === undefined) return '';
+
+  return stripMarkup(formatBlockNoteContent(raw).text)
+    .split('\n')
+    .map((line) => line.replace(/[ \t]+/g, ' ').trim())
+    .join('\n')
+    .replace(/\n{3,}/g, '\n\n')
     .trim();
 }

--- a/packages/scheduling/src/lib/workItemDescription.ts
+++ b/packages/scheduling/src/lib/workItemDescription.ts
@@ -1,0 +1,10 @@
+import { formatBlockNoteContent } from '@alga-psa/formatting/blocknoteUtils';
+
+/**
+ * Work item descriptions are stored as serialized editor content. Flatten them to
+ * plain text for list/card surfaces, and collapse empty documents to ''.
+ */
+export function workItemDescriptionText(raw: unknown): string {
+  if (raw === null || raw === undefined) return '';
+  return formatBlockNoteContent(raw).text.trim();
+}

--- a/packages/scheduling/tests/ticketLookupActions.description.test.ts
+++ b/packages/scheduling/tests/ticketLookupActions.description.test.ts
@@ -1,0 +1,80 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const ticketRow = vi.hoisted(() => ({ current: null as Record<string, unknown> | null }));
+
+vi.mock('@alga-psa/db', () => {
+  const query = {
+    where: () => query,
+    select: () => query,
+    first: async () => ticketRow.current,
+  };
+
+  return {
+    createTenantKnex: async () => ({ knex: {} }),
+    tenantDb: () => ({ table: () => query, tenantJoin: () => undefined }),
+    withTransaction: async (_knex: unknown, callback: (trx: unknown) => unknown) =>
+      callback({ raw: (sql: string) => sql }),
+  };
+});
+
+vi.mock('@alga-psa/auth', () => ({
+  withAuth: (action: any) => async (...args: any[]) =>
+    action({ user_id: 'user-1' }, { tenant: 'tenant-1' }, ...args),
+}));
+
+import { getSchedulingTicketById } from '../src/actions/ticketLookupActions';
+
+describe('getSchedulingTicketById description', () => {
+  beforeEach(() => {
+    ticketRow.current = null;
+  });
+
+  it('flattens serialized editor content instead of returning raw JSON', async () => {
+    ticketRow.current = {
+      ticket_id: 'ticket-1',
+      attributes: {
+        description: JSON.stringify([
+          {
+            id: '1',
+            type: 'paragraph',
+            props: { textColor: 'default', backgroundColor: 'default', textAlignment: 'left' },
+            content: [{ type: 'text', text: 'Printer jams', styles: {} }],
+            children: [],
+          },
+          {
+            id: '2',
+            type: 'paragraph',
+            props: { textColor: 'default', backgroundColor: 'default', textAlignment: 'left' },
+            content: [{ type: 'text', text: 'Only on duplex jobs', styles: {} }],
+            children: [],
+          },
+        ]),
+      },
+    };
+
+    const ticket = await getSchedulingTicketById('ticket-1');
+
+    expect(ticket?.description).toBe('Printer jams\n\nOnly on duplex jobs');
+  });
+
+  it('returns null for an empty editor document', async () => {
+    ticketRow.current = {
+      ticket_id: 'ticket-1',
+      attributes: {
+        description: JSON.stringify([
+          {
+            id: '1',
+            type: 'paragraph',
+            props: { textColor: 'default', backgroundColor: 'default', textAlignment: 'left' },
+            content: [],
+            children: [],
+          },
+        ]),
+      },
+    };
+
+    const ticket = await getSchedulingTicketById('ticket-1');
+
+    expect(ticket?.description).toBeNull();
+  });
+});

--- a/packages/scheduling/tests/workItemDescription.test.ts
+++ b/packages/scheduling/tests/workItemDescription.test.ts
@@ -1,0 +1,41 @@
+import { describe, expect, it } from 'vitest';
+import { workItemDescriptionText } from '../src/lib/workItemDescription';
+
+describe('workItemDescriptionText', () => {
+  it('flattens serialized BlockNote paragraphs to plain text', () => {
+    const raw = JSON.stringify([
+      {
+        id: '1',
+        type: 'paragraph',
+        props: { textColor: 'default', backgroundColor: 'default', textAlignment: 'left' },
+        content: [{ type: 'text', text: 'Printer jams on duplex jobs', styles: {} }],
+        children: [],
+      },
+    ]);
+
+    expect(workItemDescriptionText(raw)).toBe('Printer jams on duplex jobs');
+  });
+
+  it('returns an empty string for an empty paragraph document', () => {
+    const raw = JSON.stringify([
+      {
+        id: '1',
+        type: 'paragraph',
+        props: { textColor: 'default', backgroundColor: 'default', textAlignment: 'left' },
+        content: [],
+        children: [],
+      },
+    ]);
+
+    expect(workItemDescriptionText(raw)).toBe('');
+  });
+
+  it('passes legacy plain-string descriptions through unchanged', () => {
+    expect(workItemDescriptionText('Legacy plain text description')).toBe('Legacy plain text description');
+  });
+
+  it('returns an empty string for null and undefined', () => {
+    expect(workItemDescriptionText(null)).toBe('');
+    expect(workItemDescriptionText(undefined)).toBe('');
+  });
+});

--- a/packages/scheduling/tests/workItemDescription.test.ts
+++ b/packages/scheduling/tests/workItemDescription.test.ts
@@ -34,6 +34,52 @@ describe('workItemDescriptionText', () => {
     expect(workItemDescriptionText('Legacy plain text description')).toBe('Legacy plain text description');
   });
 
+  it('strips styling markup that survives the markdown flattening', () => {
+    const raw = JSON.stringify([
+      {
+        id: '1',
+        type: 'heading',
+        props: { level: 1, textColor: 'default', backgroundColor: 'default', textAlignment: 'left' },
+        content: [{ type: 'text', text: 'Outage', styles: {} }],
+        children: [],
+      },
+      {
+        id: '2',
+        type: 'paragraph',
+        props: { textColor: 'default', backgroundColor: 'default', textAlignment: 'left' },
+        content: [
+          { type: 'text', text: 'Highlighted', styles: { backgroundColor: 'purple' } },
+          { type: 'text', text: ' and ', styles: {} },
+          { type: 'text', text: 'bold', styles: { bold: true } },
+        ],
+        children: [],
+      },
+    ]);
+
+    expect(workItemDescriptionText(raw)).toBe('Outage Highlighted and bold');
+  });
+
+  it('collapses multi-block documents onto a single line', () => {
+    const raw = JSON.stringify([
+      {
+        id: '1',
+        type: 'paragraph',
+        props: { textColor: 'default', backgroundColor: 'default', textAlignment: 'left' },
+        content: [{ type: 'text', text: 'First block', styles: {} }],
+        children: [],
+      },
+      {
+        id: '2',
+        type: 'paragraph',
+        props: { textColor: 'default', backgroundColor: 'default', textAlignment: 'left' },
+        content: [{ type: 'text', text: 'Second block', styles: {} }],
+        children: [],
+      },
+    ]);
+
+    expect(workItemDescriptionText(raw)).toBe('First block Second block');
+  });
+
   it('returns an empty string for null and undefined', () => {
     expect(workItemDescriptionText(null)).toBe('');
     expect(workItemDescriptionText(undefined)).toBe('');

--- a/packages/scheduling/tests/workItemDescription.test.ts
+++ b/packages/scheduling/tests/workItemDescription.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest';
-import { workItemDescriptionText } from '../src/lib/workItemDescription';
+import { workItemDescriptionParagraphs, workItemDescriptionText } from '../src/lib/workItemDescription';
 
 describe('workItemDescriptionText', () => {
   it('flattens serialized BlockNote paragraphs to plain text', () => {
@@ -83,5 +83,55 @@ describe('workItemDescriptionText', () => {
   it('returns an empty string for null and undefined', () => {
     expect(workItemDescriptionText(null)).toBe('');
     expect(workItemDescriptionText(undefined)).toBe('');
+  });
+});
+
+describe('workItemDescriptionParagraphs', () => {
+  it('keeps multi-block documents as separate paragraphs', () => {
+    const raw = JSON.stringify([
+      {
+        id: '1',
+        type: 'heading',
+        props: { level: 1, textColor: 'default', backgroundColor: 'default', textAlignment: 'left' },
+        content: [{ type: 'text', text: 'Outage', styles: {} }],
+        children: [],
+      },
+      {
+        id: '2',
+        type: 'paragraph',
+        props: { textColor: 'default', backgroundColor: 'default', textAlignment: 'left' },
+        content: [{ type: 'text', text: 'First block', styles: { backgroundColor: 'purple' } }],
+        children: [],
+      },
+      {
+        id: '3',
+        type: 'paragraph',
+        props: { textColor: 'default', backgroundColor: 'default', textAlignment: 'left' },
+        content: [{ type: 'text', text: 'Second block', styles: {} }],
+        children: [],
+      },
+    ]);
+
+    expect(workItemDescriptionParagraphs(raw)).toBe('Outage\n\nFirst block\n\nSecond block');
+  });
+
+  it('returns an empty string for empty documents and nullish input', () => {
+    const raw = JSON.stringify([
+      {
+        id: '1',
+        type: 'paragraph',
+        props: { textColor: 'default', backgroundColor: 'default', textAlignment: 'left' },
+        content: [],
+        children: [],
+      },
+    ]);
+
+    expect(workItemDescriptionParagraphs(raw)).toBe('');
+    expect(workItemDescriptionParagraphs(null)).toBe('');
+    expect(workItemDescriptionParagraphs(undefined)).toBe('');
+  });
+
+  it('passes legacy plain-string descriptions through unchanged', () => {
+    expect(workItemDescriptionParagraphs('Legacy plain text description')).toBe('Legacy plain text description');
   });
 });


### PR DESCRIPTION
## Summary
Ticket and work item descriptions are stored as serialized BlockNote editor content, but several Technician Dispatch surfaces (work item cards, the picker, the drag overlay, and the ticket drawer) rendered that content verbatim, dumping raw JSON/markup at users instead of plain text. This adds a shared helper that flattens BlockNote documents to readable text and wires it into every dispatch code path that displays a description.

## Changes
- **New helper** (`packages/scheduling/src/lib/workItemDescription.ts`): `workItemDescriptionText()` flattens a BlockNote document to a single line of plain text for card/list surfaces; `workItemDescriptionParagraphs()` preserves block structure as blank-line-separated paragraphs for detail views. Both strip residual markup (HTML tags, heading/list markers, bold/italic, links) left over from the BlockNote-to-text conversion, collapse whitespace, and pass legacy plain-string descriptions through untouched.
- **Work item search actions** (`packages/scheduling/src/actions/workItemActions.ts`): `searchDispatchWorkItems` and the ticket branch of `searchPickerWorkItems` now flatten `description` through `workItemDescriptionText()` before returning it.
- **Ticket lookup action** (`packages/scheduling/src/actions/ticketLookupActions.ts`): `getSchedulingTicketById` now flattens the description via `workItemDescriptionParagraphs()` and falls back to `null` for empty documents so the existing "No description" placeholder still shows in the ticket drawer.
- **WorkItemCard** (`packages/scheduling/src/components/technician-dispatch/WorkItemCard.tsx`): only renders the description row when there's actual text, instead of showing a stray empty line.
- **Dependency**: added `@alga-psa/formatting` as a workspace dependency of `packages/scheduling` to reuse its BlockNote flattening utility.

## Testing
- Added unit tests: `tests/workItemDescription.test.ts` (BlockNote flattening, markup stripping, paragraph preservation) and `tests/ticketLookupActions.description.test.ts` (drawer description flattening and null fallback for empty documents).
- Ran `npx vitest run tests/workItemDescription.test.ts tests/ticketLookupActions.description.test.ts` in `packages/scheduling` — 11/11 passing.
