### PR TITLE
alga0002194: Renewal suggestion workflow fails every run (NULL payload_json vs strict clock schema)

### DIFF
--- a/docs/plans/2026-08-05-renewal-clock-payload-plan.md
+++ b/docs/plans/2026-08-05-renewal-clock-payload-plan.md
@@ -1,0 +1,29 @@
+# Repair scheduled workflow clock payloads
+
+## Intent
+
+Make clock-pinned recurring workflows launch with the strict synthetic clock payload the UI promises, including existing renewal-suggestion schedules and newly published time-triggered workflows.
+
+## Code findings
+
+The branch is clean at `860071a686`. Direct inspection confirmed `workflowScheduledRunHandlers.ts` builds clock metadata but launches with `schedule.payload_json ?? {}`; that metadata includes `scheduleName`, which the strict `WorkflowClockTrigger` schema does not allow. `workflowScheduleLifecycle.ts` also writes `{}` for inline schedules, while the 20260713 opportunity seed pins the clock schema without seeding a payload.
+
+## Implementation
+
+1. Add a small typed helper in the scheduled-run handler that derives the exact `WorkflowClockTriggerPayload` fields from schedule/run context and deliberately omits display-only `scheduleName`.
+2. Resolve the workflow version's effective payload schema before launch. When it is `WORKFLOW_CLOCK_PAYLOAD_SCHEMA_REF`, use the synthetic clock payload; otherwise preserve the stored `payload_json` behavior.
+3. Keep the richer trigger metadata (including schedule name) separate for observability; do not relax the strict schema merely to accept metadata.
+4. Add a forward migration that repairs the seeded renewal schedule rows for existing tenants in an idempotent, tenant-safe way. Prefer repairing schedule registration/state without inventing stale timestamps; runtime synthesis remains the source of truth for each fire.
+5. Align the onboarding seed and inline schedule creation path so new clock schedules do not depend on a user-authored payload.
+6. Add behavioral tests for a clock-pinned scheduled launch, a non-clock schedule retaining its payload, strict omission of `scheduleName`, existing renewal-row migration, and newly published time-triggered workflow registration.
+7. Run focused workflow/job tests and migration tests, then trigger the renewal schedule against the wired stack and confirm step history begins rather than failing pre-step validation.
+
+## Deliberate non-goals
+
+- Do not weaken `workflowClockTriggerPayloadSchema.strict()`.
+- Do not synthesize clock payloads for arbitrary schemas.
+- Do not change cron timing or renewal suggestion business logic.
+
+## Risks
+
+Schema resolution must match the exact workflow version being launched. Migration selection must be narrow enough not to rewrite unrelated tenant schedules.

--- a/ee/packages/workflows/src/lib/__tests__/workflowClockPayload.test.ts
+++ b/ee/packages/workflows/src/lib/__tests__/workflowClockPayload.test.ts
@@ -1,0 +1,74 @@
+import { describe, expect, it } from 'vitest';
+import { workflowClockTriggerPayloadSchema } from '@alga-psa/workflows/runtime/core';
+import {
+  buildWorkflowClockPayload,
+  isClockPinnedSchemaRef,
+  WORKFLOW_CLOCK_PAYLOAD_SCHEMA_REF
+} from '@alga-psa/workflows/lib/workflowClockPayload';
+
+describe('workflowClockPayload', () => {
+  it('builds a clock payload that passes the strict schema and omits display-only fields', () => {
+    const payload = buildWorkflowClockPayload({
+      scheduleId: 'sched-1',
+      workflowId: 'wf-1',
+      workflowVersion: 4,
+      triggerType: 'recurring',
+      scheduledFor: '2026-08-06T06:00:00.000Z',
+      cron: '0 6 * * *',
+      timezone: 'UTC'
+    });
+
+    const parsed = workflowClockTriggerPayloadSchema.safeParse(payload);
+    expect(parsed.success).toBe(true);
+    expect(workflowClockTriggerPayloadSchema.parse(payload)).toMatchObject({
+      triggerType: 'recurring',
+      scheduleId: 'sched-1',
+      scheduledFor: '2026-08-06T06:00:00.000Z',
+      timezone: 'UTC',
+      workflowId: 'wf-1',
+      workflowVersion: 4,
+      cron: '0 6 * * *'
+    });
+    // .strict() must reject a stray scheduleName; the builder never emits it.
+    expect('scheduleName' in payload).toBe(false);
+    expect(typeof payload.firedAt).toBe('string');
+  });
+
+  it('omits cron and defaults timezone for one-time schedule triggers', () => {
+    const payload = buildWorkflowClockPayload({
+      scheduleId: 'sched-2',
+      workflowId: 'wf-2',
+      workflowVersion: 1,
+      triggerType: 'schedule',
+      scheduledFor: '2026-08-09T10:00:00.000Z',
+      timezone: null
+    });
+
+    expect(payload).toMatchObject({
+      triggerType: 'schedule',
+      timezone: 'UTC'
+    });
+    expect('cron' in payload).toBe(false);
+    expect(workflowClockTriggerPayloadSchema.safeParse(payload).success).toBe(true)
+  });
+
+  it('falls back to firedAt when scheduledFor is invalid or missing', () => {
+    const payload = buildWorkflowClockPayload({
+      scheduleId: 'sched-3',
+      workflowId: 'wf-3',
+      workflowVersion: 2,
+      triggerType: 'recurring',
+      scheduledFor: 'not-a-date',
+      cron: '0 6 * * *',
+      timezone: 'UTC'
+    });
+
+    expect(payload.scheduledFor).toBe(payload.firedAt);
+  });
+
+  it('marks the clock schema ref as clock-pinned and ignores unrelated refs', () => {
+    expect(isClockPinnedSchemaRef(WORKFLOW_CLOCK_PAYLOAD_SCHEMA_REF)).toBe(true);
+    expect(isClockPinnedSchemaRef('payload.OpportunityStalled.v1')).toBe(false);
+    expect(isClockPinnedSchemaRef(null)).toBe(false);
+  });
+});

--- a/ee/packages/workflows/src/lib/__tests__/workflowScheduleLifecycle.inline-schedule.test.ts
+++ b/ee/packages/workflows/src/lib/__tests__/workflowScheduleLifecycle.inline-schedule.test.ts
@@ -50,6 +50,7 @@ vi.mock('@alga-psa/workflows/persistence', async () => {
   };
 });
 
+import { WorkflowDefinitionVersionModelV2, WorkflowScheduleStateModel } from '@alga-psa/workflows/persistence';
 import { registerWorkflowScheduleJobRunner, resetWorkflowScheduleJobRunner } from '@alga-psa/workflows/lib/jobRunnerProvider';
 import { syncWorkflowScheduleState } from '@alga-psa/workflows/lib/workflowScheduleLifecycle';
 
@@ -153,5 +154,38 @@ describe('workflowScheduleLifecycle inline schedule creation', () => {
       cron: '0 6 * * *'
     });
     expect(workflowClockTriggerPayloadSchema.safeParse(schedule?.payload_json).success).toBe(true);
