### PR TITLE
Restore Microsoft 365 inbound email to Community Edition

### DIFF
--- a/docs/plans/2026-08-05-restore-m365-inbound-ce-plan.md
+++ b/docs/plans/2026-08-05-restore-m365-inbound-ce-plan.md
@@ -1,0 +1,27 @@
+# Restore Microsoft 365 inbound email to Community Edition
+
+## Intent
+
+Remove the UI-only edition gate that inadvertently hid Microsoft 365 inbound email from Community Edition while preserving the deliberate Pro boundaries around calendar, Teams, and hosted/platform credentials.
+
+## Code findings
+
+The current branch is clean at `860071a686`. Direct inspection confirmed the gate remains in `EmailProviderSelector.tsx` (`isEnterpriseEdition`, conditional Microsoft card, `UpgradePrompt`, conditional help copy) and in `EmailProviderConfiguration.tsx` (edition-only loader behavior, edit rejection, Microsoft filtering, conditional header/count copy, conditional provider UI). The backend is not part of this gate.
+
+## Implementation
+
+1. Make `EmailProviderSelector.tsx` edition-neutral: remove the edition helper and upgrade prompt imports/state, render the Microsoft card unconditionally, retain the three-column layout, and use one provider-neutral help string.
+2. Make `EmailProviderConfiguration.tsx` edition-neutral for inbound providers: always load Microsoft configuration support, allow editing Microsoft providers, include them in `visibleProviders`, and remove edition-conditioned header/count/add-provider rendering and feedback.
+3. Remove only translation keys made unreachable by this change, after searching all locales/usages; do not disturb shared Microsoft integration copy.
+4. Update behavioral component tests so CE renders/selects Microsoft, lists existing Microsoft providers, and opens the edit path. Keep an EE assertion to prove behavior remains unchanged.
+5. Run the focused integration component tests plus package typecheck/build. Smoke in a CE runtime with `EDITION=ce` and `NEXT_PUBLIC_EDITION=community`: create, list, and edit a bring-your-own-app Microsoft provider.
+
+## Deliberate non-goals
+
+- Do not change `microsoftConsumerVisibility.ts`: email remains CE-visible; calendar and Teams remain Pro-only.
+- Do not unlock platform/hosted Microsoft credentials in `MicrosoftIntegrationSettings.tsx`.
+- Do not remove `assertTenantProductAccess(email_to_ticket)` or alter backend Graph/webhook behavior.
+
+## Risks
+
+The main risk is accidentally broadening Microsoft integration access beyond inbound email. Tests must exercise the email provider components in CE and retain visibility-contract coverage for calendar, Teams, and platform credentials.

--- a/packages/integrations/src/components/email/EmailProviderConfiguration.resync.test.tsx
+++ b/packages/integrations/src/components/email/EmailProviderConfiguration.resync.test.tsx
@@ -8,6 +8,7 @@ import type { EmailProvider } from './types';
 
 const getEmailProvidersMock = vi.hoisted(() => vi.fn());
 const resyncImapProviderMock = vi.hoisted(() => vi.fn());
+const isEnterpriseEditionMock = vi.hoisted(() => vi.fn(() => true));
 const toastMock = vi.hoisted(() => Object.assign(vi.fn(), {
   error: vi.fn(),
   loading: vi.fn(() => 'resync-toast'),
@@ -64,7 +65,7 @@ vi.mock('./admin/Microsoft365DiagnosticsDialog', () => ({
 }));
 
 vi.mock('../../lib/microsoftConsumerVisibility', () => ({
-  isMicrosoftConsumerEnterpriseEdition: () => true,
+  isMicrosoftConsumerEnterpriseEdition: () => isEnterpriseEditionMock(),
 }));
 
 vi.mock('./EmailProviderList', () => ({
@@ -306,5 +307,40 @@ describe('IMAP resync status recovery', () => {
     expect(screen.queryByText('Inactive')).not.toBeInTheDocument();
     expect(view.container.firstElementChild).not.toHaveClass('opacity-60');
     expect(screen.getByRole('button')).toBeDisabled();
+  });
+});
+
+describe('EmailProviderConfiguration setup guidance across editions', () => {
+  afterEach(() => {
+    cleanup();
+    isEnterpriseEditionMock.mockImplementation(() => true);
+  });
+
+  it('shows the Microsoft setup guidance without the hosted Providers hint in CE', async () => {
+    isEnterpriseEditionMock.mockImplementation(() => false);
+    getEmailProvidersMock.mockResolvedValueOnce({ providers: [] });
+
+    await act(async () => {
+      render(<EmailProviderConfiguration />);
+    });
+
+    // Edition-neutral bring-your-own-app guidance renders in every edition.
+    expect(screen.getByText(/Bring your own Microsoft app/)).toBeInTheDocument();
+    // The hosted/platform-credentials Providers hint stays EE-only.
+    expect(screen.queryByText('Microsoft app setup is managed in Providers.')).not.toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: 'Open Providers' })).not.toBeInTheDocument();
+  });
+
+  it('shows the hosted Providers hint alongside the setup guidance in EE', async () => {
+    isEnterpriseEditionMock.mockImplementation(() => true);
+    getEmailProvidersMock.mockResolvedValueOnce({ providers: [] });
+
+    await act(async () => {
+      render(<EmailProviderConfiguration />);
+    });
+
+    expect(screen.getByText(/Bring your own Microsoft app/)).toBeInTheDocument();
+    expect(screen.getByText('Microsoft app setup is managed in Providers.')).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Open Providers' })).toBeInTheDocument();
   });
 });

--- a/packages/integrations/src/components/email/EmailProviderConfiguration.tsx
+++ b/packages/integrations/src/components/email/EmailProviderConfiguration.tsx
@@ -551,25 +551,32 @@ function EmailProviderConfigurationContent({
             })}</CardTitle>
           </CardHeader>
           <CardContent className="space-y-4">
