### PR TITLE
29.8.46 — Configurable notification priorities

### DIFF
--- a/docs/plans/2026-08-11-notification-priorities-plan.md
+++ b/docs/plans/2026-08-11-notification-priorities-plan.md
@@ -1,0 +1,306 @@
+# Configurable notification priorities
+
+**Branch:** `feature/notification-priorities`
+**Date:** 2026-08-11
+**Status:** Design complete; no product or test code implemented
+**Source task:** 29.8.46 — Configurable notification priorities (release v1.5)
+
+## Outcome
+
+Give every in-app notification a priority — **high**, **normal**, or **low** —
+so the bell stops presenting a weekly digest and an exhausted-AI-credits alert
+as fourteen identical blue dots. Priority is configured per notification
+subtype in three layers: each subtype ships with a sensible system default,
+tenant admins can override it in the existing internal-notification settings
+screen, and each user can override it again for themselves in their profile's
+notification preferences — the user's choice always wins, because it is their
+attention being managed. The resolved priority (user ?? tenant ?? default) is
+stamped onto each notification at creation time and then drives three things
+in the MSP and client-portal UIs:
+
+1. **Badge counting** — the bell badge counts unread *high* notifications
+   only, in the muted attention-red used for the high tier. When no high
+   items are unread but normal/low unread exist, the bell shows a subtle
+   neutral dot instead of a number.
+2. **Panel sections** — the bell dropdown groups by tier: a "Needs attention"
+   section pinned on top (high), the normal stream in the middle, and low
+   items collapsed behind a "Low priority (n)" expander.
+3. **Filtering and visual weight elsewhere** — the full notifications list
+   (User Activities and the client-portal activity tab) gains a priority
+   filter and a per-row priority indicator while keeping chronological order.
+4. **A real "View all" destination** — the bell's "View all notifications"
+   deep-links into the User Activities screen's card view with the
+   notifications section shown in full: server-paged with numbered
+   pagination instead of today's 5-item cap. The deep link (and every
+   section's "View All" button) switches the view ephemerally — the user's
+   saved Cards/Table default only changes when they use the view switcher
+   explicitly.
+
+Mobile push carries the priority as **payload metadata only**: the Expo push
+`data` object gains a `priority` field so the mobile app can render and sort
+accordingly. Which templates push, and how loudly the OS delivers them, does
+not change in this card.
+
+All user-visible changes are gated behind the `release-v1.5-feature` feature
+flag. With the flag off, the badge, panel, settings screen, and activities
+list look and behave exactly as today. Schema changes, priority stamping, and
+push metadata are flag-independent because they are invisible to users.
+
+## Current state (verified in this worktree)
+
+- The in-app system rides on four tables from
+  `server/migrations/20251031160000_create_internal_notifications.cjs`:
+  `internal_notification_categories` and `internal_notification_subtypes`
+  (both global, not tenant-scoped), `internal_notification_templates`
+  (global, one row **per language** — unique on `name` + `language_code`,
+  FK to subtype), and `internal_notifications` (tenant-scoped instance rows
+  with a `type` enum `info|success|warning|error` but no priority).
+- Tenant-level overrides for enablement already exist:
+  `tenant_internal_notification_category_settings` and
+  `tenant_internal_notification_subtype_settings`
+  (`server/migrations/20251211120000_add_tenant_notification_settings.cjs`,
+  Citus-aware pattern).
+- Creation funnels through `createNotificationFromTemplateInternal` in
+  `packages/notifications/src/actions/internal-notification-actions/internalNotificationActions.ts`,
+  which loads the template, renders it, inserts the instance, broadcasts via
+  `packages/notifications/src/realtime/internalNotificationBroadcaster.ts`,
+  and runs post-creation hooks (push lives in a hook).
+- The bell UI is `packages/notifications/src/components/NotificationBell.tsx`
+  → `NotificationDropdown.tsx` → `NotificationItem.tsx`, mounted in
+  `server/src/components/layout/Header.tsx` and
+  `packages/client-portal/src/components/layout/ClientPortalTopBar.tsx`.
+- The "View all" experiences already synthesize a priority **derived from
+  `type`** in two duplicated mappers:
+  `packages/user-activities/…/activityAggregationActions.ts`
+  (error→HIGH, warning→MEDIUM, else LOW) and
+  `packages/client-portal/src/actions/client-portal-actions/notificationActivities.ts`.
+  This card replaces that derivation with the real stored priority.
+- Push is Expo-only: `server/src/lib/pushNotifications/expoPushService.ts`
+  (hardcodes Expo `priority: 'high'` for delivery — unrelated to this
+  feature and unchanged) behind a template-name allowlist in
+  `pushNotificationDispatcher.ts`.
+- Tenant admin settings screen:
+  `packages/notifications/src/components/settings/InternalNotificationCategories.tsx`
+  (per-category/per-subtype enable switches with batch save), mounted at
+  `server/src/app/msp/settings/notifications/page.tsx`.
+- The bell's "View all notifications" today lands on `/msp/user-activities`
+  bare. `UserActivitiesDashboard` renders whichever view mode the
+  `activitiesDashboardViewMode` user preference holds (default `table`);
+  the card view's `NotificationsSection` fetches, sorts, and slices to a
+  hard `limit={5}` with no paging; and every section's "View All" button
+  calls `setViewModePreference('table')` — silently rewriting the user's
+  saved default as a side effect of navigation.
+
+## Design decisions (settled in the design session)
+
+| Decision | Choice |
+| --- | --- |
+| Scale | 3 tiers: `high` / `normal` / `low` |
+| Attach point | Notification **subtype** (not per-language template rows, not per template name). MSP and client-portal variants of one event share a priority. |
+| Configuration | Three layers: system default per subtype → tenant admin override → per-user override; the user's setting always wins |
+| Badge | Count unread high only; color escalates when high present; dot (no number) when only normal/low unread |
+| Panel | Sections by tier: "Needs attention" (high) pinned top, normal stream, low collapsed behind an expander |
+| Full-page lists | Priority filter + per-row indicator, chronological order preserved |
+| "View all" flow | Bell deep-links to User Activities card view with the notifications card expanded in place (other sections collapsed below): flat chronological list, numbered server-side pagination, priority filter chips. Ephemeral — no view-mode preference write; all sections' "View All" buttons stop persisting the view mode. |
+| Notification card style | Squarer corners (~5px), no colored left rail; soft shadow treatment (high tier adds a muted attention-red ring, low renders dimmed) |
+| High-tier visual language | Muted "attention red" (desaturated, no tinted row background) for rails, pills, section header, and badge — attention-worthy, not emergency |
+| Mobile push | Priority included as payload metadata; no delivery gating, no OS-priority mapping |
+| Email notifications | Out of scope (separate `notification_*` system untouched) |
+| Feature flag | `release-v1.5-feature` gates every user-visible change |
+
+### Rejected alternatives
+
+- **Priority per template row or template name.** Template rows are language
+  variants (unique on `name` + `language_code`), so a column there duplicates
+  the value per locale; keying by template name would need a new
+  template-listing settings layer and diverge from how enable/disable
+  configuration works (category → subtype). The subtype is the unit admins
+  already manage and the unit the tenant-override tables already model.
+- **4-tier scale with Critical.** Three tiers cover the observed need
+  (badge-worthy / standard / quiet); a fourth tier adds vocabulary without a
+  distinct behavior.
+- **Priority-gated or OS-mapped push.** The card asks for priority to *reach*
+  mobile push; changing which notifications push or how the OS presents them
+  is a behavior change with its own risk surface, deferred deliberately.
+- **Caller-supplied priority.** `createNotificationFromTemplateInternal` will
+  not accept a priority from call sites; it is resolved from configuration
+  only. ~40 emit sites already pass ad-hoc `type` values — priority stays
+  centrally governed so configuration is authoritative.
+- **Admin-locked subtypes.** A per-subtype "enforced" flag letting tenant
+  admins pin priorities against user overrides was considered and rejected:
+  it adds schema and UI concepts for a policing need nobody has demonstrated,
+  and the user is the best judge of their own attention. Revisit only if
+  real tenants ask for it.
+
+## Data model
+
+One new migration (Citus-aware, following the
+`20251211120000_add_tenant_notification_settings.cjs` pattern):
+
+1. `internal_notification_subtypes.default_priority` — `text NOT NULL
+   DEFAULT 'normal'` with `CHECK (default_priority IN
+   ('high','normal','low'))`. Global table; plain column add.
+2. `tenant_internal_notification_subtype_settings.priority` — nullable
+   `text` with the same CHECK. `NULL` means "inherit the system default".
+   No new table: this is exactly the existing tenant-override row's job.
+3. `user_internal_notification_preferences.priority` — nullable `text` with
+   the same CHECK. `NULL` means "inherit tenant/default". Priority is only
+   meaningful on subtype-level rows (`subtype_id` set); category-level rows
+   (`subtype_id IS NULL`) keep priority `NULL` — the enable/disable
+   semantics of category rows are unchanged.
+4. `internal_notifications.priority` — `text NOT NULL DEFAULT 'normal'`
+   with the same CHECK, on the distributed table.
+5. **Seed defaults** (UPDATE by subtype name; everything not listed stays
+   `normal`):
+   - **High:** `sla-breach`, `sla-escalation`, `rmm-alert-triggered`,
+     `payment-overdue`, `system-announcement`, `project-budget-exceeded`
+   - **Low:** `opportunity-weekly-digest`, `milestone-completed`,
+     `sla-response-met`, `sla-resolution-met`
+6. **Backfill existing instance rows** from their subtype's default:
+   `UPDATE internal_notifications` joined through
+   `internal_notification_templates` on `template_name` (any language row —
+   all share the subtype) to `internal_notification_subtypes`. Rows whose
+   template name no longer resolves keep the column default `'normal'`.
+   Use the tenant-safe batch pattern if the table is large.
+
+`down()` drops the four columns.
+
+A CHECK-constrained text column is preferred over a Postgres enum to match
+the tenant-settings migration style and avoid enum-alteration friction later.
+
+## Server changes
+
+- **Types** (`packages/notifications/src/types/internalNotification.ts`):
+  add `InternalNotificationPriority = 'high' | 'normal' | 'low'`; add
+  `priority` to `InternalNotification`; extend the subtype/preference
+  interfaces with `default_priority` and the tenant override. Do **not**
+  add priority to `CreateInternalNotificationRequest`.
+- **Resolution at creation**: in `createNotificationFromTemplateInternal`,
+  resolve `user override ?? tenant override ?? subtype default ?? 'normal'`
+  (one joined query alongside the existing subtype/enablement lookup, which
+  already touches the user-preference and tenant-setting tables) and stamp
+  it on the inserted row. The instance row is per-user, so per-user
+  resolution needs no fan-out changes. Verify the broadcaster and the Hocuspocus
+  `NotificationExtension.js` mirror pass the new field through to the client
+  (they forward the notification object; confirm no field whitelisting).
+- **Read actions**: include `priority` in `getNotificationsAction` results;
+  extend the unread-count path so the bell can render without a second
+  round-trip — return `{ total, high }` (keep the existing action's return
+  shape backward-compatible or add a sibling action; prefer extending the
+  payload).
+- **Settings actions**: extend the internal category/subtype fetch action to
+  return `default_priority` plus the tenant's override, and extend the
+  subtype settings update path to accept `priority` (nullable = reset to
+  default). Same permissions as the existing settings screen. Extend the
+  user-preference fetch/update actions the same way so a user can read the
+  effective priority (their override, else tenant/default) and set or clear
+  their own on subtype rows.
+- **Paged notification activities**: extend the notification-activities
+  fetch in `packages/user-activities` (and its shared aggregation action)
+  to accept offset/limit and return a total count, so the full card view
+  can render numbered pagination server-side instead of slicing a
+  full fetch client-side.
+- **Activities mappers**: replace the two duplicated `type`→priority
+  derivations (`activityAggregationActions.ts`,
+  `notificationActivities.ts`) with the stored priority
+  (`high→ActivityPriority.HIGH`, `normal→MEDIUM`, `low→LOW`), keeping the
+  old derivation only as a fallback when `priority` is absent.
+- **Push metadata**: in `pushNotificationDispatcher.ts` /
+  `expoPushService.ts`, add the notification's priority to the Expo message
+  `data` payload. The `TICKET_PUSH_TEMPLATES` allowlist and Expo delivery
+  options are unchanged.
+
+## UI changes (all gated on `release-v1.5-feature`)
+
+Use the client-side feature-flag hook per
+`server/src/lib/feature-flags/README.md`; with the flag off every component
+renders exactly the current markup.
+
+- **`NotificationBell.tsx`** — flag on: badge number = unread high count,
+  red styling when > 0; when 0 high but total unread > 0, render a small
+  neutral dot instead of the numeric pill. Flag off: total-count badge as
+  today.
+- **`NotificationDropdown.tsx`** — flag on: three-part list — "Needs
+  attention (n)" header + high items pinned on top, normal items below,
+  low items collapsed behind a "Low priority (n)" expander (chronological
+  within each section; empty sections render nothing). "Mark all read",
+  refresh, and footer behavior unchanged and still act on all tiers.
+- **`NotificationItem.tsx` / `NotificationDetailView.tsx`** — flag on:
+  high rows get a muted attention-red left accent (no tinted background —
+  deliberately not emergency styling), low rows render dimmed. The `type` icon logic stays; priority styles the row, type
+  styles the icon. Keep UI copy saying "priority" distinct from the ticket
+  priority already rendered from `metadata.changes.priority`.
+- **`InternalNotificationCategories.tsx`** (tenant admin settings) — flag
+  on: add a priority `CustomSelect` (High / Normal / Low) to each subtype
+  row showing the effective value, participating in the existing
+  dirty-state batch save, with a "reset to default" affordance (shown when
+  a tenant override exists). Flag off: switches only, as today.
+- **`InternalNotificationPreferences.tsx`** (user profile, MSP and client
+  portal) — flag on: add the same priority `CustomSelect` to each subtype
+  row showing the effective value, with a "reset" affordance when a personal
+  override exists; writes to `user_internal_notification_preferences`. Flag
+  off: switches only, as today.
+- **User Activities** (`NotificationsSection.tsx`,
+  `NotificationSectionFiltersDialog.tsx`, `NotificationCard.tsx`) — flag
+  on: priority filter (All / High / Normal / Low) wired to the real stored
+  priority, plus a per-row priority indicator. Order stays chronological.
+- **"View all" flow** (flag on):
+  - The bell footer's "View all notifications" navigates to
+    `/msp/user-activities?focus=notifications`.
+  - `UserActivitiesDashboard` treats `focus=notifications` as an ephemeral
+    view override: render the card view with the notifications card
+    **expanded in place** to its full mode and the other dashboard
+    sections (Schedule, Tickets, Projects, Workflow Tasks) rendered
+    collapsed below it — still present and expandable, so the screen
+    stays the familiar dashboard. No call to `setViewModePreference`;
+    the Cards/Table switcher remains the only thing that writes the
+    saved preference.
+  - `NotificationsSection` full mode stays a single flat chronological
+    list — deliberately the closest shape to today's section — with
+    numbered server-side pagination (product-standard pager), the
+    existing Unread/All/Read tabs, and the priority filter chips
+    (All / High / Normal / Low). Priority shows on rows as accent, not
+    as grouping; the bell panel keeps the tiered layout, this page keeps
+    the stream. The dashboard's default card layout keeps the 5-item
+    preview.
+  - `NotificationCard` is restyled in the same pass: corner radius
+    reduced (~5px), the colored left rail removed, cards carried by a
+    soft shadow (no border); high-tier cards add a muted attention-red
+    ring to the shadow, low-tier cards render dimmed.
+  - `handleViewAll` in `UserActivitiesDashboard` stops persisting
+    `'table'` for **all** sections — every "View All" switches the view
+    ephemerally for the current visit only.
+  - Flag off: plain `/msp/user-activities` link, 5-item section, and
+    today's persist-on-View-All behavior are preserved.
+- **Client portal** (`ClientNotificationsList.tsx` and the bell in
+  `ClientPortalTopBar.tsx`) — same panel sectioning and indicators as MSP.
+- **i18n**: every new string (section headers, expander, filter labels,
+  settings labels, priority names) added to all supported locales
+  (en/fr/es/de/nl/it/pl/pt) — translation-quality checks are enforced in CI.
+
+## Testing
+
+- **Unit**: priority resolution (default only / tenant override / user
+  override beats tenant / missing subtype → normal); activities mapper
+  (stored priority wins, legacy fallback works).
+- **Migration**: backfill assigns subtype defaults to existing rows and
+  leaves unresolvable template names at `normal`.
+- **Action-level integration** (existing patterns): unread counts split by
+  tier; settings updates write and clear the tenant and user overrides;
+  created notifications carry the stamped, per-user-resolved priority.
+- **Component/flag**: bell and dropdown render current markup with the flag
+  off and the new sections/badge with the flag on (mock the flag hook);
+  dashboard honors `focus=notifications` without writing the view-mode
+  preference, and "View All" no longer persists the view mode when the
+  flag is on (still does when off).
+- Full click-through happens in the card's later Smoke Test step (dev
+  server on port 3729; `NEXT_PUBLIC_FORCE_FEATURE_FLAGS=release-v1.5-feature:true`
+  to force the flag on).
+
+## Out of scope
+
+- Email notification system (`notification_*` / `system_email_templates`).
+- Push delivery gating, Expo/OS delivery-priority mapping, Android channels,
+  and mobile-app rendering of the new metadata (mobile consumes the payload
+  field in its own release).
+- The EE platform-notification banner system (`platform_notifications`).

--- a/packages/client-portal/src/actions/client-portal-actions/notificationActivities.ts
+++ b/packages/client-portal/src/actions/client-portal-actions/notificationActivities.ts
@@ -10,7 +10,26 @@ import {
   NotificationActivity,
 } from '@alga-psa/types';
 
