### PR TITLE
Outbound email via Microsoft Graph (alga0002216)

### DIFF
--- a/docs/inbound-email/setup/microsoft.md
+++ b/docs/inbound-email/setup/microsoft.md
@@ -1,12 +1,12 @@
 # Microsoft 365 Provider Setup (Outlook / Exchange Online)
 
-Connect a Microsoft 365 mailbox to turn incoming messages into tickets. The
-connector uses delegated Microsoft Graph access on behalf of the user who
-authorizes it.
+Connect a Microsoft 365 mailbox to turn incoming messages into tickets and,
+optionally, send outbound email from the same mailbox. The connector uses
+delegated Microsoft Graph access on behalf of the user who authorizes it.
 
-> **Inbound only.** This connector reads mail. It does not move messages, mark
-> them as read, or send replies. Configure ticket replies and notifications
-> separately under **Settings → Email → Outbound**.
+> Existing Microsoft connections must be reauthorized before outbound use so
+> the delegated token includes `Mail.Send`. A provider showing **Ready** only
+> confirms that its Microsoft credentials are configured.
 
 > Microsoft 365 inbound email is a Pro feature. It is not
 > offered in Community Edition builds.
@@ -47,18 +47,18 @@ by Outlook email is explicit.
 ## Required Microsoft permissions
 
 Add these permissions as **Microsoft Graph → Delegated permissions**. The
-inbound OAuth flow requests exactly these three scopes:
+Microsoft mailbox OAuth flow requests exactly these four scopes:
 
 | Permission | Why Alga PSA requests it |
 | --- | --- |
 | `Mail.Read` | Reads the signed-in user's mailbox. It also permits message and folder access used for that user's change-notification subscription. |
 | `Mail.Read.Shared` | Reads shared or delegated mailboxes that the signed-in user can already access. It does not grant Exchange mailbox access. |
+| `Mail.Send` | Sends outbound email as the configured mailbox when Microsoft 365 is selected under **Settings → Email → Outbound Email**. It does not grant Exchange **Send As** rights for a shared mailbox. |
 | `offline_access` | Requests a refresh token so polling, reconciliation, and subscription maintenance can continue without another interactive sign-in. |
 
-Do not add **Application permissions** for this connector. `Mail.ReadWrite` and
-`Mail.Send` are not required for inbound ingestion. The broader Email scope list
-shown in some Microsoft provider guidance covers other Microsoft capabilities;
-it is not the inbound mailbox runtime checklist.
+Do not add **Application permissions** for this connector. `Mail.ReadWrite` is
+not required: inbound ingestion remains read-only, and outbound sending uses
+delegated `Mail.Send`.
 
 Microsoft lists these delegated permissions as not requiring admin consent by
 default. Your tenant can still restrict user consent. Grant tenant-wide admin
@@ -97,8 +97,8 @@ Confirm all of the following:
    type.
 3. Under **Authentication**, add the callback from Alga PSA as a **Web** redirect
    URI: `https://<your-host>/api/auth/microsoft/callback`.
-4. Under **API permissions**, add `Mail.Read`, `Mail.Read.Shared`, and
-   `offline_access` as delegated permissions.
+4. Under **API permissions**, add `Mail.Read`, `Mail.Read.Shared`, `Mail.Send`,
+   and `offline_access` as delegated permissions.
 5. If your tenant policy requires administrator approval, select **Grant admin
    consent** for the tenant.
 6. Under **Certificates & secrets**, create a client secret and copy its
@@ -153,7 +153,9 @@ application-level mail permission.
 3. In Exchange Online, grant that user **Read and manage (Full Access)** to the
    shared mailbox. `Mail.Read.Shared` lets Graph use access the user already
    has; it does not assign Full Access.
-4. Before authorizing Alga PSA, verify that the user can open the shared mailbox
+4. To send outbound email from the shared mailbox, also grant that user **Send
+   As** permission. Delegated `Mail.Send` does not assign this Exchange right.
+5. Before authorizing Alga PSA, verify that the user can open the shared mailbox
    in Outlook or Outlook on the web.
 
 Microsoft Graph does not support Outlook change-notification subscriptions on
@@ -202,25 +204,33 @@ At runtime:
 * Polling providers retry webhook registration every 24 hours and when you use
   **Test Connection**.
 
-The connector remains read-only in both modes. Refresh tokens are stored
-server-side and are used to renew access tokens for background work.
+Inbound processing remains read-only in both modes. Refresh tokens are stored
+server-side and are used to renew access tokens for background work and
+outbound delivery.
 
-## Outbound email is configured separately
+## Enable outbound Microsoft Graph email
 
-Connecting a Microsoft mailbox does not enable sending. Ticket replies,
-notifications, and other outbound mail use SMTP or a managed Resend domain.
-Appliance and Essentials installations use SMTP.
+Connecting a Microsoft mailbox makes it available for selection but does not
+change the tenant's outbound provider automatically.
 
-For an appliance, open **Settings → Email → Outbound**, configure SMTP, then set
-**Ticketing From** to the reply address. This is usually the same address as the
-inbound mailbox so customer replies thread correctly.
+1. Open **Settings → Email → Outbound Email**.
+2. Select **Microsoft 365 (Microsoft Graph)**.
+3. Select the connected sending mailbox and save. The sender and ticketing From
+   address are tied to that mailbox; arbitrary From spoofing is not supported.
+4. Use **Test Outbound Email** to verify the connection and optionally send a
+   test message.
+
+Alga PSA sends through `/users/{mailbox}/sendMail` and requests that Microsoft
+save a copy in Sent Items. A Graph 403 generally means `Mail.Send` consent or,
+for a shared mailbox, Exchange **Send As** permission is missing. Reconnect the
+provider after adding or changing delegated permissions.
 
 ## Troubleshooting
 
 | Symptom | Check |
 | --- | --- |
 | **Authorize Access** is disabled | Open **Settings → Integrations → Providers**. Enable a Microsoft app for Outlook email and select it in the Outlook email service row, or confirm the hosted platform setup is ready. |
-| Microsoft shows **Need admin approval** | The tenant's consent policy blocks user consent. Ask an authorized Entra administrator to grant tenant-wide admin consent for the three delegated scopes. |
+| Microsoft shows **Need admin approval** | The tenant's consent policy blocks user consent. Ask an authorized Entra administrator to grant tenant-wide admin consent for the four delegated scopes. |
 | OAuth reports a redirect error | Compare the displayed redirect URI with the Entra **Web** redirect URI character for character. Confirm the app supports accounts in any organizational directory. |
 | OAuth succeeds, but the shared mailbox returns 403 | Confirm Exchange Full Access for the authorizing user, then confirm and re-consent `Mail.Read.Shared`. Graph consent does not grant mailbox membership. |
 | Shared-mailbox authorization reports a subscription access error | Microsoft does not support delegated change notifications for shared folders. Do not add application permissions. Leave the provider enabled and check polling delivery and last-ingested time after the next cycle. |
@@ -228,4 +238,5 @@ inbound mailbox so customer replies thread correctly.
 | New mail does not create tickets | Check delivery mode and last-ingested time. Polling needs outbound access to Microsoft. Webhook mode also needs public inbound access. Use **Test Connection** to check Graph access and retry webhook registration. |
 | Token refresh fails after working previously | The refresh token or consent may have expired or been revoked, or the bound app's client ID/secret changed. Restore the issuing app credentials if appropriate, then reauthorize the mailbox. |
 | Mail from a custom folder is missing | Set **Folder Filters** to `Inbox` and reauthorize. Multiple/custom Microsoft folders are not currently reliable across subscription maintenance and reconciliation. |
-| The provider is Ready, but Alga PSA sends no replies | Ready describes inbound credentials only. Configure SMTP or Resend under **Settings → Email → Outbound**. |
+| The provider is Ready, but Alga PSA sends no replies | Select the mailbox under **Settings → Email → Outbound Email**, reconnect it if it predates `Mail.Send`, and run the outbound test. |
+| The outbound test returns 403 | Reconnect the mailbox to grant `Mail.Send`. For a shared mailbox, also verify that the authorizing user has Exchange **Send As** permission. |

--- a/docs/plans/2026-08-02-microsoft-graph-outbound-email-plan.md
+++ b/docs/plans/2026-08-02-microsoft-graph-outbound-email-plan.md
@@ -1,0 +1,86 @@
+# Microsoft Graph outbound email implementation plan
+
+## Goal
+
+Allow a tenant's existing Microsoft email-provider connection to send outbound mail through Microsoft Graph, so ticket replies and every other path already routed through `TenantEmailService` / `EmailProviderManager` can use Microsoft 365 without a separate SMTP or Resend provider.
+
+## Current code shape
+
+- `packages/email/src/providers/EmailProviderManager.ts` owns outbound provider construction. Its factory recognizes only `smtp` and `resend`, while the persisted inbound configuration uses `provider_type = 'microsoft'`.
+- `server/src/components/MicrosoftProviderForm.tsx` and the existing Microsoft OAuth callback/configuration flow already create and refresh Microsoft provider credentials for inbound Graph mail.
+- Microsoft provider configuration is stored in the email-provider tables and already carries mailbox/token/refresh-token data used by webhook and inbound processing.
+- Callers such as ticket replies, billing mail, and workflows already use the common email service; they should not gain Microsoft-specific branches.
+
+## Design decisions
+
+1. Treat `microsoft` as another implementation of the existing `IEmailProvider` contract. Keep provider selection and all outbound callers unchanged.
+2. Reuse the existing Microsoft email-provider row and OAuth token lifecycle. Do not introduce a second Microsoft connection or duplicate client secrets.
+3. Send as the explicitly configured mailbox. Use Graph `POST /users/{encoded-mailbox}/sendMail` rather than `/me/sendMail`, because app/shared-mailbox configurations must not depend on the token's interactive identity.
+4. Extend the existing Microsoft consent request to include the least outbound permission needed by the current auth model: `Mail.Send`, plus the inbound scopes already requested. Existing connections missing the scope must show a reconnect/consent-required error rather than silently falling back to another sender.
+5. Preserve the common `EmailMessage` semantics: To/Cc/Bcc, subject, HTML/text body, reply-to, attachments, and provider-neutral result/error fields. The Graph adapter performs only the wire-format conversion.
+6. Graph's successful `sendMail` response normally has no message id. Return a stable successful provider result without inventing an id; retain any request/correlation id only as diagnostic metadata if the interface supports it.
+7. Token refresh and one bounded retry on 401 belong in the Microsoft provider/auth helper, using the established refresh-token persistence path. Never log access tokens, refresh tokens, or full message bodies.
+
+## Implementation sequence
+
+### 1. Make the shared outbound types accept Microsoft
+
+- Locate the canonical `EmailProviderConfig` / provider-type declarations exported by `@alga-psa/types` and add `microsoft` to the allowed outbound provider type.
+- Update settings-loading mappings that currently narrow provider types to `smtp | resend`; keep the persisted provider id and tenant association intact.
+- Confirm the manager receives the same Microsoft config that inbound services use, including provider id, mailbox address, OAuth tokens, expiry, and Microsoft profile/client binding.
+
+### 2. Add `MicrosoftGraphEmailProvider`
+
+Create `packages/email/src/providers/MicrosoftGraphEmailProvider.ts` implementing `IEmailProvider`, following the SMTP and Resend providers for lifecycle, capabilities, logging, and `EmailProviderError` behavior.
+
+- Validate configuration during `initialize`: tenant/provider identity, sender mailbox, access token or refreshable credentials, and Graph endpoint inputs.
+- Map `EmailMessage` to the Graph message shape: recipients, HTML/text body, reply-to, and file attachments as Graph fileAttachment objects with base64 content.
+- Call `https://graph.microsoft.com/v1.0/users/{mailbox}/sendMail` with `saveToSentItems: true`.
+- Normalize Graph failures into retryable/non-retryable `EmailProviderError` values: 401/expired token triggers refresh once; 403 reports missing consent or mailbox Send As rights; 429/5xx are retryable; validation/4xx errors are not.
+- Implement a lightweight health check that verifies configuration/token viability without sending mail.
+- Declare no native bulk capability initially so the manager uses its existing per-message fallback.
+
+### 3. Wire provider construction and credential resolution
+
+- Add the `microsoft` case to `EmailProviderManager.createProvider`.
+- Extend `resolveProviderConfig` (or introduce a small Microsoft-specific resolver) so the provider receives fresh credentials from the existing Microsoft email-provider configuration rather than stale client-supplied values.
+- Reuse the existing Microsoft token refresh/profile-resolution utilities. If their location creates an invalid dependency direction for `packages/email`, define a narrow injected token-source interface in the email package and provide the server implementation; do not copy OAuth logic into the adapter.
+- Keep tenant/provider cache invalidation behavior unchanged so reconnecting or editing the mailbox rebuilds the active provider.
+
+### 4. Extend Microsoft consent and settings UX
+
+- Add `Mail.Send` to the existing Microsoft email OAuth scope set and its user-facing scope disclosure.
+- Update the Microsoft provider form/status copy to state that the connection supports inbound and outbound mail, identify the configured sending mailbox, and prompt existing installations to reconnect when outbound permission is absent.
+- Keep sender selection tied to the configured Microsoft mailbox. Do not add arbitrary per-message From spoofing.
+- Update `docs/inbound-email/setup/microsoft.md` so it no longer claims Microsoft is inbound-only and documents `Mail.Send`, shared-mailbox Send As requirements, and reconnect behavior.
+
+### 5. Cover common and ticket-reply paths behaviorally
+
+- Provider unit tests for message mapping, mailbox URL encoding, success, authorization/rate-limit failures, token refresh plus one retry, and secret-safe logging.
+- Manager tests proving a `microsoft` config constructs and uses the Graph provider and bulk fallback sends each message.
+- Settings/auth tests proving `Mail.Send` is requested and persisted Microsoft configuration initializes outbound sending.
+- A service-level ticket-reply test proving a public reply selects Microsoft, preserves threading/reply-to data, and calls Graph with the configured mailbox.
+- Regression coverage that SMTP/Resend selection and inbound Microsoft polling/webhooks remain unchanged.
+
+## Manual smoke evidence
+
+1. Reconnect a Microsoft provider and confirm consent includes `Mail.Send`.
+2. Send a normal message and verify delivery plus a Sent Items copy.
+3. Send a public reply from a ticket; verify it comes from the configured mailbox and replies route to the same ticket.
+4. Exercise HTML, Cc/Bcc, reply-to, and a small attachment.
+5. Remove `Mail.Send` or Send As permission and confirm an actionable, secret-safe authorization error.
+6. Confirm inbound Graph webhook/poll processing still works.
+
+## Deliberately out of scope
+
+- A separate Microsoft outbound-provider database model.
+- Arbitrary From spoofing or automatic mailbox discovery.
+- Graph batch sending, large-attachment upload sessions, national-cloud endpoints, and delivery/read receipts.
+- Microsoft-specific branches in ticket, invoice, workflow, or notification callers.
+
+## Risks
+
+- Existing tenants need admin re-consent for `Mail.Send`.
+- Delegated vs application permissions and shared-mailbox Send As rights produce different 403 failures.
+- Graph limits simple file attachments; oversized mail must fail clearly until upload sessions are implemented.
+- Token helpers may be server-only; preserve package boundaries through a narrow credential source.

--- a/package-lock.json
+++ b/package-lock.json
@@ -46525,6 +46525,7 @@
         "@alga-psa/core": "*",
         "@alga-psa/db": "*",
         "@alga-psa/event-bus": "*",
+        "@alga-psa/shared": "*",
         "@alga-psa/types": "*",
         "axios": "^1.16.0",
         "nodemailer": "^9.0.3"

--- a/packages/email/package.json
+++ b/packages/email/package.json
@@ -27,6 +27,7 @@
     "@alga-psa/core": "*",
     "@alga-psa/db": "*",
     "@alga-psa/event-bus": "*",
+    "@alga-psa/shared": "*",
     "@alga-psa/types": "*",
     "axios": "^1.16.0",
     "nodemailer": "^9.0.3"

