### PR TITLE
Remove stale CE build scaffolding + edition doc rewrite (alga0002211)

### DIFF
--- a/Dockerfile.build
+++ b/Dockerfile.build
@@ -37,26 +37,9 @@ WORKDIR /app
 
 COPY . .
 
-# Remove only the EE server tree for CE builds.
-# The workflows workspace now lives under ee/packages/workflows and must remain
-# present because node_modules/@alga-psa/workflows is a workspace symlink.
+# Remove the proprietary server tree. CE resolution is owned by the Next aliases
+# and checked-in fallback modules. Keep ee/packages/workflows for its workspace symlink.
 RUN rm -rf /app/ee/server
-
-# Stage the canonical CE substitutions at the removed EE source path so relative
-# EE imports still resolve during the container build.
-RUN mkdir -p /app/ee/server/src && \
-    cp -r /app/packages/ee/src/. /app/ee/server/src/
-
-# Create a dummy file for the relative import that webpack tries to resolve
-RUN mkdir -p /app/ee/server/src/lib/extensions && \
-    echo "export const initializeExtensions = async () => { console.log('CE build - extensions not available'); };" > /app/ee/server/src/lib/extensions/initialize.js
-
-# Create minimal stubs for packages that use relative paths (not @ee alias)
-# packages/product-chat/ee/entry.tsx uses ../../../ee/server/src/services/*
-RUN mkdir -p /app/ee/server/src/services && \
-    printf "export class ChatStreamService {\n  static async handleChatStream(req) {\n    return new Response(JSON.stringify({ error: 'Chat streaming is only available in Enterprise Edition' }), {\n      status: 404,\n      headers: { 'Content-Type': 'application/json' },\n    });\n  }\n  static async handleTitleStream(req) {\n    return new Response(JSON.stringify({ error: 'Chat streaming is only available in Enterprise Edition' }), {\n      status: 404,\n      headers: { 'Content-Type': 'application/json' },\n    });\n  }\n}\n" > /app/ee/server/src/services/chatStreamService.js && \
-    printf "export class TemporaryApiKeyService {\n  static async cleanupExpiredAiKeys() {\n    return 0;\n  }\n}\n" > /app/ee/server/src/services/temporaryApiKeyService.js && \
-    printf "export class ChatCompletionsService {\n  static async handleRequest(req) {\n    return new Response(JSON.stringify({ error: 'Chat completions are only available in Enterprise Edition' }), {\n      status: 404,\n      headers: { 'Content-Type': 'application/json' },\n    });\n  }\n  static async handleExecute(req) {\n    return new Response(JSON.stringify({ error: 'Chat completions are only available in Enterprise Edition' }), {\n      status: 404,\n      headers: { 'Content-Type': 'application/json' },\n    });\n  }\n}\n" > /app/ee/server/src/services/chatCompletionsService.js
 
 # Remove EE-specific scripts that shouldn't be in CE build
 RUN rm -f /app/server/src/scripts/check-extension.ts

--- a/docs/getting-started/enterprise_edition_architecture.md
+++ b/docs/getting-started/enterprise_edition_architecture.md
@@ -33,7 +33,6 @@ npm run build:ee       # EE, Webpack
 | --- | --- |
 | `server/src` | Shared application and server code. |
 | `packages/ee/src` | Checked-in CE-compatible implementations for the `@ee/*` surface. These files also provide the default TypeScript path targets. |
-| `server/src/empty` | Narrow CE fallbacks and empty shims used by seams that mirror paths under `ee/server/src`. |
 | `ee/server/src` | Enterprise server implementations selected in EE builds. |
 | `packages/product-*/oss` and `packages/product-*/ee` | Package-local implementations selected by stable product entry points. |
 
@@ -60,15 +59,14 @@ generated `ee/server` tree.
 
 ### `@/empty/*`
 
-Use `@/empty/*` for a shared-server seam whose CE implementation belongs in the
-small fallback tree under `server/src/empty`. The normal `@/*` mapping sends the
-CE import there. In an EE build, `server/next.config.mjs` redirects the same
+`@/empty/*` is an established compatibility spelling for a path-mirrored
+edition seam. CE resolves it to `packages/ee/src/*`; EE resolves the same
 relative path to `ee/server/src/*`.
 