-function getNotificationPriority(type: string | null | undefined): ActivityPriority {
+// LEVERAGE: friction notification-priority-mapper — duplicated verbatim in
+// packages/user-activities/.../activityAggregationActions.ts. Kept local per the
+// task's "no drive-by refactors" scope; a shared @alga-psa/types helper is the
+// natural home if a third copy appears.
+//
+// Prefer the stored, configuration-resolved priority (high|normal|low) from
+// task 29.8.46; fall back to the legacy type→priority derivation only when it
+// is absent (rows created before the backfill).
+function getNotificationPriority(
+  storedPriority: string | null | undefined,
+  type: string | null | undefined
+): ActivityPriority {
+  switch (storedPriority) {
+    case 'high':
+      return ActivityPriority.HIGH;
+    case 'normal':
+      return ActivityPriority.MEDIUM;
+    case 'low':
+      return ActivityPriority.LOW;
+  }
   switch (type) {
     case 'error':
       return ActivityPriority.HIGH;
@@ -64,7 +83,7 @@ export const fetchNotificationActivities = withAuth(async (
       description: notification.message,
       type: ActivityType.NOTIFICATION,
       status: notification.type || 'info',
-      priority: getNotificationPriority(notification.type),
+      priority: getNotificationPriority(notification.priority, notification.type),
       assignedTo: notification.user_id ? [notification.user_id] : [],
       sourceId: String(notification.internal_notification_id),
       sourceType: ActivityType.NOTIFICATION,

--- a/packages/client-portal/src/actions/client-portal-actions/notificationActivities.ts
+++ b/packages/client-portal/src/actions/client-portal-actions/notificationActivities.ts
@@ -1,6 +1,7 @@
 'use server';
 
 import { withAuth } from '@alga-psa/auth';
+import { isFeatureFlagEnabled } from '@alga-psa/core';
 import { createTenantKnex, withTransaction, tenantDb } from '@alga-psa/db';
 import type { Knex } from 'knex';
 import {
@@ -20,15 +21,18 @@ import {
 // is absent (rows created before the backfill).
 function getNotificationPriority(
   storedPriority: string | null | undefined,
-  type: string | null | undefined
+  type: string | null | undefined,
+  priorityFeatureEnabled: boolean
 ): ActivityPriority {
-  switch (storedPriority) {
-    case 'high':
-      return ActivityPriority.HIGH;
-    case 'normal':
-      return ActivityPriority.MEDIUM;
-    case 'low':
-      return ActivityPriority.LOW;
+  if (priorityFeatureEnabled) {
+    switch (storedPriority) {
+      case 'high':
+        return ActivityPriority.HIGH;
+      case 'normal':
+        return ActivityPriority.MEDIUM;
+      case 'low':
+        return ActivityPriority.LOW;
+    }
   }
   switch (type) {
     case 'error':
@@ -51,6 +55,10 @@ export const fetchNotificationActivities = withAuth(async (
   filters: ActivityFilters = {},
 ): Promise<NotificationActivity[]> => {
   const { knex } = await createTenantKnex();
+  const priorityFeatureEnabled = await isFeatureFlagEnabled('release-v1.5-feature', {
+    tenantId: tenant,
+    userId: user.user_id,
+  });
 
   return withTransaction(knex, async (trx: Knex.Transaction) => {
     const notifications = await tenantDb(trx, tenant).table('internal_notifications')
@@ -83,7 +91,7 @@ export const fetchNotificationActivities = withAuth(async (
       description: notification.message,
       type: ActivityType.NOTIFICATION,
       status: notification.type || 'info',
-      priority: getNotificationPriority(notification.priority, notification.type),
+      priority: getNotificationPriority(notification.priority, notification.type, priorityFeatureEnabled),
       assignedTo: notification.user_id ? [notification.user_id] : [],
       sourceId: String(notification.internal_notification_id),
       sourceType: ActivityType.NOTIFICATION,

--- a/packages/client-portal/src/components/notifications/ClientNotificationCard.tsx
+++ b/packages/client-portal/src/components/notifications/ClientNotificationCard.tsx
@@ -4,6 +4,7 @@ import { formatDistanceToNow } from 'date-fns';
 import { AlertCircle, Bell, CheckCircle, Info } from 'lucide-react';
 import { markAsReadAction } from '@alga-psa/notifications/actions';
 import { Badge } from '@alga-psa/ui/components/Badge';
+import { useFeatureFlag } from '@alga-psa/ui/hooks';
 import { useTranslation } from '@alga-psa/ui/lib/i18n/client';
 import type { NotificationActivity } from '@alga-psa/types';
 
@@ -43,12 +44,30 @@ function getBorderColor(type: string) {
   }
 }
 
+// Configurable notification priorities (task 29.8.46). Muted attention-red for
+// high; low renders dimmed. activity.priority is ActivityPriority.
+const PRIORITY_INDICATOR: Record<string, { label: string; dot: string }> = {
+  high: { label: 'High', dot: 'bg-rose-500' },
+  medium: { label: 'Normal', dot: 'bg-gray-400' },
+  low: { label: 'Low', dot: 'bg-gray-300' },
+};
+
 export function ClientNotificationCard({
   activity,
   onActionComplete,
   onOpen,
 }: ClientNotificationCardProps) {
   const { t } = useTranslation('client-portal');
+  // Flag off: markup/behavior exactly as today. Flag on: priority ring/dim + indicator.
+  const { enabled: priorityEnabled } = useFeatureFlag('release-v1.5-feature');
+  const priorityCardClass = priorityEnabled
+    ? activity.priority === 'high'
+      ? ' ring-1 ring-rose-400'
+      : activity.priority === 'low'
+        ? ' opacity-70'
+        : ''
+    : '';
+  const priorityIndicator = priorityEnabled ? PRIORITY_INDICATOR[activity.priority] : undefined;
 
   const handleClick = async () => {
     if (!activity.isRead) {
@@ -73,7 +92,7 @@ export function ClientNotificationCard({
   return (
     <button
       type="button"
-      className={`w-full rounded-md border-l-4 p-4 text-left shadow-sm transition-shadow hover:shadow-md ${getBorderColor(activity.status)} ${activity.isRead ? 'bg-white' : 'bg-primary-50'}`}
+      className={`w-full rounded-md border-l-4 p-4 text-left shadow-sm transition-shadow hover:shadow-md ${getBorderColor(activity.status)} ${activity.isRead ? 'bg-white' : 'bg-primary-50'}${priorityCardClass}`}
       onClick={handleClick}
       id={`notification-card-${activity.id}`}
     >
@@ -93,6 +112,12 @@ export function ClientNotificationCard({
 
       <div className="flex items-center justify-between text-xs">
         <div className="flex items-center gap-2">
+          {priorityIndicator ? (
+            <span className="flex items-center gap-1 text-gray-500" title={`Priority: ${priorityIndicator.label}`}>
+              <span className={`h-2 w-2 rounded-full ${priorityIndicator.dot}`} />
+              {priorityIndicator.label}
+            </span>
+          ) : null}
           {activity.category ? <Badge variant="default">{activity.category}</Badge> : null}
           {hasValidCreatedAt ? (
             <span className="text-gray-500">{formatDistanceToNow(createdAt, { addSuffix: true })}</span>

--- a/packages/client-portal/src/components/notifications/ClientNotificationFiltersDialog.tsx
+++ b/packages/client-portal/src/components/notifications/ClientNotificationFiltersDialog.tsx
@@ -13,8 +13,18 @@ import { Checkbox } from '@alga-psa/ui/components/Checkbox';
 import { Label } from '@alga-psa/ui/components/Label';
 import { StringDateRangePicker } from '@alga-psa/ui/components/DateRangePicker';
 import CustomSelect from '@alga-psa/ui/components/CustomSelect';
+import { useFeatureFlag } from '@alga-psa/ui/hooks';
 import { useTranslation } from '@alga-psa/ui/lib/i18n/client';
-import type { ActivityFilters, ISO8601String } from '@alga-psa/types';
+import { ActivityPriority, type ActivityFilters, type ISO8601String } from '@alga-psa/types';
+
+type PriorityFilterKey = 'all' | 'high' | 'normal' | 'low';
+
+function priorityKeyFromFilters(filters: Partial<ActivityFilters>): PriorityFilterKey {
+  if (filters.priority?.includes(ActivityPriority.HIGH)) return 'high';
+  if (filters.priority?.includes(ActivityPriority.MEDIUM)) return 'normal';
+  if (filters.priority?.includes(ActivityPriority.LOW)) return 'low';
+  return 'all';
+}
 
 interface ClientNotificationFiltersDialogProps {
   isOpen: boolean;
@@ -30,12 +40,15 @@ export function ClientNotificationFiltersDialog({
   onApplyFilters,
 }: ClientNotificationFiltersDialogProps) {
   const { t } = useTranslation('client-portal');
+  const { enabled: priorityEnabled } = useFeatureFlag('release-v1.5-feature');
   const [localFilters, setLocalFilters] = useState<Partial<ActivityFilters>>(() => initialFilters);
   const [selectedCategory, setSelectedCategory] = useState<string>(initialFilters.search || 'all');
+  const [selectedPriority, setSelectedPriority] = useState<PriorityFilterKey>(() => priorityKeyFromFilters(initialFilters));
 
   useEffect(() => {
     setLocalFilters(initialFilters);
     setSelectedCategory(initialFilters.search || 'all');
+    setSelectedPriority(priorityKeyFromFilters(initialFilters));
   }, [initialFilters]);
 
   const handleDateChange = (range: { from: string; to: string }) => {
@@ -64,6 +77,16 @@ export function ClientNotificationFiltersDialog({
       delete filtersToApply.search;
     }
 
+    if (priorityEnabled && selectedPriority !== 'all') {
+      filtersToApply.priority = [
+        selectedPriority === 'normal'
+          ? ActivityPriority.MEDIUM
+          : selectedPriority as ActivityPriority,
+      ];
+    } else {
+      delete filtersToApply.priority;
+    }
+
     onApplyFilters(filtersToApply);
     onOpenChange(false);
   };
@@ -77,6 +100,7 @@ export function ClientNotificationFiltersDialog({
     };
     setLocalFilters(clearedFilters);
     setSelectedCategory('all');
+    setSelectedPriority('all');
   };
 
   const notificationCategories = [
@@ -136,6 +160,24 @@ export function ClientNotificationFiltersDialog({
               placeholder={t('notifications.filters.categoryPlaceholder', { defaultValue: 'Select Category...' })}
             />
           </div>
+
+          {priorityEnabled ? (
+            <div className="space-y-1">
+              <Label htmlFor="notification-priority-select" className="text-base font-semibold">{t('notifications.filters.priorityLabel', { defaultValue: 'Priority' })}</Label>
+              <CustomSelect
+                id="notification-priority-select"
+                value={selectedPriority}
+                onValueChange={(value) => setSelectedPriority(value as PriorityFilterKey)}
+                options={[
+                  { value: 'all', label: t('notifications.filters.allPriorities', { defaultValue: 'All Priorities' }) },
+                  { value: 'high', label: t('notifications.preferences.priority.high', { defaultValue: 'High' }) },
+                  { value: 'normal', label: t('notifications.preferences.priority.normal', { defaultValue: 'Normal' }) },
+                  { value: 'low', label: t('notifications.preferences.priority.low', { defaultValue: 'Low' }) },
+                ]}
+                placeholder={t('notifications.filters.priorityPlaceholder', { defaultValue: 'Select Priority...' })}
+              />
+            </div>
+          ) : null}
 
           <div className="space-y-1">
             <Label htmlFor="notification-date-range" className="text-base font-semibold">{t('notifications.filters.dateRangeLabel', { defaultValue: 'Date Range' })}</Label>

--- a/packages/event-bus/src/adapters/serverEventPublisher.ts
+++ b/packages/event-bus/src/adapters/serverEventPublisher.ts
@@ -75,6 +75,14 @@ export class ServerEventPublisher implements IEventPublisher {
   }): Promise<void> {
     await this.safePublishWorkflowEvent('TICKET_ASSIGNED', data.tenantId, data.assignedByUserId ?? data.userId, {
       ticketId: data.ticketId,
+      // The recipient must ride in payload.userId — that is the single field the
+      // internal-notification subscriber reads for the assignee (handleTicketAssigned
+      // destructures event.payload.userId). Emitting only assignedToUserId (the v2
+      // workflow field) loses the recipient through union validation, so the
+      // notification is either created for the wrong user or stamped the subtype
+      // default. Every other TICKET_ASSIGNED publisher carries userId; this one
+      // must too.
+      userId: data.userId,
       assignedToUserId: data.userId,
       assignedByUserId: data.assignedByUserId,
       assignedAt: new Date().toISOString(),

--- a/packages/notifications/src/actions/internal-notification-actions/internalNotificationActions.ts
+++ b/packages/notifications/src/actions/internal-notification-actions/internalNotificationActions.ts
@@ -11,6 +11,7 @@ import {
   InternalNotificationCategory,
   InternalNotificationSubtype,
   InternalNotificationType,
+  InternalNotificationPriority,
   CreateInternalNotificationRequest,
   GetInternalNotificationsRequest,
   InternalNotificationListResponse,
@@ -27,6 +28,7 @@ import {
 } from "../../realtime/internalNotificationBroadcaster";
 import logger from '@alga-psa/core/logger';
 import { runPostCreationHooks } from './notificationHooks';
+import { pickNotificationPriority } from './priorityResolution';
 import { publishWorkflowEvent } from '@alga-psa/event-bus/publishers';
 import {
   buildNotificationReadPayload,
@@ -214,6 +216,10 @@ export async function createNotificationFromTemplateInternal(
       return null;
     }
 
+    // Resolve the configured priority (user ?? tenant ?? subtype default ?? 'normal').
+    // Governed centrally by configuration — the caller cannot supply a priority.
+    const priority = await resolveNotificationPriority(trx, request.tenant, request.user_id, subtypeId);
+
     // Render template with data
     const title = renderTemplate(template.title, request.data);
     const message = renderTemplate(template.message, request.data);
@@ -228,6 +234,7 @@ export async function createNotificationFromTemplateInternal(
         title,
         message,
         type: request.type || 'info',
+        priority,
         category: request.category || null,
         link: request.link || null,
         metadata: request.metadata ? JSON.stringify(request.metadata) : null,
@@ -329,6 +336,10 @@ export const createNotificationFromTemplateAction = withAuth(async (
         return null;
       }
 
+      // Resolve the configured priority (user ?? tenant ?? subtype default ?? 'normal').
+      // Governed centrally by configuration — the caller cannot supply a priority.
+      const priority = await resolveNotificationPriority(trx, targetTenant, targetUserId, subtypeId);
+
       // Render template with data
       const title = renderTemplate(template.title, request.data);
       const message = renderTemplate(template.message, request.data);
@@ -343,6 +354,7 @@ export const createNotificationFromTemplateAction = withAuth(async (
           title,
           message,
           type: request.type || 'info',
+          priority,
           category: request.category || null,
           link: request.link || null,
           metadata: request.metadata ? JSON.stringify(request.metadata) : null,
@@ -467,6 +479,36 @@ async function checkInternalNotificationEnabled(
 }
 
 /**
+ * Resolve the effective priority for a notification about to be created.
+ *
+ * Runs inside the creation transaction, alongside the enablement lookup, so
+ * call sites cannot influence the stamped priority — it is governed centrally
+ * by configuration only. Per-user priority is meaningful on subtype-level rows.
+ */
+export async function resolveNotificationPriority(
+  trx: Knex.Transaction,
+  tenant: string,
+  userId: string,
+  subtypeId: number
+): Promise<InternalNotificationPriority> {
+  const userPreference = await tenantScopedTable(trx, 'user_internal_notification_preferences', tenant)
+    .where({ user_id: userId, subtype_id: subtypeId })
+    .first();
+  const tenantSetting = await tenantScopedTable(trx, 'tenant_internal_notification_subtype_settings', tenant)
+    .where({ subtype_id: subtypeId })
+    .first();
+  const subtype = await tenantScopedTable(trx, 'internal_notification_subtypes', tenant)
+    .where({ internal_notification_subtype_id: subtypeId })
+    .first();
+
+  return pickNotificationPriority(
+    userPreference?.priority,
+    tenantSetting?.priority,
+    subtype?.default_priority
+  );
+}
+
+/**
  * Get paginated notifications for a user
  *
  * Only the authenticated user's own notifications are returned — tenant and
@@ -528,10 +570,22 @@ export const getNotificationsAction = withAuth(async (
       .whereNull('deleted_at')
       .count('* as count');
 
+    // Unread high-priority count so the bell badge can render high-only
+    // (task 29.8.46) without a second round-trip.
+    const [{ count: unreadHighCount }] = await tenantScopedTable(trx, 'internal_notifications', tenant)
+      .where({
+        user_id: userId,
+        is_read: false,
+        priority: 'high'
+      })
+      .whereNull('deleted_at')
+      .count('* as count');
+
     return {
       notifications,
       total: Number(totalCount),
       unread_count: Number(unreadCount),
+      unread_high: Number(unreadHighCount),
       has_more: Number(totalCount) > offset + limit
     };
   });
@@ -594,8 +648,22 @@ export const getUnreadCountAction = withAuth(async (
       .whereNull('deleted_at')
       .count('* as count');
 
+    // Split the unread count by priority tier so the bell can render a
+    // high-only badge (and a neutral dot for normal/low) without a second
+    // round-trip. `total` mirrors `unread_count`; `high` is unread-high.
+    const [{ count: highUnreadCount }] = await tenantScopedTable(trx, 'internal_notifications', tenant)
+      .where({
+        user_id: userId,
+        is_read: false,
+        priority: 'high'
+      })
+      .whereNull('deleted_at')
+      .count('* as count');
+
     const response: UnreadCountResponse = {
-      unread_count: Number(unreadCount)
+      unread_count: Number(unreadCount),
+      total: Number(unreadCount),
+      high: Number(highUnreadCount)
     };
 
     // Get counts by category if requested
@@ -845,7 +913,12 @@ export const getSubtypesAction = withAuth(async (
         'ins.created_at',
         'ins.updated_at',
         trx.raw('COALESCE(tiss.is_enabled, true) as is_enabled'),
-        trx.raw('COALESCE(tiss.is_default_enabled, true) as is_default_enabled')
+        trx.raw('COALESCE(tiss.is_default_enabled, true) as is_default_enabled'),
+        // Priority (task 29.8.46): the subtype's system default, the tenant's
+        // override (NULL = inherit), and the effective value to display.
+        trx.raw("COALESCE(ins.default_priority, 'normal') as default_priority"),
+        trx.raw('tiss.priority as tenant_priority'),
+        trx.raw("COALESCE(tiss.priority, ins.default_priority, 'normal') as effective_priority")
       );
 
     // Get translated title using subquery to avoid duplicate rows
@@ -939,6 +1012,14 @@ export const updateUserInternalNotificationPreferenceAction = withAuth(async (
       })
       .first();
 
+    // Priority overrides are meaningful on subtype-level rows only; category
+    // rows always keep priority NULL. `null` clears an override; omitting the
+    // key preserves any existing value (task 29.8.46).
+    const isSubtypeRow = (request.subtype_id ?? null) !== null;
+    const priority = isSubtypeRow
+      ? ('priority' in request ? (request.priority ?? null) : (existing?.priority ?? null))
+      : null;
+
     if (existing) {
       // Update existing preference
       const [updated] = await tenantScopedTable(trx, 'user_internal_notification_preferences', tenant)
@@ -947,6 +1028,7 @@ export const updateUserInternalNotificationPreferenceAction = withAuth(async (
         })
         .update({
           is_enabled: request.is_enabled,
+          priority,
           updated_at: trx.fn.now()
         })
         .returning('*');
@@ -959,7 +1041,8 @@ export const updateUserInternalNotificationPreferenceAction = withAuth(async (
           user_id: userId,
           category_id: request.category_id || null,
           subtype_id: request.subtype_id || null,
-          is_enabled: request.is_enabled
+          is_enabled: request.is_enabled,
+          priority
         })
         .returning('*');
       return created;
@@ -1101,7 +1184,10 @@ export const updateInternalSubtypeAction = withAuth(async (
   currentUser,
   { tenant },
   subtypeId: number,
-  updates: Partial<Pick<InternalNotificationSubtype, 'is_enabled' | 'is_default_enabled'>>
+  updates: Partial<Pick<InternalNotificationSubtype, 'is_enabled' | 'is_default_enabled'>> & {
+    /** Tenant priority override. `null` clears it (reset to subtype default); `undefined` leaves it unchanged. */
+    priority?: InternalNotificationPriority | null;
+  }
 ): Promise<InternalNotificationSubtype | NotificationActionError> => {
   const { knex } = await (await import("@alga-psa/db")).createTenantKnex();
 
@@ -1130,6 +1216,11 @@ export const updateInternalSubtypeAction = withAuth(async (
       // Build update object with only defined values, defaulting to existing or true
       const is_enabled = updates.is_enabled ?? existingSettings?.is_enabled ?? true;
       const is_default_enabled = updates.is_default_enabled ?? existingSettings?.is_default_enabled ?? true;
+      // Priority override (task 29.8.46): only touch it when the caller supplied a
+      // `priority` key. `null` clears the override; omitting the key preserves it.
+      const priority = 'priority' in updates
+        ? (updates.priority ?? null)
+        : (existingSettings?.priority ?? null);
       // Compute timestamp before query - CitusDB requires IMMUTABLE values in ON CONFLICT UPDATE
       const now = new Date();
 
@@ -1139,19 +1230,23 @@ export const updateInternalSubtypeAction = withAuth(async (
           tenant,
           subtype_id: subtypeId,
           is_enabled,
-          is_default_enabled
+          is_default_enabled,
+          priority
         })
         .onConflict(['tenant', 'subtype_id'])
         .merge({
           is_enabled,
           is_default_enabled,
+          priority,
           updated_at: now
         });
 
       return {
         ...subtype,
         is_enabled,
-        is_default_enabled
+        is_default_enabled,
+        tenant_priority: priority as InternalNotificationPriority | null,
+        effective_priority: (priority ?? subtype.default_priority ?? 'normal') as InternalNotificationPriority
       };
     });
   } catch (error) {

--- a/packages/notifications/src/actions/internal-notification-actions/priorityResolution.test.ts
+++ b/packages/notifications/src/actions/internal-notification-actions/priorityResolution.test.ts
@@ -1,0 +1,44 @@
+import { describe, expect, it } from 'vitest';
+import { asPriority, pickNotificationPriority } from './priorityResolution';
+
+describe('pickNotificationPriority (task 29.8.46 resolution chain)', () => {
+  it('falls back to subtype default when no overrides exist', () => {
+    expect(pickNotificationPriority(null, null, 'high')).toBe('high');
+    expect(pickNotificationPriority(undefined, undefined, 'low')).toBe('low');
+  });
+
+  it('uses the tenant override over the subtype default', () => {
+    expect(pickNotificationPriority(null, 'low', 'high')).toBe('low');
+  });
+
+  it("lets the user's override beat the tenant override", () => {
+    expect(pickNotificationPriority('high', 'low', 'normal')).toBe('high');
+  });
+
+  it("resolves to 'normal' when nothing is configured (missing subtype)", () => {
+    expect(pickNotificationPriority(null, null, null)).toBe('normal');
+    expect(pickNotificationPriority(undefined, undefined, undefined)).toBe('normal');
+  });
+
+  it('ignores invalid values and continues down the chain', () => {
+    expect(pickNotificationPriority('bogus', 'high', 'low')).toBe('high');
+    expect(pickNotificationPriority('', '', 'low')).toBe('low');
+    expect(pickNotificationPriority('critical', 'urgent', 'nope')).toBe('normal');
+  });
+});
+
+describe('asPriority', () => {
+  it('accepts the three valid tiers', () => {
+    expect(asPriority('high')).toBe('high');
+    expect(asPriority('normal')).toBe('normal');
+    expect(asPriority('low')).toBe('low');
+  });
+
+  it('rejects anything else', () => {
+    expect(asPriority('HIGH')).toBeNull();
+    expect(asPriority('medium')).toBeNull();
+    expect(asPriority(null)).toBeNull();
+    expect(asPriority(undefined)).toBeNull();
+    expect(asPriority(3)).toBeNull();
+  });
+});

--- a/packages/notifications/src/actions/internal-notification-actions/priorityResolution.ts
+++ b/packages/notifications/src/actions/internal-notification-actions/priorityResolution.ts
@@ -1,0 +1,37 @@
+import type { InternalNotificationPriority } from '../../types/internalNotification';
+
+/**
+ * Pure priority-resolution helpers for configurable notification priorities
+ * (task 29.8.46).
+ *
+ * This file is intentionally NOT a "use server" module so the helpers can be
+ * imported directly (and unit-tested) without being registered as async
+ * Server Actions.
+ */
+
+const VALID_PRIORITIES: ReadonlySet<string> = new Set(['high', 'normal', 'low']);
+
+/** Narrow an unknown DB value to a valid priority, or null. */
+export function asPriority(value: unknown): InternalNotificationPriority | null {
+  return typeof value === 'string' && VALID_PRIORITIES.has(value)
+    ? (value as InternalNotificationPriority)
+    : null;
+}
+
+/**
+ * Precedence for the resolved notification priority (the user's choice always
+ * wins — it is their attention):
+ *   user override ?? tenant override ?? subtype default ?? 'normal'.
+ */
+export function pickNotificationPriority(
+  userPriority: unknown,
+  tenantPriority: unknown,
+  subtypeDefault: unknown
+): InternalNotificationPriority {
+  return (
+    asPriority(userPriority) ??
+    asPriority(tenantPriority) ??
+    asPriority(subtypeDefault) ??
+    'normal'
+  );
+}

--- a/packages/notifications/src/components/NotificationBell.tsx
+++ b/packages/notifications/src/components/NotificationBell.tsx
@@ -5,6 +5,7 @@ import React, { useState } from 'react';
 import { Bell } from 'lucide-react';
 import * as DropdownMenu from '@radix-ui/react-dropdown-menu';
 import { Button } from '@alga-psa/ui/components/Button';
+import { useFeatureFlag } from '@alga-psa/ui/hooks';
 import { NotificationDropdown } from './NotificationDropdown';
 import { useSession } from 'next-auth/react';
 import { useInternalNotifications } from '../hooks/useInternalNotifications';
@@ -16,10 +17,15 @@ interface NotificationBellProps {
 function NotificationBellInner({ tenant, userId, className = '' }: { tenant: string; userId: string; className?: string }) {
   const [open, setOpen] = useState(false);
 
+  // Configurable notification priorities (task 29.8.46) — every user-visible
+  // change is gated behind this flag. Flag off reproduces today's markup exactly.
+  const { enabled: priorityEnabled } = useFeatureFlag('release-v1.5-feature');
+
   // Use the internal notifications hook
   const {
     notifications,
     unreadCount,
+    highUnreadCount,
     isConnected,
     isLoading,
     error,
@@ -33,6 +39,13 @@ function NotificationBellInner({ tenant, userId, className = '' }: { tenant: str
     enablePolling: true
   });
 
+  // Flag on: the badge counts unread *high* only (attention-red); when no high
+  // items are unread but normal/low unread exist, a subtle neutral dot renders
+  // instead of a number. Flag off: today's total-count badge.
+  const showHighBadge = priorityEnabled && highUnreadCount > 0;
+  const showNeutralDot = priorityEnabled && highUnreadCount === 0 && unreadCount > 0;
+  const ariaUnread = priorityEnabled ? highUnreadCount : unreadCount;
+
   return (
     <DropdownMenu.Root open={open} onOpenChange={setOpen}>
       <DropdownMenu.Trigger asChild>
@@ -41,13 +54,26 @@ function NotificationBellInner({ tenant, userId, className = '' }: { tenant: str
           variant="ghost"
           size="icon"
           className={`relative h-9 w-9 ${className}`}
-          aria-label={`Notifications${unreadCount > 0 ? ` (${unreadCount} unread)` : ''}`}
+          aria-label={`Notifications${ariaUnread > 0 ? ` (${ariaUnread} unread)` : ''}`}
         >
           <Bell className="w-5 h-5" />
-          {unreadCount > 0 && (
-            <span className="absolute -top-0.5 -right-0.5 flex items-center justify-center min-w-[18px] h-[18px] px-1 text-[10px] font-semibold text-white bg-red-500 rounded-full border-2 border-[rgb(var(--color-card))]">
-              {unreadCount > 99 ? '99+' : unreadCount}
-            </span>
+          {priorityEnabled ? (
+            <>
+              {showHighBadge && (
+                <span className="absolute -top-0.5 -right-0.5 flex items-center justify-center min-w-[18px] h-[18px] px-1 text-[10px] font-semibold text-white bg-rose-600 rounded-full border-2 border-[rgb(var(--color-card))]">
+                  {highUnreadCount > 99 ? '99+' : highUnreadCount}
+                </span>
+              )}
+              {showNeutralDot && (
+                <span className="absolute top-0.5 right-0.5 w-2 h-2 bg-[rgb(var(--color-text-400))] rounded-full border border-[rgb(var(--color-card))]" title="Unread notifications" />
+              )}
+            </>
+          ) : (
+            unreadCount > 0 && (
+              <span className="absolute -top-0.5 -right-0.5 flex items-center justify-center min-w-[18px] h-[18px] px-1 text-[10px] font-semibold text-white bg-red-500 rounded-full border-2 border-[rgb(var(--color-card))]">
+                {unreadCount > 99 ? '99+' : unreadCount}
+              </span>
+            )
           )}
           {!isConnected && (
             <span className="absolute -bottom-0.5 -right-0.5 w-2 h-2 bg-yellow-500 rounded-full border border-[rgb(var(--color-card))]" title="Reconnecting..." />
@@ -64,6 +90,7 @@ function NotificationBellInner({ tenant, userId, className = '' }: { tenant: str
           <NotificationDropdown
             notifications={notifications}
             unreadCount={unreadCount}
+            priorityEnabled={priorityEnabled}
             isLoading={isLoading}
             error={error}
             isConnected={isConnected}

--- a/packages/notifications/src/components/NotificationDetailView.tsx
+++ b/packages/notifications/src/components/NotificationDetailView.tsx
@@ -18,6 +18,7 @@ import {
 } from 'lucide-react';
 import { format, formatDistanceToNow } from 'date-fns';
 import { useRouter } from 'next/navigation';
+import { useFeatureFlag } from '@alga-psa/ui/hooks';
 
 interface NotificationDetailViewProps {
   notification: NotificationActivity;
@@ -84,6 +85,20 @@ const renderPriority = (name: string, color?: string) => {
 export function NotificationDetailView({ notification, onClose, onNavigateToDocument, onNavigateToTicket, onNavigateToProjectTask }: NotificationDetailViewProps) {
   const router = useRouter();
   const style = getNotificationStyle(notification.status);
+
+  // Configurable notification priorities (task 29.8.46). Flag on: priority (the
+  // stored, config-resolved value carried on the activity) styles the panel —
+  // high gets a muted attention-red left accent, low renders dimmed. The type
+  // icon/styling above is unchanged. Distinct from the ticket priority rendered
+  // from metadata.changes.priority. Flag off: exactly today's markup.
+  const { enabled: priorityEnabled } = useFeatureFlag('release-v1.5-feature');
+  const priorityContainerClass = priorityEnabled
+    ? notification.priority === 'high'
+      ? ' border-l-4 border-rose-500'
+      : notification.priority === 'low'
+        ? ' opacity-70'
+        : ''
+    : '';
 
   const handleNavigateToEntity = () => {
     if (notification.link) {
@@ -301,7 +316,7 @@ export function NotificationDetailView({ notification, onClose, onNavigateToDocu
   const isInternalComment = notification.metadata?.comment?.isInternal || false;
 
   return (
-    <div className="h-full flex flex-col bg-white" id="notification-detail-view">
+    <div className={`h-full flex flex-col bg-white${priorityContainerClass}`} id="notification-detail-view">
       {/* Header */}
       <div className="flex-shrink-0 border-b border-gray-200">
         <div className="px-6 py-4">

--- a/packages/notifications/src/components/NotificationDropdown.tsx
+++ b/packages/notifications/src/components/NotificationDropdown.tsx
@@ -2,7 +2,7 @@
 
 
 import React, { useState } from 'react';
-import { CheckCheck, RefreshCw, WifiOff, AlertCircle, Bell as BellIcon } from 'lucide-react';
+import { CheckCheck, RefreshCw, WifiOff, AlertCircle, Bell as BellIcon, ChevronDown, ChevronRight } from 'lucide-react';
 import Link from 'next/link';
 import Spinner from '@alga-psa/ui/components/Spinner';
 import { NotificationItem } from './NotificationItem';
@@ -14,6 +14,9 @@ import { useSession } from 'next-auth/react';
 interface NotificationDropdownProps {
   notifications: InternalNotification[];
   unreadCount: number;
+  // Configurable notification priorities (task 29.8.46). When true, the panel
+  // groups by tier; when false/undefined it renders today's flat list.
+  priorityEnabled?: boolean;
   isLoading: boolean;
   error: string | null;
   isConnected: boolean;
@@ -26,6 +29,7 @@ interface NotificationDropdownProps {
 export function NotificationDropdown({
   notifications,
   unreadCount,
+  priorityEnabled = false,
   isLoading,
   error,
   isConnected,
@@ -36,6 +40,7 @@ export function NotificationDropdown({
 }: NotificationDropdownProps) {
   const [isMarkingAllAsRead, setIsMarkingAllAsRead] = useState(false);
   const [isRefreshing, setIsRefreshing] = useState(false);
+  const [lowExpanded, setLowExpanded] = useState(false);
   const { data: session } = useSession();
   const tenant = useTenant();
 
@@ -168,6 +173,60 @@ export function NotificationDropdown({
             <p className="text-sm text-[rgb(var(--color-text-500))] font-medium">No notifications</p>
             <p className="text-xs text-[rgb(var(--color-text-400))] mt-1">You're all caught up!</p>
           </div>
+        ) : priorityEnabled ? (
+          (() => {
+            // Group by tier, preserving the incoming chronological order.
+            const high = notifications.filter((n) => n.priority === 'high');
+            const low = notifications.filter((n) => n.priority === 'low');
+            const normal = notifications.filter((n) => n.priority !== 'high' && n.priority !== 'low');
+
+            const renderItems = (items: InternalNotification[]) => (
+              <div className="divide-y divide-[rgb(var(--color-border-100))]">
+                {items.map((notification) => (
+                  <NotificationItem
+                    key={notification.internal_notification_id}
+                    notification={notification}
+                    priorityEnabled
+                    onClick={() => handleNotificationClick(notification)}
+                  />
+                ))}
+              </div>
+            );
+
+            return (
+              <div>
+                {/* "Needs attention" (high) pinned on top */}
+                {high.length > 0 && (
+                  <div>
+                    <div className="px-4 py-1.5 bg-[rgb(var(--color-border-50))] border-b border-[rgb(var(--color-border-200))]">
+                      <span className="text-xs font-semibold uppercase tracking-wide text-rose-700">
+                        {t('notifications.needsAttention', { defaultValue: 'Needs attention ({{count}})', count: high.length })}
+                      </span>
+                    </div>
+                    {renderItems(high)}
+                  </div>
+                )}
+
+                {/* Normal stream in the middle */}
+                {normal.length > 0 && renderItems(normal)}
+
+                {/* Low priority collapsed behind an expander */}
+                {low.length > 0 && (
+                  <div className="border-t border-[rgb(var(--color-border-100))]">
+                    <button
+                      type="button"
+                      onClick={() => setLowExpanded((v) => !v)}
+                      className="flex items-center gap-1 w-full px-4 py-2 text-xs font-medium text-[rgb(var(--color-text-500))] hover:text-[rgb(var(--color-text-700))]"
+                    >
+                      {lowExpanded ? <ChevronDown className="w-3 h-3" /> : <ChevronRight className="w-3 h-3" />}
+                      <span>{t('notifications.lowPriority', { defaultValue: 'Low priority ({{count}})', count: low.length })}</span>
+                    </button>
+                    {lowExpanded && renderItems(low)}
+                  </div>
+                )}
+              </div>
+            );
+          })()
         ) : (
           <div className="divide-y divide-[rgb(var(--color-border-100))]">
             {notifications.map((notification) => (
@@ -185,7 +244,13 @@ export function NotificationDropdown({
       {userType && (
         <div className="border-t border-[rgb(var(--color-border-200))]">
           <Link
-            href={userType === 'client' ? '/client-portal/profile?tab=activity' : '/msp/user-activities'}
+            href={
+              userType === 'client'
+                ? '/client-portal/profile?tab=activity'
+                : priorityEnabled
+                  ? '/msp/user-activities?focus=notifications'
+                  : '/msp/user-activities'
+            }
             onClick={onClose}
             className="flex items-center justify-center px-4 py-3 text-sm font-medium text-main-600 hover:text-main-700 hover:bg-[rgb(var(--color-border-50))] transition-colors"
           >

--- a/packages/notifications/src/components/NotificationItem.tsx
+++ b/packages/notifications/src/components/NotificationItem.tsx
@@ -7,11 +7,25 @@ import type { InternalNotification } from '../types/internalNotification';
 
 interface NotificationItemProps {
   notification: InternalNotification;
+  // Configurable notification priorities (task 29.8.46). When true, priority
+  // styles the row (high = muted attention-red left accent, low = dimmed).
+  priorityEnabled?: boolean;
   onClick: () => void;
 }
 
-export function NotificationItem({ notification, onClick }: NotificationItemProps) {
+export function NotificationItem({ notification, priorityEnabled = false, onClick }: NotificationItemProps) {
   const isUnread = !notification.is_read;
+
+  // Priority row styling (flag-gated). Priority styles the row; the `type` icon
+  // logic below is unchanged. Deliberately no tinted row background for high —
+  // an attention-red left accent only (attention-worthy, not emergency).
+  const priorityRowClass = priorityEnabled
+    ? notification.priority === 'high'
+      ? 'border-l-2 border-rose-500'
+      : notification.priority === 'low'
+        ? 'opacity-60'
+        : ''
+    : '';
 
   // Get icon based on notification type
   const getIcon = () => {
@@ -204,7 +218,7 @@ export function NotificationItem({ notification, onClick }: NotificationItemProp
       onClick={onClick}
       className={`w-full text-left px-4 py-3 hover:bg-[rgb(var(--color-border-50))] transition-colors ${
         isUnread ? 'bg-blue-500/5' : ''
-      }`}
+      }${priorityRowClass ? ` ${priorityRowClass}` : ''}`}
     >
       <div className="flex gap-3">
         {/* Icon */}

--- a/packages/notifications/src/components/settings/InternalNotificationCategories.tsx
+++ b/packages/notifications/src/components/settings/InternalNotificationCategories.tsx
@@ -4,9 +4,11 @@
 import { useState, useEffect, useCallback } from "react";
 import { Button } from "@alga-psa/ui/components/Button";
 import { Switch } from "@alga-psa/ui/components/Switch";
+import CustomSelect from "@alga-psa/ui/components/CustomSelect";
 import { DataTable } from "@alga-psa/ui/components/DataTable";
 import { ColumnDefinition } from "@alga-psa/types";
-import { ChevronDown, ChevronRight, CornerDownRight, MoreVertical } from "lucide-react";
+import { ChevronDown, ChevronRight, CornerDownRight, MoreVertical, RotateCcw } from "lucide-react";
+import { useFeatureFlag } from "@alga-psa/ui/hooks";
 import { toast } from "react-hot-toast";
 import { getErrorMessage, handleError } from '@alga-psa/ui/lib/errorHandling';
 import { useUserPreference } from "@alga-psa/user-composition/hooks";
@@ -19,6 +21,7 @@ import {
 } from "../../actions";
 import {
   InternalNotificationCategory,
+  InternalNotificationPriority,
   InternalNotificationSubtype
 } from "../../types/internalNotification";
 import LoadingIndicator from "@alga-psa/ui/components/LoadingIndicator";
@@ -45,6 +48,10 @@ interface PendingSubtypeChange {
   categoryId: number;
   is_enabled?: boolean;
   is_default_enabled?: boolean;
+  // Present only when the tenant priority override was changed. `null` clears
+  // the override (reset to system default); a value sets it. The key's presence
+  // is what tells the save path to send `priority` at all (task 29.8.46).
+  priority?: InternalNotificationPriority | null;
 }
 
 // Combined row type for the flat list
@@ -102,6 +109,9 @@ function InternalNotificationCategoriesContent({
   initialCategories: InternalNotificationCategory[];
 }) {
   const { t } = useTranslation('msp/settings');
+  // Priority configuration is gated behind the v1.5 release flag. With the flag
+  // off this component renders exactly as before (switches only).
+  const { enabled: priorityEnabled } = useFeatureFlag('release-v1.5-feature');
   // Current state (what's displayed)
   const [categories, setCategories] = useState(initialCategories);
   const [subtypesByCategory, setSubtypesByCategory] = useState<Record<number, InternalNotificationSubtype[]>>({});
@@ -242,6 +252,32 @@ function InternalNotificationCategoriesContent({
     });
   };
 
+  // Set (or reset) a subtype's tenant priority override in local state and
+  // stage it into the existing batch. `null` clears the override. Only reachable
+  // when the feature flag is on, so the flag-off save payload is unchanged.
+  const handleChangeSubtypePriority = (
+    subtype: InternalNotificationSubtype,
+    categoryId: number,
+    priority: InternalNotificationPriority | null
+  ) => {
+    setSubtypesByCategory(prev => ({
+      ...prev,
+      [categoryId]: prev[categoryId].map(s =>
+        s.internal_notification_subtype_id === subtype.internal_notification_subtype_id
+          ? { ...s, tenant_priority: priority }
+          : s
+      )
+    }));
+
+    setPendingSubtypeChanges(prev => {
+      const next = new Map(prev);
+      const existing = next.get(subtype.internal_notification_subtype_id)
+        || { id: subtype.internal_notification_subtype_id, categoryId };
+      next.set(subtype.internal_notification_subtype_id, { ...existing, priority });
+      return next;
+    });
+  };
+
   // Save all pending changes
   const handleSave = async () => {
     setIsSaving(true);
@@ -254,13 +290,20 @@ function InternalNotificationCategoriesContent({
         })
       );
 
-      // Save subtype changes
-      const subtypePromises = Array.from(pendingSubtypeChanges.values()).map(change =>
-        updateInternalSubtypeAction(change.id, {
+      // Save subtype changes. Only include `priority` when it was actually
+      // changed — the action treats the mere presence of the key as intent
+      // (a bare `undefined` would clear the override), so we must not send it
+      // for enable/disable-only edits.
+      const subtypePromises = Array.from(pendingSubtypeChanges.values()).map(change => {
+        const updates: Parameters<typeof updateInternalSubtypeAction>[1] = {
           is_enabled: change.is_enabled,
           is_default_enabled: change.is_default_enabled
-        })
-      );
+        };
+        if ('priority' in change) {
+          updates.priority = change.priority;
+        }
+        return updateInternalSubtypeAction(change.id, updates);
+      });
 
       const results = await Promise.all([...categoryPromises, ...subtypePromises]);
       const firstError = results.find(isNotificationActionError);
@@ -542,6 +585,67 @@ function InternalNotificationCategoriesContent({
       },
     },
   ];
+
+  // Priority selector column (feature-flagged). Inserted before the Actions
+  // column so the flag-off layout stays byte-for-byte identical to today.
+  if (priorityEnabled) {
+    const priorityOptions = [
+      { value: 'high', label: t('notifications.internalCategoriesUi.priority.high', 'High') },
+      { value: 'normal', label: t('notifications.internalCategoriesUi.priority.normal', 'Normal') },
+      { value: 'low', label: t('notifications.internalCategoriesUi.priority.low', 'Low') },
+    ];
+
+    const priorityColumn: ColumnDefinition<NotificationRow> = {
+      title: t('notifications.internalCategoriesUi.columns.priority', 'Priority'),
+      dataIndex: 'id',
+      width: '18%',
+      render: (_value: string, record: NotificationRow) => {
+        // Priority is a subtype-level concept; category rows have none.
+        if (record.isCategory) {
+          return null;
+        }
+        const category = categories.find(c => c.internal_notification_category_id === record.categoryId);
+        const subtype = subtypesByCategory[record.categoryId!]?.find(
+          s => s.internal_notification_subtype_id === record.originalId
+        );
+        if (!subtype) return null;
+
+        const effectivePriority = subtype.tenant_priority ?? subtype.default_priority ?? 'normal';
+        const hasOverride = subtype.tenant_priority != null;
+
+        return (
+          <div className="flex items-center gap-2" onClick={(e) => e.stopPropagation()}>
+            <CustomSelect
+              id={`internal-subtype-priority-${record.id}`}
+              size="sm"
+              value={effectivePriority}
+              options={priorityOptions}
+              disabled={!category?.is_enabled}
+              onValueChange={(v) =>
+                handleChangeSubtypePriority(subtype, record.categoryId!, v as InternalNotificationPriority)
+              }
+            />
+            {hasOverride && (
+              <Button
+                id={`reset-internal-subtype-priority-${record.id}`}
+                variant="ghost"
+                size="sm"
+                className="h-8 w-8 p-0"
+                title={t('notifications.internalCategoriesUi.actions.resetToDefault', 'Reset to default')}
+                aria-label={t('notifications.internalCategoriesUi.actions.resetToDefault', 'Reset to default')}
+                onClick={() => handleChangeSubtypePriority(subtype, record.categoryId!, null)}
+              >
+                <RotateCcw className="h-4 w-4" />
+              </Button>
+            )}
+          </div>
+        );
+      },
+    };
+
+    // Insert before the trailing Actions column.
+    columns.splice(columns.length - 1, 0, priorityColumn);
+  }
 
   return (
     <div className="space-y-4">

--- a/packages/notifications/src/components/settings/InternalNotificationPreferences.tsx
+++ b/packages/notifications/src/components/settings/InternalNotificationPreferences.tsx
@@ -7,6 +7,10 @@ import { useState, useEffect } from "react";
 import { useSession } from "next-auth/react";
 import { Switch } from "@alga-psa/ui/components/Switch";
 import { Label } from "@alga-psa/ui/components/Label";
+import { Button } from "@alga-psa/ui/components/Button";
+import CustomSelect from "@alga-psa/ui/components/CustomSelect";
+import { RotateCcw } from "lucide-react";
+import { useFeatureFlag } from "@alga-psa/ui/hooks";
 import {
   getInternalNotificationCategoriesAction as getInternalCategoriesAction,
   getSubtypesAction as getInternalSubtypesAction,
@@ -15,6 +19,7 @@ import {
 } from "../../actions";
 import {
   InternalNotificationCategory,
+  InternalNotificationPriority,
   InternalNotificationSubtype,
   UserInternalNotificationPreference
 } from "../../types/internalNotification";
@@ -22,6 +27,9 @@ import { useTranslation } from "@alga-psa/ui/lib/i18n/client";
 
 export function InternalNotificationPreferences() {
   const { t, i18n } = useTranslation('client-portal');
+  // Priority configuration is gated behind the v1.5 release flag. With the flag
+  // off this component renders exactly as before (switches only).
+  const { enabled: priorityEnabled } = useFeatureFlag('release-v1.5-feature');
   const { data: session } = useSession();
   const [categories, setCategories] = useState<InternalNotificationCategory[]>([]);
   const [subtypes, setSubtypes] = useState<Record<number, InternalNotificationSubtype[]>>({});
@@ -170,6 +178,57 @@ export function InternalNotificationPreferences() {
     }
   };
 
+  // Effective priority a user sees for a subtype: their personal override, else
+  // the tenant/default effective priority carried on the subtype row.
+  const getSubtypeEffectivePriority = (categoryId: number, subtypeId: number): InternalNotificationPriority => {
+    const subtypePref = preferences.find(p => p.subtype_id === subtypeId);
+    if (subtypePref?.priority) {
+      return subtypePref.priority;
+    }
+    const categorySubtypes = subtypes[categoryId] || [];
+    const subtype = categorySubtypes.find(s => s.internal_notification_subtype_id === subtypeId);
+    return subtype?.effective_priority ?? subtype?.default_priority ?? 'normal';
+  };
+
+  const subtypeHasPriorityOverride = (subtypeId: number): boolean => {
+    const subtypePref = preferences.find(p => p.subtype_id === subtypeId);
+    return subtypePref?.priority != null;
+  };
+
+  // Set (or reset) the user's personal priority override on a subtype. `null`
+  // clears it. Preserves the current enabled state so the row's toggle is
+  // unaffected. Only reachable when the feature flag is on.
+  const handleSubtypePriorityChange = async (
+    categoryId: number,
+    subtypeId: number,
+    priority: InternalNotificationPriority | null
+  ) => {
+    if (!tenant || !userId) return;
+
+    try {
+      await updateUserInternalNotificationPreferenceAction({
+        tenant,
+        user_id: userId,
+        category_id: categoryId,
+        subtype_id: subtypeId,
+        is_enabled: getSubtypePreference(categoryId, subtypeId),
+        priority
+      });
+
+      const updatedPreferences = await getUserInternalNotificationPreferencesAction(tenant, userId);
+      setPreferences(updatedPreferences);
+    } catch (err) {
+      console.error("Failed to update subtype priority:", err);
+      setError(t('notifications.preferences.saveError', 'Failed to save preference'));
+    }
+  };
+
+  const priorityOptions = [
+    { value: 'high', label: t('notifications.preferences.priority.high', 'High') },
+    { value: 'normal', label: t('notifications.preferences.priority.normal', 'Normal') },
+    { value: 'low', label: t('notifications.preferences.priority.low', 'Low') },
+  ];
+
   if (loading) {
     return <div>{t('notifications.preferences.loading', 'Loading preferences...')}</div>;
   }
@@ -204,14 +263,59 @@ export function InternalNotificationPreferences() {
                 return (
                   <div key={`${category.internal_notification_category_id}-${subtype.internal_notification_subtype_id}-${index}`} className="flex items-center justify-between">
                     <Label className="text-sm">{subtype.display_title || subtype.name}</Label>
-                    <Switch
-                      checked={subtypeEnabled}
-                      disabled={!category.is_enabled || !subtype.is_enabled || !isEnabled}
-                      onCheckedChange={() => handleSubtypeToggle(
-                        category.internal_notification_category_id,
-                        subtype.internal_notification_subtype_id
-                      )}
-                    />
+                    {priorityEnabled ? (
+                      <div className="flex items-center gap-2">
+                        <CustomSelect
+                          id={`user-internal-subtype-priority-${subtype.internal_notification_subtype_id}`}
+                          size="sm"
+                          value={getSubtypeEffectivePriority(
+                            category.internal_notification_category_id,
+                            subtype.internal_notification_subtype_id
+                          )}
+                          options={priorityOptions}
+                          disabled={!category.is_enabled || !subtype.is_enabled || !isEnabled || !subtypeEnabled}
+                          onValueChange={(v) => handleSubtypePriorityChange(
+                            category.internal_notification_category_id,
+                            subtype.internal_notification_subtype_id,
+                            v as InternalNotificationPriority
+                          )}
+                        />
+                        {subtypeHasPriorityOverride(subtype.internal_notification_subtype_id) && (
+                          <Button
+                            id={`reset-user-internal-subtype-priority-${subtype.internal_notification_subtype_id}`}
+                            variant="ghost"
+                            size="sm"
+                            className="h-8 w-8 p-0"
+                            title={t('notifications.preferences.resetPriority', 'Reset')}
+                            aria-label={t('notifications.preferences.resetPriority', 'Reset')}
+                            onClick={() => handleSubtypePriorityChange(
+                              category.internal_notification_category_id,
+                              subtype.internal_notification_subtype_id,
+                              null
+                            )}
+                          >
+                            <RotateCcw className="h-4 w-4" />
+                          </Button>
+                        )}
+                        <Switch
+                          checked={subtypeEnabled}
+                          disabled={!category.is_enabled || !subtype.is_enabled || !isEnabled}
+                          onCheckedChange={() => handleSubtypeToggle(
+                            category.internal_notification_category_id,
+                            subtype.internal_notification_subtype_id
+                          )}
+                        />
+                      </div>
+                    ) : (
+                      <Switch
+                        checked={subtypeEnabled}
+                        disabled={!category.is_enabled || !subtype.is_enabled || !isEnabled}
+                        onCheckedChange={() => handleSubtypeToggle(
+                          category.internal_notification_category_id,
+                          subtype.internal_notification_subtype_id
+                        )}
+                      />
+                    )}
                   </div>
                 );
               })}

--- a/packages/notifications/src/hooks/useInternalNotifications.ts
+++ b/packages/notifications/src/hooks/useInternalNotifications.ts
@@ -84,6 +84,7 @@ export function useInternalNotifications(
     if (!tenant || !userId) {
       setNotifications([]);
       setUnreadCount(0);
+      setHighUnreadCount(0);
       setError(null);
       setIsLoading(false);
       return;
@@ -112,6 +113,9 @@ export function useInternalNotifications(
 
         notificationsMap.set('data', response.notifications);
         unreadCountMap.set('count', response.unread_count);
+        if (typeof response.unread_high === 'number') {
+          unreadCountMap.set('high', response.unread_high);
+        }
       }
     } finally {
       setIsLoading(false);
@@ -201,15 +205,23 @@ export function useInternalNotifications(
       if (notifData) {
         const list = notifData as InternalNotification[];
         setNotifications(list);
-        // Keep the high-priority badge count in sync with realtime updates.
-        setHighUnreadCount(list.filter((n) => !n.is_read && n.priority === 'high').length);
+        // A shared Yjs document can contain only another consumer's limited
+        // notification window. Recount against the database instead of deriving
+        // the bell badge from that incomplete page.
+        void fetchUnreadCount();
       }
     });
 
-    unreadCountMap.observe(() => {
+    unreadCountMap.observe((event) => {
       const count = unreadCountMap.get('count');
       if (typeof count === 'number') {
         setUnreadCount(count);
+      }
+      const high = unreadCountMap.get('high');
+      if (event.keysChanged.has('high') && typeof high === 'number') {
+        setHighUnreadCount(high);
+      } else if (event.keysChanged.has('count')) {
+        void fetchUnreadCount();
       }
     });
 
@@ -217,7 +229,7 @@ export function useInternalNotifications(
       provider.destroy();
       ydoc.destroy();
     };
-  }, [pollNotificationsNow, tenant, userId]);
+  }, [fetchUnreadCount, pollNotificationsNow, tenant, userId]);
 
   useEffect(() => {
     setIsLoading(true);

--- a/packages/notifications/src/hooks/useInternalNotifications.ts
+++ b/packages/notifications/src/hooks/useInternalNotifications.ts
@@ -53,6 +53,8 @@ interface UseInternalNotificationsOptions {
 interface UseInternalNotificationsReturn {
   notifications: InternalNotification[];
   unreadCount: number;
+  // Unread count of `high`-priority notifications, for the priority-aware bell badge.
+  highUnreadCount: number;
   isConnected: boolean;
   isLoading: boolean;
   error: string | null;
@@ -68,6 +70,7 @@ export function useInternalNotifications(
 
   const [notifications, setNotifications] = useState<InternalNotification[]>([]);
   const [unreadCount, setUnreadCount] = useState<number>(0);
+  const [highUnreadCount, setHighUnreadCount] = useState<number>(0);
   const [isConnected, setIsConnected] = useState<boolean>(false);
   const [isLoading, setIsLoading] = useState<boolean>(true);
   const [error, setError] = useState<string | null>(null);
@@ -94,6 +97,13 @@ export function useInternalNotifications(
       });
       setNotifications(response.notifications);
       setUnreadCount(response.unread_count);
+      // Prefer the server's authoritative unread-high count; fall back to
+      // deriving it from the loaded page for older payloads.
+      setHighUnreadCount(
+        typeof response.unread_high === 'number'
+          ? response.unread_high
+          : response.notifications.filter((n) => !n.is_read && n.priority === 'high').length
+      );
       setError(null);
 
       if (ydocRef.current && providerRef.current?.status === 'connected') {
@@ -117,6 +127,9 @@ export function useInternalNotifications(
 	    try {
 	      const response: UnreadCountResponse = await getUnreadCountAction(tenant, userId);
 	      setUnreadCount(response.unread_count);
+	      if (typeof response.high === 'number') {
+	        setHighUnreadCount(response.high);
+	      }
     } catch (err) {
       console.error('Failed to fetch unread count:', err);
     }
@@ -186,7 +199,10 @@ export function useInternalNotifications(
     notificationsMap.observe(() => {
       const notifData = notificationsMap.get('data');
       if (notifData) {
-        setNotifications(notifData as InternalNotification[]);
+        const list = notifData as InternalNotification[];
+        setNotifications(list);
+        // Keep the high-priority badge count in sync with realtime updates.
+        setHighUnreadCount(list.filter((n) => !n.is_read && n.priority === 'high').length);
       }
     });
 
@@ -249,6 +265,7 @@ export function useInternalNotifications(
   return {
     notifications,
     unreadCount,
+    highUnreadCount,
     isConnected,
     isLoading,
     error,

--- a/packages/notifications/src/types/internalNotification.ts
+++ b/packages/notifications/src/types/internalNotification.ts
@@ -25,6 +25,12 @@ export interface InternalNotificationSubtype {
   is_default_enabled: boolean;
   available_for_client_portal: boolean;
   display_title?: string;
+  /** System default priority for this subtype (from internal_notification_subtypes). */
+  default_priority?: InternalNotificationPriority;
+  /** Tenant admin override, if any (from tenant_internal_notification_subtype_settings). NULL = inherit default. */
+  tenant_priority?: InternalNotificationPriority | null;
+  /** Effective priority to display: tenant override ?? default. */
+  effective_priority?: InternalNotificationPriority;
   created_at: string;
   updated_at: string;
 }
@@ -42,6 +48,13 @@ export interface InternalNotificationTemplate {
 
 export type InternalNotificationType = 'info' | 'success' | 'warning' | 'error';
 
+/**
+ * Configurable priority tier for an in-app notification.
+ * Resolved from user override ?? tenant override ?? subtype default ?? 'normal'
+ * and stamped onto each notification at creation (task 29.8.46).
+ */
+export type InternalNotificationPriority = 'high' | 'normal' | 'low';
+
 export type InternalNotificationDeliveryStatus = 'pending' | 'delivered' | 'failed';
 
 export interface InternalNotification {
@@ -53,6 +66,7 @@ export interface InternalNotification {
   title: string;
   message: string;
   type: InternalNotificationType;
+  priority: InternalNotificationPriority;
   category: string | null;
   link: string | null;
   metadata: Record<string, any> | null;
@@ -106,12 +120,21 @@ export interface InternalNotificationListResponse {
   notifications: InternalNotification[];
   total: number;
   unread_count: number;
+  /** Unread count of `high`-priority notifications, so the bell badge can render high-only. */
+  unread_high?: number;
   has_more: boolean;
 }
 
 export interface UnreadCountResponse {
   unread_count: number;
   by_category?: Record<string, number>;
+  /**
+   * Unread count split by priority tier so the bell can render a high-only
+   * badge without a second round-trip. `high` is the unread-high count;
+   * `total` mirrors `unread_count` for a symmetric `{ total, high }` shape.
+   */
+  total?: number;
+  high?: number;
 }
 
 export interface TemplateRenderContext {
@@ -134,6 +157,11 @@ export interface UserInternalNotificationPreference {
   category_id: number | null;
   subtype_id: number | null;
   is_enabled: boolean;
+  /**
+   * Per-user priority override. Meaningful on subtype rows only (subtype_id set);
+   * category rows keep this NULL. NULL = inherit tenant override / subtype default.
+   */
+  priority?: InternalNotificationPriority | null;
   created_at: string;
   updated_at: string;
 }
@@ -144,5 +172,11 @@ export interface UpdateUserInternalNotificationPreferenceRequest {
   category_id?: number | null;
   subtype_id?: number | null;
   is_enabled: boolean;
+  /**
+   * When present, sets the per-user priority override on a subtype row.
+   * Pass `null` to clear the override (reset to tenant/default). `undefined`
+   * leaves any existing override untouched.
+   */
+  priority?: InternalNotificationPriority | null;
 }
 

--- a/packages/sla/src/services/__tests__/escalationService.test.ts
+++ b/packages/sla/src/services/__tests__/escalationService.test.ts
@@ -13,6 +13,13 @@ import {
   EscalationResult,
 } from '../escalationService';
 import { Knex } from 'knex';
+import { createNotificationFromTemplateInternal } from '@alga-psa/notifications/actions/internal-notification-actions/internalNotificationActions';
+
+vi.mock('@alga-psa/notifications/actions/internal-notification-actions/internalNotificationActions', () => ({
+  createNotificationFromTemplateInternal: vi.fn().mockResolvedValue({
+    internal_notification_id: 'notification-1',
+  }),
+}));
 
 // =============================================================================
 // Mock Database Transaction Builder
@@ -696,6 +703,19 @@ describe('escalateTicket', () => {
 
       expect(result.success).toBe(true);
       expect(result.notificationsSent.inApp).toBe(true);
+      expect(createNotificationFromTemplateInternal).toHaveBeenCalledWith(
+        mockTrx.trx,
+        expect.objectContaining({
+          tenant: TENANT,
+          user_id: MANAGER_USER_ID,
+          template_name: 'sla-escalation',
+          data: expect.objectContaining({
+            ticketNumber: 'T-001',
+            ticketTitle: 'Test Ticket',
+            escalationLevel: 1,
+          }),
+        })
+      );
     });
   });
 

--- a/packages/sla/src/services/escalationService.ts
+++ b/packages/sla/src/services/escalationService.ts
@@ -13,6 +13,7 @@ import { Knex } from 'knex';
 import { tenantDb } from '@alga-psa/db';
 import { IEscalationManagerWithUser } from '../types';
 import { getEmailNotificationService } from '@alga-psa/notifications/notifications/email';
+import { createNotificationFromTemplateInternal } from '@alga-psa/notifications/actions/internal-notification-actions/internalNotificationActions';
 
 /**
  * Result of escalating a ticket
@@ -356,28 +357,28 @@ async function sendEscalationInAppNotification(
   level: number
 ): Promise<boolean> {
   try {
-    // Insert notification directly into internal_notifications table
-    await tenantDb(trx, tenant).table('internal_notifications').insert({
+    // Use the central template creation path so enablement, locale, configured
+    // priority resolution, broadcasts, and post-creation delivery hooks all run.
+    const notification = await createNotificationFromTemplateInternal(trx, {
       tenant,
       user_id: userId,
       template_name: 'sla-escalation',
-      language_code: 'en',
       type: 'warning',
-      title: `Ticket Escalated to Level ${level}`,
-      message: `Ticket #${ticketNumber}: "${ticketTitle}" has been escalated to level ${level} and requires your attention.`,
+      data: {
+        ticketNumber,
+        ticketTitle,
+        escalationLevel: level,
+      },
       category: 'sla',
       link: `/msp/tickets/${ticketId}`,
-      metadata: JSON.stringify({
+      metadata: {
         ticket_id: ticketId,
         escalation_level: level,
         subtype: 'sla-escalation'
-      }),
-      is_read: false,
-      delivery_status: 'pending',
-      delivery_attempts: 0
+      },
     });
 
-    return true;
+    return notification !== null;
   } catch (error) {
     console.error('Error sending escalation in-app notification:', error);
     return false;

--- a/packages/user-activities/src/actions/activityAggregationActions.ts
+++ b/packages/user-activities/src/actions/activityAggregationActions.ts
@@ -1432,145 +1432,144 @@ function sortActivities(
   });
 }
 
-/**
- * Fetch notification activities for a user
- */
+function applyNotificationActivityFilters(
+  queryBuilder: Knex.QueryBuilder,
+  filters: ActivityFilters,
+  priorityFeatureEnabled: boolean
+): void {
+  if (filters.isClosed === false) {
+    queryBuilder.where('internal_notifications.is_read', false);
+  } else if (filters.isClosed === true) {
+    queryBuilder.where('internal_notifications.is_read', true);
+  }
+
+  if (filters.search) {
+    queryBuilder.where('internal_notifications.category', filters.search);
+  }
+  if (filters.dateRangeStart) {
+    queryBuilder.where('internal_notifications.created_at', '>=', filters.dateRangeStart);
+  }
+  if (filters.dateRangeEnd) {
+    queryBuilder.where('internal_notifications.created_at', '<=', filters.dateRangeEnd);
+  }
+
+  if (!filters.priority?.length) return;
+
+  if (priorityFeatureEnabled) {
+    const storedPriorities = filters.priority.map((priority) =>
+      priority === ActivityPriority.MEDIUM ? 'normal' : priority
+    );
+    queryBuilder.whereIn('internal_notifications.priority', storedPriorities);
+    return;
+  }
+
+  const legacyTypes: string[] = [];
+  if (filters.priority.includes(ActivityPriority.HIGH)) legacyTypes.push('error');
+  if (filters.priority.includes(ActivityPriority.MEDIUM)) legacyTypes.push('warning');
+  const includesLegacyLow = filters.priority.includes(ActivityPriority.LOW);
+
+  queryBuilder.where(function legacyPriorityFilter() {
+    if (legacyTypes.length > 0) {
+      this.whereIn('internal_notifications.type', legacyTypes);
+    }
+    if (includesLegacyLow) {
+      const addLowClause = legacyTypes.length > 0 ? this.orWhere.bind(this) : this.where.bind(this);
+      addLowClause(function legacyLowPriority() {
+        this.whereNull('internal_notifications.type')
+          .orWhereNotIn('internal_notifications.type', ['error', 'warning']);
+      });
+    }
+  });
+}
+
+function mapNotificationActivity(
+  notification: any,
+  priorityFeatureEnabled: boolean
+): NotificationActivity {
+  const priority = mapStoredNotificationPriority(
+    notification.priority,
+    notification.type,
+    priorityFeatureEnabled
+  );
+  const toIsoString = (value: unknown): string => {
+    const parsed = value ? new Date(value as string | number | Date) : new Date();
+    return Number.isNaN(parsed.getTime()) ? new Date().toISOString() : parsed.toISOString();
+  };
+
+  return {
+    id: notification.internal_notification_id.toString(),
+    title: notification.title,
+    description: notification.message,
+    type: ActivityType.NOTIFICATION,
+    status: notification.type || 'info',
+    priority,
+    assignedTo: [notification.user_id],
+    sourceId: notification.internal_notification_id.toString(),
+    sourceType: ActivityType.NOTIFICATION,
+    notificationId: notification.internal_notification_id,
+    templateName: notification.template_name,
+    message: notification.message,
+    isRead: notification.is_read,
+    readAt: notification.read_at,
+    link: notification.link,
+    metadata: notification.metadata,
+    category: notification.category,
+    actions: [
+      { id: 'view', label: 'View Details' },
+      { id: 'mark-read', label: notification.is_read ? 'Mark Unread' : 'Mark Read' }
+    ],
+    tenant: notification.tenant,
+    createdAt: toIsoString(notification.created_at),
+    updatedAt: toIsoString(notification.updated_at)
+  };
+}
+
+function buildNotificationActivitiesQuery(
+  trx: Knex.Transaction,
+  tenant: string,
+  userId: string,
+  filters: ActivityFilters,
+  priorityFeatureEnabled: boolean
+): Knex.QueryBuilder {
+  return tenantDb(trx, tenant).table('internal_notifications')
+    .where('internal_notifications.user_id', userId)
+    .whereNull('internal_notifications.deleted_at')
+    .modify((queryBuilder) => {
+      applyNotificationActivityFilters(queryBuilder, filters, priorityFeatureEnabled);
+    });
+}
+
+/** Fetch notification activities for a user. */
 export async function fetchNotificationActivities(
   userId: string,
   tenantId: string,
   filters: ActivityFilters
 ): Promise<Activity[]> {
   try {
-    if (filters.clientId) {
-      return [];
-    }
+    if (filters.clientId) return [];
 
     const { knex: db, tenant } = await createTenantKnex(tenantId);
-    if (!tenant) {
-      throw new Error("Tenant is required");
-    }
-
-    // Query for notifications for the user
-    const notifications = await withTransaction(db, async (trx: Knex.Transaction) => {
-      return await tenantDb(trx, tenant).table("internal_notifications")
-        .where("internal_notifications.user_id", userId)
-        .whereNull("internal_notifications.deleted_at")
-        .modify(function(queryBuilder) {
-          // Apply read/unread filter
-          if (filters.isClosed === false) {
-            // Show unread only (default)
-            queryBuilder.where("internal_notifications.is_read", false);
-          } else if (filters.isClosed === true) {
-            // Show read only
-            queryBuilder.where("internal_notifications.is_read", true);
-          }
-          // If isClosed is undefined, show all
-
-          // Apply category filter (using search field as category)
-          if (filters.search) {
-            queryBuilder.where("internal_notifications.category", filters.search);
-          }
-
-          // Apply date range filter
-          if (filters.dateRangeStart) {
-            queryBuilder.where("internal_notifications.created_at", ">=", filters.dateRangeStart);
-          }
-          if (filters.dateRangeEnd) {
-            queryBuilder.where("internal_notifications.created_at", "<=", filters.dateRangeEnd);
-          }
-        })
-        .orderBy("internal_notifications.created_at", "desc");
+    if (!tenant) throw new Error('Tenant is required');
+    const priorityFeatureEnabled = await isFeatureFlagEnabled('release-v1.5-feature', {
+      tenantId: tenant,
+      userId,
     });
 
-    // Convert to activities
-    const activities: NotificationActivity[] = notifications.map((notification: any) => {
-      // Use the stored, configuration-resolved priority (task 29.8.46), falling
-      // back to the legacy type→priority derivation only when it is absent.
-      const priority: ActivityPriority = mapStoredNotificationPriority(
-        notification.priority,
-        notification.type
-      );
+    const notifications = await withTransaction(db, async (trx: Knex.Transaction) =>
+      buildNotificationActivitiesQuery(trx, tenant, userId, filters, priorityFeatureEnabled)
+        .orderBy('internal_notifications.created_at', 'desc')
+    );
+    const activities = notifications.map((notification: any) =>
+      mapNotificationActivity(notification, priorityFeatureEnabled)
+    );
 
-      // Ensure dates are properly formatted
-      let createdAtISO: string;
-      let updatedAtISO: string;
-
-      try {
-        if (notification.created_at) {
-          const createdDate = new Date(notification.created_at);
-          if (isNaN(createdDate.getTime())) {
-            console.warn('Invalid created_at date for notification:', notification.internal_notification_id, notification.created_at);
-            createdAtISO = new Date().toISOString();
-          } else {
-            createdAtISO = createdDate.toISOString();
-          }
-        } else {
-          createdAtISO = new Date().toISOString();
-        }
-
-        if (notification.updated_at) {
-          const updatedDate = new Date(notification.updated_at);
-          if (isNaN(updatedDate.getTime())) {
-            console.warn('Invalid updated_at date for notification:', notification.internal_notification_id, notification.updated_at);
-            updatedAtISO = new Date().toISOString();
-          } else {
-            updatedAtISO = updatedDate.toISOString();
-          }
-        } else {
-          updatedAtISO = new Date().toISOString();
-        }
-      } catch (error) {
-        console.error('Error parsing notification dates:', error, notification);
-        createdAtISO = new Date().toISOString();
-        updatedAtISO = new Date().toISOString();
-      }
-
-      return {
-        id: notification.internal_notification_id.toString(),
-        title: notification.title,
-        description: notification.message,
-        type: ActivityType.NOTIFICATION,
-        status: notification.type || 'info',
-        priority,
-        assignedTo: [notification.user_id],
-        sourceId: notification.internal_notification_id.toString(),
-        sourceType: ActivityType.NOTIFICATION,
-        notificationId: notification.internal_notification_id,
-        templateName: notification.template_name,
-        message: notification.message,
-        isRead: notification.is_read,
-        readAt: notification.read_at,
-        link: notification.link,
-        metadata: notification.metadata,
-        category: notification.category,
-        actions: [
-          { id: 'view', label: 'View Details' },
-          { id: 'mark-read', label: notification.is_read ? 'Mark Unread' : 'Mark Read' }
-        ],
-        tenant: notification.tenant,
-        createdAt: createdAtISO,
-        updatedAt: updatedAtISO
-      };
-    });
-
-    // Apply priority filter post-mapping (priority is derived from notification type)
-    let filteredActivities: NotificationActivity[] = activities;
-    if (filters.priority && filters.priority.length > 0) {
-      const normalizedFilterPriorities = filters.priority.map(p => p.toLowerCase());
-      filteredActivities = activities.filter(activity =>
-        normalizedFilterPriorities.includes(activity.priority.toLowerCase())
-      );
-    }
-
-    // Cache individual activity type results
-    if (filteredActivities.length > 0) {
+    if (activities.length > 0) {
       const cacheKey = `notification-activities:${userId}:${JSON.stringify(filters)}`;
-      await cache.set(cacheKey, JSON.stringify(filteredActivities), cache.ttl.LIST, [`user:${userId}`, `type:${ActivityType.NOTIFICATION}`]);
+      await cache.set(cacheKey, JSON.stringify(activities), cache.ttl.LIST, [`user:${userId}`, `type:${ActivityType.NOTIFICATION}`]);
     }
-
-    return filteredActivities;
+    return activities;
   } catch (error) {
-    console.error("Error fetching notification activities:", error);
+    console.error('Error fetching notification activities:', error);
     return [];
   }
 }
@@ -1585,13 +1584,9 @@ export interface PagedNotificationActivities {
 }
 
 /**
- * Paged variant of {@link fetchNotificationActivities} (task 29.8.46). Reuses the
- * exact same query + priority-mapping + priority-filter logic — the underlying
- * fetch already orders by created_at desc (chronological, newest first) — then
- * returns a single offset/limit window plus the total matching count so the User
- * Activities card view can render numbered server-side pagination instead of
- * slicing a full client-side fetch. The unpaged fetchNotificationActivities is
- * intentionally left untouched.
+ * Paged variant of {@link fetchNotificationActivities} (task 29.8.46). The
+ * database applies the shared filters, count, offset, and limit before rows are
+ * mapped, so the focused view does not load the entire notification history.
  */
 export async function fetchNotificationActivitiesPagedInternal(
   userId: string,
@@ -1600,11 +1595,36 @@ export async function fetchNotificationActivitiesPagedInternal(
   offset: number = 0,
   limit: number = 20
 ): Promise<PagedNotificationActivities> {
-  const all = await fetchNotificationActivities(userId, tenantId, filters) as NotificationActivity[];
-  const total = all.length;
-  const start = Math.max(0, offset);
-  const end = start + Math.max(0, limit);
-  return { activities: all.slice(start, end), total };
+  if (filters.clientId) return { activities: [], total: 0 };
+
+  const { knex: db, tenant } = await createTenantKnex(tenantId);
+  if (!tenant) throw new Error('Tenant is required');
+  const priorityFeatureEnabled = await isFeatureFlagEnabled('release-v1.5-feature', {
+    tenantId: tenant,
+    userId,
+  });
+  const safeOffset = Math.max(0, Math.floor(offset));
+  const safeLimit = Math.max(0, Math.min(100, Math.floor(limit)));
+
+  return withTransaction(db, async (trx: Knex.Transaction) => {
+    const baseQuery = buildNotificationActivitiesQuery(
+      trx,
+      tenant,
+      userId,
+      filters,
+      priorityFeatureEnabled
+    );
+    const [{ count }] = await baseQuery.clone().count('* as count');
+    const rows = await baseQuery.clone()
+      .orderBy('internal_notifications.created_at', 'desc')
+      .offset(safeOffset)
+      .limit(safeLimit);
+
+    return {
+      activities: rows.map((row: any) => mapNotificationActivity(row, priorityFeatureEnabled)),
+      total: Number(count),
+    };
+  });
 }
 
 /**

--- a/packages/user-activities/src/actions/activityAggregationActions.ts
+++ b/packages/user-activities/src/actions/activityAggregationActions.ts
@@ -1432,6 +1432,9 @@ function sortActivities(
   });
 }
 
+/**
+ * Fetch notification activities
+ */
 function applyNotificationActivityFilters(
   queryBuilder: Knex.QueryBuilder,
   filters: ActivityFilters,

--- a/packages/user-activities/src/actions/activityAggregationActions.ts
+++ b/packages/user-activities/src/actions/activityAggregationActions.ts
@@ -31,6 +31,11 @@ import { IProjectTask } from '@alga-psa/types';
 import { fetchWorkflowTaskActivities } from '@alga-psa/user-activities/server/workflow-tasks';
 export { fetchWorkflowTaskActivities };
 
+// Configurable notification priorities (task 29.8.46): map the stored priority
+// to the activity tier, with legacy type-fallback. Extracted to a typed module
+// so it is unit-testable outside this @ts-nocheck file.
+import { mapStoredNotificationPriority } from './notificationPriority';
+
 // Enhanced in-memory cache implementation with different TTLs and invalidation
 const cache = {
   data: new Map<string, { value: string; expiry: number; tags: string[] }>(),
@@ -1479,18 +1484,12 @@ export async function fetchNotificationActivities(
 
     // Convert to activities
     const activities: NotificationActivity[] = notifications.map((notification: any) => {
-      // Map notification type to activity priority
-      let priority: ActivityPriority;
-      switch (notification.type) {
-        case 'error':
-          priority = ActivityPriority.HIGH;
-          break;
-        case 'warning':
-          priority = ActivityPriority.MEDIUM;
-          break;
-        default:
-          priority = ActivityPriority.LOW;
-      }
+      // Use the stored, configuration-resolved priority (task 29.8.46), falling
+      // back to the legacy type→priority derivation only when it is absent.
+      const priority: ActivityPriority = mapStoredNotificationPriority(
+        notification.priority,
+        notification.type
+      );
 
       // Ensure dates are properly formatted
       let createdAtISO: string;
@@ -1574,6 +1573,38 @@ export async function fetchNotificationActivities(
     console.error("Error fetching notification activities:", error);
     return [];
   }
+}
+
+/**
+ * Result of a single paged window of notification activities.
+ */
+export interface PagedNotificationActivities {
+  activities: NotificationActivity[];
+  /** Total number of notification activities matching the filters (before paging). */
+  total: number;
+}
+
+/**
+ * Paged variant of {@link fetchNotificationActivities} (task 29.8.46). Reuses the
+ * exact same query + priority-mapping + priority-filter logic — the underlying
+ * fetch already orders by created_at desc (chronological, newest first) — then
+ * returns a single offset/limit window plus the total matching count so the User
+ * Activities card view can render numbered server-side pagination instead of
+ * slicing a full client-side fetch. The unpaged fetchNotificationActivities is
+ * intentionally left untouched.
+ */
+export async function fetchNotificationActivitiesPagedInternal(
+  userId: string,
+  tenantId: string,
+  filters: ActivityFilters,
+  offset: number = 0,
+  limit: number = 20
+): Promise<PagedNotificationActivities> {
+  const all = await fetchNotificationActivities(userId, tenantId, filters) as NotificationActivity[];
+  const total = all.length;
+  const start = Math.max(0, offset);
+  const end = start + Math.max(0, limit);
+  return { activities: all.slice(start, end), total };
 }
 
 /**

--- a/packages/user-activities/src/actions/activityAggregationActionsNotificationRootTenantScoped.contract.test.ts
+++ b/packages/user-activities/src/actions/activityAggregationActionsNotificationRootTenantScoped.contract.test.ts
@@ -5,20 +5,25 @@ import { resolve } from 'path';
 const sourcePath = resolve(__dirname, 'activityAggregationActions.ts');
 const source = readFileSync(sourcePath, 'utf8');
 
-function sectionFrom(startMarker: string): string {
+function sectionBetween(startMarker: string, endMarker: string): string {
   const start = source.indexOf(startMarker);
+  const end = source.indexOf(endMarker, start);
 
   expect(start).toBeGreaterThanOrEqual(0);
+  expect(end).toBeGreaterThan(start);
 
-  return source.slice(start);
+  return source.slice(start, end);
 }
 
 describe('activity aggregation notification root tenant-scoped query contract', () => {
   it('uses structural tenant scoping for the notification activity root', () => {
-    const section = sectionFrom('export async function fetchNotificationActivities');
+    const section = sectionBetween(
+      'function buildNotificationActivitiesQuery',
+      '/** Fetch notification activities for a user. */'
+    );
 
-    expect(section).toContain(".table(\"internal_notifications");
-    expect(section).toContain('.where("internal_notifications.user_id", userId)');
+    expect(section).toContain("tenantDb(trx, tenant).table('internal_notifications')");
+    expect(section).toContain(".where('internal_notifications.user_id', userId)");
 
     expect(section).not.toContain('return await trx("internal_notifications")');
     expect(section).not.toContain('.where("internal_notifications.tenant", tenant)');

--- a/packages/user-activities/src/actions/activityServerActions.ts
+++ b/packages/user-activities/src/actions/activityServerActions.ts
@@ -21,8 +21,10 @@ import {
   fetchTicketActivities as fetchTicketActivitiesInternal,
   fetchTimeEntryActivities as fetchTimeEntryActivitiesInternal,
   fetchWorkflowTaskActivities as fetchWorkflowTaskActivitiesInternal,
-  fetchNotificationActivities as fetchNotificationActivitiesInternal
+  fetchNotificationActivities as fetchNotificationActivitiesInternal,
+  fetchNotificationActivitiesPagedInternal
 } from "./activityAggregationActions";
+import type { PagedNotificationActivities } from "./activityAggregationActions";
 import { withAuth, hasPermission } from "@alga-psa/auth";
 import { revalidatePath } from "next/cache";
 import {
@@ -178,6 +180,32 @@ export const fetchNotificationActivities = withAuth(async (
     return await fetchNotificationActivitiesInternal(user.user_id, tenant, filters) as NotificationActivity[];
   } catch (error) {
     console.error("Error fetching notification activities:", error);
+    throw error;
+  }
+});
+
+/**
+ * Server action to fetch a single offset/limit window of notification activities for
+ * the current user, together with the total matching count. Powers the numbered
+ * server-side pagination of the User Activities notifications card full view
+ * (task 29.8.46). Reuses the same query + filtering as fetchNotificationActivities.
+ *
+ * @param filters Optional filters (read/unread, category, date range, priority)
+ * @param offset  Zero-based index of the first item to return
+ * @param limit   Maximum number of items to return
+ * @returns Promise resolving to { activities, total }
+ */
+export const fetchNotificationActivitiesPaged = withAuth(async (
+  user,
+  { tenant },
+  filters: ActivityFilters = {},
+  offset: number = 0,
+  limit: number = 20
+): Promise<PagedNotificationActivities> => {
+  try {
+    return await fetchNotificationActivitiesPagedInternal(user.user_id, tenant, filters, offset, limit);
+  } catch (error) {
+    console.error("Error fetching paged notification activities:", error);
     throw error;
   }
 });

--- a/packages/user-activities/src/actions/notificationPriority.test.ts
+++ b/packages/user-activities/src/actions/notificationPriority.test.ts
@@ -20,4 +20,10 @@ describe('mapStoredNotificationPriority (task 29.8.46 activities mapper)', () =>
   it('falls back to legacy when the stored value is not a recognized tier', () => {
     expect(mapStoredNotificationPriority('bogus', 'warning')).toBe(ActivityPriority.MEDIUM);
   });
+
+  it('preserves legacy type mapping while the feature flag is off', () => {
+    expect(mapStoredNotificationPriority('low', 'error', false)).toBe(ActivityPriority.HIGH);
+    expect(mapStoredNotificationPriority('high', 'warning', false)).toBe(ActivityPriority.MEDIUM);
+    expect(mapStoredNotificationPriority('high', 'info', false)).toBe(ActivityPriority.LOW);
+  });
 });

--- a/packages/user-activities/src/actions/notificationPriority.test.ts
+++ b/packages/user-activities/src/actions/notificationPriority.test.ts
@@ -1,0 +1,23 @@
+import { describe, expect, it } from 'vitest';
+import { ActivityPriority } from '@alga-psa/types';
+import { mapStoredNotificationPriority } from './notificationPriority';
+
+describe('mapStoredNotificationPriority (task 29.8.46 activities mapper)', () => {
+  it('uses the stored priority when present (stored wins over type)', () => {
+    // stored 'low' beats a type of 'error' that would legacy-derive HIGH
+    expect(mapStoredNotificationPriority('low', 'error')).toBe(ActivityPriority.LOW);
+    expect(mapStoredNotificationPriority('high', 'info')).toBe(ActivityPriority.HIGH);
+    expect(mapStoredNotificationPriority('normal', 'error')).toBe(ActivityPriority.MEDIUM);
+  });
+
+  it('falls back to the legacy type derivation when stored priority is absent', () => {
+    expect(mapStoredNotificationPriority(null, 'error')).toBe(ActivityPriority.HIGH);
+    expect(mapStoredNotificationPriority(undefined, 'warning')).toBe(ActivityPriority.MEDIUM);
+    expect(mapStoredNotificationPriority(null, 'info')).toBe(ActivityPriority.LOW);
+    expect(mapStoredNotificationPriority(undefined, undefined)).toBe(ActivityPriority.LOW);
+  });
+
+  it('falls back to legacy when the stored value is not a recognized tier', () => {
+    expect(mapStoredNotificationPriority('bogus', 'warning')).toBe(ActivityPriority.MEDIUM);
+  });
+});

--- a/packages/user-activities/src/actions/notificationPriority.ts
+++ b/packages/user-activities/src/actions/notificationPriority.ts
@@ -1,0 +1,36 @@
+import { ActivityPriority } from '@alga-psa/types';
+
+/**
+ * Map the stored in-app notification priority (high|normal|low, from task
+ * 29.8.46) to the activity feed's ActivityPriority tier. Falls back to the
+ * legacy notification `type`→priority derivation (error→HIGH, warning→MEDIUM,
+ * else LOW) only when the stored priority is absent — e.g. rows created before
+ * the backfill, or a payload that predates the column.
+ *
+ * LEVERAGE: friction notification-priority-mapper — the same stored→tier +
+ * legacy-fallback logic also exists in
+ * packages/client-portal/.../notificationActivities.ts. Kept per-package per
+ * the task's "no drive-by refactors" scope; a shared @alga-psa/types helper is
+ * the natural home if a third copy appears.
+ */
+export function mapStoredNotificationPriority(
+  storedPriority: string | null | undefined,
+  type: string | null | undefined
+): ActivityPriority {
+  switch (storedPriority) {
+    case 'high':
+      return ActivityPriority.HIGH;
+    case 'normal':
+      return ActivityPriority.MEDIUM;
+    case 'low':
+      return ActivityPriority.LOW;
+  }
+  switch (type) {
+    case 'error':
+      return ActivityPriority.HIGH;
+    case 'warning':
+      return ActivityPriority.MEDIUM;
+    default:
+      return ActivityPriority.LOW;
+  }
+}

--- a/packages/user-activities/src/actions/notificationPriority.ts
+++ b/packages/user-activities/src/actions/notificationPriority.ts
@@ -15,15 +15,18 @@ import { ActivityPriority } from '@alga-psa/types';
  */
 export function mapStoredNotificationPriority(
   storedPriority: string | null | undefined,
-  type: string | null | undefined
+  type: string | null | undefined,
+  priorityFeatureEnabled: boolean = true
 ): ActivityPriority {
-  switch (storedPriority) {
-    case 'high':
-      return ActivityPriority.HIGH;
-    case 'normal':
-      return ActivityPriority.MEDIUM;
-    case 'low':
-      return ActivityPriority.LOW;
+  if (priorityFeatureEnabled) {
+    switch (storedPriority) {
+      case 'high':
+        return ActivityPriority.HIGH;
+      case 'normal':
+        return ActivityPriority.MEDIUM;
+      case 'low':
+        return ActivityPriority.LOW;
+    }
   }
   switch (type) {
     case 'error':

--- a/packages/user-activities/src/components/NotificationCard.tsx
+++ b/packages/user-activities/src/components/NotificationCard.tsx
@@ -3,7 +3,8 @@ import React from 'react';
 import {
   Activity,
   NotificationActivity,
-  ActivityType
+  ActivityType,
+  ActivityPriority
 } from "@alga-psa/types";
 import { useActivityDrawer } from "./ActivityDrawerProvider";
 import { Badge } from "@alga-psa/ui/components/Badge";
@@ -11,6 +12,7 @@ import { ActivityActionMenu } from "./ActivityActionMenu";
 import { Bell, Info, CheckCircle, AlertCircle } from 'lucide-react';
 import { formatDistanceToNow } from 'date-fns';
 import { markAsReadAction } from '@alga-psa/notifications/actions';
+import { useFeatureFlag } from '@alga-psa/ui/hooks';
 import { useTranslation } from '@alga-psa/ui/lib/i18n/client';
 
 interface NotificationCardProps {
@@ -51,10 +53,32 @@ const getBorderColor = (type: string) => {
   }
 };
 
+// Per-row priority indicator dot colour (task 29.8.46). High uses a muted
+// "attention red" (desaturated, not emergency); normal/low stay neutral.
+const PRIORITY_DOT_COLOR: Record<string, string> = {
+  [ActivityPriority.HIGH]: '#b45454',
+  [ActivityPriority.MEDIUM]: '#9ca3af',
+  [ActivityPriority.LOW]: '#cbd5e1',
+};
+
+// Map the activity priority onto the i18n key stem used for the row label.
+const priorityLabelKey = (priority: ActivityPriority | undefined): 'high' | 'normal' | 'low' => {
+  switch (priority) {
+    case ActivityPriority.HIGH:
+      return 'high';
+    case ActivityPriority.LOW:
+      return 'low';
+    default:
+      return 'normal';
+  }
+};
+
 export function NotificationCard({ activity, onViewDetails, onActionComplete }: NotificationCardProps) {
   const { t } = useTranslation('msp/user-activities');
+  const { enabled } = useFeatureFlag('release-v1.5-feature');
   const { openActivityDrawer } = useActivityDrawer();
   const notification = activity as NotificationActivity;
+  const priority = notification.priority as ActivityPriority | undefined;
 
   const handleClick = async () => {
     // Mark as read if unread
@@ -76,9 +100,31 @@ export function NotificationCard({ activity, onViewDetails, onActionComplete }: 
     openActivityDrawer(activity);
   };
 
+  // Flag on (task 29.8.46): ~5px corners, no colored left rail, carried by a soft
+  // shadow with no border. High-tier cards add a muted attention-red ring to the
+  // shadow; low-tier cards render dimmed. Flag off: original markup unchanged.
+  const restyled = enabled;
+  const isHigh = priority === ActivityPriority.HIGH;
+  const isLow = priority === ActivityPriority.LOW;
+
+  const restyledClassName = [
+    'p-4 transition-shadow cursor-pointer',
+    !notification.isRead ? 'bg-primary-50' : 'bg-white',
+    isHigh ? 'shadow-md hover:shadow-lg' : 'shadow-sm hover:shadow-md',
+    isLow ? 'opacity-60 hover:opacity-100' : '',
+  ].filter(Boolean).join(' ');
+
+  const restyledStyle: React.CSSProperties = {
+    borderRadius: '5px',
+    ...(isHigh ? { boxShadow: '0 1px 3px rgba(0,0,0,0.10), 0 0 0 1px rgba(180,84,84,0.45)' } : {}),
+  };
+
   return (
     <div
-      className={`p-4 border-l-4 ${getBorderColor(notification.status)} ${!notification.isRead ? 'bg-primary-50' : 'bg-white'} rounded-md shadow-sm hover:shadow-md transition-shadow cursor-pointer`}
+      className={restyled
+        ? restyledClassName
+        : `p-4 border-l-4 ${getBorderColor(notification.status)} ${!notification.isRead ? 'bg-primary-50' : 'bg-white'} rounded-md shadow-sm hover:shadow-md transition-shadow cursor-pointer`}
+      style={restyled ? restyledStyle : undefined}
       onClick={handleClick}
       id={`notification-card-${notification.id}`}
     >
@@ -107,6 +153,17 @@ export function NotificationCard({ activity, onViewDetails, onActionComplete }: 
 
       <div className="flex items-center justify-between text-xs">
         <div className="flex items-center gap-2">
+          {restyled && (
+            <span className="inline-flex items-center gap-1 text-gray-600" title={t('sections.notifications.priority.label', { defaultValue: 'Priority' })}>
+              <span
+                className="w-2 h-2 rounded-full flex-shrink-0"
+                style={{ backgroundColor: PRIORITY_DOT_COLOR[priority ?? ActivityPriority.MEDIUM] }}
+              />
+              {t(`sections.notifications.priority.${priorityLabelKey(priority)}`, {
+                defaultValue: priorityLabelKey(priority) === 'high' ? 'High' : priorityLabelKey(priority) === 'low' ? 'Low' : 'Normal',
+              })}
+            </span>
+          )}
           {notification.category && (
             <Badge variant="default">{notification.category}</Badge>
           )}

--- a/packages/user-activities/src/components/NotificationsSection.tsx
+++ b/packages/user-activities/src/components/NotificationsSection.tsx
@@ -3,17 +3,19 @@
 
 import React, { useEffect, useState, useCallback, useRef, useMemo } from 'react';
 import { useSearchParams } from 'next/navigation';
-import { ActivityFilters, NotificationActivity } from "@alga-psa/types";
+import { ActivityFilters, ActivityPriority, NotificationActivity } from "@alga-psa/types";
 import { Button } from "@alga-psa/ui/components/Button";
 import { Card, CardContent, CardHeader, CardTitle } from "@alga-psa/ui/components/Card";
 import { NotificationCard } from "./NotificationCard";
-import { fetchNotificationActivities } from "@alga-psa/user-activities/actions";
+import { fetchNotificationActivities, fetchNotificationActivitiesPaged } from "@alga-psa/user-activities/actions";
 import { NotificationSectionFiltersDialog } from "./filters/NotificationSectionFiltersDialog";
 import { Filter, XCircle } from 'lucide-react';
 import { useActivityDrawer } from "./ActivityDrawerProvider";
 import { getCurrentUser } from "@alga-psa/user-composition/actions";
 import { Badge } from "@alga-psa/ui/components/Badge";
+import Pagination from '@alga-psa/ui/components/Pagination';
 import { useInternalNotifications } from "@alga-psa/notifications/hooks";
+import { useFeatureFlag } from '@alga-psa/ui/hooks';
 import { useSession } from 'next-auth/react';
 import CustomTabs from '@alga-psa/ui/components/CustomTabs';
 import { useTranslation } from '@alga-psa/ui/lib/i18n/client';
@@ -22,12 +24,40 @@ interface NotificationsSectionProps {
   limit?: number;
   onViewAll?: () => void;
   noCard?: boolean;
+  /**
+   * Full-view mode (task 29.8.46, flag-gated): render the numbered server-side
+   * pager and priority filter chips instead of the fixed 5-item preview. Only
+   * takes effect when the `release-v1.5-feature` flag is enabled; with the flag
+   * off the component behaves exactly as before regardless of this prop.
+   */
+  fullMode?: boolean;
 }
 
 const DEFAULT_TAB = 'unread';
+// Page size for the flag-on full-view server-side pagination.
+const FULL_MODE_PAGE_SIZE = 20;
+type PriorityFilterKey = 'all' | 'high' | 'normal' | 'low';
 
-export function NotificationsSection({ limit = 5, onViewAll, noCard = false }: NotificationsSectionProps) {
+// Map a priority filter chip to the ActivityPriority value stored on notification
+// activities (stored 'normal' → ActivityPriority.MEDIUM).
+function priorityKeyToActivityPriority(key: PriorityFilterKey): ActivityPriority | undefined {
+  switch (key) {
+    case 'high':
+      return ActivityPriority.HIGH;
+    case 'normal':
+      return ActivityPriority.MEDIUM;
+    case 'low':
+      return ActivityPriority.LOW;
+    default:
+      return undefined;
+  }
+}
+
+export function NotificationsSection({ limit = 5, onViewAll, noCard = false, fullMode = false }: NotificationsSectionProps) {
   const { t } = useTranslation('msp/user-activities');
+  const { enabled } = useFeatureFlag('release-v1.5-feature');
+  // Full-view behaviour (pager + priority chips) is only active with the flag on.
+  const isFullView = enabled && fullMode;
   const { data: session } = useSession();
   const searchParams = useSearchParams();
   const notificationTabParam = searchParams?.get('notificationTab');
@@ -47,6 +77,21 @@ export function NotificationsSection({ limit = 5, onViewAll, noCard = false }: N
   const [notificationFilters, setNotificationFilters] = useState<Partial<ActivityFilters>>({
     isClosed: false // Default: show unread only
   });
+
+  // Full-view (flag-on) server-side pagination state.
+  const [currentPage, setCurrentPage] = useState(1);
+  const [totalCount, setTotalCount] = useState(0);
+
+  // Derive the active priority chip from the shared notification filters, so the
+  // chips and the filter dialog stay in sync off a single source of truth.
+  const activePriorityKey: PriorityFilterKey =
+    notificationFilters.priority?.includes(ActivityPriority.HIGH)
+      ? 'high'
+      : notificationFilters.priority?.includes(ActivityPriority.MEDIUM)
+        ? 'normal'
+        : notificationFilters.priority?.includes(ActivityPriority.LOW)
+          ? 'low'
+          : 'all';
 
   // Use real-time notifications hook to detect changes
   const tenant = session?.user?.tenant;
@@ -68,22 +113,43 @@ export function NotificationsSection({ limit = 5, onViewAll, noCard = false }: N
       setLoading(true);
       setError(null);
 
-      // Fetch notification activities using current filters
-      const result = await fetchNotificationActivities(filters);
+      if (isFullView) {
+        // Full view (flag on): server-side paginated window + total count. The
+        // underlying fetch already orders newest-first (chronological).
+        const offset = (currentPage - 1) * FULL_MODE_PAGE_SIZE;
+        const { activities: paged, total } = await fetchNotificationActivitiesPaged(
+          filters,
+          offset,
+          FULL_MODE_PAGE_SIZE
+        );
+        setActivities(paged);
+        setTotalCount(total);
+      } else {
+        // Fetch notification activities using current filters
+        const result = await fetchNotificationActivities(filters);
 
-      // Sort by creation date (newest first)
-      const sortedActivities = result.sort((a: NotificationActivity, b: NotificationActivity) => {
-        return new Date(b.createdAt).getTime() - new Date(a.createdAt).getTime();
-      });
+        // Sort by creation date (newest first)
+        const sortedActivities = result.sort((a: NotificationActivity, b: NotificationActivity) => {
+          return new Date(b.createdAt).getTime() - new Date(a.createdAt).getTime();
+        });
 
-      setActivities(sortedActivities.slice(0, limit));
+        setActivities(sortedActivities.slice(0, limit));
+      }
     } catch (err) {
       console.error('Error loading notification activities:', err);
       setError(t('sections.notifications.errors.loadFailed', { defaultValue: 'Failed to load notification activities. Please try again later.' }));
     } finally {
       setLoading(false);
     }
-  }, [limit]);
+  }, [limit, isFullView, currentPage]);
+
+  // In full view, reset to the first page whenever the effective filters change so
+  // the user is never stranded on an out-of-range page.
+  useEffect(() => {
+    if (isFullView) {
+      setCurrentPage(1);
+    }
+  }, [notificationFilters, isFullView]);
 
   // Load activities initially and when filters change
   useEffect(() => {
@@ -251,42 +317,106 @@ export function NotificationsSection({ limit = 5, onViewAll, noCard = false }: N
     </div>
   );
 
+  // Apply a priority filter chip by writing the shared notification filters (the
+  // filter dialog reads/writes the same `priority` key, keeping the two in sync).
+  const handlePriorityChip = (key: PriorityFilterKey) => {
+    setNotificationFilters(prev => {
+      const next = { ...prev };
+      const mapped = priorityKeyToActivityPriority(key);
+      if (mapped) {
+        next.priority = [mapped];
+      } else {
+        delete next.priority;
+      }
+      return next;
+    });
+  };
+
+  // Priority filter chips (full view only). Chronological order is preserved; the
+  // chips only narrow the list, they never regroup it.
+  const priorityChips = (
+    <div className="flex flex-wrap items-center gap-2 mb-4">
+      <span className="text-sm font-medium text-gray-600 mr-1">
+        {t('sections.notifications.priority.label', { defaultValue: 'Priority' })}
+      </span>
+      {(['all', 'high', 'normal', 'low'] as PriorityFilterKey[]).map(key => (
+        <Button
+          key={key}
+          id={`notification-priority-filter-${key}`}
+          variant={activePriorityKey === key ? 'default' : 'outline'}
+          size="sm"
+          onClick={() => handlePriorityChip(key)}
+          disabled={loading}
+        >
+          {t(`sections.notifications.priority.${key}`, {
+            defaultValue: key === 'all' ? 'All' : key === 'high' ? 'High' : key === 'normal' ? 'Normal' : 'Low',
+          })}
+        </Button>
+      ))}
+    </div>
+  );
+
   // Render notifications content
   const renderNotifications = () => {
-    if (loading) {
+    const body = (() => {
+      if (loading) {
+        return (
+          <div className="flex justify-center items-center h-40">
+            <p className="text-gray-500">{t('sections.notifications.states.loading', { defaultValue: 'Loading notification activities...' })}</p>
+          </div>
+        );
+      }
+
+      if (error) {
+        return (
+          <div className="flex justify-center items-center h-40">
+            <p className="text-destructive">{error}</p>
+          </div>
+        );
+      }
+
+      if (activities.length === 0) {
+        return (
+          <div className="flex justify-center items-center h-40">
+            <p className="text-gray-500">{t('sections.notifications.states.empty', { defaultValue: 'No notification activities found' })}</p>
+          </div>
+        );
+      }
+
       return (
-        <div className="flex justify-center items-center h-40">
-          <p className="text-gray-500">{t('sections.notifications.states.loading', { defaultValue: 'Loading notification activities...' })}</p>
+        <div className="grid grid-cols-1 gap-4">
+          {activities.map(activity => (
+            <NotificationCard
+              key={activity.id}
+              activity={activity}
+              onViewDetails={() => openActivityDrawer(activity)}
+              onActionComplete={handleRefresh}
+            />
+          ))}
         </div>
       );
+    })();
+
+    // Flag off / preview mode: identical markup to before.
+    if (!isFullView) {
+      return body;
     }
 
-    if (error) {
-      return (
-        <div className="flex justify-center items-center h-40">
-          <p className="text-destructive">{error}</p>
-        </div>
-      );
-    }
-
-    if (activities.length === 0) {
-      return (
-        <div className="flex justify-center items-center h-40">
-          <p className="text-gray-500">{t('sections.notifications.states.empty', { defaultValue: 'No notification activities found' })}</p>
-        </div>
-      );
-    }
-
+    // Flag on / full view: priority chips above the list, numbered server-side pager below.
     return (
-      <div className="grid grid-cols-1 gap-4">
-        {activities.map(activity => (
-          <NotificationCard
-            key={activity.id}
-            activity={activity}
-            onViewDetails={() => openActivityDrawer(activity)}
-            onActionComplete={handleRefresh}
+      <div>
+        {priorityChips}
+        {body}
+        {totalCount > FULL_MODE_PAGE_SIZE && (
+          <Pagination
+            id="notification-activities-pagination"
+            totalItems={totalCount}
+            itemsPerPage={FULL_MODE_PAGE_SIZE}
+            currentPage={currentPage}
+            onPageChange={setCurrentPage}
+            variant="clients"
           />
-        ))}
+        )}
       </div>
     );
   };

--- a/packages/user-activities/src/components/UserActivitiesDashboard.tsx
+++ b/packages/user-activities/src/components/UserActivitiesDashboard.tsx
@@ -2,6 +2,7 @@
 
 
 import React, { useState, useEffect, useMemo } from 'react';
+import { useSearchParams } from 'next/navigation';
 import ViewSwitcher, { ViewSwitcherOption } from '@alga-psa/ui/components/ViewSwitcher';
 import { ScheduleSection } from './ScheduleSection';
 import { TicketsSection } from './TicketsSection';
@@ -12,17 +13,23 @@ import { ActivitiesDataTableSection } from './ActivitiesDataTableSection';
 import { LayoutGrid, List, ChevronDown, ChevronUp } from 'lucide-react';
 import { ActivityFilters as ActivityFiltersType, ActivityType } from '@alga-psa/types';
 import { useUserPreference } from '@alga-psa/user-composition/hooks';
+import { useFeatureFlag } from '@alga-psa/ui/hooks';
 import { Card, CardHeader } from '@alga-psa/ui/components/Card';
 import { useTranslation } from '@alga-psa/ui/lib/i18n/client';
 
 export function UserActivitiesDashboard() {
   const { t } = useTranslation('msp/user-activities');
+  const { enabled } = useFeatureFlag('release-v1.5-feature');
+  const searchParams = useSearchParams();
+  // Bell "View all notifications" deep-links here with ?focus=notifications. Treat it
+  // as an EPHEMERAL card-view override (task 29.8.46) — only honoured with the flag on.
+  const focusNotifications = enabled && searchParams?.get('focus') === 'notifications';
   // Define view mode type
   type UserActivitiesViewMode = 'cards' | 'table';
-  
+
   // Use the custom hook for view mode preference
-  const { 
-    value: viewMode, 
+  const {
+    value: viewMode,
     setValue: setViewModePreference
   } = useUserPreference<UserActivitiesViewMode>(
     'activitiesDashboardViewMode',
@@ -32,13 +39,28 @@ export function UserActivitiesDashboard() {
       debounceMs: 300
     }
   );
-  
+
+  // Ephemeral, in-memory view override (flag on only): "View All" and the focus deep
+  // link switch the view for the current visit WITHOUT persisting the saved preference.
+  // The ViewSwitcher remains the only thing that writes the preference.
+  const [ephemeralView, setEphemeralView] = useState<UserActivitiesViewMode | null>(null);
+
   const [tableInitialFilters, setTableInitialFilters] = useState<ActivityFiltersType | null>(null); // State for specific filters
 
   // Collapsible sections state
   const [expandedSections, setExpandedSections] = useState({
     notifications: true,
     schedule: true,
+  });
+
+  // Focus-mode collapsible state (flag on): notifications expanded to full mode with
+  // the other sections present but collapsed below it.
+  const [focusExpandedSections, setFocusExpandedSections] = useState({
+    notifications: true,
+    schedule: false,
+    tickets: false,
+    projects: false,
+    workflowTasks: false,
   });
 
   const toggleSection = (section: keyof typeof expandedSections) => {
@@ -48,11 +70,24 @@ export function UserActivitiesDashboard() {
     }));
   };
 
+  const toggleFocusSection = (section: keyof typeof focusExpandedSections) => {
+    setFocusExpandedSections(prev => ({
+      ...prev,
+      [section]: !prev[section]
+    }));
+  };
+
   // Generic handler for "View All" clicks
   const handleViewAll = (types: ActivityType[]) => {
     const filters: ActivityFiltersType = { types, isClosed: false };
     setTableInitialFilters(filters);
-    setViewModePreference('table');
+    if (enabled) {
+      // Flag on: switch to the table view ephemerally; do NOT persist the preference.
+      setEphemeralView('table');
+    } else {
+      // Flag off: preserve today's behaviour (persist 'table' for every section).
+      setViewModePreference('table');
+    }
   };
 
   // Specific handlers calling the generic one
@@ -162,13 +197,143 @@ export function UserActivitiesDashboard() {
     { value: 'table', label: t('dashboard.viewSwitcher.table', { defaultValue: 'Table' }), icon: List },
   ];
 
-  // Handler for view change
+  // Handler for view change (the ViewSwitcher — the only writer of the saved preference)
   const handleViewChange = (newView: UserActivitiesViewMode) => {
     setViewModePreference(newView);
+    // Flag on: an explicit switch also wins over any ephemeral/focus override this visit.
+    if (enabled) {
+      setEphemeralView(newView);
+    }
     if (newView === 'table') {
       setTableInitialFilters(null); // Reset specific filters when switching to table view
     }
   };
+
+  // Effective view mode. Flag off: exactly the saved preference (today's behaviour).
+  // Flag on: an ephemeral override wins, else the focus deep link forces cards, else pref.
+  const effectiveViewMode: UserActivitiesViewMode = enabled
+    ? (ephemeralView ?? (focusNotifications ? 'cards' : viewMode))
+    : viewMode;
+
+  // Focus-mode card layout (flag on): notifications expanded to full mode, the other
+  // sections rendered collapsed below — still present and expandable.
+  const focusCardViewContent = (
+    <div className="space-y-6">
+      {/* Notifications — expanded, full mode with server-side pagination + priority chips */}
+      <Card>
+        <CardHeader
+          className="cursor-pointer hover:bg-muted/50 transition-colors"
+          onClick={() => toggleFocusSection('notifications')}
+        >
+          <div className="flex items-center justify-between">
+            <h2 className="text-lg font-semibold">{t('dashboard.sections.notifications', { defaultValue: 'Notifications' })}</h2>
+            {focusExpandedSections.notifications ? (
+              <ChevronUp className="h-5 w-5 text-muted-foreground" />
+            ) : (
+              <ChevronDown className="h-5 w-5 text-muted-foreground" />
+            )}
+          </div>
+        </CardHeader>
+        {focusExpandedSections.notifications && (
+          <NotificationsSection
+            fullMode
+            onViewAll={handleViewAllNotifications}
+          />
+        )}
+      </Card>
+
+      {/* Schedule — collapsed */}
+      <Card>
+        <CardHeader
+          className="cursor-pointer hover:bg-muted/50 transition-colors"
+          onClick={() => toggleFocusSection('schedule')}
+        >
+          <div className="flex items-center justify-between">
+            <h2 className="text-lg font-semibold">{t('dashboard.sections.schedule', { defaultValue: 'Schedule' })}</h2>
+            {focusExpandedSections.schedule ? (
+              <ChevronUp className="h-5 w-5 text-muted-foreground" />
+            ) : (
+              <ChevronDown className="h-5 w-5 text-muted-foreground" />
+            )}
+          </div>
+        </CardHeader>
+        {focusExpandedSections.schedule && (
+          <ScheduleSection limit={5} onViewAll={handleViewAllSchedule} />
+        )}
+      </Card>
+
+      {/* Tickets — collapsed */}
+      <Card>
+        <CardHeader
+          className="cursor-pointer hover:bg-muted/50 transition-colors"
+          onClick={() => toggleFocusSection('tickets')}
+        >
+          <div className="flex items-center justify-between">
+            <h2 className="text-lg font-semibold">{t('sections.tickets.title', { defaultValue: 'Tickets' })}</h2>
+            {focusExpandedSections.tickets ? (
+              <ChevronUp className="h-5 w-5 text-muted-foreground" />
+            ) : (
+              <ChevronDown className="h-5 w-5 text-muted-foreground" />
+            )}
+          </div>
+        </CardHeader>
+        {focusExpandedSections.tickets && (
+          <TicketsSection limit={5} onViewAll={handleViewAllTickets} />
+        )}
+      </Card>
+
+      {/* Projects — collapsed */}
+      <Card>
+        <CardHeader
+          className="cursor-pointer hover:bg-muted/50 transition-colors"
+          onClick={() => toggleFocusSection('projects')}
+        >
+          <div className="flex items-center justify-between">
+            <h2 className="text-lg font-semibold">{t('sections.projects.title', { defaultValue: 'Project Tasks' })}</h2>
+            {focusExpandedSections.projects ? (
+              <ChevronUp className="h-5 w-5 text-muted-foreground" />
+            ) : (
+              <ChevronDown className="h-5 w-5 text-muted-foreground" />
+            )}
+          </div>
+        </CardHeader>
+        {focusExpandedSections.projects && (
+          <ProjectsSection limit={5} onViewAll={handleViewAllProjects} />
+        )}
+      </Card>
+
+      {/* Workflow Tasks — collapsed */}
+      <Card>
+        <CardHeader
+          className="cursor-pointer hover:bg-muted/50 transition-colors"
+          onClick={() => toggleFocusSection('workflowTasks')}
+        >
+          <div className="flex items-center justify-between">
+            <h2 className="text-lg font-semibold">{t('sections.workflowTasks.title', { defaultValue: 'Workflow Tasks' })}</h2>
+            {focusExpandedSections.workflowTasks ? (
+              <ChevronUp className="h-5 w-5 text-muted-foreground" />
+            ) : (
+              <ChevronDown className="h-5 w-5 text-muted-foreground" />
+            )}
+          </div>
+        </CardHeader>
+        {focusExpandedSections.workflowTasks && (
+          <WorkflowTasksSection limit={5} onViewAll={handleViewAllWorkflowTasks} />
+        )}
+      </Card>
+    </div>
+  );
+
+  // Pick the main content. Table always wins when selected; otherwise the focus deep
+  // link (flag on) renders the focus layout, else the standard card view.
+  let mainContent: React.ReactNode;
+  if (effectiveViewMode === 'table') {
+    mainContent = tableViewContent;
+  } else if (enabled && focusNotifications) {
+    mainContent = focusCardViewContent;
+  } else {
+    mainContent = cardViewContent;
+  }
 
   return (
     <div className="container mx-auto p-6">
@@ -177,13 +342,13 @@ export function UserActivitiesDashboard() {
         <div className="flex items-center gap-4">
           <ViewSwitcher
             options={viewOptions}
-            currentView={viewMode}
+            currentView={effectiveViewMode}
             onChange={handleViewChange}
           />
         </div>
       </div>
 
-      {viewMode === 'cards' ? cardViewContent : tableViewContent}
+      {mainContent}
     </div>
   );
 }

--- a/packages/user-activities/src/components/filters/NotificationSectionFiltersDialog.tsx
+++ b/packages/user-activities/src/components/filters/NotificationSectionFiltersDialog.tsx
@@ -13,10 +13,34 @@ import { Button } from "@alga-psa/ui/components/Button";
 import { Checkbox } from "@alga-psa/ui/components/Checkbox";
 import { Label } from "@alga-psa/ui/components/Label";
 import { StringDateRangePicker } from "@alga-psa/ui/components/DateRangePicker";
-import { ActivityFilters } from "@alga-psa/types";
+import { ActivityFilters, ActivityPriority } from "@alga-psa/types";
 import { ISO8601String } from '@alga-psa/types';
 import CustomSelect from "@alga-psa/ui/components/CustomSelect";
+import { useFeatureFlag } from '@alga-psa/ui/hooks';
 import { useTranslation } from '@alga-psa/ui/lib/i18n/client';
+
+type PriorityFilterKey = 'all' | 'high' | 'normal' | 'low';
+
+// Map the stored notification priority (ActivityPriority) onto the filter select key.
+function activityFiltersToPriorityKey(filters: Partial<ActivityFilters>): PriorityFilterKey {
+  if (filters.priority?.includes(ActivityPriority.HIGH)) return 'high';
+  if (filters.priority?.includes(ActivityPriority.MEDIUM)) return 'normal';
+  if (filters.priority?.includes(ActivityPriority.LOW)) return 'low';
+  return 'all';
+}
+
+function priorityKeyToActivityPriority(key: PriorityFilterKey): ActivityPriority | undefined {
+  switch (key) {
+    case 'high':
+      return ActivityPriority.HIGH;
+    case 'normal':
+      return ActivityPriority.MEDIUM;
+    case 'low':
+      return ActivityPriority.LOW;
+    default:
+      return undefined;
+  }
+}
 
 interface NotificationSectionFiltersDialogProps {
   isOpen: boolean;
@@ -32,6 +56,7 @@ export function NotificationSectionFiltersDialog({
   onApplyFilters,
 }: NotificationSectionFiltersDialogProps) {
   const { t } = useTranslation('msp/user-activities');
+  const { enabled } = useFeatureFlag('release-v1.5-feature');
 
   // Notification categories mapping
   const NOTIFICATION_CATEGORIES = [
@@ -43,11 +68,13 @@ export function NotificationSectionFiltersDialog({
   // Local state for filters
   const [localFilters, setLocalFilters] = useState<Partial<ActivityFilters>>(() => initialFilters);
   const [selectedCategory, setSelectedCategory] = useState<string>(initialFilters.search || 'all');
+  const [selectedPriority, setSelectedPriority] = useState<PriorityFilterKey>(() => activityFiltersToPriorityKey(initialFilters));
 
   // Sync local state when initial filters change from parent
   useEffect(() => {
     setLocalFilters(initialFilters);
     setSelectedCategory(initialFilters.search || 'all');
+    setSelectedPriority(activityFiltersToPriorityKey(initialFilters));
   }, [initialFilters]);
 
   const handleDateChange = (range: { from: string; to: string }) => {
@@ -75,6 +102,16 @@ export function NotificationSectionFiltersDialog({
 
     if (!filtersToApply.search) delete filtersToApply.search;
 
+    // Priority filter only exists when the flag is on; leave filters untouched otherwise.
+    if (enabled) {
+      const mappedPriority = priorityKeyToActivityPriority(selectedPriority);
+      if (mappedPriority) {
+        filtersToApply.priority = [mappedPriority];
+      } else {
+        delete filtersToApply.priority;
+      }
+    }
+
     onApplyFilters(filtersToApply);
     onOpenChange(false);
   };
@@ -88,6 +125,7 @@ export function NotificationSectionFiltersDialog({
     };
     setLocalFilters(clearedFilters);
     setSelectedCategory('all');
+    setSelectedPriority('all');
   };
 
   const footer = (
@@ -148,6 +186,25 @@ export function NotificationSectionFiltersDialog({
               placeholder={t('sections.notifications.filterDialog.fields.categoryPlaceholder', { defaultValue: 'Select Category...' })}
             />
           </div>
+
+          {/* Priority Filter (flag-gated) */}
+          {enabled && (
+            <div className="space-y-1">
+              <Label htmlFor="notification-priority-select" className="text-base font-semibold">{t('sections.notifications.priority.label', { defaultValue: 'Priority' })}</Label>
+              <CustomSelect
+                id="notification-priority-select"
+                value={selectedPriority}
+                onValueChange={(value) => setSelectedPriority(value as PriorityFilterKey)}
+                options={[
+                  { value: 'all', label: t('sections.notifications.priority.allPriorities', { defaultValue: 'All Priorities' }) },
+                  { value: 'high', label: t('sections.notifications.priority.high', { defaultValue: 'High' }) },
+                  { value: 'normal', label: t('sections.notifications.priority.normal', { defaultValue: 'Normal' }) },
+                  { value: 'low', label: t('sections.notifications.priority.low', { defaultValue: 'Low' }) },
+                ]}
+                placeholder={t('sections.notifications.priority.placeholder', { defaultValue: 'Select Priority...' })}
+              />
+            </div>
+          )}
 
           {/* Date Range */}
           <div className="space-y-1">

--- a/packages/user-activities/vitest.config.ts
+++ b/packages/user-activities/vitest.config.ts
@@ -1,0 +1,11 @@
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  test: {
+    globals: true,
+    environment: 'node',
+    include: ['src/**/*.{test,spec}.{ts,tsx}', 'tests/**/*.{test,spec}.{ts,tsx}'],
+    passWithNoTests: true,
+    testTimeout: 10000,
+  },
+});

--- a/server/migrations/20260811120000_add_notification_priorities.cjs
+++ b/server/migrations/20260811120000_add_notification_priorities.cjs
@@ -1,0 +1,126 @@
+/**
+ * Configurable notification priorities (task 29.8.46).
+ *
+ * Adds a three-layer priority configuration chain to the in-app
+ * `internal_notification_*` system plus a stamped priority on each
+ * notification instance:
+ *
+ *   1. internal_notification_subtypes.default_priority (system default)
+ *   2. tenant_internal_notification_subtype_settings.priority (tenant override)
+ *   3. user_internal_notification_preferences.priority (per-user override)
+ *   4. internal_notifications.priority (resolved value stamped at creation)
+ *
+ * All four are CHECK-constrained text columns (high|normal|low) — matching the
+ * tenant-settings migration style and avoiding enum-alteration friction later.
+ *
+ * Column adds propagate automatically on Citus (ALTER TABLE ... ADD COLUMN),
+ * so no explicit distribution work is needed here; the backfill is written as
+ * a set of `WHERE template_name IN (...)` multi-shard updates rather than a
+ * cross-table distributed join so it is safe on both Citus and plain Postgres.
+ */
+
+const PRIORITY_CHECK = "IN ('high','normal','low')";
+
+// Exact High/Low subtype lists from the plan
+// (docs/plans/2026-08-11-notification-priorities-plan.md, §"Data model").
+// Everything not listed keeps the column default 'normal'.
+//
+// NOTE: the plan lists `rmm-alert-triggered`, but the live subtype is named
+// `RMM Alert Triggered`; both spellings are included so the plan's intent is
+// realized regardless of which name a given database carries. Names that do
+// not resolve (e.g. `project-budget-exceeded`, not yet seeded) are harmless
+// no-ops.
+const HIGH_SUBTYPES = [
+  'sla-breach',
+  'sla-escalation',
+  'rmm-alert-triggered',
+  'RMM Alert Triggered',
+  'payment-overdue',
+  'system-announcement',
+  'project-budget-exceeded',
+];
+
+const LOW_SUBTYPES = [
+  'opportunity-weekly-digest',
+  'milestone-completed',
+  'sla-response-met',
+  'sla-resolution-met',
+];
+
+async function addPriorityColumn(knex, table, column, { notNull }) {
+  const nullClause = notNull ? "NOT NULL DEFAULT 'normal'" : 'NULL';
+  await knex.raw(
+    `ALTER TABLE ?? ADD COLUMN IF NOT EXISTS ?? text ${nullClause} ` +
+    `CHECK (?? ${PRIORITY_CHECK})`,
+    [table, column, column]
+  );
+}
+
+async function dropPriorityColumn(knex, table, column) {
+  await knex.raw('ALTER TABLE ?? DROP COLUMN IF EXISTS ??', [table, column]);
+}
+
+exports.up = async function up(knex) {
+  console.log('Adding notification priority columns...');
+
+  // 1. System default per subtype.
+  await addPriorityColumn(knex, 'internal_notification_subtypes', 'default_priority', { notNull: true });
+  // 2. Tenant override (NULL = inherit default).
+  await addPriorityColumn(knex, 'tenant_internal_notification_subtype_settings', 'priority', { notNull: false });
+  // 3. Per-user override (NULL = inherit tenant/default; meaningful on subtype rows only).
+  await addPriorityColumn(knex, 'user_internal_notification_preferences', 'priority', { notNull: false });
+  // 4. Stamped priority on the distributed instance table.
+  await addPriorityColumn(knex, 'internal_notifications', 'priority', { notNull: true });
+  console.log('  ✓ Added priority columns');
+
+  // 5. Seed subtype system defaults (everything else stays 'normal').
+  const highUpdated = await knex('internal_notification_subtypes')
+    .whereIn('name', HIGH_SUBTYPES)
+    .update({ default_priority: 'high', updated_at: knex.fn.now() });
+  const lowUpdated = await knex('internal_notification_subtypes')
+    .whereIn('name', LOW_SUBTYPES)
+    .update({ default_priority: 'low', updated_at: knex.fn.now() });
+  console.log(`  ✓ Seeded subtype defaults (high: ${highUpdated}, low: ${lowUpdated})`);
+
+  // 6. Backfill existing instance rows from their subtype default via the
+  //    template-name join. Computed on the coordinator (templates + subtypes
+  //    are small catalog tables), then applied as multi-shard IN-list updates
+  //    so it works identically on Citus and plain Postgres. Rows whose
+  //    template name no longer resolves keep the column default 'normal'.
+  const templatePriorities = await knex('internal_notification_templates as t')
+    .join('internal_notification_subtypes as s', 't.subtype_id', 's.internal_notification_subtype_id')
+    .whereIn('s.default_priority', ['high', 'low'])
+    .distinct('t.name as template_name', 's.default_priority as priority');
+
+  const namesByPriority = { high: [], low: [] };
+  for (const row of templatePriorities) {
+    if (namesByPriority[row.priority]) {
+      namesByPriority[row.priority].push(row.template_name);
+    }
+  }
+
+  let backfilled = 0;
+  for (const priority of ['high', 'low']) {
+    const names = namesByPriority[priority];
+    if (names.length === 0) continue;
+    // Batch to keep the IN-list bounded on very large template catalogs.
+    for (let i = 0; i < names.length; i += 100) {
+      const batch = names.slice(i, i + 100);
+      backfilled += await knex('internal_notifications')
+        .whereIn('template_name', batch)
+        .update({ priority, updated_at: knex.fn.now() });
+    }
+  }
+  console.log(`  ✓ Backfilled ${backfilled} existing notification rows`);
+
+  console.log('Notification priority migration completed.');
+};
+
+exports.down = async function down(knex) {
+  console.log('Reverting notification priority columns...');
+  await dropPriorityColumn(knex, 'internal_notifications', 'priority');
+  await dropPriorityColumn(knex, 'user_internal_notification_preferences', 'priority');
+  await dropPriorityColumn(knex, 'tenant_internal_notification_subtype_settings', 'priority');
+  await dropPriorityColumn(knex, 'internal_notification_subtypes', 'default_priority');
+  console.log('  ✓ Dropped priority columns');
+};

--- a/server/migrations/20260811120000_add_notification_priorities.cjs
+++ b/server/migrations/20260811120000_add_notification_priorities.cjs
@@ -49,11 +49,28 @@ const LOW_SUBTYPES = [
 
 async function addPriorityColumn(knex, table, column, { notNull }) {
   const nullClause = notNull ? "NOT NULL DEFAULT 'normal'" : 'NULL';
+  // Citus rejects an inline CHECK on ADD COLUMN ("cannot execute ADD COLUMN
+  // command with ... CHECK constraints" / "all constraints in Citus must have
+  // explicit names"), so the column and its CHECK must be separate statements
+  // and the constraint must be named. Add the column first, then the named
+  // CHECK in its own statement — idempotent via a pg_constraint probe because
+  // Postgres has no ADD CONSTRAINT IF NOT EXISTS. This works identically on
+  // Citus (distributed/reference tables) and plain Postgres.
   await knex.raw(
-    `ALTER TABLE ?? ADD COLUMN IF NOT EXISTS ?? text ${nullClause} ` +
-    `CHECK (?? ${PRIORITY_CHECK})`,
-    [table, column, column]
+    `ALTER TABLE ?? ADD COLUMN IF NOT EXISTS ?? text ${nullClause}`,
+    [table, column]
   );
+  const constraintName = `${column}_priority_ck`;
+  const existing = await knex.raw(
+    `SELECT 1 FROM pg_constraint WHERE conname = ? AND conrelid = ?::regclass`,
+    [constraintName, table]
+  );
+  if (existing.rows.length === 0) {
+    await knex.raw(
+      `ALTER TABLE ?? ADD CONSTRAINT ?? CHECK (?? ${PRIORITY_CHECK})`,
+      [table, constraintName, column]
+    );
+  }
 }
 
 async function dropPriorityColumn(knex, table, column) {

--- a/server/public/locales/de/client-portal.json
+++ b/server/public/locales/de/client-portal.json
@@ -701,7 +701,13 @@
       "saveError": "Einstellung konnte nicht gespeichert werden",
       "noCategories": "Keine Benachrichtigungskategorien verfügbar",
       "emailPreferences": "E-Mail",
-      "internalPreferences": "Intern"
+      "internalPreferences": "Intern",
+      "priority": {
+        "high": "Hoch",
+        "normal": "Normal",
+        "low": "Niedrig"
+      },
+      "resetPriority": "Zurücksetzen"
     },
     "categories": {
       "tickets": "Tickets",
@@ -710,6 +716,8 @@
       "projects": "Projekte",
       "system": "System"
     },
+    "needsAttention": "Erfordert Aufmerksamkeit ({{count}})",
+    "lowPriority": "Niedrige Priorität ({{count}})",
     "filters": {
       "title": "Benachrichtigungen filtern",
       "description": "Wählen Sie Kriterien zum Filtern von Benachrichtigungsaktivitäten aus.",

--- a/server/public/locales/de/client-portal.json
+++ b/server/public/locales/de/client-portal.json
@@ -728,6 +728,9 @@
       "allCategories": "Alle Kategorien",
       "categoryPlaceholder": "Kategorie auswählen...",
       "dateRangeLabel": "Datumsbereich",
+      "priorityLabel": "Priorität",
+      "allPriorities": "Alle Prioritäten",
+      "priorityPlaceholder": "Priorität auswählen...",
       "reset": "Zurücksetzen",
       "cancel": "Abbrechen",
       "apply": "Filter anwenden"

--- a/server/public/locales/de/common.json
+++ b/server/public/locales/de/common.json
@@ -1328,5 +1328,9 @@
       "description": "Dieser Bereich gehört zum vollständigen AlgaPSA-Produkt. AlgaDesk enthält ausschließlich fokussierte Helpdesk-Funktionen.",
       "cta": "Zurück zum AlgaDesk-Dashboard"
     }
+  },
+  "notifications": {
+    "needsAttention": "Erfordert Aufmerksamkeit ({{count}})",
+    "lowPriority": "Niedrige Priorität ({{count}})"
   }
 }

--- a/server/public/locales/de/msp/settings.json
+++ b/server/public/locales/de/msp/settings.json
@@ -1494,7 +1494,8 @@
         "description": "Beschreibung",
         "enabled": "Aktiviert",
         "defaultForUsers": "Standard für Benutzer",
-        "actions": "Aktionen"
+        "actions": "Aktionen",
+        "priority": "Priorität"
       },
       "actions": {
         "enableAllSubtypes": "Alle Untertypen aktivieren",
@@ -1506,7 +1507,8 @@
         "discardChanges": "Änderungen verwerfen",
         "saving": "Wird gespeichert...",
         "saveChanges": "Änderungen speichern",
-        "cancel": "Abbrechen"
+        "cancel": "Abbrechen",
+        "resetToDefault": "Auf Standard zurücksetzen"
       },
       "intro": "Legen Sie fest, welche internen Benachrichtigungstypen verfügbar sind, und definieren Sie Standardwerte für neue Benutzer.",
       "enabledLabel": "Aktiviert:",
@@ -1517,6 +1519,11 @@
       "discardDialog": {
         "title": "Änderungen verwerfen?",
         "message": "Sind Sie sicher, dass Sie alle nicht gespeicherten Änderungen verwerfen möchten? Diese Aktion kann nicht rückgängig gemacht werden."
+      },
+      "priority": {
+        "high": "Hoch",
+        "normal": "Normal",
+        "low": "Niedrig"
       }
     }
   },

--- a/server/public/locales/de/msp/user-activities.json
+++ b/server/public/locales/de/msp/user-activities.json
@@ -435,6 +435,15 @@
           "cancel": "Abbrechen",
           "apply": "Filter anwenden"
         }
+      },
+      "priority": {
+        "label": "Priorität",
+        "all": "Alle",
+        "allPriorities": "Alle Prioritäten",
+        "placeholder": "Priorität auswählen…",
+        "high": "Hoch",
+        "normal": "Normal",
+        "low": "Niedrig"
       }
     }
   },

--- a/server/public/locales/en/client-portal.json
+++ b/server/public/locales/en/client-portal.json
@@ -750,7 +750,13 @@
       "saveError": "Failed to save preference",
       "noCategories": "No notification categories available",
       "emailPreferences": "Email preferences",
-      "internalPreferences": "Internal preferences"
+      "internalPreferences": "Internal preferences",
+      "priority": {
+        "high": "High",
+        "normal": "Normal",
+        "low": "Low"
+      },
+      "resetPriority": "Reset"
     },
     "categories": {
       "tickets": "Tickets",
@@ -759,6 +765,8 @@
       "projects": "Projects",
       "system": "System"
     },
+    "needsAttention": "Needs attention ({{count}})",
+    "lowPriority": "Low priority ({{count}})",
     "filters": {
       "title": "Filter Notifications",
       "description": "Select criteria to filter notification activities.",

--- a/server/public/locales/en/client-portal.json
+++ b/server/public/locales/en/client-portal.json
@@ -777,6 +777,9 @@
       "allCategories": "All Categories",
       "categoryPlaceholder": "Select Category...",
       "dateRangeLabel": "Date Range",
+      "priorityLabel": "Priority",
+      "allPriorities": "All Priorities",
+      "priorityPlaceholder": "Select Priority...",
       "reset": "Reset",
       "cancel": "Cancel",
       "apply": "Apply Filters"

--- a/server/public/locales/en/common.json
+++ b/server/public/locales/en/common.json
@@ -1328,5 +1328,9 @@
       "description": "This page is not available in your current product experience.",
       "cta": "Go to dashboard"
     }
+  },
+  "notifications": {
+    "needsAttention": "Needs attention ({{count}})",
+    "lowPriority": "Low priority ({{count}})"
   }
 }

--- a/server/public/locales/en/msp/settings.json
+++ b/server/public/locales/en/msp/settings.json
@@ -1494,7 +1494,8 @@
         "description": "Description",
         "enabled": "Enabled",
         "defaultForUsers": "Default for Users",
-        "actions": "Actions"
+        "actions": "Actions",
+        "priority": "Priority"
       },
       "actions": {
         "enableAllSubtypes": "Enable all subtypes",
@@ -1506,7 +1507,8 @@
         "discardChanges": "Discard Changes",
         "saving": "Saving...",
         "saveChanges": "Save Changes",
-        "cancel": "Cancel"
+        "cancel": "Cancel",
+        "resetToDefault": "Reset to default"
       },
       "intro": "Control which internal notification types are available and set defaults for new users.",
       "enabledLabel": "Enabled:",
@@ -1517,6 +1519,11 @@
       "discardDialog": {
         "title": "Discard Changes?",
         "message": "Are you sure you want to discard all unsaved changes? This action cannot be undone."
+      },
+      "priority": {
+        "high": "High",
+        "normal": "Normal",
+        "low": "Low"
       }
     }
   },

--- a/server/public/locales/en/msp/user-activities.json
+++ b/server/public/locales/en/msp/user-activities.json
@@ -435,6 +435,15 @@
           "cancel": "Cancel",
           "apply": "Apply Filters"
         }
+      },
+      "priority": {
+        "label": "Priority",
+        "all": "All",
+        "allPriorities": "All Priorities",
+        "placeholder": "Select Priority...",
+        "high": "High",
+        "normal": "Normal",
+        "low": "Low"
       }
     }
   },

--- a/server/public/locales/es/client-portal.json
+++ b/server/public/locales/es/client-portal.json
@@ -701,7 +701,13 @@
       "saveError": "Error al guardar la preferencia",
       "noCategories": "No hay categorías de notificaciones disponibles",
       "emailPreferences": "Correo electrónico",
-      "internalPreferences": "Interno"
+      "internalPreferences": "Interno",
+      "priority": {
+        "high": "Alta",
+        "normal": "Normal",
+        "low": "Baja"
+      },
+      "resetPriority": "Restablecer"
     },
     "categories": {
       "tickets": "Tickets",
@@ -710,6 +716,8 @@
       "projects": "Proyectos",
       "system": "Sistema"
     },
+    "needsAttention": "Requiere atención ({{count}})",
+    "lowPriority": "Prioridad baja ({{count}})",
     "filters": {
       "title": "Filtrar notificaciones",
       "description": "Seleccione criterios para filtrar las actividades de notificación.",

--- a/server/public/locales/es/client-portal.json
+++ b/server/public/locales/es/client-portal.json
@@ -728,6 +728,9 @@
       "allCategories": "Todas las categorías",
       "categoryPlaceholder": "Seleccione una categoría...",
       "dateRangeLabel": "Intervalo de fechas",
+      "priorityLabel": "Prioridad",
+      "allPriorities": "Todas las prioridades",
+      "priorityPlaceholder": "Seleccione una prioridad...",
       "reset": "Restablecer",
       "cancel": "Cancelar",
       "apply": "Aplicar filtros"

--- a/server/public/locales/es/common.json
+++ b/server/public/locales/es/common.json
@@ -1328,5 +1328,9 @@
       "description": "Esta área forma parte del producto completo AlgaPSA. AlgaDesk incluye únicamente funciones específicas de mesa de ayuda.",
       "cta": "Volver al panel de AlgaDesk"
     }
+  },
+  "notifications": {
+    "needsAttention": "Requiere atención ({{count}})",
+    "lowPriority": "Prioridad baja ({{count}})"
   }
 }

--- a/server/public/locales/es/msp/settings.json
+++ b/server/public/locales/es/msp/settings.json
@@ -1494,7 +1494,8 @@
         "description": "Descripción",
         "enabled": "Habilitado",
         "defaultForUsers": "Predeterminado para usuarios",
-        "actions": "Acciones"
+        "actions": "Acciones",
+        "priority": "Prioridad"
       },
       "actions": {
         "enableAllSubtypes": "Habilitar todos los subtipos",
@@ -1506,7 +1507,8 @@
         "discardChanges": "Descartar cambios",
         "saving": "Guardando...",
         "saveChanges": "Guardar cambios",
-        "cancel": "Cancelar"
+        "cancel": "Cancelar",
+        "resetToDefault": "Restablecer al valor predeterminado"
       },
       "intro": "Controle qué tipos de notificaciones internas están disponibles y establezca los valores predeterminados para los nuevos usuarios.",
       "enabledLabel": "Habilitado:",
@@ -1517,6 +1519,11 @@
       "discardDialog": {
         "title": "¿Descartar cambios?",
         "message": "¿Está seguro de que desea descartar todos los cambios sin guardar? Esta acción no se puede deshacer."
+      },
+      "priority": {
+        "high": "Alta",
+        "normal": "Normal",
+        "low": "Baja"
       }
     }
   },

--- a/server/public/locales/es/msp/user-activities.json
+++ b/server/public/locales/es/msp/user-activities.json
@@ -435,6 +435,15 @@
           "cancel": "Cancelar",
           "apply": "Aplicar filtros"
         }
+      },
+      "priority": {
+        "label": "Prioridad",
+        "all": "Todas",
+        "allPriorities": "Todas las prioridades",
+        "placeholder": "Seleccionar prioridad…",
+        "high": "Alta",
+        "normal": "Normal",
+        "low": "Baja"
       }
     }
   },

--- a/server/public/locales/fr/client-portal.json
+++ b/server/public/locales/fr/client-portal.json
@@ -701,7 +701,13 @@
       "saveError": "Échec de l'enregistrement de la préférence",
       "noCategories": "Aucune catégorie de notification disponible",
       "emailPreferences": "E-mail",
-      "internalPreferences": "Internes"
+      "internalPreferences": "Internes",
+      "priority": {
+        "high": "Élevée",
+        "normal": "Normale",
+        "low": "Faible"
+      },
+      "resetPriority": "Réinitialiser"
     },
     "categories": {
       "tickets": "Tickets",
@@ -710,6 +716,8 @@
       "projects": "Projets",
       "system": "Système"
     },
+    "needsAttention": "Requiert votre attention ({{count}})",
+    "lowPriority": "Priorité basse ({{count}})",
     "filters": {
       "title": "Filtrer les notifications",
       "description": "Sélectionnez des critères pour filtrer les activités de notification.",

--- a/server/public/locales/fr/client-portal.json
+++ b/server/public/locales/fr/client-portal.json
@@ -728,6 +728,9 @@
       "allCategories": "Toutes les catégories",
       "categoryPlaceholder": "Sélectionnez une catégorie...",
       "dateRangeLabel": "Plage de dates",
+      "priorityLabel": "Priorité",
+      "allPriorities": "Toutes les priorités",
+      "priorityPlaceholder": "Sélectionnez une priorité...",
       "reset": "Réinitialiser",
       "cancel": "Annuler",
       "apply": "Appliquer les filtres"

--- a/server/public/locales/fr/common.json
+++ b/server/public/locales/fr/common.json
@@ -1328,5 +1328,9 @@
       "description": "Cette page n'est pas disponible dans votre expérience produit actuelle.",
       "cta": "Aller au tableau de bord"
     }
+  },
+  "notifications": {
+    "needsAttention": "Requiert votre attention ({{count}})",
+    "lowPriority": "Priorité basse ({{count}})"
   }
 }

--- a/server/public/locales/fr/msp/settings.json
+++ b/server/public/locales/fr/msp/settings.json
@@ -1494,7 +1494,8 @@
         "description": "Description",
         "enabled": "Activé",
         "defaultForUsers": "Par défaut pour les utilisateurs",
-        "actions": "Actions"
+        "actions": "Actions",
+        "priority": "Priorité"
       },
       "actions": {
         "enableAllSubtypes": "Activer tous les sous-types",
@@ -1506,7 +1507,8 @@
         "discardChanges": "Annuler les modifications",
         "saving": "Enregistrement...",
         "saveChanges": "Enregistrer les modifications",
-        "cancel": "Annuler"
+        "cancel": "Annuler",
+        "resetToDefault": "Réinitialiser par défaut"
       },
       "intro": "Contrôlez quels types de notifications internes sont disponibles et définissez les valeurs par défaut pour les nouveaux utilisateurs.",
       "enabledLabel": "Activé :",
@@ -1517,6 +1519,11 @@
       "discardDialog": {
         "title": "Annuler les modifications ?",
         "message": "Êtes-vous sûr de vouloir annuler toutes les modifications non enregistrées ? Cette action est irréversible."
+      },
+      "priority": {
+        "high": "Élevée",
+        "normal": "Normale",
+        "low": "Faible"
       }
     }
   },

--- a/server/public/locales/fr/msp/user-activities.json
+++ b/server/public/locales/fr/msp/user-activities.json
@@ -435,6 +435,15 @@
           "cancel": "Annuler",
           "apply": "Appliquer les filtres"
         }
+      },
+      "priority": {
+        "label": "Priorité",
+        "all": "Toutes",
+        "allPriorities": "Toutes les priorités",
+        "placeholder": "Sélectionner une priorité…",
+        "high": "Élevée",
+        "normal": "Normale",
+        "low": "Basse"
       }
     }
   },

--- a/server/public/locales/it/client-portal.json
+++ b/server/public/locales/it/client-portal.json
@@ -701,7 +701,13 @@
       "saveError": "Impossibile salvare la preferenza",
       "noCategories": "Nessuna categoria di notifica disponibile",
       "emailPreferences": "Email",
-      "internalPreferences": "Interne"
+      "internalPreferences": "Interne",
+      "priority": {
+        "high": "Alta",
+        "normal": "Normale",
+        "low": "Bassa"
+      },
+      "resetPriority": "Ripristina"
     },
     "categories": {
       "tickets": "Ticket",
@@ -710,6 +716,8 @@
       "projects": "Progetti",
       "system": "Sistema"
     },
+    "needsAttention": "Richiede attenzione ({{count}})",
+    "lowPriority": "Priorità bassa ({{count}})",
     "filters": {
       "title": "Filtra notifiche",
       "description": "Seleziona i criteri per filtrare le attività di notifica.",

--- a/server/public/locales/it/client-portal.json
+++ b/server/public/locales/it/client-portal.json
@@ -728,6 +728,9 @@
       "allCategories": "Tutte le categorie",
       "categoryPlaceholder": "Seleziona categoria...",
       "dateRangeLabel": "Intervallo date",
+      "priorityLabel": "Priorità",
+      "allPriorities": "Tutte le priorità",
+      "priorityPlaceholder": "Seleziona priorità...",
       "reset": "Reimposta",
       "cancel": "Annulla",
       "apply": "Applica filtri"

--- a/server/public/locales/it/common.json
+++ b/server/public/locales/it/common.json
@@ -1328,5 +1328,9 @@
       "description": "Questa pagina non è disponibile nella tua esperienza di prodotto attuale.",
       "cta": "Vai alla dashboard"
     }
+  },
+  "notifications": {
+    "needsAttention": "Richiede attenzione ({{count}})",
+    "lowPriority": "Priorità bassa ({{count}})"
   }
 }

--- a/server/public/locales/it/msp/settings.json
+++ b/server/public/locales/it/msp/settings.json
@@ -1494,7 +1494,8 @@
         "description": "Descrizione",
         "enabled": "Abilitato",
         "defaultForUsers": "Predefinito per gli utenti",
-        "actions": "Azioni"
+        "actions": "Azioni",
+        "priority": "Priorità"
       },
       "actions": {
         "enableAllSubtypes": "Abilita tutti i sottotipi",
@@ -1506,7 +1507,8 @@
         "discardChanges": "Annulla modifiche",
         "saving": "Salvataggio...",
         "saveChanges": "Salva modifiche",
-        "cancel": "Annulla"
+        "cancel": "Annulla",
+        "resetToDefault": "Ripristina predefinito"
       },
       "intro": "Controlla quali tipi di notifiche interne sono disponibili e imposta i valori predefiniti per i nuovi utenti.",
       "enabledLabel": "Abilitato:",
@@ -1517,6 +1519,11 @@
       "discardDialog": {
         "title": "Annullare le modifiche?",
         "message": "Sei sicuro di voler annullare tutte le modifiche non salvate? Questa azione non può essere annullata."
+      },
+      "priority": {
+        "high": "Alta",
+        "normal": "Normale",
+        "low": "Bassa"
       }
     }
   },

--- a/server/public/locales/it/msp/user-activities.json
+++ b/server/public/locales/it/msp/user-activities.json
@@ -435,6 +435,15 @@
           "cancel": "Annulla",
           "apply": "Applica filtri"
         }
+      },
+      "priority": {
+        "label": "Priorità",
+        "all": "Tutte",
+        "allPriorities": "Tutte le priorità",
+        "placeholder": "Seleziona priorità…",
+        "high": "Alta",
+        "normal": "Normale",
+        "low": "Bassa"
       }
     }
   },

--- a/server/public/locales/nl/client-portal.json
+++ b/server/public/locales/nl/client-portal.json
@@ -701,7 +701,13 @@
       "saveError": "Voorkeur kon niet worden opgeslagen",
       "noCategories": "Geen notificatiecategorieën beschikbaar",
       "emailPreferences": "E-mail",
-      "internalPreferences": "Intern"
+      "internalPreferences": "Intern",
+      "priority": {
+        "high": "Hoog",
+        "normal": "Normaal",
+        "low": "Laag"
+      },
+      "resetPriority": "Terugzetten"
     },
     "categories": {
       "tickets": "Tickets",
@@ -710,6 +716,8 @@
       "projects": "Projecten",
       "system": "Systeem"
     },
+    "needsAttention": "Vereist aandacht ({{count}})",
+    "lowPriority": "Lage prioriteit ({{count}})",
     "filters": {
       "title": "Notificaties filteren",
       "description": "Selecteer criteria om notificatieactiviteiten te filteren.",

--- a/server/public/locales/nl/client-portal.json
+++ b/server/public/locales/nl/client-portal.json
@@ -728,6 +728,9 @@
       "allCategories": "Alle categorieën",
       "categoryPlaceholder": "Selecteer een categorie...",
       "dateRangeLabel": "Datumbereik",
+      "priorityLabel": "Prioriteit",
+      "allPriorities": "Alle prioriteiten",
+      "priorityPlaceholder": "Selecteer een prioriteit...",
       "reset": "Opnieuw instellen",
       "cancel": "Annuleren",
       "apply": "Filters toepassen"

--- a/server/public/locales/nl/common.json
+++ b/server/public/locales/nl/common.json
@@ -1328,5 +1328,9 @@
       "description": "Deze pagina is niet beschikbaar in uw huidige productervaring.",
       "cta": "Ga naar dashboard"
     }
+  },
+  "notifications": {
+    "needsAttention": "Vereist aandacht ({{count}})",
+    "lowPriority": "Lage prioriteit ({{count}})"
   }
 }

--- a/server/public/locales/nl/msp/settings.json
+++ b/server/public/locales/nl/msp/settings.json
@@ -1494,7 +1494,8 @@
         "description": "Beschrijving",
         "enabled": "Ingeschakeld",
         "defaultForUsers": "Standaard voor gebruikers",
-        "actions": "Acties"
+        "actions": "Acties",
+        "priority": "Prioriteit"
       },
       "actions": {
         "enableAllSubtypes": "Alle subtypes inschakelen",
@@ -1506,7 +1507,8 @@
         "discardChanges": "Wijzigingen verwerpen",
         "saving": "Opslaan...",
         "saveChanges": "Wijzigingen opslaan",
-        "cancel": "Annuleren"
+        "cancel": "Annuleren",
+        "resetToDefault": "Terugzetten naar standaard"
       },
       "intro": "Bepaal welke interne meldingstypes beschikbaar zijn en stel standaardwaarden in voor nieuwe gebruikers.",
       "enabledLabel": "Ingeschakeld:",
@@ -1517,6 +1519,11 @@
       "discardDialog": {
         "title": "Wijzigingen verwerpen?",
         "message": "Weet u zeker dat u alle niet-opgeslagen wijzigingen wilt verwerpen? Deze actie kan niet ongedaan worden gemaakt."
+      },
+      "priority": {
+        "high": "Hoog",
+        "normal": "Normaal",
+        "low": "Laag"
       }
     }
   },

--- a/server/public/locales/nl/msp/user-activities.json
+++ b/server/public/locales/nl/msp/user-activities.json
@@ -435,6 +435,15 @@
           "cancel": "Annuleren",
           "apply": "Filters toepassen"
         }
+      },
+      "priority": {
+        "label": "Prioriteit",
+        "all": "Alle",
+        "allPriorities": "Alle prioriteiten",
+        "placeholder": "Selecteer prioriteit…",
+        "high": "Hoog",
+        "normal": "Normaal",
+        "low": "Laag"
       }
     }
   },

--- a/server/public/locales/pl/client-portal.json
+++ b/server/public/locales/pl/client-portal.json
@@ -730,6 +730,9 @@
       "allCategories": "Wszystkie kategorie",
       "categoryPlaceholder": "Wybierz kategorię...",
       "dateRangeLabel": "Zakres dat",
+      "priorityLabel": "Priorytet",
+      "allPriorities": "Wszystkie priorytety",
+      "priorityPlaceholder": "Wybierz priorytet...",
       "reset": "Resetuj",
       "cancel": "Anuluj",
       "apply": "Zastosuj filtry"

--- a/server/public/locales/pl/client-portal.json
+++ b/server/public/locales/pl/client-portal.json
@@ -703,7 +703,13 @@
       "saveError": "Nie udało się zapisać preferencji",
       "noCategories": "Brak dostępnych kategorii powiadomień",
       "emailPreferences": "E-mail",
-      "internalPreferences": "Wewnętrzne"
+      "internalPreferences": "Wewnętrzne",
+      "priority": {
+        "high": "Wysoki",
+        "normal": "Normalny",
+        "low": "Niski"
+      },
+      "resetPriority": "Resetuj"
     },
     "categories": {
       "tickets": "Zgłoszenia",
@@ -712,6 +718,8 @@
       "projects": "Projekty",
       "system": "System"
     },
+    "needsAttention": "Wymaga uwagi ({{count}})",
+    "lowPriority": "Niski priorytet ({{count}})",
     "filters": {
       "title": "Filtruj powiadomienia",
       "description": "Wybierz kryteria filtrowania aktywności powiadomień.",

--- a/server/public/locales/pl/common.json
+++ b/server/public/locales/pl/common.json
@@ -1360,5 +1360,9 @@
       "description": "Ta strona nie jest dostępna w bieżącej wersji produktu.",
       "cta": "Przejdź do pulpitu"
     }
+  },
+  "notifications": {
+    "needsAttention": "Wymaga uwagi ({{count}})",
+    "lowPriority": "Niski priorytet ({{count}})"
   }
 }

--- a/server/public/locales/pl/msp/settings.json
+++ b/server/public/locales/pl/msp/settings.json
@@ -1500,7 +1500,8 @@
         "description": "Opis",
         "enabled": "Włączone",
         "defaultForUsers": "Domyślne dla użytkowników",
-        "actions": "Akcje"
+        "actions": "Akcje",
+        "priority": "Priorytet"
       },
       "actions": {
         "enableAllSubtypes": "Włącz wszystkie podtypy",
@@ -1512,7 +1513,8 @@
         "discardChanges": "Odrzuć zmiany",
         "saving": "Zapisywanie...",
         "saveChanges": "Zapisz zmiany",
-        "cancel": "Anuluj"
+        "cancel": "Anuluj",
+        "resetToDefault": "Przywróć domyślne"
       },
       "intro": "Określ, które typy powiadomień wewnętrznych są dostępne, i ustaw wartości domyślne dla nowych użytkowników.",
       "enabledLabel": "Włączone:",
@@ -1523,6 +1525,11 @@
       "discardDialog": {
         "title": "Odrzucić zmiany?",
         "message": "Czy na pewno chcesz odrzucić wszystkie niezapisane zmiany? Tej akcji nie można cofnąć."
+      },
+      "priority": {
+        "high": "Wysoki",
+        "normal": "Normalny",
+        "low": "Niski"
       }
     }
   },

--- a/server/public/locales/pl/msp/user-activities.json
+++ b/server/public/locales/pl/msp/user-activities.json
@@ -435,6 +435,15 @@
           "cancel": "Anuluj",
           "apply": "Zastosuj filtry"
         }
+      },
+      "priority": {
+        "label": "Priorytet",
+        "all": "Wszystkie",
+        "allPriorities": "Wszystkie priorytety",
+        "placeholder": "Wybierz priorytet…",
+        "high": "Wysoki",
+        "normal": "Normalny",
+        "low": "Niski"
       }
     }
   },

--- a/server/public/locales/pt/client-portal.json
+++ b/server/public/locales/pt/client-portal.json
@@ -777,6 +777,9 @@
       "allCategories": "Todas as categorias",
       "categoryPlaceholder": "Selecione uma categoria...",
       "dateRangeLabel": "Intervalo de datas",
+      "priorityLabel": "Prioridade",
+      "allPriorities": "Todas as prioridades",
+      "priorityPlaceholder": "Selecione uma prioridade...",
       "reset": "Redefinir",
       "cancel": "Cancelar",
       "apply": "Aplicar filtros"

--- a/server/public/locales/pt/client-portal.json
+++ b/server/public/locales/pt/client-portal.json
@@ -750,7 +750,13 @@
       "saveError": "Falha ao salvar preferência",
       "noCategories": "Nenhuma categoria de notificação disponível",
       "emailPreferences": "Preferências de e-mail",
-      "internalPreferences": "Preferências internas"
+      "internalPreferences": "Preferências internas",
+      "priority": {
+        "high": "Alta",
+        "normal": "Normal",
+        "low": "Baixa"
+      },
+      "resetPriority": "Repor"
     },
     "categories": {
       "tickets": "Tickets",
@@ -759,6 +765,8 @@
       "projects": "Projetos",
       "system": "Sistema"
     },
+    "needsAttention": "Requer atenção ({{count}})",
+    "lowPriority": "Prioridade baixa ({{count}})",
     "filters": {
       "title": "Filtrar notificações",
       "description": "Selecione critérios para filtrar as atividades de notificação.",

--- a/server/public/locales/pt/common.json
+++ b/server/public/locales/pt/common.json
@@ -1328,5 +1328,9 @@
       "description": "Esta página não está disponível na sua experiência de produto atual.",
       "cta": "Ir para o painel"
     }
+  },
+  "notifications": {
+    "needsAttention": "Requer atenção ({{count}})",
+    "lowPriority": "Prioridade baixa ({{count}})"
   }
 }

--- a/server/public/locales/pt/msp/settings.json
+++ b/server/public/locales/pt/msp/settings.json
@@ -1494,7 +1494,8 @@
         "description": "Descrição",
         "enabled": "Habilitado",
         "defaultForUsers": "Padrão para usuários",
-        "actions": "Ações"
+        "actions": "Ações",
+        "priority": "Prioridade"
       },
       "actions": {
         "enableAllSubtypes": "Habilitar todos os subtipos",
@@ -1506,7 +1507,8 @@
         "discardChanges": "Descartar alterações",
         "saving": "Salvando...",
         "saveChanges": "Salvar alterações",
-        "cancel": "Cancelar"
+        "cancel": "Cancelar",
+        "resetToDefault": "Repor predefinição"
       },
       "intro": "Controle quais tipos de notificação interna estão disponíveis e defina os padrões para novos usuários.",
       "enabledLabel": "Habilitado:",
@@ -1517,6 +1519,11 @@
       "discardDialog": {
         "title": "Descartar alterações?",
         "message": "Tem certeza de que deseja descartar todas as alterações não salvas? Esta ação não pode ser desfeita."
+      },
+      "priority": {
+        "high": "Alta",
+        "normal": "Normal",
+        "low": "Baixa"
       }
     }
   },

--- a/server/public/locales/pt/msp/user-activities.json
+++ b/server/public/locales/pt/msp/user-activities.json
@@ -435,6 +435,15 @@
           "cancel": "Cancelar",
           "apply": "Aplicar filtros"
         }
+      },
+      "priority": {
+        "label": "Prioridade",
+        "all": "Todas",
+        "allPriorities": "Todas as prioridades",
+        "placeholder": "Selecionar prioridade…",
+        "high": "Alta",
+        "normal": "Normal",
+        "low": "Baixa"
       }
     }
   },

--- a/server/public/locales/xx/client-portal.json
+++ b/server/public/locales/xx/client-portal.json
@@ -750,7 +750,13 @@
       "saveError": "11111",
       "noCategories": "11111",
       "emailPreferences": "11111",
-      "internalPreferences": "11111"
+      "internalPreferences": "11111",
+      "priority": {
+        "high": "11111",
+        "normal": "11111",
+        "low": "11111"
+      },
+      "resetPriority": "11111"
     },
     "categories": {
       "tickets": "11111",
@@ -759,6 +765,8 @@
       "projects": "11111",
       "system": "11111"
     },
+    "needsAttention": "11111 {{count}} 11111",
+    "lowPriority": "11111 {{count}} 11111",
     "filters": {
       "title": "11111",
       "description": "11111",

--- a/server/public/locales/xx/client-portal.json
+++ b/server/public/locales/xx/client-portal.json
@@ -777,6 +777,9 @@
       "allCategories": "11111",
       "categoryPlaceholder": "11111",
       "dateRangeLabel": "11111",
+      "priorityLabel": "11111",
+      "allPriorities": "11111",
+      "priorityPlaceholder": "11111",
       "reset": "11111",
       "cancel": "11111",
       "apply": "11111"

--- a/server/public/locales/xx/common.json
+++ b/server/public/locales/xx/common.json
@@ -1328,5 +1328,9 @@
       "description": "11111",
       "cta": "11111"
     }
+  },
+  "notifications": {
+    "needsAttention": "11111 {{count}} 11111",
+    "lowPriority": "11111 {{count}} 11111"
   }
 }

--- a/server/public/locales/xx/msp/settings.json
+++ b/server/public/locales/xx/msp/settings.json
@@ -1494,7 +1494,8 @@
         "description": "11111",
         "enabled": "11111",
         "defaultForUsers": "11111",
-        "actions": "11111"
+        "actions": "11111",
+        "priority": "11111"
       },
       "actions": {
         "enableAllSubtypes": "11111",
@@ -1506,7 +1507,8 @@
         "discardChanges": "11111",
         "saving": "11111",
         "saveChanges": "11111",
-        "cancel": "11111"
+        "cancel": "11111",
+        "resetToDefault": "11111"
       },
       "intro": "11111",
       "enabledLabel": "11111",
@@ -1517,6 +1519,11 @@
       "discardDialog": {
         "title": "11111",
         "message": "11111"
+      },
+      "priority": {
+        "high": "11111",
+        "normal": "11111",
+        "low": "11111"
       }
     }
   },

--- a/server/public/locales/xx/msp/user-activities.json
+++ b/server/public/locales/xx/msp/user-activities.json
@@ -435,6 +435,15 @@
           "cancel": "11111",
           "apply": "11111"
         }
+      },
+      "priority": {
+        "label": "11111",
+        "all": "11111",
+        "allPriorities": "11111",
+        "placeholder": "11111",
+        "high": "11111",
+        "normal": "11111",
+        "low": "11111"
       }
     }
   },

--- a/server/public/locales/yy/client-portal.json
+++ b/server/public/locales/yy/client-portal.json
@@ -777,6 +777,9 @@
       "allCategories": "55555",
       "categoryPlaceholder": "55555",
       "dateRangeLabel": "55555",
+      "priorityLabel": "55555",
+      "allPriorities": "55555",
+      "priorityPlaceholder": "55555",
       "reset": "55555",
       "cancel": "55555",
       "apply": "55555"

--- a/server/public/locales/yy/client-portal.json
+++ b/server/public/locales/yy/client-portal.json
@@ -750,7 +750,13 @@
       "saveError": "55555",
       "noCategories": "55555",
       "emailPreferences": "55555",
-      "internalPreferences": "55555"
+      "internalPreferences": "55555",
+      "priority": {
+        "high": "55555",
+        "normal": "55555",
+        "low": "55555"
+      },
+      "resetPriority": "55555"
     },
     "categories": {
       "tickets": "55555",
@@ -759,6 +765,8 @@
       "projects": "55555",
       "system": "55555"
     },
+    "needsAttention": "55555 {{count}} 55555",
+    "lowPriority": "55555 {{count}} 55555",
     "filters": {
       "title": "55555",
       "description": "55555",

--- a/server/public/locales/yy/common.json
+++ b/server/public/locales/yy/common.json
@@ -1328,5 +1328,9 @@
       "description": "55555",
       "cta": "55555"
     }
+  },
+  "notifications": {
+    "needsAttention": "55555 {{count}} 55555",
+    "lowPriority": "55555 {{count}} 55555"
   }
 }

--- a/server/public/locales/yy/msp/settings.json
+++ b/server/public/locales/yy/msp/settings.json
@@ -1494,7 +1494,8 @@
         "description": "55555",
         "enabled": "55555",
         "defaultForUsers": "55555",
-        "actions": "55555"
+        "actions": "55555",
+        "priority": "55555"
       },
       "actions": {
         "enableAllSubtypes": "55555",
@@ -1506,7 +1507,8 @@
         "discardChanges": "55555",
         "saving": "55555",
         "saveChanges": "55555",
-        "cancel": "55555"
+        "cancel": "55555",
+        "resetToDefault": "55555"
       },
       "intro": "55555",
       "enabledLabel": "55555",
@@ -1517,6 +1519,11 @@
       "discardDialog": {
         "title": "55555",
         "message": "55555"
+      },
+      "priority": {
+        "high": "55555",
+        "normal": "55555",
+        "low": "55555"
       }
     }
   },

