### PR TITLE
Email sender identity: fix defaults & portal-invite display name

### DIFF
--- a/docs/plans/2026-08-04-email-sender-identity-plan.md
+++ b/docs/plans/2026-08-04-email-sender-identity-plan.md
@@ -1,0 +1,504 @@
+# Email sender identity: defaults and portal-invite display name
+
+**Branch:** `fix/outbound-email-branding`  
+**Date:** 2026-08-04  
+**Status:** Design complete; no feature code implemented
+
+## Outcome
+
+Make outbound sender identity predictable without collapsing two deliberately
+different concerns:
+
+1. **Ticket identity** controls the From address/name used on ticket email and,
+   critically, the inbox to which a client's reply is routed.
+2. **Everything-else identity** brands portal invitations, password resets,
+   billing mail, workflow mail, and general notifications sent through the
+   tenant's active outbound provider.
+
+The settings screen must show these identities side by side and explain the
+routing difference. A blank everything-else display name means “use the tenant's
+company name,” not “use Alga PSA.” A portal invitation's explicit
+`<Tenant Company> Portal` name must override that ordinary notification default.
+
+## Confirmed repository behavior
+
+- `packages/email/src/TenantEmailService.ts`
+  - `getProviderConfiguredAddress()` already reads the enabled provider's
+    `config.from` and `config.fromName`/`config.from_name`.
+  - `getDefaultFromAddress()` currently falls back from provider name to
+    `EMAIL_FROM`, `EMAIL_FROM_NAME`, and finally `Alga PSA Notifications`; it has
+    no tenant-company lookup.
+  - `getFromAddress()` honors `params.from`, but does not independently apply the
+    already-declared `fromName` parameter.
+  - static `sendEmail()` omits `fromName` when it builds `BaseEmailParams`.
+  - `testConnection()` builds its test message with the hard-coded name
+    `Alga PSA`, bypassing the tenant default.
+- `packages/email/src/sendPortalInvitationEmail.ts` accepts `fromName`, renames
+  it to `_fromName`, and never puts it into either the tenant-provider attempt or
+  the system-provider fallback.
+- `packages/portal-shared/src/actions/portalInvitationActions.ts` does compute
+  `${tenantDefaultClient.client_name} Portal` at the `sendPortalInvitationEmail`
+  call. The value is correct at the caller and is lost in the email helper.
+- `packages/integrations/src/actions/email-actions/emailSettingsActions.ts`
+  persists ticket identity in `tenant_email_settings.ticketing_from_email` and
+  `ticketing_from_name`, while ordinary outbound identity lives in the enabled
+  provider JSON as `config.from`/`config.fromName`.
+  - Its Microsoft branch currently sets `nextTicketingFromEmail` to the selected
+    outbound mailbox. Choosing an outbound transport therefore silently mutates
+    ticket routing.
+  - The same branch rebuilds the Microsoft provider config and copies
+    `email_providers.sender_display_name` into `config.fromName`, so it must be
+    careful not to discard an independently edited notification name.
+- `server/src/lib/eventBus/subscribers/ticketEmailSubscriber.ts`
+  `resolveTicketingFromAddress()` is the ticket-only resolver. It correctly
+  prefers `ticketingFromName`, then a matching inbound provider's
+  `sender_display_name`, while the caller retains board-name/`Support` fallback.
+  This path must remain ticket-specific.
+- `packages/email/src/providers/SMTPEmailProvider.ts` and
+  `packages/email/src/providers/ResendEmailProvider.ts` both serialize
+  `EmailMessage.from.name`; they need no provider-specific branding logic.
+- `packages/email/src/providers/MicrosoftGraphEmailProvider.ts`
+  - The JSON Graph payload does not include the message's From name.
+  - The MIME path explicitly renders `message.from.name` with the selected
+    Microsoft mailbox. Ticket mail already takes this path because of threading
+    headers; ordinary notifications do not.
+- The two edition screens have diverged:
+  - CE/OSS: `packages/integrations/src/components/email/admin/EmailSettings.tsx`
+    exposes provider From addresses but no ticket-identity editor and no display
+    name field.
+  - EE: `ee/server/src/components/settings/email/ManagedEmailSettings.tsx`
+    has a separate Ticketing From card below provider configuration, but ordinary
+    notification identity is implicit and not displayed beside it.
+- No schema change is required. The two identities already have separate storage:
+  ticket columns plus provider-config JSON.
+
+## Binding identity rules
+
+| Mail class | From address | Display-name precedence | Reply/routing meaning |
+| --- | --- | --- | --- |
+| Ticket mail | `ticketingFromEmail` when configured; otherwise the active outbound address | `ticketingFromName` → matching inbound provider `sender_display_name` → ticket board name → `Support` | Prefer a monitored inbound inbox so replies re-enter the correct ticket flow. |
+| Everything else | Active provider `config.from`, or the existing environment/domain-derived default | per-message `fromName` override → provider `config.fromName`/name embedded in `config.from` → tenant company → environment name → `Alga PSA Notifications` | Branding only; it must not change ticket reply routing. |
+| Portal invitation | Same address as ordinary outbound mail | explicit `${tenant company} Portal`, including on system-provider fallback | Reply-To remains the configured MSP support address. |
+
+For Microsoft 365, Exchange constrains the wire From address to the selected
+mailbox. Ticket and everything-else names remain independent, but a configured
+ticket address must be that mailbox because the Graph provider cannot safely
+spoof an arbitrary address. The UI and server validation should state this
+capability constraint instead of silently rewriting ticket settings.
+
+## Data and API design
+
+### Reuse existing persisted fields
+
+- Keep `tenant_email_settings.ticketing_from_email` and
+  `tenant_email_settings.ticketing_from_name` exclusively for ticket mail.
+- Keep ordinary outbound `from` and `fromName` in the active
+  `EmailProviderConfig.config` object for SMTP, Resend, and Microsoft.
+- Do not add a `notification_from_*` column, copy the company name into the
+  database as a fake explicit override, or backfill existing tenants. Leaving
+  `fromName` blank must remain a live fallback so a tenant-company rename is
+  reflected without rewriting email settings.
+
+### Add one shared resolver
+
+Create `packages/email/src/senderIdentity.ts` and export it through
+`packages/email/src/index.ts`:
+
+- `resolveTenantCompanyName(knex, tenantId)` reads the default
+  `tenant_companies` row, tenant-joins `clients`, and returns trimmed
+  `clients.client_name`; fall back to the tenant record's current company/client
+  name, then `null`. All queries use `tenantDb`/`tenantJoin`.
+- `resolveDefaultFromAddress(settings, tenantCompanyName)` contains the current
+  address parsing/domain re-homing behavior and the new display-name precedence.
+  Keep this part pure so provider/address cases remain cheap unit tests.
+- `applyFromNameOverride(address, fromName)` changes only the display name and
+  never substitutes a tenant address into a system provider. This is important
+  for fallback delivery from a platform-owned domain.
+
+Add an action-level view type in
+`packages/integrations/src/actions/email-actions/emailSettingsActions.ts`, for
+example `EmailSettingsView`, containing the persisted `TenantEmailSettings` plus:
+
+- `tenantCompanyName: string | null`
+- `effectiveNotificationFrom: EmailAddress`
+
+`getEmailSettings()` and the result returned by `updateEmailSettings()` populate
+those computed values without persisting them. Both CE and EE can therefore show
+the actual effective identity, including a derived managed-Resend address, while
+editing only real stored fields.
+
+## Implementation order
+
+### 1. Centralize ordinary sender resolution
+
+Files:
+
+- New `packages/email/src/senderIdentity.ts`
+- `packages/email/src/TenantEmailService.ts`
+- `packages/email/src/index.ts`
+- `packages/email/src/BaseEmailService.ts`
+
+Changes:
+
+1. Move the pure parsing, provider-address, domain, and local-part helpers out of
+   `TenantEmailService.ts` into `senderIdentity.ts`.
+2. Add `fromName?: string` explicitly to `BaseEmailParams`; keep `from` as the
+   address override and `fromName` as a name-only override.
+3. In `TenantEmailService.sendEmail()`, reuse the connection already opened for
+   the suspension check and resolve the tenant company before calling
+   `super.sendEmail()`. Pass it on that call's params as an internal resolved
+   fallback (for example `resolvedTenantCompanyName`), rather than mutating the
+   tenant singleton or creating a long-lived company-name cache, so concurrent
+   sends stay isolated and default-client/name changes take effect on later
+   messages. Run the suspension and company reads together when safe.
+4. Update `TenantEmailService.getFromAddress()` so `fromName` overrides the name
+   on either an explicit `params.from` address or the resolved default address,
+   and the call-scoped resolved company supplies the fallback, without changing
+   the email address.
+5. Keep `TenantEmailService.getDefaultFromAddress()` as a compatibility wrapper
+   for the ticket subscriber/tests, accepting the resolved company name when a
+   full identity (rather than only its email) is needed.
+6. Forward `fromName` in the deprecated static `TenantEmailService.sendEmail()`
+   path as well; verification and other legacy callers must not silently lose it.
+7. Change `TenantEmailService.testConnection()` to use the same effective
+   identity instead of `{ name: 'Alga PSA' }`.
+
+### 2. Make explicit display-name overrides survive tenant and system sending
+
+Files:
+
+- `packages/email/src/system/SystemEmailService.ts`
+- `packages/email/src/sendPortalInvitationEmail.ts`
+- `packages/portal-shared/src/actions/portalInvitationActions.ts`
+
+Changes:
+
+1. Make `SystemEmailService.getFromAddress()` return an `EmailAddress` when
+   needed and apply `params.fromName` to the system provider's own configured
+   From email. Never send a tenant's provider address through the fallback.
+2. Stop destructuring `fromName` as `_fromName` in
+   `sendPortalInvitationEmail()`; include it in the shared `emailParams` used by
+   both attempts.
+3. Retain the existing portal action computation
+   `` `${tenantDefaultClient.client_name} Portal` `` and existing support
+   Reply-To. No portal template or invitation transaction behavior changes.
+4. Add a narrow regression test at both seams: the portal action computes the
+   expected value, and the email helper forwards it to the tenant attempt and to
+   the fallback after an injected tenant-provider failure.
+
+### 3. Preserve ticket routing during provider changes
+
+Files:
+
+- `packages/integrations/src/actions/email-actions/emailSettingsActions.ts`
+- `packages/integrations/src/actions/email-actions/emailSettingsActions.providers.test.ts`
+- `packages/integrations/src/actions/email-actions/emailSettingsActions.clear.test.ts`
+
+Changes:
+
+1. Remove the Microsoft-selection assignment to `nextTicketingFromEmail`.
+   Provider selection may update `emailProvider`, `defaultFromDomain`, and the
+   Microsoft provider config, but not either `ticketingFrom*` field unless the
+   caller explicitly supplies those fields.
+2. When rebuilding a validated Microsoft config, preserve the submitted
+   notification `config.fromName` after trimming. If it is blank, leave it blank
+   so runtime company fallback applies; do not convert the fallback into stored
+   state. The inbound row's `sender_display_name` remains an initial suggestion,
+   not a forced coupling to ticket identity.
+3. Add Microsoft-specific validation: a non-null ticket From address must equal
+   the selected mailbox (case-insensitive). Return an actionable error that asks
+   the admin to update the Ticket emails identity; do not rewrite it.
+4. Preserve the existing domain validation for SMTP/Resend and the partial-update
+   semantics established by `hasOwnUpdate()`.
+5. Have `getEmailSettings()` resolve `tenantCompanyName` and
+   `effectiveNotificationFrom`, including the no-row/default-config path, and
+   return the same enriched view after saves.
+
+### 4. Carry display names on the Microsoft Graph wire path
+
+Files:
+
+- `packages/email/src/providers/MicrosoftGraphEmailProvider.ts`
+- `packages/email/src/providers/__tests__/MicrosoftGraphEmailProvider.test.ts`
+
+Changes:
+
+1. Extend `buildSendPayload()` so a nonblank `message.from.name` selects MIME,
+   even when no ticket-threading header requires MIME. The existing
+   `buildMimeMessage()` already pins the email address to `this.mailbox` and
+   renders the supplied name.
+2. Retain Graph JSON for genuinely nameless messages with only JSON-compatible
+   headers; do not add arbitrary From spoofing to the JSON payload.
+3. Keep the existing MIME selection for Message-ID/In-Reply-To/References and
+   preserve attachments, Cc/Bcc, Reply-To, and Sent Items behavior.
+4. Test the raw decoded MIME header for both ordinary tenant branding and the
+   explicit `Company Portal` override. Retain a nameless JSON-path test so both
+   transports stay covered.
+
+### 5. Put both identities side by side in CE and EE settings
+
+Files:
+
+- New `packages/integrations/src/components/email/admin/EmailSenderIdentityCards.tsx`
+- `packages/integrations/src/components/email/admin/EmailSettings.tsx`
+- `ee/server/src/components/settings/email/ManagedEmailSettings.tsx`
+- `server/public/locales/*/msp/admin.json`
+- `server/public/locales/*/msp/email-providers.json`
+
+Create a shared presentational component rendered as a responsive two-column
+grid (stacked on narrow screens):
+
+- **Ticket emails**
+  - From address (connected-inbox selector plus custom input where currently
+    supported)
+  - Sender display name
+  - Copy explaining that this address receives ticket replies and should be a
+    connected/monitored inbox
+  - Existing warnings/errors for unconnected inboxes and invalid domains
+- **All other emails**
+  - Effective From address
+  - Sender display name bound to active provider `config.fromName`
+  - Help text: blank uses the tenant company name, shown as the live fallback
+  - Examples in the explanation: portal invitations, password resets, invoices,
+    and general notifications
+
+Provider rules in the component:
+
+- SMTP and customer-managed Resend keep their editable provider From address.
+- Managed Resend shows the effective address derived from its verified domain;
+  it must not invent an editable provider address the managed flow cannot honor.
+- Microsoft shows the selected mailbox as a locked address, while its ordinary
+  display name remains independently editable.
+- Ticket fields always bind to `ticketingFromEmail`/`ticketingFromName`; ordinary
+  fields always bind to the active provider config. Editing one card must not
+  mutate the other card's state.
+
+Integration in the parent screens:
+
+1. In CE `EmailSettings`, remove duplicate SMTP/Resend From-address markup from
+   `renderSMTPConfig()`/`renderResendConfig()`, load connected inbound providers,
+   render the shared identity cards, and let the existing Save Settings action
+   persist the combined state.
+2. In EE `ManagedEmailSettings`, replace the standalone Ticketing From card and
+   the SMTP card's duplicate From field with the shared identity cards. Replace
+   `handleSaveTicketingFrom()` with a sender-identity save that submits the two
+   explicitly edited field groups in one `updateEmailSettings()` call; retain
+   clear/confirmation behavior for ticket identity.
+3. Keep provider credentials, TLS controls, managed-domain controls, test-send
+   controls, and Microsoft mailbox selection in their existing provider cards.
+4. Use stable ids for automation, including `#ticket-from-address`,
+   `#ticket-from-name`, `#notification-from-address`,
+   `#notification-from-name`, and `#save-sender-identities` (EE).
+5. Add equivalent copy keys to the CE `msp/admin` and EE
+   `msp/email-providers` namespaces, including supported/pseudo locale files as
+   required by the repository's locale consistency checks.
+
+### 6. Verify all provider paths and regressions
+
+Land the automated tests below before manual smoke. Run package-level typechecks
+for `packages/email` and `packages/integrations`, EE/server typecheck, the focused
+Vitest files, and the repository locale/format checks that cover changed files.
+
+## Automated behavioral tests
+
+### Pure/service tests
+
+Extend `packages/email/src/__tests__/TenantEmailService.fromAddress.test.ts`:
+
+1. Provider `fromName` wins over tenant company.
+2. Blank provider name uses the tenant company for SMTP and Resend.
+3. Tenant company wins over environment/product branding; environment/product
+   remain last-resort fallbacks when the tenant has no resolvable company.
+4. A per-message `fromName` changes only the name, not the resolved email.
+5. An explicit ticket `from` object retains its ticket name unless a deliberate
+   per-message name override is passed.
+6. Test email uses the same resolved ordinary identity.
+
+Add a DB-backed integration test at
+`server/src/test/integration/emailSenderIdentity.integration.test.ts`:
+
+- Happy path: a real tenant/default-company/client/settings fixture with blank
+  provider `fromName` resolves the default client's current name and provider
+  address through real tenant-scoped queries.
+- Guard path: no default-company association falls back to the tenant record and
+  never reads another tenant's company.
+- Update the default company's name and prove a later send resolution observes
+  it without persisting that name into `provider_configs`.
+
+### Portal-invitation tests
+
+Add `packages/email/src/__tests__/sendPortalInvitationEmail.test.ts` and a focused
+portal-action test under `packages/portal-shared/src/actions/`:
+
+1. `sendPortalInvitation` computes `Example MSP Portal` from the default tenant
+   company.
+2. `sendPortalInvitationEmail` passes that name to the successful tenant send.
+3. When the tenant send fails, the system fallback uses its own email address
+   with the same `Example MSP Portal` display name.
+4. Support Reply-To, locale resolution, and transaction rollback on total
+   failure remain unchanged.
+
+### Provider tests
+
+- Extend `packages/email/src/providers/__tests__/SMTPEmailProvider.test.ts` and
+  `ResendEmailProvider.test.ts` to assert the serialized named From value for the
+  tenant default and an explicit portal override.
+- Extend `MicrosoftGraphEmailProvider.test.ts` as described in implementation
+  step 4: ordinary named notification → MIME, portal override → MIME with the
+  selected mailbox, threading headers still present for tickets, nameless mail →
+  JSON.
+- Extend `emailSettingsActions.providers.test.ts` so Microsoft selection:
+  - preserves existing `ticketingFromEmail` and `ticketingFromName` when they are
+    compatible;
+  - never writes those fields merely because a mailbox was selected;
+  - rejects an incompatible existing ticket address instead of overwriting it;
+  - preserves/clears ordinary `config.fromName` with the intended fallback
+    semantics.
+
+### Component tests
+
+- Add a CE jsdom test beside
+  `packages/integrations/src/components/email/admin/EmailSettings.tsx`.
+- Extend
+  `ee/server/src/__tests__/unit/ManagedEmailSettings.actions.test.tsx`.
+
+Both editions must prove:
+
+1. Ticket emails and All other emails render side by side with the routing
+   explanation.
+2. Editing/saving notification name does not change either ticket field.
+3. Editing/saving ticket name/address does not change provider `fromName`/`from`.
+4. Blank notification name visibly previews the tenant-company fallback.
+5. Microsoft mailbox address is read-only while notification name is editable.
+6. Reloading after save reconstructs the same stored/effective split rather than
+   relying on optimistic component state.
+
+## Manual smoke plan
+
+The smoke steps below are derived from the current components and intended
+post-change behavior; no live screen was driven during this design-only task.
+
+### Preflight
+
+- Use the existing `alga-psa-local-test` Compose project.
+- The worktree dev server is `http://localhost:3305`.
+- Host-run wire-in configuration is `server/.env.local`.
+- Use a tenant whose default company is visibly named (for example
+  `Example MSP`) and an SMTP/Graph capture path where raw From and Reply-To
+  headers can be inspected. The seeded login password rotates per stack boot;
+  take it from the server boot banner.
+
+### Risks this smoke defends
+
+- Ticket replies silently route to the wrong mailbox after changing outbound
+  provider.
+- Clients see Alga/platform branding instead of the MSP's company name.
+- Portal invitations report success while discarding the computed Portal name.
+- Microsoft accepts the message but Exchange emits a different display name.
+- The settings screen looks correct optimistically but persists the identities
+  into the wrong fields.
+
+### Flow 1 — prevent identity fields from crossing on save
+
+1. Open `/msp/settings/email` → **Outbound Email**.
+2. Confirm **Ticket emails** and **All other emails** are visible side by side and
+   their explanations distinguish reply routing from branding.
+3. Set ticket identity to `support@example.test` / `Example Support`; set the
+   everything-else name to `Example MSP`; save.
+4. Reload the page. Both cards must retain their own values.
+5. Out-of-band, inspect `tenant_email_settings`: the ticket values must be in
+   `ticketing_from_email`/`ticketing_from_name`; the ordinary name/address must be
+   only in the active `provider_configs[].config`.
+
+### Flow 2 — prevent platform branding when ordinary name is blank
+
+1. Clear the **All other emails** display name but keep a valid SMTP From address;
+   save and reload.
+2. The card must show `Example MSP` as the effective fallback without storing it
+   as an explicit provider `fromName`.
+3. Send a test email from the existing **Test Outbound Email** control.
+4. Inspect the raw captured message. From must be `Example MSP <configured
+   address>`, never `Alga PSA` or `Alga PSA Notifications`.
+
+### Flow 3 — prevent portal-invite branding loss
+
+1. Open a client contact → **Portal** tab and click **Send Portal Invitation**
+   (`#send-invite-button`).
+2. Confirm the UI reports success and invitation history gains the invitation.
+3. Inspect the raw message: From name is `Example MSP Portal`, the address is the
+   active ordinary outbound address, and Reply-To is the configured MSP support
+   address.
+4. This must remain true with blank provider display name. In a controlled test
+   where the tenant provider fails and system fallback succeeds, the fallback's
+   address must remain platform-owned while its display name is still
+   `Example MSP Portal`.
+
+### Flow 4 — prevent ticket-routing regression
+
+1. From a ticket on a board with a distinct name, send a public reply or trigger a
+   ticket notification.
+2. Inspect the raw From header: it uses `Example Support
+   <support@example.test>`, not `Example MSP` or `Example MSP Portal`.
+3. Reply from the recipient mailbox and confirm the reply is ingested into the
+   same ticket through the connected support inbox.
+4. Re-open settings and confirm the everything-else identity did not change.
+
+### Flow 5 — prevent Microsoft Graph from discarding names
+
+1. Select an authorized Microsoft 365 outbound mailbox.
+2. If the saved ticket address is a different mailbox, the save must stop with an
+   actionable message; it must not silently replace the ticket field.
+3. Set the ordinary display name to `Example MSP` and send a non-ticket test or
+   notification. Confirm delivery/Sent Items and raw From
+   `Example MSP <selected-mailbox>`.
+4. Send a ticket reply with ticket display name `Example Support`; confirm raw
+   From `Example Support <selected-mailbox>` and preserved threading headers.
+5. Send a portal invitation; confirm `Example MSP Portal <selected-mailbox>`.
+
+### Manual pass criteria
+
+The smoke passes only if raw delivered headers, reloaded UI state, and the
+tenant-scoped DB row agree: ticket routing remains in the ticket fields; ordinary
+branding remains in provider config with live company fallback; portal override
+survives; and SMTP/Resend/Microsoft all emit the intended display name.
+
+## Risks and mitigations
+
+- **One extra tenant-company read per send.** Correctness after a default-company
+  rename is more important than a stale singleton cache. Reuse the connection
+  already opened by `TenantEmailService.sendEmail`, keep the query narrow, and
+  measure it in focused tests; do not add a cross-tenant/global cache.
+- **Microsoft MIME expansion.** Once default names are populated, most Microsoft
+  sends will use MIME rather than JSON. Existing ticket sends already exercise
+  MIME. Provider tests must cover attachments, recipients, Reply-To, and headers
+  on the newly expanded path.
+- **Microsoft cannot honor arbitrary From addresses.** Enforce mailbox equality
+  for ticket address rather than implying Graph can spoof it. Names remain
+  independent.
+- **System fallback domain safety.** A name override must never carry a tenant
+  address into the system provider; `applyFromNameOverride` is deliberately
+  address-preserving.
+- **CE/EE UI drift.** Use one shared identity-card component and edition-specific
+  parent wiring rather than copying the identity form a third time.
+- **Partial updates and secret masking.** Sender saves still flow through
+  `mergeProviderSecrets`; regression tests must retain the `***` password/API-key
+  protections.
+- **Default-company absence.** Keep environment and product fallbacks after the
+  company lookup so a partially provisioned tenant can still send.
+
+## Explicit non-goals
+
+- No feature implementation or workflow-board mutation in this design task.
+- No database migration, backfill, or rewriting blank provider names to company
+  names.
+- No change to inbound provider setup, webhook processing, ticket parsing,
+  ticket threading, or `email_providers.sender_display_name` semantics.
+- No arbitrary Microsoft From spoofing, extra mailbox discovery, OAuth-scope
+  changes, or Send As permission work.
+- No changes to SMTP credentials/TLS, Resend domain verification, managed-domain
+  lifecycle, rate limits, or provider failover policy.
+- No email-template content/subject redesign and no change to portal invitation
+  token, expiration, locale, transaction, support contact, or Reply-To behavior.
+- No per-template or per-notification-category sender identities; there remain
+  exactly the ticket identity, the everything-else identity, and deliberate
+  per-message name overrides such as Company Portal.