-Despite the name, this is an edition-switched seam in an EE build. Use it for
-the established path-mirrored fallbacks. Prefer `@ee/*` for the broader
-package-backed EE surface, or a product alias when the feature already has a
-package entry point.
+Despite the name, it does not resolve to `server/src/empty`. Use it only for
+established imports that already use this spelling. Prefer `@ee/*` for new
+path-mirrored imports, or a product alias when the feature already has a package
+entry point.
 
 ### `@product/*`
 
@@ -96,9 +94,8 @@ for that seam instead of copying a long alias inventory into documentation.
 
 1. Choose a stable import seam. Prefer a product entry point for a packaged
    feature and `@ee/*` for a path-mirrored implementation surface.
-2. Add and export the CE implementation from `packages/ee/src`,
-   `server/src/empty`, or the product package's `oss` entry, as required by the
-   selected seam.
+2. Add and export the CE implementation from `packages/ee/src` or the product
+   package's `oss` entry, as required by the selected seam.
 3. Add the matching EE implementation.
 4. Wire exact and subpath variants in both the Turbopack and Webpack sections of
    `server/next.config.mjs`. Add replacement wiring when the existing seam uses

--- a/docs/getting-started/enterprise_edition_architecture.md
+++ b/docs/getting-started/enterprise_edition_architecture.md
@@ -1,254 +1,112 @@
-# Building Enterprise Edition
+# Edition-aware source architecture
 
-This project uses a monorepo structure to integrate the enterprise edition (EE) code with the community edition (CE) code while maintaining them as a single unit.
+AlgaPSA keeps shared server code and edition-specific implementations in one
+workspace. Shared code imports stable aliases. `server/next.config.mjs` selects
+the Community Edition (CE) or Enterprise Edition (EE) implementation when Next.js
+builds the application.
 
-## Project Structure
+Do not create edition stubs during a Docker build. CE fallbacks are checked-in
+source files so local development, type checking, Turbopack, and Webpack use the
+same implementations.
 
-```
-/
-├── package.json          # Root package.json with all dependencies
-├── docker-compose.yaml   # Base docker-compose configuration
-├── server/              # Community Edition
-│   ├── package.json     # CE package.json (minimal, uses workspace)
-│   ├── tsconfig.json    # Base TypeScript config
-│   └── src/
-│       ├── components/
-│       ├── lib/
-│       └── services/
-└── ee/
-    └── server/          # Enterprise Edition
-        ├── package.json # EE package.json (minimal, uses workspace)
-        ├── tsconfig.json# EE TypeScript config (extends base)
-        └── src/
-            ├── components/
-            ├── lib/
-            └── services/
-```
+## Selecting an edition
 
-## Docker Compose Configuration
+`server/next.config.mjs` enables EE when any of these conditions is true:
 
-The project uses a layered docker-compose configuration to support both CE and EE deployments:
+- `EDITION=ee`
+- `EDITION=enterprise`
+- `NEXT_PUBLIC_EDITION=enterprise`
 
-1. **Base Configuration** (`docker-compose.yaml`):
-   - Contains common service definitions
-   - Defines shared environment variables including EDITION
-   - Sets up base networking
+All other values select CE. Keep `EDITION` and `NEXT_PUBLIC_EDITION` consistent
+because the first is server-facing and the second may be included in browser
+code. The root scripts set both variables:
 
-2. **EE Configuration** (`ee/setup/docker-compose.yaml`):
-   - Extends services from base configuration
-   - Sets EDITION=enterprise
-   - Uses EE-specific Dockerfile and configurations
-
-### Running CE Version
 ```bash
-# From project root
-EDITION=community docker compose -f docker-compose.yaml up
+npm run build          # CE, Turbopack
+npm run build:webpack  # CE, Webpack
+npm run build:ee       # EE, Webpack
 ```
 
-### Running EE Version
-```bash
-# From project root
-EDITION=enterprise docker compose -f docker-compose.yaml -f ee/setup/docker-compose.yaml up
-```
+## Source ownership
 
-## Workspace Setup
+| Path | Responsibility |
+| --- | --- |
+| `server/src` | Shared application and server code. |
+| `packages/ee/src` | Checked-in CE-compatible implementations for the `@ee/*` surface. These files also provide the default TypeScript path targets. |
+| `server/src/empty` | Narrow CE fallbacks and empty shims used by seams that mirror paths under `ee/server/src`. |
+| `ee/server/src` | Enterprise server implementations selected in EE builds. |
+| `packages/product-*/oss` and `packages/product-*/ee` | Package-local implementations selected by stable product entry points. |
 
