### PR TITLE
ci(i18n): let the translation checks fail

### DIFF
--- a/.github/workflows/validate-translations.yml
+++ b/.github/workflows/validate-translations.yml
@@ -19,12 +19,20 @@ on:
       - main
 
 env:
-  # Rollout switch for the three translation-quality jobs below. While 'false'
-  # they run on every PR and publish what they found, but always exit 0 — the
-  # check goes green even with findings, so nothing blocks a merge. Flip to
-  # 'true' (and add the jobs to branch protection) to make them blocking.
-  # The two key-consistency jobs are unaffected: they were already enforcing.
-  I18N_ENFORCE: 'false'
+  # The three translation-quality jobs below fail the run when they find
+  # something. Failing is not the same as blocking: `main` lists no required
+  # status checks, so a red run here is a visible signal on the PR that nobody
+  # has to wait on. Making these gate a merge means adding them to branch
+  # protection — a separate, deliberate decision, not a side effect of this
+  # flag.
+  #
+  # Set to 'false' to go back to reporting findings on a green check. That was
+  # the rollout mode, and it hid a real defect: PR 3139 carried 11 untranslated
+  # strings in five packs and showed a passing tick, because the failure was
+  # swallowed before it reached the step.
+  #
+  # The two key-consistency jobs ignore this flag; they were always enforcing.
+  I18N_ENFORCE: 'true'
 
 jobs:
   validate:


### PR DESCRIPTION
The three translation-quality jobs ran behind I18N_ENFORCE='false', which swallowed the exit code and reported findings on a green check. PR 3139 is what that costs: 11 untranslated strings across de, es, it, nl and pt — templates.statuses.* pasted in as English while fr and pl were translated — detected correctly, logged as FAILED, and displayed as a passing tick. The only trace was a line in the run summary nobody opens.

Failing is not blocking. `main` lists no required status checks, so a red run here is a signal on the PR rather than a gate; making these gate a merge means adding them to branch protection, which is a separate decision.

Verified both directions against that defect shape: enforcing exits 1, the old mode exits 0, and a clean tree still passes all three.

The Queen of Hearts had a herald who cried "ALL IS WELL" at the end of every trial, having been instructed never to alarm anyone, and so the tarts went on disappearing for a year and a day. He has been relieved of the instruction. He may now say what he sees — though he still cannot stop the procession, which was never his to stop. 👑📯🥧