### PR TITLE
Informative responses for EE-only API routes (alga0002214)

### DIFF
--- a/docs/plans/2026-08-02-informative-ee-api-responses-plan.md
+++ b/docs/plans/2026-08-02-informative-ee-api-responses-plan.md
@@ -1,0 +1,50 @@
+# Informative responses for EE-only API routes
+
+## Problem
+
+Community Edition route shells for Enterprise-only capabilities currently return unrelated bare 404 payloads such as `{ "error": "Enterprise feature" }` or `{ "error": "Not found" }`. That makes an intentionally unavailable product capability indistinguishable from a missing endpoint and gives clients no stable signal for showing the shared upgrade experience.
+
+## Design decisions
+
+1. Add a server-owned edition-gate response helper in the CE-safe server library. It returns a stable JSON contract with HTTP 403:
+   - `error`: concise human-readable explanation
+   - `code`: `EE_REQUIRED`
+   - `feature`: stable machine-readable feature key
+   - `message`: display-ready feature-specific copy
+   - `upgrade`: structured metadata needed by the shared upgrade prompt (including the public Pro product name and an upgrade path/CTA when available)
+2. Keep authentication and authorization semantics separate. The helper is used only after a route has determined the build lacks the capability; ordinary 401/403 authorization failures and genuine 404 resources retain their existing contracts.
+3. Convert the identified CE route shells to the helper, starting with MCP agents and covering the same edition-gated families: MCP/discovery `.well-known` endpoints, platform notifications, platform reports, platform feature flags, tenant management, and appliance installs. Each call supplies an explicit feature key and feature name.
+4. Preserve protocol-specific payloads where standards require them. OAuth discovery/authorization responses may retain required OAuth fields, but should add or map the same `EE_REQUIRED` signal where doing so is protocol-safe. Continue `Cache-Control: no-store` on discovery endpoints.
+5. Add a small client-side type guard/parser for the contract and route it to the existing shared upgrade prompt/stub instead of duplicating banners. Fetch callers that currently treat every non-2xx response as “not found” should recognize `EE_REQUIRED`; other errors continue through existing handling.
+
+## Implementation sequence
+
+1. Inventory edition checks in `server/src/app/api/v1/**`, `server/src/app/.well-known/**`, and CE seam modules such as `packages/product-mcp/oss/entry.ts`; classify standard JSON routes versus protocol-specific routes.
+2. Introduce the typed response body and helper in a CE-safe server module with a feature-key union or constants for the migrated families.
+3. Replace repeated inline `NextResponse.json(..., { status: 404 })` gates in the scoped route families. Avoid changing route success behavior, EE dynamic imports, or authorization order.
+4. Introduce/reuse a client parser and connect affected UI consumers to the shared upgrade prompt component delivered by alga0002208. Keep the component dependency one-way: generic API code recognizes the contract; feature screens decide how and where to render the prompt.
+5. Add behavioral tests that call representative route handlers in CE mode and assert HTTP 403 plus the typed body, including no-store headers for discovery. Add client behavior tests proving `EE_REQUIRED` renders the shared upgrade stub while genuine 404 and authorization errors do not.
+6. Run targeted tests, TypeScript checks for touched packages, and a CE smoke pass against at least MCP plus one platform route.
+
+## Deliberate non-goals
+
+- Do not expose Enterprise implementation details or dynamically import EE modules in CE.
+- Do not convert genuine missing-resource 404s or ordinary permission failures.
+- Do not redesign the shared upgrade prompt; consume the component owned by alga0002208.
+- Do not rename unrelated “Enterprise” internals as part of this card; public-facing upgrade copy should say Pro, while edition environment identifiers may remain unchanged.
+- Do not make a repository-wide conversion of every historical edition check in one change; cover the ticket’s enumerated API families and leave a reusable helper for follow-up migration.
+
+## Risks and mitigations
+
+- **Clients rely on 404:** migrate known consumers in the same change and document the new 403 contract.
+- **Information disclosure:** feature names are product catalog metadata only; no tenant, license, or implementation details belong in the response.
+- **Protocol incompatibility:** retain protocol-mandated shapes and headers, adding the signal only where compatible.
+- **Partial migration:** maintain an explicit inventory/checklist in the implementation PR and test representative handlers from each route family.
+
+## Acceptance criteria
+
+- Scoped CE-only routes return a consistent, typed `EE_REQUIRED` response rather than a bare 404.
+- The response identifies the unavailable feature and carries enough structured upgrade metadata for the shared Pro upgrade prompt.
+- Affected client surfaces render the shared upgrade stub for this contract.
+- Real 404, 401, and authorization 403 behavior remains unchanged.
+- CE builds do not import EE implementations, and targeted behavioral tests and type checks pass.

--- a/packages/ui/src/components/tier-gating/FeatureUpgradeNotice.tsx
+++ b/packages/ui/src/components/tier-gating/FeatureUpgradeNotice.tsx
@@ -11,6 +11,10 @@ interface FeatureUpgradeNoticeProps {
   requiredTier: TenantTier;
   /** Optional description of the feature */
   description?: string;
+  /** Optional upgrade destination supplied by an API edition gate */
+  upgradeHref?: string;
+  /** Optional upgrade CTA supplied by an API edition gate */
+  upgradeLabel?: string;
 }
 
 /**
@@ -21,6 +25,8 @@ export function FeatureUpgradeNotice({
   featureName,
   requiredTier,
   description,
+  upgradeHref = '/msp/account',
+  upgradeLabel = 'View Plans',
 }: FeatureUpgradeNoticeProps) {
   const tierLabel = TIER_LABELS[requiredTier];
 
@@ -40,10 +46,10 @@ export function FeatureUpgradeNotice({
       </p>
 
       <Link
-        href="/msp/account"
+        href={upgradeHref}
         className="inline-flex items-center justify-center px-6 py-3 bg-primary text-primary-foreground hover:bg-primary/90 font-medium rounded-lg transition-colors"
       >
-        View Plans
+        {upgradeLabel}
       </Link>
     </div>
   );

--- a/server/src/app/.well-known/jwks.json/route.ts
+++ b/server/src/app/.well-known/jwks.json/route.ts
@@ -5,6 +5,7 @@
  */
 import { NextRequest, NextResponse } from 'next/server';
 import { isEnterpriseEdition } from '@/lib/features';
+import { editionGateResponse } from '@/lib/editionGating/response';
 
 export const dynamic = 'force-dynamic';
 export const runtime = 'nodejs';