--- a/server/public/locales/yy/msp/user-activities.json
+++ b/server/public/locales/yy/msp/user-activities.json
@@ -435,6 +435,15 @@
           "cancel": "55555",
           "apply": "55555"
         }
+      },
+      "priority": {
+        "label": "55555",
+        "all": "55555",
+        "allPriorities": "55555",
+        "placeholder": "55555",
+        "high": "55555",
+        "normal": "55555",
+        "low": "55555"
       }
     }
   },

--- a/server/src/lib/pushNotifications/expoPushService.ts
+++ b/server/src/lib/pushNotifications/expoPushService.ts
@@ -10,6 +10,12 @@ export interface TicketPushParams {
   body: string;
   ticketId: string;
   tenant: string;
+  /**
+   * Configured in-app notification priority (high|normal|low), carried to the
+   * mobile app as payload metadata only (task 29.8.46). This does NOT change
+   * Expo/OS delivery priority — that stays 'high' below.
+   */
+  priority?: 'high' | 'normal' | 'low';
 }
 
 export function buildTicketPushMessage(params: TicketPushParams): ExpoPushMessage {
@@ -21,7 +27,10 @@ export function buildTicketPushMessage(params: TicketPushParams): ExpoPushMessag
     data: {
       ticketId: params.ticketId,
       url: `alga://ticket/${params.ticketId}`,
+      // Payload metadata so the mobile app can render/sort by priority.
+      priority: params.priority ?? 'normal',
     },
+    // Expo/OS delivery priority is intentionally unchanged (out of scope).
     priority: 'high' as const,
   };
 }

