### PR TITLE
fix: improve hosted cancellation flow

### DIFF
--- a/ee/server/src/__tests__/unit/AccountManagement.cancellation.test.tsx
+++ b/ee/server/src/__tests__/unit/AccountManagement.cancellation.test.tsx
@@ -8,7 +8,6 @@ const mocks = vi.hoisted(() => ({
   cancelSubscriptionAction: vi.fn(),
   checkAccountManagementPermission: vi.fn(),
   sendCancellationFeedbackAction: vi.fn(),
-  signOut: vi.fn(),
   toastError: vi.fn(),
   toastSuccess: vi.fn(),
 }));
@@ -59,7 +58,6 @@ vi.mock('next/navigation', () => ({
 }));
 
 vi.mock('next-auth/react', () => ({
-  signOut: mocks.signOut,
   useSession: () => ({ update: vi.fn() }),
 }));
 
@@ -148,12 +146,13 @@ vi.mock('@alga-psa/ui/components/Dialog', () => ({
     footer?: React.ReactNode;
     isOpen: boolean;
   }) => isOpen ? <div>{children}{footer}</div> : null,
+  DialogDescription: ({ children }: { children: React.ReactNode }) => <p>{children}</p>,
 }));
 vi.mock('@alga-psa/ui/components/ConfirmationDialog', () => ({
   ConfirmationDialog: () => null,
 }));
 vi.mock('@alga-psa/ui/components/TextArea', () => ({
-  TextArea: ({ label, ...props }: React.TextareaHTMLAttributes<HTMLTextAreaElement> & { label?: string }) => (
+  TextArea: ({ label, wrapperClassName: _wrapperClassName, ...props }: React.TextareaHTMLAttributes<HTMLTextAreaElement> & { label?: string; wrapperClassName?: string }) => (
     <label>{label}<textarea {...props} /></label>
   ),
 }));
@@ -162,11 +161,13 @@ vi.mock('@alga-psa/ui/components/CustomSelect', () => ({
     label,
     options,
     onValueChange,
+    allowClear: _allowClear,
     ...props
   }: {
     label: string;
     options: Array<{ value: string; label: string }>;
     onValueChange: (value: string) => void;
+    allowClear?: boolean;
   } & React.SelectHTMLAttributes<HTMLSelectElement>) => (
     <label>
       {label}
@@ -185,7 +186,10 @@ describe('AccountManagement cancellation failures', () => {
     vi.clearAllMocks();
     mocks.checkAccountManagementPermission.mockResolvedValue(true);
     mocks.sendCancellationFeedbackAction.mockResolvedValue({ success: true });
-    mocks.cancelSubscriptionAction.mockResolvedValue({ success: true });
+    mocks.cancelSubscriptionAction.mockResolvedValue({
+      success: true,
+      data: { cancel_at: '2026-09-01T00:00:00.000Z' },
+    });
   });
 
   async function submitCancellation() {
@@ -198,25 +202,23 @@ describe('AccountManagement cancellation failures', () => {
     fireEvent.change(feedback, {
       target: { value: 'The service no longer fits our current workflow.' },
     });
-    fireEvent.click(screen.getByRole('button', { name: 'cancellationModal.submitFeedback' }));
+    fireEvent.click(document.getElementById('confirm-cancellation-btn')!);
 
     return { category, feedback };
   }
 
-  it('keeps the modal open when feedback submission is rejected', async () => {
+  it('does not let feedback delivery failure block cancellation', async () => {
     mocks.sendCancellationFeedbackAction.mockResolvedValue({
       success: false,
       error: 'Feedback could not be sent',
     });
 
-    const { category, feedback } = await submitCancellation();
+    await submitCancellation();
 
-    await waitFor(() => expect(mocks.toastError).toHaveBeenCalledWith('Feedback could not be sent'));
-    expect(mocks.cancelSubscriptionAction).not.toHaveBeenCalled();
-    expect(mocks.toastSuccess).not.toHaveBeenCalled();
-    expect(mocks.signOut).not.toHaveBeenCalled();
-    expect(category).toHaveValue('Other');
-    expect(feedback).toHaveValue('The service no longer fits our current workflow.');
+    await waitFor(() => expect(mocks.toastSuccess).toHaveBeenCalledWith('messages.cancellationScheduled'));
+    expect(mocks.cancelSubscriptionAction).toHaveBeenCalledOnce();
+    expect(mocks.sendCancellationFeedbackAction).toHaveBeenCalledOnce();
+    expect(mocks.toastError).not.toHaveBeenCalled();
   });
 
   it('keeps the modal open when cancellation is rejected', async () => {
@@ -230,10 +232,19 @@ describe('AccountManagement cancellation failures', () => {
     await waitFor(() => {
       expect(mocks.toastError).toHaveBeenCalledWith('Cancellation could not be scheduled');
     });
-    expect(mocks.sendCancellationFeedbackAction).toHaveBeenCalledOnce();
+    expect(mocks.sendCancellationFeedbackAction).not.toHaveBeenCalled();
     expect(mocks.toastSuccess).not.toHaveBeenCalled();
-    expect(mocks.signOut).not.toHaveBeenCalled();
     expect(category).toHaveValue('Other');
     expect(feedback).toHaveValue('The service no longer fits our current workflow.');
+  });
+
+  it('does not send an empty feedback email', async () => {
+    render(<AccountManagement />);
+
+    fireEvent.click(await screen.findByRole('button', { name: 'dangerZone.cancelSubscription' }));
+    fireEvent.click(document.getElementById('confirm-cancellation-btn')!);
+
+    await waitFor(() => expect(mocks.cancelSubscriptionAction).toHaveBeenCalledOnce());
+    expect(mocks.sendCancellationFeedbackAction).not.toHaveBeenCalled();
   });
 });

--- a/ee/server/src/__tests__/unit/CancellationFeedbackModal.test.tsx
+++ b/ee/server/src/__tests__/unit/CancellationFeedbackModal.test.tsx
@@ -6,8 +6,26 @@ import { toast } from 'react-hot-toast';
 import CancellationFeedbackModal from '../../components/settings/account/CancellationFeedbackModal';
 
 vi.mock('@alga-psa/ui/components/Dialog', () => ({
-  Dialog: ({ children, footer, isOpen }: { children: React.ReactNode; footer: React.ReactNode; isOpen: boolean }) =>
-    isOpen ? <div>{children}{footer}</div> : null,
+  Dialog: ({
+    children,
+    footer,
+    hideCloseButton,
+    isOpen,
+    onClose,
+  }: {
+    children: React.ReactNode;
+    footer: React.ReactNode;
+    hideCloseButton?: boolean;
+    isOpen: boolean;
+    onClose: () => void;
+  }) => isOpen ? (
+    <div>
+      {children}
+      {footer}
+      {!hideCloseButton && <button aria-label="Close" onClick={onClose}>Close</button>}
+    </div>
+  ) : null,
+  DialogDescription: ({ children }: { children: React.ReactNode }) => <p>{children}</p>,
 }));
 
 vi.mock('@alga-psa/ui/components/Button', () => ({
@@ -21,7 +39,7 @@ vi.mock('@alga-psa/ui/components/Alert', () => ({
 }));
 
 vi.mock('@alga-psa/ui/components/TextArea', () => ({
-  TextArea: ({ label, ...props }: React.TextareaHTMLAttributes<HTMLTextAreaElement> & { label?: string }) => (
+  TextArea: ({ label, wrapperClassName: _wrapperClassName, ...props }: React.TextareaHTMLAttributes<HTMLTextAreaElement> & { label?: string; wrapperClassName?: string }) => (
     <label>{label}<textarea {...props} /></label>
   ),
 }));
@@ -31,11 +49,13 @@ vi.mock('@alga-psa/ui/components/CustomSelect', () => ({
     label,
     options,
     onValueChange,
+    allowClear: _allowClear,
     ...props
   }: {
     label: string;
     options: Array<{ value: string; label: string }>;
     onValueChange: (value: string) => void;
+    allowClear?: boolean;
   } & React.SelectHTMLAttributes<HTMLSelectElement>) => (
     <label>
       {label}
@@ -49,9 +69,9 @@ vi.mock('@alga-psa/ui/components/CustomSelect', () => ({
 
 vi.mock('@alga-psa/ui/lib/i18n/client', () => ({
   useTranslation: () => ({
-    t: (key: string) => {
-      if (key === 'cancellationModal.otherReasonHelp') {
-        return 'Please share a little more about what led to your decision.';
+    t: (key: string, values?: Record<string, string>) => {
+      if (key === 'cancellationModal.beforeYouCancelBody') {
+        return `Access ends ${values?.date}`;
       }
       return key;
     },
@@ -70,7 +90,8 @@ describe('CancellationFeedbackModal', () => {
 
   function renderModal(overrides: {
     onClose?: () => void;
-    onLogout?: () => Promise<void>;
+    subscriptionEndDate?: string;
+    hasScheduledLicenseChange?: boolean;
   } = {}) {
     const onClose = overrides.onClose ?? vi.fn();
 
@@ -79,14 +100,15 @@ describe('CancellationFeedbackModal', () => {
         isOpen
         onClose={onClose}
         onConfirm={onConfirm}
-        onLogout={overrides.onLogout}
+        subscriptionEndDate={overrides.subscriptionEndDate}
+        hasScheduledLicenseChange={overrides.hasScheduledLicenseChange}
       />
     );
 
     return {
       category: screen.getByRole('combobox'),
       feedback: screen.getByRole('textbox'),
-      submit: screen.getByRole('button', { name: 'cancellationModal.submitFeedback' }),
+      submit: screen.getByRole('button', { name: 'dangerZone.cancelSubscription' }),
       onClose,
     };
   }
@@ -120,18 +142,19 @@ describe('CancellationFeedbackModal', () => {
     expect(onConfirm).toHaveBeenCalledWith(reasonText, 'Pricing too high');
   });
 
-  it('shows a gentle request for detail when Other is selected', () => {
-    const { category } = renderModal();
+  it('shows the subscription end date and scheduled-change consequence', () => {
+    renderModal({
+      subscriptionEndDate: '2026-09-01T00:00:00.000Z',
+      hasScheduledLicenseChange: true,
+    });
 
-    fireEvent.change(category, { target: { value: 'Other' } });
-
-    expect(screen.getByText('Please share a little more about what led to your decision.')).toBeInTheDocument();
+    expect(screen.getByText(/Access ends .*2026/)).toBeInTheDocument();
+    expect(screen.getByText('cancellationModal.replacesScheduledChange')).toBeInTheDocument();
   });
 
-  it('keeps the modal data open and does not log out when cancellation submission rejects', async () => {
-    const onLogout = vi.fn(async () => undefined);
+  it('keeps the modal data open when cancellation submission rejects', async () => {
     onConfirm.mockRejectedValue(new Error('Cancellation request failed'));
-    const { category, feedback, submit, onClose } = renderModal({ onLogout });
+    const { category, feedback, submit, onClose } = renderModal();
 
     fireEvent.change(category, { target: { value: 'Other' } });
     fireEvent.change(feedback, {
@@ -145,8 +168,25 @@ describe('CancellationFeedbackModal', () => {
     expect(toast.error).toHaveBeenCalledWith('Cancellation request failed');
     expect(toast.success).not.toHaveBeenCalled();
     expect(onClose).not.toHaveBeenCalled();
-    expect(onLogout).not.toHaveBeenCalled();
     expect(category).toHaveValue('Other');
     expect(feedback).toHaveValue('The service no longer fits our current workflow.');
+  });
+
+  it('prevents dismissal while cancellation is in progress', async () => {
+    let resolveCancellation: (() => void) | undefined;
+    onConfirm.mockReturnValue(new Promise<void>((resolve) => {
+      resolveCancellation = resolve;
+    }));
+    const { submit, onClose } = renderModal();
+
+    fireEvent.click(submit);
+
+    expect(screen.queryByRole('button', { name: 'Close' })).not.toBeInTheDocument();
+    expect(submit).toBeDisabled();
+    expect(onClose).not.toHaveBeenCalled();
+
+    await act(async () => {
+      resolveCancellation?.();
+    });
   });
 });

--- a/ee/server/src/__tests__/unit/CancellationFeedbackModal.test.tsx
+++ b/ee/server/src/__tests__/unit/CancellationFeedbackModal.test.tsx
@@ -49,12 +49,9 @@ vi.mock('@alga-psa/ui/components/CustomSelect', () => ({
 
 vi.mock('@alga-psa/ui/lib/i18n/client', () => ({
   useTranslation: () => ({
-    t: (key: string, values?: Record<string, number>) => {
+    t: (key: string) => {
       if (key === 'cancellationModal.otherReasonHelp') {
         return 'Please share a little more about what led to your decision.';
-      }
-      if (key === 'cancellationModal.minimumCharacters') {
-        return `At least ${values?.min} characters required`;
       }
       return key;
     },
@@ -94,26 +91,33 @@ describe('CancellationFeedbackModal', () => {
     };
   }
 
-  it('keeps submit disabled without a category and for blank, punctuation, or short feedback', () => {
+  it('allows cancellation without providing feedback', async () => {
     const { category, feedback, submit } = renderModal();
-
-    fireEvent.change(feedback, { target: { value: 'This feedback has enough detail.' } });
-    expect(submit).toBeDisabled();
-
-    fireEvent.change(category, { target: { value: 'Other' } });
-    for (const reasonText of ['', '.', 'Too little detail']) {
-      fireEvent.change(feedback, { target: { value: reasonText } });
-      expect(submit).toBeDisabled();
-    }
-  });
-
-  it('enables submit for a known category and 20 trimmed characters', () => {
-    const { category, feedback, submit } = renderModal();
-
-    fireEvent.change(category, { target: { value: 'Pricing too high' } });
-    fireEvent.change(feedback, { target: { value: '  12345678901234567890  ' } });
 
     expect(submit).toBeEnabled();
+    expect(category).not.toBeRequired();
+    expect(feedback).not.toBeRequired();
+    expect(feedback).not.toHaveAttribute('maxlength');
+
+    await act(async () => {
+      fireEvent.click(submit);
+    });
+
+    expect(onConfirm).toHaveBeenCalledWith('', undefined);
+  });
+
+  it('submits trimmed feedback without imposing a maximum length', async () => {
+    const { category, feedback, submit } = renderModal();
+    const reasonText = 'x'.repeat(5_000);
+
+    fireEvent.change(category, { target: { value: 'Pricing too high' } });
+    fireEvent.change(feedback, { target: { value: `  ${reasonText}  ` } });
+
+    await act(async () => {
+      fireEvent.click(submit);
+    });
+
+    expect(onConfirm).toHaveBeenCalledWith(reasonText, 'Pricing too high');
   });
 
   it('shows a gentle request for detail when Other is selected', () => {

--- a/ee/server/src/__tests__/unit/cancellationFeedbackValidation.test.ts
+++ b/ee/server/src/__tests__/unit/cancellationFeedbackValidation.test.ts
@@ -1,40 +1,35 @@
 import { describe, expect, it } from 'vitest';
 import {
-  CANCELLATION_FEEDBACK_MAX_LENGTH,
-  CANCELLATION_FEEDBACK_MIN_LENGTH,
   cancellationFeedbackSchema,
 } from '../../lib/cancellationFeedbackValidation';
 
 describe('cancellationFeedbackSchema', () => {
-  it.each(['', 'Not a category'])('rejects an unknown category: %j', (reasonCategory) => {
+  it('rejects an unknown category', () => {
     const result = cancellationFeedbackSchema.safeParse({
-      reasonCategory,
-      reasonText: 'This feedback is long enough to submit.',
+      reasonCategory: 'Not a category',
+      reasonText: 'Optional feedback',
     });
 
     expect(result.success).toBe(false);
   });
 
-  it.each(['', '.', 'Too little detail'])('rejects low-information feedback: %j', (reasonText) => {
+  it.each(['', '.', 'Brief'])('accepts optional feedback of any length: %j', (reasonText) => {
     const result = cancellationFeedbackSchema.safeParse({
-      reasonCategory: 'Other',
+      reasonCategory: '',
       reasonText,
     });
 
-    expect(result.success).toBe(false);
-  });
-
-  it('rejects feedback over the existing maximum length', () => {
-    const result = cancellationFeedbackSchema.safeParse({
-      reasonCategory: 'Other',
-      reasonText: 'x'.repeat(CANCELLATION_FEEDBACK_MAX_LENGTH + 1),
+    expect(result).toEqual({
+      success: true,
+      data: {
+        reasonCategory: undefined,
+        reasonText,
+      },
     });
-
-    expect(result.success).toBe(false);
   });
 
-  it('accepts and trims feedback at the minimum length', () => {
-    const reasonText = 'x'.repeat(CANCELLATION_FEEDBACK_MIN_LENGTH);
+  it('accepts unbounded feedback and trims surrounding whitespace', () => {
+    const reasonText = 'x'.repeat(5_000);
     const result = cancellationFeedbackSchema.safeParse({
       reasonCategory: 'Pricing too high',
       reasonText: `  ${reasonText}  `,

--- a/ee/server/src/__tests__/unit/sendCancellationFeedbackAction.test.ts
+++ b/ee/server/src/__tests__/unit/sendCancellationFeedbackAction.test.ts
@@ -79,18 +79,26 @@ describe('sendCancellationFeedbackAction', () => {
     mocks.sendCancellationFeedbackEmail.mockResolvedValue(undefined);
   });
 
-  it.each([
-    ['Not a category', 'This feedback has enough detail to otherwise be valid.'],
-    ['Other', 'Too short'],
-  ])('rejects invalid feedback before lookup or email dispatch', async (reasonCategory, reasonText) => {
+  it('rejects an unknown category before lookup or email dispatch', async () => {
+    const reasonCategory = 'Not a category';
+    const reasonText = 'Optional feedback';
     const result = await sendCancellationFeedbackAction(reasonText, reasonCategory);
 
     expect(result).toEqual({
       success: false,
-      error: 'Select a cancellation reason and provide between 20 and 500 characters of feedback',
+      error: 'Invalid cancellation feedback',
     });
     expect(mocks.getConnection).not.toHaveBeenCalled();
     expect(mocks.sendCancellationFeedbackEmail).not.toHaveBeenCalled();
+  });
+
+  it('accepts blank feedback without a category', async () => {
+    const result = await sendCancellationFeedbackAction('', undefined);
+
+    expect(result).toEqual({ success: true });
+    expect(mocks.sendCancellationFeedbackEmail).toHaveBeenCalledWith(
+      expect.objectContaining({ reasonText: '', reasonCategory: undefined })
+    );
   });
 
   it('sends trimmed, validated feedback to the mailer', async () => {

--- a/ee/server/src/components/settings/account/AccountManagement.tsx
+++ b/ee/server/src/components/settings/account/AccountManagement.tsx
@@ -301,10 +301,15 @@ export default function AccountManagement({ selectedAddOn }: AccountManagementPr
       }
 
       if (reasonCategory || reasonText.trim()) {
-        const feedbackResult = await sendCancellationFeedbackAction(reasonText, reasonCategory);
-        if (!feedbackResult.success) {
-          console.warn('Subscription canceled, but feedback could not be sent:', feedbackResult.error);
-        }
+        void sendCancellationFeedbackAction(reasonText, reasonCategory)
+          .then((feedbackResult) => {
+            if (!feedbackResult.success) {
+              console.warn('Subscription canceled, but feedback could not be sent:', feedbackResult.error);
+            }
+          })
+          .catch((error) => {
+            console.warn('Subscription canceled, but feedback could not be sent:', error);
+          });
       }
     } catch (error) {
       console.error('Error canceling subscription:', error);
@@ -1620,9 +1625,6 @@ export default function AccountManagement({ selectedAddOn }: AccountManagementPr
           <CardTitle className="text-destructive">{t('dangerZone.title')}</CardTitle>
         </CardHeader>
         <CardContent>
-          <p className="text-sm text-muted-foreground mb-4">
-            {t('dangerZone.body')}
-          </p>
           {subscriptionInfo?.cancel_at ? (
             <Alert variant="warning" id="cancellation-scheduled-alert">
               <AlertDescription>
@@ -1632,9 +1634,14 @@ export default function AccountManagement({ selectedAddOn }: AccountManagementPr
               </AlertDescription>
             </Alert>
           ) : (
-            <Button id="cancel-subscription-btn" variant="destructive" onClick={handleCancelSubscription}>
-              {t('dangerZone.cancelSubscription')}
-            </Button>
+            <>
+              <p className="text-sm text-muted-foreground mb-4">
+                {t('dangerZone.body')}
+              </p>
+              <Button id="cancel-subscription-btn" variant="destructive" onClick={handleCancelSubscription}>
+                {t('dangerZone.cancelSubscription')}
+              </Button>
+            </>
           )}
         </CardContent>
       </Card>

--- a/ee/server/src/components/settings/account/AccountManagement.tsx
+++ b/ee/server/src/components/settings/account/AccountManagement.tsx
@@ -284,7 +284,7 @@ export default function AccountManagement({ selectedAddOn }: AccountManagementPr
 
   const handleConfirmCancellation = async (
     reasonText: string,
-    reasonCategory: CancellationReasonCategory
+    reasonCategory?: CancellationReasonCategory
   ) => {
     try {
       // Send feedback email

--- a/ee/server/src/components/settings/account/AccountManagement.tsx
+++ b/ee/server/src/components/settings/account/AccountManagement.tsx
@@ -49,7 +49,7 @@ import { ConfirmationDialog } from '@alga-psa/ui/components/ConfirmationDialog';
 import ReduceLicensesModal from '@ee/components/licensing/ReduceLicensesModal';
 import CancellationFeedbackModal from './CancellationFeedbackModal';
 import AiUsageSection from './AiUsageSection';
-import { signOut, useSession } from 'next-auth/react';
+import { useSession } from 'next-auth/react';
 import { useTier } from 'server/src/context/TierContext';
 import { useProduct } from 'server/src/context/ProductContext';
 import { ADD_ONS, ADD_ON_LABELS, TIER_LABELS, TIER_FEATURE_MAP, TIER_FEATURES, type AddOnKey } from '@alga-psa/types';
@@ -287,27 +287,29 @@ export default function AccountManagement({ selectedAddOn }: AccountManagementPr
     reasonCategory?: CancellationReasonCategory
   ) => {
     try {
-      // Send feedback email
-      const feedbackResult = await sendCancellationFeedbackAction(reasonText, reasonCategory);
-      if (!feedbackResult.success) {
-        throw new Error(feedbackResult.error || t('messages.feedbackSendFailed'));
-      }
-
-      // Actually cancel the subscription
       const cancelResult = await cancelSubscriptionAction();
       if (!cancelResult.success) {
         throw new Error(cancelResult.error || t('messages.cancelSubscriptionFailed'));
       }
 
-      // Success - the modal will show the toast and then log the user out
+      const cancelAt = cancelResult.data?.cancel_at;
+      if (cancelAt) {
+        setSubscriptionInfo((current) => current
+          ? { ...current, cancel_at: cancelAt }
+          : current
+        );
+      }
+
+      if (reasonCategory || reasonText.trim()) {
+        const feedbackResult = await sendCancellationFeedbackAction(reasonText, reasonCategory);
+        if (!feedbackResult.success) {
+          console.warn('Subscription canceled, but feedback could not be sent:', feedbackResult.error);
+        }
+      }
     } catch (error) {
-      console.error('Error submitting cancellation feedback:', error);
+      console.error('Error canceling subscription:', error);
       throw error; // Re-throw to let modal handle the error
     }
-  };
-
-  const handleLogout = async () => {
-    await signOut({ callbackUrl: '/auth/msp/login' });
   };
 
   const handleReduceLicenses = () => {
@@ -1621,9 +1623,19 @@ export default function AccountManagement({ selectedAddOn }: AccountManagementPr
           <p className="text-sm text-muted-foreground mb-4">
             {t('dangerZone.body')}
           </p>
-          <Button id="cancel-subscription-btn" variant="destructive" onClick={handleCancelSubscription}>
-            {t('dangerZone.cancelSubscription')}
-          </Button>
+          {subscriptionInfo?.cancel_at ? (
+            <Alert variant="warning" id="cancellation-scheduled-alert">
+              <AlertDescription>
+                {t('dangerZone.scheduledBody', {
+                  date: formatDate(subscriptionInfo.cancel_at),
+                })}
+              </AlertDescription>
+            </Alert>
+          ) : (
+            <Button id="cancel-subscription-btn" variant="destructive" onClick={handleCancelSubscription}>
+              {t('dangerZone.cancelSubscription')}
+            </Button>
+          )}
         </CardContent>
       </Card>
 
@@ -1641,7 +1653,8 @@ export default function AccountManagement({ selectedAddOn }: AccountManagementPr
         isOpen={showCancellationFeedback}
         onClose={() => setShowCancellationFeedback(false)}
         onConfirm={handleConfirmCancellation}
-        onLogout={handleLogout}
+        subscriptionEndDate={subscriptionInfo?.current_period_end}
+        hasScheduledLicenseChange={Boolean(scheduledChanges)}
       />
 
       <Dialog

--- a/ee/server/src/components/settings/account/CancellationFeedbackModal.tsx
+++ b/ee/server/src/components/settings/account/CancellationFeedbackModal.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import React, { useState } from 'react';
-import { Dialog } from '@alga-psa/ui/components/Dialog';
+import { Dialog, DialogDescription } from '@alga-psa/ui/components/Dialog';
 import { Button } from '@alga-psa/ui/components/Button';
 import { Alert, AlertDescription } from '@alga-psa/ui/components/Alert';
 import { TextArea } from '@alga-psa/ui/components/TextArea';
@@ -18,7 +18,8 @@ interface CancellationFeedbackModalProps {
   isOpen: boolean;
   onClose: () => void;
   onConfirm: (reasonText: string, reasonCategory?: CancellationReasonCategory) => Promise<void>;
-  onLogout?: () => Promise<void>;
+  subscriptionEndDate?: string | null;
+  hasScheduledLicenseChange?: boolean;
 }
 
 const CANCELLATION_REASON_LABEL_KEYS: Record<CancellationReasonCategory, string> = {
@@ -34,7 +35,8 @@ export default function CancellationFeedbackModal({
   isOpen,
   onClose,
   onConfirm,
-  onLogout,
+  subscriptionEndDate,
+  hasScheduledLicenseChange = false,
 }: CancellationFeedbackModalProps) {
   const { t } = useTranslation('msp/account');
   const [reasonText, setReasonText] = useState('');
@@ -44,46 +46,46 @@ export default function CancellationFeedbackModal({
     value,
     label: t(CANCELLATION_REASON_LABEL_KEYS[value]),
   }));
+  const parsedEndDate = subscriptionEndDate ? new Date(subscriptionEndDate) : null;
+  const formattedEndDate = parsedEndDate && !Number.isNaN(parsedEndDate.getTime())
+    ? parsedEndDate.toLocaleDateString()
+    : t('cancellationModal.currentBillingPeriod');
 
   const handleSubmit = async () => {
     const result = cancellationFeedbackSchema.safeParse({ reasonText, reasonCategory });
 
     if (!result.success) {
-      toast.error(t('messages.feedbackSubmitFailed'));
+      toast.error(t('messages.cancelSubscriptionFailed'));
       return;
     }
 
     setLoading(true);
     try {
       await onConfirm(result.data.reasonText, result.data.reasonCategory);
-      toast.success(t('messages.feedbackSubmitted'));
+      toast.success(t('messages.cancellationScheduled'));
       onClose();
       // Reset form
       setReasonText('');
       setReasonCategory('');
 
-      // Wait 2 seconds to let the user see the toast, then log out
-      if (onLogout) {
-        setTimeout(async () => {
-          await onLogout();
-        }, 2000);
-      }
     } catch (error) {
       console.error('Error submitting cancellation feedback:', error);
-      toast.error(error instanceof Error ? error.message : t('messages.feedbackSubmitFailed'));
+      toast.error(error instanceof Error ? error.message : t('messages.cancelSubscriptionFailed'));
     } finally {
       setLoading(false);
     }
   };
 
   const handleClose = () => {
+    if (loading) return;
+
     setReasonText('');
     setReasonCategory('');
     onClose();
   };
 
   const footer = (
-    <div className="flex justify-end space-x-2">
+    <>
       <Button
         id="cancel-feedback-cancel-btn"
         variant="outline"
@@ -93,14 +95,14 @@ export default function CancellationFeedbackModal({
         {t('cancellationModal.keepSubscription')}
       </Button>
       <Button
-        id="cancel-feedback-submit-btn"
-        variant="default"
+        id="confirm-cancellation-btn"
+        variant="destructive"
         onClick={handleSubmit}
         disabled={loading}
       >
-        {loading ? t('cancellationModal.submitting') : t('cancellationModal.submitFeedback')}
+        {loading ? t('cancellationModal.canceling') : t('dangerZone.cancelSubscription')}
       </Button>
-    </div>
+    </>
   );
 
   return (
@@ -108,19 +110,23 @@ export default function CancellationFeedbackModal({
       isOpen={isOpen}
       onClose={handleClose}
       title={t('cancellationModal.title')}
-      className="max-w-[600px]"
+      className="max-w-xl"
       id="cancellation-feedback-modal"
       footer={footer}
+      draggable={false}
+      hideCloseButton={loading}
     >
-      <div className="space-y-6">
+      <div className="space-y-5">
         {/* Warning */}
         <Alert variant="destructive" id="cancellation-warning-alert">
-          <div>
-            <p className="font-semibold">{t('cancellationModal.beforeYouCancel')}</p>
-            <AlertDescription className="mt-1">
-              {t('cancellationModal.beforeYouCancelBody')}
-            </AlertDescription>
-          </div>
+          <AlertDescription>
+            <DialogDescription>
+              {t('cancellationModal.beforeYouCancelBody', { date: formattedEndDate })}
+            </DialogDescription>
+            {hasScheduledLicenseChange && (
+              <p className="mt-2">{t('cancellationModal.replacesScheduledChange')}</p>
+            )}
+          </AlertDescription>
         </Alert>
 
         {/* Reason Category (Optional) */}
@@ -135,11 +141,6 @@ export default function CancellationFeedbackModal({
             disabled={loading}
             allowClear
           />
-          {reasonCategory === 'Other' && (
-            <p id="reason-category-other-help" className="text-xs text-muted-foreground -mt-3">
-              {t('cancellationModal.otherReasonHelp')}
-            </p>
-          )}
         </div>
 
         {/* Feedback Text (Optional) */}
@@ -150,7 +151,8 @@ export default function CancellationFeedbackModal({
           onChange={(e) => setReasonText(e.target.value)}
           placeholder={t('cancellationModal.feedbackPlaceholder')}
           disabled={loading}
-          className="min-h-[120px]"
+          rows={4}
+          wrapperClassName="mb-0"
         />
 
       </div>

--- a/ee/server/src/components/settings/account/CancellationFeedbackModal.tsx
+++ b/ee/server/src/components/settings/account/CancellationFeedbackModal.tsx
@@ -9,8 +9,6 @@ import CustomSelect from '@alga-psa/ui/components/CustomSelect';
 import { toast } from 'react-hot-toast';
 import { useTranslation } from '@alga-psa/ui/lib/i18n/client';
 import {
-  CANCELLATION_FEEDBACK_MAX_LENGTH,
-  CANCELLATION_FEEDBACK_MIN_LENGTH,
   CANCELLATION_REASON_CATEGORIES,
   cancellationFeedbackSchema,
   type CancellationReasonCategory,
@@ -19,7 +17,7 @@ import {
 interface CancellationFeedbackModalProps {
   isOpen: boolean;
   onClose: () => void;
-  onConfirm: (reasonText: string, reasonCategory: CancellationReasonCategory) => Promise<void>;
+  onConfirm: (reasonText: string, reasonCategory?: CancellationReasonCategory) => Promise<void>;
   onLogout?: () => Promise<void>;
 }
 
@@ -47,29 +45,11 @@ export default function CancellationFeedbackModal({
     label: t(CANCELLATION_REASON_LABEL_KEYS[value]),
   }));
 
-  const trimmedReasonLength = reasonText.trim().length;
-  const remainingChars = CANCELLATION_FEEDBACK_MAX_LENGTH - reasonText.length;
-  const feedbackResult = cancellationFeedbackSchema.safeParse({ reasonText, reasonCategory });
-  const hasValidCategory = CANCELLATION_REASON_CATEGORIES.some(
-    (category) => category === reasonCategory
-  );
-  const hasMinimumFeedback = trimmedReasonLength >= CANCELLATION_FEEDBACK_MIN_LENGTH;
-
   const handleSubmit = async () => {
     const result = cancellationFeedbackSchema.safeParse({ reasonText, reasonCategory });
 
-    if (!hasValidCategory) {
-      toast.error(t('messages.feedbackCategoryRequired'));
-      return;
-    }
-
-    if (!hasMinimumFeedback) {
-      toast.error(t('messages.feedbackMinimumLength', { min: CANCELLATION_FEEDBACK_MIN_LENGTH }));
-      return;
-    }
-
     if (!result.success) {
-      toast.error(t('messages.feedbackMaxLength', { max: CANCELLATION_FEEDBACK_MAX_LENGTH }));
+      toast.error(t('messages.feedbackSubmitFailed'));
       return;
     }
 
@@ -116,7 +96,7 @@ export default function CancellationFeedbackModal({
         id="cancel-feedback-submit-btn"
         variant="default"
         onClick={handleSubmit}
-        disabled={loading || !feedbackResult.success}
+        disabled={loading}
       >
         {loading ? t('cancellationModal.submitting') : t('cancellationModal.submitFeedback')}
       </Button>
@@ -143,18 +123,8 @@ export default function CancellationFeedbackModal({
           </div>
         </Alert>
 
-        {/* Reason Category (Required) */}
-        <div
-          role="group"
-          aria-describedby={
-            !hasValidCategory
-              ? 'reason-category-error'
-              : reasonCategory === 'Other'
-                ? 'reason-category-other-help'
-                : undefined
-          }
-          aria-invalid={!hasValidCategory}
-        >
+        {/* Reason Category (Optional) */}
+        <div>
           <CustomSelect
             id="reason-category"
             label={t('cancellationModal.reasonLabel')}
@@ -163,13 +133,8 @@ export default function CancellationFeedbackModal({
             onValueChange={setReasonCategory}
             placeholder={t('cancellationModal.reasonPlaceholder')}
             disabled={loading}
-            required
+            allowClear
           />
-          {!hasValidCategory && (
-            <p id="reason-category-error" className="text-xs text-destructive -mt-3" role="alert">
-              {t('cancellationModal.reasonRequired')}
-            </p>
-          )}
           {reasonCategory === 'Other' && (
             <p id="reason-category-other-help" className="text-xs text-muted-foreground -mt-3">
               {t('cancellationModal.otherReasonHelp')}
@@ -177,35 +142,16 @@ export default function CancellationFeedbackModal({
           )}
         </div>
 
-        {/* Feedback Text (Required) */}
-        <div>
-          <TextArea
-            id="feedback-text"
-            label={t('cancellationModal.feedbackLabel')}
-            value={reasonText}
-            onChange={(e) => setReasonText(e.target.value)}
-            placeholder={t('cancellationModal.feedbackPlaceholder')}
-            disabled={loading}
-            maxLength={CANCELLATION_FEEDBACK_MAX_LENGTH}
-            required
-            className="min-h-[120px]"
-            aria-describedby="feedback-text-requirements feedback-text-remaining"
-            aria-invalid={!hasMinimumFeedback}
-          />
-          <div className="flex justify-between text-xs text-muted-foreground -mt-3 px-0.5">
-            <span id="feedback-text-requirements" className={!hasMinimumFeedback ? 'text-destructive' : ''}>
-              {t('cancellationModal.minimumCharacters', {
-                min: CANCELLATION_FEEDBACK_MIN_LENGTH,
-              })}
-            </span>
-            <span
-              id="feedback-text-remaining"
-              className={remainingChars < 50 ? 'text-destructive font-semibold' : ''}
-            >
-              {t('cancellationModal.charactersRemaining', { count: remainingChars })}
-            </span>
-          </div>
-        </div>
+        {/* Feedback Text (Optional) */}
+        <TextArea
+          id="feedback-text"
+          label={t('cancellationModal.feedbackLabel')}
+          value={reasonText}
+          onChange={(e) => setReasonText(e.target.value)}
+          placeholder={t('cancellationModal.feedbackPlaceholder')}
+          disabled={loading}
+          className="min-h-[120px]"
+        />
 
       </div>
     </Dialog>

--- a/ee/server/src/components/settings/account/CancellationFeedbackModal.tsx
+++ b/ee/server/src/components/settings/account/CancellationFeedbackModal.tsx
@@ -67,9 +67,8 @@ export default function CancellationFeedbackModal({
       // Reset form
       setReasonText('');
       setReasonCategory('');
-
     } catch (error) {
-      console.error('Error submitting cancellation feedback:', error);
+      console.error('Error canceling subscription:', error);
       toast.error(error instanceof Error ? error.message : t('messages.cancelSubscriptionFailed'));
     } finally {
       setLoading(false);
@@ -154,7 +153,6 @@ export default function CancellationFeedbackModal({
           rows={4}
           wrapperClassName="mb-0"
         />
-
       </div>
     </Dialog>
   );

--- a/ee/server/src/lib/actions/license-actions.ts
+++ b/ee/server/src/lib/actions/license-actions.ts
@@ -9,11 +9,7 @@ import { getConnection } from '@/lib/db/db';
 import { tenantDb } from '@alga-psa/db';
 import logger from '@alga-psa/core/logger';
 import { sendCancellationRequestEmail } from '@alga-psa/email/sendCancellationRequestEmail';
-import {
-  CANCELLATION_FEEDBACK_MAX_LENGTH,
-  CANCELLATION_FEEDBACK_MIN_LENGTH,
-  cancellationFeedbackSchema,
-} from '../cancellationFeedbackValidation';
+import { cancellationFeedbackSchema } from '../cancellationFeedbackValidation';
 import {
   IGetSubscriptionInfoResponse,
   IGetPaymentMethodResponse,
@@ -700,7 +696,7 @@ export async function sendCancellationFeedbackAction(
     if (!feedbackResult.success) {
       return {
         success: false,
-        error: `Select a cancellation reason and provide between ${CANCELLATION_FEEDBACK_MIN_LENGTH} and ${CANCELLATION_FEEDBACK_MAX_LENGTH} characters of feedback`,
+        error: 'Invalid cancellation feedback',
       };
     }
 

--- a/ee/server/src/lib/cancellationFeedbackValidation.ts
+++ b/ee/server/src/lib/cancellationFeedbackValidation.ts
@@ -9,16 +9,12 @@ export const CANCELLATION_REASON_CATEGORIES = [
   'Other',
 ] as const;
 
-export const CANCELLATION_FEEDBACK_MIN_LENGTH = 20;
-export const CANCELLATION_FEEDBACK_MAX_LENGTH = 500;
-
 export const cancellationFeedbackSchema = z.object({
-  reasonCategory: z.enum(CANCELLATION_REASON_CATEGORIES),
-  reasonText: z
-    .string()
-    .trim()
-    .min(CANCELLATION_FEEDBACK_MIN_LENGTH)
-    .max(CANCELLATION_FEEDBACK_MAX_LENGTH),
+  reasonCategory: z.preprocess(
+    (value) => (value === '' ? undefined : value),
+    z.enum(CANCELLATION_REASON_CATEGORIES).optional()
+  ),
+  reasonText: z.string().trim(),
 });
 
 export type CancellationReasonCategory = (typeof CANCELLATION_REASON_CATEGORIES)[number];

--- a/packages/email/src/__tests__/sendCancellationFeedbackEmail.test.ts
+++ b/packages/email/src/__tests__/sendCancellationFeedbackEmail.test.ts
@@ -1,0 +1,42 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const mocks = vi.hoisted(() => ({
+  sendEmail: vi.fn(),
+}));
+
+vi.mock('../system/SystemEmailService', () => ({
+  getSystemEmailService: async () => ({ sendEmail: mocks.sendEmail }),
+}));
+
+import { sendCancellationFeedbackEmail } from '../sendCancellationFeedbackEmail';
+
+describe('sendCancellationFeedbackEmail', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.sendEmail.mockResolvedValue(undefined);
+  });
+
+  it('escapes dynamic values in the HTML email', async () => {
+    await sendCancellationFeedbackEmail({
+      tenantName: 'A&B <script>alert(1)</script>',
+      tenantEmail: 'owner+<tag>@example.test',
+      reasonText: '<img src=x onerror=alert(1)>\nSecond & final line',
+      reasonCategory: 'Other <unsafe>',
+      licenseCount: 3,
+      monthlyCost: 75,
+      cancelAt: '<tomorrow>',
+    });
+
+    expect(mocks.sendEmail).toHaveBeenCalledOnce();
+    const message = mocks.sendEmail.mock.calls[0][0];
+
+    expect(message.html).toContain('A&amp;B &lt;script&gt;alert(1)&lt;/script&gt;');
+    expect(message.html).toContain('owner+&lt;tag&gt;@example.test');
+    expect(message.html).toContain('&lt;img src=x onerror=alert(1)&gt;<br>Second &amp; final line');
+    expect(message.html).toContain('Other &lt;unsafe&gt;');
+    expect(message.html).toContain('&lt;tomorrow&gt;');
+    expect(message.html).not.toContain('<script>');
+    expect(message.html).not.toContain('<img');
+    expect(message.text).toContain('<img src=x onerror=alert(1)>');
+  });
+});

--- a/packages/email/src/sendCancellationFeedbackEmail.ts
+++ b/packages/email/src/sendCancellationFeedbackEmail.ts
@@ -10,6 +10,19 @@ export interface CancellationFeedbackData {
   cancelAt: string;
 }
 
+function escapeHtml(value: string): string {
+  return value.replace(/[&<>"']/g, (character) => {
+    switch (character) {
+      case '&': return '&amp;';
+      case '<': return '&lt;';
+      case '>': return '&gt;';
+      case '"': return '&quot;';
+      case "'": return '&#39;';
+      default: return character;
+    }
+  });
+}
+
 /**
  * Send cancellation feedback email to support team
  */
@@ -18,7 +31,13 @@ export async function sendCancellationFeedbackEmail(
 ): Promise<void> {
   const emailService = await getSystemEmailService();
 
-  const subject = `Subscription Cancellation Feedback - ${data.tenantName}`;
+  const subjectTenantName = data.tenantName.replace(/[\r\n]+/g, ' ');
+  const subject = `Subscription Cancellation Feedback - ${subjectTenantName}`;
+  const tenantName = escapeHtml(data.tenantName);
+  const tenantEmail = escapeHtml(data.tenantEmail);
+  const cancelAt = escapeHtml(data.cancelAt);
+  const reasonCategory = data.reasonCategory ? escapeHtml(data.reasonCategory) : undefined;
+  const reasonText = escapeHtml(data.reasonText).replace(/\n/g, '<br>');
 
   const htmlBody = `
     <div style="font-family: Arial, sans-serif; max-width: 600px; margin: 0 auto;">
@@ -26,22 +45,22 @@ export async function sendCancellationFeedbackEmail(
 
       <h3>Tenant Information</h3>
       <ul>
-        <li><strong>Tenant:</strong> ${data.tenantName}</li>
-        <li><strong>Email:</strong> ${data.tenantEmail}</li>
+        <li><strong>Tenant:</strong> ${tenantName}</li>
+        <li><strong>Email:</strong> ${tenantEmail}</li>
       </ul>
 
       <h3>Subscription Details</h3>
       <ul>
         <li><strong>License Count:</strong> ${data.licenseCount}</li>
         <li><strong>Monthly Cost:</strong> $${data.monthlyCost.toFixed(2)}</li>
-        <li><strong>Subscription Ends:</strong> ${data.cancelAt}</li>
+        <li><strong>Subscription Ends:</strong> ${cancelAt}</li>
       </ul>
 
       <h3>Cancellation Reason</h3>
-      ${data.reasonCategory ? `<p><strong>Category:</strong> ${data.reasonCategory}</p>` : ''}
+      ${reasonCategory ? `<p><strong>Category:</strong> ${reasonCategory}</p>` : ''}
       <p><strong>Feedback:</strong></p>
       <blockquote style="border-left: 3px solid #ccc; padding-left: 15px; color: #666; margin: 10px 0;">
-        ${data.reasonText.replace(/\n/g, '<br>')}
+        ${reasonText}
       </blockquote>
 
       <p style="margin-top: 30px; color: #999; font-size: 12px;">

--- a/packages/ui/src/components/CustomSelect.tsx
+++ b/packages/ui/src/components/CustomSelect.tsx
@@ -223,7 +223,11 @@ const CustomSelect = ({
   return (
     <div className={label ? 'mb-4' : ''} id={containerId} data-automation-type={dataAutomationType} suppressHydrationWarning>
       {label && (
-        <label className="block text-sm font-medium text-foreground mb-1">
+        <label
+          id={`${selectId}-label`}
+          htmlFor={selectId}
+          className="block text-sm font-medium text-foreground mb-1"
+        >
           {label}
         </label>
       )}
@@ -274,7 +278,8 @@ const CustomSelect = ({
             ${className}
             ${customStyles?.trigger || ''}
           `}
-          aria-label={resolvedPlaceholder}
+          aria-label={label ? undefined : resolvedPlaceholder}
+          aria-labelledby={label ? `${selectId}-label` : undefined}
           suppressHydrationWarning
           onPointerDown={(e) => {
             // Prevent click events from bubbling up to parent dialogs

--- a/packages/ui/src/components/TextArea.tsx
+++ b/packages/ui/src/components/TextArea.tsx
@@ -134,7 +134,10 @@ export function TextArea({
   return (
     <div className={cn('mb-4 px-0.5', wrapperClassName)}>
       {label && (
-        <label className="block text-sm font-medium text-[rgb(var(--color-text-700))] mb-1">
+        <label
+          htmlFor={finalAutomationProps.id}
+          className="block text-sm font-medium text-[rgb(var(--color-text-700))] mb-1"
+        >
           {label}
         </label>
       )}

--- a/server/public/locales/de/msp/account.json
+++ b/server/public/locales/de/msp/account.json
@@ -30,12 +30,7 @@
     "aiCheckoutFailed": "AI Assistant-Checkout konnte nicht gestartet werden",
     "aiRemoved": "AI Assistant wird aus Ihrem Abonnement entfernt.",
     "aiCancelFailed": "AI Assistant konnte nicht abgebrochen werden",
-    "feedbackReasonRequired": "Bitte geben Sie einen Grund für die Kündigung an",
-    "feedbackCategoryRequired": "Bitte wählen Sie einen Kündigungsgrund aus",
-    "feedbackMinimumLength": "Bitte geben Sie mindestens {{min}} Zeichen Feedback ein",
-    "feedbackMaxLength": "Das Feedback muss {{max}} Zeichen oder weniger enthalten",
-    "feedbackSubmitted": "Vielen Dank für Ihr Feedback. Wir haben Ihre Kündigungsanfrage erhalten. Sie werden in Kürze abgemeldet.",
-    "feedbackSubmitFailed": "Feedback konnte nicht gesendet werden. Bitte erneut versuchen."
+    "cancellationScheduled": "Abonnement gekündigt. Sie können Alga PSA bis zum Ende Ihres Abrechnungszeitraums weiter nutzen."
   },
   "common": {
     "loading": "Wird geladen...",
@@ -204,7 +199,8 @@
   "dangerZone": {
     "title": "Gefahrenzone",
     "body": "Durch die Kündigung Ihres Abonnements wird der Zugriff für alle Benutzer am Ende des aktuellen Abrechnungszeitraums deaktiviert.",
-    "cancelSubscription": "Abonnement kündigen"
+    "cancelSubscription": "Abonnement kündigen",
+    "scheduledBody": "Ihr Abonnement endet planmäßig am {{date}}. Bis dahin können alle Alga PSA weiter nutzen."
   },
   "aiCheckoutDialog": {
     "title": "AI Assistant hinzufügen",
@@ -344,19 +340,14 @@
   "cancellationModal": {
     "title": "Abonnement kündigen",
     "keepSubscription": "Abonnement behalten",
-    "submitting": "Wird übermittelt...",
-    "submitFeedback": "Feedback senden",
-    "beforeYouCancel": "Bevor Sie kündigen",
-    "beforeYouCancelBody": "Wir würden uns freuen, Ihr Feedback zu hören, damit wir unseren Service verbessern können. Ihr Beitrag ist wertvoll für uns.",
-    "reasonLabel": "Grund für die Kündigung",
+    "canceling": "Wird gekündigt...",
+    "beforeYouCancelBody": "Ihr Abonnement endet am {{date}}. Bis dahin können alle Alga PSA weiter nutzen.",
+    "currentBillingPeriod": "Ende Ihres aktuellen Abrechnungszeitraums",
+    "replacesScheduledChange": "Dies ersetzt Ihre geplante Lizenzänderung.",
+    "reasonLabel": "Grund (optional)",
     "reasonPlaceholder": "Grund auswählen",
-    "reasonRequired": "Wählen Sie einen Grund aus, um fortzufahren.",
-    "otherReasonHelp": "Bitte teilen Sie uns etwas genauer mit, was zu Ihrer Entscheidung geführt hat.",
-    "feedbackLabel": "Warum verlassen Sie uns?",
-    "feedbackPlaceholder": "Wir würden uns freuen, Ihr Feedback zu hören, damit wir uns verbessern können. Ihr Beitrag hilft uns, unsere Kunden besser zu bedienen.",
-    "required": "* Pflichtfeld",
-    "minimumCharacters": "Mindestens {{min}} Zeichen erforderlich",
-    "charactersRemaining": "Noch {{count}} Zeichen übrig",
+    "feedbackLabel": "Details (optional)",
+    "feedbackPlaceholder": "Fügen Sie alle Details hinzu, die Sie uns mitteilen möchten.",
     "reasons": {
       "pricingTooHigh": "Preise zu hoch",
       "missingFeatures": "Fehlende Funktionen, die ich benötige",

--- a/server/public/locales/en/msp/account.json
+++ b/server/public/locales/en/msp/account.json
@@ -30,12 +30,7 @@
     "aiCheckoutFailed": "Failed to start AI Assistant checkout",
     "aiRemoved": "AI Assistant will be removed from your subscription.",
     "aiCancelFailed": "Failed to cancel AI Assistant",
-    "feedbackReasonRequired": "Please provide a reason for cancellation",
-    "feedbackCategoryRequired": "Please select a cancellation reason",
-    "feedbackMinimumLength": "Please provide at least {{min}} characters of feedback",
-    "feedbackMaxLength": "Feedback must be {{max}} characters or less",
-    "feedbackSubmitted": "Thank you for your feedback. We have received your cancellation request. You will be logged out shortly.",
-    "feedbackSubmitFailed": "Failed to submit feedback. Please try again."
+    "cancellationScheduled": "Subscription canceled. You can keep using Alga PSA until the end of your billing period."
   },
   "common": {
     "loading": "Loading...",
@@ -204,7 +199,8 @@
   "dangerZone": {
     "title": "Danger Zone",
     "body": "Canceling your subscription will disable access for all users at the end of the current billing period.",
-    "cancelSubscription": "Cancel Subscription"
+    "cancelSubscription": "Cancel Subscription",
+    "scheduledBody": "Your subscription is scheduled to end on {{date}}. Everyone can keep using Alga PSA until then."
   },
   "aiCheckoutDialog": {
     "title": "Add AI Assistant",
@@ -342,27 +338,22 @@
     "infoBox": "Pro-only features unlock immediately. This trial is only available after your initial Solo trial has ended."
   },
   "cancellationModal": {
-    "title": "Cancel Subscription",
-    "keepSubscription": "Keep Subscription",
-    "submitting": "Submitting...",
-    "submitFeedback": "Submit Feedback",
-    "beforeYouCancel": "Before you cancel",
-    "beforeYouCancelBody": "We'd love to hear your feedback to help us improve our service. Your input is valuable to us.",
-    "reasonLabel": "Reason for Cancellation",
+    "title": "Cancel subscription?",
+    "keepSubscription": "Keep subscription",
+    "canceling": "Canceling...",
+    "beforeYouCancelBody": "Your subscription will end on {{date}}. Everyone can keep using Alga PSA until then.",
+    "currentBillingPeriod": "the end of your current billing period",
+    "replacesScheduledChange": "This replaces your scheduled license change.",
+    "reasonLabel": "Reason (optional)",
     "reasonPlaceholder": "Select a reason",
-    "reasonRequired": "Select a reason to continue.",
-    "otherReasonHelp": "Please share a little more about what led to your decision.",
-    "feedbackLabel": "Why are you leaving us?",
-    "feedbackPlaceholder": "We'd love to hear your feedback so we can improve. Your input helps us serve our customers better.",
-    "required": "* Required",
-    "minimumCharacters": "At least {{min}} characters required",
-    "charactersRemaining": "{{count}} characters remaining",
+    "feedbackLabel": "Details (optional)",
+    "feedbackPlaceholder": "Add any details you'd like to share.",
     "reasons": {
-      "pricingTooHigh": "Pricing too high",
-      "missingFeatures": "Missing features I need",
-      "poorSupport": "Poor customer support",
-      "switchingCompetitor": "Switching to competitor",
-      "noLongerNeed": "No longer need the service",
+      "pricingTooHigh": "Too expensive",
+      "missingFeatures": "Missing features",
+      "poorSupport": "Support problems",
+      "switchingCompetitor": "Moving to another product",
+      "noLongerNeed": "No longer needed",
       "other": "Other"
     }
   },

--- a/server/public/locales/es/msp/account.json
+++ b/server/public/locales/es/msp/account.json
@@ -30,12 +30,7 @@
     "aiCheckoutFailed": "Error al iniciar el pago del AI Assistant",
     "aiRemoved": "AI Assistant se eliminará de su suscripción.",
     "aiCancelFailed": "Error al cancelar el AI Assistant",
-    "feedbackReasonRequired": "Proporcione un motivo para la cancelación",
-    "feedbackCategoryRequired": "Seleccione un motivo de cancelación",
-    "feedbackMinimumLength": "Proporcione al menos {{min}} caracteres de comentarios",
-    "feedbackMaxLength": "El comentario debe tener {{max}} caracteres o menos",
-    "feedbackSubmitted": "Gracias por sus comentarios. Hemos recibido su solicitud de cancelación. Se cerrará su sesión en breve.",
-    "feedbackSubmitFailed": "Error al enviar el comentario. Inténtelo de nuevo."
+    "cancellationScheduled": "Suscripción cancelada. Puede seguir usando Alga PSA hasta el final de su período de facturación."
   },
   "common": {
     "loading": "Cargando...",
@@ -204,7 +199,8 @@
   "dangerZone": {
     "title": "Zona de peligro",
     "body": "Cancelar su suscripción desactivará el acceso para todos los usuarios al final del período de facturación actual.",
-    "cancelSubscription": "Cancelar suscripción"
+    "cancelSubscription": "Cancelar suscripción",
+    "scheduledBody": "Su suscripción finalizará el {{date}}. Todos podrán seguir usando Alga PSA hasta entonces."
   },
   "aiCheckoutDialog": {
     "title": "Añadir AI Assistant",
@@ -344,19 +340,14 @@
   "cancellationModal": {
     "title": "Cancelar suscripción",
     "keepSubscription": "Mantener suscripción",
-    "submitting": "Enviando...",
-    "submitFeedback": "Enviar comentario",
-    "beforeYouCancel": "Antes de cancelar",
-    "beforeYouCancelBody": "Nos encantaría escuchar sus comentarios para ayudarnos a mejorar nuestro servicio. Sus aportaciones son valiosas para nosotros.",
-    "reasonLabel": "Motivo de la cancelación",
+    "canceling": "Cancelando...",
+    "beforeYouCancelBody": "Su suscripción finalizará el {{date}}. Todos podrán seguir usando Alga PSA hasta entonces.",
+    "currentBillingPeriod": "el final de su período de facturación actual",
+    "replacesScheduledChange": "Esto sustituye su cambio de licencia programado.",
+    "reasonLabel": "Motivo (opcional)",
     "reasonPlaceholder": "Seleccione un motivo",
-    "reasonRequired": "Seleccione un motivo para continuar.",
-    "otherReasonHelp": "Cuéntenos un poco más sobre lo que le llevó a tomar esta decisión.",
-    "feedbackLabel": "¿Por qué nos deja?",
-    "feedbackPlaceholder": "Nos encantaría escuchar sus comentarios para poder mejorar. Sus aportaciones nos ayudan a servir mejor a nuestros clientes.",
-    "required": "* Obligatorio",
-    "minimumCharacters": "Se requieren al menos {{min}} caracteres",
-    "charactersRemaining": "{{count}} caracteres restantes",
+    "feedbackLabel": "Detalles (opcional)",
+    "feedbackPlaceholder": "Añada cualquier detalle que desee compartir.",
     "reasons": {
       "pricingTooHigh": "Precio demasiado alto",
       "missingFeatures": "Faltan funciones que necesito",

--- a/server/public/locales/fr/msp/account.json
+++ b/server/public/locales/fr/msp/account.json
@@ -30,12 +30,7 @@
     "aiCheckoutFailed": "Échec du démarrage du paiement pour l'AI Assistant",
     "aiRemoved": "L'AI Assistant sera supprimé de votre abonnement.",
     "aiCancelFailed": "Échec de l'annulation de l'AI Assistant",
-    "feedbackReasonRequired": "Veuillez fournir une raison pour l'annulation",
-    "feedbackCategoryRequired": "Veuillez sélectionner un motif d'annulation",
-    "feedbackMinimumLength": "Veuillez fournir au moins {{min}} caractères de commentaire",
-    "feedbackMaxLength": "Le commentaire doit contenir {{max}} caractères ou moins",
-    "feedbackSubmitted": "Merci pour votre commentaire. Nous avons reçu votre demande d'annulation. Vous allez être déconnecté sous peu.",
-    "feedbackSubmitFailed": "Échec de l'envoi du commentaire. Veuillez réessayer."
+    "cancellationScheduled": "Abonnement annulé. Vous pouvez continuer à utiliser Alga PSA jusqu'à la fin de votre période de facturation."
   },
   "common": {
     "loading": "Chargement...",
@@ -204,7 +199,8 @@
   "dangerZone": {
     "title": "Zone de danger",
     "body": "L'annulation de votre abonnement désactivera l'accès pour tous les utilisateurs à la fin de la période de facturation actuelle.",
-    "cancelSubscription": "Annuler l'abonnement"
+    "cancelSubscription": "Annuler l'abonnement",
+    "scheduledBody": "Votre abonnement prendra fin le {{date}}. Tout le monde pourra continuer à utiliser Alga PSA jusque-là."
   },
   "aiCheckoutDialog": {
     "title": "Ajouter AI Assistant",
@@ -344,19 +340,14 @@
   "cancellationModal": {
     "title": "Annuler l'abonnement",
     "keepSubscription": "Conserver l'abonnement",
-    "submitting": "Envoi en cours...",
-    "submitFeedback": "Envoyer les commentaires",
-    "beforeYouCancel": "Avant d'annuler",
-    "beforeYouCancelBody": "Nous aimerions recevoir vos commentaires pour nous aider à améliorer notre service. Votre avis nous est précieux.",
-    "reasonLabel": "Raison de l'annulation",
+    "canceling": "Annulation...",
+    "beforeYouCancelBody": "Votre abonnement prendra fin le {{date}}. Tout le monde pourra continuer à utiliser Alga PSA jusque-là.",
+    "currentBillingPeriod": "la fin de votre période de facturation actuelle",
+    "replacesScheduledChange": "Cela remplace votre modification de licence programmée.",
+    "reasonLabel": "Motif (facultatif)",
     "reasonPlaceholder": "Sélectionnez une raison",
-    "reasonRequired": "Sélectionnez une raison pour continuer.",
-    "otherReasonHelp": "Veuillez nous en dire un peu plus sur ce qui a motivé votre décision.",
-    "feedbackLabel": "Pourquoi nous quittez-vous ?",
-    "feedbackPlaceholder": "Nous aimerions recevoir vos commentaires pour nous améliorer. Votre avis nous aide à mieux servir nos clients.",
-    "required": "* Requis",
-    "minimumCharacters": "Au moins {{min}} caractères requis",
-    "charactersRemaining": "{{count}} caractères restants",
+    "feedbackLabel": "Détails (facultatif)",
+    "feedbackPlaceholder": "Ajoutez les détails que vous souhaitez partager.",
     "reasons": {
       "pricingTooHigh": "Tarification trop élevée",
       "missingFeatures": "Fonctionnalités manquantes dont j'ai besoin",

--- a/server/public/locales/it/msp/account.json
+++ b/server/public/locales/it/msp/account.json
@@ -30,12 +30,7 @@
     "aiCheckoutFailed": "Impossibile avviare il checkout per AI Assistant",
     "aiRemoved": "AI Assistant sarà rimosso dal tuo abbonamento.",
     "aiCancelFailed": "Impossibile annullare AI Assistant",
-    "feedbackReasonRequired": "Fornisci un motivo per l'annullamento",
-    "feedbackCategoryRequired": "Seleziona un motivo per l'annullamento",
-    "feedbackMinimumLength": "Fornisci almeno {{min}} caratteri di feedback",
-    "feedbackMaxLength": "Il feedback deve essere di {{max}} caratteri o meno",
-    "feedbackSubmitted": "Grazie per il tuo feedback. Abbiamo ricevuto la tua richiesta di annullamento. Verrai disconnesso a breve.",
-    "feedbackSubmitFailed": "Impossibile inviare il feedback. Riprova."
+    "cancellationScheduled": "Abbonamento annullato. Puoi continuare a usare Alga PSA fino alla fine del periodo di fatturazione."
   },
   "common": {
     "loading": "Caricamento in corso...",
@@ -204,7 +199,8 @@
   "dangerZone": {
     "title": "Zona Pericolosa",
     "body": "L'annullamento dell'abbonamento disabiliterà l'accesso per tutti gli utenti alla fine del periodo di fatturazione corrente.",
-    "cancelSubscription": "Annulla Abbonamento"
+    "cancelSubscription": "Annulla Abbonamento",
+    "scheduledBody": "L'abbonamento terminerà il {{date}}. Fino ad allora, tutti potranno continuare a usare Alga PSA."
   },
   "aiCheckoutDialog": {
     "title": "Aggiungi AI Assistant",
@@ -344,19 +340,14 @@
   "cancellationModal": {
     "title": "Annulla Abbonamento",
     "keepSubscription": "Mantieni Abbonamento",
-    "submitting": "Invio in corso...",
-    "submitFeedback": "Invia Feedback",
-    "beforeYouCancel": "Prima di annullare",
-    "beforeYouCancelBody": "Ci piacerebbe ricevere il tuo feedback per aiutarci a migliorare il nostro servizio. Il tuo contributo è prezioso per noi.",
-    "reasonLabel": "Motivo dell'Annullamento",
+    "canceling": "Annullamento...",
+    "beforeYouCancelBody": "L'abbonamento terminerà il {{date}}. Fino ad allora, tutti potranno continuare a usare Alga PSA.",
+    "currentBillingPeriod": "la fine del periodo di fatturazione corrente",
+    "replacesScheduledChange": "Questo sostituisce la modifica della licenza programmata.",
+    "reasonLabel": "Motivo (facoltativo)",
     "reasonPlaceholder": "Seleziona un motivo",
-    "reasonRequired": "Seleziona un motivo per continuare.",
-    "otherReasonHelp": "Condividi qualche dettaglio in più su ciò che ha portato alla tua decisione.",
-    "feedbackLabel": "Perché ci stai lasciando?",
-    "feedbackPlaceholder": "Ci piacerebbe ricevere il tuo feedback per poter migliorare. Il tuo contributo ci aiuta a servire meglio i nostri clienti.",
-    "required": "* Obbligatorio",
-    "minimumCharacters": "Sono richiesti almeno {{min}} caratteri",
-    "charactersRemaining": "{{count}} caratteri rimanenti",
+    "feedbackLabel": "Dettagli (facoltativi)",
+    "feedbackPlaceholder": "Aggiungi i dettagli che desideri condividere.",
     "reasons": {
       "pricingTooHigh": "Prezzo troppo alto",
       "missingFeatures": "Mancano funzionalità di cui ho bisogno",

--- a/server/public/locales/nl/msp/account.json
+++ b/server/public/locales/nl/msp/account.json
@@ -30,12 +30,7 @@
     "aiCheckoutFailed": "AI Assistant-afrekening kon niet worden gestart",
     "aiRemoved": "AI Assistant wordt verwijderd uit uw abonnement.",
     "aiCancelFailed": "AI Assistant kon niet worden geannuleerd",
-    "feedbackReasonRequired": "Geef een reden op voor de annulering",
-    "feedbackCategoryRequired": "Selecteer een reden voor annulering",
-    "feedbackMinimumLength": "Geef ten minste {{min}} tekens feedback",
-    "feedbackMaxLength": "Feedback moet {{max}} tekens of minder zijn",
-    "feedbackSubmitted": "Bedankt voor uw feedback. We hebben uw annuleringsverzoek ontvangen. U wordt binnenkort afgemeld.",
-    "feedbackSubmitFailed": "Feedback kon niet worden verzonden. Probeer het opnieuw."
+    "cancellationScheduled": "Abonnement geannuleerd. U kunt Alga PSA blijven gebruiken tot het einde van uw factureringsperiode."
   },
   "common": {
     "loading": "Laden...",
@@ -204,7 +199,8 @@
   "dangerZone": {
     "title": "Gevarenzone",
     "body": "Als u uw abonnement annuleert, wordt de toegang voor alle gebruikers aan het einde van de huidige factureringsperiode uitgeschakeld.",
-    "cancelSubscription": "Abonnement annuleren"
+    "cancelSubscription": "Abonnement annuleren",
+    "scheduledBody": "Uw abonnement eindigt op {{date}}. Tot die tijd kan iedereen Alga PSA blijven gebruiken."
   },
   "aiCheckoutDialog": {
     "title": "AI Assistant toevoegen",
@@ -344,19 +340,14 @@
   "cancellationModal": {
     "title": "Abonnement annuleren",
     "keepSubscription": "Abonnement behouden",
-    "submitting": "Verzenden...",
-    "submitFeedback": "Feedback verzenden",
-    "beforeYouCancel": "Voordat u annuleert",
-    "beforeYouCancelBody": "We horen graag uw feedback om onze service te verbeteren. Uw input is waardevol voor ons.",
-    "reasonLabel": "Reden voor annulering",
+    "canceling": "Annuleren...",
+    "beforeYouCancelBody": "Uw abonnement eindigt op {{date}}. Tot die tijd kan iedereen Alga PSA blijven gebruiken.",
+    "currentBillingPeriod": "het einde van uw huidige factureringsperiode",
+    "replacesScheduledChange": "Dit vervangt uw geplande licentiewijziging.",
+    "reasonLabel": "Reden (optioneel)",
     "reasonPlaceholder": "Selecteer een reden",
-    "reasonRequired": "Selecteer een reden om door te gaan.",
-    "otherReasonHelp": "Vertel ons iets meer over wat tot uw beslissing heeft geleid.",
-    "feedbackLabel": "Waarom verlaat u ons?",
-    "feedbackPlaceholder": "We horen graag uw feedback zodat we kunnen verbeteren. Uw input helpt ons onze klanten beter van dienst te zijn.",
-    "required": "* Verplicht",
-    "minimumCharacters": "Minimaal {{min}} tekens vereist",
-    "charactersRemaining": "{{count}} tekens resterend",
+    "feedbackLabel": "Details (optioneel)",
+    "feedbackPlaceholder": "Voeg details toe die u wilt delen.",
     "reasons": {
       "pricingTooHigh": "Prijzen te hoog",
       "missingFeatures": "Ontbrekende functies die ik nodig heb",

--- a/server/public/locales/pl/msp/account.json
+++ b/server/public/locales/pl/msp/account.json
@@ -30,12 +30,7 @@
     "aiCheckoutFailed": "Nie udało się rozpocząć płatności za AI Assistant",
     "aiRemoved": "AI Assistant zostanie usunięty z Twojej subskrypcji.",
     "aiCancelFailed": "Nie udało się anulować AI Assistant",
-    "feedbackReasonRequired": "Podaj powód anulowania",
-    "feedbackCategoryRequired": "Wybierz powód anulowania",
-    "feedbackMinimumLength": "Podaj co najmniej {{min}} znaków opinii",
-    "feedbackMaxLength": "Opinia musi zawierać {{max}} znaków lub mniej",
-    "feedbackSubmitted": "Dziękujemy za opinię. Otrzymaliśmy Twoją prośbę o anulowanie. Zostaniesz wkrótce wylogowany.",
-    "feedbackSubmitFailed": "Nie udało się przesłać opinii. Spróbuj ponownie."
+    "cancellationScheduled": "Subskrypcja anulowana. Możesz nadal korzystać z Alga PSA do końca okresu rozliczeniowego."
   },
   "common": {
     "loading": "Ładowanie...",
@@ -204,7 +199,8 @@
   "dangerZone": {
     "title": "Strefa Niebezpieczna",
     "body": "Anulowanie subskrypcji wyłączy dostęp dla wszystkich użytkowników na koniec bieżącego okresu rozliczeniowego.",
-    "cancelSubscription": "Anuluj Subskrypcję"
+    "cancelSubscription": "Anuluj Subskrypcję",
+    "scheduledBody": "Subskrypcja zakończy się {{date}}. Do tego czasu wszyscy mogą nadal korzystać z Alga PSA."
   },
   "aiCheckoutDialog": {
     "title": "Dodaj AI Assistant",
@@ -344,19 +340,14 @@
   "cancellationModal": {
     "title": "Anuluj Subskrypcję",
     "keepSubscription": "Zachowaj Subskrypcję",
-    "submitting": "Wysyłanie...",
-    "submitFeedback": "Wyślij Opinię",
-    "beforeYouCancel": "Zanim anulujesz",
-    "beforeYouCancelBody": "Chcielibyśmy usłyszeć Twoją opinię, która pomoże nam ulepszyć naszą usługę. Twój wkład jest dla nas cenny.",
-    "reasonLabel": "Powód Anulowania",
+    "canceling": "Anulowanie...",
+    "beforeYouCancelBody": "Subskrypcja zakończy się {{date}}. Do tego czasu wszyscy mogą nadal korzystać z Alga PSA.",
+    "currentBillingPeriod": "koniec bieżącego okresu rozliczeniowego",
+    "replacesScheduledChange": "To zastępuje zaplanowaną zmianę licencji.",
+    "reasonLabel": "Powód (opcjonalnie)",
     "reasonPlaceholder": "Wybierz powód",
-    "reasonRequired": "Wybierz powód, aby kontynuować.",
-    "otherReasonHelp": "Opisz nieco dokładniej, co wpłynęło na Twoją decyzję.",
-    "feedbackLabel": "Dlaczego nas opuszczasz?",
-    "feedbackPlaceholder": "Chcielibyśmy usłyszeć Twoją opinię, abyśmy mogli się poprawić. Twój wkład pomaga nam lepiej obsługiwać naszych klientów.",
-    "required": "* Wymagane",
-    "minimumCharacters": "Wymagane jest co najmniej {{min}} znaków",
-    "charactersRemaining": "Pozostało {{count}} znaków",
+    "feedbackLabel": "Szczegóły (opcjonalnie)",
+    "feedbackPlaceholder": "Dodaj szczegóły, którymi chcesz się podzielić.",
     "reasons": {
       "pricingTooHigh": "Zbyt wysokie ceny",
       "missingFeatures": "Brakuje funkcji, których potrzebuję",

--- a/server/public/locales/pt/msp/account.json
+++ b/server/public/locales/pt/msp/account.json
@@ -30,12 +30,7 @@
     "aiCheckoutFailed": "Falha ao iniciar a finalização da compra do IA Assistant",
     "aiRemoved": "O IA Assistant será removido da sua assinatura.",
     "aiCancelFailed": "Falha ao cancelar o IA Assistant",
-    "feedbackReasonRequired": "Forneça um motivo para o cancelamento",
-    "feedbackCategoryRequired": "Selecione um motivo para o cancelamento",
-    "feedbackMinimumLength": "Forneça pelo menos {{min}} caracteres de feedback",
-    "feedbackMaxLength": "O feedback deve ter caracteres {{max}} ou menos",
-    "feedbackSubmitted": "Obrigado pelo seu feedback. Recebemos sua solicitação de cancelamento. Você será desconectado em breve.",
-    "feedbackSubmitFailed": "Falha ao enviar comentários. Por favor, tente novamente."
+    "cancellationScheduled": "Assinatura cancelada. Você pode continuar usando o Alga PSA até o fim do período de cobrança."
   },
   "common": {
     "loading": "Carregando...",
@@ -204,7 +199,8 @@
   "dangerZone": {
     "title": "Zona de perigo",
     "body": "O cancelamento da sua assinatura desativará o acesso de todos os usuários no final do período de cobrança atual.",
-    "cancelSubscription": "Cancelar assinatura"
+    "cancelSubscription": "Cancelar assinatura",
+    "scheduledBody": "Sua assinatura terminará em {{date}}. Até lá, todos poderão continuar usando o Alga PSA."
   },
   "aiCheckoutDialog": {
     "title": "Adicionar assistente de IA",
@@ -344,19 +340,14 @@
   "cancellationModal": {
     "title": "Cancelar assinatura",
     "keepSubscription": "Manter assinatura",
-    "submitting": "Enviando...",
-    "submitFeedback": "Enviar comentários",
-    "beforeYouCancel": "Antes de cancelar",
-    "beforeYouCancelBody": "Adoraríamos ouvir seus comentários para nos ajudar a melhorar nosso serviço. Sua opinião é valiosa para nós.",
-    "reasonLabel": "Motivo do cancelamento",
+    "canceling": "Cancelando...",
+    "beforeYouCancelBody": "Sua assinatura terminará em {{date}}. Até lá, todos poderão continuar usando o Alga PSA.",
+    "currentBillingPeriod": "o fim do período de cobrança atual",
+    "replacesScheduledChange": "Isso substitui a alteração de licença programada.",
+    "reasonLabel": "Motivo (opcional)",
     "reasonPlaceholder": "Selecione um motivo",
-    "reasonRequired": "Selecione um motivo para continuar.",
-    "otherReasonHelp": "Conte-nos um pouco mais sobre o que levou à sua decisão.",
-    "feedbackLabel": "Por que você está nos deixando?",
-    "feedbackPlaceholder": "Adoraríamos ouvir seus comentários para que possamos melhorar. Sua opinião nos ajuda a atender melhor nossos clientes.",
-    "required": "* Obrigatório",
-    "minimumCharacters": "Pelo menos {{min}} caracteres são necessários",
-    "charactersRemaining": "Caracteres {{count}} restantes",
+    "feedbackLabel": "Detalhes (opcional)",
+    "feedbackPlaceholder": "Adicione os detalhes que quiser compartilhar.",
     "reasons": {
       "pricingTooHigh": "Preço muito alto",
       "missingFeatures": "Recursos ausentes que preciso",

--- a/server/public/locales/xx/msp/account.json
+++ b/server/public/locales/xx/msp/account.json
@@ -30,12 +30,7 @@
     "aiCheckoutFailed": "11111",
     "aiRemoved": "11111",
     "aiCancelFailed": "11111",
-    "feedbackReasonRequired": "11111",
-    "feedbackCategoryRequired": "11111",
-    "feedbackMinimumLength": "11111 {{min}} 11111",
-    "feedbackMaxLength": "11111 {{max}} 11111",
-    "feedbackSubmitted": "11111",
-    "feedbackSubmitFailed": "11111"
+    "cancellationScheduled": "11111"
   },
   "common": {
     "loading": "11111",
@@ -204,7 +199,8 @@
   "dangerZone": {
     "title": "11111",
     "body": "11111",
-    "cancelSubscription": "11111"
+    "cancelSubscription": "11111",
+    "scheduledBody": "11111 {{date}} 11111"
   },
   "aiCheckoutDialog": {
     "title": "11111",
@@ -344,19 +340,14 @@
   "cancellationModal": {
     "title": "11111",
     "keepSubscription": "11111",
-    "submitting": "11111",
-    "submitFeedback": "11111",
-    "beforeYouCancel": "11111",
-    "beforeYouCancelBody": "11111",
+    "canceling": "11111",
+    "beforeYouCancelBody": "11111 {{date}} 11111",
+    "currentBillingPeriod": "11111",
+    "replacesScheduledChange": "11111",
     "reasonLabel": "11111",
     "reasonPlaceholder": "11111",
-    "reasonRequired": "11111",
-    "otherReasonHelp": "11111",
     "feedbackLabel": "11111",
     "feedbackPlaceholder": "11111",
-    "required": "11111",
-    "minimumCharacters": "11111 {{min}} 11111",
-    "charactersRemaining": "11111 {{count}} 11111",
     "reasons": {
       "pricingTooHigh": "11111",
       "missingFeatures": "11111",

--- a/server/public/locales/yy/msp/account.json
+++ b/server/public/locales/yy/msp/account.json
@@ -30,12 +30,7 @@
     "aiCheckoutFailed": "55555",
     "aiRemoved": "55555",
     "aiCancelFailed": "55555",
-    "feedbackReasonRequired": "55555",
-    "feedbackCategoryRequired": "55555",
-    "feedbackMinimumLength": "55555 {{min}} 55555",
-    "feedbackMaxLength": "55555 {{max}} 55555",
-    "feedbackSubmitted": "55555",
-    "feedbackSubmitFailed": "55555"
+    "cancellationScheduled": "55555"
   },
   "common": {
     "loading": "55555",
@@ -204,7 +199,8 @@
   "dangerZone": {
     "title": "55555",
     "body": "55555",
-    "cancelSubscription": "55555"
+    "cancelSubscription": "55555",
+    "scheduledBody": "55555 {{date}} 55555"
   },
   "aiCheckoutDialog": {
     "title": "55555",
@@ -344,19 +340,14 @@
   "cancellationModal": {
     "title": "55555",
     "keepSubscription": "55555",
-    "submitting": "55555",
-    "submitFeedback": "55555",
-    "beforeYouCancel": "55555",
-    "beforeYouCancelBody": "55555",
+    "canceling": "55555",
+    "beforeYouCancelBody": "55555 {{date}} 55555",
+    "currentBillingPeriod": "55555",
+    "replacesScheduledChange": "55555",
     "reasonLabel": "55555",
     "reasonPlaceholder": "55555",
-    "reasonRequired": "55555",
-    "otherReasonHelp": "55555",
     "feedbackLabel": "55555",
     "feedbackPlaceholder": "55555",
-    "required": "55555",
-    "minimumCharacters": "55555 {{min}} 55555",
-    "charactersRemaining": "55555 {{count}} 55555",
     "reasons": {
       "pricingTooHigh": "55555",
       "missingFeatures": "55555",


### PR DESCRIPTION
## What changed

- make cancellation reason and details optional with no arbitrary length limits
- label and style the destructive action accurately, show the access end date, and preserve a durable scheduled-cancellation state
- schedule cancellation before sending optional feedback; skip blank feedback and keep feedback delivery off the critical path
- keep administrators signed in and prevent dismissing the dialog while cancellation is running
- escape dynamic cancellation-feedback email HTML and associate form labels with their controls
- update cancellation copy across supported locales

## Why

The previous dialog gated cancellation on mandatory 20–500 character feedback, disguised the destructive action as “Submit Feedback,” and allowed a feedback-email failure to block cancellation. It also omitted the effective end date and logged the administrator out even though access continued through the billing period.

## Validation

- 16 focused EE cancellation unit tests
- cancellation-feedback email escaping test
- EE server TypeScript check
- email package TypeScript check
- UI package TypeScript check
- JSON parsing for all 10 affected locale files