### PR TITLE
29.8.21 — Client portal: prepaid balance & hours visibility

### DIFF
--- a/docs/plans/2026-08-11-client-portal-prepaid-balance-plan.md
+++ b/docs/plans/2026-08-11-client-portal-prepaid-balance-plan.md
@@ -1,0 +1,184 @@
+# Client Portal: Prepaid Balance & Hours Visibility — Implementation Plan
+
+**Card:** 29.8.21 (release v1.5) · **Branch:** `feature/client-portal-prepaid-balance`
+**Date:** 2026-08-11
+
+## Goal
+
+Surface prepaid state in the client portal so prepaid stops being a black box:
+
+1. **Credit balance with recent issuance/application history** — the client can see not
+   just the balance but where credit came from and where it went.
+2. **Bucket hours meters** — used / remaining / rollover per contract line, with the
+   service period they cover.
+3. **Discoverability** — an hours-remaining widget on the portal dashboard (the landing
+   page), so clients see prepaid state without digging into More → Billing.
+
+Read-only throughout. No new tenant-level setting: visibility follows the existing
+client-portal billing gates (`hasBillingAccess` for nav/pages, per-action billing read
+permission server-side).
+
+## Current state (verified live + in code)
+
+The portal Billing area (`/client-portal/billing`, `packages/client-portal/src/components/billing/`)
+already has:
+
+- `CreditsSummaryCard.tsx` — headline available credit (via `getClientCreditSummary`)
+  plus up to 3 active credits with remaining amount and expiry badge. **No history.**
+- `BucketUsageChart.tsx` rendered per bucket row on `BillingOverviewTab.tsx` — % used,
+  hours used / hours total, a note when rollover hours are included. **No first-class
+  remaining number, no period dates.**
+- `Hours by Service` and `Usage Metrics` tabs (date-ranged, unaffected by this card).
+
+The portal dashboard (`ClientDashboard.tsx`) has no billing/prepaid presence.
+
+The feature flag `release-v1.5-feature` appears nowhere in the repo yet; this card
+introduces the first portal-side flag check.
+
+## Feature flag gating (standing release requirement)
+
+Every UI change below is gated behind `release-v1.5-feature` via
+`useFeatureFlag('release-v1.5-feature', { defaultValue: false })`
+(`packages/ui/src/hooks/useFeatureFlag.tsx`; PostHog provider is mounted in the root
+layout so portal routes are covered). Flag off ⇒ the rendered UI is exactly today's:
+no history affordance, unchanged bucket meter, no dashboard widget. While the flag
+state is loading, render the flag-off UI (never flash the new surfaces).
+
+The server-side permission hardening in item 4 is not UI and ships ungated.
+
+## Work items
+
+### 1. Portal server action: credit history
+
+In `packages/client-portal/src/actions/client-portal-actions/client-billing.ts` add
+`getClientCreditHistory()`:
+
+- Resolve the caller's client via `getClientIdFromPortalUser()` and gate with
+  `hasClientBillingReadPermission()` (same pattern as `getClientCreditSummary`).
+- Query `transactions` scoped to tenant + client,
+  `whereIn('type', ['credit_issuance', 'prepayment', 'credit_application',
+  'credit_adjustment', 'credit_expiration', 'credit_transfer',
+  'credit_issuance_from_negative_invoice'])`, newest first, limit 20.
+- Left-join `invoices` to carry `invoice_number` for application entries (mirror the
+  MSP `getCreditHistory` in `packages/billing/src/actions/creditActions.ts:1045`, which
+  cannot be reused directly — it runs under MSP `withAuth` + `credit:read` permission).
+- Return a typed row: `{ transaction_id, type, description, amount, balance_after,
+  created_at, invoice_id, invoice_number, currency_code }`.
+
+Do NOT expose MSP-internal fields (metadata, parent/related transaction ids).
+
+### 2. Credit history UI (lightweight)
+
+**Chosen presentation (mockup options 1A + 2A):** the card itself is unchanged except
+for one new "View history" link; the history opens in a Dialog rendered as a **ledger**.
+
+`CreditsSummaryCard.tsx`: when the flag is on, add the "View history" link below the
+credit list. It opens a Dialog (follow `InvoiceDetailsDialog.tsx` conventions) listing
+the recent entries, one ledger row each:
+
+- left: friendly type label (Issued — prepayment #INV-N / Applied to invoice #N /
+  Adjusted / Expired / Transferred) over the date;
+- right: signed amount (credits green `+`, debits plain `−`) over a muted
+  "balance $X.XX" line derived from the transaction's `balance_after`.
+
+Loading skeleton, empty state ("No credit activity yet"), and error state degrade
+gracefully (dialog shows empty state; card behavior unchanged).
+
+Friendly type labels and all new strings go under `credits.history.*` in
+`server/public/locales/<locale>/features/billing.json` for **all** locales
+(de, en, es, fr, it, nl, pl, pt, xx, yy) — translation quality checks are enforced
+in CI.
+
+### 3. Bucket meter upgrade (Billing overview)
+
+**Chosen presentation (mockup option 3B — remaining-first):** `BucketUsageChart.tsx`
+(portal copy), flag on only, restructures each meter as:
+
+- Header row: line/service name on the left, the covering period as a small chip on
+  the right (`period_start` – `period_end`).
+- **Headline: remaining hours** — "7.0 hours left of 22.0 (incl. 2.0 rollover)".
+  Semantics must mirror `getRemainingBucketUnits`
+  (`packages/reporting/src/actions/report-actions/getRemainingBucketUnits.ts`):
+  `remaining = total_minutes + rolled_over_minutes − minutes_used`.
+- The existing progress bar stays below the headline as context, footed by
+  "used / left" figures.
+- **Overage state:** when remaining < 0, the headline turns red and reads
+  "0.5 hours over" with an "OVER BUCKET" badge, and the bar shows the overage as a red
+  segment — never render a negative remaining number.
+- No segmented rollover visualization (rejected option 3C): the billing engine does not
+  track a rollover-vs-base draw order, so the bar must not imply one.
+
+Flag off ⇒ the current layout (% headline, used/total, rollover footnote) renders
+byte-identical.
+
+`getClientBucketUsage` (`client-billing-metrics.ts:405`) already returns every needed
+field; no query changes.
+
+### 4. Server-side permission hardening (ungated)
+
+`packages/client-portal/src/actions/client-portal-actions/client-billing-metrics.ts`
+actions (`getClientBucketUsage`, `getClientBucketUsageHistory`, `getClientHoursByService`,
+`getClientUsageMetrics`) currently skip the billing read permission that
+`getClientCreditSummary` enforces. Add `hasClientBillingReadPermission()` to each,
+returning the actions' existing error shape. The only existing callers sit behind the
+billing nav gate (`hasBillingAccess`), so no visible behavior changes for legitimate
+users; direct invocation without the permission now fails closed.
+
+### 5. Dashboard hours-remaining widget
+
+`ClientDashboard.tsx` (`packages/client-portal/src/components/dashboard/`), flag on only:
+
+- **Chosen presentation (mockup option 4A):** a compact "Prepaid hours" card in the
+  existing card grid below the KPI row: header row with the card label and a
+  "View billing →" link to `/client-portal/billing`; then one row per bucket line —
+  line/service label on the left, bold "7.0h left" on the right (or a red "0.5h OVER"
+  badge in overage), with a slim mini progress bar underneath (reuse the meter color
+  logic from item 3). No KPI-tile summing across lines (rejected option 4B — bucket
+  lines are not interchangeable, a summed number misleads).
+- Render only when ALL hold: flag on, the user's portal permissions include billing
+  access (`checkClientPortalPermissions().hasBillingAccess` — plumb through the same
+  path the sidebar uses), and `getClientBucketUsage()` returns ≥ 1 row. Otherwise
+  render nothing — the dashboard looks exactly as today.
+- A permission error from the action (post-item-4) counts as "render nothing".
+
+### 6. Tests
+
+- **Action tests** for `getClientCreditHistory`: tenant + client scoping, permission
+  gate (denied → error shape, not a throw), type filtering (a `payment` or
+  `invoice_generated` row never appears), ordering and limit.
+- **Permission tests** for item 4: each metrics action fails closed without billing read.
+- **Component/contract tests** (follow `ClientDashboard.contract.test.ts` pattern):
+  - Credit card: flag off ⇒ no history affordance; flag on ⇒ affordance renders,
+    dialog lists rows, empty state.
+  - Bucket meter: flag off ⇒ no remaining/period line; flag on ⇒ remaining math
+    matches the `getRemainingBucketUnits` formula, overage renders "over" not negative.
+  - Dashboard: flag off / no permission / no buckets ⇒ widget absent; all three met ⇒
+    widget renders.
+- Typecheck + existing test suites stay green.
+
+## Explicitly out of scope
+
+- **Usage Metrics history bug**: the existing "Hours Usage History" chart renders
+  impossible values against dirty data (observed live: 2513% usage on a 2-hour bucket).
+  Pre-existing, in a seam this card doesn't touch (`getClientBucketUsageHistory`
+  consumers). Flag for a separate card.
+- Per-tenant prepaid-visibility toggle in `clientPortalFeatureSettings` (decided
+  against; revisit only if an MSP asks).
+- A dedicated "Credits" tab / full-page history (lightweight dialog chosen instead).
+- The hardcoded `SHOW_USAGE_FEATURES = true` in `BillingOverview.tsx` (leave as is).
+
+## Verification plan (for the Implement/Smoke steps)
+
+1. Flag off (default): portal Billing overview and Dashboard pixel-identical to main.
+2. Flag on, client with credits + bucket lines: history dialog shows issuance and
+   application entries with invoice numbers; meters show remaining + period; dashboard
+   widget lists each bucket line.
+3. Flag on, user without billing access: no dashboard widget; Billing hidden from nav
+   (existing behavior); metrics actions fail closed when invoked directly.
+4. Flag on, client with no bucket lines: no dashboard widget; overview shows credit
+   card only.
+
+Dev-stack note: seeding credit history locally requires credit transactions
+(`credit_issuance` / `prepayment` / `credit_application`) — the current local dataset
+has none; create them via the MSP Prepayment Invoices flow or targeted inserts during
+smoke testing.

--- a/packages/client-portal/src/actions/client-portal-actions/client-billing-metrics.permissions.test.ts
+++ b/packages/client-portal/src/actions/client-portal-actions/client-billing-metrics.permissions.test.ts
@@ -1,0 +1,154 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+let currentUser: any;
+let billingPermissionGranted: boolean;
+
+const createTenantKnexMock = vi.fn();
+const withTransactionMock = vi.fn();
+const hasBillingReadPermissionMock = vi.fn();
+
+vi.mock('@alga-psa/auth', () => ({
+  withAuth: (action: any) => async (...args: any[]) =>
+    action(currentUser, { tenant: currentUser.tenant }, ...args),
+}));
+
+vi.mock('@alga-psa/db', () => ({
+  createTenantKnex: (...args: any[]) => createTenantKnexMock(...args),
+  withTransaction: (...args: any[]) => withTransactionMock(...args),
+  tenantDb: (conn: any, _tenant: string) => ({
+    table: (table: string) => conn(table),
+    unscoped: (table: string) => conn(table),
+    tenantJoin: (query: any, _table?: string, _left?: string, _right?: string, options: any = {}) => {
+      const join = options?.type === 'left' ? query.leftJoin : query.join;
+      return typeof join === 'function' ? join.call(query) : query;
+    },
+  }),
+}));
+
+vi.mock('./clientBillingPermissions', () => ({
+  hasClientBillingReadPermission: (...args: any[]) => hasBillingReadPermissionMock(...args),
+  getClientIdFromPortalUser: vi.fn(),
+}));
+
+function buildThenableQuery(result: any) {
+  const chain: any = {};
+  chain.where = vi.fn(() => chain);
+  chain.andWhere = vi.fn(() => chain);
+  chain.whereNull = vi.fn(() => chain);
+  chain.orWhere = vi.fn(() => chain);
+  chain.select = vi.fn(() => chain);
+  chain.orderBy = vi.fn(() => chain);
+  chain.join = vi.fn(() => chain);
+  chain.leftJoin = vi.fn(() => chain);
+  chain.then = (onFulfilled: any, onRejected: any) => Promise.resolve(result).then(onFulfilled, onRejected);
+  chain.catch = (onRejected: any) => Promise.resolve(result).catch(onRejected);
+  chain.finally = (handler: any) => Promise.resolve(result).finally(handler);
+  return chain;
+}
+
+function buildTrx(grantedQuery?: any) {
+  const contactQuery = {
+    where: vi.fn(() => ({
+      first: vi.fn(async () => ({ client_id: 'client-1' })),
+    })),
+  };
+  const userQuery = {
+    where: vi.fn(() => ({
+      first: vi.fn(async () => ({ contact_id: 'contact-1' })),
+    })),
+  };
+  return Object.assign(
+    (table: string) => {
+      if (table === 'users') {
+        return userQuery;
+      }
+      if (table === 'contacts') {
+        return contactQuery;
+      }
+      if (table === 'client_contracts as cc' && grantedQuery) {
+        return grantedQuery;
+      }
+      throw new Error(`Unexpected table: ${table}`);
+    },
+    {
+      raw: vi.fn((sql: string, bindings?: any[]) => ({ sql, bindings })),
+    }
+  ) as any;
+}
+
+describe('client billing metrics permission hardening', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.resetModules();
+
+    currentUser = {
+      user_id: 'portal-user-1',
+      user_type: 'client',
+      contact_id: 'contact-1',
+      tenant: 'tenant-1',
+    };
+    billingPermissionGranted = false;
+
+    createTenantKnexMock.mockResolvedValue({ knex: vi.fn() });
+    withTransactionMock.mockImplementation(async (_db: any, callback: (trx: any) => Promise<any>) =>
+      callback(buildTrx())
+    );
+    hasBillingReadPermissionMock.mockImplementation(async () => billingPermissionGranted);
+  });
+
+  it('T149: getClientBucketUsage fails closed without billing read', async () => {
+    const { getClientBucketUsage } = await import('./client-billing-metrics');
+
+    const result = await getClientBucketUsage();
+
+    expect(hasBillingReadPermissionMock).toHaveBeenCalledWith(expect.anything(), currentUser, 'tenant-1');
+    expect(result).toEqual({ permissionError: 'Unauthorized to access billing data' });
+  });
+
+  it('T150: getClientBucketUsageHistory fails closed without billing read', async () => {
+    const { getClientBucketUsageHistory } = await import('./client-billing-metrics');
+
+    const result = await getClientBucketUsageHistory();
+
+    expect(hasBillingReadPermissionMock).toHaveBeenCalledWith(expect.anything(), currentUser, 'tenant-1');
+    expect(result).toEqual({ permissionError: 'Unauthorized to access billing data' });
+  });
+
+  it('T151: getClientHoursByService fails closed without billing read', async () => {
+    const { getClientHoursByService } = await import('./client-billing-metrics');
+
+    const result = await getClientHoursByService({
+      startDate: '2026-01-01',
+      endDate: '2026-02-01',
+      groupByServiceType: false,
+    });
+
+    expect(hasBillingReadPermissionMock).toHaveBeenCalledWith(expect.anything(), currentUser, 'tenant-1');
+    expect(result).toEqual({ permissionError: 'Unauthorized to access billing data' });
+  });
+
+  it('T152: getClientUsageMetrics fails closed without billing read', async () => {
+    const { getClientUsageMetrics } = await import('./client-billing-metrics');
+
+    const result = await getClientUsageMetrics({
+      startDate: '2026-01-01',
+      endDate: '2026-02-01',
+    });
+
+    expect(hasBillingReadPermissionMock).toHaveBeenCalledWith(expect.anything(), currentUser, 'tenant-1');
+    expect(result).toEqual({ permissionError: 'Unauthorized to access billing data' });
+  });
+
+  it('T153: each metrics action runs its query when billing read is granted', async () => {
+    billingPermissionGranted = true;
+    withTransactionMock.mockImplementation(async (_db: any, callback: (trx: any) => Promise<any>) =>
+      callback(buildTrx(buildThenableQuery([])))
+    );
+    const { getClientBucketUsage } = await import('./client-billing-metrics');
+
+    const result = await getClientBucketUsage();
+
+    expect(hasBillingReadPermissionMock).toHaveBeenCalled();
+    expect(Array.isArray(result)).toBe(true);
+  });
+});

