### PR TITLE
docs: update ITIL lifecycle and extension CSP docs (2026-08-06)

### DIFF
--- a/docs/extensions/extension-system-troubleshooting.md
+++ b/docs/extensions/extension-system-troubleshooting.md
@@ -7,7 +7,7 @@ Guided playbook for diagnosing and fixing AlgaPSA extension UI delivery when the
 `extensions` `runner` `docker` `minio` `ui`
 
 ## When to Use
-- Extension iframe in MSP app stays on “Starting extension / Loading extension UI…”
+- Extension iframe in MSP app stays on "Starting extension / Loading extension UI…"
 - Runner logs show `verify_archive fetch failed`, `strict validation on and tenant resolution failed`, or 404s for bundle assets.
 - After publishing/installing an extension locally and the UI never loads.
 
@@ -30,7 +30,7 @@ RUNNER_BUNDLE_STORE_BASE=http://host.docker.internal:9000/extensions \
 ```
 
 ### 2. Check Bundle Fetch
-- Watch for `verify archive fetch failed` or 404s; if present, the runner can’t locate `bundle.tar.zst`.
+- Watch for `verify archive fetch failed` or 404s; if present, the runner can't locate `bundle.tar.zst`.
 - Ensure MinIO has the tenant-scoped path:
 ```bash
 mc ls local/extensions/tenants/<tenant-id>/extensions/<ext-id>/sha256/<hash>/
@@ -48,7 +48,7 @@ node scripts/dev-install-extension.mjs --info <extension-id>
 - In the MSP app, ensure `buildExtUiSrc(...)` emits both query params (this is handled automatically after commit `HEAD`).
 
 ### 5. Frontend Spinner
-- The Docker iframe uses a hard stop gap: it toggles loading state on iframe `onLoad` or after 1.5 s.
+- The Docker iframe uses a hard stop gap: it toggles loading state on iframe `onLoad` or after 1.5 s.
 - If the spinner persists:
   1. Open Chrome DevTools MCP page list.
   2. Navigate to `http://localhost:8085/ext-ui/<ext-id>/<hash>/index.html?tenant=<tenant>`.
@@ -59,11 +59,35 @@ node scripts/dev-install-extension.mjs --info <extension-id>
 - Environment variable `EXT_STATIC_STRICT_VALIDATION=false` relaxes tenant enforcement for local dev.
 - For CI/production, keep it `true` and ensure host sets `x-tenant-id` before shipping.
 