--- a/packages/email/src/TenantEmailService.ts
+++ b/packages/email/src/TenantEmailService.ts
@@ -6,7 +6,8 @@ import {
   EmailAddress,
   IEmailProvider,
   EmailMessage,
-  EmailProviderConfig
+  EmailProviderConfig,
+  EmailProviderError,
 } from '@alga-psa/types';
 import logger from '@alga-psa/core/logger';
 import {
@@ -430,6 +431,9 @@ export class TenantEmailService extends BaseEmailService {
       // For SMTP this opens a connection and runs verify() (incl. AUTH/TLS).
       await manager.initialize(settings);
     } catch (error) {
+      if (error instanceof EmailProviderError) {
+        return { success: false, error: error.message };
+      }
       return { success: false, error: 'The outbound email provider could not be initialized. Check host, credentials, and security settings.' };
     }
 
@@ -462,6 +466,9 @@ export class TenantEmailService extends BaseEmailService {
       }
       return { success: false, error: result.error || 'The provider rejected the test message.' };
     } catch (error) {
+      if (error instanceof EmailProviderError) {
+        return { success: false, error: error.message };
+      }
       return { success: false, error: 'Failed to send the test email. Check provider settings and try again.' };
     }
   }

--- a/packages/email/src/providerConfig.ts
+++ b/packages/email/src/providerConfig.ts
@@ -18,8 +18,14 @@ export function createDefaultProviderConfig(
           password: '',
           from: '',
         }
-      : {
+      : providerType === 'resend'
+      ? {
           apiKey: '',
+          from: '',
+        }
+      : {
+          inboundProviderId: '',
+          mailbox: '',
           from: '',
         },
   };

--- a/packages/email/src/providers/EmailProviderManager.ts
+++ b/packages/email/src/providers/EmailProviderManager.ts
@@ -4,6 +4,8 @@
 
 import logger from '@alga-psa/core/logger';
 import { getSecretProviderInstance } from '@alga-psa/core/secrets';
