### PR TITLE
Fix 401 on Refresh Pub/Sub & Watch (middleware allowlist)

### DIFF
--- a/docs/plans/2026-08-02-email-refresh-watch-session-auth/PRD.md
+++ b/docs/plans/2026-08-02-email-refresh-watch-session-auth/PRD.md
@@ -1,0 +1,81 @@
+# PRD — Email Refresh Watch Session Authentication
+
+- Slug: `email-refresh-watch-session-auth`
+- Date: `2026-08-02`
+- Status: Implemented; authenticated UI smoke pending
+
+## Summary
+
+Allow the Google email provider's **Refresh Pub/Sub & Watch** browser action to reach its session-authenticated route without requiring an API key.
+
+## Problem
+
+The email provider configuration UI sends a cookie-authenticated `POST` request to `/api/email/refresh-watch`. The route authenticates the current user in the handler, but edge middleware applies the API-key gate first. Because the route is absent from the middleware skip list, browser requests without `x-api-key` are rejected with `401 Unauthorized: API key missing` before the route handler can evaluate the session.
+
+## Goals
+
+- Permit `/api/email/refresh-watch` to use its existing in-route session authentication.
+- Preserve the route handler's existing authorization and tenant-scoped provider lookup.
+- Add focused regression coverage for the middleware allowlist entry.
+- Audit direct browser calls under `/api/email/*` for the same middleware mismatch.
+
+## Non-goals
+
+- Change the refresh route's business logic, response contract, or Google integration behavior.
+- Add API-key authentication to the browser request.
+- Change authentication behavior for unrelated email API routes.
+- Address inbound email service availability or webhook delivery issues.
+
+## Users and Primary Flows
+
+An authenticated MSP user opens a configured Google email provider and selects **Refresh Pub/Sub & Watch**. The browser posts the provider identifier with the user's session cookie. Middleware allows the request through, and the route handler authenticates the session before refreshing the provider.
+
+Unauthenticated requests must still be rejected by the route handler.
+
+## UX / UI Notes
+
+No UI changes are required. The existing action and error display remain in place. Successful behavior is that the action no longer reports the middleware-specific `API key missing` error.
+
+## Requirements
+
+### Functional Requirements
+
+1. `POST /api/email/refresh-watch` without an `x-api-key` header must pass the middleware API-key presence gate.
+2. The route handler must remain responsible for session authentication through `getCurrentUser`.
+3. An unauthenticated request may return `401 Unauthorized` from the route handler, but must not return `401 Unauthorized: API key missing` from middleware.
+4. Existing browser calls to `/api/email/oauth/imap/initiate` must remain covered by the `/api/email/oauth/` prefix.
+
+### Non-functional Requirements
+
+- Keep the change limited to the middleware allowlist and focused unit coverage.
+- Preserve existing middleware and route code style.
+- Pass the focused middleware test, server typecheck, and production build.
+
+## Data / API / Integrations
+
+No data model or API payload changes are required. The existing route accepts `{ "providerId": string }` and performs tenant-scoped Google provider lookup before invoking the existing Gmail configuration workflow.
+
+## Security / Permissions
+
+The allowlist bypasses only middleware's API-key-header presence check. It does not make the route public: `getCurrentUser` continues to reject requests without a valid session, and tenant scoping remains in the handler.
+
+## Observability
+
+No new telemetry is required. Existing middleware development logging and route logging remain unchanged.
+
+## Rollout / Migration
+
+No migration or feature flag is required. The middleware change takes effect with the normal application deployment.
+
+## Open Questions
+
+- Complete an authenticated UI smoke against a configured Google provider to confirm the full Pub/Sub and Gmail watch refresh path in an environment with valid Google credentials.
+
+## Acceptance Criteria (Definition of Done)
+
+- `/api/email/refresh-watch` is included in `apiKeySkipPaths`.
+- Unit coverage verifies `shouldSkipApiKeyAuth('/api/email/refresh-watch')` is `true`.
+- Direct browser `/api/email/*` calls are audited and no other uncovered session-authenticated routes are found.
+- A no-API-key request reaches the route handler and returns the handler's `Unauthorized` response when no session is present.
+- The focused unit test, server typecheck, and production build pass.
+- An authenticated Google provider UI smoke no longer displays `API key missing`.