--- a/server/src/lib/pushNotifications/pushNotificationDispatcher.ts
+++ b/server/src/lib/pushNotifications/pushNotificationDispatcher.ts
@@ -24,6 +24,7 @@ interface InternalNotification {
   template_name: string;
   title: string;
   message: string;
+  priority?: 'high' | 'normal' | 'low' | null;
   link?: string | null;
   metadata?: Record<string, unknown> | null;
 }
@@ -63,6 +64,7 @@ export async function triggerPushForNotification(
       body: notification.message,
       ticketId: ticketId ?? '',
       tenant: notification.tenant,
+      priority: notification.priority ?? 'normal',
     }),
   );
 

--- a/server/src/test/unit/internal-notifications/serverEventPublisherTicketAssignedRecipient.test.ts
+++ b/server/src/test/unit/internal-notifications/serverEventPublisherTicketAssignedRecipient.test.ts
@@ -1,0 +1,48 @@
+import { describe, expect, it } from 'vitest';
+import { randomUUID } from 'node:crypto';
+
+describe('regression: v2 TICKET_ASSIGNED publisher must carry the assignee as userId', () => {
+  it('ServerEventPublisher.publishTicketAssigned emits userId so the assignee survives schema validation', async () => {
+    const { ServerEventPublisher } = await import('@alga-psa/event-bus/adapters/serverEventPublisher');
+    const { EventSchemas } = await import('@alga-psa/event-schemas');
+
+    const TENANT = 'dd8cb218-d46d-47f3-be27-8aa50aad5fce';
+    const ASSIGNEE = '6684ee32-8f0a-46fb-b84c-4563337b2766';
+    const ASSIGNER = '00000000-0000-4000-8000-000000000001';
+
+    // Capture the payload the publisher emits before it hits the bus.
+    let captured: Record<string, any> = {};
+    const publisher = new ServerEventPublisher() as any;
+    const orig = publisher.safePublishWorkflowEvent;
+    publisher.safePublishWorkflowEvent = async (_t: string, _te: string, _a: string | undefined, payload: Record<string, any>) => {
+      captured = payload;
+    };
+    await publisher.publishTicketAssigned({
+      tenantId: TENANT,
+      ticketId: randomUUID(),
+      userId: ASSIGNEE,
+      assignedByUserId: ASSIGNER,
+    });
+    publisher.safePublishWorkflowEvent = orig;
+
+    expect(captured.userId).toBe(ASSIGNEE);
+
+    // The subscriber validates with EventSchemas.TICKET_ASSIGNED (union). Confirm
+    // the emitted payload retains payload.userId = the assignee after validation.
+    const event = {
+      id: randomUUID(),
+      eventType: 'TICKET_ASSIGNED',
+      timestamp: new Date().toISOString(),
+      payload: {
+        ...captured,
+        tenantId: TENANT,
+        occurredAt: new Date().toISOString(),
+        actorType: 'USER',
+        actorUserId: ASSIGNER,
+      },
+    } as any;
+
+    const validated: any = EventSchemas.TICKET_ASSIGNED.parse(event);
+    expect(validated.payload.userId).toBe(ASSIGNEE);
+  });
+});