+### 7. Content Security Policy (CSP) on Extension UI
+
+The Rust runner emits a `Content-Security-Policy` header on every extension HTML document (200, 304, and SPA fallback responses), plus `X-Content-Type-Options: nosniff` on all assets. This covers every extension automatically without per-file `<meta>` tags.
+
+If an extension's iframe is blocked by CSP (check for a CSP violation in the browser console), two environment variables control the policy:
+
+- **`EXT_UI_FRAME_ANCESTORS`** — appends the given value to the policy's `frame-ancestors` directive. Use this when an extension iframe is embedded inside a page served from a different origin:
+  ```
+  EXT_UI_FRAME_ANCESTORS=https://my-portal.example.com
+  ```
+- **`EXT_UI_CONTENT_SECURITY_POLICY`** — provides a complete replacement policy, overriding the runner's default entirely. Use this only when you need full control over the policy for a production deployment:
+  ```
+  EXT_UI_CONTENT_SECURITY_POLICY="default-src 'self'; style-src 'self' 'unsafe-inline'; frame-ancestors 'self' https://trusted.example.com"
+  ```
+
+The legacy `EXT_UI_HOST_MODE=nextjs` path mirrors the same CSP headers.
+
+> **Local dev note**: CSP violations that block extension content are typically resolved by setting `EXT_UI_FRAME_ANCESTORS` rather than replacing the policy wholesale. Reserve `EXT_UI_CONTENT_SECURITY_POLICY` for production deployments with specific security requirements.
+
 ## Quick Reference Commands
 ```bash
 # Restart runner with correct bundle store and strict validation disabled
 RUNNER_BUNDLE_STORE_BASE=http://host.docker.internal:9000/extensions \
 EXT_STATIC_STRICT_VALIDATION=false \
+docker compose -f docker-compose.runner-dev.yml up --build -d extension-runner
+
+# Restart runner with a custom frame-ancestors (e.g. for iframe embedding)
+RUNNER_BUNDLE_STORE_BASE=http://host.docker.internal:9000/extensions \
+EXT_UI_FRAME_ANCESTORS=https://my-portal.example.com \
 docker compose -f docker-compose.runner-dev.yml up --build -d extension-runner
 
 # Tail runner logs
@@ -78,4 +102,3 @@ curl -I "http://localhost:8085/ext-ui/<ext-id>/<hash>/main.js"
 - The iframe URL builder now appends `extensionId` to queries; ensure any custom consumers follow the same pattern.
 - Browser testing via Chrome DevTools MCP requires pointing at the runner port (8085) and supplying the tenant query manually.
 - For persistent issues, re-run `npx vitest run ee/server/src/lib/extensions/__tests__/assets/url.shared.test.ts` to confirm URL builder behaviour.
-

--- a/docs/itil/itil-integration.md
+++ b/docs/itil/itil-integration.md
@@ -9,6 +9,7 @@ This document provides comprehensive information about the ITIL (Information Tec
 - [Implementation](#implementation)
 - [Usage](#usage)
 - [Configuration](#configuration)
+- [ITIL Board and Priority Lifecycle](#itil-board-and-priority-lifecycle)
 - [API Reference](#api-reference)
 - [Workflows](#workflows)
 - [Best Practices](#best-practices)
@@ -242,6 +243,33 @@ const escalationRules = {
   level3: ['manager', 'director', 'service_desk_manager']
 };
 ```
+
+## ITIL Board and Priority Lifecycle
+
+### Board-scoped priority pickers
+
+When a user creates or edits a ticket, the priority picker filters options by the board's declared priority type:
+
+- **ITIL boards** — surface only ITIL priorities (Critical, High, Medium, Low, Planning).
+- **Non-ITIL boards** — hide ITIL priorities and show only the custom priorities defined for that board.
+
+A ticket's already-assigned priority always remains visible in the picker even if the ticket is later moved to a board whose type no longer matches. This prevents existing tickets from losing their assigned value while guiding new assignments to the correct priority set for the board.
+
+### ITIL priority protection and deletion
+
+ITIL priorities are protected from deletion as long as at least one board with `priority_type: 'itil'` exists in the tenant. While any such board is present, the delete action does not appear for ITIL priorities in **Settings > Ticketing > Priorities**.
+
+Once every ITIL-typed board has been removed, ITIL priorities become deletable: a delete action appears alongside an informational note explaining the change, and each priority can be removed individually.
+
+### Last-board deletion cleanup
+
+Deleting the last ITIL board triggers an automatic cleanup sequence that runs **before** the board row is removed, so the operation completes cleanly without leaving orphaned data or foreign-key constraint errors:
+
+1. **Category re-pointing** — ITIL categories that still reference the board being deleted are re-pointed to another surviving ITIL board. If no other ITIL board exists, the category's board reference is cleared.
+2. **Priority reference release** — all FK references that would block priority deletion are released: `sla_policy_targets.priority_id`, board `default_priority_id`, and `inbound_ticket_defaults` are cleared or updated before any priority rows are dropped.
+3. **SLA policy retirement** — the auto-created "ITIL Standard" SLA policy is retired once it has no remaining targets and is not assigned to any client. Any ITIL-Standard stamp on tickets and boards is cleared before the policy row is removed.
+
+This means tenants can fully decommission ITIL ticketing — removing the last ITIL board, then deleting ITIL priorities from Settings — without requiring any manual database intervention.
 
 ## API Reference
 


### PR DESCRIPTION
## Source PRs

