### PR TITLE
Let inbound Microsoft email select its OAuth application

### DIFF
--- a/docs/plans/2026-08-10-microsoft-inbound-email-oauth-app-selection-plan.md
+++ b/docs/plans/2026-08-10-microsoft-inbound-email-oauth-app-selection-plan.md
@@ -1,0 +1,17 @@
+# Microsoft Inbound Email OAuth App Selection — Implementation Map
+
+Canonical artifacts:
+
+- [PRD](2026-08-10-microsoft-inbound-email-oauth-app-selection/PRD.md) defines behavior, invariants, compatibility, rollout, and acceptance criteria.
+- [Features](2026-08-10-microsoft-inbound-email-oauth-app-selection/features.json) is the atomic implementation checklist.
+- [Tests](2026-08-10-microsoft-inbound-email-oauth-app-selection/tests.json) is the Pareto validation suite.
+- [Scratchpad](2026-08-10-microsoft-inbound-email-oauth-app-selection/SCRATCHPAD.md) records architectural decisions, touchpoints, migration reuse, and validation commands.
+
+Implementation sequence:
+
+1. **Selection contract:** add the explicit choice DTO, eligible-profile query, hosted recommendation, guards, and stable errors.
+2. **UI:** implement explicit create/reconnect choices, current issuer display, and reconnect warning for client-ID changes.
+3. **OAuth state and callback:** sign the complete non-secret selection context, enforce nonce/purpose validation, revalidate eligibility, and atomically persist issuer plus credentials while preserving old connections on failure.
+4. **Runtime resolver:** make provider-row issuer metadata authoritative, support same-client secret rotation, and reject different-client changes pending reconnect.
+5. **Backfill:** reuse existing fields and conservatively associate only unique eligible same-client matches without touching Teams.
+6. **Tests:** execute the PostgreSQL integration, guard, state security, compatibility, migration, runtime, and UI cases in `tests.json`.

--- a/docs/plans/2026-08-10-microsoft-inbound-email-oauth-app-selection/PRD.md
+++ b/docs/plans/2026-08-10-microsoft-inbound-email-oauth-app-selection/PRD.md
@@ -1,0 +1,71 @@
+# Microsoft Inbound Email OAuth App Selection
+
+## Problem
+
+Microsoft inbound email currently resolves the tenant `Email` binding when choosing an OAuth application. That binding is not an authoritative issuer record and may point at Teams or another application. The resulting redirect URI/client mismatch can fail Microsoft authorization with `AADSTS50011`.
+
+## Goals
+
+- Require an explicit choice between the managed Microsoft application and an eligible tenant Microsoft profile when creating or reconnecting inbound email.
+- Treat the provider row's issuer identity as authoritative after connection.
+- Use the tenant `Email` binding only as the create-flow default and as a conservative legacy migration hint.
+- Allow secret rotation when the client ID is unchanged; require reconnect for every client-ID change.
+- Leave all Teams behavior, bindings, and credentials untouched.
+
+## Product behavior
+
+### Create
+
+The UI presents an explicit issuer choice. It recommends the hosted/managed application when ready and also lists eligible tenant profiles. The submitted create request carries the selected choice explicitly; the server never infers the final choice solely from the `Email` binding.
+
+### Reconnect
+
+The UI displays the current authoritative issuer and requires an explicit reconnect choice. Changing the client ID shows a warning that reconnect is required. Rotating a secret for the same client ID does not require reconnect.
+
+### Current issuer
+
+Connected providers display whether their issuer is managed or a named tenant profile, using the persisted provider-row identity rather than the current binding.
+
+## Server invariants
+
+Before authorization, the server verifies tenant ownership, active status, Microsoft provider type, `Email` capability, credential readiness, redirect readiness, and required consent configuration. Tenant profiles that are Teams-only or otherwise ineligible are rejected.
+
+OAuth state is signed and contains tenant ID, provider ID, explicit issuer choice, client ID, nonce, and purpose (`create` or `reconnect`). It never contains a client secret or secret reference.
+
+The callback verifies signature, expiry, nonce single use, tenant/provider relationship, purpose, selected profile eligibility, and that the client ID still matches the selected issuer. After token exchange, credentials and issuer metadata are persisted atomically. A failed callback preserves the previous working connection.
+
+## Persistence and compatibility
+
+Reuse the existing `microsoft_profile_id` and `client_secret_ref` migration and columns; do not introduce duplicated secret storage. For managed and legacy rows, persisted `client_id` is the authoritative issuer identifier. For tenant-profile rows, `microsoft_profile_id` identifies the profile and persisted `client_id` must agree with it.
+
+Legacy backfill is conservative: populate a tenant profile only when the existing provider client ID has exactly one eligible same-client match. Ambiguous, missing, cross-tenant, inactive, or non-Email-capable matches remain legacy rows with `client_id` authoritative. The `Email` binding may narrow a same-client candidate but may never override a different persisted client ID.
+
+## Runtime resolution
+
+Runtime token refresh and mailbox access resolve credentials from provider-authoritative issuer metadata. Same-client secret rotation may update `client_secret_ref`. A different client ID is rejected with a reconnect-required error. Binding changes cannot silently change the issuer of an existing connection.
+
+## Stable errors
+
+Expose stable machine-readable errors for invalid choice, profile not found, cross-tenant profile, inactive profile, missing Email capability, issuer not ready, consent not ready, client mismatch/reconnect required, invalid state, expired state, replayed state, and callback persistence failure. User-facing copy may evolve independently.
+
+## Rollout
+
+1. Ship DTOs, validation, signed state, callback revalidation, and atomic persistence behind the existing Microsoft inbound-email boundary.
+2. Ship provider-authoritative runtime resolution and observability for legacy fallbacks.
+3. Run conservative same-client backfill with ambiguity reporting and no Teams mutations.
+4. Enable the explicit create/reconnect UI and current-issuer display.
+5. Monitor stable error codes, authorization completion, refresh failures, and legacy fallback counts before removing compatibility paths.
+
+## Acceptance criteria
+
+- Create and reconnect require an explicit managed or eligible tenant-profile choice.
+- Hosted deployments recommend the ready managed application without silently selecting it server-side.
+- Only active, tenant-owned, Email-capable, ready and consent-ready tenant profiles are selectable.
+- Signed OAuth state includes tenant, provider, choice, client ID, nonce, and purpose, and contains no secret.
+- Callback revalidation prevents cross-tenant, stale-choice, tampered, expired, and replayed authorization.
+- Successful callbacks atomically persist tokens and authoritative issuer metadata; failures preserve old credentials.
+- Existing providers continue using their persisted issuer when the tenant `Email` binding changes.
+- Same-client secret rotation succeeds without reconnect; every client-ID change returns reconnect required.
+- Legacy backfill occurs only for a unique eligible same-client match; ambiguous rows remain unchanged.
+- Teams selection and operation are unchanged.
+- APIs return stable machine-readable error codes for all guarded failure modes.

--- a/docs/plans/2026-08-10-microsoft-inbound-email-oauth-app-selection/PRD.md
+++ b/docs/plans/2026-08-10-microsoft-inbound-email-oauth-app-selection/PRD.md
@@ -18,6 +18,8 @@ Microsoft inbound email currently resolves the tenant `Email` binding when choos
 
 The UI presents an explicit issuer choice. It recommends the hosted/managed application when ready and also lists eligible tenant profiles. The submitted create request carries the selected choice explicitly; the server never infers the final choice solely from the `Email` binding.
 
+The choice list is the only readiness surface, and it discloses progressively: every listed application is fully authorized to start sign-in, so selecting one enables authorization with no separate setup banner. Registering a tenant-owned Microsoft app is an optional path surfaced as a quiet prompt (or a pending-admin-approval status once started), and the UI warns about missing setup only when no application can be offered at all.
+
 ### Reconnect
 
 The UI displays the current authoritative issuer and requires an explicit reconnect choice. Changing the client ID shows a warning that reconnect is required. Rotating a secret for the same client ID does not require reconnect.

--- a/docs/plans/2026-08-10-microsoft-inbound-email-oauth-app-selection/SCRATCHPAD.md
+++ b/docs/plans/2026-08-10-microsoft-inbound-email-oauth-app-selection/SCRATCHPAD.md
@@ -1,0 +1,42 @@
+# Scratchpad
+
+## Chosen architecture
+
+Persist issuer identity on the inbound-email provider row and make it authoritative at callback and runtime. Creation and reconnection use an explicit managed-or-tenant-profile selection. The tenant `Email` binding supplies only a UI/default suggestion and a conservative legacy hint. OAuth state binds tenant, provider, issuer choice, client ID, nonce, and purpose; callback validation is repeated before atomic credential and issuer persistence.
+
+## Rejected alternatives
+
+- **Binding-authoritative resolution:** rejected because bindings can change independently, can reference Teams or another application, and can silently change the token issuer or trigger `AADSTS50011`.
+- **Duplicated client secrets:** rejected because it creates divergent secret lifecycles and unnecessary sensitive state. Reuse `client_secret_ref` and resolve the selected profile or managed secret through the existing secret mechanism.
+
+## Relevant paths already inspected
+
+- `server/src/components/settings/integrations/InboundEmailSettings.tsx`
+- `server/src/components/settings/integrations/MicrosoftProviderForm.tsx`
+- `server/src/lib/actions/email-actions/inboundEmailActions.ts`
+- `server/src/lib/email/microsoft/microsoftOAuth.ts`
+- `server/src/lib/email/microsoft/microsoftGraphAdapter.ts`
+- `server/src/lib/models/inboundEmailProvider.ts`
+- `server/src/lib/models/microsoftProfile.ts`
+- `server/migrations/20250626165000_add_microsoft_profile_to_inbound_email_providers.cjs`
+
+These paths identify implementation touchpoints; names should be re-confirmed immediately before implementation if repository movement occurred.
+
+## Migration reuse
+
+Reuse the existing migration-backed `microsoft_profile_id` and `client_secret_ref` fields. Treat `client_id` as authoritative for managed and legacy rows. Add only a conservative same-client data backfill if needed; do not duplicate secrets or alter Teams rows.
+
+## Worktree preservation
+
+`package-lock.json` is an unrelated user modification. Do not edit, restore, or stage it. Stage only the five planning artifacts in this plan set.
+
+## Validation commands
+
+```bash
+jq empty docs/plans/2026-08-10-microsoft-inbound-email-oauth-app-selection/features.json
+jq empty docs/plans/2026-08-10-microsoft-inbound-email-oauth-app-selection/tests.json
+jq -e 'all(.[]; .implemented == false) and ((map(.id) | unique | length) == length)' docs/plans/2026-08-10-microsoft-inbound-email-oauth-app-selection/features.json
+jq -e 'all(.[]; .implemented == false) and ((map(.id) | unique | length) == length)' docs/plans/2026-08-10-microsoft-inbound-email-oauth-app-selection/tests.json
+git diff --check
+git status --short
+```

--- a/docs/plans/2026-08-10-microsoft-inbound-email-oauth-app-selection/features.json
+++ b/docs/plans/2026-08-10-microsoft-inbound-email-oauth-app-selection/features.json
@@ -1,20 +1,110 @@
 [
-  {"id":"F001","title":"Choice DTO","description":"Define a managed-or-tenant-profile issuer choice DTO with explicit client identity.","implemented":false},
-  {"id":"F002","title":"Hosted recommendation","description":"Recommend the managed issuer when hosted configuration is ready.","implemented":false},
-  {"id":"F003","title":"Eligible tenant profiles","description":"List only active tenant-owned Microsoft profiles with Email capability and readiness.","implemented":false},
-  {"id":"F004","title":"Current issuer display","description":"Show the provider-authoritative current issuer in the inbound email UI.","implemented":false},
-  {"id":"F005","title":"Reauthorization warning","description":"Warn that changing client ID requires reconnection.","implemented":false},
-  {"id":"F006","title":"Explicit create input","description":"Require an explicit issuer choice when creating a Microsoft inbound email provider.","implemented":false},
-  {"id":"F007","title":"Explicit reconnect input","description":"Require an explicit issuer choice when reconnecting a Microsoft inbound email provider.","implemented":false},
-  {"id":"F008","title":"Tenant and capability guards","description":"Enforce ownership, active, Email capability, readiness, and consent guards.","implemented":false},
-  {"id":"F009","title":"Signed OAuth state","description":"Sign tenant, provider, choice, client ID, nonce, and purpose without secrets.","implemented":false},
-  {"id":"F010","title":"Callback revalidation","description":"Revalidate state, nonce, tenant ownership, eligibility, purpose, and client ID at callback.","implemented":false},
-  {"id":"F011","title":"Atomic issuer persistence","description":"Atomically persist tokens and authoritative issuer metadata after callback.","implemented":false},
-  {"id":"F012","title":"Old connection preservation","description":"Keep existing working credentials when authorization or callback persistence fails.","implemented":false},
-  {"id":"F013","title":"Provider-authoritative runtime resolution","description":"Resolve runtime credentials from persisted provider issuer metadata, not current bindings.","implemented":false},
-  {"id":"F014","title":"Same-client secret rotation","description":"Allow secret-reference rotation when client ID is unchanged.","implemented":false},
-  {"id":"F015","title":"Different-client rejection","description":"Reject client-ID changes with a stable reconnect-required result.","implemented":false},
-  {"id":"F016","title":"Conservative backfill","description":"Backfill only unique eligible same-client profile matches and preserve ambiguous legacy rows.","implemented":false},
-  {"id":"F017","title":"Teams isolation","description":"Ensure inbound email selection and migration never modify Teams behavior or credentials.","implemented":false},
-  {"id":"F018","title":"Stable errors","description":"Return stable machine-readable error codes for selection, state, eligibility, and persistence failures.","implemented":false}
+  {
+    "id": "F001",
+    "title": "Choice DTO",
+    "description": "Define a managed-or-tenant-profile issuer choice DTO with explicit client identity.",
+    "implemented": true
+  },
+  {
+    "id": "F002",
+    "title": "Hosted recommendation",
+    "description": "Recommend the managed issuer when hosted configuration is ready.",
+    "implemented": true
+  },
+  {
+    "id": "F003",
+    "title": "Eligible tenant profiles",
+    "description": "List only active tenant-owned Microsoft profiles with Email capability and readiness.",
+    "implemented": true
+  },
+  {
+    "id": "F004",
+    "title": "Current issuer display",
+    "description": "Show the provider-authoritative current issuer in the inbound email UI.",
+    "implemented": true
+  },
+  {
+    "id": "F005",
+    "title": "Reauthorization warning",
+    "description": "Warn that changing client ID requires reconnection.",
+    "implemented": true
+  },
+  {
+    "id": "F006",
+    "title": "Explicit create input",
+    "description": "Require an explicit issuer choice when creating a Microsoft inbound email provider.",
+    "implemented": true
+  },
+  {
+    "id": "F007",
+    "title": "Explicit reconnect input",
+    "description": "Require an explicit issuer choice when reconnecting a Microsoft inbound email provider.",
+    "implemented": true
+  },
+  {
+    "id": "F008",
+    "title": "Tenant and capability guards",
+    "description": "Enforce ownership, active, Email capability, readiness, and consent guards.",
+    "implemented": true
+  },
+  {
+    "id": "F009",
+    "title": "Signed OAuth state",
+    "description": "Sign tenant, provider, choice, client ID, nonce, and purpose without secrets.",
+    "implemented": true
+  },
+  {
+    "id": "F010",
+    "title": "Callback revalidation",
+    "description": "Revalidate state, nonce, tenant ownership, eligibility, purpose, and client ID at callback.",
+    "implemented": true
+  },
+  {
+    "id": "F011",
+    "title": "Atomic issuer persistence",
+    "description": "Atomically persist tokens and authoritative issuer metadata after callback.",
+    "implemented": true
+  },
+  {
+    "id": "F012",
+    "title": "Old connection preservation",
+    "description": "Keep existing working credentials when authorization or callback persistence fails.",
+    "implemented": true
+  },
+  {
+    "id": "F013",
+    "title": "Provider-authoritative runtime resolution",
+    "description": "Resolve runtime credentials from persisted provider issuer metadata, not current bindings.",
+    "implemented": true
+  },
+  {
+    "id": "F014",
+    "title": "Same-client secret rotation",
+    "description": "Allow secret-reference rotation when client ID is unchanged.",
+    "implemented": true
+  },
+  {
+    "id": "F015",
+    "title": "Different-client rejection",
+    "description": "Reject client-ID changes with a stable reconnect-required result.",
+    "implemented": true
+  },
+  {
+    "id": "F016",
+    "title": "Conservative backfill",
+    "description": "Backfill only unique eligible same-client profile matches and preserve ambiguous legacy rows.",
+    "implemented": true
+  },
+  {
+    "id": "F017",
+    "title": "Teams isolation",
+    "description": "Ensure inbound email selection and migration never modify Teams behavior or credentials.",
+    "implemented": true
+  },
+  {
+    "id": "F018",
+    "title": "Stable errors",
+    "description": "Return stable machine-readable error codes for selection, state, eligibility, and persistence failures.",
+    "implemented": true
+  }
 ]

--- a/docs/plans/2026-08-10-microsoft-inbound-email-oauth-app-selection/features.json
+++ b/docs/plans/2026-08-10-microsoft-inbound-email-oauth-app-selection/features.json
@@ -1,0 +1,20 @@
+[
+  {"id":"F001","title":"Choice DTO","description":"Define a managed-or-tenant-profile issuer choice DTO with explicit client identity.","implemented":false},
+  {"id":"F002","title":"Hosted recommendation","description":"Recommend the managed issuer when hosted configuration is ready.","implemented":false},
+  {"id":"F003","title":"Eligible tenant profiles","description":"List only active tenant-owned Microsoft profiles with Email capability and readiness.","implemented":false},
+  {"id":"F004","title":"Current issuer display","description":"Show the provider-authoritative current issuer in the inbound email UI.","implemented":false},
+  {"id":"F005","title":"Reauthorization warning","description":"Warn that changing client ID requires reconnection.","implemented":false},
+  {"id":"F006","title":"Explicit create input","description":"Require an explicit issuer choice when creating a Microsoft inbound email provider.","implemented":false},
+  {"id":"F007","title":"Explicit reconnect input","description":"Require an explicit issuer choice when reconnecting a Microsoft inbound email provider.","implemented":false},
+  {"id":"F008","title":"Tenant and capability guards","description":"Enforce ownership, active, Email capability, readiness, and consent guards.","implemented":false},
+  {"id":"F009","title":"Signed OAuth state","description":"Sign tenant, provider, choice, client ID, nonce, and purpose without secrets.","implemented":false},
+  {"id":"F010","title":"Callback revalidation","description":"Revalidate state, nonce, tenant ownership, eligibility, purpose, and client ID at callback.","implemented":false},
+  {"id":"F011","title":"Atomic issuer persistence","description":"Atomically persist tokens and authoritative issuer metadata after callback.","implemented":false},
+  {"id":"F012","title":"Old connection preservation","description":"Keep existing working credentials when authorization or callback persistence fails.","implemented":false},
+  {"id":"F013","title":"Provider-authoritative runtime resolution","description":"Resolve runtime credentials from persisted provider issuer metadata, not current bindings.","implemented":false},
+  {"id":"F014","title":"Same-client secret rotation","description":"Allow secret-reference rotation when client ID is unchanged.","implemented":false},
+  {"id":"F015","title":"Different-client rejection","description":"Reject client-ID changes with a stable reconnect-required result.","implemented":false},
+  {"id":"F016","title":"Conservative backfill","description":"Backfill only unique eligible same-client profile matches and preserve ambiguous legacy rows.","implemented":false},
+  {"id":"F017","title":"Teams isolation","description":"Ensure inbound email selection and migration never modify Teams behavior or credentials.","implemented":false},
+  {"id":"F018","title":"Stable errors","description":"Return stable machine-readable error codes for selection, state, eligibility, and persistence failures.","implemented":false}
+]

--- a/docs/plans/2026-08-10-microsoft-inbound-email-oauth-app-selection/tests.json
+++ b/docs/plans/2026-08-10-microsoft-inbound-email-oauth-app-selection/tests.json
@@ -1,0 +1,12 @@
+[
+  {"id":"T001","title":"Managed selection persists in PostgreSQL","description":"With real PostgreSQL, select managed issuer, complete OAuth, and verify tokens plus authoritative client ID persist atomically.","featureIds":["F001","F002","F006","F009","F010","F011"],"implemented":false},
+  {"id":"T002","title":"Tenant profile selection among multiple profiles","description":"Select one of multiple eligible tenant profiles and verify the chosen profile and client ID persist.","featureIds":["F003","F006","F008","F011"],"implemented":false},
+  {"id":"T003","title":"Cross-tenant and Teams-only guards","description":"Reject cross-tenant profiles and profiles lacking Email capability without affecting Teams.","featureIds":["F008","F017","F018"],"implemented":false},
+  {"id":"T004","title":"Binding change preserves token issuer","description":"Change the tenant Email binding after connection and verify refresh still uses the provider's persisted issuer.","featureIds":["F012","F013"],"implemented":false},
+  {"id":"T005","title":"Same-client secret rotation","description":"Rotate the secret reference for an unchanged client ID and verify refresh succeeds without reconnect.","featureIds":["F014"],"implemented":false},
+  {"id":"T006","title":"Different-client requires reconnect","description":"Attempt to change client ID without OAuth and verify stable reconnect-required rejection.","featureIds":["F005","F015","F018"],"implemented":false},
+  {"id":"T007","title":"Failed callback preserves credentials","description":"Force callback validation or persistence failure and verify old tokens and issuer metadata remain intact.","featureIds":["F010","F011","F012","F018"],"implemented":false},
+  {"id":"T008","title":"Signed-state tamper and replay rejection","description":"Reject modified signed fields and a second use of the same valid nonce.","featureIds":["F009","F010","F018"],"implemented":false},
+  {"id":"T009","title":"Conservative backfill ambiguity","description":"Backfill a unique same-client eligible profile but leave zero-match and multiple-match legacy rows unchanged.","featureIds":["F016","F017"],"implemented":false},
+  {"id":"T010","title":"UI recommendation issuer and warning","description":"Verify managed recommendation, current issuer display, explicit choices, and client-change warning across create and reconnect.","featureIds":["F002","F004","F005","F006","F007"],"implemented":false}
+]

--- a/docs/plans/2026-08-10-microsoft-inbound-email-oauth-app-selection/tests.json
+++ b/docs/plans/2026-08-10-microsoft-inbound-email-oauth-app-selection/tests.json
@@ -76,7 +76,7 @@
       "F012",
       "F018"
     ],
-    "implemented": false
+    "implemented": true
   },
   {
     "id": "T008",

--- a/docs/plans/2026-08-10-microsoft-inbound-email-oauth-app-selection/tests.json
+++ b/docs/plans/2026-08-10-microsoft-inbound-email-oauth-app-selection/tests.json
@@ -1,12 +1,115 @@
 [
-  {"id":"T001","title":"Managed selection persists in PostgreSQL","description":"With real PostgreSQL, select managed issuer, complete OAuth, and verify tokens plus authoritative client ID persist atomically.","featureIds":["F001","F002","F006","F009","F010","F011"],"implemented":false},
-  {"id":"T002","title":"Tenant profile selection among multiple profiles","description":"Select one of multiple eligible tenant profiles and verify the chosen profile and client ID persist.","featureIds":["F003","F006","F008","F011"],"implemented":false},
-  {"id":"T003","title":"Cross-tenant and Teams-only guards","description":"Reject cross-tenant profiles and profiles lacking Email capability without affecting Teams.","featureIds":["F008","F017","F018"],"implemented":false},
-  {"id":"T004","title":"Binding change preserves token issuer","description":"Change the tenant Email binding after connection and verify refresh still uses the provider's persisted issuer.","featureIds":["F012","F013"],"implemented":false},
-  {"id":"T005","title":"Same-client secret rotation","description":"Rotate the secret reference for an unchanged client ID and verify refresh succeeds without reconnect.","featureIds":["F014"],"implemented":false},
-  {"id":"T006","title":"Different-client requires reconnect","description":"Attempt to change client ID without OAuth and verify stable reconnect-required rejection.","featureIds":["F005","F015","F018"],"implemented":false},
-  {"id":"T007","title":"Failed callback preserves credentials","description":"Force callback validation or persistence failure and verify old tokens and issuer metadata remain intact.","featureIds":["F010","F011","F012","F018"],"implemented":false},
-  {"id":"T008","title":"Signed-state tamper and replay rejection","description":"Reject modified signed fields and a second use of the same valid nonce.","featureIds":["F009","F010","F018"],"implemented":false},
-  {"id":"T009","title":"Conservative backfill ambiguity","description":"Backfill a unique same-client eligible profile but leave zero-match and multiple-match legacy rows unchanged.","featureIds":["F016","F017"],"implemented":false},
-  {"id":"T010","title":"UI recommendation issuer and warning","description":"Verify managed recommendation, current issuer display, explicit choices, and client-change warning across create and reconnect.","featureIds":["F002","F004","F005","F006","F007"],"implemented":false}
+  {
+    "id": "T001",
+    "title": "Managed selection persists in PostgreSQL",
+    "description": "With real PostgreSQL, select managed issuer, complete OAuth, and verify tokens plus authoritative client ID persist atomically.",
+    "featureIds": [
+      "F001",
+      "F002",
+      "F006",
+      "F009",
+      "F010",
+      "F011"
+    ],
+    "implemented": true
+  },
+  {
+    "id": "T002",
+    "title": "Tenant profile selection among multiple profiles",
+    "description": "Select one of multiple eligible tenant profiles and verify the chosen profile and client ID persist.",
+    "featureIds": [
+      "F003",
+      "F006",
+      "F008",
+      "F011"
+    ],
+    "implemented": true
+  },
+  {
+    "id": "T003",
+    "title": "Cross-tenant and Teams-only guards",
+    "description": "Reject cross-tenant profiles and profiles lacking Email capability without affecting Teams.",
+    "featureIds": [
+      "F008",
+      "F017",
+      "F018"
+    ],
+    "implemented": true
+  },
+  {
+    "id": "T004",
+    "title": "Binding change preserves token issuer",
+    "description": "Change the tenant Email binding after connection and verify refresh still uses the provider's persisted issuer.",
+    "featureIds": [
+      "F012",
+      "F013"
+    ],
+    "implemented": true
+  },
+  {
+    "id": "T005",
+    "title": "Same-client secret rotation",
+    "description": "Rotate the secret reference for an unchanged client ID and verify refresh succeeds without reconnect.",
+    "featureIds": [
+      "F014"
+    ],
+    "implemented": true
+  },
+  {
+    "id": "T006",
+    "title": "Different-client requires reconnect",
+    "description": "Attempt to change client ID without OAuth and verify stable reconnect-required rejection.",
+    "featureIds": [
+      "F005",
+      "F015",
+      "F018"
+    ],
+    "implemented": true
+  },
+  {
+    "id": "T007",
+    "title": "Failed callback preserves credentials",
+    "description": "Force callback validation or persistence failure and verify old tokens and issuer metadata remain intact.",
+    "featureIds": [
+      "F010",
+      "F011",
+      "F012",
+      "F018"
+    ],
+    "implemented": false
+  },
+  {
+    "id": "T008",
+    "title": "Signed-state tamper and replay rejection",
+    "description": "Reject modified signed fields and a second use of the same valid nonce.",
+    "featureIds": [
+      "F009",
+      "F010",
+      "F018"
+    ],
+    "implemented": true
+  },
+  {
+    "id": "T009",
+    "title": "Conservative backfill ambiguity",
+    "description": "Backfill a unique same-client eligible profile but leave zero-match and multiple-match legacy rows unchanged.",
+    "featureIds": [
+      "F016",
+      "F017"
+    ],
+    "implemented": true
+  },
+  {
+    "id": "T010",
+    "title": "UI recommendation issuer and warning",
+    "description": "Verify managed recommendation, current issuer display, explicit choices, and client-change warning across create and reconnect.",
+    "featureIds": [
+      "F002",
+      "F004",
+      "F005",
+      "F006",
+      "F007"
+    ],
+    "implemented": true
+  }
 ]

--- a/packages/integrations/src/actions/email-actions/emailProviderActions.ts
+++ b/packages/integrations/src/actions/email-actions/emailProviderActions.ts
@@ -26,9 +26,6 @@ import { MicrosoftGraphAdapter } from '@alga-psa/shared/services/email/providers
 import type { Microsoft365DiagnosticsReport } from '@alga-psa/shared/interfaces/microsoft365-diagnostics.interfaces';
 import { buildMicrosoftEmailProviderConfig } from '@alga-psa/shared/services/email/microsoftEmailProviderConfig';
 import {
-  resolveMicrosoftConsumerProfileConfig,
-} from '../../lib/microsoftConsumerProfileResolution';
-import {
   MicrosoftEmailIssuerError,
   MICROSOFT_EMAIL_ISSUER_ERRORS,
   isSameMicrosoftClientId,
@@ -352,36 +349,27 @@ async function persistMicrosoftConfig(
   if (!config) return undefined;
   if (!tenant) throwExpectedEmailProviderError('Tenant context is required to save Microsoft email configuration');
 
-  // Resolve the intended issuing app from the explicit selection when
-  // available; otherwise fall back to the tenant Email binding (legacy callers).
-  let effectiveClientId = '';
-  let effectiveClientSecret = '';
-  let effectiveTenantId = 'common';
-  let effectiveProfileId: string | null = null;
-  let effectiveClientSecretRef: string | null = null;
-
-  if (issuer) {
-    const resolution = await resolveMicrosoftEmailIssuerChoice(tenant, issuer);
-    effectiveClientId = resolution.clientId;
-    effectiveClientSecret = resolution.clientSecret;
-    effectiveTenantId = resolution.microsoftTenantId || 'common';
-    effectiveProfileId = resolution.profileId || null;
-    effectiveClientSecretRef = resolution.clientSecretRef || null;
-  } else {
-    const microsoftProfile = await resolveMicrosoftConsumerProfileConfig(tenant, 'email', {
-      credentialPreference: 'tenant',
-    });
-    if (microsoftProfile.status !== 'ready') {
-      throwExpectedEmailProviderError(
-        microsoftProfile.message || 'Microsoft Email profile is not configured'
-      );
-    }
-    effectiveClientId = microsoftProfile.clientId || '';
-    effectiveClientSecret = microsoftProfile.clientSecret || '';
-    effectiveTenantId = microsoftProfile.microsoftTenantId || 'common';
-    effectiveProfileId = microsoftProfile.profileId || null;
-    effectiveClientSecretRef = microsoftProfile.clientSecretRef || null;
+  // An explicit issuer selection is mandatory on create/save. The server never
+  // silently falls back to the tenant Email binding for a new write: the
+  // binding may only inform the UI's default pre-selection and the documented
+  // legacy runtime backfill for pre-existing providers. A request without an
+  // explicit selection fails loudly instead of guessing the app.
+  if (!issuer) {
+    throw new MicrosoftEmailIssuerError(
+      MICROSOFT_EMAIL_ISSUER_ERRORS.ISSUER_REQUIRED,
+      'Choose which Microsoft application authorizes this mailbox before saving'
+    );
   }
+
+  // Resolve the intended issuing app from the explicit selection. This is the
+  // authoritative gate: ownership, active status, Email capability, readiness,
+  // and consent are all revalidated server-side.
+  const resolution = await resolveMicrosoftEmailIssuerChoice(tenant, issuer);
+  let effectiveClientId = resolution.clientId;
+  let effectiveClientSecret = resolution.clientSecret;
+  let effectiveTenantId = resolution.microsoftTenantId || 'common';
+  let effectiveProfileId = resolution.profileId || null;
+  let effectiveClientSecretRef = resolution.clientSecretRef || null;
 
   const effectiveRedirectUri = (await getMicrosoftEmailSetupMetadataInternal()).mailboxRedirectUri;
 

--- a/packages/integrations/src/actions/email-actions/emailProviderActions.ts
+++ b/packages/integrations/src/actions/email-actions/emailProviderActions.ts
@@ -28,13 +28,23 @@ import { buildMicrosoftEmailProviderConfig } from '@alga-psa/shared/services/ema
 import {
   resolveMicrosoftConsumerProfileConfig,
 } from '../../lib/microsoftConsumerProfileResolution';
+import {
+  MicrosoftEmailIssuerError,
+  MICROSOFT_EMAIL_ISSUER_ERRORS,
+  isSameMicrosoftClientId,
+  resolveMicrosoftEmailIssuerChoice,
+  type MicrosoftEmailIssuerChoice,
+} from '../../lib/microsoftEmailIssuerSelection';
 import { getMicrosoftEmailSetupMetadataInternal } from '../integrations/microsoftActions';
 
 type EmailProviderActionError = ActionMessageError;
 type MicrosoftEmailProviderConfigInput = Omit<
   MicrosoftEmailProviderConfig,
   'email_provider_id' | 'tenant' | 'created_at' | 'updated_at' | 'redirect_uri'
->;
+> & {
+  /** Explicit issuing-app selection carried through create/reconnect saves. */
+  issuer?: MicrosoftEmailIssuerChoice;
+};
 type EmailProviderSetupActionResult = EmailProviderSetupResult | EmailProviderActionError;
 type EmailProviderOperationErrorCode =
   | 'not_found'
@@ -58,6 +68,16 @@ class ExpectedEmailProviderActionError extends Error {
 
 function throwExpectedEmailProviderError(message: string): never {
   throw new ExpectedEmailProviderActionError(message);
+}
+
+function emailProviderActionError(
+  message: string,
+  errorCode?: string
+): EmailProviderActionError {
+  return {
+    actionError: message,
+    ...(errorCode ? { errorCode } : {}),
+  } as EmailProviderActionError;
 }
 
 function emailProviderOperationError(
@@ -314,31 +334,57 @@ function normalizeSenderDisplayName(value?: string | null): string | null {
 }
 
 /**
- * Persist Microsoft email provider configuration
+ * Persist Microsoft email provider configuration.
+ *
+ * The provider row's issuing app is authoritative. When a settings save carries
+ * no new token, the app that issued the stored refresh token is preserved;
+ * switching to a *different* client ID without a reauthorization is rejected
+ * with a stable reconnect-required error. Same-client secret rotation flows
+ * through the selected profile's secret reference.
  */
 async function persistMicrosoftConfig(
   trx: any,
   tenant: string,
   providerId: string,
-  config?: MicrosoftEmailProviderConfigInput
+  config?: MicrosoftEmailProviderConfigInput,
+  issuer?: MicrosoftEmailIssuerChoice
 ): Promise<MicrosoftEmailProviderConfig | undefined> {
   if (!config) return undefined;
   if (!tenant) throwExpectedEmailProviderError('Tenant context is required to save Microsoft email configuration');
 
-  const microsoftProfile = await resolveMicrosoftConsumerProfileConfig(tenant, 'email', {
-    credentialPreference: 'tenant',
-  });
-  if (microsoftProfile.status !== 'ready') {
-    throwExpectedEmailProviderError(
-      microsoftProfile.message || 'Microsoft Email profile is not configured'
-    );
+  // Resolve the intended issuing app from the explicit selection when
+  // available; otherwise fall back to the tenant Email binding (legacy callers).
+  let effectiveClientId = '';
+  let effectiveClientSecret = '';
+  let effectiveTenantId = 'common';
+  let effectiveProfileId: string | null = null;
+  let effectiveClientSecretRef: string | null = null;
+
+  if (issuer) {
+    const resolution = await resolveMicrosoftEmailIssuerChoice(tenant, issuer);
+    effectiveClientId = resolution.clientId;
+    effectiveClientSecret = resolution.clientSecret;
+    effectiveTenantId = resolution.microsoftTenantId || 'common';
+    effectiveProfileId = resolution.profileId || null;
+    effectiveClientSecretRef = resolution.clientSecretRef || null;
+  } else {
+    const microsoftProfile = await resolveMicrosoftConsumerProfileConfig(tenant, 'email', {
+      credentialPreference: 'tenant',
+    });
+    if (microsoftProfile.status !== 'ready') {
+      throwExpectedEmailProviderError(
+        microsoftProfile.message || 'Microsoft Email profile is not configured'
+      );
+    }
+    effectiveClientId = microsoftProfile.clientId || '';
+    effectiveClientSecret = microsoftProfile.clientSecret || '';
+    effectiveTenantId = microsoftProfile.microsoftTenantId || 'common';
+    effectiveProfileId = microsoftProfile.profileId || null;
+    effectiveClientSecretRef = microsoftProfile.clientSecretRef || null;
   }
 
-  const effectiveClientId = microsoftProfile.clientId || '';
-  const effectiveClientSecret = microsoftProfile.clientSecret || '';
-  const effectiveTenantId = microsoftProfile.microsoftTenantId || 'common';
   const effectiveRedirectUri = (await getMicrosoftEmailSetupMetadataInternal()).mailboxRedirectUri;
-  
+
   // Ensure required fields are not undefined
   if (!effectiveTenantId) {
     throwExpectedEmailProviderError('Tenant ID is required for Microsoft configuration');
@@ -349,15 +395,35 @@ async function persistMicrosoftConfig(
     .where({ email_provider_id: providerId })
     .first();
   const preserveIssuingApp = Boolean(existingConfig?.refresh_token && !config.refresh_token);
-  const pinnedClientId = preserveIssuingApp ? existingConfig.client_id : effectiveClientId;
-  const pinnedClientSecret = preserveIssuingApp ? existingConfig.client_secret : effectiveClientSecret;
-  const pinnedProfileId = preserveIssuingApp
-    ? existingConfig.microsoft_profile_id
-    : microsoftProfile.profileId || null;
-  const pinnedClientSecretRef = preserveIssuingApp
-    ? existingConfig.client_secret_ref
-    : microsoftProfile.clientSecretRef || null;
-  const pinnedTenantId = preserveIssuingApp ? existingConfig.tenant_id : effectiveTenantId;
+
+  // A plain settings save must keep the app that issued the stored refresh
+  // token. When an explicit issuer is selected, a different client ID without a
+  // fresh token is a client-ID change that requires an explicit reconnect.
+  if (
+    preserveIssuingApp &&
+    issuer &&
+    existingConfig?.client_id &&
+    !isSameMicrosoftClientId(existingConfig.client_id, effectiveClientId)
+  ) {
+    throw new MicrosoftEmailIssuerError(
+      MICROSOFT_EMAIL_ISSUER_ERRORS.CLIENT_MISMATCH_RECONNECT_REQUIRED,
+      'Reconnect the mailbox to switch Microsoft applications before saving'
+    );
+  }
+
+  let pinnedClientId = preserveIssuingApp ? existingConfig.client_id : effectiveClientId;
+  let pinnedClientSecret = preserveIssuingApp ? existingConfig.client_secret : effectiveClientSecret;
+  let pinnedProfileId = preserveIssuingApp ? existingConfig.microsoft_profile_id : effectiveProfileId;
+  let pinnedClientSecretRef = preserveIssuingApp ? existingConfig.client_secret_ref : effectiveClientSecretRef;
+  let pinnedTenantId = preserveIssuingApp ? existingConfig.tenant_id : effectiveTenantId;
+
+  if (preserveIssuingApp && issuer) {
+    // Same app, explicit choice: let the selected profile's (possibly rotated)
+    // secret and secret reference flow through so rotation needs no reconnect.
+    if (effectiveClientSecretRef) pinnedClientSecretRef = effectiveClientSecretRef;
+    if (effectiveProfileId) pinnedProfileId = effectiveProfileId;
+    if (effectiveClientSecret) pinnedClientSecret = effectiveClientSecret;
+  }
 
   // Upsert config while preserving existing sensitive/webhook fields when incoming values are NULL
   const msConfigRows = await tenantDb(trx, tenant)
@@ -683,6 +749,8 @@ export const getEmailProviders = withAuth(async (
             'tenant',
             'client_id',
             'client_secret',
+            'microsoft_profile_id',
+            'client_secret_ref',
             'tenant_id',
             'redirect_uri',
             'auto_process_emails',
@@ -807,6 +875,7 @@ export const upsertEmailProvider = withAuth(async (
   isActive: boolean;
   inboundTicketDefaultsId?: string;
   microsoftConfig?: MicrosoftEmailProviderConfigInput;
+  microsoftIssuer?: MicrosoftEmailIssuerChoice;
   googleConfig?: Omit<GoogleEmailProviderConfig, 'email_provider_id' | 'tenant' | 'created_at' | 'updated_at'>;
   imapConfig?: Omit<ImapEmailProviderConfig, 'email_provider_id' | 'tenant' | 'created_at' | 'updated_at'>;
 },
@@ -828,7 +897,8 @@ export const upsertEmailProvider = withAuth(async (
           trx,
           tenant,
           base.id,
-          data.microsoftConfig
+          data.microsoftConfig,
+          data.microsoftIssuer
         );
       } else if (data.providerType === 'google') {
         base.googleConfig = await persistGoogleConfig(trx, tenant, base.id, data.googleConfig);
@@ -909,6 +979,9 @@ export const upsertEmailProvider = withAuth(async (
     if (error instanceof ExpectedEmailProviderActionError) {
       return actionError(error.message);
     }
+    if (error instanceof MicrosoftEmailIssuerError) {
+      return emailProviderActionError(error.message, error.code);
+    }
     console.error('Unexpected failure while upserting email provider:', error);
     return actionError('Failed to save email provider. Please review the settings and try again.');
   }
@@ -926,6 +999,7 @@ export const createEmailProvider = withAuth(async (
   isActive: boolean;
   inboundTicketDefaultsId?: string;
   microsoftConfig?: MicrosoftEmailProviderConfigInput;
+  microsoftIssuer?: MicrosoftEmailIssuerChoice;
   googleConfig?: Omit<GoogleEmailProviderConfig, 'email_provider_id' | 'tenant' | 'created_at' | 'updated_at'>;
   imapConfig?: Omit<ImapEmailProviderConfig, 'email_provider_id' | 'tenant' | 'created_at' | 'updated_at'>;
 },
@@ -948,6 +1022,7 @@ export const updateEmailProvider = withAuth(async (
     isActive: boolean;
     inboundTicketDefaultsId?: string;
     microsoftConfig?: MicrosoftEmailProviderConfigInput;
+    microsoftIssuer?: MicrosoftEmailIssuerChoice;
     googleConfig?: Omit<GoogleEmailProviderConfig, 'email_provider_id' | 'tenant' | 'created_at' | 'updated_at'>;
     imapConfig?: Omit<ImapEmailProviderConfig, 'email_provider_id' | 'tenant' | 'created_at' | 'updated_at'>;
   },
@@ -969,7 +1044,8 @@ export const updateEmailProvider = withAuth(async (
           trx,
           tenant,
           base.id,
-          data.microsoftConfig
+          data.microsoftConfig,
+          data.microsoftIssuer
         );
       } else if (data.providerType === 'google') {
         base.googleConfig = await persistGoogleConfig(trx, tenant, base.id, data.googleConfig);
@@ -1049,6 +1125,9 @@ export const updateEmailProvider = withAuth(async (
   } catch (error) {
     if (error instanceof ExpectedEmailProviderActionError) {
       return actionError(error.message);
+    }
+    if (error instanceof MicrosoftEmailIssuerError) {
+      return emailProviderActionError(error.message, error.code);
     }
     console.error('Unexpected failure while updating email provider:', error);
     return actionError('Failed to update email provider. Please review the settings and try again.');

--- a/packages/integrations/src/actions/email-actions/oauthActions.test.ts
+++ b/packages/integrations/src/actions/email-actions/oauthActions.test.ts
@@ -2,10 +2,11 @@ import { afterAll, beforeEach, describe, expect, it, vi } from "vitest";
 
 const mocks = vi.hoisted(() => ({
   hasPermission: vi.fn(),
-  resolveMicrosoftConsumerProfileConfig: vi.fn(),
+  resolveMicrosoftEmailIssuerChoice: vi.fn(),
   getAppSecret: vi.fn(),
   getTenantSecret: vi.fn(),
   getMicrosoftEmailSetupMetadataInternal: vi.fn(),
+  storeMicrosoftEmailOAuthNonce: vi.fn(),
 }));
 
 vi.mock("@alga-psa/auth", () => ({
@@ -27,13 +28,44 @@ vi.mock("@alga-psa/core/secrets", () => ({
 }));
 
 vi.mock("@alga-psa/db", () => ({
-  createTenantKnex: vi.fn(),
-  tenantDb: vi.fn(),
+  createTenantKnex: async () => ({ knex: {} }),
+  tenantDb: () => ({
+    table: () => ({
+      where: () => ({ first: async () => ({ id: "provider-1" }) }),
+    }),
+  }),
 }));
 
-vi.mock("../../lib/microsoftConsumerProfileResolution", () => ({
-  resolveMicrosoftConsumerProfileConfig: (...args: unknown[]) =>
-    mocks.resolveMicrosoftConsumerProfileConfig(...args),
+vi.mock("../../lib/microsoftEmailIssuerSelection", () => ({
+  resolveMicrosoftEmailIssuerChoice: (...args: unknown[]) =>
+    mocks.resolveMicrosoftEmailIssuerChoice(...args),
+  MicrosoftEmailIssuerError: class MicrosoftEmailIssuerError extends Error {
+    code: string;
+    constructor(code: string, message: string) {
+      super(message);
+      this.name = "MicrosoftEmailIssuerError";
+      this.code = code;
+    }
+  },
+  MICROSOFT_EMAIL_ISSUER_ERRORS: {
+    INVALID_CHOICE: "ms_email_invalid_choice",
+    PROFILE_NOT_FOUND: "ms_email_profile_not_found",
+    CROSS_TENANT_PROFILE: "ms_email_cross_tenant_profile",
+    INACTIVE_PROFILE: "ms_email_inactive_profile",
+    MISSING_EMAIL_CAPABILITY: "ms_email_missing_email_capability",
+    ISSUER_NOT_READY: "ms_email_issuer_not_ready",
+    CONSENT_NOT_READY: "ms_email_consent_not_ready",
+    CLIENT_MISMATCH_RECONNECT_REQUIRED: "ms_email_client_mismatch_reconnect_required",
+    INVALID_STATE: "ms_email_invalid_state",
+    EXPIRED_STATE: "ms_email_expired_state",
+    REPLAYED_STATE: "ms_email_replayed_state",
+    CALLBACK_PERSISTENCE_FAILED: "ms_email_callback_persistence_failed",
+  },
+}));
+
+vi.mock("../../utils/email/microsoftEmailOAuthStateStore", () => ({
+  storeMicrosoftEmailOAuthNonce: (...args: unknown[]) =>
+    mocks.storeMicrosoftEmailOAuthNonce(...args),
 }));
 
 vi.mock("../integrations/microsoftActions", () => ({
@@ -41,19 +73,43 @@ vi.mock("../integrations/microsoftActions", () => ({
 }));
 
 import { initiateEmailOAuth } from "./oauthActions";
+import {
+  validateMicrosoftEmailOAuthState,
+} from "../../utils/email/microsoftEmailOAuthState";
 
 const originalBaseUrl = process.env.NEXT_PUBLIC_BASE_URL;
+const originalNextAuthSecret = process.env.NEXTAUTH_SECRET;
 
-describe("initiateEmailOAuth Microsoft credential source", () => {
+const managedResolution = {
+  choice: { kind: "managed", clientId: "platform-client-id" },
+  issuerKind: "managed" as const,
+  clientId: "platform-client-id",
+  clientSecret: "platform-client-secret",
+  microsoftTenantId: "common",
+};
+
+const profileResolution = {
+  choice: { kind: "profile", profileId: "profile-1", clientId: "tenant-client-id" },
+  issuerKind: "profile" as const,
+  clientId: "tenant-client-id",
+  clientSecret: "tenant-client-secret",
+  clientSecretRef: "microsoft_profile_profile-1_client_secret",
+  microsoftTenantId: "tenant-directory-id",
+  profileId: "profile-1",
+};
+
+describe("initiateEmailOAuth Microsoft explicit issuer selection", () => {
   beforeEach(() => {
     vi.clearAllMocks();
     mocks.hasPermission.mockResolvedValue(true);
     mocks.getAppSecret.mockResolvedValue(null);
     mocks.getTenantSecret.mockResolvedValue(null);
+    mocks.storeMicrosoftEmailOAuthNonce.mockResolvedValue(undefined);
     mocks.getMicrosoftEmailSetupMetadataInternal.mockResolvedValue({
       mailboxRedirectUri: 'https://psa.example.com/api/auth/microsoft/callback',
     });
     process.env.NEXT_PUBLIC_BASE_URL = "https://psa.example.com";
+    process.env.NEXTAUTH_SECRET = "test-state-signing-secret";
   });
 
   afterAll(() => {
@@ -62,62 +118,119 @@ describe("initiateEmailOAuth Microsoft credential source", () => {
     } else {
       process.env.NEXT_PUBLIC_BASE_URL = originalBaseUrl;
     }
+    if (originalNextAuthSecret === undefined) {
+      delete process.env.NEXTAUTH_SECRET;
+    } else {
+      process.env.NEXTAUTH_SECRET = originalNextAuthSecret;
+    }
   });
 
-  it("initiates platform OAuth without tenant-owned app credentials", async () => {
-    mocks.resolveMicrosoftConsumerProfileConfig.mockResolvedValue({
-      status: "ready",
-      tenantId: "tenant-1",
-      consumerType: "email",
-      credentialSource: "app",
-      clientId: "platform-client-id",
-      clientSecret: "platform-client-secret",
-      microsoftTenantId: "common",
-    });
+  it("selects the managed app and carries a signed state with the explicit choice", async () => {
+    mocks.resolveMicrosoftEmailIssuerChoice.mockResolvedValue(managedResolution);
 
     const result = await initiateEmailOAuth({
       provider: "microsoft",
-      redirectUri: "https://attacker.example/callback",
+      providerId: "provider-1",
+      purpose: "reconnect",
+      issuer: { kind: "managed", clientId: "platform-client-id" },
     });
 
     expect(result.success).toBe(true);
     if (!result.success) return;
     expect(result.authUrl).toContain("client_id=platform-client-id");
-    expect(mocks.resolveMicrosoftConsumerProfileConfig).toHaveBeenCalledWith("tenant-1", "email", {
-      credentialPreference: "tenant",
+    expect(mocks.resolveMicrosoftEmailIssuerChoice).toHaveBeenCalledWith("tenant-1", {
+      kind: "managed",
+      clientId: "platform-client-id",
+    });
+    // The state is the signed token, not plain base64 JSON.
+    expect(result.state).toContain(".");
+    expect(mocks.storeMicrosoftEmailOAuthNonce).toHaveBeenCalledTimes(1);
+
+    const payload = validateMicrosoftEmailOAuthState({
+      token: result.state,
+      secret: process.env.NEXTAUTH_SECRET,
+    });
+    expect(payload).toMatchObject({
+      purpose: "reconnect",
+      tenant: "tenant-1",
+      userId: "user-1",
+      providerId: "provider-1",
+      issuerKind: "managed",
+      clientId: "platform-client-id",
+      redirectUri: "https://psa.example.com/api/auth/microsoft/callback",
     });
     expect(result.authUrl).toContain(encodeURIComponent('https://psa.example.com/api/auth/microsoft/callback'));
     expect(result.authUrl).not.toContain('attacker.example');
-    expect(
-      JSON.parse(Buffer.from(result.state, "base64").toString("utf8")),
-    ).toMatchObject({
-      tenant: "tenant-1",
-      microsoftCredentialSource: "platform",
-      hosted: true,
-    });
   });
 
-  it("keeps an explicit tenant app authoritative for OAuth", async () => {
-    mocks.resolveMicrosoftConsumerProfileConfig.mockResolvedValue({
-      status: "ready",
-      tenantId: "tenant-1",
-      consumerType: "email",
-      credentialSource: "binding",
-      profileId: "profile-1",
-      clientId: "tenant-client-id",
-      clientSecret: "tenant-client-secret",
-      microsoftTenantId: "tenant-directory-id",
-    });
+  it("selects an explicit tenant profile and pins its profile ID in the signed state", async () => {
+    mocks.resolveMicrosoftEmailIssuerChoice.mockResolvedValue(profileResolution);
 
     const result = await initiateEmailOAuth({
       provider: "microsoft",
+      providerId: "provider-1",
+      purpose: "reconnect",
+      issuer: { kind: "profile", profileId: "profile-1", clientId: "tenant-client-id" },
     });
 
     expect(result.success).toBe(true);
     if (!result.success) return;
     expect(result.authUrl).toContain("client_id=tenant-client-id");
-    expect(mocks.resolveMicrosoftConsumerProfileConfig).toHaveBeenCalledWith("tenant-1", "email", {
-      credentialPreference: "tenant",
+    expect(mocks.resolveMicrosoftEmailIssuerChoice).toHaveBeenCalledWith("tenant-1", {
+      kind: "profile",
+      profileId: "profile-1",
+      clientId: "tenant-client-id",
     });
+    const payload = validateMicrosoftEmailOAuthState({
+      token: result.state,
+      secret: process.env.NEXTAUTH_SECRET,
+    });
+    expect(payload).toMatchObject({
+      purpose: "reconnect",
+      issuerKind: "profile",
+      issuerProfileId: "profile-1",
+      clientId: "tenant-client-id",
+    });
+  });
+
+  it("defaults purpose to create when no provider ID is present", async () => {
+    mocks.resolveMicrosoftEmailIssuerChoice.mockResolvedValue(managedResolution);
+
+    const result = await initiateEmailOAuth({
+      provider: "microsoft",
+      issuer: { kind: "managed", clientId: "platform-client-id" },
+    });
+
+    expect(result.success).toBe(true);
+    if (!result.success) return;
+    const payload = validateMicrosoftEmailOAuthState({
+      token: result.state,
+      secret: process.env.NEXTAUTH_SECRET,
+    });
+    expect(payload?.purpose).toBe("create");
+  });
+
+  it("rejects a Teams-only (non-Email-capable) app with a stable error code", async () => {
+    const { MicrosoftEmailIssuerError, MICROSOFT_EMAIL_ISSUER_ERRORS } = await import(
+      "../../lib/microsoftEmailIssuerSelection"
+    );
+    mocks.resolveMicrosoftEmailIssuerChoice.mockRejectedValue(
+      new MicrosoftEmailIssuerError(
+        MICROSOFT_EMAIL_ISSUER_ERRORS.MISSING_EMAIL_CAPABILITY,
+        "The selected Microsoft application is not enabled for Outlook email"
+      )
+    );
+
+    const result = await initiateEmailOAuth({
+      provider: "microsoft",
+      providerId: "provider-1",
+      purpose: "reconnect",
+      issuer: { kind: "profile", profileId: "teams-profile", clientId: "teams-client-id" },
+    });
+
+    expect(result.success).toBe(false);
+    if (result.success) return;
+    expect(result.errorCode).toBe("ms_email_missing_email_capability");
+    expect(result.error).toContain("not enabled for Outlook email");
   });
 });

--- a/packages/integrations/src/actions/email-actions/oauthActions.ts
+++ b/packages/integrations/src/actions/email-actions/oauthActions.ts
@@ -6,8 +6,15 @@ import { hasPermission } from '@alga-psa/auth/rbac';
 import { createTenantKnex, tenantDb } from '@alga-psa/db';
 import { generateMicrosoftAuthUrl, generateGoogleAuthUrl, generateNonce, type OAuthState } from '../../utils/email/oauthHelpers';
 import {
-  resolveMicrosoftConsumerProfileConfig,
-} from '../../lib/microsoftConsumerProfileResolution';
+  resolveMicrosoftEmailIssuerChoice,
+  type MicrosoftEmailIssuerChoice,
+} from '../../lib/microsoftEmailIssuerSelection';
+import {
+  createMicrosoftEmailOAuthState,
+  getMicrosoftEmailOAuthSigningSecret,
+  type MicrosoftEmailOAuthPurpose,
+} from '../../utils/email/microsoftEmailOAuthState';
+import { storeMicrosoftEmailOAuthNonce } from '../../utils/email/microsoftEmailOAuthStateStore';
 import { getMicrosoftEmailSetupMetadataInternal } from '../integrations/microsoftActions';
 
 export const initiateEmailOAuth = withAuth(async (
@@ -17,8 +24,16 @@ export const initiateEmailOAuth = withAuth(async (
     provider: 'microsoft' | 'google';
     providerId?: string;
     redirectUri?: string;
+    /**
+     * Explicit issuer choice for Microsoft mailbox authorization. Required for
+     * Microsoft; the server resolves and validates it — it never infers the
+     * app from the tenant Email binding.
+     */
+    issuer?: MicrosoftEmailIssuerChoice;
+    /** create vs reconnect. Defaults to reconnect when a providerId is present. */
+    purpose?: MicrosoftEmailOAuthPurpose;
   }
-): Promise<{ success: true; authUrl: string; state: string } | { success: false; error: string }> => {
+): Promise<{ success: true; authUrl: string; state: string } | { success: false; error: string; errorCode?: string }> => {
 
   try {
     // RBAC: validate permission based on intent (create vs update)
@@ -52,18 +67,13 @@ export const initiateEmailOAuth = withAuth(async (
       // Google is always tenant-owned (CE and EE): do not fall back to app-level secrets.
       clientId = (await secretProvider.getTenantSecret(tenant, 'google_client_id')) || null;
     } else {
-      const microsoftProfile = await resolveMicrosoftConsumerProfileConfig(tenant, 'email', {
-        credentialPreference: 'tenant',
-      });
-      if (microsoftProfile.status !== 'ready') {
-        return {
-          success: false,
-          error: microsoftProfile.message || 'Microsoft Email binding is not configured',
-        };
-      }
+      // Explicit issuer selection is mandatory for Microsoft. The server
+      // resolves and validates ownership + Email capability + readiness and
+      // returns the issuing app's credentials, never the tenant binding's.
+      const resolution = await resolveMicrosoftEmailIssuerChoice(tenant, params.issuer);
 
-      clientId = microsoftProfile.clientId || null;
-      microsoftCredentialSource = microsoftProfile.credentialSource === 'app' ? 'platform' : 'tenant';
+      clientId = resolution.clientId;
+      microsoftCredentialSource = resolution.issuerKind === 'managed' ? 'platform' : 'tenant';
       effectiveRedirectUri = (await getMicrosoftEmailSetupMetadataInternal()).mailboxRedirectUri;
     }
 
@@ -96,17 +106,47 @@ export const initiateEmailOAuth = withAuth(async (
     // This allows users from any Azure AD tenant to authenticate
     const msTenantAuthority = 'common';
 
-    const authUrl = provider === 'microsoft'
-      ? generateMicrosoftAuthUrl(clientId, state.redirectUri, state, undefined as any, msTenantAuthority)
-      : generateGoogleAuthUrl(clientId, state.redirectUri, state);
+    let authUrl: string;
+    let returnedState = Buffer.from(JSON.stringify(state)).toString('base64');
 
-    return { success: true, authUrl, state: Buffer.from(JSON.stringify(state)).toString('base64') };
+    if (provider === 'microsoft' && params.issuer) {
+      // Signed state carries the complete non-secret selection context so the
+      // callback can revalidate eligibility and detect tampering/replay.
+      const signingSecret = await getMicrosoftEmailOAuthSigningSecret();
+      if (!signingSecret) {
+        return { success: false, error: 'OAuth state signing is not configured on this server.', errorCode: 'ms_email_invalid_state' };
+      }
+      const purpose: MicrosoftEmailOAuthPurpose =
+        params.purpose ?? (providerId ? 'reconnect' : 'create');
+      const signed = createMicrosoftEmailOAuthState({
+        purpose,
+        tenant,
+        userId: user.user_id,
+        providerId,
+        issuer: params.issuer,
+        clientId,
+        redirectUri: effectiveRedirectUri,
+        secret: signingSecret,
+      });
+      await storeMicrosoftEmailOAuthNonce(signed.payload.nonce);
+
+      authUrl = generateMicrosoftAuthUrl(clientId, effectiveRedirectUri, state, undefined as any, msTenantAuthority, signed.token);
+      returnedState = signed.token;
+    } else {
+      authUrl = provider === 'microsoft'
+        ? generateMicrosoftAuthUrl(clientId, state.redirectUri, state, undefined as any, msTenantAuthority)
+        : generateGoogleAuthUrl(clientId, state.redirectUri, state);
+    }
+
+    return { success: true, authUrl, state: returnedState };
   } catch (err: any) {
+    const errorCode =
+      typeof err?.code === 'string' ? err.code : undefined;
     console.error('[EmailOAuthActions] Failed to initiate OAuth', {
       provider: params.provider,
       providerId: params.providerId,
       error: err,
     });
-    return { success: false, error: 'Failed to initiate OAuth' };
+    return { success: false, error: err?.message || 'Failed to initiate OAuth', errorCode };
   }
 });

--- a/packages/integrations/src/actions/index.ts
+++ b/packages/integrations/src/actions/index.ts
@@ -122,6 +122,7 @@ export {
 export {
   getMicrosoftIntegrationStatus,
   getMicrosoftConsumerSetupStatus,
+  getMicrosoftEmailIssuerOptions,
   listMicrosoftProfiles,
   listMicrosoftConsumerBindings,
   createMicrosoftProfile,

--- a/packages/integrations/src/actions/index.ts
+++ b/packages/integrations/src/actions/index.ts
@@ -133,7 +133,8 @@ export {
   setDefaultMicrosoftProfile,
   resolveMicrosoftProfileForConsumer,
   saveMicrosoftIntegrationSettings,
-  resetMicrosoftProvidersToDisconnected
+  resetMicrosoftProvidersToDisconnected,
+  runMicrosoftEmailIssuerBackfill
 } from './integrations/microsoftActions';
 export {
   getMicrosoftEmailSetupOptions,

--- a/packages/integrations/src/actions/integrations/index.ts
+++ b/packages/integrations/src/actions/integrations/index.ts
@@ -12,7 +12,8 @@ export {
   setDefaultMicrosoftProfile,
   resolveMicrosoftProfileForConsumer,
   saveMicrosoftIntegrationSettings,
-  resetMicrosoftProvidersToDisconnected
+  resetMicrosoftProvidersToDisconnected,
+  runMicrosoftEmailIssuerBackfill
 } from './microsoftActions';
 export {
   getMicrosoftEmailSetupOptions,

--- a/packages/integrations/src/actions/integrations/microsoftActions.test.ts
+++ b/packages/integrations/src/actions/integrations/microsoftActions.test.ts
@@ -325,6 +325,7 @@ import {
   listMicrosoftConsumerBindings,
   listMicrosoftProfiles,
   resetMicrosoftProvidersToDisconnected,
+  runMicrosoftEmailIssuerBackfill,
   saveMicrosoftIntegrationSettings,
   setDefaultMicrosoftProfile,
   updateMicrosoftProfile,
@@ -797,7 +798,7 @@ describe('Microsoft integration actions', () => {
     }
   });
 
-  it('T016: the email issuer backfill does not run on the shared status read path; only the email settings flow opts in', async () => {
+  it('T016: the email issuer backfill never runs on the status read path; it runs only via the explicit mutation action', async () => {
     // A legacy email provider row whose persisted client id has exactly one
     // eligible same-client profile match — the exact shape backfill would pin.
     const legacyProfileId = 'profile-backfill-1';
@@ -830,22 +831,25 @@ describe('Microsoft integration actions', () => {
     });
     const before = JSON.stringify(microsoftEmailProviderConfigs[0]);
 
-    // Teams settings path: getMicrosoftIntegrationStatus() with default options
-    // is a pure read — zero writes to microsoft_email_provider_config rows.
-    const teamsStatus = await getMicrosoftIntegrationStatus();
-    expect(teamsStatus.success).toBe(true);
-    expect(teamsStatus.issuerBackfill).toBeUndefined();
+    // Status reads (Teams picker + email settings load) are pure reads: the
+    // backfill must NOT run and no `runIssuerBackfill` surface may exist.
+    const status = await getMicrosoftIntegrationStatus();
+    expect(status.success).toBe(true);
+    expect(status).not.toHaveProperty('issuerBackfill');
     expect(JSON.stringify(microsoftEmailProviderConfigs[0])).toBe(before);
 
-    // Microsoft email settings path opts in and receives the conservative
-    // same-client backfill.
-    const emailStatus = await getMicrosoftIntegrationStatus({ runIssuerBackfill: true });
-    expect(emailStatus.success).toBe(true);
-    expect(emailStatus.issuerBackfill).toMatchObject({ backfilled: 1 });
+    // A second status read after the explicit backfill is still a pure read.
+    const backfillResult = await runMicrosoftEmailIssuerBackfill();
+    expect(backfillResult.success).toBe(true);
+    expect(backfillResult.result).toMatchObject({ backfilled: 1 });
     expect(microsoftEmailProviderConfigs[0]).toMatchObject({
       microsoft_profile_id: legacyProfileId,
       client_secret_ref: 'ref-backfill',
     });
+    const pinnedBefore = JSON.stringify(microsoftEmailProviderConfigs[0]);
+    const readAfterBackfill = await getMicrosoftIntegrationStatus();
+    expect(readAfterBackfill.success).toBe(true);
+    expect(JSON.stringify(microsoftEmailProviderConfigs[0])).toBe(pinnedBefore);
   });
 
   it('T011/T012: reset action disconnects Microsoft email and calendar providers', async () => {

--- a/packages/integrations/src/actions/integrations/microsoftActions.test.ts
+++ b/packages/integrations/src/actions/integrations/microsoftActions.test.ts
@@ -54,6 +54,15 @@ const hoisted = vi.hoisted(() => {
     provider_type: string;
   };
 
+  type MicrosoftEmailProviderConfigRecord = {
+    tenant: string;
+    email_provider_id: string;
+    client_id: string | null;
+    microsoft_profile_id: string | null;
+    client_secret_ref: string | null;
+    tenant_id: string | null;
+  };
+
   type CalendarProviderRecord = {
     id: string;
     tenant: string;
@@ -76,6 +85,7 @@ const hoisted = vi.hoisted(() => {
     teamsIntegrations: [] as TeamsIntegrationRecord[],
     tenantAddOns: [] as Array<{ tenant: string; addon_key: string; expires_at: string | null }>,
     emailProviders: [] as EmailProviderRecord[],
+    microsoftEmailProviderConfigs: [] as MicrosoftEmailProviderConfigRecord[],
     calendarProviders: [] as CalendarProviderRecord[],
     mspSsoLoginDomains: [] as MspSsoLoginDomainRecord[],
     resetUpdates: [] as Array<{ table: string; where: Record<string, unknown>; values: Record<string, unknown> }>,
@@ -100,6 +110,9 @@ const hoisted = vi.hoisted(() => {
       }
       if (table === 'email_providers') {
         return state.emailProviders;
+      }
+      if (table === 'microsoft_email_provider_config') {
+        return state.microsoftEmailProviderConfigs;
       }
       if (table === 'calendar_providers') {
         return state.calendarProviders;
@@ -157,6 +170,11 @@ const hoisted = vi.hoisted(() => {
             state.emailProviders.push(clone(row) as EmailProviderRecord);
           });
         }
+        if (table === 'microsoft_email_provider_config') {
+          rows.forEach((row) => {
+            state.microsoftEmailProviderConfigs.push(clone(row) as MicrosoftEmailProviderConfigRecord);
+          });
+        }
         if (table === 'calendar_providers') {
           rows.forEach((row) => {
             state.calendarProviders.push(clone(row) as CalendarProviderRecord);
@@ -171,22 +189,18 @@ const hoisted = vi.hoisted(() => {
         return rows.length;
       },
       async update(values: Record<string, unknown>) {
-        if (
-          table === 'microsoft_profiles' ||
-          table === 'microsoft_profile_consumer_bindings' ||
-          table === 'teams_integrations'
-        ) {
-          const rows = filteredRows();
-          rows.forEach((row) => Object.assign(row, values));
-          return rows.length;
-        }
+        // Mutate in-memory rows for every backed table so backfill/status
+        // writes are observable, and always record the write so the reset
+        // contract assertions (T011/T012) keep passing.
+        const rows = filteredRows();
+        rows.forEach((row) => Object.assign(row, values));
 
         state.resetUpdates.push({
           table,
           where: Object.assign({}, ...filters),
           values: clone(values),
         });
-        return 1;
+        return rows.length || 1;
       },
       async delete() {
         const rows = filteredRows();
@@ -259,6 +273,7 @@ const {
   teamsIntegrations,
   tenantAddOns,
   emailProviders,
+  microsoftEmailProviderConfigs,
   calendarProviders,
   mspSsoLoginDomains,
 } = hoisted.state;
@@ -327,6 +342,7 @@ describe('Microsoft integration actions', () => {
     tenantAddOns.length = 0;
     tenantAddOns.push({ tenant: 'tenant-1', addon_key: 'teams', expires_at: null });
     emailProviders.length = 0;
+    microsoftEmailProviderConfigs.length = 0;
     calendarProviders.length = 0;
     mspSsoLoginDomains.length = 0;
     resetUpdates.length = 0;
@@ -779,6 +795,57 @@ describe('Microsoft integration actions', () => {
         process.env.NEXT_PUBLIC_EDITION = originalEdition;
       }
     }
+  });
+
+  it('T016: the email issuer backfill does not run on the shared status read path; only the email settings flow opts in', async () => {
+    // A legacy email provider row whose persisted client id has exactly one
+    // eligible same-client profile match — the exact shape backfill would pin.
+    const legacyProfileId = 'profile-backfill-1';
+    microsoftProfiles.push({
+      tenant: 'tenant-1',
+      profile_id: legacyProfileId,
+      display_name: 'Legacy Match App',
+      display_name_normalized: 'legacy match app',
+      client_id: 'legacy-email-app',
+      tenant_id: 'tenant-guid',
+      client_secret_ref: 'ref-backfill',
+      capabilities: JSON.stringify(['email']),
+      is_default: true,
+      is_archived: false,
+      archived_at: null,
+      created_by: null,
+      updated_by: null,
+      created_at: new Date(),
+      updated_at: new Date(),
+    });
+    tenantSecrets.set('tenant-1:ref-backfill', 'secret-value');
+    emailProviders.push({ id: 'provider-1', tenant: 'tenant-1', provider_type: 'microsoft' });
+    microsoftEmailProviderConfigs.push({
+      tenant: 'tenant-1',
+      email_provider_id: 'provider-1',
+      client_id: 'legacy-email-app',
+      microsoft_profile_id: null,
+      client_secret_ref: null,
+      tenant_id: 'common',
+    });
+    const before = JSON.stringify(microsoftEmailProviderConfigs[0]);
+
+    // Teams settings path: getMicrosoftIntegrationStatus() with default options
+    // is a pure read — zero writes to microsoft_email_provider_config rows.
+    const teamsStatus = await getMicrosoftIntegrationStatus();
+    expect(teamsStatus.success).toBe(true);
+    expect(teamsStatus.issuerBackfill).toBeUndefined();
+    expect(JSON.stringify(microsoftEmailProviderConfigs[0])).toBe(before);
+
+    // Microsoft email settings path opts in and receives the conservative
+    // same-client backfill.
+    const emailStatus = await getMicrosoftIntegrationStatus({ runIssuerBackfill: true });
+    expect(emailStatus.success).toBe(true);
+    expect(emailStatus.issuerBackfill).toMatchObject({ backfilled: 1 });
+    expect(microsoftEmailProviderConfigs[0]).toMatchObject({
+      microsoft_profile_id: legacyProfileId,
+      client_secret_ref: 'ref-backfill',
+    });
   });
 
   it('T011/T012: reset action disconnects Microsoft email and calendar providers', async () => {

--- a/packages/integrations/src/actions/integrations/microsoftActions.ts
+++ b/packages/integrations/src/actions/integrations/microsoftActions.ts
@@ -1617,16 +1617,22 @@ export const getMicrosoftEmailIssuerOptions = withAuth(async (
 
 export const getMicrosoftIntegrationStatus = withAuth(async (
   user,
-  { tenant }
+  { tenant },
+  params: { runIssuerBackfill?: boolean } = {}
 ): Promise<MicrosoftProfileStatusResponse> => {
   try {
     if (isClientPortalUser(user)) return { success: false, error: 'Forbidden' };
 
     const profiles = await listMicrosoftProfilesForTenant(tenant, (user as any)?.user_id);
-    // Conservative same-client backfill: associates a legacy provider row with a
-    // profile only when its persisted client ID has exactly one eligible
-    // match. Never touches Teams rows.
-    const backfill = await backfillMicrosoftEmailProviderIssuerMetadata(tenant);
+    // The conservative same-client issuer backfill WRITES
+    // microsoft_email_provider_config rows. It must never run on shared read
+    // paths: the Teams settings page loads this status purely to render its
+    // profile picker, so a Teams page load would otherwise mutate email
+    // provider state. Only the Microsoft email settings / inbound-email flow
+    // opts in via runIssuerBackfill: true.
+    const backfill = params.runIssuerBackfill
+      ? await backfillMicrosoftEmailProviderIssuerMetadata(tenant)
+      : undefined;
     const baseUrl = await getDeploymentBaseUrl();
     const metadata = getVisibleMicrosoftIntegrationMetadata(baseUrl);
     const mspSsoProfile = await resolveMicrosoftProfileForConsumer(tenant, 'msp_sso');

--- a/packages/integrations/src/actions/integrations/microsoftActions.ts
+++ b/packages/integrations/src/actions/integrations/microsoftActions.ts
@@ -26,6 +26,11 @@ import {
   type MicrosoftProfileConsumer,
 } from './microsoftShared';
 import { resolveMicrosoftBindingCandidateProfile } from '../../lib/microsoftConsumerProfileResolution';
+import {
+  backfillMicrosoftEmailProviderIssuerMetadata,
+  listEligibleMicrosoftEmailIssuers,
+  type MicrosoftEmailIssuerOptions,
+} from '../../lib/microsoftEmailIssuerSelection';
 
 const MICROSOFT_CLIENT_ID_SECRET = 'microsoft_client_id';
 const MICROSOFT_CLIENT_SECRET_SECRET = 'microsoft_client_secret';
@@ -161,6 +166,7 @@ export interface MicrosoftProfileStatusResponse {
   };
   emailSetup?: MicrosoftEmailSetupReadiness;
   profiles?: MicrosoftProfileSummary[];
+  issuerBackfill?: { backfilled: number; ambiguous: number; unchanged: number };
 }
 
 function maskSecret(value: string): string {
@@ -1592,6 +1598,23 @@ export const getMicrosoftConsumerSetupStatus = withAuth(async (
   }
 });
 
+export const getMicrosoftEmailIssuerOptions = withAuth(async (
+  user,
+  { tenant }
+): Promise<{ success: boolean; error?: string; issuers?: MicrosoftEmailIssuerOptions }> => {
+  try {
+    if (isClientPortalUser(user)) return { success: false, error: 'Forbidden' };
+    if (!(await canManageMicrosoftSettings(user))) return { success: false, error: 'Forbidden' };
+
+    return {
+      success: true,
+      issuers: await listEligibleMicrosoftEmailIssuers(tenant),
+    };
+  } catch (err: any) {
+    return { success: false, error: microsoftActionErrorMessage(err, 'Failed to load Microsoft email application options') };
+  }
+});
+
 export const getMicrosoftIntegrationStatus = withAuth(async (
   user,
   { tenant }
@@ -1600,6 +1623,10 @@ export const getMicrosoftIntegrationStatus = withAuth(async (
     if (isClientPortalUser(user)) return { success: false, error: 'Forbidden' };
 
     const profiles = await listMicrosoftProfilesForTenant(tenant, (user as any)?.user_id);
+    // Conservative same-client backfill: associates a legacy provider row with a
+    // profile only when its persisted client ID has exactly one eligible
+    // match. Never touches Teams rows.
+    const backfill = await backfillMicrosoftEmailProviderIssuerMetadata(tenant);
     const baseUrl = await getDeploymentBaseUrl();
     const metadata = getVisibleMicrosoftIntegrationMetadata(baseUrl);
     const mspSsoProfile = await resolveMicrosoftProfileForConsumer(tenant, 'msp_sso');
@@ -1622,6 +1649,7 @@ export const getMicrosoftIntegrationStatus = withAuth(async (
       },
       emailSetup,
       profiles: visibleProfiles,
+      issuerBackfill: backfill,
     };
   } catch (err: any) {
     return { success: false, error: microsoftActionErrorMessage(err, 'Failed to load Microsoft integration status') };

--- a/packages/integrations/src/actions/integrations/microsoftActions.ts
+++ b/packages/integrations/src/actions/integrations/microsoftActions.ts
@@ -37,6 +37,14 @@ const MICROSOFT_CLIENT_SECRET_SECRET = 'microsoft_client_secret';
 const MICROSOFT_TENANT_ID_SECRET = 'microsoft_tenant_id';
 const DEFAULT_MICROSOFT_PROFILE_NAME = 'Default Microsoft Profile';
 
+/**
+ * Stable, non-UUID sentinel used ONLY for the read-only legacy profile view
+ * synthesized on the status path when a tenant has legacy Microsoft secrets but
+ * no `microsoft_profiles` rows yet. It never corresponds to a materialized row,
+ * so it must never be passed to a mutation action as a profile id.
+ */
+const LEGACY_MICROSOFT_PROFILE_ID = 'legacy';
+
 function microsoftActionErrorMessage(error: unknown, fallback: string): string {
   const message = error instanceof Error ? error.message : '';
   if (message === 'Forbidden' || message.includes('Permission denied')) {
@@ -122,6 +130,14 @@ export interface MicrosoftProfileSummary {
   status: 'ready' | 'incomplete' | 'archived';
   archivedAt?: string | null;
   consumers: string[];
+  /**
+   * Present only on the synthesized view of legacy tenant credentials surfaced
+   * by the read-only status path. When true, the profile is NOT a materialized
+   * `microsoft_profiles` row; it is a read-only interpretation of the legacy
+   * `microsoft_client_*` tenant secrets. Its profileId must never be used as a
+   * mutation target.
+   */
+  isLegacyUnmigrated?: boolean;
 }
 
 export interface MicrosoftConsumerBindingSummary {
@@ -455,6 +471,100 @@ function hasLegacyMicrosoftConfig(values: {
   );
 }
 
+/**
+ * PURE READ: loads the legacy singleton Microsoft tenant secrets
+ * (`microsoft_client_id` / `microsoft_client_secret` / `microsoft_tenant_id`).
+ * These are the pre-profile way tenants configured Microsoft, and are the only
+ * source from which the read-only status path can surface an unmigrated legacy
+ * tenant. Never writes.
+ */
+async function readLegacyMicrosoftSecrets(
+  secretProvider: Awaited<ReturnType<typeof getSecretProviderInstance>>,
+  tenant: string
+): Promise<{ clientId: string; clientSecret: string; tenantId: string }> {
+  const [clientId, clientSecret, tenantId] = await Promise.all([
+    secretProvider.getTenantSecret(tenant, MICROSOFT_CLIENT_ID_SECRET),
+    secretProvider.getTenantSecret(tenant, MICROSOFT_CLIENT_SECRET_SECRET),
+    secretProvider.getTenantSecret(tenant, MICROSOFT_TENANT_ID_SECRET),
+  ]);
+
+  return {
+    clientId: (clientId || '').trim(),
+    clientSecret: (clientSecret || '').trim(),
+    tenantId: normalizeTenantId(tenantId),
+  };
+}
+
+/**
+ * PURE READ: which visible consumers have legacy usage that a migration would
+ * bind. Mirrors the decision made by `ensureMicrosoftConsumerBindingMigration`
+ * (msp_sso domain, email provider + client credentials, calendar provider) but
+ * performs zero writes so a status read can reflect legacy state read-only.
+ */
+async function readLegacyConsumerLabels(
+  knex: any,
+  tenant: string,
+  secretProvider: Awaited<ReturnType<typeof getSecretProviderInstance>>,
+  legacy: { clientId: string; clientSecret: string }
+): Promise<string[]> {
+  const labels: string[] = [];
+  const visibleConsumers = new Set(getVisibleMicrosoftConsumerTypes());
+
+  if (visibleConsumers.has('msp_sso') && await tenantHasLegacyMspSsoUsage(knex, tenant)) {
+    labels.push(getMicrosoftConsumerLabel('msp_sso'));
+  }
+  if (
+    visibleConsumers.has('email') &&
+    await tenantHasLegacyMicrosoftEmailUsage(knex, tenant) &&
+    Boolean((legacy.clientId || '').trim()) &&
+    Boolean((legacy.clientSecret || '').trim())
+  ) {
+    labels.push(getMicrosoftConsumerLabel('email'));
+  }
+  if (visibleConsumers.has('calendar') && await tenantHasLegacyMicrosoftCalendarUsage(knex, tenant)) {
+    labels.push(getMicrosoftConsumerLabel('calendar'));
+  }
+
+  return labels;
+}
+
+/**
+ * PURE READ: synthesizes a read-only legacy profile view from the legacy
+ * Microsoft tenant secrets WITHOUT materializing a `microsoft_profiles` row.
+ * The client secret is read straight from the legacy secret key so readiness
+ * reflects the actual legacy credential state. `isLegacyUnmigrated` marks the
+ * view so callers know the profile id is a display-only sentinel.
+ */
+async function buildLegacyMicrosoftProfileSummaryReadOnly(
+  tenant: string,
+  legacy: { clientId: string; clientSecret: string; tenantId: string },
+  secretProvider: Awaited<ReturnType<typeof getSecretProviderInstance>>,
+  knex: any
+): Promise<MicrosoftProfileSummary> {
+  const row: MicrosoftProfileRow = {
+    tenant,
+    profile_id: LEGACY_MICROSOFT_PROFILE_ID,
+    display_name: DEFAULT_MICROSOFT_PROFILE_NAME,
+    display_name_normalized: normalizeDisplayNameKey(DEFAULT_MICROSOFT_PROFILE_NAME),
+    client_id: normalizeMicrosoftClientId(legacy.clientId || ''),
+    tenant_id: legacy.tenantId,
+    client_secret_ref: MICROSOFT_CLIENT_SECRET_SECRET,
+    capabilities: [...DEFAULT_MICROSOFT_PROFILE_CAPABILITIES],
+    is_default: true,
+    is_archived: false,
+    archived_at: null,
+    created_by: null,
+    updated_by: null,
+    created_at: new Date(),
+    updated_at: new Date(),
+  };
+
+  const summary = await buildMicrosoftProfileSummary(tenant, row, secretProvider);
+  const consumers = await readLegacyConsumerLabels(knex, tenant, secretProvider, legacy);
+
+  return { ...summary, isLegacyUnmigrated: true, consumers };
+}
+
 async function mirrorLegacyMicrosoftSecrets(
   tenant: string,
   row: Pick<MicrosoftProfileRow, 'client_id' | 'tenant_id' | 'client_secret_ref'>,
@@ -557,14 +667,19 @@ async function tenantHasLegacyMicrosoftCalendarUsage(knex: any, tenant: string):
   return Boolean(provider);
 }
 
-async function ensureMicrosoftConsumerBindingMigration(
+/**
+ * PURE READ: computes the consumer→profile bindings a tenant SHOULD have —
+ * the explicitly persisted bindings plus any bindings a legacy migration would
+ * create (from msp_sso login domains, Microsoft email providers + client
+ * credentials, and Microsoft calendar providers mapped to a unique capable
+ * profile). Performs ZERO writes. Read paths use this to interpret legacy state
+ * without materializing rows; the migration wrapper inserts the missing rows.
+ */
+async function resolveExpectedMicrosoftConsumerBindingsReadOnly(
   knex: any,
   tenant: string,
-  secretProvider: Awaited<ReturnType<typeof getSecretProviderInstance>>,
-  userId?: string | null
+  secretProvider: Awaited<ReturnType<typeof getSecretProviderInstance>>
 ): Promise<MicrosoftConsumerBindingRow[]> {
-  await ensureLegacyMicrosoftProfileBackfill(knex, tenant, secretProvider, userId);
-
   const existingBindings = await getTenantMicrosoftConsumerBindings(knex, tenant);
   const now = new Date();
   const visibleConsumers = new Set(getVisibleMicrosoftConsumerTypes());
@@ -588,39 +703,65 @@ async function ensureMicrosoftConsumerBindingMigration(
   ]);
   const shouldBackfillEmail = hasLegacyEmailUsage && hasLegacyEmailClientCredentials;
 
-  const consumersToBackfill: MicrosoftProfileConsumer[] = [];
+  const result = [...existingBindings];
 
-  if (shouldBackfillMspSso) {
-    consumersToBackfill.push('msp_sso');
-  }
-  if (shouldBackfillEmail) {
-    consumersToBackfill.push('email');
-  }
-  if (shouldBackfillCalendar) {
-    consumersToBackfill.push('calendar');
-  }
+  for (const [consumerType, shouldBackfill] of [
+    ['msp_sso', shouldBackfillMspSso],
+    ['email', shouldBackfillEmail],
+    ['calendar', shouldBackfillCalendar],
+  ] as Array<[MicrosoftProfileConsumer, boolean]>) {
+    if (!shouldBackfill) {
+      continue;
+    }
 
-  for (const consumerType of consumersToBackfill) {
     const candidateProfile = await resolveMicrosoftBindingCandidateProfile(knex, tenant, secretProvider, consumerType);
     if (!candidateProfile) {
       continue;
     }
 
-    const binding: MicrosoftConsumerBindingRow = {
+    result.push({
       tenant,
       consumer_type: consumerType,
       profile_id: candidateProfile.profile_id,
+      created_by: null,
+      updated_by: null,
+      created_at: now,
+      updated_at: now,
+    });
+  }
+
+  return result;
+}
+
+async function ensureMicrosoftConsumerBindingMigration(
+  knex: any,
+  tenant: string,
+  secretProvider: Awaited<ReturnType<typeof getSecretProviderInstance>>,
+  userId?: string | null
+): Promise<MicrosoftConsumerBindingRow[]> {
+  await ensureLegacyMicrosoftProfileBackfill(knex, tenant, secretProvider, userId);
+
+  const expected = await resolveExpectedMicrosoftConsumerBindingsReadOnly(knex, tenant, secretProvider);
+  const existing = await getTenantMicrosoftConsumerBindings(knex, tenant);
+  const existingKeys = new Set(existing.map((row) => row.consumer_type));
+  const now = new Date();
+
+  for (const binding of expected) {
+    if (existingKeys.has(binding.consumer_type)) {
+      continue;
+    }
+
+    await tenantDb(knex, tenant).table('microsoft_profile_consumer_bindings').insert({
+      ...binding,
       created_by: userId || null,
       updated_by: userId || null,
       created_at: now,
       updated_at: now,
-    };
-
-    await tenantDb(knex, tenant).table('microsoft_profile_consumer_bindings').insert(binding);
-    existingBindings.push(binding);
+    });
+    existingKeys.add(binding.consumer_type);
   }
 
-  return existingBindings;
+  return expected;
 }
 
 function getVisibleConsumerLabels(
@@ -768,17 +909,39 @@ async function buildMicrosoftProfileSummary(
   };
 }
 
-async function listMicrosoftProfilesForTenant(
-  tenant: string,
-  userId?: string | null
+/**
+ * PURE READ core for listing Microsoft profiles. Reads persisted profiles and
+ * bindings directly and derives legacy-implied consumer labels without running
+ * any migration/backfill helper. Used by the status/settings read path, which
+ * must never write profile, binding, or secret rows as a page-load side effect.
+ */
+async function readMicrosoftProfilesForTenant(
+  tenant: string
 ): Promise<MicrosoftProfileSummary[]> {
   const { knex } = await createTenantKnex();
   const secretProvider = await getSecretProviderInstance();
+  return readMicrosoftProfilesWithKnex(knex, tenant, secretProvider);
+}
 
-  await ensureLegacyMicrosoftProfileBackfill(knex, tenant, secretProvider, userId);
-
+async function readMicrosoftProfilesWithKnex(
+  knex: any,
+  tenant: string,
+  secretProvider: Awaited<ReturnType<typeof getSecretProviderInstance>>
+): Promise<MicrosoftProfileSummary[]> {
   const rows = await getTenantMicrosoftProfiles(knex, tenant);
-  const bindings = await ensureMicrosoftConsumerBindingMigration(knex, tenant, secretProvider, userId);
+
+  if (rows.length === 0) {
+    const legacy = await readLegacyMicrosoftSecrets(secretProvider, tenant);
+    if (hasLegacyMicrosoftConfig(legacy)) {
+      // Legacy tenant with no migrated profile: surface the legacy credentials
+      // as an unmigrated profile view instead of misleading emptiness. No row
+      // is materialized.
+      return [await buildLegacyMicrosoftProfileSummaryReadOnly(tenant, legacy, secretProvider, knex)];
+    }
+    return [];
+  }
+
+  const bindings = await resolveExpectedMicrosoftConsumerBindingsReadOnly(knex, tenant, secretProvider);
 
   return Promise.all(rows.map((row) => {
     const consumerLabels = bindings
@@ -787,6 +950,25 @@ async function listMicrosoftProfilesForTenant(
 
     return buildMicrosoftProfileSummary(tenant, row, secretProvider, consumerLabels);
   }));
+}
+
+/**
+ * Migrate-then-read listing used by the `listMicrosoftProfiles` action. It is
+ * the explicit profile-management entry point: unlike the status read it is
+ * allowed to materialize the legacy profile and its bindings. The status read
+ * path must use `readMicrosoftProfilesForTenant` instead.
+ */
+async function listMicrosoftProfilesForTenant(
+  tenant: string,
+  userId?: string | null
+): Promise<MicrosoftProfileSummary[]> {
+  const { knex } = await createTenantKnex();
+  const secretProvider = await getSecretProviderInstance();
+
+  await ensureLegacyMicrosoftProfileBackfill(knex, tenant, secretProvider, userId);
+  await ensureMicrosoftConsumerBindingMigration(knex, tenant, secretProvider, userId);
+
+  return readMicrosoftProfilesWithKnex(knex, tenant, secretProvider);
 }
 
 async function resolveDefaultMicrosoftProfileRow(
@@ -1526,6 +1708,90 @@ export const resolveMicrosoftProfileForConsumer = async (
   return null;
 };
 
+/**
+ * PURE READ variant of `resolveMicrosoftProfileForConsumer`. Resolves the
+ * CURRENT persisted binding, plus a read-only legacy interpretation (an implied
+ * binding to a unique capable profile, or the synthesized legacy profile view
+ * when the tenant has only legacy secrets), WITHOUT running any migration or
+ * backfill helper. Status/settings reads must use this variant so a page load
+ * never writes profile or binding rows.
+ */
+export const resolveMicrosoftProfileForConsumerReadOnly = async (
+  tenant: string,
+  consumerType: string
+): Promise<MicrosoftProfileSummary | null> => {
+  if (!isSupportedMicrosoftProfileConsumer(consumerType)) {
+    return null;
+  }
+
+  const { knex } = await createTenantKnex();
+  const secretProvider = await getSecretProviderInstance();
+
+  // Explicit, persisted binding — pure read.
+  const binding = await getMicrosoftConsumerBindingRow(knex, tenant, consumerType as MicrosoftProfileConsumer);
+  if (binding) {
+    const row = await getMicrosoftProfileRow(knex, tenant, binding.profile_id);
+    if (row && !row.is_archived && profileHasCapability(row, consumerType)) {
+      return buildMicrosoftProfileSummary(tenant, row, secretProvider, [getMicrosoftConsumerLabel(consumerType as MicrosoftProfileConsumer)]);
+    }
+  }
+
+  const rows = await getTenantMicrosoftProfiles(knex, tenant);
+
+  // Legacy interpretation: an implied binding to a unique capable profile is
+  // surfaced without materializing a binding row.
+  if (rows.length > 0 && await consumerHasLegacyUsageFor(knex, tenant, secretProvider, consumerType)) {
+    const candidate = await resolveMicrosoftBindingCandidateProfile(knex, tenant, secretProvider, consumerType);
+    if (candidate) {
+      const row = rows.find((candidateRow) => candidateRow.profile_id === candidate.profile_id);
+      if (row && !row.is_archived && profileHasCapability(row, consumerType)) {
+        return buildMicrosoftProfileSummary(
+          tenant,
+          row,
+          secretProvider,
+          [getMicrosoftConsumerLabel(consumerType as MicrosoftProfileConsumer)]
+        );
+      }
+    }
+  }
+
+  // Legacy tenant with no profile rows: surface the legacy credentials as an
+  // unmigrated profile view (read-only, no rows materialized).
+  if (rows.length === 0 && consumerType !== 'teams') {
+    const legacy = await readLegacyMicrosoftSecrets(secretProvider, tenant);
+    if (
+      hasLegacyMicrosoftConfig(legacy) &&
+      await consumerHasLegacyUsageFor(knex, tenant, secretProvider, consumerType)
+    ) {
+      return buildLegacyMicrosoftProfileSummaryReadOnly(tenant, legacy, secretProvider, knex);
+    }
+  }
+
+  return null;
+};
+
+async function consumerHasLegacyUsageFor(
+  knex: any,
+  tenant: string,
+  secretProvider: Awaited<ReturnType<typeof getSecretProviderInstance>>,
+  consumerType: string
+): Promise<boolean> {
+  if (consumerType === 'msp_sso') {
+    return tenantHasLegacyMspSsoUsage(knex, tenant);
+  }
+  if (consumerType === 'email') {
+    const [hasUsage, hasCredentials] = await Promise.all([
+      tenantHasLegacyMicrosoftEmailUsage(knex, tenant),
+      tenantHasLegacyMicrosoftEmailClientCredentials(secretProvider, tenant),
+    ]);
+    return hasUsage && hasCredentials;
+  }
+  if (consumerType === 'calendar') {
+    return tenantHasLegacyMicrosoftCalendarUsage(knex, tenant);
+  }
+  return false;
+}
+
 export const getMicrosoftConsumerSetupStatus = withAuth(async (
   user,
   { tenant },
@@ -1567,7 +1833,9 @@ export const getMicrosoftConsumerSetupStatus = withAuth(async (
       };
     }
 
-    const profile = await resolveMicrosoftProfileForConsumer(tenant, consumerType);
+    // Read-only resolution: this is a status read that feeds settings pages,
+    // so it must never run the legacy profile/binding migration as a side effect.
+    const profile = await resolveMicrosoftProfileForConsumerReadOnly(tenant, consumerType);
     if (!profile) {
       return {
         success: true,
@@ -1621,17 +1889,21 @@ export const getMicrosoftIntegrationStatus = withAuth(async (
   try {
     if (isClientPortalUser(user)) return { success: false, error: 'Forbidden' };
 
-    const profiles = await listMicrosoftProfilesForTenant(tenant, (user as any)?.user_id);
+    const profiles = await readMicrosoftProfilesForTenant(tenant);
     // STRICTLY READ-ONLY. This status powers both the Microsoft email settings
     // page and the Teams settings profile picker, so it must never write to
-    // microsoft_email_provider_config (or any other table). The conservative
+    // microsoft_profiles, microsoft_profile_consumer_bindings,
+    // microsoft_email_provider_config, or the secret provider. The conservative
     // same-client issuer backfill is a deliberate mutation and lives in the
     // dedicated runMicrosoftEmailIssuerBackfill action, which the email
     // settings surface calls only as part of a user-initiated save/reconnect —
-    // never as a side effect of loading a status page.
+    // never as a side effect of loading a status page. Profile listing and
+    // consumer resolution below use the read-only variants; for a legacy
+    // tenant whose migration has not run, the legacy credentials are surfaced
+    // as an unmigrated profile view without materializing rows.
     const baseUrl = await getDeploymentBaseUrl();
     const metadata = getVisibleMicrosoftIntegrationMetadata(baseUrl);
-    const mspSsoProfile = await resolveMicrosoftProfileForConsumer(tenant, 'msp_sso');
+    const mspSsoProfile = await resolveMicrosoftProfileForConsumerReadOnly(tenant, 'msp_sso');
     const emailSetup = await getMicrosoftEmailSetupReadiness(tenant);
     const visibleProfiles = profiles.map((profile) => ({
       ...profile,

--- a/packages/integrations/src/actions/integrations/microsoftActions.ts
+++ b/packages/integrations/src/actions/integrations/microsoftActions.ts
@@ -166,7 +166,6 @@ export interface MicrosoftProfileStatusResponse {
   };
   emailSetup?: MicrosoftEmailSetupReadiness;
   profiles?: MicrosoftProfileSummary[];
-  issuerBackfill?: { backfilled: number; ambiguous: number; unchanged: number };
 }
 
 function maskSecret(value: string): string {
@@ -1617,22 +1616,19 @@ export const getMicrosoftEmailIssuerOptions = withAuth(async (
 
 export const getMicrosoftIntegrationStatus = withAuth(async (
   user,
-  { tenant },
-  params: { runIssuerBackfill?: boolean } = {}
+  { tenant }
 ): Promise<MicrosoftProfileStatusResponse> => {
   try {
     if (isClientPortalUser(user)) return { success: false, error: 'Forbidden' };
 
     const profiles = await listMicrosoftProfilesForTenant(tenant, (user as any)?.user_id);
-    // The conservative same-client issuer backfill WRITES
-    // microsoft_email_provider_config rows. It must never run on shared read
-    // paths: the Teams settings page loads this status purely to render its
-    // profile picker, so a Teams page load would otherwise mutate email
-    // provider state. Only the Microsoft email settings / inbound-email flow
-    // opts in via runIssuerBackfill: true.
-    const backfill = params.runIssuerBackfill
-      ? await backfillMicrosoftEmailProviderIssuerMetadata(tenant)
-      : undefined;
+    // STRICTLY READ-ONLY. This status powers both the Microsoft email settings
+    // page and the Teams settings profile picker, so it must never write to
+    // microsoft_email_provider_config (or any other table). The conservative
+    // same-client issuer backfill is a deliberate mutation and lives in the
+    // dedicated runMicrosoftEmailIssuerBackfill action, which the email
+    // settings surface calls only as part of a user-initiated save/reconnect —
+    // never as a side effect of loading a status page.
     const baseUrl = await getDeploymentBaseUrl();
     const metadata = getVisibleMicrosoftIntegrationMetadata(baseUrl);
     const mspSsoProfile = await resolveMicrosoftProfileForConsumer(tenant, 'msp_sso');
@@ -1655,10 +1651,37 @@ export const getMicrosoftIntegrationStatus = withAuth(async (
       },
       emailSetup,
       profiles: visibleProfiles,
-      issuerBackfill: backfill,
     };
   } catch (err: any) {
     return { success: false, error: microsoftActionErrorMessage(err, 'Failed to load Microsoft integration status') };
+  }
+});
+
+/**
+ * Explicitly run the conservative same-client email issuer backfill.
+ *
+ * This is a deliberate mutation of `microsoft_email_provider_config` rows: it
+ * pins legacy providers that have exactly one eligible same-client profile
+ * match. It must NEVER be invoked as a side effect of loading a settings or
+ * status page — the Microsoft email settings surface calls it only from an
+ * explicit user-initiated save/reconnect, and tests exercise it directly. The
+ * backfill keeps its internal secret-resolvability guard, so a profile whose
+ * secret cannot be resolved is never used as a pin.
+ */
+export const runMicrosoftEmailIssuerBackfill = withAuth(async (
+  user,
+  { tenant }
+): Promise<{ success: boolean; error?: string; result?: { backfilled: number; ambiguous: number; unchanged: number } }> => {
+  try {
+    if (isClientPortalUser(user)) return { success: false, error: 'Forbidden' };
+    if (!(await canManageMicrosoftSettings(user))) return { success: false, error: 'Forbidden' };
+
+    return {
+      success: true,
+      result: await backfillMicrosoftEmailProviderIssuerMetadata(tenant),
+    };
+  } catch (err: any) {
+    return { success: false, error: microsoftActionErrorMessage(err, 'Failed to backfill Microsoft email issuer metadata') };
   }
 });
 

--- a/packages/integrations/src/actions/integrations/providerReadiness.test.ts
+++ b/packages/integrations/src/actions/integrations/providerReadiness.test.ts
@@ -17,6 +17,7 @@ vi.mock('@alga-psa/core/secrets', () => ({
 
 vi.mock('../../lib/microsoftConsumerProfileResolution', () => ({
   resolveMicrosoftConsumerProfileConfig: (...args: unknown[]) => resolveMicrosoftConsumerProfileConfigMock(...args),
+  resolveMicrosoftConsumerProfileConfigReadOnly: (...args: unknown[]) => resolveMicrosoftConsumerProfileConfigMock(...args),
   getMicrosoftPlatformCredentialAvailability: (...args: unknown[]) => getMicrosoftPlatformCredentialAvailabilityMock(...args),
 }));
 

--- a/packages/integrations/src/actions/integrations/providerReadiness.ts
+++ b/packages/integrations/src/actions/integrations/providerReadiness.ts
@@ -4,7 +4,7 @@ import { getSecretProviderInstance } from '@alga-psa/core/secrets';
 import { isSelfHostLicensing } from '@alga-psa/licensing';
 import {
   getMicrosoftPlatformCredentialAvailability,
-  resolveMicrosoftConsumerProfileConfig,
+  resolveMicrosoftConsumerProfileConfigReadOnly,
 } from '../../lib/microsoftConsumerProfileResolution';
 
 const MICROSOFT_CLIENT_ID_SECRET = 'microsoft_client_id';
@@ -61,15 +61,18 @@ export async function getMicrosoftEmailSetupReadiness(
   tenant: string
 ): Promise<MicrosoftEmailSetupReadiness> {
   const hosted = !(await isSelfHostLicensing());
+  // Read-only resolution: this helper feeds settings/status surfaces only
+  // (email setup options, consumer setup status, integration status). It must
+  // never run the legacy profile/binding migration as a page-load side effect.
   const [resolution, platform, platformResolution] = await Promise.all([
-    resolveMicrosoftConsumerProfileConfig(
+    resolveMicrosoftConsumerProfileConfigReadOnly(
       tenant,
       'email',
       { credentialPreference: 'tenant' }
     ),
     getMicrosoftPlatformCredentialAvailability(),
     hosted
-      ? resolveMicrosoftConsumerProfileConfig(tenant, 'email', { credentialPreference: 'platform' })
+      ? resolveMicrosoftConsumerProfileConfigReadOnly(tenant, 'email', { credentialPreference: 'platform' })
       : Promise.resolve(null),
   ]);
 

--- a/packages/integrations/src/components/email/MicrosoftProviderForm.tsx
+++ b/packages/integrations/src/components/email/MicrosoftProviderForm.tsx
@@ -95,13 +95,31 @@ export function MicrosoftProviderForm({
     };
   }, [provider]);
 
-  const selectedIssuerLabel = React.useMemo(() => {
-    if (!issuerOptions) return null;
-    const option = [...(issuerOptions.managed ? [issuerOptions.managed] : []), ...issuerOptions.profiles].find(
-      (candidate) => candidate.clientId.toLowerCase() === selectedIssuer?.clientId.toLowerCase()
-    );
-    return option?.label ?? null;
-  }, [issuerOptions, selectedIssuer]);
+  const resolveIssuerLabel = React.useCallback(
+    (choice: MicrosoftEmailIssuerChoice | null): string | null => {
+      if (!issuerOptions || !choice) return null;
+      const option = [...(issuerOptions.managed ? [issuerOptions.managed] : []), ...issuerOptions.profiles].find(
+        (candidate) => candidate.clientId.toLowerCase() === choice.clientId.toLowerCase()
+      );
+      return option?.label ?? null;
+    },
+    [issuerOptions]
+  );
+
+  // Label for the app currently selected in the form (pending reauthorization).
+  const selectedIssuerLabel = React.useMemo(
+    () => resolveIssuerLabel(selectedIssuer),
+    [resolveIssuerLabel, selectedIssuer]
+  );
+
+  // Label for the app that actually issued this provider's refresh token.
+  // "Current" must always come from the persisted provider config (server
+  // truth), never from the unsaved selection — selecting a different app is
+  // pending reauthorization until the callback persists it.
+  const currentIssuerLabel = React.useMemo(
+    () => resolveIssuerLabel(currentIssuer),
+    [resolveIssuerLabel, currentIssuer]
+  );
 
   const isSwitchingIssuer = Boolean(
     isEditing &&
@@ -670,11 +688,29 @@ export function MicrosoftProviderForm({
             )}
 
             {isEditing && currentIssuer && (
-              <div className="text-xs text-muted-foreground">
-                {t('forms.microsoft.issuer.currentApp', {
-                  defaultValue: 'Current app: {{app}}',
-                  app: selectedIssuerLabel || currentIssuer.clientId,
-                })}
+              <div className="space-y-2">
+                <div className="text-xs text-muted-foreground">
+                  {t('forms.microsoft.issuer.currentApp', {
+                    defaultValue: 'Current app: {{app}}',
+                    app: currentIssuerLabel || currentIssuer.clientId,
+                  })}
+                </div>
+
+                {isSwitchingIssuer && selectedIssuer && (
+                  <div className="flex flex-wrap items-center gap-2 rounded-md border border-warning/30 bg-warning/10 px-3 py-2">
+                    <span className="text-xs font-medium">
+                      {t('forms.microsoft.issuer.selectedApp', {
+                        defaultValue: 'Selected app: {{app}}',
+                        app: selectedIssuerLabel || selectedIssuer.clientId,
+                      })}
+                    </span>
+                    <Badge variant="warning">
+                      {t('forms.microsoft.issuer.pendingReauth', {
+                        defaultValue: 'Pending reauthorization',
+                      })}
+                    </Badge>
+                  </div>
+                )}
               </div>
             )}
 

--- a/packages/integrations/src/components/email/MicrosoftProviderForm.tsx
+++ b/packages/integrations/src/components/email/MicrosoftProviderForm.tsx
@@ -14,6 +14,7 @@ import { Input } from '@alga-psa/ui/components/Input';
 import { Label } from '@alga-psa/ui/components/Label';
 import { Switch } from '@alga-psa/ui/components/Switch';
 import { Alert, AlertDescription } from '@alga-psa/ui/components/Alert';
+import { Badge } from '@alga-psa/ui/components/Badge';
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@alga-psa/ui/components/Card';
 import { useTranslation } from '@alga-psa/ui/lib/i18n/client';
 import { CheckCircle } from 'lucide-react';
@@ -23,6 +24,7 @@ import {
   updateEmailProvider,
   upsertEmailProvider,
   initiateEmailOAuth,
+  getMicrosoftEmailIssuerOptions,
 } from '@alga-psa/integrations/actions';
 import CustomSelect from '@alga-psa/ui/components/CustomSelect';
 import { getInboundTicketDefaults } from '@alga-psa/integrations/actions';
@@ -31,6 +33,11 @@ import {
   isActionMessageError,
 } from '@alga-psa/ui/lib/errorHandling';
 import type { MicrosoftEmailSetupReadiness } from '../../actions/integrations/providerReadiness';
+import type {
+  MicrosoftEmailIssuerChoice,
+  MicrosoftEmailIssuerOption,
+  MicrosoftEmailIssuerOptions,
+} from '../../lib/microsoftEmailIssuerSelection';
 
 type MicrosoftProviderFormData = {
   providerName: string;
@@ -66,9 +73,90 @@ export function MicrosoftProviderForm({
   const oauthCleanupRef = useRef<(() => void) | null>(null);
   const [hasAttemptedSubmit, setHasAttemptedSubmit] = useState(false);
   const [defaultsOptions, setDefaultsOptions] = useState<{ value: string; label: string }[]>([]);
+  const [issuerOptions, setIssuerOptions] = useState<MicrosoftEmailIssuerOptions | null>(null);
+  const [issuerOptionsLoading, setIssuerOptionsLoading] = useState(false);
+  const [issuerOptionsError, setIssuerOptionsError] = useState<string | null>(null);
+  const [selectedIssuer, setSelectedIssuer] = useState<MicrosoftEmailIssuerChoice | null>(null);
 
   const isEditing = !!provider;
   const providerSetupReady = emailSetup?.state === 'ready';
+
+  // The app that issued this provider's refresh token, derived from the
+  // persisted provider row (never from the current binding).
+  const currentIssuer = React.useMemo<MicrosoftEmailIssuerChoice | null>(() => {
+    const config = provider?.microsoftConfig;
+    if (!config?.client_id) return null;
+    return {
+      kind: config.microsoft_profile_id ? 'profile' : 'managed',
+      ...(config.microsoft_profile_id ? { profileId: config.microsoft_profile_id } : {}),
+      clientId: config.client_id,
+    };
+  }, [provider]);
+
+  const selectedIssuerLabel = React.useMemo(() => {
+    if (!issuerOptions) return null;
+    const option = [...(issuerOptions.managed ? [issuerOptions.managed] : []), ...issuerOptions.profiles].find(
+      (candidate) => candidate.clientId.toLowerCase() === selectedIssuer?.clientId.toLowerCase()
+    );
+    return option?.label ?? null;
+  }, [issuerOptions, selectedIssuer]);
+
+  const isSwitchingIssuer = Boolean(
+    isEditing &&
+    currentIssuer &&
+    selectedIssuer &&
+    currentIssuer.clientId.toLowerCase() !== selectedIssuer.clientId.toLowerCase()
+  );
+
+  // Load the eligible Microsoft applications once and default the selection.
+  const loadIssuerOptions = React.useCallback(async () => {
+    setIssuerOptionsLoading(true);
+    setIssuerOptionsError(null);
+    try {
+      const result = await getMicrosoftEmailIssuerOptions();
+      if (!result.success || !result.issuers) {
+        setIssuerOptionsError(result.error || 'Failed to load Microsoft app options');
+        return;
+      }
+      const options = result.issuers;
+      setIssuerOptions(options);
+
+      const allOptions = [...(options.managed ? [options.managed] : []), ...options.profiles];
+      const matchesClientId = (candidate: MicrosoftEmailIssuerOption) =>
+        candidate.clientId.toLowerCase() === (provider?.microsoftConfig?.client_id || '').toLowerCase();
+
+      let defaultChoice: MicrosoftEmailIssuerChoice | null = null;
+      const current = provider?.microsoftConfig;
+      if (current?.client_id) {
+        const managedMatch = options.managed && matchesClientId(options.managed) ? options.managed : undefined;
+        const profileMatch = options.profiles.find(matchesClientId);
+        if (current.microsoft_profile_id && profileMatch) {
+          defaultChoice = { kind: 'profile', profileId: profileMatch.profileId, clientId: profileMatch.clientId };
+        } else if (managedMatch) {
+          defaultChoice = { kind: 'managed', clientId: managedMatch.clientId };
+        } else if (profileMatch) {
+          defaultChoice = { kind: 'profile', profileId: profileMatch.profileId, clientId: profileMatch.clientId };
+        }
+      }
+      if (!defaultChoice && options.recommended) defaultChoice = options.recommended;
+      if (!defaultChoice && options.managed) defaultChoice = { kind: 'managed', clientId: options.managed.clientId };
+      if (!defaultChoice && options.profiles[0]) {
+        defaultChoice = { kind: 'profile', profileId: options.profiles[0].profileId, clientId: options.profiles[0].clientId };
+      }
+      if (!defaultChoice && allOptions[0]) {
+        defaultChoice = { kind: allOptions[0].kind, ...(allOptions[0].profileId ? { profileId: allOptions[0].profileId } : {}), clientId: allOptions[0].clientId };
+      }
+      setSelectedIssuer(defaultChoice);
+    } catch (e) {
+      setIssuerOptionsError('Failed to load Microsoft app options');
+    } finally {
+      setIssuerOptionsLoading(false);
+    }
+  }, [provider]);
+
+  React.useEffect(() => {
+    void loadIssuerOptions();
+  }, [loadIssuerOptions]);
 
   const microsoftProviderSchema = z.object({
     providerName: z.string().min(1, t('forms.microsoft.validation.providerNameRequired', { defaultValue: 'Configuration name is required' })),
@@ -152,6 +240,7 @@ export function MicrosoftProviderForm({
         mailbox: data.mailbox,
         isActive: data.isActive,
         inboundTicketDefaultsId: data.inboundTicketDefaultsId,
+        microsoftIssuer: selectedIssuer || undefined,
         microsoftConfig: {
           client_id: '',
           client_secret: '',
@@ -196,6 +285,13 @@ export function MicrosoftProviderForm({
         return;
       }
 
+      // An explicit issuer choice is mandatory so the server never guesses the app.
+      if (!selectedIssuer) {
+        setOauthStatus('error');
+        setError(t('forms.microsoft.validation.issuerRequired', { defaultValue: 'Choose a Microsoft app before signing in' }));
+        return;
+      }
+
       // Save provider first so credentials are available for OAuth
       let providerId = provider?.id;
       if (!providerId) {
@@ -207,6 +303,7 @@ export function MicrosoftProviderForm({
           mailbox: formData.mailbox,
           isActive: formData.isActive,
           inboundTicketDefaultsId: formData.inboundTicketDefaultsId || undefined,
+          microsoftIssuer: selectedIssuer,
           microsoftConfig: {
             client_id: '',
             client_secret: '',
@@ -228,6 +325,8 @@ export function MicrosoftProviderForm({
       const oauthInit = await initiateEmailOAuth({
         provider: 'microsoft',
         providerId: providerId,
+        purpose: isEditing ? 'reconnect' : 'create',
+        issuer: selectedIssuer,
       });
       if (!oauthInit.success) {
         throw new Error((oauthInit as { success: false; error: string }).error || t('forms.microsoft.validation.oauthInitiateFailed', { defaultValue: 'Failed to initiate OAuth' }));
@@ -468,6 +567,145 @@ export function MicrosoftProviderForm({
               </AlertDescription>
             </Alert>
           )}
+
+          {/* Explicit issuer choice: which Microsoft app authorizes this mailbox. */}
+          <div className="space-y-3">
+            <div>
+              <div className="text-sm font-medium">
+                {t('forms.microsoft.issuer.title', { defaultValue: 'Microsoft app that authorizes this mailbox' })}
+              </div>
+              <p className="mt-1 text-xs text-muted-foreground">
+                {t('forms.microsoft.issuer.description', {
+                  defaultValue: 'Choose which application signs in as this mailbox. This choice is stored with the mailbox and does not affect other services.',
+                })}
+              </p>
+            </div>
+
+            {issuerOptionsLoading ? (
+              <div className="space-y-2">
+                <div className="h-16 w-full animate-pulse rounded-lg border" />
+              </div>
+            ) : issuerOptionsError ? (
+              <Alert variant="destructive">
+                <AlertDescription>
+                  <div className="space-y-2">
+                    <div>{issuerOptionsError}</div>
+                    <Button
+                      id="retry-microsoft-issuer-options-button"
+                      type="button"
+                      variant="link"
+                      className="h-auto p-0"
+                      onClick={() => void loadIssuerOptions()}
+                    >
+                      {t('forms.microsoft.issuer.retry', { defaultValue: 'Try again' })}
+                    </Button>
+                  </div>
+                </AlertDescription>
+              </Alert>
+            ) : issuerOptions && (issuerOptions.managed || issuerOptions.profiles.length > 0) ? (
+              <div className="space-y-2">
+                {issuerOptions.managed && (
+                  <button
+                    id="microsoft-issuer-option-managed"
+                    type="button"
+                    onClick={() => setSelectedIssuer({ kind: 'managed', clientId: issuerOptions.managed!.clientId })}
+                    className={`flex w-full items-start gap-3 rounded-lg border p-4 text-left transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary-500 focus-visible:ring-offset-2 ${
+                      selectedIssuer?.kind === 'managed'
+                        ? 'border-blue-500 bg-blue-50 dark:border-blue-400 dark:bg-blue-500/20'
+                        : 'border-[rgb(var(--color-border-200))] bg-[rgb(var(--color-card))] hover:bg-muted/30'
+                    }`}
+                  >
+                    <input
+                      id="microsoft-issuer-managed-radio"
+                      type="radio"
+                      name="microsoft-issuer"
+                      className="mt-1"
+                      checked={selectedIssuer?.kind === 'managed'}
+                      onChange={() => setSelectedIssuer({ kind: 'managed', clientId: issuerOptions.managed!.clientId })}
+                    />
+                    <div className="min-w-0 space-y-1">
+                      <div className="flex flex-wrap items-center gap-2 text-sm font-medium">
+                        {t('forms.microsoft.issuer.managedLabel', { defaultValue: 'AlgaPSA app (managed by Nine Minds)' })}
+                        <Badge variant="success">{t('forms.microsoft.issuer.recommended', { defaultValue: 'Recommended' })}</Badge>
+                      </div>
+                      <p className="text-xs text-muted-foreground">
+                        {t('forms.microsoft.issuer.managedDescription', { defaultValue: 'No Microsoft app registration is required on your side.' })}
+                      </p>
+                    </div>
+                  </button>
+                )}
+
+                {issuerOptions.profiles.map((option) => (
+                  <button
+                    key={option.profileId}
+                    id={`microsoft-issuer-option-profile-${option.profileId}`}
+                    type="button"
+                    onClick={() =>
+                      option.profileId &&
+                      setSelectedIssuer({ kind: 'profile', profileId: option.profileId, clientId: option.clientId })
+                    }
+                    className={`flex w-full items-start gap-3 rounded-lg border p-4 text-left transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary-500 focus-visible:ring-offset-2 ${
+                      selectedIssuer?.kind === 'profile' && selectedIssuer.profileId === option.profileId
+                        ? 'border-blue-500 bg-blue-50 dark:border-blue-400 dark:bg-blue-500/20'
+                        : 'border-[rgb(var(--color-border-200))] bg-[rgb(var(--color-card))] hover:bg-muted/30'
+                    }`}
+                  >
+                    <input
+                      id={`microsoft-issuer-profile-radio-${option.profileId}`}
+                      type="radio"
+                      name="microsoft-issuer"
+                      className="mt-1"
+                      checked={selectedIssuer?.kind === 'profile' && selectedIssuer.profileId === option.profileId}
+                      onChange={() =>
+                        option.profileId &&
+                        setSelectedIssuer({ kind: 'profile', profileId: option.profileId, clientId: option.clientId })
+                      }
+                    />
+                    <div className="min-w-0 space-y-1">
+                      <div className="text-sm font-medium">{option.label}</div>
+                      <p className="break-all font-mono text-xs text-muted-foreground">{option.clientId}</p>
+                    </div>
+                  </button>
+                ))}
+              </div>
+            ) : (
+              <Alert variant="warning">
+                <AlertDescription>
+                  <div className="space-y-2">
+                    <div>{t('forms.microsoft.issuer.noneAvailable', { defaultValue: 'No Microsoft app is ready for mailbox authorization yet. Set one up in Providers, then come back.' })}</div>
+                    <Button
+                      id="microsoft-issuer-none-open-providers-button"
+                      type="button"
+                      variant="link"
+                      className="h-auto p-0"
+                      onClick={() => window.location.assign('/msp/settings/integrations?category=providers')}
+                    >
+                      {t('forms.microsoft.readiness.openProviders', { defaultValue: 'Open Providers' })}
+                    </Button>
+                  </div>
+                </AlertDescription>
+              </Alert>
+            )}
+
+            {isEditing && currentIssuer && (
+              <div className="text-xs text-muted-foreground">
+                {t('forms.microsoft.issuer.currentApp', {
+                  defaultValue: 'Current app: {{app}}',
+                  app: selectedIssuerLabel || currentIssuer.clientId,
+                })}
+              </div>
+            )}
+
+            {isSwitchingIssuer && (
+              <Alert variant="warning">
+                <AlertDescription>
+                  {t('forms.microsoft.issuer.switchWarning', {
+                    defaultValue: 'Changing the Microsoft app requires reconnecting this mailbox. Sign in with Microsoft again to finish the switch.',
+                  })}
+                </AlertDescription>
+              </Alert>
+            )}
+          </div>
 
           <div className="flex justify-end">
             <Button

--- a/packages/integrations/src/components/email/MicrosoftProviderForm.tsx
+++ b/packages/integrations/src/components/email/MicrosoftProviderForm.tsx
@@ -79,7 +79,9 @@ export function MicrosoftProviderForm({
   const [selectedIssuer, setSelectedIssuer] = useState<MicrosoftEmailIssuerChoice | null>(null);
 
   const isEditing = !!provider;
-  const providerSetupReady = emailSetup?.state === 'ready';
+  // A tenant profile awaiting Microsoft 365 admin approval. Only surfaced as a
+  // status note on the bring-your-own-app path — never as a global warning.
+  const ownAppPendingConsent = emailSetup?.state === 'pending_admin_consent';
 
   // The app that issued this provider's refresh token, derived from the
   // persisted provider row (never from the current binding).
@@ -520,55 +522,9 @@ export function MicrosoftProviderForm({
           <CardTitle>{t('forms.microsoft.hostedOauth.sectionTitle', { defaultValue: 'Connect Microsoft 365' })}</CardTitle>
         </CardHeader>
         <CardContent className="space-y-4">
-          {emailSetup === undefined ? (
-            <Alert variant="info">
-              <AlertDescription>
-                {t('forms.microsoft.readiness.checking', { defaultValue: 'Checking Microsoft setup…' })}
-              </AlertDescription>
-            </Alert>
-          ) : emailSetup?.state === 'ready' ? (
-            <Alert variant="info">
-              <AlertDescription>
-                {t('forms.microsoft.readiness.ready', { defaultValue: 'Microsoft is set up. Sign in as this mailbox to finish.' })}
-              </AlertDescription>
-            </Alert>
-          ) : emailSetup?.state === 'pending_admin_consent' ? (
-            <Alert variant="warning">
-              <AlertDescription>
-                <div className="space-y-2">
-                  <div>{t('forms.microsoft.readiness.pending', { defaultValue: "Waiting for your Microsoft 365 administrator. Setup was started in Providers but hasn't been approved yet." })}</div>
-                  <Button
-                    id="open-microsoft-providers-button"
-                    type="button"
-                    variant="link"
-                    className="h-auto p-0"
-                    onClick={() => window.location.assign('/msp/settings/integrations?category=providers')}
-                  >
-                    {t('forms.microsoft.readiness.openProviders', { defaultValue: 'Open Providers' })}
-                  </Button>
-                </div>
-              </AlertDescription>
-            </Alert>
-          ) : (
-            <Alert variant="warning">
-              <AlertDescription>
-                <div className="space-y-2">
-                  <div>{t('forms.microsoft.readiness.notConfigured', { defaultValue: "Microsoft isn't set up yet. Set it up once in Providers, then come back." })}</div>
-                  <Button
-                    id="set-up-microsoft-in-providers-button"
-                    type="button"
-                    variant="link"
-                    className="h-auto p-0"
-                    onClick={() => window.location.assign('/msp/settings/integrations?category=providers')}
-                  >
-                    {t('forms.microsoft.readiness.setUpInProviders', { defaultValue: 'Set up in Providers' })}
-                  </Button>
-                </div>
-              </AlertDescription>
-            </Alert>
-          )}
-
-          {/* Explicit issuer choice: which Microsoft app authorizes this mailbox. */}
+          {/* Explicit issuer choice: which Microsoft app authorizes this mailbox.
+              The picker is the single readiness surface — every option it lists
+              is fully authorized to sign in, so no separate setup banner. */}
           <div className="space-y-3">
             <div>
               <div className="text-sm font-medium">
@@ -672,7 +628,11 @@ export function MicrosoftProviderForm({
               <Alert variant="warning">
                 <AlertDescription>
                   <div className="space-y-2">
-                    <div>{t('forms.microsoft.issuer.noneAvailable', { defaultValue: 'No Microsoft app is ready for mailbox authorization yet. Set one up in Providers, then come back.' })}</div>
+                    <div>
+                      {ownAppPendingConsent
+                        ? t('forms.microsoft.issuer.pendingConsentEmpty', { defaultValue: 'Your Microsoft app is waiting for Microsoft 365 administrator approval. Once it is approved in Providers, come back to sign in.' })
+                        : t('forms.microsoft.issuer.noneAvailable', { defaultValue: 'To connect Microsoft 365, first set up a Microsoft app in Providers, then come back.' })}
+                    </div>
                     <Button
                       id="microsoft-issuer-none-open-providers-button"
                       type="button"
@@ -685,6 +645,28 @@ export function MicrosoftProviderForm({
                   </div>
                 </AlertDescription>
               </Alert>
+            )}
+
+            {/* Progressive disclosure: bringing your own Microsoft app is an
+                optional path, so it is a quiet prompt — not a warning — and only
+                appears while no tenant app is usable yet. */}
+            {!issuerOptionsLoading && !issuerOptionsError && issuerOptions?.managed && issuerOptions.profiles.length === 0 && (
+              <p className="text-xs text-muted-foreground">
+                {ownAppPendingConsent
+                  ? t('forms.microsoft.issuer.pendingConsentHint', { defaultValue: 'Your own Microsoft app is still waiting for Microsoft 365 administrator approval.' })
+                  : t('forms.microsoft.issuer.ownAppPrompt', { defaultValue: 'Prefer to sign in with your own Microsoft app?' })}{' '}
+                <Button
+                  id="microsoft-issuer-own-app-providers-link"
+                  type="button"
+                  variant="link"
+                  className="h-auto p-0 text-xs"
+                  onClick={() => window.location.assign('/msp/settings/integrations?category=providers')}
+                >
+                  {ownAppPendingConsent
+                    ? t('forms.microsoft.readiness.openProviders', { defaultValue: 'Open Providers' })
+                    : t('forms.microsoft.issuer.ownAppSetupLink', { defaultValue: 'Set it up in Providers' })}
+                </Button>
+              </p>
             )}
 
             {isEditing && currentIssuer && (
@@ -712,7 +694,7 @@ export function MicrosoftProviderForm({
               id="oauth-authorize-btn"
               type="button"
               onClick={handleOAuthAuthorization}
-              disabled={!providerSetupReady || oauthStatus === 'authorizing'}
+              disabled={issuerOptionsLoading || !selectedIssuer || oauthStatus === 'authorizing'}
             >
               {oauthStatus === 'authorizing' && t('forms.microsoft.oauth.signingIn', { defaultValue: 'Signing in…' })}
               {oauthStatus === 'success' && <><CheckCircle className="mr-2 h-4 w-4" />{t('forms.common.oauth.authorized', { defaultValue: 'Connected' })}</>}

--- a/packages/integrations/src/components/microsoftProviders.providersFirst.test.ts
+++ b/packages/integrations/src/components/microsoftProviders.providersFirst.test.ts
@@ -45,7 +45,7 @@ describe('Microsoft providers-first form contracts', () => {
   it('T019: Microsoft email form delegates app setup to Providers', () => {
     expect(emailFormSource).not.toContain('Use your own Microsoft app');
     expect(emailFormSource).not.toContain('Redirect URI');
-    expect(emailFormSource).toContain('Set up in Providers');
+    expect(emailFormSource).toContain('Set it up in Providers');
     expect(emailFormSource).toContain('Open Providers');
     expect(emailFormSource).toContain('/msp/settings/integrations?category=providers');
   });
@@ -55,8 +55,13 @@ describe('Microsoft providers-first form contracts', () => {
       "@alga-psa/integrations/components/email/MicrosoftProviderForm"
     );
     expect(emailFormSource).toContain('emailSetup?: MicrosoftEmailSetupReadiness | null');
-    expect(emailFormSource).toContain('providerSetupReady');
-    expect(emailFormSource).toContain('Microsoft is set up. Sign in as this mailbox to finish.');
+    // Progressive disclosure: the issuer picker is the only readiness surface.
+    // Sign-in is gated on the selected issuer, never on a global setup banner,
+    // and pending admin consent surfaces only as own-app path status.
+    expect(emailFormSource).toContain('ownAppPendingConsent');
+    expect(emailFormSource).not.toContain('providerSetupReady');
+    expect(emailFormSource).not.toContain('Microsoft is set up. Sign in as this mailbox to finish.');
+    expect(emailFormSource).toContain("disabled={issuerOptionsLoading || !selectedIssuer || oauthStatus === 'authorizing'}");
     expect(emailFormSource).toContain('Sign in with Microsoft');
     expect(emailFormSource).toContain('/msp/settings/integrations?category=providers');
   });

--- a/packages/integrations/src/components/microsoftProviders.providersFirst.test.ts
+++ b/packages/integrations/src/components/microsoftProviders.providersFirst.test.ts
@@ -92,16 +92,19 @@ describe('Microsoft providers-first form contracts', () => {
     expect(calendarFormSource).toContain("tenant_id: ''");
   });
 
-  it('T022: Microsoft email persistence derives credentials from tenant providers secrets instead of form fields', () => {
+  it('T022: Microsoft email persistence pins the explicit issuer and keeps the binding as a legacy fallback', () => {
+    expect(emailActionsSource).toContain('resolveMicrosoftEmailIssuerChoice(tenant, issuer)');
+    expect(emailActionsSource).toContain('preserveIssuingApp');
+    expect(emailActionsSource).toContain('CLIENT_MISMATCH_RECONNECT_REQUIRED');
     expect(emailActionsSource).toContain("resolveMicrosoftConsumerProfileConfig(tenant, 'email', {");
     expect(emailActionsSource).toContain("credentialPreference: 'tenant'");
     expect(emailActionsSource).not.toContain('microsoftCredentialSource');
     expect(emailActionsSource).toContain('getMicrosoftEmailSetupMetadataInternal()).mailboxRedirectUri');
     expect(emailActionsSource).toContain(
-      "const effectiveClientId = microsoftProfile.clientId || '';"
+      "effectiveClientId = microsoftProfile.clientId || '';"
     );
     expect(emailActionsSource).toContain(
-      "const effectiveClientSecret = microsoftProfile.clientSecret || '';"
+      "effectiveClientSecret = microsoftProfile.clientSecret || '';"
     );
     expect(emailActionsSource).toContain('microsoft_profile_id: pinnedProfileId');
     expect(emailActionsSource).toContain('client_secret_ref: pinnedClientSecretRef');

--- a/packages/integrations/src/components/microsoftProviders.providersFirst.test.ts
+++ b/packages/integrations/src/components/microsoftProviders.providersFirst.test.ts
@@ -92,19 +92,20 @@ describe('Microsoft providers-first form contracts', () => {
     expect(calendarFormSource).toContain("tenant_id: ''");
   });
 
-  it('T022: Microsoft email persistence pins the explicit issuer and keeps the binding as a legacy fallback', () => {
+  it('T022: Microsoft email persistence requires an explicit issuer and never falls back to the Email binding on create/save', () => {
     expect(emailActionsSource).toContain('resolveMicrosoftEmailIssuerChoice(tenant, issuer)');
     expect(emailActionsSource).toContain('preserveIssuingApp');
     expect(emailActionsSource).toContain('CLIENT_MISMATCH_RECONNECT_REQUIRED');
-    expect(emailActionsSource).toContain("resolveMicrosoftConsumerProfileConfig(tenant, 'email', {");
-    expect(emailActionsSource).toContain("credentialPreference: 'tenant'");
+    expect(emailActionsSource).toContain('ISSUER_REQUIRED');
+    expect(emailActionsSource).toContain('explicit selection fails loudly');
+    // The silent tenant-binding fallback on new writes is gone; the binding may
+    // only inform the UI default and the legacy runtime backfill.
+    expect(emailActionsSource).not.toContain("resolveMicrosoftConsumerProfileConfig(tenant, 'email', {");
+    expect(emailActionsSource).not.toContain("credentialPreference: 'tenant'");
     expect(emailActionsSource).not.toContain('microsoftCredentialSource');
     expect(emailActionsSource).toContain('getMicrosoftEmailSetupMetadataInternal()).mailboxRedirectUri');
     expect(emailActionsSource).toContain(
-      "effectiveClientId = microsoftProfile.clientId || '';"
-    );
-    expect(emailActionsSource).toContain(
-      "effectiveClientSecret = microsoftProfile.clientSecret || '';"
+      'let effectiveClientId = resolution.clientId;'
     );
     expect(emailActionsSource).toContain('microsoft_profile_id: pinnedProfileId');
     expect(emailActionsSource).toContain('client_secret_ref: pinnedClientSecretRef');

--- a/packages/integrations/src/components/settings/integrations/MicrosoftIntegrationSettings.contract.test.tsx
+++ b/packages/integrations/src/components/settings/integrations/MicrosoftIntegrationSettings.contract.test.tsx
@@ -11,6 +11,7 @@ import '@testing-library/jest-dom';
 
 const useFeatureFlagMock = vi.hoisted(() => vi.fn());
 const getMicrosoftIntegrationStatusMock = vi.hoisted(() => vi.fn());
+const runMicrosoftEmailIssuerBackfillMock = vi.hoisted(() => vi.fn());
 const listMicrosoftConsumerBindingsMock = vi.hoisted(() => vi.fn());
 const setMicrosoftConsumerBindingMock = vi.hoisted(() => vi.fn());
 const createMicrosoftProfileMock = vi.hoisted(() => vi.fn());
@@ -32,6 +33,7 @@ vi.mock('next/navigation', () => ({
 
 vi.mock('@alga-psa/integrations/actions', () => ({
   getMicrosoftIntegrationStatus: (...args: unknown[]) => getMicrosoftIntegrationStatusMock(...args),
+  runMicrosoftEmailIssuerBackfill: (...args: unknown[]) => runMicrosoftEmailIssuerBackfillMock(...args),
   listMicrosoftConsumerBindings: (...args: unknown[]) => listMicrosoftConsumerBindingsMock(...args),
   setMicrosoftConsumerBinding: (...args: unknown[]) => setMicrosoftConsumerBindingMock(...args),
   createMicrosoftProfile: (...args: unknown[]) => createMicrosoftProfileMock(...args),
@@ -44,6 +46,7 @@ vi.mock('@alga-psa/integrations/actions', () => ({
 
 vi.mock('../../../actions/integrations/microsoftActions', () => ({
   getMicrosoftIntegrationStatus: (...args: unknown[]) => getMicrosoftIntegrationStatusMock(...args),
+  runMicrosoftEmailIssuerBackfill: (...args: unknown[]) => runMicrosoftEmailIssuerBackfillMock(...args),
   listMicrosoftConsumerBindings: (...args: unknown[]) => listMicrosoftConsumerBindingsMock(...args),
   setMicrosoftConsumerBinding: (...args: unknown[]) => setMicrosoftConsumerBindingMock(...args),
   createMicrosoftProfile: (...args: unknown[]) => createMicrosoftProfileMock(...args),
@@ -288,6 +291,7 @@ describe('MicrosoftIntegrationSettings contracts', () => {
       value: true,
     });
     getMicrosoftIntegrationStatusMock.mockReset();
+    runMicrosoftEmailIssuerBackfillMock.mockReset().mockResolvedValue({ success: true, result: { backfilled: 0, ambiguous: 0, unchanged: 0 } });
     listMicrosoftConsumerBindingsMock.mockReset();
     setMicrosoftConsumerBindingMock.mockReset();
     createMicrosoftProfileMock.mockReset();
@@ -797,26 +801,38 @@ describe('MicrosoftIntegrationSettings contracts', () => {
     });
   });
 
-  it('loads status with the email issuer backfill opt-in (the email settings flow still backfills)', async () => {
+  it('loading the page is a pure read: no backfill runs and the status action receives no write opt-in', async () => {
     render(<MicrosoftIntegrationSettings />);
 
     await waitFor(() => {
       expect(getMicrosoftIntegrationStatusMock).toHaveBeenCalled();
     });
-    expect(getMicrosoftIntegrationStatusMock).toHaveBeenCalledWith({ runIssuerBackfill: true });
+    // Pure read — no runIssuerBackfill param anywhere.
+    expect(getMicrosoftIntegrationStatusMock).toHaveBeenCalledWith();
+    // The backfill is a deliberate write: it must NOT run on page load.
+    expect(runMicrosoftEmailIssuerBackfillMock).not.toHaveBeenCalled();
   });
 
-  it('contract: only the Microsoft email settings page opts into the email issuer backfill', () => {
+  it('contract: the removed runIssuerBackfill surface is gone and the backfill is only reachable via the explicit mutation action', () => {
     const filePath = path.resolve(__dirname, 'MicrosoftIntegrationSettings.tsx');
     const teamsFilePath = path.resolve(__dirname, 'TeamsIntegrationSettings.tsx');
     const source = fs.readFileSync(filePath, 'utf8');
     const teamsSource = fs.readFileSync(teamsFilePath, 'utf8');
 
-    // The Microsoft email settings page explicitly opts into the backfill.
-    expect(source).toContain('getMicrosoftIntegrationStatus({ runIssuerBackfill: true })');
-    // The Teams settings page shares the status action only to build its
-    // profile picker and must remain a pure read (no backfill writes).
-    expect(teamsSource).toContain('getMicrosoftIntegrationStatus()');
+    // The read-path foot-gun is removed: neither page references it.
+    expect(source).not.toContain('runIssuerBackfill');
     expect(teamsSource).not.toContain('runIssuerBackfill');
+    // Both pages load the shared status as a pure read.
+    expect(source).toContain('getMicrosoftIntegrationStatus()');
+    expect(teamsSource).toContain('getMicrosoftIntegrationStatus()');
+    // The email settings page invokes the explicit backfill mutation only from
+    // its deliberate save/reconnect handler — never from the load effect.
+    const loadStart = source.indexOf('const load = React.useCallback');
+    const loadEnd = source.indexOf('}, [onStatusChange, t]);', loadStart);
+    const loadHandlerSource = source.slice(loadStart, loadEnd);
+    expect(loadHandlerSource).not.toContain('runMicrosoftEmailIssuerBackfill');
+    expect(source).toContain('runMicrosoftEmailIssuerBackfill');
+    // The Teams page never touches the backfill at all.
+    expect(teamsSource).not.toContain('runMicrosoftEmailIssuerBackfill');
   });
 });

--- a/packages/integrations/src/components/settings/integrations/MicrosoftIntegrationSettings.contract.test.tsx
+++ b/packages/integrations/src/components/settings/integrations/MicrosoftIntegrationSettings.contract.test.tsx
@@ -2,6 +2,8 @@
  * @vitest-environment jsdom
  */
 import React from 'react';
+import fs from 'node:fs';
+import path from 'node:path';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { render, screen, waitFor, within } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
@@ -793,5 +795,28 @@ describe('MicrosoftIntegrationSettings contracts', () => {
     await waitFor(() => {
       expect(archiveMicrosoftProfileMock).toHaveBeenCalledWith('profile-2');
     });
+  });
+
+  it('loads status with the email issuer backfill opt-in (the email settings flow still backfills)', async () => {
+    render(<MicrosoftIntegrationSettings />);
+
+    await waitFor(() => {
+      expect(getMicrosoftIntegrationStatusMock).toHaveBeenCalled();
+    });
+    expect(getMicrosoftIntegrationStatusMock).toHaveBeenCalledWith({ runIssuerBackfill: true });
+  });
+
+  it('contract: only the Microsoft email settings page opts into the email issuer backfill', () => {
+    const filePath = path.resolve(__dirname, 'MicrosoftIntegrationSettings.tsx');
+    const teamsFilePath = path.resolve(__dirname, 'TeamsIntegrationSettings.tsx');
+    const source = fs.readFileSync(filePath, 'utf8');
+    const teamsSource = fs.readFileSync(teamsFilePath, 'utf8');
+
+    // The Microsoft email settings page explicitly opts into the backfill.
+    expect(source).toContain('getMicrosoftIntegrationStatus({ runIssuerBackfill: true })');
+    // The Teams settings page shares the status action only to build its
+    // profile picker and must remain a pure read (no backfill writes).
+    expect(teamsSource).toContain('getMicrosoftIntegrationStatus()');
+    expect(teamsSource).not.toContain('runIssuerBackfill');
   });
 });

--- a/packages/integrations/src/components/settings/integrations/MicrosoftIntegrationSettings.tsx
+++ b/packages/integrations/src/components/settings/integrations/MicrosoftIntegrationSettings.tsx
@@ -28,6 +28,7 @@ import {
   getMicrosoftIntegrationStatus,
   listMicrosoftConsumerBindings,
   resetMicrosoftProvidersToDisconnected,
+  runMicrosoftEmailIssuerBackfill,
   setDefaultMicrosoftProfile,
   setMicrosoftConsumerBinding,
   updateMicrosoftProfile,
@@ -438,10 +439,11 @@ export function MicrosoftIntegrationSettings({
     setError(null);
 
     const [statusResult, bindingsResult] = await Promise.all([
-      // The Microsoft email settings flow opts into the conservative same-client
-      // issuer backfill. The shared status action does NOT backfill by default,
-      // so Teams settings loads stay pure reads of email provider state.
-      getMicrosoftIntegrationStatus({ runIssuerBackfill: true }),
+      // PURE READ. Loading this page must never write to
+      // microsoft_email_provider_config (the Teams settings page shares this
+      // status action to build its profile picker). The conservative same-client
+      // issuer backfill runs only from the deliberate save/reconnect handler.
+      getMicrosoftIntegrationStatus(),
       listMicrosoftConsumerBindings(),
     ]);
 
@@ -628,6 +630,14 @@ export function MicrosoftIntegrationSettings({
             : t('integrations.microsoft.settings.toasts.profileUpdatedDescription', { defaultValue: 'Microsoft app changes saved.' }),
       });
       closeDialog();
+      // Deliberate mutation, not a load side effect: the conservative same-client
+      // issuer backfill pins legacy email providers to the app just saved. It is
+      // best-effort here — a backfill failure must not fail the profile save.
+      try {
+        await runMicrosoftEmailIssuerBackfill();
+      } catch (backfillErr) {
+        console.warn('Microsoft email issuer backfill after profile save failed', backfillErr);
+      }
       await load();
     } finally {
       setSaving(false);

--- a/packages/integrations/src/components/settings/integrations/MicrosoftIntegrationSettings.tsx
+++ b/packages/integrations/src/components/settings/integrations/MicrosoftIntegrationSettings.tsx
@@ -438,7 +438,10 @@ export function MicrosoftIntegrationSettings({
     setError(null);
 
     const [statusResult, bindingsResult] = await Promise.all([
-      getMicrosoftIntegrationStatus(),
+      // The Microsoft email settings flow opts into the conservative same-client
+      // issuer backfill. The shared status action does NOT backfill by default,
+      // so Teams settings loads stay pure reads of email provider state.
+      getMicrosoftIntegrationStatus({ runIssuerBackfill: true }),
       listMicrosoftConsumerBindings(),
     ]);
 

--- a/packages/integrations/src/components/settings/integrations/MicrosoftIntegrationSettings.tsx
+++ b/packages/integrations/src/components/settings/integrations/MicrosoftIntegrationSettings.tsx
@@ -1027,6 +1027,16 @@ export function MicrosoftIntegrationSettings({
                         </Alert>
                       </div>
                     )}
+
+                    {consumer.consumerType === 'email' && (
+                      <div className="lg:col-span-3">
+                        <p className="text-xs text-muted-foreground">
+                          {t('integrations.microsoft.settings.consumers.email.perProviderIssuerNote', {
+                            defaultValue: 'Existing mailbox connections keep their current Microsoft app until they are reconnected. This choice applies to new mailbox connections.',
+                          })}
+                        </p>
+                      </div>
+                    )}
                   </div>
                 );
               })}

--- a/packages/integrations/src/components/settings/integrations/TeamsIntegrationSettings.lifecycle.test.tsx
+++ b/packages/integrations/src/components/settings/integrations/TeamsIntegrationSettings.lifecycle.test.tsx
@@ -176,4 +176,13 @@ describe('TeamsIntegrationSettings add-on lifecycle + stale manifest', () => {
     render(<TeamsIntegrationSettings />);
     await waitFor(() => expect(document.querySelector('#teams-stale-manifest-warning')).toBeInTheDocument());
   });
+
+  it('Teams settings loads Microsoft status WITHOUT the email issuer backfill opt-in', async () => {
+    // The Teams page shares getMicrosoftIntegrationStatus for its profile
+    // picker. It must never trigger the email issuer backfill, which writes
+    // microsoft_email_provider_config rows: the call has to be a pure read.
+    render(<TeamsIntegrationSettings />);
+    await waitFor(() => expect(getMicrosoftIntegrationStatusMock).toHaveBeenCalled());
+    expect(getMicrosoftIntegrationStatusMock).toHaveBeenCalledWith();
+  });
 });

--- a/packages/integrations/src/lib/microsoftConsumerProfileResolution.ts
+++ b/packages/integrations/src/lib/microsoftConsumerProfileResolution.ts
@@ -480,34 +480,20 @@ async function ensureMicrosoftConsumerBindingMigration(
   return binding;
 }
 
-export async function resolveMicrosoftConsumerProfileConfig(
-  tenantId: string,
-  consumerType: MicrosoftProfileConsumer,
-  options?: { credentialPreference?: MicrosoftCredentialPreference }
-): Promise<MicrosoftConsumerProfileResolution> {
-  if (!(MICROSOFT_PROFILE_CONSUMERS as readonly string[]).includes(consumerType)) {
-    return {
-      status: 'not_configured',
-      tenantId,
-      consumerType,
-      message: 'Unsupported Microsoft consumer type',
-    };
-  }
-
-  const db = await getAdminConnection();
-  const secretProvider = await getSecretProviderInstance();
-
-  if (consumerType === 'email' && options?.credentialPreference === 'platform') {
-    const hostedEmailConfig = await resolveHostedMicrosoftEmailConfig(tenantId, secretProvider);
-    return hostedEmailConfig || {
-      status: 'not_configured',
-      tenantId,
-      consumerType,
-      message: 'Platform Microsoft credentials are not configured',
-    };
-  }
-
-  const binding = await ensureMicrosoftConsumerBindingMigration(db, tenantId, consumerType, secretProvider);
+/**
+ * Pure resolution core shared by the migrating and read-only entry points.
+ * Given an already-resolved binding (or none), derives the consumer profile
+ * status WITHOUT writing anything. Never calls the ensure/backfill helpers.
+ */
+async function resolveConsumerProfileFromBinding(input: {
+  db: any;
+  tenantId: string;
+  consumerType: MicrosoftProfileConsumer;
+  secretProvider: Awaited<ReturnType<typeof getSecretProviderInstance>>;
+  options?: { credentialPreference?: MicrosoftCredentialPreference };
+  binding: MicrosoftConsumerBindingRow | undefined;
+}): Promise<MicrosoftConsumerProfileResolution> {
+  const { db, tenantId, consumerType, secretProvider, options, binding } = input;
 
   if (!binding) {
     if (consumerType === 'email') {
@@ -606,4 +592,83 @@ export async function resolveMicrosoftConsumerProfileConfig(
     microsoftTenantId: normalizeTenantId(profile.tenant_id),
     credentialSource: 'binding',
   };
+}
+
+function isSupportedConsumerType(consumerType: MicrosoftProfileConsumer): boolean {
+  return (MICROSOFT_PROFILE_CONSUMERS as readonly string[]).includes(consumerType);
+}
+
+export async function resolveMicrosoftConsumerProfileConfig(
+  tenantId: string,
+  consumerType: MicrosoftProfileConsumer,
+  options?: { credentialPreference?: MicrosoftCredentialPreference }
+): Promise<MicrosoftConsumerProfileResolution> {
+  if (!isSupportedConsumerType(consumerType)) {
+    return {
+      status: 'not_configured',
+      tenantId,
+      consumerType,
+      message: 'Unsupported Microsoft consumer type',
+    };
+  }
+
+  const db = await getAdminConnection();
+  const secretProvider = await getSecretProviderInstance();
+
+  if (consumerType === 'email' && options?.credentialPreference === 'platform') {
+    const hostedEmailConfig = await resolveHostedMicrosoftEmailConfig(tenantId, secretProvider);
+    return hostedEmailConfig || {
+      status: 'not_configured',
+      tenantId,
+      consumerType,
+      message: 'Platform Microsoft credentials are not configured',
+    };
+  }
+
+  // Runtime resolution is allowed to migrate: auth, calendar, and inbound-email
+  // operations legitimately backfill legacy state so the tenant keeps working.
+  const binding = await ensureMicrosoftConsumerBindingMigration(db, tenantId, consumerType, secretProvider);
+  return resolveConsumerProfileFromBinding({ db, tenantId, consumerType, secretProvider, options, binding });
+}
+
+/**
+ * Read-only variant of `resolveMicrosoftConsumerProfileConfig`.
+ *
+ * Resolves the CURRENT persisted state without running the legacy profile
+ * backfill or the consumer-binding migration — the two `ensure*` helpers can
+ * insert profile/binding rows and write secrets. Status/settings read paths
+ * (`getMicrosoftEmailSetupReadiness`, `getMicrosoftIntegrationStatus`,
+ * `getMicrosoftConsumerSetupStatus`) must use this variant so a page load never
+ * mutates the database. Runtime consumers (auth, calendar, email OAuth and
+ * token refresh) intentionally keep using the migrating variant.
+ */
+export async function resolveMicrosoftConsumerProfileConfigReadOnly(
+  tenantId: string,
+  consumerType: MicrosoftProfileConsumer,
+  options?: { credentialPreference?: MicrosoftCredentialPreference }
+): Promise<MicrosoftConsumerProfileResolution> {
+  if (!isSupportedConsumerType(consumerType)) {
+    return {
+      status: 'not_configured',
+      tenantId,
+      consumerType,
+      message: 'Unsupported Microsoft consumer type',
+    };
+  }
+
+  const db = await getAdminConnection();
+  const secretProvider = await getSecretProviderInstance();
+
+  if (consumerType === 'email' && options?.credentialPreference === 'platform') {
+    const hostedEmailConfig = await resolveHostedMicrosoftEmailConfig(tenantId, secretProvider);
+    return hostedEmailConfig || {
+      status: 'not_configured',
+      tenantId,
+      consumerType,
+      message: 'Platform Microsoft credentials are not configured',
+    };
+  }
+
+  const binding = await getMicrosoftConsumerBindingRow(db, tenantId, consumerType);
+  return resolveConsumerProfileFromBinding({ db, tenantId, consumerType, secretProvider, options, binding });
 }

--- a/packages/integrations/src/lib/microsoftEmailIssuerSelection.test.ts
+++ b/packages/integrations/src/lib/microsoftEmailIssuerSelection.test.ts
@@ -1,0 +1,447 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const hoisted = vi.hoisted(() => {
+  type Row = Record<string, unknown>;
+
+  const state = {
+    tenantSecrets: new Map<string, string>(),
+    appSecrets: new Map<string, string>(),
+    microsoftProfiles: [] as Row[],
+    microsoftConsumerBindings: [] as Row[],
+    emailProviders: [] as Row[],
+    microsoftEmailProviderConfigs: [] as Row[],
+  };
+
+  const clone = <T,>(value: T): T => JSON.parse(JSON.stringify(value));
+
+  const rowsFor = (table: string): Row[] => {
+    switch (table) {
+      case 'microsoft_profiles':
+        return state.microsoftProfiles;
+      case 'microsoft_profile_consumer_bindings':
+        return state.microsoftConsumerBindings;
+      case 'email_providers':
+        return state.emailProviders;
+      case 'microsoft_email_provider_config':
+        return state.microsoftEmailProviderConfigs;
+      default:
+        return [] as Row[];
+    }
+  };
+
+  const matches = (row: Row, conditions: Row): boolean =>
+    Object.entries(conditions).every(([key, value]) => row[key] === value);
+
+  const createQuery = (table: string) => {
+    const filters: Row[] = [];
+    const filteredRows = () =>
+      rowsFor(table).filter((row) => filters.every((f) => matches(row, f)));
+
+    return {
+      where(conditions: Row) {
+        filters.push(conditions);
+        return this;
+      },
+      async first() {
+        const row = filteredRows()[0];
+        return row ? clone(row) : undefined;
+      },
+      async select(..._args: unknown[]) {
+        return filteredRows().map((row) => clone(row));
+      },
+      async insert(values: Row | Row[]) {
+        const rows = Array.isArray(values) ? values : [values];
+        rows.forEach((row) => rowsFor(table).push(clone(row)));
+        return rows.length;
+      },
+      async update(values: Row) {
+        const rows = filteredRows();
+        rows.forEach((row) => Object.assign(row, clone(values)));
+        return rows.length;
+      },
+    };
+  };
+
+  const dbMock: any = ((table: string) => createQuery(table)) as any;
+  (dbMock as any).fn = { now: () => new Date().toISOString() };
+
+  const resolveMicrosoftConsumerProfileConfig = vi.fn();
+
+  return {
+    state,
+    getTenantSecret: vi.fn(async (tenant: string, key: string) => state.tenantSecrets.get(`${tenant}:${key}`) || null),
+    getAppSecret: vi.fn(async (key: string) => state.appSecrets.get(key) || null),
+    setTenantSecret: vi.fn(async (tenant: string, key: string, value: string | null) => {
+      if (value === null) {
+        state.tenantSecrets.delete(`${tenant}:${key}`);
+      } else {
+        state.tenantSecrets.set(`${tenant}:${key}`, value);
+      }
+    }),
+    getAdminConnection: vi.fn(async () => dbMock),
+    resolveMicrosoftConsumerProfileConfig,
+  };
+});
+
+vi.mock('@alga-psa/core/secrets', () => ({
+  getSecretProviderInstance: async () => ({
+    getTenantSecret: hoisted.getTenantSecret,
+    getAppSecret: hoisted.getAppSecret,
+    setTenantSecret: hoisted.setTenantSecret,
+  }),
+}));
+
+vi.mock('@alga-psa/db/admin', () => ({
+  getAdminConnection: hoisted.getAdminConnection,
+}));
+
+vi.mock('@alga-psa/db', () => ({
+  tenantDb: (conn: any, tenant: string) => ({
+    table: (table: string) => conn(table).where({ tenant }),
+  }),
+}));
+
+vi.mock('./microsoftConsumerProfileResolution', () => ({
+  resolveMicrosoftConsumerProfileConfig: (...args: unknown[]) =>
+    hoisted.resolveMicrosoftConsumerProfileConfig(...args),
+}));
+
+import {
+  MICROSOFT_EMAIL_ISSUER_ERRORS,
+  MicrosoftEmailIssuerError,
+  backfillMicrosoftEmailProviderIssuerMetadata,
+  listEligibleMicrosoftEmailIssuers,
+  resolveMicrosoftEmailIssuerChoice,
+} from './microsoftEmailIssuerSelection';
+
+const profile = (overrides: Record<string, unknown> = {}): Record<string, unknown> => ({
+  tenant: 'tenant-1',
+  profile_id: 'profile-1',
+  display_name: 'Profile One',
+  client_id: 'client-1',
+  tenant_id: 'tenant-dir-1',
+  client_secret_ref: 'ref-1',
+  capabilities: ['email', 'calendar'],
+  is_default: true,
+  is_archived: false,
+  email_admin_consent_required: false,
+  email_admin_consent_granted_at: null,
+  ...overrides,
+});
+
+function seedProfiles(rows: Record<string, unknown>[]): void {
+  hoisted.state.microsoftProfiles.push(...rows);
+}
+
+function seedProviderConfig(clientId: string | null, profileId: string | null = null): string {
+  const providerId = `provider-${hoisted.state.emailProviders.length + 1}`;
+  hoisted.state.emailProviders.push({
+    id: providerId,
+    tenant: 'tenant-1',
+    provider_type: 'microsoft',
+  });
+  hoisted.state.microsoftEmailProviderConfigs.push({
+    tenant: 'tenant-1',
+    email_provider_id: providerId,
+    client_id: clientId,
+    microsoft_profile_id: profileId,
+    client_secret_ref: null,
+    tenant_id: 'common',
+  });
+  return providerId;
+}
+
+describe('listEligibleMicrosoftEmailIssuers', () => {
+  beforeEach(() => {
+    hoisted.state.tenantSecrets.clear();
+    hoisted.state.appSecrets.clear();
+    hoisted.state.microsoftProfiles.length = 0;
+    hoisted.state.microsoftConsumerBindings.length = 0;
+    hoisted.state.emailProviders.length = 0;
+    hoisted.state.microsoftEmailProviderConfigs.length = 0;
+    hoisted.resolveMicrosoftConsumerProfileConfig.mockReset();
+  });
+
+  it('recommends the managed app when the platform is ready and lists eligible tenant profiles', async () => {
+    hoisted.resolveMicrosoftConsumerProfileConfig.mockResolvedValue({
+      status: 'ready',
+      tenantId: 'tenant-1',
+      consumerType: 'email',
+      credentialSource: 'app',
+      clientId: 'managed-client-id',
+      clientSecret: 'managed-client-secret',
+      microsoftTenantId: 'common',
+    });
+    seedProfiles([
+      profile({ profile_id: 'p-1', display_name: 'Email App', client_id: 'client-1' }),
+    ]);
+    hoisted.state.tenantSecrets.set('tenant-1:ref-1', 'secret-1');
+
+    const issuers = await listEligibleMicrosoftEmailIssuers('tenant-1');
+
+    expect(issuers.managed).toMatchObject({
+      kind: 'managed',
+      clientId: 'managed-client-id',
+      recommended: true,
+    });
+    expect(issuers.recommended).toEqual({ kind: 'managed', clientId: 'managed-client-id' });
+    expect(issuers.profiles).toHaveLength(1);
+    expect(issuers.profiles[0]).toMatchObject({
+      kind: 'profile',
+      profileId: 'p-1',
+      clientId: 'client-1',
+    });
+  });
+
+  it('falls back to the tenant Email binding profile as the recommended default when managed is unavailable', async () => {
+    hoisted.resolveMicrosoftConsumerProfileConfig.mockResolvedValue({
+      status: 'not_configured',
+      tenantId: 'tenant-1',
+      consumerType: 'email',
+      message: 'Platform Microsoft credentials are not configured',
+    });
+    seedProfiles([profile({ profile_id: 'p-1', display_name: 'Bound Email App', client_id: 'bound-client' })]);
+    hoisted.state.tenantSecrets.set('tenant-1:ref-1', 'secret-1');
+    hoisted.state.microsoftConsumerBindings.push({
+      tenant: 'tenant-1',
+      consumer_type: 'email',
+      profile_id: 'p-1',
+    });
+
+    const issuers = await listEligibleMicrosoftEmailIssuers('tenant-1');
+
+    expect(issuers.managed).toBeUndefined();
+    expect(issuers.recommended).toEqual({
+      kind: 'profile',
+      profileId: 'p-1',
+      clientId: 'bound-client',
+    });
+  });
+
+  it('lists multiple eligible tenant profiles so the admin can choose one', async () => {
+    hoisted.resolveMicrosoftConsumerProfileConfig.mockResolvedValue({
+      status: 'not_configured',
+      tenantId: 'tenant-1',
+      consumerType: 'email',
+      message: 'not configured',
+    });
+    seedProfiles([
+      profile({ profile_id: 'p-1', display_name: 'App A', client_id: 'client-a' }),
+      profile({ profile_id: 'p-2', display_name: 'App B', client_id: 'client-b', is_default: false }),
+    ]);
+    hoisted.state.tenantSecrets.set('tenant-1:ref-1', 'secret-a');
+
+    const issuers = await listEligibleMicrosoftEmailIssuers('tenant-1');
+
+    expect(issuers.profiles.map((p) => p.profileId)).toEqual(['p-1', 'p-2']);
+  });
+
+  it('never lists a Teams-only app or a pending-consent app for Email', async () => {
+    hoisted.resolveMicrosoftConsumerProfileConfig.mockResolvedValue({
+      status: 'not_configured',
+      tenantId: 'tenant-1',
+      consumerType: 'email',
+      message: 'not configured',
+    });
+    seedProfiles([
+      profile({ profile_id: 'p-teams', display_name: 'Teams Only', client_id: 'teams-client', capabilities: ['teams'] }),
+      profile({
+        profile_id: 'p-consent',
+        display_name: 'Pending Consent',
+        client_id: 'consent-client',
+        email_admin_consent_required: true,
+        email_admin_consent_granted_at: null,
+        is_default: false,
+      }),
+    ]);
+
+    const issuers = await listEligibleMicrosoftEmailIssuers('tenant-1');
+
+    expect(issuers.profiles).toHaveLength(0);
+  });
+});
+
+describe('resolveMicrosoftEmailIssuerChoice', () => {
+  beforeEach(() => {
+    hoisted.state.tenantSecrets.clear();
+    hoisted.state.appSecrets.clear();
+    hoisted.state.microsoftProfiles.length = 0;
+    hoisted.state.microsoftConsumerBindings.length = 0;
+    hoisted.state.emailProviders.length = 0;
+    hoisted.state.microsoftEmailProviderConfigs.length = 0;
+    hoisted.resolveMicrosoftConsumerProfileConfig.mockReset();
+  });
+
+  it('resolves a managed selection to the platform app', async () => {
+    hoisted.resolveMicrosoftConsumerProfileConfig.mockResolvedValue({
+      status: 'ready',
+      tenantId: 'tenant-1',
+      consumerType: 'email',
+      credentialSource: 'app',
+      clientId: 'managed-client-id',
+      clientSecret: 'managed-client-secret',
+      microsoftTenantId: 'common',
+    });
+
+    const resolution = await resolveMicrosoftEmailIssuerChoice('tenant-1', {
+      kind: 'managed',
+      clientId: 'managed-client-id',
+    });
+
+    expect(resolution).toMatchObject({
+      issuerKind: 'managed',
+      clientId: 'managed-client-id',
+      clientSecret: 'managed-client-secret',
+      microsoftTenantId: 'common',
+    });
+  });
+
+  it('rejects a managed choice when the platform app is not configured', async () => {
+    hoisted.resolveMicrosoftConsumerProfileConfig.mockResolvedValue({
+      status: 'not_configured',
+      tenantId: 'tenant-1',
+      consumerType: 'email',
+      message: 'Platform Microsoft credentials are not configured',
+    });
+
+    await expect(
+      resolveMicrosoftEmailIssuerChoice('tenant-1', { kind: 'managed', clientId: 'managed-client-id' })
+    ).rejects.toMatchObject({
+      code: MICROSOFT_EMAIL_ISSUER_ERRORS.ISSUER_NOT_READY,
+    });
+  });
+
+  it('resolves an eligible tenant profile and pins its profile and secret reference', async () => {
+    seedProfiles([profile({ profile_id: 'p-1', client_id: 'client-1' })]);
+    hoisted.state.tenantSecrets.set('tenant-1:ref-1', 'secret-1');
+
+    const resolution = await resolveMicrosoftEmailIssuerChoice('tenant-1', {
+      kind: 'profile',
+      profileId: 'p-1',
+      clientId: 'client-1',
+    });
+
+    expect(resolution).toMatchObject({
+      issuerKind: 'profile',
+      profileId: 'p-1',
+      clientId: 'client-1',
+      clientSecret: 'secret-1',
+      clientSecretRef: 'ref-1',
+      microsoftTenantId: 'tenant-dir-1',
+    });
+  });
+
+  it('rejects a Teams-only profile for Email with a stable capability error', async () => {
+    seedProfiles([profile({ profile_id: 'p-teams', client_id: 'teams-client', capabilities: ['teams'] })]);
+
+    const promise = resolveMicrosoftEmailIssuerChoice('tenant-1', {
+      kind: 'profile',
+      profileId: 'p-teams',
+      clientId: 'teams-client',
+    });
+    await expect(promise).rejects.toBeInstanceOf(MicrosoftEmailIssuerError);
+    await expect(promise).rejects.toMatchObject({
+      code: MICROSOFT_EMAIL_ISSUER_ERRORS.MISSING_EMAIL_CAPABILITY,
+    });
+  });
+
+  it('rejects an archived profile', async () => {
+    seedProfiles([profile({ profile_id: 'p-archived', is_archived: true })]);
+
+    await expect(
+      resolveMicrosoftEmailIssuerChoice('tenant-1', { kind: 'profile', profileId: 'p-archived', clientId: 'client-1' })
+    ).rejects.toMatchObject({ code: MICROSOFT_EMAIL_ISSUER_ERRORS.INACTIVE_PROFILE });
+  });
+
+  it('rejects a profile whose tenant consent is still pending', async () => {
+    seedProfiles([
+      profile({
+        profile_id: 'p-consent',
+        email_admin_consent_required: true,
+        email_admin_consent_granted_at: null,
+      }),
+    ]);
+
+    await expect(
+      resolveMicrosoftEmailIssuerChoice('tenant-1', { kind: 'profile', profileId: 'p-consent', clientId: 'client-1' })
+    ).rejects.toMatchObject({ code: MICROSOFT_EMAIL_ISSUER_ERRORS.CONSENT_NOT_READY });
+  });
+
+  it('rejects an unknown / cross-tenant profile', async () => {
+    await expect(
+      resolveMicrosoftEmailIssuerChoice('tenant-1', { kind: 'profile', profileId: 'missing', clientId: 'x' })
+    ).rejects.toMatchObject({ code: MICROSOFT_EMAIL_ISSUER_ERRORS.PROFILE_NOT_FOUND });
+  });
+
+  it('rejects a malformed choice', async () => {
+    await expect(resolveMicrosoftEmailIssuerChoice('tenant-1', null)).rejects.toMatchObject({
+      code: MICROSOFT_EMAIL_ISSUER_ERRORS.INVALID_CHOICE,
+    });
+    await expect(
+      resolveMicrosoftEmailIssuerChoice('tenant-1', { kind: 'profile', clientId: '' })
+    ).rejects.toMatchObject({ code: MICROSOFT_EMAIL_ISSUER_ERRORS.INVALID_CHOICE });
+  });
+});
+
+describe('backfillMicrosoftEmailProviderIssuerMetadata', () => {
+  beforeEach(() => {
+    hoisted.state.tenantSecrets.clear();
+    hoisted.state.appSecrets.clear();
+    hoisted.state.microsoftProfiles.length = 0;
+    hoisted.state.microsoftConsumerBindings.length = 0;
+    hoisted.state.emailProviders.length = 0;
+    hoisted.state.microsoftEmailProviderConfigs.length = 0;
+    hoisted.resolveMicrosoftConsumerProfileConfig.mockReset();
+  });
+
+  it('backfills a unique same-client eligible profile and leaves ambiguous rows unchanged', async () => {
+    seedProfiles([
+      profile({ profile_id: 'p-1', display_name: 'App A', client_id: 'shared-client', is_default: true }),
+      profile({ profile_id: 'p-2', display_name: 'App B', client_id: 'shared-client', is_default: false }),
+      profile({ profile_id: 'p-3', display_name: 'Unique App', client_id: 'unique-client', is_default: false }),
+    ]);
+    hoisted.state.tenantSecrets.set('tenant-1:ref-1', 'secret-1');
+
+    // unique-client: exactly one eligible match -> backfilled.
+    const uniqueProviderId = seedProviderConfig('unique-client');
+    // shared-client: two eligible matches -> ambiguous, left untouched.
+    const ambiguousProviderId = seedProviderConfig('shared-client');
+    // no client id -> untouched.
+    const noClientProviderId = seedProviderConfig(null);
+
+    const result = await backfillMicrosoftEmailProviderIssuerMetadata('tenant-1');
+
+    expect(result.backfilled).toBe(1);
+    expect(result.ambiguous).toBe(1);
+    expect(result.unchanged).toBe(1);
+
+    const uniqueConfig = hoisted.state.microsoftEmailProviderConfigs.find(
+      (row) => row.email_provider_id === uniqueProviderId
+    );
+    expect(uniqueConfig).toMatchObject({
+      microsoft_profile_id: 'p-3',
+      client_secret_ref: 'ref-1',
+    });
+
+    const ambiguousConfig = hoisted.state.microsoftEmailProviderConfigs.find(
+      (row) => row.email_provider_id === ambiguousProviderId
+    );
+    expect(ambiguousConfig?.microsoft_profile_id).toBeNull();
+
+    const noClientConfig = hoisted.state.microsoftEmailProviderConfigs.find(
+      (row) => row.email_provider_id === noClientProviderId
+    );
+    expect(noClientConfig?.microsoft_profile_id).toBeNull();
+  });
+
+  it('does not touch rows already pinned to a profile', async () => {
+    seedProfiles([profile({ profile_id: 'p-1', client_id: 'client-1' })]);
+    seedProviderConfig('client-1', 'p-1');
+
+    const result = await backfillMicrosoftEmailProviderIssuerMetadata('tenant-1');
+
+    expect(result.backfilled).toBe(0);
+    const config = hoisted.state.microsoftEmailProviderConfigs[0];
+    expect(config.microsoft_profile_id).toBe('p-1');
+  });
+});

--- a/packages/integrations/src/lib/microsoftEmailIssuerSelection.test.ts
+++ b/packages/integrations/src/lib/microsoftEmailIssuerSelection.test.ts
@@ -259,6 +259,46 @@ describe('listEligibleMicrosoftEmailIssuers', () => {
 
     expect(issuers.profiles).toHaveLength(0);
   });
+
+  it('never lists a profile whose credential secret cannot be resolved', async () => {
+    hoisted.resolveMicrosoftConsumerProfileConfig.mockResolvedValue({
+      status: 'not_configured',
+      tenantId: 'tenant-1',
+      consumerType: 'email',
+      message: 'not configured',
+    });
+    // Structurally eligible (active, Email-capable, consented) but the secret
+    // behind client_secret_ref is absent — it must not be selectable.
+    seedProfiles([
+      profile({ profile_id: 'p-nosecret', display_name: 'No Secret', client_id: 'nosecret-client', client_secret_ref: 'ref-nosecret' }),
+      profile({ profile_id: 'p-ready', display_name: 'Ready App', client_id: 'ready-client', is_default: false }),
+    ]);
+    hoisted.state.tenantSecrets.set('tenant-1:ref-1', 'secret-1');
+
+    const issuers = await listEligibleMicrosoftEmailIssuers('tenant-1');
+
+    expect(issuers.profiles.map((p) => p.profileId)).toEqual(['p-ready']);
+  });
+
+  it('does not recommend a bound profile whose secret cannot be resolved', async () => {
+    hoisted.resolveMicrosoftConsumerProfileConfig.mockResolvedValue({
+      status: 'not_configured',
+      tenantId: 'tenant-1',
+      consumerType: 'email',
+      message: 'not configured',
+    });
+    seedProfiles([profile({ profile_id: 'p-bound', display_name: 'Bound No Secret', client_id: 'bound-client' })]);
+    hoisted.state.microsoftConsumerBindings.push({
+      tenant: 'tenant-1',
+      consumer_type: 'email',
+      profile_id: 'p-bound',
+    });
+
+    const issuers = await listEligibleMicrosoftEmailIssuers('tenant-1');
+
+    expect(issuers.recommended).toBeNull();
+    expect(issuers.profiles).toHaveLength(0);
+  });
 });
 
 describe('resolveMicrosoftEmailIssuerChoice', () => {
@@ -443,5 +483,21 @@ describe('backfillMicrosoftEmailProviderIssuerMetadata', () => {
     expect(result.backfilled).toBe(0);
     const config = hoisted.state.microsoftEmailProviderConfigs[0];
     expect(config.microsoft_profile_id).toBe('p-1');
+  });
+
+  it('does not backfill a profile whose secret cannot be resolved', async () => {
+    seedProfiles([
+      profile({ profile_id: 'p-1', client_id: 'unique-client', client_secret_ref: 'ref-nosecret' }),
+    ]);
+    const providerId = seedProviderConfig('unique-client');
+
+    const result = await backfillMicrosoftEmailProviderIssuerMetadata('tenant-1');
+
+    expect(result.backfilled).toBe(0);
+    const config = hoisted.state.microsoftEmailProviderConfigs.find(
+      (row) => row.email_provider_id === providerId
+    );
+    expect(config?.microsoft_profile_id).toBeNull();
+    expect(config?.client_secret_ref).toBeNull();
   });
 });

--- a/packages/integrations/src/lib/microsoftEmailIssuerSelection.test.ts
+++ b/packages/integrations/src/lib/microsoftEmailIssuerSelection.test.ts
@@ -280,6 +280,37 @@ describe('listEligibleMicrosoftEmailIssuers', () => {
     expect(issuers.profiles.map((p) => p.profileId)).toEqual(['p-ready']);
   });
 
+  it('never lists or recommends the tenant Teams app even when it carries Email capability', async () => {
+    hoisted.resolveMicrosoftConsumerProfileConfig.mockResolvedValue({
+      status: 'not_configured',
+      tenantId: 'tenant-1',
+      consumerType: 'email',
+      message: 'not configured',
+    });
+    // The well-known Teams client id must be excluded regardless of how the
+    // profile is labeled.
+    seedProfiles([
+      profile({
+        profile_id: 'p-teams-app',
+        display_name: 'Teams App',
+        client_id: '02c1ecbc-10db-4439-b002-1187acf7b268',
+        capabilities: ['teams', 'email'],
+        is_default: true,
+      }),
+    ]);
+    hoisted.state.tenantSecrets.set('tenant-1:ref-1', 'secret-1');
+    hoisted.state.microsoftConsumerBindings.push({
+      tenant: 'tenant-1',
+      consumer_type: 'email',
+      profile_id: 'p-teams-app',
+    });
+
+    const issuers = await listEligibleMicrosoftEmailIssuers('tenant-1');
+
+    expect(issuers.profiles).toHaveLength(0);
+    expect(issuers.recommended).toBeNull();
+  });
+
   it('does not recommend a bound profile whose secret cannot be resolved', async () => {
     hoisted.resolveMicrosoftConsumerProfileConfig.mockResolvedValue({
       status: 'not_configured',
@@ -383,6 +414,25 @@ describe('resolveMicrosoftEmailIssuerChoice', () => {
     await expect(promise).rejects.toMatchObject({
       code: MICROSOFT_EMAIL_ISSUER_ERRORS.MISSING_EMAIL_CAPABILITY,
     });
+  });
+
+  it('rejects the tenant Teams app client id even when the profile claims Email capability', async () => {
+    seedProfiles([
+      profile({
+        profile_id: 'p-teams-app',
+        client_id: '02c1ecbc-10db-4439-b002-1187acf7b268',
+        capabilities: ['teams', 'email'],
+      }),
+    ]);
+    hoisted.state.tenantSecrets.set('tenant-1:ref-1', 'secret-1');
+
+    await expect(
+      resolveMicrosoftEmailIssuerChoice('tenant-1', {
+        kind: 'profile',
+        profileId: 'p-teams-app',
+        clientId: '02c1ecbc-10db-4439-b002-1187acf7b268',
+      })
+    ).rejects.toMatchObject({ code: MICROSOFT_EMAIL_ISSUER_ERRORS.INVALID_CHOICE });
   });
 
   it('rejects an archived profile', async () => {
@@ -490,6 +540,28 @@ describe('backfillMicrosoftEmailProviderIssuerMetadata', () => {
       profile({ profile_id: 'p-1', client_id: 'unique-client', client_secret_ref: 'ref-nosecret' }),
     ]);
     const providerId = seedProviderConfig('unique-client');
+
+    const result = await backfillMicrosoftEmailProviderIssuerMetadata('tenant-1');
+
+    expect(result.backfilled).toBe(0);
+    const config = hoisted.state.microsoftEmailProviderConfigs.find(
+      (row) => row.email_provider_id === providerId
+    );
+    expect(config?.microsoft_profile_id).toBeNull();
+    expect(config?.client_secret_ref).toBeNull();
+  });
+
+  it('never backfills an email provider onto the tenant Teams app', async () => {
+    seedProfiles([
+      profile({
+        profile_id: 'p-teams-app',
+        client_id: '02c1ecbc-10db-4439-b002-1187acf7b268',
+        capabilities: ['teams', 'email'],
+        is_default: true,
+      }),
+    ]);
+    hoisted.state.tenantSecrets.set('tenant-1:ref-1', 'secret-1');
+    const providerId = seedProviderConfig('02c1ecbc-10db-4439-b002-1187acf7b268');
 
     const result = await backfillMicrosoftEmailProviderIssuerMetadata('tenant-1');
 

--- a/packages/integrations/src/lib/microsoftEmailIssuerSelection.ts
+++ b/packages/integrations/src/lib/microsoftEmailIssuerSelection.ts
@@ -15,6 +15,7 @@
 import { getSecretProviderInstance } from '@alga-psa/core/secrets';
 import { tenantDb } from '@alga-psa/db';
 import { getAdminConnection } from '@alga-psa/db/admin';
+import { MICROSOFT_TEAMS_APP_CLIENT_ID } from '@alga-psa/shared/services/email/microsoftGraphEndpoints';
 import {
   hasMicrosoftProfileCapability,
   normalizeMicrosoftProfileCapabilities,
@@ -131,6 +132,17 @@ export function isSameMicrosoftClientId(left: string | null | undefined, right: 
   return normalizeClientId(left).toLowerCase() === normalizeClientId(right).toLowerCase();
 }
 
+/**
+ * True when the client id belongs to the tenant-wide Teams application. The
+ * Teams app must never be treated as Email-eligible: it has no mailbox redirect
+ * URI and no Mail.Read grant, so offering it as an email issuer or backfilling
+ * an email provider onto it would hand the mailbox OAuth flow an app that
+ * cannot authorize.
+ */
+export function isMicrosoftTeamsAppClientId(value: string | null | undefined): boolean {
+  return isSameMicrosoftClientId(value, MICROSOFT_TEAMS_APP_CLIENT_ID);
+}
+
 function profileHasEmailCapability(profile: Pick<MicrosoftProfileRow, 'capabilities'>): boolean {
   return hasMicrosoftProfileCapability(normalizeMicrosoftProfileCapabilities(profile.capabilities), 'email');
 }
@@ -143,6 +155,7 @@ function isEligibleProfile(profile: MicrosoftProfileRow): boolean {
   return (
     !profile.is_archived &&
     profileHasEmailCapability(profile) &&
+    !isMicrosoftTeamsAppClientId(profile.client_id) &&
     Boolean(normalizeClientId(profile.client_id)) &&
     Boolean((profile.tenant_id || '').trim()) &&
     isConsentReady(profile)
@@ -243,6 +256,12 @@ async function resolveProfileIssuer(tenant: string, choice: MicrosoftEmailIssuer
     throw new MicrosoftEmailIssuerError(
       MICROSOFT_EMAIL_ISSUER_ERRORS.MISSING_EMAIL_CAPABILITY,
       'The selected Microsoft application is not enabled for Outlook email'
+    );
+  }
+  if (isMicrosoftTeamsAppClientId(profile.client_id)) {
+    throw new MicrosoftEmailIssuerError(
+      MICROSOFT_EMAIL_ISSUER_ERRORS.INVALID_CHOICE,
+      'The selected application is the Microsoft Teams app and cannot authorize mailboxes'
     );
   }
   if (!isConsentReady(profile)) {

--- a/packages/integrations/src/lib/microsoftEmailIssuerSelection.ts
+++ b/packages/integrations/src/lib/microsoftEmailIssuerSelection.ts
@@ -83,6 +83,12 @@ export const MICROSOFT_EMAIL_ISSUER_ERRORS = {
   EXPIRED_STATE: 'ms_email_expired_state',
   REPLAYED_STATE: 'ms_email_replayed_state',
   CALLBACK_PERSISTENCE_FAILED: 'ms_email_callback_persistence_failed',
+  ISSUER_REQUIRED: 'ms_email_issuer_required',
+  STATE_USER_MISMATCH: 'ms_email_state_user_mismatch',
+  STATE_PURPOSE_MISMATCH: 'ms_email_state_purpose_mismatch',
+  PROVIDER_NOT_FOUND: 'ms_email_provider_not_found',
+  PROVIDER_TENANT_MISMATCH: 'ms_email_provider_tenant_mismatch',
+  PROVIDER_TYPE_NOT_SUPPORTED: 'ms_email_provider_type_not_supported',
 } as const;
 
 export type MicrosoftEmailIssuerErrorCode =
@@ -141,6 +147,22 @@ function isEligibleProfile(profile: MicrosoftProfileRow): boolean {
     Boolean((profile.tenant_id || '').trim()) &&
     isConsentReady(profile)
   );
+}
+
+/**
+ * An eligible profile must also prove its credential secret is actually
+ * resolvable — not merely claim readiness via a `client_secret_ref`. A profile
+ * whose secret cannot be resolved must never surface as a selectable issuer or
+ * as a backfill candidate.
+ */
+async function isEligibleProfileWithResolvableSecret(
+  tenant: string,
+  profile: MicrosoftProfileRow
+): Promise<boolean> {
+  if (!isEligibleProfile(profile)) return false;
+  const secretProvider = await getSecretProviderInstance();
+  const clientSecret = await secretProvider.getTenantSecret(tenant, profile.client_secret_ref);
+  return Boolean(clientSecret && clientSecret.trim());
 }
 
 async function getTenantProfiles(db: any, tenant: string): Promise<MicrosoftProfileRow[]> {
@@ -326,10 +348,18 @@ export async function listEligibleMicrosoftEmailIssuers(
     getBoundEmailProfile(db, tenant),
   ]);
 
-  const eligibleProfiles = profiles.filter(isEligibleProfile).sort((left, right) => {
-    if (left.is_default !== right.is_default) return left.is_default ? -1 : 1;
-    return left.display_name.localeCompare(right.display_name);
-  });
+  const eligibleProfiles = (await Promise.all(
+    profiles.map(async (profile) => ({
+      profile,
+      eligible: await isEligibleProfileWithResolvableSecret(tenant, profile),
+    }))
+  ))
+    .filter((entry) => entry.eligible)
+    .map((entry) => entry.profile)
+    .sort((left, right) => {
+      if (left.is_default !== right.is_default) return left.is_default ? -1 : 1;
+      return left.display_name.localeCompare(right.display_name);
+    });
 
   const profileOptions: MicrosoftEmailIssuerOption[] = eligibleProfiles.map((profile) => ({
     kind: 'profile',
@@ -349,11 +379,11 @@ export async function listEligibleMicrosoftEmailIssuers(
     : undefined;
 
   // The create-flow default: managed when offered, else the tenant Email
-  // binding's profile when it is eligible.
+  // binding's profile when it is eligible and its secret is resolvable.
   let recommended: MicrosoftEmailIssuerChoice | null = null;
   if (managedOption) {
     recommended = { kind: 'managed', clientId: managedOption.clientId };
-  } else if (boundProfile && isEligibleProfile(boundProfile)) {
+  } else if (boundProfile && await isEligibleProfileWithResolvableSecret(tenant, boundProfile)) {
     recommended = {
       kind: 'profile',
       profileId: boundProfile.profile_id,
@@ -405,7 +435,7 @@ export async function backfillMicrosoftEmailProviderIssuerMetadata(tenant: strin
   const profiles = await getTenantProfiles(db, tenant);
   const eligibleByClientId = new Map<string, MicrosoftProfileRow[]>();
   for (const profile of profiles) {
-    if (!isEligibleProfile(profile)) continue;
+    if (!(await isEligibleProfileWithResolvableSecret(tenant, profile))) continue;
     const key = normalizeClientId(profile.client_id).toLowerCase();
     if (!key) continue;
     const bucket = eligibleByClientId.get(key) || [];

--- a/packages/integrations/src/lib/microsoftEmailIssuerSelection.ts
+++ b/packages/integrations/src/lib/microsoftEmailIssuerSelection.ts
@@ -1,0 +1,467 @@
+/**
+ * Explicit Microsoft inbound-email issuer selection.
+ *
+ * When an admin creates or reconnects a Microsoft inbound-email provider they
+ * must choose which Microsoft OAuth application authorizes the mailbox. That
+ * choice travels through OAuth initiation, signed state, and callback, and is
+ * persisted on `microsoft_email_provider_config` as provider-authoritative
+ * issuer metadata (`client_id` + optional `microsoft_profile_id`).
+ *
+ * This module owns the choice DTO, the eligibility listing shown in the UI, the
+ * server-side validation of a submitted choice, and the conservative legacy
+ * backfill. It never touches Teams profiles, credentials, or bindings.
+ */
+
+import { getSecretProviderInstance } from '@alga-psa/core/secrets';
+import { tenantDb } from '@alga-psa/db';
+import { getAdminConnection } from '@alga-psa/db/admin';
+import {
+  hasMicrosoftProfileCapability,
+  normalizeMicrosoftProfileCapabilities,
+  type MicrosoftProfileConsumer,
+} from '../actions/integrations/microsoftShared';
+import { resolveMicrosoftConsumerProfileConfig } from './microsoftConsumerProfileResolution';
+
+export type MicrosoftEmailIssuerKind = 'managed' | 'profile';
+
+/**
+ * The explicit issuer choice submitted by the admin. Carries the client
+ * identity so the server never has to infer the intended app from bindings.
+ */
+export interface MicrosoftEmailIssuerChoice {
+  kind: MicrosoftEmailIssuerKind;
+  /** Present and required when `kind === 'profile'`. */
+  profileId?: string;
+  /** The explicit client ID of the chosen application. */
+  clientId: string;
+}
+
+/** A selectable option surfaced by `getMicrosoftEmailIssuerOptions`. */
+export interface MicrosoftEmailIssuerOption {
+  kind: MicrosoftEmailIssuerKind;
+  label: string;
+  clientId: string;
+  profileId?: string;
+  tenantId?: string;
+  recommended?: boolean;
+}
+
+export interface MicrosoftEmailIssuerOptions {
+  /** The hosted/managed application, when the platform is ready. */
+  managed?: MicrosoftEmailIssuerOption;
+  /** Eligible tenant-owned profiles (active, Email-capable, ready, consent-ready). */
+  profiles: MicrosoftEmailIssuerOption[];
+  /**
+   * The recommended default choice for a new provider: the managed app when
+   * offered, otherwise the tenant Email binding's profile when eligible.
+   */
+  recommended: MicrosoftEmailIssuerChoice | null;
+}
+
+/** Resolved, validated credentials for a chosen issuer. */
+export interface MicrosoftEmailIssuerResolution {
+  choice: MicrosoftEmailIssuerChoice;
+  issuerKind: MicrosoftEmailIssuerKind;
+  clientId: string;
+  clientSecret: string;
+  clientSecretRef?: string;
+  microsoftTenantId: string;
+  profileId?: string;
+}
+
+/** Stable, machine-readable error codes for guarded selection failures. */
+export const MICROSOFT_EMAIL_ISSUER_ERRORS = {
+  INVALID_CHOICE: 'ms_email_invalid_choice',
+  PROFILE_NOT_FOUND: 'ms_email_profile_not_found',
+  CROSS_TENANT_PROFILE: 'ms_email_cross_tenant_profile',
+  INACTIVE_PROFILE: 'ms_email_inactive_profile',
+  MISSING_EMAIL_CAPABILITY: 'ms_email_missing_email_capability',
+  ISSUER_NOT_READY: 'ms_email_issuer_not_ready',
+  CONSENT_NOT_READY: 'ms_email_consent_not_ready',
+  CLIENT_MISMATCH_RECONNECT_REQUIRED: 'ms_email_client_mismatch_reconnect_required',
+  INVALID_STATE: 'ms_email_invalid_state',
+  EXPIRED_STATE: 'ms_email_expired_state',
+  REPLAYED_STATE: 'ms_email_replayed_state',
+  CALLBACK_PERSISTENCE_FAILED: 'ms_email_callback_persistence_failed',
+} as const;
+
+export type MicrosoftEmailIssuerErrorCode =
+  (typeof MICROSOFT_EMAIL_ISSUER_ERRORS)[keyof typeof MICROSOFT_EMAIL_ISSUER_ERRORS];
+
+/** Error thrown for a guarded selection/eligibility failure. Carries a stable code. */
+export class MicrosoftEmailIssuerError extends Error {
+  readonly code: MicrosoftEmailIssuerErrorCode;
+
+  constructor(code: MicrosoftEmailIssuerErrorCode, message: string) {
+    super(message);
+    this.name = 'MicrosoftEmailIssuerError';
+    this.code = code;
+  }
+}
+
+interface MicrosoftProfileRow {
+  tenant: string;
+  profile_id: string;
+  display_name: string;
+  client_id: string;
+  tenant_id: string;
+  client_secret_ref: string;
+  email_admin_consent_required?: boolean;
+  email_admin_consent_granted_at?: string | Date | null;
+  capabilities: MicrosoftProfileConsumer[] | string | null;
+  is_default: boolean;
+  is_archived: boolean;
+}
+
+function normalizeTenantId(value?: string | null): string {
+  return (value || '').trim() || 'common';
+}
+
+function normalizeClientId(value?: string | null): string {
+  return (value || '').trim();
+}
+
+export function isSameMicrosoftClientId(left: string | null | undefined, right: string | null | undefined): boolean {
+  return normalizeClientId(left).toLowerCase() === normalizeClientId(right).toLowerCase();
+}
+
+function profileHasEmailCapability(profile: Pick<MicrosoftProfileRow, 'capabilities'>): boolean {
+  return hasMicrosoftProfileCapability(normalizeMicrosoftProfileCapabilities(profile.capabilities), 'email');
+}
+
+function isConsentReady(profile: Pick<MicrosoftProfileRow, 'email_admin_consent_required' | 'email_admin_consent_granted_at'>): boolean {
+  return !profile.email_admin_consent_required || Boolean(profile.email_admin_consent_granted_at);
+}
+
+function isEligibleProfile(profile: MicrosoftProfileRow): boolean {
+  return (
+    !profile.is_archived &&
+    profileHasEmailCapability(profile) &&
+    Boolean(normalizeClientId(profile.client_id)) &&
+    Boolean((profile.tenant_id || '').trim()) &&
+    isConsentReady(profile)
+  );
+}
+
+async function getTenantProfiles(db: any, tenant: string): Promise<MicrosoftProfileRow[]> {
+  const rows = (await tenantDb(db, tenant)
+    .table('microsoft_profiles')
+    .select('*')) as MicrosoftProfileRow[];
+  return rows;
+}
+
+async function getProfileRow(db: any, tenant: string, profileId: string): Promise<MicrosoftProfileRow | undefined> {
+  const row = await tenantDb(db, tenant)
+    .table('microsoft_profiles')
+    .where({ profile_id: profileId })
+    .first() as MicrosoftProfileRow | undefined;
+  return row;
+}
+
+/**
+ * The tenant-wide Email binding — the create-flow default and a conservative
+ * legacy hint. It is never treated as authoritative for an existing provider.
+ */
+async function getBoundEmailProfile(db: any, tenant: string): Promise<MicrosoftProfileRow | undefined> {
+  const binding = await tenantDb(db, tenant)
+    .table('microsoft_profile_consumer_bindings')
+    .where({ consumer_type: 'email' })
+    .first();
+  if (!binding?.profile_id) return undefined;
+  return getProfileRow(db, tenant, binding.profile_id);
+}
+
+async function resolveManagedIssuer(tenant: string): Promise<MicrosoftEmailIssuerResolution | null> {
+  const resolution = await resolveMicrosoftConsumerProfileConfig(tenant, 'email', {
+    credentialPreference: 'platform',
+  });
+  if (resolution.status !== 'ready' || !resolution.clientId || !resolution.clientSecret) {
+    return null;
+  }
+  return {
+    choice: { kind: 'managed', clientId: resolution.clientId },
+    issuerKind: 'managed',
+    clientId: resolution.clientId,
+    clientSecret: resolution.clientSecret,
+    microsoftTenantId: resolution.microsoftTenantId || 'common',
+  };
+}
+
+async function resolveProfileIssuer(tenant: string, choice: MicrosoftEmailIssuerChoice): Promise<MicrosoftEmailIssuerResolution> {
+  if (!choice.profileId) {
+    throw new MicrosoftEmailIssuerError(
+      MICROSOFT_EMAIL_ISSUER_ERRORS.INVALID_CHOICE,
+      'Select a Microsoft application to authorize this mailbox'
+    );
+  }
+
+  const db = await getAdminConnection();
+  const profile = await getProfileRow(db, tenant, choice.profileId);
+
+  // Tenant-scoped lookup: a missing row is either cross-tenant or unknown.
+  if (!profile) {
+    throw new MicrosoftEmailIssuerError(
+      MICROSOFT_EMAIL_ISSUER_ERRORS.PROFILE_NOT_FOUND,
+      'The selected Microsoft application was not found in this workspace'
+    );
+  }
+  if (profile.tenant !== tenant) {
+    throw new MicrosoftEmailIssuerError(
+      MICROSOFT_EMAIL_ISSUER_ERRORS.CROSS_TENANT_PROFILE,
+      'The selected Microsoft application belongs to another workspace'
+    );
+  }
+  if (profile.is_archived) {
+    throw new MicrosoftEmailIssuerError(
+      MICROSOFT_EMAIL_ISSUER_ERRORS.INACTIVE_PROFILE,
+      'The selected Microsoft application is archived and cannot authorize mailboxes'
+    );
+  }
+  if (!profileHasEmailCapability(profile)) {
+    throw new MicrosoftEmailIssuerError(
+      MICROSOFT_EMAIL_ISSUER_ERRORS.MISSING_EMAIL_CAPABILITY,
+      'The selected Microsoft application is not enabled for Outlook email'
+    );
+  }
+  if (!isConsentReady(profile)) {
+    throw new MicrosoftEmailIssuerError(
+      MICROSOFT_EMAIL_ISSUER_ERRORS.CONSENT_NOT_READY,
+      'A Microsoft 365 administrator must approve the selected application before mailboxes can use it'
+    );
+  }
+
+  const secretProvider = await getSecretProviderInstance();
+  const clientSecret = (await secretProvider.getTenantSecret(tenant, profile.client_secret_ref)) || '';
+  const clientId = normalizeClientId(profile.client_id);
+
+  if (!clientId || !clientSecret || !(profile.tenant_id || '').trim()) {
+    throw new MicrosoftEmailIssuerError(
+      MICROSOFT_EMAIL_ISSUER_ERRORS.ISSUER_NOT_READY,
+      'The selected Microsoft application is missing required setup values'
+    );
+  }
+
+  return {
+    choice: { kind: 'profile', profileId: profile.profile_id, clientId },
+    issuerKind: 'profile',
+    clientId,
+    clientSecret,
+    clientSecretRef: profile.client_secret_ref,
+    microsoftTenantId: normalizeTenantId(profile.tenant_id),
+    profileId: profile.profile_id,
+  };
+}
+
+/**
+ * Validate a submitted issuer choice and resolve its credentials. This is the
+ * mandatory server-side gate used by OAuth initiation and by the callback
+ * (which never trusts the client's claim alone). Throws `MicrosoftEmailIssuerError`
+ * with a stable code for every guarded failure mode.
+ */
+export async function resolveMicrosoftEmailIssuerChoice(
+  tenant: string,
+  choice: MicrosoftEmailIssuerChoice | null | undefined
+): Promise<MicrosoftEmailIssuerResolution> {
+  if (!choice || typeof choice !== 'object') {
+    throw new MicrosoftEmailIssuerError(
+      MICROSOFT_EMAIL_ISSUER_ERRORS.INVALID_CHOICE,
+      'Choose which Microsoft application authorizes this mailbox'
+    );
+  }
+
+  const clientId = normalizeClientId(choice.clientId);
+  if (!clientId) {
+    throw new MicrosoftEmailIssuerError(
+      MICROSOFT_EMAIL_ISSUER_ERRORS.INVALID_CHOICE,
+      'The selected Microsoft application is missing its client ID'
+    );
+  }
+
+  if (choice.kind === 'managed') {
+    const resolution = await resolveManagedIssuer(tenant);
+    if (!resolution) {
+      throw new MicrosoftEmailIssuerError(
+        MICROSOFT_EMAIL_ISSUER_ERRORS.ISSUER_NOT_READY,
+        'The AlgaPSA-managed Microsoft application is not ready for mailbox authorization'
+      );
+    }
+    if (!isSameMicrosoftClientId(resolution.clientId, clientId)) {
+      throw new MicrosoftEmailIssuerError(
+        MICROSOFT_EMAIL_ISSUER_ERRORS.INVALID_CHOICE,
+        'The managed application choice does not match the configured client ID'
+      );
+    }
+    return resolution;
+  }
+
+  if (choice.kind !== 'profile') {
+    throw new MicrosoftEmailIssuerError(
+      MICROSOFT_EMAIL_ISSUER_ERRORS.INVALID_CHOICE,
+      'Unknown Microsoft application selection'
+    );
+  }
+
+  const resolution = await resolveProfileIssuer(tenant, choice);
+  if (!isSameMicrosoftClientId(resolution.clientId, clientId)) {
+    throw new MicrosoftEmailIssuerError(
+      MICROSOFT_EMAIL_ISSUER_ERRORS.INVALID_CHOICE,
+      'The selected application does not match its client ID'
+    );
+  }
+  return resolution;
+}
+
+/**
+ * List the eligible issuers presented to the admin. Hosted deployments
+ * recommend the managed application; eligible tenant profiles follow. A
+ * Teams-only app is never listed.
+ */
+export async function listEligibleMicrosoftEmailIssuers(
+  tenant: string
+): Promise<MicrosoftEmailIssuerOptions> {
+  const db = await getAdminConnection();
+  const [managed, profiles, boundProfile] = await Promise.all([
+    resolveManagedIssuer(tenant),
+    getTenantProfiles(db, tenant),
+    getBoundEmailProfile(db, tenant),
+  ]);
+
+  const eligibleProfiles = profiles.filter(isEligibleProfile).sort((left, right) => {
+    if (left.is_default !== right.is_default) return left.is_default ? -1 : 1;
+    return left.display_name.localeCompare(right.display_name);
+  });
+
+  const profileOptions: MicrosoftEmailIssuerOption[] = eligibleProfiles.map((profile) => ({
+    kind: 'profile',
+    label: profile.display_name,
+    clientId: profile.client_id,
+    profileId: profile.profile_id,
+    tenantId: normalizeTenantId(profile.tenant_id),
+  }));
+
+  const managedOption: MicrosoftEmailIssuerOption | undefined = managed
+    ? {
+        kind: 'managed',
+        label: 'AlgaPSA (managed Microsoft app)',
+        clientId: managed.clientId,
+        recommended: true,
+      }
+    : undefined;
+
+  // The create-flow default: managed when offered, else the tenant Email
+  // binding's profile when it is eligible.
+  let recommended: MicrosoftEmailIssuerChoice | null = null;
+  if (managedOption) {
+    recommended = { kind: 'managed', clientId: managedOption.clientId };
+  } else if (boundProfile && isEligibleProfile(boundProfile)) {
+    recommended = {
+      kind: 'profile',
+      profileId: boundProfile.profile_id,
+      clientId: boundProfile.client_id,
+    };
+  }
+
+  return {
+    managed: managedOption,
+    profiles: profileOptions,
+    recommended,
+  };
+}
+
+/** Describe a persisted provider issuer for display ("current app"). */
+export function describePersistedMicrosoftEmailIssuer(config: {
+  client_id?: string | null;
+  microsoft_profile_id?: string | null;
+}): { kind: 'managed' | 'profile' | 'legacy' | 'none'; clientId?: string; profileId?: string } {
+  const clientId = normalizeClientId(config.client_id);
+  const profileId = normalizeClientId(config.microsoft_profile_id);
+  if (profileId && clientId) {
+    return { kind: 'profile', clientId, profileId };
+  }
+  if (clientId) {
+    // Whether it maps to the managed app is decided by the caller against the
+    // option list; without a profile reference it is a legacy row.
+    return { kind: 'legacy', clientId };
+  }
+  return { kind: 'none' };
+}
+
+/**
+ * Conservative legacy backfill. Populates `microsoft_profile_id` (and the
+ * profile's `client_secret_ref`) only when a legacy provider row's persisted
+ * `client_id` has exactly one eligible same-client profile match. Ambiguous,
+ * missing, cross-tenant, inactive, or non-Email-capable matches stay legacy
+ * rows with `client_id` authoritative. The tenant Email binding may narrow a
+ * same-client candidate but never overrides a different persisted client ID.
+ * Teams rows are never touched.
+ */
+export async function backfillMicrosoftEmailProviderIssuerMetadata(tenant: string): Promise<{
+  backfilled: number;
+  ambiguous: number;
+  unchanged: number;
+}> {
+  const db = await getAdminConnection();
+
+  const profiles = await getTenantProfiles(db, tenant);
+  const eligibleByClientId = new Map<string, MicrosoftProfileRow[]>();
+  for (const profile of profiles) {
+    if (!isEligibleProfile(profile)) continue;
+    const key = normalizeClientId(profile.client_id).toLowerCase();
+    if (!key) continue;
+    const bucket = eligibleByClientId.get(key) || [];
+    bucket.push(profile);
+    eligibleByClientId.set(key, bucket);
+  }
+
+  const providers = (await tenantDb(db, tenant)
+    .table('email_providers')
+    .where({ provider_type: 'microsoft' })
+    .select('id')) as Array<{ id: string }>;
+
+  let backfilled = 0;
+  let ambiguous = 0;
+  let unchanged = 0;
+
+  for (const provider of providers) {
+    const config = await tenantDb(db, tenant)
+      .table('microsoft_email_provider_config')
+      .where({ email_provider_id: provider.id })
+      .first() as (Partial<MicrosoftEmailProviderConfigRow> & { email_provider_id: string }) | undefined;
+
+    if (!config) continue;
+
+    const persistedClientId = normalizeClientId(config.client_id);
+    const persistedProfileId = normalizeClientId(config.microsoft_profile_id);
+    // Managed-issued and already-pinned rows are not legacy candidates.
+    if (!persistedClientId || Boolean(persistedProfileId)) {
+      unchanged += 1;
+      continue;
+    }
+
+    const matches = eligibleByClientId.get(persistedClientId.toLowerCase()) || [];
+    if (matches.length !== 1) {
+      if (matches.length > 1) ambiguous += 1;
+      else unchanged += 1;
+      continue;
+    }
+
+    const match = matches[0];
+    await tenantDb(db, tenant)
+      .table('microsoft_email_provider_config')
+      .where({ email_provider_id: provider.id })
+      .update({
+        microsoft_profile_id: match.profile_id,
+        client_secret_ref: match.client_secret_ref,
+        tenant_id: normalizeTenantId(match.tenant_id),
+        updated_at: db.fn.now(),
+      });
+    backfilled += 1;
+  }
+
+  return { backfilled, ambiguous, unchanged };
+}
+
+interface MicrosoftEmailProviderConfigRow {
+  client_id?: string | null;
+  microsoft_profile_id?: string | null;
+}

--- a/packages/integrations/src/lib/microsoftEmailStateGuard.test.ts
+++ b/packages/integrations/src/lib/microsoftEmailStateGuard.test.ts
@@ -1,0 +1,190 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  MICROSOFT_EMAIL_ISSUER_ERRORS,
+} from './microsoftEmailIssuerSelection';
+import {
+  verifyMicrosoftEmailOAuthStateRelationships,
+  type MicrosoftEmailStateProviderContext,
+} from './microsoftEmailStateGuard';
+import type { MicrosoftEmailOAuthStatePayload } from '../utils/email/microsoftEmailOAuthState';
+
+function signedPayload(overrides: Partial<MicrosoftEmailOAuthStatePayload> = {}): MicrosoftEmailOAuthStatePayload {
+  return {
+    purpose: 'create',
+    tenant: 'tenant-1',
+    userId: 'user-1',
+    issuerKind: 'managed',
+    clientId: 'managed-client',
+    redirectUri: 'https://psa.example.com/api/auth/microsoft/callback',
+    nonce: 'nonce-1',
+    issuedAt: 1700000000,
+    expiresAt: 1700000600,
+    ...overrides,
+  };
+}
+
+function sessionUser(overrides: Record<string, unknown> = {}) {
+  return { user_id: 'user-1', tenant: 'tenant-1', ...overrides };
+}
+
+function provider(overrides: Partial<MicrosoftEmailStateProviderContext> = {}): MicrosoftEmailStateProviderContext {
+  return {
+    id: 'provider-1',
+    tenant: 'tenant-1',
+    provider_type: 'microsoft',
+    refresh_token: null,
+    status: 'configuring',
+    ...overrides,
+  };
+}
+
+describe('verifyMicrosoftEmailOAuthStateRelationships', () => {
+  it('accepts a create state for a brand-new provider row (no refresh token yet)', () => {
+    const result = verifyMicrosoftEmailOAuthStateRelationships({
+      payload: signedPayload({ purpose: 'create', providerId: 'provider-1' }),
+      sessionUser: sessionUser(),
+      provider: provider({ refresh_token: null, status: 'configuring' }),
+    });
+
+    expect(result).toEqual({ ok: true });
+  });
+
+  it('rejects a create state that would overwrite an already-connected provider', () => {
+    const result = verifyMicrosoftEmailOAuthStateRelationships({
+      payload: signedPayload({ purpose: 'create', providerId: 'provider-1' }),
+      sessionUser: sessionUser(),
+      provider: provider({ refresh_token: 'old-refresh-token', status: 'connected' }),
+    });
+
+    expect(result).toMatchObject({
+      ok: false,
+      code: MICROSOFT_EMAIL_ISSUER_ERRORS.STATE_PURPOSE_MISMATCH,
+    });
+  });
+
+  it('rejects a reconnect state that carries no providerId', () => {
+    const result = verifyMicrosoftEmailOAuthStateRelationships({
+      payload: signedPayload({ purpose: 'reconnect' }),
+      sessionUser: sessionUser(),
+      provider: null,
+    });
+
+    expect(result).toMatchObject({
+      ok: false,
+      code: MICROSOFT_EMAIL_ISSUER_ERRORS.STATE_PURPOSE_MISMATCH,
+    });
+  });
+
+  it('accepts a reconnect state for an existing connected provider', () => {
+    const result = verifyMicrosoftEmailOAuthStateRelationships({
+      payload: signedPayload({ purpose: 'reconnect', providerId: 'provider-1' }),
+      sessionUser: sessionUser(),
+      provider: provider({ refresh_token: 'old-refresh-token', status: 'connected' }),
+    });
+
+    expect(result).toEqual({ ok: true });
+  });
+
+  it('rejects when the session user differs from the user signed into the state', () => {
+    const result = verifyMicrosoftEmailOAuthStateRelationships({
+      payload: signedPayload({ purpose: 'reconnect', providerId: 'provider-1' }),
+      sessionUser: sessionUser({ user_id: 'attacker-user' }),
+      provider: provider(),
+    });
+
+    expect(result).toMatchObject({
+      ok: false,
+      code: MICROSOFT_EMAIL_ISSUER_ERRORS.STATE_USER_MISMATCH,
+    });
+  });
+
+  it('rejects a state naming a provider that no longer exists', () => {
+    const result = verifyMicrosoftEmailOAuthStateRelationships({
+      payload: signedPayload({ purpose: 'reconnect', providerId: 'provider-gone' }),
+      sessionUser: sessionUser(),
+      provider: null,
+    });
+
+    expect(result).toMatchObject({
+      ok: false,
+      code: MICROSOFT_EMAIL_ISSUER_ERRORS.PROVIDER_NOT_FOUND,
+    });
+  });
+
+  it('rejects a state naming a provider from another tenant', () => {
+    const result = verifyMicrosoftEmailOAuthStateRelationships({
+      payload: signedPayload({ purpose: 'reconnect', providerId: 'provider-1' }),
+      sessionUser: sessionUser(),
+      provider: provider({ tenant: 'other-tenant' }),
+    });
+
+    expect(result).toMatchObject({
+      ok: false,
+      code: MICROSOFT_EMAIL_ISSUER_ERRORS.PROVIDER_TENANT_MISMATCH,
+    });
+  });
+
+  it('rejects a state naming a non-Microsoft provider', () => {
+    const result = verifyMicrosoftEmailOAuthStateRelationships({
+      payload: signedPayload({ purpose: 'reconnect', providerId: 'provider-1' }),
+      sessionUser: sessionUser(),
+      provider: provider({ provider_type: 'google' }),
+    });
+
+    expect(result).toMatchObject({
+      ok: false,
+      code: MICROSOFT_EMAIL_ISSUER_ERRORS.PROVIDER_TYPE_NOT_SUPPORTED,
+    });
+  });
+
+  it('rejects a state consumed by a session with no matching tenant', () => {
+    const result = verifyMicrosoftEmailOAuthStateRelationships({
+      payload: signedPayload({ purpose: 'create', providerId: 'provider-1' }),
+      sessionUser: null,
+      provider: provider(),
+    });
+
+    expect(result).toMatchObject({
+      ok: false,
+      code: MICROSOFT_EMAIL_ISSUER_ERRORS.INVALID_STATE,
+    });
+  });
+
+  it('returns a distinguishable code for each rejection', () => {
+    const codes = [
+      verifyMicrosoftEmailOAuthStateRelationships({
+        payload: signedPayload({ purpose: 'create', providerId: 'p' }),
+        sessionUser: sessionUser(),
+        provider: provider({ refresh_token: 'x' }),
+      }),
+      verifyMicrosoftEmailOAuthStateRelationships({
+        payload: signedPayload({ purpose: 'reconnect', providerId: 'p' }),
+        sessionUser: sessionUser({ user_id: 'other' }),
+        provider: provider(),
+      }),
+      verifyMicrosoftEmailOAuthStateRelationships({
+        payload: signedPayload({ purpose: 'reconnect', providerId: 'p' }),
+        sessionUser: sessionUser(),
+        provider: null,
+      }),
+      verifyMicrosoftEmailOAuthStateRelationships({
+        payload: signedPayload({ purpose: 'reconnect', providerId: 'p' }),
+        sessionUser: sessionUser(),
+        provider: provider({ tenant: 'other' }),
+      }),
+      verifyMicrosoftEmailOAuthStateRelationships({
+        payload: signedPayload({ purpose: 'reconnect', providerId: 'p' }),
+        sessionUser: sessionUser(),
+        provider: provider({ provider_type: 'google' }),
+      }),
+      verifyMicrosoftEmailOAuthStateRelationships({
+        payload: signedPayload({ purpose: 'create', providerId: 'p' }),
+        sessionUser: null,
+        provider: provider(),
+      }),
+    ].map((r) => (r.ok ? 'ok' : r.code));
+
+    expect(new Set(codes).size).toBe(codes.length);
+  });
+});

--- a/packages/integrations/src/lib/microsoftEmailStateGuard.ts
+++ b/packages/integrations/src/lib/microsoftEmailStateGuard.ts
@@ -1,0 +1,116 @@
+/**
+ * Server-side enforcement of the relationships signed into the Microsoft
+ * inbound-email mailbox OAuth state.
+ *
+ * A signed state is only a *cryptographically intact* claim. The callback must
+ * additionally verify every relationship the claim asserts before touching a
+ * provider's credentials: the authenticated session user owns the state, the
+ * provider referenced by the state exists in the state's tenant and is a
+ * Microsoft email provider, and the purpose cannot be abused (a `create` state
+ * must never clobber an already-connected provider; a `reconnect` state must
+ * actually name a provider).
+ *
+ * Each rejection is a distinct, stable machine-readable failure — never a
+ * silent fallthrough.
+ */
+
+import {
+  MICROSOFT_EMAIL_ISSUER_ERRORS,
+  type MicrosoftEmailIssuerErrorCode,
+} from './microsoftEmailIssuerSelection';
+import type { MicrosoftEmailOAuthStatePayload } from '../utils/email/microsoftEmailOAuthState';
+
+export interface MicrosoftEmailStateProviderContext {
+  id?: string | null;
+  tenant?: string | null;
+  provider_type?: string | null;
+  refresh_token?: string | null;
+  status?: string | null;
+}
+
+export type MicrosoftEmailStateGuardResult =
+  | { ok: true }
+  | { ok: false; code: MicrosoftEmailIssuerErrorCode; message: string };
+
+function reject(
+  code: MicrosoftEmailIssuerErrorCode,
+  message: string
+): MicrosoftEmailStateGuardResult {
+  return { ok: false, code, message };
+}
+
+export function verifyMicrosoftEmailOAuthStateRelationships(input: {
+  payload: MicrosoftEmailOAuthStatePayload;
+  sessionUser?: { user_id?: string | null; tenant?: string | null } | null;
+  /** The `email_providers` row for the state's providerId, when it exists. */
+  provider?: MicrosoftEmailStateProviderContext | null;
+}): MicrosoftEmailStateGuardResult {
+  const { payload, sessionUser, provider } = input;
+
+  // User binding: the session user handling the callback must be the user who
+  // signed the state. A mismatch means another user (or a forged session) is
+  // trying to consume someone else's authorization.
+  if (!sessionUser?.tenant || sessionUser.tenant !== payload.tenant) {
+    return reject(
+      MICROSOFT_EMAIL_ISSUER_ERRORS.INVALID_STATE,
+      'Your session does not match the requested tenant. Please sign in and retry.'
+    );
+  }
+  if (!sessionUser.user_id || sessionUser.user_id !== payload.userId) {
+    return reject(
+      MICROSOFT_EMAIL_ISSUER_ERRORS.STATE_USER_MISMATCH,
+      'This Microsoft authorization request belongs to another user. Start again from the mailbox form.'
+    );
+  }
+
+  // Reconnect must name a provider; without one the callback has nowhere to
+  // store the renewed credentials.
+  if (payload.purpose === 'reconnect' && !payload.providerId) {
+    return reject(
+      MICROSOFT_EMAIL_ISSUER_ERRORS.STATE_PURPOSE_MISMATCH,
+      'A reconnect request must reference the mailbox being reconnected. Start again from the mailbox form.'
+    );
+  }
+
+  // Any state that names a provider must point at a real Microsoft email
+  // provider in the state's tenant. Without this, a forged or stale state could
+  // write tokens into an unrelated or non-Microsoft row.
+  if (payload.providerId) {
+    if (!provider?.id) {
+      return reject(
+        MICROSOFT_EMAIL_ISSUER_ERRORS.PROVIDER_NOT_FOUND,
+        'The mailbox for this authorization request no longer exists. Start again from the mailbox form.'
+      );
+    }
+    if (provider.tenant !== payload.tenant) {
+      return reject(
+        MICROSOFT_EMAIL_ISSUER_ERRORS.PROVIDER_TENANT_MISMATCH,
+        'The mailbox for this authorization request belongs to another workspace. Start again from the mailbox form.'
+      );
+    }
+    if (provider.provider_type !== 'microsoft') {
+      return reject(
+        MICROSOFT_EMAIL_ISSUER_ERRORS.PROVIDER_TYPE_NOT_SUPPORTED,
+        'The mailbox for this authorization request is not a Microsoft mailbox. Start again from the mailbox form.'
+      );
+    }
+  }
+
+  // Purpose semantics: a `create` state must never overwrite the credentials
+  // of an already-connected provider. Create flows sign a state for a brand-new
+  // row (no refresh token yet); anything else is a reconnect and must go
+  // through the reconnect flow.
+  if (
+    payload.purpose === 'create' &&
+    payload.providerId &&
+    provider &&
+    Boolean(provider.refresh_token)
+  ) {
+    return reject(
+      MICROSOFT_EMAIL_ISSUER_ERRORS.STATE_PURPOSE_MISMATCH,
+      'This mailbox is already connected. Reconnect it instead of authorizing it as new.'
+    );
+  }
+
+  return { ok: true };
+}

--- a/packages/integrations/src/services/email/EmailProviderService.ts
+++ b/packages/integrations/src/services/email/EmailProviderService.ts
@@ -46,6 +46,34 @@ export interface ProviderStatus {
   lastSyncAt?: string;
 }
 
+// Real writable columns on microsoft_email_provider_config (identity columns
+// email_provider_id/tenant and the timestamp columns are managed separately).
+// Only these may ever reach an UPDATE so a stray caller key (e.g.
+// `subscriptionId`) can never be written to a nonexistent column.
+const MICROSOFT_PROVIDER_CONFIG_COLUMNS = [
+  'client_id',
+  'client_secret',
+  'tenant_id',
+  'redirect_uri',
+  'auto_process_emails',
+  'max_emails_per_sync',
+  'folder_filters',
+  'access_token',
+  'refresh_token',
+  'token_expires_at',
+  'webhook_subscription_id',
+  'webhook_expires_at',
+  'webhook_verification_token',
+  'last_subscription_renewal',
+  'delivery_mode',
+  'last_webhook_delivery_at',
+  'webhook_silent_runs',
+  'next_subscription_probe_at',
+  'last_reconciliation_at',
+  'microsoft_profile_id',
+  'client_secret_ref',
+] as const;
+
 export class EmailProviderService {
   private readonly lifecycleService = new EmailProviderLifecycleService();
   private async getDb(tenant: string) {
@@ -289,13 +317,25 @@ export class EmailProviderService {
               updated_at: db.fn.now()
             });
         } else if (existingProvider.provider_type === 'microsoft') {
-          // Update Microsoft-specific configuration
+          // Update Microsoft-specific configuration. Only real
+          // microsoft_email_provider_config columns may reach the UPDATE: the
+          // merged config carries the existing row plus caller keys, and a
+          // non-column key (e.g. `subscriptionId`) would make Postgres throw,
+          // leaving the provider in Error. folder_filters is a jsonb column
+          // that the pg driver returns as a parsed array, so it must be
+          // re-stringified before it can be written back.
+          const microsoftUpdate: Record<string, unknown> = { updated_at: db.fn.now() };
+          for (const column of MICROSOFT_PROVIDER_CONFIG_COLUMNS) {
+            const value = (mergedConfig as Record<string, unknown>)[column];
+            if (value === undefined) continue;
+            microsoftUpdate[column] =
+              column === 'folder_filters' && Array.isArray(value)
+                ? JSON.stringify(value)
+                : value;
+          }
           await scopedDb.table('microsoft_email_provider_config')
             .where('email_provider_id', providerId)
-            .update({
-              ...mergedConfig,
-              updated_at: db.fn.now()
-            });
+            .update(microsoftUpdate);
         } else if (existingProvider.provider_type === 'imap') {
           const updatePayload = { ...mergedConfig };
           if (updatePayload.folder_filters && Array.isArray(updatePayload.folder_filters)) {
@@ -417,13 +457,13 @@ export class EmailProviderService {
           reason: 'provider configuration subscription succeeded',
         });
 
-        // Update provider with webhook subscription ID
-        await this.updateProvider(providerId, tenant, {
-          vendorConfig: {
-            ...provider.provider_config,
-            subscriptionId: result.subscriptionId
-          }
-        });
+        // The adapter already persisted the replacement subscription id and
+        // expiry (webhook_subscription_id / webhook_expires_at on
+        // microsoft_email_provider_config) inside registerWebhookSubscription,
+        // and it rethrows a persistence failure so webhookCompensation can
+        // delete the orphaned Graph subscription. Writing it again here would
+        // only duplicate that write with a wrong column name (`subscriptionId`
+        // is not a column), so nothing is done.
 
       } else if (provider.provider_type === 'google') {
         const gmailWebhookService = GmailWebhookService.getInstance();

--- a/packages/integrations/src/utils/email/microsoftEmailOAuthState.test.ts
+++ b/packages/integrations/src/utils/email/microsoftEmailOAuthState.test.ts
@@ -1,0 +1,120 @@
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+
+import {
+  createMicrosoftEmailOAuthState,
+  validateMicrosoftEmailOAuthState,
+} from './microsoftEmailOAuthState';
+
+const SECRET = 'test-signing-secret';
+
+describe('Microsoft email OAuth signed state', () => {
+  it('round-trips a valid signed state', () => {
+    const { token, payload } = createMicrosoftEmailOAuthState({
+      purpose: 'create',
+      tenant: 'tenant-1',
+      userId: 'user-1',
+      providerId: 'provider-1',
+      issuer: { kind: 'profile', profileId: 'profile-1', clientId: 'client-1' },
+      clientId: 'client-1',
+      redirectUri: 'https://psa.example.com/api/auth/microsoft/callback',
+      secret: SECRET,
+    });
+
+    expect(token).toContain('.');
+    expect(payload).toMatchObject({
+      purpose: 'create',
+      tenant: 'tenant-1',
+      userId: 'user-1',
+      providerId: 'provider-1',
+      issuerKind: 'profile',
+      issuerProfileId: 'profile-1',
+      clientId: 'client-1',
+      redirectUri: 'https://psa.example.com/api/auth/microsoft/callback',
+    });
+
+    const verified = validateMicrosoftEmailOAuthState({ token, secret: SECRET });
+    expect(verified).toEqual(payload);
+  });
+
+  it('carries a managed issuer choice without a profile reference', () => {
+    const { token } = createMicrosoftEmailOAuthState({
+      purpose: 'reconnect',
+      tenant: 'tenant-1',
+      userId: 'user-1',
+      issuer: { kind: 'managed', clientId: 'managed-client' },
+      clientId: 'managed-client',
+      redirectUri: 'https://psa.example.com/api/auth/microsoft/callback',
+      secret: SECRET,
+    });
+
+    const verified = validateMicrosoftEmailOAuthState({ token, secret: SECRET });
+    expect(verified).toMatchObject({
+      purpose: 'reconnect',
+      issuerKind: 'managed',
+      clientId: 'managed-client',
+    });
+  });
+
+  it('rejects a tampered payload', () => {
+    const { token } = createMicrosoftEmailOAuthState({
+      purpose: 'create',
+      tenant: 'tenant-1',
+      userId: 'user-1',
+      issuer: { kind: 'profile', profileId: 'profile-1', clientId: 'client-1' },
+      clientId: 'client-1',
+      redirectUri: 'https://psa.example.com/api/auth/microsoft/callback',
+      secret: SECRET,
+    });
+
+    const [payloadEncoded, signature] = token.split('.');
+    const tamperedPayload = Buffer.from(
+      JSON.stringify({
+        ...JSON.parse(Buffer.from(payloadEncoded, 'base64url').toString('utf8')),
+        clientId: 'attacker-client',
+      })
+    ).toString('base64url');
+
+    expect(validateMicrosoftEmailOAuthState({ token: `${tamperedPayload}.${signature}`, secret: SECRET })).toBeNull();
+  });
+
+  it('rejects a token signed with a different secret', () => {
+    const { token } = createMicrosoftEmailOAuthState({
+      purpose: 'create',
+      tenant: 'tenant-1',
+      userId: 'user-1',
+      issuer: { kind: 'managed', clientId: 'managed-client' },
+      clientId: 'managed-client',
+      redirectUri: 'https://psa.example.com/api/auth/microsoft/callback',
+      secret: SECRET,
+    });
+
+    expect(validateMicrosoftEmailOAuthState({ token, secret: 'other-secret' })).toBeNull();
+  });
+
+  it('rejects an expired token', () => {
+    const { token } = createMicrosoftEmailOAuthState({
+      purpose: 'create',
+      tenant: 'tenant-1',
+      userId: 'user-1',
+      issuer: { kind: 'managed', clientId: 'managed-client' },
+      clientId: 'managed-client',
+      redirectUri: 'https://psa.example.com/api/auth/microsoft/callback',
+      secret: SECRET,
+      ttlSeconds: 10,
+    });
+
+    expect(
+      validateMicrosoftEmailOAuthState({
+        token,
+        secret: SECRET,
+        now: Math.floor(Date.now() / 1000) + 11,
+      })
+    ).toBeNull();
+  });
+
+  it('rejects malformed tokens', () => {
+    expect(validateMicrosoftEmailOAuthState({ token: 'not-a-token', secret: SECRET })).toBeNull();
+    expect(validateMicrosoftEmailOAuthState({ token: null, secret: SECRET })).toBeNull();
+    expect(validateMicrosoftEmailOAuthState({ token: 'abc.def.ghi', secret: SECRET })).toBeNull();
+  });
+});

--- a/packages/integrations/src/utils/email/microsoftEmailOAuthState.ts
+++ b/packages/integrations/src/utils/email/microsoftEmailOAuthState.ts
@@ -1,0 +1,143 @@
+/**
+ * Signed OAuth state for the Microsoft inbound-email mailbox flow.
+ *
+ * The state carries the complete non-secret selection context (tenant,
+ * provider, issuer choice, client ID, nonce, purpose) and is HMAC-signed so the
+ * callback can reject tampered, stale, or replayed authorization requests. It
+ * never contains a client secret or a secret reference.
+ */
+
+import { createHmac, randomBytes, timingSafeEqual } from 'node:crypto';
+import { getSecretProviderInstance } from '@alga-psa/core/secrets';
+import type { MicrosoftEmailIssuerChoice } from '../../lib/microsoftEmailIssuerSelection';
+
+export type MicrosoftEmailOAuthPurpose = 'create' | 'reconnect';
+
+export interface MicrosoftEmailOAuthStatePayload {
+  purpose: MicrosoftEmailOAuthPurpose;
+  tenant: string;
+  userId: string;
+  providerId?: string;
+  issuerKind: 'managed' | 'profile';
+  issuerProfileId?: string;
+  clientId: string;
+  redirectUri: string;
+  nonce: string;
+  issuedAt: number;
+  expiresAt: number;
+}
+
+export const MICROSOFT_EMAIL_OAUTH_STATE_TTL_SECONDS = 10 * 60;
+
+function toBase64Url(value: Buffer | string): string {
+  return Buffer.from(value).toString('base64url');
+}
+
+function fromBase64Url(value: string): string {
+  return Buffer.from(value, 'base64url').toString('utf8');
+}
+
+function signPayload(payloadEncoded: string, secret: string): string {
+  return toBase64Url(createHmac('sha256', secret).update(payloadEncoded).digest());
+}
+
+/** Resolve the state-signing secret (NextAuth secret with env fallback). */
+export async function getMicrosoftEmailOAuthSigningSecret(): Promise<string | null> {
+  const fromEnv = process.env.NEXTAUTH_SECRET?.trim();
+  if (fromEnv) return fromEnv;
+
+  try {
+    const secretProvider = await getSecretProviderInstance();
+    const fromAppSecret = (await secretProvider.getAppSecret('NEXTAUTH_SECRET'))?.trim();
+    return fromAppSecret || null;
+  } catch {
+    return null;
+  }
+}
+
+export function createMicrosoftEmailOAuthState(input: {
+  purpose: MicrosoftEmailOAuthPurpose;
+  tenant: string;
+  userId: string;
+  providerId?: string;
+  issuer: MicrosoftEmailIssuerChoice;
+  clientId: string;
+  redirectUri: string;
+  secret: string;
+  ttlSeconds?: number;
+}): { token: string; payload: MicrosoftEmailOAuthStatePayload } {
+  if (!input.secret.trim()) {
+    throw new Error('Microsoft email OAuth state signing secret is not configured');
+  }
+
+  const issuedAt = Math.floor(Date.now() / 1000);
+  const payload: MicrosoftEmailOAuthStatePayload = {
+    purpose: input.purpose,
+    tenant: input.tenant,
+    userId: input.userId,
+    ...(input.providerId ? { providerId: input.providerId } : {}),
+    issuerKind: input.issuer.kind,
+    ...(input.issuer.kind === 'profile' && input.issuer.profileId
+      ? { issuerProfileId: input.issuer.profileId }
+      : {}),
+    clientId: input.clientId,
+    redirectUri: new URL(input.redirectUri).toString(),
+    nonce: randomBytes(24).toString('hex'),
+    issuedAt,
+    expiresAt: issuedAt + (input.ttlSeconds ?? MICROSOFT_EMAIL_OAUTH_STATE_TTL_SECONDS),
+  };
+  const payloadEncoded = toBase64Url(JSON.stringify(payload));
+  return {
+    token: `${payloadEncoded}.${signPayload(payloadEncoded, input.secret)}`,
+    payload,
+  };
+}
+
+/**
+ * Verify a signed Microsoft email OAuth state. Returns the payload when the
+ * signature is valid, the shape is intact, and the token has not expired.
+ */
+export function validateMicrosoftEmailOAuthState(input: {
+  token: string | null | undefined;
+  secret: string | null | undefined;
+  now?: number;
+}): MicrosoftEmailOAuthStatePayload | null {
+  if (!input.token || !input.secret) return null;
+
+  const [payloadEncoded, signature, extra] = input.token.split('.');
+  if (!payloadEncoded || !signature || extra) return null;
+
+  const expected = Buffer.from(signPayload(payloadEncoded, input.secret));
+  const received = Buffer.from(signature);
+  if (expected.length !== received.length || !timingSafeEqual(expected, received)) {
+    return null;
+  }
+
+  try {
+    const payload = JSON.parse(fromBase64Url(payloadEncoded)) as Partial<MicrosoftEmailOAuthStatePayload>;
+    if (
+      (payload.purpose !== 'create' && payload.purpose !== 'reconnect') ||
+      typeof payload.tenant !== 'string' ||
+      typeof payload.userId !== 'string' ||
+      (payload.issuerKind !== 'managed' && payload.issuerKind !== 'profile') ||
+      typeof payload.clientId !== 'string' ||
+      typeof payload.redirectUri !== 'string' ||
+      typeof payload.nonce !== 'string' ||
+      typeof payload.issuedAt !== 'number' ||
+      typeof payload.expiresAt !== 'number'
+    ) {
+      return null;
+    }
+    if (payload.issuerKind === 'profile' && typeof payload.issuerProfileId !== 'string') {
+      return null;
+    }
+
+    new URL(payload.redirectUri);
+    const now = input.now ?? Math.floor(Date.now() / 1000);
+    if (payload.issuedAt > now + 60 || payload.expiresAt <= now) return null;
+
+    return payload as MicrosoftEmailOAuthStatePayload;
+  } catch {
+    return null;
+  }
+}

--- a/packages/integrations/src/utils/email/microsoftEmailOAuthStateStore.test.ts
+++ b/packages/integrations/src/utils/email/microsoftEmailOAuthStateStore.test.ts
@@ -1,0 +1,47 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const mocks = vi.hoisted(() => ({
+  createClient: vi.fn(),
+}));
+
+vi.mock('redis', () => ({
+  createClient: mocks.createClient,
+}));
+
+vi.mock('@alga-psa/core/logger', () => ({
+  default: { error: vi.fn(), warn: vi.fn(), info: vi.fn() },
+}));
+
+vi.mock('@alga-psa/core/secrets', () => ({
+  getSecretProviderInstance: async () => ({
+    getAppSecret: async () => null,
+  }),
+}));
+
+vi.mock('@alga-psa/event-bus', () => ({
+  getRedisConfig: () => ({ url: 'redis://localhost:6379' }),
+}));
+
+import {
+  consumeMicrosoftEmailOAuthNonce,
+  storeMicrosoftEmailOAuthNonce,
+} from './microsoftEmailOAuthStateStore';
+
+describe('Microsoft email OAuth nonce store (memory fallback)', () => {
+  beforeEach(() => {
+    mocks.createClient.mockImplementation(() => {
+      throw new Error('redis unavailable');
+    });
+  });
+
+  it('allows the first consume of a nonce and rejects the second (replay)', async () => {
+    await storeMicrosoftEmailOAuthNonce('nonce-1');
+
+    expect(await consumeMicrosoftEmailOAuthNonce('nonce-1')).toBe(true);
+    expect(await consumeMicrosoftEmailOAuthNonce('nonce-1')).toBe(false);
+  });
+
+  it('rejects an unknown nonce', async () => {
+    expect(await consumeMicrosoftEmailOAuthNonce('never-stored')).toBe(false);
+  });
+});

--- a/packages/integrations/src/utils/email/microsoftEmailOAuthStateStore.ts
+++ b/packages/integrations/src/utils/email/microsoftEmailOAuthStateStore.ts
@@ -1,0 +1,101 @@
+/**
+ * Single-use nonce store for the Microsoft inbound-email mailbox OAuth state.
+ *
+ * A successful callback consumes the nonce so the same signed state cannot be
+ * replayed to swap credentials twice. Redis-backed with an in-memory fallback,
+ * mirroring the Microsoft email setup state store.
+ */
+
+import { createClient, type RedisClientType } from 'redis';
+import logger from '@alga-psa/core/logger';
+import { getSecretProviderInstance } from '@alga-psa/core/secrets';
+import { getRedisConfig } from '@alga-psa/event-bus';
+
+const STATE_NAMESPACE = 'microsoft:email_oauth';
+const DEFAULT_TTL_SECONDS = 10 * 60;
+
+let redisClientPromise: Promise<RedisClientType | null> | null = null;
+const memoryStore = new Map<string, { consumed: boolean; expiresAt: number }>();
+
+async function getRedisClient(): Promise<RedisClientType | null> {
+  if (!redisClientPromise) {
+    redisClientPromise = (async () => {
+      try {
+        const config = getRedisConfig();
+        const secretProvider = await getSecretProviderInstance();
+        const password =
+          (await secretProvider.getAppSecret('redis_password')) ||
+          process.env.REDIS_PASSWORD ||
+          undefined;
+        const client = createClient({ url: config.url, password });
+        client.on('error', (error) => {
+          logger.error('[MicrosoftEmailOAuthStateStore] Redis client error', error);
+        });
+        await client.connect();
+        return client as RedisClientType;
+      } catch (error) {
+        logger.error('[MicrosoftEmailOAuthStateStore] Failed to create Redis client', error);
+        return null;
+      }
+    })();
+  }
+
+  return redisClientPromise;
+}
+
+function buildKey(nonce: string): string {
+  return `${STATE_NAMESPACE}:${nonce}`;
+}
+
+export async function storeMicrosoftEmailOAuthNonce(
+  nonce: string,
+  ttlSeconds = DEFAULT_TTL_SECONDS
+): Promise<void> {
+  const key = buildKey(nonce);
+  try {
+    const client = await getRedisClient();
+    if (client) {
+      await client.set(key, '1', { EX: ttlSeconds });
+      return;
+    }
+  } catch (error) {
+    logger.warn(
+      '[MicrosoftEmailOAuthStateStore] Falling back to in-memory nonce storage',
+      error instanceof Error ? error.message : error
+    );
+  }
+
+  memoryStore.set(key, {
+    consumed: false,
+    expiresAt: Date.now() + ttlSeconds * 1000,
+  });
+}
+
+/**
+ * Atomically mark a nonce as used. Returns `true` only on the first successful
+ * consume; a replayed state (second use of the same nonce) returns `false`.
+ */
+export async function consumeMicrosoftEmailOAuthNonce(
+  nonce: string
+): Promise<boolean> {
+  const key = buildKey(nonce);
+  try {
+    const client = await getRedisClient();
+    if (client) {
+      const removed = await client.del(key);
+      // A missing key means it was already consumed or never stored. In
+      // single-node dev the callback still must not proceed on an unknown nonce.
+      return removed === 1;
+    }
+  } catch (error) {
+    logger.warn(
+      '[MicrosoftEmailOAuthStateStore] Redis unavailable while consuming nonce',
+      error instanceof Error ? error.message : error
+    );
+  }
+
+  const stored = memoryStore.get(key);
+  if (!stored || stored.consumed || stored.expiresAt <= Date.now()) return false;
+  stored.consumed = true;
+  return true;
+}

--- a/packages/integrations/src/utils/email/oauthHelpers.ts
+++ b/packages/integrations/src/utils/email/oauthHelpers.ts
@@ -22,13 +22,17 @@ export interface OAuthState {
 /**
  * Generate OAuth authorization URL for Microsoft
  * Requests inbound read access and Mail.Send for the same configured mailbox.
+ *
+ * Pass `encodedState` to supply a pre-signed state string (used by the
+ * Microsoft mailbox flow). Otherwise `state` is base64-encoded as before.
  */
 export function generateMicrosoftAuthUrl(
   clientId: string,
   redirectUri: string,
   state: OAuthState,
   scopes: string[] = [...MICROSOFT_EMAIL_OAUTH_SCOPES],
-  tenantAuthority: string = 'common'
+  tenantAuthority: string = 'common',
+  encodedState?: string
 ): string {
   const baseUrl = getMicrosoftAuthorizeUrl(tenantAuthority);
 
@@ -38,7 +42,7 @@ export function generateMicrosoftAuthUrl(
     redirect_uri: redirectUri,
     response_mode: 'query',
     scope: scopes.join(' '),
-    state: encodeState(state),
+    state: encodedState ?? encodeState(state),
     prompt: 'consent' // Force consent to ensure we get refresh token
   });
 

--- a/server/public/locales/de/msp/email-providers.json
+++ b/server/public/locales/de/msp/email-providers.json
@@ -293,6 +293,8 @@
         "managedDescription": "No Microsoft app registration is required on your side.",
         "recommended": "Recommended",
         "currentApp": "Current app: {{app}}",
+        "selectedApp": "Selected app: {{app}}",
+        "pendingReauth": "Pending reauthorization",
         "switchWarning": "Changing the Microsoft app requires reconnecting this mailbox. Sign in with Microsoft again to finish the switch.",
         "noneAvailable": "To connect Microsoft 365, first set up a Microsoft app in Providers, then come back.",
         "retry": "Try again",

--- a/server/public/locales/de/msp/email-providers.json
+++ b/server/public/locales/de/msp/email-providers.json
@@ -251,7 +251,8 @@
         "popupBlocked": "Das OAuth-Popup konnte nicht geöffnet werden. Bitte erlauben Sie Popups für diese Website.",
         "closedEarly": "Das Autorisierungsfenster wurde vor dem Abschluss geschlossen. Bitte versuchen Sie es erneut.",
         "authorizationFailed": "Die Autorisierung ist fehlgeschlagen",
-        "senderDisplayNameInvalid": "Der Anzeigename darf keine Anführungszeichen, spitzen Klammern oder Zeilenumbrüche enthalten"
+        "senderDisplayNameInvalid": "Der Anzeigename darf keine Anführungszeichen, spitzen Klammern oder Zeilenumbrüche enthalten",
+        "issuerRequired": "Choose a Microsoft app before signing in"
       },
       "requiredFields": {
         "providerName": "Konfigurationsname",
@@ -289,6 +290,17 @@
         "openProviders": "Anbieter öffnen",
         "notConfigured": "Microsoft ist noch nicht eingerichtet. Richten Sie Microsoft einmal unter „Anbieter“ ein und kehren Sie dann zurück.",
         "setUpInProviders": "Unter „Anbieter“ einrichten"
+      },
+      "issuer": {
+        "title": "Microsoft app that authorizes this mailbox",
+        "description": "Choose which application signs in as this mailbox. This choice is stored with the mailbox and does not affect other services.",
+        "managedLabel": "AlgaPSA app (managed by Nine Minds)",
+        "managedDescription": "No Microsoft app registration is required on your side.",
+        "recommended": "Recommended",
+        "currentApp": "Current app: {{app}}",
+        "switchWarning": "Changing the Microsoft app requires reconnecting this mailbox. Sign in with Microsoft again to finish the switch.",
+        "noneAvailable": "No Microsoft app is ready for mailbox authorization yet. Set one up in Providers, then come back.",
+        "retry": "Try again"
       }
     },
     "gmail": {

--- a/server/public/locales/de/msp/email-providers.json
+++ b/server/public/locales/de/msp/email-providers.json
@@ -284,12 +284,7 @@
         "maxEmailsPerSync": "Maximale E-Mails pro Synchronisierung"
       },
       "readiness": {
-        "checking": "Microsoft-Einrichtung wird geprüft…",
-        "ready": "Microsoft ist eingerichtet. Melden Sie sich zum Abschluss mit diesem Postfach an.",
-        "pending": "Warten auf Ihren Microsoft 365-Administrator. Die Einrichtung wurde unter „Anbieter“ gestartet, aber noch nicht genehmigt.",
-        "openProviders": "Anbieter öffnen",
-        "notConfigured": "Microsoft ist noch nicht eingerichtet. Richten Sie Microsoft einmal unter „Anbieter“ ein und kehren Sie dann zurück.",
-        "setUpInProviders": "Unter „Anbieter“ einrichten"
+        "openProviders": "Anbieter öffnen"
       },
       "issuer": {
         "title": "Microsoft app that authorizes this mailbox",
@@ -299,8 +294,12 @@
         "recommended": "Recommended",
         "currentApp": "Current app: {{app}}",
         "switchWarning": "Changing the Microsoft app requires reconnecting this mailbox. Sign in with Microsoft again to finish the switch.",
-        "noneAvailable": "No Microsoft app is ready for mailbox authorization yet. Set one up in Providers, then come back.",
-        "retry": "Try again"
+        "noneAvailable": "To connect Microsoft 365, first set up a Microsoft app in Providers, then come back.",
+        "retry": "Try again",
+        "pendingConsentEmpty": "Your Microsoft app is waiting for Microsoft 365 administrator approval. Once it is approved in Providers, come back to sign in.",
+        "pendingConsentHint": "Your own Microsoft app is still waiting for Microsoft 365 administrator approval.",
+        "ownAppPrompt": "Prefer to sign in with your own Microsoft app?",
+        "ownAppSetupLink": "Set it up in Providers"
       }
     },
     "gmail": {

--- a/server/public/locales/de/msp/email-providers.json
+++ b/server/public/locales/de/msp/email-providers.json
@@ -252,7 +252,7 @@
         "closedEarly": "Das Autorisierungsfenster wurde vor dem Abschluss geschlossen. Bitte versuchen Sie es erneut.",
         "authorizationFailed": "Die Autorisierung ist fehlgeschlagen",
         "senderDisplayNameInvalid": "Der Anzeigename darf keine Anführungszeichen, spitzen Klammern oder Zeilenumbrüche enthalten",
-        "issuerRequired": "Choose a Microsoft app before signing in"
+        "issuerRequired": "Wählen Sie vor der Anmeldung eine Microsoft-App aus."
       },
       "requiredFields": {
         "providerName": "Konfigurationsname",
@@ -287,21 +287,21 @@
         "openProviders": "Anbieter öffnen"
       },
       "issuer": {
-        "title": "Microsoft app that authorizes this mailbox",
-        "description": "Choose which application signs in as this mailbox. This choice is stored with the mailbox and does not affect other services.",
-        "managedLabel": "AlgaPSA app (managed by Nine Minds)",
-        "managedDescription": "No Microsoft app registration is required on your side.",
-        "recommended": "Recommended",
-        "currentApp": "Current app: {{app}}",
-        "selectedApp": "Selected app: {{app}}",
-        "pendingReauth": "Pending reauthorization",
-        "switchWarning": "Changing the Microsoft app requires reconnecting this mailbox. Sign in with Microsoft again to finish the switch.",
-        "noneAvailable": "To connect Microsoft 365, first set up a Microsoft app in Providers, then come back.",
-        "retry": "Try again",
-        "pendingConsentEmpty": "Your Microsoft app is waiting for Microsoft 365 administrator approval. Once it is approved in Providers, come back to sign in.",
-        "pendingConsentHint": "Your own Microsoft app is still waiting for Microsoft 365 administrator approval.",
-        "ownAppPrompt": "Prefer to sign in with your own Microsoft app?",
-        "ownAppSetupLink": "Set it up in Providers"
+        "title": "Microsoft-App, die dieses Postfach autorisiert",
+        "description": "Wählen Sie aus, welche Anwendung sich als dieses Postfach anmeldet. Diese Auswahl wird mit dem Postfach gespeichert und wirkt sich nicht auf andere Dienste aus.",
+        "managedLabel": "AlgaPSA-App (verwaltet von Nine Minds)",
+        "managedDescription": "Auf Ihrer Seite ist keine Registrierung einer Microsoft-App erforderlich.",
+        "recommended": "Empfohlen",
+        "currentApp": "Aktuelle App: {{app}}",
+        "selectedApp": "Ausgewählte App: {{app}}",
+        "pendingReauth": "Erneute Autorisierung ausstehend",
+        "switchWarning": "Der Wechsel der Microsoft-App erfordert eine erneute Verbindung dieses Postfachs. Melden Sie sich erneut bei Microsoft an, um den Wechsel abzuschließen.",
+        "noneAvailable": "Um Microsoft 365 zu verbinden, richten Sie zuerst eine Microsoft-App unter Anbieter ein und kommen Sie dann hierher zurück.",
+        "retry": "Erneut versuchen",
+        "pendingConsentEmpty": "Ihre Microsoft-App wartet auf die Genehmigung eines Microsoft-365-Administrators. Sobald sie unter Anbieter genehmigt wurde, kehren Sie hierher zurück, um sich anzumelden.",
+        "pendingConsentHint": "Ihre eigene Microsoft-App wartet noch auf die Genehmigung eines Microsoft-365-Administrators.",
+        "ownAppPrompt": "Möchten Sie sich lieber mit Ihrer eigenen Microsoft-App anmelden?",
+        "ownAppSetupLink": "Unter Anbieter einrichten"
       }
     },
     "gmail": {

--- a/server/public/locales/de/msp/integrations.json
+++ b/server/public/locales/de/msp/integrations.json
@@ -1659,7 +1659,8 @@
           "email": {
             "description": "Wählen Sie das Microsoft-Profil für eingehende und ausgehende Outlook-E-Mails aus.",
             "label": "E-Mail",
-            "reconnect": "Bestehende Outlook-E-Mail-Verbindungen müssen erneut autorisiert werden, um Mail.Send zu gewähren, bevor sie ausgehende E-Mails senden können."
+            "reconnect": "Bestehende Outlook-E-Mail-Verbindungen müssen erneut autorisiert werden, um Mail.Send zu gewähren, bevor sie ausgehende E-Mails senden können.",
+            "perProviderIssuerNote": "Existing mailbox connections keep their current Microsoft app until they are reconnected. This choice applies to new mailbox connections."
           },
           "mspSso": {
             "description": "Wählen Sie aus, welches Microsoft-Profil die MSP-SSO-Anmeldedomänen, die Microsoft-Anmeldung und die Tenant-Erkennung unterstützt.",

--- a/server/public/locales/de/msp/integrations.json
+++ b/server/public/locales/de/msp/integrations.json
@@ -1660,7 +1660,7 @@
             "description": "Wählen Sie das Microsoft-Profil für eingehende und ausgehende Outlook-E-Mails aus.",
             "label": "E-Mail",
             "reconnect": "Bestehende Outlook-E-Mail-Verbindungen müssen erneut autorisiert werden, um Mail.Send zu gewähren, bevor sie ausgehende E-Mails senden können.",
-            "perProviderIssuerNote": "Existing mailbox connections keep their current Microsoft app until they are reconnected. This choice applies to new mailbox connections."
+            "perProviderIssuerNote": "Bestehende Postfachverbindungen behalten ihre aktuelle Microsoft-App, bis sie neu verbunden werden. Diese Auswahl gilt für neue Postfachverbindungen."
           },
           "mspSso": {
             "description": "Wählen Sie aus, welches Microsoft-Profil die MSP-SSO-Anmeldedomänen, die Microsoft-Anmeldung und die Tenant-Erkennung unterstützt.",

--- a/server/public/locales/en/msp/email-providers.json
+++ b/server/public/locales/en/msp/email-providers.json
@@ -285,6 +285,8 @@
         "managedDescription": "No Microsoft app registration is required on your side.",
         "recommended": "Recommended",
         "currentApp": "Current app: {{app}}",
+        "selectedApp": "Selected app: {{app}}",
+        "pendingReauth": "Pending reauthorization",
         "switchWarning": "Changing the Microsoft app requires reconnecting this mailbox. Sign in with Microsoft again to finish the switch.",
         "noneAvailable": "To connect Microsoft 365, first set up a Microsoft app in Providers, then come back.",
         "retry": "Try again",

--- a/server/public/locales/en/msp/email-providers.json
+++ b/server/public/locales/en/msp/email-providers.json
@@ -276,12 +276,7 @@
         "signIn": "Sign in with Microsoft"
       },
       "readiness": {
-        "checking": "Checking Microsoft setup…",
-        "ready": "Microsoft is set up. Sign in as this mailbox to finish.",
-        "pending": "Waiting for your Microsoft 365 administrator. Setup was started in Providers but hasn't been approved yet.",
-        "openProviders": "Open Providers",
-        "notConfigured": "Microsoft isn't set up yet. Set it up once in Providers, then come back.",
-        "setUpInProviders": "Set up in Providers"
+        "openProviders": "Open Providers"
       },
       "issuer": {
         "title": "Microsoft app that authorizes this mailbox",
@@ -291,8 +286,12 @@
         "recommended": "Recommended",
         "currentApp": "Current app: {{app}}",
         "switchWarning": "Changing the Microsoft app requires reconnecting this mailbox. Sign in with Microsoft again to finish the switch.",
-        "noneAvailable": "No Microsoft app is ready for mailbox authorization yet. Set one up in Providers, then come back.",
-        "retry": "Try again"
+        "noneAvailable": "To connect Microsoft 365, first set up a Microsoft app in Providers, then come back.",
+        "retry": "Try again",
+        "pendingConsentEmpty": "Your Microsoft app is waiting for Microsoft 365 administrator approval. Once it is approved in Providers, come back to sign in.",
+        "pendingConsentHint": "Your own Microsoft app is still waiting for Microsoft 365 administrator approval.",
+        "ownAppPrompt": "Prefer to sign in with your own Microsoft app?",
+        "ownAppSetupLink": "Set it up in Providers"
       },
       "advanced": {
         "title": "Advanced Settings",

--- a/server/public/locales/en/msp/email-providers.json
+++ b/server/public/locales/en/msp/email-providers.json
@@ -251,7 +251,8 @@
         "popupBlocked": "Failed to open OAuth popup. Please allow popups for this site.",
         "closedEarly": "Authorization window closed before completing. Please try again.",
         "authorizationFailed": "Authorization failed",
-        "senderDisplayNameInvalid": "Display name cannot contain quotes, angle brackets, or line breaks"
+        "senderDisplayNameInvalid": "Display name cannot contain quotes, angle brackets, or line breaks",
+        "issuerRequired": "Choose a Microsoft app before signing in"
       },
       "requiredFields": {
         "providerName": "Configuration Name",
@@ -281,6 +282,17 @@
         "openProviders": "Open Providers",
         "notConfigured": "Microsoft isn't set up yet. Set it up once in Providers, then come back.",
         "setUpInProviders": "Set up in Providers"
+      },
+      "issuer": {
+        "title": "Microsoft app that authorizes this mailbox",
+        "description": "Choose which application signs in as this mailbox. This choice is stored with the mailbox and does not affect other services.",
+        "managedLabel": "AlgaPSA app (managed by Nine Minds)",
+        "managedDescription": "No Microsoft app registration is required on your side.",
+        "recommended": "Recommended",
+        "currentApp": "Current app: {{app}}",
+        "switchWarning": "Changing the Microsoft app requires reconnecting this mailbox. Sign in with Microsoft again to finish the switch.",
+        "noneAvailable": "No Microsoft app is ready for mailbox authorization yet. Set one up in Providers, then come back.",
+        "retry": "Try again"
       },
       "advanced": {
         "title": "Advanced Settings",

--- a/server/public/locales/en/msp/integrations.json
+++ b/server/public/locales/en/msp/integrations.json
@@ -1659,7 +1659,8 @@
           "email": {
             "description": "Choose the Microsoft app for Outlook inbound and outbound email.",
             "label": "Outlook email",
-            "reconnect": "Existing Outlook email connections need re-authorization to grant Mail.Send before they can send outbound email."
+            "reconnect": "Existing Outlook email connections need re-authorization to grant Mail.Send before they can send outbound email.",
+            "perProviderIssuerNote": "Existing mailbox connections keep their current Microsoft app until they are reconnected. This choice applies to new mailbox connections."
           },
           "mspSso": {
             "description": "Choose the Microsoft app for staff sign-in and login-domain discovery.",

--- a/server/public/locales/es/msp/email-providers.json
+++ b/server/public/locales/es/msp/email-providers.json
@@ -293,6 +293,8 @@
         "managedDescription": "No Microsoft app registration is required on your side.",
         "recommended": "Recommended",
         "currentApp": "Current app: {{app}}",
+        "selectedApp": "Selected app: {{app}}",
+        "pendingReauth": "Pending reauthorization",
         "switchWarning": "Changing the Microsoft app requires reconnecting this mailbox. Sign in with Microsoft again to finish the switch.",
         "noneAvailable": "To connect Microsoft 365, first set up a Microsoft app in Providers, then come back.",
         "retry": "Try again",

--- a/server/public/locales/es/msp/email-providers.json
+++ b/server/public/locales/es/msp/email-providers.json
@@ -284,12 +284,7 @@
         "maxEmailsPerSync": "Máximo de correos electrónicos por sincronización"
       },
       "readiness": {
-        "checking": "Comprobando la configuración de Microsoft…",
-        "ready": "Microsoft está configurado. Inicie sesión con este buzón para finalizar.",
-        "pending": "Esperando a su administrador de Microsoft 365. La configuración se inició en Proveedores, pero aún no se aprobó.",
-        "openProviders": "Abrir Proveedores",
-        "notConfigured": "Microsoft aún no está configurado. Configúrelo una vez en Proveedores y luego regrese.",
-        "setUpInProviders": "Configurar en Proveedores"
+        "openProviders": "Abrir Proveedores"
       },
       "issuer": {
         "title": "Microsoft app that authorizes this mailbox",
@@ -299,8 +294,12 @@
         "recommended": "Recommended",
         "currentApp": "Current app: {{app}}",
         "switchWarning": "Changing the Microsoft app requires reconnecting this mailbox. Sign in with Microsoft again to finish the switch.",
-        "noneAvailable": "No Microsoft app is ready for mailbox authorization yet. Set one up in Providers, then come back.",
-        "retry": "Try again"
+        "noneAvailable": "To connect Microsoft 365, first set up a Microsoft app in Providers, then come back.",
+        "retry": "Try again",
+        "pendingConsentEmpty": "Your Microsoft app is waiting for Microsoft 365 administrator approval. Once it is approved in Providers, come back to sign in.",
+        "pendingConsentHint": "Your own Microsoft app is still waiting for Microsoft 365 administrator approval.",
+        "ownAppPrompt": "Prefer to sign in with your own Microsoft app?",
+        "ownAppSetupLink": "Set it up in Providers"
       }
     },
     "gmail": {

--- a/server/public/locales/es/msp/email-providers.json
+++ b/server/public/locales/es/msp/email-providers.json
@@ -251,7 +251,8 @@
         "popupBlocked": "No se pudo abrir la ventana emergente de OAuth. Permita ventanas emergentes para este sitio.",
         "closedEarly": "La ventana de autorización se cerró antes de completar. Por favor inténtelo de nuevo.",
         "authorizationFailed": "Autorización fallida",
-        "senderDisplayNameInvalid": "El nombre para mostrar no puede contener comillas, corchetes angulares ni saltos de línea"
+        "senderDisplayNameInvalid": "El nombre para mostrar no puede contener comillas, corchetes angulares ni saltos de línea",
+        "issuerRequired": "Choose a Microsoft app before signing in"
       },
       "requiredFields": {
         "providerName": "Nombre de configuración",
@@ -289,6 +290,17 @@
         "openProviders": "Abrir Proveedores",
         "notConfigured": "Microsoft aún no está configurado. Configúrelo una vez en Proveedores y luego regrese.",
         "setUpInProviders": "Configurar en Proveedores"
+      },
+      "issuer": {
+        "title": "Microsoft app that authorizes this mailbox",
+        "description": "Choose which application signs in as this mailbox. This choice is stored with the mailbox and does not affect other services.",
+        "managedLabel": "AlgaPSA app (managed by Nine Minds)",
+        "managedDescription": "No Microsoft app registration is required on your side.",
+        "recommended": "Recommended",
+        "currentApp": "Current app: {{app}}",
+        "switchWarning": "Changing the Microsoft app requires reconnecting this mailbox. Sign in with Microsoft again to finish the switch.",
+        "noneAvailable": "No Microsoft app is ready for mailbox authorization yet. Set one up in Providers, then come back.",
+        "retry": "Try again"
       }
     },
     "gmail": {

--- a/server/public/locales/es/msp/email-providers.json
+++ b/server/public/locales/es/msp/email-providers.json
@@ -252,7 +252,7 @@
         "closedEarly": "La ventana de autorización se cerró antes de completar. Por favor inténtelo de nuevo.",
         "authorizationFailed": "Autorización fallida",
         "senderDisplayNameInvalid": "El nombre para mostrar no puede contener comillas, corchetes angulares ni saltos de línea",
-        "issuerRequired": "Choose a Microsoft app before signing in"
+        "issuerRequired": "Elija una aplicación de Microsoft antes de iniciar sesión"
       },
       "requiredFields": {
         "providerName": "Nombre de configuración",
@@ -287,21 +287,21 @@
         "openProviders": "Abrir Proveedores"
       },
       "issuer": {
-        "title": "Microsoft app that authorizes this mailbox",
-        "description": "Choose which application signs in as this mailbox. This choice is stored with the mailbox and does not affect other services.",
-        "managedLabel": "AlgaPSA app (managed by Nine Minds)",
-        "managedDescription": "No Microsoft app registration is required on your side.",
-        "recommended": "Recommended",
-        "currentApp": "Current app: {{app}}",
-        "selectedApp": "Selected app: {{app}}",
-        "pendingReauth": "Pending reauthorization",
-        "switchWarning": "Changing the Microsoft app requires reconnecting this mailbox. Sign in with Microsoft again to finish the switch.",
-        "noneAvailable": "To connect Microsoft 365, first set up a Microsoft app in Providers, then come back.",
-        "retry": "Try again",
-        "pendingConsentEmpty": "Your Microsoft app is waiting for Microsoft 365 administrator approval. Once it is approved in Providers, come back to sign in.",
-        "pendingConsentHint": "Your own Microsoft app is still waiting for Microsoft 365 administrator approval.",
-        "ownAppPrompt": "Prefer to sign in with your own Microsoft app?",
-        "ownAppSetupLink": "Set it up in Providers"
+        "title": "Aplicación de Microsoft que autoriza este buzón",
+        "description": "Elija qué aplicación inicia sesión como este buzón. Esta elección se guarda con el buzón y no afecta a otros servicios.",
+        "managedLabel": "Aplicación de AlgaPSA (administrada por Nine Minds)",
+        "managedDescription": "No se requiere ningún registro de aplicación de Microsoft por su parte.",
+        "recommended": "Recomendada",
+        "currentApp": "Aplicación actual: {{app}}",
+        "selectedApp": "Aplicación seleccionada: {{app}}",
+        "pendingReauth": "Reautorización pendiente",
+        "switchWarning": "Cambiar la aplicación de Microsoft requiere reconectar este buzón. Inicie sesión con Microsoft de nuevo para completar el cambio.",
+        "noneAvailable": "Para conectar Microsoft 365, primero configure una aplicación de Microsoft en Proveedores y luego vuelva.",
+        "retry": "Reintentar",
+        "pendingConsentEmpty": "Su aplicación de Microsoft espera la aprobación de un administrador de Microsoft 365. Una vez aprobada en Proveedores, vuelva para iniciar sesión.",
+        "pendingConsentHint": "Su propia aplicación de Microsoft todavía espera la aprobación de un administrador de Microsoft 365.",
+        "ownAppPrompt": "¿Prefiere iniciar sesión con su propia aplicación de Microsoft?",
+        "ownAppSetupLink": "Configurarla en Proveedores"
       }
     },
     "gmail": {

--- a/server/public/locales/es/msp/integrations.json
+++ b/server/public/locales/es/msp/integrations.json
@@ -1659,7 +1659,8 @@
           "email": {
             "description": "Elija el perfil de Microsoft para el correo entrante y saliente de Outlook.",
             "label": "Correo",
-            "reconnect": "Las conexiones existentes de correo de Outlook deben volver a autorizarse para conceder Mail.Send antes de poder enviar correo saliente."
+            "reconnect": "Las conexiones existentes de correo de Outlook deben volver a autorizarse para conceder Mail.Send antes de poder enviar correo saliente.",
+            "perProviderIssuerNote": "Existing mailbox connections keep their current Microsoft app until they are reconnected. This choice applies to new mailbox connections."
           },
           "mspSso": {
             "description": "Elija qué perfil de Microsoft respalda los dominios de inicio de sesión de MSP SSO, el inicio de sesión con Microsoft y el descubrimiento de inquilinos.",

--- a/server/public/locales/es/msp/integrations.json
+++ b/server/public/locales/es/msp/integrations.json
@@ -1660,7 +1660,7 @@
             "description": "Elija el perfil de Microsoft para el correo entrante y saliente de Outlook.",
             "label": "Correo",
             "reconnect": "Las conexiones existentes de correo de Outlook deben volver a autorizarse para conceder Mail.Send antes de poder enviar correo saliente.",
-            "perProviderIssuerNote": "Existing mailbox connections keep their current Microsoft app until they are reconnected. This choice applies to new mailbox connections."
+            "perProviderIssuerNote": "Las conexiones de buzón existentes mantienen su aplicación de Microsoft actual hasta que se reconectan. Esta elección se aplica a las conexiones de buzón nuevas."
           },
           "mspSso": {
             "description": "Elija qué perfil de Microsoft respalda los dominios de inicio de sesión de MSP SSO, el inicio de sesión con Microsoft y el descubrimiento de inquilinos.",

--- a/server/public/locales/fr/msp/email-providers.json
+++ b/server/public/locales/fr/msp/email-providers.json
@@ -293,6 +293,8 @@
         "managedDescription": "No Microsoft app registration is required on your side.",
         "recommended": "Recommended",
         "currentApp": "Current app: {{app}}",
+        "selectedApp": "Selected app: {{app}}",
+        "pendingReauth": "Pending reauthorization",
         "switchWarning": "Changing the Microsoft app requires reconnecting this mailbox. Sign in with Microsoft again to finish the switch.",
         "noneAvailable": "To connect Microsoft 365, first set up a Microsoft app in Providers, then come back.",
         "retry": "Try again",

--- a/server/public/locales/fr/msp/email-providers.json
+++ b/server/public/locales/fr/msp/email-providers.json
@@ -284,12 +284,7 @@
         "maxEmailsPerSync": "Nombre maximum d'e-mails par synchronisation"
       },
       "readiness": {
-        "checking": "Vérification de la configuration Microsoft…",
-        "ready": "Microsoft est configuré. Connectez-vous avec cette boîte aux lettres pour terminer.",
-        "pending": "En attente de votre administrateur Microsoft 365. La configuration a été lancée dans Fournisseurs, mais n'a pas encore été approuvée.",
-        "openProviders": "Ouvrir Fournisseurs",
-        "notConfigured": "Microsoft n'est pas encore configuré. Configurez-le une fois dans Fournisseurs, puis revenez.",
-        "setUpInProviders": "Configurer dans Fournisseurs"
+        "openProviders": "Ouvrir Fournisseurs"
       },
       "issuer": {
         "title": "Microsoft app that authorizes this mailbox",
@@ -299,8 +294,12 @@
         "recommended": "Recommended",
         "currentApp": "Current app: {{app}}",
         "switchWarning": "Changing the Microsoft app requires reconnecting this mailbox. Sign in with Microsoft again to finish the switch.",
-        "noneAvailable": "No Microsoft app is ready for mailbox authorization yet. Set one up in Providers, then come back.",
-        "retry": "Try again"
+        "noneAvailable": "To connect Microsoft 365, first set up a Microsoft app in Providers, then come back.",
+        "retry": "Try again",
+        "pendingConsentEmpty": "Your Microsoft app is waiting for Microsoft 365 administrator approval. Once it is approved in Providers, come back to sign in.",
+        "pendingConsentHint": "Your own Microsoft app is still waiting for Microsoft 365 administrator approval.",
+        "ownAppPrompt": "Prefer to sign in with your own Microsoft app?",
+        "ownAppSetupLink": "Set it up in Providers"
       }
     },
     "gmail": {

--- a/server/public/locales/fr/msp/email-providers.json
+++ b/server/public/locales/fr/msp/email-providers.json
@@ -251,7 +251,8 @@
         "popupBlocked": "Échec de l'ouverture de la fenêtre contextuelle OAuth. Veuillez autoriser les popups pour ce site.",
         "closedEarly": "Fenêtre d'autorisation fermée avant de terminer. Veuillez réessayer.",
         "authorizationFailed": "L'autorisation a échoué",
-        "senderDisplayNameInvalid": "Le nom d'affichage ne peut pas contenir de guillemets, de chevrons ni de sauts de ligne"
+        "senderDisplayNameInvalid": "Le nom d'affichage ne peut pas contenir de guillemets, de chevrons ni de sauts de ligne",
+        "issuerRequired": "Choose a Microsoft app before signing in"
       },
       "requiredFields": {
         "providerName": "Nom de configuration",
@@ -289,6 +290,17 @@
         "openProviders": "Ouvrir Fournisseurs",
         "notConfigured": "Microsoft n'est pas encore configuré. Configurez-le une fois dans Fournisseurs, puis revenez.",
         "setUpInProviders": "Configurer dans Fournisseurs"
+      },
+      "issuer": {
+        "title": "Microsoft app that authorizes this mailbox",
+        "description": "Choose which application signs in as this mailbox. This choice is stored with the mailbox and does not affect other services.",
+        "managedLabel": "AlgaPSA app (managed by Nine Minds)",
+        "managedDescription": "No Microsoft app registration is required on your side.",
+        "recommended": "Recommended",
+        "currentApp": "Current app: {{app}}",
+        "switchWarning": "Changing the Microsoft app requires reconnecting this mailbox. Sign in with Microsoft again to finish the switch.",
+        "noneAvailable": "No Microsoft app is ready for mailbox authorization yet. Set one up in Providers, then come back.",
+        "retry": "Try again"
       }
     },
     "gmail": {

--- a/server/public/locales/fr/msp/email-providers.json
+++ b/server/public/locales/fr/msp/email-providers.json
@@ -252,7 +252,7 @@
         "closedEarly": "Fenêtre d'autorisation fermée avant de terminer. Veuillez réessayer.",
         "authorizationFailed": "L'autorisation a échoué",
         "senderDisplayNameInvalid": "Le nom d'affichage ne peut pas contenir de guillemets, de chevrons ni de sauts de ligne",
-        "issuerRequired": "Choose a Microsoft app before signing in"
+        "issuerRequired": "Choisissez une application Microsoft avant de vous connecter"
       },
       "requiredFields": {
         "providerName": "Nom de configuration",
@@ -287,21 +287,21 @@
         "openProviders": "Ouvrir Fournisseurs"
       },
       "issuer": {
-        "title": "Microsoft app that authorizes this mailbox",
-        "description": "Choose which application signs in as this mailbox. This choice is stored with the mailbox and does not affect other services.",
-        "managedLabel": "AlgaPSA app (managed by Nine Minds)",
-        "managedDescription": "No Microsoft app registration is required on your side.",
-        "recommended": "Recommended",
-        "currentApp": "Current app: {{app}}",
-        "selectedApp": "Selected app: {{app}}",
-        "pendingReauth": "Pending reauthorization",
-        "switchWarning": "Changing the Microsoft app requires reconnecting this mailbox. Sign in with Microsoft again to finish the switch.",
-        "noneAvailable": "To connect Microsoft 365, first set up a Microsoft app in Providers, then come back.",
-        "retry": "Try again",
-        "pendingConsentEmpty": "Your Microsoft app is waiting for Microsoft 365 administrator approval. Once it is approved in Providers, come back to sign in.",
-        "pendingConsentHint": "Your own Microsoft app is still waiting for Microsoft 365 administrator approval.",
-        "ownAppPrompt": "Prefer to sign in with your own Microsoft app?",
-        "ownAppSetupLink": "Set it up in Providers"
+        "title": "Application Microsoft qui autorise cette boîte aux lettres",
+        "description": "Choisissez l'application qui se connecte en tant que cette boîte aux lettres. Ce choix est enregistré avec la boîte aux lettres et n'affecte pas les autres services.",
+        "managedLabel": "Application AlgaPSA (gérée par Nine Minds)",
+        "managedDescription": "Aucun enregistrement d'application Microsoft n'est requis de votre côté.",
+        "recommended": "Recommandée",
+        "currentApp": "Application actuelle : {{app}}",
+        "selectedApp": "Application sélectionnée : {{app}}",
+        "pendingReauth": "Réautorisation en attente",
+        "switchWarning": "Changer l'application Microsoft nécessite de reconnecter cette boîte aux lettres. Connectez-vous à nouveau avec Microsoft pour terminer le changement.",
+        "noneAvailable": "Pour connecter Microsoft 365, configurez d'abord une application Microsoft dans Fournisseurs, puis revenez.",
+        "retry": "Réessayer",
+        "pendingConsentEmpty": "Votre application Microsoft attend l'approbation d'un administrateur Microsoft 365. Une fois approuvée dans Fournisseurs, revenez pour vous connecter.",
+        "pendingConsentHint": "Votre propre application Microsoft attend encore l'approbation d'un administrateur Microsoft 365.",
+        "ownAppPrompt": "Préférez-vous vous connecter avec votre propre application Microsoft ?",
+        "ownAppSetupLink": "La configurer dans Fournisseurs"
       }
     },
     "gmail": {

--- a/server/public/locales/fr/msp/integrations.json
+++ b/server/public/locales/fr/msp/integrations.json
@@ -1659,7 +1659,8 @@
           "email": {
             "description": "Choisissez le profil Microsoft pour les e-mails Outlook entrants et sortants.",
             "label": "E-mail",
-            "reconnect": "Les connexions e-mail Outlook existantes doivent être autorisées à nouveau pour accorder Mail.Send avant de pouvoir envoyer des e-mails sortants."
+            "reconnect": "Les connexions e-mail Outlook existantes doivent être autorisées à nouveau pour accorder Mail.Send avant de pouvoir envoyer des e-mails sortants.",
+            "perProviderIssuerNote": "Existing mailbox connections keep their current Microsoft app until they are reconnected. This choice applies to new mailbox connections."
           },
           "mspSso": {
             "description": "Choisissez quel profil Microsoft sous-tend les domaines de connexion MSP SSO, la connexion Microsoft et la découverte de tenant.",

--- a/server/public/locales/fr/msp/integrations.json
+++ b/server/public/locales/fr/msp/integrations.json
@@ -1660,7 +1660,7 @@
             "description": "Choisissez le profil Microsoft pour les e-mails Outlook entrants et sortants.",
             "label": "E-mail",
             "reconnect": "Les connexions e-mail Outlook existantes doivent être autorisées à nouveau pour accorder Mail.Send avant de pouvoir envoyer des e-mails sortants.",
-            "perProviderIssuerNote": "Existing mailbox connections keep their current Microsoft app until they are reconnected. This choice applies to new mailbox connections."
+            "perProviderIssuerNote": "Les connexions de boîte aux lettres existantes conservent leur application Microsoft actuelle jusqu'à ce qu'elles soient reconnectées. Ce choix s'applique aux nouvelles connexions de boîte aux lettres."
           },
           "mspSso": {
             "description": "Choisissez quel profil Microsoft sous-tend les domaines de connexion MSP SSO, la connexion Microsoft et la découverte de tenant.",

--- a/server/public/locales/it/msp/email-providers.json
+++ b/server/public/locales/it/msp/email-providers.json
@@ -293,6 +293,8 @@
         "managedDescription": "No Microsoft app registration is required on your side.",
         "recommended": "Recommended",
         "currentApp": "Current app: {{app}}",
+        "selectedApp": "Selected app: {{app}}",
+        "pendingReauth": "Pending reauthorization",
         "switchWarning": "Changing the Microsoft app requires reconnecting this mailbox. Sign in with Microsoft again to finish the switch.",
         "noneAvailable": "To connect Microsoft 365, first set up a Microsoft app in Providers, then come back.",
         "retry": "Try again",

--- a/server/public/locales/it/msp/email-providers.json
+++ b/server/public/locales/it/msp/email-providers.json
@@ -284,12 +284,7 @@
         "maxEmailsPerSync": "Numero massimo di email per sincronizzazione"
       },
       "readiness": {
-        "checking": "Verifica della configurazione Microsoft…",
-        "ready": "Microsoft è configurato. Accedi con questa cassetta postale per terminare.",
-        "pending": "In attesa del tuo amministratore di Microsoft 365. La configurazione è stata avviata in Fornitori, ma non è ancora stata approvata.",
-        "openProviders": "Apri Fornitori",
-        "notConfigured": "Microsoft non è ancora configurato. Configuralo una volta in Fornitori, quindi torna qui.",
-        "setUpInProviders": "Configura in Fornitori"
+        "openProviders": "Apri Fornitori"
       },
       "issuer": {
         "title": "Microsoft app that authorizes this mailbox",
@@ -299,8 +294,12 @@
         "recommended": "Recommended",
         "currentApp": "Current app: {{app}}",
         "switchWarning": "Changing the Microsoft app requires reconnecting this mailbox. Sign in with Microsoft again to finish the switch.",
-        "noneAvailable": "No Microsoft app is ready for mailbox authorization yet. Set one up in Providers, then come back.",
-        "retry": "Try again"
+        "noneAvailable": "To connect Microsoft 365, first set up a Microsoft app in Providers, then come back.",
+        "retry": "Try again",
+        "pendingConsentEmpty": "Your Microsoft app is waiting for Microsoft 365 administrator approval. Once it is approved in Providers, come back to sign in.",
+        "pendingConsentHint": "Your own Microsoft app is still waiting for Microsoft 365 administrator approval.",
+        "ownAppPrompt": "Prefer to sign in with your own Microsoft app?",
+        "ownAppSetupLink": "Set it up in Providers"
       }
     },
     "gmail": {

--- a/server/public/locales/it/msp/email-providers.json
+++ b/server/public/locales/it/msp/email-providers.json
@@ -252,7 +252,7 @@
         "closedEarly": "Finestra di autorizzazione chiusa prima del completamento. Per favore riprova.",
         "authorizationFailed": "Autorizzazione fallita",
         "senderDisplayNameInvalid": "Il nome visualizzato non può contenere virgolette, parentesi angolari o interruzioni di riga",
-        "issuerRequired": "Choose a Microsoft app before signing in"
+        "issuerRequired": "Scegli un'app Microsoft prima di accedere"
       },
       "requiredFields": {
         "providerName": "Nome configurazione",
@@ -287,21 +287,21 @@
         "openProviders": "Apri Fornitori"
       },
       "issuer": {
-        "title": "Microsoft app that authorizes this mailbox",
-        "description": "Choose which application signs in as this mailbox. This choice is stored with the mailbox and does not affect other services.",
-        "managedLabel": "AlgaPSA app (managed by Nine Minds)",
-        "managedDescription": "No Microsoft app registration is required on your side.",
-        "recommended": "Recommended",
-        "currentApp": "Current app: {{app}}",
-        "selectedApp": "Selected app: {{app}}",
-        "pendingReauth": "Pending reauthorization",
-        "switchWarning": "Changing the Microsoft app requires reconnecting this mailbox. Sign in with Microsoft again to finish the switch.",
-        "noneAvailable": "To connect Microsoft 365, first set up a Microsoft app in Providers, then come back.",
-        "retry": "Try again",
-        "pendingConsentEmpty": "Your Microsoft app is waiting for Microsoft 365 administrator approval. Once it is approved in Providers, come back to sign in.",
-        "pendingConsentHint": "Your own Microsoft app is still waiting for Microsoft 365 administrator approval.",
-        "ownAppPrompt": "Prefer to sign in with your own Microsoft app?",
-        "ownAppSetupLink": "Set it up in Providers"
+        "title": "App Microsoft che autorizza questa casella di posta",
+        "description": "Scegli quale applicazione accede come questa casella di posta. Questa scelta viene salvata con la casella di posta e non influisce sugli altri servizi.",
+        "managedLabel": "App AlgaPSA (gestita da Nine Minds)",
+        "managedDescription": "Nessuna registrazione di un'app Microsoft è richiesta da parte tua.",
+        "recommended": "Consigliata",
+        "currentApp": "App attuale: {{app}}",
+        "selectedApp": "App selezionata: {{app}}",
+        "pendingReauth": "Ri-autorizzazione in sospeso",
+        "switchWarning": "La modifica dell'app Microsoft richiede di ricollegare questa casella di posta. Accedi di nuovo con Microsoft per completare il passaggio.",
+        "noneAvailable": "Per collegare Microsoft 365, configura prima un'app Microsoft in Fornitori, poi torna qui.",
+        "retry": "Riprova",
+        "pendingConsentEmpty": "La tua app Microsoft è in attesa dell'approvazione di un amministratore di Microsoft 365. Una volta approvata in Fornitori, torna qui per accedere.",
+        "pendingConsentHint": "La tua app Microsoft attende ancora l'approvazione di un amministratore di Microsoft 365.",
+        "ownAppPrompt": "Preferisci accedere con la tua app Microsoft?",
+        "ownAppSetupLink": "Configurala in Fornitori"
       }
     },
     "gmail": {

--- a/server/public/locales/it/msp/email-providers.json
+++ b/server/public/locales/it/msp/email-providers.json
@@ -251,7 +251,8 @@
         "popupBlocked": "Impossibile aprire il popup OAuth. Si prega di consentire i popup per questo sito.",
         "closedEarly": "Finestra di autorizzazione chiusa prima del completamento. Per favore riprova.",
         "authorizationFailed": "Autorizzazione fallita",
-        "senderDisplayNameInvalid": "Il nome visualizzato non può contenere virgolette, parentesi angolari o interruzioni di riga"
+        "senderDisplayNameInvalid": "Il nome visualizzato non può contenere virgolette, parentesi angolari o interruzioni di riga",
+        "issuerRequired": "Choose a Microsoft app before signing in"
       },
       "requiredFields": {
         "providerName": "Nome configurazione",
@@ -289,6 +290,17 @@
         "openProviders": "Apri Fornitori",
         "notConfigured": "Microsoft non è ancora configurato. Configuralo una volta in Fornitori, quindi torna qui.",
         "setUpInProviders": "Configura in Fornitori"
+      },
+      "issuer": {
+        "title": "Microsoft app that authorizes this mailbox",
+        "description": "Choose which application signs in as this mailbox. This choice is stored with the mailbox and does not affect other services.",
+        "managedLabel": "AlgaPSA app (managed by Nine Minds)",
+        "managedDescription": "No Microsoft app registration is required on your side.",
+        "recommended": "Recommended",
+        "currentApp": "Current app: {{app}}",
+        "switchWarning": "Changing the Microsoft app requires reconnecting this mailbox. Sign in with Microsoft again to finish the switch.",
+        "noneAvailable": "No Microsoft app is ready for mailbox authorization yet. Set one up in Providers, then come back.",
+        "retry": "Try again"
       }
     },
     "gmail": {

--- a/server/public/locales/it/msp/integrations.json
+++ b/server/public/locales/it/msp/integrations.json
@@ -1659,7 +1659,8 @@
           "email": {
             "description": "Scegli il profilo Microsoft per la posta Outlook in arrivo e in uscita.",
             "label": "E-mail",
-            "reconnect": "Le connessioni e-mail Outlook esistenti devono essere autorizzate nuovamente per concedere Mail.Send prima di poter inviare e-mail in uscita."
+            "reconnect": "Le connessioni e-mail Outlook esistenti devono essere autorizzate nuovamente per concedere Mail.Send prima di poter inviare e-mail in uscita.",
+            "perProviderIssuerNote": "Existing mailbox connections keep their current Microsoft app until they are reconnected. This choice applies to new mailbox connections."
           },
           "mspSso": {
             "description": "Scegli quale profilo Microsoft supporta i domini di accesso MSP SSO, l'accesso Microsoft e la discovery del tenant.",

--- a/server/public/locales/it/msp/integrations.json
+++ b/server/public/locales/it/msp/integrations.json
@@ -1660,7 +1660,7 @@
             "description": "Scegli il profilo Microsoft per la posta Outlook in arrivo e in uscita.",
             "label": "E-mail",
             "reconnect": "Le connessioni e-mail Outlook esistenti devono essere autorizzate nuovamente per concedere Mail.Send prima di poter inviare e-mail in uscita.",
-            "perProviderIssuerNote": "Existing mailbox connections keep their current Microsoft app until they are reconnected. This choice applies to new mailbox connections."
+            "perProviderIssuerNote": "Le connessioni esistenti della casella di posta mantengono la loro app Microsoft attuale finché non vengono ricollegate. Questa scelta si applica alle nuove connessioni della casella di posta."
           },
           "mspSso": {
             "description": "Scegli quale profilo Microsoft supporta i domini di accesso MSP SSO, l'accesso Microsoft e la discovery del tenant.",

--- a/server/public/locales/nl/msp/email-providers.json
+++ b/server/public/locales/nl/msp/email-providers.json
@@ -293,6 +293,8 @@
         "managedDescription": "No Microsoft app registration is required on your side.",
         "recommended": "Recommended",
         "currentApp": "Current app: {{app}}",
+        "selectedApp": "Selected app: {{app}}",
+        "pendingReauth": "Pending reauthorization",
         "switchWarning": "Changing the Microsoft app requires reconnecting this mailbox. Sign in with Microsoft again to finish the switch.",
         "noneAvailable": "To connect Microsoft 365, first set up a Microsoft app in Providers, then come back.",
         "retry": "Try again",

--- a/server/public/locales/nl/msp/email-providers.json
+++ b/server/public/locales/nl/msp/email-providers.json
@@ -284,12 +284,7 @@
         "maxEmailsPerSync": "Max. e-mails per synchronisatie"
       },
       "readiness": {
-        "checking": "Microsoft-configuratie controleren…",
-        "ready": "Microsoft is ingesteld. Meld u aan met dit postvak om de configuratie te voltooien.",
-        "pending": "Wachten op uw Microsoft 365-beheerder. De configuratie is gestart in Aanbieders, maar is nog niet goedgekeurd.",
-        "openProviders": "Aanbieders openen",
-        "notConfigured": "Microsoft is nog niet ingesteld. Stel Microsoft eenmaal in via Aanbieders en kom daarna terug.",
-        "setUpInProviders": "Instellen in Aanbieders"
+        "openProviders": "Aanbieders openen"
       },
       "issuer": {
         "title": "Microsoft app that authorizes this mailbox",
@@ -299,8 +294,12 @@
         "recommended": "Recommended",
         "currentApp": "Current app: {{app}}",
         "switchWarning": "Changing the Microsoft app requires reconnecting this mailbox. Sign in with Microsoft again to finish the switch.",
-        "noneAvailable": "No Microsoft app is ready for mailbox authorization yet. Set one up in Providers, then come back.",
-        "retry": "Try again"
+        "noneAvailable": "To connect Microsoft 365, first set up a Microsoft app in Providers, then come back.",
+        "retry": "Try again",
+        "pendingConsentEmpty": "Your Microsoft app is waiting for Microsoft 365 administrator approval. Once it is approved in Providers, come back to sign in.",
+        "pendingConsentHint": "Your own Microsoft app is still waiting for Microsoft 365 administrator approval.",
+        "ownAppPrompt": "Prefer to sign in with your own Microsoft app?",
+        "ownAppSetupLink": "Set it up in Providers"
       }
     },
     "gmail": {

--- a/server/public/locales/nl/msp/email-providers.json
+++ b/server/public/locales/nl/msp/email-providers.json
@@ -251,7 +251,8 @@
         "popupBlocked": "Kan de OAuth-pop-up niet openen. Sta pop-ups toe voor deze site.",
         "closedEarly": "Autorisatievenster gesloten vóór voltooiing. Probeer het opnieuw.",
         "authorizationFailed": "Autorisatie mislukt",
-        "senderDisplayNameInvalid": "Weergavenaam mag geen aanhalingstekens, punthaken of regeleinden bevatten"
+        "senderDisplayNameInvalid": "Weergavenaam mag geen aanhalingstekens, punthaken of regeleinden bevatten",
+        "issuerRequired": "Choose a Microsoft app before signing in"
       },
       "requiredFields": {
         "providerName": "Configuratienaam",
@@ -289,6 +290,17 @@
         "openProviders": "Aanbieders openen",
         "notConfigured": "Microsoft is nog niet ingesteld. Stel Microsoft eenmaal in via Aanbieders en kom daarna terug.",
         "setUpInProviders": "Instellen in Aanbieders"
+      },
+      "issuer": {
+        "title": "Microsoft app that authorizes this mailbox",
+        "description": "Choose which application signs in as this mailbox. This choice is stored with the mailbox and does not affect other services.",
+        "managedLabel": "AlgaPSA app (managed by Nine Minds)",
+        "managedDescription": "No Microsoft app registration is required on your side.",
+        "recommended": "Recommended",
+        "currentApp": "Current app: {{app}}",
+        "switchWarning": "Changing the Microsoft app requires reconnecting this mailbox. Sign in with Microsoft again to finish the switch.",
+        "noneAvailable": "No Microsoft app is ready for mailbox authorization yet. Set one up in Providers, then come back.",
+        "retry": "Try again"
       }
     },
     "gmail": {

--- a/server/public/locales/nl/msp/email-providers.json
+++ b/server/public/locales/nl/msp/email-providers.json
@@ -252,7 +252,7 @@
         "closedEarly": "Autorisatievenster gesloten vóór voltooiing. Probeer het opnieuw.",
         "authorizationFailed": "Autorisatie mislukt",
         "senderDisplayNameInvalid": "Weergavenaam mag geen aanhalingstekens, punthaken of regeleinden bevatten",
-        "issuerRequired": "Choose a Microsoft app before signing in"
+        "issuerRequired": "Kies een Microsoft-app voordat u zich aanmeldt"
       },
       "requiredFields": {
         "providerName": "Configuratienaam",
@@ -287,21 +287,21 @@
         "openProviders": "Aanbieders openen"
       },
       "issuer": {
-        "title": "Microsoft app that authorizes this mailbox",
-        "description": "Choose which application signs in as this mailbox. This choice is stored with the mailbox and does not affect other services.",
-        "managedLabel": "AlgaPSA app (managed by Nine Minds)",
-        "managedDescription": "No Microsoft app registration is required on your side.",
-        "recommended": "Recommended",
-        "currentApp": "Current app: {{app}}",
-        "selectedApp": "Selected app: {{app}}",
-        "pendingReauth": "Pending reauthorization",
-        "switchWarning": "Changing the Microsoft app requires reconnecting this mailbox. Sign in with Microsoft again to finish the switch.",
-        "noneAvailable": "To connect Microsoft 365, first set up a Microsoft app in Providers, then come back.",
-        "retry": "Try again",
-        "pendingConsentEmpty": "Your Microsoft app is waiting for Microsoft 365 administrator approval. Once it is approved in Providers, come back to sign in.",
-        "pendingConsentHint": "Your own Microsoft app is still waiting for Microsoft 365 administrator approval.",
-        "ownAppPrompt": "Prefer to sign in with your own Microsoft app?",
-        "ownAppSetupLink": "Set it up in Providers"
+        "title": "Microsoft-app die dit postvak autoriseert",
+        "description": "Kies welke toepassing zich aanmeldt als dit postvak. Deze keuze wordt bij het postvak opgeslagen en heeft geen invloed op andere services.",
+        "managedLabel": "AlgaPSA-app (beheerd door Nine Minds)",
+        "managedDescription": "Aan uw kant is geen registratie van een Microsoft-app vereist.",
+        "recommended": "Aanbevolen",
+        "currentApp": "Huidige app: {{app}}",
+        "selectedApp": "Geselecteerde app: {{app}}",
+        "pendingReauth": "Herautorisatie in behandeling",
+        "switchWarning": "Het wijzigen van de Microsoft-app vereist dat dit postvak opnieuw wordt verbonden. Meld u opnieuw aan met Microsoft om de overstap af te ronden.",
+        "noneAvailable": "Om Microsoft 365 te verbinden, stelt u eerst een Microsoft-app in bij Aanbieders en komt u daarna terug.",
+        "retry": "Opnieuw proberen",
+        "pendingConsentEmpty": "Uw Microsoft-app wacht op goedkeuring van een Microsoft 365-beheerder. Zodra deze bij Aanbieders is goedgekeurd, komt u terug om u aan te melden.",
+        "pendingConsentHint": "Uw eigen Microsoft-app wacht nog op goedkeuring van een Microsoft 365-beheerder.",
+        "ownAppPrompt": "Liever aanmelden met uw eigen Microsoft-app?",
+        "ownAppSetupLink": "Instellen bij Aanbieders"
       }
     },
     "gmail": {

--- a/server/public/locales/nl/msp/integrations.json
+++ b/server/public/locales/nl/msp/integrations.json
@@ -1660,7 +1660,7 @@
             "description": "Kies het Microsoft-profiel voor inkomende en uitgaande Outlook-e-mail.",
             "label": "E-mail",
             "reconnect": "Bestaande Outlook-e-mailverbindingen moeten opnieuw worden geautoriseerd om Mail.Send toe te kennen voordat ze uitgaande e-mail kunnen verzenden.",
-            "perProviderIssuerNote": "Existing mailbox connections keep their current Microsoft app until they are reconnected. This choice applies to new mailbox connections."
+            "perProviderIssuerNote": "Bestaande postvakverbindingen behouden hun huidige Microsoft-app totdat ze opnieuw worden verbonden. Deze keuze geldt voor nieuwe postvakverbindingen."
           },
           "mspSso": {
             "description": "Kies welk Microsoft-profiel MSP SSO-aanmeldingsdomeinen, Microsoft-aanmelding en tenant-detectie ondersteunt.",

--- a/server/public/locales/nl/msp/integrations.json
+++ b/server/public/locales/nl/msp/integrations.json
@@ -1659,7 +1659,8 @@
           "email": {
             "description": "Kies het Microsoft-profiel voor inkomende en uitgaande Outlook-e-mail.",
             "label": "E-mail",
-            "reconnect": "Bestaande Outlook-e-mailverbindingen moeten opnieuw worden geautoriseerd om Mail.Send toe te kennen voordat ze uitgaande e-mail kunnen verzenden."
+            "reconnect": "Bestaande Outlook-e-mailverbindingen moeten opnieuw worden geautoriseerd om Mail.Send toe te kennen voordat ze uitgaande e-mail kunnen verzenden.",
+            "perProviderIssuerNote": "Existing mailbox connections keep their current Microsoft app until they are reconnected. This choice applies to new mailbox connections."
           },
           "mspSso": {
             "description": "Kies welk Microsoft-profiel MSP SSO-aanmeldingsdomeinen, Microsoft-aanmelding en tenant-detectie ondersteunt.",

--- a/server/public/locales/pl/msp/email-providers.json
+++ b/server/public/locales/pl/msp/email-providers.json
@@ -293,6 +293,8 @@
         "managedDescription": "No Microsoft app registration is required on your side.",
         "recommended": "Recommended",
         "currentApp": "Current app: {{app}}",
+        "selectedApp": "Selected app: {{app}}",
+        "pendingReauth": "Pending reauthorization",
         "switchWarning": "Changing the Microsoft app requires reconnecting this mailbox. Sign in with Microsoft again to finish the switch.",
         "noneAvailable": "To connect Microsoft 365, first set up a Microsoft app in Providers, then come back.",
         "retry": "Try again",

--- a/server/public/locales/pl/msp/email-providers.json
+++ b/server/public/locales/pl/msp/email-providers.json
@@ -284,12 +284,7 @@
         "maxEmailsPerSync": "Maksymalna liczba e-maili na synchronizację"
       },
       "readiness": {
-        "checking": "Sprawdzanie konfiguracji Microsoft…",
-        "ready": "Microsoft jest skonfigurowany. Zaloguj się za pomocą tej skrzynki pocztowej, aby zakończyć.",
-        "pending": "Oczekiwanie na administratora Microsoft 365. Konfiguracja została rozpoczęta w sekcji Dostawcy, ale nie została jeszcze zatwierdzona.",
-        "openProviders": "Otwórz Dostawców",
-        "notConfigured": "Microsoft nie jest jeszcze skonfigurowany. Skonfiguruj go raz w sekcji Dostawcy, a następnie wróć.",
-        "setUpInProviders": "Skonfiguruj w sekcji Dostawcy"
+        "openProviders": "Otwórz Dostawców"
       },
       "issuer": {
         "title": "Microsoft app that authorizes this mailbox",
@@ -299,8 +294,12 @@
         "recommended": "Recommended",
         "currentApp": "Current app: {{app}}",
         "switchWarning": "Changing the Microsoft app requires reconnecting this mailbox. Sign in with Microsoft again to finish the switch.",
-        "noneAvailable": "No Microsoft app is ready for mailbox authorization yet. Set one up in Providers, then come back.",
-        "retry": "Try again"
+        "noneAvailable": "To connect Microsoft 365, first set up a Microsoft app in Providers, then come back.",
+        "retry": "Try again",
+        "pendingConsentEmpty": "Your Microsoft app is waiting for Microsoft 365 administrator approval. Once it is approved in Providers, come back to sign in.",
+        "pendingConsentHint": "Your own Microsoft app is still waiting for Microsoft 365 administrator approval.",
+        "ownAppPrompt": "Prefer to sign in with your own Microsoft app?",
+        "ownAppSetupLink": "Set it up in Providers"
       }
     },
     "gmail": {

--- a/server/public/locales/pl/msp/email-providers.json
+++ b/server/public/locales/pl/msp/email-providers.json
@@ -251,7 +251,8 @@
         "popupBlocked": "Nie udało się otworzyć wyskakującego okienka OAuth. Zezwól na wyświetlanie wyskakujących okienek w tej witrynie.",
         "closedEarly": "Okno autoryzacji zostało zamknięte przed zakończeniem. Spróbuj ponownie.",
         "authorizationFailed": "Autoryzacja nie powiodła się",
-        "senderDisplayNameInvalid": "Nazwa wyświetlana nie może zawierać cudzysłowów, nawiasów ostrych ani znaków nowego wiersza"
+        "senderDisplayNameInvalid": "Nazwa wyświetlana nie może zawierać cudzysłowów, nawiasów ostrych ani znaków nowego wiersza",
+        "issuerRequired": "Choose a Microsoft app before signing in"
       },
       "requiredFields": {
         "providerName": "Nazwa konfiguracji",
@@ -289,6 +290,17 @@
         "openProviders": "Otwórz Dostawców",
         "notConfigured": "Microsoft nie jest jeszcze skonfigurowany. Skonfiguruj go raz w sekcji Dostawcy, a następnie wróć.",
         "setUpInProviders": "Skonfiguruj w sekcji Dostawcy"
+      },
+      "issuer": {
+        "title": "Microsoft app that authorizes this mailbox",
+        "description": "Choose which application signs in as this mailbox. This choice is stored with the mailbox and does not affect other services.",
+        "managedLabel": "AlgaPSA app (managed by Nine Minds)",
+        "managedDescription": "No Microsoft app registration is required on your side.",
+        "recommended": "Recommended",
+        "currentApp": "Current app: {{app}}",
+        "switchWarning": "Changing the Microsoft app requires reconnecting this mailbox. Sign in with Microsoft again to finish the switch.",
+        "noneAvailable": "No Microsoft app is ready for mailbox authorization yet. Set one up in Providers, then come back.",
+        "retry": "Try again"
       }
     },
     "gmail": {

--- a/server/public/locales/pl/msp/email-providers.json
+++ b/server/public/locales/pl/msp/email-providers.json
@@ -252,7 +252,7 @@
         "closedEarly": "Okno autoryzacji zostało zamknięte przed zakończeniem. Spróbuj ponownie.",
         "authorizationFailed": "Autoryzacja nie powiodła się",
         "senderDisplayNameInvalid": "Nazwa wyświetlana nie może zawierać cudzysłowów, nawiasów ostrych ani znaków nowego wiersza",
-        "issuerRequired": "Choose a Microsoft app before signing in"
+        "issuerRequired": "Wybierz aplikację Microsoft przed zalogowaniem się"
       },
       "requiredFields": {
         "providerName": "Nazwa konfiguracji",
@@ -287,21 +287,21 @@
         "openProviders": "Otwórz Dostawców"
       },
       "issuer": {
-        "title": "Microsoft app that authorizes this mailbox",
-        "description": "Choose which application signs in as this mailbox. This choice is stored with the mailbox and does not affect other services.",
-        "managedLabel": "AlgaPSA app (managed by Nine Minds)",
-        "managedDescription": "No Microsoft app registration is required on your side.",
-        "recommended": "Recommended",
-        "currentApp": "Current app: {{app}}",
-        "selectedApp": "Selected app: {{app}}",
-        "pendingReauth": "Pending reauthorization",
-        "switchWarning": "Changing the Microsoft app requires reconnecting this mailbox. Sign in with Microsoft again to finish the switch.",
-        "noneAvailable": "To connect Microsoft 365, first set up a Microsoft app in Providers, then come back.",
-        "retry": "Try again",
-        "pendingConsentEmpty": "Your Microsoft app is waiting for Microsoft 365 administrator approval. Once it is approved in Providers, come back to sign in.",
-        "pendingConsentHint": "Your own Microsoft app is still waiting for Microsoft 365 administrator approval.",
-        "ownAppPrompt": "Prefer to sign in with your own Microsoft app?",
-        "ownAppSetupLink": "Set it up in Providers"
+        "title": "Aplikacja Microsoft, która autoryzuje tę skrzynkę pocztową",
+        "description": "Wybierz, która aplikacja loguje się jako ta skrzynka pocztowa. Ten wybór jest zapisywany wraz ze skrzynką pocztową i nie wpływa na inne usługi.",
+        "managedLabel": "Aplikacja AlgaPSA (zarządzana przez Nine Minds)",
+        "managedDescription": "Po Twojej stronie nie jest wymagana żadna rejestracja aplikacji Microsoft.",
+        "recommended": "Zalecana",
+        "currentApp": "Bieżąca aplikacja: {{app}}",
+        "selectedApp": "Wybrana aplikacja: {{app}}",
+        "pendingReauth": "Ponowna autoryzacja w toku",
+        "switchWarning": "Zmiana aplikacji Microsoft wymaga ponownego połączenia tej skrzynki pocztowej. Zaloguj się ponownie przez Microsoft, aby dokończyć zmianę.",
+        "noneAvailable": "Aby połączyć Microsoft 365, najpierw skonfiguruj aplikację Microsoft u Dostawców, a następnie wróć tutaj.",
+        "retry": "Spróbuj ponownie",
+        "pendingConsentEmpty": "Twoja aplikacja Microsoft czeka na zatwierdzenie przez administratora Microsoft 365. Po zatwierdzeniu u Dostawców wróć tutaj, aby się zalogować.",
+        "pendingConsentHint": "Twoja własna aplikacja Microsoft nadal czeka na zatwierdzenie przez administratora Microsoft 365.",
+        "ownAppPrompt": "Wolisz zalogować się za pomocą własnej aplikacji Microsoft?",
+        "ownAppSetupLink": "Skonfiguruj ją u Dostawców"
       }
     },
     "gmail": {

--- a/server/public/locales/pl/msp/integrations.json
+++ b/server/public/locales/pl/msp/integrations.json
@@ -1659,7 +1659,8 @@
           "email": {
             "description": "Wybierz profil Microsoft dla przychodzącej i wychodzącej poczty Outlook.",
             "label": "E-mail",
-            "reconnect": "Istniejące połączenia e-mail Outlook muszą zostać ponownie autoryzowane, aby przyznać Mail.Send przed wysyłaniem poczty wychodzącej."
+            "reconnect": "Istniejące połączenia e-mail Outlook muszą zostać ponownie autoryzowane, aby przyznać Mail.Send przed wysyłaniem poczty wychodzącej.",
+            "perProviderIssuerNote": "Existing mailbox connections keep their current Microsoft app until they are reconnected. This choice applies to new mailbox connections."
           },
           "mspSso": {
             "description": "Wybierz, który profil Microsoft obsługuje domeny logowania MSP SSO, logowanie Microsoft i wykrywanie tenanta.",

--- a/server/public/locales/pl/msp/integrations.json
+++ b/server/public/locales/pl/msp/integrations.json
@@ -1660,7 +1660,7 @@
             "description": "Wybierz profil Microsoft dla przychodzącej i wychodzącej poczty Outlook.",
             "label": "E-mail",
             "reconnect": "Istniejące połączenia e-mail Outlook muszą zostać ponownie autoryzowane, aby przyznać Mail.Send przed wysyłaniem poczty wychodzącej.",
-            "perProviderIssuerNote": "Existing mailbox connections keep their current Microsoft app until they are reconnected. This choice applies to new mailbox connections."
+            "perProviderIssuerNote": "Istniejące połączenia skrzynek pocztowych zachowują swoją bieżącą aplikację Microsoft, dopóki nie zostaną ponownie połączone. Ten wybór dotyczy nowych połączeń skrzynek pocztowych."
           },
           "mspSso": {
             "description": "Wybierz, który profil Microsoft obsługuje domeny logowania MSP SSO, logowanie Microsoft i wykrywanie tenanta.",

--- a/server/public/locales/pt/msp/email-providers.json
+++ b/server/public/locales/pt/msp/email-providers.json
@@ -293,6 +293,8 @@
         "managedDescription": "No Microsoft app registration is required on your side.",
         "recommended": "Recommended",
         "currentApp": "Current app: {{app}}",
+        "selectedApp": "Selected app: {{app}}",
+        "pendingReauth": "Pending reauthorization",
         "switchWarning": "Changing the Microsoft app requires reconnecting this mailbox. Sign in with Microsoft again to finish the switch.",
         "noneAvailable": "To connect Microsoft 365, first set up a Microsoft app in Providers, then come back.",
         "retry": "Try again",

--- a/server/public/locales/pt/msp/email-providers.json
+++ b/server/public/locales/pt/msp/email-providers.json
@@ -284,12 +284,7 @@
         "maxEmailsPerSync": "Máximo de e-mails por sincronização"
       },
       "readiness": {
-        "checking": "Verificando a configuração da Microsoft…",
-        "ready": "A Microsoft está configurada. Entre com esta caixa de correio para concluir.",
-        "pending": "Aguardando seu administrador do Microsoft 365. A configuração foi iniciada em Provedores, mas ainda não foi aprovada.",
-        "openProviders": "Abrir Provedores",
-        "notConfigured": "A Microsoft ainda não está configurada. Configure-a uma vez em Provedores e depois volte.",
-        "setUpInProviders": "Configurar em Provedores"
+        "openProviders": "Abrir Provedores"
       },
       "issuer": {
         "title": "Microsoft app that authorizes this mailbox",
@@ -299,8 +294,12 @@
         "recommended": "Recommended",
         "currentApp": "Current app: {{app}}",
         "switchWarning": "Changing the Microsoft app requires reconnecting this mailbox. Sign in with Microsoft again to finish the switch.",
-        "noneAvailable": "No Microsoft app is ready for mailbox authorization yet. Set one up in Providers, then come back.",
-        "retry": "Try again"
+        "noneAvailable": "To connect Microsoft 365, first set up a Microsoft app in Providers, then come back.",
+        "retry": "Try again",
+        "pendingConsentEmpty": "Your Microsoft app is waiting for Microsoft 365 administrator approval. Once it is approved in Providers, come back to sign in.",
+        "pendingConsentHint": "Your own Microsoft app is still waiting for Microsoft 365 administrator approval.",
+        "ownAppPrompt": "Prefer to sign in with your own Microsoft app?",
+        "ownAppSetupLink": "Set it up in Providers"
       }
     },
     "gmail": {

--- a/server/public/locales/pt/msp/email-providers.json
+++ b/server/public/locales/pt/msp/email-providers.json
@@ -252,7 +252,7 @@
         "closedEarly": "Janela de autorização fechada antes da conclusão. Por favor, tente novamente.",
         "authorizationFailed": "Falha na autorização",
         "senderDisplayNameInvalid": "O nome de exibição não pode conter aspas, colchetes angulares ou quebras de linha",
-        "issuerRequired": "Choose a Microsoft app before signing in"
+        "issuerRequired": "Escolha um aplicativo da Microsoft antes de entrar"
       },
       "requiredFields": {
         "providerName": "Nome da configuração",
@@ -287,21 +287,21 @@
         "openProviders": "Abrir Provedores"
       },
       "issuer": {
-        "title": "Microsoft app that authorizes this mailbox",
-        "description": "Choose which application signs in as this mailbox. This choice is stored with the mailbox and does not affect other services.",
-        "managedLabel": "AlgaPSA app (managed by Nine Minds)",
-        "managedDescription": "No Microsoft app registration is required on your side.",
-        "recommended": "Recommended",
-        "currentApp": "Current app: {{app}}",
-        "selectedApp": "Selected app: {{app}}",
-        "pendingReauth": "Pending reauthorization",
-        "switchWarning": "Changing the Microsoft app requires reconnecting this mailbox. Sign in with Microsoft again to finish the switch.",
-        "noneAvailable": "To connect Microsoft 365, first set up a Microsoft app in Providers, then come back.",
-        "retry": "Try again",
-        "pendingConsentEmpty": "Your Microsoft app is waiting for Microsoft 365 administrator approval. Once it is approved in Providers, come back to sign in.",
-        "pendingConsentHint": "Your own Microsoft app is still waiting for Microsoft 365 administrator approval.",
-        "ownAppPrompt": "Prefer to sign in with your own Microsoft app?",
-        "ownAppSetupLink": "Set it up in Providers"
+        "title": "Aplicativo da Microsoft que autoriza esta caixa de correio",
+        "description": "Escolha qual aplicativo entra como esta caixa de correio. Esta escolha é armazenada com a caixa de correio e não afeta outros serviços.",
+        "managedLabel": "Aplicativo AlgaPSA (gerenciado pela Nine Minds)",
+        "managedDescription": "Nenhum registro de aplicativo da Microsoft é necessário do seu lado.",
+        "recommended": "Recomendado",
+        "currentApp": "Aplicativo atual: {{app}}",
+        "selectedApp": "Aplicativo selecionado: {{app}}",
+        "pendingReauth": "Reautorização pendente",
+        "switchWarning": "Alterar o aplicativo da Microsoft exige reconectar esta caixa de correio. Entre novamente com a Microsoft para concluir a troca.",
+        "noneAvailable": "Para conectar o Microsoft 365, primeiro configure um aplicativo da Microsoft em Provedores e depois volte.",
+        "retry": "Tentar novamente",
+        "pendingConsentEmpty": "Seu aplicativo da Microsoft está aguardando aprovação de um administrador do Microsoft 365. Depois de aprovado em Provedores, volte para entrar.",
+        "pendingConsentHint": "Seu próprio aplicativo da Microsoft ainda aguarda aprovação de um administrador do Microsoft 365.",
+        "ownAppPrompt": "Prefere entrar com seu próprio aplicativo da Microsoft?",
+        "ownAppSetupLink": "Configurá-lo em Provedores"
       }
     },
     "gmail": {

--- a/server/public/locales/pt/msp/email-providers.json
+++ b/server/public/locales/pt/msp/email-providers.json
@@ -251,7 +251,8 @@
         "popupBlocked": "Falha ao abrir o pop-up do OAuth. Por favor, permita pop-ups para este site.",
         "closedEarly": "Janela de autorização fechada antes da conclusão. Por favor, tente novamente.",
         "authorizationFailed": "Falha na autorização",
-        "senderDisplayNameInvalid": "O nome de exibição não pode conter aspas, colchetes angulares ou quebras de linha"
+        "senderDisplayNameInvalid": "O nome de exibição não pode conter aspas, colchetes angulares ou quebras de linha",
+        "issuerRequired": "Choose a Microsoft app before signing in"
       },
       "requiredFields": {
         "providerName": "Nome da configuração",
@@ -289,6 +290,17 @@
         "openProviders": "Abrir Provedores",
         "notConfigured": "A Microsoft ainda não está configurada. Configure-a uma vez em Provedores e depois volte.",
         "setUpInProviders": "Configurar em Provedores"
+      },
+      "issuer": {
+        "title": "Microsoft app that authorizes this mailbox",
+        "description": "Choose which application signs in as this mailbox. This choice is stored with the mailbox and does not affect other services.",
+        "managedLabel": "AlgaPSA app (managed by Nine Minds)",
+        "managedDescription": "No Microsoft app registration is required on your side.",
+        "recommended": "Recommended",
+        "currentApp": "Current app: {{app}}",
+        "switchWarning": "Changing the Microsoft app requires reconnecting this mailbox. Sign in with Microsoft again to finish the switch.",
+        "noneAvailable": "No Microsoft app is ready for mailbox authorization yet. Set one up in Providers, then come back.",
+        "retry": "Try again"
       }
     },
     "gmail": {

--- a/server/public/locales/pt/msp/integrations.json
+++ b/server/public/locales/pt/msp/integrations.json
@@ -1659,7 +1659,8 @@
           "email": {
             "description": "Escolha o perfil da Microsoft para e-mails recebidos e enviados do Outlook.",
             "label": "E-mail",
-            "reconnect": "As conexões de e-mail existentes do Outlook precisam ser autorizadas novamente para conceder Mail.Send antes de poderem enviar e-mails."
+            "reconnect": "As conexões de e-mail existentes do Outlook precisam ser autorizadas novamente para conceder Mail.Send antes de poderem enviar e-mails.",
+            "perProviderIssuerNote": "Existing mailbox connections keep their current Microsoft app until they are reconnected. This choice applies to new mailbox connections."
           },
           "mspSso": {
             "description": "Escolha qual perfil da Microsoft oferece suporte a domínios de login SSO do MSP, entrada da Microsoft e descoberta de locatário.",

--- a/server/public/locales/pt/msp/integrations.json
+++ b/server/public/locales/pt/msp/integrations.json
@@ -1660,7 +1660,7 @@
             "description": "Escolha o perfil da Microsoft para e-mails recebidos e enviados do Outlook.",
             "label": "E-mail",
             "reconnect": "As conexões de e-mail existentes do Outlook precisam ser autorizadas novamente para conceder Mail.Send antes de poderem enviar e-mails.",
-            "perProviderIssuerNote": "Existing mailbox connections keep their current Microsoft app until they are reconnected. This choice applies to new mailbox connections."
+            "perProviderIssuerNote": "Conexões de caixa de correio existentes mantêm seu aplicativo da Microsoft atual até serem reconectadas. Esta escolha se aplica a novas conexões de caixa de correio."
           },
           "mspSso": {
             "description": "Escolha qual perfil da Microsoft oferece suporte a domínios de login SSO do MSP, entrada da Microsoft e descoberta de locatário.",

--- a/server/public/locales/xx/msp/email-providers.json
+++ b/server/public/locales/xx/msp/email-providers.json
@@ -251,7 +251,8 @@
         "popupBlocked": "11111",
         "closedEarly": "11111",
         "authorizationFailed": "11111",
-        "senderDisplayNameInvalid": "11111"
+        "senderDisplayNameInvalid": "11111",
+        "issuerRequired": "Choose a Microsoft app before signing in"
       },
       "requiredFields": {
         "providerName": "11111",
@@ -281,6 +282,17 @@
         "openProviders": "11111",
         "notConfigured": "11111",
         "setUpInProviders": "11111"
+      },
+      "issuer": {
+        "title": "Microsoft app that authorizes this mailbox",
+        "description": "Choose which application signs in as this mailbox. This choice is stored with the mailbox and does not affect other services.",
+        "managedLabel": "AlgaPSA app (managed by Nine Minds)",
+        "managedDescription": "No Microsoft app registration is required on your side.",
+        "recommended": "Recommended",
+        "currentApp": "Current app: {{app}}",
+        "switchWarning": "Changing the Microsoft app requires reconnecting this mailbox. Sign in with Microsoft again to finish the switch.",
+        "noneAvailable": "No Microsoft app is ready for mailbox authorization yet. Set one up in Providers, then come back.",
+        "retry": "Try again"
       },
       "advanced": {
         "title": "11111",

--- a/server/public/locales/xx/msp/email-providers.json
+++ b/server/public/locales/xx/msp/email-providers.json
@@ -285,6 +285,8 @@
         "managedDescription": "11111",
         "recommended": "11111",
         "currentApp": "11111 {{app}} 11111",
+        "selectedApp": "11111 {{app}} 11111",
+        "pendingReauth": "11111",
         "switchWarning": "11111",
         "noneAvailable": "11111",
         "retry": "11111",

--- a/server/public/locales/xx/msp/email-providers.json
+++ b/server/public/locales/xx/msp/email-providers.json
@@ -252,7 +252,7 @@
         "closedEarly": "11111",
         "authorizationFailed": "11111",
         "senderDisplayNameInvalid": "11111",
-        "issuerRequired": "Choose a Microsoft app before signing in"
+        "issuerRequired": "11111"
       },
       "requiredFields": {
         "providerName": "11111",
@@ -284,15 +284,15 @@
         "setUpInProviders": "11111"
       },
       "issuer": {
-        "title": "Microsoft app that authorizes this mailbox",
-        "description": "Choose which application signs in as this mailbox. This choice is stored with the mailbox and does not affect other services.",
-        "managedLabel": "AlgaPSA app (managed by Nine Minds)",
-        "managedDescription": "No Microsoft app registration is required on your side.",
-        "recommended": "Recommended",
-        "currentApp": "Current app: {{app}}",
-        "switchWarning": "Changing the Microsoft app requires reconnecting this mailbox. Sign in with Microsoft again to finish the switch.",
-        "noneAvailable": "No Microsoft app is ready for mailbox authorization yet. Set one up in Providers, then come back.",
-        "retry": "Try again"
+        "title": "11111",
+        "description": "11111",
+        "managedLabel": "11111",
+        "managedDescription": "11111",
+        "recommended": "11111",
+        "currentApp": "11111 {{app}} 11111",
+        "switchWarning": "11111",
+        "noneAvailable": "11111",
+        "retry": "11111"
       },
       "advanced": {
         "title": "11111",

--- a/server/public/locales/xx/msp/email-providers.json
+++ b/server/public/locales/xx/msp/email-providers.json
@@ -276,12 +276,7 @@
         "signIn": "11111"
       },
       "readiness": {
-        "checking": "11111",
-        "ready": "11111",
-        "pending": "11111",
-        "openProviders": "11111",
-        "notConfigured": "11111",
-        "setUpInProviders": "11111"
+        "openProviders": "11111"
       },
       "issuer": {
         "title": "11111",
@@ -292,7 +287,11 @@
         "currentApp": "11111 {{app}} 11111",
         "switchWarning": "11111",
         "noneAvailable": "11111",
-        "retry": "11111"
+        "retry": "11111",
+        "pendingConsentEmpty": "11111",
+        "pendingConsentHint": "11111",
+        "ownAppPrompt": "11111",
+        "ownAppSetupLink": "11111"
       },
       "advanced": {
         "title": "11111",

--- a/server/public/locales/xx/msp/integrations.json
+++ b/server/public/locales/xx/msp/integrations.json
@@ -1660,7 +1660,7 @@
             "description": "11111",
             "label": "11111",
             "reconnect": "11111",
-            "perProviderIssuerNote": "Existing mailbox connections keep their current Microsoft app until they are reconnected. This choice applies to new mailbox connections."
+            "perProviderIssuerNote": "11111"
           },
           "mspSso": {
             "description": "11111",

--- a/server/public/locales/xx/msp/integrations.json
+++ b/server/public/locales/xx/msp/integrations.json
@@ -1659,7 +1659,8 @@
           "email": {
             "description": "11111",
             "label": "11111",
-            "reconnect": "11111"
+            "reconnect": "11111",
+            "perProviderIssuerNote": "Existing mailbox connections keep their current Microsoft app until they are reconnected. This choice applies to new mailbox connections."
           },
           "mspSso": {
             "description": "11111",

--- a/server/public/locales/yy/msp/email-providers.json
+++ b/server/public/locales/yy/msp/email-providers.json
@@ -285,6 +285,8 @@
         "managedDescription": "55555",
         "recommended": "55555",
         "currentApp": "55555 {{app}} 55555",
+        "selectedApp": "55555 {{app}} 55555",
+        "pendingReauth": "55555",
         "switchWarning": "55555",
         "noneAvailable": "55555",
         "retry": "55555",

--- a/server/public/locales/yy/msp/email-providers.json
+++ b/server/public/locales/yy/msp/email-providers.json
@@ -252,7 +252,7 @@
         "closedEarly": "55555",
         "authorizationFailed": "55555",
         "senderDisplayNameInvalid": "55555",
-        "issuerRequired": "Choose a Microsoft app before signing in"
+        "issuerRequired": "55555"
       },
       "requiredFields": {
         "providerName": "55555",
@@ -284,15 +284,15 @@
         "setUpInProviders": "55555"
       },
       "issuer": {
-        "title": "Microsoft app that authorizes this mailbox",
-        "description": "Choose which application signs in as this mailbox. This choice is stored with the mailbox and does not affect other services.",
-        "managedLabel": "AlgaPSA app (managed by Nine Minds)",
-        "managedDescription": "No Microsoft app registration is required on your side.",
-        "recommended": "Recommended",
-        "currentApp": "Current app: {{app}}",
-        "switchWarning": "Changing the Microsoft app requires reconnecting this mailbox. Sign in with Microsoft again to finish the switch.",
-        "noneAvailable": "No Microsoft app is ready for mailbox authorization yet. Set one up in Providers, then come back.",
-        "retry": "Try again"
+        "title": "55555",
+        "description": "55555",
+        "managedLabel": "55555",
+        "managedDescription": "55555",
+        "recommended": "55555",
+        "currentApp": "55555 {{app}} 55555",
+        "switchWarning": "55555",
+        "noneAvailable": "55555",
+        "retry": "55555"
       },
       "advanced": {
         "title": "55555",

--- a/server/public/locales/yy/msp/email-providers.json
+++ b/server/public/locales/yy/msp/email-providers.json
@@ -251,7 +251,8 @@
         "popupBlocked": "55555",
         "closedEarly": "55555",
         "authorizationFailed": "55555",
-        "senderDisplayNameInvalid": "55555"
+        "senderDisplayNameInvalid": "55555",
+        "issuerRequired": "Choose a Microsoft app before signing in"
       },
       "requiredFields": {
         "providerName": "55555",
@@ -281,6 +282,17 @@
         "openProviders": "55555",
         "notConfigured": "55555",
         "setUpInProviders": "55555"
+      },
+      "issuer": {
+        "title": "Microsoft app that authorizes this mailbox",
+        "description": "Choose which application signs in as this mailbox. This choice is stored with the mailbox and does not affect other services.",
+        "managedLabel": "AlgaPSA app (managed by Nine Minds)",
+        "managedDescription": "No Microsoft app registration is required on your side.",
+        "recommended": "Recommended",
+        "currentApp": "Current app: {{app}}",
+        "switchWarning": "Changing the Microsoft app requires reconnecting this mailbox. Sign in with Microsoft again to finish the switch.",
+        "noneAvailable": "No Microsoft app is ready for mailbox authorization yet. Set one up in Providers, then come back.",
+        "retry": "Try again"
       },
       "advanced": {
         "title": "55555",

--- a/server/public/locales/yy/msp/email-providers.json
+++ b/server/public/locales/yy/msp/email-providers.json
@@ -276,12 +276,7 @@
         "signIn": "55555"
       },
       "readiness": {
-        "checking": "55555",
-        "ready": "55555",
-        "pending": "55555",
-        "openProviders": "55555",
-        "notConfigured": "55555",
-        "setUpInProviders": "55555"
+        "openProviders": "55555"
       },
       "issuer": {
         "title": "55555",
@@ -292,7 +287,11 @@
         "currentApp": "55555 {{app}} 55555",
         "switchWarning": "55555",
         "noneAvailable": "55555",
-        "retry": "55555"
+        "retry": "55555",
+        "pendingConsentEmpty": "55555",
+        "pendingConsentHint": "55555",
+        "ownAppPrompt": "55555",
+        "ownAppSetupLink": "55555"
       },
       "advanced": {
         "title": "55555",

--- a/server/public/locales/yy/msp/integrations.json
+++ b/server/public/locales/yy/msp/integrations.json
@@ -1659,7 +1659,8 @@
           "email": {
             "description": "55555",
             "label": "55555",
-            "reconnect": "55555"
+            "reconnect": "55555",
+            "perProviderIssuerNote": "Existing mailbox connections keep their current Microsoft app until they are reconnected. This choice applies to new mailbox connections."
           },
           "mspSso": {
             "description": "55555",

--- a/server/public/locales/yy/msp/integrations.json
+++ b/server/public/locales/yy/msp/integrations.json
@@ -1660,7 +1660,7 @@
             "description": "55555",
             "label": "55555",
             "reconnect": "55555",
-            "perProviderIssuerNote": "Existing mailbox connections keep their current Microsoft app until they are reconnected. This choice applies to new mailbox connections."
+            "perProviderIssuerNote": "55555"
           },
           "mspSso": {
             "description": "55555",

--- a/server/src/app/api/auth/microsoft/callback/route.ts
+++ b/server/src/app/api/auth/microsoft/callback/route.ts
@@ -18,6 +18,8 @@ import {
   type MicrosoftEmailOAuthStatePayload,
 } from '@alga-psa/integrations/utils/email/microsoftEmailOAuthState';
 import { consumeMicrosoftEmailOAuthNonce } from '@alga-psa/integrations/utils/email/microsoftEmailOAuthStateStore';
+import { verifyMicrosoftEmailOAuthStateRelationships } from '@alga-psa/integrations/lib/microsoftEmailStateGuard';
+import { persistMicrosoftEmailOAuthResult } from '../../../../../services/email/MicrosoftEmailOAuthResultPersistence';
 import { getWebhookBaseUrl } from '../../../../../utils/email/webhookHelpers';
 import { getCurrentUser } from '@alga-psa/user-composition/actions';
 import axios from 'axios';
@@ -286,6 +288,80 @@ export async function GET(request: NextRequest) {
       });
     }
 
+    // Enforce every relationship signed into the state. A valid signature only
+    // proves the token was issued by us; ownership, provider binding, and
+    // purpose semantics must each be verified before any credential write.
+    if (signedPayload) {
+      let stateProvider: {
+        id: string;
+        tenant: string;
+        provider_type: string;
+        status?: string | null;
+        refresh_token?: string | null;
+      } | null = null;
+
+      if (signedPayload.providerId) {
+        try {
+          stateProvider = await runWithTenant(stateContext.tenant!, async () => {
+            const { knex } = await createTenantKnex();
+            const db = tenantDb(knex, stateContext.tenant!);
+            const providerRow = await db.table('email_providers')
+              .where('id', signedPayload.providerId)
+              .select('id', 'tenant', 'provider_type', 'status')
+              .first();
+            if (!providerRow) return null;
+            const configRow = await db.table('microsoft_email_provider_config')
+              .where('email_provider_id', signedPayload.providerId)
+              .select('refresh_token')
+              .first();
+            return {
+              id: providerRow.id,
+              tenant: providerRow.tenant,
+              provider_type: providerRow.provider_type,
+              status: providerRow.status,
+              refresh_token: configRow?.refresh_token ?? null,
+            };
+          });
+        } catch (providerError: any) {
+          console.error('[MS OAuth] Failed to load state provider for verification', {
+            providerId: signedPayload.providerId,
+            error: providerError?.message || String(providerError),
+          });
+          return respondWithPostMessage({
+            type: 'oauth-callback',
+            provider: 'microsoft',
+            success: false,
+            error: MICROSOFT_EMAIL_ISSUER_ERRORS.INVALID_STATE,
+            errorDescription: 'This Microsoft authorization request is invalid or tampered with. Start again from the mailbox form.'
+          });
+        }
+      }
+
+      const guard = verifyMicrosoftEmailOAuthStateRelationships({
+        payload: signedPayload,
+        sessionUser,
+        provider: stateProvider,
+      });
+
+      if (!guard.ok) {
+        console.error('[MS OAuth] Signed state relationship verification failed', {
+          code: guard.code,
+          purpose: signedPayload.purpose,
+          providerId: signedPayload.providerId,
+        });
+        // The prior connection is left untouched — these are authorization /
+        // state-integrity failures, not provider failures, and writing an
+        // error status would take a working mailbox offline.
+        return respondWithPostMessage({
+          type: 'oauth-callback',
+          provider: 'microsoft',
+          success: false,
+          error: guard.code,
+          errorDescription: guard.message,
+        });
+      }
+    }
+
     // Get OAuth client credentials - prefer server-side NEXTAUTH_URL for hosted detection
     const secretProvider = await getSecretProviderInstance();
     const nextauthUrl = process.env.NEXTAUTH_URL || (await secretProvider.getAppSecret('NEXTAUTH_URL')) || '';
@@ -402,69 +478,40 @@ export async function GET(request: NextRequest) {
       // Calculate expiration time
       const expiresAt = new Date(Date.now() + expires_in * 1000);
 
-      // Persist tokens and initialize webhook if we have provider context
+      // Persist tokens and initialize the webhook if we have provider context.
+      // The write is atomic with webhook/subscription setup: any failure after
+      // the token write restores the prior connection (old refresh token, old
+      // client_id/profile pinning, old subscription state).
       if (stateContext.providerId && stateContext.tenant) {
         try {
-          await runWithTenant(stateContext.tenant, async () => {
-            const { knex } = await createTenantKnex();
-
-            // The effective issuer metadata to persist. For the explicit flow it
-            // comes from the revalidated selection; for legacy flows from the
-            // resolved binding/platform config.
-            const issuerMetadata = issuerResolution
-              ? {
-                  client_id: issuerResolution.clientId,
-                  client_secret: issuerResolution.clientSecret,
-                  tenant_id: issuerResolution.microsoftTenantId || 'common',
-                  microsoft_profile_id: issuerResolution.profileId || null,
-                  client_secret_ref: issuerResolution.clientSecretRef || null,
-                }
-              : null;
-
-            // Atomically write tokens + authoritative issuer metadata so a
-            // partial failure cannot clobber a previous working connection.
-            await knex.transaction(async (trx) => {
-              const db = tenantDb(trx, stateContext.tenant!);
-              const updatePayload: Record<string, unknown> = {
-                access_token: access_token,
-                refresh_token: refresh_token || null,
-                token_expires_at: expiresAt.toISOString(),
-                updated_at: new Date().toISOString(),
-              };
-              if (issuerMetadata) {
-                updatePayload.client_id = issuerMetadata.client_id;
-                updatePayload.client_secret = issuerMetadata.client_secret;
-                updatePayload.tenant_id = issuerMetadata.tenant_id;
-                updatePayload.microsoft_profile_id = issuerMetadata.microsoft_profile_id;
-                updatePayload.client_secret_ref = issuerMetadata.client_secret_ref;
+          // The effective issuer metadata to persist. For the explicit flow it
+          // comes from the revalidated state choice; for legacy flows from the
+          // resolved binding/platform config. It is never re-resolved from the
+          // tenant binding after this point.
+          const issuerMetadata = issuerResolution
+            ? {
+                client_id: issuerResolution.clientId,
+                client_secret: issuerResolution.clientSecret,
+                tenant_id: issuerResolution.microsoftTenantId || 'common',
+                microsoft_profile_id: issuerResolution.profileId || null,
+                client_secret_ref: issuerResolution.clientSecretRef || null,
               }
+            : null;
 
-              await db.table('microsoft_email_provider_config')
-                .where('email_provider_id', stateContext.providerId)
-                .update(updatePayload);
+          await runWithTenant(stateContext.tenant, async () => {
+            await persistMicrosoftEmailOAuthResult({
+              tenant: stateContext.tenant!,
+              providerId: stateContext.providerId!,
+              tokens: {
+                accessToken: access_token,
+                refreshToken: refresh_token || null,
+                expiresAt,
+              },
+              issuerMetadata,
+              setupWebhook: async (ctx) => {
+                const { provider, config: msConfig } = ctx;
+                if (!provider || !msConfig) return;
 
-              await db.table('email_providers')
-                .where('id', stateContext.providerId)
-                .update({
-                  status: 'connected',
-                  error_message: null,
-                  updated_at: trx.fn.now(),
-                });
-            });
-
-            // Build provider config and register webhook subscription
-            try {
-              const { knex: webhookKnex } = await createTenantKnex();
-              const db = tenantDb(webhookKnex, stateContext.tenant);
-              const provider = await db.table('email_providers')
-                .where('id', stateContext.providerId)
-                .first();
-
-              const msConfig = await db.table('microsoft_email_provider_config')
-                .where('email_provider_id', stateContext.providerId)
-                .first();
-
-              if (provider && msConfig) {
                 const baseUrl = getWebhookBaseUrl();
                 const webhookUrl = `${baseUrl}/api/email/webhooks/microsoft`;
 
@@ -493,12 +540,12 @@ export async function GET(request: NextRequest) {
                   created_at: provider.created_at,
                   updated_at: provider.updated_at,
                   provider_config: {
-                    client_id: msConfig.client_id || clientId,
-                    client_secret: msConfig.client_secret || clientSecret,
+                    client_id: msConfig.client_id || ctx.clientId,
+                    client_secret: msConfig.client_secret || ctx.clientSecret,
                     tenant_id: msConfig.tenant_id || null,
-                    access_token: access_token,
-                    refresh_token: refresh_token || null,
-                    token_expires_at: expiresAt.toISOString(),
+                    access_token: ctx.accessToken,
+                    refresh_token: ctx.refreshToken || null,
+                    token_expires_at: ctx.expiresAt.toISOString(),
                     microsoft_profile_id: msConfig.microsoft_profile_id || undefined,
                     client_secret_ref: msConfig.client_secret_ref || undefined,
                   },
@@ -552,11 +599,8 @@ export async function GET(request: NextRequest) {
                   });
                   throw subErr;
                 }
-              }
-            } catch (e) {
-              console.warn('⚠️ Microsoft webhook initialization failed after OAuth:', (e as any)?.message || e);
-              throw e;
-            }
+              },
+            });
           });
         } catch (persistErr: any) {
           console.warn('⚠️ Failed to persist Microsoft OAuth tokens or initialize webhook:', persistErr?.message || persistErr);

--- a/server/src/app/api/auth/microsoft/callback/route.ts
+++ b/server/src/app/api/auth/microsoft/callback/route.ts
@@ -451,10 +451,10 @@ export async function GET(request: NextRequest) {
       // client_id/profile pinning, old subscription state).
       if (stateContext.providerId && stateContext.tenant) {
         try {
-          // The effective issuer metadata to persist. For the explicit flow it
-          // comes from the revalidated state choice; for legacy flows from the
-          // resolved binding/platform config. It is never re-resolved from the
-          // tenant binding after this point.
+          // The effective issuer metadata to persist comes from the signed
+          // state's revalidated selection (issuerResolution is always non-null
+          // here — this callback only runs with a verified signed state). It is
+          // never re-resolved from the tenant binding after this point.
           const issuerMetadata = issuerResolution
             ? {
                 client_id: issuerResolution.clientId,

--- a/server/src/app/api/auth/microsoft/callback/route.ts
+++ b/server/src/app/api/auth/microsoft/callback/route.ts
@@ -1,5 +1,4 @@
 import { NextRequest, NextResponse } from 'next/server';
-import { headers } from 'next/headers.js';
 import { getSecretProviderInstance } from '@alga-psa/core/secrets';
 import { tenantDb } from '@alga-psa/db';
 import { createTenantKnex, runWithTenant } from '../../../../../lib/db';
@@ -8,6 +7,17 @@ import {
   MicrosoftSubscriptionError,
 } from '@alga-psa/shared/services/email/providers/MicrosoftGraphAdapter';
 import { resolveMicrosoftConsumerProfileConfig } from '@alga-psa/integrations/lib/microsoftConsumerProfileResolution';
+import {
+  MicrosoftEmailIssuerError,
+  MICROSOFT_EMAIL_ISSUER_ERRORS,
+  resolveMicrosoftEmailIssuerChoice,
+} from '@alga-psa/integrations/lib/microsoftEmailIssuerSelection';
+import {
+  getMicrosoftEmailOAuthSigningSecret,
+  validateMicrosoftEmailOAuthState,
+  type MicrosoftEmailOAuthStatePayload,
+} from '@alga-psa/integrations/utils/email/microsoftEmailOAuthState';
+import { consumeMicrosoftEmailOAuthNonce } from '@alga-psa/integrations/utils/email/microsoftEmailOAuthStateStore';
 import { getWebhookBaseUrl } from '../../../../../utils/email/webhookHelpers';
 import { getCurrentUser } from '@alga-psa/user-composition/actions';
 import axios from 'axios';
@@ -22,7 +32,22 @@ export const dynamic = 'force-dynamic';
 /**
  * Microsoft OAuth callback endpoint
  * Handles the authorization code exchange for access and refresh tokens
+ *
+ * The explicit issuer choice initiated by the form arrives here as a signed
+ * state token. The callback revalidates ownership, eligibility, and client ID
+ * server-side, consumes the single-use nonce, exchanges the code against the
+ * selected app, and atomically persists tokens plus authoritative issuer
+ * metadata. A failed callback preserves the previous working connection.
  */
+
+type CallbackStateContext = {
+  tenant?: string;
+  providerId?: string;
+  redirectUri?: string;
+  microsoftCredentialSource?: 'tenant' | 'platform' | null;
+  issuer?: { kind: 'managed' | 'profile'; profileId?: string; clientId: string };
+};
+
 export async function GET(request: NextRequest) {
   try {
     const searchParams = request.nextUrl.searchParams;
@@ -104,7 +129,7 @@ export async function GET(request: NextRequest) {
       }
     };
 
-    const persistProviderError = async (stateData: any, errorCode: string, description?: string | null) => {
+    const persistProviderError = async (stateData: CallbackStateContext, errorCode: string, description?: string | null) => {
       if (!stateData?.providerId || !stateData?.tenant) {
         return;
       }
@@ -169,32 +194,88 @@ export async function GET(request: NextRequest) {
       });
     }
 
-    // Parse state to get tenant and other info
-    let stateData;
-    try {
-      stateData = parseStateValue(state);
-      if (!stateData) {
-        throw new Error('Invalid state parameter');
+    /**
+     * The state may be either:
+     *  - the new signed token `base64url(payload).signature` (issued by the
+     *    explicit-selection flow), or
+     *  - a legacy base64-encoded JSON object (in-flight OAuth started before
+     *    this deploy).
+     */
+    const isSignedState = state.includes('.');
+    let stateContext: CallbackStateContext;
+    let signedPayload: MicrosoftEmailOAuthStatePayload | null = null;
+
+    if (isSignedState) {
+      const signingSecret = await getMicrosoftEmailOAuthSigningSecret();
+      const payload = validateMicrosoftEmailOAuthState({ token: state, secret: signingSecret });
+
+      if (!payload) {
+        // Distinguish an expired token from a tampered/invalid one.
+        const [payloadEncoded] = state.split('.');
+        let expired = false;
+        try {
+          const decoded = JSON.parse(Buffer.from(payloadEncoded, 'base64url').toString('utf8')) as {
+            expiresAt?: number;
+          };
+          expired = typeof decoded.expiresAt === 'number' && decoded.expiresAt <= Math.floor(Date.now() / 1000);
+        } catch {
+          // fall through to invalid_state
+        }
+        return respondWithPostMessage({
+          type: 'oauth-callback',
+          provider: 'microsoft',
+          success: false,
+          error: expired ? MICROSOFT_EMAIL_ISSUER_ERRORS.EXPIRED_STATE : MICROSOFT_EMAIL_ISSUER_ERRORS.INVALID_STATE,
+          errorDescription: expired
+            ? 'This Microsoft authorization request expired. Start again from the mailbox form.'
+            : 'This Microsoft authorization request is invalid or tampered with. Start again from the mailbox form.'
+        });
       }
-    } catch (e: any) {
-      return respondWithPostMessage({
-        type: 'oauth-callback',
-        provider: 'microsoft',
-        success: false,
-        error: 'invalid_state',
-        errorDescription: 'Invalid state parameter'
-      });
+
+      // Single-use nonce: the same signed state cannot complete twice.
+      const consumed = await consumeMicrosoftEmailOAuthNonce(payload.nonce);
+      if (!consumed) {
+        return respondWithPostMessage({
+          type: 'oauth-callback',
+          provider: 'microsoft',
+          success: false,
+          error: MICROSOFT_EMAIL_ISSUER_ERRORS.REPLAYED_STATE,
+          errorDescription: 'This Microsoft authorization request has already been used. Start again from the mailbox form.'
+        });
+      }
+
+      signedPayload = payload;
+      stateContext = {
+        tenant: payload.tenant,
+        providerId: payload.providerId,
+        redirectUri: payload.redirectUri,
+        issuer: {
+          kind: payload.issuerKind,
+          profileId: payload.issuerProfileId,
+          clientId: payload.clientId,
+        },
+      };
+    } else {
+      stateContext = parseStateValue(state);
+      if (!stateContext) {
+        return respondWithPostMessage({
+          type: 'oauth-callback',
+          provider: 'microsoft',
+          success: false,
+          error: 'invalid_state',
+          errorDescription: 'Invalid state parameter'
+        });
+      }
     }
 
-    // The state parameter is not integrity-protected, so its tenant cannot be
-    // trusted on its own. Require an authenticated session whose tenant matches
-    // the state tenant before writing any tokens — otherwise a forged callback
-    // could overwrite another tenant's email provider credentials.
+    // The state parameter is not trusted on its own. Require an authenticated
+    // session whose tenant matches the state tenant before writing any tokens —
+    // otherwise a forged callback could overwrite another tenant's credentials.
     const sessionUser = await getCurrentUser();
-    if (!sessionUser?.tenant || sessionUser.tenant !== stateData.tenant) {
+    if (!sessionUser?.tenant || sessionUser.tenant !== stateContext.tenant) {
       console.error('[MS OAuth] Session tenant does not match state tenant', {
         hasSession: Boolean(sessionUser?.tenant),
-        stateTenant: stateData.tenant,
+        stateTenant: stateContext.tenant,
       });
       return respondWithPostMessage({
         type: 'oauth-callback',
@@ -207,37 +288,66 @@ export async function GET(request: NextRequest) {
 
     // Get OAuth client credentials - prefer server-side NEXTAUTH_URL for hosted detection
     const secretProvider = await getSecretProviderInstance();
-    let clientId: string | null = null;
-    let clientSecret: string | null = null;
     const nextauthUrl = process.env.NEXTAUTH_URL || (await secretProvider.getAppSecret('NEXTAUTH_URL')) || '';
     const isHostedFlow = nextauthUrl.startsWith('https://algapsa.com');
-    const microsoftProfile = stateData.microsoftCredentialSource
-      ? await resolveMicrosoftConsumerProfileConfig(stateData.tenant, 'email', {
-          credentialPreference: stateData.microsoftCredentialSource,
-        })
-      : await resolveMicrosoftConsumerProfileConfig(stateData.tenant, 'email');
+    let clientId: string | null = null;
+    let clientSecret: string | null = null;
+    let issuerResolution: Awaited<ReturnType<typeof resolveMicrosoftEmailIssuerChoice>> | null = null;
 
-    let credentialSource = stateData.microsoftCredentialSource || 'automatic';
-    if (microsoftProfile.status === 'ready') {
-      clientId = microsoftProfile.clientId || null;
-      clientSecret = microsoftProfile.clientSecret || null;
+    if (signedPayload) {
+      // Revalidate the explicit selection server-side: ownership, active status,
+      // Email capability, readiness, and consent. Never trust the client's claim.
+      try {
+        issuerResolution = await resolveMicrosoftEmailIssuerChoice(stateContext.tenant!, {
+          kind: signedPayload.issuerKind,
+          profileId: signedPayload.issuerProfileId,
+          clientId: signedPayload.clientId,
+        });
+        clientId = issuerResolution.clientId;
+        clientSecret = issuerResolution.clientSecret;
+      } catch (issuerError: any) {
+        const code = issuerError instanceof MicrosoftEmailIssuerError
+          ? issuerError.code
+          : MICROSOFT_EMAIL_ISSUER_ERRORS.INVALID_STATE;
+        console.error('[MS OAuth] Issuer revalidation failed', { code });
+        try {
+          await persistProviderError(stateContext, code, issuerError?.message || 'Issuer revalidation failed');
+        } catch (persistError: any) {
+          console.warn('⚠️ Failed to persist Microsoft OAuth issuer error:', persistError?.message || persistError);
+        }
+        return respondWithPostMessage({
+          type: 'oauth-callback',
+          provider: 'microsoft',
+          success: false,
+          error: code,
+          errorDescription: issuerError?.message || 'The selected Microsoft application is no longer eligible for mailbox authorization.'
+        });
+      }
     } else {
-      credentialSource = 'unavailable';
+      const microsoftProfile = stateContext.microsoftCredentialSource
+        ? await resolveMicrosoftConsumerProfileConfig(stateContext.tenant, 'email', {
+            credentialPreference: stateContext.microsoftCredentialSource,
+          })
+        : await resolveMicrosoftConsumerProfileConfig(stateContext.tenant, 'email');
+
+      if (microsoftProfile.status === 'ready') {
+        clientId = microsoftProfile.clientId || null;
+        clientSecret = microsoftProfile.clientSecret || null;
+      }
     }
+
     // Normalize whitespace just in case the secret was copied with spaces/newlines
     clientId = clientId?.trim() || null;
     clientSecret = clientSecret?.trim() || null;
-    
+
     // Resolve redirect URI with priority:
     // CRITICAL: The redirect URI MUST match exactly what was used in the authorization URL
-    // Priority: State-provided redirectUri (what was actually used) > configured values > fallback
     const hostedRedirect = await secretProvider.getAppSecret('MICROSOFT_REDIRECT_URI');
-    const tenantRedirect = await secretProvider.getTenantSecret(stateData.tenant, 'microsoft_redirect_uri');
+    const tenantRedirect = await secretProvider.getTenantSecret(stateContext.tenant, 'microsoft_redirect_uri');
     const baseUrl = process.env.NEXT_PUBLIC_BASE_URL || (await secretProvider.getAppSecret('NEXT_PUBLIC_BASE_URL')) || 'http://localhost:3000';
-    
+
     // Use state-provided redirectUri first (this is what was used in authorization URL)
-    // Only fall back to configured values if state doesn't have it
-    const redirectUri = stateData.redirectUri || (
+    const redirectUri = stateContext.redirectUri || (
       isHostedFlow
         ? hostedRedirect
         : (process.env.MICROSOFT_REDIRECT_URI || tenantRedirect)
@@ -246,17 +356,17 @@ export async function GET(request: NextRequest) {
     // Log non-sensitive debug information to help diagnose invalid_client
     const maskedClientId = clientId ? `${clientId.substring(0, 4)}...${clientId.substring(clientId.length - 4)}` : 'null';
     console.log('[MS OAuth] Using credentials', {
-      source: credentialSource,
+      source: signedPayload ? 'explicit-selection' : (stateContext.microsoftCredentialSource || 'automatic'),
       clientId: maskedClientId,
       redirectUri,
-      stateRedirectUri: stateData.redirectUri,
-      redirectUriSource: stateData.redirectUri ? 'state' : (isHostedFlow ? 'hosted_config' : 'env_or_tenant')
+      stateRedirectUri: stateContext.redirectUri,
+      redirectUriSource: stateContext.redirectUri ? 'state' : 'env_or_tenant'
     });
 
     if (!clientId || !clientSecret) {
       console.error('Microsoft OAuth credentials not configured');
       try {
-        await persistProviderError(stateData, 'configuration_error', 'OAuth credentials not configured');
+        await persistProviderError(stateContext, 'configuration_error', 'OAuth credentials not configured');
       } catch (persistError: any) {
         console.warn('⚠️ Failed to persist Microsoft OAuth configuration error:', persistError?.message || persistError);
       }
@@ -293,43 +403,65 @@ export async function GET(request: NextRequest) {
       const expiresAt = new Date(Date.now() + expires_in * 1000);
 
       // Persist tokens and initialize webhook if we have provider context
-      if (stateData.providerId && stateData.tenant) {
+      if (stateContext.providerId && stateContext.tenant) {
         try {
-          await runWithTenant(stateData.tenant, async () => {
+          await runWithTenant(stateContext.tenant, async () => {
             const { knex } = await createTenantKnex();
-            const db = tenantDb(knex, stateData.tenant);
-            // Save tokens
-            await db.table('microsoft_email_provider_config')
-              .where('email_provider_id', stateData.providerId)
-              .update({
+
+            // The effective issuer metadata to persist. For the explicit flow it
+            // comes from the revalidated selection; for legacy flows from the
+            // resolved binding/platform config.
+            const issuerMetadata = issuerResolution
+              ? {
+                  client_id: issuerResolution.clientId,
+                  client_secret: issuerResolution.clientSecret,
+                  tenant_id: issuerResolution.microsoftTenantId || 'common',
+                  microsoft_profile_id: issuerResolution.profileId || null,
+                  client_secret_ref: issuerResolution.clientSecretRef || null,
+                }
+              : null;
+
+            // Atomically write tokens + authoritative issuer metadata so a
+            // partial failure cannot clobber a previous working connection.
+            await knex.transaction(async (trx) => {
+              const db = tenantDb(trx, stateContext.tenant!);
+              const updatePayload: Record<string, unknown> = {
                 access_token: access_token,
                 refresh_token: refresh_token || null,
                 token_expires_at: expiresAt.toISOString(),
-                client_id: clientId,
-                client_secret: clientSecret,
-                tenant_id: microsoftProfile.status === 'ready' ? microsoftProfile.microsoftTenantId || 'common' : 'common',
-                microsoft_profile_id: microsoftProfile.status === 'ready' ? microsoftProfile.profileId || null : null,
-                client_secret_ref: microsoftProfile.status === 'ready' ? microsoftProfile.clientSecretRef || null : null,
                 updated_at: new Date().toISOString(),
-              });
+              };
+              if (issuerMetadata) {
+                updatePayload.client_id = issuerMetadata.client_id;
+                updatePayload.client_secret = issuerMetadata.client_secret;
+                updatePayload.tenant_id = issuerMetadata.tenant_id;
+                updatePayload.microsoft_profile_id = issuerMetadata.microsoft_profile_id;
+                updatePayload.client_secret_ref = issuerMetadata.client_secret_ref;
+              }
 
-            // Mark provider connected
-            await db.table('email_providers')
-              .where('id', stateData.providerId)
-              .update({
-                status: 'connected',
-                error_message: null,
-                updated_at: knex.fn.now(),
-              });
+              await db.table('microsoft_email_provider_config')
+                .where('email_provider_id', stateContext.providerId)
+                .update(updatePayload);
+
+              await db.table('email_providers')
+                .where('id', stateContext.providerId)
+                .update({
+                  status: 'connected',
+                  error_message: null,
+                  updated_at: trx.fn.now(),
+                });
+            });
 
             // Build provider config and register webhook subscription
             try {
+              const { knex: webhookKnex } = await createTenantKnex();
+              const db = tenantDb(webhookKnex, stateContext.tenant);
               const provider = await db.table('email_providers')
-                .where('id', stateData.providerId)
+                .where('id', stateContext.providerId)
                 .first();
 
               const msConfig = await db.table('microsoft_email_provider_config')
-                .where('email_provider_id', stateData.providerId)
+                .where('email_provider_id', stateContext.providerId)
                 .first();
 
               if (provider && msConfig) {
@@ -353,7 +485,7 @@ export async function GET(request: NextRequest) {
                   // Persisted and looked up via microsoft vendor config
                   webhook_subscription_id: msConfig.webhook_subscription_id || null,
                   // Use tenant as verification token when none exists yet
-                  webhook_verification_token: msConfig.webhook_verification_token || stateData.tenant,
+                  webhook_verification_token: msConfig.webhook_verification_token || stateContext.tenant,
                   webhook_expires_at: msConfig.webhook_expires_at || null,
                   connection_status: provider.status || 'connected',
                   last_connection_test: provider.last_sync_at || null,
@@ -361,14 +493,14 @@ export async function GET(request: NextRequest) {
                   created_at: provider.created_at,
                   updated_at: provider.updated_at,
                   provider_config: {
-                    client_id: clientId,
-                    client_secret: clientSecret,
-                    tenant_id: microsoftProfile.status === 'ready' ? microsoftProfile.microsoftTenantId : null,
+                    client_id: msConfig.client_id || clientId,
+                    client_secret: msConfig.client_secret || clientSecret,
+                    tenant_id: msConfig.tenant_id || null,
                     access_token: access_token,
                     refresh_token: refresh_token || null,
                     token_expires_at: expiresAt.toISOString(),
-                    microsoft_profile_id: microsoftProfile.status === 'ready' ? microsoftProfile.profileId : undefined,
-                    client_secret_ref: microsoftProfile.status === 'ready' ? microsoftProfile.clientSecretRef : undefined,
+                    microsoft_profile_id: msConfig.microsoft_profile_id || undefined,
+                    client_secret_ref: msConfig.client_secret_ref || undefined,
                   },
                 };
 
@@ -429,7 +561,7 @@ export async function GET(request: NextRequest) {
         } catch (persistErr: any) {
           console.warn('⚠️ Failed to persist Microsoft OAuth tokens or initialize webhook:', persistErr?.message || persistErr);
           try {
-            await persistProviderError(stateData, 'token_persistence_failed', persistErr?.message || 'Failed to persist Microsoft OAuth tokens or initialize webhook');
+            await persistProviderError(stateContext, 'token_persistence_failed', persistErr?.message || 'Failed to persist Microsoft OAuth tokens or initialize webhook');
           } catch (providerErrorPersistErr: any) {
             console.warn('⚠️ Failed to persist Microsoft OAuth token persistence error:', providerErrorPersistErr?.message || providerErrorPersistErr);
           }
@@ -437,7 +569,7 @@ export async function GET(request: NextRequest) {
             type: 'oauth-callback',
             provider: 'microsoft',
             success: false,
-            error: 'token_persistence_failed',
+            error: MICROSOFT_EMAIL_ISSUER_ERRORS.CALLBACK_PERSISTENCE_FAILED,
             errorDescription: persistErr?.message || 'Failed to persist Microsoft OAuth tokens or initialize webhook'
           });
         }
@@ -460,7 +592,7 @@ export async function GET(request: NextRequest) {
       const errorData = tokenError.response?.data || {};
       const errorMessage = errorData.error_description || errorData.error || tokenError.message;
       const errorCode = errorData.error || 'token_exchange_failed';
-      
+
       console.error('[MS OAuth] Failed to exchange authorization code:', {
         error: errorCode,
         errorDescription: errorMessage,
@@ -474,11 +606,11 @@ export async function GET(request: NextRequest) {
       });
 
       try {
-        await persistProviderError(stateData, errorCode, errorMessage);
+        await persistProviderError(stateContext, errorCode, errorMessage);
       } catch (persistError: any) {
         console.warn('⚠️ Failed to persist Microsoft OAuth token exchange error:', persistError?.message || persistError);
       }
-      
+
       return respondWithPostMessage({
         type: 'oauth-callback',
         provider: 'microsoft',

--- a/server/src/app/api/auth/microsoft/callback/route.ts
+++ b/server/src/app/api/auth/microsoft/callback/route.ts
@@ -6,7 +6,6 @@ import {
   MicrosoftGraphAdapter,
   MicrosoftSubscriptionError,
 } from '@alga-psa/shared/services/email/providers/MicrosoftGraphAdapter';
-import { resolveMicrosoftConsumerProfileConfig } from '@alga-psa/integrations/lib/microsoftConsumerProfileResolution';
 import {
   MicrosoftEmailIssuerError,
   MICROSOFT_EMAIL_ISSUER_ERRORS,
@@ -46,9 +45,18 @@ type CallbackStateContext = {
   tenant?: string;
   providerId?: string;
   redirectUri?: string;
-  microsoftCredentialSource?: 'tenant' | 'platform' | null;
   issuer?: { kind: 'managed' | 'profile'; profileId?: string; clientId: string };
 };
+
+/**
+ * Verify the OAuth state is one of our signed tokens. Every callback must pass
+ * signature verification; legacy unsigned base64-encoded state is no longer
+ * accepted — there is no backward-compat path that skips it.
+ */
+async function verifySignedState(state: string): Promise<MicrosoftEmailOAuthStatePayload | null> {
+  const signingSecret = await getMicrosoftEmailOAuthSigningSecret();
+  return validateMicrosoftEmailOAuthState({ token: state, secret: signingSecret });
+}
 
 export async function GET(request: NextRequest) {
   try {
@@ -117,20 +125,6 @@ export async function GET(request: NextRequest) {
       return new NextResponse(html, { status: 200, headers: { 'Content-Type': 'text/html' } });
     };
 
-    const parseStateValue = (rawState: string) => {
-      try {
-        const decodedState = Buffer.from(rawState, 'base64').toString();
-        return JSON.parse(decodedState);
-      } catch (e: any) {
-        console.error('[MS OAuth] Failed to parse state:', {
-          error: e.message,
-          stateLength: rawState?.length,
-          statePreview: rawState ? `${rawState.substring(0, 20)}...` : 'null'
-        });
-        return null;
-      }
-    };
-
     const persistProviderError = async (stateData: CallbackStateContext, errorCode: string, description?: string | null) => {
       if (!stateData?.providerId || !stateData?.tenant) {
         return;
@@ -159,12 +153,19 @@ export async function GET(request: NextRequest) {
       });
     };
 
-    // Handle OAuth errors
+    // Handle OAuth errors. Microsoft rejected the authorization before any
+    // token exchange. We may attribute the failure to a provider only when the
+    // echoed state is one of our signed tokens; an unverifiable state is
+    // ignored and never causes a provider status write.
     if (error) {
-      const errorStateData = state ? parseStateValue(state) : null;
-      if (errorStateData?.providerId) {
+      const errorPayload = state ? await verifySignedState(state) : null;
+      if (errorPayload?.providerId) {
         try {
-          await persistProviderError(errorStateData, error, errorDescription || '');
+          await persistProviderError(
+            { tenant: errorPayload.tenant, providerId: errorPayload.providerId },
+            error,
+            errorDescription || ''
+          );
         } catch (persistError: any) {
           console.warn('⚠️ Failed to persist Microsoft OAuth error:', persistError?.message || persistError);
         }
@@ -197,78 +198,57 @@ export async function GET(request: NextRequest) {
     }
 
     /**
-     * The state may be either:
-     *  - the new signed token `base64url(payload).signature` (issued by the
-     *    explicit-selection flow), or
-     *  - a legacy base64-encoded JSON object (in-flight OAuth started before
-     *    this deploy).
+     * The state must be the signed token issued by the explicit-selection flow
+     * (`base64url(payload).signature`). Legacy unsigned base64-encoded state is
+     * no longer accepted: every callback must pass signature verification and
+     * relationship checks or fail with a stable error code.
      */
-    const isSignedState = state.includes('.');
-    let stateContext: CallbackStateContext;
-    let signedPayload: MicrosoftEmailOAuthStatePayload | null = null;
-
-    if (isSignedState) {
-      const signingSecret = await getMicrosoftEmailOAuthSigningSecret();
-      const payload = validateMicrosoftEmailOAuthState({ token: state, secret: signingSecret });
-
-      if (!payload) {
-        // Distinguish an expired token from a tampered/invalid one.
-        const [payloadEncoded] = state.split('.');
-        let expired = false;
-        try {
-          const decoded = JSON.parse(Buffer.from(payloadEncoded, 'base64url').toString('utf8')) as {
-            expiresAt?: number;
-          };
-          expired = typeof decoded.expiresAt === 'number' && decoded.expiresAt <= Math.floor(Date.now() / 1000);
-        } catch {
-          // fall through to invalid_state
-        }
-        return respondWithPostMessage({
-          type: 'oauth-callback',
-          provider: 'microsoft',
-          success: false,
-          error: expired ? MICROSOFT_EMAIL_ISSUER_ERRORS.EXPIRED_STATE : MICROSOFT_EMAIL_ISSUER_ERRORS.INVALID_STATE,
-          errorDescription: expired
-            ? 'This Microsoft authorization request expired. Start again from the mailbox form.'
-            : 'This Microsoft authorization request is invalid or tampered with. Start again from the mailbox form.'
-        });
+    const signedPayload = await verifySignedState(state);
+    if (!signedPayload) {
+      // Distinguish an expired token from a tampered/invalid one.
+      const [payloadEncoded] = state.split('.');
+      let expired = false;
+      try {
+        const decoded = JSON.parse(Buffer.from(payloadEncoded, 'base64url').toString('utf8')) as {
+          expiresAt?: number;
+        };
+        expired = typeof decoded.expiresAt === 'number' && decoded.expiresAt <= Math.floor(Date.now() / 1000);
+      } catch {
+        // fall through to invalid_state
       }
-
-      // Single-use nonce: the same signed state cannot complete twice.
-      const consumed = await consumeMicrosoftEmailOAuthNonce(payload.nonce);
-      if (!consumed) {
-        return respondWithPostMessage({
-          type: 'oauth-callback',
-          provider: 'microsoft',
-          success: false,
-          error: MICROSOFT_EMAIL_ISSUER_ERRORS.REPLAYED_STATE,
-          errorDescription: 'This Microsoft authorization request has already been used. Start again from the mailbox form.'
-        });
-      }
-
-      signedPayload = payload;
-      stateContext = {
-        tenant: payload.tenant,
-        providerId: payload.providerId,
-        redirectUri: payload.redirectUri,
-        issuer: {
-          kind: payload.issuerKind,
-          profileId: payload.issuerProfileId,
-          clientId: payload.clientId,
-        },
-      };
-    } else {
-      stateContext = parseStateValue(state);
-      if (!stateContext) {
-        return respondWithPostMessage({
-          type: 'oauth-callback',
-          provider: 'microsoft',
-          success: false,
-          error: 'invalid_state',
-          errorDescription: 'Invalid state parameter'
-        });
-      }
+      return respondWithPostMessage({
+        type: 'oauth-callback',
+        provider: 'microsoft',
+        success: false,
+        error: expired ? MICROSOFT_EMAIL_ISSUER_ERRORS.EXPIRED_STATE : MICROSOFT_EMAIL_ISSUER_ERRORS.INVALID_STATE,
+        errorDescription: expired
+          ? 'This Microsoft authorization request expired. Start again from the mailbox form.'
+          : 'This Microsoft authorization request is invalid or tampered with. Start again from the mailbox form.'
+      });
     }
+
+    // Single-use nonce: the same signed state cannot complete twice.
+    const consumed = await consumeMicrosoftEmailOAuthNonce(signedPayload.nonce);
+    if (!consumed) {
+      return respondWithPostMessage({
+        type: 'oauth-callback',
+        provider: 'microsoft',
+        success: false,
+        error: MICROSOFT_EMAIL_ISSUER_ERRORS.REPLAYED_STATE,
+        errorDescription: 'This Microsoft authorization request has already been used. Start again from the mailbox form.'
+      });
+    }
+
+    const stateContext: CallbackStateContext = {
+      tenant: signedPayload.tenant,
+      providerId: signedPayload.providerId,
+      redirectUri: signedPayload.redirectUri,
+      issuer: {
+        kind: signedPayload.issuerKind,
+        profileId: signedPayload.issuerProfileId,
+        clientId: signedPayload.clientId,
+      },
+    };
 
     // The state parameter is not trusted on its own. Require an authenticated
     // session whose tenant matches the state tenant before writing any tokens —
@@ -291,7 +271,7 @@ export async function GET(request: NextRequest) {
     // Enforce every relationship signed into the state. A valid signature only
     // proves the token was issued by us; ownership, provider binding, and
     // purpose semantics must each be verified before any credential write.
-    if (signedPayload) {
+    {
       let stateProvider: {
         id: string;
         tenant: string;
@@ -368,48 +348,35 @@ export async function GET(request: NextRequest) {
     const isHostedFlow = nextauthUrl.startsWith('https://algapsa.com');
     let clientId: string | null = null;
     let clientSecret: string | null = null;
+
+    // Revalidate the explicit selection server-side: ownership, active status,
+    // Email capability, readiness, and consent. Never trust the client's claim.
     let issuerResolution: Awaited<ReturnType<typeof resolveMicrosoftEmailIssuerChoice>> | null = null;
-
-    if (signedPayload) {
-      // Revalidate the explicit selection server-side: ownership, active status,
-      // Email capability, readiness, and consent. Never trust the client's claim.
+    try {
+      issuerResolution = await resolveMicrosoftEmailIssuerChoice(stateContext.tenant!, {
+        kind: signedPayload.issuerKind,
+        profileId: signedPayload.issuerProfileId,
+        clientId: signedPayload.clientId,
+      });
+      clientId = issuerResolution.clientId;
+      clientSecret = issuerResolution.clientSecret;
+    } catch (issuerError: any) {
+      const code = issuerError instanceof MicrosoftEmailIssuerError
+        ? issuerError.code
+        : MICROSOFT_EMAIL_ISSUER_ERRORS.INVALID_STATE;
+      console.error('[MS OAuth] Issuer revalidation failed', { code });
       try {
-        issuerResolution = await resolveMicrosoftEmailIssuerChoice(stateContext.tenant!, {
-          kind: signedPayload.issuerKind,
-          profileId: signedPayload.issuerProfileId,
-          clientId: signedPayload.clientId,
-        });
-        clientId = issuerResolution.clientId;
-        clientSecret = issuerResolution.clientSecret;
-      } catch (issuerError: any) {
-        const code = issuerError instanceof MicrosoftEmailIssuerError
-          ? issuerError.code
-          : MICROSOFT_EMAIL_ISSUER_ERRORS.INVALID_STATE;
-        console.error('[MS OAuth] Issuer revalidation failed', { code });
-        try {
-          await persistProviderError(stateContext, code, issuerError?.message || 'Issuer revalidation failed');
-        } catch (persistError: any) {
-          console.warn('⚠️ Failed to persist Microsoft OAuth issuer error:', persistError?.message || persistError);
-        }
-        return respondWithPostMessage({
-          type: 'oauth-callback',
-          provider: 'microsoft',
-          success: false,
-          error: code,
-          errorDescription: issuerError?.message || 'The selected Microsoft application is no longer eligible for mailbox authorization.'
-        });
+        await persistProviderError(stateContext, code, issuerError?.message || 'Issuer revalidation failed');
+      } catch (persistError: any) {
+        console.warn('⚠️ Failed to persist Microsoft OAuth issuer error:', persistError?.message || persistError);
       }
-    } else {
-      const microsoftProfile = stateContext.microsoftCredentialSource
-        ? await resolveMicrosoftConsumerProfileConfig(stateContext.tenant, 'email', {
-            credentialPreference: stateContext.microsoftCredentialSource,
-          })
-        : await resolveMicrosoftConsumerProfileConfig(stateContext.tenant, 'email');
-
-      if (microsoftProfile.status === 'ready') {
-        clientId = microsoftProfile.clientId || null;
-        clientSecret = microsoftProfile.clientSecret || null;
-      }
+      return respondWithPostMessage({
+        type: 'oauth-callback',
+        provider: 'microsoft',
+        success: false,
+        error: code,
+        errorDescription: issuerError?.message || 'The selected Microsoft application is no longer eligible for mailbox authorization.'
+      });
     }
 
     // Normalize whitespace just in case the secret was copied with spaces/newlines
@@ -432,7 +399,7 @@ export async function GET(request: NextRequest) {
     // Log non-sensitive debug information to help diagnose invalid_client
     const maskedClientId = clientId ? `${clientId.substring(0, 4)}...${clientId.substring(clientId.length - 4)}` : 'null';
     console.log('[MS OAuth] Using credentials', {
-      source: signedPayload ? 'explicit-selection' : (stateContext.microsoftCredentialSource || 'automatic'),
+      source: 'explicit-selection',
       clientId: maskedClientId,
       redirectUri,
       stateRedirectUri: stateContext.redirectUri,
@@ -552,6 +519,15 @@ export async function GET(request: NextRequest) {
                 };
 
                 const adapter = new MicrosoftGraphAdapter(providerConfig);
+                // Record every Graph subscription the setup deletes or creates
+                // so a later failure can compensate (delete new subs, avoid
+                // resurrecting deleted ones).
+                adapter.attachWebhookLifecycle({
+                  onSubscriptionDeleted: (subscriptionId) =>
+                    ctx.webhookCompensation.onSubscriptionDeleted(subscriptionId),
+                  onSubscriptionCreated: (subscriptionId) =>
+                    ctx.webhookCompensation.onSubscriptionCreated(subscriptionId),
+                });
                 try {
                   // Load credentials and authenticated user email before subscription
                   // This ensures mailbox path auto-detection works correctly
@@ -598,6 +574,62 @@ export async function GET(request: NextRequest) {
                     requestId: subErr?.requestId,
                   });
                   throw subErr;
+                }
+              },
+              compensateWebhook: async (compLedger) => {
+                // Delete every Graph subscription the failed setup created, so a
+                // retry of the callback cannot duplicate subscriptions. The
+                // database restore (run by persistMicrosoftEmailOAuthResult after
+                // this hook) reverts the config/provider rows.
+                if (!compLedger.createdSubscriptionIds.length) return;
+                try {
+                  const { knex: compKnex } = await createTenantKnex();
+                  const compDb = tenantDb(compKnex, stateContext.tenant!);
+                  const [compConfig, compProvider] = await Promise.all([
+                    compDb.table('microsoft_email_provider_config')
+                      .where('email_provider_id', stateContext.providerId)
+                      .first(),
+                    compDb.table('email_providers')
+                      .where('id', stateContext.providerId)
+                      .first(),
+                  ]);
+                  if (!compConfig || !compProvider) return;
+
+                  const compAdapter = new MicrosoftGraphAdapter({
+                    id: compProvider.id,
+                    tenant: compProvider.tenant,
+                    name: compProvider.provider_name || compProvider.mailbox,
+                    provider_type: 'microsoft',
+                    mailbox: compProvider.mailbox,
+                    folder_to_monitor: 'Inbox',
+                    active: compProvider.is_active,
+                    provider_config: {
+                      client_id: compConfig.client_id,
+                      client_secret: compConfig.client_secret,
+                      tenant_id: compConfig.tenant_id || null,
+                      access_token,
+                      refresh_token: refresh_token || null,
+                      token_expires_at: expiresAt.toISOString(),
+                      microsoft_profile_id: compConfig.microsoft_profile_id || undefined,
+                      client_secret_ref: compConfig.client_secret_ref || undefined,
+                    },
+                  } as any);
+
+                  for (const subscriptionId of compLedger.createdSubscriptionIds) {
+                    try {
+                      await compAdapter.deleteSubscription(subscriptionId);
+                      console.info('[MS OAuth Callback] Deleted subscription created by failed webhook setup', { subscriptionId });
+                    } catch (delErr: any) {
+                      console.warn('[MS OAuth Callback] Failed to delete subscription created by failed webhook setup', {
+                        subscriptionId,
+                        error: delErr?.message || String(delErr),
+                      });
+                    }
+                  }
+                } catch (compErr: any) {
+                  console.warn('[MS OAuth Callback] Graph compensation failed; leaving cleanup to the maintenance probe', {
+                    error: compErr?.message || String(compErr),
+                  });
                 }
               },
             });

--- a/server/src/app/api/auth/microsoft/callback/route.ts
+++ b/server/src/app/api/auth/microsoft/callback/route.ts
@@ -58,6 +58,36 @@ async function verifySignedState(state: string): Promise<MicrosoftEmailOAuthStat
   return validateMicrosoftEmailOAuthState({ token: state, secret: signingSecret });
 }
 
+/**
+ * Load the provider row (plus its persisted refresh-token flag) that the state
+ * names, exactly as the relationship guard needs it. Used by both the success
+ * path and the guarded error path; returns `null` when the state names no
+ * provider or the row is absent.
+ */
+async function loadStateProviderRow(stateContext: CallbackStateContext) {
+  if (!stateContext.providerId || !stateContext.tenant) return null;
+  const db = tenantDb(
+    (await createTenantKnex()).knex,
+    stateContext.tenant
+  );
+  const providerRow = await db.table('email_providers')
+    .where('id', stateContext.providerId)
+    .select('id', 'tenant', 'provider_type', 'status')
+    .first();
+  if (!providerRow) return null;
+  const configRow = await db.table('microsoft_email_provider_config')
+    .where('email_provider_id', stateContext.providerId)
+    .select('refresh_token')
+    .first();
+  return {
+    id: providerRow.id,
+    tenant: providerRow.tenant,
+    provider_type: providerRow.provider_type,
+    status: providerRow.status,
+    refresh_token: configRow?.refresh_token ?? null,
+  };
+}
+
 export async function GET(request: NextRequest) {
   try {
     const searchParams = request.nextUrl.searchParams;
@@ -155,19 +185,109 @@ export async function GET(request: NextRequest) {
 
     // Handle OAuth errors. Microsoft rejected the authorization before any
     // token exchange. We may attribute the failure to a provider only when the
-    // echoed state is one of our signed tokens; an unverifiable state is
-    // ignored and never causes a provider status write.
+    // echoed state is one of our signed tokens AND every relationship the state
+    // asserts still holds — the same guard chain as the success path: single-use
+    // nonce, session ownership, purpose, provider existence/tenant/type, and
+    // issuer readiness. A forged, replayed, or mismatched error callback must
+    // change nothing.
     if (error) {
       const errorPayload = state ? await verifySignedState(state) : null;
-      if (errorPayload?.providerId) {
-        try {
-          await persistProviderError(
-            { tenant: errorPayload.tenant, providerId: errorPayload.providerId },
-            error,
-            errorDescription || ''
-          );
-        } catch (persistError: any) {
-          console.warn('⚠️ Failed to persist Microsoft OAuth error:', persistError?.message || persistError);
+
+      // An error callback that echoes unsigned or tampered state is rejected
+      // outright — the same no-dual-acceptance rule as the success path. It
+      // must never be attributed to a provider.
+      if (state && !errorPayload) {
+        console.error('[MS OAuth] OAuth error callback rejected: unsigned or tampered state', {
+          error,
+          hasState: Boolean(state),
+        });
+        return respondWithPostMessage({
+          type: 'oauth-callback',
+          provider: 'microsoft',
+          success: false,
+          error: MICROSOFT_EMAIL_ISSUER_ERRORS.INVALID_STATE,
+          errorDescription: 'This Microsoft authorization request is invalid or tampered with. Start again from the mailbox form.'
+        });
+      }
+
+      if (errorPayload) {
+        // Single-use: consume the nonce so neither this nor a replayed error
+        // callback can ever be attributed again (and the state can never be
+        // reused for a later success).
+        const consumed = await consumeMicrosoftEmailOAuthNonce(errorPayload.nonce);
+
+        if (consumed) {
+          const errorContext: CallbackStateContext = {
+            tenant: errorPayload.tenant,
+            providerId: errorPayload.providerId,
+          };
+
+          let stateProvider: Awaited<ReturnType<typeof loadStateProviderRow>> = null;
+          if (errorPayload.providerId) {
+            try {
+              stateProvider = await runWithTenant(errorPayload.tenant, () =>
+                loadStateProviderRow(errorContext)
+              );
+            } catch (providerError: any) {
+              console.error('[MS OAuth] Failed to load state provider for error-callback verification', {
+                providerId: errorPayload.providerId,
+                error: providerError?.message || String(providerError),
+              });
+              stateProvider = null;
+            }
+          }
+
+          const guard = verifyMicrosoftEmailOAuthStateRelationships({
+            payload: errorPayload,
+            sessionUser: await getCurrentUser(),
+            provider: stateProvider,
+          });
+
+          // Issuer readiness is part of the guard: an app that can no longer
+          // authorize mailboxes makes this callback "mismatched", so it must
+          // not change the provider.
+          let issuerReady = false;
+          if (guard.ok && errorContext.tenant) {
+            try {
+              await resolveMicrosoftEmailIssuerChoice(errorContext.tenant, {
+                kind: errorPayload.issuerKind,
+                profileId: errorPayload.issuerProfileId,
+                clientId: errorPayload.clientId,
+              });
+              issuerReady = true;
+            } catch (issuerError: any) {
+              console.error('[MS OAuth] OAuth error callback issuer revalidation failed', {
+                code: issuerError instanceof MicrosoftEmailIssuerError ? issuerError.code : 'unknown',
+              });
+              issuerReady = false;
+            }
+          }
+
+          if (guard.ok && issuerReady && errorPayload.providerId) {
+            try {
+              await persistProviderError(
+                { tenant: errorPayload.tenant, providerId: errorPayload.providerId },
+                error,
+                errorDescription || ''
+              );
+            } catch (persistError: any) {
+              console.warn('⚠️ Failed to persist Microsoft OAuth error:', persistError?.message || persistError);
+            }
+          } else {
+            console.error('[MS OAuth] OAuth error callback rejected before any provider mutation', {
+              guardCode: guard.ok ? undefined : guard.code,
+              issuerReady,
+              purpose: errorPayload.purpose,
+              providerId: errorPayload.providerId,
+            });
+          }
+        } else {
+          // A replayed error callback: the nonce was already consumed by an
+          // earlier callback. Never attribute it.
+          console.error('[MS OAuth] Replayed OAuth error callback ignored', {
+            nonce: errorPayload.nonce,
+            providerId: errorPayload.providerId,
+          });
         }
       }
 
@@ -272,36 +392,13 @@ export async function GET(request: NextRequest) {
     // proves the token was issued by us; ownership, provider binding, and
     // purpose semantics must each be verified before any credential write.
     {
-      let stateProvider: {
-        id: string;
-        tenant: string;
-        provider_type: string;
-        status?: string | null;
-        refresh_token?: string | null;
-      } | null = null;
+      let stateProvider: Awaited<ReturnType<typeof loadStateProviderRow>> = null;
 
       if (signedPayload.providerId) {
         try {
-          stateProvider = await runWithTenant(stateContext.tenant!, async () => {
-            const { knex } = await createTenantKnex();
-            const db = tenantDb(knex, stateContext.tenant!);
-            const providerRow = await db.table('email_providers')
-              .where('id', signedPayload.providerId)
-              .select('id', 'tenant', 'provider_type', 'status')
-              .first();
-            if (!providerRow) return null;
-            const configRow = await db.table('microsoft_email_provider_config')
-              .where('email_provider_id', signedPayload.providerId)
-              .select('refresh_token')
-              .first();
-            return {
-              id: providerRow.id,
-              tenant: providerRow.tenant,
-              provider_type: providerRow.provider_type,
-              status: providerRow.status,
-              refresh_token: configRow?.refresh_token ?? null,
-            };
-          });
+          stateProvider = await runWithTenant(stateContext.tenant!, () =>
+            loadStateProviderRow(stateContext)
+          );
         } catch (providerError: any) {
           console.error('[MS OAuth] Failed to load state provider for verification', {
             providerId: signedPayload.providerId,
@@ -635,12 +732,12 @@ export async function GET(request: NextRequest) {
             });
           });
         } catch (persistErr: any) {
-          console.warn('⚠️ Failed to persist Microsoft OAuth tokens or initialize webhook:', persistErr?.message || persistErr);
-          try {
-            await persistProviderError(stateContext, 'token_persistence_failed', persistErr?.message || 'Failed to persist Microsoft OAuth tokens or initialize webhook');
-          } catch (providerErrorPersistErr: any) {
-            console.warn('⚠️ Failed to persist Microsoft OAuth token persistence error:', providerErrorPersistErr?.message || providerErrorPersistErr);
-          }
+          // `persistMicrosoftEmailOAuthResult` already compensated the Graph
+          // side and restored the provider to its prior connected/polling
+          // snapshot before throwing. Do NOT mark the provider `error` here —
+          // that would clobber the restored state and take a working mailbox
+          // offline. The user still sees the failed callback.
+          console.warn('⚠️ Failed to persist Microsoft OAuth tokens or initialize webhook (provider restored to its prior state):', persistErr?.message || persistErr);
           return respondWithPostMessage({
             type: 'oauth-callback',
             provider: 'microsoft',

--- a/server/src/app/api/email/oauth/initiate/route.ts
+++ b/server/src/app/api/email/oauth/initiate/route.ts
@@ -1,11 +1,10 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { getCurrentUser } from '@alga-psa/user-composition/actions';
 import { getSecretProviderInstance } from '@alga-psa/core/secrets';
-import { 
-  generateMicrosoftAuthUrl, 
-  generateGoogleAuthUrl, 
+import {
+  generateGoogleAuthUrl,
   generateNonce,
-  OAuthState 
+  OAuthState
 } from '@/utils/email/oauthHelpers';
 import { assertTenantProductAccess, isProductAccessError, toProductAccessDeniedResponse } from '@/lib/productAccess';
 
@@ -28,18 +27,27 @@ export async function POST(request: NextRequest) {
       return NextResponse.json({ error: 'Invalid provider' }, { status: 400 });
     }
 
+    // Microsoft mailbox OAuth must go through the signed explicit-selection
+    // flow (initiateEmailOAuth server action), which issues a
+    // base64url(JSON).HMAC state token that the callback verifies. This
+    // unsigned HTTP initiate must never mint Microsoft state: the callback
+    // rejects unsigned state, so a Microsoft flow started here could never
+    // complete and would only teach callers the wrong path.
+    if (provider === 'microsoft') {
+      return NextResponse.json({
+        error: 'Microsoft mailbox OAuth must be initiated from the mailbox form with an explicit application selection.',
+      }, { status: 400 });
+    }
+
     // Get OAuth credentials - use hosted credentials for EE or tenant-specific secrets for CE
     const secretProvider = await getSecretProviderInstance();
     let clientId: string | null = null;
     let effectiveRedirectUri = redirectUri;
 
-    if (provider === 'google') {
-      // Google is always tenant-owned (CE and EE): do not fall back to app-level secrets.
-      clientId = await secretProvider.getTenantSecret(user.tenant, 'google_client_id') || null;
-    } else {
-      // Microsoft remains as-is.
-      clientId = await secretProvider.getAppSecret('MICROSOFT_CLIENT_ID') || await secretProvider.getTenantSecret(user.tenant, 'microsoft_client_id') || null;
-    }
+    // Microsoft was rejected above: only Google flows through this unsigned
+    // HTTP initiate, and Google is always tenant-owned (CE and EE) — no
+    // fallback to app-level secrets.
+    clientId = await secretProvider.getTenantSecret(user.tenant, 'google_client_id') || null;
 
     if (!effectiveRedirectUri) {
       const base =
@@ -69,23 +77,11 @@ export async function POST(request: NextRequest) {
     };
 
     // Generate authorization URL
-    // For multi-tenant Azure AD apps, always use 'common' for the authorization URL
-    // This allows users from any Azure AD tenant to authenticate
-    const msTenantAuthority = 'common';
-
-    const authUrl = provider === 'microsoft'
-      ? generateMicrosoftAuthUrl(
-          clientId,
-          state.redirectUri,
-          state,
-          undefined as any,
-          msTenantAuthority
-        )
-      : generateGoogleAuthUrl(
-          clientId,
-          state.redirectUri,
-          state
-        );
+    const authUrl = generateGoogleAuthUrl(
+      clientId,
+      state.redirectUri,
+      state
+    );
 
     return NextResponse.json({
       success: true,

--- a/server/src/lib/api/openapi/routes/email.ts
+++ b/server/src/lib/api/openapi/routes/email.ts
@@ -261,7 +261,7 @@ export function registerEmailRoutes(registry: ApiOpenApiRegistry) {
     path: '/api/email/oauth/initiate',
     summary: 'Initiate email OAuth flow',
     description:
-      'Starts the OAuth 2.0 authorization flow for a Google or Microsoft email provider. Requires a valid Auth.js session cookie. The handler builds secure OAuth state containing tenant, user, providerId, redirect URI, timestamp, and nonce, resolves the provider client ID from configured secrets, and returns the authorization URL for the browser to visit.',
+      'Starts the OAuth 2.0 authorization flow for a Google email provider. Requires a valid Auth.js session cookie. The handler builds secure OAuth state containing tenant, user, providerId, redirect URI, timestamp, and nonce, resolves the provider client ID from configured secrets, and returns the authorization URL for the browser to visit. Microsoft mailbox OAuth is not served by this unsigned route: it must be initiated from the mailbox form with an explicit application selection so the callback receives a signed state token.',
     tags: [tag],
     security: [{ SessionCookieAuth: [] }],
     request: {

--- a/server/src/services/email/MicrosoftEmailOAuthResultPersistence.ts
+++ b/server/src/services/email/MicrosoftEmailOAuthResultPersistence.ts
@@ -5,7 +5,7 @@
  * them must be atomic with the webhook/subscription initialization that follows:
  * if setup fails *after* the credential write, the previously connected
  * provider must be left fully working (old refresh token, old client_id /
- * profile pinning, old subscription state).
+ * profile pinning, coherent subscription state).
  *
  * This module uses a compensating restore rather than a single database
  * transaction because webhook initialization makes external Microsoft Graph
@@ -14,12 +14,23 @@
  *   1. capture the prior `microsoft_email_provider_config` + `email_providers`
  *      rows,
  *   2. persist the new tokens + authoritative issuer metadata transactionally,
- *   3. run webhook/subscription setup against the freshly written rows,
- *   4. on any post-persistence failure, restore the captured prior rows in a
- *      transaction and rethrow.
+ *   3. run webhook/subscription setup against the freshly written rows. The
+ *      setup receives a compensation ledger and records every Graph
+ *      subscription it deletes or creates,
+ *   4. on any post-persistence failure, run the caller's Graph compensation
+ *      (delete subscriptions the failed setup created) and then restore the
+ *      captured rows in a transaction, re-deriving the subscription fields so
+ *      they never resurrect a subscription id that no longer exists in Graph.
+ *
+ * Restoration is retry-safe: it updates (never inserts) the existing rows and
+ * the caller deletes any subscription created by the failed attempt, so a
+ * second callback attempt neither duplicates rows nor subscriptions.
  */
 
 import { createTenantKnex, tenantDb } from '@alga-psa/db';
+
+/** How long before a compensated provider re-probes Graph for a subscription. */
+const COMPENSATED_POLLING_PROBE_INTERVAL_MS = 24 * 60 * 60 * 1000;
 
 /** Mutable columns on `microsoft_email_provider_config` that the OAuth callback
  * or webhook setup can change, and that a failed flow must restore. */
@@ -46,6 +57,23 @@ const CONFIG_RESTORE_COLUMNS = [
 /** Mutable columns on `email_providers` that the OAuth callback can change. */
 const PROVIDER_RESTORE_COLUMNS = ['status', 'error_message', 'last_sync_at', 'updated_at'] as const;
 
+/**
+ * Ledger of Graph subscription mutations recorded by the failed webhook setup.
+ * `deletedSubscriptionIds` are subscriptions the setup removed from Graph;
+ * `createdSubscriptionIds` are subscriptions the setup created and that the
+ * caller must delete to leave Graph clean for a retry.
+ */
+export interface MicrosoftEmailWebhookCompensationLedger {
+  deletedSubscriptionIds: string[];
+  createdSubscriptionIds: string[];
+}
+
+/** Live ledger exposed to `setupWebhook` so its adapter can record mutations. */
+export interface MicrosoftEmailWebhookCompensation {
+  onSubscriptionDeleted(subscriptionId: string): void;
+  onSubscriptionCreated(subscriptionId: string): void;
+}
+
 export interface MicrosoftEmailOAuthPersistContext {
   provider: Record<string, any>;
   config: Record<string, any>;
@@ -54,6 +82,12 @@ export interface MicrosoftEmailOAuthPersistContext {
   accessToken: string;
   refreshToken: string | null;
   expiresAt: Date;
+  /**
+   * Record every Graph subscription the webhook setup deletes or creates. The
+   * restore consults the ledger so it never resurrects a subscription id that
+   * the setup already removed from Graph.
+   */
+  webhookCompensation: MicrosoftEmailWebhookCompensation;
 }
 
 export interface MicrosoftEmailOAuthIssuerPersistMetadata {
@@ -74,9 +108,14 @@ export interface PersistMicrosoftEmailOAuthResultParams {
    * Runs webhook/subscription initialization after the token write. It receives
    * the freshly persisted rows and effective credentials. A resolved validation
    * failure should fall back to polling and return normally; any thrown error
-   * triggers a restore of the prior connection.
+   * triggers Graph compensation + restore of the prior connection.
    */
   setupWebhook: (ctx: MicrosoftEmailOAuthPersistContext) => Promise<void>;
+  /**
+   * Compensates the Graph side of a failed setup: delete every subscription the
+   * setup created (tracked in the ledger). Runs before the database restore.
+   */
+  compensateWebhook: (ledger: MicrosoftEmailWebhookCompensationLedger) => Promise<void>;
 }
 
 function pickRestorePayload(prior: Record<string, any>, columns: readonly string[]): Record<string, any> {
@@ -87,6 +126,35 @@ function pickRestorePayload(prior: Record<string, any>, columns: readonly string
     }
   }
   return payload;
+}
+
+/**
+ * Re-derive the subscription fields of a restored config row from the ledger.
+ * The captured snapshot's subscription id is only truthful if the failed setup
+ * never deleted it in Graph; otherwise restoring it would resurrect a phantom
+ * subscription. When the prior subscription is gone, the restored row lands on
+ * a coherent polling state that the maintenance probe will rebuild.
+ */
+function reconcileSubscriptionRestore(
+  payload: Record<string, any>,
+  priorConfig: Record<string, any>,
+  ledger: MicrosoftEmailWebhookCompensationLedger
+): void {
+  const priorSubscriptionId = priorConfig?.webhook_subscription_id ?? null;
+  const priorSubscriptionDeleted =
+    Boolean(priorSubscriptionId) &&
+    ledger.deletedSubscriptionIds.includes(String(priorSubscriptionId));
+  if (!priorSubscriptionDeleted) return;
+
+  payload.webhook_subscription_id = null;
+  payload.webhook_expires_at = null;
+  payload.delivery_mode = 'polling';
+  payload.webhook_silent_runs = 0;
+  payload.last_webhook_delivery_at = null;
+  payload.next_subscription_probe_at = new Date(
+    Date.now() + COMPENSATED_POLLING_PROBE_INTERVAL_MS
+  ).toISOString();
+  payload.updated_at = new Date().toISOString();
 }
 
 export async function persistMicrosoftEmailOAuthResult(
@@ -102,6 +170,20 @@ export async function persistMicrosoftEmailOAuthResult(
   const priorProvider = await db.table('email_providers')
     .where('id', providerId)
     .first();
+
+  const ledger: MicrosoftEmailWebhookCompensationLedger = {
+    deletedSubscriptionIds: [],
+    createdSubscriptionIds: [],
+  };
+  const record = (bucket: 'deletedSubscriptionIds' | 'createdSubscriptionIds') =>
+    (subscriptionId: string) => {
+      if (!subscriptionId || ledger[bucket].includes(subscriptionId)) return;
+      ledger[bucket].push(subscriptionId);
+    };
+  const webhookCompensation: MicrosoftEmailWebhookCompensation = {
+    onSubscriptionDeleted: record('deletedSubscriptionIds'),
+    onSubscriptionCreated: record('createdSubscriptionIds'),
+  };
 
   try {
     await knex.transaction(async (trx) => {
@@ -148,16 +230,36 @@ export async function persistMicrosoftEmailOAuthResult(
       accessToken: params.tokens.accessToken,
       refreshToken: params.tokens.refreshToken,
       expiresAt: params.tokens.expiresAt,
+      webhookCompensation,
     });
   } catch (error) {
+    // Compensate the Graph side first (delete subscriptions the failed setup
+    // created) so a retry cannot duplicate them. Best-effort: a failed
+    // compensation must not prevent the database restore.
+    try {
+      await params.compensateWebhook({
+        deletedSubscriptionIds: [...ledger.deletedSubscriptionIds],
+        createdSubscriptionIds: [...ledger.createdSubscriptionIds],
+      });
+    } catch (compensationError) {
+      console.error('[MicrosoftEmailOAuthResultPersistence] Failed to compensate Graph subscriptions after OAuth failure', {
+        tenant,
+        providerId,
+        ledger,
+        compensationError: compensationError instanceof Error ? compensationError.message : String(compensationError),
+      });
+    }
+
     if (priorConfig || priorProvider) {
       try {
         await knex.transaction(async (trx) => {
           const trxDb = tenantDb(trx, tenant);
           if (priorConfig) {
+            const restorePayload = pickRestorePayload(priorConfig, CONFIG_RESTORE_COLUMNS);
+            reconcileSubscriptionRestore(restorePayload, priorConfig, ledger);
             await trxDb.table('microsoft_email_provider_config')
               .where('email_provider_id', providerId)
-              .update(pickRestorePayload(priorConfig, CONFIG_RESTORE_COLUMNS));
+              .update(restorePayload);
           }
           if (priorProvider) {
             await trxDb.table('email_providers')

--- a/server/src/services/email/MicrosoftEmailOAuthResultPersistence.ts
+++ b/server/src/services/email/MicrosoftEmailOAuthResultPersistence.ts
@@ -1,0 +1,178 @@
+/**
+ * Atomic persistence of a successful Microsoft inbound-email OAuth result.
+ *
+ * The mailbox OAuth callback receives fresh tokens from Microsoft. Persisting
+ * them must be atomic with the webhook/subscription initialization that follows:
+ * if setup fails *after* the credential write, the previously connected
+ * provider must be left fully working (old refresh token, old client_id /
+ * profile pinning, old subscription state).
+ *
+ * This module uses a compensating restore rather than a single database
+ * transaction because webhook initialization makes external Microsoft Graph
+ * calls that cannot be rolled back. The flow is:
+ *
+ *   1. capture the prior `microsoft_email_provider_config` + `email_providers`
+ *      rows,
+ *   2. persist the new tokens + authoritative issuer metadata transactionally,
+ *   3. run webhook/subscription setup against the freshly written rows,
+ *   4. on any post-persistence failure, restore the captured prior rows in a
+ *      transaction and rethrow.
+ */
+
+import { createTenantKnex, tenantDb } from '@alga-psa/db';
+
+/** Mutable columns on `microsoft_email_provider_config` that the OAuth callback
+ * or webhook setup can change, and that a failed flow must restore. */
+const CONFIG_RESTORE_COLUMNS = [
+  'client_id',
+  'client_secret',
+  'tenant_id',
+  'microsoft_profile_id',
+  'client_secret_ref',
+  'access_token',
+  'refresh_token',
+  'token_expires_at',
+  'webhook_subscription_id',
+  'webhook_verification_token',
+  'webhook_expires_at',
+  'last_subscription_renewal',
+  'delivery_mode',
+  'last_webhook_delivery_at',
+  'next_subscription_probe_at',
+  'webhook_silent_runs',
+  'updated_at',
+] as const;
+
+/** Mutable columns on `email_providers` that the OAuth callback can change. */
+const PROVIDER_RESTORE_COLUMNS = ['status', 'error_message', 'last_sync_at', 'updated_at'] as const;
+
+export interface MicrosoftEmailOAuthPersistContext {
+  provider: Record<string, any>;
+  config: Record<string, any>;
+  clientId: string;
+  clientSecret: string;
+  accessToken: string;
+  refreshToken: string | null;
+  expiresAt: Date;
+}
+
+export interface MicrosoftEmailOAuthIssuerPersistMetadata {
+  client_id: string;
+  client_secret: string;
+  tenant_id: string;
+  microsoft_profile_id: string | null;
+  client_secret_ref: string | null;
+}
+
+export interface PersistMicrosoftEmailOAuthResultParams {
+  tenant: string;
+  providerId: string;
+  tokens: { accessToken: string; refreshToken: string | null; expiresAt: Date };
+  /** Authoritative issuer metadata resolved from the signed state's choice. */
+  issuerMetadata?: MicrosoftEmailOAuthIssuerPersistMetadata | null;
+  /**
+   * Runs webhook/subscription initialization after the token write. It receives
+   * the freshly persisted rows and effective credentials. A resolved validation
+   * failure should fall back to polling and return normally; any thrown error
+   * triggers a restore of the prior connection.
+   */
+  setupWebhook: (ctx: MicrosoftEmailOAuthPersistContext) => Promise<void>;
+}
+
+function pickRestorePayload(prior: Record<string, any>, columns: readonly string[]): Record<string, any> {
+  const payload: Record<string, any> = {};
+  for (const column of columns) {
+    if (column in prior) {
+      payload[column] = prior[column];
+    }
+  }
+  return payload;
+}
+
+export async function persistMicrosoftEmailOAuthResult(
+  params: PersistMicrosoftEmailOAuthResultParams
+): Promise<void> {
+  const { knex } = await createTenantKnex();
+  const db = tenantDb(knex, params.tenant);
+  const { providerId, tenant } = params;
+
+  const priorConfig = await db.table('microsoft_email_provider_config')
+    .where('email_provider_id', providerId)
+    .first();
+  const priorProvider = await db.table('email_providers')
+    .where('id', providerId)
+    .first();
+
+  try {
+    await knex.transaction(async (trx) => {
+      const trxDb = tenantDb(trx, tenant);
+      const updatePayload: Record<string, unknown> = {
+        access_token: params.tokens.accessToken,
+        refresh_token: params.tokens.refreshToken || null,
+        token_expires_at: params.tokens.expiresAt.toISOString(),
+        updated_at: new Date().toISOString(),
+      };
+      if (params.issuerMetadata) {
+        updatePayload.client_id = params.issuerMetadata.client_id;
+        updatePayload.client_secret = params.issuerMetadata.client_secret;
+        updatePayload.tenant_id = params.issuerMetadata.tenant_id;
+        updatePayload.microsoft_profile_id = params.issuerMetadata.microsoft_profile_id;
+        updatePayload.client_secret_ref = params.issuerMetadata.client_secret_ref;
+      }
+
+      await trxDb.table('microsoft_email_provider_config')
+        .where('email_provider_id', providerId)
+        .update(updatePayload);
+
+      await trxDb.table('email_providers')
+        .where('id', providerId)
+        .update({
+          status: 'connected',
+          error_message: null,
+          updated_at: trx.fn.now(),
+        });
+    });
+
+    const config = await db.table('microsoft_email_provider_config')
+      .where('email_provider_id', providerId)
+      .first();
+    const provider = await db.table('email_providers')
+      .where('id', providerId)
+      .first();
+
+    await params.setupWebhook({
+      provider,
+      config,
+      clientId: params.issuerMetadata?.client_id || '',
+      clientSecret: params.issuerMetadata?.client_secret || '',
+      accessToken: params.tokens.accessToken,
+      refreshToken: params.tokens.refreshToken,
+      expiresAt: params.tokens.expiresAt,
+    });
+  } catch (error) {
+    if (priorConfig || priorProvider) {
+      try {
+        await knex.transaction(async (trx) => {
+          const trxDb = tenantDb(trx, tenant);
+          if (priorConfig) {
+            await trxDb.table('microsoft_email_provider_config')
+              .where('email_provider_id', providerId)
+              .update(pickRestorePayload(priorConfig, CONFIG_RESTORE_COLUMNS));
+          }
+          if (priorProvider) {
+            await trxDb.table('email_providers')
+              .where('id', providerId)
+              .update(pickRestorePayload(priorProvider, PROVIDER_RESTORE_COLUMNS));
+          }
+        });
+      } catch (restoreError) {
+        console.error('[MicrosoftEmailOAuthResultPersistence] Failed to restore prior connection after OAuth failure', {
+          tenant,
+          providerId,
+          restoreError: restoreError instanceof Error ? restoreError.message : String(restoreError),
+        });
+      }
+    }
+    throw error;
+  }
+}

--- a/server/src/test/integration/emailProviderCreation.test.ts
+++ b/server/src/test/integration/emailProviderCreation.test.ts
@@ -213,7 +213,7 @@ describe('Email Provider Creation', () => {
   });
 
   describe('Microsoft Provider', () => {
-    it('should create a new Microsoft email provider with all required fields', async () => {
+    it('should create a new Microsoft email provider with an explicit issuer choice', async () => {
       // Arrange
       const providerData = {
         tenant: testTenant,
@@ -221,10 +221,15 @@ describe('Email Provider Creation', () => {
         providerName: 'Client Outlook',
         mailbox: 'outlook-support@client.com',
         isActive: true,
+        microsoftIssuer: {
+          kind: 'profile' as const,
+          profileId: microsoftProfileId,
+          clientId: microsoftProfileClientId,
+        },
         microsoftConfig: {
-          client_id: 'microsoft-client-id',
-          client_secret: 'microsoft-client-secret',
-          tenant_id: 'common',
+          client_id: '',
+          client_secret: '',
+          tenant_id: '',
           redirect_uri: 'http://localhost:3000/api/auth/microsoft/callback',
           max_emails_per_sync: 100
         } as any
@@ -244,6 +249,8 @@ describe('Email Provider Creation', () => {
         .where('email_provider_id', result.provider.id)
         .first();
 
+      // The explicit issuer selection is pinned per-provider as authoritative
+      // issuer metadata, agreeing with the chosen profile.
       expect(configRecord).toMatchObject({
         client_id: microsoftProfileClientId,
         client_secret: microsoftProfileClientSecret,
@@ -252,6 +259,95 @@ describe('Email Provider Creation', () => {
         client_secret_ref: microsoftProfileSecretRef,
         max_emails_per_sync: 100
       });
+    });
+
+    it('should reject switching to a different Microsoft app without a reconnect', async () => {
+      // Arrange: a second eligible profile represents the "other" app.
+      const otherProfileId = uuidv4();
+      const otherSecretRef = `microsoft_profile_${otherProfileId}_client_secret`;
+      const otherSecretEnvKey = `TENANT_${testTenant}_${otherSecretRef}`;
+      process.env[otherSecretEnvKey] = 'other-profile-client-secret';
+      const otherNow = new Date();
+      await tenantTable('microsoft_profiles').insert({
+        tenant: testTenant,
+        profile_id: otherProfileId,
+        display_name: 'Other Email App',
+        display_name_normalized: 'other email app',
+        client_id: 'other-profile-client-id',
+        tenant_id: 'other-tenant-id',
+        client_secret_ref: otherSecretRef,
+        capabilities: JSON.stringify(['email']),
+        is_default: false,
+        is_archived: false,
+        archived_at: null,
+        created_by: null,
+        updated_by: null,
+        created_at: otherNow,
+        updated_at: otherNow
+      });
+
+      // A connected provider pinned to the bound profile.
+      const created = await createEmailProvider({
+        tenant: testTenant,
+        providerType: 'microsoft' as const,
+        providerName: 'Connected Outlook',
+        mailbox: 'connected-outlook@client.com',
+        isActive: true,
+        microsoftIssuer: {
+          kind: 'profile' as const,
+          profileId: microsoftProfileId,
+          clientId: microsoftProfileClientId,
+        },
+        microsoftConfig: {
+          client_id: '',
+          client_secret: '',
+          tenant_id: '',
+          redirect_uri: 'http://localhost:3000/api/auth/microsoft/callback',
+          auto_process_emails: true,
+          max_emails_per_sync: 50,
+          refresh_token: 'refresh-token-abc',
+          access_token: 'access-token-xyz',
+          token_expires_at: new Date(Date.now() + 3600000).toISOString(),
+        } as any,
+      }, true);
+
+      const connectedProviderId = (created as { provider: { id: string } }).provider.id;
+
+      // Act: a settings save that swaps the issuer to a different valid app
+      // without carrying a fresh token (i.e. without a reconnect).
+      const { updateEmailProvider } = await import('@alga-psa/integrations/actions/email-actions/emailProviderActions');
+      const result = await updateEmailProvider(connectedProviderId, {
+        tenant: testTenant,
+        providerType: 'microsoft' as const,
+        providerName: 'Connected Outlook',
+        mailbox: 'connected-outlook@client.com',
+        isActive: true,
+        microsoftIssuer: {
+          kind: 'profile' as const,
+          profileId: otherProfileId,
+          clientId: 'other-profile-client-id',
+        },
+        microsoftConfig: {
+          client_id: '',
+          client_secret: '',
+          tenant_id: '',
+          redirect_uri: 'http://localhost:3000/api/auth/microsoft/callback',
+          auto_process_emails: true,
+          max_emails_per_sync: 50,
+        } as any,
+      }, true);
+
+      // Assert: stable reconnect-required rejection, old issuer preserved.
+      expect((result as any).actionError).toContain('Reconnect the mailbox to switch Microsoft applications');
+      expect((result as any).errorCode).toBe('ms_email_client_mismatch_reconnect_required');
+
+      const configRecord = await tenantTable<any>('microsoft_email_provider_config')
+        .where('email_provider_id', connectedProviderId)
+        .first();
+      expect(configRecord.client_id).toBe(microsoftProfileClientId);
+      expect(configRecord.refresh_token).toBe('refresh-token-abc');
+
+      delete process.env[otherSecretEnvKey];
     });
   });
 

--- a/server/src/test/integration/emailProviderCreation.test.ts
+++ b/server/src/test/integration/emailProviderCreation.test.ts
@@ -349,6 +349,34 @@ describe('Email Provider Creation', () => {
 
       delete process.env[otherSecretEnvKey];
     });
+
+    it('fails loudly when creating a Microsoft provider without an explicit issuer choice', async () => {
+      // No microsoftIssuer: the server must reject rather than silently
+      // resolving the tenant Email binding.
+      const result = await createEmailProvider({
+        tenant: testTenant,
+        providerType: 'microsoft' as const,
+        providerName: 'No Issuer',
+        mailbox: 'no-issuer@client.com',
+        isActive: true,
+        microsoftConfig: {
+          client_id: '',
+          client_secret: '',
+          tenant_id: '',
+          redirect_uri: 'http://localhost:3000/api/auth/microsoft/callback',
+          auto_process_emails: true,
+          max_emails_per_sync: 50,
+        } as any,
+      }, true);
+
+      expect((result as any).actionError).toContain('Choose which Microsoft application authorizes this mailbox');
+      expect((result as any).errorCode).toBe('ms_email_issuer_required');
+
+      const dbRecord = await tenantTable<any>('email_providers')
+        .where('mailbox', 'no-issuer@client.com')
+        .first();
+      expect(dbRecord).toBeUndefined();
+    });
   });
 
   describe('Provider Management', () => {
@@ -370,6 +398,11 @@ describe('Email Provider Creation', () => {
         providerName: 'Outlook Provider',
         mailbox: 'outlook@client.com',
         isActive: true,
+        microsoftIssuer: {
+          kind: 'profile',
+          profileId: microsoftProfileId,
+          clientId: microsoftProfileClientId,
+        },
         microsoftConfig: {
           client_id: 'microsoft-client-id',
           client_secret: 'microsoft-client-secret',

--- a/server/src/test/integration/microsoftEmailOAuthCallbackRoute.integration.test.ts
+++ b/server/src/test/integration/microsoftEmailOAuthCallbackRoute.integration.test.ts
@@ -1,0 +1,652 @@
+/**
+ * Behavioral, DB-backed tests for the real Microsoft inbound-email OAuth
+ * callback route (`server/src/app/api/auth/microsoft/callback/route.ts`).
+ *
+ * These invoke the actual `GET` handler with constructed signed-state requests
+ * against real PostgreSQL, so every blocker below is proven on the production
+ * code path — not on an extracted helper:
+ *
+ *  1. Microsoft-error callbacks are fully guarded: the handler consumes the
+ *     single-use nonce and runs the same relationship guard (session user,
+ *     purpose, provider existence/tenant/type, issuer readiness) before it may
+ *     mutate provider status. Forged / foreign / replayed error callbacks
+ *     change nothing.
+ *  2. Unsigned state at the callback is rejected outright (no dual acceptance).
+ *  4. A post-token persistence failure reaches the ledger compensation: the
+ *     Graph subscription the failed setup created is deleted and neither Graph
+ *     nor DB is left with a stale subscription id.
+ *  5. After compensation restores the provider to its prior connected/polling
+ *     snapshot, the callback's outer handling does NOT mark it `error`.
+ *
+ * External Microsoft/secret/Graph-token infrastructure is stubbed (axios,
+ * Graph adapter, secret provider); every database operation the route performs
+ * is real. The nonce store runs its in-memory fallback (redis mocked away).
+ */
+
+import { describe, it, expect, beforeAll, afterAll, vi, beforeEach } from 'vitest';
+import type { Knex } from 'knex';
+import fs from 'node:fs';
+import path from 'node:path';
+import { v4 as uuidv4 } from 'uuid';
+import { tenantDb } from '@alga-psa/db';
+import { runWithApiKeyUser } from '@alga-psa/auth';
+import { createTestDbConnection } from '../../../test-utils/dbConfig';
+import {
+  createMicrosoftEmailOAuthState,
+  getMicrosoftEmailOAuthSigningSecret,
+  type MicrosoftEmailOAuthPurpose,
+} from '@alga-psa/integrations/utils/email/microsoftEmailOAuthState';
+import { storeMicrosoftEmailOAuthNonce } from '@alga-psa/integrations/utils/email/microsoftEmailOAuthStateStore';
+import { MICROSOFT_EMAIL_ISSUER_ERRORS } from '@alga-psa/integrations/lib/microsoftEmailIssuerSelection';
+import { NextRequest } from 'next/server';
+import { GET } from '../../app/api/auth/microsoft/callback/route';
+import { POST as initiatePost } from '../../app/api/email/oauth/initiate/route';
+
+const REDIRECT_URI = 'https://psa.example.com/api/auth/microsoft/callback';
+
+let testDb: Knex;
+let testTenant: string;
+let sessionUserId: string;
+let profileId: string;
+let profileSecretRef: string;
+
+/** Profile secrets the route's issuer revalidation resolves (filesystem store
+ * has no per-tenant rows in tests, so the secret provider is stubbed). */
+const tenantSecrets = new Map<string, string>();
+const appSecrets = new Map<string, string>();
+
+const capturedAdapterConfigs: any[] = [];
+const deletedSubscriptions: string[] = [];
+let failSetupWebhook = false;
+let failSetupWebhookMessage = 'graph subscription persistence failed';
+
+function tenantTable<Row = Record<string, unknown>>(table: string) {
+  return tenantDb(testDb, testTenant).table<Row>(table);
+}
+
+function tenantFixtureTable() {
+  return tenantDb(testDb, testTenant).unscoped(
+    'tenants',
+    'Microsoft OAuth callback route test fixture creates and removes tenant rows'
+  );
+}
+
+vi.mock('redis', () => ({
+  createClient: () => {
+    throw new Error('redis unavailable in Microsoft OAuth callback route tests');
+  },
+}));
+
+vi.mock('@alga-psa/db', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@alga-psa/db')>();
+  return {
+    ...actual,
+    createTenantKnex: async () => ({ knex: testDb, tenant: testTenant }),
+    getConnection: async () => testDb,
+  };
+});
+
+vi.mock('@alga-psa/db/admin', () => ({
+  getAdminConnection: async () => testDb,
+}));
+
+vi.mock('@alga-psa/core/secrets', () => ({
+  getSecret: async (_name: string, envVar?: string, fallback = '') =>
+    (envVar ? process.env[envVar] : undefined) ?? fallback,
+  getSecretProviderInstance: async () => ({
+    getTenantSecret: async (tenant: string, key: string) =>
+      tenantSecrets.get(`${tenant}:${key}`) || undefined,
+    setTenantSecret: async () => undefined,
+    getAppSecret: async (key: string) => appSecrets.get(key) || undefined,
+  }),
+}));
+
+vi.mock('axios', () => ({
+  default: {
+    post: async () => ({
+      data: {
+        access_token: 'new-access-token',
+        refresh_token: 'new-refresh-token',
+        expires_in: 3600,
+      },
+    }),
+  },
+}));
+
+vi.mock('@alga-psa/shared/services/email/providers/MicrosoftGraphAdapter', () => ({
+  MicrosoftSubscriptionError: class MicrosoftSubscriptionError extends Error {
+    constructor(public kind: string, message: string) {
+      super(message);
+    }
+  },
+  MicrosoftGraphAdapter: class MicrosoftGraphAdapter {
+    lifecycle: {
+      onSubscriptionDeleted?: (id: string) => void;
+      onSubscriptionCreated?: (id: string) => void;
+    } | null = null;
+
+    constructor(public config: Record<string, any>) {
+      capturedAdapterConfigs.push(config);
+    }
+
+    attachWebhookLifecycle(lifecycle: {
+      onSubscriptionDeleted?: (id: string) => void;
+      onSubscriptionCreated?: (id: string) => void;
+    }) {
+      this.lifecycle = lifecycle;
+    }
+
+    async connect() {}
+
+    async registerWebhookSubscription() {
+      if (failSetupWebhook) {
+        // Simulates the real adapter deleting the old subscription, creating a
+        // replacement, and then failing while persisting subscription state.
+        this.lifecycle?.onSubscriptionDeleted?.('old-sub');
+        this.lifecycle?.onSubscriptionCreated?.('new-sub');
+        throw new Error(failSetupWebhookMessage);
+      }
+      return {};
+    }
+
+    async deleteSubscription(subscriptionId: string) {
+      deletedSubscriptions.push(subscriptionId);
+    }
+  },
+}));
+
+vi.mock('@alga-psa/shared/services/email/EmailWebhookMaintenanceService', () => ({
+  EmailWebhookMaintenanceService: class {
+    async recordWebhookDeliveryMode() {}
+    async usePollingDelivery() {
+      return new Date(Date.now() + 3600000).toISOString();
+    }
+  },
+}));
+
+async function parsePostMessage(res: Response): Promise<Record<string, any>> {
+  const html = await res.text();
+  const match = /atob\('([^']+)'\)/.exec(html);
+  if (!match) {
+    throw new Error(`No postMessage payload found in callback response. Body: ${html.slice(0, 400)}`);
+  }
+  return JSON.parse(Buffer.from(match[1], 'base64').toString('utf8'));
+}
+
+function callbackRequest(params: Record<string, string>): NextRequest {
+  const qs = new URLSearchParams(params).toString();
+  return new NextRequest(`http://localhost:3000/api/auth/microsoft/callback?${qs}`, {
+    method: 'GET',
+  });
+}
+
+async function invokeCallback(
+  params: Record<string, string>,
+  session: { user_id?: string; tenant?: string } = { user_id: sessionUserId, tenant: testTenant }
+): Promise<{ response: Response; payload: Record<string, any> }> {
+  const response = await runWithApiKeyUser(
+    { user_id: session.user_id ?? sessionUserId, tenant: session.tenant ?? testTenant },
+    () => GET(callbackRequest(params))
+  );
+  return { response, payload: await parsePostMessage(response) };
+}
+
+async function signAndStoreState(params: {
+  purpose: MicrosoftEmailOAuthPurpose;
+  providerId?: string;
+  userId?: string;
+  tenant?: string;
+  clientId?: string;
+  profileIdArg?: string;
+}): Promise<string> {
+  const secret = await getMicrosoftEmailOAuthSigningSecret();
+  if (!secret) throw new Error('No state signing secret available');
+  const signed = createMicrosoftEmailOAuthState({
+    purpose: params.purpose,
+    tenant: params.tenant ?? testTenant,
+    userId: params.userId ?? sessionUserId,
+    ...(params.providerId ? { providerId: params.providerId } : {}),
+    issuer: {
+      kind: 'profile',
+      profileId: params.profileIdArg ?? profileId,
+      clientId: params.clientId ?? 'profile-client-id',
+    },
+    clientId: params.clientId ?? 'profile-client-id',
+    redirectUri: REDIRECT_URI,
+    secret,
+  });
+  await storeMicrosoftEmailOAuthNonce(signed.payload.nonce);
+  return signed.token;
+}
+
+async function seedProfile(overrides: Record<string, unknown> = {}): Promise<string> {
+  const id = uuidv4();
+  const secretRef = `microsoft_profile_${id}_client_secret`;
+  const clientId = String(overrides.client_id ?? 'profile-client-id');
+  await tenantTable('microsoft_profiles').insert({
+    tenant: testTenant,
+    profile_id: id,
+    display_name: 'Mailbox Email App',
+    display_name_normalized: 'mailbox email app',
+    client_id: clientId,
+    tenant_id: 'directory-tenant-guid',
+    client_secret_ref: secretRef,
+    capabilities: JSON.stringify(['email']),
+    is_default: true,
+    is_archived: false,
+    archived_at: null,
+    created_by: null,
+    updated_by: null,
+    created_at: new Date(),
+    updated_at: new Date(),
+    ...overrides,
+  });
+  tenantSecrets.set(`${testTenant}:${secretRef}`, 'profile-secret-value');
+  return id;
+}
+
+async function seedProvider(overrides: {
+  refreshToken?: string | null;
+  status?: string;
+  microsoftProfileId?: string | null;
+} = {}): Promise<string> {
+  const providerId = uuidv4();
+  const now = new Date();
+  const hasTokens = overrides.refreshToken !== null;
+  const refreshToken = overrides.refreshToken === undefined ? 'old-refresh' : overrides.refreshToken;
+  await tenantTable('email_providers').insert({
+    id: providerId,
+    tenant: testTenant,
+    provider_type: 'microsoft',
+    provider_name: 'Mailbox',
+    mailbox: `box-${providerId.slice(0, 8)}@client.com`,
+    is_active: true,
+    status: overrides.status ?? (hasTokens ? 'connected' : 'configuring'),
+    error_message: null,
+    created_at: now,
+    updated_at: now,
+  });
+  await tenantTable('microsoft_email_provider_config').insert({
+    email_provider_id: providerId,
+    tenant: testTenant,
+    client_id: 'profile-client-id',
+    client_secret: 'stored-secret',
+    tenant_id: 'directory-tenant-guid',
+    microsoft_profile_id: overrides.microsoftProfileId ?? profileId,
+    client_secret_ref: profileSecretRef,
+    redirect_uri: REDIRECT_URI,
+    auto_process_emails: true,
+    max_emails_per_sync: 50,
+    folder_filters: JSON.stringify(['Inbox']),
+    access_token: 'old-access',
+    refresh_token: refreshToken,
+    token_expires_at: new Date(Date.now() + 3600000).toISOString(),
+    webhook_subscription_id: 'old-sub',
+    webhook_verification_token: 'old-token',
+    webhook_expires_at: new Date(Date.now() + 7200000).toISOString(),
+    last_subscription_renewal: now,
+    delivery_mode: 'webhook',
+    webhook_silent_runs: 0,
+    next_subscription_probe_at: null,
+    created_at: now,
+    updated_at: now,
+  });
+  return providerId;
+}
+
+async function readProviderRow(providerId: string) {
+  return tenantTable<any>('microsoft_email_provider_config')
+    .where('email_provider_id', providerId)
+    .first();
+}
+
+async function readProviderStatus(providerId: string) {
+  return tenantTable<any>('email_providers').where('id', providerId).first();
+}
+
+describe('Microsoft email OAuth callback route (DB-backed behavioral)', () => {
+  beforeAll(async () => {
+    // Point DB-backed bootstrap at the local compose Postgres, resolving the
+    // admin/app passwords from ./secrets (mocked secrets provider falls back
+    // to env for getSecret).
+    const secretsDir = path.resolve(__dirname, '../../../../secrets');
+    const readSecret = (name: string) => {
+      try {
+        return fs.readFileSync(path.join(secretsDir, name), 'utf8').trim();
+      } catch {
+        return undefined;
+      }
+    };
+    // Override unconditionally: .env.localtest points DB_PASSWORD_* at container
+    // secret paths that do not exist on this host, and the secrets provider is
+    // mocked below, so getSecret() falls back to these env vars.
+    process.env.DB_HOST = '127.0.0.1';
+    process.env.DB_PORT = '5472';
+    process.env.DB_USER_ADMIN = 'postgres';
+    process.env.DB_USER_SERVER = 'app_user';
+    process.env.DB_PASSWORD_ADMIN = readSecret('postgres_password') || 'postpass123';
+    process.env.DB_PASSWORD_SERVER = readSecret('db_password_server') || 'postpass123';
+    process.env.NODE_ENV = 'test';
+
+    testDb = await createTestDbConnection();
+    testTenant = uuidv4();
+    sessionUserId = uuidv4();
+    await tenantFixtureTable().insert({
+      tenant: testTenant,
+      client_name: 'MS Callback Test Client',
+      email: 'ms-callback@client.com',
+      created_at: new Date(),
+      updated_at: new Date(),
+    });
+    profileId = await seedProfile();
+    profileSecretRef = `microsoft_profile_${profileId}_client_secret`;
+  }, 180_000);
+
+  afterAll(async () => {
+    if (testTenant) {
+      await tenantTable('microsoft_email_provider_config').delete();
+      await tenantTable('email_providers').delete();
+      await tenantTable('microsoft_profiles').delete();
+      await tenantFixtureTable().where('tenant', testTenant).delete();
+    }
+    await testDb?.destroy().catch(() => undefined);
+  }, 30_000);
+
+  beforeEach(() => {
+    capturedAdapterConfigs.length = 0;
+    deletedSubscriptions.length = 0;
+    failSetupWebhook = false;
+    failSetupWebhookMessage = 'graph subscription persistence failed';
+  });
+
+  describe('success path', () => {
+    it('success create: writes tokens + issuer pin atomically and returns success', async () => {
+      const providerId = await seedProvider({ refreshToken: null });
+      const state = await signAndStoreState({ purpose: 'create', providerId });
+
+      const { payload } = await invokeCallback({ code: 'auth-code-create', state });
+
+      expect(payload).toMatchObject({ type: 'oauth-callback', provider: 'microsoft', success: true });
+
+      const config = await readProviderRow(providerId);
+      expect(config).toMatchObject({
+        client_id: 'profile-client-id',
+        microsoft_profile_id: profileId,
+        client_secret_ref: profileSecretRef,
+        access_token: 'new-access-token',
+        refresh_token: 'new-refresh-token',
+      });
+      const provider = await readProviderStatus(providerId);
+      expect(provider.status).toBe('connected');
+    });
+
+    it('success reconnect: refreshes tokens and keeps the pinned issuer', async () => {
+      const providerId = await seedProvider({});
+      const state = await signAndStoreState({ purpose: 'reconnect', providerId });
+
+      const { payload } = await invokeCallback({ code: 'auth-code-reconnect', state });
+
+      expect(payload).toMatchObject({ type: 'oauth-callback', provider: 'microsoft', success: true });
+
+      const config = await readProviderRow(providerId);
+      expect(config).toMatchObject({
+        access_token: 'new-access-token',
+        refresh_token: 'new-refresh-token',
+        client_id: 'profile-client-id',
+        microsoft_profile_id: profileId,
+        client_secret_ref: profileSecretRef,
+      });
+      const provider = await readProviderStatus(providerId);
+      expect(provider.status).toBe('connected');
+    });
+
+    it('a signed state is single-use: the second callback with the same state is a replay and changes nothing', async () => {
+      const providerId = await seedProvider({});
+      const state = await signAndStoreState({ purpose: 'reconnect', providerId });
+
+      const first = await invokeCallback({ code: 'auth-code-once', state });
+      expect(first.payload.success).toBe(true);
+
+      const second = await invokeCallback({ code: 'auth-code-twice', state });
+      expect(second.payload.success).toBe(false);
+      expect(second.payload.error).toBe(MICROSOFT_EMAIL_ISSUER_ERRORS.REPLAYED_STATE);
+
+      // Tokens reflect only the first (consumed) callback.
+      const config = await readProviderRow(providerId);
+      expect(config.refresh_token).toBe('new-refresh-token');
+    });
+  });
+
+  describe('blocker 2: the unsigned HTTP initiate path is gone for Microsoft', () => {
+    it('rejects Microsoft initiation with no unsigned state (the signed server action is the only Microsoft path)', async () => {
+      const request = new NextRequest('http://localhost:3000/api/email/oauth/initiate', {
+        method: 'POST',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify({ provider: 'microsoft' }),
+      });
+
+      const response = await runWithApiKeyUser(
+        { user_id: sessionUserId, tenant: testTenant },
+        () => initiatePost(request)
+      );
+
+      expect(response.status).toBe(400);
+      const body = await response.json();
+      expect(body).not.toHaveProperty('authUrl');
+      expect(body).not.toHaveProperty('state');
+      expect(String(body.error)).toContain('explicit application selection');
+    });
+
+    it('still serves the unsigned Google initiate (legacy path unaffected)', async () => {
+      tenantSecrets.set(`${testTenant}:google_client_id`, 'google-client');
+      const request = new NextRequest('http://localhost:3000/api/email/oauth/initiate', {
+        method: 'POST',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify({ provider: 'google' }),
+      });
+
+      const response = await runWithApiKeyUser(
+        { user_id: sessionUserId, tenant: testTenant },
+        () => initiatePost(request)
+      );
+      tenantSecrets.delete(`${testTenant}:google_client_id`);
+
+      expect(response.status).toBe(200);
+      const body = await response.json();
+      expect(body.success).toBe(true);
+      expect(body.provider).toBe('google');
+    });
+  });
+
+  describe('blocker 1: Microsoft-error callbacks are fully guarded', () => {
+    it('a valid signed error callback attributes the failure after consuming the nonce and running the guard', async () => {
+      const providerId = await seedProvider({});
+      const state = await signAndStoreState({ purpose: 'reconnect', providerId });
+
+      const { payload } = await invokeCallback({ error: 'access_denied', state });
+      expect(payload.success).toBe(false);
+
+      const provider = await readProviderStatus(providerId);
+      expect(provider.status).toBe('error');
+      expect(String(provider.error_message)).toContain('access_denied');
+
+      // The error path consumed the nonce: a later success callback using the
+      // same state is a replay and must NOT write tokens.
+      const replay = await invokeCallback({ code: 'auth-code-after-error', state });
+      expect(replay.payload.success).toBe(false);
+      expect(replay.payload.error).toBe(MICROSOFT_EMAIL_ISSUER_ERRORS.REPLAYED_STATE);
+      const config = await readProviderRow(providerId);
+      expect(config.refresh_token).toBe('old-refresh');
+    });
+
+    it('a forged (tampered) error callback changes nothing', async () => {
+      const providerId = await seedProvider({});
+      const state = await signAndStoreState({ purpose: 'reconnect', providerId });
+      const forged = `${state.slice(0, -1)}${state.endsWith('A') ? 'B' : 'A'}`;
+
+      const { payload } = await invokeCallback({ error: 'access_denied', state: forged });
+      expect(payload.success).toBe(false);
+
+      const provider = await readProviderStatus(providerId);
+      expect(provider.status).toBe('connected');
+      expect(provider.error_message).toBeNull();
+    });
+
+    it('an unsigned base64 state at the callback is rejected outright (blocker 2 — no dual acceptance)', async () => {
+      const providerId = await seedProvider({});
+      const unsigned = Buffer.from(
+        JSON.stringify({ tenant: testTenant, userId: sessionUserId, providerId, timestamp: Date.now() })
+      ).toString('base64');
+
+      const { payload } = await invokeCallback({ error: 'access_denied', state: unsigned });
+      expect(payload.success).toBe(false);
+      expect(payload.error).toBe(MICROSOFT_EMAIL_ISSUER_ERRORS.INVALID_STATE);
+
+      const successPayload = await invokeCallback({ code: 'unsigned-code', state: unsigned });
+      expect(successPayload.payload.success).toBe(false);
+      expect(successPayload.payload.error).toBe(MICROSOFT_EMAIL_ISSUER_ERRORS.INVALID_STATE);
+
+      const provider = await readProviderStatus(providerId);
+      expect(provider.status).toBe('connected');
+      expect(provider.error_message).toBeNull();
+    });
+
+    it('a state signed for another user cannot attribute an error (foreign session)', async () => {
+      const providerId = await seedProvider({});
+      const state = await signAndStoreState({ purpose: 'reconnect', providerId, userId: 'some-other-user' });
+
+      const { payload } = await invokeCallback({ error: 'access_denied', state }, {
+        user_id: sessionUserId,
+        tenant: testTenant,
+      });
+      expect(payload.success).toBe(false);
+
+      const provider = await readProviderStatus(providerId);
+      expect(provider.status).toBe('connected');
+      expect(provider.error_message).toBeNull();
+    });
+
+    it('a state signed for another workspace cannot attribute an error', async () => {
+      const providerId = await seedProvider({});
+      const otherTenant = uuidv4();
+      await tenantFixtureTable()
+        .insert({
+          tenant: otherTenant,
+          client_name: 'Other Workspace',
+          email: 'other@workspace.com',
+          created_at: new Date(),
+          updated_at: new Date(),
+        })
+        .onConflict('tenant')
+        .ignore();
+      const state = await signAndStoreState({ purpose: 'reconnect', providerId, tenant: otherTenant });
+
+      const { payload } = await invokeCallback({ error: 'access_denied', state }, {
+        user_id: sessionUserId,
+        tenant: testTenant,
+      });
+      expect(payload.success).toBe(false);
+
+      const provider = await readProviderStatus(providerId);
+      expect(provider.status).toBe('connected');
+      expect(provider.error_message).toBeNull();
+    });
+
+    it('a replayed error callback (nonce already consumed) does not write again', async () => {
+      const providerId = await seedProvider({});
+      const state = await signAndStoreState({ purpose: 'reconnect', providerId });
+
+      const first = await invokeCallback({ error: 'access_denied', state });
+      expect(first.payload.success).toBe(false);
+
+      // Second error callback with the same state: nonce already consumed.
+      const second = await invokeCallback({ error: 'access_denied', state });
+      expect(second.payload.success).toBe(false);
+
+      // Exactly one attribution; error_message is stable.
+      const provider = await readProviderStatus(providerId);
+      expect(provider.status).toBe('error');
+      expect(String(provider.error_message)).toContain('access_denied');
+    });
+  });
+
+  describe('blockers 4+5: post-token persistence failure reaches compensation and never marks error', () => {
+    it('when subscription persistence fails after Graph create/delete, compensation deletes the created subscription, the restored row has no stale subscription id, and the provider is NOT marked error', async () => {
+      const providerId = await seedProvider({});
+      const state = await signAndStoreState({ purpose: 'reconnect', providerId });
+
+      failSetupWebhook = true;
+      failSetupWebhookMessage = 'failed persisting webhook subscription state to database';
+
+      const { payload } = await invokeCallback({ code: 'auth-code-persist-fail', state });
+      expect(payload.success).toBe(false);
+      expect(payload.error).toBe(MICROSOFT_EMAIL_ISSUER_ERRORS.CALLBACK_PERSISTENCE_FAILED);
+
+      // The compensation deleted the Graph subscription the failed setup created.
+      expect(deletedSubscriptions).toEqual(['new-sub']);
+
+      // DB is restored to the prior connected snapshot with NO stale
+      // subscription id (the old subscription was deleted from Graph by the
+      // failed setup, so the row lands on coherent polling).
+      const config = await readProviderRow(providerId);
+      expect(config).toMatchObject({
+        client_id: 'profile-client-id',
+        microsoft_profile_id: profileId,
+        client_secret_ref: profileSecretRef,
+        access_token: 'old-access',
+        refresh_token: 'old-refresh',
+        webhook_subscription_id: null,
+        webhook_expires_at: null,
+        delivery_mode: 'polling',
+        webhook_silent_runs: 0,
+        last_webhook_delivery_at: null,
+      });
+      expect(config.webhook_subscription_id).not.toBe('new-sub');
+      expect(config.webhook_subscription_id).not.toBe('old-sub');
+
+      // Blocker 5: the outer callback error handling must NOT have marked the
+      // restored provider `error`.
+      const provider = await readProviderStatus(providerId);
+      expect(provider.status).toBe('connected');
+      expect(provider.error_message).toBeNull();
+    });
+
+    it('a retry after a compensated persistence failure completes cleanly with no duplicate subscriptions', async () => {
+      const providerId = await seedProvider({});
+      const deletedSubs: string[] = [];
+
+      failSetupWebhook = true;
+      const state1 = await signAndStoreState({ purpose: 'reconnect', providerId });
+      const first = await invokeCallback({ code: 'code-attempt-1', state: state1 });
+      expect(first.payload.success).toBe(false);
+      deletedSubs.push(...deletedSubscriptions);
+      expect(deletedSubs).toEqual(['new-sub']);
+
+      // Retry with a fresh signed state completes cleanly.
+      failSetupWebhook = false;
+      const state2 = await signAndStoreState({ purpose: 'reconnect', providerId });
+      const second = await invokeCallback({ code: 'code-attempt-2', state: state2 });
+      expect(second.payload.success).toBe(true);
+
+      // Single coherent row, no stale deleted subscription id, no error status.
+      const rows = await tenantTable<any>('microsoft_email_provider_config')
+        .where('email_provider_id', providerId)
+        .select('*');
+      expect(rows).toHaveLength(1);
+      expect(rows[0]).toMatchObject({
+        access_token: 'new-access-token',
+        refresh_token: 'new-refresh-token',
+        client_id: 'profile-client-id',
+        microsoft_profile_id: profileId,
+      });
+      // The failed attempt's subscription was deleted from Graph; neither the
+      // deleted id nor the failed attempt's id is persisted (the stub adapter
+      // records no replacement subscription on the clean retry).
+      expect(rows[0].webhook_subscription_id).not.toBe('new-sub');
+      expect(rows[0].webhook_subscription_id).not.toBe('old-sub');
+      const provider = await readProviderStatus(providerId);
+      expect(provider.status).toBe('connected');
+      expect(provider.error_message).toBeNull();
+    });
+  });
+});

--- a/server/src/test/integration/microsoftEmailOAuthCallbackRoute.integration.test.ts
+++ b/server/src/test/integration/microsoftEmailOAuthCallbackRoute.integration.test.ts
@@ -59,6 +59,10 @@ const capturedAdapterConfigs: any[] = [];
 const deletedSubscriptions: string[] = [];
 let failSetupWebhook = false;
 let failSetupWebhookMessage = 'graph subscription persistence failed';
+// When set, the mocked adapter throws a MicrosoftSubscriptionError with this
+// kind instead of a plain Error (mirrors how the real adapter classifies
+// failures — including a DB persistence failure, which classifies as 'other').
+let failSetupWebhookKind: string | null = null;
 
 function tenantTable<Row = Record<string, unknown>>(table: string) {
   return tenantDb(testDb, testTenant).table<Row>(table);
@@ -144,6 +148,9 @@ vi.mock('@alga-psa/shared/services/email/providers/MicrosoftGraphAdapter', () =>
         // replacement, and then failing while persisting subscription state.
         this.lifecycle?.onSubscriptionDeleted?.('old-sub');
         this.lifecycle?.onSubscriptionCreated?.('new-sub');
+        if (failSetupWebhookKind !== null) {
+          throw new MicrosoftSubscriptionError(failSetupWebhookKind, failSetupWebhookMessage);
+        }
         throw new Error(failSetupWebhookMessage);
       }
       return {};
@@ -357,6 +364,7 @@ describe('Microsoft email OAuth callback route (DB-backed behavioral)', () => {
     deletedSubscriptions.length = 0;
     failSetupWebhook = false;
     failSetupWebhookMessage = 'graph subscription persistence failed';
+    failSetupWebhookKind = null;
   });
 
   describe('success path', () => {
@@ -571,6 +579,38 @@ describe('Microsoft email OAuth callback route (DB-backed behavioral)', () => {
   });
 
   describe('blockers 4+5: post-token persistence failure reaches compensation and never marks error', () => {
+    it('a non-validation subscription error (e.g. a DB persistence failure) propagates to compensation and is NOT treated as a polling fallback', async () => {
+      const providerId = await seedProvider({});
+      const state = await signAndStoreState({ purpose: 'reconnect', providerId });
+
+      // The real adapter classifies a failed webhook_subscription_id UPDATE as
+      // kind 'other' (it has no Graph status/code). Such a failure must NOT be
+      // silently downgraded to the polling fallback — that would leave the
+      // config row pointing at a subscription deleted from Graph.
+      failSetupWebhook = true;
+      failSetupWebhookKind = 'other';
+      failSetupWebhookMessage = 'Failed to persist Microsoft webhook subscription state';
+
+      const { payload } = await invokeCallback({ code: 'auth-code-db-persist-fail', state });
+      expect(payload.success).toBe(false);
+      expect(payload.error).toBe(MICROSOFT_EMAIL_ISSUER_ERRORS.CALLBACK_PERSISTENCE_FAILED);
+
+      // Compensation ran and deleted the created Graph subscription; the row
+      // landed on coherent polling (never the new or deleted-prior id).
+      expect(deletedSubscriptions).toEqual(['new-sub']);
+      const config = await readProviderRow(providerId);
+      expect(config.webhook_subscription_id).not.toBe('new-sub');
+      expect(config.webhook_subscription_id).not.toBe('old-sub');
+      expect(config).toMatchObject({
+        delivery_mode: 'polling',
+        webhook_silent_runs: 0,
+        last_webhook_delivery_at: null,
+      });
+      const provider = await readProviderStatus(providerId);
+      expect(provider.status).toBe('connected');
+      expect(provider.error_message).toBeNull();
+    });
+
     it('when subscription persistence fails after Graph create/delete, compensation deletes the created subscription, the restored row has no stale subscription id, and the provider is NOT marked error', async () => {
       const providerId = await seedProvider({});
       const state = await signAndStoreState({ purpose: 'reconnect', providerId });

--- a/server/src/test/integration/microsoftEmailOAuthResultPersistence.test.ts
+++ b/server/src/test/integration/microsoftEmailOAuthResultPersistence.test.ts
@@ -3,12 +3,14 @@
  *
  * A reconnect whose callback setup fails *after* the token exchange must leave
  * the previously connected provider fully working: old refresh token, old
- * client_id/profile pinning, and old subscription state all restored.
+ * client_id/profile pinning, and a subscription state that never contradicts
+ * what actually exists in Graph.
  *
  * `persistMicrosoftEmailOAuthResult` is the exact function the
  * /api/auth/microsoft/callback route uses to write tokens and initialize the
  * webhook. Exercising it against real PostgreSQL with a failing
- * `setupWebhook` is the behavioral regression for the atomicity requirement.
+ * `setupWebhook` (plus a compensation ledger recording the Graph mutations the
+ * setup performed) is the behavioral regression for the atomicity requirement.
  */
 
 import { describe, it, expect, beforeAll, afterAll, vi } from 'vitest';
@@ -16,7 +18,10 @@ import { Knex } from 'knex';
 import { v4 as uuidv4 } from 'uuid';
 import { tenantDb } from '@alga-psa/db';
 import { createTestDbConnection } from '../../../test-utils/dbConfig';
-import { persistMicrosoftEmailOAuthResult } from '../../services/email/MicrosoftEmailOAuthResultPersistence';
+import {
+  persistMicrosoftEmailOAuthResult,
+  type MicrosoftEmailWebhookCompensationLedger,
+} from '../../services/email/MicrosoftEmailOAuthResultPersistence';
 
 const OLD_PROFILE_ID = '00000000-0000-4000-8000-000000000001';
 const NEW_PROFILE_ID = '00000000-0000-4000-8000-000000000002';
@@ -88,6 +93,26 @@ async function seedConnectedProvider(overrides: { refreshToken?: string; clientI
   return providerId;
 }
 
+function persistParams(providerId: string, overrides: Record<string, unknown> = {}) {
+  return {
+    tenant: testTenant,
+    providerId,
+    tokens: {
+      accessToken: 'new-access',
+      refreshToken: 'new-refresh',
+      expiresAt: new Date(Date.now() + 3600000),
+    },
+    issuerMetadata: {
+      client_id: 'new-client',
+      client_secret: 'new-secret',
+      tenant_id: 'new-tenant-id',
+      microsoft_profile_id: NEW_PROFILE_ID,
+      client_secret_ref: 'new-ref',
+    },
+    ...overrides,
+  };
+}
+
 describe('MicrosoftEmailOAuthResultPersistence (T007 atomicity)', () => {
   beforeAll(async () => {
     testDb = await createTestDbConnection();
@@ -108,32 +133,28 @@ describe('MicrosoftEmailOAuthResultPersistence (T007 atomicity)', () => {
     await testDb.destroy();
   });
 
-  it('T007: a reconnect whose callback setup fails after token exchange leaves the original connection intact and functional', async () => {
+  it('T007: a reconnect whose callback setup fails before touching Graph leaves the original connection intact', async () => {
     const providerId = await seedConnectedProvider();
 
+    const compensateCalls: MicrosoftEmailWebhookCompensationLedger[] = [];
     await expect(
-      persistMicrosoftEmailOAuthResult({
-        tenant: testTenant,
-        providerId,
-        tokens: {
-          accessToken: 'new-access',
-          refreshToken: 'new-refresh',
-          expiresAt: new Date(Date.now() + 3600000),
-        },
-        issuerMetadata: {
-          client_id: 'new-client',
-          client_secret: 'new-secret',
-          tenant_id: 'new-tenant-id',
-          microsoft_profile_id: NEW_PROFILE_ID,
-          client_secret_ref: 'new-ref',
-        },
-        setupWebhook: async () => {
-          throw new Error('webhook registration exploded');
-        },
-      })
+      persistMicrosoftEmailOAuthResult(
+        persistParams(providerId, {
+          setupWebhook: async () => {
+            throw new Error('webhook registration exploded');
+          },
+          compensateWebhook: async (ledger) => {
+            compensateCalls.push({ ...ledger });
+          },
+        })
+      )
     ).rejects.toThrow('webhook registration exploded');
 
-    // Old credentials, issuer pinning, and subscription state are all restored.
+    // No Graph mutation was recorded, so the old subscription is still live and
+    // must be restored verbatim.
+    expect(compensateCalls).toHaveLength(1);
+    expect(compensateCalls[0]).toEqual({ deletedSubscriptionIds: [], createdSubscriptionIds: [] });
+
     const config = await tenantTable<any>('microsoft_email_provider_config')
       .where('email_provider_id', providerId)
       .first();
@@ -157,28 +178,160 @@ describe('MicrosoftEmailOAuthResultPersistence (T007 atomicity)', () => {
     expect(provider.error_message).toBeNull();
   });
 
+  it('restores a coherent polling state instead of resurrecting a subscription the failed setup deleted from Graph', async () => {
+    const providerId = await seedConnectedProvider();
+
+    const deletedSubs: string[] = [];
+    let ledgerSeen: MicrosoftEmailWebhookCompensationLedger | null = null;
+    await expect(
+      persistMicrosoftEmailOAuthResult(
+        persistParams(providerId, {
+          setupWebhook: async (ctx) => {
+            // Simulates registerWebhookSubscription: the adapter deletes the old
+            // subscription, creates a replacement, then a later step explodes.
+            ctx.webhookCompensation.onSubscriptionDeleted('old-sub');
+            ctx.webhookCompensation.onSubscriptionCreated('new-sub');
+            throw new Error('post-subscription step exploded');
+          },
+          compensateWebhook: async (ledger) => {
+            ledgerSeen = { ...ledger };
+            deletedSubs.push(...ledger.createdSubscriptionIds);
+          },
+        })
+      )
+    ).rejects.toThrow('post-subscription step exploded');
+
+    // The ledger captured the Graph mutations and the caller compensated the
+    // created subscription.
+    expect(ledgerSeen).toEqual({
+      deletedSubscriptionIds: ['old-sub'],
+      createdSubscriptionIds: ['new-sub'],
+    });
+    expect(deletedSubs).toEqual(['new-sub']);
+
+    // Tokens/issuer are restored, but the old subscription id (already deleted
+    // in Graph) is NOT resurrected: the row lands on a coherent polling state
+    // that the maintenance probe will rebuild.
+    const config = await tenantTable<any>('microsoft_email_provider_config')
+      .where('email_provider_id', providerId)
+      .first();
+    expect(config).toMatchObject({
+      client_id: 'old-client',
+      client_secret: 'old-secret',
+      microsoft_profile_id: OLD_PROFILE_ID,
+      client_secret_ref: 'old-ref',
+      access_token: 'old-access',
+      refresh_token: 'old-refresh',
+      webhook_subscription_id: null,
+      webhook_expires_at: null,
+      webhook_verification_token: 'old-token',
+      delivery_mode: 'polling',
+      webhook_silent_runs: 0,
+      last_webhook_delivery_at: null,
+    });
+    expect(config.next_subscription_probe_at).toBeTruthy();
+    const probeAt = new Date(config.next_subscription_probe_at).getTime();
+    expect(probeAt).toBeGreaterThan(Date.now());
+    expect(probeAt).toBeLessThanOrEqual(Date.now() + 25 * 60 * 60 * 1000);
+
+    const provider = await tenantTable<any>('email_providers')
+      .where('id', providerId)
+      .first();
+    expect(provider.status).toBe('connected');
+    expect(provider.error_message).toBeNull();
+  });
+
+  it('retry after a compensated failure succeeds and leaves a single coherent row with no duplicate subscriptions', async () => {
+    const providerId = await seedConnectedProvider();
+
+    const deletedSubs: string[] = [];
+    const compensateCalls: MicrosoftEmailWebhookCompensationLedger[] = [];
+    const createdSubs: string[] = [];
+
+    // Attempt 1: setup creates a replacement subscription then explodes. The
+    // compensation deletes the created subscription.
+    await expect(
+      persistMicrosoftEmailOAuthResult(
+        persistParams(providerId, {
+          setupWebhook: async (ctx) => {
+            ctx.webhookCompensation.onSubscriptionDeleted('old-sub');
+            ctx.webhookCompensation.onSubscriptionCreated('new-sub-1');
+            throw new Error('first attempt exploded');
+          },
+          compensateWebhook: async (ledger) => {
+            compensateCalls.push({ ...ledger });
+            deletedSubs.push(...ledger.createdSubscriptionIds);
+          },
+        })
+      )
+    ).rejects.toThrow('first attempt exploded');
+    expect(deletedSubs).toEqual(['new-sub-1']);
+
+    // Attempt 2: the reconnect is retried and completes cleanly with a brand-new
+    // subscription. Compensation must not run again. The setup also persists the
+    // subscription id + webhook delivery mode exactly as registerWebhookSubscription
+    // does against the freshly written config row.
+    await persistMicrosoftEmailOAuthResult(
+      persistParams(providerId, {
+        setupWebhook: async (ctx) => {
+          ctx.webhookCompensation.onSubscriptionDeleted('old-sub');
+          ctx.webhookCompensation.onSubscriptionCreated('new-sub-2');
+          createdSubs.push('new-sub-2');
+          await tenantTable('microsoft_email_provider_config')
+            .where('email_provider_id', providerId)
+            .update({
+              webhook_subscription_id: 'new-sub-2',
+              webhook_expires_at: new Date(Date.now() + 3600000).toISOString(),
+              delivery_mode: 'webhook',
+              webhook_silent_runs: 0,
+              next_subscription_probe_at: null,
+              updated_at: new Date(),
+            });
+        },
+        compensateWebhook: async (ledger) => {
+          compensateCalls.push({ ...ledger });
+        },
+      })
+    );
+
+    // Only one config row exists for the provider — no duplicate rows.
+    const configRows = await tenantTable<any>('microsoft_email_provider_config')
+      .where('email_provider_id', providerId)
+      .select('*');
+    expect(configRows).toHaveLength(1);
+
+    // The final row reflects the successful second attempt, not a mix.
+    expect(configRows[0]).toMatchObject({
+      client_id: 'new-client',
+      client_secret: 'new-secret',
+      microsoft_profile_id: NEW_PROFILE_ID,
+      client_secret_ref: 'new-ref',
+      access_token: 'new-access',
+      refresh_token: 'new-refresh',
+      webhook_subscription_id: 'new-sub-2',
+      delivery_mode: 'webhook',
+    });
+
+    // No duplicate Graph subscriptions: only the second attempt's subscription
+    // is live/recorded, and the first attempt's was compensated away.
+    expect(createdSubs).toEqual(['new-sub-2']);
+    expect(deletedSubs).toEqual(['new-sub-1']);
+    expect(compensateCalls).toHaveLength(1);
+  });
+
   it('persists new tokens and issuer metadata atomically when setup succeeds', async () => {
     const providerId = await seedConnectedProvider();
 
-    await persistMicrosoftEmailOAuthResult({
-      tenant: testTenant,
-      providerId,
-      tokens: {
-        accessToken: 'new-access',
-        refreshToken: 'new-refresh',
-        expiresAt: new Date(Date.now() + 3600000),
-      },
-      issuerMetadata: {
-        client_id: 'new-client',
-        client_secret: 'new-secret',
-        tenant_id: 'new-tenant-id',
-        microsoft_profile_id: NEW_PROFILE_ID,
-        client_secret_ref: 'new-ref',
-      },
-      setupWebhook: async () => {
-        // no-op: setup succeeds, nothing to restore
-      },
-    });
+    await persistMicrosoftEmailOAuthResult(
+      persistParams(providerId, {
+        setupWebhook: async () => {
+          // no-op: setup succeeds, nothing to restore
+        },
+        compensateWebhook: async () => {
+          throw new Error('compensation must not run on success');
+        },
+      })
+    );
 
     const config = await tenantTable<any>('microsoft_email_provider_config')
       .where('email_provider_id', providerId)

--- a/server/src/test/integration/microsoftEmailOAuthResultPersistence.test.ts
+++ b/server/src/test/integration/microsoftEmailOAuthResultPersistence.test.ts
@@ -22,12 +22,54 @@ import {
   persistMicrosoftEmailOAuthResult,
   type MicrosoftEmailWebhookCompensationLedger,
 } from '../../services/email/MicrosoftEmailOAuthResultPersistence';
+import {
+  MicrosoftGraphAdapter,
+  MicrosoftSubscriptionError,
+} from '@alga-psa/shared/services/email/providers/MicrosoftGraphAdapter';
 
 const OLD_PROFILE_ID = '00000000-0000-4000-8000-000000000001';
 const NEW_PROFILE_ID = '00000000-0000-4000-8000-000000000002';
 
 let testDb: Knex;
 let testTenant: string;
+
+/**
+ * A controllable Microsoft Graph HTTP layer for the REAL adapter. `post`
+ * returns an incrementing subscription id exactly like Graph does; `delete`
+ * records what was deleted so the test can assert the compensation really
+ * removed the orphaned subscription.
+ */
+const graphHttp = vi.hoisted(() => {
+  const deletedSubscriptions: string[] = [];
+  const createdSubscriptions: string[] = [];
+  const instance = () => ({
+    get: vi.fn(async () => ({ data: {} })),
+    post: vi.fn(async () => {
+      const id = `new-sub-${createdSubscriptions.length + 1}`;
+      createdSubscriptions.push(id);
+      return {
+        data: { id, expirationDateTime: new Date(Date.now() + 3600000).toISOString() },
+      };
+    }),
+    delete: vi.fn(async (url: string) => {
+      const id = String(url).split('/').filter(Boolean).pop() || '';
+      deletedSubscriptions.push(id);
+      return { data: {} };
+    }),
+    patch: vi.fn(async () => ({ data: {} })),
+    interceptors: { request: { use: vi.fn() } },
+  });
+  return { instance, deletedSubscriptions, createdSubscriptions };
+});
+
+vi.mock('axios', () => ({
+  default: {
+    create: () => graphHttp.instance(),
+    post: vi.fn(async () => ({
+      data: { access_token: 'x', refresh_token: 'y', expires_in: 3600 },
+    })),
+  },
+}));
 
 function tenantTable<Row extends object = Record<string, unknown>>(table: string) {
   return tenantDb(testDb, testTenant).table<Row>(table);
@@ -40,12 +82,15 @@ function tenantFixtureTable() {
   );
 }
 
-// Route the service's connection acquisition at the test database/tenant.
+// Route the service's connection acquisition at the test database/tenant. The
+// real adapter persists its webhook subscription through getAdminConnection(),
+// so that is also pointed at the test database.
 vi.mock('@alga-psa/db', async (importOriginal) => {
   const actual = await importOriginal<typeof import('@alga-psa/db')>();
   return {
     ...actual,
     createTenantKnex: vi.fn(async () => ({ knex: testDb, tenant: testTenant })),
+    getAdminConnection: async () => testDb,
   };
 });
 
@@ -111,6 +156,89 @@ function persistParams(providerId: string, overrides: Record<string, unknown> = 
     },
     ...overrides,
   };
+}
+
+/**
+ * Mirrors the callback route's webhook setup: build a REAL
+ * MicrosoftGraphAdapter against the freshly-persisted rows, wire its Graph
+ * mutations into the compensation ledger, and register the webhook. The
+ * adapter's subscription-id persistence hits real PostgreSQL via the mocked
+ * admin connection (testDb).
+ */
+function realAdapterSetup(ctx: {
+  provider: Record<string, any>;
+  config: Record<string, any>;
+  clientId: string;
+  clientSecret: string;
+  accessToken: string;
+  refreshToken: string | null;
+  expiresAt: Date;
+  webhookCompensation: {
+    onSubscriptionDeleted(subscriptionId: string): void;
+    onSubscriptionCreated(subscriptionId: string): void;
+  };
+}) {
+  const { provider, config, accessToken, refreshToken, expiresAt, webhookCompensation } = ctx;
+  const adapter = new MicrosoftGraphAdapter({
+    id: provider.id,
+    tenant: provider.tenant,
+    name: provider.provider_name || provider.mailbox,
+    provider_type: 'microsoft',
+    mailbox: provider.mailbox,
+    folder_to_monitor: 'Inbox',
+    active: provider.is_active,
+    webhook_notification_url: 'https://psa.example.com/api/email/webhooks/microsoft',
+    webhook_subscription_id: config.webhook_subscription_id || null,
+    webhook_verification_token: config.webhook_verification_token || 'test-token',
+    webhook_expires_at: config.webhook_expires_at || null,
+    provider_config: {
+      client_id: config.client_id,
+      client_secret: config.client_secret,
+      tenant_id: config.tenant_id || null,
+      access_token: accessToken,
+      refresh_token: refreshToken || null,
+      token_expires_at: expiresAt.toISOString(),
+      microsoft_profile_id: config.microsoft_profile_id || undefined,
+      client_secret_ref: config.client_secret_ref || undefined,
+    },
+  } as any);
+  adapter.attachWebhookLifecycle({
+    onSubscriptionDeleted: (subscriptionId) =>
+      webhookCompensation.onSubscriptionDeleted(subscriptionId),
+    onSubscriptionCreated: (subscriptionId) =>
+      webhookCompensation.onSubscriptionCreated(subscriptionId),
+  });
+  return adapter;
+}
+
+const FAILURE_TRIGGER_NAME = 'alga_test_fail_ms_subscription_persist_trigger';
+const FAILURE_FUNCTION_NAME = 'alga_test_fail_ms_subscription_persist';
+// The exact subscription id the mocked Graph `post` returns on its first call.
+const FIRST_ATTEMPT_SUBSCRIPTION_ID = 'new-sub-1';
+
+async function installSubscriptionPersistFailureTrigger(): Promise<void> {
+  await testDb.raw(`
+    CREATE OR REPLACE FUNCTION ${FAILURE_FUNCTION_NAME}() RETURNS trigger AS $$
+    BEGIN
+      IF NEW.webhook_subscription_id = '${FIRST_ATTEMPT_SUBSCRIPTION_ID}' THEN
+        RAISE EXCEPTION 'injected subscription-id persistence failure (${FIRST_ATTEMPT_SUBSCRIPTION_ID})';
+      END IF;
+      RETURN NEW;
+    END;
+    $$ LANGUAGE plpgsql;
+
+    DROP TRIGGER IF EXISTS ${FAILURE_TRIGGER_NAME} ON microsoft_email_provider_config;
+    CREATE TRIGGER ${FAILURE_TRIGGER_NAME}
+    BEFORE UPDATE ON microsoft_email_provider_config
+    FOR EACH ROW EXECUTE FUNCTION ${FAILURE_FUNCTION_NAME}();
+  `);
+}
+
+async function dropSubscriptionPersistFailureTrigger(): Promise<void> {
+  await testDb.raw(`
+    DROP TRIGGER IF EXISTS ${FAILURE_TRIGGER_NAME} ON microsoft_email_provider_config;
+    DROP FUNCTION IF EXISTS ${FAILURE_FUNCTION_NAME}();
+  `);
 }
 
 describe('MicrosoftEmailOAuthResultPersistence (T007 atomicity)', () => {
@@ -348,5 +476,146 @@ describe('MicrosoftEmailOAuthResultPersistence (T007 atomicity)', () => {
       .where('id', providerId)
       .first();
     expect(provider.status).toBe('connected');
+  });
+
+  it('T007c: a REAL subscription-id persistence failure propagates through the real adapter and is compensated (pre-fix code swallows it and fails this test)', async () => {
+    const providerId = await seedConnectedProvider();
+
+    const ledgerSeen: MicrosoftEmailWebhookCompensationLedger[] = [];
+    // A real adapter whose deleteSubscription() records through the mocked
+    // Graph HTTP layer, mirroring the callback route's compensation hook.
+    const compensateWebhook = async (ledger: MicrosoftEmailWebhookCompensationLedger) => {
+      ledgerSeen.push({ ...ledger });
+      const compConfig = await tenantTable<any>('microsoft_email_provider_config')
+        .where('email_provider_id', providerId)
+        .first();
+      const compProvider = await tenantTable<any>('email_providers')
+        .where('id', providerId)
+        .first();
+      const compAdapter = new MicrosoftGraphAdapter({
+        id: compProvider.id,
+        tenant: compProvider.tenant,
+        name: compProvider.provider_name,
+        provider_type: 'microsoft',
+        mailbox: compProvider.mailbox,
+        folder_to_monitor: 'Inbox',
+        active: compProvider.is_active,
+        provider_config: {
+          client_id: compConfig.client_id,
+          client_secret: compConfig.client_secret,
+          tenant_id: compConfig.tenant_id || null,
+          access_token: 'x',
+          refresh_token: 'y',
+          token_expires_at: new Date().toISOString(),
+        },
+      } as any);
+      for (const subscriptionId of ledger.createdSubscriptionIds) {
+        await compAdapter.deleteSubscription(subscriptionId);
+      }
+    };
+
+    await installSubscriptionPersistFailureTrigger();
+    let capturedError: any;
+    try {
+      await persistMicrosoftEmailOAuthResult(
+        persistParams(providerId, {
+          setupWebhook: (ctx) => realAdapterSetup(ctx).registerWebhookSubscription(),
+          compensateWebhook,
+        })
+      );
+    } catch (error) {
+      capturedError = error;
+    } finally {
+      await dropSubscriptionPersistFailureTrigger();
+    }
+
+    // The persistence failure must propagate as a MicrosoftSubscriptionError
+    // (kind 'other', never the 'validation' polling fallback) and keep the
+    // original DB error in its cause chain. Pre-fix, the adapter swallows the
+    // UPDATE failure, so this call resolves and `capturedError` is undefined.
+    expect(capturedError).toBeInstanceOf(MicrosoftSubscriptionError);
+    expect((capturedError as MicrosoftSubscriptionError).kind).toBe('other');
+    expect(String((capturedError as any)?.cause?.message ?? '')).toContain(
+      'injected subscription-id persistence failure'
+    );
+
+    // The adapter created the new subscription and deleted the prior one in
+    // Graph; the compensation then deleted the orphaned new subscription.
+    expect(graphHttp.createdSubscriptions).toEqual([FIRST_ATTEMPT_SUBSCRIPTION_ID]);
+    expect(graphHttp.deletedSubscriptions).toEqual([
+      'old-sub',
+      FIRST_ATTEMPT_SUBSCRIPTION_ID,
+    ]);
+    expect(ledgerSeen).toHaveLength(1);
+    expect(ledgerSeen[0]).toEqual({
+      deletedSubscriptionIds: ['old-sub'],
+      createdSubscriptionIds: [FIRST_ATTEMPT_SUBSCRIPTION_ID],
+    });
+
+    // The row does NOT retain the new subscription id nor the deleted prior id:
+    // it is restored to the prior connected snapshot on coherent polling.
+    const config = await tenantTable<any>('microsoft_email_provider_config')
+      .where('email_provider_id', providerId)
+      .first();
+    expect(config.webhook_subscription_id).not.toBe(FIRST_ATTEMPT_SUBSCRIPTION_ID);
+    expect(config.webhook_subscription_id).not.toBe('old-sub');
+    expect(config).toMatchObject({
+      client_id: 'old-client',
+      client_secret: 'old-secret',
+      microsoft_profile_id: OLD_PROFILE_ID,
+      client_secret_ref: 'old-ref',
+      access_token: 'old-access',
+      refresh_token: 'old-refresh',
+      webhook_subscription_id: null,
+      webhook_expires_at: null,
+      delivery_mode: 'polling',
+      webhook_silent_runs: 0,
+      last_webhook_delivery_at: null,
+    });
+    expect(config.next_subscription_probe_at).toBeTruthy();
+    const probeAt = new Date(config.next_subscription_probe_at).getTime();
+    expect(probeAt).toBeGreaterThan(Date.now());
+    expect(probeAt).toBeLessThanOrEqual(Date.now() + 25 * 60 * 60 * 1000);
+
+    const provider = await tenantTable<any>('email_providers')
+      .where('id', providerId)
+      .first();
+    expect(provider.status).toBe('connected');
+    expect(provider.error_message).toBeNull();
+
+    // RETRY-SAFE: a second callback attempt with the transient failure cleared
+    // completes cleanly — a fresh subscription, no duplicates, no compensation.
+    const createdBeforeRetry = graphHttp.createdSubscriptions.length;
+    const retryLedgers: MicrosoftEmailWebhookCompensationLedger[] = [];
+    await persistMicrosoftEmailOAuthResult(
+      persistParams(providerId, {
+        setupWebhook: (ctx) => realAdapterSetup(ctx).registerWebhookSubscription(),
+        compensateWebhook: async (ledger) => {
+          retryLedgers.push({ ...ledger });
+        },
+      })
+    );
+
+    expect(graphHttp.createdSubscriptions).toEqual([
+      FIRST_ATTEMPT_SUBSCRIPTION_ID,
+      'new-sub-2',
+    ]);
+    expect(graphHttp.createdSubscriptions.length).toBe(createdBeforeRetry + 1);
+    expect(retryLedgers).toHaveLength(0);
+
+    const configRows = await tenantTable<any>('microsoft_email_provider_config')
+      .where('email_provider_id', providerId)
+      .select('*');
+    expect(configRows).toHaveLength(1);
+    expect(configRows[0]).toMatchObject({
+      client_id: 'new-client',
+      client_secret: 'new-secret',
+      microsoft_profile_id: NEW_PROFILE_ID,
+      client_secret_ref: 'new-ref',
+      access_token: 'new-access',
+      refresh_token: 'new-refresh',
+      webhook_subscription_id: 'new-sub-2',
+      delivery_mode: 'webhook',
+    });
   });
 });

--- a/server/src/test/integration/microsoftEmailOAuthResultPersistence.test.ts
+++ b/server/src/test/integration/microsoftEmailOAuthResultPersistence.test.ts
@@ -1,0 +1,199 @@
+/**
+ * T007 — callback persistence atomicity (DB-backed).
+ *
+ * A reconnect whose callback setup fails *after* the token exchange must leave
+ * the previously connected provider fully working: old refresh token, old
+ * client_id/profile pinning, and old subscription state all restored.
+ *
+ * `persistMicrosoftEmailOAuthResult` is the exact function the
+ * /api/auth/microsoft/callback route uses to write tokens and initialize the
+ * webhook. Exercising it against real PostgreSQL with a failing
+ * `setupWebhook` is the behavioral regression for the atomicity requirement.
+ */
+
+import { describe, it, expect, beforeAll, afterAll, vi } from 'vitest';
+import { Knex } from 'knex';
+import { v4 as uuidv4 } from 'uuid';
+import { tenantDb } from '@alga-psa/db';
+import { createTestDbConnection } from '../../../test-utils/dbConfig';
+import { persistMicrosoftEmailOAuthResult } from '../../services/email/MicrosoftEmailOAuthResultPersistence';
+
+const OLD_PROFILE_ID = '00000000-0000-4000-8000-000000000001';
+const NEW_PROFILE_ID = '00000000-0000-4000-8000-000000000002';
+
+let testDb: Knex;
+let testTenant: string;
+
+function tenantTable<Row extends object = Record<string, unknown>>(table: string) {
+  return tenantDb(testDb, testTenant).table<Row>(table);
+}
+
+function tenantFixtureTable() {
+  return tenantDb(testDb, testTenant).unscoped(
+    'tenants',
+    'Microsoft OAuth result persistence test fixture creates and removes tenant rows'
+  );
+}
+
+// Route the service's connection acquisition at the test database/tenant.
+vi.mock('@alga-psa/db', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@alga-psa/db')>();
+  return {
+    ...actual,
+    createTenantKnex: vi.fn(async () => ({ knex: testDb, tenant: testTenant })),
+  };
+});
+
+async function seedConnectedProvider(overrides: { refreshToken?: string; clientId?: string; mailbox?: string } = {}) {
+  const providerId = uuidv4();
+  const now = new Date();
+  const mailbox = overrides.mailbox ?? `reconnect-${uuidv4().slice(0, 8)}@client.com`;
+  await tenantTable('email_providers').insert({
+    id: providerId,
+    tenant: testTenant,
+    provider_type: 'microsoft',
+    provider_name: 'Reconnect Mailbox',
+    mailbox,
+    is_active: true,
+    status: 'connected',
+    error_message: null,
+    created_at: now,
+    updated_at: now,
+  });
+  await tenantTable('microsoft_email_provider_config').insert({
+    email_provider_id: providerId,
+    tenant: testTenant,
+    client_id: overrides.clientId ?? 'old-client',
+    client_secret: 'old-secret',
+    tenant_id: 'old-tenant-id',
+    microsoft_profile_id: OLD_PROFILE_ID,
+    client_secret_ref: 'old-ref',
+    redirect_uri: 'http://localhost:3000/api/auth/microsoft/callback',
+    auto_process_emails: true,
+    max_emails_per_sync: 50,
+    folder_filters: JSON.stringify(['Inbox']),
+    access_token: 'old-access',
+    refresh_token: overrides.refreshToken ?? 'old-refresh',
+    token_expires_at: new Date(Date.now() + 3600000).toISOString(),
+    webhook_subscription_id: 'old-sub',
+    webhook_verification_token: 'old-token',
+    webhook_expires_at: new Date(Date.now() + 7200000).toISOString(),
+    last_subscription_renewal: now,
+    delivery_mode: 'webhook',
+    webhook_silent_runs: 0,
+    next_subscription_probe_at: null,
+    created_at: now,
+    updated_at: now,
+  });
+  return providerId;
+}
+
+describe('MicrosoftEmailOAuthResultPersistence (T007 atomicity)', () => {
+  beforeAll(async () => {
+    testDb = await createTestDbConnection();
+    testTenant = uuidv4();
+    await tenantFixtureTable().insert({
+      tenant: testTenant,
+      client_name: 'Test Client',
+      email: 'test@client.com',
+      created_at: new Date(),
+      updated_at: new Date(),
+    });
+  });
+
+  afterAll(async () => {
+    await tenantTable('microsoft_email_provider_config').delete();
+    await tenantTable('email_providers').delete();
+    await tenantFixtureTable().where('tenant', testTenant).delete();
+    await testDb.destroy();
+  });
+
+  it('T007: a reconnect whose callback setup fails after token exchange leaves the original connection intact and functional', async () => {
+    const providerId = await seedConnectedProvider();
+
+    await expect(
+      persistMicrosoftEmailOAuthResult({
+        tenant: testTenant,
+        providerId,
+        tokens: {
+          accessToken: 'new-access',
+          refreshToken: 'new-refresh',
+          expiresAt: new Date(Date.now() + 3600000),
+        },
+        issuerMetadata: {
+          client_id: 'new-client',
+          client_secret: 'new-secret',
+          tenant_id: 'new-tenant-id',
+          microsoft_profile_id: NEW_PROFILE_ID,
+          client_secret_ref: 'new-ref',
+        },
+        setupWebhook: async () => {
+          throw new Error('webhook registration exploded');
+        },
+      })
+    ).rejects.toThrow('webhook registration exploded');
+
+    // Old credentials, issuer pinning, and subscription state are all restored.
+    const config = await tenantTable<any>('microsoft_email_provider_config')
+      .where('email_provider_id', providerId)
+      .first();
+    expect(config).toMatchObject({
+      client_id: 'old-client',
+      client_secret: 'old-secret',
+      tenant_id: 'old-tenant-id',
+      microsoft_profile_id: OLD_PROFILE_ID,
+      client_secret_ref: 'old-ref',
+      access_token: 'old-access',
+      refresh_token: 'old-refresh',
+      webhook_subscription_id: 'old-sub',
+      webhook_verification_token: 'old-token',
+      delivery_mode: 'webhook',
+    });
+
+    const provider = await tenantTable<any>('email_providers')
+      .where('id', providerId)
+      .first();
+    expect(provider.status).toBe('connected');
+    expect(provider.error_message).toBeNull();
+  });
+
+  it('persists new tokens and issuer metadata atomically when setup succeeds', async () => {
+    const providerId = await seedConnectedProvider();
+
+    await persistMicrosoftEmailOAuthResult({
+      tenant: testTenant,
+      providerId,
+      tokens: {
+        accessToken: 'new-access',
+        refreshToken: 'new-refresh',
+        expiresAt: new Date(Date.now() + 3600000),
+      },
+      issuerMetadata: {
+        client_id: 'new-client',
+        client_secret: 'new-secret',
+        tenant_id: 'new-tenant-id',
+        microsoft_profile_id: NEW_PROFILE_ID,
+        client_secret_ref: 'new-ref',
+      },
+      setupWebhook: async () => {
+        // no-op: setup succeeds, nothing to restore
+      },
+    });
+
+    const config = await tenantTable<any>('microsoft_email_provider_config')
+      .where('email_provider_id', providerId)
+      .first();
+    expect(config).toMatchObject({
+      client_id: 'new-client',
+      access_token: 'new-access',
+      refresh_token: 'new-refresh',
+      microsoft_profile_id: NEW_PROFILE_ID,
+      client_secret_ref: 'new-ref',
+    });
+
+    const provider = await tenantTable<any>('email_providers')
+      .where('id', providerId)
+      .first();
+    expect(provider.status).toBe('connected');
+  });
+});

--- a/server/src/test/integration/microsoftEmailOAuthStateRelationshipDb.test.ts
+++ b/server/src/test/integration/microsoftEmailOAuthStateRelationshipDb.test.ts
@@ -1,0 +1,293 @@
+/**
+ * Callback relationship validation against real PostgreSQL.
+ *
+ * The /api/auth/microsoft/callback route verifies every relationship signed
+ * into the OAuth state before touching credentials. It loads the referenced
+ * `email_providers` row plus the persisted refresh-token flag exactly as shown
+ * here and feeds them to `verifyMicrosoftEmailOAuthStateRelationships`. This
+ * suite seeds real rows and reuses that same load path so each rejection code
+ * is demonstrated against real provider state, not a hand-built object.
+ */
+
+import { describe, it, expect, beforeAll, afterAll, vi } from 'vitest';
+import { Knex } from 'knex';
+import { v4 as uuidv4 } from 'uuid';
+import { tenantDb } from '@alga-psa/db';
+import { createTestDbConnection } from '../../../test-utils/dbConfig';
+import { verifyMicrosoftEmailOAuthStateRelationships } from '@alga-psa/integrations/lib/microsoftEmailStateGuard';
+import { MICROSOFT_EMAIL_ISSUER_ERRORS } from '@alga-psa/integrations/lib/microsoftEmailIssuerSelection';
+import type { MicrosoftEmailOAuthStatePayload } from '@alga-psa/integrations/utils/email/microsoftEmailOAuthState';
+
+let testDb: Knex;
+let testTenant: string;
+let connectedProviderId: string;
+const createdTenants: string[] = [];
+
+function tenantTable<Row extends object = Record<string, unknown>>(table: string) {
+  return tenantDb(testDb, testTenant).table<Row>(table);
+}
+
+function tenantFixtureTable() {
+  return tenantDb(testDb, testTenant).unscoped(
+    'tenants',
+    'Microsoft email OAuth state relationship test fixture creates and removes tenant rows'
+  );
+}
+
+vi.mock('@alga-psa/db', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@alga-psa/db')>();
+  return {
+    ...actual,
+    createTenantKnex: vi.fn(async () => ({ knex: testDb, tenant: testTenant })),
+  };
+});
+
+/** Mirrors the provider context the callback loads before the relationship guard. */
+async function loadStateProvider(providerId: string | null | undefined, tenantScope: string = testTenant) {
+  if (!providerId) return null;
+  const db = tenantDb(testDb, tenantScope);
+  const providerRow = await db.table('email_providers')
+    .where('id', providerId)
+    .select('id', 'tenant', 'provider_type', 'status')
+    .first();
+  if (!providerRow) return null;
+  const configRow = await db.table('microsoft_email_provider_config')
+    .where('email_provider_id', providerId)
+    .select('refresh_token')
+    .first();
+  return {
+    id: providerRow.id,
+    tenant: providerRow.tenant,
+    provider_type: providerRow.provider_type,
+    status: providerRow.status,
+    refresh_token: configRow?.refresh_token ?? null,
+  };
+}
+
+function signedPayload(overrides: Partial<MicrosoftEmailOAuthStatePayload> = {}): MicrosoftEmailOAuthStatePayload {
+  return {
+    purpose: 'reconnect',
+    tenant: testTenant,
+    userId: 'user-1',
+    issuerKind: 'managed',
+    clientId: 'managed-client',
+    redirectUri: 'https://psa.example.com/api/auth/microsoft/callback',
+    nonce: 'nonce-1',
+    issuedAt: Math.floor(Date.now() / 1000) - 5,
+    expiresAt: Math.floor(Date.now() / 1000) + 300,
+    ...overrides,
+  };
+}
+
+function sessionUser(overrides: Record<string, unknown> = {}) {
+  return { user_id: 'user-1', tenant: testTenant, ...overrides };
+}
+
+async function seedProvider(overrides: {
+  tenant?: string;
+  providerType?: string;
+  refreshToken?: string | null;
+} = {}) {
+  const providerId = uuidv4();
+  const now = new Date();
+  const ownerTenant = overrides.tenant ?? testTenant;
+  // `email_providers.tenant` is a FK into the tenants table; the provider (and
+  // its config) must live in the tenant that owns it.
+  await tenantFixtureTable()
+    .insert({
+      tenant: ownerTenant,
+      client_name: 'Relationship Other Client',
+      email: 'other@client.com',
+      created_at: now,
+      updated_at: now,
+    })
+    .onConflict('tenant')
+    .ignore();
+  if (!createdTenants.includes(ownerTenant)) createdTenants.push(ownerTenant);
+
+  const ownerDb = ownerTenant === testTenant
+    ? tenantTable
+    : (table: string) => tenantDb(testDb, ownerTenant).table(table);
+
+  await ownerDb('email_providers').insert({
+    id: providerId,
+    tenant: ownerTenant,
+    provider_type: overrides.providerType ?? 'microsoft',
+    provider_name: 'Relationship Mailbox',
+    mailbox: `relationship-${uuidv4().slice(0, 8)}@client.com`,
+    is_active: true,
+    status: overrides.refreshToken ? 'connected' : 'configuring',
+    error_message: null,
+    created_at: now,
+    updated_at: now,
+  });
+  await ownerDb('microsoft_email_provider_config').insert({
+    email_provider_id: providerId,
+    tenant: ownerTenant,
+    client_id: 'client-id',
+    client_secret: 'client-secret',
+    tenant_id: 'tenant-id',
+    microsoft_profile_id: null,
+    client_secret_ref: null,
+    redirect_uri: 'http://localhost:3000/api/auth/microsoft/callback',
+    auto_process_emails: true,
+    max_emails_per_sync: 50,
+    folder_filters: JSON.stringify(['Inbox']),
+    access_token: 'access',
+    refresh_token: overrides.refreshToken === null ? null : (overrides.refreshToken ?? 'refresh-token'),
+    token_expires_at: new Date(Date.now() + 3600000).toISOString(),
+    webhook_subscription_id: 'sub',
+    webhook_verification_token: 'token',
+    webhook_expires_at: new Date(Date.now() + 7200000).toISOString(),
+    last_subscription_renewal: now,
+    delivery_mode: 'webhook',
+    webhook_silent_runs: 0,
+    next_subscription_probe_at: null,
+    created_at: now,
+    updated_at: now,
+  });
+  return providerId;
+}
+
+describe('Microsoft email OAuth callback relationship validation (DB-backed)', () => {
+  beforeAll(async () => {
+    testDb = await createTestDbConnection();
+    testTenant = uuidv4();
+    await tenantFixtureTable().insert({
+      tenant: testTenant,
+      client_name: 'Relationship Test Client',
+      email: 'relationship@client.com',
+      created_at: new Date(),
+      updated_at: new Date(),
+    });
+    connectedProviderId = await seedProvider();
+  });
+
+  afterAll(async () => {
+    // Delete provider rows in every tenant created by this suite (the fixture
+    // seeds cross-tenant providers), then the tenant rows themselves.
+    for (const tenant of createdTenants) {
+      const db = tenantDb(testDb, tenant);
+      await db.table('microsoft_email_provider_config').delete();
+      await db.table('email_providers').delete();
+    }
+    await tenantFixtureTable().whereIn('tenant', createdTenants).delete();
+    await testDb.destroy();
+  });
+
+  it('accepts a reconnect state whose relationships all hold against real rows', async () => {
+    const guard = verifyMicrosoftEmailOAuthStateRelationships({
+      payload: signedPayload({ purpose: 'reconnect', providerId: connectedProviderId }),
+      sessionUser: sessionUser(),
+      provider: await loadStateProvider(connectedProviderId),
+    });
+    expect(guard).toEqual({ ok: true });
+  });
+
+  it('rejects a state naming a provider that does not exist', async () => {
+    const guard = verifyMicrosoftEmailOAuthStateRelationships({
+      payload: signedPayload({ purpose: 'reconnect', providerId: uuidv4() }),
+      sessionUser: sessionUser(),
+      provider: await loadStateProvider(uuidv4()),
+    });
+    expect(guard).toMatchObject({ ok: false, code: MICROSOFT_EMAIL_ISSUER_ERRORS.PROVIDER_NOT_FOUND });
+  });
+
+  it('rejects a state naming a provider that belongs to another tenant', async () => {
+    const otherTenant = uuidv4();
+    // The provider physically lives in the other tenant's schema, so the state
+    // signed for our tenant cannot legally reference it.
+    const crossTenantProviderId = await seedProvider({ tenant: otherTenant });
+    const guard = verifyMicrosoftEmailOAuthStateRelationships({
+      payload: signedPayload({ purpose: 'reconnect', providerId: crossTenantProviderId }),
+      sessionUser: sessionUser(),
+      provider: await loadStateProvider(crossTenantProviderId, otherTenant),
+    });
+    expect(guard).toMatchObject({ ok: false, code: MICROSOFT_EMAIL_ISSUER_ERRORS.PROVIDER_TENANT_MISMATCH });
+  });
+
+  it('rejects a state naming a non-Microsoft provider', async () => {
+    const googleProviderId = await seedProvider({ providerType: 'google' });
+    const guard = verifyMicrosoftEmailOAuthStateRelationships({
+      payload: signedPayload({ purpose: 'reconnect', providerId: googleProviderId }),
+      sessionUser: sessionUser(),
+      provider: await loadStateProvider(googleProviderId),
+    });
+    expect(guard).toMatchObject({ ok: false, code: MICROSOFT_EMAIL_ISSUER_ERRORS.PROVIDER_TYPE_NOT_SUPPORTED });
+  });
+
+  it('rejects a create state aimed at an already-connected provider', async () => {
+    const guard = verifyMicrosoftEmailOAuthStateRelationships({
+      payload: signedPayload({ purpose: 'create', providerId: connectedProviderId }),
+      sessionUser: sessionUser(),
+      provider: await loadStateProvider(connectedProviderId),
+    });
+    expect(guard).toMatchObject({ ok: false, code: MICROSOFT_EMAIL_ISSUER_ERRORS.STATE_PURPOSE_MISMATCH });
+  });
+
+  it('rejects a reconnect state that does not name a provider', async () => {
+    const guard = verifyMicrosoftEmailOAuthStateRelationships({
+      payload: signedPayload({ purpose: 'reconnect' }),
+      sessionUser: sessionUser(),
+      provider: null,
+    });
+    expect(guard).toMatchObject({ ok: false, code: MICROSOFT_EMAIL_ISSUER_ERRORS.STATE_PURPOSE_MISMATCH });
+  });
+
+  it('rejects when the session user differs from the user signed into the state', async () => {
+    const guard = verifyMicrosoftEmailOAuthStateRelationships({
+      payload: signedPayload({ purpose: 'reconnect', providerId: connectedProviderId }),
+      sessionUser: sessionUser({ user_id: 'attacker-user' }),
+      provider: await loadStateProvider(connectedProviderId),
+    });
+    expect(guard).toMatchObject({ ok: false, code: MICROSOFT_EMAIL_ISSUER_ERRORS.STATE_USER_MISMATCH });
+  });
+
+  it('rejects when the session tenant does not match the state tenant', async () => {
+    const guard = verifyMicrosoftEmailOAuthStateRelationships({
+      payload: signedPayload({ purpose: 'reconnect', providerId: connectedProviderId }),
+      sessionUser: sessionUser({ tenant: 'some-other-workspace' }),
+      provider: await loadStateProvider(connectedProviderId),
+    });
+    expect(guard).toMatchObject({ ok: false, code: MICROSOFT_EMAIL_ISSUER_ERRORS.INVALID_STATE });
+  });
+
+  it('rejects with a distinct code for each guarded failure mode', async () => {
+    const otherTenant = uuidv4();
+    const crossTenantProviderId = await seedProvider({ tenant: otherTenant });
+    const googleProviderId = await seedProvider({ providerType: 'google' });
+    const cases = [
+      verifyMicrosoftEmailOAuthStateRelationships({
+        payload: signedPayload({ purpose: 'reconnect', providerId: uuidv4() }),
+        sessionUser: sessionUser(),
+        provider: null,
+      }),
+      verifyMicrosoftEmailOAuthStateRelationships({
+        payload: signedPayload({ purpose: 'reconnect', providerId: crossTenantProviderId }),
+        sessionUser: sessionUser(),
+        provider: await loadStateProvider(crossTenantProviderId, otherTenant),
+      }),
+      verifyMicrosoftEmailOAuthStateRelationships({
+        payload: signedPayload({ purpose: 'reconnect', providerId: googleProviderId }),
+        sessionUser: sessionUser(),
+        provider: await loadStateProvider(googleProviderId),
+      }),
+      verifyMicrosoftEmailOAuthStateRelationships({
+        payload: signedPayload({ purpose: 'create', providerId: connectedProviderId }),
+        sessionUser: sessionUser(),
+        provider: await loadStateProvider(connectedProviderId),
+      }),
+      verifyMicrosoftEmailOAuthStateRelationships({
+        payload: signedPayload({ purpose: 'reconnect', providerId: connectedProviderId }),
+        sessionUser: sessionUser({ user_id: 'attacker-user' }),
+        provider: await loadStateProvider(connectedProviderId),
+      }),
+      verifyMicrosoftEmailOAuthStateRelationships({
+        payload: signedPayload({ purpose: 'reconnect', providerId: connectedProviderId }),
+        sessionUser: sessionUser({ tenant: 'other-workspace' }),
+        provider: await loadStateProvider(connectedProviderId),
+      }),
+    ].map((r) => (r.ok ? 'ok' : r.code));
+    expect(new Set(cases).size).toBe(cases.length);
+  });
+});

--- a/server/src/test/integration/microsoftEmailRuntimePinning.integration.test.ts
+++ b/server/src/test/integration/microsoftEmailRuntimePinning.integration.test.ts
@@ -1,0 +1,411 @@
+/**
+ * Blocker 3 — issuer pinning through every inbound email runtime.
+ *
+ * A provider pinned to a Microsoft profile (`microsoft_profile_id` +
+ * `client_secret_ref` on `microsoft_email_provider_config`) must resolve its
+ * Graph credentials ONLY through that profile in every runtime that mints or
+ * refreshes tokens, and must FAIL CLOSED (`ms_email_provider_not_found` /
+ * `ms_email_client_mismatch_reconnect_required`) when the pin is unresolvable
+ * — never a silent fallback to the tenant Email binding.
+ *
+ * These tests exercise the real production entrypoints against real
+ * PostgreSQL:
+ *   - the unified-queue worker (`processUnifiedInboundEmailQueueJob`) token
+ *     path, and
+ *   - artifact/attachment processing (`processInboundEmailArtifactsBestEffort`
+ *     original-email download path).
+ *
+ * The Graph adapter is stubbed (no live Microsoft calls); the provider config
+ * resolution — including which profile the resolver used — is real.
+ */
+
+import { describe, it, expect, beforeAll, afterAll, vi, beforeEach } from 'vitest';
+import type { Knex } from 'knex';
+import fs from 'node:fs';
+import path from 'node:path';
+import { v4 as uuidv4 } from 'uuid';
+import { tenantDb } from '@alga-psa/db';
+import { createTestDbConnection } from '../../../test-utils/dbConfig';
+import { processUnifiedInboundEmailQueueJob } from '@alga-psa/shared/services/email/unifiedInboundEmailQueueJobProcessor';
+import { processInboundEmailArtifactsBestEffort } from '@alga-psa/shared/services/email/processInboundEmailArtifacts';
+
+let testDb: Knex;
+let testTenant: string;
+let profileId: string;
+let profileSecretRef: string;
+let systemUserId: string;
+
+const tenantSecrets = new Map<string, string>();
+const capturedAdapterConfigs: any[] = [];
+
+function tenantTable<Row = Record<string, unknown>>(table: string) {
+  return tenantDb(testDb, testTenant).table<Row>(table);
+}
+
+function tenantFixtureTable() {
+  return tenantDb(testDb, testTenant).unscoped(
+    'tenants',
+    'Microsoft email runtime pinning test fixture creates and removes tenant rows'
+  );
+}
+
+vi.mock('redis', () => ({
+  createClient: () => {
+    throw new Error('redis unavailable in Microsoft email runtime pinning tests');
+  },
+}));
+
+vi.mock('@alga-psa/db', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@alga-psa/db')>();
+  return {
+    ...actual,
+    createTenantKnex: async () => ({ knex: testDb, tenant: testTenant }),
+    getConnection: async () => testDb,
+  };
+});
+
+vi.mock('@alga-psa/db/admin', () => ({
+  getAdminConnection: async () => testDb,
+}));
+
+vi.mock('@alga-psa/core/secrets', () => ({
+  getSecret: async (_name: string, envVar?: string, fallback = '') =>
+    (envVar ? process.env[envVar] : undefined) ?? fallback,
+  getSecretProviderInstance: async () => ({
+    getTenantSecret: async (tenant: string, key: string) =>
+      tenantSecrets.get(`${tenant}:${key}`) || undefined,
+    setTenantSecret: async () => undefined,
+    getAppSecret: async () => undefined,
+  }),
+}));
+
+vi.mock('@alga-psa/shared/services/email/providers/MicrosoftGraphAdapter', () => ({
+  MicrosoftSubscriptionError: class MicrosoftSubscriptionError extends Error {
+    constructor(public kind: string, message: string) {
+      super(message);
+    }
+  },
+  MicrosoftGraphAdapter: class MicrosoftGraphAdapter {
+    constructor(public config: Record<string, any>) {
+      capturedAdapterConfigs.push(config);
+    }
+    async connect() {}
+    async downloadAttachmentBytes() {
+      return { buffer: Buffer.from('attachment bytes', 'utf8'), contentType: 'text/plain', fileName: 'a.txt' };
+    }
+    async downloadMessageSource() {
+      return Buffer.from(
+        'From: sender@example.com\r\nTo: support@example.com\r\nSubject: Hello\r\n\r\nbody',
+        'utf8'
+      );
+    }
+  },
+}));
+
+// The unified queue worker continues into in-app processing after fetching the
+// message. That flow is covered by its own suites; here the resolver/token path
+// is the unit under test, so the rest is a deterministic stub.
+vi.mock('@alga-psa/shared/services/email/processInboundEmailInApp', () => ({
+  processInboundEmailInApp: async () => ({
+    outcome: 'created',
+    ticketId: '00000000-0000-4000-8000-0000000000aa',
+    diagnostics: { outcome: { kind: 'created' } },
+  }),
+}));
+
+// Artifact persistence uploads to object storage; stub it like the existing
+// attachment-ingestion suite so the download/resolution path (the unit under
+// test) is exercised without a live storage backend.
+vi.mock('@alga-psa/storage', () => ({
+  StorageProviderFactory: {
+    createProvider: async () => ({
+      upload: async (file: Buffer, filePath: string) => ({
+        path: filePath,
+        size: file.length,
+      }),
+    }),
+    clearProvider: vi.fn(),
+  },
+  generateStoragePath: (_tenant: string, _basePath: string, originalFilename: string) =>
+    `test/${originalFilename}`,
+}));
+
+async function seedProfile(overrides: Record<string, unknown> = {}): Promise<string> {
+  const id = uuidv4();
+  const secretRef = `microsoft_profile_${id}_client_secret`;
+  const clientId = String(overrides.client_id ?? 'profile-client-id');
+  const displayName = String(overrides.display_name ?? `Runtime Email App ${id.slice(0, 8)}`);
+  await tenantTable('microsoft_profiles').insert({
+    tenant: testTenant,
+    profile_id: id,
+    display_name: displayName,
+    display_name_normalized: displayName.toLowerCase(),
+    client_id: clientId,
+    tenant_id: 'directory-tenant-guid',
+    client_secret_ref: secretRef,
+    capabilities: JSON.stringify(['email']),
+    is_default: true,
+    is_archived: false,
+    archived_at: null,
+    created_by: null,
+    updated_by: null,
+    created_at: new Date(),
+    updated_at: new Date(),
+    ...overrides,
+  });
+  tenantSecrets.set(`${testTenant}:${secretRef}`, 'profile-secret-value');
+  return id;
+}
+
+async function seedPinnedProvider(overrides: {
+  clientId?: string;
+  profileId?: string | null;
+  clientSecretRef?: string | null;
+  active?: boolean;
+} = {}): Promise<string> {
+  const providerId = uuidv4();
+  const now = new Date();
+  const pinnedProfileId = overrides.profileId === undefined ? profileId : overrides.profileId;
+  const pinnedRef = overrides.clientSecretRef === undefined ? profileSecretRef : overrides.clientSecretRef;
+  await tenantTable('email_providers').insert({
+    id: providerId,
+    tenant: testTenant,
+    provider_type: 'microsoft',
+    provider_name: 'Runtime Mailbox',
+    mailbox: `runtime-${providerId.slice(0, 8)}@client.com`,
+    is_active: overrides.active ?? true,
+    status: 'connected',
+    inbound_paused_at: null,
+    error_message: null,
+    created_at: now,
+    updated_at: now,
+  });
+  await tenantTable('microsoft_email_provider_config').insert({
+    email_provider_id: providerId,
+    tenant: testTenant,
+    client_id: overrides.clientId ?? 'profile-client-id',
+    client_secret: 'stored-secret',
+    tenant_id: 'directory-tenant-guid',
+    microsoft_profile_id: pinnedProfileId,
+    client_secret_ref: pinnedRef,
+    redirect_uri: 'https://psa.example.com/api/auth/microsoft/callback',
+    auto_process_emails: true,
+    max_emails_per_sync: 50,
+    folder_filters: JSON.stringify(['Inbox']),
+    access_token: 'runtime-access',
+    refresh_token: 'runtime-refresh',
+    token_expires_at: new Date(Date.now() + 3600000).toISOString(),
+    webhook_subscription_id: 'sub-1',
+    webhook_verification_token: 'token',
+    webhook_expires_at: new Date(Date.now() + 7200000).toISOString(),
+    last_subscription_renewal: now,
+    delivery_mode: 'webhook',
+    webhook_silent_runs: 0,
+    next_subscription_probe_at: null,
+    created_at: now,
+    updated_at: now,
+  });
+  return providerId;
+}
+
+async function seedUser(): Promise<string> {
+  const userId = uuidv4();
+  await tenantTable('users').insert({
+    tenant: testTenant,
+    user_id: userId,
+    username: `runtime-${userId.slice(0, 8)}`,
+    hashed_password: 'unused',
+    user_type: 'internal',
+    email: `runtime-${userId.slice(0, 8)}@test.co`,
+    created_at: new Date(),
+    updated_at: new Date(),
+  });
+  return userId;
+}
+
+function unifiedJob(providerId: string) {
+  return {
+    jobId: `job-${uuidv4()}`,
+    tenantId: testTenant,
+    providerId,
+    provider: 'microsoft',
+    pointer: {
+      subscriptionId: 'sub-1',
+      messageId: 'msg-1',
+      resource: '/users/user-1/messages/msg-1',
+      changeType: 'created',
+    },
+  } as const;
+}
+
+describe('Microsoft inbound email runtime issuer pinning (DB-backed)', () => {
+  beforeAll(async () => {
+    const secretsDir = path.resolve(__dirname, '../../../../secrets');
+    const readSecret = (name: string) => {
+      try {
+        return fs.readFileSync(path.join(secretsDir, name), 'utf8').trim();
+      } catch {
+        return undefined;
+      }
+    };
+    // Override unconditionally: .env.localtest points DB_PASSWORD_* at container
+    // secret paths that do not exist on this host, and the secrets provider is
+    // mocked below, so getSecret() falls back to these env vars.
+    process.env.DB_HOST = '127.0.0.1';
+    process.env.DB_PORT = '5472';
+    process.env.DB_USER_ADMIN = 'postgres';
+    process.env.DB_USER_SERVER = 'app_user';
+    process.env.DB_PASSWORD_ADMIN = readSecret('postgres_password') || 'postpass123';
+    process.env.DB_PASSWORD_SERVER = readSecret('db_password_server') || 'postpass123';
+    process.env.NODE_ENV = 'test';
+
+    testDb = await createTestDbConnection();
+    testTenant = uuidv4();
+    await tenantFixtureTable().insert({
+      tenant: testTenant,
+      client_name: 'Runtime Pinning Test Client',
+      email: 'runtime-pinning@client.com',
+      created_at: new Date(),
+      updated_at: new Date(),
+    });
+    systemUserId = await seedUser();
+    profileId = await seedProfile();
+    profileSecretRef = `microsoft_profile_${profileId}_client_secret`;
+  }, 180_000);
+
+  afterAll(async () => {
+    if (testTenant) {
+      const docIds = (
+        await tenantTable('documents').select('document_id')
+      ).map((row: any) => row.document_id);
+      if (docIds.length > 0) {
+        for (const table of ['document_associations', 'document_versions', 'document_content', 'document_block_content']) {
+          await tenantTable(table).whereIn('document_id', docIds).delete();
+        }
+        await tenantTable('documents').whereIn('document_id', docIds).delete();
+      }
+      await tenantTable('external_files').delete();
+      await tenantTable('document_folders').delete();
+      await tenantTable('email_processed_attachments').delete();
+      await tenantTable('email_processed_messages').delete();
+      await tenantTable('microsoft_email_provider_config').delete();
+      await tenantTable('email_providers').delete();
+      await tenantTable('microsoft_profiles').delete();
+      await tenantTable('users').delete();
+      await tenantFixtureTable().where('tenant', testTenant).delete();
+    }
+    await testDb?.destroy().catch(() => undefined);
+  }, 30_000);
+
+  beforeEach(() => {
+    capturedAdapterConfigs.length = 0;
+  });
+
+  describe('unified queue worker token path', () => {
+    it('resolves a pinned provider through its profile (resolved_profile_id + client_secret_ref)', async () => {
+      const providerId = await seedPinnedProvider();
+
+      const result = await processUnifiedInboundEmailQueueJob(unifiedJob(providerId));
+
+      expect(result.outcome).toBe('processed');
+      const config = capturedAdapterConfigs[capturedAdapterConfigs.length - 1];
+      expect(config.provider_config).toMatchObject({
+        resolved_profile_id: profileId,
+        resolved_client_secret_ref: profileSecretRef,
+        resolved_client_id: 'profile-client-id',
+        resolved_credential_source: 'profile',
+      });
+    });
+
+    it('fails closed when the pinned profile no longer exists (ms_email_provider_not_found)', async () => {
+      const missingProfileId = uuidv4();
+      const providerId = await seedPinnedProvider({ profileId: missingProfileId });
+
+      await expect(processUnifiedInboundEmailQueueJob(unifiedJob(providerId))).rejects.toThrow(
+        /ms_email_provider_not_found/
+      );
+    });
+
+    it('fails closed when the pinned profile exists but its app disagrees with the persisted client id (ms_email_client_mismatch_reconnect_required)', async () => {
+      const mismatchProfileId = await seedProfile({
+        client_id: 'a-different-app-client-id',
+        is_default: false,
+      });
+      const providerId = await seedPinnedProvider({ profileId: mismatchProfileId });
+
+      await expect(processUnifiedInboundEmailQueueJob(unifiedJob(providerId))).rejects.toThrow(
+        /ms_email_client_mismatch_reconnect_required/
+      );
+    });
+  });
+
+  describe('artifact / attachment processing token path', () => {
+    it('resolves a pinned provider through its profile when downloading the original email source', async () => {
+      const providerId = await seedPinnedProvider();
+      const emailId = `source-${uuidv4()}@example.com`;
+
+      await processInboundEmailArtifactsBestEffort({
+        tenantId: testTenant,
+        providerId,
+        ticketId: uuidv4(),
+        scopeLabel: 'reply',
+        emailData: {
+          id: emailId,
+          from: { email: 'from@example.com', name: 'From' },
+          to: [{ email: 'to@example.com', name: 'To' }],
+          subject: 'Artifact pinning',
+          body: { text: 'body' },
+          receivedAt: new Date().toISOString(),
+        },
+      });
+
+      const config = capturedAdapterConfigs[capturedAdapterConfigs.length - 1];
+      expect(config.provider_config).toMatchObject({
+        resolved_profile_id: profileId,
+        resolved_client_secret_ref: profileSecretRef,
+        resolved_client_id: 'profile-client-id',
+        resolved_credential_source: 'profile',
+      });
+
+      const originalRow = await tenantTable<any>('email_processed_attachments')
+        .where({ provider_id: providerId, email_id: emailId })
+        .first();
+      expect(originalRow?.processing_status).toBe('success');
+    });
+
+    it('fails closed (no binding fallback) when the pinned profile is missing — attachment marked failed, no document', async () => {
+      const missingProfileId = uuidv4();
+      const providerId = await seedPinnedProvider({ profileId: missingProfileId });
+      const emailId = `source-missing-${uuidv4()}@example.com`;
+      const docsBefore = (await tenantTable<any>('documents').count<{ count: string }>('* as count').first())?.count;
+
+      const result = await processInboundEmailArtifactsBestEffort({
+        tenantId: testTenant,
+        providerId,
+        ticketId: uuidv4(),
+        scopeLabel: 'new-ticket',
+        emailData: {
+          id: emailId,
+          from: { email: 'from@example.com', name: 'From' },
+          to: [{ email: 'to@example.com', name: 'To' }],
+          subject: 'Missing pin',
+          body: { text: 'body' },
+          receivedAt: new Date().toISOString(),
+        },
+      });
+
+      // processInboundEmailArtifactsBestEffort is best-effort: the download
+      // failure is recorded on the attachment row, not thrown.
+      expect(result.embeddedImageUrlMappings).toEqual([]);
+
+      const originalRow = await tenantTable<any>('email_processed_attachments')
+        .where({ provider_id: providerId, email_id: emailId })
+        .first();
+      expect(originalRow?.processing_status).toBe('failed');
+      expect(String(originalRow?.error_message)).toContain('ms_email_provider_not_found');
+
+      const docsAfter = (await tenantTable<any>('documents').count<{ count: string }>('* as count').first())?.count;
+      expect(Number(docsAfter ?? 0)).toBe(Number(docsBefore ?? 0));
+    });
+  });
+});

--- a/server/src/test/integration/microsoftEmailSameAppUpdate.integration.test.ts
+++ b/server/src/test/integration/microsoftEmailSameAppUpdate.integration.test.ts
@@ -1,0 +1,405 @@
+/**
+ * Same-app Update Provider webhook-subscription persistence (DB-backed).
+ *
+ * An ordinary update of a connected Microsoft provider with its already-current
+ * app runs full webhook replacement through the REAL `updateEmailProvider`
+ * server action: delete the prior Graph subscription, create a replacement,
+ * persist it, and mark the provider connected. The provider must never land in
+ * Error, and no nonexistent `microsoft_email_provider_config` column may ever
+ * reach an UPDATE.
+ *
+ * Regression this guards (found live on HEAD 436ac967d1): after a successful
+ * webhook replacement, `initializeProviderWebhook` called
+ * `EmailProviderService.updateProvider` with `vendorConfig:
+ * { ...provider_config, subscriptionId }`; `subscriptionId` is not a column, so
+ * Postgres rejected the UPDATE, the action's catch marked the provider Error,
+ * and the replacement Graph subscription id was never persisted a second time.
+ * The adapter already persists `webhook_subscription_id`/`webhook_expires_at`
+ * inside `registerWebhookSubscription` and rethrows DB failures so the
+ * compensation ledger can delete the orphaned Graph subscription.
+ */
+
+import { describe, it, expect, beforeAll, afterAll, beforeEach, vi } from 'vitest';
+import type { Knex } from 'knex';
+import fs from 'node:fs';
+import path from 'node:path';
+import { v4 as uuidv4 } from 'uuid';
+import { tenantDb } from '@alga-psa/db';
+import { createTestDbConnection } from '../../../test-utils/dbConfig';
+import { updateEmailProvider } from '@alga-psa/integrations/actions/email-actions/emailProviderActions';
+import { EmailProviderService } from '@alga-psa/integrations/services/email/EmailProviderService';
+
+const PROFILE_CLIENT_ID = '11111111-aaaa-2222-bbbb-333333333333';
+const PROFILE_TENANT_ID = 'directory-tenant-guid';
+const PROFILE_SECRET = 'profile-secret-value';
+const PRIOR_SUBSCRIPTION_ID = 'old-sub';
+
+const testContext = vi.hoisted(() => ({
+  tenant: '',
+  appSecrets: new Map<string, string>(),
+  tenantSecrets: new Map<string, string>(),
+}));
+
+// The global test setup mocks `@alga-psa/auth` and resolves the authenticated
+// tenant through server/src/lib/db's getCurrentTenantId; point that at the test
+// tenant so the real `updateEmailProvider` action runs in our workspace.
+vi.mock('../../lib/db', () => ({
+  getCurrentTenantId: () => testContext.tenant,
+  createTenantKnex: vi.fn(async () => ({ knex: testDb, tenant: testContext.tenant })),
+}));
+
+/**
+ * A controllable Microsoft Graph HTTP layer for the REAL adapter. `post`
+ * returns an incrementing subscription id exactly like Graph does; `delete`
+ * records what was deleted so the test can assert the prior subscription was
+ * removed and the replacement was created exactly once.
+ */
+const graphHttp = vi.hoisted(() => {
+  const deletedSubscriptions: string[] = [];
+  const createdSubscriptions: string[] = [];
+  const instance = () => ({
+    get: vi.fn(async () => ({ data: {} })),
+    post: vi.fn(async () => {
+      const id = `new-sub-${createdSubscriptions.length + 1}`;
+      createdSubscriptions.push(id);
+      return {
+        data: { id, expirationDateTime: new Date(Date.now() + 3600000).toISOString() },
+      };
+    }),
+    delete: vi.fn(async (url: string) => {
+      const id = String(url).split('/').filter(Boolean).pop() || '';
+      deletedSubscriptions.push(id);
+      return { data: {} };
+    }),
+    patch: vi.fn(async () => ({ data: {} })),
+    interceptors: { request: { use: vi.fn() } },
+  });
+  return { instance, deletedSubscriptions, createdSubscriptions };
+});
+
+vi.mock('axios', () => ({
+  default: {
+    create: () => graphHttp.instance(),
+    post: vi.fn(async () => ({
+      data: { access_token: 'x', refresh_token: 'y', expires_in: 3600 },
+    })),
+  },
+}));
+
+let testDb: Knex;
+let testTenant: string;
+let profileId: string;
+let profileSecretRef: string;
+
+function tenantTable<Row = Record<string, unknown>>(table: string) {
+  return tenantDb(testDb, testTenant).table<Row>(table);
+}
+
+function tenantFixtureTable() {
+  return tenantDb(testDb, testTenant).unscoped(
+    'tenants',
+    'Microsoft email same-app update test fixture creates and removes tenant rows'
+  );
+}
+
+// Route the service/action connection acquisition at the test database/tenant.
+// The real adapter persists its webhook subscription through the admin
+// connection, so that is also pointed at the test database.
+vi.mock('@alga-psa/db', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@alga-psa/db')>();
+  return {
+    ...actual,
+    createTenantKnex: async () => ({ knex: testDb, tenant: testTenant }),
+    getAdminConnection: async () => testDb,
+  };
+});
+
+vi.mock('@alga-psa/db/admin', () => ({
+  getAdminConnection: async () => testDb,
+}));
+
+vi.mock('@alga-psa/core/secrets', () => ({
+  getSecretProviderInstance: async () => ({
+    getAppSecret: async (name: string) => testContext.appSecrets.get(name),
+    getTenantSecret: async (tenant: string, name: string) =>
+      testContext.tenantSecrets.get(`${tenant}:${name}`),
+    setTenantSecret: async () => undefined,
+    deleteTenantSecret: async () => undefined,
+  }),
+  getSecret: async (_name: string, envVar?: string, fallback = '') =>
+    (envVar ? process.env[envVar] : undefined) ?? fallback,
+}));
+
+const WRITE_LOG_TABLE = 'alga_test_ms_sub_write_log';
+const WRITE_LOG_FUNCTION = 'alga_test_ms_sub_write_log_fn';
+const WRITE_LOG_TRIGGER = 'alga_test_ms_sub_write_log_trigger';
+
+async function installSubscriptionWriteLog(): Promise<void> {
+  await testDb.raw(`
+    CREATE TABLE IF NOT EXISTS ${WRITE_LOG_TABLE} (
+      id serial PRIMARY KEY,
+      provider_id uuid NOT NULL,
+      subscription_id text NOT NULL
+    );
+    CREATE OR REPLACE FUNCTION ${WRITE_LOG_FUNCTION}() RETURNS trigger AS $$
+    BEGIN
+      IF NEW.webhook_subscription_id IS DISTINCT FROM OLD.webhook_subscription_id THEN
+        INSERT INTO ${WRITE_LOG_TABLE} (provider_id, subscription_id)
+        VALUES (NEW.email_provider_id, NEW.webhook_subscription_id);
+      END IF;
+      RETURN NEW;
+    END;
+    $$ LANGUAGE plpgsql;
+    DROP TRIGGER IF EXISTS ${WRITE_LOG_TRIGGER} ON microsoft_email_provider_config;
+    CREATE TRIGGER ${WRITE_LOG_TRIGGER}
+    BEFORE UPDATE ON microsoft_email_provider_config
+    FOR EACH ROW EXECUTE FUNCTION ${WRITE_LOG_FUNCTION}();
+  `);
+}
+
+async function dropSubscriptionWriteLog(): Promise<void> {
+  await testDb.raw(`
+    DROP TRIGGER IF EXISTS ${WRITE_LOG_TRIGGER} ON microsoft_email_provider_config;
+    DROP FUNCTION IF EXISTS ${WRITE_LOG_FUNCTION}();
+    DROP TABLE IF EXISTS ${WRITE_LOG_TABLE};
+  `);
+}
+
+async function seedProfile(): Promise<string> {
+  const id = uuidv4();
+  const secretRef = `microsoft_profile_${id}_client_secret`;
+  await tenantTable('microsoft_profiles').insert({
+    tenant: testTenant,
+    profile_id: id,
+    display_name: 'Same-App Update Email App',
+    display_name_normalized: 'same-app update email app',
+    client_id: PROFILE_CLIENT_ID,
+    tenant_id: PROFILE_TENANT_ID,
+    client_secret_ref: secretRef,
+    capabilities: JSON.stringify(['email']),
+    is_default: true,
+    is_archived: false,
+    archived_at: null,
+    created_by: null,
+    updated_by: null,
+    created_at: new Date(),
+    updated_at: new Date(),
+  });
+  testContext.tenantSecrets.set(`${testTenant}:${secretRef}`, PROFILE_SECRET);
+  return id;
+}
+
+async function seedConnectedProvider(overrides: {
+  accessToken?: string;
+  refreshToken?: string;
+  webhookSubscriptionId?: string | null;
+} = {}): Promise<string> {
+  const providerId = uuidv4();
+  const now = new Date();
+  await tenantTable('email_providers').insert({
+    id: providerId,
+    tenant: testTenant,
+    provider_type: 'microsoft',
+    provider_name: 'Same-App Mailbox',
+    mailbox: `same-app-${providerId.slice(0, 8)}@client.com`,
+    is_active: true,
+    status: 'connected',
+    error_message: null,
+    created_at: now,
+    updated_at: now,
+  });
+  await tenantTable('microsoft_email_provider_config').insert({
+    email_provider_id: providerId,
+    tenant: testTenant,
+    client_id: PROFILE_CLIENT_ID,
+    client_secret: PROFILE_SECRET,
+    tenant_id: PROFILE_TENANT_ID,
+    microsoft_profile_id: profileId,
+    client_secret_ref: profileSecretRef,
+    redirect_uri: 'http://localhost:3340/api/auth/microsoft/callback',
+    auto_process_emails: true,
+    max_emails_per_sync: 50,
+    folder_filters: JSON.stringify(['Inbox']),
+    access_token: overrides.accessToken ?? 'access-before',
+    refresh_token: overrides.refreshToken ?? 'refresh-before',
+    token_expires_at: new Date(Date.now() + 3600000).toISOString(),
+    webhook_subscription_id: overrides.webhookSubscriptionId === undefined
+      ? PRIOR_SUBSCRIPTION_ID
+      : overrides.webhookSubscriptionId,
+    webhook_verification_token: 'verify-token',
+    webhook_expires_at: new Date(Date.now() + 7200000).toISOString(),
+    last_subscription_renewal: now,
+    delivery_mode: 'webhook',
+    webhook_silent_runs: 0,
+    next_subscription_probe_at: null,
+    created_at: now,
+    updated_at: now,
+  });
+  return providerId;
+}
+
+function sameAppUpdatePayload() {
+  return {
+    tenant: testTenant,
+    providerType: 'microsoft',
+    providerName: 'Same-App Mailbox',
+    senderDisplayName: null,
+    mailbox: 'same-app@client.com',
+    isActive: true,
+    inboundTicketDefaultsId: null,
+    // The form carries an explicit issuer choice plus mostly-empty config;
+    // tokens and webhook state are preserved server-side.
+    microsoftIssuer: { kind: 'profile', profileId, clientId: PROFILE_CLIENT_ID },
+    microsoftConfig: {
+      client_id: '',
+      client_secret: '',
+      tenant_id: '',
+      auto_process_emails: true,
+      folder_filters: ['Inbox'],
+      max_emails_per_sync: 50,
+    },
+  };
+}
+
+describe('Microsoft same-app Update Provider webhook persistence (DB-backed)', () => {
+  beforeAll(async () => {
+    const secretsDir = path.resolve(__dirname, '../../../../secrets');
+    const readSecret = (name: string) => {
+      try {
+        return fs.readFileSync(path.join(secretsDir, name), 'utf8').trim();
+      } catch {
+        return undefined;
+      }
+    };
+    // .env.localtest points DB_PASSWORD_* at container secret paths that do
+    // not exist on this host; point the test bootstrap at the real secrets.
+    process.env.DB_HOST = '127.0.0.1';
+    process.env.DB_PORT = '5472';
+    process.env.DB_USER_ADMIN = 'postgres';
+    process.env.DB_USER_SERVER = 'app_user';
+    process.env.DB_PASSWORD_ADMIN = readSecret('postgres_password') || 'postpass123';
+    process.env.DB_PASSWORD_SERVER = readSecret('db_password_server') || 'postpass123';
+    process.env.NODE_ENV = 'test';
+
+    testDb = await createTestDbConnection();
+    testTenant = uuidv4();
+    testContext.tenant = testTenant;
+    await tenantFixtureTable().insert({
+      tenant: testTenant,
+      client_name: 'Same-App Update Test Client',
+      email: 'same-app-update@client.com',
+      created_at: new Date(),
+      updated_at: new Date(),
+    });
+    profileId = await seedProfile();
+    profileSecretRef = `microsoft_profile_${profileId}_client_secret`;
+    await installSubscriptionWriteLog();
+  }, 180_000);
+
+  afterAll(async () => {
+    await dropSubscriptionWriteLog();
+    await tenantTable('microsoft_email_provider_config').delete();
+    await tenantTable('email_providers').delete();
+    await tenantTable('microsoft_profiles').delete();
+    await tenantFixtureTable().where('tenant', testTenant).delete();
+    await testDb.destroy();
+  }, 30_000);
+
+  beforeEach(() => {
+    graphHttp.deletedSubscriptions.length = 0;
+    graphHttp.createdSubscriptions.length = 0;
+  });
+
+  it('same-app update through the real updateEmailProvider action ends connected with a once-persisted replacement subscription', async () => {
+    const providerId = await seedConnectedProvider();
+    const providerTable = () => tenantTable('email_providers');
+    const configTable = () => tenantTable('microsoft_email_provider_config');
+
+    const beforeConfig = await configTable().where('email_provider_id', providerId).first();
+
+    const result = await updateEmailProvider(providerId, sameAppUpdatePayload());
+
+    // The action completed without a webhook/setup error and reported the
+    // provider connected — never Error.
+    expect(result.setupError).toBeUndefined();
+    expect(result.provider.status).toBe('connected');
+
+    // The seeded connected provider had a prior live subscription; the update
+    // deletes it in Graph and creates exactly one replacement.
+    expect(graphHttp.deletedSubscriptions).toEqual([PRIOR_SUBSCRIPTION_ID]);
+    expect(graphHttp.createdSubscriptions).toEqual(['new-sub-1']);
+
+    const provider = await providerTable().where('id', providerId).first();
+    expect(provider.status).toBe('connected');
+    expect(provider.error_message).toBeNull();
+
+    const config = await configTable().where('email_provider_id', providerId).first();
+
+    // Tokens and issuer pinning are byte-identical across the update.
+    expect(config).toMatchObject({
+      access_token: beforeConfig.access_token,
+      refresh_token: beforeConfig.refresh_token,
+      client_id: beforeConfig.client_id,
+      microsoft_profile_id: beforeConfig.microsoft_profile_id,
+      client_secret_ref: beforeConfig.client_secret_ref,
+      client_secret: beforeConfig.client_secret,
+      tenant_id: beforeConfig.tenant_id,
+    });
+    expect(config.access_token).toBe('access-before');
+    expect(config.refresh_token).toBe('refresh-before');
+
+    // The replacement subscription id is persisted in the real column
+    // (webhook_subscription_id) with the new Graph expiry, and the prior id is
+    // gone from the DB.
+    expect(config.webhook_subscription_id).toBe('new-sub-1');
+    expect(config.webhook_subscription_id).not.toBe(PRIOR_SUBSCRIPTION_ID);
+    expect(config.webhook_expires_at).toBeTruthy();
+    const expiryMs = new Date(config.webhook_expires_at).getTime();
+    expect(expiryMs).toBeGreaterThan(Date.now());
+    expect(expiryMs).toBeLessThanOrEqual(Date.now() + 2 * 60 * 60 * 1000);
+    expect(config.delivery_mode).toBe('webhook');
+
+    // Exactly one UPDATE ever wrote webhook_subscription_id (the adapter's
+    // persistence); the removed `updateProvider` write would have attempted a
+    // second, failing write instead.
+    const writes = await testDb(WRITE_LOG_TABLE)
+      .where({ provider_id: providerId })
+      .select('subscription_id');
+    expect(writes).toEqual([{ subscription_id: 'new-sub-1' }]);
+    expect(writes).toHaveLength(1);
+  });
+
+  it('updateProvider drops non-column keys so a nonexistent column write can never recur', async () => {
+    const providerId = await seedConnectedProvider();
+
+    // This is the exact failure that landed providers in Error on HEAD: a
+    // vendorConfig carrying `subscriptionId` (plus another non-column key).
+    await new EmailProviderService().updateProvider(providerId, testTenant, {
+      vendorConfig: {
+        subscriptionId: 'not-a-column',
+        resolved_client_id: 'not-a-column',
+        webhook_subscription_id: 'injected-real-column',
+        refresh_token: 'rotated-refresh',
+      },
+    });
+
+    const config = await tenantTable<any>('microsoft_email_provider_config')
+      .where('email_provider_id', providerId)
+      .first();
+
+    // Real columns written through, non-column keys silently dropped.
+    expect(config.webhook_subscription_id).toBe('injected-real-column');
+    expect(config.refresh_token).toBe('rotated-refresh');
+    expect(config.access_token).toBe('access-before');
+    expect(config.client_id).toBe(PROFILE_CLIENT_ID);
+    expect(config.microsoft_profile_id).toBe(profileId);
+
+    // Prove `subscriptionId` is not a column and nothing was ever written for it.
+    const columns = await testDb.raw(
+      `SELECT column_name FROM information_schema.columns
+       WHERE table_name = 'microsoft_email_provider_config'
+         AND column_name = 'subscriptionId'`
+    );
+    expect(columns.rows).toHaveLength(0);
+  });
+});

--- a/server/src/test/integration/microsoftLegacyTenantStatusReadPurity.integration.test.ts
+++ b/server/src/test/integration/microsoftLegacyTenantStatusReadPurity.integration.test.ts
@@ -1,0 +1,421 @@
+/**
+ * Mitigation round — status reads are pure even for UNMIGRATED legacy tenants.
+ *
+ * The prior Teams/email status-purity test seeded a fully-migrated tenant
+ * (profile + every consumer binding already present), which masked the real
+ * defect: on a legacy tenant whose migration has never run,
+ * `getMicrosoftIntegrationStatus()` still reached the migration helpers
+ * (`ensureLegacyMicrosoftProfileBackfill`, `ensureMicrosoftConsumerBindingMigration`)
+ * via `listMicrosoftProfilesForTenant`, `resolveMicrosoftProfileForConsumer`, and
+ * `getMicrosoftEmailSetupReadiness` — writing profile/binding rows and tenant
+ * secrets as a side effect of a settings page load.
+ *
+ * This suite seeds a TRUE legacy tenant: legacy Microsoft tenant secrets
+ * present, legacy usage present (msp_sso login domain, Microsoft email + calendar
+ * providers), but NO `microsoft_profiles` rows, NO
+ * `microsoft_profile_consumer_bindings` rows, and no migration-completion marker.
+ * It asserts the status read (the same action both the Microsoft email settings
+ * page and the Teams settings page invoke) performs ZERO writes across the
+ * profile/binding/provider-config tables and ZERO secret-provider writes, while
+ * still returning a useful legacy status — and that an explicit mutation action
+ * afterwards still performs the migration, so the pure read strands nobody.
+ */
+
+import { describe, it, expect, beforeAll, afterAll, vi } from 'vitest';
+import type { Knex } from 'knex';
+import fs from 'node:fs';
+import path from 'node:path';
+import { v4 as uuidv4 } from 'uuid';
+import { tenantDb, runWithTenant } from '@alga-psa/db';
+import { runWithApiKeyUser } from '@alga-psa/auth';
+import { createTestDbConnection } from '../../../test-utils/dbConfig';
+import {
+  getMicrosoftIntegrationStatus,
+  listMicrosoftConsumerBindings,
+  saveMicrosoftIntegrationSettings,
+} from '@alga-psa/integrations/actions/integrations/microsoftActions';
+
+const hoisted = vi.hoisted(() => ({
+  tenantSecrets: new Map<string, string>(),
+  secretWrites: [] as Array<{ tenant: string; key: string; value: string | null }>,
+}));
+
+let testDb: Knex;
+let testTenant: string;
+let sessionUserId: string;
+let legacyEmailProviderId: string;
+
+function tenantTable<Row = Record<string, unknown>>(table: string) {
+  return tenantDb(testDb, testTenant).table<Row>(table);
+}
+
+function tenantFixtureTable() {
+  return tenantDb(testDb, testTenant).unscoped(
+    'tenants',
+    'Microsoft legacy tenant status read purity test fixture creates and removes tenant rows'
+  );
+}
+
+vi.mock('redis', () => ({
+  createClient: () => {
+    throw new Error('redis unavailable in Microsoft legacy tenant status read purity tests');
+  },
+}));
+
+vi.mock('@alga-psa/db', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@alga-psa/db')>();
+  return {
+    ...actual,
+    createTenantKnex: async () => ({ knex: testDb, tenant: testTenant }),
+    getConnection: async () => testDb,
+  };
+});
+
+// The action is wrapped with the real @alga-psa/auth/withAuth, which resolves
+// the session user. Unwrap it to the tenant set by runWithTenant (the same
+// shape the wrapped action receives in production).
+vi.mock('@alga-psa/auth/withAuth', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@alga-psa/auth/withAuth')>();
+  return {
+    ...actual,
+    withAuth:
+      (action: (...args: any[]) => Promise<unknown>) =>
+      async (...args: any[]) => {
+        const { getTenantContext } = await import('@alga-psa/db');
+        const tenant = getTenantContext() || 'test-tenant';
+        return action({ user_id: sessionUserId, user_type: 'internal', tenant }, { tenant }, ...args);
+      },
+  };
+});
+
+vi.mock('@alga-psa/db/admin', () => ({
+  getAdminConnection: async () => testDb,
+}));
+
+// Write-capturing secret provider: every setTenantSecret/deleteTenantSecret is
+// recorded so the test can assert the status read never writes a secret. The
+// legacy tenant's credentials live here as the legacy singleton keys.
+vi.mock('@alga-psa/core/secrets', () => ({
+  getSecret: async (_name: string, envVar?: string, fallback = '') =>
+    (envVar ? process.env[envVar] : undefined) ?? fallback,
+  getSecretProviderInstance: async () => ({
+    getTenantSecret: async (tenant: string, key: string) =>
+      hoisted.tenantSecrets.get(`${tenant}:${key}`) || undefined,
+    setTenantSecret: async (tenant: string, key: string, value: string | null) => {
+      hoisted.secretWrites.push({ tenant, key, value });
+    },
+    deleteTenantSecret: async (tenant: string, key: string) => {
+      hoisted.secretWrites.push({ tenant, key, value: null });
+    },
+    getAppSecret: async () => undefined,
+  }),
+}));
+
+async function snapshot() {
+  const [profileRows, bindingRows, configRows, providerRows, calendarRows, domainRows] = await Promise.all([
+    tenantTable('microsoft_profiles').select('*'),
+    tenantTable('microsoft_profile_consumer_bindings').select('*'),
+    tenantTable('microsoft_email_provider_config').select('*'),
+    tenantTable('email_providers').select('*'),
+    tenantTable('calendar_providers').select('*'),
+    tenantTable('msp_sso_tenant_login_domains').select('*'),
+  ]);
+  return JSON.stringify({
+    profiles: profileRows,
+    bindings: bindingRows,
+    config: configRows,
+    emailProviders: providerRows,
+    calendarProviders: calendarRows,
+    domains: domainRows,
+  });
+}
+
+async function countRows(table: string): Promise<number> {
+  const row = await tenantTable<{ count: string }>(table).count<{ count: string }>('* as count').first();
+  return Number(row?.count ?? 0);
+}
+
+// The explicit mutation actions are guarded by canManageMicrosoftSettings
+// (hasPermission('system_settings', 'update')). Grant the session user that
+// permission through the real roles/permissions tables so the mutation half of
+// this suite passes its auth guard in this DB-backed run.
+async function grantSystemSettingsUpdate(connection: Knex, tenant: string, userId: string) {
+  const roleId = uuidv4();
+  await tenantDb(connection, tenant).table('users').insert({
+    tenant,
+    user_id: userId,
+    username: `legacy-purity-${userId.slice(0, 8)}`,
+    hashed_password: 'unused',
+    user_type: 'internal',
+    email: `legacy-purity-${userId.slice(0, 8)}@client.com`,
+    created_at: new Date(),
+    updated_at: new Date(),
+  });
+
+  await tenantDb(connection, tenant).table('roles').insert({
+    tenant,
+    role_id: roleId,
+    role_name: `Legacy Status Read Purity Test Role ${uuidv4().slice(0, 8)}`,
+    description: 'Test role for the Microsoft legacy tenant status read purity test',
+    msp: true,
+    client: false,
+    created_at: new Date(),
+    updated_at: new Date(),
+  });
+
+  const existingPermission = await tenantDb(connection, tenant).table('permissions')
+    .where({ resource: 'system_settings', action: 'update' })
+    .first<{ permission_id: string }>('permission_id');
+  const permissionId = existingPermission?.permission_id ?? uuidv4();
+  if (!existingPermission) {
+    await tenantDb(connection, tenant).table('permissions').insert({
+      tenant,
+      permission_id: permissionId,
+      resource: 'system_settings',
+      action: 'update',
+      msp: true,
+      client: false,
+      created_at: new Date(),
+    });
+  }
+
+  await tenantDb(connection, tenant).table('role_permissions').insert({
+    tenant,
+    role_id: roleId,
+    permission_id: permissionId,
+    created_at: new Date(),
+  });
+
+  await tenantDb(connection, tenant).table('user_roles').insert({
+    tenant,
+    user_id: userId,
+    role_id: roleId,
+    created_at: new Date(),
+  });
+}
+
+describe('Microsoft legacy tenant status read purity (DB-backed)', () => {
+  beforeAll(async () => {
+    const secretsDir = path.resolve(__dirname, '../../../../secrets');
+    const readSecret = (name: string) => {
+      try {
+        return fs.readFileSync(path.join(secretsDir, name), 'utf8').trim();
+      } catch {
+        return undefined;
+      }
+    };
+    // Override unconditionally: .env.localtest points DB_PASSWORD_* at container
+    // secret paths that do not exist on this host, and the secrets provider is
+    // mocked below, so getSecret() falls back to these env vars.
+    process.env.DB_HOST = '127.0.0.1';
+    process.env.DB_PORT = '5472';
+    process.env.DB_USER_ADMIN = 'postgres';
+    process.env.DB_USER_SERVER = 'app_user';
+    process.env.DB_PASSWORD_ADMIN = readSecret('postgres_password') || 'postpass123';
+    process.env.DB_PASSWORD_SERVER = readSecret('db_password_server') || 'postpass123';
+    process.env.NODE_ENV = 'test';
+    process.env.NEXT_PUBLIC_EDITION = 'enterprise';
+
+    testDb = await createTestDbConnection();
+    testTenant = uuidv4();
+    sessionUserId = uuidv4();
+    await tenantFixtureTable().insert({
+      tenant: testTenant,
+      client_name: 'Legacy Tenant Purity Test Client',
+      email: 'legacy-purity@client.com',
+      created_at: new Date(),
+      updated_at: new Date(),
+    });
+    await grantSystemSettingsUpdate(testDb, testTenant, sessionUserId);
+
+    // TRUE legacy tenant: legacy singleton Microsoft secrets + legacy usage, but
+    // NO microsoft_profiles rows, NO consumer bindings, no migration marker.
+    hoisted.tenantSecrets.set(`${testTenant}:microsoft_client_id`, 'legacy-client-id');
+    hoisted.tenantSecrets.set(`${testTenant}:microsoft_client_secret`, 'legacy-client-secret');
+    hoisted.tenantSecrets.set(`${testTenant}:microsoft_tenant_id`, 'directory-guid');
+
+    await tenantTable('msp_sso_tenant_login_domains').insert({
+      tenant: testTenant,
+      domain: 'legacy.example.com',
+      is_active: true,
+      created_at: new Date(),
+      updated_at: new Date(),
+    });
+
+    legacyEmailProviderId = uuidv4();
+    const now = new Date();
+    await tenantTable('email_providers').insert({
+      id: legacyEmailProviderId,
+      tenant: testTenant,
+      provider_type: 'microsoft',
+      provider_name: 'Legacy Mailbox',
+      mailbox: `legacy-${uuidv4().slice(0, 8)}@client.com`,
+      is_active: true,
+      status: 'connected',
+      error_message: null,
+      created_at: now,
+      updated_at: now,
+    });
+    await tenantTable('microsoft_email_provider_config').insert({
+      email_provider_id: legacyEmailProviderId,
+      tenant: testTenant,
+      client_id: 'legacy-client-id',
+      client_secret: 'legacy-secret',
+      tenant_id: 'directory-guid',
+      microsoft_profile_id: null,
+      client_secret_ref: null,
+      redirect_uri: 'https://psa.example.com/api/auth/microsoft/callback',
+      auto_process_emails: true,
+      max_emails_per_sync: 50,
+      folder_filters: JSON.stringify(['Inbox']),
+      access_token: 'access',
+      refresh_token: 'refresh',
+      token_expires_at: new Date(Date.now() + 3600000).toISOString(),
+      webhook_subscription_id: null,
+      webhook_verification_token: null,
+      webhook_expires_at: null,
+      last_subscription_renewal: null,
+      delivery_mode: 'webhook',
+      webhook_silent_runs: 0,
+      next_subscription_probe_at: null,
+      created_at: now,
+      updated_at: now,
+    });
+
+    await tenantTable('calendar_providers').insert({
+      id: uuidv4(),
+      tenant: testTenant,
+      provider_type: 'microsoft',
+      provider_name: 'Legacy Calendar',
+      calendar_id: `legacy-calendar-${uuidv4().slice(0, 8)}@client.com`,
+      is_active: true,
+      status: 'connected',
+      error_message: null,
+      created_at: now,
+      updated_at: now,
+    });
+  }, 180_000);
+
+  afterAll(async () => {
+    if (testTenant) {
+      await tenantTable('user_roles').where('user_id', sessionUserId).delete();
+      await tenantTable('role_permissions').delete();
+      await tenantTable('roles').delete();
+      await tenantTable('permissions').delete();
+      await tenantTable('users').where('user_id', sessionUserId).delete();
+      await tenantTable('msp_sso_tenant_login_domains').delete();
+      await tenantTable('microsoft_email_provider_config').delete();
+      await tenantTable('email_providers').delete();
+      await tenantTable('calendar_providers').delete();
+      await tenantTable('microsoft_profile_consumer_bindings').delete();
+      await tenantTable('microsoft_profiles').delete();
+      await tenantFixtureTable().where('tenant', testTenant).delete();
+    }
+    await testDb?.destroy().catch(() => undefined);
+  }, 30_000);
+
+  beforeEach(async () => {
+    // Tests may shuffle, and the explicit-mutation test legitimately migrates
+    // this tenant. Reset the migration-visible state (and the secret-write log)
+    // so every test starts from the pristine legacy tenant seeded in beforeAll.
+    hoisted.secretWrites.length = 0;
+    await tenantTable('microsoft_profile_consumer_bindings').delete();
+    await tenantTable('microsoft_profiles').delete();
+  });
+
+  it('status read on an unmigrated legacy tenant is pure: zero table writes, zero secret writes, and a useful legacy status', async () => {
+    expect(await countRows('microsoft_profiles')).toBe(0);
+    expect(await countRows('microsoft_profile_consumer_bindings')).toBe(0);
+
+    const before = await snapshot();
+
+    // Both the Microsoft email settings page and the Teams settings page invoke
+    // the same shared no-arg status action for their page loads.
+    const status = await runWithApiKeyUser(
+      { user_id: sessionUserId, tenant: testTenant },
+      () => runWithTenant(testTenant, () => getMicrosoftIntegrationStatus())
+    );
+
+    // The read does not throw and reflects the legacy state.
+    expect(status.success).toBe(true);
+    expect(status.error).toBeUndefined();
+    expect(status.emailSetup).toBeDefined();
+
+    // The legacy credentials surface as an unmigrated/legacy profile view
+    // WITHOUT materializing a profile row.
+    expect(status.profiles).toHaveLength(1);
+    const legacyView = status.profiles![0];
+    expect(legacyView.isLegacyUnmigrated).toBe(true);
+    expect(legacyView.profileId).toBe('legacy');
+    expect(legacyView.displayName).toBe('Default Microsoft Profile');
+    expect(legacyView.clientId).toBe('legacy-client-id');
+    expect(legacyView.tenantId).toBe('directory-guid');
+    expect(legacyView.clientSecretConfigured).toBe(true);
+    expect(legacyView.readiness.ready).toBe(true);
+    expect(legacyView.consumers).toEqual(expect.arrayContaining(['MSP SSO', 'Email', 'Calendar']));
+
+    // The msp_sso interpretation populates the legacy config.
+    expect(status.config).toMatchObject({
+      clientId: 'legacy-client-id',
+      tenantId: 'directory-guid',
+      ready: true,
+    });
+
+    // Zero writes: no rows inserted or changed in any watched table.
+    expect(await snapshot()).toBe(before);
+    expect(await countRows('microsoft_profiles')).toBe(0);
+    expect(await countRows('microsoft_profile_consumer_bindings')).toBe(0);
+    const config = await tenantTable<any>('microsoft_email_provider_config').first();
+    expect(config.microsoft_profile_id).toBeNull();
+    expect(config.client_secret_ref).toBeNull();
+
+    // Zero secret-provider writes.
+    expect(hoisted.secretWrites).toEqual([]);
+  });
+
+  it('an explicit mutation action still performs the migration, so the pure read strands nobody', async () => {
+    // Deliberate, user-initiated save: allowed to materialize the profile and
+    // mirror the legacy secrets.
+    const saveResult = await runWithApiKeyUser(
+      { user_id: sessionUserId, tenant: testTenant },
+      () => runWithTenant(testTenant, () =>
+        saveMicrosoftIntegrationSettings({
+          clientId: 'legacy-client-id',
+          clientSecret: 'legacy-client-secret',
+          tenantId: 'directory-guid',
+        })
+      )
+    );
+    expect(saveResult).toEqual({ success: true });
+
+    const profiles = await tenantTable<any>('microsoft_profiles').select('*');
+    expect(profiles).toHaveLength(1);
+    expect(profiles[0].client_id).toBe('legacy-client-id');
+    expect(profiles[0].client_secret_ref).toMatch(/^microsoft_profile_.+_client_secret$/);
+    expect(profiles[0].profile_id).not.toBe('legacy');
+
+    // The migration machine still runs on explicit actions: binding the legacy
+    // usage to the materialized profile.
+    const bindingsResult = await runWithApiKeyUser(
+      { user_id: sessionUserId, tenant: testTenant },
+      () => runWithTenant(testTenant, () => listMicrosoftConsumerBindings())
+    );
+    expect(bindingsResult.success).toBe(true);
+    const mspSsoBinding = bindingsResult.bindings?.find((binding) => binding.consumerType === 'msp_sso');
+    expect(mspSsoBinding).toMatchObject({
+      profileId: profiles[0].profile_id,
+      profileDisplayName: 'Default Microsoft Profile',
+    });
+
+    // A follow-up status read now shows the REAL materialized profile, not the
+    // synthetic legacy view — the pure read transitioned cleanly.
+    const status = await runWithApiKeyUser(
+      { user_id: sessionUserId, tenant: testTenant },
+      () => runWithTenant(testTenant, () => getMicrosoftIntegrationStatus())
+    );
+    expect(status.success).toBe(true);
+    expect(status.profiles).toHaveLength(1);
+    expect(status.profiles![0].isLegacyUnmigrated).toBeUndefined();
+    expect(status.profiles![0].profileId).toBe(profiles[0].profile_id);
+  });
+});

--- a/server/src/test/integration/microsoftTeamsStatusReadPurity.integration.test.ts
+++ b/server/src/test/integration/microsoftTeamsStatusReadPurity.integration.test.ts
@@ -5,13 +5,15 @@
  * Loading it (the shared status read path) must make ZERO writes to
  * `microsoft_email_provider_config`, `microsoft_profile_consumer_bindings`, or
  * `microsoft_profiles` — including any legacy shape migration or readiness
- * logic buried in the read path. The email issuer backfill is opt-in and only
- * the Microsoft email settings flow passes `runIssuerBackfill: true`.
+ * logic buried in the read path. The email issuer backfill is an explicit
+ * mutation (runMicrosoftEmailIssuerBackfill) that the email settings surface
+ * invokes only as a deliberate write, never as a page-load side effect.
  *
  * This test seeds a fully-migrated tenant (profile + every consumer binding
- * already present, plus a legacy email provider that a non-opt-in backfill
+ * already present, plus a legacy email provider that a read-path backfill
  * would pin) and asserts the three tables are byte-identical before and after
- * the real action runs against real PostgreSQL.
+ * the real status action runs against real PostgreSQL — and that only the
+ * explicit backfill action performs the write.
  */
 
 import { describe, it, expect, beforeAll, afterAll, vi } from 'vitest';
@@ -22,7 +24,10 @@ import { v4 as uuidv4 } from 'uuid';
 import { tenantDb, runWithTenant } from '@alga-psa/db';
 import { runWithApiKeyUser } from '@alga-psa/auth';
 import { createTestDbConnection } from '../../../test-utils/dbConfig';
-import { getMicrosoftIntegrationStatus } from '@alga-psa/integrations/actions/integrations/microsoftActions';
+import {
+  getMicrosoftIntegrationStatus,
+  runMicrosoftEmailIssuerBackfill,
+} from '@alga-psa/integrations/actions/integrations/microsoftActions';
 
 let testDb: Knex;
 let testTenant: string;
@@ -97,6 +102,65 @@ async function snapshot(scope: { configRows: any[]; bindingRows: any[]; profileR
   });
 }
 
+// The explicit backfill mutation is guarded by canManageMicrosoftSettings
+// (hasPermission('system_settings', 'update')). Grant the session user that
+// permission through the real roles/permissions tables so the action's auth
+// guard passes in this DB-backed run.
+async function grantSystemSettingsUpdate(connection: Knex, tenant: string, userId: string) {
+  const roleId = uuidv4();
+  await tenantDb(connection, tenant).table('users').insert({
+    tenant,
+    user_id: userId,
+    username: `purity-${userId.slice(0, 8)}`,
+    hashed_password: 'unused',
+    user_type: 'internal',
+    email: `purity-${userId.slice(0, 8)}@client.com`,
+    created_at: new Date(),
+    updated_at: new Date(),
+  });
+
+  await tenantDb(connection, tenant).table('roles').insert({
+    tenant,
+    role_id: roleId,
+    role_name: `Status Read Purity Test Role ${uuidv4().slice(0, 8)}`,
+    description: 'Test role for the Microsoft status read purity test',
+    msp: true,
+    client: false,
+    created_at: new Date(),
+    updated_at: new Date(),
+  });
+
+  const existingPermission = await tenantDb(connection, tenant).table('permissions')
+    .where({ resource: 'system_settings', action: 'update' })
+    .first<{ permission_id: string }>('permission_id');
+  const permissionId = existingPermission?.permission_id ?? uuidv4();
+  if (!existingPermission) {
+    await tenantDb(connection, tenant).table('permissions').insert({
+      tenant,
+      permission_id: permissionId,
+      resource: 'system_settings',
+      action: 'update',
+      msp: true,
+      client: false,
+      created_at: new Date(),
+    });
+  }
+
+  await tenantDb(connection, tenant).table('role_permissions').insert({
+    tenant,
+    role_id: roleId,
+    permission_id: permissionId,
+    created_at: new Date(),
+  });
+
+  await tenantDb(connection, tenant).table('user_roles').insert({
+    tenant,
+    user_id: userId,
+    role_id: roleId,
+    created_at: new Date(),
+  });
+}
+
 describe('Teams status read path purity (DB-backed)', () => {
   beforeAll(async () => {
     const secretsDir = path.resolve(__dirname, '../../../../secrets');
@@ -128,6 +192,7 @@ describe('Teams status read path purity (DB-backed)', () => {
       created_at: new Date(),
       updated_at: new Date(),
     });
+    await grantSystemSettingsUpdate(testDb, testTenant, sessionUserId);
 
     // A fully-migrated tenant: one active Email-capable profile whose client id
     // is the same as a legacy email provider's persisted client id. The
@@ -219,6 +284,11 @@ describe('Teams status read path purity (DB-backed)', () => {
 
   afterAll(async () => {
     if (testTenant) {
+      await tenantTable('user_roles').where('user_id', sessionUserId).delete();
+      await tenantTable('role_permissions').delete();
+      await tenantTable('roles').delete();
+      await tenantTable('permissions').delete();
+      await tenantTable('users').where('user_id', sessionUserId).delete();
       await tenantTable('tenant_addons').delete();
       await tenantTable('microsoft_email_provider_config').delete();
       await tenantTable('email_providers').delete();
@@ -230,9 +300,9 @@ describe('Teams status read path purity (DB-backed)', () => {
   }, 30_000);
 
   it('loads Teams/status read path without writing to email config, bindings, or profiles', async () => {
-    // Order-independent: tests shuffle, so the opt-in test may have already
-    // pinned the legacy provider. Start this read from an unpinned state so the
-    // assertion below proves the read path itself never re-pins it.
+    // Order-independent: tests shuffle, so the explicit backfill test may have
+    // already pinned the legacy provider. Start this read from an unpinned
+    // state so the assertion below proves the read path itself never re-pins it.
     await tenantTable('microsoft_email_provider_config').update({
       microsoft_profile_id: null,
       client_secret_ref: null,
@@ -255,7 +325,7 @@ describe('Teams status read path purity (DB-backed)', () => {
     );
 
     expect(status.success).toBe(true);
-    expect(status.issuerBackfill).toBeUndefined();
+    expect(status).not.toHaveProperty('issuerBackfill');
 
     const after = await snapshot(await readScope());
     expect(after).toBe(before);
@@ -266,34 +336,38 @@ describe('Teams status read path purity (DB-backed)', () => {
     expect(config.client_secret_ref).toBeNull();
   });
 
-  it('the opt-in path still backfills when explicitly requested by the email settings flow', async () => {
-    const before = await snapshot(await (async () => {
+  it('the conservative issuer backfill runs only through the explicit mutation action, never on a status read', async () => {
+    const readScope = async () => {
       const [configRows, bindingRows, profileRows] = await Promise.all([
         tenantTable('microsoft_email_provider_config').select('*'),
         tenantTable('microsoft_profile_consumer_bindings').select('*'),
         tenantTable('microsoft_profiles').select('*'),
       ]);
       return { configRows, bindingRows, profileRows };
-    })());
+    };
 
-    const status = await runWithApiKeyUser(
+    const before = await snapshot(await readScope());
+
+    const result = await runWithApiKeyUser(
       { user_id: sessionUserId, tenant: testTenant },
-      () => runWithTenant(testTenant, () => getMicrosoftIntegrationStatus({ runIssuerBackfill: true }))
+      () => runWithTenant(testTenant, () => runMicrosoftEmailIssuerBackfill())
     );
 
-    expect(status.success).toBe(true);
-    expect(status.issuerBackfill).toMatchObject({ backfilled: 1 });
-    expect(before).not.toBe(await snapshot(await (async () => {
-      const [configRows, bindingRows, profileRows] = await Promise.all([
-        tenantTable('microsoft_email_provider_config').select('*'),
-        tenantTable('microsoft_profile_consumer_bindings').select('*'),
-        tenantTable('microsoft_profiles').select('*'),
-      ]);
-      return { configRows, bindingRows, profileRows };
-    })()));
+    expect(result.success).toBe(true);
+    expect(result.result).toMatchObject({ backfilled: 1 });
+    expect(before).not.toBe(await snapshot(await readScope()));
 
     const config = await tenantTable<any>('microsoft_email_provider_config').first();
     expect(config.microsoft_profile_id).toBe(legacyProfileId);
     expect(config.client_secret_ref).toBe(`microsoft_profile_${legacyProfileId}_client_secret`);
+
+    // A status read after the explicit backfill is still a pure read.
+    const pinnedBefore = await snapshot(await readScope());
+    const status = await runWithApiKeyUser(
+      { user_id: sessionUserId, tenant: testTenant },
+      () => runWithTenant(testTenant, () => getMicrosoftIntegrationStatus())
+    );
+    expect(status.success).toBe(true);
+    expect(await snapshot(await readScope())).toBe(pinnedBefore);
   });
 });

--- a/server/src/test/integration/microsoftTeamsStatusReadPurity.integration.test.ts
+++ b/server/src/test/integration/microsoftTeamsStatusReadPurity.integration.test.ts
@@ -1,0 +1,299 @@
+/**
+ * Blocker 6 — Teams reads are pure.
+ *
+ * `getMicrosoftIntegrationStatus()` powers the Teams settings profile picker.
+ * Loading it (the shared status read path) must make ZERO writes to
+ * `microsoft_email_provider_config`, `microsoft_profile_consumer_bindings`, or
+ * `microsoft_profiles` — including any legacy shape migration or readiness
+ * logic buried in the read path. The email issuer backfill is opt-in and only
+ * the Microsoft email settings flow passes `runIssuerBackfill: true`.
+ *
+ * This test seeds a fully-migrated tenant (profile + every consumer binding
+ * already present, plus a legacy email provider that a non-opt-in backfill
+ * would pin) and asserts the three tables are byte-identical before and after
+ * the real action runs against real PostgreSQL.
+ */
+
+import { describe, it, expect, beforeAll, afterAll, vi } from 'vitest';
+import type { Knex } from 'knex';
+import fs from 'node:fs';
+import path from 'node:path';
+import { v4 as uuidv4 } from 'uuid';
+import { tenantDb, runWithTenant } from '@alga-psa/db';
+import { runWithApiKeyUser } from '@alga-psa/auth';
+import { createTestDbConnection } from '../../../test-utils/dbConfig';
+import { getMicrosoftIntegrationStatus } from '@alga-psa/integrations/actions/integrations/microsoftActions';
+
+let testDb: Knex;
+let testTenant: string;
+let sessionUserId: string;
+let legacyProfileId: string;
+
+const tenantSecrets = new Map<string, string>();
+
+function tenantTable<Row = Record<string, unknown>>(table: string) {
+  return tenantDb(testDb, testTenant).table<Row>(table);
+}
+
+function tenantFixtureTable() {
+  return tenantDb(testDb, testTenant).unscoped(
+    'tenants',
+    'Microsoft Teams status read purity test fixture creates and removes tenant rows'
+  );
+}
+
+vi.mock('redis', () => ({
+  createClient: () => {
+    throw new Error('redis unavailable in Microsoft Teams status read purity tests');
+  },
+}));
+
+vi.mock('@alga-psa/db', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@alga-psa/db')>();
+  return {
+    ...actual,
+    createTenantKnex: async () => ({ knex: testDb, tenant: testTenant }),
+    getConnection: async () => testDb,
+  };
+});
+
+// The action is wrapped with the real @alga-psa/auth/withAuth, which resolves
+// the session user. Unwrap it to the tenant set by runWithTenant (the same
+// shape the wrapped action receives in production).
+vi.mock('@alga-psa/auth/withAuth', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@alga-psa/auth/withAuth')>();
+  return {
+    ...actual,
+    withAuth:
+      (action: (...args: any[]) => Promise<unknown>) =>
+      async (...args: any[]) => {
+        const { getTenantContext } = await import('@alga-psa/db');
+        const tenant = getTenantContext() || 'test-tenant';
+        return action({ user_id: sessionUserId, user_type: 'internal', tenant }, { tenant }, ...args);
+      },
+  };
+});
+
+vi.mock('@alga-psa/db/admin', () => ({
+  getAdminConnection: async () => testDb,
+}));
+
+vi.mock('@alga-psa/core/secrets', () => ({
+  getSecret: async (_name: string, envVar?: string, fallback = '') =>
+    (envVar ? process.env[envVar] : undefined) ?? fallback,
+  getSecretProviderInstance: async () => ({
+    getTenantSecret: async (tenant: string, key: string) =>
+      tenantSecrets.get(`${tenant}:${key}`) || undefined,
+    setTenantSecret: async () => undefined,
+    getAppSecret: async () => undefined,
+  }),
+}));
+
+async function snapshot(scope: { configRows: any[]; bindingRows: any[]; profileRows: any[] }) {
+  return JSON.stringify({
+    config: scope.configRows,
+    bindings: scope.bindingRows,
+    profiles: scope.profileRows,
+  });
+}
+
+describe('Teams status read path purity (DB-backed)', () => {
+  beforeAll(async () => {
+    const secretsDir = path.resolve(__dirname, '../../../../secrets');
+    const readSecret = (name: string) => {
+      try {
+        return fs.readFileSync(path.join(secretsDir, name), 'utf8').trim();
+      } catch {
+        return undefined;
+      }
+    };
+    // Override unconditionally: .env.localtest points DB_PASSWORD_* at container
+    // secret paths that do not exist on this host, and the secrets provider is
+    // mocked below, so getSecret() falls back to these env vars.
+    process.env.DB_HOST = '127.0.0.1';
+    process.env.DB_PORT = '5472';
+    process.env.DB_USER_ADMIN = 'postgres';
+    process.env.DB_USER_SERVER = 'app_user';
+    process.env.DB_PASSWORD_ADMIN = readSecret('postgres_password') || 'postpass123';
+    process.env.DB_PASSWORD_SERVER = readSecret('db_password_server') || 'postpass123';
+    process.env.NODE_ENV = 'test';
+
+    testDb = await createTestDbConnection();
+    testTenant = uuidv4();
+    sessionUserId = uuidv4();
+    await tenantFixtureTable().insert({
+      tenant: testTenant,
+      client_name: 'Teams Purity Test Client',
+      email: 'teams-purity@client.com',
+      created_at: new Date(),
+      updated_at: new Date(),
+    });
+
+    // A fully-migrated tenant: one active Email-capable profile whose client id
+    // is the same as a legacy email provider's persisted client id. The
+    // opt-in-only issuer backfill would pin that provider; if it ever ran on
+    // this read path, the snapshot below would differ.
+    legacyProfileId = uuidv4();
+    const secretRef = `microsoft_profile_${legacyProfileId}_client_secret`;
+    tenantSecrets.set(`${testTenant}:${secretRef}`, 'secret-value');
+    await tenantTable('microsoft_profiles').insert({
+      tenant: testTenant,
+      profile_id: legacyProfileId,
+      display_name: 'Legacy Match App',
+      display_name_normalized: 'legacy match app',
+      client_id: 'legacy-app-client',
+      tenant_id: 'directory-tenant-guid',
+      client_secret_ref: secretRef,
+      capabilities: JSON.stringify(['msp_sso', 'email', 'calendar', 'teams']),
+      is_default: true,
+      is_archived: false,
+      archived_at: null,
+      created_by: null,
+      updated_by: null,
+      created_at: new Date(),
+      updated_at: new Date(),
+    });
+
+    // Every visible consumer binding already present so the binding migration
+    // helpers are no-ops.
+    for (const consumerType of ['msp_sso', 'email', 'calendar', 'teams']) {
+      await tenantTable('microsoft_profile_consumer_bindings').insert({
+        tenant: testTenant,
+        consumer_type: consumerType,
+        profile_id: legacyProfileId,
+        created_by: null,
+        updated_by: null,
+        created_at: new Date(),
+        updated_at: new Date(),
+      });
+    }
+
+    // A legacy email provider the (opt-in only) issuer backfill would pin to
+    // the profile above if it ran.
+    const providerId = uuidv4();
+    await tenantTable('email_providers').insert({
+      id: providerId,
+      tenant: testTenant,
+      provider_type: 'microsoft',
+      provider_name: 'Legacy Mailbox',
+      mailbox: `legacy-${uuidv4().slice(0, 8)}@client.com`,
+      is_active: true,
+      status: 'connected',
+      error_message: null,
+      created_at: new Date(),
+      updated_at: new Date(),
+    });
+    await tenantTable('microsoft_email_provider_config').insert({
+      email_provider_id: providerId,
+      tenant: testTenant,
+      client_id: 'legacy-app-client',
+      client_secret: 'legacy-secret',
+      tenant_id: 'common',
+      microsoft_profile_id: null,
+      client_secret_ref: null,
+      redirect_uri: 'https://psa.example.com/api/auth/microsoft/callback',
+      auto_process_emails: true,
+      max_emails_per_sync: 50,
+      folder_filters: JSON.stringify(['Inbox']),
+      access_token: 'access',
+      refresh_token: 'refresh',
+      token_expires_at: new Date(Date.now() + 3600000).toISOString(),
+      webhook_subscription_id: 'sub',
+      webhook_verification_token: 'token',
+      webhook_expires_at: new Date(Date.now() + 7200000).toISOString(),
+      last_subscription_renewal: new Date(),
+      delivery_mode: 'webhook',
+      webhook_silent_runs: 0,
+      next_subscription_probe_at: null,
+      created_at: new Date(),
+      updated_at: new Date(),
+    });
+
+    // Teams add-on present so the Teams picker path is exercised.
+    await tenantTable('tenant_addons').insert({
+      tenant: testTenant,
+      addon_key: 'teams',
+      expires_at: null,
+    });
+  }, 180_000);
+
+  afterAll(async () => {
+    if (testTenant) {
+      await tenantTable('tenant_addons').delete();
+      await tenantTable('microsoft_email_provider_config').delete();
+      await tenantTable('email_providers').delete();
+      await tenantTable('microsoft_profile_consumer_bindings').delete();
+      await tenantTable('microsoft_profiles').delete();
+      await tenantFixtureTable().where('tenant', testTenant).delete();
+    }
+    await testDb?.destroy().catch(() => undefined);
+  }, 30_000);
+
+  it('loads Teams/status read path without writing to email config, bindings, or profiles', async () => {
+    // Order-independent: tests shuffle, so the opt-in test may have already
+    // pinned the legacy provider. Start this read from an unpinned state so the
+    // assertion below proves the read path itself never re-pins it.
+    await tenantTable('microsoft_email_provider_config').update({
+      microsoft_profile_id: null,
+      client_secret_ref: null,
+    });
+
+    const readScope = async () => {
+      const [configRows, bindingRows, profileRows] = await Promise.all([
+        tenantTable('microsoft_email_provider_config').select('*'),
+        tenantTable('microsoft_profile_consumer_bindings').select('*'),
+        tenantTable('microsoft_profiles').select('*'),
+      ]);
+      return { configRows, bindingRows, profileRows };
+    };
+
+    const before = await snapshot(await readScope());
+
+    const status = await runWithApiKeyUser(
+      { user_id: sessionUserId, tenant: testTenant },
+      () => runWithTenant(testTenant, () => getMicrosoftIntegrationStatus())
+    );
+
+    expect(status.success).toBe(true);
+    expect(status.issuerBackfill).toBeUndefined();
+
+    const after = await snapshot(await readScope());
+    expect(after).toBe(before);
+
+    // The legacy provider row is untouched: no email issuer pin, no secret ref.
+    const config = await tenantTable<any>('microsoft_email_provider_config').first();
+    expect(config.microsoft_profile_id).toBeNull();
+    expect(config.client_secret_ref).toBeNull();
+  });
+
+  it('the opt-in path still backfills when explicitly requested by the email settings flow', async () => {
+    const before = await snapshot(await (async () => {
+      const [configRows, bindingRows, profileRows] = await Promise.all([
+        tenantTable('microsoft_email_provider_config').select('*'),
+        tenantTable('microsoft_profile_consumer_bindings').select('*'),
+        tenantTable('microsoft_profiles').select('*'),
+      ]);
+      return { configRows, bindingRows, profileRows };
+    })());
+
+    const status = await runWithApiKeyUser(
+      { user_id: sessionUserId, tenant: testTenant },
+      () => runWithTenant(testTenant, () => getMicrosoftIntegrationStatus({ runIssuerBackfill: true }))
+    );
+
+    expect(status.success).toBe(true);
+    expect(status.issuerBackfill).toMatchObject({ backfilled: 1 });
+    expect(before).not.toBe(await snapshot(await (async () => {
+      const [configRows, bindingRows, profileRows] = await Promise.all([
+        tenantTable('microsoft_email_provider_config').select('*'),
+        tenantTable('microsoft_profile_consumer_bindings').select('*'),
+        tenantTable('microsoft_profiles').select('*'),
+      ]);
+      return { configRows, bindingRows, profileRows };
+    })()));
+
+    const config = await tenantTable<any>('microsoft_email_provider_config').first();
+    expect(config.microsoft_profile_id).toBe(legacyProfileId);
+    expect(config.client_secret_ref).toBe(`microsoft_profile_${legacyProfileId}_client_secret`);
+  });
+});

--- a/server/src/test/unit/components/MicrosoftProviderForm.test.tsx
+++ b/server/src/test/unit/components/MicrosoftProviderForm.test.tsx
@@ -500,4 +500,119 @@ describe('MicrosoftProviderForm', () => {
       )
     ).toBeInTheDocument();
   });
+
+  it('keeps the persisted app labeled Current while a different app is selected pending reauthorization', async () => {
+    const existingProvider = {
+      id: '123',
+      tenant: 'test-tenant-123',
+      providerType: 'microsoft' as const,
+      providerName: 'Existing Microsoft',
+      mailbox: 'existing@microsoft.com',
+      isActive: true,
+      status: 'connected' as const,
+      microsoftConfig: {
+        client_id: 'acme-client-id',
+        microsoft_profile_id: 'profile-1',
+        client_secret_ref: 'microsoft_profile_profile-1_client_secret',
+        tenant_id: 'tenant-dir-1',
+        redirect_uri: 'http://localhost:3000/api/auth/microsoft/callback',
+        folder_filters: ['Inbox'],
+        auto_process_emails: true,
+        max_emails_per_sync: 50,
+      },
+      createdAt: '2024-01-01',
+      updatedAt: '2024-01-01',
+    };
+
+    const user = userEvent.setup();
+    renderWithProviders(<MicrosoftProviderForm {...defaultProps} provider={existingProvider as any} />);
+    await screen.findByText('AlgaPSA app (managed by Nine Minds)');
+
+    // Persisted app is current; nothing selected differently yet, so no pending state.
+    expect(screen.getByText('Current app: Acme Email App')).toBeInTheDocument();
+    expect(screen.queryByText(/Selected app:/i)).not.toBeInTheDocument();
+    expect(screen.queryByText(/pending reauthorization/i)).not.toBeInTheDocument();
+
+    // Select the managed app (a different app than the persisted Acme profile).
+    await user.click(screen.getByText('AlgaPSA app (managed by Nine Minds)'));
+
+    // Current must still be the persisted issuer; the new pick is selected/pending.
+    expect(screen.getByText('Current app: Acme Email App')).toBeInTheDocument();
+    expect(screen.getByText('Selected app: AlgaPSA app (managed by Nine Minds)')).toBeInTheDocument();
+    expect(screen.getByText('Pending reauthorization')).toBeInTheDocument();
+  });
+
+  it('labels the persisted issuer Current with no pending state after a successful reconnect persistence', async () => {
+    const postReconnectProvider = {
+      id: '123',
+      tenant: 'test-tenant-123',
+      providerType: 'microsoft' as const,
+      providerName: 'Existing Microsoft',
+      mailbox: 'existing@microsoft.com',
+      isActive: true,
+      status: 'connected' as const,
+      microsoftConfig: {
+        client_id: 'managed-client-id',
+        client_secret_ref: 'microsoft_managed_app_client_secret',
+        tenant_id: 'common',
+        redirect_uri: 'http://localhost:3000/api/auth/microsoft/callback',
+        folder_filters: ['Inbox'],
+        auto_process_emails: true,
+        max_emails_per_sync: 50,
+      },
+      createdAt: '2024-01-01',
+      updatedAt: '2024-01-01',
+    };
+
+    renderWithProviders(<MicrosoftProviderForm {...defaultProps} provider={postReconnectProvider as any} />);
+    await screen.findByText('AlgaPSA app (managed by Nine Minds)');
+
+    // Beta (managed) is now the persisted issuer: it is Current, and because the
+    // form defaults to the persisted app there is no pending/switch state.
+    expect(screen.getByText('Current app: AlgaPSA app (managed by Nine Minds)')).toBeInTheDocument();
+    expect(screen.queryByText(/Selected app:/i)).not.toBeInTheDocument();
+    expect(screen.queryByText(/pending reauthorization/i)).not.toBeInTheDocument();
+    expect(screen.queryByText(/changing the microsoft app requires reconnecting/i)).not.toBeInTheDocument();
+  });
+
+  it('shows no pending state when the already-persisted app is reselected', async () => {
+    const existingProvider = {
+      id: '123',
+      tenant: 'test-tenant-123',
+      providerType: 'microsoft' as const,
+      providerName: 'Existing Microsoft',
+      mailbox: 'existing@microsoft.com',
+      isActive: true,
+      status: 'connected' as const,
+      microsoftConfig: {
+        client_id: 'acme-client-id',
+        microsoft_profile_id: 'profile-1',
+        client_secret_ref: 'microsoft_profile_profile-1_client_secret',
+        tenant_id: 'tenant-dir-1',
+        redirect_uri: 'http://localhost:3000/api/auth/microsoft/callback',
+        folder_filters: ['Inbox'],
+        auto_process_emails: true,
+        max_emails_per_sync: 50,
+      },
+      createdAt: '2024-01-01',
+      updatedAt: '2024-01-01',
+    };
+
+    const user = userEvent.setup();
+    renderWithProviders(<MicrosoftProviderForm {...defaultProps} provider={existingProvider as any} />);
+    await screen.findByText('AlgaPSA app (managed by Nine Minds)');
+
+    // Defaults to the persisted Acme profile: current, no pending.
+    expect(screen.getByText('Current app: Acme Email App')).toBeInTheDocument();
+    expect(screen.queryByText(/pending reauthorization/i)).not.toBeInTheDocument();
+
+    // Switch away, then reselect the persisted app: pending state clears.
+    await user.click(screen.getByText('AlgaPSA app (managed by Nine Minds)'));
+    expect(screen.getByText('Selected app: AlgaPSA app (managed by Nine Minds)')).toBeInTheDocument();
+
+    await user.click(screen.getByText('Acme Email App'));
+    expect(screen.queryByText(/Selected app:/i)).not.toBeInTheDocument();
+    expect(screen.queryByText(/pending reauthorization/i)).not.toBeInTheDocument();
+    expect(screen.queryByText(/changing the microsoft app requires reconnecting/i)).not.toBeInTheDocument();
+  });
 });

--- a/server/src/test/unit/components/MicrosoftProviderForm.test.tsx
+++ b/server/src/test/unit/components/MicrosoftProviderForm.test.tsx
@@ -236,15 +236,57 @@ describe('MicrosoftProviderForm', () => {
     });
   });
 
-  it('shows the ready state and enables Microsoft sign-in', () => {
+  it('enables Microsoft sign-in once an app is selected, without a setup banner', async () => {
     renderWithProviders(<MicrosoftProviderForm {...defaultProps} />);
 
-    expect(screen.getByText('Microsoft is set up. Sign in as this mailbox to finish.')).toBeInTheDocument();
+    await screen.findByText('AlgaPSA app (managed by Nine Minds)');
     expect(screen.getByRole('button', { name: /sign in with microsoft/i })).toBeEnabled();
-    expect(screen.queryByText(/platform-managed/i)).not.toBeInTheDocument();
+    expect(screen.queryByText(/isn't set up yet/i)).not.toBeInTheDocument();
+    expect(screen.queryByText('Microsoft is set up. Sign in as this mailbox to finish.')).not.toBeInTheDocument();
   });
 
-  it('shows one Providers action while administrator approval is pending', () => {
+  it('offers the own-app path as a quiet prompt when only the managed app exists', async () => {
+    vi.mocked(emailProviderActions.getMicrosoftEmailIssuerOptions).mockResolvedValue({
+      success: true,
+      issuers: {
+        managed: managedIssuers.issuers.managed,
+        profiles: [],
+        recommended: { kind: 'managed', clientId: 'managed-client-id' },
+      },
+    } as any);
+
+    renderWithProviders(
+      <MicrosoftProviderForm
+        {...defaultProps}
+        emailSetup={{
+          state: 'not_configured',
+          source: null,
+          hosted: true,
+          platformOffered: true,
+          automatedCreationAvailable: true,
+        }}
+      />
+    );
+
+    await screen.findByText('AlgaPSA app (managed by Nine Minds)');
+    expect(screen.getByText('Prefer to sign in with your own Microsoft app?')).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /Set it up in Providers/i })).toBeInTheDocument();
+    // Optional path guidance is not a warning and never blocks sign-in.
+    expect(screen.queryByText(/isn't set up yet/i)).not.toBeInTheDocument();
+    expect(screen.queryByRole('alert')).not.toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /sign in with microsoft/i })).toBeEnabled();
+  });
+
+  it('keeps sign-in available and shows a quiet status while the own app awaits admin approval', async () => {
+    vi.mocked(emailProviderActions.getMicrosoftEmailIssuerOptions).mockResolvedValue({
+      success: true,
+      issuers: {
+        managed: managedIssuers.issuers.managed,
+        profiles: [],
+        recommended: { kind: 'managed', clientId: 'managed-client-id' },
+      },
+    } as any);
+
     renderWithProviders(
       <MicrosoftProviderForm
         {...defaultProps}
@@ -259,27 +301,63 @@ describe('MicrosoftProviderForm', () => {
       />
     );
 
-    expect(screen.getByText(/Waiting for your Microsoft 365 administrator/i)).toBeInTheDocument();
+    await screen.findByText('AlgaPSA app (managed by Nine Minds)');
+    expect(
+      screen.getByText(/still waiting for Microsoft 365 administrator approval/i)
+    ).toBeInTheDocument();
     expect(screen.getAllByRole('button', { name: /Open Providers/i })).toHaveLength(1);
-    expect(screen.getByRole('button', { name: /Sign in with Microsoft/i })).toBeDisabled();
+    expect(screen.getByRole('button', { name: /Sign in with Microsoft/i })).toBeEnabled();
   });
 
-  it('points an unconfigured mailbox to Providers', () => {
+  it('warns and points to Providers only when no Microsoft app can be selected', async () => {
+    vi.mocked(emailProviderActions.getMicrosoftEmailIssuerOptions).mockResolvedValue({
+      success: true,
+      issuers: { managed: undefined, profiles: [], recommended: null },
+    } as any);
+
     renderWithProviders(
       <MicrosoftProviderForm
         {...defaultProps}
         emailSetup={{
           state: 'not_configured',
           source: null,
-          hosted: true,
-          platformOffered: true,
-          automatedCreationAvailable: true,
+          hosted: false,
+          platformOffered: false,
+          automatedCreationAvailable: false,
         }}
       />
     );
 
-    expect(screen.getByText(/Microsoft isn't set up yet/i)).toBeInTheDocument();
-    expect(screen.getByRole('button', { name: /Set up in Providers/i })).toBeInTheDocument();
+    expect(
+      await screen.findByText(/first set up a Microsoft app in Providers/i)
+    ).toBeInTheDocument();
+    expect(screen.getAllByRole('button', { name: /Open Providers/i })).toHaveLength(1);
+    expect(screen.getByRole('button', { name: /Sign in with Microsoft/i })).toBeDisabled();
+  });
+
+  it('explains the pending own app in the empty state while approval is outstanding', async () => {
+    vi.mocked(emailProviderActions.getMicrosoftEmailIssuerOptions).mockResolvedValue({
+      success: true,
+      issuers: { managed: undefined, profiles: [], recommended: null },
+    } as any);
+
+    renderWithProviders(
+      <MicrosoftProviderForm
+        {...defaultProps}
+        emailSetup={{
+          state: 'pending_admin_consent',
+          source: 'tenant_app',
+          hosted: false,
+          platformOffered: false,
+          automatedCreationAvailable: false,
+          profileId: 'microsoft-profile-123',
+        }}
+      />
+    );
+
+    expect(
+      await screen.findByText(/waiting for Microsoft 365 administrator approval/i)
+    ).toBeInTheDocument();
     expect(screen.getByRole('button', { name: /Sign in with Microsoft/i })).toBeDisabled();
   });
 

--- a/server/src/test/unit/components/MicrosoftProviderForm.test.tsx
+++ b/server/src/test/unit/components/MicrosoftProviderForm.test.tsx
@@ -17,9 +17,32 @@ vi.mock('@alga-psa/integrations/actions', () => ({
   upsertEmailProvider: vi.fn(),
   initiateEmailOAuth: vi.fn().mockResolvedValue({ success: false, error: 'not used in unit tests' }),
   getInboundTicketDefaults: vi.fn().mockResolvedValue({ defaults: [] }),
+  getMicrosoftEmailIssuerOptions: vi.fn(),
 }));
 
 import * as emailProviderActions from '@alga-psa/integrations/actions';
+
+const managedIssuers = {
+  success: true,
+  issuers: {
+    managed: {
+      kind: 'managed',
+      label: 'AlgaPSA app (managed by Nine Minds)',
+      clientId: 'managed-client-id',
+      recommended: true,
+    },
+    profiles: [
+      {
+        kind: 'profile',
+        label: 'Acme Email App',
+        clientId: 'acme-client-id',
+        profileId: 'profile-1',
+        tenantId: 'tenant-dir-1',
+      },
+    ],
+    recommended: { kind: 'managed', clientId: 'managed-client-id' },
+  },
+};
 
 describe('MicrosoftProviderForm', () => {
   const mockOnSuccess = vi.fn();
@@ -40,6 +63,7 @@ describe('MicrosoftProviderForm', () => {
 
   beforeEach(() => {
     vi.clearAllMocks();
+    vi.mocked(emailProviderActions.getMicrosoftEmailIssuerOptions).mockResolvedValue(managedIssuers as any);
     // Mock window.location
     Object.defineProperty(window, 'location', {
       configurable: true,
@@ -176,6 +200,7 @@ describe('MicrosoftProviderForm', () => {
         mailbox: 'test@microsoft.com',
         isActive: true,
         inboundTicketDefaultsId: undefined,
+        microsoftIssuer: { kind: 'managed', clientId: 'managed-client-id' },
         microsoftConfig: {
           client_id: '',
           client_secret: '',
@@ -312,5 +337,89 @@ describe('MicrosoftProviderForm', () => {
     await user.clear(maxEmailsInput);
     await user.type(maxEmailsInput, '200');
     expect(maxEmailsInput).toHaveValue(200);
+  });
+
+  it('lists the managed issuer as Recommended alongside eligible tenant apps', async () => {
+    renderWithProviders(<MicrosoftProviderForm {...defaultProps} />);
+
+    expect(await screen.findByText('AlgaPSA app (managed by Nine Minds)')).toBeInTheDocument();
+    expect(screen.getByText('Recommended')).toBeInTheDocument();
+    expect(screen.getByText('Acme Email App')).toBeInTheDocument();
+  });
+
+  it('carries the selected issuer and create purpose into OAuth initiation for a new mailbox', async () => {
+    vi.mocked(emailProviderActions.upsertEmailProvider).mockResolvedValueOnce({
+      provider: {
+        id: 'provider-new',
+        tenant: 'test-tenant-123',
+        providerType: 'microsoft',
+        providerName: 'New Microsoft',
+        mailbox: 'new@microsoft.com',
+        isActive: true,
+        status: 'configuring',
+        createdAt: new Date().toISOString(),
+        updatedAt: new Date().toISOString(),
+      },
+    } as any);
+    vi.mocked(emailProviderActions.initiateEmailOAuth).mockResolvedValueOnce({
+      success: true,
+      authUrl: 'https://login.microsoftonline.com/common/oauth2/v2.0/authorize',
+      state: 'signed-token',
+    } as any);
+
+    const user = userEvent.setup();
+    renderWithProviders(<MicrosoftProviderForm {...defaultProps} />);
+    await screen.findByText('AlgaPSA app (managed by Nine Minds)');
+
+    await user.type(screen.getByPlaceholderText('e.g., Support Mailbox (internal)'), 'New Microsoft');
+    await user.type(screen.getByPlaceholderText('support@client.com'), 'new@microsoft.com');
+    await user.click(screen.getByRole('button', { name: /sign in with microsoft/i }));
+
+    await waitFor(() => {
+      expect(emailProviderActions.initiateEmailOAuth).toHaveBeenCalledWith({
+        provider: 'microsoft',
+        providerId: 'provider-new',
+        purpose: 'create',
+        issuer: { kind: 'managed', clientId: 'managed-client-id' },
+      });
+    });
+  });
+
+  it('warns that switching the Microsoft app requires reconnecting an existing mailbox', async () => {
+    const existingProvider = {
+      id: '123',
+      tenant: 'test-tenant-123',
+      providerType: 'microsoft' as const,
+      providerName: 'Existing Microsoft',
+      mailbox: 'existing@microsoft.com',
+      isActive: true,
+      status: 'connected' as const,
+      microsoftConfig: {
+        client_id: 'acme-client-id',
+        microsoft_profile_id: 'profile-1',
+        client_secret_ref: 'microsoft_profile_profile-1_client_secret',
+        tenant_id: 'tenant-dir-1',
+        redirect_uri: 'http://localhost:3000/api/auth/microsoft/callback',
+        folder_filters: ['Inbox'],
+        auto_process_emails: true,
+        max_emails_per_sync: 50,
+      },
+      createdAt: '2024-01-01',
+      updatedAt: '2024-01-01',
+    };
+
+    const user = userEvent.setup();
+    renderWithProviders(<MicrosoftProviderForm {...defaultProps} provider={existingProvider as any} />);
+    const managedOption = await screen.findByText('AlgaPSA app (managed by Nine Minds)');
+
+    expect(screen.queryByText(/changing the microsoft app requires reconnecting/i)).not.toBeInTheDocument();
+
+    await user.click(managedOption);
+
+    expect(
+      screen.getByText(
+        'Changing the Microsoft app requires reconnecting this mailbox. Sign in with Microsoft again to finish the switch.'
+      )
+    ).toBeInTheDocument();
   });
 });

--- a/server/src/test/unit/email/MicrosoftGraphAdapter.subscription.test.ts
+++ b/server/src/test/unit/email/MicrosoftGraphAdapter.subscription.test.ts
@@ -3,6 +3,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 const mocks = vi.hoisted(() => {
   const requestUse = vi.fn();
   const tokenPost = vi.fn();
+  const dbUpdate = vi.fn().mockResolvedValue(1);
   const client = {
     interceptors: { request: { use: requestUse } },
     get: vi.fn(),
@@ -10,7 +11,7 @@ const mocks = vi.hoisted(() => {
     patch: vi.fn(),
     delete: vi.fn(),
   };
-  return { client, requestUse, tokenPost };
+  return { client, requestUse, tokenPost, dbUpdate };
 });
 
 vi.mock('axios', () => ({
@@ -24,7 +25,7 @@ vi.mock('@alga-psa/shared/db/admin', () => ({
   getAdminConnection: vi.fn(async () => {
     const query: any = {
       where: vi.fn().mockReturnThis(),
-      update: vi.fn().mockResolvedValue(1),
+      update: mocks.dbUpdate,
     };
     return vi.fn(() => query);
   }),
@@ -65,6 +66,7 @@ function jwt(claims: Record<string, unknown>): string {
 describe('MicrosoftGraphAdapter subscription hygiene', () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    mocks.dbUpdate.mockResolvedValue(1);
     mocks.client.delete.mockResolvedValue({ status: 204 });
     mocks.client.post.mockResolvedValue({
       data: { id: 'new-subscription', expirationDateTime: new Date(Date.now() + 3600000).toISOString() },
@@ -160,6 +162,20 @@ describe('MicrosoftGraphAdapter subscription hygiene', () => {
 
     await expect(new MicrosoftGraphAdapter(config()).registerWebhookSubscription())
       .rejects.toMatchObject<Partial<MicrosoftSubscriptionError>>({ kind: 'authentication', status: 403 });
+  });
+
+  it('propagates a subscription-id persistence failure instead of swallowing it (the callback can then compensate)', async () => {
+    const dbError = new Error('injected: UPDATE microsoft_email_provider_config failed');
+    mocks.dbUpdate.mockRejectedValue(dbError);
+
+    // The failure must leave registerWebhookSubscription as a
+    // MicrosoftSubscriptionError classified 'other' (never 'validation', which
+    // the callback would downgrade to a polling fallback), and must keep the
+    // original DB error in its cause chain for diagnostics/compensation.
+    await expect(new MicrosoftGraphAdapter(config()).registerWebhookSubscription())
+      .rejects.toMatchObject<Partial<MicrosoftSubscriptionError>>({ kind: 'other' });
+    await expect(new MicrosoftGraphAdapter(config()).registerWebhookSubscription())
+      .rejects.toSatisfy((err: any) => err?.cause?.message === dbError.message);
   });
 });
 

--- a/server/src/test/unit/email/microsoftEmailProviderConfig.test.ts
+++ b/server/src/test/unit/email/microsoftEmailProviderConfig.test.ts
@@ -1,5 +1,77 @@
-import { describe, expect, it } from 'vitest';
+import { afterAll, beforeAll, describe, expect, it, vi } from 'vitest';
+
+const hoisted = vi.hoisted(() => {
+  const state = {
+    tenantSecrets: new Map<string, string>(),
+    appSecrets: new Map<string, string>(),
+    microsoftProfiles: [] as Record<string, unknown>[],
+    bindings: [] as Record<string, unknown>[],
+  };
+
+  const clone = <T,>(value: T): T => JSON.parse(JSON.stringify(value));
+  const matches = (row: Record<string, unknown>, conditions: Record<string, unknown>): boolean =>
+    Object.entries(conditions).every(([key, value]) => row[key] === value);
+
+  const createQuery = (table: string) => {
+    const filters: Record<string, unknown>[] = [];
+    const filteredRows = () =>
+      (table.startsWith('microsoft_profile_consumer_bindings')
+        ? state.bindings
+        : table === 'microsoft_profiles'
+          ? state.microsoftProfiles
+          : []
+      ).filter((row) => filters.every((filter) => matches(row, filter)));
+
+    return {
+      where(conditions: Record<string, unknown>) {
+        filters.push(conditions);
+        return this;
+      },
+      andWhere(conditions: Record<string, unknown>) {
+        filters.push(conditions);
+        return this;
+      },
+      tenantJoin() {
+        return this;
+      },
+      async first() {
+        const row = filteredRows()[0];
+        return row ? clone(row) : undefined;
+      },
+    };
+  };
+
+  const dbMock: any = ((table: string) => createQuery(table)) as any;
+
+  return {
+    state,
+    getAdminConnection: vi.fn(async () => dbMock),
+    getAppSecret: vi.fn(async (key: string) => state.appSecrets.get(key) || null),
+    getTenantSecret: vi.fn(async (tenant: string, key: string) =>
+      state.tenantSecrets.get(`${tenant}:${key}`) || null
+    ),
+  };
+});
+
+vi.mock('@alga-psa/db', () => ({
+  getAdminConnection: hoisted.getAdminConnection,
+  destroyAdminConnection: vi.fn(),
+  refreshAdminConnection: vi.fn(),
+  tenantDb: (conn: any, tenant: string) => ({
+    table: (table: string) => conn(table).where({ tenant }),
+    tenantJoin: (query: any) => query,
+  }),
+}));
+
+vi.mock('@alga-psa/core/secrets', () => ({
+  getSecretProviderInstance: async () => ({
+    getAppSecret: hoisted.getAppSecret,
+    getTenantSecret: hoisted.getTenantSecret,
+  }),
+}));
+
 import {
+  buildMicrosoftEmailProviderConfig,
   selectMicrosoftEmailRuntimeCredentials,
   type MicrosoftEmailRuntimeCredentials,
 } from '@alga-psa/shared/services/email/microsoftEmailProviderConfig';
@@ -59,5 +131,73 @@ describe('Microsoft email runtime credential selection', () => {
     });
 
     expect(selected).toBeNull();
+  });
+});
+
+describe('buildMicrosoftEmailProviderConfig provider-pinned issuer resolution', () => {
+  beforeEach(() => {
+    hoisted.state.tenantSecrets.clear();
+    hoisted.state.appSecrets.clear();
+    hoisted.state.microsoftProfiles.length = 0;
+    hoisted.state.bindings.length = 0;
+  });
+
+  it('T004/T014: resolves the pinned profile secret after the Email binding changes', async () => {
+    // Provider pinned to profile p-pinned (issuing app), current binding now
+    // points at a different app; the pinned profile holds a rotated secret.
+    hoisted.state.microsoftProfiles.push({
+      tenant: 'tenant-1',
+      profile_id: 'p-pinned',
+      client_id: 'provider-app',
+      client_secret_ref: 'ref-pinned',
+      tenant_id: 'tenant-dir',
+      capabilities: JSON.stringify(['email']),
+      is_archived: false,
+    });
+    hoisted.state.tenantSecrets.set('tenant-1:ref-pinned', 'rotated-secret');
+
+    const config = await buildMicrosoftEmailProviderConfig({
+      id: 'provider-1',
+      tenant: 'tenant-1',
+      name: 'Mailbox',
+      provider_type: 'microsoft',
+      mailbox: 'support@client.com',
+      folder_to_monitor: 'Inbox',
+      active: true,
+      provider_config: {
+        client_id: 'provider-app',
+        client_secret: 'stale-vendor-secret',
+        microsoft_profile_id: 'p-pinned',
+        client_secret_ref: 'ref-pinned',
+        tenant_id: 'tenant-dir',
+      },
+    } as any);
+
+    expect(config.provider_config.resolved_client_id).toBe('provider-app');
+    expect(config.provider_config.resolved_client_secret).toBe('rotated-secret');
+    expect(config.provider_config.resolved_profile_id).toBe('p-pinned');
+    expect(config.provider_config.resolved_client_secret_ref).toBe('ref-pinned');
+    expect(config.provider_config.resolved_credential_source).toBe('profile');
+  });
+
+  it('T009/T013: legacy rows without a pinned profile fall back to stored vendor credentials', async () => {
+    const config = await buildMicrosoftEmailProviderConfig({
+      id: 'provider-1',
+      tenant: 'tenant-1',
+      name: 'Mailbox',
+      provider_type: 'microsoft',
+      mailbox: 'support@client.com',
+      folder_to_monitor: 'Inbox',
+      active: true,
+      provider_config: {
+        client_id: 'legacy-app',
+        client_secret: 'legacy-vendor-secret',
+        tenant_id: 'common',
+      },
+    } as any);
+
+    expect(config.provider_config.resolved_client_id).toBe('legacy-app');
+    expect(config.provider_config.resolved_client_secret).toBe('legacy-vendor-secret');
+    expect(config.provider_config.resolved_credential_source).toBe('vendor');
   });
 });

--- a/server/src/test/unit/email/microsoftEmailProviderConfig.test.ts
+++ b/server/src/test/unit/email/microsoftEmailProviderConfig.test.ts
@@ -200,4 +200,133 @@ describe('buildMicrosoftEmailProviderConfig provider-pinned issuer resolution', 
     expect(config.provider_config.resolved_client_secret).toBe('legacy-vendor-secret');
     expect(config.provider_config.resolved_credential_source).toBe('vendor');
   });
+
+  it('fails closed when the pinned profile no longer exists instead of falling back to the Email binding', async () => {
+    // The provider pinned its issuer to profile p-gone, which has been deleted.
+    // A fallback Email binding points at a different app; the resolver must
+    // hard-fail rather than silently re-issuing tokens from another app.
+    hoisted.state.tenantSecrets.set('tenant-1:ref-gone', 'secret-for-gone-profile');
+    hoisted.state.bindings.push({
+      tenant: 'tenant-1',
+      consumer_type: 'email',
+      profile_id: 'p-bound',
+    });
+    hoisted.state.microsoftProfiles.push({
+      tenant: 'tenant-1',
+      profile_id: 'p-bound',
+      client_id: 'bound-app',
+      client_secret_ref: 'ref-bound',
+      tenant_id: 'tenant-dir',
+      capabilities: JSON.stringify(['email']),
+      is_archived: false,
+    });
+    hoisted.state.tenantSecrets.set('tenant-1:ref-bound', 'bound-secret');
+
+    await expect(
+      buildMicrosoftEmailProviderConfig({
+        id: 'provider-1',
+        tenant: 'tenant-1',
+        name: 'Mailbox',
+        provider_type: 'microsoft',
+        mailbox: 'support@client.com',
+        folder_to_monitor: 'Inbox',
+        active: true,
+        provider_config: {
+          client_id: 'pinned-app',
+          client_secret: 'stale-vendor-secret',
+          microsoft_profile_id: 'p-gone',
+          client_secret_ref: 'ref-gone',
+          tenant_id: 'tenant-dir',
+        },
+      } as any)
+    ).rejects.toThrow(/pinned to profile p-gone/);
+    await expect(
+      buildMicrosoftEmailProviderConfig({
+        id: 'provider-1',
+        tenant: 'tenant-1',
+        name: 'Mailbox',
+        provider_type: 'microsoft',
+        mailbox: 'support@client.com',
+        folder_to_monitor: 'Inbox',
+        active: true,
+        provider_config: {
+          client_id: 'pinned-app',
+          client_secret: 'stale-vendor-secret',
+          microsoft_profile_id: 'p-gone',
+          client_secret_ref: 'ref-gone',
+          tenant_id: 'tenant-dir',
+        },
+      } as any)
+    ).rejects.toThrow(/ms_email_provider_not_found/);
+  });
+
+  it('fails closed when the pinned profile resolves but disagrees with the persisted issuing client', async () => {
+    // The pin references an existing profile whose app differs from the
+    // persisted client_id; that is a corrupted pin, not a fallback signal.
+    hoisted.state.microsoftProfiles.push({
+      tenant: 'tenant-1',
+      profile_id: 'p-wrong',
+      client_id: 'different-app',
+      client_secret_ref: 'ref-wrong',
+      tenant_id: 'tenant-dir',
+      capabilities: JSON.stringify(['email']),
+      is_archived: false,
+    });
+    hoisted.state.tenantSecrets.set('tenant-1:ref-wrong', 'wrong-secret');
+
+    await expect(
+      buildMicrosoftEmailProviderConfig({
+        id: 'provider-1',
+        tenant: 'tenant-1',
+        name: 'Mailbox',
+        provider_type: 'microsoft',
+        mailbox: 'support@client.com',
+        folder_to_monitor: 'Inbox',
+        active: true,
+        provider_config: {
+          client_id: 'pinned-app',
+          client_secret: 'stale-vendor-secret',
+          microsoft_profile_id: 'p-wrong',
+          client_secret_ref: 'ref-wrong',
+          tenant_id: 'tenant-dir',
+        },
+      } as any)
+    ).rejects.toThrow(/ms_email_client_mismatch_reconnect_required/);
+  });
+
+  it('never resolves the tenant Teams app as an email credential source', async () => {
+    // Even if a provider row is somehow pinned to a profile carrying the
+    // well-known Teams app client id (with email capability misconfigured on),
+    // the resolver must fail closed instead of handing the Teams app's
+    // credentials to a mailbox.
+    hoisted.state.microsoftProfiles.push({
+      tenant: 'tenant-1',
+      profile_id: 'p-teams',
+      client_id: '02c1ecbc-10db-4439-b002-1187acf7b268',
+      client_secret_ref: 'ref-teams',
+      tenant_id: 'tenant-dir',
+      capabilities: JSON.stringify(['email', 'teams']),
+      is_archived: false,
+    });
+    hoisted.state.tenantSecrets.set('tenant-1:ref-teams', 'teams-secret');
+
+    await expect(
+      buildMicrosoftEmailProviderConfig({
+        id: 'provider-1',
+        tenant: 'tenant-1',
+        name: 'Mailbox',
+        provider_type: 'microsoft',
+        mailbox: 'support@client.com',
+        folder_to_monitor: 'Inbox',
+        active: true,
+        provider_config: {
+          client_id: '02c1ecbc-10db-4439-b002-1187acf7b268',
+          client_secret: 'teams-secret',
+          microsoft_profile_id: 'p-teams',
+          client_secret_ref: 'ref-teams',
+          tenant_id: 'tenant-dir',
+        },
+      } as any)
+    ).rejects.toThrow(/ms_email_provider_not_found/);
+  });
 });

--- a/server/src/test/unit/microsoft/microsoftConsumerRuntimeResolution.contract.test.ts
+++ b/server/src/test/unit/microsoft/microsoftConsumerRuntimeResolution.contract.test.ts
@@ -88,7 +88,12 @@ describe('microsoft consumer runtime resolution contracts', () => {
     expect(emailCallbackSource).toContain("status: 'error'");
     expect(emailCallbackSource).toContain('error_message: message');
     expect(emailCallbackSource).toContain('CALLBACK_PERSISTENCE_FAILED');
-    expect(emailCallbackSource).toContain("resolveMicrosoftConsumerProfileConfig(stateContext.tenant, 'email')");
+    // Every callback verifies the signed state; the legacy binding resolution
+    // path is gone — no unsigned state, no automatic binding-based resolution.
+    expect(emailCallbackSource).toContain('verifySignedState');
+    expect(emailCallbackSource).not.toContain("resolveMicrosoftConsumerProfileConfig(stateContext.tenant, 'email')");
+    expect(emailCallbackSource).not.toContain('parseStateValue');
+    expect(emailCallbackSource).not.toContain('microsoftCredentialSource');
     expect(emailCallbackSource).not.toContain("getTenantSecret(stateData.tenant, 'microsoft_client_id')");
     expect(emailCallbackSource).not.toContain('process.env.MICROSOFT_CLIENT_ID');
 

--- a/server/src/test/unit/microsoft/microsoftConsumerRuntimeResolution.contract.test.ts
+++ b/server/src/test/unit/microsoft/microsoftConsumerRuntimeResolution.contract.test.ts
@@ -67,18 +67,28 @@ describe('microsoft consumer runtime resolution contracts', () => {
     expect(sharedResolverSource).toContain('resolveMicrosoftBindingCandidateProfile(db, tenant, secretProvider, consumerType)');
     expect(sharedResolverSource).not.toContain("from '../actions/integrations/microsoftActions'");
 
-    expect(emailOauthActionSource).toContain("resolveMicrosoftConsumerProfileConfig(tenant, 'email', {");
-    expect(emailOauthActionSource).toContain("credentialPreference: 'tenant'");
+    // Email OAuth initiation resolves an explicit issuer choice (managed or an
+    // eligible tenant profile) instead of silently following the Email binding.
+    expect(emailOauthActionSource).toContain('resolveMicrosoftEmailIssuerChoice(tenant, params.issuer)');
+    expect(emailOauthActionSource).toContain('purpose');
+    expect(emailOauthActionSource).not.toContain("credentialPreference: 'tenant'");
+    expect(emailOauthActionSource).not.toContain("resolveMicrosoftConsumerProfileConfig(tenant, 'email', {");
     expect(emailOauthActionSource).not.toContain("getTenantSecret(tenant, 'microsoft_client_id')");
     expect(emailOauthActionSource).not.toContain('process.env.MICROSOFT_CLIENT_ID');
     expect(emailProviderActionSource).toContain('preserveIssuingApp');
     expect(emailProviderActionSource).toContain('existingConfig?.refresh_token && !config.refresh_token');
+    // Explicit selection is authoritative; the binding survives only as the
+    // conservative legacy fallback inside persistence.
+    expect(emailProviderActionSource).toContain('resolveMicrosoftEmailIssuerChoice(tenant, issuer)');
+    expect(emailProviderActionSource).toContain('CLIENT_MISMATCH_RECONNECT_REQUIRED');
 
-    expect(emailCallbackSource).toContain("resolveMicrosoftConsumerProfileConfig(stateData.tenant, 'email')");
+    expect(emailCallbackSource).toContain('resolveMicrosoftEmailIssuerChoice(');
+    expect(emailCallbackSource).toContain('consumeMicrosoftEmailOAuthNonce');
     expect(emailCallbackSource).toContain('persistProviderError');
     expect(emailCallbackSource).toContain("status: 'error'");
     expect(emailCallbackSource).toContain('error_message: message');
-    expect(emailCallbackSource).toContain("error: 'token_persistence_failed'");
+    expect(emailCallbackSource).toContain('CALLBACK_PERSISTENCE_FAILED');
+    expect(emailCallbackSource).toContain("resolveMicrosoftConsumerProfileConfig(stateContext.tenant, 'email')");
     expect(emailCallbackSource).not.toContain("getTenantSecret(stateData.tenant, 'microsoft_client_id')");
     expect(emailCallbackSource).not.toContain('process.env.MICROSOFT_CLIENT_ID');
 

--- a/services/workflow-worker/src/actions/registerEmailAttachmentActions.ts
+++ b/services/workflow-worker/src/actions/registerEmailAttachmentActions.ts
@@ -105,6 +105,12 @@ async function buildMicrosoftProviderConfig(
       access_token: mc.access_token,
       refresh_token: mc.refresh_token,
       token_expires_at: mc.token_expires_at,
+      // The persisted profile pin is authoritative for which app issued the
+      // refresh token. Propagate it so buildMicrosoftEmailProviderConfig
+      // resolves ONLY through the pinned profile and fails closed when the
+      // pin is unresolvable — never silently falls back to the Email binding.
+      microsoft_profile_id: mc.microsoft_profile_id ?? null,
+      client_secret_ref: mc.client_secret_ref ?? null,
     },
   } as any;
 }

--- a/shared/services/email/microsoftEmailProviderConfig.ts
+++ b/shared/services/email/microsoftEmailProviderConfig.ts
@@ -87,6 +87,53 @@ async function resolveBoundProfileCredentials(
   };
 }
 
+/**
+ * Resolve credentials from the provider row's pinned profile (the persisted
+ * `microsoft_profile_id` + `client_secret_ref`), which is authoritative for the
+ * app that issued the refresh token. Unlike the current Email binding this
+ * keeps working after a binding change, and it lets a same-client secret
+ * rotation flow through without a reconnect.
+ */
+async function resolveProviderPinnedProfileCredentials(
+  tenant: string,
+  vendorConfig: NonNullable<EmailProviderConfig['provider_config']>
+): Promise<MicrosoftEmailRuntimeCredentials | null> {
+  const profileId = normalized(vendorConfig.microsoft_profile_id);
+  const secretRef = normalized(vendorConfig.client_secret_ref);
+  if (!profileId || !secretRef) return null;
+
+  const knex = await getAdminConnection();
+  const db = tenantDb(knex, tenant);
+  const profile = await db
+    .table('microsoft_profiles')
+    .where({ profile_id: profileId })
+    .first(
+      'profile_id',
+      'client_id',
+      'client_secret_ref',
+      'tenant_id',
+      'capabilities',
+      'is_archived'
+    );
+
+  if (!profile || profile.is_archived || !hasEmailCapability(profile.capabilities)) return null;
+  const secretProvider = await getSecretProviderInstance();
+  const clientSecret = normalized(
+    await secretProvider.getTenantSecret(tenant, profile.client_secret_ref)
+  );
+  const clientId = normalized(profile.client_id);
+  if (!clientId || !clientSecret) return null;
+
+  return {
+    clientId,
+    clientSecret,
+    tenantId: normalized(profile.tenant_id) || 'common',
+    profileId: profile.profile_id,
+    clientSecretRef: profile.client_secret_ref,
+    source: 'profile',
+  };
+}
+
 async function resolveFallbackCredentials(
   tenant: string,
   vendorConfig: NonNullable<EmailProviderConfig['provider_config']>,
@@ -139,24 +186,25 @@ async function resolveFallbackCredentials(
 
 /**
  * Resolves credentials before adapter construction. The client id stored on the
- * vendor row pins an existing refresh token to its issuing app. A newly-bound
- * profile may supply a rotated secret only when its client id still matches.
+ * vendor row pins an existing refresh token to its issuing app. The provider's
+ * pinned profile (persisted issuer metadata) is authoritative; the current
+ * Email binding is only consulted as a fallback, and a newly-bound profile may
+ * supply a rotated secret only when its client id still matches.
  */
 export async function buildMicrosoftEmailProviderConfig(
   config: EmailProviderConfig
 ): Promise<EmailProviderConfig> {
   const vendorConfig = config.provider_config || {};
   const issuingClientId = normalized(vendorConfig.client_id);
-  const profileCredentials = await resolveBoundProfileCredentials(config.tenant);
-  const fallbackCredentials = await resolveFallbackCredentials(
-    config.tenant,
-    vendorConfig,
-    issuingClientId
-  );
+  const [pinnedProfileCredentials, boundProfileCredentials, fallbackCredentials] = await Promise.all([
+    resolveProviderPinnedProfileCredentials(config.tenant, vendorConfig),
+    resolveBoundProfileCredentials(config.tenant),
+    resolveFallbackCredentials(config.tenant, vendorConfig, issuingClientId),
+  ]);
 
   const selected = selectMicrosoftEmailRuntimeCredentials({
     issuingClientId,
-    profileCredentials,
+    profileCredentials: pinnedProfileCredentials ?? boundProfileCredentials,
     fallbackCredentials,
   });
 

--- a/shared/services/email/microsoftEmailProviderConfig.ts
+++ b/shared/services/email/microsoftEmailProviderConfig.ts
@@ -2,6 +2,7 @@ import { getSecretProviderInstance } from '../../core/secretProvider';
 import { getAdminConnection } from '../../db/admin';
 import { tenantDb } from '@alga-psa/db';
 import type { EmailProviderConfig } from '../../interfaces/inbound-email.interfaces';
+import { MICROSOFT_TEAMS_APP_CLIENT_ID } from './microsoftGraphEndpoints';
 
 export type MicrosoftEmailCredentialSource = 'profile' | 'vendor' | 'environment' | 'legacy';
 
@@ -51,6 +52,11 @@ function hasEmailCapability(value: unknown): boolean {
   return !Array.isArray(capabilities) || capabilities.includes('email');
 }
 
+function isTeamsAppClientId(clientId: string): boolean {
+  const normalizedClientId = clientId.trim().toLowerCase();
+  return Boolean(normalizedClientId) && normalizedClientId === MICROSOFT_TEAMS_APP_CLIENT_ID.toLowerCase();
+}
+
 async function resolveBoundProfileCredentials(
   tenant: string
 ): Promise<MicrosoftEmailRuntimeCredentials | null> {
@@ -69,7 +75,7 @@ async function resolveBoundProfileCredentials(
       'profile.capabilities'
     );
 
-  if (!profile || !hasEmailCapability(profile.capabilities)) return null;
+  if (!profile || !hasEmailCapability(profile.capabilities) || isTeamsAppClientId(normalized(profile.client_id))) return null;
   const secretProvider = await getSecretProviderInstance();
   const clientSecret = normalized(
     await secretProvider.getTenantSecret(tenant, profile.client_secret_ref)
@@ -116,7 +122,7 @@ async function resolveProviderPinnedProfileCredentials(
       'is_archived'
     );
 
-  if (!profile || profile.is_archived || !hasEmailCapability(profile.capabilities)) return null;
+  if (!profile || profile.is_archived || !hasEmailCapability(profile.capabilities) || isTeamsAppClientId(normalized(profile.client_id))) return null;
   const secretProvider = await getSecretProviderInstance();
   const clientSecret = normalized(
     await secretProvider.getTenantSecret(tenant, profile.client_secret_ref)
@@ -186,27 +192,49 @@ async function resolveFallbackCredentials(
 
 /**
  * Resolves credentials before adapter construction. The client id stored on the
- * vendor row pins an existing refresh token to its issuing app. The provider's
- * pinned profile (persisted issuer metadata) is authoritative; the current
- * Email binding is only consulted as a fallback, and a newly-bound profile may
- * supply a rotated secret only when its client id still matches.
+ * vendor row pins an existing refresh token to its issuing app. A provider
+ * pinned to a tenant profile (persisted `microsoft_profile_id`) is resolved
+ * *only* through that profile: an unresolvable pin (profile deleted, archived,
+ * secret missing, capability removed) is a hard failure, never a silent
+ * fallback to the current Email binding. Providers without a profile pin
+ * (managed or legacy rows) fall back to stored/environment/legacy credentials
+ * that still match the pinned client id; the current Email binding may narrow a
+ * same-client candidate but never supplies a different app.
  */
 export async function buildMicrosoftEmailProviderConfig(
   config: EmailProviderConfig
 ): Promise<EmailProviderConfig> {
   const vendorConfig = config.provider_config || {};
   const issuingClientId = normalized(vendorConfig.client_id);
-  const [pinnedProfileCredentials, boundProfileCredentials, fallbackCredentials] = await Promise.all([
-    resolveProviderPinnedProfileCredentials(config.tenant, vendorConfig),
-    resolveBoundProfileCredentials(config.tenant),
-    resolveFallbackCredentials(config.tenant, vendorConfig, issuingClientId),
-  ]);
+  const profileId = normalized(vendorConfig.microsoft_profile_id);
+  const hasProfilePin = Boolean(profileId);
 
-  const selected = selectMicrosoftEmailRuntimeCredentials({
-    issuingClientId,
-    profileCredentials: pinnedProfileCredentials ?? boundProfileCredentials,
-    fallbackCredentials,
-  });
+  let selected: MicrosoftEmailRuntimeCredentials | null = null;
+  if (hasProfilePin) {
+    const pinnedProfileCredentials = await resolveProviderPinnedProfileCredentials(config.tenant, vendorConfig);
+    if (!pinnedProfileCredentials) {
+      throw new Error(
+        `Microsoft email provider ${config.id} is pinned to profile ${profileId}, but that profile's credentials cannot be resolved (profile deleted, archived, or its secret/capability missing). Reconnect the mailbox to re-authorize it. (ms_email_provider_not_found)`
+      );
+    }
+    if (issuingClientId && !isSameClientId(issuingClientId, pinnedProfileCredentials.clientId)) {
+      throw new Error(
+        `Microsoft email provider ${config.id} is pinned to profile ${profileId} with client ${pinnedProfileCredentials.clientId}, which does not match the persisted issuing client ${issuingClientId}. Reconnect the mailbox to re-authorize it. (ms_email_client_mismatch_reconnect_required)`
+      );
+    }
+    selected = pinnedProfileCredentials;
+  } else {
+    const [boundProfileCredentials, fallbackCredentials] = await Promise.all([
+      resolveBoundProfileCredentials(config.tenant),
+      resolveFallbackCredentials(config.tenant, vendorConfig, issuingClientId),
+    ]);
+
+    selected = selectMicrosoftEmailRuntimeCredentials({
+      issuingClientId,
+      profileCredentials: boundProfileCredentials,
+      fallbackCredentials,
+    });
+  }
 
   if (!selected) {
     throw new Error(
@@ -226,4 +254,8 @@ export async function buildMicrosoftEmailProviderConfig(
       resolved_client_secret_ref: selected.clientSecretRef,
     },
   };
+}
+
+function isSameClientId(left: string, right: string): boolean {
+  return left.trim().toLowerCase() === right.trim().toLowerCase();
 }

--- a/shared/services/email/microsoftGraphEndpoints.ts
+++ b/shared/services/email/microsoftGraphEndpoints.ts
@@ -1,6 +1,14 @@
 const DEFAULT_GRAPH_BASE_URL = 'https://graph.microsoft.com/v1.0';
 const DEFAULT_LOGIN_BASE_URL = 'https://login.microsoftonline.com';
 
+/**
+ * The well-known Microsoft Teams application client id. The Teams app has no
+ * mailbox redirect URI and no Mail.Read grant, so it must never be resolved as
+ * an inbound-email issuer, backfilled onto an email provider, or used as an
+ * Email binding candidate.
+ */
+export const MICROSOFT_TEAMS_APP_CLIENT_ID = '02c1ecbc-10db-4439-b002-1187acf7b268';
+
 export const MICROSOFT_EMAIL_OAUTH_SCOPES = [
   'https://graph.microsoft.com/Mail.Read',
   'https://graph.microsoft.com/Mail.Read.Shared',

--- a/shared/services/email/processInboundEmailArtifacts.ts
+++ b/shared/services/email/processInboundEmailArtifacts.ts
@@ -168,6 +168,12 @@ async function buildMicrosoftProviderConfig(
       access_token: config.access_token,
       refresh_token: config.refresh_token,
       token_expires_at: config.token_expires_at,
+      // The persisted profile pin is authoritative for which app issued the
+      // refresh token. Propagate it so resolveMicrosoftEmailProviderConfig
+      // resolves ONLY through the pinned profile and fails closed when the
+      // pin is unresolvable — never silently falls back to the Email binding.
+      microsoft_profile_id: config.microsoft_profile_id ?? null,
+      client_secret_ref: config.client_secret_ref ?? null,
     },
   } as any;
 }

--- a/shared/services/email/providers/MicrosoftGraphAdapter.ts
+++ b/shared/services/email/providers/MicrosoftGraphAdapter.ts
@@ -44,6 +44,17 @@ export class MicrosoftSubscriptionError extends Error {
   }
 }
 
+/**
+ * Receives a record of Graph subscription mutations performed by the adapter.
+ * The OAuth callback wires this into a compensation ledger so that a failed
+ * webhook setup can delete subscriptions it created and can avoid resurrecting
+ * a subscription id that no longer exists in Graph.
+ */
+export interface MicrosoftGraphWebhookLifecycleObserver {
+  onSubscriptionDeleted(subscriptionId: string): void;
+  onSubscriptionCreated(subscriptionId: string): void;
+}
+
 export interface MicrosoftWebhookInitializationResult {
   success: boolean;
   subscriptionId?: string;
@@ -97,6 +108,7 @@ export class MicrosoftGraphAdapter extends BaseEmailAdapter {
   private httpClient: AxiosInstance;
   private baseUrl = getMicrosoftGraphBaseUrl();
   private authenticatedUserEmail: string | undefined; // Email of the user who authorized the app
+  private webhookLifecycle: MicrosoftGraphWebhookLifecycleObserver | undefined;
 
   constructor(config: EmailProviderConfig) {
     super(config);
@@ -118,6 +130,15 @@ export class MicrosoftGraphAdapter extends BaseEmailAdapter {
       }
       return config;
     });
+  }
+
+  /**
+   * Register an observer for Graph subscription mutations so the OAuth
+   * callback can compensate (delete) any subscription created by a setup that
+   * subsequently fails.
+   */
+  attachWebhookLifecycle(observer: MicrosoftGraphWebhookLifecycleObserver): void {
+    this.webhookLifecycle = observer;
   }
 
   /**
@@ -546,13 +567,18 @@ export class MicrosoftGraphAdapter extends BaseEmailAdapter {
     if (!oldSubscriptionId) return;
     try {
       await this.httpClient.delete(`/subscriptions/${encodeURIComponent(oldSubscriptionId)}`);
+      this.webhookLifecycle?.onSubscriptionDeleted(oldSubscriptionId);
     } catch (error: any) {
-      if (error?.response?.status !== 404) {
-        this.log('warn', 'Failed to delete previous Microsoft subscription before replacement', {
-          subscriptionId: oldSubscriptionId,
-          error: error?.message || String(error),
-        });
+      if (error?.response?.status === 404) {
+        // The previous subscription no longer exists in Graph; record that so
+        // compensation never restores a phantom id.
+        this.webhookLifecycle?.onSubscriptionDeleted(oldSubscriptionId);
+        return;
       }
+      this.log('warn', 'Failed to delete previous Microsoft subscription before replacement', {
+        subscriptionId: oldSubscriptionId,
+        error: error?.message || String(error),
+      });
     }
   }
 
@@ -595,10 +621,11 @@ export class MicrosoftGraphAdapter extends BaseEmailAdapter {
 
       await this.deletePreviousSubscription();
       const response = await this.httpClient.post('/subscriptions', subscription);
-      
+
       // Update config with subscription ID
       this.config.webhook_subscription_id = response.data.id;
       this.config.webhook_expires_at = response.data.expirationDateTime;
+      this.webhookLifecycle?.onSubscriptionCreated(response.data.id);
 
       // Persist webhook details only in microsoft vendor config
       try {
@@ -1485,10 +1512,12 @@ export class MicrosoftGraphAdapter extends BaseEmailAdapter {
 
     try {
       await this.httpClient.delete(`/subscriptions/${encodeURIComponent(subscriptionId)}`);
+      this.webhookLifecycle?.onSubscriptionDeleted(subscriptionId);
     } catch (error: any) {
       if (error?.response?.status !== 404) {
         throw this.handleError(error, 'deleteWebhookSubscription');
       }
+      this.webhookLifecycle?.onSubscriptionDeleted(subscriptionId);
     }
   }
 

--- a/shared/services/email/providers/MicrosoftGraphAdapter.ts
+++ b/shared/services/email/providers/MicrosoftGraphAdapter.ts
@@ -627,7 +627,12 @@ export class MicrosoftGraphAdapter extends BaseEmailAdapter {
       this.config.webhook_expires_at = response.data.expirationDateTime;
       this.webhookLifecycle?.onSubscriptionCreated(response.data.id);
 
-      // Persist webhook details only in microsoft vendor config
+      // Persist webhook details in the microsoft vendor config. A failure here
+      // MUST propagate: the Graph subscription has already been created and the
+      // previous one already deleted, so a swallowed write would leave the
+      // config row pointing at a subscription that no longer exists in Graph.
+      // The OAuth callback's compensation ledger then deletes the orphaned
+      // subscription and restores the prior connected/polling state.
       try {
         const knex = await getAdminConnection();
         await tenantDb(knex, this.config.tenant).table('microsoft_email_provider_config')
@@ -642,7 +647,11 @@ export class MicrosoftGraphAdapter extends BaseEmailAdapter {
             updated_at: new Date().toISOString(),
           });
       } catch (dbErr: any) {
-        this.log('warn', `Failed to persist Microsoft webhook subscription: ${dbErr?.message}`);
+        this.log('error', 'Failed to persist Microsoft webhook subscription state; propagating so compensation can delete the orphaned Graph subscription', {
+          subscriptionId: response.data.id,
+          error: dbErr?.message || String(dbErr),
+        });
+        throw dbErr;
       }
 
       this.log('info', `Webhook subscription created: ${response.data.id}`);

--- a/shared/services/email/unifiedInboundEmailQueueJobProcessor.ts
+++ b/shared/services/email/unifiedInboundEmailQueueJobProcessor.ts
@@ -288,7 +288,9 @@ async function fetchMicrosoftProviderConfig(job: UnifiedInboundEmailQueueJob): P
       db.raw('mc.token_expires_at as mc_token_expires_at'),
       db.raw('mc.webhook_subscription_id as mc_webhook_subscription_id'),
       db.raw('mc.webhook_expires_at as mc_webhook_expires_at'),
-      db.raw('mc.folder_filters as mc_folder_filters')
+      db.raw('mc.folder_filters as mc_folder_filters'),
+      db.raw('mc.microsoft_profile_id as mc_microsoft_profile_id'),
+      db.raw('mc.client_secret_ref as mc_client_secret_ref')
     )) as any;
 
   if (!row) {
@@ -330,6 +332,12 @@ async function fetchMicrosoftProviderConfig(job: UnifiedInboundEmailQueueJob): P
       access_token: (row as any).mc_access_token,
       refresh_token: (row as any).mc_refresh_token,
       token_expires_at: (row as any).mc_token_expires_at,
+      // The persisted profile pin is authoritative for which app issued the
+      // refresh token. Propagate it so buildMicrosoftEmailProviderConfig
+      // resolves ONLY through the pinned profile and fails closed when the
+      // pin is unresolvable — never silently falls back to the Email binding.
+      microsoft_profile_id: (row as any).mc_microsoft_profile_id ?? null,
+      client_secret_ref: (row as any).mc_client_secret_ref ?? null,
     },
   } as any);
 }


### PR DESCRIPTION
## Let inbound Microsoft email select its OAuth application

Inbound Microsoft email no longer infers its OAuth application from the tenant `Email` binding (which may point at Teams or another app and can fail authorization with `AADSTS50011`). It now requires an explicit choice between the hosted/managed application and eligible tenant Microsoft profiles, and treats the persisted provider-row issuer identity as authoritative after connection.

### What changed

**Selection contract**
- Explicit issuer choice DTO, eligible-profile query, hosted-managed recommendation, and stable machine-readable errors (`ms_email_*`) for invalid choice, missing/foreign/inactive/non-Email profile, issuer not ready, client mismatch/reconnect-required, and invalid/expired/replayed state.
- Eligible issuer list proves each profile secret is resolvable (`getTenantSecret` on `client_secret_ref`) before offering or backfilling it; a profile that claims readiness but has no resolvable secret is never selectable. Teams stays untouched and never Email-eligible (Teams-only client `02c1ecbc-10db-4439-b002-1187acf7b268` is excluded).
- The tenant `Email` binding survives only as the create-flow UI default and a conservative runtime/backfill hint, never as an authoritative issuer.

**Signed OAuth state**
- Microsoft email OAuth state is now the signed `base64url(JSON).HMAC` token carrying tenant, provider, explicit issuer choice, client ID, nonce, and purpose (`create`/`reconnect`) — never a secret.
- The callback consumes the nonce and enforces relationships server-side: purpose misuse (`ms_email_state_purpose_mismatch`), session-user mismatch (`ms_email_state_user_mismatch`), and reconnect providerId missing/foreign/non-Microsoft (`ms_email_provider_not_found` / `ms_email_provider_tenant_mismatch` / `ms_email_provider_type_not_supported`).
- The unsigned base64-JSON state path and the binding-resolution fallback are removed; the `/api/email/oauth/initiate` route no longer serves Microsoft (rejects with 400).

**Atomic persistence with compensation**
- Callback success atomically persists tokens and authoritative issuer metadata; failure preserves the previous working connection.
- Compensation is ledger-driven: every Graph subscription delete/create is recorded, and on failure created subscriptions are deleted (retry-safe, no duplicates) while the DB is restored to the prior snapshot with subscription fields re-derived so restore never resurrects a phantom subscription or contradicts Graph state.
- `MicrosoftGraphAdapter.registerWebhookSubscription` no longer swallows a subscription-id/expiry UPDATE failure; it rethrows to the compensation path.

**Runtime resolution**
- The runtime resolver (`microsoftEmailProviderConfig.ts`) fails closed: a provider pinned via `microsoft_profile_id` resolves only through that profile and throws `ms_email_provider_not_found` / `ms_email_client_mismatch_reconnect_required` instead of falling back to the Email binding.
- Same-client secret rotation is allowed; a different client ID requires reconnect.
- The unified-queue worker, `processInboundEmailArtifacts`, and the workflow-worker attachment action propagate `microsoft_profile_id`/`client_secret_ref` into the resolver.

**Read purity**
- `getMicrosoftIntegrationStatus()` / `getMicrosoftConsumerSetupStatus()` are strictly read-only (zero writes, no issuer/binding backfill, no migrations). Backfill is a separate auth-guarded mutation (`runMicrosoftEmailIssuerBackfill()`, `system_settings:update`) invoked only from an explicit profile save/reconnect.
- Legacy unmigrated tenants surface their `microsoft_client_*` secrets as an unmigrated/legacy profile view without materializing rows; `ensure*` stay only on mutation surfaces.

**UI**
- Progressive-disclosure create/reconnect form: hosted app preselected and recommended, eligible tenant profiles listed, Teams-only excluded, setup warning only when nothing can be offered.
- Connected edit form shows the current authoritative issuer ("Current app: …"), a newly selected different app as "Selected app" + "Pending reauthorization", and rejects a plain Update with reconnect-required while DB stays pinned to the current issuer pre-callback.

### Tests

Large DB-backed behavioral suite against real PostgreSQL: callback-route integration, signed-state relationship DB guard, OAuth result persistence/compensation, runtime pinning, Teams status read purity, legacy tenant read purity, same-app Update regression, plus unit coverage of the state guard, issuer selection, resolver, provider form, and OAuth state utils.

### Smoke test — PASS with one concern

Real UI on port 3340 verified: hosted Nine Minds app is preselected and Recommended; two eligible tenant apps appeared; Teams-only client `02c1ecbc-10db-4439-b002-1187acf7b268` was excluded. Alpha OAuth completed end-to-end through the repository Graph/OAuth emulator and persisted signed-state issuer selection, tokens, and webhook delivery. The exact same-app Update regression passed: provider remained Connected, client/profile/token hashes were unchanged, the old subscription was deleted, and one replacement subscription ID/expiry was persisted. Switching Alpha→Beta showed Current app Alpha, Selected app Beta, and Pending reauthorization; plain Update was rejected and DB state remained unchanged. Reconnect completed through the callback, pinned Beta, and reloading showed Current app Beta. Tenant-wide bindings and the Teams-only profile were unchanged.

Fidelity compromise: Microsoft OAuth/Graph used the repository simulator because no real Entra tenant credentials/admin consent were available; the hosted managed-app callback was therefore not completed against Azure.

Concern: after an app switch, the old Alpha-owned Graph subscription remained live beside Beta because a Beta token cannot delete an Alpha-owned subscription; it will linger until expiry.

Cleanup completed: disposable rows/secrets removed, emulator stopped, normal non-emulator server restored on 3340, worktree clean.

Evidence: `/tmp/alga-smoke-evidence/ms-inbound-app-selection-20260811-073412`


### Latest updates

- Rebased onto `origin/main` to pick up the translation quality tooling and gates added on main.
- Added the 17 new UI strings to all seven locale packs (`pt`, `de`, `es`, `fr`, `it`, `nl`, `pl`) so the locale quality gate (untranslated / English-left-in-pack) passes with 0.
