### PR TITLE
fix: restore hosted Microsoft refresh authority

### DIFF
--- a/ee/appliance/flux/profiles/single-node/values/temporal-worker.single-node.yaml
+++ b/ee/appliance/flux/profiles/single-node/values/temporal-worker.single-node.yaml
@@ -2,6 +2,8 @@ namespace: msp
 enabled: true
 replicaCount: 1
 
+deploymentProfile: appliance
+
 image:
   repository: ghcr.io/nine-minds/temporal-worker
   tag: latest

--- a/ee/helm/temporal-worker/templates/deployment.yaml
+++ b/ee/helm/temporal-worker/templates/deployment.yaml
@@ -90,7 +90,7 @@ spec:
             - |
               . /vault/secrets/internal-api
               . /vault/secrets/auth-key
-              exec node dist/worker.js
+              exec node dist/ee/temporal-workflows/src/worker.js
           {{- end }}
           env:
             # Node.js module resolution

--- a/ee/helm/temporal-worker/templates/deployment.yaml
+++ b/ee/helm/temporal-worker/templates/deployment.yaml
@@ -135,7 +135,14 @@ spec:
             - name: LOG_LEVEL
               value: "{{ .Values.logLevel }}"
             - name: APPLICATION_URL
+              {{- with .Values.applicationUrlSecret }}
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .name | quote }}
+                  key: {{ .key | quote }}
+              {{- else }}
               value: "{{ .Values.applicationUrl }}"
+              {{- end }}
             - name: NEXT_PUBLIC_BASE_URL
               value: "{{ .Values.publicBaseUrl }}"
             - name: NM_STORE_URL

--- a/ee/helm/temporal-worker/templates/deployment.yaml
+++ b/ee/helm/temporal-worker/templates/deployment.yaml
@@ -17,7 +17,6 @@ spec:
   selector:
     matchLabels:
       {{- include "temporal-worker.selectorLabels" . | nindent 6 }}
-      app.kubernetes.io/component: temporal-worker
   template:
     metadata:
       annotations:
@@ -131,6 +130,8 @@ spec:
             # Application Configuration
             - name: NODE_ENV
               value: "production"
+            - name: DEPLOYMENT_PROFILE
+              value: {{ .Values.deploymentProfile | default "hosted" | quote }}
             - name: LOG_LEVEL
               value: "{{ .Values.logLevel }}"
             - name: APPLICATION_URL

--- a/ee/helm/temporal-worker/values.yaml
+++ b/ee/helm/temporal-worker/values.yaml
@@ -73,6 +73,8 @@ secrets:
 
 # Service Account configuration
 serviceAccount:
+  # Required for the hosted Vault Kubernetes auth role and chart-managed RBAC.
+  create: true
   # Annotations to add to the service account
   annotations: {}
   # Automatically mount service account token

--- a/ee/helm/temporal-worker/values.yaml
+++ b/ee/helm/temporal-worker/values.yaml
@@ -233,6 +233,9 @@ stripe:
 
 # Application configuration
 applicationUrl: ""  # Set to your application URL (e.g., https://example.com)
+# Prefer an existing Secret in hosted environments; when set, this takes
+# precedence over applicationUrl.
+applicationUrlSecret: {}
 publicBaseUrl: ""  # Public URL used in recipient-facing links (e.g., https://example.com)
 
 # Namespace override (optional)

--- a/ee/helm/temporal-worker/values.yaml
+++ b/ee/helm/temporal-worker/values.yaml
@@ -5,6 +5,10 @@
 # Enable/disable the temporal worker deployment
 enabled: true
 
+# Hosted uses Alga's shared multi-tenant OAuth applications. Appliance installs
+# use customer-owned applications and tenant-specific OAuth authorities.
+deploymentProfile: hosted
+
 # Image configuration
 image:
   repository: ""  # Set to your container registry and image name