--- a/server/src/test/unit/internal-notifications/ticketAssignedUserPriority.behavioral.test.ts
+++ b/server/src/test/unit/internal-notifications/ticketAssignedUserPriority.behavioral.test.ts
@@ -28,6 +28,15 @@ import { internalNotificationSubscriberTestHarness } from '../../../lib/eventBus
 // The handler only reads the ticket row, so the suite creates its own
 // throwaway ticket (assigned to the target user) and deletes it afterwards.
 
+// Opt-in: this repro drives the REAL server actions and event bus against a
+// live, seeded database (the Glinda tenant fixtures below only exist in the
+// local dev DB). The DB-less unit CI job has neither a database nor those
+// rows, so — following the repo convention for DB-backed suites — it is gated
+// behind RUN_DB_TESTS=1 and skipped at collection time otherwise (so beforeAll
+// never attempts a connection there). The priority-resolution logic itself is
+// covered in CI by priorityResolution.test.ts and the publisher-recipient test.
+const RUN_DB_TESTS = process.env.RUN_DB_TESTS === '1';
+
 const TENANT = 'dd8cb218-d46d-47f3-be27-8aa50aad5fce';
 const USER = '6684ee32-8f0a-46fb-b84c-4563337b2766'; // glinda
 const ASSIGNER = '00000000-0000-4000-8000-000000000001'; // smoke actor
