### PR TITLE
Add Teams Bot Framework surface to msgraph emulator

### DIFF
--- a/ee/packages/microsoft-teams/src/lib/actions/integrations/teamsSetupValidationActions.ts
+++ b/ee/packages/microsoft-teams/src/lib/actions/integrations/teamsSetupValidationActions.ts
@@ -6,7 +6,7 @@ import { withAuth } from '@alga-psa/auth/withAuth';
 import { resolveTeamsMicrosoftProviderConfigImpl } from '../../auth/teamsMicrosoftProviderResolution';
 import { fetchMicrosoftGraphAppToken } from '../../graphAuth';
 import { readBotCredentialsFromEnv } from '../../teams/bot/teamsBotConnector';
-import { getMicrosoftTokenUrl } from '../../teams/microsoftEndpoints';
+import { getMicrosoftLoginBaseUrl, getMicrosoftTokenUrl } from '../../teams/microsoftEndpoints';
 import { getTeamsAvailability } from '../../teams/teamsAvailability';
 
 // Every Graph application permission the Teams integration actually exercises
@@ -94,6 +94,19 @@ function extractAadstsCode(text: string): string | null {
   return match ? match[0].toUpperCase() : null;
 }
 
+/**
+ * The host the token request actually went to. When the login base URL is
+ * redirected at an emulator, naming login.microsoftonline.com would send
+ * whoever is debugging a failed wizard check to the wrong host.
+ */
+function tokenHostLabel(url: string = getMicrosoftLoginBaseUrl()): string {
+  try {
+    return new URL(url).host;
+  } catch {
+    return url;
+  }
+}
+
 type GraphTokenFailureReason = Exclude<TeamsGraphCredentialFailureReason, 'addon_inactive'>;
 
 type GraphTokenAcquisition =
@@ -137,7 +150,7 @@ function classifyGraphTokenError(error: unknown): { reason: GraphTokenFailureRea
 
   return {
     reason: 'network_error',
-    message: `Could not reach login.microsoftonline.com to validate the Microsoft Graph credentials: ${raw}`,
+    message: `Could not reach ${tokenHostLabel()} to validate the Microsoft Graph credentials: ${raw}`,
   };
 }
 
