### PR TITLE
Contract simulator feature flag

### DIFF
--- a/docs/features/feature-flags.md
+++ b/docs/features/feature-flags.md
@@ -231,6 +231,21 @@ Gates the QuickBooks Online Products & Services import (tenant-scoped for piloti
 - Also gated by EE edition and billing/service RBAC (`billing_settings:read` for preview;
   `billing_settings:update` + `service:create` for execute).
 
+### 15. `contract-simulator`
+Controls discovery of the Contract Simulator while it is being rolled out.
+
+**Affected Areas:**
+- **MSP Portal:**
+  - Contract Details → Simulate tab
+
+**Behavior:**
+- When disabled (default): The Simulate tab and its content are not rendered. A direct
+  `contractView=simulator` selection falls back to Overview and removes only that query
+  parameter.
+- When enabled: The Simulate tab is available subject to its existing edition and tier checks.
+- Simulator routes, APIs, server actions, and all other entry points remain unchanged. This
+  flag controls only the Contract Details tab and is not an authorization boundary.
+
 ## Implementation Details
 
 ### User Identification

--- a/docs/plans/2026-08-02-contract-simulator-tab-feature-flag-plan.md
+++ b/docs/plans/2026-08-02-contract-simulator-tab-feature-flag-plan.md
@@ -1,0 +1,45 @@
+# Contract Simulator Tab Feature Flag - Implementation Plan
+
+**Card:** Contract simulator feature flag
+**Branch:** `feature/contract-simulator-flag`
+**Scope decision:** Gate only the Contract Simulator tab/entry surface. Routes, server actions, APIs, tier enforcement, and other simulator entry points are deliberately unchanged.
+
+## Current code
+
+- `packages/billing/src/components/billing-dashboard/contracts/ContractDetail.tsx` is a client component and renders both the `TabsTrigger value="simulator"` and matching `TabsContent` unconditionally.
+- The simulator remains dynamically loaded from `@product/billing/entry`; the workspace already performs its own tier check with `TIER_FEATURES.CONTRACT_SIMULATOR`.
+- Product UI feature flags use `useFeatureFlag` from `@alga-psa/ui/hooks`. Existing callers pass a stable key and an explicit default when the flag should fail closed.
+- The current checkout has an unrelated modified `package-lock.json`; implementation must leave it untouched.
+
+## Design
+
+Use a PostHog feature flag named `contract-simulator`, defaulting to disabled while unresolved.
+
+In `ContractDetail.tsx`:
+
+1. Import `useFeatureFlag` from `@alga-psa/ui/hooks`.
+2. Evaluate `useFeatureFlag('contract-simulator', { defaultValue: false })` in `ContractDetail` and retain the boolean `enabled` result.
+3. Render the Simulator `TabsTrigger` only when the flag is enabled.
+4. Render the matching Simulator `TabsContent` only when the flag is enabled, so a hidden entry surface also does not mount or load the simulator.
+5. If the URL requests `contractView=simulator` while the flag is disabled, normalize the selected tab to the existing safe default (`edit`) and update/replace the query through the component's existing tab/query-state path. This prevents a hidden selected value and blank content while keeping all backend surfaces untouched. Do not redirect or block simulator routes/APIs.
+
+Keep the dynamic import and tier guard unchanged. The feature flag controls discoverability of this one contract-detail tab; it is not an authorization boundary.
+
+## Verification
+
+Add or extend a behavioral React test around Contract Detail's tab rendering:
+
+- flag disabled (including the loading/default state): the Simulate tab is absent and simulator content is not mounted;
+- flag enabled: the Simulate tab is present;
+- direct `contractView=simulator` with the flag disabled falls back to Overview/edit rather than leaving a hidden active tab.
+
+Mock the feature-flag hook at its public `@alga-psa/ui/hooks` boundary. Do not add source-text or import-presence assertions.
+
+Run the narrow Contract Detail test target, then the billing package typecheck/build command used by the package. Manually spot-check the running dev stack on port 3195 with the flag off and on if local PostHog overrides are available.
+
+## Explicit non-goals and risks
+
+- No route, API, server-action, or billing-engine gating.
+- No changes to simulator tier/edition behavior, wizard/template entry points, or flag administration.
+- Do not remove or rename `contractView=simulator`; enabled users retain existing deep links.
+- Fail closed while flag state loads to avoid a tab flashing briefly before disappearing. Query normalization must avoid a render/update loop and must preserve unrelated query parameters.

--- a/packages/billing/src/components/billing-dashboard/contracts/ContractDetail.tsx
+++ b/packages/billing/src/components/billing-dashboard/contracts/ContractDetail.tsx
@@ -180,7 +180,10 @@ const ContractDetail: React.FC<ContractDetailProps> = ({
   const billingFrequencyOptions = useBillingFrequencyOptions();
   const searchParams = useSearchParams();
   const router = useRouter();
-  const { enabled: contractSimulatorEnabled } = useFeatureFlag('contract-simulator', {
+  const {
+    enabled: contractSimulatorEnabled,
+    loading: contractSimulatorFlagLoading,
+  } = useFeatureFlag('contract-simulator', {
     defaultValue: false,
   });
   const contractId = (searchParams?.get('contractId') ?? resolvedContractId ?? null) as string | null;
@@ -361,7 +364,9 @@ const ContractDetail: React.FC<ContractDetailProps> = ({
     const requested = searchParams?.get('contractView');
     if (requested === 'simulator' && !contractSimulatorEnabled) {
       setActiveTab('edit');
-      updateContractViewParam('edit');
+      if (!contractSimulatorFlagLoading) {
+        updateContractViewParam('edit');
+      }
       return;
     }
 
@@ -370,7 +375,13 @@ const ContractDetail: React.FC<ContractDetailProps> = ({
     } else if (!requested) {
       setActiveTab('edit');
     }
-  }, [contractSimulatorEnabled, searchParams, updateContractViewParam, validTabs]);
+  }, [
+    contractSimulatorEnabled,
+    contractSimulatorFlagLoading,
+    searchParams,
+    updateContractViewParam,
+    validTabs,
+  ]);
 
   // Sync documents from server props when they change (e.g., after router.refresh())
   useEffect(() => {

--- a/packages/billing/src/components/billing-dashboard/contracts/ContractDetail.tsx
+++ b/packages/billing/src/components/billing-dashboard/contracts/ContractDetail.tsx
@@ -16,6 +16,7 @@ import { Switch } from '@alga-psa/ui/components/Switch';
 import { DatePicker } from '@alga-psa/ui/components/DatePicker';
 import CustomSelect from '@alga-psa/ui/components/CustomSelect';
 import { useDrawer } from '@alga-psa/ui';
+import { useFeatureFlag } from '@alga-psa/ui/hooks';
 import { ConfirmationDialog } from '@alga-psa/ui/components/ConfirmationDialog';
 import { DataTable } from '@alga-psa/ui/components/DataTable';
 import type {
@@ -179,6 +180,9 @@ const ContractDetail: React.FC<ContractDetailProps> = ({
   const billingFrequencyOptions = useBillingFrequencyOptions();
   const searchParams = useSearchParams();
   const router = useRouter();
+  const { enabled: contractSimulatorEnabled } = useFeatureFlag('contract-simulator', {
+    defaultValue: false,
+  });
   const contractId = (searchParams?.get('contractId') ?? resolvedContractId ?? null) as string | null;
   const clientContractId = searchParams?.get('clientContractId') ?? resolvedClientContractId ?? null;
   const tenant = useTenant()!;
@@ -190,8 +194,12 @@ const ContractDetail: React.FC<ContractDetailProps> = ({
   const validTabs = useMemo(() => new Set(['edit', 'lines', 'pricing', 'documents', 'invoices', 'simulator']), []);
   const initialTab = useMemo(() => {
     const requested = searchParams?.get('contractView');
-    return requested && validTabs.has(requested) ? requested : 'edit';
-  }, [searchParams, validTabs]);
+    if (!requested || !validTabs.has(requested)) {
+      return 'edit';
+    }
+
+    return requested === 'simulator' && !contractSimulatorEnabled ? 'edit' : requested;
+  }, [contractSimulatorEnabled, searchParams, validTabs]);
 
   const [activeTab, setActiveTab] = useState(initialTab);
   const [saveSuccess, setSaveSuccess] = useState(false);
@@ -337,16 +345,32 @@ const ContractDetail: React.FC<ContractDetailProps> = ({
   const editingAssignment = editingAssignmentId ? editAssignments[editingAssignmentId] : null;
   const editingRenewalTicketBoardId = editingAssignment?.renewal_ticket_board_id ?? null;
 
+  const updateContractViewParam = useCallback((tabValue: string) => {
+    const params = new URLSearchParams(searchParams?.toString() ?? '');
+    if (tabValue === 'edit') {
+      params.delete('contractView');
+    } else {
+      params.set('contractView', tabValue);
+    }
+    router.replace(`/msp/billing?${params.toString()}`, { scroll: false });
+  }, [router, searchParams]);
+
   // Sync tab state FROM URL changes (e.g., browser back/forward)
   // Don't include activeTab in deps - handleTabChange handles state → URL direction
   useEffect(() => {
     const requested = searchParams?.get('contractView');
+    if (requested === 'simulator' && !contractSimulatorEnabled) {
+      setActiveTab('edit');
+      updateContractViewParam('edit');
+      return;
+    }
+
     if (requested && validTabs.has(requested)) {
       setActiveTab(requested);
     } else if (!requested) {
       setActiveTab('edit');
     }
-  }, [searchParams, validTabs]);
+  }, [contractSimulatorEnabled, searchParams, updateContractViewParam, validTabs]);
 
   // Sync documents from server props when they change (e.g., after router.refresh())
   useEffect(() => {
@@ -461,16 +485,6 @@ const ContractDetail: React.FC<ContractDetailProps> = ({
       active = false;
     };
   }, [editingAssignmentId, editingRenewalTicketBoardId]);
-
-  const updateContractViewParam = useCallback((tabValue: string) => {
-    const params = new URLSearchParams(searchParams?.toString() ?? '');
-    if (tabValue === 'edit') {
-      params.delete('contractView');
-    } else {
-      params.set('contractView', tabValue);
-    }
-    router.replace(`/msp/billing?${params.toString()}`, { scroll: false });
-  }, [router, searchParams]);
 
   const handleTabChange = useCallback((value: string) => {
     setActiveTab(value);
@@ -1380,9 +1394,11 @@ const ContractDetail: React.FC<ContractDetailProps> = ({
           <TabsTrigger value="invoices">
             {t('contractDetail.tabs.invoices', { defaultValue: 'Invoices' })}
           </TabsTrigger>
-          <TabsTrigger value="simulator">
-            {t('contractDetail.tabs.simulator', { defaultValue: 'Simulate' })}
-          </TabsTrigger>
+          {contractSimulatorEnabled && (
+            <TabsTrigger value="simulator">
+              {t('contractDetail.tabs.simulator', { defaultValue: 'Simulate' })}
+            </TabsTrigger>
+          )}
         </TabsList>
 
         <TabsContent value="edit">
@@ -2639,13 +2655,15 @@ const ContractDetail: React.FC<ContractDetailProps> = ({
           </Card>
         </TabsContent>
 
-        <TabsContent value="simulator">
-          <ContractSimulator
-            contractId={contract.contract_id}
-            clientContractId={clientContractId}
-            clientId={primaryAssignment?.client_id ?? contract.owner_client_id ?? null}
-          />
-        </TabsContent>
+        {contractSimulatorEnabled && (
+          <TabsContent value="simulator">
+            <ContractSimulator
+              contractId={contract.contract_id}
+              clientContractId={clientContractId}
+              clientId={primaryAssignment?.client_id ?? contract.owner_client_id ?? null}
+            />
+          </TabsContent>
+        )}
       </Tabs>
 
       <ConfirmationDialog

--- a/packages/billing/tests/ContractDetail.featureFlag.test.tsx
+++ b/packages/billing/tests/ContractDetail.featureFlag.test.tsx
@@ -1,0 +1,281 @@
+/**
+ * @vitest-environment jsdom
+ */
+import React from "react";
+import {
+  afterEach,
+  beforeAll,
+  beforeEach,
+  describe,
+  expect,
+  it,
+  vi,
+} from "vitest";
+import { cleanup, render, screen, waitFor } from "@testing-library/react";
+import "@testing-library/jest-dom/vitest";
+
+const navigationState = vi.hoisted(() => ({
+  params: null as URLSearchParams | null,
+  push: vi.fn(),
+  replace: vi.fn(),
+}));
+const featureFlagState = vi.hoisted(() => ({
+  enabled: false,
+  loading: true,
+  error: null as Error | null,
+}));
+const useFeatureFlagMock = vi.hoisted(() => vi.fn(() => featureFlagState));
+const tabsState = vi.hoisted(() => ({ activeValue: "edit" }));
+
+const getContractByIdMock = vi.hoisted(() => vi.fn());
+const getContractSummaryMock = vi.hoisted(() => vi.fn());
+const getContractAssignmentsMock = vi.hoisted(() => vi.fn());
+
+vi.mock("next/navigation", () => ({
+  useRouter: () => ({
+    push: navigationState.push,
+    replace: navigationState.replace,
+  }),
+  useSearchParams: () => navigationState.params,
+}));
+
+vi.mock("next/dynamic", () => ({
+  default: () =>
+    function MockContractSimulator() {
+      return <div data-testid="contract-simulator-mounted" />;
+    },
+}));
+
+vi.mock("@alga-psa/ui/hooks", () => ({
+  useFeatureFlag: (...args: unknown[]) => useFeatureFlagMock(...args),
+}));
+
+vi.mock("@alga-psa/ui/components/Tabs", () => ({
+  Tabs: ({ value, children }: { value: string; children: React.ReactNode }) => {
+    tabsState.activeValue = value;
+    return <div>{children}</div>;
+  },
+  TabsList: ({ children }: { children: React.ReactNode }) => (
+    <div>{children}</div>
+  ),
+  TabsTrigger: ({
+    value,
+    children,
+  }: {
+    value: string;
+    children: React.ReactNode;
+  }) => (
+    <button type="button" role="tab" data-value={value}>
+      {children}
+    </button>
+  ),
+  TabsContent: ({
+    value,
+    children,
+  }: {
+    value: string;
+    children: React.ReactNode;
+  }) => {
+    if (tabsState.activeValue !== value) {
+      return null;
+    }
+
+    return (
+      <section data-testid={`tab-content-${value}`}>
+        {value === "simulator" ? children : null}
+      </section>
+    );
+  },
+}));
+
+vi.mock("@alga-psa/ui", () => ({
+  useDrawer: () => ({ openDrawer: vi.fn(), replaceDrawer: vi.fn() }),
+}));
+
+vi.mock("@alga-psa/ui/components/providers/TenantProvider", () => ({
+  useTenant: () => "tenant-1",
+}));
+
+vi.mock("@alga-psa/ui/lib/i18n/client", () => ({
+  useTranslation: () => ({
+    t: (key: string, options?: { defaultValue?: string }) =>
+      options?.defaultValue ?? key,
+  }),
+  useFormatters: () => ({
+    formatCurrency: (value: number) => String(value),
+  }),
+}));
+
+vi.mock("@alga-psa/core/context/DocumentsCrossFeatureContext", () => ({
+  useDocumentsCrossFeature: () => ({
+    getDocumentsByContractId: vi.fn(async () => []),
+    renderDocuments: vi.fn(() => null),
+  }),
+}));
+
+vi.mock("@alga-psa/billing/hooks/useBillingEnumOptions", () => ({
+  useBillingFrequencyOptions: () => [],
+}));
+
+vi.mock("@alga-psa/billing/actions/contractActions", () => ({
+  getContractById: (...args: unknown[]) => getContractByIdMock(...args),
+  getContractSummary: (...args: unknown[]) => getContractSummaryMock(...args),
+  getContractAssignments: (...args: unknown[]) =>
+    getContractAssignmentsMock(...args),
+  updateContract: vi.fn(),
+  deleteContract: vi.fn(),
+}));
+
+vi.mock("@alga-psa/billing/actions/quoteActions", () => ({
+  getQuoteByConvertedContractId: vi.fn(async () => null),
+}));
+
+vi.mock("@alga-psa/billing/actions/billingClientsActions", () => ({
+  getClientContractByIdForBilling: vi.fn(async () => null),
+  updateClientContractForBilling: vi.fn(),
+  getClientByIdForBilling: vi.fn(),
+}));
+
+vi.mock("@alga-psa/reference-data/actions/boardActions", () => ({
+  getAllBoards: vi.fn(async () => []),
+}));
+
+vi.mock(
+  "@alga-psa/reference-data/actions/status-actions/statusActions",
+  () => ({
+    getTicketStatuses: vi.fn(async () => []),
+  }),
+);
+
+vi.mock("@alga-psa/billing/actions/invoiceQueries", () => ({
+  fetchInvoicesByContract: vi.fn(async () => []),
+}));
+
+vi.mock("@alga-psa/billing/actions/invoiceTemplates", () => ({
+  getInvoiceTemplates: vi.fn(async () => []),
+}));
+
+vi.mock("../src/components/billing-dashboard/contracts/ContractHeader", () => ({
+  default: () => null,
+}));
+
+vi.mock("../src/components/billing-dashboard/contracts/ContractLines", () => ({
+  default: () => null,
+}));
+
+vi.mock(
+  "../src/components/billing-dashboard/contracts/ContractOverview",
+  () => ({
+    default: () => null,
+  }),
+);
+
+vi.mock(
+  "../src/components/billing-dashboard/contracts/PricingSchedules",
+  () => ({
+    default: () => null,
+  }),
+);
+
+vi.mock(
+  "../src/components/billing-dashboard/invoicing/InvoicePreviewPanel",
+  () => ({
+    default: () => null,
+  }),
+);
+
+describe("ContractDetail contract simulator feature flag", () => {
+  let ContractDetail: React.ComponentType<{
+    resolvedContractId?: string | null;
+  }>;
+
+  beforeAll(async () => {
+    ContractDetail = (
+      await import("../src/components/billing-dashboard/contracts/ContractDetail")
+    ).default;
+  }, 60_000);
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    navigationState.params = new URLSearchParams(
+      "tab=contracts&contractId=contract-1",
+    );
+    featureFlagState.enabled = false;
+    featureFlagState.loading = true;
+    featureFlagState.error = null;
+    tabsState.activeValue = "edit";
+
+    getContractByIdMock.mockResolvedValue({
+      contract_id: "contract-1",
+      contract_name: "Support contract",
+      contract_description: null,
+      billing_frequency: "monthly",
+      currency_code: "USD",
+      is_template: false,
+      is_system_managed_default: false,
+      owner_client_id: null,
+      status: "draft",
+    });
+    getContractSummaryMock.mockResolvedValue(null);
+    getContractAssignmentsMock.mockResolvedValue([]);
+  });
+
+  afterEach(() => {
+    cleanup();
+  });
+
+  it("fails closed while the flag is unresolved and does not mount simulator content", async () => {
+    render(<ContractDetail resolvedContractId="contract-1" />);
+
+    expect(
+      await screen.findByRole("tab", { name: "Overview" }),
+    ).toBeInTheDocument();
+    expect(
+      screen.queryByRole("tab", { name: "Simulate" }),
+    ).not.toBeInTheDocument();
+    expect(
+      screen.queryByTestId("contract-simulator-mounted"),
+    ).not.toBeInTheDocument();
+    expect(useFeatureFlagMock).toHaveBeenCalledWith("contract-simulator", {
+      defaultValue: false,
+    });
+  });
+
+  it("renders the Simulate tab when the flag is enabled", async () => {
+    navigationState.params = new URLSearchParams(
+      "tab=contracts&contractId=contract-1&contractView=simulator",
+    );
+    featureFlagState.enabled = true;
+    featureFlagState.loading = false;
+
+    render(<ContractDetail resolvedContractId="contract-1" />);
+
+    expect(
+      await screen.findByRole("tab", { name: "Simulate" }),
+    ).toBeInTheDocument();
+    expect(
+      await screen.findByTestId("contract-simulator-mounted"),
+    ).toBeInTheDocument();
+    expect(navigationState.replace).not.toHaveBeenCalled();
+  });
+
+  it("normalizes a disabled simulator deep link to Overview and preserves other query parameters", async () => {
+    navigationState.params = new URLSearchParams(
+      "tab=contracts&contractId=contract-1&contractView=simulator&foo=bar",
+    );
+    featureFlagState.loading = false;
+
+    render(<ContractDetail resolvedContractId="contract-1" />);
+
+    expect(await screen.findByTestId("tab-content-edit")).toBeInTheDocument();
+    expect(
+      screen.queryByRole("tab", { name: "Simulate" }),
+    ).not.toBeInTheDocument();
+    await waitFor(() => {
+      expect(navigationState.replace).toHaveBeenCalledWith(
+        "/msp/billing?tab=contracts&contractId=contract-1&foo=bar",
+        { scroll: false },
+      );
+    });
+  });
+});

--- a/packages/billing/tests/ContractDetail.featureFlag.test.tsx
+++ b/packages/billing/tests/ContractDetail.featureFlag.test.tsx
@@ -259,6 +259,34 @@ describe("ContractDetail contract simulator feature flag", () => {
     expect(navigationState.replace).not.toHaveBeenCalled();
   });
 
+  it("preserves a simulator deep link until the flag verdict is available", async () => {
+    navigationState.params = new URLSearchParams(
+      "tab=contracts&contractId=contract-1&contractView=simulator&foo=bar",
+    );
+
+    const { rerender } = render(
+      <ContractDetail resolvedContractId="contract-1" />,
+    );
+
+    expect(await screen.findByTestId("tab-content-edit")).toBeInTheDocument();
+    expect(
+      screen.queryByRole("tab", { name: "Simulate" }),
+    ).not.toBeInTheDocument();
+    expect(navigationState.replace).not.toHaveBeenCalled();
+
+    featureFlagState.enabled = true;
+    featureFlagState.loading = false;
+    rerender(<ContractDetail resolvedContractId="contract-1" />);
+
+    expect(
+      await screen.findByRole("tab", { name: "Simulate" }),
+    ).toBeInTheDocument();
+    expect(
+      await screen.findByTestId("contract-simulator-mounted"),
+    ).toBeInTheDocument();
+    expect(navigationState.replace).not.toHaveBeenCalled();
+  });
+
   it("normalizes a disabled simulator deep link to Overview and preserves other query parameters", async () => {
     navigationState.params = new URLSearchParams(
       "tab=contracts&contractId=contract-1&contractView=simulator&foo=bar",


### PR DESCRIPTION
## Summary

- Add the `contract-simulator` PostHog feature flag with a fail-closed default around only the Contract Details Simulate tab and content.
- Preserve simulator routes, APIs, server actions, tier checks, and every other non-UI surface unchanged.
- Normalize disabled simulator deep links back to Overview by removing only `contractView`, preserving other query parameters and ordinary tab/URL synchronization.
- Wait for the feature-flag verdict before normalizing a simulator deep link, so an unresolved → enabled transition retains and selects `contractView=simulator`.
- Document the flag and add behavioral coverage for disabled, enabled, and unresolved verdicts.

## Testing

- `npm test --workspace=packages/billing -- ContractDetail.featureFlag.test.tsx` — PASS (4 tests).
- Authenticated UI smoke — PASS. Exercised the real branch server on port 3195 with the `alga-psa-local-test` infrastructure and authenticated as Glinda. Verified: real disabled verdict hides Simulate; disabled simulator deep links fall back to Overview, remove only `contractView`, and preserve other parameters; ordinary Contract Lines navigation still synchronizes the URL; enabled verdict exposes/selects Simulate and preserves its deep link; unresolved → enabled behavior preserved `contractView` until the verdict resolved; clearing the override restored disabled behavior.
- Used the repository’s documented temporary environment override and PostHog SDK’s supported non-persistent override—no mock or custom simulator. Both were removed; the service is healthy and unforced, and `package-lock.json` remains untouched.
- Limitation: the mounted simulator surface hit the existing “Contract Simulator requires Pro” gate despite the tenant showing “Pro trial active,” so downstream simulator calculations were unreachable.
- Temporary restart-related JWT/500 errors cleared after re-login; no failed requests occurred in the final run.

Evidence: `/tmp/alga-smoke-evidence/contract-simulator-feature-flag-20260802-222836`