### PR TITLE
CE source-build compose: persistent volumes + target parity (alga0002219)

### DIFF
--- a/docker-compose.ce.yaml
+++ b/docker-compose.ce.yaml
@@ -34,6 +34,7 @@ services:
       LOG_LEVEL: ${LOG_LEVEL:-INFO}
       LOG_IS_FORMAT_JSON: ${LOG_IS_FORMAT_JSON:-false}
       LOG_IS_FULL_DETAILS: ${LOG_IS_FULL_DETAILS:-false}
+      STORAGE_LOCAL_BASE_PATH: ${STORAGE_LOCAL_BASE_PATH:-/data/files}
       EMAIL_ENABLE: ${EMAIL_ENABLE:-false}
       EMAIL_FROM: ${EMAIL_FROM:-noreply@example.com}
       EMAIL_PORT: ${EMAIL_PORT:-587}

--- a/docker-compose.ce.yaml
+++ b/docker-compose.ce.yaml
@@ -9,9 +9,7 @@ services:
     image: ${APP_NAME:-sebastian}_server_ce_local
     build:
       context: .
-      dockerfile: Dockerfile.build
-      args:
-        NEXT_BUILD_MAX_OLD_SPACE_SIZE: ${NEXT_BUILD_MAX_OLD_SPACE_SIZE:-12288}
+      dockerfile: Dockerfile.dev
     environment:
       EDITION: community
       DB_NAME: server
@@ -51,6 +49,8 @@ services:
       WORKFLOW_REDIS_CONSUMER_GROUP: "workflow-workers"
       IMAP_WEBHOOK_SECRET: ${IMAP_WEBHOOK_SECRET:-}
     volumes:
+      # Persist user-uploaded documents and generated files
+      - files_data:/data/files
       - type: bind
         source: ./secrets/db_password_server
         target: /run/secrets/db_password_server
@@ -88,9 +88,7 @@ services:
     image: ${APP_NAME:-sebastian}_server_ce_local
     build:
       context: .
-      dockerfile: Dockerfile.build
-      args:
-        NEXT_BUILD_MAX_OLD_SPACE_SIZE: ${NEXT_BUILD_MAX_OLD_SPACE_SIZE:-12288}
+      dockerfile: Dockerfile.dev
     environment:
       EDITION: community
       NODE_OPTIONS: --experimental-vm-modules
@@ -344,6 +342,9 @@ services:
       DB_TYPE: ${DB_TYPE:-postgres}
       DB_HOST: postgres
       DB_PORT: ${DB_PORT:-5432}
+    volumes:
+      # Persist Postgres data across restarts
+      - postgres_data:/var/lib/postgresql/data
     secrets:
       - postgres_password
 
@@ -355,3 +356,7 @@ services:
 networks:
   app-network:
     driver: bridge
+
+volumes:
+  postgres_data:
+  files_data:

--- a/docs/getting-started/docker_compose.md
+++ b/docs/getting-started/docker_compose.md
@@ -20,10 +20,13 @@ The base configuration (`docker-compose.base.yaml`) includes:
 ### Community Edition (CE)
 The CE configuration (`docker-compose.ce.yaml`) includes:
 - Standard service configurations
-- CE-specific Dockerfile paths
+- The shared `Dockerfile.dev` development image with Community Edition enabled
 - Default community settings
 - Service environment variables
+- Named volumes for PostgreSQL data and application files
 - Network and dependency configurations
+
+The `postgres_data` and `files_data` volumes retain database records and application files across ordinary `docker compose down` and `up` commands. Running `docker compose down -v` explicitly removes these volumes and their data.
 
 ### Enterprise Edition (EE)
 The EE configuration (`docker-compose.ee.yaml`) includes:

