### PR TITLE
Appliance: stale in-progress install-state permanently blocks updates after control-plane restart

### DIFF
--- a/docs/plans/2026-08-03-appliance-update-interruption-recovery-plan.md
+++ b/docs/plans/2026-08-03-appliance-update-interruption-recovery-plan.md
@@ -132,4 +132,3 @@ No automatic resume, distributed lock or Kubernetes Lease, rollback of already-a
 - Corrupt state: atomic writes.
 - Misleading readiness: never erase transaction interruption using serving readiness.
 - Retry side effects: rely on existing declarative release-selection, storage, and Flux reconciliation, then exercise restart/retry manually.
-

--- a/docs/plans/2026-08-03-appliance-update-interruption-recovery-plan.md
+++ b/docs/plans/2026-08-03-appliance-update-interruption-recovery-plan.md
@@ -1,0 +1,135 @@
+# Appliance update interruption recovery plan
+
+Date: 2026-08-03
+
+## Goal and invariant
+
+Recover app-channel updates interrupted by a control-plane restart without allowing concurrent mutations.
+
+Persisted update-queued or *-running text records intent, not proof of a live owner. Boot-time reconciliation must land before the 409 guard; reversing that order would preserve the current permanent wedge.
+
+## Current implementation
+
+- ee/appliance/host-service/server.mjs owns POST /api/updates. It writes update-queued and queueUpdateWorkflow(channel) launches an unobserved detached update-engine.mjs child.
+- ee/appliance/host-service/update-engine.mjs writes running phases and terminal update-complete/update-blocked. Its CLI catch handles ordinary exceptions, but not SIGKILL, pod loss, or host restart.
+- ee/appliance/host-service/manage-engine.mjs maps install state to the Manage API and suppresses some blocked state when live Helm readiness proves convergence.
+- ee/appliance/status-ui/app/manage/ManageView.tsx starts updates, polls while locally busy, and renders terminal messages.
+- ee/docs/appliance/architecture.md and ee/appliance/docs/registry-metadata-design.md establish durable host-path state, explicit operator updates, signed channel resolution, and pinned manifest digests. Recovery must preserve those boundaries.
+- Existing behavioral coverage lives in tests/update-engine.test.mjs, tests/manage-engine.test.mjs, and status UI smoke tests.
+- package-lock.json is already modified by Wire Up. Do not stage, revert, or reformat it.
+
+## 1. Explicit owner generation
+
+Add ee/appliance/host-service/update-ownership.mjs with pure, injected helpers:
+
+- isUpdateInProgressStatus(status): recognize only update-queued, update-running, release-config-running, and storage-install-running; never setup states.
+- classifyUpdateOwner(state, { nowMs, isPidAlive, maxAgeMs }): return none, live, dead, aged, or invalid plus a reason.
+- interruptedUpdateState(state, classification, nowIso): build the canonical retry-safe terminal state.
+
+Every queued/running state carries update.owner = { pid, startedAt }, alongside requestedChannel and scope. Use both fields as the generation identity. process.kill(pid, 0) success or EPERM means present; ESRCH means dead. Missing/non-positive PID or invalid/future timestamp is invalid. A live PID older than configurable ALGA_APPLIANCE_UPDATE_OWNER_MAX_AGE_MS is aged; default well beyond the existing 15-minute Flux envelope. Terminal states clear owner.
+
+Change queueUpdateWorkflow to generate startedAt, spawn first, return child.pid, and pass --started-at to the child. Publish update-queued only after a real PID exists. A spawn failure must not create a running state.
+
+## 2. Boot-time reconciliation first
+
+Add reconcileInterruptedUpdate() using shared atomic state helpers. Invoke it synchronously during server.mjs initialization before server.listen.
+
+For an in-progress state:
+
+1. Fresh verified owner: preserve it and log adoption.
+2. Dead, aged, missing, or invalid owner: atomically replace it (temporary sibling plus rename) with status update-blocked, phase update-interrupted, preserved requested channel/scope, no owner, current updatedAt, and a failure containing:
+   - category update-interrupted
+   - phase update
+   - step recover-update-owner
+   - a clear interruption message
+   - classifier reason as suspectedCause
+   - retry instruction as suggestedNextStep
+   - retrySafe true
+3. Append the same event to update history through a shared exported history writer.
+
+Do not auto-resume at boot. Reconciliation unlocks an explicit retry; it does not repeat registry or rollout work.
+
+## 3. Live-owner-only 409 guard
+
+In POST /api/updates, after auth/method validation and before overwriting state:
+
+- Re-read and classify state using the same helper.
+- Return 409 only for a fresh live owner, with structured JSON: error, code update_in_progress, retryable true, and requestedChannel/startedAt/status.
+- For dead, aged, or invalid ownership, reconcile immediately to close the post-boot race, then permit a new generation.
+- Never reject solely because the stored status string is queued/running.
+- Serialize start decisions in-process so simultaneous requests produce one spawn and one 409.
+
+## 4. Engine ownership and terminal failure plumbing
+
+In update-engine.mjs:
+
+- Extend parseRunArgs with --started-at. Build owner from process.pid plus that timestamp (generate one only for direct CLI use).
+- Thread owner through runAppChannelUpdate and setup-engine helpers that write release-config-running or storage-install-running. The longest phases must not erase ownership.
+- Centralize transitions and terminal failure writes. Validation, storage, registry, and Flux failures retain detailed causes but clear owner.
+- Success preserves channel/version/digest results, writes update-complete, clears owner, and appends history.
+- Best-effort SIGTERM/SIGINT handlers write update-blocked/update-interrupted. Boot reconciliation remains authoritative for uncatchable exits.
+
+## 5. Manage API and UI
+
+In manage-engine.mjs, include optional code/category, retrySafe, startedAt, and requestedChannel beside update status/message.
+
+Do not erase update-interrupted merely because HelmRelease is Ready: readiness proves serving health, not transaction completion. Retain current readiness suppression only for rollout/convergence failures it disproves.
+
+In ManageView.tsx:
+
+- Treat 409/update_in_progress neutrally: show already running since startedAt, keep polling, and do not label the start failed.
+- Render update-interrupted as actionable blocked state with backend detail and Retry enabled.
+- Keep other 4xx/5xx responses as errors.
+- Never infer PID liveness in React.
+
+## Behavioral regression tests
+
+Add tests/update-ownership.test.mjs for exact status recognition, fresh live PID, ESRCH dead, EPERM live, aged owner, malformed/missing/future owner, and canonical interrupted state preserving intent while clearing owner.
+
+Refactor startup/route logic into exported dependency-injected helpers, or launch the server with temp files, to test:
+
+- boot dead-owner running state becomes interrupted before traffic;
+- boot live owner remains running;
+- live-owner POST returns 409 without spawn/write;
+- stale text plus dead owner reconciles then starts a new generation;
+- concurrent POSTs produce one child and one 409;
+- spawn failure leaves no orphaned running state;
+- setup-running state is ignored by the app-update guard.
+
+Extend update-engine.test.mjs and manage-engine.test.mjs:
+
+- owner survives initial, release-config, and storage phases;
+- success and every failure clear owner and preserve cause;
+- CLI exception becomes retry-safe terminal state;
+- interrupted remains blocked despite Ready HelmRelease;
+- a genuine recovered convergence failure is still suppressed.
+
+Use a React behavioral test only if a DOM harness is practical. Otherwise manually validate start, duplicate 409, process/control-plane interruption, restart, interrupted message, retry, and a new owner generation. Do not add source-string tests.
+
+## Delivery order
+
+1. Ownership and atomic transition helpers plus unit tests.
+2. Boot reconciliation plus integration tests.
+3. PID and startedAt propagation through every running phase.
+4. Live-owner-only guard plus concurrency and spawn-failure tests.
+5. Manage API structured plumbing.
+6. UI handling and manual restart/retry validation.
+7. Operational documentation.
+
+Boot reconciliation and the guard must not ship in the opposite order.
+
+## Deliberate non-goals
+
+No automatic resume, distributed lock or Kubernetes Lease, rollback of already-applied Flux work, setup-workflow ownership redesign, registry signature/channel changes, OS/k3s update changes, host-agent protocol changes, or unrelated lockfile cleanup.
+
+## Risks and mitigations
+
+- PID reuse: pair PID with timestamp and a conservative age ceiling.
+- Start race: serialize classify/spawn/persist.
+- Crash between spawn and parent write: pass generation to the child and have it write immediately; centralize transitions.
+- Helper overwrites: assert owner at every running phase.
+- False aging: configurable ceiling and explicit failure reason.
+- Corrupt state: atomic writes.
+- Misleading readiness: never erase transaction interruption using serving readiness.
+- Retry side effects: rely on existing declarative release-selection, storage, and Flux reconciliation, then exercise restart/retry manually.
+

--- a/ee/appliance/host-service/manage-engine.mjs
+++ b/ee/appliance/host-service/manage-engine.mjs
@@ -7,6 +7,12 @@
 
 import fs from 'node:fs';
 import path from 'node:path';
+import {
+  DEFAULT_UPDATE_OWNER_MAX_AGE_MS,
+  classifyUpdateOwner,
+  interruptedUpdateState,
+  isPidAlive
+} from './update-ownership.mjs';
 import http from 'node:http';
 import { appUrlFromInput, hostFromAppUrl, setYamlScalar } from './setup-engine.mjs';
 import { licenseSeedFromRedeem } from './install-code.mjs';
@@ -406,6 +412,9 @@ export async function collectManageStatus(deps) {
     resolveReleaseManifest,
     appHelmReleaseNamespace = 'alga-system',
     appHelmReleaseName = 'alga-core',
+    updateOwnerNowMs = Date.now(),
+    updateOwnerIsPidAlive = isPidAlive,
+    updateOwnerMaxAgeMs = DEFAULT_UPDATE_OWNER_MAX_AGE_MS,
     licenseNamespace = 'msp',
     licenseSecretName = 'appliance-license-seed'
   } = deps;