--- a/packages/client-portal/src/actions/client-portal-actions/client-billing-metrics.ts
+++ b/packages/client-portal/src/actions/client-portal-actions/client-billing-metrics.ts
@@ -12,6 +12,8 @@ import { IProjectTask } from '@alga-psa/types';
 import { IUsageRecord } from '@alga-psa/types';
 import { toPlainDate, formatDateOnly } from '@alga-psa/core';
 import { withAuth } from '@alga-psa/auth';
+import { permissionError } from '@alga-psa/ui/lib/errorHandling';
+import { hasClientBillingReadPermission } from './clientBillingPermissions';
 import { clientPortalActionErrorFrom, type ClientPortalActionError } from './clientPortalActionErrors';
 
 // Define the schema for the hours by service input parameters
@@ -82,6 +84,11 @@ export const getClientHoursByService = withAuth(async (
       }
 
       const clientId = contact.client_id;
+
+      const hasAccess = await hasClientBillingReadPermission(trx, user, tenant);
+      if (!hasAccess) {
+        return permissionError('Unauthorized to access billing data');
+      }
 
       console.log(`Fetching hours by service for client client ${clientId} in tenant ${tenant} from ${startDate} to ${endDate}`);
 
@@ -228,7 +235,10 @@ export const getClientUsageMetrics = withAuth(async (
 
       const clientId = contact.client_id;
 
-      // No permission check needed for usage metrics - all users can access
+      const hasAccess = await hasClientBillingReadPermission(trx, user, tenant);
+      if (!hasAccess) {
+        return permissionError('Unauthorized to access billing data');
+      }
 
       console.log(`Fetching usage metrics for client client ${clientId} in tenant ${tenant} from ${startDate} to ${endDate}`);
 
@@ -325,6 +335,11 @@ export const getClientBucketUsageHistory = withAuth(async (
       if (!contact?.client_id) throw new Error('Contact not associated with a client');
 
       const clientId = contact.client_id;
+
+      const hasAccess = await hasClientBillingReadPermission(trx, user, tenant);
+      if (!hasAccess) {
+        return permissionError('Unauthorized to access billing data');
+      }
 
       let query: any = scopedDb.table('bucket_usage as bu')
         .where('bu.client_id', clientId)
@@ -432,7 +447,10 @@ export const getClientBucketUsage = withAuth(async (user, { tenant }): Promise<C
 
       const clientId = contact.client_id;
 
-      // No permission check needed for bucket usage - all users can access
+      const hasAccess = await hasClientBillingReadPermission(trx, user, tenant);
+      if (!hasAccess) {
+        return permissionError('Unauthorized to access billing data');
+      }
 
       const currentDate = new Date().toISOString().split('T')[0]; // Format as YYYY-MM-DD
       console.log(`Fetching bucket usage for client client ${clientId} in tenant ${tenant} as of ${currentDate}`);

--- a/packages/client-portal/src/actions/client-portal-actions/client-billing.bucketPeriods.test.ts
+++ b/packages/client-portal/src/actions/client-portal-actions/client-billing.bucketPeriods.test.ts
@@ -100,6 +100,9 @@ describe('client billing bucket period actions', () => {
         if (table === 'contacts') {
           return contactQuery;
         }
+        if (table === 'role_permissions as rp') {
+          return buildThenableQuery({ permission_id: 'perm-1' });
+        }
         if (table === 'client_contracts as cc') {
           return detailedBucketQuery;
         }

--- a/packages/client-portal/src/actions/client-portal-actions/client-billing.creditHistory.test.ts
+++ b/packages/client-portal/src/actions/client-portal-actions/client-billing.creditHistory.test.ts
@@ -1,0 +1,271 @@
+import { readFileSync } from 'node:fs';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+let currentUser: any;
+let clientIdForCurrentUser: string | null;
+let billingPermissionGranted: boolean;
+let transactionRows: any[];
+let txQuery: any;
+
+const getConnectionMock = vi.fn();
+const withTransactionMock = vi.fn();
+
+vi.mock('@alga-psa/auth', () => ({
+  withAuth: (action: any) => async (...args: any[]) =>
+    action(currentUser, { tenant: currentUser.tenant }, ...args),
+}));
+
+vi.mock('@alga-psa/db', () => ({
+  getConnection: (...args: any[]) => getConnectionMock(...args),
+  withTransaction: (...args: any[]) => withTransactionMock(...args),
+  createTenantKnex: vi.fn(),
+  tenantDb: (conn: any, tenant: string) => ({
+    table: (table: string) => conn(table),
+    unscoped: (table: string) => conn(table),
+    tenantJoin: (query: any, _table?: string, _left?: string, _right?: string, options: any = {}) => {
+      const join = options?.type === 'left' ? query.leftJoin : query.join;
+      return typeof join === 'function' ? join.call(query) : query;
+    },
+  }),
+}));
+
+vi.mock('./clientBillingPermissions', () => ({
+  getClientIdFromPortalUser: vi.fn(async () => clientIdForCurrentUser),
+  hasClientBillingReadPermission: vi.fn(async () => billingPermissionGranted),
+}));
+
+vi.mock('@alga-psa/billing/models/quote', () => ({ default: {} }));
+vi.mock('@alga-psa/billing/models/quoteActivity', () => ({ default: {} }));
+vi.mock('@alga-psa/billing/services', () => ({ recalculateQuoteFinancials: vi.fn() }));
+vi.mock('@alga-psa/billing/actions/invoiceQueries', () => ({
+  fetchInvoicesByClient: vi.fn().mockResolvedValue([]),
+  getInvoiceLineItems: vi.fn().mockResolvedValue([]),
+  getInvoiceForRendering: vi.fn(),
+}));
+vi.mock('@alga-psa/billing/actions/invoiceTemplates', () => ({
+  getInvoiceTemplates: vi.fn().mockResolvedValue([]),
+}));
+vi.mock('@alga-psa/billing/actions/invoiceModification', () => ({
+  finalizeInvoice: vi.fn(),
+  unfinalizeInvoice: vi.fn(),
+}));
+vi.mock('@alga-psa/billing/actions/invoiceJobActions', () => ({
+  scheduleInvoiceEmailAction: vi.fn(),
+  scheduleInvoiceZipAction: vi.fn(),
+}));
+vi.mock('@alga-psa/billing/models/invoice', () => ({ default: {} }));
+vi.mock('@alga-psa/jobs', () => ({
+  JobService: class {},
+  JobStatus: {},
+}));
+
+function buildTransactionQuery() {
+  const chain: any = {};
+  chain.where = vi.fn((criteria: Record<string, unknown>) => {
+    chain.lastWhere = criteria;
+    return chain;
+  });
+  chain.whereIn = vi.fn((column: string, values: string[]) => {
+    chain.lastWhereIn = { column, values };
+    return chain;
+  });
+  chain.select = vi.fn(() => chain);
+  chain.orderBy = vi.fn((column: string, direction?: string) => {
+    chain.lastOrderBy = { column, direction };
+    return chain;
+  });
+  chain.limit = vi.fn((count: number) => {
+    chain.lastLimit = count;
+    return chain;
+  });
+  chain.leftJoin = vi.fn(() => chain);
+  chain.join = vi.fn(() => chain);
+  chain.then = (onFulfilled: any, onRejected: any) => Promise.resolve(transactionRows).then(onFulfilled, onRejected);
+  chain.catch = (onRejected: any) => Promise.resolve(transactionRows).catch(onRejected);
+  chain.finally = (handler: any) => Promise.resolve(transactionRows).finally(handler);
+  return chain;
+}
+
+function buildTrx(query: any) {
+  return Object.assign(
+    (table: string) => {
+      if (table === 'transactions as t') {
+        return query;
+      }
+      throw new Error(`Unexpected table: ${table}`);
+    },
+    {
+      fn: { now: () => 'db-now' },
+    }
+  ) as any;
+}
+
+const clientBillingSource = readFileSync(new URL('./client-billing.ts', import.meta.url), 'utf8');
+
+describe('getClientCreditHistory portal action', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.resetModules();
+
+    currentUser = {
+      user_id: 'portal-user-1',
+      user_type: 'client',
+      contact_id: 'contact-1',
+      email: 'client@example.com',
+      tenant: 'tenant-1',
+    };
+    clientIdForCurrentUser = 'client-1';
+    billingPermissionGranted = true;
+    transactionRows = [
+      {
+        transaction_id: 'tx-issuance',
+        type: 'credit_issuance',
+        description: 'Prepayment credit',
+        amount: 10000,
+        balance_after: 15000,
+        created_at: '2026-07-01T10:00:00.000Z',
+        invoice_id: 'inv-1',
+        currency_code: 'USD',
+        invoice_number: 'INV-001',
+      },
+      {
+        transaction_id: 'tx-application',
+        type: 'credit_application',
+        description: 'Applied to invoice',
+        amount: -5000,
+        balance_after: 10000,
+        created_at: '2026-07-05T10:00:00.000Z',
+        invoice_id: 'inv-2',
+        currency_code: 'USD',
+        invoice_number: 'INV-002',
+      },
+      {
+        transaction_id: 'tx-expiration',
+        type: 'credit_expiration',
+        description: 'Credit expired',
+        amount: -2000,
+        balance_after: null,
+        created_at: '2026-07-10T10:00:00.000Z',
+        invoice_id: null,
+        currency_code: null,
+        invoice_number: null,
+      },
+    ];
+    txQuery = buildTransactionQuery();
+
+    getConnectionMock.mockResolvedValue({ tenant: 'tenant-1' });
+    withTransactionMock.mockImplementation(async (_db: any, callback: (trx: any) => Promise<any>) =>
+      callback(buildTrx(txQuery))
+    );
+  });
+
+  it('T141: returns typed ledger rows including the left-joined invoice number', async () => {
+    const { getClientCreditHistory } = await import('./client-billing');
+
+    const result = await getClientCreditHistory();
+
+    expect(result).toHaveLength(3);
+    expect(result[0]).toEqual({
+      transaction_id: 'tx-issuance',
+      type: 'credit_issuance',
+      description: 'Prepayment credit',
+      amount: 10000,
+      balance_after: 15000,
+      created_at: '2026-07-01T10:00:00.000Z',
+      invoice_id: 'inv-1',
+      invoice_number: 'INV-001',
+      currency_code: 'USD',
+    });
+    expect(result[1].invoice_number).toBe('INV-002');
+    expect(result[2]).toEqual({
+      transaction_id: 'tx-expiration',
+      type: 'credit_expiration',
+      description: 'Credit expired',
+      amount: -2000,
+      balance_after: null,
+      created_at: '2026-07-10T10:00:00.000Z',
+      invoice_id: null,
+      invoice_number: null,
+      currency_code: null,
+    });
+  });
+
+  it('T142: scopes the query to the portal client and tenant', async () => {
+    const { getClientCreditHistory } = await import('./client-billing');
+
+    await getClientCreditHistory();
+
+    expect(txQuery.where).toHaveBeenCalledWith({
+      't.client_id': 'client-1',
+      't.tenant': 'tenant-1',
+    });
+    expect(txQuery.leftJoin).toHaveBeenCalledTimes(1);
+  });
+
+  it('T143: filters to credit-bearing types only — never payment or invoice_generated', async () => {
+    expect(clientBillingSource).toContain("'credit_issuance'");
+    expect(clientBillingSource).toContain("'prepayment'");
+    expect(clientBillingSource).toContain("'credit_application'");
+    expect(clientBillingSource).toContain("'credit_issuance_from_negative_invoice'");
+    expect(clientBillingSource).not.toContain("'payment'");
+    expect(clientBillingSource).not.toContain("'invoice_generated'");
+
+    const { getClientCreditHistory } = await import('./client-billing');
+
+    await getClientCreditHistory();
+
+    const whereIn = txQuery.whereIn.mock.calls[0];
+    expect(whereIn[0]).toBe('t.type');
+    for (const type of [
+      'credit_issuance',
+      'prepayment',
+      'credit_application',
+      'credit_adjustment',
+      'credit_expiration',
+      'credit_transfer',
+      'credit_issuance_from_negative_invoice',
+    ]) {
+      expect(whereIn[1]).toContain(type);
+    }
+    expect(whereIn[1]).not.toContain('payment');
+    expect(whereIn[1]).not.toContain('invoice_generated');
+  });
+
+  it('T144: orders newest first and caps the ledger at 20 rows', async () => {
+    const { getClientCreditHistory } = await import('./client-billing');
+
+    await getClientCreditHistory();
+
+    expect(txQuery.orderBy).toHaveBeenCalledWith('t.created_at', 'desc');
+    expect(txQuery.limit).toHaveBeenCalledWith(20);
+  });
+
+  it('T146: does not expose MSP-internal transaction fields', async () => {
+    const { getClientCreditHistory } = await import('./client-billing');
+
+    await getClientCreditHistory();
+
+    const select = txQuery.select.mock.calls[0][0];
+    expect(select).not.toContain('metadata');
+    expect(select).not.toContain('parent_transaction_id');
+    expect(select).not.toContain('related_transaction_id');
+  });
+
+  it('T147: returns a permission error (not a throw) when billing read is denied', async () => {
+    billingPermissionGranted = false;
+    const { getClientCreditHistory } = await import('./client-billing');
+
+    await expect(getClientCreditHistory()).resolves.toEqual({
+      permissionError: 'Unauthorized to access billing data',
+    });
+  });
+
+  it('T148: returns a permission error when the portal user has no client', async () => {
+    clientIdForCurrentUser = null;
+    const { getClientCreditHistory } = await import('./client-billing');
+
+    await expect(getClientCreditHistory()).resolves.toEqual({
+      permissionError: 'Unauthorized',
+    });
+  });
+});

--- a/packages/client-portal/src/actions/client-portal-actions/client-billing.ts
+++ b/packages/client-portal/src/actions/client-portal-actions/client-billing.ts
@@ -384,6 +384,97 @@ export const getClientCreditSummary = withAuth(async (user, { tenant }): Promise
   }
 });
 
+export interface ClientPortalCreditHistoryEntry {
+  transaction_id: string;
+  type: string;
+  description: string | null;
+  amount: number;
+  balance_after: number | null;
+  created_at: string;
+  invoice_id: string | null;
+  invoice_number: string | null;
+  currency_code: string | null;
+}
+
+/**
+ * Recent credit transactions for the portal client, newest first (limit 20).
+ *
+ * This mirrors the MSP `getCreditHistory` query shape but runs under portal
+ * auth: the caller's client is resolved from the portal user and gated by the
+ * client billing read permission. Only a whitelist of credit-bearing types is
+ * returned, and the row shape deliberately excludes MSP-internal fields
+ * (metadata, parent/related transaction ids) — the ledger only needs the
+ * signed amount, the running balance, and an invoice reference when one exists.
+ */
+export const getClientCreditHistory = withAuth(async (user, { tenant }): Promise<ClientBillingActionResult<ClientPortalCreditHistoryEntry[]>> => {
+  const knex = await getConnection(tenant);
+
+  try {
+    return await withTransaction(knex, async (trx: Knex.Transaction) => {
+      const clientId = await getClientIdFromUser(trx, user, tenant);
+      if (!clientId) {
+        return permissionError('Unauthorized');
+      }
+
+      const hasAccess = await hasBillingPermission(trx, user, tenant);
+      if (!hasAccess) {
+        return permissionError('Unauthorized to access billing data');
+      }
+
+      const db = tenantDb(trx, tenant);
+      const query = db.table('transactions as t')
+        .where({
+          't.client_id': clientId,
+          't.tenant': tenant,
+        })
+        .whereIn('t.type', [
+          'credit_issuance',
+          'prepayment',
+          'credit_application',
+          'credit_adjustment',
+          'credit_expiration',
+          'credit_transfer',
+          'credit_issuance_from_negative_invoice',
+        ])
+        .select(
+          't.transaction_id',
+          't.type',
+          't.description',
+          't.amount',
+          't.balance_after',
+          't.created_at',
+          't.invoice_id',
+          't.currency_code',
+          { invoice_number: 'i.invoice_number' }
+        )
+        .orderBy('t.created_at', 'desc')
+        .limit(20);
+      db.tenantJoin(query, 'invoices as i', 't.invoice_id', 'i.invoice_id', { type: 'left' });
+
+      const rows = await query;
+
+      return rows.map((row: Record<string, unknown>) => ({
+        transaction_id: String(row.transaction_id),
+        type: String(row.type),
+        description: row.description ? String(row.description) : null,
+        amount: Number(row.amount ?? 0),
+        balance_after: row.balance_after != null ? Number(row.balance_after) : null,
+        created_at: String(row.created_at),
+        invoice_id: row.invoice_id ? String(row.invoice_id) : null,
+        invoice_number: row.invoice_number ? String(row.invoice_number) : null,
+        currency_code: row.currency_code ? String(row.currency_code) : null,
+      }));
+    });
+  } catch (error) {
+    const expected = billingActionErrorFrom(error);
+    if (expected) {
+      return expected;
+    }
+    console.error('Error fetching client credit history:', error);
+    throw error;
+  }
+});
+
 export const getClientQuotes = withAuth(async (user, { tenant }): Promise<ClientBillingActionResult<IQuoteWithClient[]>> => {
   const knex = await getConnection(tenant);
 

--- a/packages/client-portal/src/components/billing/BillingOverviewTab.servicePeriods.test.tsx
+++ b/packages/client-portal/src/components/billing/BillingOverviewTab.servicePeriods.test.tsx
@@ -17,6 +17,19 @@ vi.mock('@alga-psa/ui/lib/i18n/client', () => ({
   }),
 }));
 
+vi.mock('@alga-psa/ui/hooks', () => ({
+  useFeatureFlag: () => ({ enabled: false, loading: false, error: null }),
+}));
+
+vi.mock('@alga-psa/ui/components/Dialog', () => ({
+  Dialog: () => null,
+  DialogContent: () => null,
+}));
+
+vi.mock('@alga-psa/ui/components/Badge', () => ({
+  Badge: ({ children }: any) => <span>{children}</span>,
+}));
+
 vi.mock('./BucketUsageChart', () => ({
   default: () => <div>bucket-chart</div>,
 }));

--- a/packages/client-portal/src/components/billing/BucketUsageChart.contract.test.tsx
+++ b/packages/client-portal/src/components/billing/BucketUsageChart.contract.test.tsx
@@ -1,0 +1,115 @@
+/**
+ * @vitest-environment jsdom
+ */
+import React from 'react';
+import { cleanup, render, screen } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import BucketUsageChart from './BucketUsageChart';
+import type { ClientBucketUsageResult } from '@alga-psa/client-portal/actions';
+
+const featureFlagState = vi.hoisted(() => ({
+  enabled: false,
+  loading: false,
+  error: null as Error | null,
+}));
+
+vi.mock('@alga-psa/ui/hooks', () => ({
+  useFeatureFlag: () => featureFlagState,
+}));
+
+vi.mock('@alga-psa/ui/lib/i18n/client', () => ({
+  useTranslation: () => ({
+    t: (key: string, fallback?: string | ({ defaultValue?: string } & Record<string, unknown>)) => {
+      if (!fallback) return key;
+      if (typeof fallback === 'string') return fallback;
+      const base = typeof fallback.defaultValue === 'string' ? fallback.defaultValue : key;
+      return base.replace(/\{\{(\w+)\}\}/g, (_, name: string) => String(fallback[name] ?? ''));
+    },
+  }),
+}));
+
+vi.mock('@alga-psa/ui/components/Badge', () => ({
+  Badge: ({ children, ...props }: any) => <span {...props}>{children}</span>,
+}));
+
+function bucket(overrides: Partial<ClientBucketUsageResult> = {}): ClientBucketUsageResult {
+  return {
+    contract_line_id: 'line-1',
+    contract_line_name: 'Managed Support',
+    service_id: 'service-1',
+    service_name: 'Help Desk',
+    display_label: 'Managed Support - Help Desk',
+    total_minutes: 1200,
+    minutes_used: 900,
+    rolled_over_minutes: 120,
+    remaining_minutes: 420,
+    period_start: '2026-01-01',
+    period_end: '2026-02-01',
+    percentage_used: 68.18,
+    percentage_remaining: 31.82,
+    hours_total: 22,
+    hours_used: 15,
+    hours_remaining: 7,
+    ...overrides,
+  };
+}
+
+describe('BucketUsageChart remaining-first meter (release-v1.5-feature)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    featureFlagState.enabled = false;
+    featureFlagState.loading = false;
+    featureFlagState.error = null;
+  });
+
+  afterEach(() => {
+    cleanup();
+  });
+
+  it('T159: flag off renders the legacy used-percentage layout with no remaining headline', () => {
+    render(<BucketUsageChart bucketData={bucket()} />);
+
+    expect(screen.getByText('Usage')).toBeInTheDocument();
+    expect(screen.getByText('68%')).toBeInTheDocument();
+    expect(screen.queryByText(/hours left of/i)).not.toBeInTheDocument();
+    expect(screen.queryByText(/hours over/i)).not.toBeInTheDocument();
+    expect(screen.queryByText(/OVER BUCKET/i)).not.toBeInTheDocument();
+  });
+
+  it('T160: flag on shows remaining-first headline matching the getRemainingBucketUnits formula', () => {
+    featureFlagState.enabled = true;
+    const data = bucket();
+    render(<BucketUsageChart bucketData={data} />);
+
+    // remaining = total + rollover − used = 1200 + 120 − 900 = 420 min = 7.0h
+    expect(
+      screen.getByText('7.0 hours left of 22.0 (incl. 2.0 rollover)')
+    ).toBeInTheDocument();
+    // Period chip
+    expect(screen.getByText('1/1/2026 – 2/1/2026')).toBeInTheDocument();
+  });
+
+  it('T161: flag on omits the rollover clause when there is no rollover', () => {
+    featureFlagState.enabled = true;
+    const data = bucket({
+      rolled_over_minutes: 0,
+      total_minutes: 1200,
+      minutes_used: 540,
+      hours_total: 20,
+      hours_used: 9,
+    });
+    render(<BucketUsageChart bucketData={data} />);
+
+    expect(screen.getByText('11.0 hours left of 20.0')).toBeInTheDocument();
+  });
+
+  it('T162: overage renders "hours over" plus the OVER BUCKET badge — never a negative number', () => {
+    featureFlagState.enabled = true;
+    const data = bucket({ minutes_used: 1500, percentage_used: 113.64 });
+    render(<BucketUsageChart bucketData={data} />);
+
+    expect(screen.getByText('3.0 hours over')).toBeInTheDocument();
+    expect(screen.getByText('OVER BUCKET')).toBeInTheDocument();
+    expect(screen.queryByText(/-3\.0/i)).not.toBeInTheDocument();
+  });
+});