--- a/docs/plans/2026-08-02-ce-compose-persistence-plan.md
+++ b/docs/plans/2026-08-02-ce-compose-persistence-plan.md
@@ -1,0 +1,34 @@
+# CE Source Compose Persistence and Target Parity Plan
+
+## Goal
+
+Make the source-built Community Edition compose stack retain customer data across ordinary `docker compose down/up`, align the CE make target with the development-image behavior of EE, and make the getting-started documentation describe files that actually exist.
+
+## Current code
+
+- `docker-compose.ce.yaml` builds the server/setup image from `Dockerfile.build` and extends base services without adding PostgreSQL or application-file persistence.
+- `docker-compose.base.yaml` defines PostgreSQL without a data volume; only the AI gateway database currently has a named volume.
+- `Makefile` exposes separate `docker-up-ee` and `docker-up-ce` targets.
+- `docs/getting-started/docker_compose.md` contains the stale CE-Dockerfile claim.
+
+## Implementation
+
+1. In `docker-compose.ce.yaml`, add CE-owned named volumes `postgres_data` and `files_data` at the top level.
+2. Override/extend the CE `postgres` service to mount `postgres_data:/var/lib/postgresql/data`.
+3. Mount `files_data` at the canonical application persistent-files directory for every CE service that reads or writes those files, matching the prebuilt CE compose contract. Confirm the path from the prebuilt compose before editing; do not guess.
+4. Change the source CE server/setup build definitions and `make docker-up-ce` path to use `Dockerfile.dev` consistently with `docker-up-ee`, while retaining `EDITION=community` and CE service selection.
+5. Correct `docs/getting-started/docker_compose.md` to name the shared development Dockerfile and explain that named volumes survive `down` but are removed by explicit `down -v`.
+6. Keep volume names compose-project scoped and avoid external/global volumes.
+
+## Verification
+
+- `docker compose -f ... config` resolves both mounts and the expected Dockerfile.
+- Start CE, create a database sentinel and representative uploaded/generated file, run ordinary down/up, and prove both survive.
+- Run `down -v` only in an isolated test project and confirm documented destructive behavior.
+- Compare CE and EE make targets/build args for intended parity without changing edition flags.
+
+## Out of scope and risks
+
+- Do not retrofit persistence into every base-compose consumer; scope is the CE source path.
+- Do not rename existing prebuilt-stack volumes or alter production deployment storage.
+- File-volume mount ownership must match the runtime UID; verify writes after recreation.

