### PR TITLE
Edition-aware CE navigation (alga0002209)

### DIFF
--- a/docs/plans/2026-08-02-ce-edition-aware-navigation-plan.md
+++ b/docs/plans/2026-08-02-ce-edition-aware-navigation-plan.md
@@ -1,0 +1,43 @@
+# Edition-aware CE navigation plan
+
+Date: 2026-08-02  
+Card: alga0002209
+
+## Problem
+
+Community Edition currently treats every feature and add-on as enabled in `TierContext`, so enterprise-only sidebar entries remain visible and can lead to blank pages. Navigation must be edition-aware without changing the broader feature semantics used elsewhere.
+
+## Design
+
+1. Add explicit edition availability metadata to menu entries in `server/src/config/menuConfig.ts`; default entries remain available in both editions and enterprise-only entries opt into EE-only visibility.
+2. Update `SidebarWithFeatureFlags.tsx` to recursively filter sections and children by edition before applying existing feature/add-on checks. Remove empty groups and preserve ordering, permissions, active-route behavior, and mobile/desktop parity.
+3. Read edition through the established product/edition context rather than hostname or deployment heuristics.
+4. Hide EE-only entries in CE for this change. Do not globally change CE `hasFeature()` or `hasAddOn()` behavior because those APIs have consumers beyond navigation.
+5. Keep the shared CE upgrade prompt integration separable so alga0002208 can later supply a stable badge/deep-link treatment without coupling this fix to unfinished work.
+
+## Behavioral tests
+
+- CE hides representative EE-only leaf entries and recursively removes an empty parent group.
+- EE retains the same entries and ordering.
+- CE-visible entries still obey permissions and existing feature/add-on rules.
+- Mixed groups retain their CE-visible children.
+- Active-route and responsive sidebar behavior remain unchanged.
+
+## Acceptance criteria
+
+- CE users cannot navigate from the sidebar into known EE-only blank pages.
+- EE navigation is unchanged.
+- Edition metadata is explicit and reviewable in menu configuration.
+- No global change to `TierContext` feature/add-on semantics is required.
+
+## Evidence inspected
+
+- Card description and trail for alga0002209.
+- `TierContext.tsx`, `SidebarWithFeatureFlags.tsx`, `menuConfig.ts`, and `tierFeatures.ts`.
+- Existing `TierContext.test.tsx` and `SidebarWithFeatureFlags.productShell.test.tsx` coverage.
+
+## Risks
+
+- Incorrect metadata could hide valid CE navigation; cover representative sections and audit every gated entry.
+- Recursive filtering can leave empty containers; test nested and mixed groups explicitly.
+- Future upgrade badges must use the shared alga0002208 component rather than duplicating paywall copy.

