### PR TITLE
helm: source sign-in OAuth from google_sso block

### DIFF
--- a/helm/templates/_helpers.tpl
+++ b/helm/templates/_helpers.tpl
@@ -84,9 +84,17 @@ app.kubernetes.io/instance: {{ .Release.Name }}
 {{- end -}}
 {{- end }}
 
-{{/* Render GOOGLE_OAUTH_* env vars from gmail_integration config */}}
+{{/* Render GOOGLE_OAUTH_* env vars for sign-in SSO. Prefers the dedicated
+     google_sso block; falls back to gmail_integration credentials so releases
+     without google_sso keep their historical behavior. */}}
 {{- define "sebastian.googleOAuthEnv" -}}
-{{- if and .Values.gmail_integration.enabled .Values.gmail_integration.client_id .Values.gmail_integration.client_secret }}
+{{- $sso := .Values.google_sso | default dict }}
+{{- if and $sso.client_id $sso.client_secret }}
+- name: GOOGLE_OAUTH_CLIENT_ID
+  value: "{{ $sso.client_id }}"
+- name: GOOGLE_OAUTH_CLIENT_SECRET
+  value: "{{ $sso.client_secret }}"
+{{- else if and .Values.gmail_integration.enabled .Values.gmail_integration.client_id .Values.gmail_integration.client_secret }}
 - name: GOOGLE_OAUTH_CLIENT_ID
   value: "{{ .Values.gmail_integration.client_id }}"
 - name: GOOGLE_OAUTH_CLIENT_SECRET


### PR DESCRIPTION
GOOGLE_OAUTH_CLIENT_ID/SECRET were always mirrored from the gmail_integration credentials, coupling login SSO to the inbox integration's OAuth client. sebastian.googleOAuthEnv now prefers a dedicated google_sso values block so sign-in can run on its own Google client ("AlgaPSA Identity"), falling back to gmail_integration when the block is absent so existing releases behave unchanged.

"Who are YOU?" said the Caterpillar — and for the first time, sebastian.googleOAuthEnv could answer with its own credentials instead of borrowing the mail-octopus's calling card; though should google_sso ever forget itself, the Gmail post rider will still vouch at the gate. 🐛🔑📬