### PR TITLE
docs: 72-hour managed email domain verification window (2026-08-01)

### DIFF
--- a/docs/email/email_settings_access.md
+++ b/docs/email/email_settings_access.md
@@ -23,7 +23,7 @@ Alternatively, you can directly access it via:
 >
 > Outbound email is sent through **SMTP** (available on all tiers) or **managed
 > Resend domains** (Solo tier and up). On appliance / Essentials-tier installs the
-> outbound provider is locked to SMTP: go to **Settings > Email > Outbound**, fill in
+> outbound provider is locked to SMTP: go to **Settings → Email → Outbound**, fill in
 > the SMTP host, port, username, password, and From address, then save. The outbound
 > domain is derived from the SMTP From address (not from any inbound mailbox), which
 > enables the "Ticketing From" field.

--- a/docs/email/email_settings_access.md
+++ b/docs/email/email_settings_access.md
@@ -23,7 +23,7 @@ Alternatively, you can directly access it via:
 >
 > Outbound email is sent through **SMTP** (available on all tiers) or **managed
 > Resend domains** (Solo tier and up). On appliance / Essentials-tier installs the
-> outbound provider is locked to SMTP: go to **Settings → Email → Outbound**, fill in
+> outbound provider is locked to SMTP: go to **Settings > Email > Outbound**, fill in
 > the SMTP host, port, username, password, and From address, then save. The outbound
 > domain is derived from the SMTP From address (not from any inbound mailbox), which
 > enables the "Ticketing From" field.
@@ -76,4 +76,4 @@ The following tables store email configuration:
 
 ## Workflow Integration
 
-Domain verification is handled through the workflow system. When a new domain is added, a verification workflow is automatically triggered to handle DNS verification and provider setup.
+Domain verification is handled through the workflow system. When a new domain is added, a verification workflow is automatically triggered to handle DNS verification and provider setup. The workflow polls for DNS record detection with exponential back-off, starting at 5-minute intervals and increasing to a maximum of once per hour, for up to **72 hours** from when the domain was added. If DNS records are not detected within that 72-hour window, the workflow records a failure and the domain status is automatically set to **Failed**; the domain must then be removed and re-added to start a new verification attempt.


### PR DESCRIPTION
## Source PRs

- [#3064 — Fixes all four bugs from the managedEmailDomainWorkflow prod audit](https://github.com/Nine-Minds/alga-psa/pull/3064) (merged 2026-07-31)

## Files edited

### `docs/email/email_settings_access.md`

**Behavior conveyed:** The domain verification workflow now has a bounded 72-hour lifetime with exponential back-off (5-minute to 1-hour intervals). If DNS records are not detected within 72 hours the workflow marks the domain Failed rather than polling indefinitely. The Workflow Integration section previously described only that "a verification workflow is automatically triggered" with no mention of bounds; updated it to document the timeout and back-off schedule so admins and developers understand the limits of automatic verification.

## Needs human review

- **PR #3063 — Expose `board_id` on `tickets.find` workflow action**: The `tickets.find` runtime action now returns a `board_id` (nullable UUID) alongside the existing ticket summary fields. No in-scope doc in `docs/workflow/` or `sdk/docs/` currently documents the `tickets.find` output schema, so there is no stale page to update here. A workflow action reference listing `tickets.find` fields (including `board_id`) would be a useful addition but is not drafted to avoid speculative copy.
- **PR #3066 — Fix raw BlockNote JSON in Technician Dispatch**: Pure rendering bug fix. No behavioral change to document.

---
_Generated by [Claude Code](https://claude.ai/code/session_01QRMSMUU5w46XExmsjU228s)_