@@ -288,9 +301,10 @@ async function requestBotFrameworkToken(credentials: {
   tenantId: string;
   password: string;
 }): Promise<BotTokenRequestResult> {
+  const tokenUrl = getMicrosoftTokenUrl(credentials.tenantId);
   let response: Response;
   try {
-    response = await fetch(getMicrosoftTokenUrl(credentials.tenantId), {
+    response = await fetch(tokenUrl, {
       method: 'POST',
       headers: {
         'Content-Type': 'application/x-www-form-urlencoded',
@@ -306,7 +320,7 @@ async function requestBotFrameworkToken(credentials: {
     return {
       ok: false,
       reason: 'network_error',
-      message: `Could not reach login.microsoftonline.com to validate the bot credentials: ${toErrorMessage(error)}`,
+      message: `Could not reach ${tokenHostLabel(tokenUrl)} to validate the bot credentials: ${toErrorMessage(error)}`,
     };
   }
 

--- a/ee/packages/microsoft-teams/src/lib/actions/integrations/teamsSetupValidationActions.ts
+++ b/ee/packages/microsoft-teams/src/lib/actions/integrations/teamsSetupValidationActions.ts
@@ -6,6 +6,7 @@ import { withAuth } from '@alga-psa/auth/withAuth';
 import { resolveTeamsMicrosoftProviderConfigImpl } from '../../auth/teamsMicrosoftProviderResolution';
 import { fetchMicrosoftGraphAppToken } from '../../graphAuth';
 import { readBotCredentialsFromEnv } from '../../teams/bot/teamsBotConnector';
+import { getMicrosoftTokenUrl } from '../../teams/microsoftEndpoints';
 import { getTeamsAvailability } from '../../teams/teamsAvailability';
 
 // Every Graph application permission the Teams integration actually exercises
@@ -289,21 +290,18 @@ async function requestBotFrameworkToken(credentials: {
 }): Promise<BotTokenRequestResult> {
   let response: Response;
   try {
-    response = await fetch(
-      `https://login.microsoftonline.com/${encodeURIComponent(credentials.tenantId)}/oauth2/v2.0/token`,
-      {
-        method: 'POST',
-        headers: {
-          'Content-Type': 'application/x-www-form-urlencoded',
-        },
-        body: new URLSearchParams({
-          grant_type: 'client_credentials',
-          client_id: credentials.appId,
-          client_secret: credentials.password,
-          scope: 'https://api.botframework.com/.default',
-        }),
-      }
-    );
+    response = await fetch(getMicrosoftTokenUrl(credentials.tenantId), {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/x-www-form-urlencoded',
+      },
+      body: new URLSearchParams({
+        grant_type: 'client_credentials',
+        client_id: credentials.appId,
+        client_secret: credentials.password,
+        scope: 'https://api.botframework.com/.default',
+      }),
+    });
   } catch (error) {
     return {
       ok: false,

--- a/ee/packages/microsoft-teams/src/lib/graphAuth.ts
+++ b/ee/packages/microsoft-teams/src/lib/graphAuth.ts
@@ -1,3 +1,5 @@
+import { getMicrosoftTokenUrl } from './teams/microsoftEndpoints';
+
 function normalizeString(value: unknown): string {
   return typeof value === 'string' ? value.trim() : '';
 }
@@ -8,7 +10,7 @@ export async function fetchMicrosoftGraphAppToken(params: {
   clientSecret: string;
 }): Promise<string> {
   const tokenResponse = await fetch(
-    `https://login.microsoftonline.com/${encodeURIComponent(params.tenantAuthority)}/oauth2/v2.0/token`,
+    getMicrosoftTokenUrl(params.tenantAuthority),
     {
       method: 'POST',
       headers: {

--- a/ee/packages/microsoft-teams/src/lib/notifications/teamsNotificationDelivery.ts
+++ b/ee/packages/microsoft-teams/src/lib/notifications/teamsNotificationDelivery.ts
@@ -9,6 +9,7 @@ import {
   buildNotificationSentPayload,
 } from '@alga-psa/workflow-streams';
 import { fetchMicrosoftGraphAppToken } from '../graphAuth';
+import { getMicrosoftGraphBaseUrl } from '../teams/microsoftEndpoints';
 import { tenantHasTeamsAddOn } from '../teams/teamsAddOnGate';
 import { buildTeamsNotificationDeepLinkFromPsaUrl } from '../teams/teamsDeepLinks';
 import { sendBotActivity, type SendBotActivityInput } from '../teams/bot/teamsBotConnector';
@@ -609,7 +610,7 @@ async function deliverTeamsActivityFeedNotification(params: {
     });
 
     const response = await sendGraphActivityNotificationWithRetry({
-      url: `https://graph.microsoft.com/v1.0/users/${encodeURIComponent(recipientLink.providerAccountId)}/teamwork/sendActivityNotification`,
+      url: `${getMicrosoftGraphBaseUrl()}/users/${encodeURIComponent(recipientLink.providerAccountId)}/teamwork/sendActivityNotification`,
       init: {
         method: 'POST',
         headers: {

--- a/ee/packages/microsoft-teams/src/lib/teams/__tests__/microsoftEndpoints.test.ts
+++ b/ee/packages/microsoft-teams/src/lib/teams/__tests__/microsoftEndpoints.test.ts
@@ -1,0 +1,54 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import {
+  getMicrosoftGraphBaseUrl,
+  getMicrosoftLoginBaseUrl,
+  getMicrosoftTokenUrl,
+} from '../microsoftEndpoints';
+
+/**
+ * These endpoints receive the bot secret, the setup-probe credentials, the
+ * Graph client secret, and activity-notification bearer tokens, so the
+ * emulator overrides must not survive into production.
+ */
+
+const EMULATOR = 'http://127.0.0.1:4010';
+
+afterEach(() => {
+  vi.unstubAllEnvs();
+});
+
+function stubOverrides(): void {
+  vi.stubEnv('MICROSOFT_LOGIN_BASE_URL', EMULATOR);
+  vi.stubEnv('MICROSOFT_GRAPH_BASE_URL', `${EMULATOR}/v1.0`);
+}
+
+describe('Teams Microsoft endpoints', () => {
+  it('honors the overrides outside production', () => {
+    vi.stubEnv('NODE_ENV', 'development');
+    stubOverrides();
+
+    expect(getMicrosoftLoginBaseUrl()).toBe(EMULATOR);
+    expect(getMicrosoftGraphBaseUrl()).toBe(`${EMULATOR}/v1.0`);
+    expect(getMicrosoftTokenUrl('tenant-1')).toBe(`${EMULATOR}/tenant-1/oauth2/v2.0/token`);
+  });
+
+  it('ignores the overrides in production', () => {
+    vi.stubEnv('NODE_ENV', 'production');
+    stubOverrides();
+
+    expect(getMicrosoftLoginBaseUrl()).toBe('https://login.microsoftonline.com');
+    expect(getMicrosoftGraphBaseUrl()).toBe('https://graph.microsoft.com/v1.0');
+    expect(getMicrosoftTokenUrl('tenant-1')).toBe(
+      'https://login.microsoftonline.com/tenant-1/oauth2/v2.0/token'
+    );
+  });
+
+  it('falls back to the Microsoft defaults when nothing is set', () => {
+    vi.stubEnv('NODE_ENV', 'development');
+    vi.stubEnv('MICROSOFT_LOGIN_BASE_URL', '');
+    vi.stubEnv('MICROSOFT_GRAPH_BASE_URL', '');
+
+    expect(getMicrosoftLoginBaseUrl()).toBe('https://login.microsoftonline.com');
+    expect(getMicrosoftGraphBaseUrl()).toBe('https://graph.microsoft.com/v1.0');
+  });
+});

--- a/ee/packages/microsoft-teams/src/lib/teams/__tests__/microsoftEndpoints.test.ts
+++ b/ee/packages/microsoft-teams/src/lib/teams/__tests__/microsoftEndpoints.test.ts
@@ -8,10 +8,13 @@ import {
 /**
  * These endpoints receive the bot secret, the setup-probe credentials, the
  * Graph client secret, and activity-notification bearer tokens, so the
- * emulator overrides must not survive into production.
+ * emulator overrides are honored only behind an explicit opt-in — never
+ * because NODE_ENV happens not to be the literal string "production".
  */
 
 const EMULATOR = 'http://127.0.0.1:4010';
+const MICROSOFT_LOGIN = 'https://login.microsoftonline.com';
+const MICROSOFT_GRAPH = 'https://graph.microsoft.com/v1.0';
 
 afterEach(() => {
   vi.unstubAllEnvs();
@@ -22,9 +25,16 @@ function stubOverrides(): void {
   vi.stubEnv('MICROSOFT_GRAPH_BASE_URL', `${EMULATOR}/v1.0`);
 }
 
+function expectMicrosoftDefaults(): void {
+  expect(getMicrosoftLoginBaseUrl()).toBe(MICROSOFT_LOGIN);
+  expect(getMicrosoftGraphBaseUrl()).toBe(MICROSOFT_GRAPH);
+  expect(getMicrosoftTokenUrl('tenant-1')).toBe(`${MICROSOFT_LOGIN}/tenant-1/oauth2/v2.0/token`);
+}
+
 describe('Teams Microsoft endpoints', () => {
-  it('honors the overrides outside production', () => {
+  it('honors the overrides when the emulator gate is explicitly on', () => {
     vi.stubEnv('NODE_ENV', 'development');
+    vi.stubEnv('TEAMS_EMULATOR_MODE', 'true');
     stubOverrides();
 
     expect(getMicrosoftLoginBaseUrl()).toBe(EMULATOR);
@@ -32,23 +42,37 @@ describe('Teams Microsoft endpoints', () => {
     expect(getMicrosoftTokenUrl('tenant-1')).toBe(`${EMULATOR}/tenant-1/oauth2/v2.0/token`);
   });
 
-  it('ignores the overrides in production', () => {
+  it('ignores the overrides in production even with the gate on', () => {
     vi.stubEnv('NODE_ENV', 'production');
+    vi.stubEnv('TEAMS_EMULATOR_MODE', 'true');
     stubOverrides();
 
-    expect(getMicrosoftLoginBaseUrl()).toBe('https://login.microsoftonline.com');
-    expect(getMicrosoftGraphBaseUrl()).toBe('https://graph.microsoft.com/v1.0');
-    expect(getMicrosoftTokenUrl('tenant-1')).toBe(
-      'https://login.microsoftonline.com/tenant-1/oauth2/v2.0/token'
-    );
+    expectMicrosoftDefaults();
+  });
+
+  // The fail-open case this replaced: a worker or staging host that never sets
+  // NODE_ENV used to honor every override.
+  it.each([
+    ['unset NODE_ENV and no gate', undefined, undefined],
+    ['staging with no gate', 'staging', undefined],
+    ['unset NODE_ENV with the gate on a value it does not recognize', undefined, 'staging'],
+    ['development with the gate explicitly off', 'development', 'false'],
+    ['development with an empty gate', 'development', ''],
+  ])('ignores the overrides with %s', (_label, nodeEnv, gate) => {
+    vi.stubEnv('NODE_ENV', nodeEnv as string | undefined);
+    vi.stubEnv('TEAMS_EMULATOR_MODE', gate as string | undefined);
+    stubOverrides();
+
+    expectMicrosoftDefaults();
   });
 
   it('falls back to the Microsoft defaults when nothing is set', () => {
     vi.stubEnv('NODE_ENV', 'development');
+    vi.stubEnv('TEAMS_EMULATOR_MODE', 'true');
     vi.stubEnv('MICROSOFT_LOGIN_BASE_URL', '');
     vi.stubEnv('MICROSOFT_GRAPH_BASE_URL', '');
 
-    expect(getMicrosoftLoginBaseUrl()).toBe('https://login.microsoftonline.com');
-    expect(getMicrosoftGraphBaseUrl()).toBe('https://graph.microsoft.com/v1.0');
+    expect(getMicrosoftLoginBaseUrl()).toBe(MICROSOFT_LOGIN);
+    expect(getMicrosoftGraphBaseUrl()).toBe(MICROSOFT_GRAPH);
   });
 });

--- a/ee/packages/microsoft-teams/src/lib/teams/bot/__tests__/teamsBotConnectorRetry.test.ts
+++ b/ee/packages/microsoft-teams/src/lib/teams/bot/__tests__/teamsBotConnectorRetry.test.ts
@@ -1,0 +1,184 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import {
+  BotConnectorRequestError,
+  sendBotActivity,
+  updateBotActivity,
+} from '../teamsBotConnector';
+
+/**
+ * The connector caches its access token, so an expiry between the cache check
+ * and the request is normal traffic, not a failure. It is replayed here — the
+ * one place every caller goes through (bot replies, DM notifications, the
+ * proactive welcome card, the diagnostics test send) — so no caller has to
+ * know about it, and none can forget.
+ */
+
+const SERVICE_URL = 'https://smba.trafficmanager.net/amer/';
+const TOKEN_URL = 'https://login.microsoftonline.com/bot-tenant-1/oauth2/v2.0/token';
+
+let fetchMock: ReturnType<typeof vi.fn>;
+
+function tokenResponse(token: string): Response {
+  return new Response(JSON.stringify({ access_token: token, expires_in: 3600 }), {
+    status: 200,
+    headers: { 'Content-Type': 'application/json' },
+  });
+}
+
+function activityResponse(status: number, body = '{}'): Response {
+  return new Response(body, { status, statusText: status === 401 ? 'Unauthorized' : 'Error' });
+}
+
+/** URLs of the activity POST/PUTs only, in order. */
+function activityCalls(): Array<{ url: string; init: RequestInit }> {
+  return fetchMock.mock.calls
+    .map(([url, init]) => ({ url: String(url), init: (init ?? {}) as RequestInit }))
+    .filter((call) => call.url !== TOKEN_URL);
+}
+
+function bearerTokens(): string[] {
+  return activityCalls().map(
+    (call) => String((call.init.headers as Record<string, string>).Authorization)
+  );
+}
+
+beforeEach(() => {
+  // Each test gets a fresh module registry so the connector's cached token
+  // never leaks between cases.
+  vi.resetModules();
+  vi.stubEnv('TEAMS_BOT_APP_ID', 'bot-app-1');
+  vi.stubEnv('TEAMS_BOT_APP_TENANT_ID', 'bot-tenant-1');
+  vi.stubEnv('TEAMS_BOT_APP_PASSWORD', 'bot-secret-1');
+  fetchMock = vi.fn();
+  vi.stubGlobal('fetch', fetchMock);
+});
+
+afterEach(() => {
+  vi.unstubAllEnvs();
+  vi.unstubAllGlobals();
+});
+
+async function loadConnector(): Promise<typeof import('../teamsBotConnector')> {
+  return import('../teamsBotConnector');
+}
+
+describe('bot connector expired-token replay', () => {
+  it('retries a 401 send once with a freshly minted token', async () => {
+    const connector = await loadConnector();
+    fetchMock
+      .mockResolvedValueOnce(tokenResponse('stale-token'))
+      .mockResolvedValueOnce(activityResponse(401))
+      .mockResolvedValueOnce(tokenResponse('fresh-token'))
+      .mockResolvedValueOnce(activityResponse(200));
+
+    await expect(
+      connector.sendBotActivity({
+        serviceUrl: SERVICE_URL,
+        conversationId: 'conversation-1',
+        activity: { type: 'message', text: 'hello' },
+      })
+    ).resolves.toEqual({ status: 'sent' });
+
+    expect(bearerTokens()).toEqual(['Bearer stale-token', 'Bearer fresh-token']);
+    // Same activity, byte for byte — a replay, not a downgrade.
+    expect(activityCalls()[0].init.body).toBe(activityCalls()[1].init.body);
+  });
+
+  it('surfaces a second 401 instead of retrying forever', async () => {
+    const connector = await loadConnector();
+    fetchMock
+      .mockResolvedValueOnce(tokenResponse('stale-token'))
+      .mockResolvedValueOnce(activityResponse(401))
+      .mockResolvedValueOnce(tokenResponse('fresh-token'))
+      .mockResolvedValueOnce(activityResponse(401));
+
+    await expect(
+      connector.sendBotActivity({
+        serviceUrl: SERVICE_URL,
+        conversationId: 'conversation-1',
+        activity: { type: 'message', text: 'hello' },
+      })
+    ).rejects.toMatchObject({ name: 'BotConnectorRequestError', status: 401 });
+
+    expect(activityCalls()).toHaveLength(2);
+  });
+
+  it('surfaces a card rejection that follows the replay, so callers can fall back', async () => {
+    const connector = await loadConnector();
+    fetchMock
+      .mockResolvedValueOnce(tokenResponse('stale-token'))
+      .mockResolvedValueOnce(activityResponse(401))
+      .mockResolvedValueOnce(tokenResponse('fresh-token'))
+      .mockResolvedValueOnce(activityResponse(415, 'adaptive rejected'));
+
+    await expect(
+      connector.sendBotActivity({
+        serviceUrl: SERVICE_URL,
+        conversationId: 'conversation-1',
+        activity: { type: 'message', text: 'hello' },
+      })
+    ).rejects.toMatchObject({ status: 415 });
+  });
+
+  it('does not retry a non-401 failure', async () => {
+    const connector = await loadConnector();
+    fetchMock
+      .mockResolvedValueOnce(tokenResponse('token-1'))
+      .mockResolvedValueOnce(activityResponse(403, 'nope'));
+
+    await expect(
+      connector.sendBotActivity({
+        serviceUrl: SERVICE_URL,
+        conversationId: 'conversation-1',
+        activity: { type: 'message', text: 'hello' },
+      })
+    ).rejects.toMatchObject({ status: 403 });
+
+    expect(activityCalls()).toHaveLength(1);
+  });
+
+  it('replays an in-place card update too', async () => {
+    const connector = await loadConnector();
+    fetchMock
+      .mockResolvedValueOnce(tokenResponse('stale-token'))
+      .mockResolvedValueOnce(activityResponse(401))
+      .mockResolvedValueOnce(tokenResponse('fresh-token'))
+      .mockResolvedValueOnce(activityResponse(200));
+
+    await expect(
+      connector.updateBotActivity({
+        serviceUrl: SERVICE_URL,
+        conversationId: 'conversation-1',
+        activityId: 'card-activity-1',
+        activity: { type: 'message', text: 'updated' },
+      })
+    ).resolves.toEqual({ status: 'sent' });
+
+    const calls = activityCalls();
+    expect(calls).toHaveLength(2);
+    expect(calls.every((call) => call.init.method === 'PUT')).toBe(true);
+    expect(calls[0].url).toContain('/v3/conversations/conversation-1/activities/card-activity-1');
+  });
+
+  it('keeps the untrusted-serviceUrl guard ahead of any send', async () => {
+    const connector = await loadConnector();
+
+    await expect(
+      connector.sendBotActivity({
+        serviceUrl: 'http://attacker.example.com',
+        conversationId: 'conversation-1',
+        activity: { type: 'message', text: 'hello' },
+      })
+    ).resolves.toEqual({ status: 'skipped', reason: 'untrusted_service_url' });
+
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+});
+
+describe('module exports', () => {
+  it('exposes the typed connector error the callers classify on', () => {
+    expect(new BotConnectorRequestError('boom', 429).status).toBe(429);
+    expect(typeof sendBotActivity).toBe('function');
+    expect(typeof updateBotActivity).toBe('function');
+  });
+});

--- a/ee/packages/microsoft-teams/src/lib/teams/bot/__tests__/teamsBotOpenIdOverride.test.ts
+++ b/ee/packages/microsoft-teams/src/lib/teams/bot/__tests__/teamsBotOpenIdOverride.test.ts
@@ -66,6 +66,7 @@ function configureBotCredentials(): void {
 
 function configureBot(): void {
   configureBotCredentials();
+  vi.stubEnv('TEAMS_EMULATOR_MODE', 'true');
   vi.stubEnv('TEAMS_BOT_OPENID_CONFIG_URL', `${baseUrl}/v1/.well-known/openidconfiguration`);
 }
 
@@ -101,9 +102,16 @@ describe('verifyTeamsBotRequest with TEAMS_BOT_OPENID_CONFIG_URL', () => {
     expect(result.status).toBe('rejected');
   });
 
-  it('ignores the override in production', async () => {
+  it.each([
+    ['in production', 'production', 'true'],
+    // Deny by default: a host that simply never sets NODE_ENV must not decide
+    // on its own whose JWTs the bot endpoint accepts.
+    ['when NODE_ENV is unset and the gate is off', undefined, undefined],
+    ['when the gate value is not recognized', 'development', 'staging'],
+  ])('ignores the override %s', async (_label, nodeEnv, gate) => {
     configureBot();
-    vi.stubEnv('NODE_ENV', 'production');
+    vi.stubEnv('NODE_ENV', nodeEnv as string | undefined);
+    vi.stubEnv('TEAMS_EMULATOR_MODE', gate as string | undefined);
 
     const requested: string[] = [];
     const realFetch = globalThis.fetch;

--- a/ee/packages/microsoft-teams/src/lib/teams/bot/__tests__/teamsBotOpenIdOverride.test.ts
+++ b/ee/packages/microsoft-teams/src/lib/teams/bot/__tests__/teamsBotOpenIdOverride.test.ts
@@ -1,0 +1,122 @@
+import http from 'node:http';
+import { SignJWT, exportJWK, generateKeyPair } from 'jose';
+import { afterAll, afterEach, beforeAll, describe, expect, it, vi } from 'vitest';
+import { resetTeamsBotJwksCacheForTests, verifyTeamsBotRequest } from '../teamsBotJwtVerifier';
+
+/**
+ * The emulator stands in for login.botframework.com by publishing its own
+ * OpenID config + JWKS and signing the activities it injects. This exercises
+ * that redirection through the real verifier: only discovery moves, signature,
+ * issuer, and audience checks all still run.
+ */
+
+const ISSUER = 'https://api.botframework.com';
+const APP_ID = 'emulated-teams-bot-app-id';
+
+let server: http.Server;
+let baseUrl: string;
+let signToken: (claims: Record<string, unknown>) => Promise<string>;
+
+beforeAll(async () => {
+  const { privateKey, publicKey } = await generateKeyPair('RS256');
+  const jwk = { ...(await exportJWK(publicKey)), kid: 'emulator-key', use: 'sig', alg: 'RS256' };
+
+  server = http
+    .createServer((req, res) => {
+      res.setHeader('content-type', 'application/json');
+      if (req.url === '/v1/.well-known/openidconfiguration') {
+        res.end(JSON.stringify({ issuer: ISSUER, jwks_uri: `${baseUrl}/v1/.well-known/keys` }));
+        return;
+      }
+      if (req.url === '/v1/.well-known/keys') {
+        res.end(JSON.stringify({ keys: [jwk] }));
+        return;
+      }
+      res.writeHead(404).end('{}');
+    })
+    .listen(0, '127.0.0.1');
+  await new Promise<void>((resolve) => server.once('listening', resolve));
+  baseUrl = `http://127.0.0.1:${(server.address() as { port: number }).port}`;
+
+  signToken = (claims) =>
+    new SignJWT(claims)
+      .setProtectedHeader({ alg: 'RS256', kid: 'emulator-key' })
+      .setIssuer(ISSUER)
+      .setAudience(APP_ID)
+      .setIssuedAt()
+      .setExpirationTime('1h')
+      .sign(privateKey);
+});
+
+afterAll(async () => {
+  await new Promise((resolve) => server.close(resolve));
+});
+
+afterEach(() => {
+  vi.unstubAllEnvs();
+  resetTeamsBotJwksCacheForTests();
+});
+
+function configureBot(): void {
+  vi.stubEnv('NODE_ENV', 'development');
+  vi.stubEnv('TEAMS_BOT_APP_ID', APP_ID);
+  vi.stubEnv('TEAMS_BOT_APP_TENANT_ID', 'tenant-1');
+  vi.stubEnv('TEAMS_BOT_APP_PASSWORD', 'secret');
+  vi.stubEnv('TEAMS_BOT_OPENID_CONFIG_URL', `${baseUrl}/v1/.well-known/openidconfiguration`);
+}
+
+describe('verifyTeamsBotRequest with TEAMS_BOT_OPENID_CONFIG_URL', () => {
+  it('verifies a token signed by the redirected identity provider', async () => {
+    configureBot();
+    const token = await signToken({ oid: 'guest-1', tid: 'tenant-1', serviceurl: baseUrl });
+
+    const result = await verifyTeamsBotRequest(`Bearer ${token}`);
+    expect(result.status).toBe('verified');
+    expect(result.status === 'verified' && result.payload).toMatchObject({
+      oid: 'guest-1',
+      serviceurl: baseUrl,
+    });
+  });
+
+  it('still rejects a token whose audience is not the bot app id', async () => {
+    configureBot();
+    vi.stubEnv('TEAMS_BOT_APP_ID', 'another-app-id');
+
+    const result = await verifyTeamsBotRequest(`Bearer ${await signToken({ oid: 'guest-1' })}`);
+    expect(result.status).toBe('rejected');
+  });
+
+  it('still rejects a tampered signature', async () => {
+    configureBot();
+    const token = await signToken({ oid: 'guest-1' });
+    const [header, payload, signature] = token.split('.');
+
+    const result = await verifyTeamsBotRequest(
+      `Bearer ${header}.${payload}.${signature.slice(0, -3)}abc`
+    );
+    expect(result.status).toBe('rejected');
+  });
+
+  it('ignores the override in production', async () => {
+    configureBot();
+    vi.stubEnv('NODE_ENV', 'production');
+
+    const requested: string[] = [];
+    const realFetch = globalThis.fetch;
+    globalThis.fetch = (async (input: RequestInfo | URL) => {
+      requested.push(String(input));
+      return new Response('{}', { status: 500 });
+    }) as typeof fetch;
+
+    try {
+      const result = await verifyTeamsBotRequest(`Bearer ${await signToken({ oid: 'guest-1' })}`);
+      expect(result.status).toBe('rejected');
+    } finally {
+      globalThis.fetch = realFetch;
+    }
+
+    expect(requested).toEqual([
+      'https://login.botframework.com/v1/.well-known/openidconfiguration',
+    ]);
+  });
+});

--- a/ee/packages/microsoft-teams/src/lib/teams/bot/__tests__/teamsBotOpenIdOverride.test.ts
+++ b/ee/packages/microsoft-teams/src/lib/teams/bot/__tests__/teamsBotOpenIdOverride.test.ts
@@ -1,6 +1,6 @@
 import http from 'node:http';
 import { SignJWT, exportJWK, generateKeyPair } from 'jose';
-import { afterAll, afterEach, beforeAll, describe, expect, it, vi } from 'vitest';
+import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it, vi } from 'vitest';
 import { resetTeamsBotJwksCacheForTests, verifyTeamsBotRequest } from '../teamsBotJwtVerifier';
 
 /**
@@ -57,11 +57,15 @@ afterEach(() => {
   resetTeamsBotJwksCacheForTests();
 });
 
-function configureBot(): void {
+function configureBotCredentials(): void {
   vi.stubEnv('NODE_ENV', 'development');
   vi.stubEnv('TEAMS_BOT_APP_ID', APP_ID);
   vi.stubEnv('TEAMS_BOT_APP_TENANT_ID', 'tenant-1');
   vi.stubEnv('TEAMS_BOT_APP_PASSWORD', 'secret');
+}
+
+function configureBot(): void {
+  configureBotCredentials();
   vi.stubEnv('TEAMS_BOT_OPENID_CONFIG_URL', `${baseUrl}/v1/.well-known/openidconfiguration`);
 }
 
@@ -118,5 +122,91 @@ describe('verifyTeamsBotRequest with TEAMS_BOT_OPENID_CONFIG_URL', () => {
     expect(requested).toEqual([
       'https://login.botframework.com/v1/.well-known/openidconfiguration',
     ]);
+  });
+});
+
+/**
+ * A restarted emulator signs with a fresh keypair, so the discovered JWKS has to
+ * go stale quickly on the override path — otherwise every injected activity is
+ * rejected until the app restarts. The default path must keep the 12h TTL.
+ *
+ * Only Date.now is moved; jose reads expiry off `new Date()`, so the signed
+ * tokens stay valid however far the cache clock is advanced.
+ */
+describe('JWKS cache TTL', () => {
+  const TWELVE_HOURS_MS = 12 * 60 * 60 * 1000;
+  let clockOffsetMs = 0;
+
+  beforeEach(() => {
+    clockOffsetMs = 0;
+    const realNow = Date.now.bind(Date);
+    vi.spyOn(Date, 'now').mockImplementation(() => realNow() + clockOffsetMs);
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  /** Counts discovery round trips, pointing the real Bot Framework host at the stub. */
+  function trackFetches(): { count: () => number; restore: () => void } {
+    const realFetch = globalThis.fetch;
+    let count = 0;
+    globalThis.fetch = ((input: RequestInfo | URL, init?: RequestInit) => {
+      count += 1;
+      return realFetch(
+        String(input).replace('https://login.botframework.com', baseUrl),
+        init
+      );
+    }) as typeof fetch;
+    return {
+      count: () => count,
+      restore: () => {
+        globalThis.fetch = realFetch;
+      },
+    };
+  }
+
+  it('re-discovers within seconds while the override is active', async () => {
+    configureBot();
+    const token = await signToken({ oid: 'guest-1' });
+    const fetches = trackFetches();
+
+    try {
+      expect((await verifyTeamsBotRequest(`Bearer ${token}`)).status).toBe('verified');
+      expect(fetches.count()).toBe(2);
+
+      clockOffsetMs = 29_000;
+      expect((await verifyTeamsBotRequest(`Bearer ${token}`)).status).toBe('verified');
+      expect(fetches.count()).toBe(2);
+
+      clockOffsetMs = 31_000;
+      expect((await verifyTeamsBotRequest(`Bearer ${token}`)).status).toBe('verified');
+      expect(fetches.count()).toBe(4);
+    } finally {
+      fetches.restore();
+    }
+  });
+
+  it('keeps the 12h TTL when TEAMS_BOT_OPENID_CONFIG_URL is unset', async () => {
+    configureBotCredentials();
+    vi.stubEnv('TEAMS_BOT_OPENID_CONFIG_URL', '');
+    const token = await signToken({ oid: 'guest-1' });
+    const fetches = trackFetches();
+
+    try {
+      expect((await verifyTeamsBotRequest(`Bearer ${token}`)).status).toBe('verified');
+      expect(fetches.count()).toBe(2);
+
+      // Far past the emulator TTL, still well inside the production one.
+      clockOffsetMs = TWELVE_HOURS_MS - 1_000;
+      expect((await verifyTeamsBotRequest(`Bearer ${token}`)).status).toBe('verified');
+      expect(fetches.count()).toBe(2);
+
+      clockOffsetMs = TWELVE_HOURS_MS + 1_000;
+      expect((await verifyTeamsBotRequest(`Bearer ${token}`)).status).toBe('verified');
+      expect(fetches.count()).toBe(4);
+    } finally {
+      fetches.restore();
+    }
   });
 });

--- a/ee/packages/microsoft-teams/src/lib/teams/bot/__tests__/teamsBotServiceUrlTrust.test.ts
+++ b/ee/packages/microsoft-teams/src/lib/teams/bot/__tests__/teamsBotServiceUrlTrust.test.ts
@@ -3,7 +3,13 @@ import { isTrustedServiceUrl } from '../teamsBotConnector';
 
 afterEach(() => {
   vi.unstubAllEnvs();
+  vi.restoreAllMocks();
 });
+
+function enableEmulatorMode(): void {
+  vi.stubEnv('NODE_ENV', 'development');
+  vi.stubEnv('TEAMS_EMULATOR_MODE', 'true');
+}
 
 describe('isTrustedServiceUrl', () => {
   it('rejects non-Microsoft service urls when no allowlist is configured', () => {
@@ -20,8 +26,8 @@ describe('isTrustedServiceUrl', () => {
     expect(isTrustedServiceUrl('http://smba.trafficmanager.net/amer/')).toBe(false);
   });
 
-  it('accepts exact allowlisted origins outside production', () => {
-    vi.stubEnv('NODE_ENV', 'development');
+  it('accepts exact allowlisted origins when the emulator gate is on', () => {
+    enableEmulatorMode();
     vi.stubEnv('TEAMS_BOT_SERVICE_URL_ALLOWLIST', 'http://localhost:4010, http://127.0.0.1:4010');
     expect(isTrustedServiceUrl('http://localhost:4010')).toBe(true);
     expect(isTrustedServiceUrl('http://localhost:4010/v3/conversations')).toBe(true);
@@ -33,8 +39,55 @@ describe('isTrustedServiceUrl', () => {
 
   it('ignores the allowlist entirely in production', () => {
     vi.stubEnv('NODE_ENV', 'production');
+    vi.stubEnv('TEAMS_EMULATOR_MODE', 'true');
     vi.stubEnv('TEAMS_BOT_SERVICE_URL_ALLOWLIST', 'http://localhost:4010');
     expect(isTrustedServiceUrl('http://localhost:4010')).toBe(false);
     expect(isTrustedServiceUrl('https://smba.trafficmanager.net/amer/')).toBe(true);
+  });
+
+  // Deny by default: an unset or unrecognized gate must leave the trust list
+  // exactly as narrow as production's, whatever NODE_ENV says.
+  it.each([
+    ['unset NODE_ENV and no gate', undefined, undefined],
+    ['staging with no gate', 'staging', undefined],
+    ['unset NODE_ENV with an unrecognized gate value', undefined, 'staging'],
+    ['development with the gate explicitly off', 'development', 'false'],
+  ])('ignores the allowlist with %s', (_label, nodeEnv, gate) => {
+    vi.stubEnv('NODE_ENV', nodeEnv as string | undefined);
+    vi.stubEnv('TEAMS_EMULATOR_MODE', gate as string | undefined);
+    vi.stubEnv('TEAMS_BOT_SERVICE_URL_ALLOWLIST', 'http://localhost:4010');
+    expect(isTrustedServiceUrl('http://localhost:4010')).toBe(false);
+    expect(isTrustedServiceUrl('https://smba.trafficmanager.net/amer/')).toBe(true);
+  });
+
+  /**
+   * `new URL('localhost:4010')` does not throw — it yields the opaque origin
+   * "null". Admitting that would trust every opaque-origin serviceUrl, so the
+   * entry is dropped and reported instead.
+   */
+  it('rejects a scheme-less allowlist entry instead of trusting opaque origins', () => {
+    enableEmulatorMode();
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    vi.stubEnv('TEAMS_BOT_SERVICE_URL_ALLOWLIST', 'localhost:4010');
+
+    expect(isTrustedServiceUrl('http://localhost:4010')).toBe(false);
+    expect(isTrustedServiceUrl('localhost:4010')).toBe(false);
+    expect(isTrustedServiceUrl('data:text/plain,hi')).toBe(false);
+    expect(warn).toHaveBeenCalledWith(
+      expect.stringContaining('TEAMS_BOT_SERVICE_URL_ALLOWLIST'),
+      { entry: 'localhost:4010' }
+    );
+  });
+
+  it('drops unparseable and non-http entries but keeps the valid ones', () => {
+    enableEmulatorMode();
+    vi.spyOn(console, 'warn').mockImplementation(() => {});
+    vi.stubEnv(
+      'TEAMS_BOT_SERVICE_URL_ALLOWLIST',
+      'not a url, ftp://localhost:4010, http://127.0.0.1:4010'
+    );
+
+    expect(isTrustedServiceUrl('http://127.0.0.1:4010')).toBe(true);
+    expect(isTrustedServiceUrl('ftp://localhost:4010')).toBe(false);
   });
 });

--- a/ee/packages/microsoft-teams/src/lib/teams/bot/__tests__/teamsBotServiceUrlTrust.test.ts
+++ b/ee/packages/microsoft-teams/src/lib/teams/bot/__tests__/teamsBotServiceUrlTrust.test.ts
@@ -1,0 +1,40 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { isTrustedServiceUrl } from '../teamsBotConnector';
+
+afterEach(() => {
+  vi.unstubAllEnvs();
+});
+
+describe('isTrustedServiceUrl', () => {
+  it('rejects non-Microsoft service urls when no allowlist is configured', () => {
+    vi.stubEnv('TEAMS_BOT_SERVICE_URL_ALLOWLIST', undefined);
+    expect(isTrustedServiceUrl('http://localhost:4010')).toBe(false);
+    expect(isTrustedServiceUrl('http://localhost:4010/')).toBe(false);
+    expect(isTrustedServiceUrl('http://127.0.0.1:4010')).toBe(false);
+    expect(isTrustedServiceUrl('https://attacker.example.com')).toBe(false);
+  });
+
+  it('keeps accepting real Bot Framework service urls', () => {
+    expect(isTrustedServiceUrl('https://smba.trafficmanager.net/amer/')).toBe(true);
+    expect(isTrustedServiceUrl('https://europe.botframework.com')).toBe(true);
+    expect(isTrustedServiceUrl('http://smba.trafficmanager.net/amer/')).toBe(false);
+  });
+
+  it('accepts exact allowlisted origins outside production', () => {
+    vi.stubEnv('NODE_ENV', 'development');
+    vi.stubEnv('TEAMS_BOT_SERVICE_URL_ALLOWLIST', 'http://localhost:4010, http://127.0.0.1:4010');
+    expect(isTrustedServiceUrl('http://localhost:4010')).toBe(true);
+    expect(isTrustedServiceUrl('http://localhost:4010/v3/conversations')).toBe(true);
+    expect(isTrustedServiceUrl('http://127.0.0.1:4010')).toBe(true);
+    // Exact origins only: a different port or host is still untrusted.
+    expect(isTrustedServiceUrl('http://localhost:4011')).toBe(false);
+    expect(isTrustedServiceUrl('http://evil.localhost:4010')).toBe(false);
+  });
+
+  it('ignores the allowlist entirely in production', () => {
+    vi.stubEnv('NODE_ENV', 'production');
+    vi.stubEnv('TEAMS_BOT_SERVICE_URL_ALLOWLIST', 'http://localhost:4010');
+    expect(isTrustedServiceUrl('http://localhost:4010')).toBe(false);
+    expect(isTrustedServiceUrl('https://smba.trafficmanager.net/amer/')).toBe(true);
+  });
+});

--- a/ee/packages/microsoft-teams/src/lib/teams/bot/teamsBotConnector.ts
+++ b/ee/packages/microsoft-teams/src/lib/teams/bot/teamsBotConnector.ts
@@ -1,3 +1,4 @@
+import { isTeamsEmulatorModeEnabled } from '../emulatorMode';
 import { getMicrosoftTokenUrl } from '../microsoftEndpoints';
 import type { TeamsBotResponseActivity } from './teamsBotHandler';
 
@@ -42,36 +43,74 @@ export function isBotConnectorConfigured(): boolean {
   return readBotCredentialsFromEnv() !== null;
 }
 
+const EMPTY_ALLOWLIST: ReadonlySet<string> = new Set();
+
+let allowlistCache: { raw: string; origins: ReadonlySet<string> } | null = null;
+
 /**
- * Extra serviceUrl origins trusted outside production, for pointing the bot at
- * a local emulator (algasim). Exact origins only, comma-separated, no
- * wildcards. Unset — the default — leaves the trust list byte-identical to the
- * Microsoft-only allowlist above, and it is ignored entirely under
- * NODE_ENV=production so it can never loosen the deployed trust boundary.
+ * A scheme-less entry such as `localhost:4010` still parses — as protocol
+ * `localhost:` with the opaque origin "null". Admitting "null" to the trust set
+ * would trust every opaque-origin serviceUrl, so only real http(s) origins are
+ * accepted and anything else is rejected loudly.
  */
-function developmentServiceUrlAllowlist(): Set<string> {
-  if (process.env.NODE_ENV === 'production') {
-    return new Set();
+function parseAllowlistOrigin(entry: string): string | null {
+  let parsed: URL;
+  try {
+    parsed = new URL(entry);
+  } catch {
+    return null;
+  }
+  if (parsed.origin === 'null' || (parsed.protocol !== 'http:' && parsed.protocol !== 'https:')) {
+    return null;
+  }
+  return parsed.origin.toLowerCase();
+}
+
+/**
+ * Extra serviceUrl origins trusted when the emulator gate is explicitly on, for
+ * pointing the bot at a local emulator (algasim). Exact origins only,
+ * comma-separated, no wildcards. Unset — the default — leaves the trust list
+ * byte-identical to the Microsoft-only allowlist above.
+ */
+function developmentServiceUrlAllowlist(): ReadonlySet<string> {
+  if (!isTeamsEmulatorModeEnabled()) {
+    return EMPTY_ALLOWLIST;
   }
   const raw = process.env.TEAMS_BOT_SERVICE_URL_ALLOWLIST?.trim();
   if (!raw) {
-    return new Set();
+    return EMPTY_ALLOWLIST;
+  }
+  // Parsed once per distinct value so a rejected entry is not re-logged on
+  // every send.
+  if (allowlistCache?.raw === raw) {
+    return allowlistCache.origins;
   }
   const origins = new Set<string>();
   for (const entry of raw.split(',')) {
-    try {
-      origins.add(new URL(entry.trim()).origin.toLowerCase());
-    } catch {
-      // Ignore unparseable entries rather than widening the trust list.
+    const trimmed = entry.trim();
+    if (!trimmed) {
+      continue;
     }
+    const origin = parseAllowlistOrigin(trimmed);
+    if (!origin) {
+      console.warn(
+        '[teams-bot] ignoring TEAMS_BOT_SERVICE_URL_ALLOWLIST entry that is not an exact http(s) origin',
+        { entry: trimmed }
+      );
+      continue;
+    }
+    origins.add(origin);
   }
+  allowlistCache = { raw, origins };
   return origins;
 }
 
 export function isTrustedServiceUrl(serviceUrl: string): boolean {
   try {
     const url = new URL(serviceUrl);
-    if (developmentServiceUrlAllowlist().has(url.origin.toLowerCase())) {
+    // An opaque origin can never match an allowlist entry, and must not be
+    // compared as the literal string "null".
+    if (url.origin !== 'null' && developmentServiceUrlAllowlist().has(url.origin.toLowerCase())) {
       return true;
     }
     if (url.protocol !== 'https:') {

--- a/ee/packages/microsoft-teams/src/lib/teams/bot/teamsBotConnector.ts
+++ b/ee/packages/microsoft-teams/src/lib/teams/bot/teamsBotConnector.ts
@@ -181,20 +181,35 @@ async function dispatchBotConnectorRequest(params: {
     throw new Error('Bot Framework credentials are not configured.');
   }
 
-  const token = await getAccessToken(credentials);
-  const response = await fetch(params.url, {
-    method: params.method,
-    headers: {
-      Authorization: `Bearer ${token}`,
-      'Content-Type': 'application/json',
-    },
-    body: JSON.stringify(params.activity),
-  });
+  const body = JSON.stringify(params.activity);
+  const attempt = async (): Promise<Response> => {
+    const token = await getAccessToken(credentials);
+    return fetch(params.url, {
+      method: params.method,
+      headers: {
+        Authorization: `Bearer ${token}`,
+        'Content-Type': 'application/json',
+      },
+      body,
+    });
+  };
 
+  let response = await attempt();
+
+  // A 401 means the cached token expired between the cache check and the
+  // request, which says nothing about the activity itself. Drop the token and
+  // replay the same request once with a fresh one, here rather than at each
+  // call site so every caller — bot replies, DM notifications, the proactive
+  // welcome card, the diagnostics test send — survives an expiry identically.
+  // A second 401 is a real credential problem and is surfaced.
   if (response.status === 401) {
-    // Token likely expired between cache check and request. Clear the cache
-    // so the next send forces a fresh token, then surface the error.
     cachedToken = null;
+    // Drain the discarded body so the connection is released before the replay.
+    await response.text().catch(() => '');
+    response = await attempt();
+    if (response.status === 401) {
+      cachedToken = null;
+    }
   }
 
   if (!response.ok) {

--- a/ee/packages/microsoft-teams/src/lib/teams/bot/teamsBotConnector.ts
+++ b/ee/packages/microsoft-teams/src/lib/teams/bot/teamsBotConnector.ts
@@ -1,3 +1,4 @@
+import { getMicrosoftTokenUrl } from '../microsoftEndpoints';
 import type { TeamsBotResponseActivity } from './teamsBotHandler';
 
 interface CachedToken {
@@ -41,9 +42,38 @@ export function isBotConnectorConfigured(): boolean {
   return readBotCredentialsFromEnv() !== null;
 }
 
+/**
+ * Extra serviceUrl origins trusted outside production, for pointing the bot at
+ * a local emulator (algasim). Exact origins only, comma-separated, no
+ * wildcards. Unset — the default — leaves the trust list byte-identical to the
+ * Microsoft-only allowlist above, and it is ignored entirely under
+ * NODE_ENV=production so it can never loosen the deployed trust boundary.
+ */
+function developmentServiceUrlAllowlist(): Set<string> {
+  if (process.env.NODE_ENV === 'production') {
+    return new Set();
+  }
+  const raw = process.env.TEAMS_BOT_SERVICE_URL_ALLOWLIST?.trim();
+  if (!raw) {
+    return new Set();
+  }
+  const origins = new Set<string>();
+  for (const entry of raw.split(',')) {
+    try {
+      origins.add(new URL(entry.trim()).origin.toLowerCase());
+    } catch {
+      // Ignore unparseable entries rather than widening the trust list.
+    }
+  }
+  return origins;
+}
+
 export function isTrustedServiceUrl(serviceUrl: string): boolean {
   try {
     const url = new URL(serviceUrl);
+    if (developmentServiceUrlAllowlist().has(url.origin.toLowerCase())) {
+      return true;
+    }
     if (url.protocol !== 'https:') {
       return false;
     }
@@ -55,9 +85,7 @@ export function isTrustedServiceUrl(serviceUrl: string): boolean {
 }
 
 async function fetchAccessToken(credentials: BotCredentials): Promise<string> {
-  const tokenUrl = `https://login.microsoftonline.com/${encodeURIComponent(
-    credentials.tenantId
-  )}/oauth2/v2.0/token`;
+  const tokenUrl = getMicrosoftTokenUrl(credentials.tenantId);
 
   const body = new URLSearchParams({
     grant_type: 'client_credentials',

--- a/ee/packages/microsoft-teams/src/lib/teams/bot/teamsBotHandler.ts
+++ b/ee/packages/microsoft-teams/src/lib/teams/bot/teamsBotHandler.ts
@@ -2378,17 +2378,27 @@ function isExpiredConnectorTokenError(error: unknown): boolean {
   return botConnectorErrorStatus(error) === 401;
 }
 
+// Only the connector's activity dispatch reports a status. Token-acquisition
+// failures carry a status in their message too, but retrying or downgrading the
+// card would not help a bad TEAMS_BOT_APP_PASSWORD — they classify as neither.
 function botConnectorErrorStatus(error: unknown): number | null {
-  if (error instanceof BotConnectorRequestError) {
-    return error.status;
-  }
-  if (error instanceof Error) {
-    const match = error.message.match(/\((\d{3})\s/);
-    if (match) {
-      return Number.parseInt(match[1], 10);
+  return error instanceof BotConnectorRequestError ? error.status : null;
+}
+
+/**
+ * Retry a connector call once on an expired token: the connector drops its
+ * cached token on a 401, so the retry mints a fresh one. A second 401 is a real
+ * credential problem and propagates.
+ */
+async function withExpiredTokenRetry<T>(send: () => Promise<T>): Promise<T> {
+  try {
+    return await send();
+  } catch (error) {
+    if (!isExpiredConnectorTokenError(error)) {
+      throw error;
     }
+    return send();
   }
-  return null;
 }
 
 export async function handleTeamsBotActivityRequest(
@@ -2430,44 +2440,32 @@ export async function handleTeamsBotActivityRequest(
     const fallback = buildWireActivity(response, false);
     const hasAdaptive = Boolean(response.adaptiveAttachments && response.adaptiveAttachments.length > 0);
 
+    const sendReply = async (
+      outgoing: TeamsBotResponseActivity,
+      skipLabel: string
+    ): Promise<void> => {
+      const result = await sendBotActivity({
+        serviceUrl,
+        conversationId,
+        replyToId,
+        activity: outgoing,
+      });
+      if (result.status === 'skipped' && result.reason) {
+        console.warn(skipLabel, { reason: result.reason });
+      }
+    };
+
     const sendReplyWithFallback = async (): Promise<void> => {
       try {
-        const result = await sendBotActivity({
-          serviceUrl,
-          conversationId,
-          replyToId,
-          activity: primary,
-        });
-        if (result.status === 'skipped' && result.reason) {
-          console.warn('[teams-bot] reply skipped', { reason: result.reason });
-        }
+        await withExpiredTokenRetry(() => sendReply(primary, '[teams-bot] reply skipped'));
       } catch (sendError) {
-        if (isExpiredConnectorTokenError(sendError)) {
-          // The cached token expired between the cache check and the request;
-          // the connector already dropped it, so resend the same activity.
-          const result = await sendBotActivity({
-            serviceUrl,
-            conversationId,
-            replyToId,
-            activity: primary,
-          });
-          if (result.status === 'skipped' && result.reason) {
-            console.warn('[teams-bot] reply skipped', { reason: result.reason });
-          }
-          return;
-        }
         // Some clients/channels reject Adaptive Cards with a 4xx — retry once
-        // with the hero-card fallback rendering kept on the response.
+        // with the hero-card fallback rendering kept on the response. A token
+        // expiry on the fallback itself is retried the same way.
         if (hasAdaptive && isCardRejectionError(sendError)) {
-          const result = await sendBotActivity({
-            serviceUrl,
-            conversationId,
-            replyToId,
-            activity: fallback,
-          });
-          if (result.status === 'skipped' && result.reason) {
-            console.warn('[teams-bot] fallback reply skipped', { reason: result.reason });
-          }
+          await withExpiredTokenRetry(() =>
+            sendReply(fallback, '[teams-bot] fallback reply skipped')
+          );
         } else {
           throw sendError;
         }
@@ -2477,14 +2475,18 @@ export async function handleTeamsBotActivityRequest(
     try {
       if (response.replaceActivityId) {
         // Inline card action: update the originating card in place; if the
-        // update fails, deliver the result as a normal reply instead.
+        // update fails, deliver the result as a normal reply instead. Retrying
+        // an expired token here keeps a transient 401 from duplicating the
+        // reply and leaving the stale card behind.
         try {
-          await updateBotActivity({
-            serviceUrl,
-            conversationId,
-            activityId: response.replaceActivityId,
-            activity: primary,
-          });
+          await withExpiredTokenRetry(() =>
+            updateBotActivity({
+              serviceUrl,
+              conversationId,
+              activityId: response.replaceActivityId!,
+              activity: primary,
+            })
+          );
         } catch (updateError) {
           console.warn('[teams-bot] in-place card update failed; sending reply instead', {
             error: updateError instanceof Error ? updateError.message : String(updateError),

--- a/ee/packages/microsoft-teams/src/lib/teams/bot/teamsBotHandler.ts
+++ b/ee/packages/microsoft-teams/src/lib/teams/bot/teamsBotHandler.ts
@@ -2373,32 +2373,11 @@ function isCardRejectionError(error: unknown): boolean {
   return status !== null && status >= 400 && status < 500 && !NON_CARD_REJECTION_STATUSES.has(status);
 }
 
-/** True when the send failed only because the cached connector token expired. */
-function isExpiredConnectorTokenError(error: unknown): boolean {
-  return botConnectorErrorStatus(error) === 401;
-}
-
 // Only the connector's activity dispatch reports a status. Token-acquisition
-// failures carry a status in their message too, but retrying or downgrading the
-// card would not help a bad TEAMS_BOT_APP_PASSWORD — they classify as neither.
+// failures carry a status in their message too, but downgrading the card would
+// not help a bad TEAMS_BOT_APP_PASSWORD — they classify as neither.
 function botConnectorErrorStatus(error: unknown): number | null {
   return error instanceof BotConnectorRequestError ? error.status : null;
-}
-
-/**
- * Retry a connector call once on an expired token: the connector drops its
- * cached token on a 401, so the retry mints a fresh one. A second 401 is a real
- * credential problem and propagates.
- */
-async function withExpiredTokenRetry<T>(send: () => Promise<T>): Promise<T> {
-  try {
-    return await send();
-  } catch (error) {
-    if (!isExpiredConnectorTokenError(error)) {
-      throw error;
-    }
-    return send();
-  }
 }
 
 export async function handleTeamsBotActivityRequest(
@@ -2457,15 +2436,15 @@ export async function handleTeamsBotActivityRequest(
 
     const sendReplyWithFallback = async (): Promise<void> => {
       try {
-        await withExpiredTokenRetry(() => sendReply(primary, '[teams-bot] reply skipped'));
+        await sendReply(primary, '[teams-bot] reply skipped');
       } catch (sendError) {
         // Some clients/channels reject Adaptive Cards with a 4xx — retry once
-        // with the hero-card fallback rendering kept on the response. A token
-        // expiry on the fallback itself is retried the same way.
+        // with the hero-card fallback rendering kept on the response. Token
+        // expiry is not one of those: the connector already replays the send
+        // with a fresh token, so a 401 that reaches here is a real credential
+        // problem and must not downgrade the card.
         if (hasAdaptive && isCardRejectionError(sendError)) {
-          await withExpiredTokenRetry(() =>
-            sendReply(fallback, '[teams-bot] fallback reply skipped')
-          );
+          await sendReply(fallback, '[teams-bot] fallback reply skipped');
         } else {
           throw sendError;
         }
@@ -2475,18 +2454,16 @@ export async function handleTeamsBotActivityRequest(
     try {
       if (response.replaceActivityId) {
         // Inline card action: update the originating card in place; if the
-        // update fails, deliver the result as a normal reply instead. Retrying
-        // an expired token here keeps a transient 401 from duplicating the
-        // reply and leaving the stale card behind.
+        // update fails, deliver the result as a normal reply instead. The
+        // connector replays an expired token on its own, so a transient 401
+        // refreshes the card rather than duplicating the reply.
         try {
-          await withExpiredTokenRetry(() =>
-            updateBotActivity({
-              serviceUrl,
-              conversationId,
-              activityId: response.replaceActivityId!,
-              activity: primary,
-            })
-          );
+          await updateBotActivity({
+            serviceUrl,
+            conversationId,
+            activityId: response.replaceActivityId!,
+            activity: primary,
+          });
         } catch (updateError) {
           console.warn('[teams-bot] in-place card update failed; sending reply instead', {
             error: updateError instanceof Error ? updateError.message : String(updateError),

--- a/ee/packages/microsoft-teams/src/lib/teams/bot/teamsBotHandler.ts
+++ b/ee/packages/microsoft-teams/src/lib/teams/bot/teamsBotHandler.ts
@@ -2363,18 +2363,32 @@ function buildWireActivity(
   return wire;
 }
 
+// 401/403 mean the connector token was rejected and 429 means throttling —
+// none of them say anything about the card content, so downgrading the reply
+// to the hero rendering on those would silently lose the Adaptive Card.
+const NON_CARD_REJECTION_STATUSES = new Set([401, 403, 429]);
+
 function isCardRejectionError(error: unknown): boolean {
+  const status = botConnectorErrorStatus(error);
+  return status !== null && status >= 400 && status < 500 && !NON_CARD_REJECTION_STATUSES.has(status);
+}
+
+/** True when the send failed only because the cached connector token expired. */
+function isExpiredConnectorTokenError(error: unknown): boolean {
+  return botConnectorErrorStatus(error) === 401;
+}
+
+function botConnectorErrorStatus(error: unknown): number | null {
   if (error instanceof BotConnectorRequestError) {
-    return error.status >= 400 && error.status < 500;
+    return error.status;
   }
   if (error instanceof Error) {
     const match = error.message.match(/\((\d{3})\s/);
     if (match) {
-      const status = Number.parseInt(match[1], 10);
-      return status >= 400 && status < 500;
+      return Number.parseInt(match[1], 10);
     }
   }
-  return false;
+  return null;
 }
 
 export async function handleTeamsBotActivityRequest(
@@ -2428,6 +2442,20 @@ export async function handleTeamsBotActivityRequest(
           console.warn('[teams-bot] reply skipped', { reason: result.reason });
         }
       } catch (sendError) {
+        if (isExpiredConnectorTokenError(sendError)) {
+          // The cached token expired between the cache check and the request;
+          // the connector already dropped it, so resend the same activity.
+          const result = await sendBotActivity({
+            serviceUrl,
+            conversationId,
+            replyToId,
+            activity: primary,
+          });
+          if (result.status === 'skipped' && result.reason) {
+            console.warn('[teams-bot] reply skipped', { reason: result.reason });
+          }
+          return;
+        }
         // Some clients/channels reject Adaptive Cards with a 4xx — retry once
         // with the hero-card fallback rendering kept on the response.
         if (hasAdaptive && isCardRejectionError(sendError)) {

--- a/ee/packages/microsoft-teams/src/lib/teams/bot/teamsBotJwtVerifier.ts
+++ b/ee/packages/microsoft-teams/src/lib/teams/bot/teamsBotJwtVerifier.ts
@@ -30,6 +30,19 @@ interface CachedJwksContext {
 }
 
 const JWKS_CACHE_TTL_MS = 12 * 60 * 60 * 1000;
+const EMULATOR_JWKS_CACHE_TTL_MS = 30 * 1000;
+
+/**
+ * A restarted emulator regenerates its signing keypair, so caching its JWKS for
+ * 12h would reject every injected activity until the app itself is restarted.
+ * Keying off the resolved URL keeps production — and any run without the
+ * override — on the long TTL automatically.
+ */
+function jwksCacheTtlMs(): number {
+  return openIdConfigUrl() === BOT_FRAMEWORK_OPENID_URL
+    ? JWKS_CACHE_TTL_MS
+    : EMULATOR_JWKS_CACHE_TTL_MS;
+}
 
 let cachedContext: CachedJwksContext | null = null;
 let inFlightConfigFetch: Promise<CachedJwksContext> | null = null;
@@ -40,7 +53,7 @@ export function resetTeamsBotJwksCacheForTests(): void {
 }
 
 async function loadJwksContext(): Promise<CachedJwksContext> {
-  if (cachedContext && Date.now() - cachedContext.refreshedAt < JWKS_CACHE_TTL_MS) {
+  if (cachedContext && Date.now() - cachedContext.refreshedAt < jwksCacheTtlMs()) {
     return cachedContext;
   }
 

--- a/ee/packages/microsoft-teams/src/lib/teams/bot/teamsBotJwtVerifier.ts
+++ b/ee/packages/microsoft-teams/src/lib/teams/bot/teamsBotJwtVerifier.ts
@@ -5,6 +5,19 @@ const BOT_FRAMEWORK_OPENID_URL =
   'https://login.botframework.com/v1/.well-known/openidconfiguration';
 const BOT_FRAMEWORK_ISSUER = 'https://api.botframework.com';
 
+/**
+ * Outside production, the OpenID discovery document may be redirected at a
+ * local emulator (algasim), which publishes its own JWKS and signs the
+ * activities it injects. Verification itself is untouched: signature, issuer,
+ * and audience are still fully checked against whatever JWKS is discovered.
+ */
+function openIdConfigUrl(): string {
+  if (process.env.NODE_ENV === 'production') {
+    return BOT_FRAMEWORK_OPENID_URL;
+  }
+  return process.env.TEAMS_BOT_OPENID_CONFIG_URL?.trim() || BOT_FRAMEWORK_OPENID_URL;
+}
+
 interface OpenIdConfig {
   jwks_uri?: string;
   issuer?: string;
@@ -36,7 +49,7 @@ async function loadJwksContext(): Promise<CachedJwksContext> {
   }
 
   inFlightConfigFetch = (async () => {
-    const response = await fetch(BOT_FRAMEWORK_OPENID_URL);
+    const response = await fetch(openIdConfigUrl());
     if (!response.ok) {
       throw new Error(
         `Failed to fetch Bot Framework OpenID config (${response.status} ${response.statusText})`

--- a/ee/packages/microsoft-teams/src/lib/teams/bot/teamsBotJwtVerifier.ts
+++ b/ee/packages/microsoft-teams/src/lib/teams/bot/teamsBotJwtVerifier.ts
@@ -1,4 +1,5 @@
 import { createLocalJWKSet, jwtVerify, type JWTPayload } from 'jose';
+import { isTeamsEmulatorModeEnabled } from '../emulatorMode';
 import { readBotCredentialsFromEnv } from './teamsBotConnector';
 
 const BOT_FRAMEWORK_OPENID_URL =
@@ -6,13 +7,14 @@ const BOT_FRAMEWORK_OPENID_URL =
 const BOT_FRAMEWORK_ISSUER = 'https://api.botframework.com';
 
 /**
- * Outside production, the OpenID discovery document may be redirected at a
- * local emulator (algasim), which publishes its own JWKS and signs the
- * activities it injects. Verification itself is untouched: signature, issuer,
- * and audience are still fully checked against whatever JWKS is discovered.
+ * With the emulator gate explicitly on, the OpenID discovery document may be
+ * redirected at a local emulator (algasim), which publishes its own JWKS and
+ * signs the activities it injects. Verification itself is untouched: signature,
+ * issuer, and audience are still fully checked against whatever JWKS is
+ * discovered.
  */
 function openIdConfigUrl(): string {
-  if (process.env.NODE_ENV === 'production') {
+  if (!isTeamsEmulatorModeEnabled()) {
     return BOT_FRAMEWORK_OPENID_URL;
   }
   return process.env.TEAMS_BOT_OPENID_CONFIG_URL?.trim() || BOT_FRAMEWORK_OPENID_URL;

--- a/ee/packages/microsoft-teams/src/lib/teams/emulatorMode.ts
+++ b/ee/packages/microsoft-teams/src/lib/teams/emulatorMode.ts
@@ -1,0 +1,22 @@
+/**
+ * Single deny-by-default gate for every Teams emulator override
+ * (`TEAMS_BOT_OPENID_CONFIG_URL`, `TEAMS_BOT_SERVICE_URL_ALLOWLIST`, and — for
+ * the Teams surface only — `MICROSOFT_LOGIN_BASE_URL` /
+ * `MICROSOFT_GRAPH_BASE_URL`). Those decide where the bot secret is POSTed and
+ * whose JWTs are accepted, so they must never turn themselves on: a host with
+ * NODE_ENV unset, or set to "staging", is not a licence to redirect them.
+ *
+ * The overrides are honored only when TEAMS_EMULATOR_MODE is explicitly one of
+ * the recognized on-values. Anything else — unset, empty, "staging", "yes",
+ * a typo — fails closed, and production is a hard second lock the flag cannot
+ * unlock.
+ */
+const ENABLED_VALUES = new Set(['true', '1']);
+
+export function isTeamsEmulatorModeEnabled(): boolean {
+  if (process.env.NODE_ENV === 'production') {
+    return false;
+  }
+  const raw = process.env.TEAMS_EMULATOR_MODE?.trim().toLowerCase();
+  return raw !== undefined && ENABLED_VALUES.has(raw);
+}

--- a/ee/packages/microsoft-teams/src/lib/teams/microsoftEndpoints.ts
+++ b/ee/packages/microsoft-teams/src/lib/teams/microsoftEndpoints.ts
@@ -1,0 +1,27 @@
+const DEFAULT_GRAPH_BASE_URL = 'https://graph.microsoft.com/v1.0';
+const DEFAULT_LOGIN_BASE_URL = 'https://login.microsoftonline.com';
+
+function withoutTrailingSlash(value: string): string {
+  return value.replace(/\/+$/, '');
+}
+
+/**
+ * Package-local mirror of shared/services/email/microsoftGraphEndpoints. The
+ * Teams add-on cannot depend on `shared`, but it honors the same env overrides
+ * so `algasim` can stand in for Microsoft. Defaults are the real endpoints.
+ */
+export function getMicrosoftGraphBaseUrl(): string {
+  return withoutTrailingSlash(
+    (process.env.MICROSOFT_GRAPH_BASE_URL || '').trim() || DEFAULT_GRAPH_BASE_URL
+  );
+}
+
+export function getMicrosoftLoginBaseUrl(): string {
+  return withoutTrailingSlash(
+    (process.env.MICROSOFT_LOGIN_BASE_URL || '').trim() || DEFAULT_LOGIN_BASE_URL
+  );
+}
+
+export function getMicrosoftTokenUrl(tenantAuthority: string): string {
+  return `${getMicrosoftLoginBaseUrl()}/${encodeURIComponent(tenantAuthority)}/oauth2/v2.0/token`;
+}

--- a/ee/packages/microsoft-teams/src/lib/teams/microsoftEndpoints.ts
+++ b/ee/packages/microsoft-teams/src/lib/teams/microsoftEndpoints.ts
@@ -1,25 +1,31 @@
-const DEFAULT_GRAPH_BASE_URL = 'https://graph.microsoft.com/v1.0';
-const DEFAULT_LOGIN_BASE_URL = 'https://login.microsoftonline.com';
-
-function withoutTrailingSlash(value: string): string {
-  return value.replace(/\/+$/, '');
-}
+import {
+  DEFAULT_MICROSOFT_GRAPH_BASE_URL,
+  DEFAULT_MICROSOFT_LOGIN_BASE_URL,
+  getMicrosoftGraphBaseUrl as getConfiguredGraphBaseUrl,
+  getMicrosoftLoginBaseUrl as getConfiguredLoginBaseUrl,
+} from '@shared/services/email/microsoftGraphEndpoints';
 
 /**
- * Package-local mirror of shared/services/email/microsoftGraphEndpoints. The
- * Teams add-on cannot depend on `shared`, but it honors the same env overrides
- * so `algasim` can stand in for Microsoft. Defaults are the real endpoints.
+ * Microsoft endpoints for the Teams surface, so `algasim` can stand in for
+ * Microsoft outside production. These are the endpoints the bot secret, the
+ * setup-probe credentials, the Graph client secret, and activity-notification
+ * bearer tokens are sent to, so under NODE_ENV=production the overrides are
+ * ignored and the real Microsoft hosts are always used — matching the posture
+ * of TEAMS_BOT_OPENID_CONFIG_URL and TEAMS_BOT_SERVICE_URL_ALLOWLIST.
+ *
+ * The email module keeps honoring MICROSOFT_*_BASE_URL unconditionally; that is
+ * pre-existing behavior and deliberately unchanged here.
  */
 export function getMicrosoftGraphBaseUrl(): string {
-  return withoutTrailingSlash(
-    (process.env.MICROSOFT_GRAPH_BASE_URL || '').trim() || DEFAULT_GRAPH_BASE_URL
-  );
+  return process.env.NODE_ENV === 'production'
+    ? DEFAULT_MICROSOFT_GRAPH_BASE_URL
+    : getConfiguredGraphBaseUrl();
 }
 
 export function getMicrosoftLoginBaseUrl(): string {
-  return withoutTrailingSlash(
-    (process.env.MICROSOFT_LOGIN_BASE_URL || '').trim() || DEFAULT_LOGIN_BASE_URL
-  );
+  return process.env.NODE_ENV === 'production'
+    ? DEFAULT_MICROSOFT_LOGIN_BASE_URL
+    : getConfiguredLoginBaseUrl();
 }
 
 export function getMicrosoftTokenUrl(tenantAuthority: string): string {

--- a/ee/packages/microsoft-teams/src/lib/teams/microsoftEndpoints.ts
+++ b/ee/packages/microsoft-teams/src/lib/teams/microsoftEndpoints.ts
@@ -4,28 +4,29 @@ import {
   getMicrosoftGraphBaseUrl as getConfiguredGraphBaseUrl,
   getMicrosoftLoginBaseUrl as getConfiguredLoginBaseUrl,
 } from '@shared/services/email/microsoftGraphEndpoints';
+import { isTeamsEmulatorModeEnabled } from './emulatorMode';
 
 /**
  * Microsoft endpoints for the Teams surface, so `algasim` can stand in for
- * Microsoft outside production. These are the endpoints the bot secret, the
- * setup-probe credentials, the Graph client secret, and activity-notification
- * bearer tokens are sent to, so under NODE_ENV=production the overrides are
- * ignored and the real Microsoft hosts are always used — matching the posture
- * of TEAMS_BOT_OPENID_CONFIG_URL and TEAMS_BOT_SERVICE_URL_ALLOWLIST.
+ * Microsoft. These are the endpoints the bot secret, the setup-probe
+ * credentials, the Graph client secret, and activity-notification bearer
+ * tokens are sent to, so the overrides are honored only when the emulator
+ * gate is explicitly on — matching the posture of TEAMS_BOT_OPENID_CONFIG_URL
+ * and TEAMS_BOT_SERVICE_URL_ALLOWLIST.
  *
  * The email module keeps honoring MICROSOFT_*_BASE_URL unconditionally; that is
  * pre-existing behavior and deliberately unchanged here.
  */
 export function getMicrosoftGraphBaseUrl(): string {
-  return process.env.NODE_ENV === 'production'
-    ? DEFAULT_MICROSOFT_GRAPH_BASE_URL
-    : getConfiguredGraphBaseUrl();
+  return isTeamsEmulatorModeEnabled()
+    ? getConfiguredGraphBaseUrl()
+    : DEFAULT_MICROSOFT_GRAPH_BASE_URL;
 }
 
 export function getMicrosoftLoginBaseUrl(): string {
-  return process.env.NODE_ENV === 'production'
-    ? DEFAULT_MICROSOFT_LOGIN_BASE_URL
-    : getConfiguredLoginBaseUrl();
+  return isTeamsEmulatorModeEnabled()
+    ? getConfiguredLoginBaseUrl()
+    : DEFAULT_MICROSOFT_LOGIN_BASE_URL;
 }
 
 export function getMicrosoftTokenUrl(tenantAuthority: string): string {

--- a/ee/packages/microsoft-teams/vitest.config.ts
+++ b/ee/packages/microsoft-teams/vitest.config.ts
@@ -1,6 +1,12 @@
+import path from 'node:path';
 import { defineConfig } from 'vitest/config';
 
 export default defineConfig({
+  // Package sources reach `shared` through the same @shared alias the server
+  // build supplies; the package's own runner has to resolve it too.
+  resolve: {
+    alias: [{ find: '@shared', replacement: path.resolve(__dirname, '../../../shared') }],
+  },
   test: {
     globals: true,
     environment: 'node',

--- a/package-lock.json
+++ b/package-lock.json
@@ -46700,7 +46700,7 @@
     },
     "packages/core": {
       "name": "@alga-psa/core",
-      "version": "1.4.0",
+      "version": "1.4.2",
       "dependencies": {
         "dotenv": "^16.4.5",
         "node-vault": "^0.10.2",
@@ -47165,6 +47165,7 @@
       },
       "devDependencies": {
         "@types/express": "^5.0.3",
+        "jose": "^6.1.3",
         "tsup": "^8.0.0",
         "typescript": "^5.7.3",
         "vitest": "^4.1.9"
@@ -49996,7 +49997,7 @@
       }
     },
     "server": {
-      "version": "1.4.0",
+      "version": "1.4.2",
       "license": "ISC",
       "dependencies": {
         "@alga-psa/authorization": "*",

--- a/packages/emulators/README.md
+++ b/packages/emulators/README.md
@@ -16,7 +16,7 @@ This starts every emulator on its default port and the console at
 
 | Emulator | Package | Port | Emulates |
 | --- | --- | --- | --- |
-| `msgraph` | `@alga-psa/emulator-msgraph` | 4010 | Microsoft login (OAuth2) + Graph v1.0 mail, subscriptions, change notifications |
+| `msgraph` | `@alga-psa/emulator-msgraph` | 4010 | Microsoft login (OAuth2) + Graph v1.0 mail, subscriptions, change notifications, Teams; Bot Framework connector + its OpenID/JWKS |
 | `qbo` | `@alga-psa/emulator-qbo` | 4020 | Intuit OAuth + QBO v3 company API (query, CDC, void/delete, SyncTokens, credits) |
 | `webhook-sink` | `@alga-psa/emulator-webhook-sink` | 4030 | Any webhook receiver; records requests, echoes Graph validation tokens |
 | `smtp-sink` | `@alga-psa/emulator-smtp-sink` | 4040 | SMTP capture (MailHog stand-in) |
@@ -50,9 +50,42 @@ overrides:
 | Vendor | Env vars |
 | --- | --- |
 | Microsoft | `MICROSOFT_LOGIN_BASE_URL=http://localhost:4010`, `MICROSOFT_GRAPH_BASE_URL=http://localhost:4010/v1.0` |
+| Teams / Bot Framework | The two Microsoft vars above, plus `TEAMS_BOT_OPENID_CONFIG_URL=http://localhost:4010/v1/.well-known/openidconfiguration` and `TEAMS_BOT_SERVICE_URL_ALLOWLIST=http://localhost:4010` |
 | QBO | `QBO_OAUTH_AUTHORIZE_URL=http://localhost:4020/connect/oauth2`, `QBO_OAUTH_TOKEN_URL=http://localhost:4020/oauth2/v1/tokens/bearer`, `QBO_API_BASE_URL=http://localhost:4020/v3/company` |
 | Webhooks | Point the integration's webhook/notification URL at `http://localhost:4030/<any path>` |
 | SMTP | Configure the SMTP provider with host `localhost`, port `4040`, no TLS |
+
+Both Teams vars are off by default and ignored entirely under
+`NODE_ENV=production`, so they cannot loosen a deployed trust boundary.
+`TEAMS_BOT_OPENID_CONFIG_URL` moves *discovery only*: the emulator generates
+an RSA keypair, publishes a JWKS, and RS256-signs the activities it injects,
+so the app's signature, issuer, and audience checks all still run.
+`TEAMS_BOT_SERVICE_URL_ALLOWLIST` takes exact origins (comma-separated, no
+wildcards) and is what lets the bot send back to the emulator.
+
+### Teams round trip
+
+```bash
+# Point the emulator at your app, and match TEAMS_BOT_APP_ID.
+algasim action msgraph configure -p '{
+  "botTargetUrl": "http://localhost:3000/api/teams/bot/messages",
+  "botServiceUrl": "http://localhost:4010",
+  "botAppId": "<TEAMS_BOT_APP_ID>"
+}'
+
+# An external/guest client identity, then an inbound message from them.
+algasim seed msgraph teams-user -p '{"id":"guest-1","displayName":"Wanda","userType":"Guest"}'
+algasim seed msgraph bot-activity -p '{
+  "text": "My printer is on fire",
+  "fromAadObjectId": "guest-1",
+  "conversationId": "a:conversation-1",
+  "conversationType": "personal"
+}'
+
+# Read back what the bot sent, adaptive cards and all.
+algasim state msgraph bot-activities
+algasim state msgraph activity-notifications
+```
 
 ## Drive them
 
@@ -97,8 +130,9 @@ Three tiers, so most failure modes cost nothing to support:
   come free with every HTTP emulator via host middleware.
 - **Protocol** — token expiry and revocation actions on `msgraph` and `qbo`.
 - **Domain** — emulator-specific, e.g. `msgraph` `operation-fault` (fail
-  `"GET /me"` N times), QBO stale SyncTokens produced by out-of-band
-  `receive-payment`/`apply-credit` actions.
+  `"GET /me"` or `"POST /v3/conversations/{id}/activities"` N times, for
+  Graph throttling and bot-connector failures), QBO stale SyncTokens
+  produced by out-of-band `receive-payment`/`apply-credit` actions.
 
 ### Scenarios
 

--- a/packages/emulators/README.md
+++ b/packages/emulators/README.md
@@ -69,15 +69,87 @@ a restart heals on its own — no need to restart the app.
 
 ### Teams round trip
 
-```bash
-# The bot's own credentials, so its client_credentials token grant succeeds.
-algasim seed msgraph client -p '{"clientId":"<TEAMS_BOT_APP_ID>","clientSecret":"<TEAMS_BOT_APP_PASSWORD>"}'
+The whole walkthrough below was run end to end against a real EE dev server;
+every step is reproducible from a clean worktree.
 
+**1. A server to point at.** Teams is EE, so the app has to run enterprise.
+Give the worktree its own database rather than sharing the dev one:
+
+```bash
+PW=$(cat secrets/postgres_password)
+docker exec -e PGPASSWORD=$PW alga_psa_postgres psql -U postgres \
+  -c 'CREATE DATABASE server_mine'
+# Clone an existing dev database (pg_dump, because CREATE DATABASE ... TEMPLATE
+# refuses to run while the source has open connections), or migrate from empty.
+docker exec -e PGPASSWORD=$PW alga_psa_postgres bash -lc \
+  'pg_dump -U postgres -d server --no-owner --no-acl -Fc -f /tmp/s.dump &&
+   pg_restore -U postgres -d server_mine --no-owner --no-acl -j4 /tmp/s.dump'
+
+# CE and EE migrations share one knex_migrations table, so `knex migrate:latest`
+# on ./migrations alone reports the EE rows as a "corrupt migration directory".
+# Always use the merged runner:
+cd server && DB_HOST=127.0.0.1 DB_PORT=5432 DB_USER_ADMIN=postgres \
+  DB_NAME_SERVER=server_mine node scripts/run-ee-migrations.js latest
+
+cd .. && npx nx build-deps server
+cd server && npx next dev -p 3210
+```
+
+`server/.env.local` needs `NEXT_PUBLIC_EDITION=enterprise`, `NEXTAUTH_URL`
+matching the port, `DB_NAME`/`DB_NAME_SERVER` pointing at the new database, and
+the emulator vars:
+
+```
+MICROSOFT_LOGIN_BASE_URL=http://127.0.0.1:4010
+MICROSOFT_GRAPH_BASE_URL=http://127.0.0.1:4010/v1.0
+TEAMS_BOT_OPENID_CONFIG_URL=http://127.0.0.1:4010/v1/.well-known/openidconfiguration
+TEAMS_BOT_SERVICE_URL_ALLOWLIST=http://127.0.0.1:4010
+TEAMS_BOT_APP_ID=11111111-2222-4333-8444-999999999999
+TEAMS_BOT_APP_PASSWORD=algasim-bot-secret
+TEAMS_BOT_APP_TENANT_ID=11111111-2222-4333-8444-555555555555
+```
+
+Use one host spelling everywhere: the allowlist matches origins exactly, so a
+`serviceUrl` of `http://localhost:4010` is *not* covered by an allowlist entry
+of `http://127.0.0.1:4010`.
+
+**2. Seed the Microsoft side.** The Graph client is the one you will enter as a
+Microsoft profile; `appRoles` are the admin-consented application permissions
+its app-only tokens carry, which is what the setup wizard's permission probe
+reads:
+
+```bash
+algasim seed msgraph client -p '{
+  "clientId": "alga-teams-graph-client",
+  "clientSecret": "alga-teams-graph-secret",
+  "appRoles": ["Calendars.ReadWrite","OnlineMeetings.ReadWrite.All",
+               "OnlineMeetingRecording.Read.All","OnlineMeetingTranscript.Read.All",
+               "TeamsActivity.Send","User.Read.All"]
+}'
+# The bot's own credentials, so its client_credentials token grant succeeds.
+algasim seed msgraph client -p '{"clientId":"11111111-2222-4333-8444-999999999999","clientSecret":"algasim-bot-secret"}'
+```
+
+**3. Set the tenant up through the product.** The Teams add-on has to be
+granted (`POST /api/v1/tenant-management/tenants/<tenant>/addons` with
+`{"action":"grant","addonKey":"teams"}`, from the master billing tenant), then
+in **Settings → Integrations**:
+
+- *Providers → Microsoft → Add profile*: client id, tenant id
+  (`11111111-2222-4333-8444-555555555555`) and secret from step 2.
+- *Communication → Teams*: pick that profile, save the draft, then run the
+  wizard's three checks — validate the Microsoft profile, probe Graph
+  permissions, validate the Bot Framework connector — and Activate. All three
+  hit the emulator.
+
+**4. Drive a conversation.**
+
+```bash
 # Point the emulator at your app, and match TEAMS_BOT_APP_ID.
 algasim action msgraph configure -p '{
-  "botTargetUrl": "http://localhost:3000/api/teams/bot/messages",
-  "botServiceUrl": "http://localhost:4010",
-  "botAppId": "<TEAMS_BOT_APP_ID>"
+  "botTargetUrl": "http://localhost:3210/api/teams/bot/messages",
+  "botServiceUrl": "http://127.0.0.1:4010",
+  "botAppId": "11111111-2222-4333-8444-999999999999"
 }'
 
 # An external/guest client identity, then an inbound message from them.
@@ -93,6 +165,16 @@ algasim seed msgraph bot-activity -p '{
 algasim state msgraph bot-activities
 algasim state msgraph activity-notifications
 ```
+
+`seed bot-activity` returns the app's HTTP status and body, so a rejected
+activity shows up immediately (`401` with `{"error":"unauthorized"}` when the
+audience or signature does not check out).
+
+The bot answers an unlinked Teams identity with the "Teams sign-in required"
+card. Linking a Teams user to a PSA user happens through Microsoft SSO sign-in,
+which the emulator does not serve yet (no OIDC discovery document on the login
+surface), so richer command replies still need a tenant whose users are already
+linked.
 
 ## Drive them
 

--- a/packages/emulators/README.md
+++ b/packages/emulators/README.md
@@ -50,15 +50,19 @@ overrides:
 | Vendor | Env vars |
 | --- | --- |
 | Microsoft | `MICROSOFT_LOGIN_BASE_URL=http://localhost:4010`, `MICROSOFT_GRAPH_BASE_URL=http://localhost:4010/v1.0` |
-| Teams / Bot Framework | The two Microsoft vars above, plus `TEAMS_BOT_OPENID_CONFIG_URL=http://localhost:4010/v1/.well-known/openidconfiguration` and `TEAMS_BOT_SERVICE_URL_ALLOWLIST=http://localhost:4010` |
+| Teams / Bot Framework | `TEAMS_EMULATOR_MODE=true`, the two Microsoft vars above, plus `TEAMS_BOT_OPENID_CONFIG_URL=http://localhost:4010/v1/.well-known/openidconfiguration` and `TEAMS_BOT_SERVICE_URL_ALLOWLIST=http://localhost:4010` |
 | QBO | `QBO_OAUTH_AUTHORIZE_URL=http://localhost:4020/connect/oauth2`, `QBO_OAUTH_TOKEN_URL=http://localhost:4020/oauth2/v1/tokens/bearer`, `QBO_API_BASE_URL=http://localhost:4020/v3/company` |
 | Webhooks | Point the integration's webhook/notification URL at `http://localhost:4030/<any path>` |
 | SMTP | Configure the SMTP provider with host `localhost`, port `4040`, no TLS |
 
-Every var the Teams surface reads is off by default and ignored entirely under
-`NODE_ENV=production`, so none of them can loosen a deployed trust boundary:
-`TEAMS_BOT_OPENID_CONFIG_URL` and `TEAMS_BOT_SERVICE_URL_ALLOWLIST`, plus —
-for the Teams add-on specifically — `MICROSOFT_LOGIN_BASE_URL` and
+`TEAMS_EMULATOR_MODE` is the single gate for every Teams override, and it is
+deny-by-default: unless it is explicitly `true` (or `1`), the Teams surface
+behaves exactly as it does in production. Any other value — unset, empty,
+`staging`, a typo — fails closed, so a worker or staging host that never sets
+`NODE_ENV` cannot redirect anything by accident, and `NODE_ENV=production` is a
+second lock the flag cannot unlock. The vars it gates are
+`TEAMS_BOT_OPENID_CONFIG_URL` and `TEAMS_BOT_SERVICE_URL_ALLOWLIST`, plus — for
+the Teams add-on specifically — `MICROSOFT_LOGIN_BASE_URL` and
 `MICROSOFT_GRAPH_BASE_URL`, which is where the bot secret, the setup-probe
 credentials, the Graph client secret, and activity-notification tokens are
 sent. (The email module honors those two Microsoft vars unconditionally; that
@@ -68,7 +72,9 @@ is pre-existing behavior, unchanged here.)
 an RSA keypair, publishes a JWKS, and RS256-signs the activities it injects,
 so the app's signature, issuer, and audience checks all still run.
 `TEAMS_BOT_SERVICE_URL_ALLOWLIST` takes exact origins (comma-separated, no
-wildcards) and is what lets the bot send back to the emulator.
+wildcards) and is what lets the bot send back to the emulator. Entries must
+include the scheme: `localhost:4010` is not an origin, and is rejected with a
+warning rather than quietly widening the trust list.
 
 Restarting the emulator mints a fresh keypair. While the override is set the
 app re-discovers the JWKS every 30s (instead of the 12h production cache), so
@@ -107,6 +113,7 @@ matching the port, `DB_NAME`/`DB_NAME_SERVER` pointing at the new database, and
 the emulator vars:
 
 ```
+TEAMS_EMULATOR_MODE=true
 MICROSOFT_LOGIN_BASE_URL=http://127.0.0.1:4010
 MICROSOFT_GRAPH_BASE_URL=http://127.0.0.1:4010/v1.0
 TEAMS_BOT_OPENID_CONFIG_URL=http://127.0.0.1:4010/v1/.well-known/openidconfiguration

--- a/packages/emulators/README.md
+++ b/packages/emulators/README.md
@@ -63,6 +63,10 @@ so the app's signature, issuer, and audience checks all still run.
 `TEAMS_BOT_SERVICE_URL_ALLOWLIST` takes exact origins (comma-separated, no
 wildcards) and is what lets the bot send back to the emulator.
 
+Restarting the emulator mints a fresh keypair. While the override is set the
+app re-discovers the JWKS every 30s (instead of the 12h production cache), so
+a restart heals on its own — no need to restart the app.
+
 ### Teams round trip
 
 ```bash

--- a/packages/emulators/README.md
+++ b/packages/emulators/README.md
@@ -55,8 +55,15 @@ overrides:
 | Webhooks | Point the integration's webhook/notification URL at `http://localhost:4030/<any path>` |
 | SMTP | Configure the SMTP provider with host `localhost`, port `4040`, no TLS |
 
-Both Teams vars are off by default and ignored entirely under
-`NODE_ENV=production`, so they cannot loosen a deployed trust boundary.
+Every var the Teams surface reads is off by default and ignored entirely under
+`NODE_ENV=production`, so none of them can loosen a deployed trust boundary:
+`TEAMS_BOT_OPENID_CONFIG_URL` and `TEAMS_BOT_SERVICE_URL_ALLOWLIST`, plus —
+for the Teams add-on specifically — `MICROSOFT_LOGIN_BASE_URL` and
+`MICROSOFT_GRAPH_BASE_URL`, which is where the bot secret, the setup-probe
+credentials, the Graph client secret, and activity-notification tokens are
+sent. (The email module honors those two Microsoft vars unconditionally; that
+is pre-existing behavior, unchanged here.)
+
 `TEAMS_BOT_OPENID_CONFIG_URL` moves *discovery only*: the emulator generates
 an RSA keypair, publishes a JWKS, and RS256-signs the activities it injects,
 so the app's signature, issuer, and audience checks all still run.

--- a/packages/emulators/README.md
+++ b/packages/emulators/README.md
@@ -66,6 +66,9 @@ wildcards) and is what lets the bot send back to the emulator.
 ### Teams round trip
 
 ```bash
+# The bot's own credentials, so its client_credentials token grant succeeds.
+algasim seed msgraph client -p '{"clientId":"<TEAMS_BOT_APP_ID>","clientSecret":"<TEAMS_BOT_APP_PASSWORD>"}'
+
 # Point the emulator at your app, and match TEAMS_BOT_APP_ID.
 algasim action msgraph configure -p '{
   "botTargetUrl": "http://localhost:3000/api/teams/bot/messages",

--- a/packages/emulators/README.md
+++ b/packages/emulators/README.md
@@ -170,6 +170,16 @@ algasim state msgraph activity-notifications
 activity shows up immediately (`401` with `{"error":"unauthorized"}` when the
 audience or signature does not check out).
 
+The inbound JWT is stamped with wall time, not the virtual clock, so
+`clock advance` and activity injection compose: advancing the clock to expire
+Graph tokens never invalidates the activities injected afterwards. To test the
+app rejecting an expired inbound token, backdate that token on its own with
+`tokenAgeSeconds` (past the 1h TTL):
+
+```bash
+algasim seed msgraph bot-activity -p '{"text":"stale","tokenAgeSeconds":7200}'
+```
+
 The bot answers an unlinked Teams identity with the "Teams sign-in required"
 card. Linking a Teams user to a PSA user happens through Microsoft SSO sign-in,
 which the emulator does not serve yet (no OIDC discovery document on the login
@@ -246,6 +256,11 @@ steps:
 All emulator time flows through one host clock. `algasim clock advance 2h`
 expires OAuth tokens; `32d` crosses billing periods and subscription
 expirations. Runs are reproducible: the host PRNG is seeded (`--seed`).
+
+One deliberate exception: the JWT `seed msgraph bot-activity` signs is stamped
+with wall time, because the app verifies it with jose against the real clock
+(as real Microsoft does). Emulator state stays on the virtual clock, so the two
+compose; `tokenAgeSeconds` is the knob for an intentionally expired one.
 
 ## Write an emulator
 

--- a/packages/emulators/msgraph/package.json
+++ b/packages/emulators/msgraph/package.json
@@ -24,6 +24,7 @@
   },
   "devDependencies": {
     "@types/express": "^5.0.3",
+    "jose": "^6.1.3",
     "tsup": "^8.0.0",
     "typescript": "^5.7.3",
     "vitest": "^4.1.9"

--- a/packages/emulators/msgraph/src/botFramework.ts
+++ b/packages/emulators/msgraph/src/botFramework.ts
@@ -1,0 +1,73 @@
+import { generateKeyPairSync, sign, type KeyObject } from 'node:crypto';
+
+/**
+ * Bot Framework identity provider. The emulator is a real signer, not a
+ * verification bypass: it publishes an OpenID config + JWKS and RS256-signs the
+ * activities it injects, so the app's jose `createLocalJWKSet`/`jwtVerify` path
+ * runs unmodified with full signature checking.
+ */
+export const BOT_FRAMEWORK_ISSUER = 'https://api.botframework.com';
+
+interface SigningKey {
+  privateKey: KeyObject;
+  kid: string;
+  jwk: Record<string, unknown>;
+}
+
+// One keypair per process, created on first use. It must never be replaced on
+// reset(): the app caches the JWKS for 12h, so rotating it mid-run would make
+// previously-issued tokens unverifiable.
+let signingKey: SigningKey | null = null;
+
+function key(): SigningKey {
+  if (!signingKey) {
+    const { privateKey, publicKey } = generateKeyPairSync('rsa', { modulusLength: 2048 });
+    const kid = 'algasim-botframework-signing-key';
+    signingKey = {
+      privateKey,
+      kid,
+      jwk: { ...(publicKey.export({ format: 'jwk' }) as Record<string, unknown>), kid, use: 'sig', alg: 'RS256' },
+    };
+  }
+  return signingKey;
+}
+
+export function botFrameworkJwks(): { keys: Array<Record<string, unknown>> } {
+  return { keys: [key().jwk] };
+}
+
+export interface BotFrameworkClaims {
+  aud: string;
+  serviceurl: string;
+  oid?: string;
+  tid?: string;
+}
+
+/**
+ * Sign an inbound Bot Framework token. `issuedAtSeconds` comes from the host
+ * clock so `algasim clock advance` ages tokens; `nbf` is backdated slightly so
+ * a virtual clock nudged ahead of wall time still yields an active token.
+ */
+export function signBotFrameworkJwt(
+  claims: BotFrameworkClaims,
+  issuedAtSeconds: number,
+  ttlSeconds = 3600,
+): string {
+  const { privateKey, kid } = key();
+  const header = base64url(JSON.stringify({ alg: 'RS256', typ: 'JWT', kid }));
+  const payload = base64url(
+    JSON.stringify({
+      ...claims,
+      iss: BOT_FRAMEWORK_ISSUER,
+      iat: issuedAtSeconds,
+      nbf: issuedAtSeconds - 300,
+      exp: issuedAtSeconds + ttlSeconds,
+    }),
+  );
+  const signingInput = `${header}.${payload}`;
+  return `${signingInput}.${sign('RSA-SHA256', Buffer.from(signingInput), privateKey).toString('base64url')}`;
+}
+
+function base64url(value: string): string {
+  return Buffer.from(value).toString('base64url');
+}

--- a/packages/emulators/msgraph/src/botFramework.ts
+++ b/packages/emulators/msgraph/src/botFramework.ts
@@ -44,9 +44,10 @@ export interface BotFrameworkClaims {
 }
 
 /**
- * Sign an inbound Bot Framework token. `issuedAtSeconds` comes from the host
- * clock so `algasim clock advance` ages tokens; `nbf` is backdated slightly so
- * a virtual clock nudged ahead of wall time still yields an active token.
+ * Sign an inbound Bot Framework token. `issuedAtSeconds` is wall time, because
+ * the app's jose verifier reads the real clock — the caller backdates it when a
+ * test wants an expired token. `nbf` is backdated slightly so small clock skew
+ * between emulator and app still yields an active token.
  */
 export function signBotFrameworkJwt(
   claims: BotFrameworkClaims,

--- a/packages/emulators/msgraph/src/core.ts
+++ b/packages/emulators/msgraph/src/core.ts
@@ -149,6 +149,12 @@ export interface InboundBotActivityInput {
   value?: Record<string, unknown>;
   targetUrl?: string;
   appId?: string;
+  /**
+   * Backdate the signed inbound token by this many seconds, to test the app
+   * rejecting an expired one. Delivery-only: the activity itself is unaffected,
+   * so buildInboundActivity ignores it.
+   */
+  tokenAgeSeconds?: number;
 }
 
 export interface OperationFault {

--- a/packages/emulators/msgraph/src/core.ts
+++ b/packages/emulators/msgraph/src/core.ts
@@ -293,7 +293,7 @@ export class MsGraphCore implements EmulatorCore {
     this.accessTokenTtlSeconds = 3600;
     this.rotateRefreshTokens = true;
     // Deliberately does not rotate the Bot Framework signing key: the app
-    // caches the JWKS for 12h, so a reset between tests must not invalidate
+    // caches the discovered JWKS, so a reset between tests must not invalidate
     // tokens it has already learned how to verify.
     this.botConfig = { ...DEFAULT_BOT_CONFIG };
   }

--- a/packages/emulators/msgraph/src/core.ts
+++ b/packages/emulators/msgraph/src/core.ts
@@ -51,6 +51,104 @@ export interface GraphDirectoryUser {
   jobTitle: string | null;
   mobilePhone: string | null;
   businessPhones: string[];
+  /** "Guest" marks a B2B/external identity, e.g. a client submitting via Teams. */
+  userType: 'Member' | 'Guest';
+  externalUserState: string | null;
+}
+
+export interface GraphTeamChannel {
+  id: string;
+  displayName: string;
+  description: string | null;
+  membershipType: 'standard' | 'private' | 'shared';
+}
+
+export interface GraphTeam {
+  id: string;
+  displayName: string;
+  description: string | null;
+  /** Stripped from the vendor surface; Graph serves channels on a sub-route. */
+  channels: GraphTeamChannel[];
+}
+
+export interface GraphChatMember {
+  id: string;
+  displayName: string;
+  userId: string | null;
+}
+
+export interface GraphChat {
+  id: string;
+  topic: string | null;
+  chatType: 'oneOnOne' | 'group' | 'meeting';
+  createdDateTime: string;
+  members: GraphChatMember[];
+}
+
+export interface GraphChatMessage {
+  id: string;
+  chatId: string;
+  createdDateTime: string;
+  from: { user: { id: string; displayName: string } };
+  body: { contentType: string; content: string };
+}
+
+/** A conversation created through the Bot Framework connector (proactive send). */
+export interface BotConversation {
+  id: string;
+  createdDateTime: string;
+  isGroup: boolean;
+  tenantId: string | null;
+  members: unknown[];
+}
+
+/** One outbound activity the bot pushed at the connector. */
+export interface CapturedBotActivity {
+  id: string;
+  method: 'POST' | 'PUT';
+  conversationId: string;
+  /** Activity id from the request path: the reply target (POST) or update target (PUT). */
+  pathActivityId: string | null;
+  replyToId: string | null;
+  type: string | null;
+  text: string | null;
+  /** Card payloads verbatim, including Adaptive Card JSON. */
+  attachments: unknown[];
+  activity: Record<string, unknown>;
+  receivedAt: string;
+}
+
+export interface ActivityNotificationRecord {
+  id: string;
+  userId: string;
+  body: unknown;
+  receivedAt: string;
+}
+
+/** Defaults for inbound activity injection; tune with the `configure` action. */
+export interface BotConfig {
+  /** Where injected activities are POSTed (the app's bot endpoint). */
+  targetUrl: string;
+  /** serviceUrl stamped on injected activities; the bot replies here. */
+  serviceUrl: string;
+  /** Audience of the signed inbound JWT; must equal TEAMS_BOT_APP_ID. */
+  appId: string;
+  tenantId: string;
+}
+
+export interface InboundBotActivityInput {
+  type?: 'message' | 'invoke' | 'conversationUpdate';
+  text?: string;
+  fromId?: string;
+  fromAadObjectId?: string;
+  fromName?: string;
+  conversationId?: string;
+  conversationType?: 'personal' | 'groupChat' | 'channel';
+  tenantId?: string;
+  serviceUrl?: string;
+  value?: Record<string, unknown>;
+  targetUrl?: string;
+  appId?: string;
 }
 
 export interface OperationFault {
@@ -109,7 +207,35 @@ export interface SeedDirectoryUserInput {
   jobTitle?: string | null;
   mobilePhone?: string | null;
   businessPhones?: string[];
+  userType?: 'Member' | 'Guest';
+  externalUserState?: string | null;
 }
+
+export interface SeedTeamChannelInput {
+  teamId?: string;
+  teamDisplayName?: string;
+  id?: string;
+  displayName?: string;
+  description?: string | null;
+  membershipType?: 'standard' | 'private' | 'shared';
+}
+
+export interface SeedChatInput {
+  id?: string;
+  topic?: string | null;
+  chatType?: 'oneOnOne' | 'group' | 'meeting';
+  members?: Array<{ id?: string; displayName?: string; userId?: string | null }>;
+  messages?: Array<{ id?: string; from?: string; fromName?: string; content?: string }>;
+}
+
+export const EMULATED_TENANT_ID = '11111111-2222-4333-8444-555555555555';
+
+const DEFAULT_BOT_CONFIG: BotConfig = {
+  targetUrl: 'http://localhost:3000/api/teams/bot/messages',
+  serviceUrl: 'http://localhost:4010',
+  appId: 'emulated-teams-bot-app-id',
+  tenantId: EMULATED_TENANT_ID,
+};
 
 /**
  * Pure state machine for the emulated Microsoft login + Graph service.
@@ -132,9 +258,16 @@ export class MsGraphCore implements EmulatorCore {
   readonly directoryUsers = new Map<string, GraphDirectoryUser>();
   readonly applications = new Map<string, GraphApplication>();
   readonly servicePrincipals = new Map<string, GraphServicePrincipal>();
+  readonly teams = new Map<string, GraphTeam>();
+  readonly chats = new Map<string, GraphChat>();
+  readonly chatMessages = new Map<string, GraphChatMessage[]>();
+  readonly botConversations = new Map<string, BotConversation>();
+  readonly capturedBotActivities: CapturedBotActivity[] = [];
+  readonly activityNotifications: ActivityNotificationRecord[] = [];
   readonly faults = new Map<string, OperationFault>();
   accessTokenTtlSeconds = 3600;
   rotateRefreshTokens = true;
+  botConfig: BotConfig = { ...DEFAULT_BOT_CONFIG };
   private idCounter = 0;
 
   constructor(readonly env: HostEnv) {}
@@ -150,9 +283,19 @@ export class MsGraphCore implements EmulatorCore {
     this.directoryUsers.clear();
     this.applications.clear();
     this.servicePrincipals.clear();
+    this.teams.clear();
+    this.chats.clear();
+    this.chatMessages.clear();
+    this.botConversations.clear();
+    this.capturedBotActivities.length = 0;
+    this.activityNotifications.length = 0;
     this.faults.clear();
     this.accessTokenTtlSeconds = 3600;
     this.rotateRefreshTokens = true;
+    // Deliberately does not rotate the Bot Framework signing key: the app
+    // caches the JWKS for 12h, so a reset between tests must not invalidate
+    // tokens it has already learned how to verify.
+    this.botConfig = { ...DEFAULT_BOT_CONFIG };
   }
 
   private newId(prefix: string): string {
@@ -182,7 +325,8 @@ export class MsGraphCore implements EmulatorCore {
 
   grantToken(input: TokenGrantInput): {
     access_token: string;
-    refresh_token: string;
+    /** Absent for the app-only client_credentials grant, exactly like Entra. */
+    refresh_token?: string;
     expires_in: number;
     token_type: 'Bearer';
     id_token?: string;
@@ -208,6 +352,18 @@ export class MsGraphCore implements EmulatorCore {
       }
       return this.issueTokens(String(input.client_id), String(input.refresh_token));
     }
+    if (input.grant_type === 'client_credentials') {
+      // App-only flow used by the Teams bot connector
+      // (scope https://api.botframework.com/.default) and by Graph
+      // app tokens. No user, so no refresh token is issued.
+      const { refresh_token: issuedRefreshToken, ...appOnly } = this.issueTokens(
+        String(input.client_id),
+        undefined,
+        { scope: input.scope || 'https://graph.microsoft.com/.default' },
+      );
+      this.refreshTokens.delete(issuedRefreshToken);
+      return appOnly;
+    }
     throw new GraphApiError(400, { error: 'unsupported_grant_type' });
   }
 
@@ -222,7 +378,7 @@ export class MsGraphCore implements EmulatorCore {
     existingRefreshToken?: string,
     claims?: { nonce?: string; scope?: string }
   ) {
-    const tenantId = '11111111-2222-4333-8444-555555555555';
+    const tenantId = EMULATED_TENANT_ID;
     const accessToken = this.encodeJwt({
       tid: tenantId,
       iss: `https://login.microsoftonline.com/${tenantId}/v2.0`,
@@ -359,6 +515,8 @@ export class MsGraphCore implements EmulatorCore {
       jobTitle: input.jobTitle ?? null,
       mobilePhone: input.mobilePhone ?? null,
       businessPhones: input.businessPhones ?? [],
+      userType: input.userType ?? 'Member',
+      externalUserState: input.externalUserState ?? null,
     };
     this.directoryUsers.set(id, user);
     return user;
@@ -475,6 +633,189 @@ export class MsGraphCore implements EmulatorCore {
       (subscription) => new Date(subscription.expirationDateTime).getTime() > this.nowMs(),
     );
   }
+
+  // --- Teams directory (teams, channels, chats) ---
+
+  addTeamChannel(input: SeedTeamChannelInput): { team: GraphTeam; channel: GraphTeamChannel } {
+    const teamId = input.teamId ?? this.newId('team');
+    const team = this.teams.get(teamId) ?? {
+      id: teamId,
+      displayName: input.teamDisplayName ?? 'Emulated Team',
+      description: null,
+      channels: [],
+    };
+    if (input.teamDisplayName) team.displayName = input.teamDisplayName;
+    this.teams.set(teamId, team);
+
+    const channelId = input.id ?? this.newId('channel');
+    const channel: GraphTeamChannel = {
+      id: channelId,
+      displayName: input.displayName ?? 'General',
+      description: input.description ?? null,
+      membershipType: input.membershipType ?? 'standard',
+    };
+    team.channels = [...team.channels.filter((existing) => existing.id !== channelId), channel];
+    return { team, channel };
+  }
+
+  getTeam(id: string): GraphTeam {
+    const team = this.teams.get(id);
+    if (!team) {
+      throw new GraphApiError(404, { error: { code: 'Request_ResourceNotFound' } });
+    }
+    return team;
+  }
+
+  addChat(input: SeedChatInput): GraphChat {
+    const id = input.id ?? this.newId('chat');
+    const chat: GraphChat = {
+      id,
+      topic: input.topic ?? null,
+      chatType: input.chatType ?? 'oneOnOne',
+      createdDateTime: this.env.clock.now().toISOString(),
+      members: (input.members ?? []).map((member) => ({
+        id: member.id ?? this.newId('chat-member'),
+        displayName: member.displayName ?? 'Emulated Chat Member',
+        userId: member.userId ?? null,
+      })),
+    };
+    this.chats.set(id, chat);
+    this.chatMessages.set(
+      id,
+      (input.messages ?? []).map((message) => ({
+        id: message.id ?? this.newId('chat-message'),
+        chatId: id,
+        createdDateTime: this.env.clock.now().toISOString(),
+        from: { user: { id: message.from ?? 'emulated-user', displayName: message.fromName ?? 'Emulated Sender' } },
+        body: { contentType: 'html', content: message.content ?? '' },
+      })),
+    );
+    return chat;
+  }
+
+  getChat(id: string): GraphChat {
+    const chat = this.chats.get(id);
+    if (!chat) {
+      throw new GraphApiError(404, { error: { code: 'Request_ResourceNotFound' } });
+    }
+    return chat;
+  }
+
+  listChatMessages(id: string): GraphChatMessage[] {
+    this.getChat(id);
+    return this.chatMessages.get(id) ?? [];
+  }
+
+  // --- Bot Framework connector ---
+
+  createConversation(input: { isGroup?: boolean; tenantId?: string; members?: unknown[] }): BotConversation {
+    const conversation: BotConversation = {
+      id: this.newId('conversation'),
+      createdDateTime: this.env.clock.now().toISOString(),
+      isGroup: input.isGroup ?? false,
+      tenantId: input.tenantId ?? this.botConfig.tenantId,
+      members: input.members ?? [],
+    };
+    this.botConversations.set(conversation.id, conversation);
+    return conversation;
+  }
+
+  /** Capture an activity the bot pushed at the connector; returns its new id. */
+  recordBotActivity(input: {
+    method: 'POST' | 'PUT';
+    conversationId: string;
+    pathActivityId?: string | null;
+    activity: Record<string, unknown>;
+  }): CapturedBotActivity {
+    const activity = input.activity ?? {};
+    const captured: CapturedBotActivity = {
+      id: input.method === 'PUT' && input.pathActivityId ? input.pathActivityId : this.newId('activity'),
+      method: input.method,
+      conversationId: input.conversationId,
+      pathActivityId: input.pathActivityId ?? null,
+      replyToId: typeof activity.replyToId === 'string' ? activity.replyToId : input.pathActivityId ?? null,
+      type: typeof activity.type === 'string' ? activity.type : null,
+      text: typeof activity.text === 'string' ? activity.text : null,
+      attachments: Array.isArray(activity.attachments) ? activity.attachments : [],
+      activity,
+      receivedAt: this.env.clock.now().toISOString(),
+    };
+    this.capturedBotActivities.push(captured);
+    return captured;
+  }
+
+  clearBotActivities(): number {
+    const cleared = this.capturedBotActivities.length;
+    this.capturedBotActivities.length = 0;
+    return cleared;
+  }
+
+  recordActivityNotification(userId: string, body: unknown): ActivityNotificationRecord {
+    const record: ActivityNotificationRecord = {
+      id: this.newId('activity-notification'),
+      userId,
+      body,
+      receivedAt: this.env.clock.now().toISOString(),
+    };
+    this.activityNotifications.push(record);
+    return record;
+  }
+
+  /**
+   * Assemble the Bot Framework Activity that inbound injection delivers to the
+   * app's bot endpoint. Pure: the notifier signs it and performs the POST.
+   */
+  buildInboundActivity(input: InboundBotActivityInput): {
+    activity: Record<string, unknown>;
+    targetUrl: string;
+    serviceUrl: string;
+    audience: string;
+    aadObjectId: string;
+    tenantId: string;
+  } {
+    const serviceUrl = input.serviceUrl ?? this.botConfig.serviceUrl;
+    const tenantId = input.tenantId ?? this.botConfig.tenantId;
+    const audience = input.appId ?? this.botConfig.appId;
+    const aadObjectId = input.fromAadObjectId ?? this.newId('aad-object');
+    const conversationType = input.conversationType ?? 'personal';
+    const activity: Record<string, unknown> = {
+      type: input.type ?? 'message',
+      id: this.newId('inbound-activity'),
+      timestamp: this.env.clock.now().toISOString(),
+      channelId: 'msteams',
+      serviceUrl,
+      from: {
+        id: input.fromId ?? `29:${aadObjectId}`,
+        aadObjectId,
+        name: input.fromName ?? 'Emulated Teams User',
+      },
+      recipient: { id: `28:${audience}`, name: 'AlgaPSA' },
+      conversation: {
+        id: input.conversationId ?? this.newId('conversation'),
+        conversationType,
+        tenantId,
+        isGroup: conversationType !== 'personal',
+      },
+      channelData: { tenant: { id: tenantId } },
+      locale: 'en-US',
+      text: input.text ?? '',
+      ...(input.value ? { value: input.value } : {}),
+    };
+    return {
+      activity,
+      targetUrl: input.targetUrl ?? this.botConfig.targetUrl,
+      serviceUrl,
+      audience,
+      aadObjectId,
+      tenantId,
+    };
+  }
+}
+
+/** Vendor-surface representation: channels are served on a sub-route. */
+export function publicTeam(team: GraphTeam): Omit<GraphTeam, 'channels'> {
+  const { channels: _channels, ...rest } = team;
+  return rest;
 }
 
 /** Vendor-surface representation: the owning client id stays internal. */

--- a/packages/emulators/msgraph/src/core.ts
+++ b/packages/emulators/msgraph/src/core.ts
@@ -243,7 +243,7 @@ const DEFAULT_BOT_CONFIG: BotConfig = {
  * expires access tokens and subscriptions exactly like real elapsed time.
  */
 export class MsGraphCore implements EmulatorCore {
-  private readonly clients = new Map<string, string>();
+  private readonly clients = new Map<string, { secret: string; appRoles: string[] }>();
   private readonly codes = new Map<string, {
     clientId: string;
     redirectUri: string;
@@ -310,8 +310,13 @@ export class MsGraphCore implements EmulatorCore {
 
   // --- OAuth ---
 
-  registerClient(clientId: string, clientSecret: string): void {
-    this.clients.set(clientId, clientSecret);
+  /**
+   * `appRoles` are the admin-consented application permissions Entra stamps
+   * into the `roles` claim of an app-only token. Empty (the default) emulates
+   * an app registration whose permissions were never consented.
+   */
+  registerClient(clientId: string, clientSecret: string, appRoles: string[] = []): void {
+    this.clients.set(clientId, { secret: clientSecret, appRoles: [...appRoles] });
   }
 
   authorize(clientId: string, redirectUri: string, input?: { nonce?: string; scope?: string }): string {
@@ -331,7 +336,7 @@ export class MsGraphCore implements EmulatorCore {
     token_type: 'Bearer';
     id_token?: string;
   } {
-    if (this.clients.get(String(input.client_id)) !== String(input.client_secret)) {
+    if (this.clients.get(String(input.client_id))?.secret !== String(input.client_secret)) {
       throw new GraphApiError(401, { error: 'invalid_client' });
     }
     if (input.grant_type === 'authorization_code') {
@@ -359,7 +364,7 @@ export class MsGraphCore implements EmulatorCore {
       const { refresh_token: issuedRefreshToken, ...appOnly } = this.issueTokens(
         String(input.client_id),
         undefined,
-        { scope: input.scope || 'https://graph.microsoft.com/.default' },
+        { scope: input.scope || 'https://graph.microsoft.com/.default', appOnly: true },
       );
       this.refreshTokens.delete(issuedRefreshToken);
       return appOnly;
@@ -376,13 +381,18 @@ export class MsGraphCore implements EmulatorCore {
   private issueTokens(
     clientId: string,
     existingRefreshToken?: string,
-    claims?: { nonce?: string; scope?: string }
+    claims?: { nonce?: string; scope?: string; appOnly?: boolean }
   ) {
     const tenantId = EMULATED_TENANT_ID;
+    // App-only tokens carry the consented application permissions in `roles`
+    // and no `scp`; delegated tokens are the other way round. Setup probes
+    // read `roles` straight off the token, exactly as Entra issues it.
     const accessToken = this.encodeJwt({
       tid: tenantId,
       iss: `https://login.microsoftonline.com/${tenantId}/v2.0`,
-      scp: claims?.scope || 'Mail.Read Mail.Read.Shared offline_access',
+      ...(claims?.appOnly
+        ? { roles: this.clients.get(clientId)?.appRoles ?? [] }
+        : { scp: claims?.scope || 'Mail.Read Mail.Read.Shared offline_access' }),
       aud: '00000003-0000-0000-c000-000000000000',
       exp: Math.floor((this.nowMs() + this.accessTokenTtlSeconds * 1000) / 1000),
     });

--- a/packages/emulators/msgraph/src/index.ts
+++ b/packages/emulators/msgraph/src/index.ts
@@ -15,4 +15,19 @@ const msgraphEmulator: EmulatorPackage<MsGraphCore> = {
 export default msgraphEmulator;
 export { msgraphEmulator as emulator };
 export { GraphApiError, MsGraphCore } from './core';
-export type { GraphApplication, GraphMessage, GraphServicePrincipal, GraphSubscription } from './core';
+export type {
+  ActivityNotificationRecord,
+  BotConfig,
+  BotConversation,
+  CapturedBotActivity,
+  GraphApplication,
+  GraphChat,
+  GraphChatMessage,
+  GraphMessage,
+  GraphServicePrincipal,
+  GraphSubscription,
+  GraphTeam,
+  GraphTeamChannel,
+  InboundBotActivityInput,
+} from './core';
+export { BOT_FRAMEWORK_ISSUER } from './botFramework';

--- a/packages/emulators/msgraph/src/notifier.ts
+++ b/packages/emulators/msgraph/src/notifier.ts
@@ -71,9 +71,16 @@ export async function deliverInboundBotActivity(
   env: HostEnv,
 ): Promise<InboundBotActivityResult> {
   const { activity, targetUrl, serviceUrl, audience, aadObjectId, tenantId } = core.buildInboundActivity(input);
+  // The token is stamped with wall time, not env.clock: its iat/nbf/exp are
+  // consumed by the app's jose verifier, which reads the real clock with zero
+  // tolerance — and real Microsoft stamps wall time too. Emulator STATE (access
+  // token expiry, subscriptions, activity timestamps) still flows through
+  // env.clock, so `clock advance` and activity injection compose. Backdate
+  // deliberately with tokenAgeSeconds to test an expired inbound token.
+  const issuedAt = Math.floor(Date.now() / 1000) - (input.tokenAgeSeconds ?? 0);
   const token = signBotFrameworkJwt(
     { aud: audience, serviceurl: serviceUrl, oid: aadObjectId, tid: tenantId },
-    Math.floor(env.clock.now().getTime() / 1000),
+    issuedAt,
   );
 
   try {

--- a/packages/emulators/msgraph/src/notifier.ts
+++ b/packages/emulators/msgraph/src/notifier.ts
@@ -1,5 +1,6 @@
 import type { HostEnv } from '@alga-psa/emulator-host';
-import type { GraphMessage, GraphSubscription, MsGraphCore } from './core';
+import { signBotFrameworkJwt } from './botFramework';
+import type { GraphMessage, GraphSubscription, InboundBotActivityInput, MsGraphCore } from './core';
 
 /**
  * Webhook I/O lives here, outside the pure core: Graph's subscription
@@ -44,5 +45,54 @@ async function deliverOne(subscription: GraphSubscription, message: GraphMessage
       subscriptionId: subscription.id,
       error: error instanceof Error ? error.message : String(error),
     });
+  }
+}
+
+export interface InboundBotActivityResult {
+  targetUrl: string;
+  delivered: boolean;
+  /** Status the app's bot endpoint answered with, or null when unreachable. */
+  status: number | null;
+  /** The app's synchronous reply body, so callers see the bot's answer inline. */
+  response?: unknown;
+  error?: string;
+  activity: Record<string, unknown>;
+}
+
+/**
+ * Inbound injection: build a Bot Framework Activity, sign it with the
+ * emulator's Bot Framework key, and POST it at the app's bot endpoint the way
+ * Microsoft would. The app verifies the signature against the emulator's JWKS,
+ * so the real inbound-security path is exercised end to end.
+ */
+export async function deliverInboundBotActivity(
+  core: MsGraphCore,
+  input: InboundBotActivityInput,
+  env: HostEnv,
+): Promise<InboundBotActivityResult> {
+  const { activity, targetUrl, serviceUrl, audience, aadObjectId, tenantId } = core.buildInboundActivity(input);
+  const token = signBotFrameworkJwt(
+    { aud: audience, serviceurl: serviceUrl, oid: aadObjectId, tid: tenantId },
+    Math.floor(env.clock.now().getTime() / 1000),
+  );
+
+  try {
+    const response = await fetch(targetUrl, {
+      method: 'POST',
+      headers: { 'content-type': 'application/json', authorization: `Bearer ${token}` },
+      body: JSON.stringify(activity),
+    });
+    const raw = await response.text();
+    let parsed: unknown = raw;
+    try {
+      parsed = raw ? JSON.parse(raw) : null;
+    } catch {
+      /* non-JSON bodies pass through as text */
+    }
+    return { targetUrl, delivered: true, status: response.status, response: parsed, activity };
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    env.log('msgraph inbound bot activity delivery failed', { targetUrl, error: message });
+    return { targetUrl, delivered: false, status: null, error: message, activity };
   }
 }

--- a/packages/emulators/msgraph/src/register.ts
+++ b/packages/emulators/msgraph/src/register.ts
@@ -135,7 +135,7 @@ export function register(reg: ControlRegistry, core: MsGraphCore): void {
   reg.seeder({
     name: 'bot-activity',
     description:
-      "Sign and POST an inbound Bot Framework activity at the app's bot endpoint, returning the app's synchronous reply",
+      "Sign and POST an inbound Bot Framework activity at the app's bot endpoint, returning the app's synchronous reply (tokenAgeSeconds backdates the signed token to test expiry)",
     params: z.object({
       type: z.enum(['message', 'invoke', 'conversationUpdate']).optional(),
       text: z.string().optional(),
@@ -149,6 +149,7 @@ export function register(reg: ControlRegistry, core: MsGraphCore): void {
       value: z.record(z.unknown()).optional(),
       targetUrl: z.string().optional(),
       appId: z.string().optional(),
+      tokenAgeSeconds: z.number().int().nonnegative().optional(),
     }),
     run: (input) => deliverInboundBotActivity(core, input, core.env),
   });

--- a/packages/emulators/msgraph/src/register.ts
+++ b/packages/emulators/msgraph/src/register.ts
@@ -21,11 +21,16 @@ const directoryUserParams = {
 export function register(reg: ControlRegistry, core: MsGraphCore): void {
   reg.seeder({
     name: 'client',
-    description: 'Register an OAuth client id/secret pair',
-    params: z.object({ clientId: z.string(), clientSecret: z.string() }),
-    run: ({ clientId, clientSecret }) => {
-      core.registerClient(clientId, clientSecret);
-      return { clientId };
+    description:
+      'Register an OAuth client id/secret pair, optionally with the admin-consented application permissions its app-only tokens carry in "roles"',
+    params: z.object({
+      clientId: z.string(),
+      clientSecret: z.string(),
+      appRoles: z.array(z.string()).optional(),
+    }),
+    run: ({ clientId, clientSecret, appRoles }) => {
+      core.registerClient(clientId, clientSecret, appRoles ?? []);
+      return { clientId, appRoles: appRoles ?? [] };
     },
   });
 

--- a/packages/emulators/msgraph/src/register.ts
+++ b/packages/emulators/msgraph/src/register.ts
@@ -1,7 +1,22 @@
 import { z } from 'zod';
 import type { ControlRegistry } from '@alga-psa/emulator-host';
 import type { MsGraphCore } from './core';
-import { deliverNotifications } from './notifier';
+import { deliverInboundBotActivity, deliverNotifications } from './notifier';
+
+const directoryUserParams = {
+  id: z.string().optional(),
+  displayName: z.string().optional(),
+  givenName: z.string().nullable().optional(),
+  surname: z.string().nullable().optional(),
+  mail: z.string().nullable().optional(),
+  userPrincipalName: z.string().optional(),
+  accountEnabled: z.boolean().optional(),
+  jobTitle: z.string().nullable().optional(),
+  mobilePhone: z.string().nullable().optional(),
+  businessPhones: z.array(z.string()).optional(),
+  userType: z.enum(['Member', 'Guest']).optional(),
+  externalUserState: z.string().nullable().optional(),
+};
 
 export function register(reg: ControlRegistry, core: MsGraphCore): void {
   reg.seeder({
@@ -46,19 +61,97 @@ export function register(reg: ControlRegistry, core: MsGraphCore): void {
   reg.seeder({
     name: 'directory-user',
     description: 'Add an Entra directory user returned by Graph /users',
+    params: z.object(directoryUserParams),
+    run: (input) => core.addDirectoryUser(input),
+  });
+
+  reg.seeder({
+    name: 'teams-user',
+    description:
+      'Add a Teams-addressable directory user (userType "Guest" seeds an external/guest identity) and return the bot identity fields to feed into "bot-activity"',
+    params: z.object(directoryUserParams),
+    run: (input) => {
+      const user = core.addDirectoryUser({
+        ...input,
+        externalUserState:
+          input.externalUserState ?? (input.userType === 'Guest' ? 'PendingAcceptance' : null),
+      });
+      return {
+        ...user,
+        botIdentity: { id: `29:${user.id}`, aadObjectId: user.id, name: user.displayName },
+      };
+    },
+  });
+
+  reg.seeder({
+    name: 'teams-channel',
+    description: 'Add a channel to a team (creating the team when teamId is new)',
     params: z.object({
+      teamId: z.string().optional(),
+      teamDisplayName: z.string().optional(),
       id: z.string().optional(),
       displayName: z.string().optional(),
-      givenName: z.string().nullable().optional(),
-      surname: z.string().nullable().optional(),
-      mail: z.string().nullable().optional(),
-      userPrincipalName: z.string().optional(),
-      accountEnabled: z.boolean().optional(),
-      jobTitle: z.string().nullable().optional(),
-      mobilePhone: z.string().nullable().optional(),
-      businessPhones: z.array(z.string()).optional(),
+      description: z.string().nullable().optional(),
+      membershipType: z.enum(['standard', 'private', 'shared']).optional(),
     }),
-    run: (input) => core.addDirectoryUser(input),
+    run: (input) => core.addTeamChannel(input),
+  });
+
+  reg.seeder({
+    name: 'teams-chat',
+    description: 'Add a Teams chat (with optional members and messages) served by Graph /chats',
+    params: z.object({
+      id: z.string().optional(),
+      topic: z.string().nullable().optional(),
+      chatType: z.enum(['oneOnOne', 'group', 'meeting']).optional(),
+      members: z
+        .array(
+          z.object({
+            id: z.string().optional(),
+            displayName: z.string().optional(),
+            userId: z.string().nullable().optional(),
+          }),
+        )
+        .optional(),
+      messages: z
+        .array(
+          z.object({
+            id: z.string().optional(),
+            from: z.string().optional(),
+            fromName: z.string().optional(),
+            content: z.string().optional(),
+          }),
+        )
+        .optional(),
+    }),
+    run: (input) => core.addChat(input),
+  });
+
+  reg.seeder({
+    name: 'bot-activity',
+    description:
+      "Sign and POST an inbound Bot Framework activity at the app's bot endpoint, returning the app's synchronous reply",
+    params: z.object({
+      type: z.enum(['message', 'invoke', 'conversationUpdate']).optional(),
+      text: z.string().optional(),
+      fromId: z.string().optional(),
+      fromAadObjectId: z.string().optional(),
+      fromName: z.string().optional(),
+      conversationId: z.string().optional(),
+      conversationType: z.enum(['personal', 'groupChat', 'channel']).optional(),
+      tenantId: z.string().optional(),
+      serviceUrl: z.string().optional(),
+      value: z.record(z.unknown()).optional(),
+      targetUrl: z.string().optional(),
+      appId: z.string().optional(),
+    }),
+    run: (input) => deliverInboundBotActivity(core, input, core.env),
+  });
+
+  reg.action({
+    name: 'clear-bot-activities',
+    description: 'Drop every captured outbound Bot Framework activity',
+    run: () => ({ cleared: core.clearBotActivities() }),
   });
 
   reg.action({
@@ -76,17 +169,25 @@ export function register(reg: ControlRegistry, core: MsGraphCore): void {
 
   reg.action({
     name: 'configure',
-    description: 'Tune token behavior: access token TTL and refresh-token rotation',
+    description:
+      'Tune token behavior (access token TTL, refresh-token rotation) and the inbound bot activity defaults',
     params: z.object({
       accessTokenTtlSeconds: z.number().int().positive().optional(),
       rotateRefreshTokens: z.boolean().optional(),
+      botTargetUrl: z.string().optional(),
+      botServiceUrl: z.string().optional(),
+      botAppId: z.string().optional(),
     }),
-    run: ({ accessTokenTtlSeconds, rotateRefreshTokens }) => {
+    run: ({ accessTokenTtlSeconds, rotateRefreshTokens, botTargetUrl, botServiceUrl, botAppId }) => {
       if (accessTokenTtlSeconds !== undefined) core.accessTokenTtlSeconds = accessTokenTtlSeconds;
       if (rotateRefreshTokens !== undefined) core.rotateRefreshTokens = rotateRefreshTokens;
+      if (botTargetUrl !== undefined) core.botConfig.targetUrl = botTargetUrl;
+      if (botServiceUrl !== undefined) core.botConfig.serviceUrl = botServiceUrl;
+      if (botAppId !== undefined) core.botConfig.appId = botAppId;
       return {
         accessTokenTtlSeconds: core.accessTokenTtlSeconds,
         rotateRefreshTokens: core.rotateRefreshTokens,
+        bot: { ...core.botConfig },
       };
     },
   });
@@ -94,7 +195,7 @@ export function register(reg: ControlRegistry, core: MsGraphCore): void {
   reg.fault({
     name: 'operation-fault',
     description:
-      'Fail a specific operation ("token", or "<METHOD> <graph path>" like "GET /me") with a fixed response, optionally only N times',
+      'Fail a specific operation ("token", "<METHOD> <graph path>" like "GET /me", or "<METHOD> <connector path>" like "POST /v3/conversations") with a fixed response, optionally only N times',
     params: z.object({
       operation: z.string(),
       status: z.number().int().min(400).max(599).default(500),
@@ -144,6 +245,31 @@ export function register(reg: ControlRegistry, core: MsGraphCore): void {
   });
 
   reg.stateView({
+    name: 'bot-activities',
+    description: 'Outbound Bot Framework activities the bot pushed at the connector, newest last',
+    get: () => [...core.capturedBotActivities],
+  });
+
+  reg.stateView({
+    name: 'activity-notifications',
+    description: 'Graph teamwork/sendActivityNotification calls',
+    get: () => [...core.activityNotifications],
+  });
+
+  reg.stateView({
+    name: 'teams',
+    description: 'Teams and their channels',
+    get: () => [...core.teams.values()],
+  });
+
+  reg.stateView({
+    name: 'chats',
+    description: 'Teams chats with their messages',
+    get: () =>
+      [...core.chats.values()].map((chat) => ({ ...chat, messages: core.chatMessages.get(chat.id) ?? [] })),
+  });
+
+  reg.stateView({
     name: 'faults',
     description: 'Armed operation faults',
     get: () => Object.fromEntries(core.faults),
@@ -151,10 +277,11 @@ export function register(reg: ControlRegistry, core: MsGraphCore): void {
 
   reg.stateView({
     name: 'config',
-    description: 'Token behavior configuration',
+    description: 'Token behavior and inbound bot activity configuration',
     get: () => ({
       accessTokenTtlSeconds: core.accessTokenTtlSeconds,
       rotateRefreshTokens: core.rotateRefreshTokens,
+      bot: { ...core.botConfig },
     }),
   });
 }

--- a/packages/emulators/msgraph/src/wire.ts
+++ b/packages/emulators/msgraph/src/wire.ts
@@ -2,8 +2,9 @@ import express from 'express';
 import type { NextFunction, Request, Response, Router } from 'express';
 import { route } from '@alga-psa/emulator-host';
 import type { HostEnv } from '@alga-psa/emulator-host';
-import { GraphApiError, publicSubscription } from './core';
+import { GraphApiError, publicSubscription, publicTeam } from './core';
 import type { MsGraphCore } from './core';
+import { BOT_FRAMEWORK_ISSUER, botFrameworkJwks } from './botFramework';
 import { deliverNotifications, validateNotificationUrl } from './notifier';
 
 interface Authed {
@@ -15,13 +16,29 @@ function authed(res: Response): Authed {
 }
 
 /**
- * Vendor surface: Microsoft login (OAuth2 v2.0) plus the Graph v1.0 routes
- * Alga's email integration uses. Point MICROSOFT_LOGIN_BASE_URL and
- * MICROSOFT_GRAPH_BASE_URL (including the /v1.0 suffix) at this emulator.
+ * Vendor surface: Microsoft login (OAuth2 v2.0), the Graph v1.0 routes Alga's
+ * email and Teams integrations use, and the Bot Framework connector plus its
+ * OpenID/JWKS surface. Point MICROSOFT_LOGIN_BASE_URL, MICROSOFT_GRAPH_BASE_URL
+ * (including the /v1.0 suffix) and TEAMS_BOT_OPENID_CONFIG_URL at this emulator.
  */
 export function wire(router: Router, core: MsGraphCore, env: HostEnv): void {
   router.use(express.json());
   router.use(express.urlencoded({ extended: false }));
+
+  // --- Bot Framework identity provider ---
+  // Registered before the /:tenant login routes so the well-known paths win.
+
+  router.get('/v1/.well-known/openidconfiguration', (req, res) => {
+    res.json({
+      issuer: BOT_FRAMEWORK_ISSUER,
+      jwks_uri: `${req.protocol}://${req.get('host')}/v1/.well-known/keys`,
+      id_token_signing_alg_values_supported: ['RS256'],
+    });
+  });
+
+  router.get('/v1/.well-known/keys', (_req, res) => {
+    res.json(botFrameworkJwks());
+  });
 
   // --- Microsoft login surface ---
 
@@ -65,6 +82,55 @@ export function wire(router: Router, core: MsGraphCore, env: HostEnv): void {
     res.redirect(302, callback.toString());
   });
 
+  // --- Bot Framework connector surface ---
+  // These hang off the root router, so they need their own auth + fault gate;
+  // the /v1.0 middleware below does not reach them.
+
+  router.use('/v3', (req, res, next) => {
+    const bearer = String(req.headers.authorization ?? '').replace(/^Bearer\s+/i, '');
+    res.locals.access = core.authenticate(bearer);
+    // req.path is mount-relative here, so fault keys read "POST /v3/...".
+    const fault = core.consumeFault(`${req.method} /v3${req.path}`);
+    if (fault) {
+      res.status(fault.status).json(fault.body);
+      return;
+    }
+    next();
+  });
+
+  router.post('/v3/conversations', (req, res) => {
+    res.status(201).json({ id: core.createConversation(req.body ?? {}).id });
+  });
+
+  router.post('/v3/conversations/:conversationId/activities', (req, res) => {
+    const captured = core.recordBotActivity({
+      method: 'POST',
+      conversationId: String(req.params.conversationId),
+      activity: req.body ?? {},
+    });
+    res.json({ id: captured.id });
+  });
+
+  router.post('/v3/conversations/:conversationId/activities/:activityId', (req, res) => {
+    const captured = core.recordBotActivity({
+      method: 'POST',
+      conversationId: String(req.params.conversationId),
+      pathActivityId: String(req.params.activityId),
+      activity: req.body ?? {},
+    });
+    res.json({ id: captured.id });
+  });
+
+  router.put('/v3/conversations/:conversationId/activities/:activityId', (req, res) => {
+    const captured = core.recordBotActivity({
+      method: 'PUT',
+      conversationId: String(req.params.conversationId),
+      pathActivityId: String(req.params.activityId),
+      activity: req.body ?? {},
+    });
+    res.json({ id: captured.id });
+  });
+
   // --- Graph v1.0 surface ---
 
   const graph = express.Router();
@@ -102,6 +168,37 @@ export function wire(router: Router, core: MsGraphCore, env: HostEnv): void {
       return;
     }
     res.json(mailboxUser);
+  });
+
+  // Teams surface: activity feed notifications plus the channel/chat lookups
+  // the Teams add-on resolves conversation targets with.
+  graph.post('/users/:userId/teamwork/sendActivityNotification', (req, res) => {
+    core.recordActivityNotification(String(req.params.userId), req.body ?? {});
+    res.status(202).end();
+  });
+
+  graph.get('/teams', (_req, res) => {
+    res.json({ value: [...core.teams.values()].map(publicTeam) });
+  });
+
+  graph.get('/teams/:teamId', (req, res) => {
+    res.json(publicTeam(core.getTeam(String(req.params.teamId))));
+  });
+
+  graph.get('/teams/:teamId/channels', (req, res) => {
+    res.json({ value: core.getTeam(String(req.params.teamId)).channels });
+  });
+
+  graph.get('/chats', (_req, res) => {
+    res.json({ value: [...core.chats.values()] });
+  });
+
+  graph.get('/chats/:chatId', (req, res) => {
+    res.json(core.getChat(String(req.params.chatId)));
+  });
+
+  graph.get('/chats/:chatId/messages', (req, res) => {
+    res.json({ value: core.listChatMessages(String(req.params.chatId)) });
   });
 
   graph.post('/applications', (req, res) => {

--- a/packages/emulators/msgraph/src/wire.ts
+++ b/packages/emulators/msgraph/src/wire.ts
@@ -15,6 +15,14 @@ function authed(res: Response): Authed {
   return res.locals.access as Authed;
 }
 
+function decodePath(path: string): string {
+  try {
+    return decodeURIComponent(path);
+  } catch {
+    return path;
+  }
+}
+
 /**
  * Vendor surface: Microsoft login (OAuth2 v2.0), the Graph v1.0 routes Alga's
  * email and Teams integrations use, and the Bot Framework connector plus its
@@ -90,7 +98,9 @@ export function wire(router: Router, core: MsGraphCore, env: HostEnv): void {
     const bearer = String(req.headers.authorization ?? '').replace(/^Bearer\s+/i, '');
     res.locals.access = core.authenticate(bearer);
     // req.path is mount-relative here, so fault keys read "POST /v3/...".
-    const fault = core.consumeFault(`${req.method} /v3${req.path}`);
+    // Decoded, because the connector percent-encodes conversation ids and
+    // faults are armed with the readable id ("19:...@thread.v2").
+    const fault = core.consumeFault(`${req.method} /v3${decodePath(req.path)}`);
     if (fault) {
       res.status(fault.status).json(fault.body);
       return;

--- a/packages/emulators/msgraph/tests/smoke.test.ts
+++ b/packages/emulators/msgraph/tests/smoke.test.ts
@@ -447,6 +447,54 @@ describe('msgraph emulator', { shuffle: false }, () => {
     });
   });
 
+  it('stamps consented application permissions into app-only tokens', async () => {
+    const seeded = await controlPost('/control/msgraph/seed/client', {
+      clientId: 'teams-graph-app',
+      clientSecret: 'teams-graph-secret',
+      appRoles: ['TeamsActivity.Send', 'User.Read.All'],
+    });
+    expect(seeded.ok).toBe(true);
+
+    const claimsOf = (token: string) =>
+      JSON.parse(Buffer.from(token.split('.')[1], 'base64url').toString('utf8'));
+
+    const consented = await (
+      await fetch(
+        `${base}/common/oauth2/v2.0/token`,
+        form({
+          client_id: 'teams-graph-app',
+          client_secret: 'teams-graph-secret',
+          grant_type: 'client_credentials',
+          scope: 'https://graph.microsoft.com/.default',
+        }),
+      )
+    ).json();
+    // Entra puts admin-consented application permissions in `roles` (never
+    // `scp`) on app-only tokens; the Teams setup probe reads them from there.
+    expect(claimsOf(consented.access_token)).toMatchObject({
+      roles: ['TeamsActivity.Send', 'User.Read.All'],
+    });
+    expect(claimsOf(consented.access_token).scp).toBeUndefined();
+
+    // A client seeded without consent gets an empty roles claim.
+    const unconsented = await (
+      await fetch(
+        `${base}/common/oauth2/v2.0/token`,
+        form({
+          client_id: 'premise-app',
+          client_secret: 'premise-secret',
+          grant_type: 'client_credentials',
+          scope: 'https://graph.microsoft.com/.default',
+        }),
+      )
+    ).json();
+    expect(claimsOf(unconsented.access_token).roles).toEqual([]);
+
+    // Delegated tokens are the other way round.
+    expect(claimsOf(accessToken).scp).toBeTruthy();
+    expect(claimsOf(accessToken).roles).toBeUndefined();
+  });
+
   it('records activity notifications and serves teams, channels, and chats', async () => {
     const headers = { authorization: `Bearer ${accessToken}`, 'content-type': 'application/json' };
 

--- a/packages/emulators/msgraph/tests/smoke.test.ts
+++ b/packages/emulators/msgraph/tests/smoke.test.ts
@@ -610,6 +610,37 @@ describe('msgraph emulator', { shuffle: false }, () => {
     expect((await fetch(`${base}/v1.0/me`, { headers: { authorization: `Bearer ${tokens.access_token}` } })).status).toBe(401);
   });
 
+  // Runs after the clock advanced 2h above: inbound JWTs are stamped with wall
+  // time on purpose, because jose reads the real clock. Otherwise advancing the
+  // virtual clock would silently break every injected activity.
+  it('keeps injected bot tokens verifiable across a clock advance, and ages them on demand', async () => {
+    const jwks = createLocalJWKSet(await (await fetch(`${base}/v1/.well-known/keys`)).json());
+    const deliveredToken = () => inboundBotRequests.at(-1)!.authorization!.replace(/^Bearer\s+/i, '');
+
+    const fresh = await controlPost('/control/msgraph/seed/bot-activity', {
+      text: 'after the clock moved',
+      conversationId,
+    });
+    expect(fresh.result).toMatchObject({ delivered: true, status: 200 });
+    const { payload } = await jwtVerify(deliveredToken(), jwks, {
+      issuer: 'https://api.botframework.com',
+      audience: BOT_APP_ID,
+    });
+    expect(payload.exp! * 1000).toBeGreaterThan(Date.now());
+
+    // tokenAgeSeconds backdates the token past the 1h TTL so inbound-auth
+    // rejection is testable without touching the clock.
+    const stale = await controlPost('/control/msgraph/seed/bot-activity', {
+      text: 'issued two hours ago',
+      conversationId,
+      tokenAgeSeconds: 7200,
+    });
+    expect(stale.result.delivered).toBe(true);
+    await expect(
+      jwtVerify(deliveredToken(), jwks, { issuer: 'https://api.botframework.com', audience: BOT_APP_ID }),
+    ).rejects.toMatchObject({ code: 'ERR_JWT_EXPIRED' });
+  });
+
   it('revokes refresh tokens via action', async () => {
     const authorize = new URL(`${base}/common/oauth2/v2.0/authorize`);
     authorize.search = new URLSearchParams({ client_id: 'premise-app', redirect_uri: 'http://localhost/cb' }).toString();

--- a/packages/emulators/msgraph/tests/smoke.test.ts
+++ b/packages/emulators/msgraph/tests/smoke.test.ts
@@ -1,4 +1,5 @@
 import http from 'node:http';
+import { createLocalJWKSet, jwtVerify } from 'jose';
 import { afterAll, beforeAll, describe, expect, it } from 'vitest';
 import { EmulatorHost } from '@alga-psa/emulator-host';
 import msgraphEmulator from '../src/index';
@@ -13,7 +14,13 @@ let base: string;
 let control: string;
 let webhook: http.Server;
 let webhookPort: number;
+let botEndpoint: http.Server;
+let botEndpointUrl: string;
 const notifications: any[] = [];
+/** Stand-in for the app's /api/teams/bot/messages route. */
+const inboundBotRequests: Array<{ authorization: string | null; activity: any }> = [];
+
+const BOT_APP_ID = 'emulated-bot-app-id';
 
 async function controlPost(path: string, body?: unknown): Promise<any> {
   const response = await fetch(`${control}${path}`, {
@@ -22,6 +29,16 @@ async function controlPost(path: string, body?: unknown): Promise<any> {
     body: JSON.stringify(body ?? {}),
   });
   return response.json();
+}
+
+async function controlState(view: string): Promise<any> {
+  return (await (await fetch(`${control}/control/msgraph/state/${view}`)).json()).result;
+}
+
+async function readJsonBody(req: http.IncomingMessage): Promise<any> {
+  const chunks: Buffer[] = [];
+  for await (const chunk of req) chunks.push(chunk as Buffer);
+  return JSON.parse(Buffer.concat(chunks).toString('utf8'));
 }
 
 function form(entries: Record<string, string>): RequestInit {
@@ -41,15 +58,28 @@ beforeAll(async () => {
         res.end(url.searchParams.get('validationToken'));
         return;
       }
-      const chunks: Buffer[] = [];
-      for await (const chunk of req) chunks.push(chunk as Buffer);
-      notifications.push(JSON.parse(Buffer.concat(chunks).toString('utf8')));
+      notifications.push(await readJsonBody(req));
       res.writeHead(202);
       res.end();
     })
     .listen(0, '127.0.0.1');
   await new Promise<void>((resolve) => webhook.once('listening', resolve));
   webhookPort = (webhook.address() as { port: number }).port;
+
+  botEndpoint = http
+    .createServer(async (req, res) => {
+      if (req.url !== '/api/teams/bot/messages') {
+        res.writeHead(404).end();
+        return;
+      }
+      const activity = await readJsonBody(req);
+      inboundBotRequests.push({ authorization: req.headers.authorization ?? null, activity });
+      res.writeHead(200, { 'content-type': 'application/json' });
+      res.end(JSON.stringify({ type: 'message', text: 'ack' }));
+    })
+    .listen(0, '127.0.0.1');
+  await new Promise<void>((resolve) => botEndpoint.once('listening', resolve));
+  botEndpointUrl = `http://127.0.0.1:${(botEndpoint.address() as { port: number }).port}/api/teams/bot/messages`;
 
   host = new EmulatorHost({ emulators: [msgraphEmulator], controlPort: 0, ports: { msgraph: 0 } });
   const { controlPort, ports } = await host.start();
@@ -60,6 +90,7 @@ beforeAll(async () => {
 afterAll(async () => {
   await host.stop();
   await new Promise((resolve) => webhook.close(resolve));
+  await new Promise((resolve) => botEndpoint.close(resolve));
 });
 
 // Tests narrate one protocol session (token minted early, reused later);
@@ -267,6 +298,244 @@ describe('msgraph emulator', { shuffle: false }, () => {
     ]);
   });
 
+  let botToken: string;
+  let jwksBeforeReset: unknown;
+  const conversationId = 'a:teams-conversation-1';
+
+  it('injects a signed inbound Teams activity into the app bot endpoint', async () => {
+    const configured = await controlPost('/control/msgraph/actions/configure', {
+      botTargetUrl: botEndpointUrl,
+      botServiceUrl: base,
+      botAppId: BOT_APP_ID,
+    });
+    expect(configured.result.bot).toMatchObject({ targetUrl: botEndpointUrl, appId: BOT_APP_ID });
+
+    const guest = await controlPost('/control/msgraph/seed/teams-user', {
+      id: 'guest-client-contact',
+      displayName: 'Wanda Client',
+      mail: 'wanda@client.example',
+      userType: 'Guest',
+    });
+    expect(guest.result).toMatchObject({ userType: 'Guest', externalUserState: 'PendingAcceptance' });
+    expect(guest.result.botIdentity.id).toBe('29:guest-client-contact');
+
+    const seeded = await controlPost('/control/msgraph/seed/bot-activity', {
+      text: 'My printer is on fire',
+      fromAadObjectId: 'guest-client-contact',
+      fromName: 'Wanda Client',
+      conversationId,
+      conversationType: 'personal',
+      tenantId: '11111111-2222-4333-8444-555555555555',
+    });
+    expect(seeded.ok).toBe(true);
+    expect(seeded.result).toMatchObject({ delivered: true, status: 200 });
+    expect(seeded.result.response).toEqual({ type: 'message', text: 'ack' });
+
+    const received = inboundBotRequests.at(-1)!;
+    expect(received.activity).toMatchObject({
+      type: 'message',
+      channelId: 'msteams',
+      serviceUrl: base,
+      text: 'My printer is on fire',
+      from: { id: '29:guest-client-contact', aadObjectId: 'guest-client-contact', name: 'Wanda Client' },
+      conversation: { id: conversationId, conversationType: 'personal' },
+      channelData: { tenant: { id: '11111111-2222-4333-8444-555555555555' } },
+    });
+
+    // The app verifies this token against the emulator's JWKS with jose, so
+    // verify it exactly the way teamsBotJwtVerifier does.
+    const config = await (await fetch(`${base}/v1/.well-known/openidconfiguration`)).json();
+    expect(config.issuer).toBe('https://api.botframework.com');
+    expect(config.jwks_uri).toBe(`${base}/v1/.well-known/keys`);
+
+    const jwksDocument = await (await fetch(config.jwks_uri)).json();
+    expect(jwksDocument.keys[0]).toMatchObject({ kty: 'RSA', alg: 'RS256', use: 'sig' });
+    expect(jwksDocument.keys[0].kid).toBeTruthy();
+    jwksBeforeReset = jwksDocument;
+
+    const { payload } = await jwtVerify(
+      received.authorization!.replace(/^Bearer\s+/i, ''),
+      createLocalJWKSet(jwksDocument),
+      { issuer: config.issuer, audience: BOT_APP_ID },
+    );
+    expect(payload).toMatchObject({
+      serviceurl: base,
+      oid: 'guest-client-contact',
+      tid: '11111111-2222-4333-8444-555555555555',
+    });
+
+    const users = await (
+      await fetch(`${base}/v1.0/users`, { headers: { authorization: `Bearer ${accessToken}` } })
+    ).json();
+    expect(users.value).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          id: 'guest-client-contact',
+          userType: 'Guest',
+          externalUserState: 'PendingAcceptance',
+        }),
+        expect.objectContaining({ id: 'user-ada', userType: 'Member', externalUserState: null }),
+      ]),
+    );
+  });
+
+  it('captures outbound connector activities including adaptive cards', async () => {
+    const tokenResponse = await fetch(
+      `${base}/common/oauth2/v2.0/token`,
+      form({
+        client_id: 'premise-app',
+        client_secret: 'premise-secret',
+        grant_type: 'client_credentials',
+        scope: 'https://api.botframework.com/.default',
+      }),
+    );
+    expect(tokenResponse.status).toBe(200);
+    const tokens = await tokenResponse.json();
+    expect(tokens.refresh_token).toBeUndefined();
+    botToken = tokens.access_token;
+
+    const headers = { authorization: `Bearer ${botToken}`, 'content-type': 'application/json' };
+    expect((await fetch(`${base}/v3/conversations/${conversationId}/activities`, { method: 'POST' })).status).toBe(401);
+
+    const created = await fetch(`${base}/v3/conversations`, {
+      method: 'POST',
+      headers,
+      body: JSON.stringify({ isGroup: false, members: [{ id: '29:guest-client-contact' }] }),
+    });
+    expect(created.status).toBe(201);
+    expect((await created.json()).id).toBeTruthy();
+
+    const card = {
+      contentType: 'application/vnd.microsoft.card.adaptive',
+      content: {
+        type: 'AdaptiveCard',
+        version: '1.5',
+        body: [{ type: 'TextBlock', text: 'Ticket TKT-1042 created' }],
+      },
+    };
+    const sent = await fetch(`${base}/v3/conversations/${encodeURIComponent(conversationId)}/activities`, {
+      method: 'POST',
+      headers,
+      body: JSON.stringify({ type: 'message', text: 'Ticket created', attachments: [card] }),
+    });
+    expect(sent.status).toBe(200);
+    const sentActivityId = (await sent.json()).id;
+    expect(sentActivityId).toBeTruthy();
+
+    const updated = await fetch(
+      `${base}/v3/conversations/${encodeURIComponent(conversationId)}/activities/${encodeURIComponent(sentActivityId)}`,
+      { method: 'PUT', headers, body: JSON.stringify({ type: 'message', text: 'Ticket TKT-1042 assigned' }) },
+    );
+    expect(updated.status).toBe(200);
+    expect((await updated.json()).id).toBe(sentActivityId);
+
+    const captured = await controlState('bot-activities');
+    expect(captured).toHaveLength(2);
+    expect(captured[0]).toMatchObject({
+      method: 'POST',
+      conversationId,
+      type: 'message',
+      text: 'Ticket created',
+      id: sentActivityId,
+    });
+    expect(captured[0].attachments[0].content.body[0].text).toBe('Ticket TKT-1042 created');
+    expect(captured[1]).toMatchObject({
+      method: 'PUT',
+      id: sentActivityId,
+      pathActivityId: sentActivityId,
+      text: 'Ticket TKT-1042 assigned',
+    });
+  });
+
+  it('records activity notifications and serves teams, channels, and chats', async () => {
+    const headers = { authorization: `Bearer ${accessToken}`, 'content-type': 'application/json' };
+
+    const channel = await controlPost('/control/msgraph/seed/teams-channel', {
+      teamId: 'team-helpdesk',
+      teamDisplayName: 'Helpdesk',
+      id: 'channel-triage',
+      displayName: 'Triage',
+    });
+    expect(channel.ok).toBe(true);
+
+    const chat = await controlPost('/control/msgraph/seed/teams-chat', {
+      id: 'chat-wanda',
+      chatType: 'oneOnOne',
+      members: [{ id: '29:guest-client-contact', displayName: 'Wanda Client', userId: 'guest-client-contact' }],
+      messages: [{ content: 'My printer is on fire', fromName: 'Wanda Client' }],
+    });
+    expect(chat.ok).toBe(true);
+
+    const teams = await (await fetch(`${base}/v1.0/teams`, { headers })).json();
+    expect(teams.value).toEqual([{ id: 'team-helpdesk', displayName: 'Helpdesk', description: null }]);
+
+    const channels = await (await fetch(`${base}/v1.0/teams/team-helpdesk/channels`, { headers })).json();
+    expect(channels.value).toEqual([
+      { id: 'channel-triage', displayName: 'Triage', description: null, membershipType: 'standard' },
+    ]);
+    expect((await fetch(`${base}/v1.0/teams/nope`, { headers })).status).toBe(404);
+
+    const chats = await (await fetch(`${base}/v1.0/chats`, { headers })).json();
+    expect(chats.value).toEqual([expect.objectContaining({ id: 'chat-wanda', chatType: 'oneOnOne' })]);
+
+    const chatMessages = await (await fetch(`${base}/v1.0/chats/chat-wanda/messages`, { headers })).json();
+    expect(chatMessages.value[0].body.content).toBe('My printer is on fire');
+
+    const notification = await fetch(
+      `${base}/v1.0/users/guest-client-contact/teamwork/sendActivityNotification`,
+      {
+        method: 'POST',
+        headers,
+        body: JSON.stringify({ activityType: 'taskAssigned', topic: { source: 'text', value: 'TKT-1042' } }),
+      },
+    );
+    expect(notification.status).toBe(202);
+
+    const recorded = await controlState('activity-notifications');
+    expect(recorded).toEqual([
+      expect.objectContaining({
+        userId: 'guest-client-contact',
+        body: { activityType: 'taskAssigned', topic: { source: 'text', value: 'TKT-1042' } },
+      }),
+    ]);
+  });
+
+  it('throttles the connector and activity notification routes via operation faults', async () => {
+    await controlPost('/control/msgraph/faults/operation-fault/arm', {
+      operation: `POST /v3/conversations/${conversationId}/activities`,
+      status: 429,
+      body: { error: { code: 'Throttled' } },
+      remaining: 1,
+    });
+    const botHeaders = { authorization: `Bearer ${botToken}`, 'content-type': 'application/json' };
+    const activityUrl = `${base}/v3/conversations/${encodeURIComponent(conversationId)}/activities`;
+    const throttled = await fetch(activityUrl, {
+      method: 'POST',
+      headers: botHeaders,
+      body: JSON.stringify({ type: 'message', text: 'retry me' }),
+    });
+    expect(throttled.status).toBe(429);
+    expect((await throttled.json()).error.code).toBe('Throttled');
+    expect(
+      (await fetch(activityUrl, { method: 'POST', headers: botHeaders, body: JSON.stringify({ type: 'message', text: 'retry me' }) }))
+        .status,
+    ).toBe(200);
+
+    await controlPost('/control/msgraph/faults/operation-fault/arm', {
+      operation: 'POST /users/guest-client-contact/teamwork/sendActivityNotification',
+      status: 429,
+      remaining: 1,
+    });
+    const headers = { authorization: `Bearer ${accessToken}`, 'content-type': 'application/json' };
+    const url = `${base}/v1.0/users/guest-client-contact/teamwork/sendActivityNotification`;
+    expect((await fetch(url, { method: 'POST', headers, body: '{}' })).status).toBe(429);
+    expect((await fetch(url, { method: 'POST', headers, body: '{}' })).status).toBe(202);
+
+    const cleared = await controlPost('/control/msgraph/actions/clear-bot-activities');
+    expect(cleared.result.cleared).toBe(3);
+    expect(await controlState('bot-activities')).toEqual([]);
+  });
+
   it('injects operation faults that expire after N uses', async () => {
     await controlPost('/control/msgraph/faults/operation-fault/arm', {
       operation: 'GET /me',
@@ -311,5 +580,45 @@ describe('msgraph emulator', { shuffle: false }, () => {
     );
     expect(refused.status).toBe(400);
     expect((await refused.json()).error).toBe('invalid_grant');
+  });
+
+  // Last: reset wipes the client registrations every earlier test relies on.
+  it('clears the Teams surface on reset', async () => {
+    const appToken = (
+      await (
+        await fetch(
+          `${base}/common/oauth2/v2.0/token`,
+          form({
+            client_id: 'premise-app',
+            client_secret: 'premise-secret',
+            grant_type: 'client_credentials',
+            scope: 'https://api.botframework.com/.default',
+          }),
+        )
+      ).json()
+    ).access_token;
+    await fetch(`${base}/v3/conversations/${encodeURIComponent(conversationId)}/activities`, {
+      method: 'POST',
+      headers: { authorization: `Bearer ${appToken}`, 'content-type': 'application/json' },
+      body: JSON.stringify({ type: 'message', text: 'still here' }),
+    });
+    expect(await controlState('bot-activities')).toHaveLength(1);
+    expect(await controlState('teams')).toHaveLength(1);
+
+    await controlPost('/control/msgraph/reset');
+
+    for (const view of ['bot-activities', 'activity-notifications', 'teams', 'chats']) {
+      expect(await controlState(view)).toEqual([]);
+    }
+    expect((await controlState('config')).bot).toEqual({
+      targetUrl: 'http://localhost:3000/api/teams/bot/messages',
+      serviceUrl: 'http://localhost:4010',
+      appId: 'emulated-teams-bot-app-id',
+      tenantId: '11111111-2222-4333-8444-555555555555',
+    });
+
+    // reset() must not rotate the signing key: the app caches the JWKS for 12h.
+    const jwksAfterReset = await (await fetch(`${base}/v1/.well-known/keys`)).json();
+    expect(jwksAfterReset).toEqual(jwksBeforeReset);
   });
 });

--- a/server/src/test/unit/lib/teams/actions/teamsSetupValidationActions.test.ts
+++ b/server/src/test/unit/lib/teams/actions/teamsSetupValidationActions.test.ts
@@ -343,6 +343,18 @@ describe('validateTeamsBotConnector (T093)', () => {
     expect(body.get('scope')).toBe('https://api.botframework.com/.default');
   });
 
+  it('sends the bot token request to MICROSOFT_LOGIN_BASE_URL when it is set', async () => {
+    stubBotEnv();
+    vi.stubEnv('MICROSOFT_LOGIN_BASE_URL', 'http://127.0.0.1:4010');
+    fetchMock.mockResolvedValueOnce(tokenResponse(mintJwt({ aud: 'https://api.botframework.com' })));
+
+    await expect(validateTeamsBotConnectorImpl(USER, { tenant: TENANT })).resolves.toEqual({
+      status: 'ok',
+      appId: 'bot-app-1',
+    });
+    expect(fetchMock.mock.calls[0][0]).toBe('http://127.0.0.1:4010/bot-tenant-1/oauth2/v2.0/token');
+  });
+
   it('maps a wrong password (AADSTS7000215) to invalid_password naming TEAMS_BOT_APP_PASSWORD', async () => {
     stubBotEnv({ TEAMS_BOT_APP_PASSWORD: 'wrong-password' });
     fetchMock.mockResolvedValueOnce(

--- a/server/src/test/unit/lib/teams/actions/teamsSetupValidationActions.test.ts
+++ b/server/src/test/unit/lib/teams/actions/teamsSetupValidationActions.test.ts
@@ -237,6 +237,18 @@ describe('validateTeamsGraphCredentials (T091)', () => {
     const result = await validateTeamsGraphCredentialsImpl(USER, { tenant: TENANT });
     expect(result).toMatchObject({ status: 'failed', reason: 'network_error' });
     expect((result as { message: string }).message).toContain('fetch failed');
+    expect((result as { message: string }).message).toContain('login.microsoftonline.com');
+  });
+
+  it('names the emulator host in network_error when the login base url is redirected', async () => {
+    vi.stubEnv('TEAMS_EMULATOR_MODE', 'true');
+    vi.stubEnv('MICROSOFT_LOGIN_BASE_URL', 'http://127.0.0.1:4010');
+    fetchMock.mockRejectedValueOnce(new TypeError('fetch failed'));
+
+    const result = await validateTeamsGraphCredentialsImpl(USER, { tenant: TENANT });
+    const message = (result as { message: string }).message;
+    expect(message).toContain('Could not reach 127.0.0.1:4010');
+    expect(message).not.toContain('login.microsoftonline.com');
   });
 });
 
@@ -354,6 +366,43 @@ describe('validateTeamsBotConnector (T093)', () => {
       appId: 'bot-app-1',
     });
     expect(fetchMock.mock.calls[0][0]).toBe('http://127.0.0.1:4010/bot-tenant-1/oauth2/v2.0/token');
+  });
+
+  it('ignores MICROSOFT_LOGIN_BASE_URL when the emulator gate is off', async () => {
+    stubBotEnv();
+    vi.stubEnv('TEAMS_EMULATOR_MODE', undefined);
+    vi.stubEnv('MICROSOFT_LOGIN_BASE_URL', 'http://127.0.0.1:4010');
+    fetchMock.mockResolvedValueOnce(tokenResponse(mintJwt({ aud: 'https://api.botframework.com' })));
+
+    await validateTeamsBotConnectorImpl(USER, { tenant: TENANT });
+    expect(fetchMock.mock.calls[0][0]).toBe(
+      'https://login.microsoftonline.com/bot-tenant-1/oauth2/v2.0/token'
+    );
+  });
+
+  // A failed check has to name the host it actually contacted, or it sends
+  // whoever is debugging to a host the request never touched.
+  it('names the host that was actually contacted when the bot token request cannot connect', async () => {
+    stubBotEnv();
+    vi.stubEnv('TEAMS_EMULATOR_MODE', 'true');
+    vi.stubEnv('MICROSOFT_LOGIN_BASE_URL', 'http://127.0.0.1:4010');
+    fetchMock.mockRejectedValueOnce(new Error('connect ECONNREFUSED 127.0.0.1:4010'));
+
+    const result = await validateTeamsBotConnectorImpl(USER, { tenant: TENANT });
+    expect(result).toMatchObject({ status: 'failed', reason: 'network_error' });
+    const message = (result as { message: string }).message;
+    expect(message).toContain('127.0.0.1:4010');
+    expect(message).not.toContain('login.microsoftonline.com');
+  });
+
+  it('names login.microsoftonline.com when that is the host that was contacted', async () => {
+    stubBotEnv();
+    fetchMock.mockRejectedValueOnce(new Error('getaddrinfo ENOTFOUND'));
+
+    const result = await validateTeamsBotConnectorImpl(USER, { tenant: TENANT });
+    expect((result as { message: string }).message).toContain(
+      'Could not reach login.microsoftonline.com'
+    );
   });
 
   it('maps a wrong password (AADSTS7000215) to invalid_password naming TEAMS_BOT_APP_PASSWORD', async () => {

--- a/server/src/test/unit/lib/teams/actions/teamsSetupValidationActions.test.ts
+++ b/server/src/test/unit/lib/teams/actions/teamsSetupValidationActions.test.ts
@@ -343,8 +343,9 @@ describe('validateTeamsBotConnector (T093)', () => {
     expect(body.get('scope')).toBe('https://api.botframework.com/.default');
   });
 
-  it('sends the bot token request to MICROSOFT_LOGIN_BASE_URL when it is set', async () => {
+  it('sends the bot token request to MICROSOFT_LOGIN_BASE_URL when the emulator gate is on', async () => {
     stubBotEnv();
+    vi.stubEnv('TEAMS_EMULATOR_MODE', 'true');
     vi.stubEnv('MICROSOFT_LOGIN_BASE_URL', 'http://127.0.0.1:4010');
     fetchMock.mockResolvedValueOnce(tokenResponse(mintJwt({ aud: 'https://api.botframework.com' })));
 

--- a/server/src/test/unit/lib/teams/bot/teamsBotHandler.test.ts
+++ b/server/src/test/unit/lib/teams/bot/teamsBotHandler.test.ts
@@ -1692,6 +1692,48 @@ describe('teamsBotHandler', () => {
     expect(fallbackActivity.attachments?.[0]?.contentType).toBe('application/vnd.microsoft.card.hero');
   });
 
+  it('T071b: an expired connector token resends the Adaptive Card instead of downgrading to the hero fallback', async () => {
+    isBotConnectorConfiguredMock.mockReturnValue(true);
+    executeTeamsActionMock.mockResolvedValue(
+      buildActionSuccess('my_tickets', {
+        summary: { title: 'My tickets', text: 'Found 1 assigned ticket for the signed-in technician.' },
+        items: [
+          {
+            id: 'ticket-uuid-1',
+            displayId: 'ALGA-101',
+            title: 'ALGA-101',
+            summary: 'Printer offline • Open',
+            entityType: 'ticket',
+            links: [{ type: 'teams_tab', label: 'Open in Teams tab', url: 'https://teams.test/ticket-1' }],
+          },
+        ],
+      })
+    );
+    // 401 means the cached connector token expired, not that the client
+    // rejected the card; the connector already dropped the token, so the same
+    // activity must go back out with a fresh one.
+    sendBotActivityMock
+      .mockRejectedValueOnce(new Error('Failed to send Bot Framework activity (401 Unauthorized): token expired'))
+      .mockResolvedValueOnce({ status: 'sent' });
+
+    const request = new Request('https://example.test/api/teams/bot/messages?tenantId=tenant-1', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        ...buildPersonalMessageActivity('my tickets'),
+        id: 'activity-1',
+        serviceUrl: 'https://smba.trafficmanager.net/amer/',
+      }),
+    });
+
+    const response = await handleTeamsBotActivityRequest(request);
+    expect(response.status).toBe(200);
+    expect(sendBotActivityMock).toHaveBeenCalledTimes(2);
+    expect(sendBotActivityMock.mock.calls[1][0].activity.attachments?.[0]?.contentType).toBe(
+      'application/vnd.microsoft.card.adaptive'
+    );
+  });
+
   it('T072: the "Assign to me" card action executes assign_ticket and updates the card in place', async () => {
     isBotConnectorConfiguredMock.mockReturnValue(true);
     executeTeamsActionMock.mockResolvedValue(

--- a/server/src/test/unit/lib/teams/bot/teamsBotHandler.test.ts
+++ b/server/src/test/unit/lib/teams/bot/teamsBotHandler.test.ts
@@ -183,6 +183,42 @@ function buildFullAvailability(overrides: Partial<Record<string, boolean>> = {})
   }));
 }
 
+/**
+ * The handler classifies connector failures with `instanceof`, so rejections
+ * have to carry the mocked class the module graph handed it — a plain Error
+ * with a status in its message is deliberately not a connector failure.
+ */
+async function connectorError(message: string, status: number): Promise<Error> {
+  const { BotConnectorRequestError } = await import(
+    '@alga-psa/ee-microsoft-teams/lib/teams/bot/teamsBotConnector'
+  );
+  return new BotConnectorRequestError(message, status);
+}
+
+function buildMyTicketsSuccess() {
+  return buildActionSuccess('my_tickets', {
+    summary: { title: 'My tickets', text: 'Found 1 assigned ticket for the signed-in technician.' },
+    items: [
+      {
+        id: 'ticket-uuid-1',
+        displayId: 'ALGA-101',
+        title: 'ALGA-101',
+        summary: 'Printer offline • Open',
+        entityType: 'ticket',
+        links: [{ type: 'teams_tab', label: 'Open in Teams tab', url: 'https://teams.test/ticket-1' }],
+      },
+    ],
+  });
+}
+
+function buildConnectorRequest(body: Record<string, unknown>): Request {
+  return new Request('https://example.test/api/teams/bot/messages?tenantId=tenant-1', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ serviceUrl: 'https://smba.trafficmanager.net/amer/', ...body }),
+  });
+}
+
 function buildActionSuccess(actionId: string, overrides: Record<string, unknown> = {}) {
   return {
     success: true,
@@ -1654,7 +1690,9 @@ describe('teamsBotHandler', () => {
       })
     );
     sendBotActivityMock
-      .mockRejectedValueOnce(new Error('Failed to send Bot Framework activity (415 Unsupported Media Type): adaptive rejected'))
+      .mockRejectedValueOnce(
+        await connectorError('Failed to send Bot Framework activity (415 Unsupported Media Type): adaptive rejected', 415)
+      )
       .mockResolvedValueOnce({ status: 'sent' });
 
     const request = new Request('https://example.test/api/teams/bot/messages?tenantId=tenant-1', {
@@ -1713,7 +1751,9 @@ describe('teamsBotHandler', () => {
     // rejected the card; the connector already dropped the token, so the same
     // activity must go back out with a fresh one.
     sendBotActivityMock
-      .mockRejectedValueOnce(new Error('Failed to send Bot Framework activity (401 Unauthorized): token expired'))
+      .mockRejectedValueOnce(
+        await connectorError('Failed to send Bot Framework activity (401 Unauthorized): token expired', 401)
+      )
       .mockResolvedValueOnce({ status: 'sent' });
 
     const request = new Request('https://example.test/api/teams/bot/messages?tenantId=tenant-1', {
@@ -1732,6 +1772,53 @@ describe('teamsBotHandler', () => {
     expect(sendBotActivityMock.mock.calls[1][0].activity.attachments?.[0]?.contentType).toBe(
       'application/vnd.microsoft.card.adaptive'
     );
+  });
+
+  it('T071b: a card rejection on the post-401 resend still falls back to the hero rendering', async () => {
+    isBotConnectorConfiguredMock.mockReturnValue(true);
+    executeTeamsActionMock.mockResolvedValue(buildMyTicketsSuccess());
+    sendBotActivityMock
+      .mockRejectedValueOnce(
+        await connectorError('Failed to send Bot Framework activity (401 Unauthorized): token expired', 401)
+      )
+      .mockRejectedValueOnce(
+        await connectorError('Failed to send Bot Framework activity (415 Unsupported Media Type): adaptive rejected', 415)
+      )
+      .mockResolvedValueOnce({ status: 'sent' });
+
+    const response = await handleTeamsBotActivityRequest(
+      buildConnectorRequest({ ...buildPersonalMessageActivity('my tickets'), id: 'activity-1' })
+    );
+
+    expect(response.status).toBe(200);
+    expect(sendBotActivityMock).toHaveBeenCalledTimes(3);
+    expect(sendBotActivityMock.mock.calls[2][0].activity.attachments?.[0]?.contentType).toBe(
+      'application/vnd.microsoft.card.hero'
+    );
+  });
+
+  it('T071b: a bot token acquisition failure is surfaced instead of retried or downgraded', async () => {
+    isBotConnectorConfiguredMock.mockReturnValue(true);
+    executeTeamsActionMock.mockResolvedValue(buildMyTicketsSuccess());
+    // Thrown by the connector's token grant (e.g. a bad TEAMS_BOT_APP_PASSWORD),
+    // not by the activity dispatch: neither a resend nor the hero fallback can
+    // help, so the real cause has to reach the log verbatim.
+    const acquisitionError = new Error(
+      'Failed to acquire Bot Framework token (401 Unauthorized): invalid_client'
+    );
+    sendBotActivityMock.mockRejectedValueOnce(acquisitionError);
+    const consoleError = vi.spyOn(console, 'error').mockImplementation(() => {});
+
+    try {
+      const response = await handleTeamsBotActivityRequest(
+        buildConnectorRequest({ ...buildPersonalMessageActivity('my tickets'), id: 'activity-1' })
+      );
+      expect(response.status).toBe(200);
+      expect(sendBotActivityMock).toHaveBeenCalledTimes(1);
+      expect(consoleError).toHaveBeenCalledWith('[teams-bot] failed to send reply', acquisitionError);
+    } finally {
+      consoleError.mockRestore();
+    }
   });
 
   it('T072: the "Assign to me" card action executes assign_ticket and updates the card in place', async () => {
@@ -1792,7 +1879,7 @@ describe('teamsBotHandler', () => {
       })
     );
     updateBotActivityMock.mockRejectedValueOnce(
-      new Error('Failed to update Bot Framework activity (403 Forbidden): nope')
+      await connectorError('Failed to update Bot Framework activity (403 Forbidden): nope', 403)
     );
 
     const request = new Request('https://example.test/api/teams/bot/messages?tenantId=tenant-1', {
@@ -1814,6 +1901,66 @@ describe('teamsBotHandler', () => {
 
     await handleTeamsBotActivityRequest(request);
     expect(updateBotActivityMock).toHaveBeenCalledTimes(1);
+    expect(sendBotActivityMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('T072: an expired connector token retries the in-place update instead of duplicating the reply', async () => {
+    isBotConnectorConfiguredMock.mockReturnValue(true);
+    executeTeamsActionMock.mockResolvedValue(
+      buildActionSuccess('assign_ticket', {
+        operation: 'mutation',
+        summary: { title: 'Ticket assigned', text: 'Ticket ALGA-101 was reassigned successfully.' },
+      })
+    );
+    updateBotActivityMock.mockRejectedValueOnce(
+      await connectorError('Failed to update Bot Framework activity (401 Unauthorized): token expired', 401)
+    );
+
+    await handleTeamsBotActivityRequest(
+      buildConnectorRequest({
+        ...buildPersonalMessageActivity(''),
+        id: 'submit-activity-3',
+        replyToId: 'card-activity-3',
+        value: {
+          command: 'bot_card_action',
+          actionId: 'assign_ticket',
+          ticketId: 'ALGA-101',
+          idempotencyKey: 'card-idem-4',
+        },
+      })
+    );
+
+    expect(updateBotActivityMock).toHaveBeenCalledTimes(2);
+    expect(sendBotActivityMock).not.toHaveBeenCalled();
+  });
+
+  it('T072: an in-place update that stays unauthorized still falls back to a normal reply', async () => {
+    isBotConnectorConfiguredMock.mockReturnValue(true);
+    executeTeamsActionMock.mockResolvedValue(
+      buildActionSuccess('assign_ticket', {
+        operation: 'mutation',
+        summary: { title: 'Ticket assigned', text: 'Ticket ALGA-101 was reassigned successfully.' },
+      })
+    );
+    updateBotActivityMock.mockRejectedValue(
+      await connectorError('Failed to update Bot Framework activity (401 Unauthorized): token expired', 401)
+    );
+
+    await handleTeamsBotActivityRequest(
+      buildConnectorRequest({
+        ...buildPersonalMessageActivity(''),
+        id: 'submit-activity-4',
+        replyToId: 'card-activity-4',
+        value: {
+          command: 'bot_card_action',
+          actionId: 'assign_ticket',
+          ticketId: 'ALGA-101',
+          idempotencyKey: 'card-idem-5',
+        },
+      })
+    );
+
+    expect(updateBotActivityMock).toHaveBeenCalledTimes(2);
     expect(sendBotActivityMock).toHaveBeenCalledTimes(1);
   });
 

--- a/server/src/test/unit/lib/teams/bot/teamsBotHandler.test.ts
+++ b/server/src/test/unit/lib/teams/bot/teamsBotHandler.test.ts
@@ -1730,71 +1730,36 @@ describe('teamsBotHandler', () => {
     expect(fallbackActivity.attachments?.[0]?.contentType).toBe('application/vnd.microsoft.card.hero');
   });
 
-  it('T071b: an expired connector token resends the Adaptive Card instead of downgrading to the hero fallback', async () => {
-    isBotConnectorConfiguredMock.mockReturnValue(true);
-    executeTeamsActionMock.mockResolvedValue(
-      buildActionSuccess('my_tickets', {
-        summary: { title: 'My tickets', text: 'Found 1 assigned ticket for the signed-in technician.' },
-        items: [
-          {
-            id: 'ticket-uuid-1',
-            displayId: 'ALGA-101',
-            title: 'ALGA-101',
-            summary: 'Printer offline • Open',
-            entityType: 'ticket',
-            links: [{ type: 'teams_tab', label: 'Open in Teams tab', url: 'https://teams.test/ticket-1' }],
-          },
-        ],
-      })
-    );
-    // 401 means the cached connector token expired, not that the client
-    // rejected the card; the connector already dropped the token, so the same
-    // activity must go back out with a fresh one.
-    sendBotActivityMock
-      .mockRejectedValueOnce(
-        await connectorError('Failed to send Bot Framework activity (401 Unauthorized): token expired', 401)
-      )
-      .mockResolvedValueOnce({ status: 'sent' });
-
-    const request = new Request('https://example.test/api/teams/bot/messages?tenantId=tenant-1', {
-      method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({
-        ...buildPersonalMessageActivity('my tickets'),
-        id: 'activity-1',
-        serviceUrl: 'https://smba.trafficmanager.net/amer/',
-      }),
-    });
-
-    const response = await handleTeamsBotActivityRequest(request);
-    expect(response.status).toBe(200);
-    expect(sendBotActivityMock).toHaveBeenCalledTimes(2);
-    expect(sendBotActivityMock.mock.calls[1][0].activity.attachments?.[0]?.contentType).toBe(
-      'application/vnd.microsoft.card.adaptive'
-    );
-  });
-
-  it('T071b: a card rejection on the post-401 resend still falls back to the hero rendering', async () => {
+  /**
+   * The connector replays an expired token itself (see the connector's
+   * expired-token replay suite), so a 401 reaching the handler is a real
+   * credential problem — and must still never be mistaken for the client
+   * rejecting the Adaptive Card.
+   */
+  it('T071b: a 401 that survived the connector replay is logged, never downgraded to the hero card', async () => {
     isBotConnectorConfiguredMock.mockReturnValue(true);
     executeTeamsActionMock.mockResolvedValue(buildMyTicketsSuccess());
-    sendBotActivityMock
-      .mockRejectedValueOnce(
-        await connectorError('Failed to send Bot Framework activity (401 Unauthorized): token expired', 401)
-      )
-      .mockRejectedValueOnce(
-        await connectorError('Failed to send Bot Framework activity (415 Unsupported Media Type): adaptive rejected', 415)
-      )
-      .mockResolvedValueOnce({ status: 'sent' });
-
-    const response = await handleTeamsBotActivityRequest(
-      buildConnectorRequest({ ...buildPersonalMessageActivity('my tickets'), id: 'activity-1' })
+    const expiredToken = await connectorError(
+      'Failed to send Bot Framework activity (401 Unauthorized): token expired',
+      401
     );
+    sendBotActivityMock.mockRejectedValueOnce(expiredToken);
+    const consoleError = vi.spyOn(console, 'error').mockImplementation(() => {});
 
-    expect(response.status).toBe(200);
-    expect(sendBotActivityMock).toHaveBeenCalledTimes(3);
-    expect(sendBotActivityMock.mock.calls[2][0].activity.attachments?.[0]?.contentType).toBe(
-      'application/vnd.microsoft.card.hero'
-    );
+    try {
+      const response = await handleTeamsBotActivityRequest(
+        buildConnectorRequest({ ...buildPersonalMessageActivity('my tickets'), id: 'activity-1' })
+      );
+
+      expect(response.status).toBe(200);
+      expect(sendBotActivityMock).toHaveBeenCalledTimes(1);
+      expect(sendBotActivityMock.mock.calls[0][0].activity.attachments?.[0]?.contentType).toBe(
+        'application/vnd.microsoft.card.adaptive'
+      );
+      expect(consoleError).toHaveBeenCalledWith('[teams-bot] failed to send reply', expiredToken);
+    } finally {
+      consoleError.mockRestore();
+    }
   });
 
   it('T071b: a bot token acquisition failure is surfaced instead of retried or downgraded', async () => {
@@ -1904,37 +1869,12 @@ describe('teamsBotHandler', () => {
     expect(sendBotActivityMock).toHaveBeenCalledTimes(1);
   });
 
-  it('T072: an expired connector token retries the in-place update instead of duplicating the reply', async () => {
-    isBotConnectorConfiguredMock.mockReturnValue(true);
-    executeTeamsActionMock.mockResolvedValue(
-      buildActionSuccess('assign_ticket', {
-        operation: 'mutation',
-        summary: { title: 'Ticket assigned', text: 'Ticket ALGA-101 was reassigned successfully.' },
-      })
-    );
-    updateBotActivityMock.mockRejectedValueOnce(
-      await connectorError('Failed to update Bot Framework activity (401 Unauthorized): token expired', 401)
-    );
-
-    await handleTeamsBotActivityRequest(
-      buildConnectorRequest({
-        ...buildPersonalMessageActivity(''),
-        id: 'submit-activity-3',
-        replyToId: 'card-activity-3',
-        value: {
-          command: 'bot_card_action',
-          actionId: 'assign_ticket',
-          ticketId: 'ALGA-101',
-          idempotencyKey: 'card-idem-4',
-        },
-      })
-    );
-
-    expect(updateBotActivityMock).toHaveBeenCalledTimes(2);
-    expect(sendBotActivityMock).not.toHaveBeenCalled();
-  });
-
-  it('T072: an in-place update that stays unauthorized still falls back to a normal reply', async () => {
+  /**
+   * A transient 401 never reaches here — the connector replays it — so an
+   * unauthorized update means the credentials are genuinely bad, and the
+   * result still has to reach the user somehow.
+   */
+  it('T072: an in-place update that stays unauthorized falls back to a normal reply', async () => {
     isBotConnectorConfiguredMock.mockReturnValue(true);
     executeTeamsActionMock.mockResolvedValue(
       buildActionSuccess('assign_ticket', {
@@ -1960,7 +1900,7 @@ describe('teamsBotHandler', () => {
       })
     );
 
-    expect(updateBotActivityMock).toHaveBeenCalledTimes(2);
+    expect(updateBotActivityMock).toHaveBeenCalledTimes(1);
     expect(sendBotActivityMock).toHaveBeenCalledTimes(1);
   });
 

--- a/server/src/test/unit/lib/teams/bot/teamsBotWelcomeCardTokenRetry.test.ts
+++ b/server/src/test/unit/lib/teams/bot/teamsBotWelcomeCardTokenRetry.test.ts
@@ -1,0 +1,152 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+/**
+ * The proactive welcome card goes out through the same connector as bot
+ * replies, but with a plain try/catch that downgrades *any* failure to a hero
+ * card. Before the expired-token replay moved into the connector, a token that
+ * happened to expire mid-flow silently cost the user the Adaptive Card.
+ *
+ * Everything around the connector is mocked; the connector itself is real, so
+ * this pins the behavior of the whole non-bot-reply path.
+ */
+
+const {
+  getTeamsAvailabilityMock,
+  resolveTeamsTabAuthStateMock,
+  findTeamsConversationReferenceByConversationIdMock,
+} = vi.hoisted(() => ({
+  getTeamsAvailabilityMock: vi.fn(),
+  resolveTeamsTabAuthStateMock: vi.fn(),
+  findTeamsConversationReferenceByConversationIdMock: vi.fn(),
+}));
+
+vi.mock('@alga-psa/ee-microsoft-teams/lib/teams/teamsAvailability', () => ({
+  getTeamsAvailability: getTeamsAvailabilityMock,
+  resolveTeamsAvailability: vi.fn(),
+}));
+
+vi.mock('@alga-psa/ee-microsoft-teams/lib/teams/resolveTeamsTabAuthState', () => ({
+  resolveTeamsTabAuthState: resolveTeamsTabAuthStateMock,
+}));
+
+vi.mock('@alga-psa/ee-microsoft-teams/lib/teams/bot/teamsConversationReferences', () => ({
+  findTeamsConversationReferenceByConversationId:
+    findTeamsConversationReferenceByConversationIdMock,
+}));
+
+const SERVICE_URL = 'https://smba.trafficmanager.net/amer/';
+const TOKEN_URL = 'https://login.microsoftonline.com/bot-tenant-1/oauth2/v2.0/token';
+
+let fetchMock: ReturnType<typeof vi.fn>;
+
+function tokenResponse(token: string): Response {
+  return new Response(JSON.stringify({ access_token: token, expires_in: 3600 }), {
+    status: 200,
+    headers: { 'Content-Type': 'application/json' },
+  });
+}
+
+function activityResponse(status: number): Response {
+  return new Response('{}', { status, statusText: status === 401 ? 'Unauthorized' : 'OK' });
+}
+
+/** Bodies of the activity POSTs only, in order. */
+function sentActivities(): Array<Record<string, any>> {
+  return fetchMock.mock.calls
+    .filter(([url]) => String(url) !== TOKEN_URL)
+    .map(([, init]) => JSON.parse(String((init as RequestInit).body)));
+}
+
+async function runCallback(): Promise<Response> {
+  const { handleTeamsAuthCallback } = await import(
+    '@alga-psa/ee-microsoft-teams/lib/teams/handleTeamsAuthCallback'
+  );
+  return handleTeamsAuthCallback(
+    new Request(
+      'https://example.test/api/teams/auth/callback/bot?tenantId=tenant-1&conversationId=conversation-9',
+      { method: 'GET' }
+    ),
+    'bot'
+  );
+}
+
+beforeEach(() => {
+  // Fresh module registry per test so the connector's cached token never
+  // carries over.
+  vi.resetModules();
+  vi.clearAllMocks();
+
+  vi.stubEnv('TEAMS_BOT_APP_ID', 'bot-app-1');
+  vi.stubEnv('TEAMS_BOT_APP_TENANT_ID', 'bot-tenant-1');
+  vi.stubEnv('TEAMS_BOT_APP_PASSWORD', 'bot-secret-1');
+
+  fetchMock = vi.fn();
+  vi.stubGlobal('fetch', fetchMock);
+
+  getTeamsAvailabilityMock.mockResolvedValue({ enabled: true });
+  resolveTeamsTabAuthStateMock.mockResolvedValue({
+    status: 'ready',
+    tenantId: 'tenant-1',
+    userId: 'user-1',
+    userName: 'Alex Tech',
+    userEmail: 'alex@example.test',
+    profileId: 'profile-1',
+    microsoftTenantId: 'entra-tenant-1',
+  });
+  findTeamsConversationReferenceByConversationIdMock.mockResolvedValue({
+    tenant: 'tenant-1',
+    microsoftUserId: 'aad-user-1',
+    conversationId: 'conversation-9',
+    conversationType: 'personal',
+    serviceUrl: SERVICE_URL,
+    tenantIdAad: 'entra-tenant-1',
+    channelIdBotFramework: 'msteams',
+    lastActivityAt: null,
+    createdAt: null,
+    updatedAt: null,
+  });
+});
+
+afterEach(() => {
+  vi.unstubAllEnvs();
+  vi.unstubAllGlobals();
+});
+
+describe('Teams sign-in welcome card delivery', () => {
+  it('keeps the Adaptive Card when the connector token expires mid-flow', async () => {
+    fetchMock
+      .mockResolvedValueOnce(tokenResponse('stale-token'))
+      .mockResolvedValueOnce(activityResponse(401))
+      .mockResolvedValueOnce(tokenResponse('fresh-token'))
+      .mockResolvedValueOnce(activityResponse(200));
+
+    const response = await runCallback();
+    expect(response.status).toBe(200);
+
+    const activities = sentActivities();
+    expect(activities).toHaveLength(2);
+    // Both attempts carry the Adaptive Card: replayed, not downgraded.
+    for (const activity of activities) {
+      expect(activity.attachments?.[0]?.contentType).toBe(
+        'application/vnd.microsoft.card.adaptive'
+      );
+    }
+    expect(activities[1].text).toContain('Alex Tech');
+  });
+
+  it('still downgrades to the hero card when the client rejects adaptive content', async () => {
+    fetchMock
+      .mockResolvedValueOnce(tokenResponse('token-1'))
+      .mockResolvedValueOnce(activityResponse(415))
+      .mockResolvedValueOnce(activityResponse(200));
+
+    const response = await runCallback();
+    expect(response.status).toBe(200);
+
+    const activities = sentActivities();
+    expect(activities).toHaveLength(2);
+    expect(activities[1].attachments?.[0]?.contentType).toBe(
+      'application/vnd.microsoft.card.hero'
+    );
+  });
+});

--- a/shared/services/email/microsoftGraphEndpoints.ts
+++ b/shared/services/email/microsoftGraphEndpoints.ts
@@ -1,5 +1,5 @@
-const DEFAULT_GRAPH_BASE_URL = 'https://graph.microsoft.com/v1.0';
-const DEFAULT_LOGIN_BASE_URL = 'https://login.microsoftonline.com';
+export const DEFAULT_MICROSOFT_GRAPH_BASE_URL = 'https://graph.microsoft.com/v1.0';
+export const DEFAULT_MICROSOFT_LOGIN_BASE_URL = 'https://login.microsoftonline.com';
 
 export const MICROSOFT_EMAIL_OAUTH_SCOPES = [
   'https://graph.microsoft.com/Mail.Read',
@@ -17,13 +17,13 @@ function withoutTrailingSlash(value: string): string {
 
 export function getMicrosoftGraphBaseUrl(): string {
   return withoutTrailingSlash(
-    (process.env.MICROSOFT_GRAPH_BASE_URL || '').trim() || DEFAULT_GRAPH_BASE_URL
+    (process.env.MICROSOFT_GRAPH_BASE_URL || '').trim() || DEFAULT_MICROSOFT_GRAPH_BASE_URL
   );
 }
 
 export function getMicrosoftLoginBaseUrl(): string {
   return withoutTrailingSlash(
-    (process.env.MICROSOFT_LOGIN_BASE_URL || '').trim() || DEFAULT_LOGIN_BASE_URL
+    (process.env.MICROSOFT_LOGIN_BASE_URL || '').trim() || DEFAULT_MICROSOFT_LOGIN_BASE_URL
   );
 }
 


### PR DESCRIPTION
## Summary

Extends the `msgraph` emulator with a Teams/Bot Framework surface (directory users, teams/channels, chats, a Bot Framework connector, and inbound activity injection with real RS256-signed tokens) so the Teams bot and notification paths can be exercised end to end without hitting Microsoft. Wiring this up surfaced several real bugs in the Teams bot connector, JWT verifier, and setup validation that are fixed here, plus a deny-by-default gate so none of the new redirection hooks can activate outside an explicit opt-in.

## Changes

**msgraph emulator (`packages/emulators/msgraph`)**
- New `botFramework.ts`: per-process RSA keypair, publishes an OpenID config + JWKS, and RS256-signs injected Bot Framework activities so the app's real `jose` verification path runs unmodified.
- `core.ts`: adds Teams directory users (with `Guest`/external state), teams/channels, chats + messages, Bot Framework conversations, captured outbound activities, activity-notification records, and app-only `client_credentials` token issuance carrying consented `appRoles` in the `roles` claim (mirroring how Entra stamps admin-consented app permissions).
- `wire.ts`: serves `/v1/.well-known/openidconfiguration` + `/v1/.well-known/keys`, the `/v3/conversations[...]` Bot Framework connector routes (with fault injection keyed on the decoded path), and the Graph `/teams`, `/chats`, `/users/{id}/teamwork/sendActivityNotification` routes.
- `notifier.ts`: `deliverInboundBotActivity` builds, signs (wall-clock `iat`/`nbf`/`exp`, with `tokenAgeSeconds` to backdate for expiry tests), and POSTs an activity at the app's bot endpoint, returning the app's synchronous reply.
- `register.ts`: new seeders (`directory-user` params extended, `teams-user`, `teams-channel`, `teams-chat`, `bot-activity`), `clear-bot-activities` action, `configure` extended with bot target/service URL/app id, and new state views (`bot-activities`, `activity-notifications`, `teams`, `chats`).
- `index.ts` / `package.json`: export the new types and `BOT_FRAMEWORK_ISSUER`; add `jose` as a dev dependency for the connector test surface.

**Teams bot fixes (`ee/packages/microsoft-teams`)**
- New `emulatorMode.ts`: single deny-by-default gate (`TEAMS_EMULATOR_MODE`) for every Teams emulator override; forced off whenever `NODE_ENV=production`, independent of the flag value.
- New `microsoftEndpoints.ts`: Teams-specific wrapper around the shared Microsoft Graph/login base URL helpers that only honors overrides when the emulator gate is on, used by the bot connector, `graphAuth.ts`, and `teamsNotificationDelivery.ts`.
- `teamsBotConnector.ts`: adds an exact-origin, http(s)-only service-URL allowlist (gated by the emulator flag) alongside the existing HTTPS/domain trust check, and replays a request once with a fresh token on a 401 instead of just clearing the cache and failing — applied uniformly across replies, DM notifications, the welcome card, and diagnostics sends.
- `teamsBotHandler.ts`: no longer downgrades an Adaptive Card reply to the hero-card fallback on 401/403/429 (those indicate a rejected/throttled token, not bad card content), since the connector already retries expired tokens transparently.
- `teamsBotJwtVerifier.ts`: OpenID config URL is redirectable only under the emulator gate; JWKS cache TTL shortens to 30s when redirected (vs. 12h in production) so a restarted emulator's rotated keypair doesn't get stuck as unverifiable.
- `teamsSetupValidationActions.ts`: error messages now name the actual host the token/setup probe called instead of hardcoding `login.microsoftonline.com`.
- `shared/services/email/microsoftGraphEndpoints.ts`: exports the default Graph/login base URLs as named constants for reuse by the Teams-specific wrapper.

**Docs**
- `packages/emulators/README.md`: documents the Teams emulator surface, the `TEAMS_EMULATOR_MODE` gate and what it protects, and a full reproducible round-trip recipe (EE dev server setup, seeding, sending/receiving activities).

## Testing
- `npx vitest run` in `ee/packages/microsoft-teams` (connector retry, OpenID override, service-URL trust, JWT verifier, bot handler, welcome-card token retry, setup validation action tests — new and updated suites).
- `npx vitest run` in `packages/emulators/msgraph` (expanded `smoke.test.ts` covering the Teams/Bot Framework surface end to end: seeding, signed inbound activity delivery, outbound capture, fault injection).