+  });
+
+  it('leaves no provider job registered when payload schema resolution fails before scheduling', async () => {
+    const workflowId = uuidv4();
+    runner.scheduleRecurringJob.mockClear();
+    runner.scheduleJobAt.mockClear();
+    vi.mocked(WorkflowScheduleStateModel.create).mockClear();
+    vi.mocked(WorkflowDefinitionVersionModelV2.getByWorkflowAndVersion).mockRejectedValueOnce(
+      new Error('version lookup failed')
+    );
+
+    await expect(
+      syncWorkflowScheduleState(knex, {
+        tenantId: 'tenant-1',
+        workflowId,
+        desired: {
+          triggerType: 'recurring',
+          workflowVersion: 5,
+          dayTypeFilter: 'any',
+          cron: '0 6 * * *',
+          timezone: 'UTC',
+          enabled: true,
+          status: 'scheduled'
+        }
+      })
+    ).rejects.toThrow('version lookup failed');
+
+    // Resolution runs before provider registration, so a resolver failure must
+    // not orphan an external job or persist any schedule state.
+    expect(runner.scheduleRecurringJob).not.toHaveBeenCalled();
+    expect(runner.scheduleJobAt).not.toHaveBeenCalled();
+    expect(WorkflowScheduleStateModel.create).not.toHaveBeenCalled();
+    expect(scheduleState.size).toBe(0);
   });
 });

--- a/ee/packages/workflows/src/lib/__tests__/workflowScheduleLifecycle.inline-schedule.test.ts
+++ b/ee/packages/workflows/src/lib/__tests__/workflowScheduleLifecycle.inline-schedule.test.ts
@@ -1,0 +1,121 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { v4 as uuidv4 } from 'uuid';
+
+import { WORKFLOW_CLOCK_PAYLOAD_SCHEMA_REF } from '@alga-psa/workflows/runtime';
+import { workflowClockTriggerPayloadSchema } from '@alga-psa/workflows/runtime/core';
+
+type ScheduleRow = Record<string, any>;
+
+const scheduleState = new Map<string, ScheduleRow>();
+const versionsByNumber = new Map<number, Record<string, any>>();
+
+const runner = {
+  scheduleJobAt: vi.fn(async () => ({ jobId: uuidv4(), externalId: `one-${uuidv4()}` })),
+  scheduleRecurringJob: vi.fn(async () => ({ jobId: uuidv4(), externalId: `rec-${uuidv4()}` })),
+  cancelJob: vi.fn(async () => true),
+  getJobStatus: vi.fn(async () => ({ status: 'cancelled' }))
+};
+
+vi.mock('@alga-psa/workflows/persistence', async () => {
+  const { WorkflowScheduleStateModel } = await vi.importActual<typeof import('@alga-psa/workflows/persistence')>(
+    '@alga-psa/workflows/persistence'
+  );
+  return {
+    ...(await vi.importActual<typeof import('@alga-psa/workflows/persistence')>(
+      '@alga-psa/workflows/persistence'
+    )),
+    WorkflowScheduleStateModel: {
+      ...WorkflowScheduleStateModel,
+      getByWorkflowId: vi.fn(async (_knex: unknown, workflowId: string) =>
+        Array.from(scheduleState.values()).find((row) => row.workflow_id === workflowId) ?? null),
+      create: vi.fn(async (_knex: unknown, data: ScheduleRow) => {
+        const record: ScheduleRow = {
+          created_at: new Date().toISOString(),
+          updated_at: new Date().toISOString(),
+          ...data
+        };
+        scheduleState.set(String(record.id), record);
+        return record;
+      })
+    },
+    WorkflowDefinitionVersionModelV2: {
+      getByWorkflowAndVersion: vi.fn(async (_knex: unknown, _workflowId: string, version: number) =>
+        versionsByNumber.get(Number(version)) ?? null)
+    }
+  };
+});
+
+import { registerWorkflowScheduleJobRunner, resetWorkflowScheduleJobRunner } from '@alga-psa/workflows/lib/jobRunnerProvider';
+import { syncWorkflowScheduleState } from '@alga-psa/workflows/lib/workflowScheduleLifecycle';
+
+const knex = {} as any;
+
+describe('workflowScheduleLifecycle inline schedule creation', () => {
+  beforeEach(() => {
+    scheduleState.clear();
+    versionsByNumber.clear();
+    registerWorkflowScheduleJobRunner(async () => runner);
+  });
+
+  afterEach(() => {
+    resetWorkflowScheduleJobRunner();
+    vi.restoreAllMocks();
+  });
+
+  it('creates a schedule holding a strict-valid clock payload for a clock-pinned time-triggered workflow', async () => {
+    const workflowId = uuidv4();
+    versionsByNumber.set(3, {
+      version: 3,
+      definition_json: { id: workflowId, version: 3, payloadSchemaRef: WORKFLOW_CLOCK_PAYLOAD_SCHEMA_REF }
+    });
+
+    const schedule = await syncWorkflowScheduleState(knex, {
+      tenantId: 'tenant-1',
+      workflowId,
+      desired: {
+        triggerType: 'recurring',
+        workflowVersion: 3,
+        dayTypeFilter: 'any',
+        cron: '0 6 * * *',
+        timezone: 'UTC',
+        enabled: true,
+        status: 'scheduled'
+      }
+    });
+
+    expect(schedule).not.toBeNull();
+    expect(schedule?.payload_json).not.toBeNull();
+    expect(schedule?.payload_json).toMatchObject({
+      triggerType: 'recurring',
+      workflowId,
+      workflowVersion: 3,
+      timezone: 'UTC',
+      cron: '0 6 * * *'
+    });
+    expect((schedule?.payload_json as Record<string, unknown>)?.scheduleName).toBeUndefined();
+    expect(workflowClockTriggerPayloadSchema.safeParse(schedule?.payload_json).success).toBe(true);
+  });
+
+  it('keeps the legacy `{}` payload for non-clock time-triggered workflows', async () => {
+    const workflowId = uuidv4();
+    versionsByNumber.set(1, {
+      version: 1,
+      definition_json: { id: workflowId, version: 1, payloadSchemaRef: 'payload.OpportunityStalled.v1' }
+    });
+
+    const schedule = await syncWorkflowScheduleState(knex, {
+      tenantId: 'tenant-1',
+      workflowId,
+      desired: {
+        triggerType: 'schedule',
+        workflowVersion: 1,
+        dayTypeFilter: 'any',
+        runAt: '2099-01-01T10:00:00.000Z',
+        enabled: true,
+        status: 'scheduled'
+      }
+    });
+
+    expect(schedule?.payload_json).toEqual({});
+  });
+});

--- a/ee/packages/workflows/src/lib/__tests__/workflowScheduleLifecycle.inline-schedule.test.ts
+++ b/ee/packages/workflows/src/lib/__tests__/workflowScheduleLifecycle.inline-schedule.test.ts
@@ -8,6 +8,7 @@ type ScheduleRow = Record<string, any>;
 
 const scheduleState = new Map<string, ScheduleRow>();
 const versionsByNumber = new Map<number, Record<string, any>>();
+const workflowById = new Map<string, Record<string, any>>();
 
 const runner = {
   scheduleJobAt: vi.fn(async () => ({ jobId: uuidv4(), externalId: `one-${uuidv4()}` })),
@@ -41,6 +42,10 @@ vi.mock('@alga-psa/workflows/persistence', async () => {
     WorkflowDefinitionVersionModelV2: {
       getByWorkflowAndVersion: vi.fn(async (_knex: unknown, _workflowId: string, version: number) =>
         versionsByNumber.get(Number(version)) ?? null)
+    },
+    WorkflowDefinitionModelV2: {
+      getById: vi.fn(async (_knex: unknown, _tenant: string, workflowId: string) =>
+        workflowById.get(workflowId) ?? null)
     }
   };
 });