--- a/packages/client-portal/src/components/billing/BucketUsageChart.contract.test.tsx
+++ b/packages/client-portal/src/components/billing/BucketUsageChart.contract.test.tsx
@@ -112,4 +112,58 @@ describe('BucketUsageChart remaining-first meter (release-v1.5-feature)', () => 
     expect(screen.getByText('OVER BUCKET')).toBeInTheDocument();
     expect(screen.queryByText(/-3\.0/i)).not.toBeInTheDocument();
   });
+
+  it('T162a: overage rescales the segments inside the track and clamps widths to [0, 100]', () => {
+    featureFlagState.enabled = true;
+    // used = 1500 of 1320 available -> percentage_used = 113.64
+    const data = bucket({ minutes_used: 1500, percentage_used: 113.64 });
+    const { container } = render(<BucketUsageChart bucketData={data} />);
+
+    const segments = Array.from(
+      container.querySelectorAll<HTMLElement>('.absolute.inset-y-0')
+    ).filter((el) => el.style.width !== '');
+
+    // base (used-within-total) first, overage second
+    expect(segments).toHaveLength(2);
+    const [base, over] = segments;
+
+    // Rescaled so total consumption maps to 100% of the track, using the same
+    // rounded percentage the bar/headline display:
+    // base = 100 * 100 / percentage, overage = 100 - base.
+    const rounded = Math.round(113.64);
+    expect(parseFloat(base.style.width)).toBeCloseTo((100 * 100) / rounded, 1);
+    expect(parseFloat(over.style.width)).toBeCloseTo(100 - (100 * 100) / rounded, 1);
+    for (const segment of segments) {
+      const width = parseFloat(segment.style.width);
+      expect(width).toBeGreaterThanOrEqual(0);
+      expect(width).toBeLessThanOrEqual(100);
+    }
+    // Track container clips segment edges.
+    expect(
+      container.querySelector('.relative.w-full.h-2\\.5.overflow-hidden.rounded-full')
+    ).not.toBeNull();
+  });
+
+  it('T162b: dirty overage data (2513% used) never paints a segment wider than the track', () => {
+    featureFlagState.enabled = true;
+    const data = bucket({ minutes_used: 34000, percentage_used: 2513 });
+    const { container } = render(<BucketUsageChart bucketData={data} />);
+
+    const segments = Array.from(
+      container.querySelectorAll<HTMLElement>('.absolute.inset-y-0')
+    ).filter((el) => el.style.width !== '');
+
+    expect(segments.length).toBeGreaterThanOrEqual(1);
+    for (const segment of segments) {
+      const width = parseFloat(segment.style.width);
+      expect(width).toBeGreaterThanOrEqual(0);
+      expect(width).toBeLessThanOrEqual(100);
+    }
+    // The overage is the final segment; with 2513% its rescaled width is ~96%.
+    const over = segments[segments.length - 1];
+    expect(parseFloat(over.style.width)).toBeLessThanOrEqual(100);
+    expect(parseFloat(over.style.width)).toBeGreaterThan(0);
+    // Used hours are still shown uncapped in the footer, not as a bar.
+    expect(screen.queryByText(/-25[0-9]+\.\d+h/i)).not.toBeInTheDocument();
+  });
 });

--- a/packages/client-portal/src/components/billing/BucketUsageChart.tsx
+++ b/packages/client-portal/src/components/billing/BucketUsageChart.tsx
@@ -2,17 +2,30 @@
 
 import React, { useMemo } from 'react';
 import { Info } from 'lucide-react';
+import { Badge } from '@alga-psa/ui/components/Badge';
+import { useFeatureFlag } from '@alga-psa/ui/hooks';
 import { useTranslation } from '@alga-psa/ui/lib/i18n/client';
 import type { ClientBucketUsageResult } from '@alga-psa/client-portal/actions';