+import { getConnection, tenantDb } from '@alga-psa/db';
+import { buildMicrosoftEmailProviderConfig } from '@alga-psa/shared/services/email/microsoftEmailProviderConfig';
 import { SystemEmailProviderFactory } from '../system/SystemEmailProviderFactory';
 import {
   IEmailProvider,
@@ -210,6 +212,10 @@ export class EmailProviderManager implements IEmailProviderManager {
   private async resolveProviderConfig(tenantId: string, config: EmailProviderConfig): Promise<Record<string, any>> {
     const originalConfig = typeof config.config === 'object' && config.config !== null ? config.config : {};
 
+    if (config.providerType === 'microsoft') {
+      return this.resolveMicrosoftProviderConfig(tenantId, config);
+    }
+
     if (config.providerType !== 'resend') {
       return originalConfig;
     }
@@ -231,6 +237,68 @@ export class EmailProviderManager implements IEmailProviderManager {
       ...originalConfig,
       apiKey: fallbackApiKey,
     };
+  }
+
+  private async resolveMicrosoftProviderConfig(
+    tenantId: string,
+    config: EmailProviderConfig
+  ): Promise<Record<string, any>> {
+    const requestedProviderId = this.normalizeSecretValue(config.config?.inboundProviderId)
+      || config.providerId;
+    const knex = await getConnection(tenantId);
+    const db = tenantDb(knex, tenantId);
+    const provider = await db.table('email_providers')
+      .where({ id: requestedProviderId, provider_type: 'microsoft' })
+      .first();
+
+    if (!provider) {
+      throw new EmailProviderError(
+        'The selected Microsoft mailbox no longer exists. Choose an active Microsoft 365 mailbox in outbound email settings.',
+        config.providerId,
+        config.providerType,
+        false,
+        'MICROSOFT_PROVIDER_NOT_FOUND'
+      );
+    }
+    if (!provider.is_active || provider.status !== 'connected') {
+      throw new EmailProviderError(
+        'The selected Microsoft mailbox is not connected. Reconnect it before using it for outbound email.',
+        config.providerId,
+        config.providerType,
+        false,
+        'MICROSOFT_PROVIDER_NOT_CONNECTED'
+      );
+    }
+
+    const vendorConfig = await db.table('microsoft_email_provider_config')
+      .where({ email_provider_id: provider.id })
+      .first();
+    if (!vendorConfig) {
+      throw new EmailProviderError(
+        'The selected Microsoft mailbox has no OAuth configuration. Reconnect it before sending email.',
+        config.providerId,
+        config.providerType,
+        false,
+        'MICROSOFT_CONFIG_NOT_FOUND'
+      );
+    }
+
+    const inboundProvider = await buildMicrosoftEmailProviderConfig({
+      id: provider.id,
+      tenant: provider.tenant,
+      name: provider.provider_name || provider.mailbox,
+      provider_type: 'microsoft',
+      mailbox: provider.mailbox,
+      folder_to_monitor: 'Inbox',
+      active: provider.is_active,
+      webhook_notification_url: '',
+      connection_status: provider.status,
+      created_at: provider.created_at,
+      updated_at: provider.updated_at,
+      provider_config: vendorConfig,
+    });
+
+    return { inboundProvider };
   }
 
   private async getResendFallbackApiKey(
@@ -320,6 +388,10 @@ export class EmailProviderManager implements IEmailProviderManager {
       case 'resend':
         const { ResendEmailProvider } = await import('./ResendEmailProvider');
         return new ResendEmailProvider(config.providerId);
+
+      case 'microsoft':
+        const { MicrosoftGraphEmailProvider } = await import('./MicrosoftGraphEmailProvider');
+        return new MicrosoftGraphEmailProvider(config.providerId);
       
       default:
         throw new Error(`Unsupported provider type: ${config.providerType}`);

--- a/packages/email/src/providers/MicrosoftGraphEmailProvider.ts
+++ b/packages/email/src/providers/MicrosoftGraphEmailProvider.ts
@@ -1,0 +1,386 @@
+/**
+ * Microsoft Graph outbound email provider.
+ *
+ * Wire-format conversion stays here; OAuth refresh and credential persistence
+ * remain in the existing inbound MicrosoftGraphAdapter.
+ */
+
+import logger from '@alga-psa/core/logger';
+import nodemailer from 'nodemailer';
+import type Mail from 'nodemailer/lib/mailer';
+import type {
+  EmailAddress,
+  EmailAttachment,
+  EmailMessage,
+  EmailProviderCapabilities,
+  EmailSendResult,
+  IEmailProvider,
+} from '@alga-psa/types';
+import { EmailProviderError } from '@alga-psa/types';
+import {
+  MicrosoftGraphAdapter,
+  type MicrosoftGraphSendMailPayload,
+} from '@alga-psa/shared/services/email/providers/MicrosoftGraphAdapter';
+import type { EmailProviderConfig as InboundEmailProviderConfig } from '@alga-psa/shared/interfaces/inbound-email.interfaces';
+
+const SIMPLE_ATTACHMENT_LIMIT = 3 * 1024 * 1024;
+
+interface MicrosoftGraphConfig {
+  inboundProvider: InboundEmailProviderConfig;
+}
+
+interface GraphRecipient {
+  emailAddress: {
+    address: string;
+    name?: string;
+  };
+}
+
+export class MicrosoftGraphEmailProvider implements IEmailProvider {
+  public readonly providerId: string;
+  public readonly providerType = 'microsoft';
+  public readonly capabilities: EmailProviderCapabilities = {
+    supportsHtml: true,
+    supportsAttachments: true,
+    supportsTemplating: false,
+    supportsBulkSending: false,
+    supportsTracking: false,
+    supportsCustomDomains: false,
+    maxAttachmentSize: SIMPLE_ATTACHMENT_LIMIT,
+    maxRecipientsPerMessage: 500,
+  };
+
+  private adapter: MicrosoftGraphAdapter | null = null;
+  private mailbox = '';
+  private initialized = false;
+  private readonly mimeTransport = nodemailer.createTransport({
+    streamTransport: true,
+    buffer: true,
+    newline: 'unix',
+  });
+
+  constructor(providerId: string) {
+    this.providerId = providerId;
+  }
+
+  async initialize(config: Record<string, any>): Promise<void> {
+    try {
+      const validated = this.validateConfig(config);
+      this.mailbox = validated.inboundProvider.mailbox.trim();
+      this.assertMailSendConsent(validated.inboundProvider.provider_config?.access_token);
+      this.adapter = new MicrosoftGraphAdapter(validated.inboundProvider);
+      await this.adapter.connect();
+      this.initialized = true;
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      logger.error(`[MicrosoftGraphEmailProvider:${this.providerId}] Initialization failed`, {
+        error: message,
+      });
+      throw new EmailProviderError(
+        `Microsoft Graph initialization failed: ${message}`,
+        this.providerId,
+        this.providerType,
+        false,
+        'INIT_FAILED'
+      );
+    }
+  }
+
+  async sendEmail(message: EmailMessage, tenantId: string): Promise<EmailSendResult> {
+    this.ensureInitialized();
+
+    try {
+      const payload = await this.buildSendPayload(message);
+      const metadata = await this.adapter!.sendMail(payload);
+      logger.info(`[MicrosoftGraphEmailProvider:${this.providerId}] Email accepted by Microsoft Graph`, {
+        tenantId,
+        mailbox: this.mailbox,
+        requestId: metadata.requestId,
+      });
+
+      return {
+        success: true,
+        providerId: this.providerId,
+        providerType: this.providerType,
+        sentAt: new Date(),
+        metadata,
+      };
+    } catch (error: any) {
+      throw this.toProviderError(error);
+    }
+  }
+
+  async healthCheck(): Promise<{ healthy: boolean; details?: string }> {
+    if (!this.initialized || !this.adapter) {
+      return { healthy: false, details: 'Provider not initialized' };
+    }
+
+    try {
+      const result = await this.adapter.testConnection();
+      return result.success
+        ? { healthy: true, details: `Microsoft Graph mailbox ${this.mailbox} is reachable` }
+        : { healthy: false, details: result.error || 'Microsoft Graph connection test failed' };
+    } catch (error) {
+      return {
+        healthy: false,
+        details: error instanceof Error ? error.message : 'Microsoft Graph connection test failed',
+      };
+    }
+  }
+
+  private validateConfig(config: Record<string, any>): MicrosoftGraphConfig {
+    const inboundProvider = config?.inboundProvider as InboundEmailProviderConfig | undefined;
+    if (!inboundProvider?.id || inboundProvider.provider_type !== 'microsoft') {
+      throw new Error('A Microsoft inbound email provider is required');
+    }
+    if (!inboundProvider.tenant) {
+      throw new Error('Microsoft provider tenant is required');
+    }
+    if (!inboundProvider.mailbox?.trim()) {
+      throw new Error('Microsoft sending mailbox is required');
+    }
+
+    const vendorConfig = inboundProvider.provider_config || {};
+    if (!vendorConfig.access_token && !vendorConfig.refresh_token) {
+      throw new Error('Microsoft OAuth tokens are missing. Reconnect the mailbox.');
+    }
+
+    return { inboundProvider };
+  }
+
+  private assertMailSendConsent(accessToken: unknown): void {
+    if (typeof accessToken !== 'string') return;
+    const payload = this.decodeJwtPayload(accessToken);
+    if (!payload || typeof payload.scp !== 'string') return;
+
+    const scopes = new Set(payload.scp.split(/\s+/).filter(Boolean));
+    if (!scopes.has('Mail.Send')) {
+      throw new Error('Microsoft Mail.Send consent is missing. Reconnect the mailbox and grant outbound mail permission.');
+    }
+  }
+
+  private decodeJwtPayload(token: string): Record<string, unknown> | null {
+    try {
+      const payload = token.split('.')[1];
+      if (!payload) return null;
+      const normalized = payload.replace(/-/g, '+').replace(/_/g, '/');
+      const padded = normalized.padEnd(Math.ceil(normalized.length / 4) * 4, '=');
+      return JSON.parse(Buffer.from(padded, 'base64').toString('utf8'));
+    } catch {
+      return null;
+    }
+  }
+
+  private buildGraphMessage(message: EmailMessage): Record<string, unknown> {
+    if (!message.to?.length) {
+      throw new EmailProviderError(
+        'At least one recipient is required',
+        this.providerId,
+        this.providerType,
+        false,
+        'INVALID_MESSAGE'
+      );
+    }
+
+    const graphMessage: Record<string, unknown> = {
+      subject: message.subject,
+      body: {
+        contentType: message.html ? 'HTML' : 'Text',
+        content: message.html || message.text || '',
+      },
+      toRecipients: message.to.map(address => this.toRecipient(address)),
+    };
+
+    if (message.cc?.length) graphMessage.ccRecipients = message.cc.map(address => this.toRecipient(address));
+    if (message.bcc?.length) graphMessage.bccRecipients = message.bcc.map(address => this.toRecipient(address));
+    if (message.replyTo) graphMessage.replyTo = [this.toRecipient(message.replyTo)];
+    if (message.headers && Object.keys(message.headers).length > 0) {
+      graphMessage.internetMessageHeaders = Object.entries(message.headers).map(([name, value]) => ({ name, value }));
+    }
+    if (message.attachments?.length) {
+      graphMessage.attachments = message.attachments.map(attachment => this.toAttachment(attachment));
+    }
+
+    return graphMessage;
+  }
+
+  private async buildSendPayload(message: EmailMessage): Promise<MicrosoftGraphSendMailPayload> {
+    const headers = Object.keys(message.headers || {});
+    const requiresMime = headers.some(name => !name.toLowerCase().startsWith('x-'));
+
+    if (!requiresMime) {
+      return { kind: 'json', message: this.buildGraphMessage(message) };
+    }
+
+    const mime = await this.buildMimeMessage(message);
+    return { kind: 'mime', content: mime.toString('base64') };
+  }
+
+  private async buildMimeMessage(message: EmailMessage): Promise<Buffer> {
+    if (!message.to?.length) {
+      throw new EmailProviderError(
+        'At least one recipient is required',
+        this.providerId,
+        this.providerType,
+        false,
+        'INVALID_MESSAGE'
+      );
+    }
+
+    const specialHeaders = this.extractSpecialHeaders(message.headers || {});
+    const mail: Mail.Options = {
+      from: {
+        address: this.mailbox,
+        name: message.from?.name || '',
+      },
+      to: message.to.map(address => ({ address: address.email, name: address.name || '' })),
+      cc: message.cc?.map(address => ({ address: address.email, name: address.name || '' })),
+      bcc: message.bcc?.map(address => ({ address: address.email, name: address.name || '' })),
+      replyTo: message.replyTo
+        ? { address: message.replyTo.email, name: message.replyTo.name || '' }
+        : undefined,
+      subject: message.subject,
+      text: message.text,
+      html: message.html,
+      messageId: specialHeaders.messageId,
+      inReplyTo: specialHeaders.inReplyTo,
+      references: specialHeaders.references,
+      headers: specialHeaders.remaining,
+      attachments: message.attachments?.map(attachment => {
+        const content = Buffer.isBuffer(attachment.content)
+          ? attachment.content
+          : Buffer.from(attachment.content);
+        this.assertAttachmentSize(attachment.filename, content);
+        return {
+          filename: attachment.filename,
+          content,
+          contentType: attachment.contentType,
+          cid: attachment.cid,
+          contentDisposition: attachment.cid ? 'inline' as const : 'attachment' as const,
+        };
+      }),
+    };
+
+    const result = await this.mimeTransport.sendMail(mail);
+    if (!Buffer.isBuffer(result.message)) {
+      throw new Error('Microsoft Graph MIME compilation did not return a buffer');
+    }
+    return result.message;
+  }
+
+  private extractSpecialHeaders(headers: Record<string, string>): {
+    messageId?: string;
+    inReplyTo?: string;
+    references?: string;
+    remaining: Record<string, string>;
+  } {
+    const result: {
+      messageId?: string;
+      inReplyTo?: string;
+      references?: string;
+      remaining: Record<string, string>;
+    } = { remaining: {} };
+
+    for (const [name, value] of Object.entries(headers)) {
+      switch (name.toLowerCase()) {
+        case 'message-id':
+          result.messageId = value;
+          break;
+        case 'in-reply-to':
+          result.inReplyTo = value;
+          break;
+        case 'references':
+          result.references = value;
+          break;
+        default:
+          result.remaining[name] = value;
+      }
+    }
+
+    return result;
+  }
+
+  private toRecipient(address: EmailAddress): GraphRecipient {
+    return {
+      emailAddress: {
+        address: address.email,
+        ...(address.name ? { name: address.name } : {}),
+      },
+    };
+  }
+
+  private toAttachment(attachment: EmailAttachment): Record<string, unknown> {
+    const content = Buffer.isBuffer(attachment.content)
+      ? attachment.content
+      : Buffer.from(attachment.content);
+    this.assertAttachmentSize(attachment.filename, content);
+
+    return {
+      '@odata.type': '#microsoft.graph.fileAttachment',
+      name: attachment.filename,
+      contentType: attachment.contentType || 'application/octet-stream',
+      contentBytes: content.toString('base64'),
+      ...(attachment.cid ? { contentId: attachment.cid, isInline: true } : {}),
+    };
+  }
+
+  private assertAttachmentSize(filename: string, content: Buffer): void {
+    if (content.byteLength <= SIMPLE_ATTACHMENT_LIMIT) return;
+
+    throw new EmailProviderError(
+      `Attachment ${filename} exceeds Microsoft Graph's 3 MB simple attachment limit`,
+      this.providerId,
+      this.providerType,
+      false,
+      'ATTACHMENT_TOO_LARGE'
+    );
+  }
+
+  private ensureInitialized(): void {
+    if (!this.initialized || !this.adapter) {
+      throw new EmailProviderError(
+        'Microsoft Graph provider not initialized',
+        this.providerId,
+        this.providerType,
+        false,
+        'NOT_INITIALIZED'
+      );
+    }
+  }
+
+  private toProviderError(error: any): EmailProviderError {
+    if (error instanceof EmailProviderError) return error;
+
+    const status = Number(error?.status || error?.response?.status || 0) || undefined;
+    const code = String(error?.code || error?.response?.data?.error?.code || status || 'SEND_FAILED');
+    const requestId = error?.requestId || error?.response?.headers?.['request-id'];
+    const retryable = status === 429 || Boolean(status && status >= 500);
+
+    let message = 'Microsoft Graph could not send the email.';
+    if (status === 401) {
+      message = 'Microsoft authorization expired. Reconnect the mailbox and try again.';
+    } else if (status === 403) {
+      message = 'Microsoft rejected the send. Reconnect to grant Mail.Send and verify Send As permission for the configured mailbox.';
+    } else if (status === 429) {
+      message = 'Microsoft Graph throttled the send. Try again later.';
+    } else if (status && status >= 500) {
+      message = 'Microsoft Graph is temporarily unavailable. Try again later.';
+    }
+
+    logger.error(`[MicrosoftGraphEmailProvider:${this.providerId}] Send failed`, {
+      status,
+      code,
+      requestId,
+      retryable,
+    });
+
+    return new EmailProviderError(
+      message,
+      this.providerId,
+      this.providerType,
+      retryable,
+      code,
+      { status, requestId }
+    );
+  }
+}

--- a/packages/email/src/providers/__tests__/EmailProviderManager.microsoft.test.ts
+++ b/packages/email/src/providers/__tests__/EmailProviderManager.microsoft.test.ts
@@ -1,0 +1,152 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import type { EmailMessage, TenantEmailSettings } from '@alga-psa/types';
+
+const {
+  buildConfigMock,
+  connectMock,
+  sendMailMock,
+  testConnectionMock,
+  tableRows,
+} = vi.hoisted(() => ({
+  buildConfigMock: vi.fn(async (config: any) => config),
+  connectMock: vi.fn(async () => undefined),
+  sendMailMock: vi.fn(async () => ({ requestId: 'request-1' })),
+  testConnectionMock: vi.fn(async () => ({ success: true })),
+  tableRows: {
+    email_providers: null as any,
+    microsoft_email_provider_config: null as any,
+  },
+}));
+
+vi.mock('@alga-psa/db', () => ({
+  getConnection: vi.fn(async () => ({})),
+  tenantDb: () => ({
+    table: (tableName: keyof typeof tableRows) => ({
+      where: () => ({
+        first: vi.fn(async () => tableRows[tableName]),
+      }),
+    }),
+  }),
+}));
+
+vi.mock('@alga-psa/shared/services/email/microsoftEmailProviderConfig', () => ({
+  buildMicrosoftEmailProviderConfig: buildConfigMock,
+}));
+
+vi.mock('@alga-psa/shared/services/email/providers/MicrosoftGraphAdapter', () => ({
+  MicrosoftGraphAdapter: class {
+    connect = connectMock;
+    sendMail = sendMailMock;
+    testConnection = testConnectionMock;
+  },
+}));
+
+import { EmailProviderManager } from '../EmailProviderManager';
+
+function makeJwt(): string {
+  const header = Buffer.from('{}').toString('base64url');
+  const payload = Buffer.from(JSON.stringify({ scp: 'Mail.Read Mail.Send' })).toString('base64url');
+  return `${header}.${payload}.signature`;
+}
+
+function settings(): TenantEmailSettings {
+  return {
+    tenantId: 'tenant-1',
+    customDomains: [],
+    emailProvider: 'microsoft',
+    providerConfigs: [{
+      providerId: 'microsoft-outbound-placeholder',
+      providerType: 'microsoft',
+      isEnabled: true,
+      config: {
+        inboundProviderId: 'inbound-microsoft-1',
+        accessToken: 'stale-browser-value-must-not-be-used',
+      },
+    }],
+    trackingEnabled: false,
+    createdAt: new Date('2026-08-01T00:00:00.000Z'),
+    updatedAt: new Date('2026-08-01T00:00:00.000Z'),
+  };
+}
+
+function message(subject: string): EmailMessage {
+  return {
+    from: { email: 'support@example.com' },
+    to: [{ email: 'customer@example.net' }],
+    subject,
+    html: `<p>${subject}</p>`,
+  };
+}
+
+describe('EmailProviderManager Microsoft Graph support', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    tableRows.email_providers = {
+      id: 'inbound-microsoft-1',
+      tenant: 'tenant-1',
+      provider_type: 'microsoft',
+      provider_name: 'Support mailbox',
+      mailbox: 'support@example.com',
+      is_active: true,
+      status: 'connected',
+      created_at: new Date('2026-08-01T00:00:00.000Z'),
+      updated_at: new Date('2026-08-01T00:00:00.000Z'),
+    };
+    tableRows.microsoft_email_provider_config = {
+      email_provider_id: 'inbound-microsoft-1',
+      tenant: 'tenant-1',
+      access_token: makeJwt(),
+      refresh_token: 'stored-refresh-token',
+      token_expires_at: new Date(Date.now() + 60 * 60 * 1000).toISOString(),
+      resolved_client_id: 'profile-client-id',
+      resolved_client_secret: 'profile-client-secret',
+    };
+  });
+
+  it('resolves fresh inbound credentials and sends through the common manager path', async () => {
+    const manager = new EmailProviderManager();
+    await manager.initialize(settings());
+
+    const result = await manager.sendEmail(message('Common path'), 'tenant-1');
+
+    expect(buildConfigMock).toHaveBeenCalledWith(expect.objectContaining({
+      id: 'inbound-microsoft-1',
+      tenant: 'tenant-1',
+      mailbox: 'support@example.com',
+      provider_config: expect.objectContaining({
+        refresh_token: 'stored-refresh-token',
+      }),
+    }));
+    expect(buildConfigMock.mock.calls[0]?.[0].provider_config.accessToken).toBeUndefined();
+    expect(sendMailMock).toHaveBeenCalledWith({
+      kind: 'json',
+      message: expect.objectContaining({ subject: 'Common path' }),
+    });
+    expect(result).toMatchObject({ success: true, providerType: 'microsoft' });
+  });
+
+  it('uses per-message fallback for Microsoft bulk sends', async () => {
+    const manager = new EmailProviderManager();
+    await manager.initialize(settings());
+
+    const results = await manager.sendBulkEmails(
+      [message('First'), message('Second')],
+      'tenant-1'
+    );
+
+    expect(sendMailMock).toHaveBeenCalledTimes(2);
+    expect(results).toHaveLength(2);
+    expect(results.every(result => result.success)).toBe(true);
+  });
+
+  it('fails before adapter construction when the selected mailbox is disconnected', async () => {
+    tableRows.email_providers.status = 'disconnected';
+    const manager = new EmailProviderManager();
+
+    await expect(manager.initialize(settings())).rejects.toMatchObject({
+      name: 'EmailProviderError',
+      errorCode: 'MICROSOFT_PROVIDER_NOT_CONNECTED',
+    });
+    expect(connectMock).not.toHaveBeenCalled();
+  });
+});

--- a/packages/email/src/providers/__tests__/MicrosoftGraphEmailProvider.test.ts
+++ b/packages/email/src/providers/__tests__/MicrosoftGraphEmailProvider.test.ts
@@ -1,0 +1,179 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import type { EmailMessage } from '@alga-psa/types';
+
+const { connectMock, sendMailMock, testConnectionMock } = vi.hoisted(() => ({
+  connectMock: vi.fn(),
+  sendMailMock: vi.fn(),
+  testConnectionMock: vi.fn(),
+}));
+
+vi.mock('@alga-psa/shared/services/email/providers/MicrosoftGraphAdapter', () => ({
+  MicrosoftGraphAdapter: class {
+    connect = connectMock;
+    sendMail = sendMailMock;
+    testConnection = testConnectionMock;
+  },
+}));
+
+import { MicrosoftGraphEmailProvider } from '../MicrosoftGraphEmailProvider';
+
+function makeJwt(scopes: string): string {
+  const header = Buffer.from(JSON.stringify({ alg: 'none' })).toString('base64url');
+  const payload = Buffer.from(JSON.stringify({ scp: scopes })).toString('base64url');
+  return `${header}.${payload}.signature`;
+}
+
+function providerConfig(accessToken = makeJwt('Mail.Read Mail.Read.Shared Mail.Send')) {
+  return {
+    inboundProvider: {
+      id: 'microsoft-provider-1',
+      tenant: 'tenant-1',
+      name: 'Support mailbox',
+      provider_type: 'microsoft',
+      mailbox: 'support+desk@example.com',
+      folder_to_monitor: 'Inbox',
+      active: true,
+      webhook_notification_url: '',
+      connection_status: 'connected',
+      created_at: '2026-08-01T00:00:00.000Z',
+      updated_at: '2026-08-01T00:00:00.000Z',
+      provider_config: {
+        access_token: accessToken,
+        refresh_token: 'refresh-token',
+      },
+    },
+  };
+}
+
+function message(overrides: Partial<EmailMessage> = {}): EmailMessage {
+  return {
+    from: { email: 'ignored@example.net', name: 'Ignored sender' },
+    to: [{ email: 'customer@example.net', name: 'Customer' }],
+    cc: [{ email: 'cc@example.net' }],
+    bcc: [{ email: 'bcc@example.net' }],
+    subject: 'Ticket reply',
+    text: 'Plain reply',
+    html: '<p>HTML reply</p>',
+    replyTo: { email: 'replies@example.com', name: 'Ticket replies' },
+    headers: {
+      'Message-ID': '<ticket-anchor@example.com>',
+      'In-Reply-To': '<customer-message@example.net>',
+      References: '<customer-message@example.net>',
+    },
+    attachments: [{
+      filename: 'notes.txt',
+      content: Buffer.from('attachment'),
+      contentType: 'text/plain',
+      cid: 'inline-notes',
+    }],
+    ...overrides,
+  };
+}
+
+describe('MicrosoftGraphEmailProvider', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    connectMock.mockResolvedValue(undefined);
+    sendMailMock.mockResolvedValue({ requestId: 'graph-request-1' });
+    testConnectionMock.mockResolvedValue({ success: true });
+  });
+
+  it('maps provider-neutral messages to Graph JSON', async () => {
+    const provider = new MicrosoftGraphEmailProvider('microsoft-provider-1');
+    await provider.initialize(providerConfig());
+
+    const result = await provider.sendEmail(message({ headers: undefined }), 'tenant-1');
+
+    expect(sendMailMock).toHaveBeenCalledWith({
+      kind: 'json',
+      message: {
+        subject: 'Ticket reply',
+        body: { contentType: 'HTML', content: '<p>HTML reply</p>' },
+        toRecipients: [{ emailAddress: { address: 'customer@example.net', name: 'Customer' } }],
+        ccRecipients: [{ emailAddress: { address: 'cc@example.net' } }],
+        bccRecipients: [{ emailAddress: { address: 'bcc@example.net' } }],
+        replyTo: [{ emailAddress: { address: 'replies@example.com', name: 'Ticket replies' } }],
+        attachments: [{
+          '@odata.type': '#microsoft.graph.fileAttachment',
+          name: 'notes.txt',
+          contentType: 'text/plain',
+          contentBytes: Buffer.from('attachment').toString('base64'),
+          contentId: 'inline-notes',
+          isInline: true,
+        }],
+      },
+    });
+    expect(result).toMatchObject({
+      success: true,
+      providerId: 'microsoft-provider-1',
+      providerType: 'microsoft',
+      metadata: { requestId: 'graph-request-1' },
+    });
+    expect(result.messageId).toBeUndefined();
+  });
+
+  it('uses MIME to retain ticket threading headers that Graph JSON cannot set', async () => {
+    const provider = new MicrosoftGraphEmailProvider('microsoft-provider-1');
+    await provider.initialize(providerConfig());
+
+    await provider.sendEmail(message(), 'tenant-1');
+
+    expect(sendMailMock).toHaveBeenCalledOnce();
+    const payload = sendMailMock.mock.calls[0]?.[0];
+    expect(payload.kind).toBe('mime');
+    const mime = Buffer.from(payload.content, 'base64').toString('utf8');
+    expect(mime).toContain('From: Ignored sender <support+desk@example.com>');
+    expect(mime).toContain('Reply-To: Ticket replies <replies@example.com>');
+    expect(mime).toContain('Message-ID: <ticket-anchor@example.com>');
+    expect(mime).toContain('In-Reply-To: <customer-message@example.net>');
+    expect(mime).toContain('References: <customer-message@example.net>');
+    expect(mime).toContain('Bcc: bcc@example.net');
+    expect(mime).toContain('filename=notes.txt');
+  });
+
+  it('requires existing connections to be re-consented for Mail.Send', async () => {
+    const provider = new MicrosoftGraphEmailProvider('microsoft-provider-1');
+
+    await expect(provider.initialize(providerConfig(makeJwt('Mail.Read Mail.Read.Shared'))))
+      .rejects.toMatchObject({
+        name: 'EmailProviderError',
+        errorCode: 'INIT_FAILED',
+      });
+    expect(connectMock).not.toHaveBeenCalled();
+  });
+
+  it('returns an actionable non-retryable error for missing Send As rights', async () => {
+    const provider = new MicrosoftGraphEmailProvider('microsoft-provider-1');
+    await provider.initialize(providerConfig());
+    sendMailMock.mockRejectedValue(Object.assign(new Error('Forbidden'), {
+      status: 403,
+      code: 'ErrorAccessDenied',
+      requestId: 'graph-request-403',
+    }));
+
+    await expect(provider.sendEmail(message(), 'tenant-1')).rejects.toMatchObject({
+      name: 'EmailProviderError',
+      isRetryable: false,
+      errorCode: 'ErrorAccessDenied',
+      metadata: { status: 403, requestId: 'graph-request-403' },
+    });
+  });
+
+  it('marks throttling as retryable and rejects oversized simple attachments', async () => {
+    const provider = new MicrosoftGraphEmailProvider('microsoft-provider-1');
+    await provider.initialize(providerConfig());
+    sendMailMock.mockRejectedValueOnce(Object.assign(new Error('Throttled'), { status: 429 }));
+
+    await expect(provider.sendEmail(message({ attachments: [] }), 'tenant-1')).rejects.toMatchObject({
+      isRetryable: true,
+      errorCode: '429',
+    });
+
+    await expect(provider.sendEmail(message({
+      attachments: [{ filename: 'large.bin', content: Buffer.alloc(3 * 1024 * 1024 + 1) }],
+    }), 'tenant-1')).rejects.toMatchObject({
+      isRetryable: false,
+      errorCode: 'ATTACHMENT_TOO_LARGE',
+    });
+  });
+});

