### PR TITLE
fix: normalize www host in email webhook base URL

### DIFF
--- a/packages/emulators/msgraph/src/notifier.ts
+++ b/packages/emulators/msgraph/src/notifier.ts
@@ -4,12 +4,16 @@ import type { GraphMessage, GraphSubscription, MsGraphCore } from './core';
 /**
  * Webhook I/O lives here, outside the pure core: Graph's subscription
  * validation handshake and change-notification delivery.
+ *
+ * Real Graph never follows redirects on either call, so both use
+ * `redirect: 'manual'`. Node's default of following them would let a
+ * redirecting notificationUrl pass here and fail in production.
  */
 export async function validateNotificationUrl(notificationUrl: string, validationToken: string): Promise<boolean> {
   const url = new URL(notificationUrl);
   url.searchParams.set('validationToken', validationToken);
   try {
-    const response = await fetch(url, { method: 'POST' });
+    const response = await fetch(url, { method: 'POST', redirect: 'manual' });
     return response.ok && (await response.text()) === validationToken;
   } catch {
     return false;
@@ -26,6 +30,7 @@ async function deliverOne(subscription: GraphSubscription, message: GraphMessage
   try {
     await fetch(subscription.notificationUrl, {
       method: 'POST',
+      redirect: 'manual',
       headers: { 'content-type': 'application/json' },
       body: JSON.stringify({
         value: [

--- a/packages/projects/src/components/__tests__/TaskFormCreateFromTicket.test.tsx
+++ b/packages/projects/src/components/__tests__/TaskFormCreateFromTicket.test.tsx
@@ -106,12 +106,14 @@ vi.mock('@alga-psa/ui/components/UserAndTeamPicker', () => ({
 
 vi.mock('@alga-psa/teams/actions', () => ({
   getTeams: vi.fn().mockResolvedValue([]),
-  getTeamAvatarUrlsBatchAction: vi.fn().mockResolvedValue([])
+  getTeamAvatarUrlsBatchAction: vi.fn().mockResolvedValue([]),
+  isTeamActionError: () => false,
 }));
 
 vi.mock('@alga-psa/tags/actions', () => ({
   findTagsByEntityId: vi.fn().mockResolvedValue([]),
-  createTagsForEntity: vi.fn().mockResolvedValue([])
+  createTagsForEntity: vi.fn().mockResolvedValue([]),
+  isTagActionError: () => false,
 }));
 
 vi.mock('@alga-psa/user-composition/actions', () => ({

--- a/packages/projects/src/components/__tests__/TaskFormPrefill.test.tsx
+++ b/packages/projects/src/components/__tests__/TaskFormPrefill.test.tsx
@@ -89,12 +89,14 @@ vi.mock('@alga-psa/ui/components/UserAndTeamPicker', () => ({
 
 vi.mock('@alga-psa/teams/actions', () => ({
   getTeams: vi.fn().mockResolvedValue([]),
-  getTeamAvatarUrlsBatchAction: vi.fn().mockResolvedValue([])
+  getTeamAvatarUrlsBatchAction: vi.fn().mockResolvedValue([]),
+  isTeamActionError: () => false,
 }));
 
 vi.mock('@alga-psa/tags/actions', () => ({
   findTagsByEntityId: vi.fn().mockResolvedValue([]),
-  createTagsForEntity: vi.fn().mockResolvedValue([])
+  createTagsForEntity: vi.fn().mockResolvedValue([]),
+  isTagActionError: () => false,
 }));
 
 vi.mock('@alga-psa/user-composition/actions', () => ({

--- a/packages/projects/src/components/__tests__/TaskFormTaskDataProps.test.tsx
+++ b/packages/projects/src/components/__tests__/TaskFormTaskDataProps.test.tsx
@@ -86,12 +86,14 @@ vi.mock('@alga-psa/ui/components/UserAndTeamPicker', () => ({
 
 vi.mock('@alga-psa/teams/actions', () => ({
   getTeams: vi.fn().mockResolvedValue([]),
-  getTeamAvatarUrlsBatchAction: vi.fn().mockResolvedValue([])
+  getTeamAvatarUrlsBatchAction: vi.fn().mockResolvedValue([]),
+  isTeamActionError: () => false,
 }));
 
 vi.mock('@alga-psa/tags/actions', () => ({
   findTagsByEntityId: vi.fn().mockResolvedValue([]),
-  createTagsForEntity: vi.fn().mockResolvedValue([])
+  createTagsForEntity: vi.fn().mockResolvedValue([]),
+  isTagActionError: () => false,
 }));
 
 vi.mock('@alga-psa/user-composition/actions', () => ({

--- a/packages/tickets/src/components/ticket/__tests__/TicketDetailsCreateTask.test.tsx
+++ b/packages/tickets/src/components/ticket/__tests__/TicketDetailsCreateTask.test.tsx
@@ -176,7 +176,8 @@ vi.mock('../../actions/ticketDisplaySettings', () => ({
 }));
 
 vi.mock('@alga-psa/tags/actions', () => ({
-  findTagsByEntityId: vi.fn().mockResolvedValue([])
+  findTagsByEntityId: vi.fn().mockResolvedValue([]),
+  isTagActionError: () => false,
 }));
 
 vi.mock('@alga-psa/user-composition/actions', () => ({
@@ -218,6 +219,7 @@ vi.mock('@alga-psa/reference-data/actions', () => ({
 vi.mock('@alga-psa/teams/actions', () => ({
   getTeamById: vi.fn().mockResolvedValue(null),
   getTeams: vi.fn().mockResolvedValue([]),
+  isTeamActionError: () => false,
 }));
 
 vi.mock('@alga-psa/documents/actions/documentActions', () => ({

--- a/shared/services/email/webhookBaseUrl.ts
+++ b/shared/services/email/webhookBaseUrl.ts
@@ -11,12 +11,20 @@ export function getEmailWebhookBaseUrl(): string {
     || process.env.NEXTAUTH_URL
     || process.env.NEXT_PUBLIC_BASE_URL;
 
-  if (!envApplicationUrl || envApplicationUrl === 'www.algapsa.com') {
+  if (!envApplicationUrl) {
     return 'https://algapsa.com';
   }
 
   const withScheme = envApplicationUrl.startsWith('http://localhost') || envApplicationUrl.startsWith('https://')
     ? envApplicationUrl
     : `https://${envApplicationUrl}`;
-  return withScheme.replace(/\/$/, '');
+
+  // Graph does not follow redirects during the subscription validation
+  // handshake, and www.algapsa.com 301s to the apex, so a www value fails
+  // every registration with 400 ValidationError and degrades the provider to
+  // polling. Only normalize the host we own — a self-hosted www. domain may
+  // legitimately be canonical.
+  return withScheme
+    .replace(/\/$/, '')
+    .replace(/^(https:\/\/)www\.algapsa\.com\b/i, '$1algapsa.com');
 }


### PR DESCRIPTION
Microsoft Graph does not follow redirects during the subscription validation handshake. www.algapsa.com 301s to the apex, so every registration built from that host failed with 400 ValidationError and EmailWebhookMaintenanceService degraded the provider to polling.

getEmailWebhookBaseUrl only special-cased the bare string 'www.algapsa.com', not the scheme-prefixed 'https://www.algapsa.com' that production actually set on temporal-worker. Normalize after scheme and trailing-slash handling instead, case-insensitively. Scoped to the host we own: a self-hosted www. domain may legitimately be canonical, so stripping www universally would break those installs.

The msgraph emulator models the handshake and the exact 400, but Node's fetch follows redirects by default, so it accepted URLs real Graph rejects. validateNotificationUrl and deliverOne now pass redirect: 'manual' to match Graph's behavior.

The White Rabbit left a 301 to a far nicer burrow, but Graph flatly refuses to follow anybody anywhere â so we moved the tea party to the apex and taught the looking-glass to stop chasing rabbits as well. ððµð«