### PR TITLE
Honor status pause and closed status at SLA start

### DIFF
--- a/docs/features/sla.md
+++ b/docs/features/sla.md
@@ -72,6 +72,12 @@ On resume:
 - Both response and resolution deadlines are shifted forward by the pause duration (only for unfulfilled milestones)
 - The ticket's `due_date` is kept in sync with the resolution deadline
 
+Both triggers are also evaluated at creation time, not only on later changes:
+
+- **Created in a pausing status** — On `TICKET_CREATED`, the subscriber runs `syncPauseState()` in the same transaction as `startSlaForTicket()`, so a ticket that is created directly in a pause-configured status (or already `awaiting_client`) is paused immediately and never burns SLA time before its first status change.
+
+- **Created in a closed status** — `startSlaForTicket()` reads the creation status and, when it is a closed status, records the policy and `sla_started_at` but immediately stamps `sla_resolution_at` at the creation time (with `sla_resolution_met = true` when a resolution target exists) and starts no backend timer. The ticket keeps its SLA data for reporting, while the timer job and the Temporal backend both skip it — so it can never breach. The `sla_started` audit entry carries `created_in_closed_status: true`, followed by a `resolution_recorded` entry with `reason: created_in_closed_status`.
+
 ### Notification System
 
 Notifications are threshold-based and configurable per policy:

--- a/packages/sla/src/services/slaService.ts
+++ b/packages/sla/src/services/slaService.ts
@@ -52,6 +52,11 @@ export interface StartSlaResult {
   sla_response_due_at: Date | null;
   sla_resolution_due_at: Date | null;
   error?: string;
+  /**
+   * True when the ticket was created directly in a closed status, so the SLA
+   * was closed out at creation time and no timer is running.
+   */
+  created_in_closed_status?: boolean;
   /** Dispatch with dispatchSlaBackendActions() after the transaction commits. */
   backendActions?: SlaBackendAction[];
 }
@@ -76,6 +81,10 @@ export interface RecordSlaEventResult {
  * 2. Gets the target times for the ticket's priority
  * 3. Calculates due dates based on business hours
  * 4. Updates the ticket with SLA tracking fields
+ *
+ * Tickets created directly in a closed status never get a running timer: the
+ * policy and start time are recorded for reporting, the resolution is stamped
+ * at creation time, and no backend timer is started.
  *
  * @param trx - Database transaction
  * @param tenant - Tenant ID
@@ -111,7 +120,18 @@ export async function startSlaForTicket(
       };
     }
 
