### PR TITLE
Automatically replenish recurring service periods as billing cycles advance

### DIFF
--- a/docs/plans/2026-08-07-recurring-service-period-replenishment-plan.md
+++ b/docs/plans/2026-08-07-recurring-service-period-replenishment-plan.md
@@ -1,0 +1,153 @@
+# Recurring Service-Period Replenishment Plan
+
+## Status
+
+Approved under the card's `conn` delegation for Draft Implementation.
+
+## Problem
+
+The nightly `createClientContractLineCycles` job advances
+`client_billing_cycles`, but it does not replenish the canonical
+`recurring_service_periods` ledger. A client can therefore have a valid new
+invoice window while an arrears or advance obligation has no row for the
+service period due in that window. Automatic invoice generation then reports a
+materialization gap and requires the operator to run **Fix all**.
+
+The production example is an arrears schedule where the 2026-08-01 to
+2026-09-01 billing cycle existed, but the 2026-07-01 to 2026-08-01 service
+period that should invoice in that window did not.
+
+## Existing architecture
+
+- `packages/billing/src/lib/billing/createBillingCycles.ts` is the shared
+  boundary used by both the nightly scheduler and the manual next-cycle action.
+- `server/src/lib/initializeApp.ts` already runs that boundary once per active
+  client every 24 hours.
+- `shared/billingClients/clientCadenceScheduleRegeneration.ts` already loads
+  active client-cadence lines, derives advance versus arrears windows, clips
+  candidates to assignment dates, preserves billed history, supersedes only
+  mutable drift, and inserts missing rows idempotently.
+- `shared/billingClients/materializeClientCadenceServicePeriods.ts` uses the
+  common 180-day generation horizon and 45-day replenishment threshold.
+
+## Decision
+
+Replenish the affected client's client-cadence service periods immediately
+after successful billing-cycle advancement, in the same per-client
+transaction. Also replenish on a successful no-op nightly pass so the moving
+180-day horizon stays full even when no new cycle row is needed that day.
+
+Do not add another recurring job and do not call the tenant-wide repair action
+from the nightly client loop. A targeted hook is cheaper, covers manual and
+automatic creation, and makes the invariant true at the mutation boundary.
+
+## Detailed design
+
+### 1. Expose a targeted replenishment operation
+
+In `shared/billingClients/clientCadenceScheduleRegeneration.ts`:
+
+- Extract the compute-and-persist body of
+  `regenerateClientCadenceServicePeriodsForScheduleChange` into an exported
+  `replenishClientCadenceServicePeriods` operation.
+- Accept the existing transaction plus tenant, client id, billing cycle, and
+  normalized anchor settings. Reuse `computeClientCadenceRegeneration` and
+  `persistRecurringServicePeriodRegeneration`; do not create a second
+  materialization algorithm.
+- Keep the existing schedule-change export as a compatibility wrapper around
+  the new operation.
+- Return a small summary only if useful for logging. Database state remains the
+  authoritative result.
+
+The canonical flow remains:
+
+1. Load all active, non-system-managed client contracts and client-cadence
+   recurring lines for the client.
+2. Start regeneration at the later of assignment start and billed-history end.
+3. Materialize through the shared horizon for the line's advance or arrears
+   due position.
+4. Clip candidates to assignment end.
+5. Use `backfillRecurringServicePeriods` to preserve billed/overridden rows,
+   supersede mutable drift, and insert missing records.
+6. Persist only the delta; a matching ledger writes nothing.
+
+Contract-cadence lines stay out of scope because client billing-cycle
+advancement does not define their anniversary schedule.
+
+### 2. Make cycle advancement and replenishment one transaction
+
+In `packages/billing/src/lib/billing/createBillingCycles.ts`:
+
+- Wrap one invocation of `createClientContractLineCycles` in
+  `withTransaction`.
+- Move cycle lookup/insertion into the transaction and pass that transaction to
+  `createBillingCycle`.
+- Centralize successful exits so every successful path calls the targeted
+  replenishment operation with the already loaded cycle and anchor settings:
+  initial automatic creation and catch-up, existing-cycle catch-up, manual
+  next-cycle creation, and automatic no-op when coverage is current.
+- Preserve existing duplicate and invalid-date results. Do not replenish after
+  a failed cycle result.
+- Let replenishment errors reject the transaction. The existing per-client
+  scheduler boundary logs the failure and retries on the next run.
+- Keep current unique and overlap checks as the concurrency guard.
+
+No scheduler change is needed: `initializeApp.ts` and
+`createNextBillingCycle` already use this function.
+
+### 3. Keep operational recovery and logging focused
+
+- Log errors at the existing per-client scheduler boundary.
+- If replenishment returns a summary, log only when rows changed.
+- Keep **Fix all** as recovery for historical drift; normally advancing
+  schedules should no longer need it.
+
+## Behavioral test plan
+
+Add a database-backed integration suite beside
+`server/src/test/infrastructure/billing/invoices/clientBillingCycle.test.ts`,
+for example `clientBillingCycleRecurringServicePeriods.test.ts`. Reuse
+`TestContext`, freeze time, and query real cycle and service-period rows.
+Do not add source-string wiring tests.
+
+1. **Arrears advancement:** advancing to the 2026-08-01 to 2026-09-01 client
+   cycle creates the missing 2026-07-01 to 2026-08-01 service period with that
+   new cycle as its invoice window.
+2. **Advance advancement:** the service period due at the newly opened window
+   is materialized with the correct advance mapping.
+3. **Idempotent repeated nightly runs:** a second automatic run at the same
+   frozen time adds no cycles, rows, revisions, or superseded records.
+4. **Multiple active lines:** one advancement replenishes every active
+   client-cadence line without cross-obligation collisions.
+5. **Billed-history preservation:** a seeded billed row keeps its identity,
+   revision, dates, lifecycle state, and invoice linkage while future gaps are
+   filled.
+6. **Assignment boundaries and horizon:** no row precedes assignment start or
+   extends past assignment end, and future coverage follows the shared horizon
+   rather than stopping at one billing window.
+
+Run the focused integration suite, existing client-cycle tests, existing
+recurring-service-period regeneration/domain tests, and billing/shared
+typechecks.
+
+## Alternatives rejected
+
+- **Tenant-wide repair after each tenant loop:** rescans every client, misses
+  the manual boundary, and leaves cycle and ledger updates as separate
+  outcomes.
+- **A second recurring replenishment job:** introduces lag, ordering races, and
+  duplicate retry/observability machinery.
+- **Lazy repair during invoice generation:** is too late; the Generate screen
+  and preflight logic must observe a complete canonical ledger.
+
+## Risks and mitigations
+
+- **Import layering:** verify the Nx dependency graph and typecheck; the billing
+  package already imports the shared billing-client layer elsewhere.
+- **Transaction duration:** keep work targeted to the current client's active
+  lines and persist only deltas.
+- **Race behavior:** preserve existing unique/overlap checks and duplicate
+  results.
+- **Historical rows:** never update billed rows in place; all changes flow
+  through the canonical regeneration plan.
+