@@ -475,11 +484,25 @@ export async function collectManageStatus(deps) {
   // App-update status, reconciled against live reality. install-state persists the
   // *last* update attempt's outcome, which goes stale: a block that has since
   // converged (or a transient that recovered) must not keep showing as a current
-  // error. If the alga-core HelmRelease is actually Ready, the app is healthy and
-  // there is no error to show — surface no failure rather than a stale one.
-  let appUpdateStatus = mapUpdateStatus(installState.status);
-  let appUpdateMessage = installState.lastAction || null;
-  if (appUpdateStatus === 'blocked' && (await isHelmReleaseReady(kube, appHelmReleaseNamespace, appHelmReleaseName)) === true) {
+  // error. If the alga-core HelmRelease is actually Ready, rollout/convergence
+  // failures are stale and can be hidden. An interrupted transaction is different:
+  // readiness does not prove that the attempted update reached a terminal state.
+  const ownerClassification = classifyUpdateOwner(installState, {
+    nowMs: updateOwnerNowMs,
+    isPidAlive: updateOwnerIsPidAlive,
+    maxAgeMs: updateOwnerMaxAgeMs
+  });
+  const effectiveInstallState = ['dead', 'aged', 'invalid'].includes(ownerClassification.status)
+    ? interruptedUpdateState(installState, ownerClassification, new Date(updateOwnerNowMs).toISOString())
+    : installState;
+  let appUpdateStatus = mapUpdateStatus(effectiveInstallState.status);
+  let appUpdateMessage = effectiveInstallState.lastAction || null;
+  const isInterrupted = effectiveInstallState.failure?.category === 'update-interrupted';
+  if (
+    appUpdateStatus === 'blocked'
+    && !isInterrupted
+    && (await isHelmReleaseReady(kube, appHelmReleaseNamespace, appHelmReleaseName)) === true
+  ) {
     appUpdateStatus = 'idle';
     appUpdateMessage = null;
   }
@@ -492,7 +515,17 @@ export async function collectManageStatus(deps) {
       availableVersion: updateAvailable ? resolvedReleaseVersion : null,
       pinnedReleaseDigest: selection.manifestDigest || null,
       resolvedReleaseDigest,
-      update: { status: appUpdateStatus, message: appUpdateMessage }
+      update: {
+        status: appUpdateStatus,
+        message: appUpdateMessage,
+        code: effectiveInstallState.failure?.code || null,
+        category: effectiveInstallState.failure?.category || null,
+        suspectedCause: effectiveInstallState.failure?.suspectedCause || null,
+        suggestedNextStep: effectiveInstallState.failure?.suggestedNextStep || null,
+        retrySafe: effectiveInstallState.failure?.retrySafe ?? null,
+        startedAt: effectiveInstallState.update?.owner?.startedAt || effectiveInstallState.update?.startedAt || null,
+        requestedChannel: effectiveInstallState.update?.requestedChannel || null
+      }
     },
     controlPlane: {
       channel,

--- a/ee/appliance/host-service/server.mjs
+++ b/ee/appliance/host-service/server.mjs
@@ -15,6 +15,8 @@ import { PodExecManager } from './pod-exec-manager.mjs';
 import { PortForwardManager } from './port-forward-manager.mjs';
 import { ensurePodAccessRbac } from './pod-access-rbac.mjs';
 import { accessError, PodAccessError, requestHasSameOrigin } from './pod-access-common.mjs';
+import { createUpdateCoordinator } from './update-controller.mjs';
+import { DEFAULT_UPDATE_OWNER_MAX_AGE_MS } from './update-ownership.mjs';
 import {
   collectManageStatus,
   applyLicense,
@@ -47,6 +49,7 @@ const releaseSelectionFile = process.env.ALGA_APPLIANCE_RELEASE_SELECTION_FILE |
 const kubeconfigPath = process.env.ALGA_APPLIANCE_KUBECONFIG || '/etc/rancher/k3s/k3s.yaml';
 const staticUiDir = process.env.ALGA_APPLIANCE_STATUS_UI_DIR || '/opt/alga-appliance/status-ui/dist';
 const cpUpgradeStatusFile = process.env.ALGA_APPLIANCE_CP_UPGRADE_STATUS_FILE || '/var/lib/alga-appliance/control-plane-upgrade.json';
+const updateHistoryFile = process.env.ALGA_APPLIANCE_UPDATE_HISTORY_FILE || '/var/lib/alga-appliance/update-history.json';
 const hostAgentSocket = process.env.ALGA_APPLIANCE_HOST_AGENT_SOCKET || '/run/alga-appliance/host-agent.sock';
 const STATUS_CACHE_TTL_MS = Number(process.env.ALGA_APPLIANCE_STATUS_CACHE_TTL_MS || 10_000);
 const KUBECTL_REQUEST_TIMEOUT_MS = Number(process.env.ALGA_APPLIANCE_KUBECTL_REQUEST_TIMEOUT_MS || 20_000);
@@ -55,6 +58,12 @@ const KUBECTL_API_TIMEOUT_MS = Number(process.env.ALGA_APPLIANCE_KUBECTL_API_TIM
 const KUBECTL_LOG_TIMEOUT_MS = Number(process.env.ALGA_APPLIANCE_KUBECTL_LOG_TIMEOUT_MS || 60_000);
 const NETWORK_PROBE_TTL_MS = Number(process.env.ALGA_APPLIANCE_NETWORK_PROBE_TTL_MS || 20_000);
 const NETWORK_PROBE_FAILURE_DEBOUNCE = Number(process.env.ALGA_APPLIANCE_NETWORK_PROBE_DEBOUNCE || 2);
+const UPDATE_OWNER_MAX_AGE_MS = Number(
+  process.env.ALGA_APPLIANCE_UPDATE_OWNER_MAX_AGE_MS || DEFAULT_UPDATE_OWNER_MAX_AGE_MS
+);
+if (!Number.isFinite(UPDATE_OWNER_MAX_AGE_MS) || UPDATE_OWNER_MAX_AGE_MS <= 0) {
+  throw new Error('ALGA_APPLIANCE_UPDATE_OWNER_MAX_AGE_MS must be a positive number.');
+}
 const kubectlQueue = createKubectlQueue({ name: 'host-service-kubectl' });
 const podAccessAdapter = createNativeKubernetesAdapter({ kubeconfigPath });
 const podExecManager = new PodExecManager({ adapter: podAccessAdapter });
@@ -177,7 +186,11 @@ const retryStateFile = path.join(path.dirname(stateFile), 'auto-retry-state.json
 let reconcileRunning = false;
 
 function installStateBlocked(state) {
-  return Boolean(state?.failure) && state.failure.retrySafe !== false && String(state.status || '').includes('blocked');
+  const isAppUpdate = state?.update?.scope === 'application-only';
+  return !isAppUpdate
+    && Boolean(state?.failure)
+    && state.failure.retrySafe !== false
+    && String(state.status || '').includes('blocked');
 }
 
 function installStateRunning(state) {
@@ -557,17 +570,19 @@ function queueSetupWorkflow() {
 // enough for the pod's liveness probe to kill the control plane mid-update
 // (alga0002202). The child writes install-state as it goes, so the Manage UI's
 // /api/manage/status polling keeps working while the update runs.
-function queueUpdateWorkflow(channel) {
+function queueUpdateWorkflow(channel, startedAt) {
   if (process.env.ALGA_APPLIANCE_DISABLE_UPDATE_QUEUE === '1') {
-    return;
+    throw new Error('App update queue is disabled.');
   }
 
   const child = spawn(process.execPath, [
     new URL('./update-engine.mjs', import.meta.url).pathname,
     'run',
     '--channel', channel,
+    '--started-at', startedAt,
     '--state-file', stateFile,
     '--release-selection-file', releaseSelectionFile,
+    '--update-history-file', updateHistoryFile,
     '--kubeconfig', kubeconfigPath
   ], {
     detached: true,
@@ -575,7 +590,16 @@ function queueUpdateWorkflow(channel) {
     env: process.env
   });
   child.unref();
+  return child.pid;
 }
+
+const updateCoordinator = createUpdateCoordinator({
+  stateFile,
+  historyFile: updateHistoryFile,
+  maxAgeMs: UPDATE_OWNER_MAX_AGE_MS,
+  spawnUpdate: queueUpdateWorkflow
+});
+updateCoordinator.reconcile();
 
 function shellQuote(value) {
   return `'${String(value).replaceAll("'", "'\\''")}'`;
@@ -1316,19 +1340,16 @@ const server = http.createServer(async (req, res) => {
       return;
     }
 
-    // Record the queued update before spawning so the Manage UI's very next
-    // status poll already reflects it, then hand off to the detached child.
-    fs.mkdirSync(path.dirname(stateFile), { recursive: true, mode: 0o750 });
-    fs.writeFileSync(stateFile, `${JSON.stringify({
-      status: 'update-queued',
-      phase: 'registry-release-source',
-      lastAction: `Update to ${channel} queued; background workflow is starting`,
-      updatedAt: new Date().toISOString(),
-      update: { requestedChannel: channel, scope: 'application-only' }
-    }, null, 2)}\n`, { mode: 0o600 });
-    queueUpdateWorkflow(channel);
-    res.writeHead(202, { 'content-type': 'application/json' });
-    res.end(JSON.stringify({ ok: true, started: true }));
+    try {
+      const result = updateCoordinator.start(channel);
+      jsonResponse(res, result.status, result.body);
+    } catch (error) {
+      jsonResponse(res, 500, {
+        error: error instanceof Error ? error.message : 'Failed to start app update.',
+        code: 'update_start_failed',
+        retryable: true
+      });
+    }
     return;
   }
 

--- a/ee/appliance/host-service/setup-engine.mjs
+++ b/ee/appliance/host-service/setup-engine.mjs
@@ -8,6 +8,7 @@ import { spawnSync } from 'node:child_process';
 import path from 'node:path';
 import { persistMaintenanceMetadata } from './metadata-engine.mjs';
 import { redeemInstallCode, deriveApplianceId, licenseSeedFromRedeem } from './install-code.mjs';
+import { writeSecureJsonFileAtomic } from './update-state.mjs';
 
 // Path defaults honor the ALGA_APPLIANCE_* environment the control plane runs
 // with, falling back to the bare-host locations. This keeps the setup workflow
@@ -55,11 +56,29 @@ function readSystemResolvers(resolvConfPath = DEFAULT_RESOLV_CONF) {
 }
 
 function writeInstallState(state, stateFile = DEFAULT_STATE_FILE) {
-  const stateDir = path.dirname(stateFile);
-  fs.mkdirSync(stateDir, { recursive: true, mode: 0o750 });
-  fs.writeFileSync(stateFile, `${JSON.stringify(state, null, 2)}\n`, { mode: 0o600 });
-  fs.chmodSync(stateDir, 0o750);
-  fs.chmodSync(stateFile, 0o600);
+  writeSecureJsonFileAtomic(stateFile, state);
+}
+
+function writeWorkflowInstallState(state, stateFile, options) {
+  if (!options.update) {
+    writeInstallState(state, stateFile);
+    return;
+  }
+
+  const isBlocked = state.status.endsWith('-blocked');
+  const keepSpecificRunningStatus = [
+    'storage-install-running',
+    'release-config-running'
+  ].includes(state.status);
+  const status = !isBlocked && !keepSpecificRunningStatus
+    ? 'update-running'
+    : state.status;
+  const { owner: _owner, ...terminalUpdate } = options.update;
+  writeInstallState({
+    ...state,
+    status,
+    update: isBlocked ? terminalUpdate : options.update
+  }, stateFile);
 }
 
 function writeSecureJsonFile(targetFile, value) {
@@ -773,12 +792,12 @@ export function installStorage(options = {}) {
   const installCommand = options.storageInstallCommand
     || `${shellQuote(installerPath)} --kubeconfig ${shellQuote(kubeconfigPath)}`;
 
-  writeInstallState({
+  writeWorkflowInstallState({
     status: 'storage-install-running',
     phase: 'storage',
     lastAction: 'Reconciling the appliance local-path storage provider',
     updatedAt: nowIso()
-  }, stateFile);
+  }, stateFile, options);
 
   const result = spawnSync('sh', ['-c', installCommand], {
     env: process.env,
@@ -793,7 +812,7 @@ export function installStorage(options = {}) {
       'Local-path storage reconciliation failed.',
       detail
     );
-    writeInstallState({
+    writeWorkflowInstallState({
       status: 'storage-install-blocked',
       phase: 'storage',
       lastAction: failure.message,
@@ -803,7 +822,7 @@ export function installStorage(options = {}) {
         stderr: result.stderr || ''
       },
       updatedAt: nowIso()
-    }, stateFile);
+    }, stateFile, options);
     return failure;
   }
 
@@ -812,12 +831,12 @@ export function installStorage(options = {}) {
     phase: 'storage',
     message: 'Local-path storage reconciliation and PVC smoke test completed successfully.'
   };
-  writeInstallState({
+  writeWorkflowInstallState({
     status: 'storage-install-complete',
     phase: 'storage',
     lastAction: success.message,
     updatedAt: nowIso()
-  }, stateFile);
+  }, stateFile, options);
   return success;
 }
 
@@ -912,12 +931,12 @@ export async function resolveChannelMetadata(inputs, options = {}) {
   // version/digest pin via inputs.releaseRef). No git, no branch.
   const reference = (inputs.releaseRef || inputs.channel || 'stable').trim();
 
-  writeInstallState({
+  writeWorkflowInstallState({
     status: 'release-resolve-running',
     phase: 'registry-release-source',
     lastAction: `Resolving ${inputs.channel} release manifest from ${registryHost}`,
     updatedAt: nowIso()
-  }, stateFile);
+  }, stateFile, options);
 
   let resolved;
   try {
@@ -935,13 +954,13 @@ export async function resolveChannelMetadata(inputs, options = {}) {
       `Unable to resolve release manifest for "${reference}" from ${registryHost}.`,
       error instanceof Error ? error.message : String(error)
     );
-    writeInstallState({
+    writeWorkflowInstallState({
       status: 'release-resolve-blocked',
       phase: 'registry-release-source',
       lastAction: failure.message,
       failure,
       updatedAt: nowIso()
-    }, stateFile);
+    }, stateFile, options);
     return failure;
   }
 
@@ -959,7 +978,7 @@ export async function resolveChannelMetadata(inputs, options = {}) {
     manifest
   };
 
-  writeInstallState({
+  writeWorkflowInstallState({
     status: 'release-resolve-complete',
     phase: 'registry-release-source',
     lastAction: success.message,
@@ -971,7 +990,7 @@ export async function resolveChannelMetadata(inputs, options = {}) {
       manifestDigest: resolved.manifestDigest
     },
     updatedAt: nowIso()
-  }, stateFile);
+  }, stateFile, options);
 
   return success;
 }
@@ -985,12 +1004,12 @@ export async function applyRuntimeValuesAndReleaseSelection(inputs, releaseSelec
     : releaseSelection.manifest;
   const tempDir = options.runtimeValuesDir || fs.mkdtempSync(path.join(os.tmpdir(), 'alga-runtime-values-'));
   const valuesDir = path.join(tempDir, 'values');
-  writeInstallState({
+  writeWorkflowInstallState({
     status: 'runtime-values-running',
     phase: 'registry-release-source',
     lastAction: 'Creating Kubernetes runtime values and release selection',
     updatedAt: nowIso()
-  }, stateFile);
+  }, stateFile, options);
 
   if (!manifest) {
     const failure = preflightFailure(
@@ -999,7 +1018,7 @@ export async function applyRuntimeValuesAndReleaseSelection(inputs, releaseSelec
       'Release selection did not include a resolved manifest.',
       'resolveChannelMetadata must run (and succeed) before applyRuntimeValuesAndReleaseSelection.'
     );
-    writeInstallState({ status: 'runtime-values-blocked', phase: 'registry-release-source', lastAction: failure.message, failure, updatedAt: nowIso() }, stateFile);
+    writeWorkflowInstallState({ status: 'runtime-values-blocked', phase: 'registry-release-source', lastAction: failure.message, failure, updatedAt: nowIso() }, stateFile, options);
     return failure;
   }
 
@@ -1058,7 +1077,7 @@ export async function applyRuntimeValuesAndReleaseSelection(inputs, releaseSelec
       'Unable to render runtime values for the selected release.',
       error instanceof Error ? error.message : String(error)
     );
-    writeInstallState({ status: 'runtime-values-blocked', phase: 'registry-release-source', lastAction: failure.message, failure, updatedAt: nowIso() }, stateFile);
+    writeWorkflowInstallState({ status: 'runtime-values-blocked', phase: 'registry-release-source', lastAction: failure.message, failure, updatedAt: nowIso() }, stateFile, options);
     return failure;
   }
 
@@ -1095,7 +1114,7 @@ export async function applyRuntimeValuesAndReleaseSelection(inputs, releaseSelec
         failure.correctable = true;
         failure.retrySafe = false;
       }
-      writeInstallState({ status: 'runtime-values-blocked', phase: 'registry-release-source', lastAction: failure.message, failure, updatedAt: nowIso() }, stateFile);
+      writeWorkflowInstallState({ status: 'runtime-values-blocked', phase: 'registry-release-source', lastAction: failure.message, failure, updatedAt: nowIso() }, stateFile, options);
       return failure;
     }
   }
@@ -1113,7 +1132,7 @@ export async function applyRuntimeValuesAndReleaseSelection(inputs, releaseSelec
         'Unable to render initial tenant Secret for appliance bootstrap.',
         error instanceof Error ? error.message : String(error)
       );
-      writeInstallState({ status: 'runtime-values-blocked', phase: 'registry-release-source', lastAction: failure.message, failure, updatedAt: nowIso() }, stateFile);
+      writeWorkflowInstallState({ status: 'runtime-values-blocked', phase: 'registry-release-source', lastAction: failure.message, failure, updatedAt: nowIso() }, stateFile, options);
       return failure;
     }
   }
@@ -1151,7 +1170,7 @@ export async function applyRuntimeValuesAndReleaseSelection(inputs, releaseSelec
         'Failed to apply Kubernetes runtime values or release selection.',
         (result.stderr || result.stdout || `exit ${result.status}`).trim()
       );
-      writeInstallState({ status: 'runtime-values-blocked', phase: 'registry-release-source', lastAction: failure.message, failure, updatedAt: nowIso() }, stateFile);
+      writeWorkflowInstallState({ status: 'runtime-values-blocked', phase: 'registry-release-source', lastAction: failure.message, failure, updatedAt: nowIso() }, stateFile, options);
       return failure;
     }
   }
@@ -1164,13 +1183,13 @@ export async function applyRuntimeValuesAndReleaseSelection(inputs, releaseSelec
     profile
   };
 
-  writeInstallState({
+  writeWorkflowInstallState({
     status: 'runtime-values-complete',
     phase: 'registry-release-source',
     lastAction: success.message,
     runtimeValues: { profile, releaseVersion },
     updatedAt: nowIso()
-  }, stateFile);
+  }, stateFile, options);
 
   return success;
 }
@@ -1193,7 +1212,7 @@ export function applyFluxSource(inputs, releaseSelection, options = {}) {
       'Release selection did not include a resolved manifest.',
       'resolveChannelMetadata must run (and succeed) before applyFluxSource.'
     );
-    writeInstallState({ status: 'flux-source-blocked', phase: 'flux', lastAction: failure.message, failure, updatedAt: nowIso() }, stateFile);
+    writeWorkflowInstallState({ status: 'flux-source-blocked', phase: 'flux', lastAction: failure.message, failure, updatedAt: nowIso() }, stateFile, options);
     return failure;
   }
 
@@ -1206,12 +1225,12 @@ export function applyFluxSource(inputs, releaseSelection, options = {}) {
   // an OCI artifact pinned to its digest -- no GitRepository, no branch.
   const manifest = `apiVersion: source.toolkit.fluxcd.io/v1\nkind: OCIRepository\nmetadata:\n  name: ${sourceName}\n  namespace: ${sourceNamespace}\nspec:\n  interval: 1m0s\n  url: ${ociUrl}\n  ref:\n    digest: ${configDigest}\n---\napiVersion: kustomize.toolkit.fluxcd.io/v1\nkind: Kustomization\nmetadata:\n  name: ${sourceName}\n  namespace: ${sourceNamespace}\nspec:\n  interval: 5m0s\n  path: ${fluxPath}\n  prune: true\n  sourceRef:\n    kind: OCIRepository\n    name: ${sourceName}\n`;
 
-  writeInstallState({
+  writeWorkflowInstallState({
     status: 'flux-source-running',
     phase: 'flux',
     lastAction: 'Applying Flux OCIRepository/Kustomization source configuration',
     updatedAt: nowIso()
-  }, stateFile);
+  }, stateFile, options);
 
   const result = spawnSync('sh', ['-c', applyCommand], {
     env: process.env,
@@ -1230,13 +1249,13 @@ export function applyFluxSource(inputs, releaseSelection, options = {}) {
       message
     );
 
-    writeInstallState({
+    writeWorkflowInstallState({
       status: 'flux-source-blocked',
       phase: 'flux',
       lastAction: failure.message,
       failure,
       updatedAt: nowIso()
-    }, stateFile);
+    }, stateFile, options);
 
     return failure;
   }
@@ -1255,13 +1274,13 @@ export function applyFluxSource(inputs, releaseSelection, options = {}) {
     }
   };
 
-  writeInstallState({
+  writeWorkflowInstallState({
     status: 'flux-source-complete',
     phase: 'flux',
     lastAction: success.message,
     fluxSource: success.source,
     updatedAt: nowIso()
-  }, stateFile);
+  }, stateFile, options);
 
   return success;
 }
@@ -1270,12 +1289,12 @@ export function applyReleaseSelectionConfiguration(inputs, releaseSelection, opt
   const stateFile = options.stateFile || DEFAULT_STATE_FILE;
   const releaseSelectionFile = options.releaseSelectionFile || DEFAULT_RELEASE_SELECTION_FILE;
 
-  writeInstallState({
+  writeWorkflowInstallState({
     status: 'release-config-running',
     phase: 'registry-release-source',
     lastAction: 'Persisting runtime values and selected release configuration',
     updatedAt: nowIso()
-  }, stateFile);
+  }, stateFile, options);
 
   const payload = {
     updatedAt: nowIso(),
@@ -1300,13 +1319,13 @@ export function applyReleaseSelectionConfiguration(inputs, releaseSelection, opt
       'Unable to persist release selection configuration.',
       error instanceof Error ? error.message : String(error)
     );
-    writeInstallState({
+    writeWorkflowInstallState({
       status: 'release-config-blocked',
       phase: 'registry-release-source',
       lastAction: failure.message,
       failure,
       updatedAt: nowIso()
-    }, stateFile);
+    }, stateFile, options);
     return failure;
   }
 
@@ -1317,7 +1336,7 @@ export function applyReleaseSelectionConfiguration(inputs, releaseSelection, opt
     releaseSelectionFile
   };
 
-  writeInstallState({
+  writeWorkflowInstallState({
     status: 'release-config-complete',
     phase: 'registry-release-source',
     lastAction: success.message,
@@ -1327,7 +1346,7 @@ export function applyReleaseSelectionConfiguration(inputs, releaseSelection, opt
       selectedReleaseVersion: payload.selectedReleaseVersion
     },
     updatedAt: nowIso()
-  }, stateFile);
+  }, stateFile, options);
 
   return success;
 }

--- a/ee/appliance/host-service/tests/manage-engine.test.mjs
+++ b/ee/appliance/host-service/tests/manage-engine.test.mjs
@@ -193,7 +193,12 @@ test('collectManageStatus reports upgradeAvailable on digest mismatch', async ()
     runtime: { appHostname: 'http://10.0.0.5:3000', dnsMode: 'system', dnsServers: '' }
   }));
   const installStateFile = path.join(tmp, 'install-state.json');
-  fs.writeFileSync(installStateFile, JSON.stringify({ status: 'update-running', lastAction: 'updating' }));
+  const startedAt = new Date().toISOString();
+  fs.writeFileSync(installStateFile, JSON.stringify({
+    status: 'update-running',
+    lastAction: 'updating',
+    update: { owner: { pid: 42, startedAt } }
+  }));
 
   const kube = fakeKube({
     json: (args) => {
@@ -212,7 +217,8 @@ test('collectManageStatus reports upgradeAvailable on digest mismatch', async ()
     releaseSelectionFile,
     installStateFile,
     cpUpgradeStatusFile: path.join(tmp, 'cp-upgrade.json'),
-    resolveControlPlaneRef: async () => 'ghcr.io/x/cp@sha256:NEW'
+    resolveControlPlaneRef: async () => 'ghcr.io/x/cp@sha256:NEW',
+    updateOwnerIsPidAlive: () => true
   });
 
   assert.equal(status.app.channel, 'stable');
@@ -239,7 +245,13 @@ test('collectManageStatus maps queued and storage-phase statuses onto the update
   for (const [installStatus, expected] of cases) {
     const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'alga-manage-status-map-'));
     const installStateFile = path.join(tmp, 'install-state.json');
-    fs.writeFileSync(installStateFile, JSON.stringify({ status: installStatus, lastAction: 'x' }));
+    fs.writeFileSync(installStateFile, JSON.stringify({
+      status: installStatus,
+      lastAction: 'x',
+      ...(expected === 'running' ? {
+        update: { owner: { pid: 42, startedAt: new Date().toISOString() } }
+      } : {})
+    }));
     const releaseSelectionFile = path.join(tmp, 'release-selection.json');
     fs.writeFileSync(releaseSelectionFile, JSON.stringify({ selectedChannel: 'stable' }));
 
@@ -248,7 +260,8 @@ test('collectManageStatus maps queued and storage-phase statuses onto the update
       releaseSelectionFile,
       installStateFile,
       cpUpgradeStatusFile: path.join(tmp, 'cp-upgrade.json'),
-      resolveControlPlaneRef: async () => null
+      resolveControlPlaneRef: async () => null,
+      updateOwnerIsPidAlive: () => true
     });
 
     assert.equal(status.app.update.status, expected, `install-state ${installStatus}`);
@@ -366,6 +379,71 @@ test('collectManageStatus keeps a blocked app-update when the alga-core HelmRele
     resolveControlPlaneRef: async () => null
   });
   assert.equal(status.app.update.status, 'blocked');
+});
+
+test('collectManageStatus keeps an interrupted update blocked despite a Ready HelmRelease and exposes failure detail', async () => {
+  const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'alga-manage-interrupted-'));
+  const releaseSelectionFile = path.join(tmp, 'release-selection.json');
+  fs.writeFileSync(releaseSelectionFile, JSON.stringify({ selectedChannel: 'stable' }));
+  const installStateFile = path.join(tmp, 'install-state.json');
+  fs.writeFileSync(installStateFile, JSON.stringify({
+    status: 'update-blocked',
+    lastAction: 'The previous app update was interrupted and reset. You can start it again.',
+    failure: {
+      code: 'update_interrupted',
+      category: 'update-interrupted',
+      suspectedCause: 'interrupted by control-plane restart',
+      suggestedNextStep: 'Start the app update again from the Manage page.',
+      retrySafe: true
+    },
+    update: { requestedChannel: 'stable', scope: 'application-only' }
+  }));
+  const kube = fakeKube({
+    json: (args) => args.includes('helmrelease alga-core')
+      ? { ok: true, value: { status: { conditions: [{ type: 'Ready', status: 'True' }] } } }
+      : { ok: true, value: {} }
+  });
+  const status = await collectManageStatus({
+    kube,
+    releaseSelectionFile,
+    installStateFile,
+    cpUpgradeStatusFile: path.join(tmp, 'cp.json'),
+    resolveControlPlaneRef: async () => null
+  });
+  assert.equal(status.app.update.status, 'blocked');
+  assert.equal(status.app.update.category, 'update-interrupted');
+  assert.equal(status.app.update.suspectedCause, 'interrupted by control-plane restart');
+  assert.equal(status.app.update.suggestedNextStep, 'Start the app update again from the Manage page.');
+  assert.equal(status.app.update.retrySafe, true);
+  assert.equal(status.app.update.requestedChannel, 'stable');
+});
+
+test('collectManageStatus treats a dead in-progress owner as interrupted', async () => {
+  const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'alga-manage-dead-owner-'));
+  const releaseSelectionFile = path.join(tmp, 'release-selection.json');
+  fs.writeFileSync(releaseSelectionFile, JSON.stringify({ selectedChannel: 'stable' }));
+  const installStateFile = path.join(tmp, 'install-state.json');
+  fs.writeFileSync(installStateFile, JSON.stringify({
+    status: 'update-running',
+    lastAction: 'updating',
+    update: {
+      requestedChannel: 'stable',
+      scope: 'application-only',
+      owner: { pid: 42, startedAt: '2026-08-03T19:00:00.000Z' }
+    }
+  }));
+  const status = await collectManageStatus({
+    kube: fakeKube({ json: () => ({ ok: true, value: {} }) }),
+    releaseSelectionFile,
+    installStateFile,
+    cpUpgradeStatusFile: path.join(tmp, 'cp.json'),
+    resolveControlPlaneRef: async () => null,
+    updateOwnerNowMs: Date.parse('2026-08-03T20:00:00.000Z'),
+    updateOwnerIsPidAlive: () => false
+  });
+  assert.equal(status.app.update.status, 'blocked');
+  assert.equal(status.app.update.category, 'update-interrupted');
+  assert.equal(status.app.update.startedAt, '2026-08-03T19:00:00.000Z');
 });
 
 test('collectManageStatus: app.updateAvailable false (not a crash) when the registry is unreachable', async () => {

--- a/ee/appliance/host-service/tests/update-controller.test.mjs
+++ b/ee/appliance/host-service/tests/update-controller.test.mjs
@@ -1,0 +1,142 @@
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import test from 'node:test';
+import { createUpdateCoordinator, reconcileInterruptedUpdate } from '../update-controller.mjs';
+
+const fixedDate = new Date('2026-08-03T20:00:00.000Z');
+const silentLogger = { info() {}, warn() {} };
+
+function fixture(state, overrides = {}) {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'alga-update-controller-'));
+  const stateFile = path.join(dir, 'install-state.json');
+  const historyFile = path.join(dir, 'update-history.json');
+  if (state) fs.writeFileSync(stateFile, JSON.stringify(state));
+  const spawned = [];
+  const coordinator = createUpdateCoordinator({
+    stateFile,
+    historyFile,
+    now: () => fixedDate,
+    pidIsAlive: () => false,
+    maxAgeMs: 6 * 60 * 60 * 1000,
+    logger: silentLogger,
+    spawnUpdate: (channel, startedAt) => {
+      spawned.push({ channel, startedAt });
+      return 9001;
+    },
+    ...overrides
+  });
+  return { coordinator, stateFile, historyFile, spawned };
+}
+
+function inProgress(pid = 42) {
+  return {
+    status: 'update-running',
+    updatedAt: '2026-08-03T19:00:00.000Z',
+    update: {
+      requestedChannel: 'stable',
+      scope: 'application-only',
+      owner: { pid, startedAt: '2026-08-03T19:00:00.000Z' }
+    }
+  };
+}
+
+test('boot reconciliation turns a dead owner into a durable interrupted state', () => {
+  const { stateFile, historyFile } = fixture(inProgress());
+  const result = reconcileInterruptedUpdate({
+    stateFile,
+    historyFile,
+    now: () => fixedDate,
+    pidIsAlive: () => false,
+    logger: silentLogger
+  });
+  assert.equal(result.classification.status, 'dead');
+  const state = JSON.parse(fs.readFileSync(stateFile, 'utf8'));
+  assert.equal(state.status, 'update-blocked');
+  assert.equal(state.failure.category, 'update-interrupted');
+  assert.equal(state.update.owner, undefined);
+  const history = JSON.parse(fs.readFileSync(historyFile, 'utf8'));
+  assert.equal(history.history[0].category, 'update-interrupted');
+});
+
+test('boot reconciliation preserves a fresh live owner', () => {
+  const { coordinator, stateFile } = fixture(inProgress(), { pidIsAlive: () => true });
+  const result = coordinator.reconcile();
+  assert.equal(result.classification.status, 'live');
+  assert.equal(JSON.parse(fs.readFileSync(stateFile, 'utf8')).status, 'update-running');
+});
+
+test('live owner returns structured 409 without spawning or writing', () => {
+  const { coordinator, stateFile, spawned } = fixture(inProgress(), { pidIsAlive: () => true });
+  const before = fs.readFileSync(stateFile, 'utf8');
+  const result = coordinator.start('nightly');
+  assert.equal(result.status, 409);
+  assert.equal(result.body.code, 'update_in_progress');
+  assert.equal(result.body.startedAt, '2026-08-03T19:00:00.000Z');
+  assert.equal(spawned.length, 0);
+  assert.equal(fs.readFileSync(stateFile, 'utf8'), before);
+});
+
+test('dead owner is reconciled before a new generation starts', () => {
+  const { coordinator, stateFile, historyFile, spawned } = fixture(inProgress());
+  const result = coordinator.start('nightly');
+  assert.equal(result.status, 202);
+  assert.equal(spawned.length, 1);
+  const state = JSON.parse(fs.readFileSync(stateFile, 'utf8'));
+  assert.equal(state.status, 'update-queued');
+  assert.equal(state.update.owner.pid, 9001);
+  assert.equal(state.update.requestedChannel, 'nightly');
+  assert.equal(JSON.parse(fs.readFileSync(historyFile, 'utf8')).history[0].category, 'update-interrupted');
+});
+
+test('simultaneous starts produce one child and one live-owner 409', async () => {
+  let livePid = null;
+  const { coordinator, spawned } = fixture(null, {
+    pidIsAlive: (pid) => pid === livePid,
+    spawnUpdate: (channel, startedAt) => {
+      spawned.push({ channel, startedAt });
+      livePid = 77;
+      return livePid;
+    }
+  });
+  const results = await Promise.all([
+    Promise.resolve().then(() => coordinator.start('stable')),
+    Promise.resolve().then(() => coordinator.start('stable'))
+  ]);
+  assert.deepEqual(results.map((result) => result.status).sort(), [202, 409]);
+  assert.equal(spawned.length, 1);
+});
+
+test('spawn failure does not publish an orphaned running state', () => {
+  const { coordinator, stateFile } = fixture(null, {
+    spawnUpdate: () => { throw new Error('spawn failed'); }
+  });
+  assert.throws(() => coordinator.start('stable'), /spawn failed/);
+  assert.equal(fs.existsSync(stateFile), false);
+});
+
+test('a child-published terminal state is not overwritten by the parent queue write', () => {
+  let statePath;
+  const fixtureResult = fixture(null, {
+    spawnUpdate: (channel, startedAt) => {
+      fs.writeFileSync(statePath, JSON.stringify({
+        status: 'update-blocked',
+        failure: { message: 'failed immediately' },
+        update: { requestedChannel: channel, scope: 'application-only', startedAt }
+      }));
+      return 88;
+    }
+  });
+  statePath = fixtureResult.stateFile;
+  const result = fixtureResult.coordinator.start('stable');
+  assert.equal(result.status, 202);
+  assert.equal(JSON.parse(fs.readFileSync(statePath, 'utf8')).status, 'update-blocked');
+});
+
+test('setup state is outside the app-update guard', () => {
+  const { coordinator, stateFile } = fixture({ status: 'setup-queued', phase: 'setup' });
+  const result = coordinator.start('stable');
+  assert.equal(result.status, 202);
+  assert.equal(JSON.parse(fs.readFileSync(stateFile, 'utf8')).status, 'update-queued');
+});

