### PR TITLE
M365 inbound email: subscription renewal exceeds Graph 4230-minute cap

### DIFF
--- a/docs/plans/2026-08-03-microsoft-email-subscription-renewal-plan.md
+++ b/docs/plans/2026-08-03-microsoft-email-subscription-renewal-plan.md
@@ -1,0 +1,35 @@
+# Microsoft Graph inbound subscription renewal plan
+
+## Problem
+
+Microsoft Graph caps Outlook message-subscription lifetimes at 4,230 minutes. Creation currently requests a safe 60-hour lifetime, while renewal requests 72 hours, so every renewal PATCH can be rejected. The maintenance sweep only recreates on 404, leaving an invalid-parameter renewal failure unhealthy until the customer re-authenticates.
+
+## Design decisions
+
+1. Define one named message-subscription lifetime constant in `shared/services/email/providers/MicrosoftGraphAdapter.ts` and use it for both creation and renewal. Keep the value at 60 hours, below the Graph cap, so the two paths cannot drift.
+2. Keep Graph-specific error interpretation narrow. Add a maintenance-service predicate for a renewal response that Graph rejected as an invalid parameter: HTTP 400 with Graph code `ErrorInvalidParameter`. Treat that alongside 404 ResourceNotFound as a signal to recreate the subscription through the existing `recreateSubscription` path.
+3. Do not recreate on arbitrary 400s or unrelated failures. They must retain the existing error/health behavior so configuration and authentication faults are not hidden.
+4. Preserve the existing polling fallback and webhook URL validation. The repair path must reuse `initializeWebhook`, health updates, and persistence already owned by `recreateSubscription`.
+5. Do not add production-data access or change the reported customer's provider row in this change.
+
+## Implementation sequence
+
+1. In `MicrosoftGraphAdapter.ts`, introduce an exported or module-local constant such as `MICROSOFT_MESSAGE_SUBSCRIPTION_EXPIRATION_MS` equal to 60 hours.
+2. Replace the separate creation and renewal duration expressions with that constant.
+3. In `EmailWebhookMaintenanceService.ts`, add a focused helper that recognizes the Graph invalid-expiration response from its status/code shape, without matching every HTTP 400.
+4. In the renewal catch block, recreate when either the existing 404 predicate or the new invalid-parameter predicate matches; log which recoverable condition triggered the replacement.
+5. Keep all other exceptions flowing to the existing outer failure handling.
+
+## Behavioral tests
+
+1. Extend `server/src/test/unit/email/MicrosoftGraphAdapter.subscription.test.ts` to capture both POST and PATCH payloads and assert their requested expirations are no more than 4,230 minutes ahead and use the same safe lifetime.
+2. Extend `server/src/test/unit/email/EmailWebhookMaintenanceService.test.ts` with a renewal rejection shaped as HTTP 400 plus `ErrorInvalidParameter`; assert `initializeWebhook` is called and the result is `{ success: true, action: 'recreated' }`.
+3. Add a negative case for an unrelated HTTP 400/code and assert it is not recreated and follows the existing failed-health path.
+4. Run the two focused Vitest files, then the repository's relevant typecheck/build command used by the draft lane.
+
+## Risks and boundaries
+
+- Graph error objects may expose the code at more than one nested location; match the shapes already produced by `MicrosoftGraphAdapter.handleError` and covered by tests.
+- Expiration assertions need a small clock tolerance or a fixed fake clock to avoid timing flakes.
+- Recreating on every 400 would mask real configuration defects, so the predicate must remain code-specific.
+- No migration, UI, OAuth-consent, calendar-subscription, or polling-cadence changes are in scope.

--- a/server/src/test/unit/email/EmailWebhookMaintenanceService.test.ts
+++ b/server/src/test/unit/email/EmailWebhookMaintenanceService.test.ts
@@ -200,6 +200,56 @@ describe('EmailWebhookMaintenanceService Microsoft recovery sweep', () => {
     expect(results[0]).toMatchObject({ success: true, action: 'recreated' });
   });
 
