### PR TITLE
Inbound email docs accuracy pass (alga0002218)

### DIFF
--- a/docs/inbound-email/README.md
+++ b/docs/inbound-email/README.md
@@ -14,9 +14,9 @@ This folder hosts everything related to converting inbound emails into Tickets. 
 |----------|-------|
 Set up Microsoft 365 / Entra (Outlook, Exchange Online) | `setup/microsoft.md` |
 Set up Gmail with OAuth | `setup/gmail.md` |
-Set up IMAP with OAuth2 | *(coming soon)* |
+Understand IMAP in-app processing flags | [`setup/imap.md`](setup/imap.md) |
 Refresh an expired Pub/Sub subscription | `setup/refresh-pubsub.md` |
-Understand the overall architecture | `architecture/overall.md` *(coming soon)* |
+Understand the overall architecture | [`architecture/overall.md`](architecture/overall.md) |
 See the email-to-ticket workflow diagram | `architecture/workflow.md` |
 Learn about the single-initialisation Pub/Sub design | `architecture/pubsub.md` |
 Develop or modify an adapter | `development/adapters.md` |

--- a/docs/inbound-email/architecture/overall.md
+++ b/docs/inbound-email/architecture/overall.md
@@ -1,4 +1,85 @@
-# Inbound Email – Overall Architecture
+# Inbound Email Overall Architecture
 
-*Placeholder.*  Will contain a high-level component diagram linking webhooks, queue workers, workflow engine and storage.  For now, see `architecture/workflow.md` for the detailed flow and `architecture/pubsub.md` for infrastructure specifics.
+Inbound email providers detect a message, enqueue a provider pointer, and fetch
+the message only inside a worker. The processing pipeline then normalizes the
+provider payload and creates a new ticket or adds a reply to an existing ticket.
 
+```mermaid
+flowchart LR
+    subgraph Providers
+        MS[Microsoft Graph]
+        G[Gmail and Pub/Sub]
+        IMAP[IMAP mailbox]
+    end
+
+    MS -->|Validated webhook| INGRESS[Provider ingress handlers]
+    MS -->|Reconciliation or polling| POLL[Background maintenance]
+    G -->|Validated Pub/Sub push| INGRESS
+    IMAP -->|Mailbox notification or resync| INGRESS
+
+    INGRESS --> QUEUE[Unified inbound pointer queue]
+    POLL --> QUEUE
+    QUEUE --> FETCH[Provider-specific message fetch]
+    FETCH --> NORMALIZE[Normalized inbound message]
+    NORMALIZE --> PROCESS[Rules, threading, and client matching]
+    PROCESS --> TICKET[Create ticket or append comment]
+    PROCESS --> FILES[Store attachments and original message]
+```
+
+The queue contains a provider, tenant, provider ID, and remote message pointer.
+It does not need the full message body. The worker uses the tenant-scoped
+provider configuration to fetch the source message, normalize headers and MIME
+content, and pass it to the common ticket-processing path. Processed-message
+records and queue idempotency prevent the same provider message from creating
+duplicate work.
+
+See [`workflow.md`](workflow.md) for the detailed ticket decision flow.
+
+## Microsoft 365 path
+
+1. An administrator authorizes delegated `Mail.Read`, `Mail.Read.Shared`, and
+   `offline_access`. Alga PSA stores the OAuth tokens server-side with the
+   provider configuration. The Email-bound Microsoft profile supplies the app
+   credentials used for token refresh. Hosted deployments can use the platform
+   app when no tenant Email binding exists.
+2. For a user mailbox, Alga PSA attempts to create a Microsoft Graph
+   change-notification subscription for the watched folder. Graph validates the
+   public HTTPS notification URL during creation.
+3. A notification is accepted only when its subscription maps to an active
+   provider and its `clientState` matches the stored verification token. The
+   handler then enqueues the Graph message ID.
+4. A maintenance cycle renews subscriptions and reconciles Inbox. If webhook
+   validation fails or webhook delivery repeatedly misses messages, polling
+   enqueues the same kind of message pointer instead.
+5. The queue worker uses Graph to download the message source and passes the
+   normalized message to the shared processing pipeline.
+
+Microsoft's delegated shared-mail scopes can read mailboxes the signed-in user
+already has access to, but they do not support change-notification subscriptions
+on shared or delegated folders. Shared-mailbox providers therefore normally use
+polling. See [`../setup/microsoft.md`](../setup/microsoft.md) for the setup and
+permission checklist.
+
+## Other provider paths
+
+| Provider | Detection path | Provider-specific state |
+| --- | --- | --- |
+| Gmail | Google Pub/Sub push and Gmail history | OAuth tokens, Pub/Sub topic/subscription, Gmail watch, and history cursor |
+| IMAP | IMAP mailbox notification/resync path | Host, TLS and authentication settings, mailbox folder, and message UID |
+
+Google Pub/Sub provisioning is initialized separately from the shared queue
+pipeline. See [`pubsub.md`](pubsub.md) for that design. See
+[`../setup/imap.md`](../setup/imap.md) for the current IMAP in-app processing
+flags.
+
+## Trust boundaries
+
+* Inbound connectors read source mail. Processing state is stored in Alga PSA;
+  the connectors do not mark source messages as read, move them, or send mail.
+* Client secrets, access tokens, refresh tokens, and mailbox credentials stay on
+  the server. Browser forms receive readiness state, not stored secret values.
+* Provider webhooks are validated before queueing. Microsoft notifications are
+  matched by subscription and `clientState`; Gmail Pub/Sub requests require a
+  Google-signed bearer token.
+* Provider lookup, queue jobs, message fetches, and ticket writes retain tenant
+  and provider identity across the pipeline.