+import {
+  getRemainingMinutes,
+  getBucketMeterColors,
+  formatBucketHours,
+} from './bucketUsageMeter';
 
 interface BucketUsageChartProps {
   bucketData: ClientBucketUsageResult;
 }
 
 const BucketUsageChart: React.FC<BucketUsageChartProps> = React.memo(({ bucketData }) => {
-  const { t } = useTranslation('client-portal');
+  const { t } = useTranslation('features/billing');
+  // The legacy (flag-off) rendering was i18n-wired on main under the
+  // client-portal namespace; the flag-on meter uses features/billing keys.
+  const { t: tLegacy } = useTranslation('client-portal');
+  const { enabled: remainingFirstEnabled } = useFeatureFlag('release-v1.5-feature', {
+    defaultValue: false,
+  });
   const percentage = Math.round(bucketData.percentage_used);
-  
+
   // Format dates consistently - memoized to prevent recalculation
   const formatPeriodDate = useMemo(() => {
     return (dateStr: string | undefined) => {
@@ -21,7 +34,7 @@ const BucketUsageChart: React.FC<BucketUsageChartProps> = React.memo(({ bucketDa
       return `${date.getMonth() + 1}/${date.getDate()}/${date.getFullYear()}`;
     };
   }, []);
-  
+
   // Determine color based on usage percentage - memoized to prevent recalculation
   const getColorClasses = useMemo(() => {
     return (percent: number) => {
@@ -49,46 +62,152 @@ const BucketUsageChart: React.FC<BucketUsageChartProps> = React.memo(({ bucketDa
   // Memoize the color classes to prevent unnecessary recalculation
   const colorClasses = useMemo(() => getColorClasses(percentage), [getColorClasses, percentage]);
 
+  if (!remainingFirstEnabled) {
+    return (
+      <div className={`border rounded-lg p-4 shadow-sm ${colorClasses.bgLight} ${colorClasses.border}`}>
+        <div className="flex justify-between items-start mb-2">
+          <div>
+            <h4 className="font-medium text-gray-900">{bucketData.service_name}</h4>
+            <p className="text-sm text-gray-500">
+              {formatPeriodDate(bucketData.period_start)} - {formatPeriodDate(bucketData.period_end)}
+            </p>
+          </div>
+          <div className="flex items-center">
+            <span className="text-sm text-gray-500 mr-1">{tLegacy('billing.bucketUsage.contractLineLabel', { defaultValue: 'Bucket Contract Line' })}</span>
+            <Info className="h-4 w-4 text-gray-400" />
+          </div>
+        </div>
+
+        <div className="mt-4">
+          <div className="flex justify-between items-center mb-1">
+            <span className="text-sm font-medium">{tLegacy('billing.bucketUsage.usage', { defaultValue: 'Usage' })}</span>
+            <span className={`text-sm font-medium ${colorClasses.text}`}>
+              {percentage}%
+            </span>
+          </div>
+          <div className="w-full bg-gray-200 rounded-full h-2.5">
+            <div
+              className={`h-2.5 rounded-full ${colorClasses.bg}`}
+              style={{ width: `${percentage}%` }}
+            ></div>
+          </div>
+          <div className="flex justify-between mt-1 text-xs text-gray-500">
+            <span>{tLegacy('billing.bucketUsage.hoursUsed', { defaultValue: '{{hours}} hours used', hours: bucketData.hours_used.toFixed(1) })}</span>
+            <span>{tLegacy('billing.bucketUsage.hoursTotal', { defaultValue: '{{hours}} hours total', hours: bucketData.hours_total.toFixed(1) })}</span>
+          </div>
+        </div>
+
+        {bucketData.rolled_over_minutes > 0 && (
+          <div className="mt-3 text-xs text-gray-500 flex items-center">
+            <span className="mr-1">{tLegacy('billing.bucketUsage.rolloverHours', { defaultValue: 'Includes {{hours}} rollover hours', hours: (bucketData.rolled_over_minutes / 60).toFixed(1) })}</span>
+            <Info className="h-3 w-3 text-gray-400" />
+          </div>
+        )}
+      </div>
+    );
+  }
+
+  const remainingMinutes = getRemainingMinutes(bucketData);
+  const totalWithRollover = bucketData.total_minutes + bucketData.rolled_over_minutes;
+  const remainingHours = remainingMinutes / 60;
+  const isOver = remainingMinutes < 0;
+  const overHours = isOver ? -remainingHours : 0;
+  const meterColors = getBucketMeterColors(remainingMinutes, totalWithRollover);
+
+  const baseFillPercent = Math.max(0, Math.min(100, percentage));
+  const overFillPercent = isOver ? percentage - 100 : 0;
+  const hasPeriod = Boolean(bucketData.period_start && bucketData.period_end);
+
+  // Parse the date-only string directly so the chip is not shifted by the
+  // server's timezone (new Date('2026-02-01') can render as Jan 31 in UTC−x).
+  const formatPeriodChipDate = (dateStr: string | undefined): string => {
+    if (!dateStr) return '';
+    const [year, month, day] = dateStr.split('-');
+    return `${Number(month)}/${Number(day)}/${year}`;
+  };
+
   return (
-    <div className={`border rounded-lg p-4 shadow-sm ${colorClasses.bgLight} ${colorClasses.border}`}>
+    <div className={`border rounded-lg p-4 shadow-sm ${meterColors.bgLight} ${meterColors.border}`}>
       <div className="flex justify-between items-start mb-2">
         <div>
           <h4 className="font-medium text-gray-900">{bucketData.service_name}</h4>
-          <p className="text-sm text-gray-500">
-            {formatPeriodDate(bucketData.period_start)} - {formatPeriodDate(bucketData.period_end)}
-          </p>
         </div>
-        <div className="flex items-center">
-          <span className="text-sm text-gray-500 mr-1">{t('billing.bucketUsage.contractLineLabel', { defaultValue: 'Bucket Contract Line' })}</span>
-          <Info className="h-4 w-4 text-gray-400" />
-        </div>
+        {hasPeriod && (
+          <span className="inline-flex items-center rounded-full bg-gray-100 px-2.5 py-0.5 text-xs font-medium text-gray-600">
+            {formatPeriodChipDate(bucketData.period_start)} – {formatPeriodChipDate(bucketData.period_end)}
+          </span>
+        )}
       </div>
 
-      <div className="mt-4">
-        <div className="flex justify-between items-center mb-1">
-          <span className="text-sm font-medium">{t('billing.bucketUsage.usage', { defaultValue: 'Usage' })}</span>
-          <span className={`text-sm font-medium ${colorClasses.text}`}>
+      <div className="mt-3">
+        {isOver ? (
+          <div className="flex items-center gap-2">
+            <span className={`text-lg font-semibold ${meterColors.text}`}>
+              {t('bucket.overageSummary', {
+                hours: formatBucketHours(overHours),
+                defaultValue: '{{hours}} hours over',
+              })}
+            </span>
+            <Badge variant="error">{t('bucket.overBucket', 'OVER BUCKET')}</Badge>
+          </div>
+        ) : bucketData.rolled_over_minutes > 0 ? (
+          <div className="text-lg font-semibold text-gray-900">
+            {t('bucket.remainingSummaryWithRollover', {
+              remaining: formatBucketHours(remainingHours),
+              total: formatBucketHours(bucketData.hours_total),
+              rollover: formatBucketHours(bucketData.rolled_over_minutes / 60),
+              defaultValue: '{{remaining}} hours left of {{total}} (incl. {{rollover}} rollover)',
+            })}
+          </div>
+        ) : (
+          <div className="text-lg font-semibold text-gray-900">
+            {t('bucket.remainingSummary', {
+              remaining: formatBucketHours(remainingHours),
+              total: formatBucketHours(bucketData.hours_total),
+              defaultValue: '{{remaining}} hours left of {{total}}',
+            })}
+          </div>
+        )}
+
+        <div className="mt-2 flex justify-between items-center mb-1">
+          <span className="text-sm font-medium">{t('bucket.usage', 'Usage')}</span>
+          <span className={`text-sm font-medium ${meterColors.text}`}>
             {percentage}%
           </span>
         </div>
-        <div className="w-full bg-gray-200 rounded-full h-2.5">
+        <div className="relative w-full h-2.5">
+          <div className="absolute inset-0 bg-gray-200 rounded-full"></div>
           <div
-            className={`h-2.5 rounded-full ${colorClasses.bg}`}
-            style={{ width: `${percentage}%` }}
+            className={`absolute inset-y-0 left-0 rounded-full ${meterColors.bg}`}
+            style={{ width: `${baseFillPercent}%` }}
           ></div>
+          {overFillPercent > 0 && (
+            <div
+              className="absolute inset-y-0 bg-destructive"
+              style={{ left: `${baseFillPercent}%`, width: `${overFillPercent}%` }}
+            ></div>
+          )}
         </div>
         <div className="flex justify-between mt-1 text-xs text-gray-500">
-          <span>{t('billing.bucketUsage.hoursUsed', { defaultValue: '{{hours}} hours used', hours: bucketData.hours_used.toFixed(1) })}</span>
-          <span>{t('billing.bucketUsage.hoursTotal', { defaultValue: '{{hours}} hours total', hours: bucketData.hours_total.toFixed(1) })}</span>
+          <span>
+            {t('bucket.usedHours', {
+              hours: formatBucketHours(bucketData.hours_used),
+              defaultValue: '{{hours}}h used',
+            })}
+          </span>
+          <span>
+            {isOver
+              ? t('bucket.overHours', {
+                  hours: formatBucketHours(overHours),
+                  defaultValue: '{{hours}}h OVER',
+                })
+              : t('bucket.leftHours', {
+                  hours: formatBucketHours(remainingHours),
+                  defaultValue: '{{hours}}h left',
+                })}
+          </span>
         </div>
       </div>
-
-      {bucketData.rolled_over_minutes > 0 && (
-        <div className="mt-3 text-xs text-gray-500 flex items-center">
-          <span className="mr-1">{t('billing.bucketUsage.rolloverHours', { defaultValue: 'Includes {{hours}} rollover hours', hours: (bucketData.rolled_over_minutes / 60).toFixed(1) })}</span>
-          <Info className="h-3 w-3 text-gray-400" />
-        </div>
-      )}
     </div>
   );
 });

--- a/packages/client-portal/src/components/billing/BucketUsageChart.tsx
+++ b/packages/client-portal/src/components/billing/BucketUsageChart.tsx
@@ -114,8 +114,19 @@ const BucketUsageChart: React.FC<BucketUsageChartProps> = React.memo(({ bucketDa
   const overHours = isOver ? -remainingHours : 0;
   const meterColors = getBucketMeterColors(remainingMinutes, totalWithRollover);
 
-  const baseFillPercent = Math.max(0, Math.min(100, percentage));
-  const overFillPercent = isOver ? percentage - 100 : 0;
+  const clampPercent = (value: number): number => Math.max(0, Math.min(100, value));
+
+  let baseFillPercent = clampPercent(percentage);
+  let overFillPercent = 0;
+  if (isOver && percentage > 100) {
+    // Overage: scale total consumption (used) onto the full track so the
+    // overage stays INSIDE the bar instead of painting a segment beyond it.
+    // With percentage_used uncapped upstream (2513% has been observed live),
+    // an unclamped `width: percentage - 100` would streak far past the track.
+    // base = 100 * total/used = 100 * 100/percentage; red = the remainder.
+    baseFillPercent = clampPercent((100 * 100) / percentage);
+    overFillPercent = clampPercent(100 - baseFillPercent);
+  }
   const hasPeriod = Boolean(bucketData.period_start && bucketData.period_end);
 
   // Parse the date-only string directly so the chip is not shifted by the
@@ -175,15 +186,15 @@ const BucketUsageChart: React.FC<BucketUsageChartProps> = React.memo(({ bucketDa
             {percentage}%
           </span>
         </div>
-        <div className="relative w-full h-2.5">
+        <div className="relative w-full h-2.5 overflow-hidden rounded-full">
           <div className="absolute inset-0 bg-gray-200 rounded-full"></div>
           <div
-            className={`absolute inset-y-0 left-0 rounded-full ${meterColors.bg}`}
+            className={`absolute inset-y-0 left-0 ${isOver ? 'rounded-l-full' : 'rounded-full'} ${meterColors.bg}`}
             style={{ width: `${baseFillPercent}%` }}
           ></div>
           {overFillPercent > 0 && (
             <div
-              className="absolute inset-y-0 bg-destructive"
+              className="absolute inset-y-0 rounded-r-full bg-destructive"
               style={{ left: `${baseFillPercent}%`, width: `${overFillPercent}%` }}
             ></div>
           )}

--- a/packages/client-portal/src/components/billing/CreditsSummaryCard.contract.test.tsx
+++ b/packages/client-portal/src/components/billing/CreditsSummaryCard.contract.test.tsx
@@ -1,0 +1,186 @@
+/**
+ * @vitest-environment jsdom
+ */
+import React from 'react';
+import { cleanup, fireEvent, render, screen } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import CreditsSummaryCard from './CreditsSummaryCard';
+
+const featureFlagState = vi.hoisted(() => ({
+  enabled: false,
+  loading: false,
+  error: null as Error | null,
+}));
+
+const getClientCreditSummaryMock = vi.hoisted(() => vi.fn());
+const getClientCreditHistoryMock = vi.hoisted(() => vi.fn());
+
+vi.mock('@alga-psa/ui/hooks', () => ({
+  useFeatureFlag: () => featureFlagState,
+}));
+
+vi.mock('@alga-psa/ui/lib/i18n/client', () => ({
+  useTranslation: () => ({
+    t: (key: string, fallback?: string | ({ defaultValue?: string } & Record<string, unknown>)) => {
+      if (!fallback) return key;
+      if (typeof fallback === 'string') return fallback;
+      const base = typeof fallback.defaultValue === 'string' ? fallback.defaultValue : key;
+      return base.replace(/\{\{(\w+)\}\}/g, (_, name: string) => String(fallback[name] ?? ''));
+    },
+  }),
+}));
+
+vi.mock('../../actions/client-portal-actions/client-billing', () => ({
+  getClientCreditSummary: (...args: unknown[]) => getClientCreditSummaryMock(...args),
+  getClientCreditHistory: (...args: unknown[]) => getClientCreditHistoryMock(...args),
+}));
+
+vi.mock('@alga-psa/ui/components/Card', () => ({
+  Card: ({ children, ...props }: any) => <div {...props}>{children}</div>,
+}));
+
+vi.mock('@alga-psa/ui/components/Badge', () => ({
+  Badge: ({ children, ...props }: any) => <span {...props}>{children}</span>,
+}));
+
+vi.mock('@alga-psa/ui/components/Skeleton', () => ({
+  Skeleton: ({ ...props }: any) => <div {...props}>loading</div>,
+}));
+
+vi.mock('@alga-psa/ui/components/Button', () => ({
+  Button: ({ children, ...props }: any) => <button {...props}>{children}</button>,
+}));
+
+vi.mock('@alga-psa/ui/components/Dialog', () => ({
+  Dialog: ({ isOpen, children, ...props }: any) =>
+    isOpen ? <div data-testid="dialog" {...props}>{children}</div> : null,
+  DialogContent: ({ children, ...props }: any) => <div {...props}>{children}</div>,
+}));
+
+const formatCurrency = (amount: number, _currencyCode?: string) =>
+  `${amount >= 0 ? '' : '-'}$${(Math.abs(amount) / 100).toFixed(2)}`;
+const formatDate = (date: string | { toString(): string } | undefined | null) =>
+  date ? String(date) : 'N/A';
+
+function summaryWith(credits: any[]): any {
+  return { available_credit: 50000, credits };
+}
+
+function activeCreditRow() {
+  return {
+    credit_id: 'credit-1',
+    description: 'Prepayment credit',
+    amount: 10000,
+    remaining_amount: 5000,
+    created_at: '2026-01-01',
+    expiration_date: null,
+    is_expired: false,
+    currency_code: 'USD',
+  };
+}
+
+describe('CreditsSummaryCard credit history (release-v1.5-feature)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    featureFlagState.enabled = false;
+    featureFlagState.loading = false;
+    featureFlagState.error = null;
+    getClientCreditSummaryMock.mockResolvedValue(summaryWith([activeCreditRow()]));
+    getClientCreditHistoryMock.mockResolvedValue([
+      {
+        transaction_id: 'tx-issuance',
+        type: 'prepayment',
+        description: null,
+        amount: 10000,
+        balance_after: 15000,
+        created_at: '2026-07-01T10:00:00.000Z',
+        invoice_id: 'inv-1',
+        invoice_number: 'INV-001',
+        currency_code: 'USD',
+      },
+      {
+        transaction_id: 'tx-application',
+        type: 'credit_application',
+        description: null,
+        amount: -5000,
+        balance_after: 10000,
+        created_at: '2026-07-05T10:00:00.000Z',
+        invoice_id: 'inv-2',
+        invoice_number: 'INV-002',
+        currency_code: 'USD',
+      },
+    ]);
+  });
+
+  afterEach(() => {
+    cleanup();
+  });
+
+  it('T154: renders no history affordance when the flag is off', async () => {
+    render(
+      <CreditsSummaryCard formatCurrency={formatCurrency} formatDate={formatDate} />
+    );
+
+    expect(await screen.findByText('Available Credit')).toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: /view history/i })).not.toBeInTheDocument();
+  });
+
+  it('T155: flag on renders the history button and opens a ledger dialog listing rows', async () => {
+    featureFlagState.enabled = true;
+    render(
+      <CreditsSummaryCard formatCurrency={formatCurrency} formatDate={formatDate} />
+    );
+
+    const historyButton = await screen.findByRole('button', { name: /view history/i });
+    expect(historyButton).toBeInTheDocument();
+
+    fireEvent.click(historyButton);
+
+    expect(await screen.findByText('Issued — prepayment #INV-001')).toBeInTheDocument();
+    expect(screen.getByText('Applied to invoice #INV-002')).toBeInTheDocument();
+    expect(screen.getByText('+$100.00')).toBeInTheDocument();
+    expect(screen.getByText('−$50.00')).toBeInTheDocument();
+    expect(screen.getByText('balance $150.00')).toBeInTheDocument();
+    expect(getClientCreditHistoryMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('T156: flag on with empty history shows the empty state', async () => {
+    featureFlagState.enabled = true;
+    getClientCreditHistoryMock.mockResolvedValue([]);
+    render(
+      <CreditsSummaryCard formatCurrency={formatCurrency} formatDate={formatDate} />
+    );
+
+    fireEvent.click(await screen.findByRole('button', { name: /view history/i }));
+
+    expect(await screen.findByText('No credit activity yet')).toBeInTheDocument();
+  });
+
+  it('T157: a history load error degrades to the dialog empty state', async () => {
+    featureFlagState.enabled = true;
+    getClientCreditHistoryMock.mockResolvedValue({ permissionError: 'denied' });
+    render(
+      <CreditsSummaryCard formatCurrency={formatCurrency} formatDate={formatDate} />
+    );
+
+    fireEvent.click(await screen.findByRole('button', { name: /view history/i }));
+
+    expect(await screen.findByText('No credit activity yet')).toBeInTheDocument();
+  });
+
+  it('T158: history errors never break the underlying credit card', async () => {
+    featureFlagState.enabled = true;
+    getClientCreditHistoryMock.mockRejectedValue(new Error('boom'));
+    render(
+      <CreditsSummaryCard formatCurrency={formatCurrency} formatDate={formatDate} />
+    );
+
+    expect(await screen.findByText('Available Credit')).toBeInTheDocument();
+    expect(screen.getByText('Prepayment credit')).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole('button', { name: /view history/i }));
+
+    expect(await screen.findByText('No credit activity yet')).toBeInTheDocument();
+    expect(screen.getByText('Available Credit')).toBeInTheDocument();
+  });
+});

--- a/packages/client-portal/src/components/billing/CreditsSummaryCard.contract.test.tsx
+++ b/packages/client-portal/src/components/billing/CreditsSummaryCard.contract.test.tsx
@@ -144,6 +144,42 @@ describe('CreditsSummaryCard credit history (release-v1.5-feature)', () => {
     expect(getClientCreditHistoryMock).toHaveBeenCalledTimes(1);
   });
 
+  it('T155a: credit_issuance rows (production prepayment finalization) keep their invoice reference', async () => {
+    featureFlagState.enabled = true;
+    getClientCreditHistoryMock.mockResolvedValue([
+      {
+        transaction_id: 'tx-real-issuance',
+        type: 'credit_issuance',
+        description: null,
+        amount: 12500,
+        balance_after: 12500,
+        created_at: '2026-07-10T10:00:00.000Z',
+        invoice_id: 'inv-3',
+        invoice_number: 'INV-003',
+        currency_code: 'USD',
+      },
+      {
+        transaction_id: 'tx-manual-issuance',
+        type: 'credit_issuance',
+        description: null,
+        amount: 2500,
+        balance_after: 15000,
+        created_at: '2026-07-12T10:00:00.000Z',
+        invoice_id: null,
+        invoice_number: null,
+        currency_code: 'USD',
+      },
+    ]);
+    render(
+      <CreditsSummaryCard formatCurrency={formatCurrency} formatDate={formatDate} />
+    );
+
+    fireEvent.click(await screen.findByRole('button', { name: /view history/i }));
+
+    expect(await screen.findByText('Issued — invoice #INV-003')).toBeInTheDocument();
+    expect(screen.getByText('Issued')).toBeInTheDocument();
+  });
+
   it('T156: flag on with empty history shows the empty state', async () => {
     featureFlagState.enabled = true;
     getClientCreditHistoryMock.mockResolvedValue([]);

--- a/packages/client-portal/src/components/billing/CreditsSummaryCard.tsx
+++ b/packages/client-portal/src/components/billing/CreditsSummaryCard.tsx
@@ -4,14 +4,22 @@ import React, { useEffect, useState } from 'react';
 import { Card } from '@alga-psa/ui/components/Card';
 import { Badge } from '@alga-psa/ui/components/Badge';
 import { Skeleton } from '@alga-psa/ui/components/Skeleton';
-import { Wallet } from 'lucide-react';
+import { Button } from '@alga-psa/ui/components/Button';
+import { Dialog, DialogContent } from '@alga-psa/ui/components/Dialog';
+import { Wallet, History } from 'lucide-react';
+import { useFeatureFlag } from '@alga-psa/ui/hooks';
 import { useTranslation } from '@alga-psa/ui/lib/i18n/client';
-import type { ClientPortalCreditSummary } from '../../actions/client-portal-actions/client-billing';
+import type {
+  ClientPortalCreditSummary,
+  ClientPortalCreditHistoryEntry,
+} from '../../actions/client-portal-actions/client-billing';
 
 interface CreditsSummaryCardProps {
   formatCurrency: (amount: number, currencyCode?: string) => string;
   formatDate: (date: string | { toString(): string } | undefined | null) => string;
 }
+
+type TranslateFn = ReturnType<typeof useTranslation>['t'];
 
 function isActionError(value: unknown): boolean {
   const candidate = value as Record<string, unknown> | null;
@@ -22,15 +30,55 @@ function isActionError(value: unknown): boolean {
   );
 }
 
+function getCreditHistoryLabel(t: TranslateFn, entry: ClientPortalCreditHistoryEntry): string {
+  const invoiceNumber = entry.invoice_number;
+  switch (entry.type) {
+    case 'prepayment':
+      return invoiceNumber
+        ? t('credits.history.issuedWithInvoice', {
+            invoice: invoiceNumber,
+            defaultValue: 'Issued — prepayment #{{invoice}}',
+          })
+        : t('credits.history.issued', 'Issued');
+    case 'credit_application':
+      return invoiceNumber
+        ? t('credits.history.appliedToInvoice', {
+            invoice: invoiceNumber,
+            defaultValue: 'Applied to invoice #{{invoice}}',
+          })
+        : t('credits.history.applied', 'Applied');
+    case 'credit_issuance':
+      return t('credits.history.issued', 'Issued');
+    case 'credit_issuance_from_negative_invoice':
+      return t('credits.history.issuedFromCreditNote', 'Issued from credit note');
+    case 'credit_adjustment':
+      return t('credits.history.adjusted', 'Adjusted');
+    case 'credit_expiration':
+      return t('credits.history.expired', 'Expired');
+    case 'credit_transfer':
+      return t('credits.history.transferred', 'Transferred');
+    default:
+      return t('credits.history.transaction', 'Credit activity');
+  }
+}
+
 /**
  * Available-credit card for the portal billing overview: headline derived
- * balance plus the client's recent credit history with provenance.
+ * balance plus the client's recent credit history with provenance. When the
+ * release-v1.5-feature flag is on, a "View history" link opens a ledger dialog
+ * of recent credit transactions.
  */
 export default function CreditsSummaryCard({ formatCurrency, formatDate }: CreditsSummaryCardProps) {
   const { t } = useTranslation('features/billing');
+  const { enabled: historyEnabled } = useFeatureFlag('release-v1.5-feature', {
+    defaultValue: false,
+  });
   const [summary, setSummary] = useState<ClientPortalCreditSummary | null>(null);
   const [loading, setLoading] = useState(true);
   const [unavailable, setUnavailable] = useState(false);
+  const [isHistoryOpen, setIsHistoryOpen] = useState(false);
+  const [history, setHistory] = useState<ClientPortalCreditHistoryEntry[] | null>(null);
+  const [isHistoryLoading, setIsHistoryLoading] = useState(false);
 
   useEffect(() => {
     let cancelled = false;
@@ -59,6 +107,38 @@ export default function CreditsSummaryCard({ formatCurrency, formatDate }: Credi
       cancelled = true;
     };
   }, []);
+
+  // Load the ledger when the dialog opens. Degrades to the dialog's empty
+  // state on any error — the card itself is unaffected.
+  useEffect(() => {
+    if (!isHistoryOpen) {
+      return;
+    }
+    let cancelled = false;
+    setIsHistoryLoading(true);
+    (async () => {
+      try {
+        const { getClientCreditHistory } = await import(
+          '../../actions/client-portal-actions/client-billing'
+        );
+        const result = await getClientCreditHistory();
+        if (cancelled) return;
+        if (isActionError(result)) {
+          setHistory([]);
+          return;
+        }
+        setHistory(result as ClientPortalCreditHistoryEntry[]);
+      } catch (error) {
+        console.error('Error loading credit history:', error);
+        if (!cancelled) setHistory([]);
+      } finally {
+        if (!cancelled) setIsHistoryLoading(false);
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, [isHistoryOpen]);
 
   if (unavailable) {
     return null;
@@ -107,11 +187,87 @@ export default function CreditsSummaryCard({ formatCurrency, formatDate }: Credi
                   ))}
                 </ul>
               )}
+              {historyEnabled && (
+                <Button
+                  id="credits-view-history-button"
+                  className="mt-3 w-full"
+                  variant="outline"
+                  onClick={() => setIsHistoryOpen(true)}
+                >
+                  <History className="mr-2 h-4 w-4" />
+                  {t('credits.history.viewHistory', 'View history')}
+                </Button>
+              )}
             </>
           )}
         </div>
         <Wallet className="h-5 w-5 text-gray-400" />
       </div>
+
+      <Dialog
+        isOpen={isHistoryOpen}
+        onClose={() => setIsHistoryOpen(false)}
+        title={t('credits.history.title', 'Credit History')}
+        id="credit-history-dialog"
+        data-automation-id="credit-history-dialog"
+      >
+        <DialogContent>
+          <div className="space-y-1" data-automation-id="credit-history-content">
+            {isHistoryLoading ? (
+              <div className="space-y-4">
+                {[...Array(4)].map((_, i) => (
+                  <div key={i} className="flex items-start justify-between gap-4">
+                    <div className="space-y-1">
+                      <Skeleton className="h-4 w-40" />
+                      <Skeleton className="h-3 w-24" />
+                    </div>
+                    <div className="space-y-1">
+                      <Skeleton className="h-4 w-20" />
+                      <Skeleton className="h-3 w-16" />
+                    </div>
+                  </div>
+                ))}
+              </div>
+            ) : !history || history.length === 0 ? (
+              <div className="py-8 text-center">
+                <History className="mx-auto h-8 w-8 text-gray-400" />
+                <p className="mt-2 text-sm text-gray-500">
+                  {t('credits.history.empty', 'No credit activity yet')}
+                </p>
+              </div>
+            ) : (
+              <ul className="divide-y divide-gray-100">
+                {history.map((entry) => (
+                  <li key={entry.transaction_id} className="flex items-start justify-between gap-4 py-3">
+                    <div className="min-w-0 flex-1">
+                      <p className="text-sm font-medium text-gray-900">
+                        {getCreditHistoryLabel(t, entry)}
+                      </p>
+                      <p className="mt-0.5 text-xs text-gray-500">
+                        {formatDate(entry.created_at)}
+                      </p>
+                    </div>
+                    <div className="shrink-0 text-right">
+                      <p className={entry.amount >= 0 ? 'text-sm font-semibold text-success' : 'text-sm font-medium'}>
+                        {entry.amount >= 0 ? '+' : '−'}
+                        {formatCurrency(Math.abs(entry.amount), entry.currency_code ?? undefined)}
+                      </p>
+                      {entry.balance_after != null && (
+                        <p className="mt-0.5 text-xs text-gray-500">
+                          {t('credits.history.balance', {
+                            amount: formatCurrency(entry.balance_after, entry.currency_code ?? undefined),
+                            defaultValue: 'balance {{amount}}',
+                          })}
+                        </p>
+                      )}
+                    </div>
+                  </li>
+                ))}
+              </ul>
+            )}
+          </div>
+        </DialogContent>
+      </Dialog>
     </Card>
   );
 }

--- a/packages/client-portal/src/components/billing/CreditsSummaryCard.tsx
+++ b/packages/client-portal/src/components/billing/CreditsSummaryCard.tsx
@@ -48,7 +48,12 @@ function getCreditHistoryLabel(t: TranslateFn, entry: ClientPortalCreditHistoryE
           })
         : t('credits.history.applied', 'Applied');
     case 'credit_issuance':
-      return t('credits.history.issued', 'Issued');
+      return invoiceNumber
+        ? t('credits.history.issuedForInvoice', {
+            invoice: invoiceNumber,
+            defaultValue: 'Issued — invoice #{{invoice}}',
+          })
+        : t('credits.history.issued', 'Issued');
     case 'credit_issuance_from_negative_invoice':
       return t('credits.history.issuedFromCreditNote', 'Issued from credit note');
     case 'credit_adjustment':

--- a/packages/client-portal/src/components/billing/bucketUsageMeter.ts
+++ b/packages/client-portal/src/components/billing/bucketUsageMeter.ts
@@ -1,0 +1,63 @@
+/**
+ * Shared remaining-hours math and meter colors for the client-portal bucket
+ * surfaces (Billing overview meter + dashboard widget).
+ *
+ * The remaining semantics mirror `getRemainingBucketUnits` in
+ * `packages/reporting`: remaining = total + rollover − used.
+ */
+
+import type { ClientBucketUsageResult } from '@alga-psa/client-portal/actions';
+
+export type BucketMinutesFields = Pick<
+  ClientBucketUsageResult,
+  'total_minutes' | 'rolled_over_minutes' | 'minutes_used'
+>;
+
+export function getRemainingMinutes(bucket: BucketMinutesFields): number {
+  return bucket.total_minutes + bucket.rolled_over_minutes - bucket.minutes_used;
+}
+
+export function formatBucketHours(hours: number): string {
+  return hours.toFixed(1);
+}
+
+export interface BucketMeterColors {
+  text: string;
+  bg: string;
+  bgLight: string;
+  border: string;
+}
+
+/**
+ * Thresholds mirror the legacy used-percentage meter (90%/75%) expressed as
+ * remaining fraction of the total available (base + rollover). A negative
+ * remaining value (overage) is always destructive.
+ */
+export function getBucketMeterColors(
+  remainingMinutes: number,
+  totalMinutes: number
+): BucketMeterColors {
+  const remainingFraction = totalMinutes > 0 ? remainingMinutes / totalMinutes : 0;
+  if (remainingFraction <= 0.1) {
+    return {
+      text: 'text-destructive',
+      bg: 'bg-destructive',
+      bgLight: 'bg-destructive/10',
+      border: 'border-destructive/30',
+    };
+  }
+  if (remainingFraction <= 0.25) {
+    return {
+      text: 'text-warning',
+      bg: 'bg-warning',
+      bgLight: 'bg-warning/10',
+      border: 'border-warning/30',
+    };
+  }
+  return {
+    text: 'text-success',
+    bg: 'bg-success',
+    bgLight: 'bg-success/10',
+    border: 'border-success/30',
+  };
+}

--- a/packages/client-portal/src/components/dashboard/ClientDashboard.contract.test.ts
+++ b/packages/client-portal/src/components/dashboard/ClientDashboard.contract.test.ts
@@ -58,4 +58,9 @@ describe('ClientDashboard quick-action distribution contract', () => {
   it('removes the duplicate Request Appointment button from the side rail', () => {
     expect(source).not.toContain('dashboard-request-appointment-quick');
   });
+
+  it('wires the PrepaidHoursCard widget below the KPI row, only for the PSA portal', () => {
+    expect(source).toContain("import { PrepaidHoursCard } from './PrepaidHoursCard';");
+    expect(source).toMatch(/!isAlgaDeskPortal && <PrepaidHoursCard \/>/);
+  });
 });

--- a/packages/client-portal/src/components/dashboard/ClientDashboard.tsx
+++ b/packages/client-portal/src/components/dashboard/ClientDashboard.tsx
@@ -16,6 +16,7 @@ import {
 import type { Asset, ProductCode } from '@alga-psa/types';
 import { RequestAppointmentModal } from '../appointments/RequestAppointmentModal';
 import { ClientAddTicket } from '../tickets/ClientAddTicket';
+import { PrepaidHoursCard } from './PrepaidHoursCard';
 import { useTranslation } from '@alga-psa/ui/lib/i18n/client';
 import {
   Calendar,
@@ -513,6 +514,9 @@ export function ClientDashboard({
           );
         })}
       </div>
+
+      {/* Prepaid hours widget: self-gating on feature flag + billing access + bucket lines */}
+      {!isAlgaDeskPortal && <PrepaidHoursCard />}
 
       {/* Activity + side rail (Schedule + Devices) */}
       <div className="grid grid-cols-1 gap-4 lg:grid-cols-4">

--- a/packages/client-portal/src/components/dashboard/PrepaidHoursCard.contract.test.tsx
+++ b/packages/client-portal/src/components/dashboard/PrepaidHoursCard.contract.test.tsx
@@ -1,0 +1,143 @@
+/**
+ * @vitest-environment jsdom
+ */
+import React from 'react';
+import { cleanup, render, screen } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { PrepaidHoursCard } from './PrepaidHoursCard';
+
+const featureFlagState = vi.hoisted(() => ({
+  enabled: false,
+  loading: false,
+  error: null as Error | null,
+}));
+
+const checkClientPortalPermissionsMock = vi.hoisted(() => vi.fn());
+const getClientBucketUsageMock = vi.hoisted(() => vi.fn());
+
+vi.mock('@alga-psa/ui/hooks', () => ({
+  useFeatureFlag: () => featureFlagState,
+}));
+
+vi.mock('@alga-psa/ui/lib/i18n/client', () => ({
+  useTranslation: () => ({
+    t: (key: string, fallback?: string | ({ defaultValue?: string } & Record<string, unknown>)) => {
+      if (!fallback) return key;
+      if (typeof fallback === 'string') return fallback;
+      const base = typeof fallback.defaultValue === 'string' ? fallback.defaultValue : key;
+      return base.replace(/\{\{(\w+)\}\}/g, (_, name: string) => String(fallback[name] ?? ''));
+    },
+  }),
+}));
+
+vi.mock('next/link', () => ({
+  default: ({ href, children, ...props }: any) => <a href={href} {...props}>{children}</a>,
+}));
+
+vi.mock('@alga-psa/client-portal/actions', () => ({
+  checkClientPortalPermissions: (...args: unknown[]) => checkClientPortalPermissionsMock(...args),
+  getClientBucketUsage: (...args: unknown[]) => getClientBucketUsageMock(...args),
+}));
+
+vi.mock('@alga-psa/ui/components/Card', () => ({
+  Card: ({ children, ...props }: any) => <div {...props}>{children}</div>,
+  CardHeader: ({ children, ...props }: any) => <div {...props}>{children}</div>,
+  CardTitle: ({ children, ...props }: any) => <h3 {...props}>{children}</h3>,
+  CardContent: ({ children, ...props }: any) => <div {...props}>{children}</div>,
+}));
+
+vi.mock('@alga-psa/ui/components/Badge', () => ({
+  Badge: ({ children, ...props }: any) => <span {...props}>{children}</span>,
+}));
+
+function bucketRow(overrides: Record<string, unknown> = {}) {
+  return {
+    contract_line_id: 'line-1',
+    contract_line_name: 'Managed Support',
+    service_id: 'service-1',
+    service_name: 'Help Desk',
+    display_label: 'Managed Support - Help Desk',
+    total_minutes: 1200,
+    minutes_used: 900,
+    rolled_over_minutes: 120,
+    remaining_minutes: 420,
+    period_start: '2026-01-01',
+    period_end: '2026-02-01',
+    percentage_used: 68.18,
+    percentage_remaining: 31.82,
+    hours_total: 22,
+    hours_used: 15,
+    hours_remaining: 7,
+    ...overrides,
+  };
+}
+
+describe('PrepaidHoursCard dashboard widget (release-v1.5-feature)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    featureFlagState.enabled = false;
+    featureFlagState.loading = false;
+    featureFlagState.error = null;
+    checkClientPortalPermissionsMock.mockResolvedValue({ hasBillingAccess: true });
+    getClientBucketUsageMock.mockResolvedValue([bucketRow()]);
+  });
+
+  afterEach(() => {
+    cleanup();
+  });
+
+  it('T163: renders nothing when the flag is off', () => {
+    const { container } = render(<PrepaidHoursCard />);
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it('T164: renders nothing without billing access', async () => {
+    featureFlagState.enabled = true;
+    checkClientPortalPermissionsMock.mockResolvedValue({ hasBillingAccess: false });
+    const { container } = render(<PrepaidHoursCard />);
+    await vi.waitFor(() => expect(checkClientPortalPermissionsMock).toHaveBeenCalled());
+    expect(container).toBeEmptyDOMElement();
+    expect(getClientBucketUsageMock).not.toHaveBeenCalled();
+  });
+
+  it('T165: renders nothing when the bucket action returns a permission error', async () => {
+    featureFlagState.enabled = true;
+    getClientBucketUsageMock.mockResolvedValue({ permissionError: 'Unauthorized' });
+    const { container } = render(<PrepaidHoursCard />);
+    await vi.waitFor(() => expect(getClientBucketUsageMock).toHaveBeenCalled());
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it('T166: renders nothing when there are no bucket lines', async () => {
+    featureFlagState.enabled = true;
+    getClientBucketUsageMock.mockResolvedValue([]);
+    const { container } = render(<PrepaidHoursCard />);
+    await vi.waitFor(() => expect(getClientBucketUsageMock).toHaveBeenCalled());
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it('T167: renders the card with a per-line meter and a View billing link when all gates pass', async () => {
+    featureFlagState.enabled = true;
+    render(<PrepaidHoursCard />);
+
+    expect(await screen.findByText('Prepaid hours')).toBeInTheDocument();
+    expect(screen.getByText('View billing')).toBeInTheDocument();
+    expect(screen.getByText('Managed Support - Help Desk')).toBeInTheDocument();
+    expect(screen.getByText('7.0h left')).toBeInTheDocument();
+    expect(screen.getByRole('link', { name: /view billing/i })).toHaveAttribute(
+      'href',
+      '/client-portal/billing'
+    );
+  });
+
+  it('T168: overage rows render a red OVER badge instead of a negative number', async () => {
+    featureFlagState.enabled = true;
+    getClientBucketUsageMock.mockResolvedValue([
+      bucketRow({ minutes_used: 1500, percentage_used: 113.64, remaining_minutes: -180 }),
+    ]);
+    render(<PrepaidHoursCard />);
+
+    expect(await screen.findByText('3.0h OVER')).toBeInTheDocument();
+    expect(screen.queryByText(/-3\.0h/i)).not.toBeInTheDocument();
+  });
+});

--- a/packages/client-portal/src/components/dashboard/PrepaidHoursCard.tsx
+++ b/packages/client-portal/src/components/dashboard/PrepaidHoursCard.tsx
@@ -1,0 +1,136 @@
+'use client';
+
+import React, { useEffect, useState } from 'react';
+import Link from 'next/link';
+import { Card, CardHeader, CardTitle, CardContent } from '@alga-psa/ui/components/Card';
+import { Badge } from '@alga-psa/ui/components/Badge';
+import { Clock, ArrowRight } from 'lucide-react';
+import { useFeatureFlag } from '@alga-psa/ui/hooks';
+import { useTranslation } from '@alga-psa/ui/lib/i18n/client';
+import {
+  checkClientPortalPermissions,
+  getClientBucketUsage,
+  type ClientBucketUsageResult,
+} from '@alga-psa/client-portal/actions';
+import { isActionMessageError, isActionPermissionError } from '@alga-psa/ui/lib/errorHandling';
+import {
+  getRemainingMinutes,
+  getBucketMeterColors,
+  formatBucketHours,
+} from '../billing/bucketUsageMeter';
+
+/**
+ * "Prepaid hours" dashboard widget: one mini remaining-hours meter per bucket
+ * line. Renders nothing unless the release flag is on, the portal user has
+ * billing access, and there is at least one bucket line. A permission error
+ * from the bucket action also counts as "render nothing".
+ */
+export function PrepaidHoursCard() {
+  const { t } = useTranslation('features/billing');
+  const { enabled: widgetEnabled } = useFeatureFlag('release-v1.5-feature', {
+    defaultValue: false,
+  });
+  const [buckets, setBuckets] = useState<ClientBucketUsageResult[] | null>(null);
+
+  useEffect(() => {
+    if (!widgetEnabled) {
+      setBuckets(null);
+      return;
+    }
+    let cancelled = false;
+    (async () => {
+      try {
+        const permissions = await checkClientPortalPermissions();
+        if (cancelled) return;
+        if (!permissions.hasBillingAccess) {
+          setBuckets([]);
+          return;
+        }
+        const result = await getClientBucketUsage();
+        if (cancelled) return;
+        if (isActionMessageError(result) || isActionPermissionError(result)) {
+          setBuckets([]);
+          return;
+        }
+        setBuckets(result);
+      } catch (error) {
+        console.error('Error loading prepaid hours widget:', error);
+        if (!cancelled) setBuckets([]);
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, [widgetEnabled]);
+
+  if (!widgetEnabled || !buckets || buckets.length === 0) {
+    return null;
+  }
+
+  return (
+    <Card id="prepaid-hours-card" className="bg-[rgb(var(--color-card))]">
+      <CardHeader>
+        <div className="flex items-center justify-between">
+          <div className="flex items-center gap-2">
+            <Clock className="h-4 w-4 text-[rgb(var(--color-primary-500))]" />
+            <CardTitle>{t('dashboard.prepaidHours', 'Prepaid hours')}</CardTitle>
+          </div>
+          <Link
+            href="/client-portal/billing"
+            className="inline-flex items-center gap-1 text-xs font-medium text-[rgb(var(--color-primary-500))] hover:text-[rgb(var(--color-primary-600))]"
+          >
+            {t('dashboard.viewBilling', 'View billing')}
+            <ArrowRight className="h-3 w-3" />
+          </Link>
+        </div>
+      </CardHeader>
+      <CardContent>
+        <ul className="space-y-3">
+          {buckets.map((bucket, index) => {
+            const remainingMinutes = getRemainingMinutes(bucket);
+            const totalWithRollover = bucket.total_minutes + bucket.rolled_over_minutes;
+            const remainingHours = remainingMinutes / 60;
+            const isOver = remainingMinutes < 0;
+            const overHours = isOver ? -remainingHours : 0;
+            const meterColors = getBucketMeterColors(remainingMinutes, totalWithRollover);
+            const fillPercent = Math.max(0, Math.min(100, bucket.percentage_used));
+
+            return (
+              <li
+                key={`${bucket.contract_line_id}-${bucket.service_id}-${index}`}
+                className="rounded-md border border-[rgb(var(--color-border-100))] p-2.5"
+              >
+                <div className="flex items-baseline justify-between gap-2">
+                  <span className="truncate text-sm font-medium text-[rgb(var(--color-text-900))]">
+                    {bucket.display_label}
+                  </span>
+                  {isOver ? (
+                    <Badge variant="error" size="sm" className="shrink-0">
+                      {t('bucket.overHours', {
+                        hours: formatBucketHours(overHours),
+                        defaultValue: '{{hours}}h OVER',
+                      })}
+                    </Badge>
+                  ) : (
+                    <span className="shrink-0 text-sm font-semibold text-[rgb(var(--color-text-900))]">
+                      {t('bucket.leftHours', {
+                        hours: formatBucketHours(remainingHours),
+                        defaultValue: '{{hours}}h left',
+                      })}
+                    </span>
+                  )}
+                </div>
+                <div className="mt-1.5 h-1.5 w-full rounded-full bg-gray-200">
+                  <div
+                    className={`h-1.5 rounded-full ${meterColors.bg}`}
+                    style={{ width: `${fillPercent}%` }}
+                  ></div>
+                </div>
+              </li>
+            );
+          })}
+        </ul>
+      </CardContent>
+    </Card>
+  );
+}

--- a/server/public/locales/de/features/billing.json
+++ b/server/public/locales/de/features/billing.json
@@ -122,7 +122,14 @@
     "usage": "Nutzung",
     "overage": "Überschreitung",
     "noContractLineTitle": "Keine Stundenpläne verfügbar",
-    "noContractLineDescription": "Für Ihr Konto sind keine aktiven Stundenkontingent-Vertragslinien vorhanden."
+    "noContractLineDescription": "Für Ihr Konto sind keine aktiven Stundenkontingent-Vertragslinien vorhanden.",
+    "remainingSummary": "{{remaining}} Stunden übrig von {{total}}",
+    "remainingSummaryWithRollover": "{{remaining}} Stunden übrig von {{total}} (inkl. {{rollover}} Übertrag)",
+    "overageSummary": "{{hours}} Stunden überschritten",
+    "overBucket": "KONTINGENT ÜBERSCHRITTEN",
+    "usedHours": "{{hours}} Std. verbraucht",
+    "leftHours": "{{hours}} Std. übrig",
+    "overHours": "{{hours}} Std. ÜBERSCHRITTEN"
   },
   "messages": {
     "noInvoices": "Keine Rechnungen gefunden",
@@ -335,6 +342,25 @@
     "availableCredit": "Verfügbares Guthaben",
     "appliedAutomatically": "Wird automatisch mit Ihrer nächsten Rechnung verrechnet.",
     "credit": "Guthaben",
-    "expires": "Läuft ab am {{date}}"
+    "expires": "Läuft ab am {{date}}",
+    "history": {
+      "viewHistory": "Verlauf anzeigen",
+      "title": "Guthabenverlauf",
+      "empty": "Noch keine Guthabenaktivität",
+      "issued": "Gutschrift erteilt",
+      "issuedWithInvoice": "Gutschrift erteilt — Vorauszahlung #{{invoice}}",
+      "issuedFromCreditNote": "Gutschrift aus Kreditnota",
+      "applied": "Verrechnet",
+      "appliedToInvoice": "Mit Rechnung #{{invoice}} verrechnet",
+      "adjusted": "Angepasst",
+      "expired": "Abgelaufen",
+      "transferred": "Übertragen",
+      "transaction": "Guthabenaktivität",
+      "balance": "Saldo {{amount}}"
+    }
+  },
+  "dashboard": {
+    "prepaidHours": "Vorausbezahlte Stunden",
+    "viewBilling": "Zur Abrechnung"
   }
 }

--- a/server/public/locales/de/features/billing.json
+++ b/server/public/locales/de/features/billing.json
@@ -349,6 +349,7 @@
       "empty": "Noch keine Guthabenaktivität",
       "issued": "Gutschrift erteilt",
       "issuedWithInvoice": "Gutschrift erteilt — Vorauszahlung #{{invoice}}",
+      "issuedForInvoice": "Gutschrift erteilt — Rechnung #{{invoice}}",
       "issuedFromCreditNote": "Gutschrift aus Kreditnota",
       "applied": "Verrechnet",
       "appliedToInvoice": "Mit Rechnung #{{invoice}} verrechnet",

--- a/server/public/locales/en/features/billing.json
+++ b/server/public/locales/en/features/billing.json
@@ -122,7 +122,14 @@
     "usage": "Usage",
     "overage": "Overage",
     "noContractLineTitle": "No bucket contract lines available",
-    "noContractLineDescription": "There are no active bucket contract lines for your account."
+    "noContractLineDescription": "There are no active bucket contract lines for your account.",
+    "remainingSummary": "{{remaining}} hours left of {{total}}",
+    "remainingSummaryWithRollover": "{{remaining}} hours left of {{total}} (incl. {{rollover}} rollover)",
+    "overageSummary": "{{hours}} hours over",
+    "overBucket": "OVER BUCKET",
+    "usedHours": "{{hours}}h used",
+    "leftHours": "{{hours}}h left",
+    "overHours": "{{hours}}h OVER"
   },
   "messages": {
     "noInvoices": "No invoices found",
@@ -335,6 +342,25 @@
     "availableCredit": "Available Credit",
     "appliedAutomatically": "Applied automatically to your next invoice.",
     "credit": "Credit",
-    "expires": "Expires {{date}}"
+    "expires": "Expires {{date}}",
+    "history": {
+      "viewHistory": "View history",
+      "title": "Credit History",
+      "empty": "No credit activity yet",
+      "issued": "Issued",
+      "issuedWithInvoice": "Issued — prepayment #{{invoice}}",
+      "issuedFromCreditNote": "Issued from credit note",
+      "applied": "Applied",
+      "appliedToInvoice": "Applied to invoice #{{invoice}}",
+      "adjusted": "Adjusted",
+      "expired": "Expired",
+      "transferred": "Transferred",
+      "transaction": "Credit activity",
+      "balance": "balance {{amount}}"
+    }
+  },
+  "dashboard": {
+    "prepaidHours": "Prepaid hours",
+    "viewBilling": "View billing"
   }
 }

--- a/server/public/locales/en/features/billing.json
+++ b/server/public/locales/en/features/billing.json
@@ -349,6 +349,7 @@
       "empty": "No credit activity yet",
       "issued": "Issued",
       "issuedWithInvoice": "Issued — prepayment #{{invoice}}",
+      "issuedForInvoice": "Issued — invoice #{{invoice}}",
       "issuedFromCreditNote": "Issued from credit note",
       "applied": "Applied",
       "appliedToInvoice": "Applied to invoice #{{invoice}}",

--- a/server/public/locales/es/features/billing.json
+++ b/server/public/locales/es/features/billing.json
@@ -122,7 +122,14 @@
     "usage": "Uso",
     "overage": "Exceso",
     "noContractLineTitle": "No hay planes de horas disponibles",
-    "noContractLineDescription": "No existen planes de horas activos para su cuenta."
+    "noContractLineDescription": "No existen planes de horas activos para su cuenta.",
+    "remainingSummary": "Quedan {{remaining}} horas de {{total}}",
+    "remainingSummaryWithRollover": "Quedan {{remaining}} horas de {{total}} (incl. {{rollover}} de prórroga)",
+    "overageSummary": "{{hours}} horas de exceso",
+    "overBucket": "SALDO EXCEDIDO",
+    "usedHours": "{{hours}} h usadas",
+    "leftHours": "{{hours}} h disponibles",
+    "overHours": "{{hours}} h DE MÁS"
   },
   "messages": {
     "noInvoices": "No se encontraron facturas",
@@ -335,6 +342,25 @@
     "availableCredit": "Crédito disponible",
     "appliedAutomatically": "Se aplica automáticamente a su próxima factura.",
     "credit": "Crédito",
-    "expires": "Vence el {{date}}"
+    "expires": "Vence el {{date}}",
+    "history": {
+      "viewHistory": "Ver historial",
+      "title": "Historial de crédito",
+      "empty": "Aún no hay actividad de crédito",
+      "issued": "Emitido",
+      "issuedWithInvoice": "Emitido — prepago n.º {{invoice}}",
+      "issuedFromCreditNote": "Emitido desde nota de crédito",
+      "applied": "Aplicado",
+      "appliedToInvoice": "Aplicado a la factura n.º {{invoice}}",
+      "adjusted": "Ajustado",
+      "expired": "Caducado",
+      "transferred": "Transferido",
+      "transaction": "Actividad de crédito",
+      "balance": "saldo {{amount}}"
+    }
+  },
+  "dashboard": {
+    "prepaidHours": "Horas prepagadas",
+    "viewBilling": "Ver facturación"
   }
 }

--- a/server/public/locales/es/features/billing.json
+++ b/server/public/locales/es/features/billing.json
@@ -349,6 +349,7 @@
       "empty": "Aún no hay actividad de crédito",
       "issued": "Emitido",
       "issuedWithInvoice": "Emitido — prepago n.º {{invoice}}",
+      "issuedForInvoice": "Emitido — factura n.º {{invoice}}",
       "issuedFromCreditNote": "Emitido desde nota de crédito",
       "applied": "Aplicado",
       "appliedToInvoice": "Aplicado a la factura n.º {{invoice}}",

--- a/server/public/locales/fr/features/billing.json
+++ b/server/public/locales/fr/features/billing.json
@@ -349,6 +349,7 @@
       "empty": "Aucune activité de crédit pour le moment",
       "issued": "Émis",
       "issuedWithInvoice": "Émis — prépaiement n°{{invoice}}",
+      "issuedForInvoice": "Émis — facture n°{{invoice}}",
       "issuedFromCreditNote": "Émis à partir d'une note de crédit",
       "applied": "Appliqué",
       "appliedToInvoice": "Appliqué à la facture n°{{invoice}}",

--- a/server/public/locales/fr/features/billing.json
+++ b/server/public/locales/fr/features/billing.json
@@ -122,7 +122,14 @@
     "usage": "Utilisation",
     "overage": "Dépassement",
     "noContractLineTitle": "Aucune banque d'heures disponible",
-    "noContractLineDescription": "Aucun forfait d'heures actif pour votre compte."
+    "noContractLineDescription": "Aucun forfait d'heures actif pour votre compte.",
+    "remainingSummary": "Il reste {{remaining}} heures sur {{total}}",
+    "remainingSummaryWithRollover": "Il reste {{remaining}} heures sur {{total}} (dont {{rollover}} reportées)",
+    "overageSummary": "{{hours}} heures de dépassement",
+    "overBucket": "QUOTA DÉPASSÉ",
+    "usedHours": "{{hours}} h utilisées",
+    "leftHours": "{{hours}} h restantes",
+    "overHours": "{{hours}} h EN EXCÈS"
   },
   "messages": {
     "noInvoices": "Aucune facture trouvée",
@@ -335,6 +342,25 @@
     "availableCredit": "Crédit disponible",
     "appliedAutomatically": "Appliqué automatiquement à votre prochaine facture.",
     "credit": "Crédit",
-    "expires": "Expire le {{date}}"
+    "expires": "Expire le {{date}}",
+    "history": {
+      "viewHistory": "Voir l'historique",
+      "title": "Historique des crédits",
+      "empty": "Aucune activité de crédit pour le moment",
+      "issued": "Émis",
+      "issuedWithInvoice": "Émis — prépaiement n°{{invoice}}",
+      "issuedFromCreditNote": "Émis à partir d'une note de crédit",
+      "applied": "Appliqué",
+      "appliedToInvoice": "Appliqué à la facture n°{{invoice}}",
+      "adjusted": "Ajusté",
+      "expired": "Expiré",
+      "transferred": "Transféré",
+      "transaction": "Activité de crédit",
+      "balance": "solde {{amount}}"
+    }
+  },
+  "dashboard": {
+    "prepaidHours": "Heures prépayées",
+    "viewBilling": "Voir la facturation"
   }
 }

--- a/server/public/locales/it/features/billing.json
+++ b/server/public/locales/it/features/billing.json
@@ -349,6 +349,7 @@
       "empty": "Nessuna attività di credito per ora",
       "issued": "Erogato",
       "issuedWithInvoice": "Erogato — pagamento anticipato n. {{invoice}}",
+      "issuedForInvoice": "Erogato — fattura n. {{invoice}}",
       "issuedFromCreditNote": "Erogato da nota di credito",
       "applied": "Applicato",
       "appliedToInvoice": "Applicato alla fattura n. {{invoice}}",

--- a/server/public/locales/it/features/billing.json
+++ b/server/public/locales/it/features/billing.json
@@ -122,7 +122,14 @@
     "usage": "Utilizzo",
     "overage": "Eccedenza",
     "noContractLineTitle": "Nessun piano ore disponibile",
-    "noContractLineDescription": "Non ci sono piani ore attivi per il tuo account."
+    "noContractLineDescription": "Non ci sono piani ore attivi per il tuo account.",
+    "remainingSummary": "Restano {{remaining}} ore su {{total}}",
+    "remainingSummaryWithRollover": "Restano {{remaining}} ore su {{total}} (incl. {{rollover}} di riporto)",
+    "overageSummary": "{{hours}} ore di eccedenza",
+    "overBucket": "QUOTA SUPERATA",
+    "usedHours": "{{hours}} h usate",
+    "leftHours": "{{hours}} h rimanenti",
+    "overHours": "{{hours}} h IN ECCESSO"
   },
   "messages": {
     "noInvoices": "Nessuna fattura trovata",
@@ -335,6 +342,25 @@
     "availableCredit": "Credito disponibile",
     "appliedAutomatically": "Applicato automaticamente alla prossima fattura.",
     "credit": "Credito",
-    "expires": "Scade il {{date}}"
+    "expires": "Scade il {{date}}",
+    "history": {
+      "viewHistory": "Visualizza cronologia",
+      "title": "Cronologia crediti",
+      "empty": "Nessuna attività di credito per ora",
+      "issued": "Erogato",
+      "issuedWithInvoice": "Erogato — pagamento anticipato n. {{invoice}}",
+      "issuedFromCreditNote": "Erogato da nota di credito",
+      "applied": "Applicato",
+      "appliedToInvoice": "Applicato alla fattura n. {{invoice}}",
+      "adjusted": "Modificato",
+      "expired": "Scaduto",
+      "transferred": "Trasferito",
+      "transaction": "Attività di credito",
+      "balance": "saldo {{amount}}"
+    }
+  },
+  "dashboard": {
+    "prepaidHours": "Ore prepagate",
+    "viewBilling": "Vai alla fatturazione"
   }
 }

--- a/server/public/locales/nl/features/billing.json
+++ b/server/public/locales/nl/features/billing.json
@@ -349,6 +349,7 @@
       "empty": "Nog geen kredietactiviteit",
       "issued": "Uitgegeven",
       "issuedWithInvoice": "Uitgegeven — vooruitbetaling #{{invoice}}",
+      "issuedForInvoice": "Uitgegeven — factuur #{{invoice}}",
       "issuedFromCreditNote": "Uitgegeven via creditnota",
       "applied": "Toegepast",
       "appliedToInvoice": "Toegepast op factuur #{{invoice}}",

--- a/server/public/locales/nl/features/billing.json
+++ b/server/public/locales/nl/features/billing.json
@@ -122,7 +122,14 @@
     "usage": "Verbruik",
     "overage": "Overschrijding",
     "noContractLineTitle": "Geen urenbundels beschikbaar",
-    "noContractLineDescription": "Er zijn geen actieve urenbundels voor uw account."
+    "noContractLineDescription": "Er zijn geen actieve urenbundels voor uw account.",
+    "remainingSummary": "{{remaining}} uur resterend van {{total}}",
+    "remainingSummaryWithRollover": "{{remaining}} uur resterend van {{total}} (incl. {{rollover}} overgedragen)",
+    "overageSummary": "{{hours}} uur te veel",
+    "overBucket": "BUDGET OVERSCHREDEN",
+    "usedHours": "{{hours}} u verbruikt",
+    "leftHours": "{{hours}} u resterend",
+    "overHours": "{{hours}} u TE VEEL"
   },
   "messages": {
     "noInvoices": "Geen facturen gevonden",
@@ -335,6 +342,25 @@
     "availableCredit": "Beschikbaar krediet",
     "appliedAutomatically": "Wordt automatisch verrekend met uw volgende factuur.",
     "credit": "Krediet",
-    "expires": "Verloopt op {{date}}"
+    "expires": "Verloopt op {{date}}",
+    "history": {
+      "viewHistory": "Geschiedenis weergeven",
+      "title": "Kredietgeschiedenis",
+      "empty": "Nog geen kredietactiviteit",
+      "issued": "Uitgegeven",
+      "issuedWithInvoice": "Uitgegeven — vooruitbetaling #{{invoice}}",
+      "issuedFromCreditNote": "Uitgegeven via creditnota",
+      "applied": "Toegepast",
+      "appliedToInvoice": "Toegepast op factuur #{{invoice}}",
+      "adjusted": "Aangepast",
+      "expired": "Verlopen",
+      "transferred": "Overgedragen",
+      "transaction": "Kredietactiviteit",
+      "balance": "saldo {{amount}}"
+    }
+  },
+  "dashboard": {
+    "prepaidHours": "Vooruitbetaalde uren",
+    "viewBilling": "Facturatie bekijken"
   }
 }

--- a/server/public/locales/pl/features/billing.json
+++ b/server/public/locales/pl/features/billing.json
@@ -122,7 +122,14 @@
     "usage": "Wykorzystanie",
     "overage": "Nadwyżka",
     "noContractLineTitle": "Brak dostępnych linii umowy z pakietem godzin",
-    "noContractLineDescription": "Brak aktywnych linii umowy z pakietem godzin dla tego konta."
+    "noContractLineDescription": "Brak aktywnych linii umowy z pakietem godzin dla tego konta.",
+    "remainingSummary": "Pozostało {{remaining}} z {{total}} godzin",
+    "remainingSummaryWithRollover": "Pozostało {{remaining}} z {{total}} godzin (w tym {{rollover}} przeniesionych)",
+    "overageSummary": "{{hours}} godzin ponad limit",
+    "overBucket": "LIMIT PRZEKROCZONY",
+    "usedHours": "{{hours}} h wykorzystano",
+    "leftHours": "{{hours}} h pozostało",
+    "overHours": "{{hours}} h PONAD LIMIT"
   },
   "messages": {
     "noInvoices": "Brak faktur",
@@ -335,6 +342,25 @@
     "availableCredit": "Dostępny kredyt",
     "appliedAutomatically": "Zostanie automatycznie zastosowany do następnej faktury.",
     "credit": "Kredyt",
-    "expires": "Wygasa {{date}}"
+    "expires": "Wygasa {{date}}",
+    "history": {
+      "viewHistory": "Zobacz historię",
+      "title": "Historia kredytu",
+      "empty": "Brak aktywności kredytu",
+      "issued": "Przyznano",
+      "issuedWithInvoice": "Przyznano — przedpłata #{{invoice}}",
+      "issuedFromCreditNote": "Przyznano z noty kredytowej",
+      "applied": "Zastosowano",
+      "appliedToInvoice": "Zastosowano do faktury #{{invoice}}",
+      "adjusted": "Skorygowano",
+      "expired": "Wygasło",
+      "transferred": "Przeniesiono",
+      "transaction": "Aktywność kredytu",
+      "balance": "saldo {{amount}}"
+    }
+  },
+  "dashboard": {
+    "prepaidHours": "Godziny przedpłacone",
+    "viewBilling": "Przejdź do rozliczeń"
   }
 }

--- a/server/public/locales/pl/features/billing.json
+++ b/server/public/locales/pl/features/billing.json
@@ -349,6 +349,7 @@
       "empty": "Brak aktywności kredytu",
       "issued": "Przyznano",
       "issuedWithInvoice": "Przyznano — przedpłata #{{invoice}}",
+      "issuedForInvoice": "Przyznano — faktura #{{invoice}}",
       "issuedFromCreditNote": "Przyznano z noty kredytowej",
       "applied": "Zastosowano",
       "appliedToInvoice": "Zastosowano do faktury #{{invoice}}",

--- a/server/public/locales/pt/features/billing.json
+++ b/server/public/locales/pt/features/billing.json
@@ -122,7 +122,14 @@
     "usage": "Uso",
     "overage": "Excedente",
     "noContractLineTitle": "Nenhuma linha de contrato bucket disponível",
-    "noContractLineDescription": "Não há linhas de contrato de intervalo ativas para sua conta."
+    "noContractLineDescription": "Não há linhas de contrato de intervalo ativas para sua conta.",
+    "remainingSummary": "Restam {{remaining}} horas de {{total}}",
+    "remainingSummaryWithRollover": "Restam {{remaining}} horas de {{total}} (incl. {{rollover}} de remanescente)",
+    "overageSummary": "{{hours}} horas acima do limite",
+    "overBucket": "LIMITE EXCEDIDO",
+    "usedHours": "{{hours}} h utilizadas",
+    "leftHours": "{{hours}} h restantes",
+    "overHours": "{{hours}} h ACIMA"
   },
   "messages": {
     "noInvoices": "Nenhuma fatura encontrada",
@@ -335,6 +342,25 @@
     "availableCredit": "Crédito disponível",
     "appliedAutomatically": "Aplicado automaticamente à sua próxima fatura.",
     "credit": "Crédito",
-    "expires": "Expira em {{date}}"
+    "expires": "Expira em {{date}}",
+    "history": {
+      "viewHistory": "Ver histórico",
+      "title": "Histórico de créditos",
+      "empty": "Ainda não há atividade de crédito",
+      "issued": "Emitido",
+      "issuedWithInvoice": "Emitido — pré-pagamento n.º {{invoice}}",
+      "issuedFromCreditNote": "Emitido a partir de nota de crédito",
+      "applied": "Aplicado",
+      "appliedToInvoice": "Aplicado à fatura n.º {{invoice}}",
+      "adjusted": "Ajustado",
+      "expired": "Expirado",
+      "transferred": "Transferido",
+      "transaction": "Atividade de crédito",
+      "balance": "saldo {{amount}}"
+    }
+  },
+  "dashboard": {
+    "prepaidHours": "Horas pré-pagas",
+    "viewBilling": "Ver faturação"
   }
 }

--- a/server/public/locales/pt/features/billing.json
+++ b/server/public/locales/pt/features/billing.json
@@ -349,6 +349,7 @@
       "empty": "Ainda não há atividade de crédito",
       "issued": "Emitido",
       "issuedWithInvoice": "Emitido — pré-pagamento n.º {{invoice}}",
+      "issuedForInvoice": "Emitido — fatura n.º {{invoice}}",
       "issuedFromCreditNote": "Emitido a partir de nota de crédito",
       "applied": "Aplicado",
       "appliedToInvoice": "Aplicado à fatura n.º {{invoice}}",

--- a/server/public/locales/xx/features/billing.json
+++ b/server/public/locales/xx/features/billing.json
@@ -122,7 +122,14 @@
     "usage": "11111",
     "overage": "11111",
     "noContractLineTitle": "11111",
-    "noContractLineDescription": "11111"
+    "noContractLineDescription": "11111",
+    "remainingSummary": "11111 {{remaining}} 11111 {{total}} 11111",
+    "remainingSummaryWithRollover": "11111 {{remaining}} 11111 {{total}} 11111 {{rollover}} 11111",
+    "overageSummary": "11111 {{hours}} 11111",
+    "overBucket": "11111",
+    "usedHours": "11111 {{hours}} 11111",
+    "leftHours": "11111 {{hours}} 11111",
+    "overHours": "11111 {{hours}} 11111"
   },
   "messages": {
     "noInvoices": "11111",
@@ -335,6 +342,25 @@
     "availableCredit": "11111",
     "appliedAutomatically": "11111",
     "credit": "11111",
-    "expires": "11111 {{date}} 11111"
+    "expires": "11111 {{date}} 11111",
+    "history": {
+      "viewHistory": "11111",
+      "title": "11111",
+      "empty": "11111",
+      "issued": "11111",
+      "issuedWithInvoice": "11111 {{invoice}} 11111",
+      "issuedFromCreditNote": "11111",
+      "applied": "11111",
+      "appliedToInvoice": "11111 {{invoice}} 11111",
+      "adjusted": "11111",
+      "expired": "11111",
+      "transferred": "11111",
+      "transaction": "11111",
+      "balance": "11111 {{amount}} 11111"
+    }
+  },
+  "dashboard": {
+    "prepaidHours": "11111",
+    "viewBilling": "11111"
   }
 }