--- a/packages/email/tsup.config.ts
+++ b/packages/email/tsup.config.ts
@@ -13,4 +13,7 @@ export default defineConfig({
     /^@alga-psa\//,
     /^@shared\//,
   ],
+  noExternal: [
+    /^@alga-psa\/shared(?:\/|$)/,
+  ],
 });

--- a/packages/integrations/src/actions/email-actions/emailSettingsActions.providers.test.ts
+++ b/packages/integrations/src/actions/email-actions/emailSettingsActions.providers.test.ts
@@ -26,7 +26,7 @@ vi.mock('@alga-psa/email', () => ({
 
 vi.mock('@alga-psa/email/providerConfig', () => ({
   createDefaultProviderConfig: (
-    providerType: 'smtp' | 'resend',
+    providerType: 'smtp' | 'resend' | 'microsoft',
     { isEnabled }: { isEnabled: boolean }
   ): EmailProviderConfig => ({
     providerId: `${providerType}-provider`,
@@ -34,7 +34,9 @@ vi.mock('@alga-psa/email/providerConfig', () => ({
     isEnabled,
     config: providerType === 'smtp'
       ? { host: '', port: 587, username: '', password: '', from: '' }
-      : { apiKey: '', from: '' },
+      : providerType === 'resend'
+      ? { apiKey: '', from: '' }
+      : { inboundProviderId: '', mailbox: '', from: '' },
   }),
 }));
 
@@ -81,6 +83,12 @@ describe('email settings provider invariants', () => {
           isEnabled: true,
           config: { apiKey: '', from: '' },
         },
+        {
+          providerId: 'microsoft-provider',
+          providerType: 'microsoft',
+          isEnabled: false,
+          config: { inboundProviderId: '', mailbox: '', from: '' },
+        },
       ],
     });
   });
@@ -111,6 +119,11 @@ describe('email settings provider invariants', () => {
         {
           providerId: 'smtp-provider',
           providerType: 'smtp',
+          isEnabled: false,
+        },
+        {
+          providerId: 'microsoft-provider',
+          providerType: 'microsoft',
           isEnabled: false,
         },
       ],
@@ -182,5 +195,84 @@ describe('email settings provider invariants', () => {
         config: expect.objectContaining({ apiKey: 'stored-api-key' }),
       }),
     ]);
+  });
+
+  it('pins Microsoft outbound settings to a connected tenant mailbox', async () => {
+    const existingSettings = buildSettings('smtp', [
+      {
+        providerId: 'smtp-provider',
+        providerType: 'smtp',
+        isEnabled: true,
+        config: { host: 'smtp.test', port: 587, from: 'old@example.net' },
+      },
+      {
+        providerId: 'microsoft-provider',
+        providerType: 'microsoft',
+        isEnabled: false,
+        config: { inboundProviderId: '', mailbox: '', from: '' },
+      },
+    ]);
+    const updateMock = vi.fn(async (_value: Record<string, unknown>) => 1);
+    const knexMock = vi.fn((table: string) => {
+      const builder: any = {
+        where: vi.fn(() => builder),
+        first: vi.fn(async () => table === 'email_providers'
+          ? {
+              id: 'microsoft-inbound-1',
+              mailbox: 'support@contoso.example',
+              provider_name: 'Contoso Support',
+              sender_display_name: 'Contoso Support',
+              status: 'connected',
+            }
+          : { tenant: 'tenant-123' }),
+        update: updateMock,
+        insert: vi.fn(async () => 1),
+      };
+      return builder;
+    }) as any;
+    createTenantKnexMock.mockResolvedValue({ knex: knexMock });
+    getTenantEmailSettingsMock
+      .mockResolvedValueOnce(existingSettings)
+      .mockResolvedValueOnce({
+        ...existingSettings,
+        emailProvider: 'microsoft',
+        defaultFromDomain: 'contoso.example',
+        ticketingFromEmail: 'support@contoso.example',
+      });
+
+    const { updateEmailSettings } = await import('./emailSettingsActions');
+    const result = await updateEmailSettings({
+      emailProvider: 'microsoft',
+      providerConfigs: existingSettings.providerConfigs.map(config =>
+        config.providerType === 'microsoft'
+          ? {
+              ...config,
+              config: { inboundProviderId: 'microsoft-inbound-1' },
+            }
+          : config
+      ),
+    });
+
+    expect(result).toMatchObject({ emailProvider: 'microsoft' });
+    expect(updateMock).toHaveBeenCalledOnce();
+    const payload = updateMock.mock.calls[0]?.[0];
+    expect(payload).toMatchObject({
+      email_provider: 'microsoft',
+      default_from_domain: 'contoso.example',
+      ticketing_from_email: 'support@contoso.example',
+    });
+    const configs = JSON.parse(String(payload?.provider_configs));
+    expect(configs).toContainEqual({
+      providerId: 'microsoft-inbound-1',
+      providerType: 'microsoft',
+      isEnabled: true,
+      config: {
+        inboundProviderId: 'microsoft-inbound-1',
+        mailbox: 'support@contoso.example',
+        from: 'support@contoso.example',
+        fromName: 'Contoso Support',
+      },
+    });
+    expect(configs.find((config: EmailProviderConfig) => config.providerType === 'smtp')?.isEnabled).toBe(false);
   });
 });

