### PR TITLE
Fix custom client portal root 404 after successful login

### DIFF
--- a/docs/plans/2026-08-11-client-portal-root-404-plan.md
+++ b/docs/plans/2026-08-11-client-portal-root-404-plan.md
@@ -1,0 +1,53 @@
+# Client portal root 404 implementation plan
+
+## Problem
+
+A registered vanity portal host resolves `/` to `/client-portal`, and the sign-in/handoff flow is allowed to preserve that path. The protected client portal has a shared layout and a dashboard page at `/client-portal/dashboard`, but no page at the exact `/client-portal` route. After a successful domain-session exchange, an authenticated request to the preserved root therefore reaches a real 404.
+
+The current code confirms the split:
+
+- `server/src/lib/deployment/rootRedirect.ts` returns `/client-portal` for a matching portal-domain row.
+- `server/src/app/route.tsx` redirects the request to that result.
+- `server/src/app/client-portal/dashboard/page.tsx` is the dashboard implementation.
+- `server/src/app/client-portal/page.tsx` does not exist.
+- The domain-session route safely accepts relative client-portal return paths and defaults to `/client-portal/dashboard`; changing its session or OTT behavior is unnecessary.
+
+## Design
+
+1. Normalize vanity-host root resolution to the real dashboard route.
+   - Change `RootRedirectTarget` and the matching-portal-domain result in `server/src/lib/deployment/rootRedirect.ts` from `/client-portal` to `/client-portal/dashboard`.
+   - Preserve the canonical-host result (`/msp/dashboard`), unknown-host fallback, lookup failure behavior, and non-standard-port candidate ordering.
+
+2. Make the exact client-portal root a durable authenticated alias.
+   - Add `server/src/app/client-portal/page.tsx` as a server route that redirects to `/client-portal/dashboard` with Next's `redirect()` primitive.
+   - This is defense in depth for preserved callbacks, bookmarks, and direct authenticated requests. It reuses the existing client-portal layout/auth boundary and dashboard implementation rather than duplicating UI or data loading.
+
+3. Leave the established auth/session handoff contract alone.
+   - Do not change domain-session OTT creation, cookie issuance, vanity-host preservation, general relative return-path support, or middleware user-type checks.
+   - The exact-root alias makes an already-preserved `/client-portal` safe, while new vanity-root journeys are normalized earlier by the resolver.
+
+## Behavioral tests
+
+- Update `server/src/test/unit/rootRedirect.test.ts` so matching portal-domain cases, including canonical-host-unavailable and non-standard-port lookup cases, expect `/client-portal/dashboard`.
+- Add a runtime unit test for the new exact-root page: invoke the page with `next/navigation.redirect` mocked and assert it redirects to `/client-portal/dashboard`. Do not use a source-string/import-presence assertion.
+- Keep and run the existing unknown-host, canonical-host, lookup-failure, domain-session, and vanity-middleware suites to guard unchanged behavior.
+- Run the focused Vitest suites plus the relevant server typecheck/build target. Hocuspocus-only failures remain non-blocking per standing order.
+
+## Smoke coverage
+
+- Vanity host `/` completes canonical sign-in/domain-session exchange and lands on the same vanity host at `/client-portal/dashboard` without a 404.
+- An authenticated direct request to `/client-portal` redirects to `/client-portal/dashboard`.
+- Canonical application `/` still redirects to `/msp/dashboard`.
+- An unknown host retains the MSP-dashboard fallback.
+
+## Deliberate non-goals
+
+- Do not commit, attach, or inspect the credential-bearing customer HAR beyond the already-redacted card description.
+- Do not address the separately reported password-reset email/log issue.
+- Do not redesign the client portal, duplicate the dashboard component, broaden accepted return URLs, or change session/OTT security behavior.
+- No `release-v1.5-feature` gate is needed because this is route correction with no new or changed UI.
+
+## Risks and handling
+
+- The worktree currently has an unrelated `package-lock.json` diff produced during environment wiring. Do not include it in the plan commit or implementation unless the implementation step proves it is required.
+- Redirect behavior can be obscured by middleware or auth state, so tests must exercise the resolver and page redirect as runtime functions, and smoke must cover both authenticated direct-root and full vanity-domain login flows.

--- a/server/src/app/client-portal/page.tsx
+++ b/server/src/app/client-portal/page.tsx
@@ -1,0 +1,5 @@
+import { redirect } from 'next/navigation';
+
+export default function ClientPortalPage() {
+  redirect('/client-portal/dashboard');
+}