--- a/docs/inbound-email/architecture/overall.md
+++ b/docs/inbound-email/architecture/overall.md
@@ -76,8 +76,11 @@ flags.
 
 * Inbound connectors read source mail. Processing state is stored in Alga PSA;
   the connectors do not mark source messages as read, move them, or send mail.
-* Client secrets, access tokens, refresh tokens, and mailbox credentials stay on
-  the server. Browser forms receive readiness state, not stored secret values.
+* Provider credentials are persisted in Alga PSA's server-side configuration.
+  During hosted Microsoft setup, the provider form receives app configuration
+  that includes the client secret. The OAuth callback also returns newly issued
+  access and refresh tokens to the opener after persisting them. These browser
+  payloads are sensitive and must not be logged or exposed to other clients.
 * Provider webhooks are validated before queueing. Microsoft notifications are
   matched by subscription and `clientState`; Gmail Pub/Sub requests require a
   Google-signed bearer token.

--- a/docs/inbound-email/setup/microsoft.md
+++ b/docs/inbound-email/setup/microsoft.md
@@ -1,116 +1,229 @@
 # Microsoft 365 Provider Setup (Outlook / Exchange Online)
 
-This guide walks an administrator through connecting a Microsoft 365 / Exchange Online mailbox so that incoming email is turned into tickets. It uses a tenant-owned Microsoft Entra ID app registration plus Microsoft Graph change notifications (webhooks).
+Connect a Microsoft 365 mailbox to turn incoming messages into tickets. The
+connector uses delegated Microsoft Graph access on behalf of the user who
+authorizes it.
 
