### PR TITLE
fix: reject OAuth user type mismatches

### DIFF
--- a/ee/server/src/__tests__/unit/auth/ssoProviders.clientPortal.test.ts
+++ b/ee/server/src/__tests__/unit/auth/ssoProviders.clientPortal.test.ts
@@ -25,7 +25,7 @@ vi.mock('@alga-psa/db/models/user', () => ({
   },
 }));
 
-describe('client portal OAuth profile mapping', () => {
+describe('OAuth profile mapping user boundaries', () => {
   const tenantId = '11111111-1111-4111-8111-111111111111';
   beforeEach(() => {
     vi.clearAllMocks();
@@ -80,6 +80,54 @@ describe('client portal OAuth profile mapping', () => {
         profile: {},
         tenantHint: tenantId,
         userTypeHint: 'client',
+      })
+    ).rejects.toThrow('User not found');
+  });
+
+  it('authenticates internal users through a type-scoped lookup', async () => {
+    findUserByEmailAndTypeMock.mockResolvedValueOnce({
+      user_id: 'user-3',
+      email: 'internal@example.com',
+      username: 'internal',
+      first_name: 'Internal',
+      last_name: 'User',
+      user_type: 'internal',
+      tenant: tenantId,
+      is_inactive: false,
+    });
+
+    const { mapOAuthProfileToExtendedUser } = await import('../../../lib/auth/ssoProviders');
+    const mapped = await mapOAuthProfileToExtendedUser({
+      provider: 'microsoft',
+      email: 'internal@example.com',
+      profile: {},
+    });
+
+    expect(mapped.user_type).toBe('internal');
+    expect(findUserByEmailAndTypeMock).toHaveBeenCalledWith('internal@example.com', 'internal');
+    expect(findUserByEmailMock).not.toHaveBeenCalled();
+  });
+
+  it('rejects a client record returned during internal OAuth mode', async () => {
+    findUserByEmailAndTypeMock.mockResolvedValueOnce({
+      user_id: 'user-4',
+      email: 'client@example.com',
+      username: 'client',
+      first_name: 'Client',
+      last_name: 'User',
+      user_type: 'client',
+      tenant: tenantId,
+      is_inactive: false,
+      contact_id: 'contact-2',
+      client_id: 'client-2',
+    });
+
+    const { mapOAuthProfileToExtendedUser } = await import('../../../lib/auth/ssoProviders');
+    await expect(
+      mapOAuthProfileToExtendedUser({
+        provider: 'microsoft',
+        email: 'client@example.com',
+        profile: {},
       })
     ).rejects.toThrow('User not found');
   });

--- a/ee/server/src/lib/auth/ssoProviders.ts
+++ b/ee/server/src/lib/auth/ssoProviders.ts
@@ -5,11 +5,6 @@ import { buildTenantPortalSlug, isValidTenantSlug, getSlugParts } from '@shared/
 
 type InternalUserType = 'internal' | 'client';
 
-async function findUserByEmail(email: string): Promise<IUser | undefined> {
-  const User = (await import('@alga-psa/db/models/user')).default;
-  return User.findUserByEmail(email);
-}
-
 async function findUserByEmailAndType(email: string, userType: InternalUserType): Promise<IUser | undefined> {
   const User = (await import('@alga-psa/db/models/user')).default;
   return User.findUserByEmailAndType(email, userType);
@@ -141,7 +136,7 @@ async function locateUser(
     return findUserByEmailTenantAndType(email, tenantId, 'client');
   }
 
-  const defaultUser = await findUserByEmail(email);
+  const defaultUser = await findUserByEmailAndType(email, normalizedType);
   if (defaultUser) {
     return defaultUser;
   }
@@ -164,7 +159,7 @@ async function locateUser(
     }
   }
 
-  return findUserByEmailAndType(email, normalizedType);
+  return undefined;
 }
 
 function coerceString(value: unknown): string | undefined {
@@ -290,10 +285,11 @@ export async function mapOAuthProfileToExtendedUser(
     throw new Error('User not found');
   }
 
-  if (requestedUserType === 'client' && user.user_type !== 'client') {
-    logger.warn(`[auth] Non-client user attempted client portal ${provider} OAuth`, {
+  if (user.user_type !== requestedUserType) {
+    logger.warn(`[auth] User type mismatch during ${provider} OAuth`, {
       email: normalizedEmail,
-      userType: user.user_type,
+      requestedUserType,
+      storedUserType: user.user_type,
     });
     throw new Error('User not found');
   }


### PR DESCRIPTION
## Summary
- scope internal OAuth lookup to internal database users
- reject any mismatch between the OAuth route mode and stored user type
- add behavioral coverage for both legitimate internal login and client-to-internal escalation rejection

## Validation
- npm test -- --run src/__tests__/unit/auth/ssoProviders.clientPortal.test.ts (4 passed)
- npm run typecheck (passed)
- npx eslint ee/server/src/lib/auth/ssoProviders.ts ee/server/src/__tests__/unit/auth/ssoProviders.clientPortal.test.ts (0 errors; existing warnings only)
- broader auth-directory run: changed suite passed, but untouched getLinkedSsoProvidersAction.test.ts could not resolve next/server from next-auth in the local dependency tree