### PR TITLE
fix(appliance): keep app-channel updates from liveness-killing the control plane

### DIFF
--- a/ee/appliance/host-service/manage-engine.mjs
+++ b/ee/appliance/host-service/manage-engine.mjs
@@ -351,14 +351,20 @@ export function requestControlPlaneUpgrade(deps) {
 
 function mapUpdateStatus(installStateStatus) {
   switch (installStateStatus) {
+    case 'update-queued':
     case 'update-running':
     case 'release-config-running':
+    // The update engine's storage-reconcile step writes its own phase statuses
+    // to the shared install-state file; without these the Manage UI would show
+    // an in-flight update as idle for the entire storage phase.
+    case 'storage-install-running':
       return 'running';
     case 'update-complete':
       return 'complete';
     case 'update-blocked':
     case 'release-config-blocked':
     case 'runtime-values-blocked':
+    case 'storage-install-blocked':
       return 'blocked';
     default:
       return 'idle';

--- a/ee/appliance/host-service/server.mjs
+++ b/ee/appliance/host-service/server.mjs
@@ -10,7 +10,6 @@ import { collectStatusSnapshotAsync } from './status-engine.mjs';
 import { createKubectlQueue } from './kubectl-queue.mjs';
 import { persistSetupInputs, validateSetupInputs, runNetworkChecks, resolveReleaseManifest } from './setup-engine.mjs';
 import { generateSupportBundle } from './support-bundle.mjs';
-import { runAppChannelUpdate } from './update-engine.mjs';
 import { createNativeKubernetesAdapter } from './kubernetes-client-adapter.mjs';
 import { PodExecManager } from './pod-exec-manager.mjs';
 import { PortForwardManager } from './port-forward-manager.mjs';
@@ -538,6 +537,35 @@ function queueSetupWorkflow() {
     new URL('./setup-engine.mjs', import.meta.url).pathname,
     'run',
     '--setup-inputs', setupInputsFile,
+    '--state-file', stateFile,
+    '--release-selection-file', releaseSelectionFile,
+    '--kubeconfig', kubeconfigPath
+  ], {
+    detached: true,
+    stdio: 'ignore',
+    env: process.env
+  });
+  child.unref();
+}
+
+// LEVERAGE: pattern detached-engine-workflow — queueSetupWorkflow and
+// queueUpdateWorkflow duplicate the detached-child spawn shape; a shared
+// queueEngineWorkflow(scriptUrl, args) would collapse them.
+// App-channel updates run in a detached child for the same reason setup does:
+// the engine shells out through spawnSync (storage reconcile, flux reconcile),
+// which would freeze this server's event loop — including /healthz — long
+// enough for the pod's liveness probe to kill the control plane mid-update
+// (alga0002202). The child writes install-state as it goes, so the Manage UI's
+// /api/manage/status polling keeps working while the update runs.
+function queueUpdateWorkflow(channel) {
+  if (process.env.ALGA_APPLIANCE_DISABLE_UPDATE_QUEUE === '1') {
+    return;
+  }
+
+  const child = spawn(process.execPath, [
+    new URL('./update-engine.mjs', import.meta.url).pathname,
+    'run',
+    '--channel', channel,
     '--state-file', stateFile,
     '--release-selection-file', releaseSelectionFile,
     '--kubeconfig', kubeconfigPath
@@ -1288,10 +1316,17 @@ const server = http.createServer(async (req, res) => {
       return;
     }
 
-    // Kick the update off and return immediately. The control-plane pod survives
-    // an app-channel update (only the app pod restarts), so it runs to completion
-    // here while the Manage UI polls /api/manage/status (install-state).
-    runAppChannelUpdate({ channel }).catch(() => {});
+    // Record the queued update before spawning so the Manage UI's very next
+    // status poll already reflects it, then hand off to the detached child.
+    fs.mkdirSync(path.dirname(stateFile), { recursive: true, mode: 0o750 });
+    fs.writeFileSync(stateFile, `${JSON.stringify({
+      status: 'update-queued',
+      phase: 'registry-release-source',
+      lastAction: `Update to ${channel} queued; background workflow is starting`,
+      updatedAt: new Date().toISOString(),
+      update: { requestedChannel: channel, scope: 'application-only' }
+    }, null, 2)}\n`, { mode: 0o600 });
+    queueUpdateWorkflow(channel);
     res.writeHead(202, { 'content-type': 'application/json' });
     res.end(JSON.stringify({ ok: true, started: true }));
     return;

--- a/ee/appliance/host-service/tests/install-storage.test.mjs
+++ b/ee/appliance/host-service/tests/install-storage.test.mjs
@@ -188,7 +188,8 @@ exit 0
       FAKE_BUNDLED_REAPPEAR_ON_GET: String(options.bundledReappearOnGet || 0),
       FAKE_SMOKE_JOB_FAIL: options.smokeJobFail ? 'true' : 'false',
       FAKE_STORAGE_CLASS_POLICY: options.storageClassPolicy || 'Retain',
-      ALGA_APPLIANCE_STORAGE_LOCK_DIR: path.join(tmp, 'storage-reconcile.lock'),
+      ALGA_APPLIANCE_STORAGE_LOCK_PATH: path.join(tmp, 'storage-reconcile.lock'),
+      ALGA_APPLIANCE_STORAGE_LOCK_ATTEMPTS: options.lockWaitAttempts || '150',
       ALGA_APPLIANCE_STORAGE_STABILITY_SECONDS: '0'
     }
   };
@@ -257,6 +258,56 @@ test('smoke failures still transition and remove only the smoke PV', () => {
   assert.equal(fs.existsSync(path.join(harness.stateDir, 'current-smoke-pv')), false);
   assert.equal(fs.existsSync(path.join(harness.stateDir, 'pv-leaked.exists')), false);
   assert.doesNotMatch(calls, /delete persistentvolume pv-(?:postgresql|redis|application)/);
+});
+
+// lstat-based: a dangling symlink (the lock's normal shape — its target is a
+// PID, not a path) makes fs.existsSync return false even when it still exists.
+function lockAbsent(lockPath) {
+  try {
+    fs.lstatSync(lockPath);
+    return false;
+  } catch {
+    return true;
+  }
+}
+
+// The control-plane container being restarted mid-reconcile (e.g. by its
+// liveness probe) SIGKILLs the lock holder, so its cleanup trap never runs.
+// A leftover lock must never block future reconciles — that previously left
+// appliances permanently unable to update (alga0002202).
+test('a stale lock whose owner is dead is reclaimed instead of blocking', () => {
+  const harness = createHarness();
+  // PID above every platform's pid_max, so it can never name a live process.
+  fs.symlinkSync('99999999', harness.env.ALGA_APPLIANCE_STORAGE_LOCK_PATH);
+  const result = runInstaller(harness);
+
+  assert.equal(result.status, 0, result.stderr || result.stdout);
+  assert.match(result.stdout, /Storage prerequisites are ready/);
+  assert.equal(lockAbsent(harness.env.ALGA_APPLIANCE_STORAGE_LOCK_PATH), true);
+});
+
+test('a legacy mkdir-style lock directory left by an older build is reclaimed', () => {
+  const harness = createHarness();
+  fs.mkdirSync(harness.env.ALGA_APPLIANCE_STORAGE_LOCK_PATH);
+  const result = runInstaller(harness);
+
+  assert.equal(result.status, 0, result.stderr || result.stdout);
+  assert.match(result.stdout, /Storage prerequisites are ready/);
+  assert.equal(lockAbsent(harness.env.ALGA_APPLIANCE_STORAGE_LOCK_PATH), true);
+});
+
+test('a lock held by a live process still blocks until the wait times out', () => {
+  const harness = createHarness({ lockWaitAttempts: '1' });
+  fs.symlinkSync(String(process.pid), harness.env.ALGA_APPLIANCE_STORAGE_LOCK_PATH);
+  const result = runInstaller(harness);
+
+  assert.notEqual(result.status, 0);
+  assert.match(result.stderr, /Timed out waiting for another storage reconciliation to finish/);
+  // The held lock must be left in place for its owner.
+  assert.equal(
+    fs.readlinkSync(harness.env.ALGA_APPLIANCE_STORAGE_LOCK_PATH),
+    String(process.pid)
+  );
 });
 
 test('repeated reconciliation preserves application PVs and leaves no smoke resources or side effects', () => {

--- a/ee/appliance/host-service/tests/manage-engine.test.mjs
+++ b/ee/appliance/host-service/tests/manage-engine.test.mjs
@@ -226,6 +226,35 @@ test('collectManageStatus reports upgradeAvailable on digest mismatch', async ()
   assert.equal(status.appUrl.host, '10.0.0.5');
 });
 
+// The detached update child (queueUpdateWorkflow) moves install-state through
+// update-queued and the storage-reconcile phase statuses; each must read as an
+// in-flight or blocked update, or the Manage UI would show a running update as
+// idle for those stretches.
+test('collectManageStatus maps queued and storage-phase statuses onto the update lifecycle', async () => {
+  const cases = [
+    ['update-queued', 'running'],
+    ['storage-install-running', 'running'],
+    ['storage-install-blocked', 'blocked']
+  ];
+  for (const [installStatus, expected] of cases) {
+    const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'alga-manage-status-map-'));
+    const installStateFile = path.join(tmp, 'install-state.json');
+    fs.writeFileSync(installStateFile, JSON.stringify({ status: installStatus, lastAction: 'x' }));
+    const releaseSelectionFile = path.join(tmp, 'release-selection.json');
+    fs.writeFileSync(releaseSelectionFile, JSON.stringify({ selectedChannel: 'stable' }));
+
+    const status = await collectManageStatus({
+      kube: fakeKube({ json: () => ({ ok: true, value: {} }) }),
+      releaseSelectionFile,
+      installStateFile,
+      cpUpgradeStatusFile: path.join(tmp, 'cp-upgrade.json'),
+      resolveControlPlaneRef: async () => null
+    });
+
+    assert.equal(status.app.update.status, expected, `install-state ${installStatus}`);
+  }
+});
+
 test('collectManageStatus: no upgrade when digests match', async () => {
   const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'alga-manage-status2-'));
   const releaseSelectionFile = path.join(tmp, 'release-selection.json');

--- a/ee/appliance/host-service/tests/update-engine.test.mjs
+++ b/ee/appliance/host-service/tests/update-engine.test.mjs
@@ -3,7 +3,11 @@ import os from 'node:os';
 import path from 'node:path';
 import test from 'node:test';
 import assert from 'node:assert/strict';
+import { spawnSync } from 'node:child_process';
 import { runAppChannelUpdate } from '../update-engine.mjs';
+
+const enginePath = path.join(import.meta.dirname, '..', 'update-engine.mjs');
+const serverPath = path.join(import.meta.dirname, '..', 'server.mjs');
 
 test('runAppChannelUpdate applies channel update and persists history without OS/k3s mutation scope', async () => {
   const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'alga-update-engine-'));
@@ -183,6 +187,70 @@ test('app update: helm reconcile exits non-zero and HelmRelease is unreadable ->
   const { result, state } = await runWithReconcileOutcome('false'); // kubectl read itself fails
   assert.equal(result.ok, false);
   assert.equal(state.status, 'update-blocked');
+});
+
+// The update must run in a separate process: the engine's spawnSync steps
+// (storage reconcile, flux reconcile) block the event loop of whichever
+// process runs them, and inside the control-plane server that freezes /healthz
+// long enough for the pod's liveness probe to kill the container mid-update
+// (alga0002202). server.mjs therefore spawns this CLI detached instead of
+// calling runAppChannelUpdate in-process.
+test('server runs app-channel updates in a detached child, never in-process', () => {
+  const server = fs.readFileSync(serverPath, 'utf8');
+  assert.doesNotMatch(server, /runAppChannelUpdate/);
+  assert.match(server, /function queueUpdateWorkflow/);
+  assert.match(server, /update-engine\.mjs/);
+  assert.match(server, /queueUpdateWorkflow\(channel\)/);
+});
+
+test('update-engine CLI reports a blocked terminal state when the update fails cleanly', () => {
+  const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'alga-update-cli-'));
+  const stateFile = path.join(tmp, 'install-state.json');
+  const historyFile = path.join(tmp, 'update-history.json');
+
+  // No release-selection.json: the engine refuses the update before touching
+  // storage, the registry, or the cluster — deterministic and offline.
+  const result = spawnSync(process.execPath, [
+    enginePath,
+    'run',
+    '--channel', 'stable',
+    '--state-file', stateFile,
+    '--release-selection-file', path.join(tmp, 'release-selection.json'),
+    '--update-history-file', historyFile
+  ], { encoding: 'utf8' });
+
+  assert.equal(result.status, 1, result.stderr || result.stdout);
+  const state = JSON.parse(fs.readFileSync(stateFile, 'utf8'));
+  assert.equal(state.status, 'update-blocked');
+  const history = JSON.parse(fs.readFileSync(historyFile, 'utf8'));
+  assert.equal(history.history[0].ok, false);
+});
+
+test('update-engine CLI writes a blocked terminal state even when the engine throws', () => {
+  const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'alga-update-cli-throw-'));
+  const stateFile = path.join(tmp, 'install-state.json');
+  const historyFile = path.join(tmp, 'update-history.json');
+  const releaseSelectionFile = path.join(tmp, 'release-selection.json');
+  fs.writeFileSync(releaseSelectionFile, JSON.stringify({
+    runtime: { appHostname: 'psa.example.com', dnsMode: 'system', dnsServers: '' }
+  }));
+
+  // An invalid channel makes validateSetupInputs throw; the Manage UI polls
+  // install-state until a terminal status, so the crash must still land on
+  // update-blocked instead of leaving the state mid-flight forever.
+  const result = spawnSync(process.execPath, [
+    enginePath,
+    'run',
+    '--channel', 'bogus',
+    '--state-file', stateFile,
+    '--release-selection-file', releaseSelectionFile,
+    '--update-history-file', historyFile
+  ], { encoding: 'utf8' });
+
+  assert.equal(result.status, 1, result.stderr || result.stdout);
+  const state = JSON.parse(fs.readFileSync(stateFile, 'utf8'));
+  assert.equal(state.status, 'update-blocked');
+  assert.match(state.failure.suspectedCause, /Invalid channel/);
 });
 
 test('app update stops before release reconciliation when storage repair fails', async () => {

--- a/ee/appliance/host-service/update-engine.mjs
+++ b/ee/appliance/host-service/update-engine.mjs
@@ -343,3 +343,69 @@ export async function runAppChannelUpdate(rawInputs, options = {}) {
 
   return result;
 }
+
+function parseCliArgs(argv) {
+  const parsed = { command: argv[0] || '' };
+  for (let i = 1; i < argv.length; i += 1) {
+    const arg = argv[i];
+    if (arg === '--channel') {
+      parsed.channel = argv[i + 1];
+      i += 1;
+    } else if (arg === '--state-file') {
+      parsed.stateFile = argv[i + 1];
+      i += 1;
+    } else if (arg === '--release-selection-file') {
+      parsed.releaseSelectionFile = argv[i + 1];
+      i += 1;
+    } else if (arg === '--update-history-file') {
+      parsed.updateHistoryFile = argv[i + 1];
+      i += 1;
+    } else if (arg === '--kubeconfig') {
+      parsed.kubeconfigPath = argv[i + 1];
+      i += 1;
+    }
+  }
+  return parsed;
+}
+
+// CLI entry so server.mjs can run app-channel updates in a detached child
+// (queueUpdateWorkflow), keeping the control plane's event loop — and its
+// /healthz liveness probe — responsive while the engine's spawnSync steps run.
+if (import.meta.url === `file://${process.argv[1]}`) {
+  const args = parseCliArgs(process.argv.slice(2));
+  if (args.command === 'run') {
+    const channel = args.channel || 'stable';
+    try {
+      const result = await runAppChannelUpdate({ channel }, args);
+      process.stdout.write(`${JSON.stringify(result)}\n`);
+      if (!result.ok) process.exitCode = 1;
+    } catch (error) {
+      // The Manage UI polls install-state until it reaches update-complete or
+      // update-blocked; an unexpected crash must still land on a terminal
+      // state instead of leaving update-running behind forever.
+      const failure = {
+        ok: false,
+        phase: 'update',
+        step: 'run-app-channel-update',
+        message: 'App-channel update failed before it could complete.',
+        suspectedCause: error instanceof Error ? error.message : String(error),
+        suggestedNextStep: 'Retry the update from the Manage page; inspect control-plane logs if it recurs.',
+        retrySafe: true
+      };
+      writeInstallState({
+        status: 'update-blocked',
+        phase: failure.phase,
+        lastAction: failure.message,
+        failure,
+        updatedAt: nowIso(),
+        update: { requestedChannel: channel, scope: 'application-only' }
+      }, args.stateFile || DEFAULT_STATE_FILE);
+      appendUpdateHistory(
+        { at: nowIso(), channel, ok: false, phase: failure.phase, message: failure.message },
+        args.updateHistoryFile || DEFAULT_UPDATE_HISTORY_FILE
+      );
+      process.stderr.write(`${JSON.stringify(failure)}\n`);
+      process.exitCode = 1;
+    }
+  }
+}

--- a/ee/appliance/scripts/install-storage.sh
+++ b/ee/appliance/scripts/install-storage.sh
@@ -8,7 +8,8 @@ STORAGE_PATH="/var/mnt/alga-data/local-path-provisioner"
 K3S_CONFIG_DROP_IN="/etc/rancher/k3s/config.yaml.d/20-alga-local-storage.yaml"
 K3S_LOCAL_STORAGE_SKIP_FILE="/var/lib/rancher/k3s/server/manifests/local-storage.yaml.skip"
 SMOKE_NAMESPACE="storage-smoke"
-LOCK_DIR="${ALGA_APPLIANCE_STORAGE_LOCK_DIR:-/var/lib/alga-appliance/storage-reconcile.lock}"
+LOCK_PATH="${ALGA_APPLIANCE_STORAGE_LOCK_PATH:-/var/lib/alga-appliance/storage-reconcile.lock}"
+LOCK_WAIT_ATTEMPTS="${ALGA_APPLIANCE_STORAGE_LOCK_ATTEMPTS:-150}"
 STORAGE_STABILITY_SECONDS="${ALGA_APPLIANCE_STORAGE_STABILITY_SECONDS:-10}"
 DRY_RUN=false
 KUBE_COMMAND=()
@@ -38,22 +39,55 @@ run_cmd() {
   "$@"
 }
 
+# Serialize concurrent reconciles with an atomic symlink lock whose target is
+# the owner's PID. Claiming the lock and recording its owner happen in one
+# atomic step, so a holder that dies without running its cleanup trap — the
+# control-plane container being SIGKILLed mid-reconcile leaves no chance to
+# clean up — is detected as stale by the next caller and reclaimed, instead of
+# blocking every future reconcile until someone hand-deletes the lock.
+lock_reclaimed_if_stale() {
+  local owner
+  owner="$(readlink "$LOCK_PATH" 2>/dev/null || true)"
+  if [ -n "$owner" ] && ! kill -0 "$owner" 2>/dev/null; then
+    # Best-effort reclaim: two callers racing over the same dead owner could
+    # momentarily both hold the lock. Reconciliation is idempotent kubectl
+    # applies, so an overlapping run is safe — a permanently wedged lock is not.
+    rm -f "$LOCK_PATH" 2>/dev/null
+    return
+  fi
+  return 1
+}
+
 acquire_lock() {
   if $DRY_RUN; then
     return 0
   fi
 
   local attempts=0
-  mkdir -p "$(dirname "$LOCK_DIR")"
-  until mkdir "$LOCK_DIR" 2>/dev/null; do
+  mkdir -p "$(dirname "$LOCK_PATH")"
+  while :; do
+    if [ -d "$LOCK_PATH" ]; then
+      # mkdir-style lock directory from an older build. That scheme recorded
+      # no owner, so a surviving directory (always empty by construction) can
+      # only be stale: a live legacy holder and this build never run
+      # concurrently. Reclaim it before the ln attempt — `ln -s` against an
+      # existing directory would "succeed" by creating the link inside it.
+      rmdir "$LOCK_PATH" 2>/dev/null || true
+    fi
+    if ln -s "$$" "$LOCK_PATH" 2>/dev/null; then
+      break
+    fi
+    if lock_reclaimed_if_stale; then
+      continue
+    fi
     attempts=$((attempts + 1))
-    if [ "$attempts" -ge 150 ]; then
+    if [ "$attempts" -ge "$LOCK_WAIT_ATTEMPTS" ]; then
       echo "Timed out waiting for another storage reconciliation to finish." >&2
       exit 1
     fi
     sleep 2
   done
-  trap 'rmdir "$LOCK_DIR" 2>/dev/null || true' EXIT INT TERM
+  trap 'rm -f "$LOCK_PATH" 2>/dev/null || true' EXIT INT TERM
 }
 
 configure_kube_command() {


### PR DESCRIPTION
## Problem (alga0002202)

App-channel updates ran in-process in the control-plane server. The update engine's `spawnSync` steps (release resolve, storage reconcile, flux reconcile) froze the event loop — including `/healthz` — long enough for the pod's liveness probe to kill the container mid-update. The Manage UI surfaced this as "failed to fetch" (observed at "Reconciling the appliance local-path storage provider"), and the SIGKILLed reconcile left a stale lock directory that permanently blocked every retry.

## Fix

- Run app-channel updates in a detached child (new `update-engine run` CLI), mirroring how setup already avoids this; write `update-queued` state up front and guarantee a terminal `update-blocked` state if the child crashes.
- Replace the storage reconcile's mkdir lock with an atomic symlink lock owned by PID: dead-owner locks and legacy lock directories are reclaimed instead of wedging updates until a VM rebuild.
- Map `update-queued` and `storage-install-*` install-state statuses onto the Manage UI update lifecycle so the storage phase reads as running, not idle.

## Validation (local libvirt appliance, 2026-08-01)

Reproduced on the old stable control plane: each update attempt froze the API (POST timed out, status fetches failed), liveness-killed the pod (+1 restart per attempt), and left the install state poisoned at `release-resolve-running`. On this hardware the kill landed at the release-resolve `spawnSync` — the bug fires at whichever `spawnSync` runs first; detaching the whole update covers all of them.

With the fixed control plane: POST returned in ~7 ms (`update-queued`), zero failed status fetches, PID-owned symlink lock visible and reclaimed correctly, the poisoned state self-recovered, `update-complete` in ~60–75 s, app version advanced, **zero control-plane restarts**. Validated on both the nightly channel and the released stable 1.3.11 (which pins this branch's control-plane image `sha256:22edcd98…`).

## Rollout note

The fix cannot ship via the app update itself (updating into the fix runs the old broken updater). Customer sequence: control-plane upgrade first (Manage page, or reboot on installs whose host-agent predates the upgrade endpoint — bootstrap re-resolves the channel-pinned control-plane image at boot), then retry the app update. No manual lock cleanup needed.

Validation also surfaced two adjacent issues (not addressed here): stable-channel releases must include a config publish alongside a control-plane bump (post-1.3.10 engines require `publicBaseUrl` in temporal-worker profileValues, and `setYamlScalar` won't create missing keys), and the self-heal reconciler resets its attempt ledger whenever it observes a running state, so a permanently-blocked setup retries forever.
