### PR TITLE
Fix nightly test failures and billing test drift

### DIFF
--- a/packages/billing/src/lib/billing/compute/computeBucketCharges.ts
+++ b/packages/billing/src/lib/billing/compute/computeBucketCharges.ts
@@ -13,8 +13,9 @@ import type { ChargeComputeClient, ChargeComputeTaxPorts } from "./types";
  * usage buckets; for usage buckets these values are quantities, not minutes.
  */
 export interface BucketUsageComputeRow {
-  period_start?: ISO8601String | null;
-  period_end?: ISO8601String | null;
+  /** ISO string when simulated; the pg driver returns Date for persisted rows. */
+  period_start?: ISO8601String | Date | null;
+  period_end?: ISO8601String | Date | null;
   minutes_used?: number | string | null;
   hours_used?: number | string | null;
   overage_minutes?: number | string | null;
@@ -127,6 +128,13 @@ function formatQuantity(quantity: number): string {
   return Number.isInteger(quantity) ? String(quantity) : quantity.toFixed(2);
 }
 
+function toDateOnly(value: ISO8601String | Date | null | undefined): string | null {
+  if (value == null) {
+    return null;
+  }
+  return (value instanceof Date ? value.toISOString() : value).slice(0, 10);
+}
+
 function aggregateUsagePeriods(
   usageRecords: BucketUsageComputeRow[],
   billingPeriod: IBillingPeriod,
@@ -138,8 +146,8 @@ function aggregateUsagePeriods(
   const fallbackEnd = fallbackEndDate.toISOString().slice(0, 10);
 
   for (const record of usageRecords) {
-    const periodStart = (record.period_start ?? fallbackStart).slice(0, 10);
-    const periodEnd = (record.period_end ?? fallbackEnd).slice(0, 10);
+    const periodStart = toDateOnly(record.period_start) ?? fallbackStart;
+    const periodEnd = toDateOnly(record.period_end) ?? fallbackEnd;
     const key = `${periodStart}:${periodEnd}`;
     const existing = byPeriod.get(key) ?? {
       periodStart,

--- a/server/src/test/infrastructure/billing/invoices/billingInvoiceGeneration_tax.test.ts
+++ b/server/src/test/infrastructure/billing/invoices/billingInvoiceGeneration_tax.test.ts
@@ -204,7 +204,6 @@ describe('Billing Invoice Tax Calculations', () => {
         is_tax_exempt: false,
         created_at: Temporal.Now.plainDateISO().toString(),
         updated_at: Temporal.Now.plainDateISO().toString(),
-        credit_balance: 0,
         url: '',
         is_inactive: false
       }, 'client_id');
@@ -310,7 +309,6 @@ describe('Billing Invoice Tax Calculations', () => {
         client_id: uuidv4(),
         region_code: 'US-NY',
         is_tax_exempt: false,
-        credit_balance: 0,
         url: '',
         is_inactive: false,
         created_at: Temporal.Now.plainDateISO().toString(),
@@ -497,7 +495,6 @@ describe('Billing Invoice Tax Calculations', () => {
         is_tax_exempt: false,
         created_at: Temporal.Now.plainDateISO().toString(),
         updated_at: Temporal.Now.plainDateISO().toString(),
-        credit_balance: 0,
         url: '',
         is_inactive: false
       }, 'client_id');
@@ -632,7 +629,6 @@ describe('Billing Invoice Tax Calculations', () => {
         is_tax_exempt: false,
         created_at: Temporal.Now.plainDateISO().toString(),
         updated_at: Temporal.Now.plainDateISO().toString(),
-        credit_balance: 0,
         url: '',
         is_inactive: false
       }, 'client_id');
@@ -751,7 +747,6 @@ describe('Billing Invoice Tax Calculations', () => {
       is_tax_exempt: true, // Set client as tax exempt
       created_at: Temporal.Now.plainDateISO().toString(),
       updated_at: Temporal.Now.plainDateISO().toString(),
-      credit_balance: 0,
       url: '',
       is_inactive: false
     }, 'client_id');
@@ -881,7 +876,6 @@ describe('Billing Invoice Tax Calculations', () => {
       is_tax_exempt: false,
       created_at: Temporal.Now.plainDateISO().toString(),
       updated_at: Temporal.Now.plainDateISO().toString(),
-      credit_balance: 0,
       url: '',
       is_inactive: false
     }, 'client_id');
@@ -965,7 +959,6 @@ describe('Billing Invoice Tax Calculations', () => {
       client_id: uuidv4(),
       region_code: 'US-NY', // Default tax region
       is_tax_exempt: false,
-      credit_balance: 0,
       url: '',
       is_inactive: false,
       created_at: Temporal.Now.plainDateISO().toString(),
@@ -1285,7 +1278,6 @@ describe('Billing Invoice Tax Calculations', () => {
       client_id: uuidv4(),
       region_code: 'US-NY', // Client has a tax region
       is_tax_exempt: false, // NOT tax exempt - reverse charge is different
-      credit_balance: 0,
       url: '',
       is_inactive: false,
       created_at: Temporal.Now.plainDateISO().toString(),

--- a/server/src/test/infrastructure/billing/invoices/usageBucketAndFinalization.test.ts
+++ b/server/src/test/infrastructure/billing/invoices/usageBucketAndFinalization.test.ts
@@ -231,13 +231,15 @@ describe('Billing Invoice Generation – Usage, Bucket Contract Lines, and Final
         tenant: context.tenantId
       });
 
-      // Create billing cycle and assign contract line
+      // Create billing cycle and assign contract line. Usage lines default to
+      // arrears timing, so January's service period is invoiced in the
+      // February window (invoice_window = service period shifted one cycle).
       const billingCycleId = await context.createEntity('client_billing_cycles', {
         client_id: context.clientId,
         billing_cycle: 'monthly',
-        effective_date: createTestDateISO({ year: 2023, month: 1, day: 1 }),
-        period_start_date: createTestDateISO({ year: 2023, month: 1, day: 1 }),
-        period_end_date: createTestDateISO({ year: 2023, month: 1, day: 31 })
+        effective_date: createTestDateISO({ year: 2023, month: 2, day: 1 }),
+        period_start_date: createTestDateISO({ year: 2023, month: 2, day: 1 }),
+        period_end_date: createTestDateISO({ year: 2023, month: 3, day: 1 })
       }, 'billing_cycle_id');
 
       await assignContractLineToClient(context, contractLineId, {
@@ -322,7 +324,9 @@ describe('Billing Invoice Generation – Usage, Bucket Contract Lines, and Final
         detailBaseRateCents: 0,
         billingFrequency: 'monthly',
         startDate: createTestDateISO({ year: 2023, month: 1, day: 1 }),
-        billingTiming: 'advance'
+        billingTiming: 'advance',
+        ensureBillingEmail: true,
+        materializeServicePeriods: true
       });
 
       await createBucketOverlayForPlan(context, contractLineId, {
@@ -339,7 +343,7 @@ describe('Billing Invoice Generation – Usage, Bucket Contract Lines, and Final
         billing_cycle: 'monthly',
         effective_date: createTestDateISO({ year: 2023, month: 1, day: 1 }),
         period_start_date: createTestDateISO({ year: 2023, month: 1, day: 1 }),
-        period_end_date: createTestDateISO({ year: 2023, month: 1, day: 31 })
+        period_end_date: createTestDateISO({ year: 2023, month: 2, day: 1 })
       }, 'billing_cycle_id');
 
       // Record bucket usage for the period (45 hours consumed, 5 hours overage)
@@ -403,7 +407,9 @@ describe('Billing Invoice Generation – Usage, Bucket Contract Lines, and Final
         detailBaseRateCents: 20000,
         quantity: 1,
         startDate: createTestDateISO({ year: 2023, month: 1, day: 1 }),
-        billingTiming: 'advance'
+        billingTiming: 'advance',
+        ensureBillingEmail: true,
+        materializeServicePeriods: true
       });
 
       // Create billing cycle
@@ -412,7 +418,7 @@ describe('Billing Invoice Generation – Usage, Bucket Contract Lines, and Final
         billing_cycle: 'monthly',
         effective_date: createTestDateISO({ year: 2023, month: 1, day: 1 }),
         period_start_date: createTestDateISO({ year: 2023, month: 1, day: 1 }),
-        period_end_date: createTestDateISO({ year: 2023, month: 1, day: 31 })
+        period_end_date: createTestDateISO({ year: 2023, month: 2, day: 1 })
       }, 'billing_cycle_id');
 
       await assignContractLineToClient(context, contractLineId, {

--- a/server/src/test/infrastructure/billing/tax/taxExemptionHandling.test.ts
+++ b/server/src/test/infrastructure/billing/tax/taxExemptionHandling.test.ts
@@ -79,7 +79,6 @@ describe('Tax Exemption Handling', () => {
       client_name: overrides.client_name ?? 'Test Client',
       is_tax_exempt: overrides.is_tax_exempt ?? false,
       region_code: overrides.region_code ?? 'US-NY',
-      credit_balance: overrides.credit_balance ?? 0,
       billing_cycle: overrides.billing_cycle ?? 'monthly',
       is_inactive: overrides.is_inactive ?? false,
       created_at: overrides.created_at ?? now,

--- a/server/src/test/infrastructure/clients/clientPulse.test.ts
+++ b/server/src/test/infrastructure/clients/clientPulse.test.ts
@@ -995,7 +995,6 @@ describe('client pulse infrastructure', () => {
       created_at: NOW.toISOString(),
       updated_at: NOW.toISOString(),
       is_inactive: false,
-      credit_balance: 0,
       properties: {},
     });
 

--- a/server/src/test/integration/apiRateLimit.dbOverride.test.ts
+++ b/server/src/test/integration/apiRateLimit.dbOverride.test.ts
@@ -35,6 +35,8 @@ vi.mock('@alga-psa/auth', () => ({
   ApiKeyService: {
     validateApiKey: (...args: unknown[]) => testState.validateApiKeyMock(...args),
   },
+  runWithApiKeyUser: (_user: unknown, fn: () => Promise<unknown>) => fn(),
+  getApiKeyUserOverride: () => undefined,
 }));
 
 vi.mock('@alga-psa/user-composition/actions', () => ({

--- a/server/src/test/integration/apiRateLimit.headers.test.ts
+++ b/server/src/test/integration/apiRateLimit.headers.test.ts
@@ -37,6 +37,8 @@ vi.mock('@alga-psa/auth', () => ({
   ApiKeyService: {
     validateApiKey: (...args: unknown[]) => testState.validateApiKeyMock(...args),
   },
+  runWithApiKeyUser: (_user: unknown, fn: () => Promise<unknown>) => fn(),
+  getApiKeyUserOverride: () => undefined,
 }));
 
 vi.mock('@alga-psa/user-composition/actions', () => ({

--- a/server/src/test/integration/surveyEmailTemplates.integration.test.ts
+++ b/server/src/test/integration/surveyEmailTemplates.integration.test.ts
@@ -8,7 +8,7 @@ const TEMPLATE_NAME = 'SURVEY_TICKET_CLOSED';
 const SUPPORTED_LOCALES = [
   { code: 'en', subject: "We'd love your feedback on ticket {{ticket_number}}" },
   { code: 'fr', subject: 'Votre avis sur le ticket {{ticket_number}} nous intéresse' },
-  { code: 'es', subject: 'Queremos conocer tu opinión sobre el ticket {{ticket_number}}' },
+  { code: 'es', subject: 'Queremos conocer su opinión sobre el ticket {{ticket_number}}' },
   { code: 'de', subject: 'Wir freuen uns über Ihr Feedback zu Ticket {{ticket_number}}' },
   { code: 'nl', subject: 'We horen graag uw feedback over ticket {{ticket_number}}' },
   { code: 'it', subject: 'Ci farebbe piacere il tuo feedback sul ticket {{ticket_number}}' },

--- a/server/src/test/setup.ts
+++ b/server/src/test/setup.ts
@@ -394,8 +394,13 @@ vi.mock('@alga-psa/auth', async () => {
     };
   };
 
+  // Every name that production code value-imports from '@alga-psa/auth' must
+  // exist here — a missing one makes vitest throw at the import binding and
+  // every API test 500s (see the runWithApiKeyUser nightly break). The
+  // authGlobalMock contract test enumerates prod imports and enforces this.
   return {
     getSession: vi.fn().mockResolvedValue(null),
+    getSessionWithRevocationCheck: vi.fn().mockResolvedValue(null),
     getCurrentUser,
     hasPermission,
     withAuth,
@@ -403,5 +408,36 @@ vi.mock('@alga-psa/auth', async () => {
     withOptionalAuth,
     runWithApiKeyUser,
     getApiKeyUserOverride,
+    getSessionCookieName: vi.fn(() => 'authjs.session-token'),
+    getNextAuthSecret: vi.fn(async () => 'test-nextauth-secret'),
+    formatRateLimitError: vi.fn(async () => 'Too many attempts. Please try again later.'),
+    checkPortalInvitationLimit: vi.fn(async () => undefined),
+    verifyAuthenticator: vi.fn(async () => false),
+    registerAuthEmailProvider: vi.fn(),
+    preCheckDeletion: vi.fn(async () => ({ canDelete: true })),
+    buildSessionCookie: vi.fn(() => ({ name: 'authjs.session-token', value: 'test-session', options: {} })),
+    consumePortalDomainOtt: vi.fn(async () => null),
+    encodePortalSessionToken: vi.fn(async () => 'test-portal-session-token'),
+    generateDeviceFingerprint: vi.fn(() => 'test-device-fingerprint'),
+    getClientIp: vi.fn(() => '127.0.0.1'),
+    getDeviceInfo: vi.fn(() => ({})),
+    getLocationFromIp: vi.fn(async () => null),
+    getSessionMaxAge: vi.fn(() => 60 * 60 * 24),
+    ApiKeyService: {
+      generateApiKey: vi.fn(() => 'test-api-key'),
+      createApiKey: vi.fn(),
+      validateApiKey: vi.fn(async () => null),
+      deactivateApiKey: vi.fn(),
+      listUserApiKeys: vi.fn(async () => []),
+      listAllApiKeys: vi.fn(async () => []),
+    },
+    PasswordResetService: {
+      generateSecureToken: vi.fn(() => 'test-reset-token'),
+      hashToken: vi.fn((token: string) => `hashed:${token}`),
+      createResetToken: vi.fn(),
+      createResetTokenWithTransaction: vi.fn(),
+      verifyToken: vi.fn(async () => ({ valid: false })),
+      markTokenAsUsed: vi.fn(async () => false),
+    },
   };
 });

--- a/server/src/test/setup.ts
+++ b/server/src/test/setup.ts
@@ -328,14 +328,23 @@ vi.mock('server/src/app/api/auth/[...nextauth]/edge-auth', () => ({
   auth: vi.fn().mockResolvedValue(null),
 }));
 
-vi.mock('@alga-psa/auth', () => {
+vi.mock('@alga-psa/auth', async () => {
+  const { AsyncLocalStorage } = await import('node:async_hooks');
+
   const defaultUser = {
     user_id: '00000000-0000-0000-0000-000000000001',
     tenant: '00000000-0000-0000-0000-000000000001',
     roles: [],
   };
 
-  const getCurrentUser = vi.fn().mockResolvedValue(defaultUser);
+  // Mirrors packages/auth apiKeyUserContext: API routes wrap handlers in
+  // runWithApiKeyUser and getCurrentUser() prefers the override.
+  const apiKeyUserStorage = new AsyncLocalStorage<any>();
+  const runWithApiKeyUser = (user: any, fn: () => Promise<any>) =>
+    apiKeyUserStorage.run(user, fn);
+  const getApiKeyUserOverride = () => apiKeyUserStorage.getStore();
+
+  const getCurrentUser = vi.fn(async () => getApiKeyUserOverride() ?? defaultUser);
   const hasPermission = vi.fn().mockResolvedValue(true);
 
   const resolveTenant = async (user: any): Promise<string> => {
@@ -392,5 +401,7 @@ vi.mock('@alga-psa/auth', () => {
     withAuth,
     withAuthCheck,
     withOptionalAuth,
+    runWithApiKeyUser,
+    getApiKeyUserOverride,
   };
 });

--- a/server/src/test/unit/authGlobalMock.contract.test.ts
+++ b/server/src/test/unit/authGlobalMock.contract.test.ts
@@ -1,0 +1,147 @@
+import { describe, expect, it } from 'vitest';
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+/**
+ * The global '@alga-psa/auth' mock in src/test/setup.ts is a full factory:
+ * any name production code value-imports but the factory omits makes vitest
+ * throw at the import binding, which surfaces as opaque 500s in every API
+ * test (the runWithApiKeyUser nightly break, PR #3120). This contract
+ * enumerates every prod value-import of the package and requires the mock to
+ * export it, so adding an export to '@alga-psa/auth' fails here — loudly and
+ * with the name — instead of in the next nightly.
+ */
+
+const REPO_ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '../../../..');
+
+const SKIP_DIR_NAMES = new Set([
+  'node_modules',
+  'dist',
+  '.next',
+  'test',
+  'tests',
+  '__tests__',
+  'test-utils',
+  'e2e',
+]);
+
+function collectSourceFiles(dir: string, files: string[] = []): string[] {
+  for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
+    if (entry.isDirectory()) {
+      if (SKIP_DIR_NAMES.has(entry.name)) {
+        continue;
+      }
+      collectSourceFiles(path.join(dir, entry.name), files);
+    } else if (/\.tsx?$/.test(entry.name) && !/\.(test|spec)\.tsx?$/.test(entry.name)) {
+      files.push(path.join(dir, entry.name));
+    }
+  }
+  return files;
+}
+
+function scanRoots(): string[] {
+  const roots = [path.join(REPO_ROOT, 'server/src')];
+  const packagesDir = path.join(REPO_ROOT, 'packages');
+  for (const entry of fs.readdirSync(packagesDir, { withFileTypes: true })) {
+    // packages/auth importing itself is not a mock consumer.
+    if (!entry.isDirectory() || entry.name === 'auth') {
+      continue;
+    }
+    const src = path.join(packagesDir, entry.name, 'src');
+    if (fs.existsSync(src)) {
+      roots.push(src);
+    }
+  }
+  return roots;
+}
+
+interface ScanResult {
+  namedImports: Map<string, string[]>;
+  namespaceImportFiles: string[];
+}
+
+const NAMED_IMPORT_RE = /import\s+(type\s+)?\{([^}]+)\}\s+from\s+['"]@alga-psa\/auth['"]/g;
+const NAMESPACE_IMPORT_RE = /import\s+\*\s+as\s+\w+\s+from\s+['"]@alga-psa\/auth['"]/;
+
+function scanProdImports(): ScanResult {
+  const namedImports = new Map<string, string[]>();
+  const namespaceImportFiles: string[] = [];
+
+  for (const root of scanRoots()) {
+    for (const file of collectSourceFiles(root)) {
+      const content = fs.readFileSync(file, 'utf8');
+      if (!content.includes('@alga-psa/auth')) {
+        continue;
+      }
+      const rel = path.relative(REPO_ROOT, file);
+
+      if (NAMESPACE_IMPORT_RE.test(content)) {
+        namespaceImportFiles.push(rel);
+      }
+
+      for (const match of content.matchAll(NAMED_IMPORT_RE)) {
+        if (match[1]) {
+          continue; // import type { ... } — no runtime binding
+        }
+        for (const rawSpecifier of match[2].split(',')) {
+          const specifier = rawSpecifier.trim();
+          if (!specifier || specifier.startsWith('type ')) {
+            continue;
+          }
+          const name = specifier.split(/\s+as\s+/)[0].trim();
+          const usages = namedImports.get(name) ?? [];
+          usages.push(rel);
+          namedImports.set(name, usages);
+        }
+      }
+    }
+  }
+
+  return { namedImports, namespaceImportFiles };
+}
+
+describe('global @alga-psa/auth mock contract', () => {
+  const scan = scanProdImports();
+
+  it('finds the known baseline imports (scanner sanity check)', () => {
+    for (const name of ['withAuth', 'hasPermission', 'getCurrentUser', 'runWithApiKeyUser']) {
+      expect(scan.namedImports.has(name), `scanner should find prod imports of ${name}`).toBe(true);
+    }
+  });
+
+  it('exports every name production code value-imports', async () => {
+    const mocked = await import('@alga-psa/auth');
+    const missing = [...scan.namedImports.entries()]
+      .filter(([name]) => !(name in mocked))
+      .map(([name, files]) => `${name} (e.g. ${files[0]})`);
+
+    expect(
+      missing,
+      'Add these exports to the @alga-psa/auth factory in src/test/setup.ts — a missing one 500s every API test',
+    ).toEqual([]);
+  });
+
+  it('has no namespace imports in production code (they defeat this contract)', () => {
+    expect(scan.namespaceImportFiles).toEqual([]);
+  });
+
+  it('getCurrentUser honors the runWithApiKeyUser override, like production', async () => {
+    const { getCurrentUser, runWithApiKeyUser, getApiKeyUserOverride } = await import('@alga-psa/auth');
+    const apiKeyUser = { user_id: 'api-key-user', tenant: 'api-key-tenant', roles: [] };
+
+    expect(getApiKeyUserOverride()).toBeUndefined();
+
+    const seen = await runWithApiKeyUser(apiKeyUser as never, async () => ({
+      current: await getCurrentUser(),
+      override: getApiKeyUserOverride(),
+    }));
+    expect(seen.current).toMatchObject({ user_id: 'api-key-user' });
+    expect(seen.override).toMatchObject({ user_id: 'api-key-user' });
+
+    expect(getApiKeyUserOverride()).toBeUndefined();
+    await expect(getCurrentUser()).resolves.toMatchObject({
+      user_id: '00000000-0000-0000-0000-000000000001',
+    });
+  });
+});

--- a/server/test-utils/billingTestHelpers.ts
+++ b/server/test-utils/billingTestHelpers.ts
@@ -277,6 +277,8 @@ interface CreateServiceOptions {
   custom_service_type_id?: string;
   tax_region?: string;
   tax_rate_id?: string | null;
+  currency_code?: string;
+  seedServicePrice?: boolean;
 }
 
 interface CreateFixedPlanOptions {
@@ -555,6 +557,20 @@ export async function createTestService(
   }
 
   await tenantTable(context, 'service_catalog').insert(serviceData);
+
+  // Rate resolution reads currency-tagged service_prices, never the legacy
+  // currency-untagged service_catalog.default_rate.
+  if ((overrides.seedServicePrice ?? true) && await context.db.schema.hasTable('service_prices')) {
+    await tenantTable(context, 'service_prices')
+      .insert({
+        tenant: context.tenantId,
+        service_id: serviceId,
+        currency_code: overrides.currency_code ?? 'USD',
+        rate: overrides.default_rate ?? 1000
+      })
+      .onConflict(['tenant', 'service_id', 'currency_code'])
+      .merge({ rate: overrides.default_rate ?? 1000 });
+  }
 
   if (overrides.tax_region) {
     await assignServiceTaxRate(context, serviceId, overrides.tax_region);
@@ -1779,6 +1795,13 @@ export async function createBucketOverlayForPlan(
         }
       }
     }
+  }
+
+  // The legacy client_contract_services* chain was dropped from the live
+  // schema; only mirror the overlay into it on schema iterations that still
+  // carry those tables.
+  if (!(await context.db.schema.hasTable('client_contract_services'))) {
+    return { configId, serviceId };
   }
 
   const legacyClientContractServicesForOverlay = () => dynamicTenantTable(


### PR DESCRIPTION
The nightly integration step broke when PR #3120 taught the API middleware to wrap handlers in runWithApiKeyUser: the @alga-psa/auth test mocks (global setup.ts and the apiRateLimit locals) never exported it, so twelve tests 500'd. The setup.ts mock now mirrors production with an AsyncLocalStorage-backed override that getCurrentUser honors. The survey template test also learns formal Spanish, matching the deliberate usted migration.

On the infra suite: usageBucketAndFinalization catches up with four layers of engine drift â exclusive-end cycle windows, arrears billing shifting January's usage into February's cycle, currency-tagged service_prices (now auto-seeded by createTestService), and a guard around the dropped client_contract_services tables. One real engine bug fixed along the way: computeBucketCharges called .slice() on period_start, which the pg driver returns as a Date.

"Curiouser and curiouser!" cried Alice, as the White Rabbit invoiced her January tea party in February. "First you tell me a Date is not a string, then you demand su opiniÃ³n instead of tu, and now every request must run with an API key user or turn into a 500!" The Rabbit merely stamped her service_prices in USD and hopped down the AsyncLocalStorage. ðð«â°