### PR TITLE
Stop full-page reload on billing contract subtab switch

### DIFF
--- a/packages/billing/src/components/billing-dashboard/contracts/ContractDetail.tsx
+++ b/packages/billing/src/components/billing-dashboard/contracts/ContractDetail.tsx
@@ -348,15 +348,22 @@ const ContractDetail: React.FC<ContractDetailProps> = ({
   const editingAssignment = editingAssignmentId ? editAssignments[editingAssignmentId] : null;
   const editingRenewalTicketBoardId = editingAssignment?.renewal_ticket_board_id ?? null;
 
+  // Uses history.replaceState to avoid a Next.js soft navigation: router.replace
+  // would re-render the billing route server-side on every subtab click, which
+  // remounts the detail view and flashes a loading skeleton.
   const updateContractViewParam = useCallback((tabValue: string) => {
-    const params = new URLSearchParams(searchParams?.toString() ?? '');
+    if (typeof window === 'undefined') {
+      return;
+    }
+    const params = new URLSearchParams(window.location.search);
     if (tabValue === 'edit') {
       params.delete('contractView');
     } else {
       params.set('contractView', tabValue);
     }
-    router.replace(`/msp/billing?${params.toString()}`, { scroll: false });
-  }, [router, searchParams]);
+    const queryString = params.toString();
+    window.history.replaceState(null, '', queryString ? `/msp/billing?${queryString}` : '/msp/billing');
+  }, []);
 
   // Sync tab state FROM URL changes (e.g., browser back/forward)
   // Don't include activeTab in deps - handleTabChange handles state → URL direction

--- a/packages/billing/src/components/billing-dashboard/contracts/ContractDetailSwitcher.tsx
+++ b/packages/billing/src/components/billing-dashboard/contracts/ContractDetailSwitcher.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import React, { useEffect, useState } from 'react';
+import React, { useEffect, useRef, useState } from 'react';
 import { useRouter } from 'next/navigation';
 import { useSearchParams } from 'next/navigation';
 import { Alert, AlertDescription } from '@alga-psa/ui/components/Alert';