--- a/packages/billing/src/lib/billing/createBillingCycles.ts
+++ b/packages/billing/src/lib/billing/createBillingCycles.ts
@@ -1,8 +1,9 @@
-import { Knex } from 'knex';
-import { tenantDb } from '@alga-psa/db';
+import type { Knex } from 'knex';
+import { tenantDb, withTransaction } from '@alga-psa/db';
 import { Temporal } from '@js-temporal/polyfill';
 import type { IClientContractLineCycle, IClient, ISO8601String, BillingCycleType } from '@alga-psa/types';
 import { parseISO } from 'date-fns';
+import { replenishClientCadenceServicePeriods } from '@alga-psa/shared/billingClients/clientCadenceScheduleRegeneration';
 import {
   ensureUtcMidnightIsoDate,
   getAnchorDefaultsForCycle,
@@ -30,6 +31,13 @@ export type BillingCycleCreationResult = {
   message?: string;
   suggestedDate?: ISO8601String;
 };
+
+class BillingCycleCreationAbort extends Error {
+  constructor(readonly result: BillingCycleCreationResult) {
+    super(result.message);
+    this.name = 'BillingCycleCreationAbort';
+  }
+}
 
 function getNextCycleDate(
   currentDate: ISO8601String,
@@ -149,12 +157,12 @@ async function createBillingCycle(
       // Handle race condition - another cycle was created between our check and insert
       const nextDate = new Date(cycle.effective_date);
       nextDate.setDate(nextDate.getDate() + 1);
-      return {
+      throw new BillingCycleCreationAbort({
         success: false,
         error: 'duplicate',
         message: 'A billing period for this date already exists. Please select a different date.',
         suggestedDate: nextDate.toISOString().split('T')[0] + 'T00:00:00Z'
-      };
+      });
     }
     console.error(`Error creating billing cycle:`, error);
     throw error;
@@ -194,53 +202,114 @@ export async function createClientContractLineCycles(
     };
   }
 
-  const anchorSettings = await loadClientAnchorSettings(knex, client, billingCycle);
-  const db = tenantDb(knex, tenant);
+  return withTransaction<BillingCycleCreationResult>(knex, async (trx) => {
+    const anchorSettings = await loadClientAnchorSettings(trx, client, billingCycle);
+    const db = tenantDb(trx, tenant);
 
-  const lastCycle = await db.table('client_billing_cycles')
-    .where({
-      client_id: client.client_id,
-      tenant,
-      is_active: true
-    })
-    .orderBy('period_start_date', 'desc')
-    .first()
-    .select('period_start_date', 'period_end_date') as IClientContractLineCycle | undefined;
+    const finishSuccessfulPass = async (): Promise<BillingCycleCreationResult> => {
+      await replenishClientCadenceServicePeriods(trx, {
+        tenant,
+        clientId: client.client_id,
+        billingCycle,
+        anchor: anchorSettings
+      });
+      return { success: true };
+    };
 
-  const referenceDate = options.effectiveDate ? ensureUtcMidnightIsoDate(options.effectiveDate) : now;
+    const lastCycle = await db.table('client_billing_cycles')
+      .where({
+        client_id: client.client_id,
+        tenant,
+        is_active: true
+      })
+      .orderBy('period_start_date', 'desc')
+      .first()
+      .select('period_start_date', 'period_end_date') as IClientContractLineCycle | undefined;
 
-  if (!lastCycle) {
-    const initial = getStartOfCurrentCycle(referenceDate, billingCycle, anchorSettings);
-    const initialResult = await createBillingCycle(knex, {
-      client_id: client.client_id,
-      billing_cycle: billingCycle,
-      effective_date: initial.effectiveDate,
-      period_start_date: initial.periodStart,
-      period_end_date: initial.periodEnd,
-      tenant: client.tenant
-    });
+    const referenceDate = options.effectiveDate ? ensureUtcMidnightIsoDate(options.effectiveDate) : now;
 
-    if (!initialResult.success) {
-      return initialResult;
+    if (!lastCycle) {
+      const initial = getStartOfCurrentCycle(referenceDate, billingCycle, anchorSettings);
+      const initialResult = await createBillingCycle(trx, {
+        client_id: client.client_id,
+        billing_cycle: billingCycle,
+        effective_date: initial.effectiveDate,
+        period_start_date: initial.periodStart,
+        period_end_date: initial.periodEnd,
+        tenant
+      });
+
+      if (!initialResult.success) {
+        return initialResult;
+      }
+
+      if (options.manual) {
+        return finishSuccessfulPass();
+      }
+
+      // Backfill additional cycles until we cover "now" (i.e., lastEnd > now).
+      let start = initial.periodEnd;
+      let iterations = 0;
+      const MAX_ITERATIONS = 200;
+      while (parseISO(start) <= parseISO(now) && iterations < MAX_ITERATIONS) {
+        const end = getNextBillingBoundaryAfter(start, billingCycle, anchorSettings);
+        const result = await createBillingCycle(trx, {
+          client_id: client.client_id,
+          billing_cycle: billingCycle,
+          effective_date: start,
+          period_start_date: start,
+          period_end_date: end,
+          tenant
+        });
+
+        if (!result.success) {
+          return result;
+        }
+
+        iterations++;
+        start = end;
+      }
+
+      return finishSuccessfulPass();
     }
+
+    if (!lastCycle.period_end_date) {
+      return {
+        success: false,
+        error: 'db_error',
+        message: 'Client has an active billing cycle without a period end date.'
+      };
+    }
+
+    // Next cycle starts at the last cycle's exclusive end boundary.
+    let start = normalizeDbIsoUtcMidnight(lastCycle.period_end_date);
 
     if (options.manual) {
-      return { success: true };
-    }
-
-    // Backfill additional cycles until we cover "now" (i.e., lastEnd > now).
-    let start = initial.periodEnd;
-    let iterations = 0;
-    const MAX_ITERATIONS = 200;
-    while (parseISO(start) <= parseISO(now) && iterations < MAX_ITERATIONS) {
+      // Manual mode creates exactly one cycle (including a transition period if start isn't aligned).
       const end = getNextBillingBoundaryAfter(start, billingCycle, anchorSettings);
-      const result = await createBillingCycle(knex, {
+      const result = await createBillingCycle(trx, {
         client_id: client.client_id,
         billing_cycle: billingCycle,
         effective_date: start,
         period_start_date: start,
         period_end_date: end,
-        tenant: client.tenant
+        tenant
+      });
+      return result.success ? finishSuccessfulPass() : result;
+    }
+
+    // Automatic mode backfills until we cover "now".
+    let iterations = 0;
+    const MAX_ITERATIONS = 200;
+    while (parseISO(start) <= parseISO(now) && iterations < MAX_ITERATIONS) {
+      const end = getNextBillingBoundaryAfter(start, billingCycle, anchorSettings);
+      const result = await createBillingCycle(trx, {
+        client_id: client.client_id,
+        billing_cycle: billingCycle,
+        effective_date: start,
+        period_start_date: start,
+        period_end_date: end,
+        tenant
       });
 
       if (!result.success) {
@@ -251,56 +320,13 @@ export async function createClientContractLineCycles(
       start = end;
     }
 
-    return { success: true };
-  }
-
-  if (!lastCycle.period_end_date) {
-    return {
-      success: false,
-      error: 'db_error',
-      message: 'Client has an active billing cycle without a period end date.'
-    };
-  }
-
-  // Next cycle starts at the last cycle's exclusive end boundary.
-  let start = normalizeDbIsoUtcMidnight(lastCycle.period_end_date);
-
-  if (options.manual) {
-    // Manual mode creates exactly one cycle (including a transition period if start isn't aligned).
-    const end = getNextBillingBoundaryAfter(start, billingCycle, anchorSettings);
-    return await createBillingCycle(knex, {
-      client_id: client.client_id,
-      billing_cycle: billingCycle,
-      effective_date: start,
-      period_start_date: start,
-      period_end_date: end,
-      tenant: client.tenant
-    });
-  }
-
-  // Automatic mode backfills until we cover "now".
-  let iterations = 0;
-  const MAX_ITERATIONS = 200;
-  while (parseISO(start) <= parseISO(now) && iterations < MAX_ITERATIONS) {
-    const end = getNextBillingBoundaryAfter(start, billingCycle, anchorSettings);
-    const result = await createBillingCycle(knex, {
-      client_id: client.client_id,
-      billing_cycle: billingCycle,
-      effective_date: start,
-      period_start_date: start,
-      period_end_date: end,
-      tenant: client.tenant
-    });
-
-    if (!result.success) {
-      return result;
+    return finishSuccessfulPass();
+  }).catch((error: unknown) => {
+    if (error instanceof BillingCycleCreationAbort) {
+      return error.result;
     }
-
-    iterations++;
-    start = end;
-  }
-
-  return { success: true };
+    throw error;
+  });
 }
 
 async function loadClientAnchorSettings(

--- a/server/src/test/infrastructure/billing/invoices/clientBillingCycleRecurringServicePeriods.test.ts
+++ b/server/src/test/infrastructure/billing/invoices/clientBillingCycleRecurringServicePeriods.test.ts
@@ -1,0 +1,334 @@
+import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it, vi } from 'vitest';
+import { v4 as uuidv4 } from 'uuid';
+import { createClientContractLineCycles } from '../../../../../../packages/billing/src/lib/billing/createBillingCycles';
+import { TestContext } from 'server/test-utils/testContext';
+import { assignContractLineToClient } from '../../../../../test-utils/billingTestHelpers';
+
+const {
+  beforeAll: setupContext,
+  beforeEach: resetContext,
+  afterEach: rollbackContext,
+  afterAll: cleanupContext,
+} = TestContext.createHelpers();
+
+const dateOnly = (value: unknown) => new Date(value as string | Date).toISOString().slice(0, 10);
+
+describe('Client billing-cycle recurring service-period replenishment', () => {
+  let context: TestContext;
+
+  async function createClientCadenceLine(options: {
+    startDate?: string;
+    endDate?: string | null;
+    billingTiming?: 'arrears' | 'advance';
+    name?: string;
+  } = {}) {
+    const contractLineId = await context.createEntity('contract_lines', {
+      contract_line_name: options.name ?? `Client Cadence Line ${uuidv4().slice(0, 8)}`,
+      billing_frequency: 'monthly',
+      billing_timing: options.billingTiming ?? 'arrears',
+      is_custom: false,
+      contract_line_type: 'Fixed',
+      cadence_owner: 'client',
+    }, 'contract_line_id');
+
+    await assignContractLineToClient(context, contractLineId, {
+      startDate: options.startDate ?? '2026-07-01T00:00:00Z',
+      endDate: options.endDate ?? null,
+      materializeServicePeriods: false,
+    });
+
+    return contractLineId;
+  }
+
+  async function seedCycle(start: string, end: string) {
+    const billingCycleId = uuidv4();
+    await context.db('client_billing_cycles').insert({
+      billing_cycle_id: billingCycleId,
+      tenant: context.tenantId,
+      client_id: context.clientId,
+      billing_cycle: 'monthly',
+      effective_date: start,
+      period_start_date: start,
+      period_end_date: end,
+      is_active: true,
+      created_at: new Date(),
+      updated_at: new Date(),
+    });
+    return billingCycleId;
+  }
+
+  async function loadPeriods(obligationId: string) {
+    return context.db('recurring_service_periods')
+      .where({ tenant: context.tenantId, obligation_id: obligationId })
+      .orderBy('service_period_start', 'asc')
+      .orderBy('revision', 'asc');
+  }
+
+  async function insertHistoricalPeriod(input: {
+    recordId: string;
+    obligationId: string;
+    revision: number;
+    lifecycleState: 'billed' | 'superseded';
+    provenanceKind: 'generated' | 'regenerated';
+    supersedesRecordId?: string | null;
+    invoiceLinkage?: {
+      invoiceId: string;
+      invoiceChargeId: string;
+      invoiceChargeDetailId: string;
+      linkedAt: string;
+    };
+    createdAt: string;
+    updatedAt: string;
+  }) {
+    await context.db('recurring_service_periods').insert({
+      record_id: input.recordId,
+      tenant: context.tenantId,
+      schedule_key: `schedule:${context.tenantId}:client_contract_line:${input.obligationId}:client:arrears`,
+      period_key: 'period:2026-06-01:2026-07-01',
+      revision: input.revision,
+      obligation_id: input.obligationId,
+      obligation_type: 'client_contract_line',
+      charge_family: 'fixed',
+      cadence_owner: 'client',
+      due_position: 'arrears',
+      lifecycle_state: input.lifecycleState,
+      service_period_start: '2026-06-01',
+      service_period_end: '2026-07-01',
+      invoice_window_start: '2026-07-01',
+      invoice_window_end: '2026-08-01',
+      activity_window_start: null,
+      activity_window_end: null,
+      timing_metadata: null,
+      provenance_kind: input.provenanceKind,
+      source_rule_version: 'client_schedule|monthly|dom:1|moy:none|dow:none|ref:none',
+      reason_code: input.provenanceKind === 'regenerated' ? 'billing_schedule_changed' : 'initial_materialization',
+      source_run_key: 'historical-test-run',
+      supersedes_record_id: input.supersedesRecordId ?? null,
+      invoice_id: input.invoiceLinkage?.invoiceId ?? null,
+      invoice_charge_id: input.invoiceLinkage?.invoiceChargeId ?? null,
+      invoice_charge_detail_id: input.invoiceLinkage?.invoiceChargeDetailId ?? null,
+      invoice_linked_at: input.invoiceLinkage?.linkedAt ?? null,
+      created_at: input.createdAt,
+      updated_at: input.updatedAt,
+    });
+  }
+
+  beforeAll(async () => {
+    context = await setupContext({
+      runSeeds: true,
+      cleanupTables: [
+        'recurring_service_periods',
+        'client_billing_cycles',
+        'client_billing_settings',
+      ],
+      clientName: 'Recurring Period Replenishment Client',
+      userType: 'internal',
+    });
+  }, 120000);
+
+  beforeEach(async () => {
+    context = await resetContext();
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2026-08-07T12:00:00Z'));
+
+    await context.db('clients')
+      .where({ tenant: context.tenantId, client_id: context.clientId })
+      .update({ billing_cycle: 'monthly' });
+    context.client.billing_cycle = 'monthly';
+  }, 30000);
+
+  afterEach(async () => {
+    vi.useRealTimers();
+    await rollbackContext();
+  }, 30000);
+
+  afterAll(async () => {
+    await cleanupContext();
+  }, 30000);
+
+  it('replenishes the arrears period due in a newly advanced client cycle', async () => {
+    const obligationId = await createClientCadenceLine({
+      startDate: '2026-06-01T00:00:00Z',
+      billingTiming: 'arrears',
+    });
+    await seedCycle('2026-07-01T00:00:00Z', '2026-08-01T00:00:00Z');
+
+    const result = await createClientContractLineCycles(context.db, context.client);
+
+    expect(result).toEqual({ success: true });
+    const advancedCycle = await context.db('client_billing_cycles')
+      .where({ tenant: context.tenantId, client_id: context.clientId })
+      .andWhere('period_start_date', '2026-08-01T00:00:00Z')
+      .first();
+    expect(advancedCycle).toBeTruthy();
+    expect(dateOnly(advancedCycle.period_end_date)).toBe('2026-09-01');
+
+    const duePeriod = (await loadPeriods(obligationId)).find((row) =>
+      dateOnly(row.service_period_start) === '2026-07-01'
+      && dateOnly(row.service_period_end) === '2026-08-01'
+      && row.lifecycle_state !== 'superseded',
+    );
+    expect(duePeriod).toBeTruthy();
+    expect(dateOnly(duePeriod.invoice_window_start)).toBe('2026-08-01');
+    expect(dateOnly(duePeriod.invoice_window_end)).toBe('2026-09-01');
+    expect(duePeriod.due_position).toBe('arrears');
+  });
+
+  it('replenishes the advance period due in a newly advanced client cycle', async () => {
+    const obligationId = await createClientCadenceLine({
+      startDate: '2026-07-01T00:00:00Z',
+      billingTiming: 'advance',
+    });
+    await seedCycle('2026-07-01T00:00:00Z', '2026-08-01T00:00:00Z');
+
+    await createClientContractLineCycles(context.db, context.client);
+
+    const duePeriod = (await loadPeriods(obligationId)).find((row) =>
+      dateOnly(row.service_period_start) === '2026-08-01'
+      && dateOnly(row.service_period_end) === '2026-09-01'
+      && row.lifecycle_state !== 'superseded',
+    );
+    expect(duePeriod).toBeTruthy();
+    expect(dateOnly(duePeriod.invoice_window_start)).toBe('2026-08-01');
+    expect(dateOnly(duePeriod.invoice_window_end)).toBe('2026-09-01');
+    expect(duePeriod.due_position).toBe('advance');
+  });
+
+  it('heals a no-op nightly pass and repeated runs do not add cycles, revisions, or superseded rows', async () => {
+    const obligationId = await createClientCadenceLine({ startDate: '2026-07-01T00:00:00Z' });
+    await seedCycle('2026-08-01T00:00:00Z', '2026-09-01T00:00:00Z');
+
+    await createClientContractLineCycles(context.db, context.client);
+
+    const firstCycles = await context.db('client_billing_cycles')
+      .where({ tenant: context.tenantId, client_id: context.clientId });
+    const firstRows = await loadPeriods(obligationId);
+    expect(firstCycles).toHaveLength(1);
+    expect(firstRows.length).toBeGreaterThan(1);
+    expect(firstRows.some((row) => dateOnly(row.service_period_start) === '2026-07-01')).toBe(true);
+
+    await createClientContractLineCycles(context.db, context.client);
+
+    const secondCycles = await context.db('client_billing_cycles')
+      .where({ tenant: context.tenantId, client_id: context.clientId });
+    const secondRows = await loadPeriods(obligationId);
+    expect(secondCycles).toHaveLength(firstCycles.length);
+    expect(secondRows).toEqual(firstRows);
+    expect(secondRows.filter((row) => row.lifecycle_state === 'superseded')).toHaveLength(0);
+    expect(new Set(secondRows.map((row) => `${row.schedule_key}:${row.period_key}`)).size).toBe(secondRows.length);
+  });
+
+  it('replenishes every active client-cadence contract line in one advancement', async () => {
+    const firstObligationId = await createClientCadenceLine({
+      startDate: '2026-06-01T00:00:00Z',
+      name: 'First Active Line',
+    });
+    const secondObligationId = await createClientCadenceLine({
+      startDate: '2026-07-01T00:00:00Z',
+      name: 'Second Active Line',
+    });
+    await seedCycle('2026-07-01T00:00:00Z', '2026-08-01T00:00:00Z');
+
+    await createClientContractLineCycles(context.db, context.client);
+
+    for (const obligationId of [firstObligationId, secondObligationId]) {
+      const rows = await loadPeriods(obligationId);
+      expect(rows.length).toBeGreaterThan(1);
+      expect(rows.every((row) => row.obligation_id === obligationId)).toBe(true);
+      expect(rows.some((row) =>
+        dateOnly(row.service_period_start) === '2026-07-01'
+        && dateOnly(row.invoice_window_start) === '2026-08-01',
+      )).toBe(true);
+    }
+  });
+
+  it('preserves billed audit history and superseded revisions while filling future gaps', async () => {
+    const obligationId = await createClientCadenceLine({ startDate: '2026-06-01T00:00:00Z' });
+    await seedCycle('2026-07-01T00:00:00Z', '2026-08-01T00:00:00Z');
+
+    const supersededRecordId = uuidv4();
+    const billedRecordId = uuidv4();
+    const invoiceLinkage = {
+      invoiceId: uuidv4(),
+      invoiceChargeId: uuidv4(),
+      invoiceChargeDetailId: uuidv4(),
+      linkedAt: '2026-07-02T15:30:00Z',
+    };
+    await insertHistoricalPeriod({
+      recordId: supersededRecordId,
+      obligationId,
+      revision: 1,
+      lifecycleState: 'superseded',
+      provenanceKind: 'generated',
+      createdAt: '2026-06-01T00:00:00Z',
+      updatedAt: '2026-07-02T15:00:00Z',
+    });
+    await insertHistoricalPeriod({
+      recordId: billedRecordId,
+      obligationId,
+      revision: 2,
+      lifecycleState: 'billed',
+      provenanceKind: 'regenerated',
+      supersedesRecordId: supersededRecordId,
+      invoiceLinkage,
+      createdAt: '2026-07-02T15:00:00Z',
+      updatedAt: '2026-07-02T15:30:00Z',
+    });
+
+    const before = await loadPeriods(obligationId);
+    await createClientContractLineCycles(context.db, context.client);
+    const after = await loadPeriods(obligationId);
+
+    const billedBefore = before.find((row) => row.record_id === billedRecordId);
+    const billedAfter = after.find((row) => row.record_id === billedRecordId);
+    expect(billedAfter).toEqual(billedBefore);
+    expect(billedAfter).toMatchObject({
+      revision: 2,
+      lifecycle_state: 'billed',
+      supersedes_record_id: supersededRecordId,
+      invoice_id: invoiceLinkage.invoiceId,
+      invoice_charge_id: invoiceLinkage.invoiceChargeId,
+      invoice_charge_detail_id: invoiceLinkage.invoiceChargeDetailId,
+    });
+    expect(after.find((row) => row.record_id === supersededRecordId)).toEqual(
+      before.find((row) => row.record_id === supersededRecordId),
+    );
+    expect(after.some((row) =>
+      row.lifecycle_state !== 'superseded'
+      && dateOnly(row.service_period_start) === '2026-07-01'
+      && dateOnly(row.service_period_end) === '2026-08-01',
+    )).toBe(true);
+  });
+
+  it('clips assignment bounds and fills the configured generation horizon', async () => {
+    const boundedObligationId = await createClientCadenceLine({
+      startDate: '2026-07-15T00:00:00Z',
+      endDate: '2026-11-15T00:00:00Z',
+      name: 'Bounded Line',
+    });
+    const horizonObligationId = await createClientCadenceLine({
+      startDate: '2026-07-01T00:00:00Z',
+      name: 'Horizon Line',
+    });
+    await seedCycle('2026-08-01T00:00:00Z', '2026-09-01T00:00:00Z');
+
+    await createClientContractLineCycles(context.db, context.client);
+
+    const boundedRows = await loadPeriods(boundedObligationId);
+    expect(boundedRows.length).toBeGreaterThan(1);
+    for (const row of boundedRows) {
+      const effectiveStart = dateOnly(row.activity_window_start ?? row.service_period_start);
+      const effectiveEnd = dateOnly(row.activity_window_end ?? row.service_period_end);
+      expect(effectiveStart >= '2026-07-15').toBe(true);
+      expect(effectiveEnd <= '2026-11-15').toBe(true);
+    }
+    expect(dateOnly(boundedRows[0].activity_window_start)).toBe('2026-07-15');
+    expect(dateOnly(boundedRows.at(-1)?.activity_window_end)).toBe('2026-11-15');
+
+    const horizonRows = await loadPeriods(horizonObligationId);
+    const lastHorizonRow = horizonRows.at(-1);
+    expect(horizonRows.length).toBeGreaterThan(5);
+    expect(dateOnly(lastHorizonRow?.service_period_start) < '2027-02-03').toBe(true);
+    expect(dateOnly(lastHorizonRow?.service_period_end) >= '2027-02-03').toBe(true);
+  });
+});

--- a/server/src/test/infrastructure/billing/invoices/clientBillingCycleRecurringServicePeriods.test.ts
+++ b/server/src/test/infrastructure/billing/invoices/clientBillingCycleRecurringServicePeriods.test.ts
@@ -21,6 +21,8 @@ describe('Client billing-cycle recurring service-period replenishment', () => {
     endDate?: string | null;
     billingTiming?: 'arrears' | 'advance';
     name?: string;
+    contractActive?: boolean;
+    lineActive?: boolean;
   } = {}) {
     const contractLineId = await context.createEntity('contract_lines', {
       contract_line_name: options.name ?? `Client Cadence Line ${uuidv4().slice(0, 8)}`,
@@ -29,11 +31,13 @@ describe('Client billing-cycle recurring service-period replenishment', () => {
       is_custom: false,
       contract_line_type: 'Fixed',
       cadence_owner: 'client',
+      is_active: options.lineActive ?? true,
     }, 'contract_line_id');
 
     await assignContractLineToClient(context, contractLineId, {
       startDate: options.startDate ?? '2026-07-01T00:00:00Z',
       endDate: options.endDate ?? null,
+      contractHeaderIsActive: options.contractActive ?? true,
       materializeServicePeriods: false,
     });
 
@@ -218,7 +222,7 @@ describe('Client billing-cycle recurring service-period replenishment', () => {
     expect(new Set(secondRows.map((row) => `${row.schedule_key}:${row.period_key}`)).size).toBe(secondRows.length);
   });
 
-  it('replenishes every active client-cadence contract line in one advancement', async () => {
+  it('replenishes every active line while skipping inactive contracts and contract lines', async () => {
     const firstObligationId = await createClientCadenceLine({
       startDate: '2026-06-01T00:00:00Z',
       name: 'First Active Line',
@@ -226,6 +230,16 @@ describe('Client billing-cycle recurring service-period replenishment', () => {
     const secondObligationId = await createClientCadenceLine({
       startDate: '2026-07-01T00:00:00Z',
       name: 'Second Active Line',
+    });
+    const inactiveContractObligationId = await createClientCadenceLine({
+      startDate: '2026-06-01T00:00:00Z',
+      name: 'Inactive Contract Line',
+      contractActive: false,
+    });
+    const inactiveLineObligationId = await createClientCadenceLine({
+      startDate: '2026-06-01T00:00:00Z',
+      name: 'Inactive Line',
+      lineActive: false,
     });
     await seedCycle('2026-07-01T00:00:00Z', '2026-08-01T00:00:00Z');
 
@@ -239,6 +253,12 @@ describe('Client billing-cycle recurring service-period replenishment', () => {
         dateOnly(row.service_period_start) === '2026-07-01'
         && dateOnly(row.invoice_window_start) === '2026-08-01',
       )).toBe(true);
+    }
+
+    for (const obligationId of [inactiveContractObligationId, inactiveLineObligationId]) {
+      const liveRows = (await loadPeriods(obligationId))
+        .filter((row) => row.lifecycle_state !== 'superseded');
+      expect(liveRows).toHaveLength(0);
     }
   });
 

--- a/server/src/test/unit/docs/servicePeriodFirstBillingPlan.contract.test.ts
+++ b/server/src/test/unit/docs/servicePeriodFirstBillingPlan.contract.test.ts
@@ -172,6 +172,7 @@ const servicePeriodPostInventoryRefs = new Set([
   // rows keyed off the charge's servicePeriodStart.
   'server/test-utils/billingTestHelpers.ts',
   'server/src/test/infrastructure/billing/invoices/clientBillingCycleAnchors.test.ts',
+  'server/src/test/infrastructure/billing/invoices/clientBillingCycleRecurringServicePeriods.test.ts',
   'server/src/test/integration/api/invoiceService.recurringCoexistence.integration.test.ts',
   'server/src/test/integration/contractWizard.integration.test.ts',
   // P0 journey suites (tests/p0_journeys) landed after the pass-0 snapshot and

--- a/shared/billingClients/clientCadenceScheduleRegeneration.ts
+++ b/shared/billingClients/clientCadenceScheduleRegeneration.ts
@@ -383,12 +383,14 @@ async function persistRecurringServicePeriodRegeneration(
   }
 }
 
-type ClientCadenceScheduleChangeParams = {
+export type ClientCadenceServicePeriodReplenishmentParams = {
   tenant: string;
   clientId: string;
   billingCycle: BillingCycleType;
   anchor: NormalizedBillingCycleAnchorSettings;
 };
+
+type ClientCadenceScheduleChangeParams = ClientCadenceServicePeriodReplenishmentParams;
 
 type ClientCadenceObligationRegenerationPlan = {
   obligationId: string;
@@ -487,9 +489,9 @@ async function computeClientCadenceRegeneration(
   return { billedBoundaryEnd, obligationPlans };
 }
 
-export async function regenerateClientCadenceServicePeriodsForScheduleChange(
+export async function replenishClientCadenceServicePeriods(
   trx: Knex.Transaction,
-  params: ClientCadenceScheduleChangeParams,
+  params: ClientCadenceServicePeriodReplenishmentParams,
 ): Promise<void> {
   const { obligationPlans } = await computeClientCadenceRegeneration(trx, params);
 
@@ -503,6 +505,13 @@ export async function regenerateClientCadenceServicePeriodsForScheduleChange(
       ],
     });
   }
+}
+
+export async function regenerateClientCadenceServicePeriodsForScheduleChange(
+  trx: Knex.Transaction,
+  params: ClientCadenceScheduleChangeParams,
+): Promise<void> {
+  await replenishClientCadenceServicePeriods(trx, params);
 }
 
 export type ClientCadenceChangePreview = {

--- a/shared/billingClients/clientCadenceScheduleRegeneration.ts
+++ b/shared/billingClients/clientCadenceScheduleRegeneration.ts
@@ -297,6 +297,8 @@ async function loadClientCadenceRecurringObligations(
   return query
     .andWhere('cc.client_id', params.clientId)
     .where('cc.is_active', true)
+    .where('ct.is_active', true)
+    .where('cl.is_active', true)
     .where((builder) =>
       builder.whereNull('ct.is_system_managed_default').orWhere('ct.is_system_managed_default', false),
     )


### PR DESCRIPTION
## Summary

- Replenish client-cadence recurring service periods in the same per-client transaction as automatic billing-cycle creation and catch-up.
- Run the canonical replenishment engine on successful no-op nightly passes so the rolling horizon heals and stays populated without requiring Generate **Fix all**.
- Preserve billed history and idempotency while restricting replenishment to active assignments, contract headers, and contract lines.
- Add real PostgreSQL coverage for arrears and advance timing, no-op healing and idempotency, multiple active lines, inactive obligations, billed-history preservation, assignment bounds, and horizon behavior.
- Register the new persisted service-period reader test in the service-period-first plan’s post-inventory set.

## Implementation

`createClientContractLineCycles` now performs cycle advancement and client-cadence replenishment atomically. It reuses the canonical schedule-regeneration/backfill implementation through a targeted `replenishClientCadenceServicePeriods` entry point. Failed cycle creation still returns the existing structured result, while replenishment failures roll back the client transaction for the next scheduled retry.

## Verification

- PASS — focused PostgreSQL replenishment suite: 6/6.
- PASS — recurring-service-period domain tests: 42/42.
- PASS — existing client billing-cycle test: 1/1.
- PASS — service-period-first plan artifact contract: 66/66.
- PASS — billing/shared typechecks, billing package build, and server typecheck with a 16 GB heap.
- Known unrelated baseline: `clientBillingCycleAnchors.test.ts` retains four existing schedule/action fixture failures; its three direct cycle tests pass.

## Smoke test

PASS for the changed automatic/nightly path. The real app on port 3834 and real PostgreSQL fixture showed the initial Generate **Fix all** gap. Running the exact `packages/billing` function used by `initializeApp` created/healed the required arrears and advance periods; Generate then showed the advance line **Ready** and arrears line **Not yet due** without repair. Both active lines contain 17 periods through 2027-03-01; the inactive line has zero. A rerun preserved identical cycle, ledger, and billed-row fingerprints with zero duplicate live periods.

Adjacent concern: the UI’s manual **Create next cycle** uses a separate shared implementation. It created the August–September cycle but did not replenish periods; the automatic path subsequently healed them.

Fidelity: real Next.js app, authentication, Chromium, server actions, and PostgreSQL; no simulator or mock. The scheduler has no manual trigger, so its exact production function was invoked directly, bypassing only the 24-hour dispatch wait. The newly created card browser pane was uncontrollable due to cross-host routing, so an unoccupied Ryzen-hosted Alga Dev pane was used. Glinda lacked Service Periods management permission, requiring DB ledger assertions. Unrelated Client Billing settings requests returned schema-drift 500s; the cycle action itself succeeded. Final Generate refresh had no new console errors or failed requests.

Evidence: `/tmp/alga-smoke-evidence/recurring-service-period-replenishment-20260807T211626Z`
