### PR TITLE
Fix duplicated dialog titles and add a dev-time guard against regressions

### DIFF
--- a/ee/packages/workflows/src/components/automation-hub/EventsCatalogV2.tsx
+++ b/ee/packages/workflows/src/components/automation-hub/EventsCatalogV2.tsx
@@ -9,7 +9,7 @@ import { Button } from '@alga-psa/ui/components/Button';
 import { Input } from '@alga-psa/ui/components/Input';
 import { Badge } from '@alga-psa/ui/components/Badge';
 import { Skeleton } from '@alga-psa/ui/components/Skeleton';
-import { Dialog, DialogContent, DialogHeader, DialogTitle } from '@alga-psa/ui/components/Dialog';
+import { Dialog, DialogContent } from '@alga-psa/ui/components/Dialog';
 import { TextArea } from '@alga-psa/ui/components/TextArea';
 import CustomSelect from '@alga-psa/ui/components/CustomSelect';
 import { Switch } from '@alga-psa/ui/components/Switch';
@@ -1514,7 +1514,7 @@ export default function EventsCatalogV2({ pickerActions }: { pickerActions: Work
       <Dialog
         isOpen={schemaModalOpen}
         onClose={() => setSchemaModalOpen(false)}
-        title={t('automation.eventsCatalog.schemaModal.title', { defaultValue: 'Schema' })}
+        title={t('automation.eventsCatalog.schemaModal.headerTitle', { defaultValue: 'Payload schema' })}
         className="max-w-4xl"
         footer={
           <div className="flex justify-end space-x-2">
@@ -1523,9 +1523,6 @@ export default function EventsCatalogV2({ pickerActions }: { pickerActions: Work
         }
       >
         <DialogContent>
-          <DialogHeader>
-            <DialogTitle>{t('automation.eventsCatalog.schemaModal.headerTitle', { defaultValue: 'Payload schema' })}</DialogTitle>
-          </DialogHeader>
           {schemaLoading && <div className="text-sm text-gray-500">{t('automation.eventsCatalog.schemaModal.loading', { defaultValue: 'Loading…' })}</div>}
           {!schemaLoading && !fullSchema && <div className="text-sm text-destructive">{t('automation.eventsCatalog.schemaModal.unavailable', { defaultValue: 'Schema not available.' })}</div>}
           {!schemaLoading && fullSchema && (
@@ -1631,7 +1628,7 @@ const MetricsDialog: React.FC<{ open: boolean; eventType: string | null; onClose
     <Dialog
       isOpen={open}
       onClose={onClose}
-      title={t('automation.eventsCatalog.metricsDialog.title', { defaultValue: 'Metrics' })}
+      title={t('automation.eventsCatalog.metricsDialog.headerTitle', { defaultValue: 'Metrics · {{eventType}}', eventType: eventType ?? '' })}
       className="max-w-4xl"
       footer={
         <div className="flex justify-end space-x-2">
@@ -1640,9 +1637,6 @@ const MetricsDialog: React.FC<{ open: boolean; eventType: string | null; onClose
       }
     >
       <DialogContent>
-        <DialogHeader>
-          <DialogTitle>{t('automation.eventsCatalog.metricsDialog.headerTitle', { defaultValue: 'Metrics · {{eventType}}', eventType: eventType ?? '' })}</DialogTitle>
-        </DialogHeader>
         <div className="space-y-4">
           <div className="flex flex-wrap items-end gap-3">
             <div className="flex flex-col gap-1">
@@ -1933,7 +1927,7 @@ const SimulateDialog: React.FC<{
     <Dialog
       isOpen={open}
       onClose={onClose}
-      title={t('automation.eventsCatalog.simulateDialog.title', { defaultValue: 'Simulate event' })}
+      title={t('automation.eventsCatalog.simulateDialog.headerTitle', { defaultValue: 'Simulate · {{eventType}}', eventType: eventType ?? '' })}
       className="max-w-4xl"
       footer={
         <div className="flex justify-end space-x-2">
@@ -1947,10 +1941,6 @@ const SimulateDialog: React.FC<{
       }
     >
       <DialogContent>
-        <DialogHeader>
-          <DialogTitle>{t('automation.eventsCatalog.simulateDialog.headerTitle', { defaultValue: 'Simulate · {{eventType}}', eventType: eventType ?? '' })}</DialogTitle>
-        </DialogHeader>
-
         <div className="space-y-4">
           <div className="grid grid-cols-1 md:grid-cols-2 gap-3">
             <Input
@@ -2142,9 +2132,6 @@ const DefineCustomEventDialog: React.FC<{ open: boolean; schemaRefs: string[]; o
       }
     >
       <DialogContent>
-        <DialogHeader>
-          <DialogTitle>{t('automation.eventsCatalog.defineEventDialog.headerTitle', { defaultValue: 'Define Custom Event' })}</DialogTitle>
-        </DialogHeader>
         <div className="space-y-4">
           <div className="grid grid-cols-1 md:grid-cols-2 gap-3">
             <Input label={t('automation.eventsCatalog.defineEventDialog.fields.eventType', { defaultValue: 'Event type' })} value={eventType} onChange={(e) => setEventType(e.target.value)} placeholder={t('automation.eventsCatalog.defineEventDialog.fields.eventTypePlaceholder', { defaultValue: 'e.g. ticket.created' })} />

--- a/ee/packages/workflows/src/components/automation-hub/WorkflowScheduleDialog.tsx
+++ b/ee/packages/workflows/src/components/automation-hub/WorkflowScheduleDialog.tsx
@@ -11,8 +11,7 @@ import {
   Dialog,
   DialogContent,
   DialogDescription,
-  DialogHeader,
-  DialogTitle
+  DialogHeader
 } from '@alga-psa/ui/components/Dialog';
 import CustomSelect, { type SelectOption } from '@alga-psa/ui/components/CustomSelect';
 import { Switch } from '@alga-psa/ui/components/Switch';
@@ -1071,11 +1070,6 @@ export default function WorkflowScheduleDialog({
     >
       <DialogContent>
         <DialogHeader>
-          <DialogTitle>
-            {mode === 'edit'
-              ? t('schedules.dialog.title.edit', { defaultValue: 'Edit Schedule' })
-              : t('schedules.dialog.title.create', { defaultValue: 'Create Schedule' })}
-          </DialogTitle>
           <DialogDescription>
             {t('schedules.dialog.description', {
               defaultValue: 'Configure timing and static payload data for a workflow schedule.',

--- a/ee/server/src/components/workflow-designer/__tests__/InputMappingEditorUnifiedEditor.test.tsx
+++ b/ee/server/src/components/workflow-designer/__tests__/InputMappingEditorUnifiedEditor.test.tsx
@@ -62,10 +62,17 @@ vi.mock('@alga-psa/ui/components/Dialog', () => ({
   Dialog: ({
     isOpen,
     children,
+    footer,
   }: {
     isOpen: boolean;
     children: React.ReactNode;
-  }) => (isOpen ? <div data-testid="workflow-editor-dialog">{children}</div> : null),
+    footer?: React.ReactNode;
+  }) => (isOpen ? (
+    <div data-testid="workflow-editor-dialog">
+      {children}
+      {footer}
+    </div>
+  ) : null),
   DialogContent: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
   DialogHeader: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
   DialogTitle: ({ children }: { children: React.ReactNode }) => <h2>{children}</h2>,

--- a/ee/server/src/components/workflow-designer/mapping/InputMappingEditor.tsx
+++ b/ee/server/src/components/workflow-designer/mapping/InputMappingEditor.tsx
@@ -13,7 +13,6 @@ import {
   DialogContent,
   DialogDescription,
   DialogHeader,
-  DialogTitle,
 } from '@alga-psa/ui/components/Dialog';
 import CustomSelect, { SelectOption } from '@alga-psa/ui/components/CustomSelect';
 import { useTranslation } from '@alga-psa/ui/lib/i18n/client';
@@ -1011,12 +1010,6 @@ const FixedValueEditorShell: React.FC<{
       >
         <DialogContent>
           <DialogHeader>
-            <DialogTitle>
-              {t('inputMappingEditor.fixedValueDialog.title', {
-                defaultValue: 'Edit {{fieldName}}',
-                fieldName: field.name,
-              })}
-            </DialogTitle>
             <DialogDescription>
               {t('inputMappingEditor.fixedValueDialog.description', {
                 defaultValue: 'Use the larger editor for longer fixed-value content.',

--- a/ee/server/vitest.config.ts
+++ b/ee/server/vitest.config.ts
@@ -23,6 +23,15 @@ export default defineConfig({
     },
     logHeapUsage: true,
     testTimeout: 30000, // Increased for integration tests
+    server: {
+      deps: {
+        inline: [
+          'next-auth',
+          '@auth/core',
+          'next',
+        ],
+      },
+    },
     include: [
       'src/__tests__/**/*.{test,spec}.{js,mjs,cjs,ts,mts,cts,jsx,tsx}',
       'src/__tests__/**/*.playwright.{test,spec}.{js,mjs,cjs,ts,mts,cts,jsx,tsx}',
@@ -60,6 +69,8 @@ export default defineConfig({
       { find: /^@shared\/(.*)$/, replacement: `${path.resolve(__dirname, '../../shared')}/$1` },
       { find: /^@alga-psa\/shared\/(.*)$/, replacement: `${path.resolve(__dirname, '../../shared')}/$1` },
       { find: /^@alga-psa\/workflow-streams$/, replacement: `${path.resolve(__dirname, '../../packages/workflow-streams/src/streams/index.ts')}` },
+      // Resolve the EE workflows package from source so tests do not need its dist build.
+      { find: /^@alga-psa\/workflows(\/.*)?$/, replacement: `${path.resolve(__dirname, '../packages/workflows/src')}$1` },
       { find: /^@alga-psa\/ui\/(.*)$/, replacement: `${path.resolve(__dirname, '../../packages/ui/src')}/$1` },
       { find: /^@alga-psa\/ui$/, replacement: `${path.resolve(__dirname, '../../packages/ui/src/index.ts')}` },
       { find: /^@alga-psa\/billing$/, replacement: `${path.resolve(__dirname, '../../packages/billing/src/index.ts')}` },
@@ -147,13 +158,6 @@ export default defineConfig({
     ],
   },
   server: {
-    deps: {
-      inline: [
-        'next-auth',
-        '@auth/core',
-        'next',
-      ],
-    },
     fs: {
       allow: [path.resolve(__dirname, '../..')],
     },

--- a/packages/billing/src/components/billing-dashboard/accounting/AccountingExportsTab.tsx
+++ b/packages/billing/src/components/billing-dashboard/accounting/AccountingExportsTab.tsx
@@ -3,7 +3,7 @@
 import React, { useCallback, useEffect, useMemo, useState } from 'react';
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@alga-psa/ui/components/Card';
 import { Button } from '@alga-psa/ui/components/Button';
-import { Dialog, DialogContent, DialogHeader, DialogTitle } from '@alga-psa/ui/components/Dialog';
+import { Dialog, DialogContent } from '@alga-psa/ui/components/Dialog';
 import { Input } from '@alga-psa/ui/components/Input';
 import { DatePicker } from '@alga-psa/ui/components/DatePicker';
 import { dateFromString, dateToString } from '@alga-psa/ui/lib/dateInput';
@@ -424,10 +424,6 @@ export default function AccountingExportsTab(): React.JSX.Element {
         )}
       >
         <DialogContent>
-          <DialogHeader>
-            <DialogTitle>{t('accountingExports.createDialog.title', { defaultValue: 'New Accounting Export' })}</DialogTitle>
-          </DialogHeader>
-
           <div className="space-y-4">
             <div className="space-y-2">
               <Label htmlFor="accounting-export-adapter">
@@ -553,10 +549,6 @@ export default function AccountingExportsTab(): React.JSX.Element {
         id="accounting-exports-detail"
       >
         <DialogContent>
-          <DialogHeader>
-            <DialogTitle>{t('accountingExports.detailDialog.subtitle', { defaultValue: 'Batch Details' })}</DialogTitle>
-          </DialogHeader>
-
           {detailLoading ? (
             <div className="text-sm text-muted-foreground">
               {t('accountingExports.states.loadingDetails', { defaultValue: 'Loading batch details...' })}

--- a/packages/billing/src/components/billing-dashboard/contract-lines/EditContractLineServiceQuantityDialog.tsx
+++ b/packages/billing/src/components/billing-dashboard/contract-lines/EditContractLineServiceQuantityDialog.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import React, { useEffect, useState } from 'react';
-import { Dialog, DialogContent, DialogFooter, DialogHeader, DialogTitle } from '@alga-psa/ui/components/Dialog';
+import { Dialog, DialogContent, DialogFooter } from '@alga-psa/ui/components/Dialog';
 import { Button } from '@alga-psa/ui/components/Button';
 import { Input } from '@alga-psa/ui/components/Input';
 import { useTranslation } from '@alga-psa/ui/lib/i18n/client';
@@ -87,9 +87,6 @@ export const EditPlanServiceQuantityDialog: React.FC<EditPlanServiceQuantityDial
       title={t('forms.editQuantity.dialogTitle', { defaultValue: 'Edit Service Quantity' })}
     >
       <form onSubmit={handleSubmit}>
-        <DialogHeader>
-          <DialogTitle>{t('forms.editQuantity.heading', { defaultValue: 'Adjust Quantity' })}</DialogTitle>
-        </DialogHeader>
         <DialogContent className="space-y-4">
           <div>
             <p className="text-sm text-muted-foreground">{serviceName}</p>

--- a/packages/billing/src/components/billing-dashboard/contracts/AddContractLinesDialog.tsx
+++ b/packages/billing/src/components/billing-dashboard/contracts/AddContractLinesDialog.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import React, { useState, useEffect } from 'react';
-import { Dialog, DialogContent, DialogHeader, DialogTitle } from '@alga-psa/ui/components/Dialog';
+import { Dialog, DialogContent } from '@alga-psa/ui/components/Dialog';
 import { Button } from '@alga-psa/ui/components/Button';
 import { Input } from '@alga-psa/ui/components/Input';
 import { Label } from '@alga-psa/ui/components/Label';
@@ -420,12 +420,6 @@ export const AddContractLinesDialog: React.FC<AddContractLinesDialogProps> = ({
         </div>
       )}
     >
-      <DialogHeader>
-        <DialogTitle>
-          {t('addLines.selectPresetsTitle', { defaultValue: 'Select Contract Line Presets to Add' })}
-        </DialogTitle>
-      </DialogHeader>
-
       <DialogContent className="flex flex-col">
         <div className="space-y-4 flex flex-col h-full">
           {error && (

--- a/packages/billing/tests/billing-dashboard/AccountingExportsTab.i18n.test.ts
+++ b/packages/billing/tests/billing-dashboard/AccountingExportsTab.i18n.test.ts
@@ -54,7 +54,6 @@ describe('AccountingExportsTab i18n wiring contract', () => {
     expect(source).toContain("t('accountingExports.actions.creating', { defaultValue: 'Creating...' })");
     expect(source).toContain("t('accountingExports.actions.createBatch', { defaultValue: 'Create Batch' })");
     expect(source).toContain("t('accountingExports.detailDialog.title', { defaultValue: 'Accounting Export Batch' })");
-    expect(source).toContain("t('accountingExports.detailDialog.subtitle', { defaultValue: 'Batch Details' })");
     expect(source).toContain("t('accountingExports.detailDialog.fields.batchId', { defaultValue: 'Batch ID' })");
     expect(source).toContain("t('accountingExports.detailDialog.fields.adapter', { defaultValue: 'Adapter' })");
     expect(source).toContain("t('accountingExports.detailDialog.fields.lines', { defaultValue: 'Lines' })");

--- a/packages/billing/tests/billing-dashboard/AddContractLinesDialog.i18n.test.ts
+++ b/packages/billing/tests/billing-dashboard/AddContractLinesDialog.i18n.test.ts
@@ -33,7 +33,6 @@ describe('AddContractLinesDialog i18n wiring contract', () => {
 
     const keyChecks = [
       'addLines.title',
-      'addLines.selectPresetsTitle',
       'addLines.filters.searchPlaceholder',
       'addLines.filters.allTypes',
       'addLines.filters.typePlaceholder',

--- a/packages/billing/tests/billing-dashboard/ContractLinesSubbatch.i18n.test.ts
+++ b/packages/billing/tests/billing-dashboard/ContractLinesSubbatch.i18n.test.ts
@@ -509,7 +509,6 @@ describe('MSP contract-lines sub-batch i18n wiring contract', () => {
     const source = read('../../src/components/billing-dashboard/contract-lines/EditContractLineServiceQuantityDialog.tsx');
     expectSourceHasKeys(source, [
       'forms.editQuantity.dialogTitle',
-      'forms.editQuantity.heading',
       'forms.editQuantity.labels.quantity',
       'forms.editQuantity.labels.unitPriceOverrideOptional',
       'forms.editQuantity.helperText',

--- a/packages/integrations/src/components/email/admin/Microsoft365DiagnosticsDialog.tsx
+++ b/packages/integrations/src/components/email/admin/Microsoft365DiagnosticsDialog.tsx
@@ -7,7 +7,7 @@
 
 import React from 'react';
 import { useTranslation } from '@alga-psa/ui/lib/i18n/client';
-import { Dialog, DialogContent, DialogDescription, DialogHeader, DialogTitle } from '@alga-psa/ui/components/Dialog';
+import { Dialog, DialogContent, DialogDescription, DialogHeader } from '@alga-psa/ui/components/Dialog';
 import { Button } from '@alga-psa/ui/components/Button';
 import { Alert, AlertDescription } from '@alga-psa/ui/components/Alert';
 import { Badge } from '@alga-psa/ui/components/Badge';
@@ -122,7 +122,6 @@ export function Microsoft365DiagnosticsDialog({
     <Dialog isOpen={isOpen} onClose={onClose} title={title} id="microsoft-365-diagnostics" footer={footer}>
       <DialogContent className="max-w-4xl">
         <DialogHeader>
-          <DialogTitle>{title}</DialogTitle>
           <DialogDescription>
             {t('microsoft365.description', {
               defaultValue: 'Runs a live Graph check (including create+delete subscription) to diagnose mailbox, folder, and permission issues.'

--- a/packages/integrations/src/components/settings/integrations/MicrosoftIntegrationSettings.tsx
+++ b/packages/integrations/src/components/settings/integrations/MicrosoftIntegrationSettings.tsx
@@ -13,7 +13,6 @@ import {
   DialogContent,
   DialogDescription,
   DialogHeader,
-  DialogTitle,
 } from '@alga-psa/ui/components/Dialog';
 import { Input } from '@alga-psa/ui/components/Input';
 import { Label } from '@alga-psa/ui/components/Label';
@@ -1300,7 +1299,6 @@ export function MicrosoftIntegrationSettings({
       >
         <DialogContent className="sm:max-w-2xl">
           <DialogHeader>
-            <DialogTitle>{dialogTitle}</DialogTitle>
             <DialogDescription>
               {dialogMode === 'create'
                 ? t('integrations.microsoft.settings.dialog.descriptionCreate', { defaultValue: 'Create a Microsoft app registration, then choose which services can use it.' })

--- a/packages/ui/src/components/Dialog.tsx
+++ b/packages/ui/src/components/Dialog.tsx
@@ -168,7 +168,7 @@ export function Dialog({
 
   // Guard against the duplicated-heading pattern: a `title` prop plus a child DialogTitle
   useEffect(() => {
-    if (process.env.NODE_ENV === 'production' || !isOpen || !title) return;
+    if (process.env.NODE_ENV !== 'development' || !isOpen || !title) return;
     if (!containsDialogTitle(children)) return;
 
     console.warn(

--- a/packages/ui/src/components/Dialog.tsx
+++ b/packages/ui/src/components/Dialog.tsx
@@ -27,6 +27,21 @@ function containsDialogDescription(node: ReactNode): boolean {
   return containsDialogDescription((node.props as { children?: ReactNode } | null | undefined)?.children);
 }
 
+function containsDialogTitle(node: ReactNode): boolean {
+  if (node === null || node === undefined || typeof node === 'boolean') return false;
+
+  if (Array.isArray(node)) {
+    return node.some(containsDialogTitle);
+  }
+
+  if (!React.isValidElement(node)) return false;
+
+  if (node.type === DialogTitle || node.type === RadixDialog.Title) return true;
+
+  // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
+  return containsDialogTitle((node.props as { children?: ReactNode } | null | undefined)?.children);
+}
+
 function findFirstFocusable(root: HTMLElement | null): HTMLElement | null {
   if (!root) return null;
 
@@ -150,6 +165,16 @@ export function Dialog({
   useEffect(() => {
     updateMetadata({ open: isOpen, title });
   }, [ isOpen, title, updateMetadata, id ]);
+
+  // Guard against the duplicated-heading pattern: a `title` prop plus a child DialogTitle
+  useEffect(() => {
+    if (process.env.NODE_ENV === 'production' || !isOpen || !title) return;
+    if (!containsDialogTitle(children)) return;
+
+    console.warn(
+      `[Dialog:${id}] renders both a "title" prop and a child DialogTitle — the heading will appear twice. Drop one of them.`
+    );
+  }, [isOpen, title, children, id]);
 
   // Reset position when dialog opens
   useEffect(() => {

--- a/server/public/locales/de/msp/billing.json
+++ b/server/public/locales/de/msp/billing.json
@@ -408,7 +408,6 @@
     },
     "detailDialog": {
       "title": "Buchhaltungsexportstapel",
-      "subtitle": "Chargendetails",
       "fields": {
         "batchId": "Chargen-ID",
         "adapter": "Adapter",

--- a/server/public/locales/de/msp/contract-lines.json
+++ b/server/public/locales/de/msp/contract-lines.json
@@ -363,7 +363,6 @@
         "quantityGreaterThanZero": "Die Menge muss größer als Null sein",
         "updateFailed": "Menge konnte nicht aktualisiert werden"
       },
-      "heading": "Menge anpassen",
       "helperText": "Lassen Sie das Feld leer, um den Produktkatalogpreis für die Währung dieses Vertrags zu verwenden.",
       "labels": {
         "quantity": "Menge",

--- a/server/public/locales/de/msp/contracts.json
+++ b/server/public/locales/de/msp/contracts.json
@@ -641,7 +641,6 @@
       "title": "Konfiguration der Zeitabrechnung"
     },
     "loading": "Vertragslinien-Vorlagenbausteine werden geladen...",
-    "selectPresetsTitle": "Vertragslinien-Vorlagenbausteine zum Hinzufügen auswählen",
     "selection": {
       "deselectPreset": "Vorlagenbaustein abwählen",
       "selectPreset": "Vorlagenbaustein auswählen",

--- a/server/public/locales/de/msp/workflows.json
+++ b/server/public/locales/de/msp/workflows.json
@@ -2449,7 +2449,6 @@
         }
       },
       "schemaModal": {
-        "title": "Schema",
         "close": "Schließen",
         "headerTitle": "Payload-Schema",
         "loading": "Wird geladen…",
@@ -2459,7 +2458,6 @@
         "copyFailed": "Kopieren fehlgeschlagen"
       },
       "metricsDialog": {
-        "title": "Metriken",
         "close": "Schließen",
         "headerTitle": "Metriken · {{eventType}}",
         "from": "Von",
@@ -2486,7 +2484,6 @@
         "next": "Weiter"
       },
       "simulateDialog": {
-        "title": "Ereignis simulieren",
         "headerTitle": "Simulieren · {{eventType}}",
         "submit": "Simulieren",
         "submitting": "Wird gesendet…",
@@ -2543,7 +2540,6 @@
       },
       "defineEventDialog": {
         "title": "Benutzerdefiniertes Ereignis definieren",
-        "headerTitle": "Benutzerdefiniertes Ereignis definieren",
         "cancel": "Abbrechen",
         "submit": "Ereignis erstellen",
         "submitting": "Wird erstellt…",

--- a/server/public/locales/en/msp/billing.json
+++ b/server/public/locales/en/msp/billing.json
@@ -408,7 +408,6 @@
     },
     "detailDialog": {
       "title": "Accounting Export Batch",
-      "subtitle": "Batch Details",
       "fields": {
         "batchId": "Batch ID",
         "adapter": "Adapter",

--- a/server/public/locales/en/msp/contract-lines.json
+++ b/server/public/locales/en/msp/contract-lines.json
@@ -363,7 +363,6 @@
         "quantityGreaterThanZero": "Quantity must be greater than zero",
         "updateFailed": "Failed to update quantity"
       },
-      "heading": "Adjust Quantity",
       "helperText": "Leave blank to use the product catalog price for this contract's currency.",
       "labels": {
         "quantity": "Quantity",

--- a/server/public/locales/en/msp/contracts.json
+++ b/server/public/locales/en/msp/contracts.json
@@ -641,7 +641,6 @@
       "title": "Time Billing Configuration"
     },
     "loading": "Loading contract line presets...",
-    "selectPresetsTitle": "Select Contract Line Presets to Add",
     "selection": {
       "deselectPreset": "Deselect preset",
       "selectPreset": "Select preset",

--- a/server/public/locales/en/msp/workflows.json
+++ b/server/public/locales/en/msp/workflows.json
@@ -2327,7 +2327,6 @@
         }
       },
       "schemaModal": {
-        "title": "Schema",
         "close": "Close",
         "headerTitle": "Payload schema",
         "loading": "Loading…",
@@ -2337,7 +2336,6 @@
         "copyFailed": "Copy failed"
       },
       "metricsDialog": {
-        "title": "Metrics",
         "close": "Close",
         "headerTitle": "Metrics · {{eventType}}",
         "from": "From",
@@ -2364,7 +2362,6 @@
         "next": "Next"
       },
       "simulateDialog": {
-        "title": "Simulate event",
         "headerTitle": "Simulate · {{eventType}}",
         "submit": "Simulate",
         "submitting": "Submitting…",
@@ -2421,7 +2418,6 @@
       },
       "defineEventDialog": {
         "title": "Define custom event",
-        "headerTitle": "Define Custom Event",
         "cancel": "Cancel",
         "submit": "Create event",
         "submitting": "Creating…",

--- a/server/public/locales/es/msp/billing.json
+++ b/server/public/locales/es/msp/billing.json
@@ -408,7 +408,6 @@
     },
     "detailDialog": {
       "title": "Lote de exportación contable",
-      "subtitle": "Detalles del lote",
       "fields": {
         "batchId": "ID de lote",
         "adapter": "Adaptador",

--- a/server/public/locales/es/msp/contract-lines.json
+++ b/server/public/locales/es/msp/contract-lines.json
@@ -363,7 +363,6 @@
         "quantityGreaterThanZero": "La cantidad debe ser mayor que cero.",
         "updateFailed": "No se pudo actualizar la cantidad"
       },
-      "heading": "Ajustar cantidad",
       "helperText": "Déjelo en blanco para utilizar el precio del catálogo de productos para la moneda de este contrato.",
       "labels": {
         "quantity": "Cantidad",

--- a/server/public/locales/es/msp/contracts.json
+++ b/server/public/locales/es/msp/contracts.json
@@ -641,7 +641,6 @@
       "title": "Configuración de facturación por tiempo"
     },
     "loading": "Cargando preajustes de línea de contrato...",
-    "selectPresetsTitle": "Seleccione los preajustes de línea de contrato para agregar",
     "selection": {
       "deselectPreset": "Deseleccionar preajuste",
       "selectPreset": "Seleccionar preajuste",

--- a/server/public/locales/es/msp/workflows.json
+++ b/server/public/locales/es/msp/workflows.json
@@ -2449,7 +2449,6 @@
         }
       },
       "schemaModal": {
-        "title": "Esquema",
         "close": "Cerrar",
         "headerTitle": "Esquema de payload",
         "loading": "Cargando…",
@@ -2459,7 +2458,6 @@
         "copyFailed": "Error al copiar"
       },
       "metricsDialog": {
-        "title": "Métricas",
         "close": "Cerrar",
         "headerTitle": "Métricas · {{eventType}}",
         "from": "Desde",
@@ -2486,7 +2484,6 @@
         "next": "Siguiente"
       },
       "simulateDialog": {
-        "title": "Simular evento",
         "headerTitle": "Simular · {{eventType}}",
         "submit": "Simular",
         "submitting": "Enviando…",
@@ -2543,7 +2540,6 @@
       },
       "defineEventDialog": {
         "title": "Definir evento personalizado",
-        "headerTitle": "Definir evento personalizado",
         "cancel": "Cancelar",
         "submit": "Crear evento",
         "submitting": "Creando…",

--- a/server/public/locales/fr/msp/billing.json
+++ b/server/public/locales/fr/msp/billing.json
@@ -408,7 +408,6 @@
     },
     "detailDialog": {
       "title": "Lot d'export comptable",
-      "subtitle": "Détails du lot",
       "fields": {
         "batchId": "ID de lot",
         "adapter": "Adaptateur",

--- a/server/public/locales/fr/msp/contract-lines.json
+++ b/server/public/locales/fr/msp/contract-lines.json
@@ -363,7 +363,6 @@
         "quantityGreaterThanZero": "La quantité doit être supérieure à zéro",
         "updateFailed": "Échec de la mise à jour de la quantité"
       },
-      "heading": "Ajuster la quantité",
       "helperText": "Laissez ce champ vide pour utiliser le prix du catalogue de produits dans la devise de ce contrat.",
       "labels": {
         "quantity": "Quantité",

--- a/server/public/locales/fr/msp/contracts.json
+++ b/server/public/locales/fr/msp/contracts.json
@@ -641,7 +641,6 @@
       "title": "Configuration de la facturation au temps"
     },
     "loading": "Chargement des préréglages de ligne de contrat...",
-    "selectPresetsTitle": "Sélectionnez les préréglages de ligne de contrat à ajouter",
     "selection": {
       "deselectPreset": "Désélectionner le préréglage",
       "selectPreset": "Sélectionnez un préréglage",

--- a/server/public/locales/fr/msp/workflows.json
+++ b/server/public/locales/fr/msp/workflows.json
@@ -2449,7 +2449,6 @@
         }
       },
       "schemaModal": {
-        "title": "Schéma",
         "close": "Fermer",
         "headerTitle": "Schéma de payload",
         "loading": "Chargement…",
@@ -2459,7 +2458,6 @@
         "copyFailed": "Échec de la copie"
       },
       "metricsDialog": {
-        "title": "Métriques",
         "close": "Fermer",
         "headerTitle": "Métriques · {{eventType}}",
         "from": "Du",
@@ -2486,7 +2484,6 @@
         "next": "Suiv."
       },
       "simulateDialog": {
-        "title": "Simuler un événement",
         "headerTitle": "Simuler · {{eventType}}",
         "submit": "Simuler",
         "submitting": "Envoi…",
@@ -2543,7 +2540,6 @@
       },
       "defineEventDialog": {
         "title": "Définir un événement personnalisé",
-        "headerTitle": "Définir un événement personnalisé",
         "cancel": "Annuler",
         "submit": "Créer l'événement",
         "submitting": "Création…",

--- a/server/public/locales/it/msp/billing.json
+++ b/server/public/locales/it/msp/billing.json
@@ -408,7 +408,6 @@
     },
     "detailDialog": {
       "title": "Batch di esportazione contabile",
-      "subtitle": "Dettagli del lotto",
       "fields": {
         "batchId": "ID lotto",
         "adapter": "Adattatore",

--- a/server/public/locales/it/msp/contract-lines.json
+++ b/server/public/locales/it/msp/contract-lines.json
@@ -363,7 +363,6 @@
         "quantityGreaterThanZero": "La quantità deve essere maggiore di zero",
         "updateFailed": "Impossibile aggiornare la quantità"
       },
-      "heading": "Regola la quantità",
       "helperText": "Lascia vuoto per utilizzare il prezzo del catalogo prodotti per la valuta di questo contratto.",
       "labels": {
         "quantity": "Quantità",

--- a/server/public/locales/it/msp/contracts.json
+++ b/server/public/locales/it/msp/contracts.json
@@ -641,7 +641,6 @@
       "title": "Configurazione fatturazione a tempo"
     },
     "loading": "Caricamento preimpostazioni della linea contrattuale...",
-    "selectPresetsTitle": "Seleziona le preimpostazioni della linea contrattuale da aggiungere",
     "selection": {
       "deselectPreset": "Deseleziona preimpostazione",
       "selectPreset": "Seleziona preimpostazione",

--- a/server/public/locales/it/msp/workflows.json
+++ b/server/public/locales/it/msp/workflows.json
@@ -2449,7 +2449,6 @@
         }
       },
       "schemaModal": {
-        "title": "Schema dati",
         "close": "Chiudi",
         "headerTitle": "Schema del payload",
         "loading": "Caricamento…",
@@ -2459,7 +2458,6 @@
         "copyFailed": "Copia non riuscita"
       },
       "metricsDialog": {
-        "title": "Metriche",
         "close": "Chiudi",
         "headerTitle": "Metriche · {{eventType}}",
         "from": "Da",
@@ -2486,7 +2484,6 @@
         "next": "Succ."
       },
       "simulateDialog": {
-        "title": "Simula evento",
         "headerTitle": "Simula · {{eventType}}",
         "submit": "Simula",
         "submitting": "Invio…",
@@ -2543,7 +2540,6 @@
       },
       "defineEventDialog": {
         "title": "Definisci evento personalizzato",
-        "headerTitle": "Definisci evento personalizzato",
         "cancel": "Annulla",
         "submit": "Crea evento",
         "submitting": "Creazione…",

--- a/server/public/locales/nl/msp/billing.json
+++ b/server/public/locales/nl/msp/billing.json
@@ -408,7 +408,6 @@
     },
     "detailDialog": {
       "title": "Boekhoudkundige exportbatch",
-      "subtitle": "Batchdetails",
       "fields": {
         "batchId": "Batch-ID",
         "adapter": "Adapter",

--- a/server/public/locales/nl/msp/contract-lines.json
+++ b/server/public/locales/nl/msp/contract-lines.json
@@ -363,7 +363,6 @@
         "quantityGreaterThanZero": "De hoeveelheid moet groter zijn dan nul",
         "updateFailed": "Kan aantal niet updaten"
       },
-      "heading": "Pas de hoeveelheid aan",
       "helperText": "Laat dit veld leeg als u de productcatalogusprijs voor de valuta van dit contract wilt gebruiken.",
       "labels": {
         "quantity": "Hoeveelheid",

--- a/server/public/locales/nl/msp/contracts.json
+++ b/server/public/locales/nl/msp/contracts.json
@@ -641,7 +641,6 @@
       "title": "Configuratie tijdfacturatie"
     },
     "loading": "Contractregelpresets laden...",
-    "selectPresetsTitle": "Selecteer toe te voegen contractregelpresets",
     "selection": {
       "deselectPreset": "Preset deselecteren",
       "selectPreset": "Selecteer preset",

--- a/server/public/locales/nl/msp/workflows.json
+++ b/server/public/locales/nl/msp/workflows.json
@@ -2449,7 +2449,6 @@
         }
       },
       "schemaModal": {
-        "title": "Schema",
         "close": "Sluiten",
         "headerTitle": "Payload-schema",
         "loading": "Laden…",
@@ -2459,7 +2458,6 @@
         "copyFailed": "Kopiëren mislukt"
       },
       "metricsDialog": {
-        "title": "Statistieken",
         "close": "Sluiten",
         "headerTitle": "Statistieken · {{eventType}}",
         "from": "Vanaf",
@@ -2486,7 +2484,6 @@
         "next": "Volgende"
       },
       "simulateDialog": {
-        "title": "Gebeurtenis simuleren",
         "headerTitle": "Simuleren · {{eventType}}",
         "submit": "Simuleren",
         "submitting": "Verzenden…",
@@ -2543,7 +2540,6 @@
       },
       "defineEventDialog": {
         "title": "Aangepaste gebeurtenis definiëren",
-        "headerTitle": "Aangepaste gebeurtenis definiëren",
         "cancel": "Annuleren",
         "submit": "Gebeurtenis maken",
         "submitting": "Maken…",

--- a/server/public/locales/pl/msp/billing.json
+++ b/server/public/locales/pl/msp/billing.json
@@ -408,7 +408,6 @@
     },
     "detailDialog": {
       "title": "Księgowa partia eksportowa",
-      "subtitle": "Szczegóły partii",
       "fields": {
         "batchId": "Identyfikator partii",
         "adapter": "Adapter",

--- a/server/public/locales/pl/msp/contract-lines.json
+++ b/server/public/locales/pl/msp/contract-lines.json
@@ -363,7 +363,6 @@
         "quantityGreaterThanZero": "Ilość musi być większa od zera",
         "updateFailed": "Nie udało się zaktualizować ilości"
       },
-      "heading": "Dostosuj ilość",
       "helperText": "Pozostaw puste, aby użyć ceny katalogowej produktu w walucie kontraktu.",
       "labels": {
         "quantity": "Ilość",

--- a/server/public/locales/pl/msp/contracts.json
+++ b/server/public/locales/pl/msp/contracts.json
@@ -641,7 +641,6 @@
       "title": "Konfiguracja rozliczeń czasowych"
     },
     "loading": "Ładowanie presetów linii kontraktowych...",
-    "selectPresetsTitle": "Wybierz presety linii kontraktowych do dodania",
     "selection": {
       "deselectPreset": "Odznacz preset",
       "selectPreset": "Wybierz preset",

--- a/server/public/locales/pl/msp/workflows.json
+++ b/server/public/locales/pl/msp/workflows.json
@@ -2451,7 +2451,6 @@
         }
       },
       "schemaModal": {
-        "title": "Schemat",
         "close": "Zamknij",
         "headerTitle": "Schemat ładunku",
         "loading": "Ładowanie…",
@@ -2461,7 +2460,6 @@
         "copyFailed": "Kopiowanie nie powiodło się"
       },
       "metricsDialog": {
-        "title": "Metryki",
         "close": "Zamknij",
         "headerTitle": "Metryki · {{eventType}}",
         "from": "Od",
@@ -2488,7 +2486,6 @@
         "next": "Dalej"
       },
       "simulateDialog": {
-        "title": "Symuluj zdarzenie",
         "headerTitle": "Symuluj · {{eventType}}",
         "submit": "Symuluj",
         "submitting": "Wysyłanie…",
@@ -2545,7 +2542,6 @@
       },
       "defineEventDialog": {
         "title": "Zdefiniuj zdarzenie niestandardowe",
-        "headerTitle": "Zdefiniuj zdarzenie niestandardowe",
         "cancel": "Anuluj",
         "submit": "Utwórz zdarzenie",
         "submitting": "Tworzenie…",

--- a/server/public/locales/pt/msp/billing.json
+++ b/server/public/locales/pt/msp/billing.json
@@ -408,7 +408,6 @@
     },
     "detailDialog": {
       "title": "Lote de exportação contábil",
-      "subtitle": "Detalhes do lote",
       "fields": {
         "batchId": "ID do lote",
         "adapter": "Adaptador",

--- a/server/public/locales/pt/msp/contract-lines.json
+++ b/server/public/locales/pt/msp/contract-lines.json
@@ -363,7 +363,6 @@
         "quantityGreaterThanZero": "A quantidade deve ser maior que zero",
         "updateFailed": "Falha ao atualizar a quantidade"
       },
-      "heading": "Ajustar quantidade",
       "helperText": "Deixe em branco para usar o preço de catálogo do produto para a moeda deste contrato.",
       "labels": {
         "quantity": "Quantidade",

--- a/server/public/locales/pt/msp/contracts.json
+++ b/server/public/locales/pt/msp/contracts.json
@@ -641,7 +641,6 @@
       "title": "Configuração de cobrança por tempo"
     },
     "loading": "Carregando predefinições de linha de contrato...",
-    "selectPresetsTitle": "Selecione predefinições de linha de contrato para adicionar",
     "selection": {
       "deselectPreset": "Desmarcar predefinição",
       "selectPreset": "Selecione predefinição",

--- a/server/public/locales/pt/msp/workflows.json
+++ b/server/public/locales/pt/msp/workflows.json
@@ -2327,7 +2327,6 @@
         }
       },
       "schemaModal": {
-        "title": "Esquema",
         "close": "Fechar",
         "headerTitle": "Esquema de carga útil",
         "loading": "Carregando…",
@@ -2337,7 +2336,6 @@
         "copyFailed": "Falha na cópia"
       },
       "metricsDialog": {
-        "title": "Métricas",
         "close": "Fechar",
         "headerTitle": "Métricas · {{eventType}}",
         "from": "De",
@@ -2364,7 +2362,6 @@
         "next": "Próximo"
       },
       "simulateDialog": {
-        "title": "Simular evento",
         "headerTitle": "Simular · {{eventType}}",
         "submit": "Simular",
         "submitting": "Enviando…",
@@ -2421,7 +2418,6 @@
       },
       "defineEventDialog": {
         "title": "Definir evento personalizado",
-        "headerTitle": "Definir evento personalizado",
         "cancel": "Cancelar",
         "submit": "Criar evento",
         "submitting": "Criando…",

--- a/server/public/locales/xx/msp/billing.json
+++ b/server/public/locales/xx/msp/billing.json
@@ -408,7 +408,6 @@
     },
     "detailDialog": {
       "title": "11111",
-      "subtitle": "11111",
       "fields": {
         "batchId": "11111",
         "adapter": "11111",

--- a/server/public/locales/xx/msp/contract-lines.json
+++ b/server/public/locales/xx/msp/contract-lines.json
@@ -363,7 +363,6 @@
         "quantityGreaterThanZero": "11111",
         "updateFailed": "11111"
       },
-      "heading": "11111",
       "helperText": "11111",
       "labels": {
         "quantity": "11111",

--- a/server/public/locales/xx/msp/contracts.json
+++ b/server/public/locales/xx/msp/contracts.json
@@ -641,7 +641,6 @@
       "title": "11111"
     },
     "loading": "11111",
-    "selectPresetsTitle": "11111",
     "selection": {
       "deselectPreset": "11111",
       "selectPreset": "11111",

--- a/server/public/locales/xx/msp/workflows.json
+++ b/server/public/locales/xx/msp/workflows.json
@@ -2327,7 +2327,6 @@
         }
       },
       "schemaModal": {
-        "title": "11111",
         "close": "11111",
         "headerTitle": "11111",
         "loading": "11111",
@@ -2337,7 +2336,6 @@
         "copyFailed": "11111"
       },
       "metricsDialog": {
-        "title": "11111",
         "close": "11111",
         "headerTitle": "11111 {{eventType}} 11111",
         "from": "11111",
@@ -2364,7 +2362,6 @@
         "next": "11111"
       },
       "simulateDialog": {
-        "title": "11111",
         "headerTitle": "11111 {{eventType}} 11111",
         "submit": "11111",
         "submitting": "11111",
@@ -2421,7 +2418,6 @@
       },
       "defineEventDialog": {
         "title": "11111",
-        "headerTitle": "11111",
         "cancel": "11111",
         "submit": "11111",
         "submitting": "11111",

--- a/server/public/locales/yy/msp/billing.json
+++ b/server/public/locales/yy/msp/billing.json
@@ -408,7 +408,6 @@
     },
     "detailDialog": {
       "title": "55555",
-      "subtitle": "55555",
       "fields": {
         "batchId": "55555",
         "adapter": "55555",

--- a/server/public/locales/yy/msp/contract-lines.json
+++ b/server/public/locales/yy/msp/contract-lines.json
@@ -363,7 +363,6 @@
         "quantityGreaterThanZero": "55555",
         "updateFailed": "55555"
       },
-      "heading": "55555",
       "helperText": "55555",
       "labels": {
         "quantity": "55555",

--- a/server/public/locales/yy/msp/contracts.json
+++ b/server/public/locales/yy/msp/contracts.json
@@ -641,7 +641,6 @@
       "title": "55555"
     },
     "loading": "55555",
-    "selectPresetsTitle": "55555",
     "selection": {
       "deselectPreset": "55555",
       "selectPreset": "55555",

--- a/server/public/locales/yy/msp/workflows.json
+++ b/server/public/locales/yy/msp/workflows.json
@@ -2327,7 +2327,6 @@
         }
       },
       "schemaModal": {
-        "title": "55555",
         "close": "55555",
         "headerTitle": "55555",
         "loading": "55555",
@@ -2337,7 +2336,6 @@
         "copyFailed": "55555"
       },
       "metricsDialog": {
-        "title": "55555",
         "close": "55555",
         "headerTitle": "55555 {{eventType}} 55555",
         "from": "55555",
@@ -2364,7 +2362,6 @@
         "next": "55555"
       },
       "simulateDialog": {
-        "title": "55555",
         "headerTitle": "55555 {{eventType}} 55555",
         "submit": "55555",
         "submitting": "55555",
@@ -2421,7 +2418,6 @@
       },
       "defineEventDialog": {
         "title": "55555",
-        "headerTitle": "55555",
         "cancel": "55555",
         "submit": "55555",
         "submitting": "55555",


### PR DESCRIPTION
## Summary
Several dialogs across billing, workflows, and integrations were rendering their heading twice: once via the `Dialog` component's `title` prop (used for the built-in header) and again via a `DialogTitle` nested inside `DialogHeader`/`DialogContent`. This surfaced most visibly on the New Accounting Export dialog. This change removes the redundant `DialogTitle` usages, cleans up the now-unused i18n keys across all locales, and adds a development-only console warning in the shared `Dialog` component so this pattern can't silently reappear.

## Changes
- **Dialog component (`packages/ui`)**: added a `containsDialogTitle` check that walks dialog children and emits a `console.warn` in development when both a `title` prop and a child `DialogTitle` are present.
- **Billing dialogs**: removed duplicated `DialogHeader`/`DialogTitle` blocks from `AccountingExportsTab` (create + detail dialogs), `AddContractLinesDialog`, and `EditContractLineServiceQuantityDialog`, relying solely on the `Dialog` `title` prop.
- **Workflow/automation-hub dialogs**: removed duplicate titles from `EventsCatalogV2` (schema, metrics, simulate, define-custom-event dialogs) and `WorkflowScheduleDialog`, consolidating on the `title` prop and renaming some `defaultValue` strings to be more descriptive (e.g. "Metrics · {{eventType}}").
- **Workflow designer**: removed the duplicate `DialogTitle` from `InputMappingEditor`'s fixed-value editor dialog.
- **Integrations dialogs**: removed duplicate titles from `Microsoft365DiagnosticsDialog` and `MicrosoftIntegrationSettings`.
- **i18n cleanup**: removed the now-unused translation keys (`accountingExports.detailDialog.subtitle`, `addLines.selectPresetsTitle`, `forms.editQuantity.heading`, and the workflow schema/metrics/simulate/defineEvent `title`/`headerTitle` duplicates) from `billing.json`, `contract-lines.json`, `contracts.json`, and `workflows.json` across all 12 locale directories.
- **Test infra (`ee/server`)**: fixed vitest module resolution by moving `server.deps.inline` under `test.server` and added a source alias for `@alga-psa/workflows` so tests don't require a dist build; updated the `Dialog` mock in `InputMappingEditorUnifiedEditor.test.tsx` to render the `footer` prop.

## Testing
- Updated i18n wiring-contract tests (`AccountingExportsTab.i18n.test.ts`, `AddContractLinesDialog.i18n.test.ts`, `ContractLinesSubbatch.i18n.test.ts`) to reflect the removed keys.
- Fixed EE vitest module resolution/mocking so `InputMappingEditorUnifiedEditor.test.tsx` passes with the updated `Dialog` mock.