### PR TITLE
Clean up ITIL artifacts on board deletion

### DIFF
--- a/packages/core/src/config/deletion/index.ts
+++ b/packages/core/src/config/deletion/index.ts
@@ -498,7 +498,8 @@ export const DELETION_CONFIGS: Record<string, EntityDeletionConfig> = {
     supportsArchive: false,
     dependencies: [
       { type: 'ticket', table: 'tickets', foreignKey: 'priority_id', label: 'ticket' },
-      { type: 'board_default', table: 'boards', foreignKey: 'default_priority_id', label: 'board default priority' }
+      { type: 'board_default', table: 'boards', foreignKey: 'default_priority_id', label: 'board default priority' },
+      { type: 'sla_policy_target', table: 'sla_policy_targets', foreignKey: 'priority_id', label: 'SLA policy target' }
     ]
   },
   board: {

--- a/packages/reference-data/src/actions/__tests__/priorityActions.itilDeletion.test.ts
+++ b/packages/reference-data/src/actions/__tests__/priorityActions.itilDeletion.test.ts
@@ -1,0 +1,97 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const TENANT = 'tenant-1';
+
+const state = vi.hoisted(() => ({
+  itilBoards: [] as Array<{ board_id: string }>,
+  priority: null as Record<string, unknown> | null,
+}));
+
+vi.mock('@alga-psa/db', () => ({
+  createTenantKnex: vi.fn(async () => ({ knex: {}, tenant: TENANT })),
+  withTransaction: vi.fn(async (_db: unknown, fn: (trx: unknown) => unknown) => fn({})),
+  tenantDb: () => ({
+    table: (table: string) => ({
+      where: () => ({
+        first: async () => (table === 'boards' ? state.itilBoards[0] : undefined),
+      }),
+    }),
+  }),
+}));
+
+vi.mock('@alga-psa/auth', () => ({
+  withAuth: (action: any) => (...args: any[]) => action({ user_id: 'user-1' }, { tenant: TENANT }, ...args),
+  preCheckDeletion: vi.fn(async () => ({
+    canDelete: true,
+    dependencies: [],
+    alternatives: [],
+  })),
+}));
+
+const deleteEntityWithValidationMock = vi.hoisted(() => vi.fn());
+
+vi.mock('@alga-psa/core/server', () => ({
+  deleteEntityWithValidation: deleteEntityWithValidationMock,
+}));
+
+vi.mock('@alga-psa/ui/lib/errorHandling', () => ({
+  actionError: (message: string) => ({ error: message }),
+  isActionMessageError: () => false,
+}));
+
+const priorityDeleteMock = vi.hoisted(() => vi.fn());
+
+vi.mock('../../models/priority', () => ({
+  default: {
+    get: vi.fn(async () => state.priority),
+    delete: priorityDeleteMock,
+  },
+}));
+
+import { deletePriority, validatePriorityDeletion } from '../priorityActions';
+
+const itilPriority = {
+  priority_id: 'priority-itil',
+  priority_name: 'P1 - Critical',
+  is_from_itil_standard: true,
+};
+
+describe('ITIL priority deletion guard', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    state.priority = itilPriority;
+    deleteEntityWithValidationMock.mockImplementation(async (
+      _entityType: string,
+      _entityId: string,
+      _knex: unknown,
+      tenant: string,
+      performDelete: (trx: unknown, tenant: string) => Promise<void>
+    ) => {
+      await performDelete({}, tenant);
+      return { canDelete: true, deleted: true, dependencies: [], alternatives: [] };
+    });
+  });
+
+  it('blocks deletion while a board still uses ITIL priorities', async () => {
+    state.itilBoards = [{ board_id: 'board-itil' }];
+
+    const validation = await validatePriorityDeletion(itilPriority.priority_id);
+    expect(validation.canDelete).toBe(false);
+    expect(validation.message).toContain('while a board uses ITIL priorities');
+
+    const result = await deletePriority(itilPriority.priority_id);
+    expect(result.success).toBe(false);
+    expect(deleteEntityWithValidationMock).not.toHaveBeenCalled();
+  });
+
+  it('allows deletion once no board uses ITIL priorities', async () => {
+    state.itilBoards = [];
+
+    const validation = await validatePriorityDeletion(itilPriority.priority_id);
+    expect(validation.canDelete).toBe(true);
+
+    const result = await deletePriority(itilPriority.priority_id);
+    expect(result.success).toBe(true);
+    expect(priorityDeleteMock).toHaveBeenCalledWith(expect.anything(), TENANT, itilPriority.priority_id);
+  });
+});

--- a/packages/reference-data/src/actions/priorityActions.ts
+++ b/packages/reference-data/src/actions/priorityActions.ts
@@ -15,6 +15,19 @@ import type { PriorityActionError } from './priorityActionErrors';
 const tenantScopedTable = (trx: Knex | Knex.Transaction, table: string, tenant: string) =>
   tenantDb(trx, tenant).table(table);
 
