### PR TITLE
fix: Microsoft 365 mailbox connect (User.Read) + allow Microsoft as EE outbound provider

### DIFF
--- a/ee/server/src/__tests__/unit/ManagedEmailSettings.actions.test.tsx
+++ b/ee/server/src/__tests__/unit/ManagedEmailSettings.actions.test.tsx
@@ -15,6 +15,7 @@ const {
   updateEmailSettingsMock,
   getEmailProvidersMock,
   testOutboundEmailMock,
+  getMicrosoftOutboundMailboxesMock,
   toastSuccessMock,
   toastErrorMock,
   tierContextState,
@@ -27,6 +28,7 @@ const {
   updateEmailSettingsMock: vi.fn(),
   getEmailProvidersMock: vi.fn(),
   testOutboundEmailMock: vi.fn(),
+  getMicrosoftOutboundMailboxesMock: vi.fn(),
   toastSuccessMock: vi.fn(),
   toastErrorMock: vi.fn(),
   tierContextState: { isHosted: true },
@@ -44,6 +46,7 @@ vi.mock('@alga-psa/integrations/actions', () => ({
   updateEmailSettings: updateEmailSettingsMock,
   getEmailProviders: getEmailProvidersMock,
   testOutboundEmail: testOutboundEmailMock,
+  getMicrosoftOutboundMailboxes: getMicrosoftOutboundMailboxesMock,
 }));
 
 vi.mock('@alga-psa/email/providerConfig', () => ({
@@ -244,6 +247,8 @@ describe('ManagedEmailSettings removal actions', () => {
     updateEmailSettingsMock.mockReset();
     getEmailProvidersMock.mockReset();
     testOutboundEmailMock.mockReset();
+    getMicrosoftOutboundMailboxesMock.mockReset();
+    getMicrosoftOutboundMailboxesMock.mockResolvedValue({ mailboxes: [] });
     toastSuccessMock.mockReset();
     toastErrorMock.mockReset();
     tierContextState.isHosted = true;
@@ -333,6 +338,8 @@ describe('ManagedEmailSettings outbound SMTP test and TLS controls', () => {
     updateEmailSettingsMock.mockReset();
     getEmailProvidersMock.mockReset();
     testOutboundEmailMock.mockReset();
+    getMicrosoftOutboundMailboxesMock.mockReset();
+    getMicrosoftOutboundMailboxesMock.mockResolvedValue({ mailboxes: [] });
     toastSuccessMock.mockReset();
     toastErrorMock.mockReset();
     tierContextState.isHosted = true;
@@ -427,7 +434,7 @@ describe('ManagedEmailSettings outbound SMTP test and TLS controls', () => {
     });
   });
 
-  it('shows only SMTP on self-host without loading managed domains', async () => {
+  it('offers SMTP and Microsoft but not managed email on self-host', async () => {
     tierContextState.isHosted = false;
     getManagedEmailDomainsMock.mockRejectedValue(new Error('managed domains should not load'));
     getEmailSettingsMock.mockResolvedValue(baseSettings);
@@ -441,10 +448,81 @@ describe('ManagedEmailSettings outbound SMTP test and TLS controls', () => {
       expect(getEmailSettingsMock).toHaveBeenCalled();
     });
     expect(getManagedEmailDomainsMock).not.toHaveBeenCalled();
-    expect(document.getElementById('outbound-provider-select')).toBeNull();
+
+    // Self-host can send via its own SMTP relay or an authorized Microsoft 365
+    // mailbox, but never via the hosted (Resend) managed sender.
+    const providerSelect = document.getElementById('outbound-provider-select') as HTMLSelectElement | null;
+    expect(providerSelect).not.toBeNull();
+    const offered = Array.from(providerSelect!.options).map(option => option.value);
+    expect(offered).toContain('smtp');
+    expect(offered).toContain('microsoft');
+    expect(offered).not.toContain('resend');
+
     expect(
       screen.queryByText(/Managed email domains are not available on your current plan/i)
     ).not.toBeInTheDocument();
+  });
+
+  it('switching to Microsoft saves the connected mailbox as the outbound sender', async () => {
+    tierContextState.isHosted = false;
+    getEmailSettingsMock.mockResolvedValue(baseSettings);
+    getEmailProvidersMock.mockResolvedValue({ providers: [] });
+    getMicrosoftOutboundMailboxesMock.mockResolvedValue({
+      mailboxes: [{
+        providerId: 'ms-provider-1',
+        providerName: 'Support Mailbox',
+        mailbox: 'support@acme.com',
+        senderDisplayName: 'Acme Support',
+        status: 'connected',
+      }],
+    });
+    updateEmailSettingsMock.mockResolvedValue({
+      ...baseSettings,
+      emailProvider: 'microsoft',
+      providerConfigs: [],
+    });
+
+    render(<ManagedEmailSettings />);
+
+    await waitFor(() => {
+      expect(document.getElementById('outbound-provider-select')).not.toBeNull();
+    });
+    fireEvent.change(document.getElementById('outbound-provider-select')!, {
+      target: { value: 'microsoft' },
+    });
+
+    await waitFor(() => {
+      expect(updateEmailSettingsMock).toHaveBeenCalled();
+    });
+
+    // The save must name the mailbox; updateEmailSettings rejects a Microsoft
+    // selection whose config carries no inboundProviderId.
+    const saved = updateEmailSettingsMock.mock.calls.at(-1)![0];
+    expect(saved.emailProvider).toBe('microsoft');
+    const msConfig = saved.providerConfigs.find((c: any) => c.providerType === 'microsoft');
+    expect(msConfig.config.inboundProviderId).toBe('ms-provider-1');
+    expect(msConfig.config.from).toBe('support@acme.com');
+  });
+
+  it('refuses to switch to Microsoft when no mailbox is authorized', async () => {
+    tierContextState.isHosted = false;
+    getEmailSettingsMock.mockResolvedValue(baseSettings);
+    getEmailProvidersMock.mockResolvedValue({ providers: [] });
+    getMicrosoftOutboundMailboxesMock.mockResolvedValue({ mailboxes: [] });
+
+    render(<ManagedEmailSettings />);
+
+    await waitFor(() => {
+      expect(document.getElementById('outbound-provider-select')).not.toBeNull();
+    });
+    fireEvent.change(document.getElementById('outbound-provider-select')!, {
+      target: { value: 'microsoft' },
+    });
+
+    await waitFor(() => {
+      expect(toastErrorMock).toHaveBeenCalled();
+    });
+    expect(updateEmailSettingsMock).not.toHaveBeenCalled();
   });
 
   it('accepts SMTP host input on self-host when provider configs are empty', async () => {

--- a/ee/server/src/components/settings/email/ManagedEmailSettings.tsx
+++ b/ee/server/src/components/settings/email/ManagedEmailSettings.tsx
@@ -36,10 +36,17 @@ import { EmailProviderConfiguration } from '@alga-psa/integrations/components';
 import type { EmailProvider } from '@alga-psa/integrations/components';
 import type { TenantEmailSettings } from 'server/src/types/email.types';
 import { createDefaultProviderConfig } from '@alga-psa/email/providerConfig';
-import { getEmailSettings, updateEmailSettings, getEmailProviders, testOutboundEmail } from '@alga-psa/integrations/actions';
+import {
+  getEmailSettings,
+  updateEmailSettings,
+  getEmailProviders,
+  testOutboundEmail,
+  getMicrosoftOutboundMailboxes,
+  type MicrosoftOutboundMailboxOption,
+} from '@alga-psa/integrations/actions';
 import ManagedDomainList from './ManagedDomainList';
 
-type OutboundProvider = 'resend' | 'smtp';
+type OutboundProvider = 'resend' | 'smtp' | 'microsoft';
 type EmailSettingsUpdateInput = Partial<TenantEmailSettings> & {
   defaultFromDomain?: string | null;
   ticketingFromEmail?: string | null;
@@ -131,6 +138,8 @@ export const ManagedEmailSettings: React.FC<EmailSettingsProps> = () => {
   const [outboundProvider, setOutboundProvider] = useState<OutboundProvider>(
     canUseManagedEmail ? 'resend' : 'smtp'
   );
+  const [microsoftMailboxes, setMicrosoftMailboxes] = useState<MicrosoftOutboundMailboxOption[]>([]);
+  const [microsoftMailboxError, setMicrosoftMailboxError] = useState<string | null>(null);
   const [showSmtpPassword, setShowSmtpPassword] = useState(false);
   const [savingSmtp, setSavingSmtp] = useState(false);
   const [smtpTestRecipient, setSmtpTestRecipient] = useState('');
@@ -189,20 +198,34 @@ export const ManagedEmailSettings: React.FC<EmailSettingsProps> = () => {
     }
   };
 
+  // Self-hosted tenants have no managed (Resend) option, so an unrecognised
+  // stored provider falls back to SMTP rather than something unselectable.
+  const resolveOutboundProvider = (stored: string | null | undefined): OutboundProvider => {
+    if (stored === 'microsoft') return 'microsoft';
+    if (stored === 'smtp') return 'smtp';
+    return canUseManagedEmail ? 'resend' : 'smtp';
+  };
+
   const loadOutboundState = async () => {
     setLoadingOutbound(true);
     try {
-      const [settingsResult, providerResult] = await Promise.all([
+      const [settingsResult, providerResult, mailboxResult] = await Promise.all([
         getEmailSettings(),
-        getEmailProviders()
+        getEmailProviders(),
+        getMicrosoftOutboundMailboxes()
       ]);
       const settings = resolveEmailSettingsResult(settingsResult, t('managed.messages.loadOutboundSettingsFailed'));
 
+      if (isActionMessageError(mailboxResult)) {
+        setMicrosoftMailboxError(getErrorMessage(mailboxResult));
+      } else {
+        setMicrosoftMailboxError(null);
+        setMicrosoftMailboxes(mailboxResult.mailboxes);
+      }
+
       if (settings) {
         setEmailSettings(settings);
-        setOutboundProvider(
-          !canUseManagedEmail ? 'smtp' : settings.emailProvider === 'smtp' ? 'smtp' : 'resend'
-        );
+        setOutboundProvider(resolveOutboundProvider(settings.emailProvider));
       }
 
       const providers = providerResult?.providers || [];
@@ -400,6 +423,39 @@ export const ManagedEmailSettings: React.FC<EmailSettingsProps> = () => {
   };
 
 
+  const getMicrosoftConfig = () =>
+    emailSettings?.providerConfigs.find(c => c.providerType === 'microsoft');
+
+  const microsoftConfigFor = (mailbox: MicrosoftOutboundMailboxOption) => ({
+    inboundProviderId: mailbox.providerId,
+    mailbox: mailbox.mailbox,
+    from: mailbox.mailbox,
+    fromName: mailbox.senderDisplayName || undefined,
+  });
+
+  const handleMicrosoftMailboxSelect = async (providerId: string) => {
+    if (!emailSettings) return;
+    const mailbox = microsoftMailboxes.find(option => option.providerId === providerId);
+    if (!mailbox) return;
+
+    const providerConfigs = emailSettings.providerConfigs.map(config =>
+      config.providerType === 'microsoft'
+        ? { ...config, providerId: mailbox.providerId, config: microsoftConfigFor(mailbox) }
+        : config
+    );
+
+    try {
+      const result = await updateEmailSettings({ emailProvider: 'microsoft', providerConfigs });
+      const updated = resolveEmailSettingsResult(result, t('managed.messages.switchProviderFailed'));
+      if (!updated) return;
+      setEmailSettings(updated);
+      toast.success(t('managed.outbound.microsoft.saved', 'Outbound sending mailbox updated.'));
+    } catch (err: any) {
+      console.error('[ManagedEmailSettings] Failed to select Microsoft mailbox', err);
+      toast.error(err.message || t('managed.messages.switchProviderFailed'));
+    }
+  };
+
   const handleProviderSwitch = async (provider: OutboundProvider) => {
     setOutboundProvider(provider);
 
@@ -418,6 +474,24 @@ export const ManagedEmailSettings: React.FC<EmailSettingsProps> = () => {
     if (!hasProvider) {
       const newConfig = createDefaultProviderConfig(provider, { isEnabled: true });
       updatedSettings.providerConfigs = [...(updatedSettings.providerConfigs || []), newConfig];
+    }
+
+    // updateEmailSettings rejects a Microsoft selection that names no mailbox,
+    // so carry the current choice (or the first connected one) into the switch.
+    if (provider === 'microsoft') {
+      const existing = updatedSettings.providerConfigs?.find(c => c.providerType === 'microsoft');
+      const mailbox = microsoftMailboxes.find(m => m.providerId === existing?.config?.inboundProviderId)
+        || microsoftMailboxes.find(m => m.status === 'connected');
+      if (!mailbox) {
+        toast.error(t('managed.outbound.microsoft.noneConnected', 'Authorize a Microsoft 365 mailbox on the Inbound Email tab first.'));
+        setOutboundProvider(resolveOutboundProvider(emailSettings.emailProvider));
+        return;
+      }
+      updatedSettings.providerConfigs = (updatedSettings.providerConfigs || []).map(config =>
+        config.providerType === 'microsoft'
+          ? { ...config, providerId: mailbox.providerId, config: microsoftConfigFor(mailbox) }
+          : config
+      );
     }
 
     try {
@@ -656,35 +730,30 @@ export const ManagedEmailSettings: React.FC<EmailSettingsProps> = () => {
             </CardDescription>
           </CardHeader>
           <CardContent>
-            {canUseManagedEmail ? (
-              <>
-                <CustomSelect
-                  id="outbound-provider-select"
-                  value={outboundProvider}
-                  disabled={loadingOutbound}
-                  onValueChange={(val: string) => handleProviderSwitch(val as OutboundProvider)}
-                  options={[
-                    { value: 'resend', label: t('managed.outbound.providerOptions.resend') },
-                    { value: 'smtp', label: t('managed.outbound.providerOptions.smtp') }
-                  ]}
-                  placeholder={t('managed.outbound.providerPlaceholder')}
-                />
-                <p className="text-sm text-muted-foreground mt-2">
-                  {outboundProvider === 'resend'
-                    ? t('managed.outbound.resendDescription')
-                    : t('managed.outbound.smtpDescription')}
-                </p>
-              </>
-            ) : (
-              <>
-                <div className="flex items-center gap-2 mb-2">
-                  <span className="text-sm font-medium">{t('managed.outbound.smtpLabel')}</span>
-                </div>
-                <p className="text-sm text-muted-foreground">
-                  {t('managed.outbound.smtpDescription')}
-                </p>
-              </>
-            )}
+            <CustomSelect
+              id="outbound-provider-select"
+              value={outboundProvider}
+              disabled={loadingOutbound}
+              onValueChange={(val: string) => handleProviderSwitch(val as OutboundProvider)}
+              options={[
+                ...(canUseManagedEmail
+                  ? [{ value: 'resend', label: t('managed.outbound.providerOptions.resend') }]
+                  : []),
+                { value: 'smtp', label: t('managed.outbound.providerOptions.smtp') },
+                {
+                  value: 'microsoft',
+                  label: t('managed.outbound.providerOptions.microsoft', 'Microsoft 365 (Microsoft Graph)')
+                }
+              ]}
+              placeholder={t('managed.outbound.providerPlaceholder')}
+            />
+            <p className="text-sm text-muted-foreground mt-2">
+              {outboundProvider === 'resend'
+                ? t('managed.outbound.resendDescription')
+                : outboundProvider === 'microsoft'
+                ? t('managed.outbound.microsoft.description', 'Messages are sent as the selected mailbox through Microsoft Graph and saved to Sent Items.')
+                : t('managed.outbound.smtpDescription')}
+            </p>
           </CardContent>
         </Card>
 
@@ -728,6 +797,49 @@ export const ManagedEmailSettings: React.FC<EmailSettingsProps> = () => {
                 onRefresh={handleRefreshDomain}
                 onDelete={(domain) => setPendingDomainRemoval(domain)}
               />
+            </CardContent>
+          </Card>
+        )}
+
+        {outboundProvider === 'microsoft' && (
+          <Card>
+            <CardHeader>
+              <CardTitle className="flex items-center gap-2">
+                <Mail className="h-5 w-5" />
+                {t('managed.outbound.microsoft.configTitle', 'Microsoft 365 Configuration')}
+              </CardTitle>
+              <CardDescription>
+                {t('managed.outbound.microsoft.configDescription', 'Choose which authorized Microsoft 365 mailbox sends outbound email.')}
+              </CardDescription>
+            </CardHeader>
+            <CardContent className="space-y-3">
+              <div>
+                <Label htmlFor="microsoft-outbound-mailbox">
+                  {t('managed.outbound.microsoft.mailboxLabel', 'Sending Mailbox')}
+                </Label>
+                <CustomSelect
+                  id="microsoft-outbound-mailbox"
+                  value={getMicrosoftConfig()?.config?.inboundProviderId || ''}
+                  disabled={loadingOutbound || microsoftMailboxes.length === 0}
+                  onValueChange={handleMicrosoftMailboxSelect}
+                  options={microsoftMailboxes.map(mailbox => ({
+                    value: mailbox.providerId,
+                    label: `${mailbox.providerName} — ${mailbox.mailbox}${mailbox.status === 'connected' ? '' : ` (${mailbox.status})`}`
+                  }))}
+                  placeholder={t('managed.outbound.microsoft.mailboxPlaceholder', 'Select a connected Microsoft 365 mailbox')}
+                />
+              </div>
+              {microsoftMailboxError ? (
+                <p className="text-sm text-red-600 dark:text-red-400">{microsoftMailboxError}</p>
+              ) : microsoftMailboxes.length === 0 ? (
+                <p className="text-sm text-muted-foreground">
+                  {t('managed.outbound.microsoft.none', 'Add and authorize a Microsoft 365 provider on the Inbound Email tab first.')}
+                </p>
+              ) : (
+                <p className="text-sm text-muted-foreground">
+                  {t('managed.outbound.microsoft.help', 'Messages are sent as this mailbox through Microsoft Graph and saved to Sent Items. Reconnect existing mailboxes to grant Mail.Send.')}
+                </p>
+              )}
             </CardContent>
           </Card>
         )}

--- a/packages/integrations/src/actions/email-actions/index.ts
+++ b/packages/integrations/src/actions/email-actions/index.ts
@@ -3,6 +3,7 @@ export { getEmailProviders, upsertEmailProvider, createEmailProvider, updateEmai
 export { pauseEmailProvider, resumeEmailProvider } from './inboundPauseActions';
 export { getEmailDomains, addEmailDomain, verifyEmailDomain, deleteEmailDomain } from './emailDomainActions';
 export { getEmailSettings, getMicrosoftOutboundMailboxes, updateEmailSettings, testOutboundEmail } from './emailSettingsActions';
+export type { MicrosoftOutboundMailboxOption } from './emailSettingsActions';
 export { getInboundTicketDefaults, createInboundTicketDefaults, updateInboundTicketDefaults, deleteInboundTicketDefaults } from './inboundTicketDefaultsActions';
 export { getInboundEmailRules, createInboundEmailRule, updateInboundEmailRule, setInboundEmailRuleActive, deleteInboundEmailRule, reorderInboundEmailRules, testInboundEmailRule } from './inboundEmailRulesActions';
 export { getTicketFieldOptions } from './ticketFieldOptionsActions';

--- a/packages/integrations/src/actions/index.ts
+++ b/packages/integrations/src/actions/index.ts
@@ -82,6 +82,7 @@ export {
   updateEmailSettings,
   testOutboundEmail
 } from './email-actions/emailSettingsActions';
+export type { MicrosoftOutboundMailboxOption } from './email-actions/emailSettingsActions';
 export {
   getInboundTicketDefaults,
   createInboundTicketDefaults,

--- a/packages/integrations/src/lib/microsoftEmailSetup.test.ts
+++ b/packages/integrations/src/lib/microsoftEmailSetup.test.ts
@@ -44,6 +44,7 @@ describe('Microsoft email setup builders', () => {
         { id: MICROSOFT_EMAIL_DELEGATED_PERMISSION_IDS.mailRead, type: 'Scope' },
         { id: MICROSOFT_EMAIL_DELEGATED_PERMISSION_IDS.mailReadShared, type: 'Scope' },
         { id: MICROSOFT_EMAIL_DELEGATED_PERMISSION_IDS.offlineAccess, type: 'Scope' },
+        { id: MICROSOFT_EMAIL_DELEGATED_PERMISSION_IDS.userRead, type: 'Scope' },
       ],
     }]);
     expect(JSON.stringify(manifest)).not.toContain('Mail.Send');

--- a/packages/integrations/src/lib/microsoftEmailSetup.ts
+++ b/packages/integrations/src/lib/microsoftEmailSetup.ts
@@ -6,6 +6,10 @@ export const MICROSOFT_EMAIL_DELEGATED_PERMISSION_IDS = {
   mailRead: '570282fd-fa5c-430d-a7fd-fc8dc98a9dca',
   mailReadShared: '7b9103a5-4610-446b-9670-80643382c1fa',
   offlineAccess: '7427e0e9-2fba-42fe-b0c0-848c9e6a8182',
+  // MicrosoftGraphAdapter reads /me to decide between the /me and
+  // /users/{mailbox} paths. Portal-created registrations get User.Read by
+  // default; apps we create must declare it or that call is denied.
+  userRead: 'e1fe6dd8-ba31-4d61-89e7-88639da4683d',
 } as const;
 
 export const MICROSOFT_EMAIL_SETUP_BOOTSTRAP_SCOPES = [

--- a/packages/integrations/src/utils/email/oauthHelpers.test.ts
+++ b/packages/integrations/src/utils/email/oauthHelpers.test.ts
@@ -2,7 +2,7 @@ import { describe, expect, it } from 'vitest';
 import { generateMicrosoftAuthUrl } from './oauthHelpers';
 
 describe('Microsoft email OAuth scopes', () => {
-  it('requests inbound read scopes, Mail.Send, and offline access', () => {
+  it('requests inbound read scopes, Mail.Send, User.Read, and offline access', () => {
     const url = new URL(generateMicrosoftAuthUrl(
       'client-id',
       'https://app.example/api/auth/microsoft/callback',
@@ -18,6 +18,7 @@ describe('Microsoft email OAuth scopes', () => {
       'https://graph.microsoft.com/Mail.Read',
       'https://graph.microsoft.com/Mail.Read.Shared',
       'https://graph.microsoft.com/Mail.Send',
+      'https://graph.microsoft.com/User.Read',
       'offline_access',
     ]);
     expect(url.searchParams.get('prompt')).toBe('consent');

--- a/server/public/locales/de/msp/email-providers.json
+++ b/server/public/locales/de/msp/email-providers.json
@@ -773,7 +773,8 @@
       "providerPlaceholder": "Ausgehenden Anbieter auswählen",
       "providerOptions": {
         "resend": "Nine Minds verwaltet",
-        "smtp": "SMTP"
+        "smtp": "SMTP",
+        "microsoft": "Microsoft 365 (Microsoft Graph)"
       },
       "resendDescription": "E-Mails werden über die verwaltete Infrastruktur von Nine Minds gesendet. Fügen Sie unten eine benutzerdefinierte Domain hinzu und verifizieren Sie sie.",
       "smtpDescription": "E-Mails werden über Ihren eigenen SMTP-Server gesendet.",
@@ -841,6 +842,18 @@
         "clearButton": "Absenderadresse löschen",
         "savingButton": "Speichern…",
         "saveButton": "Absenderadresse speichern"
+      },
+      "microsoft": {
+        "configTitle": "Microsoft 365-Konfiguration",
+        "configDescription": "Wählen Sie das autorisierte Microsoft 365-Postfach für den E-Mail-Versand.",
+        "mailboxLabel": "Sendepostfach",
+        "mailboxPlaceholder": "Verbundenes Microsoft 365-Postfach auswählen",
+        "help": "Nachrichten werden über Microsoft Graph als dieses Postfach gesendet und in „Gesendete Elemente“ gespeichert. Verbinden Sie bestehende Postfächer neu, um Mail.Send zu gewähren.",
+        "none": "Fügen Sie zuerst auf der Registerkarte „Eingehende E-Mail“ einen Microsoft 365-Anbieter hinzu und autorisieren Sie ihn.",
+        "noneConnected": "Autorisieren Sie zuerst ein Microsoft 365-Postfach auf der Registerkarte „Eingehende E-Mail“.",
+        "description": "Nachrichten werden über Microsoft Graph als das ausgewählte Postfach gesendet und in „Gesendete Elemente“ gespeichert.",
+        "loadFailed": "Microsoft 365-Postfächer konnten nicht geladen werden.",
+        "saved": "Sendepostfach aktualisiert."
       }
     },
     "inbound": {

--- a/server/public/locales/en/msp/email-providers.json
+++ b/server/public/locales/en/msp/email-providers.json
@@ -773,7 +773,8 @@
       "providerPlaceholder": "Select outbound provider",
       "providerOptions": {
         "resend": "Nine Minds Managed",
-        "smtp": "SMTP"
+        "smtp": "SMTP",
+        "microsoft": "Microsoft 365 (Microsoft Graph)"
       },
       "resendDescription": "Emails are sent through Nine Minds managed infrastructure. Add and verify a custom domain below.",
       "smtpDescription": "Emails are sent through your own SMTP server.",
@@ -841,6 +842,18 @@
         "clearButton": "Clear From Address",
         "savingButton": "Saving...",
         "saveButton": "Save From Address"
+      },
+      "microsoft": {
+        "configTitle": "Microsoft 365 Configuration",
+        "configDescription": "Choose which authorized Microsoft 365 mailbox sends outbound email.",
+        "mailboxLabel": "Sending Mailbox",
+        "mailboxPlaceholder": "Select a connected Microsoft 365 mailbox",
+        "help": "Messages are sent as this mailbox through Microsoft Graph and saved to Sent Items. Reconnect existing mailboxes to grant Mail.Send.",
+        "none": "Add and authorize a Microsoft 365 provider on the Inbound Email tab first.",
+        "noneConnected": "Authorize a Microsoft 365 mailbox on the Inbound Email tab first.",
+        "description": "Messages are sent as the selected mailbox through Microsoft Graph and saved to Sent Items.",
+        "loadFailed": "Could not load Microsoft 365 mailboxes.",
+        "saved": "Outbound sending mailbox updated."
       }
     },
     "inbound": {

--- a/server/public/locales/es/msp/email-providers.json
+++ b/server/public/locales/es/msp/email-providers.json
@@ -773,7 +773,8 @@
       "providerPlaceholder": "Seleccione el proveedor saliente",
       "providerOptions": {
         "resend": "Nine Minds administrado",
-        "smtp": "SMTP"
+        "smtp": "SMTP",
+        "microsoft": "Microsoft 365 (Microsoft Graph)"
       },
       "resendDescription": "Los correos se envían a través de la infraestructura administrada de Nine Minds. Añada y verifique un dominio personalizado a continuación.",
       "smtpDescription": "Los correos se envían a través de su propio servidor SMTP.",
@@ -841,6 +842,18 @@
         "clearButton": "Borrar dirección de remitente",
         "savingButton": "Guardando…",
         "saveButton": "Guardar dirección de remitente"
+      },
+      "microsoft": {
+        "configTitle": "Configuración de Microsoft 365",
+        "configDescription": "Elija qué buzón autorizado de Microsoft 365 envía el correo saliente.",
+        "mailboxLabel": "Buzón de envío",
+        "mailboxPlaceholder": "Seleccione un buzón de Microsoft 365 conectado",
+        "help": "Los mensajes se envían como este buzón a través de Microsoft Graph y se guardan en Elementos enviados. Vuelva a conectar los buzones existentes para conceder Mail.Send.",
+        "none": "Primero agregue y autorice un proveedor de Microsoft 365 en la pestaña Correo entrante.",
+        "noneConnected": "Primero autorice un buzón de Microsoft 365 en la pestaña Correo entrante.",
+        "description": "Los mensajes se envían como el buzón seleccionado a través de Microsoft Graph y se guardan en Elementos enviados.",
+        "loadFailed": "No se pudieron cargar los buzones de Microsoft 365.",
+        "saved": "Buzón de envío actualizado."
       }
     },
     "inbound": {

--- a/server/public/locales/fr/msp/email-providers.json
+++ b/server/public/locales/fr/msp/email-providers.json
@@ -773,7 +773,8 @@
       "providerPlaceholder": "Sélectionnez un fournisseur sortant",
       "providerOptions": {
         "resend": "Nine Minds géré",
-        "smtp": "SMTP"
+        "smtp": "SMTP",
+        "microsoft": "Microsoft 365 (Microsoft Graph)"
       },
       "resendDescription": "Les e-mails sont envoyés via l'infrastructure gérée de Nine Minds. Ajoutez et vérifiez un domaine personnalisé ci-dessous.",
       "smtpDescription": "Les e-mails sont envoyés via votre propre serveur SMTP.",
@@ -841,6 +842,18 @@
         "clearButton": "Effacer l'adresse d'expéditeur",
         "savingButton": "Enregistrement…",
         "saveButton": "Enregistrer l'adresse d'expéditeur"
+      },
+      "microsoft": {
+        "configTitle": "Configuration Microsoft 365",
+        "configDescription": "Choisissez la boîte aux lettres Microsoft 365 autorisée qui envoie les e-mails sortants.",
+        "mailboxLabel": "Boîte aux lettres d'envoi",
+        "mailboxPlaceholder": "Sélectionnez une boîte aux lettres Microsoft 365 connectée",
+        "help": "Les messages sont envoyés depuis cette boîte aux lettres via Microsoft Graph et enregistrés dans Éléments envoyés. Reconnectez les boîtes existantes pour accorder Mail.Send.",
+        "none": "Ajoutez et autorisez d'abord un fournisseur Microsoft 365 dans l'onglet E-mail entrant.",
+        "noneConnected": "Autorisez d'abord une boîte aux lettres Microsoft 365 dans l'onglet E-mail entrant.",
+        "description": "Les messages sont envoyés depuis la boîte sélectionnée via Microsoft Graph et enregistrés dans Éléments envoyés.",
+        "loadFailed": "Impossible de charger les boîtes aux lettres Microsoft 365.",
+        "saved": "Boîte aux lettres d'envoi mise à jour."
       }
     },
     "inbound": {

--- a/server/public/locales/it/msp/email-providers.json
+++ b/server/public/locales/it/msp/email-providers.json
@@ -773,7 +773,8 @@
       "providerPlaceholder": "Seleziona il provider in uscita",
       "providerOptions": {
         "resend": "Nine Minds gestito",
-        "smtp": "SMTP"
+        "smtp": "SMTP",
+        "microsoft": "Microsoft 365 (Microsoft Graph)"
       },
       "resendDescription": "Le email vengono inviate tramite l'infrastruttura gestita di Nine Minds. Aggiungi e verifica un dominio personalizzato di seguito.",
       "smtpDescription": "Le email vengono inviate tramite il tuo server SMTP.",
@@ -841,6 +842,18 @@
         "clearButton": "Cancella indirizzo mittente",
         "savingButton": "Salvataggio…",
         "saveButton": "Salva indirizzo mittente"
+      },
+      "microsoft": {
+        "configTitle": "Configurazione Microsoft 365",
+        "configDescription": "Scegli quale casella di posta Microsoft 365 autorizzata invia la posta in uscita.",
+        "mailboxLabel": "Casella di invio",
+        "mailboxPlaceholder": "Seleziona una casella Microsoft 365 collegata",
+        "help": "I messaggi vengono inviati da questa casella tramite Microsoft Graph e salvati in Posta inviata. Ricollega le caselle esistenti per concedere Mail.Send.",
+        "none": "Aggiungi e autorizza prima un provider Microsoft 365 nella scheda Posta in arrivo.",
+        "noneConnected": "Autorizza prima una casella Microsoft 365 nella scheda Posta in arrivo.",
+        "description": "I messaggi vengono inviati dalla casella selezionata tramite Microsoft Graph e salvati in Posta inviata.",
+        "loadFailed": "Impossibile caricare le caselle Microsoft 365.",
+        "saved": "Casella di invio aggiornata."
       }
     },
     "inbound": {

--- a/server/public/locales/nl/msp/email-providers.json
+++ b/server/public/locales/nl/msp/email-providers.json
@@ -773,7 +773,8 @@
       "providerPlaceholder": "Selecteer uitgaande provider",
       "providerOptions": {
         "resend": "Nine Minds beheerd",
-        "smtp": "SMTP"
+        "smtp": "SMTP",
+        "microsoft": "Microsoft 365 (Microsoft Graph)"
       },
       "resendDescription": "E-mails worden verzonden via de beheerde infrastructuur van Nine Minds. Voeg hieronder een aangepast domein toe en verifieer dit.",
       "smtpDescription": "E-mails worden verzonden via uw eigen SMTP-server.",
@@ -841,6 +842,18 @@
         "clearButton": "Afzenderadres wissen",
         "savingButton": "Opslaan…",
         "saveButton": "Afzenderadres opslaan"
+      },
+      "microsoft": {
+        "configTitle": "Microsoft 365-configuratie",
+        "configDescription": "Kies welke geautoriseerde Microsoft 365-mailbox uitgaande e-mail verstuurt.",
+        "mailboxLabel": "Verzendmailbox",
+        "mailboxPlaceholder": "Selecteer een verbonden Microsoft 365-mailbox",
+        "help": "Berichten worden via Microsoft Graph als deze mailbox verzonden en opgeslagen in Verzonden items. Verbind bestaande mailboxen opnieuw om Mail.Send te verlenen.",
+        "none": "Voeg eerst een Microsoft 365-provider toe en autoriseer deze op het tabblad Inkomende e-mail.",
+        "noneConnected": "Autoriseer eerst een Microsoft 365-mailbox op het tabblad Inkomende e-mail.",
+        "description": "Berichten worden via Microsoft Graph als de geselecteerde mailbox verzonden en opgeslagen in Verzonden items.",
+        "loadFailed": "Microsoft 365-mailboxen konden niet worden geladen.",
+        "saved": "Verzendmailbox bijgewerkt."
       }
     },
     "inbound": {

--- a/server/public/locales/pl/msp/email-providers.json
+++ b/server/public/locales/pl/msp/email-providers.json
@@ -773,7 +773,8 @@
       "providerPlaceholder": "Wybierz dostawcę poczty wychodzącej",
       "providerOptions": {
         "resend": "Zarządzany Nine Minds",
-        "smtp": "SMTP"
+        "smtp": "SMTP",
+        "microsoft": "Microsoft 365 (Microsoft Graph)"
       },
       "resendDescription": "Wiadomości są wysyłane przez zarządzaną infrastrukturę Nine Minds. Dodaj i zweryfikuj niestandardową domenę poniżej.",
       "smtpDescription": "Wiadomości są wysyłane przez Twój własny serwer SMTP.",
@@ -841,6 +842,18 @@
         "clearButton": "Wyczyść adres nadawcy",
         "savingButton": "Zapisywanie…",
         "saveButton": "Zapisz adres nadawcy"
+      },
+      "microsoft": {
+        "configTitle": "Konfiguracja Microsoft 365",
+        "configDescription": "Wybierz autoryzowaną skrzynkę Microsoft 365 do wysyłania poczty wychodzącej.",
+        "mailboxLabel": "Skrzynka wysyłkowa",
+        "mailboxPlaceholder": "Wybierz połączoną skrzynkę Microsoft 365",
+        "help": "Wiadomości są wysyłane z tej skrzynki przez Microsoft Graph i zapisywane w Elementach wysłanych. Połącz ponownie istniejące skrzynki, aby przyznać Mail.Send.",
+        "none": "Najpierw dodaj i autoryzuj dostawcę Microsoft 365 na karcie Poczta przychodząca.",
+        "noneConnected": "Najpierw autoryzuj skrzynkę Microsoft 365 na karcie Poczta przychodząca.",
+        "description": "Wiadomości są wysyłane z wybranej skrzynki przez Microsoft Graph i zapisywane w Elementach wysłanych.",
+        "loadFailed": "Nie można załadować skrzynek Microsoft 365.",
+        "saved": "Zaktualizowano skrzynkę wysyłkową."
       }
     },
     "inbound": {

--- a/server/public/locales/pt/msp/email-providers.json
+++ b/server/public/locales/pt/msp/email-providers.json
@@ -773,7 +773,8 @@
       "providerPlaceholder": "Selecione o provedor de saída",
       "providerOptions": {
         "resend": "Nove mentes gerenciadas",
-        "smtp": "SMTP"
+        "smtp": "SMTP",
+        "microsoft": "Microsoft 365 (Microsoft Graph)"
       },
       "resendDescription": "Os e-mails são enviados através da infraestrutura gerenciada da Nine Minds. Adicione e verifique um domínio personalizado abaixo.",
       "smtpDescription": "Os e-mails são enviados através do seu próprio servidor SMTP.",
@@ -841,6 +842,18 @@
         "clearButton": "Limpar do endereço",
         "savingButton": "Salvando...",
         "saveButton": "Salvar do endereço"
+      },
+      "microsoft": {
+        "configTitle": "Configuração do Microsoft 365",
+        "configDescription": "Escolha qual caixa de correio autorizada do Microsoft 365 envia e-mails de saída.",
+        "mailboxLabel": "Caixa de correio de envio",
+        "mailboxPlaceholder": "Selecione uma caixa de correio do Microsoft 365 conectada",
+        "help": "As mensagens são enviadas como esta caixa de correio pelo Microsoft Graph e salvas em Itens Enviados. Reconecte caixas existentes para conceder Mail.Send.",
+        "none": "Adicione e autorize primeiro um provedor do Microsoft 365 na aba E-mail de entrada.",
+        "noneConnected": "Autorize primeiro uma caixa de correio do Microsoft 365 na aba E-mail de entrada.",
+        "description": "As mensagens são enviadas como a caixa selecionada pelo Microsoft Graph e salvas em Itens Enviados.",
+        "loadFailed": "Não foi possível carregar as caixas de correio do Microsoft 365.",
+        "saved": "Caixa de correio de envio atualizada."
       }
     },
     "inbound": {

--- a/server/public/locales/xx/msp/email-providers.json
+++ b/server/public/locales/xx/msp/email-providers.json
@@ -773,7 +773,8 @@
       "providerPlaceholder": "11111",
       "providerOptions": {
         "resend": "11111",
-        "smtp": "11111"
+        "smtp": "11111",
+        "microsoft": "11111"
       },
       "resendDescription": "11111",
       "smtpDescription": "11111",
@@ -841,6 +842,18 @@
         "clearButton": "11111",
         "savingButton": "11111",
         "saveButton": "11111"
+      },
+      "microsoft": {
+        "configTitle": "11111",
+        "configDescription": "11111",
+        "mailboxLabel": "11111",
+        "mailboxPlaceholder": "11111",
+        "help": "11111",
+        "none": "11111",
+        "noneConnected": "11111",
+        "description": "11111",
+        "loadFailed": "11111",
+        "saved": "11111"
       }
     },
     "inbound": {

--- a/server/public/locales/yy/msp/email-providers.json
+++ b/server/public/locales/yy/msp/email-providers.json
@@ -773,7 +773,8 @@
       "providerPlaceholder": "55555",
       "providerOptions": {
         "resend": "55555",
-        "smtp": "55555"
+        "smtp": "55555",
+        "microsoft": "55555"
       },
       "resendDescription": "55555",
       "smtpDescription": "55555",
@@ -841,6 +842,18 @@
         "clearButton": "55555",
         "savingButton": "55555",
         "saveButton": "55555"
+      },
+      "microsoft": {
+        "configTitle": "55555",
+        "configDescription": "55555",
+        "mailboxLabel": "55555",
+        "mailboxPlaceholder": "55555",
+        "help": "55555",
+        "none": "55555",
+        "noneConnected": "55555",
+        "description": "55555",
+        "loadFailed": "55555",
+        "saved": "55555"
       }
     },
     "inbound": {

--- a/shared/services/email/microsoftGraphEndpoints.ts
+++ b/shared/services/email/microsoftGraphEndpoints.ts
@@ -5,6 +5,9 @@ export const MICROSOFT_EMAIL_OAUTH_SCOPES = [
   'https://graph.microsoft.com/Mail.Read',
   'https://graph.microsoft.com/Mail.Read.Shared',
   'https://graph.microsoft.com/Mail.Send',
+  // Mailbox path auto-detection reads /me; without this the call is denied
+  // and connect() cannot tell a personal mailbox from a shared one.
+  'https://graph.microsoft.com/User.Read',
   'offline_access',
 ] as const;
 


### PR DESCRIPTION
Two fixes found by smoke testing the Microsoft 365 email feature from #3090 end to end against a real Entra tenant, culminating in a real email delivered through Microsoft Graph.

Independent of #3098 — branched from `main`, no overlapping hunks.

## 1. Mailbox authorization could never connect (blocking)

Authorizing a Microsoft 365 mailbox failed with `403`, and the provider card showed `token_persistence_failed: Error in connect: Request failed with status code 403`.

`MicrosoftGraphAdapter.connect()` calls `loadAuthenticatedUserEmail()`, which reads `/me` to decide whether the configured mailbox is the signed-in user's own (use `/me`) or a shared one (use `/users/{mailbox}`). The mailbox OAuth scopes did not include `User.Read`, so `/me` returned `403 Authorization_RequestDenied`. The adapter fell back to `/users/{mailbox}`, which needs directory permissions it also lacked, so `testConnection()` failed, `connect()` threw, and **the OAuth tokens were never persisted**. The mailbox could never reach `connected`, so outbound sending was impossible.

Why it stayed hidden: Azure grants `User.Read` to portal-created app registrations by default. Registrations provisioned via Graph declare permissions explicitly and didn't include it — so this broke precisely on the automated setup path #3090 introduced.

Fix: request `User.Read` in the mailbox OAuth scopes so the token carries it, and declare it on the provisioned manifest so admin consent covers it rather than prompting each user.

## 2. Microsoft was unreachable as an outbound provider in enterprise

The enterprise Outbound Email tab renders `ManagedEmailSettings`, whose provider type was `'resend' | 'smtp'` only. A tenant that had authorized a Microsoft 365 mailbox for inbound could never select it for outbound, despite the backend, resolver, and `MicrosoftGraphEmailProvider` all supporting it (and a migration already allowing `email_provider='microsoft'`).

Adds Microsoft 365 to the enterprise outbound choices with a sending-mailbox picker showing authorized mailboxes and their connection status. Self-hosted previously rendered *no* selector at all (SMTP was the only option); it now renders one offering SMTP and Microsoft while still withholding the hosted managed sender.

`updateEmailSettings` rejects a Microsoft selection naming no mailbox, so switching carries the current or first connected mailbox into the save and refuses with a clear message when none is authorized.

Scope note: this is enterprise-only by design. The community-edition Pro gate on the Microsoft 365 *inbound* provider is deliberately unchanged.

## Test evidence

Verified against a real Entra tenant, not mocks:

- **Before fix 1:** authorization failed with `403 Authorization_RequestDenied`; provider stuck in `Error`.
- **After fix 1:** logs show `Using /me path for personal mailbox` then `Connected to Microsoft Graph API successfully`; `email_providers` row reaches `status=connected` with no error.
- **After fix 2:** switched the outbound provider Microsoft → SMTP → Microsoft entirely through the dropdown, confirming `tenant_email_settings.email_provider` changed in the database each time and the Microsoft config retained its `inboundProviderId`.
- **Real email sent** from `robert@speedoflightmedia.com` to an external address via Microsoft Graph from that purely UI-driven configuration (Graph request id `5b3a2193-c8ee-4d81-bd30-55c7057b7e4b`), `saveToSentItems` on.
- `ManagedEmailSettings` tests: 11 passing (9 existing plus 2 new covering the Microsoft switch and the no-mailbox refusal).
- `packages/integrations` lib + email utils: passing, including the manifest and OAuth-scope assertions.
- `node scripts/validate-translations.cjs` passes across all 9 non-English locales.
- `tsc --noEmit` clean for `ee/server` and `packages/integrations`. Note the EE typecheck needs `--max-old-space-size=8192`.

## Follow-up not addressed here

Provisioning sets `is_default` on the first profile created for a tenant and a later profile never takes over, so a tenant whose first attempt failed can end up with a stranded profile holding the default flag and shadowing a working one created on retry.