--- a/server/public/locales/xx/features/billing.json
+++ b/server/public/locales/xx/features/billing.json
@@ -349,6 +349,7 @@
       "empty": "11111",
       "issued": "11111",
       "issuedWithInvoice": "11111 {{invoice}} 11111",
+      "issuedForInvoice": "11111 {{invoice}} 11111",
       "issuedFromCreditNote": "11111",
       "applied": "11111",
       "appliedToInvoice": "11111 {{invoice}} 11111",

--- a/server/public/locales/yy/features/billing.json
+++ b/server/public/locales/yy/features/billing.json
@@ -349,6 +349,7 @@
       "empty": "55555",
       "issued": "55555",
       "issuedWithInvoice": "55555 {{invoice}} 55555",
+      "issuedForInvoice": "55555 {{invoice}} 55555",
       "issuedFromCreditNote": "55555",
       "applied": "55555",
       "appliedToInvoice": "55555 {{invoice}} 55555",

--- a/server/public/locales/yy/features/billing.json
+++ b/server/public/locales/yy/features/billing.json
@@ -122,7 +122,14 @@
     "usage": "55555",
     "overage": "55555",
     "noContractLineTitle": "55555",
-    "noContractLineDescription": "55555"
+    "noContractLineDescription": "55555",
+    "remainingSummary": "55555 {{remaining}} 55555 {{total}} 55555",
+    "remainingSummaryWithRollover": "55555 {{remaining}} 55555 {{total}} 55555 {{rollover}} 55555",
+    "overageSummary": "55555 {{hours}} 55555",
+    "overBucket": "55555",
+    "usedHours": "55555 {{hours}} 55555",
+    "leftHours": "55555 {{hours}} 55555",
+    "overHours": "55555 {{hours}} 55555"
   },
   "messages": {
     "noInvoices": "55555",
@@ -335,6 +342,25 @@
     "availableCredit": "55555",
     "appliedAutomatically": "55555",
     "credit": "55555",
-    "expires": "55555 {{date}} 55555"
+    "expires": "55555 {{date}} 55555",
+    "history": {
+      "viewHistory": "55555",
+      "title": "55555",
+      "empty": "55555",
+      "issued": "55555",
+      "issuedWithInvoice": "55555 {{invoice}} 55555",
+      "issuedFromCreditNote": "55555",
+      "applied": "55555",
+      "appliedToInvoice": "55555 {{invoice}} 55555",
+      "adjusted": "55555",
+      "expired": "55555",
+      "transferred": "55555",
+      "transaction": "55555",
+      "balance": "55555 {{amount}} 55555"
+    }
+  },
+  "dashboard": {
+    "prepaidHours": "55555",
+    "viewBilling": "55555"
   }
 }


