### PR TITLE
Automate EntraID app registration for email (alga0002215)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -277,6 +277,11 @@ GOOGLE_CALENDAR_REDIRECT_URI=https://yourdomain.com/api/auth/google/calendar/cal
 # MICROSOFT_CLIENT_SECRET=
 # MICROSOFT_TENANT_ID=common
 # MICROSOFT_REDIRECT_URI=
+# Optional dedicated multi-tenant bootstrap app for guided Graph app creation.
+# Register https://<host>/api/auth/microsoft/email-setup/callback as a Web redirect URI
+# and grant delegated Application.ReadWrite.All. Falls back to MICROSOFT_CLIENT_*.
+# MICROSOFT_EMAIL_SETUP_CLIENT_ID=
+# MICROSOFT_EMAIL_SETUP_CLIENT_SECRET=
 
 # Calendar Webhook Configuration
 # Removed: Let the code use NEXTAUTH_URL as the fallback webhook base

--- a/docs/inbound-email/setup/microsoft.md
+++ b/docs/inbound-email/setup/microsoft.md
@@ -3,13 +3,25 @@
 Connect a Microsoft 365 mailbox to turn incoming messages into tickets and,
 optionally, send outbound email from the same mailbox. The connector uses
 delegated Microsoft Graph access on behalf of the user who authorizes it.
+Providers settings can guide administrators through using the Alga platform
+app, creating a tenant-owned app through Microsoft Graph, or entering an
+existing app manually.
 
 > Existing Microsoft connections must be reauthorized before outbound use so
 > the delegated token includes `Mail.Send`. A provider showing **Ready** only
 > confirms that its Microsoft credentials are configured.
 
-> Microsoft 365 inbound email is a Pro feature. It is not
-> offered in Community Edition builds.
+## Prerequisites
+
+* A Microsoft Entra administrator who can grant tenant consent. Automated
+  tenant-owned setup also requires a role allowed to create app registrations,
+  service principals, and credentials, such as Application Administrator or
+  Cloud Application Administrator.
+* A licensed user mailbox or a shared mailbox the authorizing user can read.
+* An Alga PSA user with `system_settings:update` permission.
+* Outbound HTTPS access to `graph.microsoft.com` and
+  `login.microsoftonline.com`. A public inbound URL is optional because Alga PSA
+  falls back to polling when Microsoft cannot validate the webhook endpoint.
 
 ## Choose the hosted or self-hosted path
 
@@ -17,17 +29,11 @@ delegated Microsoft Graph access on behalf of the user who authorizes it.
 
 Hosted deployments can use Alga PSA's platform Microsoft app:
 