--- a/docs/plans/2026-08-02-email-refresh-watch-session-auth/SCRATCHPAD.md
+++ b/docs/plans/2026-08-02-email-refresh-watch-session-auth/SCRATCHPAD.md
@@ -1,0 +1,35 @@
+# Scratchpad — Email Refresh Watch Session Authentication
+
+- Plan slug: `email-refresh-watch-session-auth`
+- Created: `2026-08-02`
+
+## Decisions
+
+- 2026-08-02: Add the exact refresh-watch route to `apiKeySkipPaths`; retain the existing handler-level `getCurrentUser` authorization and request shape.
+- 2026-08-02: Limit regression coverage to the exported `shouldSkipApiKeyAuth` predicate because this is the middleware decision that previously blocked the route.
+
+## Discoveries / Constraints
+
+- 2026-08-02: Edge middleware checks API-key header presence before API route handlers run. Session-authenticated API routes therefore require an explicit skip-path entry.
+- 2026-08-02: The provider configuration UI performs a cookie-only `POST` to `/api/email/refresh-watch`.
+- 2026-08-02: The refresh route calls `getCurrentUser`; an unauthenticated request is expected to return `{ "error": "Unauthorized" }` with status 401 from the handler.
+- 2026-08-02: Audit of direct browser calls under `/api/email/*` found refresh-watch and two IMAP OAuth initiate calls. Both IMAP calls are already covered by `/api/email/oauth/`; refresh-watch was the lone gap.
+- 2026-08-02: No database schema or route payload change is needed.
+
+## Commands / Runbooks
+
+- Focused unit test: `cd server && npx vitest run src/test/unit/middleware.apiKeyAuth.test.ts --coverage.enabled=false`
+- Server typecheck: run the repository's server typecheck with sufficient Node heap for this workspace.
+- Handler-reach smoke: `curl -i -X POST http://127.0.0.1:3213/api/email/refresh-watch -H 'Content-Type: application/json' --data '{"providerId":"test"}'`
+- Expected unauthenticated smoke response: status 401 with `{"error":"Unauthorized"}`, not `Unauthorized: API key missing`.
+
+## Links / References
+
+- `server/src/middleware.ts`
+- `server/src/test/unit/middleware.apiKeyAuth.test.ts`
+- `server/src/app/api/email/refresh-watch/route.ts`
+- `packages/integrations/src/components/email/EmailProviderConfiguration.tsx`
+
+## Open Questions
+
+- Authenticated UI smoke requires a configured Google provider and valid external integration credentials.

--- a/docs/plans/2026-08-02-email-refresh-watch-session-auth/features.json
+++ b/docs/plans/2026-08-02-email-refresh-watch-session-auth/features.json
@@ -1,0 +1,20 @@
+[
+  {
+    "id": "F001",
+    "description": "The email refresh-watch route bypasses middleware's API-key-header presence gate so browser session authentication can run in the route handler.",
+    "implemented": true,
+    "prdRefs": ["Requirements > Functional Requirements", "Security / Permissions"]
+  },
+  {
+    "id": "F002",
+    "description": "Unauthenticated refresh-watch requests remain rejected by the route handler without exposing the route as a public endpoint.",
+    "implemented": true,
+    "prdRefs": ["Users and Primary Flows", "Security / Permissions"]
+  },
+  {
+    "id": "F003",
+    "description": "Focused middleware coverage protects the refresh-watch session-authentication allowlist entry from regression.",
+    "implemented": true,
+    "prdRefs": ["Requirements > Non-functional Requirements", "Acceptance Criteria (Definition of Done)"]
+  }
+]

