### PR TITLE
Fix Microsoft 365 notification email MIME corruption

### DIFF
--- a/docs/plans/2026-08-10-microsoft-graph-mime-crlf-plan.md
+++ b/docs/plans/2026-08-10-microsoft-graph-mime-crlf-plan.md
@@ -193,8 +193,9 @@ Run from the repository root:
 4. Package build:
    `npm -w packages/email run build`
 5. Relevant unchanged adapter contract test, if the shared package suite is not
-   already part of CI:
-   `npx vitest run shared/services/email/providers/__tests__/MicrosoftGraphAdapter.sendMail.test.ts`
+   already part of CI (run from the `shared` directory so the shared Vitest
+   config is picked up):
+   `npx vitest run services/email/providers/__tests__/MicrosoftGraphAdapter.sendMail.test.ts`
 
 The SMTP sink cannot reproduce this defect because SMTP transports normalize
 line endings and therefore mask the invalid MIME producer. The current

--- a/docs/plans/2026-08-10-microsoft-graph-mime-crlf-plan.md
+++ b/docs/plans/2026-08-10-microsoft-graph-mime-crlf-plan.md
@@ -1,0 +1,246 @@
+# Microsoft Graph MIME CRLF correctness
+
+**Branch:** `fix/graph-mime-crlf`
+**Date:** 2026-08-10
+**Status:** Design complete; no product or test code implemented
+
+## Outcome
+
+Compile Microsoft Graph MIME messages with RFC-standard CRLF line endings by
+changing Nodemailer's stream transport from `newline: 'unix'` to the explicit
+CRLF setting, `newline: 'windows'`. This is a MIME serialization boundary fix,
+not a content or delivery-path redesign.
+
+The fix must retain the existing reason for the MIME path: it carries branded
+From display names and headers that the Graph JSON message shape cannot safely
+preserve. It must also retain Reply-To, Message-ID, In-Reply-To, References,
+automated-message headers, attachments, and CID inline images. SMTP delivery,
+Graph JSON delivery, tenant templates, and the Graph adapter's POST contract are
+outside the change.
+
+## Problem and confirmed code path
+
+`packages/email/src/providers/MicrosoftGraphEmailProvider.ts` owns two distinct
+Graph send paths:
+
+- `buildSendPayload()` returns Graph JSON for messages that do not require a
+  branded From display name or non-`X-` headers.
+- Messages that need the richer wire representation go through
+  `buildMimeMessage()`, are compiled by a buffered Nodemailer stream transport,
+  base64 encoded, and passed to `MicrosoftGraphAdapter.sendMail()` as
+  `{ kind: 'mime', content }`.
+
+The stream transport is currently configured with `newline: 'unix'`. That
+option makes Nodemailer normalize the entire generated RFC message to bare LF,
+including quoted-printable soft line breaks (`=\n`). Exchange expects the MIME
+line boundary to be CRLF and can misdecode those soft breaks, producing visible
+equals signs, dropped characters, corrupted UTF-8, exposed hidden reply
+markers, and damaged long HTML/logo attributes.
+
+Direct inspection of the installed Nodemailer implementation confirms that its
+stream transport maps `newline: 'windows'` to its CRLF transform and
+`newline: 'unix'` to its LF transform. A local compilation probe using long
+quoted-printable HTML produced these results:
+
+| Stream option | CRLF pairs | Bare LF | QP `=\r\n` | QP `=\n` |
+| --- | ---: | ---: | ---: | ---: |
+| omitted | 27 | 0 | 7 | 0 |
+| `unix` | 0 | 27 | 0 | 7 |
+| `windows` | 27 | 0 | 7 | 0 |
+
+`shared/services/email/providers/MicrosoftGraphAdapter.ts` does not decode or
+rewrite the MIME. It posts the base64 string to the configured mailbox's
+`/sendMail` endpoint with `Content-Type: text/plain`. No adapter change is
+needed.
+
+## Chosen approach and alternatives
+
+### Chosen: explicitly force CRLF in the MIME transport
+
+Change the Nodemailer transport option in
+`packages/email/src/providers/MicrosoftGraphEmailProvider.ts` from
+`newline: 'unix'` to `newline: 'windows'`. “Windows” is Nodemailer's option name
+for CRLF serialization; the choice is about the RFC wire format, not the host
+operating system.
+
+This is the smallest deterministic fix at the boundary that creates the
+invalid bytes. Nodemailer continues to own header folding, multipart
+boundaries, quoted-printable encoding, base64 encoding, and binary attachment
+handling, while the provider states its wire-format requirement explicitly.
+
+### Alternative: remove the explicit newline option
+
+With the installed Nodemailer version, omitting `newline` currently leaves the
+composer's native CRLF output intact, so deleting the override would also repair
+the observed message. Reject this option because the RFC requirement would be
+implicit in Nodemailer's current defaults. An explicit CRLF option better
+documents and tests the Graph MIME boundary and is the same one-line scope.
+
+### Alternative: rewrite the generated Buffer after compilation
+
+Do not replace LF bytes after `sendMail()` returns. A broad byte rewrite would
+operate on an already assembled multipart document and could alter encoded or
+binary body regions, mishandle mixed CRLF/LF input, or conceal a future MIME
+compiler regression. There is no evidence that Nodemailer's supported CRLF
+mode is insufficient, so post-generation mutation adds risk without benefit.
+
+Do not switch threaded messages to Graph JSON and do not modify tenant
+templates. Those approaches would lose required identity/threading behavior or
+push a transport defect into unrelated content.
+
+## Implementation plan
+
+### 1. Correct the MIME serialization boundary
+
+File: `packages/email/src/providers/MicrosoftGraphEmailProvider.ts`
+
+1. Set the existing buffered stream transport's `newline` option to
+   `'windows'`.
+2. Leave `streamTransport: true`, `buffer: true`, MIME selection in
+   `buildSendPayload()`, mail option mapping in `buildMimeMessage()`, and base64
+   conversion unchanged.
+3. Do not add a second normalization pass or change exception handling. The
+   existing guard that requires `result.message` to be a Buffer remains the
+   failure boundary.
+
+### 2. Add a wire-format and semantic regression test
+
+Files:
+
+- `packages/email/src/providers/__tests__/MicrosoftGraphEmailProvider.test.ts`
+- `packages/email/package.json`
+- `package-lock.json`
+
+Add `mailparser` and its types as package-local development dependencies,
+matching repository versions, rather than relying on workspace hoisting. Use
+`simpleParser` in the provider test to validate the complete MIME document as a
+recipient parser would. Configure it with `skipImageLinks: true` so it does not
+replace CID URLs with data URLs before the exact-HTML assertion.
+
+Extend the existing MIME behavioral coverage with one representative message
+that deliberately forces quoted-printable wrapping and header folding:
+
+- long inline-styled HTML;
+- the production-shaped hidden `data-alga-reply-token`, ticket/comment ID, and
+  `data-alga-reply-boundary` elements;
+- a long CID logo reference plus a matching inline image attachment;
+- a separate ordinary attachment with known bytes;
+- the UTF-8 middle dot (`·`) in both HTML and plain text;
+- a branded From display name and the configured mailbox address;
+- named Reply-To;
+- Message-ID, In-Reply-To, and a long multi-value References header;
+- `Auto-Submitted: auto-generated` and
+  `X-Auto-Response-Suppress: OOF, AutoReply, AutoForward`.
+
+After the mocked adapter captures the MIME payload:
+
+1. Decode `payload.content` from base64 to the raw RFC message Buffer.
+2. Assert the message contains CRLF, every LF byte is immediately preceded by
+   CR, and there are no bare LF bytes anywhere. Include a fixture long enough
+   to prove a quoted-printable soft wrap exists as `=\r\n`, and assert no
+   `=\n` soft wrap exists without the preceding CR.
+3. Parse the raw Buffer with
+   `simpleParser(rawMime, { skipImageLinks: true })` and assert the decoded
+   `.html` and `.text` exactly equal the original inputs. This
+   checks that transfer decoding restores the entire inline style, hidden ALGA
+   marker, long logo CID, and UTF-8 middle dot rather than merely finding
+   selected substrings.
+4. Assert parsed sender address/display name, Reply-To, recipients, subject,
+   Message-ID, In-Reply-To, ordered References values, and automated-message
+   headers.
+5. Assert both attachments retain filename, content type, disposition/CID as
+   applicable, and byte-for-byte content.
+
+Retain the existing nameless/headerless Graph JSON test unchanged as a branch
+guard. Retain the existing MIME branding and threading assertions unless the
+new behavioral test cleanly subsumes only redundant string checks. Do not
+modify SMTP provider tests or Graph adapter tests: their unchanged suites serve
+as regression evidence that routing and transport contracts did not move.
+
+Avoid assertions on generated MIME boundary strings, Date, exact header-fold
+positions, or whether Nodemailer selects quoted-printable versus base64 for
+content generally. Those are library implementation details; line-ending
+validity and decoded semantics are the contract.
+
+## Error and risk handling
+
+- The change introduces no new runtime branch and no fallback that could send a
+  partially rewritten message. Existing initialization, authorization,
+  attachment-size, adapter retry, and provider-error behavior remains intact.
+- Explicit CRLF normalization applies only to the Graph MIME compiler. SMTP
+  continues to use its own transport normalization, and Graph JSON never enters
+  this compiler.
+- Tests inspect bytes before Graph receives them. This isolates the producer
+  invariant and prevents a tolerant parser from hiding bare-LF output.
+- Parsing is a second, semantic assertion rather than a substitute for the raw
+  byte check. `skipImageLinks` is required to keep mailparser's convenience CID
+  rewriting from making correct HTML appear different.
+- Attachment and inline-image bytes are asserted after parsing because this is
+  the content most likely to be endangered by an overly broad rewrite. The
+  chosen transport option lets Nodemailer normalize framing without a provider
+  touching completed MIME bytes.
+
+## Verification and smoke plan
+
+Run from the repository root:
+
+1. Focused provider regression:
+   `npm -w packages/email test -- src/providers/__tests__/MicrosoftGraphEmailProvider.test.ts`
+2. Full email package suite:
+   `npm -w packages/email test`
+3. Package typecheck:
+   `npm -w packages/email run typecheck`
+4. Package build:
+   `npm -w packages/email run build`
+5. Relevant unchanged adapter contract test, if the shared package suite is not
+   already part of CI:
+   `npx vitest run shared/services/email/providers/__tests__/MicrosoftGraphAdapter.sendMail.test.ts`
+
+The SMTP sink cannot reproduce this defect because SMTP transports normalize
+line endings and therefore mask the invalid MIME producer. The current
+Microsoft Graph emulator covers OAuth and inbound mailbox/subscription routes
+but has no `/users/:mailbox/sendMail` endpoint, so it cannot establish Exchange
+MIME acceptance or rendering. Expanding either emulator is not warranted for
+this one-line boundary correction.
+
+When a connected Microsoft 365 test mailbox is available, send the same
+representative threaded/branded message through the real Graph MIME path to an
+external recipient. Confirm in the received client and downloaded raw message
+that:
+
+- no equals signs or hidden ALGA marker are visible;
+- the middle dot and surrounding UTF-8 text are intact;
+- inline styling and the CID logo render correctly;
+- ordinary and inline attachments open with their original bytes;
+- From, Reply-To, Message-ID, In-Reply-To, References, and automated-message
+  headers are present as expected;
+- the raw source parses successfully and has no bare LF in the submitted MIME
+  framing (allowing for documented server-side reserialization when comparing
+  the received copy).
+
+If real Graph credentials are unavailable, disclose that the smoke is limited
+to the wire-level fallback: the provider unit test validates the exact
+pre-POST MIME bytes and transfer-decoded content, while the adapter unit test
+validates that the base64 body is posted unchanged with Graph's required
+content type. This gives strong producer/adapter coverage but does not claim to
+prove Exchange acceptance or client rendering.
+
+## Acceptance criteria
+
+- Graph MIME messages generated by the provider contain CRLF line endings and
+  zero bare LF bytes, including quoted-printable soft wraps.
+- Parsing and transfer-decoding the representative message reproduces the
+  exact original HTML and plain text, including long inline markup, hidden ALGA
+  reply markers, the CID logo reference, and the UTF-8 middle dot.
+- Branded From, configured mailbox address, Reply-To, Message-ID, In-Reply-To,
+  References, automated-message headers, recipients, attachments, and inline
+  images survive generation and parsing.
+- Existing Graph JSON behavior and selection remain unchanged.
+- Existing SMTP behavior and the Graph adapter POST contract remain unchanged.
+- No tenant template, MIME/JSON routing rule, or post-generation byte rewrite is
+  introduced.
+- Focused tests, the full email package suite, email package typecheck/build,
+  and the relevant adapter test pass.
+- A real connected Graph smoke passes when credentials are available; otherwise
+  the handoff explicitly records the wire-parser fallback and its Exchange
+  coverage limitation.