-* If **Authorize Access** is enabled when you
-  [add the inbound provider](#add-the-inbound-provider), the Outlook email
-  credential path is ready. The mailbox form does not display client credential
-  fields, but the hosted setup flow receives the app configuration in the
-  browser, including its client secret. Restrict provider setup access to
-  trusted administrators.
-* If you bind a tenant-owned Microsoft app to Outlook email, that app takes
-  precedence over the hosted platform app. Follow
-  [Register a tenant-owned Entra app](#register-a-tenant-owned-entra-app), then
-  reauthorize any mailbox whose refresh token was issued to a different client
-  ID.
+* **Use the Alga platform app** in the guided setup to create a tenant-specific
+  Email profile without entering client credentials.
+* A tenant-owned Microsoft app takes precedence when it is selected for Outlook
+  email. Use the automated or manual tenant-owned setup when the organization
+  explicitly requires its own app registration.
 
 ### Self-hosted or appliance Alga PSA
 
@@ -43,6 +49,30 @@ uses polling over outbound HTTPS instead.
 Operator-level app secrets and environment variables remain compatibility
 fallbacks. Use the Microsoft profile in the UI for normal setup so the app used
 by Outlook email is explicit.
+
+## Set up the Microsoft app and Email profile
+
+Open **Settings → Integrations → Providers**, then select **Set up Microsoft
+Email**. Choose one of:
+
+* **Use the Alga platform app** — enter the Microsoft tenant ID or verified
+  domain. Alga creates a pending Email profile and provides the tenant-scoped
+  administrator-consent step.
+* **Create an app in this tenant** — sign in with a Microsoft administrator. A
+  setup-only PKCE flow creates the application, service principal, and client
+  secret through Microsoft Graph. Alga stores the generated secret directly in
+  its tenant secret provider and discards the short-lived bootstrap token.
+* **Enter an existing app manually** — open the existing profile form and follow
+  the tenant-owned registration steps below.
+
+The automated option is unavailable when the deployment does not have a
+multi-tenant setup application configured. The other choices remain available
+independently.
+
+After either guided option creates a profile, complete **Grant administrator
+consent**. The profile remains unavailable for Outlook email until the callback
+records consent and selects it for the Email service in one transaction. This
+tenant-wide app consent is separate from authorizing the individual mailbox.
 
 ## Required Microsoft permissions
 

--- a/docs/plans/2026-08-02-automate-entra-email-app-registration-plan.md
+++ b/docs/plans/2026-08-02-automate-entra-email-app-registration-plan.md
@@ -1,0 +1,96 @@
+# Automate Entra ID app registration for Microsoft email
+
+## Intent
+
+Replace the current “open Azure Portal, create an app, copy credentials, then return” dead end with a guided Microsoft Email setup in Providers settings. Administrators choose either the platform-managed multi-tenant application or a tenant-owned application created through Microsoft Graph; both paths finish by creating/binding the existing Microsoft profile consumed by the mailbox OAuth form.
+
+## Existing seams
+
+- `packages/integrations/src/actions/integrations/microsoftActions.ts` owns Microsoft profile CRUD, tenant-secret storage, Email consumer binding, computed redirect URIs, and Email scopes. `createMicrosoftProfile`, `setMicrosoftConsumerBinding`, `getMicrosoftProfileStatus`, and `getMicrosoftConsumerSetupStatus` remain the source of truth.
+- `packages/integrations/src/components/email/MicrosoftProviderForm.tsx` deliberately does not collect client credentials. It checks Email consumer readiness and then starts mailbox OAuth through `initiateEmailOAuth`; keep that separation.
+- `packages/integrations/src/components/email/ProviderSetupWizardDialog.tsx` routes Microsoft mailbox setup into `MicrosoftProviderForm`; it should link back to Providers settings but should not create applications itself.
+- `docs/inbound-email/setup/microsoft.md` documents the current manual registration, required Web redirect URI, and delegated `Mail.Read`, `Mail.Read.Shared`, and `offline_access` permissions.
+- The worktree has an unrelated modified `package-lock.json`; preserve it and exclude it from this plan commit.
+
+## Design
+
+### 1. Add an Email-specific guided setup surface in Providers settings
+
+Extend the Microsoft provider/profile editor that already calls `getMicrosoftProfileStatus` and `createMicrosoftProfile`. Add a “Set up Microsoft Email” dialog with two explicit choices:
+
+1. **Use the Alga platform app** — available only when the server reports configured platform Microsoft credentials. Show the application/client ID and generated tenant admin-consent URL, with copy/open actions and a warning that an Entra administrator must grant consent before mailbox authorization.
+2. **Create an app in this tenant** — run a short bootstrap sign-in, create the application through Graph, create its service principal and password, persist the resulting profile, and bind it to the Email consumer.
+
+The dialog must render the exact callback URI returned by server metadata rather than reconstructing it in the client. Completion returns to the ordinary profile list with the new Email-bound profile selected.
+
+### 2. Introduce narrow server actions and pure builders
+
+Add a focused module beside `microsoftActions.ts`, for example `packages/integrations/src/actions/integrations/microsoftEmailSetupActions.ts`, and keep profile persistence delegated to the existing internal/profile actions.
+
+Pure helpers should build:
+
+- the tenant-specific admin-consent URL: `https://login.microsoftonline.com/{tenant}/v2.0/adminconsent?client_id=...&redirect_uri=...&state=...`;
+- the Graph application manifest with `signInAudience: AzureADMultipleOrgs`, a Web redirect URI from `getMicrosoftProfileStatus`, and delegated Microsoft Graph `requiredResourceAccess` entries for `Mail.Read`, `Mail.Read.Shared`, and `offline_access` using their stable permission IDs;
+- sanitized result/error contracts that never return an access token and return a generated client secret only to the server-side profile persistence path.
+
+Expose authenticated, `system_settings:update`-guarded actions for:
+
+- `getMicrosoftEmailSetupOptions`: deployment callback URI, whether platform credentials are available, platform client ID, and a signed/expiring setup state;
+- `getMicrosoftEmailAdminConsentUrl(tenantHint?)`: validate the tenant identifier, bind state to the current tenant/user, and return the URL;
+- `createMicrosoftEmailApplication`: accept the bootstrap Graph authorization result/state, POST `/applications`, POST `/servicePrincipals`, call `addPassword`, create a Microsoft profile with Email capability, and bind that profile to `email`.
+
+Reuse the existing tenant secret provider and Microsoft profile APIs so the generated password is stored under the profile secret reference and never written to the database, activity trail, browser logs, or response payload.
+
+### 3. Add a dedicated bootstrap OAuth callback
+
+The existing `/api/auth/microsoft/callback` is mailbox authorization and stores mailbox tokens; do not overload it. Add a setup-only callback such as `server/src/app/api/auth/microsoft/email-setup/callback/route.ts` and matching initiation helper.
+
+The bootstrap authorization requests the minimum delegated Graph administration scopes needed to create an application/service principal and password. Use authorization-code + PKCE, a short-lived signed state containing the Alga tenant/user and return location, and a single-use server-side verifier. Validate issuer/tenant, nonce/state, and the signed-in administrator before using the access token. Do not persist the bootstrap access/refresh token after provisioning completes.
+
+If Microsoft does not permit the requested app-registration operation for that administrator/tenant, return an actionable error and keep the manual/platform path available. Never silently broaden permissions.
+
+### 4. Finish through the existing profile and mailbox flow
+
+After Graph provisioning succeeds:
+
+1. create the Microsoft profile using the returned application ID, tenant ID, generated secret, Email capability, and display name;
+2. bind it with `setMicrosoftConsumerBinding({ consumerType: 'email', profileId })`;
+3. show the tenant admin-consent URL for the newly created application;
+4. return the administrator to Inbound Email, where `MicrosoftProviderForm` becomes ready and its existing **Authorize Access** button performs mailbox consent/token storage.
+
+This ordering keeps application administration, tenant-wide admin consent, and per-mailbox delegated OAuth visible as three distinct states. Readiness should distinguish “profile created,” “admin consent pending,” and “mailbox connected” instead of treating credentials alone as full completion.
+
+### 5. Tests and documentation
+
+- Unit-test URL and manifest builders against exact redirect URI, audience, and required permission IDs.
+- Action tests cover RBAC, tenant/state mismatch, Graph partial failure, secret non-disclosure, profile creation, and Email binding.
+- Callback tests cover PKCE/state replay, issuer/tenant validation, denied consent, and cleanup of the one-time verifier.
+- Component tests cover both setup choices, platform-app unavailable state, manual fallback, generated consent URL, and returning to mailbox authorization.
+- Update `docs/inbound-email/setup/microsoft.md` to lead with the guided choices while retaining a manual-registration fallback and clearly separating admin consent from mailbox authorization.
+
+## Implementation order
+
+1. Export/refactor the existing redirect/scope/profile persistence helpers needed by the setup action without duplicating tenant-secret logic.
+2. Add pure consent URL and application-manifest builders with behavioral tests.
+3. Add the PKCE setup initiation/callback and one-time state storage.
+4. Add Graph provisioning orchestration with compensating cleanup: if service-principal/password/profile creation fails, best-effort delete objects created during that attempt and report what remains.
+5. Add the Providers settings dialog and wire completion to existing profile refresh/binding behavior.
+6. Update `MicrosoftProviderForm` only to present improved readiness/progress links; leave mailbox OAuth intact.
+7. Update docs and add end-to-end smoke evidence for both platform consent URL generation and a simulated/controlled Graph provisioning response, explicitly disclosing any simulator.
+
+## Non-goals
+
+- No changes to outbound email transport or `Mail.Send` behavior.
+- No reuse of the Entra user-sync/CIPP setup flow; this feature provisions the application used by Microsoft Email.
+- No storage of bootstrap Graph tokens or generated secrets in client state, database columns, logs, or artifacts.
+- No automatic grant of tenant admin consent; Microsoft must keep that administrator-controlled boundary.
+- No removal of manual app registration, hosted credential fallback, or the existing mailbox OAuth callback.
+
+## Risks
+
+- Graph application creation is tenant-policy and role dependent. The UI must detect authorization failure and provide a clean platform/manual fallback.
+- Permission GUID mistakes create an apparently valid but unusable app. Keep a named constant table and verify it behaviorally against the emitted manifest.
+- Partial Graph provisioning can orphan an application/service principal. Track created object IDs server-side during the request and perform best-effort compensating deletion.
+- A generated client secret is irrecoverable after creation. Persist it atomically before declaring success; if persistence fails, delete/revoke the credential and fail closed.
+- Platform multi-tenant consent must use tenant-scoped admin-consent URLs and signed state; `/common` is appropriate for mailbox OAuth but insufficient to identify which tenant granted admin consent.
+- The existing metadata currently lists broader Email scopes (`Mail.ReadWrite`/`Mail.Send`) than the card’s required read-only set. The implementation must reconcile this deliberately and must not broaden the new app manifest without a documented consumer requirement.

--- a/packages/emulators/msgraph/src/core.ts
+++ b/packages/emulators/msgraph/src/core.ts
@@ -66,6 +66,21 @@ export interface TokenGrantInput {
   code?: string;
   redirect_uri?: string;
   refresh_token?: string;
+  scope?: string;
+}
+
+export interface GraphApplication {
+  id: string;
+  appId: string;
+  displayName: string;
+  signInAudience?: string;
+  web?: { redirectUris?: string[] };
+  requiredResourceAccess?: unknown[];
+}
+
+export interface GraphServicePrincipal {
+  id: string;
+  appId: string;
 }
 
 export interface SeedMessageInput {
@@ -103,13 +118,20 @@ export interface SeedDirectoryUserInput {
  */
 export class MsGraphCore implements EmulatorCore {
   private readonly clients = new Map<string, string>();
-  private readonly codes = new Map<string, { clientId: string; redirectUri: string }>();
+  private readonly codes = new Map<string, {
+    clientId: string;
+    redirectUri: string;
+    nonce?: string;
+    scope?: string;
+  }>();
   private readonly refreshTokens = new Map<string, { clientId: string; revoked: boolean }>();
   private readonly accessTokens = new Map<string, { clientId: string; expiresAt: number }>();
   readonly messages = new Map<string, GraphMessage>();
   readonly subscriptions = new Map<string, GraphSubscription>();
   readonly organizations = new Map<string, GraphOrganization>();
   readonly directoryUsers = new Map<string, GraphDirectoryUser>();
+  readonly applications = new Map<string, GraphApplication>();
+  readonly servicePrincipals = new Map<string, GraphServicePrincipal>();
   readonly faults = new Map<string, OperationFault>();
   accessTokenTtlSeconds = 3600;
   rotateRefreshTokens = true;
@@ -126,6 +148,8 @@ export class MsGraphCore implements EmulatorCore {
     this.subscriptions.clear();
     this.organizations.clear();
     this.directoryUsers.clear();
+    this.applications.clear();
+    this.servicePrincipals.clear();
     this.faults.clear();
     this.accessTokenTtlSeconds = 3600;
     this.rotateRefreshTokens = true;
@@ -147,16 +171,22 @@ export class MsGraphCore implements EmulatorCore {
     this.clients.set(clientId, clientSecret);
   }
 
-  authorize(clientId: string, redirectUri: string): string {
+  authorize(clientId: string, redirectUri: string, input?: { nonce?: string; scope?: string }): string {
     if (!this.clients.has(clientId)) {
       throw new GraphApiError(400, { error: 'invalid_client' });
     }
     const code = this.newId('code');
-    this.codes.set(code, { clientId, redirectUri });
+    this.codes.set(code, { clientId, redirectUri, nonce: input?.nonce, scope: input?.scope });
     return code;
   }
 
-  grantToken(input: TokenGrantInput): { access_token: string; refresh_token: string; expires_in: number; token_type: 'Bearer' } {
+  grantToken(input: TokenGrantInput): {
+    access_token: string;
+    refresh_token: string;
+    expires_in: number;
+    token_type: 'Bearer';
+    id_token?: string;
+  } {
     if (this.clients.get(String(input.client_id)) !== String(input.client_secret)) {
       throw new GraphApiError(401, { error: 'invalid_client' });
     }
@@ -166,7 +196,10 @@ export class MsGraphCore implements EmulatorCore {
         throw new GraphApiError(400, { error: 'invalid_grant' });
       }
       this.codes.delete(String(input.code));
-      return this.issueTokens(String(input.client_id));
+      return this.issueTokens(String(input.client_id), undefined, {
+        nonce: code.nonce,
+        scope: code.scope || input.scope,
+      });
     }
     if (input.grant_type === 'refresh_token') {
       const refresh = this.refreshTokens.get(String(input.refresh_token));
@@ -178,8 +211,25 @@ export class MsGraphCore implements EmulatorCore {
     throw new GraphApiError(400, { error: 'unsupported_grant_type' });
   }
 
-  private issueTokens(clientId: string, existingRefreshToken?: string) {
-    const accessToken = this.newId('access');
+  private encodeJwt(payload: Record<string, unknown>): string {
+    const header = Buffer.from(JSON.stringify({ alg: 'none', typ: 'JWT' })).toString('base64url');
+    const body = Buffer.from(JSON.stringify(payload)).toString('base64url');
+    return `${header}.${body}.emulator`;
+  }
+
+  private issueTokens(
+    clientId: string,
+    existingRefreshToken?: string,
+    claims?: { nonce?: string; scope?: string }
+  ) {
+    const tenantId = '11111111-2222-4333-8444-555555555555';
+    const accessToken = this.encodeJwt({
+      tid: tenantId,
+      iss: `https://login.microsoftonline.com/${tenantId}/v2.0`,
+      scp: claims?.scope || 'Mail.Read Mail.Read.Shared offline_access',
+      aud: '00000003-0000-0000-c000-000000000000',
+      exp: Math.floor((this.nowMs() + this.accessTokenTtlSeconds * 1000) / 1000),
+    });
     const refreshToken =
       existingRefreshToken && !this.rotateRefreshTokens ? existingRefreshToken : this.newId('refresh');
     this.accessTokens.set(accessToken, {
@@ -195,6 +245,9 @@ export class MsGraphCore implements EmulatorCore {
       refresh_token: refreshToken,
       expires_in: this.accessTokenTtlSeconds,
       token_type: 'Bearer' as const,
+      ...(claims?.nonce
+        ? { id_token: this.encodeJwt({ tid: tenantId, nonce: claims.nonce, aud: clientId }) }
+        : {}),
     };
   }
 
@@ -222,6 +275,53 @@ export class MsGraphCore implements EmulatorCore {
       record.revoked = true;
     }
     return Boolean(record);
+  }
+
+  // --- Application registration ---
+
+  createApplication(input: Omit<GraphApplication, 'id' | 'appId'>): GraphApplication {
+    if (!input.displayName?.trim()) {
+      throw new GraphApiError(400, { error: { code: 'Request_BadRequest', message: 'displayName is required' } });
+    }
+    const application: GraphApplication = {
+      ...input,
+      id: this.newId('application'),
+      appId: this.newId('client'),
+      displayName: input.displayName.trim(),
+    };
+    this.applications.set(application.id, application);
+    return application;
+  }
+
+  deleteApplication(id: string): void {
+    if (!this.applications.delete(id)) {
+      throw new GraphApiError(404, { error: { code: 'Request_ResourceNotFound' } });
+    }
+  }
+
+  createServicePrincipal(appId: string): GraphServicePrincipal {
+    if (![...this.applications.values()].some((application) => application.appId === appId)) {
+      throw new GraphApiError(400, { error: { code: 'Request_BadRequest', message: 'Unknown appId' } });
+    }
+    const servicePrincipal = { id: this.newId('service-principal'), appId };
+    this.servicePrincipals.set(servicePrincipal.id, servicePrincipal);
+    return servicePrincipal;
+  }
+
+  deleteServicePrincipal(id: string): void {
+    if (!this.servicePrincipals.delete(id)) {
+      throw new GraphApiError(404, { error: { code: 'Request_ResourceNotFound' } });
+    }
+  }
+
+  addApplicationPassword(applicationId: string): { keyId: string; secretText: string } {
+    if (!this.applications.has(applicationId)) {
+      throw new GraphApiError(404, { error: { code: 'Request_ResourceNotFound' } });
+    }
+    return {
+      keyId: this.newId('password'),
+      secretText: this.newId('secret'),
+    };
   }
 
   // --- Directory ---

--- a/packages/emulators/msgraph/src/index.ts
+++ b/packages/emulators/msgraph/src/index.ts
@@ -15,4 +15,4 @@ const msgraphEmulator: EmulatorPackage<MsGraphCore> = {
 export default msgraphEmulator;
 export { msgraphEmulator as emulator };
 export { GraphApiError, MsGraphCore } from './core';
-export type { GraphMessage, GraphSubscription } from './core';
+export type { GraphApplication, GraphMessage, GraphServicePrincipal, GraphSubscription } from './core';

--- a/packages/emulators/msgraph/src/register.ts
+++ b/packages/emulators/msgraph/src/register.ts
@@ -132,6 +132,18 @@ export function register(reg: ControlRegistry, core: MsGraphCore): void {
   });
 
   reg.stateView({
+    name: 'applications',
+    description: 'Entra application registrations created through Graph',
+    get: () => [...core.applications.values()],
+  });
+
+  reg.stateView({
+    name: 'service-principals',
+    description: 'Entra service principals created through Graph',
+    get: () => [...core.servicePrincipals.values()],
+  });
+
+  reg.stateView({
     name: 'faults',
     description: 'Armed operation faults',
     get: () => Object.fromEntries(core.faults),

--- a/packages/emulators/msgraph/src/wire.ts
+++ b/packages/emulators/msgraph/src/wire.ts
@@ -17,7 +17,7 @@ function authed(res: Response): Authed {
 /**
  * Vendor surface: Microsoft login (OAuth2 v2.0) plus the Graph v1.0 routes
  * Alga's email integration uses. Point MICROSOFT_LOGIN_BASE_URL and
- * MICROSOFT_GRAPH_BASE_URL (minus the /v1.0 suffix) at this emulator.
+ * MICROSOFT_GRAPH_BASE_URL (including the /v1.0 suffix) at this emulator.
  */
 export function wire(router: Router, core: MsGraphCore, env: HostEnv): void {
   router.use(express.json());
@@ -31,7 +31,10 @@ export function wire(router: Router, core: MsGraphCore, env: HostEnv): void {
     if (!clientId || !redirectUri) {
       throw new GraphApiError(400, { error: 'invalid_client' });
     }
-    const code = core.authorize(clientId, redirectUri);
+    const code = core.authorize(clientId, redirectUri, {
+      nonce: req.query.nonce ? String(req.query.nonce) : undefined,
+      scope: req.query.scope ? String(req.query.scope) : undefined,
+    });
     const callback = new URL(redirectUri);
     callback.searchParams.set('code', code);
     if (req.query.state) {
@@ -47,6 +50,19 @@ export function wire(router: Router, core: MsGraphCore, env: HostEnv): void {
       return;
     }
     res.json(core.grantToken(req.body ?? {}));
+  });
+
+  router.get('/:tenant/v2.0/adminconsent', (req, res) => {
+    const clientId = String(req.query.client_id ?? '');
+    const redirectUri = String(req.query.redirect_uri ?? '');
+    if (!clientId || !redirectUri) {
+      throw new GraphApiError(400, { error: 'invalid_request' });
+    }
+    const callback = new URL(redirectUri);
+    callback.searchParams.set('admin_consent', 'true');
+    callback.searchParams.set('tenant', '11111111-2222-4333-8444-555555555555');
+    if (req.query.state) callback.searchParams.set('state', String(req.query.state));
+    res.redirect(302, callback.toString());
   });
 
   // --- Graph v1.0 surface ---
@@ -86,6 +102,28 @@ export function wire(router: Router, core: MsGraphCore, env: HostEnv): void {
       return;
     }
     res.json(mailboxUser);
+  });
+
+  graph.post('/applications', (req, res) => {
+    res.status(201).json(core.createApplication(req.body ?? {}));
+  });
+
+  graph.post('/applications/:applicationId/addPassword', (req, res) => {
+    res.json(core.addApplicationPassword(String(req.params.applicationId)));
+  });
+
+  graph.delete('/applications/:applicationId', (req, res) => {
+    core.deleteApplication(String(req.params.applicationId));
+    res.status(204).end();
+  });
+
+  graph.post('/servicePrincipals', (req, res) => {
+    res.status(201).json(core.createServicePrincipal(String(req.body?.appId ?? '')));
+  });
+
+  graph.delete('/servicePrincipals/:servicePrincipalId', (req, res) => {
+    core.deleteServicePrincipal(String(req.params.servicePrincipalId));
+    res.status(204).end();
   });
 
   const mailboxRoots = ['/me', '/users/:userId'];

--- a/packages/emulators/msgraph/tests/smoke.test.ts
+++ b/packages/emulators/msgraph/tests/smoke.test.ts
@@ -110,6 +110,76 @@ describe('msgraph emulator', { shuffle: false }, () => {
     refreshToken = refreshedTokens.refresh_token;
   });
 
+  it('supports guided Entra application creation and administrator consent', async () => {
+    const redirectUri = 'http://localhost/email-setup/callback';
+    const authorize = new URL(`${base}/common/oauth2/v2.0/authorize`);
+    authorize.search = new URLSearchParams({
+      client_id: 'premise-app',
+      redirect_uri: redirectUri,
+      state: 'setup-state',
+      nonce: 'setup-nonce',
+      scope: 'https://graph.microsoft.com/Application.ReadWrite.All openid profile email',
+    }).toString();
+    const authorization = await fetch(authorize, { redirect: 'manual' });
+    const code = new URL(authorization.headers.get('location')!).searchParams.get('code')!;
+    const tokenResponse = await fetch(
+      `${base}/common/oauth2/v2.0/token`,
+      form({
+        client_id: 'premise-app',
+        client_secret: 'premise-secret',
+        code,
+        redirect_uri: redirectUri,
+        grant_type: 'authorization_code',
+      })
+    );
+    const tokens = await tokenResponse.json();
+    expect(tokens.access_token.split('.')).toHaveLength(3);
+    expect(tokens.id_token.split('.')).toHaveLength(3);
+
+    const headers = {
+      authorization: `Bearer ${tokens.access_token}`,
+      'content-type': 'application/json',
+    };
+    const applicationResponse = await fetch(`${base}/v1.0/applications`, {
+      method: 'POST',
+      headers,
+      body: JSON.stringify({
+        displayName: 'Alga Email',
+        signInAudience: 'AzureADMultipleOrgs',
+        web: { redirectUris: ['http://localhost/api/auth/microsoft/callback'] },
+        requiredResourceAccess: [],
+      }),
+    });
+    expect(applicationResponse.status).toBe(201);
+    const application = await applicationResponse.json();
+
+    const servicePrincipalResponse = await fetch(`${base}/v1.0/servicePrincipals`, {
+      method: 'POST',
+      headers,
+      body: JSON.stringify({ appId: application.appId }),
+    });
+    expect(servicePrincipalResponse.status).toBe(201);
+
+    const passwordResponse = await fetch(`${base}/v1.0/applications/${application.id}/addPassword`, {
+      method: 'POST',
+      headers,
+      body: JSON.stringify({ passwordCredential: { displayName: 'Alga email client secret' } }),
+    });
+    expect(passwordResponse.status).toBe(200);
+    expect((await passwordResponse.json()).secretText).toBeTruthy();
+
+    const consent = new URL(`${base}/11111111-2222-4333-8444-555555555555/v2.0/adminconsent`);
+    consent.search = new URLSearchParams({
+      client_id: application.appId,
+      redirect_uri: redirectUri,
+      state: 'consent-state',
+    }).toString();
+    const consentResponse = await fetch(consent, { redirect: 'manual' });
+    const consentCallback = new URL(consentResponse.headers.get('location')!);
+    expect(consentCallback.searchParams.get('admin_consent')).toBe('true');
+    expect(consentCallback.searchParams.get('state')).toBe('consent-state');
+  });
+
   it('lists mail, validates subscriptions, and pushes notifications (smoke parity)', async () => {
     const headers = { authorization: `Bearer ${accessToken}`, 'content-type': 'application/json' };
 

--- a/packages/integrations/src/actions/index.ts
+++ b/packages/integrations/src/actions/index.ts
@@ -131,6 +131,14 @@ export {
   resetMicrosoftProvidersToDisconnected
 } from './integrations/microsoftActions';
 export {
+  getMicrosoftEmailSetupOptions,
+  getMicrosoftEmailAdminConsentUrl,
+  configureMicrosoftEmailPlatformApplication,
+  createMicrosoftEmailApplication,
+  type MicrosoftEmailSetupOptionsResult,
+  type MicrosoftEmailSetupCompletionResult,
+} from './integrations/microsoftEmailSetupActions';
+export {
   listMspSsoLoginDomains,
   listMspSsoDomainClaims,
   saveMspSsoLoginDomains,

--- a/packages/integrations/src/actions/integrations/index.ts
+++ b/packages/integrations/src/actions/integrations/index.ts
@@ -15,6 +15,14 @@ export {
   resetMicrosoftProvidersToDisconnected
 } from './microsoftActions';
 export {
+  getMicrosoftEmailSetupOptions,
+  getMicrosoftEmailAdminConsentUrl,
+  configureMicrosoftEmailPlatformApplication,
+  createMicrosoftEmailApplication,
+  type MicrosoftEmailSetupOptionsResult,
+  type MicrosoftEmailSetupCompletionResult,
+} from './microsoftEmailSetupActions';
+export {
   listMspSsoLoginDomains,
   saveMspSsoLoginDomains,
 } from './mspSsoDomainActions';

--- a/packages/integrations/src/actions/integrations/microsoftActions.test.ts
+++ b/packages/integrations/src/actions/integrations/microsoftActions.test.ts
@@ -683,7 +683,7 @@ describe('Microsoft integration actions', () => {
     }
   });
 
-  it('returns CE status metadata with only MSP SSO guidance and masked profile data', async () => {
+  it('returns CE status metadata with MSP SSO and Email guidance plus masked profile data', async () => {
     const originalEdition = process.env.NEXT_PUBLIC_EDITION;
     process.env.NEXT_PUBLIC_EDITION = 'community';
 
@@ -708,11 +708,11 @@ describe('Microsoft integration actions', () => {
       expect(result.config?.clientSecretMasked?.endsWith('alue')).toBe(true);
       expect(result.config?.clientSecretMasked).not.toContain('super-secret-value');
       expect(result.redirectUris?.sso).toBe('https://example.com/api/auth/callback/azure-ad');
-      expect(result.redirectUris?.email).toBeUndefined();
+      expect(result.redirectUris?.email).toBe('https://example.com/api/auth/microsoft/callback');
       expect(result.redirectUris?.calendar).toBeUndefined();
       expect(result.redirectUris?.teamsTab).toBeUndefined();
       expect(result.scopes?.sso).toContain('openid');
-      expect(result.scopes?.email).toBeUndefined();
+      expect(result.scopes?.email).toContain('https://graph.microsoft.com/Mail.Read');
       expect(result.scopes?.calendar).toBeUndefined();
       expect(result.scopes?.teams).toBeUndefined();
       expect(result.profiles?.[0]?.displayName).toBe('Default Microsoft Profile');

--- a/packages/integrations/src/actions/integrations/microsoftActions.ts
+++ b/packages/integrations/src/actions/integrations/microsoftActions.ts
@@ -63,6 +63,9 @@ interface MicrosoftProfileRow {
   client_id: string;
   tenant_id: string;
   client_secret_ref: string;
+  email_admin_consent_required?: boolean;
+  email_admin_consent_granted_at?: string | Date | null;
+  email_admin_consent_tenant_id?: string | null;
   capabilities: MicrosoftProfileConsumer[] | string | null;
   is_default: boolean;
   is_archived: boolean;
@@ -105,6 +108,8 @@ export interface MicrosoftProfileSummary {
   clientSecretMasked?: string;
   clientSecretConfigured: boolean;
   clientSecretRef: string;
+  emailAdminConsentRequired: boolean;
+  emailAdminConsentGrantedAt?: string | null;
   isDefault: boolean;
   isArchived: boolean;
   capabilities: MicrosoftProfileConsumer[];
@@ -730,6 +735,12 @@ async function buildMicrosoftProfileSummary(
     }),
   ]);
 
+  const emailAdminConsentRequired = Boolean(row.email_admin_consent_required);
+  const emailAdminConsentGranted = Boolean(row.email_admin_consent_granted_at);
+  const effectiveReadiness = emailAdminConsentRequired && !emailAdminConsentGranted
+    ? { ...readiness, ready: false }
+    : readiness;
+
   return {
     profileId: row.profile_id,
     displayName: row.display_name,
@@ -738,11 +749,15 @@ async function buildMicrosoftProfileSummary(
     clientSecretMasked: clientSecret ? maskSecret(clientSecret) : undefined,
     clientSecretConfigured: readiness.clientSecretConfigured,
     clientSecretRef: row.client_secret_ref,
+    emailAdminConsentRequired,
+    emailAdminConsentGrantedAt: row.email_admin_consent_granted_at
+      ? String(row.email_admin_consent_granted_at)
+      : null,
     isDefault: row.is_default,
     isArchived: row.is_archived,
     capabilities: normalizeMicrosoftProfileCapabilities(row.capabilities),
-    readiness,
-    status: row.is_archived ? 'archived' : readiness.ready ? 'ready' : 'incomplete',
+    readiness: effectiveReadiness,
+    status: row.is_archived ? 'archived' : effectiveReadiness.ready ? 'ready' : 'incomplete',
     archivedAt: row.archived_at ? String(row.archived_at) : null,
     consumers: consumerLabels,
   };
@@ -792,6 +807,7 @@ async function createMicrosoftProfileInternal(
     tenantId?: string;
     capabilities?: MicrosoftProfileConsumer[];
     setAsDefault?: boolean;
+    requiresEmailAdminConsent?: boolean;
   }
 ): Promise<{ success: boolean; error?: string; profile?: MicrosoftProfileSummary }> {
   if (isClientPortalUser(user)) return { success: false, error: 'Forbidden' };
@@ -843,6 +859,9 @@ async function createMicrosoftProfileInternal(
       client_id: clientId,
       tenant_id: tenantId,
       client_secret_ref: clientSecretRef,
+      email_admin_consent_required: input.requiresEmailAdminConsent === true,
+      email_admin_consent_granted_at: null,
+      email_admin_consent_tenant_id: null,
       capabilities,
       is_default: shouldBeDefault,
       is_archived: false,
@@ -920,7 +939,7 @@ async function createMicrosoftProfileInternal(
   }
 }
 
-export async function createAndBindMicrosoftEmailProfileInternal(
+export async function createMicrosoftEmailProfilePendingConsentInternal(
   user: any,
   tenant: string,
   input: {
@@ -938,59 +957,97 @@ export async function createAndBindMicrosoftEmailProfileInternal(
   const created = await createMicrosoftProfileInternal(user, tenant, {
     ...input,
     capabilities: ['email'],
+    requiresEmailAdminConsent: true,
   });
   if (!created.success || !created.profile) {
     return { success: false, error: created.error || 'Failed to create Microsoft email profile' };
   }
 
+  return {
+    success: true,
+    profileId: created.profile.profileId,
+    displayName: created.profile.displayName,
+  };
+}
+
+export async function confirmMicrosoftEmailAdminConsentInternal(
+  user: any,
+  tenant: string,
+  input: {
+    profileId: string;
+    clientId: string;
+    microsoftTenantId?: string;
+  }
+): Promise<{ success: boolean; error?: string; profileId?: string }> {
+  if (isClientPortalUser(user)) return { success: false, error: 'Forbidden' };
+  if (!(await canManageMicrosoftSettings(user))) return { success: false, error: 'Forbidden' };
+
   try {
     const { knex } = await createTenantKnex();
-    const db = tenantDb(knex, tenant);
     const now = new Date();
-    const existing = await db.table<MicrosoftConsumerBindingRow>('microsoft_profile_consumer_bindings')
-      .where({ consumer_type: 'email' })
-      .first();
 
-    if (existing) {
-      await db.table('microsoft_profile_consumer_bindings')
-        .where({ consumer_type: 'email' })
+    await knex.transaction(async (trx: any) => {
+      const db = tenantDb(trx, tenant);
+      const profile = await db.table<MicrosoftProfileRow>('microsoft_profiles')
+        .where({ profile_id: input.profileId })
+        .first();
+
+      if (!profile || profile.is_archived) {
+        throw new Error('The pending Microsoft Email profile no longer exists');
+      }
+      if (!profileHasCapability(profile, 'email')) {
+        throw new Error('The pending Microsoft profile is not enabled for Email');
+      }
+      if (normalizeMicrosoftClientId(profile.client_id) !== normalizeMicrosoftClientId(input.clientId)) {
+        throw new Error('Microsoft administrator consent was returned for a different application');
+      }
+
+      await db.table('microsoft_profiles')
+        .where({ profile_id: input.profileId })
         .update({
-          profile_id: created.profile.profileId,
+          email_admin_consent_required: true,
+          email_admin_consent_granted_at: now,
+          email_admin_consent_tenant_id: input.microsoftTenantId || null,
           updated_by: user?.user_id || null,
           updated_at: now,
         });
-    } else {
-      await db.table('microsoft_profile_consumer_bindings').insert({
-        tenant,
-        consumer_type: 'email',
-        profile_id: created.profile.profileId,
-        created_by: user?.user_id || null,
-        updated_by: user?.user_id || null,
-        created_at: now,
-        updated_at: now,
-      } satisfies MicrosoftConsumerBindingRow);
-    }
 
-    return {
-      success: true,
-      profileId: created.profile.profileId,
-      displayName: created.profile.displayName,
-    };
+      const existing = await db.table<MicrosoftConsumerBindingRow>('microsoft_profile_consumer_bindings')
+        .where({ consumer_type: 'email' })
+        .first();
+      if (existing) {
+        await db.table('microsoft_profile_consumer_bindings')
+          .where({ consumer_type: 'email' })
+          .update({
+            profile_id: input.profileId,
+            updated_by: user?.user_id || null,
+            updated_at: now,
+          });
+      } else {
+        await db.table('microsoft_profile_consumer_bindings').insert({
+          tenant,
+          consumer_type: 'email',
+          profile_id: input.profileId,
+          created_by: user?.user_id || null,
+          updated_by: user?.user_id || null,
+          created_at: now,
+          updated_at: now,
+        } satisfies MicrosoftConsumerBindingRow);
+      }
+    });
+
+    return { success: true, profileId: input.profileId };
   } catch (error) {
-    const { knex } = await createTenantKnex();
-    const secretProvider = await getSecretProviderInstance();
-    await tenantDb(knex, tenant)
-      .table('microsoft_profiles')
-      .where({ profile_id: created.profile.profileId })
-      .delete()
-      .catch(() => {});
-    await secretProvider
-      .setTenantSecret(tenant, created.profile.clientSecretRef, null)
-      .catch(() => {});
-
+    const expectedMessage = error instanceof Error && [
+      'The pending Microsoft Email profile no longer exists',
+      'The pending Microsoft profile is not enabled for Email',
+      'Microsoft administrator consent was returned for a different application',
+    ].includes(error.message)
+      ? error.message
+      : 'Failed to record Microsoft administrator consent';
     return {
       success: false,
-      error: microsoftActionErrorMessage(error, 'Failed to bind the new Microsoft profile to Email'),
+      error: microsoftActionErrorMessage(error, expectedMessage),
     };
   }
 }
@@ -1006,7 +1063,7 @@ export async function getMicrosoftEmailSetupMetadataInternal(): Promise<{
     baseUrl,
     mailboxRedirectUri: `${baseUrl}/api/auth/microsoft/callback`,
     setupRedirectUri: `${baseUrl}/api/auth/microsoft/email-setup/callback`,
-    returnTo: `${baseUrl}/msp/settings?category=providers`,
+    returnTo: `${baseUrl}/msp/settings/integrations?category=providers`,
   };
 }
 
@@ -1354,6 +1411,16 @@ export const setMicrosoftConsumerBinding = withAuth(async (
       return {
         success: false,
         error: `Microsoft profile is not enabled for ${getMicrosoftConsumerLabel(input.consumerType)}`,
+      };
+    }
+    if (
+      input.consumerType === 'email' &&
+      profile.email_admin_consent_required &&
+      !profile.email_admin_consent_granted_at
+    ) {
+      return {
+        success: false,
+        error: 'Microsoft tenant administrator consent must be recorded before binding this profile to Email',
       };
     }
 

--- a/packages/integrations/src/actions/integrations/microsoftActions.ts
+++ b/packages/integrations/src/actions/integrations/microsoftActions.ts
@@ -812,6 +812,10 @@ async function createMicrosoftProfileInternal(
   if (!clientSecret) return { success: false, error: 'Microsoft OAuth Client Secret is required' };
   if (!tenantIdProvided) return { success: false, error: 'Microsoft Tenant ID is required' };
 
+  let createdProfileId: string | null = null;
+  let createdSecretRef: string | null = null;
+  let previousDefaultProfileId: string | null = null;
+
   try {
     const { knex } = await createTenantKnex();
     const secretProvider = await getSecretProviderInstance();
@@ -826,6 +830,9 @@ async function createMicrosoftProfileInternal(
     const profileId = randomUUID();
     const clientSecretRef = getMicrosoftProfileSecretRef(profileId);
     const shouldBeDefault = input.setAsDefault === true || !existing.some((row) => row.is_default && !row.is_archived);
+    createdProfileId = profileId;
+    createdSecretRef = clientSecretRef;
+    previousDefaultProfileId = existing.find((row) => row.is_default && !row.is_archived)?.profile_id || null;
     const now = new Date();
 
     const row: MicrosoftProfileRow = {
@@ -872,8 +879,135 @@ async function createMicrosoftProfileInternal(
       profile: await buildMicrosoftProfileSummary(tenant, row, secretProvider),
     };
   } catch (err: any) {
+    if (createdProfileId && createdSecretRef) {
+      try {
+        const { knex } = await createTenantKnex();
+        const secretProvider = await getSecretProviderInstance();
+        await knex.transaction(async (trx: any) => {
+          const transactionDb = tenantDb(trx, tenant);
+          await transactionDb.table('microsoft_profile_consumer_bindings')
+            .where({ profile_id: createdProfileId })
+            .delete();
+          await transactionDb.table('microsoft_profiles')
+            .where({ profile_id: createdProfileId })
+            .delete();
+          if (previousDefaultProfileId) {
+            await transactionDb.table('microsoft_profiles')
+              .where({ profile_id: previousDefaultProfileId })
+              .update({ is_default: true, updated_at: new Date() });
+          }
+        });
+        await secretProvider.setTenantSecret(tenant, createdSecretRef, null);
+
+        const previousDefault = previousDefaultProfileId
+          ? await getMicrosoftProfileRow(knex, tenant, previousDefaultProfileId)
+          : undefined;
+        if (previousDefault) {
+          await mirrorLegacyMicrosoftSecrets(tenant, previousDefault, secretProvider);
+        } else {
+          await Promise.all([
+            secretProvider.setTenantSecret(tenant, MICROSOFT_CLIENT_ID_SECRET, null),
+            secretProvider.setTenantSecret(tenant, MICROSOFT_CLIENT_SECRET_SECRET, null),
+            secretProvider.setTenantSecret(tenant, MICROSOFT_TENANT_ID_SECRET, null),
+          ]);
+        }
+      } catch {
+        // Preserve the original error. A failed cleanup is surfaced by the
+        // incomplete profile state and can be retried or removed by an admin.
+      }
+    }
     return { success: false, error: microsoftActionErrorMessage(err, 'Failed to create Microsoft profile') };
   }
+}
+
+export async function createAndBindMicrosoftEmailProfileInternal(
+  user: any,
+  tenant: string,
+  input: {
+    displayName: string;
+    clientId: string;
+    clientSecret: string;
+    tenantId: string;
+  }
+): Promise<{
+  success: boolean;
+  error?: string;
+  profileId?: string;
+  displayName?: string;
+}> {
+  const created = await createMicrosoftProfileInternal(user, tenant, {
+    ...input,
+    capabilities: ['email'],
+  });
+  if (!created.success || !created.profile) {
+    return { success: false, error: created.error || 'Failed to create Microsoft email profile' };
+  }
+
+  try {
+    const { knex } = await createTenantKnex();
+    const db = tenantDb(knex, tenant);
+    const now = new Date();
+    const existing = await db.table<MicrosoftConsumerBindingRow>('microsoft_profile_consumer_bindings')
+      .where({ consumer_type: 'email' })
+      .first();
+
+    if (existing) {
+      await db.table('microsoft_profile_consumer_bindings')
+        .where({ consumer_type: 'email' })
+        .update({
+          profile_id: created.profile.profileId,
+          updated_by: user?.user_id || null,
+          updated_at: now,
+        });
+    } else {
+      await db.table('microsoft_profile_consumer_bindings').insert({
+        tenant,
+        consumer_type: 'email',
+        profile_id: created.profile.profileId,
+        created_by: user?.user_id || null,
+        updated_by: user?.user_id || null,
+        created_at: now,
+        updated_at: now,
+      } satisfies MicrosoftConsumerBindingRow);
+    }
+
+    return {
+      success: true,
+      profileId: created.profile.profileId,
+      displayName: created.profile.displayName,
+    };
+  } catch (error) {
+    const { knex } = await createTenantKnex();
+    const secretProvider = await getSecretProviderInstance();
+    await tenantDb(knex, tenant)
+      .table('microsoft_profiles')
+      .where({ profile_id: created.profile.profileId })
+      .delete()
+      .catch(() => {});
+    await secretProvider
+      .setTenantSecret(tenant, created.profile.clientSecretRef, null)
+      .catch(() => {});
+
+    return {
+      success: false,
+      error: microsoftActionErrorMessage(error, 'Failed to bind the new Microsoft profile to Email'),
+    };
+  }
+}
+
+export async function getMicrosoftEmailSetupMetadataInternal(): Promise<{
+  baseUrl: string;
+  mailboxRedirectUri: string;
+  setupRedirectUri: string;
+  returnTo: string;
+}> {
+  const baseUrl = await getDeploymentBaseUrl();
+  return {
+    baseUrl,
+    mailboxRedirectUri: `${baseUrl}/api/auth/microsoft/callback`,
+    setupRedirectUri: `${baseUrl}/api/auth/microsoft/email-setup/callback`,
+    returnTo: `${baseUrl}/msp/settings?category=providers`,
+  };
 }
 
 async function updateMicrosoftProfileInternal(

--- a/packages/integrations/src/actions/integrations/microsoftConsumerBindings.test.ts
+++ b/packages/integrations/src/actions/integrations/microsoftConsumerBindings.test.ts
@@ -298,7 +298,7 @@ describe('Microsoft consumer binding actions', () => {
     }
   });
 
-  it('returns only the CE-visible MSP SSO binding and materializes only migration-needed rows', async () => {
+  it('returns CE-visible MSP SSO and Email bindings while materializing only migration-needed rows', async () => {
     hoisted.state.mockCtx = { tenant: 'tenant-2' };
     tenantSecrets.set('tenant-2:microsoft_client_id', 'tenant-two-client');
     tenantSecrets.set('tenant-2:microsoft_client_secret', 'tenant-two-secret');
@@ -323,8 +323,17 @@ describe('Microsoft consumer binding actions', () => {
     const result = await listMicrosoftConsumerBindings();
 
     expect(result.success).toBe(true);
-    expect(result.bindings?.map((binding) => binding.consumerType)).toEqual(['msp_sso']);
-    expect(result.bindings?.every((binding) => binding.profileDisplayName === 'Default Microsoft Profile')).toBe(true);
+    expect(result.bindings?.map((binding) => binding.consumerType)).toEqual(['msp_sso', 'email']);
+    expect(result.bindings?.find((binding) => binding.consumerType === 'msp_sso')).toMatchObject({
+      profileDisplayName: 'Default Microsoft Profile',
+    });
+    expect(result.bindings?.find((binding) => binding.consumerType === 'email')).toEqual({
+      consumerType: 'email',
+      consumerLabel: 'Email',
+      profileId: null,
+      profileDisplayName: undefined,
+      isArchived: false,
+    });
     expect(microsoftConsumerBindings.filter((binding) => binding.tenant === 'tenant-1')).toEqual([
       expect.objectContaining({ consumer_type: 'msp_sso' }),
     ]);
@@ -604,7 +613,7 @@ describe('Microsoft consumer binding actions', () => {
     });
   });
 
-  it('rejects EE-only binding writes in CE while keeping MSP SSO available', async () => {
+  it('allows MSP SSO and Email binding writes in CE while rejecting EE-only consumers', async () => {
     const created = await createMicrosoftProfile({
       displayName: 'Primary Profile',
       clientId: 'primary-client-id',
@@ -625,14 +634,17 @@ describe('Microsoft consumer binding actions', () => {
       },
     });
 
-    await expect(
-      setMicrosoftConsumerBinding({
+    expect(
+      await setMicrosoftConsumerBinding({
         consumerType: 'email',
         profileId: created.profile!.profileId,
       })
-    ).resolves.toEqual({
-      success: false,
-      error: 'Microsoft consumer type is unavailable in this edition',
+    ).toMatchObject({
+      success: true,
+      binding: {
+        consumerType: 'email',
+        profileDisplayName: 'Primary Profile',
+      },
     });
 
     await expect(

--- a/packages/integrations/src/actions/integrations/microsoftEmailSetupActions.test.ts
+++ b/packages/integrations/src/actions/integrations/microsoftEmailSetupActions.test.ts
@@ -1,0 +1,221 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const hoisted = vi.hoisted(() => ({
+  user: { user_id: 'user-1', user_type: 'internal' } as any,
+  ctx: { tenant: 'alga-tenant-1' },
+  permission: true,
+  appSecrets: new Map<string, string>(),
+  consumeState: vi.fn(),
+  storeState: vi.fn(),
+  persistProfile: vi.fn(),
+  axiosPost: vi.fn(),
+  axiosRequest: vi.fn(),
+}));
+
+vi.mock('@alga-psa/auth/withAuth', () => ({
+  withAuth:
+    (action: (...args: any[]) => Promise<unknown>) =>
+    (...args: any[]) => action(hoisted.user, hoisted.ctx, ...args),
+}));
+
+vi.mock('@alga-psa/auth/rbac', () => ({
+  hasPermission: vi.fn(async () => hoisted.permission),
+}));
+
+vi.mock('@alga-psa/core/secrets', () => ({
+  getSecretProviderInstance: vi.fn(async () => ({
+    getAppSecret: async (name: string) => hoisted.appSecrets.get(name) || null,
+  })),
+}));
+
+vi.mock('../../utils/microsoftEmailSetupStateStore', () => ({
+  consumeMicrosoftEmailSetupState: (...args: unknown[]) => hoisted.consumeState(...args),
+  storeMicrosoftEmailSetupState: (...args: unknown[]) => hoisted.storeState(...args),
+}));
+
+vi.mock('./microsoftActions', () => ({
+  getMicrosoftEmailSetupMetadataInternal: vi.fn(async () => ({
+    baseUrl: 'https://psa.example.com',
+    mailboxRedirectUri: 'https://psa.example.com/api/auth/microsoft/callback',
+    setupRedirectUri: 'https://psa.example.com/api/auth/microsoft/email-setup/callback',
+    returnTo: 'https://psa.example.com/msp/settings?category=providers',
+  })),
+  createAndBindMicrosoftEmailProfileInternal: (...args: unknown[]) => hoisted.persistProfile(...args),
+}));
+
+vi.mock('axios', () => ({
+  default: {
+    post: (...args: unknown[]) => hoisted.axiosPost(...args),
+    request: (...args: unknown[]) => hoisted.axiosRequest(...args),
+    isAxiosError: (error: unknown) => Boolean((error as any)?.isAxiosError),
+  },
+}));
+
+import {
+  completeMicrosoftEmailApplicationCreation,
+  createMicrosoftEmailApplication,
+  getMicrosoftEmailSetupOptions,
+  configureMicrosoftEmailPlatformApplication,
+} from './microsoftEmailSetupActions';
+
+function jwt(payload: Record<string, unknown>): string {
+  return `${Buffer.from('{}').toString('base64url')}.${Buffer.from(JSON.stringify(payload)).toString('base64url')}.signature`;
+}
+
+describe('Microsoft email setup actions', () => {
+  beforeEach(() => {
+    hoisted.permission = true;
+    hoisted.appSecrets.clear();
+    hoisted.appSecrets.set('NEXTAUTH_SECRET', 'test-signing-secret');
+    hoisted.appSecrets.set('MICROSOFT_CLIENT_ID', 'platform-client-id');
+    hoisted.appSecrets.set('MICROSOFT_CLIENT_SECRET', 'platform-client-secret');
+    hoisted.consumeState.mockReset();
+    hoisted.storeState.mockReset().mockResolvedValue(undefined);
+    hoisted.persistProfile.mockReset().mockResolvedValue({
+      success: true,
+      profileId: 'profile-1',
+      displayName: 'Alga Email',
+    });
+    hoisted.axiosPost.mockReset();
+    hoisted.axiosRequest.mockReset();
+  });
+
+  it('guards setup metadata with system settings update permission', async () => {
+    hoisted.permission = false;
+    await expect(getMicrosoftEmailSetupOptions()).resolves.toEqual({ success: false, error: 'Forbidden' });
+  });
+
+  it('starts automated creation with one-time PKCE state and no verifier in the browser result', async () => {
+    const result = await createMicrosoftEmailApplication({ displayName: 'Alga Email' });
+
+    expect(result.success).toBe(true);
+    expect(result.authUrl).toContain('code_challenge_method=S256');
+    expect(result.authUrl).toContain('Application.ReadWrite.All');
+    expect(result).not.toHaveProperty('verifier');
+    expect(hoisted.storeState).toHaveBeenCalledOnce();
+    expect(hoisted.storeState.mock.calls[0][1]).toMatchObject({
+      algaTenant: 'alga-tenant-1',
+      userId: 'user-1',
+    });
+  });
+
+  it('stores the platform secret only through profile persistence and never returns it', async () => {
+    const result = await configureMicrosoftEmailPlatformApplication({
+      tenantId: '11111111-2222-4333-8444-555555555555',
+      displayName: 'Platform Email',
+    });
+
+    expect(hoisted.persistProfile).toHaveBeenCalledWith(
+      hoisted.user,
+      'alga-tenant-1',
+      expect.objectContaining({ clientSecret: 'platform-client-secret' })
+    );
+    expect(JSON.stringify(result)).not.toContain('platform-client-secret');
+    expect(result).toMatchObject({ success: true, profileId: 'profile-1' });
+  });
+
+  it('creates Graph objects, persists the generated secret server-side, and sanitizes the result', async () => {
+    const tenantId = '11111111-2222-4333-8444-555555555555';
+    hoisted.consumeState.mockResolvedValue({
+      verifier: 'pkce-verifier',
+      algaTenant: 'alga-tenant-1',
+      userId: 'user-1',
+      oauthNonce: 'oauth-nonce',
+    });
+    hoisted.axiosPost.mockResolvedValue({
+      data: {
+        access_token: jwt({
+          tid: tenantId,
+          iss: `https://login.microsoftonline.com/${tenantId}/v2.0`,
+          scp: 'Application.ReadWrite.All',
+        }),
+        id_token: jwt({ nonce: 'oauth-nonce' }),
+      },
+    });
+    hoisted.axiosRequest
+      .mockResolvedValueOnce({ data: { id: 'application-object-id', appId: 'new-client-id', displayName: 'Alga Email' } })
+      .mockResolvedValueOnce({ data: { id: 'service-principal-id', appId: 'new-client-id' } })
+      .mockResolvedValueOnce({ data: { secretText: 'generated-secret-value' } });
+
+    const result = await completeMicrosoftEmailApplicationCreation({
+      user: hoisted.user,
+      code: 'authorization-code',
+      state: {
+        purpose: 'create_application',
+        algaTenant: 'alga-tenant-1',
+        userId: 'user-1',
+        returnTo: 'https://psa.example.com/msp/settings?category=providers',
+        nonce: 'state-nonce',
+        oauthNonce: 'oauth-nonce',
+        displayName: 'Alga Email',
+        issuedAt: 1,
+        expiresAt: 2,
+      },
+    });
+
+    expect(hoisted.axiosRequest.mock.calls.map(([request]) => request.url)).toEqual([
+      'https://graph.microsoft.com/v1.0/applications',
+      'https://graph.microsoft.com/v1.0/servicePrincipals',
+      'https://graph.microsoft.com/v1.0/applications/application-object-id/addPassword',
+    ]);
+    expect(hoisted.persistProfile).toHaveBeenCalledWith(
+      hoisted.user,
+      'alga-tenant-1',
+      expect.objectContaining({
+        clientId: 'new-client-id',
+        clientSecret: 'generated-secret-value',
+        tenantId,
+      })
+    );
+    expect(result).toMatchObject({ success: true, profileId: 'profile-1', clientId: 'new-client-id', tenantId });
+    expect(JSON.stringify(result)).not.toContain('generated-secret-value');
+    expect(JSON.stringify(result)).not.toContain('access_token');
+  });
+
+  it('consumes setup state once and performs compensating Graph cleanup after a partial failure', async () => {
+    const tenantId = '11111111-2222-4333-8444-555555555555';
+    hoisted.consumeState.mockResolvedValue({
+      verifier: 'pkce-verifier',
+      algaTenant: 'alga-tenant-1',
+      userId: 'user-1',
+      oauthNonce: 'oauth-nonce',
+    });
+    hoisted.axiosPost.mockResolvedValue({
+      data: {
+        access_token: jwt({ tid: tenantId, iss: `https://sts.windows.net/${tenantId}/`, scp: 'Application.ReadWrite.All' }),
+        id_token: jwt({ nonce: 'oauth-nonce' }),
+      },
+    });
+    hoisted.axiosRequest
+      .mockResolvedValueOnce({ data: { id: 'application-object-id', appId: 'new-client-id', displayName: 'Alga Email' } })
+      .mockRejectedValueOnce({ isAxiosError: true, response: { status: 403, data: { error: { code: 'Authorization_RequestDenied' } } } })
+      .mockResolvedValueOnce({ data: undefined });
+
+    const state = {
+      purpose: 'create_application' as const,
+      algaTenant: 'alga-tenant-1',
+      userId: 'user-1',
+      returnTo: 'https://psa.example.com/msp/settings?category=providers',
+      nonce: 'state-nonce',
+      oauthNonce: 'oauth-nonce',
+      displayName: 'Alga Email',
+      issuedAt: 1,
+      expiresAt: 2,
+    };
+    const result = await completeMicrosoftEmailApplicationCreation({ user: hoisted.user, code: 'code', state });
+
+    expect(result.success).toBe(false);
+    expect(result.error).toContain('Microsoft denied permission');
+    expect(hoisted.axiosRequest.mock.calls.at(-1)?.[0]).toMatchObject({
+      method: 'DELETE',
+      url: 'https://graph.microsoft.com/v1.0/applications/application-object-id',
+    });
+
+    hoisted.consumeState.mockResolvedValueOnce(null);
+    await expect(completeMicrosoftEmailApplicationCreation({ user: hoisted.user, code: 'code', state }))
+      .resolves.toEqual({
+        success: false,
+        error: 'This Microsoft setup request is invalid, expired, or has already been used.',
+      });
+  });
+});

--- a/packages/integrations/src/actions/integrations/microsoftEmailSetupActions.test.ts
+++ b/packages/integrations/src/actions/integrations/microsoftEmailSetupActions.test.ts
@@ -1,4 +1,7 @@
-import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+const originalGraphBaseUrl = process.env.MICROSOFT_GRAPH_BASE_URL;
+const originalLoginBaseUrl = process.env.MICROSOFT_LOGIN_BASE_URL;
 
 const hoisted = vi.hoisted(() => ({
   user: { user_id: 'user-1', user_type: 'internal' } as any,
@@ -38,9 +41,9 @@ vi.mock('./microsoftActions', () => ({
     baseUrl: 'https://psa.example.com',
     mailboxRedirectUri: 'https://psa.example.com/api/auth/microsoft/callback',
     setupRedirectUri: 'https://psa.example.com/api/auth/microsoft/email-setup/callback',
-    returnTo: 'https://psa.example.com/msp/settings?category=providers',
+    returnTo: 'https://psa.example.com/msp/settings/integrations?category=providers',
   })),
-  createAndBindMicrosoftEmailProfileInternal: (...args: unknown[]) => hoisted.persistProfile(...args),
+  createMicrosoftEmailProfilePendingConsentInternal: (...args: unknown[]) => hoisted.persistProfile(...args),
 }));
 
 vi.mock('axios', () => ({
@@ -80,6 +83,13 @@ describe('Microsoft email setup actions', () => {
     hoisted.axiosRequest.mockReset();
   });
 
+  afterEach(() => {
+    if (originalGraphBaseUrl === undefined) delete process.env.MICROSOFT_GRAPH_BASE_URL;
+    else process.env.MICROSOFT_GRAPH_BASE_URL = originalGraphBaseUrl;
+    if (originalLoginBaseUrl === undefined) delete process.env.MICROSOFT_LOGIN_BASE_URL;
+    else process.env.MICROSOFT_LOGIN_BASE_URL = originalLoginBaseUrl;
+  });
+
   it('guards setup metadata with system settings update permission', async () => {
     hoisted.permission = false;
     await expect(getMicrosoftEmailSetupOptions()).resolves.toEqual({ success: false, error: 'Forbidden' });
@@ -115,6 +125,8 @@ describe('Microsoft email setup actions', () => {
   });
 
   it('creates Graph objects, persists the generated secret server-side, and sanitizes the result', async () => {
+    process.env.MICROSOFT_GRAPH_BASE_URL = 'http://graph-emulator:4010/v1.0/';
+    process.env.MICROSOFT_LOGIN_BASE_URL = 'http://graph-emulator:4010/';
     const tenantId = '11111111-2222-4333-8444-555555555555';
     hoisted.consumeState.mockResolvedValue({
       verifier: 'pkce-verifier',
@@ -144,7 +156,7 @@ describe('Microsoft email setup actions', () => {
         purpose: 'create_application',
         algaTenant: 'alga-tenant-1',
         userId: 'user-1',
-        returnTo: 'https://psa.example.com/msp/settings?category=providers',
+        returnTo: 'https://psa.example.com/msp/settings/integrations?category=providers',
         nonce: 'state-nonce',
         oauthNonce: 'oauth-nonce',
         displayName: 'Alga Email',
@@ -153,10 +165,13 @@ describe('Microsoft email setup actions', () => {
       },
     });
 
+    expect(hoisted.axiosPost.mock.calls[0][0]).toBe(
+      'http://graph-emulator:4010/common/oauth2/v2.0/token'
+    );
     expect(hoisted.axiosRequest.mock.calls.map(([request]) => request.url)).toEqual([
-      'https://graph.microsoft.com/v1.0/applications',
-      'https://graph.microsoft.com/v1.0/servicePrincipals',
-      'https://graph.microsoft.com/v1.0/applications/application-object-id/addPassword',
+      'http://graph-emulator:4010/v1.0/applications',
+      'http://graph-emulator:4010/v1.0/servicePrincipals',
+      'http://graph-emulator:4010/v1.0/applications/application-object-id/addPassword',
     ]);
     expect(hoisted.persistProfile).toHaveBeenCalledWith(
       hoisted.user,
@@ -195,7 +210,7 @@ describe('Microsoft email setup actions', () => {
       purpose: 'create_application' as const,
       algaTenant: 'alga-tenant-1',
       userId: 'user-1',
-      returnTo: 'https://psa.example.com/msp/settings?category=providers',
+      returnTo: 'https://psa.example.com/msp/settings/integrations?category=providers',
       nonce: 'state-nonce',
       oauthNonce: 'oauth-nonce',
       displayName: 'Alga Email',

--- a/packages/integrations/src/actions/integrations/microsoftEmailSetupActions.ts
+++ b/packages/integrations/src/actions/integrations/microsoftEmailSetupActions.ts
@@ -1,0 +1,553 @@
+'use server';
+
+import axios, { type AxiosError } from 'axios';
+import { getSecretProviderInstance } from '@alga-psa/core/secrets';
+import { withAuth } from '@alga-psa/auth/withAuth';
+import { hasPermission } from '@alga-psa/auth/rbac';
+import {
+  buildMicrosoftEmailAdminConsentUrl,
+  buildMicrosoftEmailApplicationManifest,
+  createMicrosoftEmailSetupState,
+  createPkcePair,
+  decodeJwtPayload,
+  MICROSOFT_EMAIL_SETUP_BOOTSTRAP_SCOPES,
+  type MicrosoftEmailSetupStatePayload,
+  validateMicrosoftTenantIdentifier,
+} from '../../lib/microsoftEmailSetup';
+import {
+  consumeMicrosoftEmailSetupState,
+  storeMicrosoftEmailSetupState,
+} from '../../utils/microsoftEmailSetupStateStore';
+import {
+  createAndBindMicrosoftEmailProfileInternal,
+  getMicrosoftEmailSetupMetadataInternal,
+} from './microsoftActions';
+
+const GRAPH_BASE_URL = 'https://graph.microsoft.com/v1.0';
+
+interface PlatformMicrosoftCredentials {
+  clientId: string;
+  clientSecret: string;
+  tenantId: string;
+}
+
+interface BootstrapMicrosoftCredentials {
+  clientId: string;
+  clientSecret?: string;
+}
+
+interface GraphApplicationResult {
+  id: string;
+  appId: string;
+  displayName: string;
+}
+
+interface GraphServicePrincipalResult {
+  id: string;
+  appId: string;
+}
+
+interface GraphPasswordResult {
+  secretText: string;
+}
+
+export interface MicrosoftEmailSetupOptionsResult {
+  success: boolean;
+  error?: string;
+  callbackUri?: string;
+  setupCallbackUri?: string;
+  platformApplication?: {
+    available: boolean;
+    clientId?: string;
+  };
+  automatedCreationAvailable?: boolean;
+}
+
+export interface MicrosoftEmailSetupCompletionResult {
+  success: boolean;
+  error?: string;
+  profileId?: string;
+  displayName?: string;
+  tenantId?: string;
+  clientId?: string;
+  adminConsentUrl?: string;
+}
+
+function isClientPortalUser(user: any): boolean {
+  return user?.user_type === 'client';
+}
+
+async function canManageMicrosoftSettings(user: any): Promise<boolean> {
+  return !isClientPortalUser(user) && hasPermission(user as any, 'system_settings', 'update');
+}
+
+async function getAppSecret(name: string): Promise<string | null> {
+  const secretProvider = await getSecretProviderInstance();
+  return ((await secretProvider.getAppSecret(name)) || process.env[name] || '').trim() || null;
+}
+
+async function resolvePlatformMicrosoftCredentials(): Promise<PlatformMicrosoftCredentials | null> {
+  const [clientId, clientSecret, tenantId] = await Promise.all([
+    getAppSecret('MICROSOFT_CLIENT_ID'),
+    getAppSecret('MICROSOFT_CLIENT_SECRET'),
+    getAppSecret('MICROSOFT_TENANT_ID'),
+  ]);
+  if (!clientId || !clientSecret) return null;
+  return { clientId, clientSecret, tenantId: tenantId || 'common' };
+}
+
+async function resolveBootstrapMicrosoftCredentials(): Promise<BootstrapMicrosoftCredentials | null> {
+  const [setupClientId, setupClientSecret, platformClientId, platformClientSecret] = await Promise.all([
+    getAppSecret('MICROSOFT_EMAIL_SETUP_CLIENT_ID'),
+    getAppSecret('MICROSOFT_EMAIL_SETUP_CLIENT_SECRET'),
+    getAppSecret('MICROSOFT_CLIENT_ID'),
+    getAppSecret('MICROSOFT_CLIENT_SECRET'),
+  ]);
+  const clientId = setupClientId || platformClientId;
+  if (!clientId) return null;
+  return {
+    clientId,
+    clientSecret: setupClientSecret || platformClientSecret || undefined,
+  };
+}
+
+export async function getMicrosoftEmailSetupSigningSecret(): Promise<string | null> {
+  return getAppSecret('NEXTAUTH_SECRET');
+}
+
+function buildBootstrapAuthorizationUrl(input: {
+  clientId: string;
+  redirectUri: string;
+  state: string;
+  nonce: string;
+  challenge: string;
+}): string {
+  const params = new URLSearchParams({
+    client_id: input.clientId,
+    response_type: 'code',
+    redirect_uri: input.redirectUri,
+    response_mode: 'query',
+    scope: MICROSOFT_EMAIL_SETUP_BOOTSTRAP_SCOPES.join(' '),
+    state: input.state,
+    nonce: input.nonce,
+    code_challenge: input.challenge,
+    code_challenge_method: 'S256',
+    prompt: 'select_account',
+  });
+  return `https://login.microsoftonline.com/common/oauth2/v2.0/authorize?${params.toString()}`;
+}
+
+function getGraphErrorMessage(error: unknown, operation: string): string {
+  const axiosError = error as AxiosError<{ error?: { code?: string } }>;
+  const status = axiosError.response?.status;
+  const code = axiosError.response?.data?.error?.code;
+  if (status === 401 || status === 403) {
+    return `Microsoft denied permission to ${operation}. Sign in with an Application Administrator, Cloud Application Administrator, or another account allowed to manage app registrations.`;
+  }
+  if (status === 409) {
+    return `Microsoft reported a conflict while trying to ${operation}. Choose a different app name and retry.`;
+  }
+  return `Microsoft Graph could not ${operation}${code ? ` (${code})` : ''}. Retry, or use the platform/manual setup option.`;
+}
+
+async function graphRequest<T>(input: {
+  method: 'POST' | 'DELETE';
+  path: string;
+  accessToken: string;
+  body?: unknown;
+}): Promise<T> {
+  const response = await axios.request<T>({
+    method: input.method,
+    url: `${GRAPH_BASE_URL}${input.path}`,
+    headers: {
+      Authorization: `Bearer ${input.accessToken}`,
+      Accept: 'application/json',
+      ...(input.body ? { 'Content-Type': 'application/json' } : {}),
+    },
+    data: input.body,
+    timeout: 20_000,
+  });
+  return response.data;
+}
+
+async function cleanupGraphObjects(input: {
+  accessToken: string;
+  applicationObjectId?: string;
+  servicePrincipalObjectId?: string;
+}): Promise<string[]> {
+  const remaining: string[] = [];
+  if (input.servicePrincipalObjectId) {
+    try {
+      await graphRequest<void>({
+        method: 'DELETE',
+        path: `/servicePrincipals/${encodeURIComponent(input.servicePrincipalObjectId)}`,
+        accessToken: input.accessToken,
+      });
+    } catch {
+      remaining.push('service principal');
+    }
+  }
+  if (input.applicationObjectId) {
+    try {
+      await graphRequest<void>({
+        method: 'DELETE',
+        path: `/applications/${encodeURIComponent(input.applicationObjectId)}`,
+        accessToken: input.accessToken,
+      });
+    } catch {
+      remaining.push('application registration');
+    }
+  }
+  return remaining;
+}
+
+function assertMicrosoftTokenClaims(input: {
+  accessToken: string;
+  idToken: string;
+  expectedNonce: string;
+}): { tenantId: string } {
+  const accessClaims = decodeJwtPayload(input.accessToken);
+  const idClaims = decodeJwtPayload(input.idToken);
+  const tenantId = typeof accessClaims?.tid === 'string' ? accessClaims.tid : '';
+  const issuer = typeof accessClaims?.iss === 'string' ? accessClaims.iss : '';
+  const scope = typeof accessClaims?.scp === 'string' ? accessClaims.scp.split(' ') : [];
+  const nonce = typeof idClaims?.nonce === 'string' ? idClaims.nonce : '';
+
+  validateMicrosoftTenantIdentifier(tenantId);
+  const acceptedIssuers = new Set([
+    `https://sts.windows.net/${tenantId}/`,
+    `https://login.microsoftonline.com/${tenantId}/v2.0`,
+  ]);
+  if (!acceptedIssuers.has(issuer)) {
+    throw new Error('Microsoft returned a token for an unexpected issuer');
+  }
+  if (nonce !== input.expectedNonce) {
+    throw new Error('Microsoft sign-in nonce did not match the setup request');
+  }
+  if (!scope.some((value) => value.toLowerCase() === 'application.readwrite.all')) {
+    throw new Error('Microsoft did not grant Application.ReadWrite.All for app registration setup');
+  }
+  return { tenantId };
+}
+
+function createAdminConsentState(input: {
+  algaTenant: string;
+  userId: string;
+  returnTo: string;
+  clientId: string;
+  secret: string;
+}) {
+  return createMicrosoftEmailSetupState({
+    purpose: 'admin_consent',
+    algaTenant: input.algaTenant,
+    userId: input.userId,
+    returnTo: input.returnTo,
+    clientId: input.clientId,
+    secret: input.secret,
+  });
+}
+
+export const getMicrosoftEmailSetupOptions = withAuth(async (
+  user
+): Promise<MicrosoftEmailSetupOptionsResult> => {
+  if (!(await canManageMicrosoftSettings(user))) return { success: false, error: 'Forbidden' };
+  const [metadata, platformCredentials, bootstrapCredentials, signingSecret] = await Promise.all([
+    getMicrosoftEmailSetupMetadataInternal(),
+    resolvePlatformMicrosoftCredentials(),
+    resolveBootstrapMicrosoftCredentials(),
+    getMicrosoftEmailSetupSigningSecret(),
+  ]);
+  return {
+    success: true,
+    callbackUri: metadata.mailboxRedirectUri,
+    setupCallbackUri: metadata.setupRedirectUri,
+    platformApplication: {
+      available: Boolean(platformCredentials),
+      clientId: platformCredentials?.clientId,
+    },
+    automatedCreationAvailable: Boolean(bootstrapCredentials && signingSecret),
+  };
+});
+
+export const getMicrosoftEmailAdminConsentUrl = withAuth(async (
+  user,
+  { tenant },
+  tenantHint: string
+): Promise<{ success: boolean; error?: string; url?: string }> => {
+  if (!(await canManageMicrosoftSettings(user))) return { success: false, error: 'Forbidden' };
+  try {
+    const [credentials, metadata, secret] = await Promise.all([
+      resolvePlatformMicrosoftCredentials(),
+      getMicrosoftEmailSetupMetadataInternal(),
+      getMicrosoftEmailSetupSigningSecret(),
+    ]);
+    if (!credentials) return { success: false, error: 'The Alga platform Microsoft app is not configured.' };
+    if (!secret) return { success: false, error: 'OAuth state signing is not configured on this server.' };
+    const microsoftTenant = validateMicrosoftTenantIdentifier(tenantHint);
+    const setupState = createAdminConsentState({
+      algaTenant: tenant,
+      userId: (user as any).user_id,
+      returnTo: metadata.returnTo,
+      clientId: credentials.clientId,
+      secret,
+    });
+    return {
+      success: true,
+      url: buildMicrosoftEmailAdminConsentUrl({
+        tenant: microsoftTenant,
+        clientId: credentials.clientId,
+        redirectUri: metadata.setupRedirectUri,
+        state: setupState.token,
+      }),
+    };
+  } catch (error) {
+    return { success: false, error: error instanceof Error ? error.message : 'Failed to build admin consent URL' };
+  }
+});
+
+export const configureMicrosoftEmailPlatformApplication = withAuth(async (
+  user,
+  { tenant },
+  input: { tenantId: string; displayName?: string }
+): Promise<MicrosoftEmailSetupCompletionResult> => {
+  if (!(await canManageMicrosoftSettings(user))) return { success: false, error: 'Forbidden' };
+  try {
+    const [credentials, metadata, secret] = await Promise.all([
+      resolvePlatformMicrosoftCredentials(),
+      getMicrosoftEmailSetupMetadataInternal(),
+      getMicrosoftEmailSetupSigningSecret(),
+    ]);
+    if (!credentials) return { success: false, error: 'The Alga platform Microsoft app is not configured.' };
+    if (!secret) return { success: false, error: 'OAuth state signing is not configured on this server.' };
+    const microsoftTenant = validateMicrosoftTenantIdentifier(input.tenantId);
+    const profile = await createAndBindMicrosoftEmailProfileInternal(user, tenant, {
+      displayName: input.displayName?.trim() || 'Alga platform Microsoft Email',
+      clientId: credentials.clientId,
+      clientSecret: credentials.clientSecret,
+      tenantId: microsoftTenant,
+    });
+    if (!profile.success) return profile;
+
+    const setupState = createAdminConsentState({
+      algaTenant: tenant,
+      userId: (user as any).user_id,
+      returnTo: metadata.returnTo,
+      clientId: credentials.clientId,
+      secret,
+    });
+    return {
+      success: true,
+      profileId: profile.profileId,
+      displayName: profile.displayName,
+      tenantId: microsoftTenant,
+      clientId: credentials.clientId,
+      adminConsentUrl: buildMicrosoftEmailAdminConsentUrl({
+        tenant: microsoftTenant,
+        clientId: credentials.clientId,
+        redirectUri: metadata.setupRedirectUri,
+        state: setupState.token,
+      }),
+    };
+  } catch (error) {
+    return { success: false, error: error instanceof Error ? error.message : 'Failed to configure the platform Microsoft app' };
+  }
+});
+
+export const createMicrosoftEmailApplication = withAuth(async (
+  user,
+  { tenant },
+  input: { displayName: string }
+): Promise<{ success: boolean; error?: string; authUrl?: string }> => {
+  if (!(await canManageMicrosoftSettings(user))) return { success: false, error: 'Forbidden' };
+  try {
+    const displayName = input.displayName.normalize('NFKC').replace(/\s+/g, ' ').trim();
+    if (!displayName) return { success: false, error: 'Microsoft application display name is required' };
+    const [credentials, metadata, secret] = await Promise.all([
+      resolveBootstrapMicrosoftCredentials(),
+      getMicrosoftEmailSetupMetadataInternal(),
+      getMicrosoftEmailSetupSigningSecret(),
+    ]);
+    if (!credentials) {
+      return { success: false, error: 'Automated app creation is not configured on this server. Use the platform or manual option.' };
+    }
+    if (!secret) return { success: false, error: 'OAuth state signing is not configured on this server.' };
+
+    const state = createMicrosoftEmailSetupState({
+      purpose: 'create_application',
+      algaTenant: tenant,
+      userId: (user as any).user_id,
+      returnTo: metadata.returnTo,
+      displayName,
+      includeOauthNonce: true,
+      secret,
+    });
+    const oauthNonce = state.payload.oauthNonce;
+    if (!oauthNonce) {
+      return { success: false, error: 'Failed to generate Microsoft OAuth nonce.' };
+    }
+    const pkce = createPkcePair();
+    await storeMicrosoftEmailSetupState(state.payload.nonce, {
+      verifier: pkce.verifier,
+      algaTenant: tenant,
+      userId: (user as any).user_id,
+      oauthNonce,
+    });
+    return {
+      success: true,
+      authUrl: buildBootstrapAuthorizationUrl({
+        clientId: credentials.clientId,
+        redirectUri: metadata.setupRedirectUri,
+        state: state.token,
+        nonce: oauthNonce,
+        challenge: pkce.challenge,
+      }),
+    };
+  } catch (error) {
+    return { success: false, error: error instanceof Error ? error.message : 'Failed to start Microsoft app creation' };
+  }
+});
+
+export async function completeMicrosoftEmailApplicationCreation(input: {
+  user: any;
+  state: MicrosoftEmailSetupStatePayload;
+  code: string;
+}): Promise<MicrosoftEmailSetupCompletionResult> {
+  if (!(await canManageMicrosoftSettings(input.user))) return { success: false, error: 'Forbidden' };
+  const stored = await consumeMicrosoftEmailSetupState(input.state.nonce);
+  if (
+    !stored ||
+    stored.algaTenant !== input.state.algaTenant ||
+    stored.userId !== input.state.userId ||
+    stored.oauthNonce !== input.state.oauthNonce
+  ) {
+    return { success: false, error: 'This Microsoft setup request is invalid, expired, or has already been used.' };
+  }
+
+  const [credentials, metadata, secret] = await Promise.all([
+    resolveBootstrapMicrosoftCredentials(),
+    getMicrosoftEmailSetupMetadataInternal(),
+    getMicrosoftEmailSetupSigningSecret(),
+  ]);
+  if (!credentials || !secret) {
+    return { success: false, error: 'Microsoft automated setup configuration is no longer available.' };
+  }
+
+  let accessToken = '';
+  let application: GraphApplicationResult | undefined;
+  let servicePrincipal: GraphServicePrincipalResult | undefined;
+  try {
+    const tokenParams = new URLSearchParams({
+      client_id: credentials.clientId,
+      grant_type: 'authorization_code',
+      code: input.code,
+      redirect_uri: metadata.setupRedirectUri,
+      code_verifier: stored.verifier,
+      scope: MICROSOFT_EMAIL_SETUP_BOOTSTRAP_SCOPES.join(' '),
+      ...(credentials.clientSecret ? { client_secret: credentials.clientSecret } : {}),
+    });
+    const tokenResponse = await axios.post<{
+      access_token?: string;
+      id_token?: string;
+    }>('https://login.microsoftonline.com/common/oauth2/v2.0/token', tokenParams.toString(), {
+      headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+      timeout: 20_000,
+    });
+    accessToken = tokenResponse.data.access_token || '';
+    const idToken = tokenResponse.data.id_token || '';
+    if (!accessToken || !idToken) throw new Error('Microsoft did not return the required setup tokens');
+    const { tenantId } = assertMicrosoftTokenClaims({
+      accessToken,
+      idToken,
+      expectedNonce: stored.oauthNonce,
+    });
+
+    application = await graphRequest<GraphApplicationResult>({
+      method: 'POST',
+      path: '/applications',
+      accessToken,
+      body: buildMicrosoftEmailApplicationManifest({
+        displayName: input.state.displayName || 'Alga PSA Microsoft Email',
+        mailboxRedirectUri: metadata.mailboxRedirectUri,
+        setupRedirectUri: metadata.setupRedirectUri,
+      }),
+    });
+    servicePrincipal = await graphRequest<GraphServicePrincipalResult>({
+      method: 'POST',
+      path: '/servicePrincipals',
+      accessToken,
+      body: { appId: application.appId },
+    });
+    const password = await graphRequest<GraphPasswordResult>({
+      method: 'POST',
+      path: `/applications/${encodeURIComponent(application.id)}/addPassword`,
+      accessToken,
+      body: {
+        passwordCredential: {
+          displayName: 'Alga PSA email client secret',
+          endDateTime: new Date(Date.now() + 730 * 24 * 60 * 60 * 1000).toISOString(),
+        },
+      },
+    });
+    if (!password.secretText) throw new Error('Microsoft did not return the generated client secret');
+
+    const consentState = createAdminConsentState({
+      algaTenant: input.state.algaTenant,
+      userId: input.state.userId,
+      returnTo: input.state.returnTo,
+      clientId: application.appId,
+      secret,
+    });
+    const adminConsentUrl = buildMicrosoftEmailAdminConsentUrl({
+      tenant: tenantId,
+      clientId: application.appId,
+      redirectUri: metadata.setupRedirectUri,
+      state: consentState.token,
+    });
+
+    const profile = await createAndBindMicrosoftEmailProfileInternal(
+      input.user,
+      input.state.algaTenant,
+      {
+        displayName: application.displayName,
+        clientId: application.appId,
+        clientSecret: password.secretText,
+        tenantId,
+      }
+    );
+    if (!profile.success) {
+      throw new Error(profile.error || 'Failed to store the new Microsoft profile');
+    }
+    return {
+      success: true,
+      profileId: profile.profileId,
+      displayName: profile.displayName,
+      tenantId,
+      clientId: application.appId,
+      adminConsentUrl,
+    };
+  } catch (error) {
+    const remaining = accessToken
+      ? await cleanupGraphObjects({
+          accessToken,
+          applicationObjectId: application?.id,
+          servicePrincipalObjectId: servicePrincipal?.id,
+        })
+      : [];
+    const baseMessage = axios.isAxiosError(error)
+      ? getGraphErrorMessage(
+          error,
+          !application ? 'create the application' : !servicePrincipal ? 'create the service principal' : 'finish application setup'
+        )
+      : error instanceof Error
+        ? error.message
+        : 'Microsoft application setup failed';
+    return {
+      success: false,
+      error: remaining.length
+        ? `${baseMessage} Cleanup could not remove the ${remaining.join(' and ')}; review the tenant in Microsoft Entra.`
+        : baseMessage,
+    };
+  } finally {
+    accessToken = '';
+  }
+}

--- a/packages/integrations/src/actions/integrations/microsoftEmailSetupActions.ts
+++ b/packages/integrations/src/actions/integrations/microsoftEmailSetupActions.ts
@@ -5,6 +5,12 @@ import { getSecretProviderInstance } from '@alga-psa/core/secrets';
 import { withAuth } from '@alga-psa/auth/withAuth';
 import { hasPermission } from '@alga-psa/auth/rbac';
 import {
+  getMicrosoftAuthorizeUrl,
+  getMicrosoftGraphBaseUrl,
+  getMicrosoftLoginBaseUrl,
+  getMicrosoftTokenUrl,
+} from '@alga-psa/shared/services/email/microsoftGraphEndpoints';
+import {
   buildMicrosoftEmailAdminConsentUrl,
   buildMicrosoftEmailApplicationManifest,
   createMicrosoftEmailSetupState,
@@ -19,11 +25,9 @@ import {
   storeMicrosoftEmailSetupState,
 } from '../../utils/microsoftEmailSetupStateStore';
 import {
-  createAndBindMicrosoftEmailProfileInternal,
+  createMicrosoftEmailProfilePendingConsentInternal,
   getMicrosoftEmailSetupMetadataInternal,
 } from './microsoftActions';
-
-const GRAPH_BASE_URL = 'https://graph.microsoft.com/v1.0';
 
 interface PlatformMicrosoftCredentials {
   clientId: string;
@@ -134,7 +138,7 @@ function buildBootstrapAuthorizationUrl(input: {
     code_challenge_method: 'S256',
     prompt: 'select_account',
   });
-  return `https://login.microsoftonline.com/common/oauth2/v2.0/authorize?${params.toString()}`;
+  return `${getMicrosoftAuthorizeUrl('common')}?${params.toString()}`;
 }
 
 function getGraphErrorMessage(error: unknown, operation: string): string {
@@ -158,7 +162,7 @@ async function graphRequest<T>(input: {
 }): Promise<T> {
   const response = await axios.request<T>({
     method: input.method,
-    url: `${GRAPH_BASE_URL}${input.path}`,
+    url: `${getMicrosoftGraphBaseUrl()}${input.path}`,
     headers: {
       Authorization: `Bearer ${input.accessToken}`,
       Accept: 'application/json',
@@ -235,6 +239,7 @@ function createAdminConsentState(input: {
   userId: string;
   returnTo: string;
   clientId: string;
+  profileId: string;
   secret: string;
 }) {
   return createMicrosoftEmailSetupState({
@@ -243,6 +248,7 @@ function createAdminConsentState(input: {
     userId: input.userId,
     returnTo: input.returnTo,
     clientId: input.clientId,
+    profileId: input.profileId,
     secret: input.secret,
   });
 }
@@ -272,7 +278,7 @@ export const getMicrosoftEmailSetupOptions = withAuth(async (
 export const getMicrosoftEmailAdminConsentUrl = withAuth(async (
   user,
   { tenant },
-  tenantHint: string
+  input: { tenantHint: string; profileId: string }
 ): Promise<{ success: boolean; error?: string; url?: string }> => {
   if (!(await canManageMicrosoftSettings(user))) return { success: false, error: 'Forbidden' };
   try {
@@ -283,12 +289,13 @@ export const getMicrosoftEmailAdminConsentUrl = withAuth(async (
     ]);
     if (!credentials) return { success: false, error: 'The Alga platform Microsoft app is not configured.' };
     if (!secret) return { success: false, error: 'OAuth state signing is not configured on this server.' };
-    const microsoftTenant = validateMicrosoftTenantIdentifier(tenantHint);
+    const microsoftTenant = validateMicrosoftTenantIdentifier(input.tenantHint);
     const setupState = createAdminConsentState({
       algaTenant: tenant,
       userId: (user as any).user_id,
       returnTo: metadata.returnTo,
       clientId: credentials.clientId,
+      profileId: input.profileId,
       secret,
     });
     return {
@@ -298,6 +305,7 @@ export const getMicrosoftEmailAdminConsentUrl = withAuth(async (
         clientId: credentials.clientId,
         redirectUri: metadata.setupRedirectUri,
         state: setupState.token,
+        loginBaseUrl: getMicrosoftLoginBaseUrl(),
       }),
     };
   } catch (error) {
@@ -320,7 +328,7 @@ export const configureMicrosoftEmailPlatformApplication = withAuth(async (
     if (!credentials) return { success: false, error: 'The Alga platform Microsoft app is not configured.' };
     if (!secret) return { success: false, error: 'OAuth state signing is not configured on this server.' };
     const microsoftTenant = validateMicrosoftTenantIdentifier(input.tenantId);
-    const profile = await createAndBindMicrosoftEmailProfileInternal(user, tenant, {
+    const profile = await createMicrosoftEmailProfilePendingConsentInternal(user, tenant, {
       displayName: input.displayName?.trim() || 'Alga platform Microsoft Email',
       clientId: credentials.clientId,
       clientSecret: credentials.clientSecret,
@@ -333,6 +341,7 @@ export const configureMicrosoftEmailPlatformApplication = withAuth(async (
       userId: (user as any).user_id,
       returnTo: metadata.returnTo,
       clientId: credentials.clientId,
+      profileId: profile.profileId!,
       secret,
     });
     return {
@@ -346,6 +355,7 @@ export const configureMicrosoftEmailPlatformApplication = withAuth(async (
         clientId: credentials.clientId,
         redirectUri: metadata.setupRedirectUri,
         state: setupState.token,
+        loginBaseUrl: getMicrosoftLoginBaseUrl(),
       }),
     };
   } catch (error) {
@@ -448,7 +458,7 @@ export async function completeMicrosoftEmailApplicationCreation(input: {
     const tokenResponse = await axios.post<{
       access_token?: string;
       id_token?: string;
-    }>('https://login.microsoftonline.com/common/oauth2/v2.0/token', tokenParams.toString(), {
+    }>(getMicrosoftTokenUrl('common'), tokenParams.toString(), {
       headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
       timeout: 20_000,
     });
@@ -490,21 +500,7 @@ export async function completeMicrosoftEmailApplicationCreation(input: {
     });
     if (!password.secretText) throw new Error('Microsoft did not return the generated client secret');
 
-    const consentState = createAdminConsentState({
-      algaTenant: input.state.algaTenant,
-      userId: input.state.userId,
-      returnTo: input.state.returnTo,
-      clientId: application.appId,
-      secret,
-    });
-    const adminConsentUrl = buildMicrosoftEmailAdminConsentUrl({
-      tenant: tenantId,
-      clientId: application.appId,
-      redirectUri: metadata.setupRedirectUri,
-      state: consentState.token,
-    });
-
-    const profile = await createAndBindMicrosoftEmailProfileInternal(
+    const profile = await createMicrosoftEmailProfilePendingConsentInternal(
       input.user,
       input.state.algaTenant,
       {
@@ -517,6 +513,21 @@ export async function completeMicrosoftEmailApplicationCreation(input: {
     if (!profile.success) {
       throw new Error(profile.error || 'Failed to store the new Microsoft profile');
     }
+    const consentState = createAdminConsentState({
+      algaTenant: input.state.algaTenant,
+      userId: input.state.userId,
+      returnTo: input.state.returnTo,
+      clientId: application.appId,
+      profileId: profile.profileId!,
+      secret,
+    });
+    const adminConsentUrl = buildMicrosoftEmailAdminConsentUrl({
+      tenant: tenantId,
+      clientId: application.appId,
+      redirectUri: metadata.setupRedirectUri,
+      state: consentState.token,
+      loginBaseUrl: getMicrosoftLoginBaseUrl(),
+    });
     return {
       success: true,
       profileId: profile.profileId,

--- a/packages/integrations/src/components/email/MicrosoftProviderForm.tsx
+++ b/packages/integrations/src/components/email/MicrosoftProviderForm.tsx
@@ -555,6 +555,21 @@ export function MicrosoftProviderForm({
             </Alert>
           )}
 
+          {!providerSetupLoading && providerSetupReady && oauthStatus !== 'success' && (
+            <Alert>
+              <AlertDescription>
+                <div className="space-y-1">
+                  <div className="font-medium">
+                    {t('forms.microsoft.oauth.profileReady', { defaultValue: 'Microsoft app profile is ready.' })}
+                  </div>
+                  <div className="text-sm text-muted-foreground">
+                    {t('forms.microsoft.oauth.profileReadyHelp', { defaultValue: 'If tenant administrator consent is still pending, complete it in Providers settings. Then use Authorize Access below for this mailbox.' })}
+                  </div>
+                </div>
+              </AlertDescription>
+            </Alert>
+          )}
+
           <div className="space-y-2">
             <Label htmlFor="redirectUri">{t('forms.microsoft.oauth.redirectUriLabel', { defaultValue: 'Redirect URI *' })}</Label>
             <Input

--- a/packages/integrations/src/components/email/MicrosoftProviderForm.tsx
+++ b/packages/integrations/src/components/email/MicrosoftProviderForm.tsx
@@ -550,15 +550,17 @@ export function MicrosoftProviderForm({
                     {providerSetupMessage ||
                       t('forms.microsoft.oauth.setupHelp', { defaultValue: 'Configure Providers first in Settings → Integrations → Providers, then return here to authorize this mailbox.' })}
                   </div>
-                  <Button
-                    id="configure-microsoft-provider-readiness-link"
-                    type="button"
-                    variant="outline"
-                    size="sm"
-                    onClick={() => window.location.assign('/msp/settings/integrations?category=providers')}
-                  >
-                    {t('forms.common.actions.openProvidersSettings', { defaultValue: 'Open Providers Settings' })}
-                  </Button>
+                  {!useByoApp && (
+                    <Button
+                      id="configure-microsoft-provider-readiness-link"
+                      type="button"
+                      variant="outline"
+                      size="sm"
+                      onClick={() => window.location.assign('/msp/settings/integrations?category=providers')}
+                    >
+                      {t('forms.common.actions.openProvidersSettings', { defaultValue: 'Open Providers Settings' })}
+                    </Button>
+                  )}
                 </div>
               </AlertDescription>
             </Alert>

--- a/packages/integrations/src/components/email/MicrosoftProviderForm.tsx
+++ b/packages/integrations/src/components/email/MicrosoftProviderForm.tsx
@@ -518,7 +518,7 @@ export function MicrosoftProviderForm({
                   type="button"
                   variant="outline"
                   size="sm"
-                  onClick={() => window.location.assign('/msp/settings?tab=integrations&category=providers')}
+                  onClick={() => window.location.assign('/msp/settings/integrations?category=providers')}
                 >
                   {t('forms.common.actions.openProvidersSettings', { defaultValue: 'Open Providers Settings' })}
                 </Button>
@@ -550,6 +550,15 @@ export function MicrosoftProviderForm({
                     {providerSetupMessage ||
                       t('forms.microsoft.oauth.setupHelp', { defaultValue: 'Configure Providers first in Settings → Integrations → Providers, then return here to authorize this mailbox.' })}
                   </div>
+                  <Button
+                    id="configure-microsoft-provider-readiness-link"
+                    type="button"
+                    variant="outline"
+                    size="sm"
+                    onClick={() => window.location.assign('/msp/settings/integrations?category=providers')}
+                  >
+                    {t('forms.common.actions.openProvidersSettings', { defaultValue: 'Open Providers Settings' })}
+                  </Button>
                 </div>
               </AlertDescription>
             </Alert>

--- a/packages/integrations/src/components/microsoftProviders.providersFirst.test.ts
+++ b/packages/integrations/src/components/microsoftProviders.providersFirst.test.ts
@@ -12,6 +12,10 @@ function read(relativePathFromComponents: string): string {
 
 describe('Microsoft providers-first form contracts', () => {
   const emailFormSource = read('./email/MicrosoftProviderForm.tsx');
+  const eeEmailFormSource = fs.readFileSync(
+    path.resolve(testDir, '../../../../ee/server/src/components/MicrosoftProviderForm.tsx'),
+    'utf8'
+  );
   const calendarFormSource = fs.readFileSync(
     path.resolve(testDir, '../../../../ee/packages/calendar/src/components/calendar/MicrosoftCalendarProviderForm.tsx'),
     'utf8'
@@ -20,18 +24,52 @@ describe('Microsoft providers-first form contracts', () => {
     path.resolve(actionsDir, 'email-actions/emailProviderActions.ts'),
     'utf8'
   );
+  const microsoftActionsSource = fs.readFileSync(
+    path.resolve(actionsDir, 'integrations/microsoftActions.ts'),
+    'utf8'
+  );
 
   it('T018: Microsoft email form no longer requires manual OAuth credential fields', () => {
     expect(emailFormSource).not.toContain('clientId: z.string');
     expect(emailFormSource).not.toContain('clientSecret: z.string');
     expect(emailFormSource).toContain("client_id: ''");
     expect(emailFormSource).toContain("client_secret: ''");
-});
+  });
   it('T019: Microsoft email form keeps tenant-owned app setup behind an advanced CTA', () => {
     expect(emailFormSource).toContain('Use your own Microsoft app (advanced)');
     expect(emailFormSource).toContain('This is normally unnecessary on hosted Alga PSA.');
     expect(emailFormSource).toContain('configure-microsoft-providers-link');
-    expect(emailFormSource).toContain('/msp/settings?tab=integrations&category=providers');
+    expect(emailFormSource).toContain('/msp/settings/integrations?category=providers');
+  });
+
+  it('keeps direct Enterprise imports aligned with shared mailbox readiness', () => {
+    expect(eeEmailFormSource).toContain(
+      "@alga-psa/integrations/components/email/MicrosoftProviderForm"
+    );
+    expect(emailFormSource).toContain("getMicrosoftConsumerSetupStatus('email')");
+    expect(emailFormSource).toContain('providerSetupReady');
+    expect(emailFormSource).toContain('Microsoft app profile is ready.');
+    expect(emailFormSource).toContain('/msp/settings/integrations?category=providers');
+  });
+
+  it('records guided administrator consent before advancing the Email binding', () => {
+    const confirmationStart = microsoftActionsSource.indexOf(
+      'export async function confirmMicrosoftEmailAdminConsentInternal'
+    );
+    const confirmationEnd = microsoftActionsSource.indexOf(
+      'export async function getMicrosoftEmailSetupMetadataInternal',
+      confirmationStart
+    );
+    const confirmationSource = microsoftActionsSource.slice(confirmationStart, confirmationEnd);
+    const consentWrite = confirmationSource.indexOf('email_admin_consent_granted_at: now');
+    const bindingWrite = confirmationSource.indexOf("table('microsoft_profile_consumer_bindings')");
+
+    expect(confirmationStart).toBeGreaterThanOrEqual(0);
+    expect(consentWrite).toBeGreaterThanOrEqual(0);
+    expect(bindingWrite).toBeGreaterThan(consentWrite);
+    expect(microsoftActionsSource).toContain(
+      'Microsoft tenant administrator consent must be recorded before binding this profile to Email'
+    );
   });
 
   it('T020/T021: Microsoft calendar form uses providers-first CTA and saves without manual credentials', () => {

--- a/packages/integrations/src/components/settings/integrations/MicrosoftEmailSetupDialog.tsx
+++ b/packages/integrations/src/components/settings/integrations/MicrosoftEmailSetupDialog.tsx
@@ -45,7 +45,18 @@ export function MicrosoftEmailSetupDialog({
   const [displayName, setDisplayName] = React.useState('Alga PSA Microsoft Email');
   const [completion, setCompletion] = React.useState<MicrosoftEmailSetupCompletionResult | null>(null);
   const [adminConsentGranted, setAdminConsentGranted] = React.useState(false);
+  const popupRef = React.useRef<Window | null>(null);
+  const popupPollRef = React.useRef<ReturnType<typeof setInterval> | null>(null);
+  const popupCompletedRef = React.useRef(false);
   const adminConsentUrl = completion?.adminConsentUrl;
+
+  const clearPopupMonitor = React.useCallback(() => {
+    if (popupPollRef.current) {
+      clearInterval(popupPollRef.current);
+      popupPollRef.current = null;
+    }
+    popupRef.current = null;
+  }, []);
 
   React.useEffect(() => {
     if (!isOpen) return;
@@ -68,6 +79,8 @@ export function MicrosoftEmailSetupDialog({
       if (event.origin !== window.location.origin || event.data?.type !== 'microsoft-email-setup-callback') {
         return;
       }
+      popupCompletedRef.current = true;
+      clearPopupMonitor();
       setWorking(false);
       if (!event.data.success) {
         setError(event.data.error || t('integrations.microsoft.emailSetup.errors.generic', { defaultValue: 'Microsoft Email setup did not complete.' }));
@@ -79,6 +92,7 @@ export function MicrosoftEmailSetupDialog({
           title: t('integrations.microsoft.emailSetup.consent.confirmedTitle', { defaultValue: 'Administrator consent confirmed' }),
           description: t('integrations.microsoft.emailSetup.consent.confirmedDescription', { defaultValue: 'The Microsoft app is ready for mailbox authorization.' }),
         });
+        void onCompleted();
         return;
       }
 
@@ -90,7 +104,9 @@ export function MicrosoftEmailSetupDialog({
     };
     window.addEventListener('message', handleMessage);
     return () => window.removeEventListener('message', handleMessage);
-  }, [isOpen, onCompleted, t, toast]);
+  }, [clearPopupMonitor, isOpen, onCompleted, t, toast]);
+
+  React.useEffect(() => () => clearPopupMonitor(), [clearPopupMonitor]);
 
   const copyValue = React.useCallback(async (value: string, label: string) => {
     await navigator.clipboard.writeText(value);
@@ -100,14 +116,27 @@ export function MicrosoftEmailSetupDialog({
   }, [t, toast]);
 
   const openPopup = React.useCallback((url: string) => {
+    clearPopupMonitor();
+    popupCompletedRef.current = false;
     const popup = window.open(url, 'microsoft-email-setup', 'width=720,height=760,noopener=false');
     if (!popup) {
       setError(t('integrations.microsoft.emailSetup.errors.popupBlocked', { defaultValue: 'Allow popups for this site, then try again.' }));
-      return false;
+      return null;
     }
+    popupRef.current = popup;
+    popupPollRef.current = setInterval(() => {
+      if (!popup.closed) return;
+      clearPopupMonitor();
+      if (!popupCompletedRef.current) {
+        setWorking(false);
+        setError(t('integrations.microsoft.emailSetup.errors.popupClosed', {
+          defaultValue: 'The Microsoft window was closed before setup finished. Try again or choose another setup option.',
+        }));
+      }
+    }, 500);
     popup.focus();
-    return true;
-  }, [t]);
+    return popup;
+  }, [clearPopupMonitor, t]);
 
   const configurePlatformApplication = React.useCallback(async () => {
     if (!tenantId.trim()) {
@@ -147,7 +176,10 @@ export function MicrosoftEmailSetupDialog({
   }, [displayName, openPopup, t]);
 
   const startAdminConsent = React.useCallback(() => {
-    if (adminConsentUrl) openPopup(adminConsentUrl);
+    if (!adminConsentUrl) return;
+    setWorking(true);
+    setError(null);
+    if (!openPopup(adminConsentUrl)) setWorking(false);
   }, [adminConsentUrl, openPopup]);
 
   const close = React.useCallback(() => {
@@ -164,12 +196,12 @@ export function MicrosoftEmailSetupDialog({
   ) : step === 'complete' ? (
     <div className="flex flex-wrap justify-end gap-2">
       {adminConsentUrl && !adminConsentGranted && (
-        <Button id="microsoft-email-admin-consent-button" type="button" onClick={startAdminConsent}>
+        <Button id="microsoft-email-admin-consent-button" type="button" onClick={startAdminConsent} disabled={working}>
           <ExternalLink className="mr-2 h-4 w-4" />
           {t('integrations.microsoft.emailSetup.actions.grantConsent', { defaultValue: 'Grant administrator consent' })}
         </Button>
       )}
-      <Button id="microsoft-email-setup-finish-button" type="button" variant="outline" onClick={close}>
+      <Button id="microsoft-email-setup-finish-button" type="button" variant="outline" onClick={close} disabled={working}>
         {t('integrations.microsoft.emailSetup.actions.finish', { defaultValue: 'Finish' })}
       </Button>
     </div>

--- a/packages/integrations/src/components/settings/integrations/MicrosoftEmailSetupDialog.tsx
+++ b/packages/integrations/src/components/settings/integrations/MicrosoftEmailSetupDialog.tsx
@@ -1,0 +1,337 @@
+'use client';
+
+import React from 'react';
+import { Alert, AlertDescription } from '@alga-psa/ui/components/Alert';
+import { Badge } from '@alga-psa/ui/components/Badge';
+import { Button } from '@alga-psa/ui/components/Button';
+import { Dialog, DialogContent } from '@alga-psa/ui/components/Dialog';
+import { Input } from '@alga-psa/ui/components/Input';
+import { Label } from '@alga-psa/ui/components/Label';
+import { Skeleton } from '@alga-psa/ui/components/Skeleton';
+import { useToast } from '@alga-psa/ui/hooks/use-toast';
+import { useTranslation } from '@alga-psa/ui/lib/i18n/client';
+import {
+  createMicrosoftEmailApplication,
+  getMicrosoftEmailSetupOptions,
+  type MicrosoftEmailSetupCompletionResult,
+  type MicrosoftEmailSetupOptionsResult,
+  configureMicrosoftEmailPlatformApplication,
+} from '../../../actions/integrations/microsoftEmailSetupActions';
+import { CheckCircle2, Copy, ExternalLink, KeyRound, Settings2, WandSparkles } from 'lucide-react';
+
+type SetupStep = 'choose' | 'platform' | 'automated' | 'complete';
+
+interface MicrosoftEmailSetupDialogProps {
+  isOpen: boolean;
+  onClose: () => void;
+  onCompleted: () => void | Promise<void>;
+  onManualSetup: () => void;
+}
+
+export function MicrosoftEmailSetupDialog({
+  isOpen,
+  onClose,
+  onCompleted,
+  onManualSetup,
+}: MicrosoftEmailSetupDialogProps) {
+  const { t } = useTranslation('msp/integrations');
+  const { toast } = useToast();
+  const [step, setStep] = React.useState<SetupStep>('choose');
+  const [options, setOptions] = React.useState<MicrosoftEmailSetupOptionsResult | null>(null);
+  const [loading, setLoading] = React.useState(false);
+  const [working, setWorking] = React.useState(false);
+  const [error, setError] = React.useState<string | null>(null);
+  const [tenantId, setTenantId] = React.useState('');
+  const [displayName, setDisplayName] = React.useState('Alga PSA Microsoft Email');
+  const [completion, setCompletion] = React.useState<MicrosoftEmailSetupCompletionResult | null>(null);
+  const [adminConsentGranted, setAdminConsentGranted] = React.useState(false);
+  const adminConsentUrl = completion?.adminConsentUrl;
+
+  React.useEffect(() => {
+    if (!isOpen) return;
+    setStep('choose');
+    setError(null);
+    setCompletion(null);
+    setAdminConsentGranted(false);
+    setLoading(true);
+    void getMicrosoftEmailSetupOptions()
+      .then((result) => {
+        setOptions(result);
+        if (!result.success) setError(result.error || 'Failed to load Microsoft Email setup options.');
+      })
+      .finally(() => setLoading(false));
+  }, [isOpen]);
+
+  React.useEffect(() => {
+    if (!isOpen) return;
+    const handleMessage = (event: MessageEvent) => {
+      if (event.origin !== window.location.origin || event.data?.type !== 'microsoft-email-setup-callback') {
+        return;
+      }
+      setWorking(false);
+      if (!event.data.success) {
+        setError(event.data.error || t('integrations.microsoft.emailSetup.errors.generic', { defaultValue: 'Microsoft Email setup did not complete.' }));
+        return;
+      }
+      if (event.data.stage === 'admin_consent') {
+        setAdminConsentGranted(true);
+        toast({
+          title: t('integrations.microsoft.emailSetup.consent.confirmedTitle', { defaultValue: 'Administrator consent confirmed' }),
+          description: t('integrations.microsoft.emailSetup.consent.confirmedDescription', { defaultValue: 'The Microsoft app is ready for mailbox authorization.' }),
+        });
+        return;
+      }
+
+      const result = event.data as MicrosoftEmailSetupCompletionResult;
+      setCompletion(result);
+      setTenantId(result.tenantId || '');
+      setStep('complete');
+      void onCompleted();
+    };
+    window.addEventListener('message', handleMessage);
+    return () => window.removeEventListener('message', handleMessage);
+  }, [isOpen, onCompleted, t, toast]);
+
+  const copyValue = React.useCallback(async (value: string, label: string) => {
+    await navigator.clipboard.writeText(value);
+    toast({
+      title: t('integrations.microsoft.emailSetup.copied', { defaultValue: '{{label}} copied', label }),
+    });
+  }, [t, toast]);
+
+  const openPopup = React.useCallback((url: string) => {
+    const popup = window.open(url, 'microsoft-email-setup', 'width=720,height=760,noopener=false');
+    if (!popup) {
+      setError(t('integrations.microsoft.emailSetup.errors.popupBlocked', { defaultValue: 'Allow popups for this site, then try again.' }));
+      return false;
+    }
+    popup.focus();
+    return true;
+  }, [t]);
+
+  const configurePlatformApplication = React.useCallback(async () => {
+    if (!tenantId.trim()) {
+      setError(t('integrations.microsoft.emailSetup.errors.tenantRequired', { defaultValue: 'Enter your Microsoft tenant ID or verified domain.' }));
+      return;
+    }
+    setWorking(true);
+    setError(null);
+    try {
+      const result = await configureMicrosoftEmailPlatformApplication({ tenantId, displayName });
+      if (!result.success) {
+        setError(result.error || t('integrations.microsoft.emailSetup.errors.platform', { defaultValue: 'Could not configure the platform Microsoft app.' }));
+        return;
+      }
+      setCompletion(result);
+      setStep('complete');
+      await onCompleted();
+    } finally {
+      setWorking(false);
+    }
+  }, [displayName, onCompleted, t, tenantId]);
+
+  const startAutomatedCreation = React.useCallback(async () => {
+    if (!displayName.trim()) {
+      setError(t('integrations.microsoft.emailSetup.errors.nameRequired', { defaultValue: 'Enter a display name for the Microsoft app.' }));
+      return;
+    }
+    setWorking(true);
+    setError(null);
+    const result = await createMicrosoftEmailApplication({ displayName });
+    if (!result.success || !result.authUrl) {
+      setWorking(false);
+      setError(result.error || t('integrations.microsoft.emailSetup.errors.automated', { defaultValue: 'Could not start automated Microsoft app creation.' }));
+      return;
+    }
+    if (!openPopup(result.authUrl)) setWorking(false);
+  }, [displayName, openPopup, t]);
+
+  const startAdminConsent = React.useCallback(() => {
+    if (adminConsentUrl) openPopup(adminConsentUrl);
+  }, [adminConsentUrl, openPopup]);
+
+  const close = React.useCallback(() => {
+    if (working) return;
+    onClose();
+  }, [onClose, working]);
+
+  const footer = step === 'choose' ? (
+    <div className="flex justify-end">
+      <Button id="microsoft-email-setup-cancel-button" type="button" variant="outline" onClick={close}>
+        {t('integrations.microsoft.emailSetup.actions.cancel', { defaultValue: 'Cancel' })}
+      </Button>
+    </div>
+  ) : step === 'complete' ? (
+    <div className="flex flex-wrap justify-end gap-2">
+      {adminConsentUrl && !adminConsentGranted && (
+        <Button id="microsoft-email-admin-consent-button" type="button" onClick={startAdminConsent}>
+          <ExternalLink className="mr-2 h-4 w-4" />
+          {t('integrations.microsoft.emailSetup.actions.grantConsent', { defaultValue: 'Grant administrator consent' })}
+        </Button>
+      )}
+      <Button id="microsoft-email-setup-finish-button" type="button" variant="outline" onClick={close}>
+        {t('integrations.microsoft.emailSetup.actions.finish', { defaultValue: 'Finish' })}
+      </Button>
+    </div>
+  ) : (
+    <div className="flex justify-between gap-2">
+      <Button id="microsoft-email-setup-back-button" type="button" variant="outline" onClick={() => { setStep('choose'); setError(null); }} disabled={working}>
+        {t('integrations.microsoft.emailSetup.actions.back', { defaultValue: 'Back' })}
+      </Button>
+      <Button
+        id={step === 'platform' ? 'microsoft-email-platform-continue-button' : 'microsoft-email-automated-continue-button'}
+        type="button"
+        onClick={() => void (step === 'platform' ? configurePlatformApplication() : startAutomatedCreation())}
+        disabled={working}
+      >
+        {working
+          ? t('integrations.microsoft.emailSetup.actions.working', { defaultValue: 'Working…' })
+          : step === 'platform'
+            ? t('integrations.microsoft.emailSetup.actions.savePlatform', { defaultValue: 'Create profile and continue' })
+            : t('integrations.microsoft.emailSetup.actions.signIn', { defaultValue: 'Sign in to Microsoft' })}
+      </Button>
+    </div>
+  );
+
+  return (
+    <Dialog
+      id="microsoft-email-setup-dialog"
+      isOpen={isOpen}
+      onClose={close}
+      title={t('integrations.microsoft.emailSetup.title', { defaultValue: 'Set up Microsoft Email' })}
+      className="max-w-2xl"
+      footer={footer}
+    >
+      <DialogContent>
+        <div className="space-y-5">
+          <div>
+            <p className="text-sm text-[rgb(var(--color-text-700))]">
+              {t('integrations.microsoft.emailSetup.description', { defaultValue: 'Choose how to configure the Microsoft app used for inbound email. Mailbox authorization remains a separate final step.' })}
+            </p>
+          </div>
+
+          {error && (
+            <Alert variant="destructive">
+              <AlertDescription>{error}</AlertDescription>
+            </Alert>
+          )}
+
+          {loading ? (
+            <div className="space-y-3"><Skeleton className="h-24 w-full" /><Skeleton className="h-24 w-full" /></div>
+          ) : step === 'choose' ? (
+            <div className="grid gap-3">
+              <button
+                id="microsoft-email-choose-platform-button"
+                type="button"
+                className="rounded-lg border bg-[rgb(var(--color-card))] p-4 text-left transition-colors hover:bg-muted/30 disabled:cursor-not-allowed disabled:opacity-60"
+                disabled={!options?.platformApplication?.available}
+                onClick={() => setStep('platform')}
+              >
+                <div className="flex items-start gap-3">
+                  <KeyRound className="mt-0.5 h-5 w-5 text-primary-500" />
+                  <div className="space-y-1">
+                    <div className="flex flex-wrap items-center gap-2 font-medium">
+                      {t('integrations.microsoft.emailSetup.platform.title', { defaultValue: 'Use the Alga platform app' })}
+                      {!options?.platformApplication?.available && <Badge variant="secondary">{t('integrations.microsoft.emailSetup.unavailable', { defaultValue: 'Unavailable' })}</Badge>}
+                    </div>
+                    <p className="text-sm text-muted-foreground">
+                      {t('integrations.microsoft.emailSetup.platform.description', { defaultValue: 'Create an Email-bound profile from the server-managed multi-tenant app, then grant tenant administrator consent.' })}
+                    </p>
+                  </div>
+                </div>
+              </button>
+
+              <button
+                id="microsoft-email-choose-automated-button"
+                type="button"
+                className="rounded-lg border bg-[rgb(var(--color-card))] p-4 text-left transition-colors hover:bg-muted/30 disabled:cursor-not-allowed disabled:opacity-60"
+                disabled={!options?.automatedCreationAvailable}
+                onClick={() => setStep('automated')}
+              >
+                <div className="flex items-start gap-3">
+                  <WandSparkles className="mt-0.5 h-5 w-5 text-primary-500" />
+                  <div className="space-y-1">
+                    <div className="flex flex-wrap items-center gap-2 font-medium">
+                      {t('integrations.microsoft.emailSetup.automated.title', { defaultValue: 'Create an app in this tenant' })}
+                      {!options?.automatedCreationAvailable && <Badge variant="secondary">{t('integrations.microsoft.emailSetup.unavailable', { defaultValue: 'Unavailable' })}</Badge>}
+                    </div>
+                    <p className="text-sm text-muted-foreground">
+                      {t('integrations.microsoft.emailSetup.automated.description', { defaultValue: 'Sign in as a Microsoft administrator. Alga creates the app, service principal, secret, Email profile, and binding.' })}
+                    </p>
+                  </div>
+                </div>
+              </button>
+
+              <button
+                id="microsoft-email-choose-manual-button"
+                type="button"
+                className="rounded-lg border bg-[rgb(var(--color-card))] p-4 text-left transition-colors hover:bg-muted/30"
+                onClick={onManualSetup}
+              >
+                <div className="flex items-start gap-3">
+                  <Settings2 className="mt-0.5 h-5 w-5 text-primary-500" />
+                  <div className="space-y-1">
+                    <div className="font-medium">{t('integrations.microsoft.emailSetup.manual.title', { defaultValue: 'Enter an existing app manually' })}</div>
+                    <p className="text-sm text-muted-foreground">{t('integrations.microsoft.emailSetup.manual.description', { defaultValue: 'Keep using the existing client ID, tenant ID, and client secret form.' })}</p>
+                  </div>
+                </div>
+              </button>
+            </div>
+          ) : step === 'platform' || step === 'automated' ? (
+            <div className="space-y-4">
+              <div className="space-y-2">
+                <Label htmlFor="microsoft-email-setup-display-name-input">{t('integrations.microsoft.emailSetup.fields.displayName', { defaultValue: 'Profile display name' })}</Label>
+                <Input id="microsoft-email-setup-display-name-input" value={displayName} onChange={(event) => setDisplayName(event.target.value)} />
+              </div>
+              {step === 'platform' && (
+                <div className="space-y-2">
+                  <Label htmlFor="microsoft-email-setup-tenant-input">{t('integrations.microsoft.emailSetup.fields.tenant', { defaultValue: 'Microsoft tenant ID or verified domain' })}</Label>
+                  <Input id="microsoft-email-setup-tenant-input" value={tenantId} onChange={(event) => setTenantId(event.target.value)} placeholder="xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx" />
+                </div>
+              )}
+              <div className="rounded-lg border bg-muted/10 p-3">
+                <div className="text-xs font-semibold uppercase tracking-wide text-muted-foreground">{t('integrations.microsoft.emailSetup.callbackUri', { defaultValue: 'Mailbox callback URI' })}</div>
+                <div className="mt-2 break-all font-mono text-xs">{options?.callbackUri}</div>
+              </div>
+            </div>
+          ) : (
+            <div className="space-y-4">
+              <Alert>
+                <CheckCircle2 className="h-4 w-4" />
+                <AlertDescription>
+                  <div className="font-medium">{t('integrations.microsoft.emailSetup.complete.profileCreated', { defaultValue: 'Microsoft Email profile created and bound' })}</div>
+                  <p className="mt-1 text-sm text-muted-foreground">
+                    {adminConsentGranted
+                      ? t('integrations.microsoft.emailSetup.complete.consentDone', { defaultValue: 'Administrator consent is confirmed. Return to Inbound Email and authorize the mailbox.' })
+                      : t('integrations.microsoft.emailSetup.complete.consentPending', { defaultValue: 'Next, a Microsoft tenant administrator must grant consent. Mailbox authorization happens afterward in Inbound Email.' })}
+                  </p>
+                </AlertDescription>
+              </Alert>
+              <div className="grid gap-3 sm:grid-cols-2">
+                <div className="rounded-lg border bg-muted/10 p-3">
+                  <div className="text-xs font-semibold uppercase tracking-wide text-muted-foreground">{t('integrations.microsoft.emailSetup.fields.clientId', { defaultValue: 'Client ID' })}</div>
+                  <div className="mt-2 break-all font-mono text-xs">{completion?.clientId}</div>
+                </div>
+                <div className="rounded-lg border bg-muted/10 p-3">
+                  <div className="text-xs font-semibold uppercase tracking-wide text-muted-foreground">{t('integrations.microsoft.emailSetup.fields.tenantId', { defaultValue: 'Tenant ID' })}</div>
+                  <div className="mt-2 break-all font-mono text-xs">{completion?.tenantId}</div>
+                </div>
+              </div>
+              {adminConsentUrl && (
+                <div className="rounded-lg border bg-muted/10 p-3">
+                  <div className="flex items-center justify-between gap-2">
+                    <div className="text-xs font-semibold uppercase tracking-wide text-muted-foreground">{t('integrations.microsoft.emailSetup.consent.url', { defaultValue: 'Administrator consent URL' })}</div>
+                    <Button id="microsoft-email-copy-consent-url-button" type="button" variant="ghost" size="sm" onClick={() => void copyValue(adminConsentUrl, t('integrations.microsoft.emailSetup.consent.urlLabel', { defaultValue: 'Consent URL' }))}>
+                      <Copy className="mr-2 h-3.5 w-3.5" />{t('integrations.microsoft.emailSetup.actions.copy', { defaultValue: 'Copy' })}
+                    </Button>
+                  </div>
+                  <div className="mt-2 break-all font-mono text-xs">{adminConsentUrl}</div>
+                </div>
+              )}
+            </div>
+          )}
+        </div>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/packages/integrations/src/components/settings/integrations/MicrosoftIntegrationSettings.contract.test.tsx
+++ b/packages/integrations/src/components/settings/integrations/MicrosoftIntegrationSettings.contract.test.tsx
@@ -446,7 +446,41 @@ describe('MicrosoftIntegrationSettings contracts', () => {
     expect(await screen.findByRole('dialog', { name: 'Create Microsoft app registration' })).toBeInTheDocument();
   });
 
-  it('renders CE copy and bindings only for MSP SSO', async () => {
+  it('recovers the automated setup controls when the Microsoft popup is closed', async () => {
+    const user = userEvent.setup();
+    const popup = { closed: false, focus: vi.fn(), close: vi.fn() };
+    vi.stubGlobal('open', vi.fn(() => popup));
+    getMicrosoftEmailSetupOptionsMock.mockResolvedValue({
+      success: true,
+      callbackUri: 'https://psa.example.com/api/auth/microsoft/callback',
+      setupCallbackUri: 'https://psa.example.com/api/auth/microsoft/email-setup/callback',
+      platformApplication: { available: false },
+      automatedCreationAvailable: true,
+    });
+    createMicrosoftEmailApplicationMock.mockResolvedValue({
+      success: true,
+      authUrl: 'https://login.microsoftonline.com/common/oauth2/v2.0/authorize',
+    });
+
+    render(<MicrosoftIntegrationSettings />);
+    await user.click(await screen.findByRole('button', { name: 'Set up Microsoft Email' }));
+    const dialog = await screen.findByRole('dialog', { name: 'Set up Microsoft Email' });
+    await user.click(within(dialog).getByRole('button', { name: /Create an app in this tenant/ }));
+    await user.click(within(dialog).getByRole('button', { name: 'Sign in to Microsoft' }));
+    expect(within(dialog).getByRole('button', { name: 'Working…' })).toBeDisabled();
+
+    popup.closed = true;
+
+    expect(await within(dialog).findByText(
+      'The Microsoft window was closed before setup finished. Try again or choose another setup option.',
+      {},
+      { timeout: 2_000 }
+    )).toBeInTheDocument();
+    expect(within(dialog).getByRole('button', { name: 'Back' })).toBeEnabled();
+    expect(within(dialog).getByRole('button', { name: 'Sign in to Microsoft' })).toBeEnabled();
+  });
+
+  it('keeps guided Microsoft Email setup and binding reachable in CE', async () => {
     process.env.NEXT_PUBLIC_EDITION = 'community';
     useFeatureFlagMock.mockReturnValue({
       enabled: false,
@@ -458,14 +492,16 @@ describe('MicrosoftIntegrationSettings contracts', () => {
       buildStatus({
         redirectUris: {
           sso: 'https://psa.example.com/api/auth/callback/azure-ad',
+          email: 'https://psa.example.com/api/auth/microsoft/callback',
         },
         scopes: {
           sso: ['openid', 'profile', 'email'],
+          email: ['Mail.Read', 'Mail.Read.Shared', 'offline_access'],
         },
         profiles: [
           {
             ...buildStatus().profiles[0],
-            consumers: ['MSP SSO'],
+            consumers: ['MSP SSO', 'Email'],
           },
         ],
       })
@@ -480,6 +516,13 @@ describe('MicrosoftIntegrationSettings contracts', () => {
           profileDisplayName: 'Primary Profile',
           isArchived: false,
         },
+        {
+          consumerType: 'email',
+          consumerLabel: 'Email',
+          profileId: 'profile-1',
+          profileDisplayName: 'Primary Profile',
+          isArchived: false,
+        },
       ]),
     });
 
@@ -489,15 +532,15 @@ describe('MicrosoftIntegrationSettings contracts', () => {
       expect(document.getElementById('microsoft-profile-profile-1')).not.toBeNull();
     });
     expect(
-      screen.getByText("Manage your company's Microsoft app registration for staff sign-in.")
+      screen.getByText("Manage your company's Microsoft app registrations for staff sign-in and Outlook email.")
     ).toBeInTheDocument();
     expect(screen.getByTestId('microsoft-binding-select-msp_sso')).toBeInTheDocument();
-    expect(screen.queryByText('Inbound email redirect URI')).not.toBeInTheDocument();
+    expect(screen.getByTestId('microsoft-binding-select-email')).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Set up Microsoft Email' })).toBeInTheDocument();
     expect(screen.queryByText('Calendar sync redirect URI')).not.toBeInTheDocument();
     expect(screen.queryByText('Teams scopes')).not.toBeInTheDocument();
     expect(screen.queryByRole('button', { name: 'Disconnect Microsoft providers' })).not.toBeInTheDocument();
     expect(screen.queryByRole('button', { name: 'Open Teams Setup' })).not.toBeInTheDocument();
-    expect(screen.queryByTestId('microsoft-binding-select-email')).not.toBeInTheDocument();
     expect(screen.queryByTestId('microsoft-binding-select-calendar')).not.toBeInTheDocument();
     expect(screen.queryByTestId('microsoft-binding-select-teams')).not.toBeInTheDocument();
   });

--- a/packages/integrations/src/components/settings/integrations/MicrosoftIntegrationSettings.contract.test.tsx
+++ b/packages/integrations/src/components/settings/integrations/MicrosoftIntegrationSettings.contract.test.tsx
@@ -16,6 +16,9 @@ const updateMicrosoftProfileMock = vi.hoisted(() => vi.fn());
 const archiveMicrosoftProfileMock = vi.hoisted(() => vi.fn());
 const setDefaultMicrosoftProfileMock = vi.hoisted(() => vi.fn());
 const resetMicrosoftProvidersToDisconnectedMock = vi.hoisted(() => vi.fn());
+const getMicrosoftEmailSetupOptionsMock = vi.hoisted(() => vi.fn());
+const configureMicrosoftEmailPlatformApplicationMock = vi.hoisted(() => vi.fn());
+const createMicrosoftEmailApplicationMock = vi.hoisted(() => vi.fn());
 const toastMock = vi.hoisted(() => vi.fn());
 const routerPushMock = vi.hoisted(() => vi.fn());
 
@@ -45,6 +48,12 @@ vi.mock('../../../actions/integrations/microsoftActions', () => ({
   setDefaultMicrosoftProfile: (...args: unknown[]) => setDefaultMicrosoftProfileMock(...args),
   resetMicrosoftProvidersToDisconnected: (...args: unknown[]) =>
     resetMicrosoftProvidersToDisconnectedMock(...args),
+}));
+
+vi.mock('../../../actions/integrations/microsoftEmailSetupActions', () => ({
+  getMicrosoftEmailSetupOptions: (...args: unknown[]) => getMicrosoftEmailSetupOptionsMock(...args),
+  configureMicrosoftEmailPlatformApplication: (...args: unknown[]) => configureMicrosoftEmailPlatformApplicationMock(...args),
+  createMicrosoftEmailApplication: (...args: unknown[]) => createMicrosoftEmailApplicationMock(...args),
 }));
 
 vi.mock('@alga-psa/ui/hooks/use-toast', () => ({
@@ -282,6 +291,15 @@ describe('MicrosoftIntegrationSettings contracts', () => {
     archiveMicrosoftProfileMock.mockReset();
     setDefaultMicrosoftProfileMock.mockReset();
     resetMicrosoftProvidersToDisconnectedMock.mockReset();
+    getMicrosoftEmailSetupOptionsMock.mockReset().mockResolvedValue({
+      success: true,
+      callbackUri: 'https://psa.example.com/api/auth/microsoft/callback',
+      setupCallbackUri: 'https://psa.example.com/api/auth/microsoft/email-setup/callback',
+      platformApplication: { available: false },
+      automatedCreationAvailable: false,
+    });
+    configureMicrosoftEmailPlatformApplicationMock.mockReset();
+    createMicrosoftEmailApplicationMock.mockReset();
     toastMock.mockReset();
     routerPushMock.mockReset();
     getMicrosoftIntegrationStatusMock.mockResolvedValue(buildStatus());
@@ -408,6 +426,24 @@ describe('MicrosoftIntegrationSettings contracts', () => {
     expect(await screen.findByText('Platform Microsoft credentials are unavailable')).toBeInTheDocument();
     expect(screen.getByText('Which Microsoft app each service uses')).toBeInTheDocument();
     expect(screen.getByRole('button', { name: 'New app registration' })).toBeInTheDocument();
+  });
+
+  it('shows both guided choices as unavailable while keeping the manual fallback usable', async () => {
+    const user = userEvent.setup();
+    render(<MicrosoftIntegrationSettings />);
+
+    await user.click(await screen.findByRole('button', { name: 'Set up Microsoft Email' }));
+    const dialog = await screen.findByRole('dialog', { name: 'Set up Microsoft Email' });
+    const platformChoice = within(dialog).getByRole('button', { name: /Use the Alga platform app/ });
+    const automatedChoice = within(dialog).getByRole('button', { name: /Create an app in this tenant/ });
+    const manualChoice = within(dialog).getByRole('button', { name: /Enter an existing app manually/ });
+
+    expect(platformChoice).toBeDisabled();
+    expect(automatedChoice).toBeDisabled();
+    expect(manualChoice).toBeEnabled();
+
+    await user.click(manualChoice);
+    expect(await screen.findByRole('dialog', { name: 'Create Microsoft app registration' })).toBeInTheDocument();
   });
 
   it('renders CE copy and bindings only for MSP SSO', async () => {

--- a/packages/integrations/src/components/settings/integrations/MicrosoftIntegrationSettings.tsx
+++ b/packages/integrations/src/components/settings/integrations/MicrosoftIntegrationSettings.tsx
@@ -102,6 +102,9 @@ function getReadinessMessages(profile: MicrosoftProfile, t: TranslateFn): string
   if (!profile.readiness.tenantIdConfigured) {
     messages.push(t('integrations.microsoft.settings.readiness.tenantIdMissing', { defaultValue: 'Add a tenant ID.' }));
   }
+  if (profile.emailAdminConsentRequired && !profile.emailAdminConsentGrantedAt) {
+    messages.push(t('integrations.microsoft.settings.readiness.adminConsentPending', { defaultValue: 'Grant Microsoft tenant administrator consent to finish Email setup.' }));
+  }
 
   return messages;
 }
@@ -727,7 +730,7 @@ export function MicrosoftIntegrationSettings({
                   ? emailCredentialCapability?.source === 'platform'
                     ? t('integrations.microsoft.settings.platform.description', { defaultValue: 'Connect Microsoft 365 with the application supplied by Alga PSA. No Entra app registration is required.' })
                     : t('integrations.microsoft.settings.descriptionEe', { defaultValue: "Manage your company's Microsoft app registrations for staff sign-in, Outlook email, calendar sync, and Teams." })
-                  : t('integrations.microsoft.settings.descriptionCe', { defaultValue: "Manage your company's Microsoft app registration for staff sign-in." })}
+                  : t('integrations.microsoft.settings.descriptionCe', { defaultValue: "Manage your company's Microsoft app registrations for staff sign-in and Outlook email." })}
               </CardDescription>
             </div>
             <div className="flex flex-wrap items-center gap-2">
@@ -741,21 +744,15 @@ export function MicrosoftIntegrationSettings({
                 <RefreshCw className="mr-2 h-4 w-4" />
                 {t('integrations.microsoft.settings.actions.refresh', { defaultValue: 'Refresh' })}
               </Button>
-              {isEnterpriseEdition && (
-                <Button
-                  id="microsoft-settings-email-setup-button"
-                  type="button"
-                  variant="outline"
-                  onClick={() => setEmailSetupOpen(true)}
-                  disabled={loading}
-                >
-                  <WandSparkles className="mr-2 h-4 w-4" />
-                  {t('integrations.microsoft.emailSetup.action', { defaultValue: 'Set up Microsoft Email' })}
-                </Button>
-              )}
-              <Button id="microsoft-settings-add-profile" type="button" onClick={openCreateDialog} disabled={loading}>
-                <Plus className="mr-2 h-4 w-4" />
-                {t('integrations.microsoft.settings.actions.newProfile', { defaultValue: 'New app registration' })}
+              <Button
+                id="microsoft-settings-email-setup-button"
+                type="button"
+                variant="outline"
+                onClick={() => setEmailSetupOpen(true)}
+                disabled={loading}
+              >
+                <WandSparkles className="mr-2 h-4 w-4" />
+                {t('integrations.microsoft.emailSetup.action', { defaultValue: 'Set up Microsoft Email' })}
               </Button>
             </div>
           </div>
@@ -888,9 +885,12 @@ export function MicrosoftIntegrationSettings({
                 const boundProfile = binding?.profileId ? profileById.get(binding.profileId) : undefined;
                 const activeBoundProfile =
                   boundProfile && !boundProfile.isArchived ? boundProfile : undefined;
-                const capableProfiles = activeProfiles.filter((profile) =>
-                  profileSupportsConsumer(profile, consumer.consumerType)
-                );
+                const capableProfiles = activeProfiles.filter((profile) => {
+                  if (!profileSupportsConsumer(profile, consumer.consumerType)) return false;
+                  return consumer.consumerType !== 'email' ||
+                    !profile.emailAdminConsentRequired ||
+                    Boolean(profile.emailAdminConsentGrantedAt);
+                });
                 const warning = getBindingWarning(
                   consumer.consumerLabel,
                   consumer.consumerType,

--- a/packages/integrations/src/components/settings/integrations/MicrosoftIntegrationSettings.tsx
+++ b/packages/integrations/src/components/settings/integrations/MicrosoftIntegrationSettings.tsx
@@ -37,6 +37,7 @@ import {
   isMicrosoftConsumerEnterpriseEdition,
 } from '../../../lib/microsoftConsumerVisibility';
 import { resolveTeamsAvailability } from '../../../lib/teamsAvailabilityCore';
+import { MicrosoftEmailSetupDialog } from './MicrosoftEmailSetupDialog';
 import {
   AlertTriangle,
   Archive,
@@ -49,6 +50,7 @@ import {
   RefreshCw,
   ShieldCheck,
   Star,
+  WandSparkles,
 } from 'lucide-react';
 
 type MicrosoftIntegrationStatus = Awaited<ReturnType<typeof getMicrosoftIntegrationStatus>>;
@@ -386,6 +388,7 @@ export function MicrosoftIntegrationSettings({
   const [formError, setFormError] = React.useState<string | null>(null);
   const [advancedOpen, setAdvancedOpen] = React.useState(false);
   const advancedChoiceInitializedRef = React.useRef(false);
+  const [emailSetupOpen, setEmailSetupOpen] = React.useState(false);
 
   const isEnterpriseEdition = isMicrosoftConsumerEnterpriseEdition();
   const profiles = status?.success ? status.profiles ?? [] : [];
@@ -737,6 +740,22 @@ export function MicrosoftIntegrationSettings({
               >
                 <RefreshCw className="mr-2 h-4 w-4" />
                 {t('integrations.microsoft.settings.actions.refresh', { defaultValue: 'Refresh' })}
+              </Button>
+              {isEnterpriseEdition && (
+                <Button
+                  id="microsoft-settings-email-setup-button"
+                  type="button"
+                  variant="outline"
+                  onClick={() => setEmailSetupOpen(true)}
+                  disabled={loading}
+                >
+                  <WandSparkles className="mr-2 h-4 w-4" />
+                  {t('integrations.microsoft.emailSetup.action', { defaultValue: 'Set up Microsoft Email' })}
+                </Button>
+              )}
+              <Button id="microsoft-settings-add-profile" type="button" onClick={openCreateDialog} disabled={loading}>
+                <Plus className="mr-2 h-4 w-4" />
+                {t('integrations.microsoft.settings.actions.newProfile', { defaultValue: 'New app registration' })}
               </Button>
             </div>
           </div>
@@ -1292,6 +1311,16 @@ export function MicrosoftIntegrationSettings({
 
         </DialogContent>
       </Dialog>
+
+      <MicrosoftEmailSetupDialog
+        isOpen={emailSetupOpen}
+        onClose={() => setEmailSetupOpen(false)}
+        onCompleted={load}
+        onManualSetup={() => {
+          setEmailSetupOpen(false);
+          openCreateDialog();
+        }}
+      />
 
       <ConfirmationDialog
         id="microsoft-provider-disconnect-confirmation"

--- a/packages/integrations/src/lib/microsoftConsumerProfileResolution.test.ts
+++ b/packages/integrations/src/lib/microsoftConsumerProfileResolution.test.ts
@@ -9,6 +9,8 @@ const hoisted = vi.hoisted(() => {
     client_id: string;
     tenant_id: string;
     client_secret_ref: string;
+    email_admin_consent_required?: boolean;
+    email_admin_consent_granted_at?: string | Date | null;
     capabilities?: string[] | string | null;
     is_default: boolean;
     is_archived: boolean;
@@ -196,6 +198,49 @@ describe('resolveMicrosoftConsumerProfileConfig', () => {
     expect(result.clientId).not.toBe(process.env.MICROSOFT_CLIENT_ID);
     expect(result.clientSecret).not.toBe(process.env.MICROSOFT_CLIENT_SECRET);
     expect(result.microsoftTenantId).not.toBe(process.env.MICROSOFT_TENANT_ID);
+  });
+
+  it('keeps a bound tenant-owned Email profile unavailable until administrator consent is recorded', async () => {
+    hoisted.state.microsoftProfiles.push({
+      tenant: 'tenant-pending-consent',
+      profile_id: 'profile-pending-consent',
+      display_name: 'Pending Consent Email Profile',
+      display_name_normalized: 'pending consent email profile',
+      client_id: 'pending-consent-client-id',
+      tenant_id: 'pending-consent-tenant-id',
+      client_secret_ref: 'pending-consent-secret-ref',
+      email_admin_consent_required: true,
+      email_admin_consent_granted_at: null,
+      capabilities: ['email'],
+      is_default: false,
+      is_archived: false,
+      archived_at: null,
+      created_by: null,
+      updated_by: null,
+      created_at: new Date().toISOString(),
+      updated_at: new Date().toISOString(),
+    });
+    hoisted.state.microsoftConsumerBindings.push({
+      tenant: 'tenant-pending-consent',
+      consumer_type: 'email',
+      profile_id: 'profile-pending-consent',
+      created_by: null,
+      updated_by: null,
+      created_at: new Date().toISOString(),
+      updated_at: new Date().toISOString(),
+    });
+    hoisted.state.tenantSecrets.set(
+      'tenant-pending-consent:pending-consent-secret-ref',
+      'pending-consent-client-secret'
+    );
+
+    await expect(resolveMicrosoftConsumerProfileConfig('tenant-pending-consent', 'email')).resolves.toEqual({
+      status: 'invalid_profile',
+      tenantId: 'tenant-pending-consent',
+      consumerType: 'email',
+      profileId: 'profile-pending-consent',
+      message: 'Selected Email Microsoft profile is awaiting tenant administrator consent',
+    });
   });
 
   it('T401: falls back to hosted app-level Microsoft email credentials when no Email binding exists', async () => {

--- a/packages/integrations/src/lib/microsoftConsumerProfileResolution.ts
+++ b/packages/integrations/src/lib/microsoftConsumerProfileResolution.ts
@@ -26,6 +26,8 @@ interface MicrosoftProfileRow {
   client_id: string;
   tenant_id: string;
   client_secret_ref: string;
+  email_admin_consent_required?: boolean;
+  email_admin_consent_granted_at?: string | Date | null;
   capabilities: MicrosoftProfileConsumer[] | string | null;
   is_default: boolean;
   is_archived: boolean;
@@ -529,6 +531,20 @@ export async function resolveMicrosoftConsumerProfileConfig(
       consumerType,
       profileId: profile.profile_id,
       message: `Selected ${getConsumerLabel(consumerType)} Microsoft profile is not enabled for ${getConsumerLabel(consumerType)}`,
+    };
+  }
+
+  if (
+    consumerType === 'email' &&
+    profile.email_admin_consent_required &&
+    !profile.email_admin_consent_granted_at
+  ) {
+    return {
+      status: 'invalid_profile',
+      tenantId,
+      consumerType,
+      profileId: profile.profile_id,
+      message: 'Selected Email Microsoft profile is awaiting tenant administrator consent',
     };
   }
 

--- a/packages/integrations/src/lib/microsoftConsumerVisibility.test.ts
+++ b/packages/integrations/src/lib/microsoftConsumerVisibility.test.ts
@@ -37,10 +37,10 @@ describe('microsoftConsumerVisibility', () => {
     }
   });
 
-  it('returns only MSP SSO in community edition', () => {
-    expect(getVisibleMicrosoftConsumerTypes(false)).toEqual(['msp_sso']);
+  it('keeps Microsoft Email available in community edition', () => {
+    expect(getVisibleMicrosoftConsumerTypes(false)).toEqual(['msp_sso', 'email']);
     expect(isVisibleMicrosoftConsumerType('msp_sso', false)).toBe(true);
-    expect(isVisibleMicrosoftConsumerType('email', false)).toBe(false);
+    expect(isVisibleMicrosoftConsumerType('email', false)).toBe(true);
     expect(isVisibleMicrosoftConsumerType('calendar', false)).toBe(false);
     expect(isVisibleMicrosoftConsumerType('teams', false)).toBe(false);
   });

--- a/packages/integrations/src/lib/microsoftConsumerVisibility.ts
+++ b/packages/integrations/src/lib/microsoftConsumerVisibility.ts
@@ -1,6 +1,6 @@
 import type { MicrosoftProfileConsumer } from '../actions/integrations/microsoftShared';
 
-const CE_VISIBLE_MICROSOFT_CONSUMERS: MicrosoftProfileConsumer[] = ['msp_sso'];
+const CE_VISIBLE_MICROSOFT_CONSUMERS: MicrosoftProfileConsumer[] = ['msp_sso', 'email'];
 const EE_VISIBLE_MICROSOFT_CONSUMERS: MicrosoftProfileConsumer[] = ['msp_sso', 'email', 'calendar', 'teams'];
 
 export function isMicrosoftConsumerEnterpriseEdition(): boolean {

--- a/packages/integrations/src/lib/microsoftEmailSetup.test.ts
+++ b/packages/integrations/src/lib/microsoftEmailSetup.test.ts
@@ -1,0 +1,92 @@
+import { describe, expect, it } from 'vitest';
+import {
+  buildMicrosoftEmailAdminConsentUrl,
+  buildMicrosoftEmailApplicationManifest,
+  createMicrosoftEmailSetupState,
+  MICROSOFT_EMAIL_DELEGATED_PERMISSION_IDS,
+  MICROSOFT_GRAPH_RESOURCE_APP_ID,
+  validateMicrosoftEmailSetupState,
+  validateMicrosoftTenantIdentifier,
+} from './microsoftEmailSetup';
+
+describe('Microsoft email setup builders', () => {
+  it('builds a tenant-specific v2 admin consent URL with exact callback and state', () => {
+    const url = new URL(buildMicrosoftEmailAdminConsentUrl({
+      tenant: '11111111-2222-4333-8444-555555555555',
+      clientId: 'client-id',
+      redirectUri: 'https://psa.example.com/api/auth/microsoft/email-setup/callback',
+      state: 'signed.state',
+    }));
+
+    expect(url.origin).toBe('https://login.microsoftonline.com');
+    expect(url.pathname).toBe('/11111111-2222-4333-8444-555555555555/v2.0/adminconsent');
+    expect(url.searchParams.get('client_id')).toBe('client-id');
+    expect(url.searchParams.get('redirect_uri')).toBe('https://psa.example.com/api/auth/microsoft/email-setup/callback');
+    expect(url.searchParams.get('state')).toBe('signed.state');
+  });
+
+  it('builds a multi-tenant application manifest with only the required read-only delegated permissions', () => {
+    const manifest = buildMicrosoftEmailApplicationManifest({
+      displayName: '  Alga   Email  ',
+      mailboxRedirectUri: 'https://psa.example.com/api/auth/microsoft/callback',
+      setupRedirectUri: 'https://psa.example.com/api/auth/microsoft/email-setup/callback',
+    });
+
+    expect(manifest.displayName).toBe('Alga Email');
+    expect(manifest.signInAudience).toBe('AzureADMultipleOrgs');
+    expect(manifest.web.redirectUris).toEqual([
+      'https://psa.example.com/api/auth/microsoft/callback',
+      'https://psa.example.com/api/auth/microsoft/email-setup/callback',
+    ]);
+    expect(manifest.requiredResourceAccess).toEqual([{
+      resourceAppId: MICROSOFT_GRAPH_RESOURCE_APP_ID,
+      resourceAccess: [
+        { id: MICROSOFT_EMAIL_DELEGATED_PERMISSION_IDS.mailRead, type: 'Scope' },
+        { id: MICROSOFT_EMAIL_DELEGATED_PERMISSION_IDS.mailReadShared, type: 'Scope' },
+        { id: MICROSOFT_EMAIL_DELEGATED_PERMISSION_IDS.offlineAccess, type: 'Scope' },
+      ],
+    }]);
+    expect(JSON.stringify(manifest)).not.toContain('Mail.Send');
+    expect(JSON.stringify(manifest)).not.toContain('Mail.ReadWrite');
+  });
+
+  it('signs expiring setup state and rejects tampering or expiry', () => {
+    const created = createMicrosoftEmailSetupState({
+      purpose: 'create_application',
+      algaTenant: 'alga-tenant',
+      userId: 'user-1',
+      returnTo: 'https://psa.example.com/msp/settings?category=providers',
+      displayName: 'Alga Email',
+      includeOauthNonce: true,
+      secret: 'test-signing-secret',
+      ttlSeconds: 60,
+    });
+
+    expect(validateMicrosoftEmailSetupState({
+      token: created.token,
+      secret: 'test-signing-secret',
+      now: created.payload.issuedAt + 30,
+    })).toMatchObject({
+      purpose: 'create_application',
+      algaTenant: 'alga-tenant',
+      userId: 'user-1',
+      displayName: 'Alga Email',
+    });
+    expect(validateMicrosoftEmailSetupState({
+      token: `${created.token}tampered`,
+      secret: 'test-signing-secret',
+    })).toBeNull();
+    expect(validateMicrosoftEmailSetupState({
+      token: created.token,
+      secret: 'test-signing-secret',
+      now: created.payload.expiresAt,
+    })).toBeNull();
+  });
+
+  it('accepts tenant UUIDs and verified domains but rejects common and paths', () => {
+    expect(validateMicrosoftTenantIdentifier('Contoso.onmicrosoft.com')).toBe('contoso.onmicrosoft.com');
+    expect(validateMicrosoftTenantIdentifier('11111111-2222-4333-8444-555555555555')).toBe('11111111-2222-4333-8444-555555555555');
+    expect(() => validateMicrosoftTenantIdentifier('common')).toThrow();
+    expect(() => validateMicrosoftTenantIdentifier('contoso.com/path')).toThrow();
+  });
+});

--- a/packages/integrations/src/lib/microsoftEmailSetup.test.ts
+++ b/packages/integrations/src/lib/microsoftEmailSetup.test.ts
@@ -55,7 +55,7 @@ describe('Microsoft email setup builders', () => {
       purpose: 'create_application',
       algaTenant: 'alga-tenant',
       userId: 'user-1',
-      returnTo: 'https://psa.example.com/msp/settings?category=providers',
+      returnTo: 'https://psa.example.com/msp/settings/integrations?category=providers',
       displayName: 'Alga Email',
       includeOauthNonce: true,
       secret: 'test-signing-secret',

--- a/packages/integrations/src/lib/microsoftEmailSetup.ts
+++ b/packages/integrations/src/lib/microsoftEmailSetup.ts
@@ -38,6 +38,7 @@ export interface MicrosoftEmailSetupStatePayload {
   oauthNonce?: string;
   displayName?: string;
   clientId?: string;
+  profileId?: string;
   issuedAt: number;
   expiresAt: number;
 }
@@ -59,6 +60,7 @@ export function buildMicrosoftEmailAdminConsentUrl(input: {
   clientId: string;
   redirectUri: string;
   state: string;
+  loginBaseUrl?: string;
 }): string {
   const tenant = validateMicrosoftTenantIdentifier(input.tenant);
   const clientId = input.clientId.trim();
@@ -73,7 +75,8 @@ export function buildMicrosoftEmailAdminConsentUrl(input: {
     state: input.state,
   });
 
-  return `https://login.microsoftonline.com/${encodeURIComponent(tenant)}/v2.0/adminconsent?${params.toString()}`;
+  const loginBaseUrl = (input.loginBaseUrl || 'https://login.microsoftonline.com').replace(/\/+$/, '');
+  return `${loginBaseUrl}/${encodeURIComponent(tenant)}/v2.0/adminconsent?${params.toString()}`;
 }
 
 export function buildMicrosoftEmailApplicationManifest(input: {
@@ -116,6 +119,7 @@ export function createMicrosoftEmailSetupState(input: {
   secret: string;
   displayName?: string;
   clientId?: string;
+  profileId?: string;
   includeOauthNonce?: boolean;
   ttlSeconds?: number;
 }): { token: string; payload: MicrosoftEmailSetupStatePayload } {
@@ -133,6 +137,7 @@ export function createMicrosoftEmailSetupState(input: {
     ...(input.includeOauthNonce ? { oauthNonce: randomBytes(24).toString('hex') } : {}),
     ...(input.displayName ? { displayName: input.displayName } : {}),
     ...(input.clientId ? { clientId: input.clientId } : {}),
+    ...(input.profileId ? { profileId: input.profileId } : {}),
     issuedAt,
     expiresAt: issuedAt + (input.ttlSeconds ?? MICROSOFT_EMAIL_SETUP_STATE_TTL_SECONDS),
   };
@@ -177,6 +182,7 @@ export function validateMicrosoftEmailSetupState(input: {
     const now = input.now ?? Math.floor(Date.now() / 1000);
     if (payload.issuedAt > now + 60 || payload.expiresAt <= now) return null;
     if (payload.purpose === 'create_application' && !payload.oauthNonce) return null;
+    if (payload.purpose === 'admin_consent' && (!payload.clientId || !payload.profileId)) return null;
 
     return payload as MicrosoftEmailSetupStatePayload;
   } catch {

--- a/packages/integrations/src/lib/microsoftEmailSetup.ts
+++ b/packages/integrations/src/lib/microsoftEmailSetup.ts
@@ -1,0 +1,213 @@
+import { createHash, createHmac, randomBytes, timingSafeEqual } from 'node:crypto';
+
+export const MICROSOFT_GRAPH_RESOURCE_APP_ID = '00000003-0000-0000-c000-000000000000';
+
+export const MICROSOFT_EMAIL_DELEGATED_PERMISSION_IDS = {
+  mailRead: '570282fd-fa5c-430d-a7fd-fc8dc98a9dca',
+  mailReadShared: '7b9103a5-4610-446b-9670-80643382c1fa',
+  offlineAccess: '7427e0e9-2fba-42fe-b0c0-848c9e6a8182',
+} as const;
+
+export const MICROSOFT_EMAIL_SETUP_BOOTSTRAP_SCOPES = [
+  'https://graph.microsoft.com/Application.ReadWrite.All',
+  'openid',
+  'profile',
+  'email',
+] as const;
+
+export const MICROSOFT_EMAIL_SETUP_STATE_TTL_SECONDS = 10 * 60;
+
+export interface MicrosoftEmailApplicationManifest {
+  displayName: string;
+  signInAudience: 'AzureADMultipleOrgs';
+  web: {
+    redirectUris: string[];
+  };
+  requiredResourceAccess: Array<{
+    resourceAppId: string;
+    resourceAccess: Array<{ id: string; type: 'Scope' }>;
+  }>;
+}
+
+export interface MicrosoftEmailSetupStatePayload {
+  purpose: 'create_application' | 'admin_consent';
+  algaTenant: string;
+  userId: string;
+  returnTo: string;
+  nonce: string;
+  oauthNonce?: string;
+  displayName?: string;
+  clientId?: string;
+  issuedAt: number;
+  expiresAt: number;
+}
+
+function toBase64Url(value: Buffer | string): string {
+  return Buffer.from(value).toString('base64url');
+}
+
+function fromBase64Url(value: string): string {
+  return Buffer.from(value, 'base64url').toString('utf8');
+}
+
+function signPayload(payloadEncoded: string, secret: string): string {
+  return toBase64Url(createHmac('sha256', secret).update(payloadEncoded).digest());
+}
+
+export function buildMicrosoftEmailAdminConsentUrl(input: {
+  tenant: string;
+  clientId: string;
+  redirectUri: string;
+  state: string;
+}): string {
+  const tenant = validateMicrosoftTenantIdentifier(input.tenant);
+  const clientId = input.clientId.trim();
+  if (!clientId) {
+    throw new Error('Microsoft application client ID is required');
+  }
+
+  const redirectUri = new URL(input.redirectUri).toString();
+  const params = new URLSearchParams({
+    client_id: clientId,
+    redirect_uri: redirectUri,
+    state: input.state,
+  });
+
+  return `https://login.microsoftonline.com/${encodeURIComponent(tenant)}/v2.0/adminconsent?${params.toString()}`;
+}
+
+export function buildMicrosoftEmailApplicationManifest(input: {
+  displayName: string;
+  mailboxRedirectUri: string;
+  setupRedirectUri?: string;
+}): MicrosoftEmailApplicationManifest {
+  const displayName = input.displayName.normalize('NFKC').replace(/\s+/g, ' ').trim();
+  if (!displayName) {
+    throw new Error('Microsoft application display name is required');
+  }
+
+  const redirectUris = [input.mailboxRedirectUri, input.setupRedirectUri]
+    .filter((value): value is string => Boolean(value))
+    .map((value) => new URL(value).toString());
+
+  return {
+    displayName,
+    signInAudience: 'AzureADMultipleOrgs',
+    web: {
+      redirectUris: [...new Set(redirectUris)],
+    },
+    requiredResourceAccess: [
+      {
+        resourceAppId: MICROSOFT_GRAPH_RESOURCE_APP_ID,
+        resourceAccess: Object.values(MICROSOFT_EMAIL_DELEGATED_PERMISSION_IDS).map((id) => ({
+          id,
+          type: 'Scope' as const,
+        })),
+      },
+    ],
+  };
+}
+
+export function createMicrosoftEmailSetupState(input: {
+  purpose: MicrosoftEmailSetupStatePayload['purpose'];
+  algaTenant: string;
+  userId: string;
+  returnTo: string;
+  secret: string;
+  displayName?: string;
+  clientId?: string;
+  includeOauthNonce?: boolean;
+  ttlSeconds?: number;
+}): { token: string; payload: MicrosoftEmailSetupStatePayload } {
+  if (!input.secret.trim()) {
+    throw new Error('Microsoft email setup signing secret is not configured');
+  }
+
+  const issuedAt = Math.floor(Date.now() / 1000);
+  const payload: MicrosoftEmailSetupStatePayload = {
+    purpose: input.purpose,
+    algaTenant: input.algaTenant,
+    userId: input.userId,
+    returnTo: new URL(input.returnTo).toString(),
+    nonce: randomBytes(24).toString('hex'),
+    ...(input.includeOauthNonce ? { oauthNonce: randomBytes(24).toString('hex') } : {}),
+    ...(input.displayName ? { displayName: input.displayName } : {}),
+    ...(input.clientId ? { clientId: input.clientId } : {}),
+    issuedAt,
+    expiresAt: issuedAt + (input.ttlSeconds ?? MICROSOFT_EMAIL_SETUP_STATE_TTL_SECONDS),
+  };
+  const payloadEncoded = toBase64Url(JSON.stringify(payload));
+  return {
+    token: `${payloadEncoded}.${signPayload(payloadEncoded, input.secret)}`,
+    payload,
+  };
+}
+
+export function validateMicrosoftEmailSetupState(input: {
+  token: string | null | undefined;
+  secret: string | null | undefined;
+  now?: number;
+}): MicrosoftEmailSetupStatePayload | null {
+  if (!input.token || !input.secret) return null;
+
+  const [payloadEncoded, signature, extra] = input.token.split('.');
+  if (!payloadEncoded || !signature || extra) return null;
+
+  const expected = Buffer.from(signPayload(payloadEncoded, input.secret));
+  const received = Buffer.from(signature);
+  if (expected.length !== received.length || !timingSafeEqual(expected, received)) {
+    return null;
+  }
+
+  try {
+    const payload = JSON.parse(fromBase64Url(payloadEncoded)) as Partial<MicrosoftEmailSetupStatePayload>;
+    if (
+      (payload.purpose !== 'create_application' && payload.purpose !== 'admin_consent') ||
+      typeof payload.algaTenant !== 'string' ||
+      typeof payload.userId !== 'string' ||
+      typeof payload.returnTo !== 'string' ||
+      typeof payload.nonce !== 'string' ||
+      typeof payload.issuedAt !== 'number' ||
+      typeof payload.expiresAt !== 'number'
+    ) {
+      return null;
+    }
+
+    new URL(payload.returnTo);
+    const now = input.now ?? Math.floor(Date.now() / 1000);
+    if (payload.issuedAt > now + 60 || payload.expiresAt <= now) return null;
+    if (payload.purpose === 'create_application' && !payload.oauthNonce) return null;
+
+    return payload as MicrosoftEmailSetupStatePayload;
+  } catch {
+    return null;
+  }
+}
+
+export function createPkcePair(): { verifier: string; challenge: string } {
+  const verifier = randomBytes(64).toString('base64url');
+  const challenge = createHash('sha256').update(verifier).digest('base64url');
+  return { verifier, challenge };
+}
+
+export function validateMicrosoftTenantIdentifier(value: string): string {
+  const normalized = value.normalize('NFKC').trim().toLowerCase();
+  const uuidPattern = /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
+  const domainPattern = /^(?=.{1,253}$)(?!-)(?:[a-z0-9](?:[a-z0-9-]{0,61}[a-z0-9])?\.)+[a-z]{2,63}$/i;
+
+  if (!uuidPattern.test(normalized) && !domainPattern.test(normalized)) {
+    throw new Error('Enter a valid Microsoft tenant ID or verified tenant domain');
+  }
+
+  return normalized;
+}
+
+export function decodeJwtPayload(token: string): Record<string, unknown> | null {
+  try {
+    const parts = token.split('.');
+    if (parts.length !== 3) return null;
+    return JSON.parse(Buffer.from(parts[1], 'base64url').toString('utf8')) as Record<string, unknown>;
+  } catch {
+    return null;
+  }
+}

--- a/packages/integrations/src/utils/microsoftEmailSetupStateStore.ts
+++ b/packages/integrations/src/utils/microsoftEmailSetupStateStore.ts
@@ -1,0 +1,102 @@
+import { createClient, type RedisClientType } from 'redis';
+import logger from '@alga-psa/core/logger';
+import { getSecretProviderInstance } from '@alga-psa/core/secrets';
+import { getRedisConfig } from '@alga-psa/event-bus';
+
+const STATE_NAMESPACE = 'microsoft:email_setup';
+const DEFAULT_TTL_SECONDS = 10 * 60;
+
+export interface StoredMicrosoftEmailSetupState {
+  verifier: string;
+  algaTenant: string;
+  userId: string;
+  oauthNonce: string;
+}
+
+let redisClientPromise: Promise<RedisClientType | null> | null = null;
+const memoryStore = new Map<string, { state: StoredMicrosoftEmailSetupState; expiresAt: number }>();
+
+async function getRedisClient(): Promise<RedisClientType | null> {
+  if (!redisClientPromise) {
+    redisClientPromise = (async () => {
+      try {
+        const config = getRedisConfig();
+        const secretProvider = await getSecretProviderInstance();
+        const password =
+          (await secretProvider.getAppSecret('redis_password')) ||
+          process.env.REDIS_PASSWORD ||
+          undefined;
+        const client = createClient({ url: config.url, password });
+        client.on('error', (error) => {
+          logger.error('[MicrosoftEmailSetupStateStore] Redis client error', error);
+        });
+        await client.connect();
+        return client as RedisClientType;
+      } catch (error) {
+        logger.error('[MicrosoftEmailSetupStateStore] Failed to create Redis client', error);
+        return null;
+      }
+    })();
+  }
+
+  return redisClientPromise;
+}
+
+function buildKey(nonce: string): string {
+  return `${STATE_NAMESPACE}:${nonce}`;
+}
+
+export async function storeMicrosoftEmailSetupState(
+  nonce: string,
+  state: StoredMicrosoftEmailSetupState,
+  ttlSeconds = DEFAULT_TTL_SECONDS
+): Promise<void> {
+  const key = buildKey(nonce);
+  try {
+    const client = await getRedisClient();
+    if (client) {
+      await client.set(key, JSON.stringify(state), { EX: ttlSeconds });
+      return;
+    }
+  } catch (error) {
+    logger.warn(
+      '[MicrosoftEmailSetupStateStore] Falling back to in-memory state storage',
+      error instanceof Error ? error.message : error
+    );
+  }
+
+  memoryStore.set(key, {
+    state,
+    expiresAt: Date.now() + ttlSeconds * 1000,
+  });
+}
+
+export async function consumeMicrosoftEmailSetupState(
+  nonce: string
+): Promise<StoredMicrosoftEmailSetupState | null> {
+  const key = buildKey(nonce);
+  try {
+    const client = await getRedisClient();
+    if (client) {
+      const raw = await client.getDel(key);
+      if (raw) {
+        try {
+          return JSON.parse(raw) as StoredMicrosoftEmailSetupState;
+        } catch (error) {
+          logger.error('[MicrosoftEmailSetupStateStore] Failed to parse stored state', error);
+          return null;
+        }
+      }
+    }
+  } catch (error) {
+    logger.warn(
+      '[MicrosoftEmailSetupStateStore] Redis unavailable while consuming state',
+      error instanceof Error ? error.message : error
+    );
+  }
+
+  const stored = memoryStore.get(key);
+  memoryStore.delete(key);
+  if (!stored || stored.expiresAt <= Date.now()) return null;
+  return stored.state;
+}

--- a/scripts/microsoft-email-ready-false-smoke-fixture.mjs
+++ b/scripts/microsoft-email-ready-false-smoke-fixture.mjs
@@ -1,0 +1,233 @@
+#!/usr/bin/env node
+
+/**
+ * Create a reversible, tenant-scoped Microsoft Email readiness smoke fixture.
+ *
+ * The fixture models a fully credentialed tenant-owned Email profile whose
+ * administrator consent is still pending. It binds that profile directly so
+ * the mailbox form's defensive ready:false UI can be exercised. Normal product
+ * onboarding deliberately waits for consent before creating this binding.
+ *
+ * Usage:
+ *   node scripts/microsoft-email-ready-false-smoke-fixture.mjs apply <tenant-id>
+ *   node scripts/microsoft-email-ready-false-smoke-fixture.mjs status <tenant-id>
+ *   node scripts/microsoft-email-ready-false-smoke-fixture.mjs cleanup <tenant-id>
+ *
+ * Database settings use the same DB_* environment variables as the migration
+ * tooling. The state file contains only profile IDs and is written to /tmp by
+ * default; set MICROSOFT_EMAIL_READY_FALSE_STATE_FILE to override it.
+ */
+
+import crypto from 'node:crypto';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import knexFactory from 'knex';
+import { getSecretProviderInstance } from '@alga-psa/core/secrets';
+
+const [command, tenantId] = process.argv.slice(2);
+const allowedCommands = new Set(['apply', 'status', 'cleanup']);
+const uuidPattern = /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
+
+if (!allowedCommands.has(command) || !uuidPattern.test(tenantId || '')) {
+  console.error(
+    'Usage: node scripts/microsoft-email-ready-false-smoke-fixture.mjs <apply|status|cleanup> <tenant-id>'
+  );
+  process.exit(1);
+}
+
+function deterministicUuid(value) {
+  const bytes = crypto.createHash('sha256').update(value).digest().subarray(0, 16);
+  bytes[6] = (bytes[6] & 0x0f) | 0x40;
+  bytes[8] = (bytes[8] & 0x3f) | 0x80;
+  const hex = bytes.toString('hex');
+  return `${hex.slice(0, 8)}-${hex.slice(8, 12)}-${hex.slice(12, 16)}-${hex.slice(16, 20)}-${hex.slice(20)}`;
+}
+
+const fixtureProfileId = deterministicUuid(`alga0002215:${tenantId}:ready-false-profile`);
+const fixtureDisplayName = 'Smoke Microsoft Email - Consent Pending (alga0002215)';
+const fixtureSecretRef = `microsoft_profile_${fixtureProfileId}_client_secret`;
+const stateFile = process.env.MICROSOFT_EMAIL_READY_FALSE_STATE_FILE
+  || path.join(os.tmpdir(), `alga0002215-microsoft-email-ready-false-${tenantId}.json`);
+
+const db = knexFactory({
+  client: 'pg',
+  connection: {
+    host: process.env.DB_HOST || 'localhost',
+    port: Number(process.env.DB_PORT_DIRECT || process.env.DB_PORT || 5432),
+    user: process.env.DB_USER_ADMIN || 'postgres',
+    password: process.env.DB_PASSWORD_ADMIN || 'postpass123',
+    database: process.env.DB_NAME_SERVER || 'server',
+  },
+});
+
+const secretProvider = await getSecretProviderInstance();
+
+function scoped(table) {
+  return db(table).where({ tenant: tenantId });
+}
+
+async function readStatus() {
+  const [profile, binding, clientSecret] = await Promise.all([
+    scoped('microsoft_profiles').where({ profile_id: fixtureProfileId }).first(),
+    scoped('microsoft_profile_consumer_bindings').where({ consumer_type: 'email' }).first(),
+    secretProvider.getTenantSecret(tenantId, fixtureSecretRef),
+  ]);
+
+  return {
+    tenantId,
+    fixtureProfileId,
+    profileExists: Boolean(profile),
+    emailBindingProfileId: binding?.profile_id || null,
+    boundToFixture: binding?.profile_id === fixtureProfileId,
+    clientIdConfigured: Boolean(profile?.client_id),
+    clientSecretConfigured: Boolean(clientSecret),
+    tenantIdConfigured: Boolean(profile?.tenant_id),
+    emailAdminConsentRequired: Boolean(profile?.email_admin_consent_required),
+    emailAdminConsentGranted: Boolean(profile?.email_admin_consent_granted_at),
+    expectedReady: false,
+    stateFile,
+  };
+}
+
+async function applyFixture() {
+  const tenant = await db('tenants').where({ tenant: tenantId }).first('tenant');
+  if (!tenant) {
+    throw new Error(`Tenant ${tenantId} does not exist`);
+  }
+  if (fs.existsSync(stateFile)) {
+    const status = await readStatus();
+    if (status.boundToFixture && status.profileExists) {
+      return status;
+    }
+    throw new Error(`Fixture state file already exists but the database state is inconsistent: ${stateFile}`);
+  }
+
+  const [existingFixture, existingBinding] = await Promise.all([
+    scoped('microsoft_profiles').where({ profile_id: fixtureProfileId }).first(),
+    scoped('microsoft_profile_consumer_bindings').where({ consumer_type: 'email' }).first(),
+  ]);
+  if (existingFixture) {
+    throw new Error(`Fixture profile ${fixtureProfileId} already exists without a state file; remove it manually after review`);
+  }
+
+  fs.writeFileSync(
+    stateFile,
+    `${JSON.stringify({ tenantId, fixtureProfileId, previousEmailProfileId: existingBinding?.profile_id || null }, null, 2)}\n`,
+    { flag: 'wx', mode: 0o600 }
+  );
+
+  try {
+    await secretProvider.setTenantSecret(tenantId, fixtureSecretRef, 'smoke-secret-alga0002215-not-for-oauth');
+    const now = new Date();
+    await db.transaction(async (trx) => {
+      await trx('microsoft_profiles').insert({
+        tenant: tenantId,
+        profile_id: fixtureProfileId,
+        display_name: fixtureDisplayName,
+        display_name_normalized: fixtureDisplayName.toLocaleLowerCase(),
+        client_id: 'smoke-consent-pending-client-alga0002215',
+        tenant_id: 'smoke-consent-pending-tenant-alga0002215',
+        client_secret_ref: fixtureSecretRef,
+        email_admin_consent_required: true,
+        email_admin_consent_granted_at: null,
+        email_admin_consent_tenant_id: null,
+        capabilities: JSON.stringify(['email']),
+        is_default: false,
+        is_archived: false,
+        archived_at: null,
+        created_by: null,
+        updated_by: null,
+        created_at: now,
+        updated_at: now,
+      });
+
+      const binding = await trx('microsoft_profile_consumer_bindings')
+        .where({ tenant: tenantId, consumer_type: 'email' })
+        .first();
+      if (binding) {
+        await trx('microsoft_profile_consumer_bindings')
+          .where({ tenant: tenantId, consumer_type: 'email' })
+          .update({ profile_id: fixtureProfileId, updated_by: null, updated_at: now });
+      } else {
+        await trx('microsoft_profile_consumer_bindings').insert({
+          tenant: tenantId,
+          consumer_type: 'email',
+          profile_id: fixtureProfileId,
+          created_by: null,
+          updated_by: null,
+          created_at: now,
+          updated_at: now,
+        });
+      }
+    });
+  } catch (error) {
+    await secretProvider.setTenantSecret(tenantId, fixtureSecretRef, null).catch(() => undefined);
+    fs.rmSync(stateFile, { force: true });
+    throw error;
+  }
+
+  return readStatus();
+}
+
+async function cleanupFixture() {
+  if (!fs.existsSync(stateFile)) {
+    throw new Error(`Fixture state file does not exist: ${stateFile}`);
+  }
+  const state = JSON.parse(fs.readFileSync(stateFile, 'utf8'));
+  if (state.tenantId !== tenantId || state.fixtureProfileId !== fixtureProfileId) {
+    throw new Error(`Fixture state file does not match tenant/profile: ${stateFile}`);
+  }
+
+  await db.transaction(async (trx) => {
+    const binding = await trx('microsoft_profile_consumer_bindings')
+      .where({ tenant: tenantId, consumer_type: 'email' })
+      .first();
+    if (binding?.profile_id !== fixtureProfileId) {
+      throw new Error('Email binding no longer points to the smoke fixture; refusing to overwrite newer product state');
+    }
+
+    if (state.previousEmailProfileId) {
+      const previousProfile = await trx('microsoft_profiles')
+        .where({ tenant: tenantId, profile_id: state.previousEmailProfileId, is_archived: false })
+        .first();
+      if (!previousProfile) {
+        throw new Error(`Previous Email profile ${state.previousEmailProfileId} is unavailable; refusing cleanup`);
+      }
+      await trx('microsoft_profile_consumer_bindings')
+        .where({ tenant: tenantId, consumer_type: 'email' })
+        .update({ profile_id: state.previousEmailProfileId, updated_by: null, updated_at: new Date() });
+    } else {
+      await trx('microsoft_profile_consumer_bindings')
+        .where({ tenant: tenantId, consumer_type: 'email' })
+        .delete();
+    }
+
+    await trx('microsoft_profiles')
+      .where({ tenant: tenantId, profile_id: fixtureProfileId })
+      .delete();
+  });
+
+  await secretProvider.setTenantSecret(tenantId, fixtureSecretRef, null);
+  fs.rmSync(stateFile);
+  return {
+    tenantId,
+    fixtureProfileId,
+    restoredEmailProfileId: state.previousEmailProfileId || null,
+    cleanedUp: true,
+  };
+}
+
+try {
+  const result = command === 'apply'
+    ? await applyFixture()
+    : command === 'cleanup'
+      ? await cleanupFixture()
+      : await readStatus();
+  console.log(JSON.stringify(result, null, 2));
+} catch (error) {
+  console.error(error instanceof Error ? error.message : String(error));
+  process.exitCode = 1;
+} finally {
+  await db.destroy();
+}

--- a/server/migrations/20260803000000_add_microsoft_email_admin_consent_tracking.cjs
+++ b/server/migrations/20260803000000_add_microsoft_email_admin_consent_tracking.cjs
@@ -1,5 +1,5 @@
 /**
- * Track administrator consent for profiles created by the guided Microsoft
+ * Tracks administrator consent for profiles created by the guided Microsoft
  * Email setup. Existing/manual profiles retain their historical readiness
  * behavior because consent is not marked as required for those rows.
  */

--- a/server/migrations/20260803120000_add_microsoft_email_admin_consent_tracking.cjs
+++ b/server/migrations/20260803120000_add_microsoft_email_admin_consent_tracking.cjs
@@ -1,0 +1,47 @@
+/**
+ * Track administrator consent for profiles created by the guided Microsoft
+ * Email setup. Existing/manual profiles retain their historical readiness
+ * behavior because consent is not marked as required for those rows.
+ */
+exports.up = async function up(knex) {
+  const hasTable = await knex.schema.hasTable('microsoft_profiles');
+  if (!hasTable) return;
+
+  const hasRequired = await knex.schema.hasColumn(
+    'microsoft_profiles',
+    'email_admin_consent_required'
+  );
+  const hasGrantedAt = await knex.schema.hasColumn(
+    'microsoft_profiles',
+    'email_admin_consent_granted_at'
+  );
+  const hasTenantId = await knex.schema.hasColumn(
+    'microsoft_profiles',
+    'email_admin_consent_tenant_id'
+  );
+
+  await knex.schema.alterTable('microsoft_profiles', (table) => {
+    if (!hasRequired) {
+      table.boolean('email_admin_consent_required').notNullable().defaultTo(false);
+    }
+    if (!hasGrantedAt) {
+      table.timestamp('email_admin_consent_granted_at', { useTz: true });
+    }
+    if (!hasTenantId) {
+      table.text('email_admin_consent_tenant_id');
+    }
+  });
+};
+
+exports.down = async function down(knex) {
+  const hasTable = await knex.schema.hasTable('microsoft_profiles');
+  if (!hasTable) return;
+
+  await knex.schema.alterTable('microsoft_profiles', (table) => {
+    table.dropColumn('email_admin_consent_tenant_id');
+    table.dropColumn('email_admin_consent_granted_at');
+    table.dropColumn('email_admin_consent_required');
+  });
+};
+
+exports.config = { transaction: false };

--- a/server/public/locales/de/msp/email-providers.json
+++ b/server/public/locales/de/msp/email-providers.json
@@ -318,6 +318,8 @@
         "setupLabel": "Microsoft Entra",
         "notConfigured": "Die Microsoft-Anbietereinstellungen sind nicht konfiguriert.",
         "setupHelp": "Konfigurieren Sie zunächst Anbieter unter Einstellungen → Integrationen → Anbieter und kehren Sie dann hierher zurück, um dieses Postfach zu autorisieren.",
+        "profileReady": "Das Microsoft-App-Profil ist bereit.",
+        "profileReadyHelp": "Falls die Zustimmung des Mandantenadministrators noch aussteht, schließen Sie sie in den Anbietereinstellungen ab. Verwenden Sie anschließend unten Zugriff autorisieren für dieses Postfach.",
         "redirectUriLabel": "Weiterleitungs-URI *",
         "redirectUriPlaceholder": "https://yourapp.com/api/auth/microsoft/callback",
         "authorizationTitle": "OAuth-Autorisierung",

--- a/server/public/locales/de/msp/integrations.json
+++ b/server/public/locales/de/msp/integrations.json
@@ -1553,6 +1553,7 @@
           "nameRequired": "Enter a display name for the Microsoft app.",
           "platform": "Could not configure the platform Microsoft app.",
           "popupBlocked": "Allow popups for this site, then try again.",
+          "popupClosed": "Das Microsoft-Fenster wurde geschlossen, bevor die Einrichtung abgeschlossen war. Versuchen Sie es erneut oder wählen Sie eine andere Einrichtungsoption.",
           "tenantRequired": "Enter your Microsoft tenant ID or verified domain."
         },
         "fields": {
@@ -1737,7 +1738,8 @@
           "archived": "Archivierte Profile können nicht für neue Microsoft-Bindungen verwendet werden.",
           "clientIdMissing": "Client ID fehlt.",
           "clientSecretMissing": "Client Secret wurde nicht konfiguriert.",
-          "tenantIdMissing": "Tenant ID fehlt."
+          "tenantIdMissing": "Tenant ID fehlt.",
+          "adminConsentPending": "Erteilen Sie die Zustimmung des Microsoft-Mandantenadministrators, um die E-Mail-Einrichtung abzuschließen."
         },
         "statusBadges": {
           "archived": "Archiviert",

--- a/server/public/locales/de/msp/integrations.json
+++ b/server/public/locales/de/msp/integrations.json
@@ -1517,6 +1517,61 @@
       }
     },
     "microsoft": {
+      "emailSetup": {
+        "action": "Set up Microsoft Email",
+        "actions": {
+          "back": "Back",
+          "cancel": "Cancel",
+          "copy": "Copy",
+          "finish": "Finish",
+          "grantConsent": "Grant administrator consent",
+          "savePlatform": "Create profile and continue",
+          "signIn": "Sign in to Microsoft",
+          "working": "Working…"
+        },
+        "automated": {
+          "description": "Sign in as a Microsoft administrator. Alga creates the app, service principal, secret, Email profile, and binding.",
+          "title": "Create an app in this tenant"
+        },
+        "callbackUri": "Mailbox callback URI",
+        "complete": {
+          "consentDone": "Administrator consent is confirmed. Return to Inbound Email and authorize the mailbox.",
+          "consentPending": "Next, a Microsoft tenant administrator must grant consent. Mailbox authorization happens afterward in Inbound Email.",
+          "profileCreated": "Microsoft Email profile created and bound"
+        },
+        "consent": {
+          "confirmedDescription": "The Microsoft app is ready for mailbox authorization.",
+          "confirmedTitle": "Administrator consent confirmed",
+          "url": "Administrator consent URL",
+          "urlLabel": "Consent URL"
+        },
+        "copied": "{{label}} copied",
+        "description": "Choose how to configure the Microsoft app used for inbound email. Mailbox authorization remains a separate final step.",
+        "errors": {
+          "automated": "Could not start automated Microsoft app creation.",
+          "generic": "Microsoft Email setup did not complete.",
+          "nameRequired": "Enter a display name for the Microsoft app.",
+          "platform": "Could not configure the platform Microsoft app.",
+          "popupBlocked": "Allow popups for this site, then try again.",
+          "tenantRequired": "Enter your Microsoft tenant ID or verified domain."
+        },
+        "fields": {
+          "clientId": "Client ID",
+          "displayName": "Profile display name",
+          "tenant": "Microsoft tenant ID or verified domain",
+          "tenantId": "Tenant ID"
+        },
+        "manual": {
+          "description": "Keep using the existing client ID, tenant ID, and client secret form.",
+          "title": "Enter an existing app manually"
+        },
+        "platform": {
+          "description": "Create an Email-bound profile from the server-managed multi-tenant app, then grant tenant administrator consent.",
+          "title": "Use the Alga platform app"
+        },
+        "title": "Set up Microsoft Email",
+        "unavailable": "Unavailable"
+      },
       "settings": {
         "advanced": {
           "title": "Bring your own Microsoft app (advanced)",

--- a/server/public/locales/en/msp/email-providers.json
+++ b/server/public/locales/en/msp/email-providers.json
@@ -318,6 +318,8 @@
         "setupLabel": "Microsoft Entra",
         "notConfigured": "Microsoft provider settings are not configured.",
         "setupHelp": "Configure Providers first in Settings → Integrations → Providers, then return here to authorize this mailbox.",
+        "profileReady": "Microsoft app profile is ready.",
+        "profileReadyHelp": "If tenant administrator consent is still pending, complete it in Providers settings. Then use Authorize Access below for this mailbox.",
         "redirectUriLabel": "Redirect URI *",
         "redirectUriPlaceholder": "https://yourapp.com/api/auth/microsoft/callback",
         "authorizationTitle": "OAuth Authorization",

--- a/server/public/locales/en/msp/integrations.json
+++ b/server/public/locales/en/msp/integrations.json
@@ -1517,6 +1517,61 @@
       }
     },
     "microsoft": {
+      "emailSetup": {
+        "action": "Set up Microsoft Email",
+        "actions": {
+          "back": "Back",
+          "cancel": "Cancel",
+          "copy": "Copy",
+          "finish": "Finish",
+          "grantConsent": "Grant administrator consent",
+          "savePlatform": "Create profile and continue",
+          "signIn": "Sign in to Microsoft",
+          "working": "Working…"
+        },
+        "automated": {
+          "description": "Sign in as a Microsoft administrator. Alga creates the app, service principal, secret, Email profile, and binding.",
+          "title": "Create an app in this tenant"
+        },
+        "callbackUri": "Mailbox callback URI",
+        "complete": {
+          "consentDone": "Administrator consent is confirmed. Return to Inbound Email and authorize the mailbox.",
+          "consentPending": "Next, a Microsoft tenant administrator must grant consent. Mailbox authorization happens afterward in Inbound Email.",
+          "profileCreated": "Microsoft Email profile created and bound"
+        },
+        "consent": {
+          "confirmedDescription": "The Microsoft app is ready for mailbox authorization.",
+          "confirmedTitle": "Administrator consent confirmed",
+          "url": "Administrator consent URL",
+          "urlLabel": "Consent URL"
+        },
+        "copied": "{{label}} copied",
+        "description": "Choose how to configure the Microsoft app used for inbound email. Mailbox authorization remains a separate final step.",
+        "errors": {
+          "automated": "Could not start automated Microsoft app creation.",
+          "generic": "Microsoft Email setup did not complete.",
+          "nameRequired": "Enter a display name for the Microsoft app.",
+          "platform": "Could not configure the platform Microsoft app.",
+          "popupBlocked": "Allow popups for this site, then try again.",
+          "tenantRequired": "Enter your Microsoft tenant ID or verified domain."
+        },
+        "fields": {
+          "clientId": "Client ID",
+          "displayName": "Profile display name",
+          "tenant": "Microsoft tenant ID or verified domain",
+          "tenantId": "Tenant ID"
+        },
+        "manual": {
+          "description": "Keep using the existing client ID, tenant ID, and client secret form.",
+          "title": "Enter an existing app manually"
+        },
+        "platform": {
+          "description": "Create an Email-bound profile from the server-managed multi-tenant app, then grant tenant administrator consent.",
+          "title": "Use the Alga platform app"
+        },
+        "title": "Set up Microsoft Email",
+        "unavailable": "Unavailable"
+      },
       "settings": {
         "advanced": {
           "title": "Bring your own Microsoft app (advanced)",

--- a/server/public/locales/en/msp/integrations.json
+++ b/server/public/locales/en/msp/integrations.json
@@ -1530,14 +1530,14 @@
           "working": "Working…"
         },
         "automated": {
-          "description": "Sign in as a Microsoft administrator. Alga creates the app, service principal, secret, Email profile, and binding.",
+          "description": "Sign in as a Microsoft administrator. Alga creates the app, service principal, secret, and a pending Email profile. The Email binding is created after administrator consent.",
           "title": "Create an app in this tenant"
         },
         "callbackUri": "Mailbox callback URI",
         "complete": {
           "consentDone": "Administrator consent is confirmed. Return to Inbound Email and authorize the mailbox.",
           "consentPending": "Next, a Microsoft tenant administrator must grant consent. Mailbox authorization happens afterward in Inbound Email.",
-          "profileCreated": "Microsoft Email profile created and bound"
+          "profileCreated": "Microsoft Email profile created"
         },
         "consent": {
           "confirmedDescription": "The Microsoft app is ready for mailbox authorization.",
@@ -1553,6 +1553,7 @@
           "nameRequired": "Enter a display name for the Microsoft app.",
           "platform": "Could not configure the platform Microsoft app.",
           "popupBlocked": "Allow popups for this site, then try again.",
+          "popupClosed": "The Microsoft window was closed before setup finished. Try again or choose another setup option.",
           "tenantRequired": "Enter your Microsoft tenant ID or verified domain."
         },
         "fields": {
@@ -1566,7 +1567,7 @@
           "title": "Enter an existing app manually"
         },
         "platform": {
-          "description": "Create an Email-bound profile from the server-managed multi-tenant app, then grant tenant administrator consent.",
+          "description": "Create a pending Email profile from the server-managed multi-tenant app. It is bound after tenant administrator consent.",
           "title": "Use the Alga platform app"
         },
         "title": "Set up Microsoft Email",
@@ -1649,7 +1650,7 @@
             "label": "Teams"
           }
         },
-        "descriptionCe": "Manage your company's Microsoft app registration for staff sign-in.",
+        "descriptionCe": "Manage your company's Microsoft app registrations for staff sign-in and Outlook email.",
         "descriptionEe": "Manage your company's Microsoft app registrations for staff sign-in, Outlook email, calendar sync, and Teams.",
         "disconnectDialog": {
           "cancel": "Keep providers connected",
@@ -1746,7 +1747,8 @@
           "archived": "Archived apps cannot be selected for Microsoft services.",
           "clientIdMissing": "Add a client ID.",
           "clientSecretMissing": "Add a client secret.",
-          "tenantIdMissing": "Add a tenant ID."
+          "tenantIdMissing": "Add a tenant ID.",
+          "adminConsentPending": "Grant Microsoft tenant administrator consent to finish Email setup."
         },
         "statusBadges": {
           "archived": "Archived",

--- a/server/public/locales/es/msp/email-providers.json
+++ b/server/public/locales/es/msp/email-providers.json
@@ -318,6 +318,8 @@
         "setupLabel": "MicrosoftEntra",
         "notConfigured": "La configuración del proveedor de Microsoft no está configurada.",
         "setupHelp": "Configure Proveedores primero en Configuración → Integraciones → Proveedores, luego regrese aquí para autorizar este buzón.",
+        "profileReady": "El perfil de la aplicación de Microsoft está listo.",
+        "profileReadyHelp": "Si el consentimiento del administrador del inquilino sigue pendiente, complételo en la configuración de Proveedores. Después, use Autorizar acceso para este buzón.",
         "redirectUriLabel": "URI de redireccionamiento *",
         "redirectUriPlaceholder": "https://yourapp.com/api/auth/microsoft/callback",
         "authorizationTitle": "Autorización de OAuth",

--- a/server/public/locales/es/msp/integrations.json
+++ b/server/public/locales/es/msp/integrations.json
@@ -1553,6 +1553,7 @@
           "nameRequired": "Enter a display name for the Microsoft app.",
           "platform": "Could not configure the platform Microsoft app.",
           "popupBlocked": "Allow popups for this site, then try again.",
+          "popupClosed": "La ventana de Microsoft se cerró antes de finalizar la configuración. Inténtelo de nuevo o elija otra opción de configuración.",
           "tenantRequired": "Enter your Microsoft tenant ID or verified domain."
         },
         "fields": {
@@ -1737,7 +1738,8 @@
           "archived": "Los perfiles archivados no pueden utilizarse para nuevos enlaces de Microsoft.",
           "clientIdMissing": "Falta el Client ID.",
           "clientSecretMissing": "No se ha configurado el client secret.",
-          "tenantIdMissing": "Falta el Tenant ID."
+          "tenantIdMissing": "Falta el Tenant ID.",
+          "adminConsentPending": "Conceda el consentimiento del administrador del inquilino de Microsoft para finalizar la configuración del correo electrónico."
         },
         "statusBadges": {
           "archived": "Archivado",

--- a/server/public/locales/es/msp/integrations.json
+++ b/server/public/locales/es/msp/integrations.json
@@ -1517,6 +1517,61 @@
       }
     },
     "microsoft": {
+      "emailSetup": {
+        "action": "Set up Microsoft Email",
+        "actions": {
+          "back": "Back",
+          "cancel": "Cancel",
+          "copy": "Copy",
+          "finish": "Finish",
+          "grantConsent": "Grant administrator consent",
+          "savePlatform": "Create profile and continue",
+          "signIn": "Sign in to Microsoft",
+          "working": "Working…"
+        },
+        "automated": {
+          "description": "Sign in as a Microsoft administrator. Alga creates the app, service principal, secret, Email profile, and binding.",
+          "title": "Create an app in this tenant"
+        },
+        "callbackUri": "Mailbox callback URI",
+        "complete": {
+          "consentDone": "Administrator consent is confirmed. Return to Inbound Email and authorize the mailbox.",
+          "consentPending": "Next, a Microsoft tenant administrator must grant consent. Mailbox authorization happens afterward in Inbound Email.",
+          "profileCreated": "Microsoft Email profile created and bound"
+        },
+        "consent": {
+          "confirmedDescription": "The Microsoft app is ready for mailbox authorization.",
+          "confirmedTitle": "Administrator consent confirmed",
+          "url": "Administrator consent URL",
+          "urlLabel": "Consent URL"
+        },
+        "copied": "{{label}} copied",
+        "description": "Choose how to configure the Microsoft app used for inbound email. Mailbox authorization remains a separate final step.",
+        "errors": {
+          "automated": "Could not start automated Microsoft app creation.",
+          "generic": "Microsoft Email setup did not complete.",
+          "nameRequired": "Enter a display name for the Microsoft app.",
+          "platform": "Could not configure the platform Microsoft app.",
+          "popupBlocked": "Allow popups for this site, then try again.",
+          "tenantRequired": "Enter your Microsoft tenant ID or verified domain."
+        },
+        "fields": {
+          "clientId": "Client ID",
+          "displayName": "Profile display name",
+          "tenant": "Microsoft tenant ID or verified domain",
+          "tenantId": "Tenant ID"
+        },
+        "manual": {
+          "description": "Keep using the existing client ID, tenant ID, and client secret form.",
+          "title": "Enter an existing app manually"
+        },
+        "platform": {
+          "description": "Create an Email-bound profile from the server-managed multi-tenant app, then grant tenant administrator consent.",
+          "title": "Use the Alga platform app"
+        },
+        "title": "Set up Microsoft Email",
+        "unavailable": "Unavailable"
+      },
       "settings": {
         "advanced": {
           "title": "Bring your own Microsoft app (advanced)",

--- a/server/public/locales/fr/msp/email-providers.json
+++ b/server/public/locales/fr/msp/email-providers.json
@@ -318,6 +318,8 @@
         "setupLabel": "Microsoft Entrée",
         "notConfigured": "Les paramètres du fournisseur Microsoft ne sont pas configurés.",
         "setupHelp": "Configurez d'abord les fournisseurs dans Paramètres → Intégrations → Fournisseurs, puis revenez ici pour autoriser cette boîte aux lettres.",
+        "profileReady": "Le profil de l’application Microsoft est prêt.",
+        "profileReadyHelp": "Si le consentement de l’administrateur du locataire est encore en attente, terminez-le dans les paramètres Fournisseurs. Utilisez ensuite Autoriser l’accès pour cette boîte aux lettres.",
         "redirectUriLabel": "URI de redirection *",
         "redirectUriPlaceholder": "https://yourapp.com/api/auth/microsoft/callback",
         "authorizationTitle": "Autorisation OAuth",

--- a/server/public/locales/fr/msp/integrations.json
+++ b/server/public/locales/fr/msp/integrations.json
@@ -1553,6 +1553,7 @@
           "nameRequired": "Enter a display name for the Microsoft app.",
           "platform": "Could not configure the platform Microsoft app.",
           "popupBlocked": "Allow popups for this site, then try again.",
+          "popupClosed": "La fenêtre Microsoft a été fermée avant la fin de la configuration. Réessayez ou choisissez une autre option de configuration.",
           "tenantRequired": "Enter your Microsoft tenant ID or verified domain."
         },
         "fields": {
@@ -1737,7 +1738,8 @@
           "archived": "Les profils archivés ne peuvent pas être utilisés pour de nouvelles liaisons Microsoft.",
           "clientIdMissing": "Le Client ID est manquant.",
           "clientSecretMissing": "Le client secret n'a pas été configuré.",
-          "tenantIdMissing": "Le Tenant ID est manquant."
+          "tenantIdMissing": "Le Tenant ID est manquant.",
+          "adminConsentPending": "Accordez le consentement de l’administrateur du locataire Microsoft pour terminer la configuration de la messagerie."
         },
         "statusBadges": {
           "archived": "Archivé",

--- a/server/public/locales/fr/msp/integrations.json
+++ b/server/public/locales/fr/msp/integrations.json
@@ -1517,6 +1517,61 @@
       }
     },
     "microsoft": {
+      "emailSetup": {
+        "action": "Set up Microsoft Email",
+        "actions": {
+          "back": "Back",
+          "cancel": "Cancel",
+          "copy": "Copy",
+          "finish": "Finish",
+          "grantConsent": "Grant administrator consent",
+          "savePlatform": "Create profile and continue",
+          "signIn": "Sign in to Microsoft",
+          "working": "Working…"
+        },
+        "automated": {
+          "description": "Sign in as a Microsoft administrator. Alga creates the app, service principal, secret, Email profile, and binding.",
+          "title": "Create an app in this tenant"
+        },
+        "callbackUri": "Mailbox callback URI",
+        "complete": {
+          "consentDone": "Administrator consent is confirmed. Return to Inbound Email and authorize the mailbox.",
+          "consentPending": "Next, a Microsoft tenant administrator must grant consent. Mailbox authorization happens afterward in Inbound Email.",
+          "profileCreated": "Microsoft Email profile created and bound"
+        },
+        "consent": {
+          "confirmedDescription": "The Microsoft app is ready for mailbox authorization.",
+          "confirmedTitle": "Administrator consent confirmed",
+          "url": "Administrator consent URL",
+          "urlLabel": "Consent URL"
+        },
+        "copied": "{{label}} copied",
+        "description": "Choose how to configure the Microsoft app used for inbound email. Mailbox authorization remains a separate final step.",
+        "errors": {
+          "automated": "Could not start automated Microsoft app creation.",
+          "generic": "Microsoft Email setup did not complete.",
+          "nameRequired": "Enter a display name for the Microsoft app.",
+          "platform": "Could not configure the platform Microsoft app.",
+          "popupBlocked": "Allow popups for this site, then try again.",
+          "tenantRequired": "Enter your Microsoft tenant ID or verified domain."
+        },
+        "fields": {
+          "clientId": "Client ID",
+          "displayName": "Profile display name",
+          "tenant": "Microsoft tenant ID or verified domain",
+          "tenantId": "Tenant ID"
+        },
+        "manual": {
+          "description": "Keep using the existing client ID, tenant ID, and client secret form.",
+          "title": "Enter an existing app manually"
+        },
+        "platform": {
+          "description": "Create an Email-bound profile from the server-managed multi-tenant app, then grant tenant administrator consent.",
+          "title": "Use the Alga platform app"
+        },
+        "title": "Set up Microsoft Email",
+        "unavailable": "Unavailable"
+      },
       "settings": {
         "advanced": {
           "title": "Bring your own Microsoft app (advanced)",

--- a/server/public/locales/it/msp/email-providers.json
+++ b/server/public/locales/it/msp/email-providers.json
@@ -318,6 +318,8 @@
         "setupLabel": "Microsoft Entra",
         "notConfigured": "Le impostazioni del provider Microsoft non sono configurate.",
         "setupHelp": "Configura prima i provider in Impostazioni → Integrazioni → Provider, quindi torna qui per autorizzare questa casella di posta.",
+        "profileReady": "Il profilo dell’app Microsoft è pronto.",
+        "profileReadyHelp": "Se il consenso dell’amministratore del tenant è ancora in sospeso, completalo nelle impostazioni Provider. Quindi usa Autorizza accesso per questa casella di posta.",
         "redirectUriLabel": "URI di reindirizzamento *",
         "redirectUriPlaceholder": "https://yourapp.com/api/auth/microsoft/callback",
         "authorizationTitle": "Autorizzazione OAuth",

--- a/server/public/locales/it/msp/integrations.json
+++ b/server/public/locales/it/msp/integrations.json
@@ -1553,6 +1553,7 @@
           "nameRequired": "Enter a display name for the Microsoft app.",
           "platform": "Could not configure the platform Microsoft app.",
           "popupBlocked": "Allow popups for this site, then try again.",
+          "popupClosed": "La finestra Microsoft è stata chiusa prima del completamento della configurazione. Riprova o scegli un’altra opzione di configurazione.",
           "tenantRequired": "Enter your Microsoft tenant ID or verified domain."
         },
         "fields": {
@@ -1737,7 +1738,8 @@
           "archived": "I profili archiviati non possono essere utilizzati per nuovi collegamenti Microsoft.",
           "clientIdMissing": "Client ID mancante.",
           "clientSecretMissing": "Il client secret non è stato configurato.",
-          "tenantIdMissing": "Tenant ID mancante."
+          "tenantIdMissing": "Tenant ID mancante.",
+          "adminConsentPending": "Concedi il consenso dell’amministratore del tenant Microsoft per completare la configurazione Email."
         },
         "statusBadges": {
           "archived": "Archiviato",

--- a/server/public/locales/it/msp/integrations.json
+++ b/server/public/locales/it/msp/integrations.json
@@ -1517,6 +1517,61 @@
       }
     },
     "microsoft": {
+      "emailSetup": {
+        "action": "Set up Microsoft Email",
+        "actions": {
+          "back": "Back",
+          "cancel": "Cancel",
+          "copy": "Copy",
+          "finish": "Finish",
+          "grantConsent": "Grant administrator consent",
+          "savePlatform": "Create profile and continue",
+          "signIn": "Sign in to Microsoft",
+          "working": "Working…"
+        },
+        "automated": {
+          "description": "Sign in as a Microsoft administrator. Alga creates the app, service principal, secret, Email profile, and binding.",
+          "title": "Create an app in this tenant"
+        },
+        "callbackUri": "Mailbox callback URI",
+        "complete": {
+          "consentDone": "Administrator consent is confirmed. Return to Inbound Email and authorize the mailbox.",
+          "consentPending": "Next, a Microsoft tenant administrator must grant consent. Mailbox authorization happens afterward in Inbound Email.",
+          "profileCreated": "Microsoft Email profile created and bound"
+        },
+        "consent": {
+          "confirmedDescription": "The Microsoft app is ready for mailbox authorization.",
+          "confirmedTitle": "Administrator consent confirmed",
+          "url": "Administrator consent URL",
+          "urlLabel": "Consent URL"
+        },
+        "copied": "{{label}} copied",
+        "description": "Choose how to configure the Microsoft app used for inbound email. Mailbox authorization remains a separate final step.",
+        "errors": {
+          "automated": "Could not start automated Microsoft app creation.",
+          "generic": "Microsoft Email setup did not complete.",
+          "nameRequired": "Enter a display name for the Microsoft app.",
+          "platform": "Could not configure the platform Microsoft app.",
+          "popupBlocked": "Allow popups for this site, then try again.",
+          "tenantRequired": "Enter your Microsoft tenant ID or verified domain."
+        },
+        "fields": {
+          "clientId": "Client ID",
+          "displayName": "Profile display name",
+          "tenant": "Microsoft tenant ID or verified domain",
+          "tenantId": "Tenant ID"
+        },
+        "manual": {
+          "description": "Keep using the existing client ID, tenant ID, and client secret form.",
+          "title": "Enter an existing app manually"
+        },
+        "platform": {
+          "description": "Create an Email-bound profile from the server-managed multi-tenant app, then grant tenant administrator consent.",
+          "title": "Use the Alga platform app"
+        },
+        "title": "Set up Microsoft Email",
+        "unavailable": "Unavailable"
+      },
       "settings": {
         "advanced": {
           "title": "Bring your own Microsoft app (advanced)",

--- a/server/public/locales/nl/msp/email-providers.json
+++ b/server/public/locales/nl/msp/email-providers.json
@@ -318,6 +318,8 @@
         "setupLabel": "Microsoft Entra",
         "notConfigured": "Microsoft-providerinstellingen zijn niet geconfigureerd.",
         "setupHelp": "Configureer eerst Providers in Instellingen → Integraties → Providers en kom dan hier terug om deze mailbox te autoriseren.",
+        "profileReady": "Het Microsoft-app-profiel is gereed.",
+        "profileReadyHelp": "Als toestemming van de tenantbeheerder nog ontbreekt, voltooi die dan in de Providerinstellingen. Gebruik daarna Toegang autoriseren voor deze mailbox.",
         "redirectUriLabel": "Omleidings-URI *",
         "redirectUriPlaceholder": "https://uwapp.com/api/auth/microsoft/callback",
         "authorizationTitle": "OAuth-autorisatie",

--- a/server/public/locales/nl/msp/integrations.json
+++ b/server/public/locales/nl/msp/integrations.json
@@ -1553,6 +1553,7 @@
           "nameRequired": "Enter a display name for the Microsoft app.",
           "platform": "Could not configure the platform Microsoft app.",
           "popupBlocked": "Allow popups for this site, then try again.",
+          "popupClosed": "Het Microsoft-venster is gesloten voordat de configuratie was voltooid. Probeer het opnieuw of kies een andere configuratieoptie.",
           "tenantRequired": "Enter your Microsoft tenant ID or verified domain."
         },
         "fields": {
@@ -1737,7 +1738,8 @@
           "archived": "Gearchiveerde profielen kunnen niet worden gebruikt voor nieuwe Microsoft-bindingen.",
           "clientIdMissing": "Client ID ontbreekt.",
           "clientSecretMissing": "Client secret is niet geconfigureerd.",
-          "tenantIdMissing": "Tenant ID ontbreekt."
+          "tenantIdMissing": "Tenant ID ontbreekt.",
+          "adminConsentPending": "Verleen toestemming van de Microsoft-tenantbeheerder om de e-mailconfiguratie te voltooien."
         },
         "statusBadges": {
           "archived": "Gearchiveerd",

--- a/server/public/locales/nl/msp/integrations.json
+++ b/server/public/locales/nl/msp/integrations.json
@@ -1517,6 +1517,61 @@
       }
     },
     "microsoft": {
+      "emailSetup": {
+        "action": "Set up Microsoft Email",
+        "actions": {
+          "back": "Back",
+          "cancel": "Cancel",
+          "copy": "Copy",
+          "finish": "Finish",
+          "grantConsent": "Grant administrator consent",
+          "savePlatform": "Create profile and continue",
+          "signIn": "Sign in to Microsoft",
+          "working": "Working…"
+        },
+        "automated": {
+          "description": "Sign in as a Microsoft administrator. Alga creates the app, service principal, secret, Email profile, and binding.",
+          "title": "Create an app in this tenant"
+        },
+        "callbackUri": "Mailbox callback URI",
+        "complete": {
+          "consentDone": "Administrator consent is confirmed. Return to Inbound Email and authorize the mailbox.",
+          "consentPending": "Next, a Microsoft tenant administrator must grant consent. Mailbox authorization happens afterward in Inbound Email.",
+          "profileCreated": "Microsoft Email profile created and bound"
+        },
+        "consent": {
+          "confirmedDescription": "The Microsoft app is ready for mailbox authorization.",
+          "confirmedTitle": "Administrator consent confirmed",
+          "url": "Administrator consent URL",
+          "urlLabel": "Consent URL"
+        },
+        "copied": "{{label}} copied",
+        "description": "Choose how to configure the Microsoft app used for inbound email. Mailbox authorization remains a separate final step.",
+        "errors": {
+          "automated": "Could not start automated Microsoft app creation.",
+          "generic": "Microsoft Email setup did not complete.",
+          "nameRequired": "Enter a display name for the Microsoft app.",
+          "platform": "Could not configure the platform Microsoft app.",
+          "popupBlocked": "Allow popups for this site, then try again.",
+          "tenantRequired": "Enter your Microsoft tenant ID or verified domain."
+        },
+        "fields": {
+          "clientId": "Client ID",
+          "displayName": "Profile display name",
+          "tenant": "Microsoft tenant ID or verified domain",
+          "tenantId": "Tenant ID"
+        },
+        "manual": {
+          "description": "Keep using the existing client ID, tenant ID, and client secret form.",
+          "title": "Enter an existing app manually"
+        },
+        "platform": {
+          "description": "Create an Email-bound profile from the server-managed multi-tenant app, then grant tenant administrator consent.",
+          "title": "Use the Alga platform app"
+        },
+        "title": "Set up Microsoft Email",
+        "unavailable": "Unavailable"
+      },
       "settings": {
         "advanced": {
           "title": "Bring your own Microsoft app (advanced)",

--- a/server/public/locales/pl/msp/email-providers.json
+++ b/server/public/locales/pl/msp/email-providers.json
@@ -318,6 +318,8 @@
         "setupLabel": "Microsoft Entra",
         "notConfigured": "Ustawienia dostawcy Microsoft nie są skonfigurowane.",
         "setupHelp": "Najpierw skonfiguruj Dostawców w Ustawieniach → Integracje → Dostawcy, a następnie wróć tutaj, aby autoryzować tę skrzynkę pocztową.",
+        "profileReady": "Profil aplikacji Microsoft jest gotowy.",
+        "profileReadyHelp": "Jeśli zgoda administratora dzierżawy nadal oczekuje, dokończ ją w ustawieniach Dostawców. Następnie użyj opcji Autoryzuj dostęp dla tej skrzynki pocztowej.",
         "redirectUriLabel": "URI przekierowania *",
         "redirectUriPlaceholder": "https://yourapp.com/api/auth/microsoft/callback",
         "authorizationTitle": "Autoryzacja OAuth",

--- a/server/public/locales/pl/msp/integrations.json
+++ b/server/public/locales/pl/msp/integrations.json
@@ -1517,6 +1517,61 @@
       }
     },
     "microsoft": {
+      "emailSetup": {
+        "action": "Set up Microsoft Email",
+        "actions": {
+          "back": "Back",
+          "cancel": "Cancel",
+          "copy": "Copy",
+          "finish": "Finish",
+          "grantConsent": "Grant administrator consent",
+          "savePlatform": "Create profile and continue",
+          "signIn": "Sign in to Microsoft",
+          "working": "Working…"
+        },
+        "automated": {
+          "description": "Sign in as a Microsoft administrator. Alga creates the app, service principal, secret, Email profile, and binding.",
+          "title": "Create an app in this tenant"
+        },
+        "callbackUri": "Mailbox callback URI",
+        "complete": {
+          "consentDone": "Administrator consent is confirmed. Return to Inbound Email and authorize the mailbox.",
+          "consentPending": "Next, a Microsoft tenant administrator must grant consent. Mailbox authorization happens afterward in Inbound Email.",
+          "profileCreated": "Microsoft Email profile created and bound"
+        },
+        "consent": {
+          "confirmedDescription": "The Microsoft app is ready for mailbox authorization.",
+          "confirmedTitle": "Administrator consent confirmed",
+          "url": "Administrator consent URL",
+          "urlLabel": "Consent URL"
+        },
+        "copied": "{{label}} copied",
+        "description": "Choose how to configure the Microsoft app used for inbound email. Mailbox authorization remains a separate final step.",
+        "errors": {
+          "automated": "Could not start automated Microsoft app creation.",
+          "generic": "Microsoft Email setup did not complete.",
+          "nameRequired": "Enter a display name for the Microsoft app.",
+          "platform": "Could not configure the platform Microsoft app.",
+          "popupBlocked": "Allow popups for this site, then try again.",
+          "tenantRequired": "Enter your Microsoft tenant ID or verified domain."
+        },
+        "fields": {
+          "clientId": "Client ID",
+          "displayName": "Profile display name",
+          "tenant": "Microsoft tenant ID or verified domain",
+          "tenantId": "Tenant ID"
+        },
+        "manual": {
+          "description": "Keep using the existing client ID, tenant ID, and client secret form.",
+          "title": "Enter an existing app manually"
+        },
+        "platform": {
+          "description": "Create an Email-bound profile from the server-managed multi-tenant app, then grant tenant administrator consent.",
+          "title": "Use the Alga platform app"
+        },
+        "title": "Set up Microsoft Email",
+        "unavailable": "Unavailable"
+      },
       "settings": {
         "advanced": {
           "title": "Bring your own Microsoft app (advanced)",

--- a/server/public/locales/pl/msp/integrations.json
+++ b/server/public/locales/pl/msp/integrations.json
@@ -1553,6 +1553,7 @@
           "nameRequired": "Enter a display name for the Microsoft app.",
           "platform": "Could not configure the platform Microsoft app.",
           "popupBlocked": "Allow popups for this site, then try again.",
+          "popupClosed": "Okno Microsoft zostało zamknięte przed ukończeniem konfiguracji. Spróbuj ponownie lub wybierz inną opcję konfiguracji.",
           "tenantRequired": "Enter your Microsoft tenant ID or verified domain."
         },
         "fields": {
@@ -1737,7 +1738,8 @@
           "archived": "Zarchiwizowane profile nie mogą być używane do nowych powiązań Microsoft.",
           "clientIdMissing": "Brak Client ID.",
           "clientSecretMissing": "Client secret nie został skonfigurowany.",
-          "tenantIdMissing": "Brak Tenant ID."
+          "tenantIdMissing": "Brak Tenant ID.",
+          "adminConsentPending": "Udziel zgody administratora dzierżawy Microsoft, aby zakończyć konfigurację poczty e-mail."
         },
         "statusBadges": {
           "archived": "Zarchiwizowany",

--- a/server/public/locales/pt/msp/email-providers.json
+++ b/server/public/locales/pt/msp/email-providers.json
@@ -318,6 +318,8 @@
         "setupLabel": "Microsoft Entrada",
         "notConfigured": "As configurações do provedor Microsoft não estão definidas.",
         "setupHelp": "Configure os provedores primeiro em Configurações → Integrações → Provedores e depois retorne aqui para autorizar esta caixa de correio.",
+        "profileReady": "O perfil do aplicativo Microsoft está pronto.",
+        "profileReadyHelp": "Se o consentimento do administrador do locatário ainda estiver pendente, conclua-o nas configurações de Provedores. Depois, use Autorizar acesso para esta caixa de correio.",
         "redirectUriLabel": "Redirecionar URI *",
         "redirectUriPlaceholder": "https://yourapp.com/api/auth/microsoft/callback",
         "authorizationTitle": "Autorização OAuth",

--- a/server/public/locales/pt/msp/integrations.json
+++ b/server/public/locales/pt/msp/integrations.json
@@ -1553,6 +1553,7 @@
           "nameRequired": "Enter a display name for the Microsoft app.",
           "platform": "Could not configure the platform Microsoft app.",
           "popupBlocked": "Allow popups for this site, then try again.",
+          "popupClosed": "A janela da Microsoft foi fechada antes da conclusão da configuração. Tente novamente ou escolha outra opção de configuração.",
           "tenantRequired": "Enter your Microsoft tenant ID or verified domain."
         },
         "fields": {
@@ -1737,7 +1738,8 @@
           "archived": "Perfis arquivados não podem ser usados ​​para novas ligações da Microsoft.",
           "clientIdMissing": "O ID do cliente está ausente.",
           "clientSecretMissing": "O segredo do cliente não foi configurado.",
-          "tenantIdMissing": "O ID do locatário está ausente."
+          "tenantIdMissing": "O ID do locatário está ausente.",
+          "adminConsentPending": "Conceda o consentimento do administrador do locatário Microsoft para concluir a configuração de Email."
         },
         "statusBadges": {
           "archived": "Arquivado",

--- a/server/public/locales/pt/msp/integrations.json
+++ b/server/public/locales/pt/msp/integrations.json
@@ -1517,6 +1517,61 @@
       }
     },
     "microsoft": {
+      "emailSetup": {
+        "action": "Set up Microsoft Email",
+        "actions": {
+          "back": "Back",
+          "cancel": "Cancel",
+          "copy": "Copy",
+          "finish": "Finish",
+          "grantConsent": "Grant administrator consent",
+          "savePlatform": "Create profile and continue",
+          "signIn": "Sign in to Microsoft",
+          "working": "Working…"
+        },
+        "automated": {
+          "description": "Sign in as a Microsoft administrator. Alga creates the app, service principal, secret, Email profile, and binding.",
+          "title": "Create an app in this tenant"
+        },
+        "callbackUri": "Mailbox callback URI",
+        "complete": {
+          "consentDone": "Administrator consent is confirmed. Return to Inbound Email and authorize the mailbox.",
+          "consentPending": "Next, a Microsoft tenant administrator must grant consent. Mailbox authorization happens afterward in Inbound Email.",
+          "profileCreated": "Microsoft Email profile created and bound"
+        },
+        "consent": {
+          "confirmedDescription": "The Microsoft app is ready for mailbox authorization.",
+          "confirmedTitle": "Administrator consent confirmed",
+          "url": "Administrator consent URL",
+          "urlLabel": "Consent URL"
+        },
+        "copied": "{{label}} copied",
+        "description": "Choose how to configure the Microsoft app used for inbound email. Mailbox authorization remains a separate final step.",
+        "errors": {
+          "automated": "Could not start automated Microsoft app creation.",
+          "generic": "Microsoft Email setup did not complete.",
+          "nameRequired": "Enter a display name for the Microsoft app.",
+          "platform": "Could not configure the platform Microsoft app.",
+          "popupBlocked": "Allow popups for this site, then try again.",
+          "tenantRequired": "Enter your Microsoft tenant ID or verified domain."
+        },
+        "fields": {
+          "clientId": "Client ID",
+          "displayName": "Profile display name",
+          "tenant": "Microsoft tenant ID or verified domain",
+          "tenantId": "Tenant ID"
+        },
+        "manual": {
+          "description": "Keep using the existing client ID, tenant ID, and client secret form.",
+          "title": "Enter an existing app manually"
+        },
+        "platform": {
+          "description": "Create an Email-bound profile from the server-managed multi-tenant app, then grant tenant administrator consent.",
+          "title": "Use the Alga platform app"
+        },
+        "title": "Set up Microsoft Email",
+        "unavailable": "Unavailable"
+      },
       "settings": {
         "advanced": {
           "title": "Bring your own Microsoft app (advanced)",

--- a/server/public/locales/xx/msp/email-providers.json
+++ b/server/public/locales/xx/msp/email-providers.json
@@ -318,6 +318,8 @@
         "setupLabel": "11111",
         "notConfigured": "11111",
         "setupHelp": "11111",
+        "profileReady": "11111",
+        "profileReadyHelp": "11111",
         "redirectUriLabel": "11111",
         "redirectUriPlaceholder": "11111",
         "authorizationTitle": "11111",

--- a/server/public/locales/xx/msp/integrations.json
+++ b/server/public/locales/xx/msp/integrations.json
@@ -1553,6 +1553,7 @@
           "nameRequired": "11111",
           "platform": "11111",
           "popupBlocked": "11111",
+          "popupClosed": "11111",
           "tenantRequired": "11111"
         },
         "fields": {
@@ -1746,7 +1747,8 @@
           "archived": "11111",
           "clientIdMissing": "11111",
           "clientSecretMissing": "11111",
-          "tenantIdMissing": "11111"
+          "tenantIdMissing": "11111",
+          "adminConsentPending": "11111"
         },
         "statusBadges": {
           "archived": "11111",

--- a/server/public/locales/xx/msp/integrations.json
+++ b/server/public/locales/xx/msp/integrations.json
@@ -1517,6 +1517,61 @@
       }
     },
     "microsoft": {
+      "emailSetup": {
+        "action": "11111",
+        "actions": {
+          "back": "11111",
+          "cancel": "11111",
+          "copy": "11111",
+          "finish": "11111",
+          "grantConsent": "11111",
+          "savePlatform": "11111",
+          "signIn": "11111",
+          "working": "11111"
+        },
+        "automated": {
+          "description": "11111",
+          "title": "11111"
+        },
+        "callbackUri": "11111",
+        "complete": {
+          "consentDone": "11111",
+          "consentPending": "11111",
+          "profileCreated": "11111"
+        },
+        "consent": {
+          "confirmedDescription": "11111",
+          "confirmedTitle": "11111",
+          "url": "11111",
+          "urlLabel": "11111"
+        },
+        "copied": "11111 {{label}} 11111",
+        "description": "11111",
+        "errors": {
+          "automated": "11111",
+          "generic": "11111",
+          "nameRequired": "11111",
+          "platform": "11111",
+          "popupBlocked": "11111",
+          "tenantRequired": "11111"
+        },
+        "fields": {
+          "clientId": "11111",
+          "displayName": "11111",
+          "tenant": "11111",
+          "tenantId": "11111"
+        },
+        "manual": {
+          "description": "11111",
+          "title": "11111"
+        },
+        "platform": {
+          "description": "11111",
+          "title": "11111"
+        },
+        "title": "11111",
+        "unavailable": "11111"
+      },
       "settings": {
         "advanced": {
           "title": "11111",

--- a/server/public/locales/yy/msp/email-providers.json
+++ b/server/public/locales/yy/msp/email-providers.json
@@ -318,6 +318,8 @@
         "setupLabel": "55555",
         "notConfigured": "55555",
         "setupHelp": "55555",
+        "profileReady": "55555",
+        "profileReadyHelp": "55555",
         "redirectUriLabel": "55555",
         "redirectUriPlaceholder": "55555",
         "authorizationTitle": "55555",

--- a/server/public/locales/yy/msp/integrations.json
+++ b/server/public/locales/yy/msp/integrations.json
@@ -1553,6 +1553,7 @@
           "nameRequired": "55555",
           "platform": "55555",
           "popupBlocked": "55555",
+          "popupClosed": "55555",
           "tenantRequired": "55555"
         },
         "fields": {
@@ -1746,7 +1747,8 @@
           "archived": "55555",
           "clientIdMissing": "55555",
           "clientSecretMissing": "55555",
-          "tenantIdMissing": "55555"
+          "tenantIdMissing": "55555",
+          "adminConsentPending": "55555"
         },
         "statusBadges": {
           "archived": "55555",

--- a/server/public/locales/yy/msp/integrations.json
+++ b/server/public/locales/yy/msp/integrations.json
@@ -1517,6 +1517,61 @@
       }
     },
     "microsoft": {
+      "emailSetup": {
+        "action": "55555",
+        "actions": {
+          "back": "55555",
+          "cancel": "55555",
+          "copy": "55555",
+          "finish": "55555",
+          "grantConsent": "55555",
+          "savePlatform": "55555",
+          "signIn": "55555",
+          "working": "55555"
+        },
+        "automated": {
+          "description": "55555",
+          "title": "55555"
+        },
+        "callbackUri": "55555",
+        "complete": {
+          "consentDone": "55555",
+          "consentPending": "55555",
+          "profileCreated": "55555"
+        },
+        "consent": {
+          "confirmedDescription": "55555",
+          "confirmedTitle": "55555",
+          "url": "55555",
+          "urlLabel": "55555"
+        },
+        "copied": "55555 {{label}} 55555",
+        "description": "55555",
+        "errors": {
+          "automated": "55555",
+          "generic": "55555",
+          "nameRequired": "55555",
+          "platform": "55555",
+          "popupBlocked": "55555",
+          "tenantRequired": "55555"
+        },
+        "fields": {
+          "clientId": "55555",
+          "displayName": "55555",
+          "tenant": "55555",
+          "tenantId": "55555"
+        },
+        "manual": {
+          "description": "55555",
+          "title": "55555"
+        },
+        "platform": {
+          "description": "55555",
+          "title": "55555"
+        },
+        "title": "55555",
+        "unavailable": "55555"
+      },
       "settings": {
         "advanced": {
           "title": "yyyyy",

--- a/server/src/app/api/auth/microsoft/email-setup/callback/route.ts
+++ b/server/src/app/api/auth/microsoft/email-setup/callback/route.ts
@@ -1,0 +1,129 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { getCurrentUser } from '@alga-psa/user-composition/actions';
+import {
+  completeMicrosoftEmailApplicationCreation,
+  getMicrosoftEmailSetupSigningSecret,
+} from '@alga-psa/integrations/actions/integrations/microsoftEmailSetupActions';
+import { validateMicrosoftEmailSetupState } from '@alga-psa/integrations/lib/microsoftEmailSetup';
+import { consumeMicrosoftEmailSetupState } from '@alga-psa/integrations/utils/microsoftEmailSetupStateStore';
+
+export const dynamic = 'force-dynamic';
+
+function respondToSetupWindow(input: {
+  returnTo: string;
+  payload: Record<string, unknown>;
+}): NextResponse {
+  const encodedPayload = Buffer.from(JSON.stringify({
+    type: 'microsoft-email-setup-callback',
+    ...input.payload,
+  })).toString('base64');
+  const returnUrl = new URL(input.returnTo);
+  const encodedReturnUrl = Buffer.from(returnUrl.toString()).toString('base64');
+  const targetOrigin = returnUrl.origin;
+  const html = `<!doctype html>
+<html>
+  <head><meta charset="utf-8"><meta name="viewport" content="width=device-width"><title>Microsoft Email Setup</title></head>
+  <body>
+    <p id="status">Finishing Microsoft Email setup…</p>
+    <script>
+      (function () {
+        var payload = JSON.parse(atob('${encodedPayload}'));
+        var target = window.opener || window.parent;
+        if (target && target !== window) target.postMessage(payload, '${targetOrigin}');
+        try { window.close(); } catch (_) {}
+        setTimeout(function () {
+          if (!window.closed) {
+            document.getElementById('status').textContent = payload.success
+              ? 'Setup finished. You can close this window.'
+              : 'Setup did not finish. Return to Alga PSA to review the error.';
+            var link = document.createElement('a');
+            link.href = atob('${encodedReturnUrl}');
+            link.textContent = 'Return to Alga PSA';
+            document.body.appendChild(link);
+          }
+        }, 150);
+      })();
+    </script>
+  </body>
+</html>`;
+  return new NextResponse(html, {
+    status: 200,
+    headers: {
+      'Content-Type': 'text/html; charset=utf-8',
+      'Cache-Control': 'no-store',
+      'Content-Security-Policy': `default-src 'none'; script-src 'unsafe-inline'; style-src 'none'; base-uri 'none'; frame-ancestors 'none'`,
+    },
+  });
+}
+
+function genericFailure(error: string): NextResponse {
+  return respondToSetupWindow({
+    returnTo: `${process.env.NEXT_PUBLIC_BASE_URL || process.env.NEXTAUTH_URL || 'http://localhost:3000'}/msp/settings?category=providers`,
+    payload: { success: false, error },
+  });
+}
+
+export async function GET(request: NextRequest): Promise<NextResponse> {
+  const stateToken = request.nextUrl.searchParams.get('state');
+  const signingSecret = await getMicrosoftEmailSetupSigningSecret();
+  const state = validateMicrosoftEmailSetupState({ token: stateToken, secret: signingSecret });
+  if (!state) {
+    return genericFailure('This Microsoft setup request is invalid or expired. Start again from Providers settings.');
+  }
+
+  const user = await getCurrentUser();
+  if (!user?.tenant || user.tenant !== state.algaTenant || user.user_id !== state.userId) {
+    if (state.purpose === 'create_application') {
+      await consumeMicrosoftEmailSetupState(state.nonce).catch(() => null);
+    }
+    return respondToSetupWindow({
+      returnTo: state.returnTo,
+      payload: {
+        success: false,
+        error: 'Your Alga PSA session does not match the administrator who started this setup. Sign in and try again.',
+      },
+    });
+  }
+
+  const microsoftError = request.nextUrl.searchParams.get('error');
+  if (microsoftError) {
+    if (state.purpose === 'create_application') {
+      await consumeMicrosoftEmailSetupState(state.nonce).catch(() => null);
+    }
+    return respondToSetupWindow({
+      returnTo: state.returnTo,
+      payload: {
+        success: false,
+        error: microsoftError === 'access_denied'
+          ? 'Microsoft sign-in or administrator consent was denied. Choose another setup option or try again.'
+          : 'Microsoft could not complete the setup request. Try again or use manual setup.',
+      },
+    });
+  }
+
+  if (state.purpose === 'admin_consent') {
+    const granted = request.nextUrl.searchParams.get('admin_consent')?.toLowerCase() === 'true';
+    const microsoftTenant = request.nextUrl.searchParams.get('tenant') || undefined;
+    return respondToSetupWindow({
+      returnTo: state.returnTo,
+      payload: granted
+        ? { success: true, stage: 'admin_consent', tenantId: microsoftTenant, clientId: state.clientId }
+        : { success: false, error: 'Microsoft did not confirm tenant administrator consent.' },
+    });
+  }
+
+  const code = request.nextUrl.searchParams.get('code');
+  if (!code) {
+    await consumeMicrosoftEmailSetupState(state.nonce).catch(() => null);
+    return respondToSetupWindow({
+      returnTo: state.returnTo,
+      payload: { success: false, error: 'Microsoft did not return an authorization code. Start setup again.' },
+    });
+  }
+
+  const result = await completeMicrosoftEmailApplicationCreation({ user, state, code });
+  return respondToSetupWindow({
+    returnTo: state.returnTo,
+    payload: result,
+  });
+}

--- a/server/src/app/api/auth/microsoft/email-setup/callback/route.ts
+++ b/server/src/app/api/auth/microsoft/email-setup/callback/route.ts
@@ -4,6 +4,7 @@ import {
   completeMicrosoftEmailApplicationCreation,
   getMicrosoftEmailSetupSigningSecret,
 } from '@alga-psa/integrations/actions/integrations/microsoftEmailSetupActions';
+import { confirmMicrosoftEmailAdminConsentInternal } from '@alga-psa/integrations/actions/integrations/microsoftActions';
 import { validateMicrosoftEmailSetupState } from '@alga-psa/integrations/lib/microsoftEmailSetup';
 import { consumeMicrosoftEmailSetupState } from '@alga-psa/integrations/utils/microsoftEmailSetupStateStore';
 
@@ -58,7 +59,7 @@ function respondToSetupWindow(input: {
 
 function genericFailure(error: string): NextResponse {
   return respondToSetupWindow({
-    returnTo: `${process.env.NEXT_PUBLIC_BASE_URL || process.env.NEXTAUTH_URL || 'http://localhost:3000'}/msp/settings?category=providers`,
+    returnTo: `${process.env.NEXT_PUBLIC_BASE_URL || process.env.NEXTAUTH_URL || 'http://localhost:3000'}/msp/settings/integrations?category=providers`,
     payload: { success: false, error },
   });
 }
@@ -104,11 +105,23 @@ export async function GET(request: NextRequest): Promise<NextResponse> {
   if (state.purpose === 'admin_consent') {
     const granted = request.nextUrl.searchParams.get('admin_consent')?.toLowerCase() === 'true';
     const microsoftTenant = request.nextUrl.searchParams.get('tenant') || undefined;
+    if (!granted) {
+      return respondToSetupWindow({
+        returnTo: state.returnTo,
+        payload: { success: false, error: 'Microsoft did not confirm tenant administrator consent.' },
+      });
+    }
+
+    const persisted = await confirmMicrosoftEmailAdminConsentInternal(user, state.algaTenant, {
+      profileId: state.profileId!,
+      clientId: state.clientId!,
+      microsoftTenantId: microsoftTenant,
+    });
     return respondToSetupWindow({
       returnTo: state.returnTo,
-      payload: granted
-        ? { success: true, stage: 'admin_consent', tenantId: microsoftTenant, clientId: state.clientId }
-        : { success: false, error: 'Microsoft did not confirm tenant administrator consent.' },
+      payload: persisted.success
+        ? { success: true, stage: 'admin_consent', tenantId: microsoftTenant, clientId: state.clientId, profileId: state.profileId }
+        : { success: false, error: persisted.error || 'Failed to record Microsoft administrator consent.' },
     });
   }
 
@@ -124,6 +137,6 @@ export async function GET(request: NextRequest): Promise<NextResponse> {
   const result = await completeMicrosoftEmailApplicationCreation({ user, state, code });
   return respondToSetupWindow({
     returnTo: state.returnTo,
-    payload: result,
+    payload: { ...result },
   });
 }

--- a/server/src/test/unit/api/microsoftEmailSetupCallback.test.ts
+++ b/server/src/test/unit/api/microsoftEmailSetupCallback.test.ts
@@ -1,0 +1,97 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { NextRequest } from 'next/server';
+
+const hoisted = vi.hoisted(() => ({
+  getCurrentUser: vi.fn(),
+  getSigningSecret: vi.fn(),
+  validateState: vi.fn(),
+  consumeState: vi.fn(),
+  complete: vi.fn(),
+}));
+
+vi.mock('@alga-psa/user-composition/actions', () => ({
+  getCurrentUser: (...args: unknown[]) => hoisted.getCurrentUser(...args),
+}));
+
+vi.mock('@alga-psa/integrations/actions/integrations/microsoftEmailSetupActions', () => ({
+  getMicrosoftEmailSetupSigningSecret: (...args: unknown[]) => hoisted.getSigningSecret(...args),
+  completeMicrosoftEmailApplicationCreation: (...args: unknown[]) => hoisted.complete(...args),
+}));
+
+vi.mock('@alga-psa/integrations/lib/microsoftEmailSetup', () => ({
+  validateMicrosoftEmailSetupState: (...args: unknown[]) => hoisted.validateState(...args),
+}));
+
+vi.mock('@alga-psa/integrations/utils/microsoftEmailSetupStateStore', () => ({
+  consumeMicrosoftEmailSetupState: (...args: unknown[]) => hoisted.consumeState(...args),
+}));
+
+import { GET } from '../../../app/api/auth/microsoft/email-setup/callback/route';
+
+const createState = {
+  purpose: 'create_application' as const,
+  algaTenant: 'alga-tenant-1',
+  userId: 'user-1',
+  returnTo: 'https://psa.example.com/msp/settings?category=providers',
+  nonce: 'state-nonce',
+  oauthNonce: 'oauth-nonce',
+  issuedAt: 1,
+  expiresAt: 2,
+};
+
+describe('Microsoft email setup callback', () => {
+  beforeEach(() => {
+    hoisted.getSigningSecret.mockReset().mockResolvedValue('signing-secret');
+    hoisted.validateState.mockReset().mockReturnValue(createState);
+    hoisted.getCurrentUser.mockReset().mockResolvedValue({
+      tenant: 'alga-tenant-1',
+      user_id: 'user-1',
+    });
+    hoisted.consumeState.mockReset().mockResolvedValue({ verifier: 'one-time-verifier' });
+    hoisted.complete.mockReset().mockResolvedValue({ success: true, profileId: 'profile-1' });
+  });
+
+  it('consumes the one-time verifier when Microsoft consent is denied', async () => {
+    const response = await GET(new NextRequest(
+      'https://psa.example.com/api/auth/microsoft/email-setup/callback?error=access_denied&state=signed-state'
+    ));
+    const html = await response.text();
+
+    expect(hoisted.consumeState).toHaveBeenCalledWith('state-nonce');
+    expect(hoisted.complete).not.toHaveBeenCalled();
+    expect(html).toContain('Microsoft Email Setup');
+    expect(Buffer.from(html.match(/atob\('([^']+)'\)/)?.[1] || '', 'base64').toString()).toContain(
+      'Microsoft sign-in or administrator consent was denied'
+    );
+  });
+
+  it('rejects a state/session tenant mismatch and consumes creation state', async () => {
+    hoisted.getCurrentUser.mockResolvedValue({ tenant: 'another-tenant', user_id: 'user-1' });
+    const response = await GET(new NextRequest(
+      'https://psa.example.com/api/auth/microsoft/email-setup/callback?code=code&state=signed-state'
+    ));
+    const html = await response.text();
+
+    expect(hoisted.consumeState).toHaveBeenCalledWith('state-nonce');
+    expect(hoisted.complete).not.toHaveBeenCalled();
+    expect(Buffer.from(html.match(/atob\('([^']+)'\)/)?.[1] || '', 'base64').toString()).toContain(
+      'session does not match'
+    );
+  });
+
+  it('delegates a valid code to provisioning without exposing setup tokens', async () => {
+    const response = await GET(new NextRequest(
+      'https://psa.example.com/api/auth/microsoft/email-setup/callback?code=authorization-code&state=signed-state'
+    ));
+    const html = await response.text();
+
+    expect(hoisted.complete).toHaveBeenCalledWith({
+      user: { tenant: 'alga-tenant-1', user_id: 'user-1' },
+      state: createState,
+      code: 'authorization-code',
+    });
+    expect(Buffer.from(html.match(/atob\('([^']+)'\)/)?.[1] || '', 'base64').toString()).toContain('profile-1');
+    expect(html).not.toContain('access_token');
+    expect(html).not.toContain('one-time-verifier');
+  });
+});

--- a/server/src/test/unit/api/microsoftEmailSetupCallback.test.ts
+++ b/server/src/test/unit/api/microsoftEmailSetupCallback.test.ts
@@ -7,6 +7,7 @@ const hoisted = vi.hoisted(() => ({
   validateState: vi.fn(),
   consumeState: vi.fn(),
   complete: vi.fn(),
+  confirmConsent: vi.fn(),
 }));
 
 vi.mock('@alga-psa/user-composition/actions', () => ({
@@ -16,6 +17,10 @@ vi.mock('@alga-psa/user-composition/actions', () => ({
 vi.mock('@alga-psa/integrations/actions/integrations/microsoftEmailSetupActions', () => ({
   getMicrosoftEmailSetupSigningSecret: (...args: unknown[]) => hoisted.getSigningSecret(...args),
   completeMicrosoftEmailApplicationCreation: (...args: unknown[]) => hoisted.complete(...args),
+}));
+
+vi.mock('@alga-psa/integrations/actions/integrations/microsoftActions', () => ({
+  confirmMicrosoftEmailAdminConsentInternal: (...args: unknown[]) => hoisted.confirmConsent(...args),
 }));
 
 vi.mock('@alga-psa/integrations/lib/microsoftEmailSetup', () => ({
@@ -32,7 +37,7 @@ const createState = {
   purpose: 'create_application' as const,
   algaTenant: 'alga-tenant-1',
   userId: 'user-1',
-  returnTo: 'https://psa.example.com/msp/settings?category=providers',
+  returnTo: 'https://psa.example.com/msp/settings/integrations?category=providers',
   nonce: 'state-nonce',
   oauthNonce: 'oauth-nonce',
   issuedAt: 1,
@@ -49,6 +54,29 @@ describe('Microsoft email setup callback', () => {
     });
     hoisted.consumeState.mockReset().mockResolvedValue({ verifier: 'one-time-verifier' });
     hoisted.complete.mockReset().mockResolvedValue({ success: true, profileId: 'profile-1' });
+    hoisted.confirmConsent.mockReset().mockResolvedValue({ success: true, profileId: 'profile-1' });
+  });
+
+  it('returns invalid setup attempts to the Providers integration route', async () => {
+    const originalBaseUrl = process.env.NEXT_PUBLIC_BASE_URL;
+    process.env.NEXT_PUBLIC_BASE_URL = 'https://psa.example.com';
+    hoisted.validateState.mockReturnValue(null);
+    try {
+      const response = await GET(new NextRequest(
+        'https://psa.example.com/api/auth/microsoft/email-setup/callback?state=invalid'
+      ));
+      const html = await response.text();
+
+      expect(html).toContain(Buffer.from(
+        'https://psa.example.com/msp/settings/integrations?category=providers'
+      ).toString('base64'));
+      expect(html).not.toContain(Buffer.from(
+        'https://psa.example.com/msp/settings?category=providers'
+      ).toString('base64'));
+    } finally {
+      if (originalBaseUrl === undefined) delete process.env.NEXT_PUBLIC_BASE_URL;
+      else process.env.NEXT_PUBLIC_BASE_URL = originalBaseUrl;
+    }
   });
 
   it('consumes the one-time verifier when Microsoft consent is denied', async () => {
@@ -93,5 +121,53 @@ describe('Microsoft email setup callback', () => {
     expect(Buffer.from(html.match(/atob\('([^']+)'\)/)?.[1] || '', 'base64').toString()).toContain('profile-1');
     expect(html).not.toContain('access_token');
     expect(html).not.toContain('one-time-verifier');
+  });
+
+  it('persists administrator consent before reporting setup completion', async () => {
+    hoisted.validateState.mockReturnValue({
+      ...createState,
+      purpose: 'admin_consent',
+      clientId: 'email-client-id',
+      profileId: 'profile-1',
+      oauthNonce: undefined,
+    });
+
+    const response = await GET(new NextRequest(
+      'https://psa.example.com/api/auth/microsoft/email-setup/callback?admin_consent=true&tenant=microsoft-tenant&state=signed-state'
+    ));
+    const html = await response.text();
+
+    expect(hoisted.confirmConsent).toHaveBeenCalledWith(
+      { tenant: 'alga-tenant-1', user_id: 'user-1' },
+      'alga-tenant-1',
+      {
+        profileId: 'profile-1',
+        clientId: 'email-client-id',
+        microsoftTenantId: 'microsoft-tenant',
+      }
+    );
+    expect(Buffer.from(html.match(/atob\('([^']+)'\)/)?.[1] || '', 'base64').toString())
+      .toContain('admin_consent');
+  });
+
+  it('does not advance setup when consent persistence fails', async () => {
+    hoisted.validateState.mockReturnValue({
+      ...createState,
+      purpose: 'admin_consent',
+      clientId: 'email-client-id',
+      profileId: 'profile-1',
+      oauthNonce: undefined,
+    });
+    hoisted.confirmConsent.mockResolvedValue({ success: false, error: 'Database unavailable' });
+
+    const response = await GET(new NextRequest(
+      'https://psa.example.com/api/auth/microsoft/email-setup/callback?admin_consent=true&tenant=microsoft-tenant&state=signed-state'
+    ));
+    const html = await response.text();
+
+    expect(Buffer.from(html.match(/atob\('([^']+)'\)/)?.[1] || '', 'base64').toString())
+      .toContain('Database unavailable');
+    expect(Buffer.from(html.match(/atob\('([^']+)'\)/)?.[1] || '', 'base64').toString())
+      .not.toContain('admin_consent');
   });
 });

--- a/server/src/test/unit/components/MicrosoftProviderForm.test.tsx
+++ b/server/src/test/unit/components/MicrosoftProviderForm.test.tsx
@@ -235,6 +235,30 @@ describe('MicrosoftProviderForm', () => {
     expect(screen.getByRole('button', { name: /Open Providers Settings/i })).toBeInTheDocument();
   });
 
+  it('shows one Providers Settings action when a tenant-owned app is not ready', async () => {
+    renderWithProviders(
+      <MicrosoftProviderForm
+        {...defaultProps}
+        credentialCapability={{
+          source: 'tenant',
+          ready: false,
+          platformReady: true,
+          tenantProfileSelected: true,
+          clientIdConfigured: true,
+          clientSecretConfigured: true,
+          tenantIdConfigured: true,
+          profileId: 'microsoft-profile-123',
+          message: 'Microsoft admin consent is still pending.',
+        }}
+      />
+    );
+
+    await waitFor(() => {
+      expect(screen.getByText('Your Microsoft app is not ready yet.')).toBeInTheDocument();
+    });
+    expect(screen.getAllByRole('button', { name: /Open Providers Settings/i })).toHaveLength(1);
+  });
+
   it('should call onCancel when cancel button is clicked', async () => {
     const user = userEvent.setup();
     renderWithProviders(<MicrosoftProviderForm {...defaultProps} />);

--- a/server/src/test/unit/components/MicrosoftProviderForm.test.tsx
+++ b/server/src/test/unit/components/MicrosoftProviderForm.test.tsx
@@ -257,6 +257,7 @@ describe('MicrosoftProviderForm', () => {
       expect(screen.getByText('Your Microsoft app is not ready yet.')).toBeInTheDocument();
     });
     expect(screen.getAllByRole('button', { name: /Open Providers Settings/i })).toHaveLength(1);
+    expect(screen.getByRole('button', { name: /Authorize Access/i })).toBeDisabled();
   });
 
   it('should call onCancel when cancel button is clicked', async () => {


### PR DESCRIPTION
## Summary

- Add a guided Microsoft Email setup wizard under Providers with platform-managed, automated tenant-owned Entra registration, and manual credential paths.
- Use a setup-only PKCE/state flow to provision an application, service principal, generated secret, required callbacks, and only the delegated `Mail.Read`, `Mail.Read.Shared`, and `offline_access` permissions; bootstrap tokens are not persisted.
- Keep guided profiles unbound and unready until administrator consent succeeds, then record consent and switch the Email consumer binding transactionally.
- Add consent-aware provider resolution, mailbox readiness guidance with exactly one Providers action, popup-close recovery, Graph emulator onboarding support, translations, documentation, migrations, and focused regression coverage.
- Add a reversible tenant-scoped fixture for validating defensive stale-state behavior when a consent-pending profile is already bound despite normal onboarding preventing that state.

## Smoke test

**PASS for exact HEAD `82753fdd86` through the real Enterprise product on port 3042.**

- Applied the reversible stale-state fixture. PostgreSQL confirmed a bound Email profile requiring admin consent with no consent timestamp.
- After a full UI reload, the Microsoft 365 mailbox form showed “awaiting tenant administrator consent,” rendered exactly one Open Providers Settings action, and disabled Authorize Access.
- Cleaned up the fixture and restored the original consented profile. The form returned to ready state and enabled Authorize Access after required fields were entered.
- Followed the Providers action and opened the guided setup wizard. Platform, automated registration, and manual choices were all present.

No simulator or mock was used. Graph provisioning/admin-consent was not rerun because this server start lacked Microsoft bootstrap credentials; the platform and automated choices correctly displayed Unavailable. The fixture intentionally creates a binding normal onboarding prevents, validating the desired defensive stale-state semantics and `invalid_profile` result.

Evidence: `/tmp/alga-smoke-evidence/alga0002215-20260803-095414-exact-head`

## Compromises and concerns

- The newly created card-scoped browser pane was rejected as belonging to another host, so an existing accessible browser pane in the same card space was used.
- Known environment-only Temporal and missing `tenants.suspended_at` background errors remained; tested screens and actions were unaffected.
- Host dev logs still expose the application DB password in plaintext; no credential is included in evidence or this report.

## Cleanup

Verified the original profile `4fa142e9-ed9a-46f4-b13b-69b7affabf31` was restored, fixture profile/state removed, worktree clean, app health HTTP 200, and no recent browser console or network failures.

## Validation

- 26 focused resolver/UI tests pass.
- Server typecheck passes.
- Community and Enterprise production builds pass.