-1. Root `package.json` defines workspaces and contains all dependencies:
-```json
-{
-  "workspaces": [
-    "server",
-    "ee/server"
-  ],
-  "dependencies": {
-    // All project dependencies are defined here
-  }
-}
-```
+`ee/packages/workflows` is a separate workspace package. The CE Docker build
+keeps that workspace because the installed `@alga-psa/workflows` dependency is a
+workspace symlink, even though it removes `ee/server` before compiling the CE
+application.
 
-2. CE and EE `package.json` files are minimal:
-```json
-{
-  "name": "sebastian-ee",
-  "version": "0.1.0",
-  "private": true,
-  "workspaces": {
-    "nohoist": ["*"]
-  }
-}
-```
+## Edition seams
 
-## TypeScript Configuration
+### `@ee/*`
 
-1. Base TypeScript config in `server/tsconfig.json`:
-```json
-{
-  "compilerOptions": {
-  }
-}
-```
+Use `@ee/*` when shared code needs one module shape with a CE-compatible
+implementation and an EE implementation at the same relative path.
 
-2. EE TypeScript config in `ee/server/tsconfig.json` extends the base:
-```json
-{
-  "extends": "../../server/tsconfig.json",
-  "compilerOptions": {
-    "paths": {
-      "@/*": ["../../server/src/*"],
-      "@ee/*": ["./src/*"]
-    },
-    "baseUrl": "."
-  }
-}
-```
+- CE resolves `@ee/*` to `packages/ee/src/*`.
+- EE resolves `@ee/*` to `ee/server/src/*`.
 
-## Path Aliases
+The TypeScript configuration is CE-first and maps this alias to
+`packages/ee/src`. The Next configuration overrides it for EE builds. Webpack
+also rewrites the request before TypeScript path resolution can select a CE file.
+The Next aliases and replacement wiring are authoritative; CE must not rely on a
+generated `ee/server` tree.
 
-Use path aliases instead of relative paths:
-- `@/*` for CE imports
-- `@ee/*` for EE imports
+### `@/empty/*`
 