--- a/server/src/lib/deployment/rootRedirect.ts
+++ b/server/src/lib/deployment/rootRedirect.ts
@@ -1,6 +1,6 @@
 import logger from '@alga-psa/core/logger';
 
-export type RootRedirectTarget = '/client-portal' | '/msp/dashboard';
+export type RootRedirectTarget = '/client-portal/dashboard' | '/msp/dashboard';
 
 export async function resolveRootRedirect(args: {
   hostname: string;
@@ -23,7 +23,7 @@ export async function resolveRootRedirect(args: {
   try {
     for (const candidate of hostCandidates) {
       if (await lookupPortalDomain(candidate)) {
-        return '/client-portal';
+        return '/client-portal/dashboard';
       }
     }
   } catch (error) {

--- a/server/src/lib/productSurfaceRegistry.ts
+++ b/server/src/lib/productSurfaceRegistry.ts
@@ -89,6 +89,11 @@ export const MSP_ROUTE_RULES: readonly RouteRule[] = [
 
 export const PORTAL_ROUTE_RULES: readonly RouteRule[] = [
   {
+    group: 'portal_helpdesk_root_alias',
+    dynamicPatterns: [/^\/client-portal$/],
+    behaviorByProduct: { psa: 'allowed', algadesk: 'allowed' },
+  },
+  {
     group: 'portal_helpdesk',
     staticPrefixes: ['/client-portal/dashboard', '/client-portal/tickets', '/client-portal/knowledge-base', '/client-portal/profile', '/client-portal/client-settings'],
     behaviorByProduct: { psa: 'allowed', algadesk: 'allowed' },
@@ -256,7 +261,8 @@ export function resolveProductRouteBehavior(productCode: ProductCode, pathname: 
     return getAllowedSettingsTabIds(productCode).has(settingsSegment) ? 'allowed' : 'not_found';
   }
 
-  const rules = pathname.startsWith('/client-portal/') ? PORTAL_ROUTE_RULES : MSP_ROUTE_RULES;
+  const rules =
+    pathname === '/client-portal' || pathname.startsWith('/client-portal/') ? PORTAL_ROUTE_RULES : MSP_ROUTE_RULES;
   const matched = rules.find((rule) => matchesRule(pathname, rule));
   if (!matched) {
     return productCode === 'algadesk' ? 'not_found' : 'allowed';

--- a/server/src/test/unit/app/client-portal/page.test.ts
+++ b/server/src/test/unit/app/client-portal/page.test.ts
@@ -1,0 +1,21 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const redirectMock = vi.fn();
+
+vi.mock('next/navigation', () => ({
+  redirect: redirectMock,
+}));
+
+const { default: ClientPortalPage } = await import('server/src/app/client-portal/page');
+
+describe('client-portal root page', () => {
+  beforeEach(() => {
+    redirectMock.mockReset();
+  });
+
+  it('redirects to the client portal dashboard', async () => {
+    await ClientPortalPage();
+
+    expect(redirectMock).toHaveBeenCalledWith('/client-portal/dashboard');
+  });
+});

--- a/server/src/test/unit/app/rootRoute.test.ts
+++ b/server/src/test/unit/app/rootRoute.test.ts
@@ -41,12 +41,12 @@ describe('root route', () => {
     getAdminConnectionMock.mockResolvedValue({ connection: 'admin' });
   });
 
-  it('redirects a registered portal-domain host to the client portal', async () => {
+  it('redirects a registered portal-domain host to the client portal dashboard', async () => {
     getPortalDomainByHostnameMock.mockResolvedValue({ id: 'portal-domain-1' });
 
     await GET();
 
-    expect(redirectMock).toHaveBeenCalledWith('/client-portal');
+    expect(redirectMock).toHaveBeenCalledWith('/client-portal/dashboard');
     expect(getAdminConnectionMock).toHaveBeenCalledOnce();
     expect(getPortalDomainByHostnameMock).toHaveBeenCalledWith(
       { connection: 'admin' },

--- a/server/src/test/unit/product/routeRegistryFilesystemInventory.contract.test.ts
+++ b/server/src/test/unit/product/routeRegistryFilesystemInventory.contract.test.ts
@@ -82,6 +82,8 @@ describe('route registry filesystem inventory', () => {
   // Client-portal pages riding the portal fallback (psa: allowed,
   // algadesk: not_found) — same reporting contract as KNOWN_UNRULED_ROUTES.
   const KNOWN_UNRULED_PORTAL_ROUTES: Record<string, string> = {
+    '/client-portal':
+      'REPORTED: pure redirect alias to /client-portal/dashboard (no content); rides the fallback exactly like its ruled dashboard target (portal_helpdesk)',
     '/client-portal/account':
       'REPORTED: same class as the fixed /msp/account gap — portal account page rides the fallback (algadesk portal users get not_found)',
     '/client-portal/licenses':

--- a/server/src/test/unit/product/routeRegistryFilesystemInventory.contract.test.ts
+++ b/server/src/test/unit/product/routeRegistryFilesystemInventory.contract.test.ts
@@ -82,8 +82,6 @@ describe('route registry filesystem inventory', () => {
   // Client-portal pages riding the portal fallback (psa: allowed,
   // algadesk: not_found) — same reporting contract as KNOWN_UNRULED_ROUTES.
   const KNOWN_UNRULED_PORTAL_ROUTES: Record<string, string> = {
-    '/client-portal':
-      'REPORTED: pure redirect alias to /client-portal/dashboard (no content); rides the fallback exactly like its ruled dashboard target (portal_helpdesk)',
     '/client-portal/account':
       'REPORTED: same class as the fixed /msp/account gap — portal account page rides the fallback (algadesk portal users get not_found)',
     '/client-portal/licenses':

--- a/server/src/test/unit/productSurfaceRegistry.test.ts
+++ b/server/src/test/unit/productSurfaceRegistry.test.ts
@@ -25,6 +25,27 @@ describe('product surface registry', () => {
     expect(resolveProductRouteBehavior('algadesk', '/client-portal/billing')).toBe('upgrade_boundary');
   });
 
+  it('T003: exact /client-portal root resolves allowed like its dashboard target, never not_found', () => {
+    expect(resolveProductRouteBehavior('algadesk', '/client-portal')).toBe('allowed');
+    expect(resolveProductRouteBehavior('psa', '/client-portal')).toBe('allowed');
+  });
+
+  it('T003: exact /client-portal rule matches the root only and leaves child routes and boundaries untouched', () => {
+    expect(resolveProductRouteBehavior('algadesk', '/client-portal/dashboard')).toBe('allowed');
+    expect(resolveProductRouteBehavior('algadesk', '/client-portal/tickets')).toBe('allowed');
+    expect(resolveProductRouteBehavior('algadesk', '/client-portal/billing')).toBe('upgrade_boundary');
+    expect(resolveProductRouteBehavior('algadesk', '/client-portal/appointments')).toBe('upgrade_boundary');
+    expect(resolveProductRouteBehavior('algadesk', '/client-portal/settings')).toBe('not_found');
+    expect(resolveProductRouteBehavior('psa', '/client-portal/billing')).toBe('allowed');
+    expect(resolveProductRouteBehavior('psa', '/client-portal/settings')).toBe('allowed');
+
+    expect(resolveProductRouteBehavior('algadesk', '/client-portal/')).toBe('not_found');
+    expect(resolveProductRouteBehavior('algadesk', '/client-portalx')).toBe('not_found');
+
+    expect(resolveProductRouteBehavior('algadesk', '/msp/billing')).toBe('upgrade_boundary');
+    expect(resolveProductRouteBehavior('algadesk', '/msp/test/ui-kit')).toBe('not_found');
+  });
+
   it('T003: classifies representative API paths and fails closed for unknown API groups', () => {
     expect(resolveProductApiBehavior('algadesk', '/api/v1/tickets')).toBe('allowed');
     expect(resolveProductApiBehavior('algadesk', '/api/v1/clients')).toBe('allowed');

--- a/server/src/test/unit/rootRedirect.test.ts
+++ b/server/src/test/unit/rootRedirect.test.ts
@@ -19,7 +19,7 @@ describe('resolveRootRedirect', () => {
     expect(lookupPortalDomain).not.toHaveBeenCalled();
   });
 
-  it('returns the client portal for any matching portal-domain row', async () => {
+  it('returns the client portal dashboard for any matching portal-domain row', async () => {
     const lookupPortalDomain = vi.fn().mockResolvedValue({ status: 'disabled' });
 
     await expect(resolveRootRedirect({
@@ -27,7 +27,7 @@ describe('resolveRootRedirect', () => {
       hostHeader: 'portal.example.com',
       canonicalHostname: 'app.example.com',
       lookupPortalDomain,
-    })).resolves.toBe('/client-portal');
+    })).resolves.toBe('/client-portal/dashboard');
   });
 
   it('returns the MSP dashboard for an unknown host', async () => {
@@ -62,7 +62,7 @@ describe('resolveRootRedirect', () => {
       hostHeader: 'portal.example.com',
       canonicalHostname: null,
       lookupPortalDomain,
-    })).resolves.toBe('/client-portal');
+    })).resolves.toBe('/client-portal/dashboard');
     expect(lookupPortalDomain).toHaveBeenCalledWith('portal.example.com');
   });
 
@@ -76,7 +76,7 @@ describe('resolveRootRedirect', () => {
       hostHeader: 'portal.example.com:3553',
       canonicalHostname: 'app.example.com',
       lookupPortalDomain,
-    })).resolves.toBe('/client-portal');
+    })).resolves.toBe('/client-portal/dashboard');
     expect(lookupPortalDomain.mock.calls).toEqual([
       ['portal.example.com:3553'],
       ['portal.example.com'],


### PR DESCRIPTION
## Fix custom client portal root 404 after successful login

### Problem
On a registered vanity portal host, root resolution returned `/client-portal`, but the client-portal surface had **no exact-root page** — the authenticated dashboard lives only at `/client-portal/dashboard`. After a successful login handoff, a preserved `/client-portal` root therefore resolved to a real **404**. The product-surface route registry compounded this: rule selection only admitted `/client-portal/*` (trailing slash), so the exact `/client-portal` path fell through to the product fallback (`algadesk` → `not_found`).

### Fix
- **`server/src/lib/deployment/rootRedirect.ts`** — Portal-domain root resolution now normalizes matching vanity hosts directly to `/client-portal/dashboard` (the `RootRedirectTarget` type narrows accordingly). Canonical `/msp/dashboard`, the unknown-host fallback, and all domain-session/OTT security behavior are preserved.
- **`server/src/app/client-portal/page.tsx`** (new) — An exact `/client-portal` server component that `redirect()`s to `/client-portal/dashboard`, so any preserved post-handoff root callback lands on the dashboard instead of a 404.
- **`server/src/lib/productSurfaceRegistry.ts`** — Rule selection now admits the exact `/client-portal` path in addition to `/client-portal/*`, and a new `portal_helpdesk_root_alias` rule allows the exact root for both `psa` and `algadesk`. The rule uses an **anchored `dynamicPattern` (`^/client-portal$`)** rather than a `staticPrefix` — a prefix would treat children as matches too and shadow the `upgrade_boundary` decisions for `/client-portal/billing` and siblings.

### Tests
Unit coverage added/updated for the root-redirect target, the new exact-root page redirect, the registry exact-root alias rule, and the root-route behavior.

### Smoke test — PASS (one local-dev fidelity caveat)
Environment: real worktree server on port 3190 with the expected Docker services. Used an isolated client fixture temporarily switched to AlgaDesk and a registered `localtest.me` vanity domain.

Verified live:
- Vanity root normalized to `/client-portal/dashboard` and opened the canonical client sign-in UI.
- Real credential callback returned **200**; vanity domain-session exchange returned **200** and its OTT was confirmed consumed in PostgreSQL.
- Vanity session identified the correct client user with `product_code=algadesk`.
- Authenticated `GET /client-portal` returned **HTTP 200** at the exact URL with "Dashboard | Client Portal | AlgaPSA" metadata — no 404 / product boundary.
- Nearby `/client-portal/billing` still resolved as `upgrade_boundary`, proving the exact-root rule did not overmatch children.
- Canonical root remained a **307** to `/msp/dashboard` and displayed MSP sign-in.
- An unregistered host also remained a **307** to `/msp/dashboard`.

**Fidelity compromise:** `localtest.me` over HTTP plus a transparent `socat` canonical-origin proxy represented the appliance reverse-proxy topology. Next dev's custom-host HMR failed to hydrate vanity pages, leaving them at "Loading translations." I therefore invoked the handoff component's identical real `POST /api/client-portal/domain-session` from the handoff page; no API, auth, registry, database, or dashboard behavior was mocked. The fully rendered vanity dashboard body was not visually verified, but its authenticated document, title, HTTP status, session, and database state were verified.

**Cleanup completed:** temporary domain/OTTs removed, test password and product restored, `NEXTAUTH_URL` restored to `localhost:3190`, proxy stopped, and the card dev server restarted healthy. Only the pre-existing `package-lock.json` modification remains. The customer HAR was not accessed.

Evidence directory: `/tmp/alga-smoke-evidence/fix-client-portal-root-404-20260811-222505`
