### PR TITLE
Fix bulk task selection and phase display in move dialogs

### DIFF
--- a/packages/projects/src/components/BulkMoveTaskDialog.tsx
+++ b/packages/projects/src/components/BulkMoveTaskDialog.tsx
@@ -75,6 +75,7 @@ export default function BulkMoveTaskDialog({
         <div className="mb-6">
           <TreeSelect<'project' | 'phase' | 'status'>
             value={selectedTargetPath?.['status'] || selectedTargetPath?.['phase'] || ''}
+            selectedPath={selectedTargetPath ?? undefined}
             onValueChange={handleTreeSelect}
             options={projectTreeData}
             placeholder={t('dialogs.moveTask.placeholder', 'Select target project/phase/status...')}

--- a/packages/projects/src/components/DuplicateTaskDialog.tsx
+++ b/packages/projects/src/components/DuplicateTaskDialog.tsx
@@ -132,6 +132,7 @@ export default function DuplicateTaskDialog({
           <div className="mb-4">
             <TreeSelect<'project' | 'phase' | 'status'>
                 value={selectedTargetPath?.['status'] || selectedTargetPath?.['phase'] || ''}
+                selectedPath={selectedTargetPath ?? undefined}
                 onValueChange={handleTreeSelect}
                 options={projectTreeData}
                 placeholder={t('dialogs.duplicateTask.placeholder', 'Select target project/phase/status...')}

--- a/packages/projects/src/components/MoveTaskDialog.tsx
+++ b/packages/projects/src/components/MoveTaskDialog.tsx
@@ -94,6 +94,7 @@ export default function MoveTaskDialog({
             <TreeSelect<'project' | 'phase' | 'status'>
                 // Use status if selected, otherwise phase, to show full path including status
                 value={selectedTargetPath?.['status'] || selectedTargetPath?.['phase'] || ''}
+                selectedPath={selectedTargetPath ?? undefined}
                 onValueChange={handleTreeSelect}
                 options={projectTreeData}
                 placeholder={t('dialogs.moveTask.placeholder', 'Select target project/phase/status...')}

--- a/packages/projects/src/components/ProjectDetail.tsx
+++ b/packages/projects/src/components/ProjectDetail.tsx
@@ -1457,6 +1457,7 @@ export default function ProjectDetail({
       // previous one, preserving the relative order at the drop position.
       let prevBefore: string | null = safeBefore;
       const statusUpdatedById = new Map<string, IProjectTask>();
+      const movedIds: string[] = [];
       for (const task of tasksToMove) {
         try {
           if (task.phase_id !== newPhaseId) {
@@ -1489,6 +1490,7 @@ export default function ProjectDetail({
             statusUpdatedById.set(task.task_id, updatedTask);
           }
           prevBefore = task.task_id;
+          movedIds.push(task.task_id);
           success++;
         } catch (error) {
           console.error(`Failed to move task ${task.task_id}:`, error);
@@ -1536,6 +1538,9 @@ export default function ProjectDetail({
           }),
         );
       }
+      // Drop the moved tasks from the selection so a follow-up drag doesn't
+      // carry them along. Failed tasks stay selected for a retry.
+      setTasksSelected(movedIds, false);
       return;
     }
 
@@ -1577,7 +1582,7 @@ export default function ProjectDetail({
     } catch (error) {
       handleError(error, 'Failed to move task');
     }
-  }, [allProjectTasks, selectedTaskIds, selectedPhase, t]);
+  }, [allProjectTasks, selectedTaskIds, selectedPhase, setTasksSelected, t]);
   
   // Handle tag changes
   const handleProjectTagsChange = (tags: ITag[]) => {
@@ -2008,7 +2013,7 @@ export default function ProjectDetail({
 
     try {
       const statusUpdatedById = new Map<string, IProjectTask>();
-      let movedInCount = 0;
+      const movedInIds: string[] = [];
       let failed = 0;
 
       // Reposition same-phase tasks at the drop location, grouped consecutively
@@ -2033,7 +2038,7 @@ export default function ProjectDetail({
       for (const task of otherPhaseTasks) {
         try {
           unwrapActionResult(await moveTaskToPhase(task.task_id, currentPhaseId, targetStatusId));
-          movedInCount++;
+          movedInIds.push(task.task_id);
         } catch (error) {
           console.error(`Failed to move task ${task.task_id}:`, error);
           failed++;
@@ -2088,7 +2093,7 @@ export default function ProjectDetail({
         }, 500);
       }
 
-      const total = statusUpdatedById.size + movedInCount;
+      const total = statusUpdatedById.size + movedInIds.length;
       if (failed === 0) {
         toast.success(
           t('projectDetail.bulkTasksMovedSuccess', '{{count}} tasks moved', { count: total }),
@@ -2101,6 +2106,10 @@ export default function ProjectDetail({
           }),
         );
       }
+
+      // Drop the moved tasks from the selection so a follow-up drag doesn't
+      // carry them along. Failed tasks stay selected for a retry.
+      setTasksSelected([...statusUpdatedById.keys(), ...movedInIds], false);
     } catch (error) {
       handleError(error, 'Failed to move tasks');
     }
@@ -2532,6 +2541,9 @@ export default function ProjectDetail({
           }),
         );
       }
+      // Drop the moved tasks from the selection so a follow-up drag doesn't
+      // carry them along. Failed tasks stay selected for a retry.
+      setTasksSelected([...movedById.keys()], false);
       setMoveConfirmation(null);
       return;
     }

--- a/packages/ui/src/components/TreeSelect.tsx
+++ b/packages/ui/src/components/TreeSelect.tsx
@@ -72,6 +72,10 @@ interface TreeSelectProps<T extends string = string> extends AutomationProps {
   onModeChange?: (mode: TreeSelectMode) => void;
   // Arbitrary content rendered in the dropdown header (e.g. an active/inactive filter).
   headerContent?: React.ReactNode;
+  // Ancestors of the current selection, as handed back by onValueChange. Needed when the
+  // same value appears under several branches (project task statuses are shared across
+  // phases) — without it the trigger label shows the first match's ancestors.
+  selectedPath?: TreeSelectPath;
 }
 
 function TreeSelect<T extends string>({
@@ -99,6 +103,7 @@ function TreeSelect<T extends string>({
   modeToggle = false,
   onModeChange,
   headerContent,
+  selectedPath,
 }: TreeSelectProps<T>): React.JSX.Element {
   const { t } = useTranslation();
   const { modal: parentModal } = useModality();
@@ -145,6 +150,29 @@ function TreeSelect<T extends string>({
     return undefined;
   };
 
+  // Same search, but only through branches whose ancestors agree with the caller-supplied
+  // path, so a value that exists under several branches resolves to the selected one.
+  const findSelectedOptionAlongPath = (
+    opts: TreeSelectOption<T>[],
+    targetValue: string,
+    path: TreeSelectPath,
+    parentPath: TreeSelectOption<T>[] = []
+  ): { option: TreeSelectOption<T>; path: TreeSelectOption<T>[] } | undefined => {
+    for (const opt of opts) {
+      const expected = path[opt.type];
+      if (expected !== undefined && expected !== opt.value) continue;
+      const currentPath = [...parentPath, opt];
+      if (opt.value === targetValue) {
+        return { option: opt, path: currentPath };
+      }
+      if (opt.children) {
+        const found = findSelectedOptionAlongPath(opt.children, targetValue, path, currentPath);
+        if (found) return found;
+      }
+    }
+    return undefined;
+  };
+
   // Update expanded items and display label when value changes
   useEffect(() => {
     if (!Array.isArray(options)) {
@@ -165,7 +193,9 @@ function TreeSelect<T extends string>({
 
     // Otherwise, find and reflect the selected option
     setSelectedValue(value);
-    const result = findSelectedOptionWithPath(options, value);
+    const result =
+      (selectedPath ? findSelectedOptionAlongPath(options, value, selectedPath) : undefined) ??
+      findSelectedOptionWithPath(options, value);
     if (result) {
       // Only auto-expand parent nodes on initial mount, not on subsequent renders
       // This allows users to collapse categories while keeping their selection
@@ -209,7 +239,7 @@ function TreeSelect<T extends string>({
       });
       setDisplayLabel(labels.filter(l => l).join(' > '));
     }
-  }, [value, options]);
+  }, [value, options, selectedPath]);
 
   // Keep the mode in sync when the filter opens with a one-sided selection (e.g. a
   // persisted exclude-only filter). Only corrects a clear mismatch, so it never fights

--- a/packages/ui/src/components/__tests__/TreeSelect.test.tsx
+++ b/packages/ui/src/components/__tests__/TreeSelect.test.tsx
@@ -1,0 +1,83 @@
+/**
+ * @vitest-environment jsdom
+ */
+import React from 'react';
+import { describe, it, expect, beforeAll } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import i18next from 'i18next';
+import { initReactI18next } from 'react-i18next';
+import TreeSelect, { TreeSelectOption, TreeSelectPath } from '../TreeSelect';
+
+beforeAll(async () => {
+  if (!i18next.isInitialized) {
+    await i18next.use(initReactI18next).init({
+      lng: 'en',
+      fallbackLng: 'en',
+      resources: { en: { common: {} } },
+      interpolation: { escapeValue: false },
+    });
+  }
+});
+
+type NodeType = 'project' | 'phase' | 'status';
+
+// Project task status mappings are shared across phases, so the same status value
+// shows up under every phase of a project.
+const SHARED_STATUS = 'status-in-progress';
+
+const options: TreeSelectOption<NodeType>[] = [
+  {
+    label: 'Website Rebuild',
+    value: 'project-1',
+    type: 'project',
+    children: [
+      {
+        label: 'Discovery',
+        value: 'phase-1',
+        type: 'phase',
+        children: [{ label: 'In Progress', value: SHARED_STATUS, type: 'status' }],
+      },
+      {
+        label: 'Delivery',
+        value: 'phase-2',
+        type: 'phase',
+        children: [{ label: 'In Progress', value: SHARED_STATUS, type: 'status' }],
+      },
+    ],
+  },
+];
+
+describe('TreeSelect display label', () => {
+  it('resolves the label through selectedPath when a value repeats across branches', () => {
+    const selectedPath: TreeSelectPath = {
+      project: 'project-1',
+      phase: 'phase-2',
+      status: SHARED_STATUS,
+    };
+
+    render(
+      <TreeSelect<NodeType>
+        options={options}
+        value={SHARED_STATUS}
+        selectedPath={selectedPath}
+        onValueChange={() => {}}
+        placeholder="Select target"
+      />
+    );
+
+    expect(screen.getByText('Website Rebuild > Delivery > In Progress')).toBeTruthy();
+  });
+
+  it('falls back to the first depth-first match without selectedPath', () => {
+    render(
+      <TreeSelect<NodeType>
+        options={options}
+        value={SHARED_STATUS}
+        onValueChange={() => {}}
+        placeholder="Select target"
+      />
+    );
+
+    expect(screen.getByText('Website Rebuild > Discovery > In Progress')).toBeTruthy();
+  });
+});


### PR DESCRIPTION
## Summary
Fixes two related bugs in the project task board's move/duplicate flows. First, `TreeSelect` picked the display label via a plain depth-first search, so when a status value is shared across multiple phases of the same project (the common case), the trigger showed the wrong phase — always the first match instead of the one actually selected. Second, after a bulk drag-and-drop or bulk move, successfully moved tasks stayed selected, so a follow-up drag would carry stale tasks along with it.

## Changes
- **TreeSelect (`packages/ui`)**: added an optional `selectedPath` prop and a path-constrained lookup (`findSelectedOptionAlongPath`) that resolves the display label by walking only branches whose ancestors match the caller-supplied path, falling back to the original depth-first search when no path is given. Added unit tests covering both the path-resolved and fallback cases.
- **Task dialogs (`packages/projects`)**: `BulkMoveTaskDialog`, `DuplicateTaskDialog`, and `MoveTaskDialog` now pass `selectedTargetPath` into `TreeSelect` so the correct phase renders in the trigger label instead of the first matching branch.
- **ProjectDetail (`packages/projects`)**: after each bulk move path (drag-drop reorder within a phase, drag-drop into another phase, and dialog-driven bulk move), successfully moved task IDs are now cleared from the selection via `setTasksSelected(..., false)`. Tasks that fail to move remain selected so they can be retried.

## Testing
- `npx vitest run src/components/__tests__/TreeSelect.test.tsx` in `packages/ui` — 2/2 passing.