@@ -13,7 +14,7 @@ const NO_STORE = { 'Cache-Control': 'no-store, max-age=0' } as const;
 
 export async function GET(_req: NextRequest): Promise<NextResponse> {
   if (!isEnterpriseEdition()) {
-    return NextResponse.json({ error: 'Not found' }, { status: 404, headers: NO_STORE });
+    return editionGateResponse('mcp', { headers: NO_STORE });
   }
   const { getPublicJwks } = await import('@product/mcp/entry');
   return NextResponse.json(await getPublicJwks(), { headers: NO_STORE });

--- a/server/src/app/.well-known/oauth-authorization-server/route.ts
+++ b/server/src/app/.well-known/oauth-authorization-server/route.ts
@@ -4,6 +4,7 @@
  */
 import { NextRequest, NextResponse } from 'next/server';
 import { isEnterpriseEdition } from '@/lib/features';
+import { editionGateResponse } from '@/lib/editionGating/response';
 
 export const dynamic = 'force-dynamic';
 export const runtime = 'nodejs';
@@ -13,7 +14,7 @@ const NO_STORE = { 'Cache-Control': 'no-store, max-age=0' } as const;
 
 export async function GET(req: NextRequest): Promise<NextResponse> {
   if (!isEnterpriseEdition()) {
-    return NextResponse.json({ error: 'Not found' }, { status: 404, headers: NO_STORE });
+    return editionGateResponse('mcp', { headers: NO_STORE });
   }
   const { buildAuthServerMetadata, resolvePublicBaseUrl } = await import('@product/mcp/entry');
   const base = await resolvePublicBaseUrl(req);

--- a/server/src/app/.well-known/oauth-protected-resource/route.ts
+++ b/server/src/app/.well-known/oauth-protected-resource/route.ts
@@ -5,6 +5,7 @@
  */
 import { NextRequest, NextResponse } from 'next/server';
 import { isEnterpriseEdition } from '@/lib/features';
+import { editionGateResponse } from '@/lib/editionGating/response';
 
 export const dynamic = 'force-dynamic';
 export const runtime = 'nodejs';
@@ -17,7 +18,7 @@ const NO_STORE = { 'Cache-Control': 'no-store, max-age=0' } as const;
 
 export async function GET(req: NextRequest): Promise<NextResponse> {
   if (!isEnterpriseEdition()) {
-    return NextResponse.json({ error: 'Not found' }, { status: 404, headers: NO_STORE });
+    return editionGateResponse('mcp', { headers: NO_STORE });
   }
   const { resolvePublicBaseUrl } = await import('@product/mcp/entry');
   // External clients (e.g. claude.ai) read this, so it must be the public origin.

--- a/server/src/app/api/mcp/oauth/authorize/route.ts
+++ b/server/src/app/api/mcp/oauth/authorize/route.ts
@@ -5,6 +5,7 @@
  */
 import { NextRequest, NextResponse } from 'next/server';
 import { isEnterpriseEdition } from '@/lib/features';
+import { createEditionGateResponseBody, EDITION_GATE_CODE } from '@/lib/editionGating/types';
 
 export const dynamic = 'force-dynamic';
 export const runtime = 'nodejs';
@@ -17,12 +18,19 @@ function escapeHtml(s: string): string {
   );
 }
 
-function errorPage(message: string, status: number): NextResponse {
+function errorPage(message: string, status: number, code?: string): NextResponse {
   const html = `<!doctype html><meta charset="utf-8"><title>Authorization error</title>
 <body style="font-family:system-ui;max-width:32rem;margin:4rem auto;padding:0 1rem">
 <h1 style="font-size:1.25rem">Authorization error</h1>
 <p>${escapeHtml(message)}</p></body>`;
-  return new NextResponse(html, { status, headers: { 'content-type': 'text/html; charset=utf-8', ...NO_STORE } });
+  return new NextResponse(html, {
+    status,
+    headers: {
+      'content-type': 'text/html; charset=utf-8',
+      ...(code ? { 'X-Alga-Error-Code': code } : {}),
+      ...NO_STORE,
+    },
+  });
 }
 
 function consentPage(params: { clientName: string | null; clientId: string; signedRequest: string; tenant: string }): NextResponse {
@@ -42,7 +50,9 @@ function consentPage(params: { clientName: string | null; clientId: string; sign
 }
 
 export async function GET(req: NextRequest): Promise<NextResponse> {
-  if (!isEnterpriseEdition()) return errorPage('Not found.', 404);
+  if (!isEnterpriseEdition()) {
+    return errorPage(createEditionGateResponseBody('mcp').message, 403, EDITION_GATE_CODE);
+  }
   const { prepareAuthorize, resolvePublicBaseUrl } = await import('@product/mcp/entry');
   const base = await resolvePublicBaseUrl(req);
   const publicUrl = new URL(`${base}${req.nextUrl.pathname}${req.nextUrl.search}`);
@@ -60,7 +70,9 @@ export async function GET(req: NextRequest): Promise<NextResponse> {
 }
 
 export async function POST(req: NextRequest): Promise<NextResponse> {
-  if (!isEnterpriseEdition()) return errorPage('Not found.', 404);
+  if (!isEnterpriseEdition()) {
+    return errorPage(createEditionGateResponseBody('mcp').message, 403, EDITION_GATE_CODE);
+  }
   const { completeAuthorize, resolvePublicBaseUrl } = await import('@product/mcp/entry');
   const base = await resolvePublicBaseUrl(req);
 

--- a/server/src/app/api/mcp/oauth/revoke/route.ts
+++ b/server/src/app/api/mcp/oauth/revoke/route.ts
@@ -4,6 +4,7 @@
  */
 import { NextRequest, NextResponse } from 'next/server';
 import { isEnterpriseEdition } from '@/lib/features';
+import { editionGateOAuthResponse } from '@/lib/editionGating/response';
 
 export const dynamic = 'force-dynamic';
 export const runtime = 'nodejs';
@@ -12,7 +13,7 @@ const NO_STORE = { 'Cache-Control': 'no-store, max-age=0' };
 
 export async function POST(req: NextRequest): Promise<NextResponse> {
   if (!isEnterpriseEdition()) {
-    return new NextResponse(null, { status: 404, headers: NO_STORE });
+    return editionGateOAuthResponse('mcp', { headers: NO_STORE });
   }
   const { handleRevoke } = await import('@product/mcp/entry');
   let form: URLSearchParams;

--- a/server/src/app/api/mcp/oauth/token/route.ts
+++ b/server/src/app/api/mcp/oauth/token/route.ts
@@ -4,6 +4,7 @@
  */
 import { NextRequest, NextResponse } from 'next/server';
 import { isEnterpriseEdition } from '@/lib/features';
+import { editionGateOAuthResponse } from '@/lib/editionGating/response';
 
 export const dynamic = 'force-dynamic';
 export const runtime = 'nodejs';
@@ -12,7 +13,7 @@ const NO_STORE = { 'Cache-Control': 'no-store, max-age=0' };
 
 export async function POST(req: NextRequest): Promise<NextResponse> {
   if (!isEnterpriseEdition()) {
-    return NextResponse.json({ error: 'invalid_request' }, { status: 404, headers: NO_STORE });
+    return editionGateOAuthResponse('mcp', { headers: NO_STORE });
   }
   const { handleToken, resolvePublicBaseUrl } = await import('@product/mcp/entry');
   const base = await resolvePublicBaseUrl(req);

--- a/server/src/app/api/mcp/route.ts
+++ b/server/src/app/api/mcp/route.ts
@@ -5,13 +5,14 @@
  */
 import { NextRequest, NextResponse } from 'next/server';
 import { isEnterpriseEdition } from '@/lib/features';
+import { editionGateResponse } from '@/lib/editionGating/response';
 
 export const dynamic = 'force-dynamic';
 export const runtime = 'nodejs';
 
 export async function POST(req: NextRequest): Promise<Response> {
   if (!isEnterpriseEdition()) {
-    return NextResponse.json({ error: 'The remote MCP server is an Enterprise feature.' }, { status: 404 });
+    return editionGateResponse('mcp');
   }
   const { handleMcpJsonRpc } = await import('@product/mcp/entry');
   return handleMcpJsonRpc(req);

--- a/server/src/app/api/v1/appliance-installs/[tenantId]/route.ts
+++ b/server/src/app/api/v1/appliance-installs/[tenantId]/route.ts
@@ -1,6 +1,8 @@
 /**
- * Appliance Console API — appliance install detail CE stub. Lazy-loads the EE route, or returns 501 for CE builds.
+ * Appliance Console API — appliance install detail CE stub. Lazy-loads the EE route, or returns an informative 403 for CE builds.
  */
+
+import { editionGateResponse } from '@/lib/editionGating/response';
 
 export const runtime = 'nodejs';
 export const dynamic = 'force-dynamic';
@@ -38,16 +40,10 @@ async function loadEeRoute(): Promise<EeRouteModule | null> {
 }
 
 function eeUnavailable(): Response {
-  return new Response(
-    JSON.stringify({
-      success: false,
-      error: 'Appliance console is only available in Enterprise Edition.',
-    }),
-    {
-      status: 501,
-      headers: { 'content-type': 'application/json' },
-    }
-  );
+  if (isEnterpriseEdition) {
+    throw new Error('The Enterprise route failed to load.');
+  }
+  return editionGateResponse('appliance-installs');
 }
 
 export async function GET(request: Request, context: RouteContext): Promise<Response> {

--- a/server/src/app/api/v1/appliance-installs/access/route.ts
+++ b/server/src/app/api/v1/appliance-installs/access/route.ts
@@ -1,6 +1,8 @@
 /**
- * Appliance Console API — access logging CE stub. Lazy-loads the EE route, or returns 501 for CE builds.
+ * Appliance Console API — access logging CE stub. Lazy-loads the EE route, or returns an informative 403 for CE builds.
  */
+
+import { editionGateResponse } from '@/lib/editionGating/response';
 
 export const runtime = 'nodejs';
 export const dynamic = 'force-dynamic';
@@ -34,16 +36,10 @@ async function loadEeRoute(): Promise<EeRouteModule | null> {
 }
 
 function eeUnavailable(): Response {
-  return new Response(
-    JSON.stringify({
-      success: false,
-      error: 'Appliance console is only available in Enterprise Edition.',
-    }),
-    {
-      status: 501,
-      headers: { 'content-type': 'application/json' },
-    }
-  );
+  if (isEnterpriseEdition) {
+    throw new Error('The Enterprise route failed to load.');
+  }
+  return editionGateResponse('appliance-installs');
 }
 
 export async function POST(request: Request): Promise<Response> {

--- a/server/src/app/api/v1/appliance-installs/route.ts
+++ b/server/src/app/api/v1/appliance-installs/route.ts
@@ -1,6 +1,8 @@
 /**
- * Appliance Console API — CE stub. Lazy-loads the EE route, or returns 501 for CE builds.
+ * Appliance Console API — CE stub. Lazy-loads the EE route, or returns an informative 403 for CE builds.
  */
+
+import { editionGateResponse } from '@/lib/editionGating/response';
 
 export const runtime = 'nodejs';
 export const dynamic = 'force-dynamic';
@@ -34,16 +36,10 @@ async function loadEeRoute(): Promise<EeRouteModule | null> {
 }
 
 function eeUnavailable(): Response {
-  return new Response(
-    JSON.stringify({
-      success: false,
-      error: 'Appliance console is only available in Enterprise Edition.',
-    }),
-    {
-      status: 501,
-      headers: { 'content-type': 'application/json' },
-    }
-  );
+  if (isEnterpriseEdition) {
+    throw new Error('The Enterprise route failed to load.');
+  }
+  return editionGateResponse('appliance-installs');
 }
 
 export async function GET(request: Request): Promise<Response> {

--- a/server/src/app/api/v1/mcp/agents/route.ts
+++ b/server/src/app/api/v1/mcp/agents/route.ts
@@ -1,6 +1,8 @@
 /**
  * MCP agent provisioning (EE). Implementation loaded via the @product/mcp seam.
  */
+
+import { editionGateResponse } from '@/lib/editionGating/response';
 import { NextRequest, NextResponse } from 'next/server';
 import { isEnterpriseEdition } from '@/lib/features';
 
@@ -8,7 +10,7 @@ export const dynamic = 'force-dynamic';
 export const runtime = 'nodejs';
 
 export async function GET(req: NextRequest): Promise<NextResponse> {
-  if (!isEnterpriseEdition()) return NextResponse.json({ error: 'Enterprise feature' }, { status: 404 });
+  if (!isEnterpriseEdition()) return editionGateResponse('mcp');
   const { authenticateMcpAdmin, listAgents } = await import('@product/mcp/entry');
   const admin = await authenticateMcpAdmin(req);
   if (!admin) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
@@ -16,7 +18,7 @@ export async function GET(req: NextRequest): Promise<NextResponse> {
 }
 
 export async function POST(req: NextRequest): Promise<NextResponse> {
-  if (!isEnterpriseEdition()) return NextResponse.json({ error: 'Enterprise feature' }, { status: 404 });
+  if (!isEnterpriseEdition()) return editionGateResponse('mcp');
   const { authenticateMcpAdmin, createAgent } = await import('@product/mcp/entry');
   const admin = await authenticateMcpAdmin(req);
   if (!admin) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
@@ -52,7 +54,7 @@ export async function POST(req: NextRequest): Promise<NextResponse> {
 
 // Toggle an agent's active flag (the reversible soft-disable).
 export async function PATCH(req: NextRequest): Promise<NextResponse> {
-  if (!isEnterpriseEdition()) return NextResponse.json({ error: 'Enterprise feature' }, { status: 404 });
+  if (!isEnterpriseEdition()) return editionGateResponse('mcp');
   const { authenticateMcpAdmin, setAgentActive } = await import('@product/mcp/entry');
   const admin = await authenticateMcpAdmin(req);
   if (!admin) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
@@ -67,7 +69,7 @@ export async function PATCH(req: NextRequest): Promise<NextResponse> {
 
 // Permanently remove an agent (irreversible — tears down roles, audit, backing user).
 export async function DELETE(req: NextRequest): Promise<NextResponse> {
-  if (!isEnterpriseEdition()) return NextResponse.json({ error: 'Enterprise feature' }, { status: 404 });
+  if (!isEnterpriseEdition()) return editionGateResponse('mcp');
   const { authenticateMcpAdmin, deleteAgent } = await import('@product/mcp/entry');
   const admin = await authenticateMcpAdmin(req);
   if (!admin) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });

--- a/server/src/app/api/v1/mcp/audit/route.ts
+++ b/server/src/app/api/v1/mcp/audit/route.ts
@@ -1,6 +1,8 @@
 /**
  * MCP agent-action audit export (EE). Implementation loaded via the @product/mcp seam.
  */
+
+import { editionGateResponse } from '@/lib/editionGating/response';
 import { NextRequest, NextResponse } from 'next/server';
 import { isEnterpriseEdition } from '@/lib/features';
 
@@ -8,7 +10,7 @@ export const dynamic = 'force-dynamic';
 export const runtime = 'nodejs';
 
 export async function GET(req: NextRequest): Promise<NextResponse> {
-  if (!isEnterpriseEdition()) return NextResponse.json({ error: 'Enterprise feature' }, { status: 404 });
+  if (!isEnterpriseEdition()) return editionGateResponse('mcp');
   const { authenticateMcpAdmin, exportAgentAudit } = await import('@product/mcp/entry');
   const admin = await authenticateMcpAdmin(req);
   if (!admin) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });

--- a/server/src/app/api/v1/mcp/connect/callback/route.ts
+++ b/server/src/app/api/v1/mcp/connect/callback/route.ts
@@ -7,6 +7,7 @@
  */
 import { NextRequest, NextResponse } from 'next/server';
 import { isEnterpriseEdition } from '@/lib/features';
+import { createEditionGateResponseBody, EDITION_GATE_CODE } from '@/lib/editionGating/types';
 
 export const dynamic = 'force-dynamic';
 export const runtime = 'nodejs';
@@ -45,10 +46,12 @@ export async function GET(req: NextRequest): Promise<NextResponse> {
     /* ignore — validated below */
   }
 
-  const fail = (error: string) =>
-    htmlResponse(postMessageHtml({ type: 'oauth-callback', provider, success: false, error }), true);
+  const fail = (error: string, errorCode?: string) =>
+    htmlResponse(postMessageHtml({ type: 'oauth-callback', provider, success: false, error, errorCode }), true);
 
-  if (!isEnterpriseEdition()) return fail('The MCP server is an Enterprise feature.');
+  if (!isEnterpriseEdition()) {
+    return fail(createEditionGateResponseBody('mcp').message, EDITION_GATE_CODE);
+  }
   if (oauthError) return fail(sp.get('error_description') || oauthError);
   if (!code || !state) return fail('Missing authorization code or state.');
 

--- a/server/src/app/api/v1/mcp/connect/start/route.ts
+++ b/server/src/app/api/v1/mcp/connect/start/route.ts
@@ -3,6 +3,8 @@
  * provider authorize URL and sets the signed, path-scoped state cookie that the
  * callback requires. Implementation loaded via the @product/mcp seam.
  */
+
+import { editionGateResponse } from '@/lib/editionGating/response';
 import { NextRequest, NextResponse } from 'next/server';
 import { isEnterpriseEdition } from '@/lib/features';
 import { getSecretProviderInstance } from '@alga-psa/core/secrets';
@@ -24,7 +26,7 @@ async function resolveBaseUrl(req: NextRequest): Promise<string> {
 }
 
 export async function POST(req: NextRequest): Promise<NextResponse> {
-  if (!isEnterpriseEdition()) return NextResponse.json({ error: 'Enterprise feature' }, { status: 404 });
+  if (!isEnterpriseEdition()) return editionGateResponse('mcp');
   const { authenticateMcpAdmin, buildConnectAuthUrl } = await import('@product/mcp/entry');
   const admin = await authenticateMcpAdmin(req);
   if (!admin) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });

--- a/server/src/app/api/v1/mcp/connections/route.ts
+++ b/server/src/app/api/v1/mcp/connections/route.ts
@@ -4,6 +4,8 @@
  * the clients (e.g. Claude) they've authorized. User-session authed (not admin).
  * Implementation loaded via the @product/mcp seam.
  */
+
+import { editionGateResponse } from '@/lib/editionGating/response';
 import { NextRequest, NextResponse } from 'next/server';
 import { isEnterpriseEdition } from '@/lib/features';
 import { getCurrentUser } from '@/lib/auth/session';
@@ -12,7 +14,7 @@ export const dynamic = 'force-dynamic';
 export const runtime = 'nodejs';
 
 export async function GET(): Promise<NextResponse> {
-  if (!isEnterpriseEdition()) return NextResponse.json({ error: 'Enterprise feature' }, { status: 404 });
+  if (!isEnterpriseEdition()) return editionGateResponse('mcp');
   const user = await getCurrentUser();
   if (!user) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
   const { listConnectedClients } = await import('@product/mcp/entry');
@@ -20,7 +22,7 @@ export async function GET(): Promise<NextResponse> {
 }
 
 export async function DELETE(req: NextRequest): Promise<NextResponse> {
-  if (!isEnterpriseEdition()) return NextResponse.json({ error: 'Enterprise feature' }, { status: 404 });
+  if (!isEnterpriseEdition()) return editionGateResponse('mcp');
   const user = await getCurrentUser();
   if (!user) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
   const grantId = req.nextUrl.searchParams.get('grantId') ?? undefined;

--- a/server/src/app/api/v1/mcp/idp-providers/route.ts
+++ b/server/src/app/api/v1/mcp/idp-providers/route.ts
@@ -1,6 +1,8 @@
 /**
  * MCP trusted IdP providers (EE). Implementation loaded via the @product/mcp seam.
  */
+
+import { editionGateResponse } from '@/lib/editionGating/response';
 import { NextRequest, NextResponse } from 'next/server';
 import { isEnterpriseEdition } from '@/lib/features';
 
@@ -8,7 +10,7 @@ export const dynamic = 'force-dynamic';
 export const runtime = 'nodejs';
 
 export async function GET(req: NextRequest): Promise<NextResponse> {
-  if (!isEnterpriseEdition()) return NextResponse.json({ error: 'Enterprise feature' }, { status: 404 });
+  if (!isEnterpriseEdition()) return editionGateResponse('mcp');
   const { authenticateMcpAdmin, listTrustedIdps } = await import('@product/mcp/entry');
   const admin = await authenticateMcpAdmin(req);
   if (!admin) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
@@ -16,7 +18,7 @@ export async function GET(req: NextRequest): Promise<NextResponse> {
 }
 
 export async function POST(req: NextRequest): Promise<NextResponse> {
-  if (!isEnterpriseEdition()) return NextResponse.json({ error: 'Enterprise feature' }, { status: 404 });
+  if (!isEnterpriseEdition()) return editionGateResponse('mcp');
   const { authenticateMcpAdmin, addTrustedIdp } = await import('@product/mcp/entry');
   const admin = await authenticateMcpAdmin(req);
   if (!admin) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });

--- a/server/src/app/api/v1/mcp/idp-suggestions/route.ts
+++ b/server/src/app/api/v1/mcp/idp-suggestions/route.ts
@@ -2,6 +2,8 @@
  * IdP setup suggestions (EE, F008): if the tenant already linked Microsoft, we
  * know their Entra tenant id and can pre-fill the agent IdP. Loaded via the seam.
  */
+
+import { editionGateResponse } from '@/lib/editionGating/response';
 import { NextRequest, NextResponse } from 'next/server';
 import { isEnterpriseEdition } from '@/lib/features';
 
@@ -9,7 +11,7 @@ export const dynamic = 'force-dynamic';
 export const runtime = 'nodejs';
 
 export async function GET(req: NextRequest): Promise<NextResponse> {
-  if (!isEnterpriseEdition()) return NextResponse.json({ error: 'Enterprise feature' }, { status: 404 });
+  if (!isEnterpriseEdition()) return editionGateResponse('mcp');
   const { authenticateMcpAdmin, getIdpSuggestions } = await import('@product/mcp/entry');
   const admin = await authenticateMcpAdmin(req);
   if (!admin) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });

--- a/server/src/app/api/v1/mcp/platform-providers/route.ts
+++ b/server/src/app/api/v1/mcp/platform-providers/route.ts
@@ -2,6 +2,8 @@
  * Hosted platform providers (EE): which shared Microsoft/Google apps are
  * available for zero-config agent provisioning. Loaded via the @product/mcp seam.
  */
+
+import { editionGateResponse } from '@/lib/editionGating/response';
 import { NextRequest, NextResponse } from 'next/server';
 import { isEnterpriseEdition } from '@/lib/features';
 
@@ -9,7 +11,7 @@ export const dynamic = 'force-dynamic';
 export const runtime = 'nodejs';
 
 export async function GET(req: NextRequest): Promise<NextResponse> {
-  if (!isEnterpriseEdition()) return NextResponse.json({ error: 'Enterprise feature' }, { status: 404 });
+  if (!isEnterpriseEdition()) return editionGateResponse('mcp');
   const { authenticateMcpAdmin, listPlatformProviders } = await import('@product/mcp/entry');
   const admin = await authenticateMcpAdmin(req);
   if (!admin) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });

--- a/server/src/app/api/v1/mcp/roles/route.ts
+++ b/server/src/app/api/v1/mcp/roles/route.ts
@@ -2,6 +2,8 @@
  * Assignable MSP roles for agent provisioning (EE). Powers the role picker in
  * the admin UI. Implementation loaded via the @product/mcp seam.
  */
+
+import { editionGateResponse } from '@/lib/editionGating/response';
 import { NextRequest, NextResponse } from 'next/server';
 import { isEnterpriseEdition } from '@/lib/features';
 
@@ -9,7 +11,7 @@ export const dynamic = 'force-dynamic';
 export const runtime = 'nodejs';
 
 export async function GET(req: NextRequest): Promise<NextResponse> {
-  if (!isEnterpriseEdition()) return NextResponse.json({ error: 'Enterprise feature' }, { status: 404 });
+  if (!isEnterpriseEdition()) return editionGateResponse('mcp');
   const { authenticateMcpAdmin, listAssignableRoles } = await import('@product/mcp/entry');
   const admin = await authenticateMcpAdmin(req);
   if (!admin) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });

--- a/server/src/app/api/v1/platform-feature-flags/[flagId]/route.ts
+++ b/server/src/app/api/v1/platform-feature-flags/[flagId]/route.ts
@@ -1,8 +1,10 @@
 /**
  * Platform Feature Flags API - Single Flag CE Stub
  *
- * This stub lazy-loads the EE implementation or returns 501 for CE builds.
+ * This stub lazy-loads the EE implementation or returns an informative 403 for CE builds.
  */
+
+import { editionGateResponse } from '@/lib/editionGating/response';
 
 export const runtime = 'nodejs';
 export const dynamic = 'force-dynamic';
@@ -43,16 +45,10 @@ async function loadEeRoute(): Promise<EeRouteModule | null> {
 }
 
 function eeUnavailable(): Response {
-  return new Response(
-    JSON.stringify({
-      success: false,
-      error: 'Feature flag management is only available in Enterprise Edition.',
-    }),
-    {
-      status: 501,
-      headers: { 'content-type': 'application/json' },
-    }
-  );
+  if (isEnterpriseEdition) {
+    throw new Error('The Enterprise route failed to load.');
+  }
+  return editionGateResponse('platform-feature-flags');
 }
 
 export async function GET(request: Request, context: RouteContext): Promise<Response> {

--- a/server/src/app/api/v1/platform-feature-flags/[flagId]/tenants/route.ts
+++ b/server/src/app/api/v1/platform-feature-flags/[flagId]/tenants/route.ts
@@ -1,8 +1,10 @@
 /**
  * Platform Feature Flags API - Tenant Management CE Stub
  *
- * This stub lazy-loads the EE implementation or returns 501 for CE builds.
+ * This stub lazy-loads the EE implementation or returns an informative 403 for CE builds.
  */
+
+import { editionGateResponse } from '@/lib/editionGating/response';
 
 export const runtime = 'nodejs';
 export const dynamic = 'force-dynamic';
@@ -40,16 +42,10 @@ async function loadEeRoute(): Promise<EeRouteModule | null> {
 }
 
 function eeUnavailable(): Response {
-  return new Response(
-    JSON.stringify({
-      success: false,
-      error: 'Feature flag management is only available in Enterprise Edition.',
-    }),
-    {
-      status: 501,
-      headers: { 'content-type': 'application/json' },
-    }
-  );
+  if (isEnterpriseEdition) {
+    throw new Error('The Enterprise route failed to load.');
+  }
+  return editionGateResponse('platform-feature-flags');
 }
 
 export async function POST(request: Request, context: RouteContext): Promise<Response> {

--- a/server/src/app/api/v1/platform-feature-flags/route.ts
+++ b/server/src/app/api/v1/platform-feature-flags/route.ts
@@ -1,8 +1,10 @@
 /**
  * Platform Feature Flags API - CE Stub
  *
- * This stub lazy-loads the EE implementation or returns 501 for CE builds.
+ * This stub lazy-loads the EE implementation or returns an informative 403 for CE builds.
  */
+
+import { editionGateResponse } from '@/lib/editionGating/response';
 
 export const runtime = 'nodejs';
 export const dynamic = 'force-dynamic';
@@ -37,16 +39,10 @@ async function loadEeRoute(): Promise<EeRouteModule | null> {
 }
 
 function eeUnavailable(): Response {
-  return new Response(
-    JSON.stringify({
-      success: false,
-      error: 'Feature flag management is only available in Enterprise Edition.',
-    }),
-    {
-      status: 501,
-      headers: { 'content-type': 'application/json' },
-    }
-  );
+  if (isEnterpriseEdition) {
+    throw new Error('The Enterprise route failed to load.');
+  }
+  return editionGateResponse('platform-feature-flags');
 }
 
 export async function GET(request: Request): Promise<Response> {

--- a/server/src/app/api/v1/platform-notifications/[notificationId]/reads/route.ts
+++ b/server/src/app/api/v1/platform-notifications/[notificationId]/reads/route.ts
@@ -1,8 +1,10 @@
 /**
  * Platform Notifications [notificationId] Reads API - CE Stub
  *
- * This stub lazy-loads the EE implementation or returns 501 for CE builds.
+ * This stub lazy-loads the EE implementation or returns an informative 403 for CE builds.
  */
+
+import { editionGateResponse } from '@/lib/editionGating/response';
 
 export const runtime = 'nodejs';
 export const dynamic = 'force-dynamic';
@@ -40,16 +42,10 @@ async function loadEeRoute(): Promise<EeRouteModule | null> {
 }
 
 function eeUnavailable(): Response {
-  return new Response(
-    JSON.stringify({
-      success: false,
-      error: 'Platform notifications are only available in Enterprise Edition.',
-    }),
-    {
-      status: 501,
-      headers: { 'content-type': 'application/json' },
-    }
-  );
+  if (isEnterpriseEdition) {
+    throw new Error('The Enterprise route failed to load.');
+  }
+  return editionGateResponse('platform-notifications');
 }
 
 export async function GET(request: Request, context: RouteContext): Promise<Response> {

--- a/server/src/app/api/v1/platform-notifications/[notificationId]/route.ts
+++ b/server/src/app/api/v1/platform-notifications/[notificationId]/route.ts
@@ -1,8 +1,10 @@
 /**
  * Platform Notifications [notificationId] API - CE Stub
  *
- * This stub lazy-loads the EE implementation or returns 501 for CE builds.
+ * This stub lazy-loads the EE implementation or returns an informative 403 for CE builds.
  */
+
+import { editionGateResponse } from '@/lib/editionGating/response';
 
 export const runtime = 'nodejs';
 export const dynamic = 'force-dynamic';
@@ -43,16 +45,10 @@ async function loadEeRoute(): Promise<EeRouteModule | null> {
 }
 
 function eeUnavailable(): Response {
-  return new Response(
-    JSON.stringify({
-      success: false,
-      error: 'Platform notifications are only available in Enterprise Edition.',
-    }),
-    {
-      status: 501,
-      headers: { 'content-type': 'application/json' },
-    }
-  );
+  if (isEnterpriseEdition) {
+    throw new Error('The Enterprise route failed to load.');
+  }
+  return editionGateResponse('platform-notifications');
 }
 
 export async function GET(request: Request, context: RouteContext): Promise<Response> {

--- a/server/src/app/api/v1/platform-notifications/[notificationId]/stats/route.ts
+++ b/server/src/app/api/v1/platform-notifications/[notificationId]/stats/route.ts
@@ -1,8 +1,10 @@
 /**
  * Platform Notifications [notificationId] Stats API - CE Stub
  *
- * This stub lazy-loads the EE implementation or returns 501 for CE builds.
+ * This stub lazy-loads the EE implementation or returns an informative 403 for CE builds.
  */
+
+import { editionGateResponse } from '@/lib/editionGating/response';
 
 export const runtime = 'nodejs';
 export const dynamic = 'force-dynamic';
@@ -40,16 +42,10 @@ async function loadEeRoute(): Promise<EeRouteModule | null> {
 }
 
 function eeUnavailable(): Response {
-  return new Response(
-    JSON.stringify({
-      success: false,
-      error: 'Platform notifications are only available in Enterprise Edition.',
-    }),
-    {
-      status: 501,
-      headers: { 'content-type': 'application/json' },
-    }
-  );
+  if (isEnterpriseEdition) {
+    throw new Error('The Enterprise route failed to load.');
+  }
+  return editionGateResponse('platform-notifications');
 }
 
 export async function GET(request: Request, context: RouteContext): Promise<Response> {

--- a/server/src/app/api/v1/platform-notifications/resolve-recipients/route.ts
+++ b/server/src/app/api/v1/platform-notifications/resolve-recipients/route.ts
@@ -1,8 +1,10 @@
 /**
  * Platform Notifications Resolve Recipients API - CE Stub
  *
- * This stub lazy-loads the EE implementation or returns 501 for CE builds.
+ * This stub lazy-loads the EE implementation or returns an informative 403 for CE builds.
  */
+
+import { editionGateResponse } from '@/lib/editionGating/response';
 
 export const runtime = 'nodejs';
 export const dynamic = 'force-dynamic';
@@ -36,16 +38,10 @@ async function loadEeRoute(): Promise<EeRouteModule | null> {
 }
 
 function eeUnavailable(): Response {
-  return new Response(
-    JSON.stringify({
-      success: false,
-      error: 'Platform notifications are only available in Enterprise Edition.',
-    }),
-    {
-      status: 501,
-      headers: { 'content-type': 'application/json' },
-    }
-  );
+  if (isEnterpriseEdition) {
+    throw new Error('The Enterprise route failed to load.');
+  }
+  return editionGateResponse('platform-notifications');
 }
 
 export async function POST(request: Request): Promise<Response> {

--- a/server/src/app/api/v1/platform-notifications/route.ts
+++ b/server/src/app/api/v1/platform-notifications/route.ts
@@ -1,8 +1,10 @@
 /**
  * Platform Notifications API - CE Stub
  *
- * This stub lazy-loads the EE implementation or returns 501 for CE builds.
+ * This stub lazy-loads the EE implementation or returns an informative 403 for CE builds.
  */
+
+import { editionGateResponse } from '@/lib/editionGating/response';
 
 export const runtime = 'nodejs';
 export const dynamic = 'force-dynamic';
@@ -37,16 +39,10 @@ async function loadEeRoute(): Promise<EeRouteModule | null> {
 }
 
 function eeUnavailable(): Response {
-  return new Response(
-    JSON.stringify({
-      success: false,
-      error: 'Platform notifications are only available in Enterprise Edition.',
-    }),
-    {
-      status: 501,
-      headers: { 'content-type': 'application/json' },
-    }
-  );
+  if (isEnterpriseEdition) {
+    throw new Error('The Enterprise route failed to load.');
+  }
+  return editionGateResponse('platform-notifications');
 }
 
 export async function GET(request: Request): Promise<Response> {

--- a/server/src/app/api/v1/platform-reports/[reportId]/execute/route.ts
+++ b/server/src/app/api/v1/platform-reports/[reportId]/execute/route.ts
@@ -1,8 +1,10 @@
 /**
  * Platform Reports API - Execute Report CE Stub
  *
- * This stub lazy-loads the EE implementation or returns 501 for CE builds.
+ * This stub lazy-loads the EE implementation or returns an informative 403 for CE builds.
  */
+
+import { editionGateResponse } from '@/lib/editionGating/response';
 
 export const runtime = 'nodejs';
 export const dynamic = 'force-dynamic';
@@ -40,16 +42,10 @@ async function loadEeRoute(): Promise<EeRouteModule | null> {
 }
 
 function eeUnavailable(): Response {
-  return new Response(
-    JSON.stringify({
-      success: false,
-      error: 'Platform reports are only available in Enterprise Edition.',
-    }),
-    {
-      status: 501,
-      headers: { 'content-type': 'application/json' },
-    }
-  );
+  if (isEnterpriseEdition) {
+    throw new Error('The Enterprise route failed to load.');
+  }
+  return editionGateResponse('platform-reports');
 }
 
 export async function POST(

--- a/server/src/app/api/v1/platform-reports/[reportId]/route.ts
+++ b/server/src/app/api/v1/platform-reports/[reportId]/route.ts
@@ -1,8 +1,10 @@
 /**
  * Platform Reports API - Single Report CE Stub
  *
- * This stub lazy-loads the EE implementation or returns 501 for CE builds.
+ * This stub lazy-loads the EE implementation or returns an informative 403 for CE builds.
  */
+
+import { editionGateResponse } from '@/lib/editionGating/response';
 
 export const runtime = 'nodejs';
 export const dynamic = 'force-dynamic';
@@ -43,16 +45,10 @@ async function loadEeRoute(): Promise<EeRouteModule | null> {
 }
 
 function eeUnavailable(): Response {
-  return new Response(
-    JSON.stringify({
-      success: false,
-      error: 'Platform reports are only available in Enterprise Edition.',
-    }),
-    {
-      status: 501,
-      headers: { 'content-type': 'application/json' },
-    }
-  );
+  if (isEnterpriseEdition) {
+    throw new Error('The Enterprise route failed to load.');
+  }
+  return editionGateResponse('platform-reports');
 }
 
 export async function GET(

--- a/server/src/app/api/v1/platform-reports/access/route.ts
+++ b/server/src/app/api/v1/platform-reports/access/route.ts
@@ -1,10 +1,11 @@
 /**
  * Platform Reports Access API - CE Stub
  *
- * This stub lazy-loads the EE implementation or returns 501 for CE builds.
+ * This stub lazy-loads the EE implementation or returns an informative 403 for CE builds.
  */
 
 import { NextRequest, NextResponse } from 'next/server';
+import { editionGateResponse } from '@/lib/editionGating/response';
 
 export const runtime = 'nodejs';
 export const dynamic = 'force-dynamic';
@@ -38,13 +39,10 @@ async function loadEeRoute(): Promise<EeRouteModule | null> {
 }
 
 function eeUnavailable(): NextResponse {
-  return NextResponse.json(
-    {
-      success: false,
-      error: 'Platform reports access logging is only available in Enterprise Edition.',
-    },
-    { status: 501 }
-  );
+  if (isEnterpriseEdition) {
+    throw new Error('The Enterprise route failed to load.');
+  }
+  return editionGateResponse('platform-reports');
 }
 
 export async function POST(request: NextRequest): Promise<NextResponse> {

--- a/server/src/app/api/v1/platform-reports/audit/route.ts
+++ b/server/src/app/api/v1/platform-reports/audit/route.ts
@@ -1,8 +1,10 @@
 /**
  * Platform Reports Audit API - CE Stub
  *
- * This stub lazy-loads the EE implementation or returns 501 for CE builds.
+ * This stub lazy-loads the EE implementation or returns an informative 403 for CE builds.
  */
+
+import { editionGateResponse } from '@/lib/editionGating/response';
 
 export const runtime = 'nodejs';
 export const dynamic = 'force-dynamic';
@@ -36,16 +38,10 @@ async function loadEeRoute(): Promise<EeRouteModule | null> {
 }
 
 function eeUnavailable(): Response {
-  return new Response(
-    JSON.stringify({
-      success: false,
-      error: 'Platform reports audit is only available in Enterprise Edition.',
-    }),
-    {
-      status: 501,
-      headers: { 'content-type': 'application/json' },
-    }
-  );
+  if (isEnterpriseEdition) {
+    throw new Error('The Enterprise route failed to load.');
+  }
+  return editionGateResponse('platform-reports');
 }
 
 export async function GET(request: Request): Promise<Response> {

--- a/server/src/app/api/v1/platform-reports/route.ts
+++ b/server/src/app/api/v1/platform-reports/route.ts
@@ -1,8 +1,10 @@
 /**
  * Platform Reports API - CE Stub
  *
- * This stub lazy-loads the EE implementation or returns 501 for CE builds.
+ * This stub lazy-loads the EE implementation or returns an informative 403 for CE builds.
  */
+
+import { editionGateResponse } from '@/lib/editionGating/response';
 
 export const runtime = 'nodejs';
 export const dynamic = 'force-dynamic';
@@ -37,16 +39,10 @@ async function loadEeRoute(): Promise<EeRouteModule | null> {
 }
 
 function eeUnavailable(): Response {
-  return new Response(
-    JSON.stringify({
-      success: false,
-      error: 'Platform reports are only available in Enterprise Edition.',
-    }),
-    {
-      status: 501,
-      headers: { 'content-type': 'application/json' },
-    }
-  );
+  if (isEnterpriseEdition) {
+    throw new Error('The Enterprise route failed to load.');
+  }
+  return editionGateResponse('platform-reports');
 }
 
 export async function GET(request: Request): Promise<Response> {

--- a/server/src/app/api/v1/platform-reports/schema/route.ts
+++ b/server/src/app/api/v1/platform-reports/schema/route.ts
@@ -1,8 +1,10 @@
 /**
  * Platform Reports Schema API - CE Stub
  *
- * This stub lazy-loads the EE implementation or returns 501 for CE builds.
+ * This stub lazy-loads the EE implementation or returns an informative 403 for CE builds.
  */
+
+import { editionGateResponse } from '@/lib/editionGating/response';
 
 export const runtime = 'nodejs';
 export const dynamic = 'force-dynamic';
@@ -36,16 +38,10 @@ async function loadEeRoute(): Promise<EeRouteModule | null> {
 }
 
 function eeUnavailable(): Response {
-  return new Response(
-    JSON.stringify({
-      success: false,
-      error: 'Platform reports schema is only available in Enterprise Edition.',
-    }),
-    {
-      status: 501,
-      headers: { 'content-type': 'application/json' },
-    }
-  );
+  if (isEnterpriseEdition) {
+    throw new Error('The Enterprise route failed to load.');
+  }
+  return editionGateResponse('platform-reports');
 }
 
 export async function GET(request: Request): Promise<Response> {

--- a/server/src/app/api/v1/tenant-management/addons/route.ts
+++ b/server/src/app/api/v1/tenant-management/addons/route.ts
@@ -2,6 +2,8 @@
  * Tenant Management API - Supported add-ons - CE Stub
  */
 
+import { editionGateResponse } from '@/lib/editionGating/response';
+
 export const runtime = 'nodejs';
 export const dynamic = 'force-dynamic';
 
@@ -31,16 +33,10 @@ async function loadEeRoute(): Promise<EeRouteModule | null> {
 }
 
 function eeUnavailable(): Response {
-  return new Response(
-    JSON.stringify({
-      success: false,
-      error: 'Tenant management is only available in Enterprise Edition.',
-    }),
-    {
-      status: 501,
-      headers: { 'content-type': 'application/json' },
-    }
-  );
+  if (isEnterpriseEdition) {
+    throw new Error('The Enterprise route failed to load.');
+  }
+  return editionGateResponse('tenant-management');
 }
 
 export async function GET(request: Request): Promise<Response> {

--- a/server/src/app/api/v1/tenant-management/audit/route.ts
+++ b/server/src/app/api/v1/tenant-management/audit/route.ts
@@ -1,8 +1,10 @@
 /**
  * Tenant Management API - Audit Logs - CE Stub
  *
- * This stub lazy-loads the EE implementation or returns 501 for CE builds.
+ * This stub lazy-loads the EE implementation or returns an informative 403 for CE builds.
  */
+
+import { editionGateResponse } from '@/lib/editionGating/response';
 
 export const runtime = 'nodejs';
 export const dynamic = 'force-dynamic';
@@ -35,16 +37,10 @@ async function loadEeRoute(): Promise<EeRouteModule | null> {
 }
 
 function eeUnavailable(): Response {
-  return new Response(
-    JSON.stringify({
-      success: false,
-      error: 'Tenant management is only available in Enterprise Edition.',
-    }),
-    {
-      status: 501,
-      headers: { 'content-type': 'application/json' },
-    }
-  );
+  if (isEnterpriseEdition) {
+    throw new Error('The Enterprise route failed to load.');
+  }
+  return editionGateResponse('tenant-management');
 }
 
 export async function GET(request: Request): Promise<Response> {

--- a/server/src/app/api/v1/tenant-management/confirm-deletion/route.ts
+++ b/server/src/app/api/v1/tenant-management/confirm-deletion/route.ts
@@ -1,8 +1,10 @@
 /**
  * Tenant Management API - Confirm Deletion - CE Stub
  *
- * This stub lazy-loads the EE implementation or returns 501 for CE builds.
+ * This stub lazy-loads the EE implementation or returns an informative 403 for CE builds.
  */
+
+import { editionGateResponse } from '@/lib/editionGating/response';
 
 export const runtime = 'nodejs';
 export const dynamic = 'force-dynamic';
@@ -35,16 +37,10 @@ async function loadEeRoute(): Promise<EeRouteModule | null> {
 }
 
 function eeUnavailable(): Response {
-  return new Response(
-    JSON.stringify({
-      success: false,
-      error: 'Tenant management is only available in Enterprise Edition.',
-    }),
-    {
-      status: 501,
-      headers: { 'content-type': 'application/json' },
-    }
-  );
+  if (isEnterpriseEdition) {
+    throw new Error('The Enterprise route failed to load.');
+  }
+  return editionGateResponse('tenant-management');
 }
 
 export async function POST(request: Request): Promise<Response> {

--- a/server/src/app/api/v1/tenant-management/create-tenant/route.ts
+++ b/server/src/app/api/v1/tenant-management/create-tenant/route.ts
@@ -1,8 +1,10 @@
 /**
  * Tenant Management API - Create Tenant - CE Stub
  *
- * This stub lazy-loads the EE implementation or returns 501 for CE builds.
+ * This stub lazy-loads the EE implementation or returns an informative 403 for CE builds.
  */
+
+import { editionGateResponse } from '@/lib/editionGating/response';
 
 export const runtime = 'nodejs';
 export const dynamic = 'force-dynamic';
@@ -35,16 +37,10 @@ async function loadEeRoute(): Promise<EeRouteModule | null> {
 }
 
 function eeUnavailable(): Response {
-  return new Response(
-    JSON.stringify({
-      success: false,
-      error: 'Tenant management is only available in Enterprise Edition.',
-    }),
-    {
-      status: 501,
-      headers: { 'content-type': 'application/json' },
-    }
-  );
+  if (isEnterpriseEdition) {
+    throw new Error('The Enterprise route failed to load.');
+  }
+  return editionGateResponse('tenant-management');
 }
 
 export async function POST(request: Request): Promise<Response> {

--- a/server/src/app/api/v1/tenant-management/export-tenant/route.ts
+++ b/server/src/app/api/v1/tenant-management/export-tenant/route.ts
@@ -1,8 +1,10 @@
 /**
  * Tenant Management API - Export Tenant - CE Stub
  *
- * This stub lazy-loads the EE implementation or returns 501 for CE builds.
+ * This stub lazy-loads the EE implementation or returns an informative 403 for CE builds.
  */
+
+import { editionGateResponse } from '@/lib/editionGating/response';
 
 export const runtime = 'nodejs';
 export const dynamic = 'force-dynamic';
@@ -35,16 +37,10 @@ async function loadEeRoute(): Promise<EeRouteModule | null> {
 }
 
 function eeUnavailable(): Response {
-  return new Response(
-    JSON.stringify({
-      success: false,
-      error: 'Tenant management is only available in Enterprise Edition.',
-    }),
-    {
-      status: 501,
-      headers: { 'content-type': 'application/json' },
-    }
-  );
+  if (isEnterpriseEdition) {
+    throw new Error('The Enterprise route failed to load.');
+  }
+  return editionGateResponse('tenant-management');
 }
 
 export async function POST(request: Request): Promise<Response> {

--- a/server/src/app/api/v1/tenant-management/exports/[exportId]/download-url/route.ts
+++ b/server/src/app/api/v1/tenant-management/exports/[exportId]/download-url/route.ts
@@ -1,8 +1,10 @@
 /**
  * Tenant Management API - Get Export Download URL - CE Stub
  *
- * This stub lazy-loads the EE implementation or returns 501 for CE builds.
+ * This stub lazy-loads the EE implementation or returns an informative 403 for CE builds.
  */
+
+import { editionGateResponse } from '@/lib/editionGating/response';
 
 export const runtime = 'nodejs';
 export const dynamic = 'force-dynamic';
@@ -35,16 +37,10 @@ async function loadEeRoute(): Promise<EeRouteModule | null> {
 }
 
 function eeUnavailable(): Response {
-  return new Response(
-    JSON.stringify({
-      success: false,
-      error: 'Tenant management is only available in Enterprise Edition.',
-    }),
-    {
-      status: 501,
-      headers: { 'content-type': 'application/json' },
-    }
-  );
+  if (isEnterpriseEdition) {
+    throw new Error('The Enterprise route failed to load.');
+  }
+  return editionGateResponse('tenant-management');
 }
 
 export async function POST(

--- a/server/src/app/api/v1/tenant-management/exports/route.ts
+++ b/server/src/app/api/v1/tenant-management/exports/route.ts
@@ -1,8 +1,10 @@
 /**
  * Tenant Management API - List Exports - CE Stub
  *
- * This stub lazy-loads the EE implementation or returns 501 for CE builds.
+ * This stub lazy-loads the EE implementation or returns an informative 403 for CE builds.
  */
+
+import { editionGateResponse } from '@/lib/editionGating/response';
 
 export const runtime = 'nodejs';
 export const dynamic = 'force-dynamic';
@@ -35,16 +37,10 @@ async function loadEeRoute(): Promise<EeRouteModule | null> {
 }
 
 function eeUnavailable(): Response {
-  return new Response(
-    JSON.stringify({
-      success: false,
-      error: 'Tenant management is only available in Enterprise Edition.',
-    }),
-    {
-      status: 501,
-      headers: { 'content-type': 'application/json' },
-    }
-  );
+  if (isEnterpriseEdition) {
+    throw new Error('The Enterprise route failed to load.');
+  }
+  return editionGateResponse('tenant-management');
 }
 
 export async function GET(request: Request): Promise<Response> {

--- a/server/src/app/api/v1/tenant-management/pending-deletions/route.ts
+++ b/server/src/app/api/v1/tenant-management/pending-deletions/route.ts
@@ -1,8 +1,10 @@
 /**
  * Tenant Management API - Pending Deletions - CE Stub
  *
- * This stub lazy-loads the EE implementation or returns 501 for CE builds.
+ * This stub lazy-loads the EE implementation or returns an informative 403 for CE builds.
  */
+
+import { editionGateResponse } from '@/lib/editionGating/response';
 
 export const runtime = 'nodejs';
 export const dynamic = 'force-dynamic';
@@ -35,16 +37,10 @@ async function loadEeRoute(): Promise<EeRouteModule | null> {
 }
 
 function eeUnavailable(): Response {
-  return new Response(
-    JSON.stringify({
-      success: false,
-      error: 'Tenant management is only available in Enterprise Edition.',
-    }),
-    {
-      status: 501,
-      headers: { 'content-type': 'application/json' },
-    }
-  );
+  if (isEnterpriseEdition) {
+    throw new Error('The Enterprise route failed to load.');
+  }
+  return editionGateResponse('tenant-management');
 }
 
 export async function GET(request: Request): Promise<Response> {

--- a/server/src/app/api/v1/tenant-management/resend-welcome-email/route.ts
+++ b/server/src/app/api/v1/tenant-management/resend-welcome-email/route.ts
@@ -1,8 +1,10 @@
 /**
  * Tenant Management API - Resend Welcome Email - CE Stub
  *
- * This stub lazy-loads the EE implementation or returns 501 for CE builds.
+ * This stub lazy-loads the EE implementation or returns an informative 403 for CE builds.
  */
+
+import { editionGateResponse } from '@/lib/editionGating/response';
 
 export const runtime = 'nodejs';
 export const dynamic = 'force-dynamic';
@@ -35,16 +37,10 @@ async function loadEeRoute(): Promise<EeRouteModule | null> {
 }
 
 function eeUnavailable(): Response {
-  return new Response(
-    JSON.stringify({
-      success: false,
-      error: 'Tenant management is only available in Enterprise Edition.',
-    }),
-    {
-      status: 501,
-      headers: { 'content-type': 'application/json' },
-    }
-  );
+  if (isEnterpriseEdition) {
+    throw new Error('The Enterprise route failed to load.');
+  }
+  return editionGateResponse('tenant-management');
 }
 
 export async function POST(request: Request): Promise<Response> {

--- a/server/src/app/api/v1/tenant-management/rollback-deletion/route.ts
+++ b/server/src/app/api/v1/tenant-management/rollback-deletion/route.ts
@@ -1,8 +1,10 @@
 /**
  * Tenant Management API - Rollback Deletion - CE Stub
  *
- * This stub lazy-loads the EE implementation or returns 501 for CE builds.
+ * This stub lazy-loads the EE implementation or returns an informative 403 for CE builds.
  */
+
+import { editionGateResponse } from '@/lib/editionGating/response';
 
 export const runtime = 'nodejs';
 export const dynamic = 'force-dynamic';
@@ -35,16 +37,10 @@ async function loadEeRoute(): Promise<EeRouteModule | null> {
 }
 
 function eeUnavailable(): Response {
-  return new Response(
-    JSON.stringify({
-      success: false,
-      error: 'Tenant management is only available in Enterprise Edition.',
-    }),
-    {
-      status: 501,
-      headers: { 'content-type': 'application/json' },
-    }
-  );
+  if (isEnterpriseEdition) {
+    throw new Error('The Enterprise route failed to load.');
+  }
+  return editionGateResponse('tenant-management');
 }
 
 export async function POST(request: Request): Promise<Response> {

--- a/server/src/app/api/v1/tenant-management/start-deletion/route.ts
+++ b/server/src/app/api/v1/tenant-management/start-deletion/route.ts
@@ -1,8 +1,10 @@
 /**
  * Tenant Management API - Start Deletion - CE Stub
  *
- * This stub lazy-loads the EE implementation or returns 501 for CE builds.
+ * This stub lazy-loads the EE implementation or returns an informative 403 for CE builds.
  */
+
+import { editionGateResponse } from '@/lib/editionGating/response';
 
 export const runtime = 'nodejs';
 export const dynamic = 'force-dynamic';
@@ -35,16 +37,10 @@ async function loadEeRoute(): Promise<EeRouteModule | null> {
 }
 
 function eeUnavailable(): Response {
-  return new Response(
-    JSON.stringify({
-      success: false,
-      error: 'Tenant management is only available in Enterprise Edition.',
-    }),
-    {
-      status: 501,
-      headers: { 'content-type': 'application/json' },
-    }
-  );
+  if (isEnterpriseEdition) {
+    throw new Error('The Enterprise route failed to load.');
+  }
+  return editionGateResponse('tenant-management');
 }
 
 export async function POST(request: Request): Promise<Response> {

--- a/server/src/app/api/v1/tenant-management/start-premium-trial/route.ts
+++ b/server/src/app/api/v1/tenant-management/start-premium-trial/route.ts
@@ -1,8 +1,10 @@
 /**
  * Tenant Management API - Start Premium Trial - CE Stub
  *
- * This stub lazy-loads the EE implementation or returns 501 for CE builds.
+ * This stub lazy-loads the EE implementation or returns an informative 403 for CE builds.
  */
+
+import { editionGateResponse } from '@/lib/editionGating/response';
 
 export const runtime = 'nodejs';
 export const dynamic = 'force-dynamic';
@@ -35,16 +37,10 @@ async function loadEeRoute(): Promise<EeRouteModule | null> {
 }
 
 function eeUnavailable(): Response {
-  return new Response(
-    JSON.stringify({
-      success: false,
-      error: 'Tenant management is only available in Enterprise Edition.',
-    }),
-    {
-      status: 501,
-      headers: { 'content-type': 'application/json' },
-    }
-  );
+  if (isEnterpriseEdition) {
+    throw new Error('The Enterprise route failed to load.');
+  }
+  return editionGateResponse('tenant-management');
 }
 
 export async function POST(request: Request): Promise<Response> {

--- a/server/src/app/api/v1/tenant-management/tenants/[tenantId]/addons/route.ts
+++ b/server/src/app/api/v1/tenant-management/tenants/[tenantId]/addons/route.ts
@@ -2,6 +2,8 @@
  * Tenant Management API - Tenant add-ons - CE Stub
  */
 
+import { editionGateResponse } from '@/lib/editionGating/response';
+
 export const runtime = 'nodejs';
 export const dynamic = 'force-dynamic';
 
@@ -35,16 +37,10 @@ async function loadEeRoute(): Promise<EeRouteModule | null> {
 }
 
 function eeUnavailable(): Response {
-  return new Response(
-    JSON.stringify({
-      success: false,
-      error: 'Tenant management is only available in Enterprise Edition.',
-    }),
-    {
-      status: 501,
-      headers: { 'content-type': 'application/json' },
-    }
-  );
+  if (isEnterpriseEdition) {
+    throw new Error('The Enterprise route failed to load.');
+  }
+  return editionGateResponse('tenant-management');
 }
 
 export async function POST(request: Request, context: RouteContext): Promise<Response> {

--- a/server/src/app/api/v1/tenant-management/tenants/route.ts
+++ b/server/src/app/api/v1/tenant-management/tenants/route.ts
@@ -1,8 +1,10 @@
 /**
  * Tenant Management API - Tenants List - CE Stub
  *
- * This stub lazy-loads the EE implementation or returns 501 for CE builds.
+ * This stub lazy-loads the EE implementation or returns an informative 403 for CE builds.
  */
+
+import { editionGateResponse } from '@/lib/editionGating/response';
 
 export const runtime = 'nodejs';
 export const dynamic = 'force-dynamic';
@@ -35,16 +37,10 @@ async function loadEeRoute(): Promise<EeRouteModule | null> {
 }
 
 function eeUnavailable(): Response {
-  return new Response(
-    JSON.stringify({
-      success: false,
-      error: 'Tenant management is only available in Enterprise Edition.',
-    }),
-    {
-      status: 501,
-      headers: { 'content-type': 'application/json' },
-    }
-  );
+  if (isEnterpriseEdition) {
+    throw new Error('The Enterprise route failed to load.');
+  }
+  return editionGateResponse('tenant-management');
 }
 
 export async function GET(request: Request): Promise<Response> {

--- a/server/src/components/settings/SettingsTab.tsx
+++ b/server/src/components/settings/SettingsTab.tsx
@@ -36,7 +36,10 @@ export function SettingsTab({ tabId, children }: SettingsTabProps): React.JSX.El
   // A tab can be off-limits for the current product (AlgaDesk allowlist) or edition
   // (EE-only governance tabs). The sidebar never links there, but a direct URL hit
   // should land back on the settings home rather than render an unavailable surface.
-  const notAvailable = !meta || (isAlgaDesk && !allowedTabIds.has(tabId)) || (meta.eeOnly && !isEEAvailable);
+  const notAvailable =
+    !meta ||
+    (isAlgaDesk && !allowedTabIds.has(tabId)) ||
+    (meta.eeOnly && !isEEAvailable && !meta.handlesEditionGateResponse);
 
   useEffect(() => {
     if (notAvailable) {

--- a/server/src/components/settings/mcp/ConnectedClientsCard.tsx
+++ b/server/src/components/settings/mcp/ConnectedClientsCard.tsx
@@ -4,6 +4,8 @@ import { useCallback, useEffect, useState } from 'react';
 import { Button } from '@alga-psa/ui/components/Button';
 import { Card, CardContent, CardHeader, CardTitle, CardDescription } from '@alga-psa/ui/components/Card';
 import { ConfirmationDialog } from '@alga-psa/ui/components/ConfirmationDialog';
+import { EditionGateError, getEditionGateResponse, isEditionGateError } from '@/lib/editionGating/client';
+import type { EditionGateResponseBody } from '@/lib/editionGating/types';
 
 interface Connection {
   grantId: string;
@@ -19,7 +21,11 @@ async function api<T>(path: string, init?: RequestInit): Promise<T> {
     ...init,
   });
   const body = await res.json().catch(() => ({}));
-  if (!res.ok) throw new Error(body?.error || `Something went wrong (${res.status}).`);
+  if (!res.ok) {
+    const editionGate = getEditionGateResponse(res.status, body);
+    if (editionGate) throw new EditionGateError(editionGate);
+    throw new Error(body?.error || `Something went wrong (${res.status}).`);
+  }
   return body as T;
 }
 
@@ -36,7 +42,11 @@ function hostOf(url: string): string {
  * interactive OAuth flow (Alga as MCP Authorization Server). Self-contained:
  * manages its own fetch/revoke so it can be dropped into the MCP settings page.
  */
-export default function ConnectedClientsCard() {
+export default function ConnectedClientsCard({
+  onEditionGate,
+}: {
+  onEditionGate?: (response: EditionGateResponseBody) => void;
+}) {
   const [connections, setConnections] = useState<Connection[]>([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
@@ -49,10 +59,14 @@ export default function ConnectedClientsCard() {
       .then((r) => setConnections(r.data))
       .catch((e) => {
         console.error('Failed to load MCP connections:', e);
+        if (isEditionGateError(e)) {
+          onEditionGate?.(e.response);
+          return;
+        }
         setError('Failed to load connections.');
       })
       .finally(() => setLoading(false));
-  }, []);
+  }, [onEditionGate]);
 
   useEffect(() => {
     reload();
@@ -67,11 +81,15 @@ export default function ConnectedClientsCard() {
       reload();
     } catch (e) {
       console.error('Failed to disconnect MCP client:', e);
+      if (isEditionGateError(e)) {
+        onEditionGate?.(e.response);
+        return;
+      }
       setError('Failed to disconnect.');
     } finally {
       setBusy(false);
     }
-  }, [removeTarget, reload]);
+  }, [onEditionGate, removeTarget, reload]);
 
   return (
     <Card id="mcp-connected-clients-card">

--- a/server/src/components/settings/mcp/McpServerSettings.tsx
+++ b/server/src/components/settings/mcp/McpServerSettings.tsx
@@ -12,10 +12,13 @@ import { Checkbox } from '@alga-psa/ui/components/Checkbox';
 import CustomSelect from '@alga-psa/ui/components/CustomSelect';
 import { DataTable } from '@alga-psa/ui/components/DataTable';
 import { ConfirmationDialog } from '@alga-psa/ui/components/ConfirmationDialog';
+import { FeatureUpgradeNotice } from '@alga-psa/ui/components/tier-gating/FeatureUpgradeNotice';
 import ConnectedClientsCard from './ConnectedClientsCard';
 import type { ColumnDefinition } from '@alga-psa/types';
 import type { TrustedIdp, Agent, Role, AuditRow, PlatformProvider, ConnectIdentity } from './mcpTypes';
 import { getMcpDemoMode, demoState, demoAuditPage, demoConnectResult } from './mcpDemoData';
+import { EditionGateError, getEditionGateResponse, isEditionGateError } from '@/lib/editionGating/client';
+import type { EditionGateResponseBody } from '@/lib/editionGating/types';
 
 const AUDIT_PAGE_SIZE = 10;
 
@@ -95,6 +98,9 @@ async function api<T>(path: string, init?: RequestInit): Promise<T> {
   });
   const body = await res.json().catch(() => ({}));
   if (!res.ok) {
+    const editionGate = getEditionGateResponse(res.status, body);
+    if (editionGate) throw new EditionGateError(editionGate);
+
     const friendly =
       res.status === 404 ? "MCP settings aren't available here. The MCP server may be turned off." :
       res.status === 401 ? 'Your session expired. Sign in again.' :
@@ -113,6 +119,7 @@ export default function McpServerSettings() {
   const [auditPage, setAuditPage] = useState(1);
   const [auditTotal, setAuditTotal] = useState(0);
   const [error, setError] = useState<string | null>(null);
+  const [editionGate, setEditionGate] = useState<EditionGateResponseBody | null>(null);
   const [busy, setBusy] = useState(false);
   const [removeTarget, setRemoveTarget] = useState<Agent | null>(null);
 
@@ -150,6 +157,10 @@ export default function McpServerSettings() {
     }
     Promise.all([reloadIdps(), reloadAgents(), reloadRoles()]).catch((e) => {
       console.error('Failed to load MCP settings:', e);
+      if (isEditionGateError(e)) {
+        setEditionGate(e.response);
+        return;
+      }
       setError('Failed to load MCP settings.');
     });
     api<{ data: { microsoft?: { entraTenantId: string; displayName: string | null } } }>('/api/v1/mcp/idp-suggestions')
@@ -167,6 +178,10 @@ export default function McpServerSettings() {
       await fn();
     } catch (e) {
       console.error('Failed to update MCP settings:', e);
+      if (isEditionGateError(e)) {
+        setEditionGate(e.response);
+        return;
+      }
       setError('Failed to update MCP settings.');
     } finally {
       setBusy(false);
@@ -423,6 +438,18 @@ export default function McpServerSettings() {
       render: (_v, r) => <span className="font-mono text-xs text-[rgb(var(--color-text-600))]">{r.status_code ?? '—'}</span>,
     },
   ];
+
+  if (editionGate) {
+    return (
+      <FeatureUpgradeNotice
+        featureName={editionGate.featureName}
+        requiredTier="pro"
+        description={editionGate.message}
+        upgradeHref={editionGate.upgrade.href}
+        upgradeLabel={editionGate.upgrade.cta}
+      />
+    );
+  }
 
   return (
     <div id="mcp-server-settings" className="space-y-6">
@@ -683,7 +710,7 @@ export default function McpServerSettings() {
       )}
 
       {/* Connected MCP clients (interactive OAuth — Alga as Authorization Server) */}
-      <ConnectedClientsCard />
+      <ConnectedClientsCard onEditionGate={setEditionGate} />
 
       <ConfirmationDialog
         id="mcp-remove-agent-dialog"

--- a/server/src/components/settings/settingsTabsRegistry.ts
+++ b/server/src/components/settings/settingsTabsRegistry.ts
@@ -19,6 +19,9 @@ export interface SettingsTabMeta {
   requiredFeature?: TIER_FEATURES;
   // Governance tabs that only exist on Enterprise builds.
   eeOnly?: boolean;
+  // The tab body recognizes EE_REQUIRED and renders its own upgrade notice, so it
+  // must remain mounted in Community Edition instead of being redirected away.
+  handlesEditionGateResponse?: boolean;
   // True once the tab has its own /msp/settings/<id> route segment (heavy static tabs
   // pulled out of the monolithic SettingsPage). Drives the ?tab= compat redirect.
   hasOwnRoute?: boolean;
@@ -44,7 +47,14 @@ export const SETTINGS_TABS: readonly SettingsTabMeta[] = [
   { id: 'email', labelKey: 'tabs.email', title: 'Email', hasOwnRoute: true },
   { id: 'integrations', labelKey: 'tabs.integrations', title: 'Integrations', requiredFeature: TIER_FEATURES.INTEGRATIONS, hasOwnRoute: true },
   { id: 'extensions', labelKey: 'tabs.extensions', title: 'Extensions', requiredFeature: TIER_FEATURES.EXTENSIONS },
-  { id: 'mcp-server', labelKey: 'tabs.mcpServer', title: 'MCP Server', eeOnly: true, hasOwnRoute: true },
+  {
+    id: 'mcp-server',
+    labelKey: 'tabs.mcpServer',
+    title: 'MCP Server',
+    eeOnly: true,
+    handlesEditionGateResponse: true,
+    hasOwnRoute: true,
+  },
 ];
 
 // Ids of tabs that now live at /msp/settings/<id>; the landing page redirects legacy

--- a/server/src/lib/editionGating/client.ts
+++ b/server/src/lib/editionGating/client.ts
@@ -1,0 +1,19 @@
+import { isEditionGateResponseBody, type EditionGateResponseBody } from './types';
+
+export class EditionGateError extends Error {
+  readonly response: EditionGateResponseBody;
+
+  constructor(response: EditionGateResponseBody) {
+    super(response.message);
+    this.name = 'EditionGateError';
+    this.response = response;
+  }
+}
+
+export function getEditionGateResponse(status: number, body: unknown): EditionGateResponseBody | null {
+  return status === 403 && isEditionGateResponseBody(body) ? body : null;
+}
+
+export function isEditionGateError(error: unknown): error is EditionGateError {
+  return error instanceof EditionGateError;
+}

--- a/server/src/lib/editionGating/response.ts
+++ b/server/src/lib/editionGating/response.ts
@@ -1,0 +1,37 @@
+import { NextResponse } from 'next/server';
+import {
+  createEditionGateResponseBody,
+  type EditionGatedFeature,
+  type EditionGateResponseBody,
+} from './types';
+
+export function editionGateResponse(
+  feature: EditionGatedFeature,
+  init: Omit<ResponseInit, 'status'> = {},
+): NextResponse<EditionGateResponseBody> {
+  return NextResponse.json(createEditionGateResponseBody(feature), {
+    ...init,
+    status: 403,
+  });
+}
+
+/** Preserve OAuth's registered error fields while adding the shared edition-gate metadata. */
+export function editionGateOAuthResponse(
+  feature: EditionGatedFeature,
+  init: Omit<ResponseInit, 'status'> = {},
+): NextResponse {
+  const body = createEditionGateResponseBody(feature);
+  const { error: _error, ...metadata } = body;
+
+  return NextResponse.json(
+    {
+      error: 'access_denied',
+      error_description: body.message,
+      ...metadata,
+    },
+    {
+      ...init,
+      status: 403,
+    },
+  );
+}

--- a/server/src/lib/editionGating/types.ts
+++ b/server/src/lib/editionGating/types.ts
@@ -1,0 +1,69 @@
+export const EDITION_GATE_CODE = 'EE_REQUIRED' as const;
+
+export const EDITION_GATED_FEATURES = {
+  mcp: { name: 'MCP server' },
+  'platform-notifications': { name: 'Platform notifications' },
+  'platform-reports': { name: 'Platform reports' },
+  'platform-feature-flags': { name: 'Platform feature flags' },
+  'tenant-management': { name: 'Tenant management' },
+  'appliance-installs': { name: 'Appliance installs' },
+} as const;
+
+export type EditionGatedFeature = keyof typeof EDITION_GATED_FEATURES;
+
+export interface EditionGateResponseBody {
+  error: string;
+  code: typeof EDITION_GATE_CODE;
+  feature: EditionGatedFeature;
+  featureName: string;
+  message: string;
+  upgrade: {
+    product: 'Alga PSA Pro';
+    cta: 'View Plans';
+    href: '/msp/account';
+  };
+}
+
+export function createEditionGateResponseBody(feature: EditionGatedFeature): EditionGateResponseBody {
+  const featureName = EDITION_GATED_FEATURES[feature].name;
+
+  return {
+    error: 'This endpoint requires Alga PSA Pro.',
+    code: EDITION_GATE_CODE,
+    feature,
+    featureName,
+    message: `${featureName} is available with Alga PSA Pro.`,
+    upgrade: {
+      product: 'Alga PSA Pro',
+      cta: 'View Plans',
+      href: '/msp/account',
+    },
+  };
+}
+
+export function isEditionGateResponseBody(value: unknown): value is EditionGateResponseBody {
+  if (!value || typeof value !== 'object') return false;
+
+  const body = value as Record<string, unknown>;
+  if (
+    typeof body.feature !== 'string' ||
+    !Object.prototype.hasOwnProperty.call(EDITION_GATED_FEATURES, body.feature)
+  ) {
+    return false;
+  }
+
+  const feature = body.feature as EditionGatedFeature;
+  const upgrade = body.upgrade;
+
+  return (
+    body.code === EDITION_GATE_CODE &&
+    typeof body.error === 'string' &&
+    body.featureName === EDITION_GATED_FEATURES[feature].name &&
+    typeof body.message === 'string' &&
+    !!upgrade &&
+    typeof upgrade === 'object' &&
+    (upgrade as Record<string, unknown>).product === 'Alga PSA Pro' &&
+    (upgrade as Record<string, unknown>).cta === 'View Plans' &&
+    (upgrade as Record<string, unknown>).href === '/msp/account'
+  );
+}

--- a/server/src/lib/editionGating/types.ts
+++ b/server/src/lib/editionGating/types.ts
@@ -20,7 +20,7 @@ export interface EditionGateResponseBody {
   upgrade: {
     product: 'Alga PSA Pro';
     cta: 'View Plans';
-    href: '/msp/account';
+    href: 'https://www.nineminds.com/plans';
   };
 }
 
@@ -36,7 +36,7 @@ export function createEditionGateResponseBody(feature: EditionGatedFeature): Edi
     upgrade: {
       product: 'Alga PSA Pro',
       cta: 'View Plans',
-      href: '/msp/account',
+      href: 'https://www.nineminds.com/plans',
     },
   };
 }
@@ -64,6 +64,6 @@ export function isEditionGateResponseBody(value: unknown): value is EditionGateR
     typeof upgrade === 'object' &&
     (upgrade as Record<string, unknown>).product === 'Alga PSA Pro' &&
     (upgrade as Record<string, unknown>).cta === 'View Plans' &&
-    (upgrade as Record<string, unknown>).href === '/msp/account'
+    (upgrade as Record<string, unknown>).href === 'https://www.nineminds.com/plans'
   );
 }

--- a/server/src/test/unit/api/editionGatedRoutes.test.ts
+++ b/server/src/test/unit/api/editionGatedRoutes.test.ts
@@ -1,0 +1,107 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { NextRequest } from 'next/server';
+import { createEditionGateResponseBody } from '@/lib/editionGating/types';
+import { getEditionGateResponse } from '@/lib/editionGating/client';
+
+describe('edition-gated API responses', () => {
+  beforeEach(() => {
+    vi.resetModules();
+    process.env.EDITION = 'ce';
+    process.env.NEXT_PUBLIC_EDITION = 'community';
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it.each([
+    {
+      feature: 'mcp' as const,
+      invoke: async () => {
+        const route = await import('@/app/api/v1/mcp/agents/route');
+        return route.GET(new NextRequest('http://localhost/api/v1/mcp/agents'));
+      },
+    },
+    {
+      feature: 'platform-notifications' as const,
+      invoke: async () => {
+        const route = await import('@/app/api/v1/platform-notifications/route');
+        return route.GET(new Request('http://localhost/api/v1/platform-notifications'));
+      },
+    },
+    {
+      feature: 'platform-reports' as const,
+      invoke: async () => {
+        const route = await import('@/app/api/v1/platform-reports/route');
+        return route.GET(new Request('http://localhost/api/v1/platform-reports'));
+      },
+    },
+    {
+      feature: 'platform-feature-flags' as const,
+      invoke: async () => {
+        const route = await import('@/app/api/v1/platform-feature-flags/route');
+        return route.GET(new Request('http://localhost/api/v1/platform-feature-flags'));
+      },
+    },
+    {
+      feature: 'tenant-management' as const,
+      invoke: async () => {
+        const route = await import('@/app/api/v1/tenant-management/tenants/route');
+        return route.GET(new Request('http://localhost/api/v1/tenant-management/tenants'));
+      },
+    },
+    {
+      feature: 'appliance-installs' as const,
+      invoke: async () => {
+        const route = await import('@/app/api/v1/appliance-installs/route');
+        return route.GET(new Request('http://localhost/api/v1/appliance-installs'));
+      },
+    },
+  ])('returns the shared 403 contract for $feature', async ({ feature, invoke }) => {
+    const response = await invoke();
+
+    expect(response.status).toBe(403);
+    await expect(response.json()).resolves.toEqual(createEditionGateResponseBody(feature));
+  });
+
+  it('keeps discovery responses non-cacheable', async () => {
+    const route = await import('@/app/.well-known/oauth-protected-resource/route');
+    const response = await route.GET(
+      new NextRequest('http://localhost/.well-known/oauth-protected-resource'),
+    );
+
+    expect(response.status).toBe(403);
+    expect(response.headers.get('cache-control')).toBe('no-store, max-age=0');
+    await expect(response.json()).resolves.toEqual(createEditionGateResponseBody('mcp'));
+  });
+
+  it('preserves OAuth error fields while exposing the shared signal', async () => {
+    const route = await import('@/app/api/mcp/oauth/token/route');
+    const response = await route.POST(
+      new NextRequest('http://localhost/api/mcp/oauth/token', { method: 'POST' }),
+    );
+    const body = await response.json();
+
+    expect(response.status).toBe(403);
+    expect(response.headers.get('cache-control')).toBe('no-store, max-age=0');
+    expect(body).toMatchObject({
+      error: 'access_denied',
+      error_description: 'MCP server is available with Alga PSA Pro.',
+      code: 'EE_REQUIRED',
+      feature: 'mcp',
+    });
+  });
+
+  it('does not classify genuine not-found or authorization responses as edition gates', () => {
+    expect(getEditionGateResponse(404, { error: 'Not found' })).toBeNull();
+    expect(getEditionGateResponse(401, { error: 'Unauthorized' })).toBeNull();
+    expect(getEditionGateResponse(403, { error: 'Forbidden' })).toBeNull();
+    expect(getEditionGateResponse(404, createEditionGateResponseBody('mcp'))).toBeNull();
+    expect(
+      getEditionGateResponse(403, {
+        ...createEditionGateResponseBody('mcp'),
+        upgrade: { product: 'Alga PSA Pro', cta: 'View Plans', href: 'javascript:alert(1)' },
+      }),
+    ).toBeNull();
+  });
+});

--- a/server/src/test/unit/components/settings/McpServerSettings.editionGate.test.tsx
+++ b/server/src/test/unit/components/settings/McpServerSettings.editionGate.test.tsx
@@ -24,7 +24,10 @@ describe('McpServerSettings edition gate', () => {
 
     expect(await screen.findByRole('heading', { name: 'MCP server requires Pro' })).toBeInTheDocument();
     expect(screen.getByText('MCP server is available with Alga PSA Pro.')).toBeInTheDocument();
-    expect(screen.getByRole('link', { name: 'View Plans' })).toHaveAttribute('href', '/msp/account');
+    expect(screen.getByRole('link', { name: 'View Plans' })).toHaveAttribute(
+      'href',
+      'https://www.nineminds.com/plans',
+    );
   });
 
   it('keeps a genuine 404 on the ordinary error path', async () => {

--- a/server/src/test/unit/components/settings/McpServerSettings.editionGate.test.tsx
+++ b/server/src/test/unit/components/settings/McpServerSettings.editionGate.test.tsx
@@ -1,0 +1,45 @@
+/**
+ * @vitest-environment jsdom
+ */
+import React from 'react';
+import { render, screen, waitFor } from '@testing-library/react';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import McpServerSettings from '@/components/settings/mcp/McpServerSettings';
+import { createEditionGateResponseBody } from '@/lib/editionGating/types';
+
+describe('McpServerSettings edition gate', () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('renders the shared Pro upgrade notice for EE_REQUIRED', async () => {
+    vi.spyOn(globalThis, 'fetch').mockImplementation(async () =>
+      new Response(JSON.stringify(createEditionGateResponseBody('mcp')), {
+        status: 403,
+        headers: { 'content-type': 'application/json' },
+      }),
+    );
+
+    render(<McpServerSettings />);
+
+    expect(await screen.findByRole('heading', { name: 'MCP server requires Pro' })).toBeInTheDocument();
+    expect(screen.getByText('MCP server is available with Alga PSA Pro.')).toBeInTheDocument();
+    expect(screen.getByRole('link', { name: 'View Plans' })).toHaveAttribute('href', '/msp/account');
+  });
+
+  it('keeps a genuine 404 on the ordinary error path', async () => {
+    vi.spyOn(globalThis, 'fetch').mockImplementation(async () =>
+      new Response(JSON.stringify({ error: 'Not found' }), {
+        status: 404,
+        headers: { 'content-type': 'application/json' },
+      }),
+    );
+
+    render(<McpServerSettings />);
+
+    await waitFor(() => {
+      expect(screen.getByText('Failed to load MCP settings.')).toBeInTheDocument();
+    });
+    expect(screen.queryByRole('heading', { name: /requires Pro/ })).not.toBeInTheDocument();
+  });
+});

--- a/server/src/test/unit/components/settings/SettingsTab.editionGate.test.tsx
+++ b/server/src/test/unit/components/settings/SettingsTab.editionGate.test.tsx
@@ -1,0 +1,47 @@
+/**
+ * @vitest-environment jsdom
+ */
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { SettingsTab } from '@/components/settings/SettingsTab';
+
+const mocks = vi.hoisted(() => ({
+  replace: vi.fn(),
+}));
+
+vi.mock('next/navigation', () => ({
+  useRouter: () => ({ replace: mocks.replace }),
+}));
+
+vi.mock('@/context/ProductContext', () => ({
+  useProduct: () => ({ productCode: 'psa' }),
+}));
+
+vi.mock('@/context/TierContext', () => ({
+  useTier: () => ({ hasFeature: () => true }),
+}));
+
+vi.mock('@alga-psa/ui/lib/i18n/client', () => ({
+  useTranslation: () => ({ t: (key: string) => key }),
+}));
+
+describe('SettingsTab edition gate', () => {
+  afterEach(() => {
+    vi.unstubAllEnvs();
+    mocks.replace.mockClear();
+  });
+
+  it('mounts the MCP tab in Community Edition so it can handle EE_REQUIRED', () => {
+    vi.stubEnv('NEXT_PUBLIC_EDITION', 'community');
+
+    render(
+      <SettingsTab tabId="mcp-server">
+        <div>MCP edition gate content</div>
+      </SettingsTab>,
+    );
+
+    expect(screen.getByText('MCP edition gate content')).toBeInTheDocument();
+    expect(mocks.replace).not.toHaveBeenCalled();
+  });
+});

--- a/server/vitest.config.ts
+++ b/server/vitest.config.ts
@@ -357,6 +357,7 @@ export default defineConfig({
       { find: '@product/settings-extensions/entry', replacement: path.resolve(__dirname, './src/test/stubs/product-settings-extensions-entry.ts') },
       { find: '@product/chat/entry', replacement: path.resolve(__dirname, './src/test/stubs/product-chat-entry.ts') },
       { find: '@product/billing/entry', replacement: path.resolve(__dirname, './src/test/stubs/product-billing-entry.tsx') },
+      { find: '@product/mcp/entry', replacement: path.resolve(__dirname, '../packages/product-mcp/oss/entry.ts') },
       { find: 'pdf-lib', replacement: 'empty-module' },
     ],
   },


### PR DESCRIPTION
## Summary

- Standardize Community Edition responses for scoped Enterprise-only MCP, platform notification, platform report, platform feature flag, tenant management, appliance install, and discovery endpoints as HTTP 403 responses with a shared EE_REQUIRED contract, feature metadata, and a Pro upgrade destination.
- Preserve OAuth protocol response shapes and non-cacheable headers while exposing the same edition-gate signal, without changing genuine authentication or not-found behavior.
- Teach the MCP settings client to recognize EE_REQUIRED responses, keep the direct MCP settings route mounted in Community Edition, and render the shared Pro upgrade notice with a live View Plans link.
- Add focused API and UI regression coverage for the shared response contract, OAuth/discovery behavior, MCP upgrade rendering, settings-route mounting, and ordinary 401/404 paths.

## Smoke test

PASS overall. Real CE dev server remains running on port 3295, connected to the real PgBouncer (6472) and Redis (6380) services.

Exercised:

- Logged in through the real MSP sign-in UI.
- /msp/settings/mcp-server remained mounted and rendered the shared “MCP server requires Pro” notice from real 403 responses.
- “View Plans” navigated to the live Nine Minds plans page.
- Verified complete EE_REQUIRED payloads for MCP, platform notifications, reports, feature flags, tenant management, appliance installs, and discovery.
- Verified OAuth token/authorize protocol shapes and no-store headers.
- Regression checks: missing API key remains 401; a genuine unknown route remains 404.

No simulator or mock was used. Non-MCP API calls used a non-secret placeholder x-api-key because middleware only checks header presence before the CE stub; unauthenticated behavior was tested separately.

Evidence: /tmp/alga-smoke-evidence/alga0002214-20260802-235748

## Fidelity compromises / concerns

- Docker API access was denied, so container status could not be queried directly; real database/Redis connectivity and live application behavior proved service readiness.
- The newly created card-scoped browser pane reported an IDE cross-host error, so testing continued in an existing blank pane inside the same card space.
- Handled EE_REQUIRED responses still emit console.error messages and a development “Issues” badge.
- The MCP page breadcrumb displays “General” despite the MCP title/URL.
- Existing tenants.suspended_at schema-drift warnings affect scheduled jobs, not these routes.
- No worktree files were changed during smoke testing; pre-existing package-lock.json and workSchedule.ts changes remain untouched.