-> **Inbound only — this connector never sends email.**
->
-> The Microsoft 365 / Entra provider *reads* a mailbox and converts messages into
-> tickets. It is not an outbound transport, and there is no Microsoft/Graph send
-> path in the product — outbound email always goes through **SMTP** (all tiers) or
-> **managed Resend domains** (Solo tier and up). See
-> [Outbound email is configured separately](#outbound-email-is-configured-separately) below.
->
-> A Microsoft provider (or integration profile) showing **Ready** only means the
-> Entra app credentials (client ID + client secret, plus tenant ID for a profile)
-> are configured — it says nothing about the ability to send email.
+> **Inbound only.** This connector reads mail. It does not move messages, mark
+> them as read, or send replies. Configure ticket replies and notifications
+> separately under **Settings → Email → Outbound**.
 
-> Microsoft 365 inbound email is an Enterprise Edition feature; the provider type
-> is not offered in Community Edition builds.
+> Microsoft 365 inbound email is an Enterprise Edition feature. It is not
+> offered in Community Edition builds.
 
-## Prerequisites
+## Choose the hosted or self-hosted path
 
-* A Microsoft Entra ID **app registration** the tenant owns, with:
-  * **Client ID**, **client secret**, and (optionally) the **directory (tenant) ID**.
-  * Sign-in audience allowing multi-tenant sign-in ("Accounts in any organizational directory") — authorization uses the `login.microsoftonline.com/common` endpoint.
-  * Redirect URI (type *Web*): `https://<your-host>/api/auth/microsoft/callback`.
-  * Delegated Microsoft Graph permissions: `Mail.Read`, `Mail.Read.Shared`, `offline_access` (the OAuth flow requests read-only mail access).
-* The mailbox to connect (a licensed user mailbox or a shared mailbox the authorizing user can read).
-* An Alga PSA user with permission to manage system settings (**Settings → Integrations → Providers** requires `system_settings:update`).
-* The appliance needs outbound HTTPS access to `graph.microsoft.com` and
-  `login.microsoftonline.com`. A public inbound URL is optional: when Microsoft
-  cannot validate the notification endpoint, Alga PSA automatically uses
-  outbound-only polling.
+### Hosted Alga PSA
 
-## End-to-End Flow
+Hosted deployments can use Alga PSA's platform Microsoft app:
 
-```mermaid
-flowchart TD
-    A[Admin creates Microsoft profile in Settings -> Integrations -> Providers] --> B[Profile bound to the Email consumer]
-    B --> C[Admin adds Microsoft 365 provider under Inbound Email]
-    C --> D[Click 'Authorize Access' -> OAuth popup]
-    D --> E[User signs in and consents]
-    E --> F[/api/auth/microsoft/callback stores tokens/]
-    F --> G{Graph webhook endpoint reachable?}
-    G -->|Yes| H[Real-time webhook delivery]
-    G -->|No| I[Outbound-only polling every 3 minutes]
-    H --> J[Provider connected - new mail becomes tickets]
-    I --> J
-```
+* If **Authorize Access** is enabled when you
+  [add the inbound provider](#add-the-inbound-provider), the Outlook email
+  credential path is ready. The platform credentials remain server-side and are
+  not shown in the mailbox form.
+* If you bind a tenant-owned Microsoft app to Outlook email, that app takes
+  precedence over the hosted platform app. Follow
+  [Register a tenant-owned Entra app](#register-a-tenant-owned-entra-app), then
+  reauthorize any mailbox whose refresh token was issued to a different client
+  ID.
 
-## Step-by-Step
+### Self-hosted or appliance Alga PSA
 
-### 1. Register the Entra app
+Create and bind your own Entra app. Register your deployment's exact callback
+URL and allow outbound HTTPS to `login.microsoftonline.com` and
+`graph.microsoft.com`.
 
-1. In the [Microsoft Entra admin center](https://entra.microsoft.com), create an **App registration**.
-2. Add the *Web* redirect URI shown in the Providers screen: `https://<your-host>/api/auth/microsoft/callback`.
-3. Under **API permissions**, add the delegated Graph permissions `Mail.Read`, `Mail.Read.Shared`, and `offline_access`.
-4. Create a **client secret** and note the value.
+A public HTTPS notification URL is optional. Expose
+`https://<your-host>/api/email/webhooks/microsoft` only if you want webhook
+delivery for a user mailbox. If Microsoft cannot validate that URL, Alga PSA
+uses polling over outbound HTTPS instead.
 
-### 2. Configure the tenant credentials (profile)
+Operator-level app secrets and environment variables remain compatibility
+fallbacks. Use the Microsoft profile in the UI for normal setup so the app used
+by Outlook email is explicit.
+
+## Required Microsoft permissions
+
+Add these permissions as **Microsoft Graph → Delegated permissions**. The
+inbound OAuth flow requests exactly these three scopes:
+
+| Permission | Why Alga PSA requests it |
+| --- | --- |
+| `Mail.Read` | Reads the signed-in user's mailbox. It also permits message and folder access used for that user's change-notification subscription. |
+| `Mail.Read.Shared` | Reads shared or delegated mailboxes that the signed-in user can already access. It does not grant Exchange mailbox access. |
+| `offline_access` | Requests a refresh token so polling, reconciliation, and subscription maintenance can continue without another interactive sign-in. |
+
+Do not add **Application permissions** for this connector. `Mail.ReadWrite` and
+`Mail.Send` are not required for inbound ingestion. The broader Email scope list
+shown in some Microsoft provider guidance covers other Microsoft capabilities;
+it is not the inbound mailbox runtime checklist.
+
+Microsoft lists these delegated permissions as not requiring admin consent by
+default. Your tenant can still restrict user consent. Grant tenant-wide admin
+consent when your consent policy requires it, or when you want administrators to
+approve the scopes for all authorizing users in advance. Granting admin consent
+does not change them into application permissions.
+
+See Microsoft's references for
+[Graph mail permissions](https://learn.microsoft.com/graph/permissions-reference#mail-permissions),
+[`offline_access`](https://learn.microsoft.com/entra/identity-platform/scopes-oidc#the-offline_access-scope),
+and [delegated consent policy](https://learn.microsoft.com/graph/permissions-overview#delegated-access-scenarios).
+
+## Before you authorize
+
+Confirm all of the following:
+
+* The app's supported account type is **Accounts in any organizational
+  directory**. Alga PSA starts authorization through the Microsoft `common`
+  authority.
+* The **Web** redirect URI in Entra exactly matches the value displayed by Alga
+  PSA: `https://<your-host>/api/auth/microsoft/callback`. Scheme, host, path, and
+  trailing slash must match.
+* You copied the client secret **Value**, not its Secret ID. The value is shown
+  only when the secret is created.
+* The Microsoft app is enabled for **Outlook email** and selected in the Outlook
+  email service row under **Which Microsoft app each service uses**.
+* The user who will complete OAuth can open the configured mailbox. For a shared
+  mailbox, complete the additional checks in
+  [Connect a shared mailbox](#connect-a-shared-mailbox).
+
+## Register a tenant-owned Entra app
+
+1. In the [Microsoft Entra admin center](https://entra.microsoft.com), open
+   **App registrations** and create an app.
+2. Select **Accounts in any organizational directory** as the supported account
+   type.
+3. Under **Authentication**, add the callback from Alga PSA as a **Web** redirect
+   URI: `https://<your-host>/api/auth/microsoft/callback`.
+4. Under **API permissions**, add `Mail.Read`, `Mail.Read.Shared`, and
+   `offline_access` as delegated permissions.
+5. If your tenant policy requires administrator approval, select **Grant admin
+   consent** for the tenant.
+6. Under **Certificates & secrets**, create a client secret and copy its
+   **Value** immediately.
+
+## Configure the Microsoft profile
 
 1. Open **Settings → Integrations → Providers**.
-2. In the Microsoft section, click **New Profile** and enter a **display name**, the **Client ID**, the **Tenant ID** (or leave `common`), and the **Client secret**. Mark it as default if it is your only profile.
-3. Make sure the profile is bound to the **Email** consumer (the consumer bindings section on the same screen). The provider form's **Authorize Access** button stays disabled until an Email-bound profile is ready.
+2. In the Microsoft section, select **New app registration**.
+3. Enter a display name, the **Client ID**, **Tenant ID**, and **Client secret**.
+   Use the directory ID for the Microsoft 365 tenant. Use `common` only when
+   your deployment deliberately uses a multi-tenant app with common authority.
+4. Under **Services this app can handle**, enable **Outlook email**, then create
+   the profile.
+5. Under **Which Microsoft app each service uses**, select that app for
+   **Outlook email**. A default app is not a substitute for this service binding.
 
-Provider credentials are entered only here — the email provider form itself no longer asks for a client ID/secret. See `docs/integrations/provider-setup-order.md` for the recommended ordering across SSO, email, and calendar.
+Alga PSA stores the client secret server-side. The inbound provider form does
+not ask for the client ID or secret. See
+[`provider-setup-order.md`](../../integrations/provider-setup-order.md) when the
+same app also supports sign-in, calendar, or Teams.
 
-### 3. Add the inbound email provider
+## Add the inbound provider
 
-1. Open **Settings → Email → Inbound Email** (also reachable via **Settings → Integrations → Communication → Email**).
-2. Click **Add Email Provider** and choose **Microsoft 365**.
-3. Fill in:
-   * **Configuration Name** — display name for the provider.
-   * **Email Address** — the mailbox to ingest.
-   * **Ticket Defaults** — which board/status/priority new email tickets get (optional).
-   * **Folder Filters** — comma-separated folders to watch (defaults to `Inbox`).
-   * **Max Emails Per Sync** — 1–1000, defaults to 50.
-   * **Redirect URI** — pre-filled; must exactly match the URI registered in Entra.
-4. Click **Authorize Access** and complete the Microsoft consent in the popup.
-   The window closes automatically. Alga PSA attempts to register a Graph
-   webhook and falls back to polling when Microsoft cannot reach the configured
-   notification URL; either delivery mode appears as connected.
+1. Open **Settings → Email → Inbound Email**.
+2. Select **Add Email Provider**, then choose **Microsoft 365**.
+3. Enter the following values:
+   * **Configuration Name**: an internal name for this connection.
+   * **Email Address**: the user or shared mailbox to ingest.
+   * **Inbound Ticket Defaults**: the optional defaults for new tickets.
+   * **Folder Filters**: use `Inbox`. The form accepts multiple folder names,
+     but Microsoft setup currently subscribes only to the first entry and
+     maintenance reconciliation uses Inbox.
+   * **Max Emails Per Sync**: between 1 and 1000. The default is 50.
+   * **Redirect URI**: leave the generated value unchanged unless the matching
+     Entra redirect URI was also changed.
+4. Select **Authorize Access**. Sign in as the user whose delegated access Alga
+   PSA should use, then approve the consent prompt.
 
-## How It Works at Runtime
+The popup closes after Alga PSA stores the access and refresh tokens. A user
+mailbox normally attempts webhook setup. Polling is also a connected and
+supported delivery mode.
 
-* The OAuth callback stores the access/refresh tokens and attempts to create a Microsoft Graph **change-notification subscription** (`changeType: created`) on the watched folder(s), pointing at `https://<your-host>/api/email/webhooks/microsoft`.
-* Graph subscriptions are short-lived (created for roughly 60 hours). A background maintenance job sweeps every 15 minutes with a 24-hour look-ahead, renews subscriptions before expiry, and recreates them if Graph reports them gone.
-* With a reachable endpoint, delivery is webhook-driven and reconciliation remains a 15-minute safety net. If endpoint validation fails, or reconciliation repeatedly finds messages that webhooks missed, the provider switches to outbound-only polling every 3 minutes. Polling providers retry webhook registration daily and whenever **Test Connection** is used.
-* The connector operates read-only against the mailbox: it does not mark messages, move them, or send replies.
+## Connect a shared mailbox
 
-If no tenant profile is bound to the Email consumer, hosted deployments fall back to the platform-level Microsoft app credentials (`MICROSOFT_CLIENT_ID` / `MICROSOFT_CLIENT_SECRET` / `MICROSOFT_TENANT_ID`). Self-hosted installs should always configure their own profile.
+Use delegated access. Do not sign in as the shared mailbox and do not add an
+application-level mail permission.
 
-## Outbound Email Is Configured Separately
+1. Set **Email Address** on the Alga PSA provider to the shared mailbox address.
+2. Sign in during **Authorize Access** with a normal licensed Microsoft 365 user
+   account.
+3. In Exchange Online, grant that user **Read and manage (Full Access)** to the
+   shared mailbox. `Mail.Read.Shared` lets Graph use access the user already
+   has; it does not assign Full Access.
+4. Before authorizing Alga PSA, verify that the user can open the shared mailbox
+   in Outlook or Outlook on the web.
 
-Connecting a Microsoft mailbox does **not** enable sending. Ticket replies, notifications, and all other outbound mail use one of:
+Microsoft Graph does not support Outlook change-notification subscriptions on
+shared or delegated folders with `Mail.Read.Shared`. A shared-mailbox provider
+therefore relies on Alga PSA's polling delivery. Setup still attempts a webhook
+subscription first, so Microsoft can return a subscription access error during
+authorization. Do not add application permissions to work around that error;
+they are not used by this delegated connector. Leave the provider enabled and
+check its delivery mode and last-ingested time after the next polling cycle.
 
-* **SMTP** — available on every tier, and the only option on appliance / Essentials-tier installs (the outbound provider selector is locked to SMTP there).
-* **Managed Resend domains** — Solo tier and up.
+If OAuth succeeds for the user's own mailbox but the shared mailbox returns
+HTTP 403, check these in order:
 
-To enable outbound on an appliance install:
+1. Confirm the user can open the shared mailbox in Outlook or Outlook on the
+   web.
+2. Confirm `Mail.Read.Shared` is present and consented in the token/app setup.
+3. Reauthorize the provider, then run **Test Connection** or Microsoft 365
+   diagnostics again.
 
-1. Go to **Settings → Email → Outbound**.
-2. Fill in the SMTP **Host**, **Port**, **Username**, **Password**, and **From** address, then **Save**.
-3. The outbound domain is derived from the SMTP **From** address (not from the Entra mailbox). Once saved, the **Ticketing From** field and its Save button become editable — set it to the address replies should come from (typically the same address as the inbound mailbox, so threading works for your customers).
+Microsoft documents the distinction between
+[`Mail.Read.Shared`](https://learn.microsoft.com/graph/permissions-reference#mailreadshared)
+and [Exchange Full Access](https://learn.microsoft.com/exchange/recipients-in-exchange-online/manage-permissions-for-recipients).
+
+## Webhooks, subscriptions, and polling
+
+For a user mailbox, Alga PSA attempts to create a `changeType: created`
+subscription for the watched folder at
+`https://<your-host>/api/email/webhooks/microsoft`. The subscription uses the
+same delegated `Mail.Read` access as message retrieval. There is no separate
+Graph webhook permission.
+
+Microsoft validates the public notification URL while the subscription is
+created. This network handshake is separate from mailbox authorization. A
+validation failure means Microsoft cannot use the webhook delivery path; it
+does not by itself mean the mail permissions are wrong.
+
+At runtime:
+
+* New subscriptions are created for about 60 hours.
+* Maintenance runs every 15 minutes, looks 24 hours ahead, and renews or
+  recreates subscriptions before they expire.
+* Webhook providers also reconcile Inbox every 15 minutes as a safety net. After
+  three reconciliation runs import mail without a webhook delivery, Alga PSA
+  switches the provider to polling.
+* Polling runs every 3 minutes by default and needs only outbound HTTPS.
+* Polling providers retry webhook registration every 24 hours and when you use
+  **Test Connection**.
+
+The connector remains read-only in both modes. Refresh tokens are stored
+server-side and are used to renew access tokens for background work.
+
+## Outbound email is configured separately
+
+Connecting a Microsoft mailbox does not enable sending. Ticket replies,
+notifications, and other outbound mail use SMTP or a managed Resend domain.
+Appliance and Essentials installations use SMTP.
+
+For an appliance, open **Settings → Email → Outbound**, configure SMTP, then set
+**Ticketing From** to the reply address. This is usually the same address as the
+inbound mailbox so customer replies thread correctly.
 
 ## Troubleshooting
 
-* **"Authorize Access" is disabled / alert about provider settings** — no Microsoft profile is bound to the Email consumer. Use the **Open Providers Settings** link (or **Settings → Integrations → Providers**) and create/bind a profile first.
-* **OAuth popup fails** — confirm the redirect URI in the form exactly matches the one registered in the Entra app, and that the app allows multi-tenant sign-in (`/common` authority).
-* **Provider says Ready/connected but customers get no email** — expected: this provider is inbound-only. Configure outbound SMTP (or Resend) as described above.
-* **No new tickets from incoming mail** — check the provider's delivery mode and
-  last-ingested time. Webhook mode requires Microsoft to reach
-  `/api/email/webhooks/microsoft`; polling mode requires only outbound HTTPS to
-  `graph.microsoft.com` and `login.microsoftonline.com`. **Test Connection**
-  checks Graph access and immediately retries webhook registration without
-  changing the last-ingested cursor.
-* **Wrong folder being watched** — adjust **Folder Filters** on the provider and re-save; each watched folder needs its own subscription.
+| Symptom | Check |
+| --- | --- |
+| **Authorize Access** is disabled | Open **Settings → Integrations → Providers**. Enable a Microsoft app for Outlook email and select it in the Outlook email service row, or confirm the hosted platform setup is ready. |
+| Microsoft shows **Need admin approval** | The tenant's consent policy blocks user consent. Ask an authorized Entra administrator to grant tenant-wide admin consent for the three delegated scopes. |
+| OAuth reports a redirect error | Compare the displayed redirect URI with the Entra **Web** redirect URI character for character. Confirm the app supports accounts in any organizational directory. |
+| OAuth succeeds, but the shared mailbox returns 403 | Confirm Exchange Full Access for the authorizing user, then confirm and re-consent `Mail.Read.Shared`. Graph consent does not grant mailbox membership. |
+| Shared-mailbox authorization reports a subscription access error | Microsoft does not support delegated change notifications for shared folders. Do not add application permissions. Leave the provider enabled and check polling delivery and last-ingested time after the next cycle. |
+| Subscription creation or validation fails | Confirm public DNS, valid TLS, and inbound access to `/api/email/webhooks/microsoft`. The provider can remain connected in polling mode while you fix reachability. Shared mailboxes are expected to poll. |
+| New mail does not create tickets | Check delivery mode and last-ingested time. Polling needs outbound access to Microsoft. Webhook mode also needs public inbound access. Use **Test Connection** to check Graph access and retry webhook registration. |
+| Token refresh fails after working previously | The refresh token or consent may have expired or been revoked, or the bound app's client ID/secret changed. Restore the issuing app credentials if appropriate, then reauthorize the mailbox. |
+| Mail from a custom folder is missing | Set **Folder Filters** to `Inbox` and reauthorize. Multiple/custom Microsoft folders are not currently reliable across subscription maintenance and reconciliation. |
+| The provider is Ready, but Alga PSA sends no replies | Ready describes inbound credentials only. Configure SMTP or Resend under **Settings → Email → Outbound**. |

--- a/docs/inbound-email/setup/microsoft.md
+++ b/docs/inbound-email/setup/microsoft.md
@@ -19,8 +19,10 @@ Hosted deployments can use Alga PSA's platform Microsoft app:
 
 * If **Authorize Access** is enabled when you
   [add the inbound provider](#add-the-inbound-provider), the Outlook email
-  credential path is ready. The platform credentials remain server-side and are
-  not shown in the mailbox form.
+  credential path is ready. The mailbox form does not display client credential
+  fields, but the hosted setup flow receives the app configuration in the
+  browser, including its client secret. Restrict provider setup access to
+  trusted administrators.
 * If you bind a tenant-owned Microsoft app to Outlook email, that app takes
   precedence over the hosted platform app. Follow
   [Register a tenant-owned Entra app](#register-a-tenant-owned-entra-app), then

--- a/docs/plans/2026-08-02-inbound-email-microsoft-permissions-plan.md
+++ b/docs/plans/2026-08-02-inbound-email-microsoft-permissions-plan.md
@@ -1,6 +1,6 @@
 # Inbound Email Microsoft/Entra Documentation Accuracy Plan
 
-Date: 2026-08-02  
+Date: 2026-08-02
 Ticket: alga0002218 — Inbound email docs: remove stale “coming soon” entries, close Graph API permission gaps
 
 ## Objective

--- a/docs/plans/2026-08-02-inbound-email-microsoft-permissions-plan.md
+++ b/docs/plans/2026-08-02-inbound-email-microsoft-permissions-plan.md
@@ -1,0 +1,96 @@
+# Inbound Email Microsoft/Entra Documentation Accuracy Plan
+
+Date: 2026-08-02  
+Ticket: alga0002218 — Inbound email docs: remove stale “coming soon” entries, close Graph API permission gaps
+
+## Objective
+
+Make the inbound-email documentation a reliable setup path for an MSP administrator configuring Microsoft 365 ingestion. Remove stale index labels, clearly distinguish the permissions used by the inbound OAuth flow from broader Microsoft integration metadata, and explain shared-mailbox, consent, webhook, hosted, and self-hosted behavior without claiming capabilities the product does not provide.
+
+## Evidence and constraints
+
+- `docs/inbound-email/README.md` labels `setup/imap.md` and `architecture/overall.md` as coming soon even though both files exist.
+- `docs/inbound-email/setup/microsoft.md` currently names the actual delegated inbound scopes (`Mail.Read`, `Mail.Read.Shared`, `offline_access`) and describes webhook-to-polling fallback, but does not explain what each permission enables or how tenant consent policy affects authorization.
+- The production inbound OAuth helpers and callback request exactly `Mail.Read`, `Mail.Read.Shared`, and `offline_access` (`server/src/utils/email/oauthHelpers.ts`, `server/src/app/api/auth/microsoft/callback/route.ts`, and the mirrored helpers under `packages/integrations`). Microsoft diagnostics validate `Mail.Read` and `Mail.Read.Shared` (`packages/integrations/src/actions/email-actions/emailProviderActions.ts`).
+- Microsoft profile metadata currently advertises a broader email scope set including `Mail.ReadWrite` and `Mail.Send` (`packages/integrations/src/actions/integrations/microsoftActions.ts`). That metadata must not be presented as the inbound connector’s runtime requirement: the inbound connector is read-only and its OAuth callback does not request those write/send scopes.
+- A shared mailbox is accessed with delegated permissions on behalf of the signed-in user. `Mail.Read.Shared` does not grant mailbox membership by itself; the authorizing user must already have Exchange permission to the shared mailbox.
+- Creating and renewing Graph change-notification subscriptions does not require a separate “webhook permission”; it relies on the mail permission for the subscribed resource. A reachable public callback enables webhook delivery, while the application’s polling fallback only needs outbound HTTPS.
+- Preserve the pre-existing, unrelated `package-lock.json` modification. This task changes documentation only.
+
+## Implementation steps
+
+### 1. Repair the inbound-email index
+
+Update `docs/inbound-email/README.md`:
+
+- Replace the IMAP “coming soon” entry with a direct link to `setup/imap.md`, using wording that accurately reflects its current scope (in-app processing/configuration flags rather than promising a full OAuth setup guide).
+- Remove the “coming soon” marker from `architecture/overall.md` and link it normally.
+- Keep the quick-link wording aligned with the actual destination content; do not imply that either page covers more than it does.
+
+### 2. Turn the Microsoft setup page into a permission checklist
+
+Revise `docs/inbound-email/setup/microsoft.md` around prerequisites and app registration:
+
+- Add a compact table for the three delegated permissions:
+  - `Mail.Read`: reads the signed-in user’s mailbox and supports message/folder access used by ingestion and subscriptions.
+  - `Mail.Read.Shared`: reads shared/delegated mailboxes the signed-in user can already access.
+  - `offline_access`: permits refresh tokens so background polling, reconciliation, and subscription renewal continue without an interactive sign-in.
+- Explicitly state that all three are **Delegated** permissions for this flow; do not instruct administrators to add application permissions, `Mail.ReadWrite`, or `Mail.Send` for inbound ingestion.
+- Explain consent accurately: grant tenant-wide admin consent when the tenant’s policies require it or when the administrator wants to avoid per-user consent prompts, but do not claim admin consent is universally mandatory for delegated `Mail.Read`/`Mail.Read.Shared`.
+- Add a pre-authorization checklist: exact Web redirect URI, supported account audience, secret value (not secret ID), Email consumer binding, and mailbox access for the user who will authorize.
+
+### 3. Document shared-mailbox authorization as a separate path
+
+Extend `docs/inbound-email/setup/microsoft.md` with a focused shared-mailbox subsection:
+
+- Require the provider’s mailbox address to be the shared mailbox and the interactive OAuth user to be a real licensed/user identity with Exchange access to it.
+- State that `Mail.Read.Shared` authorizes Graph to act within the user’s existing delegated mailbox access; it does not assign Full Access or otherwise grant Exchange rights.
+- Give a verification sequence before blaming Alga PSA: confirm the user can open the shared mailbox in Outlook/OWA, confirm `Mail.Read.Shared` is present/consented, then reauthorize/test the provider.
+- Call out the common failure mode where OAuth succeeds for the user’s own mailbox but Graph returns 403 for the configured shared mailbox.
+
+### 4. Clarify webhook subscriptions and fallback behavior
+
+Refine the runtime and troubleshooting sections in `docs/inbound-email/setup/microsoft.md`:
+
+- Explain that subscriptions are created per watched folder/resource using the same delegated mail access; no additional Graph “webhook” scope is configured.
+- Distinguish Microsoft’s validation of the public notification URL from normal message access. Failure to validate the callback should be described as a delivery-mode issue, not a permissions failure.
+- Preserve the documented outbound-only polling fallback and its network requirements, but verify all intervals/expiry wording against the current adapter and maintenance code before finalizing exact numbers. If code and prose disagree, update the prose to the current implementation rather than copying historical plan documents.
+- Add actionable symptoms: OAuth/consent failure, 403 for shared mailbox, subscription validation failure, and expired/revoked refresh token.
+
+### 5. Make hosted and self-hosted setup paths explicit
+
+Split the existing credentials paragraph in `docs/inbound-email/setup/microsoft.md` into two labeled paths:
+
+- **Hosted:** explain the profile-first flow and the platform-credential fallback only to the extent confirmed by the current configuration builder; make clear that a tenant profile bound to Email takes precedence.
+- **Self-hosted/appliance:** direct administrators to create and bind their own Entra profile, register their deployment’s exact callback URL, provide outbound access to Microsoft endpoints, and expose the webhook URL only when webhook delivery is desired. Polling remains valid when inbound reachability is unavailable.
+- Avoid exposing environment-variable names as the primary customer setup method; keep them as operator-level fallback/reference details if they remain supported.
+
+### 6. Replace the architecture placeholder with a truthful overview
+
+Update `docs/inbound-email/architecture/overall.md` so removing the index’s “coming soon” marker does not point users to a placeholder:
+
+- Describe the common provider-to-normalized-message-to-ticket pipeline and link to the detailed workflow page.
+- Show Microsoft’s OAuth token storage, Graph subscription/webhook path, reconciliation/polling fallback, queue handoff, and ticket creation at a high level.
+- Keep Google Pub/Sub and IMAP distinctions brief and link to their dedicated pages; do not duplicate provider-specific setup instructions.
+- Include trust-boundary notes: inbound connectors are read-only at the mailbox layer, secrets/tokens are server-side, and webhook requests are validated before queueing.
+
+## Validation
+
+Because this is documentation-only, use behavioral/document-consistency checks rather than source-string tests:
+
+1. Follow the Microsoft guide as a new administrator and confirm every named screen, field, redirect URI, and button exists in the current UI.
+2. Cross-check the documented inbound scope list against both OAuth helper implementations and the callback’s token exchange scope.
+3. Cross-check subscription resource construction, renewal/expiry timing, reconciliation cadence, polling cadence, and callback route against the current `MicrosoftGraphAdapter` and maintenance jobs.
+4. Verify the shared-mailbox troubleshooting advice against the diagnostics path and ensure it distinguishes missing Graph consent from missing Exchange mailbox access.
+5. Render all changed Markdown and Mermaid blocks; verify links from `docs/inbound-email/README.md` resolve and no destination is still a placeholder while advertised as complete.
+6. Run the repository’s existing documentation/link validation if available. Do not add a brittle test that only asserts literal documentation strings.
+
+## Definition of done
+
+- The two stale quick-link entries no longer say “coming soon,” and their destination pages accurately describe what exists.
+- A reader can identify exactly which delegated Graph permissions inbound ingestion uses, why each is needed, and which broader Microsoft scopes are not required for this connector.
+- Shared-mailbox prerequisites and the boundary between Graph consent and Exchange mailbox access are explicit.
+- Admin-consent guidance is conditional on tenant policy rather than presented as universally mandatory.
+- Hosted and self-hosted setup paths, webhook reachability, and polling fallback are unambiguous.
+- The architecture overview is no longer a placeholder and agrees with the current implementation.
+- Only documentation files are changed; the unrelated `package-lock.json` drift remains untouched.


### PR DESCRIPTION
## Summary

- replace stale inbound-email index labels with working IMAP and architecture links
- turn the Microsoft 365 guide into an accurate hosted/self-hosted setup and delegated-permissions checklist covering `Mail.Read`, `Mail.Read.Shared`, `offline_access`, admin consent, shared mailboxes, webhook validation, polling, and the separate outbound-email path
- replace the architecture placeholder with the real provider-to-queue-to-ticket flow and document the current browser/server credential and OAuth-token trust boundaries
- add the ticket-backed implementation plan for alga0002218

## Smoke test — PASS with fidelity limits

Exercised:

- Rendered the changed inbound-email index; both stale “coming soon” labels are gone.
- Followed the IMAP and architecture links successfully to their real pages.
- Rendered and inspected hosted/self-hosted Microsoft setup, `Mail.Read`, `Mail.Read.Shared`, `offline_access`, admin consent, shared-mailbox polling, and webhook/subscription guidance.
- In the real port-3990 product, confirmed this Community stack exposes Microsoft only for staff sign-in and excludes Microsoft 365 from the inbound-provider wizard, consistent with the documented Enterprise-only boundary.
- Confirmed the adjacent Outbound Email tab loads independent SMTP configuration.
- No page errors, material console errors, or failed HTTP responses occurred. HTTP health returned 200; ports 3990, 6472, 5472, and 6380 answered, and a live database query succeeded.

Could not exercise the Enterprise Microsoft mailbox form, real Entra consent, Graph subscriptions, shared-mailbox access, or polling ingestion because this stack is Community Edition and no test Microsoft tenant was available. No Microsoft mock or simulator was used.

### Fidelity compromises

- Alga Dev created the required card-scoped browser tab, but subsequent commands rejected its returned pane as belonging to another host. I used the repository’s installed Playwright with system Chrome against the same real product instead.
- Shared dev servers had made the cached Glinda password stale. I temporarily reset its database password for login and restored the original hash immediately afterward.
- Docker API access was denied, so container listing was replaced with board-service status, live port checks, HTTP readiness, and a database query.

Evidence: `/tmp/alga-smoke-evidence/alga0002218-20260802-105808`

## Follow-up concerns

- Community Providers copy still says Microsoft registrations are used by “sign-in, Outlook, Calendar, and Teams,” although only staff-sign-in binding is available there.
- The previously identified hosted client-secret/browser and OAuth-token/opener trust boundaries remain candidates for separate security hardening.

## Worktree note

The pre-existing `package-lock.json` modification was preserved; smoke testing added no worktree changes.