### PR TITLE
Fix Teams add-on dead-end link (alga0002212)

### DIFF
--- a/docs/plans/2026-08-02-teams-addon-paywall-destination-plan.md
+++ b/docs/plans/2026-08-02-teams-addon-paywall-destination-plan.md
@@ -1,0 +1,40 @@
+# Teams add-on paywall destination plan
+
+Date: 2026-08-02  
+Card: alga0002212
+
+## Problem
+
+Teams paywall CTAs hard-code `/msp/account`, where the add-on section is collapsed, lacks a stable target, and renders no useful destination in CE. Users reach a dead end instead of a focused purchase or upgrade path.
+
+## Design
+
+1. Define a canonical internal destination `/msp/add-ons?addon=teams` and replace duplicated Teams CTA constants with a shared route helper.
+2. In hosted EE, route that destination into Account Management with the Teams add-on section selected, expanded, focused, and assigned a stable accessible heading/anchor. Preserve direct `/msp/account` behavior.
+3. In CE, resolve the same destination to the shared edition upgrade prompt rather than rendering the EE account surface or a blank page.
+4. Preserve query state across authentication redirects and client navigation so the intended add-on remains selected.
+5. Keep purchase URLs and external commerce actions behind the existing account/add-on boundary; this change only fixes internal navigation.
+
+## Behavioral tests
+
+- Both Teams CTA components use the canonical destination.
+- Hosted EE opens Account Management with Teams expanded and focused.
+- CE displays the shared upgrade prompt and never renders a blank destination.
+- Unknown add-on keys fall back safely to the normal add-ons/account view.
+- Direct account navigation, permissions, keyboard focus, and back navigation remain stable.
+
+## Acceptance criteria
+
+- Every Teams paywall CTA lands on an actionable, visible Teams destination.
+- Hosted EE and CE use edition-appropriate outcomes.
+- The add-on selection is deep-linkable and accessible.
+- No new external purchase action is introduced.
+
+## Evidence inspected
+
+- Card context, both Teams CTA components, Account routing/layout, EE add-on controls, CE/EE alias patterns, shared upgrade notice, and relevant tests.
+
+## Risks
+
+- Route rewrites can loop or lose query state; cover authenticated and unauthenticated entry.
+- Coupling to the shared upgrade component depends on alga0002208; use its stable public seam or a temporary adapter without duplicating copy.

--- a/ee/server/src/components/settings/account/AccountManagement.tsx
+++ b/ee/server/src/components/settings/account/AccountManagement.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import React, { useState, useEffect } from 'react';
+import React, { useState, useEffect, useRef } from 'react';
 import { Card, CardContent, CardHeader, CardTitle, CardDescription } from '@alga-psa/ui/components/Card';
 import { Button } from '@alga-psa/ui/components/Button';
 import { Label } from '@alga-psa/ui/components/Label';
@@ -76,7 +76,11 @@ const FEATURE_TRANSLATION_KEYS: Record<TIER_FEATURES, string> = {
   [TIER_FEATURES.ADVANCED_AUTHORIZATION_BUNDLES]: 'features.advancedAuthorizationBundles',
 };
 