--- a/scripts/smoke-test-ce-compose-persistence.sh
+++ b/scripts/smoke-test-ce-compose-persistence.sh
@@ -1,0 +1,148 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+readonly REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+readonly PROJECT_NAME="alga-ce-persistence-smoke-${USER:-user}-$$"
+readonly DB_SENTINEL="ce-db-$PPID-$$"
+readonly FILE_SENTINEL="ce-file-$PPID-$$"
+readonly FILE_PATH="/data/files/ce-compose-persistence-smoke.txt"
+readonly POSTGRES_VOLUME="${PROJECT_NAME}_postgres_data"
+readonly FILES_VOLUME="${PROJECT_NAME}_files_data"
+
+COMPOSE_FILES=(
+  -f docker-compose.yaml
+  -f docker-compose.base.yaml
+  -f docker-compose.ce.yaml
+)
+SMOKE_COMPOSE_FILES=(
+  "${COMPOSE_FILES[@]}"
+  -f scripts/tests/docker-compose.ce-persistence-smoke.yaml
+)
+
+compose() {
+  APP_NAME="$PROJECT_NAME" docker compose -p "$PROJECT_NAME" "${COMPOSE_FILES[@]}" "$@"
+}
+
+smoke_compose() {
+  APP_NAME="$PROJECT_NAME" docker compose -p "$PROJECT_NAME" "${SMOKE_COMPOSE_FILES[@]}" "$@"
+}
+
+cleanup() {
+  smoke_compose down -v --rmi local --remove-orphans >/dev/null 2>&1 || true
+}
+
+wait_for_postgres() {
+  local attempt
+
+  for attempt in $(seq 1 30); do
+    if smoke_compose exec -T postgres pg_isready -U postgres -d server >/dev/null 2>&1; then
+      return 0
+    fi
+    sleep 1
+  done
+
+  echo "PostgreSQL did not become ready" >&2
+  smoke_compose logs postgres >&2
+  return 1
+}
+
+assert_prerequisites() {
+  if ! command -v node >/dev/null 2>&1; then
+    echo "Node.js is required to validate the resolved Compose configuration" >&2
+    return 1
+  fi
+  if ! docker info >/dev/null 2>&1; then
+    echo "A reachable Docker daemon is required for the CE persistence smoke test" >&2
+    echo "If Docker group membership was added after login, start a fresh shell or run: sg docker -c './scripts/smoke-test-ce-compose-persistence.sh'" >&2
+    return 1
+  fi
+}
+
+assert_canonical_config() {
+  compose config --format json 2>/dev/null | node -e '
+    const fs = require("node:fs");
+    const config = JSON.parse(fs.readFileSync(0, "utf8"));
+    const server = config.services?.server;
+    const postgres = config.services?.postgres;
+
+    const hasMount = (service, source, target) =>
+      service?.volumes?.some((volume) => volume.source === source && volume.target === target);
+
+    if (server?.build?.dockerfile !== "Dockerfile.dev") {
+      throw new Error(`Expected CE server to build Dockerfile.dev, got ${server?.build?.dockerfile}`);
+    }
+    if (!hasMount(server, "files_data", "/data/files")) {
+      throw new Error("CE server is missing files_data:/data/files");
+    }
+    if (!hasMount(postgres, "postgres_data", "/var/lib/postgresql/data")) {
+      throw new Error("CE postgres is missing postgres_data:/var/lib/postgresql/data");
+    }
+  '
+}
+
+write_sentinels() {
+  smoke_compose exec -T postgres sh -c \
+    "PGPASSWORD=\"\$(cat /run/secrets/postgres_password)\" psql -U postgres -d server -v ON_ERROR_STOP=1 -c \"CREATE TABLE IF NOT EXISTS ce_compose_persistence_smoke (value text NOT NULL); TRUNCATE ce_compose_persistence_smoke; INSERT INTO ce_compose_persistence_smoke VALUES ('$DB_SENTINEL');\"" \
+    >/dev/null
+  smoke_compose exec -T server sh -c \
+    "mkdir -p /data/files && printf '%s' '$FILE_SENTINEL' > '$FILE_PATH'"
+}
+
+assert_sentinels() {
+  local actual_db_sentinel
+  local actual_file_sentinel
+
+  actual_db_sentinel="$(smoke_compose exec -T postgres sh -c \
+    "PGPASSWORD=\"\$(cat /run/secrets/postgres_password)\" psql -U postgres -d server -Atqc 'SELECT value FROM ce_compose_persistence_smoke LIMIT 1'")"
+  actual_file_sentinel="$(smoke_compose exec -T server sh -c "cat '$FILE_PATH'")"
+
+  if [[ "$actual_db_sentinel" != "$DB_SENTINEL" ]]; then
+    echo "Database sentinel did not survive compose down/up" >&2
+    return 1
+  fi
+  if [[ "$actual_file_sentinel" != "$FILE_SENTINEL" ]]; then
+    echo "File sentinel did not survive compose down/up" >&2
+    return 1
+  fi
+}
+
+main() {
+  cd "$REPO_ROOT"
+  assert_prerequisites
+  trap cleanup EXIT
+
+  echo "Validating canonical CE compose mounts and Dockerfile target"
+  assert_canonical_config
+
+  echo "Building the CE server from Dockerfile.dev"
+  smoke_compose build server
+
+  echo "Starting isolated source-build CE persistence services"
+  smoke_compose up -d postgres
+  wait_for_postgres
+  smoke_compose up -d --no-deps server
+  write_sentinels
+
+  echo "Running ordinary compose down/up lifecycle"
+  smoke_compose down --remove-orphans
+  docker volume inspect "$POSTGRES_VOLUME" "$FILES_VOLUME" >/dev/null
+  smoke_compose up -d postgres
+  wait_for_postgres
+  smoke_compose up -d --no-deps server
+  assert_sentinels
+
+  echo "Database and file sentinels survived compose down/up"
+
+  echo "Confirming explicit down -v removes the isolated volumes"
+  smoke_compose down -v --rmi local --remove-orphans
+  if docker volume inspect "$POSTGRES_VOLUME" "$FILES_VOLUME" >/dev/null 2>&1; then
+    echo "Expected down -v to remove the isolated persistence volumes" >&2
+    return 1
+  fi
+
+  trap - EXIT
+  echo "CE compose persistence smoke test passed"
+}
+
+main "$@"