--- a/server/src/test/unit/email/MicrosoftGraphAdapter.subscription.test.ts
+++ b/server/src/test/unit/email/MicrosoftGraphAdapter.subscription.test.ts
@@ -164,15 +164,26 @@ describe('MicrosoftGraphAdapter subscription hygiene', () => {
 });
 
 describe('MicrosoftGraphAdapter token refresh authority', () => {
+  const previousDeploymentProfile = process.env.DEPLOYMENT_PROFILE;
+
   beforeEach(() => {
     vi.clearAllMocks();
+    delete process.env.DEPLOYMENT_PROFILE;
     mocks.tokenPost.mockRejectedValue({
       message: 'Request failed with status code 400',
       response: { status: 400, data: { error: 'invalid_grant' }, headers: {} },
     });
   });
 
-  it('refreshes against the tenant that issued the access token', async () => {
+  afterEach(() => {
+    if (previousDeploymentProfile === undefined) {
+      delete process.env.DEPLOYMENT_PROFILE;
+    } else {
+      process.env.DEPLOYMENT_PROFILE = previousDeploymentProfile;
+    }
+  });
+
+  it('refreshes a hosted provider through the shared multi-tenant authority', async () => {
     const providerConfig = config();
     providerConfig.provider_config = {
       ...providerConfig.provider_config,
@@ -188,14 +199,15 @@ describe('MicrosoftGraphAdapter token refresh authority', () => {
 
     expect(mocks.tokenPost).toHaveBeenCalledOnce();
     expect(mocks.tokenPost.mock.calls[0][0]).toBe(
-      'https://login.microsoftonline.com/customer-token-tenant/oauth2/v2.0/token'
+      'https://login.microsoftonline.com/common/oauth2/v2.0/token'
     );
     const params = new URLSearchParams(mocks.tokenPost.mock.calls[0][1]);
     expect(params.get('grant_type')).toBe('refresh_token');
     expect(params.has('scope')).toBe(false);
   });
 
-  it('falls back to the configured authority when the access token is opaque', async () => {
+  it('uses the configured tenant authority for an appliance provider', async () => {
+    process.env.DEPLOYMENT_PROFILE = 'appliance';
     const providerConfig = config();
     providerConfig.provider_config = {
       ...providerConfig.provider_config,
@@ -211,6 +223,25 @@ describe('MicrosoftGraphAdapter token refresh authority', () => {
 
     expect(mocks.tokenPost.mock.calls[0][0]).toBe(
       'https://login.microsoftonline.com/configured-tenant/oauth2/v2.0/token'
+    );
+  });
+
+  it('falls back to the token tenant for an appliance provider without a configured tenant', async () => {
+    process.env.DEPLOYMENT_PROFILE = 'appliance';
+    const providerConfig = config();
+    providerConfig.provider_config = {
+      ...providerConfig.provider_config,
+      client_id: 'single-tenant-client',
+      client_secret: 'single-tenant-secret',
+      access_token: jwt({ tid: 'customer-token-tenant' }),
+      token_expires_at: new Date(0).toISOString(),
+    };
+    const adapter = new MicrosoftGraphAdapter(providerConfig);
+
+    await expect(adapter.ensureTokenHealthy()).rejects.toThrow('refreshAccessToken');
+
+    expect(mocks.tokenPost.mock.calls[0][0]).toBe(
+      'https://login.microsoftonline.com/customer-token-tenant/oauth2/v2.0/token'
     );
   });
 });

--- a/server/src/test/unit/email/MicrosoftGraphAdapter.subscription.test.ts
+++ b/server/src/test/unit/email/MicrosoftGraphAdapter.subscription.test.ts
@@ -2,6 +2,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 const mocks = vi.hoisted(() => {
   const requestUse = vi.fn();
+  const tokenPost = vi.fn();
   const client = {
     interceptors: { request: { use: requestUse } },
     get: vi.fn(),
@@ -9,13 +10,13 @@ const mocks = vi.hoisted(() => {
     patch: vi.fn(),
     delete: vi.fn(),
   };
-  return { client, requestUse };
+  return { client, requestUse, tokenPost };
 });
 
 vi.mock('axios', () => ({
   default: {
     create: vi.fn(() => mocks.client),
-    post: vi.fn(),
+    post: mocks.tokenPost,
   },
 }));
 
@@ -55,6 +56,10 @@ function config() {
       token_expires_at: new Date(Date.now() + 60 * 60 * 1000).toISOString(),
     },
   };
+}
+
+function jwt(claims: Record<string, unknown>): string {
+  return `header.${Buffer.from(JSON.stringify(claims)).toString('base64url')}.signature`;
 }
 
 describe('MicrosoftGraphAdapter subscription hygiene', () => {
@@ -155,5 +160,57 @@ describe('MicrosoftGraphAdapter subscription hygiene', () => {
 
     await expect(new MicrosoftGraphAdapter(config()).registerWebhookSubscription())
       .rejects.toMatchObject<Partial<MicrosoftSubscriptionError>>({ kind: 'authentication', status: 403 });
+  });
+});
+
+describe('MicrosoftGraphAdapter token refresh authority', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.tokenPost.mockRejectedValue({
+      message: 'Request failed with status code 400',
+      response: { status: 400, data: { error: 'invalid_grant' }, headers: {} },
+    });
+  });
+
+  it('refreshes against the tenant that issued the access token', async () => {
+    const providerConfig = config();
+    providerConfig.provider_config = {
+      ...providerConfig.provider_config,
+      client_id: 'platform-client',
+      client_secret: 'platform-secret',
+      tenant_id: 'platform-home-tenant',
+      access_token: jwt({ tid: 'customer-token-tenant' }),
+      token_expires_at: new Date(0).toISOString(),
+    };
+    const adapter = new MicrosoftGraphAdapter(providerConfig);
+
+    await expect(adapter.ensureTokenHealthy()).rejects.toThrow('refreshAccessToken');
+
+    expect(mocks.tokenPost).toHaveBeenCalledOnce();
+    expect(mocks.tokenPost.mock.calls[0][0]).toBe(
+      'https://login.microsoftonline.com/customer-token-tenant/oauth2/v2.0/token'
+    );
+    const params = new URLSearchParams(mocks.tokenPost.mock.calls[0][1]);
+    expect(params.get('grant_type')).toBe('refresh_token');
+    expect(params.has('scope')).toBe(false);
+  });
+
+  it('falls back to the configured authority when the access token is opaque', async () => {
+    const providerConfig = config();
+    providerConfig.provider_config = {
+      ...providerConfig.provider_config,
+      client_id: 'single-tenant-client',
+      client_secret: 'single-tenant-secret',
+      tenant_id: 'configured-tenant',
+      access_token: 'opaque-access-token',
+      token_expires_at: new Date(0).toISOString(),
+    };
+    const adapter = new MicrosoftGraphAdapter(providerConfig);
+
+    await expect(adapter.ensureTokenHealthy()).rejects.toThrow('refreshAccessToken');
+
+    expect(mocks.tokenPost.mock.calls[0][0]).toBe(
+      'https://login.microsoftonline.com/configured-tenant/oauth2/v2.0/token'
+    );
   });
 });

--- a/server/src/test/unit/email/microsoftOutboundOAuth.contract.test.ts
+++ b/server/src/test/unit/email/microsoftOutboundOAuth.contract.test.ts
@@ -1,24 +1,25 @@
-import { readFileSync } from 'node:fs';
-import { resolve } from 'node:path';
 import { describe, expect, it } from 'vitest';
+import { generateMicrosoftAuthUrl } from '../../../utils/email/oauthHelpers';
 
 describe('Microsoft outbound OAuth contract', () => {
-  it('uses the common email scope set for authorization, token exchange, and refresh', () => {
-    const callback = readFileSync(
-      resolve(process.cwd(), 'src/app/api/auth/microsoft/callback/route.ts'),
-      'utf8'
-    );
-    const adapter = readFileSync(
-      resolve(process.cwd(), '../shared/services/email/providers/MicrosoftGraphAdapter.ts'),
-      'utf8'
-    );
-    const scopes = readFileSync(
-      resolve(process.cwd(), '../shared/services/email/microsoftGraphEndpoints.ts'),
-      'utf8'
-    );
+  it('requests inbound, outbound, user, and offline access through the common authority', () => {
+    const redirectUri = 'https://example.test/api/auth/microsoft/callback';
+    const authUrl = new URL(generateMicrosoftAuthUrl('platform-client', redirectUri, {
+      tenant: 'tenant-id',
+      redirectUri,
+      timestamp: Date.now(),
+      nonce: 'nonce',
+    }));
 
-    expect(scopes).toContain("'https://graph.microsoft.com/Mail.Send'");
-    expect(callback).toContain("scope: MICROSOFT_EMAIL_OAUTH_SCOPES.join(' ')");
-    expect(adapter).toContain("scope: MICROSOFT_EMAIL_OAUTH_SCOPES.join(' ')");
+    expect(authUrl.origin).toBe('https://login.microsoftonline.com');
+    expect(authUrl.pathname).toBe('/common/oauth2/v2.0/authorize');
+    expect(authUrl.searchParams.get('redirect_uri')).toBe(redirectUri);
+    expect(new Set(authUrl.searchParams.get('scope')?.split(' '))).toEqual(new Set([
+      'https://graph.microsoft.com/Mail.Read',
+      'https://graph.microsoft.com/Mail.Read.Shared',
+      'https://graph.microsoft.com/Mail.Send',
+      'https://graph.microsoft.com/User.Read',
+      'offline_access',
+    ]));
   });
 });

--- a/shared/services/email/providers/MicrosoftGraphAdapter.ts
+++ b/shared/services/email/providers/MicrosoftGraphAdapter.ts
@@ -14,10 +14,22 @@ import { tenantDb } from '@alga-psa/db';
 import {
   getMicrosoftGraphBaseUrl,
   getMicrosoftTokenUrl,
-  MICROSOFT_EMAIL_OAUTH_SCOPES,
 } from '../microsoftGraphEndpoints';
 
 export type MicrosoftSubscriptionErrorKind = 'validation' | 'authentication' | 'other';
+
+function getAccessTokenTenantId(accessToken: string | undefined): string | undefined {
+  try {
+    const payload = accessToken?.split('.')[1];
+    if (!payload) return undefined;
+    const claims = JSON.parse(Buffer.from(payload, 'base64url').toString('utf8'));
+    return typeof claims?.tid === 'string' && claims.tid.trim()
+      ? claims.tid.trim()
+      : undefined;
+  } catch {
+    return undefined;
+  }
+}
 
 export class MicrosoftSubscriptionError extends Error {
   constructor(
@@ -324,9 +336,13 @@ export class MicrosoftGraphAdapter extends BaseEmailAdapter {
         throw new Error('Microsoft OAuth credentials not configured');
       }
 
-      // Determine tenant authority for single-tenant apps
+      // The token's tid is the directory that issued the refresh grant. Legacy
+      // hosted providers stored the platform app's home tenant in tenant_id,
+      // which is not the customer's token authority and causes OAuth 400s.
       const vendorTenantId = vendorConfig.resolved_tenant_id || vendorConfig.tenant_id || vendorConfig.tenantId;
-      let tenantAuthority = vendorTenantId || process.env.MICROSOFT_TENANT_ID;
+      let tenantAuthority = getAccessTokenTenantId(this.accessToken)
+        || vendorTenantId
+        || process.env.MICROSOFT_TENANT_ID;
       if (!tenantAuthority) {
         try {
           const secretProvider = await getSecretProviderInstance();
@@ -344,7 +360,6 @@ export class MicrosoftGraphAdapter extends BaseEmailAdapter {
         client_secret: clientSecret,
         refresh_token: this.refreshToken,
         grant_type: 'refresh_token',
-        scope: MICROSOFT_EMAIL_OAUTH_SCOPES.join(' '),
       });
 
       const response = await axios.post(tokenUrl, params.toString(), {

--- a/shared/services/email/providers/MicrosoftGraphAdapter.ts
+++ b/shared/services/email/providers/MicrosoftGraphAdapter.ts
@@ -336,13 +336,18 @@ export class MicrosoftGraphAdapter extends BaseEmailAdapter {
         throw new Error('Microsoft OAuth credentials not configured');
       }
 
-      // The token's tid is the directory that issued the refresh grant. Legacy
-      // hosted providers stored the platform app's home tenant in tenant_id,
-      // which is not the customer's token authority and causes OAuth 400s.
       const vendorTenantId = vendorConfig.resolved_tenant_id || vendorConfig.tenant_id || vendorConfig.tenantId;
-      let tenantAuthority = getAccessTokenTenantId(this.accessToken)
-        || vendorTenantId
-        || process.env.MICROSOFT_TENANT_ID;
+      const isHosted = (process.env.DEPLOYMENT_PROFILE || 'hosted').trim().toLowerCase() !== 'appliance';
+
+      // Hosted uses Alga's shared multi-tenant Microsoft app, so preserve the
+      // tenant-independent authority used when the refresh grant was issued.
+      // Appliance deployments use a customer-owned, normally single-tenant app
+      // and therefore require that app's concrete tenant authority.
+      let tenantAuthority = isHosted
+        ? 'common'
+        : vendorTenantId
+          || getAccessTokenTenantId(this.accessToken)
+          || process.env.MICROSOFT_TENANT_ID;
       if (!tenantAuthority) {
         try {
           const secretProvider = await getSecretProviderInstance();


### PR DESCRIPTION
## What
- refresh hosted Microsoft grants through the shared multi-tenant common authority
- retain tenant-specific refresh authority for appliance deployments
- omit scope when redeeming existing refresh tokens
- correct Temporal worker service account, startup path, selector, and application URL secret wiring

## Why
A tenant-specific authority regression caused production Microsoft subscription renewals to fail with HTTP 400. Hosted uses the Alga shared multi-tenant app, while appliance installs normally use customer-owned single-tenant apps.

## Validation
- 9 MicrosoftGraphAdapter behavioral tests
- shared and server TypeScript checks
- Temporal packaging contract and dist import smoke check
- 6 Temporal readiness tests
- Helm lint plus hosted and appliance renders
- production refresh recovery verified for Andrew and broad HTTP 400 failures reduced from 15 to 1