| # | Title | Link |
|---|-------|------|
| #3113 | Clean up ITIL artifacts on board deletion | https://github.com/Nine-Minds/alga-psa/pull/3113 |
| #3106 | security: serve extension UI with CSP headers | https://github.com/Nine-Minds/alga-psa/pull/3106 |

## Files edited

### `docs/itil/itil-integration.md`

**Behavior conveyed:** Adds a new "ITIL Board and Priority Lifecycle" section documenting three user-visible behaviors introduced by #3113:

1. **Board-scoped priority pickers** — when creating or editing a ticket, the priority picker now filters by the board's priority type. ITIL boards surface only ITIL priorities; non-ITIL boards hide them. A ticket's already-assigned priority remains visible even after board reassignment.

2. **ITIL priority deletion lifecycle** — ITIL priorities are protected from deletion while any ITIL-typed board exists. Once all ITIL boards are removed, the delete action appears in Settings > Ticketing > Priorities and priorities can be removed individually.

3. **Last-board deletion cleanup** — deleting the final ITIL board triggers an automatic pre-deletion cleanup: orphaned ITIL categories are re-pointed (or cleared), FK references blocking priority deletion (SLA policy targets, board defaults, inbound ticket defaults) are released, and the auto-created "ITIL Standard" SLA policy is retired. Tenants can fully decommission ITIL ticketing without manual database intervention.

---

### `docs/extensions/extension-system-troubleshooting.md`

**Behavior conveyed:** Adds a "Step 7 — Content Security Policy (CSP) on Extension UI" to the diagnostic flow, documenting that the Rust runner now emits a `Content-Security-Policy` header on all extension HTML documents and `X-Content-Type-Options: nosniff` on all assets (introduced by #3106). Documents the two new env vars for configuring the policy:

- `EXT_UI_FRAME_ANCESTORS` — appends a value to `frame-ancestors`; use when embedding extensions in iframes from another origin.
- `EXT_UI_CONTENT_SECURITY_POLICY` — full policy override for advanced production deployments.

Also adds a `EXT_UI_FRAME_ANCESTORS` example to the Quick Reference Commands block.

---

## PRs audited (no drift found)

| # | Title | Outcome |
|---|-------|---------|
| #3117 | update version number | Skip — version bump only, 3 files changed. No behavioral change. |
| #3116 | I18n/translation sweep august | Skip — translation strings only, no behavioral change. |
| #3115 | add so documentation | Skip — this PR itself adds `docs/features/sales-opportunities.md`, which already incorporates the step-plan, currency-grouping, and reporting changes from #3107 (both merged the same day). No pre-existing doc is stale. |
| #3107 | Fix opportunity reporting and streamline pipeline UX | Skip — the new doc added by #3115 covers the behavioral changes (step plans, per-currency grouping, Reports tab, dedicated opportunity creation route). |
| #3112 | fix: bind backfill timestamp as parameter in SLA backfill migration | Skip — Citus migration infrastructure fix; no user-visible behavioral change. |
| #3105 | Fix 194 Dependabot alerts across all manifests | Skip — dependency/security updates only; no behavioral change. |

## Needs human review

- **nm-store customer docs**: No existing nm-store doc covers ITIL priority management, board deletion, or extension CSP configuration, so no customer-facing pages were updated. If the marketing/product team plans to surface ITIL board lifecycle or extension embedding as a user-facing capability in nm-store, new content would be needed.

- **Search-index entries** in `packages/nm-store/src/lib/developer-portal/search/{concepts,guides}.ts`: the extension CSP and ITIL board lifecycle topics are not currently indexed. If a developer portal guide page is added for either topic, search entries should be added accordingly.

- **`sdk/docs/` extension guide**: No SDK guide currently documents the runner's security model or CSP headers. A new guide page under `sdk/docs/guides/` explaining the CSP policy, the two configuration env vars, and frame-ancestors usage for embedded extension scenarios would benefit extension developers, but could not be drafted confidently without knowing the intended audience and scope of the SDK guides.

---
_Generated by [Claude Code](https://claude.ai/code/session_012KKRkXx1AWBZ5pYJi7wH3C)_