--- a/server/src/components/layout/Sidebar.tsx
+++ b/server/src/components/layout/Sidebar.tsx
@@ -39,6 +39,9 @@ interface SidebarProps {
   appDisplayName?: string;
   appLogoAlt?: string;
   settingsSectionsOverride?: NavigationSection[];
+  billingSectionsOverride?: NavigationSection[];
+  extensionsSectionsOverride?: NavigationSection[];
+  inventorySectionsOverride?: NavigationSection[];
 }
 
 const Sidebar: React.FC<SidebarProps> = ({
@@ -54,6 +57,9 @@ const Sidebar: React.FC<SidebarProps> = ({
   appDisplayName = 'AlgaPSA',
   appLogoAlt = 'AlgaPSA Logo',
   settingsSectionsOverride,
+  billingSectionsOverride,
+  extensionsSectionsOverride,
+  inventorySectionsOverride,
 }): React.JSX.Element => {
   const appVersion = getAppVersion();
   const { t } = useTranslation('msp/core');
@@ -234,16 +240,18 @@ const Sidebar: React.FC<SidebarProps> = ({
   // Determine which sections to render based on mode
   const settingsSections: NavigationSection[] = settingsSectionsOverride ?? settingsNavigationSections;
 
-  const billingSections: NavigationSection[] = billingNavigationSections;
+  const billingSections: NavigationSection[] = billingSectionsOverride ?? billingNavigationSections;
+  const extensionSections: NavigationSection[] = extensionsSectionsOverride ?? extensionsNavigationSections;
+  const inventorySections: NavigationSection[] = inventorySectionsOverride ?? inventoryNavigationSections;
 
   const rawSectionsToRender: NavigationSection[] = isSettingsMode
     ? settingsSections
     : isBillingMode
       ? billingSections
       : isExtensionsMode
-        ? extensionsNavigationSections
+        ? extensionSections
         : isInventoryMode
-          ? inventoryNavigationSections
+          ? inventorySections
           : (menuSections ?? defaultNavigationSections);
 
   const sectionsToRender = rawSectionsToRender.map(translateSection);

--- a/server/src/components/layout/SidebarWithFeatureFlags.tsx
+++ b/server/src/components/layout/SidebarWithFeatureFlags.tsx
@@ -5,10 +5,14 @@ import { useFeatureFlag } from '@alga-psa/ui/hooks';
 import Sidebar from './Sidebar';
 import {
   bottomMenuItems,
+  billingNavigationSections,
+  extensionsNavigationSections,
+  inventoryNavigationSections,
   menuItems as legacyMenuItems,
   navigationSections as originalSections,
   settingsNavigationSections,
   type MenuItem,
+  type MenuEdition,
   type NavigationSection,
 } from '@/config/menuConfig';
 import { getCurrentUserPermissions } from '@alga-psa/user-composition/actions/userQueryActions';
@@ -52,6 +56,44 @@ export function filterMenuItemsByFeatureAccess(
   }, []);
 }
 
+export function filterMenuItemsByEdition(
+  items: readonly MenuItem[],
+  edition: MenuEdition,
+): MenuItem[] {
+  return items.reduce<MenuItem[]>((visibleItems, item) => {
+    if (item.availableEditions && !item.availableEditions.includes(edition)) {
+      return visibleItems;
+    }
+
+    const filteredSubItems = item.subItems
+      ? filterMenuItemsByEdition(item.subItems, edition)
+      : undefined;
+
+    if (item.subItems && filteredSubItems?.length === 0 && !item.href) {
+      return visibleItems;
+    }
+
+    visibleItems.push({
+      ...item,
+      subItems: filteredSubItems,
+    });
+
+    return visibleItems;
+  }, []);
+}
+
+export function filterNavigationSectionsByEdition(
+  sections: readonly NavigationSection[],
+  edition: MenuEdition,
+): NavigationSection[] {
+  return sections
+    .map((section) => ({
+      ...section,
+      items: filterMenuItemsByEdition(section.items, edition),
+    }))
+    .filter((section) => section.items.length > 0);
+}
+
 export function filterNavigationSectionsByFeatureAccess(
   sections: readonly NavigationSection[],
   hasFeature: (feature: NonNullable<MenuItem['requiredFeature']>) => boolean
@@ -79,7 +121,7 @@ export default function SidebarWithFeatureFlags(props: SidebarWithFeatureFlagsPr
   const [userPermissions, setUserPermissions] = useState<string[]>([]);
   const [selfHostMode, setSelfHostMode] = useState(false);
   const { hasFeature } = useTier();
-  const { productCode } = useProduct();
+  const { productCode, edition } = useProduct();
   const isAlgaDesk = productCode === 'algadesk';
 
   useEffect(() => {
@@ -150,14 +192,17 @@ export default function SidebarWithFeatureFlags(props: SidebarWithFeatureFlagsPr
       })
     }));
 
+    const editionSections = filterNavigationSectionsByEdition(filteredSections, edition);
+
     return filterMenuSectionsByProduct(
       productCode,
-      filterNavigationSectionsByFeatureAccess(filteredSections, hasFeature),
+      filterNavigationSectionsByFeatureAccess(editionSections, hasFeature),
     );
-  }, [canWorkflowAdmin, useNavigationSections, hasFeature, productCode, opportunitiesEnabled, marketingEnabled]);
+  }, [canWorkflowAdmin, useNavigationSections, hasFeature, productCode, edition, opportunitiesEnabled, marketingEnabled]);
 
   const settingsSections = useMemo<NavigationSection[]>(() => {
-    const productSections = filterMenuSectionsByProduct(productCode, settingsNavigationSections);
+    const editionSections = filterNavigationSectionsByEdition(settingsNavigationSections, edition);
+    const productSections = filterMenuSectionsByProduct(productCode, editionSections);
     const opportunitiesFilteredSections = productSections.map((section) => ({
       ...section,
       items: section.items.filter((item) => item.name !== 'Opportunities' || opportunitiesEnabled),
@@ -167,7 +212,20 @@ export default function SidebarWithFeatureFlags(props: SidebarWithFeatureFlagsPr
       opportunitiesFilteredSections,
       selfHostMode,
     );
-  }, [opportunitiesEnabled, productCode, selfHostMode]);
+  }, [edition, opportunitiesEnabled, productCode, selfHostMode]);
+
+  const billingSections = useMemo(
+    () => filterNavigationSectionsByEdition(billingNavigationSections, edition),
+    [edition],
+  );
+  const extensionsSections = useMemo(
+    () => filterNavigationSectionsByEdition(extensionsNavigationSections, edition),
+    [edition],
+  );
+  const inventorySections = useMemo(
+    () => filterNavigationSectionsByEdition(inventoryNavigationSections, edition),
+    [edition],
+  );
 
   return (
     <Sidebar
@@ -177,6 +235,9 @@ export default function SidebarWithFeatureFlags(props: SidebarWithFeatureFlagsPr
       appDisplayName={isAlgaDesk ? 'AlgaDesk' : 'AlgaPSA'}
       appLogoAlt={isAlgaDesk ? 'AlgaDesk Logo' : 'AlgaPSA Logo'}
       settingsSectionsOverride={settingsSections}
+      billingSectionsOverride={billingSections}
+      extensionsSectionsOverride={extensionsSections}
+      inventorySectionsOverride={inventorySections}
     />
   );
 }

--- a/server/src/config/menuConfig.ts
+++ b/server/src/config/menuConfig.ts
@@ -13,7 +13,6 @@ import {
   CheckCircle,
   ClipboardList,
   Clock,
-  Coins,
   CreditCard,
   Download,
   FileBarChart,
@@ -430,7 +429,6 @@ export const billingNavigationSections: NavigationSection[] = [
       { name: 'Invoice Layouts', translationKey: 'nav.billing.invoiceLayouts', icon: ReceiptText, href: '/msp/billing?tab=invoice-templates' },
       { name: 'Billing Cycles', translationKey: 'nav.billing.billingCycles', icon: CalendarClock, href: '/msp/billing?tab=billing-cycles' },
       { name: 'Service Periods', translationKey: 'nav.billing.servicePeriods', icon: CalendarClock, href: '/msp/billing?tab=service-periods' },
-      { name: 'Credits', translationKey: 'nav.billing.credits', icon: Coins, href: '/msp/billing/credits' },
     ]
   },
   {

--- a/server/src/config/menuConfig.ts
+++ b/server/src/config/menuConfig.ts
@@ -13,6 +13,7 @@ import {
   CheckCircle,
   ClipboardList,
   Clock,
+  Coins,
   CreditCard,
   Download,
   FileBarChart,
@@ -429,6 +430,7 @@ export const billingNavigationSections: NavigationSection[] = [
       { name: 'Invoice Layouts', translationKey: 'nav.billing.invoiceLayouts', icon: ReceiptText, href: '/msp/billing?tab=invoice-templates' },
       { name: 'Billing Cycles', translationKey: 'nav.billing.billingCycles', icon: CalendarClock, href: '/msp/billing?tab=billing-cycles' },
       { name: 'Service Periods', translationKey: 'nav.billing.servicePeriods', icon: CalendarClock, href: '/msp/billing?tab=service-periods' },
+      { name: 'Credits', translationKey: 'nav.billing.credits', icon: Coins, href: '/msp/billing/credits' },
     ]
   },
   {

--- a/server/src/config/menuConfig.ts
+++ b/server/src/config/menuConfig.ts
@@ -62,6 +62,9 @@ import {
 
 // Navigation modes for the unified sidebar
 export type NavMode = 'main' | 'settings' | 'billing' | 'extensions' | 'inventory';
+export type MenuEdition = 'community' | 'enterprise';
+
+const ENTERPRISE_ONLY_EDITIONS: readonly MenuEdition[] = ['enterprise'];
 
 export interface MenuItem {
   name: string;
@@ -70,6 +73,7 @@ export interface MenuItem {
   href?: string;
   subItems?: MenuItem[];
   requiredFeature?: TIER_FEATURES;
+  availableEditions?: readonly MenuEdition[];
   underConstruction?: boolean;
   requiresSelfHost?: boolean;
 }
@@ -214,8 +218,20 @@ export const navigationSections: NavigationSection[] = [
         translationKey: 'nav.workflows',
         icon: Rocket,
         subItems: [
-          { name: 'Control Panel', translationKey: 'nav.controlPanel', icon: Gauge, href: '/msp/workflow-control' },
-          { name: 'Workflow Editor', translationKey: 'nav.workflowEditor', icon: ListTree, href: '/msp/workflow-editor' },
+          {
+            name: 'Control Panel',
+            translationKey: 'nav.controlPanel',
+            icon: Gauge,
+            href: '/msp/workflow-control',
+            availableEditions: ENTERPRISE_ONLY_EDITIONS,
+          },
+          {
+            name: 'Workflow Editor',
+            translationKey: 'nav.workflowEditor',
+            icon: ListTree,
+            href: '/msp/workflow-editor',
+            availableEditions: ENTERPRISE_ONLY_EDITIONS,
+          },
         ]
       },
       {
@@ -233,6 +249,7 @@ export const navigationSections: NavigationSection[] = [
         icon: Puzzle,
         href: '/msp/extensions',
         requiredFeature: TIER_FEATURES.EXTENSIONS,
+        availableEditions: ENTERPRISE_ONLY_EDITIONS,
       }
     ]
   }
@@ -309,7 +326,13 @@ export const settingsNavigationSections: NavigationSection[] = [
       { name: 'Secrets', translationKey: 'settings.tabs.secrets', icon: KeyRound, href: '/msp/settings/secrets' },
       { name: 'Import/Export', translationKey: 'settings.tabs.importExport', icon: Download, href: '/msp/settings/import-export' },
       { name: 'Integrations', translationKey: 'settings.tabs.integrations', icon: Plug, href: '/msp/settings/integrations' },
-      { name: 'Extensions', translationKey: 'settings.tabs.extensions', icon: Puzzle, href: '/msp/settings?tab=extensions' },
+      {
+        name: 'Extensions',
+        translationKey: 'settings.tabs.extensions',
+        icon: Puzzle,
+        href: '/msp/settings?tab=extensions',
+        availableEditions: ENTERPRISE_ONLY_EDITIONS,
+      },
     ]
   },
   {
@@ -377,7 +400,13 @@ export const extensionsNavigationSections: NavigationSection[] = [
   {
     title: '',
     items: [
-      { name: 'Settings', translationKey: 'sidebar.settings', icon: Settings, href: '/msp/extensions' },
+      {
+        name: 'Settings',
+        translationKey: 'sidebar.settings',
+        icon: Settings,
+        href: '/msp/extensions',
+        availableEditions: ENTERPRISE_ONLY_EDITIONS,
+      },
     ]
   }
 ];

--- a/server/src/context/ProductContext.tsx
+++ b/server/src/context/ProductContext.tsx
@@ -4,8 +4,11 @@ import React, { createContext, useContext, useMemo } from 'react';
 import { useSession } from 'next-auth/react';
 import { ProductCode, resolveProductCode } from '@alga-psa/types';
 
+export type ProductEdition = 'community' | 'enterprise';
+
 interface ProductContextValue {
   productCode: ProductCode;
+  edition: ProductEdition;
   isMisconfigured: boolean;
   isPsa: boolean;
   isAlgaDesk: boolean;
@@ -21,6 +24,9 @@ interface ProductProviderProps {
 export function ProductProvider({ children }: ProductProviderProps) {
   const { data: session, status } = useSession();
   const isLoading = status === 'loading';
+  const edition: ProductEdition = process.env.NEXT_PUBLIC_EDITION === 'enterprise'
+    ? 'enterprise'
+    : 'community';
 
   const { productCode, isMisconfigured } = useMemo(() => {
     return resolveProductCode(session?.user?.product_code);
@@ -29,12 +35,13 @@ export function ProductProvider({ children }: ProductProviderProps) {
   const value = useMemo<ProductContextValue>(
     () => ({
       productCode,
+      edition,
       isMisconfigured,
       isPsa: productCode === 'psa',
       isAlgaDesk: productCode === 'algadesk',
       isLoading,
     }),
-    [isLoading, isMisconfigured, productCode],
+    [edition, isLoading, isMisconfigured, productCode],
   );
 
   return <ProductContext.Provider value={value}>{children}</ProductContext.Provider>;

--- a/server/src/test/unit/context/ProductContext.test.tsx
+++ b/server/src/test/unit/context/ProductContext.test.tsx
@@ -3,7 +3,7 @@
  */
 import React from 'react';
 import { renderHook } from '@testing-library/react';
-import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { ProductProvider, useProduct } from '../../../context/ProductContext';
 
@@ -16,6 +16,7 @@ vi.mock('next-auth/react', () => ({
 describe('ProductContext', () => {
   beforeEach(() => {
     vi.resetAllMocks();
+    vi.stubEnv('NEXT_PUBLIC_EDITION', 'community');
     useSession.mockReturnValue({
       status: 'authenticated',
       data: {
@@ -24,6 +25,10 @@ describe('ProductContext', () => {
         },
       },
     });
+  });
+
+  afterEach(() => {
+    vi.unstubAllEnvs();
   });
 
   const wrapper = ({ children }: { children: React.ReactNode }) => (
@@ -51,6 +56,13 @@ describe('ProductContext', () => {
     const { result } = renderHook(() => useProduct(), { wrapper });
     expect(result.current.productCode).toBe('algadesk');
     expect(result.current.isAlgaDesk).toBe(true);
+  });
+
+  it('exposes the build edition alongside the product', () => {
+    vi.stubEnv('NEXT_PUBLIC_EDITION', 'enterprise');
+
+    const { result } = renderHook(() => useProduct(), { wrapper });
+    expect(result.current.edition).toBe('enterprise');
   });
 
   it('fails closed to psa and marks misconfigured for unknown product code', () => {

--- a/server/src/test/unit/layout/SidebarWithFeatureFlags.productShell.test.tsx
+++ b/server/src/test/unit/layout/SidebarWithFeatureFlags.productShell.test.tsx
@@ -4,8 +4,13 @@
 import React from 'react';
 import { render, waitFor } from '@testing-library/react';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { TIER_FEATURES } from '@alga-psa/types';
 
-import SidebarWithFeatureFlags from '../../../components/layout/SidebarWithFeatureFlags';
+import SidebarWithFeatureFlags, {
+  filterNavigationSectionsByEdition,
+  filterNavigationSectionsByFeatureAccess,
+} from '../../../components/layout/SidebarWithFeatureFlags';
+import type { NavigationSection } from '../../../config/menuConfig';
 
 const useFeatureFlag = vi.fn();
 const getCurrentUserPermissions = vi.fn();
@@ -47,7 +52,7 @@ describe('SidebarWithFeatureFlags product shell composition', () => {
     useFeatureFlag.mockReturnValue(true);
     getCurrentUserPermissions.mockResolvedValue([]);
     useTier.mockReturnValue({ hasFeature: () => true });
-    useProduct.mockReturnValue({ productCode: 'psa' });
+    useProduct.mockReturnValue({ productCode: 'psa', edition: 'enterprise' });
     getLicenseStatus.mockResolvedValue({ selfHostMode: false });
   });
 
@@ -96,7 +101,7 @@ describe('SidebarWithFeatureFlags product shell composition', () => {
   });
 
   it('T005: AlgaDesk shell keeps only allowed nav and uses AlgaDesk branding labels', async () => {
-    useProduct.mockReturnValue({ productCode: 'algadesk' });
+    useProduct.mockReturnValue({ productCode: 'algadesk', edition: 'enterprise' });
 
     render(<SidebarWithFeatureFlags sidebarOpen={true} setSidebarOpen={vi.fn()} />);
 
@@ -121,7 +126,7 @@ describe('SidebarWithFeatureFlags product shell composition', () => {
   });
 
   it('T005: PSA shell remains unchanged and uses AlgaPSA branding labels', async () => {
-    useProduct.mockReturnValue({ productCode: 'psa' });
+    useProduct.mockReturnValue({ productCode: 'psa', edition: 'enterprise' });
 
     render(<SidebarWithFeatureFlags sidebarOpen={true} setSidebarOpen={vi.fn()} />);
 
@@ -137,7 +142,57 @@ describe('SidebarWithFeatureFlags product shell composition', () => {
     expect(names).toContain('Billing');
     expect(names).toContain('Projects');
     expect(names).toContain('Assets');
+    expect(names.indexOf('Workflows')).toBeLessThan(names.indexOf('System Monitoring'));
+    expect(names.indexOf('System Monitoring')).toBeLessThan(names.indexOf('Extensions'));
     expect(latestProps.appDisplayName).toBe('AlgaPSA');
     expect(latestProps.appLogoAlt).toBe('AlgaPSA Logo');
+  });
+
+  it('hides EE-only navigation in CE and removes the empty Workflows group', async () => {
+    useProduct.mockReturnValue({ productCode: 'psa', edition: 'community' });
+
+    render(<SidebarWithFeatureFlags sidebarOpen={true} setSidebarOpen={vi.fn()} />);
+
+    await waitFor(() => expect(sidebarPropsSpy).toHaveBeenCalled());
+
+    const latestProps = sidebarPropsSpy.mock.calls.at(-1)?.[0] as {
+      menuSections: Array<{ items: Array<{ name: string }> }>;
+      settingsSectionsOverride: Array<{ items: Array<{ name: string }> }>;
+      extensionsSectionsOverride: Array<{ items: Array<{ name: string }> }>;
+    };
+    const mainNames = latestProps.menuSections.flatMap((section) => section.items.map((item) => item.name));
+    const settingsNames = latestProps.settingsSectionsOverride.flatMap((section) =>
+      section.items.map((item) => item.name),
+    );
+
+    expect(mainNames).not.toContain('Workflows');
+    expect(mainNames).not.toContain('Extensions');
+    expect(settingsNames).not.toContain('Extensions');
+    expect(latestProps.extensionsSectionsOverride).toEqual([]);
+  });
+
+  it('recursively keeps CE-visible children and still applies feature access', () => {
+    const Icon = () => null;
+    const sections: NavigationSection[] = [
+      {
+        title: 'Mixed',
+        items: [
+          {
+            name: 'Parent',
+            icon: Icon,
+            subItems: [
+              { name: 'CE child', icon: Icon, href: '/ce' },
+              { name: 'EE child', icon: Icon, href: '/ee', availableEditions: ['enterprise'] },
+              { name: 'Feature child', icon: Icon, href: '/feature', requiredFeature: TIER_FEATURES.EXTENSIONS },
+            ],
+          },
+        ],
+      },
+    ];
+
+    const editionFiltered = filterNavigationSectionsByEdition(sections, 'community');
+    const featureFiltered = filterNavigationSectionsByFeatureAccess(editionFiltered, () => false);
+
+    expect(featureFiltered[0].items[0].subItems?.map((item) => item.name)).toEqual(['CE child']);
   });
 });


### PR DESCRIPTION
## Summary

- Add explicit Community/Enterprise availability metadata to navigation entries and expose the build edition through `ProductContext`.
- Recursively apply edition filtering across main, Settings, Billing, Extensions, and Inventory navigation before the existing product/feature filters, removing empty groups while preserving CE entries.
- Hide CE entry points for Workflows and Extensions without changing global tier feature semantics, and add focused product-context/sidebar coverage.
- Include the implementation plan for alga0002209.

## Automated validation

- PASS — targeted ProductContext and sidebar unit tests.
- PASS — server typecheck with `NODE_OPTIONS=--max-old-space-size=16384`.
- PASS — CE production build.

## Authenticated CE smoke test

PASS — authenticated CE smoke completed through the real running product.

Exercised:

- Main navigation: Workflows and Extensions were absent; normal CE entries remained.
- Settings navigation: Extensions was absent, while Integrations remained visible.
- Regression: clicked Integrations and confirmed the real `/msp/settings/integrations` page loaded.
- Direct `/msp/extensions`: rendered the Enterprise feature stub, not a blank page; extension-mode Settings link was absent.
- Direct `/msp/workflow-editor`: rendered the Enterprise Feature prompt, not a blank page.
- Final browser sweep found no console errors, failed requests, or 5xx responses.

Fidelity compromises/setup:

- No simulator or mock was used.
- The viewer ran on a Mac while the card/app ran on Linux, so a temporary `socat` bridge exposed the real Linux port 3471 as Mac localhost. It was removed afterward.
- A card-scoped nested browser tab was needed because screenshots timed out for a background root browser pane.
- Rapid dev-server credential rotation left the recorded password stale. Only Glinda’s password in the isolated `alga-psa-local-test` database was reset to the last server-printed credential; authentication then succeeded.
- Docker API access was denied, so container status could not be inspected directly. Readiness was proven through the authenticated UI, a real PgBouncer database update, HTTP 200, and reachable PostgreSQL/PgBouncer/Redis ports.

Evidence: `/tmp/alga-smoke-evidence/alga0002209-ce-edition-aware-navigation-20260802-121835`

## Concerns

The environment displays a license-expiry warning, and earlier console output contained existing Electron CSP/PostHog warnings. No feature-related runtime errors appeared. Pre-existing `package-lock.json` and untracked-file changes remain untouched.