### PR TITLE
Automatic invoices: show loading skeleton while filters reload

### DIFF
--- a/docs/plans/2026-08-07-automatic-invoice-loading-skeleton-plan.md
+++ b/docs/plans/2026-08-07-automatic-invoice-loading-skeleton-plan.md
@@ -1,0 +1,83 @@
+# Automatic invoice due-work reload skeleton plan
+
+## Goal
+
+Give Billing > Invoicing > Generate immediate, accessible feedback whenever the recurring due-work query reloads. While the server response is pending, no candidate rows, approval rows, or materialization-gap data from the previous query may be presented as current.
+
+## Existing behavior
+
+`AutomaticInvoices.tsx` already owns the right request state:
+
+- `isPeriodsLoading` is set before `getAvailableRecurringDueWork` and cleared after the active request settles.
+- The request is retriggered by the applied date range, ready-page number, page size, and parent `refreshTrigger`.
+- `initialLoadDone` intentionally limits `BillingTableSkeleton` to the first request.
+- Existing candidates and materialization gaps remain in state during later requests, so stale rows and the stale repair panel remain visible for a slow response.
+- The existing request cleanup ignores results from superseded effects; keep that race protection.
+- The existing `loadError` alert is the canonical settled error UI.
+
+## Design decision
+
+Treat `isPeriodsLoading` as the authoritative visibility boundary for all data returned by `getAvailableRecurringDueWork`, not only the initial request.
+
+At the beginning of each active request:
+
+1. clear `loadError`;
+2. mark the due-work region loading;
+3. clear `periods`, `materializationGaps`, and `totalPeriods`.
+
+Clearing the fetched model makes every server-derived presentation safe by construction, including Needs Approval, quick-view counts, the materialization-gap repair panel, grouped candidate rows, and pagination totals. It also avoids moving the current toolbar or duplicating the many rendering branches.
+
+Render `BillingTableSkeleton` whenever `isPeriodsLoading` is true. Wrap the due-work results area with `aria-busy={isPeriodsLoading}`; while loading, add a visually hidden, polite `role="status"` message such as "Loading invoice candidates." Keep the decorative skeleton `aria-hidden`.
+
+When the request succeeds, replace the cleared model with the new response and end the busy state. When it returns an action error or throws, end the busy state and show the existing destructive `loadError` alert; do not add a competing error surface. Superseded requests must continue to be ignored by the effect cleanup.
+
+## Implementation tasks
+
+### 1. Make every due-work request an explicit stale-data boundary
+
+File: `packages/billing/src/components/billing-dashboard/AutomaticInvoices.tsx`
+
+- In the recurring due-work effect, clear candidates, gaps, and totals at request start alongside `setLoadError(null)` and `setIsPeriodsLoading(true)`.
+- Retain the current `isMounted` cleanup and success/error handling.
+- Replace the initial-only ready-table loading predicate with the live `isPeriodsLoading` state for the fetched results.
+- Leave the independent invoice-history loading path and `invoicedInitialLoadDone` unchanged.
+- Do not change local-only quick filters or client search into server reloads.
+
+### 2. Make the loading state accessible
+
+File: `packages/billing/src/components/billing-dashboard/AutomaticInvoices.tsx`
+
+- Put `aria-busy` on a stable due-work results container.
+- Add a `role="status"`, `aria-live="polite"` loading announcement with screen-reader-only copy while the due-work request is pending.
+- Continue using `BillingTableSkeleton` as decorative visual feedback on initial load and all later reloads.
+- Keep filter controls available so users can supersede a slow request; the existing effect cleanup will prevent an older response from winning.
+
+### 3. Add behavioral coverage for deferred reloads
+
+File: `packages/billing/tests/automaticInvoices.groupedParentRows.test.tsx`
+
+- Expose the existing `getAvailableRecurringDueWork` mock so individual calls can return deferred promises.
+- Render an initial successful candidate and materialization gap, then start a deferred reload.
+- For each server trigger seam - Apply date range, ready-page change, page-size change, and parent `refreshTrigger` rerender - assert immediately that:
+  - the loading status and skeleton are present;
+  - the due-work container reports busy;
+  - the prior candidate row and prior materialization-gap panel are absent.
+- Resolve the deferred response and assert the busy/skeleton state disappears and only the replacement response is shown.
+- Add a settled-error case proving the skeleton disappears and the existing load-error alert is preserved.
+- Keep assertions behavioral and DOM-visible; do not assert source strings or implementation-text details.
+
+## Verification
+
+Run the focused billing component test file in the wired worktree, followed by the package-level billing test command if the focused run passes. Also verify TypeScript/lint for the touched package using the repository's existing scripts.
+
+Manual smoke check on the wired stack:
+
+1. Open Billing > Invoicing > Generate.
+2. Apply a date-range filter while throttling or delaying the request.
+3. Confirm old candidate rows and repair-gap content disappear immediately, a skeleton appears, and the region reports busy.
+4. Repeat with page, page-size, and an external refresh.
+5. Confirm success replaces the skeleton with current data and failure restores the existing error alert.
+
+## Scope guard
+
+Do not optimize `getAvailableRecurringDueWork`, redesign filters, alter invoice-history loading, or change billing semantics. The unrelated Wire Up change in `package-lock.json` must remain uncommitted and untouched.

--- a/packages/auth/src/components/ssoProviderButtonsImport.test.ts
+++ b/packages/auth/src/components/ssoProviderButtonsImport.test.ts
@@ -2,13 +2,8 @@
 
 import React from 'react';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
-import { render, waitFor } from '@testing-library/react';
+import { render, screen, waitFor } from '@testing-library/react';
 import SsoProviderButtons from './SsoProviderButtons';