### PR DESCRIPTION
## 29.8.21 — Client portal: prepaid balance & hours visibility

Surfaces prepaid balance and remaining-hours information to client-portal users: a dashboard "Prepaid hours" widget, a remaining-first bucket usage meter on the Billing overview, and a credit issuance/application history dialog on the Available Credit card. All new UI is gated behind the `release-v1.5-feature` flag; with the flag off the existing UI and behavior are preserved.

### What changed

**Dashboard**
- New `PrepaidHoursCard` widget (`packages/client-portal/src/components/dashboard/PrepaidHoursCard.tsx`): one mini remaining-hours meter per bucket line, with a "View billing" link. Renders nothing unless the flag is on, the portal user has billing access, and there is at least one bucket line (a permission error from the bucket action is also treated as "render nothing"). Wired into `ClientDashboard`.

**Billing overview**
- `BucketUsageChart` reworked to a remaining-first headline ("X hours left of Y incl. rollover"), a period chip, and a red "N hours over" state instead of a negative number. The overage bar is clamped to stay fully inside the meter track.
- `CreditsSummaryCard` gains a "View history" affordance that opens a ledger-style dialog: newest-first rows with signed amounts and running balance (`balance_after`). `credit_issuance` / `credit_issuance_from_negative_invoice` rows render their invoice provenance via `credits.history.issuedForInvoice`, matching how production prepayment finalization records credit issuance.

