### PR TITLE
Public name for "Enterprise" is Pro

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Alga PSA is a professional services automation platform built for Managed Service Providers. It brings client records, service tickets, time tracking, contracts, billing, invoicing, documents, assets, reporting, and automation into one MSP-focused system.
 
-It is designed for teams that want more control over their PSA stack: self-hostable Community Edition code, a modern TypeScript/PostgreSQL architecture, and an Enterprise Edition path for commercially licensed modules and larger deployments.
+It is designed for teams that want more control over their PSA stack: self-hostable Community Edition code, a modern TypeScript/PostgreSQL architecture, and a Pro path for commercially licensed modules and larger deployments.
 
 <a href="https://www.nineminds.com/AlgaPSA-features">
   <img src="https://www.nineminds.com/imported-media/Overview%20Dashboard.png" alt="Alga PSA overview dashboard" width="900">
@@ -23,7 +23,7 @@ Alga PSA is built around the way MSPs operate with clients:
 - **Workflow automation** for turning repeatable ticket, billing, notification, and approval steps into managed processes with Event Catalog triggers and scheduled runs.
 - **Open-source core with self-hosting support** so MSPs and technical teams can keep control over deployment, data, and code review.
 
-Community Edition is the self-hostable AGPL core. Enterprise Edition covers commercially licensed modules and larger deployment needs. See [Editions and licensing](#editions-and-licensing) for details.
+Community Edition is the self-hostable AGPL core. Pro covers commercially licensed modules and larger deployment needs. See [Editions and licensing](#editions-and-licensing) for details.
 
 ## Features at a glance
 
@@ -151,7 +151,7 @@ The Quick start above runs the Community Edition stack with Docker Compose, whic
 
 The appliance ships as a single bootable image. It installs Ubuntu Server 24.04, brings up a self-contained Kubernetes runtime, and deploys AlgaPSA with its database, cache, and background workers. You boot the image, answer a short setup wizard, and sign in. There are no containers to assemble and no manifests to write.
 
-The free **Essentials** edition runs the open-source feature set and is community-supported. Each appliance includes a 15-day trial of the Enterprise feature set that you can start from inside the app, and paid editions add the integration layer, a support contract, and an SLA.
+The free **Essentials** edition runs the open-source feature set and is community-supported. Each appliance includes a 15-day trial of the Pro feature set that you can start from inside the app, and paid editions add the integration layer, a support contract, and an SLA.
 
 ### How it installs
 
@@ -291,7 +291,7 @@ Alga PSA uses multiple licenses:
 - Enterprise Edition (`ee/`): See `ee/LICENSE`
 - All other content: GNU Affero General Public License Version 3 (AGPL-3.0)
 
-See [LICENSE.md](LICENSE.md) for details. If your deployment model requires commercial terms or a license outside the AGPL core, visit [algapsa.com](https://algapsa.com) for Enterprise Edition and hosted deployment information.
+See [LICENSE.md](LICENSE.md) for details. If your deployment model requires commercial terms or a license outside the AGPL core, visit [algapsa.com](https://algapsa.com) for Pro and hosted deployment information.
 
 ## Contributing
 

--- a/docs/architecture/overview.md
+++ b/docs/architecture/overview.md
@@ -129,7 +129,7 @@ This document provides a high-level architectural overview of the open-source MS
 
 * **Interactions:** Tracks client interactions. See `server/src/lib/models/interactions.ts` and components under `server/src/components/interactions`.
 
-* **Mobile Access (EE):** Native apps for iOS and Android for MSP technicians, available on the App Store and Google Play as an Enterprise Edition feature (`TIER_FEATURES.MOBILE_ACCESS`). Self-hosted Enterprise Edition appliance users can connect the app to their own server by entering the server URL or scanning the **Connect this server** QR code on the MSP dashboard. Open-source Community Edition (CE) self-hosted servers do not support mobile app access; CE builds explicitly reject the mobile token exchange. Sign-in uses the browser-based mobile handoff flow (`/auth/mobile/handoff`) against the selected EE host.
+* **Mobile Access (EE):** Native apps for iOS and Android for MSP technicians, available on the App Store and Google Play as a Pro feature (`TIER_FEATURES.MOBILE_ACCESS`). Self-hosted Pro appliance users can connect the app to their own server by entering the server URL or scanning the **Connect this server** QR code on the MSP dashboard. Open-source Community Edition (CE) self-hosted servers do not support mobile app access; CE builds explicitly reject the mobile token exchange. Sign-in uses the browser-based mobile handoff flow (`/auth/mobile/handoff`) against the selected EE host.
   * Operator configuration for self-hosted EE appliances: set `NEXTAUTH_URL` to the server's public URL, configure at least one SSO provider (Google or Microsoft OAuth), and optionally set `ALGA_MOBILE_HOST_ALLOWLIST` to a comma-separated list of allowed hostnames. If unset or empty, any host is allowed.
   * See `ee/appliance/docs/mobile-app-access.md` for full operator setup.
   * Key files:
@@ -399,7 +399,7 @@ No code has been merged yet – this section serves as an architectural note so 
       ```
     
   * **Implementation Strategies:**
-    * UI Components: Display "Enterprise Feature" messages with upgrade information
+    * UI Components: Display "Pro Feature" messages with upgrade information
     * Services: Return appropriate HTTP responses (e.g., 403 Forbidden) with upgrade messages
     * Storage Providers: Throw clear enterprise-only errors
     * Example:

--- a/docs/getting-started/appliance_install.md
+++ b/docs/getting-started/appliance_install.md
@@ -19,7 +19,7 @@ You work in the application on port `3000`. You check its health on port `8080` 
 
 When you register, you receive an **install code** by email. The code binds the appliance to your tenant and applies the correct edition, so you do not pick an edition during setup.
 
-- **Essentials** runs the free, open-source feature set and is community-supported. The application offers a 15-day Enterprise trial you can start at any time from inside the app.
+- **Essentials** runs the free, open-source feature set and is community-supported. The application offers a 15-day Pro trial you can start at any time from inside the app.
 - **Paid editions** add the integration layer, a support contract, and an SLA.
 
 Install codes are single-use. Keep the registration email handy. You enter the code once, in the setup wizard.

--- a/docs/inbound-email/setup/microsoft.md
+++ b/docs/inbound-email/setup/microsoft.md
@@ -8,7 +8,7 @@ authorizes it.
 > them as read, or send replies. Configure ticket replies and notifications
 > separately under **Settings → Email → Outbound**.
 
-> Microsoft 365 inbound email is an Enterprise Edition feature. It is not
+> Microsoft 365 inbound email is a Pro feature. It is not
 > offered in Community Edition builds.
 
 ## Choose the hosted or self-hosted path

--- a/docs/integrations/hudu.md
+++ b/docs/integrations/hudu.md
@@ -3,7 +3,7 @@
 AlgaPSA connects to [Hudu](https://www.hudu.com/), an IT documentation platform,
 so you can see a client's Hudu documentation and credentials without leaving
 AlgaPSA. The integration is **read-only**: AlgaPSA pulls from Hudu and never
-writes back. It is an **Enterprise Edition** feature, and each tenant connects a
+writes back. It is a **Pro** feature, and each tenant connects a
 single Hudu instance.
 
 ## Connect to Hudu

--- a/docs/integrations/tactical-rmm.md
+++ b/docs/integrations/tactical-rmm.md
@@ -4,8 +4,8 @@ AlgaPSA connects to [Tactical RMM](https://tacticalrmm.com/), an open-source RMM
 platform, to bring your monitored devices into AlgaPSA as assets and to turn
 Tactical alerts into AlgaPSA records. The core integration reads from Tactical: it
 syncs clients and agents, ingests alerts by webhook and backfill, and pulls cached
-software inventory. It is available in both Community and Enterprise editions.
-Enterprise Edition adds remote actions that run scripts and commands on agents from
+software inventory. It is available in both Community Edition and Pro.
+Pro adds remote actions that run scripts and commands on agents from
 workflows. Each tenant connects a single Tactical instance.
 
 ## Before you connect (on the Tactical server)
@@ -91,9 +91,9 @@ Click **Ingest Software** to pull Tactical's cached software inventory in bulk f
 your mapped agents. AlgaPSA writes it to the software catalog and links it to each
 asset. This reads Tactical's cached data and does not trigger a per-agent refresh.
 
-## Remote actions (Enterprise Edition)
+## Remote actions (Pro)
 
-Enterprise Edition can drive Tactical from workflows. A workflow can list and
+Pro can drive Tactical from workflows. A workflow can list and
 inspect agents, run a script or a shell command on an agent, and reboot an agent,
 all through the same stored credentials. These actions run on the endpoint, so
 scope them carefully.

--- a/docs/integrations/teams-setup.md
+++ b/docs/integrations/teams-setup.md
@@ -2,7 +2,7 @@
 
 This runbook takes a tenant from zero to a verified, working Microsoft Teams integration: personal tab, bot, message extension, activity-feed notifications, and Teams meetings with recording/transcript capture. Meeting-organizer specifics (Exchange and Teams application access policies, organizer mailbox scoping) live in [Microsoft Teams Meetings Setup](teams-meetings-setup.md); this document links there rather than repeating them.
 
-The Teams integration is an Enterprise Edition add-on. The setup wizard in `Settings -> Integrations -> Microsoft Teams` walks through the same steps and links back to the sections below.
+The Teams integration is an add-on for Pro. The setup wizard in `Settings -> Integrations -> Microsoft Teams` walks through the same steps and links back to the sections below.
 
 ## Overview
 
@@ -31,7 +31,7 @@ The generated Teams app manifest registers the bot under the tenant's Microsoft 
 
 ## Prerequisites
 
-- Alga PSA Enterprise Edition with the Microsoft Teams add-on enabled for the tenant.
+- Alga PSA Pro with the Microsoft Teams add-on enabled for the tenant.
 - An Alga PSA deployment reachable over public HTTPS. `NEXT_PUBLIC_BASE_URL` (or `NEXTAUTH_URL`) must be set to that URL; the Teams app package and webhook URLs are derived from it.
 - Admin access to the Microsoft Entra admin center and the Azure portal.
 - Permission to upload custom apps in the Teams admin center (or a Teams custom-app policy that allows sideloading).

--- a/docs/mcp-server.md
+++ b/docs/mcp-server.md
@@ -39,9 +39,9 @@ Full details: [`packages/alga-mcp-connector/README.md`](../packages/alga-mcp-con
 
 A networked MCP endpoint (`POST /api/mcp`, Streamable HTTP / JSON-RPC) that authenticates
 **agents** via the tenant's identity provider and enforces governance: distinct agent
-identity, RBAC, and an exportable audit trail. Enterprise-only.
+identity, RBAC, and an exportable audit trail. Pro-only.
 
-The admin UI (**Settings → MCP Server**) is available to all Enterprise tenants. The server endpoints (`POST /api/mcp`, `/.well-known/oauth-protected-resource`, and the `/api/v1/mcp/*` admin APIs) are live for any Enterprise instance regardless of whether agents have been provisioned.
+The admin UI (**Settings → MCP Server**) is available to all Pro tenants. The server endpoints (`POST /api/mcp`, `/.well-known/oauth-protected-resource`, and the `/api/v1/mcp/*` admin APIs) are live for any Pro instance regardless of whether agents have been provisioned.
 
 ### Auth model — OAuth 2.1 resource server (IdP delegation)
 

--- a/docs/plans/2026-08-02-public-enterprise-name-pro-plan.md
+++ b/docs/plans/2026-08-02-public-enterprise-name-pro-plan.md
@@ -1,0 +1,237 @@
+# Public product naming: Enterprise to Pro
+
+## Decision summary
+
+Customer-facing product and upgrade copy should call the paid product **Pro**. The repository's implementation edition remains **Enterprise** internally. This is a terminology change, not an entitlement, packaging, edition-selection, billing, or data-model change.
+
+The implementation should use targeted replacements at existing user-visible boundaries. It should not introduce a new global `PUBLIC_EDITION_NAME` abstraction or mechanically replace every occurrence of `Enterprise`. The tier model already has a central display source: `packages/types/src/constants/tenantTiers.ts` exports `TIER_LABELS`, and `packages/ui/src/components/tier-gating/FeatureUpgradeNotice.tsx` already renders the required tier from that map. Edition-gated stubs and localized edition copy do not share that path, so they should be updated in place while preserving their existing seams.
+
+## Repository evidence
+
+- Branch: `feature/public-enterprise-name-pro`.
+- Planning base: `3e0a46fde2`, the current `origin/main` merge commit at inspection time.
+- The recent history includes edition-aware navigation and CE upgrade-prompt work, plus the adjacent `docs/plans/2026-08-02-edition-alias-cleanup-plan.md`. Those changes reinforce the distinction between edition wiring and public upgrade language.
+- The worktree already has unrelated modifications in `package-lock.json` and `packages/core/src/workSchedule.ts`. The implementation must not include or rewrite them.
+- Build/runtime edition values are split across `EDITION=ee`, `NEXT_PUBLIC_EDITION=enterprise`, `isEnterprise`, `@enterprise`, `MenuEdition = 'enterprise'`, and package/file names under `ee/`. These are active compatibility seams, not display labels.
+- Paid tenant tiers are `essentials`, `solo`, `pro`, and `premium`. `TIER_LABELS.pro` is already `Pro`, and tier-gated notices already use that label.
+
+## Terminology inventory
+
+### Terms that should be public
+
+Use `Pro` when the text is naming the paid product or telling a customer which product unlocks a feature.
+
+Examples in the current tree include:
+
+- `Enterprise Feature`, `Enterprise feature`, and `Enterprise Edition` headings and notices in CE/OSS fallback components.
+- Upgrade, licensing, trial, and hosted-deployment copy in `server/public/locales/*/msp/licensing.json`.
+- Extension page, extension-settings, chat, billing, policy, workflow, email, RMM, SSO, integration, and contract-simulator fallback copy.
+- Public documentation that describes the paid product rather than the build architecture.
+- A direct UI rendering of an edition-gated action error, if the application presents that exact error to a person.
+
+Preferred forms are `Pro feature`, `requires Pro`, `available in Pro`, `Alga PSA Pro`, and `Pro trial`. Do not invent `Pro Edition` where the existing sentence can simply say `Pro`.
+
+### Terms that already have the right tier meaning
+
+Keep these meanings and use the existing tier source:
+
+- `Solo`, `Pro`, and `Premium` tenant plans.
+- `TIER_LABELS`, `FEATURE_MINIMUM_TIER`, `TIER_FEATURE_MAP`, and `TIER_FEATURES`.
+- `FeatureUpgradeNotice`, `TierGate`, `ServerTierGate`, and `assertTierAccess` behavior.
+- Existing license-banner copy such as `Pro trial`, `Pro features`, and `Upgrade to Pro`.
+
+No tier value, tier rank, feature minimum, trial transition, Stripe mapping, or account-plan behavior changes.
+
+### Terms that must remain internal or compatibility-sensitive
+
+Keep the following unchanged unless a specific occurrence is rendered as customer-facing copy and is handled at that boundary:
+
+- `enterprise` and `ee` environment values, `NEXT_PUBLIC_EDITION`, `EDITION`, `isEnterprise`, `isEnterpriseEdition`, and related predicates.
+- `@enterprise`, `@ee`, `@product/*`, `MenuEdition`, `ProductEdition`, and package/file/directory names.
+- `ADD_ONS.ENTERPRISE`, `assertAddOnAccess`, Enterprise Stripe product/price identifiers, license metadata, database values, and serialized API enum values.
+- Translation key names such as `enterpriseFeature`, `enterpriseOnly`, `enterpriseHeading`, `requiresEnterprise`, and `eeDisabled`. Change their values when needed; do not rename keys in this card.
+- Technical comments, architecture guides, build/configuration guides, runbooks, generated OpenAPI/MCP registries, and test names when they describe the implementation edition rather than the public product.
+- Generic English usage such as “enterprise application,” “enterprise integrations,” “enterprise-grade,” customer/company names, and named add-ons such as the Enterprise AI Assistant when Enterprise is not the paid product label.
+
+## Plausible implementation boundaries
+
+### A. Global rename
+
+Replace every `Enterprise` occurrence with `Pro` across source, tests, docs, translations, generated artifacts, API responses, and identifiers.
+
+This is rejected. It would rename the edition-selection contract, break compatibility-sensitive error strings and generated descriptions, corrupt legitimate generic usage, and conflate the Enterprise build with the Pro tenant tier.
+
+### B. New central public-edition name source
+
+Add a shared constant or helper such as `PUBLIC_EDITION_NAME = 'Pro'`, route all edition-gated components through it, and add a new translation strategy around it.
+
+This is also rejected for this card. Most copy is already localized or embedded in existing product entry points, while edition-gated CE fallbacks are intentionally separate from tier-gated notices. A new helper would add a second naming system without removing the existing translation keys or handling grammatical context. It could be reconsidered later as part of a broader copy architecture effort.
+
+### C. Targeted public-copy replacements (selected)
+
+Update only rendered product naming, its existing localized values, the small set of public documentation statements, and tests that assert those surfaces. Preserve all technical seams and wire contracts unless a UI demonstrably exposes a response verbatim.
+
+This is the smallest coherent boundary. It aligns the paid product name with the existing Pro tier, avoids a code-wide semantic rename, and leaves CE/EE resolution and feature gating untouched.
+
+## Implementation plan
+
+### 1. Establish the copy rule at the source boundary
+
+Before editing, classify each `Enterprise` match as one of:
+
+1. Product/edition label shown to a customer: change to `Pro`.
+2. Tier or plan label: use `TIER_LABELS`/existing tier copy; do not duplicate a new constant.
+3. Named add-on or generic adjective: retain it unless product strategy explicitly says otherwise.
+4. Technical edition identifier or compatibility contract: retain it.
+5. API/action error: inspect consumers. Change only if the application renders the exact message to users; otherwise retain the wire text and map it to localized Pro copy at the UI edge if needed.
+
+Use this classification instead of a case-insensitive repository-wide replacement.
+
+### 2. Update direct user-visible fallback and stub components
+
+Update the rendered strings and metadata in the existing public/OSS surfaces, keeping exports, aliases, component names, route behavior, and CE/EE replacement seams intact. The initial source inventory includes:
+
+- `packages/product-billing/oss/entry.tsx`
+- `packages/product-chat/oss/entry.tsx`
+- `packages/product-auth-ee/oss/entry.tsx`
+- `packages/product-extensions/oss/entry.tsx`
+- `packages/product-settings-extensions/oss/entry.tsx`
+- `packages/product-extensions/pages/list.tsx`
+- `packages/product-extensions/pages/details.tsx`
+- `packages/product-extensions/pages/settings.tsx`
+- `packages/product-extensions-pages/oss/list.tsx`
+- `packages/product-extensions-pages/oss/details.tsx`
+- `packages/product-extensions-pages/oss/settings.tsx`
+- `packages/ui/src/components/settings/extensions/InstallerPanel.tsx`
+- `packages/ui/src/components/settings/policy/PolicyManagement.tsx`
+- CE-facing placeholders under `packages/ee/src/components/`, including workflow, email, policy, SSO, RMM, and integration settings components.
+- Any `ee/server/src` page/component that is actually rendered as a public placeholder, such as the workflow-run, extension, or billing-simulator fallback. Do not edit comments solely because they contain Enterprise.
+
+Examples of intended outcomes:
+
+- `Enterprise Feature` becomes `Pro Feature` in a product-gated placeholder.
+- `The workflow system is only available in the Enterprise Edition` becomes `The workflow system is only available in Pro`.
+- `Extensions (Enterprise)` and `Learn about Enterprise` become `Extensions (Pro)` and `Learn about Pro` when they are rendered in the customer UI.
+- A sentence such as `Advanced authorization bundle management is available in Enterprise Premium` should be corrected to the actual public tier wording, likely `Premium`, rather than blindly becoming `Pro Premium`. Confirm the required tier from `FEATURE_MINIMUM_TIER` before editing.
+
+Do not replace `Enterprise` in a component comment, import seam, test description, or code identifier just because the neighboring UI copy changes.
+
+### 3. Update existing localization values without renaming keys
+
+Keep the current namespace and key structure. Update English values and the corresponding translated values for the public product references in every maintained locale: `de`, `en`, `es`, `fr`, `it`, `nl`, `pl`, and `pt`. Preserve the pseudo-locale key/value strategy for `xx` and `yy`; their placeholder values are not translation copy.
+
+The initial English inventory includes these namespaces and keys:
+
+- `msp/licensing.json`: `reduceModal.enterpriseOnly`, `purchaseForm.enterpriseOnlyHosted`, `workflowDesigner.enterpriseHeading`, and `workflowDesigner.unavailable`.
+- `msp/extensions.json`: `enterpriseFeature.*`, `settings.enterpriseOnly.*`, `page.description`, `detail.metadataTitle`, `detailsPage.description`, and `settingsPage.description`.
+- `msp/core.json`: `rightSidebar.enterpriseOnly`.
+- `msp/email-providers.json`: `enterpriseOnly` where it means the paid product. Retain `aiUpsell`'s `Enterprise AI Assistant add-on` if that is a distinct named add-on.
+- `msp/settings.json`: `enterpriseOnly.*`, `rmmEnterpriseNote`, and feature descriptions that use Enterprise as the edition gate. Retain the explicit Enterprise AI Assistant add-on wording and generic “enterprise application” wording.
+- `msp/contracts.json`: contract-simulator title/description where Enterprise is the edition label.
+- `msp/schedule.json`: `eeDisabled` value where it is shown to a user.
+- `msp/dashboard.json`: managed-email `enterpriseOnly` value.
+- `msp/user-activities.json`: workflow-task `enterpriseOnly` value.
+- `features/inventory.json`: `requiresEnterprise` value if it describes the Pro requirement rather than an add-on.
+- `msp/integrations.json`: public badge values such as `integrations.accounting.setup.badges.enterprise`; retain the key name and update only the displayed label if it is the product badge.
+
+The exact final list must come from a fresh English-locale search and call-site review. Do not change every string containing “enterprise”; for example, `enterprise` selector keys and `enterpriseSteps` keys remain stable, while their displayed values change only when they name the paid product.
+
+For translated sentences, keep `Pro` as the product/tier name and translate the surrounding grammar normally. Do not add new locale keys solely for this rename. Run the repository translation validator after edits to confirm identical key structures and preserved interpolation variables.
+
+### 4. Update public documentation selectively
+
+Update customer-facing product and installation prose where it labels the paid product:
+
+- `README.md` edition/licensing paragraphs and the appliance trial description.
+- `docs/getting-started/appliance_install.md` trial and upgrade wording.
+- Public feature setup documents such as `docs/inbound-email/setup/microsoft.md` and `docs/stripe-integration-setup.md` when their statement is a customer-facing availability claim.
+- Any other non-generated guide found by the same terminology inventory that says a feature requires the Enterprise product.
+
+Retain `Enterprise Edition` in technical documentation that explains the build, source ownership, or deployment contract, including `docs/getting-started/enterprise_edition_architecture.md`, CE/EE setup/configuration guides, `docs/tier-gating-guide.md` implementation terminology, and architecture/runbook material. If a technical guide contains both concepts, rewrite the customer-facing sentence to Pro but retain the code/configuration example as Enterprise.
+
+Do not edit generated SDK/OpenAPI/MCP artifacts in isolation. If a source API description is deliberately classified as public product copy, update the source and regenerate the artifact in the same implementation change; otherwise leave both unchanged for compatibility and scope control.
+
+### 5. Preserve CE and paid-edition behavior
+
+The change must not alter feature availability:
+
+- Community Edition continues to use the same CE fallbacks, edition-aware navigation, and `isEnterprise` checks. A CE user may see `Pro` in an upgrade message, but the build remains Community Edition.
+- Hosted/paid Enterprise builds continue to resolve the same EE implementations through the same aliases and environment values. Their public upgrade/license copy uses Pro where the text names the product.
+- `Essentials` remains the self-hosted appliance floor. `Solo`, `Pro`, and `Premium` retain their existing trial and billing transitions.
+- CE's tier bypass remains unchanged. Do not use `FeatureUpgradeNotice` to replace edition stubs unless the current component is genuinely tier-gated; CE edition availability and paid tenant tier access are different decisions.
+- No changes are made to navigation filtering, route guards, server-action authorization, Stripe product mapping, license enforcement, database values, or migrations.
+
+### 6. Handle API and action messages conservatively
+
+Audit direct consumers of strings in CE stubs and action/route modules, including calendar, Teams, Entra, QuickBooks, Xero, Hudu, chat, appliance, extension, and MCP boundaries.
+
+- If an existing page displays the response text verbatim, make the user-visible result say Pro. Prefer a UI translation/mapping boundary when the underlying error is also an external wire contract.
+- If the text is only a machine-facing response, log, internal exception, generated API description, or compatibility assertion, leave it as Enterprise Edition and document the reason in the implementation PR.
+- Update exact-string tests only for intentionally changed public output. Do not weaken tests to make a global rename pass.
+
+This keeps public copy accurate without silently changing integrations that may compare error messages.
+
+## Test plan
+
+### Focused component and contract coverage
+
+Update or add assertions for the public surfaces represented by the existing tests:
+
+- `server/src/test/unit/workflowsCeStubEntry.unit.test.tsx`: CE workflow placeholder says Pro while still rendering the same fallback.
+- `server/src/test/unit/ceAccountStub.unit.test.tsx`: account/billing placeholder uses the public product name selected by the copy rule.
+- `server/src/test/unit/components/integrations/EntraIntegrationPage.dynamicImport.test.tsx`: placeholder heading/body uses Pro.
+- `server/src/test/unit/app/pageTitles.metadata.test.ts`: extension metadata uses Pro only where the metadata is customer-visible.
+- `ee/server/src/__tests__/deploy/workflows-ee-deploy-no-stub.playwright.test.ts`: EE build does not accidentally render the CE Pro placeholder.
+- Existing extension, chat, billing, policy, email, integration, and license-render tests: assert the new public copy and unchanged component behavior.
+
+Add a small focused test only where no current test covers a changed public boundary. Avoid a repository-wide assertion that no `Enterprise` string remains; legitimate internal and generic uses must continue to exist.
+
+### Localization coverage
+
+- Run `node scripts/validate-translations.cjs`.
+- Run existing i18n contract tests such as `server/src/test/unit/i18n/mspDashboardBatch2b1.test.ts`, `server/src/test/unit/i18n/mspCoreBatch2b1.test.ts`, and `server/src/test/unit/layout/RightSidebar.i18n.test.tsx`, updating expected public values only.
+- Verify that all changed keys retain their interpolation variables and that `xx`/`yy` remain structurally valid.
+
+### Boundary and regression coverage
+
+- Run the targeted Vitest files for changed components and message boundaries.
+- Run the relevant CE/EE edition-resolution tests to prove aliases, edition predicates, and navigation behavior are unchanged.
+- Run `npm run build:ce` and `npm run build:ee` if the implementation changes product entry points or edition-resolved components. If a full build is unavailable, record the exact limitation and run the narrowest equivalent package tests.
+- Perform a final `rg` audit over user-visible source, locale values, and docs. The audit should show no unclassified product-label uses of `Enterprise`, while the allowlist of internal identifiers, technical docs, add-on names, generic adjectives, and compatibility strings remains intentionally present.
+
+## Exclusions
+
+This card does not include:
+
+- Renaming `Enterprise Edition` to `Pro` in environment variables, aliases, package names, directory names, TypeScript types, route paths, database/schema values, Stripe identifiers, license payloads, or feature flags.
+- Changing `Community Edition`, `Essentials`, `Solo`, or `Premium` semantics.
+- Changing tier entitlements, CE bypass behavior, edition-aware navigation, route/action guards, billing, licensing, migrations, or deployment topology.
+- Renaming translation keys or restructuring the i18n system.
+- Replacing edition-gated stubs with tier-gated components.
+- Renaming the distinct Enterprise AI Assistant or Enterprise add-on plumbing without a separate product decision.
+- A repository-wide rewrite of technical docs, generated API registries, historical plans, test names, comments, or logs.
+- Introducing a general-purpose public naming framework.
+
+## Verification checklist
+
+Before handoff, verify that:
+
+1. The English product UI says Pro in every classified edition/product label.
+2. Maintained translations preserve keys, variables, and locale structure, with Pro used consistently as the tier/product name.
+3. CE still renders the same fallback routes and messages functionally, and paid builds still resolve the same EE implementations.
+4. Existing Pro/Premium tier displays and trial flows are unchanged.
+5. Technical `enterprise`/`ee` identifiers and compatibility-sensitive messages remain unless a reviewed UI boundary required a public-copy change.
+6. Public docs use Pro for the product but retain Enterprise in build/architecture instructions where it is the actual implementation term.
+7. Focused tests, translation validation, and the appropriate CE/EE build or smoke checks pass.
+8. `git diff --check` passes and the final diff contains only the intended product-copy, locale, doc, and test changes. No unrelated worktree changes are staged.
+
+## Expected implementation file groups
+
+The implementation should be limited to the following groups after call-site verification:
+
+- Existing public/OSS and CE placeholder components listed above.
+- Existing locale JSON values under `server/public/locales/`.
+- Selected public product/install documentation.
+- Tests that assert the changed rendered copy, metadata, translations, or deliberately changed UI-facing errors.
+
+No new migration, API, shared edition helper, product-code change, or generated artifact is expected.

--- a/docs/stripe-integration-setup.md
+++ b/docs/stripe-integration-setup.md
@@ -16,7 +16,7 @@ The Stripe integration enables:
 
 ## Step-by-Step Setup
 
-> **Note:** This integration is for **Enterprise Edition (Hosted)** only. The migration is located in `ee/server/migrations/`.
+> **Note:** This integration is for **Pro (Hosted)** only. The migration is located in `ee/server/migrations/`.
 
 ### 1. Database Migration
 

--- a/ee/appliance/status-ui/app/setup/page.tsx
+++ b/ee/appliance/status-ui/app/setup/page.tsx
@@ -467,7 +467,7 @@ export default function SetupPage() {
                                   style={{ marginTop: "0.2rem" }}
                                 />
                                 <span>
-                                  <strong>Enterprise</strong> — 15-day free
+                                  <strong>Pro</strong> — 15-day free
                                   trial, then reverts to Essentials.
                                   <br />
                                   <small
@@ -502,7 +502,7 @@ export default function SetupPage() {
                                   <small
                                     style={{ color: "var(--muted, #6b7280)" }}
                                   >
-                                    You can start an Enterprise trial later from
+                                    You can start a Pro trial later from
                                     the in-app License page.
                                   </small>
                                 </span>

--- a/ee/server/src/__tests__/deploy/workflows-ee-deploy-no-stub.playwright.test.ts
+++ b/ee/server/src/__tests__/deploy/workflows-ee-deploy-no-stub.playwright.test.ts
@@ -7,7 +7,7 @@ const DEPLOY_PASSWORD = process.env.DEPLOY_PASSWORD;
 const DEPLOY_WORKFLOWS_PATH = process.env.DEPLOY_WORKFLOWS_PATH || '/msp/workflows?tab=designer';
 
 const CE_WORKFLOWS_STUB_TEXT =
-  'Workflow designer requires Enterprise Edition. Please upgrade to access this feature.';
+  'Workflow designer requires Pro. Please upgrade to access this feature.';
 
 test.describe('HV dev2 deploy: workflows (EE)', () => {
   test.skip(!DEPLOY_EMAIL || !DEPLOY_PASSWORD, 'DEPLOY_EMAIL and DEPLOY_PASSWORD are required.');

--- a/ee/server/src/__tests__/integration/workflows-ee-entry-smoke.playwright.test.ts
+++ b/ee/server/src/__tests__/integration/workflows-ee-entry-smoke.playwright.test.ts
@@ -47,8 +47,8 @@ test('EE build: workflows page loads without CE/OSS stub messaging', async ({ pa
     const workflowPage = new WorkflowDesignerPage(page);
     await workflowPage.goto(TEST_CONFIG.baseUrl);
 
-    await expect(page.getByText('Workflow designer requires Enterprise Edition. Please upgrade to access this feature.')).toHaveCount(0);
-    await expect(page.getByRole('heading', { name: 'Enterprise Feature' })).toHaveCount(0);
+    await expect(page.getByText('Workflow designer requires Pro. Please upgrade to access this feature.')).toHaveCount(0);
+    await expect(page.getByRole('heading', { name: 'Pro Feature' })).toHaveCount(0);
     await expect(workflowPage.header).toBeVisible();
   } finally {
     if (tenantData) {
@@ -57,4 +57,3 @@ test('EE build: workflows page loads without CE/OSS stub messaging', async ({ pa
     await db.destroy();
   }
 });
-

--- a/ee/server/src/components/billing/simulator/ContractDraftSimulator.tsx
+++ b/ee/server/src/components/billing/simulator/ContractDraftSimulator.tsx
@@ -32,7 +32,7 @@ export default function ContractDraftSimulator({
           setError(
             t("contractSimulator.unavailable.description", {
               defaultValue:
-                "The contract simulator is available in the Enterprise edition of Alga PSA.",
+                "The contract simulator is available in Alga PSA Pro.",
             }),
           );
           return;

--- a/ee/server/src/components/billing/simulator/ContractSimulatorWorkspace.tsx
+++ b/ee/server/src/components/billing/simulator/ContractSimulatorWorkspace.tsx
@@ -556,13 +556,13 @@ const ContractSimulatorWorkspace: React.FC<ContractSimulatorWorkspaceProps> = ({
       <div className="rounded-xl border border-[rgb(var(--color-border-200))] bg-[rgb(var(--color-card))] py-12 text-center">
         <p className="text-lg font-medium text-[rgb(var(--color-text-900))]">
           {t("contractSimulator.unavailable.title", {
-            defaultValue: "Enterprise Feature",
+            defaultValue: "Pro Feature",
           })}
         </p>
         <p className="mt-2 text-sm text-[rgb(var(--color-text-500))]">
           {t("contractSimulator.unavailable.description", {
             defaultValue:
-              "The contract simulator is available in the Enterprise edition of Alga PSA.",
+              "The contract simulator is available in Alga PSA Pro.",
           })}
         </p>
       </div>

--- a/ee/server/src/empty/app/msp/extensions/[id]/page.tsx
+++ b/ee/server/src/empty/app/msp/extensions/[id]/page.tsx
@@ -9,7 +9,7 @@ export default function Page({ params }: { params: { id: string } }) {
     <div className="p-6">
       <h1 className="text-xl font-semibold">Extension Not Available</h1>
       <p className="mt-2 text-sm text-gray-600">
-        The extensions system is available in the Enterprise Edition and is not
+        The extensions system is available in Pro and is not
         included in this Community Edition build.
       </p>
       <p className="mt-4 text-xs text-gray-500">Requested ID: {params.id}</p>

--- a/packages/auth/src/components/settings/policy/PolicyManagement.tsx
+++ b/packages/auth/src/components/settings/policy/PolicyManagement.tsx
@@ -10,11 +10,10 @@ export default function PolicyManagement() {
           Policy Management
         </Text>
         <Text>
-          Policy management is an Enterprise Edition feature. Please upgrade to access advanced policy
+          Policy management is a Pro feature. Please upgrade to access advanced policy
           controls.
         </Text>
       </Flex>
     </div>
   );
 }
-

--- a/packages/client-portal/src/components/licenses/ClientLicensesPage.tsx
+++ b/packages/client-portal/src/components/licenses/ClientLicensesPage.tsx
@@ -69,7 +69,7 @@ export default function ClientLicensesPage() {
     <div style={{ padding: '2rem' }}>
       <h1 style={{ fontSize: '1.5rem', fontWeight: 600, marginBottom: '0.5rem' }}>Appliance Licenses</h1>
       <p style={{ color: '#6b7280', fontSize: '0.875rem', marginBottom: '1.5rem' }}>
-        Your Alga appliance Enterprise license entitlements. Key documents are also available in the
+        Your Alga appliance Pro license entitlements. Key documents are also available in the
         Documents section.
       </p>
 

--- a/packages/client-portal/src/domain-settings/ClientPortalDomainSettings.tsx
+++ b/packages/client-portal/src/domain-settings/ClientPortalDomainSettings.tsx
@@ -37,12 +37,12 @@ const ClientPortalDomainSettings = () => {
             <AtSign className="h-5 w-5" />
             Custom Domain
             <Badge variant="secondary" className="uppercase text-[10px] tracking-wide">
-              Enterprise
+              Pro
             </Badge>
           </span>
         </CardTitle>
         <CardDescription>
-          Enterprise tenants can host the portal on a custom domain. Your default hosted address is shown below.
+          Pro tenants can host the portal on a custom domain. Your default hosted address is shown below.
         </CardDescription>
       </CardHeader>
       <CardContent>
@@ -57,7 +57,7 @@ const ClientPortalDomainSettings = () => {
                   {portalStatus?.canonicalHost ?? '—'}
                 </code>
                 <p className="text-xs text-gray-500">
-                  Upgrade to Enterprise to configure a branded customer portal domain and automated certificates.
+                  Upgrade to Pro to configure a branded customer portal domain and automated certificates.
                 </p>
               </div>
             )}

--- a/packages/ee/src/app/msp/extensions/[id]/page.tsx
+++ b/packages/ee/src/app/msp/extensions/[id]/page.tsx
@@ -10,7 +10,7 @@ export default function Page({ params }: any) {
     <div className="p-6">
       <h1 className="text-xl font-semibold">Extension Not Available</h1>
       <p className="mt-2 text-sm text-gray-600">
-        The extensions system is available in the Enterprise Edition and is not
+        The extensions system is available in Pro and is not
         included in this Community Edition build.
       </p>
       <p className="mt-4 text-xs text-gray-500">Requested ID: {params.id}</p>

--- a/packages/ee/src/app/msp/licenses/purchase/page.tsx
+++ b/packages/ee/src/app/msp/licenses/purchase/page.tsx
@@ -14,7 +14,7 @@ export default function LicensePurchasePage() {
         <AlertCircle className="h-12 w-12 mx-auto mb-4 text-muted-foreground" />
         <h1 className="text-2xl font-bold mb-2">License Purchase</h1>
         <p className="text-muted-foreground mb-4">
-          License purchasing is available in the Enterprise Edition for hosted deployments.
+          License purchasing is available in Pro for hosted deployments.
         </p>
         <p className="text-sm text-muted-foreground">
           Self-hosted Community Edition has unlimited users with no license restrictions or additional costs.

--- a/packages/ee/src/app/msp/licenses/purchase/success/page.tsx
+++ b/packages/ee/src/app/msp/licenses/purchase/success/page.tsx
@@ -14,7 +14,7 @@ export default function LicensePurchaseSuccessPage() {
         <AlertCircle className="h-12 w-12 mx-auto mb-4 text-muted-foreground" />
         <h1 className="text-2xl font-bold mb-2">License Purchase</h1>
         <p className="text-muted-foreground mb-4">
-          This feature is available in the Enterprise Edition only.
+          This feature is available in Pro only.
         </p>
       </Card>
     </div>

--- a/packages/ee/src/app/teams/auth/popup-complete/page.tsx
+++ b/packages/ee/src/app/teams/auth/popup-complete/page.tsx
@@ -5,7 +5,7 @@ export default function TeamsTabPopupCompletePage(): React.ReactElement {
     <div className="mx-auto max-w-3xl p-6">
       <div className="space-y-2 rounded-xl border border-gray-200 bg-white p-6 shadow-sm">
         <h1 className="text-lg font-semibold text-gray-900">Teams sign-in unavailable</h1>
-        <p className="text-sm text-gray-600">Microsoft Teams integration is only available in Enterprise Edition.</p>
+        <p className="text-sm text-gray-600">Microsoft Teams integration is only available in Pro.</p>
       </div>
     </div>
   );

--- a/packages/ee/src/app/teams/tab/page.tsx
+++ b/packages/ee/src/app/teams/tab/page.tsx
@@ -5,7 +5,7 @@ export default function TeamsTabPage(): React.ReactElement {
     <div className="mx-auto max-w-3xl p-6">
       <div className="space-y-2 rounded-xl border border-gray-200 bg-white p-6 shadow-sm">
         <h1 className="text-lg font-semibold text-gray-900">Teams tab unavailable</h1>
-        <p className="text-sm text-gray-600">Microsoft Teams integration is only available in Enterprise Edition.</p>
+        <p className="text-sm text-gray-600">Microsoft Teams integration is only available in Pro.</p>
       </div>
     </div>
   );

--- a/packages/ee/src/components/flow/DnDFlow.tsx
+++ b/packages/ee/src/components/flow/DnDFlow.tsx
@@ -5,10 +5,10 @@ const DnDFlow: React.FC = () => {
     <div className="flex items-center justify-center h-full">
       <div className="text-center p-8 max-w-2xl">
         <h2 className="text-2xl font-bold text-gray-900 mb-4">
-          Enterprise Feature
+          Pro Feature
         </h2>
         <p className="text-gray-600">
-          The workflow system is only available in the Enterprise Edition.
+          The workflow system is only available in Pro.
           Please upgrade your installation to access this feature.
         </p>
       </div>

--- a/packages/ee/src/components/licensing/LicensePurchaseForm.tsx
+++ b/packages/ee/src/components/licensing/LicensePurchaseForm.tsx
@@ -14,7 +14,7 @@ export default function LicensePurchaseForm() {
     <UpgradePrompt
       featureName={t('purchaseForm.title', { defaultValue: 'License purchase' })}
       pitch={t('purchaseForm.enterpriseOnlyHosted', {
-        defaultValue: 'Purchase and manage additional user licenses with a hosted Enterprise deployment.',
+        defaultValue: 'Purchase and manage additional user licenses with a hosted Alga PSA Pro deployment.',
       })}
       ctaId="upgrade-license-purchase-button"
     >

--- a/packages/ee/src/components/licensing/ReduceLicensesModal.tsx
+++ b/packages/ee/src/components/licensing/ReduceLicensesModal.tsx
@@ -32,7 +32,7 @@ export default function ReduceLicensesModal({
         </h2>
         <p className="text-muted-foreground mb-4">
           {t('reduceModal.enterpriseOnly', {
-            defaultValue: 'This feature is only available in the Enterprise Edition.'
+            defaultValue: 'This feature is only available in Pro.'
           })}
         </p>
         <button

--- a/packages/ee/src/components/settings/account/AccountManagement.tsx
+++ b/packages/ee/src/components/settings/account/AccountManagement.tsx
@@ -17,7 +17,7 @@ export default function AccountManagement(_props: AccountManagementProps) {
     <Card className="p-8 text-center">
       <AlertCircle className="h-12 w-12 mx-auto mb-4 text-muted-foreground" />
       <p className="text-muted-foreground mb-4">
-        Account management and billing features are available in the Enterprise Edition for hosted deployments.
+        Account management and billing features are available in Pro for hosted deployments.
       </p>
       <p className="text-sm text-muted-foreground">
         Self-hosted Community Edition has unlimited users with no license restrictions or billing.

--- a/packages/ee/src/components/settings/email/DnsRecordInstructions.tsx
+++ b/packages/ee/src/components/settings/email/DnsRecordInstructions.tsx
@@ -3,9 +3,8 @@ import React from 'react';
 export default function DnsRecordInstructions(): React.JSX.Element {
   return (
     <div className="p-6">
-      <h2 className="text-xl font-semibold mb-2">Enterprise Feature</h2>
-      <p className="text-gray-600">DNS record instructions require Enterprise Edition.</p>
+      <h2 className="text-xl font-semibold mb-2">Pro Feature</h2>
+      <p className="text-gray-600">DNS record instructions require Pro.</p>
     </div>
   );
 }
-

--- a/packages/ee/src/components/settings/email/ManagedDomainList.tsx
+++ b/packages/ee/src/components/settings/email/ManagedDomainList.tsx
@@ -3,9 +3,8 @@ import React from 'react';
 export default function ManagedDomainList(): React.JSX.Element {
   return (
     <div className="p-6">
-      <h2 className="text-xl font-semibold mb-2">Enterprise Feature</h2>
-      <p className="text-gray-600">Managed domains require Enterprise Edition.</p>
+      <h2 className="text-xl font-semibold mb-2">Pro Feature</h2>
+      <p className="text-gray-600">Managed domains require Pro.</p>
     </div>
   );
 }
-

--- a/packages/ee/src/components/settings/email/ManagedEmailSettings.tsx
+++ b/packages/ee/src/components/settings/email/ManagedEmailSettings.tsx
@@ -3,11 +3,10 @@ import React from 'react';
 export function ManagedEmailSettings(): React.JSX.Element {
   return (
     <div className="p-6">
-      <h2 className="text-xl font-semibold mb-2">Enterprise Feature</h2>
-      <p className="text-gray-600">Managed email settings require Enterprise Edition.</p>
+      <h2 className="text-xl font-semibold mb-2">Pro Feature</h2>
+      <p className="text-gray-600">Managed email settings require Pro.</p>
     </div>
   );
 }
 
 export default ManagedEmailSettings;
-

--- a/packages/ee/src/components/settings/extensions/ExtensionSettings.tsx
+++ b/packages/ee/src/components/settings/extensions/ExtensionSettings.tsx
@@ -12,7 +12,7 @@ export default function ExtensionSettings() {
     <div className="text-center py-8">
       <h3 className="text-lg font-medium text-gray-900 mb-2">Extension Settings Not Available</h3>
       <p className="text-gray-600">
-        Extension settings management is available in the Enterprise Edition of Alga PSA.
+        Extension settings management is available in Alga PSA Pro.
       </p>
     </div>
   );

--- a/packages/ee/src/components/settings/extensions/Extensions.tsx
+++ b/packages/ee/src/components/settings/extensions/Extensions.tsx
@@ -12,7 +12,7 @@ export default function Extensions() {
     <div className="text-center py-8">
       <h3 className="text-lg font-medium text-gray-900 mb-2">Extensions Not Available</h3>
       <p className="text-gray-600">
-        Extension management is available in the Enterprise Edition of Alga PSA.
+        Extension management is available in Alga PSA Pro.
       </p>
     </div>
   );

--- a/packages/ee/src/components/settings/extensions/ExtensionsSimple.tsx
+++ b/packages/ee/src/components/settings/extensions/ExtensionsSimple.tsx
@@ -12,7 +12,7 @@ export default function Extensions() {
     <div className="text-center py-8">
       <h3 className="text-lg font-medium text-gray-900 mb-2">Extensions Not Available</h3>
       <p className="text-gray-600">
-        Extension management is available in the Enterprise Edition of Alga PSA.
+        Extension management is available in Alga PSA Pro.
       </p>
     </div>
   );

--- a/packages/ee/src/components/settings/extensions/InstallExtensionSimple.tsx
+++ b/packages/ee/src/components/settings/extensions/InstallExtensionSimple.tsx
@@ -26,7 +26,7 @@ export default function InstallExtension() {
       <div className="text-center py-8">
         <h3 className="text-lg font-medium text-gray-900 mb-2">Extension Installation Not Available</h3>
         <p className="text-gray-600">
-          Extension installation is available in the Enterprise Edition of Alga PSA.
+          Extension installation is available in Alga PSA Pro.
         </p>
       </div>
     </div>

--- a/packages/ee/src/components/settings/integrations/HuduIntegrationSettings.tsx
+++ b/packages/ee/src/components/settings/integrations/HuduIntegrationSettings.tsx
@@ -12,9 +12,9 @@ import React from 'react';
 const HuduIntegrationSettings: React.FC = () => {
   return (
     <div className="text-center py-8 text-muted-foreground">
-      <p className="text-lg font-medium">Enterprise Feature</p>
+      <p className="text-lg font-medium">Pro Feature</p>
       <p className="mt-2 text-sm">
-        The Hudu IT documentation integration is available in the Enterprise edition of AlgaPSA.
+        The Hudu IT documentation integration is available in Alga PSA Pro.
       </p>
     </div>
   );

--- a/packages/ee/src/components/settings/integrations/HuntressIntegrationSettings.tsx
+++ b/packages/ee/src/components/settings/integrations/HuntressIntegrationSettings.tsx
@@ -11,7 +11,7 @@ export default function HuntressIntegrationSettings() {
     <div className="rounded-lg border p-6 text-center">
       <h3 className="text-base font-semibold">Huntress Integration</h3>
       <p className="mt-2 text-sm text-muted-foreground">
-        The Huntress security integration is an Enterprise feature.
+        The Huntress security integration is a Pro feature.
       </p>
     </div>
   );

--- a/packages/ee/src/components/settings/integrations/LevelIoIntegrationSettings.tsx
+++ b/packages/ee/src/components/settings/integrations/LevelIoIntegrationSettings.tsx
@@ -5,9 +5,9 @@ import React from 'react';
 const LevelIoIntegrationSettings: React.FC = () => {
   return (
     <div className="py-8 text-center text-muted-foreground">
-      <p className="text-lg font-medium">Enterprise Feature</p>
+      <p className="text-lg font-medium">Pro Feature</p>
       <p className="mt-2 text-sm">
-        Level.io RMM integration is available in the Enterprise edition of Alga PSA.
+        Level.io RMM integration is available in Alga PSA Pro.
       </p>
     </div>
   );

--- a/packages/ee/src/components/settings/integrations/NinjaOneIntegrationSettings.tsx
+++ b/packages/ee/src/components/settings/integrations/NinjaOneIntegrationSettings.tsx
@@ -12,9 +12,9 @@ import React from 'react';
 const NinjaOneIntegrationSettings: React.FC = () => {
   return (
     <div className="text-center py-8 text-muted-foreground">
-      <p className="text-lg font-medium">Enterprise Feature</p>
+      <p className="text-lg font-medium">Pro Feature</p>
       <p className="mt-2 text-sm">
-        NinjaOne RMM integration is available in the Enterprise edition of Alga PSA.
+        NinjaOne RMM integration is available in Alga PSA Pro.
       </p>
     </div>
   );

--- a/packages/ee/src/components/settings/integrations/TaniumIntegrationSettings.tsx
+++ b/packages/ee/src/components/settings/integrations/TaniumIntegrationSettings.tsx
@@ -5,9 +5,9 @@ import React from 'react';
 const TaniumIntegrationSettings: React.FC = () => {
   return (
     <div className="py-8 text-center text-muted-foreground">
-      <p className="text-lg font-medium">Enterprise Feature</p>
+      <p className="text-lg font-medium">Pro Feature</p>
       <p className="mt-2 text-sm">
-        Tanium RMM integration is available in the Enterprise edition of Alga PSA.
+        Tanium RMM integration is available in Alga PSA Pro.
       </p>
     </div>
   );

--- a/packages/ee/src/components/settings/integrations/entra/EntraIntegrationPage.tsx
+++ b/packages/ee/src/components/settings/integrations/entra/EntraIntegrationPage.tsx
@@ -9,9 +9,9 @@ interface EntraIntegrationPageProps {
 const EntraIntegrationPage: React.FC<EntraIntegrationPageProps> = () => {
   return (
     <div className="text-center py-8 text-muted-foreground">
-      <p className="text-lg font-medium">Enterprise Feature</p>
+      <p className="text-lg font-medium">Pro Feature</p>
       <p className="mt-2 text-sm">
-        Microsoft Entra integration is available in the Enterprise edition of Alga PSA.
+        Microsoft Entra integration is available in Alga PSA Pro.
       </p>
     </div>
   );

--- a/packages/ee/src/components/settings/integrations/entra/EntraIntegrationSummaryCard.tsx
+++ b/packages/ee/src/components/settings/integrations/entra/EntraIntegrationSummaryCard.tsx
@@ -5,9 +5,9 @@ import React from 'react';
 const EntraIntegrationSummaryCard: React.FC = () => {
   return (
     <div className="text-center py-8 text-muted-foreground">
-      <p className="text-lg font-medium">Enterprise Feature</p>
+      <p className="text-lg font-medium">Pro Feature</p>
       <p className="mt-2 text-sm">
-        Microsoft Entra integration is available in the Enterprise edition of Alga PSA.
+        Microsoft Entra integration is available in Alga PSA Pro.
       </p>
     </div>
   );

--- a/packages/ee/src/components/settings/policy/PolicyManagement.tsx
+++ b/packages/ee/src/components/settings/policy/PolicyManagement.tsx
@@ -3,7 +3,7 @@ export default function PolicyManagement() {
     <div className="space-y-4 rounded-lg border border-dashed border-muted-foreground/40 p-6 text-sm text-muted-foreground">
       <p className="font-semibold text-foreground">Authorization Bundle Library</p>
       <p>
-        Advanced authorization bundle management is available in Enterprise Premium. Upgrade to
+        Advanced authorization bundle management is available in Premium. Upgrade to
         configure narrowing bundles for roles, teams, users, and API keys.
       </p>
       <p>

--- a/packages/ee/src/components/settings/profile/ConnectSsoWrapper.tsx
+++ b/packages/ee/src/components/settings/profile/ConnectSsoWrapper.tsx
@@ -3,7 +3,7 @@ export default function ConnectSsoWrapper() {
     <div className="space-y-4 rounded-lg border border-dashed border-muted-foreground/40 p-6 text-sm text-muted-foreground">
       <p className="font-semibold text-foreground">Single Sign-On</p>
       <p>
-        SSO account linking is available in the Enterprise Edition. Upgrade to connect your
+        SSO account linking is available in Pro. Upgrade to connect your
         Google Workspace or Microsoft 365 account for seamless authentication.
       </p>
     </div>

--- a/packages/ee/src/components/settings/security/SsoBulkAssignment.tsx
+++ b/packages/ee/src/components/settings/security/SsoBulkAssignment.tsx
@@ -3,7 +3,7 @@ export default function SsoBulkAssignment() {
     <div className="space-y-4 rounded-lg border border-dashed border-muted-foreground/40 p-6 text-sm text-muted-foreground">
       <p className="font-semibold text-foreground">Single Sign-On Bulk Assignment</p>
       <p>
-        This feature is available in the Enterprise edition. Upgrade to manage Google Workspace and
+        This feature is available in Pro. Upgrade to manage Google Workspace and
         Microsoft 365 SSO assignments directly from the Security settings page.
       </p>
     </div>

--- a/packages/ee/src/components/workflow-run-studio/RunStudioShell.tsx
+++ b/packages/ee/src/components/workflow-run-studio/RunStudioShell.tsx
@@ -6,13 +6,12 @@ export default function RunStudioShell({ runId }: { runId: string }) {
   return (
     <div className="flex items-center justify-center h-full p-8">
       <div className="text-center max-w-2xl">
-        <h2 className="text-2xl font-bold text-gray-900 mb-4">Enterprise Feature</h2>
+        <h2 className="text-2xl font-bold text-gray-900 mb-4">Pro Feature</h2>
         <p className="text-gray-600">
-          Workflow run studio is only available in the Enterprise Edition.
+          Workflow run studio is only available in Pro.
         </p>
         <p className="text-sm text-gray-500 mt-3">Run id: {runId || '—'}</p>
       </div>
     </div>
   );
 }
-

--- a/packages/ee/src/workflows/entry.tsx
+++ b/packages/ee/src/workflows/entry.tsx
@@ -9,11 +9,11 @@ export const DnDFlow = () => {
     <div className="flex items-center justify-center h-64">
       <div className="text-center">
         <h2 className="text-xl font-semibold mb-2">
-          {t('workflowDesigner.enterpriseHeading', { defaultValue: 'Enterprise Feature' })}
+          {t('workflowDesigner.enterpriseHeading', { defaultValue: 'Pro Feature' })}
         </h2>
         <p className="text-gray-600">
           {t('workflowDesigner.unavailable', {
-            defaultValue: 'Workflow designer requires Enterprise Edition. Please upgrade to access this feature.'
+            defaultValue: 'Workflow designer requires Pro. Please upgrade to access this feature.'
           })}
         </p>
       </div>

--- a/packages/integrations/src/components/email/EmailProviderConfiguration.tsx
+++ b/packages/integrations/src/components/email/EmailProviderConfiguration.tsx
@@ -308,7 +308,7 @@ function EmailProviderConfigurationContent({
   const openEditDrawer = (provider: EmailProvider) => {
     if (!isEnterpriseEdition && provider.providerType === 'microsoft') {
       setError(t('configuration.feedback.enterpriseOnly', {
-        defaultValue: 'Microsoft 365 inbound email is only available in Enterprise Edition.',
+        defaultValue: 'Microsoft 365 inbound email is only available in Pro.',
       }));
       return;
     }

--- a/packages/integrations/src/components/settings/integrations/AccountingIntegrationsSetup.test.tsx
+++ b/packages/integrations/src/components/settings/integrations/AccountingIntegrationsSetup.test.tsx
@@ -78,8 +78,8 @@ describe('AccountingIntegrationsSetup live Xero contracts', () => {
     ).not.toBeDisabled();
     // No Coming Soon button — QBO is now enabled in EE
     expect(screen.queryByRole('button', { name: 'Coming Soon' })).not.toBeInTheDocument();
-    // Enterprise badge is present (at least one, for Xero and/or QBO)
-    expect(screen.getAllByText('Enterprise').length).toBeGreaterThan(0);
+    // Pro badge is present (at least one, for Xero and/or QBO)
+    expect(screen.getAllByText('Pro').length).toBeGreaterThan(0);
   });
 
   it('T002: non-enterprise mode hides the live Xero option', async () => {
@@ -109,7 +109,7 @@ describe('AccountingIntegrationsSetup live Xero contracts', () => {
     expect(screen.queryByTestId('xero-csv-settings-stub')).not.toBeInTheDocument();
   });
 
-  it('T010: enterprise mode shows the QuickBooks Online card with Enterprise badge and enabled button', async () => {
+  it('T010: enterprise mode shows the QuickBooks Online card with Pro badge and enabled button', async () => {
     const { default: AccountingIntegrationsSetup } = await import('./AccountingIntegrationsSetup');
 
     render(<AccountingIntegrationsSetup />);
@@ -119,7 +119,7 @@ describe('AccountingIntegrationsSetup live Xero contracts', () => {
     expect(
       within(qboCard as HTMLElement).getByRole('button', { name: 'Configure Integration' })
     ).not.toBeDisabled();
-    expect(within(qboCard as HTMLElement).getByText('Enterprise')).toBeInTheDocument();
+    expect(within(qboCard as HTMLElement).getByText('Pro')).toBeInTheDocument();
   });
 
   it('T011: non-enterprise mode hides the QuickBooks Online card', async () => {

--- a/packages/integrations/src/components/settings/integrations/AccountingIntegrationsSetup.tsx
+++ b/packages/integrations/src/components/settings/integrations/AccountingIntegrationsSetup.tsx
@@ -89,7 +89,7 @@ export default function AccountingIntegrationsSetup({ qboSyncHealthSlot, qboOnbo
           id: 'quickbooks_online',
           title: 'QuickBooks Online',
           description: t('integrations.accounting.setup.options.qbo.description', { defaultValue: 'Connect your realm to sync invoices and manage mappings.' }),
-          badge: { label: t('integrations.accounting.setup.badges.enterprise', { defaultValue: 'Enterprise' }), variant: 'secondary' },
+          badge: { label: t('integrations.accounting.setup.badges.enterprise', { defaultValue: 'Pro' }), variant: 'secondary' },
           highlights: [
             { label: t('integrations.accounting.setup.highlights.sync', { defaultValue: 'Sync' }), value: t('integrations.accounting.setup.highlightValues.twoWay', { defaultValue: '2-way' }) },
             { label: t('integrations.accounting.setup.highlights.delivery', { defaultValue: 'Delivery' }), value: t('integrations.accounting.setup.highlightValues.live', { defaultValue: 'Live' }) }
@@ -100,7 +100,7 @@ export default function AccountingIntegrationsSetup({ qboSyncHealthSlot, qboOnbo
           id: 'xero',
           title: 'Xero',
           description: t('integrations.accounting.setup.options.xero.description', { defaultValue: 'Connect your organisation with tenant-owned OAuth credentials for live accounting exports and mappings.' }),
-          badge: { label: t('integrations.accounting.setup.badges.enterprise', { defaultValue: 'Enterprise' }), variant: 'secondary' },
+          badge: { label: t('integrations.accounting.setup.badges.enterprise', { defaultValue: 'Pro' }), variant: 'secondary' },
           highlights: [
             { label: t('integrations.accounting.setup.highlights.sync', { defaultValue: 'Sync' }), value: t('integrations.accounting.setup.highlightValues.twoWay', { defaultValue: '2-way' }) },
             { label: t('integrations.accounting.setup.highlights.delivery', { defaultValue: 'Delivery' }), value: t('integrations.accounting.setup.highlightValues.live', { defaultValue: 'Live' }) }

--- a/packages/integrations/src/entra/components/oss/entry.tsx
+++ b/packages/integrations/src/entra/components/oss/entry.tsx
@@ -4,7 +4,7 @@ import { Card, CardContent } from '@alga-psa/ui/components/Card';
 const EnterpriseOnlyNotice = () => (
     <Card>
         <CardContent className="py-8 text-center text-muted-foreground">
-            Microsoft Entra Identity Integration is an Enterprise Feature.
+            Microsoft Entra Identity Integration is a Pro Feature.
         </CardContent>
     </Card>
 );

--- a/packages/inventory/src/components/GhostUsageReport.tsx
+++ b/packages/inventory/src/components/GhostUsageReport.tsx
@@ -474,7 +474,7 @@ export function GhostUsageReport({
             {aiStatus === null ? (
               <p className="text-sm text-gray-400">{t('ghostUsage.ai.checking', 'Checking AI availability…')}</p>
             ) : !aiStatus.available ? (
-              <p className="text-sm text-gray-500">{t('ghostUsage.ai.requiresEnterprise', 'AI triage requires Enterprise and the AI Assistant add-on.')}</p>
+              <p className="text-sm text-gray-500">{t('ghostUsage.ai.requiresEnterprise', 'AI triage requires Pro and the AI Assistant add-on.')}</p>
             ) : (
               <>
                 <Switch

--- a/packages/onboarding/src/actions/onboarding-progress.ts
+++ b/packages/onboarding/src/actions/onboarding-progress.ts
@@ -514,7 +514,7 @@ async function resolveEmailStep(tenantId: string): Promise<OnboardingStepServerS
         id: 'managed_email',
         status: 'blocked',
         lastUpdated: null,
-        blocker: 'Managed email domains are only available in the Enterprise edition.',
+        blocker: 'Managed email domains are only available in Pro.',
         blockerKey: 'onboarding.blockers.email.enterpriseOnly',
       };
     }

--- a/packages/product-auth-ee/oss/entry.tsx
+++ b/packages/product-auth-ee/oss/entry.tsx
@@ -7,9 +7,9 @@ export const parsePolicy = (_policyString: string) => {
 export const PolicyManagement: React.FC = () => (
   <div className="flex items-center justify-center h-64">
     <div className="text-center">
-      <h2 className="text-xl font-semibold mb-2">Enterprise Feature</h2>
+      <h2 className="text-xl font-semibold mb-2">Pro Feature</h2>
       <p className="text-gray-600">
-        Policy Management requires Enterprise Edition. Please upgrade to access this feature.
+        Policy Management requires Pro. Please upgrade to access this feature.
       </p>
     </div>
   </div>
@@ -19,4 +19,3 @@ export default {
   parsePolicy,
   PolicyManagement,
 };
-

--- a/packages/product-billing/oss/entry.tsx
+++ b/packages/product-billing/oss/entry.tsx
@@ -10,9 +10,9 @@ export const BillingDashboard: React.FC = () => {
   return (
     <div className="flex items-center justify-center h-64">
       <div className="text-center">
-        <h2 className="text-xl font-semibold mb-2">Enterprise Feature</h2>
+        <h2 className="text-xl font-semibold mb-2">Pro Feature</h2>
         <p className="text-gray-600">
-          Advanced billing features require Enterprise Edition. Please upgrade to access this feature.
+          Advanced billing features require Pro. Please upgrade to access this feature.
         </p>
       </div>
     </div>
@@ -23,9 +23,9 @@ export const InvoiceTemplates = () => {
   return (
     <div className="flex items-center justify-center h-64">
       <div className="text-center">
-        <h2 className="text-xl font-semibold mb-2">Enterprise Feature</h2>
+        <h2 className="text-xl font-semibold mb-2">Pro Feature</h2>
         <p className="text-gray-600">
-          Custom invoice templates require Enterprise Edition. Please upgrade to access this feature.
+          Custom invoice templates require Pro. Please upgrade to access this feature.
         </p>
       </div>
     </div>
@@ -36,9 +36,9 @@ export const PaymentProcessing = () => {
   return (
     <div className="flex items-center justify-center h-64">
       <div className="text-center">
-        <h2 className="text-xl font-semibold mb-2">Enterprise Feature</h2>
+        <h2 className="text-xl font-semibold mb-2">Pro Feature</h2>
         <p className="text-gray-600">
-          Advanced payment processing requires Enterprise Edition. Please upgrade to access this feature.
+          Advanced payment processing requires Pro. Please upgrade to access this feature.
         </p>
       </div>
     </div>
@@ -49,9 +49,9 @@ export const BillingReports = () => {
   return (
     <div className="flex items-center justify-center h-64">
       <div className="text-center">
-        <h2 className="text-xl font-semibold mb-2">Enterprise Feature</h2>
+        <h2 className="text-xl font-semibold mb-2">Pro Feature</h2>
         <p className="text-gray-600">
-          Advanced billing reports require Enterprise Edition. Please upgrade to access this feature.
+          Advanced billing reports require Pro. Please upgrade to access this feature.
         </p>
       </div>
     </div>
@@ -61,9 +61,9 @@ export const BillingReports = () => {
 export const PaymentSettings = () => {
   return (
     <div className="text-center py-8 text-muted-foreground">
-      <p className="text-lg font-medium">Enterprise Feature</p>
+      <p className="text-lg font-medium">Pro Feature</p>
       <p className="mt-2 text-sm">
-        Payment provider integration (Stripe) is available in the Enterprise edition of Alga PSA.
+        Payment provider integration (Stripe) is available in Alga PSA Pro.
       </p>
     </div>
   );
@@ -72,9 +72,9 @@ export const PaymentSettings = () => {
 export const StripeConnectionSettings: React.FC = () => {
   return (
     <div className="text-center py-8 text-muted-foreground">
-      <p className="text-lg font-medium">Enterprise Feature</p>
+      <p className="text-lg font-medium">Pro Feature</p>
       <p className="mt-2 text-sm">
-        Stripe payment integration is available in the Enterprise edition of Alga PSA.
+        Stripe payment integration is available in Alga PSA Pro.
       </p>
     </div>
   );
@@ -103,9 +103,9 @@ export const ContractDraftSimulator = () => {
 export const PaymentSettingsConfig = () => {
   return (
     <div className="text-center py-8 text-muted-foreground">
-      <p className="text-lg font-medium">Enterprise Feature</p>
+      <p className="text-lg font-medium">Pro Feature</p>
       <p className="mt-2 text-sm">
-        Payment settings configuration is available in the Enterprise edition of Alga PSA.
+        Payment settings configuration is available in Alga PSA Pro.
       </p>
     </div>
   );

--- a/packages/product-chat/oss/entry.tsx
+++ b/packages/product-chat/oss/entry.tsx
@@ -24,9 +24,9 @@ export const ChatPage = () => {
   return (
     <div className="flex items-center justify-center h-64">
       <div className="text-center">
-        <h2 className="text-xl font-semibold mb-2">Enterprise Feature</h2>
+        <h2 className="text-xl font-semibold mb-2">Pro Feature</h2>
         <p className="text-gray-600">
-          AI Chat features require Enterprise Edition. Please upgrade to access this feature.
+          AI Chat features require Pro. Please upgrade to access this feature.
         </p>
       </div>
     </div>
@@ -39,7 +39,7 @@ export const MessageComponent = () => {
   return (
     <div className="flex items-center justify-center h-32">
       <div className="text-center">
-        <p className="text-gray-600">Message features require Enterprise Edition.</p>
+        <p className="text-gray-600">Message features require Pro.</p>
       </div>
     </div>
   );
@@ -53,4 +53,3 @@ export default {
   ChatComponent,
   MessageComponent,
 };
-

--- a/packages/product-extensions-pages/oss/details.tsx
+++ b/packages/product-extensions-pages/oss/details.tsx
@@ -4,8 +4,7 @@ export default function Page() {
   return (
     <div className="p-6">
       <h1 className="text-xl font-semibold">Extension Details Unavailable</h1>
-      <p className="mt-2 text sm text-gray-600">This page is available in Enterprise Edition.</p>
+      <p className="mt-2 text sm text-gray-600">This page is available in Pro.</p>
     </div>
   );
 }
-

--- a/packages/product-extensions-pages/oss/list.tsx
+++ b/packages/product-extensions-pages/oss/list.tsx
@@ -4,8 +4,7 @@ export default function Page() {
   return (
     <div className="p-6">
       <h1 className="text-xl font-semibold">Extensions Not Available</h1>
-      <p className="mt-2 text-sm text-gray-600">Available in Enterprise Edition.</p>
+      <p className="mt-2 text-sm text-gray-600">Available in Pro.</p>
     </div>
   );
 }
-

--- a/packages/product-extensions-pages/oss/settings.tsx
+++ b/packages/product-extensions-pages/oss/settings.tsx
@@ -4,8 +4,7 @@ export default function Page() {
   return (
     <div className="p-6">
       <h1 className="text-xl font-semibold">Extension Settings Unavailable</h1>
-      <p className="mt-2 text-sm text-gray-600">This page is available in Enterprise Edition.</p>
+      <p className="mt-2 text-sm text-gray-600">This page is available in Pro.</p>
     </div>
   );
 }
-

--- a/packages/product-extensions/oss/entry.tsx
+++ b/packages/product-extensions/oss/entry.tsx
@@ -5,7 +5,7 @@ import { getServerTranslation } from '@alga-psa/ui/lib/i18n/serverOnly';
 
 // OSS stub implementation for Extensions feature
 export const metadata = {
-  title: 'Extensions - Enterprise Feature'
+  title: 'Extensions - Pro Feature'
 };
 
 export async function generateMetadata(): Promise<Metadata> {

--- a/packages/product-extensions/pages/details.tsx
+++ b/packages/product-extensions/pages/details.tsx
@@ -12,7 +12,7 @@ export default async function ExtensionDetailsPage() {
       </h1>
       <p className="text-gray-600 mt-2">
         {t('detailsPage.description', {
-          defaultValue: 'Extension details are available in Enterprise Edition.'
+          defaultValue: 'Extension details are available in Pro.'
         })}
       </p>
     </div>

--- a/packages/product-extensions/pages/list.tsx
+++ b/packages/product-extensions/pages/list.tsx
@@ -12,7 +12,7 @@ export default async function ExtensionsListPage() {
       </h1>
       <p className="text-gray-600 mt-2">
         {t('page.description', {
-          defaultValue: 'Extensions management is available in Enterprise Edition.'
+          defaultValue: 'Extensions management is available in Pro.'
         })}
       </p>
     </div>

--- a/packages/product-extensions/pages/settings.tsx
+++ b/packages/product-extensions/pages/settings.tsx
@@ -12,7 +12,7 @@ export default async function ExtensionSettingsPage() {
       </h1>
       <p className="text-gray-600 mt-2">
         {t('settingsPage.description', {
-          defaultValue: 'Extension settings are available in Enterprise Edition.'
+          defaultValue: 'Extension settings are available in Pro.'
         })}
       </p>
     </div>

--- a/packages/product-settings-extensions/oss/entry.tsx
+++ b/packages/product-settings-extensions/oss/entry.tsx
@@ -11,11 +11,11 @@ function EnterpriseFeatureStub({ featureKey, defaultFeature }: { featureKey: str
     <div className="flex items-center justify-center h-64">
       <div className="text-center">
         <h2 className="text-xl font-semibold mb-2">
-          {t('enterpriseFeature.title', { defaultValue: 'Enterprise Feature' })}
+          {t('enterpriseFeature.title', { defaultValue: 'Pro Feature' })}
         </h2>
         <p className="text-gray-600">
           {t('enterpriseFeature.description', {
-            defaultValue: '{{feature}} require Enterprise Edition. Please upgrade to access this feature.',
+            defaultValue: '{{feature}} require Pro. Please upgrade to access this feature.',
             feature: t(featureKey, { defaultValue: defaultFeature })
           })}
         </p>

--- a/packages/tenancy/src/__tests__/portalDomainStatus.test.ts
+++ b/packages/tenancy/src/__tests__/portalDomainStatus.test.ts
@@ -64,7 +64,7 @@ describe('getPortalDomainStatusForTenant', () => {
     expect(response.isEditable).toBe(false);
     expect(response.canonicalHost).toBe('tenant-.portal.algapsa.com');
     expect(response.verificationDetails).toEqual({ expected_cname: 'tenant-.portal.algapsa.com' });
-    expect(response.statusMessage).toMatch(/Enterprise/);
+    expect(response.statusMessage).toBe('Custom portal domains are available in Pro.');
   });
 
   it('maps a tenant-scoped record into the status response with ISO timestamps', async () => {

--- a/packages/tenancy/src/server/portalDomainStatus.ts
+++ b/packages/tenancy/src/server/portalDomainStatus.ts
@@ -29,7 +29,7 @@ function formatResponse(record: PortalDomain | null, canonicalHost: string): Por
     domain: record?.domain ?? null,
     canonicalHost,
     status: record?.status ?? 'disabled',
-    statusMessage: record?.statusMessage ?? 'Custom portal domains are available in the Enterprise edition.',
+    statusMessage: record?.statusMessage ?? 'Custom portal domains are available in Pro.',
     lastCheckedAt: toIsoString(record?.lastCheckedAt),
     verificationMethod: record?.verificationMethod ?? 'cname',
     verificationDetails: buildVerificationDetails(record, canonicalHost),
@@ -54,4 +54,3 @@ export async function getPortalDomainStatusForTenant(tenantId: string): Promise<
 
   return formatResponse(record, canonicalHost);
 }
-

--- a/packages/ui/src/components/UpgradePrompt.test.tsx
+++ b/packages/ui/src/components/UpgradePrompt.test.tsx
@@ -43,12 +43,12 @@ describe('UpgradePrompt', () => {
       </UpgradePrompt>,
     );
 
-    expect(screen.getByText('Enterprise edition')).toBeTruthy();
+    expect(screen.getByText('Pro')).toBeTruthy();
     expect(screen.getByRole('heading', { name: 'Microsoft Teams integration' })).toBeTruthy();
     expect(screen.getByText('Bring PSA work into Microsoft Teams.')).toBeTruthy();
     expect(screen.getByText('Tenant setup remains unchanged.')).toBeTruthy();
 
-    const cta = screen.getByRole('link', { name: /Explore Enterprise/ });
+    const cta = screen.getByRole('link', { name: /Explore Pro/ });
     expect(cta.getAttribute('href')).toBe(
       'https://www.nineminds.com/documentation/community-vs-enterprise-edition',
     );

--- a/packages/ui/src/components/UpgradePrompt.tsx
+++ b/packages/ui/src/components/UpgradePrompt.tsx
@@ -55,7 +55,7 @@ export function UpgradePrompt({
           <LockKeyhole aria-hidden="true" className="h-5 w-5" />
         </div>
         <p className="text-[10px] font-semibold uppercase tracking-wider text-[rgb(var(--color-text-400))]">
-          {t('upgradePrompt.editionLabel', { defaultValue: 'Enterprise edition' })}
+          {t('upgradePrompt.editionLabel', { defaultValue: 'Pro' })}
         </p>
         <h2 className="mt-2 text-lg font-bold text-[rgb(var(--color-text-900))]">
           {featureName}
@@ -67,7 +67,7 @@ export function UpgradePrompt({
             target={isExternalCta ? '_blank' : undefined}
             rel={isExternalCta ? 'noopener noreferrer' : undefined}
           >
-            {ctaLabel ?? t('upgradePrompt.defaultCta', { defaultValue: 'Explore Enterprise' })}
+            {ctaLabel ?? t('upgradePrompt.defaultCta', { defaultValue: 'Explore Pro' })}
             <ArrowRight aria-hidden="true" className="h-4 w-4" />
           </Link>
         </Button>

--- a/packages/ui/src/components/settings/extensions/InstallerPanel.tsx
+++ b/packages/ui/src/components/settings/extensions/InstallerPanel.tsx
@@ -14,20 +14,20 @@ export default function InstallerPanel() {
   return (
     <Card>
       <CardHeader>
-        <CardTitle>Extensions (Enterprise)</CardTitle>
+        <CardTitle>Extensions (Pro)</CardTitle>
         <CardDescription>
-          Extension installation and management are available in the Enterprise edition of Alga PSA.
+          Extension installation and management are available in Alga PSA Pro.
         </CardDescription>
       </CardHeader>
       <CardContent>
         <div className="flex flex-col items-center justify-center text-center py-10 space-y-3">
-          <div className="text-lg font-medium text-gray-900">Enterprise feature</div>
+          <div className="text-lg font-medium text-gray-900">Pro feature</div>
           <p className="text-sm text-gray-600">
-            The extensions installer is only available in Alga PSA Enterprise.
+            The extensions installer is only available in Alga PSA Pro.
           </p>
           <div className="pt-2">
             <Button id="extensions-enterprise-cta" variant="secondary" disabled>
-              Learn about Enterprise
+              Learn about Pro
             </Button>
           </div>
         </div>

--- a/packages/ui/src/components/settings/policy/PolicyManagement.tsx
+++ b/packages/ui/src/components/settings/policy/PolicyManagement.tsx
@@ -7,7 +7,7 @@ export default function PolicyManagement() {
     <div>
       <Flex direction="column" gap="4">
         <Text size="5" weight="bold">Policy Management</Text>
-        <Text>Policy management is an Enterprise Edition feature. Please upgrade to access advanced policy controls.</Text>
+        <Text>Policy management is a Pro feature. Please upgrade to access advanced policy controls.</Text>
       </Flex>
     </div>
   );

--- a/packages/user-activities/src/components/ActivityDetailViewerDrawer.tsx
+++ b/packages/user-activities/src/components/ActivityDetailViewerDrawer.tsx
@@ -460,7 +460,7 @@ export function ActivityDetailViewerDrawer({
               <div className="h-full p-6">
                 <h2 className="text-xl font-semibold mb-4">{t('drawer.workflowTaskTitle', { defaultValue: 'Workflow Task' })}</h2>
                 <div className="bg-gray-50 p-4 rounded-md">
-                  {t('drawer.enterpriseOnly', { defaultValue: 'Workflow tasks are an Enterprise feature.' })}
+                  {t('drawer.enterpriseOnly', { defaultValue: 'Workflow tasks are a Pro feature.' })}
                 </div>
               </div>
             );

--- a/scripts/guard-ce-workflows-next-build.mjs
+++ b/scripts/guard-ce-workflows-next-build.mjs
@@ -12,7 +12,7 @@ const nextDir = path.join(serverDir, '.next');
 const nextServerDir = path.join(nextDir, 'server');
 const nextStaticDir = path.join(nextDir, 'static');
 
-const needle = 'Workflow designer requires Enterprise Edition. Please upgrade to access this feature.';
+const needle = 'Workflow designer requires Pro. Please upgrade to access this feature.';
 const needleBytes = Buffer.from(needle, 'utf8');
 
 function walkFiles(rootDir) {
@@ -85,4 +85,3 @@ if (!hits.length) {
 }
 
 console.log(`[guard-ce-workflows-next-build] OK: found workflows CE stub string in CE build output (${hits.length} file(s))`);
-

--- a/scripts/guard-ee-workflows-next-build.mjs
+++ b/scripts/guard-ee-workflows-next-build.mjs
@@ -5,7 +5,7 @@ const nextDir = process.argv[2] ?? 'server/.next';
 const serverOutputDir = path.join(nextDir, 'server');
 
 const needles = [
-  'Workflow designer requires Enterprise Edition. Please upgrade to access this feature.',
+  'Workflow designer requires Pro. Please upgrade to access this feature.',
 ];
 
 async function walkFiles(dir) {
@@ -56,4 +56,3 @@ async function main() {
 }
 
 await main();
-

--- a/server/public/locales/de/common.json
+++ b/server/public/locales/de/common.json
@@ -80,8 +80,8 @@
     "printSelected": "Ausgewählte drucken ({{count}})"
   },
   "upgradePrompt": {
-    "editionLabel": "Enterprise-Edition",
-    "defaultCta": "Enterprise entdecken"
+    "editionLabel": "Pro",
+    "defaultCta": "Pro entdecken"
   },
   "status": {
     "loading": "Wird geladen...",

--- a/server/public/locales/de/features/inventory.json
+++ b/server/public/locales/de/features/inventory.json
@@ -425,7 +425,7 @@
       "classifyCandidates": "Kandidaten klassifizieren",
       "classifying": "Wird klassifiziert…",
       "didNotRun": "Die AI-Triage wurde nicht ausgeführt{{reason}}.",
-      "requiresEnterprise": "Die AI-Triage erfordert Enterprise und das Add-on AI Assistant.",
+      "requiresEnterprise": "Die AI-Triage erfordert Pro und das Add-on AI Assistant.",
       "runFailed": "Die AI-Triage ist fehlgeschlagen.",
       "toggleFailed": "Die AI-Triage-Einstellung konnte nicht geändert werden.",
       "toggleLabel": "AI-Triage — Kandidaten-Tickets mit dem AI-Add-on klassifizieren",

--- a/server/public/locales/de/msp/contracts.json
+++ b/server/public/locales/de/msp/contracts.json
@@ -2310,8 +2310,8 @@
       "title": "Simulierte Rechnungszeiträume"
     },
     "unavailable": {
-      "description": "Der Vertragssimulator ist in der Enterprise-Edition von Alga PSA verfügbar.",
-      "title": "Enterprise-Funktion"
+      "description": "Der Vertragssimulator ist in Alga PSA Pro verfügbar.",
+      "title": "Pro-Funktion"
     }
   }
 }

--- a/server/public/locales/de/msp/core.json
+++ b/server/public/locales/de/msp/core.json
@@ -273,7 +273,7 @@
   },
   "rightSidebar": {
     "title": "Chat",
-    "enterpriseOnly": "Die Chatfunktion ist nur in der Enterprise Edition verfügbar."
+    "enterpriseOnly": "Die Chatfunktion ist nur in Pro verfügbar."
   },
   "notifications": {
     "messages": {

--- a/server/public/locales/de/msp/dashboard.json
+++ b/server/public/locales/de/msp/dashboard.json
@@ -171,7 +171,7 @@
         "loadFailed": "Die Kalenderintegrationen konnten nicht geladen werden."
       },
       "email": {
-        "enterpriseOnly": "Verwaltete E-Mail-Domains sind nur in der Enterprise-Edition verfügbar.",
+        "enterpriseOnly": "Verwaltete E-Mail-Domains sind nur in Pro verfügbar.",
         "tenantRequired": "Ein Tenant-Kontext ist erforderlich, um den E-Mail-Onboarding-Status zu laden.",
         "loadFailed": "Die verwalteten E-Mail-Domains konnten nicht geladen werden.",
         "verificationFailed": "Die Verifizierung für {{domain}} ist fehlgeschlagen."

--- a/server/public/locales/de/msp/email-providers.json
+++ b/server/public/locales/de/msp/email-providers.json
@@ -11,7 +11,7 @@
       "resyncing": "{{providerName}} wird erneut synchronisiert...",
       "resyncError": "Die Neusynchronisierung des IMAP-Anbieters ist fehlgeschlagen",
       "resyncStarted": "Neusynchronisierung für {{providerName}} gestartet.",
-      "enterpriseOnly": "Eingehende E-Mails von Microsoft 365 sind nur in der Enterprise Edition verfügbar.",
+      "enterpriseOnly": "Eingehende E-Mails von Microsoft 365 sind nur in Pro verfügbar.",
       "loadProvidersError": "Failed to load email providers"
     },
     "editDrawer": {

--- a/server/public/locales/de/msp/extensions.json
+++ b/server/public/locales/de/msp/extensions.json
@@ -3,8 +3,8 @@
     "heading": "Erweiterungen"
   },
   "enterpriseFeature": {
-    "title": "Enterprise-Funktion",
-    "description": "Für {{feature}} ist die Enterprise-Edition erforderlich. Bitte führen Sie ein Upgrade durch, um auf diese Funktion zuzugreifen."
+    "title": "Pro-Funktion",
+    "description": "Für {{feature}} ist Pro erforderlich. Bitte führen Sie ein Upgrade durch, um auf diese Funktion zuzugreifen."
   },
   "settings": {
     "title": "Erweiterungsverwaltung",
@@ -14,8 +14,8 @@
       "install": "Installieren"
     },
     "enterpriseOnly": {
-      "title": "Enterprise-Funktion",
-      "description": "Erweiterungen sind in der Enterprise-Edition von Alga PSA verfügbar."
+      "title": "Pro-Funktion",
+      "description": "Erweiterungen sind in Alga PSA Pro verfügbar."
     },
     "links": {
       "needLogs": "Erweiterungsprotokolle benötigt?",
@@ -98,10 +98,10 @@
       "description": "Erweiterungen verwalten"
     },
     "title": "Erweiterungen",
-    "description": "Die Erweiterungsverwaltung ist in der Enterprise-Edition verfügbar."
+    "description": "Die Erweiterungsverwaltung ist in Pro verfügbar."
   },
   "detail": {
-    "metadataTitle": "Erweiterungen - Enterprise-Funktion",
+    "metadataTitle": "Erweiterungen - Pro-Funktion",
     "extensionId": "Erweiterungs-ID: {{id}}"
   },
   "runtime": {
@@ -121,7 +121,7 @@
       "description": "Erweiterungsdetails anzeigen"
     },
     "title": "Erweiterungsdetails",
-    "description": "Erweiterungsdetails sind in der Enterprise-Edition verfügbar."
+    "description": "Erweiterungsdetails sind in Pro verfügbar."
   },
   "settingsPage": {
     "metadata": {
@@ -129,7 +129,7 @@
       "description": "Erweiterungseinstellungen konfigurieren"
     },
     "title": "Erweiterungseinstellungen",
-    "description": "Erweiterungseinstellungen sind in der Enterprise-Edition verfügbar."
+    "description": "Erweiterungseinstellungen sind in Pro verfügbar."
   },
   "details": {
     "label": "Erweiterungsdetails",

--- a/server/public/locales/de/msp/integrations.json
+++ b/server/public/locales/de/msp/integrations.json
@@ -38,7 +38,7 @@
       "setup": {
         "activeConfiguration": "Aktive Konfiguration",
         "badges": {
-          "enterprise": "Enterprise"
+          "enterprise": "Pro"
         },
         "comingSoon": "Demnächst verfügbar",
         "configure": "Integration konfigurieren",

--- a/server/public/locales/de/msp/licensing.json
+++ b/server/public/locales/de/msp/licensing.json
@@ -1,11 +1,11 @@
 {
   "reduceModal": {
     "title": "Lizenzen reduzieren",
-    "enterpriseOnly": "Diese Funktion ist nur in der Enterprise-Edition verfügbar."
+    "enterpriseOnly": "Diese Funktion ist nur in Pro verfügbar."
   },
   "purchaseForm": {
     "title": "Lizenzkauf",
-    "enterpriseOnlyHosted": "Der Lizenzkauf ist in der Enterprise-Edition für gehostete Bereitstellungen verfügbar.",
+    "enterpriseOnlyHosted": "Der Lizenzkauf ist in Pro für gehostete Bereitstellungen verfügbar.",
     "communityEditionUnlimited": "Die selbst gehostete Community-Edition unterstützt unbegrenzt viele Benutzer ohne zusätzliche Kosten."
   },
   "purchasePage": {
@@ -167,8 +167,8 @@
     }
   },
   "workflowDesigner": {
-    "enterpriseHeading": "Enterprise-Funktion",
-    "unavailable": "Der Workflow-Designer erfordert die Enterprise Edition. Bitte upgraden Sie, um auf diese Funktion zuzugreifen."
+    "enterpriseHeading": "Pro-Funktion",
+    "unavailable": "Der Workflow-Designer erfordert Pro. Bitte upgraden Sie, um auf diese Funktion zuzugreifen."
   },
   "runStudio": {
     "unavailable": "Workflow Run Studio ist in dieser Edition nicht verfügbar. (runId: {{runId}})"

--- a/server/public/locales/de/msp/schedule.json
+++ b/server/public/locales/de/msp/schedule.json
@@ -516,7 +516,7 @@
         "valid": "Microsoft-Organisator erfolgreich verifiziert.",
         "validWithName": "Verifizierter Microsoft-Benutzer: {{displayName}}.",
         "reasons": {
-          "eeDisabled": "Die Verifizierung von Teams-Besprechungen ist nur in der Enterprise Edition verfügbar.",
+          "eeDisabled": "Die Verifizierung von Teams-Besprechungen ist nur in Pro verfügbar.",
           "notConfigured": "Die Teams-Integration muss aktiv sein, bevor ein Organisator verifiziert werden kann.",
           "userNotFound": "Microsoft konnte für diesen Organisatorwert keinen Benutzer finden.",
           "policyMissing": "Der Microsoft-Benutzer existiert, aber die Application Access Policy erlaubt die Besprechungserstellung noch nicht.",

--- a/server/public/locales/de/msp/settings.json
+++ b/server/public/locales/de/msp/settings.json
@@ -1741,8 +1741,8 @@
       "install": "Installieren"
     },
     "enterpriseOnly": {
-      "title": "Enterprise-Funktion",
-      "description": "Erweiterungen sind in der Enterprise-Edition von Alga PSA verfügbar."
+      "title": "Pro-Funktion",
+      "description": "Erweiterungen sind in Alga PSA Pro verfügbar."
     },
     "links": {
       "needLogs": "Erweiterungsprotokolle benötigt?",
@@ -2062,7 +2062,7 @@
   "integrations": {
     "betaNotice": "Einige Integrationen befinden sich noch in der Entwicklung. Bitte arbeiten Sie in einer Sandbox-Umgebung, wenn Sie diese evaluieren, und teilen Sie Ihr Feedback, um uns bei der Verbesserung zu helfen.",
     "emptyCategory": "Keine Integrationen in dieser Kategorie verfügbar.",
-    "rmmEnterpriseNote": "RMM-Integrationen sind in der Enterprise-Edition verfügbar.",
+    "rmmEnterpriseNote": "RMM-Integrationen sind in Pro verfügbar.",
     "categoryHeading": "{{label}}-Integrationen",
     "loading": {
       "payments": "Zahlungseinstellungen werden geladen..."
@@ -2086,7 +2086,7 @@
       },
       "calendar": {
         "label": "Kalender",
-        "description": "Enterprise-exklusive Kalendersynchronisation für Google und Outlook hält Disposition und Kundentermine synchron."
+        "description": "Pro-exklusive Kalendersynchronisation für Google und Outlook hält Disposition und Kundentermine synchron."
       },
       "providers": {
         "label": "Anbieter",

--- a/server/public/locales/de/msp/user-activities.json
+++ b/server/public/locales/de/msp/user-activities.json
@@ -143,7 +143,7 @@
       "title": "Ad-hoc-Element",
       "toggleDoneError": "Element konnte nicht aktualisiert werden."
     },
-    "enterpriseOnly": "Workflow-Aufgaben sind eine Enterprise-Funktion.",
+    "enterpriseOnly": "Workflow-Aufgaben sind eine Pro-Funktion.",
     "nextAction": "Nächste Aktion",
     "overdueSince": "Überfällig seit {{date}}",
     "dueOn": "Fällig am {{date}}",

--- a/server/public/locales/en/common.json
+++ b/server/public/locales/en/common.json
@@ -80,8 +80,8 @@
     "printSelected": "Print selected ({{count}})"
   },
   "upgradePrompt": {
-    "editionLabel": "Enterprise edition",
-    "defaultCta": "Explore Enterprise"
+    "editionLabel": "Pro",
+    "defaultCta": "Explore Pro"
   },
   "form": {
     "selectPlaceholder": "Select...",

--- a/server/public/locales/en/features/inventory.json
+++ b/server/public/locales/en/features/inventory.json
@@ -425,7 +425,7 @@
       "classifyCandidates": "Classify candidates",
       "classifying": "Classifying…",
       "didNotRun": "AI triage didn't run{{reason}}.",
-      "requiresEnterprise": "AI triage requires Enterprise and the AI Assistant add-on.",
+      "requiresEnterprise": "AI triage requires Pro and the AI Assistant add-on.",
       "runFailed": "AI triage failed.",
       "toggleFailed": "Couldn't change the AI triage setting.",
       "toggleLabel": "AI triage — classify candidate tickets with the AI add-on",

--- a/server/public/locales/en/msp/contracts.json
+++ b/server/public/locales/en/msp/contracts.json
@@ -2310,8 +2310,8 @@
       "title": "Simulated invoice periods"
     },
     "unavailable": {
-      "description": "The contract simulator is available in the Enterprise edition of Alga PSA.",
-      "title": "Enterprise Feature"
+      "description": "The contract simulator is available in Alga PSA Pro.",
+      "title": "Pro Feature"
     }
   }
 }

--- a/server/public/locales/en/msp/core.json
+++ b/server/public/locales/en/msp/core.json
@@ -625,7 +625,7 @@
   },
   "rightSidebar": {
     "title": "Chat",
-    "enterpriseOnly": "The chat feature is only available in the Enterprise Edition."
+    "enterpriseOnly": "The chat feature is only available in Pro."
   },
   "notifications": {
     "messages": {

--- a/server/public/locales/en/msp/dashboard.json
+++ b/server/public/locales/en/msp/dashboard.json
@@ -199,7 +199,7 @@
         "loadFailed": "Unable to load calendar integrations."
       },
       "email": {
-        "enterpriseOnly": "Managed email domains are only available in the Enterprise edition.",
+        "enterpriseOnly": "Managed email domains are only available in Pro.",
         "tenantRequired": "Tenant context is required to load email onboarding status.",
         "loadFailed": "Unable to load managed email domains.",
         "verificationFailed": "Verification for {{domain}} failed."

--- a/server/public/locales/en/msp/email-providers.json
+++ b/server/public/locales/en/msp/email-providers.json
@@ -11,7 +11,7 @@
       "resyncing": "Resyncing {{providerName}}...",
       "resyncError": "Failed to resync IMAP provider",
       "resyncStarted": "Resync started for {{providerName}}.",
-      "enterpriseOnly": "Microsoft 365 inbound email is only available in Enterprise Edition.",
+      "enterpriseOnly": "Microsoft 365 inbound email is only available in Pro.",
       "loadProvidersError": "Failed to load email providers"
     },
     "editDrawer": {

--- a/server/public/locales/en/msp/extensions.json
+++ b/server/public/locales/en/msp/extensions.json
@@ -3,8 +3,8 @@
     "heading": "Extensions"
   },
   "enterpriseFeature": {
-    "title": "Enterprise Feature",
-    "description": "{{feature}} require Enterprise Edition. Please upgrade to access this feature."
+    "title": "Pro Feature",
+    "description": "{{feature}} require Pro. Please upgrade to access this feature."
   },
   "settings": {
     "title": "Extension Management",
@@ -14,8 +14,8 @@
       "install": "Install"
     },
     "enterpriseOnly": {
-      "title": "Enterprise feature",
-      "description": "Extensions are available in the Enterprise edition of Alga PSA."
+      "title": "Pro feature",
+      "description": "Extensions are available in Alga PSA Pro."
     },
     "links": {
       "needLogs": "Need extension logs?",
@@ -98,10 +98,10 @@
       "description": "Manage extensions"
     },
     "title": "Extensions",
-    "description": "Extensions management is available in Enterprise Edition."
+    "description": "Extensions management is available in Pro."
   },
   "detail": {
-    "metadataTitle": "Extensions - Enterprise Feature",
+    "metadataTitle": "Extensions - Pro Feature",
     "extensionId": "Extension ID: {{id}}"
   },
   "runtime": {
@@ -121,7 +121,7 @@
       "description": "View extension details"
     },
     "title": "Extension Details",
-    "description": "Extension details are available in Enterprise Edition."
+    "description": "Extension details are available in Pro."
   },
   "settingsPage": {
     "metadata": {
@@ -129,7 +129,7 @@
       "description": "Configure extension settings"
     },
     "title": "Extension Settings",
-    "description": "Extension settings are available in Enterprise Edition."
+    "description": "Extension settings are available in Pro."
   },
   "details": {
     "label": "Extension Details",

--- a/server/public/locales/en/msp/integrations.json
+++ b/server/public/locales/en/msp/integrations.json
@@ -38,7 +38,7 @@
       "setup": {
         "activeConfiguration": "Active Configuration",
         "badges": {
-          "enterprise": "Enterprise"
+          "enterprise": "Pro"
         },
         "comingSoon": "Coming Soon",
         "configure": "Configure Integration",

--- a/server/public/locales/en/msp/licensing.json
+++ b/server/public/locales/en/msp/licensing.json
@@ -1,11 +1,11 @@
 {
   "reduceModal": {
     "title": "Reduce Licenses",
-    "enterpriseOnly": "This feature is only available in the Enterprise Edition."
+    "enterpriseOnly": "This feature is only available in Pro."
   },
   "purchaseForm": {
     "title": "License Purchase",
-    "enterpriseOnlyHosted": "License purchasing is available in the Enterprise Edition for hosted deployments.",
+    "enterpriseOnlyHosted": "License purchasing is available in Pro for hosted deployments.",
     "communityEditionUnlimited": "Self-hosted Community Edition has unlimited users at no additional cost."
   },
   "purchasePage": {
@@ -167,8 +167,8 @@
     }
   },
   "workflowDesigner": {
-    "enterpriseHeading": "Enterprise Feature",
-    "unavailable": "Workflow designer requires Enterprise Edition. Please upgrade to access this feature."
+    "enterpriseHeading": "Pro Feature",
+    "unavailable": "Workflow designer requires Pro. Please upgrade to access this feature."
   },
   "runStudio": {
     "unavailable": "Workflow Run Studio is not available in this edition. (runId: {{runId}})"

--- a/server/public/locales/en/msp/schedule.json
+++ b/server/public/locales/en/msp/schedule.json
@@ -516,7 +516,7 @@
         "valid": "Microsoft organizer verified successfully.",
         "validWithName": "Verified Microsoft user: {{displayName}}.",
         "reasons": {
-          "eeDisabled": "Teams meeting verification is only available in Enterprise Edition.",
+          "eeDisabled": "Teams meeting verification is only available in Pro.",
           "notConfigured": "Teams integration must be active before an organizer can be verified.",
           "userNotFound": "Microsoft could not find a user for that organizer value.",
           "policyMissing": "The Microsoft user exists, but the application access policy is not allowing meeting creation yet.",

--- a/server/public/locales/en/msp/settings.json
+++ b/server/public/locales/en/msp/settings.json
@@ -1741,8 +1741,8 @@
       "install": "Install"
     },
     "enterpriseOnly": {
-      "title": "Enterprise feature",
-      "description": "Extensions are available in the Enterprise edition of Alga PSA."
+      "title": "Pro feature",
+      "description": "Extensions are available in Alga PSA Pro."
     },
     "links": {
       "needLogs": "Need extension logs?",
@@ -2062,7 +2062,7 @@
   "integrations": {
     "betaNotice": "Some integrations are still in development. Please work in a sandbox environment when evaluating, and share your feedback to help us improve.",
     "emptyCategory": "No integrations available in this category.",
-    "rmmEnterpriseNote": "RMM integrations are available in the Enterprise edition.",
+    "rmmEnterpriseNote": "RMM integrations are available in Pro.",
     "categoryHeading": "{{label}} Integrations",
     "loading": {
       "payments": "Loading payment settings..."
@@ -2086,7 +2086,7 @@
       },
       "calendar": {
         "label": "Calendar",
-        "description": "Enterprise-only calendar sync for Google and Outlook keeps dispatch and client appointments aligned."
+        "description": "Pro-only calendar sync for Google and Outlook keeps dispatch and client appointments aligned."
       },
       "providers": {
         "label": "Providers",

--- a/server/public/locales/en/msp/user-activities.json
+++ b/server/public/locales/en/msp/user-activities.json
@@ -143,7 +143,7 @@
       "title": "Ad hoc item",
       "toggleDoneError": "Failed to update item."
     },
-    "enterpriseOnly": "Workflow tasks are an Enterprise feature.",
+    "enterpriseOnly": "Workflow tasks are a Pro feature.",
     "nextAction": "Next action",
     "overdueSince": "Overdue since {{date}}",
     "dueOn": "Due {{date}}",

--- a/server/public/locales/es/common.json
+++ b/server/public/locales/es/common.json
@@ -80,8 +80,8 @@
     "printSelected": "Imprimir seleccionados ({{count}})"
   },
   "upgradePrompt": {
-    "editionLabel": "Edición Enterprise",
-    "defaultCta": "Explorar Enterprise"
+    "editionLabel": "Pro",
+    "defaultCta": "Explorar Pro"
   },
   "status": {
     "loading": "Cargando...",

--- a/server/public/locales/es/features/inventory.json
+++ b/server/public/locales/es/features/inventory.json
@@ -425,7 +425,7 @@
       "classifyCandidates": "Clasificar candidatos",
       "classifying": "Clasificando…",
       "didNotRun": "La clasificación por IA no se ejecutó{{reason}}.",
-      "requiresEnterprise": "La clasificación por IA requiere Enterprise y el complemento Asistente de IA.",
+      "requiresEnterprise": "La clasificación por IA requiere Pro y el complemento Asistente de IA.",
       "runFailed": "La clasificación por IA falló.",
       "toggleFailed": "No se pudo cambiar la configuración de clasificación por IA.",
       "toggleLabel": "Clasificación por IA — clasifique tickets candidatos con el complemento de IA",

--- a/server/public/locales/es/msp/contracts.json
+++ b/server/public/locales/es/msp/contracts.json
@@ -2310,8 +2310,8 @@
       "title": "Períodos de factura simulados"
     },
     "unavailable": {
-      "description": "El simulador de contratos está disponible en la edición Enterprise de Alga PSA.",
-      "title": "Función Enterprise"
+      "description": "El simulador de contratos está disponible en Alga PSA Pro.",
+      "title": "Función Pro"
     }
   }
 }

--- a/server/public/locales/es/msp/core.json
+++ b/server/public/locales/es/msp/core.json
@@ -273,7 +273,7 @@
   },
   "rightSidebar": {
     "title": "Chat",
-    "enterpriseOnly": "La función de chat solo está disponible en la edición Enterprise."
+    "enterpriseOnly": "La función de chat solo está disponible en Pro."
   },
   "notifications": {
     "messages": {

--- a/server/public/locales/es/msp/dashboard.json
+++ b/server/public/locales/es/msp/dashboard.json
@@ -171,7 +171,7 @@
         "loadFailed": "No se pudieron cargar las integraciones de calendario."
       },
       "email": {
-        "enterpriseOnly": "Los dominios de correo administrados solo están disponibles en la edición Enterprise.",
+        "enterpriseOnly": "Los dominios de correo administrados solo están disponibles en Pro.",
         "tenantRequired": "Se requiere el contexto del tenant para cargar el estado de onboarding del correo.",
         "loadFailed": "No se pudieron cargar los dominios de correo administrados.",
         "verificationFailed": "La verificación de {{domain}} falló."

--- a/server/public/locales/es/msp/email-providers.json
+++ b/server/public/locales/es/msp/email-providers.json
@@ -11,7 +11,7 @@
       "resyncing": "Resincronizando {{providerName}}...",
       "resyncError": "No se pudo resincronizar el proveedor IMAP",
       "resyncStarted": "Se inició la resincronización para {{providerName}}.",
-      "enterpriseOnly": "El correo electrónico entrante de Microsoft 365 solo está disponible en Enterprise Edition.",
+      "enterpriseOnly": "El correo electrónico entrante de Microsoft 365 solo está disponible en Pro.",
       "loadProvidersError": "Failed to load email providers"
     },
     "editDrawer": {

--- a/server/public/locales/es/msp/extensions.json
+++ b/server/public/locales/es/msp/extensions.json
@@ -3,8 +3,8 @@
     "heading": "Extensiones"
   },
   "enterpriseFeature": {
-    "title": "Función empresarial",
-    "description": "La edición Enterprise es necesaria para {{feature}}. Actualice para acceder a esta función."
+    "title": "Función Pro",
+    "description": "Se requiere Pro para {{feature}}. Actualice para acceder a esta función."
   },
   "settings": {
     "title": "Gestión de extensiones",
@@ -14,8 +14,8 @@
       "install": "Instalar"
     },
     "enterpriseOnly": {
-      "title": "Función empresarial",
-      "description": "Las extensiones están disponibles en la edición Enterprise de Alga PSA."
+      "title": "Función Pro",
+      "description": "Las extensiones están disponibles en Alga PSA Pro."
     },
     "links": {
       "needLogs": "¿Necesita registros de extensiones?",
@@ -98,10 +98,10 @@
       "description": "Administrar extensiones"
     },
     "title": "Extensiones",
-    "description": "La gestión de extensiones está disponible en la edición Enterprise."
+    "description": "La gestión de extensiones está disponible en Pro."
   },
   "detail": {
-    "metadataTitle": "Extensiones - Función empresarial",
+    "metadataTitle": "Extensiones - Función Pro",
     "extensionId": "ID de la extensión: {{id}}"
   },
   "runtime": {
@@ -121,7 +121,7 @@
       "description": "Ver detalles de la extensión"
     },
     "title": "Detalles de la extensión",
-    "description": "Los detalles de la extensión están disponibles en la edición Enterprise."
+    "description": "Los detalles de la extensión están disponibles en Pro."
   },
   "settingsPage": {
     "metadata": {
@@ -129,7 +129,7 @@
       "description": "Configurar la extensión"
     },
     "title": "Configuración de extensiones",
-    "description": "La configuración de extensiones está disponible en la edición Enterprise."
+    "description": "La configuración de extensiones está disponible en Pro."
   },
   "details": {
     "label": "Detalles de la extensión",

--- a/server/public/locales/es/msp/integrations.json
+++ b/server/public/locales/es/msp/integrations.json
@@ -38,7 +38,7 @@
       "setup": {
         "activeConfiguration": "Configuración activa",
         "badges": {
-          "enterprise": "Enterprise"
+          "enterprise": "Pro"
         },
         "comingSoon": "Próximamente",
         "configure": "Configurar integración",

--- a/server/public/locales/es/msp/licensing.json
+++ b/server/public/locales/es/msp/licensing.json
@@ -1,11 +1,11 @@
 {
   "reduceModal": {
     "title": "Reducir licencias",
-    "enterpriseOnly": "Esta función solo está disponible en la edición Enterprise."
+    "enterpriseOnly": "Esta función solo está disponible en Pro."
   },
   "purchaseForm": {
     "title": "Compra de licencias",
-    "enterpriseOnlyHosted": "La compra de licencias está disponible en la edición Enterprise para implementaciones alojadas.",
+    "enterpriseOnlyHosted": "La compra de licencias está disponible en Pro para implementaciones alojadas.",
     "communityEditionUnlimited": "La Community Edition autohospedada tiene usuarios ilimitados sin costo adicional."
   },
   "purchasePage": {
@@ -167,8 +167,8 @@
     }
   },
   "workflowDesigner": {
-    "enterpriseHeading": "Función Enterprise",
-    "unavailable": "El diseñador de flujos de trabajo requiere la edición Enterprise. Actualice para acceder a esta función."
+    "enterpriseHeading": "Función Pro",
+    "unavailable": "El diseñador de flujos de trabajo requiere Pro. Actualice para acceder a esta función."
   },
   "runStudio": {
     "unavailable": "Workflow Run Studio no está disponible en esta edición. (runId: {{runId}})"

--- a/server/public/locales/es/msp/schedule.json
+++ b/server/public/locales/es/msp/schedule.json
@@ -516,7 +516,7 @@
         "valid": "Organizador de Microsoft verificado correctamente.",
         "validWithName": "Usuario de Microsoft verificado: {{displayName}}.",
         "reasons": {
-          "eeDisabled": "La verificación de reuniones de Teams solo está disponible en la Enterprise Edition.",
+          "eeDisabled": "La verificación de reuniones de Teams solo está disponible en Pro.",
           "notConfigured": "La integración de Teams debe estar activa antes de poder verificar un organizador.",
           "userNotFound": "Microsoft no pudo encontrar un usuario para ese organizador.",
           "policyMissing": "El usuario de Microsoft existe, pero la Application Access Policy aún no permite crear reuniones.",

--- a/server/public/locales/es/msp/settings.json
+++ b/server/public/locales/es/msp/settings.json
@@ -1741,8 +1741,8 @@
       "install": "Instalar"
     },
     "enterpriseOnly": {
-      "title": "Función empresarial",
-      "description": "Las extensiones están disponibles en la edición Enterprise de Alga PSA."
+      "title": "Función Pro",
+      "description": "Las extensiones están disponibles en Alga PSA Pro."
     },
     "links": {
       "needLogs": "¿Necesita registros de extensiones?",
@@ -2062,7 +2062,7 @@
   "integrations": {
     "betaNotice": "Algunas integraciones aún están en desarrollo. Por favor, trabaje en un entorno sandbox al evaluar y comparta sus comentarios para ayudarnos a mejorar.",
     "emptyCategory": "No hay integraciones disponibles en esta categoría.",
-    "rmmEnterpriseNote": "Las integraciones RMM están disponibles en la edición Enterprise.",
+    "rmmEnterpriseNote": "Las integraciones RMM están disponibles en Pro.",
     "categoryHeading": "Integraciones de {{label}}",
     "loading": {
       "payments": "Cargando configuración de pagos..."
@@ -2086,7 +2086,7 @@
       },
       "calendar": {
         "label": "Calendario",
-        "description": "Sincronización de calendario exclusiva de Enterprise para Google y Outlook mantiene el despacho y las citas con clientes alineados."
+        "description": "Sincronización de calendario exclusiva de Pro para Google y Outlook mantiene el despacho y las citas con clientes alineados."
       },
       "providers": {
         "label": "Proveedores",

--- a/server/public/locales/es/msp/user-activities.json
+++ b/server/public/locales/es/msp/user-activities.json
@@ -143,7 +143,7 @@
       "title": "Elemento ad hoc",
       "toggleDoneError": "No se pudo actualizar el elemento."
     },
-    "enterpriseOnly": "Las tareas de flujo de trabajo son una función de Enterprise.",
+    "enterpriseOnly": "Las tareas de flujo de trabajo son una función de Pro.",
     "nextAction": "Próxima acción",
     "overdueSince": "Vencido desde {{date}}",
     "dueOn": "Vence el {{date}}",

--- a/server/public/locales/fr/common.json
+++ b/server/public/locales/fr/common.json
@@ -80,8 +80,8 @@
     "printSelected": "Imprimer la sélection ({{count}})"
   },
   "upgradePrompt": {
-    "editionLabel": "Édition Enterprise",
-    "defaultCta": "Découvrir Enterprise"
+    "editionLabel": "Pro",
+    "defaultCta": "Découvrir Pro"
   },
   "status": {
     "loading": "Chargement...",

--- a/server/public/locales/fr/features/inventory.json
+++ b/server/public/locales/fr/features/inventory.json
@@ -425,7 +425,7 @@
       "classifyCandidates": "Classer les candidats",
       "classifying": "Classification…",
       "didNotRun": "Le tri AI ne s'est pas exécuté{{reason}}.",
-      "requiresEnterprise": "Le tri AI nécessite Enterprise et le module complémentaire AI Assistant.",
+      "requiresEnterprise": "Le tri AI nécessite Pro et le module complémentaire AI Assistant.",
       "runFailed": "Le tri AI a échoué.",
       "toggleFailed": "Impossible de modifier le paramètre du tri AI.",
       "toggleLabel": "Tri AI — classer les tickets candidats avec le module complémentaire AI",

--- a/server/public/locales/fr/msp/contracts.json
+++ b/server/public/locales/fr/msp/contracts.json
@@ -2310,8 +2310,8 @@
       "title": "Périodes de facturation simulées"
     },
     "unavailable": {
-      "description": "Le simulateur de contrat est disponible dans l'édition Enterprise d'Alga PSA.",
-      "title": "Fonctionnalité Enterprise"
+      "description": "Le simulateur de contrat est disponible dans Alga PSA Pro.",
+      "title": "Fonctionnalité Pro"
     }
   }
 }

--- a/server/public/locales/fr/msp/core.json
+++ b/server/public/locales/fr/msp/core.json
@@ -273,7 +273,7 @@
   },
   "rightSidebar": {
     "title": "Discussion",
-    "enterpriseOnly": "La fonctionnalité de chat est disponible uniquement dans l'édition Enterprise."
+    "enterpriseOnly": "La fonctionnalité de chat est disponible uniquement avec Pro."
   },
   "notifications": {
     "messages": {

--- a/server/public/locales/fr/msp/dashboard.json
+++ b/server/public/locales/fr/msp/dashboard.json
@@ -171,7 +171,7 @@
         "loadFailed": "Impossible de charger les intégrations de calendrier."
       },
       "email": {
-        "enterpriseOnly": "Les domaines d'e-mail gérés ne sont disponibles qu'en édition Enterprise.",
+        "enterpriseOnly": "Les domaines d'e-mail gérés ne sont disponibles uniquement avec Pro.",
         "tenantRequired": "Le contexte du tenant est requis pour charger l'état d'onboarding de l'e-mail.",
         "loadFailed": "Impossible de charger les domaines d'e-mail gérés.",
         "verificationFailed": "La vérification de {{domain}} a échoué."

--- a/server/public/locales/fr/msp/email-providers.json
+++ b/server/public/locales/fr/msp/email-providers.json
@@ -11,7 +11,7 @@
       "resyncing": "Resynchronisation de {{providerName}}...",
       "resyncError": "Échec de la resynchronisation du fournisseur IMAP",
       "resyncStarted": "Resynchronisation démarrée pour {{providerName}}.",
-      "enterpriseOnly": "Le courrier électronique entrant Microsoft 365 est uniquement disponible dans Enterprise Edition.",
+      "enterpriseOnly": "Le courrier électronique entrant Microsoft 365 est uniquement disponible avec Pro.",
       "loadProvidersError": "Failed to load email providers"
     },
     "editDrawer": {

--- a/server/public/locales/fr/msp/extensions.json
+++ b/server/public/locales/fr/msp/extensions.json
@@ -3,8 +3,8 @@
     "heading": "Extensions"
   },
   "enterpriseFeature": {
-    "title": "Fonctionnalité Enterprise",
-    "description": "L'édition Enterprise est requise pour {{feature}}. Veuillez effectuer une mise à niveau pour accéder à cette fonctionnalité."
+    "title": "Fonctionnalité Pro",
+    "description": "Pro est requis pour {{feature}}. Veuillez effectuer une mise à niveau pour accéder à cette fonctionnalité."
   },
   "settings": {
     "title": "Gestion des extensions",
@@ -14,8 +14,8 @@
       "install": "Installer"
     },
     "enterpriseOnly": {
-      "title": "Fonctionnalité Enterprise",
-      "description": "Les extensions sont disponibles dans l'édition Enterprise d'Alga PSA."
+      "title": "Fonctionnalité Pro",
+      "description": "Les extensions sont disponibles dans Alga PSA Pro."
     },
     "links": {
       "needLogs": "Besoin des journaux d'extension ?",
@@ -98,10 +98,10 @@
       "description": "Gérer les extensions"
     },
     "title": "Extensions",
-    "description": "La gestion des extensions est disponible dans l'édition Enterprise."
+    "description": "La gestion des extensions est disponible avec Pro."
   },
   "detail": {
-    "metadataTitle": "Extensions - Fonctionnalité Enterprise",
+    "metadataTitle": "Extensions - Fonctionnalité Pro",
     "extensionId": "ID de l'extension : {{id}}"
   },
   "runtime": {
@@ -121,7 +121,7 @@
       "description": "Afficher les détails de l'extension"
     },
     "title": "Détails de l'extension",
-    "description": "Les détails de l'extension sont disponibles dans l'édition Enterprise."
+    "description": "Les détails de l'extension sont disponibles avec Pro."
   },
   "settingsPage": {
     "metadata": {
@@ -129,7 +129,7 @@
       "description": "Configurer les paramètres des extensions"
     },
     "title": "Paramètres des extensions",
-    "description": "Les paramètres des extensions sont disponibles dans l'édition Enterprise."
+    "description": "Les paramètres des extensions sont disponibles avec Pro."
   },
   "details": {
     "label": "Détails de l'extension",

--- a/server/public/locales/fr/msp/integrations.json
+++ b/server/public/locales/fr/msp/integrations.json
@@ -38,7 +38,7 @@
       "setup": {
         "activeConfiguration": "Configuration active",
         "badges": {
-          "enterprise": "Enterprise"
+          "enterprise": "Pro"
         },
         "comingSoon": "Bientôt disponible",
         "configure": "Configurer l'intégration",

--- a/server/public/locales/fr/msp/licensing.json
+++ b/server/public/locales/fr/msp/licensing.json
@@ -1,11 +1,11 @@
 {
   "reduceModal": {
     "title": "Réduire les licences",
-    "enterpriseOnly": "Cette fonctionnalité est disponible uniquement dans l'édition Enterprise."
+    "enterpriseOnly": "Cette fonctionnalité est disponible uniquement avec Pro."
   },
   "purchaseForm": {
     "title": "Achat de licences",
-    "enterpriseOnlyHosted": "L'achat de licences est disponible dans l'édition Enterprise pour les déploiements hébergés.",
+    "enterpriseOnlyHosted": "L'achat de licences est disponible avec Pro pour les déploiements hébergés.",
     "communityEditionUnlimited": "L'édition Community auto-hébergée propose un nombre illimité d'utilisateurs sans coût supplémentaire."
   },
   "purchasePage": {
@@ -167,8 +167,8 @@
     }
   },
   "workflowDesigner": {
-    "enterpriseHeading": "Fonctionnalité Enterprise",
-    "unavailable": "Le concepteur de workflows nécessite l'édition Enterprise. Veuillez passer à une version supérieure pour accéder à cette fonctionnalité."
+    "enterpriseHeading": "Fonctionnalité Pro",
+    "unavailable": "Le concepteur de workflows nécessite Pro. Veuillez passer à une version supérieure pour accéder à cette fonctionnalité."
   },
   "runStudio": {
     "unavailable": "Workflow Run Studio n'est pas disponible dans cette édition. (runId : {{runId}})"

--- a/server/public/locales/fr/msp/schedule.json
+++ b/server/public/locales/fr/msp/schedule.json
@@ -516,7 +516,7 @@
         "valid": "Organisateur Microsoft vérifié avec succès.",
         "validWithName": "Utilisateur Microsoft vérifié : {{displayName}}.",
         "reasons": {
-          "eeDisabled": "La vérification des réunions Teams n'est disponible qu'en Enterprise Edition.",
+          "eeDisabled": "La vérification des réunions Teams n'est disponible qu'en Pro.",
           "notConfigured": "L'intégration Teams doit être active avant de pouvoir vérifier un organisateur.",
           "userNotFound": "Microsoft n'a pas trouvé d'utilisateur pour cette valeur d'organisateur.",
           "policyMissing": "L'utilisateur Microsoft existe, mais l'Application Access Policy n'autorise pas encore la création de réunions.",

--- a/server/public/locales/fr/msp/settings.json
+++ b/server/public/locales/fr/msp/settings.json
@@ -1741,8 +1741,8 @@
       "install": "Installer"
     },
     "enterpriseOnly": {
-      "title": "Fonctionnalité Enterprise",
-      "description": "Les extensions sont disponibles dans l'édition Enterprise d'Alga PSA."
+      "title": "Fonctionnalité Pro",
+      "description": "Les extensions sont disponibles dans Alga PSA Pro."
     },
     "links": {
       "needLogs": "Besoin des journaux d'extension ?",
@@ -2062,7 +2062,7 @@
   "integrations": {
     "betaNotice": "Certaines intégrations sont encore en cours de développement. Veuillez travailler dans un environnement sandbox lors de l'évaluation et partagez vos commentaires pour nous aider à nous améliorer.",
     "emptyCategory": "Aucune intégration disponible dans cette catégorie.",
-    "rmmEnterpriseNote": "Les intégrations RMM sont disponibles dans l'édition Enterprise.",
+    "rmmEnterpriseNote": "Les intégrations RMM sont disponibles avec Pro.",
     "categoryHeading": "Intégrations {{label}}",
     "loading": {
       "payments": "Chargement des paramètres de paiement..."
@@ -2086,7 +2086,7 @@
       },
       "calendar": {
         "label": "Calendrier",
-        "description": "Synchronisation de calendrier exclusive Enterprise pour Google et Outlook maintient la répartition et les rendez-vous clients alignés."
+        "description": "Synchronisation de calendrier exclusive Pro pour Google et Outlook maintient la répartition et les rendez-vous clients alignés."
       },
       "providers": {
         "label": "Fournisseurs",

--- a/server/public/locales/fr/msp/user-activities.json
+++ b/server/public/locales/fr/msp/user-activities.json
@@ -143,7 +143,7 @@
       "title": "Élément ponctuel",
       "toggleDoneError": "Échec de la mise à jour de l'élément."
     },
-    "enterpriseOnly": "Les tâches de workflow sont une fonctionnalité Enterprise.",
+    "enterpriseOnly": "Les tâches de workflow sont une fonctionnalité Pro.",
     "nextAction": "Prochaine action",
     "overdueSince": "En retard depuis le {{date}}",
     "dueOn": "Échéance le {{date}}",

--- a/server/public/locales/it/common.json
+++ b/server/public/locales/it/common.json
@@ -80,8 +80,8 @@
     "printSelected": "Stampa selezionati ({{count}})"
   },
   "upgradePrompt": {
-    "editionLabel": "Edizione Enterprise",
-    "defaultCta": "Scopri Enterprise"
+    "editionLabel": "Pro",
+    "defaultCta": "Scopri Pro"
   },
   "status": {
     "loading": "Caricamento...",

--- a/server/public/locales/it/features/inventory.json
+++ b/server/public/locales/it/features/inventory.json
@@ -425,7 +425,7 @@
       "classifyCandidates": "Classifica candidati",
       "classifying": "Classificazione…",
       "didNotRun": "Il triage AI non è stato eseguito{{reason}}.",
-      "requiresEnterprise": "Il triage AI richiede Enterprise e il componente aggiuntivo AI Assistant.",
+      "requiresEnterprise": "Il triage AI richiede Pro e il componente aggiuntivo AI Assistant.",
       "runFailed": "Triage AI non riuscito.",
       "toggleFailed": "Impossibile modificare l'impostazione del triage AI.",
       "toggleLabel": "Triage AI — classifica i ticket candidati con il componente aggiuntivo AI",

--- a/server/public/locales/it/msp/contracts.json
+++ b/server/public/locales/it/msp/contracts.json
@@ -2310,8 +2310,8 @@
       "title": "Periodi di fatturazione simulati"
     },
     "unavailable": {
-      "description": "Il simulatore di contratti è disponibile nell'edizione Enterprise di Alga PSA.",
-      "title": "Funzionalità Enterprise"
+      "description": "Il simulatore di contratti è disponibile in Alga PSA Pro.",
+      "title": "Funzionalità Pro"
     }
   }
 }

--- a/server/public/locales/it/msp/core.json
+++ b/server/public/locales/it/msp/core.json
@@ -273,7 +273,7 @@
   },
   "rightSidebar": {
     "title": "Chat",
-    "enterpriseOnly": "La funzionalità chat è disponibile solo nell'edizione Enterprise."
+    "enterpriseOnly": "La funzionalità chat è disponibile solo in Pro."
   },
   "notifications": {
     "messages": {

--- a/server/public/locales/it/msp/dashboard.json
+++ b/server/public/locales/it/msp/dashboard.json
@@ -171,7 +171,7 @@
         "loadFailed": "Impossibile caricare le integrazioni del calendario."
       },
       "email": {
-        "enterpriseOnly": "I domini email gestiti sono disponibili solo nell'edizione Enterprise.",
+        "enterpriseOnly": "I domini email gestiti sono disponibili solo in Pro.",
         "tenantRequired": "Il contesto tenant è richiesto per caricare lo stato di onboarding dell'email.",
         "loadFailed": "Impossibile caricare i domini email gestiti.",
         "verificationFailed": "La verifica di {{domain}} non è riuscita."

--- a/server/public/locales/it/msp/email-providers.json
+++ b/server/public/locales/it/msp/email-providers.json
@@ -11,7 +11,7 @@
       "resyncing": "Risincronizzazione {{providerName}} in corso...",
       "resyncError": "Impossibile risincronizzare il provider IMAP",
       "resyncStarted": "La risincronizzazione è iniziata per {{providerName}}.",
-      "enterpriseOnly": "La posta elettronica in entrata di Microsoft 365 è disponibile solo in Enterprise Edition.",
+      "enterpriseOnly": "La posta elettronica in entrata di Microsoft 365 è disponibile solo in Pro.",
       "loadProvidersError": "Failed to load email providers"
     },
     "editDrawer": {

--- a/server/public/locales/it/msp/extensions.json
+++ b/server/public/locales/it/msp/extensions.json
@@ -3,8 +3,8 @@
     "heading": "Estensioni"
   },
   "enterpriseFeature": {
-    "title": "Funzionalità Enterprise",
-    "description": "Per {{feature}} è necessaria l'edizione Enterprise. Effettua l'upgrade per accedere a questa funzionalità."
+    "title": "Funzionalità Pro",
+    "description": "{{feature}} richiede Pro. Effettua l'upgrade per accedere a questa funzionalità."
   },
   "settings": {
     "title": "Gestione estensioni",
@@ -14,8 +14,8 @@
       "install": "Installa"
     },
     "enterpriseOnly": {
-      "title": "Funzionalità Enterprise",
-      "description": "Le estensioni sono disponibili nell'edizione Enterprise di Alga PSA."
+      "title": "Funzionalità Pro",
+      "description": "Le estensioni sono disponibili in Alga PSA Pro."
     },
     "links": {
       "needLogs": "Servono i log delle estensioni?",
@@ -98,10 +98,10 @@
       "description": "Gestisci estensioni"
     },
     "title": "Estensioni",
-    "description": "La gestione delle estensioni è disponibile nell'edizione Enterprise."
+    "description": "La gestione delle estensioni è disponibile in Pro."
   },
   "detail": {
-    "metadataTitle": "Estensioni - Funzionalità Enterprise",
+    "metadataTitle": "Estensioni - Funzionalità Pro",
     "extensionId": "ID estensione: {{id}}"
   },
   "runtime": {
@@ -121,7 +121,7 @@
       "description": "Visualizza i dettagli dell'estensione"
     },
     "title": "Dettagli dell'estensione",
-    "description": "I dettagli dell'estensione sono disponibili nell'edizione Enterprise."
+    "description": "I dettagli dell'estensione sono disponibili in Pro."
   },
   "settingsPage": {
     "metadata": {
@@ -129,7 +129,7 @@
       "description": "Configura le impostazioni delle estensioni"
     },
     "title": "Impostazioni estensioni",
-    "description": "Le impostazioni delle estensioni sono disponibili nell'edizione Enterprise."
+    "description": "Le impostazioni delle estensioni sono disponibili in Pro."
   },
   "details": {
     "label": "Dettagli estensione",

--- a/server/public/locales/it/msp/integrations.json
+++ b/server/public/locales/it/msp/integrations.json
@@ -38,7 +38,7 @@
       "setup": {
         "activeConfiguration": "Configurazione attiva",
         "badges": {
-          "enterprise": "Enterprise"
+          "enterprise": "Pro"
         },
         "comingSoon": "Prossimamente",
         "configure": "Configura integrazione",

--- a/server/public/locales/it/msp/licensing.json
+++ b/server/public/locales/it/msp/licensing.json
@@ -1,11 +1,11 @@
 {
   "reduceModal": {
     "title": "Riduci licenze",
-    "enterpriseOnly": "Questa funzionalità è disponibile solo nell'edizione Enterprise."
+    "enterpriseOnly": "Questa funzionalità è disponibile solo in Pro."
   },
   "purchaseForm": {
     "title": "Acquisto licenze",
-    "enterpriseOnlyHosted": "L'acquisto di licenze è disponibile nell'edizione Enterprise per le distribuzioni ospitate.",
+    "enterpriseOnlyHosted": "L'acquisto di licenze è disponibile in Pro per le distribuzioni ospitate.",
     "communityEditionUnlimited": "L'edizione Community self-hosted offre utenti illimitati senza costi aggiuntivi."
   },
   "purchasePage": {
@@ -167,8 +167,8 @@
     }
   },
   "workflowDesigner": {
-    "enterpriseHeading": "Funzionalità Enterprise",
-    "unavailable": "Il designer di workflow richiede l'edizione Enterprise. Esegua l'upgrade per accedere a questa funzionalità."
+    "enterpriseHeading": "Funzionalità Pro",
+    "unavailable": "Il designer di workflow richiede Pro. Esegua l'upgrade per accedere a questa funzionalità."
   },
   "runStudio": {
     "unavailable": "Workflow Run Studio non è disponibile in questa edizione. (runId: {{runId}})"

--- a/server/public/locales/it/msp/schedule.json
+++ b/server/public/locales/it/msp/schedule.json
@@ -516,7 +516,7 @@
         "valid": "Organizzatore Microsoft verificato correttamente.",
         "validWithName": "Utente Microsoft verificato: {{displayName}}.",
         "reasons": {
-          "eeDisabled": "La verifica delle riunioni Teams è disponibile solo nella Enterprise Edition.",
+          "eeDisabled": "La verifica delle riunioni Teams è disponibile solo in Pro.",
           "notConfigured": "L'integrazione Teams deve essere attiva prima di poter verificare un organizzatore.",
           "userNotFound": "Microsoft non ha trovato un utente per questo organizzatore.",
           "policyMissing": "L'utente Microsoft esiste, ma l'Application Access Policy non consente ancora la creazione di riunioni.",

--- a/server/public/locales/it/msp/settings.json
+++ b/server/public/locales/it/msp/settings.json
@@ -1741,8 +1741,8 @@
       "install": "Installa"
     },
     "enterpriseOnly": {
-      "title": "Funzionalità Enterprise",
-      "description": "Le estensioni sono disponibili nell'edizione Enterprise di Alga PSA."
+      "title": "Funzionalità Pro",
+      "description": "Le estensioni sono disponibili in Alga PSA Pro."
     },
     "links": {
       "needLogs": "Servono i log delle estensioni?",
@@ -2062,7 +2062,7 @@
   "integrations": {
     "betaNotice": "Alcune integrazioni sono ancora in fase di sviluppo. Si prega di lavorare in un ambiente sandbox durante la valutazione e di condividere il proprio feedback per aiutarci a migliorare.",
     "emptyCategory": "Nessuna integrazione disponibile in questa categoria.",
-    "rmmEnterpriseNote": "Le integrazioni RMM sono disponibili nell'edizione Enterprise.",
+    "rmmEnterpriseNote": "Le integrazioni RMM sono disponibili in Pro.",
     "categoryHeading": "Integrazioni {{label}}",
     "loading": {
       "payments": "Caricamento impostazioni di pagamento..."
@@ -2086,7 +2086,7 @@
       },
       "calendar": {
         "label": "Calendario",
-        "description": "Sincronizzazione calendario esclusiva Enterprise per Google e Outlook mantiene allineati smistamento e appuntamenti con i clienti."
+        "description": "Sincronizzazione calendario esclusiva Pro per Google e Outlook mantiene allineati smistamento e appuntamenti con i clienti."
       },
       "providers": {
         "label": "Fornitori",

--- a/server/public/locales/it/msp/user-activities.json
+++ b/server/public/locales/it/msp/user-activities.json
@@ -143,7 +143,7 @@
       "title": "Elemento ad hoc",
       "toggleDoneError": "Impossibile aggiornare l'elemento."
     },
-    "enterpriseOnly": "Le attività del workflow sono una funzionalità Enterprise.",
+    "enterpriseOnly": "Le attività del workflow sono una funzionalità Pro.",
     "nextAction": "Azione successiva",
     "overdueSince": "In ritardo dal {{date}}",
     "dueOn": "Scadenza il {{date}}",

--- a/server/public/locales/nl/common.json
+++ b/server/public/locales/nl/common.json
@@ -80,8 +80,8 @@
     "printSelected": "Geselecteerde afdrukken ({{count}})"
   },
   "upgradePrompt": {
-    "editionLabel": "Enterprise-editie",
-    "defaultCta": "Enterprise ontdekken"
+    "editionLabel": "Pro",
+    "defaultCta": "Pro ontdekken"
   },
   "status": {
     "loading": "Bezig met laden...",

--- a/server/public/locales/nl/features/inventory.json
+++ b/server/public/locales/nl/features/inventory.json
@@ -425,7 +425,7 @@
       "classifyCandidates": "Kandidaten classificeren",
       "classifying": "Classificeren…",
       "didNotRun": "AI-triage is niet uitgevoerd{{reason}}.",
-      "requiresEnterprise": "AI-triage vereist Enterprise en de AI Assistant-add-on.",
+      "requiresEnterprise": "AI-triage vereist Pro en de AI Assistant-add-on.",
       "runFailed": "AI-triage mislukt.",
       "toggleFailed": "Kon de AI-triage-instelling niet wijzigen.",
       "toggleLabel": "AI-triage — classificeer kandidaat-tickets met de AI-add-on",

--- a/server/public/locales/nl/msp/contracts.json
+++ b/server/public/locales/nl/msp/contracts.json
@@ -2310,8 +2310,8 @@
       "title": "Gesimuleerde factuurperioden"
     },
     "unavailable": {
-      "description": "De contractsimulator is beschikbaar in de Enterprise-editie van Alga PSA.",
-      "title": "Enterprise-functie"
+      "description": "De contractsimulator is beschikbaar in Alga PSA Pro.",
+      "title": "Pro-functie"
     }
   }
 }

--- a/server/public/locales/nl/msp/core.json
+++ b/server/public/locales/nl/msp/core.json
@@ -273,7 +273,7 @@
   },
   "rightSidebar": {
     "title": "Chat",
-    "enterpriseOnly": "De chatfunctie is alleen beschikbaar in de Enterprise Edition."
+    "enterpriseOnly": "De chatfunctie is alleen beschikbaar in Pro."
   },
   "notifications": {
     "messages": {

--- a/server/public/locales/nl/msp/dashboard.json
+++ b/server/public/locales/nl/msp/dashboard.json
@@ -171,7 +171,7 @@
         "loadFailed": "De kalenderintegraties konden niet worden geladen."
       },
       "email": {
-        "enterpriseOnly": "Beheerde e-maildomeinen zijn alleen beschikbaar in de Enterprise-editie.",
+        "enterpriseOnly": "Beheerde e-maildomeinen zijn alleen beschikbaar in Pro.",
         "tenantRequired": "Tenantcontext is vereist om de onboardingstatus van e-mail te laden.",
         "loadFailed": "De beheerde e-maildomeinen konden niet worden geladen.",
         "verificationFailed": "Verificatie voor {{domain}} is mislukt."

--- a/server/public/locales/nl/msp/email-providers.json
+++ b/server/public/locales/nl/msp/email-providers.json
@@ -11,7 +11,7 @@
       "resyncing": "{{providerName}} opnieuw synchroniseren...",
       "resyncError": "Het opnieuw synchroniseren van de IMAP-provider is mislukt",
       "resyncStarted": "Hersynchronisatie gestart voor {{providerName}}.",
-      "enterpriseOnly": "Microsoft 365 inkomende e-mail is alleen beschikbaar in Enterprise Edition.",
+      "enterpriseOnly": "Microsoft 365 inkomende e-mail is alleen beschikbaar in Pro.",
       "loadProvidersError": "Failed to load email providers"
     },
     "editDrawer": {

--- a/server/public/locales/nl/msp/extensions.json
+++ b/server/public/locales/nl/msp/extensions.json
@@ -3,8 +3,8 @@
     "heading": "Extensies"
   },
   "enterpriseFeature": {
-    "title": "Enterprise-functie",
-    "description": "Voor {{feature}} is de Enterprise-editie vereist. Upgrade om toegang te krijgen tot deze functie."
+    "title": "Pro-functie",
+    "description": "Voor {{feature}} is Pro vereist. Upgrade om toegang te krijgen tot deze functie."
   },
   "settings": {
     "title": "Extensiebeheer",
@@ -14,8 +14,8 @@
       "install": "Installeren"
     },
     "enterpriseOnly": {
-      "title": "Enterprise-functie",
-      "description": "Extensies zijn beschikbaar in de Enterprise-editie van Alga PSA."
+      "title": "Pro-functie",
+      "description": "Extensies zijn beschikbaar in Alga PSA Pro."
     },
     "links": {
       "needLogs": "Extensielogs nodig?",
@@ -98,10 +98,10 @@
       "description": "Extensies beheren"
     },
     "title": "Extensies",
-    "description": "Extensiebeheer is beschikbaar in de Enterprise-editie."
+    "description": "Extensiebeheer is beschikbaar in Pro."
   },
   "detail": {
-    "metadataTitle": "Extensies - Enterprise-functie",
+    "metadataTitle": "Extensies - Pro-functie",
     "extensionId": "Extensie-ID: {{id}}"
   },
   "runtime": {
@@ -121,7 +121,7 @@
       "description": "Extensiedetails bekijken"
     },
     "title": "Extensiedetails",
-    "description": "Extensiedetails zijn beschikbaar in de Enterprise-editie."
+    "description": "Extensiedetails zijn beschikbaar in Pro."
   },
   "settingsPage": {
     "metadata": {
@@ -129,7 +129,7 @@
       "description": "Extensie-instellingen configureren"
     },
     "title": "Extensie-instellingen",
-    "description": "Extensie-instellingen zijn beschikbaar in de Enterprise-editie."
+    "description": "Extensie-instellingen zijn beschikbaar in Pro."
   },
   "details": {
     "label": "Extensiedetails",

--- a/server/public/locales/nl/msp/integrations.json
+++ b/server/public/locales/nl/msp/integrations.json
@@ -38,7 +38,7 @@
       "setup": {
         "activeConfiguration": "Actieve configuratie",
         "badges": {
-          "enterprise": "Enterprise"
+          "enterprise": "Pro"
         },
         "comingSoon": "Binnenkort beschikbaar",
         "configure": "Integratie configureren",

--- a/server/public/locales/nl/msp/licensing.json
+++ b/server/public/locales/nl/msp/licensing.json
@@ -1,11 +1,11 @@
 {
   "reduceModal": {
     "title": "Licenties verminderen",
-    "enterpriseOnly": "Deze functie is alleen beschikbaar in de Enterprise-editie."
+    "enterpriseOnly": "Deze functie is alleen beschikbaar in Pro."
   },
   "purchaseForm": {
     "title": "Licentieaankoop",
-    "enterpriseOnlyHosted": "Licenties aanschaffen is beschikbaar in de Enterprise-editie voor gehoste implementaties.",
+    "enterpriseOnlyHosted": "Licenties aanschaffen is beschikbaar in Pro voor gehoste implementaties.",
     "communityEditionUnlimited": "De zelf-gehoste Community Edition heeft onbeperkte gebruikers zonder extra kosten."
   },
   "purchasePage": {
@@ -167,8 +167,8 @@
     }
   },
   "workflowDesigner": {
-    "enterpriseHeading": "Enterprise-functie",
-    "unavailable": "De workflow-designer vereist de Enterprise Edition. Voer een upgrade uit om deze functie te gebruiken."
+    "enterpriseHeading": "Pro-functie",
+    "unavailable": "De workflow-designer vereist Pro. Voer een upgrade uit om deze functie te gebruiken."
   },
   "runStudio": {
     "unavailable": "Workflow Run Studio is niet beschikbaar in deze editie. (runId: {{runId}})"

--- a/server/public/locales/nl/msp/schedule.json
+++ b/server/public/locales/nl/msp/schedule.json
@@ -516,7 +516,7 @@
         "valid": "Microsoft-organisator succesvol geverifieerd.",
         "validWithName": "Geverifieerde Microsoft-gebruiker: {{displayName}}.",
         "reasons": {
-          "eeDisabled": "Verificatie van Teams-vergaderingen is alleen beschikbaar in de Enterprise Edition.",
+          "eeDisabled": "Verificatie van Teams-vergaderingen is alleen beschikbaar in Pro.",
           "notConfigured": "De Teams-integratie moet actief zijn voordat een organisator kan worden geverifieerd.",
           "userNotFound": "Microsoft kon geen gebruiker vinden voor deze organisatorwaarde.",
           "policyMissing": "De Microsoft-gebruiker bestaat, maar de Application Access Policy staat het maken van vergaderingen nog niet toe.",

--- a/server/public/locales/nl/msp/settings.json
+++ b/server/public/locales/nl/msp/settings.json
@@ -1741,8 +1741,8 @@
       "install": "Installeren"
     },
     "enterpriseOnly": {
-      "title": "Enterprise-functie",
-      "description": "Extensies zijn beschikbaar in de Enterprise-editie van Alga PSA."
+      "title": "Pro-functie",
+      "description": "Extensies zijn beschikbaar in Alga PSA Pro."
     },
     "links": {
       "needLogs": "Extensielogs nodig?",
@@ -2062,7 +2062,7 @@
   "integrations": {
     "betaNotice": "Sommige integraties zijn nog in ontwikkeling. Werk in een sandbox-omgeving bij het evalueren en deel uw feedback om ons te helpen verbeteren.",
     "emptyCategory": "Geen integraties beschikbaar in deze categorie.",
-    "rmmEnterpriseNote": "RMM-integraties zijn beschikbaar in de Enterprise-editie.",
+    "rmmEnterpriseNote": "RMM-integraties zijn beschikbaar in Pro.",
     "categoryHeading": "{{label}}-integraties",
     "loading": {
       "payments": "Betalingsinstellingen laden..."
@@ -2086,7 +2086,7 @@
       },
       "calendar": {
         "label": "Agenda",
-        "description": "Enterprise-exclusieve agendasynchronisatie voor Google en Outlook houdt planning en klantafspraken op één lijn."
+        "description": "Pro-exclusieve agendasynchronisatie voor Google en Outlook houdt planning en klantafspraken op één lijn."
       },
       "providers": {
         "label": "Providers",

--- a/server/public/locales/nl/msp/user-activities.json
+++ b/server/public/locales/nl/msp/user-activities.json
@@ -143,7 +143,7 @@
       "title": "Ad-hocitem",
       "toggleDoneError": "Kan item niet bijwerken."
     },
-    "enterpriseOnly": "Workflow-taken zijn een Enterprise-functie.",
+    "enterpriseOnly": "Workflow-taken zijn een Pro-functie.",
     "nextAction": "Volgende actie",
     "overdueSince": "Achterstallig sinds {{date}}",
     "dueOn": "Vervalt op {{date}}",

--- a/server/public/locales/pl/common.json
+++ b/server/public/locales/pl/common.json
@@ -94,8 +94,8 @@
     "printSelected_many": "Drukuj zaznaczone ({{count}})"
   },
   "upgradePrompt": {
-    "editionLabel": "Wersja Enterprise",
-    "defaultCta": "Poznaj Enterprise"
+    "editionLabel": "Pro",
+    "defaultCta": "Poznaj Pro"
   },
   "status": {
     "loading": "Ładowanie...",

--- a/server/public/locales/pl/features/inventory.json
+++ b/server/public/locales/pl/features/inventory.json
@@ -425,7 +425,7 @@
       "classifyCandidates": "Sklasyfikuj kandydatów",
       "classifying": "Klasyfikowanie…",
       "didNotRun": "Triaż AI nie został uruchomiony{{reason}}.",
-      "requiresEnterprise": "Triaż AI wymaga wersji Enterprise oraz dodatku AI Assistant.",
+      "requiresEnterprise": "Triaż AI wymaga Pro oraz dodatku AI Assistant.",
       "runFailed": "Triaż AI nie powiódł się.",
       "toggleFailed": "Nie udało się zmienić ustawienia triażu AI.",
       "toggleLabel": "Triaż AI — klasyfikuj zgłoszenia kandydatów z dodatkiem AI",

--- a/server/public/locales/pl/msp/contracts.json
+++ b/server/public/locales/pl/msp/contracts.json
@@ -2314,8 +2314,8 @@
       "title": "Symulowane okresy faktur"
     },
     "unavailable": {
-      "description": "Symulator umów jest dostępny w wersji Enterprise Alga PSA.",
-      "title": "Funkcja Enterprise"
+      "description": "Symulator umów jest dostępny w Alga PSA Pro.",
+      "title": "Funkcja Pro"
     }
   }
 }

--- a/server/public/locales/pl/msp/core.json
+++ b/server/public/locales/pl/msp/core.json
@@ -273,7 +273,7 @@
   },
   "rightSidebar": {
     "title": "Czat",
-    "enterpriseOnly": "Funkcja czatu jest dostępna tylko w edycji Enterprise."
+    "enterpriseOnly": "Funkcja czatu jest dostępna tylko w Pro."
   },
   "notifications": {
     "messages": {

--- a/server/public/locales/pl/msp/dashboard.json
+++ b/server/public/locales/pl/msp/dashboard.json
@@ -171,7 +171,7 @@
         "loadFailed": "Nie udało się załadować integracji kalendarza."
       },
       "email": {
-        "enterpriseOnly": "Zarządzane domeny e-mail są dostępne tylko w edycji Enterprise.",
+        "enterpriseOnly": "Zarządzane domeny e-mail są dostępne tylko w Pro.",
         "tenantRequired": "Kontekst tenant jest wymagany do załadowania statusu onboardingu e-maila.",
         "loadFailed": "Nie udało się załadować zarządzanych domen e-mail.",
         "verificationFailed": "Weryfikacja domeny {{domain}} nie powiodła się."

--- a/server/public/locales/pl/msp/email-providers.json
+++ b/server/public/locales/pl/msp/email-providers.json
@@ -11,7 +11,7 @@
       "resyncing": "Ponowna synchronizacja {{providerName}}...",
       "resyncError": "Nie udało się ponownie zsynchronizować dostawcy IMAP",
       "resyncStarted": "Rozpoczęto ponowną synchronizację dla {{providerName}}.",
-      "enterpriseOnly": "Przychodząca poczta e-mail usługi Microsoft 365 jest dostępna tylko w wersji Enterprise.",
+      "enterpriseOnly": "Przychodząca poczta e-mail usługi Microsoft 365 jest dostępna tylko w Pro.",
       "loadProvidersError": "Failed to load email providers"
     },
     "editDrawer": {

--- a/server/public/locales/pl/msp/extensions.json
+++ b/server/public/locales/pl/msp/extensions.json
@@ -3,8 +3,8 @@
     "heading": "Rozszerzenia"
   },
   "enterpriseFeature": {
-    "title": "Funkcja wersji Enterprise",
-    "description": "Do korzystania z {{feature}} wymagana jest wersja Enterprise. Wykonaj uaktualnienie, aby uzyskać dostęp do tej funkcji."
+    "title": "Funkcja Pro",
+    "description": "Korzystanie z {{feature}} wymaga Pro. Wykonaj uaktualnienie, aby uzyskać dostęp do tej funkcji."
   },
   "settings": {
     "title": "Zarządzanie rozszerzeniami",
@@ -14,8 +14,8 @@
       "install": "Instalacja"
     },
     "enterpriseOnly": {
-      "title": "Funkcja wersji Enterprise",
-      "description": "Rozszerzenia są dostępne w wersji Enterprise programu Alga PSA."
+      "title": "Funkcja Pro",
+      "description": "Rozszerzenia są dostępne w Alga PSA Pro."
     },
     "links": {
       "needLogs": "Potrzebujesz logów rozszerzenia?",
@@ -98,10 +98,10 @@
       "description": "Zarządzaj rozszerzeniami"
     },
     "title": "Rozszerzenia",
-    "description": "Zarządzanie rozszerzeniami jest dostępne w wersji Enterprise."
+    "description": "Zarządzanie rozszerzeniami jest dostępne w Pro."
   },
   "detail": {
-    "metadataTitle": "Rozszerzenia - Funkcja wersji Enterprise",
+    "metadataTitle": "Rozszerzenia - Funkcja Pro",
     "extensionId": "Identyfikator rozszerzenia: {{id}}"
   },
   "runtime": {
@@ -121,7 +121,7 @@
       "description": "Wyświetl szczegóły rozszerzenia"
     },
     "title": "Szczegóły rozszerzenia",
-    "description": "Szczegóły rozszerzenia są dostępne w wersji Enterprise."
+    "description": "Szczegóły rozszerzenia są dostępne w Pro."
   },
   "settingsPage": {
     "metadata": {
@@ -129,7 +129,7 @@
       "description": "Skonfiguruj ustawienia rozszerzeń"
     },
     "title": "Ustawienia rozszerzeń",
-    "description": "Ustawienia rozszerzeń są dostępne w wersji Enterprise."
+    "description": "Ustawienia rozszerzeń są dostępne w Pro."
   },
   "details": {
     "label": "Szczegóły rozszerzenia",

--- a/server/public/locales/pl/msp/integrations.json
+++ b/server/public/locales/pl/msp/integrations.json
@@ -38,7 +38,7 @@
       "setup": {
         "activeConfiguration": "Aktywna konfiguracja",
         "badges": {
-          "enterprise": "Enterprise"
+          "enterprise": "Pro"
         },
         "comingSoon": "Wkrótce dostępne",
         "configure": "Konfiguruj integrację",

--- a/server/public/locales/pl/msp/licensing.json
+++ b/server/public/locales/pl/msp/licensing.json
@@ -1,11 +1,11 @@
 {
   "reduceModal": {
     "title": "Zmniejsz liczbę licencji",
-    "enterpriseOnly": "Ta funkcja jest dostępna tylko w wersji Enterprise."
+    "enterpriseOnly": "Ta funkcja jest dostępna tylko w Pro."
   },
   "purchaseForm": {
     "title": "Zakup licencji",
-    "enterpriseOnlyHosted": "Zakup licencji jest dostępny w wersji Enterprise dla wdrożeń hostowanych.",
+    "enterpriseOnlyHosted": "Zakup licencji jest dostępny w Pro dla wdrożeń hostowanych.",
     "communityEditionUnlimited": "Samodzielnie hostowana wersja Community Edition ma nieograniczoną liczbę użytkowników bez dodatkowych kosztów."
   },
   "purchasePage": {
@@ -167,8 +167,8 @@
     }
   },
   "workflowDesigner": {
-    "enterpriseHeading": "Funkcja Enterprise",
-    "unavailable": "Projektant przepływów pracy wymaga edycji Enterprise. Proszę dokonać aktualizacji, aby uzyskać dostęp do tej funkcji."
+    "enterpriseHeading": "Funkcja Pro",
+    "unavailable": "Projektant przepływów pracy wymaga Pro. Proszę dokonać aktualizacji, aby uzyskać dostęp do tej funkcji."
   },
   "runStudio": {
     "unavailable": "Workflow Run Studio nie jest dostępne w tej edycji. (runId: {{runId}})"

--- a/server/public/locales/pl/msp/schedule.json
+++ b/server/public/locales/pl/msp/schedule.json
@@ -516,7 +516,7 @@
         "valid": "Pomyślnie zweryfikowano organizatora Microsoft.",
         "validWithName": "Zweryfikowany użytkownik Microsoft: {{displayName}}.",
         "reasons": {
-          "eeDisabled": "Weryfikacja spotkań Teams jest dostępna tylko w wersji Enterprise Edition.",
+          "eeDisabled": "Weryfikacja spotkań Teams jest dostępna tylko w Pro.",
           "notConfigured": "Integracja Teams musi być aktywna, aby można było zweryfikować organizatora.",
           "userNotFound": "Microsoft nie znalazł użytkownika dla tej wartości organizatora.",
           "policyMissing": "Użytkownik Microsoft istnieje, ale Application Access Policy nie zezwala jeszcze na tworzenie spotkań.",

--- a/server/public/locales/pl/msp/settings.json
+++ b/server/public/locales/pl/msp/settings.json
@@ -1747,8 +1747,8 @@
       "install": "Instalacja"
     },
     "enterpriseOnly": {
-      "title": "Funkcja wersji Enterprise",
-      "description": "Rozszerzenia są dostępne w wersji Enterprise programu Alga PSA."
+      "title": "Funkcja Pro",
+      "description": "Rozszerzenia są dostępne w Alga PSA Pro."
     },
     "links": {
       "needLogs": "Potrzebujesz logów rozszerzenia?",
@@ -2076,7 +2076,7 @@
   "integrations": {
     "betaNotice": "Niektóre integracje są jeszcze w fazie rozwoju. Prosimy o pracę w środowisku sandbox podczas oceny i dzielenie się opinią, aby pomóc nam w ulepszaniu.",
     "emptyCategory": "Brak dostępnych integracji w tej kategorii.",
-    "rmmEnterpriseNote": "Integracje RMM są dostępne w edycji Enterprise.",
+    "rmmEnterpriseNote": "Integracje RMM są dostępne w Pro.",
     "categoryHeading": "Integracje {{label}}",
     "loading": {
       "payments": "Ładowanie ustawień płatności..."
@@ -2100,7 +2100,7 @@
       },
       "calendar": {
         "label": "Kalendarz",
-        "description": "Synchronizacja kalendarza dostępna wyłącznie w Enterprise dla Google i Outlook utrzymuje zgodność dyspozycji i spotkań z klientami."
+        "description": "Synchronizacja kalendarza dostępna wyłącznie w Pro dla Google i Outlook utrzymuje zgodność dyspozycji i spotkań z klientami."
       },
       "providers": {
         "label": "Dostawcy",

--- a/server/public/locales/pl/msp/user-activities.json
+++ b/server/public/locales/pl/msp/user-activities.json
@@ -143,7 +143,7 @@
       "title": "Element ad hoc",
       "toggleDoneError": "Nie udało się zaktualizować elementu."
     },
-    "enterpriseOnly": "Zadania przepływu pracy są funkcją wersji Enterprise.",
+    "enterpriseOnly": "Zadania przepływu pracy są funkcją Pro.",
     "nextAction": "Następna akcja",
     "overdueSince": "Zaległe od {{date}}",
     "dueOn": "Termin: {{date}}",

--- a/server/public/locales/pt/common.json
+++ b/server/public/locales/pt/common.json
@@ -80,8 +80,8 @@
     "printSelected": "Imprimir selecionado ({{count}})"
   },
   "upgradePrompt": {
-    "editionLabel": "Edição Enterprise",
-    "defaultCta": "Conheça o Enterprise"
+    "editionLabel": "Pro",
+    "defaultCta": "Conheça o Pro"
   },
   "form": {
     "selectPlaceholder": "Selecione...",

--- a/server/public/locales/pt/features/inventory.json
+++ b/server/public/locales/pt/features/inventory.json
@@ -425,7 +425,7 @@
       "classifyCandidates": "Classificar candidatos",
       "classifying": "Classificando…",
       "didNotRun": "A triagem por IA não foi executada{{reason}}.",
-      "requiresEnterprise": "A triagem por IA requer o Enterprise e o complemento Assistente de IA.",
+      "requiresEnterprise": "A triagem por IA requer o Pro e o complemento Assistente de IA.",
       "runFailed": "Falha na triagem por IA.",
       "toggleFailed": "Não foi possível alterar a configuração da triagem por IA.",
       "toggleLabel": "Triagem por IA — classificar chamados candidatos com o complemento de IA",

--- a/server/public/locales/pt/msp/contracts.json
+++ b/server/public/locales/pt/msp/contracts.json
@@ -2310,8 +2310,8 @@
       "title": "Períodos de fatura simulados"
     },
     "unavailable": {
-      "description": "O simulador de contratos está disponível na edição Enterprise do Alga PSA.",
-      "title": "Recurso Enterprise"
+      "description": "O simulador de contratos está disponível no Alga PSA Pro.",
+      "title": "Recurso Pro"
     }
   }
 }

--- a/server/public/locales/pt/msp/core.json
+++ b/server/public/locales/pt/msp/core.json
@@ -273,7 +273,7 @@
   },
   "rightSidebar": {
     "title": "Bater papo",
-    "enterpriseOnly": "O recurso de bate-papo está disponível apenas na Enterprise Edition."
+    "enterpriseOnly": "O recurso de bate-papo está disponível apenas no Pro."
   },
   "notifications": {
     "messages": {

--- a/server/public/locales/pt/msp/dashboard.json
+++ b/server/public/locales/pt/msp/dashboard.json
@@ -199,7 +199,7 @@
         "loadFailed": "Não foi possível carregar integrações de calendário."
       },
       "email": {
-        "enterpriseOnly": "Os domínios de e-mail gerenciados estão disponíveis apenas na edição Enterprise.",
+        "enterpriseOnly": "Os domínios de e-mail gerenciados estão disponíveis apenas no Pro.",
         "tenantRequired": "O contexto do locatário é necessário para carregar o status de onboarding do email.",
         "loadFailed": "Não foi possível carregar domínios de e-mail gerenciados.",
         "verificationFailed": "A verificação para {{domain}} falhou."

--- a/server/public/locales/pt/msp/email-providers.json
+++ b/server/public/locales/pt/msp/email-providers.json
@@ -11,7 +11,7 @@
       "resyncing": "Ressincronizando {{providerName}}...",
       "resyncError": "Falha ao sincronizar novamente o provedor IMAP",
       "resyncStarted": "A ressincronização foi iniciada para {{providerName}}.",
-      "enterpriseOnly": "O email de entrada do Microsoft 365 está disponível apenas na Enterprise Edition.",
+      "enterpriseOnly": "O email de entrada do Microsoft 365 está disponível apenas no Pro.",
       "loadProvidersError": "Failed to load email providers"
     },
     "editDrawer": {

--- a/server/public/locales/pt/msp/extensions.json
+++ b/server/public/locales/pt/msp/extensions.json
@@ -3,8 +3,8 @@
     "heading": "Extensões"
   },
   "enterpriseFeature": {
-    "title": "Recurso Empresarial",
-    "description": "{{feature}} requer Enterprise Edition. Atualize para acessar esse recurso."
+    "title": "Recurso Pro",
+    "description": "{{feature}} requer Pro. Atualize para acessar esse recurso."
   },
   "settings": {
     "title": "Gerenciamento de extensão",
@@ -14,8 +14,8 @@
       "install": "Instalar"
     },
     "enterpriseOnly": {
-      "title": "Recurso empresarial",
-      "description": "As extensões estão disponíveis na edição Enterprise do Alga PSA."
+      "title": "Recurso Pro",
+      "description": "As extensões estão disponíveis no Alga PSA Pro."
     },
     "links": {
       "needLogs": "Precisa de registros de extensão?",
@@ -98,10 +98,10 @@
       "description": "Gerenciar extensões"
     },
     "title": "Extensões",
-    "description": "O gerenciamento de extensões está disponível na Enterprise Edition."
+    "description": "O gerenciamento de extensões está disponível no Pro."
   },
   "detail": {
-    "metadataTitle": "Extensões - Recurso Corporativo",
+    "metadataTitle": "Extensões - Recurso Pro",
     "extensionId": "ID da extensão: {{id}}"
   },
   "runtime": {
@@ -121,7 +121,7 @@
       "description": "Ver detalhes da extensão"
     },
     "title": "Detalhes da extensão",
-    "description": "Os detalhes da extensão estão disponíveis na Enterprise Edition."
+    "description": "Os detalhes da extensão estão disponíveis no Pro."
   },
   "settingsPage": {
     "metadata": {
@@ -129,7 +129,7 @@
       "description": "Definir configurações de extensão"
     },
     "title": "Configurações de extensão",
-    "description": "As configurações de extensão estão disponíveis na Enterprise Edition."
+    "description": "As configurações de extensão estão disponíveis no Pro."
   },
   "details": {
     "label": "Detalhes da extensão",

--- a/server/public/locales/pt/msp/integrations.json
+++ b/server/public/locales/pt/msp/integrations.json
@@ -38,7 +38,7 @@
       "setup": {
         "activeConfiguration": "Configuração ativa",
         "badges": {
-          "enterprise": "Empresa"
+          "enterprise": "Pro"
         },
         "comingSoon": "Em breve",
         "configure": "Configurar integração",

--- a/server/public/locales/pt/msp/licensing.json
+++ b/server/public/locales/pt/msp/licensing.json
@@ -1,11 +1,11 @@
 {
   "reduceModal": {
     "title": "Reduzir licenças",
-    "enterpriseOnly": "Este recurso está disponível apenas na Enterprise Edition."
+    "enterpriseOnly": "Este recurso está disponível apenas no Pro."
   },
   "purchaseForm": {
     "title": "Compra de licença",
-    "enterpriseOnlyHosted": "A compra de licença está disponível na Enterprise Edition para implantações hospedadas.",
+    "enterpriseOnlyHosted": "A compra de licença está disponível no Pro para implantações hospedadas.",
     "communityEditionUnlimited": "Community Edition auto-hospedado tem usuários ilimitados sem custo adicional."
   },
   "purchasePage": {
@@ -167,8 +167,8 @@
     }
   },
   "workflowDesigner": {
-    "enterpriseHeading": "Recurso Empresarial",
-    "unavailable": "O designer de fluxo de trabalho requer Enterprise Edition. Atualize para acessar esse recurso."
+    "enterpriseHeading": "Recurso Pro",
+    "unavailable": "O designer de fluxo de trabalho requer Pro. Atualize para acessar esse recurso."
   },
   "runStudio": {
     "unavailable": "Workflow Run Studio não está disponível nesta edição. (ID de execução: {{runId}})"

--- a/server/public/locales/pt/msp/schedule.json
+++ b/server/public/locales/pt/msp/schedule.json
@@ -516,7 +516,7 @@
         "valid": "Organizador da Microsoft verificado com sucesso.",
         "validWithName": "Usuário verificado da Microsoft: {{displayName}}.",
         "reasons": {
-          "eeDisabled": "A verificação de reuniões do Teams está disponível apenas na Enterprise Edition.",
+          "eeDisabled": "A verificação de reuniões do Teams está disponível apenas no Pro.",
           "notConfigured": "A integração das equipes deve estar ativa antes que um organizador possa ser verificado.",
           "userNotFound": "A Microsoft não conseguiu encontrar um usuário para esse valor de organizador.",
           "policyMissing": "O usuário Microsoft existe, mas a política de acesso ao aplicativo ainda não permite a criação de reuniões.",

--- a/server/public/locales/pt/msp/settings.json
+++ b/server/public/locales/pt/msp/settings.json
@@ -1741,8 +1741,8 @@
       "install": "Instalar"
     },
     "enterpriseOnly": {
-      "title": "Recurso empresarial",
-      "description": "As extensões estão disponíveis na edição Enterprise do Alga PSA."
+      "title": "Recurso Pro",
+      "description": "As extensões estão disponíveis no Alga PSA Pro."
     },
     "links": {
       "needLogs": "Precisa de registros de extensão?",
@@ -2062,7 +2062,7 @@
   "integrations": {
     "betaNotice": "Algumas integrações ainda estão em desenvolvimento. Trabalhe em um ambiente sandbox ao avaliar e compartilhe seus comentários para nos ajudar a melhorar.",
     "emptyCategory": "Nenhuma integração disponível nesta categoria.",
-    "rmmEnterpriseNote": "As integrações RMM estão disponíveis na edição Enterprise.",
+    "rmmEnterpriseNote": "As integrações RMM estão disponíveis no Pro.",
     "categoryHeading": "Integrações {{label}}",
     "loading": {
       "payments": "Carregando configurações de pagamento..."
@@ -2086,7 +2086,7 @@
       },
       "calendar": {
         "label": "Calendário",
-        "description": "A sincronização de calendário somente empresarial para Google e Outlook mantém o envio e os compromissos do cliente alinhados."
+        "description": "A sincronização de calendário exclusiva do Pro para Google e Outlook mantém o envio e os compromissos do cliente alinhados."
       },
       "providers": {
         "label": "Provedores",

--- a/server/public/locales/pt/msp/user-activities.json
+++ b/server/public/locales/pt/msp/user-activities.json
@@ -143,7 +143,7 @@
       "title": "Item ad hoc",
       "toggleDoneError": "Falha ao atualizar o item."
     },
-    "enterpriseOnly": "As tarefas de fluxo de trabalho são um recurso empresarial.",
+    "enterpriseOnly": "As tarefas de fluxo de trabalho são um recurso Pro.",
     "nextAction": "Próxima ação",
     "overdueSince": "Em atraso desde {{date}}",
     "dueOn": "Vence em {{date}}",

--- a/server/src/app/teams/auth/popup-complete/page.tsx
+++ b/server/src/app/teams/auth/popup-complete/page.tsx
@@ -1,12 +1,14 @@
 import type { Metadata } from 'next';
 import { Card } from '@alga-psa/ui/components/Card';
-import { isTeamsEnterpriseEdition, TEAMS_AVAILABILITY_MESSAGES } from '@alga-psa/integrations/lib/teamsAvailabilityCore';
+import { isTeamsEnterpriseEdition } from '@alga-psa/integrations/lib/teamsAvailabilityCore';
 import { getServerTranslation } from '@alga-psa/ui/lib/i18n/serverOnly';
 import type { ReactNode } from 'react';
 
 export const metadata: Metadata = {
   title: 'Teams Authentication',
 };
+
+const PUBLIC_TEAMS_UNAVAILABLE_MESSAGE = 'Microsoft Teams integration is only available in Pro.';
 
 async function renderUnavailableCard(message: string) {
   const { t } = await getServerTranslation(undefined, 'common');
@@ -28,7 +30,7 @@ let eePagePromise: Promise<EePopupCompleteModule | null> | null = null;
 
 export default async function TeamsTabPopupCompletePage() {
   if (!isTeamsEnterpriseEdition()) {
-    return await renderUnavailableCard(TEAMS_AVAILABILITY_MESSAGES.ce_unavailable);
+    return await renderUnavailableCard(PUBLIC_TEAMS_UNAVAILABLE_MESSAGE);
   }
 
   if (!eePagePromise) {
@@ -42,7 +44,7 @@ export default async function TeamsTabPopupCompletePage() {
 
   const eePage = await eePagePromise;
   if (!eePage?.default) {
-    return await renderUnavailableCard(TEAMS_AVAILABILITY_MESSAGES.ce_unavailable);
+    return await renderUnavailableCard(PUBLIC_TEAMS_UNAVAILABLE_MESSAGE);
   }
 
   return eePage.default();

--- a/server/src/app/teams/tab/page.tsx
+++ b/server/src/app/teams/tab/page.tsx
@@ -1,7 +1,7 @@
 import type { Metadata } from 'next';
 import { Card } from '@alga-psa/ui/components/Card';
 import { UpgradePrompt } from '@alga-psa/ui/components/UpgradePrompt';
-import { isTeamsEnterpriseEdition, TEAMS_AVAILABILITY_MESSAGES } from '@alga-psa/integrations/lib/teamsAvailabilityCore';
+import { isTeamsEnterpriseEdition } from '@alga-psa/integrations/lib/teamsAvailabilityCore';
 import { getServerTranslation } from '@alga-psa/ui/lib/i18n/serverOnly';
 import type { ReactNode } from 'react';
 
@@ -12,6 +12,8 @@ export const metadata: Metadata = {
 interface TeamsTabPageProps {
   searchParams?: Promise<Record<string, string | string[] | undefined>>;
 }
+
+const PUBLIC_TEAMS_UNAVAILABLE_MESSAGE = 'Microsoft Teams integration is only available in Pro.';
 
 async function renderUnavailableCard(message: string) {
   const { t } = await getServerTranslation(undefined, 'common');
@@ -66,7 +68,7 @@ export default async function TeamsTabPage({ searchParams }: TeamsTabPageProps) 
 
   const eePage = await eePagePromise;
   if (!eePage?.default) {
-    return await renderUnavailableCard(TEAMS_AVAILABILITY_MESSAGES.ce_unavailable);
+    return await renderUnavailableCard(PUBLIC_TEAMS_UNAVAILABLE_MESSAGE);
   }
 
   return eePage.default({ searchParams });

--- a/server/src/components/layout/RightSidebar.tsx
+++ b/server/src/components/layout/RightSidebar.tsx
@@ -83,7 +83,7 @@ const RightSidebar: React.FC<RightSidebarProps> = ({
             </h2>
             <p className="text-gray-600 dark:text-[rgb(var(--color-text-500))]">
               {t('rightSidebar.enterpriseOnly', {
-                defaultValue: 'The chat feature is only available in the Enterprise Edition.',
+                defaultValue: 'The chat feature is only available in Pro.',
               })}
             </p>
           </div>

--- a/server/src/components/licenses/LicenseManagementPage.tsx
+++ b/server/src/components/licenses/LicenseManagementPage.tsx
@@ -85,12 +85,12 @@ function statusPresentation(status: LicenseStatus): {
   switch (status.state) {
     case "trial":
       return {
-        eyebrow: "Enterprise trial",
-        title: "Your Enterprise trial is active",
+        eyebrow: "Pro trial",
+        title: "Your Pro trial is active",
         description:
           status.daysRemaining !== null
-            ? `You have ${status.daysRemaining} day${status.daysRemaining === 1 ? "" : "s"} left to use all Enterprise features.`
-            : "You can use all Enterprise features during the trial period.",
+            ? `You have ${status.daysRemaining} day${status.daysRemaining === 1 ? "" : "s"} left to use all Pro features.`
+            : "You can use all Pro features during the trial period.",
         badge: "Trial active",
         tone: "premium",
       };
@@ -127,7 +127,7 @@ function statusPresentation(status: LicenseStatus): {
         eyebrow: "Essentials",
         title: "You’re running Essentials",
         description:
-          "Your Enterprise trial has ended. Essentials remains active for the core PSA feature set.",
+          "Your Pro trial has ended. Essentials remains active for the core PSA feature set.",
         badge: "Essentials active",
         tone: "warning",
       };
@@ -138,7 +138,7 @@ function statusPresentation(status: LicenseStatus): {
         eyebrow: "Essentials",
         title: "You’re running Essentials",
         description:
-          "Essentials is active on this appliance. Keep using the core feature set, or start a one-time 15-day Enterprise trial.",
+          "Essentials is active on this appliance. Keep using the core feature set, or start a one-time 15-day Pro trial.",
         badge: "Essentials active",
         tone: "neutral",
       };
@@ -270,7 +270,7 @@ export default function LicenseManagementPage() {
       const result = await startTrial();
       if (result.success && result.status) {
         await refresh(result.status);
-        setSuccessMsg("15-day Enterprise trial started.");
+        setSuccessMsg("15-day Pro trial started.");
       } else {
         setError(result.error ?? "Failed to start trial.");
       }
@@ -420,11 +420,11 @@ export default function LicenseManagementPage() {
                   </div>
                   <div>
                     <h2 className="text-lg font-semibold text-[rgb(var(--color-text-900))]">
-                      Try Enterprise for 15 days
+                      Try Pro for 15 days
                     </h2>
                     <p className="mt-1 max-w-2xl text-sm text-[rgb(var(--color-text-600))]">
                       Unlock automation, advanced integrations, and the full
-                      Enterprise feature set. No credit card required; the
+                      Pro feature set. No credit card required; the
                       appliance returns to Essentials when the trial ends.
                     </p>
                   </div>
@@ -436,7 +436,7 @@ export default function LicenseManagementPage() {
                   className="w-full gap-2 md:w-auto"
                 >
                   <Sparkles className="h-4 w-4" aria-hidden="true" />
-                  {isPending ? "Starting…" : "Start 15-day Enterprise trial"}
+                  {isPending ? "Starting…" : "Start 15-day Pro trial"}
                 </Button>
               </div>
             </section>

--- a/server/src/components/settings/extensions/ExtensionManagement.tsx
+++ b/server/src/components/settings/extensions/ExtensionManagement.tsx
@@ -120,11 +120,11 @@ export default function ExtensionManagement() {
         ) : (
           <div className="text-center py-10">
             <div className="text-lg font-medium text-gray-900">
-              {t('settings.enterpriseOnly.title', { defaultValue: 'Enterprise feature' })}
+              {t('settings.enterpriseOnly.title', { defaultValue: 'Pro feature' })}
             </div>
             <p className="text-sm text-gray-600 mt-2">
               {t('settings.enterpriseOnly.description', {
-                defaultValue: 'Extensions are available in the Enterprise edition of Alga PSA.'
+                defaultValue: 'Extensions are available in Alga PSA Pro.'
               })}
             </p>
           </div>

--- a/server/src/test/unit/app/pageTitles.metadata.test.ts
+++ b/server/src/test/unit/app/pageTitles.metadata.test.ts
@@ -299,14 +299,14 @@ describe('route title metadata coverage', () => {
 
   it('T015: MSP extension re-export remains metadata-compatible', () => {
     expect(read('server/src/app/msp/extensions/[id]/page.tsx')).toContain("export { default, generateMetadata } from '@product/extensions/entry';");
-    expect(read('packages/product-extensions/oss/entry.tsx')).toContain("title: 'Extensions - Enterprise Feature'");
+    expect(read('packages/product-extensions/oss/entry.tsx')).toContain("title: 'Extensions - Pro Feature'");
     expect(read('packages/product-extensions/ee/entry.tsx')).toContain('export async function generateMetadata()');
     expect(read('packages/product-extensions/ee/entry.tsx')).toContain("defaultValue: 'Extension'");
   });
 
   it('T016: Client Portal extension re-export remains metadata-compatible', () => {
     expect(read('server/src/app/client-portal/extensions/[id]/page.tsx')).toContain("export { default, generateMetadata } from '@product/extensions/entry';");
-    expect(read('packages/product-extensions/oss/entry.tsx')).toContain("title: 'Extensions - Enterprise Feature'");
+    expect(read('packages/product-extensions/oss/entry.tsx')).toContain("title: 'Extensions - Pro Feature'");
     expect(read('packages/product-extensions/ee/entry.tsx')).toContain('export async function generateMetadata()');
     expect(read('packages/product-extensions/ee/entry.tsx')).toContain("defaultValue: 'Extension'");
   });

--- a/server/src/test/unit/authorization/cePolicyManagement.placeholder.test.ts
+++ b/server/src/test/unit/authorization/cePolicyManagement.placeholder.test.ts
@@ -9,7 +9,7 @@ describe('CE authorization bundle management placeholder', () => {
       'utf8'
     );
 
-    expect(source).toContain('Enterprise Premium');
+    expect(source).toContain('available in Premium');
     expect(source).toContain('configure narrowing bundles for roles, teams, users, and API keys');
     expect(source).toContain('Built-in authorization protections remain active');
   });

--- a/server/src/test/unit/ceAccountStub.unit.test.tsx
+++ b/server/src/test/unit/ceAccountStub.unit.test.tsx
@@ -8,7 +8,7 @@ describe('CE account management stub', () => {
   it('renders the hosted upgrade explanation without duplicating the page heading', () => {
     const html = renderToStaticMarkup(React.createElement(AccountManagement));
 
-    expect(html).toContain('Account management and billing features are available in the Enterprise Edition');
+    expect(html).toContain('Account management and billing features are available in Pro');
     expect(html).toContain('Self-hosted Community Edition has unlimited users');
     expect(html).not.toContain('<h1');
     expect(html).not.toContain('<h2');

--- a/server/src/test/unit/components/integrations/EntraIntegrationPage.dynamicImport.test.tsx
+++ b/server/src/test/unit/components/integrations/EntraIntegrationPage.dynamicImport.test.tsx
@@ -13,9 +13,9 @@ describe('EntraIntegrationPage dynamic import target', () => {
 
     render(<EntraIntegrationPage />);
 
-    expect(screen.getByText('Enterprise Feature')).toBeInTheDocument();
+    expect(screen.getByText('Pro Feature')).toBeInTheDocument();
     expect(
-      screen.getByText('Microsoft Entra integration is available in the Enterprise edition of Alga PSA.')
+      screen.getByText('Microsoft Entra integration is available in Alga PSA Pro.')
     ).toBeInTheDocument();
   });
 });

--- a/server/src/test/unit/components/integrations/IntegrationsSettingsPage.calendar.test.tsx
+++ b/server/src/test/unit/components/integrations/IntegrationsSettingsPage.calendar.test.tsx
@@ -207,7 +207,7 @@ describe('IntegrationsSettingsPage Calendar placement', () => {
     render(<IntegrationsSettingsPage />);
 
     expect(screen.getByText('Calendar Integrations')).toBeInTheDocument();
-    expect(screen.getByText('Enterprise-only calendar sync for Google and Outlook keeps dispatch and client appointments aligned.')).toBeInTheDocument();
+    expect(screen.getByText('Pro-only calendar sync for Google and Outlook keeps dispatch and client appointments aligned.')).toBeInTheDocument();
     expect(
       (await screen.findByTestId('calendar-enterprise-settings-shell').catch(() => null)) ??
         screen.getByText('Loading calendar settings...')

--- a/server/src/test/unit/components/licenses/LicenseManagementPage.test.tsx
+++ b/server/src/test/unit/components/licenses/LicenseManagementPage.test.tsx
@@ -78,7 +78,7 @@ describe("LicenseManagementPage", () => {
       await screen.findByRole("heading", { name: "You’re running Essentials" }),
     ).toBeInTheDocument();
     expect(
-      screen.getByRole("button", { name: /Start 15-day Enterprise trial/i }),
+      screen.getByRole("button", { name: /Start 15-day Pro trial/i }),
     ).toBeInTheDocument();
     expect(screen.getByText("Have a license code or key?")).toBeInTheDocument();
 
@@ -109,7 +109,7 @@ describe("LicenseManagementPage", () => {
 
     fireEvent.click(
       await screen.findByRole("button", {
-        name: /Start 15-day Enterprise trial/i,
+        name: /Start 15-day Pro trial/i,
       }),
     );
 
@@ -117,22 +117,22 @@ describe("LicenseManagementPage", () => {
     await waitFor(() => expect(mockUpdateSession).toHaveBeenCalledTimes(1));
     expect(
       screen.queryByRole("heading", {
-        name: "Your Enterprise trial is active",
+        name: "Your Pro trial is active",
       }),
     ).not.toBeInTheDocument();
     expect(
-      screen.queryByText("15-day Enterprise trial started."),
+      screen.queryByText("15-day Pro trial started."),
     ).not.toBeInTheDocument();
 
     resolveSessionUpdate();
 
     expect(
       await screen.findByRole("heading", {
-        name: "Your Enterprise trial is active",
+        name: "Your Pro trial is active",
       }),
     ).toBeInTheDocument();
     expect(
-      screen.getByText("15-day Enterprise trial started."),
+      screen.getByText("15-day Pro trial started."),
     ).toBeInTheDocument();
     expect(mockRouterRefresh).toHaveBeenCalledTimes(1);
   });
@@ -157,7 +157,7 @@ describe("LicenseManagementPage", () => {
     expect(screen.getByText("License refresh")).toBeInTheDocument();
     expect(screen.getByText("Connected")).toBeInTheDocument();
     expect(
-      screen.queryByRole("button", { name: /Start 15-day Enterprise trial/i }),
+      screen.queryByRole("button", { name: /Start 15-day Pro trial/i }),
     ).not.toBeInTheDocument();
   });
 });

--- a/server/src/test/unit/i18n/mspCoreBatch2b1.test.ts
+++ b/server/src/test/unit/i18n/mspCoreBatch2b1.test.ts
@@ -159,7 +159,7 @@ describe('MSP core locale batch 2b-1', () => {
       'quickCreate.dialogTitles.project': 'Add New Project',
       'quickCreate.dialogTitles.service': 'Add New Service',
       'rightSidebar.title': 'Chat',
-      'rightSidebar.enterpriseOnly': 'The chat feature is only available in the Enterprise Edition.',
+      'rightSidebar.enterpriseOnly': 'The chat feature is only available in Pro.',
     };
 
     for (const [key, value] of Object.entries(expectedEntries)) {

--- a/server/src/test/unit/i18n/mspDashboardBatch2b1.test.ts
+++ b/server/src/test/unit/i18n/mspDashboardBatch2b1.test.ts
@@ -149,7 +149,7 @@ describe('MSP dashboard locale batch 2b-1', () => {
       'onboarding.blockers.import.loadFailed': 'Unable to load import history.',
       'onboarding.blockers.calendar.providerAttention': '{{provider}} requires attention before syncing can resume.',
       'onboarding.blockers.calendar.loadFailed': 'Unable to load calendar integrations.',
-      'onboarding.blockers.email.enterpriseOnly': 'Managed email domains are only available in the Enterprise edition.',
+      'onboarding.blockers.email.enterpriseOnly': 'Managed email domains are only available in Pro.',
       'onboarding.blockers.email.tenantRequired': 'Tenant context is required to load email onboarding status.',
       'onboarding.blockers.email.loadFailed': 'Unable to load managed email domains.',
       'onboarding.blockers.email.verificationFailed': 'Verification for {{domain}} failed.',

--- a/server/src/test/unit/workflowsCeStubEntry.unit.test.tsx
+++ b/server/src/test/unit/workflowsCeStubEntry.unit.test.tsx
@@ -7,7 +7,7 @@ import { DnDFlow } from '@enterprise/workflows/entry';
 describe('CE workflows stub entry', () => {
   it('renders stub messaging and does not crash', () => {
     const html = renderToStaticMarkup(React.createElement(DnDFlow));
-    expect(html).toContain('Enterprise Feature');
-    expect(html).toContain('Workflow designer requires Enterprise Edition');
+    expect(html).toContain('Pro Feature');
+    expect(html).toContain('Workflow designer requires Pro');
   });
 });


### PR DESCRIPTION
## Summary

- Rename customer-facing paid-product and upgrade copy from Enterprise to Pro across application surfaces, the shared Community Edition upgrade prompt, CE/OSS fallbacks, public documentation, and maintained translations (`de`, `en`, `es`, `fr`, `it`, `nl`, `pl`, and `pt`).
- Update license/trial messaging and the QuickBooks Online/Xero product badges, along with focused UI and i18n expectations.
- Preserve internal compatibility seams and behavior: `enterprise`/`ee` identifiers, edition checks, aliases, package names, entitlement logic, billing mappings, translation keys, and persisted edition values remain unchanged.
- Rebase the branch onto the current `main`, retaining the newer shared upgrade-prompt implementation while applying the Pro public name to it.

## Validation

PASS, with the environment caveats below.

Automated validation completed before handoff:

- Public Pro-copy translation validation passed across all eight maintained locales, with `xx`/`yy` key structure preserved; it was rerun after the rebase with zero errors or warnings.
- 61 focused UI/i18n assertions passed before handoff. The three conflict-adjacent suites were rerun after the rebase and passed 13/13 assertions, covering the shared upgrade prompt, Teams delegator, and accounting integration cards.
- Server typecheck passed.
- CE production build passed.
- EE webpack production build passed with `NODE_OPTIONS=--max-old-space-size=16384`; an 8 GiB heap was insufficient during webpack cache serialization.
- `git diff --check` passes.
- CI exposed stale public-copy expectations rather than product defects. The tenancy portal-domain assertion was corrected and passed 4/4 locally; policy, calendar, and license assertions were corrected and passed 7/7 locally. The subsequent CI run has passed all completed checks, including affected unit tests, the server unit/coverage suite, affected typecheck, EE workflow build guard, and Tier-1 integrations. At the end of the current watch window, only `fresh-install-e2e` remained running.

Live smoke testing exercised the real product on port 3356 using normal MSP authentication. It covered the English dashboard Pro trial banner; License Management trial, feature, and purchase copy; Home navigation regression; QuickBooks Online and Xero Pro badges; French profile selection and the localized `Essai Pro actif` dashboard; license behavior after the locale change; and locale restoration. Every tested surface had zero visible `Enterprise` matches. PostgreSQL confirmed the locale was restored to unset and the internal compatibility value remains `license_state.edition_choice=ee`.

No simulators, fakes, or mocks were used. The required card browser was created, but cross-host control was rejected; installed Playwright with real Google Chrome drove the same live localhost application instead. The evidence bundle contains nine screenshots and a self-contained README:

`/tmp/alga-smoke-evidence/public-enterprise-name-pro-20260802-213636`

## Caveats and limits

- The French license page body remains English although its banner and navigation localize; its public product terminology is still Pro.
- The license page reports unavailable AI consent/credit services and emitted two POST 500 responses.
- Locale switching emitted a parallel preferences PATCH 401 even though its authenticated server action persisted both the French selection and the subsequent restoration correctly.
- Temporal initialization errors were present.
- These conditions appear unrelated to the rename and did not block the tested flows.
- Not exhaustively tested: inactive or expired trial states, external purchase, client-portal-only surfaces, every paywall, or all eight locales in the live UI.
- Existing unrelated worktree changes were untouched.
- The board-owned dev server was restarted after testing; port 3356 finished healthy with HTTP 200.
