### PR TITLE
docs: update Google SSO Helm configuration guidance (2026-08-05)

### DIFF
--- a/docs/integrations/msp-sso-domain-claims.md
+++ b/docs/integrations/msp-sso-domain-claims.md
@@ -43,6 +43,22 @@ Fallback prerequisites:
 
 If fallback credentials are configured, eligible app providers are returned by discovery and can be used by resolver/start flow. If not configured, provider buttons remain disabled.
 
+### Setting Google SSO credentials
+
+`GOOGLE_OAUTH_CLIENT_ID` and `GOOGLE_OAUTH_CLIENT_SECRET` are used exclusively for Google Sign-In (the app-level SSO fallback). How they are populated depends on your deployment method.
+
+**Helm deployments:** Add a `google_sso` block to your values to run Google Sign-In on its own dedicated OAuth client (the "AlgaPSA Identity" client), independent of the Gmail inbox integration:
+
+```yaml
+google_sso:
+  client_id: "YOUR_SSO_CLIENT_ID.apps.googleusercontent.com"
+  client_secret: "YOUR_SSO_CLIENT_SECRET"
+```
+
+If `google_sso` is absent, the chart falls back to the `gmail_integration` credentials — preserving historical behavior so existing releases are unaffected. However, running sign-in and inbox on the same OAuth client couples the two integrations: reconfiguring or disabling the Gmail client also removes the Google Sign-In button. Using a dedicated `google_sso` block lets you manage them independently, so sign-in continues to work even if the inbox integration is reconfigured or disabled.
+
+**Docker Compose deployments:** Set the `google_oauth_client_id` and `google_oauth_client_secret` secret files as described in the [setup guide](../getting-started/setup_guide.md#email--oauth-secrets).
+
 ## Security and UX Contracts
 
 - Discovery and resolve responses preserve anti-enumeration semantics and do not expose user existence.


### PR DESCRIPTION
## Source PRs

| # | Title | Link |
|---|-------|------|
| #3103 | helm: source sign-in OAuth from google_sso block | https://github.com/Nine-Minds/alga-psa/pull/3103 |

## Files edited

### `docs/integrations/msp-sso-domain-claims.md`

**Behavior conveyed:** Google Sign-In (app-level SSO) can now run on a dedicated OAuth client separate from the Gmail inbox integration. Helm deployments add a `google_sso` values block (`client_id` / `client_secret`) to decouple sign-in from inbox; without the block the chart falls back to `gmail_integration` credentials (historical behavior unchanged). The doc now explains this priority rule and the operational consequence — that coupling sign-in and inbox to the same client means reconfiguring Gmail also removes the sign-in button, which the new block avoids.

## PRs audited (no drift found)

| # | Title | Outcome |
|---|-------|---------|
| #3104 | Tests/fix nightly aug 4 | Skip — pure test infrastructure consolidation (knexfile moved to `packages/db`, test env isolation fix). No user-visible behavior change. |
| #3102 | add info on google | See "Needs human review" below. |

## Needs human review

**PR #3102 — "add info on google"** (`server/src/app/static/privacy_policy/page.tsx`)

The PR body is empty. The diff adds two integrations to the in-app privacy policy that were not listed there before:

- **Google Calendar** — two-way calendar sync between Alga PSA schedules and technician calendars
- **Google Sign-In** — basic account info (name, email, profile picture) used to authenticate and link a Google identity

The privacy policy edit itself is source code, not an in-scope doc. However, the additions raise a question about whether any customer-facing nm-store documentation should be updated to surface these integrations more prominently:
- `docs/integrations/calendar-sync-operations.md` already documents Google Calendar sync fully — no update needed there.
- `docs/integrations/msp-sso-domain-claims.md` already covers Google Sign-In SSO routing — updated in this PR.
- No Google/OAuth/calendar content was found in nm-store's customer-facing doc pages (`src/site/content/docs/`, `src/app/(frontend)/documentation/`, `src/app/(frontend)/developers/`).

If the privacy policy additions reflect **newly launched** features rather than a compliance catch-up, consider whether nm-store's product documentation pages should mention Google Calendar sync and Google Sign-In as supported integrations. This cannot be determined from the diff alone.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Lot4ernJcg9aANpJbPVu2H)_