@@ -121,38 +130,41 @@ async function newestStampedNotification() {
   return row;
 }
 
-beforeAll(async () => {
-  knex = (await createTenantKnex()).knex;
+// Hooks live inside the gated describe so that, when RUN_DB_TESTS is unset,
+// skipIf skips the whole block at collection time and beforeAll never runs
+// (no connection attempt, no throw) in the DB-less unit CI job.
+describe.skipIf(!RUN_DB_TESTS)('behavioral: per-user priority override honored on the ticket-assigned creation path', () => {
+  beforeAll(async () => {
+    knex = (await createTenantKnex()).knex;
 
-  // Throwaway ticket assigned to the target user (the handler reads it only).
-  fixtureTicketId = randomUUID();
-  fixtureTicketNumber = `PRIORITY-REPRO-${Date.now()}`;
-  await knex('tickets').insert({
-    tenant: TENANT,
-    ticket_id: fixtureTicketId,
-    ticket_number: fixtureTicketNumber,
-    title: 'behavioral priority repro',
-    client_id: FIXTURE_REFERENCE.client_id,
-    status_id: FIXTURE_REFERENCE.status_id,
-    priority_id: FIXTURE_REFERENCE.priority_id,
-    board_id: FIXTURE_REFERENCE.board_id,
-    assigned_to: USER,
-    source: 'api',
-    ticket_origin: 'internal',
-    entered_at: new Date().toISOString(),
+    // Throwaway ticket assigned to the target user (the handler reads it only).
+    fixtureTicketId = randomUUID();
+    fixtureTicketNumber = `PRIORITY-REPRO-${Date.now()}`;
+    await knex('tickets').insert({
+      tenant: TENANT,
+      ticket_id: fixtureTicketId,
+      ticket_number: fixtureTicketNumber,
+      title: 'behavioral priority repro',
+      client_id: FIXTURE_REFERENCE.client_id,
+      status_id: FIXTURE_REFERENCE.status_id,
+      priority_id: FIXTURE_REFERENCE.priority_id,
+      board_id: FIXTURE_REFERENCE.board_id,
+      assigned_to: USER,
+      source: 'api',
+      ticket_origin: 'internal',
+      entered_at: new Date().toISOString(),
+    });
+
+    await setTenantPriority(null);
+    await setUserPriority(null);
   });
 
-  await setTenantPriority(null);
-  await setUserPriority(null);
-});
+  afterAll(async () => {
+    await knex('tickets').where({ tenant: TENANT, ticket_id: fixtureTicketId }).delete();
+    await setTenantPriority(null);
+    await setUserPriority(null);
+  });
 
-afterAll(async () => {
-  await knex('tickets').where({ tenant: TENANT, ticket_id: fixtureTicketId }).delete();
-  await setTenantPriority(null);
-  await setUserPriority(null);
-});
-
-describe('behavioral: per-user priority override honored on the ticket-assigned creation path', () => {
   it('user=high, tenant=none -> stamps high (the reported defect case)', async () => {
     await setTenantPriority(null);
     await setUserPriority('high');

--- a/server/src/test/unit/internal-notifications/ticketAssignedUserPriority.behavioral.test.ts
+++ b/server/src/test/unit/internal-notifications/ticketAssignedUserPriority.behavioral.test.ts
@@ -1,0 +1,177 @@
+import { beforeAll, afterAll, describe, expect, it } from 'vitest';
+import { randomUUID } from 'node:crypto';
+import { createTenantKnex } from '@alga-psa/db';
+import { internalNotificationSubscriberTestHarness } from '../../../lib/eventBus/subscribers/internalNotificationSubscriber';
+
+// Behavioral regression test for the ticket-assigned creation path
+// (task 29.8.46). It drives the REAL subscriber handler (handleTicketAssigned,
+// the function the event bus invokes for TICKET_ASSIGNED) through the REAL
+// creation function (createNotificationFromTemplateInternal) against the live
+// dev DB — not the pure precedence helper. The per-user override on the
+// ticket-assigned subtype (subtype 1) is written straight to the DB exactly as
+// the profile UI writes it, so the whole chain is exercised end to end:
+//
+//   handleTicketAssigned -> createNotificationFromTemplateInternal
+//     -> resolveNotificationPriority(user ?? tenant ?? subtype default ?? 'normal')
+//     -> stamped internal_notifications.priority
+//
+// If the resolution is removed from the creation path (the pre-draft / base
+// branch behavior), every case below collapses to the column default 'normal'
+// and the user-override case fails.
+//
+// The handler only reads the ticket row, so the suite creates its own
+// throwaway ticket (assigned to the target user) and deletes it afterwards.
+
+const TENANT = 'dd8cb218-d46d-47f3-be27-8aa50aad5fce';
+const USER = '6684ee32-8f0a-46fb-b84c-4563337b2766'; // glinda
+const ASSIGNER = '00000000-0000-4000-8000-000000000001'; // smoke actor
+const SUBTYPE_TICKET_ASSIGNED = 1; // ticket-assigned
+
+// Real reference values for a valid ticket row in the Glinda tenant.
+const FIXTURE_REFERENCE = {
+  client_id: '66229c62-a609-41b1-93c2-e870d9926195',
+  status_id: '55069d07-a8d9-451f-a825-dd1ca82d485a',
+  priority_id: 'eaa5550f-b8f6-470d-ad34-61a292a0c87f',
+  board_id: '4b18fabc-b0f6-4200-bc63-cbd514840257',
+};
+
+let knex: any;
+let fixtureTicketId: string;
+let fixtureTicketNumber: string;
+
+async function setUserPriority(priority: string | null) {
+  const existing = await knex('user_internal_notification_preferences')
+    .where({ tenant: TENANT, user_id: USER, subtype_id: SUBTYPE_TICKET_ASSIGNED })
+    .first();
+  if (existing) {
+    await knex('user_internal_notification_preferences')
+      .where({ preference_id: existing.preference_id })
+      .update({ priority, is_enabled: true });
+  } else {
+    await knex('user_internal_notification_preferences').insert({
+      tenant: TENANT,
+      user_id: USER,
+      category_id: 1,
+      subtype_id: SUBTYPE_TICKET_ASSIGNED,
+      is_enabled: true,
+      priority,
+    });
+  }
+}
+
+async function setTenantPriority(priority: string | null) {
+  const existing = await knex('tenant_internal_notification_subtype_settings')
+    .where({ tenant: TENANT, subtype_id: SUBTYPE_TICKET_ASSIGNED })
+    .first();
+  if (existing) {
+    await knex('tenant_internal_notification_subtype_settings')
+      .where({ tenant: TENANT, subtype_id: SUBTYPE_TICKET_ASSIGNED })
+      .update({ priority });
+  } else {
+    await knex('tenant_internal_notification_subtype_settings').insert({
+      tenant: TENANT,
+      subtype_id: SUBTYPE_TICKET_ASSIGNED,
+      is_enabled: true,
+      is_default_enabled: true,
+      priority,
+    });
+  }
+}
+
+/** Drive the real subscriber handler exactly as the event bus does for TICKET_ASSIGNED. */
+async function driveTicketAssigned() {
+  await internalNotificationSubscriberTestHarness.handleTicketAssigned({
+    eventType: 'TICKET_ASSIGNED',
+    payload: {
+      tenantId: TENANT,
+      ticketId: fixtureTicketId,
+      userId: USER, // the assignee (recipient), as every publisher emits it
+      assignedByUserId: ASSIGNER,
+    },
+  });
+}
+
+/**
+ * The notification the handler just stamped: the newest ticket-assigned row
+ * for the assignee. Each case deletes the row it asserted against, so there is
+ * never a newer one from a sibling case.
+ */
+async function newestStampedNotification() {
+  const row = await knex('internal_notifications')
+    .where({ tenant: TENANT, user_id: USER, template_name: 'ticket-assigned' })
+    .orderBy('created_at', 'desc')
+    .orderBy('internal_notification_id', 'desc')
+    .first();
+  if (row) {
+    await knex('internal_notifications').where({ internal_notification_id: row.internal_notification_id }).delete();
+  }
+  return row;
+}
+
+beforeAll(async () => {
+  knex = (await createTenantKnex()).knex;
+
+  // Throwaway ticket assigned to the target user (the handler reads it only).
+  fixtureTicketId = randomUUID();
+  fixtureTicketNumber = `PRIORITY-REPRO-${Date.now()}`;
+  await knex('tickets').insert({
+    tenant: TENANT,
+    ticket_id: fixtureTicketId,
+    ticket_number: fixtureTicketNumber,
+    title: 'behavioral priority repro',
+    client_id: FIXTURE_REFERENCE.client_id,
+    status_id: FIXTURE_REFERENCE.status_id,
+    priority_id: FIXTURE_REFERENCE.priority_id,
+    board_id: FIXTURE_REFERENCE.board_id,
+    assigned_to: USER,
+    source: 'api',
+    ticket_origin: 'internal',
+    entered_at: new Date().toISOString(),
+  });
+
+  await setTenantPriority(null);
+  await setUserPriority(null);
+});
+
+afterAll(async () => {
+  await knex('tickets').where({ tenant: TENANT, ticket_id: fixtureTicketId }).delete();
+  await setTenantPriority(null);
+  await setUserPriority(null);
+});
+
+describe('behavioral: per-user priority override honored on the ticket-assigned creation path', () => {
+  it('user=high, tenant=none -> stamps high (the reported defect case)', async () => {
+    await setTenantPriority(null);
+    await setUserPriority('high');
+    await driveTicketAssigned();
+    const row = await newestStampedNotification();
+    expect(row).toBeTruthy();
+    expect(row.template_name).toBe('ticket-assigned');
+    expect(row.user_id).toBe(USER);
+    expect(row.priority).toBe('high');
+  });
+
+  it('user=high, tenant=low -> user still wins', async () => {
+    await setTenantPriority('low');
+    await setUserPriority('high');
+    await driveTicketAssigned();
+    const row = await newestStampedNotification();
+    expect(row?.priority).toBe('high');
+  });
+
+  it('user=none, tenant=high -> tenant wins', async () => {
+    await setTenantPriority('high');
+    await setUserPriority(null);
+    await driveTicketAssigned();
+    const row = await newestStampedNotification();
+    expect(row?.priority).toBe('high');
+  });
+
+  it('user=none, tenant=none -> subtype default (normal)', async () => {
+    await setTenantPriority(null);
+    await setUserPriority(null);
+    await driveTicketAssigned();
+    const row = await newestStampedNotification();
+    expect(row?.priority).toBe('normal');
+  });
+});

--- a/server/src/test/unit/internal-notifications/ticketAssignedUserPriority.behavioral.test.ts
+++ b/server/src/test/unit/internal-notifications/ticketAssignedUserPriority.behavioral.test.ts
@@ -1,19 +1,25 @@
 import { beforeAll, afterAll, describe, expect, it } from 'vitest';
 import { randomUUID } from 'node:crypto';
 import { createTenantKnex } from '@alga-psa/db';
+import { runWithApiKeyUser } from '@alga-psa/auth';
 import { internalNotificationSubscriberTestHarness } from '../../../lib/eventBus/subscribers/internalNotificationSubscriber';
 
 // Behavioral regression test for the ticket-assigned creation path
-// (task 29.8.46). It drives the REAL subscriber handler (handleTicketAssigned,
-// the function the event bus invokes for TICKET_ASSIGNED) through the REAL
-// creation function (createNotificationFromTemplateInternal) against the live
-// dev DB — not the pure precedence helper. The per-user override on the
-// ticket-assigned subtype (subtype 1) is written straight to the DB exactly as
-// the profile UI writes it, so the whole chain is exercised end to end:
+// (task 29.8.46). It drives the REAL server action the settings UI invokes
+// (updateUserInternalNotificationPreferenceAction) to persist the per-user
+// override, then emits TICKET_ASSIGNED through the REAL event-bus entry point
+// (handleInternalNotificationEvent — schema validation + dispatch, exactly
+// what the Redis consumer calls) so the whole chain is exercised end to end:
 //
-//   handleTicketAssigned -> createNotificationFromTemplateInternal
+//   updateUserInternalNotificationPreferenceAction  (the writer the UI calls)
+//     -> handleInternalNotificationEvent -> handleTicketAssigned
+//     -> createNotificationFromTemplateInternal
 //     -> resolveNotificationPriority(user ?? tenant ?? subtype default ?? 'normal')
 //     -> stamped internal_notifications.priority
+//
+// The override is persisted THROUGH THE WRITER ACTION — not inserted into the
+// table directly — so the test cannot accidentally seed a row in the exact
+// shape the reader expects while the product writes something different.
 //
 // If the resolution is removed from the creation path (the pre-draft / base
 // branch behavior), every case below collapses to the column default 'normal'
@@ -26,6 +32,7 @@ const TENANT = 'dd8cb218-d46d-47f3-be27-8aa50aad5fce';
 const USER = '6684ee32-8f0a-46fb-b84c-4563337b2766'; // glinda
 const ASSIGNER = '00000000-0000-4000-8000-000000000001'; // smoke actor
 const SUBTYPE_TICKET_ASSIGNED = 1; // ticket-assigned
+const CATEGORY_TICKETS = 1;
 
 // Real reference values for a valid ticket row in the Glinda tenant.
 const FIXTURE_REFERENCE = {
@@ -39,56 +46,62 @@ let knex: any;
 let fixtureTicketId: string;
 let fixtureTicketNumber: string;
 
+// The session identity the withAuth-wrapped actions see. Mirrors the profile
+// page session for glinda in the Glinda tenant.
+const sessionUser = {
+  user_id: USER,
+  user_type: 'internal',
+  tenant: TENANT,
+  roles: [] as any[],
+};
+
+/** Persist a per-user subtype override through the real server action the UI calls. */
 async function setUserPriority(priority: string | null) {
-  const existing = await knex('user_internal_notification_preferences')
-    .where({ tenant: TENANT, user_id: USER, subtype_id: SUBTYPE_TICKET_ASSIGNED })
-    .first();
-  if (existing) {
-    await knex('user_internal_notification_preferences')
-      .where({ preference_id: existing.preference_id })
-      .update({ priority, is_enabled: true });
-  } else {
-    await knex('user_internal_notification_preferences').insert({
+  await runWithApiKeyUser(sessionUser, async () => {
+    const { updateUserInternalNotificationPreferenceAction } = await import(
+      '@alga-psa/notifications/actions/internal-notification-actions/internalNotificationActions'
+    );
+    await updateUserInternalNotificationPreferenceAction({
       tenant: TENANT,
       user_id: USER,
-      category_id: 1,
+      category_id: CATEGORY_TICKETS,
       subtype_id: SUBTYPE_TICKET_ASSIGNED,
       is_enabled: true,
       priority,
     });
-  }
+  });
 }
 
+/** Persist a tenant-level subtype override through the real server action the admin settings UI calls. */
 async function setTenantPriority(priority: string | null) {
-  const existing = await knex('tenant_internal_notification_subtype_settings')
-    .where({ tenant: TENANT, subtype_id: SUBTYPE_TICKET_ASSIGNED })
-    .first();
-  if (existing) {
-    await knex('tenant_internal_notification_subtype_settings')
-      .where({ tenant: TENANT, subtype_id: SUBTYPE_TICKET_ASSIGNED })
-      .update({ priority });
-  } else {
-    await knex('tenant_internal_notification_subtype_settings').insert({
-      tenant: TENANT,
-      subtype_id: SUBTYPE_TICKET_ASSIGNED,
+  await runWithApiKeyUser(sessionUser, async () => {
+    const { updateInternalSubtypeAction } = await import(
+      '@alga-psa/notifications/actions/internal-notification-actions/internalNotificationActions'
+    );
+    await updateInternalSubtypeAction(SUBTYPE_TICKET_ASSIGNED, {
       is_enabled: true,
       is_default_enabled: true,
       priority,
     });
-  }
+  });
 }
 
-/** Drive the real subscriber handler exactly as the event bus does for TICKET_ASSIGNED. */
+/**
+ * Emit TICKET_ASSIGNED through the REAL bus entry point — the same function the
+ * Redis consumer invokes (schema validation + dispatch to handleTicketAssigned).
+ */
 async function driveTicketAssigned() {
-  await internalNotificationSubscriberTestHarness.handleTicketAssigned({
+  await internalNotificationSubscriberTestHarness.handleInternalNotificationEvent({
     eventType: 'TICKET_ASSIGNED',
+    id: randomUUID(),
+    timestamp: new Date().toISOString(),
     payload: {
       tenantId: TENANT,
       ticketId: fixtureTicketId,
       userId: USER, // the assignee (recipient), as every publisher emits it
       assignedByUserId: ASSIGNER,
     },
-  });
+  } as any);
 }
 
 /**

--- a/server/src/test/unit/push-notifications/expoPushService.test.ts
+++ b/server/src/test/unit/push-notifications/expoPushService.test.ts
@@ -51,9 +51,39 @@ describe('expoPushService', () => {
         data: {
           ticketId: 'aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee',
           url: 'alga://ticket/aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee',
+          // Payload metadata only (task 29.8.46): defaults to 'normal' when the
+          // caller does not supply the configured priority.
+          priority: 'normal',
         },
         priority: 'high',
       });
+    });
+
+    it('carries the configured priority as payload metadata (task 29.8.46)', () => {
+      const msg = buildTicketPushMessage({
+        expoPushToken: 'ExponentPushToken[abc]',
+        title: 'Ticket Assigned',
+        body: 'You were assigned ticket #42',
+        ticketId: 'aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee',
+        tenant: 'tenant-1',
+        priority: 'high',
+      });
+
+      // The in-app priority rides in data as metadata; Expo/OS delivery priority
+      // stays 'high' regardless.
+      expect(msg.data.priority).toBe('high');
+      expect(msg.priority).toBe('high');
+
+      const low = buildTicketPushMessage({
+        expoPushToken: 'ExponentPushToken[abc]',
+        title: 'Ticket Assigned',
+        body: 'You were assigned ticket #42',
+        ticketId: 'aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee',
+        tenant: 'tenant-1',
+        priority: 'low',
+      });
+      expect(low.data.priority).toBe('low');
+      expect(low.priority).toBe('high');
     });
   });
 


### PR DESCRIPTION
## Summary

Adds configurable `high`, `normal`, and `low` priorities to internal notifications. Priority resolves from user override, tenant override, subtype default, then `normal`, and is stamped when the notification is created. Callers cannot supply the stamped priority.

Every changed UI surface is gated by `release-v1.5-feature`. With the flag off, the legacy bell, dropdown, settings, navigation, and activity priority mapping remain in place.

The branch was rebased onto `main` before its final review fixes.

## What changed

- Adds Citus-safe priority columns and named CHECK constraints for subtype defaults, tenant overrides, user overrides, and stamped notification instances.
- Seeds known high- and low-priority subtype defaults and backfills existing notifications from their subtype template.
- Adds tenant and per-user priority controls, with `NULL` meaning inherit.
- Changes the flagged bell badge to count unread high-priority notifications only, with a neutral dot when unread normal or low notifications remain.
- Groups the flagged dropdown into pinned high, normal, and collapsible low sections.
- Adds flagged notification priority cards and filters to focused User Activities, with database-side count, filtering, offset, and limit pagination.
- Adds a flagged priority filter to client-portal notifications.
- Passes resolved priority to Expo as data metadata without changing Expo delivery priority.

## Correctness fixes

- Routes SLA escalation in-app notifications through the central template creation path so enablement, locale, priority resolution, broadcasts, and post-creation hooks cannot be bypassed.
- Keeps flag-off User Activities and client-portal activity mapping on the legacy notification type-to-priority behavior.
- Recounts unread-high notifications from the database on realtime changes instead of deriving the badge from the limited Yjs notification window.
- Adds `payload.userId` to `ServerEventPublisher.publishTicketAssigned`, preserving the assignee through the `TICKET_ASSIGNED` union schema and into notification priority resolution.
- Makes the migration compatible with Citus by adding columns and named constraints separately and using idempotent constraint probes.
- Gates the DB behavioral suite with `RUN_DB_TESTS=1` for the DB-less server unit job.
- Updates Expo push tests for priority metadata and updates User Activities source-contract tests for the paged query helper boundary.

## Automated verification

- Client portal typecheck and 178 tests passed.
- Notifications typecheck and 16 tests passed.
- SLA typecheck and 31 escalation tests passed.
- User Activities priority mapping tests passed 4/4.
- Server typecheck passed after dependency builds.
- Related server notification and push tests passed 7/7; the DB behavioral suite was skipped without `RUN_DB_TESTS=1` as intended.
- Targeted lint completed with zero errors.
- Translation key consistency, missing-key detection, and locale-quality gates passed.

## Smoke test

**PASS — no blocking defects found.**

Exercised through the live product on port 3729:

- Flag off: legacy 14-unread numeric bell, flat dropdown, legacy View All URL, and settings without priority controls.
- Flag on: 6-unread-high badge; grouped 7 high, 1 normal, and 7 low notifications; collapsed/expanded low section; neutral-dot fallback when no high items were unread.
- Tenant setting: ticket-assigned Normal→High, reload persistence, DB verification, then reset to NULL/inherited Normal.
- User setting: ticket-assigned Normal→Low, reload persistence, DB verification, then reset to NULL/inherited Normal.
- Focused activities: priority cards and filters, 21-row two-page pagination, High/Low/Normal filters returning 9/9/3 rows, and the Read tab returning the single read item.
- Push builder regression suite passed 6/6 and includes priority metadata.

### Fidelity compromises

- Added six temporary, clearly tagged DB fixtures to exceed the 20-row pagination threshold; all were deleted.
- Temporarily changed high-notification read state to prove the neutral dot, then restored it.
- No mocks or simulators were used.
- Expo delivery could not be tested because the environment has zero active mobile push tokens.
- Realtime bell refresh could not be trusted because the browser connects to Hocuspocus on 1234 while the stack exposes 1235; explicit Refresh/reload was used.
- The newly created card-space browser pane reported a cross-host control error, so testing used an existing browser pane already isolated in this card's workspace.

Cleanup verified: the dev server remains live from this worktree, the force flag was removed, the worktree is clean, zero smoke fixtures remain, the notification baseline was restored to 7 high/7 low/1 normal with 14 unread, and ticket-assigned tenant/user overrides are `NULL`. Console connection failures coincided with intentional server restarts; an unrelated React script-tag warning was also observed.

Evidence: `/tmp/alga-smoke-evidence/configurable-notification-priorities-20260812-022914`