-export default function AccountManagement() {
+type AccountManagementProps = {
+  selectedAddOn?: AddOnKey;
+};
+
+export default function AccountManagement({ selectedAddOn }: AccountManagementProps) {
   const { t } = useTranslation('msp/account');
   const formatAddOnDescription = useFormatAddOnDescription();
   const [loading, setLoading] = useState(true);
@@ -120,6 +124,7 @@ export default function AccountManagement() {
     : aiUsageBillingFlag?.enabled ?? false;
   const { isAlgaDesk } = useProduct();
   const { update: updateSession } = useSession();
+  const focusedAddOnRef = useRef<AddOnKey | null>(null);
 
   // Collapsible sections state
   const [expandedSections, setExpandedSections] = useState({
@@ -146,6 +151,22 @@ export default function AccountManagement() {
   const hasPendingIapTransition = Boolean(iapContext?.iap?.hasPendingTransition);
 
   const router = useRouter();
+
+  useEffect(() => {
+    if (loading || !selectedAddOn || focusedAddOnRef.current === selectedAddOn) {
+      return;
+    }
+
+    const addOnSlug = selectedAddOn.replace(/_/g, '-');
+    const selectedCard = document.getElementById(`account-addon-${addOnSlug}`);
+    if (!selectedCard) {
+      return;
+    }
+
+    focusedAddOnRef.current = selectedAddOn;
+    selectedCard.scrollIntoView({ block: 'center' });
+    selectedCard.focus({ preventScroll: true });
+  }, [loading, selectedAddOn]);
 
   const formatDate = (value?: string | Date | null) => {
     if (!value) return t('common.notAvailable');
@@ -1528,72 +1549,86 @@ export default function AccountManagement() {
         </Card>
       )}
 
-      {tierUpgradeFlowEnabled && addOnCards.map((card) => {
-        const isActive = hasAddOn(card.addOn);
-        const isPurchasing = purchasingAddOn === card.addOn;
-        const isCanceling = cancelingAddOn === card.addOn;
-        const addOnSlug = card.addOn.replace(/_/g, '-');
+      {(tierUpgradeFlowEnabled || selectedAddOn) && (
+        <section id="account-add-ons" aria-labelledby="account-add-ons-heading" className="space-y-4">
+          <h2 id="account-add-ons-heading" className="text-2xl font-semibold">
+            {t('addOns.title')}
+          </h2>
+          {addOnCards.map((card) => {
+            const isActive = hasAddOn(card.addOn);
+            const isPurchasing = purchasingAddOn === card.addOn;
+            const isCanceling = cancelingAddOn === card.addOn;
+            const addOnSlug = card.addOn.replace(/_/g, '-');
+            const isSelected = selectedAddOn === card.addOn;
 
-        return (
-          <Card key={card.addOn}>
-            <CardHeader>
-              <div className="flex items-center justify-between gap-4">
-                <div>
-                  <CardTitle>{ADD_ON_LABELS[card.addOn]}</CardTitle>
-                  <CardDescription>{formatAddOnDescription(card.addOn)}</CardDescription>
-                </div>
-                <Badge variant={isActive ? 'success' : 'default-muted'}>
-                  {isActive ? t('aiAssistant.statusActive') : t('aiAssistant.statusAvailable')}
-                </Badge>
-              </div>
-            </CardHeader>
-            <CardContent className="space-y-4">
-              <p className="text-sm text-muted-foreground">{card.description}</p>
-              {isActive ? (
-                <div className="rounded-lg border border-green-200 dark:border-green-800 bg-green-50 dark:bg-green-900/20 p-4">
+            return (
+              <Card
+                key={card.addOn}
+                id={`account-addon-${addOnSlug}`}
+                aria-labelledby={`account-addon-${addOnSlug}-heading`}
+                tabIndex={isSelected ? -1 : undefined}
+                className={isSelected ? 'scroll-mt-6 border-primary ring-2 ring-primary/30 focus:outline-none' : undefined}
+              >
+                <CardHeader>
                   <div className="flex items-center justify-between gap-4">
                     <div>
-                      <h4 className="font-semibold">{card.activeTitle}</h4>
-                      <p className="text-sm text-muted-foreground">{card.activeBody}</p>
+                      <CardTitle id={`account-addon-${addOnSlug}-heading`}>{ADD_ON_LABELS[card.addOn]}</CardTitle>
+                      <CardDescription>{formatAddOnDescription(card.addOn)}</CardDescription>
                     </div>
-                    <Button
-                      id={`cancel-${addOnSlug}-addon-btn`}
-                      variant="outline"
-                      onClick={() => setCancelAddOnConfirm(card.addOn)}
-                      disabled={isCanceling}
-                    >
-                      {isCanceling ? t('aiAssistant.cancelling') : t('aiAssistant.cancel')}
-                    </Button>
+                    <Badge variant={isActive ? 'success' : 'default-muted'}>
+                      {isActive ? t('aiAssistant.statusActive') : t('aiAssistant.statusAvailable')}
+                    </Badge>
                   </div>
-                </div>
-              ) : isIapTenant ? (
-                <div className="rounded-lg border border-muted bg-muted/30 p-4">
-                  <h4 className="font-semibold">{t('aiAssistant.iapUnavailableTitle')}</h4>
-                  <p className="text-sm text-muted-foreground mt-1">
-                    {t('aiAssistant.iapUnavailableBody')}
-                  </p>
-                </div>
-              ) : (
-                <div className="rounded-lg border border-primary/20 bg-primary/5 p-4">
-                  <div className="flex items-center justify-between gap-4">
-                    <div>
-                      <h4 className="font-semibold">{card.addTitle}</h4>
-                      <p className="text-sm text-muted-foreground">{card.addBody}</p>
+                </CardHeader>
+                <CardContent className="space-y-4">
+                  <p className="text-sm text-muted-foreground">{card.description}</p>
+                  {isActive ? (
+                    <div className="rounded-lg border border-green-200 dark:border-green-800 bg-green-50 dark:bg-green-900/20 p-4">
+                      <div className="flex items-center justify-between gap-4">
+                        <div>
+                          <h4 className="font-semibold">{card.activeTitle}</h4>
+                          <p className="text-sm text-muted-foreground">{card.activeBody}</p>
+                        </div>
+                        <Button
+                          id={`cancel-${addOnSlug}-addon-btn`}
+                          variant="outline"
+                          onClick={() => setCancelAddOnConfirm(card.addOn)}
+                          disabled={isCanceling}
+                        >
+                          {isCanceling ? t('aiAssistant.cancelling') : t('aiAssistant.cancel')}
+                        </Button>
+                      </div>
                     </div>
-                    <Button
-                      id={`purchase-${addOnSlug}-addon-btn`}
-                      onClick={() => handlePurchaseAddOn(card.addOn)}
-                      disabled={isPurchasing}
-                    >
-                      {isPurchasing ? t('aiAssistant.startingCheckout') : t('aiAssistant.addButton')}
-                    </Button>
-                  </div>
-                </div>
-              )}
-            </CardContent>
-          </Card>
-        );
-      })}
+                  ) : isIapTenant ? (
+                    <div className="rounded-lg border border-muted bg-muted/30 p-4">
+                      <h4 className="font-semibold">{t('aiAssistant.iapUnavailableTitle')}</h4>
+                      <p className="text-sm text-muted-foreground mt-1">
+                        {t('aiAssistant.iapUnavailableBody')}
+                      </p>
+                    </div>
+                  ) : (
+                    <div className="rounded-lg border border-primary/20 bg-primary/5 p-4">
+                      <div className="flex items-center justify-between gap-4">
+                        <div>
+                          <h4 className="font-semibold">{card.addTitle}</h4>
+                          <p className="text-sm text-muted-foreground">{card.addBody}</p>
+                        </div>
+                        <Button
+                          id={`purchase-${addOnSlug}-addon-btn`}
+                          onClick={() => handlePurchaseAddOn(card.addOn)}
+                          disabled={isPurchasing}
+                        >
+                          {isPurchasing ? t('aiAssistant.startingCheckout') : t('aiAssistant.addButton')}
+                        </Button>
+                      </div>
+                    </div>
+                  )}
+                </CardContent>
+              </Card>
+            );
+          })}
+        </section>
+      )}
 
       {/* Scheduled License Changes Alert */}
       {scheduledChanges && (

--- a/packages/core/src/lib/i18n/config.ts
+++ b/packages/core/src/lib/i18n/config.ts
@@ -193,6 +193,7 @@ export const ROUTE_NAMESPACES = {
   '/msp/extensions': ['common', 'msp/core', 'msp/extensions'],
   '/msp/licenses': ['common', 'msp/core', 'msp/licensing'],
   '/msp/account': ['common', 'msp/core', 'msp/account', 'msp/licensing'],
+  '/msp/add-ons': ['common', 'msp/core', 'msp/account', 'msp/licensing'],
   '/msp/user-activities': ['common', 'msp/core', 'msp/user-activities', 'msp/workflows', 'features/tickets', 'features/projects', 'msp/schedule'],
 } as const;
 

--- a/packages/ee/src/components/settings/account/AccountManagement.tsx
+++ b/packages/ee/src/components/settings/account/AccountManagement.tsx
@@ -8,7 +8,11 @@ import React from 'react';
 import { Card } from '@alga-psa/ui/components/Card';
 import { AlertCircle } from 'lucide-react';
 
-export default function AccountManagement() {
+type AccountManagementProps = {
+  selectedAddOn?: string;
+};
+
+export default function AccountManagement(_props: AccountManagementProps) {
   return (
     <Card className="p-8 text-center">
       <AlertCircle className="h-12 w-12 mx-auto mb-4 text-muted-foreground" />

--- a/packages/integrations/src/components/settings/integrations/IntegrationsSettingsPage.tsx
+++ b/packages/integrations/src/components/settings/integrations/IntegrationsSettingsPage.tsx
@@ -12,6 +12,7 @@ import { useSearchParams } from 'next/navigation';
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@alga-psa/ui/components/Card';
 import CustomTabs, { TabContent } from '@alga-psa/ui/components/CustomTabs';
 import { useFeatureFlag } from '@alga-psa/ui/hooks';
+import { ADD_ONS, type AddOnKey } from '@alga-psa/types';
 import { ENTRA_SYNC_FEATURE_FLAG } from './integrationsFeatureFlags';
 import {
   Building2,
@@ -38,6 +39,7 @@ import {
   isCalendarEnterpriseEdition,
   resolveIntegrationSettingsCategory,
 } from '../../../lib/calendarAvailability';
+import { getAddOnDestination } from '../../../lib/addOnNavigation';
 
 // Dynamic import for StripeConnectionSettings (EE/OSS modular pattern)
 // Uses dynamic import with type assertion due to TypeScript bundler mode resolution issues
@@ -97,8 +99,9 @@ interface IntegrationItem {
   isEE?: boolean;
 }
 
-function AddOnRequiredNotice({ featureName, addOnName, description }: {
+function AddOnRequiredNotice({ featureName, addOn, addOnName, description }: {
   featureName: string;
+  addOn: AddOnKey;
   addOnName: string;
   description: string;
 }) {
@@ -113,7 +116,7 @@ function AddOnRequiredNotice({ featureName, addOnName, description }: {
       <p className="text-muted-foreground max-w-md mb-6">{description}</p>
       <a
         id={`manage-${addOnName.toLowerCase()}-addon-link`}
-        href="/msp/settings/account"
+        href={getAddOnDestination(addOn)}
         className="inline-flex items-center justify-center px-6 py-3 bg-primary text-primary-foreground hover:bg-primary/90 font-medium rounded-lg transition-colors"
       >
         Manage add-ons
@@ -243,6 +246,7 @@ const IntegrationsSettingsPage: React.FC<IntegrationsSettingsPageProps> = ({
             : () => (
                 <AddOnRequiredNotice
                   featureName={t('integrations.items.teams.name')}
+                  addOn={ADD_ONS.TEAMS}
                   addOnName="Teams"
                   description="Purchase the Teams add-on to activate the Microsoft Teams tab, bot, message extension, quick actions, and activity notifications."
                 />
@@ -303,6 +307,7 @@ const IntegrationsSettingsPage: React.FC<IntegrationsSettingsPageProps> = ({
             : () => (
                 <AddOnRequiredNotice
                   featureName={t('integrations.items.entra.name')}
+                  addOn={ADD_ONS.ENTERPRISE}
                   addOnName="Enterprise"
                   description="Purchase the Enterprise add-on to activate Microsoft Entra Sync, including tenant discovery, client mapping, contact sync, and reconciliation workflows."
                 />

--- a/packages/integrations/src/components/settings/integrations/TeamsIntegrationSettings.lifecycle.test.tsx
+++ b/packages/integrations/src/components/settings/integrations/TeamsIntegrationSettings.lifecycle.test.tsx
@@ -142,7 +142,7 @@ describe('TeamsIntegrationSettings add-on lifecycle + stale manifest', () => {
     // Configuration/history is preserved: the manage view still renders.
     expect(screen.getByText('Diagnostics & Test Message')).toBeInTheDocument();
     // Same renew destination as the paywall.
-    expect(screen.getByRole('link', { name: /Renew Teams add-on/i })).toHaveAttribute('href', '/msp/account');
+    expect(screen.getByRole('link', { name: /Renew Teams add-on/i })).toHaveAttribute('href', '/msp/add-ons?addon=teams');
   });
 
   it('F065: hides the expired banner when the add-on is active', async () => {

--- a/packages/integrations/src/components/settings/integrations/teams/TeamsAddonExpiredBanner.tsx
+++ b/packages/integrations/src/components/settings/integrations/teams/TeamsAddonExpiredBanner.tsx
@@ -1,13 +1,15 @@
 'use client';
 
 import React from 'react';
+import Link from 'next/link';
 import { Alert, AlertDescription, AlertTitle } from '@alga-psa/ui/components/Alert';
 import { Button } from '@alga-psa/ui/components/Button';
 import { AlertTriangle, ExternalLink } from 'lucide-react';
 import { useTranslation } from '@alga-psa/ui/lib/i18n/client';
+import { ADD_ONS } from '@alga-psa/types';
+import { getAddOnDestination } from '../../../../lib/addOnNavigation';
 
-// Same renew destination as the paywall CTA (Account Management add-on purchase).
-const TEAMS_ADDON_PURCHASE_URL = '/msp/account';
+const TEAMS_ADDON_DESTINATION = getAddOnDestination(ADD_ONS.TEAMS);
 
 export function TeamsAddonExpiredBanner() {
   const { t } = useTranslation('msp/integrations');
@@ -26,10 +28,10 @@ export function TeamsAddonExpiredBanner() {
           })}
         </p>
         <Button id="teams-addon-expired-renew" asChild size="sm">
-          <a href={TEAMS_ADDON_PURCHASE_URL}>
+          <Link href={TEAMS_ADDON_DESTINATION}>
             <ExternalLink className="mr-2 h-4 w-4" />
             {t('integrations.teams.settings.addonExpiredBanner.cta', { defaultValue: 'Renew Teams add-on' })}
-          </a>
+          </Link>
         </Button>
       </AlertDescription>
     </Alert>

--- a/packages/integrations/src/components/settings/integrations/teams/TeamsPaywallCard.test.tsx
+++ b/packages/integrations/src/components/settings/integrations/teams/TeamsPaywallCard.test.tsx
@@ -31,7 +31,7 @@ describe('TeamsPaywallCard (F064)', () => {
     expect(screen.getByText(/recordings and transcripts/i)).toBeInTheDocument();
 
     const cta = await screen.findByRole('link', { name: /Purchase Teams add-on/i });
-    expect(cta).toHaveAttribute('href', '/msp/account');
+    expect(cta).toHaveAttribute('href', '/msp/add-ons?addon=teams');
     expect(document.querySelector('#teams-paywall-non-billing')).not.toBeInTheDocument();
   });
 

--- a/packages/integrations/src/components/settings/integrations/teams/TeamsPaywallCard.tsx
+++ b/packages/integrations/src/components/settings/integrations/teams/TeamsPaywallCard.tsx
@@ -1,14 +1,16 @@
 'use client';
 
 import React from 'react';
+import Link from 'next/link';
 import { Button } from '@alga-psa/ui/components/Button';
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@alga-psa/ui/components/Card';
 import { CheckCircle2, ExternalLink } from 'lucide-react';
 import { useTranslation } from '@alga-psa/ui/lib/i18n/client';
+import { ADD_ONS } from '@alga-psa/types';
 import { getTeamsAddonPurchaseAccess } from '../../../../actions';
+import { getAddOnDestination } from '../../../../lib/addOnNavigation';
 
-// Deep link to Account Management, where billing admins purchase add-ons.
-const TEAMS_ADDON_PURCHASE_URL = '/msp/account';
+const TEAMS_ADDON_DESTINATION = getAddOnDestination(ADD_ONS.TEAMS);
 
 const INCLUDED_FEATURES = [
   { key: 'tab', defaultValue: 'Personal tab: open Alga PSA inside Microsoft Teams.' },
@@ -67,10 +69,10 @@ export function TeamsPaywallCard() {
 
         {canPurchase ? (
           <Button id="teams-paywall-purchase" asChild>
-            <a href={TEAMS_ADDON_PURCHASE_URL}>
+            <Link href={TEAMS_ADDON_DESTINATION}>
               <ExternalLink className="mr-2 h-4 w-4" />
               {t('integrations.teams.settings.paywall.cta', { defaultValue: 'Purchase Teams add-on' })}
-            </a>
+            </Link>
           </Button>
         ) : (
           <p id="teams-paywall-non-billing" className="text-sm text-muted-foreground">

--- a/packages/integrations/src/lib/addOnNavigation.ts
+++ b/packages/integrations/src/lib/addOnNavigation.ts
@@ -1,0 +1,8 @@
+import type { AddOnKey } from '@alga-psa/types';
+
+export const ADD_ONS_DESTINATION_PATH = '/msp/add-ons';
+
+export function getAddOnDestination(addOn: AddOnKey): string {
+  const searchParams = new URLSearchParams({ addon: addOn });
+  return `${ADD_ONS_DESTINATION_PATH}?${searchParams.toString()}`;
+}

--- a/server/public/locales/de/msp/account.json
+++ b/server/public/locales/de/msp/account.json
@@ -172,6 +172,9 @@
     "sending": "Wird gesendet...",
     "requestPremiumTrial": "Premium-Testphase anfordern"
   },
+  "addOns": {
+    "title": "Add-ons"
+  },
   "aiAssistant": {
     "statusActive": "Aktiv",
     "statusAvailable": "Verfügbar",

--- a/server/public/locales/en/msp/account.json
+++ b/server/public/locales/en/msp/account.json
@@ -172,6 +172,9 @@
     "sending": "Sending...",
     "requestPremiumTrial": "Request Premium Trial"
   },
+  "addOns": {
+    "title": "Add-ons"
+  },
   "aiAssistant": {
     "statusActive": "Active",
     "statusAvailable": "Available",

--- a/server/public/locales/es/msp/account.json
+++ b/server/public/locales/es/msp/account.json
@@ -172,6 +172,9 @@
     "sending": "Enviando...",
     "requestPremiumTrial": "Solicitar prueba Premium"
   },
+  "addOns": {
+    "title": "Complementos"
+  },
   "aiAssistant": {
     "statusActive": "Activo",
     "statusAvailable": "Disponible",

--- a/server/public/locales/fr/msp/account.json
+++ b/server/public/locales/fr/msp/account.json
@@ -172,6 +172,9 @@
     "sending": "Envoi...",
     "requestPremiumTrial": "Demander un essai Premium"
   },
+  "addOns": {
+    "title": "Modules complémentaires"
+  },
   "aiAssistant": {
     "statusActive": "Actif",
     "statusAvailable": "Disponible",

--- a/server/public/locales/it/msp/account.json
+++ b/server/public/locales/it/msp/account.json
@@ -172,6 +172,9 @@
     "sending": "Invio in corso...",
     "requestPremiumTrial": "Richiedi Prova Premium"
   },
+  "addOns": {
+    "title": "Componenti aggiuntivi"
+  },
   "aiAssistant": {
     "statusActive": "Attivo",
     "statusAvailable": "Disponibile",

--- a/server/public/locales/nl/msp/account.json
+++ b/server/public/locales/nl/msp/account.json
@@ -172,6 +172,9 @@
     "sending": "Verzenden...",
     "requestPremiumTrial": "Premium-proefperiode aanvragen"
   },
+  "addOns": {
+    "title": "Add-ons"
+  },
   "aiAssistant": {
     "statusActive": "Actief",
     "statusAvailable": "Beschikbaar",

--- a/server/public/locales/pl/msp/account.json
+++ b/server/public/locales/pl/msp/account.json
@@ -172,6 +172,9 @@
     "sending": "Wysyłanie...",
     "requestPremiumTrial": "Poproś o Okres Próbny Premium"
   },
+  "addOns": {
+    "title": "Dodatki"
+  },
   "aiAssistant": {
     "statusActive": "Aktywny",
     "statusAvailable": "Dostępny",

--- a/server/public/locales/pt/msp/account.json
+++ b/server/public/locales/pt/msp/account.json
@@ -172,6 +172,9 @@
     "sending": "Enviando...",
     "requestPremiumTrial": "Solicite avaliação premium"
   },
+  "addOns": {
+    "title": "Complementos"
+  },
   "aiAssistant": {
     "statusActive": "Ativo",
     "statusAvailable": "Disponível",

--- a/server/public/locales/xx/msp/account.json
+++ b/server/public/locales/xx/msp/account.json
@@ -172,6 +172,9 @@
     "sending": "11111",
     "requestPremiumTrial": "11111"
   },
+  "addOns": {
+    "title": "11111"
+  },
   "aiAssistant": {
     "statusActive": "11111",
     "statusAvailable": "11111",

--- a/server/public/locales/yy/msp/account.json
+++ b/server/public/locales/yy/msp/account.json
@@ -172,6 +172,9 @@
     "sending": "55555",
     "requestPremiumTrial": "55555"
   },
+  "addOns": {
+    "title": "55555"
+  },
   "aiAssistant": {
     "statusActive": "55555",
     "statusAvailable": "55555",

--- a/server/src/app/msp/add-ons/layout.tsx
+++ b/server/src/app/msp/add-ons/layout.tsx
@@ -1,0 +1,9 @@
+import type { Metadata } from 'next';
+
+export const metadata: Metadata = {
+  title: 'Add-ons',
+};
+
+export default function AddOnsLayout({ children }: Readonly<{ children: React.ReactNode }>) {
+  return children;
+}

--- a/server/src/app/msp/add-ons/page.tsx
+++ b/server/src/app/msp/add-ons/page.tsx
@@ -1,0 +1,26 @@
+import React from 'react';
+import AccountManagement from '@/empty/components/settings/account/AccountManagement';
+import { ADD_ONS, type AddOnKey } from '@alga-psa/types';
+import { getServerTranslation } from '@alga-psa/ui/lib/i18n/serverOnly';
+
+type AddOnsPageProps = {
+  searchParams: Promise<{ addon?: string | string[] }>;
+};
+
+const ADD_ON_KEYS = new Set<string>(Object.values(ADD_ONS));
+
+function parseSelectedAddOn(addon: string | string[] | undefined): AddOnKey | undefined {
+  return typeof addon === 'string' && ADD_ON_KEYS.has(addon) ? (addon as AddOnKey) : undefined;
+}
+
+export default async function AddOnsPage({ searchParams }: AddOnsPageProps) {
+  const [{ addon }, { t }] = await Promise.all([searchParams, getServerTranslation(undefined, 'msp/account')]);
+  const selectedAddOn = parseSelectedAddOn(addon);
+
+  return (
+    <div className="container mx-auto p-4">
+      <h1 className="text-3xl font-bold mb-6">{t('addOns.title')}</h1>
+      <AccountManagement selectedAddOn={selectedAddOn} />
+    </div>
+  );
+}

--- a/server/src/lib/productSurfaceRegistry.ts
+++ b/server/src/lib/productSurfaceRegistry.ts
@@ -53,7 +53,7 @@ export const MSP_ROUTE_RULES: readonly RouteRule[] = [
   },
   {
     group: 'msp_core_helpdesk',
-    staticPrefixes: ['/msp/tickets', '/msp/create-ticket', '/msp/clients', '/msp/contacts', '/msp/knowledge-base', '/msp/reports', '/msp/settings', '/msp/profile', '/msp/security-settings', '/msp/account'],
+    staticPrefixes: ['/msp/tickets', '/msp/create-ticket', '/msp/clients', '/msp/contacts', '/msp/knowledge-base', '/msp/reports', '/msp/settings', '/msp/profile', '/msp/security-settings', '/msp/account', '/msp/add-ons'],
     behaviorByProduct: { psa: 'allowed', algadesk: 'allowed' },
   },
   {

--- a/server/src/test/unit/app/msp/add-ons/page.test.tsx
+++ b/server/src/test/unit/app/msp/add-ons/page.test.tsx
@@ -1,0 +1,49 @@
+/**
+ * @vitest-environment jsdom
+ */
+import React from 'react';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { cleanup, render } from '@testing-library/react';
+
+const accountManagementMock = vi.hoisted(() => vi.fn());
+
+vi.mock('@/empty/components/settings/account/AccountManagement', () => ({
+  default: (props: { selectedAddOn?: string }) => {
+    accountManagementMock(props);
+    return null;
+  },
+}));
+
+vi.mock('@alga-psa/ui/lib/i18n/serverOnly', () => ({
+  getServerTranslation: vi.fn().mockResolvedValue({
+    t: (key: string) => (key === 'addOns.title' ? 'Add-ons' : key),
+  }),
+}));
+
+import AddOnsPage from '@/app/msp/add-ons/page';
+
+afterEach(() => {
+  cleanup();
+  accountManagementMock.mockClear();
+});
+
+describe('/msp/add-ons', () => {
+  it('selects the Teams add-on from the canonical query parameter', async () => {
+    render(await AddOnsPage({ searchParams: Promise.resolve({ addon: 'teams' }) }));
+
+    expect(accountManagementMock).toHaveBeenCalledWith({
+      selectedAddOn: 'teams',
+    });
+  });
+
+  it.each([
+    ['an unknown key', 'not-an-addon'],
+    ['a repeated query parameter', ['teams', 'ai_assistant']],
+  ])('falls back to the normal account view for %s', async (_label, addon) => {
+    render(await AddOnsPage({ searchParams: Promise.resolve({ addon }) }));
+
+    expect(accountManagementMock).toHaveBeenCalledWith({
+      selectedAddOn: undefined,
+    });
+  });
+});

--- a/server/src/test/unit/app/pageTitles.metadata.test.ts
+++ b/server/src/test/unit/app/pageTitles.metadata.test.ts
@@ -110,6 +110,7 @@ describe('route title metadata coverage', () => {
     const staticMspRoutes = [
       ['server/src/app/msp/dashboard/page.tsx', 'Dashboard'],
       ['server/src/app/msp/account/layout.tsx', 'Account'],
+      ['server/src/app/msp/add-ons/layout.tsx', 'Add-ons'],
       ['server/src/app/msp/profile/layout.tsx', 'Profile'],
       ['server/src/app/msp/tickets/page.tsx', 'Tickets'],
       ['server/src/app/msp/clients/page.tsx', 'Clients'],

--- a/server/src/test/unit/components/integrations/IntegrationsSettingsPage.teams.test.tsx
+++ b/server/src/test/unit/components/integrations/IntegrationsSettingsPage.teams.test.tsx
@@ -257,5 +257,9 @@ describe('IntegrationsSettingsPage Teams placement', () => {
     expect(screen.queryByTestId('teams-integration-disabled-shell')).not.toBeInTheDocument();
     expect(screen.queryByText('Microsoft Teams integration disabled')).not.toBeInTheDocument();
     expect(screen.queryByText('Microsoft Teams integration is disabled for this tenant.')).not.toBeInTheDocument();
+    expect(screen.getByRole('link', { name: 'Manage add-ons' })).toHaveAttribute(
+      'href',
+      '/msp/add-ons?addon=teams',
+    );
   });
 });

--- a/server/src/test/unit/integrations/addOnNavigation.test.ts
+++ b/server/src/test/unit/integrations/addOnNavigation.test.ts
@@ -1,0 +1,9 @@
+import { describe, expect, it } from 'vitest';
+import { ADD_ONS } from '@alga-psa/types';
+import { getAddOnDestination } from '@alga-psa/integrations/lib/addOnNavigation';
+
+describe('getAddOnDestination', () => {
+  it('builds the canonical deep link for an add-on', () => {
+    expect(getAddOnDestination(ADD_ONS.TEAMS)).toBe('/msp/add-ons?addon=teams');
+  });
+});

--- a/server/src/test/unit/integrations/teamsAdminExperience.contract.test.ts
+++ b/server/src/test/unit/integrations/teamsAdminExperience.contract.test.ts
@@ -104,7 +104,18 @@ describe('Teams production-readiness admin experience (E6/E7) contracts', () => 
     const paywall = readRepoFile(`${TEAMS_DIR}/TeamsPaywallCard.tsx`);
     expect(paywall).toContain('id="teams-paywall-card"');
     expect(paywall).toContain('id="teams-paywall-purchase"');
-    expect(paywall).toContain("'/msp/account'");
+    expect(paywall).toContain('getAddOnDestination(ADD_ONS.TEAMS)');
+
+    const addOnNavigation = readRepoFile('packages/integrations/src/lib/addOnNavigation.ts');
+    expect(addOnNavigation).toContain("'/msp/add-ons'");
+
+    const accountManagement = readRepoFile('ee/server/src/components/settings/account/AccountManagement.tsx');
+    expect(accountManagement).toContain('selectedAddOn?: AddOnKey');
+    expect(accountManagement).toContain('id={`account-addon-${addOnSlug}`}');
+    expect(accountManagement).toContain('selectedCard.focus({ preventScroll: true })');
+
+    const ceDestination = readRepoFile('packages/ee/src/components/settings/account/AccountManagement.tsx');
+    expect(ceDestination).toContain('selectedAddOn?: string');
 
     const banner = readRepoFile(`${TEAMS_DIR}/TeamsAddonExpiredBanner.tsx`);
     expect(banner).toContain('id="teams-addon-expired-banner"');

--- a/server/src/test/unit/product/algadeskRouteAndApiBoundarySmoke.test.ts
+++ b/server/src/test/unit/product/algadeskRouteAndApiBoundarySmoke.test.ts
@@ -36,6 +36,8 @@ describe('AlgaDesk route/API boundary smoke', () => {
     // Account page hosts the self-serve AlgaDesk→AlgaPSA upgrade — open to both products.
     expect(resolveProductRouteBehavior('algadesk', '/msp/account')).toBe('allowed');
     expect(resolveProductRouteBehavior('psa', '/msp/account')).toBe('allowed');
+    expect(resolveProductRouteBehavior('algadesk', '/msp/add-ons')).toBe('allowed');
+    expect(resolveProductRouteBehavior('psa', '/msp/add-ons')).toBe('allowed');
   });
 
   it('T019: AlgaDesk API boundary allows ticket/client/contact/KB/email and denies representative PSA-only groups', () => {

--- a/server/src/test/unit/product/uiReachabilityCoherence.contract.test.ts
+++ b/server/src/test/unit/product/uiReachabilityCoherence.contract.test.ts
@@ -25,6 +25,7 @@ const PRODUCTS: ProductCode[] = ['algadesk', 'psa'];
 // without a real entry point is a product bug.
 const INTENTIONALLY_UNLINKED: Record<string, string> = {
   '/msp/account': 'reached via the header avatar menu → Account, not the sidebar',
+  '/msp/add-ons': 'reached via add-on notices and paywall CTAs, not the sidebar',
   '/msp/create-ticket': 'reached via the Quick Create button in the header, not the sidebar',
   '/msp/integrations': 'legacy path kept routable; the user-facing entry is /msp/settings/integrations',
   '/msp/test': 'internal test-only pages, deliberately unlinked from all navigation',


### PR DESCRIPTION
## Summary

Fixes the Teams add-on dead end by giving Teams notices and paywall CTAs one typed destination: `/msp/add-ons?addon=teams`.

- Adds the `/msp/add-ons` route, validates its `addon` query, and explicitly registers the route as allowed for PSA and AlgaDesk.
- In hosted EE, expands the add-on section, scrolls to and focuses the requested card, and gives cards stable accessible anchors and headings.
- In Community Edition, renders the shared Account Management upgrade stub instead of blank content.
- Updates the ordinary absent-entitlement notice as well as expired/paywall Teams CTAs to use the shared navigation helper.
- Adds route, navigation, metadata, product-boundary, contract, and absent-Teams link coverage, plus localized Add-ons headings.

## Validation

PASS. Exercised the real authenticated EE product without a simulator or mock. The absent-Teams notice showed **Manage add-ons** linking to `/msp/add-ons?addon=teams`; clicking it opened Add-ons and focused, scrolled to, and highlighted `#account-addon-teams`. `/msp/add-ons?addon=bogus` safely fell back without a 404 or invalid card. An isolated real Community server on port 3172 rendered the shared Account Management upgrade stub and was stopped afterward.

Port 3171 was initially down and was restarted from this worktree; it remains live. PostgreSQL 5472, PgBouncer 6472, and Redis 6380 answer. The requested alga-dev browser tab was created, but browser control hit the known cross-host RPC rejection, so real UI interaction used repository-installed Playwright with system Chrome. The printed dev password was rejected because of known local drift; only Glinda's hash was repaired with the repository helper, and final EE sign-in was verified.

Also completed successfully:

- 30 focused Teams, route-registry, product-boundary, and UI-reachability tests after rebasing onto current `main`
- Focused integration typecheck
- Full server typecheck with `NODE_OPTIONS=--max-old-space-size=16384`
- Community production build

## Not directly exercised / known concerns

- Expired-Teams and paywall CTA states were not directly exercised because the seeded tenant follows the ordinary absent-entitlement path and entitlement mutation was intentionally avoided.
- The focused Teams card still mislabels its action **Add AI Assistant**.
- Logs retain pre-existing Temporal-unavailable and missing `tenants.suspended_at` errors.
- No code changes were made during smoke testing. The pre-existing modified `package-lock.json` and untracked `server/.next-smoke-ce-alga0002212` artifact remain outside the commits.

## Evidence

Four assertion screenshots and a successful EE click-through WebM recording are in:

`/tmp/alga-smoke-evidence/teams-addon-paywall-route-20260802-172537`