--- a/ee/server/src/__tests__/unit/ManagedEmailSettings.actions.test.tsx
+++ b/ee/server/src/__tests__/unit/ManagedEmailSettings.actions.test.tsx
@@ -76,6 +76,44 @@ vi.mock('react-hot-toast', () => ({
 
 vi.mock('@alga-psa/integrations/components', () => ({
   EmailProviderConfiguration: () => <div id="email-provider-configuration-stub" />,
+  EmailSenderIdentityCards: ({
+    copy,
+    ticketAddress,
+    ticketName,
+    notificationAddress,
+    notificationName,
+    onTicketAddressChange,
+    onTicketNameChange,
+    onNotificationAddressChange,
+    onNotificationNameChange,
+    actions,
+  }: any) => (
+    <div>
+      <h2>{copy.ticketTitle}</h2>
+      <input
+        id="ticket-from-address"
+        value={ticketAddress}
+        onChange={(event) => onTicketAddressChange(event.target.value)}
+      />
+      <input
+        id="ticket-from-name"
+        value={ticketName}
+        onChange={(event) => onTicketNameChange(event.target.value)}
+      />
+      <h2>{copy.notificationTitle}</h2>
+      <input
+        id="notification-from-address"
+        value={notificationAddress}
+        onChange={(event) => onNotificationAddressChange(event.target.value)}
+      />
+      <input
+        id="notification-from-name"
+        value={notificationName}
+        onChange={(event) => onNotificationNameChange(event.target.value)}
+      />
+      {actions}
+    </div>
+  ),
 }));
 
 vi.mock('@alga-psa/ui/components/Card', () => ({
@@ -210,6 +248,11 @@ const baseSettings = {
   trackingEnabled: false,
   createdAt: new Date('2026-03-01T00:00:00.000Z'),
   updatedAt: new Date('2026-03-01T00:00:00.000Z'),
+  tenantCompanyName: 'Acme MSP',
+  effectiveNotificationFrom: {
+    email: 'notifications@acme.com',
+    name: 'Acme MSP',
+  },
 };
 
 const smtpSettings = {
@@ -274,7 +317,7 @@ describe('ManagedEmailSettings removal actions', () => {
 
     render(<ManagedEmailSettings />);
 
-    const clearButton = await screen.findByRole('button', { name: /clear from address/i });
+    const clearButton = await screen.findByRole('button', { name: /clear ticket identity/i });
     fireEvent.click(clearButton);
     const confirmButton = document.getElementById('managed-email-clear-ticketing-from-confirm');
     expect(confirmButton).not.toBeNull();
@@ -434,6 +477,53 @@ describe('ManagedEmailSettings outbound SMTP test and TLS controls', () => {
     });
   });
 
+  it('saves notification branding without changing the ticket identity fields', async () => {
+    render(<ManagedEmailSettings />);
+
+    await waitFor(() => expect(document.getElementById('notification-from-name')).not.toBeNull());
+    fireEvent.change(document.getElementById('notification-from-name')!, {
+      target: { value: 'Acme Billing' },
+    });
+    fireEvent.click(document.getElementById('save-sender-identities')!);
+
+    await waitFor(() => {
+      expect(updateEmailSettingsMock).toHaveBeenCalledWith(expect.objectContaining({
+        ticketingFromEmail: 'support@acme.com',
+        providerConfigs: [expect.objectContaining({
+          providerType: 'smtp',
+          config: expect.objectContaining({ fromName: 'Acme Billing' }),
+        })],
+      }));
+    });
+  });
+
+  it('saves ticket identity edits without replacing notification branding', async () => {
+    getEmailSettingsMock.mockResolvedValue({
+      ...smtpSettings,
+      providerConfigs: [{
+        ...smtpSettings.providerConfigs[0],
+        config: { ...smtpSettings.providerConfigs[0].config, fromName: 'Acme Billing' },
+      }],
+    });
+
+    render(<ManagedEmailSettings />);
+
+    await waitFor(() => expect(document.getElementById('ticket-from-name')).not.toBeNull());
+    fireEvent.change(document.getElementById('ticket-from-name')!, {
+      target: { value: 'Acme Support' },
+    });
+    fireEvent.click(document.getElementById('save-sender-identities')!);
+
+    await waitFor(() => {
+      expect(updateEmailSettingsMock).toHaveBeenCalledWith(expect.objectContaining({
+        ticketingFromName: 'Acme Support',
+        providerConfigs: [expect.objectContaining({
+          config: expect.objectContaining({ fromName: 'Acme Billing' }),
+        })],
+      }));
+    });
+  });
+
   it('offers SMTP and Microsoft but not managed email on self-host', async () => {
     tierContextState.isHosted = false;
     getManagedEmailDomainsMock.mockRejectedValue(new Error('managed domains should not load'));
@@ -547,7 +637,7 @@ describe('ManagedEmailSettings outbound SMTP test and TLS controls', () => {
     fireEvent.change(await screen.findByLabelText(/smtp host/i), {
       target: { value: 'relay.appliance.lan' },
     });
-    fireEvent.change(document.getElementById('smtp-from') as HTMLInputElement, {
+    fireEvent.change(document.getElementById('notification-from-address') as HTMLInputElement, {
       target: { value: 'support@acme.test' },
     });
     fireEvent.click(screen.getByRole('button', { name: /save smtp settings/i }));

--- a/ee/server/src/components/settings/email/ManagedEmailSettings.tsx
+++ b/ee/server/src/components/settings/email/ManagedEmailSettings.tsx
@@ -32,7 +32,7 @@ import {
   type ManagedDomainActionResult,
   type ManagedDomainActionFailure,
 } from '@ee/lib/actions/email-actions/managedDomainActions';
-import { EmailProviderConfiguration } from '@alga-psa/integrations/components';
+import { EmailProviderConfiguration, EmailSenderIdentityCards } from '@alga-psa/integrations/components';
 import type { EmailProvider } from '@alga-psa/integrations/components';
 import type { TenantEmailSettings } from 'server/src/types/email.types';
 import { createDefaultProviderConfig } from '@alga-psa/email/providerConfig';
@@ -42,6 +42,7 @@ import {
   getEmailProviders,
   testOutboundEmail,
   getMicrosoftOutboundMailboxes,
+  type EmailSettingsView,
   type MicrosoftOutboundMailboxOption,
 } from '@alga-psa/integrations/actions';
 import ManagedDomainList from './ManagedDomainList';
@@ -97,7 +98,7 @@ function isManagedDomainActionFailure(value: unknown): value is ManagedDomainAct
   );
 }
 
-type EmailSettingsActionResult = TenantEmailSettings | ActionMessageError | null;
+type EmailSettingsActionResult = EmailSettingsView | ActionMessageError | null;
 
 interface EmailSettingsProps {}
 
@@ -125,9 +126,8 @@ export const ManagedEmailSettings: React.FC<EmailSettingsProps> = () => {
   const [newDomain, setNewDomain] = useState('');
   const [busyDomain, setBusyDomain] = useState<string | null>(null);
   const [overrides] = useState<ManagedEmailOverrides | undefined>(() => getManagedEmailOverrides());
-  const [emailSettings, setEmailSettings] = useState<TenantEmailSettings | null>(null);
+  const [emailSettings, setEmailSettings] = useState<EmailSettingsView | null>(null);
   const [inboundProviders, setInboundProviders] = useState<EmailProvider[]>([]);
-  const [ticketingFromOption, setTicketingFromOption] = useState<string>('custom');
   const [ticketingFromCustom, setTicketingFromCustom] = useState('');
   const [ticketingFromName, setTicketingFromName] = useState('');
   const [ticketingFromError, setTicketingFromError] = useState<string | null>(null);
@@ -150,7 +150,7 @@ export const ManagedEmailSettings: React.FC<EmailSettingsProps> = () => {
   const resolveEmailSettingsResult = (
     result: EmailSettingsActionResult,
     fallback: string
-  ): TenantEmailSettings | null => {
+  ): EmailSettingsView | null => {
     if (isActionMessageError(result)) {
       toast.error(getErrorMessage(result) || fallback);
       return null;
@@ -274,6 +274,13 @@ export const ManagedEmailSettings: React.FC<EmailSettingsProps> = () => {
       return t('managed.validation.invalidEmail');
     }
 
+    if (outboundProvider === 'microsoft') {
+      const selectedMailbox = getMicrosoftConfig()?.config.mailbox?.trim();
+      if (selectedMailbox && trimmed.toLowerCase() !== selectedMailbox.toLowerCase()) {
+        return t('managed.validation.microsoftMustMatchMailbox', { mailbox: selectedMailbox });
+      }
+    }
+
     // For managed/resend, the domain must match exactly.
     // For SMTP, domain mismatch is a warning (handled separately), not a hard error.
     if (outboundProvider !== 'smtp') {
@@ -299,10 +306,8 @@ export const ManagedEmailSettings: React.FC<EmailSettingsProps> = () => {
     const hasMatch = current && mailboxes.some((m) => m.toLowerCase() === current.toLowerCase());
 
     if (current) {
-      setTicketingFromOption(hasMatch ? current : 'custom');
       setTicketingFromCustom(current);
     } else {
-      setTicketingFromOption('custom');
       setTicketingFromCustom('');
     }
 
@@ -339,10 +344,9 @@ export const ManagedEmailSettings: React.FC<EmailSettingsProps> = () => {
     }
   };
 
-  const handleSaveTicketingFrom = async () => {
+  const handleSaveSenderIdentities = async () => {
     const outboundDomain = getOutboundDomain(emailSettings);
-    const rawCandidate = ticketingFromOption === 'custom' ? ticketingFromCustom : ticketingFromOption;
-    const candidate = (rawCandidate || '').trim();
+    const candidate = ticketingFromCustom.trim();
 
     // The From address is optional: a tenant may configure only a display name
     // and keep the default sender address. Validate the address only when set.
@@ -356,10 +360,11 @@ export const ManagedEmailSettings: React.FC<EmailSettingsProps> = () => {
     setSavingTicketingFrom(true);
     try {
       const updates: EmailSettingsUpdateInput = {
+        providerConfigs: emailSettings?.providerConfigs,
+        ticketingFromEmail: candidate || null,
         ticketingFromName: ticketingFromName.trim() || null,
       };
-      if (candidate) {
-        updates.ticketingFromEmail = candidate;
+      if (candidate || outboundProvider === 'smtp') {
         updates.defaultFromDomain = outboundDomain || emailSettings?.defaultFromDomain;
       }
 
@@ -371,7 +376,7 @@ export const ManagedEmailSettings: React.FC<EmailSettingsProps> = () => {
 
       setEmailSettings(updated);
       initializeTicketingFromSelection(updated, inboundProviders);
-      toast.success(t('managed.messages.ticketingFromUpdated'));
+      toast.success(t('managed.messages.senderIdentitiesUpdated'));
     } catch (err: any) {
       console.error('[ManagedEmailSettings] Failed to update ticketing from address', err);
       toast.error(err.message || t('managed.messages.ticketingFromSaveFailed'));
@@ -430,7 +435,9 @@ export const ManagedEmailSettings: React.FC<EmailSettingsProps> = () => {
     inboundProviderId: mailbox.providerId,
     mailbox: mailbox.mailbox,
     from: mailbox.mailbox,
-    fromName: mailbox.senderDisplayName || undefined,
+    fromName: getMicrosoftConfig()?.config.fromName === undefined
+      ? mailbox.senderDisplayName || undefined
+      : getMicrosoftConfig()?.config.fromName,
   });
 
   const handleMicrosoftMailboxSelect = async (providerId: string) => {
@@ -527,6 +534,16 @@ export const ManagedEmailSettings: React.FC<EmailSettingsProps> = () => {
         : config
     );
     setEmailSettings({ ...emailSettings, providerConfigs: updatedConfigs });
+  };
+
+  const updateNotificationIdentityField = (field: 'from' | 'fromName', value: string) => {
+    if (!emailSettings) return;
+    const providerConfigs = emailSettings.providerConfigs.map(config =>
+      config.providerType === outboundProvider
+        ? { ...config, config: { ...config.config, [field]: value } }
+        : config
+    );
+    setEmailSettings({ ...emailSettings, providerConfigs });
   };
 
   const persistSmtpSettings = async (): Promise<TenantEmailSettings | null> => {
@@ -700,6 +717,13 @@ export const ManagedEmailSettings: React.FC<EmailSettingsProps> = () => {
   const inboundMailboxOptions = inboundProviders
     .map((provider) => provider.mailbox?.trim())
     .filter(Boolean) as string[];
+  const notificationConfig = emailSettings?.providerConfigs.find(
+    config => config.providerType === outboundProvider
+  );
+  const microsoftMailbox = getMicrosoftConfig()?.config.mailbox?.trim() || '';
+  const ticketMailboxOptions = outboundProvider === 'microsoft' && microsoftMailbox
+    ? [microsoftMailbox]
+    : inboundMailboxOptions;
 
   return (
     <Tabs value={activeTab} onValueChange={(value) => setActiveTab(value as 'inbound' | 'outbound')} className="w-full">
@@ -917,19 +941,6 @@ export const ManagedEmailSettings: React.FC<EmailSettingsProps> = () => {
                       {t('managed.outbound.smtp.authHint')}
                     </p>
 
-                    <div>
-                      <Label htmlFor="smtp-from">{t('managed.outbound.smtp.fromLabel')}</Label>
-                      <Input
-                        id="smtp-from"
-                        value={smtpConfig?.config.from || ''}
-                        placeholder={t('managed.outbound.smtp.fromPlaceholder')}
-                        onChange={(e) => updateSmtpField('from', e.target.value)}
-                      />
-                      <p className="text-xs text-muted-foreground mt-1">
-                        {t('managed.outbound.smtp.fromHelp')}
-                      </p>
-                    </div>
-
                     <div className="border-t pt-4 space-y-4">
                       <h4 className="text-sm font-medium">
                         {t('managed.outbound.smtp.security.title')}
@@ -1030,141 +1041,76 @@ export const ManagedEmailSettings: React.FC<EmailSettingsProps> = () => {
           </Card>
         )}
 
-        <Card>
-          <CardHeader>
-            <CardTitle className="flex items-center gap-2">
-              <Send className="h-5 w-5" />
-              {t('managed.outbound.ticketingFrom.title')}
-            </CardTitle>
-            <CardDescription>
-              {t('managed.outbound.ticketingFrom.description')}
-            </CardDescription>
-          </CardHeader>
-          <CardContent className="space-y-5">
-            <p className="text-sm text-muted-foreground">
-              {outboundProvider === 'smtp'
-                ? t('managed.outbound.ticketingFrom.smtpHint', { domain: outboundDomain || t('managed.outbound.ticketingFrom.domainNotSet') })
-                : t('managed.outbound.ticketingFrom.managedHint', { domain: outboundDomain || t('managed.outbound.ticketingFrom.domainNotSet') })}
-            </p>
-
-            {!outboundDomain ? (
-              <Alert variant="warning">
-                <AlertTitle>{t('managed.outbound.ticketingFrom.outboundRequiredTitle')}</AlertTitle>
-                <AlertDescription>
-                  {outboundProvider === 'smtp'
-                    ? t('managed.outbound.ticketingFrom.smtpRequiredMessage')
-                    : t('managed.outbound.ticketingFrom.managedRequiredMessage')}
-                </AlertDescription>
-              </Alert>
-            ) : (
-              <div className="space-y-4">
-                {inboundMailboxOptions.length > 0 && (
-                  <div className="space-y-2">
-                    <Label htmlFor="ticketing-from-select">{t('managed.outbound.ticketingFrom.connectedInboxLabel')}</Label>
-                    <CustomSelect
-                      id="ticketing-from-select"
-                      value={ticketingFromOption}
-                      disabled={loadingOutbound}
-                      onValueChange={(val: string) => {
-                        setTicketingFromOption(val);
-                        if (val !== 'custom') {
-                          setTicketingFromCustom(val);
-                          handleTicketingFromChange(val);
-                        } else {
-                          handleTicketingFromChange(ticketingFromCustom);
-                        }
-                      }}
-                      options={[
-                        ...inboundMailboxOptions.map((mailbox) => ({ value: mailbox, label: mailbox })),
-                        { value: 'custom', label: t('managed.outbound.ticketingFrom.customOptionLabel', { domain: outboundDomain }) }
-                      ]}
-                      placeholder={t('managed.outbound.ticketingFrom.selectPlaceholder')}
-                    />
-                    <p className="text-xs text-muted-foreground">
-                      {t('managed.outbound.ticketingFrom.connectedInboxHelp')}
-                    </p>
-                  </div>
-                )}
-
-                {(inboundMailboxOptions.length === 0 || ticketingFromOption === 'custom') && (
-                  <div className="space-y-2">
-                    <Label htmlFor="ticketing-from-custom">{t('managed.outbound.ticketingFrom.customLabel')}</Label>
-                    <Input
-                      id="ticketing-from-custom"
-                      value={ticketingFromCustom}
-                      disabled={loadingOutbound || !outboundDomain}
-                      placeholder={t('managed.outbound.ticketingFrom.customPlaceholder', { domain: outboundDomain })}
-                      onChange={(e) => handleTicketingFromChange(e.target.value)}
-                    />
-                    <p className="text-xs text-muted-foreground">
-                      {outboundProvider === 'smtp'
-                        ? t('managed.outbound.ticketingFrom.customSmtpHelp')
-                        : t('managed.outbound.ticketingFrom.customManagedHelp', { domain: outboundDomain })}
-                    </p>
-                  </div>
-                )}
-
-                <div className="space-y-2">
-                  <Label htmlFor="ticketing-from-name">{t('managed.outbound.ticketingFrom.nameLabel')}</Label>
-                  <Input
-                    id="ticketing-from-name"
-                    value={ticketingFromName}
-                    disabled={loadingOutbound || !outboundDomain}
-                    placeholder={t('managed.outbound.ticketingFrom.namePlaceholder')}
-                    onChange={(e) => setTicketingFromName(e.target.value)}
-                  />
-                  <p className="text-xs text-muted-foreground">
-                    {t('managed.outbound.ticketingFrom.nameHelp')}
-                  </p>
-                </div>
-
-                {ticketingFromWarning && (
-                  <Alert variant="warning">
-                    <AlertTitle>{t('managed.outbound.ticketingFrom.warningTitle')}</AlertTitle>
-                    <AlertDescription>{ticketingFromWarning}</AlertDescription>
-                  </Alert>
-                )}
-
-                {ticketingFromError && (
-                  <Alert variant="destructive">
-                    <AlertTitle>{t('managed.outbound.ticketingFrom.errorTitle')}</AlertTitle>
-                    <AlertDescription>{ticketingFromError}</AlertDescription>
-                  </Alert>
-                )}
-
-                <div className="flex justify-end gap-2">
-                  {emailSettings?.ticketingFromEmail ? (
-                    <Button
-                      id="clear-ticketing-from"
-                      variant="outline"
-                      onClick={() => setShowClearTicketingFromDialog(true)}
-                      disabled={savingTicketingFrom || loadingOutbound}
-                    >
-                      {t('managed.outbound.ticketingFrom.clearButton')}
-                    </Button>
-                  ) : null}
+        {emailSettings && (
+          <EmailSenderIdentityCards
+            copy={{
+              ticketTitle: t('managed.outbound.senderIdentities.ticket.title'),
+              ticketDescription: t('managed.outbound.senderIdentities.ticket.description'),
+              connectedInboxLabel: t('managed.outbound.senderIdentities.ticket.connectedInboxLabel'),
+              connectedInboxHelp: t('managed.outbound.senderIdentities.ticket.connectedInboxHelp'),
+              customAddressOption: t('managed.outbound.senderIdentities.ticket.customAddressOption'),
+              ticketAddressLabel: t('managed.outbound.senderIdentities.ticket.addressLabel'),
+              ticketAddressPlaceholder: t('managed.outbound.senderIdentities.ticket.addressPlaceholder'),
+              ticketAddressHelp: outboundProvider === 'microsoft'
+                ? t('managed.outbound.senderIdentities.ticket.microsoftAddressHelp', { mailbox: microsoftMailbox })
+                : t('managed.outbound.senderIdentities.ticket.addressHelp'),
+              ticketNameLabel: t('managed.outbound.senderIdentities.ticket.nameLabel'),
+              ticketNamePlaceholder: t('managed.outbound.senderIdentities.ticket.namePlaceholder'),
+              ticketNameHelp: t('managed.outbound.senderIdentities.ticket.nameHelp'),
+              warningTitle: t('managed.outbound.senderIdentities.warningTitle'),
+              errorTitle: t('managed.outbound.senderIdentities.errorTitle'),
+              notificationTitle: t('managed.outbound.senderIdentities.notification.title'),
+              notificationDescription: t('managed.outbound.senderIdentities.notification.description'),
+              notificationAddressLabel: t('managed.outbound.senderIdentities.notification.addressLabel'),
+              notificationAddressPlaceholder: t('managed.outbound.senderIdentities.notification.addressPlaceholder'),
+              notificationAddressHelp: outboundProvider === 'smtp'
+                ? t('managed.outbound.senderIdentities.notification.smtpAddressHelp')
+                : t('managed.outbound.senderIdentities.notification.lockedAddressHelp'),
+              notificationNameLabel: t('managed.outbound.senderIdentities.notification.nameLabel'),
+              notificationNamePlaceholder: t('managed.outbound.senderIdentities.notification.namePlaceholder'),
+              notificationNameHelp: t('managed.outbound.senderIdentities.notification.nameHelp', {
+                company: emailSettings.tenantCompanyName || t('managed.outbound.senderIdentities.notification.companyFallback'),
+              }),
+            }}
+            ticketAddress={ticketingFromCustom}
+            ticketName={ticketingFromName}
+            connectedInboxes={ticketMailboxOptions}
+            ticketFieldsDisabled={loadingOutbound || !outboundDomain}
+            ticketWarning={ticketingFromWarning}
+            ticketError={ticketingFromError}
+            notificationAddress={notificationConfig?.config.from || emailSettings.effectiveNotificationFrom.email}
+            notificationName={notificationConfig?.config.fromName || ''}
+            notificationAddressReadOnly={outboundProvider !== 'smtp'}
+            notificationFieldsDisabled={loadingOutbound}
+            onTicketAddressChange={handleTicketingFromChange}
+            onTicketNameChange={setTicketingFromName}
+            onNotificationAddressChange={(value) => updateNotificationIdentityField('from', value)}
+            onNotificationNameChange={(value) => updateNotificationIdentityField('fromName', value)}
+            actions={(
+              <div className="flex justify-end gap-2">
+                {emailSettings.ticketingFromEmail ? (
                   <Button
-                    id="save-ticketing-from"
-                    onClick={handleSaveTicketingFrom}
-                    disabled={
-                      savingTicketingFrom ||
-                      loadingOutbound ||
-                      !!ticketingFromError ||
-                      !outboundDomain ||
-                      !(
-                        (ticketingFromOption === 'custom' ? ticketingFromCustom.trim() : ticketingFromOption) ||
-                        ticketingFromName.trim() ||
-                        (emailSettings?.ticketingFromName ?? '')
-                      )
-                    }
+                    id="clear-ticketing-from"
+                    variant="outline"
+                    onClick={() => setShowClearTicketingFromDialog(true)}
+                    disabled={savingTicketingFrom || loadingOutbound}
                   >
-                    {savingTicketingFrom ? t('managed.outbound.ticketingFrom.savingButton') : t('managed.outbound.ticketingFrom.saveButton')}
+                    {t('managed.outbound.senderIdentities.clearButton')}
                   </Button>
-                </div>
+                ) : null}
+                <Button
+                  id="save-sender-identities"
+                  onClick={handleSaveSenderIdentities}
+                  disabled={savingTicketingFrom || loadingOutbound || !!ticketingFromError || !outboundDomain}
+                >
+                  {savingTicketingFrom
+                    ? t('managed.outbound.senderIdentities.savingButton')
+                    : t('managed.outbound.senderIdentities.saveButton')}
+                </Button>
               </div>
             )}
-          </CardContent>
-        </Card>
+          />
+        )}
       </TabsContent>
 
       <TabsContent value="inbound" className="space-y-6">

--- a/packages/billing/src/components/billing-dashboard/InvoiceTemplateEditor.previewWorkspace.test.tsx
+++ b/packages/billing/src/components/billing-dashboard/InvoiceTemplateEditor.previewWorkspace.test.tsx
@@ -217,6 +217,13 @@ const installLocalStorageMock = () => {
   });
 };
 
+const waitForTemplateHydration = async () => {
+  await waitFor(() => {
+    const state = useInvoiceDesignerStore.getState();
+    expect(state.nodesById[state.rootId]?.props.metadata?.__astImported).toBe(true);
+  });
+};
+
 const transformedWorkspaceState = {
   sourceBindingId: 'collection.items',
   outputBindingId: 'transformed.items',
@@ -456,7 +463,7 @@ describe('InvoiceTemplateEditor preview workspace integration', () => {
   it('persists authored transform workspace state into the save payload', async () => {
     render(<InvoiceTemplateEditor templateId="tpl-1" />);
     await waitFor(() => expect(screen.getByTestId('designer-visual-workspace')).toBeTruthy());
-    await waitFor(() => expect(getInvoiceTemplateMock).toHaveBeenCalled());
+    await waitForTemplateHydration();
 
     act(() => {
       useInvoiceDesignerStore.getState().setTransforms(transformedWorkspaceState);
@@ -480,7 +487,7 @@ describe('InvoiceTemplateEditor preview workspace integration', () => {
   it('renders the authored transforms block in the read-only code tab', async () => {
     render(<InvoiceTemplateEditor templateId="tpl-1" />);
     await waitFor(() => expect(screen.getByTestId('designer-visual-workspace')).toBeTruthy());
-    await waitFor(() => expect(getInvoiceTemplateMock).toHaveBeenCalled());
+    await waitForTemplateHydration();
 
     act(() => {
       useInvoiceDesignerStore.getState().setTransforms(transformedWorkspaceState);
@@ -519,7 +526,7 @@ describe('InvoiceTemplateEditor preview workspace integration', () => {
   it('preserves authored transforms after save and reopen without edits', async () => {
     const firstRender = render(<InvoiceTemplateEditor templateId="tpl-1" />);
     await waitFor(() => expect(screen.getByTestId('designer-visual-workspace')).toBeTruthy());
-    await waitFor(() => expect(getInvoiceTemplateMock).toHaveBeenCalled());
+    await waitForTemplateHydration();
 
     act(() => {
       useInvoiceDesignerStore.getState().setTransforms(transformedWorkspaceState);
@@ -572,7 +579,7 @@ describe('InvoiceTemplateEditor preview workspace integration', () => {
 
     const firstRender = render(<InvoiceTemplateEditor templateId="tpl-1" />);
     await waitFor(() => expect(screen.getByTestId('designer-visual-workspace')).toBeTruthy());
-    await waitFor(() => expect(getInvoiceTemplateMock).toHaveBeenCalled());
+    await waitForTemplateHydration();
 
     act(() => {
       useInvoiceDesignerStore.getState().setTransforms(reorderedTransforms);
@@ -647,7 +654,7 @@ describe('InvoiceTemplateEditor preview workspace integration', () => {
   it('shows the generated transforms block in the read-only code tab when transforms are authored', async () => {
     render(<InvoiceTemplateEditor templateId="tpl-1" />);
     await waitFor(() => expect(screen.getByTestId('designer-visual-workspace')).toBeTruthy());
-    await waitFor(() => expect(getInvoiceTemplateMock).toHaveBeenCalled());
+    await waitForTemplateHydration();
 
     act(() => {
       useInvoiceDesignerStore.getState().setTransforms({
@@ -884,7 +891,7 @@ describe('InvoiceTemplateEditor preview workspace integration', () => {
   it('keeps generated source synchronized with GUI model while switching Visual and Code', async () => {
     render(<InvoiceTemplateEditor templateId="tpl-1" />);
     await waitFor(() => expect(screen.getByTestId('designer-visual-workspace')).toBeTruthy());
-    await waitFor(() => expect(getInvoiceTemplateMock).toHaveBeenCalled());
+    await waitForTemplateHydration();
 
     fireEvent.click(screen.getByRole('tab', { name: 'Code' }));
     act(() => {

--- a/packages/billing/src/components/billing-dashboard/InvoiceTemplateEditor.previewWorkspace.test.tsx
+++ b/packages/billing/src/components/billing-dashboard/InvoiceTemplateEditor.previewWorkspace.test.tsx
@@ -220,7 +220,8 @@ const installLocalStorageMock = () => {
 const waitForTemplateHydration = async () => {
   await waitFor(() => {
     const state = useInvoiceDesignerStore.getState();
-    expect(state.nodesById[state.rootId]?.props.metadata?.__astImported).toBe(true);
+    const metadata = state.nodesById[state.rootId]?.props.metadata as Record<string, unknown> | undefined;
+    expect(metadata?.__astImported).toBe(true);
   });
 };
 

--- a/packages/email/src/BaseEmailService.ts
+++ b/packages/email/src/BaseEmailService.ts
@@ -61,6 +61,8 @@ export interface EmailTemplateContent {
 
 export interface BaseEmailParams {
   to: string | string[] | EmailAddress | EmailAddress[];
+  from?: string | EmailAddress;
+  fromName?: string;
   cc?: string[] | EmailAddress[];
   bcc?: string[] | EmailAddress[];
   attachments?: any[];
@@ -78,6 +80,8 @@ export interface BaseEmailParams {
   entityId?: string;
   contactId?: string;
   notificationSubtypeId?: number;
+  /** Internal, call-scoped tenant-company fallback resolved by TenantEmailService. */
+  resolvedTenantCompanyName?: string | null;
   replyContext?: {
     ticketId?: string;
     projectId?: string;

--- a/packages/email/src/BaseEmailService.ts
+++ b/packages/email/src/BaseEmailService.ts
@@ -82,6 +82,10 @@ export interface BaseEmailParams {
   notificationSubtypeId?: number;
   /** Internal, call-scoped tenant-company fallback resolved by TenantEmailService. */
   resolvedTenantCompanyName?: string | null;
+  /** Internal provider snapshot used by TenantEmailService during cache refreshes. */
+  resolvedEmailProvider?: IEmailProvider | null;
+  /** Internal initialization error paired with resolvedEmailProvider. */
+  resolvedProviderInitError?: string | null;
   replyContext?: {
     ticketId?: string;
     projectId?: string;
@@ -464,16 +468,27 @@ export abstract class BaseEmailService {
    * Send an email with optional template processing
    */
   public async sendEmail(params: BaseEmailParams): Promise<EmailSendResult> {
-    if (!this.initialized) {
+    const hasResolvedProvider = Object.prototype.hasOwnProperty.call(params, 'resolvedEmailProvider');
+    if (!hasResolvedProvider && !this.initialized) {
       await this.initialize();
     }
 
-    if (!this.emailProvider) {
-      if (this.providerInitError) {
-        logger.warn(`[${this.getServiceName()}] Email provider failed to initialize: ${this.providerInitError}`);
+    // A tenant settings refresh may replace the singleton's cached provider
+    // while an earlier send is still rendering its template. Keep this send on
+    // the provider snapshot paired with the settings it resolved.
+    const emailProvider = hasResolvedProvider
+      ? params.resolvedEmailProvider ?? null
+      : this.emailProvider;
+    const providerInitError = hasResolvedProvider
+      ? params.resolvedProviderInitError ?? null
+      : this.providerInitError;
+
+    if (!emailProvider) {
+      if (providerInitError) {
+        logger.warn(`[${this.getServiceName()}] Email provider failed to initialize: ${providerInitError}`);
         return {
           success: false,
-          error: `Email provider not ready: ${this.providerInitError}`
+          error: `Email provider not ready: ${providerInitError}`
         };
       }
       logger.warn(`[${this.getServiceName()}] Service disabled or not configured`);
@@ -596,7 +611,7 @@ export abstract class BaseEmailService {
             ...(ccEmails?.length ? { cc: ccEmails } : {}),
             subject,
             queuedAt: new Date().toISOString(),
-            provider: this.emailProvider.providerType,
+            provider: emailProvider.providerType,
           },
           ctx: workflowCtx,
           idempotencyKey: `outbound_email:${workflowMessageId}:queued`,
@@ -605,12 +620,12 @@ export abstract class BaseEmailService {
         logger.warn(`[${this.getServiceName()}] Failed to publish OUTBOUND_EMAIL_QUEUED workflow event`, {
           error: publishError,
           tenantId,
-          providerType: this.emailProvider.providerType,
+          providerType: emailProvider.providerType,
         });
       }
 
       // Send via provider
-      const result = await this.emailProvider.sendEmail(emailMessage, params.tenantId || 'system');
+      const result = await emailProvider.sendEmail(emailMessage, params.tenantId || 'system');
 
       // Best-effort: persist provider-level send result for auditing/debugging.
       // Awaited: inbound reply matching reads email_sending_logs immediately after
@@ -652,7 +667,7 @@ export abstract class BaseEmailService {
               ...(maybeThreadId ? { threadId: maybeThreadId } : {}),
               ...(maybeTicketId ? { ticketId: maybeTicketId } : {}),
               sentAt: result.sentAt?.toISOString?.() || new Date().toISOString(),
-              provider: result.providerType || this.emailProvider.providerType,
+              provider: result.providerType || emailProvider.providerType,
             },
             ctx: workflowCtx,
             idempotencyKey: `outbound_email:${workflowMessageId}:sent`,
@@ -665,7 +680,7 @@ export abstract class BaseEmailService {
               ...(maybeThreadId ? { threadId: maybeThreadId } : {}),
               ...(maybeTicketId ? { ticketId: maybeTicketId } : {}),
               failedAt: new Date().toISOString(),
-              provider: result.providerType || this.emailProvider.providerType,
+              provider: result.providerType || emailProvider.providerType,
               errorMessage: result.error || 'Email send failed',
               ...(result.metadata?.errorCode ? { errorCode: String(result.metadata.errorCode) } : {}),
               ...(typeof result.metadata?.retryable === 'boolean' ? { retryable: result.metadata.retryable } : {}),
@@ -678,8 +693,8 @@ export abstract class BaseEmailService {
         logger.warn(`[${this.getServiceName()}] Failed to publish outbound email workflow event`, {
           error: publishError,
           tenantId,
-          providerType: this.emailProvider.providerType,
-          providerId: this.emailProvider.providerId,
+          providerType: emailProvider.providerType,
+          providerId: emailProvider.providerId,
         });
       }
 
@@ -698,8 +713,8 @@ export abstract class BaseEmailService {
       // Best-effort: log provider failure if we made it to message construction.
       if (emailMessage) {
         const errorMessage = error instanceof Error ? error.message : 'Unknown error';
-        const providerId = this.emailProvider?.providerId ?? 'unknown';
-        const providerType = this.emailProvider?.providerType ?? 'unknown';
+        const providerId = emailProvider.providerId;
+        const providerType = emailProvider.providerType;
 
         // Awaited: inbound reply matching reads email_sending_logs immediately after
         // a send returns — fire-and-forget raced it.
@@ -736,7 +751,7 @@ export abstract class BaseEmailService {
             ...(isUuid(params.replyContext?.threadId) ? { threadId: params.replyContext?.threadId } : {}),
             ...(isUuid(params.replyContext?.ticketId) ? { ticketId: params.replyContext?.ticketId } : {}),
             failedAt: new Date().toISOString(),
-            provider: this.emailProvider?.providerType || 'unknown',
+            provider: emailProvider.providerType,
             errorMessage: error instanceof Error ? error.message : 'Unknown error',
             ...(typeof (error as any)?.code === 'string' ? { errorCode: (error as any).code } : {}),
           },
@@ -759,8 +774,8 @@ export abstract class BaseEmailService {
       return {
         success: false,
         error: error instanceof Error ? error.message : 'Unknown error',
-        providerId: this.emailProvider?.providerId,
-        providerType: this.emailProvider?.providerType
+        providerId: emailProvider.providerId,
+        providerType: emailProvider.providerType
       };
     }
   }

--- a/packages/email/src/TenantEmailService.ts
+++ b/packages/email/src/TenantEmailService.ts
@@ -51,11 +51,20 @@ export interface EmailSettingsValidation {
   settings?: TenantEmailSettings;
 }
 
+interface TenantProviderSnapshot {
+  emailProvider: IEmailProvider | null;
+  providerInitError: string | null;
+  fromAddress: EmailAddress;
+}
+
 export class TenantEmailService extends BaseEmailService {
   private static instances: Map<string, TenantEmailService> = new Map();
   private tenantId: string;
   private providerManager: EmailProviderManager | null = null;
   private tenantSettings: TenantEmailSettings | null = null;
+  private tenantSettingsLoaded = false;
+  private providerSettingsFingerprint: string | null = null;
+  private providerStateQueue: Promise<void> = Promise.resolve();
 
   private constructor(tenantId: string) {
     super();
@@ -70,6 +79,24 @@ export class TenantEmailService extends BaseEmailService {
       TenantEmailService.instances.set(tenantId, new TenantEmailService(tenantId));
     }
     return TenantEmailService.instances.get(tenantId)!;
+  }
+
+  /**
+   * Clear one tenant's process-local provider state after an email settings
+   * save. The instance itself is reset before it is evicted so callers holding
+   * an older reference cannot continue using the prior credentials.
+   */
+  public static async invalidateTenantSettings(tenantId: string): Promise<void> {
+    const instance = TenantEmailService.instances.get(tenantId);
+    if (!instance) return;
+
+    await instance.withProviderStateLock(async () => {
+      instance.resetProviderState();
+    });
+
+    if (TenantEmailService.instances.get(tenantId) === instance) {
+      TenantEmailService.instances.delete(tenantId);
+    }
   }
 
   protected getServiceName(): string {
@@ -166,7 +193,21 @@ export class TenantEmailService extends BaseEmailService {
       };
     }
 
-    return super.sendEmail({ ...params, resolvedTenantCompanyName });
+    // Settings actions invalidate this cache in-process for an immediate
+    // refresh. The database check on every actual send also covers saves made
+    // by another server process and direct settings updates outside that action.
+    const providerSnapshot = await this.refreshProviderState(
+      suspensionKnex,
+      resolvedTenantCompanyName
+    );
+
+    return super.sendEmail({
+      ...params,
+      resolvedTenantCompanyName,
+      resolvedTenantFromAddress: providerSnapshot.fromAddress,
+      resolvedEmailProvider: providerSnapshot.emailProvider,
+      resolvedProviderInitError: providerSnapshot.providerInitError,
+    });
   }
 
   /**
@@ -208,10 +249,16 @@ export class TenantEmailService extends BaseEmailService {
 
   protected async getEmailProvider(): Promise<IEmailProvider | null> {
     if (!this.providerManager) {
-      let settings: TenantEmailSettings | null = null;
+      let settings: TenantEmailSettings | null = this.tenantSettingsLoaded
+        ? this.tenantSettings
+        : null;
       try {
-        const knex = await getConnection(this.tenantId);
-        settings = await TenantEmailService.getTenantEmailSettings(this.tenantId, knex);
+        if (!this.tenantSettingsLoaded) {
+          const knex = await getConnection(this.tenantId);
+          settings = await TenantEmailService.getTenantEmailSettings(this.tenantId, knex);
+          this.tenantSettings = settings;
+          this.tenantSettingsLoaded = true;
+        }
 
         if (settings) {
           this.providerManager = new EmailProviderManager();
@@ -279,7 +326,8 @@ export class TenantEmailService extends BaseEmailService {
   protected getFromAddress(params?: BaseEmailParams): EmailAddress | string {
     const resolved = params?.from
       ? params.from as EmailAddress | string
-      : this.buildTenantFromAddress(params?.resolvedTenantCompanyName);
+      : params?.resolvedTenantFromAddress
+        ?? this.buildTenantFromAddress(params?.resolvedTenantCompanyName);
     return applyFromNameOverride(resolved, params?.fromName);
   }
   /**
@@ -291,15 +339,7 @@ export class TenantEmailService extends BaseEmailService {
     knex: Knex | Knex.Transaction
   ): Promise<TenantEmailSettings | null> {
     try {
-      const settings = await tenantDb(knex, tenantId).table('tenant_email_settings')
-        .first();
-      
-      if (!settings) {
-        logger.warn(`[TenantEmailService] No email settings found for tenant ${tenantId}`);
-        return null;
-      }
-      
-      return TenantEmailService.normalizeSettingsRecord(tenantId, settings);
+      return await TenantEmailService.loadTenantEmailSettings(tenantId, knex);
     } catch (error) {
       logger.error(`[TenantEmailService] Error fetching tenant email settings:`, error);
       return null;
@@ -382,7 +422,6 @@ export class TenantEmailService extends BaseEmailService {
   static async sendEmail(params: SendEmailParams): Promise<EmailSendResult> {
     const { tenantId } = params;
     const service = TenantEmailService.getInstance(tenantId);
-    await service.initialize();
     
     // Convert params to BaseEmailParams format
     const baseParams: BaseEmailParams = {
@@ -530,6 +569,92 @@ export class TenantEmailService extends BaseEmailService {
 
   private buildTenantFromAddress(tenantCompanyName?: string | null): EmailAddress {
     return TenantEmailService.getDefaultFromAddress(this.tenantSettings, tenantCompanyName);
+  }
+
+  private async withProviderStateLock<T>(operation: () => Promise<T>): Promise<T> {
+    const previous = this.providerStateQueue;
+    let release!: () => void;
+    this.providerStateQueue = new Promise<void>((resolve) => {
+      release = resolve;
+    });
+
+    await previous;
+    try {
+      return await operation();
+    } finally {
+      release();
+    }
+  }
+
+  private async refreshProviderState(
+    knex: Knex | Knex.Transaction,
+    tenantCompanyName?: string | null
+  ): Promise<TenantProviderSnapshot> {
+    return this.withProviderStateLock(async () => {
+      // Unlike the public compatibility helper, this strict read does not turn
+      // a transient database error into "no settings" and accidentally replace
+      // a working tenant provider with the system fallback.
+      const settings = await TenantEmailService.loadTenantEmailSettings(this.tenantId, knex);
+      const fingerprint = TenantEmailService.getProviderSettingsFingerprint(settings);
+
+      if (this.initialized && fingerprint === this.providerSettingsFingerprint) {
+        // Retain the freshly-normalized object even when its provider-relevant
+        // values are unchanged so From resolution never depends on old state.
+        this.tenantSettings = settings;
+        this.tenantSettingsLoaded = true;
+        return {
+          emailProvider: this.emailProvider,
+          providerInitError: this.providerInitError,
+          fromAddress: this.buildTenantFromAddress(tenantCompanyName),
+        };
+      }
+
+      this.resetProviderState();
+      this.tenantSettings = settings;
+      this.tenantSettingsLoaded = true;
+      await this.initialize();
+      this.providerSettingsFingerprint = fingerprint;
+      return {
+        emailProvider: this.emailProvider,
+        providerInitError: this.providerInitError,
+        fromAddress: this.buildTenantFromAddress(tenantCompanyName),
+      };
+    });
+  }
+
+  private resetProviderState(): void {
+    this.initialized = false;
+    this.emailProvider = null;
+    this.providerInitError = null;
+    this.providerManager = null;
+    this.tenantSettings = null;
+    this.tenantSettingsLoaded = false;
+    this.providerSettingsFingerprint = null;
+  }
+
+  private static getProviderSettingsFingerprint(settings: TenantEmailSettings | null): string {
+    if (!settings) return 'no-settings';
+
+    return JSON.stringify({
+      defaultFromDomain: settings.defaultFromDomain ?? null,
+      emailProvider: settings.emailProvider,
+      providerConfigs: settings.providerConfigs,
+    });
+  }
+
+  private static async loadTenantEmailSettings(
+    tenantId: string,
+    knex: Knex | Knex.Transaction
+  ): Promise<TenantEmailSettings | null> {
+    const settings = await tenantDb(knex, tenantId).table('tenant_email_settings')
+      .first();
+
+    if (!settings) {
+      logger.warn(`[TenantEmailService] No email settings found for tenant ${tenantId}`);
+      return null;
+    }
+
+    return TenantEmailService.normalizeSettingsRecord(tenantId, settings);
   }
 
   /**

--- a/packages/email/src/TenantEmailService.ts
+++ b/packages/email/src/TenantEmailService.ts
@@ -1,4 +1,5 @@
 import type { Knex } from 'knex';
+import { createHash } from 'node:crypto';
 import { tenantDb, getConnection, isTenantSuspended } from '@alga-psa/db';
 import { EmailProviderManager } from './providers/EmailProviderManager';
 import { 
@@ -330,6 +331,19 @@ export class TenantEmailService extends BaseEmailService {
         ?? this.buildTenantFromAddress(params?.resolvedTenantCompanyName);
     return applyFromNameOverride(resolved, params?.fromName);
   }
+
+  public override async isConfigured(): Promise<boolean> {
+    const knex = await getConnection(this.tenantId);
+    const providerSnapshot = await this.refreshProviderState(knex);
+    return providerSnapshot.emailProvider !== null;
+  }
+
+  public override async getInitializationError(): Promise<string | null> {
+    const knex = await getConnection(this.tenantId);
+    const providerSnapshot = await this.refreshProviderState(knex);
+    return providerSnapshot.providerInitError;
+  }
+
   /**
    * Get tenant email settings from database
    * This is the centralized method that should be used across the application
@@ -633,13 +647,22 @@ export class TenantEmailService extends BaseEmailService {
   }
 
   private static getProviderSettingsFingerprint(settings: TenantEmailSettings | null): string {
-    if (!settings) return 'no-settings';
+    const providerState = {
+      defaultFromDomain: settings?.defaultFromDomain ?? null,
+      emailProvider: settings?.emailProvider ?? null,
+      providerConfigs: settings?.providerConfigs ?? [],
+      // Every settings action advances updatedAt. Including it makes a save an
+      // explicit cross-process refresh signal even if the submitted provider
+      // values happen to be identical to the prior values.
+      updatedAt: settings?.updatedAt ?? null,
+      // Enterprise tenant mail can fall back directly to the system provider,
+      // so its environment-backed credentials are part of this snapshot too.
+      systemProvider: isEnterprise
+        ? SystemEmailProviderFactory.getConfigFingerprint()
+        : null,
+    };
 
-    return JSON.stringify({
-      defaultFromDomain: settings.defaultFromDomain ?? null,
-      emailProvider: settings.emailProvider,
-      providerConfigs: settings.providerConfigs,
-    });
+    return createHash('sha256').update(JSON.stringify(providerState)).digest('hex');
   }
 
   private static async loadTenantEmailSettings(

--- a/packages/email/src/TenantEmailService.ts
+++ b/packages/email/src/TenantEmailService.ts
@@ -19,6 +19,11 @@ import { SystemEmailProviderFactory } from './system/SystemEmailProviderFactory'
 import { isEnterprise } from './features';
 import { DelayedEmailQueue } from './DelayedEmailQueue';
 import { TokenBucketRateLimiter } from '@alga-psa/core/rateLimit';
+import {
+  applyFromNameOverride,
+  resolveDefaultFromAddress,
+  resolveTenantCompanyName,
+} from './senderIdentity';
 
 export interface SendEmailParams {
   tenantId: string;
@@ -44,108 +49,6 @@ export interface EmailSettingsValidation {
   valid: boolean;
   error?: string;
   settings?: TenantEmailSettings;
-}
-
-// Pure from-address helpers shared by the instance sender path and any caller
-// that needs the tenant's resolved default sender identity without re-deriving
-// this logic (e.g. the ticketing subscriber layering a configured display name
-// on top of the default address).
-function parseEmailAddress(value?: string | EmailAddress | null): EmailAddress | null {
-  if (!value) {
-    return null;
-  }
-
-  if (typeof value === 'object') {
-    if (!value.email) {
-      return null;
-    }
-    return { email: value.email, name: value.name };
-  }
-
-  const trimmed = value.trim();
-  if (!trimmed) {
-    return null;
-  }
-
-  const match = trimmed.match(/^(?:"?([^"]*)"?\s*)?<([^>]+)>$/);
-  if (match) {
-    const name = match[1]?.trim();
-    return {
-      email: match[2].trim(),
-      name: name || undefined
-    };
-  }
-
-  return { email: trimmed };
-}
-
-function extractEmailParts(email?: string | null): { localPart: string; domain?: string } | null {
-  if (!email) {
-    return null;
-  }
-
-  const [localPart, domain] = email.split('@');
-  if (!domain) {
-    return { localPart: localPart || email };
-  }
-
-  return { localPart, domain };
-}
-
-function sanitizeLocalPart(localPart?: string | null): string {
-  if (!localPart) {
-    return 'notifications';
-  }
-
-  const normalized = localPart
-    .toLowerCase()
-    .replace(/[^a-z0-9._+-]/g, '');
-
-  return normalized || 'notifications';
-}
-
-function sanitizeDomain(domain?: string | null): string | null {
-  if (!domain) {
-    return null;
-  }
-
-  const normalized = domain.trim().replace(/^@/, '').toLowerCase();
-  return normalized || null;
-}
-
-function extractDomainFromAddress(address?: string): string | null {
-  if (!address) {
-    return null;
-  }
-
-  const parsed = parseEmailAddress(address);
-  if (!parsed?.email) {
-    return null;
-  }
-
-  const parts = extractEmailParts(parsed.email);
-  return parts?.domain || null;
-}
-
-function getProviderConfiguredAddress(settings?: TenantEmailSettings | null): EmailAddress | null {
-  const configs = settings?.providerConfigs || [];
-  const enabledConfig = configs.find(config => config.isEnabled && config.config);
-
-  if (!enabledConfig) {
-    return null;
-  }
-
-  const configFrom = enabledConfig.config.from;
-  const configFromName = enabledConfig.config.fromName || enabledConfig.config.from_name;
-  if (typeof configFrom === 'string' && configFrom.trim().length > 0) {
-    const parsed = parseEmailAddress(configFrom.trim()) || { email: configFrom.trim() };
-    if (!parsed.name && typeof configFromName === 'string' && configFromName.trim().length > 0) {
-      parsed.name = configFromName.trim();
-    }
-    return parsed;
-  }
-
-  return null;
 }
 
 export class TenantEmailService extends BaseEmailService {
@@ -187,7 +90,11 @@ export class TenantEmailService extends BaseEmailService {
     // job/event gates. System emails (win-back, reactivation) go through
     // SystemEmailService and are unaffected. isTenantSuspended fails open.
     const suspensionKnex = await getConnection(this.tenantId);
-    if (await isTenantSuspended(suspensionKnex, this.tenantId)) {
+    const [tenantSuspended, resolvedTenantCompanyName] = await Promise.all([
+      isTenantSuspended(suspensionKnex, this.tenantId),
+      resolveTenantCompanyName(suspensionKnex, this.tenantId),
+    ]);
+    if (tenantSuspended) {
       logger.info(`[${this.getServiceName()}] Dropping email for suspended tenant`, {
         tenantId: this.tenantId,
         to: params.to,
@@ -259,7 +166,7 @@ export class TenantEmailService extends BaseEmailService {
       };
     }
 
-    return super.sendEmail(params);
+    return super.sendEmail({ ...params, resolvedTenantCompanyName });
   }
 
   /**
@@ -370,15 +277,10 @@ export class TenantEmailService extends BaseEmailService {
   }
 
   protected getFromAddress(params?: BaseEmailParams): EmailAddress | string {
-    if (params?.from) {
-      return params.from as EmailAddress | string;
-    }
-
-    const resolved = this.buildTenantFromAddress();
-    if (resolved.name) {
-      return `${resolved.name} <${resolved.email}>`;
-    }
-    return resolved.email;
+    const resolved = params?.from
+      ? params.from as EmailAddress | string
+      : this.buildTenantFromAddress(params?.resolvedTenantCompanyName);
+    return applyFromNameOverride(resolved, params?.fromName);
   }
   /**
    * Get tenant email settings from database
@@ -447,12 +349,11 @@ export class TenantEmailService extends BaseEmailService {
       return { success: true, message: `${providerLabel} connection verified.` };
     }
 
-    const fromEmail =
-      (typeof enabled.config?.from === 'string' && enabled.config.from.trim()) ||
-      (settings.defaultFromDomain ? `noreply@${settings.defaultFromDomain}` : 'noreply@localhost');
+    const tenantCompanyName = await resolveTenantCompanyName(knex, tenantId);
+    const from = resolveDefaultFromAddress(settings, tenantCompanyName);
 
     const message: EmailMessage = {
-      from: { email: fromEmail, name: 'Alga PSA' },
+      from,
       to: [{ email: toAddress }],
       subject: 'Alga PSA outbound email test',
       text: 'This is a test message confirming your outbound email configuration works.',
@@ -493,6 +394,7 @@ export class TenantEmailService extends BaseEmailService {
       templateProcessor: params.templateProcessor,
       templateData: params.templateData,
       from: params.from,
+      fromName: params.fromName,
       tenantId,
       locale: params.locale
     };
@@ -626,8 +528,8 @@ export class TenantEmailService extends BaseEmailService {
     return [];
   }
 
-  private buildTenantFromAddress(): EmailAddress {
-    return TenantEmailService.getDefaultFromAddress(this.tenantSettings);
+  private buildTenantFromAddress(tenantCompanyName?: string | null): EmailAddress {
+    return TenantEmailService.getDefaultFromAddress(this.tenantSettings, tenantCompanyName);
   }
 
   /**
@@ -638,25 +540,10 @@ export class TenantEmailService extends BaseEmailService {
    * subscriber layering a tenant display name onto the default address — reuse
    * this logic instead of re-deriving it.
    */
-  static getDefaultFromAddress(settings?: TenantEmailSettings | null): EmailAddress {
-    const providerAddress = getProviderConfiguredAddress(settings);
-    const envAddress = parseEmailAddress(process.env.EMAIL_FROM);
-    const fallbackName = providerAddress?.name || envAddress?.name || process.env.EMAIL_FROM_NAME || 'Alga PSA Notifications';
-    const fallbackEmail = providerAddress?.email || envAddress?.email || 'notifications@example.com';
-
-    const baseEmail = providerAddress?.email || envAddress?.email || fallbackEmail;
-    const emailParts = extractEmailParts(baseEmail);
-    const localPart = sanitizeLocalPart(emailParts?.localPart);
-
-    const configuredDomain = sanitizeDomain(settings?.defaultFromDomain);
-    const fallbackDomain = sanitizeDomain(emailParts?.domain) || sanitizeDomain(extractDomainFromAddress(fallbackEmail));
-    const targetDomain = configuredDomain || fallbackDomain;
-
-    const email = targetDomain ? `${localPart}@${targetDomain}` : baseEmail;
-
-    return {
-      email,
-      name: fallbackName
-    };
+  static getDefaultFromAddress(
+    settings?: TenantEmailSettings | null,
+    tenantCompanyName?: string | null
+  ): EmailAddress {
+    return resolveDefaultFromAddress(settings, tenantCompanyName);
   }
 }

--- a/packages/email/src/__tests__/SystemEmailService.senderIdentity.test.ts
+++ b/packages/email/src/__tests__/SystemEmailService.senderIdentity.test.ts
@@ -1,0 +1,84 @@
+import { afterAll, beforeEach, describe, expect, it, vi } from 'vitest';
+
+const runtime = vi.hoisted(() => ({
+  messages: [] as Array<Record<string, any>>,
+  providerCreations: 0,
+}));
+
+vi.mock('@alga-psa/core/logger', () => ({
+  default: {
+    error: vi.fn(),
+    info: vi.fn(),
+    warn: vi.fn(),
+  },
+}));
+
+vi.mock('@alga-psa/event-bus/publishers', () => ({
+  publishWorkflowEvent: vi.fn(async () => undefined),
+}));
+
+vi.mock('../system/SystemEmailProviderFactory', () => ({
+  SystemEmailProviderFactory: {
+    createProvider: vi.fn(async () => {
+      runtime.providerCreations += 1;
+      return {
+        providerId: 'system-email-provider',
+        providerType: 'smtp',
+        sendEmail: vi.fn(async (message: Record<string, any>) => {
+          runtime.messages.push(message);
+          return {
+            success: true,
+            messageId: `system-${runtime.messages.length}`,
+            providerId: 'system-email-provider',
+            providerType: 'smtp',
+            sentAt: new Date(),
+          };
+        }),
+      };
+    }),
+  },
+}));
+
+import { getSystemEmailService } from '../system/SystemEmailService';
+
+describe('SystemEmailService sender identity', () => {
+  const originalEmailFrom = process.env.EMAIL_FROM;
+
+  beforeEach(() => {
+    runtime.messages.length = 0;
+    runtime.providerCreations = 0;
+    process.env.EMAIL_FROM = 'Platform Mail <platform@example.test>';
+  });
+
+  afterAll(() => {
+    if (originalEmailFrom === undefined) {
+      delete process.env.EMAIL_FROM;
+    } else {
+      process.env.EMAIL_FROM = originalEmailFrom;
+    }
+  });
+
+  it('keeps fallback names call-scoped on a long-lived system service', async () => {
+    const service = await getSystemEmailService();
+
+    await service.sendEmail({
+      to: 'first@example.test',
+      fromName: 'First MSP Portal',
+      subject: 'First invite',
+      html: '<p>First invite</p>',
+    });
+    await service.sendEmail({
+      to: 'second@example.test',
+      fromName: 'Second MSP Portal',
+      subject: 'Second invite',
+      html: '<p>Second invite</p>',
+    });
+
+    expect(await getSystemEmailService()).toBe(service);
+    expect(runtime.providerCreations).toBe(1);
+    expect(runtime.messages.map(message => message.from)).toEqual([
+      { email: 'platform@example.test', name: 'First MSP Portal' },
+      { email: 'platform@example.test', name: 'Second MSP Portal' },
+    ]);
+  });
+});

--- a/packages/email/src/__tests__/SystemEmailService.senderIdentity.test.ts
+++ b/packages/email/src/__tests__/SystemEmailService.senderIdentity.test.ts
@@ -1,7 +1,7 @@
 import { afterAll, beforeEach, describe, expect, it, vi } from 'vitest';
 
 const runtime = vi.hoisted(() => ({
-  messages: [] as Array<Record<string, any>>,
+  sends: [] as Array<{ message: Record<string, any>; password?: string }>,
   providerCreations: 0,
 }));
 
@@ -19,16 +19,21 @@ vi.mock('@alga-psa/event-bus/publishers', () => ({
 
 vi.mock('../system/SystemEmailProviderFactory', () => ({
   SystemEmailProviderFactory: {
+    getConfigFingerprint: vi.fn(() => JSON.stringify({
+      password: process.env.EMAIL_PASSWORD,
+      from: process.env.EMAIL_FROM,
+    })),
     createProvider: vi.fn(async () => {
       runtime.providerCreations += 1;
+      const password = process.env.EMAIL_PASSWORD;
       return {
         providerId: 'system-email-provider',
         providerType: 'smtp',
         sendEmail: vi.fn(async (message: Record<string, any>) => {
-          runtime.messages.push(message);
+          runtime.sends.push({ message, password });
           return {
             success: true,
-            messageId: `system-${runtime.messages.length}`,
+            messageId: `system-${runtime.sends.length}`,
             providerId: 'system-email-provider',
             providerType: 'smtp',
             sentAt: new Date(),
@@ -43,11 +48,15 @@ import { getSystemEmailService } from '../system/SystemEmailService';
 
 describe('SystemEmailService sender identity', () => {
   const originalEmailFrom = process.env.EMAIL_FROM;
+  const originalEmailPassword = process.env.EMAIL_PASSWORD;
+  let configVersion = 0;
 
   beforeEach(() => {
-    runtime.messages.length = 0;
+    runtime.sends.length = 0;
     runtime.providerCreations = 0;
+    configVersion += 1;
     process.env.EMAIL_FROM = 'Platform Mail <platform@example.test>';
+    process.env.EMAIL_PASSWORD = `password-${configVersion}`;
   });
 
   afterAll(() => {
@@ -55,6 +64,11 @@ describe('SystemEmailService sender identity', () => {
       delete process.env.EMAIL_FROM;
     } else {
       process.env.EMAIL_FROM = originalEmailFrom;
+    }
+    if (originalEmailPassword === undefined) {
+      delete process.env.EMAIL_PASSWORD;
+    } else {
+      process.env.EMAIL_PASSWORD = originalEmailPassword;
     }
   });
 
@@ -76,9 +90,89 @@ describe('SystemEmailService sender identity', () => {
 
     expect(await getSystemEmailService()).toBe(service);
     expect(runtime.providerCreations).toBe(1);
-    expect(runtime.messages.map(message => message.from)).toEqual([
+    expect(runtime.sends.map(send => send.message.from)).toEqual([
       { email: 'platform@example.test', name: 'First MSP Portal' },
       { email: 'platform@example.test', name: 'Second MSP Portal' },
+    ]);
+  });
+
+  it('refreshes environment-backed credentials and From address between sends', async () => {
+    const service = await getSystemEmailService();
+
+    await service.sendEmail({
+      to: 'first@example.test',
+      subject: 'First',
+      html: '<p>First</p>',
+    });
+    process.env.EMAIL_PASSWORD = 'rotated-password';
+    process.env.EMAIL_FROM = 'Rotated Platform <rotated@example.test>';
+    await service.sendEmail({
+      to: 'second@example.test',
+      subject: 'Second',
+      html: '<p>Second</p>',
+    });
+
+    expect(runtime.providerCreations).toBe(2);
+    expect(runtime.sends.map(send => ({
+      password: send.password,
+      from: send.message.from,
+    }))).toEqual([
+      {
+        password: `password-${configVersion}`,
+        from: { email: 'platform@example.test', name: 'Platform Mail' },
+      },
+      {
+        password: 'rotated-password',
+        from: { email: 'rotated@example.test', name: 'Rotated Platform' },
+      },
+    ]);
+  });
+
+  it('keeps an in-flight message paired with its provider and From snapshot', async () => {
+    const service = await getSystemEmailService();
+    let releaseTemplate!: () => void;
+    let markTemplateStarted!: () => void;
+    const templateStarted = new Promise<void>((resolve) => {
+      markTemplateStarted = resolve;
+    });
+    const templateRelease = new Promise<void>((resolve) => {
+      releaseTemplate = resolve;
+    });
+
+    const firstSend = service.sendEmail({
+      to: 'first@example.test',
+      templateProcessor: {
+        process: async () => {
+          markTemplateStarted();
+          await templateRelease;
+          return { subject: 'First', html: '<p>First</p>', text: 'First' };
+        },
+      },
+    });
+    await templateStarted;
+
+    process.env.EMAIL_PASSWORD = 'concurrent-password';
+    process.env.EMAIL_FROM = 'Concurrent Platform <concurrent@example.test>';
+    await service.sendEmail({
+      to: 'second@example.test',
+      subject: 'Second',
+      html: '<p>Second</p>',
+    });
+    releaseTemplate();
+    await firstSend;
+
+    expect(runtime.sends.map(send => ({
+      password: send.password,
+      from: send.message.from,
+    }))).toEqual([
+      {
+        password: 'concurrent-password',
+        from: { email: 'concurrent@example.test', name: 'Concurrent Platform' },
+      },
+      {
+        password: `password-${configVersion}`,
+        from: { email: 'platform@example.test', name: 'Platform Mail' },
+      },
     ]);
   });
 });

--- a/packages/email/src/__tests__/TenantEmailService.fromAddress.test.ts
+++ b/packages/email/src/__tests__/TenantEmailService.fromAddress.test.ts
@@ -18,10 +18,16 @@ function buildSettings(overrides: Partial<TenantEmailSettings> = {}): TenantEmai
   };
 }
 
-function resolveFromAddress(settings: TenantEmailSettings) {
+function resolveFromAddress(settings: TenantEmailSettings, tenantCompanyName?: string | null) {
   const service = TenantEmailService.getInstance(settings.tenantId);
   (service as any).tenantSettings = settings;
-  return (service as any).buildTenantFromAddress();
+  return (service as any).buildTenantFromAddress(tenantCompanyName);
+}
+
+function resolveMessageFrom(settings: TenantEmailSettings, params: Record<string, unknown>) {
+  const service = TenantEmailService.getInstance(settings.tenantId);
+  (service as any).tenantSettings = settings;
+  return (service as any).getFromAddress(params);
 }
 
 describe('TenantEmailService from address resolution', () => {
@@ -87,5 +93,75 @@ describe('TenantEmailService from address resolution', () => {
       email: 'notifications@acme.com',
       name: 'Alga PSA Notifications',
     });
+  });
+
+  it('uses the provider display name before the tenant company name', () => {
+    const from = resolveFromAddress(buildSettings({
+      providerConfigs: [{
+        providerId: 'smtp-provider',
+        providerType: 'smtp',
+        isEnabled: true,
+        config: { from: 'notifications@example.net', fromName: 'Configured Sender' },
+      }],
+    }), 'Acme Services');
+
+    expect(from).toEqual({ email: 'notifications@acme.com', name: 'Configured Sender' });
+  });
+
+  it.each(['smtp', 'resend'] as const)(
+    'uses the tenant company for a blank %s provider display name',
+    (providerType) => {
+      const from = resolveFromAddress(buildSettings({
+        emailProvider: providerType,
+        providerConfigs: [{
+          providerId: `${providerType}-provider`,
+          providerType,
+          isEnabled: true,
+          config: { from: 'notifications@example.net', fromName: '  ' },
+        }],
+      }), 'Acme Services');
+
+      expect(from).toEqual({ email: 'notifications@acme.com', name: 'Acme Services' });
+    }
+  );
+
+  it('uses the tenant company before environment branding', () => {
+    process.env.EMAIL_FROM = 'Environment Sender <env@example.net>';
+    process.env.EMAIL_FROM_NAME = 'Environment Name';
+
+    const from = resolveFromAddress(buildSettings(), 'Acme Services');
+
+    expect(from).toEqual({ email: 'env@acme.com', name: 'Acme Services' });
+  });
+
+  it('applies a per-message display name without changing the resolved address', () => {
+    const settings = buildSettings({
+      providerConfigs: [{
+        providerId: 'smtp-provider',
+        providerType: 'smtp',
+        isEnabled: true,
+        config: { from: 'notifications@example.net' },
+      }],
+    });
+
+    const from = resolveMessageFrom(settings, {
+      fromName: 'Acme Services Portal',
+      resolvedTenantCompanyName: 'Acme Services',
+    });
+
+    expect(from).toEqual({ email: 'notifications@acme.com', name: 'Acme Services Portal' });
+  });
+
+  it('preserves an explicit ticket identity unless a name override is supplied', () => {
+    const settings = buildSettings();
+
+    expect(resolveMessageFrom(settings, {
+      from: { email: 'support@acme.com', name: 'Acme Support' },
+    })).toEqual({ email: 'support@acme.com', name: 'Acme Support' });
+
+    expect(resolveMessageFrom(settings, {
+      from: { email: 'support@acme.com', name: 'Acme Support' },
+      fromName: 'Escalations',
+    })).toEqual({ email: 'support@acme.com', name: 'Escalations' });
   });
 });

--- a/packages/email/src/__tests__/TenantEmailService.settingsFreshness.test.ts
+++ b/packages/email/src/__tests__/TenantEmailService.settingsFreshness.test.ts
@@ -26,6 +26,10 @@ vi.mock('@alga-psa/event-bus/publishers', () => ({
   publishWorkflowEvent: vi.fn(async () => undefined),
 }));
 
+vi.mock('../features', () => ({
+  isEnterprise: false,
+}));
+
 vi.mock('@alga-psa/db', () => ({
   createTenantKnex: vi.fn(async () => ({ knex: {} })),
   getConnection: vi.fn(async () => ({})),
@@ -93,7 +97,10 @@ vi.mock('../providers/EmailProviderManager', () => ({
 
 import { TenantEmailService } from '../TenantEmailService';
 
-function buildSettingsRow(config: { password: string; from: string; fromName: string }) {
+function buildSettingsRow(
+  config: { password: string; from: string; fromName: string },
+  updatedAt = new Date('2026-08-04T12:00:00.000Z')
+) {
   return {
     tenant: 'tenant-settings-freshness',
     default_from_domain: 'example.test',
@@ -113,7 +120,7 @@ function buildSettingsRow(config: { password: string; from: string; fromName: st
     }],
     tracking_enabled: false,
     created_at: new Date('2026-08-04T12:00:00.000Z'),
-    updated_at: new Date('2026-08-04T12:00:00.000Z'),
+    updated_at: updatedAt,
   };
 }
 
@@ -171,6 +178,36 @@ describe('TenantEmailService settings freshness', () => {
         from: { email: 'new-notifications@example.test', name: 'New Notifications' },
       },
     ]);
+  });
+
+  it('refreshes configuration preflights after another process creates settings', async () => {
+    runtime.settingsRow = null;
+    const service = TenantEmailService.getInstance('tenant-settings-freshness');
+
+    await expect(service.isConfigured()).resolves.toBe(false);
+    runtime.settingsRow = buildSettingsRow({
+      password: 'created-password',
+      from: 'created-notifications@example.test',
+      fromName: 'Created Notifications',
+    }, new Date('2026-08-04T12:05:00.000Z'));
+
+    await expect(service.isConfigured()).resolves.toBe(true);
+    expect(runtime.initializedSettings).toHaveLength(1);
+    expect(runtime.initializedSettings[0].providerConfigs[0].config.password).toBe('created-password');
+  });
+
+  it('treats a settings save as a cross-process provider refresh signal', async () => {
+    const service = TenantEmailService.getInstance('tenant-settings-freshness');
+
+    await expect(service.isConfigured()).resolves.toBe(true);
+    runtime.settingsRow = buildSettingsRow({
+      password: 'old-password',
+      from: 'old-notifications@example.test',
+      fromName: 'Old Notifications',
+    }, new Date('2026-08-04T12:10:00.000Z'));
+    await expect(service.isConfigured()).resolves.toBe(true);
+
+    expect(runtime.initializedSettings).toHaveLength(2);
   });
 
   it('keeps an in-flight send paired with the provider settings it resolved', async () => {

--- a/packages/email/src/__tests__/TenantEmailService.settingsFreshness.test.ts
+++ b/packages/email/src/__tests__/TenantEmailService.settingsFreshness.test.ts
@@ -1,0 +1,229 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const runtime = vi.hoisted(() => ({
+  companyName: 'Example MSP',
+  initializedSettings: [] as Array<Record<string, any>>,
+  sent: [] as Array<{ config: Record<string, any>; message: Record<string, any> }>,
+  settingsRow: null as Record<string, any> | null,
+}));
+
+vi.mock('@alga-psa/core/logger', () => ({
+  default: {
+    debug: vi.fn(),
+    error: vi.fn(),
+    info: vi.fn(),
+    warn: vi.fn(),
+  },
+}));
+
+vi.mock('@alga-psa/core/rateLimit', () => ({
+  TokenBucketRateLimiter: {
+    getInstance: () => ({ isReady: () => false }),
+  },
+}));
+
+vi.mock('@alga-psa/event-bus/publishers', () => ({
+  publishWorkflowEvent: vi.fn(async () => undefined),
+}));
+
+vi.mock('@alga-psa/db', () => ({
+  createTenantKnex: vi.fn(async () => ({ knex: {} })),
+  getConnection: vi.fn(async () => ({})),
+  isTenantSuspended: vi.fn(async () => false),
+  tenantDb: () => ({
+    table: (table: string) => {
+      if (table === 'tenant_email_settings') {
+        return { first: vi.fn(async () => runtime.settingsRow) };
+      }
+      if (table === 'email_sending_logs') {
+        return { insert: vi.fn(async () => 1) };
+      }
+      throw new Error(`Unexpected table in email freshness test: ${table}`);
+    },
+  }),
+}));
+
+vi.mock('../senderIdentity', () => ({
+  applyFromNameOverride: (
+    address: string | { email: string; name?: string },
+    fromName?: string
+  ) => {
+    const resolved = typeof address === 'string' ? { email: address } : address;
+    return fromName?.trim() ? { ...resolved, name: fromName.trim() } : resolved;
+  },
+  resolveDefaultFromAddress: (settings: Record<string, any> | null, companyName?: string | null) => {
+    const provider = settings?.providerConfigs?.find((config: Record<string, any>) => config.isEnabled);
+    return {
+      email: provider?.config?.from || 'notifications@example.test',
+      name: provider?.config?.fromName?.trim() || companyName || 'Alga PSA Notifications',
+    };
+  },
+  resolveTenantCompanyName: vi.fn(async () => runtime.companyName),
+}));
+
+vi.mock('../providers/EmailProviderManager', () => ({
+  EmailProviderManager: class {
+    private provider: Record<string, any> | null = null;
+
+    async initialize(settings: Record<string, any>) {
+      runtime.initializedSettings.push(settings);
+      const config = settings.providerConfigs.find((candidate: Record<string, any>) => candidate.isEnabled);
+      const capturedConfig = { ...config.config };
+      this.provider = {
+        providerId: config.providerId,
+        providerType: config.providerType,
+        sendEmail: vi.fn(async (message: Record<string, any>) => {
+          runtime.sent.push({ config: capturedConfig, message });
+          return {
+            success: true,
+            messageId: `message-${runtime.sent.length}`,
+            providerId: config.providerId,
+            providerType: config.providerType,
+            sentAt: new Date(),
+          };
+        }),
+      };
+    }
+
+    async getAvailableProviders() {
+      return this.provider ? [this.provider] : [];
+    }
+  },
+}));
+
+import { TenantEmailService } from '../TenantEmailService';
+
+function buildSettingsRow(config: { password: string; from: string; fromName: string }) {
+  return {
+    tenant: 'tenant-settings-freshness',
+    default_from_domain: 'example.test',
+    ticketing_from_email: 'tickets@example.test',
+    ticketing_from_name: 'Ticket Support',
+    custom_domains: [],
+    email_provider: 'smtp',
+    provider_configs: [{
+      providerId: 'smtp-provider',
+      providerType: 'smtp',
+      isEnabled: true,
+      config: {
+        host: 'smtp.example.test',
+        username: 'mailer',
+        ...config,
+      },
+    }],
+    tracking_enabled: false,
+    created_at: new Date('2026-08-04T12:00:00.000Z'),
+    updated_at: new Date('2026-08-04T12:00:00.000Z'),
+  };
+}
+
+describe('TenantEmailService settings freshness', () => {
+  beforeEach(async () => {
+    runtime.initializedSettings.length = 0;
+    runtime.sent.length = 0;
+    runtime.companyName = 'Example MSP';
+    runtime.settingsRow = buildSettingsRow({
+      password: 'old-password',
+      from: 'old-notifications@example.test',
+      fromName: 'Old Notifications',
+    });
+    await TenantEmailService.invalidateTenantSettings('tenant-settings-freshness');
+  });
+
+  it('reloads provider credentials and notification identity on a reused instance', async () => {
+    const service = TenantEmailService.getInstance('tenant-settings-freshness');
+    const params = {
+      tenantId: 'tenant-settings-freshness',
+      to: 'client@example.test',
+      subject: 'Status update',
+      html: '<p>Status update</p>',
+    };
+
+    await expect(service.sendEmail(params)).resolves.toMatchObject({ success: true });
+
+    // Keep updated_at unchanged deliberately: freshness is based on the actual
+    // persisted provider settings, not a timestamp or optimistic UI state.
+    runtime.settingsRow = buildSettingsRow({
+      password: 'new-password',
+      from: 'new-notifications@example.test',
+      fromName: 'New Notifications',
+    });
+
+    await expect(service.sendEmail(params)).resolves.toMatchObject({ success: true });
+    await expect(service.sendEmail(params)).resolves.toMatchObject({ success: true });
+
+    expect(TenantEmailService.getInstance('tenant-settings-freshness')).toBe(service);
+    expect(runtime.initializedSettings).toHaveLength(2);
+    expect(runtime.sent.map(send => ({
+      password: send.config.password,
+      from: send.message.from,
+    }))).toEqual([
+      {
+        password: 'old-password',
+        from: { email: 'old-notifications@example.test', name: 'Old Notifications' },
+      },
+      {
+        password: 'new-password',
+        from: { email: 'new-notifications@example.test', name: 'New Notifications' },
+      },
+      {
+        password: 'new-password',
+        from: { email: 'new-notifications@example.test', name: 'New Notifications' },
+      },
+    ]);
+  });
+
+  it('keeps an in-flight send paired with the provider settings it resolved', async () => {
+    const service = TenantEmailService.getInstance('tenant-settings-freshness');
+    let releaseTemplate!: () => void;
+    let markTemplateStarted!: () => void;
+    const templateStarted = new Promise<void>((resolve) => {
+      markTemplateStarted = resolve;
+    });
+    const templateRelease = new Promise<void>((resolve) => {
+      releaseTemplate = resolve;
+    });
+
+    const firstSend = service.sendEmail({
+      tenantId: 'tenant-settings-freshness',
+      to: 'first@example.test',
+      templateProcessor: {
+        process: async () => {
+          markTemplateStarted();
+          await templateRelease;
+          return { subject: 'First', html: '<p>First</p>', text: 'First' };
+        },
+      },
+    });
+    await templateStarted;
+
+    runtime.settingsRow = buildSettingsRow({
+      password: 'new-password',
+      from: 'new-notifications@example.test',
+      fromName: 'New Notifications',
+    });
+    await service.sendEmail({
+      tenantId: 'tenant-settings-freshness',
+      to: 'second@example.test',
+      subject: 'Second',
+      html: '<p>Second</p>',
+    });
+
+    releaseTemplate();
+    await firstSend;
+
+    expect(runtime.sent.map(send => ({
+      password: send.config.password,
+      from: send.message.from,
+    }))).toEqual([
+      {
+        password: 'new-password',
+        from: { email: 'new-notifications@example.test', name: 'New Notifications' },
+      },
+      {
+        password: 'old-password',
+        from: { email: 'old-notifications@example.test', name: 'Old Notifications' },
+      },
+    ]);
+  });
+});

--- a/packages/email/src/__tests__/sendPortalInvitationEmail.test.ts
+++ b/packages/email/src/__tests__/sendPortalInvitationEmail.test.ts
@@ -1,0 +1,82 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const {
+  getConnectionMock,
+  resolveEmailLocaleMock,
+  systemSendMock,
+  tenantSendMock,
+} = vi.hoisted(() => ({
+  getConnectionMock: vi.fn(),
+  resolveEmailLocaleMock: vi.fn(),
+  systemSendMock: vi.fn(),
+  tenantSendMock: vi.fn(),
+}));
+
+vi.mock('@alga-psa/db', () => ({
+  getConnection: getConnectionMock,
+  runWithTenant: (_tenant: string, callback: () => Promise<unknown>) => callback(),
+}));
+
+vi.mock('../index', () => ({
+  getSystemEmailService: vi.fn(async () => ({ sendEmail: systemSendMock })),
+  TenantEmailService: {
+    getInstance: vi.fn(() => ({ sendEmail: tenantSendMock })),
+  },
+}));
+
+vi.mock('../emailLocaleResolver', () => ({
+  getUserInfoForEmail: vi.fn(async () => null),
+  resolveEmailLocale: resolveEmailLocaleMock,
+}));
+
+vi.mock('../templateProcessors', () => ({
+  DatabaseTemplateProcessor: class {},
+}));
+
+import { sendPortalInvitationEmail } from '../sendPortalInvitationEmail';
+
+const params = {
+  email: 'contact@example.test',
+  contactName: 'Casey Client',
+  clientName: 'Example Client',
+  tenantName: 'Example MSP',
+  portalLink: 'https://portal.example.test/setup',
+  expirationTime: '24 hours',
+  tenant: 'tenant-1',
+  supportEmail: 'support@example.test',
+  fromName: 'Example MSP Portal',
+};
+
+describe('sendPortalInvitationEmail sender identity', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    getConnectionMock.mockResolvedValue({});
+    resolveEmailLocaleMock.mockResolvedValue('en');
+    tenantSendMock.mockResolvedValue({ success: true });
+    systemSendMock.mockResolvedValue({ success: true });
+  });
+
+  it('forwards the explicit portal display name to the tenant provider', async () => {
+    await sendPortalInvitationEmail(params);
+
+    expect(tenantSendMock).toHaveBeenCalledWith(expect.objectContaining({
+      tenantId: 'tenant-1',
+      fromName: 'Example MSP Portal',
+      replyTo: 'support@example.test',
+    }));
+    expect(systemSendMock).not.toHaveBeenCalled();
+  });
+
+  it('forwards the same display name to the system fallback without a tenant From address', async () => {
+    tenantSendMock.mockResolvedValue({ success: false, error: 'provider unavailable' });
+
+    await sendPortalInvitationEmail(params);
+
+    expect(systemSendMock).toHaveBeenCalledWith(expect.objectContaining({
+      tenantId: 'tenant-1',
+      fromName: 'Example MSP Portal',
+      replyTo: 'support@example.test',
+    }));
+    expect(systemSendMock.mock.calls[0]?.[0]).not.toHaveProperty('from');
+  });
+});

--- a/packages/email/src/index.ts
+++ b/packages/email/src/index.ts
@@ -60,6 +60,13 @@ export { SystemEmailProviderFactory } from './system/SystemEmailProviderFactory'
 // Tenant email provider manager
 export { EmailProviderManager } from './providers/EmailProviderManager';
 
+export {
+  applyFromNameOverride,
+  parseEmailAddress,
+  resolveDefaultFromAddress,
+  resolveTenantCompanyName,
+} from './senderIdentity';
+
 // Shared settings defaults
 export {
   createDefaultProviderConfig,

--- a/packages/email/src/providers/MicrosoftGraphEmailProvider.ts
+++ b/packages/email/src/providers/MicrosoftGraphEmailProvider.ts
@@ -206,7 +206,8 @@ export class MicrosoftGraphEmailProvider implements IEmailProvider {
 
   private async buildSendPayload(message: EmailMessage): Promise<MicrosoftGraphSendMailPayload> {
     const headers = Object.keys(message.headers || {});
-    const requiresMime = headers.some(name => !name.toLowerCase().startsWith('x-'));
+    const requiresMime = Boolean(message.from?.name?.trim())
+      || headers.some(name => !name.toLowerCase().startsWith('x-'));
 
     if (!requiresMime) {
       return { kind: 'json', message: this.buildGraphMessage(message) };

--- a/packages/email/src/providers/__tests__/MicrosoftGraphEmailProvider.test.ts
+++ b/packages/email/src/providers/__tests__/MicrosoftGraphEmailProvider.test.ts
@@ -82,7 +82,10 @@ describe('MicrosoftGraphEmailProvider', () => {
     const provider = new MicrosoftGraphEmailProvider('microsoft-provider-1');
     await provider.initialize(providerConfig());
 
-    const result = await provider.sendEmail(message({ headers: undefined }), 'tenant-1');
+    const result = await provider.sendEmail(message({
+      from: { email: 'ignored@example.net' },
+      headers: undefined,
+    }), 'tenant-1');
 
     expect(sendMailMock).toHaveBeenCalledWith({
       kind: 'json',
@@ -111,6 +114,25 @@ describe('MicrosoftGraphEmailProvider', () => {
     });
     expect(result.messageId).toBeUndefined();
   });
+
+  it.each(['Example MSP', 'Example MSP Portal'])(
+    'uses MIME to carry the %s display name with the selected mailbox',
+    async (fromName) => {
+      const provider = new MicrosoftGraphEmailProvider('microsoft-provider-1');
+      await provider.initialize(providerConfig());
+
+      await provider.sendEmail(message({
+        from: { email: 'ignored@example.net', name: fromName },
+        headers: undefined,
+        attachments: undefined,
+      }), 'tenant-1');
+
+      const payload = sendMailMock.mock.calls[0]?.[0];
+      expect(payload.kind).toBe('mime');
+      const mime = Buffer.from(payload.content, 'base64').toString('utf8');
+      expect(mime).toContain(`From: ${fromName} <support+desk@example.com>`);
+    }
+  );
 
   it('uses MIME to retain ticket threading headers that Graph JSON cannot set', async () => {
     const provider = new MicrosoftGraphEmailProvider('microsoft-provider-1');

--- a/packages/email/src/providers/__tests__/ResendEmailProvider.test.ts
+++ b/packages/email/src/providers/__tests__/ResendEmailProvider.test.ts
@@ -94,6 +94,20 @@ describe('ResendEmailProvider payload construction', () => {
     expect(client.post.mock.calls[0][1].from).toBe('noreply@alga.test');
   });
 
+  it.each(['Example MSP', 'Example MSP Portal'])(
+    'serializes the %s display name in the From field',
+    async (name) => {
+      const { provider, client } = await initializedProvider();
+
+      await provider.sendEmail(baseMessage({
+        from: { email: 'notifications@example.test', name },
+      }));
+
+      expect(client.post.mock.calls[0][1].from)
+        .toBe(`${name} <notifications@example.test>`);
+    }
+  );
+
   it('maps cc, bcc and replyTo into Resend fields', async () => {
     const { provider, client } = await initializedProvider();
 

--- a/packages/email/src/providers/__tests__/SMTPEmailProvider.test.ts
+++ b/packages/email/src/providers/__tests__/SMTPEmailProvider.test.ts
@@ -85,6 +85,20 @@ describe('SMTPEmailProvider mail options construction', () => {
     });
   });
 
+  it.each(['Example MSP', 'Example MSP Portal'])(
+    'serializes the %s display name in the From header',
+    async (name) => {
+      const { provider, transporter } = await initializedProvider();
+
+      await provider.sendEmail(baseMessage({
+        from: { email: 'notifications@example.test', name },
+      }), 'tenant-1');
+
+      expect(transporter.sendMail.mock.calls[0][0].from)
+        .toBe(`"${name}" <notifications@example.test>`);
+    }
+  );
+
   it('includes cc, bcc, replyTo, headers and converted attachments when present', async () => {
     const { provider, transporter } = await initializedProvider();
     const content = Buffer.from('attachment-bytes');

--- a/packages/email/src/sendPortalInvitationEmail.ts
+++ b/packages/email/src/sendPortalInvitationEmail.ts
@@ -32,7 +32,7 @@ export async function sendPortalInvitationEmail({
   tenant,
   supportEmail,
   supportPhone,
-  fromName: _fromName,
+  fromName,
   recipientUserId,
   clientId
 }: SendPortalInvitationEmailParams): Promise<boolean> {
@@ -93,6 +93,7 @@ export async function sendPortalInvitationEmail({
         templateProcessor,
         templateData,
         locale: recipientLocale,
+        fromName,
         replyTo: supportEmail // MSP support email as reply-to
       };
 

--- a/packages/email/src/senderIdentity.ts
+++ b/packages/email/src/senderIdentity.ts
@@ -1,0 +1,158 @@
+import type { Knex } from 'knex';
+import { tenantDb } from '@alga-psa/db';
+import type { EmailAddress, TenantEmailSettings } from '@alga-psa/types';
+
+export function parseEmailAddress(value?: string | EmailAddress | null): EmailAddress | null {
+  if (!value) {
+    return null;
+  }
+
+  if (typeof value === 'object') {
+    if (!value.email) {
+      return null;
+    }
+    return { email: value.email, name: value.name };
+  }
+
+  const trimmed = value.trim();
+  if (!trimmed) {
+    return null;
+  }
+
+  const match = trimmed.match(/^(?:"?([^"]*)"?\s*)?<([^>]+)>$/);
+  if (match) {
+    const name = match[1]?.trim();
+    return {
+      email: match[2].trim(),
+      name: name || undefined,
+    };
+  }
+
+  return { email: trimmed };
+}
+
+function extractEmailParts(email?: string | null): { localPart: string; domain?: string } | null {
+  if (!email) {
+    return null;
+  }
+
+  const [localPart, domain] = email.split('@');
+  if (!domain) {
+    return { localPart: localPart || email };
+  }
+
+  return { localPart, domain };
+}
+
+function sanitizeLocalPart(localPart?: string | null): string {
+  if (!localPart) {
+    return 'notifications';
+  }
+
+  const normalized = localPart
+    .toLowerCase()
+    .replace(/[^a-z0-9._+-]/g, '');
+
+  return normalized || 'notifications';
+}
+
+function sanitizeDomain(domain?: string | null): string | null {
+  if (!domain) {
+    return null;
+  }
+
+  const normalized = domain.trim().replace(/^@/, '').toLowerCase();
+  return normalized || null;
+}
+
+function extractDomainFromAddress(address?: string): string | null {
+  const parsed = parseEmailAddress(address);
+  const parts = extractEmailParts(parsed?.email);
+  return parts?.domain || null;
+}
+
+function getProviderConfiguredAddress(settings?: TenantEmailSettings | null): EmailAddress | null {
+  const enabledConfig = settings?.providerConfigs?.find(config => config.isEnabled && config.config);
+  if (!enabledConfig) {
+    return null;
+  }
+
+  const configFrom = enabledConfig.config.from;
+  const configFromName = enabledConfig.config.fromName ?? enabledConfig.config.from_name;
+  if (typeof configFrom !== 'string' || !configFrom.trim()) {
+    return null;
+  }
+
+  const parsed = parseEmailAddress(configFrom) || { email: configFrom.trim() };
+  const normalizedName = typeof configFromName === 'string' ? configFromName.trim() : '';
+  if (!parsed.name && normalizedName) {
+    parsed.name = normalizedName;
+  }
+  return parsed;
+}
+
+export async function resolveTenantCompanyName(
+  knex: Knex | Knex.Transaction,
+  tenantId: string
+): Promise<string | null> {
+  const db = tenantDb(knex, tenantId);
+  const defaultClientQuery = db.table('tenant_companies as tc')
+    .where({ 'tc.is_default': true })
+    .whereNull('tc.deleted_at')
+    .select('c.client_name');
+  db.tenantJoin(defaultClientQuery, 'clients as c', 'tc.client_id', 'c.client_id');
+
+  const defaultClient = await defaultClientQuery.first<{ client_name?: string | null }>();
+  const defaultClientName = defaultClient?.client_name?.trim();
+  if (defaultClientName) {
+    return defaultClientName;
+  }
+
+  const tenant = await db.table('tenants')
+    .select('client_name')
+    .first<{ client_name?: string | null }>();
+
+  return tenant?.client_name?.trim() || null;
+}
+
+export function resolveDefaultFromAddress(
+  settings?: TenantEmailSettings | null,
+  tenantCompanyName?: string | null
+): EmailAddress {
+  const providerAddress = getProviderConfiguredAddress(settings);
+  const envAddress = parseEmailAddress(process.env.EMAIL_FROM);
+  const fallbackName = providerAddress?.name
+    || tenantCompanyName?.trim()
+    || envAddress?.name
+    || process.env.EMAIL_FROM_NAME?.trim()
+    || 'Alga PSA Notifications';
+  const fallbackEmail = providerAddress?.email || envAddress?.email || 'notifications@example.com';
+
+  const emailParts = extractEmailParts(fallbackEmail);
+  const localPart = sanitizeLocalPart(emailParts?.localPart);
+  const configuredDomain = sanitizeDomain(settings?.defaultFromDomain);
+  const fallbackDomain = sanitizeDomain(emailParts?.domain)
+    || sanitizeDomain(extractDomainFromAddress(fallbackEmail));
+  const targetDomain = configuredDomain || fallbackDomain;
+
+  return {
+    email: targetDomain ? `${localPart}@${targetDomain}` : fallbackEmail,
+    name: fallbackName,
+  };
+}
+
+export function applyFromNameOverride(
+  address: string | EmailAddress,
+  fromName?: string | null
+): EmailAddress {
+  const resolved = parseEmailAddress(address);
+  if (!resolved) {
+    throw new Error('A valid From address is required');
+  }
+
+  const normalizedName = fromName?.trim();
+  return {
+    ...resolved,
+    ...(normalizedName ? { name: normalizedName } : {}),
+  };
+}

--- a/packages/email/src/system/SystemEmailProviderFactory.ts
+++ b/packages/email/src/system/SystemEmailProviderFactory.ts
@@ -1,4 +1,5 @@
 import logger from '@alga-psa/core/logger';
+import { createHash } from 'node:crypto';
 import { IEmailProvider, EmailProviderConfig } from '@alga-psa/types';
 import { SMTPEmailProvider } from '../providers/SMTPEmailProvider';
 import { ResendEmailProvider } from '../providers/ResendEmailProvider';
@@ -13,6 +14,32 @@ export interface SystemEmailProviderConfig {
  * Uses environment variables to determine which provider to create
  */
 export class SystemEmailProviderFactory {
+  /**
+   * Hash every environment value that shapes the process-wide provider. This
+   * lets long-lived services notice credential/address rotation without
+   * retaining another plaintext copy of the credentials.
+   */
+  static getConfigFingerprint(): string {
+    const config = {
+      emailEnable: process.env.EMAIL_ENABLE,
+      providerType: process.env.EMAIL_PROVIDER_TYPE,
+      resendApiKey: process.env.RESEND_API_KEY,
+      resendBaseUrl: process.env.RESEND_BASE_URL,
+      emailHost: process.env.EMAIL_HOST,
+      emailPort: process.env.EMAIL_PORT,
+      emailUsername: process.env.EMAIL_USERNAME,
+      emailUser: process.env.EMAIL_USER,
+      emailPassword: process.env.EMAIL_PASSWORD,
+      emailPass: process.env.EMAIL_PASS,
+      emailFrom: process.env.EMAIL_FROM,
+      smtpFrom: process.env.SMTP_FROM,
+      rejectUnauthorized: process.env.EMAIL_REJECT_UNAUTHORIZED,
+      requireTls: process.env.EMAIL_REQUIRE_TLS,
+    };
+
+    return createHash('sha256').update(JSON.stringify(config)).digest('hex');
+  }
+
   /**
    * Create an email provider based on environment configuration
    */

--- a/packages/email/src/system/SystemEmailService.ts
+++ b/packages/email/src/system/SystemEmailService.ts
@@ -20,6 +20,7 @@ import { tenantDb, getConnection } from '@alga-psa/db';
 import { SupportedLocale, LOCALE_CONFIG, isSupportedLocale } from '../lib/localeConfig';
 import { resolveEmailLocale } from '../emailLocaleResolver';
 import Handlebars from 'handlebars';
+import { applyFromNameOverride } from '../senderIdentity';
 
 const SYSTEM_EMAIL_TEMPLATE_LOOKUP_TENANT = '__system_email_template_lookup__';
 
@@ -72,11 +73,9 @@ export class SystemEmailService extends BaseEmailService {
     return SystemEmailProviderFactory.createProvider();
   }
 
-  protected getFromAddress(params?: BaseEmailParams): string {
-    if (params?.from) {
-      return typeof params.from === 'string' ? params.from : params.from.email;
-    }
-    return this.fromAddress || process.env.EMAIL_FROM || 'noreply@localhost';
+  protected getFromAddress(params?: BaseEmailParams) {
+    const address = params?.from || this.fromAddress || process.env.EMAIL_FROM || 'noreply@localhost';
+    return applyFromNameOverride(address, params?.fromName);
   }
 
   /**

--- a/packages/email/src/system/SystemEmailService.ts
+++ b/packages/email/src/system/SystemEmailService.ts
@@ -24,6 +24,12 @@ import { applyFromNameOverride } from '../senderIdentity';
 
 const SYSTEM_EMAIL_TEMPLATE_LOOKUP_TENANT = '__system_email_template_lookup__';
 
+interface SystemProviderSnapshot {
+  emailProvider: IEmailProvider | null;
+  providerInitError: string | null;
+  fromAddress: string;
+}
+
 // Extend BaseEmailParams for system-specific parameters
 export interface SystemEmailParams extends BaseEmailParams {
   subject?: string;
@@ -49,6 +55,8 @@ export interface SystemEmailParams extends BaseEmailParams {
 export class SystemEmailService extends BaseEmailService {
   private static instance: SystemEmailService;
   private fromAddress: string | null = null;
+  private providerConfigFingerprint: string | null = null;
+  private providerStateQueue: Promise<void> = Promise.resolve();
 
   private constructor() {
     super();
@@ -73,8 +81,16 @@ export class SystemEmailService extends BaseEmailService {
     return SystemEmailProviderFactory.createProvider();
   }
 
+  public override async initialize(): Promise<void> {
+    await this.refreshProviderState();
+  }
+
   protected getFromAddress(params?: BaseEmailParams) {
-    const address = params?.from || this.fromAddress || process.env.EMAIL_FROM || 'noreply@localhost';
+    const address = params?.from
+      || params?.resolvedSystemFromAddress
+      || this.fromAddress
+      || process.env.EMAIL_FROM
+      || 'noreply@localhost';
     return applyFromNameOverride(address, params?.fromName);
   }
 
@@ -248,7 +264,65 @@ export class SystemEmailService extends BaseEmailService {
    */
   public async sendEmail(params: SystemEmailParams): Promise<EmailSendResult> {
     // SystemEmailService can accept subject/html/text directly
-    return super.sendEmail(params);
+    const providerSnapshot = await this.refreshProviderState();
+    return super.sendEmail({
+      ...params,
+      resolvedSystemFromAddress: providerSnapshot.fromAddress,
+      resolvedEmailProvider: providerSnapshot.emailProvider,
+      resolvedProviderInitError: providerSnapshot.providerInitError,
+    });
+  }
+
+  public override async isConfigured(): Promise<boolean> {
+    const providerSnapshot = await this.refreshProviderState();
+    return providerSnapshot.emailProvider !== null;
+  }
+
+  public override async getInitializationError(): Promise<string | null> {
+    const providerSnapshot = await this.refreshProviderState();
+    return providerSnapshot.providerInitError;
+  }
+
+  private async withProviderStateLock<T>(operation: () => Promise<T>): Promise<T> {
+    const previous = this.providerStateQueue;
+    let release!: () => void;
+    this.providerStateQueue = new Promise<void>((resolve) => {
+      release = resolve;
+    });
+
+    await previous;
+    try {
+      return await operation();
+    } finally {
+      release();
+    }
+  }
+
+  private async refreshProviderState(): Promise<SystemProviderSnapshot> {
+    return this.withProviderStateLock(async () => {
+      const fingerprint = SystemEmailProviderFactory.getConfigFingerprint();
+      if (this.initialized && fingerprint === this.providerConfigFingerprint) {
+        return {
+          emailProvider: this.emailProvider,
+          providerInitError: this.providerInitError,
+          fromAddress: this.fromAddress || process.env.EMAIL_FROM || 'noreply@localhost',
+        };
+      }
+
+      this.initialized = false;
+      this.emailProvider = null;
+      this.providerInitError = null;
+      this.fromAddress = null;
+      this.providerConfigFingerprint = null;
+      await super.initialize();
+      this.providerConfigFingerprint = fingerprint;
+
+      return {
+        emailProvider: this.emailProvider,
+        providerInitError: this.providerInitError,
+        fromAddress: this.fromAddress || process.env.EMAIL_FROM || 'noreply@localhost',
+      };
+    });
   }
 
   /**

--- a/packages/integrations/src/actions/email-actions/emailSettingsActions.clear.test.ts
+++ b/packages/integrations/src/actions/email-actions/emailSettingsActions.clear.test.ts
@@ -19,6 +19,11 @@ vi.mock('@alga-psa/email', () => ({
   TenantEmailService: {
     getTenantEmailSettings: getTenantEmailSettingsMock,
   },
+  resolveTenantCompanyName: vi.fn(async () => 'Example MSP'),
+  resolveDefaultFromAddress: vi.fn(() => ({
+    email: 'notifications@acme.com',
+    name: 'Example MSP',
+  })),
 }));
 
 vi.mock('@alga-psa/email/providerConfig', () => ({

--- a/packages/integrations/src/actions/email-actions/emailSettingsActions.clear.test.ts
+++ b/packages/integrations/src/actions/email-actions/emailSettingsActions.clear.test.ts
@@ -2,6 +2,7 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 const createTenantKnexMock = vi.fn();
 const getTenantEmailSettingsMock = vi.fn();
+const invalidateTenantSettingsMock = vi.fn();
 
 vi.mock('@alga-psa/db', () => ({
   createTenantKnex: createTenantKnexMock,
@@ -18,6 +19,7 @@ vi.mock('@alga-psa/auth', () => ({
 vi.mock('@alga-psa/email', () => ({
   TenantEmailService: {
     getTenantEmailSettings: getTenantEmailSettingsMock,
+    invalidateTenantSettings: invalidateTenantSettingsMock,
   },
   resolveTenantCompanyName: vi.fn(async () => 'Example MSP'),
   resolveDefaultFromAddress: vi.fn(() => ({
@@ -44,6 +46,8 @@ describe('updateEmailSettings clear behavior', () => {
   beforeEach(() => {
     createTenantKnexMock.mockReset();
     getTenantEmailSettingsMock.mockReset();
+    invalidateTenantSettingsMock.mockReset();
+    invalidateTenantSettingsMock.mockResolvedValue(undefined);
   });
 
   it('persists null when clearing the ticketing From address', async () => {

--- a/packages/integrations/src/actions/email-actions/emailSettingsActions.providers.test.ts
+++ b/packages/integrations/src/actions/email-actions/emailSettingsActions.providers.test.ts
@@ -22,6 +22,11 @@ vi.mock('@alga-psa/email', () => ({
   TenantEmailService: {
     getTenantEmailSettings: getTenantEmailSettingsMock,
   },
+  resolveTenantCompanyName: vi.fn(async () => 'Example MSP'),
+  resolveDefaultFromAddress: vi.fn((settings: TenantEmailSettings, companyName: string) => ({
+    email: settings.providerConfigs.find(config => config.isEnabled)?.config.from || 'notifications@example.test',
+    name: companyName,
+  })),
 }));
 
 vi.mock('@alga-psa/email/providerConfig', () => ({
@@ -70,6 +75,11 @@ describe('email settings provider invariants', () => {
 
     expect(result).toMatchObject({
       emailProvider: 'resend',
+      tenantCompanyName: 'Example MSP',
+      effectiveNotificationFrom: {
+        email: 'notifications@example.test',
+        name: 'Example MSP',
+      },
       providerConfigs: [
         {
           providerId: 'smtp-provider',
@@ -197,8 +207,9 @@ describe('email settings provider invariants', () => {
     ]);
   });
 
-  it('pins Microsoft outbound settings to a connected tenant mailbox', async () => {
-    const existingSettings = buildSettings('smtp', [
+  it('pins Microsoft outbound settings to a connected tenant mailbox without changing ticket identity', async () => {
+    const existingSettings = {
+      ...buildSettings('smtp', [
       {
         providerId: 'smtp-provider',
         providerType: 'smtp',
@@ -209,9 +220,12 @@ describe('email settings provider invariants', () => {
         providerId: 'microsoft-provider',
         providerType: 'microsoft',
         isEnabled: false,
-        config: { inboundProviderId: '', mailbox: '', from: '' },
+        config: { inboundProviderId: '', mailbox: '', from: '', fromName: 'Billing Team' },
       },
-    ]);
+      ]),
+      ticketingFromEmail: 'support@contoso.example',
+      ticketingFromName: 'Support Team',
+    };
     const updateMock = vi.fn(async (_value: Record<string, unknown>) => 1);
     const knexMock = vi.fn((table: string) => {
       const builder: any = {
@@ -238,6 +252,7 @@ describe('email settings provider invariants', () => {
         emailProvider: 'microsoft',
         defaultFromDomain: 'contoso.example',
         ticketingFromEmail: 'support@contoso.example',
+        ticketingFromName: 'Support Team',
       });
 
     const { updateEmailSettings } = await import('./emailSettingsActions');
@@ -247,7 +262,7 @@ describe('email settings provider invariants', () => {
         config.providerType === 'microsoft'
           ? {
               ...config,
-              config: { inboundProviderId: 'microsoft-inbound-1' },
+              config: { inboundProviderId: 'microsoft-inbound-1', fromName: ' Billing Team ' },
             }
           : config
       ),
@@ -260,6 +275,7 @@ describe('email settings provider invariants', () => {
       email_provider: 'microsoft',
       default_from_domain: 'contoso.example',
       ticketing_from_email: 'support@contoso.example',
+      ticketing_from_name: 'Support Team',
     });
     const configs = JSON.parse(String(payload?.provider_configs));
     expect(configs).toContainEqual({
@@ -270,9 +286,52 @@ describe('email settings provider invariants', () => {
         inboundProviderId: 'microsoft-inbound-1',
         mailbox: 'support@contoso.example',
         from: 'support@contoso.example',
-        fromName: 'Contoso Support',
+        fromName: 'Billing Team',
       },
     });
     expect(configs.find((config: EmailProviderConfig) => config.providerType === 'smtp')?.isEnabled).toBe(false);
+  });
+
+  it('rejects a Microsoft mailbox that conflicts with the saved ticket identity', async () => {
+    const existingSettings = {
+      ...buildSettings('smtp', [{
+        providerId: 'microsoft-provider',
+        providerType: 'microsoft' as const,
+        isEnabled: false,
+        config: { inboundProviderId: '', mailbox: '', from: '' },
+      }]),
+      ticketingFromEmail: 'tickets@other.example',
+    };
+    const updateMock = vi.fn();
+    const knexMock = vi.fn((table: string) => {
+      const builder: any = {
+        where: vi.fn(() => builder),
+        first: vi.fn(async () => table === 'email_providers'
+          ? {
+              id: 'microsoft-inbound-1',
+              mailbox: 'support@contoso.example',
+              status: 'connected',
+            }
+          : { tenant: 'tenant-123' }),
+        update: updateMock,
+      };
+      return builder;
+    }) as any;
+    createTenantKnexMock.mockResolvedValue({ knex: knexMock });
+    getTenantEmailSettingsMock.mockResolvedValue(existingSettings);
+
+    const { updateEmailSettings } = await import('./emailSettingsActions');
+    const result = await updateEmailSettings({
+      emailProvider: 'microsoft',
+      providerConfigs: existingSettings.providerConfigs.map(config => ({
+        ...config,
+        config: { inboundProviderId: 'microsoft-inbound-1', fromName: '' },
+      })),
+    });
+
+    expect(result).toMatchObject({
+      actionError: expect.stringContaining('Update the Ticket emails address'),
+    });
+    expect(updateMock).not.toHaveBeenCalled();
   });
 });

--- a/packages/integrations/src/actions/email-actions/emailSettingsActions.providers.test.ts
+++ b/packages/integrations/src/actions/email-actions/emailSettingsActions.providers.test.ts
@@ -1,9 +1,10 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import type { EmailProviderConfig, TenantEmailSettings } from '@alga-psa/types';
 
-const { createTenantKnexMock, getTenantEmailSettingsMock } = vi.hoisted(() => ({
+const { createTenantKnexMock, getTenantEmailSettingsMock, invalidateTenantSettingsMock } = vi.hoisted(() => ({
   createTenantKnexMock: vi.fn(),
   getTenantEmailSettingsMock: vi.fn(),
+  invalidateTenantSettingsMock: vi.fn(),
 }));
 
 vi.mock('@alga-psa/db', () => ({
@@ -21,6 +22,7 @@ vi.mock('@alga-psa/auth', () => ({
 vi.mock('@alga-psa/email', () => ({
   TenantEmailService: {
     getTenantEmailSettings: getTenantEmailSettingsMock,
+    invalidateTenantSettings: invalidateTenantSettingsMock,
   },
   resolveTenantCompanyName: vi.fn(async () => 'Example MSP'),
   resolveDefaultFromAddress: vi.fn((settings: TenantEmailSettings, companyName: string) => ({
@@ -64,6 +66,8 @@ describe('email settings provider invariants', () => {
   beforeEach(() => {
     createTenantKnexMock.mockReset();
     getTenantEmailSettingsMock.mockReset();
+    invalidateTenantSettingsMock.mockReset();
+    invalidateTenantSettingsMock.mockResolvedValue(undefined);
     createTenantKnexMock.mockResolvedValue({ knex: vi.fn() });
   });
 
@@ -190,6 +194,7 @@ describe('email settings provider invariants', () => {
     });
 
     expect(updateMock).toHaveBeenCalledOnce();
+    expect(invalidateTenantSettingsMock).toHaveBeenCalledWith('tenant-123');
     const persistedPayload = updateMock.mock.calls[0]?.[0];
     expect(persistedPayload).toBeDefined();
     const persisted = JSON.parse(persistedPayload?.provider_configs as string);

--- a/packages/integrations/src/actions/email-actions/emailSettingsActions.ts
+++ b/packages/integrations/src/actions/email-actions/emailSettingsActions.ts
@@ -316,6 +316,11 @@ export const updateEmailSettings = withAuth(async (
         });
     }
 
+    // Refresh any process-local singleton immediately. TenantEmailService also
+    // checks persisted settings before every send, covering other processes and
+    // direct database updates without broad/global cache invalidation.
+    await TenantEmailService.invalidateTenantSettings(tenant || '');
+
     // Re-fetch and return updated settings
     const updatedSettings = await getEmailSettings();
     if (isActionMessageError(updatedSettings)) {

--- a/packages/integrations/src/actions/email-actions/emailSettingsActions.ts
+++ b/packages/integrations/src/actions/email-actions/emailSettingsActions.ts
@@ -6,8 +6,12 @@
 
 import { createTenantKnex, tenantDb } from '@alga-psa/db';
 import { withAuth } from '@alga-psa/auth';
-import type { EmailProviderConfig, TenantEmailSettings } from '@alga-psa/types';
-import { TenantEmailService } from '@alga-psa/email';
+import type { EmailAddress, EmailProviderConfig, TenantEmailSettings } from '@alga-psa/types';
+import {
+  resolveDefaultFromAddress,
+  resolveTenantCompanyName,
+  TenantEmailService,
+} from '@alga-psa/email';
 import { createDefaultProviderConfig } from '@alga-psa/email/providerConfig';
 import {
   actionError,
@@ -33,6 +37,11 @@ export interface MicrosoftOutboundMailboxOption {
   providerName: string;
   senderDisplayName?: string | null;
   status: 'connected' | 'disconnected' | 'error' | 'configuring';
+}
+
+export interface EmailSettingsView extends TenantEmailSettings {
+  tenantCompanyName: string | null;
+  effectiveNotificationFrom: EmailAddress;
 }
 
 function withEditableProviderConfigs(settings: TenantEmailSettings): TenantEmailSettings {
@@ -93,10 +102,23 @@ function normalizeOptionalString(value?: string | null): string | null {
   return normalized || null;
 }
 
+async function toEmailSettingsView(
+  settings: TenantEmailSettings,
+  knex: Awaited<ReturnType<typeof createTenantKnex>>['knex'],
+  tenant: string
+): Promise<EmailSettingsView> {
+  const tenantCompanyName = await resolveTenantCompanyName(knex, tenant);
+  return {
+    ...withEditableProviderConfigs(settings),
+    tenantCompanyName,
+    effectiveNotificationFrom: resolveDefaultFromAddress(settings, tenantCompanyName),
+  };
+}
+
 export const getEmailSettings = withAuth(async (
   _user,
   { tenant }
-): Promise<TenantEmailSettings | null | ActionMessageError> => {
+): Promise<EmailSettingsView | null | ActionMessageError> => {
   const { knex } = await createTenantKnex();
 
   try {
@@ -129,7 +151,7 @@ export const getEmailSettings = withAuth(async (
         updatedAt: new Date()
       };
       
-      return withEditableProviderConfigs(defaultSettings);
+      return toEmailSettingsView(defaultSettings, knex, tenant || '');
     }
 
     // Don't expose sensitive data like passwords and API keys in full
@@ -145,7 +167,7 @@ export const getEmailSettings = withAuth(async (
       }))
     };
 
-    return withEditableProviderConfigs(sanitizedSettings);
+    return toEmailSettingsView(sanitizedSettings, knex, tenant || '');
   } catch (error: any) {
     console.error('Error fetching email settings:', error);
     return actionError('Failed to fetch email settings');
@@ -156,7 +178,7 @@ export const updateEmailSettings = withAuth(async (
   _user,
   { tenant },
   updates: EmailSettingsUpdateInput
-): Promise<TenantEmailSettings | ActionMessageError> => {
+): Promise<EmailSettingsView | ActionMessageError> => {
   const { knex } = await createTenantKnex();
 
   try {
@@ -201,6 +223,19 @@ export const updateEmailSettings = withAuth(async (
         return actionError('Reconnect the selected Microsoft 365 mailbox before using it for outbound email');
       }
 
+      if (
+        nextTicketingFromEmail
+        && nextTicketingFromEmail.toLowerCase() !== microsoftProvider.mailbox.toLowerCase()
+      ) {
+        return actionError(
+          `Ticket email identity must use the selected Microsoft 365 mailbox (${microsoftProvider.mailbox}). Update the Ticket emails address before saving.`
+        );
+      }
+
+      const notificationFromName = normalizeOptionalString(
+        requested?.config?.fromName ?? requested?.config?.from_name
+      );
+
       const microsoftConfig: EmailProviderConfig = {
         providerId: microsoftProvider.id,
         providerType: 'microsoft',
@@ -209,7 +244,7 @@ export const updateEmailSettings = withAuth(async (
           inboundProviderId: microsoftProvider.id,
           mailbox: microsoftProvider.mailbox,
           from: microsoftProvider.mailbox,
-          fromName: microsoftProvider.sender_display_name || undefined,
+          fromName: notificationFromName || undefined,
         },
       };
       mergedProviderConfigs = [
@@ -217,7 +252,6 @@ export const updateEmailSettings = withAuth(async (
         microsoftConfig,
       ];
       nextDefaultFromDomain = extractDomain(microsoftProvider.mailbox) || undefined;
-      nextTicketingFromEmail = microsoftProvider.mailbox;
     }
 
     const normalizedProviderConfigs = mergedProviderConfigs.map(config => ({

--- a/packages/integrations/src/actions/index.ts
+++ b/packages/integrations/src/actions/index.ts
@@ -82,7 +82,10 @@ export {
   updateEmailSettings,
   testOutboundEmail
 } from './email-actions/emailSettingsActions';
-export type { MicrosoftOutboundMailboxOption } from './email-actions/emailSettingsActions';
+export type {
+  EmailSettingsView,
+  MicrosoftOutboundMailboxOption,
+} from './email-actions/emailSettingsActions';
 export {
   getInboundTicketDefaults,
   createInboundTicketDefaults,

--- a/packages/integrations/src/components/email/admin/EmailSenderIdentityCards.test.tsx
+++ b/packages/integrations/src/components/email/admin/EmailSenderIdentityCards.test.tsx
@@ -1,0 +1,83 @@
+// @vitest-environment jsdom
+import React from 'react';
+import { fireEvent, render, screen } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+import { EmailSenderIdentityCards, type EmailSenderIdentityCopy } from './EmailSenderIdentityCards';
+
+const copy: EmailSenderIdentityCopy = {
+  ticketTitle: 'Ticket email identity',
+  ticketDescription: 'Ticket replies return here.',
+  connectedInboxLabel: 'Connected inbox',
+  connectedInboxHelp: 'Use a monitored inbox.',
+  customAddressOption: 'Use another address',
+  ticketAddressLabel: 'From address',
+  ticketAddressPlaceholder: 'support@example.com',
+  ticketAddressHelp: 'Controls reply routing.',
+  ticketNameLabel: 'Sender display name',
+  ticketNamePlaceholder: 'Support',
+  ticketNameHelp: 'Ticket name help.',
+  warningTitle: 'Warning',
+  errorTitle: 'Error',
+  notificationTitle: 'All other email identity',
+  notificationDescription: 'Portal invites, invoices, and notifications.',
+  notificationAddressLabel: 'From address',
+  notificationAddressPlaceholder: 'notifications@example.com',
+  notificationAddressHelp: 'Branding address.',
+  notificationNameLabel: 'Sender display name',
+  notificationNamePlaceholder: 'Example MSP',
+  notificationNameHelp: 'Blank uses Example MSP automatically.',
+};
+
+describe('EmailSenderIdentityCards', () => {
+  it('renders separate ticket and notification controls with stable ids', () => {
+    render(
+      <EmailSenderIdentityCards
+        copy={copy}
+        ticketAddress="support@example.com"
+        ticketName="Example Support"
+        notificationAddress="notifications@example.com"
+        notificationName=""
+        onTicketAddressChange={vi.fn()}
+        onTicketNameChange={vi.fn()}
+        onNotificationAddressChange={vi.fn()}
+        onNotificationNameChange={vi.fn()}
+      />
+    );
+
+    expect(screen.getByText('Ticket email identity')).toBeInTheDocument();
+    expect(screen.getByText('All other email identity')).toBeInTheDocument();
+    expect(screen.getByDisplayValue('support@example.com')).toBeInTheDocument();
+    expect(screen.getByDisplayValue('Example Support')).toBeInTheDocument();
+    expect(screen.getByDisplayValue('notifications@example.com')).toBeInTheDocument();
+    expect(screen.getByText('Blank uses Example MSP automatically.')).toBeInTheDocument();
+  });
+
+  it('keeps ticket and notification change handlers independent', () => {
+    const onTicketNameChange = vi.fn();
+    const onNotificationNameChange = vi.fn();
+    render(
+      <EmailSenderIdentityCards
+        copy={copy}
+        ticketAddress="support@example.com"
+        ticketName="Example Support"
+        notificationAddress="notifications@example.com"
+        notificationName="Example MSP"
+        onTicketAddressChange={vi.fn()}
+        onTicketNameChange={onTicketNameChange}
+        onNotificationAddressChange={vi.fn()}
+        onNotificationNameChange={onNotificationNameChange}
+      />
+    );
+
+    fireEvent.change(screen.getByDisplayValue('Example MSP'), {
+      target: { value: 'Example Billing' },
+    });
+    expect(onNotificationNameChange).toHaveBeenCalledWith('Example Billing');
+    expect(onTicketNameChange).not.toHaveBeenCalled();
+
+    fireEvent.change(screen.getByDisplayValue('Example Support'), {
+      target: { value: 'Example Support Team' },
+    });
+    expect(onTicketNameChange).toHaveBeenCalledWith('Example Support Team');
+  });
+});

--- a/packages/integrations/src/components/email/admin/EmailSenderIdentityCards.tsx
+++ b/packages/integrations/src/components/email/admin/EmailSenderIdentityCards.tsx
@@ -1,0 +1,195 @@
+'use client';
+
+import type { ReactNode } from 'react';
+import { Alert, AlertDescription, AlertTitle } from '@alga-psa/ui/components/Alert';
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@alga-psa/ui/components/Card';
+import CustomSelect from '@alga-psa/ui/components/CustomSelect';
+import { Input } from '@alga-psa/ui/components/Input';
+import { Label } from '@alga-psa/ui/components/Label';
+import { Mail, Send } from 'lucide-react';
+
+export interface EmailSenderIdentityCopy {
+  ticketTitle: string;
+  ticketDescription: string;
+  connectedInboxLabel: string;
+  connectedInboxHelp: string;
+  customAddressOption: string;
+  ticketAddressLabel: string;
+  ticketAddressPlaceholder: string;
+  ticketAddressHelp: string;
+  ticketNameLabel: string;
+  ticketNamePlaceholder: string;
+  ticketNameHelp: string;
+  warningTitle: string;
+  errorTitle: string;
+  notificationTitle: string;
+  notificationDescription: string;
+  notificationAddressLabel: string;
+  notificationAddressPlaceholder: string;
+  notificationAddressHelp: string;
+  notificationNameLabel: string;
+  notificationNamePlaceholder: string;
+  notificationNameHelp: string;
+}
+
+interface EmailSenderIdentityCardsProps {
+  copy: EmailSenderIdentityCopy;
+  ticketAddress: string;
+  ticketName: string;
+  connectedInboxes?: string[];
+  ticketAddressReadOnly?: boolean;
+  ticketFieldsDisabled?: boolean;
+  ticketWarning?: string | null;
+  ticketError?: string | null;
+  notificationAddress: string;
+  notificationName: string;
+  notificationAddressReadOnly?: boolean;
+  notificationFieldsDisabled?: boolean;
+  onTicketAddressChange: (value: string) => void;
+  onTicketNameChange: (value: string) => void;
+  onNotificationAddressChange: (value: string) => void;
+  onNotificationNameChange: (value: string) => void;
+  actions?: ReactNode;
+}
+
+export function EmailSenderIdentityCards({
+  copy,
+  ticketAddress,
+  ticketName,
+  connectedInboxes = [],
+  ticketAddressReadOnly = false,
+  ticketFieldsDisabled = false,
+  ticketWarning,
+  ticketError,
+  notificationAddress,
+  notificationName,
+  notificationAddressReadOnly = false,
+  notificationFieldsDisabled = false,
+  onTicketAddressChange,
+  onTicketNameChange,
+  onNotificationAddressChange,
+  onNotificationNameChange,
+  actions,
+}: EmailSenderIdentityCardsProps) {
+  const normalizedTicketAddress = ticketAddress.trim().toLowerCase();
+  const matchedInbox = connectedInboxes.find(
+    mailbox => mailbox.toLowerCase() === normalizedTicketAddress
+  );
+  const ticketAddressOption = matchedInbox || 'custom';
+
+  return (
+    <div className="space-y-4">
+      <div className="grid gap-4 lg:grid-cols-2">
+        <Card>
+          <CardHeader>
+            <CardTitle className="flex items-center gap-2">
+              <Send className="h-5 w-5" />
+              {copy.ticketTitle}
+            </CardTitle>
+            <CardDescription>{copy.ticketDescription}</CardDescription>
+          </CardHeader>
+          <CardContent className="space-y-4">
+            {!ticketAddressReadOnly && connectedInboxes.length > 0 && (
+              <div className="space-y-2">
+                <Label htmlFor="ticket-from-inbox">{copy.connectedInboxLabel}</Label>
+                <CustomSelect
+                  id="ticket-from-inbox"
+                  value={ticketAddressOption}
+                  disabled={ticketFieldsDisabled}
+                  onValueChange={(value: string) => {
+                    onTicketAddressChange(value === 'custom' ? '' : value);
+                  }}
+                  options={[
+                    ...connectedInboxes.map(mailbox => ({ value: mailbox, label: mailbox })),
+                    { value: 'custom', label: copy.customAddressOption },
+                  ]}
+                  placeholder={copy.connectedInboxLabel}
+                />
+                <p className="text-xs text-muted-foreground">{copy.connectedInboxHelp}</p>
+              </div>
+            )}
+
+            {(ticketAddressReadOnly || connectedInboxes.length === 0 || ticketAddressOption === 'custom') && (
+              <div className="space-y-2">
+                <Label htmlFor="ticket-from-address">{copy.ticketAddressLabel}</Label>
+                <Input
+                  id="ticket-from-address"
+                  type="email"
+                  value={ticketAddress}
+                  readOnly={ticketAddressReadOnly}
+                  disabled={ticketFieldsDisabled}
+                  placeholder={copy.ticketAddressPlaceholder}
+                  onChange={(event) => onTicketAddressChange(event.target.value)}
+                />
+                <p className="text-xs text-muted-foreground">{copy.ticketAddressHelp}</p>
+              </div>
+            )}
+
+            <div className="space-y-2">
+              <Label htmlFor="ticket-from-name">{copy.ticketNameLabel}</Label>
+              <Input
+                id="ticket-from-name"
+                value={ticketName}
+                disabled={ticketFieldsDisabled}
+                placeholder={copy.ticketNamePlaceholder}
+                onChange={(event) => onTicketNameChange(event.target.value)}
+              />
+              <p className="text-xs text-muted-foreground">{copy.ticketNameHelp}</p>
+            </div>
+
+            {ticketWarning && (
+              <Alert variant="warning">
+                <AlertTitle>{copy.warningTitle}</AlertTitle>
+                <AlertDescription>{ticketWarning}</AlertDescription>
+              </Alert>
+            )}
+            {ticketError && (
+              <Alert variant="destructive">
+                <AlertTitle>{copy.errorTitle}</AlertTitle>
+                <AlertDescription>{ticketError}</AlertDescription>
+              </Alert>
+            )}
+          </CardContent>
+        </Card>
+
+        <Card>
+          <CardHeader>
+            <CardTitle className="flex items-center gap-2">
+              <Mail className="h-5 w-5" />
+              {copy.notificationTitle}
+            </CardTitle>
+            <CardDescription>{copy.notificationDescription}</CardDescription>
+          </CardHeader>
+          <CardContent className="space-y-4">
+            <div className="space-y-2">
+              <Label htmlFor="notification-from-address">{copy.notificationAddressLabel}</Label>
+              <Input
+                id="notification-from-address"
+                type="email"
+                value={notificationAddress}
+                readOnly={notificationAddressReadOnly}
+                disabled={notificationFieldsDisabled}
+                placeholder={copy.notificationAddressPlaceholder}
+                onChange={(event) => onNotificationAddressChange(event.target.value)}
+              />
+              <p className="text-xs text-muted-foreground">{copy.notificationAddressHelp}</p>
+            </div>
+
+            <div className="space-y-2">
+              <Label htmlFor="notification-from-name">{copy.notificationNameLabel}</Label>
+              <Input
+                id="notification-from-name"
+                value={notificationName}
+                disabled={notificationFieldsDisabled}
+                placeholder={copy.notificationNamePlaceholder}
+                onChange={(event) => onNotificationNameChange(event.target.value)}
+              />
+              <p className="text-xs text-muted-foreground">{copy.notificationNameHelp}</p>
+            </div>
+          </CardContent>
+        </Card>
+      </div>
+      {actions}
+    </div>
+  );
+}

--- a/packages/integrations/src/components/email/admin/EmailSettings.test.tsx
+++ b/packages/integrations/src/components/email/admin/EmailSettings.test.tsx
@@ -1,0 +1,143 @@
+// @vitest-environment jsdom
+import React from 'react';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { EmailSettings } from './EmailSettings';
+
+const {
+  getEmailDomainsMock,
+  getEmailProvidersMock,
+  getEmailSettingsMock,
+  getMicrosoftOutboundMailboxesMock,
+  updateEmailSettingsMock,
+} = vi.hoisted(() => ({
+  getEmailDomainsMock: vi.fn(),
+  getEmailProvidersMock: vi.fn(),
+  getEmailSettingsMock: vi.fn(),
+  getMicrosoftOutboundMailboxesMock: vi.fn(),
+  updateEmailSettingsMock: vi.fn(),
+}));
+
+vi.mock('../../../actions/email-actions/emailSettingsActions', () => ({
+  getEmailSettings: getEmailSettingsMock,
+  getMicrosoftOutboundMailboxes: getMicrosoftOutboundMailboxesMock,
+  updateEmailSettings: updateEmailSettingsMock,
+  testOutboundEmail: vi.fn(),
+}));
+
+vi.mock('../../../actions/email-actions/emailProviderActions', () => ({
+  getEmailProviders: getEmailProvidersMock,
+}));
+
+vi.mock('../../../actions/email-actions/emailDomainActions', () => ({
+  getEmailDomains: getEmailDomainsMock,
+  addEmailDomain: vi.fn(),
+  verifyEmailDomain: vi.fn(),
+}));
+
+vi.mock('../EmailProviderConfiguration', () => ({
+  EmailProviderConfiguration: () => <div />,
+}));
+
+vi.mock('@alga-psa/ui/components/providers/TenantProvider', () => ({
+  useTenant: () => 'tenant-1',
+}));
+
+vi.mock('@alga-psa/ui/lib/i18n/client', () => ({
+  useTranslation: () => ({
+    t: (key: string, options?: { defaultValue?: string; company?: string }) => {
+      if (key === 'email.senderIdentities.notification.nameHelp') {
+        return `Leave blank to use ${options?.company} automatically.`;
+      }
+      return options?.defaultValue || key;
+    },
+  }),
+}));
+
+vi.mock('@alga-psa/ui/components/Tabs', () => ({
+  Tabs: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+  TabsList: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+  TabsTrigger: ({ children }: { children: React.ReactNode }) => <button>{children}</button>,
+  TabsContent: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+}));
+
+vi.mock('@alga-psa/ui/components/CustomSelect', () => ({
+  default: ({ id, value, options, onValueChange }: any) => (
+    <select id={id} value={value} onChange={(event) => onValueChange(event.target.value)}>
+      {options.map((option: any) => (
+        <option key={option.value} value={option.value}>{option.label}</option>
+      ))}
+    </select>
+  ),
+}));
+
+const settings = {
+  tenantId: 'tenant-1',
+  defaultFromDomain: 'example.test',
+  ticketingFromEmail: 'support@example.test',
+  ticketingFromName: 'Example Support',
+  customDomains: [],
+  emailProvider: 'smtp' as const,
+  providerConfigs: [{
+    providerId: 'smtp-provider',
+    providerType: 'smtp' as const,
+    isEnabled: true,
+    config: {
+      host: 'smtp.example.test',
+      port: 587,
+      from: 'notifications@example.test',
+      fromName: '',
+    },
+  }],
+  trackingEnabled: false,
+  createdAt: new Date('2026-08-04T00:00:00.000Z'),
+  updatedAt: new Date('2026-08-04T00:00:00.000Z'),
+  tenantCompanyName: 'Example MSP',
+  effectiveNotificationFrom: {
+    email: 'notifications@example.test',
+    name: 'Example MSP',
+  },
+};
+
+describe('EmailSettings sender identities', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    getEmailSettingsMock.mockResolvedValue(settings);
+    updateEmailSettingsMock.mockImplementation(async (value) => value);
+    getEmailProvidersMock.mockResolvedValue({
+      providers: [{ mailbox: 'support@example.test' }],
+    });
+    getMicrosoftOutboundMailboxesMock.mockResolvedValue({ mailboxes: [] });
+    getEmailDomainsMock.mockResolvedValue([]);
+  });
+
+  it('renders both identities and saves each field to its existing storage group', async () => {
+    render(<EmailSettings />);
+
+    expect(await screen.findByText('email.senderIdentities.ticket.title')).toBeInTheDocument();
+    expect(screen.getByText('email.senderIdentities.notification.title')).toBeInTheDocument();
+    expect(screen.getByText('Leave blank to use Example MSP automatically.')).toBeInTheDocument();
+
+    fireEvent.change(screen.getByDisplayValue('Example Support'), {
+      target: { value: 'Example Helpdesk' },
+    });
+    fireEvent.change(
+      screen.getByPlaceholderText('email.senderIdentities.notification.namePlaceholder'),
+      { target: { value: 'Example Billing' } }
+    );
+    fireEvent.click(screen.getByRole('button', { name: /save settings/i }));
+
+    await waitFor(() => {
+      expect(updateEmailSettingsMock).toHaveBeenCalledWith(expect.objectContaining({
+        ticketingFromName: 'Example Helpdesk',
+        providerConfigs: [expect.objectContaining({
+          providerType: 'smtp',
+          config: expect.objectContaining({
+            from: 'notifications@example.test',
+            fromName: 'Example Billing',
+          }),
+        })],
+      }));
+    });
+  });
+});

--- a/packages/integrations/src/components/email/admin/EmailSettings.tsx
+++ b/packages/integrations/src/components/email/admin/EmailSettings.tsx
@@ -16,15 +16,18 @@ import { Switch } from '@alga-psa/ui/components/Switch';
 import { Badge } from '@alga-psa/ui/components/Badge';
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '@alga-psa/ui/components/Tabs';
 import { Mail, Globe, Settings, CheckCircle, XCircle, Clock, Eye, EyeOff, Send, Inbox } from 'lucide-react';
-import type { TenantEmailSettings } from '@alga-psa/types';
 import { createDefaultProviderConfig } from '@alga-psa/email/providerConfig';
 import {
   getEmailSettings,
   getMicrosoftOutboundMailboxes,
   updateEmailSettings,
   testOutboundEmail,
+  type EmailSettingsView,
   type MicrosoftOutboundMailboxOption,
 } from '../../../actions/email-actions/emailSettingsActions';
+import { getEmailProviders } from '../../../actions/email-actions/emailProviderActions';
+import type { EmailProvider } from '../types';
+import { EmailSenderIdentityCards } from './EmailSenderIdentityCards';
 import {
   getEmailDomains,
   addEmailDomain,
@@ -58,7 +61,8 @@ interface DomainStatus {
 export const EmailSettings: React.FC<EmailSettingsProps> = () => {
   const { t } = useTranslation('msp/admin');
   const tenantId = useTenant();
-  const [settings, setSettings] = useState<TenantEmailSettings | null>(null);
+  const [settings, setSettings] = useState<EmailSettingsView | null>(null);
+  const [inboundProviders, setInboundProviders] = useState<EmailProvider[]>([]);
   const [domains, setDomains] = useState<DomainStatus[]>([]);
   const [loading, setLoading] = useState(true);
   const [saving, setSaving] = useState(false);
@@ -77,6 +81,7 @@ export const EmailSettings: React.FC<EmailSettingsProps> = () => {
   useEffect(() => {
     loadEmailSettings();
     loadMicrosoftMailboxes();
+    loadInboundProviders();
     loadDomains();
   }, []);
 
@@ -99,6 +104,15 @@ export const EmailSettings: React.FC<EmailSettingsProps> = () => {
       setError(t('email.errors.loadEmailSettings', { defaultValue: 'Failed to load email settings' }));
     } finally {
       setLoading(false);
+    }
+  };
+
+  const loadInboundProviders = async () => {
+    try {
+      const result = await getEmailProviders();
+      setInboundProviders(result.providers || []);
+    } catch (err) {
+      console.error('Failed to load inbound email providers:', err);
     }
   };
 
@@ -241,12 +255,15 @@ export const EmailSettings: React.FC<EmailSettingsProps> = () => {
       ) || microsoftMailboxes.find(mailbox => mailbox.status === 'connected');
 
       if (microsoftConfig && selectedMailbox) {
+        const existingFromName = microsoftConfig.config.fromName;
         microsoftConfig.providerId = selectedMailbox.providerId;
         microsoftConfig.config = {
           inboundProviderId: selectedMailbox.providerId,
           mailbox: selectedMailbox.mailbox,
           from: selectedMailbox.mailbox,
-          fromName: selectedMailbox.senderDisplayName || undefined,
+          fromName: existingFromName === undefined
+            ? selectedMailbox.senderDisplayName || undefined
+            : existingFromName,
         };
       }
     }
@@ -259,6 +276,10 @@ export const EmailSettings: React.FC<EmailSettingsProps> = () => {
     const mailbox = microsoftMailboxes.find(option => option.providerId === providerId);
     if (!mailbox) return;
 
+    const existingMicrosoftConfig = settings.providerConfigs.find(
+      config => config.providerType === 'microsoft'
+    );
+
     const providerConfigs = settings.providerConfigs.map(config =>
       config.providerType === 'microsoft'
         ? {
@@ -268,7 +289,9 @@ export const EmailSettings: React.FC<EmailSettingsProps> = () => {
               inboundProviderId: mailbox.providerId,
               mailbox: mailbox.mailbox,
               from: mailbox.mailbox,
-              fromName: mailbox.senderDisplayName || undefined,
+              fromName: existingMicrosoftConfig?.config.fromName === undefined
+                ? mailbox.senderDisplayName || undefined
+                : existingMicrosoftConfig.config.fromName,
             },
           }
         : config
@@ -357,16 +380,6 @@ export const EmailSettings: React.FC<EmailSettingsProps> = () => {
           })}
         </p>
 
-        <div>
-          <Label htmlFor="smtp-from">{t('email.smtp.fromAddress.label', { defaultValue: 'From Address' })}</Label>
-          <Input
-            id="smtp-from"
-            value={config.config.from || ''}
-            placeholder={t('email.smtp.fromAddress.placeholder', { defaultValue: 'noreply@example.com' })}
-            onChange={(e) => updateProviderConfig(config.providerId, { from: e.target.value })}
-          />
-        </div>
-
         <div className="border-t pt-4 space-y-4">
           <h4 className="text-sm font-medium">
             {t('email.smtp.security.title', { defaultValue: 'Connection Security' })}
@@ -444,20 +457,6 @@ export const EmailSettings: React.FC<EmailSettingsProps> = () => {
           </p>
         </div>
 
-        <div>
-          <Label htmlFor="resend-from">{t('email.resend.fromAddress.label', { defaultValue: 'From Address' })}</Label>
-          <Input
-            id="resend-from"
-            value={config.config.from || ''}
-            placeholder={t('email.resend.fromAddress.placeholder', { defaultValue: 'noreply@yourdomain.com' })}
-            onChange={(e) => updateProviderConfig(config.providerId, { from: e.target.value })}
-          />
-          <p className="text-sm text-muted-foreground mt-1">
-            {t('email.resend.fromAddress.help', {
-              defaultValue: 'Must be from a verified domain. Use the Domains tab to add custom domains.'
-            })}
-          </p>
-        </div>
       </div>
     );
   };
@@ -573,6 +572,23 @@ export const EmailSettings: React.FC<EmailSettingsProps> = () => {
       </div>
     );
   }
+
+  if (!settings) {
+    return (
+      <div className="text-red-600 dark:text-red-400">
+        {t('email.errors.loadEmailSettings', { defaultValue: 'Failed to load email settings' })}
+      </div>
+    );
+  }
+
+  const selectedMicrosoftMailbox = selectedProvider === 'microsoft'
+    ? getCurrentProviderConfig()?.config.from?.trim() || ''
+    : '';
+  const ticketIdentityError = selectedMicrosoftMailbox
+    && settings?.ticketingFromEmail
+    && settings.ticketingFromEmail.toLowerCase() !== selectedMicrosoftMailbox.toLowerCase()
+      ? t('email.senderIdentities.ticket.microsoftMismatch', { mailbox: selectedMicrosoftMailbox })
+      : null;
 
   return (
     <Tabs value={activeTab} onValueChange={setActiveTab} className="w-full">
@@ -709,6 +725,60 @@ export const EmailSettings: React.FC<EmailSettingsProps> = () => {
             </CardContent>
           </Card>
 
+            <EmailSenderIdentityCards
+              copy={{
+                ticketTitle: t('email.senderIdentities.ticket.title'),
+                ticketDescription: t('email.senderIdentities.ticket.description'),
+                connectedInboxLabel: t('email.senderIdentities.ticket.connectedInboxLabel'),
+                connectedInboxHelp: t('email.senderIdentities.ticket.connectedInboxHelp'),
+                customAddressOption: t('email.senderIdentities.ticket.customAddressOption'),
+                ticketAddressLabel: t('email.senderIdentities.ticket.addressLabel'),
+                ticketAddressPlaceholder: t('email.senderIdentities.ticket.addressPlaceholder'),
+                ticketAddressHelp: t('email.senderIdentities.ticket.addressHelp'),
+                ticketNameLabel: t('email.senderIdentities.ticket.nameLabel'),
+                ticketNamePlaceholder: t('email.senderIdentities.ticket.namePlaceholder'),
+                ticketNameHelp: t('email.senderIdentities.ticket.nameHelp'),
+                warningTitle: t('email.senderIdentities.warningTitle'),
+                errorTitle: t('email.senderIdentities.errorTitle'),
+                notificationTitle: t('email.senderIdentities.notification.title'),
+                notificationDescription: t('email.senderIdentities.notification.description'),
+                notificationAddressLabel: t('email.senderIdentities.notification.addressLabel'),
+                notificationAddressPlaceholder: t('email.senderIdentities.notification.addressPlaceholder'),
+                notificationAddressHelp: t('email.senderIdentities.notification.addressHelp'),
+                notificationNameLabel: t('email.senderIdentities.notification.nameLabel'),
+                notificationNamePlaceholder: t('email.senderIdentities.notification.namePlaceholder'),
+                notificationNameHelp: t('email.senderIdentities.notification.nameHelp', {
+                  company: settings.tenantCompanyName || t('email.senderIdentities.notification.companyFallback'),
+                }),
+              }}
+              ticketAddress={settings.ticketingFromEmail || ''}
+              ticketName={settings.ticketingFromName || ''}
+              connectedInboxes={inboundProviders.map(provider => provider.mailbox).filter(Boolean)}
+              ticketWarning={
+                settings.ticketingFromEmail
+                && inboundProviders.length > 0
+                && !inboundProviders.some(provider =>
+                  provider.mailbox.toLowerCase() === settings.ticketingFromEmail?.toLowerCase()
+                )
+                  ? t('email.senderIdentities.ticket.notConnectedWarning')
+                  : null
+              }
+              ticketError={ticketIdentityError}
+              notificationAddress={getCurrentProviderConfig()?.config.from || settings.effectiveNotificationFrom.email}
+              notificationName={getCurrentProviderConfig()?.config.fromName || ''}
+              notificationAddressReadOnly={selectedProvider === 'microsoft'}
+              onTicketAddressChange={(value) => setSettings({ ...settings, ticketingFromEmail: value || null })}
+              onTicketNameChange={(value) => setSettings({ ...settings, ticketingFromName: value || null })}
+              onNotificationAddressChange={(value) => {
+                const config = getCurrentProviderConfig();
+                if (config) updateProviderConfig(config.providerId, { from: value });
+              }}
+              onNotificationNameChange={(value) => {
+                const config = getCurrentProviderConfig();
+                if (config) updateProviderConfig(config.providerId, { fromName: value });
+              }}
+            />
+
 
 
             {/* Connection Test */}
@@ -762,7 +832,7 @@ export const EmailSettings: React.FC<EmailSettingsProps> = () => {
 
             {/* Save Button */}
             <div className="flex justify-end">
-              <Button id="save-email-settings" onClick={saveSettings} disabled={saving}>
+              <Button id="save-email-settings" onClick={saveSettings} disabled={saving || !!ticketIdentityError}>
                 {saving
                   ? t('common.actions.saving', { defaultValue: 'Saving...' })
                   : t('common.actions.save', { defaultValue: 'Save Settings' })}

--- a/packages/integrations/src/components/email/admin/index.ts
+++ b/packages/integrations/src/components/email/admin/index.ts
@@ -1,3 +1,4 @@
 export * from './EmailSettings';
+export * from './EmailSenderIdentityCards';
 export * from './InboundTicketDefaultsManager';
 export * from './Microsoft365DiagnosticsDialog';

--- a/packages/integrations/src/components/index.ts
+++ b/packages/integrations/src/components/index.ts
@@ -7,6 +7,7 @@ export { AccountingMappingManager } from './accounting-mappings';
 export type { AccountingMappingContext, AccountingMappingModule, AccountingMappingLoadResult } from './accounting-mappings/types';
 export {
   EmailProviderConfiguration,
+  EmailSenderIdentityCards,
   INBOUND_DEFAULTS_WARNING,
   providerNeedsInboundDefaults,
   InboundTicketDefaultsManager,
@@ -21,6 +22,7 @@ export {
   ImapProviderForm,
   MicrosoftProviderForm
 } from './email';
+export type { EmailSenderIdentityCopy } from './email';
 export type { EmailProvider, MicrosoftEmailProviderConfig, GoogleEmailProviderConfig, ImapEmailProviderConfig } from './email/types';
 export type { BaseGmailProviderFormData, CEGmailProviderFormData } from './email/providers/gmail/schemas';
 export * from './settings';

--- a/packages/portal-shared/src/actions/portalInvitationActionsSendTenantScoped.contract.test.ts
+++ b/packages/portal-shared/src/actions/portalInvitationActionsSendTenantScoped.contract.test.ts
@@ -34,4 +34,10 @@ describe('portal invitation send flow tenant-scoped query contract', () => {
     expect(section).not.toMatch(/trx\('clients'\)\s*[\r\n]+\s*\.where\(\{\s*tenant,/);
     expect(section).not.toContain("'tenant_companies.tenant': tenant");
   });
+
+  it('passes the tenant company Portal display name to the invitation email helper', () => {
+    const section = sectionBetween('export const sendPortalInvitation', 'export async function verifyPortalToken');
+
+    expect(section).toContain('fromName: `${tenantDefaultClient.client_name} Portal`');
+  });
 });

--- a/server/public/locales/de/msp/admin.json
+++ b/server/public/locales/de/msp/admin.json
@@ -197,6 +197,36 @@
       "recipientPlaceholder": "sie@beispiel.com",
       "run": "Verbindung testen",
       "testing": "Wird getestet..."
+    },
+    "senderIdentities": {
+      "ticket": {
+        "title": "Ticket email identity",
+        "description": "Replies to ticket emails must return to this address so they can be matched and added to the ticket. Use a connected, monitored inbox.",
+        "connectedInboxLabel": "Connected inbox",
+        "connectedInboxHelp": "A connected inbox keeps client replies in the ticket conversation.",
+        "customAddressOption": "Use another address",
+        "addressLabel": "From address",
+        "addressPlaceholder": "support@example.com",
+        "addressHelp": "This address controls reply routing for ticket email only.",
+        "nameLabel": "Sender display name",
+        "namePlaceholder": "Support",
+        "nameHelp": "Leave blank to use the connected mailbox name or ticket board name.",
+        "notConnectedWarning": "This address is not a connected inbox, so ticket replies may not be ingested.",
+        "microsoftMismatch": "Ticket email address must match the selected Microsoft 365 mailbox ({{mailbox}})."
+      },
+      "notification": {
+        "title": "All other email identity",
+        "description": "Brand portal invitations, password resets, invoices, project updates, and general notifications independently from ticket routing.",
+        "addressLabel": "From address",
+        "addressPlaceholder": "notifications@example.com",
+        "addressHelp": "SMTP and Resend use this address. Microsoft 365 uses the selected sending mailbox.",
+        "nameLabel": "Sender display name",
+        "namePlaceholder": "Your company name",
+        "nameHelp": "Leave blank to use {{company}} automatically.",
+        "companyFallback": "your tenant company"
+      },
+      "warningTitle": "Check reply routing",
+      "errorTitle": "Fix the ticket identity"
     }
   },
   "microsoft365": {

--- a/server/public/locales/de/msp/email-providers.json
+++ b/server/public/locales/de/msp/email-providers.json
@@ -760,7 +760,8 @@
       "domainRemovalScheduled": "Domainentfernung geplant",
       "domainRemovalScheduledWithClear": "Domainentfernung geplant und Ticketing-Absenderadresse gelöscht",
       "removeDomainFailed": "Domain konnte nicht entfernt werden",
-      "testOutboundFailed": "Test der ausgehenden E-Mail fehlgeschlagen"
+      "testOutboundFailed": "Test der ausgehenden E-Mail fehlgeschlagen",
+      "senderIdentitiesUpdated": "Sender identities updated."
     },
     "tabs": {
       "inboundEmail": "Eingehende E-Mail",
@@ -854,6 +855,39 @@
         "description": "Nachrichten werden über Microsoft Graph als das ausgewählte Postfach gesendet und in „Gesendete Elemente“ gespeichert.",
         "loadFailed": "Microsoft 365-Postfächer konnten nicht geladen werden.",
         "saved": "Sendepostfach aktualisiert."
+      },
+      "senderIdentities": {
+        "ticket": {
+          "title": "Ticket email identity",
+          "description": "Replies to ticket emails must return to this address so they can be matched and added to the ticket. Use a connected, monitored inbox.",
+          "connectedInboxLabel": "Connected inbox",
+          "connectedInboxHelp": "A connected inbox keeps client replies in the ticket conversation.",
+          "customAddressOption": "Use another address",
+          "addressLabel": "From address",
+          "addressPlaceholder": "support@example.com",
+          "addressHelp": "This address controls reply routing for ticket email only.",
+          "microsoftAddressHelp": "Microsoft 365 requires ticket email to use the selected sending mailbox ({{mailbox}}).",
+          "nameLabel": "Sender display name",
+          "namePlaceholder": "Support",
+          "nameHelp": "Leave blank to use the connected mailbox name or ticket board name."
+        },
+        "notification": {
+          "title": "All other email identity",
+          "description": "Brand portal invitations, password resets, invoices, project updates, and general notifications independently from ticket routing.",
+          "addressLabel": "From address",
+          "addressPlaceholder": "notifications@example.com",
+          "smtpAddressHelp": "This is the branding address used for non-ticket email through your SMTP server.",
+          "lockedAddressHelp": "This address is determined by the active managed domain or selected Microsoft 365 mailbox.",
+          "nameLabel": "Sender display name",
+          "namePlaceholder": "Your company name",
+          "nameHelp": "Leave blank to use {{company}} automatically.",
+          "companyFallback": "your tenant company"
+        },
+        "warningTitle": "Check reply routing",
+        "errorTitle": "Fix the ticket identity",
+        "clearButton": "Clear ticket identity",
+        "savingButton": "Saving...",
+        "saveButton": "Save sender identities"
       }
     },
     "inbound": {
@@ -882,7 +916,8 @@
       "mustMatchDomain": "Die Absenderadresse muss @{{domain}} verwenden",
       "customAddressThreadWarning": "Die Verwendung einer benutzerdefinierten Adresse kann das korrekte Gruppieren eingehender Antworten verhindern.",
       "smtpDomainMismatchWarning": "Diese Domain stimmt nicht mit Ihrer SMTP-Absenderdomain überein ({{domain}}). E-Mails können fehlschlagen oder als Spam markiert werden, wenn Ihr SMTP-Server nicht berechtigt ist, von dieser Domain zu senden.",
-      "notConnectedWarning": "Die Verarbeitung eingehender Tickets funktioniert möglicherweise nicht mit dieser Adresse, da sie keines Ihrer verbundenen Postfächer ist."
+      "notConnectedWarning": "Die Verarbeitung eingehender Tickets funktioniert möglicherweise nicht mit dieser Adresse, da sie keines Ihrer verbundenen Postfächer ist.",
+      "microsoftMustMatchMailbox": "Ticket email address must match the selected Microsoft 365 mailbox ({{mailbox}})."
     },
     "domainList": {
       "loading": "Domänen werden geladen…",

--- a/server/public/locales/en/msp/admin.json
+++ b/server/public/locales/en/msp/admin.json
@@ -197,6 +197,36 @@
       "recipientPlaceholder": "you@example.com",
       "run": "Test Connection",
       "testing": "Testing..."
+    },
+    "senderIdentities": {
+      "ticket": {
+        "title": "Ticket email identity",
+        "description": "Replies to ticket emails must return to this address so they can be matched and added to the ticket. Use a connected, monitored inbox.",
+        "connectedInboxLabel": "Connected inbox",
+        "connectedInboxHelp": "A connected inbox keeps client replies in the ticket conversation.",
+        "customAddressOption": "Use another address",
+        "addressLabel": "From address",
+        "addressPlaceholder": "support@example.com",
+        "addressHelp": "This address controls reply routing for ticket email only.",
+        "nameLabel": "Sender display name",
+        "namePlaceholder": "Support",
+        "nameHelp": "Leave blank to use the connected mailbox name or ticket board name.",
+        "notConnectedWarning": "This address is not a connected inbox, so ticket replies may not be ingested.",
+        "microsoftMismatch": "Ticket email address must match the selected Microsoft 365 mailbox ({{mailbox}})."
+      },
+      "notification": {
+        "title": "All other email identity",
+        "description": "Brand portal invitations, password resets, invoices, project updates, and general notifications independently from ticket routing.",
+        "addressLabel": "From address",
+        "addressPlaceholder": "notifications@example.com",
+        "addressHelp": "SMTP and Resend use this address. Microsoft 365 uses the selected sending mailbox.",
+        "nameLabel": "Sender display name",
+        "namePlaceholder": "Your company name",
+        "nameHelp": "Leave blank to use {{company}} automatically.",
+        "companyFallback": "your tenant company"
+      },
+      "warningTitle": "Check reply routing",
+      "errorTitle": "Fix the ticket identity"
     }
   },
   "microsoft365": {

--- a/server/public/locales/en/msp/email-providers.json
+++ b/server/public/locales/en/msp/email-providers.json
@@ -760,7 +760,8 @@
       "domainRemovalScheduled": "Domain removal scheduled",
       "domainRemovalScheduledWithClear": "Domain removal scheduled and ticketing From address cleared",
       "removeDomainFailed": "Failed to remove domain",
-      "testOutboundFailed": "Failed to test outbound email"
+      "testOutboundFailed": "Failed to test outbound email",
+      "senderIdentitiesUpdated": "Sender identities updated."
     },
     "tabs": {
       "inboundEmail": "Inbound Email",
@@ -854,6 +855,39 @@
         "description": "Messages are sent as the selected mailbox through Microsoft Graph and saved to Sent Items.",
         "loadFailed": "Could not load Microsoft 365 mailboxes.",
         "saved": "Outbound sending mailbox updated."
+      },
+      "senderIdentities": {
+        "ticket": {
+          "title": "Ticket email identity",
+          "description": "Replies to ticket emails must return to this address so they can be matched and added to the ticket. Use a connected, monitored inbox.",
+          "connectedInboxLabel": "Connected inbox",
+          "connectedInboxHelp": "A connected inbox keeps client replies in the ticket conversation.",
+          "customAddressOption": "Use another address",
+          "addressLabel": "From address",
+          "addressPlaceholder": "support@example.com",
+          "addressHelp": "This address controls reply routing for ticket email only.",
+          "microsoftAddressHelp": "Microsoft 365 requires ticket email to use the selected sending mailbox ({{mailbox}}).",
+          "nameLabel": "Sender display name",
+          "namePlaceholder": "Support",
+          "nameHelp": "Leave blank to use the connected mailbox name or ticket board name."
+        },
+        "notification": {
+          "title": "All other email identity",
+          "description": "Brand portal invitations, password resets, invoices, project updates, and general notifications independently from ticket routing.",
+          "addressLabel": "From address",
+          "addressPlaceholder": "notifications@example.com",
+          "smtpAddressHelp": "This is the branding address used for non-ticket email through your SMTP server.",
+          "lockedAddressHelp": "This address is determined by the active managed domain or selected Microsoft 365 mailbox.",
+          "nameLabel": "Sender display name",
+          "namePlaceholder": "Your company name",
+          "nameHelp": "Leave blank to use {{company}} automatically.",
+          "companyFallback": "your tenant company"
+        },
+        "warningTitle": "Check reply routing",
+        "errorTitle": "Fix the ticket identity",
+        "clearButton": "Clear ticket identity",
+        "savingButton": "Saving...",
+        "saveButton": "Save sender identities"
       }
     },
     "inbound": {
@@ -882,7 +916,8 @@
       "mustMatchDomain": "From address must use @{{domain}}",
       "customAddressThreadWarning": "Using a custom address may prevent inbound ticket replies from threading correctly.",
       "smtpDomainMismatchWarning": "This domain does not match your SMTP from address domain ({{domain}}). Emails may fail to deliver or be flagged as spam if your SMTP server is not authorized to send from this domain.",
-      "notConnectedWarning": "Inbound ticket processing may not work with this address because it is not one of your connected inboxes."
+      "notConnectedWarning": "Inbound ticket processing may not work with this address because it is not one of your connected inboxes.",
+      "microsoftMustMatchMailbox": "Ticket email address must match the selected Microsoft 365 mailbox ({{mailbox}})."
     },
     "domainList": {
       "loading": "Loading domains…",

--- a/server/public/locales/es/msp/admin.json
+++ b/server/public/locales/es/msp/admin.json
@@ -197,6 +197,36 @@
       "recipientPlaceholder": "tu@ejemplo.com",
       "run": "Probar conexión",
       "testing": "Probando..."
+    },
+    "senderIdentities": {
+      "ticket": {
+        "title": "Ticket email identity",
+        "description": "Replies to ticket emails must return to this address so they can be matched and added to the ticket. Use a connected, monitored inbox.",
+        "connectedInboxLabel": "Connected inbox",
+        "connectedInboxHelp": "A connected inbox keeps client replies in the ticket conversation.",
+        "customAddressOption": "Use another address",
+        "addressLabel": "From address",
+        "addressPlaceholder": "support@example.com",
+        "addressHelp": "This address controls reply routing for ticket email only.",
+        "nameLabel": "Sender display name",
+        "namePlaceholder": "Support",
+        "nameHelp": "Leave blank to use the connected mailbox name or ticket board name.",
+        "notConnectedWarning": "This address is not a connected inbox, so ticket replies may not be ingested.",
+        "microsoftMismatch": "Ticket email address must match the selected Microsoft 365 mailbox ({{mailbox}})."
+      },
+      "notification": {
+        "title": "All other email identity",
+        "description": "Brand portal invitations, password resets, invoices, project updates, and general notifications independently from ticket routing.",
+        "addressLabel": "From address",
+        "addressPlaceholder": "notifications@example.com",
+        "addressHelp": "SMTP and Resend use this address. Microsoft 365 uses the selected sending mailbox.",
+        "nameLabel": "Sender display name",
+        "namePlaceholder": "Your company name",
+        "nameHelp": "Leave blank to use {{company}} automatically.",
+        "companyFallback": "your tenant company"
+      },
+      "warningTitle": "Check reply routing",
+      "errorTitle": "Fix the ticket identity"
     }
   },
   "microsoft365": {

--- a/server/public/locales/es/msp/email-providers.json
+++ b/server/public/locales/es/msp/email-providers.json
@@ -760,7 +760,8 @@
       "domainRemovalScheduled": "Eliminación de dominio programada",
       "domainRemovalScheduledWithClear": "Eliminación de dominio programada y dirección de remitente de tickets eliminada",
       "removeDomainFailed": "Error al eliminar el dominio",
-      "testOutboundFailed": "Error al probar el correo saliente"
+      "testOutboundFailed": "Error al probar el correo saliente",
+      "senderIdentitiesUpdated": "Sender identities updated."
     },
     "tabs": {
       "inboundEmail": "Correo entrante",
@@ -854,6 +855,39 @@
         "description": "Los mensajes se envían como el buzón seleccionado a través de Microsoft Graph y se guardan en Elementos enviados.",
         "loadFailed": "No se pudieron cargar los buzones de Microsoft 365.",
         "saved": "Buzón de envío actualizado."
+      },
+      "senderIdentities": {
+        "ticket": {
+          "title": "Ticket email identity",
+          "description": "Replies to ticket emails must return to this address so they can be matched and added to the ticket. Use a connected, monitored inbox.",
+          "connectedInboxLabel": "Connected inbox",
+          "connectedInboxHelp": "A connected inbox keeps client replies in the ticket conversation.",
+          "customAddressOption": "Use another address",
+          "addressLabel": "From address",
+          "addressPlaceholder": "support@example.com",
+          "addressHelp": "This address controls reply routing for ticket email only.",
+          "microsoftAddressHelp": "Microsoft 365 requires ticket email to use the selected sending mailbox ({{mailbox}}).",
+          "nameLabel": "Sender display name",
+          "namePlaceholder": "Support",
+          "nameHelp": "Leave blank to use the connected mailbox name or ticket board name."
+        },
+        "notification": {
+          "title": "All other email identity",
+          "description": "Brand portal invitations, password resets, invoices, project updates, and general notifications independently from ticket routing.",
+          "addressLabel": "From address",
+          "addressPlaceholder": "notifications@example.com",
+          "smtpAddressHelp": "This is the branding address used for non-ticket email through your SMTP server.",
+          "lockedAddressHelp": "This address is determined by the active managed domain or selected Microsoft 365 mailbox.",
+          "nameLabel": "Sender display name",
+          "namePlaceholder": "Your company name",
+          "nameHelp": "Leave blank to use {{company}} automatically.",
+          "companyFallback": "your tenant company"
+        },
+        "warningTitle": "Check reply routing",
+        "errorTitle": "Fix the ticket identity",
+        "clearButton": "Clear ticket identity",
+        "savingButton": "Saving...",
+        "saveButton": "Save sender identities"
       }
     },
     "inbound": {
@@ -882,7 +916,8 @@
       "mustMatchDomain": "La dirección de remitente debe usar @{{domain}}",
       "customAddressThreadWarning": "El uso de una dirección personalizada puede impedir que las respuestas entrantes se agrupen correctamente.",
       "smtpDomainMismatchWarning": "Este dominio no coincide con el dominio de remitente de su SMTP ({{domain}}). Los correos pueden no entregarse o marcarse como spam si su servidor SMTP no está autorizado a enviar desde este dominio.",
-      "notConnectedWarning": "El procesamiento de tickets entrantes puede no funcionar con esta dirección porque no es una de sus bandejas conectadas."
+      "notConnectedWarning": "El procesamiento de tickets entrantes puede no funcionar con esta dirección porque no es una de sus bandejas conectadas.",
+      "microsoftMustMatchMailbox": "Ticket email address must match the selected Microsoft 365 mailbox ({{mailbox}})."
     },
     "domainList": {
       "loading": "Cargando dominios…",

--- a/server/public/locales/fr/msp/admin.json
+++ b/server/public/locales/fr/msp/admin.json
@@ -197,6 +197,36 @@
       "recipientPlaceholder": "vous@exemple.com",
       "run": "Tester la connexion",
       "testing": "Test en cours..."
+    },
+    "senderIdentities": {
+      "ticket": {
+        "title": "Ticket email identity",
+        "description": "Replies to ticket emails must return to this address so they can be matched and added to the ticket. Use a connected, monitored inbox.",
+        "connectedInboxLabel": "Connected inbox",
+        "connectedInboxHelp": "A connected inbox keeps client replies in the ticket conversation.",
+        "customAddressOption": "Use another address",
+        "addressLabel": "From address",
+        "addressPlaceholder": "support@example.com",
+        "addressHelp": "This address controls reply routing for ticket email only.",
+        "nameLabel": "Sender display name",
+        "namePlaceholder": "Support",
+        "nameHelp": "Leave blank to use the connected mailbox name or ticket board name.",
+        "notConnectedWarning": "This address is not a connected inbox, so ticket replies may not be ingested.",
+        "microsoftMismatch": "Ticket email address must match the selected Microsoft 365 mailbox ({{mailbox}})."
+      },
+      "notification": {
+        "title": "All other email identity",
+        "description": "Brand portal invitations, password resets, invoices, project updates, and general notifications independently from ticket routing.",
+        "addressLabel": "From address",
+        "addressPlaceholder": "notifications@example.com",
+        "addressHelp": "SMTP and Resend use this address. Microsoft 365 uses the selected sending mailbox.",
+        "nameLabel": "Sender display name",
+        "namePlaceholder": "Your company name",
+        "nameHelp": "Leave blank to use {{company}} automatically.",
+        "companyFallback": "your tenant company"
+      },
+      "warningTitle": "Check reply routing",
+      "errorTitle": "Fix the ticket identity"
     }
   },
   "microsoft365": {

--- a/server/public/locales/fr/msp/email-providers.json
+++ b/server/public/locales/fr/msp/email-providers.json
@@ -760,7 +760,8 @@
       "domainRemovalScheduled": "Suppression du domaine planifiée",
       "domainRemovalScheduledWithClear": "Suppression du domaine planifiée et adresse d'expéditeur de ticket effacée",
       "removeDomainFailed": "Échec de la suppression du domaine",
-      "testOutboundFailed": "Échec du test de l'e-mail sortant"
+      "testOutboundFailed": "Échec du test de l'e-mail sortant",
+      "senderIdentitiesUpdated": "Sender identities updated."
     },
     "tabs": {
       "inboundEmail": "E-mail entrant",
@@ -854,6 +855,39 @@
         "description": "Les messages sont envoyés depuis la boîte sélectionnée via Microsoft Graph et enregistrés dans Éléments envoyés.",
         "loadFailed": "Impossible de charger les boîtes aux lettres Microsoft 365.",
         "saved": "Boîte aux lettres d'envoi mise à jour."
+      },
+      "senderIdentities": {
+        "ticket": {
+          "title": "Ticket email identity",
+          "description": "Replies to ticket emails must return to this address so they can be matched and added to the ticket. Use a connected, monitored inbox.",
+          "connectedInboxLabel": "Connected inbox",
+          "connectedInboxHelp": "A connected inbox keeps client replies in the ticket conversation.",
+          "customAddressOption": "Use another address",
+          "addressLabel": "From address",
+          "addressPlaceholder": "support@example.com",
+          "addressHelp": "This address controls reply routing for ticket email only.",
+          "microsoftAddressHelp": "Microsoft 365 requires ticket email to use the selected sending mailbox ({{mailbox}}).",
+          "nameLabel": "Sender display name",
+          "namePlaceholder": "Support",
+          "nameHelp": "Leave blank to use the connected mailbox name or ticket board name."
+        },
+        "notification": {
+          "title": "All other email identity",
+          "description": "Brand portal invitations, password resets, invoices, project updates, and general notifications independently from ticket routing.",
+          "addressLabel": "From address",
+          "addressPlaceholder": "notifications@example.com",
+          "smtpAddressHelp": "This is the branding address used for non-ticket email through your SMTP server.",
+          "lockedAddressHelp": "This address is determined by the active managed domain or selected Microsoft 365 mailbox.",
+          "nameLabel": "Sender display name",
+          "namePlaceholder": "Your company name",
+          "nameHelp": "Leave blank to use {{company}} automatically.",
+          "companyFallback": "your tenant company"
+        },
+        "warningTitle": "Check reply routing",
+        "errorTitle": "Fix the ticket identity",
+        "clearButton": "Clear ticket identity",
+        "savingButton": "Saving...",
+        "saveButton": "Save sender identities"
       }
     },
     "inbound": {
@@ -882,7 +916,8 @@
       "mustMatchDomain": "L'adresse d'expéditeur doit utiliser @{{domain}}",
       "customAddressThreadWarning": "L'utilisation d'une adresse personnalisée peut empêcher le regroupement correct des réponses entrantes.",
       "smtpDomainMismatchWarning": "Ce domaine ne correspond pas au domaine d'expéditeur de votre SMTP ({{domain}}). Les e-mails peuvent échouer à livrer ou être signalés comme spam si votre serveur SMTP n'est pas autorisé à envoyer depuis ce domaine.",
-      "notConnectedWarning": "Le traitement des tickets entrants peut ne pas fonctionner avec cette adresse car elle n'est pas l'une de vos boîtes de réception connectées."
+      "notConnectedWarning": "Le traitement des tickets entrants peut ne pas fonctionner avec cette adresse car elle n'est pas l'une de vos boîtes de réception connectées.",
+      "microsoftMustMatchMailbox": "Ticket email address must match the selected Microsoft 365 mailbox ({{mailbox}})."
     },
     "domainList": {
       "loading": "Chargement des domaines…",

--- a/server/public/locales/it/msp/admin.json
+++ b/server/public/locales/it/msp/admin.json
@@ -197,6 +197,36 @@
       "recipientPlaceholder": "tu@esempio.com",
       "run": "Prova connessione",
       "testing": "Prova in corso..."
+    },
+    "senderIdentities": {
+      "ticket": {
+        "title": "Ticket email identity",
+        "description": "Replies to ticket emails must return to this address so they can be matched and added to the ticket. Use a connected, monitored inbox.",
+        "connectedInboxLabel": "Connected inbox",
+        "connectedInboxHelp": "A connected inbox keeps client replies in the ticket conversation.",
+        "customAddressOption": "Use another address",
+        "addressLabel": "From address",
+        "addressPlaceholder": "support@example.com",
+        "addressHelp": "This address controls reply routing for ticket email only.",
+        "nameLabel": "Sender display name",
+        "namePlaceholder": "Support",
+        "nameHelp": "Leave blank to use the connected mailbox name or ticket board name.",
+        "notConnectedWarning": "This address is not a connected inbox, so ticket replies may not be ingested.",
+        "microsoftMismatch": "Ticket email address must match the selected Microsoft 365 mailbox ({{mailbox}})."
+      },
+      "notification": {
+        "title": "All other email identity",
+        "description": "Brand portal invitations, password resets, invoices, project updates, and general notifications independently from ticket routing.",
+        "addressLabel": "From address",
+        "addressPlaceholder": "notifications@example.com",
+        "addressHelp": "SMTP and Resend use this address. Microsoft 365 uses the selected sending mailbox.",
+        "nameLabel": "Sender display name",
+        "namePlaceholder": "Your company name",
+        "nameHelp": "Leave blank to use {{company}} automatically.",
+        "companyFallback": "your tenant company"
+      },
+      "warningTitle": "Check reply routing",
+      "errorTitle": "Fix the ticket identity"
     }
   },
   "microsoft365": {

--- a/server/public/locales/it/msp/email-providers.json
+++ b/server/public/locales/it/msp/email-providers.json
@@ -760,7 +760,8 @@
       "domainRemovalScheduled": "Rimozione del dominio pianificata",
       "domainRemovalScheduledWithClear": "Rimozione del dominio pianificata e indirizzo mittente per ticketing cancellato",
       "removeDomainFailed": "Impossibile rimuovere il dominio",
-      "testOutboundFailed": "Test dell'e-mail in uscita non riuscito"
+      "testOutboundFailed": "Test dell'e-mail in uscita non riuscito",
+      "senderIdentitiesUpdated": "Sender identities updated."
     },
     "tabs": {
       "inboundEmail": "Email in entrata",
@@ -854,6 +855,39 @@
         "description": "I messaggi vengono inviati dalla casella selezionata tramite Microsoft Graph e salvati in Posta inviata.",
         "loadFailed": "Impossibile caricare le caselle Microsoft 365.",
         "saved": "Casella di invio aggiornata."
+      },
+      "senderIdentities": {
+        "ticket": {
+          "title": "Ticket email identity",
+          "description": "Replies to ticket emails must return to this address so they can be matched and added to the ticket. Use a connected, monitored inbox.",
+          "connectedInboxLabel": "Connected inbox",
+          "connectedInboxHelp": "A connected inbox keeps client replies in the ticket conversation.",
+          "customAddressOption": "Use another address",
+          "addressLabel": "From address",
+          "addressPlaceholder": "support@example.com",
+          "addressHelp": "This address controls reply routing for ticket email only.",
+          "microsoftAddressHelp": "Microsoft 365 requires ticket email to use the selected sending mailbox ({{mailbox}}).",
+          "nameLabel": "Sender display name",
+          "namePlaceholder": "Support",
+          "nameHelp": "Leave blank to use the connected mailbox name or ticket board name."
+        },
+        "notification": {
+          "title": "All other email identity",
+          "description": "Brand portal invitations, password resets, invoices, project updates, and general notifications independently from ticket routing.",
+          "addressLabel": "From address",
+          "addressPlaceholder": "notifications@example.com",
+          "smtpAddressHelp": "This is the branding address used for non-ticket email through your SMTP server.",
+          "lockedAddressHelp": "This address is determined by the active managed domain or selected Microsoft 365 mailbox.",
+          "nameLabel": "Sender display name",
+          "namePlaceholder": "Your company name",
+          "nameHelp": "Leave blank to use {{company}} automatically.",
+          "companyFallback": "your tenant company"
+        },
+        "warningTitle": "Check reply routing",
+        "errorTitle": "Fix the ticket identity",
+        "clearButton": "Clear ticket identity",
+        "savingButton": "Saving...",
+        "saveButton": "Save sender identities"
       }
     },
     "inbound": {
@@ -882,7 +916,8 @@
       "mustMatchDomain": "L'indirizzo mittente deve utilizzare @{{domain}}",
       "customAddressThreadWarning": "L'uso di un indirizzo personalizzato può impedire il corretto raggruppamento delle risposte in entrata.",
       "smtpDomainMismatchWarning": "Questo dominio non corrisponde al dominio mittente del tuo SMTP ({{domain}}). Le email potrebbero non essere consegnate o essere contrassegnate come spam se il tuo server SMTP non è autorizzato a inviare da questo dominio.",
-      "notConnectedWarning": "L'elaborazione dei ticket in entrata potrebbe non funzionare con questo indirizzo perché non è una delle tue caselle di posta collegate."
+      "notConnectedWarning": "L'elaborazione dei ticket in entrata potrebbe non funzionare con questo indirizzo perché non è una delle tue caselle di posta collegate.",
+      "microsoftMustMatchMailbox": "Ticket email address must match the selected Microsoft 365 mailbox ({{mailbox}})."
     },
     "domainList": {
       "loading": "Caricamento domini…",

--- a/server/public/locales/nl/msp/admin.json
+++ b/server/public/locales/nl/msp/admin.json
@@ -197,6 +197,36 @@
       "recipientPlaceholder": "jij@voorbeeld.com",
       "run": "Verbinding testen",
       "testing": "Bezig met testen..."
+    },
+    "senderIdentities": {
+      "ticket": {
+        "title": "Ticket email identity",
+        "description": "Replies to ticket emails must return to this address so they can be matched and added to the ticket. Use a connected, monitored inbox.",
+        "connectedInboxLabel": "Connected inbox",
+        "connectedInboxHelp": "A connected inbox keeps client replies in the ticket conversation.",
+        "customAddressOption": "Use another address",
+        "addressLabel": "From address",
+        "addressPlaceholder": "support@example.com",
+        "addressHelp": "This address controls reply routing for ticket email only.",
+        "nameLabel": "Sender display name",
+        "namePlaceholder": "Support",
+        "nameHelp": "Leave blank to use the connected mailbox name or ticket board name.",
+        "notConnectedWarning": "This address is not a connected inbox, so ticket replies may not be ingested.",
+        "microsoftMismatch": "Ticket email address must match the selected Microsoft 365 mailbox ({{mailbox}})."
+      },
+      "notification": {
+        "title": "All other email identity",
+        "description": "Brand portal invitations, password resets, invoices, project updates, and general notifications independently from ticket routing.",
+        "addressLabel": "From address",
+        "addressPlaceholder": "notifications@example.com",
+        "addressHelp": "SMTP and Resend use this address. Microsoft 365 uses the selected sending mailbox.",
+        "nameLabel": "Sender display name",
+        "namePlaceholder": "Your company name",
+        "nameHelp": "Leave blank to use {{company}} automatically.",
+        "companyFallback": "your tenant company"
+      },
+      "warningTitle": "Check reply routing",
+      "errorTitle": "Fix the ticket identity"
     }
   },
   "microsoft365": {

--- a/server/public/locales/nl/msp/email-providers.json
+++ b/server/public/locales/nl/msp/email-providers.json
@@ -760,7 +760,8 @@
       "domainRemovalScheduled": "Domeinverwijdering gepland",
       "domainRemovalScheduledWithClear": "Domeinverwijdering gepland en afzenderadres voor ticketing gewist",
       "removeDomainFailed": "Kan domein niet verwijderen",
-      "testOutboundFailed": "Testen van uitgaande e-mail mislukt"
+      "testOutboundFailed": "Testen van uitgaande e-mail mislukt",
+      "senderIdentitiesUpdated": "Sender identities updated."
     },
     "tabs": {
       "inboundEmail": "Inkomende e-mail",
@@ -854,6 +855,39 @@
         "description": "Berichten worden via Microsoft Graph als de geselecteerde mailbox verzonden en opgeslagen in Verzonden items.",
         "loadFailed": "Microsoft 365-mailboxen konden niet worden geladen.",
         "saved": "Verzendmailbox bijgewerkt."
+      },
+      "senderIdentities": {
+        "ticket": {
+          "title": "Ticket email identity",
+          "description": "Replies to ticket emails must return to this address so they can be matched and added to the ticket. Use a connected, monitored inbox.",
+          "connectedInboxLabel": "Connected inbox",
+          "connectedInboxHelp": "A connected inbox keeps client replies in the ticket conversation.",
+          "customAddressOption": "Use another address",
+          "addressLabel": "From address",
+          "addressPlaceholder": "support@example.com",
+          "addressHelp": "This address controls reply routing for ticket email only.",
+          "microsoftAddressHelp": "Microsoft 365 requires ticket email to use the selected sending mailbox ({{mailbox}}).",
+          "nameLabel": "Sender display name",
+          "namePlaceholder": "Support",
+          "nameHelp": "Leave blank to use the connected mailbox name or ticket board name."
+        },
+        "notification": {
+          "title": "All other email identity",
+          "description": "Brand portal invitations, password resets, invoices, project updates, and general notifications independently from ticket routing.",
+          "addressLabel": "From address",
+          "addressPlaceholder": "notifications@example.com",
+          "smtpAddressHelp": "This is the branding address used for non-ticket email through your SMTP server.",
+          "lockedAddressHelp": "This address is determined by the active managed domain or selected Microsoft 365 mailbox.",
+          "nameLabel": "Sender display name",
+          "namePlaceholder": "Your company name",
+          "nameHelp": "Leave blank to use {{company}} automatically.",
+          "companyFallback": "your tenant company"
+        },
+        "warningTitle": "Check reply routing",
+        "errorTitle": "Fix the ticket identity",
+        "clearButton": "Clear ticket identity",
+        "savingButton": "Saving...",
+        "saveButton": "Save sender identities"
       }
     },
     "inbound": {
@@ -882,7 +916,8 @@
       "mustMatchDomain": "Afzenderadres moet @{{domain}} gebruiken",
       "customAddressThreadWarning": "Het gebruik van een aangepast adres kan voorkomen dat inkomende antwoorden correct worden gegroepeerd.",
       "smtpDomainMismatchWarning": "Dit domein komt niet overeen met uw SMTP-afzenderdomein ({{domain}}). E-mails kunnen niet worden bezorgd of als spam worden gemarkeerd als uw SMTP-server niet is geautoriseerd om vanaf dit domein te verzenden.",
-      "notConnectedWarning": "Verwerking van inkomende tickets werkt mogelijk niet met dit adres omdat het geen van uw verbonden inboxen is."
+      "notConnectedWarning": "Verwerking van inkomende tickets werkt mogelijk niet met dit adres omdat het geen van uw verbonden inboxen is.",
+      "microsoftMustMatchMailbox": "Ticket email address must match the selected Microsoft 365 mailbox ({{mailbox}})."
     },
     "domainList": {
       "loading": "Domeinen laden…",

--- a/server/public/locales/pl/msp/admin.json
+++ b/server/public/locales/pl/msp/admin.json
@@ -197,6 +197,36 @@
       "recipientPlaceholder": "ty@przyklad.com",
       "run": "Testuj połączenie",
       "testing": "Testowanie..."
+    },
+    "senderIdentities": {
+      "ticket": {
+        "title": "Ticket email identity",
+        "description": "Replies to ticket emails must return to this address so they can be matched and added to the ticket. Use a connected, monitored inbox.",
+        "connectedInboxLabel": "Connected inbox",
+        "connectedInboxHelp": "A connected inbox keeps client replies in the ticket conversation.",
+        "customAddressOption": "Use another address",
+        "addressLabel": "From address",
+        "addressPlaceholder": "support@example.com",
+        "addressHelp": "This address controls reply routing for ticket email only.",
+        "nameLabel": "Sender display name",
+        "namePlaceholder": "Support",
+        "nameHelp": "Leave blank to use the connected mailbox name or ticket board name.",
+        "notConnectedWarning": "This address is not a connected inbox, so ticket replies may not be ingested.",
+        "microsoftMismatch": "Ticket email address must match the selected Microsoft 365 mailbox ({{mailbox}})."
+      },
+      "notification": {
+        "title": "All other email identity",
+        "description": "Brand portal invitations, password resets, invoices, project updates, and general notifications independently from ticket routing.",
+        "addressLabel": "From address",
+        "addressPlaceholder": "notifications@example.com",
+        "addressHelp": "SMTP and Resend use this address. Microsoft 365 uses the selected sending mailbox.",
+        "nameLabel": "Sender display name",
+        "namePlaceholder": "Your company name",
+        "nameHelp": "Leave blank to use {{company}} automatically.",
+        "companyFallback": "your tenant company"
+      },
+      "warningTitle": "Check reply routing",
+      "errorTitle": "Fix the ticket identity"
     }
   },
   "microsoft365": {

--- a/server/public/locales/pl/msp/email-providers.json
+++ b/server/public/locales/pl/msp/email-providers.json
@@ -760,7 +760,8 @@
       "domainRemovalScheduled": "Zaplanowano usunięcie domeny",
       "domainRemovalScheduledWithClear": "Zaplanowano usunięcie domeny i wyczyszczono adres nadawcy zgłoszeń",
       "removeDomainFailed": "Nie udało się usunąć domeny",
-      "testOutboundFailed": "Nie udało się przetestować poczty wychodzącej"
+      "testOutboundFailed": "Nie udało się przetestować poczty wychodzącej",
+      "senderIdentitiesUpdated": "Sender identities updated."
     },
     "tabs": {
       "inboundEmail": "Poczta przychodząca",
@@ -854,6 +855,39 @@
         "description": "Wiadomości są wysyłane z wybranej skrzynki przez Microsoft Graph i zapisywane w Elementach wysłanych.",
         "loadFailed": "Nie można załadować skrzynek Microsoft 365.",
         "saved": "Zaktualizowano skrzynkę wysyłkową."
+      },
+      "senderIdentities": {
+        "ticket": {
+          "title": "Ticket email identity",
+          "description": "Replies to ticket emails must return to this address so they can be matched and added to the ticket. Use a connected, monitored inbox.",
+          "connectedInboxLabel": "Connected inbox",
+          "connectedInboxHelp": "A connected inbox keeps client replies in the ticket conversation.",
+          "customAddressOption": "Use another address",
+          "addressLabel": "From address",
+          "addressPlaceholder": "support@example.com",
+          "addressHelp": "This address controls reply routing for ticket email only.",
+          "microsoftAddressHelp": "Microsoft 365 requires ticket email to use the selected sending mailbox ({{mailbox}}).",
+          "nameLabel": "Sender display name",
+          "namePlaceholder": "Support",
+          "nameHelp": "Leave blank to use the connected mailbox name or ticket board name."
+        },
+        "notification": {
+          "title": "All other email identity",
+          "description": "Brand portal invitations, password resets, invoices, project updates, and general notifications independently from ticket routing.",
+          "addressLabel": "From address",
+          "addressPlaceholder": "notifications@example.com",
+          "smtpAddressHelp": "This is the branding address used for non-ticket email through your SMTP server.",
+          "lockedAddressHelp": "This address is determined by the active managed domain or selected Microsoft 365 mailbox.",
+          "nameLabel": "Sender display name",
+          "namePlaceholder": "Your company name",
+          "nameHelp": "Leave blank to use {{company}} automatically.",
+          "companyFallback": "your tenant company"
+        },
+        "warningTitle": "Check reply routing",
+        "errorTitle": "Fix the ticket identity",
+        "clearButton": "Clear ticket identity",
+        "savingButton": "Saving...",
+        "saveButton": "Save sender identities"
       }
     },
     "inbound": {
@@ -882,7 +916,8 @@
       "mustMatchDomain": "Adres nadawcy musi używać @{{domain}}",
       "customAddressThreadWarning": "Użycie niestandardowego adresu może uniemożliwić prawidłowe grupowanie odpowiedzi przychodzących.",
       "smtpDomainMismatchWarning": "Ta domena nie pasuje do domeny nadawcy Twojego SMTP ({{domain}}). Wiadomości mogą nie zostać dostarczone lub zostać oznaczone jako spam, jeśli Twój serwer SMTP nie jest autoryzowany do wysyłania z tej domeny.",
-      "notConnectedWarning": "Przetwarzanie przychodzących zgłoszeń może nie działać z tym adresem, ponieważ nie jest to jedna z Twoich podłączonych skrzynek."
+      "notConnectedWarning": "Przetwarzanie przychodzących zgłoszeń może nie działać z tym adresem, ponieważ nie jest to jedna z Twoich podłączonych skrzynek.",
+      "microsoftMustMatchMailbox": "Ticket email address must match the selected Microsoft 365 mailbox ({{mailbox}})."
     },
     "domainList": {
       "loading": "Ładowanie domen…",

--- a/server/public/locales/pt/msp/admin.json
+++ b/server/public/locales/pt/msp/admin.json
@@ -197,6 +197,36 @@
       "recipientPlaceholder": "voce@exemplo.com",
       "run": "Testar conexão",
       "testing": "Testando..."
+    },
+    "senderIdentities": {
+      "ticket": {
+        "title": "Ticket email identity",
+        "description": "Replies to ticket emails must return to this address so they can be matched and added to the ticket. Use a connected, monitored inbox.",
+        "connectedInboxLabel": "Connected inbox",
+        "connectedInboxHelp": "A connected inbox keeps client replies in the ticket conversation.",
+        "customAddressOption": "Use another address",
+        "addressLabel": "From address",
+        "addressPlaceholder": "support@example.com",
+        "addressHelp": "This address controls reply routing for ticket email only.",
+        "nameLabel": "Sender display name",
+        "namePlaceholder": "Support",
+        "nameHelp": "Leave blank to use the connected mailbox name or ticket board name.",
+        "notConnectedWarning": "This address is not a connected inbox, so ticket replies may not be ingested.",
+        "microsoftMismatch": "Ticket email address must match the selected Microsoft 365 mailbox ({{mailbox}})."
+      },
+      "notification": {
+        "title": "All other email identity",
+        "description": "Brand portal invitations, password resets, invoices, project updates, and general notifications independently from ticket routing.",
+        "addressLabel": "From address",
+        "addressPlaceholder": "notifications@example.com",
+        "addressHelp": "SMTP and Resend use this address. Microsoft 365 uses the selected sending mailbox.",
+        "nameLabel": "Sender display name",
+        "namePlaceholder": "Your company name",
+        "nameHelp": "Leave blank to use {{company}} automatically.",
+        "companyFallback": "your tenant company"
+      },
+      "warningTitle": "Check reply routing",
+      "errorTitle": "Fix the ticket identity"
     }
   },
   "microsoft365": {

--- a/server/public/locales/pt/msp/email-providers.json
+++ b/server/public/locales/pt/msp/email-providers.json
@@ -760,7 +760,8 @@
       "domainRemovalScheduled": "Remoção de domínio agendada",
       "domainRemovalScheduledWithClear": "Remoção de domínio agendada e emissão de tickets Do endereço apagado",
       "removeDomainFailed": "Falha ao remover o domínio",
-      "testOutboundFailed": "Falha ao testar o e-mail de saída"
+      "testOutboundFailed": "Falha ao testar o e-mail de saída",
+      "senderIdentitiesUpdated": "Sender identities updated."
     },
     "tabs": {
       "inboundEmail": "E-mail de entrada",
@@ -854,6 +855,39 @@
         "description": "As mensagens são enviadas como a caixa selecionada pelo Microsoft Graph e salvas em Itens Enviados.",
         "loadFailed": "Não foi possível carregar as caixas de correio do Microsoft 365.",
         "saved": "Caixa de correio de envio atualizada."
+      },
+      "senderIdentities": {
+        "ticket": {
+          "title": "Ticket email identity",
+          "description": "Replies to ticket emails must return to this address so they can be matched and added to the ticket. Use a connected, monitored inbox.",
+          "connectedInboxLabel": "Connected inbox",
+          "connectedInboxHelp": "A connected inbox keeps client replies in the ticket conversation.",
+          "customAddressOption": "Use another address",
+          "addressLabel": "From address",
+          "addressPlaceholder": "support@example.com",
+          "addressHelp": "This address controls reply routing for ticket email only.",
+          "microsoftAddressHelp": "Microsoft 365 requires ticket email to use the selected sending mailbox ({{mailbox}}).",
+          "nameLabel": "Sender display name",
+          "namePlaceholder": "Support",
+          "nameHelp": "Leave blank to use the connected mailbox name or ticket board name."
+        },
+        "notification": {
+          "title": "All other email identity",
+          "description": "Brand portal invitations, password resets, invoices, project updates, and general notifications independently from ticket routing.",
+          "addressLabel": "From address",
+          "addressPlaceholder": "notifications@example.com",
+          "smtpAddressHelp": "This is the branding address used for non-ticket email through your SMTP server.",
+          "lockedAddressHelp": "This address is determined by the active managed domain or selected Microsoft 365 mailbox.",
+          "nameLabel": "Sender display name",
+          "namePlaceholder": "Your company name",
+          "nameHelp": "Leave blank to use {{company}} automatically.",
+          "companyFallback": "your tenant company"
+        },
+        "warningTitle": "Check reply routing",
+        "errorTitle": "Fix the ticket identity",
+        "clearButton": "Clear ticket identity",
+        "savingButton": "Saving...",
+        "saveButton": "Save sender identities"
       }
     },
     "inbound": {
@@ -882,7 +916,8 @@
       "mustMatchDomain": "O endereço do remetente deve usar @{{domain}}",
       "customAddressThreadWarning": "Usar um endereço personalizado pode impedir que as respostas dos tickets de entrada sejam encadeadas corretamente.",
       "smtpDomainMismatchWarning": "Este domínio não corresponde ao seu domínio de endereço SMTP ({{domain}}). Os e-mails podem não ser entregues ou ser sinalizados como spam se o seu servidor SMTP não estiver autorizado a enviar deste domínio.",
-      "notConnectedWarning": "O processamento de tickets de entrada pode não funcionar com esse endereço porque ele não é uma das suas caixas de entrada conectadas."
+      "notConnectedWarning": "O processamento de tickets de entrada pode não funcionar com esse endereço porque ele não é uma das suas caixas de entrada conectadas.",
+      "microsoftMustMatchMailbox": "Ticket email address must match the selected Microsoft 365 mailbox ({{mailbox}})."
     },
     "domainList": {
       "loading": "Carregando domínios…",

--- a/server/public/locales/xx/msp/admin.json
+++ b/server/public/locales/xx/msp/admin.json
@@ -197,6 +197,36 @@
       "recipientPlaceholder": "11111",
       "run": "11111",
       "testing": "11111"
+    },
+    "senderIdentities": {
+      "ticket": {
+        "title": "11111",
+        "description": "11111",
+        "connectedInboxLabel": "11111",
+        "connectedInboxHelp": "11111",
+        "customAddressOption": "11111",
+        "addressLabel": "11111",
+        "addressPlaceholder": "11111",
+        "addressHelp": "11111",
+        "nameLabel": "11111",
+        "namePlaceholder": "11111",
+        "nameHelp": "11111",
+        "notConnectedWarning": "11111",
+        "microsoftMismatch": "Ticket email address must match the selected Microsoft 365 mailbox ({{mailbox}})."
+      },
+      "notification": {
+        "title": "11111",
+        "description": "11111",
+        "addressLabel": "11111",
+        "addressPlaceholder": "11111",
+        "addressHelp": "11111",
+        "nameLabel": "11111",
+        "namePlaceholder": "11111",
+        "nameHelp": "11111 {{company}} 11111",
+        "companyFallback": "11111"
+      },
+      "warningTitle": "11111",
+      "errorTitle": "11111"
     }
   },
   "microsoft365": {

--- a/server/public/locales/xx/msp/email-providers.json
+++ b/server/public/locales/xx/msp/email-providers.json
@@ -760,7 +760,8 @@
       "domainRemovalScheduled": "11111",
       "domainRemovalScheduledWithClear": "11111",
       "removeDomainFailed": "11111",
-      "testOutboundFailed": "11111"
+      "testOutboundFailed": "11111",
+      "senderIdentitiesUpdated": "11111"
     },
     "tabs": {
       "inboundEmail": "11111",
@@ -854,6 +855,39 @@
         "description": "11111",
         "loadFailed": "11111",
         "saved": "11111"
+      },
+      "senderIdentities": {
+        "ticket": {
+          "title": "11111",
+          "description": "11111",
+          "connectedInboxLabel": "11111",
+          "connectedInboxHelp": "11111",
+          "customAddressOption": "11111",
+          "addressLabel": "11111",
+          "addressPlaceholder": "11111",
+          "addressHelp": "11111",
+          "microsoftAddressHelp": "11111 {{mailbox}} 11111",
+          "nameLabel": "11111",
+          "namePlaceholder": "11111",
+          "nameHelp": "11111"
+        },
+        "notification": {
+          "title": "11111",
+          "description": "11111",
+          "addressLabel": "11111",
+          "addressPlaceholder": "11111",
+          "smtpAddressHelp": "11111",
+          "lockedAddressHelp": "11111",
+          "nameLabel": "11111",
+          "namePlaceholder": "11111",
+          "nameHelp": "11111 {{company}} 11111",
+          "companyFallback": "11111"
+        },
+        "warningTitle": "11111",
+        "errorTitle": "11111",
+        "clearButton": "11111",
+        "savingButton": "11111",
+        "saveButton": "11111"
       }
     },
     "inbound": {
@@ -882,7 +916,8 @@
       "mustMatchDomain": "11111 {{domain}} 11111",
       "customAddressThreadWarning": "11111",
       "smtpDomainMismatchWarning": "11111 {{domain}} 11111",
-      "notConnectedWarning": "11111"
+      "notConnectedWarning": "11111",
+      "microsoftMustMatchMailbox": "11111 {{mailbox}} 11111"
     },
     "domainList": {
       "loading": "11111",

--- a/server/public/locales/yy/msp/admin.json
+++ b/server/public/locales/yy/msp/admin.json
@@ -197,6 +197,36 @@
       "recipientPlaceholder": "55555",
       "run": "55555",
       "testing": "55555"
+    },
+    "senderIdentities": {
+      "ticket": {
+        "title": "55555",
+        "description": "55555",
+        "connectedInboxLabel": "55555",
+        "connectedInboxHelp": "55555",
+        "customAddressOption": "55555",
+        "addressLabel": "55555",
+        "addressPlaceholder": "55555",
+        "addressHelp": "55555",
+        "nameLabel": "55555",
+        "namePlaceholder": "55555",
+        "nameHelp": "55555",
+        "notConnectedWarning": "55555",
+        "microsoftMismatch": "Ticket email address must match the selected Microsoft 365 mailbox ({{mailbox}})."
+      },
+      "notification": {
+        "title": "55555",
+        "description": "55555",
+        "addressLabel": "55555",
+        "addressPlaceholder": "55555",
+        "addressHelp": "55555",
+        "nameLabel": "55555",
+        "namePlaceholder": "55555",
+        "nameHelp": "55555 {{company}} 55555",
+        "companyFallback": "55555"
+      },
+      "warningTitle": "55555",
+      "errorTitle": "55555"
     }
   },
   "microsoft365": {

--- a/server/public/locales/yy/msp/email-providers.json
+++ b/server/public/locales/yy/msp/email-providers.json
@@ -760,7 +760,8 @@
       "domainRemovalScheduled": "55555",
       "domainRemovalScheduledWithClear": "55555",
       "removeDomainFailed": "55555",
-      "testOutboundFailed": "55555"
+      "testOutboundFailed": "55555",
+      "senderIdentitiesUpdated": "55555"
     },
     "tabs": {
       "inboundEmail": "55555",
@@ -854,6 +855,39 @@
         "description": "55555",
         "loadFailed": "55555",
         "saved": "55555"
+      },
+      "senderIdentities": {
+        "ticket": {
+          "title": "55555",
+          "description": "55555",
+          "connectedInboxLabel": "55555",
+          "connectedInboxHelp": "55555",
+          "customAddressOption": "55555",
+          "addressLabel": "55555",
+          "addressPlaceholder": "55555",
+          "addressHelp": "55555",
+          "microsoftAddressHelp": "55555 {{mailbox}} 55555",
+          "nameLabel": "55555",
+          "namePlaceholder": "55555",
+          "nameHelp": "55555"
+        },
+        "notification": {
+          "title": "55555",
+          "description": "55555",
+          "addressLabel": "55555",
+          "addressPlaceholder": "55555",
+          "smtpAddressHelp": "55555",
+          "lockedAddressHelp": "55555",
+          "nameLabel": "55555",
+          "namePlaceholder": "55555",
+          "nameHelp": "55555 {{company}} 55555",
+          "companyFallback": "55555"
+        },
+        "warningTitle": "55555",
+        "errorTitle": "55555",
+        "clearButton": "55555",
+        "savingButton": "55555",
+        "saveButton": "55555"
       }
     },
     "inbound": {
@@ -882,7 +916,8 @@
       "mustMatchDomain": "55555 {{domain}} 55555",
       "customAddressThreadWarning": "55555",
       "smtpDomainMismatchWarning": "55555 {{domain}} 55555",
-      "notConnectedWarning": "55555"
+      "notConnectedWarning": "55555",
+      "microsoftMustMatchMailbox": "55555 {{mailbox}} 55555"
     },
     "domainList": {
       "loading": "55555",

--- a/server/src/test/integration/emailSenderIdentity.integration.test.ts
+++ b/server/src/test/integration/emailSenderIdentity.integration.test.ts
@@ -1,0 +1,131 @@
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+import type { Knex } from 'knex';
+import { v4 as uuidv4 } from 'uuid';
+import { tenantDb } from '@alga-psa/db';
+import {
+  resolveDefaultFromAddress,
+  resolveTenantCompanyName,
+  TenantEmailService,
+} from '@alga-psa/email';
+import { createTestDbConnection } from '../../../test-utils/dbConfig';
+
+describe('email sender identity integration', () => {
+  let db: Knex;
+  const tenantIds: string[] = [];
+
+  beforeAll(async () => {
+    db = await createTestDbConnection();
+  });
+
+  afterAll(async () => {
+    for (const tenantId of tenantIds) {
+      const scoped = tenantDb(db, tenantId);
+      await scoped.table('tenant_email_settings').delete();
+      await scoped.table('tenant_companies').delete();
+      await scoped.table('clients').delete();
+      await scoped.unscoped('tenants', 'email sender identity integration fixture cleanup')
+        .where({ tenant: tenantId })
+        .delete();
+    }
+    if (db) {
+      await db.destroy();
+    }
+  });
+
+  async function createTenantFixture(params: {
+    tenantName: string;
+    clientName?: string;
+    withDefaultClient?: boolean;
+  }) {
+    const tenantId = uuidv4();
+    const clientId = uuidv4();
+    tenantIds.push(tenantId);
+    const scoped = tenantDb(db, tenantId);
+
+    await scoped.unscoped('tenants', 'email sender identity integration fixture setup').insert({
+      tenant: tenantId,
+      client_name: params.tenantName,
+      email: `tenant-${tenantId.slice(0, 8)}@example.test`,
+      created_at: db.fn.now(),
+      updated_at: db.fn.now(),
+    });
+
+    if (params.clientName) {
+      await scoped.table('clients').insert({
+        tenant: tenantId,
+        client_id: clientId,
+        client_name: params.clientName,
+        created_at: db.fn.now(),
+        updated_at: db.fn.now(),
+      });
+      if (params.withDefaultClient !== false) {
+        await scoped.table('tenant_companies').insert({
+          tenant: tenantId,
+          client_id: clientId,
+          is_default: true,
+          created_at: db.fn.now(),
+          updated_at: db.fn.now(),
+        });
+      }
+    }
+
+    await scoped.table('tenant_email_settings').insert({
+      tenant: tenantId,
+      default_from_domain: 'example.test',
+      email_provider: 'smtp',
+      provider_configs: JSON.stringify([{
+        providerId: 'smtp-provider',
+        providerType: 'smtp',
+        isEnabled: true,
+        config: { from: 'notifications@example.test', fromName: '' },
+      }]),
+      tracking_enabled: false,
+      fallback_enabled: true,
+      created_at: db.fn.now(),
+      updated_at: db.fn.now(),
+    });
+
+    return { tenantId, clientId };
+  }
+
+  it('resolves a blank provider name from the current default client without persisting it', async () => {
+    const { tenantId, clientId } = await createTenantFixture({
+      tenantName: 'Tenant Record Name',
+      clientName: 'Example MSP',
+    });
+
+    const settings = await TenantEmailService.getTenantEmailSettings(tenantId, db);
+    const companyName = await resolveTenantCompanyName(db, tenantId);
+
+    expect(companyName).toBe('Example MSP');
+    expect(resolveDefaultFromAddress(settings, companyName)).toEqual({
+      email: 'notifications@example.test',
+      name: 'Example MSP',
+    });
+    expect(settings?.providerConfigs[0]?.config.fromName).toBe('');
+
+    await tenantDb(db, tenantId).table('clients')
+      .where({ client_id: clientId })
+      .update({ client_name: 'Renamed MSP' });
+
+    expect(await resolveTenantCompanyName(db, tenantId)).toBe('Renamed MSP');
+    const stored = await tenantDb(db, tenantId).table('tenant_email_settings').first('provider_configs');
+    const providerConfigs = typeof stored.provider_configs === 'string'
+      ? JSON.parse(stored.provider_configs)
+      : stored.provider_configs;
+    expect(providerConfigs[0].config.fromName).toBe('');
+  });
+
+  it('falls back to the tenant record and never reads another tenant default client', async () => {
+    const first = await createTenantFixture({
+      tenantName: 'Fallback Tenant Name',
+      withDefaultClient: false,
+    });
+    await createTenantFixture({
+      tenantName: 'Other Tenant',
+      clientName: 'Other Tenant MSP',
+    });
+
+    expect(await resolveTenantCompanyName(db, first.tenantId)).toBe('Fallback Tenant Name');
+  });
+});


### PR DESCRIPTION
## Summary

- Separate ticket-routing sender identity from the ordinary notification identity in both tenant and managed email settings, with side-by-side UI guidance and validation.
- Resolve a blank ordinary notification display name to the tenant company while preserving the provider-selected notification address; per-message names such as the portal invitation name override only the display name.
- Refresh tenant and system provider snapshots when persisted settings or environment configuration changes, invalidating saves immediately and pairing provider/from identity safely for each in-flight send.
- Use the Microsoft Graph MIME path for named messages while retaining the selected mailbox and keeping ticket identity independent.
- Add localized sender-identity UI, provider and lifecycle coverage, direct-database fallback coverage, and portal-invitation contract coverage.
- Stabilize the invoice-template preview test exposed by CI by waiting for imported workspace state and narrowing the test-only hydration metadata type.

## Validation

Automated validation passed before the live smoke:

- Email package tests: 95 passed.
- Integrations package tests: 421 passed.
- Direct PostgreSQL sender identity integration: 2 passed.
- Email, integrations, server, and EE typechecks passed.
- Lint completed with zero errors.
- Enterprise webpack build passed.
- Invoice-template preview workspace tests: 21 passed with the CI seed after the hydration-race fix.

## Live smoke test

**PASS** — exercised the live product on port 3305 with PostgreSQL and the existing GreenMail SMTP/IMAP simulator.

Verified:

- Settings UI presents “Ticket email identity” and “All other email identity” side by side, with routing explanation and distinct persisted addresses.
- With notification display name blank, a real UI-triggered SMTP message arrived as `Oz <notifications@localhost>`, not the ticket address.
- A real portal invitation was sent through the contact UI. GreenMail captured `Emerald City Portal <notifications@localhost>` and the UI showed success. This proves the computed portal name is applied while retaining the notification address.
- Changed the provider display name through the running UI and immediately sent again without restarting. GreenMail captured `Oz Branded Notifications <notifications@localhost>`; ticket identity remained separate.
- Portal invitation creation was also verified in PostgreSQL before cleanup.

Evidence: `/tmp/alga-smoke-evidence/email-sender-identity-20260804-171605`

## Fidelity compromises

- SMTP was exercised with the repo stack’s existing GreenMail simulator; no mocks were used.
- Resend and Microsoft Graph/M365 delivery were not exercised because no live credentials or suitable existing simulators were available.
- The card’s nested browser bridge could inspect and navigate the page, but `browser-type` dropped controlled-input changes and `browser-screenshot` timed out. Installed Playwright was used against the same live localhost product for reliable modal interaction and screenshots. Login setup used the product’s Auth.js credentials endpoint.
- Concurrent in-flight provider pairing, cross-process `updatedAt` refresh, and environment-fingerprint refresh were not independently stress-tested by this browser smoke.

## Concerns and cleanup

- Unrelated existing schema drift causes scheduled-job/RMM logs to fail on missing `tenants.suspended_at`; tested feature routes remained functional.
- The pre-existing `package-lock.json` modification remains untouched.
- All product database fixtures and GreenMail users/messages created by this smoke were restored or removed. Temporary smoke scripts were removed, the worktree has no new changes from the smoke, and the app was left running.