+  it('recreates the subscription when Graph rejects renewal with an invalid parameter', async () => {
+    provider.webhook_expires_at = new Date(Date.now() + 30 * 60 * 1000).toISOString();
+    mocks.adapter.renewWebhookSubscription.mockRejectedValueOnce({
+      status: 400,
+      code: 'ErrorInvalidParameter',
+      message: 'Expiration exceeds the maximum subscription lifetime',
+    });
+    mocks.adapter.initializeWebhook.mockResolvedValueOnce({ success: true });
+    mocks.adapter.getConfig.mockReturnValueOnce({
+      webhook_expires_at: new Date(Date.now() + 60 * 60 * 1000).toISOString(),
+    });
+
+    const results = await new EmailWebhookMaintenanceService().renewMicrosoftWebhooks({
+      tenantId: provider.tenant,
+      lookAheadMinutes: 60,
+    });
+
+    expect(mocks.adapter.initializeWebhook).toHaveBeenCalled();
+    expect(results[0]).toMatchObject({ success: true, action: 'recreated' });
+  });
+
+  it('does not recreate the subscription for an unrelated Graph 400', async () => {
+    provider.webhook_expires_at = new Date(Date.now() + 30 * 60 * 1000).toISOString();
+    mocks.adapter.renewWebhookSubscription.mockRejectedValueOnce({
+      status: 400,
+      code: 'BadRequest',
+      message: 'Unrelated bad request',
+    });
+
+    const results = await new EmailWebhookMaintenanceService().renewMicrosoftWebhooks({
+      tenantId: provider.tenant,
+      lookAheadMinutes: 60,
+    });
+
+    expect(mocks.adapter.initializeWebhook).not.toHaveBeenCalled();
+    expect(results[0]).toMatchObject({
+      success: false,
+      action: 'failed',
+      error: 'Unrelated bad request',
+    });
+
+    const knex = await mocks.getAdminConnection();
+    const query = knex();
+    expect(query.update).toHaveBeenCalledWith(expect.objectContaining({
+      subscription_status: 'error',
+      last_renewal_result: 'failure',
+      is_healthy: false,
+    }));
+  });
+
   it('does not renew, recreate, or reconcile polling providers before their probe is due', async () => {
     provider.delivery_mode = 'polling';
     provider.next_subscription_probe_at = new Date(Date.now() + 60 * 60 * 1000).toISOString();

--- a/server/src/test/unit/email/MicrosoftGraphAdapter.subscription.test.ts
+++ b/server/src/test/unit/email/MicrosoftGraphAdapter.subscription.test.ts
@@ -1,4 +1,4 @@
-import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 const mocks = vi.hoisted(() => {
   const requestUse = vi.fn();
@@ -64,6 +64,30 @@ describe('MicrosoftGraphAdapter subscription hygiene', () => {
     mocks.client.post.mockResolvedValue({
       data: { id: 'new-subscription', expirationDateTime: new Date(Date.now() + 3600000).toISOString() },
     });
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('keeps creation and renewal expirations within the Graph 4230-minute cap', async () => {
+    vi.useFakeTimers();
+    const now = new Date('2026-08-03T12:00:00.000Z');
+    vi.setSystemTime(now);
+    const adapter = new MicrosoftGraphAdapter(config());
+
+    await adapter.registerWebhookSubscription();
+    await adapter.renewWebhookSubscription();
+
+    const createdSubscription = mocks.client.post.mock.calls[0][1];
+    const renewedSubscription = mocks.client.patch.mock.calls[0][1];
+    const creationLifetimeMs = Date.parse(createdSubscription.expirationDateTime) - now.getTime();
+    const renewalLifetimeMs = Date.parse(renewedSubscription.expirationDateTime) - now.getTime();
+    const graphMaximumLifetimeMs = 4_230 * 60 * 1000;
+
+    expect(creationLifetimeMs).toBeLessThanOrEqual(graphMaximumLifetimeMs);
+    expect(renewalLifetimeMs).toBeLessThanOrEqual(graphMaximumLifetimeMs);
+    expect(renewalLifetimeMs).toBe(creationLifetimeMs);
   });
 
   it('best-effort deletes the previous subscription before creating its replacement', async () => {

--- a/shared/services/email/EmailWebhookMaintenanceService.ts
+++ b/shared/services/email/EmailWebhookMaintenanceService.ts
@@ -366,9 +366,15 @@ export class EmailWebhookMaintenanceService {
           newExpiration: config.webhook_expires_at // adapter updates the config object in place
         };
       } catch (error: any) {
-        // check for 404 ResourceNotFound
         if (this.isResourceNotFoundError(error)) {
           logger.warn(`Subscription not found (404) for ${config.id}, attempting to recreate`);
+          return await this.recreateSubscription(adapter, config);
+        }
+
+        if (this.isInvalidSubscriptionExpirationError(error)) {
+          logger.warn(
+            `Subscription renewal rejected (400 ErrorInvalidParameter) for ${config.id}, attempting to recreate`
+          );
           return await this.recreateSubscription(adapter, config);
         }
         
@@ -764,6 +770,12 @@ export class EmailWebhookMaintenanceService {
     if (error?.message?.includes('ResourceNotFound')) return true;
     if (error?.message?.includes('Subscription not found')) return true;
     return false;
+  }
+
+  private isInvalidSubscriptionExpirationError(error: any): boolean {
+    const status = error?.response?.status ?? error?.status;
+    const code = error?.response?.data?.error?.code ?? error?.code;
+    return status === 400 && code === 'ErrorInvalidParameter';
   }
 
   private async updateHealthStatus(providerId: string, tenant: string, status: {

--- a/shared/services/email/providers/MicrosoftGraphAdapter.ts
+++ b/shared/services/email/providers/MicrosoftGraphAdapter.ts
@@ -44,6 +44,9 @@ export interface MicrosoftGraphSendMailResult {
   clientRequestId?: string;
 }
 
+// Graph caps Outlook message subscriptions at 4,230 minutes; keep a safe 60-hour window.
+const MICROSOFT_MESSAGE_SUBSCRIPTION_EXPIRATION_MS = 60 * 60 * 60 * 1000;
+
 export type MicrosoftGraphSendMailPayload =
   | { kind: 'json'; message: Record<string, unknown> }
   | { kind: 'mime'; content: string };
@@ -543,10 +546,6 @@ export class MicrosoftGraphAdapter extends BaseEmailAdapter {
         throw new Error('Webhook notification URL not configured');
       }
 
-      // Microsoft Graph limit for Outlook message subscriptions is 4230 minutes (~70.5 hours)
-      // Use a safe window (e.g., 60 hours) to avoid 400 due to out-of-range expiration
-      const expirationMs = 60 * 60 * 1000 * 60; // 60 hours in ms
-
       const desiredFolder = (this.config.folder_to_monitor || 'Inbox').trim();
       const { resource, resolvedFolder } = await this.buildFolderResourcePath(desiredFolder);
       const mailboxBase = this.getMailboxBasePath();
@@ -555,7 +554,9 @@ export class MicrosoftGraphAdapter extends BaseEmailAdapter {
         changeType: 'created',
         notificationUrl: webhookUrl,
         resource,
-        expirationDateTime: new Date(Date.now() + expirationMs).toISOString(),
+        expirationDateTime: new Date(
+          Date.now() + MICROSOFT_MESSAGE_SUBSCRIPTION_EXPIRATION_MS
+        ).toISOString(),
         clientState: this.config.webhook_verification_token || 'email-webhook-verification',
       };
 
@@ -628,7 +629,9 @@ export class MicrosoftGraphAdapter extends BaseEmailAdapter {
         throw new Error('No webhook subscription to renew');
       }
 
-      const newExpiry = new Date(Date.now() + (3 * 24 * 60 * 60 * 1000)).toISOString();
+      const newExpiry = new Date(
+        Date.now() + MICROSOFT_MESSAGE_SUBSCRIPTION_EXPIRATION_MS
+      ).toISOString();
       
       await this.httpClient.patch(`/subscriptions/${this.config.webhook_subscription_id}`, {
         expirationDateTime: newExpiry,


### PR DESCRIPTION
## Summary

- use one 60-hour Microsoft Graph message-subscription lifetime for both creation and renewal, keeping both below Graph's 4,230-minute limit
- recreate a subscription when renewal receives the exact Graph HTTP 400 `ErrorInvalidParameter` response, as well as the existing 404 recovery case
- keep unrelated HTTP 400 responses on the existing failure path so genuine configuration or request errors are not hidden
- add focused coverage for capped creation/renewal expiration, exact-error recreation, and unrelated-400 behavior

## Automated validation

- focused M365 subscription tests: 23/23 passed
- server typecheck: passed with `NODE_OPTIONS=--max-old-space-size=8192`
- root `npm run build`: passed

## Smoke test

**PASS.** Exercised the real Next.js product at http://localhost:3990 using dev login and the Inbound Email UI.

Flows:

1. **Happy renewal:** Retry Renewal changed the M365 card from “Expires in 1h” to “Expires in 3d.” Database and emulator reported about 3,600 minutes, below Graph's 4,230-minute cap.
2. **Exact Graph 400 `ErrorInvalidParameter`:** injected once on PATCH. Runtime logs showed the recreate fallback; subscription ID changed from `subscription-5-47f6662f` to `subscription-6-b8829f5b`. The provider remained connected and healthy with a new 60-hour expiry, without re-authentication.
3. **Nearby regression:** injected unrelated 400 `Request_BadRequest`. It was not recreated; the UI displayed the renewal error, while database health became error/failure and retained the existing subscription.

Fidelity: used the repository Microsoft Graph emulator on port 4010 with real emulator OAuth tokens. Because recreation requires an HTTPS callback and the repository webhook sink is HTTP-only, the test used a temporary minimal HTTPS validation simulator under `tools/smoke-sim`; it was removed afterward. No mock was used. The emulator does not independently enforce the 4,230-minute cap, so expiry was verified from its captured subscription and database state; the exact Microsoft error envelope was fault-injected.

Not tested: live Microsoft Graph, Jaime's production provider row, or the reported weekly cadence.

Evidence: `/tmp/alga-smoke-evidence/m365-subscription-renewal-20260803-143153`

## Known concern

After an unrelated renewal failure, the page shows the error banner but the provider card remains visually “Connected” until refreshed, even though database status is already error. This appears pre-existing and outside this change.

## Cleanup

Fixture rows, emulator, HTTPS simulator, temporary credentials/certificates, and environment overrides were removed. The dev server is restored and answering on port 3990. The worktree retains only the pre-existing, unrelated `package-lock.json` modification, which is excluded from this PR.