-
-// The server-suite setup stubs this hook with empty automationIdProps, which
-// strips DOM ids off UI Buttons — this test locates the provider buttons by
-// id. No-op under this package's own config.
-vi.unmock('@alga-psa/ui/ui-reflection/useAutomationIdAndRegister');
 
 const reactWithAct = React as unknown as { act?: (callback: () => unknown) => unknown };
 if (typeof reactWithAct.act !== 'function') {
@@ -76,14 +71,12 @@ describe('SsoProviderButtons runtime DOM behavior', () => {
     );
 
     await waitFor(() => {
-      const googleButton = document.getElementById('sso-provider-google-button');
-      const microsoftButton = document.getElementById('sso-provider-azure-ad-button');
-      expect(googleButton).toBeTruthy();
-      expect(microsoftButton).toBeTruthy();
+      expect(screen.getByRole('button', { name: 'Sign in with Google' })).toBeTruthy();
+      expect(screen.getByRole('button', { name: 'Sign in with Microsoft' })).toBeTruthy();
     });
 
-    const googleButton = document.getElementById('sso-provider-google-button');
-    const microsoftButton = document.getElementById('sso-provider-azure-ad-button');
+    const googleButton = screen.getByRole('button', { name: 'Sign in with Google' });
+    const microsoftButton = screen.getByRole('button', { name: 'Sign in with Microsoft' });
     expect(googleButton?.querySelector('svg')).toBeTruthy();
     expect(microsoftButton?.querySelector('svg')).toBeTruthy();
   });
@@ -100,11 +93,15 @@ describe('SsoProviderButtons runtime DOM behavior', () => {
     );
 
     await waitFor(() => {
-      const microsoftButton = document.getElementById('sso-provider-azure-ad-button') as HTMLButtonElement | null;
-      expect(Boolean(microsoftButton && !microsoftButton.disabled)).toBe(true);
+      const microsoftButton = screen.getByRole('button', {
+        name: 'Sign in with Microsoft',
+      }) as HTMLButtonElement;
+      expect(microsoftButton.disabled).toBe(false);
     });
 
-    const googleButton = document.getElementById('sso-provider-google-button') as HTMLButtonElement | null;
-    expect(Boolean(googleButton?.disabled)).toBe(true);
+    const googleButton = screen.getByRole('button', {
+      name: 'Sign in with Google',
+    }) as HTMLButtonElement;
+    expect(googleButton.disabled).toBe(true);
   });
 });