@@ -54,6 +59,7 @@ describe('workflowScheduleLifecycle inline schedule creation', () => {
   beforeEach(() => {
     scheduleState.clear();
     versionsByNumber.clear();
+    workflowById.clear();
     registerWorkflowScheduleJobRunner(async () => runner);
   });
 
@@ -117,5 +123,35 @@ describe('workflowScheduleLifecycle inline schedule creation', () => {
     });
 
     expect(schedule?.payload_json).toEqual({});
+  });
+
+  it('falls back to the workflow payload_schema_ref when the version lacks a def ref', async () => {
+    const workflowId = uuidv4();
+    // Version has no definition_json.payloadSchemaRef; only the workflow row does.
+    versionsByNumber.set(2, { version: 2, definition_json: { id: workflowId, version: 2 } });
+    workflowById.set(workflowId, { workflow_id: workflowId, payload_schema_ref: WORKFLOW_CLOCK_PAYLOAD_SCHEMA_REF });
+
+    const schedule = await syncWorkflowScheduleState(knex, {
+      tenantId: 'tenant-1',
+      workflowId,
+      desired: {
+        triggerType: 'recurring',
+        workflowVersion: 2,
+        dayTypeFilter: 'any',
+        cron: '0 6 * * *',
+        timezone: 'UTC',
+        enabled: true,
+        status: 'scheduled'
+      }
+    });
+
+    expect(schedule?.payload_json).toMatchObject({
+      triggerType: 'recurring',
+      workflowId,
+      workflowVersion: 2,
+      timezone: 'UTC',
+      cron: '0 6 * * *'
+    });
+    expect(workflowClockTriggerPayloadSchema.safeParse(schedule?.payload_json).success).toBe(true);
   });
 });

--- a/ee/packages/workflows/src/lib/workflowClockPayload.ts
+++ b/ee/packages/workflows/src/lib/workflowClockPayload.ts
@@ -1,6 +1,6 @@
 import type { Knex } from 'knex';
 
