### PR TITLE
File generated invoices and sales orders as documents

### DIFF
--- a/ee/server/seeds/onboarding/psa/08_document_folder_templates.cjs
+++ b/ee/server/seeds/onboarding/psa/08_document_folder_templates.cjs
@@ -17,6 +17,7 @@ const DEFAULTS = [
       { folder_path: '/Clients/Technical',               folder_name: 'Technical',      sort_order: 6,  is_client_visible: false },
       { folder_path: '/Clients/Technical/Runbooks',      folder_name: 'Runbooks',       sort_order: 7,  is_client_visible: false },
       { folder_path: '/Clients/Meeting Notes',           folder_name: 'Meeting Notes',  sort_order: 8,  is_client_visible: true },
+      { folder_path: '/Clients/Sales Orders',            folder_name: 'Sales Orders',   sort_order: 9,  is_client_visible: false },
     ],
   },
   {

--- a/packages/billing/src/actions/invoiceGeneration.ts
+++ b/packages/billing/src/actions/invoiceGeneration.ts
@@ -2743,9 +2743,10 @@ export const generateInvoicePDF = withAuth(async (
 });
 
 /**
- * Bytes of the invoice's filed PDF: reuses the document already on file, refreshing
- * it when the invoice has not been issued yet. Falls back to a plain render if the
- * document store is unavailable — a download must not depend on filing succeeding.
+ * Bytes of the invoice's filed PDF: reuses the document already on file — unless a
+ * different template was asked for — and refreshes it while the invoice has not been
+ * issued yet. Falls back to a plain render if the document store is unavailable: a
+ * download must not depend on filing succeeding.
  */
 async function getStoredInvoicePdf(options: {
   tenant: string;
@@ -2761,7 +2762,6 @@ async function getStoredInvoicePdf(options: {
       invoiceId: options.invoiceId,
       invoiceNumber: options.invoiceNumber,
       templateId: options.templateId,
-      regenerate: Boolean(options.templateId),
       userId: options.userId,
     });
 
@@ -2808,7 +2808,6 @@ export const downloadInvoicePDF = withAuth(async (
     console.log('[downloadInvoicePDF] Generating PDF for invoice:', invoice.invoice_number);
     // File the PDF as a document and hand back the stored bytes, so what the
     // biller downloads is the artifact on record rather than a throwaway render.
-    // Picking a template is an explicit request for a fresh one.
     const pdfBuffer = await getStoredInvoicePdf({
       tenant,
       invoiceId,

--- a/packages/billing/src/actions/invoiceGeneration.ts
+++ b/packages/billing/src/actions/invoiceGeneration.ts
@@ -34,6 +34,7 @@ import Invoice from '@alga-psa/billing/models/invoice';
 import { createTenantKnex } from '@alga-psa/db';
 import { Temporal } from '@js-temporal/polyfill';
 import { createPDFGenerationService } from '../services/pdfGenerationService';
+import { StorageService } from '@alga-psa/storage/StorageService';
 import { toPlainDate, toISODate, toISOTimestamp } from '@alga-psa/core';
 import { ISO8601String } from '@alga-psa/types';
 import { TaxService } from '../services/taxService';
@@ -2741,6 +2742,41 @@ export const generateInvoicePDF = withAuth(async (
   });
 });
 
+/**
+ * Bytes of the invoice's filed PDF: reuses the document already on file, refreshing
+ * it when the invoice has not been issued yet. Falls back to a plain render if the
+ * document store is unavailable — a download must not depend on filing succeeding.
+ */
+async function getStoredInvoicePdf(options: {
+  tenant: string;
+  invoiceId: string;
+  invoiceNumber: string;
+  userId: string;
+  templateId?: string;
+}): Promise<Buffer> {
+  const pdfGenerationService = createPDFGenerationService(options.tenant);
+
+  try {
+    const stored = await pdfGenerationService.generateAndStore({
+      invoiceId: options.invoiceId,
+      invoiceNumber: options.invoiceNumber,
+      templateId: options.templateId,
+      regenerate: Boolean(options.templateId),
+      userId: options.userId,
+    });
+
+    const { buffer } = await StorageService.downloadFile(stored.file_id);
+    return Buffer.from(buffer);
+  } catch (error) {
+    console.error('[downloadInvoicePDF] Falling back to an unfiled render:', error);
+    return pdfGenerationService.generatePDF({
+      invoiceId: options.invoiceId,
+      userId: options.userId,
+      templateId: options.templateId,
+    });
+  }
+}
+
 export const downloadInvoicePDF = withAuth(async (
   user,
   { tenant },
@@ -2770,11 +2806,13 @@ export const downloadInvoicePDF = withAuth(async (
     }
 
     console.log('[downloadInvoicePDF] Generating PDF for invoice:', invoice.invoice_number);
-    // Use the PDF generation service to generate the PDF
-    const pdfGenerationService = createPDFGenerationService(tenant);
-
-    const pdfBuffer = await pdfGenerationService.generatePDF({
+    // File the PDF as a document and hand back the stored bytes, so what the
+    // biller downloads is the artifact on record rather than a throwaway render.
+    // Picking a template is an explicit request for a fresh one.
+    const pdfBuffer = await getStoredInvoicePdf({
+      tenant,
       invoiceId,
+      invoiceNumber: invoice.invoice_number,
       userId: user.user_id,
       templateId: templateId || undefined,
     });

--- a/packages/billing/src/actions/invoiceJobActions.ts
+++ b/packages/billing/src/actions/invoiceJobActions.ts
@@ -4,7 +4,7 @@ import logger from '@alga-psa/core/logger';
 import { createTenantKnex, tenantDb } from '@alga-psa/db';
 import { fetchTenantParty } from '../lib/adapters/tenantPartyAdapter';
 import { getInvoiceForRendering } from './invoiceQueries';
-import { createPDFGenerationService } from '../services/pdfGenerationService';
+import { createPDFGenerationService, publishGeneratedDocumentsToClient } from '../services/pdfGenerationService';
 import { StorageService } from '@alga-psa/storage/StorageService';
 import { SystemEmailProviderFactory } from '@alga-psa/email';
 import { EmailMessage, EmailAddress } from '@alga-psa/types';
@@ -613,6 +613,15 @@ export const sendInvoiceEmailAction = withAuth(async (
       });
 
       await emailProvider.sendEmail(message, tenant);
+
+      // The invoice has now reached the client, so the filed document may be
+      // shown in the client portal.
+      await publishGeneratedDocumentsToClient(tenant, 'invoice', invoiceId).catch((error) => {
+        logger.warn('[sendInvoiceEmailAction] Failed to publish invoice document to client', {
+          error,
+          invoiceId,
+        });
+      });
 
       results.push({
         success: true,

--- a/packages/billing/src/actions/quoteActions.ts
+++ b/packages/billing/src/actions/quoteActions.ts
@@ -1,7 +1,6 @@
 'use server';
-/* eslint-disable custom-rules/no-feature-to-feature-imports -- Quote PDF generation creates document records - direct model access required in server action context */
+/* eslint-disable custom-rules/no-feature-to-feature-imports -- Quote lifecycle spans opportunities/documents in server action context */
 
-import { randomUUID } from 'crypto';
 import Handlebars from 'handlebars';
 import { createTenantKnex, tenantDb, withTransaction } from '@alga-psa/db';
 import type { Knex } from 'knex';
@@ -20,7 +19,6 @@ import { resolveEmailLocale } from '@alga-psa/notifications/notifications/emailL
 import { getQuoteApprovalWorkflowSettings as loadQuoteApprovalWorkflowSettings, setQuoteApprovalWorkflowRequired as persistQuoteApprovalWorkflowRequired, type QuoteApprovalWorkflowSettings } from '../lib/quoteApprovalSettings';
 import { createQuoteItemSchema, createQuoteSchema, updateQuoteItemSchema, updateQuoteSchema } from '../schemas/quoteSchemas';
 import { buildQuoteConversionPreview, convertQuoteToDraftContract, convertQuoteToDraftContractAndInvoice, convertQuoteToDraftInvoice, convertQuoteToDraftSalesOrder, createPDFGenerationService } from '../services';
-import { Document as DocumentModel, DocumentAssociation } from '@alga-psa/documents/models';
 import {
   BuiltinAuthorizationKernelProvider,
   BundleAuthorizationKernelProvider,
@@ -439,43 +437,17 @@ const getQuoteRecipients = async (
   );
 };
 
+// Filing (documents row + quote association, /Quotes/Generated, client-visible)
+// lives in the PDF service alongside invoice and sales-order filing.
 const storeQuotePdf = async (
-  knex: Knex,
   tenant: string,
   quote: IQuote,
   userId: string
 ): Promise<string> => {
-  const pdfService = createPDFGenerationService(tenant);
-  const fileRecord = await pdfService.generateAndStore({
+  const fileRecord = await createPDFGenerationService(tenant).generateAndStore({
     quoteId: quote.quote_id,
     quoteNumber: quote.quote_number ?? undefined,
     userId,
-  });
-
-  const documentId = randomUUID();
-  const resolvedQuoteNumber = quote.quote_number ?? quote.quote_id;
-
-  await DocumentModel.insert(knex, {
-    document_id: documentId,
-    document_name: `Quote_${resolvedQuoteNumber}.pdf`,
-    type_id: null,
-    user_id: userId,
-    created_by: userId,
-    order_number: 0,
-    tenant,
-    file_id: fileRecord.file_id,
-    storage_path: fileRecord.storage_path,
-    mime_type: 'application/pdf',
-    file_size: fileRecord.file_size,
-    folder_path: '/Quotes/Generated',
-    is_client_visible: true,
-  });
-
-  await DocumentAssociation.create(knex, {
-    document_id: documentId,
-    entity_id: quote.quote_id,
-    entity_type: 'quote',
-    tenant,
   });
 
   return fileRecord.file_id;
@@ -1553,7 +1525,7 @@ export const sendQuote = withAuth(async (
 
   // Store the generated PDF as a document associated with the quote (best-effort)
   try {
-    await storeQuotePdf(knex, tenant, quote, actorUserId ?? quote.created_by ?? 'system');
+    await storeQuotePdf(tenant, quote, actorUserId ?? quote.created_by ?? 'system');
   } catch (pdfStoreError) {
     console.error('Failed to store quote PDF:', pdfStoreError);
   }
@@ -2139,7 +2111,7 @@ export const regenerateQuotePdf = withAuth(async (
   );
 
   const actorUserId = getActorUserId(user) ?? quote.created_by ?? 'system';
-  const fileId = await storeQuotePdf(knex, tenant, quote, actorUserId);
+  const fileId = await storeQuotePdf(tenant, quote, actorUserId);
   return fileId;
   });
 });

--- a/packages/billing/src/actions/salesOrderDocumentActions.ts
+++ b/packages/billing/src/actions/salesOrderDocumentActions.ts
@@ -71,14 +71,27 @@ async function renderStoredSalesOrderPdf(
   documentType: SalesOrderDocumentType,
   userId: string,
 ): Promise<Buffer> {
-  const stored = await createPDFGenerationService(tenant).generateAndStore({
-    salesOrderId: soId,
-    salesOrderDocumentType: documentType,
-    userId,
-  });
+  const pdfGenerationService = createPDFGenerationService(tenant);
 
-  const { buffer } = await StorageService.downloadFile(stored.file_id);
-  return Buffer.from(buffer);
+  try {
+    const stored = await pdfGenerationService.generateAndStore({
+      salesOrderId: soId,
+      salesOrderDocumentType: documentType,
+      userId,
+    });
+
+    const { buffer } = await StorageService.downloadFile(stored.file_id);
+    return Buffer.from(buffer);
+  } catch (error) {
+    // Filing is what makes the document findable, but it is not what the caller
+    // asked for: an unavailable document store must not cost them the PDF.
+    console.error('[salesOrderDocument] Falling back to an unfiled render:', error);
+    return pdfGenerationService.generatePDF({
+      salesOrderId: soId,
+      salesOrderDocumentType: documentType,
+      userId,
+    });
+  }
 }
 
 /**

--- a/packages/billing/src/actions/salesOrderDocumentActions.ts
+++ b/packages/billing/src/actions/salesOrderDocumentActions.ts
@@ -4,9 +4,10 @@ import { withAuth } from '@alga-psa/auth';
 import { hasPermission } from '@alga-psa/auth/rbac';
 import { createTenantKnex } from '@alga-psa/db';
 import { TenantEmailService } from '@alga-psa/email';
+import { StorageService } from '@alga-psa/storage/StorageService';
 import { getServerTranslation } from '@alga-psa/ui/lib/i18n/serverOnly';
 
-import { createPDFGenerationService } from '../services/pdfGenerationService';
+import { createPDFGenerationService, publishGeneratedDocumentsToClient } from '../services/pdfGenerationService';
 import {
   buildSalesOrderConfirmationEmailContent,
   dedupeRecipients,
@@ -54,16 +55,31 @@ export const downloadSalesOrderPDF = withAuth(
       );
     }
 
-    const pdfGenerationService = createPDFGenerationService(tenant);
-    const pdfBuffer = await pdfGenerationService.generatePDF({
-      salesOrderId: soId,
-      salesOrderDocumentType: documentType,
-      userId: user.user_id,
-    });
+    const pdfBuffer = await renderStoredSalesOrderPdf(tenant, soId, documentType, user.user_id);
 
     return { pdfData: Array.from(pdfBuffer), soNumber: so.so_number, documentType };
   },
 );
+
+/**
+ * File the Sales Order document (reusing an already-filed one) and hand back its bytes, so a
+ * download and the emailed copy are the same stored artifact rather than two independent renders.
+ */
+async function renderStoredSalesOrderPdf(
+  tenant: string,
+  soId: string,
+  documentType: SalesOrderDocumentType,
+  userId: string,
+): Promise<Buffer> {
+  const stored = await createPDFGenerationService(tenant).generateAndStore({
+    salesOrderId: soId,
+    salesOrderDocumentType: documentType,
+    userId,
+  });
+
+  const { buffer } = await StorageService.downloadFile(stored.file_id);
+  return Buffer.from(buffer);
+}
 
 /**
  * Resolve the recipient email(s) for a Sales Order: any explicitly-passed addresses, else the
@@ -139,11 +155,7 @@ export const emailSalesOrderConfirmation = withAuth(
       };
     }
 
-    const pdfBuffer = await createPDFGenerationService(tenant).generatePDF({
-      salesOrderId: soId,
-      salesOrderDocumentType: 'sales-order',
-      userId: user.user_id,
-    });
+    const pdfBuffer = await renderStoredSalesOrderPdf(tenant, soId, 'sales-order', user.user_id);
 
     const soNumber = so.so_number ?? soId;
     const tenantRow = await knex('tenants').select('client_name').where({ tenant }).first();
@@ -167,6 +179,11 @@ export const emailSalesOrderConfirmation = withAuth(
       entityId: soId,
       userId: user.user_id,
     });
+
+    if (result.success) {
+      // Sent, so the filed confirmation may now be shown in the client portal.
+      await publishGeneratedDocumentsToClient(tenant, 'sales_order', soId).catch(() => undefined);
+    }
 
     return {
       success: result.success,

--- a/packages/billing/src/lib/document-templates/resolution.ts
+++ b/packages/billing/src/lib/document-templates/resolution.ts
@@ -23,21 +23,42 @@ export interface DocumentTemplateResolvers {
   getStandard: () => TemplateAst;
 }
 
+/** A template plus the provenance a rendered document records about it. */
+export interface DocumentTemplateRef {
+  ast: TemplateAst;
+  /** Custom template uuid, or the standard template's code. */
+  templateId: string | null;
+  version: number | null;
+}
+
+/**
+ * Resolve which template to render: entity override → tenant default → standard fallback.
+ * Generic in what a resolver yields so callers can carry provenance alongside the AST.
+ */
+export async function resolveDocumentTemplate<T>(resolvers: {
+  fetchOverride: () => Promise<T | null>;
+  fetchTenantDefault: () => Promise<T | null>;
+  getStandard: () => T;
+}): Promise<{ value: T; source: DocumentTemplateSource }> {
+  const override = await resolvers.fetchOverride();
+  if (override) {
+    return { value: override, source: 'override' };
+  }
+
+  const tenantDefault = await resolvers.fetchTenantDefault();
+  if (tenantDefault) {
+    return { value: tenantDefault, source: 'tenant-default' };
+  }
+
+  return { value: resolvers.getStandard(), source: 'standard' };
+}
+
 /**
  * Resolve which template AST to render: entity override → tenant default → standard fallback.
  */
 export async function resolveDocumentTemplateAst(
   resolvers: DocumentTemplateResolvers,
 ): Promise<DocumentTemplateResolution> {
-  const override = await resolvers.fetchOverride();
-  if (override) {
-    return { ast: override, source: 'override' };
-  }
-
-  const tenantDefault = await resolvers.fetchTenantDefault();
-  if (tenantDefault) {
-    return { ast: tenantDefault, source: 'tenant-default' };
-  }
-
-  return { ast: resolvers.getStandard(), source: 'standard' };
+  const { value, source } = await resolveDocumentTemplate<TemplateAst>(resolvers);
+  return { ast: value, source };
 }

--- a/packages/billing/src/lib/document-templates/storage.ts
+++ b/packages/billing/src/lib/document-templates/storage.ts
@@ -2,6 +2,7 @@ import type { Knex } from 'knex';
 import type { TemplateAst } from '@alga-psa/types';
 
 import { type DocumentType, getDocumentTypeRegistryEntry } from './registry';
+import type { DocumentTemplateRef } from './resolution';
 
 const CUSTOM_TABLE = 'document_templates';
 const ASSIGNMENT_TABLE = 'document_template_assignments';
@@ -114,48 +115,49 @@ export async function deleteCustomDocumentTemplate(
   return knex(CUSTOM_TABLE).where({ tenant, document_type: documentType, template_id: templateId }).del();
 }
 
-/** Resolve an assignment row to a concrete AST (custom from DB, or standard from the registry). */
-async function assignmentToAst(
+/** Resolve an assignment row to a concrete template (custom from DB, or standard from the registry). */
+async function assignmentToTemplate(
   knex: Knex | Knex.Transaction,
   tenant: string,
   documentType: DocumentType,
   assignment: AssignmentRow | undefined,
-): Promise<TemplateAst | null> {
+): Promise<DocumentTemplateRef | null> {
   if (!assignment) return null;
   if (assignment.template_source === 'standard' && assignment.standard_template_code) {
-    return getDocumentTypeRegistryEntry(documentType).getStandardTemplateAstByCode(assignment.standard_template_code);
+    const ast = getDocumentTypeRegistryEntry(documentType).getStandardTemplateAstByCode(assignment.standard_template_code);
+    return ast ? { ast, templateId: assignment.standard_template_code, version: null } : null;
   }
   if (assignment.template_source === 'custom' && assignment.template_id) {
     const row = await getCustomDocumentTemplate(knex, tenant, documentType, assignment.template_id);
-    return row?.templateAst ?? null;
+    return row?.templateAst ? { ast: row.templateAst, templateId: row.template_id, version: row.version ?? null } : null;
   }
   return null;
 }
 
-/** The tenant-default template AST for a type, or null when none is assigned. */
-export async function fetchTenantDefaultTemplateAst(
+/** The tenant-default template for a type, or null when none is assigned. */
+export async function fetchTenantDefaultTemplate(
   knex: Knex | Knex.Transaction,
   tenant: string,
   documentType: DocumentType,
-): Promise<TemplateAst | null> {
+): Promise<DocumentTemplateRef | null> {
   const assignment = await knex(ASSIGNMENT_TABLE)
     .where({ tenant, document_type: documentType, scope_type: 'tenant' })
     .whereNull('scope_id')
     .first<AssignmentRow>();
-  return assignmentToAst(knex, tenant, documentType, assignment);
+  return assignmentToTemplate(knex, tenant, documentType, assignment);
 }
 
-/** A client-scoped override template AST for a type, or null when none is assigned. */
-export async function fetchClientOverrideTemplateAst(
+/** A client-scoped override template for a type, or null when none is assigned. */
+export async function fetchClientOverrideTemplate(
   knex: Knex | Knex.Transaction,
   tenant: string,
   documentType: DocumentType,
   clientId: string,
-): Promise<TemplateAst | null> {
+): Promise<DocumentTemplateRef | null> {
   const assignment = await knex(ASSIGNMENT_TABLE)
     .where({ tenant, document_type: documentType, scope_type: 'client', scope_id: clientId })
     .first<AssignmentRow>();
-  return assignmentToAst(knex, tenant, documentType, assignment);
+  return assignmentToTemplate(knex, tenant, documentType, assignment);
 }
 
 export type SetDefaultPayload =

--- a/packages/billing/src/lib/sales-order-template-ast/templateSelection.ts
+++ b/packages/billing/src/lib/sales-order-template-ast/templateSelection.ts
@@ -2,19 +2,23 @@ import type { Knex } from 'knex';
 import type { TemplateAst } from '@alga-psa/types';
 
 import {
-  resolveDocumentTemplateAst,
+  resolveDocumentTemplate,
+  type DocumentTemplateRef,
   type DocumentTemplateSource,
 } from '../document-templates/resolution';
 import { getDocumentTypeRegistryEntry, getDocumentTypeStandardAst, type DocumentType } from '../document-templates/registry';
 import {
-  fetchClientOverrideTemplateAst,
-  fetchTenantDefaultTemplateAst,
+  fetchClientOverrideTemplate,
+  fetchTenantDefaultTemplate,
 } from '../document-templates/storage';
 
 export interface ResolveSalesOrderTemplateResult {
   ast: TemplateAst;
   source: DocumentTemplateSource;
   code: string | null;
+  /** Provenance of the winning template: custom uuid or standard code. */
+  templateId: string | null;
+  templateVersion: number | null;
 }
 
 /**
@@ -28,18 +32,21 @@ export async function resolveSalesOrderTemplateAst(
   documentType: DocumentType = 'sales-order',
   opts?: { clientId?: string | null },
 ): Promise<ResolveSalesOrderTemplateResult> {
-  const { ast, source } = await resolveDocumentTemplateAst({
+  const standardCode = getDocumentTypeRegistryEntry(documentType).defaultStandardCode;
+  const { value, source } = await resolveDocumentTemplate<DocumentTemplateRef>({
     fetchOverride: () =>
       opts?.clientId
-        ? fetchClientOverrideTemplateAst(knex, tenant, documentType, opts.clientId)
+        ? fetchClientOverrideTemplate(knex, tenant, documentType, opts.clientId)
         : Promise.resolve(null),
-    fetchTenantDefault: () => fetchTenantDefaultTemplateAst(knex, tenant, documentType),
-    getStandard: () => getDocumentTypeStandardAst(documentType),
+    fetchTenantDefault: () => fetchTenantDefaultTemplate(knex, tenant, documentType),
+    getStandard: () => ({ ast: getDocumentTypeStandardAst(documentType), templateId: standardCode, version: null }),
   });
 
   return {
-    ast,
+    ast: value.ast,
     source,
-    code: source === 'standard' ? getDocumentTypeRegistryEntry(documentType).defaultStandardCode : null,
+    code: source === 'standard' ? standardCode : null,
+    templateId: value.templateId,
+    templateVersion: value.version,
   };
 }

--- a/packages/billing/src/services/index.ts
+++ b/packages/billing/src/services/index.ts
@@ -7,7 +7,12 @@
 export { TaxService } from './taxService';
 export { BillingEngine } from '../lib/billing/billingEngine';
 export { recalculateQuoteFinancials } from './quoteCalculationService';
-export { PDFGenerationService, createPDFGenerationService } from './pdfGenerationService';
+export {
+  PDFGenerationService,
+  createPDFGenerationService,
+  publishGeneratedDocumentsToClient,
+  type StoredPdfResult,
+} from './pdfGenerationService';
 export {
   buildQuoteConversionPreview,
   convertQuoteToDraftContract,

--- a/packages/billing/src/services/pdfGenerationService.ts
+++ b/packages/billing/src/services/pdfGenerationService.ts
@@ -3,7 +3,7 @@ import type { Page } from 'puppeteer';
 import type { Knex } from 'knex';
 
 import { createTenantKnex, runWithTenant, tenantDb, withTransaction } from '@alga-psa/db';
-import type { DocumentAssociationEntityType, TemplateAst } from '@alga-psa/types';
+import type { DocumentAssociationEntityType, IDocument, TemplateAst } from '@alga-psa/types';
 import type { FileStore } from '@alga-psa/storage/types/storage';
 import { StorageProviderFactory, generateStoragePath, FileStoreModel } from '@alga-psa/storage';
 import { convertBlockContentToHTML } from '@alga-psa/formatting/blocknoteUtils';
@@ -54,6 +54,7 @@ interface PDFGenerationOptions {
   invoiceNumber?: string;
   quoteNumber?: string;
   salesOrderNumber?: string;
+  templateId?: string;
   version?: number;
   cacheKey?: string;
   userId: string;
@@ -62,7 +63,20 @@ interface PDFGenerationOptions {
 }
 
 /** The stored file, plus the `documents` row it was filed as (absent for the export branch). */
-export type StoredPdfResult = FileStore & { document_id?: string };
+export type StoredPdfResult = FileStore & { document_id?: string; is_client_visible?: boolean };
+
+/**
+ * How a generated PDF is filed against its source entity.
+ *
+ * `refresh` keeps one document per entity: while it is still MSP-only the filed
+ * copy is re-rendered in place, so a draft invoice's document always matches the
+ * invoice. Once the document has been published to the client it is the artifact
+ * they received, so it is frozen and reused, and a deliberate re-render files a
+ * new document rather than mutating it.
+ *
+ * `append` files every render as its own document (quotes: each send is its own copy).
+ */
+type FilingMode = 'refresh' | 'append';
 
 /** Where a generated PDF is filed, and what it is filed against. */
 interface FilingTarget {
@@ -74,7 +88,7 @@ interface FilingTarget {
   documentName: string;
   /** Base name for the stored file — preserved from the pre-filing behaviour. */
   fileBaseName: string;
-  reuseExisting: boolean;
+  mode: FilingMode;
 }
 
 interface RenderedPdf {
@@ -170,11 +184,11 @@ export class PDFGenerationService {
 
   /**
    * Render (or reuse) a PDF, store the bytes, and file the result as a `documents`
-   * row associated with its source entity and client. Invoice and sales-order
-   * documents are reused when one is already on file: `generateAndStore` is called
-   * from download paths too, and re-rendering there both drifts from the artifact
-   * that was sent and grows storage on every click. Pass `regenerate` for a
-   * deliberate new render.
+   * row associated with its source entity and client. Once an invoice or
+   * sales-order document has been published to the client it is handed straight
+   * back rather than re-rendered: `generateAndStore` is called from download paths
+   * too, and re-rendering there drifts from the artifact the client received.
+   * Pass `regenerate` to render again anyway.
    */
   async generateAndStore(options: PDFGenerationOptions): Promise<StoredPdfResult> {
     return runWithTenant(this.tenant, async () => {
@@ -184,17 +198,16 @@ export class PDFGenerationService {
       let fileName: string;
       let sourceType: string;
       let sourceId: string;
-      const reuse = Boolean(target?.reuseExisting) && !options.regenerate;
 
       if (target) {
         fileName = target.fileBaseName;
         sourceType = target.sourceType;
         sourceId = target.entityId;
 
-        if (reuse) {
-          const reused = await this.findStoredPdf(knex, target);
-          if (reused) {
-            return reused;
+        if (target.mode === 'refresh' && !options.regenerate) {
+          const issued = await this.findStoredPdf(knex, target, true);
+          if (issued) {
+            return issued;
           }
         }
       } else {
@@ -213,6 +226,7 @@ export class PDFGenerationService {
         salesOrderId: options.salesOrderId,
         salesOrderDocumentType: options.salesOrderDocumentType,
         documentId: options.documentId,
+        templateId: options.templateId,
         userId: options.userId,
       });
 
@@ -239,11 +253,21 @@ export class PDFGenerationService {
 
       if (target) {
         try {
-          const filed = await this.fileGeneratedDocument(knex, target, fileRecord, rendered, options.userId, reuse);
+          const filed = await this.fileGeneratedDocument(
+            knex,
+            target,
+            fileRecord,
+            rendered,
+            options.userId,
+            Boolean(options.regenerate)
+          );
           documentId = filed.document_id;
-          // Lost a filing race: an equivalent document already existed, so return it
-          // rather than handing back a second copy of the same artifact.
-          result = filed.reusedFile ?? { ...fileRecord, document_id: filed.document_id };
+          // Lost a filing race: the document was published while we rendered, so
+          // return the issued artifact rather than a second copy of it.
+          result = filed.issuedFile ?? { ...fileRecord, document_id: filed.document_id };
+          // Outside the filing transaction on purpose: retiring the superseded PDF
+          // is housekeeping, and a failure here must not roll the filing back.
+          await this.discardStoredFile(knex, filed.supersededFileId, options.userId);
         } catch (filingError) {
           // Best-effort: the stored file is still usable (it is what gets emailed
           // and downloaded), so a filing failure must not take the caller down
@@ -304,7 +328,7 @@ export class PDFGenerationService {
         isClientVisible: false,
         documentName: `Invoice_${invoiceNumber}.pdf`,
         fileBaseName: options.invoiceNumber || options.invoiceId,
-        reuseExisting: true,
+        mode: 'refresh',
       };
     }
 
@@ -323,7 +347,7 @@ export class PDFGenerationService {
         isClientVisible: false,
         documentName: `${SALES_ORDER_DOCUMENT_PREFIX[documentType]}_${soNumber}.pdf`,
         fileBaseName: options.salesOrderNumber || salesOrder?.so_number || options.salesOrderId,
-        reuseExisting: true,
+        mode: 'refresh',
       };
     }
 
@@ -339,7 +363,7 @@ export class PDFGenerationService {
         documentName: `Quote_${quoteNumber}.pdf`,
         fileBaseName: quoteNumber,
         // A quote is re-rendered on every send, and each send is its own artifact.
-        reuseExisting: false,
+        mode: 'append',
       };
     }
 
@@ -350,10 +374,16 @@ export class PDFGenerationService {
     throw new Error('One of invoiceId, quoteId, salesOrderId, or documentId must be provided');
   }
 
-  /** The most recently filed PDF for this target, or null when none exists. */
+  /**
+   * The most recently filed PDF for this target, or null when none exists.
+   * `clientVisible` picks between the copy the client was issued and the MSP-only
+   * working copy, which are governed by different rules: the issued one is frozen,
+   * the working one is refreshed in place.
+   */
   private async findStoredPdf(
     knexOrTrx: Knex | Knex.Transaction,
-    target: FilingTarget
+    target: FilingTarget,
+    clientVisible: boolean
   ): Promise<StoredPdfResult | null> {
     const db = tenantDb(knexOrTrx, this.tenant);
     const query = db.table('document_associations as da')
@@ -362,10 +392,11 @@ export class PDFGenerationService {
         'da.entity_type': target.sourceType,
       })
       .andWhere('d.document_name', target.documentName)
+      .andWhere('d.is_client_visible', clientVisible)
       .whereNotNull('d.file_id')
       .orderBy('da.created_at', 'desc')
-      .select('d.document_id', 'd.file_id')
-      .first<{ document_id: string; file_id: string } | undefined>();
+      .select('d.document_id', 'd.file_id', 'd.is_client_visible')
+      .first<{ document_id: string; file_id: string; is_client_visible?: boolean } | undefined>();
     db.tenantJoin(query, 'documents as d', 'da.document_id', 'd.document_id');
 
     const existing = await query;
@@ -374,7 +405,13 @@ export class PDFGenerationService {
     }
 
     const fileRecord = await FileStoreModel.findById(knexOrTrx, existing.file_id);
-    return fileRecord ? { ...fileRecord, document_id: existing.document_id } : null;
+    return fileRecord
+      ? {
+          ...fileRecord,
+          document_id: existing.document_id,
+          is_client_visible: existing.is_client_visible === true,
+        }
+      : null;
   }
 
   private async fileGeneratedDocument(
@@ -383,12 +420,13 @@ export class PDFGenerationService {
     fileRecord: FileStore,
     rendered: RenderedPdf,
     userId: string,
-    reuse: boolean
-  ): Promise<{ document_id: string; reusedFile: StoredPdfResult | null }> {
+    regenerate: boolean
+  ): Promise<{ document_id: string; issuedFile: StoredPdfResult | null; supersededFileId?: string }> {
     const renderedLocale = await this.resolveRenderedLocale(knex, target.clientId);
+    const documentType = await this.resolvePdfDocumentType(knex);
 
     return withTransaction(knex, async (trx: Knex.Transaction) => {
-      if (reuse) {
+      if (target.mode === 'refresh') {
         // Serialize filing per source entity so two concurrent generations do not
         // both file the same artifact.
         await trx.raw('SELECT pg_advisory_xact_lock(hashtext(?), hashtext(?))', [
@@ -396,17 +434,49 @@ export class PDFGenerationService {
           `${this.tenant}:${target.sourceType}:${target.entityId}:${target.documentName}`,
         ]);
 
-        const raced = await this.findStoredPdf(trx, target);
-        if (raced?.document_id) {
-          return { document_id: raced.document_id, reusedFile: raced };
+        if (!regenerate) {
+          const issued = await this.findStoredPdf(trx, target, true);
+          if (issued?.document_id) {
+            // Published while we rendered. Leave the client's copy alone and retire
+            // the render we just stored, so both sides see the same bytes.
+            return {
+              document_id: issued.document_id,
+              issuedFile: issued,
+              supersededFileId: fileRecord.file_id,
+            };
+          }
+        }
+
+        const working = await this.findStoredPdf(trx, target, false);
+        if (working?.document_id) {
+          // Not issued yet: keep one document per entity and point it at the fresh
+          // render, so a draft invoice's filed PDF never goes stale behind the invoice.
+          await DocumentModel.update(trx, working.document_id, {
+            ...(documentType ?? {}),
+            file_id: fileRecord.file_id,
+            storage_path: fileRecord.storage_path,
+            mime_type: 'application/pdf',
+            file_size: fileRecord.file_size,
+            folder_path: target.folderPath,
+            edited_by: userId,
+            updated_at: new Date(),
+            source_template_id: rendered.templateId,
+            source_template_version: rendered.templateVersion,
+            rendered_locale: renderedLocale,
+          });
+          return {
+            document_id: working.document_id,
+            issuedFile: null,
+            supersededFileId: working.file_id,
+          };
         }
       }
 
       const documentId = uuidv4();
       await DocumentModel.insert(trx, {
+        ...(documentType ?? { type_id: null }),
         document_id: documentId,
         document_name: target.documentName,
-        type_id: null,
         user_id: userId,
         created_by: userId,
         order_number: 0,
@@ -438,8 +508,52 @@ export class PDFGenerationService {
         });
       }
 
-      return { document_id: documentId, reusedFile: null };
+      return { document_id: documentId, issuedFile: null };
     });
+  }
+
+  /**
+   * The PDF document type, so a filed invoice carries the same type/icon as an
+   * uploaded PDF and answers the Documents page's type filter.
+   */
+  private async resolvePdfDocumentType(
+    knex: Knex
+  ): Promise<(Pick<IDocument, 'type_id'> & Partial<Pick<IDocument, 'shared_type_id'>>) | null> {
+    try {
+      const db = tenantDb(knex, this.tenant);
+
+      const tenantType = await db.table('document_types')
+        .where({ type_name: 'application/pdf' })
+        .first<{ type_id: string } | undefined>('type_id');
+      if (tenantType?.type_id) {
+        return { type_id: tenantType.type_id };
+      }
+
+      const sharedType = await db.table('shared_document_types')
+        .where({ type_name: 'application/pdf' })
+        .first<{ type_id: string } | undefined>('type_id');
+      if (sharedType?.type_id) {
+        return { type_id: null, shared_type_id: sharedType.type_id };
+      }
+    } catch (error) {
+      console.error('Failed to resolve the PDF document type:', error);
+    }
+
+    return null;
+  }
+
+  /** Retire a stored PDF that is no longer any document's file, so repeat renders do not pile up. */
+  private async discardStoredFile(
+    knex: Knex,
+    fileId: string | undefined,
+    userId: string
+  ): Promise<void> {
+    if (!fileId) return;
+    try {
+      await FileStoreModel.softDelete(knex, fileId, userId);
+    } catch (error) {
+      console.error('Failed to retire superseded generated PDF:', error);
+    }
   }
 
   /**

--- a/packages/billing/src/services/pdfGenerationService.ts
+++ b/packages/billing/src/services/pdfGenerationService.ts
@@ -9,6 +9,7 @@ import { StorageProviderFactory, generateStoragePath, FileStoreModel } from '@al
 import { convertBlockContentToHTML } from '@alga-psa/formatting/blocknoteUtils';
 import { publishWorkflowEvent } from '@alga-psa/event-bus/publishers';
 import { buildDocumentGeneratedPayload } from '@alga-psa/workflow-streams';
+// eslint-disable-next-line custom-rules/no-feature-to-feature-imports -- filing a generated PDF is a documents write; direct model access, as quoteActions did before this moved here
 import { Document as DocumentModel, DocumentAssociation } from '@alga-psa/documents/models';
 import {
   getTenantDefaultLocale,
@@ -237,31 +238,41 @@ export class PDFGenerationService {
       let result: StoredPdfResult = { ...fileRecord };
 
       if (target) {
-        const filed = await this.fileGeneratedDocument(knex, target, fileRecord, rendered, options.userId, reuse);
-        documentId = filed.document_id;
-        // Lost a filing race: an equivalent document already existed, so return it
-        // rather than handing back a second copy of the same artifact.
-        result = filed.reusedFile ?? { ...fileRecord, document_id: filed.document_id };
+        try {
+          const filed = await this.fileGeneratedDocument(knex, target, fileRecord, rendered, options.userId, reuse);
+          documentId = filed.document_id;
+          // Lost a filing race: an equivalent document already existed, so return it
+          // rather than handing back a second copy of the same artifact.
+          result = filed.reusedFile ?? { ...fileRecord, document_id: filed.document_id };
+        } catch (filingError) {
+          // Best-effort: the stored file is still usable (it is what gets emailed
+          // and downloaded), so a filing failure must not take the caller down
+          // with it. Without a document row there is nothing to announce, so the
+          // generated-document event is skipped too.
+          console.error(`Failed to file generated ${target.sourceType} document:`, filingError);
+        }
       }
 
-      try {
-        await publishWorkflowEvent({
-          eventType: 'DOCUMENT_GENERATED',
-          ctx: {
-            tenantId: this.tenant,
-            actor: { actorType: 'USER', actorUserId: options.userId },
-          },
-          payload: buildDocumentGeneratedPayload({
-            documentId: documentId!,
-            sourceType,
-            sourceId,
-            generatedByUserId: options.userId,
-            generatedAt: new Date().toISOString(),
-            fileName: `${fileName}.pdf`,
-          }),
-        });
-      } catch {
-        // Non-blocking
+      if (documentId) {
+        try {
+          await publishWorkflowEvent({
+            eventType: 'DOCUMENT_GENERATED',
+            ctx: {
+              tenantId: this.tenant,
+              actor: { actorType: 'USER', actorUserId: options.userId },
+            },
+            payload: buildDocumentGeneratedPayload({
+              documentId,
+              sourceType,
+              sourceId,
+              generatedByUserId: options.userId,
+              generatedAt: new Date().toISOString(),
+              fileName: `${fileName}.pdf`,
+            }),
+          });
+        } catch {
+          // Non-blocking
+        }
       }
 
       return result;

--- a/packages/billing/src/services/pdfGenerationService.ts
+++ b/packages/billing/src/services/pdfGenerationService.ts
@@ -63,7 +63,11 @@ interface PDFGenerationOptions {
 }
 
 /** The stored file, plus the `documents` row it was filed as (absent for the export branch). */
-export type StoredPdfResult = FileStore & { document_id?: string; is_client_visible?: boolean };
+export type StoredPdfResult = FileStore & {
+  document_id?: string;
+  is_client_visible?: boolean;
+  source_template_id?: string | null;
+};
 
 /**
  * How a generated PDF is filed against its source entity.
@@ -206,7 +210,7 @@ export class PDFGenerationService {
 
         if (target.mode === 'refresh' && !options.regenerate) {
           const issued = await this.findStoredPdf(knex, target, true);
-          if (issued) {
+          if (issued && this.matchesRequest(issued, options.templateId)) {
             return issued;
           }
         }
@@ -259,7 +263,7 @@ export class PDFGenerationService {
             fileRecord,
             rendered,
             options.userId,
-            Boolean(options.regenerate)
+            { regenerate: Boolean(options.regenerate), templateId: options.templateId }
           );
           documentId = filed.document_id;
           // Lost a filing race: the document was published while we rendered, so
@@ -395,8 +399,11 @@ export class PDFGenerationService {
       .andWhere('d.is_client_visible', clientVisible)
       .whereNotNull('d.file_id')
       .orderBy('da.created_at', 'desc')
-      .select('d.document_id', 'd.file_id', 'd.is_client_visible')
-      .first<{ document_id: string; file_id: string; is_client_visible?: boolean } | undefined>();
+      .select('d.document_id', 'd.file_id', 'd.is_client_visible', 'd.source_template_id')
+      .first<
+        | { document_id: string; file_id: string; is_client_visible?: boolean; source_template_id?: string | null }
+        | undefined
+      >();
     db.tenantJoin(query, 'documents as d', 'da.document_id', 'd.document_id');
 
     const existing = await query;
@@ -410,8 +417,18 @@ export class PDFGenerationService {
           ...fileRecord,
           document_id: existing.document_id,
           is_client_visible: existing.is_client_visible === true,
+          source_template_id: existing.source_template_id ?? null,
         }
       : null;
+  }
+
+  /**
+   * Whether a stored PDF answers this request. Asking for a specific template is
+   * asking for that template's output, so the copy on file only counts if it is
+   * what it was rendered from.
+   */
+  private matchesRequest(stored: StoredPdfResult, templateId?: string): boolean {
+    return !templateId || stored.source_template_id === templateId;
   }
 
   private async fileGeneratedDocument(
@@ -420,7 +437,7 @@ export class PDFGenerationService {
     fileRecord: FileStore,
     rendered: RenderedPdf,
     userId: string,
-    regenerate: boolean
+    options: { regenerate: boolean; templateId?: string }
   ): Promise<{ document_id: string; issuedFile: StoredPdfResult | null; supersededFileId?: string }> {
     const renderedLocale = await this.resolveRenderedLocale(knex, target.clientId);
     const documentType = await this.resolvePdfDocumentType(knex);
@@ -434,9 +451,9 @@ export class PDFGenerationService {
           `${this.tenant}:${target.sourceType}:${target.entityId}:${target.documentName}`,
         ]);
 
-        if (!regenerate) {
+        if (!options.regenerate) {
           const issued = await this.findStoredPdf(trx, target, true);
-          if (issued?.document_id) {
+          if (issued?.document_id && this.matchesRequest(issued, options.templateId)) {
             // Published while we rendered. Leave the client's copy alone and retire
             // the render we just stored, so both sides see the same bytes.
             return {

--- a/packages/billing/src/services/pdfGenerationService.ts
+++ b/packages/billing/src/services/pdfGenerationService.ts
@@ -2,13 +2,19 @@ import { v4 as uuidv4 } from 'uuid';
 import type { Page } from 'puppeteer';
 import type { Knex } from 'knex';
 
-import { createTenantKnex, runWithTenant, tenantDb } from '@alga-psa/db';
-import type { TemplateAst } from '@alga-psa/types';
+import { createTenantKnex, runWithTenant, tenantDb, withTransaction } from '@alga-psa/db';
+import type { DocumentAssociationEntityType, TemplateAst } from '@alga-psa/types';
 import type { FileStore } from '@alga-psa/storage/types/storage';
 import { StorageProviderFactory, generateStoragePath, FileStoreModel } from '@alga-psa/storage';
 import { convertBlockContentToHTML } from '@alga-psa/formatting/blocknoteUtils';
 import { publishWorkflowEvent } from '@alga-psa/event-bus/publishers';
 import { buildDocumentGeneratedPayload } from '@alga-psa/workflow-streams';
+import { Document as DocumentModel, DocumentAssociation } from '@alga-psa/documents/models';
+import {
+  getTenantDefaultLocale,
+  getUserInfoForEmail,
+  resolveEmailLocale,
+} from '@alga-psa/notifications/notifications/emailLocaleResolver';
 
 import { mapDbInvoiceToWasmViewModel } from '../lib/adapters/invoiceAdapters';
 import { enrichInvoiceViewModelWithLocations } from '../lib/adapters/invoiceAdapters.server';
@@ -36,16 +42,51 @@ import { browserPoolService } from './browserPoolService';
 // Types
 // ---------------------------------------------------------------------------
 
+export type SalesOrderDocumentKind = 'sales-order' | 'packing-slip' | 'pick-list';
+
 interface PDFGenerationOptions {
   invoiceId?: string;
   quoteId?: string;
+  salesOrderId?: string;
+  salesOrderDocumentType?: SalesOrderDocumentKind;
   documentId?: string;
   invoiceNumber?: string;
   quoteNumber?: string;
+  salesOrderNumber?: string;
   version?: number;
   cacheKey?: string;
   userId: string;
+  /** Force a fresh render even when a stored document already exists. */
+  regenerate?: boolean;
 }
+
+/** The stored file, plus the `documents` row it was filed as (absent for the export branch). */
+export type StoredPdfResult = FileStore & { document_id?: string };
+
+/** Where a generated PDF is filed, and what it is filed against. */
+interface FilingTarget {
+  sourceType: Extract<DocumentAssociationEntityType, 'invoice' | 'quote' | 'sales_order'>;
+  entityId: string;
+  clientId: string | null;
+  folderPath: string;
+  isClientVisible: boolean;
+  documentName: string;
+  /** Base name for the stored file — preserved from the pre-filing behaviour. */
+  fileBaseName: string;
+  reuseExisting: boolean;
+}
+
+interface RenderedPdf {
+  buffer: Buffer;
+  templateId: string | null;
+  templateVersion: number | null;
+}
+
+const SALES_ORDER_DOCUMENT_PREFIX: Record<SalesOrderDocumentKind, string> = {
+  'sales-order': 'SalesOrder',
+  'packing-slip': 'PackingSlip',
+  'pick-list': 'PickList',
+};
 
 export interface QuotePDFOptions {
   quoteId: string;
@@ -56,7 +97,7 @@ export interface QuotePDFOptions {
 export interface SalesOrderPDFOptions {
   salesOrderId: string;
   /** Which Sales Order document to render — confirmation (default), packing slip, or pick list. */
-  documentType?: 'sales-order' | 'packing-slip' | 'pick-list';
+  documentType?: SalesOrderDocumentKind;
   templateCode?: string;
   templateAst?: TemplateAst;
 }
@@ -85,82 +126,123 @@ export class PDFGenerationService {
 
   // ---- Generic entry points ------------------------------------------------
 
-  async generatePDF(options: { invoiceId?: string; quoteId?: string; salesOrderId?: string; salesOrderDocumentType?: 'sales-order' | 'packing-slip' | 'pick-list'; documentId?: string; userId: string; templateAst?: TemplateAst; templateId?: string }): Promise<Buffer> {
+  async generatePDF(options: { invoiceId?: string; quoteId?: string; salesOrderId?: string; salesOrderDocumentType?: SalesOrderDocumentKind; documentId?: string; userId: string; templateAst?: TemplateAst; templateId?: string }): Promise<Buffer> {
+    return (await this.renderPdf(options)).buffer;
+  }
+
+  private async renderPdf(options: { invoiceId?: string; quoteId?: string; salesOrderId?: string; salesOrderDocumentType?: SalesOrderDocumentKind; documentId?: string; userId: string; templateAst?: TemplateAst; templateId?: string }): Promise<RenderedPdf> {
     let htmlContent: string;
     let templateAst: TemplateAst | null = null;
+    let templateId: string | null = null;
+    let templateVersion: number | null = null;
 
     if (options.invoiceId) {
       const result = await this.getInvoiceHtml(options.invoiceId, options.templateId);
       htmlContent = result.htmlContent;
       templateAst = result.templateAst;
+      templateId = result.templateId;
+      templateVersion = result.templateVersion;
     } else if (options.quoteId) {
       const result = await this.getQuoteHtml({ quoteId: options.quoteId, templateAst: options.templateAst });
       htmlContent = result.htmlContent;
       templateAst = result.templateAst;
+      templateId = result.templateId;
+      templateVersion = result.templateVersion;
     } else if (options.salesOrderId) {
       const result = await this.getSalesOrderHtml({ salesOrderId: options.salesOrderId, documentType: options.salesOrderDocumentType, templateAst: options.templateAst });
       htmlContent = result.htmlContent;
       templateAst = result.templateAst;
+      templateId = result.templateId;
+      templateVersion = result.templateVersion;
     } else if (options.documentId) {
       htmlContent = await this.getDocumentHtml(options.documentId);
     } else {
       throw new Error('One of invoiceId, quoteId, salesOrderId, or documentId must be provided');
     }
 
-    return this.generatePDFBuffer(htmlContent, templateAst);
+    return {
+      buffer: await this.generatePDFBuffer(htmlContent, templateAst),
+      templateId,
+      templateVersion,
+    };
   }
 
-  async generateAndStore(options: PDFGenerationOptions): Promise<FileStore> {
-    let entityId: string;
-    let fileName: string;
-    let sourceType: string;
-
-    if (options.invoiceId) {
-      entityId = options.invoiceId;
-      fileName = options.invoiceNumber || options.invoiceId;
-      sourceType = 'invoice';
-    } else if (options.quoteId) {
-      entityId = options.quoteId;
-      fileName = options.quoteNumber || options.quoteId;
-      sourceType = 'quote';
-    } else if (options.documentId) {
-      entityId = options.documentId;
-      sourceType = 'document';
-      const document = await this.getDocumentRecord(options.documentId);
-      if (!document) {
-        throw new Error(`Document ${options.documentId} not found.`);
-      }
-      fileName = document.document_name || options.documentId;
-    } else {
-      throw new Error('One of invoiceId, quoteId, or documentId must be provided');
-    }
-
-    const pdfBuffer = await this.generatePDF({
-      invoiceId: options.invoiceId,
-      quoteId: options.quoteId,
-      documentId: options.documentId,
-      userId: options.userId,
-    });
-
+  /**
+   * Render (or reuse) a PDF, store the bytes, and file the result as a `documents`
+   * row associated with its source entity and client. Invoice and sales-order
+   * documents are reused when one is already on file: `generateAndStore` is called
+   * from download paths too, and re-rendering there both drifts from the artifact
+   * that was sent and grows storage on every click. Pass `regenerate` for a
+   * deliberate new render.
+   */
+  async generateAndStore(options: PDFGenerationOptions): Promise<StoredPdfResult> {
     return runWithTenant(this.tenant, async () => {
+      const { knex } = await createTenantKnex();
+      const target = await this.resolveFilingTarget(knex, options);
+
+      let fileName: string;
+      let sourceType: string;
+      let sourceId: string;
+      const reuse = Boolean(target?.reuseExisting) && !options.regenerate;
+
+      if (target) {
+        fileName = target.fileBaseName;
+        sourceType = target.sourceType;
+        sourceId = target.entityId;
+
+        if (reuse) {
+          const reused = await this.findStoredPdf(knex, target);
+          if (reused) {
+            return reused;
+          }
+        }
+      } else {
+        const document = await this.getDocumentRecord(options.documentId!);
+        if (!document) {
+          throw new Error(`Document ${options.documentId} not found.`);
+        }
+        fileName = document.document_name || options.documentId!;
+        sourceType = 'document';
+        sourceId = options.documentId!;
+      }
+
+      const rendered = await this.renderPdf({
+        invoiceId: options.invoiceId,
+        quoteId: options.quoteId,
+        salesOrderId: options.salesOrderId,
+        salesOrderDocumentType: options.salesOrderDocumentType,
+        documentId: options.documentId,
+        userId: options.userId,
+      });
+
       const fileId = uuidv4();
       const storagePath = generateStoragePath(this.tenant, 'pdfs', `${fileName}.pdf`);
 
       const provider = await StorageProviderFactory.createProvider();
-      const uploadResult = await provider.upload(Buffer.from(pdfBuffer), storagePath, {
+      const uploadResult = await provider.upload(Buffer.from(rendered.buffer), storagePath, {
         mime_type: 'application/pdf',
       });
 
-      const { knex } = await createTenantKnex();
       const fileRecord = await FileStoreModel.create(knex, {
         fileId,
         file_name: storagePath.split('/').pop()!,
         original_name: `${fileName}.pdf`,
         mime_type: 'application/pdf',
-        file_size: pdfBuffer.length,
+        file_size: rendered.buffer.length,
         storage_path: uploadResult.path,
         uploaded_by_id: options.userId,
       });
+
+      let documentId = target ? undefined : options.documentId;
+      let result: StoredPdfResult = { ...fileRecord };
+
+      if (target) {
+        const filed = await this.fileGeneratedDocument(knex, target, fileRecord, rendered, options.userId, reuse);
+        documentId = filed.document_id;
+        // Lost a filing race: an equivalent document already existed, so return it
+        // rather than handing back a second copy of the same artifact.
+        result = filed.reusedFile ?? { ...fileRecord, document_id: filed.document_id };
+      }
 
       try {
         await publishWorkflowEvent({
@@ -170,9 +252,9 @@ export class PDFGenerationService {
             actor: { actorType: 'USER', actorUserId: options.userId },
           },
           payload: buildDocumentGeneratedPayload({
-            documentId: fileRecord.file_id,
+            documentId: documentId!,
             sourceType,
-            sourceId: entityId,
+            sourceId,
             generatedByUserId: options.userId,
             generatedAt: new Date().toISOString(),
             fileName: `${fileName}.pdf`,
@@ -182,8 +264,209 @@ export class PDFGenerationService {
         // Non-blocking
       }
 
-      return fileRecord;
+      return result;
     });
+  }
+
+  // ---- Filing --------------------------------------------------------------
+
+  private async resolveFilingTarget(
+    knex: Knex,
+    options: PDFGenerationOptions
+  ): Promise<FilingTarget | null> {
+    if (options.invoiceId) {
+      const invoice = await tenantDb(knex, this.tenant).table('invoices')
+        .where({ invoice_id: options.invoiceId })
+        .first<{ invoice_number?: string | null; client_id?: string | null } | undefined>(
+          'invoice_number',
+          'client_id'
+        );
+      const invoiceNumber = options.invoiceNumber || invoice?.invoice_number || options.invoiceId;
+
+      return {
+        sourceType: 'invoice',
+        entityId: options.invoiceId,
+        clientId: invoice?.client_id ?? null,
+        folderPath: '/Clients/Invoices',
+        // Explicit, never inherited from the folder default: an invoice document
+        // becomes client-visible when the invoice is sent, not when it is generated.
+        isClientVisible: false,
+        documentName: `Invoice_${invoiceNumber}.pdf`,
+        fileBaseName: options.invoiceNumber || options.invoiceId,
+        reuseExisting: true,
+      };
+    }
+
+    if (options.salesOrderId) {
+      const salesOrder = await tenantDb(knex, this.tenant).table('sales_orders')
+        .where({ so_id: options.salesOrderId })
+        .first<{ so_number?: string | null; client_id?: string | null } | undefined>('so_number', 'client_id');
+      const soNumber = options.salesOrderNumber || salesOrder?.so_number || options.salesOrderId;
+      const documentType = options.salesOrderDocumentType ?? 'sales-order';
+
+      return {
+        sourceType: 'sales_order',
+        entityId: options.salesOrderId,
+        clientId: salesOrder?.client_id ?? null,
+        folderPath: '/Clients/Sales Orders',
+        isClientVisible: false,
+        documentName: `${SALES_ORDER_DOCUMENT_PREFIX[documentType]}_${soNumber}.pdf`,
+        fileBaseName: options.salesOrderNumber || salesOrder?.so_number || options.salesOrderId,
+        reuseExisting: true,
+      };
+    }
+
+    if (options.quoteId) {
+      const quoteNumber = options.quoteNumber || options.quoteId;
+      return {
+        sourceType: 'quote',
+        entityId: options.quoteId,
+        // Quotes keep their pre-existing filing exactly: quote association only.
+        clientId: null,
+        folderPath: '/Quotes/Generated',
+        isClientVisible: true,
+        documentName: `Quote_${quoteNumber}.pdf`,
+        fileBaseName: quoteNumber,
+        // A quote is re-rendered on every send, and each send is its own artifact.
+        reuseExisting: false,
+      };
+    }
+
+    if (options.documentId) {
+      return null;
+    }
+
+    throw new Error('One of invoiceId, quoteId, salesOrderId, or documentId must be provided');
+  }
+
+  /** The most recently filed PDF for this target, or null when none exists. */
+  private async findStoredPdf(
+    knexOrTrx: Knex | Knex.Transaction,
+    target: FilingTarget
+  ): Promise<StoredPdfResult | null> {
+    const db = tenantDb(knexOrTrx, this.tenant);
+    const query = db.table('document_associations as da')
+      .where({
+        'da.entity_id': target.entityId,
+        'da.entity_type': target.sourceType,
+      })
+      .andWhere('d.document_name', target.documentName)
+      .whereNotNull('d.file_id')
+      .orderBy('da.created_at', 'desc')
+      .select('d.document_id', 'd.file_id')
+      .first<{ document_id: string; file_id: string } | undefined>();
+    db.tenantJoin(query, 'documents as d', 'da.document_id', 'd.document_id');
+
+    const existing = await query;
+    if (!existing?.file_id) {
+      return null;
+    }
+
+    const fileRecord = await FileStoreModel.findById(knexOrTrx, existing.file_id);
+    return fileRecord ? { ...fileRecord, document_id: existing.document_id } : null;
+  }
+
+  private async fileGeneratedDocument(
+    knex: Knex,
+    target: FilingTarget,
+    fileRecord: FileStore,
+    rendered: RenderedPdf,
+    userId: string,
+    reuse: boolean
+  ): Promise<{ document_id: string; reusedFile: StoredPdfResult | null }> {
+    const renderedLocale = await this.resolveRenderedLocale(knex, target.clientId);
+
+    return withTransaction(knex, async (trx: Knex.Transaction) => {
+      if (reuse) {
+        // Serialize filing per source entity so two concurrent generations do not
+        // both file the same artifact.
+        await trx.raw('SELECT pg_advisory_xact_lock(hashtext(?), hashtext(?))', [
+          'alga:generated-document-filing',
+          `${this.tenant}:${target.sourceType}:${target.entityId}:${target.documentName}`,
+        ]);
+
+        const raced = await this.findStoredPdf(trx, target);
+        if (raced?.document_id) {
+          return { document_id: raced.document_id, reusedFile: raced };
+        }
+      }
+
+      const documentId = uuidv4();
+      await DocumentModel.insert(trx, {
+        document_id: documentId,
+        document_name: target.documentName,
+        type_id: null,
+        user_id: userId,
+        created_by: userId,
+        order_number: 0,
+        tenant: this.tenant,
+        file_id: fileRecord.file_id,
+        storage_path: fileRecord.storage_path,
+        mime_type: 'application/pdf',
+        file_size: fileRecord.file_size,
+        folder_path: target.folderPath,
+        is_client_visible: target.isClientVisible,
+        source_template_id: rendered.templateId,
+        source_template_version: rendered.templateVersion,
+        rendered_locale: renderedLocale,
+      });
+
+      await DocumentAssociation.create(trx, {
+        document_id: documentId,
+        entity_id: target.entityId,
+        entity_type: target.sourceType,
+        tenant: this.tenant,
+      });
+
+      if (target.clientId) {
+        await DocumentAssociation.create(trx, {
+          document_id: documentId,
+          entity_id: target.clientId,
+          entity_type: 'client',
+          tenant: this.tenant,
+        });
+      }
+
+      return { document_id: documentId, reusedFile: null };
+    });
+  }
+
+  /**
+   * The locale this document was issued in: the billing contact's, else the
+   * client's, else the tenant's. Recorded now so that when template labels become
+   * translatable every stored document already answers "what language was this?".
+   */
+  private async resolveRenderedLocale(knex: Knex, clientId: string | null): Promise<string | null> {
+    try {
+      if (!clientId) {
+        return await getTenantDefaultLocale(this.tenant, 'client');
+      }
+
+      const client = await tenantDb(knex, this.tenant).table('clients')
+        .where({ client_id: clientId })
+        .first<{ billing_contact_id?: string | null; billing_email?: string | null } | undefined>(
+          'billing_contact_id',
+          'billing_email'
+        );
+
+      let email = client?.billing_email ?? null;
+      if (client?.billing_contact_id) {
+        const contact = await tenantDb(knex, this.tenant).table('contacts')
+          .where({ contact_name_id: client.billing_contact_id })
+          .first<{ email?: string | null } | undefined>('email');
+        email = contact?.email ?? email;
+      }
+
+      const recipient = email ? await getUserInfoForEmail(this.tenant, email) : null;
+      return await resolveEmailLocale(this.tenant, {
+        email: email ?? '',
+        userId: recipient?.userId,
+        userType: 'client',
+        clientId,
+      });
+    } catch {
+      return null;
+    }
   }
 
   // ---- Preview entry points -------------------------------------------------
@@ -294,7 +577,7 @@ export class PDFGenerationService {
   private async getInvoiceHtml(
     invoiceId: string,
     overrideTemplateId?: string
-  ): Promise<{ htmlContent: string; templateAst: TemplateAst | null }> {
+  ): Promise<{ htmlContent: string; templateAst: TemplateAst | null; templateId: string | null; templateVersion: number | null }> {
     return runWithTenant(this.tenant, async () => {
       const { knex } = await createTenantKnex();
       const [dbInvoiceData, templates] = await Promise.all([
@@ -318,6 +601,9 @@ export class PDFGenerationService {
         const canonicalTemplate = await this.getInvoiceTemplate(knex, templateId);
         templateAst = (canonicalTemplate?.templateAst ?? null) as TemplateAst | null;
       }
+
+      let renderedTemplateId: string | null = templateId ?? null;
+      let renderedTemplateVersion: number | null = selectedTemplate?.version ?? null;
 
       if (!templateAst) {
         throw new Error(`Template ${templateId} does not have a templateAst payload.`);
@@ -348,6 +634,8 @@ export class PDFGenerationService {
           const fallbackAst = getStandardTemplateAstByCode(fallbackCode);
           if (fallbackAst) {
             templateAst = fallbackAst;
+            renderedTemplateId = fallbackCode;
+            renderedTemplateVersion = null;
           }
         }
       }
@@ -363,7 +651,12 @@ export class PDFGenerationService {
         knex,
       });
 
-      return { htmlContent, templateAst };
+      return {
+        htmlContent,
+        templateAst,
+        templateId: renderedTemplateId,
+        templateVersion: renderedTemplateVersion,
+      };
     });
   }
 
@@ -405,7 +698,7 @@ export class PDFGenerationService {
 
   private async getQuoteHtml(
     options: QuotePDFOptions
-  ): Promise<{ htmlContent: string; templateAst: TemplateAst | null }> {
+  ): Promise<{ htmlContent: string; templateAst: TemplateAst | null; templateId: string | null; templateVersion: number | null }> {
     return runWithTenant(this.tenant, async () => {
       const { knex } = await createTenantKnex();
       const quoteViewModel = await mapDbQuoteToViewModel(knex, this.tenant, options.quoteId);
@@ -414,10 +707,17 @@ export class PDFGenerationService {
         throw new Error(`Quote ${options.quoteId} not found`);
       }
 
-      const templateAst = options.templateAst
-        ?? (options.templateCode
-          ? getStandardQuoteTemplateAstByCode(options.templateCode)
-          : (await resolveQuoteTemplateAst(knex, this.tenant, options.quoteId)).templateAst);
+      let templateAst = options.templateAst ?? null;
+      let templateId: string | null = null;
+
+      if (!templateAst && options.templateCode) {
+        templateAst = getStandardQuoteTemplateAstByCode(options.templateCode);
+        templateId = options.templateCode;
+      } else if (!templateAst) {
+        const resolved = await resolveQuoteTemplateAst(knex, this.tenant, options.quoteId);
+        templateAst = resolved.templateAst;
+        templateId = resolved.templateId ?? resolved.standardCode ?? null;
+      }
 
       if (!templateAst) {
         throw new Error('No quote template AST available for PDF generation');
@@ -433,7 +733,7 @@ export class PDFGenerationService {
         knex,
       });
 
-      return { htmlContent, templateAst };
+      return { htmlContent, templateAst, templateId, templateVersion: null };
     });
   }
 
@@ -441,7 +741,7 @@ export class PDFGenerationService {
 
   private async getSalesOrderHtml(
     options: SalesOrderPDFOptions
-  ): Promise<{ htmlContent: string; templateAst: TemplateAst | null }> {
+  ): Promise<{ htmlContent: string; templateAst: TemplateAst | null; templateId: string | null; templateVersion: number | null }> {
     return runWithTenant(this.tenant, async () => {
       const { knex } = await createTenantKnex();
       const viewModel = await mapDbSalesOrderToViewModel(knex, this.tenant, options.salesOrderId);
@@ -451,10 +751,19 @@ export class PDFGenerationService {
       }
 
       const documentType = options.documentType ?? 'sales-order';
-      const templateAst = options.templateAst
-        ?? (options.templateCode
-          ? getStandardSalesOrderTemplateAstByCode(options.templateCode)
-          : (await resolveSalesOrderTemplateAst(knex, this.tenant, documentType, { clientId: viewModel.client_id })).ast);
+      let templateAst = options.templateAst ?? null;
+      let templateId: string | null = null;
+      let templateVersion: number | null = null;
+
+      if (!templateAst && options.templateCode) {
+        templateAst = getStandardSalesOrderTemplateAstByCode(options.templateCode);
+        templateId = options.templateCode;
+      } else if (!templateAst) {
+        const resolved = await resolveSalesOrderTemplateAst(knex, this.tenant, documentType, { clientId: viewModel.client_id });
+        templateAst = resolved.ast;
+        templateId = resolved.templateId;
+        templateVersion = resolved.templateVersion;
+      }
 
       if (!templateAst) {
         throw new Error('No sales order template AST available for PDF generation');
@@ -471,7 +780,7 @@ export class PDFGenerationService {
         knex,
       });
 
-      return { htmlContent, templateAst };
+      return { htmlContent, templateAst, templateId, templateVersion };
     });
   }
 
@@ -588,4 +897,32 @@ export class PDFGenerationService {
 
 export function createPDFGenerationService(tenant: string): PDFGenerationService {
   return new PDFGenerationService(tenant);
+}
+
+/**
+ * Publish generated documents for an entity to the client portal. Generated
+ * invoice/sales-order documents are filed MSP-only; they become client-visible
+ * at send time, not at generation time.
+ */
+export async function publishGeneratedDocumentsToClient(
+  tenant: string,
+  sourceType: 'invoice' | 'sales_order',
+  entityId: string
+): Promise<number> {
+  return runWithTenant(tenant, async () => {
+    const { knex } = await createTenantKnex();
+    const db = tenantDb(knex, tenant);
+
+    const associations = await db.table('document_associations')
+      .where({ entity_id: entityId, entity_type: sourceType })
+      .pluck<string[]>('document_id');
+
+    if (associations.length === 0) {
+      return 0;
+    }
+
+    return db.table('documents')
+      .whereIn('document_id', associations)
+      .update({ is_client_visible: true });
+  });
 }

--- a/packages/billing/tests/generatedDocumentFiling.test.ts
+++ b/packages/billing/tests/generatedDocumentFiling.test.ts
@@ -1,0 +1,356 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const TENANT_ID = '22222222-2222-4222-8222-222222222222';
+const USER_ID = '11111111-1111-4111-8111-111111111111';
+const CLIENT_ID = '44444444-4444-4444-8444-444444444444';
+const INVOICE_ID = '33333333-3333-4333-8333-333333333333';
+const SALES_ORDER_ID = '55555555-5555-4555-8555-555555555555';
+
+type ChainResult = any;
+
+// Minimal knex-ish chain: enough for the tenantDb facade calls the filing path makes.
+function makeChain(result: ChainResult) {
+  const chain: any = {
+    calls: { where: [] as any[], update: [] as any[] },
+  };
+  const passthrough = ['where', 'andWhere', 'whereNotNull', 'whereIn', 'orderBy', 'select'];
+  for (const method of passthrough) {
+    chain[method] = vi.fn((...args: any[]) => {
+      if (method === 'where') chain.calls.where.push(args[0]);
+      return chain;
+    });
+  }
+  chain.first = vi.fn(async () => (Array.isArray(result) ? result[0] : result));
+  chain.pluck = vi.fn(async () => (Array.isArray(result) ? result : []));
+  chain.update = vi.fn(async (values: any) => {
+    chain.calls.update.push(values);
+    return Array.isArray(result) ? result.length : 1;
+  });
+  chain.then = (onFulfilled: any, onRejected: any) => Promise.resolve(result).then(onFulfilled, onRejected);
+  return chain;
+}
+
+const tableResults: Record<string, ChainResult> = {};
+const tableChains: Record<string, any> = {};
+const rawMock = vi.fn(async () => ({ rows: [] }));
+
+const mockKnex: any = Object.assign(
+  (table: string) => {
+    const chain = makeChain(tableResults[table] ?? undefined);
+    tableChains[table] = chain;
+    return chain;
+  },
+  { raw: (...args: any[]) => rawMock(...args) }
+);
+
+const createTenantKnex = vi.fn();
+const uploadMock = vi.fn();
+const createFileStoreMock = vi.fn();
+const findFileStoreMock = vi.fn();
+const documentInsertMock = vi.fn();
+const documentAssociationCreateMock = vi.fn();
+const publishWorkflowEventMock = vi.fn();
+const getBrowserMock = vi.fn();
+const releaseBrowserMock = vi.fn();
+const resolveSalesOrderTemplateAstMock = vi.fn();
+
+vi.mock('@alga-psa/db', () => ({
+  createTenantKnex: (...args: any[]) => createTenantKnex(...args),
+  runWithTenant: async (_tenant: string, fn: () => Promise<unknown>) => fn(),
+  withTransaction: (conn: any, handler: (trx: any) => Promise<unknown>) => handler(conn),
+  tenantDb: (conn: any) => ({
+    table: (table: string) => conn(table),
+    tenantJoin: (builder: any) => builder,
+  }),
+}));
+
+vi.mock('@alga-psa/storage', () => ({
+  StorageProviderFactory: {
+    createProvider: async () => ({ upload: (...args: any[]) => uploadMock(...args) }),
+  },
+  generateStoragePath: (...parts: string[]) => parts.join('/'),
+  FileStoreModel: {
+    create: (...args: any[]) => createFileStoreMock(...args),
+    findById: (...args: any[]) => findFileStoreMock(...args),
+  },
+}));
+
+vi.mock('@alga-psa/documents/models', () => ({
+  Document: { insert: (...args: any[]) => documentInsertMock(...args) },
+  DocumentAssociation: { create: (...args: any[]) => documentAssociationCreateMock(...args) },
+}));
+
+vi.mock('@alga-psa/event-bus/publishers', () => ({
+  publishWorkflowEvent: (...args: any[]) => publishWorkflowEventMock(...args),
+}));
+
+vi.mock('@alga-psa/notifications/notifications/emailLocaleResolver', () => ({
+  getTenantDefaultLocale: async () => 'en',
+  getUserInfoForEmail: async () => null,
+  resolveEmailLocale: async () => 'pt-BR',
+}));
+
+vi.mock('../src/services/browserPoolService', () => ({
+  browserPoolService: {
+    getBrowser: (...args: any[]) => getBrowserMock(...args),
+    releaseBrowser: (...args: any[]) => releaseBrowserMock(...args),
+  },
+}));
+
+// The render pipeline itself is covered elsewhere; this file is about what
+// happens to the bytes afterwards.
+vi.mock('../src/models/invoice', () => ({
+  default: {
+    getFullInvoiceById: async () => ({ invoice_id: INVOICE_ID, client_id: CLIENT_ID }),
+    getAllTemplates: async () => [
+      {
+        template_id: 'template-1',
+        name: 'Standard Invoice',
+        version: 7,
+        is_default: true,
+        isStandard: true,
+        templateAst: { kind: 'ast' },
+      },
+    ],
+  },
+}));
+
+vi.mock('../src/lib/adapters/invoiceAdapters', () => ({
+  mapDbInvoiceToWasmViewModel: () => ({ invoice_number: 'INV-100', hasMultipleLocations: false }),
+}));
+
+vi.mock('../src/lib/adapters/invoiceAdapters.server', () => ({
+  enrichInvoiceViewModelWithLocations: async () => undefined,
+}));
+
+vi.mock('../src/lib/adapters/salesOrderAdapters', () => ({
+  mapDbSalesOrderToViewModel: async () => ({ so_number: 'SO-9', client_id: CLIENT_ID }),
+}));
+
+vi.mock('../src/lib/adapters/tenantPartyAdapter', () => ({
+  fetchTenantParty: async () => null,
+}));
+
+vi.mock('../src/lib/invoice-template-ast/evaluator', () => ({
+  evaluateTemplateAst: () => ({}),
+}));
+
+vi.mock('../src/lib/invoice-template-ast/server-render', () => ({
+  renderTemplateAstHtmlDocument: async () => '<!doctype html><html><body>doc</body></html>',
+}));
+
+vi.mock('../src/lib/invoice-template-ast/printSettings', () => ({
+  resolvePdfPrintOptionsFromAst: () => ({ format: 'A4' }),
+}));
+
+vi.mock('../src/lib/sales-order-template-ast/templateSelection', () => ({
+  resolveSalesOrderTemplateAst: (...args: any[]) => resolveSalesOrderTemplateAstMock(...args),
+}));
+
+import {
+  createPDFGenerationService,
+  publishGeneratedDocumentsToClient,
+} from '../src/services/pdfGenerationService';
+
+describe('generated document filing', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    for (const key of Object.keys(tableResults)) delete tableResults[key];
+    for (const key of Object.keys(tableChains)) delete tableChains[key];
+
+    const pageMock = {
+      setContent: vi.fn().mockResolvedValue(undefined),
+      pdf: vi.fn().mockResolvedValue(Buffer.from('%PDF-filing-test')),
+      close: vi.fn().mockResolvedValue(undefined),
+    };
+    getBrowserMock.mockResolvedValue({ newPage: vi.fn().mockResolvedValue(pageMock) });
+    releaseBrowserMock.mockResolvedValue(undefined);
+
+    createTenantKnex.mockResolvedValue({ knex: mockKnex, tenant: TENANT_ID });
+    uploadMock.mockResolvedValue({ path: 'stored/pdfs/INV-100.pdf' });
+    createFileStoreMock.mockResolvedValue({
+      file_id: 'file-1',
+      storage_path: 'stored/pdfs/INV-100.pdf',
+      file_size: 16,
+    });
+    findFileStoreMock.mockResolvedValue(null);
+    documentInsertMock.mockResolvedValue({ document_id: 'doc-1' });
+    documentAssociationCreateMock.mockResolvedValue({ association_id: 'assoc-1' });
+    publishWorkflowEventMock.mockResolvedValue(undefined);
+    resolveSalesOrderTemplateAstMock.mockResolvedValue({
+      ast: { kind: 'ast' },
+      source: 'tenant-default',
+      code: null,
+      templateId: 'so-template-1',
+      templateVersion: 3,
+    });
+
+    tableResults.invoices = { invoice_number: 'INV-100', client_id: CLIENT_ID };
+    tableResults.sales_orders = { so_number: 'SO-9', client_id: CLIENT_ID };
+    tableResults.clients = { billing_contact_id: null, billing_email: 'billing@client.test' };
+  });
+
+  it('files a generated invoice under /Clients/Invoices, MSP-only, with both associations', async () => {
+    const service = createPDFGenerationService(TENANT_ID);
+    const result = await service.generateAndStore({
+      invoiceId: INVOICE_ID,
+      invoiceNumber: 'INV-100',
+      userId: USER_ID,
+    });
+
+    expect(documentInsertMock).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({
+        document_name: 'Invoice_INV-100.pdf',
+        folder_path: '/Clients/Invoices',
+        // Explicit, not inherited: /Clients/Invoices is a client-visible default
+        // folder, but an unsent invoice stays MSP-only.
+        is_client_visible: false,
+        file_id: 'file-1',
+        mime_type: 'application/pdf',
+        tenant: TENANT_ID,
+      })
+    );
+
+    const associations = documentAssociationCreateMock.mock.calls.map(([, input]) => input);
+    expect(associations).toHaveLength(2);
+    expect(associations).toContainEqual(
+      expect.objectContaining({ entity_id: INVOICE_ID, entity_type: 'invoice', tenant: TENANT_ID })
+    );
+    expect(associations).toContainEqual(
+      expect.objectContaining({ entity_id: CLIENT_ID, entity_type: 'client', tenant: TENANT_ID })
+    );
+    expect(result.document_id).toBeDefined();
+  });
+
+  it('records the template and locale the invoice was rendered from', async () => {
+    const service = createPDFGenerationService(TENANT_ID);
+    await service.generateAndStore({ invoiceId: INVOICE_ID, invoiceNumber: 'INV-100', userId: USER_ID });
+
+    expect(documentInsertMock).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({
+        source_template_id: 'template-1',
+        source_template_version: 7,
+        rendered_locale: 'pt-BR',
+      })
+    );
+  });
+
+  it('emits DOCUMENT_GENERATED with the documents row id so the search indexer resolves it', async () => {
+    const service = createPDFGenerationService(TENANT_ID);
+    const result = await service.generateAndStore({
+      invoiceId: INVOICE_ID,
+      invoiceNumber: 'INV-100',
+      userId: USER_ID,
+    });
+
+    const [event] = publishWorkflowEventMock.mock.calls[0];
+    expect(event.eventType).toBe('DOCUMENT_GENERATED');
+    expect(event.payload).toMatchObject({
+      documentId: result.document_id,
+      sourceType: 'invoice',
+      sourceId: INVOICE_ID,
+      fileName: 'INV-100.pdf',
+    });
+    expect(event.payload.documentId).not.toBe('file-1');
+  });
+
+  it('reuses the stored invoice PDF instead of rendering a second artifact', async () => {
+    tableResults['document_associations as da'] = { document_id: 'doc-1', file_id: 'file-1' };
+    findFileStoreMock.mockResolvedValue({ file_id: 'file-1', storage_path: 'stored/pdfs/INV-100.pdf' });
+
+    const service = createPDFGenerationService(TENANT_ID);
+    const result = await service.generateAndStore({
+      invoiceId: INVOICE_ID,
+      invoiceNumber: 'INV-100',
+      userId: USER_ID,
+    });
+
+    expect(result).toMatchObject({ file_id: 'file-1', document_id: 'doc-1' });
+    expect(getBrowserMock).not.toHaveBeenCalled();
+    expect(uploadMock).not.toHaveBeenCalled();
+    expect(documentInsertMock).not.toHaveBeenCalled();
+    expect(publishWorkflowEventMock).not.toHaveBeenCalled();
+  });
+
+  it('renders and files afresh when regeneration is explicitly requested', async () => {
+    tableResults['document_associations as da'] = { document_id: 'doc-1', file_id: 'file-1' };
+    findFileStoreMock.mockResolvedValue({ file_id: 'file-1', storage_path: 'stored/pdfs/INV-100.pdf' });
+    createFileStoreMock.mockResolvedValue({
+      file_id: 'file-2',
+      storage_path: 'stored/pdfs/INV-100-2.pdf',
+      file_size: 16,
+    });
+
+    const service = createPDFGenerationService(TENANT_ID);
+    const result = await service.generateAndStore({
+      invoiceId: INVOICE_ID,
+      invoiceNumber: 'INV-100',
+      userId: USER_ID,
+      regenerate: true,
+    });
+
+    expect(uploadMock).toHaveBeenCalledTimes(1);
+    expect(documentInsertMock).toHaveBeenCalledTimes(1);
+    expect(result.file_id).toBe('file-2');
+    expect(result.document_id).not.toBe('doc-1');
+  });
+
+  it('files a sales order confirmation under /Clients/Sales Orders', async () => {
+    const service = createPDFGenerationService(TENANT_ID);
+    await service.generateAndStore({ salesOrderId: SALES_ORDER_ID, userId: USER_ID });
+
+    expect(documentInsertMock).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({
+        document_name: 'SalesOrder_SO-9.pdf',
+        folder_path: '/Clients/Sales Orders',
+        is_client_visible: false,
+        source_template_id: 'so-template-1',
+        source_template_version: 3,
+      })
+    );
+
+    const associations = documentAssociationCreateMock.mock.calls.map(([, input]) => input);
+    expect(associations).toContainEqual(
+      expect.objectContaining({ entity_id: SALES_ORDER_ID, entity_type: 'sales_order' })
+    );
+    expect(associations).toContainEqual(
+      expect.objectContaining({ entity_id: CLIENT_ID, entity_type: 'client' })
+    );
+  });
+
+  it('keeps packing slips separate from the confirmation document', async () => {
+    const service = createPDFGenerationService(TENANT_ID);
+    await service.generateAndStore({
+      salesOrderId: SALES_ORDER_ID,
+      salesOrderDocumentType: 'packing-slip',
+      userId: USER_ID,
+    });
+
+    expect(documentInsertMock).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({ document_name: 'PackingSlip_SO-9.pdf' })
+    );
+  });
+
+  it('publishes filed documents to the client only when asked (send time)', async () => {
+    tableResults.document_associations = ['doc-1', 'doc-2'];
+    tableResults.documents = ['doc-1', 'doc-2'];
+
+    const updated = await publishGeneratedDocumentsToClient(TENANT_ID, 'invoice', INVOICE_ID);
+
+    expect(updated).toBe(2);
+    expect(tableChains.documents.calls.update[0]).toEqual({ is_client_visible: true });
+  });
+
+  it('does not touch documents when the entity has none filed', async () => {
+    tableResults.document_associations = [];
+
+    const updated = await publishGeneratedDocumentsToClient(TENANT_ID, 'invoice', INVOICE_ID);
+
+    expect(updated).toBe(0);
+    expect(tableChains.documents).toBeUndefined();
+  });
+});

--- a/packages/billing/tests/generatedDocumentFiling.test.ts
+++ b/packages/billing/tests/generatedDocumentFiling.test.ts
@@ -297,6 +297,25 @@ describe('generated document filing', () => {
     expect(result.document_id).not.toBe('doc-1');
   });
 
+  it('still returns the stored file when filing fails, and announces nothing', async () => {
+    documentInsertMock.mockRejectedValue(new Error('documents_created_by_fkey'));
+    const consoleError = vi.spyOn(console, 'error').mockImplementation(() => {});
+
+    const service = createPDFGenerationService(TENANT_ID);
+    const result = await service.generateAndStore({
+      invoiceId: INVOICE_ID,
+      invoiceNumber: 'INV-100',
+      userId: USER_ID,
+    });
+
+    // The bytes are what gets emailed and downloaded — filing must not take the
+    // caller down with it.
+    expect(result.file_id).toBe('file-1');
+    expect(result.document_id).toBeUndefined();
+    expect(publishWorkflowEventMock).not.toHaveBeenCalled();
+    consoleError.mockRestore();
+  });
+
   it('files a sales order confirmation under /Clients/Sales Orders', async () => {
     const service = createPDFGenerationService(TENANT_ID);
     await service.generateAndStore({ salesOrderId: SALES_ORDER_ID, userId: USER_ID });

--- a/packages/billing/tests/generatedDocumentFiling.test.ts
+++ b/packages/billing/tests/generatedDocumentFiling.test.ts
@@ -16,17 +16,27 @@ function makeChain(result: ChainResult) {
   const passthrough = ['where', 'andWhere', 'whereNotNull', 'whereIn', 'orderBy', 'select'];
   for (const method of passthrough) {
     chain[method] = vi.fn((...args: any[]) => {
-      if (method === 'where') chain.calls.where.push(args[0]);
+      if (method === 'where' || method === 'andWhere') chain.calls.where.push(args);
       return chain;
     });
   }
-  chain.first = vi.fn(async () => (Array.isArray(result) ? result[0] : result));
-  chain.pluck = vi.fn(async () => (Array.isArray(result) ? result : []));
+  // A table fixture may be a function so a test can answer differently depending on
+  // what was filtered on — the filing lookups differ only by client visibility.
+  const resolve = () => (typeof result === 'function' ? result(chain.calls.where) : result);
+  chain.first = vi.fn(async () => {
+    const value = resolve();
+    return Array.isArray(value) ? value[0] : value;
+  });
+  chain.pluck = vi.fn(async () => {
+    const value = resolve();
+    return Array.isArray(value) ? value : [];
+  });
   chain.update = vi.fn(async (values: any) => {
     chain.calls.update.push(values);
-    return Array.isArray(result) ? result.length : 1;
+    const value = resolve();
+    return Array.isArray(value) ? value.length : 1;
   });
-  chain.then = (onFulfilled: any, onRejected: any) => Promise.resolve(result).then(onFulfilled, onRejected);
+  chain.then = (onFulfilled: any, onRejected: any) => Promise.resolve(resolve()).then(onFulfilled, onRejected);
   return chain;
 }
 
@@ -48,7 +58,9 @@ const uploadMock = vi.fn();
 const createFileStoreMock = vi.fn();
 const findFileStoreMock = vi.fn();
 const documentInsertMock = vi.fn();
+const documentUpdateMock = vi.fn();
 const documentAssociationCreateMock = vi.fn();
+const softDeleteFileMock = vi.fn();
 const publishWorkflowEventMock = vi.fn();
 const getBrowserMock = vi.fn();
 const releaseBrowserMock = vi.fn();
@@ -72,11 +84,15 @@ vi.mock('@alga-psa/storage', () => ({
   FileStoreModel: {
     create: (...args: any[]) => createFileStoreMock(...args),
     findById: (...args: any[]) => findFileStoreMock(...args),
+    softDelete: (...args: any[]) => softDeleteFileMock(...args),
   },
 }));
 
 vi.mock('@alga-psa/documents/models', () => ({
-  Document: { insert: (...args: any[]) => documentInsertMock(...args) },
+  Document: {
+    insert: (...args: any[]) => documentInsertMock(...args),
+    update: (...args: any[]) => documentUpdateMock(...args),
+  },
   DocumentAssociation: { create: (...args: any[]) => documentAssociationCreateMock(...args) },
 }));
 
@@ -152,6 +168,18 @@ import {
   publishGeneratedDocumentsToClient,
 } from '../src/services/pdfGenerationService';
 
+/**
+ * Put one already-filed document on record. The filing path asks separately for the
+ * copy issued to the client and the MSP-only working copy, so the fixture answers
+ * only the lookup whose visibility matches.
+ */
+function filedDocument(row: { document_id: string; file_id: string; is_client_visible: boolean }) {
+  tableResults['document_associations as da'] = (wheres: any[][]) => {
+    const visibility = wheres.find(([column]) => column === 'd.is_client_visible')?.[1];
+    return visibility === row.is_client_visible ? row : undefined;
+  };
+}
+
 describe('generated document filing', () => {
   beforeEach(() => {
     vi.clearAllMocks();
@@ -174,7 +202,9 @@ describe('generated document filing', () => {
       file_size: 16,
     });
     findFileStoreMock.mockResolvedValue(null);
+    softDeleteFileMock.mockResolvedValue({});
     documentInsertMock.mockResolvedValue({ document_id: 'doc-1' });
+    documentUpdateMock.mockResolvedValue(undefined);
     documentAssociationCreateMock.mockResolvedValue({ association_id: 'assoc-1' });
     publishWorkflowEventMock.mockResolvedValue(undefined);
     resolveSalesOrderTemplateAstMock.mockResolvedValue({
@@ -185,6 +215,7 @@ describe('generated document filing', () => {
       templateVersion: 3,
     });
 
+    tableResults.shared_document_types = { type_id: 'shared-pdf-type' };
     tableResults.invoices = { invoice_number: 'INV-100', client_id: CLIENT_ID };
     tableResults.sales_orders = { so_number: 'SO-9', client_id: CLIENT_ID };
     tableResults.clients = { billing_contact_id: null, billing_email: 'billing@client.test' };
@@ -223,6 +254,27 @@ describe('generated document filing', () => {
     expect(result.document_id).toBeDefined();
   });
 
+  it('files it as a PDF, so it carries a type in the Documents list like any upload', async () => {
+    const service = createPDFGenerationService(TENANT_ID);
+    await service.generateAndStore({ invoiceId: INVOICE_ID, invoiceNumber: 'INV-100', userId: USER_ID });
+
+    expect(documentInsertMock).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({ type_id: null, shared_type_id: 'shared-pdf-type' })
+    );
+  });
+
+  it('prefers the tenant PDF type over the shared one', async () => {
+    tableResults.document_types = { type_id: 'tenant-pdf-type' };
+
+    const service = createPDFGenerationService(TENANT_ID);
+    await service.generateAndStore({ invoiceId: INVOICE_ID, invoiceNumber: 'INV-100', userId: USER_ID });
+
+    const [, inserted] = documentInsertMock.mock.calls[0];
+    expect(inserted.type_id).toBe('tenant-pdf-type');
+    expect(inserted.shared_type_id).toBeUndefined();
+  });
+
   it('records the template and locale the invoice was rendered from', async () => {
     const service = createPDFGenerationService(TENANT_ID);
     await service.generateAndStore({ invoiceId: INVOICE_ID, invoiceNumber: 'INV-100', userId: USER_ID });
@@ -256,8 +308,8 @@ describe('generated document filing', () => {
     expect(event.payload.documentId).not.toBe('file-1');
   });
 
-  it('reuses the stored invoice PDF instead of rendering a second artifact', async () => {
-    tableResults['document_associations as da'] = { document_id: 'doc-1', file_id: 'file-1' };
+  it('hands back an issued invoice PDF instead of rendering a second artifact', async () => {
+    filedDocument({ document_id: 'doc-1', file_id: 'file-1', is_client_visible: true });
     findFileStoreMock.mockResolvedValue({ file_id: 'file-1', storage_path: 'stored/pdfs/INV-100.pdf' });
 
     const service = createPDFGenerationService(TENANT_ID);
@@ -274,9 +326,40 @@ describe('generated document filing', () => {
     expect(publishWorkflowEventMock).not.toHaveBeenCalled();
   });
 
-  it('renders and files afresh when regeneration is explicitly requested', async () => {
-    tableResults['document_associations as da'] = { document_id: 'doc-1', file_id: 'file-1' };
+  it('refreshes the filed document in place while the invoice is still MSP-only', async () => {
+    filedDocument({ document_id: 'doc-1', file_id: 'file-1', is_client_visible: false });
     findFileStoreMock.mockResolvedValue({ file_id: 'file-1', storage_path: 'stored/pdfs/INV-100.pdf' });
+    createFileStoreMock.mockResolvedValue({
+      file_id: 'file-2',
+      storage_path: 'stored/pdfs/INV-100-2.pdf',
+      file_size: 16,
+    });
+
+    const service = createPDFGenerationService(TENANT_ID);
+    const result = await service.generateAndStore({
+      invoiceId: INVOICE_ID,
+      invoiceNumber: 'INV-100',
+      userId: USER_ID,
+    });
+
+    // One document per invoice: the same row now points at the fresh render, so a
+    // draft's filed PDF cannot fall behind the invoice and downloads cannot pile up.
+    expect(documentInsertMock).not.toHaveBeenCalled();
+    expect(documentUpdateMock).toHaveBeenCalledWith(
+      expect.anything(),
+      'doc-1',
+      expect.objectContaining({ file_id: 'file-2', storage_path: 'stored/pdfs/INV-100-2.pdf' })
+    );
+    expect(softDeleteFileMock).toHaveBeenCalledWith(expect.anything(), 'file-1', USER_ID);
+    expect(result).toMatchObject({ file_id: 'file-2', document_id: 'doc-1' });
+  });
+
+  it('files a new document when an already-issued invoice is deliberately re-rendered', async () => {
+    filedDocument({ document_id: 'doc-1', file_id: 'file-1', is_client_visible: true });
+    findFileStoreMock.mockResolvedValue({
+      file_id: 'file-1',
+      storage_path: 'stored/pdfs/INV-100.pdf',
+    });
     createFileStoreMock.mockResolvedValue({
       file_id: 'file-2',
       storage_path: 'stored/pdfs/INV-100-2.pdf',
@@ -291,8 +374,14 @@ describe('generated document filing', () => {
       regenerate: true,
     });
 
+    // The copy the client received is never mutated: the re-render is its own,
+    // still MSP-only, document.
     expect(uploadMock).toHaveBeenCalledTimes(1);
-    expect(documentInsertMock).toHaveBeenCalledTimes(1);
+    expect(documentUpdateMock).not.toHaveBeenCalled();
+    expect(documentInsertMock).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({ file_id: 'file-2', is_client_visible: false })
+    );
     expect(result.file_id).toBe('file-2');
     expect(result.document_id).not.toBe('doc-1');
   });

--- a/packages/billing/tests/generatedDocumentFiling.test.ts
+++ b/packages/billing/tests/generatedDocumentFiling.test.ts
@@ -173,7 +173,12 @@ import {
  * copy issued to the client and the MSP-only working copy, so the fixture answers
  * only the lookup whose visibility matches.
  */
-function filedDocument(row: { document_id: string; file_id: string; is_client_visible: boolean }) {
+function filedDocument(row: {
+  document_id: string;
+  file_id: string;
+  is_client_visible: boolean;
+  source_template_id?: string | null;
+}) {
   tableResults['document_associations as da'] = (wheres: any[][]) => {
     const visibility = wheres.find(([column]) => column === 'd.is_client_visible')?.[1];
     return visibility === row.is_client_visible ? row : undefined;
@@ -352,6 +357,50 @@ describe('generated document filing', () => {
     );
     expect(softDeleteFileMock).toHaveBeenCalledWith(expect.anything(), 'file-1', USER_ID);
     expect(result).toMatchObject({ file_id: 'file-2', document_id: 'doc-1' });
+  });
+
+  it('re-renders when a different template than the issued one is asked for', async () => {
+    filedDocument({
+      document_id: 'doc-1',
+      file_id: 'file-1',
+      is_client_visible: true,
+      source_template_id: 'a-different-template',
+    });
+    findFileStoreMock.mockResolvedValue({ file_id: 'file-1', storage_path: 'stored/pdfs/INV-100.pdf' });
+
+    const service = createPDFGenerationService(TENANT_ID);
+    await service.generateAndStore({
+      invoiceId: INVOICE_ID,
+      invoiceNumber: 'INV-100',
+      userId: USER_ID,
+      templateId: 'template-1',
+    });
+
+    // Asking for a template is asking for its output, so the copy on file does
+    // not answer the request.
+    expect(uploadMock).toHaveBeenCalledTimes(1);
+    expect(documentInsertMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('hands back the issued copy when it is the template that was asked for', async () => {
+    filedDocument({
+      document_id: 'doc-1',
+      file_id: 'file-1',
+      is_client_visible: true,
+      source_template_id: 'template-1',
+    });
+    findFileStoreMock.mockResolvedValue({ file_id: 'file-1', storage_path: 'stored/pdfs/INV-100.pdf' });
+
+    const service = createPDFGenerationService(TENANT_ID);
+    const result = await service.generateAndStore({
+      invoiceId: INVOICE_ID,
+      invoiceNumber: 'INV-100',
+      userId: USER_ID,
+      templateId: 'template-1',
+    });
+
+    expect(result).toMatchObject({ file_id: 'file-1', document_id: 'doc-1' });
+    expect(uploadMock).not.toHaveBeenCalled();
   });
 
   it('files a new document when an already-issued invoice is deliberately re-rendered', async () => {

--- a/packages/billing/tests/invoiceDownloadFiling.test.ts
+++ b/packages/billing/tests/invoiceDownloadFiling.test.ts
@@ -70,7 +70,6 @@ describe('downloading an invoice PDF as an MSP biller', () => {
       expect.objectContaining({
         invoiceId: 'invoice-1',
         invoiceNumber: 'INV-42',
-        regenerate: false,
         userId: 'user-1',
       })
     );
@@ -80,11 +79,11 @@ describe('downloading an invoice PDF as an MSP biller', () => {
     expect(result.invoiceNumber).toBe('INV-42');
   });
 
-  it('renders again when the biller picks a different template', async () => {
+  it('passes the picked template through, so the stored copy is only reused when it matches', async () => {
     await downloadInvoicePDF('invoice-1', 'template-9');
 
     expect(generateAndStoreMock).toHaveBeenCalledWith(
-      expect.objectContaining({ templateId: 'template-9', regenerate: true })
+      expect.objectContaining({ templateId: 'template-9' })
     );
   });
 

--- a/packages/billing/tests/invoiceDownloadFiling.test.ts
+++ b/packages/billing/tests/invoiceDownloadFiling.test.ts
@@ -1,0 +1,100 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const generateAndStoreMock = vi.fn();
+const generatePDFMock = vi.fn();
+const downloadFileMock = vi.fn();
+
+function createQueryBuilder() {
+  const builder: any = {};
+  builder.where = vi.fn(() => builder);
+  builder.andWhere = vi.fn(() => builder);
+  builder.first = vi.fn(async () => ({
+    invoice_id: 'invoice-1',
+    invoice_number: 'INV-42',
+    client_id: 'client-1',
+  }));
+  return builder;
+}
+
+const mockTrx = ((_table: string) => createQueryBuilder()) as any;
+
+vi.mock('@alga-psa/auth', () => ({
+  withAuth: (fn: any) => (...args: any[]) =>
+    fn({ user_id: 'user-1' }, { tenant: 'tenant-1' }, ...args),
+  getSession: vi.fn(async () => ({ user: { id: 'user-1' } })),
+}));
+
+vi.mock('@alga-psa/auth/rbac', () => ({
+  hasPermission: vi.fn().mockResolvedValue(true),
+}));
+
+vi.mock('@alga-psa/db', async () => {
+  const actual = await vi.importActual<any>('@alga-psa/db');
+  return {
+    ...actual,
+    createTenantKnex: vi.fn(async () => ({ knex: mockTrx, tenant: 'tenant-1' })),
+    withTransaction: vi.fn(async (_knex: any, callback: any) => callback(mockTrx)),
+    tenantDb: () => ({ table: () => createQueryBuilder() }),
+  };
+});
+
+vi.mock('../src/services/pdfGenerationService', () => ({
+  createPDFGenerationService: () => ({
+    generateAndStore: (...args: any[]) => generateAndStoreMock(...args),
+    generatePDF: (...args: any[]) => generatePDFMock(...args),
+  }),
+}));
+
+vi.mock('@alga-psa/storage/StorageService', () => ({
+  StorageService: {
+    downloadFile: (...args: any[]) => downloadFileMock(...args),
+  },
+}));
+
+import { downloadInvoicePDF } from '../src/actions/invoiceGeneration';
+
+describe('downloading an invoice PDF as an MSP biller', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    generateAndStoreMock.mockResolvedValue({ file_id: 'file-1', document_id: 'doc-1' });
+    downloadFileMock.mockResolvedValue({ buffer: Buffer.from('%PDF-stored') });
+    generatePDFMock.mockResolvedValue(Buffer.from('%PDF-rendered'));
+  });
+
+  it('files the invoice and hands back the stored bytes', async () => {
+    const result: any = await downloadInvoicePDF('invoice-1');
+
+    // The download is what a biller actually clicks, so it is the path that has to
+    // put the invoice in Documents.
+    expect(generateAndStoreMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        invoiceId: 'invoice-1',
+        invoiceNumber: 'INV-42',
+        regenerate: false,
+        userId: 'user-1',
+      })
+    );
+    expect(downloadFileMock).toHaveBeenCalledWith('file-1');
+    expect(generatePDFMock).not.toHaveBeenCalled();
+    expect(Buffer.from(result.pdfData).toString()).toBe('%PDF-stored');
+    expect(result.invoiceNumber).toBe('INV-42');
+  });
+
+  it('renders again when the biller picks a different template', async () => {
+    await downloadInvoicePDF('invoice-1', 'template-9');
+
+    expect(generateAndStoreMock).toHaveBeenCalledWith(
+      expect.objectContaining({ templateId: 'template-9', regenerate: true })
+    );
+  });
+
+  it('still downloads when filing the document is not possible', async () => {
+    generateAndStoreMock.mockRejectedValue(new Error('storage provider unavailable'));
+    const consoleError = vi.spyOn(console, 'error').mockImplementation(() => {});
+
+    const result: any = await downloadInvoicePDF('invoice-1');
+
+    expect(Buffer.from(result.pdfData).toString()).toBe('%PDF-rendered');
+    consoleError.mockRestore();
+  });
+});

--- a/packages/billing/tests/quote/quoteActions.test.ts
+++ b/packages/billing/tests/quote/quoteActions.test.ts
@@ -1150,7 +1150,9 @@ describe('quoteActions', () => {
     }));
   });
 
-  it('T129: sendQuote stores a PDF document and creates a quote association', async () => {
+  // Filing (documents row + quote association) moved into the PDF service; see
+  // quotePdfGenerationService.test.ts T084b. The action's job is to delegate.
+  it('T129: sendQuote delegates PDF storage to the generation service', async () => {
     const sendableQuote = {
       quote_id: QUOTE_ID,
       quote_number: 'Q-0001',
@@ -1177,25 +1179,7 @@ describe('quoteActions', () => {
         userId: USER_ID,
       })
     );
-    expect(documentInsertMock).toHaveBeenCalledWith(
-      mockKnex,
-      expect.objectContaining({
-        document_name: 'Quote_Q-0001.pdf',
-        mime_type: 'application/pdf',
-        file_id: 'stored-file-1',
-        folder_path: '/Quotes/Generated',
-        is_client_visible: true,
-        tenant: TENANT_ID,
-      })
-    );
-    expect(documentAssociationCreateMock).toHaveBeenCalledWith(
-      mockKnex,
-      expect.objectContaining({
-        entity_id: QUOTE_ID,
-        entity_type: 'quote',
-        tenant: TENANT_ID,
-      })
-    );
+    expect(documentInsertMock).not.toHaveBeenCalled();
   });
 
   it('T130: sendQuote succeeds even if PDF storage fails', async () => {
@@ -1287,7 +1271,7 @@ describe('quoteActions', () => {
     expect(result).toBeNull();
   });
 
-  it('T133: regenerateQuotePdf generates a new PDF and stores it as a document', async () => {
+  it('T133: regenerateQuotePdf generates a new PDF through the generation service', async () => {
     vi.spyOn(Quote, 'getById').mockResolvedValueOnce({
       quote_id: QUOTE_ID,
       quote_number: 'Q-0001',
@@ -1304,8 +1288,6 @@ describe('quoteActions', () => {
         userId: USER_ID,
       })
     );
-    expect(documentInsertMock).toHaveBeenCalled();
-    expect(documentAssociationCreateMock).toHaveBeenCalled();
     expect(result).toBe('stored-file-1');
   });
 

--- a/packages/billing/tests/quote/quotePdfGenerationService.test.ts
+++ b/packages/billing/tests/quote/quotePdfGenerationService.test.ts
@@ -12,10 +12,35 @@ const uploadMock = vi.fn();
 const createFileStoreMock = vi.fn();
 const getBrowserMock = vi.fn();
 const releaseBrowserMock = vi.fn();
+const documentInsertMock = vi.fn();
+const documentAssociationCreateMock = vi.fn();
+const publishWorkflowEventMock = vi.fn();
 
 vi.mock('@alga-psa/db', () => ({
   createTenantKnex: (...args: any[]) => createTenantKnex(...args),
   runWithTenant: async (_tenant: string, fn: () => Promise<unknown>) => fn(),
+  withTransaction: (conn: any, handler: (trx: any) => Promise<unknown>) => handler(conn),
+  tenantDb: () => ({
+    table: (table: string) => {
+      throw new Error(`Unexpected tenantDb table access: ${table}`);
+    },
+    tenantJoin: (builder: any) => builder,
+  }),
+}));
+
+vi.mock('@alga-psa/documents/models', () => ({
+  Document: { insert: (...args: any[]) => documentInsertMock(...args) },
+  DocumentAssociation: { create: (...args: any[]) => documentAssociationCreateMock(...args) },
+}));
+
+vi.mock('@alga-psa/notifications/notifications/emailLocaleResolver', () => ({
+  getTenantDefaultLocale: async () => 'en',
+  getUserInfoForEmail: async () => null,
+  resolveEmailLocale: async () => 'en',
+}));
+
+vi.mock('@alga-psa/event-bus/publishers', () => ({
+  publishWorkflowEvent: (...args: any[]) => publishWorkflowEventMock(...args),
 }));
 
 vi.mock('../../src/lib/adapters/quoteAdapters', () => ({
@@ -131,7 +156,10 @@ describe('quotePdfGenerationService', () => {
     });
     quoteGetById.mockResolvedValue({ quote_id: QUOTE_ID, quote_number: 'Q-0042' });
     uploadMock.mockResolvedValue({ path: 'stored/pdfs/Q-0042.pdf' });
-    createFileStoreMock.mockResolvedValue({ file_id: 'file-1', storage_path: 'stored/pdfs/Q-0042.pdf' });
+    createFileStoreMock.mockResolvedValue({ file_id: 'file-1', storage_path: 'stored/pdfs/Q-0042.pdf', file_size: 15 });
+    documentInsertMock.mockResolvedValue({ document_id: 'doc-1' });
+    documentAssociationCreateMock.mockResolvedValue({ association_id: 'assoc-1' });
+    publishWorkflowEventMock.mockResolvedValue(undefined);
   });
 
   it('T083: generates a valid PDF buffer from quote data', async () => {
@@ -160,5 +188,46 @@ describe('quotePdfGenerationService', () => {
       })
     );
     expect(result).toMatchObject({ file_id: 'file-1' });
+  });
+
+  it('T084b: files the stored quote PDF as a client-visible document under /Quotes/Generated', async () => {
+    const service = createPDFGenerationService(TENANT_ID);
+    const result = await service.generateAndStore({ quoteId: QUOTE_ID, quoteNumber: 'Q-0042', userId: USER_ID });
+
+    expect(documentInsertMock).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({
+        document_name: 'Quote_Q-0042.pdf',
+        mime_type: 'application/pdf',
+        file_id: 'file-1',
+        folder_path: '/Quotes/Generated',
+        is_client_visible: true,
+        tenant: TENANT_ID,
+        source_template_id: 'standard-quote-default',
+        rendered_locale: 'en',
+      })
+    );
+    // Quote filing carries the quote association only — unchanged from before.
+    expect(documentAssociationCreateMock).toHaveBeenCalledTimes(1);
+    expect(documentAssociationCreateMock).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({ entity_id: QUOTE_ID, entity_type: 'quote', tenant: TENANT_ID })
+    );
+    expect(result.document_id).toBeDefined();
+  });
+
+  it('T084c: DOCUMENT_GENERATED carries the documents row id, not the file id', async () => {
+    const service = createPDFGenerationService(TENANT_ID);
+    const result = await service.generateAndStore({ quoteId: QUOTE_ID, quoteNumber: 'Q-0042', userId: USER_ID });
+
+    const [event] = publishWorkflowEventMock.mock.calls[0];
+    expect(event.eventType).toBe('DOCUMENT_GENERATED');
+    expect(event.payload).toMatchObject({
+      documentId: result.document_id,
+      sourceType: 'quote',
+      sourceId: QUOTE_ID,
+      fileName: 'Q-0042.pdf',
+    });
+    expect(event.payload.documentId).not.toBe('file-1');
   });
 });

--- a/packages/client-portal/src/actions/client-portal-actions/client-billing.invoicePdf.test.ts
+++ b/packages/client-portal/src/actions/client-portal-actions/client-billing.invoicePdf.test.ts
@@ -1,0 +1,106 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const currentUser = { user_id: 'user-1', tenant: 'tenant-1', roles: [] };
+
+const getConnectionMock = vi.fn();
+const scheduleInvoiceZipActionMock = vi.fn();
+let storedInvoiceDocument: { file_id: string } | undefined;
+let invoiceRow: Record<string, unknown> | undefined;
+
+vi.mock('@alga-psa/auth', () => ({
+  withAuth:
+    (action: any) =>
+    async (...args: any[]) =>
+      action(currentUser, { tenant: currentUser.tenant }, ...args),
+}));
+
+vi.mock('@alga-psa/db', () => ({
+  getConnection: (...args: any[]) => getConnectionMock(...args),
+  withTransaction: (conn: any, handler: (trx: any) => Promise<unknown>) => handler(conn),
+  createTenantKnex: vi.fn(),
+  tenantDb: (conn: any) => ({
+    table: (table: string) => conn(table),
+    unscoped: (table: string) => conn(table),
+    tenantJoin: (query: any) => query,
+  }),
+}));
+
+vi.mock('./clientBillingPermissions', () => ({
+  getClientIdFromPortalUser: vi.fn(async () => 'client-1'),
+  hasClientBillingReadPermission: vi.fn(async () => true),
+}));
+
+vi.mock('@alga-psa/billing/actions/invoiceJobActions', () => ({
+  scheduleInvoiceEmailAction: vi.fn(),
+  scheduleInvoiceZipAction: (...args: any[]) => scheduleInvoiceZipActionMock(...args),
+}));
+
+vi.mock('@alga-psa/billing/models/invoice', () => ({ default: {} }));
+vi.mock('@alga-psa/billing/models/quote', () => ({ default: {} }));
+vi.mock('@alga-psa/billing/models/quoteActivity', () => ({ default: {} }));
+vi.mock('@alga-psa/billing/services', () => ({ recalculateQuoteFinancials: vi.fn() }));
+vi.mock('@alga-psa/billing/actions/invoiceQueries', () => ({
+  fetchInvoicesByClient: vi.fn(),
+  getInvoiceLineItems: vi.fn(),
+  getInvoiceForRendering: vi.fn(),
+}));
+vi.mock('@alga-psa/billing/actions/invoiceTemplates', () => ({ getInvoiceTemplates: vi.fn() }));
+vi.mock('@alga-psa/billing/actions/invoiceModification', () => ({
+  finalizeInvoice: vi.fn(),
+  unfinalizeInvoice: vi.fn(),
+}));
+vi.mock('@alga-psa/jobs', () => ({ JobService: class {}, JobStatus: {} }));
+
+function makeChain(result: unknown) {
+  const chain: any = {};
+  for (const method of ['where', 'whereNot', 'whereNotNull', 'orderBy', 'select', 'join', 'leftJoin']) {
+    chain[method] = vi.fn(() => chain);
+  }
+  chain.first = vi.fn(async () => result);
+  return chain;
+}
+
+describe('downloadClientInvoicePdf', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    storedInvoiceDocument = undefined;
+    invoiceRow = { invoice_id: 'invoice-1', client_id: 'client-1', status: 'sent' };
+
+    getConnectionMock.mockResolvedValue((table: string) => {
+      if (table === 'invoices') return makeChain(invoiceRow);
+      if (table === 'document_associations as da') return makeChain(storedInvoiceDocument);
+      throw new Error(`Unexpected table: ${table}`);
+    });
+  });
+
+  it('returns the stored PDF the client was issued instead of regenerating', async () => {
+    storedInvoiceDocument = { file_id: 'stored-invoice-file-1' };
+
+    const { downloadClientInvoicePdf } = await import('./client-billing');
+    const result = await downloadClientInvoicePdf('invoice-1');
+
+    expect(result).toEqual({ success: true, fileId: 'stored-invoice-file-1' });
+    expect(scheduleInvoiceZipActionMock).not.toHaveBeenCalled();
+  });
+
+  it('falls back to generating one for invoices filed before documents existed', async () => {
+    storedInvoiceDocument = undefined;
+    scheduleInvoiceZipActionMock.mockResolvedValue({ actionError: 'scheduled' });
+
+    const { downloadClientInvoicePdf } = await import('./client-billing');
+    const result = await downloadClientInvoicePdf('invoice-1');
+
+    expect(scheduleInvoiceZipActionMock).toHaveBeenCalledWith(['invoice-1']);
+    expect(result).toEqual({ actionError: 'scheduled' });
+  });
+
+  it('refuses invoices the portal user cannot see before looking for a document', async () => {
+    invoiceRow = undefined;
+
+    const { downloadClientInvoicePdf } = await import('./client-billing');
+    const result = await downloadClientInvoicePdf('invoice-other-client');
+
+    expect(result).toEqual({ actionError: 'Invoice not found or access denied' });
+    expect(scheduleInvoiceZipActionMock).not.toHaveBeenCalled();
+  });
+});

--- a/packages/client-portal/src/actions/client-portal-actions/client-billing.ts
+++ b/packages/client-portal/src/actions/client-portal-actions/client-billing.ts
@@ -761,8 +761,10 @@ export const downloadClientInvoicePdf = withAuth(async (user, { tenant }, invoic
       return accessError;
     }
 
-    // Serve the document that was issued rather than re-rendering it. Invoices
-    // generated before documents were filed fall through to the job below.
+    // Serve the document that was issued rather than re-rendering it — the copy
+    // published to the client first, so a later MSP-side re-render cannot change
+    // what they download. Invoices generated before documents were filed fall
+    // through to the job below.
     const scopedDb = tenantDb(knex, tenant);
     const docQuery = scopedDb.table('document_associations as da')
       .where({
@@ -770,6 +772,7 @@ export const downloadClientInvoicePdf = withAuth(async (user, { tenant }, invoic
         'da.entity_type': 'invoice',
       })
       .whereNotNull('d.file_id')
+      .orderBy('d.is_client_visible', 'desc')
       .orderBy('da.created_at', 'desc')
       .select('d.file_id')
       .first<{ file_id: string } | undefined>();

--- a/packages/client-portal/src/actions/client-portal-actions/client-billing.ts
+++ b/packages/client-portal/src/actions/client-portal-actions/client-billing.ts
@@ -745,7 +745,8 @@ export interface DownloadPdfResult {
 }
 
 /**
- * Download invoice PDF - schedules job, waits for completion, returns file ID
+ * Download invoice PDF - returns the stored PDF when one exists, otherwise
+ * schedules generation, waits for completion, and returns the file ID.
  */
 export const downloadClientInvoicePdf = withAuth(async (user, { tenant }, invoiceId: string): Promise<ClientBillingActionResult<DownloadPdfResult>> => {
   const knex = await getConnection(tenant);
@@ -758,6 +759,25 @@ export const downloadClientInvoicePdf = withAuth(async (user, { tenant }, invoic
 
     if (accessError) {
       return accessError;
+    }
+
+    // Serve the document that was issued rather than re-rendering it. Invoices
+    // generated before documents were filed fall through to the job below.
+    const scopedDb = tenantDb(knex, tenant);
+    const docQuery = scopedDb.table('document_associations as da')
+      .where({
+        'da.entity_id': invoiceId,
+        'da.entity_type': 'invoice',
+      })
+      .whereNotNull('d.file_id')
+      .orderBy('da.created_at', 'desc')
+      .select('d.file_id')
+      .first<{ file_id: string } | undefined>();
+    scopedDb.tenantJoin(docQuery, 'documents as d', 'da.document_id', 'd.document_id');
+    const storedDoc = await docQuery;
+
+    if (storedDoc?.file_id) {
+      return { success: true, fileId: storedDoc.file_id };
     }
 
     // Schedule PDF generation

--- a/packages/documents/src/actions/defaultFolderActions.ts
+++ b/packages/documents/src/actions/defaultFolderActions.ts
@@ -166,6 +166,7 @@ const SUGGESTED_DEFAULTS: ISuggestedDefault[] = [
       { folderPath: '/Clients/Technical', sortOrder: 6, isClientVisible: false },
       { folderPath: '/Clients/Technical/Runbooks', sortOrder: 7, isClientVisible: false },
       { folderPath: '/Clients/Meeting Notes', sortOrder: 8, isClientVisible: true },
+      { folderPath: '/Clients/Sales Orders', sortOrder: 9, isClientVisible: false },
     ],
   },
   {

--- a/packages/documents/src/components/DocumentsPage.tsx
+++ b/packages/documents/src/components/DocumentsPage.tsx
@@ -25,7 +25,7 @@ import HuduDocumentsTab from './HuduDocumentsTab';
 import { useHuduDocumentsTab } from './useHuduDocumentsTab';
 
 const FILTERS_PANE_COLLAPSED_SETTING = 'documents_filters_pane_collapsed';
-const DOCUMENT_FILTER_ENTITY_TYPES = ['client', 'contact', 'ticket', 'asset', 'project_task', 'contract', 'quote'];
+const DOCUMENT_FILTER_ENTITY_TYPES = ['client', 'contact', 'ticket', 'asset', 'project_task', 'contract', 'quote', 'invoice', 'sales_order'];
 
 export default function DocumentsPage() {
   const { t } = useTranslation('common');

--- a/packages/types/src/interfaces/document-association.interface.ts
+++ b/packages/types/src/interfaces/document-association.interface.ts
@@ -1,6 +1,6 @@
 import { TenantEntity } from ".";
 
-export type DocumentAssociationEntityType = 'user' | 'ticket' | 'client' | 'contact' | 'asset' | 'project_task' | 'contract' | 'tenant' | 'quote';
+export type DocumentAssociationEntityType = 'user' | 'ticket' | 'client' | 'contact' | 'asset' | 'project_task' | 'contract' | 'tenant' | 'quote' | 'invoice' | 'sales_order';
 
 export interface IDocumentAssociation extends TenantEntity {
     association_id: string;

--- a/packages/types/src/interfaces/document.interface.ts
+++ b/packages/types/src/interfaces/document.interface.ts
@@ -27,6 +27,11 @@ export interface IDocument extends TenantEntity {
     folder_path?: string;
     is_client_visible?: boolean;
 
+    // Render provenance (generated documents only)
+    source_template_id?: string | null;
+    source_template_version?: number | null;
+    rendered_locale?: string | null;
+
     // Preview/thumbnail system
     thumbnail_file_id?: string;
     preview_file_id?: string;

--- a/server/migrations/20260812090000_add_document_render_provenance.cjs
+++ b/server/migrations/20260812090000_add_document_render_provenance.cjs
@@ -16,6 +16,7 @@ exports.up = async function up(knex) {
 
   const columns = ['source_template_id', 'source_template_version', 'rendered_locale'];
   const existing = await Promise.all(columns.map((c) => knex.schema.hasColumn('documents', c)));
+  if (existing.every(Boolean)) return;
 
   await knex.schema.alterTable('documents', (table) => {
     if (!existing[0]) table.text('source_template_id').nullable();
@@ -33,6 +34,7 @@ exports.down = async function down(knex) {
 
   const columns = ['source_template_id', 'source_template_version', 'rendered_locale'];
   const existing = await Promise.all(columns.map((c) => knex.schema.hasColumn('documents', c)));
+  if (!existing.some(Boolean)) return;
 
   await knex.schema.alterTable('documents', (table) => {
     columns.forEach((column, index) => {

--- a/server/migrations/20260812090000_add_document_render_provenance.cjs
+++ b/server/migrations/20260812090000_add_document_render_provenance.cjs
@@ -1,0 +1,42 @@
+/**
+ * Records how a generated document was rendered: which template produced it and
+ * which locale was resolved at render time. Nullable across the board — only
+ * documents filed by the PDF generation pipeline carry provenance, and existing
+ * rows are deliberately left alone (forward-only).
+ *
+ * source_template_id is text rather than uuid: standard templates are addressed
+ * by code (e.g. 'standard-invoice-by-location'), tenant templates by uuid, and
+ * both must be recordable.
+ *
+ * @param { import("knex").Knex } knex
+ * @returns { Promise<void> }
+ */
+exports.up = async function up(knex) {
+  if (!(await knex.schema.hasTable('documents'))) return;
+
+  const columns = ['source_template_id', 'source_template_version', 'rendered_locale'];
+  const existing = await Promise.all(columns.map((c) => knex.schema.hasColumn('documents', c)));
+
+  await knex.schema.alterTable('documents', (table) => {
+    if (!existing[0]) table.text('source_template_id').nullable();
+    if (!existing[1]) table.integer('source_template_version').nullable();
+    if (!existing[2]) table.text('rendered_locale').nullable();
+  });
+};
+
+/**
+ * @param { import("knex").Knex } knex
+ * @returns { Promise<void> }
+ */
+exports.down = async function down(knex) {
+  if (!(await knex.schema.hasTable('documents'))) return;
+
+  const columns = ['source_template_id', 'source_template_version', 'rendered_locale'];
+  const existing = await Promise.all(columns.map((c) => knex.schema.hasColumn('documents', c)));
+
+  await knex.schema.alterTable('documents', (table) => {
+    columns.forEach((column, index) => {
+      if (existing[index]) table.dropColumn(column);
+    });
+  });
+};

--- a/server/migrations/20260812090100_add_invoice_sales_order_to_document_associations.cjs
+++ b/server/migrations/20260812090100_add_invoice_sales_order_to_document_associations.cjs
@@ -1,0 +1,53 @@
+exports.up = async function up(knex) {
+  await knex.raw(`
+    ALTER TABLE document_associations
+    DROP CONSTRAINT IF EXISTS document_associations_entity_type_check;
+  `);
+
+  await knex.raw(`
+    ALTER TABLE document_associations
+    ADD CONSTRAINT document_associations_entity_type_check
+    CHECK (entity_type IN (
+      'asset',
+      'client',
+      'contact',
+      'contract',
+      'invoice',
+      'project_task',
+      'quote',
+      'sales_order',
+      'team',
+      'tenant',
+      'ticket',
+      'user'
+    )) NOT VALID;
+  `);
+};
+
+exports.down = async function down(knex) {
+  await knex('document_associations').whereIn('entity_type', ['invoice', 'sales_order']).del();
+
+  await knex.raw(`
+    ALTER TABLE document_associations
+    DROP CONSTRAINT IF EXISTS document_associations_entity_type_check;
+  `);
+
+  await knex.raw(`
+    ALTER TABLE document_associations
+    ADD CONSTRAINT document_associations_entity_type_check
+    CHECK (entity_type IN (
+      'asset',
+      'client',
+      'contact',
+      'contract',
+      'project_task',
+      'quote',
+      'team',
+      'tenant',
+      'ticket',
+      'user'
+    )) NOT VALID;
+  `);
+};
+
+exports.config = { transaction: false };

--- a/server/migrations/20260812090200_add_sales_orders_default_folder.cjs
+++ b/server/migrations/20260812090200_add_sales_orders_default_folder.cjs
@@ -1,0 +1,48 @@
+/**
+ * Adds /Clients/Sales Orders to the client default folder structure so generated
+ * Sales Order documents have somewhere to land. Not client-visible: like
+ * invoices, a Sales Order document only reaches the client when it is sent.
+ *
+ * @param { import("knex").Knex } knex
+ * @returns { Promise<void> }
+ */
+const FOLDER_PATH = '/Clients/Sales Orders';
+
+exports.up = async function up(knex) {
+  if (!(await knex.schema.hasTable('document_default_folders'))) return;
+
+  const tenants = await knex('tenants').select('tenant');
+  const now = new Date();
+
+  for (const { tenant } of tenants) {
+    const existing = await knex('document_default_folders')
+      .where({ tenant, entity_type: 'client', folder_path: FOLDER_PATH })
+      .first();
+
+    if (existing) continue;
+
+    await knex('document_default_folders').insert({
+      default_folder_id: knex.raw('gen_random_uuid()'),
+      tenant,
+      entity_type: 'client',
+      folder_path: FOLDER_PATH,
+      folder_name: 'Sales Orders',
+      is_client_visible: false,
+      sort_order: 9,
+      created_at: now,
+      updated_at: now,
+    });
+  }
+};
+
+/**
+ * @param { import("knex").Knex } knex
+ * @returns { Promise<void> }
+ */
+exports.down = async function down(knex) {
+  if (!(await knex.schema.hasTable('document_default_folders'))) return;
+
+  await knex('document_default_folders')
+    .where({ entity_type: 'client', folder_path: FOLDER_PATH })
+    .del();
+};

--- a/server/src/lib/jobs/handlers/invoiceEmailHandler.ts
+++ b/server/src/lib/jobs/handlers/invoiceEmailHandler.ts
@@ -1,5 +1,5 @@
 import { JobService, JobStepResult } from 'server/src/services/job.service';
-import { PDFGenerationService, createPDFGenerationService } from '@alga-psa/billing/services';
+import { PDFGenerationService, createPDFGenerationService, publishGeneratedDocumentsToClient } from '@alga-psa/billing/services';
 import { getEmailService } from 'server/src/services/emailService';
 import { StorageService } from '@alga-psa/storage/StorageService';
 import { getClientById, getContactByContactNameId } from '@alga-psa/clients/actions';
@@ -259,6 +259,16 @@ export class InvoiceEmailHandler {
             if (!success) {
               throw new Error('Failed to send invoice email');
             }
+
+            // The invoice has reached the client, so the filed document may now
+            // be shown in the client portal.
+            await publishGeneratedDocumentsToClient(tenantId, 'invoice', invoiceId).catch((visibilityError) => {
+              logger.warn('[InvoiceEmailHandler] Failed to publish invoice document to client', {
+                tenantId,
+                invoiceId,
+                error: visibilityError instanceof Error ? visibilityError.message : 'Unknown error',
+              });
+            });
 
             const emailCompleteDetails = {
               invoiceId,

--- a/server/src/test/integration/journeys/invoiceRenderToDelivery.journey.integration.test.ts
+++ b/server/src/test/integration/journeys/invoiceRenderToDelivery.journey.integration.test.ts
@@ -31,8 +31,9 @@ import {
 // The filing contract this pins: a generated invoice PDF becomes a real
 // document — filed under /Clients/Invoices, MSP-only until the invoice is sent,
 // associated with both the invoice and its client, carrying the template and
-// locale it was rendered from — and a second generateAndStore call reuses it
-// rather than rendering a second, silently different artifact.
+// locale it was rendered from. Until it is published to the client that one
+// document is refreshed in place; once published it is frozen and handed back,
+// so the copy the client received never changes underneath them.
 
 let db: Knex;
 let tenantId: string;
@@ -371,34 +372,68 @@ describe('journey: invoice render → stored PDF', () => {
       .where({ file_id: fileRecord.file_id });
     expect(foreignScopeRows).toHaveLength(0);
 
-    // Seam 7: a second call reuses the filed document rather than re-rendering.
-    // This is what keeps a client-portal download from drifting away from the
-    // copy that was sent, and what stops storage growing per download.
+    // Seam 7: while the invoice is still MSP-only, generating again refreshes the
+    // one filed document in place. Downloads therefore neither pile up documents
+    // nor leave the filed copy behind the invoice it renders.
     const secondRecord = await pdfService.generateAndStore({
       invoiceId,
       invoiceNumber,
       version: 1,
       userId: journeyUserId,
     });
-    expect(secondRecord.file_id).toBe(fileRecord.file_id);
     expect(secondRecord.document_id).toBe(fileRecord.document_id);
+    expect(secondRecord.file_id).not.toBe(fileRecord.file_id);
 
-    const allStoredRows = await tenantTable(db, tenantId, 'external_files')
-      .where({ tenant: tenantId, original_name: `${invoiceNumber}.pdf` });
-    expect(allStoredRows).toHaveLength(1);
+    const refreshedDocument = await tenantTable(db, tenantId, 'documents')
+      .where({ tenant: tenantId, document_id: fileRecord.document_id })
+      .first();
+    expect(refreshedDocument?.file_id).toBe(secondRecord.file_id);
 
     const allDocumentRows = await tenantTable(db, tenantId, 'documents')
       .where({ tenant: tenantId, document_name: `Invoice_${invoiceNumber}.pdf` });
     expect(allDocumentRows).toHaveLength(1);
 
-    // Reuse renders nothing, so it publishes nothing.
-    const eventsAfterReuse = publishWorkflowEventMock.mock.calls
+    // The superseded render is retired rather than left to accumulate.
+    const liveStoredRows = await tenantTable(db, tenantId, 'external_files')
+      .where({ tenant: tenantId, original_name: `${invoiceNumber}.pdf`, is_deleted: false });
+    expect(liveStoredRows).toHaveLength(1);
+    expect(liveStoredRows[0].file_id).toBe(secondRecord.file_id);
+
+    const supersededRow = await tenantTable(db, tenantId, 'external_files')
+      .where({ tenant: tenantId, file_id: fileRecord.file_id })
+      .first();
+    expect(supersededRow?.is_deleted).toBe(true);
+
+    // A refresh changes the bytes, so the search indexer hears about it again.
+    const eventsAfterRefresh = publishWorkflowEventMock.mock.calls
       .map(([event]) => event as PublishedWorkflowEvent)
       .filter((e) => e.eventType === 'DOCUMENT_GENERATED');
-    expect(eventsAfterReuse).toHaveLength(1);
+    expect(eventsAfterRefresh).toHaveLength(2);
+    expect(eventsAfterRefresh[1].payload.documentId).toBe(fileRecord.document_id);
 
-    // Seam 8: a deliberate re-render is visibly a new document, not a silent
-    // mutation of the one already sent.
+    // Seam 8: once the document has been published to the client — what happens
+    // when the invoice is sent — it is the artifact they received. Generating
+    // again hands the same bytes back rather than re-rendering underneath them.
+    await tenantTable(db, tenantId, 'documents')
+      .where({ tenant: tenantId, document_id: fileRecord.document_id })
+      .update({ is_client_visible: true });
+
+    const issuedRecord = await pdfService.generateAndStore({
+      invoiceId,
+      invoiceNumber,
+      version: 1,
+      userId: journeyUserId,
+    });
+    expect(issuedRecord.document_id).toBe(fileRecord.document_id);
+    expect(issuedRecord.file_id).toBe(secondRecord.file_id);
+
+    const eventsAfterIssuedReuse = publishWorkflowEventMock.mock.calls
+      .map(([event]) => event as PublishedWorkflowEvent)
+      .filter((e) => e.eventType === 'DOCUMENT_GENERATED');
+    expect(eventsAfterIssuedReuse).toHaveLength(2);
+
+    // Seam 9: a deliberate re-render of an issued invoice is visibly a new
+    // document, not a silent mutation of the one already sent.
     const regenerated = await pdfService.generateAndStore({
       invoiceId,
       invoiceNumber,
@@ -406,25 +441,31 @@ describe('journey: invoice render → stored PDF', () => {
       userId: journeyUserId,
       regenerate: true,
     });
-    expect(regenerated.file_id).not.toBe(fileRecord.file_id);
+    expect(regenerated.file_id).not.toBe(secondRecord.file_id);
     expect(regenerated.document_id).not.toBe(fileRecord.document_id);
 
-    const rowsAfterRegenerate = await tenantTable(db, tenantId, 'external_files')
-      .where({ tenant: tenantId, original_name: `${invoiceNumber}.pdf` })
-      .orderBy('created_at', 'asc');
-    expect(rowsAfterRegenerate).toHaveLength(2);
-    expect(rowsAfterRegenerate[0].storage_path).not.toBe(rowsAfterRegenerate[1].storage_path);
+    const issuedDocument = await tenantTable(db, tenantId, 'documents')
+      .where({ tenant: tenantId, document_id: fileRecord.document_id })
+      .first();
+    expect(issuedDocument?.file_id, 'the issued copy is left alone').toBe(secondRecord.file_id);
 
+    const documentsAfterRegenerate = await tenantTable(db, tenantId, 'documents')
+      .where({ tenant: tenantId, document_name: `Invoice_${invoiceNumber}.pdf` });
+    expect(documentsAfterRegenerate).toHaveLength(2);
+
+    const regeneratedStoredRow = await tenantTable(db, tenantId, 'external_files')
+      .where({ tenant: tenantId, file_id: regenerated.file_id })
+      .first();
     const regeneratedBytes = await fs.readFile(
-      path.join(storageBaseDir, String(rowsAfterRegenerate[1].storage_path)),
+      path.join(storageBaseDir, String(regeneratedStoredRow!.storage_path)),
     );
     expect(regeneratedBytes.subarray(0, 5).toString('utf8')).toBe('%PDF-');
 
     const eventsAfterRegenerate = publishWorkflowEventMock.mock.calls
       .map(([event]) => event as PublishedWorkflowEvent)
       .filter((e) => e.eventType === 'DOCUMENT_GENERATED');
-    expect(eventsAfterRegenerate).toHaveLength(2);
-    expect(eventsAfterRegenerate[1].payload).toMatchObject({
+    expect(eventsAfterRegenerate).toHaveLength(3);
+    expect(eventsAfterRegenerate[2].payload).toMatchObject({
       documentId: regenerated.document_id,
       sourceType: 'invoice',
       sourceId: invoiceId,

--- a/server/src/test/integration/journeys/invoiceRenderToDelivery.journey.integration.test.ts
+++ b/server/src/test/integration/journeys/invoiceRenderToDelivery.journey.integration.test.ts
@@ -22,16 +22,17 @@ import {
 // journeys stop short of — a finalized invoice goes through the REAL renderer
 // (createPDFGenerationService → standard-template AST from the migrations →
 // server-rendered HTML → headless Chromium via puppeteer → PDF bytes) and the
-// REAL storage path (LocalStorageProvider → external_files row → the
-// DOCUMENT_GENERATED workflow event that carries the file↔invoice linkage).
-// Nothing in the render/store pipeline is mocked; the only mocked seam is the
+// REAL storage path (LocalStorageProvider → external_files row → documents row
+// + document_associations → the DOCUMENT_GENERATED workflow event). Nothing in
+// the render/store/file pipeline is mocked; the only mocked seam is the
 // event-bus publisher, replaced with a capture so the linkage payload can be
 // asserted instead of disappearing into Redis.
 //
-// What the code does NOT do (asserted as-is, not aspirationally): invoice PDFs
-// never get a `documents`/`document_associations` row — the only DB record is
-// the external_files row, and the only invoice linkage is the event payload
-// (sourceType/sourceId) plus the invoice-number-derived original_name.
+// The filing contract this pins: a generated invoice PDF becomes a real
+// document — filed under /Clients/Invoices, MSP-only until the invoice is sent,
+// associated with both the invoice and its client, carrying the template and
+// locale it was rendered from — and a second generateAndStore call reuses it
+// rather than rendering a second, silently different artifact.
 
 let db: Knex;
 let tenantId: string;
@@ -295,10 +296,8 @@ describe('journey: invoice render → stored PDF', () => {
     expect(preview.html).toContain(invoiceNumber);
 
     // Seam 3: generateAndStore writes the bytes through the real
-    // LocalStorageProvider and records them as a tenant-scoped external_files
-    // row. Note what does NOT happen: no documents row, no
-    // document_associations row — for invoice PDFs the file store IS the
-    // document record.
+    // LocalStorageProvider, records them as a tenant-scoped external_files row,
+    // and files the result as a document.
     const fileRecord = await pdfService.generateAndStore({
       invoiceId,
       invoiceNumber,
@@ -306,6 +305,7 @@ describe('journey: invoice render → stored PDF', () => {
       userId: journeyUserId,
     });
     expect(fileRecord?.file_id, JSON.stringify(fileRecord)).toBeDefined();
+    expect(fileRecord?.document_id, JSON.stringify(fileRecord)).toBeDefined();
 
     const storedRow = await tenantTable(db, tenantId, 'external_files')
       .where({ tenant: tenantId, file_id: fileRecord.file_id })
@@ -325,18 +325,45 @@ describe('journey: invoice render → stored PDF', () => {
     expect(storedBytes.subarray(0, 5).toString('utf8')).toBe('%PDF-');
     expect(storedBytes.length).toBe(Number(storedRow?.file_size));
 
-    // Seam 4: the invoice↔file linkage travels on the DOCUMENT_GENERATED
-    // workflow event (there is no linking table for this path).
+    // Seam 4: the PDF is filed as a document — a real row in the Documents UI,
+    // under /Clients/Invoices, MSP-only until the invoice is sent, and carrying
+    // the template it was rendered from.
+    const documentRow = await tenantTable(db, tenantId, 'documents')
+      .where({ tenant: tenantId, document_id: fileRecord.document_id })
+      .first();
+    expect(documentRow, 'documents row for the generated PDF').toBeTruthy();
+    expect(documentRow?.document_name).toBe(`Invoice_${invoiceNumber}.pdf`);
+    expect(documentRow?.folder_path).toBe('/Clients/Invoices');
+    expect(documentRow?.file_id).toBe(fileRecord.file_id);
+    expect(documentRow?.mime_type).toBe('application/pdf');
+    // Explicit, not inherited: /Clients/Invoices is itself a client-visible
+    // default folder, but a generated-but-unsent invoice stays MSP-only.
+    expect(documentRow?.is_client_visible).toBe(false);
+    expect(documentRow?.source_template_id, 'template provenance').toBeTruthy();
+    expect(documentRow).toHaveProperty('rendered_locale');
+
+    // Seam 5: both associations — the invoice it renders and the client it
+    // belongs to, so it surfaces in the client's Documents tab.
+    const associations = await tenantTable(db, tenantId, 'document_associations')
+      .where({ tenant: tenantId, document_id: fileRecord.document_id })
+      .orderBy('entity_type', 'asc');
+    expect(associations.map((a) => a.entity_type).sort()).toEqual(['client', 'invoice']);
+    expect(associations.find((a) => a.entity_type === 'invoice')?.entity_id).toBe(invoiceId);
+    expect(associations.find((a) => a.entity_type === 'client')?.entity_id).toBe(clientId);
+
+    // Seam 6: the linkage event carries the documents row id (not the file id),
+    // which is what the search indexer looks up.
     const generatedEvents = publishWorkflowEventMock.mock.calls
       .map(([event]) => event as PublishedWorkflowEvent)
       .filter((e) => e.eventType === 'DOCUMENT_GENERATED');
     expect(generatedEvents).toHaveLength(1);
     expect(generatedEvents[0].payload).toMatchObject({
-      documentId: fileRecord.file_id,
+      documentId: fileRecord.document_id,
       sourceType: 'invoice',
       sourceId: invoiceId,
       fileName: `${invoiceNumber}.pdf`,
     });
+    expect(generatedEvents[0].payload.documentId).not.toBe(fileRecord.file_id);
 
     // Tenant scoping: the tenantDb facade cannot see the row from another
     // tenant's scope.
@@ -344,34 +371,61 @@ describe('journey: invoice render → stored PDF', () => {
       .where({ file_id: fileRecord.file_id });
     expect(foreignScopeRows).toHaveLength(0);
 
-    // Seam 5: re-render. The code has no reuse or versioning — every
-    // generateAndStore call renders again and creates a brand-new
-    // external_files row and a brand-new file on disk (the `version` option is
-    // accepted but never read). Asserted as the current behavior.
+    // Seam 7: a second call reuses the filed document rather than re-rendering.
+    // This is what keeps a client-portal download from drifting away from the
+    // copy that was sent, and what stops storage growing per download.
     const secondRecord = await pdfService.generateAndStore({
       invoiceId,
       invoiceNumber,
       version: 1,
       userId: journeyUserId,
     });
-    expect(secondRecord.file_id).not.toBe(fileRecord.file_id);
+    expect(secondRecord.file_id).toBe(fileRecord.file_id);
+    expect(secondRecord.document_id).toBe(fileRecord.document_id);
 
     const allStoredRows = await tenantTable(db, tenantId, 'external_files')
-      .where({ tenant: tenantId, original_name: `${invoiceNumber}.pdf` })
-      .orderBy('created_at', 'asc');
-    expect(allStoredRows).toHaveLength(2);
-    expect(allStoredRows[0].storage_path).not.toBe(allStoredRows[1].storage_path);
+      .where({ tenant: tenantId, original_name: `${invoiceNumber}.pdf` });
+    expect(allStoredRows).toHaveLength(1);
 
-    const secondBytes = await fs.readFile(path.join(storageBaseDir, String(allStoredRows[1].storage_path)));
-    expect(secondBytes.subarray(0, 5).toString('utf8')).toBe('%PDF-');
+    const allDocumentRows = await tenantTable(db, tenantId, 'documents')
+      .where({ tenant: tenantId, document_name: `Invoice_${invoiceNumber}.pdf` });
+    expect(allDocumentRows).toHaveLength(1);
 
-    // Each render publishes its own linkage event.
-    const eventsAfterRerender = publishWorkflowEventMock.mock.calls
+    // Reuse renders nothing, so it publishes nothing.
+    const eventsAfterReuse = publishWorkflowEventMock.mock.calls
       .map(([event]) => event as PublishedWorkflowEvent)
       .filter((e) => e.eventType === 'DOCUMENT_GENERATED');
-    expect(eventsAfterRerender).toHaveLength(2);
-    expect(eventsAfterRerender[1].payload).toMatchObject({
-      documentId: secondRecord.file_id,
+    expect(eventsAfterReuse).toHaveLength(1);
+
+    // Seam 8: a deliberate re-render is visibly a new document, not a silent
+    // mutation of the one already sent.
+    const regenerated = await pdfService.generateAndStore({
+      invoiceId,
+      invoiceNumber,
+      version: 1,
+      userId: journeyUserId,
+      regenerate: true,
+    });
+    expect(regenerated.file_id).not.toBe(fileRecord.file_id);
+    expect(regenerated.document_id).not.toBe(fileRecord.document_id);
+
+    const rowsAfterRegenerate = await tenantTable(db, tenantId, 'external_files')
+      .where({ tenant: tenantId, original_name: `${invoiceNumber}.pdf` })
+      .orderBy('created_at', 'asc');
+    expect(rowsAfterRegenerate).toHaveLength(2);
+    expect(rowsAfterRegenerate[0].storage_path).not.toBe(rowsAfterRegenerate[1].storage_path);
+
+    const regeneratedBytes = await fs.readFile(
+      path.join(storageBaseDir, String(rowsAfterRegenerate[1].storage_path)),
+    );
+    expect(regeneratedBytes.subarray(0, 5).toString('utf8')).toBe('%PDF-');
+
+    const eventsAfterRegenerate = publishWorkflowEventMock.mock.calls
+      .map(([event]) => event as PublishedWorkflowEvent)
+      .filter((e) => e.eventType === 'DOCUMENT_GENERATED');
+    expect(eventsAfterRegenerate).toHaveLength(2);
+    expect(eventsAfterRegenerate[1].payload).toMatchObject({
+      documentId: regenerated.document_id,
       sourceType: 'invoice',
       sourceId: invoiceId,
     });

--- a/server/src/test/unit/jobs/invoiceEmailHandler.test.ts
+++ b/server/src/test/unit/jobs/invoiceEmailHandler.test.ts
@@ -12,6 +12,7 @@ const mocks = vi.hoisted(() => ({
   // PDF generation
   generateAndStore: vi.fn(),
   createPDFGenerationService: vi.fn(),
+  publishGeneratedDocumentsToClient: vi.fn(),
   // Storage
   downloadFile: vi.fn(),
   // Clients
@@ -39,6 +40,7 @@ vi.mock('server/src/services/job.service', () => ({
 
 vi.mock('@alga-psa/billing/services', () => ({
   createPDFGenerationService: mocks.createPDFGenerationService,
+  publishGeneratedDocumentsToClient: mocks.publishGeneratedDocumentsToClient,
   PDFGenerationService: class {},
 }));
 
@@ -145,7 +147,8 @@ describe('InvoiceEmailHandler', () => {
     mocks.sendInvoiceEmail.mockResolvedValue(true);
 
     mocks.createPDFGenerationService.mockReturnValue({ generateAndStore: mocks.generateAndStore });
-    mocks.generateAndStore.mockResolvedValue({ file_id: 'file-1' });
+    mocks.generateAndStore.mockResolvedValue({ file_id: 'file-1', document_id: 'doc-1' });
+    mocks.publishGeneratedDocumentsToClient.mockResolvedValue(1);
 
     mocks.downloadFile.mockResolvedValue({ buffer: Buffer.from('%PDF-1.4 test') });
     mocks.writeFile.mockResolvedValue(undefined);
@@ -231,6 +234,30 @@ describe('InvoiceEmailHandler', () => {
       expect(finalStatusCall[0]).toBe('job-service-1');
       expect(finalStatusCall[1]).toBe(JobStatus.Completed);
       expect(mocks.updateJobStatus).not.toHaveBeenCalledWith('job-service-1', JobStatus.Failed, expect.anything());
+    });
+
+    it('should attach the stored document and publish it to the client only after a successful send', async () => {
+      await InvoiceEmailHandler.handle('pg-1', buildJobData());
+
+      // One render per send: generateAndStore reuses the filed document.
+      expect(mocks.generateAndStore).toHaveBeenCalledTimes(1);
+      expect(mocks.generateAndStore.mock.calls[0][0]).not.toHaveProperty('regenerate', true);
+      expect(mocks.downloadFile).toHaveBeenCalledWith('file-1');
+
+      expect(mocks.publishGeneratedDocumentsToClient).toHaveBeenCalledWith(TENANT, 'invoice', 'invoice-1');
+      const publishOrder = mocks.publishGeneratedDocumentsToClient.mock.invocationCallOrder[0];
+      const sendOrder = mocks.sendInvoiceEmail.mock.invocationCallOrder[0];
+      expect(publishOrder).toBeGreaterThan(sendOrder);
+    });
+
+    it('should leave the generated document MSP-only when the send fails', async () => {
+      mocks.sendInvoiceEmail.mockResolvedValue(false);
+
+      await expect(InvoiceEmailHandler.handle('pg-1', buildJobData())).rejects.toThrow(
+        'Failed to send invoice email',
+      );
+
+      expect(mocks.publishGeneratedDocumentsToClient).not.toHaveBeenCalled();
     });
 
     it('should prefer the billing contact email over location and billing emails', async () => {


### PR DESCRIPTION
## Summary

Generated invoice and sales order PDFs are now filed as `documents` rows (with `document_associations` to the source entity and, where applicable, the client) instead of existing only as ephemeral renders. Invoices and sales orders follow a "refresh until issued" model: while a document is MSP-only it is re-rendered in place on each generation, and once it has been sent to the client it is frozen and reused so the biller's download, the emailed copy, and the client-portal copy are always the same artifact. Quotes keep their existing "one document per send" behavior, now implemented through the same filing path in `PDFGenerationService`. Filed documents also record render provenance (source template id/version, resolved locale) so a stored PDF can be checked against the template it was asked for and refreshed when it's stale.

## Changes

**Schema**
- Add `documents.source_template_id` / `source_template_version` / `rendered_locale` (nullable, forward-only) to record render provenance.
- Allow `invoice` and `sales_order` in the `document_associations` entity-type check constraint.
- Add `/Clients/Sales Orders` to the default client folder structure (CE migration + EE onboarding seed), MSP-only like invoices.

**PDF generation / filing (`packages/billing`)**
- `PDFGenerationService.generateAndStore` now resolves a `FilingTarget` per entity (invoice/sales order use `refresh` mode; quotes use `append` mode), reuses an already-issued document when it matches the requested template, otherwise renders and files a document under an advisory lock keyed per entity to avoid duplicate filings from concurrent generations.
- New `publishGeneratedDocumentsToClient(tenant, sourceType, entityId)` flips a filed document's associations to client-visible once the invoice/SO has actually been sent.
- Document-template resolution (`resolution.ts`, `storage.ts`, `templateSelection.ts`) now threads through template id/version alongside the AST so filed documents can record what produced them.
- A filing failure is logged and swallowed rather than surfaced — the stored PDF itself is still usable for download/email even if filing fails; a superseded working copy's underlying file is soft-deleted after a successful refresh.

**Invoice actions**
- `downloadInvoicePDF` now files/reuses the stored document via `generateAndStore` and streams its bytes (falling back to a plain render if filing fails).
- `sendInvoiceEmailAction` and `InvoiceEmailHandler` call `publishGeneratedDocumentsToClient` after a successful send.
- Client portal `downloadClientInvoicePdf` now serves the already-issued filed document directly when one exists, only falling back to the async PDF-zip job for invoices generated before filing existed.

**Sales order actions**
- `downloadSalesOrderPDF` and `emailSalesOrderConfirmation` route through a shared `renderStoredSalesOrderPdf` helper (file/reuse + stream, fallback to unfiled render on failure).
- `emailSalesOrderConfirmation` publishes the filed confirmation to the client portal on successful send.

**Quotes**
- `storeQuotePdf` now delegates document creation to `PDFGenerationService` instead of building the `documents`/`document_associations` rows itself.

**Documents UI/types**
- `DocumentsPage` type filter includes `invoice` and `sales_order`.
- `DocumentAssociationEntityType` and `IDocument` updated accordingly.

## Testing
- `packages/billing/tests/generatedDocumentFiling.test.ts` (new) — filing/refresh/append behavior, template-match reuse, concurrent-render locking, client-visibility publishing.
- `packages/billing/tests/invoiceDownloadFiling.test.ts` (new) and `client-billing.invoicePdf.test.ts` (new) — download paths serve stored/filed documents with fallback on filing failure.
- Updated `quoteActions.test.ts`, `quotePdfGenerationService.test.ts`, `invoiceEmailHandler.test.ts`, and the `invoiceRenderToDelivery` integration journey test for the new filing/publish flow.