-    // 2. Get the target for this priority
+    // 2. Read current ticket state (creation status + manually set due date)
+    const currentTicket = await tenantScopedTable(trx, tenant, 'tickets')
+      .where('ticket_id', ticketId)
+      .select('due_date', 'status_id')
+      .first();
+
+    // A ticket created directly in a closed status has nothing left to work on,
+    // so its timer must never run - not even when the creation status is also
+    // configured to pause SLA.
+    const createdInClosedStatus = await isClosedStatus(trx, tenant, currentTicket?.status_id ?? null);
+
+    // 3. Get the target for this priority
     const target = policy.targets.find(t => t.priority_id === priorityId);
 
     if (!target) {
@@ -120,7 +140,8 @@ export async function startSlaForTicket(
         .where('ticket_id', ticketId)
         .update({
           sla_policy_id: policy.sla_policy_id,
-          sla_started_at: createdAt
+          sla_started_at: createdAt,
+          ...(createdInClosedStatus ? { sla_resolution_at: createdAt } : {})
         });
 
       return {
@@ -128,14 +149,15 @@ export async function startSlaForTicket(
         sla_policy_id: policy.sla_policy_id,
         sla_started_at: createdAt,
         sla_response_due_at: null,
-        sla_resolution_due_at: null
+        sla_resolution_due_at: null,
+        created_in_closed_status: createdInClosedStatus
       };
     }
 
-    // 3. Get business hours schedule
+    // 4. Get business hours schedule
     const schedule = await getBusinessHoursSchedule(trx, tenant, policy, target);
 
-    // 4. Calculate due dates
+    // 5. Calculate due dates
     let responseDueAt: Date | null = null;
     let resolutionDueAt: Date | null = null;
 
@@ -147,19 +169,20 @@ export async function startSlaForTicket(
       resolutionDueAt = calculateDeadline(schedule, createdAt, target.resolution_time_minutes);
     }
 
-    // 5. Update ticket with SLA tracking fields
-    // Check if due_date should be auto-filled from SLA resolution target
-    const currentTicket = await tenantScopedTable(trx, tenant, 'tickets')
-      .where('ticket_id', ticketId)
-      .select('due_date')
-      .first();
-
+    // 6. Update ticket with SLA tracking fields
     const slaUpdateData: Record<string, any> = {
       sla_policy_id: policy.sla_policy_id,
       sla_started_at: createdAt,
       sla_response_due_at: responseDueAt,
       sla_resolution_due_at: resolutionDueAt
     };
+
+    // Created closed: stamp the resolution at creation time so the timer job
+    // and the backend never treat this ticket as running.
+    if (createdInClosedStatus) {
+      slaUpdateData.sla_resolution_at = createdAt;
+      slaUpdateData.sla_resolution_met = resolutionDueAt ? true : null;
+    }
 
     // Auto-fill due_date from SLA resolution target if not manually set
     if (!currentTicket?.due_date && resolutionDueAt) {
@@ -170,7 +193,7 @@ export async function startSlaForTicket(
       .where('ticket_id', ticketId)
       .update(slaUpdateData);
 
-    // 6. Log SLA started event
+    // 7. Log SLA started event
     await logSlaEvent(trx, tenant, ticketId, 'sla_started', {
       policy_id: policy.sla_policy_id,
       policy_name: policy.policy_name,
@@ -178,8 +201,28 @@ export async function startSlaForTicket(
       response_target_minutes: target.response_time_minutes,
       resolution_target_minutes: target.resolution_time_minutes,
       response_due_at: responseDueAt?.toISOString(),
-      resolution_due_at: resolutionDueAt?.toISOString()
+      resolution_due_at: resolutionDueAt?.toISOString(),
+      created_in_closed_status: createdInClosedStatus
     });
+
+    if (createdInClosedStatus) {
+      await logSlaEvent(trx, tenant, ticketId, 'resolution_recorded', {
+        resolved_at: createdAt.toISOString(),
+        due_at: resolutionDueAt?.toISOString(),
+        met: resolutionDueAt ? true : null,
+        reason: 'created_in_closed_status'
+      });
+
+      // No backend action: nothing should be timing this ticket.
+      return {
+        success: true,
+        sla_policy_id: policy.sla_policy_id,
+        sla_started_at: createdAt,
+        sla_response_due_at: responseDueAt,
+        sla_resolution_due_at: resolutionDueAt,
+        created_in_closed_status: true
+      };
+    }
 
     // Query configured notification thresholds for this policy
     const thresholdRows = await tenantScopedTable(trx, tenant, 'sla_notification_thresholds')
@@ -197,6 +240,7 @@ export async function startSlaForTicket(
       sla_started_at: createdAt,
       sla_response_due_at: responseDueAt,
       sla_resolution_due_at: resolutionDueAt,
+      created_in_closed_status: false,
       backendActions: [{
         kind: 'start',
         ticketId,
@@ -808,6 +852,24 @@ async function resolveSlaPolicy(
   }
 
   return null;
+}
+
+/**
+ * Check whether a status is a closed status.
+ */
+async function isClosedStatus(
+  trx: Knex | Knex.Transaction,
+  tenant: string,
+  statusId: string | null
+): Promise<boolean> {
+  if (!statusId) return false;
+
+  const status = await tenantScopedTable(trx, tenant, 'statuses')
+    .where('status_id', statusId)
+    .select('is_closed')
+    .first();
+
+  return status?.is_closed === true;
 }
 
 /**

--- a/server/migrations/20260803120000_backfill_sla_state_for_tickets_created_paused_or_closed.cjs
+++ b/server/migrations/20260803120000_backfill_sla_state_for_tickets_created_paused_or_closed.cjs
@@ -1,0 +1,106 @@
+/**
+ * Backfill SLA state for tickets that were created paused or closed.
+ *
+ * Until now the SLA timer only reacted to status *changes*, so a ticket that
+ * was created directly in a closed status kept a running timer, and a ticket
+ * created directly in a pause-configured status burned SLA time until its
+ * first status change. Both are fixed at creation time now; this migration
+ * repairs the rows that already exist:
+ *
+ * 1. Tickets whose current status is closed but that never recorded a
+ *    resolution get sla_resolution_at stamped (closed_at when known), which
+ *    takes them out of the timer job's selection. sla_resolution_met is left
+ *    untouched: we do not invent a compliance verdict for historical rows.
+ * 2. Tickets whose current status is configured to pause SLA get sla_paused_at
+ *    set, so the timer job stops evaluating them until they move on.
+ *
+ * EE tenants may still have Temporal SLA workflows running for these tickets;
+ * those do not observe a DB-only backfill and need operator action.
+ */
+
+const AUDIT_CHUNK_SIZE = 500;
+
+async function insertAuditRows(knex, tenant, ticketIds, eventType, eventData) {
+  if (ticketIds.length === 0) {
+    return;
+  }
+
+  const rows = ticketIds.map((ticketId) => ({
+    tenant,
+    ticket_id: ticketId,
+    event_type: eventType,
+    event_data: JSON.stringify(eventData),
+    triggered_by: null,
+  }));
+
+  await knex.batchInsert('sla_audit_log', rows, AUDIT_CHUNK_SIZE);
+}
+
+exports.up = async function up(knex) {
+  const tenants = await knex('tenants').select('tenant');
+
+  let resolvedCount = 0;
+  let pausedCount = 0;
+
+  for (const { tenant } of tenants) {
+    // 1. Neutralize SLA on tickets sitting in a closed status.
+    const closed = await knex.raw(
+      `UPDATE tickets t
+          SET sla_resolution_at = COALESCE(t.closed_at, t.updated_at, t.entered_at, now())
+        WHERE t.tenant = ?
+          AND t.sla_policy_id IS NOT NULL
+          AND t.sla_resolution_at IS NULL
+          AND EXISTS (
+            SELECT 1 FROM statuses s
+             WHERE s.tenant = t.tenant
+               AND s.status_id = t.status_id
+               AND s.is_closed = true
+          )
+        RETURNING t.ticket_id`,
+      [tenant]
+    );
+
+    const closedTicketIds = (closed.rows || []).map((row) => row.ticket_id);
+    resolvedCount += closedTicketIds.length;
+
+    await insertAuditRows(knex, tenant, closedTicketIds, 'resolution_recorded', {
+      reason: 'backfill_ticket_in_closed_status',
+    });
+
+    // 2. Pause SLA on tickets sitting in a pause-configured status.
+    const paused = await knex.raw(
+      `UPDATE tickets t
+          SET sla_paused_at = now()
+        WHERE t.tenant = ?
+          AND t.sla_policy_id IS NOT NULL
+          AND t.sla_resolution_at IS NULL
+          AND t.sla_paused_at IS NULL
+          AND EXISTS (
+            SELECT 1 FROM status_sla_pause_config c
+             WHERE c.tenant = t.tenant
+               AND c.status_id = t.status_id
+               AND c.pauses_sla = true
+          )
+        RETURNING t.ticket_id`,
+      [tenant]
+    );
+
+    const pausedTicketIds = (paused.rows || []).map((row) => row.ticket_id);
+    pausedCount += pausedTicketIds.length;
+
+    await insertAuditRows(knex, tenant, pausedTicketIds, 'sla_paused', {
+      reason: 'status_pause',
+      backfill: 'backfill_ticket_in_pausing_status',
+    });
+  }
+
+  console.log(
+    `SLA backfill: resolved ${resolvedCount} ticket(s) in closed statuses, paused ${pausedCount} ticket(s) in pausing statuses.`
+  );
+};
+
+exports.down = async function down() {
+  // Data backfill only: the previous state (a running timer on a closed or
+  // pause-configured ticket) is the bug this repairs, so there is nothing
+  // worth restoring. The sla_audit_log rows record what was changed.
+};

--- a/server/src/lib/eventBus/subscribers/slaSubscriber.ts
+++ b/server/src/lib/eventBus/subscribers/slaSubscriber.ts
@@ -36,7 +36,8 @@ import {
 } from '@alga-psa/sla';
 import {
   handleStatusChange,
-  handleResponseStateChange
+  handleResponseStateChange,
+  syncPauseState
 } from '@alga-psa/sla';
 import type { Knex } from 'knex';
 
@@ -115,7 +116,9 @@ async function handleTicketCreatedEvent(event: unknown): Promise<void> {
       }
       const createdTicket = ticket;
 
-      const result = await withTransaction(knex, async (trx: Knex.Transaction) => {
+      const backendActions = await withTransaction(knex, async (trx: Knex.Transaction) => {
+        const collected: SlaBackendAction[] = [];
+
         const startResult = await startSlaForTicket(
           trx,
           tenantId,
@@ -127,13 +130,32 @@ async function handleTicketCreatedEvent(event: unknown): Promise<void> {
         );
 
         if (startResult.success && startResult.sla_policy_id) {
+          collected.push(...(startResult.backendActions ?? []));
+
           logger.info('[SlaSubscriber] Started SLA tracking for ticket', {
             tenantId,
             ticketId,
             policyId: startResult.sla_policy_id,
             responseDueAt: startResult.sla_response_due_at?.toISOString(),
-            resolutionDueAt: startResult.sla_resolution_due_at?.toISOString()
+            resolutionDueAt: startResult.sla_resolution_due_at?.toISOString(),
+            createdInClosedStatus: startResult.created_in_closed_status ?? false
           });
+
+          // Apply the creation status' pause configuration (and awaiting-client
+          // pause) right away, so a ticket created straight into a pausing
+          // status never burns SLA time. Tickets created closed already have
+          // their SLA closed out, so there is nothing to pause.
+          if (!startResult.created_in_closed_status) {
+            const pauseResult = await syncPauseState(trx, tenantId, ticketId, userId);
+            collected.push(...(pauseResult.backendActions ?? []));
+
+            if (pauseResult.is_now_paused) {
+              logger.info('[SlaSubscriber] SLA paused at creation', {
+                tenantId,
+                ticketId
+              });
+            }
+          }
         } else if (!startResult.success) {
           logger.error('[SlaSubscriber] Failed to start SLA tracking', {
             tenantId,
@@ -142,10 +164,10 @@ async function handleTicketCreatedEvent(event: unknown): Promise<void> {
           });
         }
         // If no policy assigned, that's normal - just log at debug level
-        return startResult;
+        return collected;
       });
 
-      await dispatchSlaBackendActions(result?.backendActions);
+      await dispatchSlaBackendActions(backendActions);
     });
   } catch (error) {
     logger.error('[SlaSubscriber] Failed to handle TICKET_CREATED event', {

--- a/server/src/test/integration/sla/slaPauseService.integration.test.ts
+++ b/server/src/test/integration/sla/slaPauseService.integration.test.ts
@@ -69,6 +69,7 @@ let resumeSla: typeof import('@alga-psa/sla/services').resumeSla;
 let handleStatusChange: typeof import('@alga-psa/sla/services').handleStatusChange;
 let handleResponseStateChange: typeof import('@alga-psa/sla/services').handleResponseStateChange;
 let shouldSlaBePaused: typeof import('@alga-psa/sla/services').shouldSlaBePaused;
+let syncPauseState: typeof import('@alga-psa/sla/services').syncPauseState;
 let getPauseStats: typeof import('@alga-psa/sla/services').getPauseStats;
 
 const tenantTable = (dbOrTrx: Knex | Knex.Transaction, tenant: string, tableName: string) =>
@@ -108,6 +109,7 @@ describe('SLA Pause Service Integration Tests', () => {
       handleStatusChange,
       handleResponseStateChange,
       shouldSlaBePaused,
+      syncPauseState,
       getPauseStats,
     } = await import('@alga-psa/sla/services'));
 
@@ -400,6 +402,73 @@ describe('SLA Pause Service Integration Tests', () => {
       });
 
       // Verify ticket was updated
+      const ticket = await tenantTable(db, tenantId, 'tickets').where({ tenant: tenantId, ticket_id: ticketId }).first();
+      expect(ticket.sla_paused_at).toBeNull();
+    });
+  });
+
+  // ==========================================================================
+  // Creation-Time Pause Tests
+  // ==========================================================================
+  describe('Creation-Time Pause', () => {
+    it('pauses SLA for a ticket created in a pause-configured status', async () => {
+      const ticketId = uuidv4();
+
+      await insertTicket(db, {
+        tenant: tenantId,
+        ticketId,
+        ticketNumber: `CREATE-PAUSE-${uuidv4().slice(0, 6)}`,
+        title: 'Created In Pending Status',
+        clientId,
+        contactId,
+        statusId: statusPendingId, // Configured to pause SLA
+        priorityId: priorityHighId,
+        boardId,
+      });
+
+      await db.transaction(async (trx) => {
+        // Mirrors the TICKET_CREATED subscriber: start, then sync pause state.
+        const startResult = await startSlaForTicket(trx, tenantId, ticketId, clientId, boardId, priorityHighId);
+        expect(startResult.sla_policy_id).toBe(slaPolicyId);
+        expect(startResult.created_in_closed_status).toBe(false);
+
+        const pauseResult = await syncPauseState(trx, tenantId, ticketId, internalUserId);
+
+        expect(pauseResult.success).toBe(true);
+        expect(pauseResult.is_now_paused).toBe(true);
+        expect(pauseResult.backendActions).toEqual([
+          { kind: 'pause', ticketId, reason: 'status_pause' },
+        ]);
+      });
+
+      const ticket = await tenantTable(db, tenantId, 'tickets').where({ tenant: tenantId, ticket_id: ticketId }).first();
+      expect(ticket.sla_paused_at).not.toBeNull();
+    });
+
+    it('leaves SLA running for a ticket created in a normal status', async () => {
+      const ticketId = uuidv4();
+
+      await insertTicket(db, {
+        tenant: tenantId,
+        ticketId,
+        ticketNumber: `CREATE-RUN-${uuidv4().slice(0, 6)}`,
+        title: 'Created In Open Status',
+        clientId,
+        contactId,
+        statusId: statusOpenId,
+        priorityId: priorityHighId,
+        boardId,
+      });
+
+      await db.transaction(async (trx) => {
+        await startSlaForTicket(trx, tenantId, ticketId, clientId, boardId, priorityHighId);
+
+        const pauseResult = await syncPauseState(trx, tenantId, ticketId, internalUserId);
+
+        expect(pauseResult.success).toBe(true);
+        expect(pauseResult.is_now_paused).toBe(false);
+      });
+
       const ticket = await tenantTable(db, tenantId, 'tickets').where({ tenant: tenantId, ticket_id: ticketId }).first();
       expect(ticket.sla_paused_at).toBeNull();
     });

--- a/server/src/test/integration/sla/slaService.integration.test.ts
+++ b/server/src/test/integration/sla/slaService.integration.test.ts
@@ -256,6 +256,56 @@ describe('SLA Service Integration Tests', () => {
       await tenantTable(db, tenantId, 'clients').where({ tenant: tenantId, client_id: clientId }).update({ sla_policy_id: null });
     });
 
+    it('does not run a timer for a ticket created in a closed status', async () => {
+      const ticketId = uuidv4();
+      const createdAt = new Date();
+
+      await insertTicket(db, {
+        tenant: tenantId,
+        ticketId,
+        ticketNumber: `SLA-${uuidv4().slice(0, 6)}`,
+        title: 'Created Closed Ticket',
+        clientId,
+        contactId,
+        statusId: statusClosedId,
+        priorityId: priorityHighId,
+        boardId,
+      });
+
+      await db.transaction(async (trx) => {
+        const result = await startSlaForTicket(
+          trx,
+          tenantId,
+          ticketId,
+          clientId,
+          boardId,
+          priorityHighId,
+          createdAt
+        );
+
+        expect(result.success).toBe(true);
+        expect(result.sla_policy_id).toBe(slaPolicyId);
+        expect(result.created_in_closed_status).toBe(true);
+        // No backend timer may be started for a ticket that arrives closed.
+        expect(result.backendActions).toBeUndefined();
+      });
+
+      const ticket = await tenantTable(db, tenantId, 'tickets').where({ tenant: tenantId, ticket_id: ticketId }).first();
+      expect(ticket.sla_resolution_at).not.toBeNull();
+      expect(ticket.sla_resolution_met).toBe(true);
+      expect(ticket.sla_paused_at).toBeNull();
+
+      // The timer job only picks up unresolved, unpaused tickets, so this one
+      // can never be flagged as breached.
+      const timerCandidates = await tenantTable(db, tenantId, 'tickets')
+        .where({ tenant: tenantId })
+        .whereNotNull('sla_policy_id')
+        .whereNull('sla_resolution_at')
+        .whereNull('sla_paused_at')
+        .select('ticket_id');
+      expect(timerCandidates.map((t: { ticket_id: string }) => t.ticket_id)).not.toContain(ticketId);
+    });
+
     it('returns no SLA when no matching policy exists', async () => {
       // Create a new client without SLA policy
       const newClientId = await createClient(db, tenantId, 'No SLA Client');

--- a/server/src/test/unit/sla/slaSubscriber.test.ts
+++ b/server/src/test/unit/sla/slaSubscriber.test.ts
@@ -8,7 +8,11 @@ const loggerMock = vi.hoisted(() => ({
 }));
 
 const withTenantTransactionRetryReadOnlyMock = vi.hoisted(() => vi.fn());
+const withTransactionMock = vi.hoisted(() => vi.fn());
+const createTenantKnexMock = vi.hoisted(() => vi.fn());
 const recordResolutionMock = vi.hoisted(() => vi.fn());
+const startSlaForTicketMock = vi.hoisted(() => vi.fn());
+const syncPauseStateMock = vi.hoisted(() => vi.fn());
 const dispatchSlaBackendActionsMock = vi.hoisted(() => vi.fn());
 
 vi.mock('@alga-psa/core/logger', () => ({
@@ -16,9 +20,10 @@ vi.mock('@alga-psa/core/logger', () => ({
 }));
 
 vi.mock('@alga-psa/db', () => ({
-  createTenantKnex: vi.fn(),
+  createTenantKnex: (...args: unknown[]) => createTenantKnexMock(...args),
   runWithTenant: vi.fn(async (_tenantId: string, fn: () => Promise<unknown>) => fn()),
-  withTransaction: vi.fn(),
+  withTransaction: (knex: unknown, callback: (trx: unknown) => Promise<unknown>) =>
+    withTransactionMock(knex, callback),
   withTenantTransactionRetryReadOnly: (
     tenantId: string,
     callback: (trx: unknown) => Promise<unknown>
@@ -29,13 +34,14 @@ vi.mock('@alga-psa/db', () => ({
 }));
 
 vi.mock('@alga-psa/sla', () => ({
-  startSlaForTicket: vi.fn(),
+  startSlaForTicket: (...args: unknown[]) => startSlaForTicketMock(...args),
   recordFirstResponse: vi.fn(),
   recordResolution: (...args: unknown[]) => recordResolutionMock(...args),
   handlePriorityChange: vi.fn(),
   handlePolicyChange: vi.fn(),
   handleStatusChange: vi.fn(),
   handleResponseStateChange: vi.fn(),
+  syncPauseState: (...args: unknown[]) => syncPauseStateMock(...args),
   dispatchSlaBackendActions: (...args: unknown[]) => dispatchSlaBackendActionsMock(...args),
 }));
 
@@ -57,6 +63,127 @@ function createClosedTicketTrx(closedAt = '2026-04-28T22:24:44Z') {
     return chain;
   });
 }
+
+const TENANT_ID = '00000000-0000-0000-0000-000000000002';
+const TICKET_ID = '00000000-0000-0000-0000-000000000003';
+const USER_ID = '00000000-0000-0000-0000-000000000004';
+
+function createCreatedTicketKnex() {
+  const chain = {
+    where: vi.fn(),
+    select: vi.fn(),
+    first: vi.fn(async () => ({
+      client_id: '00000000-0000-0000-0000-000000000010',
+      board_id: '00000000-0000-0000-0000-000000000011',
+      priority_id: '00000000-0000-0000-0000-000000000012',
+      entered_at: '2026-04-28T22:00:00Z',
+    })),
+  };
+  chain.where.mockReturnValue(chain);
+  chain.select.mockReturnValue(chain);
+
+  return vi.fn((table: string) => {
+    if (table !== 'tickets') {
+      throw new Error(`Unexpected table ${table}`);
+    }
+    return chain;
+  });
+}
+
+function createdEvent() {
+  return {
+    id: '00000000-0000-0000-0000-000000000006',
+    eventType: 'TICKET_CREATED' as const,
+    timestamp: '2026-04-28T22:00:01Z',
+    payload: {
+      tenantId: TENANT_ID,
+      ticketId: TICKET_ID,
+      userId: USER_ID,
+    },
+  };
+}
+
+const startAction = {
+  kind: 'start',
+  ticketId: TICKET_ID,
+  policyId: '00000000-0000-0000-0000-000000000020',
+  targets: [],
+  schedule: {},
+};
+
+describe('slaSubscriber TICKET_CREATED handling', () => {
+  beforeEach(() => {
+    loggerMock.info.mockReset();
+    loggerMock.error.mockReset();
+    startSlaForTicketMock.mockReset();
+    syncPauseStateMock.mockReset();
+    dispatchSlaBackendActionsMock.mockReset();
+    createTenantKnexMock.mockResolvedValue({ knex: createCreatedTicketKnex() });
+    withTransactionMock.mockImplementation(async (_knex, callback) => callback('trx'));
+  });
+
+  it('applies the creation status pause configuration', async () => {
+    startSlaForTicketMock.mockResolvedValue({
+      success: true,
+      sla_policy_id: startAction.policyId,
+      sla_started_at: new Date('2026-04-28T22:00:00Z'),
+      sla_response_due_at: null,
+      sla_resolution_due_at: null,
+      created_in_closed_status: false,
+      backendActions: [startAction],
+    });
+    const pauseAction = { kind: 'pause', ticketId: TICKET_ID, reason: 'status_pause' };
+    syncPauseStateMock.mockResolvedValue({
+      success: true,
+      was_paused: false,
+      is_now_paused: true,
+      backendActions: [pauseAction],
+    });
+
+    await __testHooks.handleTicketCreatedEvent(createdEvent());
+
+    expect(syncPauseStateMock).toHaveBeenCalledWith('trx', TENANT_ID, TICKET_ID, USER_ID);
+    expect(dispatchSlaBackendActionsMock).toHaveBeenCalledWith([startAction, pauseAction]);
+  });
+
+  it('does not start or pause a timer for a ticket created closed', async () => {
+    startSlaForTicketMock.mockResolvedValue({
+      success: true,
+      sla_policy_id: startAction.policyId,
+      sla_started_at: new Date('2026-04-28T22:00:00Z'),
+      sla_response_due_at: null,
+      sla_resolution_due_at: null,
+      created_in_closed_status: true,
+    });
+
+    await __testHooks.handleTicketCreatedEvent(createdEvent());
+
+    expect(syncPauseStateMock).not.toHaveBeenCalled();
+    expect(dispatchSlaBackendActionsMock).toHaveBeenCalledWith([]);
+  });
+
+  it('dispatches only the start action for a normal status', async () => {
+    startSlaForTicketMock.mockResolvedValue({
+      success: true,
+      sla_policy_id: startAction.policyId,
+      sla_started_at: new Date('2026-04-28T22:00:00Z'),
+      sla_response_due_at: null,
+      sla_resolution_due_at: null,
+      created_in_closed_status: false,
+      backendActions: [startAction],
+    });
+    syncPauseStateMock.mockResolvedValue({
+      success: true,
+      was_paused: false,
+      is_now_paused: false,
+    });
+
+    await __testHooks.handleTicketCreatedEvent(createdEvent());
+
+    expect(syncPauseStateMock).toHaveBeenCalledTimes(1);
+    expect(dispatchSlaBackendActionsMock).toHaveBeenCalledWith([startAction]);
+  });
+});
 
 describe('slaSubscriber TICKET_CLOSED handling', () => {
   beforeEach(() => {


### PR DESCRIPTION
## Summary

The SLA timer only reacted to status *changes*, so a ticket created directly in a closed status kept a running timer indefinitely, and a ticket created directly in a pause-configured (or `awaiting_client`) status burned SLA time until its first status change. This PR makes `startSlaForTicket()` and the `TICKET_CREATED` subscriber evaluate the creation status up front so both cases are handled correctly from the moment the ticket exists, and backfills existing rows that were affected by the bug.

## Changes

**SLA service (`packages/sla`)**
- `startSlaForTicket()` now reads the ticket's creation status and checks whether it is closed via a new `isClosedStatus()` helper.
- When created in a closed status, the SLA policy/start time are still recorded for reporting, but `sla_resolution_at` is stamped at creation time (`sla_resolution_met = true` when a resolution target exists), no backend timer action is dispatched, and a `resolution_recorded` audit event (`reason: created_in_closed_status`) is logged alongside `sla_started`.
- `StartSlaResult` gains a `created_in_closed_status` flag so callers know a timer was intentionally not started.

**Event subscriber (`server/src/lib/eventBus/subscribers/slaSubscriber.ts`)**
- `handleTicketCreatedEvent` now calls `syncPauseState()` in the same transaction as `startSlaForTicket()`, so a ticket created directly into a pause-configured (or `awaiting_client`) status is paused immediately instead of after the first status change.
- This step is skipped when the ticket was created in a closed status, since there is nothing to pause.
- Backend actions from both `startSlaForTicket()` and `syncPauseState()` are collected and dispatched together after the transaction commits.

**Migration**
- Adds `20260803120000_backfill_sla_state_for_tickets_created_paused_or_closed.cjs` to repair existing data per tenant:
  1. Tickets currently in a closed status with an SLA policy and no recorded resolution get `sla_resolution_at` stamped (`closed_at`/`updated_at`/`entered_at`/`now()` fallback chain), removing them from the timer job's selection. `sla_resolution_met` is left untouched for historical rows.
  2. Tickets currently in a pause-configured status with no resolution/pause recorded get `sla_paused_at` set to `now()`.
  3. Both changes are recorded in `sla_audit_log` in batches.
  - Note: EE tenants with Temporal SLA workflows already running for these tickets are not affected by this DB-only backfill and need operator follow-up.

**Docs**
- `docs/features/sla.md` documents that both the pause and closed-status checks are now evaluated at creation time, not only on later changes.

## Testing

- Added integration coverage in `slaPauseService.integration.test.ts` and `slaService.integration.test.ts` for creation-time pause and closed-status start behavior.
- Extended `server/src/test/unit/sla/slaSubscriber.test.ts` to cover the new pause-at-creation path in the subscriber.