--- a/ee/appliance/host-service/tests/update-engine.test.mjs
+++ b/ee/appliance/host-service/tests/update-engine.test.mjs
@@ -5,6 +5,7 @@ import test from 'node:test';
 import assert from 'node:assert/strict';
 import { spawnSync } from 'node:child_process';
 import { runAppChannelUpdate } from '../update-engine.mjs';
+import { applyReleaseSelectionConfiguration, installStorage } from '../setup-engine.mjs';
 
 const enginePath = path.join(import.meta.dirname, '..', 'update-engine.mjs');
 const serverPath = path.join(import.meta.dirname, '..', 'server.mjs');
@@ -78,6 +79,7 @@ test('runAppChannelUpdate applies channel update and persists history without OS
   const state = JSON.parse(fs.readFileSync(stateFile, 'utf8'));
   assert.equal(state.status, 'update-complete');
   assert.equal(state.update.scope, 'application-only');
+  assert.equal(state.update.owner, undefined);
 
   const releaseSelection = JSON.parse(fs.readFileSync(releaseSelectionFile, 'utf8'));
   assert.equal(releaseSelection.selectedChannel, 'nightly');
@@ -200,7 +202,40 @@ test('server runs app-channel updates in a detached child, never in-process', ()
   assert.doesNotMatch(server, /runAppChannelUpdate/);
   assert.match(server, /function queueUpdateWorkflow/);
   assert.match(server, /update-engine\.mjs/);
-  assert.match(server, /queueUpdateWorkflow\(channel\)/);
+  assert.match(server, /spawnUpdate: queueUpdateWorkflow/);
+});
+
+test('update owner survives storage and release-configuration phases', () => {
+  const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'alga-update-owner-phases-'));
+  const stateFile = path.join(tmp, 'install-state.json');
+  const releaseSelectionFile = path.join(tmp, 'release-selection.json');
+  const update = {
+    requestedChannel: 'stable',
+    scope: 'application-only',
+    owner: { pid: 321, startedAt: '2026-08-03T20:00:00.000Z' }
+  };
+
+  const storage = installStorage({ stateFile, storageInstallCommand: 'true', update });
+  assert.equal(storage.ok, true);
+  let state = JSON.parse(fs.readFileSync(stateFile, 'utf8'));
+  assert.equal(state.status, 'update-running');
+  assert.deepEqual(state.update.owner, update.owner);
+
+  const config = applyReleaseSelectionConfiguration({
+    channel: 'stable',
+    appHostname: 'psa.example.com',
+    dnsMode: 'system',
+    dnsServers: ''
+  }, {
+    channel: 'stable',
+    releaseVersion: '1.3.12',
+    repository: 'nine-minds/alga-appliance-release',
+    manifestDigest: 'sha256:abc'
+  }, { stateFile, releaseSelectionFile, update });
+  assert.equal(config.ok, true);
+  state = JSON.parse(fs.readFileSync(stateFile, 'utf8'));
+  assert.equal(state.status, 'update-running');
+  assert.deepEqual(state.update.owner, update.owner);
 });
 
 test('update-engine CLI reports a blocked terminal state when the update fails cleanly', () => {
@@ -251,6 +286,8 @@ test('update-engine CLI writes a blocked terminal state even when the engine thr
   const state = JSON.parse(fs.readFileSync(stateFile, 'utf8'));
   assert.equal(state.status, 'update-blocked');
   assert.match(state.failure.suspectedCause, /Invalid channel/);
+  assert.equal(state.failure.retrySafe, true);
+  assert.equal(state.update.owner, undefined);
 });
 
 test('app update stops before release reconciliation when storage repair fails', async () => {
@@ -269,6 +306,9 @@ test('app update stops before release reconciliation when storage repair fails',
     const state = JSON.parse(fs.readFileSync(stateFile, 'utf8'));
     assert.equal(state.status, 'update-blocked');
     assert.equal(state.phase, 'storage');
+    assert.equal(state.failure.suspectedCause, 'Local-path storage reconciliation failed.');
+    assert.equal(state.failure.suggestedNextStep, 'storage unavailable');
+    assert.equal(state.update.owner, undefined);
   } finally {
     process.env.PATH = originalPath;
   }

--- a/ee/appliance/host-service/tests/update-ownership.test.mjs
+++ b/ee/appliance/host-service/tests/update-ownership.test.mjs
@@ -1,0 +1,76 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import {
+  classifyUpdateOwner,
+  interruptedUpdateState,
+  isPidAlive,
+  isUpdateInProgressStatus
+} from '../update-ownership.mjs';
+
+const nowMs = Date.parse('2026-08-03T20:00:00.000Z');
+
+function runningState(owner = { pid: 42, startedAt: '2026-08-03T19:00:00.000Z' }) {
+  return {
+    status: 'update-running',
+    phase: 'storage',
+    update: { requestedChannel: 'stable', scope: 'application-only', owner }
+  };
+}
+
+test('recognizes only app-update in-progress statuses', () => {
+  for (const status of ['update-queued', 'update-running', 'release-config-running', 'storage-install-running']) {
+    assert.equal(isUpdateInProgressStatus(status), true, status);
+  }
+  for (const status of ['setup-queued', 'setup-running', 'runtime-values-running', 'update-blocked', 'update-complete']) {
+    assert.equal(isUpdateInProgressStatus(status), false, status);
+  }
+});
+
+test('classifies a fresh live owner', () => {
+  const result = classifyUpdateOwner(runningState(), {
+    nowMs,
+    maxAgeMs: 2 * 60 * 60 * 1000,
+    isPidAlive: () => true
+  });
+  assert.equal(result.status, 'live');
+  assert.equal(result.owner.pid, 42);
+});
+
+test('process liveness treats ESRCH as dead and EPERM as present', () => {
+  assert.equal(isPidAlive(42, () => {
+    const error = new Error('missing');
+    error.code = 'ESRCH';
+    throw error;
+  }), false);
+  assert.equal(isPidAlive(42, () => {
+    const error = new Error('permission denied');
+    error.code = 'EPERM';
+    throw error;
+  }), true);
+});
+
+test('classifies dead, aged, malformed, missing, and future owners', () => {
+  assert.equal(classifyUpdateOwner(runningState(), { nowMs, isPidAlive: () => false }).status, 'dead');
+  assert.equal(classifyUpdateOwner(runningState(), {
+    nowMs,
+    maxAgeMs: 30 * 60 * 1000,
+    isPidAlive: () => true
+  }).status, 'aged');
+  assert.equal(classifyUpdateOwner(runningState({ pid: '42', startedAt: 'invalid' }), { nowMs }).status, 'invalid');
+  assert.equal(classifyUpdateOwner(runningState(null), { nowMs }).status, 'invalid');
+  assert.equal(classifyUpdateOwner(runningState({ pid: 42, startedAt: '2026-08-03T21:00:00.000Z' }), { nowMs }).status, 'invalid');
+});
+
+test('builds a canonical retry-safe interruption while preserving update intent', () => {
+  const original = runningState();
+  const classification = { status: 'dead', reason: 'interrupted by control-plane restart' };
+  const state = interruptedUpdateState(original, classification, '2026-08-03T20:00:00.000Z');
+  assert.equal(state.status, 'update-blocked');
+  assert.equal(state.phase, 'update-interrupted');
+  assert.equal(state.failure.category, 'update-interrupted');
+  assert.equal(state.failure.retrySafe, true);
+  assert.equal(state.update.requestedChannel, 'stable');
+  assert.equal(state.update.scope, 'application-only');
+  assert.equal(state.update.startedAt, '2026-08-03T19:00:00.000Z');
+  assert.equal(state.update.owner, undefined);
+});

--- a/ee/appliance/host-service/update-controller.mjs
+++ b/ee/appliance/host-service/update-controller.mjs
@@ -1,0 +1,130 @@
+import {
+  DEFAULT_UPDATE_OWNER_MAX_AGE_MS,
+  classifyUpdateOwner,
+  interruptedUpdateState,
+  isPidAlive
+} from './update-ownership.mjs';
+import { appendUpdateHistory, readJsonFile, writeSecureJsonFileAtomic } from './update-state.mjs';
+
+export function reconcileInterruptedUpdate(options) {
+  const {
+    stateFile,
+    historyFile,
+    now = () => new Date(),
+    pidIsAlive = isPidAlive,
+    maxAgeMs = DEFAULT_UPDATE_OWNER_MAX_AGE_MS,
+    logger = console
+  } = options;
+  const state = readJsonFile(stateFile);
+  const classification = classifyUpdateOwner(state, {
+    nowMs: now().getTime(),
+    isPidAlive: pidIsAlive,
+    maxAgeMs
+  });
+  if (classification.status === 'none') return { classification, state };
+  if (classification.status === 'live') {
+    logger.info?.(`Adopting live app update owner PID ${classification.owner.pid}.`);
+    return { classification, state };
+  }
+
+  const at = now().toISOString();
+  const interrupted = interruptedUpdateState(state, classification, at);
+  writeSecureJsonFileAtomic(stateFile, interrupted);
+  appendUpdateHistory({
+    at,
+    channel: interrupted.update.requestedChannel || null,
+    ok: false,
+    category: interrupted.failure.category,
+    phase: interrupted.failure.phase,
+    message: interrupted.failure.message
+  }, historyFile, () => at);
+  logger.warn?.(interrupted.failure.suspectedCause);
+  return { classification, state: interrupted };
+}
+
+export function createUpdateCoordinator(options) {
+  const {
+    stateFile,
+    historyFile,
+    spawnUpdate,
+    now = () => new Date(),
+    pidIsAlive = isPidAlive,
+    maxAgeMs = DEFAULT_UPDATE_OWNER_MAX_AGE_MS,
+    logger = console
+  } = options;
+  let deciding = false;
+
+  function reconcile() {
+    return reconcileInterruptedUpdate({
+      stateFile,
+      historyFile,
+      now,
+      pidIsAlive,
+      maxAgeMs,
+      logger
+    });
+  }
+
+  function start(channel) {
+    if (deciding) {
+      return {
+        status: 409,
+        body: { error: 'An app update is already starting.', code: 'update_in_progress', retryable: true }
+      };
+    }
+    deciding = true;
+    try {
+      const current = readJsonFile(stateFile);
+      const classification = classifyUpdateOwner(current, {
+        nowMs: now().getTime(),
+        isPidAlive: pidIsAlive,
+        maxAgeMs
+      });
+      if (classification.status === 'live') {
+        return {
+          status: 409,
+          body: {
+            error: 'An app update is already running.',
+            code: 'update_in_progress',
+            retryable: true,
+            requestedChannel: current.update?.requestedChannel || null,
+            startedAt: classification.owner.startedAt,
+            status: current.status
+          }
+        };
+      }
+      if (classification.status !== 'none') reconcile();
+
+      const startedAt = now().toISOString();
+      const pid = spawnUpdate(channel, startedAt);
+      if (!Number.isInteger(pid) || pid <= 0) {
+        throw new Error('Update workflow did not return a valid child PID.');
+      }
+      const state = {
+        status: 'update-queued',
+        phase: 'registry-release-source',
+        lastAction: `Update to ${channel} queued; background workflow is starting`,
+        updatedAt: startedAt,
+        update: {
+          requestedChannel: channel,
+          scope: 'application-only',
+          startedAt,
+          owner: { pid, startedAt }
+        }
+      };
+      const childState = readJsonFile(stateFile);
+      const childPublishedGeneration = childState?.update?.startedAt === startedAt
+        && childState?.update?.requestedChannel === channel;
+      if (!childPublishedGeneration) writeSecureJsonFileAtomic(stateFile, state);
+      return {
+        status: 202,
+        body: { ok: true, started: true },
+        state: childPublishedGeneration ? childState : state
+      };
+    } finally {
+      deciding = false;
+    }
+  }
+
+  return { reconcile, start };
+}

--- a/ee/appliance/host-service/update-engine.mjs
+++ b/ee/appliance/host-service/update-engine.mjs
@@ -1,9 +1,8 @@
 #!/usr/bin/env node
-import fs from 'node:fs';
-import path from 'node:path';
 import { spawnSync } from 'node:child_process';
 import { applyFluxSource, applyReleaseSelectionConfiguration, applyRuntimeValuesAndReleaseSelection, installStorage, resolveChannelMetadata, validateSetupInputs } from './setup-engine.mjs';
 import { persistMaintenanceMetadata } from './metadata-engine.mjs';
+import { appendUpdateHistory, readJsonFile, writeSecureJsonFileAtomic } from './update-state.mjs';
 
 const DEFAULT_STATE_FILE = process.env.ALGA_APPLIANCE_STATE_FILE || '/var/lib/alga-appliance/install-state.json';
 // release-selection.json lives in /var/lib/alga-appliance — the writable hostPath
@@ -23,37 +22,38 @@ function nowIso() {
   return new Date().toISOString();
 }
 
-function writeSecureJsonFile(targetFile, value) {
-  const dir = path.dirname(targetFile);
-  fs.mkdirSync(dir, { recursive: true, mode: 0o750 });
-  fs.writeFileSync(targetFile, `${JSON.stringify(value, null, 2)}\n`, { mode: 0o600 });
-  fs.chmodSync(dir, 0o750);
-  fs.chmodSync(targetFile, 0o600);
-}
-
-function readJsonFile(file) {
-  if (!fs.existsSync(file)) {
-    return null;
-  }
-  try {
-    return JSON.parse(fs.readFileSync(file, 'utf8'));
-  } catch {
-    return null;
-  }
-}
-
 function writeInstallState(state, stateFile) {
-  writeSecureJsonFile(stateFile, state);
+  writeSecureJsonFileAtomic(stateFile, state);
 }
 
-function appendUpdateHistory(entry, historyFile) {
-  const existing = readJsonFile(historyFile);
-  const history = Array.isArray(existing?.history) ? existing.history : [];
-  const payload = {
-    updatedAt: nowIso(),
-    history: [entry, ...history].slice(0, 50)
+function updateIntent(channel, owner, startedAt = owner?.startedAt) {
+  return {
+    requestedChannel: channel,
+    scope: 'application-only',
+    ...(startedAt ? { startedAt } : {}),
+    ...(owner ? { owner } : {})
   };
-  writeSecureJsonFile(historyFile, payload);
+}
+
+function finishUpdateFailure(failure, context) {
+  const at = nowIso();
+  writeInstallState({
+    status: 'update-blocked',
+    phase: failure.phase,
+    lastAction: failure.message,
+    failure,
+    updatedAt: at,
+    update: updateIntent(context.channel, null, context.owner?.startedAt || context.startedAt)
+  }, context.stateFile);
+  appendUpdateHistory({
+    at,
+    channel: context.channel,
+    ok: false,
+    category: failure.category,
+    phase: failure.phase,
+    message: failure.message
+  }, context.updateHistoryFile);
+  return failure;
 }
 
 // Read the alga-core HelmRelease Ready condition so a non-zero `flux reconcile`
@@ -153,6 +153,10 @@ export async function runAppChannelUpdate(rawInputs, options = {}) {
   const stateFile = options.stateFile || DEFAULT_STATE_FILE;
   const releaseSelectionFile = options.releaseSelectionFile || DEFAULT_RELEASE_SELECTION_FILE;
   const updateHistoryFile = options.updateHistoryFile || DEFAULT_UPDATE_HISTORY_FILE;
+  const owner = options.owner || {
+    pid: process.pid,
+    startedAt: options.startedAt || nowIso()
+  };
 
   const previousSelection = readJsonFile(releaseSelectionFile);
   // An app-channel update rebuilds runtime values from the release's baked template
@@ -173,16 +177,7 @@ export async function runAppChannelUpdate(rawInputs, options = {}) {
       suggestedNextStep: 'Re-run setup so the app hostname is persisted, then retry the update.',
       retrySafe: false
     };
-    writeInstallState({
-      status: 'update-blocked',
-      phase: failure.phase,
-      lastAction: failure.message,
-      failure,
-      updatedAt: nowIso(),
-      update: { requestedChannel: channel, scope: 'application-only' }
-    }, stateFile);
-    appendUpdateHistory({ at: nowIso(), channel, ok: false, phase: failure.phase, message: failure.message }, updateHistoryFile);
-    return failure;
+    return finishUpdateFailure(failure, { stateFile, updateHistoryFile, channel, owner });
   }
   const selection = previousSelection || {};
   const validated = validateSetupInputs({
@@ -198,108 +193,80 @@ export async function runAppChannelUpdate(rawInputs, options = {}) {
     phase: 'registry-release-source',
     lastAction: `Starting app-channel update to ${validated.channel}`,
     updatedAt: nowIso(),
-    update: {
-      requestedChannel: validated.channel,
-      scope: 'application-only'
-    }
+    update: updateIntent(validated.channel, owner)
   }, stateFile);
+
+  const workflowOptions = {
+    ...options,
+    stateFile,
+    update: updateIntent(validated.channel, owner)
+  };
 
   // Channel updates are also the delivery path for appliance control-plane
   // fixes. Reconcile the storage prerequisite first so an appliance affected by
   // the historical duplicate local-path controllers can recover before Helm is
   // asked to converge PostgreSQL, Redis, and the application deployment.
-  const storageResult = installStorage({ ...options, stateFile });
+  const storageResult = installStorage(workflowOptions);
   if (!storageResult.ok) {
-    writeInstallState({
-      status: 'update-blocked',
-      phase: storageResult.phase,
-      lastAction: storageResult.message,
-      failure: storageResult,
-      updatedAt: nowIso(),
-      update: { requestedChannel: validated.channel, scope: 'application-only' }
-    }, stateFile);
-    appendUpdateHistory({
-      at: nowIso(),
+    return finishUpdateFailure(storageResult, {
+      stateFile,
+      updateHistoryFile,
       channel: validated.channel,
-      ok: false,
-      phase: storageResult.phase,
-      message: storageResult.message
-    }, updateHistoryFile);
-    return storageResult;
+      owner
+    });
   }
 
-  const releaseSelection = await resolveChannelMetadata(validated, options);
+  const releaseSelection = await resolveChannelMetadata(validated, workflowOptions);
   if (!releaseSelection.ok) {
-    appendUpdateHistory({
-      at: nowIso(),
+    return finishUpdateFailure(releaseSelection, {
+      stateFile,
+      updateHistoryFile,
       channel: validated.channel,
-      ok: false,
-      phase: releaseSelection.phase,
-      message: releaseSelection.message
-    }, updateHistoryFile);
-    return releaseSelection;
+      owner
+    });
   }
 
-  const runtimeValuesResult = await applyRuntimeValuesAndReleaseSelection(validated, releaseSelection, options);
+  const runtimeValuesResult = await applyRuntimeValuesAndReleaseSelection(validated, releaseSelection, workflowOptions);
   if (!runtimeValuesResult.ok) {
-    appendUpdateHistory({
-      at: nowIso(),
+    return finishUpdateFailure(runtimeValuesResult, {
+      stateFile,
+      updateHistoryFile,
       channel: validated.channel,
-      ok: false,
-      phase: runtimeValuesResult.phase,
-      message: runtimeValuesResult.message
-    }, updateHistoryFile);
-    return runtimeValuesResult;
+      owner
+    });
   }
 
-  const fluxSourceResult = applyFluxSource(validated, releaseSelection, options);
+  const fluxSourceResult = applyFluxSource(validated, releaseSelection, workflowOptions);
   if (!fluxSourceResult.ok) {
-    appendUpdateHistory({
-      at: nowIso(),
+    return finishUpdateFailure(fluxSourceResult, {
+      stateFile,
+      updateHistoryFile,
       channel: validated.channel,
-      ok: false,
-      phase: fluxSourceResult.phase,
-      message: fluxSourceResult.message
-    }, updateHistoryFile);
-    return fluxSourceResult;
+      owner
+    });
   }
 
   const configResult = applyReleaseSelectionConfiguration(validated, releaseSelection, {
-    ...options,
+    ...workflowOptions,
     releaseSelectionFile
   });
   if (!configResult.ok) {
-    appendUpdateHistory({
-      at: nowIso(),
+    return finishUpdateFailure(configResult, {
+      stateFile,
+      updateHistoryFile,
       channel: validated.channel,
-      ok: false,
-      phase: configResult.phase,
-      message: configResult.message
-    }, updateHistoryFile);
-    return configResult;
+      owner
+    });
   }
 
   const reconcileResult = reconcileFluxAndHelm(options);
   if (!reconcileResult.ok) {
-    writeInstallState({
-      status: 'update-blocked',
-      phase: reconcileResult.phase,
-      lastAction: reconcileResult.message,
-      failure: reconcileResult,
-      updatedAt: nowIso(),
-      update: {
-        requestedChannel: validated.channel,
-        scope: 'application-only'
-      }
-    }, stateFile);
-    appendUpdateHistory({
-      at: nowIso(),
+    return finishUpdateFailure(reconcileResult, {
+      stateFile,
+      updateHistoryFile,
       channel: validated.channel,
-      ok: false,
-      phase: reconcileResult.phase,
-      message: reconcileResult.message
-    }, updateHistoryFile);
-    return reconcileResult;
+      owner
+    });
   }
 
   const result = {
@@ -319,9 +286,8 @@ export async function runAppChannelUpdate(rawInputs, options = {}) {
     lastAction: result.message,
     updatedAt: nowIso(),
     update: {
-      requestedChannel: validated.channel,
-      selectedReleaseVersion: releaseSelection.releaseVersion,
-      scope: 'application-only'
+      ...updateIntent(validated.channel, null, owner.startedAt),
+      selectedReleaseVersion: releaseSelection.releaseVersion
     }
   }, stateFile);
 
@@ -360,6 +326,9 @@ function parseCliArgs(argv) {
     } else if (arg === '--update-history-file') {
       parsed.updateHistoryFile = argv[i + 1];
       i += 1;
+    } else if (arg === '--started-at') {
+      parsed.startedAt = argv[i + 1];
+      i += 1;
     } else if (arg === '--kubeconfig') {
       parsed.kubeconfigPath = argv[i + 1];
       i += 1;
@@ -375,6 +344,34 @@ if (import.meta.url === `file://${process.argv[1]}`) {
   const args = parseCliArgs(process.argv.slice(2));
   if (args.command === 'run') {
     const channel = args.channel || 'stable';
+    args.owner = {
+      pid: process.pid,
+      startedAt: args.startedAt || nowIso()
+    };
+    const writeInterruptedState = (signal) => {
+      const failure = {
+        ok: false,
+        code: 'update_interrupted',
+        category: 'update-interrupted',
+        phase: 'update',
+        step: 'handle-update-signal',
+        message: `App-channel update was interrupted by ${signal}.`,
+        suspectedCause: `The update child received ${signal}.`,
+        suggestedNextStep: 'Retry the update from the Manage page; inspect control-plane logs if it recurs.',
+        retrySafe: true
+      };
+      finishUpdateFailure(failure, {
+        stateFile: args.stateFile || DEFAULT_STATE_FILE,
+        updateHistoryFile: args.updateHistoryFile || DEFAULT_UPDATE_HISTORY_FILE,
+        channel,
+        owner: args.owner
+      });
+      process.exit(1);
+    };
+    const onSigterm = () => writeInterruptedState('SIGTERM');
+    const onSigint = () => writeInterruptedState('SIGINT');
+    process.once('SIGTERM', onSigterm);
+    process.once('SIGINT', onSigint);
     try {
       const result = await runAppChannelUpdate({ channel }, args);
       process.stdout.write(`${JSON.stringify(result)}\n`);
@@ -392,20 +389,17 @@ if (import.meta.url === `file://${process.argv[1]}`) {
         suggestedNextStep: 'Retry the update from the Manage page; inspect control-plane logs if it recurs.',
         retrySafe: true
       };
-      writeInstallState({
-        status: 'update-blocked',
-        phase: failure.phase,
-        lastAction: failure.message,
-        failure,
-        updatedAt: nowIso(),
-        update: { requestedChannel: channel, scope: 'application-only' }
-      }, args.stateFile || DEFAULT_STATE_FILE);
-      appendUpdateHistory(
-        { at: nowIso(), channel, ok: false, phase: failure.phase, message: failure.message },
-        args.updateHistoryFile || DEFAULT_UPDATE_HISTORY_FILE
-      );
+      finishUpdateFailure(failure, {
+        stateFile: args.stateFile || DEFAULT_STATE_FILE,
+        updateHistoryFile: args.updateHistoryFile || DEFAULT_UPDATE_HISTORY_FILE,
+        channel,
+        owner: args.owner
+      });
       process.stderr.write(`${JSON.stringify(failure)}\n`);
       process.exitCode = 1;
+    } finally {
+      process.off('SIGTERM', onSigterm);
+      process.off('SIGINT', onSigint);
     }
   }
 }

--- a/ee/appliance/host-service/update-ownership.mjs
+++ b/ee/appliance/host-service/update-ownership.mjs
@@ -1,0 +1,111 @@
+export const DEFAULT_UPDATE_OWNER_MAX_AGE_MS = 6 * 60 * 60 * 1000;
+
+const UPDATE_IN_PROGRESS_STATUSES = new Set([
+  'update-queued',
+  'update-running',
+  'release-config-running',
+  'storage-install-running'
+]);
+
+export function isUpdateInProgressStatus(status) {
+  return UPDATE_IN_PROGRESS_STATUSES.has(status);
+}
+
+export function isPidAlive(pid, kill = process.kill) {
+  try {
+    kill(pid, 0);
+    return true;
+  } catch (error) {
+    if (error?.code === 'EPERM') return true;
+    if (error?.code === 'ESRCH') return false;
+    throw error;
+  }
+}
+
+export function classifyUpdateOwner(state, options = {}) {
+  if (!isUpdateInProgressStatus(state?.status)) {
+    return { status: 'none', reason: 'Install state is not an app update in progress.' };
+  }
+
+  const owner = state?.update?.owner;
+  const pid = owner?.pid;
+  if (!Number.isInteger(pid) || pid <= 0) {
+    return {
+      status: 'invalid',
+      reason: 'The previous update was interrupted by control-plane restart and has no valid owner PID.'
+    };
+  }
+
+  const startedAtMs = Date.parse(owner?.startedAt || '');
+  const nowMs = options.nowMs ?? Date.now();
+  if (!Number.isFinite(startedAtMs) || startedAtMs > nowMs) {
+    return {
+      status: 'invalid',
+      reason: 'The previous update was interrupted by control-plane restart and has an invalid owner start time.'
+    };
+  }
+
+  const checkPid = options.isPidAlive || isPidAlive;
+  let alive;
+  try {
+    alive = checkPid(pid);
+  } catch (error) {
+    return {
+      status: 'invalid',
+      reason: `The previous update owner could not be verified: ${error instanceof Error ? error.message : String(error)}.`
+    };
+  }
+  if (!alive) {
+    return {
+      status: 'dead',
+      reason: `The previous update was interrupted by control-plane restart; owner PID ${pid} is no longer alive.`,
+      owner
+    };
+  }
+
+  const maxAgeMs = options.maxAgeMs ?? DEFAULT_UPDATE_OWNER_MAX_AGE_MS;
+  if (!Number.isFinite(maxAgeMs) || maxAgeMs <= 0) {
+    return { status: 'invalid', reason: 'The configured update owner maximum age is invalid.', owner };
+  }
+  if (nowMs - startedAtMs > maxAgeMs) {
+    return {
+      status: 'aged',
+      reason: `The previous update owner PID ${pid} exceeded the ${maxAgeMs} ms safety limit.`,
+      owner
+    };
+  }
+
+  return { status: 'live', reason: `Update owner PID ${pid} is alive.`, owner };
+}
+
+export function interruptedUpdateState(state, classification, nowIso = new Date().toISOString()) {
+  const message = 'The previous app update was interrupted and reset. You can start it again.';
+  const failure = {
+    ok: false,
+    code: 'update_interrupted',
+    category: 'update-interrupted',
+    phase: 'update',
+    step: 'recover-update-owner',
+    message,
+    suspectedCause: classification.reason,
+    suggestedNextStep: 'Start the app update again from the Manage page.',
+    retrySafe: true
+  };
+  const previousUpdate = state?.update || {};
+  const update = {
+    ...(previousUpdate.requestedChannel ? { requestedChannel: previousUpdate.requestedChannel } : {}),
+    ...(previousUpdate.owner?.startedAt || previousUpdate.startedAt
+      ? { startedAt: previousUpdate.owner?.startedAt || previousUpdate.startedAt }
+      : {}),
+    scope: previousUpdate.scope || 'application-only'
+  };
+  return {
+    ...state,
+    status: 'update-blocked',
+    phase: 'update-interrupted',
+    lastAction: message,
+    failure,
+    updatedAt: nowIso,
+    update
+  };
+}

--- a/ee/appliance/host-service/update-state.mjs
+++ b/ee/appliance/host-service/update-state.mjs
@@ -1,0 +1,44 @@
+import { randomUUID } from 'node:crypto';
+import fs from 'node:fs';
+import path from 'node:path';
+
+export function readJsonFile(file) {
+  if (!fs.existsSync(file)) return null;
+  try {
+    return JSON.parse(fs.readFileSync(file, 'utf8'));
+  } catch {
+    return null;
+  }
+}
+
+export function writeSecureJsonFileAtomic(targetFile, value) {
+  const dir = path.dirname(targetFile);
+  const temporaryFile = path.join(
+    dir,
+    `.${path.basename(targetFile)}.${process.pid}.${randomUUID()}.tmp`
+  );
+  fs.mkdirSync(dir, { recursive: true, mode: 0o750 });
+  try {
+    fs.writeFileSync(temporaryFile, `${JSON.stringify(value, null, 2)}\n`, {
+      flag: 'wx',
+      mode: 0o600
+    });
+    fs.renameSync(temporaryFile, targetFile);
+    fs.chmodSync(dir, 0o750);
+    fs.chmodSync(targetFile, 0o600);
+  } catch (error) {
+    try {
+      fs.unlinkSync(temporaryFile);
+    } catch { /* best effort cleanup */ }
+    throw error;
+  }
+}
+
+export function appendUpdateHistory(entry, historyFile, now = () => new Date().toISOString()) {
+  const existing = readJsonFile(historyFile);
+  const history = Array.isArray(existing?.history) ? existing.history : [];
+  writeSecureJsonFileAtomic(historyFile, {
+    updatedAt: now(),
+    history: [entry, ...history].slice(0, 50)
+  });
+}

--- a/ee/appliance/status-ui/app/manage/ManageView.tsx
+++ b/ee/appliance/status-ui/app/manage/ManageView.tsx
@@ -16,7 +16,17 @@ type ManageStatus = {
     availableVersion?: string | null;
     pinnedReleaseDigest?: string | null;
     resolvedReleaseDigest?: string | null;
-    update: { status: "idle" | "running" | "complete" | "blocked"; message: string | null };
+    update: {
+      status: "idle" | "running" | "complete" | "blocked";
+      message: string | null;
+      code?: string | null;
+      category?: string | null;
+      suspectedCause?: string | null;
+      suggestedNextStep?: string | null;
+      retrySafe?: boolean | null;
+      startedAt?: string | null;
+      requestedChannel?: string | null;
+    };
   };
   controlPlane: {
     channel: string;
@@ -93,10 +103,10 @@ function UpdatesTab({
       setResult(
         updateStatus === "complete"
           ? "Update complete."
-          : `Update blocked: ${status.app.update.message || "unknown reason"}`,
+          : `Update blocked: ${status.app.update.suspectedCause || status.app.update.message || "No failure detail was reported."}`,
       );
     }
-  }, [busy, status.app.update.status, status.app.update.message]);
+  }, [busy, status.app.update.status, status.app.update.message, status.app.update.suspectedCause]);
 
   // Clean up on unmount.
   useEffect(() => () => stopPoll(), []);
@@ -117,6 +127,14 @@ function UpdatesTab({
       });
       if (response.status === 401) { window.location.reload(); return; }
       const data = await response.json().catch(() => ({}));
+      if (response.status === 409 && data.code === "update_in_progress") {
+        const since = data.startedAt ? ` since ${new Date(data.startedAt).toLocaleString()}` : "";
+        setResult(`An app update is already running${since}.`);
+        stopPoll();
+        try { await onRefresh(); } catch { /* keep polling through a transient refresh failure */ }
+        pollRef.current = setInterval(onRefresh, 3000);
+        return;
+      }
       if (!response.ok) throw new Error(data.error || "Failed to start update.");
       // Poll until the update status reaches a terminal state.
       pollRef.current = setInterval(onRefresh, 3000);
@@ -170,6 +188,12 @@ function UpdatesTab({
               {app.update.message ? (
                 <span className={styles.manageStatusMsg}>{app.update.message}</span>
               ) : null}
+              {app.update.suspectedCause && app.update.suspectedCause !== app.update.message ? (
+                <span className={styles.manageStatusMsg}>Cause: {app.update.suspectedCause}</span>
+              ) : null}
+              {app.update.suggestedNextStep ? (
+                <span className={styles.manageStatusMsg}>Next step: {app.update.suggestedNextStep}</span>
+              ) : null}
             </dd>
           </div>
         ) : null}
@@ -177,6 +201,11 @@ function UpdatesTab({
 
       {error ? <div className={styles.alert}>{error}</div> : null}
       {result ? <p className={styles.manageResult}>{result}</p> : null}
+      {app.update.category === "update-interrupted" ? (
+        <p className={styles.manageResult}>
+          The interrupted attempt was reset and is safe to retry.
+        </p>
+      ) : null}
 
       {!app.updateAvailable && !updateRunning && !updateBlocked ? (
         <p className={styles.muted}>No update is available on the {app.channel} channel.</p>
@@ -188,6 +217,7 @@ function UpdatesTab({
       {app.updateAvailable || updateRunning || updateBlocked ? (
         <div className={styles.toolbar}>
           <button
+            id="manage-run-app-update"
             type="button"
             className={styles.actionButton}
             disabled={busy || updateRunning}
@@ -205,7 +235,7 @@ function UpdatesTab({
               : "Run update"}
           </button>
           {confirm && !busy && !updateRunning ? (
-            <button type="button" onClick={() => setConfirm(false)}>
+            <button id="manage-cancel-app-update" type="button" onClick={() => setConfirm(false)}>
               Cancel
             </button>
           ) : null}
@@ -214,7 +244,8 @@ function UpdatesTab({
 
       {updateRunning ? (
         <p className={styles.helpText}>
-          Update is running. This page will reflect the result when it finishes.
+          Update is running{app.update.startedAt ? ` since ${new Date(app.update.startedAt).toLocaleString()}` : ""}.
+          {" "}This page will reflect the result when it finishes.
         </p>
       ) : null}
     </div>

--- a/ee/docs/appliance/architecture.md
+++ b/ee/docs/appliance/architecture.md
@@ -108,6 +108,8 @@ Plain Node ESM (`.mjs`), no build step. The pieces:
 | `server.mjs` | HTTP server on :8080. Routes: `/healthz`, `/setup` (UI), `/api/setup/config`, `/api/setup` (POST), `/api/status`. Serves the static status UI, validates input, and dispatches the setup workflow. |
 | `setup-engine.mjs` | The setup workflow (see §3). Resolves the release from the registry, renders runtime values, writes the initial-tenant Secret + release-selection ConfigMap, and applies the Flux source. |
 | `update-engine.mjs` | Channel **upgrades**: re-resolve the channel, update release selection, `flux reconcile`. |
+| `update-controller.mjs` / `update-ownership.mjs` | App-update admission and interruption recovery. A queued/running update is live only while its recorded PID and start time remain valid. |
+| `update-state.mjs` | Atomic install-state writes and bounded update history. |
 | `status-engine.mjs` | Cluster health: HelmReleases, pods, readiness tiers (platform / core / bootstrap / login). Backs `/api/status`. |
 | `console.mjs` | Console (tty1) setup banner + fallback flow; writes `/etc/issue` and `/etc/motd`. |
 | `host-agent.mjs` | The diagnostics socket daemon (host side of `alga-host-agent.service`). |
@@ -124,6 +126,15 @@ A small Next.js app. `app/setup/page.tsx` is the wizard (channel, app hostname,
 DNS, tenant + admin); `app/page.tsx` is the status view. It's built into static
 `dist/` and served by the control-plane pod (the Dockerfile copies it to
 `ALGA_APPLIANCE_STATUS_UI_DIR`).
+
+App updates run in a detached child so synchronous storage and Flux commands do
+not starve the control plane's health endpoint. Each attempt records an owner
+PID and start time in the durable host-path `install-state.json`. On control-plane
+startup, and again before accepting a new update, a dead, missing, malformed, or
+over-age owner is converted to a retry-safe `update-interrupted` result. Recovery
+never auto-resumes registry or rollout work: the Manage page explains the
+interruption and leaves the retry decision with the operator. A duplicate start
+is rejected only when the recorded owner is verified live.
 
 ### Flux / Helm layer (`ee/appliance/flux/`)
 GitOps definitions, published to the registry as the **config bundle**:


### PR DESCRIPTION
## Summary

- Recover stale appliance app-update state after a control-plane restart instead of permanently treating it as an update already in progress.
- Record app-update ownership as a child PID plus start time, reconcile dead, invalid, or older-than-six-hours owners into a structured retry-safe update-blocked result, and reserve HTTP 409 for a verified live owner.
- Surface the interruption cause and next step in Manage, keep blocked updates retryable, and prevent application-only failures from entering setup auto-retry.
- Use atomic install-state writes with bounded update history, preserve ownership through update phases, clear it on terminal outcomes, and document the recovery model.

## Root cause

The durable install-state file could retain an in-progress update phase after the detached update child or its control-plane container disappeared. Admission trusted that persisted phase without proving that the owning process was still alive, so every later request could be rejected indefinitely.

## Validation

PASS — tested on the real libvirt appliance VM using a branch-built control-plane image and real Manage UI/API/Kubernetes rollout.

Exercised:

- Legacy update-running state plus real control-plane restart reconciled to structured, retry-safe update-blocked state; UI showed cause, next step, and enabled Retry.
- Live PID ownership rejected a UI retry with HTTP 409, displayed “already running,” and disabled the update action.
- Killing a real owned child was detected without restarting the container; UI returned to blocked/retryable.
- A live owner older than six hours was classified blocked-stale.
- Status/Manage navigation, control-plane health, and installed app reachability remained healthy.

No simulator or mock was used. Test state and controlled sleep processes were injected into the real appliance hostPath. I did not run a complete 1.3.9→1.3.11 workload update or setup recovery path because that would materially upgrade/reconfigure the shared VM.

Additional verification passed:

- 140 host-service tests in the appliance container environment.
- Status UI Next.js build/typecheck.
- Full appliance control-plane Docker image build.
- `git diff --check` against `main`.

Evidence: `/tmp/alga-smoke-evidence/appliance-update-wedge-recovery-20260803T224332Z`

## Known concern

After a 409 subsequently becomes dead-owner blocked, the green “already running” result can remain beside the new blocked state until the view is remounted.

## Fidelity compromise

Card-scoped browser tabs were created as requested, but the IDE placed them on another connected host and rejected control commands. UI driving therefore used an existing disposable local alga-dev browser pane; its historical console log was not isolated.

## Cleanup

Restored the original control-plane digest, install state, credential, and session secret byte-for-byte; removed smoke history, imported image, SSH key, and temporary files. Only the pre-existing `package-lock.json` worktree modification remains.