--- a/package-lock.json
+++ b/package-lock.json
@@ -5731,9 +5731,6 @@
       "cpu": [
         "arm"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -5749,9 +5746,6 @@
       "integrity": "sha512-dqVSFynCox4C/J8kT16V7SIFAns0IjgLwkvYT7p8LQVmJ5OS5b6tI9IGflxTeuBS//zXeFIUbwt5dwxyZ17cnA==",
       "cpu": [
         "arm64"
-      ],
-      "libc": [
-        "glibc"
       ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
@@ -5769,9 +5763,6 @@
       "cpu": [
         "ppc64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -5787,9 +5778,6 @@
       "integrity": "sha512-bsb4rI+NldGOsXuej2r8OdSS8+zXDVaCWxyWrcv6kneTOlgAHtZABRzBBCwdsPiD90J4myNJuHpg6kA20ImW/w==",
       "cpu": [
         "riscv64"
-      ],
-      "libc": [
-        "glibc"
       ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
@@ -5807,9 +5795,6 @@
       "cpu": [
         "s390x"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -5825,9 +5810,6 @@
       "integrity": "sha512-ITPEtgffGJ0S6G9dRyw/366tJQqFRcHWPHhC+Stpg3Z8AEMrDrTr2lhdz4f/Y/HMbRh//7Z5mBzEpVdi62Oc3w==",
       "cpu": [
         "x64"
-      ],
-      "libc": [
-        "glibc"
       ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
@@ -5845,9 +5827,6 @@
       "cpu": [
         "arm64"
       ],
-      "libc": [
-        "musl"
-      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -5864,9 +5843,6 @@
       "cpu": [
         "x64"
       ],
-      "libc": [
-        "musl"
-      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -5882,9 +5858,6 @@
       "integrity": "sha512-affVWCTLooy8TSxbDx2qkzuDeaWLNVBA+P//FNBirHsXpP2fuBhk5AuboYUnrDnzoXes8GFjpTx0SBFOCRg+FA==",
       "cpu": [
         "arm"
-      ],
-      "libc": [
-        "glibc"
       ],
       "license": "Apache-2.0",
       "optional": true,
@@ -5908,9 +5881,6 @@
       "cpu": [
         "arm64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -5932,9 +5902,6 @@
       "integrity": "sha512-sMd8rDxmpLOwv/7N44klFjOD5DUO7FLdjiXDI0hoxYaf7Ar262dQIEkosE98bps+5HPLtp/EvNqeqQtOycP/IA==",
       "cpu": [
         "ppc64"
-      ],
-      "libc": [
-        "glibc"
       ],
       "license": "Apache-2.0",
       "optional": true,
@@ -5958,9 +5925,6 @@
       "cpu": [
         "riscv64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -5982,9 +5946,6 @@
       "integrity": "sha512-KgAxQ0DxpNOq1rG2t5cgTgShJFGSuU7XO45cqC+1NVOuZnP6tlgZRuSYOfNupGkHID0o3cJOsw4DVeJpMovcGw==",
       "cpu": [
         "s390x"
-      ],
-      "libc": [
-        "glibc"
       ],
       "license": "Apache-2.0",
       "optional": true,
@@ -6008,9 +5969,6 @@
       "cpu": [
         "x64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -6033,9 +5991,6 @@
       "cpu": [
         "arm64"
       ],
-      "libc": [
-        "musl"
-      ],
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -6057,9 +6012,6 @@
       "integrity": "sha512-6O1NPKcDVj9QEdg7Hx549EX8U0rp6yXQERqru6yRN7fGBn32UvIRJUlWnk+8xDCiG76hXVBbX82NZ/ZKr0euIg==",
       "cpu": [
         "x64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "Apache-2.0",
       "optional": true,
@@ -7955,9 +7907,6 @@
       "cpu": [
         "arm64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -7973,9 +7922,6 @@
       "integrity": "sha512-0qjhiYBaKAqF63LA1ZWAAnKTzFUguAaZiRa5etMLGGPj/B6uEVjtIZldIzFEp3wHlB0koK6aTzqPtSdplTCjoA==",
       "cpu": [
         "arm64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -7993,9 +7939,6 @@
       "cpu": [
         "x64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -8011,9 +7954,6 @@
       "integrity": "sha512-qSjL/uppm+cbh21s72Ss8gkiOhQ4dExWHNGOWy6eZV7STj5WsKehgxT61beSsOj+YYQuTplL376lOCdMQU5T8w==",
       "cpu": [
         "x64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -8652,9 +8592,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -8669,9 +8606,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -8686,9 +8620,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -8703,9 +8634,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -46700,7 +46628,7 @@
     },
     "packages/core": {
       "name": "@alga-psa/core",
-      "version": "1.4.0",
+      "version": "1.4.2",
       "dependencies": {
         "dotenv": "^16.4.5",
         "node-vault": "^0.10.2",
@@ -46875,6 +46803,8 @@
         "nodemailer": "^9.0.3"
       },
       "devDependencies": {
+        "@types/mailparser": "^3.4.6",
+        "mailparser": "^3.9.8",
         "tsup": "^8.0.0",
         "typescript": "^5.7.3"
       }
@@ -48988,11 +48918,7 @@
         "typescript": "^5.3.0"
       }
     },
-    "sdk": {
-      "dev": true,
-      "optional": true,
-      "peer": true
-    },
+    "sdk": {},
     "sdk/alga-cli": {
       "name": "@alga-psa/cli",
       "version": "0.2.0",
@@ -49996,7 +49922,7 @@
       }
     },
     "server": {
-      "version": "1.4.0",
+      "version": "1.4.2",
       "license": "ISC",
       "dependencies": {
         "@alga-psa/authorization": "*",

--- a/package-lock.json
+++ b/package-lock.json
@@ -5731,6 +5731,9 @@
       "cpu": [
         "arm"
       ],
+      "libc": [
+        "glibc"
+      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -5746,6 +5749,9 @@
       "integrity": "sha512-dqVSFynCox4C/J8kT16V7SIFAns0IjgLwkvYT7p8LQVmJ5OS5b6tI9IGflxTeuBS//zXeFIUbwt5dwxyZ17cnA==",
       "cpu": [
         "arm64"
+      ],
+      "libc": [
+        "glibc"
       ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
@@ -5763,6 +5769,9 @@
       "cpu": [
         "ppc64"
       ],
+      "libc": [
+        "glibc"
+      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -5778,6 +5787,9 @@
       "integrity": "sha512-bsb4rI+NldGOsXuej2r8OdSS8+zXDVaCWxyWrcv6kneTOlgAHtZABRzBBCwdsPiD90J4myNJuHpg6kA20ImW/w==",
       "cpu": [
         "riscv64"
+      ],
+      "libc": [
+        "glibc"
       ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
@@ -5795,6 +5807,9 @@
       "cpu": [
         "s390x"
       ],
+      "libc": [
+        "glibc"
+      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -5810,6 +5825,9 @@
       "integrity": "sha512-ITPEtgffGJ0S6G9dRyw/366tJQqFRcHWPHhC+Stpg3Z8AEMrDrTr2lhdz4f/Y/HMbRh//7Z5mBzEpVdi62Oc3w==",
       "cpu": [
         "x64"
+      ],
+      "libc": [
+        "glibc"
       ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
@@ -5827,6 +5845,9 @@
       "cpu": [
         "arm64"
       ],
+      "libc": [
+        "musl"
+      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -5843,6 +5864,9 @@
       "cpu": [
         "x64"
       ],
+      "libc": [
+        "musl"
+      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -5858,6 +5882,9 @@
       "integrity": "sha512-affVWCTLooy8TSxbDx2qkzuDeaWLNVBA+P//FNBirHsXpP2fuBhk5AuboYUnrDnzoXes8GFjpTx0SBFOCRg+FA==",
       "cpu": [
         "arm"
+      ],
+      "libc": [
+        "glibc"
       ],
       "license": "Apache-2.0",
       "optional": true,
@@ -5881,6 +5908,9 @@
       "cpu": [
         "arm64"
       ],
+      "libc": [
+        "glibc"
+      ],
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -5902,6 +5932,9 @@
       "integrity": "sha512-sMd8rDxmpLOwv/7N44klFjOD5DUO7FLdjiXDI0hoxYaf7Ar262dQIEkosE98bps+5HPLtp/EvNqeqQtOycP/IA==",
       "cpu": [
         "ppc64"
+      ],
+      "libc": [
+        "glibc"
       ],
       "license": "Apache-2.0",
       "optional": true,
@@ -5925,6 +5958,9 @@
       "cpu": [
         "riscv64"
       ],
+      "libc": [
+        "glibc"
+      ],
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -5946,6 +5982,9 @@
       "integrity": "sha512-KgAxQ0DxpNOq1rG2t5cgTgShJFGSuU7XO45cqC+1NVOuZnP6tlgZRuSYOfNupGkHID0o3cJOsw4DVeJpMovcGw==",
       "cpu": [
         "s390x"
+      ],
+      "libc": [
+        "glibc"
       ],
       "license": "Apache-2.0",
       "optional": true,
@@ -5969,6 +6008,9 @@
       "cpu": [
         "x64"
       ],
+      "libc": [
+        "glibc"
+      ],
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -5991,6 +6033,9 @@
       "cpu": [
         "arm64"
       ],
+      "libc": [
+        "musl"
+      ],
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -6012,6 +6057,9 @@
       "integrity": "sha512-6O1NPKcDVj9QEdg7Hx549EX8U0rp6yXQERqru6yRN7fGBn32UvIRJUlWnk+8xDCiG76hXVBbX82NZ/ZKr0euIg==",
       "cpu": [
         "x64"
+      ],
+      "libc": [
+        "musl"
       ],
       "license": "Apache-2.0",
       "optional": true,
@@ -7907,6 +7955,9 @@
       "cpu": [
         "arm64"
       ],
+      "libc": [
+        "glibc"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -7922,6 +7973,9 @@
       "integrity": "sha512-0qjhiYBaKAqF63LA1ZWAAnKTzFUguAaZiRa5etMLGGPj/B6uEVjtIZldIzFEp3wHlB0koK6aTzqPtSdplTCjoA==",
       "cpu": [
         "arm64"
+      ],
+      "libc": [
+        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -7939,6 +7993,9 @@
       "cpu": [
         "x64"
       ],
+      "libc": [
+        "glibc"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -7954,6 +8011,9 @@
       "integrity": "sha512-qSjL/uppm+cbh21s72Ss8gkiOhQ4dExWHNGOWy6eZV7STj5WsKehgxT61beSsOj+YYQuTplL376lOCdMQU5T8w==",
       "cpu": [
         "x64"
+      ],
+      "libc": [
+        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -8592,6 +8652,9 @@
         "arm64"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -8606,6 +8669,9 @@
         "arm64"
       ],
       "dev": true,
+      "libc": [
+        "musl"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -8620,6 +8686,9 @@
         "x64"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -8634,6 +8703,9 @@
         "x64"
       ],
       "dev": true,
+      "libc": [
+        "musl"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -46628,7 +46700,7 @@
     },
     "packages/core": {
       "name": "@alga-psa/core",
-      "version": "1.4.2",
+      "version": "1.4.0",
       "dependencies": {
         "dotenv": "^16.4.5",
         "node-vault": "^0.10.2",
@@ -48918,7 +48990,11 @@
         "typescript": "^5.3.0"
       }
     },
-    "sdk": {},
+    "sdk": {
+      "dev": true,
+      "optional": true,
+      "peer": true
+    },
     "sdk/alga-cli": {
       "name": "@alga-psa/cli",
       "version": "0.2.0",
@@ -49922,7 +49998,7 @@
       }
     },
     "server": {
-      "version": "1.4.2",
+      "version": "1.4.0",
       "license": "ISC",
       "dependencies": {
         "@alga-psa/authorization": "*",

--- a/packages/email/package.json
+++ b/packages/email/package.json
@@ -33,6 +33,8 @@
     "nodemailer": "^9.0.3"
   },
   "devDependencies": {
+    "@types/mailparser": "^3.4.6",
+    "mailparser": "^3.9.8",
     "tsup": "^8.0.0",
     "typescript": "^5.7.3"
   }

--- a/packages/email/src/providers/MicrosoftGraphEmailProvider.ts
+++ b/packages/email/src/providers/MicrosoftGraphEmailProvider.ts
@@ -56,7 +56,7 @@ export class MicrosoftGraphEmailProvider implements IEmailProvider {
   private readonly mimeTransport = nodemailer.createTransport({
     streamTransport: true,
     buffer: true,
-    newline: 'unix',
+    newline: 'windows',
   });
 
   constructor(providerId: string) {

--- a/packages/email/src/providers/__tests__/MicrosoftGraphEmailProvider.test.ts
+++ b/packages/email/src/providers/__tests__/MicrosoftGraphEmailProvider.test.ts
@@ -1,4 +1,5 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { simpleParser } from 'mailparser';
 import type { EmailMessage } from '@alga-psa/types';
 
 const { connectMock, sendMailMock, testConnectionMock } = vi.hoisted(() => ({
@@ -68,6 +69,39 @@ function message(overrides: Partial<EmailMessage> = {}): EmailMessage {
     }],
     ...overrides,
   };
+}
+
+function countSequence(buffer: Buffer, sequence: string): number {
+  const needle = Buffer.from(sequence);
+  let count = 0;
+  let index = 0;
+  while ((index = buffer.indexOf(needle, index)) !== -1) {
+    count += 1;
+    index += needle.length;
+  }
+  return count;
+}
+
+interface ParsedGraphMime {
+  html: string | false;
+  text?: string;
+  subject?: string;
+  messageId?: string;
+  inReplyTo?: string;
+  references?: string[] | string;
+  from?: { value: Array<{ address?: string; name: string }> };
+  replyTo?: { value: Array<{ address?: string; name: string }> };
+  to?: { value: Array<{ address?: string; name: string }> };
+  cc?: { value: Array<{ address?: string; name: string }> };
+  bcc?: { value: Array<{ address?: string; name: string }> };
+  headers: Map<string, unknown>;
+  attachments: Array<{
+    filename?: string;
+    contentType: string;
+    contentDisposition: string;
+    cid?: string;
+    content: Buffer;
+  }>;
 }
 
 describe('MicrosoftGraphEmailProvider', () => {
@@ -151,6 +185,110 @@ describe('MicrosoftGraphEmailProvider', () => {
     expect(mime).toContain('References: <customer-message@example.net>');
     expect(mime).toContain('Bcc: bcc@example.net');
     expect(mime).toContain('filename=notes.txt');
+  });
+
+  it('emits CRLF-clean MIME that survives parsing as a recipient would see it', async () => {
+    const html =
+      '<div style="font-family:Arial,sans-serif;color:#333333;background-color:#f7f7f7;padding:16px;border:1px solid #dddddd;border-radius:6px;max-width:640px;margin:0 auto">' +
+      '<p style="font-size:16px;line-height:1.5;margin:0 0 12px 0">Hi \u00b7 customer, your request has been updated.</p>' +
+      '<p data-alga-reply-token="a3f9c1e2-8b4d-4f6a-9c2e-5d8b1a4f7c9d" data-alga-ticket-id="ticket-1842" data-alga-comment-id="comment-99371" data-alga-reply-boundary="BEGIN-ALGA-REPLY" style="display:none">' +
+      'ALGA HIDDEN REPLY MARKER: any reply above this line is appended to ticket #1842 for the tenant billing review.' +
+      '</p>' +
+      '<p>Our team resolved this request. The endpoint at <code>10.20.30.41</code> was decommissioned and removed from monitoring; the alert rule and its associated maintenance window have both been closed out.</p>' +
+      '<img src="cid:alga-logo@example.com" alt="Alga" width="180" height="60" style="margin-top:16px;display:block"/>' +
+      '</div>';
+    const text = 'Hi \u00b7 customer\n\nYour ticket #1842 is resolved. Reply above this line to reopen it.\n';
+    const logoBytes = Buffer.from('89504e470d0a1a0a0000000d49484452', 'hex');
+    const pdfBytes = Buffer.from([0x25, 0x50, 0x44, 0x46, 0x2d, 0x31, 0x2e, 0x34, 0x00, 0xff, 0xfe, 0x01]);
+    const references = [
+      '<customer-message-1234567890@example.net>',
+      '<support-message-000001@example.com>',
+      '<support-message-000002@example.com>',
+      '<support-message-000003@example.com>',
+    ];
+    const fromName = 'Example MSP Support';
+
+    const provider = new MicrosoftGraphEmailProvider('microsoft-provider-1');
+    await provider.initialize(providerConfig());
+
+    await provider.sendEmail(message({
+      from: { email: 'ignored@example.net', name: fromName },
+      subject: 'Ticket #1842 resolved \u00b7 follow-up',
+      text,
+      html,
+      replyTo: { email: 'replies@example.com', name: 'Ticket replies' },
+      headers: {
+        'Message-ID': '<ticket-reply-1@example.com>',
+        'In-Reply-To': '<customer-message-1234567890@example.net>',
+        References: references.join(' '),
+        'Auto-Submitted': 'auto-generated',
+        'X-Auto-Response-Suppress': 'OOF, AutoReply, AutoForward',
+      },
+      attachments: [
+        {
+          filename: 'alga-logo.png',
+          content: logoBytes,
+          contentType: 'image/png',
+          cid: 'alga-logo@example.com',
+        },
+        {
+          filename: 'invoice-1842.pdf',
+          content: pdfBytes,
+          contentType: 'application/pdf',
+        },
+      ],
+    }), 'tenant-1');
+
+    expect(sendMailMock).toHaveBeenCalledOnce();
+    const payload = sendMailMock.mock.calls[0]?.[0];
+    expect(payload.kind).toBe('mime');
+    const rawMime = Buffer.from(payload.content, 'base64');
+
+    let bareLf = 0;
+    let crlf = 0;
+    for (let i = 0; i < rawMime.length; i++) {
+      if (rawMime[i] === 0x0a) {
+        if (i > 0 && rawMime[i - 1] === 0x0d) crlf += 1;
+        else bareLf += 1;
+      }
+    }
+    expect(crlf).toBeGreaterThan(0);
+    expect(bareLf).toBe(0);
+
+    const qpSoftWraps = countSequence(rawMime, '=\r\n');
+    const qpBareWraps = countSequence(rawMime, '=\n');
+    expect(qpSoftWraps).toBeGreaterThan(0);
+    expect(qpBareWraps).toBe(0);
+
+    const parsed = (await simpleParser(rawMime, { skipImageLinks: true })) as ParsedGraphMime;
+
+    expect(parsed.html).toBe(html);
+    expect(parsed.text).toBe(text);
+
+    expect(parsed.from?.value[0]).toEqual({ address: 'support+desk@example.com', name: fromName });
+    expect(parsed.replyTo?.value[0]).toEqual({ address: 'replies@example.com', name: 'Ticket replies' });
+    expect(parsed.to?.value).toEqual([{ address: 'customer@example.net', name: 'Customer' }]);
+    expect(parsed.cc?.value).toEqual([{ address: 'cc@example.net', name: '' }]);
+    expect(parsed.bcc?.value).toEqual([{ address: 'bcc@example.net', name: '' }]);
+    expect(parsed.subject).toBe('Ticket #1842 resolved \u00b7 follow-up');
+    expect(parsed.messageId).toBe('<ticket-reply-1@example.com>');
+    expect(parsed.inReplyTo).toBe('<customer-message-1234567890@example.net>');
+    expect(parsed.references).toEqual(references);
+    expect(parsed.headers.get('auto-submitted')).toBe('auto-generated');
+    expect(parsed.headers.get('x-auto-response-suppress')).toBe('OOF, AutoReply, AutoForward');
+
+    const logo = parsed.attachments.find(attachment => attachment.filename === 'alga-logo.png');
+    expect(logo).toBeDefined();
+    expect(logo!.contentType).toBe('image/png');
+    expect(logo!.contentDisposition).toBe('inline');
+    expect(logo!.cid).toBe('alga-logo@example.com');
+    expect(logo!.content.equals(logoBytes)).toBe(true);
+
+    const pdf = parsed.attachments.find(attachment => attachment.filename === 'invoice-1842.pdf');
+    expect(pdf).toBeDefined();
+    expect(pdf!.contentType).toBe('application/pdf');
+    expect(pdf!.contentDisposition).toBe('attachment');
+    expect(pdf!.content.equals(pdfBytes)).toBe(true);
   });
 
   it('requires existing connections to be re-consented for Mail.Send', async () => {


### PR DESCRIPTION
## What

Fix Microsoft 365 notification email MIME corruption.

Microsoft Graph MIME messages were serialized with bare LF line endings
(`newline: 'unix'` on Nodemailer's buffered stream transport). Exchange
expects RFC-standard CRLF line boundaries, so quoted-printable soft wraps
(`=\n`) were misdecoded on the wire — producing visible equals signs,
dropped characters, corrupted UTF-8, exposed hidden reply markers, and
damaged long HTML/logo attributes in notification emails.

This changes the transport to `newline: 'windows'` so the entire generated
RFC message uses CRLF, including QP soft wraps (`=\r\n`). It is a MIME
serialization boundary fix only: no content, delivery path, or adapter
POST contract changes. The MIME path is retained because it preserves
branded From display names and threading/automation headers that the Graph
JSON shape cannot; SMTP and Graph JSON delivery are untouched.

## Changes

- `packages/email/src/providers/MicrosoftGraphEmailProvider.ts` — switch
  stream transport from `newline: 'unix'` to `newline: 'windows'`.
- `packages/email/src/providers/__tests__/MicrosoftGraphEmailProvider.test.ts`
  — new regression test: proves zero bare LF in the compiled MIME, exact QP
  soft-wrap placement, and that a recipient-side parse (`mailparser`) recovers
  exact HTML/text, the hidden reply marker, threading + automation headers,
  CID logo, UTF-8 punctuation, branded sender, and inline-image bytes.
- `packages/email/package.json` / `package-lock.json` — add `mailparser` +
  `@types/mailparser` devDependencies for the round-trip test (minimal
  lockfile delta).
- `docs/plans/2026-08-10-microsoft-graph-mime-crlf-plan.md` — design plan.

## Smoke-test results — PASS at the highest available fidelity

In the real product on port 3372, the customer-facing **Ticket Created Client**
preview rendered intact: middle-dot/em-dash punctuation survived, with no
stray equals signs, replacement glyphs, or visible ALGA token.

No usable Microsoft 365 connection existed — the tenant uses SMTP
localhost:3025 and both saved Microsoft providers are error-state test
records — so Exchange delivery could not be tested. A direct provider MIME
capture using a stubbed Graph adapter produced 3,526 bytes with 69 CRLF, 0
bare LF, 30 valid QP soft wraps, and 0 invalid wraps. Mailparser recovered
exact HTML/text, hidden marker, CID logo, UTF-8, branded sender,
threading/automation headers, and inline-image bytes.

Focused provider tests passed 8/8; full email package 100/100; adapter 5/5;
typecheck/build passed. Graph JSON and SMTP coverage remained green.

Fidelity compromises: the card-scoped alga-dev pane was host-misbound, so the
real UI was driven through Alga Dev's remote Chromium via direct CDP; Graph was
replaced only at the final adapter boundary. Template test sending was
additionally blocked by the tenant's existing localhost default-from domain.

Evidence directory: `/tmp/alga-smoke-evidence/graph-mime-crlf-20260810-170749`. Worktree remained clean.

## Test

- `npx vitest run packages/email` — 100/100
- `npx vitest run services/email/providers/__tests__/MicrosoftGraphEmailProvider.test.ts` (from `shared/`) — 8/8
- `npx vitest run services/email/providers/__tests__/MicrosoftGraphAdapter.sendMail.test.ts` (from `shared/`) — 5/5
- Typecheck + build pass; Graph JSON and SMTP suites remain green.