**Shared meter math**
- New `bucketUsageMeter.ts` helper centralizes remaining-hours math (`remaining = total + rollover − used`, mirroring `getRemainingBucketUnits` in `packages/reporting`), hour formatting, and threshold-based meter colors, shared by the Billing meter and the dashboard widget.

**Server actions**
- `client-billing.ts`: new `getClientCreditHistory` action returning a ledger of credit transactions with running balances, scoped by client-portal billing permission.
- `client-billing-metrics.ts` updated for the remaining-hours/period display.

**i18n**
- New `features/billing` keys (credit history, remaining hours, period, overage) added across all 10 locales.

**Tests**
- Contract tests for `PrepaidHoursCard`, `BucketUsageChart`, `CreditsSummaryCard`, and `ClientDashboard`; action tests for credit history, bucket periods, and billing-metrics permissions (including the credit-issuance provenance contract).

### Smoke test — PASS (feature as implemented)

Live flows exercised on the real Next/Postgres stack at localhost:3683 (no simulator or mock):
- **Flag off:** Dashboard had no Prepaid hours card; Billing retained the legacy meter and no View history control. Reconfirmed with populated credit/rollover data.
- **Flag on:** Dashboard displayed prepaid hours and linked to Billing.
- **Dirty-data overage:** 2513% usage rendered "48.3 hours over"; measured bar segments were 3.97931% + 96.0207%, fully contained inside the track.
- **Positive rollover:** displayed "2.5 hours left of 3.0 (incl. 1.0 rollover)," the 8/1–9/1 period, 0.5h used, and 2.5h left.
- **Credit history:** Available Credit showed $75.00; the dialog rendered newest-first −$50 applied to INV-000001 and +$125 issued entries with running balances.

**Fidelity / setup**
- No simulator or mock used.
- Credit and bucket prerequisites were temporarily DB-seeded. The real MSP Prepayment flow was attempted first but failed because the wired schema lacks `invoices.credit_expiration_date`; it created no data.
- Ozma's documented password had drifted, so it was temporarily reset. An active shared custom-domain record also had to be disabled for localhost login.
- The requested card-scoped tab creation returned a pane owned by another host, so testing used the existing browser pane in the same card workspace.

**Concerns**
- Prepayment invoice creation currently returns HTTP 500 due to the `invoices.credit_expiration_date` schema drift above.
- The legacy flag-off meter shifts 8/1–9/1 dates to 7/31–8/31; the new flag-on chip is correct. This appears pre-existing.
- One initial Billing server-action POST returned 500, although all target actions subsequently returned successfully and the complete UI loaded.
- The no-billing-permission identity path was not exercised because no working restricted portal credential was available.

**Cleanup completed:** forced flags removed, service restarted and answering HTTP 307 from this worktree, bucket/history/password changes restored, smoke transactions removed, and domain status restored. The pre-existing `package-lock.json` modification was untouched.

**Evidence:** `/tmp/alga-smoke-evidence/client-portal-prepaid-balance-20260811-180223`

