### PR TITLE
fix: reject mismatched session identity claims

### DIFF
--- a/packages/auth/src/lib/getSession.test.ts
+++ b/packages/auth/src/lib/getSession.test.ts
@@ -18,7 +18,7 @@ vi.mock('../nextauth/auth', () => ({
 
 vi.mock('@alga-psa/db/models/UserSession', () => ({
   UserSession: {
-    isRevoked: vi.fn(),
+    isRevokedOrIdentityMismatch: vi.fn(),
   },
 }));
 
@@ -28,7 +28,12 @@ import { auth as fullAuth } from '../nextauth/auth';
 import { UserSession } from '@alga-psa/db/models/UserSession';
 
 const trackedSession = {
-  user: { id: 'user-1', tenant: 'tenant-1', email: 'user@example.test' },
+  user: {
+    id: 'user-1',
+    tenant: 'tenant-1',
+    email: 'user@example.test',
+    user_type: 'internal',
+  },
   session_id: 'session-1',
 } as any;
 
@@ -37,7 +42,7 @@ const envSnapshot = { ...process.env };
 beforeEach(() => {
   vi.mocked(edgeAuth).mockReset();
   vi.mocked(fullAuth).mockReset();
-  vi.mocked(UserSession.isRevoked).mockReset();
+  vi.mocked(UserSession.isRevokedOrIdentityMismatch).mockReset();
 });
 
 afterEach(() => {
@@ -53,17 +58,21 @@ afterEach(() => {
 describe('getSession', () => {
   it('returns the edge-decoded session once the sessions table confirms it is live', async () => {
     vi.mocked(edgeAuth).mockResolvedValue(trackedSession);
-    vi.mocked(UserSession.isRevoked).mockResolvedValue(false);
+    vi.mocked(UserSession.isRevokedOrIdentityMismatch).mockResolvedValue(false);
 
     const session = await getSession();
 
     expect(session).toBe(trackedSession);
-    expect(UserSession.isRevoked).toHaveBeenCalledWith('tenant-1', 'session-1');
+    expect(UserSession.isRevokedOrIdentityMismatch).toHaveBeenCalledWith(
+      'tenant-1',
+      'session-1',
+      { userId: 'user-1', userType: 'internal' }
+    );
   });
 
   it('rejects a revoked session even though the edge decoder accepts its JWT', async () => {
     vi.mocked(edgeAuth).mockResolvedValue(trackedSession);
-    vi.mocked(UserSession.isRevoked).mockResolvedValue(true);
+    vi.mocked(UserSession.isRevokedOrIdentityMismatch).mockResolvedValue(true);
 
     await expect(getSession()).resolves.toBeNull();
   });
@@ -74,7 +83,7 @@ describe('getSession', () => {
     } as any);
 
     await expect(getSession()).resolves.toBeNull();
-    expect(UserSession.isRevoked).not.toHaveBeenCalled();
+    expect(UserSession.isRevokedOrIdentityMismatch).not.toHaveBeenCalled();
   });
 
   it('rejects a session whose tenant claim is missing', async () => {
@@ -84,12 +93,12 @@ describe('getSession', () => {
     } as any);
 
     await expect(getSession()).resolves.toBeNull();
-    expect(UserSession.isRevoked).not.toHaveBeenCalled();
+    expect(UserSession.isRevokedOrIdentityMismatch).not.toHaveBeenCalled();
   });
 
   it('fails closed when the revocation lookup throws', async () => {
     vi.mocked(edgeAuth).mockResolvedValue(trackedSession);
-    vi.mocked(UserSession.isRevoked).mockRejectedValue(new Error('connection refused'));
+    vi.mocked(UserSession.isRevokedOrIdentityMismatch).mockRejectedValue(new Error('connection refused'));
 
     await expect(getSession()).resolves.toBeNull();
   });
@@ -97,7 +106,7 @@ describe('getSession', () => {
   it('still enforces revocation on the full-auth fallback path', async () => {
     vi.mocked(edgeAuth).mockResolvedValue(null);
     vi.mocked(fullAuth).mockResolvedValue(trackedSession);
-    vi.mocked(UserSession.isRevoked).mockResolvedValue(true);
+    vi.mocked(UserSession.isRevokedOrIdentityMismatch).mockResolvedValue(true);
 
     await expect(getSession()).resolves.toBeNull();
     expect(fullAuth).toHaveBeenCalled();
@@ -107,7 +116,7 @@ describe('getSession', () => {
 describe('getSessionWithRevocationCheck', () => {
   it('returns a live session decoded by full auth', async () => {
     vi.mocked(fullAuth).mockResolvedValue(trackedSession);
-    vi.mocked(UserSession.isRevoked).mockResolvedValue(false);
+    vi.mocked(UserSession.isRevokedOrIdentityMismatch).mockResolvedValue(false);
 
     await expect(getSessionWithRevocationCheck()).resolves.toBe(trackedSession);
   });
@@ -116,7 +125,7 @@ describe('getSessionWithRevocationCheck', () => {
     process.env.NODE_ENV = 'development';
     vi.mocked(fullAuth).mockResolvedValue(null);
     vi.mocked(edgeAuth).mockResolvedValue(trackedSession);
-    vi.mocked(UserSession.isRevoked).mockResolvedValue(true);
+    vi.mocked(UserSession.isRevokedOrIdentityMismatch).mockResolvedValue(true);
 
     await expect(getSessionWithRevocationCheck()).resolves.toBeNull();
   });

--- a/packages/auth/src/lib/getSession.ts
+++ b/packages/auth/src/lib/getSession.ts
@@ -7,14 +7,15 @@ import { auth as fullAuth } from '../nextauth/auth';
 
 /**
  * Decoding a session cookie only proves the JWT is authentic; it says nothing
- * about whether the session is still alive. Revocation state lives in the
- * sessions table (SCIM deactivation, admin revoke, sign out everywhere), so
- * every session handed to a caller is checked against it on every request and
- * fails closed:
+ * about whether the session is still alive or correctly stamped. Revocation
+ * state and the session owner's canonical user type live in the database, so
+ * every session handed to a caller is checked against them on every request
+ * and fails closed:
  *
  * - a session with no tracked tenant/session identifier (e.g. an OAuth token
  *   minted before session tracking existed) is treated as revoked, and
- * - an unreachable sessions table is treated as revoked.
+ * - an unreachable sessions table is treated as revoked, and
+ * - identity claims that disagree with the tracked user are rejected.
  *
  * This is the single gate for the edge-decoded path, which cannot query the
  * database itself, and the reason callers may authorize on any session this
@@ -26,20 +27,28 @@ async function requireLiveSession(session: Session | null): Promise<Session | nu
   }
 
   const tenant = (session.user as { tenant?: unknown }).tenant;
+  const userId = (session.user as { id?: unknown }).id;
+  const userType = (session.user as { user_type?: unknown }).user_type;
   const sessionId = (session as { session_id?: unknown }).session_id;
 
   if (
     typeof tenant !== 'string'
     || tenant.length === 0
+    || typeof userId !== 'string'
+    || userId.length === 0
+    || (userType !== 'internal' && userType !== 'client')
     || typeof sessionId !== 'string'
     || sessionId.length === 0
   ) {
-    logger.warn('[auth] Rejecting session without a tracked tenant or session identifier');
+    logger.warn('[auth] Rejecting session without complete tracked identity claims');
     return null;
   }
 
   try {
-    if (await UserSession.isRevoked(tenant, sessionId)) {
+    if (await UserSession.isRevokedOrIdentityMismatch(tenant, sessionId, {
+      userId,
+      userType,
+    })) {
       return null;
     }
   } catch (error) {

--- a/packages/auth/src/lib/nextAuthOptions.productCodeMapping.test.ts
+++ b/packages/auth/src/lib/nextAuthOptions.productCodeMapping.test.ts
@@ -98,7 +98,7 @@ vi.mock('./sso/mspSsoResolution', () => ({
 vi.mock('@alga-psa/db/models/UserSession', () => ({
   UserSession: {
     create: vi.fn(async () => 'session-1'),
-    isRevoked: vi.fn(async () => false),
+    isRevokedOrIdentityMismatch: vi.fn(async () => false),
     updateLocation: vi.fn(),
   },
 }));

--- a/packages/auth/src/lib/nextAuthOptions.sessionExpiry.test.ts
+++ b/packages/auth/src/lib/nextAuthOptions.sessionExpiry.test.ts
@@ -1,7 +1,7 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 const extendExpiryMock = vi.fn(async () => undefined);
-const isRevokedMock = vi.fn(async () => false);
+const isRevokedOrIdentityMismatchMock = vi.fn(async () => false);
 const createMock = vi.fn(async () => 'sess-created');
 
 const tenantFirstMock = vi.fn();
@@ -98,7 +98,7 @@ vi.mock('./sso/mspSsoResolution', () => ({
 }));
 vi.mock('@alga-psa/db/models/UserSession', () => ({
   UserSession: {
-    isRevoked: (...args: unknown[]) => isRevokedMock(...(args as [])),
+    isRevokedOrIdentityMismatch: (...args: unknown[]) => isRevokedOrIdentityMismatchMock(...(args as [])),
     extendExpiry: (...args: unknown[]) => extendExpiryMock(...(args as [])),
     create: (...args: unknown[]) => createMock(...(args as [])),
     updateLocation: vi.fn(),
@@ -120,7 +120,7 @@ const { getAuthOptions, options } = await import('./nextAuthOptions');
 describe('nextAuth session expiry sliding', () => {
   beforeEach(() => {
     vi.clearAllMocks();
-    isRevokedMock.mockResolvedValue(false);
+    isRevokedOrIdentityMismatchMock.mockResolvedValue(false);
     createMock.mockResolvedValue('sess-created');
     extendExpiryMock.mockResolvedValue(undefined);
     // Keep plan refresh quiet/side-effect-free for these cases.
@@ -141,6 +141,7 @@ describe('nextAuth session expiry sliding', () => {
     await runJwt({
       id: 'u-1',
       tenant: 'tenant-1',
+      user_type: 'internal',
       session_id: 'sess-1',
       last_plan_check: before,
       // no last_session_extend -> treated as 0 -> stale -> should fire
@@ -159,6 +160,7 @@ describe('nextAuth session expiry sliding', () => {
     await runJwt({
       id: 'u-1',
       tenant: 'tenant-1',
+      user_type: 'internal',
       session_id: 'sess-1',
       last_plan_check: Date.now(),
       last_session_extend: Date.now(), // just extended -> inside throttle -> skip
@@ -171,24 +173,26 @@ describe('nextAuth session expiry sliding', () => {
     const token = {
       id: 'u-1',
       tenant: 'tenant-1',
+      user_type: 'internal',
       session_id: 'sess-1',
       last_plan_check: Date.now(),
       last_session_extend: Date.now(),
     };
 
     await runJwt(token);
-    isRevokedMock.mockResolvedValue(true);
+    isRevokedOrIdentityMismatchMock.mockResolvedValue(true);
 
     await expect(runJwt(token)).resolves.toBeNull();
-    expect(isRevokedMock).toHaveBeenCalledTimes(2);
+    expect(isRevokedOrIdentityMismatchMock).toHaveBeenCalledTimes(2);
   });
 
   it('fails closed when durable revocation state cannot be read', async () => {
-    isRevokedMock.mockRejectedValue(new Error('database unavailable'));
+    isRevokedOrIdentityMismatchMock.mockRejectedValue(new Error('database unavailable'));
 
     await expect(runJwt({
       id: 'u-1',
       tenant: 'tenant-1',
+      user_type: 'internal',
       session_id: 'sess-1',
       last_plan_check: Date.now(),
       last_session_extend: Date.now(),
@@ -198,12 +202,13 @@ describe('nextAuth session expiry sliding', () => {
   it('applies immediate fail-closed revocation checks in the synchronous auth config', async () => {
     const jwt = options.callbacks?.jwt;
     expect(jwt).toBeTypeOf('function');
-    isRevokedMock.mockResolvedValue(true);
+    isRevokedOrIdentityMismatchMock.mockResolvedValue(true);
 
     await expect(jwt!({
       token: {
         id: 'u-1',
         tenant: 'tenant-1',
+        user_type: 'internal',
         session_id: 'sess-1',
         last_plan_check: Date.now(),
         last_session_extend: Date.now(),
@@ -219,7 +224,7 @@ describe('nextAuth session expiry sliding', () => {
       last_plan_check: Date.now(),
     })).resolves.toBeNull();
 
-    expect(isRevokedMock).not.toHaveBeenCalled();
+    expect(isRevokedOrIdentityMismatchMock).not.toHaveBeenCalled();
     expect(extendExpiryMock).not.toHaveBeenCalled();
   });
 
@@ -251,7 +256,11 @@ describe('nextAuth session expiry sliding', () => {
       session_id: 'sess-created',
       login_method: 'azure-ad',
     });
-    expect(isRevokedMock).toHaveBeenCalledWith('tenant-1', 'sess-created');
+    expect(isRevokedOrIdentityMismatchMock).toHaveBeenCalledWith(
+      'tenant-1',
+      'sess-created',
+      { userId: 'u-1', userType: 'internal' }
+    );
   });
 
   it('creates a durable OAuth session in the synchronous auth config', async () => {

--- a/packages/auth/src/lib/nextAuthOptions.ts
+++ b/packages/auth/src/lib/nextAuthOptions.ts
@@ -129,19 +129,27 @@ const SESSION_COOKIE = getSessionCookieConfig();
 async function rejectRevokedOrUnverifiableSession(
     tenant: unknown,
     sessionId: unknown,
+    userId: unknown,
+    userType: unknown,
 ): Promise<boolean> {
     if (
         typeof tenant !== 'string'
         || tenant.length === 0
         || typeof sessionId !== 'string'
         || sessionId.length === 0
+        || typeof userId !== 'string'
+        || userId.length === 0
+        || (userType !== 'internal' && userType !== 'client')
     ) {
-        console.error('[auth] Tracked session is missing its tenant or session identifier.');
+        console.error('[auth] Tracked session is missing required identity claims.');
         return true;
     }
 
     try {
-        return await UserSession.isRevoked(tenant, sessionId);
+        return await UserSession.isRevokedOrIdentityMismatch(tenant, sessionId, {
+            userId,
+            userType,
+        });
     } catch (error) {
         console.error('[auth] Session revocation check failed closed:', error);
         return true;
@@ -2012,9 +2020,15 @@ export async function buildAuthOptions(context?: BuildAuthOptionsContext): Promi
                 }
             }
 
-            // Check durable revocation state on every authenticated request.
-            // Missing/untracked sessions fail closed so SCIM revocation is terminal.
-            if (await rejectRevokedOrUnverifiableSession(token.tenant, token.session_id)) {
+            // Check durable revocation and canonical identity state on every
+            // authenticated request. Missing, untracked, or mismatched sessions
+            // fail closed.
+            if (await rejectRevokedOrUnverifiableSession(
+                token.tenant,
+                token.session_id,
+                token.id || token.sub,
+                token.user_type,
+            )) {
                 return null;
             }
 
@@ -2832,9 +2846,15 @@ export const options: NextAuthConfig = {
                 }
             }
 
-            // Check durable revocation state on every authenticated request.
-            // Missing/untracked sessions fail closed so SCIM revocation is terminal.
-            if (await rejectRevokedOrUnverifiableSession(token.tenant, token.session_id)) {
+            // Check durable revocation and canonical identity state on every
+            // authenticated request. Missing, untracked, or mismatched sessions
+            // fail closed.
+            if (await rejectRevokedOrUnverifiableSession(
+                token.tenant,
+                token.session_id,
+                token.id || token.sub,
+                token.user_type,
+            )) {
                 return null;
             }
 

--- a/packages/auth/src/lib/withAuth.revocation.test.ts
+++ b/packages/auth/src/lib/withAuth.revocation.test.ts
@@ -5,7 +5,7 @@ const mocks = vi.hoisted(() => ({
   edgeAuth: vi.fn(),
   fullAuth: vi.fn(),
   getUserWithRoles: vi.fn(),
-  isRevoked: vi.fn(),
+  isRevokedOrIdentityMismatch: vi.fn(),
   runWithTenant: vi.fn(),
 }));
 
@@ -27,7 +27,7 @@ vi.mock('../nextauth/auth', () => ({
 
 vi.mock('@alga-psa/db/models/UserSession', () => ({
   UserSession: {
-    isRevoked: mocks.isRevoked,
+    isRevokedOrIdentityMismatch: mocks.isRevokedOrIdentityMismatch,
   },
 }));
 
@@ -45,6 +45,7 @@ const trackedSession = {
     id: 'user-1',
     tenant: 'tenant-1',
     email: 'user@example.test',
+    user_type: 'internal',
   },
   session_id: 'session-1',
 } as unknown as Session;
@@ -61,7 +62,7 @@ beforeEach(() => {
 describe('withAuth durable session enforcement', () => {
   it('rejects a revoked JWT before the wrapped action runs', async () => {
     mocks.fullAuth.mockResolvedValue(trackedSession);
-    mocks.isRevoked.mockResolvedValue(true);
+    mocks.isRevokedOrIdentityMismatch.mockResolvedValue(true);
     const action = vi.fn();
     const wrapped = withAuth(action);
 
@@ -69,7 +70,11 @@ describe('withAuth durable session enforcement', () => {
 
     expect(mocks.fullAuth).toHaveBeenCalledOnce();
     expect(mocks.edgeAuth).not.toHaveBeenCalled();
-    expect(mocks.isRevoked).toHaveBeenCalledWith('tenant-1', 'session-1');
+    expect(mocks.isRevokedOrIdentityMismatch).toHaveBeenCalledWith(
+      'tenant-1',
+      'session-1',
+      { userId: 'user-1', userType: 'internal' }
+    );
     expect(mocks.getUserWithRoles).not.toHaveBeenCalled();
     expect(action).not.toHaveBeenCalled();
   });
@@ -89,14 +94,14 @@ describe('withAuth durable session enforcement', () => {
 
     expect(mocks.fullAuth).toHaveBeenCalledOnce();
     expect(mocks.edgeAuth).not.toHaveBeenCalled();
-    expect(mocks.isRevoked).not.toHaveBeenCalled();
+    expect(mocks.isRevokedOrIdentityMismatch).not.toHaveBeenCalled();
     expect(mocks.getUserWithRoles).not.toHaveBeenCalled();
     expect(action).not.toHaveBeenCalled();
   });
 
   it('authorizes a live tracked session through the full-auth-first path', async () => {
     mocks.fullAuth.mockResolvedValue(trackedSession);
-    mocks.isRevoked.mockResolvedValue(false);
+    mocks.isRevokedOrIdentityMismatch.mockResolvedValue(false);
     mocks.getUserWithRoles.mockResolvedValue({
       user_id: 'user-1',
       tenant: 'tenant-1',
@@ -110,7 +115,11 @@ describe('withAuth durable session enforcement', () => {
 
     expect(mocks.fullAuth).toHaveBeenCalledOnce();
     expect(mocks.edgeAuth).not.toHaveBeenCalled();
-    expect(mocks.isRevoked).toHaveBeenCalledWith('tenant-1', 'session-1');
+    expect(mocks.isRevokedOrIdentityMismatch).toHaveBeenCalledWith(
+      'tenant-1',
+      'session-1',
+      { userId: 'user-1', userType: 'internal' }
+    );
     expect(mocks.runWithTenant).toHaveBeenCalledWith('tenant-1', expect.any(Function));
     expect(action).toHaveBeenCalledOnce();
   });

--- a/packages/db/src/models/UserSession.test.ts
+++ b/packages/db/src/models/UserSession.test.ts
@@ -6,6 +6,7 @@ const builder = {
   where: vi.fn(() => builder),
   whereNull: vi.fn(() => builder),
   select: vi.fn(() => builder),
+  leftJoin: vi.fn(() => builder),
   first: firstMock,
   update: updateMock,
 };
@@ -57,5 +58,25 @@ describe('UserSession.extendExpiry', () => {
     await expect(UserSession.isRevoked('tenant-1', 'scim-session-revoked')).resolves.toBe(true);
 
     expect(firstMock).toHaveBeenCalledTimes(2);
+  });
+
+  it('rejects a live session when its JWT user type does not match the database user', async () => {
+    firstMock.mockResolvedValue({
+      revoked_at: null,
+      session_user_id: 'client-user-1',
+      actual_user_type: 'client',
+    });
+
+    await expect(UserSession.isRevokedOrIdentityMismatch(
+      'tenant-1',
+      'client-session',
+      { userId: 'client-user-1', userType: 'internal' }
+    )).resolves.toBe(true);
+
+    await expect(UserSession.isRevokedOrIdentityMismatch(
+      'tenant-1',
+      'client-session',
+      { userId: 'client-user-1', userType: 'client' }
+    )).resolves.toBe(false);
   });
 });

--- a/packages/db/src/models/UserSession.ts
+++ b/packages/db/src/models/UserSession.ts
@@ -50,6 +50,11 @@ export interface CreateSessionParams {
   login_method: string;
 }
 
+export interface SessionIdentity {
+  userId: string;
+  userType: 'internal' | 'client';
+}
+
 export type RevocationReason =
   | 'user_logout'
   | 'user_logout_all'
@@ -207,6 +212,36 @@ export class UserSession {
     const session = await sessions(knex, tenant).where({ session_id: sessionId }).select('revoked_at').first();
 
     return session ? (session as any).revoked_at !== null : true;
+  }
+
+  /**
+   * Validates both durable session state and the identity claims carried by the
+   * JWT. A signed JWT is not sufficient authority when its user type disagrees
+   * with the user that owns the tracked session.
+   */
+  static async isRevokedOrIdentityMismatch(
+    tenant: string,
+    sessionId: string,
+    identity: SessionIdentity
+  ): Promise<boolean> {
+    const knex = await getConnection(tenant);
+    const db = tenantDb(knex, tenant);
+    const query = db.table<Record<string, any>>('sessions')
+      .where({ 'sessions.session_id': sessionId })
+      .select({
+        revoked_at: 'sessions.revoked_at',
+        session_user_id: 'sessions.user_id',
+        actual_user_type: 'users.user_type',
+      });
+
+    db.tenantJoin(query, 'users', 'sessions.user_id', 'users.user_id', { type: 'left' });
+
+    const session = await query.first();
+
+    return !session
+      || session.revoked_at !== null
+      || session.session_user_id !== identity.userId
+      || session.actual_user_type !== identity.userType;
   }
 
   static async enforceMaxSessions(tenant: string, userId: string, maxSessions: number): Promise<void> {

--- a/server/src/middleware.ts
+++ b/server/src/middleware.ts
@@ -155,6 +155,19 @@ export function shouldSkipApiKeyAuth(pathname: string): boolean {
       (pathname.endsWith('/document') || pathname.endsWith('/email-confirmation')));
 }
 
+export function hasContradictoryPortalIdentity(user: {
+  user_type?: unknown;
+  clientId?: unknown;
+  contactId?: unknown;
+} | null | undefined): boolean {
+  if (user?.user_type !== 'internal') {
+    return false;
+  }
+
+  return (typeof user.clientId === 'string' && user.clientId.length > 0)
+    || (typeof user.contactId === 'string' && user.contactId.length > 0);
+}
+
 export function getVanityClientPortalInternalRedirectTarget(args: {
   pathname: string;
   isAuthPage: boolean;
@@ -247,6 +260,45 @@ const _middleware = auth((request) => {
       headers: requestHeaders,
     },
   });
+
+  // Edge middleware cannot query the database, but client-scoped identifiers
+  // are incompatible with an internal user. Reject this contradictory token
+  // immediately; the Node session gate performs the definitive DB comparison.
+  if (
+    !pathname.startsWith('/api/auth/')
+    && hasContradictoryPortalIdentity(request.auth?.user)
+  ) {
+    console.warn('[middleware] rejecting contradictory internal/client session claims', {
+      tenant: request.auth?.user?.tenant,
+      userId: request.auth?.user?.id,
+    });
+
+    const invalidResponse = pathname.startsWith('/api/')
+      ? NextResponse.json({ error: 'Invalid session identity' }, { status: 401 })
+      : (() => {
+          const loginUrl = request.nextUrl.clone();
+          loginUrl.pathname = pathname.includes('/client-portal')
+            ? '/auth/client-portal/signin'
+            : '/auth/msp/signin';
+          loginUrl.search = '';
+          loginUrl.searchParams.set('error', 'SessionTypeMismatch');
+          return NextResponse.redirect(loginUrl);
+        })();
+
+    const sessionCookieName = getSessionCookieName();
+    const sessionCookies = request.cookies.getAll().filter(({ name }) =>
+      name === sessionCookieName || name.startsWith(`${sessionCookieName}.`)
+    );
+    if (sessionCookies.length === 0) {
+      invalidResponse.cookies.delete(sessionCookieName);
+    } else {
+      for (const { name } of sessionCookies) {
+        invalidResponse.cookies.delete(name);
+      }
+    }
+
+    return applyCorsHeaders(invalidResponse, origin);
+  }
 
   // Add pathname header for use in layouts (e.g., for branding injection)
   response.headers.set('x-pathname', pathname);

--- a/server/src/middleware/express/authMiddleware.ts
+++ b/server/src/middleware/express/authMiddleware.ts
@@ -3,6 +3,7 @@ import crypto from 'crypto';
 import { getToken, decode } from 'next-auth/jwt';
 import { ApiKeyServiceForApi } from '../../lib/services/apiKeyServiceForApi';
 import { getSecretProviderInstance } from '@alga-psa/core/secrets';
+import { UserSession } from '@alga-psa/db/models/UserSession';
 import { getSessionCookieName } from 'server/src/lib/auth/sessionCookies';
 import { resolveDeploymentCapabilities } from '../../lib/deployment/deploymentProfile';
 import { resolveRequestHost, resolveRequestProto } from '../../lib/deployment/requestHost';
@@ -431,7 +432,33 @@ export async function sessionAuthMiddleware(
 
     const userType = token.user_type as string;
     const tenant = token.tenant as string;
+    const userId = ((token as any).id || token.sub) as string | undefined;
+    const sessionId = token.session_id as string | undefined;
     const isClientPortal = req.path.includes('/client-portal');
+
+    if (
+      !tenant
+      || !userId
+      || !sessionId
+      || (userType !== 'internal' && userType !== 'client')
+      || await UserSession.isRevokedOrIdentityMismatch(tenant, sessionId, {
+        userId,
+        userType,
+      })
+    ) {
+      console.warn('[auth] Rejecting session whose claims do not match its database user', {
+        tenant,
+        userId,
+        sessionId,
+        claimedUserType: userType,
+      });
+      res.clearCookie(getSessionCookieName(), { path: '/' });
+      if (isClientPortal) {
+        return res.redirect(buildClientPortalSigninUrl(req, { error: 'SessionTypeMismatch' }));
+      }
+      const callbackUrl = encodeURIComponent(req.originalUrl);
+      return res.redirect(`/auth/msp/signin?error=SessionTypeMismatch&callbackUrl=${callbackUrl}`);
+    }
 
     // Enforce access rules based on user type
     if (isClientPortal && userType !== 'client') {
@@ -449,7 +476,7 @@ export async function sessionAuthMiddleware(
 
 	    // Store user info for downstream middleware
 	    req.user = {
-	      id: (token as any).id || token.sub || '',
+	      id: userId,
 	      tenant: tenant,
 	      userType: userType
 	    };

--- a/server/src/test/unit/middleware.vanityClientPortalRedirect.test.ts
+++ b/server/src/test/unit/middleware.vanityClientPortalRedirect.test.ts
@@ -1,6 +1,28 @@
 import { describe, expect, it } from 'vitest';
 
-import { getVanityClientPortalInternalRedirectTarget } from 'server/src/middleware';
+import {
+  getVanityClientPortalInternalRedirectTarget,
+  hasContradictoryPortalIdentity,
+} from 'server/src/middleware';
+
+describe('hasContradictoryPortalIdentity', () => {
+  it('rejects an internal-stamped identity carrying client scope', () => {
+    expect(hasContradictoryPortalIdentity({
+      user_type: 'internal',
+      clientId: 'client-1',
+      contactId: 'contact-1',
+    })).toBe(true);
+  });
+
+  it('accepts correctly stamped internal and client identities', () => {
+    expect(hasContradictoryPortalIdentity({ user_type: 'internal' })).toBe(false);
+    expect(hasContradictoryPortalIdentity({
+      user_type: 'client',
+      clientId: 'client-1',
+      contactId: 'contact-1',
+    })).toBe(false);
+  });
+});
 
 describe('getVanityClientPortalInternalRedirectTarget', () => {
   const canonicalUrlEnv = new URL('https://algapsa.com');


### PR DESCRIPTION
## Summary
- reject internal-stamped sessions that carry client-scoped identity claims in Edge middleware
- compare tracked session ownership and canonical database user type against JWT claims
- clear contradictory browser sessions and fail closed across shared and Express auth gates

## Why
An already-issued OAuth JWT could retain an internal user_type even when its tracked user is a client. This defense-in-depth check removes the existing token on the next request and prevents any signed but contradictory identity from being authorized.

## Validation
- 135 auth library tests passed
- focused session model and middleware tests passed
- server TypeScript typecheck passed
- ESLint completed with zero errors