+/**
+ * ITIL priorities are immutable while any board offers them, but once the tenant
+ * has walked back the ITIL choice they must be removable — otherwise the rows are
+ * stranded in every picker forever.
+ */
+const hasItilPriorityBoard = async (trx: Knex | Knex.Transaction, tenant: string): Promise<boolean> => {
+  const board = await tenantScopedTable(trx, 'boards', tenant)
+    .where({ priority_type: 'itil' })
+    .first('board_id');
+
+  return Boolean(board);
+};
+
 function priorityActionErrorMessage(error: unknown, fallback: string): string {
   const message = error instanceof Error ? error.message : typeof error === 'string' ? error : '';
 
@@ -137,11 +150,11 @@ export const validatePriorityDeletion = withAuth(async (
       };
     }
 
-    if (priority.is_from_itil_standard) {
+    if (priority.is_from_itil_standard && await hasItilPriorityBoard(trx, tenant)) {
       return {
         canDelete: false,
         code: 'VALIDATION_FAILED',
-        message: 'ITIL standard priorities cannot be deleted.',
+        message: 'ITIL standard priorities cannot be deleted while a board uses ITIL priorities.',
         dependencies: [],
         alternatives: []
       };
@@ -158,9 +171,10 @@ export const deletePriority = withAuth(async (
 ): Promise<DeletionValidationResult & { success: boolean; deleted?: boolean }> => {
   try {
     const { knex: db } = await createTenantKnex();
-    const priority = await withTransaction(db, async (trx: Knex.Transaction) => {
-      return Priority.get(trx, tenant, priorityId);
-    });
+    const { priority, itilBoardExists } = await withTransaction(db, async (trx: Knex.Transaction) => ({
+      priority: await Priority.get(trx, tenant, priorityId),
+      itilBoardExists: await hasItilPriorityBoard(trx, tenant)
+    }));
 
     if (!priority) {
       return {
@@ -173,12 +187,12 @@ export const deletePriority = withAuth(async (
       };
     }
 
-    if (priority.is_from_itil_standard) {
+    if (priority.is_from_itil_standard && itilBoardExists) {
       return {
         success: false,
         canDelete: false,
         code: 'VALIDATION_FAILED',
-        message: 'ITIL standard priorities cannot be deleted.',
+        message: 'ITIL standard priorities cannot be deleted while a board uses ITIL priorities.',
         dependencies: [],
         alternatives: []
       };
@@ -275,6 +289,15 @@ export const getPrioritiesByBoardType = withAuth(async (_user, { tenant }, board
       throw error;
     }
   });
+});
+
+/**
+ * Whether any board still offers ITIL priorities. Settings uses this to decide
+ * whether ITIL rows are protected or removable.
+ */
+export const hasItilPriorityBoards = withAuth(async (_user, { tenant }): Promise<boolean> => {
+  const { knex: db } = await createTenantKnex();
+  return withTransaction(db, async (trx: Knex.Transaction) => hasItilPriorityBoard(trx, tenant));
 });
 
 export interface FindPriorityByNameOutput {

--- a/packages/reference-data/src/components/settings/PrioritySettings.tsx
+++ b/packages/reference-data/src/components/settings/PrioritySettings.tsx
@@ -5,7 +5,7 @@ import { Button } from '@alga-psa/ui/components/Button';
 import { Plus, MoreVertical, Palette } from "lucide-react";
 import { Alert, AlertDescription } from '@alga-psa/ui/components/Alert';
 import ColorPicker from '@alga-psa/ui/components/ColorPicker';
-import { getAllPriorities, createPriority, deletePriority, updatePriority, validatePriorityDeletion } from '../../actions/priorityActions';
+import { getAllPriorities, createPriority, deletePriority, updatePriority, validatePriorityDeletion, hasItilPriorityBoards } from '../../actions/priorityActions';
 import { isPriorityActionError } from '../../actions/priorityActionErrors';
 import { importReferenceData, getAvailableReferenceData, checkImportConflicts, type ImportConflict } from '../../actions/referenceDataActions';
 import type { IPriority, IStandardPriority, DeletionValidationResult } from '@alga-psa/types';
@@ -46,6 +46,8 @@ const PrioritySettings = ({ onShowConflictDialog, initialPriorityType }: Priorit
   const [availableReferencePriorities, setAvailableReferencePriorities] = useState<IStandardPriority[]>([]);
   const [selectedImportPriorities, setSelectedImportPriorities] = useState<string[]>([]);
   const [priorityColor, setPriorityColor] = useState('#6B7280');
+  // ITIL priorities stay protected only while a board still offers them.
+  const [itilBoardExists, setItilBoardExists] = useState(true);
 
   // Delete dialog state
   const [priorityToDelete, setPriorityToDelete] = useState<IPriority | null>(null);
@@ -74,6 +76,18 @@ const PrioritySettings = ({ onShowConflictDialog, initialPriorityType }: Priorit
     };
 
     fetchPriorities();
+  }, []);
+
+  useEffect(() => {
+    const fetchItilBoardUsage = async (): Promise<void> => {
+      try {
+        setItilBoardExists(await hasItilPriorityBoards());
+      } catch (error) {
+        console.error('Error checking ITIL board usage:', error);
+      }
+    };
+
+    fetchItilBoardUsage();
   }, []);
 
   const updatePriorityItem = async (updatedPriority: IPriority): Promise<void> => {
@@ -262,7 +276,9 @@ const PrioritySettings = ({ onShowConflictDialog, initialPriorityType }: Priorit
           <AlertDescription>
             <strong>{t('ticketing.priorities.alert.header')}</strong> {t('ticketing.priorities.alert.description')}
             {priorities.some(p => 'is_from_itil_standard' in p && p.is_from_itil_standard && p.item_type === selectedPriorityType) ?
-              ` ${t('ticketing.priorities.alert.itilNote')}` :
+              ` ${itilBoardExists
+                ? t('ticketing.priorities.alert.itilNote')
+                : t('ticketing.priorities.alert.itilRemovableNote', 'ITIL standard priorities cannot be edited, but can be deleted now that no board uses ITIL priorities.')}` :
               ` ${t('ticketing.priorities.alert.nonItilNote')}`}
           </AlertDescription>
         </Alert>
@@ -278,8 +294,11 @@ const PrioritySettings = ({ onShowConflictDialog, initialPriorityType }: Priorit
             dataIndex: 'action',
             width: '5%',
             render: (_, item) => {
-              // ITIL imported priorities cannot be edited or deleted
-              if ('is_from_itil_standard' in item && item.is_from_itil_standard) {
+              const isItilPriority = 'is_from_itil_standard' in item && Boolean(item.is_from_itil_standard);
+
+              // ITIL imported priorities are never editable, and stay fully
+              // protected only while a board still offers ITIL priorities.
+              if (isItilPriority && itilBoardExists) {
                 return (
                   <span className="text-xs text-gray-400">{t('ticketing.priorities.table.itilProtected')}</span>
                 );
@@ -299,17 +318,19 @@ const PrioritySettings = ({ onShowConflictDialog, initialPriorityType }: Priorit
                     </Button>
                   </DropdownMenuTrigger>
                   <DropdownMenuContent align="end">
-                    <DropdownMenuItem
-                      id={`edit-priority-${item.priority_id}`}
-                      onClick={(e) => {
-                        e.stopPropagation();
-                        setEditingPriority(item as IPriority);
-                        setPriorityColor(item.color || '#6B7280');
-                        setShowPriorityDialog(true);
-                      }}
-                    >
-                      {t('ticketing.priorities.actions.edit')}
-                    </DropdownMenuItem>
+                    {!isItilPriority && (
+                      <DropdownMenuItem
+                        id={`edit-priority-${item.priority_id}`}
+                        onClick={(e) => {
+                          e.stopPropagation();
+                          setEditingPriority(item as IPriority);
+                          setPriorityColor(item.color || '#6B7280');
+                          setShowPriorityDialog(true);
+                        }}
+                      >
+                        {t('ticketing.priorities.actions.edit')}
+                      </DropdownMenuItem>
+                    )}
                     <DropdownMenuItem
                       id={`delete-priority-${item.priority_id}`}
                       className="text-red-600 focus:text-red-600"

--- a/packages/tickets/src/actions/board-actions/boardActions.ts
+++ b/packages/tickets/src/actions/board-actions/boardActions.ts
@@ -627,7 +627,54 @@ export const deleteBoard = withAuth(async (
       }
     }
 
-    if (!force && !isLastItilBoard && allCategoryIds.length === 0) {
+    // 8b. Retire unused ITIL data while the board row is still present (the
+    // cleanup counts ITIL boards, so the one being deleted is excluded). Doing
+    // this before the DELETE keeps the FK teardown and the delete in one order
+    // that both CE and prod accept.
+    let itilCleanupMessage = '';
+    if (isLastItilBoard && cleanupItil) {
+      const cleanupResult = await ItilStandardsService.cleanupUnusedItilStandards(trx, tenant, [boardId]);
+
+      // Build informative message about what was cleaned up
+      const cleanedParts: string[] = [];
+      const skippedParts: string[] = [];
+
+      if (cleanupResult.categoriesDeleted > 0) {
+        cleanedParts.push(`${cleanupResult.categoriesDeleted} ITIL categor${cleanupResult.categoriesDeleted === 1 ? 'y' : 'ies'}`);
+      }
+      if (cleanupResult.prioritiesDeleted > 0) {
+        cleanedParts.push(`${cleanupResult.prioritiesDeleted} ITIL priorit${cleanupResult.prioritiesDeleted === 1 ? 'y' : 'ies'}`);
+      }
+      if (cleanupResult.categoriesSkippedReason) {
+        skippedParts.push(`categories (${cleanupResult.categoriesSkippedReason})`);
+      }
+      if (cleanupResult.prioritiesSkippedReason) {
+        skippedParts.push(`priorities (${cleanupResult.prioritiesSkippedReason})`);
+      }
+
+      if (cleanedParts.length > 0) {
+        itilCleanupMessage = ` Cleaned up: ${cleanedParts.join(', ')}.`;
+      }
+      if (skippedParts.length > 0) {
+        itilCleanupMessage += ` Could not clean up: ${skippedParts.join(', ')}.`;
+      }
+    }
+
+    // 8c. ITIL categories are shared across ITIL boards, so any that survived
+    // cleanup must stop pointing at the board we are about to delete.
+    const fallbackItilBoard = await tenantScopedTable('boards')
+      .whereNot('board_id', boardId)
+      .where('category_type', 'itil')
+      .orderBy('board_name', 'asc')
+      .first('board_id');
+
+    const repointedItilCategories = await tenantScopedTable('categories')
+      .where({ board_id: boardId, is_from_itil_standard: true })
+      .update({ board_id: fallbackItilBoard?.board_id ?? null });
+
+    // The lightweight path below validates in its own transaction and therefore
+    // cannot see the re-point above, so boards that needed one take the main path.
+    if (!force && !isLastItilBoard && allCategoryIds.length === 0 && repointedItilCategories === 0) {
       const result = await deleteEntityWithValidation('board', boardId, db, tenant, async (boardTrx, tenantId) => {
         // Clean up board statuses (can't be deleted manually due to
         // "at least one default status" enforcement, safe because
@@ -694,36 +741,6 @@ export const deleteBoard = withAuth(async (
         timestamp: new Date().toISOString(),
       },
     });
-
-    // 12. If last ITIL board and cleanup confirmed, remove unused ITIL data
-    let itilCleanupMessage = '';
-    if (isLastItilBoard && cleanupItil) {
-      const cleanupResult = await ItilStandardsService.cleanupUnusedItilStandards(trx, tenant);
-
-      // Build informative message about what was cleaned up
-      const cleanedParts: string[] = [];
-      const skippedParts: string[] = [];
-
-      if (cleanupResult.categoriesDeleted > 0) {
-        cleanedParts.push(`${cleanupResult.categoriesDeleted} ITIL categor${cleanupResult.categoriesDeleted === 1 ? 'y' : 'ies'}`);
-      }
-      if (cleanupResult.prioritiesDeleted > 0) {
-        cleanedParts.push(`${cleanupResult.prioritiesDeleted} ITIL priorit${cleanupResult.prioritiesDeleted === 1 ? 'y' : 'ies'}`);
-      }
-      if (cleanupResult.categoriesSkippedReason) {
-        skippedParts.push(`categories (${cleanupResult.categoriesSkippedReason})`);
-      }
-      if (cleanupResult.prioritiesSkippedReason) {
-        skippedParts.push(`priorities (${cleanupResult.prioritiesSkippedReason})`);
-      }
-
-      if (cleanedParts.length > 0) {
-        itilCleanupMessage = ` Cleaned up: ${cleanedParts.join(', ')}.`;
-      }
-      if (skippedParts.length > 0) {
-        itilCleanupMessage += ` Could not clean up: ${skippedParts.join(', ')}.`;
-      }
-    }
 
     return {
       success: true,

--- a/packages/tickets/src/actions/optimizedTicketActions.ts
+++ b/packages/tickets/src/actions/optimizedTicketActions.ts
@@ -552,11 +552,33 @@ export const getConsolidatedTicketData = withAuth(async (user, { tenant }, ticke
       tenantScopedTable(trx, 'boards', tenant)
         .orderBy('board_name', 'asc'),
       
-      // Priorities - fetch only tenant-specific ticket priorities
-      tenantScopedTable(trx, 'priorities', tenant)
-        .where({ item_type: 'ticket' })
-        .orderBy('priority_name', 'asc'),
-      
+      // Priorities for the ticket's current board. Mirrors the categories fetch
+      // below: a board only offers the priority family its priority_type declares,
+      // so a custom board never lists leftover ITIL priorities.
+      (async () => {
+        const boardPriorities = () => tenantScopedTable(trx, 'priorities', tenant)
+          .where({ item_type: 'ticket' })
+          .orderBy('priority_name', 'asc');
+
+        if (!ticket.board_id) {
+          return boardPriorities();
+        }
+
+        const ticketBoard = await tenantScopedTable(trx, 'boards', tenant)
+          .where({ board_id: ticket.board_id })
+          .select('priority_type')
+          .first();
+
+        if (ticketBoard?.priority_type === 'itil') {
+          return boardPriorities().where('is_from_itil_standard', true);
+        }
+
+        return boardPriorities()
+          .where((builder: Knex.QueryBuilder) => {
+            builder.where('is_from_itil_standard', false).orWhereNull('is_from_itil_standard');
+          });
+      })(),
+
       // Categories for the ticket's current board. This must match
       // getTicketCategoriesByBoard so the hydrated dropdown doesn't briefly
       // show tenant-wide categories before the client-side board fetch returns.
@@ -780,10 +802,11 @@ export const getConsolidatedTicketData = withAuth(async (user, { tenant }, ticke
         label: board.board_name || ""
       }));
 
-    const priorityOptions = (priorities as Array<{ priority_id: string; priority_name: string; color?: string | null }>).map((priority) => ({
+    const priorityOptions = (priorities as Array<{ priority_id: string; priority_name: string; color?: string | null; is_from_itil_standard?: boolean | null }>).map((priority) => ({
       value: priority.priority_id,
       label: priority.priority_name,
-      color: priority.color
+      color: priority.color,
+      is_from_itil_standard: Boolean(priority.is_from_itil_standard)
     }));
 
     // Get scheduled hours for ticket

--- a/packages/tickets/src/components/QuickAddTicket.tsx
+++ b/packages/tickets/src/components/QuickAddTicket.tsx
@@ -1052,20 +1052,31 @@ export function QuickAddTicket({
   );
 
   const memoizedPriorityOptions = useMemo(
-    () =>
-      priorities.map((priority): SelectOption => ({
-        value: priority.priority_id,
-        label: (
-          <div className="flex items-center gap-2">
-            <div 
-              className="w-3 h-3 rounded-full border border-gray-300" 
-              style={{ backgroundColor: priority.color || '#6B7280' }}
-            />
-            <span>{priority.priority_name}</span>
-          </div>
-        )
-      })),
-    [priorities]
+    () => {
+      // A board only offers the priority family its priority_type declares
+      // (same rule as getBoardDefaultPriorityId and the category picker), so a
+      // custom board never lists leftover ITIL priorities.
+      const selectedBoard = boards.find(board => board.board_id === boardId);
+      const priorityType = selectedBoard?.priority_type ?? boardConfig.priority_type ?? 'custom';
+
+      return priorities
+        .filter(priority => priorityType === 'itil'
+          ? Boolean(priority.is_from_itil_standard)
+          : !priority.is_from_itil_standard)
+        .map((priority): SelectOption => ({
+          value: priority.priority_id,
+          label: (
+            <div className="flex items-center gap-2">
+              <div
+                className="w-3 h-3 rounded-full border border-gray-300"
+                style={{ backgroundColor: priority.color || '#6B7280' }}
+              />
+              <span>{priority.priority_name}</span>
+            </div>
+          )
+        }));
+    },
+    [priorities, boards, boardId, boardConfig.priority_type]
   );
 
   const footer = (

--- a/packages/tickets/src/components/__tests__/QuickAddTicket.boardScopedPriorities.test.tsx
+++ b/packages/tickets/src/components/__tests__/QuickAddTicket.boardScopedPriorities.test.tsx
@@ -1,0 +1,387 @@
+/* @vitest-environment jsdom */
+/// <reference types="@testing-library/jest-dom/vitest" />
+
+import React from 'react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+
+import { QuickAddTicket } from '../QuickAddTicket';
+
+const getTicketFormDataMock = vi.fn();
+const getTicketStatusesMock = vi.fn();
+
+vi.mock('next/server', () => ({
+  NextRequest: class NextRequest {},
+  NextResponse: {
+    next: vi.fn(),
+    json: vi.fn(),
+  },
+}));
+
+vi.mock('next-auth', () => ({
+  __esModule: true,
+  default: vi.fn(() => ({
+    handlers: {},
+    auth: vi.fn(),
+    signIn: vi.fn(),
+    signOut: vi.fn(),
+  })),
+}));
+
+vi.mock('next-auth/lib/env', () => ({
+  setEnvDefaults: vi.fn(),
+}));
+
+vi.mock('next/navigation', () => ({
+  useRouter: () => ({ push: vi.fn() }),
+}));
+
+vi.mock('next-auth/react', () => ({
+  useSession: () => ({ data: null, status: 'unauthenticated' }),
+}));
+
+vi.mock('../../actions/ticketActions', () => ({
+  addTicket: vi.fn(),
+  updateTicket: vi.fn(),
+}));
+
+vi.mock('../../actions/ticketResourceActions', () => ({
+  addTicketResource: vi.fn(),
+}));
+
+vi.mock('../../actions/ticketFormActions', () => ({
+  getTicketFormData: (...args: unknown[]) => getTicketFormDataMock(...args),
+}));
+
+vi.mock('../../actions/clientLookupActions', () => ({
+  getContactsByClient: vi.fn().mockResolvedValue([]),
+  getClientLocations: vi.fn().mockResolvedValue([]),
+}));
+
+vi.mock('@alga-psa/reference-data/actions', () => ({
+  getTicketStatuses: (...args: unknown[]) => getTicketStatusesMock(...args),
+}));
+
+vi.mock('@alga-psa/reference-data/actions/status-actions/statusActions', () => ({
+  getTicketStatuses: (...args: unknown[]) => getTicketStatusesMock(...args),
+}));
+
+vi.mock('@alga-psa/tickets/actions', () => ({
+  getTicketCategoriesByBoard: vi.fn().mockResolvedValue({
+    categories: [],
+    boardConfig: {
+      category_type: 'custom',
+      priority_type: 'custom',
+      display_itil_impact: false,
+      display_itil_urgency: false,
+    },
+  }),
+}));
+
+vi.mock('../../actions/ticketCategoryActions', () => ({
+  getTicketCategoriesByBoard: vi.fn().mockResolvedValue({
+    categories: [],
+    boardConfig: {
+      category_type: 'custom',
+      priority_type: 'custom',
+      display_itil_impact: false,
+      display_itil_urgency: false,
+    },
+  }),
+}));
+
+vi.mock('@alga-psa/user-composition/actions', () => ({
+  getCurrentUser: vi.fn().mockResolvedValue(null),
+  getUserAvatarUrlsBatchAction: vi.fn(),
+  searchUsersForMentions: vi.fn().mockResolvedValue([]),
+}));
+
+vi.mock('@alga-psa/user-composition/actions/userQueryActions', () => ({
+  getCurrentUser: vi.fn().mockResolvedValue(null),
+}));
+
+vi.mock('@alga-psa/user-composition/actions/avatarActions', () => ({
+  getUserAvatarUrlsBatchAction: vi.fn(),
+}));
+
+vi.mock('@alga-psa/user-composition/actions/searchUsersForMentions', () => ({
+  searchUsersForMentions: vi.fn().mockResolvedValue([]),
+}));
+
+vi.mock('@alga-psa/teams/actions', () => ({
+  getTeams: vi.fn().mockResolvedValue([]),
+  getTeamAvatarUrlsBatchAction: vi.fn(),
+}));
+
+vi.mock('@alga-psa/teams/actions/team-actions/teamActions', () => ({
+  getTeams: vi.fn().mockResolvedValue([]),
+}));
+
+vi.mock('@alga-psa/teams/actions/team-actions/avatarActions', () => ({
+  getTeamAvatarUrlsBatchAction: vi.fn(),
+}));
+
+vi.mock('@alga-psa/teams/actions/team-actions/teamActionErrors', () => ({
+  isTeamActionError: () => false,
+}));
+
+vi.mock('../../actions/teamAssignmentActions', () => ({
+  assignTeamToTicket: vi.fn(),
+}));
+
+vi.mock('@alga-psa/ui/hooks', () => ({
+  useFeatureFlag: () => ({ enabled: false }),
+}));
+
+vi.mock('@alga-psa/ui/lib/i18n/client', () => ({
+  useTranslation: () => ({
+    t: (
+      _key: string,
+      fallbackOrOptions?: string | Record<string, unknown>,
+      maybeOptions?: Record<string, unknown>,
+    ) => {
+      // i18next's `t` accepts either `t(key, fallbackString, options)` or
+      // `t(key, optionsObject)` where the options object carries `defaultValue`.
+      const fallback =
+        typeof fallbackOrOptions === 'string'
+          ? fallbackOrOptions
+          : (fallbackOrOptions?.defaultValue as string | undefined);
+      const options =
+        typeof fallbackOrOptions === 'string' ? maybeOptions : fallbackOrOptions;
+
+      if (!fallback) {
+        return _key;
+      }
+
+      return fallback.replace(/\{\{(\w+)\}\}/g, (_match, name) => String(options?.[name] ?? ''));
+    },
+  }),
+}));
+
+vi.mock('@alga-psa/ui/context', () => ({
+  useQuickAddClient: () => ({
+    renderQuickAddClient: () => null,
+    renderQuickAddContact: () => null,
+  }),
+}));
+
+vi.mock('@alga-psa/ui/components/Dialog', () => ({
+  Dialog: ({ isOpen, children }: { isOpen: boolean; children: React.ReactNode }) => (isOpen ? <div>{children}</div> : null),
+  DialogContent: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+  DialogHeader: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+  DialogTitle: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+  DialogFooter: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+}));
+
+vi.mock('@alga-psa/ui/components/Button', () => ({
+  Button: ({ children, ...props }: React.ButtonHTMLAttributes<HTMLButtonElement>) => <button {...props}>{children}</button>,
+}));
+
+vi.mock('@alga-psa/ui/components/Input', () => ({
+  Input: (props: React.InputHTMLAttributes<HTMLInputElement>) => <input {...props} />,
+}));
+
+vi.mock('@alga-psa/ui/components/ClientPicker', () => ({
+  ClientPicker: () => <div data-testid="client-picker" />,
+}));
+
+vi.mock('@alga-psa/ui/components/ContactPicker', () => ({
+  ContactPicker: () => <div data-testid="contact-picker" />,
+}));
+
+vi.mock('../CategoryPicker', () => ({
+  CategoryPicker: () => <div data-testid="category-picker" />,
+}));
+
+vi.mock('../QuickAddCategory', () => ({
+  __esModule: true,
+  default: () => null,
+}));
+
+vi.mock('@alga-psa/ui/components/settings/general/BoardPicker', () => ({
+  __esModule: true,
+  BoardPicker: ({
+    boards,
+    onSelect,
+    selectedBoardId,
+  }: {
+    boards: Array<{ board_id?: string | null; board_name?: string | null }>;
+    onSelect: (boardId: string) => void;
+    selectedBoardId: string | null;
+  }) => (
+    <div>
+      <div data-testid="board-picker-selected">{selectedBoardId || ''}</div>
+      {boards.map((board) => (
+        <button key={board.board_id} type="button" onClick={() => onSelect(board.board_id || '')}>
+          Select {board.board_name}
+        </button>
+      ))}
+    </div>
+  ),
+}));
+
+vi.mock('@alga-psa/ui/components/CustomSelect', () => ({
+  __esModule: true,
+  default: ({
+    id,
+    value,
+    options,
+    onValueChange,
+    disabled,
+  }: {
+    id?: string;
+    value?: string;
+    options: Array<{ value: string; label: string }>;
+    onValueChange: (value: string) => void;
+    disabled?: boolean;
+  }) => (
+    <select
+      data-testid={id || 'custom-select'}
+      value={value || ''}
+      disabled={disabled}
+      onChange={(event) => onValueChange(event.target.value)}
+    >
+      <option value="" />
+      {options.map((option) => (
+      <option key={option.value} value={option.value}>
+          {typeof option.label === 'string' ? option.label : option.value}
+      </option>
+      ))}
+    </select>
+  ),
+}));
+
+vi.mock('@alga-psa/ui/components/UserPicker', () => ({
+  __esModule: true,
+  default: () => <div data-testid="user-picker" />,
+}));
+
+vi.mock('@alga-psa/ui/components/UserAndTeamPicker', () => ({
+  __esModule: true,
+  default: () => <div data-testid="user-team-picker" />,
+}));
+
+vi.mock('@alga-psa/ui/editor', () => ({
+  TextEditor: () => <div data-testid="text-editor" />,
+}));
+
+vi.mock('@alga-psa/ui/components/Alert', () => ({
+  Alert: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+  AlertDescription: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+}));
+
+vi.mock('@alga-psa/ui/components/ConfirmationDialog', () => ({
+  ConfirmationDialog: () => null,
+}));
+
+vi.mock('@alga-psa/ui/components/DatePicker', () => ({
+  DatePicker: () => <div data-testid="date-picker" />,
+}));
+
+vi.mock('@alga-psa/ui/components/TimePicker', () => ({
+  TimePicker: () => <div data-testid="time-picker" />,
+}));
+
+vi.mock('@alga-psa/ui/components/Spinner', () => ({
+  __esModule: true,
+  default: () => <div data-testid="spinner" />,
+}));
+
+vi.mock('@alga-psa/tags/components', () => ({
+  QuickAddTagPicker: () => <div data-testid="tag-picker" />,
+}));
+
+vi.mock('@alga-psa/tags/components/QuickAddTagPicker', () => ({
+  QuickAddTagPicker: () => <div data-testid="tag-picker" />,
+}));
+
+vi.mock('@alga-psa/tags/actions/tagActions', () => ({
+  createTagsForEntity: vi.fn(),
+}));
+
+vi.mock('@alga-psa/ui/ui-reflection/useAutomationIdAndRegister', () => ({
+  useAutomationIdAndRegister: () => ({ automationIdProps: {}, updateMetadata: vi.fn() }),
+}));
+
+vi.mock('@alga-psa/ui/ui-reflection/useRegisterUIComponent', () => ({
+  useRegisterUIComponent: () => vi.fn(),
+}));
+
+vi.mock('@alga-psa/ui/ui-reflection/ReflectionContainer', () => ({
+  ReflectionContainer: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+}));
+
+vi.mock('@alga-psa/ui/ui-reflection/withDataAutomationId', () => ({
+  withDataAutomationId: () => ({}),
+}));
+
+vi.mock('../useQuickAddRichTextUploadSession', () => ({
+  useQuickAddRichTextUploadSession: () => ({
+    uploadFile: vi.fn(),
+    requestDiscard: vi.fn(),
+    resetDraftTracking: vi.fn(),
+    showDraftCancelDialog: false,
+    setShowDraftCancelDialog: vi.fn(),
+    deleteTrackedDraftClipboardImages: vi.fn(),
+    keepDraftClipboardImages: vi.fn(),
+  }),
+}));
+
+vi.mock('../../lib/ticketRichText', () => ({
+  parseTicketRichTextContent: vi.fn().mockReturnValue([]),
+  serializeTicketRichTextContent: vi.fn().mockReturnValue(''),
+}));
+
+vi.mock('../../lib/ticketRichTextImages', () => ({
+  removeTicketRichTextImageUrls: vi.fn().mockImplementation((value) => value),
+  replaceTicketRichTextImageUrls: vi.fn().mockImplementation((value) => value),
+}));
+
+
+describe('QuickAddTicket board-scoped priorities', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    getTicketFormDataMock.mockResolvedValue({
+      users: [],
+      boards: [
+        { board_id: 'board-custom', board_name: 'Custom Board', priority_type: 'custom', category_type: 'custom' },
+      ],
+      statuses: [],
+      priorities: [
+        { priority_id: 'priority-custom', priority_name: 'High', item_type: 'ticket', is_from_itil_standard: false },
+        { priority_id: 'priority-itil', priority_name: 'P1 - Critical', item_type: 'ticket', is_from_itil_standard: true, itil_priority_level: 1 },
+      ],
+      clients: [],
+    });
+    getTicketStatusesMock.mockResolvedValue([
+      { status_id: 'status-default', name: 'New', is_default: true, is_closed: false },
+    ]);
+  });
+
+  it('offers only custom priorities once a custom board is selected', async () => {
+    render(
+      <QuickAddTicket
+        open={true}
+        onOpenChange={vi.fn()}
+        onTicketAdded={vi.fn()}
+      />
+    );
+
+    await waitFor(() => {
+      expect(getTicketFormDataMock).toHaveBeenCalled();
+    });
+
+    fireEvent.click(screen.getByText('Select Custom Board'));
+
+    const prioritySelect = await screen.findByTestId('ticket-quick-add-priority');
+    const optionValues = Array.from(prioritySelect.querySelectorAll('option'))
+      .map((option) => option.getAttribute('value'))
+      .filter((value) => value);
+
+    expect(optionValues).toEqual(['priority-custom']);
+    expect(optionValues).not.toContain('priority-itil');
+    await waitFor(() => {
+      expect(prioritySelect).toHaveValue('priority-custom');
+    });
+  });
+});

--- a/packages/tickets/src/components/ticket/TicketDetails.tsx
+++ b/packages/tickets/src/components/ticket/TicketDetails.tsx
@@ -168,7 +168,7 @@ interface TicketDetailsProps {
     statusOptions?: { value: string; label: string; is_closed?: boolean; className?: string; board_id?: string | null }[];
     agentOptions?: { value: string; label: string }[];
     boardOptions?: { value: string; label: string }[];
-    priorityOptions?: { value: string; label: string }[];
+    priorityOptions?: { value: string; label: string; color?: string | null; is_from_itil_standard?: boolean }[];
     initialCategories?: ITicketCategory[];
     initialClients?: IClient[];
     initialLocations?: IClientLocation[];

--- a/packages/tickets/src/components/ticket/TicketInfo.tsx
+++ b/packages/tickets/src/components/ticket/TicketInfo.tsx
@@ -69,7 +69,7 @@ interface TicketInfoProps {
   statusOptions: { value: string; label: string }[];
   agentOptions: { value: string; label: string }[];
   boardOptions: { value: string; label: string }[];
-  priorityOptions: { value: string; label: string }[];
+  priorityOptions: { value: string; label: string; is_from_itil_standard?: boolean }[];
   onSelectChange: (field: keyof ITicket, newValue: string | null) => void;
   onSaveChanges?: (
     changes: Record<string, unknown>,
@@ -275,6 +275,18 @@ const TicketInfo: React.FC<TicketInfoProps> = ({
 
   // Get the effective categories (pending or current)
   const effectiveCategories = pendingCategories ?? categories;
+
+  // A board only offers the priority family its priority_type declares. The
+  // ticket's own priority stays listed so a legacy value still renders.
+  const scopedPriorityOptions = useMemo(() => {
+    const wantsItil = effectiveBoardConfig.priority_type === 'itil';
+    const currentPriorityId = pendingChanges.priority_id ?? originalTicketValues.priority_id ?? null;
+
+    return priorityOptions.filter((option) =>
+      (wantsItil ? Boolean(option.is_from_itil_standard) : !option.is_from_itil_standard)
+      || option.value === currentPriorityId
+    );
+  }, [priorityOptions, effectiveBoardConfig.priority_type, pendingChanges.priority_id, originalTicketValues.priority_id]);
 
   // Calculate ITIL priority when impact and urgency are available
   // Use pending ITIL values if available, otherwise use prop values
@@ -1744,7 +1756,7 @@ const TicketInfo: React.FC<TicketInfoProps> = ({
                   <div className={`transition-opacity ${isFieldRemotelyEdited('priority_id') ? 'opacity-60' : ''}`}>
                     <PrioritySelect
                       value={pendingChanges.priority_id ?? originalTicketValues.priority_id ?? null}
-                      options={priorityOptions}
+                      options={scopedPriorityOptions}
                       onValueChange={(value) => handlePendingChange('priority_id', value)}
                       customStyles={customStyles}
                       className="!w-fit"

--- a/packages/tickets/src/components/ticket/bento/BentoHero.tsx
+++ b/packages/tickets/src/components/ticket/bento/BentoHero.tsx
@@ -42,6 +42,7 @@ interface HeroSelectOption {
   is_closed?: boolean;
   board_id?: string | null;
   color?: string | null;
+  is_from_itil_standard?: boolean;
 }
 
 type HeroPendingChanges = Record<string, string | null>;
@@ -521,11 +522,20 @@ export function BentoHero({
     [boardCategories],
   );
 
-  // Priority options may carry the priority color; render it as a dot.
+  // Priority options may carry the priority color; render it as a dot. A board
+  // only offers the priority family its priority_type declares, so a custom board
+  // hides leftover ITIL priorities — except the one this ticket already carries.
+  const effectiveBoardConfig = pendingBoardConfig ?? savedBoardConfig;
+  const displayedPriorityId = displayValue('priority_id');
   const priorityJsxOptions = useMemo<SelectOption[]>(
     () =>
       priorityOptions
         .filter((option) => option.value !== 'all')
+        .filter((option) => (
+          effectiveBoardConfig?.priority_type === 'itil'
+            ? Boolean(option.is_from_itil_standard)
+            : !option.is_from_itil_standard
+        ) || option.value === displayedPriorityId)
         .map((option) => ({
           value: option.value,
           textValue: option.label,
@@ -539,7 +549,7 @@ export function BentoHero({
             </span>
           ),
         })),
-    [priorityOptions],
+    [priorityOptions, effectiveBoardConfig?.priority_type, displayedPriorityId],
   );
 
   // The team currently assigned to the ticket, resolved from the teams pool so

--- a/packages/tickets/src/services/itilStandardsService.ts
+++ b/packages/tickets/src/services/itilStandardsService.ts
@@ -10,6 +10,9 @@ export function registerItilSlaConfiguration(fn: (trx: Knex.Transaction, tenant:
   _configureItilSlaForBoardFn = fn;
 }
 
+// Name of the SLA policy auto-created by configureItilSlaForBoard (@alga-psa/sla).
+const ITIL_SLA_POLICY_NAME = 'ITIL Standard';
+
 /**
  * Service to manage copying ITIL standards to tenant-specific tables
  */
@@ -222,10 +225,12 @@ export class ItilStandardsService {
 
   /**
    * Remove ITIL standards from tenant if no boards use them
-   * This is called when switching from ITIL to custom
+   * This is called when switching from ITIL to custom, and when the last ITIL
+   * board is deleted — in that case the board row still exists (the delete runs
+   * after this cleanup), so it is passed in `excludeBoardIds` and ignored.
    * Returns information about what was cleaned up
    */
-  static async cleanupUnusedItilStandards(trx: Knex.Transaction, tenant: string): Promise<{
+  static async cleanupUnusedItilStandards(trx: Knex.Transaction, tenant: string, excludeBoardIds: string[] = []): Promise<{
     prioritiesDeleted: number;
     categoriesDeleted: number;
     prioritiesSkippedReason?: string;
@@ -249,10 +254,13 @@ export class ItilStandardsService {
     console.log(`[ItilStandardsService.cleanup] Found ${itilPrioritiesCount} ITIL priorities for tenant ${tenant}`);
 
     // Check if any boards still use ITIL priorities
-    const itilPriorityBoards = await db.table('boards')
+    const itilPriorityBoardsQuery = db.table('boards')
       .where('priority_type', 'itil')
-      .count('* as count')
-      .first();
+      .count('* as count');
+    if (excludeBoardIds.length > 0) {
+      itilPriorityBoardsQuery.whereNotIn('board_id', excludeBoardIds);
+    }
+    const itilPriorityBoards = await itilPriorityBoardsQuery.first();
 
     const itilPriorityBoardCount = Number(itilPriorityBoards?.count || 0);
     console.log(`[ItilStandardsService.cleanup] Boards with priority_type='itil': ${itilPriorityBoardCount}`);
@@ -260,25 +268,31 @@ export class ItilStandardsService {
     if (itilPriorityBoardCount === 0) {
       // No boards use ITIL priorities - delete unused ones individually
       // Get ITIL priorities that ARE used by tickets
-      const itilPriorityIds = db.table('priorities')
-        .select('priority_id')
-        .where('is_from_itil_standard', true);
-      const usedPriorityIds = await db.table('tickets')
-        .whereIn('priority_id', itilPriorityIds)
-        .distinct('priority_id')
+      const itilPriorityIds: string[] = await db.table('priorities')
+        .where('is_from_itil_standard', true)
         .pluck('priority_id');
+      const usedPriorityIds: string[] = itilPriorityIds.length > 0
+        ? await db.table('tickets')
+          .whereIn('priority_id', itilPriorityIds)
+          .distinct('priority_id')
+          .pluck('priority_id')
+        : [];
 
       console.log(`[ItilStandardsService.cleanup] ITIL priorities in use by tickets: ${usedPriorityIds.length} (${usedPriorityIds.join(', ')})`);
 
-      // Delete ITIL priorities that are NOT in use
-      const deleteQuery = db.table('priorities')
-        .where('is_from_itil_standard', true);
+      // Delete ITIL priorities that are NOT in use, after releasing the rows
+      // that reference them (SLA targets and board defaults have hard FKs).
+      const usedPriorityIdSet = new Set(usedPriorityIds);
+      const deletablePriorityIds = itilPriorityIds.filter(id => !usedPriorityIdSet.has(id));
 
-      if (usedPriorityIds.length > 0) {
-        deleteQuery.whereNotIn('priority_id', usedPriorityIds);
+      let deleted = 0;
+      if (deletablePriorityIds.length > 0) {
+        await this.releaseItilPriorityReferences(trx, tenant, deletablePriorityIds);
+
+        deleted = await db.table('priorities')
+          .whereIn('priority_id', deletablePriorityIds)
+          .del();
       }
-
-      const deleted = await deleteQuery.del();
       result.prioritiesDeleted = deleted;
 
       if (usedPriorityIds.length > 0) {
@@ -301,10 +315,13 @@ export class ItilStandardsService {
     console.log(`[ItilStandardsService.cleanup] Found ${itilCategoriesCount} ITIL categories for tenant ${tenant}`);
 
     // Check if any boards still use ITIL categories
-    const itilCategoryBoards = await db.table('boards')
+    const itilCategoryBoardsQuery = db.table('boards')
       .where('category_type', 'itil')
-      .count('* as count')
-      .first();
+      .count('* as count');
+    if (excludeBoardIds.length > 0) {
+      itilCategoryBoardsQuery.whereNotIn('board_id', excludeBoardIds);
+    }
+    const itilCategoryBoards = await itilCategoryBoardsQuery.first();
 
     const itilCategoryBoardCount = Number(itilCategoryBoards?.count || 0);
     console.log(`[ItilStandardsService.cleanup] Boards with category_type='itil': ${itilCategoryBoardCount}`);
@@ -362,18 +379,22 @@ export class ItilStandardsService {
         deletedCount += await childDeleteQuery.del();
       }
 
-      // Then delete unused parents
-      if (parentIds.length > 0) {
-        const parentDeleteQuery = db.table('categories')
-          .where('is_from_itil_standard', true)
-          .whereNull('parent_category')
-          .whereIn('category_id', parentIds);
+      // Then delete unused parents, skipping any parent a surviving child still
+      // points at (categories_tenant_parent_category_foreign)
+      const parentDeleteCandidates = parentIds.filter(id => !usedIds.has(id));
+      if (parentDeleteCandidates.length > 0) {
+        const stillReferencedParentIds: string[] = await db.table('categories')
+          .whereIn('parent_category', parentDeleteCandidates)
+          .distinct('parent_category')
+          .pluck('parent_category');
+        const stillReferencedParentIdSet = new Set(stillReferencedParentIds);
+        const deletableParentIds = parentDeleteCandidates.filter(id => !stillReferencedParentIdSet.has(id));
 
-        if (usedCategoryIdArray.length > 0) {
-          parentDeleteQuery.whereNotIn('category_id', usedCategoryIdArray);
+        if (deletableParentIds.length > 0) {
+          deletedCount += await db.table('categories')
+            .whereIn('category_id', deletableParentIds)
+            .del();
         }
-
-        deletedCount += await parentDeleteQuery.del();
       }
 
       result.categoriesDeleted = deletedCount;
@@ -389,5 +410,69 @@ export class ItilStandardsService {
     }
 
     return result;
+  }
+
+  /**
+   * Drop the rows that point at ITIL priorities about to be deleted.
+   * Without this the DELETE trips sla_policy_targets / boards FKs and rolls the
+   * whole cleanup (and the board deletion around it) back.
+   */
+  private static async releaseItilPriorityReferences(
+    trx: Knex.Transaction,
+    tenant: string,
+    priorityIds: string[]
+  ): Promise<void> {
+    const db = tenantDb(trx, tenant);
+
+    const affectedPolicyIds: string[] = await db.table('sla_policy_targets')
+      .whereIn('priority_id', priorityIds)
+      .distinct('sla_policy_id')
+      .pluck('sla_policy_id');
+
+    const targetsDeleted = await db.table('sla_policy_targets')
+      .whereIn('priority_id', priorityIds)
+      .del();
+    console.log(`[ItilStandardsService.cleanup] Deleted ${targetsDeleted} SLA targets for retiring ITIL priorities`);
+
+    // The auto-created "ITIL Standard" policy is meaningless once it has no
+    // targets left; retire it so the tenant isn't left with an empty policy.
+    for (const policyId of affectedPolicyIds) {
+      const policy = await db.table('sla_policies')
+        .where({ sla_policy_id: policyId, policy_name: ITIL_SLA_POLICY_NAME })
+        .first();
+      if (!policy) continue;
+
+      const remainingTargets = await db.table('sla_policy_targets')
+        .where({ sla_policy_id: policyId })
+        .count('* as count')
+        .first();
+      if (Number(remainingTargets?.count || 0) > 0) continue;
+
+      await db.table('boards')
+        .where({ sla_policy_id: policyId })
+        .update({ sla_policy_id: null });
+
+      const clientRefs = await db.table('clients')
+        .where({ sla_policy_id: policyId })
+        .count('* as count')
+        .first();
+      if (Number(clientRefs?.count || 0) > 0) {
+        console.log(`[ItilStandardsService.cleanup] Kept empty ITIL Standard SLA policy ${policyId}: still assigned to client(s)`);
+        continue;
+      }
+
+      await db.table('sla_notification_thresholds').where({ sla_policy_id: policyId }).del();
+      await db.table('sla_policies').where({ sla_policy_id: policyId }).del();
+      console.log(`[ItilStandardsService.cleanup] Removed empty ITIL Standard SLA policy ${policyId}`);
+    }
+
+    await db.table('boards')
+      .whereIn('default_priority_id', priorityIds)
+      .update({ default_priority_id: null });
+
+    // No FK here, but a dangling id silently breaks email-created tickets.
+    await db.table('inbound_ticket_defaults')
+      .whereIn('priority_id', priorityIds)
+      .update({ priority_id: null });
   }
 }

--- a/packages/tickets/src/services/itilStandardsService.ts
+++ b/packages/tickets/src/services/itilStandardsService.ts
@@ -448,10 +448,6 @@ export class ItilStandardsService {
         .first();
       if (Number(remainingTargets?.count || 0) > 0) continue;
 
-      await db.table('boards')
-        .where({ sla_policy_id: policyId })
-        .update({ sla_policy_id: null });
-
       const clientRefs = await db.table('clients')
         .where({ sla_policy_id: policyId })
         .count('* as count')
@@ -460,6 +456,16 @@ export class ItilStandardsService {
         console.log(`[ItilStandardsService.cleanup] Kept empty ITIL Standard SLA policy ${policyId}: still assigned to client(s)`);
         continue;
       }
+
+      await db.table('boards')
+        .where({ sla_policy_id: policyId })
+        .update({ sla_policy_id: null });
+
+      // Tickets keep the policy stamped on them at SLA start even after moving
+      // off the board or changing priority (tickets_sla_policy_fkey).
+      await db.table('tickets')
+        .where({ sla_policy_id: policyId })
+        .update({ sla_policy_id: null });
 
       await db.table('sla_notification_thresholds').where({ sla_policy_id: policyId }).del();
       await db.table('sla_policies').where({ sla_policy_id: policyId }).del();

--- a/server/migrations/20260805090000_add_categories_board_foreign_key.cjs
+++ b/server/migrations/20260805090000_add_categories_board_foreign_key.cjs
@@ -1,0 +1,52 @@
+/**
+ * Adds the categories -> boards foreign key that production already carries as
+ * `categories_board_fkey`. The channels->boards rename deferred the FK to an EE
+ * Citus migration that never runs, so CE drifted: deleting a board silently
+ * orphaned its categories instead of failing like prod does.
+ *
+ * @param { import("knex").Knex } knex
+ * @returns { Promise<void> }
+ */
+exports.up = async function(knex) {
+  // Detach categories pointing at boards that no longer exist, otherwise the
+  // constraint cannot be validated on drifted CE databases.
+  await knex.raw(`
+    UPDATE categories c
+    SET board_id = NULL
+    WHERE c.board_id IS NOT NULL
+      AND NOT EXISTS (
+        SELECT 1
+        FROM boards b
+        WHERE b.tenant = c.tenant
+          AND b.board_id = c.board_id
+      )
+  `);
+
+  await knex.raw(`
+    DO $$
+    BEGIN
+      IF NOT EXISTS (
+        SELECT 1
+        FROM pg_constraint
+        WHERE conname = 'categories_board_fkey'
+      ) THEN
+        ALTER TABLE categories
+        ADD CONSTRAINT categories_board_fkey
+        FOREIGN KEY (tenant, board_id)
+        REFERENCES boards (tenant, board_id);
+      END IF;
+    END
+    $$;
+  `);
+};
+
+/**
+ * @param { import("knex").Knex } knex
+ * @returns { Promise<void> }
+ */
+exports.down = async function(knex) {
+  await knex.raw('ALTER TABLE categories DROP CONSTRAINT IF EXISTS categories_board_fkey');
+};
+
+// Citus requires ALTER TABLE with foreign key constraints to run outside a transaction block
+exports.config = { transaction: false };

--- a/server/public/locales/de/msp/settings.json
+++ b/server/public/locales/de/msp/settings.json
@@ -809,6 +809,7 @@
         "header": "Prioritätsverwaltung:",
         "description": "Erstellen Sie benutzerdefinierte Prioritäten für Ihre Organisation oder importieren Sie aus Standardvorlagen.",
         "itilNote": "ITIL-Standardprioritäten können nicht bearbeitet oder gelöscht werden.",
+        "itilRemovableNote": "ITIL-Standardprioritäten können nicht bearbeitet werden, aber sie können gelöscht werden, sobald kein Board mehr ITIL-Prioritäten verwendet.",
         "nonItilNote": "Alle Prioritäten können bearbeitet oder gelöscht werden, um Ihrem Workflow zu entsprechen."
       },
       "table": {

--- a/server/public/locales/en/msp/settings.json
+++ b/server/public/locales/en/msp/settings.json
@@ -809,6 +809,7 @@
         "header": "Priority Management:",
         "description": "Create custom priorities for your organization or import from standard templates.",
         "itilNote": "ITIL standard priorities cannot be edited or deleted.",
+        "itilRemovableNote": "ITIL standard priorities cannot be edited, but can be deleted now that no board uses ITIL priorities.",
         "nonItilNote": "All priorities can be edited or deleted to fit your workflow."
       },
       "table": {

--- a/server/public/locales/es/msp/settings.json
+++ b/server/public/locales/es/msp/settings.json
@@ -809,6 +809,7 @@
         "header": "Gestión de prioridades:",
         "description": "Cree prioridades personalizadas para su organización o importe desde plantillas estándar.",
         "itilNote": "Las prioridades estándar ITIL no se pueden editar ni eliminar.",
+        "itilRemovableNote": "Las prioridades estándar ITIL no se pueden editar, pero se pueden eliminar ahora que ningún tablero usa prioridades ITIL.",
         "nonItilNote": "Todas las prioridades se pueden editar o eliminar para adaptarse a su flujo de trabajo."
       },
       "table": {

--- a/server/public/locales/fr/msp/settings.json
+++ b/server/public/locales/fr/msp/settings.json
@@ -809,6 +809,7 @@
         "header": "Gestion des priorités :",
         "description": "Créez des priorités personnalisées pour votre organisation ou importez depuis des modèles standard.",
         "itilNote": "Les priorités standard ITIL ne peuvent pas être modifiées ou supprimées.",
+        "itilRemovableNote": "Les priorités standard ITIL ne peuvent pas être modifiées, mais elles peuvent être supprimées dès qu’aucun tableau n’utilise les priorités ITIL.",
         "nonItilNote": "Toutes les priorités peuvent être modifiées ou supprimées selon votre flux de travail."
       },
       "table": {

--- a/server/public/locales/it/msp/settings.json
+++ b/server/public/locales/it/msp/settings.json
@@ -809,6 +809,7 @@
         "header": "Gestione delle priorità:",
         "description": "Crea priorità personalizzate per la tua organizzazione o importa da modelli standard.",
         "itilNote": "Le priorità standard ITIL non possono essere modificate o eliminate.",
+        "itilRemovableNote": "Le priorità standard ITIL non possono essere modificate, ma possono essere eliminate ora che nessuna bacheca usa le priorità ITIL.",
         "nonItilNote": "Tutte le priorità possono essere modificate o eliminate per adattarsi al tuo flusso di lavoro."
       },
       "table": {

--- a/server/public/locales/nl/msp/settings.json
+++ b/server/public/locales/nl/msp/settings.json
@@ -809,6 +809,7 @@
         "header": "Prioriteitsbeheer:",
         "description": "Maak aangepaste prioriteiten voor uw organisatie of importeer vanuit standaardsjablonen.",
         "itilNote": "ITIL-standaardprioriteiten kunnen niet worden bewerkt of verwijderd.",
+        "itilRemovableNote": "ITIL-standaardprioriteiten kunnen niet worden bewerkt, maar ze kunnen worden verwijderd nu geen enkel bord ITIL-prioriteiten gebruikt.",
         "nonItilNote": "Alle prioriteiten kunnen worden bewerkt of verwijderd om aan uw werkstroom te voldoen."
       },
       "table": {

--- a/server/public/locales/pl/msp/settings.json
+++ b/server/public/locales/pl/msp/settings.json
@@ -813,6 +813,7 @@
         "header": "Zarządzanie priorytetami:",
         "description": "Utwórz niestandardowe priorytety dla swojej organizacji lub zaimportuj ze standardowych szablonów.",
         "itilNote": "Standardowych priorytetów ITIL nie można edytować ani usuwać.",
+        "itilRemovableNote": "Standardowych priorytetów ITIL nie można edytować, ale można je usunąć, gdy żadna tablica nie używa priorytetów ITIL.",
         "nonItilNote": "Wszystkie priorytety można edytować lub usuwać, aby dopasować je do przepływu pracy."
       },
       "table": {

--- a/server/public/locales/pt/msp/settings.json
+++ b/server/public/locales/pt/msp/settings.json
@@ -809,6 +809,7 @@
         "header": "Gestão de prioridades:",
         "description": "Crie prioridades personalizadas para sua organização ou importe de modelos padrão.",
         "itilNote": "As prioridades padrão ITIL não podem ser editadas ou excluídas.",
+        "itilRemovableNote": "As prioridades padrão ITIL não podem ser editadas, mas podem ser excluídas agora que nenhum quadro usa prioridades ITIL.",
         "nonItilNote": "Todas as prioridades podem ser editadas ou excluídas para se adequarem ao seu fluxo de trabalho."
       },
       "table": {

--- a/server/public/locales/xx/msp/settings.json
+++ b/server/public/locales/xx/msp/settings.json
@@ -809,6 +809,7 @@
         "header": "11111",
         "description": "11111",
         "itilNote": "11111",
+        "itilRemovableNote": "11111",
         "nonItilNote": "11111"
       },
       "table": {

--- a/server/public/locales/yy/msp/settings.json
+++ b/server/public/locales/yy/msp/settings.json
@@ -809,6 +809,7 @@
         "header": "55555",
         "description": "55555",
         "itilNote": "55555",
+        "itilRemovableNote": "55555",
         "nonItilNote": "55555"
       },
       "table": {

--- a/server/src/test/integration/itilBoardDeletionCleanup.integration.test.ts
+++ b/server/src/test/integration/itilBoardDeletionCleanup.integration.test.ts
@@ -1,0 +1,369 @@
+import { afterAll, afterEach, beforeAll, describe, expect, it, vi } from 'vitest';
+import type { Knex } from 'knex';
+import { v4 as uuidv4 } from 'uuid';
+
+import { tenantDb } from '@alga-psa/db';
+import { createTestDbConnection } from '../../../test-utils/dbConfig';
+
+const dbRef = vi.hoisted(() => ({
+  knex: null as Knex | null,
+  tenant: '',
+}));
+
+const userRef = vi.hoisted(() => ({
+  user: null as any,
+}));
+
+vi.mock('@alga-psa/db', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('@alga-psa/db')>()),
+  createTenantKnex: vi.fn(async () => ({ knex: dbRef.knex, tenant: dbRef.tenant })),
+}));
+
+vi.mock('@alga-psa/auth', () => ({
+  withAuth: (action: any) => (...args: any[]) =>
+    action(userRef.user, { tenant: dbRef.tenant }, ...args),
+  hasPermission: vi.fn(async () => true),
+}));
+
+vi.mock('@alga-psa/event-bus/publishers', () => ({
+  publishEvent: vi.fn(),
+  publishWorkflowEvent: vi.fn(),
+}));
+
+import { deleteBoard } from '../../../../packages/tickets/src/actions/board-actions/boardActions';
+
+const HOOK_TIMEOUT = 180_000;
+
+let db: Knex;
+const tenantsToCleanup = new Set<string>();
+
+function tenantTable(tenantId: string, table: string) {
+  return tenantDb(db, tenantId).table(table);
+}
+
+function tenantRows() {
+  return tenantDb(db, '__test_tenant_fixture__')
+    .unscoped('tenants', 'test fixture creates and removes tenant rows');
+}
+
+async function cleanupTenant(tenantId: string): Promise<void> {
+  await tenantTable(tenantId, 'tickets').del();
+  await tenantTable(tenantId, 'clients').del();
+  await tenantTable(tenantId, 'categories').whereNotNull('parent_category').del();
+  await tenantTable(tenantId, 'categories').del();
+  await tenantTable(tenantId, 'sla_policy_targets').del();
+  await tenantTable(tenantId, 'sla_notification_thresholds').del();
+  await tenantTable(tenantId, 'boards').update({ default_priority_id: null, sla_policy_id: null });
+  await tenantTable(tenantId, 'sla_policies').del();
+  await tenantTable(tenantId, 'priorities').del();
+  await tenantTable(tenantId, 'statuses').del();
+  await tenantTable(tenantId, 'boards').del();
+  await tenantTable(tenantId, 'users').del();
+  await tenantRows().where({ tenant: tenantId }).del();
+}
+
+interface BoardSpec {
+  boardId: string;
+  name: string;
+  isDefault?: boolean;
+  categoryType?: 'custom' | 'itil';
+  priorityType?: 'custom' | 'itil';
+}
+
+async function createTenantFixture(boards: BoardSpec[]) {
+  const tenantId = uuidv4();
+  const userId = uuidv4();
+
+  tenantsToCleanup.add(tenantId);
+
+  await tenantRows().insert({
+    tenant: tenantId,
+    client_name: `Tenant ${tenantId.slice(0, 8)}`,
+    email: `tenant-${tenantId.slice(0, 8)}@example.com`,
+  });
+
+  await tenantTable(tenantId, 'users').insert({
+    tenant: tenantId,
+    user_id: userId,
+    username: `user-${tenantId.slice(0, 8)}`,
+    hashed_password: 'not-used',
+    email: `user-${tenantId.slice(0, 8)}@example.com`,
+  });
+
+  await tenantTable(tenantId, 'boards').insert(boards.map((board, index) => ({
+    tenant: tenantId,
+    board_id: board.boardId,
+    board_name: board.name,
+    display_order: (index + 1) * 10,
+    is_default: board.isDefault ?? false,
+    is_inactive: false,
+    category_type: board.categoryType ?? 'custom',
+    priority_type: board.priorityType ?? 'custom',
+  })));
+
+  dbRef.knex = db;
+  dbRef.tenant = tenantId;
+  userRef.user = { user_id: userId, user_type: 'internal', tenant: tenantId };
+
+  return { tenantId, userId };
+}
+
+async function createItilPriorities(tenantId: string, userId: string, levels: number[]) {
+  const priorityIds = levels.map(() => uuidv4());
+
+  await tenantTable(tenantId, 'priorities').insert(levels.map((level, index) => ({
+    tenant: tenantId,
+    priority_id: priorityIds[index],
+    priority_name: `P${level} - ITIL`,
+    color: '#DC2626',
+    order_number: level * 10,
+    item_type: 'ticket',
+    is_from_itil_standard: true,
+    itil_priority_level: level,
+    created_by: userId,
+  })));
+
+  return priorityIds;
+}
+
+async function createItilSlaPolicy(tenantId: string, priorityIds: string[]) {
+  const policyId = uuidv4();
+
+  await tenantTable(tenantId, 'sla_policies').insert({
+    tenant: tenantId,
+    sla_policy_id: policyId,
+    policy_name: 'ITIL Standard',
+    description: 'Auto-created for ITIL priorities',
+    is_default: false,
+  });
+
+  await tenantTable(tenantId, 'sla_notification_thresholds').insert({
+    tenant: tenantId,
+    threshold_id: uuidv4(),
+    sla_policy_id: policyId,
+    threshold_percent: 100,
+    notification_type: 'breach',
+    channels: ['in_app'],
+  });
+
+  await tenantTable(tenantId, 'sla_policy_targets').insert(priorityIds.map((priorityId) => ({
+    tenant: tenantId,
+    target_id: uuidv4(),
+    sla_policy_id: policyId,
+    priority_id: priorityId,
+    response_time_minutes: 30,
+    resolution_time_minutes: 240,
+  })));
+
+  return policyId;
+}
+
+describe('ITIL board deletion cleanup', () => {
+  beforeAll(async () => {
+    process.env.APP_ENV = process.env.APP_ENV || 'test';
+    process.env.DB_PORT = process.env.DB_PORT || '5432';
+    db = await createTestDbConnection({ runSeeds: false });
+  }, HOOK_TIMEOUT);
+
+  afterEach(async () => {
+    for (const tenantId of tenantsToCleanup) {
+      await cleanupTenant(tenantId);
+      tenantsToCleanup.delete(tenantId);
+    }
+  });
+
+  afterAll(async () => {
+    await db?.destroy().catch(() => undefined);
+  }, HOOK_TIMEOUT);
+
+  it('deletes the last ITIL board and releases every reference to the retired ITIL priorities', async () => {
+    const defaultBoardId = uuidv4();
+    const itilBoardId = uuidv4();
+    const { tenantId, userId } = await createTenantFixture([
+      { boardId: defaultBoardId, name: 'General', isDefault: true },
+      { boardId: itilBoardId, name: 'ITIL Service Desk', categoryType: 'itil', priorityType: 'itil' },
+    ]);
+
+    const itilPriorityIds = await createItilPriorities(tenantId, userId, [1, 2]);
+    const policyId = await createItilSlaPolicy(tenantId, itilPriorityIds);
+
+    await tenantTable(tenantId, 'boards')
+      .where({ board_id: itilBoardId })
+      .update({ sla_policy_id: policyId });
+    await tenantTable(tenantId, 'boards')
+      .where({ board_id: defaultBoardId })
+      .update({ default_priority_id: itilPriorityIds[0] });
+
+    const parentCategoryId = uuidv4();
+    const usedChildCategoryId = uuidv4();
+    const unusedChildCategoryId = uuidv4();
+    await tenantTable(tenantId, 'categories').insert([
+      {
+        tenant: tenantId,
+        category_id: parentCategoryId,
+        category_name: 'Incident',
+        board_id: itilBoardId,
+        is_from_itil_standard: true,
+        created_by: userId,
+      },
+    ]);
+    await tenantTable(tenantId, 'categories').insert([
+      {
+        tenant: tenantId,
+        category_id: usedChildCategoryId,
+        category_name: 'Hardware',
+        parent_category: parentCategoryId,
+        board_id: itilBoardId,
+        is_from_itil_standard: true,
+        created_by: userId,
+      },
+      {
+        tenant: tenantId,
+        category_id: unusedChildCategoryId,
+        category_name: 'Software',
+        parent_category: parentCategoryId,
+        board_id: itilBoardId,
+        is_from_itil_standard: true,
+        created_by: userId,
+      },
+    ]);
+
+    // A ticket parked on the surviving board keeps one ITIL category in use —
+    // it must survive (detached), everything else must go.
+    const clientId = uuidv4();
+    await tenantTable(tenantId, 'clients').insert({
+      tenant: tenantId,
+      client_id: clientId,
+      client_name: 'Acme',
+    });
+    await tenantTable(tenantId, 'tickets').insert({
+      tenant: tenantId,
+      ticket_id: uuidv4(),
+      ticket_number: `T-${tenantId.slice(0, 8)}`,
+      title: 'Legacy ITIL ticket',
+      client_id: clientId,
+      board_id: defaultBoardId,
+      category_id: usedChildCategoryId,
+      entered_by: userId,
+      entered_at: db.fn.now(),
+    });
+
+    const result = await deleteBoard(itilBoardId, true, true);
+
+    expect(result.success).toBe(true);
+    expect(result.message).toContain('Cleaned up');
+
+    const remainingBoards = await tenantTable(tenantId, 'boards').pluck('board_id');
+    expect(remainingBoards).toEqual([defaultBoardId]);
+
+    const remainingPriorities = await tenantTable(tenantId, 'priorities').select('*');
+    expect(remainingPriorities).toHaveLength(0);
+
+    const remainingTargets = await tenantTable(tenantId, 'sla_policy_targets').select('*');
+    expect(remainingTargets).toHaveLength(0);
+
+    const remainingPolicies = await tenantTable(tenantId, 'sla_policies').select('*');
+    expect(remainingPolicies).toHaveLength(0);
+
+    const remainingThresholds = await tenantTable(tenantId, 'sla_notification_thresholds').select('*');
+    expect(remainingThresholds).toHaveLength(0);
+
+    const survivingBoard = await tenantTable(tenantId, 'boards')
+      .where({ board_id: defaultBoardId })
+      .first('default_priority_id');
+    expect(survivingBoard.default_priority_id).toBeNull();
+
+    // The in-use category (and the parent it hangs off) survive, detached from
+    // the deleted board; the unused sibling is gone.
+    const remainingCategories = await tenantTable(tenantId, 'categories')
+      .select('category_id', 'board_id')
+      .orderBy('category_name', 'asc');
+    expect(remainingCategories.map((category) => category.category_id).sort()).toEqual(
+      [parentCategoryId, usedChildCategoryId].sort()
+    );
+    expect(remainingCategories.every((category) => category.board_id === null)).toBe(true);
+  }, HOOK_TIMEOUT);
+
+  it('keeps an ITIL priority that tickets still use, along with its SLA target', async () => {
+    const defaultBoardId = uuidv4();
+    const itilBoardId = uuidv4();
+    const { tenantId, userId } = await createTenantFixture([
+      { boardId: defaultBoardId, name: 'General', isDefault: true },
+      { boardId: itilBoardId, name: 'ITIL Service Desk', categoryType: 'custom', priorityType: 'itil' },
+    ]);
+
+    const [usedPriorityId, unusedPriorityId] = await createItilPriorities(tenantId, userId, [1, 2]);
+    const policyId = await createItilSlaPolicy(tenantId, [usedPriorityId, unusedPriorityId]);
+
+    const clientId = uuidv4();
+    await tenantTable(tenantId, 'clients').insert({
+      tenant: tenantId,
+      client_id: clientId,
+      client_name: 'Acme',
+    });
+    await tenantTable(tenantId, 'tickets').insert({
+      tenant: tenantId,
+      ticket_id: uuidv4(),
+      ticket_number: `T-${tenantId.slice(0, 8)}`,
+      title: 'Legacy ITIL ticket',
+      client_id: clientId,
+      board_id: defaultBoardId,
+      priority_id: usedPriorityId,
+      entered_by: userId,
+      entered_at: db.fn.now(),
+    });
+
+    const result = await deleteBoard(itilBoardId, true, true);
+
+    expect(result.success).toBe(true);
+    expect(result.message).toContain('still in use');
+
+    const remainingPriorities = await tenantTable(tenantId, 'priorities').pluck('priority_id');
+    expect(remainingPriorities).toEqual([usedPriorityId]);
+
+    const remainingTargets = await tenantTable(tenantId, 'sla_policy_targets').pluck('priority_id');
+    expect(remainingTargets).toEqual([usedPriorityId]);
+
+    // The policy still targets a live priority, so it stays.
+    const remainingPolicies = await tenantTable(tenantId, 'sla_policies').pluck('sla_policy_id');
+    expect(remainingPolicies).toEqual([policyId]);
+  }, HOOK_TIMEOUT);
+
+  it('re-points ITIL categories to a remaining ITIL board when another one is left', async () => {
+    const defaultBoardId = uuidv4();
+    const dyingItilBoardId = uuidv4();
+    const survivingItilBoardId = uuidv4();
+    const { tenantId, userId } = await createTenantFixture([
+      { boardId: defaultBoardId, name: 'General', isDefault: true },
+      { boardId: dyingItilBoardId, name: 'ITIL One', categoryType: 'itil', priorityType: 'itil' },
+      { boardId: survivingItilBoardId, name: 'ITIL Two', categoryType: 'itil', priorityType: 'itil' },
+    ]);
+
+    const priorityIds = await createItilPriorities(tenantId, userId, [1]);
+    const categoryId = uuidv4();
+    await tenantTable(tenantId, 'categories').insert({
+      tenant: tenantId,
+      category_id: categoryId,
+      category_name: 'Incident',
+      board_id: dyingItilBoardId,
+      is_from_itil_standard: true,
+      created_by: userId,
+    });
+
+    const result = await deleteBoard(dyingItilBoardId);
+
+    expect(result.success).toBe(true);
+
+    const remainingBoards = await tenantTable(tenantId, 'boards').pluck('board_id');
+    expect(remainingBoards.sort()).toEqual([defaultBoardId, survivingItilBoardId].sort());
+
+    const category = await tenantTable(tenantId, 'categories')
+      .where({ category_id: categoryId })
+      .first('board_id');
+    expect(category.board_id).toBe(survivingItilBoardId);
+
+    // Other ITIL boards remain, so the shared ITIL priorities stay put.
+    const remainingPriorities = await tenantTable(tenantId, 'priorities').pluck('priority_id');
+    expect(remainingPriorities).toEqual(priorityIds);
+  }, HOOK_TIMEOUT);
+});

--- a/server/src/test/integration/itilBoardDeletionCleanup.integration.test.ts
+++ b/server/src/test/integration/itilBoardDeletionCleanup.integration.test.ts
@@ -284,6 +284,67 @@ describe('ITIL board deletion cleanup', () => {
     expect(remainingCategories.every((category) => category.board_id === null)).toBe(true);
   }, HOOK_TIMEOUT);
 
+  it('releases tickets still stamped with the retiring ITIL SLA policy', async () => {
+    const defaultBoardId = uuidv4();
+    const itilBoardId = uuidv4();
+    const { tenantId, userId } = await createTenantFixture([
+      { boardId: defaultBoardId, name: 'General', isDefault: true },
+      { boardId: itilBoardId, name: 'ITIL Service Desk', categoryType: 'custom', priorityType: 'itil' },
+    ]);
+
+    const itilPriorityIds = await createItilPriorities(tenantId, userId, [1, 2]);
+    const policyId = await createItilSlaPolicy(tenantId, itilPriorityIds);
+
+    // The full off-ramp: tickets were moved off the ITIL board and given custom
+    // priorities, but keep the sla_policy_id stamped on them at SLA start.
+    const customPriorityId = uuidv4();
+    await tenantTable(tenantId, 'priorities').insert({
+      tenant: tenantId,
+      priority_id: customPriorityId,
+      priority_name: 'Normal',
+      color: '#2563EB',
+      order_number: 10,
+      item_type: 'ticket',
+      is_from_itil_standard: false,
+      created_by: userId,
+    });
+
+    const clientId = uuidv4();
+    await tenantTable(tenantId, 'clients').insert({
+      tenant: tenantId,
+      client_id: clientId,
+      client_name: 'Acme',
+    });
+    const ticketId = uuidv4();
+    await tenantTable(tenantId, 'tickets').insert({
+      tenant: tenantId,
+      ticket_id: ticketId,
+      ticket_number: `T-${tenantId.slice(0, 8)}`,
+      title: 'Ticket carried off the ITIL board',
+      client_id: clientId,
+      board_id: defaultBoardId,
+      priority_id: customPriorityId,
+      sla_policy_id: policyId,
+      entered_by: userId,
+      entered_at: db.fn.now(),
+    });
+
+    const result = await deleteBoard(itilBoardId, true, true);
+
+    expect(result.success).toBe(true);
+
+    const remainingPolicies = await tenantTable(tenantId, 'sla_policies').select('*');
+    expect(remainingPolicies).toHaveLength(0);
+
+    const remainingPriorities = await tenantTable(tenantId, 'priorities').pluck('priority_id');
+    expect(remainingPriorities).toEqual([customPriorityId]);
+
+    const ticket = await tenantTable(tenantId, 'tickets')
+      .where({ ticket_id: ticketId })
+      .first('sla_policy_id');
+    expect(ticket.sla_policy_id).toBeNull();
+  }, HOOK_TIMEOUT);
+
   it('keeps an ITIL priority that tickets still use, along with its SLA target', async () => {
     const defaultBoardId = uuidv4();
     const itilBoardId = uuidv4();

--- a/server/src/test/integration/tier1.manifest.json
+++ b/server/src/test/integration/tier1.manifest.json
@@ -12,6 +12,7 @@
     "src/test/integration/contractAssignmentLookup.postDrop.integration.test.ts",
     "src/test/integration/pricingScheduleIntegration.test.ts",
     "src/test/integration/multiCurrencyGaps.integration.test.ts",
+    "src/test/integration/itilBoardDeletionCleanup.integration.test.ts",
     "src/test/integration/ticketCreateBoardStatusValidation.integration.test.ts",
     "src/test/integration/ticketCloseRules.integration.test.ts",
     "src/test/integration/ticketAssignmentResources.integration.test.ts",


### PR DESCRIPTION
## Summary

Deleting the last ITIL board left the tenant with orphaned ITIL data: the cleanup ran too late to see the board being removed, ITIL priorities couldn't be dropped because SLA targets and board defaults still pointed at them, and shared ITIL categories were left dangling. This branch reorders the cleanup to run before the board delete, releases the FK references blocking priority deletion (including retiring the now-empty auto-generated "ITIL Standard" SLA policy), re-points orphaned ITIL categories to a fallback board, adds the missing `categories -> boards` FK so CE stops silently drifting from prod, and scopes ticket priority pickers to the board's declared priority type so custom boards no longer surface leftover ITIL priorities.

## Changes

**ITIL board deletion cleanup**
- `boardActions.ts`: run `cleanupUnusedItilStandards` before the board row is deleted (passing the board's own id in `excludeBoardIds` so it doesn't count itself), and re-point any surviving ITIL categories that still reference the board to another ITIL board (or null) before the delete proceeds.
- `itilStandardsService.ts`: accept `excludeBoardIds` so the last-board-standing checks are accurate mid-deletion; before deleting unused ITIL priorities, release `sla_policy_targets`, board `default_priority_id`, and `inbound_ticket_defaults` references; retire the auto-created "ITIL Standard" SLA policy once it has no targets and isn't assigned to a client, clearing the stamp from tickets/boards first; skip deleting ITIL category parents that a surviving child still references.
- `packages/core/.../deletion/index.ts`: register `sla_policy_targets.priority_id` as a dependency so priority deletion validation accounts for it.

**Removable ITIL priorities**
- `priorityActions.ts`: ITIL priorities are now only protected while a board with `priority_type: 'itil'` still exists; added `hasItilPriorityBoards()` to expose that check.
- `PrioritySettings.tsx`: show a delete action (and an updated note) for ITIL priorities once no board uses ITIL priorities anymore.

**Board-scoped priority pickers**
- `optimizedTicketActions.ts`, `QuickAddTicket.tsx`, `TicketInfo.tsx`, `BentoHero.tsx`, `TicketDetails.tsx`: filter priority options by the selected/current board's `priority_type` (ITIL boards show only ITIL priorities, others hide them), always keeping the ticket's already-assigned priority visible even if it no longer matches the board type.

**Schema**
- New migration `20260805090000_add_categories_board_foreign_key.cjs` adds the `categories_board_fkey` FK that production already has, nulling out any already-orphaned `board_id` references first so the constraint can be added on drifted CE databases.

**i18n**
- Added `ticketing.priorities.alert.itilRemovableNote` key across all locale files.

## Testing
- Added `priorityActions.itilDeletion.test.ts` covering the removable-ITIL-priority validation path.
- Added `QuickAddTicket.boardScopedPriorities.test.tsx` covering board-scoped priority filtering.
- Added `itilBoardDeletionCleanup.integration.test.ts` and registered it in `tier1.manifest.json` so it runs on every PR.