--- a/scripts/tests/docker-compose.ce-persistence-smoke.yaml
+++ b/scripts/tests/docker-compose.ce-persistence-smoke.yaml
@@ -1,0 +1,12 @@
+services:
+  postgres:
+    ports: !reset []
+
+  server:
+    command: !reset []
+    depends_on: !reset {}
+    entrypoint: ["/bin/sh", "-c", "while :; do sleep 3600; done"]
+    ports: !reset []
+    secrets: !reset []
+    volumes: !override
+      - files_data:/data/files


### PR DESCRIPTION
## Summary

- Build the CE source Compose server and setup services from `Dockerfile.dev`, matching the development-image target used by the source stack.
- Persist PostgreSQL data and local application files in Compose-managed `postgres_data` and `files_data` volumes.
- Default CE local storage to `/data/files`, document ordinary `down` versus destructive `down -v` behavior, and add an isolated lifecycle smoke harness.

## Smoke test

PASS.

Exercised:

- Resolved CE Compose config: `Dockerfile.dev`, `STORAGE_LOCAL_BASE_PATH=/data/files`, `files_data:/data/files`, and `postgres_data:/var/lib/postgresql/data` all present.
- Built the real CE server image from `Dockerfile.dev`.
- Real isolated Docker lifecycle: database and file sentinels survived ordinary Compose down/up; `down -v` removed both named volumes.
- Live CE product on port 3620: confirmed the port fully stopped, restarted to fresh Next.js PID 2317112, signed in, and verified the persisted document remained visible.
- Rendered its inline and full-size 400×400 preview. Authenticated download returned 200; its 9,383 bytes and SHA-256 matched the database metadata and persisted file exactly.
- Final state: product answers with the expected auth redirect, wired `alga-psa-local-test` services remain up, and isolated smoke resources were cleaned up.

Evidence: `/tmp/alga-smoke-evidence/alga0002219-20260802-233000`

## Fidelity compromises

- The full all-services `make docker-up-ce` stack was not launched. The repository harness used the real source-built image, PostgreSQL, and named volumes, but replaced the server entrypoint with an idle process for focused lifecycle validation. The UI ran from this worktree’s host dev server against real wired Compose infrastructure.
- Alga Dev created the required card-scoped browser pane, but commands failed because it belonged to another host. Local desktop control was also unreliable under Wayland, so repository Playwright drove a real local Chrome instance. No simulator or mock was used.
- The shared Glinda password had been rotated by another dev server; only that scoped test user’s password hash was refreshed to the current dev-login value.

## Concerns noticed

- CE-mode UI displays a “License expires in 9 days” banner.
- Wired environment logs PostgreSQL 42703 errors because `tenants.suspended_at` is missing, affecting scheduled jobs/RMM reconciliation.
- The lifecycle harness emits extensive unset-variable warnings.
- A first parent-only restart left an orphan listener; the final verification caught this, invalidated it, confirmed port-down, and repeated all post-restart assertions against the fresh PID.
- Existing unrelated `package-lock.json` and `server/next.config.mjs` modifications remain untouched and are not included in this PR.