-Example:
-```typescript
-// Instead of relative paths like:
-import { Something } from "../../../../../server/src/components/Something";
+Use `@/empty/*` for a shared-server seam whose CE implementation belongs in the
+small fallback tree under `server/src/empty`. The normal `@/*` mapping sends the
+CE import there. In an EE build, `server/next.config.mjs` redirects the same
+relative path to `ee/server/src/*`.
 
-// Use path aliases:
-import { Something } from "server/src/components/Something";
-import { EEFeature } from "ee/components/EEFeature";
-```
+Despite the name, this is an edition-switched seam in an EE build. Use it for
+the established path-mirrored fallbacks. Prefer `@ee/*` for the broader
+package-backed EE surface, or a product alias when the feature already has a
+package entry point.
 
-## Feature Flags
+### `@product/*`
 
-Use feature flags to conditionally include EE features:
+Product entry points expose a stable import while keeping both implementations
+inside a product package. For example, `@product/chat/entry` selects
+`packages/product-chat/oss/entry` in CE and `packages/product-chat/ee/entry` in
+EE. Other product seams use the same pattern where their configuration requires
+it.
 
-```typescript
-// server/src/lib/features.ts
-export const isEnterprise = process.env.EDITION === 'enterprise';
+Import the stable entry point from shared code. Do not import an `oss` or `ee`
+directory directly and do not reach into `ee/server` with a relative path.
+`server/next.config.mjs` contains the current product mappings.
 
-export function getFeatureImplementation<T>(ceModule: T, eeModule?: T): T {
-  if (isEnterprise && eeModule) {
-    return eeModule;
-  }
-  return ceModule;
-}
-```
+## Keep Webpack and Turbopack in sync
 
-Usage:
-```typescript
-import { CEFeature } from "features/CEFeature";
-import { EEFeature } from "ee/features/EEFeature";
-import { getFeatureImplementation } from "server/src/lib/features";
+`server/next.config.mjs` configures Turbopack in `turbopack.resolveAlias` and
+Webpack in `config.resolve.alias`, with replacement plugins where an alias alone
+cannot win over TypeScript paths or package exports. A seam may need both an
+exact key and a trailing-slash or subpath form.
 
-const FeatureComponent = getFeatureImplementation(CEFeature, EEFeature);
-```
+When you change an edition seam, update both bundlers. Follow the existing shape
+for that seam instead of copying a long alias inventory into documentation.
 
-## Conditional Dependencies
+## Add an edition-aware feature
 
-Some packages may only be needed when running in enterprise mode. To handle these cases:
+1. Choose a stable import seam. Prefer a product entry point for a packaged
+   feature and `@ee/*` for a path-mirrored implementation surface.
+2. Add and export the CE implementation from `packages/ee/src`,
+   `server/src/empty`, or the product package's `oss` entry, as required by the
+   selected seam.
+3. Add the matching EE implementation.
+4. Wire exact and subpath variants in both the Turbopack and Webpack sections of
+   `server/next.config.mjs`. Add replacement wiring when the existing seam uses
+   it.
+5. Keep shared code free of cross-edition relative imports.
+6. Type-check and build both CE and EE. Include the CE Webpack build because it
+   is the path used by `Dockerfile.build`.
 
-1. Install the package conditionally in your code:
-```typescript
-let anthropicClient;
-if (process.env.EDITION === 'enterprise') {
-  // Dynamic import ensures the package is only loaded if EE is active
-  const { default: Anthropic } = await import('anthropic-sdk');
-  anthropicClient = new Anthropic();
-}
-```
-
-2. Add the package to your dependencies in root package.json:
-```json
-{
-  "dependencies": {
-    "anthropic-sdk": "^0.1.0"  // Will only be used when EE is active
-  }
-}
-```
-
-This approach ensures that:
-- The package is available when needed in EE mode
-- The package is not loaded or used in CE mode
-- TypeScript still has access to types for development
-
-## Type Declarations
-
-For TypeScript support of EE imports:
-
-```typescript
-// server/src/types/ee.d.ts
-declare module '@ee/*' {
-  const content: unknown;
-  export default content;
-}
-```
-
-## Build Scripts
-
-The build scripts are defined in the root `package.json`:
-
-```json
-{
-  "scripts": {
-    "dev": "cd server && EDITION=enterprise next dev",
-    "build": "cd server && next build",
-    "build:ee": "cd server && EDITION=enterprise next build"
-  }
-}
-```
-
-## Best Practices
-
-1. **Dependencies**: 
-   - Keep all dependencies in the root `package.json`
-   - Use workspace references in CE and EE packages
-   - Use dynamic imports for EE-only packages
-
-2. **Code Organization**:
-   - Keep shared code in the CE codebase
-   - Use path aliases consistently
-   - Mirror CE directory structure in EE when extending features
-
-3. **Types**:
-   - Define shared interfaces in CE
-   - Extend CE types in EE when needed
-   - Use TypeScript path aliases for clean imports
-
-4. **Feature Flags**:
-   - Use the feature flag system for EE features
-   - Document feature flag usage
-   - Test both CE and EE configurations
-
-5. **Testing**:
-   - Test both editions during development
-   - Use environment variables to control edition in tests
-   - Ensure CE works independently of EE
-
-## Development Workflow
-
-1. Run the development server:
-```bash
-npm run dev  # Runs with EE features enabled
-```
-
-2. Build the project:
-```bash
-npm run build      # CE build
-npm run build:ee   # EE build
-```
-
-3. Run with Docker Compose:
-```bash
-# Community Edition
-EDITION=community docker compose -f docker-compose.yaml up
-
-# Enterprise Edition
-EDITION=enterprise docker compose -f docker-compose.yaml -f ee/setup/docker-compose.yaml up
-```
-
-Remember to:
-- Document new EE features
-- Test both CE and EE builds
-- Keep the dependency tree unified
-- Use TypeScript path aliases consistently
-- Follow the established directory structure
+For container setup and deployment commands, see
+[Docker Compose Structure](docker_compose.md). For local development, see the
+[Development Guide](development_guide.md).

--- a/docs/plans/2026-08-02-edition-alias-cleanup-plan.md
+++ b/docs/plans/2026-08-02-edition-alias-cleanup-plan.md
@@ -1,0 +1,58 @@
+# Edition alias cleanup and architecture documentation plan
+
+Ticket: `alga0002211` — Remove stale CE stub-synthesis from `Dockerfile.build` and rewrite the edition architecture doc
+
+## Context
+
+The CE image build currently deletes `ee/server` and then recreates a partial version of it from `server/src/empty`, plus four handwritten JavaScript shims. That mechanism predates the edition-aware aliases now maintained in `server/next.config.mjs`. It has drifted from the real CE fallback surface and can mask missing or incorrect aliases.
+
+The existing `docs/getting-started/enterprise_edition_architecture.md` describes the former `ee/server`-centric workspace, obsolete package scripts, and a compose overlay that no longer represents the supported build and runtime paths. The replacement should document the configuration that actually selects CE versus EE code today.
+
+## Implementation
+
+### 1. Remove Docker-time EE stub synthesis
+
+Update `Dockerfile.build` in the builder stage:
+
+- Keep `RUN rm -rf /app/ee/server`; CE must not ship or compile the proprietary server tree.
+- Keep `ee/packages/workflows` intact because the workspace symlink is required by dependency installation.
+- Delete the commands that recreate `/app/ee/server/src` from `server/src/empty`.
+- Delete the handwritten `lib/extensions/initialize.js` shim.
+- Delete the handwritten `chatStreamService.js`, `temporaryApiKeyService.js`, and `chatCompletionsService.js` shims.
+- Replace the surrounding comments with a short statement that CE resolution is owned by the Next aliases and checked-in fallback modules, so future contributors do not reintroduce build-generated source.
+
+No product behavior or checked-in fallback implementation should move as part of this cleanup. If the CE build exposes an unresolved import, fix the authoritative alias/fallback mapping rather than restoring generated files.
+
+### 2. Rewrite the edition architecture guide from current configuration
+
+Replace `docs/getting-started/enterprise_edition_architecture.md` with a concise guide derived from the repository's live configuration. Cover:
+
+- **Edition selection:** explain how `EDITION`, `NEXT_PUBLIC_EDITION`, and the `isEE` calculation in `server/next.config.mjs` select community or enterprise behavior. Use the accepted values visible in code and avoid presenting invented package scripts.
+- **Source ownership:** distinguish shared/open server code (`server/src`), checked-in CE fallback modules (`server/src/empty`), enterprise server implementations (`ee/server/src`), and the package-level EE surface (`packages/ee/src`). Mention the separately retained `ee/packages/workflows` workspace where relevant.
+- **`@ee/*` seam:** document that EE builds resolve to `ee/server/src`, while CE builds resolve the same import surface to checked-in files under `server/src/empty`. Make `server/next.config.mjs` the source of truth and explain that CE must never depend on generated `ee/server` files.
+- **`@/empty/*` seam:** describe it as an explicit import of the checked-in no-op/unsupported implementation, independent of edition switching, and clarify when it is preferable to an `@ee/*` import.
+- **`@product/*` seams:** explain that product entry points choose an EE entry or CE entry/fallback in `server/next.config.mjs`; contributors should import the stable product alias rather than reaching across repository directories with relative paths.
+- **Bundler parity:** note that Webpack and Turbopack mappings must be updated together, including exact and directory/subpath variants where the configuration requires them. Point readers to the alias definitions and replacement wiring rather than duplicating a long, drift-prone alias inventory.
+- **Adding a new edition-aware feature:** provide a short checklist: define the stable import seam, add the CE implementation, add the EE implementation, wire both bundlers, avoid direct cross-edition relative imports, and test both editions.
+- **Build/deployment references:** state only commands that exist in the current repository. Link to the current compose/build documentation for operational setup rather than preserving the obsolete `ee/setup/docker-compose.yaml` walkthrough.
+
+Remove the old sample workspace manifests, fictional `getFeatureImplementation` example, stale dependency advice, obsolete build scripts, and old compose commands. They imply an architecture the repository no longer uses.
+
+### 3. Validate the cleanup behaviorally
+
+Run the repository's existing build paths rather than adding source-string tests:
+
+1. Build the CE image or execute the equivalent CE Next/Webpack build used by `Dockerfile.build`; confirm it succeeds after `/app/ee/server` is removed and without recreating that directory.
+2. Run the corresponding EE build to ensure the real `ee/server/src` implementations still resolve.
+3. If a faster documented alias/build smoke command exists in the repository, run it in addition to—not instead of—the CE build that exercises the deleted Docker behavior.
+4. Inspect the built CE context/image (or add a temporary diagnostic during local validation) to confirm none of the deleted handwritten files are synthesized.
+5. Review every command and path in the rewritten guide against `package.json`, compose files, and `server/next.config.mjs` before committing.
+
+Do not add tests that merely grep `Dockerfile.build` or assert documentation/source strings. The meaningful regression check is that a CE build resolves all edition seams without a fabricated `ee/server` tree.
+
+## Expected files
+
+- `Dockerfile.build`
+- `docs/getting-started/enterprise_edition_architecture.md`
+
+Any change to `server/next.config.mjs`, `server/src/empty`, or product entries should occur only if the CE build reveals a real missing mapping; keep such fixes narrowly scoped and document the newly required seam.

--- a/docs/plans/2026-08-02-edition-alias-cleanup-plan.md
+++ b/docs/plans/2026-08-02-edition-alias-cleanup-plan.md
@@ -4,7 +4,7 @@ Ticket: `alga0002211` — Remove stale CE stub-synthesis from `Dockerfile.build`
 
 ## Context
 
-The CE image build currently deletes `ee/server` and then recreates a partial version of it from `server/src/empty`, plus four handwritten JavaScript shims. That mechanism predates the edition-aware aliases now maintained in `server/next.config.mjs`. It has drifted from the real CE fallback surface and can mask missing or incorrect aliases.
+The CE image build currently deletes `ee/server` and then recreates a partial version of it from a legacy fallback tree, plus four handwritten JavaScript shims. That mechanism predates the edition-aware aliases now maintained in `server/next.config.mjs`. It has drifted from the real CE fallback surface and can mask missing or incorrect aliases.
 
 The existing `docs/getting-started/enterprise_edition_architecture.md` describes the former `ee/server`-centric workspace, obsolete package scripts, and a compose overlay that no longer represents the supported build and runtime paths. The replacement should document the configuration that actually selects CE versus EE code today.
 
@@ -16,7 +16,7 @@ Update `Dockerfile.build` in the builder stage:
 
 - Keep `RUN rm -rf /app/ee/server`; CE must not ship or compile the proprietary server tree.
 - Keep `ee/packages/workflows` intact because the workspace symlink is required by dependency installation.
-- Delete the commands that recreate `/app/ee/server/src` from `server/src/empty`.
+- Delete the commands that recreate `/app/ee/server/src` from the legacy fallback tree.
 - Delete the handwritten `lib/extensions/initialize.js` shim.
 - Delete the handwritten `chatStreamService.js`, `temporaryApiKeyService.js`, and `chatCompletionsService.js` shims.
 - Replace the surrounding comments with a short statement that CE resolution is owned by the Next aliases and checked-in fallback modules, so future contributors do not reintroduce build-generated source.
@@ -28,9 +28,9 @@ No product behavior or checked-in fallback implementation should move as part of
 Replace `docs/getting-started/enterprise_edition_architecture.md` with a concise guide derived from the repository's live configuration. Cover:
 
 - **Edition selection:** explain how `EDITION`, `NEXT_PUBLIC_EDITION`, and the `isEE` calculation in `server/next.config.mjs` select community or enterprise behavior. Use the accepted values visible in code and avoid presenting invented package scripts.
-- **Source ownership:** distinguish shared/open server code (`server/src`), checked-in CE fallback modules (`server/src/empty`), enterprise server implementations (`ee/server/src`), and the package-level EE surface (`packages/ee/src`). Mention the separately retained `ee/packages/workflows` workspace where relevant.
-- **`@ee/*` seam:** document that EE builds resolve to `ee/server/src`, while CE builds resolve the same import surface to checked-in files under `server/src/empty`. Make `server/next.config.mjs` the source of truth and explain that CE must never depend on generated `ee/server` files.
-- **`@/empty/*` seam:** describe it as an explicit import of the checked-in no-op/unsupported implementation, independent of edition switching, and clarify when it is preferable to an `@ee/*` import.
+- **Source ownership:** distinguish shared/open server code (`server/src`), checked-in CE-compatible implementations (`packages/ee/src`), and enterprise server implementations (`ee/server/src`). Mention the separately retained `ee/packages/workflows` workspace where relevant.
+- **`@ee/*` seam:** document that CE builds resolve to `packages/ee/src`, while EE builds resolve the same import surface to `ee/server/src`. Make `server/next.config.mjs` the source of truth and explain that CE must never depend on generated `ee/server` files.
+- **`@/empty/*` seam:** describe it as an established compatibility spelling for the same edition-switched, path-mirrored surface: CE resolves it to `packages/ee/src`, and EE resolves it to `ee/server/src`. Clarify that new code should prefer `@ee/*` or a product alias.
 - **`@product/*` seams:** explain that product entry points choose an EE entry or CE entry/fallback in `server/next.config.mjs`; contributors should import the stable product alias rather than reaching across repository directories with relative paths.
 - **Bundler parity:** note that Webpack and Turbopack mappings must be updated together, including exact and directory/subpath variants where the configuration requires them. Point readers to the alias definitions and replacement wiring rather than duplicating a long, drift-prone alias inventory.
 - **Adding a new edition-aware feature:** provide a short checklist: define the stable import seam, add the CE implementation, add the EE implementation, wire both bundlers, avoid direct cross-edition relative imports, and test both editions.
@@ -55,4 +55,4 @@ Do not add tests that merely grep `Dockerfile.build` or assert documentation/sou
 - `Dockerfile.build`
 - `docs/getting-started/enterprise_edition_architecture.md`
 
-Any change to `server/next.config.mjs`, `server/src/empty`, or product entries should occur only if the CE build reveals a real missing mapping; keep such fixes narrowly scoped and document the newly required seam.
+Any change to `server/next.config.mjs`, `packages/ee/src`, or product entries should occur only if the CE build reveals a real missing mapping; keep such fixes narrowly scoped and document the newly required seam.

--- a/packages/billing/tests/contractLineServiceMembershipEditing.test.tsx
+++ b/packages/billing/tests/contractLineServiceMembershipEditing.test.tsx
@@ -298,7 +298,7 @@ describe('contract line service membership editing', () => {
 
     fireEvent.click(screen.getByRole('button', { name: 'Add Item' }));
     const dialog = await screen.findByRole('dialog');
-    fireEvent.click(within(dialog).getByText('New service'));
+    fireEvent.click(await within(dialog).findByText('New service'));
     fireEvent.click(within(dialog).getByRole('button', { name: 'Add Selected Services' }));
     expect(await screen.findByText('New service')).not.toBeNull();
     expect(actionMocks.applyContractLineServiceMembershipChanges).not.toHaveBeenCalled();
@@ -319,7 +319,7 @@ describe('contract line service membership editing', () => {
 
     fireEvent.click(screen.getByRole('button', { name: 'Add Item' }));
     const dialog = await screen.findByRole('dialog');
-    fireEvent.click(within(dialog).getByText('New service'));
+    fireEvent.click(await within(dialog).findByText('New service'));
     fireEvent.click(within(dialog).getByRole('button', { name: 'Add Selected Services' }));
     expect(await screen.findByText('New service')).not.toBeNull();
 


### PR DESCRIPTION
## Summary

- Remove Docker-time synthesis of the stale partial `ee/server` CE tree. CE now removes only `/app/ee/server`, preserves `ee/packages/workflows`, and relies on the checked-in alias and fallback sources used by normal builds.
- Rewrite the edition-aware architecture guide from the current `server/next.config.mjs` behavior: `@ee/*` and the established `@/empty/*` compatibility seam resolve to `packages/ee/src/*` in CE and `ee/server/src/*` in EE, while `@product/*` selects package-local OSS or EE entries.
- Add the ticket-backed implementation and validation plan for `alga0002211`.
- Harden the contract-line service membership test exposed by earlier CI so it waits for asynchronously loaded service rows before selecting one.

## Smoke test

**PASS with disclosed gaps.** Fresh live testing on the real EE app at port 3404 verified the authenticated dashboard, EE Extensions, EE payment settings showing “Stripe Not Connected” with the CE placeholder absent, and the shared Tickets screen. Chat selected the EE chunk but reproduced the known unrelated `messages.map` failure. `/msp/account` redirected externally, so the `@/empty` component remains inconclusive.

No mocks or simulators were used. The card-local sign-in required the documented React-handler fallback, and screenshots required local Playwright after `alga-dev browser-screenshot` timed out.

Prior CE Webpack and full server typecheck evidence was checksum-verified against the identical current Git tree. CE succeeded with `ee/server` absent throughout; the typecheck passed with a 16 GB heap. Direct Docker image inspection remains blocked by local socket permissions.

The unrelated `package-lock.json` change was untouched.

Evidence: `/tmp/alga-smoke-evidence/alga0002211-20260802-180108`