@@ -46,10 +46,25 @@ const ContractDetailSwitcher: React.FC<ContractDetailSwitcherProps> = ({
   const [error, setError] = useState<string | null>(null);
   const [resolvedContractId, setResolvedContractId] = useState<string | null>(contractId);
 
+  // Other query params (contractView, subtab…) change on every subtab switch.
+  // Only the contract identity should re-resolve the contract type, otherwise
+  // ContractDetail unmounts and reloads on each tab click.
+  const lastResolvedRef = useRef<{ contractId: string | null; clientContractId: string | null } | null>(null);
+
   useEffect(() => {
     let isMounted = true;
 
     const resolveContractType = async () => {
+      const lastResolved = lastResolvedRef.current;
+      if (
+        lastResolved &&
+        lastResolved.contractId === contractId &&
+        lastResolved.clientContractId === clientContractId
+      ) {
+        return;
+      }
+      lastResolvedRef.current = { contractId, clientContractId };
+
       if (!contractId && !clientContractId) {
         if (isMounted) {
           setViewMode('error');
@@ -77,10 +92,15 @@ const ContractDetailSwitcher: React.FC<ContractDetailSwitcherProps> = ({
           if (clientContract) {
             setResolvedContractId(clientContract.contract_id);
             if (!contractId) {
-              const params = new URLSearchParams(searchParams?.toString() ?? '');
+              const params = new URLSearchParams(
+                typeof window === 'undefined' ? '' : window.location.search
+              );
               params.set('tab', 'client-contracts');
               params.set('clientContractId', clientContractId);
               params.set('contractId', clientContract.contract_id);
+              // The redirect only adds the resolved contractId, so treat it as
+              // already resolved and skip the re-run it would otherwise trigger.
+              lastResolvedRef.current = { contractId: clientContract.contract_id, clientContractId };
               router.replace(`/msp/billing?${params.toString()}`, { scroll: false });
             }
             setViewMode('client');
@@ -129,7 +149,7 @@ const ContractDetailSwitcher: React.FC<ContractDetailSwitcherProps> = ({
     return () => {
       isMounted = false;
     };
-  }, [clientContractId, contractId, router, searchParams, t]);
+  }, [clientContractId, contractId, router]);
 
   if (!contractId && !clientContractId) {
     return (

--- a/packages/billing/tests/ContractDetail.featureFlag.test.tsx
+++ b/packages/billing/tests/ContractDetail.featureFlag.test.tsx
@@ -184,6 +184,13 @@ vi.mock(
   }),
 );
 
+// ContractDetail normalizes the URL with history.replaceState, so the jsdom
+// location has to stay in sync with the mocked useSearchParams value.
+const setSearchParams = (query: string) => {
+  navigationState.params = new URLSearchParams(query);
+  window.history.replaceState(null, "", `/msp/billing?${query}`);
+};
+
 describe("ContractDetail contract simulator feature flag", () => {
   let ContractDetail: React.ComponentType<{
     resolvedContractId?: string | null;
@@ -197,9 +204,7 @@ describe("ContractDetail contract simulator feature flag", () => {
 
   beforeEach(() => {
     vi.clearAllMocks();
-    navigationState.params = new URLSearchParams(
-      "tab=contracts&contractId=contract-1",
-    );
+    setSearchParams("tab=contracts&contractId=contract-1");
     featureFlagState.enabled = false;
     featureFlagState.loading = true;
     featureFlagState.error = null;
@@ -242,9 +247,7 @@ describe("ContractDetail contract simulator feature flag", () => {
   });
 
   it("renders the Simulate tab when the flag is enabled", async () => {
-    navigationState.params = new URLSearchParams(
-      "tab=contracts&contractId=contract-1&contractView=simulator",
-    );
+    setSearchParams("tab=contracts&contractId=contract-1&contractView=simulator");
     featureFlagState.enabled = true;
     featureFlagState.loading = false;
 
@@ -257,10 +260,11 @@ describe("ContractDetail contract simulator feature flag", () => {
       await screen.findByTestId("contract-simulator-mounted"),
     ).toBeInTheDocument();
     expect(navigationState.replace).not.toHaveBeenCalled();
+    expect(window.location.search).toContain("contractView=simulator");
   });
 
   it("preserves a simulator deep link until the flag verdict is available", async () => {
-    navigationState.params = new URLSearchParams(
+    setSearchParams(
       "tab=contracts&contractId=contract-1&contractView=simulator&foo=bar",
     );
 
@@ -273,6 +277,7 @@ describe("ContractDetail contract simulator feature flag", () => {
       screen.queryByRole("tab", { name: "Simulate" }),
     ).not.toBeInTheDocument();
     expect(navigationState.replace).not.toHaveBeenCalled();
+    expect(window.location.search).toContain("contractView=simulator");
 
     featureFlagState.enabled = true;
     featureFlagState.loading = false;
@@ -288,7 +293,7 @@ describe("ContractDetail contract simulator feature flag", () => {
   });
 
   it("normalizes a disabled simulator deep link to Overview and preserves other query parameters", async () => {
-    navigationState.params = new URLSearchParams(
+    setSearchParams(
       "tab=contracts&contractId=contract-1&contractView=simulator&foo=bar",
     );
     featureFlagState.loading = false;
@@ -299,11 +304,12 @@ describe("ContractDetail contract simulator feature flag", () => {
     expect(
       screen.queryByRole("tab", { name: "Simulate" }),
     ).not.toBeInTheDocument();
+    // The subtab URL is now updated in place, without a route navigation.
     await waitFor(() => {
-      expect(navigationState.replace).toHaveBeenCalledWith(
+      expect(window.location.pathname + window.location.search).toBe(
         "/msp/billing?tab=contracts&contractId=contract-1&foo=bar",
-        { scroll: false },
       );
     });
+    expect(navigationState.replace).not.toHaveBeenCalled();
   });
 });

--- a/server/src/app/msp/billing/page.tsx
+++ b/server/src/app/msp/billing/page.tsx
@@ -75,15 +75,18 @@ const BillingPage = async ({ searchParams }: BillingPageProps) => {
     ? servicesResponse
     : (servicesResponse.services || []);
 
-  // Fetch documents server-side when viewing the documents tab
+  // The contract detail view switches subtabs client-side (no server navigation),
+  // so the user id has to be available for any contract deep link, not just the
+  // documents tab. Documents themselves are only prefetched for direct documents
+  // links — ContractDetail loads them client-side otherwise.
   let contractDocuments: IDocument[] | null = null;
   let currentUserId: string | null = null;
-  if (contractId && contractView === 'documents') {
+  if (contractId) {
     const [documents, user] = await Promise.all([
-      getDocumentsByContractId(contractId),
+      contractView === 'documents' ? getDocumentsByContractId(contractId) : Promise.resolve(null),
       getCurrentUser()
     ]);
-    contractDocuments = Array.isArray(documents) ? documents : [];
+    contractDocuments = Array.isArray(documents) ? documents : contractView === 'documents' ? [] : null;
     currentUserId = user?.user_id || null;
   }
 

--- a/server/src/test/unit/billing/contractDetailTabSwitch.ui.test.tsx
+++ b/server/src/test/unit/billing/contractDetailTabSwitch.ui.test.tsx
@@ -1,0 +1,203 @@
+/**
+ * @vitest-environment jsdom
+ */
+import React from 'react';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react';
+
+(globalThis as unknown as { React?: typeof React }).React = React;
+
+const routerMock = {
+  push: vi.fn(),
+  replace: vi.fn(),
+  refresh: vi.fn(),
+  back: vi.fn(),
+  prefetch: vi.fn(),
+};
+
+let currentSearchParams = new URLSearchParams('tab=client-contracts&contractId=contract-1');
+
+vi.mock('next/navigation', () => ({
+  useRouter: () => routerMock,
+  useSearchParams: () => currentSearchParams,
+  usePathname: () => '/msp/billing',
+}));
+
+vi.mock('@alga-psa/ui/lib/i18n/client', () => ({
+  useTranslation: () => ({
+    t: (key: string, options?: string | Record<string, unknown>) =>
+      typeof options === 'string' ? options : ((options?.defaultValue as string | undefined) ?? key),
+  }),
+  useFormatters: () => ({
+    formatCurrency: (value: number, currency = 'USD') =>
+      new Intl.NumberFormat('en-US', { style: 'currency', currency }).format(value),
+    formatDate: (value: unknown) => String(value),
+    formatNumber: (value: number) => String(value),
+  }),
+}));
+
+vi.mock('@alga-psa/ui/components/Tabs', async () => {
+  const react = await vi.importActual<typeof import('react')>('react');
+  const TabsContext = react.createContext<{ value: string; onValueChange: (value: string) => void }>({
+    value: '',
+    onValueChange: () => undefined,
+  });
+
+  return {
+    Tabs: ({ value, onValueChange, children }: any) => (
+      <TabsContext.Provider value={{ value, onValueChange }}>{children}</TabsContext.Provider>
+    ),
+    TabsList: ({ children }: any) => <div role="tablist">{children}</div>,
+    TabsTrigger: ({ value, children, disabled }: any) => {
+      const context = react.useContext(TabsContext);
+      return (
+        <button
+          type="button"
+          role="tab"
+          disabled={disabled}
+          data-value={value}
+          aria-selected={context.value === value}
+          onClick={() => context.onValueChange(value)}
+        >
+          {children}
+        </button>
+      );
+    },
+    // Panel bodies are irrelevant to tab-switch navigation and pull in the whole
+    // contract editor tree, so they stay unrendered here.
+    TabsContent: () => null,
+  };
+});
+
+vi.mock('@alga-psa/ui', () => ({
+  useDrawer: () => ({ openDrawer: vi.fn(), replaceDrawer: vi.fn(), closeDrawer: vi.fn() }),
+}));
+
+vi.mock('@alga-psa/ui/hooks', () => ({
+  useFeatureFlag: () => ({ enabled: false, loading: false }),
+}));
+
+vi.mock('@alga-psa/ui/components/providers/TenantProvider', () => ({
+  useTenant: () => 'tenant-1',
+}));
+
+vi.mock('@alga-psa/core/context/DocumentsCrossFeatureContext', () => ({
+  useDocumentsCrossFeature: () => ({
+    getDocumentsByContractId: vi.fn(async () => []),
+    renderDocuments: () => null,
+  }),
+}));
+
+const contractFixture = {
+  contract_id: 'contract-1',
+  contract_name: 'Managed Services',
+  contract_description: 'Base contract',
+  status: 'active',
+  billing_frequency: 'monthly',
+  is_template: false,
+  currency_code: 'USD',
+};
+
+const getContractById = vi.fn(async () => contractFixture);
+
+vi.mock('@alga-psa/billing/actions/contractActions', () => ({
+  getContractById: (...args: unknown[]) => getContractById(...(args as [])),
+  getContractSummary: vi.fn(async () => null),
+  getContractAssignments: vi.fn(async () => []),
+  updateContract: vi.fn(async () => contractFixture),
+  deleteContract: vi.fn(async () => undefined),
+}));
+
+vi.mock('@alga-psa/billing/actions/billingClientsActions', () => ({
+  getClientContractByIdForBilling: vi.fn(async () => null),
+  updateClientContractForBilling: vi.fn(async () => null),
+  getClientByIdForBilling: vi.fn(async () => null),
+}));
+
+vi.mock('@alga-psa/billing/actions/quoteActions', () => ({
+  getQuoteByConvertedContractId: vi.fn(async () => null),
+}));
+
+vi.mock('@alga-psa/billing/actions/invoiceQueries', () => ({
+  fetchInvoicesByContract: vi.fn(async () => []),
+}));
+
+vi.mock('@alga-psa/billing/actions/invoiceTemplates', () => ({
+  getInvoiceTemplates: vi.fn(async () => []),
+}));
+
+vi.mock('@alga-psa/reference-data/actions/boardActions', () => ({
+  getAllBoards: vi.fn(async () => []),
+}));
+
+vi.mock('@alga-psa/reference-data/actions/status-actions/statusActions', () => ({
+  getTicketStatuses: vi.fn(async () => []),
+}));
+
+vi.mock('@alga-psa/billing/hooks/useBillingEnumOptions', () => ({
+  useBillingFrequencyOptions: () => [],
+}));
+
+vi.mock('../../../../../packages/billing/src/components/billing-dashboard/contracts/ContractHeader', () => ({
+  default: () => <div data-testid="contract-header" />,
+}));
+
+vi.mock('../../../../../packages/billing/src/components/billing-dashboard/contracts/ContractTemplateDetail', () => ({
+  default: () => <div data-testid="contract-template-detail" />,
+}));
+
+import ContractDetail from '../../../../../packages/billing/src/components/billing-dashboard/contracts/ContractDetail';
+import ContractDetailSwitcher from '../../../../../packages/billing/src/components/billing-dashboard/contracts/ContractDetailSwitcher';
+
+const setSearchParams = (query: string) => {
+  currentSearchParams = new URLSearchParams(query);
+  window.history.replaceState(null, '', `/msp/billing?${query}`);
+};
+
+describe('contract detail tab switching', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    getContractById.mockResolvedValue(contractFixture);
+    setSearchParams('tab=client-contracts&contractId=contract-1');
+  });
+
+  afterEach(() => {
+    cleanup();
+  });
+
+  it('keeps the contract mounted when only the contractView param changes', async () => {
+    const { rerender } = render(<ContractDetailSwitcher />);
+
+    await waitFor(() => expect(screen.getByRole('tab', { name: 'Contract Lines' })).toBeInTheDocument());
+    const callsAfterMount = getContractById.mock.calls.length;
+
+    // Next hands back a fresh searchParams object on every URL change.
+    setSearchParams('tab=client-contracts&contractId=contract-1&contractView=lines');
+    rerender(<ContractDetailSwitcher />);
+
+    expect(screen.queryByText('Loading contract...')).not.toBeInTheDocument();
+    expect(screen.getByRole('tab', { name: 'Contract Lines' })).toBeInTheDocument();
+    // A remount of the detail view would re-run both the switcher resolution and
+    // the detail's own contract load.
+    await waitFor(() => expect(getContractById.mock.calls.length).toBe(callsAfterMount));
+  });
+
+  it('switches subtabs with history.replaceState instead of a route navigation', async () => {
+    const replaceStateSpy = vi.spyOn(window.history, 'replaceState');
+
+    render(<ContractDetail resolvedContractId="contract-1" resolvedClientContractId={null} />);
+
+    const linesTab = await screen.findByRole('tab', { name: 'Contract Lines' });
+    replaceStateSpy.mockClear();
+
+    fireEvent.click(linesTab);
+
+    await waitFor(() => expect(replaceStateSpy).toHaveBeenCalled());
+    const [, , nextUrl] = replaceStateSpy.mock.calls[0];
+    expect(String(nextUrl)).toContain('contractView=lines');
+    expect(routerMock.replace).not.toHaveBeenCalled();
+    expect(routerMock.push).not.toHaveBeenCalled();
+
+    replaceStateSpy.mockRestore();
+  });
+});


### PR DESCRIPTION
## Summary

Switching subtabs inside the contract detail view (Overview, Contract Lines, Documents, Simulate, etc.) triggered a Next.js soft navigation via `router.replace`, which re-ran the billing route server-side, remounted `ContractDetailSwitcher`/`ContractDetail`, and flashed a loading skeleton on every click. This change moves subtab URL updates to `history.replaceState` so the URL still reflects the active subtab without forcing a route re-render, and adjusts the contract-type resolution and server data fetch to stop re-triggering on those URL changes.

## Changes

- **ContractDetail**: `updateContractViewParam` now updates the URL with `window.history.replaceState` instead of `router.replace`, avoiding the server-side re-render/remount on subtab switches.
- **ContractDetailSwitcher**: tracks the last-resolved `contractId`/`clientContractId` in a ref and skips re-resolving the contract type when those values haven't changed, so the effect no longer fires on every query-param change (e.g. `contractView`); the `searchParams`/`t` deps were dropped from the effect accordingly, and the redirect path pre-seeds the ref to avoid a redundant resolve.
- **server/msp/billing/page.tsx**: loads `currentUserId` for any contract deep link (not just the documents tab), since subtab switching is now fully client-side and the server route only runs once per deep link. Documents are still only prefetched when `contractView === 'documents'`.
- **Tests**: updated `ContractDetail.featureFlag.test.tsx` to assert against `window.location` instead of the mocked router's `replace` call, since URL updates now go through `history.replaceState`; added a new `contractDetailTabSwitch.ui.test.tsx` covering that (a) the switcher keeps the contract mounted (no extra `getContractById` call) when only `contractView` changes, and (b) clicking a subtab updates the URL via `history.replaceState` without calling `router.replace`/`push`.

## Testing

- Added/updated unit tests as described above; not run in this session — recommend running `vitest` for `packages/billing/tests/ContractDetail.featureFlag.test.tsx` and `server/src/test/unit/billing/contractDetailTabSwitch.ui.test.tsx` before merge.
