### PR TITLE
IMAP resync UI shows stale Disconnected/inactive state

### DIFF
--- a/docs/plans/2026-08-02-imap-resync-status-recovery-plan.md
+++ b/docs/plans/2026-08-02-imap-resync-status-recovery-plan.md
@@ -28,3 +28,16 @@ After IMAP resync starts, present the intentional disconnect as temporary reconn
 - Prevent stale updates with cancellation plus a generation token; bound request pressure to one multi-second poll per provider.
 - Treat only fresh persisted status as recovery, and timeout as ambiguity rather than failure.
 - Rebase/restack if the nearby middleware card changes the same component; preserve its semantics.
+
+## Mitigation override and natural-recovery smoke
+
+Live GreenMail and worktree-built email-service smoke superseded the original 90-second polling limit. Resync invalidates the active worker's lease; one refresh can stop that worker and the next refresh recreates it. The observed natural recovery took 102.6 seconds, so the UI must keep the provider-scoped Reconnecting presentation after 90 seconds. Poll every 5 seconds through 2 minutes, every 15 seconds through 5 minutes, then cap at every 30 seconds until fresh provider state leaves `disconnected` or the component unmounts/supersedes the poll.
+
+The follow-up smoke must use the production-default 60-second email-service refresh with real GreenMail and no provider-status edit, page reload, worker restart, or other intervention after clicking Resync. Keep the email-provider page mounted and untouched while collecting:
+
+1. A transient screenshot showing Reconnecting with active (not dimmed/inactive) styling.
+2. Email-service timestamps for the resync, lease-lost worker stop, later worker recreation, and persisted `connected` transition.
+3. A database observation confirming `status='connected'` and `is_active=true` after natural recovery.
+4. A final screenshot from the same untouched page showing Connected, plus browser console/network checks.
+
+Record the exact timing and all fidelity compromises in a fresh evidence-directory README so another reviewer can correlate the two screenshots, service log, and database observation without relying on an earlier failed smoke run.

--- a/docs/plans/2026-08-02-imap-resync-status-recovery-plan.md
+++ b/docs/plans/2026-08-02-imap-resync-status-recovery-plan.md
@@ -1,0 +1,30 @@
+# IMAP resync status recovery plan
+
+## Goal
+
+After IMAP resync starts, present the intentional disconnect as temporary reconnecting work and refresh until the backend reconnects, without a reload or disabled-looking card.
+
+## Code findings
+
+- `resyncImapProvider` clears cursor/lease fields and writes `status='disconnected'`; it never changes `is_active`.
+- `handleResyncProvider` does one immediate `loadProviders()`, exposing that temporary disconnected value but never following recovery.
+- `EmailProviderList` owns busy state only while the callback runs. `EmailProviderCard` renders persisted status and dims only when `isActive` is false.
+- The service reconnects on a 60-second refresh cycle, so the UI window must exceed one cycle.
+
+## Design and order
+
+1. Track provider ids in a local reconnecting set in `EmailProviderConfiguration.tsx`. On success, add the id before the first reload so the card never flashes bare Disconnected.
+2. Poll fresh `getEmailProviders` results every 3-5 seconds for at most 90 seconds. Replace the list on successful reads and stop when the target status leaves `disconnected`. Cancel on unmount and supersede older work for the same provider.
+3. Clear reconnecting on recovery or timeout. Announce Connected only from freshly persisted status. On timeout, warn that reconnect is still pending and leave manual Refresh available.
+4. Thread an explicit provider-scoped `reconnecting` prop through the list to the card; do not mutate the persisted status union. Show a yellow/secondary Reconnecting badge with accessible text, retain normal opacity while active, and block duplicate resync.
+5. Add reconnecting/recovered/timeout copy to the email-provider locale catalogs.
+6. Add behavioral component coverage with fake timers and mocked actions: immediate Reconnecting, automatic Connected without remount, no dimming, cancellation on unmount, honest timeout, and no poll after failed resync.
+7. Run focused tests and package typecheck/lint. Smoke the wired UI and capture transient Reconnecting plus automatic Connected within 90 seconds.
+
+## Non-goals and risks
+
+- Do not change backend resync, cursor, lease, refresh-loop, `is_active`, Test Connection, or non-IMAP behavior.
+- Do not add a persisted status solely for presentation.
+- Prevent stale updates with cancellation plus a generation token; bound request pressure to one multi-second poll per provider.
+- Treat only fresh persisted status as recovery, and timeout as ambiguity rather than failure.
+- Rebase/restack if the nearby middleware card changes the same component; preserve its semantics.