-            {isEnterpriseEdition && (
-              <div className="space-y-2">
-                <h4 className="font-medium mb-2">{t('configuration.setup.microsoft.title', {
-                  defaultValue: 'Microsoft 365 Setup',
-                })}</h4>
-                <p className="text-sm text-muted-foreground">
-                  {t('configuration.setup.microsoft.providersPointer', { defaultValue: 'Microsoft app setup is managed in Providers.' })}
-                </p>
-                <Button
-                  id="open-microsoft-providers-settings-button"
-                  type="button"
-                  variant="link"
-                  className="h-auto p-0"
-                  onClick={() => window.location.assign('/msp/settings/integrations?category=providers')}
-                >
-                  {t('configuration.setup.microsoft.openProviders', { defaultValue: 'Open Providers' })}
-                </Button>
-              </div>
-            )}
+            <div className="space-y-2">
+              <h4 className="font-medium mb-2">{t('configuration.setup.microsoft.title', {
+                defaultValue: 'Microsoft 365 Setup',
+              })}</h4>
+              <p className="text-sm text-muted-foreground">
+                {t('configuration.setup.microsoft.ownApp', {
+                  defaultValue: 'Bring your own Microsoft app — register it in Azure AD (Microsoft Entra ID), grant mail permissions, and connect it to your Microsoft 365 mailbox.',
+                })}
+              </p>
+              {isEnterpriseEdition && (
+                <div className="space-y-2 pt-1">
+                  <p className="text-sm text-muted-foreground">
+                    {t('configuration.setup.microsoft.providersPointer', { defaultValue: 'Microsoft app setup is managed in Providers.' })}
+                  </p>
+                  <Button
+                    id="open-microsoft-providers-settings-button"
+                    type="button"
+                    variant="link"
+                    className="h-auto p-0"
+                    onClick={() => window.location.assign('/msp/settings/integrations?category=providers')}
+                  >
+                    {t('configuration.setup.microsoft.openProviders', { defaultValue: 'Open Providers' })}
+                  </Button>
+                </div>
+              )}
+            </div>
             <div>
               <h4 className="font-medium mb-2">{t('configuration.setup.gmail.title', {
                 defaultValue: 'Gmail Setup',

--- a/packages/integrations/src/components/email/EmailProviderConfiguration.tsx
+++ b/packages/integrations/src/components/email/EmailProviderConfiguration.tsx
@@ -106,8 +106,6 @@ function EmailProviderConfigurationContent({
   }, []);
 
   useEffect(() => {
-    if (!isEnterpriseEdition) return;
-
     const loadMicrosoftEmailSetup = async () => {
       try {
         const result = await getMicrosoftConsumerSetupStatus('email');
@@ -118,7 +116,7 @@ function EmailProviderConfigurationContent({
     };
 
     loadMicrosoftEmailSetup();
-  }, [isEnterpriseEdition]);
+  }, []);
 
   useEffect(() => {
     mountedRef.current = true;
@@ -424,13 +422,6 @@ function EmailProviderConfigurationContent({
   };
 
   const openEditDrawer = (provider: EmailProvider) => {
-    if (!isEnterpriseEdition && provider.providerType === 'microsoft') {
-      setError(t('configuration.feedback.enterpriseOnly', {
-        defaultValue: 'Microsoft 365 inbound email is only available in Pro.',
-      }));
-      return;
-    }
-
     openDrawer(
       (
         <div className="space-y-4">
@@ -489,9 +480,7 @@ function EmailProviderConfigurationContent({
 
   // Build right-hand content for Providers section
   const renderProvidersContent = () => {
-    const visibleProviders = isEnterpriseEdition
-      ? providers
-      : providers.filter((provider) => provider.providerType !== 'microsoft');
+    const visibleProviders = providers;
     const providerCounts = providers.reduce(
       (acc, provider) => {
         acc[provider.providerType] = (acc[provider.providerType] || 0) + 1;
@@ -508,27 +497,17 @@ function EmailProviderConfigurationContent({
               defaultValue: 'Email Provider Configuration',
             })}</h2>
             <p className="text-muted-foreground">
-              {isEnterpriseEdition
-                ? t('configuration.header.description.enterprise', {
-                  defaultValue: 'Configure Gmail, Microsoft 365, or IMAP providers to receive and process inbound emails as tickets',
-                })
-                : t('configuration.header.description.standard', {
-                  defaultValue: 'Configure Gmail or IMAP providers to receive and process inbound emails as tickets',
-                })}
+              {t('configuration.header.description', {
+                defaultValue: 'Configure Gmail, Microsoft 365, or IMAP providers to receive and process inbound emails as tickets',
+              })}
             </p>
             <p className="text-xs text-muted-foreground mt-1">
-              {isEnterpriseEdition
-                ? t('configuration.header.counts.enterprise', {
-                  defaultValue: 'Gmail: {{gmail}} · Microsoft: {{microsoft}} · IMAP: {{imap}}',
-                  gmail: providerCounts.google || 0,
-                  microsoft: providerCounts.microsoft || 0,
-                  imap: providerCounts.imap || 0,
-                })
-                : t('configuration.header.counts.standard', {
-                  defaultValue: 'Gmail: {{gmail}} · IMAP: {{imap}}',
-                  gmail: providerCounts.google || 0,
-                  imap: providerCounts.imap || 0,
-                })}
+              {t('configuration.header.counts', {
+                defaultValue: 'Gmail: {{gmail}} · Microsoft: {{microsoft}} · IMAP: {{imap}}',
+                gmail: providerCounts.google || 0,
+                microsoft: providerCounts.microsoft || 0,
+                imap: providerCounts.imap || 0,
+              })}
             </p>
           </div>
           <Button

--- a/packages/integrations/src/components/email/EmailProviderSelector.test.tsx
+++ b/packages/integrations/src/components/email/EmailProviderSelector.test.tsx
@@ -52,26 +52,27 @@ describe('EmailProviderSelector edition gates', () => {
     else process.env.NEXT_PUBLIC_EDITION = originalPublicEdition;
   });
 
-  it('shows working Gmail and IMAP setup alongside a Microsoft 365 upgrade prompt in CE', () => {
+  it('shows Gmail, Microsoft 365, and IMAP setup cards in CE', () => {
     process.env.EDITION = 'community';
     process.env.NEXT_PUBLIC_EDITION = 'community';
 
     render(<EmailProviderSelector onProviderSelected={vi.fn()} />);
 
     expect(document.getElementById('setup-google-provider-button')).toBeTruthy();
+    expect(document.getElementById('setup-microsoft-provider-button')).toBeTruthy();
     expect(document.getElementById('setup-imap-provider-button')).toBeTruthy();
-    expect(document.getElementById('setup-microsoft-provider-button')).toBeNull();
-    expect(screen.getByTestId('upgrade-prompt')).toBeTruthy();
-    expect(document.getElementById('upgrade-microsoft-email-provider-button')).toBeTruthy();
+    expect(screen.queryByTestId('upgrade-prompt')).toBeNull();
   });
 
-  it('shows Microsoft 365 setup instead of the upgrade prompt in Enterprise Edition', () => {
+  it('still shows Gmail, Microsoft 365, and IMAP setup cards in Enterprise Edition', () => {
     process.env.EDITION = 'ee';
     process.env.NEXT_PUBLIC_EDITION = 'enterprise';
 
     render(<EmailProviderSelector onProviderSelected={vi.fn()} />);
 
+    expect(document.getElementById('setup-google-provider-button')).toBeTruthy();
     expect(document.getElementById('setup-microsoft-provider-button')).toBeTruthy();
+    expect(document.getElementById('setup-imap-provider-button')).toBeTruthy();
     expect(screen.queryByTestId('upgrade-prompt')).toBeNull();
   });
 });

--- a/packages/integrations/src/components/email/EmailProviderSelector.test.tsx
+++ b/packages/integrations/src/components/email/EmailProviderSelector.test.tsx
@@ -1,7 +1,7 @@
 /** @vitest-environment jsdom */
 
 import React from 'react';
-import { cleanup, render, screen } from '@testing-library/react';
+import { cleanup, fireEvent, render, screen } from '@testing-library/react';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 import { EmailProviderSelector } from './EmailProviderSelector';
 
@@ -62,6 +62,32 @@ describe('EmailProviderSelector edition gates', () => {
     expect(document.getElementById('setup-microsoft-provider-button')).toBeTruthy();
     expect(document.getElementById('setup-imap-provider-button')).toBeTruthy();
     expect(screen.queryByTestId('upgrade-prompt')).toBeNull();
+  });
+
+  it('fires the selection callback when the Microsoft 365 card is selected in CE', () => {
+    process.env.EDITION = 'community';
+    process.env.NEXT_PUBLIC_EDITION = 'community';
+
+    const onProviderSelected = vi.fn();
+    render(<EmailProviderSelector onProviderSelected={onProviderSelected} />);
+
+    fireEvent.click(document.getElementById('microsoft-provider-selector-card')!);
+
+    expect(onProviderSelected).toHaveBeenCalledTimes(1);
+    expect(onProviderSelected).toHaveBeenCalledWith('microsoft');
+  });
+
+  it('still fires the selection callback for the Microsoft 365 card in Enterprise Edition', () => {
+    process.env.EDITION = 'ee';
+    process.env.NEXT_PUBLIC_EDITION = 'enterprise';
+
+    const onProviderSelected = vi.fn();
+    render(<EmailProviderSelector onProviderSelected={onProviderSelected} />);
+
+    fireEvent.click(document.getElementById('microsoft-provider-selector-card')!);
+
+    expect(onProviderSelected).toHaveBeenCalledTimes(1);
+    expect(onProviderSelected).toHaveBeenCalledWith('microsoft');
   });
 
   it('still shows Gmail, Microsoft 365, and IMAP setup cards in Enterprise Edition', () => {

--- a/packages/integrations/src/components/email/EmailProviderSelector.tsx
+++ b/packages/integrations/src/components/email/EmailProviderSelector.tsx
@@ -8,9 +8,7 @@
 import React from 'react';
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@alga-psa/ui/components/Card';
 import { Button } from '@alga-psa/ui/components/Button';
-import { UpgradePrompt } from '@alga-psa/ui/components/UpgradePrompt';
 import { Search, Building2, Mail } from 'lucide-react';
-import { isMicrosoftConsumerEnterpriseEdition } from '../../lib/microsoftConsumerVisibility';
 import { useTranslation } from '@alga-psa/ui/lib/i18n/client';
 
 interface EmailProviderSelectorProps {
@@ -25,7 +23,6 @@ export function EmailProviderSelector({
   hideHeader = false,
 }: EmailProviderSelectorProps) {
   const { t } = useTranslation('msp/email-providers');
-  const isEnterpriseEdition = isMicrosoftConsumerEnterpriseEdition();
   
   const handleProviderClick = (providerType: 'google' | 'microsoft' | 'imap') => {
     onProviderSelected(providerType);
@@ -101,60 +98,50 @@ export function EmailProviderSelector({
           </CardContent>
         </Card>
 
-        {isEnterpriseEdition ? (
-          <Card 
-            id="microsoft-provider-selector-card"
-            className="cursor-pointer transition-all duration-200 hover:shadow-lg hover:-translate-y-1 border-2 hover:border-blue-200 bg-gradient-to-br from-[rgb(var(--color-card))] to-blue-500/10"
-            onClick={() => handleProviderClick('microsoft')}
-          >
-            <CardHeader className="text-center pb-4">
-              <div className="flex justify-center mb-4">
-                <div className="p-4 rounded-full bg-gradient-to-br from-blue-600 to-blue-800 shadow-lg">
-                  <div className="flex items-center justify-center">
-                    <Building2 className="h-8 w-8 text-white" />
-                  </div>
+        {/* Microsoft 365 Card */}
+        <Card 
+          id="microsoft-provider-selector-card"
+          className="cursor-pointer transition-all duration-200 hover:shadow-lg hover:-translate-y-1 border-2 hover:border-blue-200 bg-gradient-to-br from-[rgb(var(--color-card))] to-blue-500/10"
+          onClick={() => handleProviderClick('microsoft')}
+        >
+          <CardHeader className="text-center pb-4">
+            <div className="flex justify-center mb-4">
+              <div className="p-4 rounded-full bg-gradient-to-br from-blue-600 to-blue-800 shadow-lg">
+                <div className="flex items-center justify-center">
+                  <Building2 className="h-8 w-8 text-white" />
                 </div>
               </div>
-              <CardTitle className="text-xl font-bold text-[rgb(var(--color-text-800))]">{t('selector.cards.microsoft.title', {
-                defaultValue: 'Microsoft 365',
-              })}</CardTitle>
-              <CardDescription className="text-base text-[rgb(var(--color-text-600))]">
-                {t('selector.cards.microsoft.description', {
-                  defaultValue: 'Microsoft 365 / Outlook Integration',
-                })}
-              </CardDescription>
-            </CardHeader>
-            <CardContent className="text-center space-y-4">
-              <div className="text-sm text-[rgb(var(--color-text-600))] space-y-2">
-                <p>{t('selector.cards.microsoft.features.accounts', { defaultValue: '✓ Microsoft 365 and Outlook accounts' })}</p>
-                <p>{t('selector.cards.microsoft.features.filtering', { defaultValue: '✓ Folder-based email filtering' })}</p>
-                <p>{t('selector.cards.microsoft.features.processing', { defaultValue: '✓ Real-time email processing' })}</p>
-                <p>{t('selector.cards.microsoft.features.authentication', { defaultValue: '✓ Azure AD OAuth integration' })}</p>
-              </div>
-              <Button 
-                id="setup-microsoft-provider-button"
-                className="w-full bg-gradient-to-r from-blue-600 to-blue-700 hover:from-blue-700 hover:to-blue-800 text-white font-semibold shadow-md"
-                onClick={(e) => {
-                  e.stopPropagation();
-                  handleProviderClick('microsoft');
-                }}
-              >
-                {t('selector.cards.microsoft.action', {
-                  defaultValue: 'Set up Microsoft 365',
-                })}
-              </Button>
-            </CardContent>
-          </Card>
-        ) : (
-          <UpgradePrompt
-            featureName={t('selector.cards.microsoft.title', { defaultValue: 'Microsoft 365' })}
-            pitch={t('selector.cards.microsoft.description', {
-              defaultValue: 'Microsoft 365 / Outlook Integration',
-            })}
-            ctaId="upgrade-microsoft-email-provider-button"
-            className="h-full"
-          />
-        )}
+            </div>
+            <CardTitle className="text-xl font-bold text-[rgb(var(--color-text-800))]">{t('selector.cards.microsoft.title', {
+              defaultValue: 'Microsoft 365',
+            })}</CardTitle>
+            <CardDescription className="text-base text-[rgb(var(--color-text-600))]">
+              {t('selector.cards.microsoft.description', {
+                defaultValue: 'Microsoft 365 / Outlook Integration',
+              })}
+            </CardDescription>
+          </CardHeader>
+          <CardContent className="text-center space-y-4">
+            <div className="text-sm text-[rgb(var(--color-text-600))] space-y-2">
+              <p>{t('selector.cards.microsoft.features.accounts', { defaultValue: '✓ Microsoft 365 and Outlook accounts' })}</p>
+              <p>{t('selector.cards.microsoft.features.filtering', { defaultValue: '✓ Folder-based email filtering' })}</p>
+              <p>{t('selector.cards.microsoft.features.processing', { defaultValue: '✓ Real-time email processing' })}</p>
+              <p>{t('selector.cards.microsoft.features.authentication', { defaultValue: '✓ Azure AD OAuth integration' })}</p>
+            </div>
+            <Button 
+              id="setup-microsoft-provider-button"
+              className="w-full bg-gradient-to-r from-blue-600 to-blue-700 hover:from-blue-700 hover:to-blue-800 text-white font-semibold shadow-md"
+              onClick={(e) => {
+                e.stopPropagation();
+                handleProviderClick('microsoft');
+              }}
+            >
+              {t('selector.cards.microsoft.action', {
+                defaultValue: 'Set up Microsoft 365',
+              })}
+            </Button>
+          </CardContent>
+        </Card>
 
         {/* IMAP Card */}
         <Card
@@ -220,13 +207,9 @@ export function EmailProviderSelector({
       {/* Help Text */}
       <div className="text-center">
         <p className="text-xs text-muted-foreground max-w-2xl mx-auto">
-          {isEnterpriseEdition
-            ? t('selector.help.enterprise', {
-              defaultValue: 'Choose the provider your organization already uses. If you use Google Workspace, pick Gmail; if you use Microsoft 365, pick Microsoft 365. You can change this later by removing and reconfiguring your email provider.',
-            })
-            : t('selector.help.standard', {
-              defaultValue: 'Choose the provider your organization already uses. If you use Google Workspace, pick Gmail; otherwise choose IMAP. You can change this later by removing and reconfiguring your email provider.',
-            })}
+          {t('selector.help', {
+            defaultValue: 'Choose the provider your organization already uses. If you use Google Workspace, pick Gmail; if you use Microsoft 365, pick Microsoft 365. You can change this later by removing and reconfiguring your email provider.',
+          })}
         </p>
       </div>
     </div>

--- a/server/public/locales/de/msp/email-providers.json
+++ b/server/public/locales/de/msp/email-providers.json
@@ -35,6 +35,7 @@
       "title": "Einrichtungsanweisungen",
       "microsoft": {
         "title": "Microsoft 365-Setup",
+        "ownApp": "Verwenden Sie Ihre eigene Microsoft-App – registrieren Sie sie in Azure AD (Microsoft Entra ID), erteilen Sie E-Mail-Berechtigungen und verbinden Sie sie mit Ihrem Microsoft-365-Postfach.",
         "providersPointer": "Die Einrichtung der Microsoft-App wird unter „Anbieter“ verwaltet.",
         "openProviders": "Anbieter öffnen"
       },

--- a/server/public/locales/de/msp/email-providers.json
+++ b/server/public/locales/de/msp/email-providers.json
@@ -12,7 +12,6 @@
       "resyncError": "Die Neusynchronisierung des IMAP-Anbieters ist fehlgeschlagen",
       "resyncStarted": "Neusynchronisierung für {{providerName}} gestartet.",
       "resyncRecovered": "{{providerName}} wurde erfolgreich wieder verbunden.",
-      "enterpriseOnly": "Eingehende E-Mails von Microsoft 365 sind nur in Pro verfügbar.",
       "loadProvidersError": "E-Mail-Anbieter konnten nicht geladen werden"
     },
     "editDrawer": {
@@ -21,14 +20,8 @@
     },
     "header": {
       "title": "Konfiguration des E-Mail-Anbieters",
-      "description": {
-        "enterprise": "Konfigurieren Sie Gmail-, Microsoft 365- oder IMAP-Anbieter so, dass sie eingehende E-Mails als Tickets empfangen und verarbeiten",
-        "standard": "Konfigurieren Sie Gmail- oder IMAP-Anbieter so, dass sie eingehende E-Mails als Tickets empfangen und verarbeiten"
-      },
-      "counts": {
-        "enterprise": "Gmail: {{gmail}} · Microsoft: {{microsoft}} · IMAP: {{imap}}",
-        "standard": "Gmail: {{gmail}} · IMAP: {{imap}}"
-      }
+      "description": "Konfigurieren Sie Gmail-, Microsoft 365- oder IMAP-Anbieter so, dass sie eingehende E-Mails als Tickets empfangen und verarbeiten",
+      "counts": "Gmail: {{gmail}} · Microsoft: {{microsoft}} · IMAP: {{imap}}"
     },
     "actions": {
       "addProvider": "E-Mail-Anbieter hinzufügen"
@@ -117,10 +110,7 @@
     "actions": {
       "cancel": "Abbrechen"
     },
-    "help": {
-      "enterprise": "Wählen Sie den Anbieter, den Ihre Organisation bereits nutzt. Wenn Sie Google Workspace verwenden, wählen Sie Gmail; Wenn Sie Microsoft 365 verwenden, wählen Sie Microsoft 365. Sie können dies später ändern, indem Sie Ihren E-Mail-Anbieter entfernen und neu konfigurieren.",
-      "standard": "Wählen Sie den Anbieter, den Ihre Organisation bereits nutzt. Wenn Sie Google Workspace verwenden, wählen Sie Gmail; andernfalls wählen Sie IMAP. Sie können dies später ändern, indem Sie Ihren E-Mail-Anbieter entfernen und neu konfigurieren."
-    }
+    "help": "Wählen Sie den Anbieter, den Ihre Organisation bereits nutzt. Wenn Sie Google Workspace verwenden, wählen Sie Gmail; Wenn Sie Microsoft 365 verwenden, wählen Sie Microsoft 365. Sie können dies später ändern, indem Sie Ihren E-Mail-Anbieter entfernen und neu konfigurieren."
   },
   "wizard": {
     "title": {

--- a/server/public/locales/en/msp/email-providers.json
+++ b/server/public/locales/en/msp/email-providers.json
@@ -12,7 +12,6 @@
       "resyncError": "Failed to resync IMAP provider",
       "resyncStarted": "Resync started for {{providerName}}.",
       "resyncRecovered": "{{providerName}} reconnected successfully.",
-      "enterpriseOnly": "Microsoft 365 inbound email is only available in Pro.",
       "loadProvidersError": "Failed to load email providers"
     },
     "editDrawer": {
@@ -21,14 +20,8 @@
     },
     "header": {
       "title": "Email Provider Configuration",
-      "description": {
-        "enterprise": "Configure Gmail, Microsoft 365, or IMAP providers to receive and process inbound emails as tickets",
-        "standard": "Configure Gmail or IMAP providers to receive and process inbound emails as tickets"
-      },
-      "counts": {
-        "enterprise": "Gmail: {{gmail}} · Microsoft: {{microsoft}} · IMAP: {{imap}}",
-        "standard": "Gmail: {{gmail}} · IMAP: {{imap}}"
-      }
+      "description": "Configure Gmail, Microsoft 365, or IMAP providers to receive and process inbound emails as tickets",
+      "counts": "Gmail: {{gmail}} · Microsoft: {{microsoft}} · IMAP: {{imap}}"
     },
     "actions": {
       "addProvider": "Add Email Provider"
@@ -117,10 +110,7 @@
     "actions": {
       "cancel": "Cancel"
     },
-    "help": {
-      "enterprise": "Choose the provider your organization already uses. If you use Google Workspace, pick Gmail; if you use Microsoft 365, pick Microsoft 365. You can change this later by removing and reconfiguring your email provider.",
-      "standard": "Choose the provider your organization already uses. If you use Google Workspace, pick Gmail; otherwise choose IMAP. You can change this later by removing and reconfiguring your email provider."
-    }
+    "help": "Choose the provider your organization already uses. If you use Google Workspace, pick Gmail; if you use Microsoft 365, pick Microsoft 365. You can change this later by removing and reconfiguring your email provider."
   },
   "wizard": {
     "title": {

--- a/server/public/locales/en/msp/email-providers.json
+++ b/server/public/locales/en/msp/email-providers.json
@@ -35,6 +35,7 @@
       "title": "Setup Instructions",
       "microsoft": {
         "title": "Microsoft 365 Setup",
+        "ownApp": "Bring your own Microsoft app — register it in Azure AD (Microsoft Entra ID), grant mail permissions, and connect it to your Microsoft 365 mailbox.",
         "providersPointer": "Microsoft app setup is managed in Providers.",
         "openProviders": "Open Providers"
       },

--- a/server/public/locales/es/msp/email-providers.json
+++ b/server/public/locales/es/msp/email-providers.json
@@ -35,6 +35,7 @@
       "title": "Instrucciones de configuración",
       "microsoft": {
         "title": "Configuración de Microsoft 365",
+        "ownApp": "Traiga su propia aplicación de Microsoft: regístrela en Azure AD (Microsoft Entra ID), conceda permisos de correo y conéctela a su buzón de Microsoft 365.",
         "providersPointer": "La configuración de la aplicación de Microsoft se administra en Proveedores.",
         "openProviders": "Abrir Proveedores"
       },

--- a/server/public/locales/es/msp/email-providers.json
+++ b/server/public/locales/es/msp/email-providers.json
@@ -12,7 +12,6 @@
       "resyncError": "No se pudo resincronizar el proveedor IMAP",
       "resyncStarted": "Se inició la resincronización para {{providerName}}.",
       "resyncRecovered": "{{providerName}} se volvió a conectar correctamente.",
-      "enterpriseOnly": "El correo electrónico entrante de Microsoft 365 solo está disponible en Pro.",
       "loadProvidersError": "No se pudieron cargar los proveedores de correo electrónico"
     },
     "editDrawer": {
@@ -21,14 +20,8 @@
     },
     "header": {
       "title": "Configuración del proveedor de correo electrónico",
-      "description": {
-        "enterprise": "Configure proveedores de Gmail, Microsoft 365 o IMAP para recibir y procesar correos electrónicos entrantes como tickets",
-        "standard": "Configure proveedores de Gmail o IMAP para recibir y procesar correos electrónicos entrantes como tickets"
-      },
-      "counts": {
-        "enterprise": "Gmail: {{gmail}} · Microsoft: {{microsoft}} · IMAP: {{imap}}",
-        "standard": "Gmail: {{gmail}} · IMAP: {{imap}}"
-      }
+      "description": "Configure proveedores de Gmail, Microsoft 365 o IMAP para recibir y procesar correos electrónicos entrantes como tickets",
+      "counts": "Gmail: {{gmail}} · Microsoft: {{microsoft}} · IMAP: {{imap}}"
     },
     "actions": {
       "addProvider": "Agregar proveedor de correo electrónico"
@@ -117,10 +110,7 @@
     "actions": {
       "cancel": "Cancelar"
     },
-    "help": {
-      "enterprise": "Elija el proveedor que su organización ya utiliza. Si utiliza Google Workspace, elija Gmail; Si usa Microsoft 365, elija Microsoft 365. Puede cambiar esto más adelante eliminando y reconfigurando su proveedor de correo electrónico.",
-      "standard": "Elija el proveedor que su organización ya utiliza. Si utiliza Google Workspace, elija Gmail; de lo contrario, elija IMAP. Puede cambiar esto más adelante eliminando y reconfigurando su proveedor de correo electrónico."
-    }
+    "help": "Elija el proveedor que su organización ya utiliza. Si utiliza Google Workspace, elija Gmail; Si usa Microsoft 365, elija Microsoft 365. Puede cambiar esto más adelante eliminando y reconfigurando su proveedor de correo electrónico."
   },
   "wizard": {
     "title": {

--- a/server/public/locales/fr/msp/email-providers.json
+++ b/server/public/locales/fr/msp/email-providers.json
@@ -35,6 +35,7 @@
       "title": "Instructions de configuration",
       "microsoft": {
         "title": "Configuration de Microsoft 365",
+        "ownApp": "Apportez votre propre application Microsoft – enregistrez-la dans Azure AD (Microsoft Entra ID), accordez les autorisations de messagerie et connectez-la à votre boîte aux lettres Microsoft 365.",
         "providersPointer": "La configuration de l'application Microsoft est gérée dans Fournisseurs.",
         "openProviders": "Ouvrir Fournisseurs"
       },

--- a/server/public/locales/fr/msp/email-providers.json
+++ b/server/public/locales/fr/msp/email-providers.json
@@ -12,7 +12,6 @@
       "resyncError": "Échec de la resynchronisation du fournisseur IMAP",
       "resyncStarted": "Resynchronisation démarrée pour {{providerName}}.",
       "resyncRecovered": "{{providerName}} s’est reconnecté avec succès.",
-      "enterpriseOnly": "Le courrier électronique entrant Microsoft 365 est uniquement disponible avec Pro.",
       "loadProvidersError": "Échec du chargement des fournisseurs d'e-mail"
     },
     "editDrawer": {
@@ -21,14 +20,8 @@
     },
     "header": {
       "title": "Configuration du fournisseur de messagerie",
-      "description": {
-        "enterprise": "Configurer les fournisseurs Gmail, Microsoft 365 ou IMAP pour recevoir et traiter les e-mails entrants sous forme de tickets",
-        "standard": "Configurer les fournisseurs Gmail ou IMAP pour recevoir et traiter les e-mails entrants sous forme de tickets"
-      },
-      "counts": {
-        "enterprise": "Gmail : {{gmail}} · Microsoft : {{microsoft}} · IMAP : {{imap}}",
-        "standard": "Gmail : {{gmail}} · IMAP : {{imap}}"
-      }
+      "description": "Configurer les fournisseurs Gmail, Microsoft 365 ou IMAP pour recevoir et traiter les e-mails entrants sous forme de tickets",
+      "counts": "Gmail : {{gmail}} · Microsoft : {{microsoft}} · IMAP : {{imap}}"
     },
     "actions": {
       "addProvider": "Ajouter un fournisseur de messagerie"
@@ -117,10 +110,7 @@
     "actions": {
       "cancel": "Annuler"
     },
-    "help": {
-      "enterprise": "Choisissez le fournisseur que votre organisation utilise déjà. Si vous utilisez Google Workspace, choisissez Gmail ; si vous utilisez Microsoft 365, choisissez Microsoft 365. Vous pourrez modifier cela ultérieurement en supprimant et en reconfigurant votre fournisseur de messagerie.",
-      "standard": "Choisissez le fournisseur que votre organisation utilise déjà. Si vous utilisez Google Workspace, choisissez Gmail ; sinon choisissez IMAP. Vous pourrez modifier cela ultérieurement en supprimant et en reconfigurant votre fournisseur de messagerie."
-    }
+    "help": "Choisissez le fournisseur que votre organisation utilise déjà. Si vous utilisez Google Workspace, choisissez Gmail ; si vous utilisez Microsoft 365, choisissez Microsoft 365. Vous pourrez modifier cela ultérieurement en supprimant et en reconfigurant votre fournisseur de messagerie."
   },
   "wizard": {
     "title": {

--- a/server/public/locales/it/msp/email-providers.json
+++ b/server/public/locales/it/msp/email-providers.json
@@ -12,7 +12,6 @@
       "resyncError": "Impossibile risincronizzare il provider IMAP",
       "resyncStarted": "La risincronizzazione è iniziata per {{providerName}}.",
       "resyncRecovered": "{{providerName}} si è riconnesso correttamente.",
-      "enterpriseOnly": "La posta elettronica in entrata di Microsoft 365 è disponibile solo in Pro.",
       "loadProvidersError": "Impossibile caricare i provider di posta elettronica"
     },
     "editDrawer": {
@@ -21,14 +20,8 @@
     },
     "header": {
       "title": "Configurazione del provider di posta elettronica",
-      "description": {
-        "enterprise": "Configura Gmail, Microsoft 365 o i provider IMAP per ricevere ed elaborare le email in entrata come ticket",
-        "standard": "Configura i provider Gmail o IMAP per ricevere ed elaborare le email in entrata come ticket"
-      },
-      "counts": {
-        "enterprise": "Gmail: {{gmail}} · Microsoft: {{microsoft}} · IMAP: {{imap}}",
-        "standard": "Gmail: {{gmail}} · IMAP: {{imap}}"
-      }
+      "description": "Configura Gmail, Microsoft 365 o i provider IMAP per ricevere ed elaborare le email in entrata come ticket",
+      "counts": "Gmail: {{gmail}} · Microsoft: {{microsoft}} · IMAP: {{imap}}"
     },
     "actions": {
       "addProvider": "Aggiungi fornitore di posta elettronica"
@@ -117,10 +110,7 @@
     "actions": {
       "cancel": "Annulla"
     },
-    "help": {
-      "enterprise": "Scegli il provider già utilizzato dalla tua organizzazione. Se utilizzi Google Workspace, scegli Gmail; se utilizzi Microsoft 365, scegli Microsoft 365. Puoi modificare questa impostazione in un secondo momento rimuovendo e riconfigurando il tuo provider di posta elettronica.",
-      "standard": "Scegli il provider già utilizzato dalla tua organizzazione. Se utilizzi Google Workspace, scegli Gmail; altrimenti scegli IMAP. Puoi modificarlo in seguito rimuovendo e riconfigurando il tuo provider di posta elettronica."
-    }
+    "help": "Scegli il provider già utilizzato dalla tua organizzazione. Se utilizzi Google Workspace, scegli Gmail; se utilizzi Microsoft 365, scegli Microsoft 365. Puoi modificare questa impostazione in un secondo momento rimuovendo e riconfigurando il tuo provider di posta elettronica."
   },
   "wizard": {
     "title": {

--- a/server/public/locales/it/msp/email-providers.json
+++ b/server/public/locales/it/msp/email-providers.json
@@ -35,6 +35,7 @@
       "title": "Istruzioni per l'installazione",
       "microsoft": {
         "title": "Installazione di Microsoft 365",
+        "ownApp": "Usa l'app Microsoft: registrala in Azure AD (Microsoft Entra ID), autorizza le autorizzazioni di posta e collegala alla tua cassetta di posta Microsoft 365.",
         "providersPointer": "La configurazione dell'app Microsoft viene gestita in Fornitori.",
         "openProviders": "Apri Fornitori"
       },

--- a/server/public/locales/nl/msp/email-providers.json
+++ b/server/public/locales/nl/msp/email-providers.json
@@ -12,7 +12,6 @@
       "resyncError": "Het opnieuw synchroniseren van de IMAP-provider is mislukt",
       "resyncStarted": "Hersynchronisatie gestart voor {{providerName}}.",
       "resyncRecovered": "{{providerName}} is opnieuw verbonden.",
-      "enterpriseOnly": "Microsoft 365 inkomende e-mail is alleen beschikbaar in Pro.",
       "loadProvidersError": "Kan e-mailproviders niet laden"
     },
     "editDrawer": {
@@ -21,14 +20,8 @@
     },
     "header": {
       "title": "Configuratie van e-mailprovider",
-      "description": {
-        "enterprise": "Configureer Gmail-, Microsoft 365- of IMAP-providers om inkomende e-mails als tickets te ontvangen en te verwerken",
-        "standard": "Configureer Gmail- of IMAP-providers om inkomende e-mails als tickets te ontvangen en te verwerken"
-      },
-      "counts": {
-        "enterprise": "Gmail: {{gmail}} · Microsoft: {{microsoft}} · IMAP: {{imap}}",
-        "standard": "Gmail: {{gmail}} · IMAP: {{imap}}"
-      }
+      "description": "Configureer Gmail-, Microsoft 365- of IMAP-providers om inkomende e-mails als tickets te ontvangen en te verwerken",
+      "counts": "Gmail: {{gmail}} · Microsoft: {{microsoft}} · IMAP: {{imap}}"
     },
     "actions": {
       "addProvider": "E-mailprovider toevoegen"
@@ -117,10 +110,7 @@
     "actions": {
       "cancel": "Annuleren"
     },
-    "help": {
-      "enterprise": "Kies de provider die uw organisatie al gebruikt. Gebruikt u Google Workspace, kies dan Gmail; gebruikt u Microsoft 365, kies dan Microsoft 365. U kunt dit later wijzigen door uw e-mailprovider te verwijderen en opnieuw te configureren.",
-      "standard": "Kies de provider die uw organisatie al gebruikt. Gebruikt u Google Workspace, kies dan Gmail; kies anders IMAP. U kunt dit later wijzigen door uw e-mailprovider te verwijderen en opnieuw te configureren."
-    }
+    "help": "Kies de provider die uw organisatie al gebruikt. Gebruikt u Google Workspace, kies dan Gmail; gebruikt u Microsoft 365, kies dan Microsoft 365. U kunt dit later wijzigen door uw e-mailprovider te verwijderen en opnieuw te configureren."
   },
   "wizard": {
     "title": {

--- a/server/public/locales/nl/msp/email-providers.json
+++ b/server/public/locales/nl/msp/email-providers.json
@@ -35,6 +35,7 @@
       "title": "Installatie-instructies",
       "microsoft": {
         "title": "Microsoft 365-installatie",
+        "ownApp": "Breng uw eigen Microsoft-app mee – registreer deze in Azure AD (Microsoft Entra ID), verleen e-mailmachtigingen en verbind deze met uw Microsoft 365-postvak.",
         "providersPointer": "De configuratie van de Microsoft-app wordt beheerd in Aanbieders.",
         "openProviders": "Aanbieders openen"
       },

--- a/server/public/locales/pl/msp/email-providers.json
+++ b/server/public/locales/pl/msp/email-providers.json
@@ -35,6 +35,7 @@
       "title": "Instrukcje konfiguracji",
       "microsoft": {
         "title": "Konfiguracja Microsoft 365",
+        "ownApp": "Skorzystaj z własnej aplikacji Microsoft — zarejestruj ją w Azure AD (Microsoft Entra ID), przyznaj uprawnienia poczty i podłącz ją do skrzynki Microsoft 365.",
         "providersPointer": "Konfiguracją aplikacji Microsoft zarządza się w sekcji Dostawcy.",
         "openProviders": "Otwórz Dostawców"
       },

--- a/server/public/locales/pl/msp/email-providers.json
+++ b/server/public/locales/pl/msp/email-providers.json
@@ -12,7 +12,6 @@
       "resyncError": "Nie udało się ponownie zsynchronizować dostawcy IMAP",
       "resyncStarted": "Rozpoczęto ponowną synchronizację dla {{providerName}}.",
       "resyncRecovered": "Ponownie połączono z {{providerName}}.",
-      "enterpriseOnly": "Przychodząca poczta e-mail usługi Microsoft 365 jest dostępna tylko w Pro.",
       "loadProvidersError": "Nie udało się wczytać dostawców poczty e-mail"
     },
     "editDrawer": {
@@ -21,14 +20,8 @@
     },
     "header": {
       "title": "Konfiguracja dostawcy poczty e-mail",
-      "description": {
-        "enterprise": "Skonfiguruj dostawców usług Gmail, Microsoft 365 lub IMAP, aby odbierać i przetwarzać przychodzące wiadomości e-mail jako zgłoszenia",
-        "standard": "Skonfiguruj dostawców Gmaila lub IMAP, aby odbierali i przetwarzali przychodzące wiadomości e-mail jako zgłoszenia"
-      },
-      "counts": {
-        "enterprise": "Gmail: {{gmail}} · Microsoft: {{microsoft}} · IMAP: {{imap}}",
-        "standard": "Gmail: {{gmail}} · IMAP: {{imap}}"
-      }
+      "description": "Skonfiguruj dostawców usług Gmail, Microsoft 365 lub IMAP, aby odbierać i przetwarzać przychodzące wiadomości e-mail jako zgłoszenia",
+      "counts": "Gmail: {{gmail}} · Microsoft: {{microsoft}} · IMAP: {{imap}}"
     },
     "actions": {
       "addProvider": "Dodaj dostawcę poczty e-mail"
@@ -117,10 +110,7 @@
     "actions": {
       "cancel": "Anuluj"
     },
-    "help": {
-      "enterprise": "Wybierz dostawcę, z którego korzysta już Twoja organizacja. Jeśli korzystasz z Google Workspace, wybierz Gmail; jeśli korzystasz z Microsoft 365, wybierz Microsoft 365. Możesz to zmienić później, usuwając i ponownie konfigurując dostawcę poczty e-mail.",
-      "standard": "Wybierz dostawcę, z którego korzysta już Twoja organizacja. Jeśli korzystasz z Google Workspace, wybierz Gmail; w przeciwnym razie wybierz IMAP. Możesz to zmienić później, usuwając i ponownie konfigurując dostawcę poczty e-mail."
-    }
+    "help": "Wybierz dostawcę, z którego korzysta już Twoja organizacja. Jeśli korzystasz z Google Workspace, wybierz Gmail; jeśli korzystasz z Microsoft 365, wybierz Microsoft 365. Możesz to zmienić później, usuwając i ponownie konfigurując dostawcę poczty e-mail."
   },
   "wizard": {
     "title": {

--- a/server/public/locales/pt/msp/email-providers.json
+++ b/server/public/locales/pt/msp/email-providers.json
@@ -35,6 +35,7 @@
       "title": "Instruções de configuração",
       "microsoft": {
         "title": "Configuração do Microsoft 365",
+        "ownApp": "Traga seu próprio aplicativo da Microsoft — registre-o no Azure AD (Microsoft Entra ID), conceda permissões de email e conecte-o à sua caixa de correio do Microsoft 365.",
         "providersPointer": "A configuração do aplicativo da Microsoft é gerenciada em Provedores.",
         "openProviders": "Abrir Provedores"
       },

--- a/server/public/locales/pt/msp/email-providers.json
+++ b/server/public/locales/pt/msp/email-providers.json
@@ -12,7 +12,6 @@
       "resyncError": "Falha ao sincronizar novamente o provedor IMAP",
       "resyncStarted": "A ressincronização foi iniciada para {{providerName}}.",
       "resyncRecovered": "{{providerName}} foi reconectado com sucesso.",
-      "enterpriseOnly": "O email de entrada do Microsoft 365 está disponível apenas no Pro.",
       "loadProvidersError": "Falha ao carregar os provedores de email"
     },
     "editDrawer": {
@@ -21,14 +20,8 @@
     },
     "header": {
       "title": "Configuração do provedor de e-mail",
-      "description": {
-        "enterprise": "Configure provedores do Gmail, Microsoft 365 ou IMAP para receber e processar emails de entrada como tickets",
-        "standard": "Configure provedores Gmail ou IMAP para receber e processar e-mails recebidos como tickets"
-      },
-      "counts": {
-        "enterprise": "Gmail: {{gmail}} · Microsoft: {{microsoft}} · IMAP: {{imap}}",
-        "standard": "Gmail: {{gmail}} · IMAP: {{imap}}"
-      }
+      "description": "Configure provedores do Gmail, Microsoft 365 ou IMAP para receber e processar emails de entrada como tickets",
+      "counts": "Gmail: {{gmail}} · Microsoft: {{microsoft}} · IMAP: {{imap}}"
     },
     "actions": {
       "addProvider": "Adicionar provedor de e-mail"
@@ -117,10 +110,7 @@
     "actions": {
       "cancel": "Cancelar"
     },
-    "help": {
-      "enterprise": "Escolha o provedor que sua organização já usa. Se você usa o Google Workspace, escolha Gmail; se você usa Microsoft 365, escolha Microsoft 365. Você pode alterar isso mais tarde removendo e reconfigurando seu provedor de e-mail.",
-      "standard": "Escolha o provedor que sua organização já usa. Se você usa o Google Workspace, escolha Gmail; caso contrário, escolha IMAP. Você pode alterar isso posteriormente removendo e reconfigurando seu provedor de e-mail."
-    }
+    "help": "Escolha o provedor que sua organização já usa. Se você usa o Google Workspace, escolha Gmail; se você usa Microsoft 365, escolha Microsoft 365. Você pode alterar isso mais tarde removendo e reconfigurando seu provedor de e-mail."
   },
   "wizard": {
     "title": {

--- a/server/public/locales/xx/msp/email-providers.json
+++ b/server/public/locales/xx/msp/email-providers.json
@@ -35,6 +35,7 @@
       "title": "11111",
       "microsoft": {
         "title": "11111",
+        "ownApp": "11111",
         "providersPointer": "11111",
         "openProviders": "11111"
       },

--- a/server/public/locales/xx/msp/email-providers.json
+++ b/server/public/locales/xx/msp/email-providers.json
@@ -12,7 +12,6 @@
       "resyncError": "11111",
       "resyncStarted": "11111 {{providerName}} 11111",
       "resyncRecovered": "11111 {{providerName}} 11111",
-      "enterpriseOnly": "11111",
       "loadProvidersError": "11111"
     },
     "editDrawer": {
@@ -21,14 +20,8 @@
     },
     "header": {
       "title": "11111",
-      "description": {
-        "enterprise": "11111",
-        "standard": "11111"
-      },
-      "counts": {
-        "enterprise": "11111 {{gmail}} 11111 {{microsoft}} 11111 {{imap}} 11111",
-        "standard": "11111 {{gmail}} 11111 {{imap}} 11111"
-      }
+      "description": "11111",
+      "counts": "11111 {{gmail}} 11111 {{microsoft}} 11111 {{imap}} 11111"
     },
     "actions": {
       "addProvider": "11111"
@@ -117,10 +110,7 @@
     "actions": {
       "cancel": "11111"
     },
-    "help": {
-      "enterprise": "11111",
-      "standard": "11111"
-    }
+    "help": "11111"
   },
   "wizard": {
     "title": {

--- a/server/public/locales/yy/msp/email-providers.json
+++ b/server/public/locales/yy/msp/email-providers.json
@@ -12,7 +12,6 @@
       "resyncError": "55555",
       "resyncStarted": "55555 {{providerName}} 55555",
       "resyncRecovered": "55555 {{providerName}} 55555",
-      "enterpriseOnly": "55555",
       "loadProvidersError": "55555"
     },
     "editDrawer": {
@@ -21,14 +20,8 @@
     },
     "header": {
       "title": "55555",
-      "description": {
-        "enterprise": "55555",
-        "standard": "55555"
-      },
-      "counts": {
-        "enterprise": "55555 {{gmail}} 55555 {{microsoft}} 55555 {{imap}} 55555",
-        "standard": "55555 {{gmail}} 55555 {{imap}} 55555"
-      }
+      "description": "55555",
+      "counts": "55555 {{gmail}} 55555 {{microsoft}} 55555 {{imap}} 55555"
     },
     "actions": {
       "addProvider": "55555"
@@ -117,10 +110,7 @@
     "actions": {
       "cancel": "55555"
     },
-    "help": {
-      "enterprise": "55555",
-      "standard": "55555"
-    }
+    "help": "55555"
   },
   "wizard": {
     "title": {

--- a/server/public/locales/yy/msp/email-providers.json
+++ b/server/public/locales/yy/msp/email-providers.json
@@ -35,6 +35,7 @@
       "title": "55555",
       "microsoft": {
         "title": "55555",
+        "ownApp": "55555",
         "providersPointer": "55555",
         "openProviders": "55555"
       },

--- a/server/src/test/unit/components/EmailProviderConfiguration.test.tsx
+++ b/server/src/test/unit/components/EmailProviderConfiguration.test.tsx
@@ -205,6 +205,10 @@ describe('EmailProviderConfiguration', () => {
   afterEach(() => {
     cleanup();
     vi.clearAllMocks();
+    // Restore the module-default edition so EE tests are not affected by a
+    // CE test that toggled the environment mid-suite.
+    process.env.NEXT_PUBLIC_EDITION = 'enterprise';
+    process.env.EDITION = 'ee';
   });
 
   it('should render loading state initially', () => {
@@ -235,11 +239,59 @@ describe('EmailProviderConfiguration', () => {
 
     render(<EmailProviderConfiguration />);
 
-    expect(await screen.findByText('Microsoft app setup is managed in Providers.')).toBeInTheDocument();
+    expect(await screen.findByText(/Bring your own Microsoft app/)).toBeInTheDocument();
+    expect(screen.getByText('Microsoft app setup is managed in Providers.')).toBeInTheDocument();
     expect(screen.getByRole('button', { name: 'Open Providers' })).toBeInTheDocument();
     expect(screen.queryByText(/no Entra app registration is needed/i)).not.toBeInTheDocument();
     expect(screen.queryByText(/use your own Microsoft app/i)).not.toBeInTheDocument();
     expect(screen.queryByText('Register an application in Azure AD')).not.toBeInTheDocument();
+  });
+
+  it('lists microsoft-type providers in CE without filtering them out', async () => {
+    process.env.NEXT_PUBLIC_EDITION = 'community';
+    process.env.EDITION = 'ce';
+    vi.mocked(emailProviderActions.getEmailProviders).mockResolvedValueOnce({ providers: mockProviders } as any);
+
+    render(<EmailProviderConfiguration />);
+
+    await waitFor(() => {
+      expect(screen.getAllByText('Test Microsoft').length).toBeGreaterThan(0);
+    });
+    expect(screen.getAllByText('Test Microsoft').length).toBeGreaterThan(0);
+    expect(screen.getAllByText('Test Gmail').length).toBeGreaterThan(0);
+  });
+
+  it('opens the edit flow for a microsoft-type provider in CE without a Pro-only error', async () => {
+    process.env.NEXT_PUBLIC_EDITION = 'community';
+    process.env.EDITION = 'ce';
+    vi.mocked(emailProviderActions.getEmailProviders).mockResolvedValueOnce({ providers: mockProviders } as any);
+
+    const user = userEvent.setup();
+    render(<EmailProviderConfiguration />);
+
+    await waitFor(() => {
+      expect(screen.getByTestId('provider-1')).toBeInTheDocument();
+    });
+
+    await user.click(screen.getAllByText('Edit')[0]);
+
+    expect(screen.getByText('Edit Email Provider')).toBeInTheDocument();
+    expect(screen.getByTestId('microsoft-form')).toBeInTheDocument();
+    expect(screen.queryByText(/only available in Pro/i)).not.toBeInTheDocument();
+  });
+
+  it('shows Microsoft setup guidance in CE without the hosted Providers hint', async () => {
+    process.env.NEXT_PUBLIC_EDITION = 'community';
+    process.env.EDITION = 'ce';
+    vi.mocked(emailProviderActions.getEmailProviders).mockResolvedValueOnce({ providers: [] } as any);
+
+    render(<EmailProviderConfiguration />);
+
+    // Edition-neutral bring-your-own-app guidance renders in every edition.
+    expect(await screen.findByText(/Bring your own Microsoft app/)).toBeInTheDocument();
+    // The hosted/platform-credentials hint stays EE-only.
+    expect(screen.queryByText('Microsoft app setup is managed in Providers.')).not.toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: 'Open Providers' })).not.toBeInTheDocument();
   });
 
   it('should open the setup wizard when add provider button is clicked', async () => {


### PR DESCRIPTION
## Restore Microsoft 365 inbound email to Community Edition

Microsoft 365 inbound email had been gated behind Enterprise Edition in the integrations email UI. This restores it as a first-class provider in Community Edition by removing the UI-layer edition gates, while deliberately preserving every other product/edition boundary (calendar, Teams, platform-credential, product-access, and the backend webhook route).

### What changed

**`EmailProviderSelector.tsx`**
- The Microsoft 365 card now always renders as a real, selectable provider card (3-column grid alongside Gmail and IMAP) instead of an `UpgradePrompt` in CE. Dropped the `isMicrosoftConsumerEnterpriseEdition()` branch and the `UpgradePrompt` import.
- Help text collapsed from `selector.help.enterprise` / `selector.help.standard` to a single edition-neutral `selector.help` key.

**`EmailProviderConfiguration.tsx`**
- Removed the `isEnterpriseEdition` early-return that skipped loading Microsoft consumer setup status — setup status now loads in every edition.
- Removed the `openEditDrawer` guard that blocked editing `microsoft`-type providers in CE with a "Microsoft 365 inbound email is only available in Pro" error.
- Provider list no longer filters out `microsoft`-type providers in CE (`visibleProviders = providers`).
- Header description/counts collapsed from `.enterprise`/`.standard` variants to unified `configuration.header.description` / `configuration.header.counts` keys (Microsoft always shown in counts).
- **Microsoft setup guidance is edition-neutral**: the bring-your-own Microsoft app (Azure AD / Entra ID) copy (`configuration.setup.microsoft.ownApp`) renders in every edition. Only the hosted/platform-credentials hint (`providersPointer` + the "Open Providers" link) stays gated behind `isEnterpriseEdition`.

**i18n** — added `configuration.setup.microsoft.ownApp` and collapsed the split `.enterprise`/`.standard` header/help keys into unified keys across all 10 locales (en, de, es, fr, it, nl, pl, pt, xx, yy).

**Tests (29 committed, all passing)** — 15 integrations + 14 server:
- `EmailProviderSelector.test.tsx`: Microsoft 365 card fires the selection callback in both CE and EE.
- `EmailProviderConfiguration.test.tsx` / `.resync.test.tsx`: microsoft-type providers list in CE; edit flow opens for a microsoft provider in CE with no Pro-only error; setup guidance renders in CE with the `ownApp` copy but without the hosted "Open Providers" hint; resync test asserts CE guidance vs EE hosted hint via a hoisted `isEnterpriseEdition` spy.
- `microsoftConsumerVisibility.test.ts` untouched and still passing.

**Preserved boundaries** — the email webhook backend route carries zero edition checks and `assertTenantProductAccess` (a separate product axis) is untouched. Calendar, Teams, and platform-credential gates are unchanged.

Implementation plan committed at `docs/plans/2026-08-05-restore-m365-inbound-ce-plan.md`.

### Smoke test

Live CE smoke of this change at `http://localhost:3701` (no `EDITION` set = Community Edition). All VERIFY criteria **PASSED** in the real UI:

1. Provider selector renders the 3-column grid with a real Microsoft 365 card (not an `UpgradePrompt`).
2. Two existing microsoft-type providers appear in the CE provider list (DB-confirmed 2 rows; header counts `Gmail:0 · Microsoft:2 · IMAP:0`).
3. Editing a microsoft provider opens the Edit drawer with **no** "only available in Pro" error.
4. The Microsoft 365 create form opens with no edition rejection.
5. Setup guidance shows the edition-neutral `ownApp` copy ("Bring your own Microsoft app — register it in Azure AD…") **without** the EE-only "Open Providers" hosted hint; header uses the unified copy.

Backend regression guard confirmed: the email webhook route has zero edition checks and `assertTenantProductAccess` is untouched. 29 committed tests pass (15 integrations incl. CE+EE selector/resync assertions, 14 server config).

**Fidelity compromises (disclosed):**
- (a) Freshly-created alga-dev card-space browser panes rejected automation ("belongs to a different host" — blank panes never attach a CDP target, even after foregrounding the space); drove the card space's **existing** logged-in pane at `:3701` instead (same app/space, existing pane).
- (b) Did **not** complete live OAuth "Sign in with Microsoft" (requires real Azure creds / live Microsoft Graph we don't run) — create-form-open verified, connected creation not end-to-end.
- (c) EE behavior not live-verified (no EE stack up); covered by passing component tests asserting the EE hosted hint present.

**Observation (not a defect in the fix):** immediately after closing a drawer the list briefly showed a stale "No Email Providers Configured" empty state while the count still said `Microsoft:2`; a hard reload rendered the 2 providers correctly — a client-side stale render.

Evidence directory: `/tmp/alga-smoke-evidence/m365-inbound-ce-20260806-000508`
