### PR TITLE
fix: OAuth vanity handoff and blank SSO alert

### DIFF
--- a/packages/auth/src/components/ClientPortalSignIn.tsx
+++ b/packages/auth/src/components/ClientPortalSignIn.tsx
@@ -74,6 +74,11 @@ export default function ClientPortalSignIn({ branding, portalDomain }: ClientPor
 
   const handleError = (error: AlertProps | string) => {
     if (typeof error === 'string') {
+      // SsoProviderButtons signals "clear previous error" with an empty string.
+      if (!error.trim()) {
+        setIsAlertOpen(false);
+        return;
+      }
       setAlertInfo({
         type: 'error',
         title: 'Error',

--- a/packages/auth/src/components/MspSignIn.tsx
+++ b/packages/auth/src/components/MspSignIn.tsx
@@ -47,6 +47,11 @@ export default function MspSignIn({ initialEmail }: MspSignInProps) {
 
   const handleError = (error: AlertProps | string) => {
     if (typeof error === 'string') {
+      // SsoProviderButtons signals "clear previous error" with an empty string.
+      if (!error.trim()) {
+        setIsAlertOpen(false);
+        return;
+      }
       setAlertInfo({
         type: 'error',
         title: 'Error',

--- a/packages/auth/src/lib/nextAuthOptions.clientPortalSso.contract.test.ts
+++ b/packages/auth/src/lib/nextAuthOptions.clientPortalSso.contract.test.ts
@@ -14,6 +14,12 @@ describe('NextAuth client portal SSO contract', () => {
     expect(source).toContain('const vanityRedirect = await computeVanityRedirect({');
   });
 
+  it('T006b: OAuth client sign-in computes vanity redirect even when state lacks callback_url', () => {
+    // Auth.js drops the OAuth state from the account object, so the branch must
+    // not depend on a state-smuggled callback_url to reach computeVanityRedirect.
+    expect(source).toContain("const callbackUrl = metadata.callbackUrl ?? '/client-portal/dashboard';");
+  });
+
   it('T006/F021: client portal SSO discovery and resolution cookies are cleared after OAuth completion handling', () => {
     expect(source).toContain('async function clearClientPortalSsoStateCookies(): Promise<void>');
     expect(source).toContain('store.delete(CLIENT_PORTAL_SSO_DISCOVERY_COOKIE);');

--- a/packages/auth/src/lib/nextAuthOptions.ts
+++ b/packages/auth/src/lib/nextAuthOptions.ts
@@ -1774,8 +1774,15 @@ export async function buildAuthOptions(context?: BuildAuthOptionsContext): Promi
             if (providerId && providerId !== 'credentials' && extendedUser?.user_type === 'client') {
                 const accountRecord = account as unknown as Record<string, unknown> | null;
                 const metadata = extractOAuthAccountMetadata(accountRecord);
-                const callbackUrl = metadata.callbackUrl;
+                // Auth.js does not copy the OAuth state onto the account, so the
+                // state-smuggled callback_url is normally absent; computeVanityRedirect
+                // resolves the tenant's portal domain from a same-origin path alone.
+                const callbackUrl = metadata.callbackUrl ?? '/client-portal/dashboard';
                 const canonicalBaseUrl = process.env.NEXTAUTH_URL;
+
+                if (!canonicalBaseUrl) {
+                    console.warn('[signIn] NEXTAUTH_URL unset; cannot compute client portal vanity redirect');
+                }
 
                 if (callbackUrl && canonicalBaseUrl) {
                     try {
@@ -2634,8 +2641,15 @@ export const options: NextAuthConfig = {
             if (providerId && providerId !== 'credentials' && extendedUser?.user_type === 'client') {
                 const accountRecord = account as unknown as Record<string, unknown> | null;
                 const metadata = extractOAuthAccountMetadata(accountRecord);
-                const callbackUrl = metadata.callbackUrl;
+                // Auth.js does not copy the OAuth state onto the account, so the
+                // state-smuggled callback_url is normally absent; computeVanityRedirect
+                // resolves the tenant's portal domain from a same-origin path alone.
+                const callbackUrl = metadata.callbackUrl ?? '/client-portal/dashboard';
                 const canonicalBaseUrl = process.env.NEXTAUTH_URL;
+
+                if (!canonicalBaseUrl) {
+                    console.warn('[signIn] NEXTAUTH_URL unset; cannot compute client portal vanity redirect');
+                }
 
                 if (callbackUrl && canonicalBaseUrl) {
                     try {


### PR DESCRIPTION
Auth.js never copies the OAuth state onto the account object, so the state-smuggled callback_url was always absent and the client-portal vanity-domain handoff branch silently skipped after Google/Microsoft sign-in, stranding clients on the canonical domain. Default the callback to /client-portal/dashboard so computeVanityRedirect can resolve the tenant's portal domain on its own, and warn when NEXTAUTH_URL is missing (console.log is stripped from prod builds).

Also treat the empty-string onError signal from SsoProviderButtons as "clear" in ClientPortalSignIn and MspSignIn, which previously opened an alert dialog with no message on every SSO button click.

Like Dorothy discovering the ruby slippers worked all along, computeVanityRedirect could always carry clients home to their own domain â Auth.js simply never handed over the note with the address. As for the great and terrible alert box: pay no attention to the dialog with no message behind the curtain. ðªï¸ð ð 