--- a/packages/integrations/src/components/email/EmailProviderCard.tsx
+++ b/packages/integrations/src/components/email/EmailProviderCard.tsx
@@ -33,6 +33,7 @@ import { INBOUND_DEFAULTS_WARNING, providerNeedsInboundDefaults } from './emailP
 
 interface EmailProviderCardProps {
   provider: EmailProvider;
+  reconnecting?: boolean;
   defaultsOptions: { value: string; label: string }[];
   updatingProviderId: string | null;
   busy?: boolean;
@@ -64,6 +65,7 @@ const getProviderIcon = (providerType: string) => {
 
 export function EmailProviderCard({
   provider,
+  reconnecting = false,
   defaultsOptions,
   updatingProviderId,
   busy = false,
@@ -106,6 +108,10 @@ export function EmailProviderCard({
   };
 
   const getStatusIcon = (status: EmailProvider['status']) => {
+    if (reconnecting) {
+      return <Clock className="h-4 w-4 text-[rgb(var(--badge-warning-text))]" />;
+    }
+
     switch (status) {
       case 'connected':
         return <CheckCircle className="h-4 w-4 text-green-500" />;
@@ -125,6 +131,14 @@ export function EmailProviderCard({
     isActive: boolean,
     isPaused: boolean
   ) => {
+    if (reconnecting) {
+      return (
+        <Badge id={`provider-reconnecting-badge-${provider.id}`} variant="warning" role="status">
+          {t('providerCard.badges.reconnecting', { defaultValue: 'Reconnecting' })}
+        </Badge>
+      );
+    }
+
     if (isPaused) {
       return (
         <Badge id={`provider-paused-badge-${provider.id}`} variant="secondary">
@@ -165,6 +179,7 @@ export function EmailProviderCard({
   };
 
   const expirationStatus = getExpirationStatus(provider);
+  const interactionBusy = busy || reconnecting;
 
   return (
     <Card className={`transition-all ${!provider.isActive ? 'opacity-60' : ''}`}>
@@ -187,47 +202,47 @@ export function EmailProviderCard({
 
             <DropdownMenu>
               <DropdownMenuTrigger asChild>
-                <Button id={`provider-menu-${provider.id}`} variant="ghost" size="sm" disabled={busy}>
+                <Button id={`provider-menu-${provider.id}`} variant="ghost" size="sm" disabled={interactionBusy}>
                   <MoreVertical className="h-4 w-4" />
                 </Button>
               </DropdownMenuTrigger>
               <DropdownMenuContent align="end">
-                <DropdownMenuItem onClick={() => onEdit(provider)} disabled={busy}>
+                <DropdownMenuItem onClick={() => onEdit(provider)} disabled={interactionBusy}>
                   <Settings className="h-4 w-4 mr-2" />
                   {t('providerCard.actions.edit', { defaultValue: 'Edit Configuration' })}
                 </DropdownMenuItem>
-                <DropdownMenuItem onClick={() => onTestConnection(provider)} disabled={busy}>
+                <DropdownMenuItem onClick={() => onTestConnection(provider)} disabled={interactionBusy}>
                   <TestTube className="h-4 w-4 mr-2" />
                   {busy && busyAction === 'test'
                     ? t('providerCard.actions.testing', { defaultValue: 'Testing…' })
                     : t('providerCard.actions.testConnection', { defaultValue: 'Test Connection' })}
                 </DropdownMenuItem>
                 {provider.providerType === 'google' && (
-                  <DropdownMenuItem onClick={() => onRefreshWatchSubscription(provider)} disabled={busy}>
+                  <DropdownMenuItem onClick={() => onRefreshWatchSubscription(provider)} disabled={interactionBusy}>
                     <Repeat className="h-4 w-4 mr-2" />
                     {t('providerCard.actions.refreshWatch', { defaultValue: 'Refresh Pub/Sub & Watch' })}
                   </DropdownMenuItem>
                 )}
                 {provider.providerType === 'microsoft' && (
                   <>
-                    <DropdownMenuItem onClick={() => onRetryRenewal(provider)} disabled={busy}>
+                    <DropdownMenuItem onClick={() => onRetryRenewal(provider)} disabled={interactionBusy}>
                       <RefreshCw className="h-4 w-4 mr-2" />
                       {t('providerCard.actions.retryRenewal', { defaultValue: 'Retry Renewal' })}
                     </DropdownMenuItem>
-                    <DropdownMenuItem onClick={() => onRunDiagnostics(provider)} disabled={busy}>
+                    <DropdownMenuItem onClick={() => onRunDiagnostics(provider)} disabled={interactionBusy}>
                       <Stethoscope className="h-4 w-4 mr-2" />
                       {t('providerCard.actions.runDiagnostics', { defaultValue: 'Run Microsoft 365 Diagnostics' })}
                     </DropdownMenuItem>
                   </>
                 )}
                 {provider.providerType === 'imap' && provider.imapConfig?.auth_type === 'oauth2' && onReconnectOAuth && (
-                  <DropdownMenuItem onClick={() => onReconnectOAuth(provider)} disabled={busy}>
+                  <DropdownMenuItem onClick={() => onReconnectOAuth(provider)} disabled={interactionBusy}>
                     <RefreshCw className="h-4 w-4 mr-2" />
                     {t('providerCard.actions.reconnectOauth', { defaultValue: 'Reconnect OAuth' })}
                   </DropdownMenuItem>
                 )}
                 {provider.providerType === 'imap' && onResyncProvider && (
-                  <DropdownMenuItem onClick={() => onResyncProvider(provider)} disabled={busy}>
+                  <DropdownMenuItem onClick={() => onResyncProvider(provider)} disabled={interactionBusy}>
                     <Repeat className="h-4 w-4 mr-2" />
                     {busy && busyAction === 'resync'
                       ? t('providerCard.actions.resyncing', { defaultValue: 'Resyncing…' })
@@ -237,7 +252,7 @@ export function EmailProviderCard({
                 <DropdownMenuItem
                   id={`${provider.inboundPausedAt ? 'resume' : 'pause'}-provider-${provider.id}`}
                   onClick={() => onTogglePause(provider)}
-                  disabled={busy}
+                  disabled={interactionBusy}
                 >
                   {provider.inboundPausedAt
                     ? <PlayCircle className="h-4 w-4 mr-2" />
@@ -250,7 +265,7 @@ export function EmailProviderCard({
                 <DropdownMenuItem
                   onClick={() => onDelete(provider.id)}
                   className="text-red-600"
-                  disabled={busy}
+                  disabled={interactionBusy}
                 >
                   <Trash2 className="h-4 w-4 mr-2" />
                   {t('providerCard.actions.delete', { defaultValue: 'Delete Provider' })}
@@ -269,7 +284,9 @@ export function EmailProviderCard({
               <span>{t('providerCard.fields.status', { defaultValue: 'Status' })}</span>
             </div>
             <div className="font-medium">
-              {provider.status === 'connected' && provider.isActive
+              {reconnecting
+                ? t('providerCard.values.reconnecting', { defaultValue: 'Reconnecting' })
+                : provider.status === 'connected' && provider.isActive
                 ? t('providerCard.values.active', { defaultValue: 'Active' })
                 : provider.status === 'error'
                 ? t('providerCard.values.error', { defaultValue: 'Error' })

--- a/packages/integrations/src/components/email/EmailProviderConfiguration.resync.test.tsx
+++ b/packages/integrations/src/components/email/EmailProviderConfiguration.resync.test.tsx
@@ -1,0 +1,250 @@
+/**
+ * @vitest-environment jsdom
+ */
+import React from 'react';
+import { act, cleanup, fireEvent, render, screen } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import type { EmailProvider } from './types';
+
+const getEmailProvidersMock = vi.hoisted(() => vi.fn());
+const resyncImapProviderMock = vi.hoisted(() => vi.fn());
+const toastMock = vi.hoisted(() => Object.assign(vi.fn(), {
+  error: vi.fn(),
+  loading: vi.fn(() => 'resync-toast'),
+  success: vi.fn(),
+}));
+
+vi.mock('react-hot-toast', () => ({ default: toastMock }));
+
+vi.mock('../../actions/email-actions/emailProviderActions', () => ({
+  deleteEmailProvider: vi.fn(),
+  getEmailProviders: (...args: unknown[]) => getEmailProvidersMock(...args),
+  resyncImapProvider: (...args: unknown[]) => resyncImapProviderMock(...args),
+  retryMicrosoftSubscriptionRenewal: vi.fn(),
+  testEmailProviderConnection: vi.fn(),
+}));
+
+vi.mock('@alga-psa/user-composition/actions', () => ({
+  getCurrentUser: vi.fn().mockResolvedValue({ tenant: 'tenant-1' }),
+}));
+
+vi.mock('@alga-psa/integrations/email/providers/entry', () => ({
+  GmailProviderForm: () => null,
+  ImapProviderForm: () => null,
+  MicrosoftProviderForm: () => null,
+}));
+
+vi.mock('@alga-psa/ui', () => ({
+  DrawerOutlet: () => null,
+  DrawerProvider: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+  useDrawer: () => ({ closeDrawer: vi.fn(), openDrawer: vi.fn() }),
+}));
+
+vi.mock('./ProviderSetupWizardDialog', () => ({
+  ProviderSetupWizardDialog: () => null,
+}));
+
+vi.mock('./admin/InboundTicketDefaultsManager', () => ({
+  InboundTicketDefaultsManager: () => null,
+}));
+
+vi.mock('./admin/InboundEmailRulesManager', () => ({
+  InboundEmailRulesManager: () => null,
+}));
+
+vi.mock('./admin/Microsoft365DiagnosticsDialog', () => ({
+  Microsoft365DiagnosticsDialog: () => null,
+}));
+
+vi.mock('../../lib/microsoftConsumerVisibility', () => ({
+  isMicrosoftConsumerEnterpriseEdition: () => true,
+}));
+
+vi.mock('./EmailProviderList', () => ({
+  EmailProviderList: ({
+    providers,
+    reconnectingProviderIds,
+    onResyncProvider,
+  }: {
+    providers: EmailProvider[];
+    reconnectingProviderIds: ReadonlySet<string>;
+    onResyncProvider: (provider: EmailProvider) => Promise<void>;
+  }) => {
+    const provider = providers[0];
+    if (!provider) {
+      return <div>No providers</div>;
+    }
+    const reconnecting = reconnectingProviderIds.has(provider.id);
+    return (
+      <div>
+        <div data-testid="provider-presentation">
+          {reconnecting
+            ? 'Reconnecting'
+            : provider.status === 'connected'
+              ? 'Connected'
+              : 'Disconnected'}
+        </div>
+        <button
+          id="test-resync-provider"
+          type="button"
+          disabled={reconnecting}
+          onClick={() => void onResyncProvider(provider)}
+        >
+          Resync Mailbox
+        </button>
+      </div>
+    );
+  },
+}));
+
+import { EmailProviderCard } from './EmailProviderCard';
+import { EmailProviderConfiguration } from './EmailProviderConfiguration';
+
+const connectedProvider: EmailProvider = {
+  id: 'imap-provider-1',
+  tenant: 'tenant-1',
+  providerType: 'imap',
+  providerName: 'Support inbox',
+  mailbox: 'support@example.com',
+  isActive: true,
+  status: 'connected',
+  createdAt: '2026-08-01T12:00:00.000Z',
+  updatedAt: '2026-08-01T12:00:00.000Z',
+  imapConfig: {
+    email_provider_id: 'imap-provider-1',
+    tenant: 'tenant-1',
+    host: 'imap.example.com',
+    port: 993,
+    secure: true,
+    allow_starttls: true,
+    auth_type: 'password',
+    username: 'support@example.com',
+    folder_filters: ['INBOX'],
+    auto_process_emails: true,
+    max_emails_per_sync: 100,
+    created_at: '2026-08-01T12:00:00.000Z',
+    updated_at: '2026-08-01T12:00:00.000Z',
+  },
+};
+
+const disconnectedProvider: EmailProvider = {
+  ...connectedProvider,
+  status: 'disconnected',
+};
+
+async function renderConfiguration() {
+  let result!: ReturnType<typeof render>;
+  await act(async () => {
+    result = render(<EmailProviderConfiguration />);
+  });
+  return result;
+}
+
+async function startResync() {
+  fireEvent.click(screen.getByRole('button', { name: 'Resync Mailbox' }));
+  await act(async () => {});
+}
+
+describe('IMAP resync status recovery', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.clearAllMocks();
+    resyncImapProviderMock.mockResolvedValue({ success: true });
+  });
+
+  afterEach(() => {
+    cleanup();
+    vi.useRealTimers();
+  });
+
+  it('shows Reconnecting immediately and automatically presents a freshly connected provider', async () => {
+    getEmailProvidersMock
+      .mockResolvedValueOnce({ providers: [connectedProvider] })
+      .mockResolvedValueOnce({ providers: [disconnectedProvider] })
+      .mockResolvedValueOnce({ providers: [connectedProvider] });
+
+    await renderConfiguration();
+    await startResync();
+
+    expect(screen.getByTestId('provider-presentation')).toHaveTextContent('Reconnecting');
+    expect(screen.getByRole('button', { name: 'Resync Mailbox' })).toBeDisabled();
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(5_000);
+    });
+
+    expect(screen.getByTestId('provider-presentation')).toHaveTextContent('Connected');
+    expect(toastMock.success).toHaveBeenCalledWith('Support inbox reconnected successfully.');
+  });
+
+  it('stops polling when the component unmounts', async () => {
+    getEmailProvidersMock.mockResolvedValue({ providers: [disconnectedProvider] });
+    getEmailProvidersMock.mockResolvedValueOnce({ providers: [connectedProvider] });
+
+    const view = await renderConfiguration();
+    await startResync();
+    expect(getEmailProvidersMock).toHaveBeenCalledTimes(2);
+
+    view.unmount();
+    await vi.advanceTimersByTimeAsync(90_000);
+
+    expect(getEmailProvidersMock).toHaveBeenCalledTimes(2);
+    expect(toastMock).not.toHaveBeenCalled();
+  });
+
+  it('ends the transient presentation with an honest warning after 90 seconds', async () => {
+    getEmailProvidersMock.mockResolvedValue({ providers: [disconnectedProvider] });
+    getEmailProvidersMock.mockResolvedValueOnce({ providers: [connectedProvider] });
+
+    await renderConfiguration();
+    await startResync();
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(90_000);
+    });
+
+    expect(screen.getByTestId('provider-presentation')).toHaveTextContent('Disconnected');
+    expect(toastMock).toHaveBeenCalledWith(
+      'Support inbox is still reconnecting. Refresh to check its latest status.',
+      { icon: '⚠️', duration: 6_000 }
+    );
+  });
+
+  it('does not reload or poll after a failed resync request', async () => {
+    getEmailProvidersMock.mockResolvedValue({ providers: [connectedProvider] });
+    resyncImapProviderMock.mockResolvedValue({ success: false, error: 'Resync failed' });
+
+    await renderConfiguration();
+    await startResync();
+    await vi.advanceTimersByTimeAsync(90_000);
+
+    expect(getEmailProvidersMock).toHaveBeenCalledTimes(1);
+    expect(screen.getByTestId('provider-presentation')).toHaveTextContent('Connected');
+    expect(toastMock.error).toHaveBeenCalledWith('Resync failed', { id: 'resync-toast' });
+  });
+
+  it('renders the reconnecting card without inactive styling and blocks duplicate actions', () => {
+    const view = render(
+      <EmailProviderCard
+        provider={disconnectedProvider}
+        reconnecting
+        defaultsOptions={[]}
+        updatingProviderId={null}
+        onEdit={vi.fn()}
+        onDelete={vi.fn()}
+        onTestConnection={vi.fn()}
+        onRefreshWatchSubscription={vi.fn()}
+        onRetryRenewal={vi.fn()}
+        onResyncProvider={vi.fn()}
+        onRunDiagnostics={vi.fn()}
+        onChangeDefaults={vi.fn()}
+        onTogglePause={vi.fn()}
+      />
+    );
+
+    expect(screen.getAllByText('Reconnecting')).toHaveLength(2);
+    expect(screen.queryByText('Inactive')).not.toBeInTheDocument();
+    expect(view.container.firstElementChild).not.toHaveClass('opacity-60');
+    expect(screen.getByRole('button')).toBeDisabled();
+  });
+});

--- a/packages/integrations/src/components/email/EmailProviderConfiguration.resync.test.tsx
+++ b/packages/integrations/src/components/email/EmailProviderConfiguration.resync.test.tsx
@@ -28,6 +28,13 @@ vi.mock('@alga-psa/user-composition/actions', () => ({
   getCurrentUser: vi.fn().mockResolvedValue({ tenant: 'tenant-1' }),
 }));
 
+vi.mock('@alga-psa/integrations/actions', () => ({
+  getMicrosoftConsumerSetupStatus: vi.fn().mockResolvedValue({
+    success: true,
+    credentialCapability: null,
+  }),
+}));
+
 vi.mock('@alga-psa/integrations/email/providers/entry', () => ({
   GmailProviderForm: () => null,
   ImapProviderForm: () => null,

--- a/packages/integrations/src/components/email/EmailProviderConfiguration.resync.test.tsx
+++ b/packages/integrations/src/components/email/EmailProviderConfiguration.resync.test.tsx
@@ -186,15 +186,19 @@ describe('IMAP resync status recovery', () => {
     expect(getEmailProvidersMock).toHaveBeenCalledTimes(2);
 
     view.unmount();
-    await vi.advanceTimersByTimeAsync(90_000);
+    await vi.advanceTimersByTimeAsync(300_000);
 
     expect(getEmailProvidersMock).toHaveBeenCalledTimes(2);
     expect(toastMock).not.toHaveBeenCalled();
   });
 
-  it('ends the transient presentation with an honest warning after 90 seconds', async () => {
-    getEmailProvidersMock.mockResolvedValue({ providers: [disconnectedProvider] });
-    getEmailProvidersMock.mockResolvedValueOnce({ providers: [connectedProvider] });
+  it('keeps presenting Reconnecting beyond 90 seconds and recovers automatically', async () => {
+    const recoversAt = Date.now() + 105_000;
+    getEmailProvidersMock
+      .mockResolvedValueOnce({ providers: [connectedProvider] })
+      .mockImplementation(() => Promise.resolve({
+        providers: [Date.now() >= recoversAt ? connectedProvider : disconnectedProvider],
+      }));
 
     await renderConfiguration();
     await startResync();
@@ -203,11 +207,54 @@ describe('IMAP resync status recovery', () => {
       await vi.advanceTimersByTimeAsync(90_000);
     });
 
-    expect(screen.getByTestId('provider-presentation')).toHaveTextContent('Disconnected');
-    expect(toastMock).toHaveBeenCalledWith(
-      'Support inbox is still reconnecting. Refresh to check its latest status.',
-      { icon: '⚠️', duration: 6_000 }
-    );
+    expect(screen.getByTestId('provider-presentation')).toHaveTextContent('Reconnecting');
+    expect(toastMock).not.toHaveBeenCalled();
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(15_000);
+    });
+
+    expect(screen.getByTestId('provider-presentation')).toHaveTextContent('Connected');
+    expect(toastMock.success).toHaveBeenCalledWith('Support inbox reconnected successfully.');
+  });
+
+  it('backs off after the expected recovery window while continuing to poll', async () => {
+    getEmailProvidersMock.mockResolvedValue({ providers: [disconnectedProvider] });
+    getEmailProvidersMock.mockResolvedValueOnce({ providers: [connectedProvider] });
+
+    await renderConfiguration();
+    await startResync();
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(120_000);
+    });
+    const callsAfterFastPolling = getEmailProvidersMock.mock.calls.length;
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(14_999);
+    });
+    expect(getEmailProvidersMock).toHaveBeenCalledTimes(callsAfterFastPolling);
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(1);
+    });
+    expect(getEmailProvidersMock).toHaveBeenCalledTimes(callsAfterFastPolling + 1);
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(165_000);
+    });
+    const callsAfterBackoffPolling = getEmailProvidersMock.mock.calls.length;
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(29_999);
+    });
+    expect(getEmailProvidersMock).toHaveBeenCalledTimes(callsAfterBackoffPolling);
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(1);
+    });
+    expect(getEmailProvidersMock).toHaveBeenCalledTimes(callsAfterBackoffPolling + 1);
+    expect(screen.getByTestId('provider-presentation')).toHaveTextContent('Reconnecting');
   });
 
   it('does not reload or poll after a failed resync request', async () => {
@@ -216,7 +263,7 @@ describe('IMAP resync status recovery', () => {
 
     await renderConfiguration();
     await startResync();
-    await vi.advanceTimersByTimeAsync(90_000);
+    await vi.advanceTimersByTimeAsync(300_000);
 
     expect(getEmailProvidersMock).toHaveBeenCalledTimes(1);
     expect(screen.getByTestId('provider-presentation')).toHaveTextContent('Connected');

--- a/packages/integrations/src/components/email/EmailProviderConfiguration.resync.test.tsx
+++ b/packages/integrations/src/components/email/EmailProviderConfiguration.resync.test.tsx
@@ -192,8 +192,8 @@ describe('IMAP resync status recovery', () => {
     expect(toastMock).not.toHaveBeenCalled();
   });
 
-  it('keeps presenting Reconnecting beyond 90 seconds and recovers automatically', async () => {
-    const recoversAt = Date.now() + 105_000;
+  it('keeps presenting Reconnecting beyond 90 seconds and recovers after the observed 102.6-second cycle', async () => {
+    const recoversAt = Date.now() + 102_600;
     getEmailProvidersMock
       .mockResolvedValueOnce({ providers: [connectedProvider] })
       .mockImplementation(() => Promise.resolve({
@@ -211,7 +211,13 @@ describe('IMAP resync status recovery', () => {
     expect(toastMock).not.toHaveBeenCalled();
 
     await act(async () => {
-      await vi.advanceTimersByTimeAsync(15_000);
+      await vi.advanceTimersByTimeAsync(10_000);
+    });
+
+    expect(screen.getByTestId('provider-presentation')).toHaveTextContent('Reconnecting');
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(5_000);
     });
 
     expect(screen.getByTestId('provider-presentation')).toHaveTextContent('Connected');

--- a/packages/integrations/src/components/email/EmailProviderConfiguration.tsx
+++ b/packages/integrations/src/components/email/EmailProviderConfiguration.tsx
@@ -5,7 +5,7 @@
 
 'use client';
 
-import React, { useState, useEffect } from 'react';
+import React, { useState, useEffect, useRef } from 'react';
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@alga-psa/ui/components/Card';
 import { Button } from '@alga-psa/ui/components/Button';
 import { Alert, AlertDescription } from '@alga-psa/ui/components/Alert';
@@ -47,6 +47,15 @@ import { isMicrosoftConsumerEnterpriseEdition } from '../../lib/microsoftConsume
 import { getMicrosoftConsumerSetupStatus } from '@alga-psa/integrations/actions';
 import type { MicrosoftCredentialCapability } from '../../actions/integrations/providerReadiness';
 
+const IMAP_RESYNC_POLL_INTERVAL_MS = 5_000;
+const IMAP_RESYNC_TIMEOUT_MS = 90_000;
+
+interface ImapResyncPoll {
+  deadline: number;
+  generation: number;
+  timeoutId?: ReturnType<typeof setTimeout>;
+}
+
 export interface EmailProviderConfigurationProps {
   onProviderAdded?: (provider: EmailProvider) => void;
   onProviderUpdated?: (provider: EmailProvider) => void;
@@ -70,6 +79,10 @@ function EmailProviderConfigurationContent({
   const [diagnosticsOpen, setDiagnosticsOpen] = useState(false);
   const [diagnosticsProvider, setDiagnosticsProvider] = useState<EmailProvider | null>(null);
   const [microsoftCredentialCapability, setMicrosoftCredentialCapability] = useState<MicrosoftCredentialCapability | null | undefined>(undefined);
+  const [reconnectingProviderIds, setReconnectingProviderIds] = useState<Set<string>>(new Set());
+  const resyncPollsRef = useRef<Map<string, ImapResyncPoll>>(new Map());
+  const nextResyncGenerationRef = useRef(0);
+  const mountedRef = useRef(true);
   const { openDrawer, closeDrawer } = useDrawer();
 
   // Load existing providers on component mount
@@ -91,6 +104,21 @@ function EmailProviderConfigurationContent({
 
     loadMicrosoftCredentialCapability();
   }, [isEnterpriseEdition]);
+
+  useEffect(() => {
+    mountedRef.current = true;
+    const resyncPolls = resyncPollsRef.current;
+
+    return () => {
+      mountedRef.current = false;
+      resyncPolls.forEach(({ timeoutId }) => {
+        if (timeoutId) {
+          clearTimeout(timeoutId);
+        }
+      });
+      resyncPolls.clear();
+    };
+  }, []);
 
   // Get tenant on mount
   useEffect(() => {
@@ -264,6 +292,79 @@ function EmailProviderConfigurationContent({
     }
   };
 
+  const finishResyncPolling = (providerId: string, generation: number) => {
+    const poll = resyncPollsRef.current.get(providerId);
+    if (!poll || poll.generation !== generation) {
+      return false;
+    }
+
+    if (poll.timeoutId) {
+      clearTimeout(poll.timeoutId);
+    }
+    resyncPollsRef.current.delete(providerId);
+    setReconnectingProviderIds((current) => {
+      const next = new Set(current);
+      next.delete(providerId);
+      return next;
+    });
+    return true;
+  };
+
+  const pollForResyncRecovery = async (
+    providerId: string,
+    providerName: string,
+    generation: number
+  ): Promise<void> => {
+    const activePoll = resyncPollsRef.current.get(providerId);
+    if (!mountedRef.current || !activePoll || activePoll.generation !== generation) {
+      return;
+    }
+
+    let refreshedProvider: EmailProvider | undefined;
+    try {
+      const data = await getEmailProviders();
+      const currentPoll = resyncPollsRef.current.get(providerId);
+      if (!mountedRef.current || !currentPoll || currentPoll.generation !== generation) {
+        return;
+      }
+
+      const refreshedProviders = data.providers || [];
+      setProviders(refreshedProviders);
+      refreshedProvider = refreshedProviders.find((candidate) => candidate.id === providerId);
+    } catch (err) {
+      console.error('Failed to refresh IMAP provider during resync:', err);
+    }
+
+    const currentPoll = resyncPollsRef.current.get(providerId);
+    if (!mountedRef.current || !currentPoll || currentPoll.generation !== generation) {
+      return;
+    }
+
+    if (refreshedProvider && refreshedProvider.status !== 'disconnected') {
+      if (finishResyncPolling(providerId, generation) && refreshedProvider.status === 'connected') {
+        toast.success(t('configuration.feedback.resyncRecovered', {
+          defaultValue: '{{providerName}} reconnected successfully.',
+          providerName,
+        }));
+      }
+      return;
+    }
+
+    if (Date.now() >= currentPoll.deadline) {
+      if (finishResyncPolling(providerId, generation)) {
+        toast(t('configuration.feedback.resyncPending', {
+          defaultValue: '{{providerName}} is still reconnecting. Refresh to check its latest status.',
+          providerName,
+        }), { icon: '⚠️', duration: 6_000 });
+      }
+      return;
+    }
+
+    currentPoll.timeoutId = setTimeout(() => {
+      void pollForResyncRecovery(providerId, providerName, generation);
+    }, IMAP_RESYNC_POLL_INTERVAL_MS);
+  };
+
   const handleResyncProvider = async (provider: EmailProvider) => {
     try {
       setError(null);
@@ -284,7 +385,19 @@ function EmailProviderConfigurationContent({
         defaultValue: 'Resync started for {{providerName}}.',
         providerName: provider.providerName,
       }), { id: toastId });
-      await loadProviders();
+
+      setReconnectingProviderIds((current) => new Set(current).add(provider.id));
+
+      const previousPoll = resyncPollsRef.current.get(provider.id);
+      if (previousPoll?.timeoutId) {
+        clearTimeout(previousPoll.timeoutId);
+      }
+      const generation = ++nextResyncGenerationRef.current;
+      resyncPollsRef.current.set(provider.id, {
+        deadline: Date.now() + IMAP_RESYNC_TIMEOUT_MS,
+        generation,
+      });
+      void pollForResyncRecovery(provider.id, provider.providerName, generation);
     } catch (err) {
       const message = t('configuration.feedback.resyncError', {
         defaultValue: 'Failed to resync IMAP provider',
@@ -432,6 +545,7 @@ function EmailProviderConfigurationContent({
 
         <EmailProviderList
           providers={visibleProviders}
+          reconnectingProviderIds={reconnectingProviderIds}
           onEdit={openEditDrawer}
           onDelete={handleProviderDeleted}
           onTestConnection={handleTestConnection}

--- a/packages/integrations/src/components/email/EmailProviderConfiguration.tsx
+++ b/packages/integrations/src/components/email/EmailProviderConfiguration.tsx
@@ -47,14 +47,29 @@ import { isMicrosoftConsumerEnterpriseEdition } from '../../lib/microsoftConsume
 import { getMicrosoftConsumerSetupStatus } from '@alga-psa/integrations/actions';
 import type { MicrosoftCredentialCapability } from '../../actions/integrations/providerReadiness';
 
-const IMAP_RESYNC_POLL_INTERVAL_MS = 5_000;
-const IMAP_RESYNC_TIMEOUT_MS = 90_000;
+const IMAP_RESYNC_FAST_POLL_INTERVAL_MS = 5_000;
+const IMAP_RESYNC_FAST_POLL_DURATION_MS = 120_000;
+const IMAP_RESYNC_BACKOFF_POLL_INTERVAL_MS = 15_000;
+const IMAP_RESYNC_MAX_BACKOFF_AFTER_MS = 300_000;
+const IMAP_RESYNC_MAX_POLL_INTERVAL_MS = 30_000;
 
 interface ImapResyncPoll {
-  deadline: number;
   generation: number;
+  startedAt: number;
   timeoutId?: ReturnType<typeof setTimeout>;
 }
+
+const getImapResyncPollInterval = (elapsedMs: number) => {
+  if (elapsedMs < IMAP_RESYNC_FAST_POLL_DURATION_MS) {
+    return IMAP_RESYNC_FAST_POLL_INTERVAL_MS;
+  }
+
+  if (elapsedMs < IMAP_RESYNC_MAX_BACKOFF_AFTER_MS) {
+    return IMAP_RESYNC_BACKOFF_POLL_INTERVAL_MS;
+  }
+
+  return IMAP_RESYNC_MAX_POLL_INTERVAL_MS;
+};
 
 export interface EmailProviderConfigurationProps {
   onProviderAdded?: (provider: EmailProvider) => void;
@@ -350,19 +365,9 @@ function EmailProviderConfigurationContent({
       return;
     }
 
-    if (Date.now() >= currentPoll.deadline) {
-      if (finishResyncPolling(providerId, generation)) {
-        toast(t('configuration.feedback.resyncPending', {
-          defaultValue: '{{providerName}} is still reconnecting. Refresh to check its latest status.',
-          providerName,
-        }), { icon: '⚠️', duration: 6_000 });
-      }
-      return;
-    }
-
     currentPoll.timeoutId = setTimeout(() => {
       void pollForResyncRecovery(providerId, providerName, generation);
-    }, IMAP_RESYNC_POLL_INTERVAL_MS);
+    }, getImapResyncPollInterval(Date.now() - currentPoll.startedAt));
   };
 
   const handleResyncProvider = async (provider: EmailProvider) => {
@@ -394,8 +399,8 @@ function EmailProviderConfigurationContent({
       }
       const generation = ++nextResyncGenerationRef.current;
       resyncPollsRef.current.set(provider.id, {
-        deadline: Date.now() + IMAP_RESYNC_TIMEOUT_MS,
         generation,
+        startedAt: Date.now(),
       });
       void pollForResyncRecovery(provider.id, provider.providerName, generation);
     } catch (err) {

--- a/packages/integrations/src/components/email/EmailProviderList.tsx
+++ b/packages/integrations/src/components/email/EmailProviderList.tsx
@@ -27,6 +27,7 @@ import {
 
 interface EmailProviderListProps {
   providers: EmailProvider[];
+  reconnectingProviderIds?: ReadonlySet<string>;
   onEdit: (provider: EmailProvider) => void;
   onDelete: (providerId: string) => void;
   onTestConnection: (provider: EmailProvider) => Promise<void>;
@@ -41,6 +42,7 @@ interface EmailProviderListProps {
 
 export function EmailProviderList({
   providers,
+  reconnectingProviderIds,
   onEdit,
   onDelete,
   onTestConnection,
@@ -202,10 +204,15 @@ export function EmailProviderList({
           <EmailProviderCard
             key={provider.id}
             provider={provider}
+            reconnecting={reconnectingProviderIds?.has(provider.id) ?? false}
             defaultsOptions={defaultsOptions}
             updatingProviderId={updatingProviderId}
-            busy={busyProviderId === provider.id}
-            busyAction={busyProviderId === provider.id ? busyAction : null}
+            busy={busyProviderId === provider.id || reconnectingProviderIds?.has(provider.id)}
+            busyAction={busyProviderId === provider.id
+              ? busyAction
+              : reconnectingProviderIds?.has(provider.id)
+                ? 'resync'
+                : null}
             onEdit={onEdit}
             onDelete={onDelete}
             onTestConnection={handleTestConnectionInternal}

--- a/server/public/locales/de/msp/email-providers.json
+++ b/server/public/locales/de/msp/email-providers.json
@@ -12,7 +12,6 @@
       "resyncError": "Die Neusynchronisierung des IMAP-Anbieters ist fehlgeschlagen",
       "resyncStarted": "Neusynchronisierung für {{providerName}} gestartet.",
       "resyncRecovered": "{{providerName}} wurde erfolgreich wieder verbunden.",
-      "resyncPending": "{{providerName}} stellt die Verbindung noch wieder her. Aktualisieren Sie, um den neuesten Status zu prüfen.",
       "enterpriseOnly": "Eingehende E-Mails von Microsoft 365 sind nur in Pro verfügbar.",
       "loadProvidersError": "Failed to load email providers"
     },

--- a/server/public/locales/de/msp/email-providers.json
+++ b/server/public/locales/de/msp/email-providers.json
@@ -11,6 +11,8 @@
       "resyncing": "{{providerName}} wird erneut synchronisiert...",
       "resyncError": "Die Neusynchronisierung des IMAP-Anbieters ist fehlgeschlagen",
       "resyncStarted": "Neusynchronisierung für {{providerName}} gestartet.",
+      "resyncRecovered": "{{providerName}} wurde erfolgreich wieder verbunden.",
+      "resyncPending": "{{providerName}} stellt die Verbindung noch wieder her. Aktualisieren Sie, um den neuesten Status zu prüfen.",
       "enterpriseOnly": "Eingehende E-Mails von Microsoft 365 sind nur in Pro verfügbar.",
       "loadProvidersError": "Failed to load email providers"
     },
@@ -163,6 +165,7 @@
       "disabled": "Deaktiviert",
       "paused": "Pausiert",
       "connected": "Verbunden",
+      "reconnecting": "Verbindung wird wiederhergestellt",
       "disconnected": "Getrennt",
       "error": "Fehler",
       "configuring": "Konfigurieren",
@@ -211,6 +214,7 @@
     },
     "values": {
       "active": "Aktiv",
+      "reconnecting": "Verbindung wird wiederhergestellt",
       "inactive": "Inaktiv",
       "disabled": "Deaktiviert",
       "error": "Fehler"

--- a/server/public/locales/en/msp/email-providers.json
+++ b/server/public/locales/en/msp/email-providers.json
@@ -12,7 +12,6 @@
       "resyncError": "Failed to resync IMAP provider",
       "resyncStarted": "Resync started for {{providerName}}.",
       "resyncRecovered": "{{providerName}} reconnected successfully.",
-      "resyncPending": "{{providerName}} is still reconnecting. Refresh to check its latest status.",
       "enterpriseOnly": "Microsoft 365 inbound email is only available in Pro.",
       "loadProvidersError": "Failed to load email providers"
     },

--- a/server/public/locales/en/msp/email-providers.json
+++ b/server/public/locales/en/msp/email-providers.json
@@ -11,6 +11,8 @@
       "resyncing": "Resyncing {{providerName}}...",
       "resyncError": "Failed to resync IMAP provider",
       "resyncStarted": "Resync started for {{providerName}}.",
+      "resyncRecovered": "{{providerName}} reconnected successfully.",
+      "resyncPending": "{{providerName}} is still reconnecting. Refresh to check its latest status.",
       "enterpriseOnly": "Microsoft 365 inbound email is only available in Pro.",
       "loadProvidersError": "Failed to load email providers"
     },
@@ -163,6 +165,7 @@
       "disabled": "Disabled",
       "paused": "Paused",
       "connected": "Connected",
+      "reconnecting": "Reconnecting",
       "disconnected": "Disconnected",
       "error": "Error",
       "configuring": "Configuring",
@@ -211,6 +214,7 @@
     },
     "values": {
       "active": "Active",
+      "reconnecting": "Reconnecting",
       "inactive": "Inactive",
       "disabled": "Disabled",
       "error": "Error"

--- a/server/public/locales/es/msp/email-providers.json
+++ b/server/public/locales/es/msp/email-providers.json
@@ -12,7 +12,6 @@
       "resyncError": "No se pudo resincronizar el proveedor IMAP",
       "resyncStarted": "Se inició la resincronización para {{providerName}}.",
       "resyncRecovered": "{{providerName}} se volvió a conectar correctamente.",
-      "resyncPending": "{{providerName}} aún se está reconectando. Actualiza para comprobar el estado más reciente.",
       "enterpriseOnly": "El correo electrónico entrante de Microsoft 365 solo está disponible en Pro.",
       "loadProvidersError": "Failed to load email providers"
     },

--- a/server/public/locales/es/msp/email-providers.json
+++ b/server/public/locales/es/msp/email-providers.json
@@ -11,6 +11,8 @@
       "resyncing": "Resincronizando {{providerName}}...",
       "resyncError": "No se pudo resincronizar el proveedor IMAP",
       "resyncStarted": "Se inició la resincronización para {{providerName}}.",
+      "resyncRecovered": "{{providerName}} se volvió a conectar correctamente.",
+      "resyncPending": "{{providerName}} aún se está reconectando. Actualiza para comprobar el estado más reciente.",
       "enterpriseOnly": "El correo electrónico entrante de Microsoft 365 solo está disponible en Pro.",
       "loadProvidersError": "Failed to load email providers"
     },
@@ -163,6 +165,7 @@
       "disabled": "Desactivado",
       "paused": "En pausa",
       "connected": "Conectado",
+      "reconnecting": "Reconectando",
       "disconnected": "Desconectado",
       "error": "Error",
       "configuring": "Configurando",
@@ -211,6 +214,7 @@
     },
     "values": {
       "active": "Activo",
+      "reconnecting": "Reconectando",
       "inactive": "Inactivo",
       "disabled": "Desactivado",
       "error": "Error"

--- a/server/public/locales/fr/msp/email-providers.json
+++ b/server/public/locales/fr/msp/email-providers.json
@@ -12,7 +12,6 @@
       "resyncError": "Échec de la resynchronisation du fournisseur IMAP",
       "resyncStarted": "Resynchronisation démarrée pour {{providerName}}.",
       "resyncRecovered": "{{providerName}} s’est reconnecté avec succès.",
-      "resyncPending": "{{providerName}} est toujours en cours de reconnexion. Actualisez pour vérifier son dernier état.",
       "enterpriseOnly": "Le courrier électronique entrant Microsoft 365 est uniquement disponible avec Pro.",
       "loadProvidersError": "Failed to load email providers"
     },

--- a/server/public/locales/fr/msp/email-providers.json
+++ b/server/public/locales/fr/msp/email-providers.json
@@ -11,6 +11,8 @@
       "resyncing": "Resynchronisation de {{providerName}}...",
       "resyncError": "Échec de la resynchronisation du fournisseur IMAP",
       "resyncStarted": "Resynchronisation démarrée pour {{providerName}}.",
+      "resyncRecovered": "{{providerName}} s’est reconnecté avec succès.",
+      "resyncPending": "{{providerName}} est toujours en cours de reconnexion. Actualisez pour vérifier son dernier état.",
       "enterpriseOnly": "Le courrier électronique entrant Microsoft 365 est uniquement disponible avec Pro.",
       "loadProvidersError": "Failed to load email providers"
     },
@@ -163,6 +165,7 @@
       "disabled": "Désactivé",
       "paused": "En pause",
       "connected": "Connecté",
+      "reconnecting": "Reconnexion",
       "disconnected": "Déconnecté",
       "error": "Erreur",
       "configuring": "Configuration",
@@ -211,6 +214,7 @@
     },
     "values": {
       "active": "Actif",
+      "reconnecting": "Reconnexion",
       "inactive": "Inactif",
       "disabled": "Désactivé",
       "error": "Erreur"

--- a/server/public/locales/it/msp/email-providers.json
+++ b/server/public/locales/it/msp/email-providers.json
@@ -11,6 +11,8 @@
       "resyncing": "Risincronizzazione {{providerName}} in corso...",
       "resyncError": "Impossibile risincronizzare il provider IMAP",
       "resyncStarted": "La risincronizzazione è iniziata per {{providerName}}.",
+      "resyncRecovered": "{{providerName}} si è riconnesso correttamente.",
+      "resyncPending": "{{providerName}} si sta ancora riconnettendo. Aggiorna per verificarne lo stato più recente.",
       "enterpriseOnly": "La posta elettronica in entrata di Microsoft 365 è disponibile solo in Pro.",
       "loadProvidersError": "Failed to load email providers"
     },
@@ -163,6 +165,7 @@
       "disabled": "Disabilitato",
       "paused": "In pausa",
       "connected": "Collegato",
+      "reconnecting": "Riconnessione",
       "disconnected": "Disconnesso",
       "error": "Errore",
       "configuring": "Configurazione",
@@ -211,6 +214,7 @@
     },
     "values": {
       "active": "Attivo",
+      "reconnecting": "Riconnessione",
       "inactive": "Inattivo",
       "disabled": "Disabilitato",
       "error": "Errore"

--- a/server/public/locales/it/msp/email-providers.json
+++ b/server/public/locales/it/msp/email-providers.json
@@ -12,7 +12,6 @@
       "resyncError": "Impossibile risincronizzare il provider IMAP",
       "resyncStarted": "La risincronizzazione è iniziata per {{providerName}}.",
       "resyncRecovered": "{{providerName}} si è riconnesso correttamente.",
-      "resyncPending": "{{providerName}} si sta ancora riconnettendo. Aggiorna per verificarne lo stato più recente.",
       "enterpriseOnly": "La posta elettronica in entrata di Microsoft 365 è disponibile solo in Pro.",
       "loadProvidersError": "Failed to load email providers"
     },

--- a/server/public/locales/nl/msp/email-providers.json
+++ b/server/public/locales/nl/msp/email-providers.json
@@ -11,6 +11,8 @@
       "resyncing": "{{providerName}} opnieuw synchroniseren...",
       "resyncError": "Het opnieuw synchroniseren van de IMAP-provider is mislukt",
       "resyncStarted": "Hersynchronisatie gestart voor {{providerName}}.",
+      "resyncRecovered": "{{providerName}} is opnieuw verbonden.",
+      "resyncPending": "{{providerName}} maakt nog steeds opnieuw verbinding. Vernieuw om de nieuwste status te bekijken.",
       "enterpriseOnly": "Microsoft 365 inkomende e-mail is alleen beschikbaar in Pro.",
       "loadProvidersError": "Failed to load email providers"
     },
@@ -163,6 +165,7 @@
       "disabled": "Gehandicapt",
       "paused": "Gepauzeerd",
       "connected": "Aangesloten",
+      "reconnecting": "Opnieuw verbinden",
       "disconnected": "Verbinding verbroken",
       "error": "Fout",
       "configuring": "Configureren",
@@ -211,6 +214,7 @@
     },
     "values": {
       "active": "Actief",
+      "reconnecting": "Opnieuw verbinden",
       "inactive": "Inactief",
       "disabled": "Gehandicapt",
       "error": "Fout"

--- a/server/public/locales/nl/msp/email-providers.json
+++ b/server/public/locales/nl/msp/email-providers.json
@@ -12,7 +12,6 @@
       "resyncError": "Het opnieuw synchroniseren van de IMAP-provider is mislukt",
       "resyncStarted": "Hersynchronisatie gestart voor {{providerName}}.",
       "resyncRecovered": "{{providerName}} is opnieuw verbonden.",
-      "resyncPending": "{{providerName}} maakt nog steeds opnieuw verbinding. Vernieuw om de nieuwste status te bekijken.",
       "enterpriseOnly": "Microsoft 365 inkomende e-mail is alleen beschikbaar in Pro.",
       "loadProvidersError": "Failed to load email providers"
     },

--- a/server/public/locales/pl/msp/email-providers.json
+++ b/server/public/locales/pl/msp/email-providers.json
@@ -11,6 +11,8 @@
       "resyncing": "Ponowna synchronizacja {{providerName}}...",
       "resyncError": "Nie udało się ponownie zsynchronizować dostawcy IMAP",
       "resyncStarted": "Rozpoczęto ponowną synchronizację dla {{providerName}}.",
+      "resyncRecovered": "Ponownie połączono z {{providerName}}.",
+      "resyncPending": "{{providerName}} nadal ponownie nawiązuje połączenie. Odśwież, aby sprawdzić najnowszy stan.",
       "enterpriseOnly": "Przychodząca poczta e-mail usługi Microsoft 365 jest dostępna tylko w Pro.",
       "loadProvidersError": "Failed to load email providers"
     },
@@ -163,6 +165,7 @@
       "disabled": "Wyłączony",
       "paused": "Wstrzymano",
       "connected": "Połączony",
+      "reconnecting": "Ponowne łączenie",
       "disconnected": "Rozłączony",
       "error": "Błąd",
       "configuring": "Konfigurowanie",
@@ -211,6 +214,7 @@
     },
     "values": {
       "active": "Aktywny",
+      "reconnecting": "Ponowne łączenie",
       "inactive": "Nieaktywny",
       "disabled": "Wyłączony",
       "error": "Błąd"

--- a/server/public/locales/pl/msp/email-providers.json
+++ b/server/public/locales/pl/msp/email-providers.json
@@ -12,7 +12,6 @@
       "resyncError": "Nie udało się ponownie zsynchronizować dostawcy IMAP",
       "resyncStarted": "Rozpoczęto ponowną synchronizację dla {{providerName}}.",
       "resyncRecovered": "Ponownie połączono z {{providerName}}.",
-      "resyncPending": "{{providerName}} nadal ponownie nawiązuje połączenie. Odśwież, aby sprawdzić najnowszy stan.",
       "enterpriseOnly": "Przychodząca poczta e-mail usługi Microsoft 365 jest dostępna tylko w Pro.",
       "loadProvidersError": "Failed to load email providers"
     },

--- a/server/public/locales/pt/msp/email-providers.json
+++ b/server/public/locales/pt/msp/email-providers.json
@@ -12,7 +12,6 @@
       "resyncError": "Falha ao sincronizar novamente o provedor IMAP",
       "resyncStarted": "A ressincronização foi iniciada para {{providerName}}.",
       "resyncRecovered": "{{providerName}} foi reconectado com sucesso.",
-      "resyncPending": "{{providerName}} ainda está se reconectando. Atualize para verificar o status mais recente.",
       "enterpriseOnly": "O email de entrada do Microsoft 365 está disponível apenas no Pro.",
       "loadProvidersError": "Failed to load email providers"
     },

--- a/server/public/locales/pt/msp/email-providers.json
+++ b/server/public/locales/pt/msp/email-providers.json
@@ -11,6 +11,8 @@
       "resyncing": "Ressincronizando {{providerName}}...",
       "resyncError": "Falha ao sincronizar novamente o provedor IMAP",
       "resyncStarted": "A ressincronização foi iniciada para {{providerName}}.",
+      "resyncRecovered": "{{providerName}} foi reconectado com sucesso.",
+      "resyncPending": "{{providerName}} ainda está se reconectando. Atualize para verificar o status mais recente.",
       "enterpriseOnly": "O email de entrada do Microsoft 365 está disponível apenas no Pro.",
       "loadProvidersError": "Failed to load email providers"
     },
@@ -163,6 +165,7 @@
       "disabled": "Desabilitado",
       "paused": "Pausado",
       "connected": "Conectado",
+      "reconnecting": "Reconectando",
       "disconnected": "Desconectado",
       "error": "Erro",
       "configuring": "Configurando",
@@ -211,6 +214,7 @@
     },
     "values": {
       "active": "Ativo",
+      "reconnecting": "Reconectando",
       "inactive": "Inativo",
       "disabled": "Desabilitado",
       "error": "Erro"

--- a/server/public/locales/xx/msp/email-providers.json
+++ b/server/public/locales/xx/msp/email-providers.json
@@ -12,7 +12,6 @@
       "resyncError": "11111",
       "resyncStarted": "11111 {{providerName}} 11111",
       "resyncRecovered": "11111 {{providerName}} 11111",
-      "resyncPending": "11111 {{providerName}} 11111",
       "enterpriseOnly": "11111",
       "loadProvidersError": "11111"
     },

--- a/server/public/locales/xx/msp/email-providers.json
+++ b/server/public/locales/xx/msp/email-providers.json
@@ -11,6 +11,8 @@
       "resyncing": "11111 {{providerName}} 11111",
       "resyncError": "11111",
       "resyncStarted": "11111 {{providerName}} 11111",
+      "resyncRecovered": "11111 {{providerName}} 11111",
+      "resyncPending": "11111 {{providerName}} 11111",
       "enterpriseOnly": "11111",
       "loadProvidersError": "11111"
     },
@@ -163,6 +165,7 @@
       "disabled": "11111",
       "paused": "11111",
       "connected": "11111",
+      "reconnecting": "11111",
       "disconnected": "11111",
       "error": "11111",
       "configuring": "11111",
@@ -211,6 +214,7 @@
     },
     "values": {
       "active": "11111",
+      "reconnecting": "11111",
       "inactive": "11111",
       "disabled": "11111",
       "error": "11111"

--- a/server/public/locales/yy/msp/email-providers.json
+++ b/server/public/locales/yy/msp/email-providers.json
@@ -11,6 +11,8 @@
       "resyncing": "55555 {{providerName}} 55555",
       "resyncError": "55555",
       "resyncStarted": "55555 {{providerName}} 55555",
+      "resyncRecovered": "55555 {{providerName}} 55555",
+      "resyncPending": "55555 {{providerName}} 55555",
       "enterpriseOnly": "55555",
       "loadProvidersError": "55555"
     },
@@ -163,6 +165,7 @@
       "disabled": "55555",
       "paused": "55555",
       "connected": "55555",
+      "reconnecting": "55555",
       "disconnected": "55555",
       "error": "55555",
       "configuring": "55555",
@@ -211,6 +214,7 @@
     },
     "values": {
       "active": "55555",
+      "reconnecting": "55555",
       "inactive": "55555",
       "disabled": "55555",
       "error": "55555"

--- a/server/public/locales/yy/msp/email-providers.json
+++ b/server/public/locales/yy/msp/email-providers.json
@@ -12,7 +12,6 @@
       "resyncError": "55555",
       "resyncStarted": "55555 {{providerName}} 55555",
       "resyncRecovered": "55555 {{providerName}} 55555",
-      "resyncPending": "55555 {{providerName}} 55555",
       "enterpriseOnly": "55555",
       "loadProvidersError": "55555"
     },


### PR DESCRIPTION
## Summary

- Present an active IMAP provider as `Reconnecting` immediately after Resync instead of exposing the backend's intentional temporary `disconnected` state as a stale Disconnected/inactive-looking card.
- Refresh provider state automatically with provider-scoped polling: every 5 seconds through 2 minutes, every 15 seconds through 5 minutes, then at a capped 30-second interval until fresh persisted state recovers or polling is cancelled/superseded.
- Keep normal active card opacity, block conflicting duplicate actions while reconnecting, announce fresh recovery, and preserve the existing backend resync/status contract.
- Add localized reconnecting/recovery copy plus focused coverage for immediate presentation, natural delayed recovery beyond 90 seconds, adaptive backoff, unmount cleanup, failed resync, and active card styling.
- Rebased onto current `main` and preserved the merged Microsoft email setup-status capability behavior and current Pro wording in the shared component.

## Validation

- `npm run typecheck` in `packages/integrations`
- `npm test` in `packages/integrations`: 63 files, 401 tests passed
- Focused `EmailProviderConfiguration.resync.test.tsx`: 6 tests passed
- `node scripts/validate-translations.cjs`: 9 locales, 0 errors, 0 warnings

Smoke test: **PASS.** Exercised two natural-recovery cycles against the real app, PostgreSQL/Redis, GreenMail, and worktree-built email-service at its production 60-second refresh interval; no simulator or mock was used. Resync immediately presented Reconnecting in the badge and Status while retaining normal card opacity; DB confirmed `status=disconnected` and `is_active=true`. The untouched page automatically recovered to Connected/Active without reloads, worker restarts, or status edits. The evidence run remained disconnected at 101.7 seconds—past the removed 90-second deadline—and recovered at 116.1 seconds after the second service refresh. Test Connection passed before and after recovery, and no non-HMR console errors occurred. Capture compromise: alga-dev screenshots timed out because its Electron process had no native window, so the fully alga-dev-driven flow was repeated through real UI clicks in headless Chrome solely to capture PNGs; authentication used an encoded token for an existing valid session. Temporary credentials were restored, the provider and its orphaned secret were removed, and the smoke email-service/helpers were stopped. The only worktree change remains the pre-existing `package-lock.json` modification. Minor unrelated concern: deleting the provider through the UI left its IMAP secret file behind, which required manual smoke cleanup.

Evidence directory: `/tmp/alga-smoke-evidence/imap-resync-natural-recovery-20260803T040820Z`
