### PR TITLE
security: serve extension UI with CSP headers

### DIFF
--- a/ee/docs/extension-system/serving-system.md
+++ b/ee/docs/extension-system/serving-system.md
@@ -139,6 +139,8 @@ Gateway:
 
 Runner:
 - `RUNNER_PUBLIC_BASE` — public base for serving ext-ui assets
+- `EXT_UI_FRAME_ANCESTORS` — origin(s) allowed to embed extension UIs; appended as a `frame-ancestors` directive to the default ext-ui CSP (set to the main app origin in production)
+- `EXT_UI_CONTENT_SECURITY_POLICY` — full override of the ext-ui CSP (rarely needed)
 - `SIGNING_TRUST_BUNDLE` — trust anchors for signature verification
 - `EXT_EGRESS_ALLOWLIST` — hostnames allowed for `alga.http.fetch`
 - `RUNNER_DEBUG_REDIS_URL`, `RUNNER_DEBUG_REDIS_MAXLEN`, `RUNNER_DEBUG_MAX_EVENT_BYTES` — enable Redis-backed debug streaming
@@ -160,6 +162,7 @@ Caches:
 - Content-addressed artifacts; hash verification on use; signature verification against trust bundle.
 - Quotas/limits: memory caps, timeouts, and concurrency per tenant/extension.
 - UI isolation: sandboxed iframes; origin validation aligned with `RUNNER_PUBLIC_BASE`.
+- Ext-ui HTML documents are served with a `Content-Security-Policy` header (`default-src 'self'`; inline styles and `data:` images allowed; `frame-ancestors` from `EXT_UI_FRAME_ANCESTORS`) plus `X-Content-Type-Options: nosniff` on all assets. Extensions must use the postMessage UI proxy for data access — direct `fetch()` from the iframe is blocked by `connect-src 'self'` by design.
 
 ## Error Handling, Debugging & Retries
 

--- a/ee/runner/Dockerfile
+++ b/ee/runner/Dockerfile
@@ -1,4 +1,4 @@
-FROM rust:1.91-bullseye as builder
+FROM rust:1.92-bullseye as builder
 WORKDIR /app
 COPY . .
 RUN cargo build --release

--- a/ee/runner/deploy/runner.kservice.yaml
+++ b/ee/runner/deploy/runner.kservice.yaml
@@ -20,6 +20,9 @@ spec:
               value: /etc/alga/trust/trust.pem
             - name: RUNTIME_LIMITS
               value: '{"memory_mb":512,"timeout_ms":5000,"fuel":null}'
+            # Origin(s) allowed to embed extension UIs (frame-ancestors); set to the main app origin.
+            - name: EXT_UI_FRAME_ANCESTORS
+              value: https://app.example.com
           ports:
             - containerPort: 8080
 

--- a/ee/runner/src/http/ext_ui.rs
+++ b/ee/runner/src/http/ext_ui.rs
@@ -290,6 +290,11 @@ pub async fn handle_get(
         Ok(s) => s,
         Err(_) => return StatusCode::INTERNAL_SERVER_ERROR.into_response(),
     };
+    let ct = content_type_for(&file_path);
+    let is_html = ct
+        .to_str()
+        .map(|s| s.starts_with("text/html"))
+        .unwrap_or(false);
     if let Some(inm) = headers
         .get(header::IF_NONE_MATCH)
         .and_then(|v| v.to_str().ok())
@@ -305,6 +310,9 @@ pub async fn handle_get(
                 header::CACHE_CONTROL,
                 HeaderValue::from_static("public, max-age=31536000, immutable"),
             );
+            if is_html {
+                h.insert(header::CONTENT_SECURITY_POLICY, csp_header_value());
+            }
             return (StatusCode::NOT_MODIFIED, h, ()).into_response();
         }
     }
@@ -314,7 +322,6 @@ pub async fn handle_get(
         Ok(b) => b,
         Err(_) => return StatusCode::NOT_FOUND.into_response(),
     };
-    let ct = content_type_for(&file_path);
 
     let mut h = HeaderMap::new();
     h.insert(header::CONTENT_TYPE, ct);
@@ -329,6 +336,13 @@ pub async fn handle_get(
         header::CACHE_CONTROL,
         HeaderValue::from_static("public, max-age=31536000, immutable"),
     );
+    h.insert(
+        header::X_CONTENT_TYPE_OPTIONS,
+        HeaderValue::from_static("nosniff"),
+    );
+    if is_html {
+        h.insert(header::CONTENT_SECURITY_POLICY, csp_header_value());
+    }
 
     // Structured trace
     let dur_ms = started.elapsed().as_millis() as u64;