--- a/packages/integrations/src/actions/email-actions/emailSettingsActions.ts
+++ b/packages/integrations/src/actions/email-actions/emailSettingsActions.ts
@@ -25,7 +25,15 @@ type EmailSettingsUpdateInput = Partial<TenantEmailSettings> & {
 // sent to the browser. On save it means "unchanged" — restore the real value.
 const SECRET_MASK = '***';
 const SECRET_FIELDS = ['password', 'apiKey'] as const;
-const EDITABLE_PROVIDER_TYPES = ['smtp', 'resend'] as const;
+const EDITABLE_PROVIDER_TYPES = ['smtp', 'resend', 'microsoft'] as const;
+
+export interface MicrosoftOutboundMailboxOption {
+  providerId: string;
+  mailbox: string;
+  providerName: string;
+  senderDisplayName?: string | null;
+  status: 'connected' | 'disconnected' | 'error' | 'configuring';
+}
 
 function withEditableProviderConfigs(settings: TenantEmailSettings): TenantEmailSettings {
   const providerConfigs = [...(settings.providerConfigs ?? [])];
@@ -156,25 +164,66 @@ export const updateEmailSettings = withAuth(async (
 
     // Load current settings so we can merge partial updates safely
     const existingSettings = await TenantEmailService.getTenantEmailSettings(tenant || '', knex);
-    const nextDefaultFromDomain = hasOwnUpdate(updates, 'defaultFromDomain')
+    let nextDefaultFromDomain = hasOwnUpdate(updates, 'defaultFromDomain')
       ? updates.defaultFromDomain?.trim() || undefined
       : existingSettings?.defaultFromDomain;
-    const nextTicketingFromEmail = hasOwnUpdate(updates, 'ticketingFromEmail')
+    let nextTicketingFromEmail = hasOwnUpdate(updates, 'ticketingFromEmail')
       ? updates.ticketingFromEmail?.trim() || null
       : existingSettings?.ticketingFromEmail ?? null;
     const nextTicketingFromName = hasOwnUpdate(updates, 'ticketingFromName')
       ? normalizeOptionalString(updates.ticketingFromName)
       : existingSettings?.ticketingFromName ?? null;
 
-    const mergedProviderConfigs = updates.providerConfigs
+    let mergedProviderConfigs = updates.providerConfigs
       ? mergeProviderSecrets(updates.providerConfigs, existingSettings?.providerConfigs)
       : existingSettings?.providerConfigs ?? [];
-    const normalizedProviderConfigs = updates.emailProvider
-      ? mergedProviderConfigs.map(config => ({
-          ...config,
-          isEnabled: config.providerType === updates.emailProvider,
-        }))
-      : mergedProviderConfigs;
+    const selectedProviderType = updates.emailProvider ?? existingSettings?.emailProvider ?? 'smtp';
+
+    if (selectedProviderType === 'microsoft') {
+      const requested = mergedProviderConfigs.find(config => config.providerType === 'microsoft');
+      const requestedProviderId = requested?.config?.inboundProviderId || requested?.providerId;
+      if (!requestedProviderId || requestedProviderId === 'microsoft-provider') {
+        return actionError('Choose a Microsoft 365 mailbox for outbound email');
+      }
+
+      const microsoftProvider = await tenantDb(knex, tenant).table('email_providers')
+        .where({
+          id: requestedProviderId,
+          provider_type: 'microsoft',
+          is_active: true,
+        })
+        .first('id', 'mailbox', 'provider_name', 'sender_display_name', 'status');
+
+      if (!microsoftProvider) {
+        return actionError('The selected Microsoft 365 mailbox is not active or no longer exists');
+      }
+      if (microsoftProvider.status !== 'connected') {
+        return actionError('Reconnect the selected Microsoft 365 mailbox before using it for outbound email');
+      }
+
+      const microsoftConfig: EmailProviderConfig = {
+        providerId: microsoftProvider.id,
+        providerType: 'microsoft',
+        isEnabled: true,
+        config: {
+          inboundProviderId: microsoftProvider.id,
+          mailbox: microsoftProvider.mailbox,
+          from: microsoftProvider.mailbox,
+          fromName: microsoftProvider.sender_display_name || undefined,
+        },
+      };
+      mergedProviderConfigs = [
+        ...mergedProviderConfigs.filter(config => config.providerType !== 'microsoft'),
+        microsoftConfig,
+      ];
+      nextDefaultFromDomain = extractDomain(microsoftProvider.mailbox) || undefined;
+      nextTicketingFromEmail = microsoftProvider.mailbox;
+    }
+
+    const normalizedProviderConfigs = mergedProviderConfigs.map(config => ({
+      ...config,
+      isEnabled: config.providerType === selectedProviderType,
+    }));
 
     const mergedSettings: TenantEmailSettings = {
       tenantId: tenant || '',
@@ -182,7 +231,7 @@ export const updateEmailSettings = withAuth(async (
       ticketingFromEmail: nextTicketingFromEmail,
       ticketingFromName: nextTicketingFromName,
       customDomains: updates.customDomains ?? existingSettings?.customDomains ?? [],
-      emailProvider: updates.emailProvider ?? existingSettings?.emailProvider ?? 'smtp',
+      emailProvider: selectedProviderType,
       providerConfigs: normalizedProviderConfigs,
       trackingEnabled: updates.trackingEnabled ?? existingSettings?.trackingEnabled ?? false,
       maxDailyEmails: updates.maxDailyEmails ?? existingSettings?.maxDailyEmails,
@@ -246,6 +295,32 @@ export const updateEmailSettings = withAuth(async (
   } catch (error: any) {
     console.error('Error updating email settings:', error);
     return actionError('Failed to update email settings');
+  }
+});
+
+export const getMicrosoftOutboundMailboxes = withAuth(async (
+  _user,
+  { tenant }
+): Promise<{ mailboxes: MicrosoftOutboundMailboxOption[] } | ActionMessageError> => {
+  try {
+    const { knex } = await createTenantKnex();
+    const rows = await tenantDb(knex, tenant).table('email_providers')
+      .where({ provider_type: 'microsoft', is_active: true })
+      .orderBy('provider_name', 'asc')
+      .select('id', 'mailbox', 'provider_name', 'sender_display_name', 'status');
+
+    return {
+      mailboxes: rows.map(row => ({
+        providerId: row.id,
+        mailbox: row.mailbox,
+        providerName: row.provider_name,
+        senderDisplayName: row.sender_display_name,
+        status: row.status,
+      })),
+    };
+  } catch (error) {
+    console.error('Error fetching Microsoft outbound mailboxes:', error);
+    return actionError('Failed to load Microsoft 365 mailboxes');
   }
 });
 

--- a/packages/integrations/src/actions/email-actions/index.ts
+++ b/packages/integrations/src/actions/email-actions/index.ts
@@ -2,7 +2,7 @@ export { configureGmailProvider, type ConfigureGmailProviderResult } from './con
 export { getEmailProviders, upsertEmailProvider, createEmailProvider, updateEmailProvider, deleteEmailProvider, resyncImapProvider, testEmailProviderConnection, retryMicrosoftSubscriptionRenewal, runMicrosoft365Diagnostics } from './emailProviderActions';
 export { pauseEmailProvider, resumeEmailProvider } from './inboundPauseActions';
 export { getEmailDomains, addEmailDomain, verifyEmailDomain, deleteEmailDomain } from './emailDomainActions';
-export { getEmailSettings, updateEmailSettings, testOutboundEmail } from './emailSettingsActions';
+export { getEmailSettings, getMicrosoftOutboundMailboxes, updateEmailSettings, testOutboundEmail } from './emailSettingsActions';
 export { getInboundTicketDefaults, createInboundTicketDefaults, updateInboundTicketDefaults, deleteInboundTicketDefaults } from './inboundTicketDefaultsActions';
 export { getInboundEmailRules, createInboundEmailRule, updateInboundEmailRule, setInboundEmailRuleActive, deleteInboundEmailRule, reorderInboundEmailRules, testInboundEmailRule } from './inboundEmailRulesActions';
 export { getTicketFieldOptions } from './ticketFieldOptionsActions';

--- a/packages/integrations/src/actions/index.ts
+++ b/packages/integrations/src/actions/index.ts
@@ -78,6 +78,7 @@ export {
 } from './email-actions/emailDomainActions';
 export {
   getEmailSettings,
+  getMicrosoftOutboundMailboxes,
   updateEmailSettings,
   testOutboundEmail
 } from './email-actions/emailSettingsActions';

--- a/packages/integrations/src/components/email/MicrosoftProviderForm.tsx
+++ b/packages/integrations/src/components/email/MicrosoftProviderForm.tsx
@@ -367,7 +367,7 @@ export function MicrosoftProviderForm({
         <CardHeader>
           <CardTitle>{t('forms.microsoft.basic.title', { defaultValue: 'Basic Configuration' })}</CardTitle>
           <CardDescription>
-            {t('forms.microsoft.basic.description', { defaultValue: 'Basic settings for your Microsoft 365 email provider' })}
+            {t('forms.microsoft.basic.description', { defaultValue: 'Connect a Microsoft 365 mailbox for inbound tickets and optional outbound sending' })}
           </CardDescription>
         </CardHeader>
         <CardContent className="space-y-4">
@@ -574,7 +574,7 @@ export function MicrosoftProviderForm({
               <div>
                 <h4 className="font-medium">{t('forms.microsoft.oauth.authorizationTitle', { defaultValue: 'OAuth Authorization' })}</h4>
                 <p className="text-sm text-muted-foreground">
-                  {t('forms.microsoft.oauth.authorizationDescription', { defaultValue: 'Complete OAuth flow to grant access to the mailbox' })}
+                  {t('forms.microsoft.oauth.authorizationDescription', { defaultValue: 'Grant mailbox read access and Mail.Send. Reconnect older mailboxes before selecting them for outbound email.' })}
                 </p>
               </div>
               <Button

--- a/packages/integrations/src/components/email/admin/EmailSettings.tsx
+++ b/packages/integrations/src/components/email/admin/EmailSettings.tsx
@@ -20,8 +20,10 @@ import type { TenantEmailSettings } from '@alga-psa/types';
 import { createDefaultProviderConfig } from '@alga-psa/email/providerConfig';
 import {
   getEmailSettings,
+  getMicrosoftOutboundMailboxes,
   updateEmailSettings,
-  testOutboundEmail
+  testOutboundEmail,
+  type MicrosoftOutboundMailboxOption,
 } from '../../../actions/email-actions/emailSettingsActions';
 import {
   getEmailDomains,
@@ -62,7 +64,9 @@ export const EmailSettings: React.FC<EmailSettingsProps> = () => {
   const [saving, setSaving] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [newDomain, setNewDomain] = useState('');
-  const [selectedProvider, setSelectedProvider] = useState<'smtp' | 'resend'>('smtp');
+  const [selectedProvider, setSelectedProvider] = useState<'smtp' | 'resend' | 'microsoft'>('smtp');
+  const [microsoftMailboxes, setMicrosoftMailboxes] = useState<MicrosoftOutboundMailboxOption[]>([]);
+  const [microsoftMailboxError, setMicrosoftMailboxError] = useState<string | null>(null);
   const [showPassword, setShowPassword] = useState(false);
   const [showApiKey, setShowApiKey] = useState(false);
   const [activeTab, setActiveTab] = useState('inbound');
@@ -72,6 +76,7 @@ export const EmailSettings: React.FC<EmailSettingsProps> = () => {
 
   useEffect(() => {
     loadEmailSettings();
+    loadMicrosoftMailboxes();
     loadDomains();
   }, []);
 
@@ -94,6 +99,21 @@ export const EmailSettings: React.FC<EmailSettingsProps> = () => {
       setError(t('email.errors.loadEmailSettings', { defaultValue: 'Failed to load email settings' }));
     } finally {
       setLoading(false);
+    }
+  };
+
+  const loadMicrosoftMailboxes = async () => {
+    try {
+      const result = await getMicrosoftOutboundMailboxes();
+      if (isActionMessageError(result)) {
+        setMicrosoftMailboxError(getErrorMessage(result));
+        return;
+      }
+      setMicrosoftMailboxError(null);
+      setMicrosoftMailboxes(result.mailboxes);
+    } catch (err) {
+      console.error('Failed to load Microsoft outbound mailboxes:', err);
+      setMicrosoftMailboxError('Failed to load Microsoft 365 mailboxes');
     }
   };
 
@@ -192,7 +212,7 @@ export const EmailSettings: React.FC<EmailSettingsProps> = () => {
     }
   };
 
-  const handleProviderChange = (providerType: 'smtp' | 'resend') => {
+  const handleProviderChange = (providerType: 'smtp' | 'resend' | 'microsoft') => {
     if (!settings) return;
 
     setSelectedProvider(providerType);
@@ -214,7 +234,46 @@ export const EmailSettings: React.FC<EmailSettingsProps> = () => {
       updatedSettings.providerConfigs.push(newConfig);
     }
 
+    if (providerType === 'microsoft') {
+      const microsoftConfig = updatedSettings.providerConfigs.find(config => config.providerType === 'microsoft');
+      const selectedMailbox = microsoftMailboxes.find(mailbox =>
+        mailbox.providerId === microsoftConfig?.config?.inboundProviderId
+      ) || microsoftMailboxes.find(mailbox => mailbox.status === 'connected');
+
+      if (microsoftConfig && selectedMailbox) {
+        microsoftConfig.providerId = selectedMailbox.providerId;
+        microsoftConfig.config = {
+          inboundProviderId: selectedMailbox.providerId,
+          mailbox: selectedMailbox.mailbox,
+          from: selectedMailbox.mailbox,
+          fromName: selectedMailbox.senderDisplayName || undefined,
+        };
+      }
+    }
+
     setSettings(updatedSettings);
+  };
+
+  const selectMicrosoftMailbox = (providerId: string) => {
+    if (!settings) return;
+    const mailbox = microsoftMailboxes.find(option => option.providerId === providerId);
+    if (!mailbox) return;
+
+    const providerConfigs = settings.providerConfigs.map(config =>
+      config.providerType === 'microsoft'
+        ? {
+            ...config,
+            providerId: mailbox.providerId,
+            config: {
+              inboundProviderId: mailbox.providerId,
+              mailbox: mailbox.mailbox,
+              from: mailbox.mailbox,
+              fromName: mailbox.senderDisplayName || undefined,
+            },
+          }
+        : config
+    );
+    setSettings({ ...settings, providerConfigs });
   };
 
   const updateProviderConfig = (providerId: string, configUpdates: any) => {
@@ -403,6 +462,46 @@ export const EmailSettings: React.FC<EmailSettingsProps> = () => {
     );
   };
 
+  const renderMicrosoftConfig = () => {
+    const config = getCurrentProviderConfig();
+    if (!config) return null;
+
+    return (
+      <div className="space-y-3">
+        <div>
+          <Label htmlFor="microsoft-outbound-mailbox">
+            {t('email.microsoft.mailbox.label', { defaultValue: 'Sending Mailbox' })}
+          </Label>
+          <CustomSelect
+            id="microsoft-outbound-mailbox"
+            value={config.config.inboundProviderId || ''}
+            onValueChange={selectMicrosoftMailbox}
+            options={microsoftMailboxes.map(mailbox => ({
+              value: mailbox.providerId,
+              label: `${mailbox.providerName} — ${mailbox.mailbox}${mailbox.status === 'connected' ? '' : ` (${mailbox.status})`}`,
+            }))}
+            placeholder={t('email.microsoft.mailbox.placeholder', { defaultValue: 'Select a connected Microsoft 365 mailbox' })}
+          />
+        </div>
+        {microsoftMailboxError ? (
+          <p className="text-sm text-red-600 dark:text-red-400">{microsoftMailboxError}</p>
+        ) : microsoftMailboxes.length === 0 ? (
+          <p className="text-sm text-muted-foreground">
+            {t('email.microsoft.mailbox.none', {
+              defaultValue: 'Add and authorize a Microsoft 365 provider on the Inbound Email tab first.',
+            })}
+          </p>
+        ) : (
+          <p className="text-sm text-muted-foreground">
+            {t('email.microsoft.mailbox.help', {
+              defaultValue: 'Messages are sent as this mailbox through Microsoft Graph and saved to Sent Items. Reconnect existing mailboxes to grant Mail.Send.',
+            })}
+          </p>
+        )}
+      </div>
+    );
+  };
+
   const renderDomainStatus = (domain: DomainStatus) => {
     const getStatusIcon = () => {
       switch (domain.status) {
@@ -492,7 +591,7 @@ export const EmailSettings: React.FC<EmailSettingsProps> = () => {
         <>
             <div className="text-sm text-muted-foreground mb-4">
               {t('email.descriptions.outbound', {
-                defaultValue: 'Configure SMTP or API settings for sending emails from your application'
+                defaultValue: 'Choose SMTP, Resend, or a connected Microsoft 365 mailbox for outbound email'
               })}
             </div>
 
@@ -513,7 +612,7 @@ export const EmailSettings: React.FC<EmailSettingsProps> = () => {
                 <CustomSelect
                   id="provider-select"
                   value={selectedProvider}
-                  onValueChange={(value: string) => handleProviderChange(value as 'smtp' | 'resend')}
+                  onValueChange={(value: string) => handleProviderChange(value as 'smtp' | 'resend' | 'microsoft')}
                   options={[
                     {
                       value: 'smtp',
@@ -522,6 +621,10 @@ export const EmailSettings: React.FC<EmailSettingsProps> = () => {
                     {
                       value: 'resend',
                       label: t('email.providerConfig.options.resend', { defaultValue: 'Resend (Modern API Service)' })
+                    },
+                    {
+                      value: 'microsoft',
+                      label: t('email.providerConfig.options.microsoft', { defaultValue: 'Microsoft 365 (Microsoft Graph)' })
                     }
                   ]}
                   placeholder={t('email.providerConfig.placeholder', { defaultValue: 'Select email provider' })}
@@ -531,8 +634,12 @@ export const EmailSettings: React.FC<EmailSettingsProps> = () => {
                     ? t('email.providerConfig.descriptions.smtp', {
                         defaultValue: 'Configure traditional SMTP email server settings'
                       })
-                    : t('email.providerConfig.descriptions.resend', {
+                    : selectedProvider === 'resend'
+                    ? t('email.providerConfig.descriptions.resend', {
                         defaultValue: 'Configure Resend API for modern email delivery'
+                      })
+                    : t('email.providerConfig.descriptions.microsoft', {
+                        defaultValue: 'Send through the OAuth-connected Microsoft 365 mailbox used for inbound email'
                       })
                   }
                 </p>
@@ -556,6 +663,7 @@ export const EmailSettings: React.FC<EmailSettingsProps> = () => {
               {/* Provider-specific Configuration */}
               {selectedProvider === 'smtp' && renderSMTPConfig()}
               {selectedProvider === 'resend' && renderResendConfig()}
+              {selectedProvider === 'microsoft' && renderMicrosoftConfig()}
 
               {/* General Settings */}
               <div className="border-t pt-6">

--- a/packages/integrations/src/components/settings/integrations/MicrosoftIntegrationSettings.contract.test.tsx
+++ b/packages/integrations/src/components/settings/integrations/MicrosoftIntegrationSettings.contract.test.tsx
@@ -546,7 +546,7 @@ describe('MicrosoftIntegrationSettings contracts', () => {
         expect.objectContaining({
           title: 'Outlook email app choice updated',
           description: expect.stringContaining(
-            'Existing Outlook email connections may need re-authorization after changing the Microsoft app.'
+            'Existing Outlook email connections need re-authorization to grant Mail.Send before they can send outbound email.'
           ),
         })
       );

--- a/packages/integrations/src/components/settings/integrations/MicrosoftIntegrationSettings.tsx
+++ b/packages/integrations/src/components/settings/integrations/MicrosoftIntegrationSettings.tsx
@@ -171,8 +171,8 @@ function getConsumerDescriptors(showTeamsUi: boolean, t: TranslateFn): Microsoft
         return {
           consumerType,
           consumerLabel: t('integrations.microsoft.settings.consumers.email.label', { defaultValue: 'Outlook email' }),
-          description: t('integrations.microsoft.settings.consumers.email.description', { defaultValue: 'Choose the Microsoft app for Outlook inbound email.' }),
-          reconnectMessage: t('integrations.microsoft.settings.consumers.email.reconnect', { defaultValue: 'Existing Outlook email connections may need re-authorization after changing the Microsoft app.' }),
+          description: t('integrations.microsoft.settings.consumers.email.description', { defaultValue: 'Choose the Microsoft app for Outlook inbound and outbound email.' }),
+          reconnectMessage: t('integrations.microsoft.settings.consumers.email.reconnect', { defaultValue: 'Existing Outlook email connections need re-authorization to grant Mail.Send before they can send outbound email.' }),
         };
       case 'calendar':
         return {

--- a/packages/integrations/src/utils/email/oauthHelpers.test.ts
+++ b/packages/integrations/src/utils/email/oauthHelpers.test.ts
@@ -1,0 +1,25 @@
+import { describe, expect, it } from 'vitest';
+import { generateMicrosoftAuthUrl } from './oauthHelpers';
+
+describe('Microsoft email OAuth scopes', () => {
+  it('requests inbound read scopes, Mail.Send, and offline access', () => {
+    const url = new URL(generateMicrosoftAuthUrl(
+      'client-id',
+      'https://app.example/api/auth/microsoft/callback',
+      {
+        tenant: 'tenant-1',
+        redirectUri: 'https://app.example/api/auth/microsoft/callback',
+        timestamp: Date.now(),
+        nonce: 'nonce',
+      }
+    ));
+
+    expect(url.searchParams.get('scope')?.split(' ')).toEqual([
+      'https://graph.microsoft.com/Mail.Read',
+      'https://graph.microsoft.com/Mail.Read.Shared',
+      'https://graph.microsoft.com/Mail.Send',
+      'offline_access',
+    ]);
+    expect(url.searchParams.get('prompt')).toBe('consent');
+  });
+});

--- a/packages/integrations/src/utils/email/oauthHelpers.ts
+++ b/packages/integrations/src/utils/email/oauthHelpers.ts
@@ -3,7 +3,10 @@
  */
 
 import { randomBytes } from 'crypto';
-import { getMicrosoftAuthorizeUrl } from '@alga-psa/shared/services/email/microsoftGraphEndpoints';
+import {
+  getMicrosoftAuthorizeUrl,
+  MICROSOFT_EMAIL_OAUTH_SCOPES,
+} from '@alga-psa/shared/services/email/microsoftGraphEndpoints';
 
 export interface OAuthState {
   tenant: string;
@@ -18,13 +21,13 @@ export interface OAuthState {
 
 /**
  * Generate OAuth authorization URL for Microsoft
- * Using read-only scopes: Mail.Read for personal mailbox, Mail.Read.Shared for shared mailboxes
+ * Requests inbound read access and Mail.Send for the same configured mailbox.
  */
 export function generateMicrosoftAuthUrl(
   clientId: string,
   redirectUri: string,
   state: OAuthState,
-  scopes: string[] = ['https://graph.microsoft.com/Mail.Read', 'https://graph.microsoft.com/Mail.Read.Shared', 'offline_access'],
+  scopes: string[] = [...MICROSOFT_EMAIL_OAUTH_SCOPES],
   tenantAuthority: string = 'common'
 ): string {
   const baseUrl = getMicrosoftAuthorizeUrl(tenantAuthority);

--- a/packages/types/src/lib/email.ts
+++ b/packages/types/src/lib/email.ts
@@ -96,7 +96,7 @@ export interface TenantEmailSettings {
   ticketingFromEmail?: string | null;
   ticketingFromName?: string | null;
   customDomains: string[];
-  emailProvider: 'smtp' | 'resend';
+  emailProvider: 'smtp' | 'resend' | 'microsoft';
   providerConfigs: EmailProviderConfig[];
   trackingEnabled: boolean;
   maxDailyEmails?: number;

--- a/server/migrations/20260803044749_allow_microsoft_tenant_email_provider.cjs
+++ b/server/migrations/20260803044749_allow_microsoft_tenant_email_provider.cjs
@@ -1,0 +1,55 @@
+/**
+ * Allow Microsoft Graph to be selected as the tenant's outbound provider.
+ *
+ * The original table used Knex's PostgreSQL enum helper, which created a text
+ * column plus a CHECK constraint limited to smtp, resend, and hybrid. The
+ * application now persists "microsoft" when a connected Graph mailbox is
+ * selected, so deployed databases need the constraint widened explicitly.
+ *
+ * Adding the replacement NOT VALID avoids an initial table scan while holding
+ * ACCESS EXCLUSIVE. Validation follows immediately with a less restrictive
+ * lock. The new constraint is strictly wider, so existing rows already satisfy
+ * it.
+ */
+
+const { tenantDb } = require('./utils/tenantDb.cjs');
+
+const TABLE_NAME = 'tenant_email_settings';
+const CONSTRAINT_NAME = 'tenant_email_settings_email_provider_check';
+const MIGRATION_TENANT = 'migration:20260803044749_allow_microsoft_tenant_email_provider';
+const ROLLBACK_SAFETY_REASON = 'check all tenant email settings before narrowing provider constraint';
+const ORIGINAL_PROVIDERS = ['smtp', 'resend', 'hybrid'];
+const MICROSOFT_PROVIDERS = [...ORIGINAL_PROVIDERS, 'microsoft'];
+
+function sqlList(values) {
+  return values.map((value) => `'${value}'`).join(', ');
+}
+
+async function setProviderConstraint(knex, providers) {
+  await knex.raw('ALTER TABLE ?? DROP CONSTRAINT IF EXISTS ??', [TABLE_NAME, CONSTRAINT_NAME]);
+  await knex.raw(
+    `ALTER TABLE ?? ADD CONSTRAINT ?? CHECK (email_provider IN (${sqlList(providers)})) NOT VALID`,
+    [TABLE_NAME, CONSTRAINT_NAME]
+  );
+  await knex.raw('ALTER TABLE ?? VALIDATE CONSTRAINT ??', [TABLE_NAME, CONSTRAINT_NAME]);
+}
+
+exports.up = async function up(knex) {
+  await setProviderConstraint(knex, MICROSOFT_PROVIDERS);
+};
+
+exports.down = async function down(knex) {
+  const migrationDb = tenantDb(knex, MIGRATION_TENANT);
+  const microsoftSetting = await migrationDb
+    .unscoped(TABLE_NAME, ROLLBACK_SAFETY_REASON)
+    .where({ email_provider: 'microsoft' })
+    .first('id');
+
+  if (microsoftSetting) {
+    throw new Error(
+      'Cannot roll back Microsoft outbound email support while tenant email settings still use the microsoft provider'
+    );
+  }
+
+  await setProviderConstraint(knex, ORIGINAL_PROVIDERS);
+};

--- a/server/public/locales/de/msp/admin.json
+++ b/server/public/locales/de/msp/admin.json
@@ -109,12 +109,14 @@
       "providerLabel": "E-Mail-Anbieter",
       "options": {
         "smtp": "SMTP (traditioneller E-Mail-Server)",
-        "resend": "Resend (moderner API-Dienst)"
+        "resend": "Resend (moderner API-Dienst)",
+        "microsoft": "Microsoft 365 (Microsoft Graph)"
       },
       "placeholder": "E-Mail-Anbieter auswählen",
       "descriptions": {
         "smtp": "Konfigurieren Sie die klassischen SMTP-E-Mail-Servereinstellungen",
-        "resend": "Konfigurieren Sie die Resend-API für moderne E-Mail-Zustellung"
+        "resend": "Konfigurieren Sie die Resend-API für moderne E-Mail-Zustellung",
+        "microsoft": "Senden Sie über das per OAuth verbundene Microsoft 365-Postfach für eingehende E-Mails"
       },
       "status": {
         "provider": "{{provider}}-Anbieter"
@@ -160,6 +162,14 @@
         "label": "Absenderadresse",
         "placeholder": "noreply@yourdomain.com",
         "help": "Muss von einer verifizierten Domain stammen. Verwenden Sie den Reiter Domains, um benutzerdefinierte Domains hinzuzufügen."
+      }
+    },
+    "microsoft": {
+      "mailbox": {
+        "label": "Sendepostfach",
+        "placeholder": "Verbundenes Microsoft 365-Postfach auswählen",
+        "none": "Fügen Sie zuerst auf der Registerkarte Eingehende E-Mail einen Microsoft 365-Anbieter hinzu und autorisieren Sie ihn.",
+        "help": "Nachrichten werden als dieses Postfach über Microsoft Graph gesendet und in Gesendete Elemente gespeichert. Verbinden Sie vorhandene Postfächer erneut, um Mail.Send zu gewähren."
       }
     },
     "domains": {

--- a/server/public/locales/de/msp/integrations.json
+++ b/server/public/locales/de/msp/integrations.json
@@ -1581,9 +1581,9 @@
             "reconnect": "Bestehende Microsoft-Kalenderverbindungen benötigen nach dem Wechsel des gebundenen Profils möglicherweise eine erneute Autorisierung."
           },
           "email": {
-            "description": "Wählen Sie aus, welches Microsoft-Profil für eingehende Outlook-E-Mails verwendet werden soll.",
+            "description": "Wählen Sie das Microsoft-Profil für eingehende und ausgehende Outlook-E-Mails aus.",
             "label": "E-Mail",
-            "reconnect": "Bestehende Outlook-E-Mail-Verbindungen benötigen nach dem Wechsel des gebundenen Profils möglicherweise eine erneute Autorisierung."
+            "reconnect": "Bestehende Outlook-E-Mail-Verbindungen müssen erneut autorisiert werden, um Mail.Send zu gewähren, bevor sie ausgehende E-Mails senden können."
           },
           "mspSso": {
             "description": "Wählen Sie aus, welches Microsoft-Profil die MSP-SSO-Anmeldedomänen, die Microsoft-Anmeldung und die Tenant-Erkennung unterstützt.",

--- a/server/public/locales/en/msp/admin.json
+++ b/server/public/locales/en/msp/admin.json
@@ -109,12 +109,14 @@
       "providerLabel": "Email Provider",
       "options": {
         "smtp": "SMTP (Traditional Email Server)",
-        "resend": "Resend (Modern API Service)"
+        "resend": "Resend (Modern API Service)",
+        "microsoft": "Microsoft 365 (Microsoft Graph)"
       },
       "placeholder": "Select email provider",
       "descriptions": {
         "smtp": "Configure traditional SMTP email server settings",
-        "resend": "Configure Resend API for modern email delivery"
+        "resend": "Configure Resend API for modern email delivery",
+        "microsoft": "Send through the OAuth-connected Microsoft 365 mailbox used for inbound email"
       },
       "status": {
         "provider": "{{provider}} Provider"
@@ -160,6 +162,14 @@
         "label": "From Address",
         "placeholder": "noreply@yourdomain.com",
         "help": "Must be from a verified domain. Use the Domains tab to add custom domains."
+      }
+    },
+    "microsoft": {
+      "mailbox": {
+        "label": "Sending Mailbox",
+        "placeholder": "Select a connected Microsoft 365 mailbox",
+        "none": "Add and authorize a Microsoft 365 provider on the Inbound Email tab first.",
+        "help": "Messages are sent as this mailbox through Microsoft Graph and saved to Sent Items. Reconnect existing mailboxes to grant Mail.Send."
       }
     },
     "domains": {

--- a/server/public/locales/en/msp/integrations.json
+++ b/server/public/locales/en/msp/integrations.json
@@ -1581,9 +1581,9 @@
             "reconnect": "Existing Outlook calendar connections may need re-authorization after changing the Microsoft app."
           },
           "email": {
-            "description": "Choose the Microsoft app for Outlook inbound email.",
+            "description": "Choose the Microsoft app for Outlook inbound and outbound email.",
             "label": "Outlook email",
-            "reconnect": "Existing Outlook email connections may need re-authorization after changing the Microsoft app."
+            "reconnect": "Existing Outlook email connections need re-authorization to grant Mail.Send before they can send outbound email."
           },
           "mspSso": {
             "description": "Choose the Microsoft app for staff sign-in and login-domain discovery.",

--- a/server/public/locales/es/msp/admin.json
+++ b/server/public/locales/es/msp/admin.json
@@ -109,12 +109,14 @@
       "providerLabel": "Proveedor de correo",
       "options": {
         "smtp": "SMTP (servidor de correo tradicional)",
-        "resend": "Resend (servicio API moderno)"
+        "resend": "Resend (servicio API moderno)",
+        "microsoft": "Microsoft 365 (Microsoft Graph)"
       },
       "placeholder": "Seleccione el proveedor de correo",
       "descriptions": {
         "smtp": "Configure los ajustes tradicionales del servidor de correo SMTP",
-        "resend": "Configure la API de Resend para un envío de correo moderno"
+        "resend": "Configure la API de Resend para un envío de correo moderno",
+        "microsoft": "Envíe mediante el buzón de Microsoft 365 conectado por OAuth que se usa para el correo entrante"
       },
       "status": {
         "provider": "Proveedor {{provider}}"
@@ -160,6 +162,14 @@
         "label": "Dirección del remitente",
         "placeholder": "noreply@yourdomain.com",
         "help": "Debe pertenecer a un dominio verificado. Use la pestaña Dominios para agregar dominios personalizados."
+      }
+    },
+    "microsoft": {
+      "mailbox": {
+        "label": "Buzón de envío",
+        "placeholder": "Seleccione un buzón de Microsoft 365 conectado",
+        "none": "Primero agregue y autorice un proveedor de Microsoft 365 en la pestaña Correo entrante.",
+        "help": "Los mensajes se envían como este buzón mediante Microsoft Graph y se guardan en Elementos enviados. Vuelva a conectar los buzones existentes para conceder Mail.Send."
       }
     },
     "domains": {

--- a/server/public/locales/es/msp/integrations.json
+++ b/server/public/locales/es/msp/integrations.json
@@ -1581,9 +1581,9 @@
             "reconnect": "Las conexiones existentes del calendario de Microsoft pueden requerir una nueva autorización tras cambiar el perfil enlazado."
           },
           "email": {
-            "description": "Elija qué perfil de Microsoft debe utilizar el correo entrante de Outlook.",
+            "description": "Elija el perfil de Microsoft para el correo entrante y saliente de Outlook.",
             "label": "Correo",
-            "reconnect": "Las conexiones existentes de correo de Outlook pueden requerir una nueva autorización tras cambiar el perfil enlazado."
+            "reconnect": "Las conexiones existentes de correo de Outlook deben volver a autorizarse para conceder Mail.Send antes de poder enviar correo saliente."
           },
           "mspSso": {
             "description": "Elija qué perfil de Microsoft respalda los dominios de inicio de sesión de MSP SSO, el inicio de sesión con Microsoft y el descubrimiento de inquilinos.",

--- a/server/public/locales/fr/msp/admin.json
+++ b/server/public/locales/fr/msp/admin.json
@@ -109,12 +109,14 @@
       "providerLabel": "Fournisseur de messagerie",
       "options": {
         "smtp": "SMTP (serveur de messagerie traditionnel)",
-        "resend": "Resend (service API moderne)"
+        "resend": "Resend (service API moderne)",
+        "microsoft": "Microsoft 365 (Microsoft Graph)"
       },
       "placeholder": "Sélectionner un fournisseur de messagerie",
       "descriptions": {
         "smtp": "Configurer les paramètres d'un serveur de messagerie SMTP traditionnel",
-        "resend": "Configurer l'API Resend pour un envoi d'e-mails moderne"
+        "resend": "Configurer l'API Resend pour un envoi d'e-mails moderne",
+        "microsoft": "Envoyer via la boîte aux lettres Microsoft 365 connectée par OAuth utilisée pour les e-mails entrants"
       },
       "status": {
         "provider": "Fournisseur {{provider}}"
@@ -160,6 +162,14 @@
         "label": "Adresse d'expéditeur",
         "placeholder": "noreply@yourdomain.com",
         "help": "Doit provenir d'un domaine vérifié. Utilisez l'onglet Domaines pour ajouter des domaines personnalisés."
+      }
+    },
+    "microsoft": {
+      "mailbox": {
+        "label": "Boîte aux lettres d'envoi",
+        "placeholder": "Sélectionner une boîte aux lettres Microsoft 365 connectée",
+        "none": "Ajoutez et autorisez d'abord un fournisseur Microsoft 365 dans l'onglet E-mail entrant.",
+        "help": "Les messages sont envoyés depuis cette boîte aux lettres via Microsoft Graph et enregistrés dans Éléments envoyés. Reconnectez les boîtes aux lettres existantes pour accorder Mail.Send."
       }
     },
     "domains": {

--- a/server/public/locales/fr/msp/integrations.json
+++ b/server/public/locales/fr/msp/integrations.json
@@ -1581,9 +1581,9 @@
             "reconnect": "Les connexions calendrier Microsoft existantes peuvent nécessiter une nouvelle autorisation après le changement de profil lié."
           },
           "email": {
-            "description": "Choisissez quel profil Microsoft l'e-mail entrant Outlook doit utiliser.",
+            "description": "Choisissez le profil Microsoft pour les e-mails Outlook entrants et sortants.",
             "label": "E-mail",
-            "reconnect": "Les connexions e-mail Outlook existantes peuvent nécessiter une nouvelle autorisation après le changement de profil lié."
+            "reconnect": "Les connexions e-mail Outlook existantes doivent être autorisées à nouveau pour accorder Mail.Send avant de pouvoir envoyer des e-mails sortants."
           },
           "mspSso": {
             "description": "Choisissez quel profil Microsoft sous-tend les domaines de connexion MSP SSO, la connexion Microsoft et la découverte de tenant.",

--- a/server/public/locales/it/msp/admin.json
+++ b/server/public/locales/it/msp/admin.json
@@ -109,12 +109,14 @@
       "providerLabel": "Provider email",
       "options": {
         "smtp": "SMTP (server email tradizionale)",
-        "resend": "Resend (servizio API moderno)"
+        "resend": "Resend (servizio API moderno)",
+        "microsoft": "Microsoft 365 (Microsoft Graph)"
       },
       "placeholder": "Seleziona provider email",
       "descriptions": {
         "smtp": "Configura le impostazioni del server email SMTP tradizionale",
-        "resend": "Configura l'API di Resend per la consegna moderna delle email"
+        "resend": "Configura l'API di Resend per la consegna moderna delle email",
+        "microsoft": "Invia tramite la cassetta postale Microsoft 365 connessa via OAuth usata per la posta in arrivo"
       },
       "status": {
         "provider": "Provider {{provider}}"
@@ -160,6 +162,14 @@
         "label": "Indirizzo mittente",
         "placeholder": "noreply@yourdomain.com",
         "help": "Deve provenire da un dominio verificato. Usa la scheda Domini per aggiungere domini personalizzati."
+      }
+    },
+    "microsoft": {
+      "mailbox": {
+        "label": "Cassetta postale di invio",
+        "placeholder": "Seleziona una cassetta postale Microsoft 365 connessa",
+        "none": "Aggiungi e autorizza prima un provider Microsoft 365 nella scheda Email in arrivo.",
+        "help": "I messaggi vengono inviati come questa cassetta postale tramite Microsoft Graph e salvati in Posta inviata. Riconnetti le cassette postali esistenti per concedere Mail.Send."
       }
     },
     "domains": {

--- a/server/public/locales/it/msp/integrations.json
+++ b/server/public/locales/it/msp/integrations.json
@@ -1581,9 +1581,9 @@
             "reconnect": "Le connessioni del calendario Microsoft esistenti potrebbero richiedere una nuova autorizzazione dopo il cambio del profilo collegato."
           },
           "email": {
-            "description": "Scegli quale profilo Microsoft deve utilizzare l'e-mail in arrivo di Outlook.",
+            "description": "Scegli il profilo Microsoft per la posta Outlook in arrivo e in uscita.",
             "label": "E-mail",
-            "reconnect": "Le connessioni e-mail Outlook esistenti potrebbero richiedere una nuova autorizzazione dopo il cambio del profilo collegato."
+            "reconnect": "Le connessioni e-mail Outlook esistenti devono essere autorizzate nuovamente per concedere Mail.Send prima di poter inviare e-mail in uscita."
           },
           "mspSso": {
             "description": "Scegli quale profilo Microsoft supporta i domini di accesso MSP SSO, l'accesso Microsoft e la discovery del tenant.",

--- a/server/public/locales/nl/msp/admin.json
+++ b/server/public/locales/nl/msp/admin.json
@@ -109,12 +109,14 @@
       "providerLabel": "E-mailprovider",
       "options": {
         "smtp": "SMTP (traditionele e-mailserver)",
-        "resend": "Resend (moderne API-service)"
+        "resend": "Resend (moderne API-service)",
+        "microsoft": "Microsoft 365 (Microsoft Graph)"
       },
       "placeholder": "Selecteer e-mailprovider",
       "descriptions": {
         "smtp": "Configureer traditionele SMTP-e-mailserverinstellingen",
-        "resend": "Configureer de Resend-API voor moderne e-mailbezorging"
+        "resend": "Configureer de Resend-API voor moderne e-mailbezorging",
+        "microsoft": "Verzend via het met OAuth verbonden Microsoft 365-postvak dat voor inkomende e-mail wordt gebruikt"
       },
       "status": {
         "provider": "{{provider}}-provider"
@@ -160,6 +162,14 @@
         "label": "Afzenderadres",
         "placeholder": "noreply@yourdomain.com",
         "help": "Moet van een geverifieerd domein komen. Gebruik het tabblad Domeinen om aangepaste domeinen toe te voegen."
+      }
+    },
+    "microsoft": {
+      "mailbox": {
+        "label": "Postvak voor verzending",
+        "placeholder": "Selecteer een verbonden Microsoft 365-postvak",
+        "none": "Voeg eerst een Microsoft 365-provider toe en autoriseer deze op het tabblad Inkomende e-mail.",
+        "help": "Berichten worden als dit postvak via Microsoft Graph verzonden en opgeslagen in Verzonden items. Verbind bestaande postvakken opnieuw om Mail.Send toe te kennen."
       }
     },
     "domains": {

--- a/server/public/locales/nl/msp/integrations.json
+++ b/server/public/locales/nl/msp/integrations.json
@@ -1581,9 +1581,9 @@
             "reconnect": "Bestaande Microsoft-agendaverbindingen kunnen opnieuw autorisatie vereisen na het wijzigen van het gekoppelde profiel."
           },
           "email": {
-            "description": "Kies welk Microsoft-profiel Outlook (inkomende e-mail) moet gebruiken.",
+            "description": "Kies het Microsoft-profiel voor inkomende en uitgaande Outlook-e-mail.",
             "label": "E-mail",
-            "reconnect": "Bestaande Outlook-e-mailverbindingen kunnen opnieuw autorisatie vereisen na het wijzigen van het gekoppelde profiel."
+            "reconnect": "Bestaande Outlook-e-mailverbindingen moeten opnieuw worden geautoriseerd om Mail.Send toe te kennen voordat ze uitgaande e-mail kunnen verzenden."
           },
           "mspSso": {
             "description": "Kies welk Microsoft-profiel MSP SSO-aanmeldingsdomeinen, Microsoft-aanmelding en tenant-detectie ondersteunt.",

--- a/server/public/locales/pl/msp/admin.json
+++ b/server/public/locales/pl/msp/admin.json
@@ -109,12 +109,14 @@
       "providerLabel": "Dostawca poczty",
       "options": {
         "smtp": "SMTP (tradycyjny serwer pocztowy)",
-        "resend": "Resend (nowoczesna usługa API)"
+        "resend": "Resend (nowoczesna usługa API)",
+        "microsoft": "Microsoft 365 (Microsoft Graph)"
       },
       "placeholder": "Wybierz dostawcę poczty",
       "descriptions": {
         "smtp": "Skonfiguruj tradycyjne ustawienia serwera pocztowego SMTP",
-        "resend": "Skonfiguruj API Resend do nowoczesnego dostarczania poczty"
+        "resend": "Skonfiguruj API Resend do nowoczesnego dostarczania poczty",
+        "microsoft": "Wysyłaj przez połączoną za pomocą OAuth skrzynkę Microsoft 365 używaną do poczty przychodzącej"
       },
       "status": {
         "provider": "Dostawca {{provider}}"
@@ -160,6 +162,14 @@
         "label": "Adres nadawcy",
         "placeholder": "noreply@yourdomain.com",
         "help": "Musi pochodzić ze zweryfikowanej domeny. Użyj zakładki Domeny, aby dodać domeny niestandardowe."
+      }
+    },
+    "microsoft": {
+      "mailbox": {
+        "label": "Skrzynka nadawcza",
+        "placeholder": "Wybierz połączoną skrzynkę Microsoft 365",
+        "none": "Najpierw dodaj i autoryzuj dostawcę Microsoft 365 na karcie Poczta przychodząca.",
+        "help": "Wiadomości są wysyłane jako ta skrzynka przez Microsoft Graph i zapisywane w Elementach wysłanych. Połącz ponownie istniejące skrzynki, aby przyznać Mail.Send."
       }
     },
     "domains": {

--- a/server/public/locales/pl/msp/integrations.json
+++ b/server/public/locales/pl/msp/integrations.json
@@ -1581,9 +1581,9 @@
             "reconnect": "Istniejące połączenia kalendarza Microsoft mogą wymagać ponownej autoryzacji po zmianie powiązanego profilu."
           },
           "email": {
-            "description": "Wybierz, który profil Microsoft powinien być używany do poczty przychodzącej Outlook.",
+            "description": "Wybierz profil Microsoft dla przychodzącej i wychodzącej poczty Outlook.",
             "label": "E-mail",
-            "reconnect": "Istniejące połączenia e-mail Outlook mogą wymagać ponownej autoryzacji po zmianie powiązanego profilu."
+            "reconnect": "Istniejące połączenia e-mail Outlook muszą zostać ponownie autoryzowane, aby przyznać Mail.Send przed wysyłaniem poczty wychodzącej."
           },
           "mspSso": {
             "description": "Wybierz, który profil Microsoft obsługuje domeny logowania MSP SSO, logowanie Microsoft i wykrywanie tenanta.",

--- a/server/public/locales/pt/msp/admin.json
+++ b/server/public/locales/pt/msp/admin.json
@@ -109,12 +109,14 @@
       "providerLabel": "Provedor de e-mail",
       "options": {
         "smtp": "SMTP (servidor de e-mail tradicional)",
-        "resend": "Reenviar (serviço de API moderno)"
+        "resend": "Reenviar (serviço de API moderno)",
+        "microsoft": "Microsoft 365 (Microsoft Graph)"
       },
       "placeholder": "Selecione o provedor de e-mail",
       "descriptions": {
         "smtp": "Defina as configurações do servidor de e-mail SMTP tradicional",
-        "resend": "Configure a API Resend para entrega de e-mail moderna"
+        "resend": "Configure a API Resend para entrega de e-mail moderna",
+        "microsoft": "Envie pela caixa de correio do Microsoft 365 conectada via OAuth usada para e-mails recebidos"
       },
       "status": {
         "provider": "Provedor {{provider}}"
@@ -160,6 +162,14 @@
         "label": "Do endereço",
         "placeholder": "noreply@seudominio.com",
         "help": "Deve ser de um domínio verificado. Use a guia Domínios para adicionar domínios personalizados."
+      }
+    },
+    "microsoft": {
+      "mailbox": {
+        "label": "Caixa de correio de envio",
+        "placeholder": "Selecione uma caixa de correio do Microsoft 365 conectada",
+        "none": "Primeiro, adicione e autorize um provedor do Microsoft 365 na guia E-mail recebido.",
+        "help": "As mensagens são enviadas como esta caixa de correio pelo Microsoft Graph e salvas em Itens Enviados. Reconecte as caixas de correio existentes para conceder Mail.Send."
       }
     },
     "domains": {

--- a/server/public/locales/pt/msp/integrations.json
+++ b/server/public/locales/pt/msp/integrations.json
@@ -1581,9 +1581,9 @@
             "reconnect": "As conexões existentes do calendário da Microsoft podem precisar de nova autorização após a alteração do perfil vinculado."
           },
           "email": {
-            "description": "Escolha qual perfil da Microsoft o e-mail de entrada do Outlook deve usar.",
+            "description": "Escolha o perfil da Microsoft para e-mails recebidos e enviados do Outlook.",
             "label": "E-mail",
-            "reconnect": "As conexões de e-mail existentes do Outlook podem precisar de nova autorização após a alteração do perfil vinculado."
+            "reconnect": "As conexões de e-mail existentes do Outlook precisam ser autorizadas novamente para conceder Mail.Send antes de poderem enviar e-mails."
           },
           "mspSso": {
             "description": "Escolha qual perfil da Microsoft oferece suporte a domínios de login SSO do MSP, entrada da Microsoft e descoberta de locatário.",

--- a/server/public/locales/xx/msp/admin.json
+++ b/server/public/locales/xx/msp/admin.json
@@ -109,12 +109,14 @@
       "providerLabel": "11111",
       "options": {
         "smtp": "11111",
-        "resend": "11111"
+        "resend": "11111",
+        "microsoft": "11111"
       },
       "placeholder": "11111",
       "descriptions": {
         "smtp": "11111",
-        "resend": "11111"
+        "resend": "11111",
+        "microsoft": "11111"
       },
       "status": {
         "provider": "11111 {{provider}} 11111"
@@ -159,6 +161,14 @@
       "fromAddress": {
         "label": "11111",
         "placeholder": "11111",
+        "help": "11111"
+      }
+    },
+    "microsoft": {
+      "mailbox": {
+        "label": "11111",
+        "placeholder": "11111",
+        "none": "11111",
         "help": "11111"
       }
     },

--- a/server/public/locales/yy/msp/admin.json
+++ b/server/public/locales/yy/msp/admin.json
@@ -109,12 +109,14 @@
       "providerLabel": "55555",
       "options": {
         "smtp": "55555",
-        "resend": "55555"
+        "resend": "55555",
+        "microsoft": "55555"
       },
       "placeholder": "55555",
       "descriptions": {
         "smtp": "55555",
-        "resend": "55555"
+        "resend": "55555",
+        "microsoft": "55555"
       },
       "status": {
         "provider": "55555 {{provider}} 55555"
@@ -159,6 +161,14 @@
       "fromAddress": {
         "label": "55555",
         "placeholder": "55555",
+        "help": "55555"
+      }
+    },
+    "microsoft": {
+      "mailbox": {
+        "label": "55555",
+        "placeholder": "55555",
+        "none": "55555",
         "help": "55555"
       }
     },

--- a/server/src/app/api/auth/microsoft/callback/route.ts
+++ b/server/src/app/api/auth/microsoft/callback/route.ts
@@ -11,7 +11,10 @@ import { resolveMicrosoftConsumerProfileConfig } from '@alga-psa/integrations/li
 import { getWebhookBaseUrl } from '../../../../../utils/email/webhookHelpers';
 import { getCurrentUser } from '@alga-psa/user-composition/actions';
 import axios from 'axios';
-import { getMicrosoftTokenUrl } from '@alga-psa/shared/services/email/microsoftGraphEndpoints';
+import {
+  getMicrosoftTokenUrl,
+  MICROSOFT_EMAIL_OAUTH_SCOPES,
+} from '@alga-psa/shared/services/email/microsoftGraphEndpoints';
 import { EmailWebhookMaintenanceService } from '@alga-psa/shared/services/email/EmailWebhookMaintenanceService';
 
 export const dynamic = 'force-dynamic';
@@ -275,7 +278,7 @@ export async function GET(request: NextRequest) {
         code: code,
         grant_type: 'authorization_code',
         redirect_uri: redirectUri,
-        scope: 'https://graph.microsoft.com/Mail.Read https://graph.microsoft.com/Mail.Read.Shared offline_access'
+        scope: MICROSOFT_EMAIL_OAUTH_SCOPES.join(' ')
       });
 
       const response = await axios.post(tokenUrl, params.toString(), {

--- a/server/src/test/integration/microsoftOutboundEmailProviderMigration.integration.test.ts
+++ b/server/src/test/integration/microsoftOutboundEmailProviderMigration.integration.test.ts
@@ -1,0 +1,76 @@
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+import type { Knex } from 'knex';
+import { createRequire } from 'node:module';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { createTestDbConnection } from '../../../test-utils/dbConfig';
+
+const require = createRequire(import.meta.url);
+const here = path.dirname(fileURLToPath(import.meta.url));
+const repoRoot = path.resolve(here, '../../../..');
+const migration = require(
+  path.join(
+    repoRoot,
+    'server/migrations/20260803044749_allow_microsoft_tenant_email_provider.cjs'
+  )
+) as {
+  up: (knex: Knex | Knex.Transaction) => Promise<void>;
+  down: (knex: Knex | Knex.Transaction) => Promise<void>;
+};
+
+describe('Microsoft outbound email provider migration', () => {
+  let db: Knex;
+
+  beforeAll(async () => {
+    db = await createTestDbConnection({
+      databaseName: 'microsoft_outbound_email_migration_test',
+      runSeeds: true,
+    });
+  }, 180_000);
+
+  afterAll(async () => {
+    await db?.destroy().catch(() => undefined);
+  });
+
+  it('widens the original provider constraint and persists Microsoft settings', async () => {
+    const trx = await db.transaction();
+    try {
+      const seededTenant = await trx('tenants').first('tenant');
+      expect(seededTenant).toBeDefined();
+      if (!seededTenant) {
+        throw new Error('Expected a seeded tenant');
+      }
+
+      const [settings] = await trx('tenant_email_settings')
+        .insert({
+          tenant: seededTenant.tenant,
+          email_provider: 'smtp',
+        })
+        .returning(['id', 'tenant', 'email_provider']);
+
+      await migration.down(trx);
+
+      await expect(
+        trx.transaction(async (savepoint) => {
+          await savepoint('tenant_email_settings')
+            .where({ id: settings.id, tenant: settings.tenant })
+            .update({ email_provider: 'microsoft' });
+        })
+      ).rejects.toMatchObject({ code: '23514' });
+
+      await migration.up(trx);
+
+      const updated = await trx('tenant_email_settings')
+        .where({ id: settings.id, tenant: settings.tenant })
+        .update({ email_provider: 'microsoft' });
+      expect(updated).toBe(1);
+
+      const persisted = await trx('tenant_email_settings')
+        .where({ id: settings.id, tenant: settings.tenant })
+        .first('email_provider');
+      expect(persisted?.email_provider).toBe('microsoft');
+    } finally {
+      await trx.rollback();
+    }
+  });
+});

--- a/server/src/test/unit/email/microsoftOutboundOAuth.contract.test.ts
+++ b/server/src/test/unit/email/microsoftOutboundOAuth.contract.test.ts
@@ -1,0 +1,24 @@
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+import { describe, expect, it } from 'vitest';
+
+describe('Microsoft outbound OAuth contract', () => {
+  it('uses the common email scope set for authorization, token exchange, and refresh', () => {
+    const callback = readFileSync(
+      resolve(process.cwd(), 'src/app/api/auth/microsoft/callback/route.ts'),
+      'utf8'
+    );
+    const adapter = readFileSync(
+      resolve(process.cwd(), '../shared/services/email/providers/MicrosoftGraphAdapter.ts'),
+      'utf8'
+    );
+    const scopes = readFileSync(
+      resolve(process.cwd(), '../shared/services/email/microsoftGraphEndpoints.ts'),
+      'utf8'
+    );
+
+    expect(scopes).toContain("'https://graph.microsoft.com/Mail.Send'");
+    expect(callback).toContain("scope: MICROSOFT_EMAIL_OAUTH_SCOPES.join(' ')");
+    expect(adapter).toContain("scope: MICROSOFT_EMAIL_OAUTH_SCOPES.join(' ')");
+  });
+});

--- a/server/src/types/email.types.ts
+++ b/server/src/types/email.types.ts
@@ -85,7 +85,7 @@ export interface TenantEmailSettings {
   ticketingFromEmail?: string | null;
   ticketingFromName?: string | null;
   customDomains: string[];
-  emailProvider: 'smtp' | 'resend';
+  emailProvider: 'smtp' | 'resend' | 'microsoft';
   providerConfigs: EmailProviderConfig[];
   trackingEnabled: boolean;
   maxDailyEmails?: number;

--- a/server/src/utils/email/oauthHelpers.ts
+++ b/server/src/utils/email/oauthHelpers.ts
@@ -3,6 +3,10 @@
  */
 
 import { randomBytes } from 'crypto';
+import {
+  getMicrosoftAuthorizeUrl,
+  MICROSOFT_EMAIL_OAUTH_SCOPES,
+} from '@alga-psa/shared/services/email/microsoftGraphEndpoints';
 
 export interface OAuthState {
   tenant: string;
@@ -16,16 +20,16 @@ export interface OAuthState {
 
 /**
  * Generate OAuth authorization URL for Microsoft
- * Using read-only scopes: Mail.Read for personal mailbox, Mail.Read.Shared for shared mailboxes
+ * Requests inbound read access and Mail.Send for the same configured mailbox.
  */
 export function generateMicrosoftAuthUrl(
   clientId: string,
   redirectUri: string,
   state: OAuthState,
-  scopes: string[] = ['https://graph.microsoft.com/Mail.Read', 'https://graph.microsoft.com/Mail.Read.Shared', 'offline_access'],
+  scopes: string[] = [...MICROSOFT_EMAIL_OAUTH_SCOPES],
   tenantAuthority: string = 'common'
 ): string {
-  const baseUrl = `https://login.microsoftonline.com/common/oauth2/v2.0/authorize`;
+  const baseUrl = getMicrosoftAuthorizeUrl(tenantAuthority);
   
   const params = new URLSearchParams({
     client_id: clientId,

--- a/shared/services/email/microsoftGraphEndpoints.ts
+++ b/shared/services/email/microsoftGraphEndpoints.ts
@@ -1,6 +1,13 @@
 const DEFAULT_GRAPH_BASE_URL = 'https://graph.microsoft.com/v1.0';
 const DEFAULT_LOGIN_BASE_URL = 'https://login.microsoftonline.com';
 
+export const MICROSOFT_EMAIL_OAUTH_SCOPES = [
+  'https://graph.microsoft.com/Mail.Read',
+  'https://graph.microsoft.com/Mail.Read.Shared',
+  'https://graph.microsoft.com/Mail.Send',
+  'offline_access',
+] as const;
+
 function withoutTrailingSlash(value: string): string {
   return value.replace(/\/+$/, '');
 }

--- a/shared/services/email/providers/MicrosoftGraphAdapter.ts
+++ b/shared/services/email/providers/MicrosoftGraphAdapter.ts
@@ -11,7 +11,11 @@ import type {
 import { getSecretProviderInstance } from '../../../core/secretProvider';
 import { getAdminConnection } from '../../../db/admin';
 import { tenantDb } from '@alga-psa/db';
-import { getMicrosoftGraphBaseUrl, getMicrosoftTokenUrl } from '../microsoftGraphEndpoints';
+import {
+  getMicrosoftGraphBaseUrl,
+  getMicrosoftTokenUrl,
+  MICROSOFT_EMAIL_OAUTH_SCOPES,
+} from '../microsoftGraphEndpoints';
 
 export type MicrosoftSubscriptionErrorKind = 'validation' | 'authentication' | 'other';
 
@@ -34,6 +38,15 @@ export interface MicrosoftWebhookInitializationResult {
   error?: string;
   errorKind?: MicrosoftSubscriptionErrorKind;
 }
+
+export interface MicrosoftGraphSendMailResult {
+  requestId?: string;
+  clientRequestId?: string;
+}
+
+export type MicrosoftGraphSendMailPayload =
+  | { kind: 'json'; message: Record<string, unknown> }
+  | { kind: 'mime'; content: string };
 
 function classifySubscriptionError(error: any): MicrosoftSubscriptionErrorKind {
   const status = error?.response?.status ?? error?.status;
@@ -269,10 +282,15 @@ export class MicrosoftGraphAdapter extends BaseEmailAdapter {
       } else {
         this.log('warn', 'Could not determine authenticated user email from /me endpoint');
       }
-    } catch (error) {
+    } catch (error: any) {
       // Non-fatal error: log but don't throw
       // The adapter will still work, it will just default to /users/{mailbox} path
-      this.log('warn', 'Failed to load authenticated user email', error);
+      const failure = this.classifyGraphFailure(error);
+      this.log('warn', 'Failed to load authenticated user email', {
+        status: failure.status,
+        code: failure.code,
+        requestId: failure.requestId,
+      });
     }
   }
 
@@ -323,7 +341,7 @@ export class MicrosoftGraphAdapter extends BaseEmailAdapter {
         client_secret: clientSecret,
         refresh_token: this.refreshToken,
         grant_type: 'refresh_token',
-        scope: 'https://graph.microsoft.com/Mail.Read https://graph.microsoft.com/Mail.Read.Shared offline_access',
+        scope: MICROSOFT_EMAIL_OAUTH_SCOPES.join(' '),
       });
 
       const response = await axios.post(tokenUrl, params.toString(), {
@@ -346,7 +364,7 @@ export class MicrosoftGraphAdapter extends BaseEmailAdapter {
 
       this.log('info', 'Access token refreshed successfully');
     } catch (error) {
-      throw this.handleError(error, 'refreshAccessToken');
+      throw this.toSanitizedGraphError(error, 'refreshAccessToken');
     }
   }
 
@@ -390,7 +408,10 @@ export class MicrosoftGraphAdapter extends BaseEmailAdapter {
       await this.loadCredentials();
       // Load authenticated user email for mailbox path auto-detection
       await this.loadAuthenticatedUserEmail();
-      await this.testConnection();
+      const connection = await this.testConnection();
+      if (!connection.success) {
+        throw new Error(connection.error || 'Microsoft Graph connection test failed');
+      }
       this.log('info', 'Connected to Microsoft Graph API successfully');
     } catch (error) {
       throw this.handleError(error, 'connect');
@@ -401,6 +422,46 @@ export class MicrosoftGraphAdapter extends BaseEmailAdapter {
   async ensureTokenHealthy(bufferMinutes = 30): Promise<void> {
     if (!this.accessToken) await this.loadCredentials();
     if (this.isTokenExpired(bufferMinutes)) await this.refreshAccessToken();
+  }
+
+  /**
+   * Send an already-mapped Graph message as the configured mailbox. The
+   * adapter owns token refresh/persistence, so outbound email uses the same
+   * OAuth lifecycle as inbound polling and webhook processing.
+   */
+  async sendMail(payload: MicrosoftGraphSendMailPayload): Promise<MicrosoftGraphSendMailResult> {
+    const mailbox = (this.config.mailbox || '').trim();
+    if (!mailbox) {
+      throw new Error('Microsoft sending mailbox is not configured');
+    }
+
+    const endpoint = `/users/${encodeURIComponent(mailbox)}/sendMail`;
+    const send = () => payload.kind === 'mime'
+      ? this.httpClient.post(endpoint, payload.content, {
+          headers: { 'Content-Type': 'text/plain' },
+        })
+      : this.httpClient.post(endpoint, {
+          message: payload.message,
+          saveToSentItems: true,
+        });
+
+    try {
+      const response = await send();
+      return this.extractGraphIds(response.headers);
+    } catch (error: any) {
+      if (error?.response?.status === 401) {
+        // A single bounded retry covers tokens revoked/expired between the
+        // request interceptor's expiry check and Graph receiving the request.
+        await this.refreshAccessToken();
+        try {
+          const response = await send();
+          return this.extractGraphIds(response.headers);
+        } catch (retryError) {
+          throw this.toSanitizedGraphError(retryError, 'sendMail');
+        }
+      }
+      throw this.toSanitizedGraphError(error, 'sendMail');
+    }
   }
 
   /** List messages received since the supplied cursor, oldest first and capped. */
@@ -820,6 +881,23 @@ export class MicrosoftGraphAdapter extends BaseEmailAdapter {
       clientRequestId: ids.clientRequestId,
       responseBody: res?.data,
     };
+  }
+
+  private toSanitizedGraphError(error: unknown, context: string): Error {
+    const failure = this.classifyGraphFailure(error);
+    const details = failure.code || failure.requestId
+      ? ` (${[
+          failure.code ? `code: ${failure.code}` : undefined,
+          failure.requestId ? `request-id: ${failure.requestId}` : undefined,
+        ].filter(Boolean).join(', ')})`
+      : '';
+    const wrapped = new Error(`Error in ${context}: ${failure.message}${details}`);
+    Object.assign(wrapped, {
+      status: failure.status,
+      code: failure.code,
+      requestId: failure.requestId,
+    });
+    return wrapped;
   }
 
   private mapRecommendations(args: {

--- a/shared/services/email/providers/__tests__/MicrosoftGraphAdapter.sendMail.test.ts
+++ b/shared/services/email/providers/__tests__/MicrosoftGraphAdapter.sendMail.test.ts
@@ -1,0 +1,118 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { MicrosoftGraphAdapter } from '../MicrosoftGraphAdapter';
+
+function makeAdapter() {
+  return new MicrosoftGraphAdapter({
+    id: 'provider-1',
+    tenant: 'tenant-1',
+    name: 'Support',
+    provider_type: 'microsoft',
+    mailbox: 'support+desk@example.com',
+    folder_to_monitor: 'Inbox',
+    active: true,
+    webhook_notification_url: '',
+    connection_status: 'connected',
+    created_at: '2026-08-01T00:00:00.000Z',
+    updated_at: '2026-08-01T00:00:00.000Z',
+    provider_config: {
+      access_token: 'access-token',
+      refresh_token: 'refresh-token',
+      token_expires_at: new Date(Date.now() + 60 * 60 * 1000).toISOString(),
+    },
+  });
+}
+
+describe('MicrosoftGraphAdapter.sendMail', () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('always sends as the URL-encoded configured mailbox and saves to Sent Items', async () => {
+    const adapter = makeAdapter();
+    const post = vi.fn(async () => ({
+      headers: { 'request-id': 'request-1', 'client-request-id': 'client-request-1' },
+    }));
+    (adapter as any).httpClient = { post };
+
+    const result = await adapter.sendMail({ kind: 'json', message: { subject: 'Hello' } });
+
+    expect(post).toHaveBeenCalledWith('/users/support%2Bdesk%40example.com/sendMail', {
+      message: { subject: 'Hello' },
+      saveToSentItems: true,
+    });
+    expect(result).toEqual({ requestId: 'request-1', clientRequestId: 'client-request-1' });
+  });
+
+  it('refreshes and retries exactly once after a 401', async () => {
+    const adapter = makeAdapter();
+    const unauthorized = Object.assign(new Error('Unauthorized'), { response: { status: 401 } });
+    const post = vi.fn()
+      .mockRejectedValueOnce(unauthorized)
+      .mockResolvedValueOnce({ headers: { 'request-id': 'request-2' } });
+    const refresh = vi.spyOn(adapter as any, 'refreshAccessToken').mockResolvedValue(undefined);
+    (adapter as any).httpClient = { post };
+
+    await expect(adapter.sendMail({ kind: 'json', message: { subject: 'Retry' } }))
+      .resolves.toEqual({ requestId: 'request-2' });
+    expect(refresh).toHaveBeenCalledOnce();
+    expect(post).toHaveBeenCalledTimes(2);
+  });
+
+  it('sends MIME content with the Graph-required content type', async () => {
+    const adapter = makeAdapter();
+    const post = vi.fn(async () => ({ headers: { 'request-id': 'request-mime' } }));
+    (adapter as any).httpClient = { post };
+
+    await adapter.sendMail({ kind: 'mime', content: 'base64-mime-content' });
+
+    expect(post).toHaveBeenCalledWith(
+      '/users/support%2Bdesk%40example.com/sendMail',
+      'base64-mime-content',
+      { headers: { 'Content-Type': 'text/plain' } }
+    );
+  });
+
+  it('does not expose request credentials or message bodies when a send fails', async () => {
+    const adapter = makeAdapter();
+    const post = vi.fn().mockRejectedValue({
+      message: 'Forbidden',
+      config: {
+        headers: { Authorization: 'Bearer secret-access-token' },
+        data: 'secret-message-body',
+      },
+      response: {
+        status: 403,
+        data: { error: { code: 'ErrorAccessDenied', message: 'Forbidden' } },
+        headers: { 'request-id': 'safe-request-id' },
+      },
+    });
+    const consoleError = vi.spyOn(console, 'error').mockImplementation(() => undefined);
+    (adapter as any).httpClient = { post };
+
+    await expect(adapter.sendMail({ kind: 'json', message: { subject: 'Private' } }))
+      .rejects.toMatchObject({
+        status: 403,
+        code: 'ErrorAccessDenied',
+        requestId: 'safe-request-id',
+      });
+
+    const logged = JSON.stringify(consoleError.mock.calls);
+    expect(logged).not.toContain('secret-access-token');
+    expect(logged).not.toContain('secret-message-body');
+  });
+});
+
+describe('MicrosoftGraphAdapter.connect', () => {
+  it('does not report a failed Graph health check as connected', async () => {
+    const adapter = makeAdapter();
+    vi.spyOn(adapter as any, 'loadCredentials').mockResolvedValue(undefined);
+    vi.spyOn(adapter as any, 'loadAuthenticatedUserEmail').mockResolvedValue(undefined);
+    vi.spyOn(adapter, 'testConnection').mockResolvedValue({
+      success: false,
+      error: 'Mailbox unavailable',
+    });
+    vi.spyOn(console, 'error').mockImplementation(() => undefined);
+
+    await expect(adapter.connect()).rejects.toThrow('Mailbox unavailable');
+  });
+});

--- a/shared/tsup.config.ts
+++ b/shared/tsup.config.ts
@@ -13,6 +13,8 @@ export default defineConfig({
     'events/publisher': 'events/publisher.ts',
     'utils/encryption': 'utils/encryption.ts',
     'utils/retryUtils': 'utils/retryUtils.ts',
+    'services/email/microsoftEmailProviderConfig': 'services/email/microsoftEmailProviderConfig.ts',
+    'services/email/providers/MicrosoftGraphAdapter': 'services/email/providers/MicrosoftGraphAdapter.ts',
     'workflow/index': 'workflow/index.ts',
     'workflow/runtime/index': 'workflow/runtime/index.ts',
     'workflow/persistence/index': 'workflow/persistence/index.ts',


### PR DESCRIPTION
## Summary

Adds Microsoft 365 as an outbound email provider while keeping all senders on the common `TenantEmailService` / `EmailProviderManager` path.

- Reuses connected Microsoft inbound-provider OAuth credentials and requests delegated `Mail.Send` consent.
- Lets administrators select a connected Microsoft 365 mailbox in Outbound Email settings, persists that mailbox as the tenant provider, and supports the existing connection-test flow.
- Sends simple messages through Microsoft Graph JSON `sendMail`; switches to MIME `sendMail` when non-`x-` Internet headers are required so ticket `From`, `In-Reply-To`, `References`, and `Message-ID` headers survive.
- Sends as `/users/{mailbox}/sendMail` with `saveToSentItems=true`, including attachment and recipient validation and actionable Graph/OAuth errors.
- Widens the deployed `tenant_email_settings.email_provider` CHECK constraint to accept `microsoft`, with rollback protection when rows still use it.
- Updates Microsoft setup documentation, adds localized outbound UI copy, and adds focused provider, adapter, OAuth, settings, and PostgreSQL migration coverage.

## Validation

Automated validation passed: 20 focused Graph outbound/migration tests, affected package and full-server typechecks, the CE production build, both translation validation scripts, and the complete GitHub CI suite (24 successful checks; 1 intentionally skipped).

### Smoke test: PASS with fidelity limitations

Exercised:

- Applied and verified the migration against live PostgreSQL. The validated CHECK now permits `smtp`, `resend`, `hybrid`, and `microsoft`. The focused migration integration test passed.
- Verified rollback protection transactionally: rollback refused while a tenant used `microsoft` and left the schema/data unchanged.
- Through the real UI, selected Microsoft 365, chose the connected `support@smoke.example` mailbox, saved, reloaded, and confirmed persistence in both UI and PostgreSQL.
- Test Connection reported success. Runtime inspection confirmed Graph JSON `sendMail` to `/users/support%40smoke.example/sendMail` with `saveToSentItems=true`.
- Added a real public reply to TIC1003. The production ticket handler generated two Graph MIME sends—for the requester and assigned agent—with `From`, `In-Reply-To`, `References`, and `Message-ID` headers preserved.

Fidelity compromises:

- Microsoft Graph itself was not called. The repository emulator lacks outbound `sendMail`, so a disposable minimal simulator under `tools/smoke-sim` was used and removed afterward. No mock was used.
- The shared Redis consumer group did not deliver the UI comment event to this card’s process. The same production `handleTicketEvent` path was invoked through a temporary Vitest harness against the live database. Thus UI persistence and dispatch were separately proven, but not as one uninterrupted UI → Redis → handler flow.
- Real OAuth consent/refresh and an actual M365 Sent Items mailbox were not tested.
- The nearby SMTP UI-save regression attempt was interrupted by shared-stack Glinda password rotation. Original SMTP settings were restored and verified directly in PostgreSQL, but SMTP sending was not rerun through the UI.
- The retained raw capture contains the two MIME ticket sends; the earlier JSON test-send capture was reset before threading verification, though its successful UI result is screenshotted.

Concerns observed:

- The shared schema still lacks `tenants.suspended_at`, producing unrelated scheduled-job/RMM errors.
- New card-space browser panes landed on unavailable hosts, so interactions used an existing same-host browser pane inside this card’s space.

Cleanup completed: restored the original SMTP configuration and ticket metadata; removed test comments, reply tokens, Graph fixture, simulator, and temporary harness. The app remains genuinely available on port 3036; PostgreSQL, PgBouncer, and Redis ports are open. Git status contains only the pre-existing `package-lock.json` drift.

Evidence: `/tmp/alga-smoke-evidence/microsoft-graph-outbound-20260803T050942Z`