-import { WorkflowDefinitionVersionModelV2 } from '@alga-psa/workflows/persistence';
+import { WorkflowDefinitionModelV2, WorkflowDefinitionVersionModelV2 } from '@alga-psa/workflows/persistence';
 import {
   WORKFLOW_CLOCK_PAYLOAD_SCHEMA_REF,
   type WorkflowClockTriggerPayload
@@ -53,20 +53,26 @@ export const buildWorkflowClockPayload = (params: {
 
 /**
  * Resolve the effective payload schema ref for the exact workflow version being
- * launched. Mirrors workflowRunLauncher's primary source: the version's own
- * `definition_json.payloadSchemaRef`. The handler uses this to decide whether a
- * schedule is clock-pinned (and must launch with the synthetic clock payload)
- * versus a normal schedule that keeps its stored `payload_json`.
+ * launched. Mirrors workflowRunLauncher's resolution: the version's own
+ * `definition_json.payloadSchemaRef` wins; when the version does not carry one,
+ * fall back to the workflow definition's `payload_schema_ref` column. The
+ * handler and the schedule lifecycle both use this to decide whether a schedule
+ * is clock-pinned (and must launch with the synthetic clock payload) versus a
+ * normal schedule that keeps its stored `payload_json`.
  */
 export const resolveWorkflowVersionPayloadSchemaRef = async (
   knex: Knex,
+  tenantId: string,
   workflowId: string,
   workflowVersion: number
 ): Promise<string | null> => {
   const version = await WorkflowDefinitionVersionModelV2.getByWorkflowAndVersion(knex, workflowId, workflowVersion);
-  if (!version) return null;
-  const definition = version.definition_json as Record<string, unknown> | null;
-  return typeof definition?.payloadSchemaRef === 'string' ? definition.payloadSchemaRef : null;
+  const definition = version?.definition_json as Record<string, unknown> | null;
+  if (definition && typeof definition.payloadSchemaRef === 'string') {
+    return definition.payloadSchemaRef;
+  }
+  const workflow = await WorkflowDefinitionModelV2.getById(knex, tenantId, workflowId);
+  return typeof workflow?.payload_schema_ref === 'string' ? workflow.payload_schema_ref : null;
 };
 
 export const isClockPinnedSchemaRef = (schemaRef: string | null | undefined): boolean =>

--- a/ee/packages/workflows/src/lib/workflowClockPayload.ts
+++ b/ee/packages/workflows/src/lib/workflowClockPayload.ts
@@ -1,0 +1,73 @@
+import type { Knex } from 'knex';
+
+import { WorkflowDefinitionVersionModelV2 } from '@alga-psa/workflows/persistence';
+import {
+  WORKFLOW_CLOCK_PAYLOAD_SCHEMA_REF,
+  type WorkflowClockTriggerPayload
+} from '@alga-psa/workflows/runtime/core';
+
+export { WORKFLOW_CLOCK_PAYLOAD_SCHEMA_REF };
+
+export const toIsoDateTime = (value: unknown): string | null => {
+  if (value instanceof Date) {
+    return Number.isNaN(value.getTime()) ? null : value.toISOString();
+  }
+  if (typeof value === 'string') {
+    const trimmed = value.trim();
+    if (!trimmed) return null;
+    const parsed = new Date(trimmed);
+    return Number.isNaN(parsed.getTime()) ? null : parsed.toISOString();
+  }
+  return null;
+};
+
+/**
+ * Synthesize the exact `WorkflowClockTriggerPayload` a clock-pinned schedule is
+ * expected to launch with. Deliberately omits display-only fields (e.g.
+ * `scheduleName`, which lives in trigger metadata) so it passes the strict
+ * schema unmodified. Timestamps are the schedule's occurrence / fire time and
+ * are always re-derived at each fire; the stored `payload_json` is a placeholder.
+ */
+export const buildWorkflowClockPayload = (params: {
+  scheduleId: string;
+  workflowId: string;
+  workflowVersion: number;
+  triggerType: 'schedule' | 'recurring';
+  scheduledFor?: string | null;
+  cron?: string | null;
+  timezone?: string | null;
+}): WorkflowClockTriggerPayload => {
+  const firedAt = new Date().toISOString();
+  const scheduledFor = toIsoDateTime(params.scheduledFor) ?? firedAt;
+  return {
+    triggerType: params.triggerType,
+    scheduleId: params.scheduleId,
+    scheduledFor,
+    firedAt,
+    timezone: params.timezone ?? 'UTC',
+    workflowId: params.workflowId,
+    workflowVersion: params.workflowVersion,
+    ...(params.triggerType === 'recurring' && params.cron ? { cron: params.cron } : {})
+  };
+};
+
+/**
+ * Resolve the effective payload schema ref for the exact workflow version being
+ * launched. Mirrors workflowRunLauncher's primary source: the version's own
+ * `definition_json.payloadSchemaRef`. The handler uses this to decide whether a
+ * schedule is clock-pinned (and must launch with the synthetic clock payload)
+ * versus a normal schedule that keeps its stored `payload_json`.
+ */
+export const resolveWorkflowVersionPayloadSchemaRef = async (
+  knex: Knex,
+  workflowId: string,
+  workflowVersion: number
+): Promise<string | null> => {
+  const version = await WorkflowDefinitionVersionModelV2.getByWorkflowAndVersion(knex, workflowId, workflowVersion);
+  if (!version) return null;
+  const definition = version.definition_json as Record<string, unknown> | null;
+  return typeof definition?.payloadSchemaRef === 'string' ? definition.payloadSchemaRef : null;
+};
+
+export const isClockPinnedSchemaRef = (schemaRef: string | null | undefined): boolean =>
+  schemaRef === WORKFLOW_CLOCK_PAYLOAD_SCHEMA_REF;

--- a/ee/packages/workflows/src/lib/workflowScheduleLifecycle.ts
+++ b/ee/packages/workflows/src/lib/workflowScheduleLifecycle.ts
@@ -12,6 +12,11 @@ import {
   getWorkflowScheduleJobRunner,
   type WorkflowScheduleJobResult as ScheduleJobResult
 } from './jobRunnerProvider';
+import {
+  buildWorkflowClockPayload,
+  isClockPinnedSchemaRef,
+  resolveWorkflowVersionPayloadSchemaRef
+} from './workflowClockPayload';
 import { computeNextFireAtForSchedule } from './computeNextFireAt';
 import { workflowTenantTable } from './workflowTenantDb';
 
@@ -612,6 +617,24 @@ export async function syncWorkflowScheduleState(
   if (!existing) {
     const scheduleId = uuidv4();
     const scheduled = await scheduleDesiredWorkflow(params.tenantId, params.workflowId, scheduleId, params.desired);
+    // Clock-pinned time-triggered workflows store a schema-valid placeholder so
+    // the schedule never depends on a user-authored payload; runtime synthesis
+    // re-derives the real clock payload at each fire. Omit display-only fields.
+    const versionSchemaRef = await resolveWorkflowVersionPayloadSchemaRef(
+      knex,
+      params.workflowId,
+      params.desired.workflowVersion
+    );
+    const payload = isClockPinnedSchemaRef(versionSchemaRef)
+      ? buildWorkflowClockPayload({
+          scheduleId,
+          workflowId: params.workflowId,
+          workflowVersion: params.desired.workflowVersion,
+          triggerType: params.desired.triggerType,
+          cron: params.desired.cron,
+          timezone: params.desired.timezone
+        })
+      : {};
     try {
       return await WorkflowScheduleStateModel.create(knex, {
         id: scheduleId,
@@ -625,7 +648,7 @@ export async function syncWorkflowScheduleState(
         run_at: params.desired.runAt ?? null,
         cron: params.desired.cron ?? null,
         timezone: params.desired.timezone ?? null,
-        payload_json: {},
+        payload_json: payload,
         enabled: params.desired.enabled,
         status: params.desired.status,
         job_id: scheduled?.jobId ?? null,

--- a/ee/packages/workflows/src/lib/workflowScheduleLifecycle.ts
+++ b/ee/packages/workflows/src/lib/workflowScheduleLifecycle.ts
@@ -616,10 +616,12 @@ export async function syncWorkflowScheduleState(
 
   if (!existing) {
     const scheduleId = uuidv4();
-    const scheduled = await scheduleDesiredWorkflow(params.tenantId, params.workflowId, scheduleId, params.desired);
     // Clock-pinned time-triggered workflows store a schema-valid placeholder so
     // the schedule never depends on a user-authored payload; runtime synthesis
     // re-derives the real clock payload at each fire. Omit display-only fields.
+    // Resolve the schema ref and synthesize the payload BEFORE registering the
+    // provider job: a resolution failure here must not leave an orphaned
+    // external schedule with no persisted state row.
     const versionSchemaRef = await resolveWorkflowVersionPayloadSchemaRef(
       knex,
       params.tenantId,
@@ -636,6 +638,7 @@ export async function syncWorkflowScheduleState(
           timezone: params.desired.timezone
         })
       : {};
+    const scheduled = await scheduleDesiredWorkflow(params.tenantId, params.workflowId, scheduleId, params.desired);
     try {
       return await WorkflowScheduleStateModel.create(knex, {
         id: scheduleId,

--- a/ee/packages/workflows/src/lib/workflowScheduleLifecycle.ts
+++ b/ee/packages/workflows/src/lib/workflowScheduleLifecycle.ts
@@ -622,6 +622,7 @@ export async function syncWorkflowScheduleState(
     // re-derives the real clock payload at each fire. Omit display-only fields.
     const versionSchemaRef = await resolveWorkflowVersionPayloadSchemaRef(
       knex,
+      params.tenantId,
       params.workflowId,
       params.desired.workflowVersion
     );

--- a/ee/server/seeds/onboarding/psa/10_opportunity_workflows.cjs
+++ b/ee/server/seeds/onboarding/psa/10_opportunity_workflows.cjs
@@ -84,6 +84,23 @@ function deterministicUuid(namespace, tenantId) {
   return `${hex.slice(0, 8)}-${hex.slice(8, 12)}-4${hex.slice(13, 16)}-8${hex.slice(17, 20)}-${hex.slice(20)}`;
 }
 
+// Placeholder seed payload for clock-pinned schedules. The runtime re-derives
+// the real clock payload at each fire (runtime synthesis is the source of
+// truth); this only ensures a freshly seeded clock schedule never carries a
+// NULL/`{}` payload that fails strict validation.
+function buildClockPlaceholderPayload(scheduleId, workflowId, workflowVersion, schedule, now) {
+  return {
+    triggerType: 'recurring',
+    scheduleId,
+    scheduledFor: now,
+    firedAt: now,
+    timezone: schedule.timezone,
+    workflowId,
+    workflowVersion,
+    ...(schedule.cron ? { cron: schedule.cron } : {}),
+  };
+}
+
 async function seedWorkflow(knex, tenantId, workflow) {
   const { tenantDb } = await import('@alga-psa/db');
   const db = tenantDb(knex, tenantId);
@@ -155,6 +172,13 @@ async function seedWorkflow(knex, tenantId, workflow) {
       day_type_filter: 'any',
       cron: workflow.schedule.cron,
       timezone: workflow.schedule.timezone,
+      payload_json: buildClockPlaceholderPayload(
+        scheduleId,
+        resolvedWorkflowId,
+        definition.version,
+        workflow.schedule,
+        now
+      ),
       enabled: true,
       status: 'scheduled',
       updated_at: now,

--- a/packages/jobs/src/lib/handlers/workflowScheduledRunHandlers.ts
+++ b/packages/jobs/src/lib/handlers/workflowScheduledRunHandlers.ts
@@ -6,6 +6,12 @@ import {
   resolveWorkflowBusinessDaySettings
 } from '@alga-psa/workflows/lib/workflowBusinessDayScheduling';
 import { createTenantKnex } from '@alga-psa/db';
+import {
+  buildWorkflowClockPayload,
+  isClockPinnedSchemaRef,
+  resolveWorkflowVersionPayloadSchemaRef,
+  toIsoDateTime
+} from '@alga-psa/workflows/lib/workflowClockPayload';
 import { launchPublishedWorkflowRun } from '@alga-psa/workflows/lib/workflowRunLauncher';
 import { getJobRunner } from '../jobRunnerAccessor';
 import type { BaseJobData } from '../jobs/interfaces';
@@ -19,19 +25,6 @@ const buildWorkflowScheduleFireKey = (scheduleId: string, jobId: string): string
   `workflow-schedule-fire:${scheduleId}:${jobId}`;
 
 const TERMINAL_JOB_STATUSES = new Set(['completed', 'failed']);
-
-const toIsoDateTime = (value: unknown): string | null => {
-  if (value instanceof Date) {
-    return Number.isNaN(value.getTime()) ? null : value.toISOString();
-  }
-  if (typeof value === 'string') {
-    const trimmed = value.trim();
-    if (!trimmed) return null;
-    const parsed = new Date(trimmed);
-    return Number.isNaN(parsed.getTime()) ? null : parsed.toISOString();
-  }
-  return null;
-};
 
 const buildScheduleTriggerMetadata = (params: {
   scheduleId: string;
@@ -100,7 +93,7 @@ async function runScheduledWorkflow(
     return;
   }
 
-  const payload = (schedule.payload_json ?? {}) as Record<string, unknown>;
+  const storedPayload = (schedule.payload_json ?? {}) as Record<string, unknown>;
   const scheduledOccurrenceIso = (
     schedule.trigger_type === 'schedule'
       ? toIsoDateTime(schedule.run_at)
@@ -116,6 +109,28 @@ async function runScheduledWorkflow(
     cron: schedule.cron,
     timezone: schedule.timezone
   });
+
+  // Clock-pinned workflows launch with the strict synthetic clock payload the
+  // WorkflowDesigner promises, resolved against the exact launched version;
+  // every other schedule keeps its stored payload untouched. The synthetic
+  // payload deliberately omits display-only `scheduleName` (kept in trigger
+  // metadata for observability) so it passes the strict schema unmodified.
+  const versionSchemaRef = await resolveWorkflowVersionPayloadSchemaRef(
+    knex,
+    schedule.workflow_id,
+    schedule.workflow_version
+  );
+  const payload = isClockPinnedSchemaRef(versionSchemaRef)
+    ? buildWorkflowClockPayload({
+        scheduleId: schedule.id,
+        workflowId: schedule.workflow_id,
+        workflowVersion: schedule.workflow_version,
+        triggerType: schedule.trigger_type,
+        scheduledFor: scheduledOccurrenceIso,
+        cron: schedule.cron,
+        timezone: schedule.timezone
+      })
+    : storedPayload;
 
   if (schedule.trigger_type === 'recurring') {
     const dayTypeFilter = normalizeWorkflowDayTypeFilter(schedule.day_type_filter);

--- a/packages/jobs/src/lib/handlers/workflowScheduledRunHandlers.ts
+++ b/packages/jobs/src/lib/handlers/workflowScheduledRunHandlers.ts
@@ -117,6 +117,7 @@ async function runScheduledWorkflow(
   // metadata for observability) so it passes the strict schema unmodified.
   const versionSchemaRef = await resolveWorkflowVersionPayloadSchemaRef(
     knex,
+    tenant,
     schedule.workflow_id,
     schedule.workflow_version
   );

--- a/server/migrations/20260713090000_seed_opportunity_workflows.cjs
+++ b/server/migrations/20260713090000_seed_opportunity_workflows.cjs
@@ -91,6 +91,22 @@ function deterministicUuid(namespace, tenantId) {
   return `${hex.slice(0, 8)}-${hex.slice(8, 12)}-4${hex.slice(13, 16)}-8${hex.slice(17, 20)}-${hex.slice(20)}`;
 }
 
+// Placeholder seed payload for clock-pinned schedules. Runtime synthesis is the
+// source of truth for each fire; this only prevents a freshly seeded clock
+// schedule from carrying a NULL/`{}` payload that fails strict validation.
+function buildClockPlaceholderPayload(scheduleId, workflowId, workflowVersion, schedule, now) {
+  return {
+    triggerType: 'recurring',
+    scheduleId,
+    scheduledFor: now,
+    firedAt: now,
+    timezone: schedule.timezone,
+    workflowId,
+    workflowVersion,
+    ...(schedule.cron ? { cron: schedule.cron } : {}),
+  };
+}
+
 async function seedWorkflow(knex, tenantId, workflow) {
   const { tenantDb } = require('./utils/tenantDb.cjs');
   const db = tenantDb(knex, tenantId);
@@ -162,6 +178,13 @@ async function seedWorkflow(knex, tenantId, workflow) {
       day_type_filter: 'any',
       cron: workflow.schedule.cron,
       timezone: workflow.schedule.timezone,
+      payload_json: buildClockPlaceholderPayload(
+        scheduleId,
+        resolvedWorkflowId,
+        definition.version,
+        workflow.schedule,
+        now
+      ),
       enabled: true,
       status: 'scheduled',
       updated_at: now,

--- a/server/migrations/20260805130000_repair_renewal_clock_payload.cjs
+++ b/server/migrations/20260805130000_repair_renewal_clock_payload.cjs
@@ -2,6 +2,34 @@ const REPAIR_TENANT = 'migration:20260805130000_repair_renewal_clock_payload';
 const ENUMERATION_REASON = 'enumerate tenants for renewal schedule clock payload repair';
 const RENEWAL_KEY = 'system.opportunity.renewal-suggestions';
 
+// Mirror of the WorkflowClockTrigger.v1 payload schema's shape (tenants,
+// strict: no extra keys). Migrations must stay CJS/self-contained (the tenantDb
+// shim deliberately avoids the @alga-psa/db workspace package), so this is a
+// replicated shape check rather than a require of the shared zod schema.
+const CLOCK_PAYLOAD_KEYS = ['triggerType', 'scheduleId', 'scheduledFor', 'firedAt', 'timezone', 'workflowId', 'workflowVersion', 'cron'];
+
+function isNonEmptyString(value) {
+  return typeof value === 'string' && value.length > 0;
+}
+
+function isIsoDateTime(value) {
+  return typeof value === 'string' && !Number.isNaN(Date.parse(value));
+}
+
+function isStrictClockPayload(payload) {
+  if (!payload || typeof payload !== 'object' || Array.isArray(payload)) return false;
+  if (Object.keys(payload).some((key) => !CLOCK_PAYLOAD_KEYS.includes(key))) return false;
+  if (payload.triggerType !== 'schedule' && payload.triggerType !== 'recurring') return false;
+  if (!isNonEmptyString(payload.scheduleId)) return false;
+  if (!isIsoDateTime(payload.scheduledFor)) return false;
+  if (!isIsoDateTime(payload.firedAt)) return false;
+  if (!isNonEmptyString(payload.timezone)) return false;
+  if (!isNonEmptyString(payload.workflowId)) return false;
+  if (!Number.isInteger(payload.workflowVersion) || payload.workflowVersion <= 0) return false;
+  if (payload.cron !== undefined && (payload.cron === null || !isNonEmptyString(payload.cron))) return false;
+  return true;
+}
+
 // Placeholder clock payload for the seeded renewal schedule row. Runtime
 // synthesis re-derives the real clock payload at each fire and is the source of
 // truth; this repair only replaces the pre-fix NULL/`{}` payload so the stored
@@ -42,6 +70,12 @@ exports.up = async function up(knex) {
       .where({ workflow_id: workflow.workflow_id, name: RENEWAL_KEY })
       .first();
     if (!schedule) continue;
+
+    // Idempotent repair: if the row already carries a strict-clock-schema-valid
+    // payload, a re-run leaves it (and any real post-fix fire state such as
+    // last_error/last_run_status) untouched. Only the pre-fix NULL/`{}` payload
+    // is replaced.
+    if (isStrictClockPayload(schedule.payload_json)) continue;
 
     await db.table('tenant_workflow_schedule')
       .where({ id: schedule.id })

--- a/server/migrations/20260805130000_repair_renewal_clock_payload.cjs
+++ b/server/migrations/20260805130000_repair_renewal_clock_payload.cjs
@@ -1,0 +1,62 @@
+const REPAIR_TENANT = 'migration:20260805130000_repair_renewal_clock_payload';
+const ENUMERATION_REASON = 'enumerate tenants for renewal schedule clock payload repair';
+const RENEWAL_KEY = 'system.opportunity.renewal-suggestions';
+
+// Placeholder clock payload for the seeded renewal schedule row. Runtime
+// synthesis re-derives the real clock payload at each fire and is the source of
+// truth; this repair only replaces the pre-fix NULL/`{}` payload so the stored
+// row no longer fails strict validation. The timestamps are a neutral "repair
+// time" placeholder (not a reconstruction of a stale fire), which is why the
+// plan forbids inventing historical timestamps here.
+function buildClockPlaceholderPayload(schedule, now) {
+  return {
+    triggerType: 'recurring',
+    scheduleId: schedule.id,
+    scheduledFor: now,
+    firedAt: now,
+    timezone: schedule.timezone || 'UTC',
+    workflowId: schedule.workflow_id,
+    workflowVersion: schedule.workflow_version,
+    ...(schedule.cron ? { cron: schedule.cron } : {}),
+  };
+}
+
+exports.up = async function up(knex) {
+  const { tenantDb } = require('./utils/tenantDb.cjs');
+  const migrationDb = tenantDb(knex, REPAIR_TENANT);
+  const tenants = await migrationDb.unscoped('tenants', ENUMERATION_REASON)
+    .select('tenant');
+  const now = new Date().toISOString();
+
+  for (const row of tenants) {
+    const db = tenantDb(knex, row.tenant);
+    const workflow = await db.table('workflow_definitions')
+      .where({ key: RENEWAL_KEY })
+      .select('workflow_id')
+      .first();
+    if (!workflow) continue;
+
+    // Narrowly targeted at the seeded renewal schedule row only; never touches
+    // unrelated schedules for the workflow or other tenants.
+    const schedule = await db.table('tenant_workflow_schedule')
+      .where({ workflow_id: workflow.workflow_id, name: RENEWAL_KEY })
+      .first();
+    if (!schedule) continue;
+
+    await db.table('tenant_workflow_schedule')
+      .where({ id: schedule.id })
+      .update({
+        payload_json: buildClockPlaceholderPayload(schedule, now),
+        // Drop the failed-validation residue from pre-fix fires; the next fire
+        // re-derives everything.
+        last_error: null,
+        last_run_status: null,
+        updated_at: now,
+      });
+  }
+};
+
+exports.down = async function down() {
+  // No-op: reverting the payload to NULL/`{}` would re-break the cleared
+  // schedules. The repair is forward-only and idempotent.
+};

--- a/server/src/test/unit/repairRenewalClockMigration.unit.test.ts
+++ b/server/src/test/unit/repairRenewalClockMigration.unit.test.ts
@@ -1,0 +1,127 @@
+import { createRequire } from 'node:module';
+import path from 'node:path';
+import { describe, expect, it } from 'vitest';
+
+const require = createRequire(import.meta.url);
+const migration = require(path.resolve(process.cwd(), 'migrations', '20260805130000_repair_renewal_clock_payload.cjs'));
+
+const RENEWAL_KEY = 'system.opportunity.renewal-suggestions';
+
+const colKey = (col: string): string => String(col).split('.').pop() as string;
+
+class Q {
+  rows: Record<string, unknown>[];
+  private predicates: Array<(row: Record<string, unknown>) => boolean>;
+
+  constructor(rows: Record<string, unknown>[]) {
+    this.rows = rows;
+    this.predicates = [];
+  }
+
+  private match(row: Record<string, unknown>): boolean {
+    return this.predicates.every((p) => p(row));
+  }
+
+  where(colOrObj: string | Record<string, unknown>, value?: unknown): this {
+    if (typeof colOrObj === 'string') {
+      const col = colKey(colOrObj);
+      this.predicates.push((row) => row[col] === value);
+    } else {
+      for (const [k, v] of Object.entries(colOrObj)) {
+        const col = colKey(k);
+        this.predicates.push((row) => row[col] === v);
+      }
+    }
+    return this;
+  }
+
+  select(): this {
+    return this;
+  }
+
+  first(): Record<string, unknown> | undefined {
+    return this.rows.find((row) => this.match(row));
+  }
+
+  update(data: Record<string, unknown>): number {
+    const targets = this.rows.filter((row) => this.match(row));
+    for (const row of targets) {
+      Object.assign(row, { ...data, updated_at: new Date().toISOString() });
+    }
+    return targets.length;
+  }
+
+  then(resolve: (value: Record<string, unknown>[]) => void): void {
+    resolve(this.rows);
+  }
+}
+
+function buildKnex(tables: Record<string, Record<string, unknown>[]>) {
+  return (name: string) => new Q(tables[name] ?? []);
+}
+
+function buildHarness() {
+  const tenants = [{ tenant: 'tenant-a' }, { tenant: 'tenant-b' }];
+  const workflowDefinitions = [
+    { workflow_id: 'renewal-workflow', key: RENEWAL_KEY, tenant: 'tenant-a' },
+    { workflow_id: 'unrelated-workflow', key: 'custom.other', tenant: 'tenant-b' }
+  ];
+  const schedule = (workflowId: string, name: string, tenant: string, overrides: Record<string, unknown> = {}) => ({
+    id: `${workflowId}-schedule`,
+    tenant,
+    workflow_id: workflowId,
+    workflow_version: 1,
+    name,
+    trigger_type: 'recurring',
+    cron: '0 6 * * *',
+    timezone: 'UTC',
+    payload_json: null,
+    last_error: 'Workflow payload failed validation',
+    last_run_status: 'error',
+    ...overrides
+  });
+  const tenantWorkflowSchedule = [
+    schedule('renewal-workflow', RENEWAL_KEY, 'tenant-a'),
+    schedule('unrelated-workflow', 'Custom reminder', 'tenant-b', { cron: '0 9 * * 1-5' })
+  ];
+  return { knex: buildKnex({ tenants, workflow_definitions: workflowDefinitions, tenant_workflow_schedule: tenantWorkflowSchedule }), tenantWorkflowSchedule };
+}
+
+describe('repair renewal clock payload migration', () => {
+  it('repairs the seeded renewal payload, clears failure residue, leaves unrelated schedules untouched', async () => {
+    const { knex, tenantWorkflowSchedule } = buildHarness();
+
+    await migration.up(knex);
+
+    const renewal = tenantWorkflowSchedule.find((row) => row.id === 'renewal-workflow-schedule')!;
+    expect(renewal.payload_json).not.toBeNull();
+    expect(renewal.payload_json).toMatchObject({
+      triggerType: 'recurring',
+      scheduleId: 'renewal-workflow-schedule',
+      workflowId: 'renewal-workflow',
+      workflowVersion: 1,
+      timezone: 'UTC',
+      cron: '0 6 * * *'
+    });
+    expect((renewal.payload_json as Record<string, unknown>).scheduleName).toBeUndefined();
+    expect(renewal.last_error).toBeNull();
+    expect(renewal.last_run_status).toBeNull();
+
+    const unrelated = tenantWorkflowSchedule.find((row) => row.id === 'unrelated-workflow-schedule')!;
+    expect(unrelated.payload_json).toBeNull();
+    expect(unrelated.last_error).toBe('Workflow payload failed validation');
+    expect(unrelated.cron).toBe('0 9 * * 1-5');
+  });
+
+  it('is idempotent across re-runs', async () => {
+    const { knex, tenantWorkflowSchedule } = buildHarness();
+
+    await migration.up(knex);
+    const first = tenantWorkflowSchedule.find((row) => row.id === 'renewal-workflow-schedule')!.payload_json;
+    await migration.up(knex);
+    const second = tenantWorkflowSchedule.find((row) => row.id === 'renewal-workflow-schedule')!.payload_json;
+
+    expect(first).toMatchObject(second as Record<string, unknown>);
+    expect((first as Record<string, unknown>).scheduleName).toBeUndefined();
+  });
+});

--- a/server/src/test/unit/repairRenewalClockMigration.unit.test.ts
+++ b/server/src/test/unit/repairRenewalClockMigration.unit.test.ts
@@ -117,11 +117,19 @@ describe('repair renewal clock payload migration', () => {
     const { knex, tenantWorkflowSchedule } = buildHarness();
 
     await migration.up(knex);
-    const first = tenantWorkflowSchedule.find((row) => row.id === 'renewal-workflow-schedule')!.payload_json;
-    await migration.up(knex);
-    const second = tenantWorkflowSchedule.find((row) => row.id === 'renewal-workflow-schedule')!.payload_json;
+    const first = tenantWorkflowSchedule.find((row) => row.id === 'renewal-workflow-schedule')!;
+    // Simulate real post-fix fire state appearing on the repaired row.
+    const renewalRow = tenantWorkflowSchedule.find((row) => row.id === 'renewal-workflow-schedule')!;
+    renewalRow.last_error = 'some real post-fix fire outcome';
+    renewalRow.last_run_status = 'success';
 
-    expect(first).toMatchObject(second as Record<string, unknown>);
-    expect((first as Record<string, unknown>).scheduleName).toBeUndefined();
+    await migration.up(knex);
+
+    const after = tenantWorkflowSchedule.find((row) => row.id === 'renewal-workflow-schedule')!;
+    expect(after.payload_json).toMatchObject(first.payload_json as Record<string, unknown>);
+    expect((after.payload_json as Record<string, unknown>).scheduleName).toBeUndefined();
+    // A re-run must not rewrite the payload nor wipe real fire state.
+    expect(after.last_error).toBe('some real post-fix fire outcome');
+    expect(after.last_run_status).toBe('success');
   });
 });

--- a/server/src/test/unit/workflowScheduledRunHandlers.unit.test.ts
+++ b/server/src/test/unit/workflowScheduledRunHandlers.unit.test.ts
@@ -3,6 +3,7 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 type ScheduleRecord = Record<string, any> | null;
 
 let scheduleRecord: ScheduleRecord = null;
+let versionRecord: Record<string, any> | null = null;
 
 const knexMock = {};
 const launchPublishedWorkflowRun = vi.fn();
@@ -33,6 +34,9 @@ vi.mock('@alga-psa/workflows/persistence', () => ({
       updateScheduleState(scheduleId, data);
       return scheduleRecord;
     })
+  },
+  WorkflowDefinitionVersionModelV2: {
+    getByWorkflowAndVersion: vi.fn(async () => versionRecord)
   }
 }));
 
@@ -62,6 +66,7 @@ import { registerJobRunnerAccessor } from '@alga-psa/jobs/runner';
 describe('Workflow scheduled run handlers', () => {
   beforeEach(() => {
     scheduleRecord = null;
+    versionRecord = null;
     // The handlers resolve the runner via @alga-psa/jobs' accessor, not the
     // server JobRunnerFactory; register a matching mock for the unit test.
     registerJobRunnerAccessor(async () => ({
@@ -247,6 +252,69 @@ describe('Workflow scheduled run handlers', () => {
         last_fire_key: 'workflow-schedule-fire:schedule-2:fire-2',
         last_run_status: 'success',
         last_error: null
+      })
+    );
+  });
+
+  it('CLOCK: clock-pinned schedule synthesizes the strict clock payload (omitting scheduleName) instead of stored NULL/{} payload', async () => {
+    versionRecord = {
+      version_id: 'version-clock-1',
+      workflow_id: 'workflow-clock-1',
+      version: 4,
+      definition_json: {
+        id: 'workflow-clock-1',
+        payloadSchemaRef: 'payload.WorkflowClockTrigger.v1'
+      }
+    };
+    scheduleRecord = {
+      id: 'schedule-clock-1',
+      tenant: 'tenant-1',
+      workflow_id: 'workflow-clock-1',
+      workflow_version: 4,
+      name: 'Renewal suggestion generation',
+      trigger_type: 'recurring',
+      day_type_filter: 'any',
+      business_hours_schedule_id: null,
+      run_at: null,
+      cron: '0 6 * * *',
+      timezone: 'UTC',
+      payload_json: null,
+      enabled: true,
+      status: 'scheduled'
+    };
+
+    await workflowRecurringScheduledRunHandler('job-clock-1', {
+      tenantId: 'tenant-1',
+      workflowId: 'workflow-clock-1',
+      scheduleId: 'schedule-clock-1',
+      jobExecutionId: 'fire-clock-1',
+      jobScheduledAt: '2026-08-06T06:00:00.000Z'
+    });
+
+    expect(launchPublishedWorkflowRun).toHaveBeenCalledTimes(1);
+    const launchCall = launchPublishedWorkflowRun.mock.calls[0];
+    const payload = launchCall?.[1]?.payload as Record<string, unknown>;
+    const triggerMetadata = launchCall?.[1]?.triggerMetadata as Record<string, unknown>;
+
+    expect(payload).toMatchObject({
+      triggerType: 'recurring',
+      scheduleId: 'schedule-clock-1',
+      timezone: 'UTC',
+      workflowId: 'workflow-clock-1',
+      workflowVersion: 4,
+      cron: '0 6 * * *'
+    });
+    expect(typeof payload?.scheduledFor).toBe('string');
+    expect(typeof payload?.firedAt).toBe('string');
+    // The strict schema rejects a stray scheduleName; keep it only in metadata.
+    expect(payload?.scheduleName).toBeUndefined();
+    expect(triggerMetadata?.scheduleName).toBe('Renewal suggestion generation');
+    expect(updateScheduleState).toHaveBeenCalledWith(
+      'schedule-clock-1',
+      expect.objectContaining({
+        last_run_status: 'success',
+        last_error: null,
+        last_fire_key: 'workflow-schedule-fire:schedule-clock-1:fire-clock-1'
       })
     );
   });

--- a/server/src/test/unit/workflowScheduledRunHandlers.unit.test.ts
+++ b/server/src/test/unit/workflowScheduledRunHandlers.unit.test.ts
@@ -4,6 +4,7 @@ type ScheduleRecord = Record<string, any> | null;
 
 let scheduleRecord: ScheduleRecord = null;
 let versionRecord: Record<string, any> | null = null;
+let workflowRecord: Record<string, any> | null = null;
 
 const knexMock = {};
 const launchPublishedWorkflowRun = vi.fn();
@@ -37,6 +38,9 @@ vi.mock('@alga-psa/workflows/persistence', () => ({
   },
   WorkflowDefinitionVersionModelV2: {
     getByWorkflowAndVersion: vi.fn(async () => versionRecord)
+  },
+  WorkflowDefinitionModelV2: {
+    getById: vi.fn(async () => workflowRecord)
   }
 }));
 
@@ -67,6 +71,7 @@ describe('Workflow scheduled run handlers', () => {
   beforeEach(() => {
     scheduleRecord = null;
     versionRecord = null;
+    workflowRecord = null;
     // The handlers resolve the runner via @alga-psa/jobs' accessor, not the
     // server JobRunnerFactory; register a matching mock for the unit test.
     registerJobRunnerAccessor(async () => ({
@@ -317,6 +322,55 @@ describe('Workflow scheduled run handlers', () => {
         last_fire_key: 'workflow-schedule-fire:schedule-clock-1:fire-clock-1'
       })
     );
+  });
+
+  it('CLOCK fallback: version without a def ref synthesizes via the workflow payload_schema_ref', async () => {
+    // The launched version carries no definition_json.payloadSchemaRef; only the
+    // workflow row does. resolveWorkflowVersionPayloadSchemaRef must fall back,
+    // or this schedule would validate strictly at launch but never synthesize.
+    versionRecord = {
+      version_id: 'version-clock-2',
+      workflow_id: 'workflow-clock-2',
+      version: 5,
+      definition_json: { id: 'workflow-clock-2', version: 5 }
+    };
+    workflowRecord = { workflow_id: 'workflow-clock-2', payload_schema_ref: 'payload.WorkflowClockTrigger.v1' };
+    scheduleRecord = {
+      id: 'schedule-clock-2',
+      tenant: 'tenant-1',
+      workflow_id: 'workflow-clock-2',
+      workflow_version: 5,
+      name: 'Renewal suggestion generation',
+      trigger_type: 'recurring',
+      day_type_filter: 'any',
+      business_hours_schedule_id: null,
+      run_at: null,
+      cron: '0 6 * * *',
+      timezone: 'UTC',
+      payload_json: null,
+      enabled: true,
+      status: 'scheduled'
+    };
+
+    await workflowRecurringScheduledRunHandler('job-clock-2', {
+      tenantId: 'tenant-1',
+      workflowId: 'workflow-clock-2',
+      scheduleId: 'schedule-clock-2',
+      jobExecutionId: 'fire-clock-2',
+      jobScheduledAt: '2026-08-06T06:00:00.000Z'
+    });
+
+    expect(launchPublishedWorkflowRun).toHaveBeenCalledTimes(1);
+    const payload = launchPublishedWorkflowRun.mock.calls[0]?.[1]?.payload as Record<string, unknown>;
+    expect(payload).toMatchObject({
+      triggerType: 'recurring',
+      scheduleId: 'schedule-clock-2',
+      workflowId: 'workflow-clock-2',
+      workflowVersion: 5,
+      cron: '0 6 * * *',
+      timezone: 'UTC'
+    });
+    expect(payload?.scheduleName).toBeUndefined();
   });
 
   it('T028: invalid saved payload at fire time does not start execution and records schedule error state', async () => {


### PR DESCRIPTION
## Summary

Fixes `alga0002194`: the seeded renewal-suggestion workflow was clock-pinned to `payload.WorkflowClockTrigger.v1`, but its schedule row could carry `NULL`/`{}` or display-only schedule data that failed the strict clock payload schema on every scheduled fire.

This branch:
- Adds shared clock payload helpers that synthesize the strict `WorkflowClockTrigger` launch payload and resolve the effective payload schema ref for the exact workflow version being launched.
- Updates scheduled-run handlers so clock-pinned schedules launch with a fresh strict clock payload while keeping `scheduleName` only in trigger metadata; non-clock schedules continue to launch with their stored `payload_json` unchanged.
- Updates inline schedule creation so clock-pinned schedules store a strict-valid placeholder payload before registering the external schedule, avoiding orphaned provider jobs if schema resolution fails.
- Repairs the existing seeded `system.opportunity.renewal-suggestions` schedules idempotently and updates the opportunity workflow seed path so newly seeded renewal schedules start valid.
- Adds unit coverage for strict clock payload synthesis, runtime launch behavior, migration repair behavior, non-clock payload preservation, fallback schema-ref resolution, and the create-order regression.

## Smoke Test Results

Exercised the real running product on `alga-psa-local-test` with Next dev server on `localhost:3530`, Temporal on `localhost:17233`, Temporal worker health on `:18081`, workflow runtime worker, and the live PostgreSQL tenant `dd8cb218-d46d-47f3-be27-8aa50aad5fce`.

Evidence directory: `/tmp/alga-smoke-evidence/alga0002194-renewal-clock-payload-20260806T070801Z`

Outcomes:
- Existing seeded renewal schedule: PASS. The repaired `system.opportunity.renewal-suggestions` schedule has a strict-valid stored clock payload, `last_run_status=success`, `last_error=null`, and a real daily run at `2026-08-06T06:00:00Z` with status `SUCCEEDED`. Its run input contains the required clock fields and does not contain `scheduleName`; `scheduleName` is present only in trigger metadata. Step history exists: `generate-renewal-suggestions` succeeded and `opportunities.generate_suggestions@1` succeeded.
- UI verification: PASS. Logged into the real MSP UI with dev credentials and captured Workflow Run Studio plus Workflow Control screenshots showing the renewal run as Succeeded/Scheduled.
- Fresh inline time-trigger workflow: PASS. Created a fresh clock-pinned published smoke workflow, registered its recurring schedule through real `syncWorkflowScheduleState` + Temporal job runner, fired it through the real recurring scheduled-run handler, and verified the run `974593d5-8eb6-4cec-ba81-82d0e00f8347` succeeded with one succeeded step. Stored schedule payload and runtime input were strict clock-valid and omitted `scheduleName`; trigger metadata retained `scheduleName`. The smoke schedule was canceled/deleted after evidence to prevent repeated fires.
- Nearby regression check: PASS. A non-clock recurring schedule with an `InboundWebhookReceived` sentinel payload launched green and preserved the stored payload in `workflow_runs.input_json`; no clock `scheduleId` was injected into the run input.

Fidelity compromises:
- The normal EE migration runner was blocked by existing branch-only migration history in this shared smoke DB, so I targeted-applied and recorded only the required `20260724120000_add_suspension_to_tenants.cjs` and `20260805130000_repair_renewal_clock_payload.cjs` migrations.
- `alga-dev` browser creation worked, but direct pane control failed with “belongs to a different host”; I used local Playwright with system Chrome against the real `localhost:3530` UI for screenshots. No mocks or simulators were used for workflow execution.

Concerns:
- The worktree still has pre-existing untracked smoke helper files for local ESM/worker shims; I did not modify or commit them.
- The fresh smoke workflow definitions remain in DB for auditability, but their schedules were deleted so they will not keep firing.

## CI / Local Checks

Previously verified on this branch:
- `ee/packages/workflows` package tests: 198 passing.
- `tsc --noEmit` for the workflows package.
- GitHub PR checks were green before the review-defect follow-up commit.

This PR should now re-run CI for head `663e2ec3fc`, including the ordering regression test added for the review fix.