@@ -359,6 +373,24 @@ pub async fn warmup(_state: State<AppState>, Json(_req): Json<WarmupReq>) -> imp
         "warmup unsupported without tenant + extension context",
     )
         .into_response()
+}
+
+const DEFAULT_CSP: &str = "default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self' data:; font-src 'self'; connect-src 'self'; object-src 'none'; base-uri 'self'; form-action 'self'";
+
+/// CSP for extension HTML documents. EXT_UI_CONTENT_SECURITY_POLICY replaces the
+/// whole policy; EXT_UI_FRAME_ANCESTORS appends a frame-ancestors directive
+/// (e.g. the embedding app origin) to the default policy.
+fn csp_header_value() -> HeaderValue {
+    let policy = match std::env::var("EXT_UI_CONTENT_SECURITY_POLICY") {
+        Ok(v) if !v.trim().is_empty() => v.trim().to_string(),
+        _ => match std::env::var("EXT_UI_FRAME_ANCESTORS") {
+            Ok(v) if !v.trim().is_empty() => {
+                format!("{}; frame-ancestors {}", DEFAULT_CSP, v.trim())
+            }
+            _ => DEFAULT_CSP.to_string(),
+        },
+    };
+    HeaderValue::from_str(&policy).unwrap_or_else(|_| HeaderValue::from_static(DEFAULT_CSP))
 }
 
 fn normalize_hash(content_hash: &str) -> anyhow::Result<String> {

--- a/ee/runner/tests/ext_ui_integration.rs
+++ b/ee/runner/tests/ext_ui_integration.rs
@@ -95,24 +95,44 @@ fn make_bundle_tarzst() -> (Vec<u8>, String) {
 }
 
 async fn start_bundle_http_server(bytes: Vec<u8>) -> (Url, JoinHandle<()>) {
-    // Serve at /sha256/:hex/bundle.tar.zst (hex extracted from request path but we ignore and always return same bytes)
-    let app = Router::new().route(
-        "/sha256/:hex/bundle.tar.zst",
-        get({
-            let blob = Bytes::from(bytes);
-            move || {
-                let b = blob.clone();
-                async move {
-                    let mut h = axum::http::HeaderMap::new();
-                    h.insert(
-                        header::CONTENT_TYPE,
-                        HeaderValue::from_static("application/octet-stream"),
-                    );
-                    (StatusCode::OK, h, b).into_response()
+    // Serve the same bytes at both the legacy /sha256/... path and the
+    // tenant-scoped object key the handler actually requests.
+    let blob = Bytes::from(bytes);
+    let app = Router::new()
+        .route(
+            "/sha256/:hex/bundle.tar.zst",
+            get({
+                let blob = blob.clone();
+                move || {
+                    let b = blob.clone();
+                    async move {
+                        let mut h = axum::http::HeaderMap::new();
+                        h.insert(
+                            header::CONTENT_TYPE,
+                            HeaderValue::from_static("application/octet-stream"),
+                        );
+                        (StatusCode::OK, h, b).into_response()
+                    }
                 }
-            }
-        }),
-    );
+            }),
+        )
+        .route(
+            "/tenants/:tenant/extensions/:ext/sha256/:hex/bundle.tar.zst",
+            get({
+                let blob = blob.clone();
+                move || {
+                    let b = blob.clone();
+                    async move {
+                        let mut h = axum::http::HeaderMap::new();
+                        h.insert(
+                            header::CONTENT_TYPE,
+                            HeaderValue::from_static("application/octet-stream"),
+                        );
+                        (StatusCode::OK, h, b).into_response()
+                    }
+                }
+            }),
+        );
 
     let listener = TcpListener::bind(("127.0.0.1", 0)).await.unwrap();
     let addr = listener.local_addr().unwrap();
@@ -183,8 +203,10 @@ async fn cold_fetch_then_304() {
             .unwrap(),
         ))
         .unwrap();
+    // Warmup is intentionally unsupported without tenant + extension context;
+    // the cold GET below triggers ensure_bundle_cached instead.
     let warm_resp = request::<Json<serde_json::Value>>(&app, warm).await;
-    assert_eq!(warm_resp.status(), StatusCode::OK);
+    assert_eq!(warm_resp.status(), StatusCode::BAD_REQUEST);
 
     // GET index.html
     let get1 = Request::builder()
@@ -230,6 +252,140 @@ async fn cold_fetch_then_304() {
         .unwrap();
     let resp2 = app.clone().oneshot(get2).await.unwrap();
     assert_eq!(resp2.status(), StatusCode::NOT_MODIFIED);
+}
+
+#[tokio::test]
+#[serial]
+async fn csp_and_nosniff_headers() {
+    let (buf, hex) = make_bundle_tarzst();
+    let (base, _handle) = start_bundle_http_server(buf).await;
+
+    let tmpdir = tempfile::tempdir().unwrap();
+    let cache_root = tmpdir.path().to_path_buf();
+    let state = make_test_state(cache_root, base, false, Arc::new(AllowingRegistry));
+    let app = router_for_state(state);
+
+    std::env::remove_var("EXT_UI_CONTENT_SECURITY_POLICY");
+    std::env::remove_var("EXT_UI_FRAME_ANCESTORS");
+
+    // HTML document carries the CSP header
+    let get_html = Request::builder()
+        .method(Method::GET)
+        .uri(format!("/ext-ui/demo-ext/sha256:{}/index.html", hex))
+        .header("x-tenant-id", "tenant-a")
+        .body(Body::empty())
+        .unwrap();
+    let resp = app.clone().oneshot(get_html).await.unwrap();
+    assert_eq!(resp.status(), StatusCode::OK);
+    let csp = resp
+        .headers()
+        .get(header::CONTENT_SECURITY_POLICY)
+        .expect("html should carry CSP")
+        .to_str()
+        .unwrap()
+        .to_string();
+    assert!(csp.contains("default-src 'self'"));
+    assert!(csp.contains("script-src 'self'"));
+    assert!(!csp.contains("frame-ancestors"));
+    assert_eq!(
+        resp.headers().get(header::X_CONTENT_TYPE_OPTIONS).unwrap(),
+        "nosniff"
+    );
+    let etag = resp
+        .headers()
+        .get(header::ETAG)
+        .unwrap()
+        .to_str()
+        .unwrap()
+        .to_string();
+
+    // 304 revalidation of the document carries the CSP too
+    let get_304 = Request::builder()
+        .method(Method::GET)
+        .uri(format!("/ext-ui/demo-ext/sha256:{}/index.html", hex))
+        .header("x-tenant-id", "tenant-a")
+        .header(header::IF_NONE_MATCH, etag)
+        .body(Body::empty())
+        .unwrap();
+    let resp = app.clone().oneshot(get_304).await.unwrap();
+    assert_eq!(resp.status(), StatusCode::NOT_MODIFIED);
+    assert!(resp
+        .headers()
+        .get(header::CONTENT_SECURITY_POLICY)
+        .is_some());
+
+    // SPA fallback serves index.html, so it must carry the CSP as well
+    let get_spa = Request::builder()
+        .method(Method::GET)
+        .uri(format!("/ext-ui/demo-ext/sha256:{}/some/client/route", hex))
+        .header("x-tenant-id", "tenant-a")
+        .body(Body::empty())
+        .unwrap();
+    let resp = app.clone().oneshot(get_spa).await.unwrap();
+    assert_eq!(resp.status(), StatusCode::OK);
+    assert!(resp
+        .headers()
+        .get(header::CONTENT_SECURITY_POLICY)
+        .is_some());
+
+    // Non-HTML assets get nosniff but no CSP
+    let get_js = Request::builder()
+        .method(Method::GET)
+        .uri(format!("/ext-ui/demo-ext/sha256:{}/assets/app.js", hex))
+        .header("x-tenant-id", "tenant-a")
+        .body(Body::empty())
+        .unwrap();
+    let resp = app.clone().oneshot(get_js).await.unwrap();
+    assert_eq!(resp.status(), StatusCode::OK);
+    assert!(resp
+        .headers()
+        .get(header::CONTENT_SECURITY_POLICY)
+        .is_none());
+    assert_eq!(
+        resp.headers().get(header::X_CONTENT_TYPE_OPTIONS).unwrap(),
+        "nosniff"
+    );
+
+    // frame-ancestors appended from env
+    std::env::set_var("EXT_UI_FRAME_ANCESTORS", "https://app.example.com");
+    let get_html2 = Request::builder()
+        .method(Method::GET)
+        .uri(format!("/ext-ui/demo-ext/sha256:{}/index.html", hex))
+        .header("x-tenant-id", "tenant-a")
+        .body(Body::empty())
+        .unwrap();
+    let resp = app.clone().oneshot(get_html2).await.unwrap();
+    let csp = resp
+        .headers()
+        .get(header::CONTENT_SECURITY_POLICY)
+        .unwrap()
+        .to_str()
+        .unwrap()
+        .to_string();
+    assert!(csp.ends_with("frame-ancestors https://app.example.com"));
+    std::env::remove_var("EXT_UI_FRAME_ANCESTORS");
+
+    // Full override replaces the policy
+    std::env::set_var(
+        "EXT_UI_CONTENT_SECURITY_POLICY",
+        "default-src 'self'; connect-src 'self' https:",
+    );
+    let get_html3 = Request::builder()
+        .method(Method::GET)
+        .uri(format!("/ext-ui/demo-ext/sha256:{}/index.html", hex))
+        .header("x-tenant-id", "tenant-a")
+        .body(Body::empty())
+        .unwrap();
+    let resp = app.clone().oneshot(get_html3).await.unwrap();
+    let csp = resp
+        .headers()
+        .get(header::CONTENT_SECURITY_POLICY)
+        .unwrap()
+        .to_str()
+        .unwrap()
+        .to_string();
+    assert_eq!(csp, "default-src 'self'; connect-src 'self' https:");
+    std::env::remove_var("EXT_UI_CONTENT_SECURITY_POLICY");
 }
 
 #[tokio::test]
@@ -340,9 +496,9 @@ async fn oversize_asset_returns_413() {
         ))
         .unwrap();
     let warm_resp = app.clone().oneshot(warm).await.unwrap();
-    assert_eq!(warm_resp.status(), StatusCode::OK);
+    assert_eq!(warm_resp.status(), StatusCode::BAD_REQUEST);
 
-    // Request the oversize asset
+    // Request the oversize asset (cold GET performs ensure_bundle_cached)
     let get = Request::builder()
         .method(Method::GET)
         .uri(format!("/ext-ui/demo-ext/sha256:{}/assets/big.png", hex))

--- a/server/src/lib/extensions/assets/serve.ts
+++ b/server/src/lib/extensions/assets/serve.ts
@@ -32,10 +32,28 @@ export function serveFrom(req: NextRequest, dir: string, reqPath: string): NextR
   const ifNone = req.headers.get('if-none-match');
   if (ifNone && ifNone === etag) return new NextResponse(null, { status: 304 });
   const headers = new Headers();
-  headers.set('content-type', contentTypeFor(path));
+  const contentType = contentTypeFor(path);
+  headers.set('content-type', contentType);
   headers.set('cache-control', 'public, max-age=31536000, immutable');
   headers.set('etag', etag);
+  headers.set('x-content-type-options', 'nosniff');
+  if (contentType.startsWith('text/html')) {
+    headers.set('content-security-policy', extUiCsp());
+  }
   return new NextResponse(buf, { status: 200, headers });
+}
+
+const DEFAULT_EXT_UI_CSP =
+  "default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self' data:; font-src 'self'; connect-src 'self'; object-src 'none'; base-uri 'self'; form-action 'self'";
+
+// Mirrors the Rust host (ee/runner/src/http/ext_ui.rs): EXT_UI_CONTENT_SECURITY_POLICY
+// replaces the whole policy; EXT_UI_FRAME_ANCESTORS appends a frame-ancestors directive.
+function extUiCsp(): string {
+  const override = process.env.EXT_UI_CONTENT_SECURITY_POLICY?.trim();
+  if (override) return override;
+  const frameAncestors = process.env.EXT_UI_FRAME_ANCESTORS?.trim();
+  if (frameAncestors) return `${DEFAULT_EXT_UI_CSP}; frame-ancestors ${frameAncestors}`;
+  return DEFAULT_EXT_UI_CSP;
 }
 
 function sanitizePath(p: string): string {


### PR DESCRIPTION
Emit Content-Security-Policy on extension HTML documents (200/304/SPA fallback) and X-Content-Type-Options: nosniff on all assets from the Rust runner, covering every extension at once instead of per-file meta tags (supersedes the PR #3101 approach). Policy is configurable via EXT_UI_FRAME_ANCESTORS (appends frame-ancestors) and EXT_UI_CONTENT_SECURITY_POLICY (full override); the legacy EXT_UI_HOST_MODE=nextjs path mirrors the same headers.

Also bump the runner Dockerfile to rust:1.92 (image build has been broken since the wasmtime 44.0.3 security bump required rustc 1.92) and repair pre-existing ext_ui integration test rot: warmup now asserts its intentional 400, and the fake bundle server serves the tenant-scoped object keys the handler actually fetches.

"You may gaze through the looking-glass," said the Runner to each little iframe, "but you shall fetch nothing that is not 'self', style yourself only inline, and admit no frame-ancestors I have not named." And the extensions, who had only ever whispered through postMessage anyway, went on serving tea exactly as before. 🪞🛡️🫖