--- a/docs/plans/2026-08-02-email-refresh-watch-session-auth/tests.json
+++ b/docs/plans/2026-08-02-email-refresh-watch-session-auth/tests.json
@@ -1,0 +1,26 @@
+[
+  {
+    "id": "T001",
+    "description": "Unit: shouldSkipApiKeyAuth returns true for /api/email/refresh-watch.",
+    "implemented": true,
+    "featureIds": ["F001", "F003"]
+  },
+  {
+    "id": "T002",
+    "description": "HTTP smoke: POST /api/email/refresh-watch without x-api-key reaches the route handler and returns its Unauthorized response when no session is present, not the middleware API-key-missing response.",
+    "implemented": true,
+    "featureIds": ["F001", "F002"]
+  },
+  {
+    "id": "T003",
+    "description": "UI smoke: an authenticated user refreshes Pub/Sub and Watch for a configured Google provider without seeing API key missing.",
+    "implemented": false,
+    "featureIds": ["F001", "F002"]
+  },
+  {
+    "id": "T004",
+    "description": "Build gates: the focused middleware unit test, server typecheck, and isolated CE production build pass.",
+    "implemented": true,
+    "featureIds": ["F001", "F002", "F003"]
+  }
+]

--- a/server/src/middleware.ts
+++ b/server/src/middleware.ts
@@ -67,6 +67,7 @@ const apiKeySkipPaths = [
   '/api/calendar/webhooks/',
   '/api/calendar/appointment/',
   '/api/email/oauth/',
+  '/api/email/refresh-watch',
   '/api/teams/auth/',
   '/api/teams/bot/',
   '/api/teams/message-extension/',

--- a/server/src/test/unit/middleware.apiKeyAuth.test.ts
+++ b/server/src/test/unit/middleware.apiKeyAuth.test.ts
@@ -34,6 +34,10 @@ describe('shouldSkipApiKeyAuth', () => {
     expect(shouldSkipApiKeyAuth('/api/calendar/appointment/2187d639-b796-4b0e-b760-8a2576bb435f.ics')).toBe(true);
   });
 
+  it('allows the email watch refresh route to use session auth', () => {
+    expect(shouldSkipApiKeyAuth('/api/email/refresh-watch')).toBe(true);
+  });
+
   it('allows workflow run APIs to use MSP session auth', () => {
     expect(shouldSkipApiKeyAuth('/api/workflow-runs')).toBe(true);
     expect(shouldSkipApiKeyAuth('/api/workflow-runs/run-123/audit/export')).toBe(true);


### PR DESCRIPTION
## Summary

- Allow the cookie-authenticated `POST /api/email/refresh-watch` browser action through the middleware API-key gate so its existing session authentication can run.
- Add focused regression coverage for the middleware allowlist entry.
- Record the implementation, security boundary, route audit, and validation in the ALGA plan.
- Audit direct browser calls under `/api/email/*`; the two IMAP OAuth initiation calls are already covered by `/api/email/oauth/`, making refresh-watch the lone gap.

The route remains protected: this bypasses only middleware's API-key-header presence check. The handler still requires `getCurrentUser` and retains tenant-scoped provider lookup.

## Validation

- PASS — focused middleware unit tests.
- PASS — server typecheck with a 16 GB Node heap.
- PASS — isolated CE production Turbopack build.
- PASS — authenticated real-product smoke test.

In the authenticated Email Configuration UI, selecting **Refresh Pub/Sub & Watch** issued `POST /api/email/refresh-watch` and reached the route handler. It returned the expected fixture-level `404 Gmail configuration not found`; the UI never displayed `API key missing`. The adjacent provider-list refresh also completed without an API-key error. An unauthenticated, keyless POST returned handler-level `401 {"error":"Unauthorized"}`, confirming middleware passage.

Fidelity: real dev server, database, NextAuth session, Chrome UI, and HTTP route. No simulator or mock was used. A temporary Google provider row was required because the environment had no Google provider; it intentionally lacked Google credentials, so the external Pub/Sub/watch operation and success toast could not be tested. The fixture and temporary automation script were removed and the worktree is clean. Screenshots were captured through Playwright against the real product because the card's cross-host Alga Dev browser screenshot command timed out while its tab was hidden. The shared development database can also rotate the dev-login hash when another worktree boots; the original hash was restored. The app remains live on port 3213.

Evidence: `/tmp/alga-smoke-evidence/email-refresh-watch-auth-20260802-142507`