--- a/packages/billing/src/components/billing-dashboard/AutomaticInvoices.tsx
+++ b/packages/billing/src/components/billing-dashboard/AutomaticInvoices.tsx
@@ -805,6 +805,12 @@ const AutomaticInvoices: React.FC<AutomaticInvoicesProps> = ({ onGenerateSuccess
     const loadPeriods = async () => {
       setIsPeriodsLoading(true);
       setLoadError(null);
+      // Every due-work request is a stale-data boundary: drop the previous
+      // page's candidates, gaps, and totals immediately so nothing from the
+      // prior query is presented as current while the reload is in flight.
+      setPeriods([]);
+      setMaterializationGaps([]);
+      setTotalPeriods(0);
       try {
         const dateRangeFilter = buildDateRangeFilter(appliedDateRange);
         const result = await getAvailableRecurringDueWork({
@@ -1834,7 +1840,6 @@ const AutomaticInvoices: React.FC<AutomaticInvoicesProps> = ({ onGenerateSuccess
   // immediately instead of waiting behind one combined spinner. The fix-list +
   // Ready-to-Invoice block shares the slow due-work fetch; the History table loads
   // on its own (separate, independent server action).
-  const isReadyInitialLoading = !initialLoadDone.current && isPeriodsLoading;
   const isHistoryInitialLoading = !invoicedInitialLoadDone.current && isInvoicedLoading;
 
   return (
@@ -1869,7 +1874,20 @@ const AutomaticInvoices: React.FC<AutomaticInvoicesProps> = ({ onGenerateSuccess
             </AlertDescription>
           </Alert>
         ) : null}
-        <div>
+        <div
+          className="sr-only"
+          role="status"
+          aria-live="polite"
+          data-testid="automatic-invoices-loading-status"
+        >
+          {isPeriodsLoading
+            ? t('automaticInvoices.loading.candidates', { defaultValue: 'Loading invoice candidates.' })
+            : ''}
+        </div>
+        <div
+          aria-busy={isPeriodsLoading}
+          data-testid="automatic-invoices-due-work-region"
+        >
           {needsApprovalParentGroups.length > 0 ? (
             <div className="mb-6 rounded-md border border-warning/40 bg-warning/5 p-4" data-testid="needs-approval-section">
               <h2 className="text-lg font-semibold">
@@ -2339,7 +2357,7 @@ const AutomaticInvoices: React.FC<AutomaticInvoicesProps> = ({ onGenerateSuccess
               per-column dataIndex tricks (select/tags → compact ids) + mixed px/% widths because
               DataTable's auto-fit overrides plain widths; a first-class "column width spec" on
               DataTable would remove this dance. */}
-          {isReadyInitialLoading ? (
+          {isPeriodsLoading ? (
             <BillingTableSkeleton columns={6} />
           ) : (
           <DataTable

--- a/packages/billing/src/components/billing-dashboard/AutomaticInvoices.tsx
+++ b/packages/billing/src/components/billing-dashboard/AutomaticInvoices.tsx
@@ -826,19 +826,18 @@ const AutomaticInvoices: React.FC<AutomaticInvoicesProps> = ({ onGenerateSuccess
           setMaterializationGaps([]);
           setTotalPeriods(0);
           setLoadError(getErrorMessage(result));
-          return;
-        }
+        } else {
+          setPeriods(result.invoiceCandidates as ReadyPeriod[]);
+          setMaterializationGaps(result.materializationGaps);
+          setTotalPeriods(result.total);
+          initialLoadDone.current = true;
 
-        setPeriods(result.invoiceCandidates as ReadyPeriod[]);
-        setMaterializationGaps(result.materializationGaps);
-        setTotalPeriods(result.total);
-        initialLoadDone.current = true;
-
-        // Clamp page if current page is beyond available pages (e.g., after delete/filter)
-        const maxPage = Math.max(1, Math.ceil(result.total / pageSize));
-        if (currentReadyPage > maxPage && currentReadyPage !== maxPage) {
-          setCurrentReadyPage(maxPage);
-          setSelectedTargets(new Set()); // Clear selection since visible rows changed
+          // Clamp page if current page is beyond available pages (e.g., after delete/filter)
+          const maxPage = Math.max(1, Math.ceil(result.total / pageSize));
+          if (currentReadyPage > maxPage && currentReadyPage !== maxPage) {
+            setCurrentReadyPage(maxPage);
+            setSelectedTargets(new Set()); // Clear selection since visible rows changed
+          }
         }
       } catch (error) {
         console.error('Error loading billing periods:', error);

--- a/packages/billing/tests/automaticInvoices.groupedParentRows.test.tsx
+++ b/packages/billing/tests/automaticInvoices.groupedParentRows.test.tsx
@@ -1128,4 +1128,41 @@ describe('AutomaticInvoices grouped parent rows', () => {
       errorSpy.mockRestore();
     }
   });
+
+  it('a returned action/permission error removes the skeleton and shows the existing load-error alert (R008)', async () => {
+    const initial = deferred();
+    const denied = deferred();
+    mockGetAvailableRecurringDueWork
+      .mockReturnValueOnce(initial.promise)
+      .mockReturnValueOnce(denied.promise);
+
+    const AutomaticInvoices = (await import('../src/components/billing-dashboard/AutomaticInvoices')).default;
+    render(<AutomaticInvoices onGenerateSuccess={() => undefined} />);
+
+    await act(async () => {
+      initial.resolve(buildDueWorkResponse({ clientName: 'Acme Co' }));
+    });
+    await waitFor(() => {
+      expect(screen.getByText('Acme Co')).toBeInTheDocument();
+    });
+    expect(screen.getByTestId('automatic-invoices-due-work-region')).toHaveAttribute('aria-busy', 'false');
+
+    fireEvent.click(screen.getByRole('button', { name: 'Apply' }));
+    expect(screen.getByTestId('billing-table-skeleton')).toBeInTheDocument();
+    expect(screen.getByTestId('automatic-invoices-due-work-region')).toHaveAttribute('aria-busy', 'true');
+    expect(screen.getByRole('status')).toHaveTextContent('Loading invoice candidates.');
+    expect(screen.queryByText('Acme Co')).not.toBeInTheDocument();
+
+    // The action settles by returning a permission-error payload (resolved, not rejected).
+    await act(async () => {
+      denied.resolve({ permissionError: 'Permission denied: billing read required' });
+    });
+    await waitFor(() => {
+      expect(screen.queryByTestId('billing-table-skeleton')).not.toBeInTheDocument();
+    });
+    expect(screen.getByTestId('automatic-invoices-due-work-region')).toHaveAttribute('aria-busy', 'false');
+    expect(screen.getByRole('status')).not.toHaveTextContent('Loading invoice candidates.');
+    expect(screen.getByText('Permission denied: billing read required')).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Retry' })).toBeInTheDocument();
+  });
 });

--- a/packages/billing/tests/automaticInvoices.groupedParentRows.test.tsx
+++ b/packages/billing/tests/automaticInvoices.groupedParentRows.test.tsx
@@ -8,6 +8,7 @@ import '@testing-library/jest-dom/vitest';
 
 let mockDueWorkResponse: any;
 let mockRecurringInvoiceHistoryResponse: any;
+const mockGetAvailableRecurringDueWork = vi.fn();
 const mockPreviewGroupedInvoicesForSelectionInputs = vi.fn(async (groups: Array<{ previewGroupKey: string; selectorInputs: any[] }>) => ({
   success: true,
   invoiceCount: groups.length,
@@ -47,7 +48,7 @@ vi.mock('@alga-psa/ui/lib/i18n/client', () => ({
 }));
 
 vi.mock('@alga-psa/billing/actions/billingAndTax', () => ({
-  getAvailableRecurringDueWork: vi.fn(async () => mockDueWorkResponse),
+  getAvailableRecurringDueWork: mockGetAvailableRecurringDueWork,
 }));
 
 vi.mock('@alga-psa/billing/actions/invoiceGeneration', () => ({
@@ -71,10 +72,18 @@ vi.mock('@alga-psa/ui/components/DataTable', () => ({
     id,
     data,
     columns = [],
+    currentPage,
+    onPageChange,
+    pageSize,
+    onItemsPerPageChange,
   }: {
     id: string;
     data: any[];
     columns?: Array<{ dataIndex?: string; render?: (value: unknown, row: any, index: number) => React.ReactNode }>;
+    currentPage?: number;
+    onPageChange?: (page: number) => void;
+    pageSize?: number;
+    onItemsPerPageChange?: (size: number) => void;
   }) => (
     <div data-testid={id}>
       <div data-testid={`${id}-header`}>
@@ -101,6 +110,22 @@ vi.mock('@alga-psa/ui/components/DataTable', () => ({
           </div>
         );
       })}
+      {onPageChange ? (
+        <button data-testid={`${id}-next-page`} onClick={() => onPageChange((currentPage ?? 1) + 1)}>
+          Next page
+        </button>
+      ) : null}
+      {onItemsPerPageChange ? (
+        <select
+          data-testid={`${id}-page-size`}
+          value={pageSize}
+          onChange={(event) => onItemsPerPageChange(Number(event.target.value))}
+        >
+          <option value={5}>5</option>
+          <option value={10}>10</option>
+          <option value={25}>25</option>
+        </select>
+      ) : null}
     </div>
   ),
 }));
@@ -144,7 +169,7 @@ vi.mock('@alga-psa/ui/components/DateRangePicker', () => ({
   DateRangePicker: () => <div data-testid="date-range-picker" />,
 }));
 vi.mock('@alga-psa/ui/components/Alert', () => ({
-  Alert: ({ children }: any) => <div>{children}</div>,
+  Alert: ({ variant: _variant, ...props }: any) => <div {...props}>{props.children}</div>,
   AlertDescription: ({ children }: any) => <div>{children}</div>,
 }));
 vi.mock('@alga-psa/ui/components/Dialog', () => ({
@@ -163,6 +188,22 @@ vi.mock('@alga-psa/ui/components/DropdownMenu', () => ({
 vi.mock('@alga-psa/ui/components/ConfirmationDialog', () => ({
   ConfirmationDialog: () => null,
 }));
+vi.mock('@alga-psa/ui/components/Popover', () => ({
+  Popover: ({ children }: any) => <div>{children}</div>,
+  PopoverContent: ({ children }: any) => <div>{children}</div>,
+  PopoverTrigger: ({ children }: any) => <div>{children}</div>,
+}));
+vi.mock('@alga-psa/ui/components/Switch', () => ({
+  Switch: ({ checked, onCheckedChange, size: _size, ...props }: any) => (
+    <input
+      type="checkbox"
+      role="switch"
+      checked={Boolean(checked)}
+      onChange={(event) => onCheckedChange?.(event.target.checked)}
+      {...props}
+    />
+  ),
+}));
 vi.mock('@alga-psa/ui/components/LoadingIndicator', () => ({
   default: ({ text }: { text: string }) => <div>{text}</div>,
 }));
@@ -174,6 +215,7 @@ describe('AutomaticInvoices grouped parent rows', () => {
 
   beforeEach(() => {
     cleanup();
+    mockGetAvailableRecurringDueWork.mockReset();
     mockPreviewGroupedInvoicesForSelectionInputs.mockClear();
     mockGenerateGroupedInvoicesAsRecurringBillingRun.mockClear();
     mockDueWorkResponse = {
@@ -259,6 +301,7 @@ describe('AutomaticInvoices grouped parent rows', () => {
       totalPages: 1,
     };
     mockRecurringInvoiceHistoryResponse = { rows: [], total: 0, page: 1, pageSize: 10 };
+    mockGetAvailableRecurringDueWork.mockResolvedValue(mockDueWorkResponse);
   });
 
   it('renders one parent group row for a shared client + invoice window instead of one top-level row per child (T001)', async () => {
@@ -772,5 +815,317 @@ describe('AutomaticInvoices grouped parent rows', () => {
     });
     expect(screen.getByText('Multi-assignment invoice (2)')).toBeInTheDocument();
     expect(screen.getByText('Multi-contract invoice')).toBeInTheDocument();
+  });
+
+  // --- Deferred reload loading-skeleton coverage ---------------------------------
+  // The due-work mock is driven by promises we resolve/reject by hand so the
+  // in-flight state can be asserted. Assertions stay behavioral (DOM + a11y),
+  // never source-string based.
+
+  const deferred = () => {
+    let resolve!: (value: unknown) => void;
+    let reject!: (reason?: unknown) => void;
+    const promise = new Promise<unknown>((res, rej) => {
+      resolve = res;
+      reject = rej;
+    });
+    return { promise, resolve, reject };
+  };
+
+  const buildDueWorkResponse = ({ clientName = 'Acme Co', clientId = 'client-1', gapClientName = null, total = 1 }: {
+    clientName?: string;
+    clientId?: string;
+    gapClientName?: string | null;
+    total?: number;
+  } = {}) => ({
+    invoiceCandidates: [
+      {
+        candidateKey: `invoice-candidate:${clientId}:2026-03-01:2026-04-01`,
+        clientId,
+        clientName,
+        windowStart: '2026-03-01',
+        windowEnd: '2026-04-01',
+        windowLabel: '2026-03-01 to 2026-04-01',
+        servicePeriodStart: '2026-03-01',
+        servicePeriodEnd: '2026-04-01',
+        servicePeriodLabel: '2026-03-01 to 2026-04-01',
+        cadenceOwners: ['contract'],
+        cadenceSources: ['contract_anniversary'],
+        contractId: 'contract-1',
+        contractName: 'Main Contract',
+        splitReasons: [],
+        memberCount: 1,
+        canGenerate: true,
+        blockedReason: null,
+        members: [
+          {
+            executionIdentityKey: 'exec-1',
+            canGenerate: true,
+            billingCycleId: 'bc-1',
+            clientId,
+            purchaseOrderScopeKey: 'po-1',
+            currencyCode: 'USD',
+            taxSource: 'exclusive',
+            exportShapeKey: 'shape-a',
+            cadenceSource: 'contract_anniversary',
+            duePosition: 'advance',
+            servicePeriodLabel: '2026-03-01 to 2026-04-01',
+            amountCents: 12500,
+            selectorInput: {
+              clientId,
+              windowStart: '2026-03-01',
+              windowEnd: '2026-04-01',
+              executionWindow: {
+                kind: 'contract_cadence_window',
+                identityKey: `contract-window:line-1:2026-03-01:2026-04-01`,
+                cadenceOwner: 'contract',
+                contractId: 'contract-1',
+                contractLineId: 'line-1',
+              },
+            },
+          },
+        ],
+      },
+    ],
+    materializationGaps: gapClientName
+      ? [
+          {
+            executionIdentityKey: 'gap-exec-1',
+            selectionKey: 'gap-1',
+            clientId: 'gap-client',
+            clientName: gapClientName,
+            scheduleKey: 'client_schedule:gap-client:2026-03-01:2026-04-01',
+            periodKey: 'period-gap-1',
+            reason: 'missing_service_period_materialization',
+            invoiceWindowStart: '2026-03-01',
+            invoiceWindowEnd: '2026-04-01',
+            servicePeriodStart: '2026-03-01',
+            servicePeriodEnd: '2026-04-01',
+            detail: 'Billing schedule drifted',
+          },
+        ]
+      : [],
+    total,
+    page: 1,
+    pageSize: 10,
+    totalPages: Math.max(1, Math.ceil(total / 10)),
+  });
+
+  it('date-filter Apply shows the loading skeleton immediately (R001)', async () => {
+    const initial = deferred();
+    const reload = deferred();
+    mockGetAvailableRecurringDueWork
+      .mockReturnValueOnce(initial.promise)
+      .mockReturnValueOnce(reload.promise);
+
+    const AutomaticInvoices = (await import('../src/components/billing-dashboard/AutomaticInvoices')).default;
+    render(<AutomaticInvoices onGenerateSuccess={() => undefined} />);
+
+    await act(async () => {
+      initial.resolve(buildDueWorkResponse({ clientName: 'Acme Co' }));
+    });
+    await waitFor(() => {
+      expect(screen.getByText('Acme Co')).toBeInTheDocument();
+    });
+    expect(screen.getByTestId('automatic-invoices-due-work-region')).toHaveAttribute('aria-busy', 'false');
+
+    fireEvent.click(screen.getByRole('button', { name: 'Apply' }));
+
+    expect(screen.getByTestId('billing-table-skeleton')).toBeInTheDocument();
+    expect(screen.getByTestId('automatic-invoices-due-work-region')).toHaveAttribute('aria-busy', 'true');
+    expect(screen.getByRole('status')).toHaveTextContent('Loading invoice candidates.');
+  });
+
+  it('ready-page change shows the loading skeleton immediately (R002)', async () => {
+    const initial = deferred();
+    const reload = deferred();
+    mockGetAvailableRecurringDueWork
+      .mockReturnValueOnce(initial.promise)
+      .mockReturnValueOnce(reload.promise);
+
+    const AutomaticInvoices = (await import('../src/components/billing-dashboard/AutomaticInvoices')).default;
+    render(<AutomaticInvoices onGenerateSuccess={() => undefined} />);
+
+    await act(async () => {
+      initial.resolve(buildDueWorkResponse({ clientName: 'Acme Co' }));
+    });
+    await waitFor(() => {
+      expect(screen.getByText('Acme Co')).toBeInTheDocument();
+    });
+
+    fireEvent.click(screen.getByTestId('automatic-invoices-table-next-page'));
+
+    expect(screen.getByTestId('billing-table-skeleton')).toBeInTheDocument();
+    expect(screen.getByTestId('automatic-invoices-due-work-region')).toHaveAttribute('aria-busy', 'true');
+
+    await act(async () => {
+      reload.resolve(buildDueWorkResponse({ clientName: 'Page Two Co', total: 20 }));
+    });
+    await waitFor(() => {
+      expect(screen.getByText('Page Two Co')).toBeInTheDocument();
+    });
+    expect(screen.queryByTestId('billing-table-skeleton')).not.toBeInTheDocument();
+    expect(screen.getByTestId('automatic-invoices-due-work-region')).toHaveAttribute('aria-busy', 'false');
+  });
+
+  it('page-size change shows the loading skeleton immediately (R003)', async () => {
+    const initial = deferred();
+    const reload = deferred();
+    mockGetAvailableRecurringDueWork
+      .mockReturnValueOnce(initial.promise)
+      .mockReturnValueOnce(reload.promise);
+
+    const AutomaticInvoices = (await import('../src/components/billing-dashboard/AutomaticInvoices')).default;
+    render(<AutomaticInvoices onGenerateSuccess={() => undefined} />);
+
+    await act(async () => {
+      initial.resolve(buildDueWorkResponse({ clientName: 'Acme Co' }));
+    });
+    await waitFor(() => {
+      expect(screen.getByText('Acme Co')).toBeInTheDocument();
+    });
+
+    fireEvent.change(screen.getByTestId('automatic-invoices-table-page-size'), { target: { value: '5' } });
+
+    expect(screen.getByTestId('billing-table-skeleton')).toBeInTheDocument();
+    expect(screen.getByTestId('automatic-invoices-due-work-region')).toHaveAttribute('aria-busy', 'true');
+
+    await act(async () => {
+      reload.resolve(buildDueWorkResponse({ clientName: 'Size Five Co' }));
+    });
+    await waitFor(() => {
+      expect(screen.getByText('Size Five Co')).toBeInTheDocument();
+    });
+    expect(screen.queryByTestId('billing-table-skeleton')).not.toBeInTheDocument();
+    expect(screen.getByTestId('automatic-invoices-due-work-region')).toHaveAttribute('aria-busy', 'false');
+  });
+
+  it('parent refreshTrigger rerender shows the loading skeleton immediately (R004)', async () => {
+    const initial = deferred();
+    const reload = deferred();
+    mockGetAvailableRecurringDueWork
+      .mockReturnValueOnce(initial.promise)
+      .mockReturnValueOnce(reload.promise);
+
+    const AutomaticInvoices = (await import('../src/components/billing-dashboard/AutomaticInvoices')).default;
+    const { rerender } = render(<AutomaticInvoices onGenerateSuccess={() => undefined} />);
+
+    await act(async () => {
+      initial.resolve(buildDueWorkResponse({ clientName: 'Acme Co' }));
+    });
+    await waitFor(() => {
+      expect(screen.getByText('Acme Co')).toBeInTheDocument();
+    });
+
+    rerender(<AutomaticInvoices onGenerateSuccess={() => undefined} refreshTrigger={1} />);
+
+    expect(screen.getByTestId('billing-table-skeleton')).toBeInTheDocument();
+    expect(screen.getByTestId('automatic-invoices-due-work-region')).toHaveAttribute('aria-busy', 'true');
+
+    await act(async () => {
+      reload.resolve(buildDueWorkResponse({ clientName: 'Refreshed Co' }));
+    });
+    await waitFor(() => {
+      expect(screen.getByText('Refreshed Co')).toBeInTheDocument();
+    });
+    expect(screen.queryByTestId('billing-table-skeleton')).not.toBeInTheDocument();
+    expect(screen.getByTestId('automatic-invoices-due-work-region')).toHaveAttribute('aria-busy', 'false');
+  });
+
+  it('stale candidate rows and the stale materialization-gap panel are suppressed while loading (R005)', async () => {
+    const initial = deferred();
+    const reload = deferred();
+    mockGetAvailableRecurringDueWork
+      .mockReturnValueOnce(initial.promise)
+      .mockReturnValueOnce(reload.promise);
+
+    const AutomaticInvoices = (await import('../src/components/billing-dashboard/AutomaticInvoices')).default;
+    render(<AutomaticInvoices onGenerateSuccess={() => undefined} />);
+
+    await act(async () => {
+      initial.resolve(buildDueWorkResponse({ clientName: 'Acme Co', gapClientName: 'Gap Client' }));
+    });
+    await waitFor(() => {
+      expect(screen.getByText('Acme Co')).toBeInTheDocument();
+    });
+    expect(screen.getByTestId('recurring-materialization-gap-panel')).toBeInTheDocument();
+    expect(screen.getByText('Gap Client')).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole('button', { name: 'Apply' }));
+
+    expect(screen.getByTestId('billing-table-skeleton')).toBeInTheDocument();
+    expect(screen.queryByText('Acme Co')).not.toBeInTheDocument();
+    expect(screen.queryByTestId('recurring-materialization-gap-panel')).not.toBeInTheDocument();
+    expect(screen.queryByText('Gap Client')).not.toBeInTheDocument();
+  });
+
+  it('resolving the reload replaces the skeleton with the new rows and repair panel (R006)', async () => {
+    const initial = deferred();
+    const reload = deferred();
+    mockGetAvailableRecurringDueWork
+      .mockReturnValueOnce(initial.promise)
+      .mockReturnValueOnce(reload.promise);
+
+    const AutomaticInvoices = (await import('../src/components/billing-dashboard/AutomaticInvoices')).default;
+    render(<AutomaticInvoices onGenerateSuccess={() => undefined} />);
+
+    await act(async () => {
+      initial.resolve(buildDueWorkResponse({ clientName: 'Acme Co', gapClientName: 'Old Gap' }));
+    });
+    await waitFor(() => {
+      expect(screen.getByText('Acme Co')).toBeInTheDocument();
+    });
+
+    fireEvent.click(screen.getByRole('button', { name: 'Apply' }));
+    expect(screen.getByTestId('billing-table-skeleton')).toBeInTheDocument();
+
+    await act(async () => {
+      reload.resolve(buildDueWorkResponse({ clientName: 'Replacement Co', gapClientName: 'New Gap' }));
+    });
+    await waitFor(() => {
+      expect(screen.queryByTestId('billing-table-skeleton')).not.toBeInTheDocument();
+    });
+    expect(screen.getByText('Replacement Co')).toBeInTheDocument();
+    expect(screen.queryByText('Acme Co')).not.toBeInTheDocument();
+    expect(screen.getByTestId('recurring-materialization-gap-panel')).toBeInTheDocument();
+    expect(screen.getByText('New Gap')).toBeInTheDocument();
+    expect(screen.queryByText('Old Gap')).not.toBeInTheDocument();
+    expect(screen.getByTestId('automatic-invoices-due-work-region')).toHaveAttribute('aria-busy', 'false');
+  });
+
+  it('rejecting the reload removes the skeleton and shows the existing load-error alert (R007)', async () => {
+    const initial = deferred();
+    const failing = deferred();
+    mockGetAvailableRecurringDueWork
+      .mockReturnValueOnce(initial.promise)
+      .mockReturnValueOnce(failing.promise);
+
+    const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => undefined);
+
+    const AutomaticInvoices = (await import('../src/components/billing-dashboard/AutomaticInvoices')).default;
+    try {
+      render(<AutomaticInvoices onGenerateSuccess={() => undefined} />);
+
+      await act(async () => {
+        initial.resolve(buildDueWorkResponse({ clientName: 'Acme Co' }));
+      });
+      await waitFor(() => {
+        expect(screen.getByText('Acme Co')).toBeInTheDocument();
+      });
+
+      fireEvent.click(screen.getByRole('button', { name: 'Apply' }));
+      expect(screen.getByTestId('billing-table-skeleton')).toBeInTheDocument();
+
+      await act(async () => {
+        failing.reject(new Error('boom'));
+      });
+      await waitFor(() => {
+        expect(screen.queryByTestId('billing-table-skeleton')).not.toBeInTheDocument();
+      });
+      expect(screen.getByText('Failed to load billing periods. Please try again.')).toBeInTheDocument();
+      expect(screen.getByTestId('automatic-invoices-due-work-region')).toHaveAttribute('aria-busy', 'false');
+    } finally {
+      errorSpy.mockRestore();
+    }
   });
 });

--- a/server/public/locales/de/msp/invoicing.json
+++ b/server/public/locales/de/msp/invoicing.json
@@ -1,8 +1,5 @@
 {
   "automaticInvoices": {
-    "loading": {
-      "candidates": "Rechnungskandidaten werden geladen."
-    },
     "ready": {
       "title": "Bereit zur Rechnungsstellung",
       "description": "Überprüfen Sie wiederkehrende fällige Arbeiten und erstellen Sie Rechnungsentwürfe für die ausgewählten Zeiträume.",
@@ -229,7 +226,8 @@
       "loadHistory": "Der Verlauf der wiederkehrenden Rechnungen konnte nicht geladen werden. Bitte versuchen Sie es erneut."
     },
     "loading": {
-      "billingData": "Abrechnungsdaten werden geladen"
+      "billingData": "Abrechnungsdaten werden geladen",
+      "candidates": "Rechnungskandidaten werden geladen."
     },
     "views": {
       "all": "Alle",

--- a/server/public/locales/de/msp/invoicing.json
+++ b/server/public/locales/de/msp/invoicing.json
@@ -1,5 +1,8 @@
 {
   "automaticInvoices": {
+    "loading": {
+      "candidates": "Rechnungskandidaten werden geladen."
+    },
     "ready": {
       "title": "Bereit zur Rechnungsstellung",
       "description": "Überprüfen Sie wiederkehrende fällige Arbeiten und erstellen Sie Rechnungsentwürfe für die ausgewählten Zeiträume.",

--- a/server/public/locales/en/msp/invoicing.json
+++ b/server/public/locales/en/msp/invoicing.json
@@ -1,8 +1,5 @@
 {
   "automaticInvoices": {
-    "loading": {
-      "candidates": "Loading invoice candidates."
-    },
     "ready": {
       "title": "Ready to Invoice",
       "description": "Review recurring due work and generate draft invoices for the selected periods.",
@@ -229,7 +226,8 @@
       "loadHistory": "Failed to load recurring invoice history. Please try again."
     },
     "loading": {
-      "billingData": "Loading billing data"
+      "billingData": "Loading billing data",
+      "candidates": "Loading invoice candidates."
     },
     "views": {
       "all": "All",

--- a/server/public/locales/en/msp/invoicing.json
+++ b/server/public/locales/en/msp/invoicing.json
@@ -1,5 +1,8 @@
 {
   "automaticInvoices": {
+    "loading": {
+      "candidates": "Loading invoice candidates."
+    },
     "ready": {
       "title": "Ready to Invoice",
       "description": "Review recurring due work and generate draft invoices for the selected periods.",

--- a/server/public/locales/es/msp/invoicing.json
+++ b/server/public/locales/es/msp/invoicing.json
@@ -1,5 +1,8 @@
 {
   "automaticInvoices": {
+    "loading": {
+      "candidates": "Cargando candidatos de factura."
+    },
     "ready": {
       "title": "Listo para facturar",
       "description": "Revise el trabajo pendiente recurrente y genere borradores de facturas para los períodos seleccionados.",

--- a/server/public/locales/es/msp/invoicing.json
+++ b/server/public/locales/es/msp/invoicing.json
@@ -1,8 +1,5 @@
 {
   "automaticInvoices": {
-    "loading": {
-      "candidates": "Cargando candidatos de factura."
-    },
     "ready": {
       "title": "Listo para facturar",
       "description": "Revise el trabajo pendiente recurrente y genere borradores de facturas para los períodos seleccionados.",
@@ -229,7 +226,8 @@
       "loadHistory": "No se pudo cargar el historial de facturas recurrentes. Por favor inténtelo de nuevo."
     },
     "loading": {
-      "billingData": "Cargando datos de facturación"
+      "billingData": "Cargando datos de facturación",
+      "candidates": "Cargando candidatos de factura."
     },
     "views": {
       "all": "Todos",

--- a/server/public/locales/fr/msp/invoicing.json
+++ b/server/public/locales/fr/msp/invoicing.json
@@ -1,8 +1,5 @@
 {
   "automaticInvoices": {
-    "loading": {
-      "candidates": "Chargement des factures candidates."
-    },
     "ready": {
       "title": "Prêt à facturer",
       "description": "Examinez les travaux récurrents dus et générez des projets de factures pour les périodes sélectionnées.",
@@ -229,7 +226,8 @@
       "loadHistory": "Échec du chargement de l'historique des factures récurrentes. Veuillez réessayer."
     },
     "loading": {
-      "billingData": "Chargement des données de facturation"
+      "billingData": "Chargement des données de facturation",
+      "candidates": "Chargement des factures candidates."
     },
     "views": {
       "all": "Tout",

--- a/server/public/locales/fr/msp/invoicing.json
+++ b/server/public/locales/fr/msp/invoicing.json
@@ -1,5 +1,8 @@
 {
   "automaticInvoices": {
+    "loading": {
+      "candidates": "Chargement des factures candidates."
+    },
     "ready": {
       "title": "Prêt à facturer",
       "description": "Examinez les travaux récurrents dus et générez des projets de factures pour les périodes sélectionnées.",

--- a/server/public/locales/it/msp/invoicing.json
+++ b/server/public/locales/it/msp/invoicing.json
@@ -1,5 +1,8 @@
 {
   "automaticInvoices": {
+    "loading": {
+      "candidates": "Caricamento dei candidati alla fattura."
+    },
     "ready": {
       "title": "Pronto per la fatturazione",
       "description": "Esamina il lavoro ricorrente dovuto e genera bozze di fatture per i periodi selezionati.",

--- a/server/public/locales/it/msp/invoicing.json
+++ b/server/public/locales/it/msp/invoicing.json
@@ -1,8 +1,5 @@
 {
   "automaticInvoices": {
-    "loading": {
-      "candidates": "Caricamento dei candidati alla fattura."
-    },
     "ready": {
       "title": "Pronto per la fatturazione",
       "description": "Esamina il lavoro ricorrente dovuto e genera bozze di fatture per i periodi selezionati.",
@@ -229,7 +226,8 @@
       "loadHistory": "Impossibile caricare la cronologia delle fatture ricorrenti. Per favore riprova."
     },
     "loading": {
-      "billingData": "Caricamento dati di fatturazione"
+      "billingData": "Caricamento dati di fatturazione",
+      "candidates": "Caricamento dei candidati alla fattura."
     },
     "views": {
       "all": "Tutti",

--- a/server/public/locales/nl/msp/invoicing.json
+++ b/server/public/locales/nl/msp/invoicing.json
@@ -1,8 +1,5 @@
 {
   "automaticInvoices": {
-    "loading": {
-      "candidates": "Factuurkandidaten laden."
-    },
     "ready": {
       "title": "Klaar om te factureren",
       "description": "Beoordeel terugkerende werkzaamheden en genereer conceptfacturen voor de geselecteerde perioden.",
@@ -229,7 +226,8 @@
       "loadHistory": "Kan terugkerende factuurgeschiedenis niet laden. Probeer het opnieuw."
     },
     "loading": {
-      "billingData": "Factureringsgegevens laden"
+      "billingData": "Factureringsgegevens laden",
+      "candidates": "Factuurkandidaten laden."
     },
     "views": {
       "all": "Alle",

--- a/server/public/locales/nl/msp/invoicing.json
+++ b/server/public/locales/nl/msp/invoicing.json
@@ -1,5 +1,8 @@
 {
   "automaticInvoices": {
+    "loading": {
+      "candidates": "Factuurkandidaten laden."
+    },
     "ready": {
       "title": "Klaar om te factureren",
       "description": "Beoordeel terugkerende werkzaamheden en genereer conceptfacturen voor de geselecteerde perioden.",

--- a/server/public/locales/pl/msp/invoicing.json
+++ b/server/public/locales/pl/msp/invoicing.json
@@ -1,8 +1,5 @@
 {
   "automaticInvoices": {
-    "loading": {
-      "candidates": "Ładowanie kandydatów do faktury."
-    },
     "ready": {
       "title": "Gotowy do wystawienia faktury",
       "description": "Przeglądaj powtarzające się terminy prac i generuj wersje robocze faktur za wybrane okresy.",
@@ -247,7 +244,8 @@
       "loadHistory": "Nie udało się wczytać historii faktur cyklicznych. Spróbuj ponownie."
     },
     "loading": {
-      "billingData": "Ładowanie danych rozliczeniowych"
+      "billingData": "Ładowanie danych rozliczeniowych",
+      "candidates": "Ładowanie kandydatów do faktury."
     },
     "views": {
       "all": "Wszystkie",

--- a/server/public/locales/pl/msp/invoicing.json
+++ b/server/public/locales/pl/msp/invoicing.json
@@ -1,5 +1,8 @@
 {
   "automaticInvoices": {
+    "loading": {
+      "candidates": "Ładowanie kandydatów do faktury."
+    },
     "ready": {
       "title": "Gotowy do wystawienia faktury",
       "description": "Przeglądaj powtarzające się terminy prac i generuj wersje robocze faktur za wybrane okresy.",

--- a/server/public/locales/pt/msp/invoicing.json
+++ b/server/public/locales/pt/msp/invoicing.json
@@ -1,8 +1,5 @@
 {
   "automaticInvoices": {
-    "loading": {
-      "candidates": "Carregando candidatos a fatura."
-    },
     "ready": {
       "title": "Pronto para faturar",
       "description": "Revise o trabalho devido recorrente e gere projetos de faturas para os períodos selecionados.",
@@ -229,7 +226,8 @@
       "loadHistory": "Falha ao carregar o histórico de faturas recorrentes. Por favor, tente novamente."
     },
     "loading": {
-      "billingData": "Carregando dados de faturamento"
+      "billingData": "Carregando dados de faturamento",
+      "candidates": "Carregando candidatos a fatura."
     },
     "views": {
       "all": "Todos",

--- a/server/public/locales/pt/msp/invoicing.json
+++ b/server/public/locales/pt/msp/invoicing.json
@@ -1,5 +1,8 @@
 {
   "automaticInvoices": {
+    "loading": {
+      "candidates": "Carregando candidatos a fatura."
+    },
     "ready": {
       "title": "Pronto para faturar",
       "description": "Revise o trabalho devido recorrente e gere projetos de faturas para os períodos selecionados.",

--- a/server/public/locales/xx/msp/invoicing.json
+++ b/server/public/locales/xx/msp/invoicing.json
@@ -1,8 +1,5 @@
 {
   "automaticInvoices": {
-    "loading": {
-      "candidates": "11111"
-    },
     "ready": {
       "title": "11111",
       "description": "11111",
@@ -229,7 +226,8 @@
       "loadHistory": "11111"
     },
     "loading": {
-      "billingData": "11111"
+      "billingData": "11111",
+      "candidates": "11111"
     },
     "views": {
       "all": "11111",

--- a/server/public/locales/xx/msp/invoicing.json
+++ b/server/public/locales/xx/msp/invoicing.json
@@ -1,5 +1,8 @@
 {
   "automaticInvoices": {
+    "loading": {
+      "candidates": "11111"
+    },
     "ready": {
       "title": "11111",
       "description": "11111",

--- a/server/public/locales/yy/msp/invoicing.json
+++ b/server/public/locales/yy/msp/invoicing.json
@@ -1,8 +1,5 @@
 {
   "automaticInvoices": {
-    "loading": {
-      "candidates": "55555"
-    },
     "ready": {
       "title": "55555",
       "description": "55555",
@@ -229,7 +226,8 @@
       "loadHistory": "55555"
     },
     "loading": {
-      "billingData": "55555"
+      "billingData": "55555",
+      "candidates": "55555"
     },
     "views": {
       "all": "55555",

--- a/server/public/locales/yy/msp/invoicing.json
+++ b/server/public/locales/yy/msp/invoicing.json
@@ -1,5 +1,8 @@
 {
   "automaticInvoices": {
+    "loading": {
+      "candidates": "55555"
+    },
     "ready": {
       "title": "55555",
       "description": "55555",

--- a/server/src/test/unit/services/chatProviderResolver.test.ts
+++ b/server/src/test/unit/services/chatProviderResolver.test.ts
@@ -3,6 +3,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 const openAiConfigs = vi.hoisted(() => [] as Array<Record<string, unknown>>);
 const getSecretMock = vi.hoisted(() => vi.fn());
+const rolloutEnabledMock = vi.hoisted(() => vi.fn());
 const googleAccessTokenState = vi.hoisted(() => ({ token: 'adc-token' as string | undefined }));
 const licensingMocks = vi.hoisted(() => ({
   getLicenseStateRow: vi.fn(),
@@ -30,6 +31,10 @@ vi.mock('@alga-psa/core/secrets', () => ({
 }));
 
 vi.mock('@alga-psa/licensing', () => licensingMocks);
+
+vi.mock('@ee/lib/aiGateway/rollout', () => ({
+  isAiUsageBillingEnabled: rolloutEnabledMock,
+}));
 
 vi.mock('google-auth-library', () => ({
   GoogleAuth: class {
@@ -95,6 +100,10 @@ describe('resolveChatProvider()', () => {
   beforeEach(() => {
     vi.resetModules();
     getSecretMock.mockReset();
+    rolloutEnabledMock.mockReset();
+    rolloutEnabledMock.mockImplementation(
+      async () => process.env.AI_GATEWAY_ROLLOUT_ALL === 'true',
+    );
     openAiConfigs.splice(0, openAiConfigs.length);
     licensingMocks.getLicenseStateRow.mockReset();
     licensingMocks.isSelfHostLicensing.mockReset();


### PR DESCRIPTION
## Summary

- show the automatic-invoice due-work skeleton on every server-backed reload, not only the initial load
- treat reload start as a stale-data boundary by clearing candidates, repair gaps, and totals before fetching
- expose a stable `aria-busy` region plus a localized, polite accessible loading status while keeping Recurring Invoice History independent
- ensure returned action/permission errors, thrown errors, and successful results all settle the busy state
- add deferred-response component coverage for Apply, pagination, page size, parent refresh, stale-content suppression, success replacement, and both error shapes
- isolate the AI gateway rollout evaluator in its resolver unit test after the required Nx check exposed a deterministic live/default-PostHog dependency
- make SSO provider-button assertions use accessible roles instead of UI-reflection DOM ids after the coverage check exposed that server-suite coupling

## Why

Previously, later filter, page, page-size, and parent-refresh requests left stale invoice candidates and repair-gap content visible while loading. Returned action-error payloads also exited before the shared loading cleanup, which could leave the skeleton and `aria-busy` state active indefinitely.

## Validation

- `cd server && npx vitest run ../packages/billing/tests/automaticInvoices.groupedParentRows.test.tsx` — 29/29 PASS
- `cd server && VITEST_SEED=20260610 NODE_OPTIONS=--max-old-space-size=14336 npx vitest run src/test/unit --coverage.enabled=false --reporter=dot` — 4,666 PASS, 22 todo, 1 file skipped
- SSO provider-button test under both server Vitest 3 and package Vitest 4 — 2/2 PASS in each runner
- `node scripts/validate-translations.cjs` — PASS across all supported and pseudo locales
- Live smoke: **PASS with one adjacent concern** on the exact worktree at `localhost:3956` using real Next.js, PostgreSQL, Redis, and existing billing data; no mocks or simulators.
  - 08/07 → 09/01 Apply entered `aria-busy` in 100 ms, showed the accessible status and skeleton, and remained loading for three seconds under a real PostgreSQL lock. Releasing it rendered the Emerald City repair panel.
  - Reverse reload entered busy state in 105 ms, immediately hid the stale repair panel, and preserved the independent Recurring Invoice History row.
  - Terminating the real blocked database query cleared the skeleton/busy state and rendered the existing load-error message and Try again control.
  - A fresh session succeeded afterward with no console or HTTP failures. App readiness remained HTTP 200 and no smoke locks remained.

### Smoke-test scope and fidelity

`alga-dev` created the required card-scoped browser tab, but rejected browser commands because the pane is hosted on macOS while this agent runs on Linux. Installed Playwright with system Chrome was used only as the control channel; all product services and requests remained real.

Not proven live: pagination, page-size, parent refresh, and the returned permission-error branch. The available due-work set had no paginated rows, refresh is parent-driven, and shared RBAC was not mutated. Deferred component tests cover these paths.

Evidence: `/tmp/alga-smoke-evidence/invoice-loading-skeleton-20260807-031106`

## Adjacent concern

The pre-existing Try again button is inert when already on page 1. It clears the error but emits no POST, busy state, or reload. Evidence 08 captures the empty settled state, and the issue was recorded as a card fact. This behavior is outside the loading-skeleton change.

The worktree remains unchanged aside from the pre-existing `package-lock.json` modification, which is intentionally not included in this PR.
