### PR TITLE
Microsoft graph cleanup

### DIFF
--- a/docs/plans/2026-08-04-microsoft-email-setup-cleanup-mockup.html
+++ b/docs/plans/2026-08-04-microsoft-email-setup-cleanup-mockup.html
@@ -1,0 +1,556 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>Microsoft 365 email setup — proposed redesign</title>
+<style>
+  :root {
+    --bg: #f6f8fa;
+    --card: #ffffff;
+    --border: #e2e8f0;
+    --text: #0f172a;
+    --muted: #64748b;
+    --blue: #2563eb;
+    --blue-bg: #eff6ff;
+    --blue-border: #bfdbfe;
+    --amber-bg: #fffbeb;
+    --amber-border: #fde68a;
+    --amber-text: #92400e;
+    --green-bg: #ecfdf5;
+    --green-border: #a7f3d0;
+    --green-text: #047857;
+    --note: #7c3aed;
+    --note-bg: #f5f3ff;
+    --note-border: #ddd6fe;
+  }
+  * { box-sizing: border-box; margin: 0; padding: 0; }
+  body {
+    font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Inter, Roboto, sans-serif;
+    background: var(--bg);
+    color: var(--text);
+    font-size: 14px;
+    line-height: 1.5;
+    padding: 24px;
+  }
+  h1 { font-size: 18px; font-weight: 650; }
+  h2 { font-size: 15px; font-weight: 600; }
+  h3 { font-size: 14px; font-weight: 600; }
+  .page { max-width: 1240px; margin: 0 auto; }
+
+  /* ---------- demo control bar ---------- */
+  .demo-bar {
+    background: #0f172a;
+    color: #e2e8f0;
+    border-radius: 10px;
+    padding: 14px 18px;
+    display: flex;
+    flex-wrap: wrap;
+    gap: 24px;
+    align-items: center;
+    margin: 14px 0 22px;
+  }
+  .demo-bar .demo-tag {
+    font-size: 11px; font-weight: 700; letter-spacing: .08em;
+    color: #fbbf24; text-transform: uppercase;
+  }
+  .demo-group { display: flex; align-items: center; gap: 8px; }
+  .demo-group > span { font-size: 12px; color: #94a3b8; }
+  .seg { display: inline-flex; border: 1px solid #334155; border-radius: 7px; overflow: hidden; }
+  .seg button {
+    background: transparent; color: #cbd5e1; border: none;
+    padding: 5px 12px; font-size: 12.5px; cursor: pointer; font-family: inherit;
+  }
+  .seg button + button { border-left: 1px solid #334155; }
+  .seg button.on { background: #2563eb; color: #fff; }
+  .demo-check { display: flex; align-items: center; gap: 6px; font-size: 12.5px; color: #cbd5e1; cursor: pointer; }
+  .demo-check input { accent-color: #2563eb; }
+
+  /* ---------- layout ---------- */
+  .cols { display: grid; grid-template-columns: 1fr 1fr; gap: 22px; align-items: start; }
+  @media (max-width: 980px) { .cols { grid-template-columns: 1fr; } }
+  .crumb { font-size: 12px; color: var(--muted); margin-bottom: 8px; }
+  .crumb b { color: var(--text); font-weight: 600; }
+
+  .card {
+    background: var(--card);
+    border: 1px solid var(--border);
+    border-radius: 10px;
+    padding: 20px;
+  }
+  .card + .card { margin-top: 14px; }
+  .card .sub { color: var(--muted); font-size: 13px; margin-top: 3px; }
+
+  /* ---------- shared bits ---------- */
+  .btn {
+    display: inline-flex; align-items: center; gap: 7px;
+    font-family: inherit; font-size: 13.5px; font-weight: 500;
+    border-radius: 7px; padding: 7px 14px; cursor: pointer;
+    border: 1px solid var(--border); background: #fff; color: var(--text);
+  }
+  .btn:hover { background: #f8fafc; }
+  .btn.primary { background: #0f172a; border-color: #0f172a; color: #fff; }
+  .btn.primary:hover { background: #1e293b; }
+  .btn.link { border: none; background: none; color: var(--blue); padding: 0; font-weight: 500; }
+  .btn:disabled { opacity: .45; cursor: not-allowed; }
+  .field { margin-top: 14px; }
+  .field label { display: block; font-size: 13px; font-weight: 500; margin-bottom: 5px; }
+  .field input {
+    width: 100%; font-family: inherit; font-size: 13.5px;
+    border: 1px solid var(--border); border-radius: 7px; padding: 8px 10px;
+    color: var(--text); background: #fff;
+  }
+  .field input:focus { outline: 2px solid var(--blue-border); border-color: var(--blue); }
+  .field .hint { font-size: 12px; color: var(--muted); margin-top: 4px; }
+  .badge {
+    display: inline-flex; align-items: center; gap: 5px;
+    font-size: 11.5px; font-weight: 600; border-radius: 999px; padding: 2px 10px;
+  }
+  .badge.green { background: var(--green-bg); color: var(--green-text); border: 1px solid var(--green-border); }
+  .badge.amber { background: var(--amber-bg); color: var(--amber-text); border: 1px solid var(--amber-border); }
+  .badge.gray  { background: #f1f5f9; color: var(--muted); border: 1px solid var(--border); }
+  .alert {
+    display: flex; gap: 10px; border-radius: 8px; padding: 11px 13px;
+    font-size: 13px; margin-top: 14px; align-items: flex-start;
+  }
+  .alert .ic { flex: 0 0 auto; margin-top: 1px; }
+  .alert.info  { background: var(--blue-bg);  border: 1px solid var(--blue-border); }
+  .alert.warn  { background: var(--amber-bg); border: 1px solid var(--amber-border); color: var(--amber-text); }
+  .alert.good  { background: var(--green-bg); border: 1px solid var(--green-border); color: var(--green-text); }
+  .alert b { font-weight: 600; }
+  .alert .body { flex: 1; }
+  .alert .body .desc { color: inherit; opacity: .85; font-weight: 400; }
+
+  /* design notes */
+  .note {
+    display: flex; gap: 8px; align-items: flex-start;
+    background: var(--note-bg); border: 1px dashed var(--note-border);
+    color: #5b21b6; border-radius: 8px; font-size: 12.5px;
+    padding: 8px 11px; margin-top: 10px;
+  }
+  .note .n {
+    flex: 0 0 auto; width: 17px; height: 17px; border-radius: 50%;
+    background: var(--note); color: #fff; font-size: 11px; font-weight: 700;
+    display: flex; align-items: center; justify-content: center; margin-top: 1px;
+  }
+  body.hide-notes .note { display: none; }
+
+  /* provider row */
+  .prow {
+    display: flex; align-items: center; gap: 12px;
+    border: 1px solid var(--border); border-radius: 9px; padding: 13px 15px; margin-top: 14px;
+  }
+  .prow .logo {
+    width: 34px; height: 34px; border-radius: 7px; background: #f1f5f9;
+    display: flex; align-items: center; justify-content: center; flex: 0 0 auto;
+  }
+  .prow .meta { flex: 1; min-width: 0; }
+  .prow .meta .t { font-weight: 600; font-size: 13.5px; display: flex; gap: 8px; align-items: center; }
+  .prow .meta .d { font-size: 12.5px; color: var(--muted); margin-top: 1px; }
+  .chips { display: flex; gap: 6px; margin-top: 6px; flex-wrap: wrap; }
+  .chip { font-size: 11px; background: #f1f5f9; border: 1px solid var(--border); border-radius: 5px; padding: 1px 7px; color: #475569; }
+
+  /* ---------- wizard modal ---------- */
+  .overlay {
+    position: fixed; inset: 0; background: rgba(15,23,42,.45);
+    display: none; align-items: flex-start; justify-content: center; padding: 60px 16px; z-index: 30;
+  }
+  .overlay.open { display: flex; }
+  .modal {
+    background: #fff; border-radius: 12px; width: 100%; max-width: 520px;
+    padding: 22px; box-shadow: 0 20px 50px rgba(15,23,42,.25);
+  }
+  .modal .mhead { display: flex; justify-content: space-between; align-items: flex-start; }
+  .modal .x { border: none; background: none; font-size: 18px; color: var(--muted); cursor: pointer; line-height: 1; }
+  .opt {
+    display: flex; gap: 12px; border: 1px solid var(--border); border-radius: 9px;
+    padding: 13px 15px; margin-top: 11px; cursor: pointer; text-align: left; width: 100%;
+    background: #fff; font-family: inherit; align-items: flex-start;
+  }
+  .opt:hover { border-color: var(--blue); background: var(--blue-bg); }
+  .opt .radio {
+    flex: 0 0 auto; width: 16px; height: 16px; border: 1.5px solid #94a3b8; border-radius: 50%; margin-top: 2px;
+  }
+  .opt .ot { font-weight: 600; font-size: 13.5px; display: flex; align-items: center; gap: 8px; }
+  .opt .od { font-size: 12.5px; color: var(--muted); margin-top: 2px; }
+  .opt.rec { border-color: var(--blue-border); background: var(--blue-bg); }
+  .opt.rec:hover { border-color: var(--blue); }
+  .mfoot { display: flex; justify-content: flex-end; gap: 10px; margin-top: 18px; }
+  .kv { display: grid; grid-template-columns: 130px 1fr; gap: 6px 12px; font-size: 13px; margin-top: 12px; }
+  .kv .k { color: var(--muted); }
+  .kv .v { font-family: ui-monospace, monospace; font-size: 12.5px; word-break: break-all; }
+
+  .divider { border-top: 1px solid var(--border); margin: 18px 0 4px; }
+  .flash { animation: flash 1.2s ease-out; }
+  @keyframes flash { 0% { box-shadow: 0 0 0 3px #93c5fd; } 100% { box-shadow: 0 0 0 0 transparent; } }
+
+  /* summary strip */
+  .summary { margin-top: 26px; }
+  .summary ul { margin: 8px 0 0 18px; color: #334155; font-size: 13px; }
+  .summary li { margin-top: 4px; }
+  .summary li b { font-weight: 600; }
+</style>
+</head>
+<body>
+<div class="page">
+  <h1>Microsoft 365 email setup — proposed redesign</h1>
+  <div style="color:var(--muted); font-size:13px; margin-top:3px">
+    One app-level home (Providers), one thin mailbox flow (Communication). Use the controls to simulate states.
+  </div>
+
+  <div class="demo-bar">
+    <span class="demo-tag">Demo controls</span>
+    <div class="demo-group">
+      <span>Deployment</span>
+      <div class="seg" id="seg-deploy">
+        <button data-v="hosted" class="on">Hosted</button>
+        <button data-v="appliance">Appliance / on-prem</button>
+      </div>
+    </div>
+    <div class="demo-group">
+      <span>Microsoft app</span>
+      <div class="seg" id="seg-app">
+        <button data-v="none" class="on">Not set up</button>
+        <button data-v="pending">Consent pending</button>
+        <button data-v="ready">Ready</button>
+      </div>
+    </div>
+    <label class="demo-check"><input type="checkbox" id="notes-toggle" checked> Show design notes</label>
+  </div>
+
+  <div class="cols">
+
+    <!-- ============ SPOT 1: PROVIDERS ============ -->
+    <div id="col-providers">
+      <div class="crumb">Settings → Integrations → <b>Providers</b></div>
+      <div class="card" id="providers-card">
+        <h2>Microsoft</h2>
+        <div class="sub">Connect Alga PSA to Microsoft once. Staff sign-in, email, and calendar all reuse this connection.</div>
+        <div id="providers-body"></div>
+      </div>
+      <div class="note"><span class="n">1</span><span>App-level configuration lives <b>only</b> here. The mailbox flow (right) never asks about apps, client IDs, or redirect URIs again.</span></div>
+      <div class="note" id="note-gating"><span class="n">2</span><span>On <b>appliance / on-prem</b>, the "app provided by Alga PSA" option is <b>not rendered at all</b> (gated by <code>useTier().isHosted</code>) — today it renders and then fails with "platform credentials unavailable".</span></div>
+    </div>
+
+    <!-- ============ SPOT 2: COMMUNICATION ============ -->
+    <div id="col-mailbox">
+      <div class="crumb">Settings → Integrations → <b>Communication</b> → Add mailbox</div>
+      <div class="card" id="mailbox-card">
+        <h2>Connect a Microsoft 365 mailbox</h2>
+        <div class="sub">Inbound email from this mailbox becomes tickets. Replies can be sent from it too.</div>
+
+        <div class="field">
+          <label for="mb-addr">Mailbox address</label>
+          <input id="mb-addr" placeholder="support@yourcompany.com" value="support@yourcompany.com">
+        </div>
+        <div class="field">
+          <label for="mb-name">Sender display name</label>
+          <input id="mb-name" placeholder="Your Company Support" value="Your Company Support">
+          <div class="hint">Shown on outgoing replies sent from this mailbox.</div>
+        </div>
+
+        <div id="mailbox-status"></div>
+
+        <div class="divider"></div>
+        <div style="display:flex; justify-content:flex-end; gap:10px; margin-top:12px">
+          <button class="btn">Cancel</button>
+          <button class="btn primary" id="authorize-btn" disabled>Sign in with Microsoft</button>
+        </div>
+      </div>
+      <div class="note"><span class="n">3</span><span><b>Removed from this dialog:</b> the platform-managed vs "use your own app" choice, the "Microsoft app profile is ready" plumbing notice, and the raw <b>Redirect URI field</b> (derived server-side; never user input).</span></div>
+      <div class="note"><span class="n">4</span><span>The word "tenant" alone never appears. It's always "<b>Microsoft 365 administrator</b>", "<b>your Microsoft organization</b>", or the fully-qualified "<b>Microsoft tenant ID</b>" in advanced fields.</span></div>
+    </div>
+  </div>
+
+  <div class="card summary">
+    <h2>What changed vs. today</h2>
+    <ul>
+      <li><b>One home for app config.</b> Providers owns the Entra app (platform / auto-created / manual). The mailbox dialog only collects mailbox facts and launches sign-in — it links to Providers when the app isn't ready, instead of re-explaining app options.</li>
+      <li><b>Recommended option first, and only when real.</b> Hosted: "App provided by Alga PSA" is first and preselected. Appliance: that option doesn't exist — no disabled card with an "Unavailable" badge.</li>
+      <li><b>Deployment-aware, not edition-aware.</b> Gating uses hosted vs self-hosted (<code>useTier().isHosted</code>), not <code>EDITION === 'enterprise'</code>.</li>
+      <li><b>Terminology.</b> "Tenant" unqualified is banned from UI copy. Microsoft's concept is "your Microsoft organization" (or "Microsoft tenant ID" for the literal field); Alga's internal tenant concept never surfaces.</li>
+      <li><b>Redirect URI removed from UI.</b> Computed from the deployment's base URL; shown read-only in Providers → advanced only where a BYO app needs it copied into Entra.</li>
+    </ul>
+  </div>
+</div>
+
+<!-- ============ WIZARD MODAL ============ -->
+<div class="overlay" id="wizard">
+  <div class="modal">
+    <div class="mhead">
+      <div>
+        <h2 id="wz-title">Set up Microsoft</h2>
+        <div class="sub" id="wz-sub">Choose how Alga PSA should connect to Microsoft.</div>
+      </div>
+      <button class="x" onclick="closeWizard()">✕</button>
+    </div>
+    <div id="wz-body"></div>
+  </div>
+</div>
+
+<script>
+  const state = {
+    deploy: 'hosted',          // hosted | appliance
+    app: 'none',               // none | pending | ready
+    appSource: null,           // platform | auto | manual
+    mailboxConnected: false,
+    wizardStep: null,          // choose | auto-details | manual-details | consent
+  };
+
+  const $ = (id) => document.getElementById(id);
+  const esc = (s) => s.replace(/</g, '&lt;');
+
+  /* ---------- icons ---------- */
+  const icShield = '<svg class="ic" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M12 22s8-4 8-10V5l-8-3-8 3v7c0 6 8 10 8 10z"/></svg>';
+  const icCheck  = '<svg class="ic" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.2"><path d="M20 6 9 17l-5-5"/></svg>';
+  const icWarn   = '<svg class="ic" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M10.3 3.9 1.8 18a2 2 0 0 0 1.7 3h17a2 2 0 0 0 1.7-3L13.7 3.9a2 2 0 0 0-3.4 0z"/><line x1="12" y1="9" x2="12" y2="13"/><line x1="12" y1="17" x2="12.01" y2="17"/></svg>';
+  const msLogo   = '<svg width="18" height="18" viewBox="0 0 21 21"><rect x="1" y="1" width="9" height="9" fill="#f25022"/><rect x="11" y="1" width="9" height="9" fill="#7fba00"/><rect x="1" y="11" width="9" height="9" fill="#00a4ef"/><rect x="11" y="11" width="9" height="9" fill="#ffb900"/></svg>';
+
+  /* ---------- providers panel ---------- */
+  function renderProviders() {
+    const el = $('providers-body');
+    if (state.app === 'none') {
+      el.innerHTML = `
+        <div class="alert info">${icShield}
+          <div class="body"><b>Not set up yet.</b>
+            <div class="desc">One-time setup. After this, mailboxes connect with a single sign-in.</div>
+          </div>
+        </div>
+        <div style="margin-top:14px">
+          <button class="btn primary" onclick="openWizard()">Set up Microsoft</button>
+        </div>`;
+    } else if (state.app === 'pending') {
+      el.innerHTML = `
+        <div class="prow">
+          <div class="logo">${msLogo}</div>
+          <div class="meta">
+            <div class="t">${sourceLabel()} <span class="badge amber">Waiting for admin approval</span></div>
+            <div class="d">A <b>Microsoft 365 administrator</b> for your organization must approve access before mailboxes can connect.</div>
+            <div class="chips"><span class="chip">Email</span></div>
+          </div>
+        </div>
+        <div style="margin-top:12px; display:flex; gap:10px">
+          <button class="btn primary" onclick="grantConsent()">Approve in Microsoft</button>
+          <button class="btn" onclick="fakeCopy(this)">Copy approval link for your admin</button>
+        </div>`;
+    } else {
+      el.innerHTML = `
+        <div class="prow">
+          <div class="logo">${msLogo}</div>
+          <div class="meta">
+            <div class="t">${sourceLabel()} <span class="badge green">${icCheck} Connected</span></div>
+            <div class="d">Approved by your Microsoft 365 administrator.</div>
+            <div class="chips"><span class="chip">Email</span><span class="chip">Staff sign-in</span></div>
+          </div>
+        </div>
+        <div style="margin-top:12px; display:flex; gap:10px; align-items:center">
+          <button class="btn" onclick="jumpToMailbox()">Connect a mailbox →</button>
+          <button class="btn link" onclick="alert('(demo) advanced: view app details, rotate secret, replace app')">Advanced</button>
+        </div>`;
+    }
+  }
+
+  function sourceLabel() {
+    if (state.appSource === 'auto')   return 'App in your Microsoft organization';
+    if (state.appSource === 'manual') return 'Your Entra app registration';
+    if (state.deploy === 'hosted')    return 'Microsoft app provided by Alga PSA';
+    return 'App in your Microsoft organization';
+  }
+
+  /* ---------- mailbox panel ---------- */
+  function renderMailbox() {
+    const el = $('mailbox-status');
+    const btn = $('authorize-btn');
+    if (state.mailboxConnected) {
+      el.innerHTML = `
+        <div class="alert good">${icCheck}
+          <div class="body"><b>Mailbox connected.</b>
+            <div class="desc">support@yourcompany.com is receiving email and creating tickets.</div>
+          </div>
+        </div>`;
+      btn.disabled = true;
+      btn.textContent = 'Connected';
+      return;
+    }
+    btn.textContent = 'Sign in with Microsoft';
+    if (state.app === 'ready') {
+      el.innerHTML = `
+        <div class="alert info" style="align-items:center">${icShield}
+          <div class="body"><b>Microsoft is set up.</b>
+            <div class="desc">Sign in as this mailbox (or a user with access to it) to finish.</div>
+          </div>
+        </div>`;
+      btn.disabled = false;
+    } else if (state.app === 'pending') {
+      el.innerHTML = `
+        <div class="alert warn">${icWarn}
+          <div class="body"><b>Waiting for your Microsoft 365 administrator.</b>
+            <div class="desc">Setup was started in Providers but hasn't been approved yet.
+            <button class="btn link" onclick="jumpToProviders()">Open Providers</button></div>
+          </div>
+        </div>`;
+      btn.disabled = true;
+    } else {
+      el.innerHTML = `
+        <div class="alert warn">${icWarn}
+          <div class="body"><b>Microsoft isn't set up yet.</b>
+            <div class="desc">Set it up once in Providers, then come back to connect this mailbox.
+            <button class="btn link" onclick="jumpToProviders()">Set up in Providers</button></div>
+          </div>
+        </div>`;
+      btn.disabled = true;
+    }
+  }
+
+  /* ---------- wizard ---------- */
+  function openWizard() { state.wizardStep = 'choose'; renderWizard(); $('wizard').classList.add('open'); }
+  function closeWizard() { $('wizard').classList.remove('open'); state.wizardStep = null; }
+
+  function renderWizard() {
+    const body = $('wz-body');
+    const title = $('wz-title'), sub = $('wz-sub');
+    if (state.wizardStep === 'choose') {
+      title.textContent = 'Set up Microsoft';
+      sub.textContent = 'Choose how Alga PSA should connect to Microsoft.';
+      const platformOpt = state.deploy === 'hosted' ? `
+        <button class="opt rec" onclick="chooseSource('platform')">
+          <span class="radio"></span>
+          <span>
+            <span class="ot">Use the app provided by Alga PSA <span class="badge green">Recommended</span></span>
+            <span class="od">Nothing to register in Microsoft Entra — no client ID or secret. Your Microsoft 365 administrator just approves access.</span>
+          </span>
+        </button>` : '';
+      body.innerHTML = `
+        ${platformOpt}
+        <button class="opt" onclick="chooseSource('auto')">
+          <span class="radio"></span>
+          <span>
+            <span class="ot">Create an app in your Microsoft organization</span>
+            <span class="od">Alga PSA registers a dedicated Entra app for you automatically. Requires signing in as a Microsoft administrator.</span>
+          </span>
+        </button>
+        <button class="opt" onclick="chooseSource('manual')">
+          <span class="radio"></span>
+          <span>
+            <span class="ot">Enter an existing app manually <span class="badge gray">Advanced</span></span>
+            <span class="od">For organizations that already maintain their own Entra app registration.</span>
+          </span>
+        </button>
+        ${state.deploy === 'appliance' ? `
+        <div class="note" style="margin-top:14px"><span class="n">2</span><span>Appliance view: the platform option is absent — not shown-but-disabled. Automated creation is the recommended default here.</span></div>` : ''}`;
+    } else if (state.wizardStep === 'auto-details') {
+      title.textContent = 'Create an app in your Microsoft organization';
+      sub.textContent = 'Alga PSA will register the app for you.';
+      body.innerHTML = `
+        <div class="field">
+          <label>Microsoft tenant ID or verified domain</label>
+          <input placeholder="contoso.com or 00000000-0000-…" value="yourcompany.com">
+          <div class="hint">From the Microsoft Entra admin center → Overview. A verified domain works too.</div>
+        </div>
+        <div class="mfoot">
+          <button class="btn" onclick="state.wizardStep='choose';renderWizard()">Back</button>
+          <button class="btn primary" onclick="finishCreate('auto')">Create app</button>
+        </div>`;
+    } else if (state.wizardStep === 'manual-details') {
+      title.textContent = 'Enter your app registration';
+      sub.textContent = 'From your existing Microsoft Entra app.';
+      body.innerHTML = `
+        <div class="field"><label>Application (client) ID</label><input placeholder="00000000-0000-0000-0000-000000000000"></div>
+        <div class="field"><label>Client secret</label><input type="password" placeholder="••••••••••••"></div>
+        <div class="field"><label>Microsoft tenant ID</label><input placeholder="00000000-0000-0000-0000-000000000000"></div>
+        <div class="field">
+          <label>Redirect URI to add in Entra</label>
+          <input readonly value="https://algapsa.com/api/auth/microsoft/callback" style="background:#f8fafc;color:#64748b">
+          <div class="hint">Copy this into your app registration. It's the only place a redirect URI appears in the product.</div>
+        </div>
+        <div class="mfoot">
+          <button class="btn" onclick="state.wizardStep='choose';renderWizard()">Back</button>
+          <button class="btn primary" onclick="finishCreate('manual')">Save app</button>
+        </div>`;
+    } else if (state.wizardStep === 'consent') {
+      title.textContent = 'One more step: administrator approval';
+      sub.textContent = '';
+      body.innerHTML = `
+        <div class="alert info">${icShield}
+          <div class="body"><b>A Microsoft 365 administrator must approve access.</b>
+            <div class="desc">This is Microsoft's admin-consent step. If that's you, approve now; otherwise send the link to your admin.</div>
+          </div>
+        </div>
+        <div class="kv">
+          <span class="k">App</span><span class="v" style="font-family:inherit">${sourceLabel()}</span>
+          <span class="k">Access requested</span><span class="v" style="font-family:inherit">Read &amp; send mail, sign in mailbox users</span>
+        </div>
+        <div class="mfoot">
+          <button class="btn" onclick="fakeCopy(this)">Copy approval link</button>
+          <button class="btn primary" onclick="grantConsent(); closeWizard()">Approve in Microsoft</button>
+        </div>`;
+    }
+  }
+
+  function chooseSource(src) {
+    state.appSource = src;
+    if (src === 'platform') { state.app = 'pending'; state.wizardStep = 'consent'; }
+    else if (src === 'auto') { state.wizardStep = 'auto-details'; }
+    else { state.wizardStep = 'manual-details'; }
+    renderWizard(); renderAll();
+  }
+  function finishCreate(src) {
+    state.appSource = src; state.app = 'pending'; state.wizardStep = 'consent';
+    renderWizard(); renderAll();
+  }
+  function grantConsent() {
+    state.app = 'ready';
+    syncSeg('seg-app', 'ready');
+    renderAll();
+  }
+
+  /* ---------- interactions ---------- */
+  function jumpToProviders() {
+    $('providers-card').scrollIntoView({ behavior: 'smooth', block: 'center' });
+    $('providers-card').classList.remove('flash'); void $('providers-card').offsetWidth;
+    $('providers-card').classList.add('flash');
+  }
+  function jumpToMailbox() {
+    $('mailbox-card').scrollIntoView({ behavior: 'smooth', block: 'center' });
+    $('mailbox-card').classList.remove('flash'); void $('mailbox-card').offsetWidth;
+    $('mailbox-card').classList.add('flash');
+  }
+  function fakeCopy(btn) {
+    const old = btn.textContent; btn.textContent = 'Copied ✓';
+    setTimeout(() => btn.textContent = old, 1200);
+  }
+
+  $('authorize-btn').addEventListener('click', () => {
+    const btn = $('authorize-btn');
+    btn.disabled = true; btn.textContent = 'Waiting for Microsoft…';
+    setTimeout(() => { state.mailboxConnected = true; renderAll(); }, 900);
+  });
+
+  /* ---------- demo controls ---------- */
+  function syncSeg(segId, value) {
+    document.querySelectorAll('#' + segId + ' button').forEach(b =>
+      b.classList.toggle('on', b.dataset.v === value));
+  }
+  $('seg-deploy').addEventListener('click', (e) => {
+    const b = e.target.closest('button'); if (!b) return;
+    state.deploy = b.dataset.v; syncSeg('seg-deploy', state.deploy);
+    if (state.deploy === 'appliance' && state.appSource === 'platform') state.appSource = 'auto';
+    if (state.wizardStep) renderWizard();
+    renderAll();
+  });
+  $('seg-app').addEventListener('click', (e) => {
+    const b = e.target.closest('button'); if (!b) return;
+    state.app = b.dataset.v; syncSeg('seg-app', state.app);
+    if (state.app !== 'ready') state.mailboxConnected = false;
+    if (state.app === 'none') state.appSource = null;
+    renderAll();
+  });
+  $('notes-toggle').addEventListener('change', (e) => {
+    document.body.classList.toggle('hide-notes', !e.target.checked);
+  });
+
+  function renderAll() { renderProviders(); renderMailbox(); }
+  renderAll();
+</script>
+</body>
+</html>

--- a/docs/plans/2026-08-04-microsoft-email-setup-cleanup-plan.md
+++ b/docs/plans/2026-08-04-microsoft-email-setup-cleanup-plan.md
@@ -1,0 +1,116 @@
+# Microsoft 365 email setup cleanup — implementation plan
+
+**Date:** 2026-08-04
+**Branch:** `chore/microsoft-graph-cleanup`
+**Interactive mockup:** [`2026-08-04-microsoft-email-setup-cleanup-mockup.html`](./2026-08-04-microsoft-email-setup-cleanup-mockup.html) — open in a browser; it simulates both redesigned surfaces with toggles for deployment type (hosted / appliance) and Microsoft app state (not set up / consent pending / ready). The mockup is the visual contract for this plan.
+
+## Problem
+
+Microsoft 365 email configuration spans three chained surfaces, but the UI presents them as overlapping, competing implementations:
+
+- **Providers** (Settings → Integrations → Providers) configures the Entra app registration (`microsoft_profiles`, `microsoft_profile_consumer_bindings`).
+- **Communication** (Settings → Integrations → Communication) connects a mailbox (`email_providers`, `microsoft_email_provider_config`), consuming the profile from Providers.
+- **Outbound Email** picks an already-authorized mailbox (`tenant_email_settings`).
+
+The confusion:
+
+1. The mailbox dialog (`MicrosoftProviderForm`) **re-litigates app-level decisions** that belong to Providers: a platform-managed vs bring-your-own-app choice, a "Microsoft app profile is ready" plumbing notice, and a raw Redirect URI input. The platform/BYO explanation exists three times with drifted wording (mailbox form, provider list page, Providers screen).
+2. **No hosted-vs-self-hosted gating.** All "Alga PSA supplies the application" affordances key off `EDITION === 'enterprise'` (`microsoftConsumerVisibility.ts`). The appliance ships EE, so appliance users see hosted-only options that then fail with "Platform Microsoft credentials are unavailable". In the Providers setup dialog, the platform option renders even when unavailable (disabled with an "Unavailable" badge). The primitive that should gate this (`useTier().isHosted` / self-host licensing) is never used inside `packages/integrations`.
+3. **"Tenant" terminology is overloaded.** UI copy uses bare "tenant" ("tenant administrator consent", "tenant-owned app", a bare "Tenant ID" label) meaning the *Microsoft* tenant, in a product where tenant is the internal MSP concept. Internally one interface carries both `tenantId` (Alga) and `microsoftTenantId` (Microsoft).
+
+## Settled design
+
+One sentence: **Providers is the sole home for app-level Microsoft configuration; the Communication mailbox flow is reduced to mailbox facts plus a readiness line plus sign-in, linking out to Providers when the app isn't ready.**
+
+### Providers surface (app-level home)
+
+- **Not set up:** a single "Set up Microsoft" call to action opening the setup wizard.
+- **Wizard option list** (order and presence matter):
+  1. *"Use the app provided by Alga PSA"* — **hosted deployments only**, listed first, badged "Recommended". On self-hosted/appliance deployments this option is **not rendered at all** (not disabled-with-badge).
+  2. *"Create an app in your Microsoft organization"* — automated Entra provisioning. Becomes the lead option on self-hosted.
+  3. *"Enter an existing app manually"* — badged "Advanced". This step is the **only place in the product a Redirect URI appears**, read-only, for copying into the customer's Entra app registration.
+- **Consent step** (all paths funnel here): framed as "a **Microsoft 365 administrator** must approve access", with an "Approve in Microsoft" action and a "Copy approval link for your admin" affordance (the person clicking is often not the Microsoft admin).
+- **Pending state:** profile card with a "Waiting for admin approval" badge, approve + copy-link actions.
+- **Ready state:** profile card with capability chips and a "Connect a mailbox →" hand-off routing to the Communication tab.
+
+### Communication surface (thin mailbox flow)
+
+- Fields: mailbox address, sender display name, existing ticket defaults / advanced sync settings. Nothing app-level.
+- One status strip, driven by a single consolidated readiness payload:
+  - **Ready:** quiet info line ("Microsoft is set up. Sign in as this mailbox to finish.") and an enabled **"Sign in with Microsoft"** button (rename from "Authorize Access").
+  - **Consent pending:** warning ("Waiting for your Microsoft 365 administrator. Setup was started in Providers but hasn't been approved yet.") with an "Open Providers" link; sign-in disabled.
+  - **Not set up:** warning ("Microsoft isn't set up yet. Set it up once in Providers, then come back.") with a "Set up in Providers" link; sign-in disabled.
+- **Removed entirely from this surface:** the platform-managed alert, the "Use your own Microsoft app (advanced)" expander and its `useByoApp` state, the "Microsoft app profile is ready" notice, and the Redirect URI input.
+- The provider list page (`EmailProviderConfiguration`) loses its duplicated platform/BYO setup-instructions block in favor of a one-line pointer to Providers.
+
+### Cross-cutting rules
+
+- **Deployment-aware gating:** hosted-only affordances gate on hosted-ness (self-host licensing), not edition. Edition checks remain only where they genuinely mean edition (EE feature availability).
+- **Terminology:** bare "tenant" is banned from user-facing copy in these flows. Use "your Microsoft organization", "Microsoft 365 administrator", or the fully-qualified "Microsoft tenant ID" for the literal field. Alga's internal tenant concept never surfaces.
+- **Redirect URI** is computed server-side from the deployment's public base URL; it is never user input.
+
+## Non-goals
+
+- The Outbound Email tab (flow C) is untouched except where it already works (it gates Resend on `isHosted` correctly). The genuine duplication between `ee/server/.../ManagedEmailSettings.tsx` and `packages/integrations/.../admin/EmailSettings.tsx` outbound selectors is noted for a follow-up card, not this one.
+- Gmail flows: no behavior change. Copy edits only if a shared string forces it.
+- No data-model/migration changes. The `microsoft_profiles` → `email_providers` → `tenant_email_settings` chain is already right; this is a presentation/gating/copy cleanup.
+- No changes to OAuth scopes, callbacks' token exchange, or consent URL contents (recently fixed in b523f261be / b6f3a7eecc).
+
+## Implementation phases
+
+### Phase 1 — foundations: hosted-ness + consolidated readiness
+
+1. **Hosted-deployment helper usable from `packages/integrations`.** `useTier().isHosted` lives in `server/src/context/TierContext.tsx` (fed by `isSelfHostLicensing()` in `server/src/app/msp/layout.tsx:70`); `packages/integrations` cannot import server context. Extract the underlying hosted/self-host determination into a shared server-side helper (shared lib or `packages/integrations/src/lib`) with a single source of truth, and make `TierContext` consume it so the two can never disagree. Client components in the package receive hosted-ness via action payloads (below), not via a new React context.
+2. **Consolidated email readiness payload.** Extend/replace `getMicrosoftConsumerSetupStatus('email')` and `getMicrosoftEmailSetupOptions` so both surfaces render from one shape, e.g.:
+   ```ts
+   {
+     state: 'not_configured' | 'pending_admin_consent' | 'ready',
+     source: 'platform' | 'tenant_app' | null,
+     hosted: boolean,               // deployment, for copy + option gating
+     platformOffered: boolean,      // hosted && platform credentials present
+     automatedCreationAvailable: boolean,
+   }
+   ```
+   `pending_admin_consent` derives from the existing consent-tracking columns (`email_admin_consent_required` / `email_admin_consent_granted_at` on `microsoft_profiles`, migration `20260803000000`). The resolver work stays in `resolveMicrosoftConsumerProfileConfig` / `providerReadiness.ts` — this phase surfaces it once instead of piecemeal.
+3. **Server-side redirect URI.** `initiateEmailOAuth` (`oauthActions.ts`) and `persistMicrosoftConfig` (`emailProviderActions.ts`) compute the redirect URI from the deployment's public base URL; stop accepting it from the client form. The manual-app wizard step displays the same computed value read-only.
+
+### Phase 2 — Providers surface
+
+Files: `packages/integrations/src/components/settings/integrations/MicrosoftEmailSetupDialog.tsx`, `MicrosoftIntegrationSettings.tsx`, `microsoftEmailSetupActions.ts`.
+
+1. `getMicrosoftEmailSetupOptions` returns `platformOffered` per Phase 1; the dialog renders the platform card **only when `platformOffered`** — delete the disabled/"Unavailable" rendering path. Order: platform (hosted), automated, manual; "Recommended" badge on platform, "Advanced" on manual.
+2. Consent step: "Microsoft 365 administrator" framing, approve action, copy-approval-link action (reuses `getMicrosoftEmailAdminConsentUrl`). Reconcile the diverged inline `defaultValue` vs locale string for `integrations.microsoft.emailSetup.platform.description`.
+3. `MicrosoftIntegrationSettings`: finish the capability-based conversion started in 83ce26a80d — the edition-branched copy at ~L734-738 and ~L995-997 becomes capability/deployment-driven; the "Bring your own Microsoft app (advanced)" collapse and its copy ("normally unnecessary on hosted Alga PSA") only claims hosted behavior when `hosted` is true. Ready-state hand-off keeps routing to `?category=communication` with "Connect a mailbox →" wording per the mockup.
+
+### Phase 3 — Communication surface
+
+Files: `packages/integrations/src/components/email/MicrosoftProviderForm.tsx`, `EmailProviderConfiguration.tsx`.
+
+1. Strip `MicrosoftProviderForm` per the settled design: delete the platform-managed alert, the BYO expander + `useByoApp` state + init heuristic, the profile-ready notice, and the Redirect URI field (form no longer submits `redirect_uri`; it already submits empty credentials). Add the three-state status strip and rename the button to "Sign in with Microsoft". Providers links route to `?category=providers` (pattern already exists in `MicrosoftIntegrationSettings`).
+2. `EmailProviderConfiguration`: replace the setup-instructions platform/BYO block (~L575-638) with the one-line pointer to Providers; keep loading the consolidated readiness payload once and passing it down.
+3. The OAuth popup/postMessage flow (`initiateEmailOAuth` → `/api/auth/microsoft/callback`) is unchanged apart from server-derived redirect URI.
+
+### Phase 4 — terminology sweep
+
+1. Sweep user-facing strings in the files above plus `server/public/locales/en/msp/email-providers.json` and `server/public/locales/en/msp/integrations.json` (`integrations.microsoft.*` keys): no bare "tenant". Replacements per the cross-cutting rule. Known offenders inventoried: `MicrosoftProviderForm.tsx:577` ("tenant administrator"), `:512` ("tenant-owned"), `MicrosoftIntegrationSettings.tsx:802/822` ("tenant-owned"), `:1251` (bare "Tenant ID" label → "Microsoft tenant ID"), `EmailProviderConfiguration.tsx:603/618`, `MicrosoftEmailSetupDialog.tsx:287` ("Create an app in this tenant" → "…in your Microsoft organization"), locale keys `email-providers.json:53,58,276,282,283,322`.
+2. Internal identifiers (`tenantId` vs `microsoftTenantId`) are renamed only where they cross a user-facing boundary in the touched files; no repo-wide identifier churn.
+
+### Phase 5 — tests
+
+1. **Update copy-coupled tests:** `packages/integrations/src/components/microsoftProviders.providersFirst.test.ts` (asserts exact BYO copy, `?category=providers` link, "Microsoft app profile is ready." — all changing), `server/src/test/unit/components/MicrosoftProviderForm.test.tsx`, `server/src/test/unit/components/EmailProviderConfiguration.test.tsx`, `MicrosoftIntegrationSettings.contract.test.tsx`.
+2. **New gating tests:** hosted → platform option first + Recommended; self-hosted → platform option absent (not disabled); mailbox form three states (ready / pending consent / not configured) rendering and sign-in enablement; redirect URI absent from mailbox form payload and derived server-side.
+3. **Regression guard:** a test asserting no user-facing string in the touched components matches bare-`tenant` patterns (word-boundary "tenant" not preceded by "Microsoft ", allowing "Microsoft tenant"), to keep the terminology rule from regressing.
+
+## Acceptance criteria
+
+- On a hosted deployment: Providers wizard lists platform first with "Recommended"; mailbox dialog shows only mailbox fields + status + sign-in; no Redirect URI input anywhere; no BYO expander in the mailbox dialog.
+- On a self-hosted/appliance deployment (EE, no platform secrets): the platform option does not render anywhere; no "Platform Microsoft credentials are unavailable" error-shaped states in the default path; automated creation leads the wizard.
+- With no profile configured, the mailbox dialog blocks sign-in and links to Providers; with consent pending, it blocks with the admin-approval message; with a ready profile, sign-in is enabled with no app-level chrome.
+- `grep` over the touched components and locale namespaces finds no user-facing bare "tenant".
+- All Phase 5 tests pass; `npm run lint` and the affected package builds pass.
+
+## Notes for the implementing agent
+
+- Follow `docs/AI_coding_standards.md` in this worktree.
+- The three-surface chain and gating gap are recorded as card facts; the mockup HTML next to this plan is the visual contract — match its structure and copy tone, not necessarily pixel-for-pixel.
+- Where the same platform/BYO explanation previously lived in three places, resist re-introducing per-surface variants: the readiness payload from Phase 1 is the single input, and each surface renders its own thin view of it.

--- a/packages/integrations/src/actions/email-actions/emailProviderActions.ts
+++ b/packages/integrations/src/actions/email-actions/emailProviderActions.ts
@@ -27,10 +27,14 @@ import type { Microsoft365DiagnosticsReport } from '@alga-psa/shared/interfaces/
 import { buildMicrosoftEmailProviderConfig } from '@alga-psa/shared/services/email/microsoftEmailProviderConfig';
 import {
   resolveMicrosoftConsumerProfileConfig,
-  type MicrosoftCredentialPreference,
 } from '../../lib/microsoftConsumerProfileResolution';
+import { getMicrosoftEmailSetupMetadataInternal } from '../integrations/microsoftActions';
 
 type EmailProviderActionError = ActionMessageError;
+type MicrosoftEmailProviderConfigInput = Omit<
+  MicrosoftEmailProviderConfig,
+  'email_provider_id' | 'tenant' | 'created_at' | 'updated_at' | 'redirect_uri'
+>;
 type EmailProviderSetupActionResult = EmailProviderSetupResult | EmailProviderActionError;
 type EmailProviderOperationErrorCode =
   | 'not_found'
@@ -316,14 +320,13 @@ async function persistMicrosoftConfig(
   trx: any,
   tenant: string,
   providerId: string,
-  config?: Omit<MicrosoftEmailProviderConfig, 'email_provider_id' | 'tenant' | 'created_at' | 'updated_at'>,
-  credentialPreference?: MicrosoftCredentialPreference
+  config?: MicrosoftEmailProviderConfigInput
 ): Promise<MicrosoftEmailProviderConfig | undefined> {
   if (!config) return undefined;
   if (!tenant) throwExpectedEmailProviderError('Tenant context is required to save Microsoft email configuration');
 
   const microsoftProfile = await resolveMicrosoftConsumerProfileConfig(tenant, 'email', {
-    credentialPreference,
+    credentialPreference: 'tenant',
   });
   if (microsoftProfile.status !== 'ready') {
     throwExpectedEmailProviderError(
@@ -334,16 +337,12 @@ async function persistMicrosoftConfig(
   const effectiveClientId = microsoftProfile.clientId || '';
   const effectiveClientSecret = microsoftProfile.clientSecret || '';
   const effectiveTenantId = microsoftProfile.microsoftTenantId || 'common';
-  const effectiveRedirectUri = config.redirect_uri;
+  const effectiveRedirectUri = (await getMicrosoftEmailSetupMetadataInternal()).mailboxRedirectUri;
   
   // Ensure required fields are not undefined
   if (!effectiveTenantId) {
     throwExpectedEmailProviderError('Tenant ID is required for Microsoft configuration');
   }
-  if (!effectiveRedirectUri) {
-    throwExpectedEmailProviderError('Redirect URI is required for Microsoft configuration');
-  }
-  
   const now = new Date();
   const existingConfig = await tenantDb(trx, tenant)
     .table('microsoft_email_provider_config')
@@ -807,8 +806,7 @@ export const upsertEmailProvider = withAuth(async (
   mailbox: string;
   isActive: boolean;
   inboundTicketDefaultsId?: string;
-  microsoftConfig?: Omit<MicrosoftEmailProviderConfig, 'email_provider_id' | 'tenant' | 'created_at' | 'updated_at'>;
-  microsoftCredentialSource?: MicrosoftCredentialPreference;
+  microsoftConfig?: MicrosoftEmailProviderConfigInput;
   googleConfig?: Omit<GoogleEmailProviderConfig, 'email_provider_id' | 'tenant' | 'created_at' | 'updated_at'>;
   imapConfig?: Omit<ImapEmailProviderConfig, 'email_provider_id' | 'tenant' | 'created_at' | 'updated_at'>;
 },
@@ -830,8 +828,7 @@ export const upsertEmailProvider = withAuth(async (
           trx,
           tenant,
           base.id,
-          data.microsoftConfig,
-          data.microsoftCredentialSource
+          data.microsoftConfig
         );
       } else if (data.providerType === 'google') {
         base.googleConfig = await persistGoogleConfig(trx, tenant, base.id, data.googleConfig);
@@ -928,8 +925,7 @@ export const createEmailProvider = withAuth(async (
   mailbox: string;
   isActive: boolean;
   inboundTicketDefaultsId?: string;
-  microsoftConfig?: Omit<MicrosoftEmailProviderConfig, 'email_provider_id' | 'tenant' | 'created_at' | 'updated_at'>;
-  microsoftCredentialSource?: MicrosoftCredentialPreference;
+  microsoftConfig?: MicrosoftEmailProviderConfigInput;
   googleConfig?: Omit<GoogleEmailProviderConfig, 'email_provider_id' | 'tenant' | 'created_at' | 'updated_at'>;
   imapConfig?: Omit<ImapEmailProviderConfig, 'email_provider_id' | 'tenant' | 'created_at' | 'updated_at'>;
 },
@@ -951,8 +947,7 @@ export const updateEmailProvider = withAuth(async (
     mailbox: string;
     isActive: boolean;
     inboundTicketDefaultsId?: string;
-    microsoftConfig?: Omit<MicrosoftEmailProviderConfig, 'email_provider_id' | 'tenant' | 'created_at' | 'updated_at'>;
-    microsoftCredentialSource?: MicrosoftCredentialPreference;
+    microsoftConfig?: MicrosoftEmailProviderConfigInput;
     googleConfig?: Omit<GoogleEmailProviderConfig, 'email_provider_id' | 'tenant' | 'created_at' | 'updated_at'>;
     imapConfig?: Omit<ImapEmailProviderConfig, 'email_provider_id' | 'tenant' | 'created_at' | 'updated_at'>;
   },
@@ -974,8 +969,7 @@ export const updateEmailProvider = withAuth(async (
           trx,
           tenant,
           base.id,
-          data.microsoftConfig,
-          data.microsoftCredentialSource
+          data.microsoftConfig
         );
       } else if (data.providerType === 'google') {
         base.googleConfig = await persistGoogleConfig(trx, tenant, base.id, data.googleConfig);

--- a/packages/integrations/src/actions/email-actions/oauthActions.test.ts
+++ b/packages/integrations/src/actions/email-actions/oauthActions.test.ts
@@ -5,6 +5,7 @@ const mocks = vi.hoisted(() => ({
   resolveMicrosoftConsumerProfileConfig: vi.fn(),
   getAppSecret: vi.fn(),
   getTenantSecret: vi.fn(),
+  getMicrosoftEmailSetupMetadataInternal: vi.fn(),
 }));
 
 vi.mock("@alga-psa/auth", () => ({
@@ -35,6 +36,10 @@ vi.mock("../../lib/microsoftConsumerProfileResolution", () => ({
     mocks.resolveMicrosoftConsumerProfileConfig(...args),
 }));
 
+vi.mock("../integrations/microsoftActions", () => ({
+  getMicrosoftEmailSetupMetadataInternal: mocks.getMicrosoftEmailSetupMetadataInternal,
+}));
+
 import { initiateEmailOAuth } from "./oauthActions";
 
 const originalBaseUrl = process.env.NEXT_PUBLIC_BASE_URL;
@@ -45,6 +50,9 @@ describe("initiateEmailOAuth Microsoft credential source", () => {
     mocks.hasPermission.mockResolvedValue(true);
     mocks.getAppSecret.mockResolvedValue(null);
     mocks.getTenantSecret.mockResolvedValue(null);
+    mocks.getMicrosoftEmailSetupMetadataInternal.mockResolvedValue({
+      mailboxRedirectUri: 'https://psa.example.com/api/auth/microsoft/callback',
+    });
     process.env.NEXT_PUBLIC_BASE_URL = "https://psa.example.com";
   });
 
@@ -69,19 +77,17 @@ describe("initiateEmailOAuth Microsoft credential source", () => {
 
     const result = await initiateEmailOAuth({
       provider: "microsoft",
-      microsoftCredentialSource: "platform",
+      redirectUri: "https://attacker.example/callback",
     });
 
     expect(result.success).toBe(true);
     if (!result.success) return;
     expect(result.authUrl).toContain("client_id=platform-client-id");
-    expect(mocks.resolveMicrosoftConsumerProfileConfig).toHaveBeenCalledWith(
-      "tenant-1",
-      "email",
-      {
-        credentialPreference: "platform",
-      },
-    );
+    expect(mocks.resolveMicrosoftConsumerProfileConfig).toHaveBeenCalledWith("tenant-1", "email", {
+      credentialPreference: "tenant",
+    });
+    expect(result.authUrl).toContain(encodeURIComponent('https://psa.example.com/api/auth/microsoft/callback'));
+    expect(result.authUrl).not.toContain('attacker.example');
     expect(
       JSON.parse(Buffer.from(result.state, "base64").toString("utf8")),
     ).toMatchObject({
@@ -105,18 +111,13 @@ describe("initiateEmailOAuth Microsoft credential source", () => {
 
     const result = await initiateEmailOAuth({
       provider: "microsoft",
-      microsoftCredentialSource: "tenant",
     });
 
     expect(result.success).toBe(true);
     if (!result.success) return;
     expect(result.authUrl).toContain("client_id=tenant-client-id");
-    expect(mocks.resolveMicrosoftConsumerProfileConfig).toHaveBeenCalledWith(
-      "tenant-1",
-      "email",
-      {
-        credentialPreference: "tenant",
-      },
-    );
+    expect(mocks.resolveMicrosoftConsumerProfileConfig).toHaveBeenCalledWith("tenant-1", "email", {
+      credentialPreference: "tenant",
+    });
   });
 });

--- a/packages/integrations/src/actions/email-actions/oauthActions.ts
+++ b/packages/integrations/src/actions/email-actions/oauthActions.ts
@@ -7,8 +7,8 @@ import { createTenantKnex, tenantDb } from '@alga-psa/db';
 import { generateMicrosoftAuthUrl, generateGoogleAuthUrl, generateNonce, type OAuthState } from '../../utils/email/oauthHelpers';
 import {
   resolveMicrosoftConsumerProfileConfig,
-  type MicrosoftCredentialPreference,
 } from '../../lib/microsoftConsumerProfileResolution';
+import { getMicrosoftEmailSetupMetadataInternal } from '../integrations/microsoftActions';
 
 export const initiateEmailOAuth = withAuth(async (
   user,
@@ -17,7 +17,6 @@ export const initiateEmailOAuth = withAuth(async (
     provider: 'microsoft' | 'google';
     providerId?: string;
     redirectUri?: string;
-    microsoftCredentialSource?: MicrosoftCredentialPreference;
   }
 ): Promise<{ success: true; authUrl: string; state: string } | { success: false; error: string }> => {
 
@@ -47,16 +46,15 @@ export const initiateEmailOAuth = withAuth(async (
 
     let clientId: string | null = null;
     let effectiveRedirectUri = redirectUri || '';
+    let microsoftCredentialSource: 'tenant' | 'platform' | undefined;
 
     if (provider === 'google') {
       // Google is always tenant-owned (CE and EE): do not fall back to app-level secrets.
       clientId = (await secretProvider.getTenantSecret(tenant, 'google_client_id')) || null;
     } else {
-      const microsoftProfile = params.microsoftCredentialSource
-        ? await resolveMicrosoftConsumerProfileConfig(tenant, 'email', {
-            credentialPreference: params.microsoftCredentialSource,
-          })
-        : await resolveMicrosoftConsumerProfileConfig(tenant, 'email');
+      const microsoftProfile = await resolveMicrosoftConsumerProfileConfig(tenant, 'email', {
+        credentialPreference: 'tenant',
+      });
       if (microsoftProfile.status !== 'ready') {
         return {
           success: false,
@@ -65,6 +63,8 @@ export const initiateEmailOAuth = withAuth(async (
       }
 
       clientId = microsoftProfile.clientId || null;
+      microsoftCredentialSource = microsoftProfile.credentialSource === 'app' ? 'platform' : 'tenant';
+      effectiveRedirectUri = (await getMicrosoftEmailSetupMetadataInternal()).mailboxRedirectUri;
     }
 
     if (!effectiveRedirectUri) {
@@ -88,8 +88,8 @@ export const initiateEmailOAuth = withAuth(async (
       redirectUri: effectiveRedirectUri,
       timestamp: Date.now(),
       nonce: generateNonce(),
-      hosted: params.microsoftCredentialSource === 'platform',
-      microsoftCredentialSource: params.microsoftCredentialSource,
+      hosted: microsoftCredentialSource === 'platform',
+      microsoftCredentialSource,
     };
 
     // For multi-tenant Azure AD apps, always use 'common' for the authorization URL

--- a/packages/integrations/src/actions/integrations/microsoftActions.ts
+++ b/packages/integrations/src/actions/integrations/microsoftActions.ts
@@ -7,9 +7,9 @@ import { hasPermission } from '@alga-psa/auth/rbac';
 import { createTenantKnex, tenantDb } from '@alga-psa/db';
 import { ADD_ONS } from '@alga-psa/types';
 import {
-  getMicrosoftEmailCredentialCapability,
+  getMicrosoftEmailSetupReadiness,
   getMicrosoftProfileReadiness,
-  type MicrosoftCredentialCapability,
+  type MicrosoftEmailSetupReadiness,
   type ProviderReadinessResult,
 } from './providerReadiness';
 import {
@@ -136,7 +136,7 @@ export interface MicrosoftConsumerSetupStatusResponse {
   ready?: boolean;
   profileId?: string | null;
   profileDisplayName?: string;
-  credentialCapability?: MicrosoftCredentialCapability;
+  emailSetup?: MicrosoftEmailSetupReadiness;
   message?: string;
 }
 
@@ -159,7 +159,7 @@ export interface MicrosoftProfileStatusResponse {
     tenantId: string;
     ready: boolean;
   };
-  emailCredentialCapability?: MicrosoftCredentialCapability;
+  emailSetup?: MicrosoftEmailSetupReadiness;
   profiles?: MicrosoftProfileSummary[];
 }
 
@@ -962,11 +962,12 @@ export async function createMicrosoftEmailProfilePendingConsentInternal(
   if (!created.success || !created.profile) {
     return { success: false, error: created.error || 'Failed to create Microsoft email profile' };
   }
+  const createdProfile = created.profile;
 
   return {
     success: true,
-    profileId: created.profile.profileId,
-    displayName: created.profile.displayName,
+    profileId: createdProfile.profileId,
+    displayName: createdProfile.displayName,
   };
 }
 
@@ -1064,6 +1065,33 @@ export async function getMicrosoftEmailSetupMetadataInternal(): Promise<{
     mailboxRedirectUri: `${baseUrl}/api/auth/microsoft/callback`,
     setupRedirectUri: `${baseUrl}/api/auth/microsoft/email-setup/callback`,
     returnTo: `${baseUrl}/msp/settings/integrations?category=providers`,
+  };
+}
+
+export async function getMicrosoftEmailConsentProfileInternal(
+  tenant: string,
+  profileId: string
+): Promise<{
+  profileId: string;
+  displayName: string;
+  clientId: string;
+  microsoftTenantId: string;
+}> {
+  const { knex } = await createTenantKnex();
+  const profile = await tenantDb(knex, tenant)
+    .table<MicrosoftProfileRow>('microsoft_profiles')
+    .where({ profile_id: profileId })
+    .first();
+
+  if (!profile || profile.is_archived || !profileHasCapability(profile, 'email')) {
+    throw new Error('The pending Microsoft Email profile is unavailable');
+  }
+
+  return {
+    profileId: profile.profile_id,
+    displayName: profile.display_name,
+    clientId: profile.client_id,
+    microsoftTenantId: normalizeTenantId(profile.tenant_id),
   };
 }
 
@@ -1518,19 +1546,19 @@ export const getMicrosoftConsumerSetupStatus = withAuth(async (
     }
 
     if (consumerType === 'email') {
-      const credentialCapability = await getMicrosoftEmailCredentialCapability(tenant);
+      const emailSetup = await getMicrosoftEmailSetupReadiness(tenant);
 
       return {
         success: true,
         consumerType,
         consumerLabel,
         visible: true,
-        ready: credentialCapability.ready,
-        profileId: credentialCapability.profileId,
-        credentialCapability,
-        message: credentialCapability.ready
+        ready: emailSetup.state === 'ready',
+        profileId: emailSetup.profileId,
+        emailSetup,
+        message: emailSetup.state === 'ready'
           ? undefined
-          : credentialCapability.message || 'Microsoft email credentials are not configured.',
+          : emailSetup.message || 'Microsoft email is not configured.',
       };
     }
 
@@ -1575,9 +1603,7 @@ export const getMicrosoftIntegrationStatus = withAuth(async (
     const baseUrl = await getDeploymentBaseUrl();
     const metadata = getVisibleMicrosoftIntegrationMetadata(baseUrl);
     const mspSsoProfile = await resolveMicrosoftProfileForConsumer(tenant, 'msp_sso');
-    const emailCredentialCapability = isMicrosoftConsumerEnterpriseEdition()
-      ? await getMicrosoftEmailCredentialCapability(tenant)
-      : undefined;
+    const emailSetup = await getMicrosoftEmailSetupReadiness(tenant);
     const visibleProfiles = profiles.map((profile) => ({
       ...profile,
       consumers: getVisibleConsumerLabels(profile.consumers),
@@ -1594,7 +1620,7 @@ export const getMicrosoftIntegrationStatus = withAuth(async (
         tenantId: mspSsoProfile?.tenantId || 'common',
         ready: mspSsoProfile?.readiness.ready || false,
       },
-      emailCredentialCapability,
+      emailSetup,
       profiles: visibleProfiles,
     };
   } catch (err: any) {

--- a/packages/integrations/src/actions/integrations/microsoftEmailSetupActions.test.ts
+++ b/packages/integrations/src/actions/integrations/microsoftEmailSetupActions.test.ts
@@ -13,6 +13,14 @@ const hoisted = vi.hoisted(() => ({
   persistProfile: vi.fn(),
   axiosPost: vi.fn(),
   axiosRequest: vi.fn(),
+  selfHosted: false,
+  readiness: {
+    state: 'not_configured',
+    source: null,
+    hosted: true,
+    platformOffered: true,
+    automatedCreationAvailable: false,
+  },
 }));
 
 vi.mock('@alga-psa/auth/withAuth', () => ({
@@ -31,6 +39,14 @@ vi.mock('@alga-psa/core/secrets', () => ({
   })),
 }));
 
+vi.mock('@alga-psa/licensing', () => ({
+  isSelfHostLicensing: vi.fn(async () => hoisted.selfHosted),
+}));
+
+vi.mock('./providerReadiness', () => ({
+  getMicrosoftEmailSetupReadiness: vi.fn(async () => hoisted.readiness),
+}));
+
 vi.mock('../../utils/microsoftEmailSetupStateStore', () => ({
   consumeMicrosoftEmailSetupState: (...args: unknown[]) => hoisted.consumeState(...args),
   storeMicrosoftEmailSetupState: (...args: unknown[]) => hoisted.storeState(...args),
@@ -44,6 +60,7 @@ vi.mock('./microsoftActions', () => ({
     returnTo: 'https://psa.example.com/msp/settings/integrations?category=providers',
   })),
   createMicrosoftEmailProfilePendingConsentInternal: (...args: unknown[]) => hoisted.persistProfile(...args),
+  getMicrosoftEmailConsentProfileInternal: vi.fn(),
 }));
 
 vi.mock('axios', () => ({
@@ -59,6 +76,7 @@ import {
   createMicrosoftEmailApplication,
   getMicrosoftEmailSetupOptions,
   configureMicrosoftEmailPlatformApplication,
+  configureMicrosoftEmailManualApplication,
 } from './microsoftEmailSetupActions';
 
 function jwt(payload: Record<string, unknown>): string {
@@ -81,6 +99,7 @@ describe('Microsoft email setup actions', () => {
     });
     hoisted.axiosPost.mockReset();
     hoisted.axiosRequest.mockReset();
+    hoisted.selfHosted = false;
   });
 
   afterEach(() => {
@@ -93,6 +112,42 @@ describe('Microsoft email setup actions', () => {
   it('guards setup metadata with system settings update permission', async () => {
     hoisted.permission = false;
     await expect(getMicrosoftEmailSetupOptions()).resolves.toEqual({ success: false, error: 'Forbidden' });
+  });
+
+  it('rejects the platform application path on self-hosted deployments', async () => {
+    hoisted.selfHosted = true;
+
+    await expect(configureMicrosoftEmailPlatformApplication({
+      tenantId: '11111111-2222-4333-8444-555555555555',
+      displayName: 'Platform Email',
+    })).resolves.toEqual({
+      success: false,
+      error: 'The Alga PSA Microsoft app is available only on hosted deployments.',
+    });
+    expect(hoisted.persistProfile).not.toHaveBeenCalled();
+  });
+
+  it('persists a manual app and derives its administrator-consent callback server-side', async () => {
+    const result = await configureMicrosoftEmailManualApplication({
+      displayName: '  Customer   Email App  ',
+      clientId: 'manual-client-id',
+      clientSecret: 'manual-client-secret',
+      microsoftTenantId: '11111111-2222-4333-8444-555555555555',
+    });
+
+    expect(hoisted.persistProfile).toHaveBeenCalledWith(
+      hoisted.user,
+      'alga-tenant-1',
+      expect.objectContaining({
+        displayName: 'Customer Email App',
+        clientId: 'manual-client-id',
+        clientSecret: 'manual-client-secret',
+      })
+    );
+    expect(result.adminConsentUrl).toContain(encodeURIComponent(
+      'https://psa.example.com/api/auth/microsoft/email-setup/callback'
+    ));
+    expect(JSON.stringify(result)).not.toContain('manual-client-secret');
   });
 
   it('starts automated creation with one-time PKCE state and no verifier in the browser result', async () => {

--- a/packages/integrations/src/actions/integrations/microsoftEmailSetupActions.ts
+++ b/packages/integrations/src/actions/integrations/microsoftEmailSetupActions.ts
@@ -4,6 +4,7 @@ import axios, { type AxiosError } from 'axios';
 import { getSecretProviderInstance } from '@alga-psa/core/secrets';
 import { withAuth } from '@alga-psa/auth/withAuth';
 import { hasPermission } from '@alga-psa/auth/rbac';
+import { isSelfHostLicensing } from '@alga-psa/licensing';
 import {
   getMicrosoftAuthorizeUrl,
   getMicrosoftGraphBaseUrl,
@@ -26,8 +27,13 @@ import {
 } from '../../utils/microsoftEmailSetupStateStore';
 import {
   createMicrosoftEmailProfilePendingConsentInternal,
+  getMicrosoftEmailConsentProfileInternal,
   getMicrosoftEmailSetupMetadataInternal,
 } from './microsoftActions';
+import {
+  getMicrosoftEmailSetupReadiness,
+  type MicrosoftEmailSetupReadiness,
+} from './providerReadiness';
 
 interface PlatformMicrosoftCredentials {
   clientId: string;
@@ -58,6 +64,7 @@ interface GraphPasswordResult {
 export interface MicrosoftEmailSetupOptionsResult {
   success: boolean;
   error?: string;
+  emailSetup?: MicrosoftEmailSetupReadiness;
   callbackUri?: string;
   setupCallbackUri?: string;
   platformApplication?: {
@@ -254,47 +261,51 @@ function createAdminConsentState(input: {
 }
 
 export const getMicrosoftEmailSetupOptions = withAuth(async (
-  user
+  user,
+  { tenant }
 ): Promise<MicrosoftEmailSetupOptionsResult> => {
   if (!(await canManageMicrosoftSettings(user))) return { success: false, error: 'Forbidden' };
-  const [metadata, platformCredentials, bootstrapCredentials, signingSecret] = await Promise.all([
+  const [metadata, emailSetup, bootstrapCredentials, signingSecret] = await Promise.all([
     getMicrosoftEmailSetupMetadataInternal(),
-    resolvePlatformMicrosoftCredentials(),
+    getMicrosoftEmailSetupReadiness(tenant),
     resolveBootstrapMicrosoftCredentials(),
     getMicrosoftEmailSetupSigningSecret(),
   ]);
+  const automatedCreationAvailable = Boolean(bootstrapCredentials && signingSecret);
   return {
     success: true,
+    emailSetup: {
+      ...emailSetup,
+      automatedCreationAvailable,
+    },
     callbackUri: metadata.mailboxRedirectUri,
     setupCallbackUri: metadata.setupRedirectUri,
     platformApplication: {
-      available: Boolean(platformCredentials),
-      clientId: platformCredentials?.clientId,
+      available: emailSetup.platformOffered,
     },
-    automatedCreationAvailable: Boolean(bootstrapCredentials && signingSecret),
+    automatedCreationAvailable,
   };
 });
 
 export const getMicrosoftEmailAdminConsentUrl = withAuth(async (
   user,
   { tenant },
-  input: { tenantHint: string; profileId: string }
+  input: { tenantHint?: string; profileId: string }
 ): Promise<{ success: boolean; error?: string; url?: string }> => {
   if (!(await canManageMicrosoftSettings(user))) return { success: false, error: 'Forbidden' };
   try {
-    const [credentials, metadata, secret] = await Promise.all([
-      resolvePlatformMicrosoftCredentials(),
+    const [profile, metadata, secret] = await Promise.all([
+      getMicrosoftEmailConsentProfileInternal(tenant, input.profileId),
       getMicrosoftEmailSetupMetadataInternal(),
       getMicrosoftEmailSetupSigningSecret(),
     ]);
-    if (!credentials) return { success: false, error: 'The Alga platform Microsoft app is not configured.' };
     if (!secret) return { success: false, error: 'OAuth state signing is not configured on this server.' };
-    const microsoftTenant = validateMicrosoftTenantIdentifier(input.tenantHint);
+    const microsoftTenant = validateMicrosoftTenantIdentifier(input.tenantHint || profile.microsoftTenantId);
     const setupState = createAdminConsentState({
       algaTenant: tenant,
       userId: (user as any).user_id,
       returnTo: metadata.returnTo,
-      clientId: credentials.clientId,
+      clientId: profile.clientId,
       profileId: input.profileId,
       secret,
     });
@@ -302,7 +313,7 @@ export const getMicrosoftEmailAdminConsentUrl = withAuth(async (
       success: true,
       url: buildMicrosoftEmailAdminConsentUrl({
         tenant: microsoftTenant,
-        clientId: credentials.clientId,
+        clientId: profile.clientId,
         redirectUri: metadata.setupRedirectUri,
         state: setupState.token,
         loginBaseUrl: getMicrosoftLoginBaseUrl(),
@@ -320,6 +331,9 @@ export const configureMicrosoftEmailPlatformApplication = withAuth(async (
 ): Promise<MicrosoftEmailSetupCompletionResult> => {
   if (!(await canManageMicrosoftSettings(user))) return { success: false, error: 'Forbidden' };
   try {
+    if (await isSelfHostLicensing()) {
+      return { success: false, error: 'The Alga PSA Microsoft app is available only on hosted deployments.' };
+    }
     const [credentials, metadata, secret] = await Promise.all([
       resolvePlatformMicrosoftCredentials(),
       getMicrosoftEmailSetupMetadataInternal(),
@@ -334,14 +348,18 @@ export const configureMicrosoftEmailPlatformApplication = withAuth(async (
       clientSecret: credentials.clientSecret,
       tenantId: microsoftTenant,
     });
-    if (!profile.success) return profile;
+    if (!profile.success || !profile.profileId) {
+      return profile.success
+        ? { success: false, error: 'Microsoft app creation did not return a profile ID.' }
+        : profile;
+    }
 
     const setupState = createAdminConsentState({
       algaTenant: tenant,
       userId: (user as any).user_id,
       returnTo: metadata.returnTo,
       clientId: credentials.clientId,
-      profileId: profile.profileId!,
+      profileId: profile.profileId,
       secret,
     });
     return {
@@ -360,6 +378,70 @@ export const configureMicrosoftEmailPlatformApplication = withAuth(async (
     };
   } catch (error) {
     return { success: false, error: error instanceof Error ? error.message : 'Failed to configure the platform Microsoft app' };
+  }
+});
+
+export const configureMicrosoftEmailManualApplication = withAuth(async (
+  user,
+  { tenant },
+  input: {
+    displayName: string;
+    clientId: string;
+    clientSecret: string;
+    microsoftTenantId: string;
+  }
+): Promise<MicrosoftEmailSetupCompletionResult> => {
+  if (!(await canManageMicrosoftSettings(user))) return { success: false, error: 'Forbidden' };
+  try {
+    const displayName = input.displayName.normalize('NFKC').replace(/\s+/g, ' ').trim();
+    const clientId = input.clientId.normalize('NFKC').trim();
+    const clientSecret = input.clientSecret.trim();
+    if (!displayName || !clientId || !clientSecret) {
+      return { success: false, error: 'Display name, client ID, and client secret are required.' };
+    }
+
+    const microsoftTenantId = validateMicrosoftTenantIdentifier(input.microsoftTenantId);
+    const [metadata, secret] = await Promise.all([
+      getMicrosoftEmailSetupMetadataInternal(),
+      getMicrosoftEmailSetupSigningSecret(),
+    ]);
+    if (!secret) return { success: false, error: 'OAuth state signing is not configured on this server.' };
+
+    const profile = await createMicrosoftEmailProfilePendingConsentInternal(user, tenant, {
+      displayName,
+      clientId,
+      clientSecret,
+      tenantId: microsoftTenantId,
+    });
+    if (!profile.success) return profile;
+
+    const setupState = createAdminConsentState({
+      algaTenant: tenant,
+      userId: (user as any).user_id,
+      returnTo: metadata.returnTo,
+      clientId,
+      profileId: profile.profileId!,
+      secret,
+    });
+    return {
+      success: true,
+      profileId: profile.profileId,
+      displayName: profile.displayName,
+      tenantId: microsoftTenantId,
+      clientId,
+      adminConsentUrl: buildMicrosoftEmailAdminConsentUrl({
+        tenant: microsoftTenantId,
+        clientId,
+        redirectUri: metadata.setupRedirectUri,
+        state: setupState.token,
+        loginBaseUrl: getMicrosoftLoginBaseUrl(),
+      }),
+    };
+  } catch (error) {
+    return {
+      success: false,
+      error: error instanceof Error ? error.message : 'Failed to configure the Microsoft app',
+    };
   }
 });
 

--- a/packages/integrations/src/actions/integrations/providerReadiness.test.ts
+++ b/packages/integrations/src/actions/integrations/providerReadiness.test.ts
@@ -7,6 +7,7 @@ const getTenantSecretMock = vi.fn(async (tenant: string, key: string) => {
 });
 const resolveMicrosoftConsumerProfileConfigMock = vi.fn();
 const getMicrosoftPlatformCredentialAvailabilityMock = vi.fn();
+const isSelfHostLicensingMock = vi.fn();
 
 vi.mock('@alga-psa/core/secrets', () => ({
   getSecretProviderInstance: async () => ({
@@ -19,9 +20,13 @@ vi.mock('../../lib/microsoftConsumerProfileResolution', () => ({
   getMicrosoftPlatformCredentialAvailability: (...args: unknown[]) => getMicrosoftPlatformCredentialAvailabilityMock(...args),
 }));
 
+vi.mock('@alga-psa/licensing', () => ({
+  isSelfHostLicensing: (...args: unknown[]) => isSelfHostLicensingMock(...args),
+}));
+
 import {
   getGoogleProviderReadiness,
-  getMicrosoftEmailCredentialCapability,
+  getMicrosoftEmailSetupReadiness,
   getMicrosoftProfileReadiness,
   getMicrosoftProviderReadiness,
 } from './providerReadiness';
@@ -32,6 +37,7 @@ describe('provider readiness helpers', () => {
     getTenantSecretMock.mockClear();
     resolveMicrosoftConsumerProfileConfigMock.mockReset();
     getMicrosoftPlatformCredentialAvailabilityMock.mockReset();
+    isSelfHostLicensingMock.mockReset().mockResolvedValue(false);
     getMicrosoftPlatformCredentialAvailabilityMock.mockResolvedValue({
       ready: false,
       clientIdConfigured: false,
@@ -108,8 +114,11 @@ describe('provider readiness helpers', () => {
     });
   });
 
-  it('reports platform credentials as the safe default source without returning secret values', async () => {
-    resolveMicrosoftConsumerProfileConfigMock.mockResolvedValue({
+  it('offers platform setup without treating application secrets as organization approval', async () => {
+    resolveMicrosoftConsumerProfileConfigMock.mockResolvedValueOnce({
+      status: 'not_configured', tenantId: 'tenant-1', consumerType: 'email',
+      message: 'Email Microsoft profile binding is not configured',
+    }).mockResolvedValueOnce({
       status: 'ready', tenantId: 'tenant-1', consumerType: 'email',
       clientId: 'platform-client-id', clientSecret: 'platform-client-secret',
       microsoftTenantId: 'common', credentialSource: 'app',
@@ -118,10 +127,28 @@ describe('provider readiness helpers', () => {
       ready: true, clientIdConfigured: true, clientSecretConfigured: true, tenantIdConfigured: false,
     });
 
-    await expect(getMicrosoftEmailCredentialCapability('tenant-1')).resolves.toEqual({
-      ready: true, source: 'platform', platformReady: true, tenantProfileSelected: false,
-      clientIdConfigured: true, clientSecretConfigured: true, tenantIdConfigured: true,
-      profileId: undefined, message: undefined,
+    await expect(getMicrosoftEmailSetupReadiness('tenant-1')).resolves.toEqual({
+      state: 'not_configured', source: null, hosted: true, platformOffered: true,
+      automatedCreationAvailable: false,
+      profileId: undefined, message: 'Email Microsoft profile binding is not configured',
+    });
+  });
+
+  it('recognizes an approved profile created from the platform app', async () => {
+    resolveMicrosoftConsumerProfileConfigMock.mockResolvedValueOnce({
+      status: 'ready', tenantId: 'tenant-1', consumerType: 'email',
+      profileId: 'profile-platform', clientId: 'platform-client-id',
+      clientSecret: 'profile-secret', microsoftTenantId: 'microsoft-directory-id',
+      credentialSource: 'binding',
+    }).mockResolvedValueOnce({
+      status: 'ready', tenantId: 'tenant-1', consumerType: 'email',
+      clientId: 'platform-client-id', clientSecret: 'platform-client-secret',
+      microsoftTenantId: 'common', credentialSource: 'app',
+    });
+    getMicrosoftPlatformCredentialAvailabilityMock.mockResolvedValue({ ready: true });
+
+    await expect(getMicrosoftEmailSetupReadiness('tenant-1')).resolves.toMatchObject({
+      state: 'ready', source: 'platform', profileId: 'profile-platform', platformOffered: true,
     });
   });
 
@@ -134,8 +161,8 @@ describe('provider readiness helpers', () => {
       ready: true, clientIdConfigured: true, clientSecretConfigured: true, tenantIdConfigured: true,
     });
 
-    await expect(getMicrosoftEmailCredentialCapability('tenant-1')).resolves.toMatchObject({
-      ready: false, source: 'tenant', platformReady: true, tenantProfileSelected: true, profileId: 'profile-1',
+    await expect(getMicrosoftEmailSetupReadiness('tenant-1')).resolves.toMatchObject({
+      state: 'not_configured', source: 'tenant_app', platformOffered: true, profileId: 'profile-1',
     });
   });
 
@@ -148,13 +175,50 @@ describe('provider readiness helpers', () => {
       ready: false, clientIdConfigured: true, clientSecretConfigured: false, tenantIdConfigured: false,
     });
 
-    const capability = await getMicrosoftEmailCredentialCapability('tenant-1');
+    const capability = await getMicrosoftEmailSetupReadiness('tenant-1');
     expect(capability).toEqual({
-      ready: false, source: 'none', platformReady: false, tenantProfileSelected: false,
-      clientIdConfigured: true, clientSecretConfigured: false, tenantIdConfigured: false,
+      state: 'not_configured', source: null, hosted: true, platformOffered: false,
+      automatedCreationAvailable: false,
       profileId: undefined, message: 'Email Microsoft profile binding is not configured',
     });
     expect(capability).not.toHaveProperty('clientId');
     expect(capability).not.toHaveProperty('clientSecret');
+  });
+
+  it('reports pending Microsoft 365 administrator approval explicitly', async () => {
+    resolveMicrosoftConsumerProfileConfigMock.mockResolvedValue({
+      status: 'pending_admin_consent',
+      tenantId: 'tenant-1',
+      consumerType: 'email',
+      profileId: 'profile-pending',
+      credentialSource: 'binding',
+    });
+
+    await expect(getMicrosoftEmailSetupReadiness('tenant-1')).resolves.toMatchObject({
+      state: 'pending_admin_consent',
+      source: 'tenant_app',
+      profileId: 'profile-pending',
+    });
+  });
+
+  it('never offers the Alga PSA app on a self-hosted deployment', async () => {
+    isSelfHostLicensingMock.mockResolvedValue(true);
+    resolveMicrosoftConsumerProfileConfigMock.mockResolvedValue({
+      status: 'not_configured',
+      tenantId: 'tenant-1',
+      consumerType: 'email',
+    });
+    getMicrosoftPlatformCredentialAvailabilityMock.mockResolvedValue({ ready: true });
+
+    await expect(getMicrosoftEmailSetupReadiness('tenant-1')).resolves.toMatchObject({
+      hosted: false,
+      platformOffered: false,
+      state: 'not_configured',
+    });
+    expect(resolveMicrosoftConsumerProfileConfigMock).toHaveBeenCalledWith(
+      'tenant-1',
+      'email',
+      { credentialPreference: 'tenant' },
+    );
   });
 });

--- a/packages/integrations/src/actions/integrations/providerReadiness.ts
+++ b/packages/integrations/src/actions/integrations/providerReadiness.ts
@@ -1,6 +1,7 @@
 'use server';
 
 import { getSecretProviderInstance } from '@alga-psa/core/secrets';
+import { isSelfHostLicensing } from '@alga-psa/licensing';
 import {
   getMicrosoftPlatformCredentialAvailability,
   resolveMicrosoftConsumerProfileConfig,
@@ -19,16 +20,15 @@ export interface ProviderReadinessResult {
   active?: boolean;
 }
 
-export type MicrosoftCredentialCapabilitySource = 'tenant' | 'platform' | 'none';
+export type MicrosoftEmailSetupState = 'not_configured' | 'pending_admin_consent' | 'ready';
+export type MicrosoftEmailSetupSource = 'platform' | 'tenant_app' | null;
 
-export interface MicrosoftCredentialCapability {
-  ready: boolean;
-  source: MicrosoftCredentialCapabilitySource;
-  platformReady: boolean;
-  tenantProfileSelected: boolean;
-  clientIdConfigured: boolean;
-  clientSecretConfigured: boolean;
-  tenantIdConfigured: boolean;
+export interface MicrosoftEmailSetupReadiness {
+  state: MicrosoftEmailSetupState;
+  source: MicrosoftEmailSetupSource;
+  hosted: boolean;
+  platformOffered: boolean;
+  automatedCreationAvailable: boolean;
   profileId?: string | null;
   message?: string;
 }
@@ -57,32 +57,42 @@ export async function getMicrosoftProviderReadiness(tenant: string): Promise<Pro
   };
 }
 
-export async function getMicrosoftEmailCredentialCapability(
+export async function getMicrosoftEmailSetupReadiness(
   tenant: string
-): Promise<MicrosoftCredentialCapability> {
-  const [resolution, platform] = await Promise.all([
-    resolveMicrosoftConsumerProfileConfig(tenant, 'email'),
+): Promise<MicrosoftEmailSetupReadiness> {
+  const hosted = !(await isSelfHostLicensing());
+  const [resolution, platform, platformResolution] = await Promise.all([
+    resolveMicrosoftConsumerProfileConfig(
+      tenant,
+      'email',
+      { credentialPreference: 'tenant' }
+    ),
     getMicrosoftPlatformCredentialAvailability(),
+    hosted
+      ? resolveMicrosoftConsumerProfileConfig(tenant, 'email', { credentialPreference: 'platform' })
+      : Promise.resolve(null),
   ]);
 
-  const source: MicrosoftCredentialCapabilitySource = resolution.credentialSource === 'binding'
-    || (resolution.profileId && resolution.status !== 'ready')
-    ? 'tenant'
-    : resolution.credentialSource === 'app'
-      ? 'platform'
-      : 'none';
-  const ready = resolution.status === 'ready';
+  const source: MicrosoftEmailSetupSource = resolution.credentialSource === 'binding'
+    || Boolean(resolution.profileId)
+    ? platformResolution?.status === 'ready'
+      && Boolean(resolution.clientId)
+      && resolution.clientId === platformResolution.clientId
+        ? 'platform'
+        : 'tenant_app'
+    : null;
+  const state: MicrosoftEmailSetupState = resolution.status === 'pending_admin_consent'
+    ? 'pending_admin_consent'
+    : resolution.status === 'ready' && source
+      ? 'ready'
+      : 'not_configured';
 
   return {
-    ready,
+    state,
     source,
-    platformReady: platform.ready,
-    tenantProfileSelected: source === 'tenant',
-    clientIdConfigured: ready ? Boolean(resolution.clientId) : source === 'none' && platform.clientIdConfigured,
-    clientSecretConfigured: ready ? Boolean(resolution.clientSecret) : source === 'none' && platform.clientSecretConfigured,
-    tenantIdConfigured: ready
-      ? Boolean(resolution.microsoftTenantId)
-      : source === 'none' && platform.tenantIdConfigured,
+    hosted,
+    platformOffered: hosted && platform.ready,
+    automatedCreationAvailable: false,
     profileId: resolution.profileId,
     message: resolution.message,
   };

--- a/packages/integrations/src/components/email/EmailProviderConfiguration.resync.test.tsx
+++ b/packages/integrations/src/components/email/EmailProviderConfiguration.resync.test.tsx
@@ -31,7 +31,7 @@ vi.mock('@alga-psa/user-composition/actions', () => ({
 vi.mock('@alga-psa/integrations/actions', () => ({
   getMicrosoftConsumerSetupStatus: vi.fn().mockResolvedValue({
     success: true,
-    credentialCapability: null,
+    emailSetup: null,
   }),
 }));
 

--- a/packages/integrations/src/components/email/EmailProviderConfiguration.tsx
+++ b/packages/integrations/src/components/email/EmailProviderConfiguration.tsx
@@ -6,10 +6,10 @@
 'use client';
 
 import React, { useState, useEffect, useRef } from 'react';
-import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@alga-psa/ui/components/Card';
+import { Card, CardContent, CardHeader, CardTitle } from '@alga-psa/ui/components/Card';
 import { Button } from '@alga-psa/ui/components/Button';
 import { Alert, AlertDescription } from '@alga-psa/ui/components/Alert';
-import { AlertTriangle, Plus, ShieldCheck } from 'lucide-react';
+import { Plus } from 'lucide-react';
 import toast from 'react-hot-toast';
 import {
   getErrorMessage,
@@ -45,7 +45,7 @@ import {
 } from './types';
 import { isMicrosoftConsumerEnterpriseEdition } from '../../lib/microsoftConsumerVisibility';
 import { getMicrosoftConsumerSetupStatus } from '@alga-psa/integrations/actions';
-import type { MicrosoftCredentialCapability } from '../../actions/integrations/providerReadiness';
+import type { MicrosoftEmailSetupReadiness } from '../../actions/integrations/providerReadiness';
 
 const IMAP_RESYNC_FAST_POLL_INTERVAL_MS = 5_000;
 const IMAP_RESYNC_FAST_POLL_DURATION_MS = 120_000;
@@ -93,7 +93,7 @@ function EmailProviderConfigurationContent({
   const [activeSection, setActiveSection] = useState<'providers' | 'defaults' | 'rules'>('providers');
   const [diagnosticsOpen, setDiagnosticsOpen] = useState(false);
   const [diagnosticsProvider, setDiagnosticsProvider] = useState<EmailProvider | null>(null);
-  const [microsoftCredentialCapability, setMicrosoftCredentialCapability] = useState<MicrosoftCredentialCapability | null | undefined>(undefined);
+  const [microsoftEmailSetup, setMicrosoftEmailSetup] = useState<MicrosoftEmailSetupReadiness | null | undefined>(undefined);
   const [reconnectingProviderIds, setReconnectingProviderIds] = useState<Set<string>>(new Set());
   const resyncPollsRef = useRef<Map<string, ImapResyncPoll>>(new Map());
   const nextResyncGenerationRef = useRef(0);
@@ -108,16 +108,16 @@ function EmailProviderConfigurationContent({
   useEffect(() => {
     if (!isEnterpriseEdition) return;
 
-    const loadMicrosoftCredentialCapability = async () => {
+    const loadMicrosoftEmailSetup = async () => {
       try {
         const result = await getMicrosoftConsumerSetupStatus('email');
-        setMicrosoftCredentialCapability(result.success ? result.credentialCapability || null : null);
+        setMicrosoftEmailSetup(result.success ? result.emailSetup || null : null);
       } catch {
-        setMicrosoftCredentialCapability(null);
+        setMicrosoftEmailSetup(null);
       }
     };
 
-    loadMicrosoftCredentialCapability();
+    loadMicrosoftEmailSetup();
   }, [isEnterpriseEdition]);
 
   useEffect(() => {
@@ -449,7 +449,7 @@ function EmailProviderConfigurationContent({
               provider={provider}
               onSuccess={(p) => { handleProviderUpdated(p); closeDrawer(); }}
               onCancel={handleEditCancel}
-              credentialCapability={microsoftCredentialCapability}
+              emailSetup={microsoftEmailSetup}
             />
           )}
           {provider.providerType === 'google' && (
@@ -573,67 +573,22 @@ function EmailProviderConfigurationContent({
           </CardHeader>
           <CardContent className="space-y-4">
             {isEnterpriseEdition && (
-              <div className="space-y-3">
+              <div className="space-y-2">
                 <h4 className="font-medium mb-2">{t('configuration.setup.microsoft.title', {
                   defaultValue: 'Microsoft 365 Setup',
                 })}</h4>
-                {microsoftCredentialCapability === undefined ? (
-                  <p className="text-sm text-muted-foreground">
-                    {t('configuration.setup.microsoft.checkingCredentials', { defaultValue: 'Checking Microsoft credential availability…' })}
-                  </p>
-                ) : microsoftCredentialCapability?.source === 'platform' ? (
-                  <>
-                    <Alert>
-                      <ShieldCheck className="h-4 w-4" />
-                      <AlertDescription>
-                        <div className="font-medium">{t('configuration.setup.microsoft.platform.title', { defaultValue: 'Microsoft sign-in is ready' })}</div>
-                        <div className="text-sm text-muted-foreground">
-                          {t('configuration.setup.microsoft.platform.description', { defaultValue: 'Alga PSA supplies the Microsoft application. Add a provider, enter the mailbox details, and connect with Microsoft—no Entra app registration is needed.' })}
-                        </div>
-                      </AlertDescription>
-                    </Alert>
-                    <details className="rounded-md border px-3 py-2 text-sm">
-                      <summary id="microsoft-byo-setup-summary" className="cursor-pointer font-medium">
-                        {t('configuration.setup.microsoft.byo.summary', { defaultValue: 'Advanced: use your own Microsoft app' })}
-                      </summary>
-                      <div className="mt-2 space-y-2 text-muted-foreground">
-                        <p className="text-[rgb(var(--badge-warning-text))]">
-                          {t('configuration.setup.microsoft.byo.warning', { defaultValue: 'This is normally unnecessary on hosted Alga PSA and should be used only when your organization requires its own Entra application.' })}
-                        </p>
-                        <p>{t('configuration.setup.microsoft.byo.description', { defaultValue: 'Open Settings → Integrations → Providers, expand the Microsoft advanced options, and add your tenant-owned app before returning here.' })}</p>
-                      </div>
-                    </details>
-                  </>
-                ) : microsoftCredentialCapability?.source === 'tenant' ? (
-                  <Alert variant={microsoftCredentialCapability.ready ? 'default' : 'warning'}>
-                    {microsoftCredentialCapability.ready ? <ShieldCheck className="h-4 w-4" /> : <AlertTriangle className="h-4 w-4" />}
-                    <AlertDescription>
-                      <div className="font-medium">
-                        {microsoftCredentialCapability.ready
-                          ? t('configuration.setup.microsoft.tenant.title', { defaultValue: 'Your organization’s Microsoft app is selected' })
-                          : t('configuration.setup.microsoft.tenant.incompleteTitle', { defaultValue: 'Your Microsoft app needs attention' })}
-                      </div>
-                      <div className="text-sm text-muted-foreground">
-                        {microsoftCredentialCapability.ready
-                          ? t('configuration.setup.microsoft.tenant.description', { defaultValue: 'New Microsoft mailboxes will use the tenant-owned app selected in Providers settings. This choice is preserved even when platform credentials are available.' })
-                          : microsoftCredentialCapability.message || t('configuration.setup.microsoft.tenant.incompleteDescription', { defaultValue: 'Finish configuring the Microsoft app selected in Providers settings before connecting a mailbox.' })}
-                      </div>
-                    </AlertDescription>
-                  </Alert>
-                ) : (
-                  <Alert variant="warning">
-                    <AlertTriangle className="h-4 w-4" />
-                    <AlertDescription>
-                      <p>{t('configuration.setup.microsoft.manualRequired', { defaultValue: 'Platform Microsoft credentials are unavailable in this deployment. Configure your own Microsoft app to connect a mailbox.' })}</p>
-                      <p className="mt-2 text-sm text-muted-foreground">
-                        1. {t('configuration.setup.microsoft.steps.registerApp', { defaultValue: 'Register an application in Azure AD' })}<br/>
-                        2. {t('configuration.setup.microsoft.steps.permissions', { defaultValue: 'Configure API permissions for Mail.Read' })}<br/>
-                        3. {t('configuration.setup.microsoft.steps.redirectUrl', { defaultValue: 'Set up the redirect URL in your app registration' })}<br/>
-                        4. {t('configuration.setup.microsoft.steps.credentials', { defaultValue: 'Use the Client ID and Client Secret in the form above' })}
-                      </p>
-                    </AlertDescription>
-                  </Alert>
-                )}
+                <p className="text-sm text-muted-foreground">
+                  {t('configuration.setup.microsoft.providersPointer', { defaultValue: 'Microsoft app setup is managed in Providers.' })}
+                </p>
+                <Button
+                  id="open-microsoft-providers-settings-button"
+                  type="button"
+                  variant="link"
+                  className="h-auto p-0"
+                  onClick={() => window.location.assign('/msp/settings/integrations?category=providers')}
+                >
+                  {t('configuration.setup.microsoft.openProviders', { defaultValue: 'Open Providers' })}
+                </Button>
               </div>
             )}
             <div>
@@ -739,7 +694,7 @@ function EmailProviderConfigurationContent({
               onClose={() => setWizardOpen(false)}
               onComplete={async (provider) => { onProviderAdded?.(provider); setWizardOpen(false); await loadProviders(); }}
               tenant={tenant}
-              microsoftCredentialCapability={microsoftCredentialCapability}
+              microsoftEmailSetup={microsoftEmailSetup}
             />
             <Microsoft365DiagnosticsDialog
               isOpen={diagnosticsOpen}

--- a/packages/integrations/src/components/email/MicrosoftProviderForm.tsx
+++ b/packages/integrations/src/components/email/MicrosoftProviderForm.tsx
@@ -16,13 +16,12 @@ import { Switch } from '@alga-psa/ui/components/Switch';
 import { Alert, AlertDescription } from '@alga-psa/ui/components/Alert';
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@alga-psa/ui/components/Card';
 import { useTranslation } from '@alga-psa/ui/lib/i18n/client';
-import { AlertTriangle, CheckCircle, ChevronDown, ChevronRight, ExternalLink, ShieldCheck } from 'lucide-react';
+import { CheckCircle } from 'lucide-react';
 import type { EmailProvider } from './types';
 import {
   createEmailProvider,
   updateEmailProvider,
   upsertEmailProvider,
-  getMicrosoftConsumerSetupStatus,
   initiateEmailOAuth,
 } from '@alga-psa/integrations/actions';
 import CustomSelect from '@alga-psa/ui/components/CustomSelect';
@@ -31,14 +30,12 @@ import {
   getErrorMessage,
   isActionMessageError,
 } from '@alga-psa/ui/lib/errorHandling';
-import type { MicrosoftCredentialCapability } from '../../actions/integrations/providerReadiness';
-import type { MicrosoftCredentialPreference } from '../../lib/microsoftConsumerProfileResolution';
+import type { MicrosoftEmailSetupReadiness } from '../../actions/integrations/providerReadiness';
 
 type MicrosoftProviderFormData = {
   providerName: string;
   senderDisplayName?: string;
   mailbox: string;
-  redirectUri: string;
   isActive: boolean;
   autoProcessEmails: boolean;
   folderFilters?: string;
@@ -51,7 +48,7 @@ export interface MicrosoftProviderFormProps {
   provider?: EmailProvider;
   onSuccess: (provider: EmailProvider) => void;
   onCancel: () => void;
-  credentialCapability?: MicrosoftCredentialCapability | null;
+  emailSetup?: MicrosoftEmailSetupReadiness | null;
 }
 
 export function MicrosoftProviderForm({ 
@@ -59,33 +56,19 @@ export function MicrosoftProviderForm({
   provider, 
   onSuccess, 
   onCancel,
-  credentialCapability,
+  emailSetup,
 }: MicrosoftProviderFormProps) {
   const { t } = useTranslation('msp/email-providers');
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
-  const [resolvedCredentialCapability, setResolvedCredentialCapability] = useState<MicrosoftCredentialCapability | null>(credentialCapability ?? null);
-  const [providerSetupLoading, setProviderSetupLoading] = useState(credentialCapability === undefined);
-  const [useByoApp, setUseByoApp] = useState(false);
-  const credentialChoiceInitializedRef = useRef(false);
   const [oauthStatus, setOauthStatus] = useState<'idle' | 'authorizing' | 'success' | 'error'>('idle');
-  const [oauthMessageReceived, setOauthMessageReceived] = useState(false);
+  const oauthCompletedRef = useRef(false);
+  const oauthCleanupRef = useRef<(() => void) | null>(null);
   const [hasAttemptedSubmit, setHasAttemptedSubmit] = useState(false);
   const [defaultsOptions, setDefaultsOptions] = useState<{ value: string; label: string }[]>([]);
 
   const isEditing = !!provider;
-  const activeCredentialCapability = credentialCapability !== undefined
-    ? credentialCapability
-    : resolvedCredentialCapability;
-  const selectedCredentialSource: MicrosoftCredentialPreference = useByoApp ? 'tenant' : 'platform';
-  const providerSetupReady = selectedCredentialSource === 'tenant'
-    ? activeCredentialCapability?.source === 'tenant' && activeCredentialCapability.ready
-    : Boolean(activeCredentialCapability?.platformReady);
-  const providerSetupMessage = selectedCredentialSource === 'tenant'
-    ? activeCredentialCapability?.message || null
-    : activeCredentialCapability?.platformReady
-      ? null
-      : t('forms.microsoft.hostedOauth.platformNotConfigured', { defaultValue: 'Platform Microsoft credentials are unavailable.' });
+  const providerSetupReady = emailSetup?.state === 'ready';
 
   const microsoftProviderSchema = z.object({
     providerName: z.string().min(1, t('forms.microsoft.validation.providerNameRequired', { defaultValue: 'Configuration name is required' })),
@@ -99,7 +82,6 @@ export function MicrosoftProviderForm({
       })
       .optional(),
     mailbox: z.string().email(t('forms.microsoft.validation.emailRequired', { defaultValue: 'Valid email address is required' })),
-    redirectUri: z.string().url(t('forms.microsoft.validation.redirectRequired', { defaultValue: 'Valid redirect URI is required' })),
     isActive: z.boolean(),
     autoProcessEmails: z.boolean(),
     folderFilters: z.string().optional(),
@@ -108,20 +90,18 @@ export function MicrosoftProviderForm({
   });
 
   const form = useForm<MicrosoftProviderFormData>({
-    resolver: zodResolver(microsoftProviderSchema) as any,
+    resolver: zodResolver(microsoftProviderSchema),
     defaultValues: provider && provider.microsoftConfig ? {
       providerName: provider.providerName,
       senderDisplayName: provider.senderDisplayName || '',
       mailbox: provider.mailbox,
-      redirectUri: provider.microsoftConfig.redirect_uri,
       isActive: provider.isActive,
       autoProcessEmails: provider.microsoftConfig.auto_process_emails ?? true,
       folderFilters: provider.microsoftConfig.folder_filters?.join(', ') || '',
       maxEmailsPerSync: provider.microsoftConfig.max_emails_per_sync ?? 50,
-      inboundTicketDefaultsId: (provider as any).inboundTicketDefaultsId || undefined
+      inboundTicketDefaultsId: provider.inboundTicketDefaultsId || undefined
     } : {
       senderDisplayName: '',
-      redirectUri: `${window.location.origin}/api/auth/microsoft/callback`,
       isActive: true,
       autoProcessEmails: true,
       folderFilters: '',
@@ -143,41 +123,11 @@ export function MicrosoftProviderForm({
     };
     loadDefaults();
     const onUpdate = () => loadDefaults();
-    window.addEventListener('inbound-defaults-updated', onUpdate as any);
-    return () => window.removeEventListener('inbound-defaults-updated', onUpdate as any);
+    window.addEventListener('inbound-defaults-updated', onUpdate);
+    return () => window.removeEventListener('inbound-defaults-updated', onUpdate);
   }, []);
 
-  React.useEffect(() => {
-    if (credentialCapability !== undefined) {
-      setProviderSetupLoading(false);
-      return;
-    }
-
-    const loadProviderSetupStatus = async () => {
-      try {
-        const res = await getMicrosoftConsumerSetupStatus('email');
-        setResolvedCredentialCapability(res.success ? res.credentialCapability || null : null);
-      } catch {
-        setResolvedCredentialCapability(null);
-      } finally {
-        setProviderSetupLoading(false);
-      }
-    };
-    loadProviderSetupStatus();
-  }, [credentialCapability]);
-
-  React.useEffect(() => {
-    if (credentialChoiceInitializedRef.current || providerSetupLoading) return;
-
-    credentialChoiceInitializedRef.current = true;
-    if (provider?.microsoftConfig?.microsoft_profile_id) {
-      setUseByoApp(true);
-    } else if (provider?.microsoftConfig && provider.microsoftConfig.microsoft_profile_id === null) {
-      setUseByoApp(false);
-    } else {
-      setUseByoApp(activeCredentialCapability?.source !== 'platform');
-    }
-  }, [activeCredentialCapability, provider, providerSetupLoading]);
+  React.useEffect(() => () => oauthCleanupRef.current?.(), []);
 
   
 
@@ -202,12 +152,10 @@ export function MicrosoftProviderForm({
         mailbox: data.mailbox,
         isActive: data.isActive,
         inboundTicketDefaultsId: data.inboundTicketDefaultsId,
-        microsoftCredentialSource: selectedCredentialSource,
         microsoftConfig: {
           client_id: '',
           client_secret: '',
           tenant_id: '',
-          redirect_uri: data.redirectUri,
           auto_process_emails: data.autoProcessEmails,
           folder_filters: data.folderFilters ? data.folderFilters.split(',').map(f => f.trim()) : ['Inbox'],
           max_emails_per_sync: data.maxEmailsPerSync
@@ -258,13 +206,11 @@ export function MicrosoftProviderForm({
           senderDisplayName: formData.senderDisplayName?.trim() || null,
           mailbox: formData.mailbox,
           isActive: formData.isActive,
-          inboundTicketDefaultsId: (form.getValues() as any).inboundTicketDefaultsId || undefined,
-          microsoftCredentialSource: selectedCredentialSource,
+          inboundTicketDefaultsId: formData.inboundTicketDefaultsId || undefined,
           microsoftConfig: {
             client_id: '',
             client_secret: '',
             tenant_id: '',
-            redirect_uri: formData.redirectUri,
             auto_process_emails: formData.autoProcessEmails,
             folder_filters: formData.folderFilters && formData.folderFilters.trim() ? formData.folderFilters.split(',').map(f => f.trim()) : ['INBOX'],
             max_emails_per_sync: formData.maxEmailsPerSync
@@ -281,9 +227,7 @@ export function MicrosoftProviderForm({
       // Get OAuth URL via server action
       const oauthInit = await initiateEmailOAuth({
         provider: 'microsoft',
-        redirectUri: formData.redirectUri,
         providerId: providerId,
-        microsoftCredentialSource: selectedCredentialSource,
       });
       if (!oauthInit.success) {
         throw new Error((oauthInit as { success: false; error: string }).error || t('forms.microsoft.validation.oauthInitiateFailed', { defaultValue: 'Failed to initiate OAuth' }));
@@ -301,11 +245,14 @@ export function MicrosoftProviderForm({
         throw new Error(t('forms.microsoft.validation.popupBlocked', { defaultValue: 'Failed to open OAuth popup. Please allow popups for this site.' }));
       }
 
+      oauthCleanupRef.current?.();
+      oauthCompletedRef.current = false;
+
       // Monitor popup for completion
       const checkClosed = setInterval(() => {
         if (popup.closed) {
-          clearInterval(checkClosed);
-          if (oauthStatus === 'authorizing' && !oauthMessageReceived) {
+          oauthCleanupRef.current?.();
+          if (!oauthCompletedRef.current) {
             setOauthStatus('error');
             setError(t('forms.microsoft.validation.closedEarly', { defaultValue: 'Authorization window closed before completing. Please try again.' }));
           }
@@ -315,10 +262,14 @@ export function MicrosoftProviderForm({
       // Listen for OAuth callback
       const messageHandler = (event: MessageEvent) => {
         // Validate message is from our callback
-        if (event.data.type === 'oauth-callback' && event.data.provider === 'microsoft') {
-          clearInterval(checkClosed);
+        if (
+          event.origin === window.location.origin &&
+          event.data.type === 'oauth-callback' &&
+          event.data.provider === 'microsoft'
+        ) {
+          oauthCompletedRef.current = true;
+          oauthCleanupRef.current?.();
           popup?.close();
-          setOauthMessageReceived(true);
           
           if (event.data.success) {
             setOauthStatus('success');
@@ -327,11 +278,15 @@ export function MicrosoftProviderForm({
             setError(event.data.errorDescription || event.data.error || t('forms.microsoft.validation.authorizationFailed', { defaultValue: 'Authorization failed' }));
           }
           
-          window.removeEventListener('message', messageHandler);
         }
       };
 
       window.addEventListener('message', messageHandler);
+      oauthCleanupRef.current = () => {
+        clearInterval(checkClosed);
+        window.removeEventListener('message', messageHandler);
+        oauthCleanupRef.current = null;
+      };
 
     } catch (err) {
       setOauthStatus('error');
@@ -341,7 +296,7 @@ export function MicrosoftProviderForm({
   };
 
   return (
-    <form onSubmit={form.handleSubmit(onSubmit as any)} className="space-y-6">
+    <form onSubmit={form.handleSubmit(onSubmit)} className="space-y-6">
       {/* Error Display (moved to top for visibility) */}
       {hasAttemptedSubmit && Object.keys(form.formState.errors).length > 0 && (
         <Alert variant="destructive">
@@ -350,7 +305,6 @@ export function MicrosoftProviderForm({
             <ul className="list-disc list-inside space-y-1">
               {form.formState.errors.providerName && <li>{t('forms.microsoft.requiredFields.providerName', { defaultValue: 'Configuration Name' })}</li>}
               {form.formState.errors.mailbox && <li>{t('forms.microsoft.requiredFields.emailAddress', { defaultValue: 'Email Address' })}</li>}
-              {form.formState.errors.redirectUri && <li>{t('forms.microsoft.requiredFields.redirectUri', { defaultValue: 'Redirect URI' })}</li>}
             </ul>
           </AlertDescription>
         </Alert>
@@ -371,20 +325,20 @@ export function MicrosoftProviderForm({
           </CardDescription>
         </CardHeader>
         <CardContent className="space-y-4">
-          <div className="grid grid-cols-2 gap-4">
+          <div className="grid grid-cols-1 gap-4 md:grid-cols-2">
             <div className="space-y-2">
               <Label htmlFor="providerName">{t('forms.microsoft.basic.providerNameLabel', { defaultValue: 'Configuration Name *' })}</Label>
               <Input
                 id="providerName"
                 {...form.register('providerName')}
                 placeholder={t('forms.microsoft.basic.providerNamePlaceholder', { defaultValue: 'e.g., Support Mailbox (internal)' })}
-                className={hasAttemptedSubmit && form.formState.errors.providerName ? 'border-red-500' : ''}
+                className={hasAttemptedSubmit && form.formState.errors.providerName ? 'border-destructive' : ''}
               />
               <p className="text-xs text-muted-foreground">
                 {t('forms.microsoft.basic.providerNameHelp', { defaultValue: 'Internal name used to identify this configuration. Not shown in outbound emails.' })}
               </p>
               {form.formState.errors.providerName && (
-                <p className="text-sm text-red-500">{form.formState.errors.providerName.message}</p>
+                <p className="text-sm text-destructive">{form.formState.errors.providerName.message}</p>
               )}
             </div>
 
@@ -395,10 +349,10 @@ export function MicrosoftProviderForm({
                 type="email"
                 {...form.register('mailbox')}
                 placeholder={t('forms.microsoft.basic.emailPlaceholder', { defaultValue: 'support@client.com' })}
-                className={hasAttemptedSubmit && form.formState.errors.mailbox ? 'border-red-500' : ''}
+                className={hasAttemptedSubmit && form.formState.errors.mailbox ? 'border-destructive' : ''}
               />
               {form.formState.errors.mailbox && (
-                <p className="text-sm text-red-500">{form.formState.errors.mailbox.message}</p>
+                <p className="text-sm text-destructive">{form.formState.errors.mailbox.message}</p>
               )}
             </div>
           </div>
@@ -411,7 +365,7 @@ export function MicrosoftProviderForm({
               placeholder={t('forms.microsoft.basic.senderDisplayNamePlaceholder', { defaultValue: 'e.g., Acme Support' })}
             />
             <p className="text-xs text-muted-foreground">
-              {t('forms.microsoft.basic.senderDisplayNameHelp', { defaultValue: 'Display name shown in the From header on outbound ticket emails (replies, closures). Applied only when this mailbox matches the tenant\'s outbound ticketing-from address. Leave blank to fall back to the ticket\'s board name.' })}
+              {t('forms.microsoft.basic.senderDisplayNameHelp', { defaultValue: 'Display name shown in the From header on outbound ticket emails. It applies when this mailbox matches the configured outbound ticketing address. Leave blank to use the ticket board name.' })}
             </p>
           </div>
 
@@ -447,7 +401,7 @@ export function MicrosoftProviderForm({
         <CustomSelect
           id="microsoft-inbound-defaults-select"
           label={t('forms.common.ticketDefaults.label', { defaultValue: 'Inbound Ticket Defaults' })}
-          value={(form.watch('inboundTicketDefaultsId') as any) || ''}
+          value={form.watch('inboundTicketDefaultsId') || ''}
           onValueChange={(v) => form.setValue('inboundTicketDefaultsId', v || undefined)}
           options={defaultsOptions}
           placeholder={t('forms.common.ticketDefaults.placeholder', { defaultValue: 'Select defaults (optional)' })}
@@ -465,156 +419,67 @@ export function MicrosoftProviderForm({
       <Card>
         <CardHeader>
           <CardTitle>{t('forms.microsoft.hostedOauth.sectionTitle', { defaultValue: 'Connect Microsoft 365' })}</CardTitle>
-          <CardDescription>
-            {useByoApp
-              ? t('forms.microsoft.hostedOauth.tenantSectionDescription', { defaultValue: 'Authorize this mailbox with the Microsoft app selected in Providers settings.' })
-              : t('forms.microsoft.hostedOauth.platformSectionDescription', { defaultValue: 'Alga PSA supplies the Microsoft application. Enter the mailbox details, then sign in with Microsoft.' })}
-          </CardDescription>
         </CardHeader>
         <CardContent className="space-y-4">
-          {!useByoApp && (
-            <Alert>
-              <ShieldCheck className="h-4 w-4" />
+          {emailSetup === undefined ? (
+            <Alert variant="info">
               <AlertDescription>
-                <div className="font-medium">
-                  {t('forms.microsoft.hostedOauth.platformManagedTitle', { defaultValue: 'Platform-managed Microsoft app' })}
-                </div>
-                <div className="text-sm text-muted-foreground">
-                  {t('forms.microsoft.hostedOauth.platformManagedDescription', { defaultValue: 'No Entra app registration, client ID, or client secret is required from you.' })}
-                </div>
+                {t('forms.microsoft.readiness.checking', { defaultValue: 'Checking Microsoft setup…' })}
               </AlertDescription>
             </Alert>
-          )}
-
-          <Button
-            id="microsoft-byo-app-toggle"
-            type="button"
-            variant="ghost"
-            className="h-auto w-full justify-start px-0 text-left"
-            onClick={() => setUseByoApp((current) => !current)}
-          >
-            {useByoApp ? <ChevronDown className="mr-2 h-4 w-4" /> : <ChevronRight className="mr-2 h-4 w-4" />}
-            <span>
-              <span className="block font-medium">
-                {t('forms.microsoft.hostedOauth.byoToggle', { defaultValue: 'Use your own Microsoft app (advanced)' })}
-              </span>
-              <span className="block text-xs font-normal text-muted-foreground">
-                {t('forms.microsoft.hostedOauth.byoToggleDescription', { defaultValue: 'For organizations that deliberately require their own Entra app registration.' })}
-              </span>
-            </span>
-          </Button>
-
-          {useByoApp && (
-            <div className="space-y-3 rounded-lg border p-4">
-              <Alert variant="warning">
-                <AlertTriangle className="h-4 w-4" />
-                <AlertDescription>
-                  {t('forms.microsoft.hostedOauth.byoWarning', { defaultValue: 'This is normally unnecessary on hosted Alga PSA. Use it only when your organization requires a tenant-owned Entra application.' })}
-                </AlertDescription>
-              </Alert>
-              <div className="flex flex-wrap gap-2">
-                <Button
-                  id="configure-microsoft-providers-link"
-                  type="button"
-                  variant="outline"
-                  size="sm"
-                  onClick={() => window.location.assign('/msp/settings/integrations?category=providers')}
-                >
-                  {t('forms.common.actions.openProvidersSettings', { defaultValue: 'Open Providers Settings' })}
-                </Button>
-                <Button
-                  id="azure-portal-link"
-                  type="button"
-                  variant="outline"
-                  size="sm"
-                  onClick={() => window.open('https://portal.azure.com/#view/Microsoft_AAD_RegisteredApps/ApplicationsListBlade', '_blank')}
-                >
-                  <ExternalLink className="mr-2 h-3 w-3" />
-                  {t('forms.microsoft.oauth.setupLabel', { defaultValue: 'Microsoft Entra' })}
-                </Button>
-              </div>
-            </div>
-          )}
-
-          {!providerSetupLoading && !providerSetupReady && (
+          ) : emailSetup?.state === 'ready' ? (
+            <Alert variant="info">
+              <AlertDescription>
+                {t('forms.microsoft.readiness.ready', { defaultValue: 'Microsoft is set up. Sign in as this mailbox to finish.' })}
+              </AlertDescription>
+            </Alert>
+          ) : emailSetup?.state === 'pending_admin_consent' ? (
             <Alert variant="warning">
-              <AlertTriangle className="h-4 w-4" />
               <AlertDescription>
                 <div className="space-y-2">
-                  <div className="font-medium">
-                    {useByoApp
-                      ? t('forms.microsoft.hostedOauth.tenantNotConfigured', { defaultValue: 'Your Microsoft app is not ready yet.' })
-                      : t('forms.microsoft.hostedOauth.platformNotConfigured', { defaultValue: 'Platform Microsoft credentials are unavailable.' })}
-                  </div>
-                  <div className="text-sm text-muted-foreground">
-                    {providerSetupMessage ||
-                      t('forms.microsoft.oauth.setupHelp', { defaultValue: 'Configure Providers first in Settings → Integrations → Providers, then return here to authorize this mailbox.' })}
-                  </div>
-                  {!useByoApp && (
-                    <Button
-                      id="configure-microsoft-provider-readiness-link"
-                      type="button"
-                      variant="outline"
-                      size="sm"
-                      onClick={() => window.location.assign('/msp/settings/integrations?category=providers')}
-                    >
-                      {t('forms.common.actions.openProvidersSettings', { defaultValue: 'Open Providers Settings' })}
-                    </Button>
-                  )}
+                  <div>{t('forms.microsoft.readiness.pending', { defaultValue: "Waiting for your Microsoft 365 administrator. Setup was started in Providers but hasn't been approved yet." })}</div>
+                  <Button
+                    id="open-microsoft-providers-button"
+                    type="button"
+                    variant="link"
+                    className="h-auto p-0"
+                    onClick={() => window.location.assign('/msp/settings/integrations?category=providers')}
+                  >
+                    {t('forms.microsoft.readiness.openProviders', { defaultValue: 'Open Providers' })}
+                  </Button>
                 </div>
               </AlertDescription>
             </Alert>
-          )}
-
-          {!providerSetupLoading && providerSetupReady && oauthStatus !== 'success' && (
-            <Alert>
+          ) : (
+            <Alert variant="warning">
               <AlertDescription>
-                <div className="space-y-1">
-                  <div className="font-medium">
-                    {t('forms.microsoft.oauth.profileReady', { defaultValue: 'Microsoft app profile is ready.' })}
-                  </div>
-                  <div className="text-sm text-muted-foreground">
-                    {t('forms.microsoft.oauth.profileReadyHelp', { defaultValue: 'If tenant administrator consent is still pending, complete it in Providers settings. Then use Authorize Access below for this mailbox.' })}
-                  </div>
+                <div className="space-y-2">
+                  <div>{t('forms.microsoft.readiness.notConfigured', { defaultValue: "Microsoft isn't set up yet. Set it up once in Providers, then come back." })}</div>
+                  <Button
+                    id="set-up-microsoft-in-providers-button"
+                    type="button"
+                    variant="link"
+                    className="h-auto p-0"
+                    onClick={() => window.location.assign('/msp/settings/integrations?category=providers')}
+                  >
+                    {t('forms.microsoft.readiness.setUpInProviders', { defaultValue: 'Set up in Providers' })}
+                  </Button>
                 </div>
               </AlertDescription>
             </Alert>
           )}
 
-          <div className="space-y-2">
-            <Label htmlFor="redirectUri">{t('forms.microsoft.oauth.redirectUriLabel', { defaultValue: 'Redirect URI *' })}</Label>
-            <Input
-              id="redirectUri"
-              {...form.register('redirectUri')}
-              placeholder={t('forms.microsoft.oauth.redirectUriPlaceholder', { defaultValue: 'https://yourapp.com/api/auth/microsoft/callback' })}
-              className={hasAttemptedSubmit && form.formState.errors.redirectUri ? 'border-red-500' : ''}
-            />
-            {form.formState.errors.redirectUri && (
-              <p className="text-sm text-red-500">{form.formState.errors.redirectUri.message}</p>
-            )}
-          </div>
-
-          {/* OAuth Authorization */}
-          <div className="bg-muted/50 p-4 rounded-lg">
-            <div className="flex items-center justify-between">
-              <div>
-                <h4 className="font-medium">{t('forms.microsoft.oauth.authorizationTitle', { defaultValue: 'OAuth Authorization' })}</h4>
-                <p className="text-sm text-muted-foreground">
-                  {t('forms.microsoft.oauth.authorizationDescription', { defaultValue: 'Grant mailbox read access and Mail.Send. Reconnect older mailboxes before selecting them for outbound email.' })}
-                </p>
-              </div>
-              <Button
-                id="oauth-authorize-btn"
-                type="button"
-                variant="outline"
-                onClick={handleOAuthAuthorization}
-                disabled={!providerSetupReady || !form.watch('redirectUri') || oauthStatus === 'authorizing'}
-              >
-                {oauthStatus === 'authorizing' && t('forms.common.oauth.authorizing', { defaultValue: 'Authorizing...' })}
-                {oauthStatus === 'success' && <><CheckCircle className="h-4 w-4 mr-2" />{t('forms.common.oauth.authorized', { defaultValue: 'Authorized' })}</>}
-                {(oauthStatus === 'idle' || oauthStatus === 'error') && t('forms.common.oauth.authorizeAccess', { defaultValue: 'Authorize Access' })}
-              </Button>
-            </div>
+          <div className="flex justify-end">
+            <Button
+              id="oauth-authorize-btn"
+              type="button"
+              onClick={handleOAuthAuthorization}
+              disabled={!providerSetupReady || oauthStatus === 'authorizing'}
+            >
+              {oauthStatus === 'authorizing' && t('forms.microsoft.oauth.signingIn', { defaultValue: 'Signing in…' })}
+              {oauthStatus === 'success' && <><CheckCircle className="mr-2 h-4 w-4" />{t('forms.common.oauth.authorized', { defaultValue: 'Connected' })}</>}
+              {(oauthStatus === 'idle' || oauthStatus === 'error') && t('forms.microsoft.oauth.signIn', { defaultValue: 'Sign in with Microsoft' })}
+            </Button>
           </div>
         </CardContent>
       </Card>
@@ -628,7 +493,7 @@ export function MicrosoftProviderForm({
           </CardDescription>
         </CardHeader>
         <CardContent className="space-y-4">
-          <div className="grid grid-cols-2 gap-4">
+          <div className="grid grid-cols-1 gap-4 md:grid-cols-2">
             <div className="space-y-2">
               <Label htmlFor="folderFilters">{t('forms.microsoft.advanced.folderFiltersLabel', { defaultValue: 'Folder Filters' })}</Label>
               <Input

--- a/packages/integrations/src/components/email/MicrosoftProviderForm.tsx
+++ b/packages/integrations/src/components/email/MicrosoftProviderForm.tsx
@@ -90,7 +90,7 @@ export function MicrosoftProviderForm({
   });
 
   const form = useForm<MicrosoftProviderFormData>({
-    resolver: zodResolver(microsoftProviderSchema),
+    resolver: zodResolver(microsoftProviderSchema) as any,
     defaultValues: provider && provider.microsoftConfig ? {
       providerName: provider.providerName,
       senderDisplayName: provider.senderDisplayName || '',

--- a/packages/integrations/src/components/email/ProviderSetupWizardDialog.tsx
+++ b/packages/integrations/src/components/email/ProviderSetupWizardDialog.tsx
@@ -11,19 +11,19 @@ import {
 } from '@alga-psa/integrations/email/providers/entry';
 import type { EmailProvider } from './types';
 import { useTranslation } from '@alga-psa/ui/lib/i18n/client';
-import type { MicrosoftCredentialCapability } from '../../actions/integrations/providerReadiness';
+import type { MicrosoftEmailSetupReadiness } from '../../actions/integrations/providerReadiness';
 
 interface ProviderSetupWizardDialogProps {
   isOpen: boolean;
   onClose: () => void;
   onComplete: (provider: EmailProvider) => void;
   tenant: string;
-  microsoftCredentialCapability?: MicrosoftCredentialCapability | null;
+  microsoftEmailSetup?: MicrosoftEmailSetupReadiness | null;
 }
 
 type Step = 'select' | 'setup';
 
-export function ProviderSetupWizardDialog({ isOpen, onClose, onComplete, tenant, microsoftCredentialCapability }: ProviderSetupWizardDialogProps) {
+export function ProviderSetupWizardDialog({ isOpen, onClose, onComplete, tenant, microsoftEmailSetup }: ProviderSetupWizardDialogProps) {
   const { t } = useTranslation('msp/email-providers');
   const [step, setStep] = useState<Step>('select');
   const [providerType, setProviderType] = useState<'microsoft' | 'google' | 'imap' | null>(null);
@@ -98,7 +98,7 @@ export function ProviderSetupWizardDialog({ isOpen, onClose, onComplete, tenant,
             tenant={tenant}
             onSuccess={handleSetupSuccess}
             onCancel={handleSetupCancel}
-            credentialCapability={microsoftCredentialCapability}
+            emailSetup={microsoftEmailSetup}
           />
         )}
 

--- a/packages/integrations/src/components/microsoftProviders.providersFirst.test.ts
+++ b/packages/integrations/src/components/microsoftProviders.providersFirst.test.ts
@@ -10,6 +10,13 @@ function read(relativePathFromComponents: string): string {
   return fs.readFileSync(path.resolve(testDir, relativePathFromComponents), 'utf8');
 }
 
+function collectStrings(value: unknown): string[] {
+  if (typeof value === 'string') return [value];
+  if (Array.isArray(value)) return value.flatMap(collectStrings);
+  if (value && typeof value === 'object') return Object.values(value).flatMap(collectStrings);
+  return [];
+}
+
 describe('Microsoft providers-first form contracts', () => {
   const emailFormSource = read('./email/MicrosoftProviderForm.tsx');
   const eeEmailFormSource = fs.readFileSync(
@@ -35,10 +42,11 @@ describe('Microsoft providers-first form contracts', () => {
     expect(emailFormSource).toContain("client_id: ''");
     expect(emailFormSource).toContain("client_secret: ''");
   });
-  it('T019: Microsoft email form keeps tenant-owned app setup behind an advanced CTA', () => {
-    expect(emailFormSource).toContain('Use your own Microsoft app (advanced)');
-    expect(emailFormSource).toContain('This is normally unnecessary on hosted Alga PSA.');
-    expect(emailFormSource).toContain('configure-microsoft-providers-link');
+  it('T019: Microsoft email form delegates app setup to Providers', () => {
+    expect(emailFormSource).not.toContain('Use your own Microsoft app');
+    expect(emailFormSource).not.toContain('Redirect URI');
+    expect(emailFormSource).toContain('Set up in Providers');
+    expect(emailFormSource).toContain('Open Providers');
     expect(emailFormSource).toContain('/msp/settings/integrations?category=providers');
   });
 
@@ -46,9 +54,10 @@ describe('Microsoft providers-first form contracts', () => {
     expect(eeEmailFormSource).toContain(
       "@alga-psa/integrations/components/email/MicrosoftProviderForm"
     );
-    expect(emailFormSource).toContain("getMicrosoftConsumerSetupStatus('email')");
+    expect(emailFormSource).toContain('emailSetup?: MicrosoftEmailSetupReadiness | null');
     expect(emailFormSource).toContain('providerSetupReady');
-    expect(emailFormSource).toContain('Microsoft app profile is ready.');
+    expect(emailFormSource).toContain('Microsoft is set up. Sign in as this mailbox to finish.');
+    expect(emailFormSource).toContain('Sign in with Microsoft');
     expect(emailFormSource).toContain('/msp/settings/integrations?category=providers');
   });
 
@@ -85,7 +94,9 @@ describe('Microsoft providers-first form contracts', () => {
 
   it('T022: Microsoft email persistence derives credentials from tenant providers secrets instead of form fields', () => {
     expect(emailActionsSource).toContain("resolveMicrosoftConsumerProfileConfig(tenant, 'email', {");
-    expect(emailActionsSource).toContain('credentialPreference');
+    expect(emailActionsSource).toContain("credentialPreference: 'tenant'");
+    expect(emailActionsSource).not.toContain('microsoftCredentialSource');
+    expect(emailActionsSource).toContain('getMicrosoftEmailSetupMetadataInternal()).mailboxRedirectUri');
     expect(emailActionsSource).toContain(
       "const effectiveClientId = microsoftProfile.clientId || '';"
     );
@@ -94,5 +105,18 @@ describe('Microsoft providers-first form contracts', () => {
     );
     expect(emailActionsSource).toContain('microsoft_profile_id: pinnedProfileId');
     expect(emailActionsSource).toContain('client_secret_ref: pinnedClientSecretRef');
+  });
+
+  it('keeps bare tenant terminology out of Microsoft email setup copy', () => {
+    const emailProviderLocale = JSON.parse(read('../../../../server/public/locales/en/msp/email-providers.json'));
+    const integrationsLocale = JSON.parse(read('../../../../server/public/locales/en/msp/integrations.json'));
+    const microsoftCopy = [
+      ...collectStrings(emailProviderLocale.configuration.setup.microsoft),
+      ...collectStrings(emailProviderLocale.forms.microsoft),
+      ...collectStrings(integrationsLocale.integrations.microsoft.emailSetup),
+      ...collectStrings(integrationsLocale.integrations.microsoft.settings),
+    ];
+
+    expect(microsoftCopy.filter((copy) => /(?<!Microsoft )\btenant\b/i.test(copy))).toEqual([]);
   });
 });

--- a/packages/integrations/src/components/settings/integrations/MicrosoftEmailSetupDialog.tsx
+++ b/packages/integrations/src/components/settings/integrations/MicrosoftEmailSetupDialog.tsx
@@ -12,27 +12,26 @@ import { useToast } from '@alga-psa/ui/hooks/use-toast';
 import { useTranslation } from '@alga-psa/ui/lib/i18n/client';
 import {
   createMicrosoftEmailApplication,
+  configureMicrosoftEmailManualApplication,
   getMicrosoftEmailSetupOptions,
   type MicrosoftEmailSetupCompletionResult,
   type MicrosoftEmailSetupOptionsResult,
   configureMicrosoftEmailPlatformApplication,
 } from '../../../actions/integrations/microsoftEmailSetupActions';
-import { CheckCircle2, Copy, ExternalLink, KeyRound, Settings2, WandSparkles } from 'lucide-react';
+import { Copy, ExternalLink, KeyRound, Settings2, WandSparkles } from 'lucide-react';
 
-type SetupStep = 'choose' | 'platform' | 'automated' | 'complete';
+type SetupStep = 'choose' | 'platform' | 'automated' | 'manual' | 'complete';
 
 interface MicrosoftEmailSetupDialogProps {
   isOpen: boolean;
   onClose: () => void;
   onCompleted: () => void | Promise<void>;
-  onManualSetup: () => void;
 }
 
 export function MicrosoftEmailSetupDialog({
   isOpen,
   onClose,
   onCompleted,
-  onManualSetup,
 }: MicrosoftEmailSetupDialogProps) {
   const { t } = useTranslation('msp/integrations');
   const { toast } = useToast();
@@ -43,6 +42,8 @@ export function MicrosoftEmailSetupDialog({
   const [error, setError] = React.useState<string | null>(null);
   const [tenantId, setTenantId] = React.useState('');
   const [displayName, setDisplayName] = React.useState('Alga PSA Microsoft Email');
+  const [clientId, setClientId] = React.useState('');
+  const [clientSecret, setClientSecret] = React.useState('');
   const [completion, setCompletion] = React.useState<MicrosoftEmailSetupCompletionResult | null>(null);
   const [adminConsentGranted, setAdminConsentGranted] = React.useState(false);
   const popupRef = React.useRef<Window | null>(null);
@@ -63,6 +64,8 @@ export function MicrosoftEmailSetupDialog({
     setStep('choose');
     setError(null);
     setCompletion(null);
+    setClientId('');
+    setClientSecret('');
     setAdminConsentGranted(false);
     setLoading(true);
     void getMicrosoftEmailSetupOptions()
@@ -175,6 +178,36 @@ export function MicrosoftEmailSetupDialog({
     if (!openPopup(result.authUrl)) setWorking(false);
   }, [displayName, openPopup, t]);
 
+  const configureManualApplication = React.useCallback(async () => {
+    if (!displayName.trim() || !clientId.trim() || !clientSecret.trim() || !tenantId.trim()) {
+      setError(t('integrations.microsoft.emailSetup.errors.manualRequired', {
+        defaultValue: 'Enter the display name, client ID, client secret, and Microsoft tenant ID.',
+      }));
+      return;
+    }
+    setWorking(true);
+    setError(null);
+    try {
+      const result = await configureMicrosoftEmailManualApplication({
+        displayName,
+        clientId,
+        clientSecret,
+        microsoftTenantId: tenantId,
+      });
+      if (!result.success) {
+        setError(result.error || t('integrations.microsoft.emailSetup.errors.manual', {
+          defaultValue: 'Could not configure the Microsoft app.',
+        }));
+        return;
+      }
+      setCompletion(result);
+      setStep('complete');
+      await onCompleted();
+    } finally {
+      setWorking(false);
+    }
+  }, [clientId, clientSecret, displayName, onCompleted, t, tenantId]);
+
   const startAdminConsent = React.useCallback(() => {
     if (!adminConsentUrl) return;
     setWorking(true);
@@ -196,9 +229,21 @@ export function MicrosoftEmailSetupDialog({
   ) : step === 'complete' ? (
     <div className="flex flex-wrap justify-end gap-2">
       {adminConsentUrl && !adminConsentGranted && (
+        <Button
+          id="microsoft-email-copy-admin-approval-link-button"
+          type="button"
+          variant="outline"
+          onClick={() => void copyValue(adminConsentUrl, t('integrations.microsoft.emailSetup.consent.approvalLink', { defaultValue: 'Approval link' }))}
+          disabled={working}
+        >
+          <Copy className="mr-2 h-4 w-4" />
+          {t('integrations.microsoft.emailSetup.actions.copyApprovalLink', { defaultValue: 'Copy approval link for your admin' })}
+        </Button>
+      )}
+      {adminConsentUrl && !adminConsentGranted && (
         <Button id="microsoft-email-admin-consent-button" type="button" onClick={startAdminConsent} disabled={working}>
           <ExternalLink className="mr-2 h-4 w-4" />
-          {t('integrations.microsoft.emailSetup.actions.grantConsent', { defaultValue: 'Grant administrator consent' })}
+          {t('integrations.microsoft.emailSetup.actions.approve', { defaultValue: 'Approve in Microsoft' })}
         </Button>
       )}
       <Button id="microsoft-email-setup-finish-button" type="button" variant="outline" onClick={close} disabled={working}>
@@ -211,15 +256,25 @@ export function MicrosoftEmailSetupDialog({
         {t('integrations.microsoft.emailSetup.actions.back', { defaultValue: 'Back' })}
       </Button>
       <Button
-        id={step === 'platform' ? 'microsoft-email-platform-continue-button' : 'microsoft-email-automated-continue-button'}
+        id={step === 'platform'
+          ? 'microsoft-email-platform-continue-button'
+          : step === 'manual'
+            ? 'microsoft-email-manual-continue-button'
+            : 'microsoft-email-automated-continue-button'}
         type="button"
-        onClick={() => void (step === 'platform' ? configurePlatformApplication() : startAutomatedCreation())}
+        onClick={() => void (step === 'platform'
+          ? configurePlatformApplication()
+          : step === 'manual'
+            ? configureManualApplication()
+            : startAutomatedCreation())}
         disabled={working}
       >
         {working
           ? t('integrations.microsoft.emailSetup.actions.working', { defaultValue: 'Working…' })
           : step === 'platform'
             ? t('integrations.microsoft.emailSetup.actions.savePlatform', { defaultValue: 'Create profile and continue' })
+            : step === 'manual'
+              ? t('integrations.microsoft.emailSetup.actions.saveManual', { defaultValue: 'Save app and continue' })
             : t('integrations.microsoft.emailSetup.actions.signIn', { defaultValue: 'Sign in to Microsoft' })}
       </Button>
     </div>
@@ -230,7 +285,7 @@ export function MicrosoftEmailSetupDialog({
       id="microsoft-email-setup-dialog"
       isOpen={isOpen}
       onClose={close}
-      title={t('integrations.microsoft.emailSetup.title', { defaultValue: 'Set up Microsoft Email' })}
+      title={t('integrations.microsoft.emailSetup.title', { defaultValue: 'Set up Microsoft' })}
       className="max-w-2xl"
       footer={footer}
     >
@@ -238,7 +293,7 @@ export function MicrosoftEmailSetupDialog({
         <div className="space-y-5">
           <div>
             <p className="text-sm text-[rgb(var(--color-text-700))]">
-              {t('integrations.microsoft.emailSetup.description', { defaultValue: 'Choose how to configure the Microsoft app used for inbound email. Mailbox authorization remains a separate final step.' })}
+              {t('integrations.microsoft.emailSetup.description', { defaultValue: 'Choose how Alga PSA connects to Microsoft. You will connect mailboxes separately.' })}
             </p>
           </div>
 
@@ -252,43 +307,44 @@ export function MicrosoftEmailSetupDialog({
             <div className="space-y-3"><Skeleton className="h-24 w-full" /><Skeleton className="h-24 w-full" /></div>
           ) : step === 'choose' ? (
             <div className="grid gap-3">
-              <button
-                id="microsoft-email-choose-platform-button"
-                type="button"
-                className="rounded-lg border bg-[rgb(var(--color-card))] p-4 text-left transition-colors hover:bg-muted/30 disabled:cursor-not-allowed disabled:opacity-60"
-                disabled={!options?.platformApplication?.available}
-                onClick={() => setStep('platform')}
-              >
-                <div className="flex items-start gap-3">
-                  <KeyRound className="mt-0.5 h-5 w-5 text-primary-500" />
-                  <div className="space-y-1">
-                    <div className="flex flex-wrap items-center gap-2 font-medium">
-                      {t('integrations.microsoft.emailSetup.platform.title', { defaultValue: 'Use the Alga platform app' })}
-                      {!options?.platformApplication?.available && <Badge variant="secondary">{t('integrations.microsoft.emailSetup.unavailable', { defaultValue: 'Unavailable' })}</Badge>}
+              {options?.emailSetup?.platformOffered && (
+                <button
+                  id="microsoft-email-choose-platform-button"
+                  type="button"
+                  className="rounded-lg border bg-[rgb(var(--color-card))] p-4 text-left transition-colors hover:bg-muted/30 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary-500 focus-visible:ring-offset-2"
+                  onClick={() => setStep('platform')}
+                >
+                  <div className="flex min-w-0 items-start gap-3">
+                    <KeyRound className="mt-0.5 h-5 w-5 shrink-0 text-primary-500" />
+                    <div className="min-w-0 space-y-1">
+                      <div className="flex flex-wrap items-center gap-2 font-medium">
+                        {t('integrations.microsoft.emailSetup.platform.title', { defaultValue: 'Use the app provided by Alga PSA' })}
+                        <Badge variant="success">{t('integrations.microsoft.emailSetup.recommended', { defaultValue: 'Recommended' })}</Badge>
+                      </div>
+                      <p className="text-sm text-muted-foreground">
+                        {t('integrations.microsoft.emailSetup.platform.description', { defaultValue: 'Nothing to register in Microsoft Entra. Your Microsoft 365 administrator approves access.' })}
+                      </p>
                     </div>
-                    <p className="text-sm text-muted-foreground">
-                      {t('integrations.microsoft.emailSetup.platform.description', { defaultValue: 'Create an Email-bound profile from the server-managed multi-tenant app, then grant tenant administrator consent.' })}
-                    </p>
                   </div>
-                </div>
-              </button>
+                </button>
+              )}
 
               <button
                 id="microsoft-email-choose-automated-button"
                 type="button"
-                className="rounded-lg border bg-[rgb(var(--color-card))] p-4 text-left transition-colors hover:bg-muted/30 disabled:cursor-not-allowed disabled:opacity-60"
+                className="rounded-lg border bg-[rgb(var(--color-card))] p-4 text-left transition-colors hover:bg-muted/30 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary-500 focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-60"
                 disabled={!options?.automatedCreationAvailable}
                 onClick={() => setStep('automated')}
               >
-                <div className="flex items-start gap-3">
-                  <WandSparkles className="mt-0.5 h-5 w-5 text-primary-500" />
-                  <div className="space-y-1">
+                <div className="flex min-w-0 items-start gap-3">
+                  <WandSparkles className="mt-0.5 h-5 w-5 shrink-0 text-primary-500" />
+                  <div className="min-w-0 space-y-1">
                     <div className="flex flex-wrap items-center gap-2 font-medium">
-                      {t('integrations.microsoft.emailSetup.automated.title', { defaultValue: 'Create an app in this tenant' })}
+                      {t('integrations.microsoft.emailSetup.automated.title', { defaultValue: 'Create an app in your Microsoft organization' })}
                       {!options?.automatedCreationAvailable && <Badge variant="secondary">{t('integrations.microsoft.emailSetup.unavailable', { defaultValue: 'Unavailable' })}</Badge>}
                     </div>
                     <p className="text-sm text-muted-foreground">
-                      {t('integrations.microsoft.emailSetup.automated.description', { defaultValue: 'Sign in as a Microsoft administrator. Alga creates the app, service principal, secret, Email profile, and binding.' })}
+                      {t('integrations.microsoft.emailSetup.automated.description', { defaultValue: 'Alga PSA registers a dedicated Entra app automatically. Sign in as a Microsoft 365 administrator.' })}
                     </p>
                   </div>
                 </div>
@@ -297,14 +353,17 @@ export function MicrosoftEmailSetupDialog({
               <button
                 id="microsoft-email-choose-manual-button"
                 type="button"
-                className="rounded-lg border bg-[rgb(var(--color-card))] p-4 text-left transition-colors hover:bg-muted/30"
-                onClick={onManualSetup}
+                className="rounded-lg border bg-[rgb(var(--color-card))] p-4 text-left transition-colors hover:bg-muted/30 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary-500 focus-visible:ring-offset-2"
+                onClick={() => setStep('manual')}
               >
-                <div className="flex items-start gap-3">
-                  <Settings2 className="mt-0.5 h-5 w-5 text-primary-500" />
-                  <div className="space-y-1">
-                    <div className="font-medium">{t('integrations.microsoft.emailSetup.manual.title', { defaultValue: 'Enter an existing app manually' })}</div>
-                    <p className="text-sm text-muted-foreground">{t('integrations.microsoft.emailSetup.manual.description', { defaultValue: 'Keep using the existing client ID, tenant ID, and client secret form.' })}</p>
+                <div className="flex min-w-0 items-start gap-3">
+                  <Settings2 className="mt-0.5 h-5 w-5 shrink-0 text-primary-500" />
+                  <div className="min-w-0 space-y-1">
+                    <div className="flex flex-wrap items-center gap-2 font-medium">
+                      {t('integrations.microsoft.emailSetup.manual.title', { defaultValue: 'Enter an existing app manually' })}
+                      <Badge variant="secondary">{t('integrations.microsoft.emailSetup.advanced', { defaultValue: 'Advanced' })}</Badge>
+                    </div>
+                    <p className="text-sm text-muted-foreground">{t('integrations.microsoft.emailSetup.manual.description', { defaultValue: 'Use an existing Entra app maintained by your organization.' })}</p>
                   </div>
                 </div>
               </button>
@@ -313,53 +372,67 @@ export function MicrosoftEmailSetupDialog({
             <div className="space-y-4">
               <div className="space-y-2">
                 <Label htmlFor="microsoft-email-setup-display-name-input">{t('integrations.microsoft.emailSetup.fields.displayName', { defaultValue: 'Profile display name' })}</Label>
-                <Input id="microsoft-email-setup-display-name-input" value={displayName} onChange={(event) => setDisplayName(event.target.value)} />
+                <Input id="microsoft-email-setup-display-name-input" aria-label={t('integrations.microsoft.emailSetup.fields.displayName', { defaultValue: 'Profile display name' })} value={displayName} onChange={(event) => setDisplayName(event.target.value)} />
               </div>
               {step === 'platform' && (
                 <div className="space-y-2">
-                  <Label htmlFor="microsoft-email-setup-tenant-input">{t('integrations.microsoft.emailSetup.fields.tenant', { defaultValue: 'Microsoft tenant ID or verified domain' })}</Label>
-                  <Input id="microsoft-email-setup-tenant-input" value={tenantId} onChange={(event) => setTenantId(event.target.value)} placeholder="xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx" />
+                  <Label htmlFor="microsoft-email-setup-tenant-input">{t('integrations.microsoft.emailSetup.fields.microsoftTenant', { defaultValue: 'Microsoft tenant ID or verified domain' })}</Label>
+                  <Input id="microsoft-email-setup-tenant-input" aria-label={t('integrations.microsoft.emailSetup.fields.microsoftTenant', { defaultValue: 'Microsoft tenant ID or verified domain' })} value={tenantId} onChange={(event) => setTenantId(event.target.value)} placeholder="xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx" />
                 </div>
               )}
-              <div className="rounded-lg border bg-muted/10 p-3">
-                <div className="text-xs font-semibold uppercase tracking-wide text-muted-foreground">{t('integrations.microsoft.emailSetup.callbackUri', { defaultValue: 'Mailbox callback URI' })}</div>
-                <div className="mt-2 break-all font-mono text-xs">{options?.callbackUri}</div>
+            </div>
+          ) : step === 'manual' ? (
+            <div className="grid gap-4 md:grid-cols-2">
+              <div className="space-y-2 md:col-span-2">
+                <Label htmlFor="microsoft-email-manual-display-name-input">{t('integrations.microsoft.emailSetup.fields.displayName', { defaultValue: 'Profile display name' })}</Label>
+                <Input id="microsoft-email-manual-display-name-input" aria-label={t('integrations.microsoft.emailSetup.fields.displayName', { defaultValue: 'Profile display name' })} value={displayName} onChange={(event) => setDisplayName(event.target.value)} />
+              </div>
+              <div className="space-y-2">
+                <Label htmlFor="microsoft-email-manual-client-id-input">{t('integrations.microsoft.emailSetup.fields.clientId', { defaultValue: 'Client ID' })}</Label>
+                <Input id="microsoft-email-manual-client-id-input" aria-label={t('integrations.microsoft.emailSetup.fields.clientId', { defaultValue: 'Client ID' })} value={clientId} onChange={(event) => setClientId(event.target.value)} />
+              </div>
+              <div className="space-y-2">
+                <Label htmlFor="microsoft-email-manual-tenant-id-input">{t('integrations.microsoft.emailSetup.fields.tenantId', { defaultValue: 'Microsoft tenant ID' })}</Label>
+                <Input id="microsoft-email-manual-tenant-id-input" aria-label={t('integrations.microsoft.emailSetup.fields.tenantId', { defaultValue: 'Microsoft tenant ID' })} value={tenantId} onChange={(event) => setTenantId(event.target.value)} placeholder="xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx" />
+              </div>
+              <div className="space-y-2 md:col-span-2">
+                <Label htmlFor="microsoft-email-manual-client-secret-input">{t('integrations.microsoft.emailSetup.fields.clientSecret', { defaultValue: 'Client secret' })}</Label>
+                <Input id="microsoft-email-manual-client-secret-input" aria-label={t('integrations.microsoft.emailSetup.fields.clientSecret', { defaultValue: 'Client secret' })} type="password" value={clientSecret} onChange={(event) => setClientSecret(event.target.value)} />
+              </div>
+              <div className="space-y-2 md:col-span-2">
+                <div className="flex items-center justify-between gap-2">
+                  <Label htmlFor="microsoft-email-manual-redirect-uri-input">{t('integrations.microsoft.emailSetup.fields.redirectUri', { defaultValue: 'Redirect URI to add in Entra' })}</Label>
+                  <Button
+                    id="microsoft-email-copy-redirect-uri-button"
+                    type="button"
+                    variant="ghost"
+                    size="sm"
+                    onClick={() => void copyValue(options?.callbackUri || '', t('integrations.microsoft.emailSetup.fields.redirectUri', { defaultValue: 'Redirect URI' }))}
+                    disabled={!options?.callbackUri}
+                  >
+                    <Copy className="mr-2 h-3.5 w-3.5" />
+                    {t('integrations.microsoft.emailSetup.actions.copy', { defaultValue: 'Copy' })}
+                  </Button>
+                </div>
+                <Input id="microsoft-email-manual-redirect-uri-input" aria-label={t('integrations.microsoft.emailSetup.fields.redirectUri', { defaultValue: 'Redirect URI to add in Entra' })} value={options?.callbackUri || ''} readOnly />
               </div>
             </div>
           ) : (
             <div className="space-y-4">
-              <Alert>
-                <CheckCircle2 className="h-4 w-4" />
+              <Alert variant={adminConsentGranted ? 'success' : 'warning'}>
                 <AlertDescription>
-                  <div className="font-medium">{t('integrations.microsoft.emailSetup.complete.profileCreated', { defaultValue: 'Microsoft Email profile created and bound' })}</div>
+                  <div className="font-medium">
+                    {adminConsentGranted
+                      ? t('integrations.microsoft.emailSetup.complete.ready', { defaultValue: 'Microsoft is ready' })
+                      : t('integrations.microsoft.emailSetup.complete.waiting', { defaultValue: 'Waiting for admin approval' })}
+                  </div>
                   <p className="mt-1 text-sm text-muted-foreground">
                     {adminConsentGranted
-                      ? t('integrations.microsoft.emailSetup.complete.consentDone', { defaultValue: 'Administrator consent is confirmed. Return to Inbound Email and authorize the mailbox.' })
-                      : t('integrations.microsoft.emailSetup.complete.consentPending', { defaultValue: 'Next, a Microsoft tenant administrator must grant consent. Mailbox authorization happens afterward in Inbound Email.' })}
+                      ? t('integrations.microsoft.emailSetup.complete.consentDone', { defaultValue: 'Approved by your Microsoft 365 administrator. You can now connect a mailbox.' })
+                      : t('integrations.microsoft.emailSetup.complete.consentPending', { defaultValue: 'A Microsoft 365 administrator for your organization must approve access before mailboxes can connect.' })}
                   </p>
                 </AlertDescription>
               </Alert>
-              <div className="grid gap-3 sm:grid-cols-2">
-                <div className="rounded-lg border bg-muted/10 p-3">
-                  <div className="text-xs font-semibold uppercase tracking-wide text-muted-foreground">{t('integrations.microsoft.emailSetup.fields.clientId', { defaultValue: 'Client ID' })}</div>
-                  <div className="mt-2 break-all font-mono text-xs">{completion?.clientId}</div>
-                </div>
-                <div className="rounded-lg border bg-muted/10 p-3">
-                  <div className="text-xs font-semibold uppercase tracking-wide text-muted-foreground">{t('integrations.microsoft.emailSetup.fields.tenantId', { defaultValue: 'Tenant ID' })}</div>
-                  <div className="mt-2 break-all font-mono text-xs">{completion?.tenantId}</div>
-                </div>
-              </div>
-              {adminConsentUrl && (
-                <div className="rounded-lg border bg-muted/10 p-3">
-                  <div className="flex items-center justify-between gap-2">
-                    <div className="text-xs font-semibold uppercase tracking-wide text-muted-foreground">{t('integrations.microsoft.emailSetup.consent.url', { defaultValue: 'Administrator consent URL' })}</div>
-                    <Button id="microsoft-email-copy-consent-url-button" type="button" variant="ghost" size="sm" onClick={() => void copyValue(adminConsentUrl, t('integrations.microsoft.emailSetup.consent.urlLabel', { defaultValue: 'Consent URL' }))}>
-                      <Copy className="mr-2 h-3.5 w-3.5" />{t('integrations.microsoft.emailSetup.actions.copy', { defaultValue: 'Copy' })}
-                    </Button>
-                  </div>
-                  <div className="mt-2 break-all font-mono text-xs">{adminConsentUrl}</div>
-                </div>
-              )}
             </div>
           )}
         </div>

--- a/packages/integrations/src/components/settings/integrations/MicrosoftIntegrationSettings.contract.test.tsx
+++ b/packages/integrations/src/components/settings/integrations/MicrosoftIntegrationSettings.contract.test.tsx
@@ -19,6 +19,8 @@ const resetMicrosoftProvidersToDisconnectedMock = vi.hoisted(() => vi.fn());
 const getMicrosoftEmailSetupOptionsMock = vi.hoisted(() => vi.fn());
 const configureMicrosoftEmailPlatformApplicationMock = vi.hoisted(() => vi.fn());
 const createMicrosoftEmailApplicationMock = vi.hoisted(() => vi.fn());
+const configureMicrosoftEmailManualApplicationMock = vi.hoisted(() => vi.fn());
+const getMicrosoftEmailAdminConsentUrlMock = vi.hoisted(() => vi.fn());
 const toastMock = vi.hoisted(() => vi.fn());
 const routerPushMock = vi.hoisted(() => vi.fn());
 
@@ -54,6 +56,8 @@ vi.mock('../../../actions/integrations/microsoftEmailSetupActions', () => ({
   getMicrosoftEmailSetupOptions: (...args: unknown[]) => getMicrosoftEmailSetupOptionsMock(...args),
   configureMicrosoftEmailPlatformApplication: (...args: unknown[]) => configureMicrosoftEmailPlatformApplicationMock(...args),
   createMicrosoftEmailApplication: (...args: unknown[]) => createMicrosoftEmailApplicationMock(...args),
+  configureMicrosoftEmailManualApplication: (...args: unknown[]) => configureMicrosoftEmailManualApplicationMock(...args),
+  getMicrosoftEmailAdminConsentUrl: (...args: unknown[]) => getMicrosoftEmailAdminConsentUrlMock(...args),
 }));
 
 vi.mock('@alga-psa/ui/hooks/use-toast', () => ({
@@ -152,14 +156,12 @@ function buildStatus(overrides: Record<string, unknown> = {}) {
       tenantId: 'tenant-guid-1',
       ready: true,
     },
-    emailCredentialCapability: {
-      source: 'tenant',
-      ready: true,
-      platformReady: true,
-      tenantProfileSelected: true,
-      clientIdConfigured: true,
-      clientSecretConfigured: true,
-      tenantIdConfigured: true,
+    emailSetup: {
+      state: 'ready',
+      source: 'tenant_app',
+      hosted: true,
+      platformOffered: true,
+      automatedCreationAvailable: true,
       profileId: 'profile-1',
     },
     profiles: [
@@ -295,11 +297,20 @@ describe('MicrosoftIntegrationSettings contracts', () => {
       success: true,
       callbackUri: 'https://psa.example.com/api/auth/microsoft/callback',
       setupCallbackUri: 'https://psa.example.com/api/auth/microsoft/email-setup/callback',
+      emailSetup: {
+        state: 'not_configured',
+        source: null,
+        hosted: true,
+        platformOffered: false,
+        automatedCreationAvailable: false,
+      },
       platformApplication: { available: false },
       automatedCreationAvailable: false,
     });
     configureMicrosoftEmailPlatformApplicationMock.mockReset();
     createMicrosoftEmailApplicationMock.mockReset();
+    configureMicrosoftEmailManualApplicationMock.mockReset();
+    getMicrosoftEmailAdminConsentUrlMock.mockReset();
     toastMock.mockReset();
     routerPushMock.mockReset();
     getMicrosoftIntegrationStatusMock.mockResolvedValue(buildStatus());
@@ -360,15 +371,12 @@ describe('MicrosoftIntegrationSettings contracts', () => {
   it('keeps tenant app management collapsed when hosted platform credentials are ready', async () => {
     const user = userEvent.setup();
     getMicrosoftIntegrationStatusMock.mockResolvedValue(buildStatus({
-      emailCredentialCapability: {
+      emailSetup: {
+        state: 'ready',
         source: 'platform',
-        ready: true,
-        platformReady: true,
-        tenantProfileSelected: false,
-        clientIdConfigured: true,
-        clientSecretConfigured: true,
-        tenantIdConfigured: true,
-        profileId: null,
+        hosted: true,
+        platformOffered: true,
+        automatedCreationAvailable: true,
       },
     }));
 
@@ -378,7 +386,7 @@ describe('MicrosoftIntegrationSettings contracts', () => {
     expect(screen.queryByText('Which Microsoft app each service uses')).not.toBeInTheDocument();
     expect(screen.queryByRole('button', { name: 'New app registration' })).not.toBeInTheDocument();
 
-    await user.click(screen.getByRole('button', { name: /Bring your own Microsoft app/i }));
+    await user.click(screen.getByRole('button', { name: /Manual Microsoft apps/i }));
 
     expect(screen.getByText(/custom Entra app is normally unnecessary/i)).toBeInTheDocument();
     expect(screen.getByText('Which Microsoft app each service uses')).toBeInTheDocument();
@@ -388,62 +396,115 @@ describe('MicrosoftIntegrationSettings contracts', () => {
   it('opens inbound email provider configuration from the hosted Microsoft CTA', async () => {
     const user = userEvent.setup();
     getMicrosoftIntegrationStatusMock.mockResolvedValue(buildStatus({
-      emailCredentialCapability: {
+      emailSetup: {
+        state: 'ready',
         source: 'platform',
-        ready: true,
-        platformReady: true,
-        tenantProfileSelected: false,
-        clientIdConfigured: true,
-        clientSecretConfigured: true,
-        tenantIdConfigured: true,
-        profileId: null,
+        hosted: true,
+        platformOffered: true,
+        automatedCreationAvailable: true,
       },
     }));
 
     render(<MicrosoftIntegrationSettings />);
 
-    await user.click(await screen.findByRole('button', { name: 'Connect Microsoft email' }));
+    await user.click(await screen.findByRole('button', { name: 'Connect a mailbox →' }));
 
     expect(routerPushMock).toHaveBeenCalledWith('/msp/settings/integrations?category=communication');
   });
 
-  it('opens manual app management when platform credentials are unavailable', async () => {
+  it('does not offer the platform app when the server reports a self-hosted deployment', async () => {
+    const user = userEvent.setup();
     getMicrosoftIntegrationStatusMock.mockResolvedValue(buildStatus({
-      emailCredentialCapability: {
-        source: 'none',
-        ready: false,
-        platformReady: false,
-        tenantProfileSelected: false,
-        clientIdConfigured: false,
-        clientSecretConfigured: false,
-        tenantIdConfigured: false,
-        profileId: null,
+      emailSetup: {
+        state: 'not_configured',
+        source: null,
+        hosted: false,
+        platformOffered: false,
+        automatedCreationAvailable: false,
       },
     }));
 
     render(<MicrosoftIntegrationSettings />);
 
-    expect(await screen.findByText('Platform Microsoft credentials are unavailable')).toBeInTheDocument();
-    expect(screen.getByText('Which Microsoft app each service uses')).toBeInTheDocument();
-    expect(screen.getByRole('button', { name: 'New app registration' })).toBeInTheDocument();
+    await user.click(await screen.findByRole('button', { name: 'Set up Microsoft' }));
+    const dialog = await screen.findByRole('dialog', { name: 'Set up Microsoft' });
+    expect(within(dialog).queryByRole('button', { name: /Use the app provided by Alga PSA/ })).not.toBeInTheDocument();
+    expect(within(dialog).getByRole('button', { name: /Enter an existing app manually/ })).toBeEnabled();
   });
 
-  it('shows both guided choices as unavailable while keeping the manual fallback usable', async () => {
+  it('lists the hosted platform app first and marks it Recommended', async () => {
     const user = userEvent.setup();
+    const emailSetup = {
+      state: 'not_configured',
+      source: null,
+      hosted: true,
+      platformOffered: true,
+      automatedCreationAvailable: true,
+    };
+    getMicrosoftIntegrationStatusMock.mockResolvedValue(buildStatus({ emailSetup }));
+    getMicrosoftEmailSetupOptionsMock.mockResolvedValue({
+      success: true,
+      callbackUri: 'https://psa.example.com/api/auth/microsoft/callback',
+      setupCallbackUri: 'https://psa.example.com/api/auth/microsoft/email-setup/callback',
+      emailSetup,
+      platformApplication: { available: true },
+      automatedCreationAvailable: true,
+    });
+
+    render(<MicrosoftIntegrationSettings />);
+    await user.click(await screen.findByRole('button', { name: 'Set up Microsoft' }));
+    const dialog = await screen.findByRole('dialog', { name: 'Set up Microsoft' });
+    const platformChoice = within(dialog).getByRole('button', { name: /Use the app provided by Alga PSA/ });
+    const automatedChoice = within(dialog).getByRole('button', { name: /Create an app in your Microsoft organization/ });
+
+    expect(within(platformChoice).getByText('Recommended')).toBeInTheDocument();
+    expect(platformChoice.compareDocumentPosition(automatedChoice) & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy();
+  });
+
+  it('shows approval actions instead of setup while Microsoft consent is pending', async () => {
+    getMicrosoftIntegrationStatusMock.mockResolvedValue(buildStatus({
+      emailSetup: {
+        state: 'pending_admin_consent',
+        source: 'tenant_app',
+        hosted: true,
+        platformOffered: true,
+        automatedCreationAvailable: true,
+        profileId: 'profile-pending',
+      },
+    }));
+
     render(<MicrosoftIntegrationSettings />);
 
-    await user.click(await screen.findByRole('button', { name: 'Set up Microsoft Email' }));
-    const dialog = await screen.findByRole('dialog', { name: 'Set up Microsoft Email' });
-    const platformChoice = within(dialog).getByRole('button', { name: /Use the Alga platform app/ });
-    const automatedChoice = within(dialog).getByRole('button', { name: /Create an app in this tenant/ });
+    expect(await screen.findByText('Waiting for admin approval')).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Approve in Microsoft' })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Copy approval link for your admin' })).toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: 'Set up Microsoft' })).not.toBeInTheDocument();
+  });
+
+  it('keeps the manual fallback usable when automated setup is unavailable', async () => {
+    const user = userEvent.setup();
+    getMicrosoftIntegrationStatusMock.mockResolvedValue(buildStatus({
+      emailSetup: {
+        state: 'not_configured',
+        source: null,
+        hosted: true,
+        platformOffered: false,
+        automatedCreationAvailable: false,
+      },
+    }));
+    render(<MicrosoftIntegrationSettings />);
+
+    await user.click(await screen.findByRole('button', { name: 'Set up Microsoft' }));
+    const dialog = await screen.findByRole('dialog', { name: 'Set up Microsoft' });
+    const automatedChoice = within(dialog).getByRole('button', { name: /Create an app in your Microsoft organization/ });
     const manualChoice = within(dialog).getByRole('button', { name: /Enter an existing app manually/ });
 
-    expect(platformChoice).toBeDisabled();
+    expect(within(dialog).queryByRole('button', { name: /Use the app provided by Alga PSA/ })).not.toBeInTheDocument();
     expect(automatedChoice).toBeDisabled();
     expect(manualChoice).toBeEnabled();
 
     await user.click(manualChoice);
-    expect(await screen.findByRole('dialog', { name: 'Create Microsoft app registration' })).toBeInTheDocument();
+    expect(within(dialog).getByLabelText('Redirect URI to add in Entra')).toHaveAttribute('readonly');
   });
 
   it('recovers the automated setup controls when the Microsoft popup is closed', async () => {
@@ -454,6 +515,13 @@ describe('MicrosoftIntegrationSettings contracts', () => {
       success: true,
       callbackUri: 'https://psa.example.com/api/auth/microsoft/callback',
       setupCallbackUri: 'https://psa.example.com/api/auth/microsoft/email-setup/callback',
+      emailSetup: {
+        state: 'not_configured',
+        source: null,
+        hosted: false,
+        platformOffered: false,
+        automatedCreationAvailable: true,
+      },
       platformApplication: { available: false },
       automatedCreationAvailable: true,
     });
@@ -461,11 +529,20 @@ describe('MicrosoftIntegrationSettings contracts', () => {
       success: true,
       authUrl: 'https://login.microsoftonline.com/common/oauth2/v2.0/authorize',
     });
+    getMicrosoftIntegrationStatusMock.mockResolvedValue(buildStatus({
+      emailSetup: {
+        state: 'not_configured',
+        source: null,
+        hosted: false,
+        platformOffered: false,
+        automatedCreationAvailable: true,
+      },
+    }));
 
     render(<MicrosoftIntegrationSettings />);
-    await user.click(await screen.findByRole('button', { name: 'Set up Microsoft Email' }));
-    const dialog = await screen.findByRole('dialog', { name: 'Set up Microsoft Email' });
-    await user.click(within(dialog).getByRole('button', { name: /Create an app in this tenant/ }));
+    await user.click(await screen.findByRole('button', { name: 'Set up Microsoft' }));
+    const dialog = await screen.findByRole('dialog', { name: 'Set up Microsoft' });
+    await user.click(within(dialog).getByRole('button', { name: /Create an app in your Microsoft organization/ }));
     await user.click(within(dialog).getByRole('button', { name: 'Sign in to Microsoft' }));
     expect(within(dialog).getByRole('button', { name: 'Working…' })).toBeDisabled();
 
@@ -497,6 +574,13 @@ describe('MicrosoftIntegrationSettings contracts', () => {
         scopes: {
           sso: ['openid', 'profile', 'email'],
           email: ['Mail.Read', 'Mail.Read.Shared', 'offline_access'],
+        },
+        emailSetup: {
+          state: 'not_configured',
+          source: null,
+          hosted: false,
+          platformOffered: false,
+          automatedCreationAvailable: false,
         },
         profiles: [
           {
@@ -536,7 +620,7 @@ describe('MicrosoftIntegrationSettings contracts', () => {
     ).toBeInTheDocument();
     expect(screen.getByTestId('microsoft-binding-select-msp_sso')).toBeInTheDocument();
     expect(screen.getByTestId('microsoft-binding-select-email')).toBeInTheDocument();
-    expect(screen.getByRole('button', { name: 'Set up Microsoft Email' })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Set up Microsoft' })).toBeInTheDocument();
     expect(screen.queryByText('Calendar sync redirect URI')).not.toBeInTheDocument();
     expect(screen.queryByText('Teams scopes')).not.toBeInTheDocument();
     expect(screen.queryByRole('button', { name: 'Disconnect Microsoft providers' })).not.toBeInTheDocument();

--- a/packages/integrations/src/components/settings/integrations/MicrosoftIntegrationSettings.tsx
+++ b/packages/integrations/src/components/settings/integrations/MicrosoftIntegrationSettings.tsx
@@ -38,6 +38,7 @@ import {
 } from '../../../lib/microsoftConsumerVisibility';
 import { resolveTeamsAvailability } from '../../../lib/teamsAvailabilityCore';
 import { MicrosoftEmailSetupDialog } from './MicrosoftEmailSetupDialog';
+import { getMicrosoftEmailAdminConsentUrl } from '../../../actions/integrations/microsoftEmailSetupActions';
 import {
   AlertTriangle,
   Archive,
@@ -100,10 +101,10 @@ function getReadinessMessages(profile: MicrosoftProfile, t: TranslateFn): string
     messages.push(t('integrations.microsoft.settings.readiness.clientSecretMissing', { defaultValue: 'Add a client secret.' }));
   }
   if (!profile.readiness.tenantIdConfigured) {
-    messages.push(t('integrations.microsoft.settings.readiness.tenantIdMissing', { defaultValue: 'Add a tenant ID.' }));
+    messages.push(t('integrations.microsoft.settings.readiness.tenantIdMissing', { defaultValue: 'Add a Microsoft tenant ID.' }));
   }
   if (profile.emailAdminConsentRequired && !profile.emailAdminConsentGrantedAt) {
-    messages.push(t('integrations.microsoft.settings.readiness.adminConsentPending', { defaultValue: 'Grant Microsoft tenant administrator consent to finish Email setup.' }));
+    messages.push(t('integrations.microsoft.settings.readiness.adminConsentPending', { defaultValue: 'Ask a Microsoft 365 administrator to approve access for Email.' }));
   }
 
   return messages;
@@ -115,6 +116,13 @@ function getProfileStatusBadge(profile: MicrosoftProfile, t: TranslateFn): {
 } {
   if (profile.isArchived) {
     return { label: t('integrations.microsoft.settings.statusBadges.archived', { defaultValue: 'Archived' }), variant: 'secondary' };
+  }
+
+  if (profile.emailAdminConsentRequired && !profile.emailAdminConsentGrantedAt) {
+    return {
+      label: t('integrations.microsoft.settings.statusBadges.waitingForAdminApproval', { defaultValue: 'Waiting for admin approval' }),
+      variant: 'warning',
+    };
   }
 
   if (profile.readiness.ready) {
@@ -355,7 +363,7 @@ function getGuidanceBlocks(
     title: t('integrations.microsoft.settings.guidance.currentProfileTitle', { defaultValue: 'Saved app values' }),
     items: [
       { label: t('integrations.microsoft.settings.guidance.clientId', { defaultValue: 'Client ID' }), value: profile.clientId || notConfigured },
-      { label: t('integrations.microsoft.settings.guidance.tenantId', { defaultValue: 'Tenant ID' }), value: profile.tenantId },
+      { label: t('integrations.microsoft.settings.guidance.tenantId', { defaultValue: 'Microsoft tenant ID' }), value: profile.tenantId },
     ],
   });
 
@@ -397,7 +405,7 @@ export function MicrosoftIntegrationSettings({
   const profiles = status?.success ? status.profiles ?? [] : [];
   const hasProfiles = profiles.length > 0;
   const activeProfiles = profiles.filter((profile) => !profile.isArchived);
-  const emailCredentialCapability = status?.success ? status.emailCredentialCapability : undefined;
+  const emailSetup = status?.success ? status.emailSetup : undefined;
   const profileById = React.useMemo(
     () => new Map(profiles.map((profile) => [profile.profileId, profile])),
     [profiles]
@@ -439,7 +447,7 @@ export function MicrosoftIntegrationSettings({
 
     if (statusResult.success && !advancedChoiceInitializedRef.current) {
       advancedChoiceInitializedRef.current = true;
-      setAdvancedOpen(!isMicrosoftConsumerEnterpriseEdition() || statusResult.emailCredentialCapability?.source !== 'platform');
+      setAdvancedOpen(!isMicrosoftConsumerEnterpriseEdition() || statusResult.emailSetup?.source !== 'platform');
     }
 
     if (!statusResult.success) {
@@ -463,6 +471,41 @@ export function MicrosoftIntegrationSettings({
   React.useEffect(() => {
     void load();
   }, [load]);
+
+  const getPendingEmailApprovalUrl = React.useCallback(async () => {
+    if (!emailSetup?.profileId) {
+      setError(t('integrations.microsoft.emailSetup.errors.pendingProfileMissing', {
+        defaultValue: 'The pending Microsoft app could not be found.',
+      }));
+      return null;
+    }
+
+    const result = await getMicrosoftEmailAdminConsentUrl({ profileId: emailSetup.profileId });
+    if (!result.success || !result.url) {
+      setError(result.error || t('integrations.microsoft.emailSetup.errors.approvalLink', {
+        defaultValue: 'Could not create the Microsoft approval link.',
+      }));
+      return null;
+    }
+    return result.url;
+  }, [emailSetup?.profileId, t]);
+
+  const approvePendingEmailSetup = React.useCallback(async () => {
+    const url = await getPendingEmailApprovalUrl();
+    if (url) window.location.assign(url);
+  }, [getPendingEmailApprovalUrl]);
+
+  const copyPendingEmailApprovalLink = React.useCallback(async () => {
+    const url = await getPendingEmailApprovalUrl();
+    if (!url) return;
+    await navigator.clipboard.writeText(url);
+    toast({
+      title: t('integrations.microsoft.emailSetup.copied', {
+        defaultValue: 'Approval link copied',
+        label: t('integrations.microsoft.emailSetup.consent.approvalLink', { defaultValue: 'Approval link' }),
+      }),
+    });
+  }, [getPendingEmailApprovalUrl, t, toast]);
 
   const closeDialog = React.useCallback(() => {
     setDialogMode(null);
@@ -507,7 +550,7 @@ export function MicrosoftIntegrationSettings({
   const validateForm = React.useCallback(() => {
     if (!formState.displayName.trim()) return t('integrations.microsoft.settings.validation.displayNameRequired', { defaultValue: 'Microsoft app display name is required' });
     if (!formState.clientId.trim()) return t('integrations.microsoft.settings.validation.clientIdRequired', { defaultValue: 'Microsoft OAuth Client ID is required' });
-    if (!formState.tenantId.trim()) return t('integrations.microsoft.settings.validation.tenantIdRequired', { defaultValue: 'Microsoft Tenant ID is required' });
+    if (!formState.tenantId.trim()) return t('integrations.microsoft.settings.validation.tenantIdRequired', { defaultValue: 'Microsoft tenant ID is required' });
     if (dialogMode === 'create' && !formState.clientSecret.trim()) {
       return t('integrations.microsoft.settings.validation.clientSecretRequired', { defaultValue: 'Microsoft OAuth Client Secret is required' });
     }
@@ -731,10 +774,10 @@ export function MicrosoftIntegrationSettings({
             <div className="space-y-2">
               <CardTitle>{t('integrations.microsoft.settings.title', { defaultValue: 'Microsoft' })}</CardTitle>
               <CardDescription>
-                {isEnterpriseEdition
-                  ? emailCredentialCapability?.source === 'platform'
-                    ? t('integrations.microsoft.settings.platform.description', { defaultValue: 'Connect Microsoft 365 with the application supplied by Alga PSA. No Entra app registration is required.' })
-                    : t('integrations.microsoft.settings.descriptionEe', { defaultValue: "Manage your company's Microsoft app registrations for staff sign-in, Outlook email, calendar sync, and Teams." })
+                {emailSetup?.source === 'platform'
+                  ? t('integrations.microsoft.settings.platform.description', { defaultValue: 'Connect Microsoft 365 with the application supplied by Alga PSA. No Entra app registration is required.' })
+                  : isEnterpriseEdition
+                    ? t('integrations.microsoft.settings.descriptionEe', { defaultValue: "Manage your company's Microsoft app registrations for staff sign-in, Outlook email, calendar sync, and Teams." })
                   : t('integrations.microsoft.settings.descriptionCe', { defaultValue: "Manage your company's Microsoft app registrations for staff sign-in and Outlook email." })}
               </CardDescription>
             </div>
@@ -749,16 +792,17 @@ export function MicrosoftIntegrationSettings({
                 <RefreshCw className="mr-2 h-4 w-4" />
                 {t('integrations.microsoft.settings.actions.refresh', { defaultValue: 'Refresh' })}
               </Button>
-              <Button
-                id="microsoft-settings-email-setup-button"
-                type="button"
-                variant="outline"
-                onClick={() => setEmailSetupOpen(true)}
-                disabled={loading}
-              >
-                <WandSparkles className="mr-2 h-4 w-4" />
-                {t('integrations.microsoft.emailSetup.action', { defaultValue: 'Set up Microsoft Email' })}
-              </Button>
+              {emailSetup?.state !== 'ready' && emailSetup?.state !== 'pending_admin_consent' && (
+                <Button
+                  id="microsoft-settings-email-setup-button"
+                  type="button"
+                  onClick={() => setEmailSetupOpen(true)}
+                  disabled={loading}
+                >
+                  <WandSparkles className="mr-2 h-4 w-4" />
+                  {t('integrations.microsoft.emailSetup.action', { defaultValue: 'Set up Microsoft' })}
+                </Button>
+              )}
             </div>
           </div>
         </CardHeader>
@@ -769,15 +813,14 @@ export function MicrosoftIntegrationSettings({
             </Alert>
           )}
 
-          {isEnterpriseEdition && emailCredentialCapability?.source === 'platform' && (
-            <Alert>
-              <ShieldCheck className="h-4 w-4" />
+          {emailSetup?.state === 'ready' && (
+            <Alert variant="success">
               <AlertDescription>
                 <div className="font-medium">
                   {t('integrations.microsoft.settings.platform.title', { defaultValue: 'Microsoft email is ready to connect' })}
                 </div>
                 <div className="text-sm text-muted-foreground">
-                  {t('integrations.microsoft.settings.platform.readyDescription', { defaultValue: 'Alga PSA supplies and manages the Microsoft application. Connect a mailbox without creating an Entra app or entering client credentials.' })}
+                  {t('integrations.microsoft.settings.platform.readyDescription', { defaultValue: 'The Microsoft app is approved and ready for mailbox sign-in.' })}
                 </div>
                 <Button
                   id="microsoft-platform-connect-email"
@@ -785,21 +828,38 @@ export function MicrosoftIntegrationSettings({
                   className="mt-3"
                   onClick={() => router.push('/msp/settings/integrations?category=communication')}
                 >
-                  {t('integrations.microsoft.settings.platform.connectAction', { defaultValue: 'Connect Microsoft email' })}
+                  {t('integrations.microsoft.settings.platform.connectAction', { defaultValue: 'Connect a mailbox →' })}
                 </Button>
               </AlertDescription>
             </Alert>
           )}
 
-          {isEnterpriseEdition && emailCredentialCapability && emailCredentialCapability.source === 'none' && (
+          {emailSetup?.state === 'pending_admin_consent' && (
             <Alert variant="warning">
-              <AlertTriangle className="h-4 w-4" />
               <AlertDescription>
                 <div className="font-medium">
-                  {t('integrations.microsoft.settings.platform.unavailableTitle', { defaultValue: 'Platform Microsoft credentials are unavailable' })}
+                  {t('integrations.microsoft.emailSetup.complete.waiting', { defaultValue: 'Waiting for admin approval' })}
                 </div>
                 <div className="text-sm text-muted-foreground">
-                  {t('integrations.microsoft.settings.platform.unavailableDescription', { defaultValue: 'This deployment requires a tenant-owned Microsoft app. Use the advanced setup below to add one.' })}
+                  {t('integrations.microsoft.emailSetup.complete.consentPending', { defaultValue: 'A Microsoft 365 administrator for your organization must approve access before mailboxes can connect.' })}
+                </div>
+                <div className="mt-3 flex flex-wrap gap-2">
+                  <Button
+                    id="microsoft-pending-approve-button"
+                    type="button"
+                    onClick={() => void approvePendingEmailSetup()}
+                  >
+                    <ExternalLink className="mr-2 h-4 w-4" />
+                    {t('integrations.microsoft.emailSetup.actions.approve', { defaultValue: 'Approve in Microsoft' })}
+                  </Button>
+                  <Button
+                    id="microsoft-pending-copy-approval-link-button"
+                    type="button"
+                    variant="outline"
+                    onClick={() => void copyPendingEmailApprovalLink()}
+                  >
+                    {t('integrations.microsoft.emailSetup.actions.copyApprovalLink', { defaultValue: 'Copy approval link for your admin' })}
+                  </Button>
                 </div>
               </AlertDescription>
             </Alert>
@@ -816,10 +876,10 @@ export function MicrosoftIntegrationSettings({
               {advancedOpen ? <ChevronDown className="mr-2 h-4 w-4" /> : <ChevronRight className="mr-2 h-4 w-4" />}
               <span>
                 <span className="block font-medium">
-                  {t('integrations.microsoft.settings.advanced.title', { defaultValue: 'Bring your own Microsoft app (advanced)' })}
+                  {t('integrations.microsoft.settings.advanced.title', { defaultValue: 'Manual Microsoft apps (advanced)' })}
                 </span>
                 <span className="block text-xs font-normal text-muted-foreground">
-                  {t('integrations.microsoft.settings.advanced.description', { defaultValue: 'Create and manage tenant-owned Entra app registrations for organizations that explicitly require them.' })}
+                  {t('integrations.microsoft.settings.advanced.description', { defaultValue: 'Create and manage Entra app registrations maintained by your organization.' })}
                 </span>
               </span>
             </Button>
@@ -827,9 +887,8 @@ export function MicrosoftIntegrationSettings({
 
           {(!isEnterpriseEdition || advancedOpen) && (
             <div id="microsoft-advanced-app-settings" className="space-y-6">
-              {isEnterpriseEdition && emailCredentialCapability?.platformReady && (
+              {isEnterpriseEdition && emailSetup?.hosted && emailSetup.platformOffered && (
                 <Alert variant="warning">
-                  <AlertTriangle className="h-4 w-4" />
                   <AlertDescription>
                     {t('integrations.microsoft.settings.advanced.warning', { defaultValue: 'A custom Entra app is normally unnecessary on hosted Alga PSA. Continue only when your organization deliberately requires its own application and credentials.' })}
                   </AlertDescription>
@@ -1031,7 +1090,7 @@ export function MicrosoftIntegrationSettings({
                             <Badge variant={statusBadge.variant}>{statusBadge.label}</Badge>
                           </div>
                           <div className="text-sm text-muted-foreground">
-                            {t('integrations.microsoft.settings.profileCard.tenantIdLabel', { defaultValue: 'Tenant ID:' })} <span className="font-mono text-xs">{profile.tenantId}</span>
+                            {t('integrations.microsoft.settings.profileCard.tenantIdLabel', { defaultValue: 'Microsoft tenant ID:' })} <span className="font-mono text-xs">{profile.tenantId}</span>
                           </div>
                         </div>
                         <div className="flex flex-wrap items-center gap-2">
@@ -1248,7 +1307,7 @@ export function MicrosoftIntegrationSettings({
             </div>
 
             <div className="space-y-2">
-              <Label htmlFor="microsoft-profile-tenant-id">{t('integrations.microsoft.settings.dialog.tenantId', { defaultValue: 'Tenant ID' })}</Label>
+              <Label htmlFor="microsoft-profile-tenant-id">{t('integrations.microsoft.settings.dialog.tenantId', { defaultValue: 'Microsoft tenant ID' })}</Label>
               <Input
                 id="microsoft-profile-tenant-id"
                 value={formState.tenantId}
@@ -1327,10 +1386,6 @@ export function MicrosoftIntegrationSettings({
         isOpen={emailSetupOpen}
         onClose={() => setEmailSetupOpen(false)}
         onCompleted={load}
-        onManualSetup={() => {
-          setEmailSetupOpen(false);
-          openCreateDialog();
-        }}
       />
 
       <ConfirmationDialog

--- a/packages/integrations/src/lib/microsoftConsumerProfileResolution.test.ts
+++ b/packages/integrations/src/lib/microsoftConsumerProfileResolution.test.ts
@@ -235,11 +235,47 @@ describe('resolveMicrosoftConsumerProfileConfig', () => {
     );
 
     await expect(resolveMicrosoftConsumerProfileConfig('tenant-pending-consent', 'email')).resolves.toEqual({
-      status: 'invalid_profile',
+      status: 'pending_admin_consent',
       tenantId: 'tenant-pending-consent',
       consumerType: 'email',
       profileId: 'profile-pending-consent',
-      message: 'Selected Email Microsoft profile is awaiting tenant administrator consent',
+      clientId: 'pending-consent-client-id',
+      credentialSource: 'binding',
+      message: 'Microsoft 365 administrator approval is still required',
+    });
+  });
+
+  it('surfaces an unbound pending Email profile before the hosted app fallback', async () => {
+    hoisted.state.appSecrets.set('MICROSOFT_CLIENT_ID', 'hosted-client-id');
+    hoisted.state.appSecrets.set('MICROSOFT_CLIENT_SECRET', 'hosted-client-secret');
+    hoisted.state.microsoftProfiles.push({
+      tenant: 'tenant-unbound-pending',
+      profile_id: 'profile-unbound-pending',
+      display_name: 'Pending Platform App',
+      display_name_normalized: 'pending platform app',
+      client_id: 'hosted-client-id',
+      tenant_id: 'microsoft-directory-id',
+      client_secret_ref: 'pending-platform-secret-ref',
+      email_admin_consent_required: true,
+      email_admin_consent_granted_at: null,
+      capabilities: ['email'],
+      is_default: false,
+      is_archived: false,
+      archived_at: null,
+      created_by: null,
+      updated_by: null,
+      created_at: new Date().toISOString(),
+      updated_at: new Date().toISOString(),
+    });
+
+    await expect(resolveMicrosoftConsumerProfileConfig('tenant-unbound-pending', 'email')).resolves.toEqual({
+      status: 'pending_admin_consent',
+      tenantId: 'tenant-unbound-pending',
+      consumerType: 'email',
+      profileId: 'profile-unbound-pending',
+      clientId: 'hosted-client-id',
+      credentialSource: 'binding',
+      message: 'Microsoft 365 administrator approval is still required',
     });
   });
 

--- a/packages/integrations/src/lib/microsoftConsumerProfileResolution.ts
+++ b/packages/integrations/src/lib/microsoftConsumerProfileResolution.ts
@@ -58,7 +58,7 @@ export interface MicrosoftBindingCandidateProfile {
   is_archived: boolean;
 }
 
-type ResolverStatus = 'ready' | 'not_configured' | 'invalid_profile';
+type ResolverStatus = 'ready' | 'not_configured' | 'pending_admin_consent' | 'invalid_profile';
 export type MicrosoftCredentialSource = 'binding' | 'app';
 export type MicrosoftCredentialPreference = 'tenant' | 'platform';
 
@@ -256,6 +256,25 @@ async function getMicrosoftConsumerBindingRow(
     .first() as MicrosoftConsumerBindingRow | undefined;
 
   return row || undefined;
+}
+
+async function getPendingMicrosoftEmailProfile(
+  db: any,
+  tenant: string
+): Promise<MicrosoftProfileRow | undefined> {
+  const profiles = await getTenantMicrosoftProfiles(db, tenant);
+
+  return profiles
+    .filter((profile) => (
+      profile.email_admin_consent_required &&
+      !profile.email_admin_consent_granted_at &&
+      !profile.is_archived &&
+      profileHasCapability(profile, 'email')
+    ))
+    .sort((left, right) => {
+      if (left.is_default !== right.is_default) return left.is_default ? -1 : 1;
+      return new Date(right.updated_at).getTime() - new Date(left.updated_at).getTime();
+    })[0];
 }
 
 async function getMicrosoftProfileRow(
@@ -491,6 +510,21 @@ export async function resolveMicrosoftConsumerProfileConfig(
   const binding = await ensureMicrosoftConsumerBindingMigration(db, tenantId, consumerType, secretProvider);
 
   if (!binding) {
+    if (consumerType === 'email') {
+      const pendingProfile = await getPendingMicrosoftEmailProfile(db, tenantId);
+      if (pendingProfile) {
+        return {
+          status: 'pending_admin_consent',
+          tenantId,
+          consumerType,
+          profileId: pendingProfile.profile_id,
+          clientId: pendingProfile.client_id,
+          credentialSource: 'binding',
+          message: 'Microsoft 365 administrator approval is still required',
+        };
+      }
+    }
+
     if (consumerType === 'email' && options?.credentialPreference !== 'tenant') {
       const hostedEmailConfig = await resolveHostedMicrosoftEmailConfig(tenantId, secretProvider);
       if (hostedEmailConfig) {
@@ -540,11 +574,13 @@ export async function resolveMicrosoftConsumerProfileConfig(
     !profile.email_admin_consent_granted_at
   ) {
     return {
-      status: 'invalid_profile',
+      status: 'pending_admin_consent',
       tenantId,
       consumerType,
       profileId: profile.profile_id,
-      message: 'Selected Email Microsoft profile is awaiting tenant administrator consent',
+      clientId: profile.client_id,
+      credentialSource: 'binding',
+      message: 'Microsoft 365 administrator approval is still required',
     };
   }
 

--- a/scripts/capture-microsoft-email-smoke-evidence.mjs
+++ b/scripts/capture-microsoft-email-smoke-evidence.mjs
@@ -47,9 +47,11 @@ import fs from 'node:fs';
 import http from 'node:http';
 import path from 'node:path';
 import process from 'node:process';
+import { pathToFileURL } from 'node:url';
 import { isDeepStrictEqual } from 'node:util';
 import { parse as parseDotenv } from 'dotenv';
 import pg from 'pg';
+import { truncatedMtimeMs } from './microsoft-email-smoke-timestamps.mjs';
 
 const { Client } = pg;
 const UUID_PATTERN = /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
@@ -388,6 +390,9 @@ function secretInventory(repoRoot, environment, tenantId) {
           name: path.relative(tenantSecretDirectory, entryPath),
           bytes: stat.size,
           mode: stat.mode & 0o777,
+          // Pre-existing secret files are never mutated by the fixture, so
+          // their timestamps are compared at full stat fidelity.
+          mtimeMs: stat.mtimeMs,
           sha256: sha256File(entryPath),
         });
       } else {
@@ -403,11 +408,18 @@ function secretInventory(repoRoot, environment, tenantId) {
     visit(tenantSecretDirectory);
   }
   files.sort((left, right) => left.name.localeCompare(right.name));
+  const directoryExists = fs.existsSync(tenantSecretDirectory);
   return {
     provider: 'filesystem',
     basePath,
     tenantDirectory: tenantSecretDirectory,
-    directoryExists: fs.existsSync(tenantSecretDirectory),
+    directoryExists,
+    // The tenant directory's mtime churns when the fixture writes or deletes
+    // its secret file and is restored through fs.utimes, which is faithful to
+    // the millisecond but not the nanosecond; compare at whole milliseconds.
+    directoryMtimeMs: directoryExists
+      ? truncatedMtimeMs(fs.statSync(tenantSecretDirectory))
+      : null,
     files,
   };
 }
@@ -813,19 +825,26 @@ function createManifest(args) {
   }, null, 2));
 }
 
-try {
-  if (!COMMANDS.has(command)) {
-    fail('Expected command: before, after, correlate, or manifest');
+export { exactComparison, secretInventory };
+
+const invokedAsScript = process.argv[1]
+  && import.meta.url === pathToFileURL(process.argv[1]).href;
+
+if (invokedAsScript) {
+  try {
+    if (!COMMANDS.has(command)) {
+      fail('Expected command: before, after, correlate, or manifest');
+    }
+    const args = parseArguments(rawArguments);
+    if (command === 'before' || command === 'after') {
+      await capturePhase(command, args);
+    } else if (command === 'correlate') {
+      correlate(args);
+    } else {
+      createManifest(args);
+    }
+  } catch (error) {
+    console.error(error instanceof Error ? error.message : String(error));
+    process.exitCode = 1;
   }
-  const args = parseArguments(rawArguments);
-  if (command === 'before' || command === 'after') {
-    await capturePhase(command, args);
-  } else if (command === 'correlate') {
-    correlate(args);
-  } else {
-    createManifest(args);
-  }
-} catch (error) {
-  console.error(error instanceof Error ? error.message : String(error));
-  process.exitCode = 1;
 }

--- a/scripts/capture-microsoft-email-smoke-evidence.mjs
+++ b/scripts/capture-microsoft-email-smoke-evidence.mjs
@@ -15,9 +15,30 @@
  *   node scripts/capture-microsoft-email-smoke-evidence.mjs after <same options>
  *   node scripts/capture-microsoft-email-smoke-evidence.mjs correlate \
  *     --evidence-dir=<dir> --dom-file=<full-dom.html> \
- *     --screenshot-file=<cleanup.png> --render-method=<description>
+ *     --screenshot-file=<cleanup.png> \
+ *     --capture-provenance-file=<browser-capture.json>
  *   node scripts/capture-microsoft-email-smoke-evidence.mjs manifest \
  *     --evidence-dir=<dir>
+ *
+ * The browser capture provenance file must contain the same `provenance`
+ * object embedded in the DOM as JSON in
+ * `<script id="alga-smoke-capture-provenance" type="application/json">`.
+ * It must also bind the exact exported DOM and PNG by filename and SHA-256:
+ * {
+ *   "provenance": {
+ *     "workflowRunId": "<uuid>",
+ *     "captureNonce": "<uuid>",
+ *     "capturedAt": "<ISO timestamp>",
+ *     "browser": { "userAgent": "...", "url": "...", "platform": "..." }
+ *   },
+ *   "artifacts": {
+ *     "dom": { "file": "final.html", "sha256": "..." },
+ *     "screenshot": { "file": "final.png", "sha256": "..." }
+ *   },
+ *   "renderMethod": "...",
+ *   "crossHostFidelityNote": "...",
+ *   "externalGraphLimitation": "No external Microsoft Graph or Entra OAuth call is performed by this evidence helper."
+ * }
  */
 
 import { spawnSync } from 'node:child_process';
@@ -26,12 +47,37 @@ import fs from 'node:fs';
 import http from 'node:http';
 import path from 'node:path';
 import process from 'node:process';
+import { isDeepStrictEqual } from 'node:util';
 import { parse as parseDotenv } from 'dotenv';
 import pg from 'pg';
 
 const { Client } = pg;
 const UUID_PATTERN = /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
+const SHA256_PATTERN = /^[0-9a-f]{64}$/i;
 const COMMANDS = new Set(['before', 'after', 'correlate', 'manifest']);
+const EXTERNAL_GRAPH_LIMITATION = 'No external Microsoft Graph or Entra OAuth call is performed by this evidence helper.';
+const CROSS_HOST_CONTEXT = 'The card browser is Mac-hosted while the worktree server runs on Linux through a localhost-to-Tailscale relay.';
+const PHASE_FILES = {
+  before: [
+    '01-before-git-status.txt',
+    '01-before-secret-inventory.json',
+    '01-before-runtime-build.json',
+    '01-before-port-route-health.json',
+    '01-before-database.json',
+  ],
+  after: [
+    '90-after-git-status.txt',
+    '90-after-secret-inventory.json',
+    '90-after-runtime-build.json',
+    '90-after-port-route-health.json',
+    '90-after-database.json',
+    '91-restoration-comparison.json',
+  ],
+};
+const PHASE_MARKERS = {
+  before: '02-before-assertions-passed.json',
+  after: '92-after-assertions-passed.json',
+};
 const [command, ...rawArguments] = process.argv.slice(2);
 
 function fail(message) {
@@ -89,12 +135,31 @@ function sha256File(filePath) {
   return createHash('sha256').update(fs.readFileSync(filePath)).digest('hex');
 }
 
+function deterministicFixtureProfileId(tenantId) {
+  const bytes = createHash('sha256')
+    .update(`alga0002215:${tenantId}:ready-false-profile`)
+    .digest()
+    .subarray(0, 16);
+  bytes[6] = (bytes[6] & 0x0f) | 0x40;
+  bytes[8] = (bytes[8] & 0x3f) | 0x80;
+  const hex = bytes.toString('hex');
+  return `${hex.slice(0, 8)}-${hex.slice(8, 12)}-${hex.slice(12, 16)}-${hex.slice(16, 20)}-${hex.slice(20)}`;
+}
+
 function writeNew(filePath, contents) {
   fs.writeFileSync(filePath, contents, { encoding: 'utf8', flag: 'wx' });
 }
 
 function writeJsonNew(filePath, value) {
   writeNew(filePath, `${JSON.stringify(value, null, 2)}\n`);
+}
+
+function readJson(filePath, label = path.basename(filePath)) {
+  try {
+    return JSON.parse(fs.readFileSync(filePath, 'utf8'));
+  } catch (error) {
+    fail(`Could not read ${label}: ${error instanceof Error ? error.message : String(error)}`);
+  }
 }
 
 function transcript(result) {
@@ -127,6 +192,29 @@ function assertInsideEvidenceDirectory(evidenceDirectory, filePath, label) {
     fail(`${label} is not a regular file: ${resolved}`);
   }
   return resolved;
+}
+
+function assertNonEmptyString(value, label) {
+  if (typeof value !== 'string' || value.trim() === '') {
+    fail(`${label} must be a non-empty string`);
+  }
+  return value;
+}
+
+function fileIdentity(filePath) {
+  return {
+    file: path.basename(filePath),
+    bytes: fs.statSync(filePath).size,
+    sha256: sha256File(filePath),
+  };
+}
+
+function exactComparison(baseline, after) {
+  return {
+    exactMatch: isDeepStrictEqual(baseline, after),
+    baseline,
+    after,
+  };
 }
 
 function repositoryRoot() {
@@ -228,12 +316,18 @@ async function databaseSnapshot(environment, tenantId) {
              inet_server_port() AS server_port,
              version() AS postgres_version
     `);
+    const profileResult = await client.query(
+      `SELECT row_to_json(profile) AS profile
+         FROM microsoft_profiles AS profile
+        WHERE tenant = $1
+        ORDER BY profile_id`,
+      [tenantId]
+    );
     const bindingResult = await client.query(
       `SELECT row_to_json(binding) AS binding
          FROM microsoft_profile_consumer_bindings AS binding
         WHERE tenant = $1
-          AND consumer_type = 'email'
-        ORDER BY profile_id`,
+        ORDER BY consumer_type, profile_id`,
       [tenantId]
     );
     return {
@@ -244,26 +338,77 @@ async function databaseSnapshot(environment, tenantId) {
         database: connection.database,
       },
       identity: identityResult.rows[0],
-      emailConsumerBindings: bindingResult.rows.map((row) => row.binding),
+      microsoftProfiles: profileResult.rows.map((row) => row.profile),
+      microsoftConsumerBindings: bindingResult.rows.map((row) => row.binding),
     };
   } finally {
     await client.end();
   }
 }
 
-function secretAbsence(repoRoot, tenantId, profileId) {
-  const secretReference = `microsoft_profile_${profileId}_client_secret`;
-  const tenantSecretDirectory = path.join(repoRoot, 'secrets', 'tenants', tenantId);
-  const target = path.join(tenantSecretDirectory, secretReference);
-  const microsoftProfileFiles = fs.existsSync(tenantSecretDirectory)
-    ? fs.readdirSync(tenantSecretDirectory)
-      .filter((name) => name.startsWith('microsoft_profile_'))
-      .sort()
-    : [];
+function resolveFilesystemSecretBase(repoRoot, environment) {
+  const writeProvider = environment.SECRET_WRITE_PROVIDER || 'filesystem';
+  if (writeProvider !== 'filesystem') {
+    fail(
+      `This local evidence helper requires SECRET_WRITE_PROVIDER=filesystem to inventory every mutated tenant secret; received ${writeProvider}`
+    );
+  }
+
+  const configured = environment.SECRET_FS_BASE_PATH?.trim();
+  if (configured) {
+    return path.isAbsolute(configured) ? configured : path.resolve(repoRoot, configured);
+  }
+  if (fs.existsSync('/run/secrets')) {
+    return '/run/secrets';
+  }
+  for (const candidate of [path.join(repoRoot, 'secrets'), path.resolve(repoRoot, '../secrets')]) {
+    if (fs.existsSync(candidate)) {
+      return candidate;
+    }
+  }
+  return path.resolve(repoRoot, '../secrets');
+}
+
+function secretInventory(repoRoot, environment, tenantId) {
+  const basePath = resolveFilesystemSecretBase(repoRoot, environment);
+  const tenantSecretDirectory = path.join(basePath, 'tenants', tenantId);
+  const files = [];
+
+  function visit(directory) {
+    for (const entry of fs.readdirSync(directory, { withFileTypes: true })) {
+      const entryPath = path.join(directory, entry.name);
+      if (entry.isSymbolicLink()) {
+        fail(`Refusing to inventory symbolic link in tenant secrets: ${entryPath}`);
+      }
+      if (entry.isDirectory()) {
+        visit(entryPath);
+      } else if (entry.isFile()) {
+        const stat = fs.statSync(entryPath);
+        files.push({
+          name: path.relative(tenantSecretDirectory, entryPath),
+          bytes: stat.size,
+          mode: stat.mode & 0o777,
+          sha256: sha256File(entryPath),
+        });
+      } else {
+        fail(`Unsupported tenant secret entry: ${entryPath}`);
+      }
+    }
+  }
+
+  if (fs.existsSync(tenantSecretDirectory)) {
+    if (!fs.statSync(tenantSecretDirectory).isDirectory()) {
+      fail(`Tenant secret path is not a directory: ${tenantSecretDirectory}`);
+    }
+    visit(tenantSecretDirectory);
+  }
+  files.sort((left, right) => left.name.localeCompare(right.name));
   return {
-    target: path.relative(repoRoot, target),
-    targetExists: fs.existsSync(target),
-    microsoftProfileFiles,
+    provider: 'filesystem',
+    basePath,
+    tenantDirectory: tenantSecretDirectory,
+    directoryExists: fs.existsSync(tenantSecretDirectory),
+    files,
   };
 }
 
@@ -284,6 +429,50 @@ function provenance(repoRoot, port) {
   };
 }
 
+function writePhaseMarker(evidenceDirectory, phase, workflowRunId) {
+  const files = PHASE_FILES[phase].map((name) => {
+    const filePath = path.join(evidenceDirectory, name);
+    if (!fs.existsSync(filePath)) {
+      fail(`Cannot mark ${phase} successful because ${name} is missing`);
+    }
+    return fileIdentity(filePath);
+  });
+  writeJsonNew(path.join(evidenceDirectory, PHASE_MARKERS[phase]), {
+    workflowRunId,
+    phase,
+    assertionsPassed: true,
+    recordedAt: new Date().toISOString(),
+    externalGraphLimitation: EXTERNAL_GRAPH_LIMITATION,
+    files,
+  });
+}
+
+function verifyPhaseMarker(evidenceDirectory, phase, workflowRunId) {
+  const markerPath = path.join(evidenceDirectory, PHASE_MARKERS[phase]);
+  if (!fs.existsSync(markerPath)) {
+    fail(`The ${phase} assertions-passed marker is missing`);
+  }
+  const marker = readJson(markerPath, `${phase} assertions-passed marker`);
+  if (marker.workflowRunId !== workflowRunId
+    || marker.phase !== phase
+    || marker.assertionsPassed !== true
+    || marker.externalGraphLimitation !== EXTERNAL_GRAPH_LIMITATION) {
+    fail(`The ${phase} assertions-passed marker is invalid`);
+  }
+  if (!Array.isArray(marker.files)
+    || marker.files.length !== PHASE_FILES[phase].length
+    || !isDeepStrictEqual(marker.files.map((file) => file.file), PHASE_FILES[phase])) {
+    fail(`The ${phase} assertions-passed marker has an incomplete file inventory`);
+  }
+  for (const expected of marker.files) {
+    const filePath = path.join(evidenceDirectory, expected.file);
+    if (!fs.existsSync(filePath) || !isDeepStrictEqual(fileIdentity(filePath), expected)) {
+      fail(`The ${phase} artifact changed after its assertions passed: ${expected.file}`);
+    }
+  }
+  return marker;
+}
+
 async function capturePhase(phase, args) {
   const evidenceDirectory = resolveEvidenceDirectory(requireArgument(args, 'evidence-dir'));
   const workflowRunId = requireArgument(args, 'workflow-run-id');
@@ -291,6 +480,10 @@ async function capturePhase(phase, args) {
   const profileId = requireArgument(args, 'profile-id');
   if (!UUID_PATTERN.test(workflowRunId) || !UUID_PATTERN.test(tenantId) || !UUID_PATTERN.test(profileId)) {
     fail('workflow-run-id, tenant-id, and profile-id must be UUIDs');
+  }
+  const expectedProfileId = deterministicFixtureProfileId(tenantId);
+  if (profileId !== expectedProfileId) {
+    fail(`profile-id must identify this tenant's smoke fixture: ${expectedProfileId}`);
   }
 
   const repoRoot = repositoryRoot();
@@ -310,28 +503,75 @@ async function capturePhase(phase, args) {
       appUrl,
       tenantId,
       profileId,
-      externalGraphLimitation: 'No external Microsoft Graph or Entra OAuth call is performed by this evidence helper.',
-      crossHostFidelity: 'The card browser is Mac-hosted while the worktree server runs on Linux through a localhost-to-Tailscale relay. If native background-pane clicks or screenshots time out, record the React-handler fallback and live-DOM rendering method in the final correlation artifact.',
+      externalGraphLimitation: EXTERNAL_GRAPH_LIMITATION,
+      crossHostContext: CROSS_HOST_CONTEXT,
     });
   } else {
     const metadataPath = path.join(evidenceDirectory, '00-workflow-run.json');
-    const metadata = JSON.parse(fs.readFileSync(metadataPath, 'utf8'));
+    const metadata = readJson(metadataPath, 'workflow metadata');
     if (metadata.workflowRunId !== workflowRunId
       || metadata.tenantId !== tenantId
-      || metadata.profileId !== profileId) {
+      || metadata.profileId !== profileId
+      || metadata.externalGraphLimitation !== EXTERNAL_GRAPH_LIMITATION
+      || metadata.crossHostContext !== CROSS_HOST_CONTEXT) {
       fail('The after arguments do not match the before metadata');
     }
+    verifyPhaseMarker(evidenceDirectory, 'before', workflowRunId);
   }
 
   const prefix = phase === 'before' ? '01-before' : '90-after';
   const gitStatus = run('git', ['status', '--short'], repoRoot);
-  const secrets = secretAbsence(repoRoot, tenantId, profileId);
+  const secrets = secretInventory(repoRoot, environment, tenantId);
   const runtime = provenance(repoRoot, port);
   const routes = await routeHealth(appUrl);
   const database = await databaseSnapshot(environment, tenantId);
+  let restoration;
+  if (phase === 'after') {
+    const baselineDatabase = readJson(
+      path.join(evidenceDirectory, '01-before-database.json'),
+      'before database snapshot'
+    );
+    const baselineSecrets = readJson(
+      path.join(evidenceDirectory, '01-before-secret-inventory.json'),
+      'before secret inventory'
+    );
+    restoration = {
+      microsoftProfiles: exactComparison(
+        baselineDatabase.microsoftProfiles,
+        database.microsoftProfiles
+      ),
+      microsoftConsumerBindings: exactComparison(
+        baselineDatabase.microsoftConsumerBindings,
+        database.microsoftConsumerBindings
+      ),
+      tenantSecrets: exactComparison(baselineSecrets, secrets),
+    };
+    restoration.exactMatch = Object.values(restoration)
+      .every((comparison) => comparison === true || comparison.exactMatch === true);
+    if (!restoration.exactMatch) {
+      const failures = Object.entries(restoration)
+        .filter(([, comparison]) => comparison !== false && comparison.exactMatch === false)
+        .map(([name]) => name);
+      fail(`Cleanup did not restore the complete baseline inventories: ${failures.join(', ')}`);
+    }
+  }
+
+  if (gitStatus.exitCode !== 0) {
+    fail('git status failed');
+  }
+  const fixtureSecretName = `microsoft_profile_${profileId}_client_secret`;
+  if (database.microsoftProfiles.some((profile) => profile.profile_id === profileId)) {
+    fail(`The smoke fixture profile exists during the ${phase} capture`);
+  }
+  if (secrets.files.some((file) => file.name === fixtureSecretName)) {
+    fail(`The smoke fixture secret exists during the ${phase} capture`);
+  }
+  if (runtime.listeningProcesses.length === 0 || routes.some((route) => !route.status)) {
+    fail('The application listener or route health check failed');
+  }
 
   writeNew(path.join(evidenceDirectory, `${prefix}-git-status.txt`), transcript(gitStatus));
-  writeJsonNew(path.join(evidenceDirectory, `${prefix}-secret-absence.json`), secrets);
+  writeJsonNew(path.join(evidenceDirectory, `${prefix}-secret-inventory.json`), secrets);
   writeJsonNew(path.join(evidenceDirectory, `${prefix}-runtime-build.json`), runtime);
   writeJsonNew(path.join(evidenceDirectory, `${prefix}-port-route-health.json`), {
     appUrl,
@@ -339,34 +579,58 @@ async function capturePhase(phase, args) {
     routes,
   });
   writeJsonNew(path.join(evidenceDirectory, `${prefix}-database.json`), database);
-
   if (phase === 'after') {
-    const baseline = JSON.parse(
-      fs.readFileSync(path.join(evidenceDirectory, '01-before-database.json'), 'utf8')
-    );
-    const restoration = {
-      exactMatch: JSON.stringify(baseline.emailConsumerBindings)
-        === JSON.stringify(database.emailConsumerBindings),
-      baseline: baseline.emailConsumerBindings,
-      after: database.emailConsumerBindings,
-    };
-    writeJsonNew(path.join(evidenceDirectory, '91-database-restoration-comparison.json'), restoration);
-    if (!restoration.exactMatch) {
-      fail('The final Microsoft Email binding does not exactly match the recorded baseline');
-    }
+    writeJsonNew(path.join(evidenceDirectory, '91-restoration-comparison.json'), restoration);
   }
-
-  if (gitStatus.exitCode !== 0) {
-    fail('git status failed');
-  }
-  if (secrets.targetExists) {
-    fail(`Target smoke secret exists during the ${phase} capture`);
-  }
-  if (runtime.listeningProcesses.length === 0 || routes.some((route) => !route.status)) {
-    fail('The application listener or route health check failed');
-  }
+  writePhaseMarker(evidenceDirectory, phase, workflowRunId);
 
   console.log(JSON.stringify({ phase, workflowRunId, evidenceDirectory }, null, 2));
+}
+
+function validateCaptureProvenance(value, metadata) {
+  if (!value || typeof value !== 'object') {
+    fail('Capture provenance must be a JSON object');
+  }
+  if (value.workflowRunId !== metadata.workflowRunId) {
+    fail('Capture provenance workflowRunId does not match the evidence run');
+  }
+  if (!UUID_PATTERN.test(value.captureNonce || '')) {
+    fail('Capture provenance captureNonce must be a UUID');
+  }
+  const capturedAt = new Date(value.capturedAt);
+  if (typeof value.capturedAt !== 'string' || Number.isNaN(capturedAt.valueOf())) {
+    fail('Capture provenance capturedAt must be an ISO timestamp');
+  }
+  if (capturedAt.toISOString() !== value.capturedAt) {
+    fail('Capture provenance capturedAt must use canonical ISO format');
+  }
+  if (!value.browser || typeof value.browser !== 'object') {
+    fail('Capture provenance must include browser details');
+  }
+  assertNonEmptyString(value.browser.userAgent, 'Browser userAgent');
+  assertNonEmptyString(value.browser.url, 'Browser URL');
+  assertNonEmptyString(value.browser.platform, 'Browser platform');
+  let browserUrl;
+  try {
+    browserUrl = new URL(value.browser.url);
+  } catch {
+    fail('Browser provenance URL must be valid');
+  }
+  if (browserUrl.origin !== new URL(metadata.appUrl).origin) {
+    fail('Browser provenance URL does not belong to the recorded application origin');
+  }
+  return value;
+}
+
+function captureArtifactMatches(actualPath, declared, label) {
+  if (!declared || typeof declared !== 'object') {
+    fail(`Capture provenance is missing the ${label} artifact identity`);
+  }
+  if (declared.file !== path.basename(actualPath)
+    || !SHA256_PATTERN.test(declared.sha256 || '')
+    || declared.sha256 !== sha256File(actualPath)) {
+    fail(`Capture provenance does not bind the exact ${label} artifact`);
+  }
 }
 
 function correlate(args) {
@@ -381,12 +645,56 @@ function correlate(args) {
     requireArgument(args, 'screenshot-file'),
     'Screenshot file'
   );
-  const metadata = JSON.parse(
-    fs.readFileSync(path.join(evidenceDirectory, '00-workflow-run.json'), 'utf8')
+  const captureProvenanceFile = assertInsideEvidenceDirectory(
+    evidenceDirectory,
+    requireArgument(args, 'capture-provenance-file'),
+    'Capture provenance file'
   );
+  const metadata = readJson(
+    path.join(evidenceDirectory, '00-workflow-run.json'),
+    'workflow metadata'
+  );
+  if (metadata.externalGraphLimitation !== EXTERNAL_GRAPH_LIMITATION
+    || metadata.crossHostContext !== CROSS_HOST_CONTEXT) {
+    fail('Workflow metadata is missing the required limitations');
+  }
+  verifyPhaseMarker(evidenceDirectory, 'before', metadata.workflowRunId);
+  verifyPhaseMarker(evidenceDirectory, 'after', metadata.workflowRunId);
+
+  const captureRecord = readJson(captureProvenanceFile, 'browser capture provenance');
+  const captureProvenance = validateCaptureProvenance(captureRecord.provenance, metadata);
+  if (!captureRecord.artifacts || typeof captureRecord.artifacts !== 'object') {
+    fail('Capture provenance must include artifact identities');
+  }
+  captureArtifactMatches(domFile, captureRecord.artifacts.dom, 'DOM');
+  captureArtifactMatches(screenshotFile, captureRecord.artifacts.screenshot, 'screenshot');
+  const renderMethod = assertNonEmptyString(captureRecord.renderMethod, 'Render method');
+  const crossHostFidelityNote = assertNonEmptyString(
+    captureRecord.crossHostFidelityNote,
+    'Cross-host fidelity note'
+  );
+  if (captureRecord.externalGraphLimitation !== EXTERNAL_GRAPH_LIMITATION) {
+    fail('Capture provenance must preserve the no-external-Graph limitation');
+  }
+
   const domContents = fs.readFileSync(domFile, 'utf8');
   if (!/<html[\s>]/i.test(domContents) || !/<\/html>/i.test(domContents)) {
     fail('The DOM artifact must contain a complete HTML document');
+  }
+  const embeddedMatch = /<script\b[^>]*\bid=["']alga-smoke-capture-provenance["'][^>]*>([\s\S]*?)<\/script>/i
+    .exec(domContents);
+  if (!embeddedMatch) {
+    fail('The DOM artifact is missing its embedded capture provenance');
+  }
+  let embeddedProvenance;
+  try {
+    embeddedProvenance = JSON.parse(embeddedMatch[1]);
+  } catch (error) {
+    fail(`The DOM capture provenance is not valid JSON: ${error instanceof Error ? error.message : String(error)}`);
+  }
+  validateCaptureProvenance(embeddedProvenance, metadata);
+  if (!isDeepStrictEqual(embeddedProvenance, captureProvenance)) {
+    fail('The DOM and PNG capture record do not share the same nonce, timestamp, and browser provenance');
   }
   const pngSignature = fs.readFileSync(screenshotFile).subarray(0, 8).toString('hex');
   if (pngSignature !== '89504e470d0a1a0a') {
@@ -394,32 +702,76 @@ function correlate(args) {
   }
   writeJsonNew(path.join(evidenceDirectory, '95-final-dom-screenshot-correlation.json'), {
     workflowRunId: metadata.workflowRunId,
-    capturedAt: new Date().toISOString(),
-    dom: {
-      file: path.basename(domFile),
-      bytes: fs.statSync(domFile).size,
-      sha256: sha256File(domFile),
-    },
-    screenshot: {
-      file: path.basename(screenshotFile),
-      bytes: fs.statSync(screenshotFile).size,
-      sha256: sha256File(screenshotFile),
-    },
-    renderMethod: requireArgument(args, 'render-method'),
-    fidelityNote: args['fidelity-note'] || null,
+    correlatedAt: new Date().toISOString(),
+    sameCaptureProven: true,
+    provenance: captureProvenance,
+    dom: fileIdentity(domFile),
+    screenshot: fileIdentity(screenshotFile),
+    captureProvenanceFile: fileIdentity(captureProvenanceFile),
+    renderMethod,
+    crossHostContext: CROSS_HOST_CONTEXT,
+    crossHostFidelityNote,
+    externalGraphLimitation: EXTERNAL_GRAPH_LIMITATION,
   });
 }
 
 function createManifest(args) {
   const evidenceDirectory = resolveEvidenceDirectory(requireArgument(args, 'evidence-dir'));
-  const metadata = JSON.parse(
-    fs.readFileSync(path.join(evidenceDirectory, '00-workflow-run.json'), 'utf8')
+  const metadata = readJson(
+    path.join(evidenceDirectory, '00-workflow-run.json'),
+    'workflow metadata'
   );
-  if (!fs.existsSync(path.join(evidenceDirectory, '95-final-dom-screenshot-correlation.json'))) {
+  if (metadata.externalGraphLimitation !== EXTERNAL_GRAPH_LIMITATION
+    || metadata.crossHostContext !== CROSS_HOST_CONTEXT) {
+    fail('Workflow metadata is missing the required limitations');
+  }
+  verifyPhaseMarker(evidenceDirectory, 'before', metadata.workflowRunId);
+  verifyPhaseMarker(evidenceDirectory, 'after', metadata.workflowRunId);
+
+  const correlationPath = path.join(
+    evidenceDirectory,
+    '95-final-dom-screenshot-correlation.json'
+  );
+  if (!fs.existsSync(correlationPath)) {
     fail('Run correlate before creating the manifest');
   }
-  if (!fs.existsSync(path.join(evidenceDirectory, '91-database-restoration-comparison.json'))) {
+  const restorationPath = path.join(evidenceDirectory, '91-restoration-comparison.json');
+  if (!fs.existsSync(restorationPath)) {
     fail('Run the after capture before creating the manifest');
+  }
+  const restoration = readJson(restorationPath, 'restoration comparison');
+  const restorationSections = [
+    restoration.microsoftProfiles,
+    restoration.microsoftConsumerBindings,
+    restoration.tenantSecrets,
+  ];
+  if (restoration.exactMatch !== true
+    || restorationSections.some((comparison) => comparison?.exactMatch !== true)) {
+    fail('The complete profile, binding, and secret inventories were not restored exactly');
+  }
+  const correlation = readJson(correlationPath, 'final DOM/PNG correlation');
+  if (correlation.workflowRunId !== metadata.workflowRunId
+    || correlation.sameCaptureProven !== true
+    || correlation.externalGraphLimitation !== EXTERNAL_GRAPH_LIMITATION
+    || correlation.crossHostContext !== CROSS_HOST_CONTEXT) {
+    fail('The final DOM/PNG correlation is incomplete');
+  }
+  assertNonEmptyString(correlation.crossHostFidelityNote, 'Cross-host fidelity note');
+  assertNonEmptyString(correlation.renderMethod, 'Render method');
+  validateCaptureProvenance(correlation.provenance, metadata);
+  for (const artifact of [correlation.dom, correlation.screenshot, correlation.captureProvenanceFile]) {
+    const artifactPath = path.join(evidenceDirectory, artifact?.file || '');
+    if (!artifact?.file
+      || !fs.existsSync(artifactPath)
+      || !isDeepStrictEqual(fileIdentity(artifactPath), artifact)) {
+      fail(`A correlated capture artifact changed before sealing: ${artifact?.file || 'unknown'}`);
+    }
+  }
+
+  for (const outputName of ['98-sha256-manifest.json', 'SHA256SUMS']) {
+    if (fs.existsSync(path.join(evidenceDirectory, outputName))) {
+      fail(`Refusing to overwrite existing sealed artifact: ${outputName}`);
+    }
   }
 
   const excluded = new Set(['98-sha256-manifest.json', 'SHA256SUMS']);
@@ -436,6 +788,12 @@ function createManifest(args) {
   writeJsonNew(path.join(evidenceDirectory, '98-sha256-manifest.json'), {
     workflowRunId: metadata.workflowRunId,
     generatedAt: new Date().toISOString(),
+    assertionsPassed: true,
+    restorationExact: true,
+    sameCaptureProven: true,
+    externalGraphLimitation: EXTERNAL_GRAPH_LIMITATION,
+    crossHostContext: CROSS_HOST_CONTEXT,
+    crossHostFidelityNote: correlation.crossHostFidelityNote,
     files,
   });
 

--- a/scripts/capture-microsoft-email-smoke-evidence.mjs
+++ b/scripts/capture-microsoft-email-smoke-evidence.mjs
@@ -18,10 +18,18 @@
  * review entrypoint rendered deterministically from that sealed evidence
  * (the verifier re-renders it and fails on any byte difference), and
  * `97-verify-evidence.mjs`, a sealed copy of
- * scripts/verify-microsoft-email-smoke-evidence.mjs. After sealing, the
- * manifest stage runs that verifier against its own output and fails unless
- * every claim passes, so a sealed bundle is by construction independently
- * verifiable with:
+ * scripts/verify-microsoft-email-smoke-evidence.mjs.
+ *
+ * Before sealing, the manifest stage also runs the tamper trials: it
+ * provisionally seals a copy of the evidence, then proves the sealed
+ * verifier rejects byte-tamper, file-deletion, and
+ * review-edit-plus-dishonest-reseal copies (with an unmutated pre-record
+ * control isolating the substrate's baseline failures), and seals the
+ * outcomes as `95a-tamper-trial-outcomes.json` so a reviewer validates the
+ * record instead of re-running trials. After sealing, the manifest stage
+ * runs the verifier against its own output and fails unless every claim
+ * passes, so a sealed bundle is by construction independently verifiable
+ * with one bounded command:
  *
  *   node <evidence-dir>/97-verify-evidence.mjs <evidence-dir>
  *
@@ -64,6 +72,7 @@ import { spawnSync } from 'node:child_process';
 import { createHash } from 'node:crypto';
 import fs from 'node:fs';
 import http from 'node:http';
+import os from 'node:os';
 import path from 'node:path';
 import process from 'node:process';
 import { pathToFileURL } from 'node:url';
@@ -81,14 +90,17 @@ import {
   EXPECTED_TEMPORARY_SESSION_COUNT,
   INDEX_FILE,
   REQUIRED_CLAIMS,
+  REQUIRED_TAMPER_TRIALS,
   REVIEW_FILE,
   SESSION_CLEANUP_FILE,
+  TAMPER_TRIALS_FILE,
   VERIFIER_COPY_FILE,
   VERIFIER_SOURCE_PATH,
   buildReviewDocument,
   buildVerificationIndex,
   createContext as createVerificationContext,
   evaluateClaim,
+  validateTamperTrialRecord,
   verifyBundle,
 } from './verify-microsoft-email-smoke-evidence.mjs';
 
@@ -1041,7 +1053,14 @@ function createManifest(args) {
     }
   }
 
-  for (const outputName of [REVIEW_FILE, INDEX_FILE, VERIFIER_COPY_FILE, '98-sha256-manifest.json', 'SHA256SUMS']) {
+  for (const outputName of [
+    REVIEW_FILE,
+    INDEX_FILE,
+    VERIFIER_COPY_FILE,
+    TAMPER_TRIALS_FILE,
+    '98-sha256-manifest.json',
+    'SHA256SUMS',
+  ]) {
     if (fs.existsSync(path.join(evidenceDirectory, outputName))) {
       fail(`Refusing to overwrite existing sealed artifact: ${outputName}`);
     }
@@ -1070,6 +1089,74 @@ function createManifest(args) {
     path.join(evidenceDirectory, VERIFIER_COPY_FILE),
     fs.constants.COPYFILE_EXCL
   );
+
+  // Prove — before sealing — that this bundle's own verifier rejects tampered
+  // copies of this run's evidence, and seal the outcomes so a reviewer
+  // validates the record with the verdict command instead of re-running
+  // trials.
+  const tamperRecord = runTamperTrials(evidenceDirectory, metadata);
+  writeJsonNew(path.join(evidenceDirectory, TAMPER_TRIALS_FILE), tamperRecord);
+
+  writeSealOutputs(evidenceDirectory);
+
+  // A sealed bundle must verify on its own: run the bundled verifier's claim
+  // table against the directory that was just sealed and refuse to report
+  // success otherwise.
+  const verdict = verifyBundle(evidenceDirectory);
+  if (!verdict.passed) {
+    const failed = verdict.results
+      .filter((result) => !result.passed)
+      .map((result) => `${result.id}: ${result.failures.join('; ')}`);
+    fail(`The sealed bundle failed its own verification: ${failed.join(' | ') || verdict.setupError}`);
+  }
+  const sealedFileCount = fs.readdirSync(evidenceDirectory)
+    .filter((name) => name !== 'SHA256SUMS'
+      && fs.statSync(path.join(evidenceDirectory, name)).isFile())
+    .length;
+  console.log(JSON.stringify({
+    workflowRunId: metadata.workflowRunId,
+    evidenceDirectory,
+    files: sealedFileCount,
+    verification: {
+      passed: true,
+      claims: verdict.results.length,
+      tamperTrials: tamperRecord.trials.map((trial) => trial.name),
+      reviewEntrypoint: path.join(evidenceDirectory, REVIEW_FILE),
+      command: `node ${path.join(evidenceDirectory, VERIFIER_COPY_FILE)} ${evidenceDirectory}`,
+      bundleDigest: verdict.bundleDigest,
+    },
+  }, null, 2));
+}
+
+/**
+ * Write the seal outputs — verification index, review entrypoint, SHA-256
+ * manifest, and SHA256SUMS — for an evidence directory whose gates have
+ * already passed. Used both for the final bundle and for the provisional
+ * trial substrate the tamper trials mutate, which differs from the final
+ * bundle only in not yet containing the tamper-trial record.
+ */
+function writeSealOutputs(evidenceDirectory) {
+  const metadata = readJson(
+    path.join(evidenceDirectory, '00-workflow-run.json'),
+    'workflow metadata'
+  );
+  const restoration = readJson(
+    path.join(evidenceDirectory, '91-restoration-comparison.json'),
+    'restoration comparison'
+  );
+  const sessionCleanup = readJson(
+    path.join(evidenceDirectory, SESSION_CLEANUP_FILE),
+    'temporary-session cleanup proof'
+  );
+  const correlation = readJson(
+    path.join(evidenceDirectory, '95-final-dom-screenshot-correlation.json'),
+    'final DOM/PNG correlation'
+  );
+  const tamperRecordPath = path.join(evidenceDirectory, TAMPER_TRIALS_FILE);
+  const tamperRecord = fs.existsSync(tamperRecordPath)
+    ? readJson(tamperRecordPath, 'tamper-trial record')
+    : null;
+
   writeJsonNew(
     path.join(evidenceDirectory, INDEX_FILE),
     buildVerificationIndex(evidenceDirectory, {
@@ -1080,7 +1167,7 @@ function createManifest(args) {
   // written, so the sealed verifier can re-render it and reject any edit.
   writeNew(
     path.join(evidenceDirectory, REVIEW_FILE),
-    buildReviewDocument(sealContext)
+    buildReviewDocument(createVerificationContext(evidenceDirectory))
   );
 
   const excluded = new Set(['98-sha256-manifest.json', 'SHA256SUMS']);
@@ -1089,11 +1176,7 @@ function createManifest(args) {
     .map((name) => path.join(evidenceDirectory, name))
     .filter((filePath) => fs.statSync(filePath).isFile())
     .sort((left, right) => left.localeCompare(right))
-    .map((filePath) => ({
-      file: path.basename(filePath),
-      bytes: fs.statSync(filePath).size,
-      sha256: sha256File(filePath),
-    }));
+    .map((filePath) => fileIdentity(filePath));
   writeJsonNew(path.join(evidenceDirectory, '98-sha256-manifest.json'), {
     workflowRunId: metadata.workflowRunId,
     generatedAt: new Date().toISOString(),
@@ -1108,6 +1191,13 @@ function createManifest(args) {
     externalGraphLimitation: EXTERNAL_GRAPH_LIMITATION,
     crossHostContext: CROSS_HOST_CONTEXT,
     crossHostFidelityNote: correlation.crossHostFidelityNote,
+    ...(tamperRecord ? {
+      tamperOutcomes: {
+        file: TAMPER_TRIALS_FILE,
+        trials: tamperRecord.trials.map((trial) => trial.name),
+        allDetected: true,
+      },
+    } : {}),
     files,
   });
 
@@ -1120,29 +1210,129 @@ function createManifest(args) {
     path.join(evidenceDirectory, 'SHA256SUMS'),
     `${checksumFiles.map((filePath) => `${sha256File(filePath)}  ${path.basename(filePath)}`).join('\n')}\n`
   );
+}
 
-  // A sealed bundle must verify on its own: run the bundled verifier's claim
-  // table against the directory that was just sealed and refuse to report
-  // success otherwise.
-  const verdict = verifyBundle(evidenceDirectory);
-  if (!verdict.passed) {
-    const failed = verdict.results
-      .filter((result) => !result.passed)
-      .map((result) => `${result.id}: ${result.failures.join('; ')}`);
-    fail(`The sealed bundle failed its own verification: ${failed.join(' | ') || verdict.setupError}`);
+function flipLastByte(filePath) {
+  const buffer = fs.readFileSync(filePath);
+  buffer[buffer.length - 1] ^= 0xff;
+  fs.writeFileSync(filePath, buffer);
+}
+
+/**
+ * Recompute the manifest file entries and SHA256SUMS of a mutated bundle the
+ * way an attacker hiding an edit would, so the trial proves detection does
+ * not rely on checksums alone.
+ */
+function resealDishonestly(directory) {
+  const names = fs.readdirSync(directory)
+    .filter((name) => fs.statSync(path.join(directory, name)).isFile())
+    .sort((left, right) => left.localeCompare(right));
+  const manifestPath = path.join(directory, '98-sha256-manifest.json');
+  const manifest = readJson(manifestPath, 'trial manifest');
+  manifest.files = names
+    .filter((name) => name !== '98-sha256-manifest.json' && name !== 'SHA256SUMS')
+    .map((name) => fileIdentity(path.join(directory, name)));
+  fs.writeFileSync(manifestPath, `${JSON.stringify(manifest, null, 2)}\n`);
+  const checksumNames = names.filter((name) => name !== 'SHA256SUMS');
+  fs.writeFileSync(
+    path.join(directory, 'SHA256SUMS'),
+    `${checksumNames.map((name) => `${sha256File(path.join(directory, name))}  ${name}`).join('\n')}\n`
+  );
+}
+
+function applyTamperMutation(kind, trialDirectory) {
+  switch (kind) {
+    case 'none':
+      return { kind: 'none' };
+    case 'byte-flip': {
+      const target = '01-before-database.json';
+      flipLastByte(path.join(trialDirectory, target));
+      return { kind: 'byte-flip', file: target };
+    }
+    case 'delete': {
+      const target = '02-pending-consent-mailbox.png';
+      fs.rmSync(path.join(trialDirectory, target));
+      return { kind: 'delete', file: target };
+    }
+    case 'edit-plus-reseal': {
+      fs.appendFileSync(path.join(trialDirectory, REVIEW_FILE), '\nEdited after sealing.\n');
+      resealDishonestly(trialDirectory);
+      return { kind: 'edit-plus-reseal', file: REVIEW_FILE };
+    }
+    default:
+      return fail(`Unknown tamper mutation kind: ${kind}`);
   }
-  console.log(JSON.stringify({
-    workflowRunId: metadata.workflowRunId,
-    evidenceDirectory,
-    files: checksumFiles.length,
-    verification: {
-      passed: true,
-      claims: verdict.results.length,
-      reviewEntrypoint: path.join(evidenceDirectory, REVIEW_FILE),
-      command: `node ${path.join(evidenceDirectory, VERIFIER_COPY_FILE)} ${evidenceDirectory}`,
-      bundleDigest: verdict.bundleDigest,
-    },
-  }, null, 2));
+}
+
+/**
+ * Run the required tamper trials against a provisionally sealed copy of the
+ * evidence directory: seal the copy (without the trial record), mutate one
+ * trial copy per required trial, and run the sealed verifier on each — via
+ * its CLI for the authentic exit code and programmatically for the per-claim
+ * detail. Fails unless every trial shows exactly the required outcome, so a
+ * record can only be written for trials that actually detected the tampering.
+ */
+function runTamperTrials(evidenceDirectory, metadata) {
+  const trialRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'alga-smoke-tamper-trials-'));
+  try {
+    const substrate = path.join(trialRoot, 'substrate');
+    fs.cpSync(evidenceDirectory, substrate, { recursive: true });
+    writeSealOutputs(substrate);
+    const trials = REQUIRED_TAMPER_TRIALS.map((required) => {
+      const trialDirectory = path.join(trialRoot, required.name);
+      fs.cpSync(substrate, trialDirectory, { recursive: true });
+      const mutation = applyTamperMutation(required.mutationKind, trialDirectory);
+      const cli = spawnSync(
+        process.execPath,
+        [path.join(trialDirectory, VERIFIER_COPY_FILE), trialDirectory],
+        { encoding: 'utf8' }
+      );
+      if (cli.error) {
+        throw cli.error;
+      }
+      const programmatic = verifyBundle(trialDirectory);
+      if (cli.status !== programmatic.exitCode) {
+        fail(
+          `Tamper trial ${required.name}: the sealed verifier CLI exit (${cli.status}) and the programmatic verdict (${programmatic.exitCode}) disagree`
+        );
+      }
+      return {
+        name: required.name,
+        description: required.description,
+        mutation,
+        command: `node ${VERIFIER_COPY_FILE} <trial-copy>`,
+        exitCode: cli.status,
+        failedClaims: programmatic.results
+          .filter((result) => !result.passed)
+          .map((result) => ({ id: result.id, failures: result.failures })),
+        passedClaimIds: programmatic.results
+          .filter((result) => result.passed)
+          .map((result) => result.id),
+      };
+    });
+    const record = {
+      workflowRunId: metadata.workflowRunId,
+      recordedAt: new Date().toISOString(),
+      verifier: {
+        file: VERIFIER_COPY_FILE,
+        sha256: sha256File(path.join(evidenceDirectory, VERIFIER_COPY_FILE)),
+      },
+      substrate: 'Each trial ran against a copy of this run’s evidence provisionally sealed without this record; the pre-record control shows that substrate fails only for the record’s absence, so every additional failure in a mutation trial was caused by that trial’s mutation.',
+      trials,
+      assertionsPassed: true,
+    };
+    const failures = validateTamperTrialRecord(record, {
+      workflowRunId: metadata.workflowRunId,
+      verifierSha256: record.verifier.sha256,
+      startedAt: metadata.startedAt,
+    });
+    if (failures.length > 0) {
+      fail(`The tamper trials did not produce the required outcomes: ${failures.join('; ')}`);
+    }
+    return record;
+  } finally {
+    fs.rmSync(trialRoot, { recursive: true, force: true });
+  }
 }
 
 export {

--- a/scripts/capture-microsoft-email-smoke-evidence.mjs
+++ b/scripts/capture-microsoft-email-smoke-evidence.mjs
@@ -1,0 +1,473 @@
+#!/usr/bin/env node
+
+/**
+ * Capture auditable evidence around the Microsoft Email setup smoke test.
+ *
+ * The helper deliberately records secret presence, never secret contents. Run
+ * `before` before any fixture mutation and `after` after cleanup, then attach a
+ * final full-DOM export to its rendered screenshot with `correlate` and seal
+ * the directory with `manifest`.
+ *
+ * Usage:
+ *   node scripts/capture-microsoft-email-smoke-evidence.mjs before \
+ *     --evidence-dir=/tmp/alga-smoke-evidence/<run> \
+ *     --workflow-run-id=<uuid> --tenant-id=<uuid> --profile-id=<uuid>
+ *   node scripts/capture-microsoft-email-smoke-evidence.mjs after <same options>
+ *   node scripts/capture-microsoft-email-smoke-evidence.mjs correlate \
+ *     --evidence-dir=<dir> --dom-file=<full-dom.html> \
+ *     --screenshot-file=<cleanup.png> --render-method=<description>
+ *   node scripts/capture-microsoft-email-smoke-evidence.mjs manifest \
+ *     --evidence-dir=<dir>
+ */
+
+import { spawnSync } from 'node:child_process';
+import { createHash } from 'node:crypto';
+import fs from 'node:fs';
+import http from 'node:http';
+import path from 'node:path';
+import process from 'node:process';
+import { parse as parseDotenv } from 'dotenv';
+import pg from 'pg';
+
+const { Client } = pg;
+const UUID_PATTERN = /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
+const COMMANDS = new Set(['before', 'after', 'correlate', 'manifest']);
+const [command, ...rawArguments] = process.argv.slice(2);
+
+function fail(message) {
+  throw new Error(message);
+}
+
+function parseArguments(values) {
+  const result = {};
+  for (const value of values) {
+    const match = /^--([a-z0-9-]+)=(.*)$/i.exec(value);
+    if (!match) {
+      fail(`Arguments must use --name=value syntax; received: ${value}`);
+    }
+    result[match[1]] = match[2];
+  }
+  return result;
+}
+
+function requireArgument(argumentsByName, name) {
+  const value = argumentsByName[name];
+  if (!value) {
+    fail(`Missing required argument --${name}=...`);
+  }
+  return value;
+}
+
+function run(executable, args, cwd) {
+  const result = spawnSync(executable, args, {
+    cwd,
+    encoding: 'utf8',
+    env: process.env,
+  });
+  if (result.error) {
+    throw result.error;
+  }
+  return {
+    command: [executable, ...args],
+    exitCode: result.status,
+    signal: result.signal,
+    stdout: result.stdout,
+    stderr: result.stderr,
+  };
+}
+
+function requireSuccessful(result) {
+  if (result.exitCode !== 0) {
+    fail(
+      `Command failed (${result.command.join(' ')}):\n${result.stderr || result.stdout}`
+    );
+  }
+  return result.stdout.trim();
+}
+
+function sha256File(filePath) {
+  return createHash('sha256').update(fs.readFileSync(filePath)).digest('hex');
+}
+
+function writeNew(filePath, contents) {
+  fs.writeFileSync(filePath, contents, { encoding: 'utf8', flag: 'wx' });
+}
+
+function writeJsonNew(filePath, value) {
+  writeNew(filePath, `${JSON.stringify(value, null, 2)}\n`);
+}
+
+function transcript(result) {
+  return [
+    `$ ${result.command.join(' ')}`,
+    `exit_code=${result.exitCode}`,
+    `signal=${result.signal ?? ''}`,
+    '--- stdout ---',
+    result.stdout,
+    '--- stderr ---',
+    result.stderr,
+  ].join('\n');
+}
+
+function resolveEvidenceDirectory(value) {
+  const resolved = path.resolve(value);
+  if (resolved === path.parse(resolved).root) {
+    fail('The evidence directory cannot be a filesystem root');
+  }
+  return resolved;
+}
+
+function assertInsideEvidenceDirectory(evidenceDirectory, filePath, label) {
+  const resolved = path.resolve(filePath);
+  const relative = path.relative(evidenceDirectory, resolved);
+  if (relative.startsWith('..') || path.isAbsolute(relative)) {
+    fail(`${label} must be inside the evidence directory`);
+  }
+  if (!fs.statSync(resolved).isFile()) {
+    fail(`${label} is not a regular file: ${resolved}`);
+  }
+  return resolved;
+}
+
+function repositoryRoot() {
+  const result = run('git', ['rev-parse', '--show-toplevel'], process.cwd());
+  return requireSuccessful(result);
+}
+
+function readEnvironment(repoRoot) {
+  const fileValues = {};
+  for (const relativePath of ['server/.env', 'server/.env.local']) {
+    const filePath = path.join(repoRoot, relativePath);
+    if (fs.existsSync(filePath)) {
+      Object.assign(fileValues, parseDotenv(fs.readFileSync(filePath, 'utf8')));
+    }
+  }
+  return { ...fileValues, ...process.env };
+}
+
+function findListeningProcess(port) {
+  const result = run('fuser', [`${port}/tcp`], process.cwd());
+  const combinedOutput = `${result.stdout}\n${result.stderr}`;
+  const pids = [...combinedOutput.matchAll(/\b\d+\b/g)]
+    .map((match) => Number(match[0]))
+    .filter((value) => value !== port);
+  return {
+    commandResult: result,
+    processes: [...new Set(pids)].map((pid) => {
+      const processDirectory = `/proc/${pid}`;
+      return {
+        pid,
+        cwd: fs.existsSync(`${processDirectory}/cwd`)
+          ? fs.realpathSync(`${processDirectory}/cwd`)
+          : null,
+        command: fs.existsSync(`${processDirectory}/cmdline`)
+          ? fs.readFileSync(`${processDirectory}/cmdline`, 'utf8').replaceAll('\0', ' ').trim()
+          : null,
+      };
+    }),
+  };
+}
+
+function buildIdentity(repoRoot) {
+  const candidates = [
+    'server/.next/BUILD_ID',
+    'server/.next/build-manifest.json',
+    'server/.next/routes-manifest.json',
+    'server/.next/dev/build-manifest.json',
+    'server/.next/dev/routes-manifest.json',
+    'server/.next/dev/server/app-paths-manifest.json',
+  ];
+  return candidates.flatMap((relativePath) => {
+    const filePath = path.join(repoRoot, relativePath);
+    if (!fs.existsSync(filePath)) {
+      return [];
+    }
+    const stat = fs.statSync(filePath);
+    return [{
+      path: relativePath,
+      bytes: stat.size,
+      modifiedAt: stat.mtime.toISOString(),
+      sha256: sha256File(filePath),
+    }];
+  });
+}
+
+async function routeHealth(appUrl) {
+  const baseUrl = new URL(appUrl);
+  const routes = ['/', '/auth/signin', '/auth/msp/signin'];
+  return Promise.all(routes.map((route) => new Promise((resolve, reject) => {
+    const request = http.get(new URL(route, baseUrl), (response) => {
+      response.resume();
+      response.on('end', () => resolve({
+        route,
+        status: response.statusCode,
+        location: response.headers.location ?? null,
+        contentType: response.headers['content-type'] ?? null,
+      }));
+    });
+    request.setTimeout(10_000, () => request.destroy(new Error(`Timed out requesting ${route}`)));
+    request.on('error', reject);
+  })));
+}
+
+async function databaseSnapshot(environment, tenantId) {
+  const connection = {
+    host: environment.DB_HOST || '127.0.0.1',
+    port: Number(environment.DB_PORT || 5432),
+    user: environment.DB_USER_SERVER || 'app_user',
+    password: environment.DB_PASSWORD_SERVER,
+    database: environment.DB_NAME_SERVER || 'server',
+  };
+  const client = new Client(connection);
+  await client.connect();
+  try {
+    const identityResult = await client.query(`
+      SELECT current_database() AS database,
+             current_user AS database_user,
+             inet_server_addr()::text AS server_address,
+             inet_server_port() AS server_port,
+             version() AS postgres_version
+    `);
+    const bindingResult = await client.query(
+      `SELECT row_to_json(binding) AS binding
+         FROM microsoft_profile_consumer_bindings AS binding
+        WHERE tenant = $1
+          AND consumer_type = 'email'
+        ORDER BY profile_id`,
+      [tenantId]
+    );
+    return {
+      connection: {
+        host: connection.host,
+        port: connection.port,
+        user: connection.user,
+        database: connection.database,
+      },
+      identity: identityResult.rows[0],
+      emailConsumerBindings: bindingResult.rows.map((row) => row.binding),
+    };
+  } finally {
+    await client.end();
+  }
+}
+
+function secretAbsence(repoRoot, tenantId, profileId) {
+  const secretReference = `microsoft_profile_${profileId}_client_secret`;
+  const tenantSecretDirectory = path.join(repoRoot, 'secrets', 'tenants', tenantId);
+  const target = path.join(tenantSecretDirectory, secretReference);
+  const microsoftProfileFiles = fs.existsSync(tenantSecretDirectory)
+    ? fs.readdirSync(tenantSecretDirectory)
+      .filter((name) => name.startsWith('microsoft_profile_'))
+      .sort()
+    : [];
+  return {
+    target: path.relative(repoRoot, target),
+    targetExists: fs.existsSync(target),
+    microsoftProfileFiles,
+  };
+}
+
+function provenance(repoRoot, port) {
+  const head = requireSuccessful(run('git', ['rev-parse', 'HEAD'], repoRoot));
+  const branch = requireSuccessful(run('git', ['branch', '--show-current'], repoRoot));
+  const listening = findListeningProcess(port);
+  return {
+    capturedAt: new Date().toISOString(),
+    commit: head,
+    branch,
+    worktree: repoRoot,
+    commandCwd: process.cwd(),
+    port,
+    listenerProbe: listening.commandResult,
+    listeningProcesses: listening.processes,
+    buildFiles: buildIdentity(repoRoot),
+  };
+}
+
+async function capturePhase(phase, args) {
+  const evidenceDirectory = resolveEvidenceDirectory(requireArgument(args, 'evidence-dir'));
+  const workflowRunId = requireArgument(args, 'workflow-run-id');
+  const tenantId = requireArgument(args, 'tenant-id');
+  const profileId = requireArgument(args, 'profile-id');
+  if (!UUID_PATTERN.test(workflowRunId) || !UUID_PATTERN.test(tenantId) || !UUID_PATTERN.test(profileId)) {
+    fail('workflow-run-id, tenant-id, and profile-id must be UUIDs');
+  }
+
+  const repoRoot = repositoryRoot();
+  const environment = readEnvironment(repoRoot);
+  const port = Number(args.port || environment.PORT || 3000);
+  if (!Number.isInteger(port) || port < 1 || port > 65_535) {
+    fail(`Invalid port: ${args.port}`);
+  }
+  const appUrl = args['app-url'] || `http://localhost:${port}`;
+  fs.mkdirSync(evidenceDirectory, { recursive: true });
+
+  if (phase === 'before') {
+    writeJsonNew(path.join(evidenceDirectory, '00-workflow-run.json'), {
+      workflowRunId,
+      evidenceDirectory,
+      startedAt: new Date().toISOString(),
+      appUrl,
+      tenantId,
+      profileId,
+      externalGraphLimitation: 'No external Microsoft Graph or Entra OAuth call is performed by this evidence helper.',
+      crossHostFidelity: 'The card browser is Mac-hosted while the worktree server runs on Linux through a localhost-to-Tailscale relay. If native background-pane clicks or screenshots time out, record the React-handler fallback and live-DOM rendering method in the final correlation artifact.',
+    });
+  } else {
+    const metadataPath = path.join(evidenceDirectory, '00-workflow-run.json');
+    const metadata = JSON.parse(fs.readFileSync(metadataPath, 'utf8'));
+    if (metadata.workflowRunId !== workflowRunId
+      || metadata.tenantId !== tenantId
+      || metadata.profileId !== profileId) {
+      fail('The after arguments do not match the before metadata');
+    }
+  }
+
+  const prefix = phase === 'before' ? '01-before' : '90-after';
+  const gitStatus = run('git', ['status', '--short'], repoRoot);
+  const secrets = secretAbsence(repoRoot, tenantId, profileId);
+  const runtime = provenance(repoRoot, port);
+  const routes = await routeHealth(appUrl);
+  const database = await databaseSnapshot(environment, tenantId);
+
+  writeNew(path.join(evidenceDirectory, `${prefix}-git-status.txt`), transcript(gitStatus));
+  writeJsonNew(path.join(evidenceDirectory, `${prefix}-secret-absence.json`), secrets);
+  writeJsonNew(path.join(evidenceDirectory, `${prefix}-runtime-build.json`), runtime);
+  writeJsonNew(path.join(evidenceDirectory, `${prefix}-port-route-health.json`), {
+    appUrl,
+    listeningProcesses: runtime.listeningProcesses,
+    routes,
+  });
+  writeJsonNew(path.join(evidenceDirectory, `${prefix}-database.json`), database);
+
+  if (phase === 'after') {
+    const baseline = JSON.parse(
+      fs.readFileSync(path.join(evidenceDirectory, '01-before-database.json'), 'utf8')
+    );
+    const restoration = {
+      exactMatch: JSON.stringify(baseline.emailConsumerBindings)
+        === JSON.stringify(database.emailConsumerBindings),
+      baseline: baseline.emailConsumerBindings,
+      after: database.emailConsumerBindings,
+    };
+    writeJsonNew(path.join(evidenceDirectory, '91-database-restoration-comparison.json'), restoration);
+    if (!restoration.exactMatch) {
+      fail('The final Microsoft Email binding does not exactly match the recorded baseline');
+    }
+  }
+
+  if (gitStatus.exitCode !== 0) {
+    fail('git status failed');
+  }
+  if (secrets.targetExists) {
+    fail(`Target smoke secret exists during the ${phase} capture`);
+  }
+  if (runtime.listeningProcesses.length === 0 || routes.some((route) => !route.status)) {
+    fail('The application listener or route health check failed');
+  }
+
+  console.log(JSON.stringify({ phase, workflowRunId, evidenceDirectory }, null, 2));
+}
+
+function correlate(args) {
+  const evidenceDirectory = resolveEvidenceDirectory(requireArgument(args, 'evidence-dir'));
+  const domFile = assertInsideEvidenceDirectory(
+    evidenceDirectory,
+    requireArgument(args, 'dom-file'),
+    'DOM file'
+  );
+  const screenshotFile = assertInsideEvidenceDirectory(
+    evidenceDirectory,
+    requireArgument(args, 'screenshot-file'),
+    'Screenshot file'
+  );
+  const metadata = JSON.parse(
+    fs.readFileSync(path.join(evidenceDirectory, '00-workflow-run.json'), 'utf8')
+  );
+  const domContents = fs.readFileSync(domFile, 'utf8');
+  if (!/<html[\s>]/i.test(domContents) || !/<\/html>/i.test(domContents)) {
+    fail('The DOM artifact must contain a complete HTML document');
+  }
+  const pngSignature = fs.readFileSync(screenshotFile).subarray(0, 8).toString('hex');
+  if (pngSignature !== '89504e470d0a1a0a') {
+    fail('The correlated cleanup screenshot must be a PNG');
+  }
+  writeJsonNew(path.join(evidenceDirectory, '95-final-dom-screenshot-correlation.json'), {
+    workflowRunId: metadata.workflowRunId,
+    capturedAt: new Date().toISOString(),
+    dom: {
+      file: path.basename(domFile),
+      bytes: fs.statSync(domFile).size,
+      sha256: sha256File(domFile),
+    },
+    screenshot: {
+      file: path.basename(screenshotFile),
+      bytes: fs.statSync(screenshotFile).size,
+      sha256: sha256File(screenshotFile),
+    },
+    renderMethod: requireArgument(args, 'render-method'),
+    fidelityNote: args['fidelity-note'] || null,
+  });
+}
+
+function createManifest(args) {
+  const evidenceDirectory = resolveEvidenceDirectory(requireArgument(args, 'evidence-dir'));
+  const metadata = JSON.parse(
+    fs.readFileSync(path.join(evidenceDirectory, '00-workflow-run.json'), 'utf8')
+  );
+  if (!fs.existsSync(path.join(evidenceDirectory, '95-final-dom-screenshot-correlation.json'))) {
+    fail('Run correlate before creating the manifest');
+  }
+  if (!fs.existsSync(path.join(evidenceDirectory, '91-database-restoration-comparison.json'))) {
+    fail('Run the after capture before creating the manifest');
+  }
+
+  const excluded = new Set(['98-sha256-manifest.json', 'SHA256SUMS']);
+  const files = fs.readdirSync(evidenceDirectory)
+    .filter((name) => !excluded.has(name))
+    .map((name) => path.join(evidenceDirectory, name))
+    .filter((filePath) => fs.statSync(filePath).isFile())
+    .sort((left, right) => left.localeCompare(right))
+    .map((filePath) => ({
+      file: path.basename(filePath),
+      bytes: fs.statSync(filePath).size,
+      sha256: sha256File(filePath),
+    }));
+  writeJsonNew(path.join(evidenceDirectory, '98-sha256-manifest.json'), {
+    workflowRunId: metadata.workflowRunId,
+    generatedAt: new Date().toISOString(),
+    files,
+  });
+
+  const checksumFiles = fs.readdirSync(evidenceDirectory)
+    .filter((name) => name !== 'SHA256SUMS')
+    .map((name) => path.join(evidenceDirectory, name))
+    .filter((filePath) => fs.statSync(filePath).isFile())
+    .sort((left, right) => left.localeCompare(right));
+  writeNew(
+    path.join(evidenceDirectory, 'SHA256SUMS'),
+    `${checksumFiles.map((filePath) => `${sha256File(filePath)}  ${path.basename(filePath)}`).join('\n')}\n`
+  );
+  console.log(JSON.stringify({
+    workflowRunId: metadata.workflowRunId,
+    evidenceDirectory,
+    files: checksumFiles.length,
+  }, null, 2));
+}
+
+try {
+  if (!COMMANDS.has(command)) {
+    fail('Expected command: before, after, correlate, or manifest');
+  }
+  const args = parseArguments(rawArguments);
+  if (command === 'before' || command === 'after') {
+    await capturePhase(command, args);
+  } else if (command === 'correlate') {
+    correlate(args);
+  } else {
+    createManifest(args);
+  }
+} catch (error) {
+  console.error(error instanceof Error ? error.message : String(error));
+  process.exitCode = 1;
+}

--- a/scripts/capture-microsoft-email-smoke-evidence.mjs
+++ b/scripts/capture-microsoft-email-smoke-evidence.mjs
@@ -14,11 +14,14 @@
  * 02-pending-consent-mailbox, 03-restored-not-configured-mailbox, each as
  * .json + .png) and additionally writes `96-verification-index.json` — the
  * machine-readable map from every required smoke claim to its exact evidence
- * files, sealed identities, and assertions — plus `97-verify-evidence.mjs`, a
- * sealed copy of scripts/verify-microsoft-email-smoke-evidence.mjs. After
- * sealing, the manifest stage runs that verifier against its own output and
- * fails unless every claim passes, so a sealed bundle is by construction
- * independently verifiable with:
+ * files, sealed identities, and assertions — plus `00-REVIEW.md`, the human
+ * review entrypoint rendered deterministically from that sealed evidence
+ * (the verifier re-renders it and fails on any byte difference), and
+ * `97-verify-evidence.mjs`, a sealed copy of
+ * scripts/verify-microsoft-email-smoke-evidence.mjs. After sealing, the
+ * manifest stage runs that verifier against its own output and fails unless
+ * every claim passes, so a sealed bundle is by construction independently
+ * verifiable with:
  *
  *   node <evidence-dir>/97-verify-evidence.mjs <evidence-dir>
  *
@@ -78,9 +81,11 @@ import {
   EXPECTED_TEMPORARY_SESSION_COUNT,
   INDEX_FILE,
   REQUIRED_CLAIMS,
+  REVIEW_FILE,
   SESSION_CLEANUP_FILE,
   VERIFIER_COPY_FILE,
   VERIFIER_SOURCE_PATH,
+  buildReviewDocument,
   buildVerificationIndex,
   createContext as createVerificationContext,
   evaluateClaim,
@@ -1036,7 +1041,7 @@ function createManifest(args) {
     }
   }
 
-  for (const outputName of [INDEX_FILE, VERIFIER_COPY_FILE, '98-sha256-manifest.json', 'SHA256SUMS']) {
+  for (const outputName of [REVIEW_FILE, INDEX_FILE, VERIFIER_COPY_FILE, '98-sha256-manifest.json', 'SHA256SUMS']) {
     if (fs.existsSync(path.join(evidenceDirectory, outputName))) {
       fail(`Refusing to overwrite existing sealed artifact: ${outputName}`);
     }
@@ -1070,6 +1075,12 @@ function createManifest(args) {
     buildVerificationIndex(evidenceDirectory, {
       verifierCopySha256: sha256File(path.join(evidenceDirectory, VERIFIER_COPY_FILE)),
     })
+  );
+  // The human review entrypoint is rendered from the sealed evidence just
+  // written, so the sealed verifier can re-render it and reject any edit.
+  writeNew(
+    path.join(evidenceDirectory, REVIEW_FILE),
+    buildReviewDocument(sealContext)
   );
 
   const excluded = new Set(['98-sha256-manifest.json', 'SHA256SUMS']);
@@ -1127,6 +1138,7 @@ function createManifest(args) {
     verification: {
       passed: true,
       claims: verdict.results.length,
+      reviewEntrypoint: path.join(evidenceDirectory, REVIEW_FILE),
       command: `node ${path.join(evidenceDirectory, VERIFIER_COPY_FILE)} ${evidenceDirectory}`,
       bundleDigest: verdict.bundleDigest,
     },

--- a/scripts/capture-microsoft-email-smoke-evidence.mjs
+++ b/scripts/capture-microsoft-email-smoke-evidence.mjs
@@ -51,7 +51,12 @@ import { pathToFileURL } from 'node:url';
 import { isDeepStrictEqual } from 'node:util';
 import { parse as parseDotenv } from 'dotenv';
 import pg from 'pg';
-import { truncatedMtimeMs } from './microsoft-email-smoke-timestamps.mjs';
+import {
+  CTIME_NON_RESTORABLE_REASON,
+  ctimeDisclosure,
+  restorableInventory,
+  truncatedMtimeMs,
+} from './microsoft-email-smoke-timestamps.mjs';
 
 const { Client } = pg;
 const UUID_PATTERN = /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
@@ -393,6 +398,9 @@ function secretInventory(repoRoot, environment, tenantId) {
           // Pre-existing secret files are never mutated by the fixture, so
           // their timestamps are compared at full stat fidelity.
           mtimeMs: stat.mtimeMs,
+          // ctime is kernel-managed and not restorable from userspace; the
+          // fixture never touches pre-existing files, so it must not move.
+          ctimeMs: stat.ctimeMs,
           sha256: sha256File(entryPath),
         });
       } else {
@@ -409,6 +417,11 @@ function secretInventory(repoRoot, environment, tenantId) {
   }
   files.sort((left, right) => left.name.localeCompare(right.name));
   const directoryExists = fs.existsSync(tenantSecretDirectory);
+  // The parent directory's ctime is recorded because, when the tenant secret
+  // directory does not pre-exist, the fixture creates then removes the tenant
+  // directory and it is the parent whose ctime must be disclosed as changed.
+  const parentSecretDirectory = path.dirname(tenantSecretDirectory);
+  const parentDirectoryExists = fs.existsSync(parentSecretDirectory);
   return {
     provider: 'filesystem',
     basePath,
@@ -419,6 +432,14 @@ function secretInventory(repoRoot, environment, tenantId) {
     // the millisecond but not the nanosecond; compare at whole milliseconds.
     directoryMtimeMs: directoryExists
       ? truncatedMtimeMs(fs.statSync(tenantSecretDirectory))
+      : null,
+    // ctime cannot be restored from userspace at any precision; it is captured
+    // so the after capture can disclose the unavoidable delta, not compare it.
+    directoryCtimeMs: directoryExists
+      ? fs.statSync(tenantSecretDirectory).ctimeMs
+      : null,
+    parentDirectoryCtimeMs: parentDirectoryExists
+      ? fs.statSync(parentSecretDirectory).ctimeMs
       : null,
     files,
   };
@@ -547,6 +568,7 @@ async function capturePhase(phase, args) {
       path.join(evidenceDirectory, '01-before-secret-inventory.json'),
       'before secret inventory'
     );
+    const disclosure = ctimeDisclosure(baselineSecrets, secrets);
     restoration = {
       microsoftProfiles: exactComparison(
         baselineDatabase.microsoftProfiles,
@@ -556,15 +578,34 @@ async function capturePhase(phase, args) {
         baselineDatabase.microsoftConsumerBindings,
         database.microsoftConsumerBindings
       ),
-      tenantSecrets: exactComparison(baselineSecrets, secrets),
+      // The tenant secret inventory is compared on its restorable fields only:
+      // content hashes, names, sizes, modes, per-file mtime, and the directory
+      // mtime. ctime is kernel-managed and cannot be restored from userspace,
+      // so it is compared and disclosed separately below.
+      tenantSecrets: exactComparison(
+        restorableInventory(baselineSecrets),
+        restorableInventory(secrets)
+      ),
+      ctimeDisclosure: disclosure,
     };
-    restoration.exactMatch = Object.values(restoration)
-      .every((comparison) => comparison === true || comparison.exactMatch === true);
+    restoration.exactMatch = [
+      restoration.microsoftProfiles,
+      restoration.microsoftConsumerBindings,
+      restoration.tenantSecrets,
+    ].every((comparison) => comparison.exactMatch === true)
+      && disclosure.unexpectedChanges.length === 0;
     if (!restoration.exactMatch) {
-      const failures = Object.entries(restoration)
-        .filter(([, comparison]) => comparison !== false && comparison.exactMatch === false)
-        .map(([name]) => name);
-      fail(`Cleanup did not restore the complete baseline inventories: ${failures.join(', ')}`);
+      const failures = [
+        'microsoftProfiles',
+        'microsoftConsumerBindings',
+        'tenantSecrets',
+      ].filter((name) => restoration[name].exactMatch !== true);
+      if (disclosure.unexpectedChanges.length > 0) {
+        failures.push(
+          `unexpected ctime changes on untouched paths: ${disclosure.unexpectedChanges.join(', ')}`
+        );
+      }
+      fail(`Cleanup did not restore the complete restorable baseline inventories: ${failures.join(', ')}`);
     }
   }
 
@@ -759,7 +800,12 @@ function createManifest(args) {
   ];
   if (restoration.exactMatch !== true
     || restorationSections.some((comparison) => comparison?.exactMatch !== true)) {
-    fail('The complete profile, binding, and secret inventories were not restored exactly');
+    fail('The restorable profile, binding, and secret inventories were not restored exactly');
+  }
+  if (restoration.ctimeDisclosure?.reason !== CTIME_NON_RESTORABLE_REASON
+    || !Array.isArray(restoration.ctimeDisclosure.unexpectedChanges)
+    || restoration.ctimeDisclosure.unexpectedChanges.length !== 0) {
+    fail('The ctime disclosure is missing, mislabeled, or reports unexpected ctime changes');
   }
   const correlation = readJson(correlationPath, 'final DOM/PNG correlation');
   if (correlation.workflowRunId !== metadata.workflowRunId
@@ -802,6 +848,9 @@ function createManifest(args) {
     generatedAt: new Date().toISOString(),
     assertionsPassed: true,
     restorationExact: true,
+    ctimeDisclosed: true,
+    ctimeNonRestorableReason: CTIME_NON_RESTORABLE_REASON,
+    ctimeUnexpectedChanges: restoration.ctimeDisclosure.unexpectedChanges,
     sameCaptureProven: true,
     externalGraphLimitation: EXTERNAL_GRAPH_LIMITATION,
     crossHostContext: CROSS_HOST_CONTEXT,

--- a/scripts/capture-microsoft-email-smoke-evidence.mjs
+++ b/scripts/capture-microsoft-email-smoke-evidence.mjs
@@ -8,6 +8,19 @@
  * final full-DOM export to its rendered screenshot with `correlate` and seal
  * the directory with `manifest`.
  *
+ * Sealing requires the four structured UI captures the smoke run produces
+ * (01-self-hosted-providers-wizard, 01b-manual-setup-derived-redirect,
+ * 02-pending-consent-mailbox, 03-restored-not-configured-mailbox, each as
+ * .json + .png) and additionally writes `96-verification-index.json` — the
+ * machine-readable map from every required smoke claim to its exact evidence
+ * files, sealed identities, and assertions — plus `97-verify-evidence.mjs`, a
+ * sealed copy of scripts/verify-microsoft-email-smoke-evidence.mjs. After
+ * sealing, the manifest stage runs that verifier against its own output and
+ * fails unless every claim passes, so a sealed bundle is by construction
+ * independently verifiable with:
+ *
+ *   node <evidence-dir>/97-verify-evidence.mjs <evidence-dir>
+ *
  * Usage:
  *   node scripts/capture-microsoft-email-smoke-evidence.mjs before \
  *     --evidence-dir=/tmp/alga-smoke-evidence/<run> \
@@ -57,6 +70,16 @@ import {
   restorableInventory,
   truncatedMtimeMs,
 } from './microsoft-email-smoke-timestamps.mjs';
+import {
+  INDEX_FILE,
+  REQUIRED_CLAIMS,
+  VERIFIER_COPY_FILE,
+  VERIFIER_SOURCE_PATH,
+  buildVerificationIndex,
+  createContext as createVerificationContext,
+  evaluateClaim,
+  verifyBundle,
+} from './verify-microsoft-email-smoke-evidence.mjs';
 
 const { Client } = pg;
 const UUID_PATTERN = /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
@@ -826,11 +849,41 @@ function createManifest(args) {
     }
   }
 
-  for (const outputName of ['98-sha256-manifest.json', 'SHA256SUMS']) {
+  for (const outputName of [INDEX_FILE, VERIFIER_COPY_FILE, '98-sha256-manifest.json', 'SHA256SUMS']) {
     if (fs.existsSync(path.join(evidenceDirectory, outputName))) {
       fail(`Refusing to overwrite existing sealed artifact: ${outputName}`);
     }
   }
+
+  // Every UI-state claim must hold before the bundle can seal: the wizard
+  // licensing gate, the derived read-only Redirect URI, and both mailbox
+  // readiness states. The remaining claims are enforced by the existing gates
+  // above and re-verified as a whole after sealing.
+  const uiClaimIds = new Set([
+    'providers-wizard-platform-gating',
+    'derived-readonly-redirect-uri',
+    'pending-admin-consent-mailbox',
+    'restored-not-configured-mailbox',
+  ]);
+  const sealContext = createVerificationContext(evidenceDirectory);
+  for (const claim of REQUIRED_CLAIMS.filter((entry) => uiClaimIds.has(entry.id))) {
+    const result = evaluateClaim(claim, sealContext);
+    if (!result.passed) {
+      fail(`Cannot seal: UI claim ${claim.id} failed: ${result.failures.join('; ')}`);
+    }
+  }
+
+  fs.copyFileSync(
+    VERIFIER_SOURCE_PATH,
+    path.join(evidenceDirectory, VERIFIER_COPY_FILE),
+    fs.constants.COPYFILE_EXCL
+  );
+  writeJsonNew(
+    path.join(evidenceDirectory, INDEX_FILE),
+    buildVerificationIndex(evidenceDirectory, {
+      verifierCopySha256: sha256File(path.join(evidenceDirectory, VERIFIER_COPY_FILE)),
+    })
+  );
 
   const excluded = new Set(['98-sha256-manifest.json', 'SHA256SUMS']);
   const files = fs.readdirSync(evidenceDirectory)
@@ -867,10 +920,27 @@ function createManifest(args) {
     path.join(evidenceDirectory, 'SHA256SUMS'),
     `${checksumFiles.map((filePath) => `${sha256File(filePath)}  ${path.basename(filePath)}`).join('\n')}\n`
   );
+
+  // A sealed bundle must verify on its own: run the bundled verifier's claim
+  // table against the directory that was just sealed and refuse to report
+  // success otherwise.
+  const verdict = verifyBundle(evidenceDirectory);
+  if (!verdict.passed) {
+    const failed = verdict.results
+      .filter((result) => !result.passed)
+      .map((result) => `${result.id}: ${result.failures.join('; ')}`);
+    fail(`The sealed bundle failed its own verification: ${failed.join(' | ') || verdict.setupError}`);
+  }
   console.log(JSON.stringify({
     workflowRunId: metadata.workflowRunId,
     evidenceDirectory,
     files: checksumFiles.length,
+    verification: {
+      passed: true,
+      claims: verdict.results.length,
+      command: `node ${path.join(evidenceDirectory, VERIFIER_COPY_FILE)} ${evidenceDirectory}`,
+      bundleDigest: verdict.bundleDigest,
+    },
   }, null, 2));
 }
 

--- a/scripts/capture-microsoft-email-smoke-evidence.mjs
+++ b/scripts/capture-microsoft-email-smoke-evidence.mjs
@@ -4,9 +4,10 @@
  * Capture auditable evidence around the Microsoft Email setup smoke test.
  *
  * The helper deliberately records secret presence, never secret contents. Run
- * `before` before any fixture mutation and `after` after cleanup, then attach a
- * final full-DOM export to its rendered screenshot with `correlate` and seal
- * the directory with `manifest`.
+ * `before` before any fixture mutation, `sessions-created` after the smoke run
+ * has created its two temporary login sessions, and `after` after cleanup.
+ * Then attach a final full-DOM export to its rendered screenshot with
+ * `correlate` and seal the directory with `manifest`.
  *
  * Sealing requires the four structured UI captures the smoke run produces
  * (01-self-hosted-providers-wizard, 01b-manual-setup-derived-redirect,
@@ -25,6 +26,8 @@
  *   node scripts/capture-microsoft-email-smoke-evidence.mjs before \
  *     --evidence-dir=/tmp/alga-smoke-evidence/<run> \
  *     --workflow-run-id=<uuid> --tenant-id=<uuid> --profile-id=<uuid>
+ *   node scripts/capture-microsoft-email-smoke-evidence.mjs sessions-created \
+ *     --evidence-dir=<dir>
  *   node scripts/capture-microsoft-email-smoke-evidence.mjs after <same options>
  *   node scripts/capture-microsoft-email-smoke-evidence.mjs correlate \
  *     --evidence-dir=<dir> --dom-file=<full-dom.html> \
@@ -71,8 +74,11 @@ import {
   truncatedMtimeMs,
 } from './microsoft-email-smoke-timestamps.mjs';
 import {
+  CREATED_SESSIONS_FILE,
+  EXPECTED_TEMPORARY_SESSION_COUNT,
   INDEX_FILE,
   REQUIRED_CLAIMS,
+  SESSION_CLEANUP_FILE,
   VERIFIER_COPY_FILE,
   VERIFIER_SOURCE_PATH,
   buildVerificationIndex,
@@ -84,7 +90,7 @@ import {
 const { Client } = pg;
 const UUID_PATTERN = /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
 const SHA256_PATTERN = /^[0-9a-f]{64}$/i;
-const COMMANDS = new Set(['before', 'after', 'correlate', 'manifest']);
+const COMMANDS = new Set(['before', 'sessions-created', 'after', 'correlate', 'manifest']);
 const EXTERNAL_GRAPH_LIMITATION = 'No external Microsoft Graph or Entra OAuth call is performed by this evidence helper.';
 const CROSS_HOST_CONTEXT = 'The card browser is Mac-hosted while the worktree server runs on Linux through a localhost-to-Tailscale relay.';
 const PHASE_FILES = {
@@ -102,6 +108,7 @@ const PHASE_FILES = {
     '90-after-port-route-health.json',
     '90-after-database.json',
     '91-restoration-comparison.json',
+    SESSION_CLEANUP_FILE,
   ],
 };
 const PHASE_MARKERS = {
@@ -360,6 +367,19 @@ async function databaseSnapshot(environment, tenantId) {
         ORDER BY consumer_type, profile_id`,
       [tenantId]
     );
+    // Deliberately omit the legacy token and all mutable activity/device
+    // fields. The evidence needs stable row identity and creation provenance,
+    // never authentication material.
+    const sessionResult = await client.query(
+      `SELECT row_to_json(session_evidence) AS session
+         FROM (
+           SELECT tenant, session_id, user_id, created_at
+             FROM sessions
+            WHERE tenant = $1
+            ORDER BY session_id
+         ) AS session_evidence`,
+      [tenantId]
+    );
     return {
       connection: {
         host: connection.host,
@@ -370,10 +390,137 @@ async function databaseSnapshot(environment, tenantId) {
       identity: identityResult.rows[0],
       microsoftProfiles: profileResult.rows.map((row) => row.profile),
       microsoftConsumerBindings: bindingResult.rows.map((row) => row.binding),
+      sessions: sessionResult.rows.map((row) => row.session),
     };
   } finally {
     await client.end();
   }
+}
+
+function requireSessionRows(snapshot, label) {
+  if (!snapshot || !Array.isArray(snapshot.sessions)) {
+    fail(`${label} must include a sessions array`);
+  }
+  const seen = new Set();
+  for (const session of snapshot.sessions) {
+    if (!session || !UUID_PATTERN.test(session.session_id || '')) {
+      fail(`${label} contains a session without a UUID session_id`);
+    }
+    if (seen.has(session.session_id)) {
+      fail(`${label} contains duplicate session_id ${session.session_id}`);
+    }
+    seen.add(session.session_id);
+  }
+  return snapshot.sessions;
+}
+
+function buildTemporarySessionsCreatedProof(metadata, baselineDatabase, observedDatabase, capturedAt) {
+  const expectedCount = metadata.temporarySessionCleanup?.expectedCreatedSessionCount;
+  if (expectedCount !== EXPECTED_TEMPORARY_SESSION_COUNT
+    || metadata.temporarySessionCleanup?.createdEvidenceFile !== CREATED_SESSIONS_FILE
+    || metadata.temporarySessionCleanup?.cleanupEvidenceFile !== SESSION_CLEANUP_FILE) {
+    fail('Workflow metadata does not declare the required two-session cleanup proof');
+  }
+  const baselineIds = new Set(
+    requireSessionRows(baselineDatabase, 'Before database snapshot')
+      .map((session) => session.session_id)
+  );
+  const createdSessions = requireSessionRows(observedDatabase, 'Created-session database snapshot')
+    .filter((session) => !baselineIds.has(session.session_id));
+  if (createdSessions.length !== expectedCount) {
+    fail(`Expected exactly ${expectedCount} temporary session rows, observed ${createdSessions.length}`);
+  }
+  const startedAt = new Date(metadata.startedAt);
+  const observedAt = new Date(capturedAt);
+  for (const session of createdSessions) {
+    const createdAt = new Date(session.created_at);
+    if (session.tenant !== metadata.tenantId
+      || !UUID_PATTERN.test(session.user_id || '')
+      || Number.isNaN(createdAt.valueOf())
+      || createdAt < startedAt
+      || createdAt > observedAt) {
+      fail(`Temporary session ${session.session_id} is not attributable to this smoke run`);
+    }
+  }
+  return {
+    workflowRunId: metadata.workflowRunId,
+    tenantId: metadata.tenantId,
+    capturedAt,
+    expectedCreatedSessionCount: expectedCount,
+    assertionsPassed: true,
+    createdSessions,
+  };
+}
+
+function buildTemporarySessionCleanupProof(metadata, creation, afterDatabase, createdEvidence) {
+  const expectedCount = metadata.temporarySessionCleanup?.expectedCreatedSessionCount;
+  if (creation.workflowRunId !== metadata.workflowRunId
+    || creation.tenantId !== metadata.tenantId
+    || creation.expectedCreatedSessionCount !== expectedCount
+    || creation.assertionsPassed !== true
+    || !Array.isArray(creation.createdSessions)
+    || creation.createdSessions.length !== expectedCount) {
+    fail('The temporary-session creation evidence is invalid');
+  }
+  const createdSessionIds = creation.createdSessions
+    .map((session) => session.session_id)
+    .sort((left, right) => left.localeCompare(right));
+  if (new Set(createdSessionIds).size !== expectedCount
+    || createdSessionIds.some((sessionId) => !UUID_PATTERN.test(sessionId))) {
+    fail('The temporary-session creation evidence does not identify two distinct rows');
+  }
+  const createdIdSet = new Set(createdSessionIds);
+  const remainingSessionRows = requireSessionRows(afterDatabase, 'After database snapshot')
+    .filter((session) => createdIdSet.has(session.session_id));
+  const deletedSessionIds = createdSessionIds.filter(
+    (sessionId) => !remainingSessionRows.some((session) => session.session_id === sessionId)
+  );
+  return {
+    workflowRunId: metadata.workflowRunId,
+    tenantId: metadata.tenantId,
+    verifiedAt: new Date().toISOString(),
+    createdEvidence,
+    expectedCreatedSessionCount: expectedCount,
+    createdSessionIds,
+    deletedSessionIds,
+    remainingSessionRows,
+    allDeleted: deletedSessionIds.length === expectedCount && remainingSessionRows.length === 0,
+  };
+}
+
+async function captureCreatedSessions(args) {
+  const evidenceDirectory = resolveEvidenceDirectory(requireArgument(args, 'evidence-dir'));
+  const metadata = readJson(
+    path.join(evidenceDirectory, '00-workflow-run.json'),
+    'workflow metadata'
+  );
+  if (metadata.externalGraphLimitation !== EXTERNAL_GRAPH_LIMITATION
+    || metadata.crossHostContext !== CROSS_HOST_CONTEXT) {
+    fail('Workflow metadata is missing the required limitations');
+  }
+  verifyPhaseMarker(evidenceDirectory, 'before', metadata.workflowRunId);
+  const repoRoot = repositoryRoot();
+  const observedDatabase = await databaseSnapshot(readEnvironment(repoRoot), metadata.tenantId);
+  const baselineDatabase = readJson(
+    path.join(evidenceDirectory, '01-before-database.json'),
+    'before database snapshot'
+  );
+  const capturedAt = new Date().toISOString();
+  writeJsonNew(
+    path.join(evidenceDirectory, CREATED_SESSIONS_FILE),
+    buildTemporarySessionsCreatedProof(
+      metadata,
+      baselineDatabase,
+      observedDatabase,
+      capturedAt
+    )
+  );
+  console.log(JSON.stringify({
+    phase: 'sessions-created',
+    workflowRunId: metadata.workflowRunId,
+    evidenceDirectory,
+    temporarySessions: EXPECTED_TEMPORARY_SESSION_COUNT,
+  }, null, 2));
 }
 
 function resolveFilesystemSecretBase(repoRoot, environment) {
@@ -551,6 +698,7 @@ async function capturePhase(phase, args) {
   const appUrl = args['app-url'] || `http://localhost:${port}`;
   fs.mkdirSync(evidenceDirectory, { recursive: true });
 
+  let metadata;
   if (phase === 'before') {
     writeJsonNew(path.join(evidenceDirectory, '00-workflow-run.json'), {
       workflowRunId,
@@ -559,15 +707,23 @@ async function capturePhase(phase, args) {
       appUrl,
       tenantId,
       profileId,
+      temporarySessionCleanup: {
+        expectedCreatedSessionCount: EXPECTED_TEMPORARY_SESSION_COUNT,
+        createdEvidenceFile: CREATED_SESSIONS_FILE,
+        cleanupEvidenceFile: SESSION_CLEANUP_FILE,
+      },
       externalGraphLimitation: EXTERNAL_GRAPH_LIMITATION,
       crossHostContext: CROSS_HOST_CONTEXT,
     });
   } else {
     const metadataPath = path.join(evidenceDirectory, '00-workflow-run.json');
-    const metadata = readJson(metadataPath, 'workflow metadata');
+    metadata = readJson(metadataPath, 'workflow metadata');
     if (metadata.workflowRunId !== workflowRunId
       || metadata.tenantId !== tenantId
       || metadata.profileId !== profileId
+      || metadata.temporarySessionCleanup?.expectedCreatedSessionCount !== EXPECTED_TEMPORARY_SESSION_COUNT
+      || metadata.temporarySessionCleanup?.createdEvidenceFile !== CREATED_SESSIONS_FILE
+      || metadata.temporarySessionCleanup?.cleanupEvidenceFile !== SESSION_CLEANUP_FILE
       || metadata.externalGraphLimitation !== EXTERNAL_GRAPH_LIMITATION
       || metadata.crossHostContext !== CROSS_HOST_CONTEXT) {
       fail('The after arguments do not match the before metadata');
@@ -582,6 +738,7 @@ async function capturePhase(phase, args) {
   const routes = await routeHealth(appUrl);
   const database = await databaseSnapshot(environment, tenantId);
   let restoration;
+  let sessionCleanup;
   if (phase === 'after') {
     const baselineDatabase = readJson(
       path.join(evidenceDirectory, '01-before-database.json'),
@@ -591,6 +748,19 @@ async function capturePhase(phase, args) {
       path.join(evidenceDirectory, '01-before-secret-inventory.json'),
       'before secret inventory'
     );
+    const createdSessionsPath = path.join(evidenceDirectory, CREATED_SESSIONS_FILE);
+    const createdSessions = readJson(createdSessionsPath, 'temporary-session creation evidence');
+    sessionCleanup = buildTemporarySessionCleanupProof(
+      metadata,
+      createdSessions,
+      database,
+      fileIdentity(createdSessionsPath)
+    );
+    if (!sessionCleanup.allDeleted) {
+      fail(
+        `Cleanup left ${sessionCleanup.remainingSessionRows.length} of the two temporary session rows behind`
+      );
+    }
     const disclosure = ctimeDisclosure(baselineSecrets, secrets);
     restoration = {
       microsoftProfiles: exactComparison(
@@ -657,6 +827,7 @@ async function capturePhase(phase, args) {
   writeJsonNew(path.join(evidenceDirectory, `${prefix}-database.json`), database);
   if (phase === 'after') {
     writeJsonNew(path.join(evidenceDirectory, '91-restoration-comparison.json'), restoration);
+    writeJsonNew(path.join(evidenceDirectory, SESSION_CLEANUP_FILE), sessionCleanup);
   }
   writePhaseMarker(evidenceDirectory, phase, workflowRunId);
 
@@ -830,6 +1001,22 @@ function createManifest(args) {
     || restoration.ctimeDisclosure.unexpectedChanges.length !== 0) {
     fail('The ctime disclosure is missing, mislabeled, or reports unexpected ctime changes');
   }
+  const sessionCleanup = readJson(
+    path.join(evidenceDirectory, SESSION_CLEANUP_FILE),
+    'temporary-session cleanup proof'
+  );
+  if (sessionCleanup.workflowRunId !== metadata.workflowRunId
+    || sessionCleanup.tenantId !== metadata.tenantId
+    || sessionCleanup.expectedCreatedSessionCount !== EXPECTED_TEMPORARY_SESSION_COUNT
+    || !Array.isArray(sessionCleanup.createdSessionIds)
+    || sessionCleanup.createdSessionIds.length !== EXPECTED_TEMPORARY_SESSION_COUNT
+    || !Array.isArray(sessionCleanup.deletedSessionIds)
+    || sessionCleanup.deletedSessionIds.length !== EXPECTED_TEMPORARY_SESSION_COUNT
+    || !Array.isArray(sessionCleanup.remainingSessionRows)
+    || sessionCleanup.remainingSessionRows.length !== 0
+    || sessionCleanup.allDeleted !== true) {
+    fail('The proof does not show both temporary session rows were deleted');
+  }
   const correlation = readJson(correlationPath, 'final DOM/PNG correlation');
   if (correlation.workflowRunId !== metadata.workflowRunId
     || correlation.sameCaptureProven !== true
@@ -901,6 +1088,8 @@ function createManifest(args) {
     generatedAt: new Date().toISOString(),
     assertionsPassed: true,
     restorationExact: true,
+    temporarySessionRowsDeleted: true,
+    temporarySessionRowsDeletedCount: sessionCleanup.deletedSessionIds.length,
     ctimeDisclosed: true,
     ctimeNonRestorableReason: CTIME_NON_RESTORABLE_REASON,
     ctimeUnexpectedChanges: restoration.ctimeDisclosure.unexpectedChanges,
@@ -944,7 +1133,12 @@ function createManifest(args) {
   }, null, 2));
 }
 
-export { exactComparison, secretInventory };
+export {
+  buildTemporarySessionCleanupProof,
+  buildTemporarySessionsCreatedProof,
+  exactComparison,
+  secretInventory,
+};
 
 const invokedAsScript = process.argv[1]
   && import.meta.url === pathToFileURL(process.argv[1]).href;
@@ -952,11 +1146,13 @@ const invokedAsScript = process.argv[1]
 if (invokedAsScript) {
   try {
     if (!COMMANDS.has(command)) {
-      fail('Expected command: before, after, correlate, or manifest');
+      fail('Expected command: before, sessions-created, after, correlate, or manifest');
     }
     const args = parseArguments(rawArguments);
     if (command === 'before' || command === 'after') {
       await capturePhase(command, args);
+    } else if (command === 'sessions-created') {
+      await captureCreatedSessions(args);
     } else if (command === 'correlate') {
       correlate(args);
     } else {

--- a/scripts/microsoft-email-ready-false-smoke-fixture.mjs
+++ b/scripts/microsoft-email-ready-false-smoke-fixture.mjs
@@ -24,6 +24,10 @@ import os from 'node:os';
 import path from 'node:path';
 import knexFactory from 'knex';
 import { getSecretProviderInstance } from '@alga-psa/core/secrets';
+import {
+  directoryTimestampSnapshot,
+  restoreDirectoryTimestamps,
+} from './microsoft-email-smoke-timestamps.mjs';
 
 const [command, tenantId] = process.argv.slice(2);
 const allowedCommands = new Set(['apply', 'status', 'cleanup']);
@@ -95,6 +99,20 @@ function removeNewEmptyTenantSecretDirectory(directory, existedBefore) {
   }
 }
 
+/**
+ * Snapshot the directory whose mtime the fixture secret write will churn: the
+ * tenant secret directory itself when it already exists, otherwise the parent
+ * directory that gains (and later loses) the tenant directory.
+ */
+function mutatedSecretDirectorySnapshot(directoryExisted) {
+  if (!tenantSecretDirectory) {
+    return null;
+  }
+  return directoryExisted
+    ? directoryTimestampSnapshot(tenantSecretDirectory)
+    : directoryTimestampSnapshot(path.dirname(tenantSecretDirectory));
+}
+
 function scoped(table) {
   return db(table).where({ tenant: tenantId });
 }
@@ -143,16 +161,21 @@ async function applyFixture() {
     throw new Error(`Fixture state file already exists but the database state is inconsistent: ${stateFile}`);
   }
 
-  const [existingFixture, existingBinding] = await Promise.all([
+  const [existingFixture, existingBinding, existingSecret] = await Promise.all([
     scoped('microsoft_profiles').where({ profile_id: fixtureProfileId }).first(),
     readEmailBindingSnapshot(),
+    secretProvider.getTenantSecret(tenantId, fixtureSecretRef),
   ]);
   if (existingFixture) {
     throw new Error(`Fixture profile ${fixtureProfileId} already exists without a state file; remove it manually after review`);
   }
+  if (existingSecret) {
+    throw new Error(`A tenant secret already exists at ${fixtureSecretRef}; refusing to overwrite it`);
+  }
   const tenantSecretDirectoryExisted = tenantSecretDirectory
     ? fs.existsSync(tenantSecretDirectory)
     : null;
+  const secretDirectorySnapshot = mutatedSecretDirectorySnapshot(tenantSecretDirectoryExisted);
 
   fs.writeFileSync(
     stateFile,
@@ -163,6 +186,7 @@ async function applyFixture() {
       previousEmailBinding: existingBinding,
       tenantSecretDirectory,
       tenantSecretDirectoryExisted,
+      secretDirectorySnapshot,
     }, null, 2)}\n`,
     { flag: 'wx', mode: 0o600 }
   );
@@ -217,6 +241,7 @@ async function applyFixture() {
       tenantSecretDirectory,
       tenantSecretDirectoryExisted
     );
+    restoreDirectoryTimestamps(secretDirectorySnapshot);
     fs.rmSync(stateFile, { force: true });
     throw error;
   }
@@ -234,6 +259,11 @@ async function cleanupFixture() {
   }
   if (state.tenantSecretDirectory !== tenantSecretDirectory) {
     throw new Error('Fixture state secret directory does not match the configured filesystem provider');
+  }
+  if (state.secretDirectorySnapshot
+    && state.secretDirectorySnapshot.path !== tenantSecretDirectory
+    && state.secretDirectorySnapshot.path !== path.dirname(tenantSecretDirectory || '')) {
+    throw new Error('Fixture state timestamp snapshot does not belong to the tenant secret directory');
   }
 
   await db.transaction(async (trx) => {
@@ -283,6 +313,7 @@ async function cleanupFixture() {
     state.tenantSecretDirectory,
     state.tenantSecretDirectoryExisted
   );
+  restoreDirectoryTimestamps(state.secretDirectorySnapshot);
   fs.rmSync(stateFile);
   return {
     tenantId,

--- a/scripts/microsoft-email-ready-false-smoke-fixture.mjs
+++ b/scripts/microsoft-email-ready-false-smoke-fixture.mjs
@@ -14,8 +14,8 @@
  *   node scripts/microsoft-email-ready-false-smoke-fixture.mjs cleanup <tenant-id>
  *
  * Database settings use the same DB_* environment variables as the migration
- * tooling. The state file contains only profile IDs and is written to /tmp by
- * default; set MICROSOFT_EMAIL_READY_FALSE_STATE_FILE to override it.
+ * tooling. The state file contains only restoration metadata and is written to
+ * /tmp by default; set MICROSOFT_EMAIL_READY_FALSE_STATE_FILE to override it.
  */
 
 import crypto from 'node:crypto';
@@ -63,6 +63,38 @@ const db = knexFactory({
 
 const secretProvider = await getSecretProviderInstance();
 
+function resolveTenantSecretDirectory() {
+  const writeProvider = process.env.SECRET_WRITE_PROVIDER || 'filesystem';
+  if (writeProvider !== 'filesystem') {
+    return null;
+  }
+  const configured = process.env.SECRET_FS_BASE_PATH?.trim();
+  let basePath;
+  if (configured) {
+    basePath = path.isAbsolute(configured) ? configured : path.resolve(process.cwd(), configured);
+  } else if (fs.existsSync('/run/secrets')) {
+    basePath = '/run/secrets';
+  } else {
+    const candidates = [
+      path.resolve(process.cwd(), 'secrets'),
+      path.resolve(process.cwd(), '../secrets'),
+    ];
+    basePath = candidates.find((candidate) => fs.existsSync(candidate)) || candidates[1];
+  }
+  return path.join(basePath, 'tenants', tenantId);
+}
+
+const tenantSecretDirectory = resolveTenantSecretDirectory();
+
+function removeNewEmptyTenantSecretDirectory(directory, existedBefore) {
+  if (directory
+    && directory === tenantSecretDirectory
+    && existedBefore === false
+    && fs.existsSync(directory)) {
+    fs.rmdirSync(directory);
+  }
+}
+
 function scoped(table) {
   return db(table).where({ tenant: tenantId });
 }
@@ -90,6 +122,14 @@ async function readStatus() {
   };
 }
 
+async function readEmailBindingSnapshot() {
+  const row = await scoped('microsoft_profile_consumer_bindings as binding')
+    .where({ consumer_type: 'email' })
+    .select(db.raw('row_to_json(binding) AS binding'))
+    .first();
+  return row?.binding || null;
+}
+
 async function applyFixture() {
   const tenant = await db('tenants').where({ tenant: tenantId }).first('tenant');
   if (!tenant) {
@@ -105,15 +145,25 @@ async function applyFixture() {
 
   const [existingFixture, existingBinding] = await Promise.all([
     scoped('microsoft_profiles').where({ profile_id: fixtureProfileId }).first(),
-    scoped('microsoft_profile_consumer_bindings').where({ consumer_type: 'email' }).first(),
+    readEmailBindingSnapshot(),
   ]);
   if (existingFixture) {
     throw new Error(`Fixture profile ${fixtureProfileId} already exists without a state file; remove it manually after review`);
   }
+  const tenantSecretDirectoryExisted = tenantSecretDirectory
+    ? fs.existsSync(tenantSecretDirectory)
+    : null;
 
   fs.writeFileSync(
     stateFile,
-    `${JSON.stringify({ tenantId, fixtureProfileId, previousEmailProfileId: existingBinding?.profile_id || null }, null, 2)}\n`,
+    `${JSON.stringify({
+      tenantId,
+      fixtureProfileId,
+      previousEmailProfileId: existingBinding?.profile_id || null,
+      previousEmailBinding: existingBinding,
+      tenantSecretDirectory,
+      tenantSecretDirectoryExisted,
+    }, null, 2)}\n`,
     { flag: 'wx', mode: 0o600 }
   );
 
@@ -163,6 +213,10 @@ async function applyFixture() {
     });
   } catch (error) {
     await secretProvider.setTenantSecret(tenantId, fixtureSecretRef, null).catch(() => undefined);
+    removeNewEmptyTenantSecretDirectory(
+      tenantSecretDirectory,
+      tenantSecretDirectoryExisted
+    );
     fs.rmSync(stateFile, { force: true });
     throw error;
   }
@@ -177,6 +231,9 @@ async function cleanupFixture() {
   const state = JSON.parse(fs.readFileSync(stateFile, 'utf8'));
   if (state.tenantId !== tenantId || state.fixtureProfileId !== fixtureProfileId) {
     throw new Error(`Fixture state file does not match tenant/profile: ${stateFile}`);
+  }
+  if (state.tenantSecretDirectory !== tenantSecretDirectory) {
+    throw new Error('Fixture state secret directory does not match the configured filesystem provider');
   }
 
   await db.transaction(async (trx) => {
@@ -194,9 +251,22 @@ async function cleanupFixture() {
       if (!previousProfile) {
         throw new Error(`Previous Email profile ${state.previousEmailProfileId} is unavailable; refusing cleanup`);
       }
+      const previousBinding = state.previousEmailBinding;
+      if (!previousBinding
+        || previousBinding.tenant !== tenantId
+        || previousBinding.consumer_type !== 'email'
+        || previousBinding.profile_id !== state.previousEmailProfileId) {
+        throw new Error('Fixture state lacks the complete original Email binding; refusing lossy cleanup');
+      }
       await trx('microsoft_profile_consumer_bindings')
         .where({ tenant: tenantId, consumer_type: 'email' })
-        .update({ profile_id: state.previousEmailProfileId, updated_by: null, updated_at: new Date() });
+        .update({
+          profile_id: previousBinding.profile_id,
+          created_by: previousBinding.created_by,
+          updated_by: previousBinding.updated_by,
+          created_at: previousBinding.created_at,
+          updated_at: previousBinding.updated_at,
+        });
     } else {
       await trx('microsoft_profile_consumer_bindings')
         .where({ tenant: tenantId, consumer_type: 'email' })
@@ -209,6 +279,10 @@ async function cleanupFixture() {
   });
 
   await secretProvider.setTenantSecret(tenantId, fixtureSecretRef, null);
+  removeNewEmptyTenantSecretDirectory(
+    state.tenantSecretDirectory,
+    state.tenantSecretDirectoryExisted
+  );
   fs.rmSync(stateFile);
   return {
     tenantId,

--- a/scripts/microsoft-email-smoke-timestamps.mjs
+++ b/scripts/microsoft-email-smoke-timestamps.mjs
@@ -1,0 +1,68 @@
+/**
+ * Filesystem timestamp helpers for the Microsoft Email smoke fixture and its
+ * evidence capture.
+ *
+ * Node can only rewrite file timestamps through `fs.utimesSync`, which accepts
+ * seconds as a double. That API restores timestamps faithfully to the
+ * millisecond, but not to the nanosecond stored by filesystems such as Btrfs.
+ * Whole milliseconds are therefore the finest fidelity a restoration can
+ * guarantee, and the exactness gates compare restored directories at that
+ * precision.
+ */
+
+import fs from 'node:fs';
+
+/**
+ * Truncate an `fs.Stats` millisecond timestamp to the whole-millisecond
+ * fidelity that `fs.utimesSync` can faithfully restore.
+ */
+export function truncatedMtimeMs(stat) {
+  return Math.trunc(stat.mtimeMs);
+}
+
+/**
+ * Snapshot a directory's timestamps so they can be restored after the fixture
+ * creates or deletes entries inside it. Returns null when the directory does
+ * not exist (nothing will need restoring).
+ */
+export function directoryTimestampSnapshot(directoryPath) {
+  if (!directoryPath || !fs.existsSync(directoryPath)) {
+    return null;
+  }
+  const stat = fs.statSync(directoryPath);
+  return {
+    path: directoryPath,
+    atimeMs: stat.atimeMs,
+    mtimeMs: stat.mtimeMs,
+  };
+}
+
+/**
+ * Restore a directory's timestamps from a snapshot, verifying the result at
+ * millisecond fidelity.
+ *
+ * The double-seconds round trip through `fs.utimesSync` can drift by a few
+ * hundred nanoseconds, which crosses a millisecond boundary only when the
+ * original timestamp sat within that drift of the boundary. When that happens
+ * the restoration retries with the middle of the original millisecond, which
+ * is guaranteed to truncate identically.
+ */
+export function restoreDirectoryTimestamps(snapshot) {
+  if (!snapshot) {
+    return;
+  }
+  if (!fs.existsSync(snapshot.path)) {
+    throw new Error(`Cannot restore timestamps because the directory is missing: ${snapshot.path}`);
+  }
+  fs.utimesSync(snapshot.path, snapshot.atimeMs / 1000, snapshot.mtimeMs / 1000);
+  if (truncatedMtimeMs(fs.statSync(snapshot.path)) !== Math.trunc(snapshot.mtimeMs)) {
+    fs.utimesSync(
+      snapshot.path,
+      (Math.trunc(snapshot.atimeMs) + 0.5) / 1000,
+      (Math.trunc(snapshot.mtimeMs) + 0.5) / 1000
+    );
+  }
+  if (truncatedMtimeMs(fs.statSync(snapshot.path)) !== Math.trunc(snapshot.mtimeMs)) {
+    throw new Error(`Timestamp restoration failed for directory: ${snapshot.path}`);
+  }
+}

--- a/scripts/microsoft-email-smoke-timestamps.mjs
+++ b/scripts/microsoft-email-smoke-timestamps.mjs
@@ -3,14 +3,24 @@
  * evidence capture.
  *
  * Node can only rewrite file timestamps through `fs.utimesSync`, which accepts
- * seconds as a double. That API restores timestamps faithfully to the
+ * seconds as a double. That API restores atime/mtime faithfully to the
  * millisecond, but not to the nanosecond stored by filesystems such as Btrfs.
  * Whole milliseconds are therefore the finest fidelity a restoration can
  * guarantee, and the exactness gates compare restored directories at that
  * precision.
+ *
+ * ctime (the inode change time) is different: it is kernel-managed and cannot
+ * be set from userspace at all, so any fixture create/delete inside a mutated
+ * directory bumps that directory's ctime irreversibly. The inventory and the
+ * snapshot therefore record ctime so the harness can disclose the delta, but
+ * the exactness gate never requires it to be restored.
  */
 
 import fs from 'node:fs';
+import path from 'node:path';
+
+export const CTIME_NON_RESTORABLE_REASON =
+  'ctime is kernel-managed; not restorable from userspace';
 
 /**
  * Truncate an `fs.Stats` millisecond timestamp to the whole-millisecond
@@ -21,9 +31,14 @@ export function truncatedMtimeMs(stat) {
 }
 
 /**
- * Snapshot a directory's timestamps so they can be restored after the fixture
- * creates or deletes entries inside it. Returns null when the directory does
- * not exist (nothing will need restoring).
+ * Snapshot a directory's timestamps so atime/mtime can be restored after the
+ * fixture creates or deletes entries inside it. Returns null when the
+ * directory does not exist (nothing will need restoring).
+ *
+ * `ctimeMs` is recorded for disclosure only: the fixture churn that makes the
+ * snapshot necessary also moves the directory's ctime, which `fs.utimesSync`
+ * cannot restore. Keeping it on the snapshot makes the mutation visible to
+ * anyone reading the fixture state instead of silently losing it.
  */
 export function directoryTimestampSnapshot(directoryPath) {
   if (!directoryPath || !fs.existsSync(directoryPath)) {
@@ -34,6 +49,97 @@ export function directoryTimestampSnapshot(directoryPath) {
     path: directoryPath,
     atimeMs: stat.atimeMs,
     mtimeMs: stat.mtimeMs,
+    ctimeMs: stat.ctimeMs,
+  };
+}
+
+/**
+ * Project a secret inventory onto its restorable fields so the exactness gate
+ * can compare exactly what the fixture must restore: content hashes, names,
+ * sizes, modes, per-file mtime, and the tenant directory's whole-millisecond
+ * mtime. ctime fields are dropped here because they cannot be restored; they
+ * are compared and disclosed separately by `ctimeDisclosure`.
+ */
+export function restorableInventory(inventory) {
+  const { directoryCtimeMs, parentDirectoryCtimeMs, ...rest } = inventory;
+  return {
+    ...rest,
+    files: inventory.files.map(({ ctimeMs, ...fileRest }) => fileRest),
+  };
+}
+
+/**
+ * Compute the structured ctime disclosure between a before and after secret
+ * inventory.
+ *
+ * ctime is kernel-managed and not restorable from userspace, so a ctime delta
+ * is expected and disclosed where the fixture actually mutated a directory:
+ * the tenant secret directory when it pre-existed (the fixture writes then
+ * deletes its secret inside it), otherwise the parent directory (the fixture
+ * creates then removes the tenant directory). Every other path — untouched
+ * pre-existing secret files, and the parent when the tenant directory already
+ * existed — must keep its ctime; a change there is an `unexpectedChanges`
+ * entry that fails the gate.
+ */
+export function ctimeDisclosure(baseline, after) {
+  const paths = [];
+  const changedPaths = [];
+  const unexpectedChanges = [];
+
+  function compare(pathName, kind, expected, baselineCtimeMs, afterCtimeMs) {
+    const changed = baselineCtimeMs !== afterCtimeMs;
+    paths.push({
+      path: pathName,
+      kind,
+      expected,
+      baselineCtimeMs,
+      afterCtimeMs,
+      changed,
+    });
+    if (changed) {
+      changedPaths.push(pathName);
+      if (!expected) {
+        unexpectedChanges.push(pathName);
+      }
+    }
+  }
+
+  const tenantPath = baseline.tenantDirectory || after.tenantDirectory || '';
+  const tenantPreExisted = baseline.directoryExists === true;
+
+  if (baseline.parentDirectoryCtimeMs != null && after.parentDirectoryCtimeMs != null) {
+    compare(
+      path.dirname(tenantPath),
+      'directory',
+      !tenantPreExisted,
+      baseline.parentDirectoryCtimeMs,
+      after.parentDirectoryCtimeMs
+    );
+  }
+  if (baseline.directoryCtimeMs != null && after.directoryCtimeMs != null) {
+    compare(
+      tenantPath,
+      'directory',
+      tenantPreExisted,
+      baseline.directoryCtimeMs,
+      after.directoryCtimeMs
+    );
+  }
+
+  const afterFilesByName = new Map(after.files.map((file) => [file.name, file]));
+  for (const file of baseline.files) {
+    const afterFile = afterFilesByName.get(file.name);
+    if (!afterFile) {
+      continue;
+    }
+    compare(file.name, 'file', false, file.ctimeMs, afterFile.ctimeMs);
+  }
+
+  return {
+    reason: CTIME_NON_RESTORABLE_REASON,
+    paths,
+    changedPaths,
+    unexpectedChanges,
   };
 }
 

--- a/scripts/tests/capture-microsoft-email-smoke-evidence.test.mjs
+++ b/scripts/tests/capture-microsoft-email-smoke-evidence.test.mjs
@@ -1,0 +1,200 @@
+import { spawnSync } from 'node:child_process';
+import { createHash } from 'node:crypto';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+const REPO_ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '../..');
+const SCRIPT = path.join(REPO_ROOT, 'scripts/capture-microsoft-email-smoke-evidence.mjs');
+const WORKFLOW_RUN_ID = '11111111-1111-4111-8111-111111111111';
+const CAPTURE_NONCE = '22222222-2222-4222-8222-222222222222';
+const EXTERNAL_GRAPH_LIMITATION = 'No external Microsoft Graph or Entra OAuth call is performed by this evidence helper.';
+const CROSS_HOST_CONTEXT = 'The card browser is Mac-hosted while the worktree server runs on Linux through a localhost-to-Tailscale relay.';
+const FIDELITY_NOTE = 'React handlers were driven from the card-scoped Mac terminal; the exported live DOM was rendered to the attached PNG.';
+const PHASE_FILES = {
+  before: [
+    '01-before-git-status.txt',
+    '01-before-secret-inventory.json',
+    '01-before-runtime-build.json',
+    '01-before-port-route-health.json',
+    '01-before-database.json',
+  ],
+  after: [
+    '90-after-git-status.txt',
+    '90-after-secret-inventory.json',
+    '90-after-runtime-build.json',
+    '90-after-port-route-health.json',
+    '90-after-database.json',
+    '91-restoration-comparison.json',
+  ],
+};
+const PHASE_MARKERS = {
+  before: '02-before-assertions-passed.json',
+  after: '92-after-assertions-passed.json',
+};
+const RESTORED = {
+  exactMatch: true,
+  microsoftProfiles: { exactMatch: true, baseline: [], after: [] },
+  microsoftConsumerBindings: { exactMatch: true, baseline: [], after: [] },
+  tenantSecrets: { exactMatch: true, baseline: { files: [] }, after: { files: [] } },
+};
+const PROVENANCE = {
+  workflowRunId: WORKFLOW_RUN_ID,
+  captureNonce: CAPTURE_NONCE,
+  capturedAt: '2026-08-04T23:00:00.000Z',
+  browser: {
+    userAgent: 'Smoke Browser 1',
+    url: 'http://localhost:3100/msp/settings?category=communication',
+    platform: 'macOS',
+  },
+};
+
+function sha256(filePath) {
+  return createHash('sha256').update(fs.readFileSync(filePath)).digest('hex');
+}
+
+function writeJson(directory, name, value) {
+  fs.writeFileSync(path.join(directory, name), `${JSON.stringify(value, null, 2)}\n`);
+}
+
+function fileIdentity(directory, name) {
+  const filePath = path.join(directory, name);
+  return {
+    file: name,
+    bytes: fs.statSync(filePath).size,
+    sha256: sha256(filePath),
+  };
+}
+
+function writePhaseMarker(directory, phase) {
+  writeJson(directory, PHASE_MARKERS[phase], {
+    workflowRunId: WORKFLOW_RUN_ID,
+    phase,
+    assertionsPassed: true,
+    recordedAt: '2026-08-04T23:00:00.000Z',
+    externalGraphLimitation: EXTERNAL_GRAPH_LIMITATION,
+    files: PHASE_FILES[phase].map((name) => fileIdentity(directory, name)),
+  });
+}
+
+function setupEvidence() {
+  const directory = fs.mkdtempSync(path.join(os.tmpdir(), 'microsoft-smoke-evidence-test-'));
+  writeJson(directory, '00-workflow-run.json', {
+    workflowRunId: WORKFLOW_RUN_ID,
+    appUrl: 'http://localhost:3100',
+    tenantId: '33333333-3333-4333-8333-333333333333',
+    profileId: '44444444-4444-4444-8444-444444444444',
+    externalGraphLimitation: EXTERNAL_GRAPH_LIMITATION,
+    crossHostContext: CROSS_HOST_CONTEXT,
+  });
+  for (const name of [...PHASE_FILES.before, ...PHASE_FILES.after]) {
+    fs.writeFileSync(path.join(directory, name), 'fixture\n');
+  }
+  writeJson(directory, '91-restoration-comparison.json', RESTORED);
+  writePhaseMarker(directory, 'before');
+  writePhaseMarker(directory, 'after');
+  fs.writeFileSync(
+    path.join(directory, 'final.png'),
+    Buffer.from(
+      'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNk+A8AAQUBAScY42YAAAAASUVORK5CYII=',
+      'base64'
+    )
+  );
+  return directory;
+}
+
+function writeCapture(directory, embeddedProvenance, crossHostFidelityNote = FIDELITY_NOTE) {
+  fs.writeFileSync(
+    path.join(directory, 'final.html'),
+    `<html><body>cleanup</body><script id="alga-smoke-capture-provenance" type="application/json">${JSON.stringify(embeddedProvenance)}</script></html>`
+  );
+  writeJson(directory, 'browser-capture.json', {
+    provenance: PROVENANCE,
+    artifacts: {
+      dom: { file: 'final.html', sha256: sha256(path.join(directory, 'final.html')) },
+      screenshot: { file: 'final.png', sha256: sha256(path.join(directory, 'final.png')) },
+    },
+    renderMethod: 'Live DOM rendered by the card-scoped Mac browser',
+    crossHostFidelityNote,
+    externalGraphLimitation: EXTERNAL_GRAPH_LIMITATION,
+  });
+}
+
+function invoke(directory, command) {
+  const args = command === 'correlate'
+    ? [
+      SCRIPT,
+      command,
+      `--evidence-dir=${directory}`,
+      `--dom-file=${path.join(directory, 'final.html')}`,
+      `--screenshot-file=${path.join(directory, 'final.png')}`,
+      `--capture-provenance-file=${path.join(directory, 'browser-capture.json')}`,
+    ]
+    : [SCRIPT, command, `--evidence-dir=${directory}`];
+  return spawnSync(process.execPath, args, { cwd: REPO_ROOT, encoding: 'utf8' });
+}
+
+function assertFailure(result, message) {
+  assert.notEqual(result.status, 0);
+  assert.match(`${result.stdout}${result.stderr}`, message);
+}
+
+test('correlate requires shared capture identity, a fidelity note, and the Graph limitation', (t) => {
+  const directory = setupEvidence();
+  t.after(() => fs.rmSync(directory, { recursive: true, force: true }));
+
+  writeCapture(directory, {
+    ...PROVENANCE,
+    captureNonce: '55555555-5555-4555-8555-555555555555',
+  });
+  assertFailure(invoke(directory, 'correlate'), /do not share the same nonce/);
+
+  writeCapture(directory, PROVENANCE, undefined);
+  const withoutFidelityNote = JSON.parse(
+    fs.readFileSync(path.join(directory, 'browser-capture.json'), 'utf8')
+  );
+  delete withoutFidelityNote.crossHostFidelityNote;
+  writeJson(directory, 'browser-capture.json', withoutFidelityNote);
+  assertFailure(invoke(directory, 'correlate'), /Cross-host fidelity note/);
+
+  writeCapture(directory, PROVENANCE);
+  const withoutGraphLimitation = JSON.parse(
+    fs.readFileSync(path.join(directory, 'browser-capture.json'), 'utf8')
+  );
+  delete withoutGraphLimitation.externalGraphLimitation;
+  writeJson(directory, 'browser-capture.json', withoutGraphLimitation);
+  assertFailure(invoke(directory, 'correlate'), /no-external-Graph limitation/);
+
+  writeCapture(directory, PROVENANCE);
+  assert.equal(invoke(directory, 'correlate').status, 0);
+});
+
+test('manifest cannot seal tampered or failed after assertions', (t) => {
+  const directory = setupEvidence();
+  t.after(() => fs.rmSync(directory, { recursive: true, force: true }));
+  writeCapture(directory, PROVENANCE);
+  assert.equal(invoke(directory, 'correlate').status, 0);
+
+  fs.appendFileSync(path.join(directory, '90-after-database.json'), 'tamper');
+  assertFailure(invoke(directory, 'manifest'), /changed after its assertions passed/);
+
+  fs.writeFileSync(path.join(directory, '90-after-database.json'), 'fixture\n');
+  writeJson(directory, '91-restoration-comparison.json', { ...RESTORED, exactMatch: false });
+  writePhaseMarker(directory, 'after');
+  assertFailure(invoke(directory, 'manifest'), /were not restored exactly/);
+
+  writeJson(directory, '91-restoration-comparison.json', RESTORED);
+  writePhaseMarker(directory, 'after');
+  assert.equal(invoke(directory, 'manifest').status, 0);
+  const manifest = JSON.parse(
+    fs.readFileSync(path.join(directory, '98-sha256-manifest.json'), 'utf8')
+  );
+  assert.equal(manifest.assertionsPassed, true);
+  assert.equal(manifest.restorationExact, true);
+  assert.equal(manifest.sameCaptureProven, true);
+  assert.equal(manifest.externalGraphLimitation, EXTERNAL_GRAPH_LIMITATION);
+  assert.equal(manifest.crossHostFidelityNote, FIDELITY_NOTE);
+});

--- a/scripts/tests/capture-microsoft-email-smoke-evidence.test.mjs
+++ b/scripts/tests/capture-microsoft-email-smoke-evidence.test.mjs
@@ -12,7 +12,10 @@ import {
   secretInventory,
 } from '../capture-microsoft-email-smoke-evidence.mjs';
 import {
+  CTIME_NON_RESTORABLE_REASON,
+  ctimeDisclosure,
   directoryTimestampSnapshot,
+  restorableInventory,
   restoreDirectoryTimestamps,
 } from '../microsoft-email-smoke-timestamps.mjs';
 
@@ -49,6 +52,12 @@ const RESTORED = {
   microsoftProfiles: { exactMatch: true, baseline: [], after: [] },
   microsoftConsumerBindings: { exactMatch: true, baseline: [], after: [] },
   tenantSecrets: { exactMatch: true, baseline: { files: [] }, after: { files: [] } },
+  ctimeDisclosure: {
+    reason: CTIME_NON_RESTORABLE_REASON,
+    paths: [],
+    changedPaths: [],
+    unexpectedChanges: [],
+  },
 };
 const PROVENANCE = {
   workflowRunId: WORKFLOW_RUN_ID,
@@ -169,24 +178,30 @@ function inventory(base) {
   );
 }
 
-test('secret inventory records file mtimes and the truncated directory mtime', (t) => {
+test('secret inventory records file mtimes, the truncated directory mtime, and ctime', (t) => {
   const { base, tenantDirectory } = setupSecretBase();
   t.after(() => fs.rmSync(base, { recursive: true, force: true }));
 
   const recorded = inventory(base);
   assert.equal(recorded.files.length, 1);
-  assert.equal(
-    recorded.files[0].mtimeMs,
-    fs.statSync(path.join(tenantDirectory, 'existing_secret')).mtimeMs
-  );
+  const secretStat = fs.statSync(path.join(tenantDirectory, 'existing_secret'));
+  assert.equal(recorded.files[0].mtimeMs, secretStat.mtimeMs);
+  assert.equal(recorded.files[0].ctimeMs, secretStat.ctimeMs);
   assert.equal(recorded.directoryExists, true);
   assert.equal(recorded.directoryMtimeMs, Math.trunc(fs.statSync(tenantDirectory).mtimeMs));
+  assert.equal(recorded.directoryCtimeMs, fs.statSync(tenantDirectory).ctimeMs);
+  assert.equal(
+    recorded.parentDirectoryCtimeMs,
+    fs.statSync(path.dirname(tenantDirectory)).ctimeMs
+  );
 
   const emptyBase = fs.mkdtempSync(path.join(os.tmpdir(), 'microsoft-smoke-secret-empty-'));
   t.after(() => fs.rmSync(emptyBase, { recursive: true, force: true }));
   const absent = inventory(emptyBase);
   assert.equal(absent.directoryExists, false);
   assert.equal(absent.directoryMtimeMs, null);
+  assert.equal(absent.directoryCtimeMs, null);
+  assert.equal(absent.parentDirectoryCtimeMs, null);
   assert.deepEqual(absent.files, []);
 });
 
@@ -198,7 +213,11 @@ test('an mtime-only difference fails the restoration exactness comparison', (t) 
   const baseline = inventory(base);
   fs.utimesSync(secretFile, new Date('2026-01-01T00:00:00Z'), new Date('2026-01-01T00:00:00Z'));
   const fileTouched = inventory(base);
-  assert.equal(exactComparison(baseline, fileTouched).exactMatch, false);
+  assert.equal(
+    exactComparison(restorableInventory(baseline), restorableInventory(fileTouched)).exactMatch,
+    false
+  );
+  assert.deepEqual(ctimeDisclosure(baseline, fileTouched).unexpectedChanges, ['existing_secret']);
 
   fs.utimesSync(
     tenantDirectory,
@@ -206,10 +225,16 @@ test('an mtime-only difference fails the restoration exactness comparison', (t) 
     new Date('2026-02-02T00:00:00Z')
   );
   const directoryTouched = inventory(base);
-  assert.equal(exactComparison(fileTouched, directoryTouched).exactMatch, false);
+  assert.equal(
+    exactComparison(
+      restorableInventory(fileTouched),
+      restorableInventory(directoryTouched)
+    ).exactMatch,
+    false
+  );
 });
 
-test('directory timestamp restoration is millisecond-exact', (t) => {
+test('directory timestamp restoration restores mtime exactly while ctime is disclosed', (t) => {
   const { base, tenantDirectory } = setupSecretBase();
   t.after(() => fs.rmSync(base, { recursive: true, force: true }));
 
@@ -218,20 +243,145 @@ test('directory timestamp restoration is millisecond-exact', (t) => {
     new Date('2026-03-03T03:03:03.123Z'),
     new Date('2026-03-03T03:03:03.123Z')
   );
+  fs.utimesSync(
+    path.join(tenantDirectory, 'existing_secret'),
+    new Date('2026-03-03T03:03:03.200Z'),
+    new Date('2026-03-03T03:03:03.200Z')
+  );
   const baseline = inventory(base);
   const snapshot = directoryTimestampSnapshot(tenantDirectory);
 
   const churnFile = path.join(tenantDirectory, 'transient_secret');
   fs.writeFileSync(churnFile, 'transient\n', { mode: 0o600 });
   fs.rmSync(churnFile);
-  assert.equal(exactComparison(baseline, inventory(base)).exactMatch, false);
+  const churned = inventory(base);
+  assert.equal(
+    exactComparison(restorableInventory(baseline), restorableInventory(churned)).exactMatch,
+    false
+  );
 
   restoreDirectoryTimestamps(snapshot);
   assert.equal(
     Math.trunc(fs.statSync(tenantDirectory).mtimeMs),
     Math.trunc(snapshot.mtimeMs)
   );
-  assert.equal(exactComparison(baseline, inventory(base)).exactMatch, true);
+  const restored = inventory(base);
+  assert.equal(
+    exactComparison(restorableInventory(baseline), restorableInventory(restored)).exactMatch,
+    true
+  );
+  assert.equal(snapshot.ctimeMs, baseline.directoryCtimeMs);
+
+  const disclosure = ctimeDisclosure(baseline, restored);
+  assert.equal(disclosure.reason, CTIME_NON_RESTORABLE_REASON);
+  assert.ok(
+    disclosure.changedPaths.includes(tenantDirectory),
+    'the mutated tenant directory ctime should be disclosed as changed'
+  );
+  assert.deepEqual(disclosure.unexpectedChanges, []);
+});
+
+test('ctime changes only where the fixture mutated pass the gate', (t) => {
+  const { base, tenantDirectory } = setupSecretBase();
+  t.after(() => fs.rmSync(base, { recursive: true, force: true }));
+
+  // Pin timestamps to a fixed past date so the churn is guaranteed to move
+  // the truncated directory mtime away from the baseline value.
+  fs.utimesSync(
+    tenantDirectory,
+    new Date('2026-03-03T03:03:03.123Z'),
+    new Date('2026-03-03T03:03:03.123Z')
+  );
+  fs.utimesSync(
+    path.join(tenantDirectory, 'existing_secret'),
+    new Date('2026-03-03T03:03:03.200Z'),
+    new Date('2026-03-03T03:03:03.200Z')
+  );
+  const baseline = inventory(base);
+  const churnFile = path.join(tenantDirectory, 'transient_secret');
+  fs.writeFileSync(churnFile, 'transient\n', { mode: 0o600 });
+  fs.rmSync(churnFile);
+  const after = inventory(base);
+
+  const disclosure = ctimeDisclosure(baseline, after);
+  assert.equal(disclosure.reason, CTIME_NON_RESTORABLE_REASON);
+  assert.ok(
+    disclosure.changedPaths.includes(tenantDirectory),
+    'the mutated tenant directory ctime should be disclosed as changed'
+  );
+  assert.deepEqual(disclosure.unexpectedChanges, []);
+  const expectedChangedPath = disclosure.paths.find(
+    (entry) => entry.changed && entry.kind === 'directory'
+  );
+  assert.equal(expectedChangedPath.expected, true);
+  assert.equal(
+    exactComparison(restorableInventory(baseline), restorableInventory(after)).exactMatch,
+    false
+  );
+});
+
+test('a ctime change on an untouched path fails the disclosure gate', (t) => {
+  const { base, tenantDirectory } = setupSecretBase();
+  t.after(() => fs.rmSync(base, { recursive: true, force: true }));
+  const secretFile = path.join(tenantDirectory, 'existing_secret');
+
+  const baseline = inventory(base);
+  // chmod to the same mode moves ctime without changing content, size, or mtime,
+  // simulating an unexpected touch of a pre-existing secret file.
+  fs.chmodSync(secretFile, 0o600);
+  const after = inventory(base);
+  assert.equal(after.files[0].mode, baseline.files[0].mode);
+  assert.equal(after.files[0].mtimeMs, baseline.files[0].mtimeMs);
+  assert.notEqual(after.files[0].ctimeMs, baseline.files[0].ctimeMs);
+
+  const disclosure = ctimeDisclosure(baseline, after);
+  assert.deepEqual(disclosure.unexpectedChanges, ['existing_secret']);
+  assert.equal(
+    exactComparison(restorableInventory(baseline), restorableInventory(after)).exactMatch,
+    true,
+    'restorable fields still match; only ctime drifted'
+  );
+});
+
+test('a restorable-field mismatch still fails alongside the ctime disclosure', (t) => {
+  const { base, tenantDirectory } = setupSecretBase();
+  t.after(() => fs.rmSync(base, { recursive: true, force: true }));
+  const secretFile = path.join(tenantDirectory, 'existing_secret');
+
+  const baseline = inventory(base);
+  fs.writeFileSync(secretFile, 'different value\n', { mode: 0o600 });
+  const after = inventory(base);
+
+  const disclosure = ctimeDisclosure(baseline, after);
+  assert.deepEqual(disclosure.unexpectedChanges, ['existing_secret']);
+  assert.equal(
+    exactComparison(restorableInventory(baseline), restorableInventory(after)).exactMatch,
+    false,
+    'a content change must fail the restorable exactness gate'
+  );
+});
+
+test('a parent-directory ctime change is disclosed when the tenant directory is created fresh', (t) => {
+  const base = fs.mkdtempSync(path.join(os.tmpdir(), 'microsoft-smoke-secret-parent-'));
+  t.after(() => fs.rmSync(base, { recursive: true, force: true }));
+  const parentDirectory = path.join(base, 'tenants');
+  fs.mkdirSync(parentDirectory);
+  const tenantDirectory = path.join(parentDirectory, SECRET_TENANT_ID);
+
+  const baseline = inventory(base);
+  assert.equal(baseline.directoryExists, false);
+  fs.mkdirSync(tenantDirectory);
+  const after = inventory(base);
+  assert.equal(after.directoryExists, true);
+
+  const disclosure = ctimeDisclosure(baseline, after);
+  assert.equal(disclosure.reason, CTIME_NON_RESTORABLE_REASON);
+  const parentEntry = disclosure.paths.find((entry) => entry.kind === 'directory'
+    && entry.path === parentDirectory);
+  assert.ok(parentEntry, 'the parent directory should be part of the disclosure');
+  assert.equal(parentEntry.changed, true);
+  assert.equal(parentEntry.expected, true);
+  assert.deepEqual(disclosure.unexpectedChanges, []);
 });
 
 test('correlate requires shared capture identity, a fidelity note, and the Graph limitation', (t) => {
@@ -278,6 +428,16 @@ test('manifest cannot seal tampered or failed after assertions', (t) => {
   writePhaseMarker(directory, 'after');
   assertFailure(invoke(directory, 'manifest'), /were not restored exactly/);
 
+  writeJson(directory, '91-restoration-comparison.json', {
+    ...RESTORED,
+    ctimeDisclosure: {
+      ...RESTORED.ctimeDisclosure,
+      unexpectedChanges: ['existing_secret'],
+    },
+  });
+  writePhaseMarker(directory, 'after');
+  assertFailure(invoke(directory, 'manifest'), /reports unexpected ctime changes/);
+
   writeJson(directory, '91-restoration-comparison.json', RESTORED);
   writePhaseMarker(directory, 'after');
   assert.equal(invoke(directory, 'manifest').status, 0);
@@ -286,6 +446,9 @@ test('manifest cannot seal tampered or failed after assertions', (t) => {
   );
   assert.equal(manifest.assertionsPassed, true);
   assert.equal(manifest.restorationExact, true);
+  assert.equal(manifest.ctimeDisclosed, true);
+  assert.equal(manifest.ctimeNonRestorableReason, CTIME_NON_RESTORABLE_REASON);
+  assert.deepEqual(manifest.ctimeUnexpectedChanges, []);
   assert.equal(manifest.sameCaptureProven, true);
   assert.equal(manifest.externalGraphLimitation, EXTERNAL_GRAPH_LIMITATION);
   assert.equal(manifest.crossHostFidelityNote, FIDELITY_NOTE);

--- a/scripts/tests/capture-microsoft-email-smoke-evidence.test.mjs
+++ b/scripts/tests/capture-microsoft-email-smoke-evidence.test.mjs
@@ -1,9 +1,6 @@
-import { spawnSync } from 'node:child_process';
-import { createHash } from 'node:crypto';
 import fs from 'node:fs';
 import os from 'node:os';
 import path from 'node:path';
-import { fileURLToPath } from 'node:url';
 import assert from 'node:assert/strict';
 import test from 'node:test';
 
@@ -18,149 +15,27 @@ import {
   restorableInventory,
   restoreDirectoryTimestamps,
 } from '../microsoft-email-smoke-timestamps.mjs';
-
-const REPO_ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '../..');
-const SCRIPT = path.join(REPO_ROOT, 'scripts/capture-microsoft-email-smoke-evidence.mjs');
-const WORKFLOW_RUN_ID = '11111111-1111-4111-8111-111111111111';
-const CAPTURE_NONCE = '22222222-2222-4222-8222-222222222222';
-const EXTERNAL_GRAPH_LIMITATION = 'No external Microsoft Graph or Entra OAuth call is performed by this evidence helper.';
-const CROSS_HOST_CONTEXT = 'The card browser is Mac-hosted while the worktree server runs on Linux through a localhost-to-Tailscale relay.';
-const FIDELITY_NOTE = 'React handlers were driven from the card-scoped Mac terminal; the exported live DOM was rendered to the attached PNG.';
-const PHASE_FILES = {
-  before: [
-    '01-before-git-status.txt',
-    '01-before-secret-inventory.json',
-    '01-before-runtime-build.json',
-    '01-before-port-route-health.json',
-    '01-before-database.json',
-  ],
-  after: [
-    '90-after-git-status.txt',
-    '90-after-secret-inventory.json',
-    '90-after-runtime-build.json',
-    '90-after-port-route-health.json',
-    '90-after-database.json',
-    '91-restoration-comparison.json',
-  ],
-};
-const PHASE_MARKERS = {
-  before: '02-before-assertions-passed.json',
-  after: '92-after-assertions-passed.json',
-};
-const RESTORED = {
-  exactMatch: true,
-  microsoftProfiles: { exactMatch: true, baseline: [], after: [] },
-  microsoftConsumerBindings: { exactMatch: true, baseline: [], after: [] },
-  tenantSecrets: { exactMatch: true, baseline: { files: [] }, after: { files: [] } },
-  ctimeDisclosure: {
-    reason: CTIME_NON_RESTORABLE_REASON,
-    paths: [],
-    changedPaths: [],
-    unexpectedChanges: [],
-  },
-};
-const PROVENANCE = {
-  workflowRunId: WORKFLOW_RUN_ID,
-  captureNonce: CAPTURE_NONCE,
-  capturedAt: '2026-08-04T23:00:00.000Z',
-  browser: {
-    userAgent: 'Smoke Browser 1',
-    url: 'http://localhost:3100/msp/settings?category=communication',
-    platform: 'macOS',
-  },
-};
-
-function sha256(filePath) {
-  return createHash('sha256').update(fs.readFileSync(filePath)).digest('hex');
-}
-
-function writeJson(directory, name, value) {
-  fs.writeFileSync(path.join(directory, name), `${JSON.stringify(value, null, 2)}\n`);
-}
-
-function fileIdentity(directory, name) {
-  const filePath = path.join(directory, name);
-  return {
-    file: name,
-    bytes: fs.statSync(filePath).size,
-    sha256: sha256(filePath),
-  };
-}
-
-function writePhaseMarker(directory, phase) {
-  writeJson(directory, PHASE_MARKERS[phase], {
-    workflowRunId: WORKFLOW_RUN_ID,
-    phase,
-    assertionsPassed: true,
-    recordedAt: '2026-08-04T23:00:00.000Z',
-    externalGraphLimitation: EXTERNAL_GRAPH_LIMITATION,
-    files: PHASE_FILES[phase].map((name) => fileIdentity(directory, name)),
-  });
-}
-
-function setupEvidence() {
-  const directory = fs.mkdtempSync(path.join(os.tmpdir(), 'microsoft-smoke-evidence-test-'));
-  writeJson(directory, '00-workflow-run.json', {
-    workflowRunId: WORKFLOW_RUN_ID,
-    appUrl: 'http://localhost:3100',
-    tenantId: '33333333-3333-4333-8333-333333333333',
-    profileId: '44444444-4444-4444-8444-444444444444',
-    externalGraphLimitation: EXTERNAL_GRAPH_LIMITATION,
-    crossHostContext: CROSS_HOST_CONTEXT,
-  });
-  for (const name of [...PHASE_FILES.before, ...PHASE_FILES.after]) {
-    fs.writeFileSync(path.join(directory, name), 'fixture\n');
-  }
-  writeJson(directory, '91-restoration-comparison.json', RESTORED);
-  writePhaseMarker(directory, 'before');
-  writePhaseMarker(directory, 'after');
-  fs.writeFileSync(
-    path.join(directory, 'final.png'),
-    Buffer.from(
-      'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNk+A8AAQUBAScY42YAAAAASUVORK5CYII=',
-      'base64'
-    )
-  );
-  return directory;
-}
-
-function writeCapture(directory, embeddedProvenance, crossHostFidelityNote = FIDELITY_NOTE) {
-  fs.writeFileSync(
-    path.join(directory, 'final.html'),
-    `<html><body>cleanup</body><script id="alga-smoke-capture-provenance" type="application/json">${JSON.stringify(embeddedProvenance)}</script></html>`
-  );
-  writeJson(directory, 'browser-capture.json', {
-    provenance: PROVENANCE,
-    artifacts: {
-      dom: { file: 'final.html', sha256: sha256(path.join(directory, 'final.html')) },
-      screenshot: { file: 'final.png', sha256: sha256(path.join(directory, 'final.png')) },
-    },
-    renderMethod: 'Live DOM rendered by the card-scoped Mac browser',
-    crossHostFidelityNote,
-    externalGraphLimitation: EXTERNAL_GRAPH_LIMITATION,
-  });
-}
-
-function invoke(directory, command) {
-  const args = command === 'correlate'
-    ? [
-      SCRIPT,
-      command,
-      `--evidence-dir=${directory}`,
-      `--dom-file=${path.join(directory, 'final.html')}`,
-      `--screenshot-file=${path.join(directory, 'final.png')}`,
-      `--capture-provenance-file=${path.join(directory, 'browser-capture.json')}`,
-    ]
-    : [SCRIPT, command, `--evidence-dir=${directory}`];
-  return spawnSync(process.execPath, args, { cwd: REPO_ROOT, encoding: 'utf8' });
-}
+import {
+  DATABASE_SNAPSHOT,
+  EXTERNAL_GRAPH_LIMITATION,
+  FIDELITY_NOTE,
+  PROVENANCE,
+  REPO_ROOT,
+  RESTORED,
+  TENANT_ID,
+  invoke,
+  setupEvidence,
+  writeCapture,
+  writeJson,
+  writePhaseMarker,
+} from './helpers/microsoft-smoke-evidence-fixture.mjs';
 
 function assertFailure(result, message) {
   assert.notEqual(result.status, 0);
   assert.match(`${result.stdout}${result.stderr}`, message);
 }
 
-const SECRET_TENANT_ID = '33333333-3333-4333-8333-333333333333';
+const SECRET_TENANT_ID = TENANT_ID;
 
 function setupSecretBase() {
   const base = fs.mkdtempSync(path.join(os.tmpdir(), 'microsoft-smoke-secret-test-'));
@@ -423,7 +298,7 @@ test('manifest cannot seal tampered or failed after assertions', (t) => {
   fs.appendFileSync(path.join(directory, '90-after-database.json'), 'tamper');
   assertFailure(invoke(directory, 'manifest'), /changed after its assertions passed/);
 
-  fs.writeFileSync(path.join(directory, '90-after-database.json'), 'fixture\n');
+  writeJson(directory, '90-after-database.json', DATABASE_SNAPSHOT);
   writeJson(directory, '91-restoration-comparison.json', { ...RESTORED, exactMatch: false });
   writePhaseMarker(directory, 'after');
   assertFailure(invoke(directory, 'manifest'), /were not restored exactly/);
@@ -440,7 +315,8 @@ test('manifest cannot seal tampered or failed after assertions', (t) => {
 
   writeJson(directory, '91-restoration-comparison.json', RESTORED);
   writePhaseMarker(directory, 'after');
-  assert.equal(invoke(directory, 'manifest').status, 0);
+  const sealed = invoke(directory, 'manifest');
+  assert.equal(sealed.status, 0, `${sealed.stdout}${sealed.stderr}`);
   const manifest = JSON.parse(
     fs.readFileSync(path.join(directory, '98-sha256-manifest.json'), 'utf8')
   );

--- a/scripts/tests/capture-microsoft-email-smoke-evidence.test.mjs
+++ b/scripts/tests/capture-microsoft-email-smoke-evidence.test.mjs
@@ -5,9 +5,16 @@ import assert from 'node:assert/strict';
 import test from 'node:test';
 
 import {
+  buildTemporarySessionCleanupProof,
+  buildTemporarySessionsCreatedProof,
   exactComparison,
   secretInventory,
 } from '../capture-microsoft-email-smoke-evidence.mjs';
+import {
+  CREATED_SESSIONS_FILE,
+  EXPECTED_TEMPORARY_SESSION_COUNT,
+  SESSION_CLEANUP_FILE,
+} from '../verify-microsoft-email-smoke-evidence.mjs';
 import {
   CTIME_NON_RESTORABLE_REASON,
   ctimeDisclosure,
@@ -17,11 +24,14 @@ import {
 } from '../microsoft-email-smoke-timestamps.mjs';
 import {
   DATABASE_SNAPSHOT,
+  CREATED_SESSION_ROWS,
   EXTERNAL_GRAPH_LIMITATION,
   FIDELITY_NOTE,
   PROVENANCE,
   REPO_ROOT,
   RESTORED,
+  TEMPORARY_SESSIONS_CREATED,
+  TEMPORARY_SESSION_IDS,
   TENANT_ID,
   invoke,
   setupEvidence,
@@ -36,6 +46,73 @@ function assertFailure(result, message) {
 }
 
 const SECRET_TENANT_ID = TENANT_ID;
+
+const SESSION_PROOF_METADATA = {
+  workflowRunId: '11111111-1111-4111-8111-111111111111',
+  tenantId: TENANT_ID,
+  startedAt: '2026-08-04T22:59:00.000Z',
+  temporarySessionCleanup: {
+    expectedCreatedSessionCount: EXPECTED_TEMPORARY_SESSION_COUNT,
+    createdEvidenceFile: CREATED_SESSIONS_FILE,
+    cleanupEvidenceFile: SESSION_CLEANUP_FILE,
+  },
+};
+
+test('temporary-session proof identifies exactly two newly created rows and their deletion', () => {
+  const observedDatabase = {
+    ...DATABASE_SNAPSHOT,
+    sessions: [...DATABASE_SNAPSHOT.sessions, ...CREATED_SESSION_ROWS],
+  };
+  const creation = buildTemporarySessionsCreatedProof(
+    SESSION_PROOF_METADATA,
+    DATABASE_SNAPSHOT,
+    observedDatabase,
+    TEMPORARY_SESSIONS_CREATED.capturedAt
+  );
+  assert.deepEqual(
+    creation.createdSessions.map((session) => session.session_id),
+    TEMPORARY_SESSION_IDS
+  );
+
+  const cleanup = buildTemporarySessionCleanupProof(
+    SESSION_PROOF_METADATA,
+    creation,
+    DATABASE_SNAPSHOT,
+    { file: CREATED_SESSIONS_FILE, bytes: 1, sha256: 'ab'.repeat(32) }
+  );
+  assert.equal(cleanup.allDeleted, true);
+  assert.deepEqual(cleanup.deletedSessionIds, TEMPORARY_SESSION_IDS);
+  assert.deepEqual(cleanup.remainingSessionRows, []);
+});
+
+test('temporary-session proof rejects the wrong creation count and reports a surviving row', () => {
+  assert.throws(
+    () => buildTemporarySessionsCreatedProof(
+      SESSION_PROOF_METADATA,
+      DATABASE_SNAPSHOT,
+      {
+        ...DATABASE_SNAPSHOT,
+        sessions: [...DATABASE_SNAPSHOT.sessions, CREATED_SESSION_ROWS[0]],
+      },
+      TEMPORARY_SESSIONS_CREATED.capturedAt
+    ),
+    /Expected exactly 2 temporary session rows, observed 1/
+  );
+
+  const afterWithResidue = {
+    ...DATABASE_SNAPSHOT,
+    sessions: [...DATABASE_SNAPSHOT.sessions, CREATED_SESSION_ROWS[1]],
+  };
+  const cleanup = buildTemporarySessionCleanupProof(
+    SESSION_PROOF_METADATA,
+    TEMPORARY_SESSIONS_CREATED,
+    afterWithResidue,
+    { file: CREATED_SESSIONS_FILE, bytes: 1, sha256: 'ab'.repeat(32) }
+  );
+  assert.equal(cleanup.allDeleted, false);
+  assert.deepEqual(cleanup.deletedSessionIds, [TEMPORARY_SESSION_IDS[0]]);
+  assert.deepEqual(cleanup.remainingSessionRows, [CREATED_SESSION_ROWS[1]]);
+});
 
 function setupSecretBase() {
   const base = fs.mkdtempSync(path.join(os.tmpdir(), 'microsoft-smoke-secret-test-'));
@@ -314,6 +391,18 @@ test('manifest cannot seal tampered or failed after assertions', (t) => {
   assertFailure(invoke(directory, 'manifest'), /reports unexpected ctime changes/);
 
   writeJson(directory, '91-restoration-comparison.json', RESTORED);
+  const sessionCleanup = JSON.parse(
+    fs.readFileSync(path.join(directory, SESSION_CLEANUP_FILE), 'utf8')
+  );
+  writeJson(directory, SESSION_CLEANUP_FILE, {
+    ...sessionCleanup,
+    deletedSessionIds: [TEMPORARY_SESSION_IDS[0]],
+    allDeleted: false,
+  });
+  writePhaseMarker(directory, 'after');
+  assertFailure(invoke(directory, 'manifest'), /does not show both temporary session rows/);
+
+  writeJson(directory, SESSION_CLEANUP_FILE, sessionCleanup);
   writePhaseMarker(directory, 'after');
   const sealed = invoke(directory, 'manifest');
   assert.equal(sealed.status, 0, `${sealed.stdout}${sealed.stderr}`);
@@ -322,6 +411,8 @@ test('manifest cannot seal tampered or failed after assertions', (t) => {
   );
   assert.equal(manifest.assertionsPassed, true);
   assert.equal(manifest.restorationExact, true);
+  assert.equal(manifest.temporarySessionRowsDeleted, true);
+  assert.equal(manifest.temporarySessionRowsDeletedCount, 2);
   assert.equal(manifest.ctimeDisclosed, true);
   assert.equal(manifest.ctimeNonRestorableReason, CTIME_NON_RESTORABLE_REASON);
   assert.deepEqual(manifest.ctimeUnexpectedChanges, []);

--- a/scripts/tests/capture-microsoft-email-smoke-evidence.test.mjs
+++ b/scripts/tests/capture-microsoft-email-smoke-evidence.test.mjs
@@ -7,6 +7,15 @@ import { fileURLToPath } from 'node:url';
 import assert from 'node:assert/strict';
 import test from 'node:test';
 
+import {
+  exactComparison,
+  secretInventory,
+} from '../capture-microsoft-email-smoke-evidence.mjs';
+import {
+  directoryTimestampSnapshot,
+  restoreDirectoryTimestamps,
+} from '../microsoft-email-smoke-timestamps.mjs';
+
 const REPO_ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '../..');
 const SCRIPT = path.join(REPO_ROOT, 'scripts/capture-microsoft-email-smoke-evidence.mjs');
 const WORKFLOW_RUN_ID = '11111111-1111-4111-8111-111111111111';
@@ -141,6 +150,89 @@ function assertFailure(result, message) {
   assert.notEqual(result.status, 0);
   assert.match(`${result.stdout}${result.stderr}`, message);
 }
+
+const SECRET_TENANT_ID = '33333333-3333-4333-8333-333333333333';
+
+function setupSecretBase() {
+  const base = fs.mkdtempSync(path.join(os.tmpdir(), 'microsoft-smoke-secret-test-'));
+  const tenantDirectory = path.join(base, 'tenants', SECRET_TENANT_ID);
+  fs.mkdirSync(tenantDirectory, { recursive: true });
+  fs.writeFileSync(path.join(tenantDirectory, 'existing_secret'), 'value\n', { mode: 0o600 });
+  return { base, tenantDirectory };
+}
+
+function inventory(base) {
+  return secretInventory(
+    REPO_ROOT,
+    { SECRET_WRITE_PROVIDER: 'filesystem', SECRET_FS_BASE_PATH: base },
+    SECRET_TENANT_ID
+  );
+}
+
+test('secret inventory records file mtimes and the truncated directory mtime', (t) => {
+  const { base, tenantDirectory } = setupSecretBase();
+  t.after(() => fs.rmSync(base, { recursive: true, force: true }));
+
+  const recorded = inventory(base);
+  assert.equal(recorded.files.length, 1);
+  assert.equal(
+    recorded.files[0].mtimeMs,
+    fs.statSync(path.join(tenantDirectory, 'existing_secret')).mtimeMs
+  );
+  assert.equal(recorded.directoryExists, true);
+  assert.equal(recorded.directoryMtimeMs, Math.trunc(fs.statSync(tenantDirectory).mtimeMs));
+
+  const emptyBase = fs.mkdtempSync(path.join(os.tmpdir(), 'microsoft-smoke-secret-empty-'));
+  t.after(() => fs.rmSync(emptyBase, { recursive: true, force: true }));
+  const absent = inventory(emptyBase);
+  assert.equal(absent.directoryExists, false);
+  assert.equal(absent.directoryMtimeMs, null);
+  assert.deepEqual(absent.files, []);
+});
+
+test('an mtime-only difference fails the restoration exactness comparison', (t) => {
+  const { base, tenantDirectory } = setupSecretBase();
+  t.after(() => fs.rmSync(base, { recursive: true, force: true }));
+  const secretFile = path.join(tenantDirectory, 'existing_secret');
+
+  const baseline = inventory(base);
+  fs.utimesSync(secretFile, new Date('2026-01-01T00:00:00Z'), new Date('2026-01-01T00:00:00Z'));
+  const fileTouched = inventory(base);
+  assert.equal(exactComparison(baseline, fileTouched).exactMatch, false);
+
+  fs.utimesSync(
+    tenantDirectory,
+    new Date('2026-02-02T00:00:00Z'),
+    new Date('2026-02-02T00:00:00Z')
+  );
+  const directoryTouched = inventory(base);
+  assert.equal(exactComparison(fileTouched, directoryTouched).exactMatch, false);
+});
+
+test('directory timestamp restoration is millisecond-exact', (t) => {
+  const { base, tenantDirectory } = setupSecretBase();
+  t.after(() => fs.rmSync(base, { recursive: true, force: true }));
+
+  fs.utimesSync(
+    tenantDirectory,
+    new Date('2026-03-03T03:03:03.123Z'),
+    new Date('2026-03-03T03:03:03.123Z')
+  );
+  const baseline = inventory(base);
+  const snapshot = directoryTimestampSnapshot(tenantDirectory);
+
+  const churnFile = path.join(tenantDirectory, 'transient_secret');
+  fs.writeFileSync(churnFile, 'transient\n', { mode: 0o600 });
+  fs.rmSync(churnFile);
+  assert.equal(exactComparison(baseline, inventory(base)).exactMatch, false);
+
+  restoreDirectoryTimestamps(snapshot);
+  assert.equal(
+    Math.trunc(fs.statSync(tenantDirectory).mtimeMs),
+    Math.trunc(snapshot.mtimeMs)
+  );
+  assert.equal(exactComparison(baseline, inventory(base)).exactMatch, true);
+});
 
 test('correlate requires shared capture identity, a fidelity note, and the Graph limitation', (t) => {
   const directory = setupEvidence();

--- a/scripts/tests/helpers/microsoft-smoke-evidence-fixture.mjs
+++ b/scripts/tests/helpers/microsoft-smoke-evidence-fixture.mjs
@@ -1,0 +1,329 @@
+/**
+ * Shared fixture for the Microsoft Email smoke-evidence tests: builds a
+ * complete, internally consistent evidence directory that the capture script
+ * can correlate and seal, and that the bundle verifier can verify.
+ *
+ * Every JSON artifact here mirrors the structure the live capture produces —
+ * the verifier recomputes restoration comparisons from the database and
+ * secret-inventory snapshots, so the fixture derives the restoration file
+ * from the same objects it writes into those snapshots.
+ */
+
+import { spawnSync } from 'node:child_process';
+import { createHash } from 'node:crypto';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import {
+  CTIME_NON_RESTORABLE_REASON,
+  restorableInventory,
+} from '../../microsoft-email-smoke-timestamps.mjs';
+
+export const REPO_ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '../../..');
+export const CAPTURE_SCRIPT = path.join(REPO_ROOT, 'scripts/capture-microsoft-email-smoke-evidence.mjs');
+export const VERIFY_SCRIPT = path.join(REPO_ROOT, 'scripts/verify-microsoft-email-smoke-evidence.mjs');
+export const WORKFLOW_RUN_ID = '11111111-1111-4111-8111-111111111111';
+export const CAPTURE_NONCE = '22222222-2222-4222-8222-222222222222';
+export const TENANT_ID = '33333333-3333-4333-8333-333333333333';
+export const PROFILE_ID = '44444444-4444-4444-8444-444444444444';
+export const EXISTING_PROFILE_ID = '55555555-5555-4555-8555-555555555555';
+export const EXTERNAL_GRAPH_LIMITATION = 'No external Microsoft Graph or Entra OAuth call is performed by this evidence helper.';
+export const CROSS_HOST_CONTEXT = 'The card browser is Mac-hosted while the worktree server runs on Linux through a localhost-to-Tailscale relay.';
+export const FIDELITY_NOTE = 'React handlers were driven from the card-scoped Mac terminal; the exported live DOM was rendered to the attached PNG.';
+export const PHASE_FILES = {
+  before: [
+    '01-before-git-status.txt',
+    '01-before-secret-inventory.json',
+    '01-before-runtime-build.json',
+    '01-before-port-route-health.json',
+    '01-before-database.json',
+  ],
+  after: [
+    '90-after-git-status.txt',
+    '90-after-secret-inventory.json',
+    '90-after-runtime-build.json',
+    '90-after-port-route-health.json',
+    '90-after-database.json',
+    '91-restoration-comparison.json',
+  ],
+};
+export const PHASE_MARKERS = {
+  before: '02-before-assertions-passed.json',
+  after: '92-after-assertions-passed.json',
+};
+
+const ONE_PIXEL_PNG = Buffer.from(
+  'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNk+A8AAQUBAScY42YAAAAASUVORK5CYII=',
+  'base64'
+);
+
+export const DATABASE_SNAPSHOT = {
+  connection: { host: '127.0.0.1', port: 5432, user: 'app_user', database: 'server' },
+  identity: {
+    database: 'server',
+    database_user: 'app_user',
+    server_address: '127.0.0.1',
+    server_port: 5432,
+    postgres_version: 'PostgreSQL 17.0 (test fixture)',
+  },
+  microsoftProfiles: [
+    {
+      profile_id: EXISTING_PROFILE_ID,
+      tenant: TENANT_ID,
+      display_name: 'Pre-existing profile',
+      created_at: '2026-01-01T00:00:00.000Z',
+      updated_at: '2026-01-01T00:00:00.000Z',
+    },
+  ],
+  microsoftConsumerBindings: [
+    {
+      tenant: TENANT_ID,
+      consumer_type: 'email_provider',
+      profile_id: EXISTING_PROFILE_ID,
+      created_at: '2026-01-02T00:00:00.000Z',
+      updated_at: '2026-01-02T00:00:00.000Z',
+    },
+  ],
+};
+
+export const SECRET_INVENTORY_SNAPSHOT = {
+  provider: 'filesystem',
+  basePath: '/tmp/secret-base',
+  tenantDirectory: `/tmp/secret-base/tenants/${TENANT_ID}`,
+  directoryExists: true,
+  directoryMtimeMs: 1785886890527,
+  directoryCtimeMs: 1785886890527.123,
+  parentDirectoryCtimeMs: 1785886890000.5,
+  files: [
+    {
+      name: 'existing_secret',
+      bytes: 6,
+      mode: 0o600,
+      mtimeMs: 1785886880000.25,
+      ctimeMs: 1785886880000.25,
+      sha256: 'ab'.repeat(32),
+    },
+  ],
+};
+
+export const RUNTIME_BUILD_SNAPSHOT = {
+  capturedAt: '2026-08-04T23:00:00.000Z',
+  commit: '0123456789abcdef0123456789abcdef01234567',
+  branch: 'chore/microsoft-graph-cleanup-test',
+  worktree: '/tmp/test-worktree',
+  commandCwd: '/tmp/test-worktree',
+  port: 3100,
+  listenerProbe: { exitCode: 0 },
+  listeningProcesses: [{ pid: 4242, cwd: '/tmp/test-worktree', command: 'node server' }],
+  buildFiles: [],
+};
+
+export const RESTORED = {
+  exactMatch: true,
+  microsoftProfiles: {
+    exactMatch: true,
+    baseline: DATABASE_SNAPSHOT.microsoftProfiles,
+    after: DATABASE_SNAPSHOT.microsoftProfiles,
+  },
+  microsoftConsumerBindings: {
+    exactMatch: true,
+    baseline: DATABASE_SNAPSHOT.microsoftConsumerBindings,
+    after: DATABASE_SNAPSHOT.microsoftConsumerBindings,
+  },
+  tenantSecrets: {
+    exactMatch: true,
+    baseline: restorableInventory(SECRET_INVENTORY_SNAPSHOT),
+    after: restorableInventory(SECRET_INVENTORY_SNAPSHOT),
+  },
+  ctimeDisclosure: {
+    reason: CTIME_NON_RESTORABLE_REASON,
+    paths: [
+      {
+        path: SECRET_INVENTORY_SNAPSHOT.tenantDirectory,
+        kind: 'directory',
+        expected: true,
+        baselineCtimeMs: SECRET_INVENTORY_SNAPSHOT.directoryCtimeMs,
+        afterCtimeMs: SECRET_INVENTORY_SNAPSHOT.directoryCtimeMs,
+        changed: false,
+      },
+    ],
+    changedPaths: [],
+    unexpectedChanges: [],
+  },
+};
+
+export const PROVENANCE = {
+  workflowRunId: WORKFLOW_RUN_ID,
+  captureNonce: CAPTURE_NONCE,
+  capturedAt: '2026-08-04T23:00:00.000Z',
+  browser: {
+    userAgent: 'Smoke Browser 1',
+    url: 'http://localhost:3100/msp/settings?category=communication',
+    platform: 'macOS',
+  },
+};
+
+export const UI_CAPTURES = {
+  '01-self-hosted-providers-wizard.json': {
+    url: 'http://localhost:3100/msp/settings/integrations?category=providers',
+    text: 'Set up Microsoft — automated Entra creation Unavailable, manual setup Advanced',
+    platformOptionPresent: false,
+    automatedFirst: true,
+    automatedUnavailable: true,
+    manualAdvanced: true,
+  },
+  '01b-manual-setup-derived-redirect.json': {
+    url: 'http://localhost:3100/msp/settings/integrations?category=providers',
+    redirectUri: 'http://localhost:3100/api/auth/microsoft/callback',
+    readOnly: true,
+    mailboxRedirectInputPresent: false,
+    text: 'Redirect URI to add in Entra',
+  },
+  '02-pending-consent-mailbox.json': {
+    pointer: 'Microsoft app setup is managed in Providers.',
+    url: 'http://localhost:3100/msp/settings/integrations?category=communication',
+    text: 'Waiting for your Microsoft 365 administrator. Setup was started in Providers but has not been approved yet.',
+    redirectInputs: 0,
+    byoTextPresent: false,
+    signInText: 'Sign in with Microsoft',
+    signInDisabled: true,
+  },
+  '03-restored-not-configured-mailbox.json': {
+    pointer: 'Microsoft app setup is managed in Providers.',
+    url: 'http://localhost:3100/msp/settings/integrations?category=communication',
+    text: "Microsoft isn't set up yet. Set it up once in Providers, then come back.",
+    redirectInputs: 0,
+    byoTextPresent: false,
+    signInText: 'Sign in with Microsoft',
+    signInDisabled: true,
+  },
+};
+
+export function sha256(filePath) {
+  return createHash('sha256').update(fs.readFileSync(filePath)).digest('hex');
+}
+
+export function writeJson(directory, name, value) {
+  fs.writeFileSync(path.join(directory, name), `${JSON.stringify(value, null, 2)}\n`);
+}
+
+export function fileIdentity(directory, name) {
+  const filePath = path.join(directory, name);
+  return {
+    file: name,
+    bytes: fs.statSync(filePath).size,
+    sha256: sha256(filePath),
+  };
+}
+
+export function writePhaseMarker(directory, phase) {
+  writeJson(directory, PHASE_MARKERS[phase], {
+    workflowRunId: WORKFLOW_RUN_ID,
+    phase,
+    assertionsPassed: true,
+    recordedAt: '2026-08-04T23:00:00.000Z',
+    externalGraphLimitation: EXTERNAL_GRAPH_LIMITATION,
+    files: PHASE_FILES[phase].map((name) => fileIdentity(directory, name)),
+  });
+}
+
+/**
+ * Build a complete pre-seal evidence directory. Pass overrides to corrupt
+ * specific UI captures for negative tests, e.g.
+ * `{ uiCaptures: { '02-pending-consent-mailbox.json': { byoTextPresent: true } } }`.
+ */
+export function setupEvidence({ uiCaptures = {}, omitUiFiles = [] } = {}) {
+  const directory = fs.mkdtempSync(path.join(os.tmpdir(), 'microsoft-smoke-evidence-test-'));
+  writeJson(directory, '00-workflow-run.json', {
+    workflowRunId: WORKFLOW_RUN_ID,
+    evidenceDirectory: directory,
+    startedAt: '2026-08-04T22:59:00.000Z',
+    appUrl: 'http://localhost:3100',
+    tenantId: TENANT_ID,
+    profileId: PROFILE_ID,
+    externalGraphLimitation: EXTERNAL_GRAPH_LIMITATION,
+    crossHostContext: CROSS_HOST_CONTEXT,
+  });
+
+  for (const prefix of ['01-before', '90-after']) {
+    fs.writeFileSync(
+      path.join(directory, `${prefix}-git-status.txt`),
+      '$ git status --short\nexit_code=0\nsignal=\n--- stdout ---\n\n--- stderr ---\n'
+    );
+    writeJson(directory, `${prefix}-secret-inventory.json`, SECRET_INVENTORY_SNAPSHOT);
+    writeJson(directory, `${prefix}-runtime-build.json`, RUNTIME_BUILD_SNAPSHOT);
+    writeJson(directory, `${prefix}-port-route-health.json`, {
+      appUrl: 'http://localhost:3100',
+      listeningProcesses: RUNTIME_BUILD_SNAPSHOT.listeningProcesses,
+      routes: [{ route: '/', status: 200, location: null, contentType: 'text/html' }],
+    });
+    writeJson(directory, `${prefix}-database.json`, DATABASE_SNAPSHOT);
+  }
+  writeJson(directory, '91-restoration-comparison.json', RESTORED);
+  writePhaseMarker(directory, 'before');
+  writePhaseMarker(directory, 'after');
+
+  for (const [name, capture] of Object.entries(UI_CAPTURES)) {
+    if (omitUiFiles.includes(name)) {
+      continue;
+    }
+    writeJson(directory, name, { ...capture, ...(uiCaptures[name] || {}) });
+    const pngName = name.replace(/\.json$/, '.png');
+    if (!omitUiFiles.includes(pngName)) {
+      fs.writeFileSync(path.join(directory, pngName), ONE_PIXEL_PNG);
+    }
+  }
+
+  fs.writeFileSync(path.join(directory, 'final.png'), ONE_PIXEL_PNG);
+  return directory;
+}
+
+export function writeCapture(directory, embeddedProvenance, crossHostFidelityNote = FIDELITY_NOTE) {
+  fs.writeFileSync(
+    path.join(directory, 'final.html'),
+    `<html><body>cleanup</body><script id="alga-smoke-capture-provenance" type="application/json">${JSON.stringify(embeddedProvenance)}</script></html>`
+  );
+  writeJson(directory, 'browser-capture.json', {
+    provenance: PROVENANCE,
+    artifacts: {
+      dom: { file: 'final.html', sha256: sha256(path.join(directory, 'final.html')) },
+      screenshot: { file: 'final.png', sha256: sha256(path.join(directory, 'final.png')) },
+    },
+    renderMethod: 'Live DOM rendered by the card-scoped Mac browser',
+    crossHostFidelityNote,
+    externalGraphLimitation: EXTERNAL_GRAPH_LIMITATION,
+  });
+}
+
+export function invoke(directory, command) {
+  const args = command === 'correlate'
+    ? [
+      CAPTURE_SCRIPT,
+      command,
+      `--evidence-dir=${directory}`,
+      `--dom-file=${path.join(directory, 'final.html')}`,
+      `--screenshot-file=${path.join(directory, 'final.png')}`,
+      `--capture-provenance-file=${path.join(directory, 'browser-capture.json')}`,
+    ]
+    : [CAPTURE_SCRIPT, command, `--evidence-dir=${directory}`];
+  return spawnSync(process.execPath, args, { cwd: REPO_ROOT, encoding: 'utf8' });
+}
+
+/**
+ * Build, correlate, and seal a bundle in one step for verifier tests.
+ * Throws if sealing fails so tests surface the capture script's message.
+ */
+export function sealedBundle(options = {}) {
+  const directory = setupEvidence(options);
+  writeCapture(directory, PROVENANCE);
+  for (const command of ['correlate', 'manifest']) {
+    const result = invoke(directory, command);
+    if (result.status !== 0) {
+      fs.rmSync(directory, { recursive: true, force: true });
+      throw new Error(`${command} failed: ${result.stdout}${result.stderr}`);
+    }
+  }
+  return directory;
+}

--- a/scripts/tests/helpers/microsoft-smoke-evidence-fixture.mjs
+++ b/scripts/tests/helpers/microsoft-smoke-evidence-fixture.mjs
@@ -20,6 +20,11 @@ import {
   CTIME_NON_RESTORABLE_REASON,
   restorableInventory,
 } from '../../microsoft-email-smoke-timestamps.mjs';
+import {
+  CREATED_SESSIONS_FILE,
+  EXPECTED_TEMPORARY_SESSION_COUNT,
+  SESSION_CLEANUP_FILE,
+} from '../../verify-microsoft-email-smoke-evidence.mjs';
 
 export const REPO_ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '../../..');
 export const CAPTURE_SCRIPT = path.join(REPO_ROOT, 'scripts/capture-microsoft-email-smoke-evidence.mjs');
@@ -29,6 +34,12 @@ export const CAPTURE_NONCE = '22222222-2222-4222-8222-222222222222';
 export const TENANT_ID = '33333333-3333-4333-8333-333333333333';
 export const PROFILE_ID = '44444444-4444-4444-8444-444444444444';
 export const EXISTING_PROFILE_ID = '55555555-5555-4555-8555-555555555555';
+export const USER_ID = '66666666-6666-4666-8666-666666666666';
+export const BASELINE_SESSION_ID = '77777777-7777-4777-8777-777777777777';
+export const TEMPORARY_SESSION_IDS = [
+  '88888888-8888-4888-8888-888888888888',
+  '99999999-9999-4999-8999-999999999999',
+];
 export const EXTERNAL_GRAPH_LIMITATION = 'No external Microsoft Graph or Entra OAuth call is performed by this evidence helper.';
 export const CROSS_HOST_CONTEXT = 'The card browser is Mac-hosted while the worktree server runs on Linux through a localhost-to-Tailscale relay.';
 export const FIDELITY_NOTE = 'React handlers were driven from the card-scoped Mac terminal; the exported live DOM was rendered to the attached PNG.';
@@ -47,6 +58,7 @@ export const PHASE_FILES = {
     '90-after-port-route-health.json',
     '90-after-database.json',
     '91-restoration-comparison.json',
+    SESSION_CLEANUP_FILE,
   ],
 };
 export const PHASE_MARKERS = {
@@ -86,6 +98,30 @@ export const DATABASE_SNAPSHOT = {
       updated_at: '2026-01-02T00:00:00.000Z',
     },
   ],
+  sessions: [
+    {
+      tenant: TENANT_ID,
+      session_id: BASELINE_SESSION_ID,
+      user_id: USER_ID,
+      created_at: '2026-08-04T22:00:00.000Z',
+    },
+  ],
+};
+
+export const CREATED_SESSION_ROWS = TEMPORARY_SESSION_IDS.map((sessionId, index) => ({
+  tenant: TENANT_ID,
+  session_id: sessionId,
+  user_id: USER_ID,
+  created_at: `2026-08-04T23:00:0${index + 1}.000Z`,
+}));
+
+export const TEMPORARY_SESSIONS_CREATED = {
+  workflowRunId: WORKFLOW_RUN_ID,
+  tenantId: TENANT_ID,
+  capturedAt: '2026-08-04T23:00:03.000Z',
+  expectedCreatedSessionCount: EXPECTED_TEMPORARY_SESSION_COUNT,
+  assertionsPassed: true,
+  createdSessions: CREATED_SESSION_ROWS,
 };
 
 export const SECRET_INVENTORY_SNAPSHOT = {
@@ -243,6 +279,11 @@ export function setupEvidence({ uiCaptures = {}, omitUiFiles = [] } = {}) {
     appUrl: 'http://localhost:3100',
     tenantId: TENANT_ID,
     profileId: PROFILE_ID,
+    temporarySessionCleanup: {
+      expectedCreatedSessionCount: EXPECTED_TEMPORARY_SESSION_COUNT,
+      createdEvidenceFile: CREATED_SESSIONS_FILE,
+      cleanupEvidenceFile: SESSION_CLEANUP_FILE,
+    },
     externalGraphLimitation: EXTERNAL_GRAPH_LIMITATION,
     crossHostContext: CROSS_HOST_CONTEXT,
   });
@@ -262,6 +303,18 @@ export function setupEvidence({ uiCaptures = {}, omitUiFiles = [] } = {}) {
     writeJson(directory, `${prefix}-database.json`, DATABASE_SNAPSHOT);
   }
   writeJson(directory, '91-restoration-comparison.json', RESTORED);
+  writeJson(directory, CREATED_SESSIONS_FILE, TEMPORARY_SESSIONS_CREATED);
+  writeJson(directory, SESSION_CLEANUP_FILE, {
+    workflowRunId: WORKFLOW_RUN_ID,
+    tenantId: TENANT_ID,
+    verifiedAt: '2026-08-04T23:00:04.000Z',
+    createdEvidence: fileIdentity(directory, CREATED_SESSIONS_FILE),
+    expectedCreatedSessionCount: EXPECTED_TEMPORARY_SESSION_COUNT,
+    createdSessionIds: [...TEMPORARY_SESSION_IDS],
+    deletedSessionIds: [...TEMPORARY_SESSION_IDS],
+    remainingSessionRows: [],
+    allDeleted: true,
+  });
   writePhaseMarker(directory, 'before');
   writePhaseMarker(directory, 'after');
 

--- a/scripts/tests/verify-microsoft-email-smoke-evidence.test.mjs
+++ b/scripts/tests/verify-microsoft-email-smoke-evidence.test.mjs
@@ -7,16 +7,23 @@ import assert from 'node:assert/strict';
 import test, { after, before } from 'node:test';
 
 import {
+  CREATED_SESSIONS_FILE,
   INDEX_FILE,
   MANIFEST_FILE,
   REQUIRED_CLAIMS,
+  SESSION_CLEANUP_FILE,
   VERIFIER_COPY_FILE,
   verifyBundle,
 } from '../verify-microsoft-email-smoke-evidence.mjs';
 import {
+  CREATED_SESSION_ROWS,
+  DATABASE_SNAPSHOT,
+  PHASE_MARKERS,
   REPO_ROOT,
   VERIFY_SCRIPT,
   sealedBundle,
+  writeJson,
+  writePhaseMarker,
 } from './helpers/microsoft-smoke-evidence-fixture.mjs';
 
 let sealedSource;
@@ -88,6 +95,18 @@ function rewriteIndex(directory, mutate) {
   fs.writeFileSync(indexPath, `${JSON.stringify(index, null, 2)}\n`);
 }
 
+function repinIndexEvidence(directory, names) {
+  rewriteIndex(directory, (index) => {
+    for (const claim of index.claims) {
+      claim.evidence = claim.evidence.map((evidence) => (
+        !evidence.sealedAfterIndex && names.has(evidence.file)
+          ? fileIdentity(directory, evidence.file)
+          : evidence
+      ));
+    }
+  });
+}
+
 test('a sealed bundle passes both the repo verifier and its bundled copy', (t) => {
   const directory = copyOfSealedBundle(t);
 
@@ -121,6 +140,18 @@ test('the verification index maps every required claim to sealed evidence', (t) 
   assert.ok(index.disclosures.crossHostFidelityNote.length > 0);
   assert.ok(index.disclosures.ctimeNonRestorableReason.length > 0);
   assert.ok(index.disclosures.integrityAnchor.length > 0);
+  const cleanupClaim = index.claims.find((claim) => claim.id === 'temporary-session-cleanup');
+  assert.deepEqual(
+    cleanupClaim.evidence.map((evidence) => evidence.file),
+    [
+      '00-workflow-run.json',
+      '01-before-database.json',
+      CREATED_SESSIONS_FILE,
+      '90-after-database.json',
+      SESSION_CLEANUP_FILE,
+      MANIFEST_FILE,
+    ]
+  );
   for (const claim of index.claims) {
     for (const evidence of claim.evidence) {
       const filePath = path.join(directory, evidence.file);
@@ -198,6 +229,25 @@ test('a dishonest re-seal cannot weaken a declared assertion', (t) => {
   const result = runVerifier(directory);
   assert.equal(result.status, 1);
   assert.match(result.stdout, /declares different assertions for claim derived-readonly-redirect-uri/);
+});
+
+test('a dishonest re-seal cannot hide one surviving temporary session row', (t) => {
+  const directory = copyOfSealedBundle(t);
+  writeJson(directory, '90-after-database.json', {
+    ...DATABASE_SNAPSHOT,
+    sessions: [...DATABASE_SNAPSHOT.sessions, CREATED_SESSION_ROWS[0]],
+  });
+  writePhaseMarker(directory, 'after');
+  repinIndexEvidence(directory, new Set([
+    '90-after-database.json',
+    PHASE_MARKERS.after,
+  ]));
+  resealDishonestly(directory);
+
+  const result = runVerifier(directory);
+  assert.equal(result.status, 1);
+  assert.match(result.stdout, /FAIL temporary-session-cleanup/);
+  assert.match(result.stdout, /remains in the after snapshot/);
 });
 
 test('the verifier deadline bounds execution', (t) => {

--- a/scripts/tests/verify-microsoft-email-smoke-evidence.test.mjs
+++ b/scripts/tests/verify-microsoft-email-smoke-evidence.test.mjs
@@ -11,6 +11,8 @@ import {
   INDEX_FILE,
   MANIFEST_FILE,
   REQUIRED_CLAIMS,
+  REVIEW_FILE,
+  REVIEW_SECTIONS,
   SESSION_CLEANUP_FILE,
   VERIFIER_COPY_FILE,
   verifyBundle,
@@ -161,6 +163,75 @@ test('the verification index maps every required claim to sealed evidence', (t) 
       }
     }
   }
+});
+
+test('the review sections cover every required claim exactly once', () => {
+  const sectionIds = REVIEW_SECTIONS.flatMap((section) => section.claimIds);
+  assert.equal(new Set(sectionIds).size, sectionIds.length);
+  assert.deepEqual(
+    [...sectionIds].sort(),
+    REQUIRED_CLAIMS.map((claim) => claim.id).sort()
+  );
+});
+
+test('sealing writes a self-contained review entrypoint covered by the checksums', (t) => {
+  const directory = copyOfSealedBundle(t);
+  const reviewPath = path.join(directory, REVIEW_FILE);
+  assert.ok(fs.existsSync(reviewPath), `${REVIEW_FILE} is missing from the sealed bundle`);
+
+  const review = fs.readFileSync(reviewPath, 'utf8');
+  assert.match(review, new RegExp(`node <bundle-dir>/${VERIFIER_COPY_FILE} <bundle-dir>`));
+  assert.match(review, /sha256sum -c SHA256SUMS/);
+  assert.match(
+    review,
+    new RegExp(`VERIFIED: ${REQUIRED_CLAIMS.length}/${REQUIRED_CLAIMS.length} claims passed`)
+  );
+  for (const claim of REQUIRED_CLAIMS) {
+    assert.match(review, new RegExp(`\\*\\*${claim.id}\\*\\*`), `${claim.id} missing from claim table`);
+  }
+  for (const section of REVIEW_SECTIONS) {
+    assert.ok(review.includes(`### ${section.title}`), `section "${section.title}" missing`);
+  }
+  const cleanup = JSON.parse(fs.readFileSync(path.join(directory, SESSION_CLEANUP_FILE), 'utf8'));
+  for (const sessionId of cleanup.createdSessionIds) {
+    assert.ok(review.includes(sessionId), `temporary session ${sessionId} missing from review`);
+  }
+  assert.match(review, /Do not\ninvestigate the repository/);
+
+  const checksums = fs.readFileSync(path.join(directory, 'SHA256SUMS'), 'utf8');
+  assert.match(checksums, new RegExp(`^[0-9a-f]{64}  ${REVIEW_FILE}$`, 'm'));
+  const manifest = JSON.parse(fs.readFileSync(path.join(directory, MANIFEST_FILE), 'utf8'));
+  assert.ok(
+    manifest.files.some((entry) => entry.file === REVIEW_FILE),
+    `${REVIEW_FILE} missing from the sealed manifest`
+  );
+});
+
+test('an edited review entrypoint fails verification even after a dishonest re-seal', (t) => {
+  const directory = copyOfSealedBundle(t);
+  const reviewPath = path.join(directory, REVIEW_FILE);
+  const review = fs.readFileSync(reviewPath, 'utf8');
+  fs.writeFileSync(
+    reviewPath,
+    review.replace('Do not\ninvestigate the repository', 'Feel free to\ninvestigate the repository')
+  );
+  resealDishonestly(directory);
+
+  const result = runVerifier(directory);
+  assert.equal(result.status, 1);
+  assert.match(result.stdout, /FAIL verification-index/);
+  assert.match(result.stdout, /00-REVIEW\.md does not byte-match/);
+});
+
+test('a deleted review entrypoint fails verification even after a dishonest re-seal', (t) => {
+  const directory = copyOfSealedBundle(t);
+  fs.rmSync(path.join(directory, REVIEW_FILE));
+  resealDishonestly(directory);
+
+  const result = runVerifier(directory);
+  assert.equal(result.status, 1);
+  assert.match(result.stdout, /FAIL verification-index/);
+  assert.match(result.stdout, /00-REVIEW\.md/);
 });
 
 test('a missing evidence file fails verification', (t) => {

--- a/scripts/tests/verify-microsoft-email-smoke-evidence.test.mjs
+++ b/scripts/tests/verify-microsoft-email-smoke-evidence.test.mjs
@@ -11,10 +11,14 @@ import {
   INDEX_FILE,
   MANIFEST_FILE,
   REQUIRED_CLAIMS,
+  REQUIRED_TAMPER_TRIALS,
   REVIEW_FILE,
   REVIEW_SECTIONS,
   SESSION_CLEANUP_FILE,
+  TAMPER_TRIALS_FILE,
   VERIFIER_COPY_FILE,
+  formatVerdictLines,
+  validateTamperTrialRecord,
   verifyBundle,
 } from '../verify-microsoft-email-smoke-evidence.mjs';
 import {
@@ -114,14 +118,71 @@ test('a sealed bundle passes both the repo verifier and its bundled copy', (t) =
 
   const repoRun = runVerifier(directory);
   assert.equal(repoRun.status, 0, `${repoRun.stdout}${repoRun.stderr}`);
-  for (const claim of REQUIRED_CLAIMS) {
-    assert.match(repoRun.stdout, new RegExp(`PASS ${claim.id}`));
+  assert.match(repoRun.stdout, /^VERDICT: PASS\n/);
+  for (const section of REVIEW_SECTIONS) {
+    assert.match(
+      repoRun.stdout,
+      new RegExp(`PASS ${section.title} \\(${section.claimIds.length}/${section.claimIds.length}\\)`)
+    );
   }
-  assert.match(repoRun.stdout, /VERIFIED: \d+\/\d+ claims passed/);
+  assert.match(repoRun.stdout, /Observed licensing mode: self-host/);
+  assert.match(
+    repoRun.stdout,
+    new RegExp(`VERIFIED: ${REQUIRED_CLAIMS.length}/${REQUIRED_CLAIMS.length} claims passed`)
+  );
   assert.match(repoRun.stdout, /bundleDigest sha256\(SHA256SUMS\)=[0-9a-f]{64}/);
+  assert.match(repoRun.stdout, /Review complete: no artifact-by-artifact inspection is required\./);
 
   const bundledRun = runVerifier(directory, [], path.join(directory, VERIFIER_COPY_FILE));
   assert.equal(bundledRun.status, 0, `${bundledRun.stdout}${bundledRun.stderr}`);
+});
+
+test('success output is concise and terminal: no per-claim or per-artifact listing', (t) => {
+  const directory = copyOfSealedBundle(t);
+  const result = runVerifier(directory);
+  assert.equal(result.status, 0);
+  const lines = result.stdout.trimEnd().split('\n');
+  assert.ok(
+    lines.length <= 5 + REVIEW_SECTIONS.length,
+    `success output must stay a summary; got ${lines.length} lines`
+  );
+  for (const claim of REQUIRED_CLAIMS) {
+    assert.doesNotMatch(result.stdout, new RegExp(`PASS ${claim.id}\\b`));
+  }
+  for (const name of fs.readdirSync(directory).filter((entry) => entry !== 'SHA256SUMS')) {
+    assert.ok(!result.stdout.includes(name), `success output must not mention ${name}`);
+  }
+});
+
+test('--json emits the machine-readable result as one line', (t) => {
+  const directory = copyOfSealedBundle(t);
+  const result = runVerifier(directory, ['--json']);
+  assert.equal(result.status, 0, `${result.stdout}${result.stderr}`);
+  const outputLines = result.stdout.trimEnd().split('\n');
+  assert.equal(outputLines.length, 1, 'the JSON result must be a single line');
+  const summary = JSON.parse(outputLines[0]);
+  assert.equal(summary.verdict, 'PASS');
+  assert.equal(summary.claimsPassed, REQUIRED_CLAIMS.length);
+  assert.equal(summary.claimsTotal, REQUIRED_CLAIMS.length);
+  assert.deepEqual(
+    summary.dimensions.map((dimension) => dimension.title),
+    REVIEW_SECTIONS.map((section) => section.title)
+  );
+  assert.equal(summary.licensingMode, 'self-host');
+  assert.match(summary.bundleDigest, /^[0-9a-f]{64}$/);
+  assert.deepEqual(summary.failedClaims, []);
+});
+
+test('failure output prints per-claim detail for the failing claims only', (t) => {
+  const directory = copyOfSealedBundle(t);
+  fs.rmSync(path.join(directory, '01-self-hosted-providers-wizard.png'));
+  const verdict = verifyBundle(directory);
+  const lines = formatVerdictLines(verdict);
+  assert.equal(lines[0], 'VERDICT: FAIL');
+  assert.ok(lines.some((line) => line.startsWith('FAIL providers-wizard-platform-gating')));
+  assert.ok(lines.some((line) => line.includes('01-self-hosted-providers-wizard.png')));
+  assert.ok(!lines.some((line) => line.startsWith('FAIL restoration-profiles')));
+  assert.ok(!lines.includes('Review complete: no artifact-by-artifact inspection is required.'));
 });
 
 test('the verification index maps every required claim to sealed evidence', (t) => {
@@ -174,29 +235,40 @@ test('the review sections cover every required claim exactly once', () => {
   );
 });
 
-test('sealing writes a self-contained review entrypoint covered by the checksums', (t) => {
+test('sealing writes a review entrypoint that leads with the one bounded command', (t) => {
   const directory = copyOfSealedBundle(t);
   const reviewPath = path.join(directory, REVIEW_FILE);
   assert.ok(fs.existsSync(reviewPath), `${REVIEW_FILE} is missing from the sealed bundle`);
 
   const review = fs.readFileSync(reviewPath, 'utf8');
-  assert.match(review, new RegExp(`node <bundle-dir>/${VERIFIER_COPY_FILE} <bundle-dir>`));
-  assert.match(review, /sha256sum -c SHA256SUMS/);
+  const verdictCommand = `node <bundle-dir>/${VERIFIER_COPY_FILE} <bundle-dir>`;
+  assert.ok(review.includes(verdictCommand), 'the verdict command is missing');
+  assert.ok(
+    review.indexOf(verdictCommand) < review.indexOf('sha256sum -c SHA256SUMS'),
+    'the verdict command must come before the optional checksum confirmation'
+  );
   assert.match(
     review,
     new RegExp(`VERIFIED: ${REQUIRED_CLAIMS.length}/${REQUIRED_CLAIMS.length} claims passed`)
   );
   for (const claim of REQUIRED_CLAIMS) {
-    assert.match(review, new RegExp(`\\*\\*${claim.id}\\*\\*`), `${claim.id} missing from claim table`);
+    assert.ok(review.includes(`\`${claim.id}\``), `${claim.id} missing from the dimension list`);
   }
   for (const section of REVIEW_SECTIONS) {
-    assert.ok(review.includes(`### ${section.title}`), `section "${section.title}" missing`);
+    assert.ok(
+      review.includes(`- ${section.title} (${section.claimIds.length}):`),
+      `dimension "${section.title}" missing`
+    );
   }
+  // The document must not read as a manual inspection checklist: no per-claim
+  // evidence-file listing, and an explicit no-further-inspection statement.
+  assert.ok(!review.includes('Evidence:'), 'per-claim evidence listings must be gone');
+  assert.match(review, /No\nartifact-by-artifact inspection is required/);
+  assert.match(review, /Do not\ninvestigate the repository/);
   const cleanup = JSON.parse(fs.readFileSync(path.join(directory, SESSION_CLEANUP_FILE), 'utf8'));
   for (const sessionId of cleanup.createdSessionIds) {
     assert.ok(review.includes(sessionId), `temporary session ${sessionId} missing from review`);
   }
-  assert.match(review, /Do not\ninvestigate the repository/);
 
   const checksums = fs.readFileSync(path.join(directory, 'SHA256SUMS'), 'utf8');
   assert.match(checksums, new RegExp(`^[0-9a-f]{64}  ${REVIEW_FILE}$`, 'm'));
@@ -204,6 +276,115 @@ test('sealing writes a self-contained review entrypoint covered by the checksums
   assert.ok(
     manifest.files.some((entry) => entry.file === REVIEW_FILE),
     `${REVIEW_FILE} missing from the sealed manifest`
+  );
+});
+
+test('sealing records validated tamper-trial outcomes inside the bundle', (t) => {
+  const directory = copyOfSealedBundle(t);
+  const record = JSON.parse(fs.readFileSync(path.join(directory, TAMPER_TRIALS_FILE), 'utf8'));
+
+  assert.deepEqual(
+    record.trials.map((trial) => trial.name),
+    REQUIRED_TAMPER_TRIALS.map((trial) => trial.name)
+  );
+  assert.equal(record.verifier.sha256, sha256(path.join(directory, VERIFIER_COPY_FILE)));
+  assert.deepEqual(
+    validateTamperTrialRecord(record, {
+      workflowRunId: record.workflowRunId,
+      verifierSha256: record.verifier.sha256,
+      startedAt: null,
+    }),
+    []
+  );
+  for (const trial of record.trials) {
+    assert.equal(trial.exitCode, 1, `${trial.name} must record a rejection exit code`);
+  }
+  const manifest = JSON.parse(fs.readFileSync(path.join(directory, MANIFEST_FILE), 'utf8'));
+  assert.equal(manifest.tamperOutcomes.file, TAMPER_TRIALS_FILE);
+  assert.equal(manifest.tamperOutcomes.allDetected, true);
+  const checksums = fs.readFileSync(path.join(directory, 'SHA256SUMS'), 'utf8');
+  assert.match(checksums, new RegExp(`^[0-9a-f]{64}  ${TAMPER_TRIALS_FILE}$`, 'm'));
+});
+
+test('a forged tamper-trial record fails verification even after a dishonest re-seal', (t) => {
+  const directory = copyOfSealedBundle(t);
+  const recordPath = path.join(directory, TAMPER_TRIALS_FILE);
+  const record = JSON.parse(fs.readFileSync(recordPath, 'utf8'));
+  record.trials.find((trial) => trial.name === 'byte-tamper').exitCode = 0;
+  fs.writeFileSync(recordPath, `${JSON.stringify(record, null, 2)}\n`);
+  resealDishonestly(directory);
+
+  const result = runVerifier(directory);
+  assert.equal(result.status, 1);
+  assert.match(result.stdout, /FAIL sealed-tamper-outcomes/);
+  assert.match(result.stdout, /expected exit code 1/);
+});
+
+test('a dropped tamper trial fails verification even after a dishonest re-seal', (t) => {
+  const directory = copyOfSealedBundle(t);
+  const recordPath = path.join(directory, TAMPER_TRIALS_FILE);
+  const record = JSON.parse(fs.readFileSync(recordPath, 'utf8'));
+  record.trials = record.trials.filter((trial) => trial.name !== 'review-edit-dishonest-reseal');
+  fs.writeFileSync(recordPath, `${JSON.stringify(record, null, 2)}\n`);
+  resealDishonestly(directory);
+
+  const result = runVerifier(directory);
+  assert.equal(result.status, 1);
+  assert.match(result.stdout, /FAIL sealed-tamper-outcomes/);
+  assert.match(result.stdout, /does not record exactly the required trials/);
+});
+
+test('a missing tamper-trial record fails verification even after a dishonest re-seal', (t) => {
+  const directory = copyOfSealedBundle(t);
+  fs.rmSync(path.join(directory, TAMPER_TRIALS_FILE));
+  resealDishonestly(directory);
+
+  const result = runVerifier(directory);
+  assert.equal(result.status, 1);
+  assert.match(result.stdout, /FAIL sealed-tamper-outcomes/);
+  assert.match(result.stdout, new RegExp(TAMPER_TRIALS_FILE));
+});
+
+test('validateTamperTrialRecord rejects the forgeries the seal must never write', (t) => {
+  const directory = copyOfSealedBundle(t);
+  const record = JSON.parse(fs.readFileSync(path.join(directory, TAMPER_TRIALS_FILE), 'utf8'));
+  const context = {
+    workflowRunId: record.workflowRunId,
+    verifierSha256: record.verifier.sha256,
+    startedAt: null,
+  };
+  assert.deepEqual(validateTamperTrialRecord(record, context), []);
+
+  const wrongVerifier = validateTamperTrialRecord(record, {
+    ...context,
+    verifierSha256: 'ff'.repeat(32),
+  });
+  assert.ok(wrongVerifier.some((message) => message.includes('does not pin the sealed verifier copy')));
+
+  const wrongRun = validateTamperTrialRecord(record, {
+    ...context,
+    workflowRunId: '12345678-1234-4123-8123-123456789012',
+  });
+  assert.ok(wrongRun.some((message) => message.includes('different workflow run')));
+
+  const leakyControl = structuredClone(record);
+  const control = leakyControl.trials.find((trial) => trial.name === 'pre-record-control');
+  control.failedClaims.push({ id: 'bundle-integrity', failures: ['synthetic failure'] });
+  assert.ok(
+    validateTamperTrialRecord(leakyControl, context)
+      .some((message) => message.includes('record-absence claims')),
+    'a control that fails extra claims must be rejected'
+  );
+
+  const checksumOnlyDetection = structuredClone(record);
+  const resealTrial = checksumOnlyDetection.trials
+    .find((trial) => trial.name === 'review-edit-dishonest-reseal');
+  resealTrial.passedClaimIds = resealTrial.passedClaimIds
+    .filter((id) => id !== 'bundle-integrity');
+  assert.ok(
+    validateTamperTrialRecord(checksumOnlyDetection, context)
+      .some((message) => message.includes('not checksum-based')),
+    'the reseal trial must prove detection beyond checksums'
   );
 });
 

--- a/scripts/tests/verify-microsoft-email-smoke-evidence.test.mjs
+++ b/scripts/tests/verify-microsoft-email-smoke-evidence.test.mjs
@@ -1,0 +1,241 @@
+import { spawnSync } from 'node:child_process';
+import { createHash } from 'node:crypto';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import assert from 'node:assert/strict';
+import test, { after, before } from 'node:test';
+
+import {
+  INDEX_FILE,
+  MANIFEST_FILE,
+  REQUIRED_CLAIMS,
+  VERIFIER_COPY_FILE,
+  verifyBundle,
+} from '../verify-microsoft-email-smoke-evidence.mjs';
+import {
+  REPO_ROOT,
+  VERIFY_SCRIPT,
+  sealedBundle,
+} from './helpers/microsoft-smoke-evidence-fixture.mjs';
+
+let sealedSource;
+
+before(() => {
+  sealedSource = sealedBundle();
+});
+
+after(() => {
+  if (sealedSource) {
+    fs.rmSync(sealedSource, { recursive: true, force: true });
+  }
+});
+
+function copyOfSealedBundle(t) {
+  const directory = fs.mkdtempSync(path.join(os.tmpdir(), 'microsoft-smoke-verify-test-'));
+  t.after(() => fs.rmSync(directory, { recursive: true, force: true }));
+  fs.cpSync(sealedSource, directory, { recursive: true });
+  return directory;
+}
+
+function runVerifier(directory, extraArguments = [], script = VERIFY_SCRIPT) {
+  return spawnSync(
+    process.execPath,
+    [script, directory, ...extraArguments],
+    { cwd: REPO_ROOT, encoding: 'utf8' }
+  );
+}
+
+function sha256(filePath) {
+  return createHash('sha256').update(fs.readFileSync(filePath)).digest('hex');
+}
+
+function fileIdentity(directory, name) {
+  const filePath = path.join(directory, name);
+  return {
+    file: name,
+    bytes: fs.statSync(filePath).size,
+    sha256: sha256(filePath),
+  };
+}
+
+/**
+ * Re-seal a deliberately tampered bundle: recompute the manifest file entries
+ * and SHA256SUMS so integrity checks pass and only the hardcoded claim logic
+ * can catch the tamper.
+ */
+function resealDishonestly(directory) {
+  const names = fs.readdirSync(directory)
+    .filter((name) => fs.statSync(path.join(directory, name)).isFile())
+    .sort((left, right) => left.localeCompare(right));
+  const manifestPath = path.join(directory, MANIFEST_FILE);
+  const manifest = JSON.parse(fs.readFileSync(manifestPath, 'utf8'));
+  manifest.files = names
+    .filter((name) => name !== MANIFEST_FILE && name !== 'SHA256SUMS')
+    .map((name) => fileIdentity(directory, name));
+  fs.writeFileSync(manifestPath, `${JSON.stringify(manifest, null, 2)}\n`);
+  const checksumNames = names.filter((name) => name !== 'SHA256SUMS');
+  fs.writeFileSync(
+    path.join(directory, 'SHA256SUMS'),
+    `${checksumNames.map((name) => `${sha256(path.join(directory, name))}  ${name}`).join('\n')}\n`
+  );
+}
+
+function rewriteIndex(directory, mutate) {
+  const indexPath = path.join(directory, INDEX_FILE);
+  const index = JSON.parse(fs.readFileSync(indexPath, 'utf8'));
+  mutate(index);
+  fs.writeFileSync(indexPath, `${JSON.stringify(index, null, 2)}\n`);
+}
+
+test('a sealed bundle passes both the repo verifier and its bundled copy', (t) => {
+  const directory = copyOfSealedBundle(t);
+
+  const repoRun = runVerifier(directory);
+  assert.equal(repoRun.status, 0, `${repoRun.stdout}${repoRun.stderr}`);
+  for (const claim of REQUIRED_CLAIMS) {
+    assert.match(repoRun.stdout, new RegExp(`PASS ${claim.id}`));
+  }
+  assert.match(repoRun.stdout, /VERIFIED: \d+\/\d+ claims passed/);
+  assert.match(repoRun.stdout, /bundleDigest sha256\(SHA256SUMS\)=[0-9a-f]{64}/);
+
+  const bundledRun = runVerifier(directory, [], path.join(directory, VERIFIER_COPY_FILE));
+  assert.equal(bundledRun.status, 0, `${bundledRun.stdout}${bundledRun.stderr}`);
+});
+
+test('the verification index maps every required claim to sealed evidence', (t) => {
+  const directory = copyOfSealedBundle(t);
+  const index = JSON.parse(fs.readFileSync(path.join(directory, INDEX_FILE), 'utf8'));
+
+  assert.deepEqual(
+    index.claims.map((claim) => claim.id),
+    REQUIRED_CLAIMS.map((claim) => claim.id)
+  );
+  assert.equal(index.verification.verifier.file, VERIFIER_COPY_FILE);
+  assert.equal(
+    index.verification.verifier.sha256,
+    sha256(path.join(directory, VERIFIER_COPY_FILE))
+  );
+  assert.equal(index.provenance.observedWizardMode, 'self-host');
+  assert.ok(index.disclosures.externalGraphLimitation.length > 0);
+  assert.ok(index.disclosures.crossHostFidelityNote.length > 0);
+  assert.ok(index.disclosures.ctimeNonRestorableReason.length > 0);
+  assert.ok(index.disclosures.integrityAnchor.length > 0);
+  for (const claim of index.claims) {
+    for (const evidence of claim.evidence) {
+      const filePath = path.join(directory, evidence.file);
+      assert.ok(fs.existsSync(filePath), `${evidence.file} is missing`);
+      if (!evidence.sealedAfterIndex) {
+        assert.equal(evidence.sha256, sha256(filePath), `${evidence.file} pin mismatch`);
+      }
+    }
+  }
+});
+
+test('a missing evidence file fails verification', (t) => {
+  const directory = copyOfSealedBundle(t);
+  fs.rmSync(path.join(directory, '02-pending-consent-mailbox.png'));
+
+  const result = runVerifier(directory);
+  assert.equal(result.status, 1);
+  assert.match(result.stdout, /FAIL/);
+  assert.match(result.stdout, /02-pending-consent-mailbox\.png/);
+});
+
+test('a tampered evidence file fails verification', (t) => {
+  const directory = copyOfSealedBundle(t);
+  fs.appendFileSync(path.join(directory, '01b-manual-setup-derived-redirect.json'), '\n');
+
+  const result = runVerifier(directory);
+  assert.equal(result.status, 1);
+  assert.match(result.stdout, /01b-manual-setup-derived-redirect\.json/);
+});
+
+test('a dishonest re-seal cannot hide a failed claim assertion', (t) => {
+  const directory = copyOfSealedBundle(t);
+  const captureName = '02-pending-consent-mailbox.json';
+  const capture = JSON.parse(fs.readFileSync(path.join(directory, captureName), 'utf8'));
+  capture.byoTextPresent = true;
+  fs.writeFileSync(path.join(directory, captureName), `${JSON.stringify(capture, null, 2)}\n`);
+  rewriteIndex(directory, (index) => {
+    for (const claim of index.claims) {
+      claim.evidence = claim.evidence.map((evidence) => (
+        evidence.file === captureName ? fileIdentity(directory, captureName) : evidence
+      ));
+    }
+  });
+  resealDishonestly(directory);
+
+  const result = runVerifier(directory);
+  assert.equal(result.status, 1);
+  assert.match(result.stdout, /FAIL pending-admin-consent-mailbox/);
+  assert.match(result.stdout, /byoTextPresent/);
+});
+
+test('a dishonest re-seal cannot drop a required claim from the index', (t) => {
+  const directory = copyOfSealedBundle(t);
+  rewriteIndex(directory, (index) => {
+    index.claims = index.claims.filter((claim) => claim.id !== 'restoration-secrets');
+  });
+  resealDishonestly(directory);
+
+  const result = runVerifier(directory);
+  assert.equal(result.status, 1);
+  assert.match(result.stdout, /does not declare exactly the required claims/);
+  assert.match(result.stdout, /missing: restoration-secrets/);
+});
+
+test('a dishonest re-seal cannot weaken a declared assertion', (t) => {
+  const directory = copyOfSealedBundle(t);
+  rewriteIndex(directory, (index) => {
+    const claim = index.claims.find((entry) => entry.id === 'derived-readonly-redirect-uri');
+    claim.assertions = claim.assertions.filter(
+      (assertion) => !(assertion.path && assertion.path[0] === 'readOnly')
+    );
+  });
+  resealDishonestly(directory);
+
+  const result = runVerifier(directory);
+  assert.equal(result.status, 1);
+  assert.match(result.stdout, /declares different assertions for claim derived-readonly-redirect-uri/);
+});
+
+test('the verifier deadline bounds execution', (t) => {
+  const directory = copyOfSealedBundle(t);
+  const result = runVerifier(directory, ['--timeout-ms=0']);
+  assert.equal(result.status, 2);
+  assert.match(`${result.stdout}${result.stderr}`, /deadline/);
+});
+
+test('the verifier rejects usage errors with exit code 2', () => {
+  const missingDirectory = runVerifier(path.join(os.tmpdir(), 'does-not-exist-microsoft-smoke'));
+  assert.equal(missingDirectory.status, 2);
+
+  const noArguments = spawnSync(process.execPath, [VERIFY_SCRIPT], { encoding: 'utf8' });
+  assert.equal(noArguments.status, 2);
+  assert.match(noArguments.stderr, /Usage/);
+});
+
+test('sealing refuses a bundle whose UI captures fail their claims', () => {
+  assert.throws(
+    () => sealedBundle({
+      uiCaptures: { '02-pending-consent-mailbox.json': { byoTextPresent: true } },
+    }),
+    /UI claim pending-admin-consent-mailbox failed/
+  );
+  assert.throws(
+    () => sealedBundle({ omitUiFiles: ['01-self-hosted-providers-wizard.json'] }),
+    /Evidence file is missing: 01-self-hosted-providers-wizard\.json/
+  );
+});
+
+test('verifyBundle returns structured results for programmatic use', (t) => {
+  const directory = copyOfSealedBundle(t);
+  const verdict = verifyBundle(directory);
+  assert.equal(verdict.passed, true);
+  assert.equal(verdict.exitCode, 0);
+  assert.equal(verdict.results.length, REQUIRED_CLAIMS.length);
+  assert.match(verdict.bundleDigest, /^[0-9a-f]{64}$/);
+  const wizard = verdict.results.find((result) => result.id === 'providers-wizard-platform-gating');
+  assert.equal(wizard.matchedBranch, 'self-host');
+});

--- a/scripts/verify-microsoft-email-smoke-evidence.mjs
+++ b/scripts/verify-microsoft-email-smoke-evidence.mjs
@@ -45,10 +45,13 @@ export const MANIFEST_FILE = '98-sha256-manifest.json';
 export const CHECKSUM_FILE = 'SHA256SUMS';
 export const METADATA_FILE = '00-workflow-run.json';
 export const RESTORATION_FILE = '91-restoration-comparison.json';
+export const CREATED_SESSIONS_FILE = '89-temporary-sessions-created.json';
+export const SESSION_CLEANUP_FILE = '91-temporary-session-cleanup-proof.json';
 export const CORRELATION_FILE = '95-final-dom-screenshot-correlation.json';
-export const INDEX_SCHEMA_VERSION = 1;
+export const INDEX_SCHEMA_VERSION = 2;
 export const VERIFIER_SOURCE_PATH = fileURLToPath(import.meta.url);
 export const DEFAULT_TIMEOUT_MS = 60_000;
+export const EXPECTED_TEMPORARY_SESSION_COUNT = 2;
 
 export const EXTERNAL_GRAPH_LIMITATION = 'No external Microsoft Graph or Entra OAuth call is performed by this evidence helper.';
 export const CTIME_NON_RESTORABLE_REASON = 'ctime is kernel-managed; not restorable from userspace';
@@ -58,6 +61,7 @@ const UUID_PATTERN = /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3
 const SHA256_PATTERN = /^[0-9a-f]{64}$/i;
 const COMMIT_PATTERN = /^[0-9a-f]{40}$/i;
 const PNG_SIGNATURE_HEX = '89504e470d0a1a0a';
+const MAX_SESSION_EVIDENCE_ROWS = 10_000;
 const PHASE_FILES = {
   before: [
     '01-before-git-status.txt',
@@ -73,6 +77,7 @@ const PHASE_FILES = {
     '90-after-port-route-health.json',
     '90-after-database.json',
     '91-restoration-comparison.json',
+    SESSION_CLEANUP_FILE,
   ],
 };
 const PHASE_MARKERS = {
@@ -116,6 +121,27 @@ export const REQUIRED_CLAIMS = [
     evidence: [PHASE_MARKERS.before, PHASE_MARKERS.after],
     assertions: [],
     native: ['phase-markers'],
+  },
+  {
+    id: 'temporary-session-cleanup',
+    title: 'Both temporary session rows created by the smoke run were deleted',
+    proves: 'Exactly two tenant session rows appeared after the run began, neither existed in the baseline, and neither remains in the after-cleanup database snapshot.',
+    evidence: [
+      METADATA_FILE,
+      '01-before-database.json',
+      CREATED_SESSIONS_FILE,
+      '90-after-database.json',
+      SESSION_CLEANUP_FILE,
+      MANIFEST_FILE,
+    ],
+    assertions: [
+      { file: CREATED_SESSIONS_FILE, path: ['expectedCreatedSessionCount'], op: 'equals', expected: EXPECTED_TEMPORARY_SESSION_COUNT },
+      { file: CREATED_SESSIONS_FILE, path: ['assertionsPassed'], op: 'equals', expected: true },
+      { file: SESSION_CLEANUP_FILE, path: ['allDeleted'], op: 'equals', expected: true },
+      { file: MANIFEST_FILE, path: ['temporarySessionRowsDeleted'], op: 'equals', expected: true },
+      { file: MANIFEST_FILE, path: ['temporarySessionRowsDeletedCount'], op: 'equals', expected: EXPECTED_TEMPORARY_SESSION_COUNT },
+    ],
+    native: ['temporary-session-cleanup'],
   },
   {
     id: 'restoration-profiles',
@@ -453,6 +479,7 @@ function resolveEvidenceNames(claim, context) {
 const NATIVE_CHECKS = {
   'checksum-coverage': verifyChecksumCoverage,
   'phase-markers': verifyPhaseMarkers,
+  'temporary-session-cleanup': verifyTemporarySessionCleanup,
   'recompute-profiles': (context) => verifyRestorationSection(
     context,
     'microsoftProfiles',
@@ -570,6 +597,122 @@ function verifyPhaseMarkers(context) {
         failures.push(`${expected.file} changed after the ${phase} assertions passed`);
       }
     }
+  }
+  return failures;
+}
+
+function verifyTemporarySessionCleanup(context) {
+  const failures = [];
+  const metadataContract = context.metadata.temporarySessionCleanup;
+  if (metadataContract?.expectedCreatedSessionCount !== EXPECTED_TEMPORARY_SESSION_COUNT
+    || metadataContract?.createdEvidenceFile !== CREATED_SESSIONS_FILE
+    || metadataContract?.cleanupEvidenceFile !== SESSION_CLEANUP_FILE) {
+    failures.push(`${METADATA_FILE} does not declare the required two-session cleanup contract`);
+  }
+
+  const readSessionMap = (snapshot, label) => {
+    if (!Array.isArray(snapshot.sessions)) {
+      failures.push(`${label} does not include a sessions array`);
+      return new Map();
+    }
+    if (snapshot.sessions.length > MAX_SESSION_EVIDENCE_ROWS) {
+      failures.push(`${label} exceeds the ${MAX_SESSION_EVIDENCE_ROWS}-row verification bound`);
+      return new Map();
+    }
+    const rows = new Map();
+    for (const session of snapshot.sessions) {
+      context.checkDeadline();
+      if (!session || !UUID_PATTERN.test(session.session_id || '')) {
+        failures.push(`${label} contains a session without a UUID session_id`);
+        continue;
+      }
+      if (rows.has(session.session_id)) {
+        failures.push(`${label} contains duplicate session_id ${session.session_id}`);
+        continue;
+      }
+      if (session.tenant !== context.metadata.tenantId) {
+        failures.push(`${label} session ${session.session_id} belongs to a different tenant`);
+      }
+      rows.set(session.session_id, session);
+    }
+    return rows;
+  };
+
+  const beforeSessions = readSessionMap(
+    context.readJson('01-before-database.json'),
+    'Before database snapshot'
+  );
+  const afterSessions = readSessionMap(
+    context.readJson('90-after-database.json'),
+    'After database snapshot'
+  );
+  const creation = context.readJson(CREATED_SESSIONS_FILE);
+  const cleanup = context.readJson(SESSION_CLEANUP_FILE);
+  const createdSessions = Array.isArray(creation.createdSessions)
+    ? creation.createdSessions
+    : [];
+  if (creation.workflowRunId !== context.metadata.workflowRunId
+    || creation.tenantId !== context.metadata.tenantId
+    || creation.expectedCreatedSessionCount !== EXPECTED_TEMPORARY_SESSION_COUNT
+    || creation.assertionsPassed !== true
+    || createdSessions.length !== EXPECTED_TEMPORARY_SESSION_COUNT) {
+    failures.push(`${CREATED_SESSIONS_FILE} does not prove exactly two sessions were created`);
+  }
+
+  const runStartedAt = new Date(context.metadata.startedAt);
+  const sessionsCapturedAt = new Date(creation.capturedAt);
+  if (Number.isNaN(runStartedAt.valueOf())
+    || Number.isNaN(sessionsCapturedAt.valueOf())
+    || sessionsCapturedAt < runStartedAt) {
+    failures.push(`${CREATED_SESSIONS_FILE} has invalid smoke-run timing`);
+  }
+  const createdSessionIds = [];
+  for (const session of createdSessions) {
+    context.checkDeadline();
+    const createdAt = new Date(session?.created_at);
+    if (!session
+      || !UUID_PATTERN.test(session.session_id || '')
+      || !UUID_PATTERN.test(session.user_id || '')
+      || session.tenant !== context.metadata.tenantId
+      || Number.isNaN(createdAt.valueOf())
+      || createdAt < runStartedAt
+      || createdAt > sessionsCapturedAt) {
+      failures.push(`${CREATED_SESSIONS_FILE} contains a row not attributable to this smoke run`);
+      continue;
+    }
+    createdSessionIds.push(session.session_id);
+    if (beforeSessions.has(session.session_id)) {
+      failures.push(`Temporary session ${session.session_id} already existed in the before snapshot`);
+    }
+    if (afterSessions.has(session.session_id)) {
+      failures.push(`Temporary session ${session.session_id} remains in the after snapshot`);
+    }
+  }
+  createdSessionIds.sort((left, right) => left.localeCompare(right));
+  if (new Set(createdSessionIds).size !== EXPECTED_TEMPORARY_SESSION_COUNT) {
+    failures.push(`${CREATED_SESSIONS_FILE} does not identify two distinct session rows`);
+  }
+
+  let createdEvidenceIdentity;
+  try {
+    createdEvidenceIdentity = context.identity(CREATED_SESSIONS_FILE);
+  } catch (error) {
+    failures.push(error instanceof Error ? error.message : String(error));
+  }
+  if (cleanup.workflowRunId !== context.metadata.workflowRunId
+    || cleanup.tenantId !== context.metadata.tenantId
+    || cleanup.expectedCreatedSessionCount !== EXPECTED_TEMPORARY_SESSION_COUNT
+    || !isDeepStrictEqual(cleanup.createdEvidence, createdEvidenceIdentity)
+    || !isDeepStrictEqual(cleanup.createdSessionIds, createdSessionIds)
+    || !isDeepStrictEqual(cleanup.deletedSessionIds, createdSessionIds)
+    || !Array.isArray(cleanup.remainingSessionRows)
+    || cleanup.remainingSessionRows.length !== 0
+    || cleanup.allDeleted !== true) {
+    failures.push(`${SESSION_CLEANUP_FILE} does not match the recomputed two-row deletion proof`);
+  }
+  const cleanupVerifiedAt = new Date(cleanup.verifiedAt);
+  if (Number.isNaN(cleanupVerifiedAt.valueOf()) || cleanupVerifiedAt < sessionsCapturedAt) {
+    failures.push(`${SESSION_CLEANUP_FILE} has invalid verification timing`);
   }
   return failures;
 }
@@ -924,7 +1067,7 @@ export function buildVerificationIndex(evidenceDirectory, { verifierCopySha256 }
     verification: {
       command: `node ${VERIFIER_COPY_FILE} <bundle-dir>`,
       repoScript: 'scripts/verify-microsoft-email-smoke-evidence.mjs',
-      boundedBy: `Internal ${DEFAULT_TIMEOUT_MS} ms deadline; reads only the bundle directory (no network, database, or server); exits 0 only when every claim passes, 1 on any mismatch, 2 on usage errors or timeout.`,
+      boundedBy: `Internal ${DEFAULT_TIMEOUT_MS} ms deadline and ${MAX_SESSION_EVIDENCE_ROWS}-row session-evidence cap; reads only the bundle directory (no network, database, or server); exits 0 only when every claim passes, 1 on any mismatch, 2 on usage errors or timeout.`,
       verifier: { file: VERIFIER_COPY_FILE, sha256: verifierCopySha256 },
     },
     provenance: {

--- a/scripts/verify-microsoft-email-smoke-evidence.mjs
+++ b/scripts/verify-microsoft-email-smoke-evidence.mjs
@@ -1,0 +1,1041 @@
+#!/usr/bin/env node
+
+/**
+ * Verify a sealed Microsoft Email smoke-evidence bundle without touching the
+ * running stack, the database, the network, or the wider repository.
+ *
+ * The bundle is self-describing: `96-verification-index.json` maps every
+ * required smoke claim to the exact evidence files, their sealed SHA-256
+ * identities, and the machine-evaluable assertions that prove the claim, and
+ * `97-verify-evidence.mjs` is a sealed copy of this script. A reviewer runs
+ * one bounded command against the bundle directory:
+ *
+ *   node scripts/verify-microsoft-email-smoke-evidence.mjs <bundle-dir>
+ *   node <bundle-dir>/97-verify-evidence.mjs <bundle-dir>   # identical copy
+ *
+ * Exit codes: 0 when every claim passes, 1 on any mismatch or failed claim,
+ * 2 on usage errors or when the internal deadline (default 60000 ms,
+ * `--timeout-ms=<n>`) is exceeded.
+ *
+ * The claim table below is the verification authority: the verifier evaluates
+ * these hardcoded claims, then checks that the sealed index declares exactly
+ * the same claim set and assertions, so a tampered index can neither drop nor
+ * weaken a check. Bundle integrity is relative to the sealed SHA256SUMS file;
+ * anchor `sha256(SHA256SUMS)` (printed as `bundleDigest`) externally to detect
+ * a wholesale re-seal.
+ *
+ * This module is intentionally self-contained (Node built-ins only) so the
+ * sealed copy inside the bundle runs anywhere a Node runtime exists. The
+ * contract strings and the phase-file layout are therefore duplicated from
+ * `capture-microsoft-email-smoke-evidence.mjs`; the capture script imports
+ * this module at sealing time and runs `verifyBundle` on its own output, which
+ * keeps the two files from drifting apart unnoticed.
+ */
+
+import { createHash } from 'node:crypto';
+import fs from 'node:fs';
+import path from 'node:path';
+import process from 'node:process';
+import { fileURLToPath, pathToFileURL } from 'node:url';
+import { isDeepStrictEqual } from 'node:util';
+
+export const INDEX_FILE = '96-verification-index.json';
+export const VERIFIER_COPY_FILE = '97-verify-evidence.mjs';
+export const MANIFEST_FILE = '98-sha256-manifest.json';
+export const CHECKSUM_FILE = 'SHA256SUMS';
+export const METADATA_FILE = '00-workflow-run.json';
+export const RESTORATION_FILE = '91-restoration-comparison.json';
+export const CORRELATION_FILE = '95-final-dom-screenshot-correlation.json';
+export const INDEX_SCHEMA_VERSION = 1;
+export const VERIFIER_SOURCE_PATH = fileURLToPath(import.meta.url);
+export const DEFAULT_TIMEOUT_MS = 60_000;
+
+export const EXTERNAL_GRAPH_LIMITATION = 'No external Microsoft Graph or Entra OAuth call is performed by this evidence helper.';
+export const CTIME_NON_RESTORABLE_REASON = 'ctime is kernel-managed; not restorable from userspace';
+export const INTEGRITY_ANCHOR_NOTE = 'Bundle integrity is proven relative to the sealed SHA256SUMS file; anchor sha256(SHA256SUMS) — the bundleDigest printed by the verifier — outside the bundle to detect a wholesale re-seal.';
+
+const UUID_PATTERN = /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
+const SHA256_PATTERN = /^[0-9a-f]{64}$/i;
+const COMMIT_PATTERN = /^[0-9a-f]{40}$/i;
+const PNG_SIGNATURE_HEX = '89504e470d0a1a0a';
+const PHASE_FILES = {
+  before: [
+    '01-before-git-status.txt',
+    '01-before-secret-inventory.json',
+    '01-before-runtime-build.json',
+    '01-before-port-route-health.json',
+    '01-before-database.json',
+  ],
+  after: [
+    '90-after-git-status.txt',
+    '90-after-secret-inventory.json',
+    '90-after-runtime-build.json',
+    '90-after-port-route-health.json',
+    '90-after-database.json',
+    '91-restoration-comparison.json',
+  ],
+};
+const PHASE_MARKERS = {
+  before: '02-before-assertions-passed.json',
+  after: '92-after-assertions-passed.json',
+};
+
+/**
+ * Evidence names starting with `@correlation.` resolve at runtime to the file
+ * names the correlation record binds, so renamed DOM/PNG exports stay covered.
+ * Names listed in SEALED_AFTER_INDEX exist only after the index is written and
+ * are therefore pinned by the manifest and SHA256SUMS instead of the index.
+ */
+const SEALED_AFTER_INDEX = new Set([INDEX_FILE, MANIFEST_FILE, CHECKSUM_FILE]);
+
+export const REQUIRED_CLAIMS = [
+  {
+    id: 'verification-index',
+    title: 'The sealed verification index declares exactly the required claims and pins its verifier',
+    proves: 'The index cannot silently drop, reorder, or weaken a required check, and the bundled verifier copy is the pinned one.',
+    evidence: [INDEX_FILE, VERIFIER_COPY_FILE],
+    assertions: [],
+    native: ['index-consistency'],
+  },
+  {
+    id: 'bundle-integrity',
+    title: 'Every bundle file matches SHA256SUMS and the sealed SHA-256 manifest',
+    proves: 'No evidence file was added, removed, or altered after sealing.',
+    evidence: [CHECKSUM_FILE, MANIFEST_FILE],
+    assertions: [
+      { file: MANIFEST_FILE, path: ['assertionsPassed'], op: 'equals', expected: true },
+      { file: MANIFEST_FILE, path: ['restorationExact'], op: 'equals', expected: true },
+      { file: MANIFEST_FILE, path: ['sameCaptureProven'], op: 'equals', expected: true },
+    ],
+    native: ['checksum-coverage'],
+  },
+  {
+    id: 'phase-markers',
+    title: 'The before and after capture assertions passed and their artifacts are unchanged',
+    proves: 'The environment snapshots the restoration comparison relies on are the ones whose assertions passed.',
+    evidence: [PHASE_MARKERS.before, PHASE_MARKERS.after],
+    assertions: [],
+    native: ['phase-markers'],
+  },
+  {
+    id: 'restoration-profiles',
+    title: 'Every tenant Microsoft profile row was restored exactly',
+    proves: 'The smoke fixture left microsoft_profiles byte-identical to the before snapshot.',
+    evidence: ['01-before-database.json', '90-after-database.json', RESTORATION_FILE],
+    assertions: [
+      { file: RESTORATION_FILE, path: ['microsoftProfiles', 'exactMatch'], op: 'equals', expected: true },
+    ],
+    native: ['recompute-profiles'],
+  },
+  {
+    id: 'restoration-bindings',
+    title: 'Every Microsoft consumer binding row, including timestamps, was restored exactly',
+    proves: 'The smoke fixture left microsoft_profile_consumer_bindings — original timestamps included — byte-identical to the before snapshot.',
+    evidence: ['01-before-database.json', '90-after-database.json', RESTORATION_FILE],
+    assertions: [
+      { file: RESTORATION_FILE, path: ['microsoftConsumerBindings', 'exactMatch'], op: 'equals', expected: true },
+    ],
+    native: ['recompute-bindings'],
+  },
+  {
+    id: 'restoration-secrets',
+    title: 'The complete tenant secret inventory, including per-file mtimes and the directory mtime, was restored exactly',
+    proves: 'The filesystem secret store matches the before snapshot on every restorable field.',
+    evidence: ['01-before-secret-inventory.json', '90-after-secret-inventory.json', RESTORATION_FILE],
+    assertions: [
+      { file: RESTORATION_FILE, path: ['tenantSecrets', 'exactMatch'], op: 'equals', expected: true },
+    ],
+    native: ['recompute-secrets'],
+  },
+  {
+    id: 'ctime-disclosure',
+    title: 'Non-restorable ctime changes are disclosed and none occurred on untouched paths',
+    proves: 'The only inode-change-time drift is the kernel-managed one the fixture mutation necessarily causes, and it is disclosed rather than hidden.',
+    evidence: [RESTORATION_FILE, MANIFEST_FILE],
+    assertions: [
+      { file: RESTORATION_FILE, path: ['ctimeDisclosure', 'reason'], op: 'equals', expected: CTIME_NON_RESTORABLE_REASON },
+      { file: RESTORATION_FILE, path: ['ctimeDisclosure', 'unexpectedChanges'], op: 'isEmptyArray' },
+      { file: MANIFEST_FILE, path: ['ctimeDisclosed'], op: 'equals', expected: true },
+      { file: MANIFEST_FILE, path: ['ctimeNonRestorableReason'], op: 'equals', expected: CTIME_NON_RESTORABLE_REASON },
+      { file: MANIFEST_FILE, path: ['ctimeUnexpectedChanges'], op: 'isEmptyArray' },
+    ],
+    native: [],
+  },
+  {
+    id: 'dom-png-binding',
+    title: 'The final DOM export and PNG screenshot are hash-bound to one browser capture',
+    proves: 'The DOM, the screenshot, and the provenance record come from the same authenticated page instance against the recorded application origin.',
+    evidence: [
+      CORRELATION_FILE,
+      '@correlation.dom',
+      '@correlation.screenshot',
+      '@correlation.captureProvenanceFile',
+    ],
+    assertions: [
+      { file: CORRELATION_FILE, path: ['sameCaptureProven'], op: 'equals', expected: true },
+    ],
+    native: ['dom-png-binding'],
+  },
+  {
+    id: 'provenance-disclosures',
+    title: 'Runtime, build, database, and fidelity provenance are recorded with the required limitation disclosures',
+    proves: 'The evidence states where it ran, at which commit, through which render path, and which fidelity limits (cross-host relay, no external Graph call) apply.',
+    evidence: [
+      METADATA_FILE,
+      '01-before-runtime-build.json',
+      '90-after-runtime-build.json',
+      CORRELATION_FILE,
+    ],
+    assertions: [
+      { file: METADATA_FILE, path: ['externalGraphLimitation'], op: 'equals', expected: EXTERNAL_GRAPH_LIMITATION },
+      { file: METADATA_FILE, path: ['crossHostContext'], op: 'nonEmptyString' },
+      { file: CORRELATION_FILE, path: ['crossHostFidelityNote'], op: 'nonEmptyString' },
+      { file: CORRELATION_FILE, path: ['renderMethod'], op: 'nonEmptyString' },
+      { file: CORRELATION_FILE, path: ['externalGraphLimitation'], op: 'equals', expected: EXTERNAL_GRAPH_LIMITATION },
+      { file: MANIFEST_FILE, path: ['externalGraphLimitation'], op: 'equals', expected: EXTERNAL_GRAPH_LIMITATION },
+    ],
+    native: ['runtime-provenance'],
+  },
+  {
+    id: 'providers-wizard-platform-gating',
+    title: 'The Providers Microsoft wizard gates the hosted platform option by licensing',
+    proves: 'On self-host licensing the hosted platform option is absent and automated Entra creation is Unavailable; on hosted licensing the platform option is present. Manual setup is Advanced either way.',
+    evidence: ['01-self-hosted-providers-wizard.json', '01-self-hosted-providers-wizard.png'],
+    assertions: [
+      {
+        oneOf: [
+          {
+            name: 'self-host',
+            assertions: [
+              { file: '01-self-hosted-providers-wizard.json', path: ['platformOptionPresent'], op: 'equals', expected: false },
+              { file: '01-self-hosted-providers-wizard.json', path: ['automatedUnavailable'], op: 'equals', expected: true },
+              { file: '01-self-hosted-providers-wizard.json', path: ['manualAdvanced'], op: 'equals', expected: true },
+            ],
+          },
+          {
+            name: 'hosted',
+            assertions: [
+              { file: '01-self-hosted-providers-wizard.json', path: ['platformOptionPresent'], op: 'equals', expected: true },
+              { file: '01-self-hosted-providers-wizard.json', path: ['manualAdvanced'], op: 'equals', expected: true },
+            ],
+          },
+        ],
+      },
+    ],
+    native: [],
+  },
+  {
+    id: 'derived-readonly-redirect-uri',
+    title: 'The only Redirect URI in the product is server-derived and read-only in Providers manual setup',
+    proves: 'Manual setup shows the derived /api/auth/microsoft/callback Redirect URI read-only, and the mailbox dialog has no Redirect URI input.',
+    evidence: ['01b-manual-setup-derived-redirect.json', '01b-manual-setup-derived-redirect.png'],
+    assertions: [
+      { file: '01b-manual-setup-derived-redirect.json', path: ['redirectUri'], op: 'endsWith', expected: '/api/auth/microsoft/callback' },
+      { file: '01b-manual-setup-derived-redirect.json', path: ['readOnly'], op: 'equals', expected: true },
+      { file: '01b-manual-setup-derived-redirect.json', path: ['mailboxRedirectInputPresent'], op: 'equals', expected: false },
+    ],
+    native: [],
+  },
+  {
+    id: 'pending-admin-consent-mailbox',
+    title: 'The reduced mailbox dialog shows the pending-administrator-approval readiness state',
+    proves: 'With the pending fixture applied, the Communication mailbox dialog shows the waiting-for-administrator strip and contains no Redirect URI input and no BYO expander.',
+    evidence: ['02-pending-consent-mailbox.json', '02-pending-consent-mailbox.png'],
+    assertions: [
+      { file: '02-pending-consent-mailbox.json', path: ['redirectInputs'], op: 'equals', expected: 0 },
+      { file: '02-pending-consent-mailbox.json', path: ['byoTextPresent'], op: 'equals', expected: false },
+      { file: '02-pending-consent-mailbox.json', path: ['text'], op: 'includes', expected: 'Waiting for your Microsoft 365 administrator' },
+    ],
+    native: [],
+  },
+  {
+    id: 'restored-not-configured-mailbox',
+    title: 'After fixture cleanup the mailbox dialog shows the not-configured readiness state',
+    proves: 'With the fixture removed, the Communication mailbox dialog points to Providers for setup and contains no Redirect URI input and no BYO expander.',
+    evidence: ['03-restored-not-configured-mailbox.json', '03-restored-not-configured-mailbox.png'],
+    assertions: [
+      { file: '03-restored-not-configured-mailbox.json', path: ['redirectInputs'], op: 'equals', expected: 0 },
+      { file: '03-restored-not-configured-mailbox.json', path: ['byoTextPresent'], op: 'equals', expected: false },
+      { file: '03-restored-not-configured-mailbox.json', path: ['text'], op: 'includes', expected: "Microsoft isn't set up yet" },
+    ],
+    native: [],
+  },
+  {
+    id: 'no-fixture-residue',
+    title: 'The after snapshot contains no smoke-fixture profile and no smoke-fixture secret',
+    proves: 'The fixture left neither a database row nor a filesystem secret behind.',
+    evidence: [METADATA_FILE, '90-after-database.json', '90-after-secret-inventory.json'],
+    assertions: [],
+    native: ['no-fixture-residue'],
+  },
+];
+
+class VerificationTimeoutError extends Error {}
+
+function sha256File(filePath) {
+  return createHash('sha256').update(fs.readFileSync(filePath)).digest('hex');
+}
+
+function fileIdentity(filePath) {
+  return {
+    file: path.basename(filePath),
+    bytes: fs.statSync(filePath).size,
+    sha256: sha256File(filePath),
+  };
+}
+
+/**
+ * Project a secret inventory onto its restorable fields — the same projection
+ * `restorableInventory` applies in microsoft-email-smoke-timestamps.mjs,
+ * inlined so the sealed bundle copy stays dependency-free.
+ */
+function restorableProjection(inventory) {
+  const { directoryCtimeMs, parentDirectoryCtimeMs, ...rest } = inventory;
+  return {
+    ...rest,
+    files: inventory.files.map(({ ctimeMs, ...fileRest }) => fileRest),
+  };
+}
+
+function describeValue(value) {
+  const serialized = JSON.stringify(value);
+  if (serialized === undefined) {
+    return String(value);
+  }
+  return serialized.length > 120 ? `${serialized.slice(0, 120)}…` : serialized;
+}
+
+/**
+ * Bundle evaluation context: cached JSON reads, deadline enforcement, and the
+ * workflow metadata every claim compares against.
+ */
+export function createContext(evidenceDirectory, { timeoutMs = DEFAULT_TIMEOUT_MS } = {}) {
+  const directory = path.resolve(evidenceDirectory);
+  if (!fs.existsSync(directory) || !fs.statSync(directory).isDirectory()) {
+    throw new Error(`Evidence directory not found: ${directory}`);
+  }
+  const startedAt = Date.now();
+  const jsonCache = new Map();
+  const context = {
+    directory,
+    checkDeadline() {
+      if (Date.now() - startedAt >= timeoutMs) {
+        throw new VerificationTimeoutError(
+          `Verification exceeded its ${timeoutMs} ms deadline`
+        );
+      }
+    },
+    filePath(name) {
+      const resolved = path.resolve(directory, name);
+      const relative = path.relative(directory, resolved);
+      if (relative.startsWith('..') || path.isAbsolute(relative) || relative.includes(path.sep)) {
+        throw new Error(`Evidence file reference escapes the bundle: ${name}`);
+      }
+      return resolved;
+    },
+    readJson(name) {
+      if (!jsonCache.has(name)) {
+        const filePath = context.filePath(name);
+        if (!fs.existsSync(filePath)) {
+          throw new Error(`Required evidence file is missing: ${name}`);
+        }
+        let parsed;
+        try {
+          parsed = JSON.parse(fs.readFileSync(filePath, 'utf8'));
+        } catch (error) {
+          throw new Error(`Evidence file is not valid JSON: ${name} (${error instanceof Error ? error.message : String(error)})`);
+        }
+        jsonCache.set(name, parsed);
+      }
+      return jsonCache.get(name);
+    },
+    hashFile(name) {
+      context.checkDeadline();
+      const filePath = context.filePath(name);
+      if (!fs.existsSync(filePath)) {
+        throw new Error(`Required evidence file is missing: ${name}`);
+      }
+      return sha256File(filePath);
+    },
+    identity(name) {
+      context.checkDeadline();
+      return fileIdentity(context.filePath(name));
+    },
+  };
+  context.metadata = context.readJson(METADATA_FILE);
+  if (!UUID_PATTERN.test(context.metadata.workflowRunId || '')) {
+    throw new Error(`${METADATA_FILE} does not record a workflow run UUID`);
+  }
+  return context;
+}
+
+function valueAtPath(root, pathSegments, fileName) {
+  let value = root;
+  for (const segment of pathSegments) {
+    if (value === null || typeof value !== 'object' || !(segment in value)) {
+      throw new Error(`${fileName} has no value at ${pathSegments.join('.')}`);
+    }
+    value = value[segment];
+  }
+  return value;
+}
+
+function evaluateSimpleAssertion(assertion, context) {
+  const location = `${assertion.file} → ${assertion.path.join('.')}`;
+  let actual;
+  try {
+    actual = valueAtPath(context.readJson(assertion.file), assertion.path, assertion.file);
+  } catch (error) {
+    return [error instanceof Error ? error.message : String(error)];
+  }
+  switch (assertion.op) {
+    case 'equals':
+      return isDeepStrictEqual(actual, assertion.expected)
+        ? []
+        : [`${location} is ${describeValue(actual)}, expected ${describeValue(assertion.expected)}`];
+    case 'isEmptyArray':
+      return Array.isArray(actual) && actual.length === 0
+        ? []
+        : [`${location} is ${describeValue(actual)}, expected an empty array`];
+    case 'nonEmptyString':
+      return typeof actual === 'string' && actual.trim() !== ''
+        ? []
+        : [`${location} must be a non-empty string`];
+    case 'includes':
+      return typeof actual === 'string' && actual.includes(assertion.expected)
+        ? []
+        : [`${location} does not contain ${describeValue(assertion.expected)}`];
+    case 'endsWith':
+      return typeof actual === 'string' && actual.endsWith(assertion.expected)
+        ? []
+        : [`${location} does not end with ${describeValue(assertion.expected)}`];
+    default:
+      return [`Unknown assertion op: ${assertion.op}`];
+  }
+}
+
+function evaluateAssertion(assertion, context) {
+  if (assertion.oneOf) {
+    const branchFailures = [];
+    for (const branch of assertion.oneOf) {
+      const failures = branch.assertions.flatMap((entry) => evaluateSimpleAssertion(entry, context));
+      if (failures.length === 0) {
+        context.observedBranches = context.observedBranches || {};
+        context.observedBranches[branch.name] = true;
+        return { failures: [], matchedBranch: branch.name };
+      }
+      branchFailures.push(`[${branch.name}] ${failures.join('; ')}`);
+    }
+    return { failures: [`No licensing branch matched: ${branchFailures.join(' | ')}`], matchedBranch: null };
+  }
+  return { failures: evaluateSimpleAssertion(assertion, context), matchedBranch: null };
+}
+
+/**
+ * Resolve a claim's evidence names, expanding `@correlation.*` references to
+ * the file names the correlation record binds.
+ */
+function resolveEvidenceNames(claim, context) {
+  return claim.evidence.map((name) => {
+    if (!name.startsWith('@correlation.')) {
+      return name;
+    }
+    const key = name.slice('@correlation.'.length);
+    const correlation = context.readJson(CORRELATION_FILE);
+    const declared = correlation[key];
+    if (!declared || typeof declared.file !== 'string') {
+      throw new Error(`${CORRELATION_FILE} does not bind an artifact for ${name}`);
+    }
+    return declared.file;
+  });
+}
+
+const NATIVE_CHECKS = {
+  'checksum-coverage': verifyChecksumCoverage,
+  'phase-markers': verifyPhaseMarkers,
+  'recompute-profiles': (context) => verifyRestorationSection(
+    context,
+    'microsoftProfiles',
+    '01-before-database.json',
+    '90-after-database.json',
+    (snapshot) => snapshot.microsoftProfiles
+  ),
+  'recompute-bindings': (context) => verifyRestorationSection(
+    context,
+    'microsoftConsumerBindings',
+    '01-before-database.json',
+    '90-after-database.json',
+    (snapshot) => snapshot.microsoftConsumerBindings
+  ),
+  'recompute-secrets': (context) => verifyRestorationSection(
+    context,
+    'tenantSecrets',
+    '01-before-secret-inventory.json',
+    '90-after-secret-inventory.json',
+    restorableProjection
+  ),
+  'dom-png-binding': verifyDomPngBinding,
+  'runtime-provenance': verifyRuntimeProvenance,
+  'no-fixture-residue': verifyNoFixtureResidue,
+  'index-consistency': verifyIndexConsistency,
+};
+
+function verifyChecksumCoverage(context) {
+  const failures = [];
+  const actualFiles = fs.readdirSync(context.directory)
+    .filter((name) => fs.statSync(context.filePath(name)).isFile())
+    .sort((left, right) => left.localeCompare(right));
+
+  const checksumPath = context.filePath(CHECKSUM_FILE);
+  if (!fs.existsSync(checksumPath)) {
+    return [`${CHECKSUM_FILE} is missing`];
+  }
+  const listed = new Map();
+  for (const line of fs.readFileSync(checksumPath, 'utf8').split('\n').filter((line) => line !== '')) {
+    const match = /^([0-9a-f]{64})  (.+)$/.exec(line);
+    if (!match) {
+      failures.push(`${CHECKSUM_FILE} has a malformed line: ${line}`);
+      continue;
+    }
+    listed.set(match[2], match[1]);
+  }
+  const expectedListed = actualFiles.filter((name) => name !== CHECKSUM_FILE);
+  if (!isDeepStrictEqual([...listed.keys()].sort((a, b) => a.localeCompare(b)), expectedListed)) {
+    failures.push(
+      `${CHECKSUM_FILE} does not cover exactly the bundle files (listed ${listed.size}, present ${expectedListed.length})`
+    );
+  }
+  for (const [name, expectedHash] of listed) {
+    if (!expectedListed.includes(name)) {
+      continue;
+    }
+    if (context.hashFile(name) !== expectedHash) {
+      failures.push(`${name} does not match its SHA256SUMS entry`);
+    }
+  }
+
+  const manifest = context.readJson(MANIFEST_FILE);
+  if (manifest.workflowRunId !== context.metadata.workflowRunId) {
+    failures.push(`${MANIFEST_FILE} records a different workflow run`);
+  }
+  const expectedManifestFiles = actualFiles.filter(
+    (name) => name !== CHECKSUM_FILE && name !== MANIFEST_FILE
+  );
+  const manifestNames = Array.isArray(manifest.files)
+    ? manifest.files.map((entry) => entry.file)
+    : [];
+  if (!isDeepStrictEqual(manifestNames, expectedManifestFiles)) {
+    failures.push(`${MANIFEST_FILE} does not list exactly the sealed bundle files`);
+  } else {
+    for (const entry of manifest.files) {
+      if (!isDeepStrictEqual(context.identity(entry.file), entry)) {
+        failures.push(`${entry.file} does not match its manifest identity`);
+      }
+    }
+  }
+  return failures;
+}
+
+function verifyPhaseMarkers(context) {
+  const failures = [];
+  for (const phase of ['before', 'after']) {
+    let marker;
+    try {
+      marker = context.readJson(PHASE_MARKERS[phase]);
+    } catch (error) {
+      failures.push(error instanceof Error ? error.message : String(error));
+      continue;
+    }
+    if (marker.workflowRunId !== context.metadata.workflowRunId
+      || marker.phase !== phase
+      || marker.assertionsPassed !== true
+      || marker.externalGraphLimitation !== EXTERNAL_GRAPH_LIMITATION) {
+      failures.push(`The ${phase} assertions-passed marker is invalid`);
+      continue;
+    }
+    if (!Array.isArray(marker.files)
+      || !isDeepStrictEqual(marker.files.map((file) => file.file), PHASE_FILES[phase])) {
+      failures.push(`The ${phase} assertions-passed marker has an incomplete file inventory`);
+      continue;
+    }
+    for (const expected of marker.files) {
+      let identity;
+      try {
+        identity = context.identity(expected.file);
+      } catch (error) {
+        failures.push(error instanceof Error ? error.message : String(error));
+        continue;
+      }
+      if (!isDeepStrictEqual(identity, expected)) {
+        failures.push(`${expected.file} changed after the ${phase} assertions passed`);
+      }
+    }
+  }
+  return failures;
+}
+
+function verifyRestorationSection(context, section, beforeFile, afterFile, project) {
+  const failures = [];
+  const comparison = valueAtPath(context.readJson(RESTORATION_FILE), [section], RESTORATION_FILE);
+  if (comparison.exactMatch !== true) {
+    failures.push(`${RESTORATION_FILE} reports ${section}.exactMatch !== true`);
+  }
+  if (!isDeepStrictEqual(comparison.baseline, comparison.after)) {
+    failures.push(`${section}: recomputed baseline/after comparison is not an exact match`);
+  }
+  if (!isDeepStrictEqual(project(context.readJson(beforeFile)), comparison.baseline)) {
+    failures.push(`${section}: the recorded baseline does not derive from ${beforeFile}`);
+  }
+  if (!isDeepStrictEqual(project(context.readJson(afterFile)), comparison.after)) {
+    failures.push(`${section}: the recorded after state does not derive from ${afterFile}`);
+  }
+  return failures;
+}
+
+function validateProvenanceRecord(provenanceRecord, context, failures, label) {
+  if (!provenanceRecord || typeof provenanceRecord !== 'object') {
+    failures.push(`${label} is missing its provenance object`);
+    return;
+  }
+  if (provenanceRecord.workflowRunId !== context.metadata.workflowRunId) {
+    failures.push(`${label} provenance records a different workflow run`);
+  }
+  if (!UUID_PATTERN.test(provenanceRecord.captureNonce || '')) {
+    failures.push(`${label} provenance captureNonce is not a UUID`);
+  }
+  const capturedAt = new Date(provenanceRecord.capturedAt);
+  if (typeof provenanceRecord.capturedAt !== 'string'
+    || Number.isNaN(capturedAt.valueOf())
+    || capturedAt.toISOString() !== provenanceRecord.capturedAt) {
+    failures.push(`${label} provenance capturedAt is not a canonical ISO timestamp`);
+  }
+  const browser = provenanceRecord.browser;
+  if (!browser
+    || typeof browser.userAgent !== 'string' || browser.userAgent.trim() === ''
+    || typeof browser.platform !== 'string' || browser.platform.trim() === ''
+    || typeof browser.url !== 'string') {
+    failures.push(`${label} provenance is missing browser details`);
+    return;
+  }
+  try {
+    if (new URL(browser.url).origin !== new URL(context.metadata.appUrl).origin) {
+      failures.push(`${label} provenance URL does not belong to the recorded application origin`);
+    }
+  } catch {
+    failures.push(`${label} provenance URL is not valid`);
+  }
+}
+
+function verifyDomPngBinding(context) {
+  const failures = [];
+  const correlation = context.readJson(CORRELATION_FILE);
+  if (correlation.workflowRunId !== context.metadata.workflowRunId) {
+    failures.push(`${CORRELATION_FILE} records a different workflow run`);
+  }
+  for (const key of ['dom', 'screenshot', 'captureProvenanceFile']) {
+    const declared = correlation[key];
+    if (!declared?.file || !SHA256_PATTERN.test(declared.sha256 || '')) {
+      failures.push(`${CORRELATION_FILE} does not pin the ${key} artifact`);
+      continue;
+    }
+    try {
+      if (!isDeepStrictEqual(context.identity(declared.file), declared)) {
+        failures.push(`${declared.file} does not match its correlated ${key} identity`);
+      }
+    } catch (error) {
+      failures.push(error instanceof Error ? error.message : String(error));
+    }
+  }
+  if (failures.length > 0) {
+    return failures;
+  }
+
+  const captureRecord = context.readJson(correlation.captureProvenanceFile.file);
+  validateProvenanceRecord(captureRecord.provenance, context, failures, 'Capture record');
+  if (!isDeepStrictEqual(correlation.provenance, captureRecord.provenance)) {
+    failures.push('The correlation and capture record provenance differ');
+  }
+  if (captureRecord.externalGraphLimitation !== EXTERNAL_GRAPH_LIMITATION) {
+    failures.push('The capture record dropped the no-external-Graph limitation');
+  }
+  for (const [key, actualName] of [
+    ['dom', correlation.dom.file],
+    ['screenshot', correlation.screenshot.file],
+  ]) {
+    const declared = captureRecord.artifacts?.[key];
+    if (!declared
+      || declared.file !== actualName
+      || declared.sha256 !== context.hashFile(actualName)) {
+      failures.push(`The capture record does not hash-bind the exact ${key} artifact`);
+    }
+  }
+
+  const screenshotPath = context.filePath(correlation.screenshot.file);
+  if (fs.readFileSync(screenshotPath).subarray(0, 8).toString('hex') !== PNG_SIGNATURE_HEX) {
+    failures.push('The correlated screenshot is not a PNG');
+  }
+  const domContents = fs.readFileSync(context.filePath(correlation.dom.file), 'utf8');
+  const embeddedMatch = /<script\b[^>]*\bid=["']alga-smoke-capture-provenance["'][^>]*>([\s\S]*?)<\/script>/i
+    .exec(domContents);
+  if (!embeddedMatch) {
+    failures.push('The DOM artifact is missing its embedded capture provenance');
+    return failures;
+  }
+  let embeddedProvenance;
+  try {
+    embeddedProvenance = JSON.parse(embeddedMatch[1]);
+  } catch {
+    failures.push('The DOM-embedded capture provenance is not valid JSON');
+    return failures;
+  }
+  if (!isDeepStrictEqual(embeddedProvenance, captureRecord.provenance)) {
+    failures.push('The DOM-embedded provenance does not match the capture record (nonce, timestamp, browser)');
+  }
+  return failures;
+}
+
+function verifyRuntimeProvenance(context) {
+  const failures = [];
+  const beforeRuntime = context.readJson('01-before-runtime-build.json');
+  const afterRuntime = context.readJson('90-after-runtime-build.json');
+  for (const [label, runtime] of [['before', beforeRuntime], ['after', afterRuntime]]) {
+    if (!COMMIT_PATTERN.test(runtime.commit || '')) {
+      failures.push(`The ${label} runtime provenance has no git commit`);
+    }
+    if (typeof runtime.worktree !== 'string' || runtime.worktree.trim() === '') {
+      failures.push(`The ${label} runtime provenance has no worktree path`);
+    }
+  }
+  if (beforeRuntime.commit !== afterRuntime.commit) {
+    failures.push('The before and after captures ran at different commits');
+  }
+  const database = context.readJson('90-after-database.json');
+  if (!database.identity?.database || !database.identity?.postgres_version) {
+    failures.push('The after database snapshot has no database identity');
+  }
+  return failures;
+}
+
+function verifyNoFixtureResidue(context) {
+  const failures = [];
+  const profileId = context.metadata.profileId;
+  if (!UUID_PATTERN.test(profileId || '')) {
+    failures.push(`${METADATA_FILE} does not record the fixture profile UUID`);
+    return failures;
+  }
+  const database = context.readJson('90-after-database.json');
+  if ((database.microsoftProfiles || []).some((profile) => profile.profile_id === profileId)) {
+    failures.push(`The fixture profile ${profileId} is still present in the after database snapshot`);
+  }
+  const secrets = context.readJson('90-after-secret-inventory.json');
+  const fixtureSecretName = `microsoft_profile_${profileId}_client_secret`;
+  if ((secrets.files || []).some((file) => file.name === fixtureSecretName)) {
+    failures.push(`The fixture secret ${fixtureSecretName} is still present in the after secret inventory`);
+  }
+  return failures;
+}
+
+/**
+ * Serialize a claim exactly as the index stores it (minus evidence
+ * identities), so tampering with the declared assertions is detectable.
+ */
+function claimDeclaration(claim) {
+  return {
+    id: claim.id,
+    title: claim.title,
+    proves: claim.proves,
+    assertions: claim.assertions,
+    native: claim.native,
+  };
+}
+
+function verifyIndexConsistency(context) {
+  const failures = [];
+  const index = context.readJson(INDEX_FILE);
+  if (index.schemaVersion !== INDEX_SCHEMA_VERSION) {
+    failures.push(`${INDEX_FILE} has an unsupported schemaVersion`);
+  }
+  if (index.workflowRunId !== context.metadata.workflowRunId) {
+    failures.push(`${INDEX_FILE} records a different workflow run`);
+  }
+
+  const declaredClaims = Array.isArray(index.claims) ? index.claims : [];
+  const declaredIds = declaredClaims.map((claim) => claim.id);
+  const requiredIds = REQUIRED_CLAIMS.map((claim) => claim.id);
+  if (!isDeepStrictEqual(declaredIds, requiredIds)) {
+    const missing = requiredIds.filter((id) => !declaredIds.includes(id));
+    const extra = declaredIds.filter((id) => !requiredIds.includes(id));
+    failures.push(
+      `${INDEX_FILE} does not declare exactly the required claims`
+      + (missing.length > 0 ? `; missing: ${missing.join(', ')}` : '')
+      + (extra.length > 0 ? `; unknown: ${extra.join(', ')}` : '')
+    );
+    return failures;
+  }
+  for (const [position, requiredClaim] of REQUIRED_CLAIMS.entries()) {
+    const declared = declaredClaims[position];
+    const { evidence, ...declaration } = declared;
+    if (!isDeepStrictEqual(declaration, claimDeclaration(requiredClaim))) {
+      failures.push(`${INDEX_FILE} declares different assertions for claim ${requiredClaim.id}`);
+      continue;
+    }
+    let resolvedNames;
+    try {
+      resolvedNames = resolveEvidenceNames(requiredClaim, context);
+    } catch (error) {
+      failures.push(error instanceof Error ? error.message : String(error));
+      continue;
+    }
+    const declaredNames = (evidence || []).map((entry) => entry.file);
+    if (!isDeepStrictEqual(declaredNames, resolvedNames)) {
+      failures.push(`${INDEX_FILE} maps claim ${requiredClaim.id} to different evidence files`);
+      continue;
+    }
+    for (const entry of evidence) {
+      if (entry.sealedAfterIndex === true) {
+        if (!SEALED_AFTER_INDEX.has(entry.file)) {
+          failures.push(`${INDEX_FILE} marks ${entry.file} sealedAfterIndex, which only the seal outputs may be`);
+        } else if (!fs.existsSync(context.filePath(entry.file))) {
+          failures.push(`Evidence file is missing: ${entry.file}`);
+        }
+        continue;
+      }
+      let identity;
+      try {
+        identity = context.identity(entry.file);
+      } catch (error) {
+        failures.push(error instanceof Error ? error.message : String(error));
+        continue;
+      }
+      if (!isDeepStrictEqual(identity, { file: entry.file, bytes: entry.bytes, sha256: entry.sha256 })) {
+        failures.push(`${entry.file} does not match the identity pinned for claim ${requiredClaim.id}`);
+      }
+    }
+  }
+
+  const verifierPin = index.verification?.verifier;
+  if (!verifierPin
+    || verifierPin.file !== VERIFIER_COPY_FILE
+    || verifierPin.sha256 !== context.hashFile(VERIFIER_COPY_FILE)) {
+    failures.push(`${INDEX_FILE} does not pin the sealed verifier copy ${VERIFIER_COPY_FILE}`);
+  }
+  const runtime = context.readJson('90-after-runtime-build.json');
+  if (index.provenance?.commit !== runtime.commit) {
+    failures.push(`${INDEX_FILE} provenance commit does not match the runtime capture`);
+  }
+  if (index.provenance?.tenantId !== context.metadata.tenantId
+    || index.provenance?.profileId !== context.metadata.profileId
+    || index.provenance?.appUrl !== context.metadata.appUrl) {
+    failures.push(`${INDEX_FILE} provenance does not match the workflow metadata`);
+  }
+  if (index.disclosures?.externalGraphLimitation !== EXTERNAL_GRAPH_LIMITATION
+    || index.disclosures?.ctimeNonRestorableReason !== CTIME_NON_RESTORABLE_REASON
+    || index.disclosures?.integrityAnchor !== INTEGRITY_ANCHOR_NOTE) {
+    failures.push(`${INDEX_FILE} is missing the required limitation disclosures`);
+  }
+  return failures;
+}
+
+/**
+ * Evaluate one claim: declarative assertions first, then native checks.
+ * Returns { id, title, passed, failures, matchedBranch }.
+ */
+export function evaluateClaim(claim, context) {
+  context.checkDeadline();
+  const failures = [];
+  let matchedBranch = null;
+  for (const evidenceName of resolveEvidenceNames(claim, context)) {
+    if (!fs.existsSync(context.filePath(evidenceName))) {
+      failures.push(`Evidence file is missing: ${evidenceName}`);
+    }
+  }
+  if (failures.length === 0) {
+    for (const assertion of claim.assertions) {
+      const result = evaluateAssertion(assertion, context);
+      failures.push(...result.failures);
+      matchedBranch = matchedBranch ?? result.matchedBranch;
+    }
+    for (const nativeName of claim.native) {
+      const nativeCheck = NATIVE_CHECKS[nativeName];
+      if (!nativeCheck) {
+        failures.push(`Unknown native check: ${nativeName}`);
+        continue;
+      }
+      try {
+        failures.push(...nativeCheck(context));
+      } catch (error) {
+        if (error instanceof VerificationTimeoutError) {
+          throw error;
+        }
+        failures.push(error instanceof Error ? error.message : String(error));
+      }
+    }
+  }
+  return {
+    id: claim.id,
+    title: claim.title,
+    passed: failures.length === 0,
+    failures,
+    matchedBranch,
+  };
+}
+
+/**
+ * Build the machine-readable verification index for a bundle that has run
+ * before/after/correlate but is not yet sealed. Called by the capture script's
+ * manifest stage; the index pins every evidence file's identity except the
+ * seal outputs, which the manifest and SHA256SUMS pin in turn.
+ */
+export function buildVerificationIndex(evidenceDirectory, { verifierCopySha256 }) {
+  const context = createContext(evidenceDirectory);
+  const correlation = context.readJson(CORRELATION_FILE);
+  const afterRuntime = context.readJson('90-after-runtime-build.json');
+  const afterDatabase = context.readJson('90-after-database.json');
+
+  const wizardResult = evaluateClaim(
+    REQUIRED_CLAIMS.find((claim) => claim.id === 'providers-wizard-platform-gating'),
+    context
+  );
+  if (!wizardResult.passed) {
+    throw new Error(`Cannot index the wizard gating claim: ${wizardResult.failures.join('; ')}`);
+  }
+
+  const claims = REQUIRED_CLAIMS.map((claim) => ({
+    ...claimDeclaration(claim),
+    evidence: resolveEvidenceNames(claim, context).map((name) => {
+      if (SEALED_AFTER_INDEX.has(name)) {
+        return { file: name, sealedAfterIndex: true };
+      }
+      if (name === VERIFIER_COPY_FILE) {
+        const identity = context.identity(name);
+        if (identity.sha256 !== verifierCopySha256) {
+          throw new Error(`${VERIFIER_COPY_FILE} does not match the verifier source being pinned`);
+        }
+        return identity;
+      }
+      return context.identity(name);
+    }),
+  }));
+
+  return {
+    schemaVersion: INDEX_SCHEMA_VERSION,
+    workflowRunId: context.metadata.workflowRunId,
+    generatedAt: new Date().toISOString(),
+    verification: {
+      command: `node ${VERIFIER_COPY_FILE} <bundle-dir>`,
+      repoScript: 'scripts/verify-microsoft-email-smoke-evidence.mjs',
+      boundedBy: `Internal ${DEFAULT_TIMEOUT_MS} ms deadline; reads only the bundle directory (no network, database, or server); exits 0 only when every claim passes, 1 on any mismatch, 2 on usage errors or timeout.`,
+      verifier: { file: VERIFIER_COPY_FILE, sha256: verifierCopySha256 },
+    },
+    provenance: {
+      commit: afterRuntime.commit,
+      branch: afterRuntime.branch,
+      worktree: afterRuntime.worktree,
+      appUrl: context.metadata.appUrl,
+      tenantId: context.metadata.tenantId,
+      profileId: context.metadata.profileId,
+      database: {
+        connection: afterDatabase.connection,
+        identity: afterDatabase.identity,
+      },
+      observedWizardMode: wizardResult.matchedBranch,
+    },
+    disclosures: {
+      externalGraphLimitation: EXTERNAL_GRAPH_LIMITATION,
+      crossHostContext: context.metadata.crossHostContext,
+      crossHostFidelityNote: correlation.crossHostFidelityNote,
+      renderMethod: correlation.renderMethod,
+      ctimeNonRestorableReason: CTIME_NON_RESTORABLE_REASON,
+      integrityAnchor: INTEGRITY_ANCHOR_NOTE,
+    },
+    claims,
+  };
+}
+
+/**
+ * Verify a sealed bundle. Returns { passed, exitCode, results, bundleDigest }
+ * and never throws for verification failures — only for setup errors such as
+ * a missing directory.
+ */
+export function verifyBundle(evidenceDirectory, { timeoutMs = DEFAULT_TIMEOUT_MS } = {}) {
+  let context;
+  try {
+    context = createContext(evidenceDirectory, { timeoutMs });
+  } catch (error) {
+    return {
+      passed: false,
+      exitCode: 2,
+      results: [],
+      bundleDigest: null,
+      setupError: error instanceof Error ? error.message : String(error),
+    };
+  }
+  const results = [];
+  try {
+    for (const claim of REQUIRED_CLAIMS) {
+      results.push(evaluateClaim(claim, context));
+    }
+  } catch (error) {
+    if (error instanceof VerificationTimeoutError) {
+      return {
+        passed: false,
+        exitCode: 2,
+        results,
+        bundleDigest: null,
+        setupError: error.message,
+      };
+    }
+    throw error;
+  }
+  const passed = results.every((result) => result.passed);
+  const checksumPath = path.join(context.directory, CHECKSUM_FILE);
+  const bundleDigest = fs.existsSync(checksumPath) ? sha256File(checksumPath) : null;
+  return { passed, exitCode: passed ? 0 : 1, results, bundleDigest };
+}
+
+function main() {
+  const [directoryArgument, ...options] = process.argv.slice(2);
+  let timeoutMs = DEFAULT_TIMEOUT_MS;
+  for (const option of options) {
+    const match = /^--timeout-ms=(\d+)$/.exec(option);
+    if (!match) {
+      console.error(`Unknown option: ${option}`);
+      process.exitCode = 2;
+      return;
+    }
+    timeoutMs = Number(match[1]);
+  }
+  if (!directoryArgument) {
+    console.error('Usage: node verify-microsoft-email-smoke-evidence.mjs <bundle-dir> [--timeout-ms=60000]');
+    process.exitCode = 2;
+    return;
+  }
+  const verdict = verifyBundle(directoryArgument, { timeoutMs });
+  for (const result of verdict.results) {
+    if (result.passed) {
+      const branchNote = result.matchedBranch ? ` [${result.matchedBranch}]` : '';
+      console.log(`PASS ${result.id}${branchNote} — ${result.title}`);
+    } else {
+      console.log(`FAIL ${result.id} — ${result.title}`);
+      for (const failure of result.failures) {
+        console.log(`     ${failure}`);
+      }
+    }
+  }
+  if (verdict.setupError) {
+    console.error(verdict.setupError);
+  }
+  const passedCount = verdict.results.filter((result) => result.passed).length;
+  console.log(`${verdict.passed ? 'VERIFIED' : 'NOT VERIFIED'}: ${passedCount}/${REQUIRED_CLAIMS.length} claims passed`);
+  if (verdict.bundleDigest) {
+    console.log(`bundleDigest sha256(SHA256SUMS)=${verdict.bundleDigest}`);
+  }
+  process.exitCode = verdict.exitCode;
+}
+
+const invokedAsScript = process.argv[1]
+  && import.meta.url === pathToFileURL(process.argv[1]).href;
+
+if (invokedAsScript) {
+  main();
+}

--- a/scripts/verify-microsoft-email-smoke-evidence.mjs
+++ b/scripts/verify-microsoft-email-smoke-evidence.mjs
@@ -5,16 +5,23 @@
  * running stack, the database, the network, or the wider repository.
  *
  * The bundle is self-describing: `00-REVIEW.md` is the human review
- * entrypoint (read it first — it states the verdict commands, the claim
- * table, and the disclosed limitations without requiring any investigation
- * beyond the bundle), `96-verification-index.json` maps every required smoke
+ * entrypoint (it leads with the one verdict command below and defers every
+ * conclusion to it), `96-verification-index.json` maps every required smoke
  * claim to the exact evidence files, their sealed SHA-256 identities, and the
- * machine-evaluable assertions that prove the claim, and
- * `97-verify-evidence.mjs` is a sealed copy of this script. A reviewer runs
- * one bounded command against the bundle directory:
+ * machine-evaluable assertions that prove the claim,
+ * `95a-tamper-trial-outcomes.json` records the tamper trials the seal ran
+ * against copies of this bundle's own evidence, and `97-verify-evidence.mjs`
+ * is a sealed copy of this script. A reviewer runs one bounded command
+ * against the bundle directory:
  *
  *   node scripts/verify-microsoft-email-smoke-evidence.mjs <bundle-dir>
  *   node <bundle-dir>/97-verify-evidence.mjs <bundle-dir>   # identical copy
+ *
+ * The command's output is intentionally terminal: on success it prints the
+ * verdict, one line per verdict dimension, the claim tally, and the bundle
+ * digest — never a per-artifact listing — because nothing beyond the command
+ * needs to be inspected. Per-claim failure detail is printed only for
+ * failing claims. `--json` emits the same result as a single JSON line.
  *
  * Exit codes: 0 when every claim passes, 1 on any mismatch or failed claim,
  * 2 on usage errors or when the internal deadline (default 60000 ms,
@@ -52,7 +59,8 @@ export const RESTORATION_FILE = '91-restoration-comparison.json';
 export const CREATED_SESSIONS_FILE = '89-temporary-sessions-created.json';
 export const SESSION_CLEANUP_FILE = '91-temporary-session-cleanup-proof.json';
 export const CORRELATION_FILE = '95-final-dom-screenshot-correlation.json';
-export const INDEX_SCHEMA_VERSION = 3;
+export const TAMPER_TRIALS_FILE = '95a-tamper-trial-outcomes.json';
+export const INDEX_SCHEMA_VERSION = 4;
 export const VERIFIER_SOURCE_PATH = fileURLToPath(import.meta.url);
 export const DEFAULT_TIMEOUT_MS = 60_000;
 export const EXPECTED_TEMPORARY_SESSION_COUNT = 2;
@@ -92,10 +100,18 @@ const PHASE_MARKERS = {
 /**
  * Evidence names starting with `@correlation.` resolve at runtime to the file
  * names the correlation record binds, so renamed DOM/PNG exports stay covered.
- * Names listed in SEALED_AFTER_INDEX exist only after the index is written and
- * are therefore pinned by the manifest and SHA256SUMS instead of the index.
+ * Names listed in SEALED_AFTER_INDEX are seal-stage outputs the index pins by
+ * existence only; their byte identity is pinned by the manifest and SHA256SUMS
+ * instead. The tamper-trial record belongs here because the trial substrate is
+ * a provisionally sealed copy that does not contain the record yet.
  */
-const SEALED_AFTER_INDEX = new Set([REVIEW_FILE, INDEX_FILE, MANIFEST_FILE, CHECKSUM_FILE]);
+const SEALED_AFTER_INDEX = new Set([
+  REVIEW_FILE,
+  INDEX_FILE,
+  MANIFEST_FILE,
+  CHECKSUM_FILE,
+  TAMPER_TRIALS_FILE,
+]);
 
 export const REQUIRED_CLAIMS = [
   {
@@ -125,6 +141,17 @@ export const REQUIRED_CLAIMS = [
     evidence: [PHASE_MARKERS.before, PHASE_MARKERS.after],
     assertions: [],
     native: ['phase-markers'],
+  },
+  {
+    id: 'sealed-tamper-outcomes',
+    title: 'Recorded tamper trials prove this bundle’s sealed verifier rejects tampered copies',
+    proves: 'At sealing time the sealed verifier copy (pinned by SHA-256) rejected byte-tamper, file-deletion, and review-edit-plus-dishonest-reseal copies of this run’s provisionally sealed evidence, while a pre-record control run failed only for the then-unwritten trial record — so every additional failure was caused by the trial’s mutation. The outcomes are sealed here so a reviewer validates the record instead of re-running tamper trials.',
+    evidence: [TAMPER_TRIALS_FILE, VERIFIER_COPY_FILE, MANIFEST_FILE],
+    assertions: [
+      { file: MANIFEST_FILE, path: ['tamperOutcomes', 'allDetected'], op: 'equals', expected: true },
+      { file: MANIFEST_FILE, path: ['tamperOutcomes', 'file'], op: 'equals', expected: TAMPER_TRIALS_FILE },
+    ],
+    native: ['sealed-tamper-outcomes'],
   },
   {
     id: 'temporary-session-cleanup',
@@ -308,7 +335,12 @@ export const REQUIRED_CLAIMS = [
 export const REVIEW_SECTIONS = [
   {
     title: 'Bundle integrity and tamper resistance',
-    claimIds: ['verification-index', 'bundle-integrity', 'phase-markers'],
+    claimIds: [
+      'verification-index',
+      'bundle-integrity',
+      'phase-markers',
+      'sealed-tamper-outcomes',
+    ],
   },
   {
     title: 'UI proof',
@@ -339,6 +371,178 @@ export const REVIEW_SECTIONS = [
     claimIds: ['provenance-disclosures'],
   },
 ];
+
+function trialFailedClaimIds(trial) {
+  return Array.isArray(trial?.failedClaims)
+    ? trial.failedClaims.map((claim) => claim?.id)
+    : [];
+}
+
+function trialFailureMessages(trial) {
+  return Array.isArray(trial?.failedClaims)
+    ? trial.failedClaims.flatMap((claim) => (Array.isArray(claim?.failures) ? claim.failures : []))
+    : [];
+}
+
+/**
+ * The claims that fail on the trial substrate itself: each trial runs against
+ * a copy of the run's evidence provisionally sealed *without* the tamper-trial
+ * record, so the record-absence failures below appear in every trial. The
+ * pre-record control pins them down; any failure beyond them in a mutation
+ * trial is therefore caused by that trial's mutation.
+ */
+const CONTROL_BASELINE_FAILED_CLAIM_IDS = ['sealed-tamper-outcomes', 'verification-index'];
+
+/**
+ * The tamper trials every sealed bundle must record, in order, with the
+ * outcome each one must show. This table — not the sealed record — is the
+ * verification authority: `validateTamperTrialRecord` re-validates the record
+ * against it, so a re-sealed bundle cannot weaken a trial expectation.
+ */
+export const REQUIRED_TAMPER_TRIALS = [
+  {
+    name: 'pre-record-control',
+    description: 'The provisionally sealed trial substrate, unmutated, must fail only for the absence of the not-yet-written tamper-trial record.',
+    mutationKind: 'none',
+    validate(trial) {
+      const failures = [];
+      if (trial.exitCode !== 1) {
+        failures.push(`expected exit code 1, recorded ${trial.exitCode}`);
+      }
+      const failedIds = [...trialFailedClaimIds(trial)].sort((a, b) => a.localeCompare(b));
+      if (!isDeepStrictEqual(failedIds, [...CONTROL_BASELINE_FAILED_CLAIM_IDS].sort((a, b) => a.localeCompare(b)))) {
+        failures.push(
+          `must fail exactly the record-absence claims (${CONTROL_BASELINE_FAILED_CLAIM_IDS.join(', ')}); recorded ${failedIds.join(', ') || 'none'}`
+        );
+      }
+      const messages = trialFailureMessages(trial);
+      if (messages.length === 0
+        || !messages.every((message) => typeof message === 'string' && message.includes(TAMPER_TRIALS_FILE))) {
+        failures.push(`every control failure must be the absent ${TAMPER_TRIALS_FILE}`);
+      }
+      const expectedPassed = REQUIRED_CLAIMS
+        .map((claim) => claim.id)
+        .filter((id) => !CONTROL_BASELINE_FAILED_CLAIM_IDS.includes(id));
+      if (!isDeepStrictEqual(trial.passedClaimIds, expectedPassed)) {
+        failures.push('every claim other than the record-absence claims must pass on the unmutated substrate');
+      }
+      return failures;
+    },
+  },
+  {
+    name: 'byte-tamper',
+    description: 'Flipping a single byte of a sealed evidence file must fail verification.',
+    mutationKind: 'byte-flip',
+    validate(trial) {
+      const failures = [];
+      if (trial.exitCode !== 1) {
+        failures.push(`expected exit code 1, recorded ${trial.exitCode}`);
+      }
+      if (trial.mutation?.kind !== 'byte-flip'
+        || typeof trial.mutation.file !== 'string' || trial.mutation.file.trim() === '') {
+        failures.push('must record which file had a byte flipped');
+      }
+      if (!trialFailedClaimIds(trial).includes('bundle-integrity')) {
+        failures.push('the byte flip must fail the bundle-integrity claim');
+      }
+      return failures;
+    },
+  },
+  {
+    name: 'file-deletion',
+    description: 'Deleting a sealed evidence file must fail verification.',
+    mutationKind: 'delete',
+    validate(trial) {
+      const failures = [];
+      if (trial.exitCode !== 1) {
+        failures.push(`expected exit code 1, recorded ${trial.exitCode}`);
+      }
+      const deletedFile = trial.mutation?.file;
+      if (trial.mutation?.kind !== 'delete'
+        || typeof deletedFile !== 'string' || deletedFile.trim() === '') {
+        failures.push('must record which file was deleted');
+      }
+      if (!trialFailedClaimIds(trial).includes('bundle-integrity')) {
+        failures.push('the deletion must fail the bundle-integrity claim');
+      }
+      if (typeof deletedFile === 'string' && deletedFile.trim() !== ''
+        && !trialFailureMessages(trial).some((message) => typeof message === 'string' && message.includes(deletedFile))) {
+        failures.push('a failure must name the deleted file');
+      }
+      return failures;
+    },
+  },
+  {
+    name: 'review-edit-dishonest-reseal',
+    description: 'Editing 00-REVIEW.md and dishonestly recomputing the manifest and SHA256SUMS must still fail verification, proving detection does not rely on checksums alone.',
+    mutationKind: 'edit-plus-reseal',
+    validate(trial) {
+      const failures = [];
+      if (trial.exitCode !== 1) {
+        failures.push(`expected exit code 1, recorded ${trial.exitCode}`);
+      }
+      if (trial.mutation?.kind !== 'edit-plus-reseal' || trial.mutation.file !== REVIEW_FILE) {
+        failures.push(`must record the edited ${REVIEW_FILE}`);
+      }
+      const reviewClaim = (Array.isArray(trial.failedClaims) ? trial.failedClaims : [])
+        .find((claim) => claim?.id === 'verification-index');
+      if (!reviewClaim
+        || !(Array.isArray(reviewClaim.failures) ? reviewClaim.failures : [])
+          .some((message) => typeof message === 'string' && message.includes('does not byte-match'))) {
+        failures.push('the review re-render byte mismatch must be detected');
+      }
+      if (!Array.isArray(trial.passedClaimIds) || !trial.passedClaimIds.includes('bundle-integrity')) {
+        failures.push('the dishonestly recomputed checksums must pass bundle-integrity, proving detection is not checksum-based');
+      }
+      return failures;
+    },
+  },
+];
+
+/**
+ * Validate a sealed tamper-trial record against the trial authority table.
+ * Returns failure messages; empty means the record proves every required
+ * tamper outcome. Used both by the seal (which refuses to write a record that
+ * does not validate) and by the `sealed-tamper-outcomes` native check.
+ */
+export function validateTamperTrialRecord(record, { workflowRunId, verifierSha256, startedAt }) {
+  if (!record || typeof record !== 'object') {
+    return [`${TAMPER_TRIALS_FILE} is not a JSON object`];
+  }
+  const failures = [];
+  if (record.workflowRunId !== workflowRunId) {
+    failures.push(`${TAMPER_TRIALS_FILE} records a different workflow run`);
+  }
+  if (!isDeepStrictEqual(record.verifier, { file: VERIFIER_COPY_FILE, sha256: verifierSha256 })) {
+    failures.push(`${TAMPER_TRIALS_FILE} does not pin the sealed verifier copy ${VERIFIER_COPY_FILE}`);
+  }
+  if (record.assertionsPassed !== true) {
+    failures.push(`${TAMPER_TRIALS_FILE} does not attest that its trial assertions passed`);
+  }
+  if (typeof record.substrate !== 'string' || record.substrate.trim() === '') {
+    failures.push(`${TAMPER_TRIALS_FILE} is missing its trial-substrate disclosure`);
+  }
+  const recordedAt = new Date(record.recordedAt);
+  if (typeof record.recordedAt !== 'string'
+    || Number.isNaN(recordedAt.valueOf())
+    || recordedAt.toISOString() !== record.recordedAt) {
+    failures.push(`${TAMPER_TRIALS_FILE} recordedAt is not a canonical ISO timestamp`);
+  } else if (startedAt && recordedAt < new Date(startedAt)) {
+    failures.push(`${TAMPER_TRIALS_FILE} recordedAt predates the smoke run`);
+  }
+  const trials = Array.isArray(record.trials) ? record.trials : [];
+  if (!isDeepStrictEqual(
+    trials.map((trial) => trial?.name),
+    REQUIRED_TAMPER_TRIALS.map((trial) => trial.name)
+  )) {
+    failures.push(`${TAMPER_TRIALS_FILE} does not record exactly the required trials in order`);
+    return failures;
+  }
+  for (const [position, required] of REQUIRED_TAMPER_TRIALS.entries()) {
+    failures.push(...required.validate(trials[position]).map((message) => `trial ${required.name}: ${message}`));
+  }
+  return failures;
+}
 
 class VerificationTimeoutError extends Error {}
 
@@ -550,7 +754,16 @@ const NATIVE_CHECKS = {
   'no-fixture-residue': verifyNoFixtureResidue,
   'index-consistency': verifyIndexConsistency,
   'review-consistency': verifyReviewEntrypoint,
+  'sealed-tamper-outcomes': verifySealedTamperOutcomes,
 };
+
+function verifySealedTamperOutcomes(context) {
+  return validateTamperTrialRecord(context.readJson(TAMPER_TRIALS_FILE), {
+    workflowRunId: context.metadata.workflowRunId,
+    verifierSha256: context.hashFile(VERIFIER_COPY_FILE),
+    startedAt: context.metadata.startedAt,
+  });
+}
 
 function verifyChecksumCoverage(context) {
   const failures = [];
@@ -1045,36 +1258,42 @@ export function buildReviewDocument(context) {
   const restoration = context.readJson(RESTORATION_FILE);
   const cleanup = context.readJson(SESSION_CLEANUP_FILE);
   const claimCount = REQUIRED_CLAIMS.length;
-  const claimsById = new Map(REQUIRED_CLAIMS.map((claim) => [claim.id, claim]));
   const wizardMode = index.provenance?.observedWizardMode;
   const database = index.provenance?.database?.identity;
   const directoryMtimeMs = restoration.tenantSecrets?.baseline?.directoryMtimeMs;
-  const directoryMtimeNote = typeof directoryMtimeMs === 'number'
-    ? `, and the tenant secret directory mtime (${directoryMtimeMs} ms on both sides)`
-    : '';
+  const sessionIds = cleanup.createdSessionIds
+    .map((sessionId) => `\`${sessionId}\``)
+    .join(' and ');
 
-  const claimSections = REVIEW_SECTIONS.map((section) => {
-    const rows = section.claimIds.map((claimId) => {
-      const claim = claimsById.get(claimId);
-      const position = requiredIds.indexOf(claimId) + 1;
-      const evidence = resolveEvidenceNames(claim, context)
-        .map((name) => `\`${name}\``)
-        .join(', ');
-      return [
-        `- **${claim.id}** (PASS line ${position} of ${claimCount}) — ${claim.title}.`,
-        `  - Proves: ${claim.proves}`,
-        `  - Evidence: ${evidence}`,
-      ].join('\n');
-    });
-    return `### ${section.title}\n\n${rows.join('\n')}`;
-  });
+  const successOutput = [
+    'VERDICT: PASS',
+    ...REVIEW_SECTIONS.map(
+      (section) => `PASS ${section.title} (${section.claimIds.length}/${section.claimIds.length})`
+    ),
+    `Observed licensing mode: ${wizardMode}`,
+    `VERIFIED: ${claimCount}/${claimCount} claims passed`,
+    'bundleDigest sha256(SHA256SUMS)=<64 hex digits>',
+    'Review complete: no artifact-by-artifact inspection is required.',
+  ].map((line) => `    ${line}`).join('\n');
+
+  const dimensionNotes = {
+    'Exact restoration': typeof directoryMtimeMs === 'number'
+      ? ` — every database row (timestamps included) and the complete tenant secret inventory match the baseline exactly, down to the secret-directory mtime (${directoryMtimeMs} ms on both sides); the only non-restorable drift is kernel-managed ctime, disclosed with zero unexpected changes`
+      : '',
+    'Temporary-session deletions': ` — the run created sessions ${sessionIds}; neither existed before the run and neither remains after cleanup`,
+  };
+  const dimensionList = REVIEW_SECTIONS.map((section) => {
+    const claimIds = section.claimIds.map((claimId) => `\`${claimId}\``).join(', ');
+    return `- ${section.title} (${section.claimIds.length}): ${claimIds}${dimensionNotes[section.title] ?? ''}`;
+  }).join('\n');
 
   return `# Review this first — Microsoft Email setup smoke evidence
 
-Everything needed for a verdict is inside this bundle directory. Do not
-investigate the repository, other evidence bundles, or the running stack:
-this document and the one bounded command below are the complete review
-surface.
+The one bounded command below is the complete review: it re-derives every
+conclusion from the sealed evidence and prints a conclusive verdict. No
+artifact-by-artifact inspection is required or expected. Do not
+investigate the repository, other evidence bundles, or the running stack —
+nothing outside this bundle directory is part of the review surface.
 
 - Workflow run: \`${index.workflowRunId}\`
 - Sealed at: ${index.generatedAt}
@@ -1083,83 +1302,60 @@ surface.
 - Database: ${database?.database} — ${database?.postgres_version}
 - Observed licensing mode: ${wizardMode}
 
-## 1. The verdict command (run this first)
+## The verdict command (the entire review)
 
     node <bundle-dir>/${VERIFIER_COPY_FILE} <bundle-dir>
 
-(or, from inside this directory: \`node ${VERIFIER_COPY_FILE} .\`)
+From inside this directory: \`node ${VERIFIER_COPY_FILE} .\`. Add \`--json\`
+for the same result as one machine-readable JSON line. Typical runtime is
+well under one second.
 
-Expected on success: one \`PASS <claim-id>\` line for each of the
-${claimCount} claims in section 3, in that order
-(\`providers-wizard-platform-gating\` also prints its licensing branch, here
-\`[${wizardMode}]\`), then \`VERIFIED: ${claimCount}/${claimCount} claims passed\` and
-\`bundleDigest sha256(SHA256SUMS)=<64 hex digits>\`; exit code 0. Typical
-runtime is well under one second.
+Success is exactly this output, with exit code 0:
 
-Exit 1: at least one claim failed; each failing claim prints
-\`FAIL <claim-id>\` with the reasons. Exit 2: usage error or the internal
-deadline was exceeded.
+${successOutput}
+
+Any other outcome is a failure: exit 1 additionally prints one
+\`FAIL <claim-id>\` block per failing claim with its reasons; exit 2 is a
+usage error or an exceeded internal deadline.
 
 Bounds: ${index.verification?.boundedBy}
 
-This one command is conclusive because the verifier's hardcoded claim table
-is the authority: it re-derives every conclusion from the raw sealed
-evidence (recomputing the restoration comparisons instead of trusting
-recorded verdicts), then checks that \`${INDEX_FILE}\` declares exactly the
-same claims and assertions and that this document byte-matches a re-render
-from the sealed evidence. A dishonest re-seal therefore cannot drop, weaken,
-or reword a check without the command failing.
+The command is conclusive because its hardcoded claim table is the
+authority: it re-derives every conclusion from the raw sealed evidence
+(recomputing the restoration comparisons instead of trusting recorded
+verdicts), validates every bundle file against \`${CHECKSUM_FILE}\` and the
+sealed manifest, checks that \`${INDEX_FILE}\` declares exactly the same
+claims and assertions, and re-renders this document, failing on any byte
+difference. Tamper handling is already demonstrated inside the bundle: the
+sealed trial record \`${TAMPER_TRIALS_FILE}\` (claim
+\`sealed-tamper-outcomes\`) shows this bundle's own verifier rejected
+byte-tamper, file-deletion, and review-edit-plus-dishonest-reseal copies of
+this run's evidence at sealing time, so there is no need to re-run tamper
+trials.
 
 Sealed verifier copy: \`${VERIFIER_COPY_FILE}\`, sha256
 \`${index.verification?.verifier?.sha256}\`. The identical script lives in
 the repository at \`${index.verification?.repoScript}\`; running the sealed
 copy alone is sufficient.
 
-## 2. Checksums
+${index.disclosures?.integrityAnchor}
+
+## What the ${claimCount} claims cover
+
+All ${claimCount} claims passed when this bundle sealed; the verdict command
+re-establishes each one live from the sealed evidence.
+
+${dimensionList}
+
+## Optional independent checksum confirmation
 
     cd <bundle-dir> && sha256sum -c ${CHECKSUM_FILE}
 
-Expected: \`OK\` for every bundle file and exit code 0. \`${CHECKSUM_FILE}\`
-lists every file in the bundle except itself, including this document. The
-verdict command already performs this coverage check against the sealed
-per-file identities; run \`sha256sum -c\` only for independent-tool
-confirmation.
+The verdict command already performs this exact coverage check against the
+sealed per-file identities; run \`sha256sum -c\` only when an independent
+tool's confirmation is wanted.
 
-${index.disclosures?.integrityAnchor}
-
-## 3. The ${claimCount} claims
-
-All ${claimCount} claims passed when this bundle sealed; the verdict command
-re-establishes each PASS live from the sealed evidence.
-
-${claimSections.join('\n\n')}
-
-## 4. Both temporary-session deletions
-
-The smoke run created exactly ${cleanup.expectedCreatedSessionCount} temporary
-tenant login sessions — one for each authentication path it exercised (the
-real sign-in form and the browser capture):
-
-${cleanup.createdSessionIds.map((sessionId) => `- \`${sessionId}\``).join('\n')}
-
-Neither row exists in the baseline snapshot (\`01-before-database.json\`),
-both appear in \`${CREATED_SESSIONS_FILE}\` with creation times inside the
-run window, and neither remains in \`90-after-database.json\`. The deletion
-proof is \`${SESSION_CLEANUP_FILE}\`; the verdict command recomputes the
-entire argument under claim \`temporary-session-cleanup\`.
-
-## 5. Exact restoration at a glance
-
-Every tenant Microsoft profile row, every Microsoft consumer binding row
-(original timestamps included), and the complete tenant secret inventory
-(content hashes, names, sizes, modes, per-file mtimes${directoryMtimeNote})
-match the baseline exactly, and the fixture left no profile row and no
-secret file behind. The only non-restorable drift is kernel-managed ctime,
-disclosed with zero unexpected changes. Claims: \`restoration-profiles\`,
-\`restoration-bindings\`, \`restoration-secrets\`, \`ctime-disclosure\`,
-\`no-fixture-residue\`.
-
-## 6. Limitations disclosed
+## Limitations disclosed
 
 - ${index.disclosures?.externalGraphLimitation}
 - ${index.disclosures?.crossHostContext}
@@ -1345,10 +1541,83 @@ export function verifyBundle(evidenceDirectory, { timeoutMs = DEFAULT_TIMEOUT_MS
   return { passed, exitCode: passed ? 0 : 1, results, bundleDigest };
 }
 
+/**
+ * Reduce a `verifyBundle` result to the concise review conclusion: overall
+ * verdict, one entry per verdict dimension, the claim tally, the observed
+ * licensing mode, and the bundle digest. This — not a per-artifact listing —
+ * is what the CLI reports, because the conclusion is the entire review.
+ */
+export function summarizeVerdict(verdict) {
+  const resultsById = new Map(verdict.results.map((result) => [result.id, result]));
+  const dimensions = REVIEW_SECTIONS.map((section) => {
+    const results = section.claimIds
+      .map((claimId) => resultsById.get(claimId))
+      .filter(Boolean);
+    const passedCount = results.filter((result) => result.passed).length;
+    return {
+      title: section.title,
+      claimCount: section.claimIds.length,
+      passedCount,
+      passed: passedCount === section.claimIds.length,
+    };
+  });
+  return {
+    verdict: verdict.passed ? 'PASS' : 'FAIL',
+    exitCode: verdict.exitCode,
+    claimsPassed: verdict.results.filter((result) => result.passed).length,
+    claimsTotal: REQUIRED_CLAIMS.length,
+    dimensions,
+    licensingMode: verdict.results
+      .find((result) => result.id === 'providers-wizard-platform-gating')?.matchedBranch ?? null,
+    bundleDigest: verdict.bundleDigest,
+    setupError: verdict.setupError ?? null,
+  };
+}
+
+/**
+ * Render the concise CLI output. Success is terminal — verdict, dimensions,
+ * tally, digest, and an explicit "nothing further to inspect" — while failure
+ * additionally prints one FAIL block per failing claim with its reasons.
+ */
+export function formatVerdictLines(verdict, summary = summarizeVerdict(verdict)) {
+  const lines = [`VERDICT: ${summary.verdict}`];
+  if (verdict.results.length > 0) {
+    for (const dimension of summary.dimensions) {
+      lines.push(
+        `${dimension.passed ? 'PASS' : 'FAIL'} ${dimension.title} (${dimension.passedCount}/${dimension.claimCount})`
+      );
+    }
+  }
+  for (const result of verdict.results.filter((entry) => !entry.passed)) {
+    lines.push(`FAIL ${result.id} — ${result.title}`);
+    for (const failure of result.failures) {
+      lines.push(`     ${failure}`);
+    }
+  }
+  if (summary.licensingMode) {
+    lines.push(`Observed licensing mode: ${summary.licensingMode}`);
+  }
+  lines.push(
+    `${verdict.passed ? 'VERIFIED' : 'NOT VERIFIED'}: ${summary.claimsPassed}/${summary.claimsTotal} claims passed`
+  );
+  if (summary.bundleDigest) {
+    lines.push(`bundleDigest sha256(SHA256SUMS)=${summary.bundleDigest}`);
+  }
+  if (verdict.passed) {
+    lines.push('Review complete: no artifact-by-artifact inspection is required.');
+  }
+  return lines;
+}
+
 function main() {
   const [directoryArgument, ...options] = process.argv.slice(2);
   let timeoutMs = DEFAULT_TIMEOUT_MS;
+  let jsonOutput = false;
   for (const option of options) {
+    if (option === '--json') {
+      jsonOutput = true;
+      continue;
+    }
     const match = /^--timeout-ms=(\d+)$/.exec(option);
     if (!match) {
       console.error(`Unknown option: ${option}`);
@@ -1358,29 +1627,26 @@ function main() {
     timeoutMs = Number(match[1]);
   }
   if (!directoryArgument) {
-    console.error('Usage: node verify-microsoft-email-smoke-evidence.mjs <bundle-dir> [--timeout-ms=60000]');
+    console.error('Usage: node verify-microsoft-email-smoke-evidence.mjs <bundle-dir> [--timeout-ms=60000] [--json]');
     process.exitCode = 2;
     return;
   }
   const verdict = verifyBundle(directoryArgument, { timeoutMs });
-  for (const result of verdict.results) {
-    if (result.passed) {
-      const branchNote = result.matchedBranch ? ` [${result.matchedBranch}]` : '';
-      console.log(`PASS ${result.id}${branchNote} — ${result.title}`);
-    } else {
-      console.log(`FAIL ${result.id} — ${result.title}`);
-      for (const failure of result.failures) {
-        console.log(`     ${failure}`);
-      }
+  const summary = summarizeVerdict(verdict);
+  if (jsonOutput) {
+    console.log(JSON.stringify({
+      ...summary,
+      failedClaims: verdict.results
+        .filter((result) => !result.passed)
+        .map((result) => ({ id: result.id, failures: result.failures })),
+    }));
+  } else {
+    for (const line of formatVerdictLines(verdict, summary)) {
+      console.log(line);
     }
-  }
-  if (verdict.setupError) {
-    console.error(verdict.setupError);
-  }
-  const passedCount = verdict.results.filter((result) => result.passed).length;
-  console.log(`${verdict.passed ? 'VERIFIED' : 'NOT VERIFIED'}: ${passedCount}/${REQUIRED_CLAIMS.length} claims passed`);
-  if (verdict.bundleDigest) {
-    console.log(`bundleDigest sha256(SHA256SUMS)=${verdict.bundleDigest}`);
+    if (verdict.setupError) {
+      console.error(verdict.setupError);
+    }
   }
   process.exitCode = verdict.exitCode;
 }

--- a/scripts/verify-microsoft-email-smoke-evidence.mjs
+++ b/scripts/verify-microsoft-email-smoke-evidence.mjs
@@ -4,9 +4,12 @@
  * Verify a sealed Microsoft Email smoke-evidence bundle without touching the
  * running stack, the database, the network, or the wider repository.
  *
- * The bundle is self-describing: `96-verification-index.json` maps every
- * required smoke claim to the exact evidence files, their sealed SHA-256
- * identities, and the machine-evaluable assertions that prove the claim, and
+ * The bundle is self-describing: `00-REVIEW.md` is the human review
+ * entrypoint (read it first — it states the verdict commands, the claim
+ * table, and the disclosed limitations without requiring any investigation
+ * beyond the bundle), `96-verification-index.json` maps every required smoke
+ * claim to the exact evidence files, their sealed SHA-256 identities, and the
+ * machine-evaluable assertions that prove the claim, and
  * `97-verify-evidence.mjs` is a sealed copy of this script. A reviewer runs
  * one bounded command against the bundle directory:
  *
@@ -39,6 +42,7 @@ import process from 'node:process';
 import { fileURLToPath, pathToFileURL } from 'node:url';
 import { isDeepStrictEqual } from 'node:util';
 
+export const REVIEW_FILE = '00-REVIEW.md';
 export const INDEX_FILE = '96-verification-index.json';
 export const VERIFIER_COPY_FILE = '97-verify-evidence.mjs';
 export const MANIFEST_FILE = '98-sha256-manifest.json';
@@ -48,7 +52,7 @@ export const RESTORATION_FILE = '91-restoration-comparison.json';
 export const CREATED_SESSIONS_FILE = '89-temporary-sessions-created.json';
 export const SESSION_CLEANUP_FILE = '91-temporary-session-cleanup-proof.json';
 export const CORRELATION_FILE = '95-final-dom-screenshot-correlation.json';
-export const INDEX_SCHEMA_VERSION = 2;
+export const INDEX_SCHEMA_VERSION = 3;
 export const VERIFIER_SOURCE_PATH = fileURLToPath(import.meta.url);
 export const DEFAULT_TIMEOUT_MS = 60_000;
 export const EXPECTED_TEMPORARY_SESSION_COUNT = 2;
@@ -91,16 +95,16 @@ const PHASE_MARKERS = {
  * Names listed in SEALED_AFTER_INDEX exist only after the index is written and
  * are therefore pinned by the manifest and SHA256SUMS instead of the index.
  */
-const SEALED_AFTER_INDEX = new Set([INDEX_FILE, MANIFEST_FILE, CHECKSUM_FILE]);
+const SEALED_AFTER_INDEX = new Set([REVIEW_FILE, INDEX_FILE, MANIFEST_FILE, CHECKSUM_FILE]);
 
 export const REQUIRED_CLAIMS = [
   {
     id: 'verification-index',
-    title: 'The sealed verification index declares exactly the required claims and pins its verifier',
-    proves: 'The index cannot silently drop, reorder, or weaken a required check, and the bundled verifier copy is the pinned one.',
-    evidence: [INDEX_FILE, VERIFIER_COPY_FILE],
+    title: 'The sealed verification index declares exactly the required claims, pins its verifier, and matches the review entrypoint',
+    proves: 'The index cannot silently drop, reorder, or weaken a required check, the bundled verifier copy is the pinned one, and the human review entrypoint 00-REVIEW.md byte-matches a re-render from the sealed evidence.',
+    evidence: [INDEX_FILE, VERIFIER_COPY_FILE, REVIEW_FILE],
     assertions: [],
-    native: ['index-consistency'],
+    native: ['index-consistency', 'review-consistency'],
   },
   {
     id: 'bundle-integrity',
@@ -293,6 +297,46 @@ export const REQUIRED_CLAIMS = [
     evidence: [METADATA_FILE, '90-after-database.json', '90-after-secret-inventory.json'],
     assertions: [],
     native: ['no-fixture-residue'],
+  },
+];
+
+/**
+ * The five verdict dimensions the review entrypoint groups the claims under.
+ * Together the sections must cover every required claim exactly once;
+ * `buildReviewDocument` enforces that invariant.
+ */
+export const REVIEW_SECTIONS = [
+  {
+    title: 'Bundle integrity and tamper resistance',
+    claimIds: ['verification-index', 'bundle-integrity', 'phase-markers'],
+  },
+  {
+    title: 'UI proof',
+    claimIds: [
+      'providers-wizard-platform-gating',
+      'derived-readonly-redirect-uri',
+      'pending-admin-consent-mailbox',
+      'restored-not-configured-mailbox',
+      'dom-png-binding',
+    ],
+  },
+  {
+    title: 'Exact restoration',
+    claimIds: [
+      'restoration-profiles',
+      'restoration-bindings',
+      'restoration-secrets',
+      'ctime-disclosure',
+      'no-fixture-residue',
+    ],
+  },
+  {
+    title: 'Temporary-session deletions',
+    claimIds: ['temporary-session-cleanup'],
+  },
+  {
+    title: 'Provenance and limitation disclosures',
+    claimIds: ['provenance-disclosures'],
   },
 ];
 
@@ -505,6 +549,7 @@ const NATIVE_CHECKS = {
   'runtime-provenance': verifyRuntimeProvenance,
   'no-fixture-residue': verifyNoFixtureResidue,
   'index-consistency': verifyIndexConsistency,
+  'review-consistency': verifyReviewEntrypoint,
 };
 
 function verifyChecksumCoverage(context) {
@@ -977,6 +1022,170 @@ function verifyIndexConsistency(context) {
     failures.push(`${INDEX_FILE} is missing the required limitation disclosures`);
   }
   return failures;
+}
+
+/**
+ * Render the human review entrypoint (`00-REVIEW.md`) from the sealed
+ * evidence. The rendering is a pure function of the sealed files — the
+ * capture script writes it at sealing time and `verifyReviewEntrypoint`
+ * re-renders it at verification time, so the sealed document must byte-match
+ * or the bundle fails. Nothing in the document is asserted from memory: every
+ * value comes from the sealed index, the restoration comparison, the session
+ * cleanup proof, and the claim table this module hardcodes.
+ */
+export function buildReviewDocument(context) {
+  const sectionIds = REVIEW_SECTIONS.flatMap((section) => section.claimIds);
+  const requiredIds = REQUIRED_CLAIMS.map((claim) => claim.id);
+  if (new Set(sectionIds).size !== sectionIds.length
+    || !isDeepStrictEqual([...sectionIds].sort(), [...requiredIds].sort())) {
+    throw new Error('REVIEW_SECTIONS does not cover every required claim exactly once');
+  }
+
+  const index = context.readJson(INDEX_FILE);
+  const restoration = context.readJson(RESTORATION_FILE);
+  const cleanup = context.readJson(SESSION_CLEANUP_FILE);
+  const claimCount = REQUIRED_CLAIMS.length;
+  const claimsById = new Map(REQUIRED_CLAIMS.map((claim) => [claim.id, claim]));
+  const wizardMode = index.provenance?.observedWizardMode;
+  const database = index.provenance?.database?.identity;
+  const directoryMtimeMs = restoration.tenantSecrets?.baseline?.directoryMtimeMs;
+  const directoryMtimeNote = typeof directoryMtimeMs === 'number'
+    ? `, and the tenant secret directory mtime (${directoryMtimeMs} ms on both sides)`
+    : '';
+
+  const claimSections = REVIEW_SECTIONS.map((section) => {
+    const rows = section.claimIds.map((claimId) => {
+      const claim = claimsById.get(claimId);
+      const position = requiredIds.indexOf(claimId) + 1;
+      const evidence = resolveEvidenceNames(claim, context)
+        .map((name) => `\`${name}\``)
+        .join(', ');
+      return [
+        `- **${claim.id}** (PASS line ${position} of ${claimCount}) — ${claim.title}.`,
+        `  - Proves: ${claim.proves}`,
+        `  - Evidence: ${evidence}`,
+      ].join('\n');
+    });
+    return `### ${section.title}\n\n${rows.join('\n')}`;
+  });
+
+  return `# Review this first — Microsoft Email setup smoke evidence
+
+Everything needed for a verdict is inside this bundle directory. Do not
+investigate the repository, other evidence bundles, or the running stack:
+this document and the one bounded command below are the complete review
+surface.
+
+- Workflow run: \`${index.workflowRunId}\`
+- Sealed at: ${index.generatedAt}
+- Commit: \`${index.provenance?.commit}\` (branch \`${index.provenance?.branch}\`)
+- Application: ${index.provenance?.appUrl} — tenant \`${index.provenance?.tenantId}\`, smoke fixture profile \`${index.provenance?.profileId}\`
+- Database: ${database?.database} — ${database?.postgres_version}
+- Observed licensing mode: ${wizardMode}
+
+## 1. The verdict command (run this first)
+
+    node <bundle-dir>/${VERIFIER_COPY_FILE} <bundle-dir>
+
+(or, from inside this directory: \`node ${VERIFIER_COPY_FILE} .\`)
+
+Expected on success: one \`PASS <claim-id>\` line for each of the
+${claimCount} claims in section 3, in that order
+(\`providers-wizard-platform-gating\` also prints its licensing branch, here
+\`[${wizardMode}]\`), then \`VERIFIED: ${claimCount}/${claimCount} claims passed\` and
+\`bundleDigest sha256(SHA256SUMS)=<64 hex digits>\`; exit code 0. Typical
+runtime is well under one second.
+
+Exit 1: at least one claim failed; each failing claim prints
+\`FAIL <claim-id>\` with the reasons. Exit 2: usage error or the internal
+deadline was exceeded.
+
+Bounds: ${index.verification?.boundedBy}
+
+This one command is conclusive because the verifier's hardcoded claim table
+is the authority: it re-derives every conclusion from the raw sealed
+evidence (recomputing the restoration comparisons instead of trusting
+recorded verdicts), then checks that \`${INDEX_FILE}\` declares exactly the
+same claims and assertions and that this document byte-matches a re-render
+from the sealed evidence. A dishonest re-seal therefore cannot drop, weaken,
+or reword a check without the command failing.
+
+Sealed verifier copy: \`${VERIFIER_COPY_FILE}\`, sha256
+\`${index.verification?.verifier?.sha256}\`. The identical script lives in
+the repository at \`${index.verification?.repoScript}\`; running the sealed
+copy alone is sufficient.
+
+## 2. Checksums
+
+    cd <bundle-dir> && sha256sum -c ${CHECKSUM_FILE}
+
+Expected: \`OK\` for every bundle file and exit code 0. \`${CHECKSUM_FILE}\`
+lists every file in the bundle except itself, including this document. The
+verdict command already performs this coverage check against the sealed
+per-file identities; run \`sha256sum -c\` only for independent-tool
+confirmation.
+
+${index.disclosures?.integrityAnchor}
+
+## 3. The ${claimCount} claims
+
+All ${claimCount} claims passed when this bundle sealed; the verdict command
+re-establishes each PASS live from the sealed evidence.
+
+${claimSections.join('\n\n')}
+
+## 4. Both temporary-session deletions
+
+The smoke run created exactly ${cleanup.expectedCreatedSessionCount} temporary
+tenant login sessions — one for each authentication path it exercised (the
+real sign-in form and the browser capture):
+
+${cleanup.createdSessionIds.map((sessionId) => `- \`${sessionId}\``).join('\n')}
+
+Neither row exists in the baseline snapshot (\`01-before-database.json\`),
+both appear in \`${CREATED_SESSIONS_FILE}\` with creation times inside the
+run window, and neither remains in \`90-after-database.json\`. The deletion
+proof is \`${SESSION_CLEANUP_FILE}\`; the verdict command recomputes the
+entire argument under claim \`temporary-session-cleanup\`.
+
+## 5. Exact restoration at a glance
+
+Every tenant Microsoft profile row, every Microsoft consumer binding row
+(original timestamps included), and the complete tenant secret inventory
+(content hashes, names, sizes, modes, per-file mtimes${directoryMtimeNote})
+match the baseline exactly, and the fixture left no profile row and no
+secret file behind. The only non-restorable drift is kernel-managed ctime,
+disclosed with zero unexpected changes. Claims: \`restoration-profiles\`,
+\`restoration-bindings\`, \`restoration-secrets\`, \`ctime-disclosure\`,
+\`no-fixture-residue\`.
+
+## 6. Limitations disclosed
+
+- ${index.disclosures?.externalGraphLimitation}
+- ${index.disclosures?.crossHostContext}
+- ${index.disclosures?.crossHostFidelityNote}
+- Render method: ${index.disclosures?.renderMethod}
+- ${index.disclosures?.ctimeNonRestorableReason}.
+`;
+}
+
+function verifyReviewEntrypoint(context) {
+  const reviewPath = context.filePath(REVIEW_FILE);
+  if (!fs.existsSync(reviewPath)) {
+    return [`${REVIEW_FILE} is missing`];
+  }
+  let expected;
+  try {
+    expected = buildReviewDocument(context);
+  } catch (error) {
+    return [error instanceof Error ? error.message : String(error)];
+  }
+  if (fs.readFileSync(reviewPath, 'utf8') !== expected) {
+    return [
+      `${REVIEW_FILE} does not byte-match the document re-rendered from the sealed evidence`,
+    ];
+  }
+  return [];
 }
 
 /**

--- a/server/public/locales/de/msp/email-providers.json
+++ b/server/public/locales/de/msp/email-providers.json
@@ -42,29 +42,8 @@
       "title": "Einrichtungsanweisungen",
       "microsoft": {
         "title": "Microsoft 365-Setup",
-        "checkingCredentials": "Checking Microsoft credential availability…",
-        "platform": {
-          "title": "Microsoft sign-in is ready",
-          "description": "Alga PSA supplies the Microsoft application. Add a provider, enter the mailbox details, and connect with Microsoft—no Entra app registration is needed."
-        },
-        "byo": {
-          "summary": "Advanced: use your own Microsoft app",
-          "warning": "This is normally unnecessary on hosted Alga PSA and should be used only when your organization requires its own Entra application.",
-          "description": "Open Settings → Integrations → Providers, expand the Microsoft advanced options, and add your tenant-owned app before returning here."
-        },
-        "manualRequired": "Platform Microsoft credentials are unavailable in this deployment. Configure your own Microsoft app to connect a mailbox.",
-        "tenant": {
-          "title": "Your organization’s Microsoft app is selected",
-          "description": "New Microsoft mailboxes will use the tenant-owned app selected in Providers settings. This choice is preserved even when platform credentials are available.",
-          "incompleteTitle": "Your Microsoft app needs attention",
-          "incompleteDescription": "Finish configuring the Microsoft app selected in Providers settings before connecting a mailbox."
-        },
-        "steps": {
-          "registerApp": "Registrieren Sie eine Anwendung in Azure AD",
-          "permissions": "Konfigurieren Sie API-Berechtigungen für Mail.Read",
-          "redirectUrl": "Richten Sie die Weiterleitungs-URL in Ihrer App-Registrierung ein",
-          "credentials": "Verwenden Sie die Client-ID und das Client-Geheimnis im obigen Formular"
-        }
+        "providersPointer": "Microsoft app setup is managed in Providers.",
+        "openProviders": "Open Providers"
       },
       "gmail": {
         "title": "Gmail-Setup",
@@ -271,22 +250,11 @@
     },
     "microsoft": {
       "hostedOauth": {
-        "sectionTitle": "Connect Microsoft 365",
-        "platformUnavailableDescription": "Platform Microsoft credentials are unavailable in this deployment. Use your own Microsoft app to continue.",
-        "tenantSectionDescription": "Authorize this mailbox with the Microsoft app selected in Providers settings.",
-        "platformSectionDescription": "Alga PSA supplies the Microsoft application. Enter the mailbox details, then sign in with Microsoft.",
-        "platformManagedTitle": "Platform-managed Microsoft app",
-        "platformManagedDescription": "No Entra app registration, client ID, or client secret is required from you.",
-        "byoToggle": "Use your own Microsoft app (advanced)",
-        "byoToggleDescription": "For organizations that deliberately require their own Entra app registration.",
-        "byoWarning": "This is normally unnecessary on hosted Alga PSA. Use it only when your organization requires a tenant-owned Entra application.",
-        "tenantNotConfigured": "Your Microsoft app is not ready yet.",
-        "platformNotConfigured": "Platform Microsoft credentials are unavailable."
+        "sectionTitle": "Connect Microsoft 365"
       },
       "validation": {
         "providerNameRequired": "Konfigurationsname ist erforderlich",
         "emailRequired": "Eine gültige E-Mail-Adresse ist erforderlich",
-        "redirectRequired": "Ein gültiger Weiterleitungs-URI ist erforderlich",
         "authorizeRequiresValid": "Bitte füllen Sie vor der Autorisierung alle erforderlichen Felder aus",
         "oauthInitiateFailed": "OAuth konnte nicht gestartet werden",
         "popupBlocked": "Das OAuth-Popup konnte nicht geöffnet werden. Bitte erlauben Sie Popups für diese Website.",
@@ -296,8 +264,7 @@
       },
       "requiredFields": {
         "providerName": "Konfigurationsname",
-        "emailAddress": "E-Mail-Adresse",
-        "redirectUri": "Umleitungs-URI"
+        "emailAddress": "E-Mail-Adresse"
       },
       "basic": {
         "title": "Grundkonfiguration",
@@ -310,20 +277,11 @@
         "providerNameHelp": "Interner Name zur Identifikation dieser Konfiguration. Wird in ausgehenden E-Mails nicht angezeigt.",
         "senderDisplayNameLabel": "Anzeigename des Absenders",
         "senderDisplayNamePlaceholder": "z. B. Acme Support",
-        "senderDisplayNameHelp": "Anzeigename, der im Absenderfeld ausgehender Ticket-E-Mails (Antworten, Abschlüsse) erscheint. Wird nur angewendet, wenn dieses Postfach der ausgehenden Ticketing-Adresse des Mandanten entspricht. Leer lassen, um den Boardnamen des Tickets zu verwenden."
+        "senderDisplayNameHelp": "Display name shown in the From header on outbound ticket emails. It applies when this mailbox matches the configured outbound ticketing address. Leave blank to use the ticket board name."
       },
       "oauth": {
-        "sectionTitle": "Microsoft OAuth-Konfiguration",
-        "sectionDescription": "Anmeldeinformationen für Microsoft-Apps werden in den Anbietereinstellungen konfiguriert und hier wiederverwendet.",
-        "setupLabel": "Microsoft Entra",
-        "notConfigured": "Die Microsoft-Anbietereinstellungen sind nicht konfiguriert.",
-        "setupHelp": "Konfigurieren Sie zunächst Anbieter unter Einstellungen → Integrationen → Anbieter und kehren Sie dann hierher zurück, um dieses Postfach zu autorisieren.",
-        "profileReady": "Das Microsoft-App-Profil ist bereit.",
-        "profileReadyHelp": "Falls die Zustimmung des Mandantenadministrators noch aussteht, schließen Sie sie in den Anbietereinstellungen ab. Verwenden Sie anschließend unten Zugriff autorisieren für dieses Postfach.",
-        "redirectUriLabel": "Weiterleitungs-URI *",
-        "redirectUriPlaceholder": "https://yourapp.com/api/auth/microsoft/callback",
-        "authorizationTitle": "OAuth-Autorisierung",
-        "authorizationDescription": "Schließen Sie den OAuth-Ablauf ab, um Zugriff auf das Postfach zu gewähren"
+        "signingIn": "Signing in…",
+        "signIn": "Sign in with Microsoft"
       },
       "advanced": {
         "title": "Erweiterte Einstellungen",
@@ -332,6 +290,14 @@
         "folderFiltersPlaceholder": "Posteingang, Support, Benutzerdefinierter Ordner",
         "folderFiltersHelp": "Durch Kommas getrennte Liste der zu überwachenden Ordner (Standard: Posteingang)",
         "maxEmailsPerSync": "Maximale E-Mails pro Synchronisierung"
+      },
+      "readiness": {
+        "checking": "Checking Microsoft setup…",
+        "ready": "Microsoft is set up. Sign in as this mailbox to finish.",
+        "pending": "Waiting for your Microsoft 365 administrator. Setup was started in Providers but hasn't been approved yet.",
+        "openProviders": "Open Providers",
+        "notConfigured": "Microsoft isn't set up yet. Set it up once in Providers, then come back.",
+        "setUpInProviders": "Set up in Providers"
       }
     },
     "gmail": {

--- a/server/public/locales/de/msp/integrations.json
+++ b/server/public/locales/de/msp/integrations.json
@@ -559,22 +559,22 @@
         },
         "schedule": {
           "cadence": {
-            "10080": "wöchentlich",
-            "1440": "täglich",
-            "240": "alle 4 Stunden",
             "60": "stündlich",
-            "720": "alle 12 Stunden"
+            "240": "alle 4 Stunden",
+            "720": "alle 12 Stunden",
+            "1440": "täglich",
+            "10080": "wöchentlich"
           },
           "changeAction": "Zeitplan ändern",
           "description": "Wenn aktiviert, synchronisiert Alga jeden zugeordneten Client in dieser Taktung. Beim Ausschalten entfallen geplante Läufe; manuell können Sie weiterhin synchronisieren.",
           "enablePrompt": "Der Pilot war erfolgreich. Aktivieren Sie die automatische Synchronisierung, damit Kontakte ohne manuelle Läufe aktuell bleiben.",
           "intervalLabel": "Ausführen alle",
           "intervals": {
-            "10080": "Woche",
-            "1440": "Tag",
-            "240": "4 Stunden",
             "60": "Stunde",
-            "720": "12 Stunden"
+            "240": "4 Stunden",
+            "720": "12 Stunden",
+            "1440": "Tag",
+            "10080": "Woche"
           },
           "pause": "Pausieren",
           "pauseHint": "Pausiert. Zum Anwenden speichern.",
@@ -1518,35 +1518,40 @@
     },
     "microsoft": {
       "emailSetup": {
-        "action": "Set up Microsoft Email",
+        "action": "Set up Microsoft",
         "actions": {
           "back": "Back",
           "cancel": "Cancel",
           "copy": "Copy",
           "finish": "Finish",
-          "grantConsent": "Grant administrator consent",
           "savePlatform": "Create profile and continue",
           "signIn": "Sign in to Microsoft",
-          "working": "Working…"
+          "working": "Working…",
+          "approve": "Approve in Microsoft",
+          "copyApprovalLink": "Copy approval link for your admin",
+          "saveManual": "Save app and continue"
         },
         "automated": {
-          "description": "Sign in as a Microsoft administrator. Alga creates the app, service principal, secret, Email profile, and binding.",
-          "title": "Create an app in this tenant"
+          "description": "Alga PSA registers a dedicated Entra app automatically. Sign in as a Microsoft 365 administrator.",
+          "title": "Create an app in your Microsoft organization"
         },
         "callbackUri": "Mailbox callback URI",
         "complete": {
-          "consentDone": "Administrator consent is confirmed. Return to Inbound Email and authorize the mailbox.",
-          "consentPending": "Next, a Microsoft tenant administrator must grant consent. Mailbox authorization happens afterward in Inbound Email.",
-          "profileCreated": "Microsoft Email profile created and bound"
+          "consentDone": "Approved by your Microsoft 365 administrator. You can now connect a mailbox.",
+          "consentPending": "A Microsoft 365 administrator for your organization must approve access before mailboxes can connect.",
+          "profileCreated": "Microsoft Email profile created and bound",
+          "ready": "Microsoft is ready",
+          "waiting": "Waiting for admin approval"
         },
         "consent": {
           "confirmedDescription": "The Microsoft app is ready for mailbox authorization.",
           "confirmedTitle": "Administrator consent confirmed",
           "url": "Administrator consent URL",
-          "urlLabel": "Consent URL"
+          "urlLabel": "Consent URL",
+          "approvalLink": "Approval link"
         },
         "copied": "{{label}} copied",
-        "description": "Choose how to configure the Microsoft app used for inbound email. Mailbox authorization remains a separate final step.",
+        "description": "Choose how Alga PSA connects to Microsoft. You will connect mailboxes separately.",
         "errors": {
           "automated": "Could not start automated Microsoft app creation.",
           "generic": "Microsoft Email setup did not complete.",
@@ -1554,38 +1559,46 @@
           "platform": "Could not configure the platform Microsoft app.",
           "popupBlocked": "Allow popups for this site, then try again.",
           "popupClosed": "Das Microsoft-Fenster wurde geschlossen, bevor die Einrichtung abgeschlossen war. Versuchen Sie es erneut oder wählen Sie eine andere Einrichtungsoption.",
-          "tenantRequired": "Enter your Microsoft tenant ID or verified domain."
+          "tenantRequired": "Enter your Microsoft tenant ID or verified domain.",
+          "manual": "Could not configure the Microsoft app.",
+          "manualRequired": "Enter the display name, client ID, client secret, and Microsoft tenant ID.",
+          "pendingProfileMissing": "The pending Microsoft app could not be found.",
+          "approvalLink": "Could not create the Microsoft approval link."
         },
         "fields": {
           "clientId": "Client ID",
           "displayName": "Profile display name",
-          "tenant": "Microsoft tenant ID or verified domain",
-          "tenantId": "Tenant ID"
+          "tenantId": "Microsoft tenant ID",
+          "clientSecret": "Client secret",
+          "microsoftTenant": "Microsoft tenant ID or verified domain",
+          "redirectUri": "Redirect URI to add in Entra"
         },
         "manual": {
-          "description": "Keep using the existing client ID, tenant ID, and client secret form.",
+          "description": "Use an existing Entra app maintained by your organization.",
           "title": "Enter an existing app manually"
         },
         "platform": {
-          "description": "Create an Email-bound profile from the server-managed multi-tenant app, then grant tenant administrator consent.",
-          "title": "Use the Alga platform app"
+          "description": "Nothing to register in Microsoft Entra. Your Microsoft 365 administrator approves access.",
+          "title": "Use the app provided by Alga PSA"
         },
-        "title": "Set up Microsoft Email",
-        "unavailable": "Unavailable"
+        "title": "Set up Microsoft",
+        "unavailable": "Unavailable",
+        "recommended": "Recommended",
+        "advanced": "Advanced"
       },
       "settings": {
         "advanced": {
-          "title": "Bring your own Microsoft app (advanced)",
-          "description": "Create and manage tenant-owned Entra app registrations for organizations that explicitly require them.",
+          "title": "Manual Microsoft apps (advanced)",
+          "description": "Create and manage Entra app registrations maintained by your organization.",
           "warning": "A custom Entra app is normally unnecessary on hosted Alga PSA. Continue only when your organization deliberately requires its own application and credentials."
         },
         "platform": {
           "title": "Microsoft email is ready to connect",
           "description": "Connect Microsoft 365 with the application supplied by Alga PSA. No Entra app registration is required.",
-          "readyDescription": "Alga PSA supplies and manages the Microsoft application. Connect a mailbox without creating an Entra app or entering client credentials.",
-          "connectAction": "Connect Microsoft email",
+          "readyDescription": "The Microsoft app is approved and ready for mailbox sign-in.",
+          "connectAction": "Connect a mailbox →",
           "unavailableTitle": "Platform Microsoft credentials are unavailable",
-          "unavailableDescription": "This deployment requires a tenant-owned Microsoft app. Use the advanced setup below to add one."
+          "unavailableDescription": "This deployment requires an app maintained by your organization. Use the advanced setup below to add one."
         },
         "actions": {
           "entraLink": "Microsoft Entra",
@@ -1670,7 +1683,7 @@
           "setDefault": "Dieses Profil als Standard-Microsoft-Profil festlegen",
           "setDefaultHelp": "Standardprofile stehen für Profilverwaltungs-Workflows und migrations­sichere Metadaten zur Verfügung, jedoch nicht für das Consumer-Routing.",
           "storedSecretHint": "Gespeichertes Secret: {{secret}}. Lassen Sie dieses Feld leer, um es unverändert zu lassen.",
-          "tenantId": "Tenant ID",
+          "tenantId": "Microsoft tenant ID",
           "capabilities": "Enabled capabilities",
           "capabilitiesHelp": "Only enabled capabilities can bind to this Microsoft app."
         },
@@ -1707,7 +1720,7 @@
           "teamsScopes": "Teams-Scopes",
           "teamsTabRedirect": "Redirect-URI für persönlichen Tab",
           "teamsTitle": "Teams-Anleitung",
-          "tenantId": "Tenant ID",
+          "tenantId": "Microsoft tenant ID",
           "unavailable": "Nicht verfügbar"
         },
         "profileCard": {
@@ -1724,7 +1737,7 @@
           "setDefault": "Als Standard festlegen",
           "storedSecret": "Gespeichertes Secret",
           "teamsAppIdUri": "Teams Application ID URI",
-          "tenantIdLabel": "Tenant ID:",
+          "tenantIdLabel": "Microsoft tenant ID:",
           "updating": "Wird aktualisiert…",
           "enabledCapabilities": "Enabled capabilities",
           "noEnabledCapabilities": "No enabled capabilities"
@@ -1737,13 +1750,14 @@
           "archived": "Archivierte Profile können nicht für neue Microsoft-Bindungen verwendet werden.",
           "clientIdMissing": "Client ID fehlt.",
           "clientSecretMissing": "Client Secret wurde nicht konfiguriert.",
-          "tenantIdMissing": "Tenant ID fehlt.",
-          "adminConsentPending": "Erteilen Sie die Zustimmung des Microsoft-Mandantenadministrators, um die E-Mail-Einrichtung abzuschließen."
+          "tenantIdMissing": "Add a Microsoft tenant ID.",
+          "adminConsentPending": "Ask a Microsoft 365 administrator to approve access for Email."
         },
         "statusBadges": {
           "archived": "Archiviert",
           "needsAttention": "Erfordert Aufmerksamkeit",
-          "ready": "Bereit"
+          "ready": "Bereit",
+          "waitingForAdminApproval": "Waiting for admin approval"
         },
         "title": "Microsoft",
         "toasts": {
@@ -1770,7 +1784,7 @@
           "clientIdRequired": "Microsoft OAuth Client ID ist erforderlich",
           "clientSecretRequired": "Microsoft OAuth Client Secret ist erforderlich",
           "displayNameRequired": "Anzeigename des Microsoft-Profils ist erforderlich",
-          "tenantIdRequired": "Microsoft Tenant ID ist erforderlich"
+          "tenantIdRequired": "Microsoft tenant ID is required"
         },
         "disconnectDialog": {
           "cancel": "Keep providers connected",

--- a/server/public/locales/en/msp/email-providers.json
+++ b/server/public/locales/en/msp/email-providers.json
@@ -42,29 +42,8 @@
       "title": "Setup Instructions",
       "microsoft": {
         "title": "Microsoft 365 Setup",
-        "checkingCredentials": "Checking Microsoft credential availability…",
-        "platform": {
-          "title": "Microsoft sign-in is ready",
-          "description": "Alga PSA supplies the Microsoft application. Add a provider, enter the mailbox details, and connect with Microsoft—no Entra app registration is needed."
-        },
-        "byo": {
-          "summary": "Advanced: use your own Microsoft app",
-          "warning": "This is normally unnecessary on hosted Alga PSA and should be used only when your organization requires its own Entra application.",
-          "description": "Open Settings → Integrations → Providers, expand the Microsoft advanced options, and add your tenant-owned app before returning here."
-        },
-        "manualRequired": "Platform Microsoft credentials are unavailable in this deployment. Configure your own Microsoft app to connect a mailbox.",
-        "tenant": {
-          "title": "Your organization’s Microsoft app is selected",
-          "description": "New Microsoft mailboxes will use the tenant-owned app selected in Providers settings. This choice is preserved even when platform credentials are available.",
-          "incompleteTitle": "Your Microsoft app needs attention",
-          "incompleteDescription": "Finish configuring the Microsoft app selected in Providers settings before connecting a mailbox."
-        },
-        "steps": {
-          "registerApp": "Register an application in Azure AD",
-          "permissions": "Configure API permissions for Mail.Read",
-          "redirectUrl": "Set up the redirect URL in your app registration",
-          "credentials": "Use the Client ID and Client Secret in the form above"
-        }
+        "providersPointer": "Microsoft app setup is managed in Providers.",
+        "openProviders": "Open Providers"
       },
       "gmail": {
         "title": "Gmail Setup",
@@ -271,22 +250,11 @@
     },
     "microsoft": {
       "hostedOauth": {
-        "sectionTitle": "Connect Microsoft 365",
-        "platformUnavailableDescription": "Platform Microsoft credentials are unavailable in this deployment. Use your own Microsoft app to continue.",
-        "tenantSectionDescription": "Authorize this mailbox with the Microsoft app selected in Providers settings.",
-        "platformSectionDescription": "Alga PSA supplies the Microsoft application. Enter the mailbox details, then sign in with Microsoft.",
-        "platformManagedTitle": "Platform-managed Microsoft app",
-        "platformManagedDescription": "No Entra app registration, client ID, or client secret is required from you.",
-        "byoToggle": "Use your own Microsoft app (advanced)",
-        "byoToggleDescription": "For organizations that deliberately require their own Entra app registration.",
-        "byoWarning": "This is normally unnecessary on hosted Alga PSA. Use it only when your organization requires a tenant-owned Entra application.",
-        "tenantNotConfigured": "Your Microsoft app is not ready yet.",
-        "platformNotConfigured": "Platform Microsoft credentials are unavailable."
+        "sectionTitle": "Connect Microsoft 365"
       },
       "validation": {
         "providerNameRequired": "Configuration name is required",
         "emailRequired": "Valid email address is required",
-        "redirectRequired": "Valid redirect URI is required",
         "authorizeRequiresValid": "Please fill in all required fields before authorizing",
         "oauthInitiateFailed": "Failed to initiate OAuth",
         "popupBlocked": "Failed to open OAuth popup. Please allow popups for this site.",
@@ -296,8 +264,7 @@
       },
       "requiredFields": {
         "providerName": "Configuration Name",
-        "emailAddress": "Email Address",
-        "redirectUri": "Redirect URI"
+        "emailAddress": "Email Address"
       },
       "basic": {
         "title": "Basic Configuration",
@@ -310,20 +277,19 @@
         "providerNameHelp": "Internal name used to identify this configuration. Not shown in outbound emails.",
         "senderDisplayNameLabel": "Sender Display Name",
         "senderDisplayNamePlaceholder": "e.g., Acme Support",
-        "senderDisplayNameHelp": "Display name shown in the From header on outbound ticket emails (replies, closures). Applied only when this mailbox matches the tenant's outbound ticketing-from address. Leave blank to fall back to the ticket's board name."
+        "senderDisplayNameHelp": "Display name shown in the From header on outbound ticket emails. It applies when this mailbox matches the configured outbound ticketing address. Leave blank to use the ticket board name."
       },
       "oauth": {
-        "sectionTitle": "Microsoft OAuth Configuration",
-        "sectionDescription": "Microsoft app credentials are configured in Providers settings and reused here.",
-        "setupLabel": "Microsoft Entra",
-        "notConfigured": "Microsoft provider settings are not configured.",
-        "setupHelp": "Configure Providers first in Settings → Integrations → Providers, then return here to authorize this mailbox.",
-        "profileReady": "Microsoft app profile is ready.",
-        "profileReadyHelp": "If tenant administrator consent is still pending, complete it in Providers settings. Then use Authorize Access below for this mailbox.",
-        "redirectUriLabel": "Redirect URI *",
-        "redirectUriPlaceholder": "https://yourapp.com/api/auth/microsoft/callback",
-        "authorizationTitle": "OAuth Authorization",
-        "authorizationDescription": "Complete OAuth flow to grant access to the mailbox"
+        "signingIn": "Signing in…",
+        "signIn": "Sign in with Microsoft"
+      },
+      "readiness": {
+        "checking": "Checking Microsoft setup…",
+        "ready": "Microsoft is set up. Sign in as this mailbox to finish.",
+        "pending": "Waiting for your Microsoft 365 administrator. Setup was started in Providers but hasn't been approved yet.",
+        "openProviders": "Open Providers",
+        "notConfigured": "Microsoft isn't set up yet. Set it up once in Providers, then come back.",
+        "setUpInProviders": "Set up in Providers"
       },
       "advanced": {
         "title": "Advanced Settings",

--- a/server/public/locales/en/msp/integrations.json
+++ b/server/public/locales/en/msp/integrations.json
@@ -1518,74 +1518,87 @@
     },
     "microsoft": {
       "emailSetup": {
-        "action": "Set up Microsoft Email",
+        "action": "Set up Microsoft",
         "actions": {
+          "approve": "Approve in Microsoft",
           "back": "Back",
           "cancel": "Cancel",
           "copy": "Copy",
+          "copyApprovalLink": "Copy approval link for your admin",
           "finish": "Finish",
-          "grantConsent": "Grant administrator consent",
+          "saveManual": "Save app and continue",
           "savePlatform": "Create profile and continue",
           "signIn": "Sign in to Microsoft",
           "working": "Working…"
         },
         "automated": {
-          "description": "Sign in as a Microsoft administrator. Alga creates the app, service principal, secret, and a pending Email profile. The Email binding is created after administrator consent.",
-          "title": "Create an app in this tenant"
+          "description": "Alga PSA registers a dedicated Entra app automatically. Sign in as a Microsoft 365 administrator.",
+          "title": "Create an app in your Microsoft organization"
         },
         "callbackUri": "Mailbox callback URI",
         "complete": {
-          "consentDone": "Administrator consent is confirmed. Return to Inbound Email and authorize the mailbox.",
-          "consentPending": "Next, a Microsoft tenant administrator must grant consent. Mailbox authorization happens afterward in Inbound Email.",
-          "profileCreated": "Microsoft Email profile created"
+          "consentDone": "Approved by your Microsoft 365 administrator. You can now connect a mailbox.",
+          "consentPending": "A Microsoft 365 administrator for your organization must approve access before mailboxes can connect.",
+          "profileCreated": "Microsoft Email profile created",
+          "ready": "Microsoft is ready",
+          "waiting": "Waiting for admin approval"
         },
         "consent": {
           "confirmedDescription": "The Microsoft app is ready for mailbox authorization.",
           "confirmedTitle": "Administrator consent confirmed",
+          "approvalLink": "Approval link",
           "url": "Administrator consent URL",
           "urlLabel": "Consent URL"
         },
         "copied": "{{label}} copied",
-        "description": "Choose how to configure the Microsoft app used for inbound email. Mailbox authorization remains a separate final step.",
+        "description": "Choose how Alga PSA connects to Microsoft. You will connect mailboxes separately.",
         "errors": {
           "automated": "Could not start automated Microsoft app creation.",
           "generic": "Microsoft Email setup did not complete.",
+          "manual": "Could not configure the Microsoft app.",
+          "manualRequired": "Enter the display name, client ID, client secret, and Microsoft tenant ID.",
           "nameRequired": "Enter a display name for the Microsoft app.",
           "platform": "Could not configure the platform Microsoft app.",
           "popupBlocked": "Allow popups for this site, then try again.",
           "popupClosed": "The Microsoft window was closed before setup finished. Try again or choose another setup option.",
-          "tenantRequired": "Enter your Microsoft tenant ID or verified domain."
+          "tenantRequired": "Enter your Microsoft tenant ID or verified domain.",
+          "pendingProfileMissing": "The pending Microsoft app could not be found.",
+          "approvalLink": "Could not create the Microsoft approval link."
         },
         "fields": {
           "clientId": "Client ID",
+          "clientSecret": "Client secret",
           "displayName": "Profile display name",
-          "tenant": "Microsoft tenant ID or verified domain",
-          "tenantId": "Tenant ID"
+          "microsoftTenant": "Microsoft tenant ID or verified domain",
+          "tenantId": "Microsoft tenant ID",
+          "redirectUri": "Redirect URI to add in Entra"
         },
         "manual": {
-          "description": "Keep using the existing client ID, tenant ID, and client secret form.",
+          "description": "Use an existing Entra app maintained by your organization.",
           "title": "Enter an existing app manually"
         },
         "platform": {
-          "description": "Create a pending Email profile from the server-managed multi-tenant app. It is bound after tenant administrator consent.",
-          "title": "Use the Alga platform app"
+          "description": "Nothing to register in Microsoft Entra. Your Microsoft 365 administrator approves access.",
+          "title": "Use the app provided by Alga PSA"
         },
-        "title": "Set up Microsoft Email",
-        "unavailable": "Unavailable"
+        "title": "Set up Microsoft",
+        "unavailable": "Unavailable",
+        "recommended": "Recommended",
+        "advanced": "Advanced"
       },
       "settings": {
         "advanced": {
-          "title": "Bring your own Microsoft app (advanced)",
-          "description": "Create and manage tenant-owned Entra app registrations for organizations that explicitly require them.",
+          "title": "Manual Microsoft apps (advanced)",
+          "description": "Create and manage Entra app registrations maintained by your organization.",
           "warning": "A custom Entra app is normally unnecessary on hosted Alga PSA. Continue only when your organization deliberately requires its own application and credentials."
         },
         "platform": {
           "title": "Microsoft email is ready to connect",
           "description": "Connect Microsoft 365 with the application supplied by Alga PSA. No Entra app registration is required.",
-          "readyDescription": "Alga PSA supplies and manages the Microsoft application. Connect a mailbox without creating an Entra app or entering client credentials.",
-          "connectAction": "Connect Microsoft email",
+          "readyDescription": "The Microsoft app is approved and ready for mailbox sign-in.",
+          "connectAction": "Connect a mailbox →",
           "unavailableTitle": "Platform Microsoft credentials are unavailable",
-          "unavailableDescription": "This deployment requires a tenant-owned Microsoft app. Use the advanced setup below to add one."
+          "unavailableDescription": "This deployment requires an app maintained by your organization. Use the advanced setup below to add one."
         },
         "actions": {
           "disconnectProviders": "Disconnect Microsoft providers",
@@ -1675,7 +1688,7 @@
           "setDefault": "Set this as the default Microsoft app",
           "setDefaultHelp": "Some setup flows still need a default app. Service choices above decide which app each service uses.",
           "storedSecretHint": "Stored secret: {{secret}}. Leave this field empty to keep it unchanged.",
-          "tenantId": "Tenant ID",
+          "tenantId": "Microsoft tenant ID",
           "capabilities": "Services this app can handle",
           "capabilitiesHelp": "Only checked services can use this Microsoft app."
         },
@@ -1712,7 +1725,7 @@
           "teamsScopes": "Teams scopes",
           "teamsTabRedirect": "Personal tab redirect URI",
           "teamsTitle": "Teams",
-          "tenantId": "Tenant ID",
+          "tenantId": "Microsoft tenant ID",
           "unavailable": "Unavailable"
         },
         "profileCard": {
@@ -1729,7 +1742,7 @@
           "setDefault": "Set default",
           "storedSecret": "Stored secret",
           "teamsAppIdUri": "Teams application ID URI",
-          "tenantIdLabel": "Tenant ID:",
+          "tenantIdLabel": "Microsoft tenant ID:",
           "updating": "Updating…",
           "enabledCapabilities": "Services this app can handle",
           "noEnabledCapabilities": "No services turned on"
@@ -1746,13 +1759,14 @@
           "archived": "Archived apps cannot be selected for Microsoft services.",
           "clientIdMissing": "Add a client ID.",
           "clientSecretMissing": "Add a client secret.",
-          "tenantIdMissing": "Add a tenant ID.",
-          "adminConsentPending": "Grant Microsoft tenant administrator consent to finish Email setup."
+          "tenantIdMissing": "Add a Microsoft tenant ID.",
+          "adminConsentPending": "Ask a Microsoft 365 administrator to approve access for Email."
         },
         "statusBadges": {
           "archived": "Archived",
           "needsAttention": "Needs setup",
-          "ready": "Ready"
+          "ready": "Ready",
+          "waitingForAdminApproval": "Waiting for admin approval"
         },
         "title": "Microsoft",
         "toasts": {
@@ -1779,7 +1793,7 @@
           "clientIdRequired": "Microsoft OAuth Client ID is required",
           "clientSecretRequired": "Microsoft OAuth Client Secret is required",
           "displayNameRequired": "Microsoft app display name is required",
-          "tenantIdRequired": "Microsoft Tenant ID is required"
+          "tenantIdRequired": "Microsoft tenant ID is required"
         }
       }
     },

--- a/server/public/locales/es/msp/email-providers.json
+++ b/server/public/locales/es/msp/email-providers.json
@@ -42,29 +42,8 @@
       "title": "Instrucciones de configuración",
       "microsoft": {
         "title": "Configuración de Microsoft 365",
-        "checkingCredentials": "Checking Microsoft credential availability…",
-        "platform": {
-          "title": "Microsoft sign-in is ready",
-          "description": "Alga PSA supplies the Microsoft application. Add a provider, enter the mailbox details, and connect with Microsoft—no Entra app registration is needed."
-        },
-        "byo": {
-          "summary": "Advanced: use your own Microsoft app",
-          "warning": "This is normally unnecessary on hosted Alga PSA and should be used only when your organization requires its own Entra application.",
-          "description": "Open Settings → Integrations → Providers, expand the Microsoft advanced options, and add your tenant-owned app before returning here."
-        },
-        "manualRequired": "Platform Microsoft credentials are unavailable in this deployment. Configure your own Microsoft app to connect a mailbox.",
-        "tenant": {
-          "title": "Your organization’s Microsoft app is selected",
-          "description": "New Microsoft mailboxes will use the tenant-owned app selected in Providers settings. This choice is preserved even when platform credentials are available.",
-          "incompleteTitle": "Your Microsoft app needs attention",
-          "incompleteDescription": "Finish configuring the Microsoft app selected in Providers settings before connecting a mailbox."
-        },
-        "steps": {
-          "registerApp": "Registrar una aplicación en Azure AD",
-          "permissions": "Configurar permisos API para Mail.Read",
-          "redirectUrl": "Configure la URL de redireccionamiento en el registro de su aplicación",
-          "credentials": "Utilice el ID de cliente y el secreto de cliente en el formulario anterior"
-        }
+        "providersPointer": "Microsoft app setup is managed in Providers.",
+        "openProviders": "Open Providers"
       },
       "gmail": {
         "title": "Configuración de Gmail",
@@ -271,22 +250,11 @@
     },
     "microsoft": {
       "hostedOauth": {
-        "sectionTitle": "Connect Microsoft 365",
-        "platformUnavailableDescription": "Platform Microsoft credentials are unavailable in this deployment. Use your own Microsoft app to continue.",
-        "tenantSectionDescription": "Authorize this mailbox with the Microsoft app selected in Providers settings.",
-        "platformSectionDescription": "Alga PSA supplies the Microsoft application. Enter the mailbox details, then sign in with Microsoft.",
-        "platformManagedTitle": "Platform-managed Microsoft app",
-        "platformManagedDescription": "No Entra app registration, client ID, or client secret is required from you.",
-        "byoToggle": "Use your own Microsoft app (advanced)",
-        "byoToggleDescription": "For organizations that deliberately require their own Entra app registration.",
-        "byoWarning": "This is normally unnecessary on hosted Alga PSA. Use it only when your organization requires a tenant-owned Entra application.",
-        "tenantNotConfigured": "Your Microsoft app is not ready yet.",
-        "platformNotConfigured": "Platform Microsoft credentials are unavailable."
+        "sectionTitle": "Connect Microsoft 365"
       },
       "validation": {
         "providerNameRequired": "El nombre de configuración es obligatorio",
         "emailRequired": "Se requiere una dirección de correo electrónico válida",
-        "redirectRequired": "Se requiere un URI de redireccionamiento válido",
         "authorizeRequiresValid": "Por favor complete todos los campos requeridos antes de autorizar",
         "oauthInitiateFailed": "No se pudo iniciar OAuth",
         "popupBlocked": "No se pudo abrir la ventana emergente de OAuth. Permita ventanas emergentes para este sitio.",
@@ -296,8 +264,7 @@
       },
       "requiredFields": {
         "providerName": "Nombre de configuración",
-        "emailAddress": "Dirección de correo electrónico",
-        "redirectUri": "URI de redireccionamiento"
+        "emailAddress": "Dirección de correo electrónico"
       },
       "basic": {
         "title": "Configuración básica",
@@ -310,20 +277,11 @@
         "providerNameHelp": "Nombre interno utilizado para identificar esta configuración. No se muestra en los correos salientes.",
         "senderDisplayNameLabel": "Nombre del remitente",
         "senderDisplayNamePlaceholder": "p. ej., Soporte Acme",
-        "senderDisplayNameHelp": "Nombre que se muestra en el encabezado De de los correos salientes de tickets (respuestas, cierres). Solo se aplica cuando este buzón coincide con la dirección de envío saliente del inquilino. Déjalo en blanco para usar el nombre del tablero del ticket."
+        "senderDisplayNameHelp": "Display name shown in the From header on outbound ticket emails. It applies when this mailbox matches the configured outbound ticketing address. Leave blank to use the ticket board name."
       },
       "oauth": {
-        "sectionTitle": "Configuración de Microsoft OAuth",
-        "sectionDescription": "Las credenciales de la aplicación Microsoft se configuran en la configuración de Proveedores y se reutilizan aquí.",
-        "setupLabel": "MicrosoftEntra",
-        "notConfigured": "La configuración del proveedor de Microsoft no está configurada.",
-        "setupHelp": "Configure Proveedores primero en Configuración → Integraciones → Proveedores, luego regrese aquí para autorizar este buzón.",
-        "profileReady": "El perfil de la aplicación de Microsoft está listo.",
-        "profileReadyHelp": "Si el consentimiento del administrador del inquilino sigue pendiente, complételo en la configuración de Proveedores. Después, use Autorizar acceso para este buzón.",
-        "redirectUriLabel": "URI de redireccionamiento *",
-        "redirectUriPlaceholder": "https://yourapp.com/api/auth/microsoft/callback",
-        "authorizationTitle": "Autorización de OAuth",
-        "authorizationDescription": "Complete el flujo de OAuth para otorgar acceso al buzón"
+        "signingIn": "Signing in…",
+        "signIn": "Sign in with Microsoft"
       },
       "advanced": {
         "title": "Configuración avanzada",
@@ -332,6 +290,14 @@
         "folderFiltersPlaceholder": "Bandeja de entrada, Soporte, Carpeta personalizada",
         "folderFiltersHelp": "Lista de carpetas separadas por comas para monitorear (predeterminado: Bandeja de entrada)",
         "maxEmailsPerSync": "Máximo de correos electrónicos por sincronización"
+      },
+      "readiness": {
+        "checking": "Checking Microsoft setup…",
+        "ready": "Microsoft is set up. Sign in as this mailbox to finish.",
+        "pending": "Waiting for your Microsoft 365 administrator. Setup was started in Providers but hasn't been approved yet.",
+        "openProviders": "Open Providers",
+        "notConfigured": "Microsoft isn't set up yet. Set it up once in Providers, then come back.",
+        "setUpInProviders": "Set up in Providers"
       }
     },
     "gmail": {

--- a/server/public/locales/es/msp/integrations.json
+++ b/server/public/locales/es/msp/integrations.json
@@ -559,22 +559,22 @@
         },
         "schedule": {
           "cadence": {
-            "10080": "cada semana",
-            "1440": "cada día",
-            "240": "cada 4 horas",
             "60": "cada hora",
-            "720": "cada 12 horas"
+            "240": "cada 4 horas",
+            "720": "cada 12 horas",
+            "1440": "cada día",
+            "10080": "cada semana"
           },
           "changeAction": "Cambiar programación",
           "description": "Cuando está activada, Alga sincroniza cada cliente asignado con esta cadencia. Al desactivarla se detienen las ejecuciones programadas; puede seguir sincronizando manualmente.",
           "enablePrompt": "El piloto funcionó. Active la sincronización automática para mantener los contactos al día sin ejecutarla a mano.",
           "intervalLabel": "Ejecutar cada",
           "intervals": {
-            "10080": "Semana",
-            "1440": "Día",
-            "240": "4 horas",
             "60": "Hora",
-            "720": "12 horas"
+            "240": "4 horas",
+            "720": "12 horas",
+            "1440": "Día",
+            "10080": "Semana"
           },
           "pause": "Pausar",
           "pauseHint": "En pausa. Guarde para aplicar.",
@@ -1518,35 +1518,40 @@
     },
     "microsoft": {
       "emailSetup": {
-        "action": "Set up Microsoft Email",
+        "action": "Set up Microsoft",
         "actions": {
           "back": "Back",
           "cancel": "Cancel",
           "copy": "Copy",
           "finish": "Finish",
-          "grantConsent": "Grant administrator consent",
           "savePlatform": "Create profile and continue",
           "signIn": "Sign in to Microsoft",
-          "working": "Working…"
+          "working": "Working…",
+          "approve": "Approve in Microsoft",
+          "copyApprovalLink": "Copy approval link for your admin",
+          "saveManual": "Save app and continue"
         },
         "automated": {
-          "description": "Sign in as a Microsoft administrator. Alga creates the app, service principal, secret, Email profile, and binding.",
-          "title": "Create an app in this tenant"
+          "description": "Alga PSA registers a dedicated Entra app automatically. Sign in as a Microsoft 365 administrator.",
+          "title": "Create an app in your Microsoft organization"
         },
         "callbackUri": "Mailbox callback URI",
         "complete": {
-          "consentDone": "Administrator consent is confirmed. Return to Inbound Email and authorize the mailbox.",
-          "consentPending": "Next, a Microsoft tenant administrator must grant consent. Mailbox authorization happens afterward in Inbound Email.",
-          "profileCreated": "Microsoft Email profile created and bound"
+          "consentDone": "Approved by your Microsoft 365 administrator. You can now connect a mailbox.",
+          "consentPending": "A Microsoft 365 administrator for your organization must approve access before mailboxes can connect.",
+          "profileCreated": "Microsoft Email profile created and bound",
+          "ready": "Microsoft is ready",
+          "waiting": "Waiting for admin approval"
         },
         "consent": {
           "confirmedDescription": "The Microsoft app is ready for mailbox authorization.",
           "confirmedTitle": "Administrator consent confirmed",
           "url": "Administrator consent URL",
-          "urlLabel": "Consent URL"
+          "urlLabel": "Consent URL",
+          "approvalLink": "Approval link"
         },
         "copied": "{{label}} copied",
-        "description": "Choose how to configure the Microsoft app used for inbound email. Mailbox authorization remains a separate final step.",
+        "description": "Choose how Alga PSA connects to Microsoft. You will connect mailboxes separately.",
         "errors": {
           "automated": "Could not start automated Microsoft app creation.",
           "generic": "Microsoft Email setup did not complete.",
@@ -1554,38 +1559,46 @@
           "platform": "Could not configure the platform Microsoft app.",
           "popupBlocked": "Allow popups for this site, then try again.",
           "popupClosed": "La ventana de Microsoft se cerró antes de finalizar la configuración. Inténtelo de nuevo o elija otra opción de configuración.",
-          "tenantRequired": "Enter your Microsoft tenant ID or verified domain."
+          "tenantRequired": "Enter your Microsoft tenant ID or verified domain.",
+          "manual": "Could not configure the Microsoft app.",
+          "manualRequired": "Enter the display name, client ID, client secret, and Microsoft tenant ID.",
+          "pendingProfileMissing": "The pending Microsoft app could not be found.",
+          "approvalLink": "Could not create the Microsoft approval link."
         },
         "fields": {
           "clientId": "Client ID",
           "displayName": "Profile display name",
-          "tenant": "Microsoft tenant ID or verified domain",
-          "tenantId": "Tenant ID"
+          "tenantId": "Microsoft tenant ID",
+          "clientSecret": "Client secret",
+          "microsoftTenant": "Microsoft tenant ID or verified domain",
+          "redirectUri": "Redirect URI to add in Entra"
         },
         "manual": {
-          "description": "Keep using the existing client ID, tenant ID, and client secret form.",
+          "description": "Use an existing Entra app maintained by your organization.",
           "title": "Enter an existing app manually"
         },
         "platform": {
-          "description": "Create an Email-bound profile from the server-managed multi-tenant app, then grant tenant administrator consent.",
-          "title": "Use the Alga platform app"
+          "description": "Nothing to register in Microsoft Entra. Your Microsoft 365 administrator approves access.",
+          "title": "Use the app provided by Alga PSA"
         },
-        "title": "Set up Microsoft Email",
-        "unavailable": "Unavailable"
+        "title": "Set up Microsoft",
+        "unavailable": "Unavailable",
+        "recommended": "Recommended",
+        "advanced": "Advanced"
       },
       "settings": {
         "advanced": {
-          "title": "Bring your own Microsoft app (advanced)",
-          "description": "Create and manage tenant-owned Entra app registrations for organizations that explicitly require them.",
+          "title": "Manual Microsoft apps (advanced)",
+          "description": "Create and manage Entra app registrations maintained by your organization.",
           "warning": "A custom Entra app is normally unnecessary on hosted Alga PSA. Continue only when your organization deliberately requires its own application and credentials."
         },
         "platform": {
           "title": "Microsoft email is ready to connect",
           "description": "Connect Microsoft 365 with the application supplied by Alga PSA. No Entra app registration is required.",
-          "readyDescription": "Alga PSA supplies and manages the Microsoft application. Connect a mailbox without creating an Entra app or entering client credentials.",
-          "connectAction": "Connect Microsoft email",
+          "readyDescription": "The Microsoft app is approved and ready for mailbox sign-in.",
+          "connectAction": "Connect a mailbox →",
           "unavailableTitle": "Platform Microsoft credentials are unavailable",
-          "unavailableDescription": "This deployment requires a tenant-owned Microsoft app. Use the advanced setup below to add one."
+          "unavailableDescription": "This deployment requires an app maintained by your organization. Use the advanced setup below to add one."
         },
         "actions": {
           "entraLink": "Microsoft Entra",
@@ -1670,7 +1683,7 @@
           "setDefault": "Establecer este perfil como perfil de Microsoft predeterminado",
           "setDefaultHelp": "Los perfiles predeterminados siguen disponibles para los flujos de gestión de perfiles y los metadatos seguros en la migración, no para el enrutamiento de consumidores.",
           "storedSecretHint": "Secret almacenado: {{secret}}. Deje este campo vacío para mantenerlo sin cambios.",
-          "tenantId": "Tenant ID",
+          "tenantId": "Microsoft tenant ID",
           "capabilities": "Enabled capabilities",
           "capabilitiesHelp": "Only enabled capabilities can bind to this Microsoft app."
         },
@@ -1707,7 +1720,7 @@
           "teamsScopes": "Scopes de Teams",
           "teamsTabRedirect": "URI de redirección de pestaña personal",
           "teamsTitle": "Guía de Teams",
-          "tenantId": "Tenant ID",
+          "tenantId": "Microsoft tenant ID",
           "unavailable": "No disponible"
         },
         "profileCard": {
@@ -1724,7 +1737,7 @@
           "setDefault": "Establecer como predeterminado",
           "storedSecret": "Secret almacenado",
           "teamsAppIdUri": "Application ID URI de Teams",
-          "tenantIdLabel": "Tenant ID:",
+          "tenantIdLabel": "Microsoft tenant ID:",
           "updating": "Actualizando…",
           "enabledCapabilities": "Enabled capabilities",
           "noEnabledCapabilities": "No enabled capabilities"
@@ -1737,13 +1750,14 @@
           "archived": "Los perfiles archivados no pueden utilizarse para nuevos enlaces de Microsoft.",
           "clientIdMissing": "Falta el Client ID.",
           "clientSecretMissing": "No se ha configurado el client secret.",
-          "tenantIdMissing": "Falta el Tenant ID.",
-          "adminConsentPending": "Conceda el consentimiento del administrador del inquilino de Microsoft para finalizar la configuración del correo electrónico."
+          "tenantIdMissing": "Add a Microsoft tenant ID.",
+          "adminConsentPending": "Ask a Microsoft 365 administrator to approve access for Email."
         },
         "statusBadges": {
           "archived": "Archivado",
           "needsAttention": "Requiere atención",
-          "ready": "Listo"
+          "ready": "Listo",
+          "waitingForAdminApproval": "Waiting for admin approval"
         },
         "title": "Microsoft",
         "toasts": {
@@ -1770,7 +1784,7 @@
           "clientIdRequired": "El Microsoft OAuth Client ID es obligatorio",
           "clientSecretRequired": "El Microsoft OAuth Client Secret es obligatorio",
           "displayNameRequired": "El nombre visible del perfil de Microsoft es obligatorio",
-          "tenantIdRequired": "El Microsoft Tenant ID es obligatorio"
+          "tenantIdRequired": "Microsoft tenant ID is required"
         },
         "disconnectDialog": {
           "cancel": "Keep providers connected",

--- a/server/public/locales/fr/msp/email-providers.json
+++ b/server/public/locales/fr/msp/email-providers.json
@@ -42,29 +42,8 @@
       "title": "Instructions de configuration",
       "microsoft": {
         "title": "Configuration de Microsoft 365",
-        "checkingCredentials": "Checking Microsoft credential availability…",
-        "platform": {
-          "title": "Microsoft sign-in is ready",
-          "description": "Alga PSA supplies the Microsoft application. Add a provider, enter the mailbox details, and connect with Microsoft—no Entra app registration is needed."
-        },
-        "byo": {
-          "summary": "Advanced: use your own Microsoft app",
-          "warning": "This is normally unnecessary on hosted Alga PSA and should be used only when your organization requires its own Entra application.",
-          "description": "Open Settings → Integrations → Providers, expand the Microsoft advanced options, and add your tenant-owned app before returning here."
-        },
-        "manualRequired": "Platform Microsoft credentials are unavailable in this deployment. Configure your own Microsoft app to connect a mailbox.",
-        "tenant": {
-          "title": "Your organization’s Microsoft app is selected",
-          "description": "New Microsoft mailboxes will use the tenant-owned app selected in Providers settings. This choice is preserved even when platform credentials are available.",
-          "incompleteTitle": "Your Microsoft app needs attention",
-          "incompleteDescription": "Finish configuring the Microsoft app selected in Providers settings before connecting a mailbox."
-        },
-        "steps": {
-          "registerApp": "Enregistrer une application dans Azure AD",
-          "permissions": "Configurer les autorisations API pour Mail.Read",
-          "redirectUrl": "Configurez l'URL de redirection lors de l'inscription de votre application",
-          "credentials": "Utilisez l'ID client et le secret client dans le formulaire ci-dessus"
-        }
+        "providersPointer": "Microsoft app setup is managed in Providers.",
+        "openProviders": "Open Providers"
       },
       "gmail": {
         "title": "Configuration de Gmail",
@@ -271,22 +250,11 @@
     },
     "microsoft": {
       "hostedOauth": {
-        "sectionTitle": "Connect Microsoft 365",
-        "platformUnavailableDescription": "Platform Microsoft credentials are unavailable in this deployment. Use your own Microsoft app to continue.",
-        "tenantSectionDescription": "Authorize this mailbox with the Microsoft app selected in Providers settings.",
-        "platformSectionDescription": "Alga PSA supplies the Microsoft application. Enter the mailbox details, then sign in with Microsoft.",
-        "platformManagedTitle": "Platform-managed Microsoft app",
-        "platformManagedDescription": "No Entra app registration, client ID, or client secret is required from you.",
-        "byoToggle": "Use your own Microsoft app (advanced)",
-        "byoToggleDescription": "For organizations that deliberately require their own Entra app registration.",
-        "byoWarning": "This is normally unnecessary on hosted Alga PSA. Use it only when your organization requires a tenant-owned Entra application.",
-        "tenantNotConfigured": "Your Microsoft app is not ready yet.",
-        "platformNotConfigured": "Platform Microsoft credentials are unavailable."
+        "sectionTitle": "Connect Microsoft 365"
       },
       "validation": {
         "providerNameRequired": "Le nom de configuration est obligatoire",
         "emailRequired": "Une adresse e-mail valide est requise",
-        "redirectRequired": "Un URI de redirection valide est requis",
         "authorizeRequiresValid": "Veuillez remplir tous les champs obligatoires avant d'autoriser",
         "oauthInitiateFailed": "Échec du lancement d'OAuth",
         "popupBlocked": "Échec de l'ouverture de la fenêtre contextuelle OAuth. Veuillez autoriser les popups pour ce site.",
@@ -296,8 +264,7 @@
       },
       "requiredFields": {
         "providerName": "Nom de configuration",
-        "emailAddress": "Adresse email",
-        "redirectUri": "URI de redirection"
+        "emailAddress": "Adresse email"
       },
       "basic": {
         "title": "Configuration de base",
@@ -310,20 +277,11 @@
         "providerNameHelp": "Nom interne utilisé pour identifier cette configuration. N'apparaît pas dans les e-mails sortants.",
         "senderDisplayNameLabel": "Nom de l'expéditeur",
         "senderDisplayNamePlaceholder": "ex. : Acme Support",
-        "senderDisplayNameHelp": "Nom affiché dans l'en-tête « De » des e-mails de tickets sortants (réponses, clôtures). Appliqué uniquement lorsque cette boîte correspond à l'adresse d'envoi sortante du locataire. Laissez vide pour utiliser le nom du tableau du ticket."
+        "senderDisplayNameHelp": "Display name shown in the From header on outbound ticket emails. It applies when this mailbox matches the configured outbound ticketing address. Leave blank to use the ticket board name."
       },
       "oauth": {
-        "sectionTitle": "Configuration Microsoft OAuth",
-        "sectionDescription": "Les informations d'identification de l'application Microsoft sont configurées dans les paramètres des fournisseurs et réutilisées ici.",
-        "setupLabel": "Microsoft Entrée",
-        "notConfigured": "Les paramètres du fournisseur Microsoft ne sont pas configurés.",
-        "setupHelp": "Configurez d'abord les fournisseurs dans Paramètres → Intégrations → Fournisseurs, puis revenez ici pour autoriser cette boîte aux lettres.",
-        "profileReady": "Le profil de l’application Microsoft est prêt.",
-        "profileReadyHelp": "Si le consentement de l’administrateur du locataire est encore en attente, terminez-le dans les paramètres Fournisseurs. Utilisez ensuite Autoriser l’accès pour cette boîte aux lettres.",
-        "redirectUriLabel": "URI de redirection *",
-        "redirectUriPlaceholder": "https://yourapp.com/api/auth/microsoft/callback",
-        "authorizationTitle": "Autorisation OAuth",
-        "authorizationDescription": "Terminer le flux OAuth pour accorder l'accès à la boîte aux lettres"
+        "signingIn": "Signing in…",
+        "signIn": "Sign in with Microsoft"
       },
       "advanced": {
         "title": "Paramètres avancés",
@@ -332,6 +290,14 @@
         "folderFiltersPlaceholder": "Boîte de réception, support, dossier personnalisé",
         "folderFiltersHelp": "Liste des dossiers à surveiller séparés par des virgules (par défaut : Boîte de réception)",
         "maxEmailsPerSync": "Nombre maximum d'e-mails par synchronisation"
+      },
+      "readiness": {
+        "checking": "Checking Microsoft setup…",
+        "ready": "Microsoft is set up. Sign in as this mailbox to finish.",
+        "pending": "Waiting for your Microsoft 365 administrator. Setup was started in Providers but hasn't been approved yet.",
+        "openProviders": "Open Providers",
+        "notConfigured": "Microsoft isn't set up yet. Set it up once in Providers, then come back.",
+        "setUpInProviders": "Set up in Providers"
       }
     },
     "gmail": {

--- a/server/public/locales/fr/msp/integrations.json
+++ b/server/public/locales/fr/msp/integrations.json
@@ -559,22 +559,22 @@
         },
         "schedule": {
           "cadence": {
-            "10080": "chaque semaine",
-            "1440": "chaque jour",
-            "240": "toutes les 4 heures",
             "60": "toutes les heures",
-            "720": "toutes les 12 heures"
+            "240": "toutes les 4 heures",
+            "720": "toutes les 12 heures",
+            "1440": "chaque jour",
+            "10080": "chaque semaine"
           },
           "changeAction": "Modifier la planification",
           "description": "Lorsqu'elle est activée, Alga synchronise chaque client associé à cette cadence. La désactiver arrête les exécutions planifiées ; vous pouvez toujours synchroniser manuellement.",
           "enablePrompt": "Le pilote a réussi. Activez la synchronisation automatique pour garder les contacts à jour sans intervention.",
           "intervalLabel": "Exécuter toutes les",
           "intervals": {
-            "10080": "Semaine",
-            "1440": "Jour",
-            "240": "4 heures",
             "60": "Heure",
-            "720": "12 heures"
+            "240": "4 heures",
+            "720": "12 heures",
+            "1440": "Jour",
+            "10080": "Semaine"
           },
           "pause": "Mettre en pause",
           "pauseHint": "En pause. Enregistrez pour appliquer.",
@@ -1518,35 +1518,40 @@
     },
     "microsoft": {
       "emailSetup": {
-        "action": "Set up Microsoft Email",
+        "action": "Set up Microsoft",
         "actions": {
           "back": "Back",
           "cancel": "Cancel",
           "copy": "Copy",
           "finish": "Finish",
-          "grantConsent": "Grant administrator consent",
           "savePlatform": "Create profile and continue",
           "signIn": "Sign in to Microsoft",
-          "working": "Working…"
+          "working": "Working…",
+          "approve": "Approve in Microsoft",
+          "copyApprovalLink": "Copy approval link for your admin",
+          "saveManual": "Save app and continue"
         },
         "automated": {
-          "description": "Sign in as a Microsoft administrator. Alga creates the app, service principal, secret, Email profile, and binding.",
-          "title": "Create an app in this tenant"
+          "description": "Alga PSA registers a dedicated Entra app automatically. Sign in as a Microsoft 365 administrator.",
+          "title": "Create an app in your Microsoft organization"
         },
         "callbackUri": "Mailbox callback URI",
         "complete": {
-          "consentDone": "Administrator consent is confirmed. Return to Inbound Email and authorize the mailbox.",
-          "consentPending": "Next, a Microsoft tenant administrator must grant consent. Mailbox authorization happens afterward in Inbound Email.",
-          "profileCreated": "Microsoft Email profile created and bound"
+          "consentDone": "Approved by your Microsoft 365 administrator. You can now connect a mailbox.",
+          "consentPending": "A Microsoft 365 administrator for your organization must approve access before mailboxes can connect.",
+          "profileCreated": "Microsoft Email profile created and bound",
+          "ready": "Microsoft is ready",
+          "waiting": "Waiting for admin approval"
         },
         "consent": {
           "confirmedDescription": "The Microsoft app is ready for mailbox authorization.",
           "confirmedTitle": "Administrator consent confirmed",
           "url": "Administrator consent URL",
-          "urlLabel": "Consent URL"
+          "urlLabel": "Consent URL",
+          "approvalLink": "Approval link"
         },
         "copied": "{{label}} copied",
-        "description": "Choose how to configure the Microsoft app used for inbound email. Mailbox authorization remains a separate final step.",
+        "description": "Choose how Alga PSA connects to Microsoft. You will connect mailboxes separately.",
         "errors": {
           "automated": "Could not start automated Microsoft app creation.",
           "generic": "Microsoft Email setup did not complete.",
@@ -1554,38 +1559,46 @@
           "platform": "Could not configure the platform Microsoft app.",
           "popupBlocked": "Allow popups for this site, then try again.",
           "popupClosed": "La fenêtre Microsoft a été fermée avant la fin de la configuration. Réessayez ou choisissez une autre option de configuration.",
-          "tenantRequired": "Enter your Microsoft tenant ID or verified domain."
+          "tenantRequired": "Enter your Microsoft tenant ID or verified domain.",
+          "manual": "Could not configure the Microsoft app.",
+          "manualRequired": "Enter the display name, client ID, client secret, and Microsoft tenant ID.",
+          "pendingProfileMissing": "The pending Microsoft app could not be found.",
+          "approvalLink": "Could not create the Microsoft approval link."
         },
         "fields": {
           "clientId": "Client ID",
           "displayName": "Profile display name",
-          "tenant": "Microsoft tenant ID or verified domain",
-          "tenantId": "Tenant ID"
+          "tenantId": "Microsoft tenant ID",
+          "clientSecret": "Client secret",
+          "microsoftTenant": "Microsoft tenant ID or verified domain",
+          "redirectUri": "Redirect URI to add in Entra"
         },
         "manual": {
-          "description": "Keep using the existing client ID, tenant ID, and client secret form.",
+          "description": "Use an existing Entra app maintained by your organization.",
           "title": "Enter an existing app manually"
         },
         "platform": {
-          "description": "Create an Email-bound profile from the server-managed multi-tenant app, then grant tenant administrator consent.",
-          "title": "Use the Alga platform app"
+          "description": "Nothing to register in Microsoft Entra. Your Microsoft 365 administrator approves access.",
+          "title": "Use the app provided by Alga PSA"
         },
-        "title": "Set up Microsoft Email",
-        "unavailable": "Unavailable"
+        "title": "Set up Microsoft",
+        "unavailable": "Unavailable",
+        "recommended": "Recommended",
+        "advanced": "Advanced"
       },
       "settings": {
         "advanced": {
-          "title": "Bring your own Microsoft app (advanced)",
-          "description": "Create and manage tenant-owned Entra app registrations for organizations that explicitly require them.",
+          "title": "Manual Microsoft apps (advanced)",
+          "description": "Create and manage Entra app registrations maintained by your organization.",
           "warning": "A custom Entra app is normally unnecessary on hosted Alga PSA. Continue only when your organization deliberately requires its own application and credentials."
         },
         "platform": {
           "title": "Microsoft email is ready to connect",
           "description": "Connect Microsoft 365 with the application supplied by Alga PSA. No Entra app registration is required.",
-          "readyDescription": "Alga PSA supplies and manages the Microsoft application. Connect a mailbox without creating an Entra app or entering client credentials.",
-          "connectAction": "Connect Microsoft email",
+          "readyDescription": "The Microsoft app is approved and ready for mailbox sign-in.",
+          "connectAction": "Connect a mailbox →",
           "unavailableTitle": "Platform Microsoft credentials are unavailable",
-          "unavailableDescription": "This deployment requires a tenant-owned Microsoft app. Use the advanced setup below to add one."
+          "unavailableDescription": "This deployment requires an app maintained by your organization. Use the advanced setup below to add one."
         },
         "actions": {
           "entraLink": "Microsoft Entra",
@@ -1670,7 +1683,7 @@
           "setDefault": "Définir ce profil comme profil Microsoft par défaut",
           "setDefaultHelp": "Les profils par défaut restent disponibles pour les workflows de gestion de profil et les métadonnées sûres pour la migration, mais pas pour le routage de consommateur.",
           "storedSecretHint": "Secret enregistré : {{secret}}. Laissez ce champ vide pour le conserver inchangé.",
-          "tenantId": "Tenant ID",
+          "tenantId": "Microsoft tenant ID",
           "capabilities": "Enabled capabilities",
           "capabilitiesHelp": "Only enabled capabilities can bind to this Microsoft app."
         },
@@ -1707,7 +1720,7 @@
           "teamsScopes": "Scopes Teams",
           "teamsTabRedirect": "Redirect URI d'onglet personnel",
           "teamsTitle": "Guide Teams",
-          "tenantId": "Tenant ID",
+          "tenantId": "Microsoft tenant ID",
           "unavailable": "Indisponible"
         },
         "profileCard": {
@@ -1724,7 +1737,7 @@
           "setDefault": "Définir par défaut",
           "storedSecret": "Secret enregistré",
           "teamsAppIdUri": "Application ID URI Teams",
-          "tenantIdLabel": "Tenant ID :",
+          "tenantIdLabel": "Microsoft tenant ID:",
           "updating": "Mise à jour…",
           "enabledCapabilities": "Enabled capabilities",
           "noEnabledCapabilities": "No enabled capabilities"
@@ -1737,13 +1750,14 @@
           "archived": "Les profils archivés ne peuvent pas être utilisés pour de nouvelles liaisons Microsoft.",
           "clientIdMissing": "Le Client ID est manquant.",
           "clientSecretMissing": "Le client secret n'a pas été configuré.",
-          "tenantIdMissing": "Le Tenant ID est manquant.",
-          "adminConsentPending": "Accordez le consentement de l’administrateur du locataire Microsoft pour terminer la configuration de la messagerie."
+          "tenantIdMissing": "Add a Microsoft tenant ID.",
+          "adminConsentPending": "Ask a Microsoft 365 administrator to approve access for Email."
         },
         "statusBadges": {
           "archived": "Archivé",
           "needsAttention": "Nécessite une attention",
-          "ready": "Prêt"
+          "ready": "Prêt",
+          "waitingForAdminApproval": "Waiting for admin approval"
         },
         "title": "Microsoft",
         "toasts": {
@@ -1770,7 +1784,7 @@
           "clientIdRequired": "Le Microsoft OAuth Client ID est requis",
           "clientSecretRequired": "Le Microsoft OAuth Client Secret est requis",
           "displayNameRequired": "Le nom affiché du profil Microsoft est requis",
-          "tenantIdRequired": "Le Microsoft Tenant ID est requis"
+          "tenantIdRequired": "Microsoft tenant ID is required"
         },
         "disconnectDialog": {
           "cancel": "Keep providers connected",

--- a/server/public/locales/it/msp/email-providers.json
+++ b/server/public/locales/it/msp/email-providers.json
@@ -42,29 +42,8 @@
       "title": "Istruzioni per l'installazione",
       "microsoft": {
         "title": "Installazione di Microsoft 365",
-        "checkingCredentials": "Checking Microsoft credential availability…",
-        "platform": {
-          "title": "Microsoft sign-in is ready",
-          "description": "Alga PSA supplies the Microsoft application. Add a provider, enter the mailbox details, and connect with Microsoft—no Entra app registration is needed."
-        },
-        "byo": {
-          "summary": "Advanced: use your own Microsoft app",
-          "warning": "This is normally unnecessary on hosted Alga PSA and should be used only when your organization requires its own Entra application.",
-          "description": "Open Settings → Integrations → Providers, expand the Microsoft advanced options, and add your tenant-owned app before returning here."
-        },
-        "manualRequired": "Platform Microsoft credentials are unavailable in this deployment. Configure your own Microsoft app to connect a mailbox.",
-        "tenant": {
-          "title": "Your organization’s Microsoft app is selected",
-          "description": "New Microsoft mailboxes will use the tenant-owned app selected in Providers settings. This choice is preserved even when platform credentials are available.",
-          "incompleteTitle": "Your Microsoft app needs attention",
-          "incompleteDescription": "Finish configuring the Microsoft app selected in Providers settings before connecting a mailbox."
-        },
-        "steps": {
-          "registerApp": "Registra un'applicazione in Azure AD",
-          "permissions": "Configura le autorizzazioni API per Mail.Read",
-          "redirectUrl": "Imposta l'URL di reindirizzamento nella registrazione dell'app",
-          "credentials": "Utilizza l'ID cliente e il segreto cliente nel modulo sopra"
-        }
+        "providersPointer": "Microsoft app setup is managed in Providers.",
+        "openProviders": "Open Providers"
       },
       "gmail": {
         "title": "Configurazione di Gmail",
@@ -271,22 +250,11 @@
     },
     "microsoft": {
       "hostedOauth": {
-        "sectionTitle": "Connect Microsoft 365",
-        "platformUnavailableDescription": "Platform Microsoft credentials are unavailable in this deployment. Use your own Microsoft app to continue.",
-        "tenantSectionDescription": "Authorize this mailbox with the Microsoft app selected in Providers settings.",
-        "platformSectionDescription": "Alga PSA supplies the Microsoft application. Enter the mailbox details, then sign in with Microsoft.",
-        "platformManagedTitle": "Platform-managed Microsoft app",
-        "platformManagedDescription": "No Entra app registration, client ID, or client secret is required from you.",
-        "byoToggle": "Use your own Microsoft app (advanced)",
-        "byoToggleDescription": "For organizations that deliberately require their own Entra app registration.",
-        "byoWarning": "This is normally unnecessary on hosted Alga PSA. Use it only when your organization requires a tenant-owned Entra application.",
-        "tenantNotConfigured": "Your Microsoft app is not ready yet.",
-        "platformNotConfigured": "Platform Microsoft credentials are unavailable."
+        "sectionTitle": "Connect Microsoft 365"
       },
       "validation": {
         "providerNameRequired": "Il nome della configurazione è obbligatorio",
         "emailRequired": "È richiesto un indirizzo email valido",
-        "redirectRequired": "È richiesto un URI di reindirizzamento valido",
         "authorizeRequiresValid": "Si prega di compilare tutti i campi obbligatori prima di autorizzare",
         "oauthInitiateFailed": "Impossibile avviare OAuth",
         "popupBlocked": "Impossibile aprire il popup OAuth. Si prega di consentire i popup per questo sito.",
@@ -296,8 +264,7 @@
       },
       "requiredFields": {
         "providerName": "Nome configurazione",
-        "emailAddress": "Indirizzo e-mail",
-        "redirectUri": "URI di reindirizzamento"
+        "emailAddress": "Indirizzo e-mail"
       },
       "basic": {
         "title": "Configurazione di base",
@@ -310,20 +277,11 @@
         "providerNameHelp": "Nome interno usato per identificare questa configurazione. Non viene mostrato nelle email in uscita.",
         "senderDisplayNameLabel": "Nome visualizzato del mittente",
         "senderDisplayNamePlaceholder": "es. Acme Support",
-        "senderDisplayNameHelp": "Nome visualizzato nel campo Da delle email di ticket in uscita (risposte, chiusure). Applicato solo quando questa casella corrisponde all'indirizzo di invio in uscita del tenant. Lascia vuoto per usare il nome della board del ticket."
+        "senderDisplayNameHelp": "Display name shown in the From header on outbound ticket emails. It applies when this mailbox matches the configured outbound ticketing address. Leave blank to use the ticket board name."
       },
       "oauth": {
-        "sectionTitle": "Configurazione Microsoft OAuth",
-        "sectionDescription": "Le credenziali dell'app Microsoft vengono configurate nelle impostazioni dei provider e riutilizzate qui.",
-        "setupLabel": "Microsoft Entra",
-        "notConfigured": "Le impostazioni del provider Microsoft non sono configurate.",
-        "setupHelp": "Configura prima i provider in Impostazioni → Integrazioni → Provider, quindi torna qui per autorizzare questa casella di posta.",
-        "profileReady": "Il profilo dell’app Microsoft è pronto.",
-        "profileReadyHelp": "Se il consenso dell’amministratore del tenant è ancora in sospeso, completalo nelle impostazioni Provider. Quindi usa Autorizza accesso per questa casella di posta.",
-        "redirectUriLabel": "URI di reindirizzamento *",
-        "redirectUriPlaceholder": "https://yourapp.com/api/auth/microsoft/callback",
-        "authorizationTitle": "Autorizzazione OAuth",
-        "authorizationDescription": "Completa il flusso OAuth per concedere l'accesso alla casella di posta"
+        "signingIn": "Signing in…",
+        "signIn": "Sign in with Microsoft"
       },
       "advanced": {
         "title": "Impostazioni avanzate",
@@ -332,6 +290,14 @@
         "folderFiltersPlaceholder": "Posta in arrivo, Supporto, Cartella personalizzata",
         "folderFiltersHelp": "Elenco separato da virgole di cartelle da monitorare (impostazione predefinita: Posta in arrivo)",
         "maxEmailsPerSync": "Numero massimo di email per sincronizzazione"
+      },
+      "readiness": {
+        "checking": "Checking Microsoft setup…",
+        "ready": "Microsoft is set up. Sign in as this mailbox to finish.",
+        "pending": "Waiting for your Microsoft 365 administrator. Setup was started in Providers but hasn't been approved yet.",
+        "openProviders": "Open Providers",
+        "notConfigured": "Microsoft isn't set up yet. Set it up once in Providers, then come back.",
+        "setUpInProviders": "Set up in Providers"
       }
     },
     "gmail": {

--- a/server/public/locales/it/msp/integrations.json
+++ b/server/public/locales/it/msp/integrations.json
@@ -559,22 +559,22 @@
         },
         "schedule": {
           "cadence": {
-            "10080": "ogni settimana",
-            "1440": "ogni giorno",
-            "240": "ogni 4 ore",
             "60": "ogni ora",
-            "720": "ogni 12 ore"
+            "240": "ogni 4 ore",
+            "720": "ogni 12 ore",
+            "1440": "ogni giorno",
+            "10080": "ogni settimana"
           },
           "changeAction": "Modifica pianificazione",
           "description": "Se attiva, Alga sincronizza ogni client associato con questa cadenza. Disattivandola si fermano le esecuzioni pianificate; puoi comunque sincronizzare manualmente.",
           "enablePrompt": "Il pilota è riuscito. Attiva la sincronizzazione automatica per mantenere allineati i contatti senza eseguirla a mano.",
           "intervalLabel": "Esegui ogni",
           "intervals": {
-            "10080": "Settimana",
-            "1440": "Giorno",
-            "240": "4 ore",
             "60": "Ora",
-            "720": "12 ore"
+            "240": "4 ore",
+            "720": "12 ore",
+            "1440": "Giorno",
+            "10080": "Settimana"
           },
           "pause": "Sospendi",
           "pauseHint": "Sospesa. Salva per applicare.",
@@ -1518,35 +1518,40 @@
     },
     "microsoft": {
       "emailSetup": {
-        "action": "Set up Microsoft Email",
+        "action": "Set up Microsoft",
         "actions": {
           "back": "Back",
           "cancel": "Cancel",
           "copy": "Copy",
           "finish": "Finish",
-          "grantConsent": "Grant administrator consent",
           "savePlatform": "Create profile and continue",
           "signIn": "Sign in to Microsoft",
-          "working": "Working…"
+          "working": "Working…",
+          "approve": "Approve in Microsoft",
+          "copyApprovalLink": "Copy approval link for your admin",
+          "saveManual": "Save app and continue"
         },
         "automated": {
-          "description": "Sign in as a Microsoft administrator. Alga creates the app, service principal, secret, Email profile, and binding.",
-          "title": "Create an app in this tenant"
+          "description": "Alga PSA registers a dedicated Entra app automatically. Sign in as a Microsoft 365 administrator.",
+          "title": "Create an app in your Microsoft organization"
         },
         "callbackUri": "Mailbox callback URI",
         "complete": {
-          "consentDone": "Administrator consent is confirmed. Return to Inbound Email and authorize the mailbox.",
-          "consentPending": "Next, a Microsoft tenant administrator must grant consent. Mailbox authorization happens afterward in Inbound Email.",
-          "profileCreated": "Microsoft Email profile created and bound"
+          "consentDone": "Approved by your Microsoft 365 administrator. You can now connect a mailbox.",
+          "consentPending": "A Microsoft 365 administrator for your organization must approve access before mailboxes can connect.",
+          "profileCreated": "Microsoft Email profile created and bound",
+          "ready": "Microsoft is ready",
+          "waiting": "Waiting for admin approval"
         },
         "consent": {
           "confirmedDescription": "The Microsoft app is ready for mailbox authorization.",
           "confirmedTitle": "Administrator consent confirmed",
           "url": "Administrator consent URL",
-          "urlLabel": "Consent URL"
+          "urlLabel": "Consent URL",
+          "approvalLink": "Approval link"
         },
         "copied": "{{label}} copied",
-        "description": "Choose how to configure the Microsoft app used for inbound email. Mailbox authorization remains a separate final step.",
+        "description": "Choose how Alga PSA connects to Microsoft. You will connect mailboxes separately.",
         "errors": {
           "automated": "Could not start automated Microsoft app creation.",
           "generic": "Microsoft Email setup did not complete.",
@@ -1554,38 +1559,46 @@
           "platform": "Could not configure the platform Microsoft app.",
           "popupBlocked": "Allow popups for this site, then try again.",
           "popupClosed": "La finestra Microsoft è stata chiusa prima del completamento della configurazione. Riprova o scegli un’altra opzione di configurazione.",
-          "tenantRequired": "Enter your Microsoft tenant ID or verified domain."
+          "tenantRequired": "Enter your Microsoft tenant ID or verified domain.",
+          "manual": "Could not configure the Microsoft app.",
+          "manualRequired": "Enter the display name, client ID, client secret, and Microsoft tenant ID.",
+          "pendingProfileMissing": "The pending Microsoft app could not be found.",
+          "approvalLink": "Could not create the Microsoft approval link."
         },
         "fields": {
           "clientId": "Client ID",
           "displayName": "Profile display name",
-          "tenant": "Microsoft tenant ID or verified domain",
-          "tenantId": "Tenant ID"
+          "tenantId": "Microsoft tenant ID",
+          "clientSecret": "Client secret",
+          "microsoftTenant": "Microsoft tenant ID or verified domain",
+          "redirectUri": "Redirect URI to add in Entra"
         },
         "manual": {
-          "description": "Keep using the existing client ID, tenant ID, and client secret form.",
+          "description": "Use an existing Entra app maintained by your organization.",
           "title": "Enter an existing app manually"
         },
         "platform": {
-          "description": "Create an Email-bound profile from the server-managed multi-tenant app, then grant tenant administrator consent.",
-          "title": "Use the Alga platform app"
+          "description": "Nothing to register in Microsoft Entra. Your Microsoft 365 administrator approves access.",
+          "title": "Use the app provided by Alga PSA"
         },
-        "title": "Set up Microsoft Email",
-        "unavailable": "Unavailable"
+        "title": "Set up Microsoft",
+        "unavailable": "Unavailable",
+        "recommended": "Recommended",
+        "advanced": "Advanced"
       },
       "settings": {
         "advanced": {
-          "title": "Bring your own Microsoft app (advanced)",
-          "description": "Create and manage tenant-owned Entra app registrations for organizations that explicitly require them.",
+          "title": "Manual Microsoft apps (advanced)",
+          "description": "Create and manage Entra app registrations maintained by your organization.",
           "warning": "A custom Entra app is normally unnecessary on hosted Alga PSA. Continue only when your organization deliberately requires its own application and credentials."
         },
         "platform": {
           "title": "Microsoft email is ready to connect",
           "description": "Connect Microsoft 365 with the application supplied by Alga PSA. No Entra app registration is required.",
-          "readyDescription": "Alga PSA supplies and manages the Microsoft application. Connect a mailbox without creating an Entra app or entering client credentials.",
-          "connectAction": "Connect Microsoft email",
+          "readyDescription": "The Microsoft app is approved and ready for mailbox sign-in.",
+          "connectAction": "Connect a mailbox →",
           "unavailableTitle": "Platform Microsoft credentials are unavailable",
-          "unavailableDescription": "This deployment requires a tenant-owned Microsoft app. Use the advanced setup below to add one."
+          "unavailableDescription": "This deployment requires an app maintained by your organization. Use the advanced setup below to add one."
         },
         "actions": {
           "entraLink": "Microsoft Entra",
@@ -1670,7 +1683,7 @@
           "setDefault": "Imposta questo profilo come profilo Microsoft predefinito",
           "setDefaultHelp": "I profili predefiniti restano disponibili per i flussi di gestione del profilo e per i metadati sicuri per la migrazione, non per il routing dei consumer.",
           "storedSecretHint": "Secret memorizzato: {{secret}}. Lascia questo campo vuoto per mantenerlo invariato.",
-          "tenantId": "Tenant ID",
+          "tenantId": "Microsoft tenant ID",
           "capabilities": "Enabled capabilities",
           "capabilitiesHelp": "Only enabled capabilities can bind to this Microsoft app."
         },
@@ -1707,7 +1720,7 @@
           "teamsScopes": "Scope Teams",
           "teamsTabRedirect": "Redirect URI del tab personale",
           "teamsTitle": "Guida Teams",
-          "tenantId": "Tenant ID",
+          "tenantId": "Microsoft tenant ID",
           "unavailable": "Non disponibile"
         },
         "profileCard": {
@@ -1724,7 +1737,7 @@
           "setDefault": "Imposta come predefinito",
           "storedSecret": "Secret memorizzato",
           "teamsAppIdUri": "Application ID URI Teams",
-          "tenantIdLabel": "Tenant ID:",
+          "tenantIdLabel": "Microsoft tenant ID:",
           "updating": "Aggiornamento…",
           "enabledCapabilities": "Enabled capabilities",
           "noEnabledCapabilities": "No enabled capabilities"
@@ -1737,13 +1750,14 @@
           "archived": "I profili archiviati non possono essere utilizzati per nuovi collegamenti Microsoft.",
           "clientIdMissing": "Client ID mancante.",
           "clientSecretMissing": "Il client secret non è stato configurato.",
-          "tenantIdMissing": "Tenant ID mancante.",
-          "adminConsentPending": "Concedi il consenso dell’amministratore del tenant Microsoft per completare la configurazione Email."
+          "tenantIdMissing": "Add a Microsoft tenant ID.",
+          "adminConsentPending": "Ask a Microsoft 365 administrator to approve access for Email."
         },
         "statusBadges": {
           "archived": "Archiviato",
           "needsAttention": "Richiede attenzione",
-          "ready": "Pronto"
+          "ready": "Pronto",
+          "waitingForAdminApproval": "Waiting for admin approval"
         },
         "title": "Microsoft",
         "toasts": {
@@ -1770,7 +1784,7 @@
           "clientIdRequired": "Il Microsoft OAuth Client ID è obbligatorio",
           "clientSecretRequired": "Il Microsoft OAuth Client Secret è obbligatorio",
           "displayNameRequired": "Il nome visualizzato del profilo Microsoft è obbligatorio",
-          "tenantIdRequired": "Il Microsoft Tenant ID è obbligatorio"
+          "tenantIdRequired": "Microsoft tenant ID is required"
         },
         "disconnectDialog": {
           "cancel": "Keep providers connected",

--- a/server/public/locales/nl/msp/email-providers.json
+++ b/server/public/locales/nl/msp/email-providers.json
@@ -42,29 +42,8 @@
       "title": "Installatie-instructies",
       "microsoft": {
         "title": "Microsoft 365-installatie",
-        "checkingCredentials": "Checking Microsoft credential availability…",
-        "platform": {
-          "title": "Microsoft sign-in is ready",
-          "description": "Alga PSA supplies the Microsoft application. Add a provider, enter the mailbox details, and connect with Microsoft—no Entra app registration is needed."
-        },
-        "byo": {
-          "summary": "Advanced: use your own Microsoft app",
-          "warning": "This is normally unnecessary on hosted Alga PSA and should be used only when your organization requires its own Entra application.",
-          "description": "Open Settings → Integrations → Providers, expand the Microsoft advanced options, and add your tenant-owned app before returning here."
-        },
-        "manualRequired": "Platform Microsoft credentials are unavailable in this deployment. Configure your own Microsoft app to connect a mailbox.",
-        "tenant": {
-          "title": "Your organization’s Microsoft app is selected",
-          "description": "New Microsoft mailboxes will use the tenant-owned app selected in Providers settings. This choice is preserved even when platform credentials are available.",
-          "incompleteTitle": "Your Microsoft app needs attention",
-          "incompleteDescription": "Finish configuring the Microsoft app selected in Providers settings before connecting a mailbox."
-        },
-        "steps": {
-          "registerApp": "Registreer een toepassing in Azure AD",
-          "permissions": "Configureer API-rechten voor Mail.Read",
-          "redirectUrl": "Stel de omleidings-URL in uw app-registratie in",
-          "credentials": "Gebruik het klant-ID en klantgeheim in het bovenstaande formulier"
-        }
+        "providersPointer": "Microsoft app setup is managed in Providers.",
+        "openProviders": "Open Providers"
       },
       "gmail": {
         "title": "Gmail-configuratie",
@@ -271,22 +250,11 @@
     },
     "microsoft": {
       "hostedOauth": {
-        "sectionTitle": "Connect Microsoft 365",
-        "platformUnavailableDescription": "Platform Microsoft credentials are unavailable in this deployment. Use your own Microsoft app to continue.",
-        "tenantSectionDescription": "Authorize this mailbox with the Microsoft app selected in Providers settings.",
-        "platformSectionDescription": "Alga PSA supplies the Microsoft application. Enter the mailbox details, then sign in with Microsoft.",
-        "platformManagedTitle": "Platform-managed Microsoft app",
-        "platformManagedDescription": "No Entra app registration, client ID, or client secret is required from you.",
-        "byoToggle": "Use your own Microsoft app (advanced)",
-        "byoToggleDescription": "For organizations that deliberately require their own Entra app registration.",
-        "byoWarning": "This is normally unnecessary on hosted Alga PSA. Use it only when your organization requires a tenant-owned Entra application.",
-        "tenantNotConfigured": "Your Microsoft app is not ready yet.",
-        "platformNotConfigured": "Platform Microsoft credentials are unavailable."
+        "sectionTitle": "Connect Microsoft 365"
       },
       "validation": {
         "providerNameRequired": "Configuratienaam is verplicht",
         "emailRequired": "Een geldig e-mailadres is vereist",
-        "redirectRequired": "Een geldige omleidings-URI is vereist",
         "authorizeRequiresValid": "Vul alle verplichte velden in voordat u autoriseert",
         "oauthInitiateFailed": "Kan OAuth niet starten",
         "popupBlocked": "Kan de OAuth-pop-up niet openen. Sta pop-ups toe voor deze site.",
@@ -296,8 +264,7 @@
       },
       "requiredFields": {
         "providerName": "Configuratienaam",
-        "emailAddress": "E-mailadres",
-        "redirectUri": "Omleidings-URI"
+        "emailAddress": "E-mailadres"
       },
       "basic": {
         "title": "Basisconfiguratie",
@@ -310,20 +277,11 @@
         "providerNameHelp": "Interne naam gebruikt om deze configuratie te identificeren. Niet zichtbaar in uitgaande e-mails.",
         "senderDisplayNameLabel": "Weergavenaam afzender",
         "senderDisplayNamePlaceholder": "bv. Acme Support",
-        "senderDisplayNameHelp": "Weergavenaam in het Van-veld van uitgaande ticket-e-mails (antwoorden, sluitingen). Alleen toegepast wanneer deze mailbox overeenkomt met het uitgaande ticket-verzendadres van de tenant. Laat leeg om de boardnaam van het ticket te gebruiken."
+        "senderDisplayNameHelp": "Display name shown in the From header on outbound ticket emails. It applies when this mailbox matches the configured outbound ticketing address. Leave blank to use the ticket board name."
       },
       "oauth": {
-        "sectionTitle": "Microsoft OAuth-configuratie",
-        "sectionDescription": "Inloggegevens voor Microsoft-apps worden geconfigureerd in Providers-instellingen en hier opnieuw gebruikt.",
-        "setupLabel": "Microsoft Entra",
-        "notConfigured": "Microsoft-providerinstellingen zijn niet geconfigureerd.",
-        "setupHelp": "Configureer eerst Providers in Instellingen → Integraties → Providers en kom dan hier terug om deze mailbox te autoriseren.",
-        "profileReady": "Het Microsoft-app-profiel is gereed.",
-        "profileReadyHelp": "Als toestemming van de tenantbeheerder nog ontbreekt, voltooi die dan in de Providerinstellingen. Gebruik daarna Toegang autoriseren voor deze mailbox.",
-        "redirectUriLabel": "Omleidings-URI *",
-        "redirectUriPlaceholder": "https://uwapp.com/api/auth/microsoft/callback",
-        "authorizationTitle": "OAuth-autorisatie",
-        "authorizationDescription": "Voltooi de OAuth-stroom om toegang tot het postvak te verlenen"
+        "signingIn": "Signing in…",
+        "signIn": "Sign in with Microsoft"
       },
       "advanced": {
         "title": "Geavanceerde instellingen",
@@ -332,6 +290,14 @@
         "folderFiltersPlaceholder": "Inbox, Ondersteuning, Aangepaste map",
         "folderFiltersHelp": "Door komma's gescheiden lijst met mappen die moeten worden gecontroleerd (standaard: Inbox)",
         "maxEmailsPerSync": "Max. e-mails per synchronisatie"
+      },
+      "readiness": {
+        "checking": "Checking Microsoft setup…",
+        "ready": "Microsoft is set up. Sign in as this mailbox to finish.",
+        "pending": "Waiting for your Microsoft 365 administrator. Setup was started in Providers but hasn't been approved yet.",
+        "openProviders": "Open Providers",
+        "notConfigured": "Microsoft isn't set up yet. Set it up once in Providers, then come back.",
+        "setUpInProviders": "Set up in Providers"
       }
     },
     "gmail": {

--- a/server/public/locales/nl/msp/integrations.json
+++ b/server/public/locales/nl/msp/integrations.json
@@ -559,22 +559,22 @@
         },
         "schedule": {
           "cadence": {
-            "10080": "elke week",
-            "1440": "elke dag",
-            "240": "elke 4 uur",
             "60": "elk uur",
-            "720": "elke 12 uur"
+            "240": "elke 4 uur",
+            "720": "elke 12 uur",
+            "1440": "elke dag",
+            "10080": "elke week"
           },
           "changeAction": "Schema wijzigen",
           "description": "Wanneer aan, synchroniseert Alga elke gekoppelde klant met dit ritme. Uitzetten stopt geplande runs; handmatig synchroniseren blijft mogelijk.",
           "enablePrompt": "De pilot is geslaagd. Zet automatische synchronisatie aan om contacten bij te houden zonder handmatige runs.",
           "intervalLabel": "Uitvoeren elke",
           "intervals": {
-            "10080": "Week",
-            "1440": "Dag",
-            "240": "4 uur",
             "60": "Uur",
-            "720": "12 uur"
+            "240": "4 uur",
+            "720": "12 uur",
+            "1440": "Dag",
+            "10080": "Week"
           },
           "pause": "Pauzeren",
           "pauseHint": "Gepauzeerd. Sla op om toe te passen.",
@@ -1518,35 +1518,40 @@
     },
     "microsoft": {
       "emailSetup": {
-        "action": "Set up Microsoft Email",
+        "action": "Set up Microsoft",
         "actions": {
           "back": "Back",
           "cancel": "Cancel",
           "copy": "Copy",
           "finish": "Finish",
-          "grantConsent": "Grant administrator consent",
           "savePlatform": "Create profile and continue",
           "signIn": "Sign in to Microsoft",
-          "working": "Working…"
+          "working": "Working…",
+          "approve": "Approve in Microsoft",
+          "copyApprovalLink": "Copy approval link for your admin",
+          "saveManual": "Save app and continue"
         },
         "automated": {
-          "description": "Sign in as a Microsoft administrator. Alga creates the app, service principal, secret, Email profile, and binding.",
-          "title": "Create an app in this tenant"
+          "description": "Alga PSA registers a dedicated Entra app automatically. Sign in as a Microsoft 365 administrator.",
+          "title": "Create an app in your Microsoft organization"
         },
         "callbackUri": "Mailbox callback URI",
         "complete": {
-          "consentDone": "Administrator consent is confirmed. Return to Inbound Email and authorize the mailbox.",
-          "consentPending": "Next, a Microsoft tenant administrator must grant consent. Mailbox authorization happens afterward in Inbound Email.",
-          "profileCreated": "Microsoft Email profile created and bound"
+          "consentDone": "Approved by your Microsoft 365 administrator. You can now connect a mailbox.",
+          "consentPending": "A Microsoft 365 administrator for your organization must approve access before mailboxes can connect.",
+          "profileCreated": "Microsoft Email profile created and bound",
+          "ready": "Microsoft is ready",
+          "waiting": "Waiting for admin approval"
         },
         "consent": {
           "confirmedDescription": "The Microsoft app is ready for mailbox authorization.",
           "confirmedTitle": "Administrator consent confirmed",
           "url": "Administrator consent URL",
-          "urlLabel": "Consent URL"
+          "urlLabel": "Consent URL",
+          "approvalLink": "Approval link"
         },
         "copied": "{{label}} copied",
-        "description": "Choose how to configure the Microsoft app used for inbound email. Mailbox authorization remains a separate final step.",
+        "description": "Choose how Alga PSA connects to Microsoft. You will connect mailboxes separately.",
         "errors": {
           "automated": "Could not start automated Microsoft app creation.",
           "generic": "Microsoft Email setup did not complete.",
@@ -1554,38 +1559,46 @@
           "platform": "Could not configure the platform Microsoft app.",
           "popupBlocked": "Allow popups for this site, then try again.",
           "popupClosed": "Het Microsoft-venster is gesloten voordat de configuratie was voltooid. Probeer het opnieuw of kies een andere configuratieoptie.",
-          "tenantRequired": "Enter your Microsoft tenant ID or verified domain."
+          "tenantRequired": "Enter your Microsoft tenant ID or verified domain.",
+          "manual": "Could not configure the Microsoft app.",
+          "manualRequired": "Enter the display name, client ID, client secret, and Microsoft tenant ID.",
+          "pendingProfileMissing": "The pending Microsoft app could not be found.",
+          "approvalLink": "Could not create the Microsoft approval link."
         },
         "fields": {
           "clientId": "Client ID",
           "displayName": "Profile display name",
-          "tenant": "Microsoft tenant ID or verified domain",
-          "tenantId": "Tenant ID"
+          "tenantId": "Microsoft tenant ID",
+          "clientSecret": "Client secret",
+          "microsoftTenant": "Microsoft tenant ID or verified domain",
+          "redirectUri": "Redirect URI to add in Entra"
         },
         "manual": {
-          "description": "Keep using the existing client ID, tenant ID, and client secret form.",
+          "description": "Use an existing Entra app maintained by your organization.",
           "title": "Enter an existing app manually"
         },
         "platform": {
-          "description": "Create an Email-bound profile from the server-managed multi-tenant app, then grant tenant administrator consent.",
-          "title": "Use the Alga platform app"
+          "description": "Nothing to register in Microsoft Entra. Your Microsoft 365 administrator approves access.",
+          "title": "Use the app provided by Alga PSA"
         },
-        "title": "Set up Microsoft Email",
-        "unavailable": "Unavailable"
+        "title": "Set up Microsoft",
+        "unavailable": "Unavailable",
+        "recommended": "Recommended",
+        "advanced": "Advanced"
       },
       "settings": {
         "advanced": {
-          "title": "Bring your own Microsoft app (advanced)",
-          "description": "Create and manage tenant-owned Entra app registrations for organizations that explicitly require them.",
+          "title": "Manual Microsoft apps (advanced)",
+          "description": "Create and manage Entra app registrations maintained by your organization.",
           "warning": "A custom Entra app is normally unnecessary on hosted Alga PSA. Continue only when your organization deliberately requires its own application and credentials."
         },
         "platform": {
           "title": "Microsoft email is ready to connect",
           "description": "Connect Microsoft 365 with the application supplied by Alga PSA. No Entra app registration is required.",
-          "readyDescription": "Alga PSA supplies and manages the Microsoft application. Connect a mailbox without creating an Entra app or entering client credentials.",
-          "connectAction": "Connect Microsoft email",
+          "readyDescription": "The Microsoft app is approved and ready for mailbox sign-in.",
+          "connectAction": "Connect a mailbox →",
           "unavailableTitle": "Platform Microsoft credentials are unavailable",
-          "unavailableDescription": "This deployment requires a tenant-owned Microsoft app. Use the advanced setup below to add one."
+          "unavailableDescription": "This deployment requires an app maintained by your organization. Use the advanced setup below to add one."
         },
         "actions": {
           "entraLink": "Microsoft Entra",
@@ -1670,7 +1683,7 @@
           "setDefault": "Dit profiel instellen als standaard Microsoft-profiel",
           "setDefaultHelp": "Standaardprofielen blijven beschikbaar voor profielbeheer-workflows en migratieveilige metadata, niet voor consumer-routing.",
           "storedSecretHint": "Opgeslagen secret: {{secret}}. Laat dit veld leeg om het ongewijzigd te houden.",
-          "tenantId": "Tenant ID",
+          "tenantId": "Microsoft tenant ID",
           "capabilities": "Enabled capabilities",
           "capabilitiesHelp": "Only enabled capabilities can bind to this Microsoft app."
         },
@@ -1707,7 +1720,7 @@
           "teamsScopes": "Teams-scopes",
           "teamsTabRedirect": "Redirect-URI persoonlijk tabblad",
           "teamsTitle": "Teams-handleiding",
-          "tenantId": "Tenant ID",
+          "tenantId": "Microsoft tenant ID",
           "unavailable": "Niet beschikbaar"
         },
         "profileCard": {
@@ -1724,7 +1737,7 @@
           "setDefault": "Instellen als standaard",
           "storedSecret": "Opgeslagen secret",
           "teamsAppIdUri": "Teams Application ID URI",
-          "tenantIdLabel": "Tenant ID:",
+          "tenantIdLabel": "Microsoft tenant ID:",
           "updating": "Bijwerken…",
           "enabledCapabilities": "Enabled capabilities",
           "noEnabledCapabilities": "No enabled capabilities"
@@ -1737,13 +1750,14 @@
           "archived": "Gearchiveerde profielen kunnen niet worden gebruikt voor nieuwe Microsoft-bindingen.",
           "clientIdMissing": "Client ID ontbreekt.",
           "clientSecretMissing": "Client secret is niet geconfigureerd.",
-          "tenantIdMissing": "Tenant ID ontbreekt.",
-          "adminConsentPending": "Verleen toestemming van de Microsoft-tenantbeheerder om de e-mailconfiguratie te voltooien."
+          "tenantIdMissing": "Add a Microsoft tenant ID.",
+          "adminConsentPending": "Ask a Microsoft 365 administrator to approve access for Email."
         },
         "statusBadges": {
           "archived": "Gearchiveerd",
           "needsAttention": "Vereist aandacht",
-          "ready": "Gereed"
+          "ready": "Gereed",
+          "waitingForAdminApproval": "Waiting for admin approval"
         },
         "title": "Microsoft",
         "toasts": {
@@ -1770,7 +1784,7 @@
           "clientIdRequired": "Microsoft OAuth Client ID is verplicht",
           "clientSecretRequired": "Microsoft OAuth Client Secret is verplicht",
           "displayNameRequired": "Weergavenaam van Microsoft-profiel is verplicht",
-          "tenantIdRequired": "Microsoft Tenant ID is verplicht"
+          "tenantIdRequired": "Microsoft tenant ID is required"
         },
         "disconnectDialog": {
           "cancel": "Keep providers connected",

--- a/server/public/locales/pl/msp/email-providers.json
+++ b/server/public/locales/pl/msp/email-providers.json
@@ -42,29 +42,8 @@
       "title": "Instrukcje konfiguracji",
       "microsoft": {
         "title": "Konfiguracja Microsoft 365",
-        "checkingCredentials": "Checking Microsoft credential availability…",
-        "platform": {
-          "title": "Microsoft sign-in is ready",
-          "description": "Alga PSA supplies the Microsoft application. Add a provider, enter the mailbox details, and connect with Microsoft—no Entra app registration is needed."
-        },
-        "byo": {
-          "summary": "Advanced: use your own Microsoft app",
-          "warning": "This is normally unnecessary on hosted Alga PSA and should be used only when your organization requires its own Entra application.",
-          "description": "Open Settings → Integrations → Providers, expand the Microsoft advanced options, and add your tenant-owned app before returning here."
-        },
-        "manualRequired": "Platform Microsoft credentials are unavailable in this deployment. Configure your own Microsoft app to connect a mailbox.",
-        "tenant": {
-          "title": "Your organization’s Microsoft app is selected",
-          "description": "New Microsoft mailboxes will use the tenant-owned app selected in Providers settings. This choice is preserved even when platform credentials are available.",
-          "incompleteTitle": "Your Microsoft app needs attention",
-          "incompleteDescription": "Finish configuring the Microsoft app selected in Providers settings before connecting a mailbox."
-        },
-        "steps": {
-          "registerApp": "Zarejestruj aplikację w usłudze Azure AD",
-          "permissions": "Skonfiguruj uprawnienia API dla Mail.Read",
-          "redirectUrl": "Skonfiguruj adres URL przekierowania podczas rejestracji aplikacji",
-          "credentials": "Użyj identyfikatora klienta i sekretu klienta w powyższym formularzu"
-        }
+        "providersPointer": "Microsoft app setup is managed in Providers.",
+        "openProviders": "Open Providers"
       },
       "gmail": {
         "title": "Konfiguracja Gmaila",
@@ -271,22 +250,11 @@
     },
     "microsoft": {
       "hostedOauth": {
-        "sectionTitle": "Connect Microsoft 365",
-        "platformUnavailableDescription": "Platform Microsoft credentials are unavailable in this deployment. Use your own Microsoft app to continue.",
-        "tenantSectionDescription": "Authorize this mailbox with the Microsoft app selected in Providers settings.",
-        "platformSectionDescription": "Alga PSA supplies the Microsoft application. Enter the mailbox details, then sign in with Microsoft.",
-        "platformManagedTitle": "Platform-managed Microsoft app",
-        "platformManagedDescription": "No Entra app registration, client ID, or client secret is required from you.",
-        "byoToggle": "Use your own Microsoft app (advanced)",
-        "byoToggleDescription": "For organizations that deliberately require their own Entra app registration.",
-        "byoWarning": "This is normally unnecessary on hosted Alga PSA. Use it only when your organization requires a tenant-owned Entra application.",
-        "tenantNotConfigured": "Your Microsoft app is not ready yet.",
-        "platformNotConfigured": "Platform Microsoft credentials are unavailable."
+        "sectionTitle": "Connect Microsoft 365"
       },
       "validation": {
         "providerNameRequired": "Nazwa konfiguracji jest wymagana",
         "emailRequired": "Wymagany jest prawidłowy adres e-mail",
-        "redirectRequired": "Wymagany jest prawidłowy identyfikator URI przekierowania",
         "authorizeRequiresValid": "Przed autoryzacją wypełnij wszystkie wymagane pola",
         "oauthInitiateFailed": "Nie udało się zainicjować protokołu OAuth",
         "popupBlocked": "Nie udało się otworzyć wyskakującego okienka OAuth. Zezwól na wyświetlanie wyskakujących okienek w tej witrynie.",
@@ -296,8 +264,7 @@
       },
       "requiredFields": {
         "providerName": "Nazwa konfiguracji",
-        "emailAddress": "Adres e-mail",
-        "redirectUri": "URI przekierowania"
+        "emailAddress": "Adres e-mail"
       },
       "basic": {
         "title": "Podstawowa konfiguracja",
@@ -310,20 +277,11 @@
         "providerNameHelp": "Wewnętrzna nazwa służąca do identyfikacji tej konfiguracji. Nie jest pokazywana w wiadomościach wychodzących.",
         "senderDisplayNameLabel": "Wyświetlana nazwa nadawcy",
         "senderDisplayNamePlaceholder": "np. Acme Support",
-        "senderDisplayNameHelp": "Wyświetlana nazwa w nagłówku Od w wychodzących wiadomościach zgłoszenia (odpowiedzi, zamknięcia). Stosowana tylko, gdy ta skrzynka odpowiada wychodzącemu adresowi zgłoszeń najemcy. Zostaw puste, aby użyć nazwy tablicy zgłoszenia."
+        "senderDisplayNameHelp": "Display name shown in the From header on outbound ticket emails. It applies when this mailbox matches the configured outbound ticketing address. Leave blank to use the ticket board name."
       },
       "oauth": {
-        "sectionTitle": "Konfiguracja Microsoft OAuth",
-        "sectionDescription": "Poświadczenia aplikacji Microsoft są konfigurowane w ustawieniach dostawców i ponownie wykorzystywane w tym miejscu.",
-        "setupLabel": "Microsoft Entra",
-        "notConfigured": "Ustawienia dostawcy Microsoft nie są skonfigurowane.",
-        "setupHelp": "Najpierw skonfiguruj Dostawców w Ustawieniach → Integracje → Dostawcy, a następnie wróć tutaj, aby autoryzować tę skrzynkę pocztową.",
-        "profileReady": "Profil aplikacji Microsoft jest gotowy.",
-        "profileReadyHelp": "Jeśli zgoda administratora dzierżawy nadal oczekuje, dokończ ją w ustawieniach Dostawców. Następnie użyj opcji Autoryzuj dostęp dla tej skrzynki pocztowej.",
-        "redirectUriLabel": "URI przekierowania *",
-        "redirectUriPlaceholder": "https://yourapp.com/api/auth/microsoft/callback",
-        "authorizationTitle": "Autoryzacja OAuth",
-        "authorizationDescription": "Ukończ proces OAuth, aby przyznać dostęp do skrzynki pocztowej"
+        "signingIn": "Signing in…",
+        "signIn": "Sign in with Microsoft"
       },
       "advanced": {
         "title": "Ustawienia zaawansowane",
@@ -332,6 +290,14 @@
         "folderFiltersPlaceholder": "Skrzynka odbiorcza, pomoc techniczna, folder niestandardowy",
         "folderFiltersHelp": "Rozdzielana przecinkami lista folderów do monitorowania (domyślnie: Skrzynka odbiorcza)",
         "maxEmailsPerSync": "Maksymalna liczba e-maili na synchronizację"
+      },
+      "readiness": {
+        "checking": "Checking Microsoft setup…",
+        "ready": "Microsoft is set up. Sign in as this mailbox to finish.",
+        "pending": "Waiting for your Microsoft 365 administrator. Setup was started in Providers but hasn't been approved yet.",
+        "openProviders": "Open Providers",
+        "notConfigured": "Microsoft isn't set up yet. Set it up once in Providers, then come back.",
+        "setUpInProviders": "Set up in Providers"
       }
     },
     "gmail": {

--- a/server/public/locales/pl/msp/integrations.json
+++ b/server/public/locales/pl/msp/integrations.json
@@ -559,22 +559,22 @@
         },
         "schedule": {
           "cadence": {
-            "10080": "co tydzień",
-            "1440": "codziennie",
-            "240": "co 4 godziny",
             "60": "co godzinę",
-            "720": "co 12 godzin"
+            "240": "co 4 godziny",
+            "720": "co 12 godzin",
+            "1440": "codziennie",
+            "10080": "co tydzień"
           },
           "changeAction": "Zmień harmonogram",
           "description": "Gdy włączona, Alga synchronizuje każdego przypisanego klienta w tym rytmie. Wyłączenie zatrzymuje przebiegi zaplanowane; ręczna synchronizacja pozostaje dostępna.",
           "enablePrompt": "Pilotaż się powiódł. Włącz automatyczną synchronizację, aby kontakty pozostawały aktualne bez ręcznych uruchomień.",
           "intervalLabel": "Uruchamiaj co",
           "intervals": {
-            "10080": "Tydzień",
-            "1440": "Dobę",
-            "240": "4 godziny",
             "60": "Godzinę",
-            "720": "12 godzin"
+            "240": "4 godziny",
+            "720": "12 godzin",
+            "1440": "Dobę",
+            "10080": "Tydzień"
           },
           "pause": "Wstrzymaj",
           "pauseHint": "Wstrzymano. Zapisz, aby zastosować.",
@@ -1518,35 +1518,40 @@
     },
     "microsoft": {
       "emailSetup": {
-        "action": "Set up Microsoft Email",
+        "action": "Set up Microsoft",
         "actions": {
           "back": "Back",
           "cancel": "Cancel",
           "copy": "Copy",
           "finish": "Finish",
-          "grantConsent": "Grant administrator consent",
           "savePlatform": "Create profile and continue",
           "signIn": "Sign in to Microsoft",
-          "working": "Working…"
+          "working": "Working…",
+          "approve": "Approve in Microsoft",
+          "copyApprovalLink": "Copy approval link for your admin",
+          "saveManual": "Save app and continue"
         },
         "automated": {
-          "description": "Sign in as a Microsoft administrator. Alga creates the app, service principal, secret, Email profile, and binding.",
-          "title": "Create an app in this tenant"
+          "description": "Alga PSA registers a dedicated Entra app automatically. Sign in as a Microsoft 365 administrator.",
+          "title": "Create an app in your Microsoft organization"
         },
         "callbackUri": "Mailbox callback URI",
         "complete": {
-          "consentDone": "Administrator consent is confirmed. Return to Inbound Email and authorize the mailbox.",
-          "consentPending": "Next, a Microsoft tenant administrator must grant consent. Mailbox authorization happens afterward in Inbound Email.",
-          "profileCreated": "Microsoft Email profile created and bound"
+          "consentDone": "Approved by your Microsoft 365 administrator. You can now connect a mailbox.",
+          "consentPending": "A Microsoft 365 administrator for your organization must approve access before mailboxes can connect.",
+          "profileCreated": "Microsoft Email profile created and bound",
+          "ready": "Microsoft is ready",
+          "waiting": "Waiting for admin approval"
         },
         "consent": {
           "confirmedDescription": "The Microsoft app is ready for mailbox authorization.",
           "confirmedTitle": "Administrator consent confirmed",
           "url": "Administrator consent URL",
-          "urlLabel": "Consent URL"
+          "urlLabel": "Consent URL",
+          "approvalLink": "Approval link"
         },
         "copied": "{{label}} copied",
-        "description": "Choose how to configure the Microsoft app used for inbound email. Mailbox authorization remains a separate final step.",
+        "description": "Choose how Alga PSA connects to Microsoft. You will connect mailboxes separately.",
         "errors": {
           "automated": "Could not start automated Microsoft app creation.",
           "generic": "Microsoft Email setup did not complete.",
@@ -1554,38 +1559,46 @@
           "platform": "Could not configure the platform Microsoft app.",
           "popupBlocked": "Allow popups for this site, then try again.",
           "popupClosed": "Okno Microsoft zostało zamknięte przed ukończeniem konfiguracji. Spróbuj ponownie lub wybierz inną opcję konfiguracji.",
-          "tenantRequired": "Enter your Microsoft tenant ID or verified domain."
+          "tenantRequired": "Enter your Microsoft tenant ID or verified domain.",
+          "manual": "Could not configure the Microsoft app.",
+          "manualRequired": "Enter the display name, client ID, client secret, and Microsoft tenant ID.",
+          "pendingProfileMissing": "The pending Microsoft app could not be found.",
+          "approvalLink": "Could not create the Microsoft approval link."
         },
         "fields": {
           "clientId": "Client ID",
           "displayName": "Profile display name",
-          "tenant": "Microsoft tenant ID or verified domain",
-          "tenantId": "Tenant ID"
+          "tenantId": "Microsoft tenant ID",
+          "clientSecret": "Client secret",
+          "microsoftTenant": "Microsoft tenant ID or verified domain",
+          "redirectUri": "Redirect URI to add in Entra"
         },
         "manual": {
-          "description": "Keep using the existing client ID, tenant ID, and client secret form.",
+          "description": "Use an existing Entra app maintained by your organization.",
           "title": "Enter an existing app manually"
         },
         "platform": {
-          "description": "Create an Email-bound profile from the server-managed multi-tenant app, then grant tenant administrator consent.",
-          "title": "Use the Alga platform app"
+          "description": "Nothing to register in Microsoft Entra. Your Microsoft 365 administrator approves access.",
+          "title": "Use the app provided by Alga PSA"
         },
-        "title": "Set up Microsoft Email",
-        "unavailable": "Unavailable"
+        "title": "Set up Microsoft",
+        "unavailable": "Unavailable",
+        "recommended": "Recommended",
+        "advanced": "Advanced"
       },
       "settings": {
         "advanced": {
-          "title": "Bring your own Microsoft app (advanced)",
-          "description": "Create and manage tenant-owned Entra app registrations for organizations that explicitly require them.",
+          "title": "Manual Microsoft apps (advanced)",
+          "description": "Create and manage Entra app registrations maintained by your organization.",
           "warning": "A custom Entra app is normally unnecessary on hosted Alga PSA. Continue only when your organization deliberately requires its own application and credentials."
         },
         "platform": {
           "title": "Microsoft email is ready to connect",
           "description": "Connect Microsoft 365 with the application supplied by Alga PSA. No Entra app registration is required.",
-          "readyDescription": "Alga PSA supplies and manages the Microsoft application. Connect a mailbox without creating an Entra app or entering client credentials.",
-          "connectAction": "Connect Microsoft email",
+          "readyDescription": "The Microsoft app is approved and ready for mailbox sign-in.",
+          "connectAction": "Connect a mailbox →",
           "unavailableTitle": "Platform Microsoft credentials are unavailable",
-          "unavailableDescription": "This deployment requires a tenant-owned Microsoft app. Use the advanced setup below to add one."
+          "unavailableDescription": "This deployment requires an app maintained by your organization. Use the advanced setup below to add one."
         },
         "actions": {
           "entraLink": "Microsoft Entra",
@@ -1670,7 +1683,7 @@
           "setDefault": "Ustaw ten profil jako domyślny profil Microsoft",
           "setDefaultHelp": "Domyślne profile pozostają dostępne dla procesów zarządzania profilem i metadanych bezpiecznych dla migracji, a nie dla routingu konsumentów.",
           "storedSecretHint": "Zapisany secret: {{secret}}. Pozostaw to pole puste, aby zachować je bez zmian.",
-          "tenantId": "Tenant ID",
+          "tenantId": "Microsoft tenant ID",
           "capabilities": "Enabled capabilities",
           "capabilitiesHelp": "Only enabled capabilities can bind to this Microsoft app."
         },
@@ -1707,7 +1720,7 @@
           "teamsScopes": "Zakresy Teams",
           "teamsTabRedirect": "Redirect URI osobistego tabu",
           "teamsTitle": "Wskazówki dotyczące Teams",
-          "tenantId": "Tenant ID",
+          "tenantId": "Microsoft tenant ID",
           "unavailable": "Niedostępne"
         },
         "profileCard": {
@@ -1724,7 +1737,7 @@
           "setDefault": "Ustaw jako domyślny",
           "storedSecret": "Zapisany secret",
           "teamsAppIdUri": "Teams Application ID URI",
-          "tenantIdLabel": "Tenant ID:",
+          "tenantIdLabel": "Microsoft tenant ID:",
           "updating": "Aktualizowanie…",
           "enabledCapabilities": "Enabled capabilities",
           "noEnabledCapabilities": "No enabled capabilities"
@@ -1737,13 +1750,14 @@
           "archived": "Zarchiwizowane profile nie mogą być używane do nowych powiązań Microsoft.",
           "clientIdMissing": "Brak Client ID.",
           "clientSecretMissing": "Client secret nie został skonfigurowany.",
-          "tenantIdMissing": "Brak Tenant ID.",
-          "adminConsentPending": "Udziel zgody administratora dzierżawy Microsoft, aby zakończyć konfigurację poczty e-mail."
+          "tenantIdMissing": "Add a Microsoft tenant ID.",
+          "adminConsentPending": "Ask a Microsoft 365 administrator to approve access for Email."
         },
         "statusBadges": {
           "archived": "Zarchiwizowany",
           "needsAttention": "Wymaga uwagi",
-          "ready": "Gotowy"
+          "ready": "Gotowy",
+          "waitingForAdminApproval": "Waiting for admin approval"
         },
         "title": "Microsoft",
         "toasts": {
@@ -1770,7 +1784,7 @@
           "clientIdRequired": "Microsoft OAuth Client ID jest wymagany",
           "clientSecretRequired": "Microsoft OAuth Client Secret jest wymagany",
           "displayNameRequired": "Nazwa wyświetlana profilu Microsoft jest wymagana",
-          "tenantIdRequired": "Microsoft Tenant ID jest wymagany"
+          "tenantIdRequired": "Microsoft tenant ID is required"
         },
         "disconnectDialog": {
           "cancel": "Keep providers connected",

--- a/server/public/locales/pt/msp/email-providers.json
+++ b/server/public/locales/pt/msp/email-providers.json
@@ -42,29 +42,8 @@
       "title": "Instruções de configuração",
       "microsoft": {
         "title": "Configuração do Microsoft 365",
-        "checkingCredentials": "Checking Microsoft credential availability…",
-        "platform": {
-          "title": "Microsoft sign-in is ready",
-          "description": "Alga PSA supplies the Microsoft application. Add a provider, enter the mailbox details, and connect with Microsoft—no Entra app registration is needed."
-        },
-        "byo": {
-          "summary": "Advanced: use your own Microsoft app",
-          "warning": "This is normally unnecessary on hosted Alga PSA and should be used only when your organization requires its own Entra application.",
-          "description": "Open Settings → Integrations → Providers, expand the Microsoft advanced options, and add your tenant-owned app before returning here."
-        },
-        "manualRequired": "Platform Microsoft credentials are unavailable in this deployment. Configure your own Microsoft app to connect a mailbox.",
-        "tenant": {
-          "title": "Your organization’s Microsoft app is selected",
-          "description": "New Microsoft mailboxes will use the tenant-owned app selected in Providers settings. This choice is preserved even when platform credentials are available.",
-          "incompleteTitle": "Your Microsoft app needs attention",
-          "incompleteDescription": "Finish configuring the Microsoft app selected in Providers settings before connecting a mailbox."
-        },
-        "steps": {
-          "registerApp": "Registre um aplicativo no Azure AD",
-          "permissions": "Configurar permissões de API para Mail.Read",
-          "redirectUrl": "Configure o URL de redirecionamento no registro do seu aplicativo",
-          "credentials": "Use o ID do cliente e o segredo do cliente no formulário acima"
-        }
+        "providersPointer": "Microsoft app setup is managed in Providers.",
+        "openProviders": "Open Providers"
       },
       "gmail": {
         "title": "Configuração do Gmail",
@@ -271,22 +250,11 @@
     },
     "microsoft": {
       "hostedOauth": {
-        "sectionTitle": "Connect Microsoft 365",
-        "platformUnavailableDescription": "Platform Microsoft credentials are unavailable in this deployment. Use your own Microsoft app to continue.",
-        "tenantSectionDescription": "Authorize this mailbox with the Microsoft app selected in Providers settings.",
-        "platformSectionDescription": "Alga PSA supplies the Microsoft application. Enter the mailbox details, then sign in with Microsoft.",
-        "platformManagedTitle": "Platform-managed Microsoft app",
-        "platformManagedDescription": "No Entra app registration, client ID, or client secret is required from you.",
-        "byoToggle": "Use your own Microsoft app (advanced)",
-        "byoToggleDescription": "For organizations that deliberately require their own Entra app registration.",
-        "byoWarning": "This is normally unnecessary on hosted Alga PSA. Use it only when your organization requires a tenant-owned Entra application.",
-        "tenantNotConfigured": "Your Microsoft app is not ready yet.",
-        "platformNotConfigured": "Platform Microsoft credentials are unavailable."
+        "sectionTitle": "Connect Microsoft 365"
       },
       "validation": {
         "providerNameRequired": "O nome da configuração é obrigatório",
         "emailRequired": "É necessário um endereço de e-mail válido",
-        "redirectRequired": "O URI de redirecionamento válido é obrigatório",
         "authorizeRequiresValid": "Por favor preencha todos os campos obrigatórios antes de autorizar",
         "oauthInitiateFailed": "Falha ao iniciar o OAuth",
         "popupBlocked": "Falha ao abrir o pop-up do OAuth. Por favor, permita pop-ups para este site.",
@@ -296,8 +264,7 @@
       },
       "requiredFields": {
         "providerName": "Nome da configuração",
-        "emailAddress": "Endereço de email",
-        "redirectUri": "Redirecionar URI"
+        "emailAddress": "Endereço de email"
       },
       "basic": {
         "title": "Configuração Básica",
@@ -310,20 +277,11 @@
         "providerNameHelp": "Nome interno usado para identificar esta configuração. Não mostrado em e-mails enviados.",
         "senderDisplayNameLabel": "Nome de exibição do remetente",
         "senderDisplayNamePlaceholder": "por exemplo, Suporte Acme",
-        "senderDisplayNameHelp": "Nome de exibição mostrado no cabeçalho De em e-mails de ticket de saída (respostas, encerramentos). Aplicado somente quando esta caixa de correio corresponde ao endereço emissor de emissão de tickets do locatário. Deixe em branco para retornar ao nome do quadro do ticket."
+        "senderDisplayNameHelp": "Display name shown in the From header on outbound ticket emails. It applies when this mailbox matches the configured outbound ticketing address. Leave blank to use the ticket board name."
       },
       "oauth": {
-        "sectionTitle": "Configuração do Microsoft OAuth",
-        "sectionDescription": "As credenciais do aplicativo Microsoft são configuradas nas configurações dos Provedores e reutilizadas aqui.",
-        "setupLabel": "Microsoft Entrada",
-        "notConfigured": "As configurações do provedor Microsoft não estão definidas.",
-        "setupHelp": "Configure os provedores primeiro em Configurações → Integrações → Provedores e depois retorne aqui para autorizar esta caixa de correio.",
-        "profileReady": "O perfil do aplicativo Microsoft está pronto.",
-        "profileReadyHelp": "Se o consentimento do administrador do locatário ainda estiver pendente, conclua-o nas configurações de Provedores. Depois, use Autorizar acesso para esta caixa de correio.",
-        "redirectUriLabel": "Redirecionar URI *",
-        "redirectUriPlaceholder": "https://yourapp.com/api/auth/microsoft/callback",
-        "authorizationTitle": "Autorização OAuth",
-        "authorizationDescription": "Conclua o fluxo OAuth para conceder acesso à caixa de correio"
+        "signingIn": "Signing in…",
+        "signIn": "Sign in with Microsoft"
       },
       "advanced": {
         "title": "Configurações avançadas",
@@ -332,6 +290,14 @@
         "folderFiltersPlaceholder": "Caixa de entrada, suporte, pasta personalizada",
         "folderFiltersHelp": "Lista separada por vírgulas de pastas a serem monitoradas (padrão: Caixa de entrada)",
         "maxEmailsPerSync": "Máximo de e-mails por sincronização"
+      },
+      "readiness": {
+        "checking": "Checking Microsoft setup…",
+        "ready": "Microsoft is set up. Sign in as this mailbox to finish.",
+        "pending": "Waiting for your Microsoft 365 administrator. Setup was started in Providers but hasn't been approved yet.",
+        "openProviders": "Open Providers",
+        "notConfigured": "Microsoft isn't set up yet. Set it up once in Providers, then come back.",
+        "setUpInProviders": "Set up in Providers"
       }
     },
     "gmail": {

--- a/server/public/locales/pt/msp/integrations.json
+++ b/server/public/locales/pt/msp/integrations.json
@@ -559,22 +559,22 @@
         },
         "schedule": {
           "cadence": {
-            "10080": "todas as semanas",
-            "1440": "todos os dias",
-            "240": "a cada 4 horas",
             "60": "a cada hora",
-            "720": "a cada 12 horas"
+            "240": "a cada 4 horas",
+            "720": "a cada 12 horas",
+            "1440": "todos os dias",
+            "10080": "todas as semanas"
           },
           "changeAction": "Alterar agendamento",
           "description": "Quando ligada, o Alga sincroniza cada cliente associado nesta cadência. Desligar para as execuções agendadas; pode continuar a sincronizar manualmente.",
           "enablePrompt": "O piloto correu bem. Ligue a sincronização automática para manter os contactos em dia sem execuções manuais.",
           "intervalLabel": "Executar a cada",
           "intervals": {
-            "10080": "Semana",
-            "1440": "Dia",
-            "240": "4 horas",
             "60": "Hora",
-            "720": "12 horas"
+            "240": "4 horas",
+            "720": "12 horas",
+            "1440": "Dia",
+            "10080": "Semana"
           },
           "pause": "Pausar",
           "pauseHint": "Em pausa. Guarde para aplicar.",
@@ -1518,35 +1518,40 @@
     },
     "microsoft": {
       "emailSetup": {
-        "action": "Set up Microsoft Email",
+        "action": "Set up Microsoft",
         "actions": {
           "back": "Back",
           "cancel": "Cancel",
           "copy": "Copy",
           "finish": "Finish",
-          "grantConsent": "Grant administrator consent",
           "savePlatform": "Create profile and continue",
           "signIn": "Sign in to Microsoft",
-          "working": "Working…"
+          "working": "Working…",
+          "approve": "Approve in Microsoft",
+          "copyApprovalLink": "Copy approval link for your admin",
+          "saveManual": "Save app and continue"
         },
         "automated": {
-          "description": "Sign in as a Microsoft administrator. Alga creates the app, service principal, secret, Email profile, and binding.",
-          "title": "Create an app in this tenant"
+          "description": "Alga PSA registers a dedicated Entra app automatically. Sign in as a Microsoft 365 administrator.",
+          "title": "Create an app in your Microsoft organization"
         },
         "callbackUri": "Mailbox callback URI",
         "complete": {
-          "consentDone": "Administrator consent is confirmed. Return to Inbound Email and authorize the mailbox.",
-          "consentPending": "Next, a Microsoft tenant administrator must grant consent. Mailbox authorization happens afterward in Inbound Email.",
-          "profileCreated": "Microsoft Email profile created and bound"
+          "consentDone": "Approved by your Microsoft 365 administrator. You can now connect a mailbox.",
+          "consentPending": "A Microsoft 365 administrator for your organization must approve access before mailboxes can connect.",
+          "profileCreated": "Microsoft Email profile created and bound",
+          "ready": "Microsoft is ready",
+          "waiting": "Waiting for admin approval"
         },
         "consent": {
           "confirmedDescription": "The Microsoft app is ready for mailbox authorization.",
           "confirmedTitle": "Administrator consent confirmed",
           "url": "Administrator consent URL",
-          "urlLabel": "Consent URL"
+          "urlLabel": "Consent URL",
+          "approvalLink": "Approval link"
         },
         "copied": "{{label}} copied",
-        "description": "Choose how to configure the Microsoft app used for inbound email. Mailbox authorization remains a separate final step.",
+        "description": "Choose how Alga PSA connects to Microsoft. You will connect mailboxes separately.",
         "errors": {
           "automated": "Could not start automated Microsoft app creation.",
           "generic": "Microsoft Email setup did not complete.",
@@ -1554,38 +1559,46 @@
           "platform": "Could not configure the platform Microsoft app.",
           "popupBlocked": "Allow popups for this site, then try again.",
           "popupClosed": "A janela da Microsoft foi fechada antes da conclusão da configuração. Tente novamente ou escolha outra opção de configuração.",
-          "tenantRequired": "Enter your Microsoft tenant ID or verified domain."
+          "tenantRequired": "Enter your Microsoft tenant ID or verified domain.",
+          "manual": "Could not configure the Microsoft app.",
+          "manualRequired": "Enter the display name, client ID, client secret, and Microsoft tenant ID.",
+          "pendingProfileMissing": "The pending Microsoft app could not be found.",
+          "approvalLink": "Could not create the Microsoft approval link."
         },
         "fields": {
           "clientId": "Client ID",
           "displayName": "Profile display name",
-          "tenant": "Microsoft tenant ID or verified domain",
-          "tenantId": "Tenant ID"
+          "tenantId": "Microsoft tenant ID",
+          "clientSecret": "Client secret",
+          "microsoftTenant": "Microsoft tenant ID or verified domain",
+          "redirectUri": "Redirect URI to add in Entra"
         },
         "manual": {
-          "description": "Keep using the existing client ID, tenant ID, and client secret form.",
+          "description": "Use an existing Entra app maintained by your organization.",
           "title": "Enter an existing app manually"
         },
         "platform": {
-          "description": "Create an Email-bound profile from the server-managed multi-tenant app, then grant tenant administrator consent.",
-          "title": "Use the Alga platform app"
+          "description": "Nothing to register in Microsoft Entra. Your Microsoft 365 administrator approves access.",
+          "title": "Use the app provided by Alga PSA"
         },
-        "title": "Set up Microsoft Email",
-        "unavailable": "Unavailable"
+        "title": "Set up Microsoft",
+        "unavailable": "Unavailable",
+        "recommended": "Recommended",
+        "advanced": "Advanced"
       },
       "settings": {
         "advanced": {
-          "title": "Bring your own Microsoft app (advanced)",
-          "description": "Create and manage tenant-owned Entra app registrations for organizations that explicitly require them.",
+          "title": "Manual Microsoft apps (advanced)",
+          "description": "Create and manage Entra app registrations maintained by your organization.",
           "warning": "A custom Entra app is normally unnecessary on hosted Alga PSA. Continue only when your organization deliberately requires its own application and credentials."
         },
         "platform": {
           "title": "Microsoft email is ready to connect",
           "description": "Connect Microsoft 365 with the application supplied by Alga PSA. No Entra app registration is required.",
-          "readyDescription": "Alga PSA supplies and manages the Microsoft application. Connect a mailbox without creating an Entra app or entering client credentials.",
-          "connectAction": "Connect Microsoft email",
+          "readyDescription": "The Microsoft app is approved and ready for mailbox sign-in.",
+          "connectAction": "Connect a mailbox →",
           "unavailableTitle": "Platform Microsoft credentials are unavailable",
-          "unavailableDescription": "This deployment requires a tenant-owned Microsoft app. Use the advanced setup below to add one."
+          "unavailableDescription": "This deployment requires an app maintained by your organization. Use the advanced setup below to add one."
         },
         "actions": {
           "entraLink": "Microsoft Entrada",
@@ -1670,7 +1683,7 @@
           "setDefault": "Defina este perfil como o perfil padrão da Microsoft",
           "setDefaultHelp": "Os perfis padrão permanecem disponíveis para fluxos de trabalho de gerenciamento de perfis e metadados seguros para migração, e não para roteamento do consumidor.",
           "storedSecretHint": "Segredo armazenado: {{secret}}. Deixe este campo vazio para mantê-lo inalterado.",
-          "tenantId": "ID do locatário",
+          "tenantId": "Microsoft tenant ID",
           "capabilities": "Enabled capabilities",
           "capabilitiesHelp": "Only enabled capabilities can bind to this Microsoft app."
         },
@@ -1707,7 +1720,7 @@
           "teamsScopes": "Escopos de equipes",
           "teamsTabRedirect": "URI de redirecionamento de guia pessoal",
           "teamsTitle": "Orientação de Equipes",
-          "tenantId": "ID do locatário",
+          "tenantId": "Microsoft tenant ID",
           "unavailable": "Indisponível"
         },
         "profileCard": {
@@ -1724,7 +1737,7 @@
           "setDefault": "Definir padrão",
           "storedSecret": "Segredo armazenado",
           "teamsAppIdUri": "URI do ID do aplicativo Teams",
-          "tenantIdLabel": "ID do locatário:",
+          "tenantIdLabel": "Microsoft tenant ID:",
           "updating": "Atualizando…",
           "enabledCapabilities": "Enabled capabilities",
           "noEnabledCapabilities": "No enabled capabilities"
@@ -1737,13 +1750,14 @@
           "archived": "Perfis arquivados não podem ser usados ​​para novas ligações da Microsoft.",
           "clientIdMissing": "O ID do cliente está ausente.",
           "clientSecretMissing": "O segredo do cliente não foi configurado.",
-          "tenantIdMissing": "O ID do locatário está ausente.",
-          "adminConsentPending": "Conceda o consentimento do administrador do locatário Microsoft para concluir a configuração de Email."
+          "tenantIdMissing": "Add a Microsoft tenant ID.",
+          "adminConsentPending": "Ask a Microsoft 365 administrator to approve access for Email."
         },
         "statusBadges": {
           "archived": "Arquivado",
           "needsAttention": "Precisa de atenção",
-          "ready": "Preparar"
+          "ready": "Preparar",
+          "waitingForAdminApproval": "Waiting for admin approval"
         },
         "title": "Microsoft",
         "toasts": {
@@ -1770,7 +1784,7 @@
           "clientIdRequired": "O ID do cliente Microsoft OAuth é obrigatório",
           "clientSecretRequired": "O segredo do cliente Microsoft OAuth é obrigatório",
           "displayNameRequired": "O nome de exibição do perfil da Microsoft é obrigatório",
-          "tenantIdRequired": "O ID do locatário da Microsoft é obrigatório"
+          "tenantIdRequired": "Microsoft tenant ID is required"
         },
         "disconnectDialog": {
           "cancel": "Keep providers connected",

--- a/server/public/locales/xx/msp/email-providers.json
+++ b/server/public/locales/xx/msp/email-providers.json
@@ -42,8 +42,8 @@
       "title": "11111",
       "microsoft": {
         "title": "11111",
-        "providersPointer": "Microsoft app setup is managed in Providers.",
-        "openProviders": "Open Providers"
+        "providersPointer": "11111",
+        "openProviders": "11111"
       },
       "gmail": {
         "title": "11111",
@@ -277,11 +277,11 @@
         "providerNameHelp": "11111",
         "senderDisplayNameLabel": "11111",
         "senderDisplayNamePlaceholder": "11111",
-        "senderDisplayNameHelp": "Display name shown in the From header on outbound ticket emails. It applies when this mailbox matches the configured outbound ticketing address. Leave blank to use the ticket board name."
+        "senderDisplayNameHelp": "11111"
       },
       "oauth": {
-        "signingIn": "Signing in…",
-        "signIn": "Sign in with Microsoft"
+        "signingIn": "11111",
+        "signIn": "11111"
       },
       "advanced": {
         "title": "11111",
@@ -292,12 +292,12 @@
         "maxEmailsPerSync": "11111"
       },
       "readiness": {
-        "checking": "Checking Microsoft setup…",
-        "ready": "Microsoft is set up. Sign in as this mailbox to finish.",
-        "pending": "Waiting for your Microsoft 365 administrator. Setup was started in Providers but hasn't been approved yet.",
-        "openProviders": "Open Providers",
-        "notConfigured": "Microsoft isn't set up yet. Set it up once in Providers, then come back.",
-        "setUpInProviders": "Set up in Providers"
+        "checking": "11111",
+        "ready": "11111",
+        "pending": "11111",
+        "openProviders": "11111",
+        "notConfigured": "11111",
+        "setUpInProviders": "11111"
       }
     },
     "gmail": {

--- a/server/public/locales/xx/msp/email-providers.json
+++ b/server/public/locales/xx/msp/email-providers.json
@@ -42,29 +42,8 @@
       "title": "11111",
       "microsoft": {
         "title": "11111",
-        "checkingCredentials": "11111",
-        "platform": {
-          "title": "11111",
-          "description": "11111"
-        },
-        "byo": {
-          "summary": "11111",
-          "warning": "11111",
-          "description": "11111"
-        },
-        "manualRequired": "11111",
-        "tenant": {
-          "title": "11111",
-          "description": "11111",
-          "incompleteTitle": "11111",
-          "incompleteDescription": "11111"
-        },
-        "steps": {
-          "registerApp": "11111",
-          "permissions": "11111",
-          "redirectUrl": "11111",
-          "credentials": "11111"
-        }
+        "providersPointer": "Microsoft app setup is managed in Providers.",
+        "openProviders": "Open Providers"
       },
       "gmail": {
         "title": "11111",
@@ -271,22 +250,11 @@
     },
     "microsoft": {
       "hostedOauth": {
-        "sectionTitle": "11111",
-        "platformUnavailableDescription": "11111",
-        "tenantSectionDescription": "11111",
-        "platformSectionDescription": "11111",
-        "platformManagedTitle": "11111",
-        "platformManagedDescription": "11111",
-        "byoToggle": "11111",
-        "byoToggleDescription": "11111",
-        "byoWarning": "11111",
-        "tenantNotConfigured": "11111",
-        "platformNotConfigured": "11111"
+        "sectionTitle": "11111"
       },
       "validation": {
         "providerNameRequired": "11111",
         "emailRequired": "11111",
-        "redirectRequired": "11111",
         "authorizeRequiresValid": "11111",
         "oauthInitiateFailed": "11111",
         "popupBlocked": "11111",
@@ -296,8 +264,7 @@
       },
       "requiredFields": {
         "providerName": "11111",
-        "emailAddress": "11111",
-        "redirectUri": "11111"
+        "emailAddress": "11111"
       },
       "basic": {
         "title": "11111",
@@ -310,20 +277,11 @@
         "providerNameHelp": "11111",
         "senderDisplayNameLabel": "11111",
         "senderDisplayNamePlaceholder": "11111",
-        "senderDisplayNameHelp": "11111"
+        "senderDisplayNameHelp": "Display name shown in the From header on outbound ticket emails. It applies when this mailbox matches the configured outbound ticketing address. Leave blank to use the ticket board name."
       },
       "oauth": {
-        "sectionTitle": "11111",
-        "sectionDescription": "11111",
-        "setupLabel": "11111",
-        "notConfigured": "11111",
-        "setupHelp": "11111",
-        "profileReady": "11111",
-        "profileReadyHelp": "11111",
-        "redirectUriLabel": "11111",
-        "redirectUriPlaceholder": "11111",
-        "authorizationTitle": "11111",
-        "authorizationDescription": "11111"
+        "signingIn": "Signing in…",
+        "signIn": "Sign in with Microsoft"
       },
       "advanced": {
         "title": "11111",
@@ -332,6 +290,14 @@
         "folderFiltersPlaceholder": "11111",
         "folderFiltersHelp": "11111",
         "maxEmailsPerSync": "11111"
+      },
+      "readiness": {
+        "checking": "Checking Microsoft setup…",
+        "ready": "Microsoft is set up. Sign in as this mailbox to finish.",
+        "pending": "Waiting for your Microsoft 365 administrator. Setup was started in Providers but hasn't been approved yet.",
+        "openProviders": "Open Providers",
+        "notConfigured": "Microsoft isn't set up yet. Set it up once in Providers, then come back.",
+        "setUpInProviders": "Set up in Providers"
       }
     },
     "gmail": {

--- a/server/public/locales/xx/msp/integrations.json
+++ b/server/public/locales/xx/msp/integrations.json
@@ -1518,35 +1518,40 @@
     },
     "microsoft": {
       "emailSetup": {
-        "action": "11111",
+        "action": "Set up Microsoft",
         "actions": {
           "back": "11111",
           "cancel": "11111",
           "copy": "11111",
           "finish": "11111",
-          "grantConsent": "11111",
           "savePlatform": "11111",
           "signIn": "11111",
-          "working": "11111"
+          "working": "11111",
+          "approve": "Approve in Microsoft",
+          "copyApprovalLink": "Copy approval link for your admin",
+          "saveManual": "Save app and continue"
         },
         "automated": {
-          "description": "11111",
-          "title": "11111"
+          "description": "Alga PSA registers a dedicated Entra app automatically. Sign in as a Microsoft 365 administrator.",
+          "title": "Create an app in your Microsoft organization"
         },
         "callbackUri": "11111",
         "complete": {
-          "consentDone": "11111",
-          "consentPending": "11111",
-          "profileCreated": "11111"
+          "consentDone": "Approved by your Microsoft 365 administrator. You can now connect a mailbox.",
+          "consentPending": "A Microsoft 365 administrator for your organization must approve access before mailboxes can connect.",
+          "profileCreated": "11111",
+          "ready": "Microsoft is ready",
+          "waiting": "Waiting for admin approval"
         },
         "consent": {
           "confirmedDescription": "11111",
           "confirmedTitle": "11111",
           "url": "11111",
-          "urlLabel": "11111"
+          "urlLabel": "11111",
+          "approvalLink": "Approval link"
         },
         "copied": "11111 {{label}} 11111",
-        "description": "11111",
+        "description": "Choose how Alga PSA connects to Microsoft. You will connect mailboxes separately.",
         "errors": {
           "automated": "11111",
           "generic": "11111",
@@ -1554,38 +1559,46 @@
           "platform": "11111",
           "popupBlocked": "11111",
           "popupClosed": "11111",
-          "tenantRequired": "11111"
+          "tenantRequired": "11111",
+          "manual": "Could not configure the Microsoft app.",
+          "manualRequired": "Enter the display name, client ID, client secret, and Microsoft tenant ID.",
+          "pendingProfileMissing": "The pending Microsoft app could not be found.",
+          "approvalLink": "Could not create the Microsoft approval link."
         },
         "fields": {
           "clientId": "11111",
           "displayName": "11111",
-          "tenant": "11111",
-          "tenantId": "11111"
+          "tenantId": "Microsoft tenant ID",
+          "clientSecret": "Client secret",
+          "microsoftTenant": "Microsoft tenant ID or verified domain",
+          "redirectUri": "Redirect URI to add in Entra"
         },
         "manual": {
-          "description": "11111",
+          "description": "Use an existing Entra app maintained by your organization.",
           "title": "11111"
         },
         "platform": {
-          "description": "11111",
-          "title": "11111"
+          "description": "Nothing to register in Microsoft Entra. Your Microsoft 365 administrator approves access.",
+          "title": "Use the app provided by Alga PSA"
         },
-        "title": "11111",
-        "unavailable": "11111"
+        "title": "Set up Microsoft",
+        "unavailable": "11111",
+        "recommended": "Recommended",
+        "advanced": "Advanced"
       },
       "settings": {
         "advanced": {
-          "title": "11111",
-          "description": "11111",
+          "title": "Manual Microsoft apps (advanced)",
+          "description": "Create and manage Entra app registrations maintained by your organization.",
           "warning": "11111"
         },
         "platform": {
           "title": "11111",
           "description": "11111",
-          "readyDescription": "11111",
-          "connectAction": "11111",
+          "readyDescription": "The Microsoft app is approved and ready for mailbox sign-in.",
+          "connectAction": "Connect a mailbox →",
           "unavailableTitle": "11111",
-          "unavailableDescription": "11111"
+          "unavailableDescription": "This deployment requires an app maintained by your organization. Use the advanced setup below to add one."
         },
         "actions": {
           "disconnectProviders": "11111",
@@ -1675,7 +1688,7 @@
           "setDefault": "11111",
           "setDefaultHelp": "11111",
           "storedSecretHint": "11111 {{secret}} 11111",
-          "tenantId": "11111",
+          "tenantId": "Microsoft tenant ID",
           "capabilities": "11111",
           "capabilitiesHelp": "11111"
         },
@@ -1712,7 +1725,7 @@
           "teamsScopes": "11111",
           "teamsTabRedirect": "11111",
           "teamsTitle": "11111",
-          "tenantId": "11111",
+          "tenantId": "Microsoft tenant ID",
           "unavailable": "11111"
         },
         "profileCard": {
@@ -1729,7 +1742,7 @@
           "setDefault": "11111",
           "storedSecret": "11111",
           "teamsAppIdUri": "11111",
-          "tenantIdLabel": "11111",
+          "tenantIdLabel": "Microsoft tenant ID:",
           "updating": "11111",
           "enabledCapabilities": "11111",
           "noEnabledCapabilities": "11111"
@@ -1746,13 +1759,14 @@
           "archived": "11111",
           "clientIdMissing": "11111",
           "clientSecretMissing": "11111",
-          "tenantIdMissing": "11111",
-          "adminConsentPending": "11111"
+          "tenantIdMissing": "Add a Microsoft tenant ID.",
+          "adminConsentPending": "Ask a Microsoft 365 administrator to approve access for Email."
         },
         "statusBadges": {
           "archived": "11111",
           "needsAttention": "11111",
-          "ready": "11111"
+          "ready": "11111",
+          "waitingForAdminApproval": "Waiting for admin approval"
         },
         "title": "11111",
         "toasts": {
@@ -1779,7 +1793,7 @@
           "clientIdRequired": "11111",
           "clientSecretRequired": "11111",
           "displayNameRequired": "11111",
-          "tenantIdRequired": "11111"
+          "tenantIdRequired": "Microsoft tenant ID is required"
         }
       }
     },

--- a/server/public/locales/xx/msp/integrations.json
+++ b/server/public/locales/xx/msp/integrations.json
@@ -1518,7 +1518,7 @@
     },
     "microsoft": {
       "emailSetup": {
-        "action": "Set up Microsoft",
+        "action": "11111",
         "actions": {
           "back": "11111",
           "cancel": "11111",
@@ -1527,31 +1527,31 @@
           "savePlatform": "11111",
           "signIn": "11111",
           "working": "11111",
-          "approve": "Approve in Microsoft",
-          "copyApprovalLink": "Copy approval link for your admin",
-          "saveManual": "Save app and continue"
+          "approve": "11111",
+          "copyApprovalLink": "11111",
+          "saveManual": "11111"
         },
         "automated": {
-          "description": "Alga PSA registers a dedicated Entra app automatically. Sign in as a Microsoft 365 administrator.",
-          "title": "Create an app in your Microsoft organization"
+          "description": "11111",
+          "title": "11111"
         },
         "callbackUri": "11111",
         "complete": {
-          "consentDone": "Approved by your Microsoft 365 administrator. You can now connect a mailbox.",
-          "consentPending": "A Microsoft 365 administrator for your organization must approve access before mailboxes can connect.",
+          "consentDone": "11111",
+          "consentPending": "11111",
           "profileCreated": "11111",
-          "ready": "Microsoft is ready",
-          "waiting": "Waiting for admin approval"
+          "ready": "11111",
+          "waiting": "11111"
         },
         "consent": {
           "confirmedDescription": "11111",
           "confirmedTitle": "11111",
           "url": "11111",
           "urlLabel": "11111",
-          "approvalLink": "Approval link"
+          "approvalLink": "11111"
         },
         "copied": "11111 {{label}} 11111",
-        "description": "Choose how Alga PSA connects to Microsoft. You will connect mailboxes separately.",
+        "description": "11111",
         "errors": {
           "automated": "11111",
           "generic": "11111",
@@ -1560,45 +1560,45 @@
           "popupBlocked": "11111",
           "popupClosed": "11111",
           "tenantRequired": "11111",
-          "manual": "Could not configure the Microsoft app.",
-          "manualRequired": "Enter the display name, client ID, client secret, and Microsoft tenant ID.",
-          "pendingProfileMissing": "The pending Microsoft app could not be found.",
-          "approvalLink": "Could not create the Microsoft approval link."
+          "manual": "11111",
+          "manualRequired": "11111",
+          "pendingProfileMissing": "11111",
+          "approvalLink": "11111"
         },
         "fields": {
           "clientId": "11111",
           "displayName": "11111",
-          "tenantId": "Microsoft tenant ID",
-          "clientSecret": "Client secret",
-          "microsoftTenant": "Microsoft tenant ID or verified domain",
-          "redirectUri": "Redirect URI to add in Entra"
+          "tenantId": "11111",
+          "clientSecret": "11111",
+          "microsoftTenant": "11111",
+          "redirectUri": "11111"
         },
         "manual": {
-          "description": "Use an existing Entra app maintained by your organization.",
+          "description": "11111",
           "title": "11111"
         },
         "platform": {
-          "description": "Nothing to register in Microsoft Entra. Your Microsoft 365 administrator approves access.",
-          "title": "Use the app provided by Alga PSA"
+          "description": "11111",
+          "title": "11111"
         },
-        "title": "Set up Microsoft",
+        "title": "11111",
         "unavailable": "11111",
-        "recommended": "Recommended",
-        "advanced": "Advanced"
+        "recommended": "11111",
+        "advanced": "11111"
       },
       "settings": {
         "advanced": {
-          "title": "Manual Microsoft apps (advanced)",
-          "description": "Create and manage Entra app registrations maintained by your organization.",
+          "title": "11111",
+          "description": "11111",
           "warning": "11111"
         },
         "platform": {
           "title": "11111",
           "description": "11111",
-          "readyDescription": "The Microsoft app is approved and ready for mailbox sign-in.",
-          "connectAction": "Connect a mailbox →",
+          "readyDescription": "11111",
+          "connectAction": "11111",
           "unavailableTitle": "11111",
-          "unavailableDescription": "This deployment requires an app maintained by your organization. Use the advanced setup below to add one."
+          "unavailableDescription": "11111"
         },
         "actions": {
           "disconnectProviders": "11111",
@@ -1688,7 +1688,7 @@
           "setDefault": "11111",
           "setDefaultHelp": "11111",
           "storedSecretHint": "11111 {{secret}} 11111",
-          "tenantId": "Microsoft tenant ID",
+          "tenantId": "11111",
           "capabilities": "11111",
           "capabilitiesHelp": "11111"
         },
@@ -1725,7 +1725,7 @@
           "teamsScopes": "11111",
           "teamsTabRedirect": "11111",
           "teamsTitle": "11111",
-          "tenantId": "Microsoft tenant ID",
+          "tenantId": "11111",
           "unavailable": "11111"
         },
         "profileCard": {
@@ -1742,7 +1742,7 @@
           "setDefault": "11111",
           "storedSecret": "11111",
           "teamsAppIdUri": "11111",
-          "tenantIdLabel": "Microsoft tenant ID:",
+          "tenantIdLabel": "11111",
           "updating": "11111",
           "enabledCapabilities": "11111",
           "noEnabledCapabilities": "11111"
@@ -1759,14 +1759,14 @@
           "archived": "11111",
           "clientIdMissing": "11111",
           "clientSecretMissing": "11111",
-          "tenantIdMissing": "Add a Microsoft tenant ID.",
-          "adminConsentPending": "Ask a Microsoft 365 administrator to approve access for Email."
+          "tenantIdMissing": "11111",
+          "adminConsentPending": "11111"
         },
         "statusBadges": {
           "archived": "11111",
           "needsAttention": "11111",
           "ready": "11111",
-          "waitingForAdminApproval": "Waiting for admin approval"
+          "waitingForAdminApproval": "11111"
         },
         "title": "11111",
         "toasts": {
@@ -1793,7 +1793,7 @@
           "clientIdRequired": "11111",
           "clientSecretRequired": "11111",
           "displayNameRequired": "11111",
-          "tenantIdRequired": "Microsoft tenant ID is required"
+          "tenantIdRequired": "11111"
         }
       }
     },

--- a/server/public/locales/yy/msp/email-providers.json
+++ b/server/public/locales/yy/msp/email-providers.json
@@ -42,29 +42,8 @@
       "title": "55555",
       "microsoft": {
         "title": "55555",
-        "checkingCredentials": "55555",
-        "platform": {
-          "title": "55555",
-          "description": "55555"
-        },
-        "byo": {
-          "summary": "55555",
-          "warning": "55555",
-          "description": "55555"
-        },
-        "manualRequired": "55555",
-        "tenant": {
-          "title": "55555",
-          "description": "55555",
-          "incompleteTitle": "55555",
-          "incompleteDescription": "55555"
-        },
-        "steps": {
-          "registerApp": "55555",
-          "permissions": "55555",
-          "redirectUrl": "55555",
-          "credentials": "55555"
-        }
+        "providersPointer": "Microsoft app setup is managed in Providers.",
+        "openProviders": "Open Providers"
       },
       "gmail": {
         "title": "55555",
@@ -271,22 +250,11 @@
     },
     "microsoft": {
       "hostedOauth": {
-        "sectionTitle": "55555",
-        "platformUnavailableDescription": "55555",
-        "tenantSectionDescription": "55555",
-        "platformSectionDescription": "55555",
-        "platformManagedTitle": "55555",
-        "platformManagedDescription": "55555",
-        "byoToggle": "55555",
-        "byoToggleDescription": "55555",
-        "byoWarning": "55555",
-        "tenantNotConfigured": "55555",
-        "platformNotConfigured": "55555"
+        "sectionTitle": "yyyyy"
       },
       "validation": {
         "providerNameRequired": "55555",
         "emailRequired": "55555",
-        "redirectRequired": "55555",
         "authorizeRequiresValid": "55555",
         "oauthInitiateFailed": "55555",
         "popupBlocked": "55555",
@@ -296,8 +264,7 @@
       },
       "requiredFields": {
         "providerName": "55555",
-        "emailAddress": "55555",
-        "redirectUri": "55555"
+        "emailAddress": "55555"
       },
       "basic": {
         "title": "55555",
@@ -310,20 +277,11 @@
         "providerNameHelp": "55555",
         "senderDisplayNameLabel": "55555",
         "senderDisplayNamePlaceholder": "55555",
-        "senderDisplayNameHelp": "55555"
+        "senderDisplayNameHelp": "Display name shown in the From header on outbound ticket emails. It applies when this mailbox matches the configured outbound ticketing address. Leave blank to use the ticket board name."
       },
       "oauth": {
-        "sectionTitle": "55555",
-        "sectionDescription": "55555",
-        "setupLabel": "55555",
-        "notConfigured": "55555",
-        "setupHelp": "55555",
-        "profileReady": "55555",
-        "profileReadyHelp": "55555",
-        "redirectUriLabel": "55555",
-        "redirectUriPlaceholder": "55555",
-        "authorizationTitle": "55555",
-        "authorizationDescription": "55555"
+        "signingIn": "Signing in…",
+        "signIn": "Sign in with Microsoft"
       },
       "advanced": {
         "title": "55555",
@@ -332,6 +290,14 @@
         "folderFiltersPlaceholder": "55555",
         "folderFiltersHelp": "55555",
         "maxEmailsPerSync": "55555"
+      },
+      "readiness": {
+        "checking": "Checking Microsoft setup…",
+        "ready": "Microsoft is set up. Sign in as this mailbox to finish.",
+        "pending": "Waiting for your Microsoft 365 administrator. Setup was started in Providers but hasn't been approved yet.",
+        "openProviders": "Open Providers",
+        "notConfigured": "Microsoft isn't set up yet. Set it up once in Providers, then come back.",
+        "setUpInProviders": "Set up in Providers"
       }
     },
     "gmail": {

--- a/server/public/locales/yy/msp/email-providers.json
+++ b/server/public/locales/yy/msp/email-providers.json
@@ -42,8 +42,8 @@
       "title": "55555",
       "microsoft": {
         "title": "55555",
-        "providersPointer": "Microsoft app setup is managed in Providers.",
-        "openProviders": "Open Providers"
+        "providersPointer": "55555",
+        "openProviders": "55555"
       },
       "gmail": {
         "title": "55555",
@@ -277,11 +277,11 @@
         "providerNameHelp": "55555",
         "senderDisplayNameLabel": "55555",
         "senderDisplayNamePlaceholder": "55555",
-        "senderDisplayNameHelp": "Display name shown in the From header on outbound ticket emails. It applies when this mailbox matches the configured outbound ticketing address. Leave blank to use the ticket board name."
+        "senderDisplayNameHelp": "55555"
       },
       "oauth": {
-        "signingIn": "Signing in…",
-        "signIn": "Sign in with Microsoft"
+        "signingIn": "55555",
+        "signIn": "55555"
       },
       "advanced": {
         "title": "55555",
@@ -292,12 +292,12 @@
         "maxEmailsPerSync": "55555"
       },
       "readiness": {
-        "checking": "Checking Microsoft setup…",
-        "ready": "Microsoft is set up. Sign in as this mailbox to finish.",
-        "pending": "Waiting for your Microsoft 365 administrator. Setup was started in Providers but hasn't been approved yet.",
-        "openProviders": "Open Providers",
-        "notConfigured": "Microsoft isn't set up yet. Set it up once in Providers, then come back.",
-        "setUpInProviders": "Set up in Providers"
+        "checking": "55555",
+        "ready": "55555",
+        "pending": "55555",
+        "openProviders": "55555",
+        "notConfigured": "55555",
+        "setUpInProviders": "55555"
       }
     },
     "gmail": {

--- a/server/public/locales/yy/msp/integrations.json
+++ b/server/public/locales/yy/msp/integrations.json
@@ -1518,7 +1518,7 @@
     },
     "microsoft": {
       "emailSetup": {
-        "action": "Set up Microsoft",
+        "action": "55555",
         "actions": {
           "back": "55555",
           "cancel": "55555",
@@ -1527,31 +1527,31 @@
           "savePlatform": "55555",
           "signIn": "55555",
           "working": "55555",
-          "approve": "Approve in Microsoft",
-          "copyApprovalLink": "Copy approval link for your admin",
-          "saveManual": "Save app and continue"
+          "approve": "55555",
+          "copyApprovalLink": "55555",
+          "saveManual": "55555"
         },
         "automated": {
-          "description": "Alga PSA registers a dedicated Entra app automatically. Sign in as a Microsoft 365 administrator.",
-          "title": "Create an app in your Microsoft organization"
+          "description": "55555",
+          "title": "55555"
         },
         "callbackUri": "55555",
         "complete": {
-          "consentDone": "Approved by your Microsoft 365 administrator. You can now connect a mailbox.",
-          "consentPending": "A Microsoft 365 administrator for your organization must approve access before mailboxes can connect.",
+          "consentDone": "55555",
+          "consentPending": "55555",
           "profileCreated": "55555",
-          "ready": "Microsoft is ready",
-          "waiting": "Waiting for admin approval"
+          "ready": "55555",
+          "waiting": "55555"
         },
         "consent": {
           "confirmedDescription": "55555",
           "confirmedTitle": "55555",
           "url": "55555",
           "urlLabel": "55555",
-          "approvalLink": "Approval link"
+          "approvalLink": "55555"
         },
         "copied": "55555 {{label}} 55555",
-        "description": "Choose how Alga PSA connects to Microsoft. You will connect mailboxes separately.",
+        "description": "55555",
         "errors": {
           "automated": "55555",
           "generic": "55555",
@@ -1560,45 +1560,45 @@
           "popupBlocked": "55555",
           "popupClosed": "55555",
           "tenantRequired": "55555",
-          "manual": "Could not configure the Microsoft app.",
-          "manualRequired": "Enter the display name, client ID, client secret, and Microsoft tenant ID.",
-          "pendingProfileMissing": "The pending Microsoft app could not be found.",
-          "approvalLink": "Could not create the Microsoft approval link."
+          "manual": "55555",
+          "manualRequired": "55555",
+          "pendingProfileMissing": "55555",
+          "approvalLink": "55555"
         },
         "fields": {
           "clientId": "55555",
           "displayName": "55555",
-          "tenantId": "Microsoft tenant ID",
-          "clientSecret": "Client secret",
-          "microsoftTenant": "Microsoft tenant ID or verified domain",
-          "redirectUri": "Redirect URI to add in Entra"
+          "tenantId": "55555",
+          "clientSecret": "55555",
+          "microsoftTenant": "55555",
+          "redirectUri": "55555"
         },
         "manual": {
-          "description": "Use an existing Entra app maintained by your organization.",
+          "description": "55555",
           "title": "55555"
         },
         "platform": {
-          "description": "Nothing to register in Microsoft Entra. Your Microsoft 365 administrator approves access.",
-          "title": "Use the app provided by Alga PSA"
+          "description": "55555",
+          "title": "55555"
         },
-        "title": "Set up Microsoft",
+        "title": "55555",
         "unavailable": "55555",
-        "recommended": "Recommended",
-        "advanced": "Advanced"
+        "recommended": "55555",
+        "advanced": "55555"
       },
       "settings": {
         "advanced": {
-          "title": "Manual Microsoft apps (advanced)",
-          "description": "Create and manage Entra app registrations maintained by your organization.",
+          "title": "55555",
+          "description": "55555",
           "warning": "yyyyy"
         },
         "platform": {
           "title": "yyyyy",
           "description": "yyyyy",
-          "readyDescription": "The Microsoft app is approved and ready for mailbox sign-in.",
-          "connectAction": "Connect a mailbox →",
+          "readyDescription": "55555",
+          "connectAction": "55555",
           "unavailableTitle": "yyyyy",
-          "unavailableDescription": "This deployment requires an app maintained by your organization. Use the advanced setup below to add one."
+          "unavailableDescription": "55555"
         },
         "actions": {
           "disconnectProviders": "55555",
@@ -1688,7 +1688,7 @@
           "setDefault": "55555",
           "setDefaultHelp": "55555",
           "storedSecretHint": "55555 {{secret}} 55555",
-          "tenantId": "Microsoft tenant ID",
+          "tenantId": "55555",
           "capabilities": "55555",
           "capabilitiesHelp": "55555"
         },
@@ -1725,7 +1725,7 @@
           "teamsScopes": "55555",
           "teamsTabRedirect": "55555",
           "teamsTitle": "55555",
-          "tenantId": "Microsoft tenant ID",
+          "tenantId": "55555",
           "unavailable": "55555"
         },
         "profileCard": {
@@ -1742,7 +1742,7 @@
           "setDefault": "55555",
           "storedSecret": "55555",
           "teamsAppIdUri": "55555",
-          "tenantIdLabel": "Microsoft tenant ID:",
+          "tenantIdLabel": "55555",
           "updating": "55555",
           "enabledCapabilities": "55555",
           "noEnabledCapabilities": "55555"
@@ -1759,14 +1759,14 @@
           "archived": "55555",
           "clientIdMissing": "55555",
           "clientSecretMissing": "55555",
-          "tenantIdMissing": "Add a Microsoft tenant ID.",
-          "adminConsentPending": "Ask a Microsoft 365 administrator to approve access for Email."
+          "tenantIdMissing": "55555",
+          "adminConsentPending": "55555"
         },
         "statusBadges": {
           "archived": "55555",
           "needsAttention": "55555",
           "ready": "55555",
-          "waitingForAdminApproval": "Waiting for admin approval"
+          "waitingForAdminApproval": "55555"
         },
         "title": "55555",
         "toasts": {
@@ -1793,7 +1793,7 @@
           "clientIdRequired": "55555",
           "clientSecretRequired": "55555",
           "displayNameRequired": "55555",
-          "tenantIdRequired": "Microsoft tenant ID is required"
+          "tenantIdRequired": "55555"
         }
       }
     },

--- a/server/public/locales/yy/msp/integrations.json
+++ b/server/public/locales/yy/msp/integrations.json
@@ -1518,35 +1518,40 @@
     },
     "microsoft": {
       "emailSetup": {
-        "action": "55555",
+        "action": "Set up Microsoft",
         "actions": {
           "back": "55555",
           "cancel": "55555",
           "copy": "55555",
           "finish": "55555",
-          "grantConsent": "55555",
           "savePlatform": "55555",
           "signIn": "55555",
-          "working": "55555"
+          "working": "55555",
+          "approve": "Approve in Microsoft",
+          "copyApprovalLink": "Copy approval link for your admin",
+          "saveManual": "Save app and continue"
         },
         "automated": {
-          "description": "55555",
-          "title": "55555"
+          "description": "Alga PSA registers a dedicated Entra app automatically. Sign in as a Microsoft 365 administrator.",
+          "title": "Create an app in your Microsoft organization"
         },
         "callbackUri": "55555",
         "complete": {
-          "consentDone": "55555",
-          "consentPending": "55555",
-          "profileCreated": "55555"
+          "consentDone": "Approved by your Microsoft 365 administrator. You can now connect a mailbox.",
+          "consentPending": "A Microsoft 365 administrator for your organization must approve access before mailboxes can connect.",
+          "profileCreated": "55555",
+          "ready": "Microsoft is ready",
+          "waiting": "Waiting for admin approval"
         },
         "consent": {
           "confirmedDescription": "55555",
           "confirmedTitle": "55555",
           "url": "55555",
-          "urlLabel": "55555"
+          "urlLabel": "55555",
+          "approvalLink": "Approval link"
         },
         "copied": "55555 {{label}} 55555",
-        "description": "55555",
+        "description": "Choose how Alga PSA connects to Microsoft. You will connect mailboxes separately.",
         "errors": {
           "automated": "55555",
           "generic": "55555",
@@ -1554,38 +1559,46 @@
           "platform": "55555",
           "popupBlocked": "55555",
           "popupClosed": "55555",
-          "tenantRequired": "55555"
+          "tenantRequired": "55555",
+          "manual": "Could not configure the Microsoft app.",
+          "manualRequired": "Enter the display name, client ID, client secret, and Microsoft tenant ID.",
+          "pendingProfileMissing": "The pending Microsoft app could not be found.",
+          "approvalLink": "Could not create the Microsoft approval link."
         },
         "fields": {
           "clientId": "55555",
           "displayName": "55555",
-          "tenant": "55555",
-          "tenantId": "55555"
+          "tenantId": "Microsoft tenant ID",
+          "clientSecret": "Client secret",
+          "microsoftTenant": "Microsoft tenant ID or verified domain",
+          "redirectUri": "Redirect URI to add in Entra"
         },
         "manual": {
-          "description": "55555",
+          "description": "Use an existing Entra app maintained by your organization.",
           "title": "55555"
         },
         "platform": {
-          "description": "55555",
-          "title": "55555"
+          "description": "Nothing to register in Microsoft Entra. Your Microsoft 365 administrator approves access.",
+          "title": "Use the app provided by Alga PSA"
         },
-        "title": "55555",
-        "unavailable": "55555"
+        "title": "Set up Microsoft",
+        "unavailable": "55555",
+        "recommended": "Recommended",
+        "advanced": "Advanced"
       },
       "settings": {
         "advanced": {
-          "title": "55555",
-          "description": "55555",
-          "warning": "55555"
+          "title": "Manual Microsoft apps (advanced)",
+          "description": "Create and manage Entra app registrations maintained by your organization.",
+          "warning": "yyyyy"
         },
         "platform": {
-          "title": "55555",
-          "description": "55555",
-          "readyDescription": "55555",
-          "connectAction": "55555",
-          "unavailableTitle": "55555",
-          "unavailableDescription": "55555"
+          "title": "yyyyy",
+          "description": "yyyyy",
+          "readyDescription": "The Microsoft app is approved and ready for mailbox sign-in.",
+          "connectAction": "Connect a mailbox →",
+          "unavailableTitle": "yyyyy",
+          "unavailableDescription": "This deployment requires an app maintained by your organization. Use the advanced setup below to add one."
         },
         "actions": {
           "disconnectProviders": "55555",
@@ -1675,7 +1688,7 @@
           "setDefault": "55555",
           "setDefaultHelp": "55555",
           "storedSecretHint": "55555 {{secret}} 55555",
-          "tenantId": "55555",
+          "tenantId": "Microsoft tenant ID",
           "capabilities": "55555",
           "capabilitiesHelp": "55555"
         },
@@ -1712,7 +1725,7 @@
           "teamsScopes": "55555",
           "teamsTabRedirect": "55555",
           "teamsTitle": "55555",
-          "tenantId": "55555",
+          "tenantId": "Microsoft tenant ID",
           "unavailable": "55555"
         },
         "profileCard": {
@@ -1729,7 +1742,7 @@
           "setDefault": "55555",
           "storedSecret": "55555",
           "teamsAppIdUri": "55555",
-          "tenantIdLabel": "55555",
+          "tenantIdLabel": "Microsoft tenant ID:",
           "updating": "55555",
           "enabledCapabilities": "55555",
           "noEnabledCapabilities": "55555"
@@ -1746,13 +1759,14 @@
           "archived": "55555",
           "clientIdMissing": "55555",
           "clientSecretMissing": "55555",
-          "tenantIdMissing": "55555",
-          "adminConsentPending": "55555"
+          "tenantIdMissing": "Add a Microsoft tenant ID.",
+          "adminConsentPending": "Ask a Microsoft 365 administrator to approve access for Email."
         },
         "statusBadges": {
           "archived": "55555",
           "needsAttention": "55555",
-          "ready": "55555"
+          "ready": "55555",
+          "waitingForAdminApproval": "Waiting for admin approval"
         },
         "title": "55555",
         "toasts": {
@@ -1779,7 +1793,7 @@
           "clientIdRequired": "55555",
           "clientSecretRequired": "55555",
           "displayNameRequired": "55555",
-          "tenantIdRequired": "55555"
+          "tenantIdRequired": "Microsoft tenant ID is required"
         }
       }
     },

--- a/server/src/test/unit/components/EmailProviderConfiguration.test.tsx
+++ b/server/src/test/unit/components/EmailProviderConfiguration.test.tsx
@@ -192,16 +192,12 @@ describe('EmailProviderConfiguration', () => {
     vi.clearAllMocks();
     getMicrosoftConsumerSetupStatusMock.mockResolvedValue({
       success: true,
-      ready: true,
-      credentialCapability: {
+      emailSetup: {
+        state: 'ready',
         source: 'platform',
-        ready: true,
-        platformReady: true,
-        tenantProfileSelected: false,
-        clientIdConfigured: true,
-        clientSecretConfigured: true,
-        tenantIdConfigured: true,
-        profileId: null,
+        hosted: true,
+        platformOffered: true,
+        automatedCreationAvailable: true,
       },
     });
   });
@@ -234,14 +230,15 @@ describe('EmailProviderConfiguration', () => {
     expect(emailProviderActions.getEmailProviders).toHaveBeenCalled();
   });
 
-  it('shows platform-managed Microsoft setup as the primary hosted path', async () => {
+  it('points Microsoft app setup to Providers without duplicating the setup steps', async () => {
     vi.mocked(emailProviderActions.getEmailProviders).mockResolvedValueOnce({ providers: [] } as any);
 
     render(<EmailProviderConfiguration />);
 
-    expect(await screen.findByText('Microsoft sign-in is ready')).toBeInTheDocument();
-    expect(screen.getByText(/no Entra app registration is needed/i)).toBeInTheDocument();
-    expect(screen.getByText('Advanced: use your own Microsoft app')).toBeInTheDocument();
+    expect(await screen.findByText('Microsoft app setup is managed in Providers.')).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Open Providers' })).toBeInTheDocument();
+    expect(screen.queryByText(/no Entra app registration is needed/i)).not.toBeInTheDocument();
+    expect(screen.queryByText(/use your own Microsoft app/i)).not.toBeInTheDocument();
     expect(screen.queryByText('Register an application in Azure AD')).not.toBeInTheDocument();
   });
 

--- a/server/src/test/unit/components/MicrosoftProviderForm.test.tsx
+++ b/server/src/test/unit/components/MicrosoftProviderForm.test.tsx
@@ -15,7 +15,6 @@ vi.mock('@alga-psa/integrations/actions', () => ({
   createEmailProvider: vi.fn(),
   updateEmailProvider: vi.fn(),
   upsertEmailProvider: vi.fn(),
-  getMicrosoftConsumerSetupStatus: vi.fn().mockResolvedValue({ success: true, ready: true, message: null }),
   initiateEmailOAuth: vi.fn().mockResolvedValue({ success: false, error: 'not used in unit tests' }),
   getInboundTicketDefaults: vi.fn().mockResolvedValue({ defaults: [] }),
 }));
@@ -30,15 +29,12 @@ describe('MicrosoftProviderForm', () => {
     tenant: 'test-tenant-123',
     onSuccess: mockOnSuccess,
     onCancel: mockOnCancel,
-    credentialCapability: {
+    emailSetup: {
+      state: 'ready' as const,
       source: 'platform' as const,
-      ready: true,
-      platformReady: true,
-      tenantProfileSelected: false,
-      clientIdConfigured: true,
-      clientSecretConfigured: true,
-      tenantIdConfigured: true,
-      profileId: null,
+      hosted: true,
+      platformOffered: true,
+      automatedCreationAvailable: true,
     },
   };
 
@@ -64,9 +60,9 @@ describe('MicrosoftProviderForm', () => {
 
     expect(screen.getByPlaceholderText('e.g., Support Mailbox (internal)')).toBeInTheDocument();
     expect(screen.getByPlaceholderText('support@client.com')).toBeInTheDocument();
-    expect(screen.getByPlaceholderText('https://yourapp.com/api/auth/microsoft/callback')).toBeInTheDocument();
+    expect(screen.queryByText('Redirect URI')).not.toBeInTheDocument();
     expect(screen.getByPlaceholderText('Inbox, Support, Custom Folder')).toBeInTheDocument();
-    expect(screen.getByRole('button', { name: /authorize access/i })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /sign in with microsoft/i })).toBeInTheDocument();
     expect(screen.getByRole('button', { name: /add provider/i })).toBeInTheDocument();
   });
 
@@ -180,12 +176,10 @@ describe('MicrosoftProviderForm', () => {
         mailbox: 'test@microsoft.com',
         isActive: true,
         inboundTicketDefaultsId: undefined,
-        microsoftCredentialSource: 'platform',
         microsoftConfig: {
           client_id: '',
           client_secret: '',
           tenant_id: '',
-          redirect_uri: 'http://localhost:3000/api/auth/microsoft/callback',
           auto_process_emails: true,
           folder_filters: ['Inbox'],
           max_emails_per_sync: 50,
@@ -217,47 +211,51 @@ describe('MicrosoftProviderForm', () => {
     });
   });
 
-  it('defaults hosted setup to the platform-managed Microsoft app', () => {
+  it('shows the ready state and enables Microsoft sign-in', () => {
     renderWithProviders(<MicrosoftProviderForm {...defaultProps} />);
 
-    expect(screen.getByText('Platform-managed Microsoft app')).toBeInTheDocument();
-    expect(screen.getByText(/No Entra app registration/i)).toBeInTheDocument();
-    expect(screen.queryByText(/normally unnecessary on hosted/i)).not.toBeInTheDocument();
+    expect(screen.getByText('Microsoft is set up. Sign in as this mailbox to finish.')).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /sign in with microsoft/i })).toBeEnabled();
+    expect(screen.queryByText(/platform-managed/i)).not.toBeInTheDocument();
   });
 
-  it('reveals tenant-owned app setup only after the advanced toggle is selected', async () => {
-    const user = userEvent.setup();
-    renderWithProviders(<MicrosoftProviderForm {...defaultProps} />);
-
-    await user.click(screen.getByRole('button', { name: /Use your own Microsoft app/i }));
-
-    expect(screen.getByText(/normally unnecessary on hosted Alga PSA/i)).toBeInTheDocument();
-    expect(screen.getByRole('button', { name: /Open Providers Settings/i })).toBeInTheDocument();
-  });
-
-  it('shows one Providers Settings action when a tenant-owned app is not ready', async () => {
+  it('shows one Providers action while administrator approval is pending', () => {
     renderWithProviders(
       <MicrosoftProviderForm
         {...defaultProps}
-        credentialCapability={{
-          source: 'tenant',
-          ready: false,
-          platformReady: true,
-          tenantProfileSelected: true,
-          clientIdConfigured: true,
-          clientSecretConfigured: true,
-          tenantIdConfigured: true,
+        emailSetup={{
+          state: 'pending_admin_consent',
+          source: 'tenant_app',
+          hosted: true,
+          platformOffered: true,
+          automatedCreationAvailable: true,
           profileId: 'microsoft-profile-123',
-          message: 'Microsoft admin consent is still pending.',
         }}
       />
     );
 
-    await waitFor(() => {
-      expect(screen.getByText('Your Microsoft app is not ready yet.')).toBeInTheDocument();
-    });
-    expect(screen.getAllByRole('button', { name: /Open Providers Settings/i })).toHaveLength(1);
-    expect(screen.getByRole('button', { name: /Authorize Access/i })).toBeDisabled();
+    expect(screen.getByText(/Waiting for your Microsoft 365 administrator/i)).toBeInTheDocument();
+    expect(screen.getAllByRole('button', { name: /Open Providers/i })).toHaveLength(1);
+    expect(screen.getByRole('button', { name: /Sign in with Microsoft/i })).toBeDisabled();
+  });
+
+  it('points an unconfigured mailbox to Providers', () => {
+    renderWithProviders(
+      <MicrosoftProviderForm
+        {...defaultProps}
+        emailSetup={{
+          state: 'not_configured',
+          source: null,
+          hosted: true,
+          platformOffered: true,
+          automatedCreationAvailable: true,
+        }}
+      />
+    );
+
+    expect(screen.getByText(/Microsoft isn't set up yet/i)).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /Set up in Providers/i })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /Sign in with Microsoft/i })).toBeDisabled();
   });
 
   it('should call onCancel when cancel button is clicked', async () => {

--- a/server/src/test/unit/microsoft/microsoftConsumerRuntimeResolution.contract.test.ts
+++ b/server/src/test/unit/microsoft/microsoftConsumerRuntimeResolution.contract.test.ts
@@ -67,7 +67,8 @@ describe('microsoft consumer runtime resolution contracts', () => {
     expect(sharedResolverSource).toContain('resolveMicrosoftBindingCandidateProfile(db, tenant, secretProvider, consumerType)');
     expect(sharedResolverSource).not.toContain("from '../actions/integrations/microsoftActions'");
 
-    expect(emailOauthActionSource).toContain('resolveMicrosoftConsumerProfileConfig(tenant, \'email\')');
+    expect(emailOauthActionSource).toContain("resolveMicrosoftConsumerProfileConfig(tenant, 'email', {");
+    expect(emailOauthActionSource).toContain("credentialPreference: 'tenant'");
     expect(emailOauthActionSource).not.toContain("getTenantSecret(tenant, 'microsoft_client_id')");
     expect(emailOauthActionSource).not.toContain('process.env.MICROSOFT_CLIENT_ID');
     expect(emailProviderActionSource).toContain('preserveIssuingApp');


### PR DESCRIPTION
## Summary

- Make Providers the single place to configure the Microsoft application used by email, with hosted-only platform setup, self-host gating, automated Entra setup availability, and an Advanced manual path with a server-derived read-only callback URI.
- Reduce Communication mailbox setup to mailbox details, a three-state Microsoft readiness indicator, and mailbox sign-in; OAuth and persistence now derive the callback server-side and resolve only the tenant-preferred Email profile.
- Add focused provider/readiness/UI coverage plus a sealed, independently verifiable smoke-evidence workflow with exact profile, binding, secret, timestamp, session-cleanup, checksum, and tamper checks.

## Validation

- PASS — 83 focused Microsoft cleanup tests.
- PASS — Integrations typecheck/Nx dependency build, server typecheck, and the EE server typecheck used by CI.
- PASS — Microsoft consumer runtime resolution contract.
- PASS — fresh run `749eced8-b01c-4239-a426-a1b282ec8272` against the real port-3100 product at clean HEAD `58085a048a`.

The smoke exercised real credential-form login; self-host Providers wizard gating; Advanced manual setup with a server-derived, read-only callback URI; pending-administrator-approval mailbox state using the repository’s reversible fixture; restored not-configured mailbox state; adjacent Gmail/Microsoft 365/IMAP provider choices; tracked session cleanup; and exact database and secret restoration.

The sealed verifier passed 15/15 claims in 0.04s. All 37 checksummed files passed `sha256sum`. Byte tampering, evidence-file deletion, and an edited `00-REVIEW.md` followed by dishonest re-sealing each correctly exited 1. Both temporary sessions were deleted; profiles, bindings, and restorable secret inventory matched the baseline exactly, including directory mtime `1785886890527 ms`. `ctime unexpectedChanges` was empty. The worktree remained clean.

Evidence: `/tmp/alga-smoke-evidence/microsoft-graph-cleanup-20260805T184017Z`

## Fidelity and known baseline conditions

The required card-scoped browser tab was created, but alga-dev rejected navigation because the pane belongs to the Mac host. UI interaction therefore used local Puppeteer/headless Chrome against the same real port-3100 app. The existing repository fixture simulated pending Microsoft administrator consent; no mock was used. External Microsoft Graph/Entra OAuth was not called.

The environment already displays a seven-day license-expiry warning and a baseline Microsoft provider Error card. Neither was introduced by this run, and exact restoration confirms the smoke left no fixture residue.

