### PR TITLE
29.8.22 — Deferred-revenue / prepaid liability reporting

### DIFF
--- a/docs/plans/2026-08-11-deferred-revenue-reporting-plan.md
+++ b/docs/plans/2026-08-11-deferred-revenue-reporting-plan.md
@@ -1,0 +1,204 @@
+# Deferred revenue / prepaid liability reporting plan
+
+Card 29.8.22 (Alga project task 721fbc5d-b781-4966-8194-5a0c42e1bd42).
+
+## Problem
+
+MSPs that collect money before delivering service carry a liability: client credit
+balances (prepayment invoices, credit notes, manual grants) and unburned prepaid
+bucket hours. There is no rollup answering "what is our total outstanding prepaid
+liability across clients?" for month-end close. Credit *applications* sync to QBO as
+zero-dollar payments (`creditApplicationApplier`), but credits sourced from
+prepayment invoices are explicitly non-syncable (`resolveNonCreditMemoSource` raises
+an export error for them), so Alga is the sole system of record for exactly this
+liability. Accountants currently have nothing to tie out at close.
+
+## Goals
+
+- A per-client, per-month liability rollforward: opening balance, movement during
+  the month (issued / applied / expired / adjustments), closing balance — split into
+  a credits component and a prepaid-hours component, with a tenant-level total.
+- Value unburned bucket minutes pro-rata against the fee actually billed for the
+  bucket period, so the hours liability never exceeds cash received and ties to
+  invoices.
+- Per-client drill-down detail sufficient to prove any number: individual credits
+  (remaining amount, expiration, source — flagging prepayment-sourced credits that
+  never reach QBO) and individual bucket lines (remaining minutes, period, value).
+- CSV download of the rollforward plus a printable view.
+- All new UI gated behind the `release-v1.5-feature` feature flag; flag off
+  preserves existing UI and behavior exactly.
+
+## Non-goals
+
+- No FX conversion: amounts are grouped and totaled per `currency_code`, never
+  summed across currencies.
+- No persisted snapshot tables and no schema migrations — every number is derived
+  live from the existing ledgers.
+- No QBO journal-entry export or sync changes; the report only *annotates* sync
+  reachability.
+- No client-portal exposure; internal MSP users only.
+- No change to credit or bucket mechanics (issuance, application, expiration,
+  rollover).
+
+## Settled design decisions
+
+1. **Scope: both components.** Credits and prepaid hours from v1.
+2. **Hours valuation: pro-rata of the billed fee.** An unburned minute is worth
+   `period fee ÷ included minutes`. Not the effective service rate (would overstate
+   liability vs cash received) and not `overage_rate` (semantically the price of
+   hours *beyond* the bucket).
+3. **Time model: month rollforward.** A month picker; the report reconstructs any
+   historical month from the ledgers.
+4. **Placement: reports hub.** New page `/msp/reports/deferred-revenue` plus a card
+   in the `/msp/reports` catalog (billing category). Not a billing-dashboard tab.
+5. **Export: CSV + print.** Client-side CSV blob download of the per-client
+   rollforward; `PrintButton`/`PrintableTable` for the print view.
+6. **Drill-down: expandable client rows.** Component-level detail inline, no
+   separate per-client page.
+
+### Stated assumptions (decidable without further product input)
+
+- **Consumption basis** for hours: mid-period remaining minutes count as liability
+  even on non-rollover buckets (the card's "unburned prepaid hours valued at rate").
+  Forfeiture is recognized only when a period actually ends.
+- Rolled-over minutes are valued at the *current* period's per-minute rate (rollover
+  carries at most one period, so drift is bounded and the simplification is
+  defensible).
+- Credit `credit_adjustment` and `credit_transfer` transactions appear in a single
+  "adjustments" movement column (transfers net to zero at tenant level but move
+  liability between clients).
+- Zero-balance clients (no credits, no active buckets, no movement in the month) are
+  omitted from the table.
+
+## Data layer
+
+New hand-written server action module in
+`packages/reporting/src/actions/report-actions/` (the pattern the shipped report UIs
+use; the declarative `ReportDefinition` framework cannot express a ledger
+rollforward). One entry action, e.g. `getDeferredRevenueReport({ month })`, plus a
+detail action for the expanded row if payload size warrants splitting. Follow the
+existing report-action conventions (auth: internal user + permission check, error
+shapes from `reportingActionErrors.ts`).
+
+### Credits rollforward (per client, per currency)
+
+Source: the `transactions` ledger joined to `credit_tracking`. Movement mapping for
+month M:
+
+| Column | Transaction types |
+|---|---|
+| Issued | `credit_issuance`, `credit_issuance_from_negative_invoice`, `prepayment` issuance rows |
+| Applied | `credit_application` |
+| Expired | `credit_expiration` |
+| Adjustments | `credit_adjustment`, `credit_transfer` |
+
+Opening = signed sum of all credit-affecting transactions dated before the start of
+M; Closing = Opening + month movement. The implementer must verify the sign
+conventions of each type against `creditActions.ts` / `expiredCreditsHandler.ts`
+rather than assuming.
+
+**Tie-out invariant:** for the current month, per-client Closing must equal
+`availableCreditByClientQuery` from `packages/billing/src/lib/creditBalance.ts`.
+Enforced in tests, and cheap enough to assert at runtime in dev.
+
+### Hours rollforward (per client, per contract line)
+
+Sources: `bucket_usage` period rows, `contract_line_service_bucket_config`
+(`total_minutes`, `allow_rollover`), and `computeBucketPeriodState()` from
+`packages/billing/src/lib/billing/compute/computeBucketCharges.ts` for
+remaining-quantity semantics.
+
+**Period fee** (the valuation numerator), in order of preference:
+
+1. The billed invoice item for that bucket line and service period: `invoice_items`
+   joined through `invoice_item_details.config_id` to the bucket line's
+   `contract_line_service_configuration`, on a finalized invoice covering the
+   period.
+2. If not yet billed, the configured base fee for the line via the billing engine's
+   rate-resolution order (custom_rate → pricing schedule → catalog default), clearly
+   marked in the detail row as "not yet billed".
+
+Per-minute rate = period fee ÷ (included minutes). Rollover minutes add to remaining
+quantity but not to the denominator.
+
+Movement for month M:
+
+- **Issued** — value of allowances for bucket periods *starting* in M (their period
+  fee).
+- **Applied (burned)** — minutes consumed during M × per-minute rate. For periods
+  fully inside M (the default monthly cadence) this is the period's `minutes_used`.
+  For periods spanning month boundaries, derive in-month burn from the same dated
+  sources `reconcileBucketUsageHandler` uses (time entries / usage records dated in
+  M for that line+service).
+- **Expired** — at each period end inside M: unused minutes that do not roll
+  (non-rollover buckets), plus rollover minutes that lapse because rollover does not
+  compound. Valued at that period's per-minute rate.
+- **Opening / Closing** — remaining quantity valued as of the month boundaries.
+
+Cap applied-value so a period's recognized revenue never exceeds its fee (overage
+minutes are billed separately as overage and are not part of the prepaid liability).
+
+### Report payload shape
+
+Per client: `{ clientId, clientName, currencyCode, credits: {opening, issued,
+applied, expired, adjustments, closing}, hours: {opening, issued, applied, expired,
+closing}, total: {...} }` plus lazy/expanded detail: credit rows (from
+`credit_tracking` + source classification per `classifyInvoiceCreditHandling` /
+`resolveNonCreditMemoSource` logic — flag `qboReachable: false` for
+prepayment-sourced and project-deposit credits) and bucket rows (line, service,
+period, included/rollover/used/remaining minutes, per-minute rate, value, fee
+source).
+
+## UI
+
+- **Page:** `server/src/app/msp/reports/deferred-revenue/page.tsx` — server
+  component that checks `featureFlags.isEnabled('release-v1.5-feature', …)` and the
+  user's permission; flag off → `notFound()`. Renders a client component from
+  `packages/reporting/src/components/deferred-revenue/`.
+- **Hub card:** add a `billing`-category entry to the `REPORTS` catalog in
+  `packages/msp-composition/src/reports/Reports.tsx` (`kind: 'link'`, href to the
+  new page), rendered only when the `release-v1.5-feature` flag is on
+  (`useFeatureFlag`, `defaultValue: false`).
+- **Report component:** month picker (default: previous month — the close month);
+  summary stat row (total liability per currency, split credits vs hours, delta vs
+  prior month); per-client table with movement columns and expandable detail rows;
+  CSV download button (client-side blob of the flat rollforward, one row per
+  client×currency, plus component columns); `PrintButton` + `PrintableTable`
+  print view. Follow the dataviz/UI conventions of the existing report components in
+  `packages/billing/src/components/billing-dashboard/reports/`.
+- **Permissions:** internal users only, gated on the same permission resource the
+  billing reports use (`hasPermission` with the `report` resource, mirroring
+  `executeReport.ts`); server action enforces it independently of the page.
+
+## Implementation steps
+
+1. Build the credits rollforward query + unit tests against seeded
+   `transactions`/`credit_tracking` fixtures, including the `creditBalance.ts`
+   tie-out invariant and sign-convention coverage for every transaction type.
+2. Build the hours rollforward: period-fee resolution (billed → configured
+   fallback), per-minute valuation, issued/burned/expired/boundary math + unit tests
+   covering rollover, non-rollover forfeiture, mid-period month boundaries, and the
+   fee cap.
+3. Compose `getDeferredRevenueReport` (merge components per client×currency, tenant
+   totals) with permission enforcement and error shapes.
+4. Build the report component: month picker, summary row, rollforward table,
+   expandable detail, CSV download, print view.
+5. Add the page route with server-side flag + permission gate, and the flag-gated
+   reports-hub card.
+6. Integration test (database-backed, per `integration-testing` conventions): seed a
+   tenant with a prepayment credit, an applied credit, an expired credit, a monthly
+   bucket with partial burn, and a rollover bucket spanning a month boundary; assert
+   the rollforward for two consecutive months and that closing(M) = opening(M+1).
+7. Verify flag-off behavior: no hub card, page 404s, no other UI affected.
+
+## Risks
+
+- **Sign conventions in `transactions`** are the likeliest source of silent error;
+  the tie-out invariant against `creditBalance.ts` is the guard.
+- **In-month burn for multi-month periods** is the hairiest derivation; if the dated
+  sources prove unreliable, the acceptable v1 fallback is attributing a spanning
+  period's burn to the month the period ends in, disclosed in the plan/PR.
+- **Fee lookup via `invoice_item_details`** depends on charge linkage recently
+  reworked (invoice-charge-linkage plan, 2026-08-08); the implementer should confirm
+  the join path against a real generated invoice in the dev stack before building on
+  it.

--- a/packages/core/src/lib/i18n/config.ts
+++ b/packages/core/src/lib/i18n/config.ts
@@ -187,6 +187,7 @@ export const ROUTE_NAMESPACES = {
   '/msp/tickets': ['common', 'msp/core', 'features/tickets'],
   '/msp/projects': ['common', 'msp/core', 'features/projects'],
   '/msp/billing/credits': ['common', 'msp/core', 'features/billing', 'msp/credits'],
+  '/msp/reports': ['common', 'msp/core', 'msp/reports'],
   '/msp/billing': ['common', 'msp/core', 'features/billing', 'msp/quotes', 'msp/reports', 'msp/billing', 'msp/contract-lines', 'msp/contracts', 'msp/invoicing'],
   '/msp/quote-approvals': ['common', 'msp/core', 'features/billing', 'msp/quotes'],
   '/msp/quote-document-templates': ['common', 'msp/core', 'features/billing', 'msp/quotes'],

--- a/packages/msp-composition/src/reports/DeferredRevenueReport.expansion.test.tsx
+++ b/packages/msp-composition/src/reports/DeferredRevenueReport.expansion.test.tsx
@@ -1,0 +1,255 @@
+// @vitest-environment jsdom
+
+import React from 'react';
+import { cleanup, render, screen, within } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import type {
+  DeferredRevenueReport as DeferredRevenueReportPayload,
+  CreditDetailRow,
+} from '@alga-psa/reporting/actions/report-actions/getDeferredRevenueReport';
+const getDeferredRevenueReport = vi.fn();
+
+// Stable stubs so the report effect (keyed on `t`) does not re-fetch on every
+// render — the employeeUtilization render test uses the same echo-id pattern.
+const stubT = (_key: string, options?: { defaultValue?: string }) => options?.defaultValue ?? _key;
+const stubFormatCurrency = (value: number, currency: string) => `${currency} ${value.toFixed(2)}`;
+
+// The server-suite setup stubs this hook with empty automationIdProps, which
+// strips DOM ids off UI Buttons — echo ids back with a local stub (same
+// pattern as Reports.employeeUtilization.render.test.tsx).
+vi.mock('@alga-psa/ui/ui-reflection/useAutomationIdAndRegister', () => ({
+  useAutomationIdAndRegister: (params?: { id?: string }) => ({
+    automationIdProps: params?.id
+      ? { id: params.id, 'data-automation-id': params.id }
+      : {},
+    updateMetadata: vi.fn(),
+  }),
+}));
+
+vi.mock('@alga-psa/ui/lib/i18n/client', () => ({
+  useTranslation: () => ({ t: stubT }),
+  useFormatters: () => ({ formatCurrency: stubFormatCurrency }),
+}));
+
+vi.mock('@alga-psa/reporting/actions/report-actions/getDeferredRevenueReport', () => ({
+  getDeferredRevenueReport: (...args: unknown[]) => getDeferredRevenueReport(...args),
+}));
+
+const { default: DeferredRevenueReport } = await import(
+  '@alga-psa/reporting/components/deferred-revenue/DeferredRevenueReport'
+);
+
+function movement(over: Partial<DeferredRevenueReportPayload['sections'][number]['clients'][number]['credits']> = {}) {
+  return {
+    opening: 0,
+    issued: 0,
+    applied: 0,
+    expired: 0,
+    adjustments: 0,
+    closing: 0,
+    ...over,
+  };
+}
+
+function creditDetail(
+  over: Partial<Omit<CreditDetailRow, 'sourceKind'>> & { sourceKind?: CreditDetailRow['sourceKind'] } = {},
+): CreditDetailRow {
+  return {
+    creditId: 'credit-1',
+    transactionId: 'txn-1',
+    clientId: 'client-1',
+    issuedDate: '2026-06-15T10:00:00.000Z',
+    description: 'Prepayment',
+    amount: 5000,
+    remainingAmount: 5000,
+    expirationDate: null,
+    isExpired: false,
+    sourceKind: 'prepayment',
+    qboReachable: false,
+    invoiceNumber: 'PP-1',
+    currencyCode: 'USD',
+    ...over,
+  };
+}
+
+function clientRow(over: Partial<DeferredRevenueReportPayload['sections'][number]['clients'][number]> & {
+  clientId: string;
+  clientName: string;
+}) {
+  const base = {
+    clientId: over.clientId,
+    clientName: over.clientName,
+    currencyCode: 'USD',
+    credits: movement(),
+    hours: movement(),
+    total: movement(),
+    creditDetails: [] as DeferredRevenueReportPayload['sections'][number]['clients'][number]['creditDetails'],
+    bucketDetails: [] as DeferredRevenueReportPayload['sections'][number]['clients'][number]['bucketDetails'],
+  };
+  const merged = { ...base, ...over, clientId: over.clientId, clientName: over.clientName };
+  if (over.credits) merged.credits = over.credits;
+  if (over.hours) merged.hours = over.hours;
+  if (over.total) merged.total = over.total;
+  if (over.creditDetails) merged.creditDetails = over.creditDetails;
+  if (over.bucketDetails) merged.bucketDetails = over.bucketDetails;
+  return merged;
+}
+
+function section(sectionOver: {
+  currencyCode: string;
+  clients: DeferredRevenueReportPayload['sections'][number]['clients'];
+}): DeferredRevenueReportPayload['sections'][number] {
+  const credits = { opening: 0, issued: 0, applied: 0, expired: 0, adjustments: 0, closing: 0 };
+  const hours = { ...credits };
+  const total = { ...credits };
+  for (const client of sectionOver.clients) {
+    for (const key of ['opening', 'issued', 'applied', 'expired', 'adjustments', 'closing'] as const) {
+      credits[key] += client.credits[key];
+      hours[key] += client.hours[key];
+      total[key] += client.total[key];
+    }
+  }
+  return { currencyCode: sectionOver.currencyCode, totals: { credits, hours, total }, clients: sectionOver.clients };
+}
+
+function reportPayload(
+  sections: DeferredRevenueReportPayload['sections'],
+): DeferredRevenueReportPayload {
+  return {
+    month: '2026-07',
+    generatedAt: '2026-08-11T00:00:00.000Z',
+    sections,
+    notes: [],
+  };
+}
+
+afterEach(() => {
+  cleanup();
+  getDeferredRevenueReport.mockReset();
+});
+
+describe('DeferredRevenueReport expansion toggle', () => {
+  it('expands only the clicked client row and collapses it on a second click', async () => {
+    getDeferredRevenueReport.mockResolvedValue(
+      reportPayload([
+        section({
+          currencyCode: 'USD',
+          clients: [
+            clientRow({
+              clientId: 'client-acme',
+              clientName: 'Acme Corp',
+              credits: movement({ issued: 5000, closing: 5000 }),
+              total: movement({ issued: 5000, closing: 5000 }),
+              creditDetails: [
+                creditDetail({
+                  creditId: 'credit-acme',
+                  transactionId: 'txn-acme',
+                  clientId: 'client-acme',
+                  description: 'Acme prepayment credit',
+                  remainingAmount: 5000,
+                }),
+              ],
+            }),
+            clientRow({
+              clientId: 'client-globex',
+              clientName: 'Globex Inc',
+              credits: movement({ issued: 3000, closing: 3000 }),
+              total: movement({ issued: 3000, closing: 3000 }),
+              creditDetails: [
+                creditDetail({
+                  creditId: 'credit-globex',
+                  transactionId: 'txn-globex',
+                  clientId: 'client-globex',
+                  description: 'Globex prepayment credit',
+                  remainingAmount: 3000,
+                }),
+              ],
+            }),
+          ],
+        }),
+      ]),
+    );
+
+    render(<DeferredRevenueReport />);
+
+    // The client name appears both in the rollforward table and the print view.
+    expect((await screen.findAllByText('Acme Corp')).length).toBeGreaterThan(0);
+    expect(screen.queryByText('Acme prepayment credit')).toBeNull();
+    expect(screen.queryByText('Globex prepayment credit')).toBeNull();
+
+    await userEvent.click(screen.getAllByText('Acme Corp')[0]);
+    expect(screen.getByText('Acme prepayment credit')).toBeTruthy();
+    expect(screen.queryByText('Globex prepayment credit')).toBeNull();
+
+    await userEvent.click(screen.getAllByText('Acme Corp')[0]);
+    expect(screen.queryByText('Acme prepayment credit')).toBeNull();
+    expect(screen.queryByText('Globex prepayment credit')).toBeNull();
+  });
+
+  it('keys expansion per client×currency so one currency row does not expand the other', async () => {
+    getDeferredRevenueReport.mockResolvedValue(
+      reportPayload([
+        section({
+          currencyCode: 'USD',
+          clients: [
+            clientRow({
+              clientId: 'client-acme',
+              clientName: 'Acme Corp',
+              credits: movement({ issued: 5000, closing: 5000 }),
+              total: movement({ issued: 5000, closing: 5000 }),
+              creditDetails: [
+                creditDetail({
+                  creditId: 'credit-acme-usd',
+                  clientId: 'client-acme',
+                  description: 'USD prepayment credit',
+                  remainingAmount: 5000,
+                }),
+              ],
+            }),
+          ],
+        }),
+        section({
+          currencyCode: 'EUR',
+          clients: [
+            clientRow({
+              clientId: 'client-acme',
+              clientName: 'Acme Corp',
+              currencyCode: 'EUR',
+              credits: movement({ issued: 2000, closing: 2000 }),
+              total: movement({ issued: 2000, closing: 2000 }),
+              creditDetails: [
+                creditDetail({
+                  creditId: 'credit-acme-eur',
+                  clientId: 'client-acme',
+                  currencyCode: 'EUR',
+                  description: 'EUR prepayment credit',
+                  remainingAmount: 2000,
+                }),
+              ],
+            }),
+          ],
+        }),
+      ]),
+    );
+
+    render(<DeferredRevenueReport />);
+
+    // The client name appears both in the rollforward table and the print view.
+    expect((await screen.findAllByText('Acme Corp')).length).toBeGreaterThan(0);
+    expect(screen.queryByText('USD prepayment credit')).toBeNull();
+    expect(screen.queryByText('EUR prepayment credit')).toBeNull();
+
+    await userEvent.click(within(screen.getByLabelText('USD rollforward')).getByText('Acme Corp'));
+    expect(screen.getByText('USD prepayment credit')).toBeTruthy();
+    expect(screen.queryByText('EUR prepayment credit')).toBeNull();
+
+    await userEvent.click(within(screen.getByLabelText('EUR rollforward')).getByText('Acme Corp'));
+    expect(screen.getByText('USD prepayment credit')).toBeTruthy();
+    expect(screen.getByText('EUR prepayment credit')).toBeTruthy();
+
+    await userEvent.click(within(screen.getByLabelText('USD rollforward')).getByText('Acme Corp'));
+    expect(screen.queryByText('USD prepayment credit')).toBeNull();
+    expect(screen.getByText('EUR prepayment credit')).toBeTruthy();
+  });
+});

--- a/packages/msp-composition/src/reports/DeferredRevenueReport.expansion.test.tsx
+++ b/packages/msp-composition/src/reports/DeferredRevenueReport.expansion.test.tsx
@@ -63,6 +63,8 @@ function creditDetail(
     description: 'Prepayment',
     amount: 5000,
     remainingAmount: 5000,
+    inMonthMovement: 0,
+    reconstructionLimited: false,
     expirationDate: null,
     isExpired: false,
     sourceKind: 'prepayment',

--- a/packages/msp-composition/src/reports/Reports.employeeUtilization.render.test.tsx
+++ b/packages/msp-composition/src/reports/Reports.employeeUtilization.render.test.tsx
@@ -41,6 +41,13 @@ vi.mock('@alga-psa/reporting/actions/helpdeskReportActions', () => ({
   getTimeUtilizationReport: vi.fn(() => new Promise(() => {})),
 }));
 
+// The reports catalog gates the deferred-revenue card behind the
+// `release-v1.5-feature` flag (defaultValue: false). Stub the hook so the
+// catalog renders deterministically without a SessionProvider/PostHog.
+vi.mock('@alga-psa/ui/hooks/useFeatureFlag', () => ({
+  useFeatureFlag: () => ({ enabled: false, loading: false, error: null }),
+}));
+
 const { default: Reports } = await import('./Reports');
 
 function reportWith(byUser: any[], summary: Partial<Record<string, unknown>> = {}) {

--- a/packages/msp-composition/src/reports/Reports.tsx
+++ b/packages/msp-composition/src/reports/Reports.tsx
@@ -9,6 +9,7 @@ import {
   FileBarChart,
   Gauge,
   Ghost,
+  HandCoins,
   Lock,
   type LucideIcon,
   Mail,
@@ -29,6 +30,7 @@ import { Card, CardContent, CardHeader, CardTitle } from '@alga-psa/ui/component
 import { PrintButton } from '@alga-psa/ui/components/PrintButton';
 import { PrintableTable, type PrintableTableColumn } from '@alga-psa/ui/components/PrintableTable';
 import { Skeleton } from '@alga-psa/ui/components/Skeleton';
+import { useFeatureFlag } from '@alga-psa/ui/hooks/useFeatureFlag';
 import {
   getErrorMessage,
   isActionMessageError,
@@ -55,7 +57,7 @@ import {
 type ReportCategory = 'helpdesk' | 'operations' | 'billing' | 'inventory';
 type ReportKind = 'embedded' | 'link' | 'planned';
 type EmbeddedReportId = 'ticket-workload' | 'ticket-aging' | 'email-channel-health' | 'time-utilization' | 'team-performance' | 'employee-utilization';
-type LinkReportId = 'contract-reports' | 'inventory-margin' | 'inventory-write-offs' | 'inventory-ghost-usage';
+type LinkReportId = 'contract-reports' | 'deferred-revenue' | 'inventory-margin' | 'inventory-write-offs' | 'inventory-ghost-usage';
 
 interface ReportDefinition {
   id: EmbeddedReportId | LinkReportId;
@@ -167,6 +169,21 @@ const REPORTS: ReportDefinition[] = [
     kind: 'link',
     href: '/msp/billing?tab=reports',
     icon: FileBarChart,
+  },
+  {
+    id: 'deferred-revenue',
+    titleKey: 'reportsPage.reportCatalog.deferredRevenue.title',
+    titleDefault: 'Deferred Revenue',
+    descriptionKey: 'reportsPage.reportCatalog.deferredRevenue.description',
+    descriptionDefault: 'Prepaid liability across clients: credit balances and unburned bucket hours by month.',
+    category: 'billing',
+    products: ['psa'],
+    minimumTier: 'pro',
+    kind: 'link',
+    href: '/msp/reports/deferred-revenue',
+    openLabelKey: 'reportsPage.actions.openReport',
+    openLabelDefault: 'Open report',
+    icon: HandCoins,
   },
   {
     id: 'inventory-margin',
@@ -1150,10 +1167,16 @@ export default function Reports({ productCode = 'psa', tier = 'pro' }: ReportsPr
   const { t } = useTranslation('msp/reports');
   const [selectedReportId, setSelectedReportId] = useState<EmbeddedReportId>('ticket-workload');
   const [rangeDays, setRangeDays] = useState<ReportRangeDays>(30);
+  const { enabled: deferredRevenueEnabled } = useFeatureFlag('release-v1.5-feature', { defaultValue: false });
 
   const visibleReports = useMemo(
-    () => REPORTS.filter((report) => report.products.includes(productCode)),
-    [productCode],
+    () =>
+      REPORTS.filter(
+        (report) =>
+          report.products.includes(productCode) &&
+          (report.id !== 'deferred-revenue' || deferredRevenueEnabled),
+      ),
+    [productCode, deferredRevenueEnabled],
   );
 
   const selectedReport = visibleReports.find((report) => report.id === selectedReportId);

--- a/packages/reporting/src/actions/report-actions/deferred-revenue/compose.test.ts
+++ b/packages/reporting/src/actions/report-actions/deferred-revenue/compose.test.ts
@@ -177,4 +177,44 @@ describe('buildDeferredRevenueReportFromData', () => {
     );
     expect(report.sections).toHaveLength(0);
   });
+
+  it('omits a client whose only bucket periods do not contribute to the selected month (Defect 1)', () => {
+    // Both of client-1's periods sit outside February: one fully burned in the
+    // past, one starting in the future. Neither carries liability into the
+    // month, so no detail rows are emitted and the client is absent from the
+    // report even though its only periods would previously have surfaced rows.
+    const report = buildDeferredRevenueReportFromData(
+      makeData({
+        creditTransactions: [],
+        creditTracking: [],
+        bucketPeriods: [
+          { ...bucketPeriods[0], usageId: 'usage-past', periodStart: '2025-12-01', periodEnd: '2025-12-31', minutesUsed: 6000 },
+          { ...bucketPeriods[0], usageId: 'usage-future', periodStart: '2026-03-01', periodEnd: '2026-03-31', minutesUsed: 0 },
+        ],
+      }),
+      '2026-02',
+    );
+    expect(report.sections).toHaveLength(0);
+  });
+
+  it('retains a client whose carried-in bucket opens the selected month even with no movement (Defect 1)', () => {
+    // client-1 holds a February period that opens carrying a January rollover
+    // (nonzero opening) with no in-month burn — a contributor that must stay.
+    const report = buildDeferredRevenueReportFromData(
+      makeData({
+        creditTransactions: [],
+        creditTracking: [],
+        bucketPeriods: [
+          { ...bucketPeriods[0], rolledOverMinutes: 1200, minutesUsed: 0, allowRollover: true },
+        ],
+      }),
+      '2026-02',
+    );
+    const usd = report.sections.find((section) => section.currencyCode === 'USD');
+    expect(usd).toBeDefined();
+    const acme = usd!.clients.find((client) => client.clientName === 'Acme');
+    expect(acme).toBeDefined();
+    expect(acme!.hours.opening).toBe(1200 * (100000 / 6000));
+    expect(acme!.bucketDetails).toHaveLength(1);
+  });
 });

--- a/packages/reporting/src/actions/report-actions/deferred-revenue/compose.test.ts
+++ b/packages/reporting/src/actions/report-actions/deferred-revenue/compose.test.ts
@@ -24,6 +24,12 @@ const creditTransactions: CreditTransactionRow[] = [
     type: 'credit_application',
     amount: -200000,
     createdAt: FEB,
+    metadata: {
+      applied_credits: [
+        { creditId: 'credit-1', amount: 200000, transactionId: 'txn-credit-1' },
+      ],
+    },
+    relatedTransactionId: 'txn-credit-1',
   },
   {
     transactionId: 'txn-credit-3',
@@ -316,6 +322,134 @@ describe('buildDeferredRevenueReportFromData', () => {
     expect(acme.creditDetails[0].remainingAmount).toBe(500000);
     expect(
       acme.creditDetails.reduce((sum, detail) => sum + detail.remainingAmount, 0),
+    ).toBe(acme.credits.closing);
+  });
+
+  it('reconstructs month-M detail for a credit issued in M-1 and fully applied in M+1 (fix round 3)', () => {
+    // Regression: the credit's current tracking remaining is 0 (fully applied
+    // today), so the old remainingAmount > 0 predicate dropped the row and the
+    // detail no longer reconciled to the February closing. The ledger
+    // reconstruction restores the M-end balance and the row.
+    const report = buildDeferredRevenueReportFromData(
+      makeData({
+        creditTransactions: [
+          {
+            transactionId: 'txn-iss-jan',
+            clientId: 'client-1',
+            currencyCode: 'USD',
+            type: 'credit_issuance',
+            amount: 200000,
+            createdAt: '2026-01-15T10:00:00.000Z',
+          },
+          {
+            transactionId: 'txn-app-mar',
+            clientId: 'client-1',
+            currencyCode: 'USD',
+            type: 'credit_application',
+            amount: -200000,
+            createdAt: '2026-03-15T10:00:00.000Z',
+            metadata: {
+              applied_credits: [
+                { creditId: 'credit-later', amount: 200000, transactionId: 'txn-iss-jan' },
+              ],
+            },
+            relatedTransactionId: 'txn-iss-jan',
+          },
+        ],
+        creditTracking: [
+          {
+            creditId: 'credit-later',
+            transactionId: 'txn-iss-jan',
+            clientId: 'client-1',
+            currencyCode: 'USD',
+            amount: 200000,
+            remainingAmount: 0,
+            expirationDate: null,
+            isExpired: false,
+            transactionType: 'credit_issuance',
+            issuedDate: '2026-01-15T10:00:00.000Z',
+            description: 'Prepayment applied later',
+            invoiceId: null,
+            metadata: null,
+          },
+        ],
+        bucketPeriods: [],
+      }),
+      '2026-02',
+    );
+
+    const usd = report.sections.find((section) => section.currencyCode === 'USD');
+    expect(usd).toBeDefined();
+    expect(usd!.clients).toHaveLength(1);
+    const acme = usd!.clients[0];
+    expect(acme.credits.opening).toBe(200000);
+    expect(acme.credits.closing).toBe(200000);
+    expect(acme.creditDetails).toHaveLength(1);
+    const detail = acme.creditDetails[0];
+    expect(detail.creditId).toBe('credit-later');
+    expect(detail.remainingAmount).toBe(200000);
+    expect(detail.inMonthMovement).toBe(0);
+    expect(
+      acme.creditDetails.reduce((sum, row) => sum + row.remainingAmount, 0),
+    ).toBe(acme.credits.closing);
+  });
+
+  it('keeps the fully-applied-in-M+1 credit on the month after application with a reconciling zero detail (fix round 3)', () => {
+    const data = makeData({
+      creditTransactions: [
+        {
+          transactionId: 'txn-iss-jan',
+          clientId: 'client-1',
+          currencyCode: 'USD',
+          type: 'credit_issuance',
+          amount: 200000,
+          createdAt: '2026-01-15T10:00:00.000Z',
+        },
+        {
+          transactionId: 'txn-app-mar',
+          clientId: 'client-1',
+          currencyCode: 'USD',
+          type: 'credit_application',
+          amount: -200000,
+          createdAt: '2026-03-15T10:00:00.000Z',
+          metadata: {
+            applied_credits: [
+              { creditId: 'credit-later', amount: 200000, transactionId: 'txn-iss-jan' },
+            ],
+          },
+          relatedTransactionId: 'txn-iss-jan',
+        },
+      ],
+      creditTracking: [
+        {
+          creditId: 'credit-later',
+          transactionId: 'txn-iss-jan',
+          clientId: 'client-1',
+          currencyCode: 'USD',
+          amount: 200000,
+          remainingAmount: 0,
+          expirationDate: null,
+          isExpired: false,
+          transactionType: 'credit_issuance',
+          issuedDate: '2026-01-15T10:00:00.000Z',
+          description: 'Prepayment applied later',
+          invoiceId: null,
+          metadata: null,
+        },
+      ],
+      bucketPeriods: [],
+    });
+
+    const mar = buildDeferredRevenueReportFromData(data, '2026-03');
+    const usd = mar.sections.find((section) => section.currencyCode === 'USD');
+    expect(usd).toBeDefined();
+    const acme = usd!.clients[0];
+    expect(acme.credits.closing).toBe(0);
+    expect(acme.creditDetails).toHaveLength(1);
+    expect(acme.creditDetails[0].remainingAmount).toBe(0);
+    expect(acme.creditDetails[0].inMonthMovement).toBe(-200000);
+    expect(
+      acme.creditDetails.reduce((sum, row) => sum + row.remainingAmount, 0),
     ).toBe(acme.credits.closing);
   });
 });

--- a/packages/reporting/src/actions/report-actions/deferred-revenue/compose.test.ts
+++ b/packages/reporting/src/actions/report-actions/deferred-revenue/compose.test.ts
@@ -452,4 +452,84 @@ describe('buildDeferredRevenueReportFromData', () => {
       acme.creditDetails.reduce((sum, row) => sum + row.remainingAmount, 0),
     ).toBe(acme.credits.closing);
   });
+
+  it('restores a credit reversed by a FinancialService-shaped adjustment through the application\'s applied_credits (fix round 3)', () => {
+    // FinancialService.bulkTransactionOperation (reverse) writes a credit_adjustment
+    // with only related_transaction_id → the original credit_application and no
+    // metadata. That application carries canonical metadata.applied_credits, so
+    // the reversal must be attributed: report closing, retained detail row, and
+    // the detail-to-closing reconciliation all agree at 200000 for the month
+    // containing the reversal.
+    const report = buildDeferredRevenueReportFromData(
+      makeData({
+        creditTransactions: [
+          {
+            transactionId: 'txn-iss-jan',
+            clientId: 'client-1',
+            currencyCode: 'USD',
+            type: 'credit_issuance',
+            amount: 200000,
+            createdAt: '2026-01-15T10:00:00.000Z',
+          },
+          {
+            transactionId: 'txn-app-feb',
+            clientId: 'client-1',
+            currencyCode: 'USD',
+            type: 'credit_application',
+            amount: -200000,
+            createdAt: '2026-02-15T10:00:00.000Z',
+            metadata: {
+              applied_credits: [
+                { creditId: 'credit-rev', amount: 200000, transactionId: 'txn-iss-jan' },
+              ],
+            },
+            relatedTransactionId: 'txn-iss-jan',
+          },
+          {
+            transactionId: 'txn-rev-mar',
+            clientId: 'client-1',
+            currencyCode: 'USD',
+            type: 'credit_adjustment',
+            amount: 200000,
+            createdAt: '2026-03-15T10:00:00.000Z',
+            relatedTransactionId: 'txn-app-feb',
+          },
+        ],
+        creditTracking: [
+          {
+            creditId: 'credit-rev',
+            transactionId: 'txn-iss-jan',
+            clientId: 'client-1',
+            currencyCode: 'USD',
+            amount: 200000,
+            remainingAmount: 0,
+            expirationDate: null,
+            isExpired: false,
+            transactionType: 'credit_issuance',
+            issuedDate: '2026-01-15T10:00:00.000Z',
+            description: 'Prepayment restored by reversal',
+            invoiceId: null,
+            metadata: null,
+          },
+        ],
+        bucketPeriods: [],
+      }),
+      '2026-03',
+    );
+
+    const usd = report.sections.find((section) => section.currencyCode === 'USD');
+    expect(usd).toBeDefined();
+    expect(usd!.clients).toHaveLength(1);
+    const acme = usd!.clients[0];
+    expect(acme.credits.opening).toBe(0);
+    expect(acme.credits.adjustments).toBe(200000);
+    expect(acme.credits.closing).toBe(200000);
+    expect(acme.creditDetails).toHaveLength(1);
+    const detail = acme.creditDetails[0];
+    expect(detail.creditId).toBe('credit-rev');
+    expect(detail.remainingAmount).toBe(200000);
+    expect(
+      acme.creditDetails.reduce((sum, row) => sum + row.remainingAmount, 0),
+    ).toBe(acme.credits.closing);
+  });
 });

--- a/packages/reporting/src/actions/report-actions/deferred-revenue/compose.test.ts
+++ b/packages/reporting/src/actions/report-actions/deferred-revenue/compose.test.ts
@@ -1,0 +1,180 @@
+import { describe, expect, it } from 'vitest';
+
+import { buildDeferredRevenueReportFromData } from './compose';
+import type { CreditTrackingDetailRow } from './loaders';
+import type { CreditTransactionRow } from './credits';
+import type { RawBucketPeriodRow } from './loaders';
+import type { CreditSourceInvoice } from './creditSource';
+
+const FEB = '2026-02-15T10:00:00.000Z';
+
+const creditTransactions: CreditTransactionRow[] = [
+  {
+    transactionId: 'txn-credit-1',
+    clientId: 'client-1',
+    currencyCode: 'USD',
+    type: 'credit_issuance',
+    amount: 500000,
+    createdAt: '2026-01-15T10:00:00.000Z',
+  },
+  {
+    transactionId: 'txn-credit-2',
+    clientId: 'client-1',
+    currencyCode: 'USD',
+    type: 'credit_application',
+    amount: -200000,
+    createdAt: FEB,
+  },
+  {
+    transactionId: 'txn-credit-3',
+    clientId: 'client-2',
+    currencyCode: 'EUR',
+    type: 'credit_issuance',
+    amount: 100000,
+    createdAt: FEB,
+  },
+];
+
+const creditTracking: CreditTrackingDetailRow[] = [
+  {
+    creditId: 'credit-1',
+    transactionId: 'txn-credit-1',
+    clientId: 'client-1',
+    currencyCode: 'USD',
+    amount: 500000,
+    remainingAmount: 300000,
+    expirationDate: null,
+    isExpired: false,
+    transactionType: 'credit_issuance',
+    issuedDate: '2026-01-15T10:00:00.000Z',
+    description: 'Prepayment',
+    invoiceId: 'inv-prepay',
+    metadata: null,
+  },
+];
+
+const bucketPeriods: RawBucketPeriodRow[] = [
+  {
+    usageId: 'usage-1',
+    contractLineId: 'line-1',
+    contractId: 'contract-1',
+    contractLineName: 'Block Hours',
+    clientId: 'client-1',
+    serviceId: 'svc-1',
+    serviceName: 'Engineering',
+    periodStart: '2026-02-01',
+    periodEnd: '2026-02-28',
+    minutesUsed: 2400,
+    rolledOverMinutes: 0,
+    totalMinutes: 6000,
+    allowRollover: false,
+    currencyCode: 'USD',
+    lineCustomRate: null,
+    catalogDefaultRate: null,
+  },
+];
+
+function makeData(over: Partial<Parameters<typeof buildDeferredRevenueReportFromData>[0]> = {}) {
+  return {
+    clients: [
+      { clientId: 'client-1', clientName: 'Acme', defaultCurrencyCode: 'USD' },
+      { clientId: 'client-2', clientName: 'Zed Inc', defaultCurrencyCode: 'EUR' },
+    ],
+    creditTransactions,
+    creditTracking,
+    creditInvoices: new Map<string, CreditSourceInvoice>([
+      ['inv-prepay', { invoiceId: 'inv-prepay', invoiceNumber: 'PP-1', isPrepayment: true, invoiceType: 'prepayment' }],
+    ]),
+    bucketPeriods,
+    billedFees: [
+      {
+        contractLineId: 'line-1',
+        serviceId: 'svc-1',
+        servicePeriodStart: '2026-02-01',
+        servicePeriodEnd: '2026-02-28',
+        feeCents: 100000,
+      },
+    ],
+    fixedConfigBaseRates: new Map<string, number | null>(),
+    pricingSchedules: [],
+    ...over,
+  };
+}
+
+describe('buildDeferredRevenueReportFromData', () => {
+  it('merges credits and hours per client×currency with tenant totals', () => {
+    const report = buildDeferredRevenueReportFromData(makeData(), '2026-02');
+
+    expect(report.month).toBe('2026-02');
+    expect(report.sections).toHaveLength(2);
+    expect(report.sections.map((section) => section.currencyCode)).toEqual(['EUR', 'USD']);
+
+    const usd = report.sections.find((section) => section.currencyCode === 'USD')!;
+    expect(usd.clients).toHaveLength(1);
+    const acme = usd.clients[0];
+    expect(acme.clientName).toBe('Acme');
+    expect(acme.credits.opening).toBe(500000);
+    expect(acme.credits.applied).toBe(-200000);
+    expect(acme.credits.closing).toBe(300000);
+    expect(acme.hours.issued).toBe(100000);
+    expect(acme.hours.applied).toBeCloseTo(-(2400 * (100000 / 6000)), 6);
+    expect(acme.hours.closing).toBe(0);
+    expect(acme.total.opening).toBe(500000);
+    expect(acme.total.closing).toBeCloseTo(300000, 6);
+    // Total movement columns close arithmetically with the hours signed like
+    // the credits: 500000 + 100000 - 240000 - 60000 = 300000.
+    expect(
+      acme.total.opening + acme.total.issued + acme.total.applied + acme.total.expired,
+    ).toBeCloseTo(acme.total.closing, 6);
+
+    const eur = report.sections.find((section) => section.currencyCode === 'EUR')!;
+    expect(eur.totals.total.closing).toBe(100000);
+  });
+
+  it('flags prepayment-sourced credit details as qbo-unreachable', () => {
+    const report = buildDeferredRevenueReportFromData(makeData(), '2026-02');
+    const usd = report.sections.find((section) => section.currencyCode === 'USD')!;
+    const detail = usd.clients[0].creditDetails[0];
+    expect(detail.sourceKind).toBe('prepayment');
+    expect(detail.qboReachable).toBe(false);
+    expect(detail.invoiceNumber).toBe('PP-1');
+  });
+
+  it('discloses the spanning-period burn fallback in notes when taken', () => {
+    const report = buildDeferredRevenueReportFromData(
+      makeData({
+        bucketPeriods: [
+          {
+            ...bucketPeriods[0],
+            periodStart: '2026-02-15',
+            periodEnd: '2026-03-14',
+          },
+        ],
+      }),
+      '2026-02',
+    );
+    expect(report.notes).toContain(
+      'Bucket periods spanning calendar-month boundaries attribute their burn to the month the period ends in.',
+    );
+  });
+
+  it('keeps notes empty when no period spans a month boundary', () => {
+    const report = buildDeferredRevenueReportFromData(makeData(), '2026-02');
+    expect(report.notes).toHaveLength(0);
+  });
+
+  it('omits zero-balance clients with no movement and no outstanding credit', () => {
+    const report = buildDeferredRevenueReportFromData(
+      makeData({
+        creditTransactions: [],
+        creditTracking: [],
+        bucketPeriods: [],
+        clients: [
+          { clientId: 'client-1', clientName: 'Quiet Co', defaultCurrencyCode: 'USD' },
+        ],
+      }),
+      '2026-02',
+    );
+    expect(report.sections).toHaveLength(0);
+  });
+});

--- a/packages/reporting/src/actions/report-actions/deferred-revenue/compose.test.ts
+++ b/packages/reporting/src/actions/report-actions/deferred-revenue/compose.test.ts
@@ -217,4 +217,105 @@ describe('buildDeferredRevenueReportFromData', () => {
     expect(acme!.hours.opening).toBe(1200 * (100000 / 6000));
     expect(acme!.bucketDetails).toHaveLength(1);
   });
+
+  it('omits a client whose only credit activity is after the selected month (Defect 2)', () => {
+    // client-1's only credit is issued in April; February sees zero opening,
+    // zero movement, zero closing. The credit did not exist in February, so no
+    // detail row may surface the client for that month.
+    const report = buildDeferredRevenueReportFromData(
+      makeData({
+        creditTransactions: [
+          {
+            transactionId: 'txn-future',
+            clientId: 'client-1',
+            currencyCode: 'USD',
+            type: 'credit_issuance',
+            amount: 500000,
+            createdAt: '2026-04-15T10:00:00.000Z',
+          },
+        ],
+        creditTracking: [
+          {
+            creditId: 'credit-future',
+            transactionId: 'txn-future',
+            clientId: 'client-1',
+            currencyCode: 'USD',
+            amount: 500000,
+            remainingAmount: 500000,
+            expirationDate: null,
+            isExpired: false,
+            transactionType: 'credit_issuance',
+            issuedDate: '2026-04-15T10:00:00.000Z',
+            description: 'Future-dated credit',
+            invoiceId: null,
+            metadata: null,
+          },
+        ],
+        bucketPeriods: [],
+      }),
+      '2026-02',
+    );
+    expect(report.sections).toHaveLength(0);
+  });
+
+  it('retains a client with a pre-month credit issuance whose application lands in a future month (Defect 2)', () => {
+    // client-1's credit was issued in January and is applied in April; for
+    // February it contributes opening and closing liability of 5000. The
+    // client must appear with the February closing balance and a detail row
+    // that reconciles to it.
+    const report = buildDeferredRevenueReportFromData(
+      makeData({
+        creditTransactions: [
+          {
+            transactionId: 'txn-pre',
+            clientId: 'client-1',
+            currencyCode: 'USD',
+            type: 'credit_issuance',
+            amount: 500000,
+            createdAt: '2026-01-15T10:00:00.000Z',
+          },
+          {
+            transactionId: 'txn-app-future',
+            clientId: 'client-1',
+            currencyCode: 'USD',
+            type: 'credit_application',
+            amount: -500000,
+            createdAt: '2026-04-15T10:00:00.000Z',
+          },
+        ],
+        creditTracking: [
+          {
+            creditId: 'credit-pre',
+            transactionId: 'txn-pre',
+            clientId: 'client-1',
+            currencyCode: 'USD',
+            amount: 500000,
+            remainingAmount: 500000,
+            expirationDate: null,
+            isExpired: false,
+            transactionType: 'credit_issuance',
+            issuedDate: '2026-01-15T10:00:00.000Z',
+            description: 'Pre-month prepayment',
+            invoiceId: 'inv-prepay',
+            metadata: null,
+          },
+        ],
+        bucketPeriods: [],
+      }),
+      '2026-02',
+    );
+
+    const usd = report.sections.find((section) => section.currencyCode === 'USD');
+    expect(usd).toBeDefined();
+    expect(usd!.clients).toHaveLength(1);
+    const acme = usd!.clients[0];
+    expect(acme.credits.opening).toBe(500000);
+    expect(acme.credits.closing).toBe(500000);
+    expect(acme.creditDetails).toHaveLength(1);
+    expect(acme.creditDetails[0].creditId).toBe('credit-pre');
+    expect(acme.creditDetails[0].remainingAmount).toBe(500000);
+    expect(
+      acme.creditDetails.reduce((sum, detail) => sum + detail.remainingAmount, 0),
+    ).toBe(acme.credits.closing);
+  });
 });

--- a/packages/reporting/src/actions/report-actions/deferred-revenue/compose.ts
+++ b/packages/reporting/src/actions/report-actions/deferred-revenue/compose.ts
@@ -54,6 +54,17 @@ function isNonZero(movement: MovementColumns): boolean {
   );
 }
 
+/**
+ * Credit detail retention rule (fix round 3). A credit row stays on the report
+ * when it still carries liability as of the selected month's end (reconstructed
+ * from the ledger, not from today's tracking state) or it moved during the
+ * month. Rows that fail both carry nothing and explain nothing for the month —
+ * keeping them would break the detail-to-closing reconciliation.
+ */
+function isRetainedCreditDetail(detail: CreditDetailRow): boolean {
+  return detail.remainingAmount > 0 || detail.inMonthMovement !== 0;
+}
+
 function creditDetailsByClientCurrency(
   details: CreditDetailRow[],
 ): Map<string, CreditDetailRow[]> {
@@ -80,8 +91,14 @@ export function buildDeferredRevenueReportFromData(
 
   const creditRollforward = computeCreditRollforward(month, data.creditTransactions);
   const hoursRollforward = computeHoursRollforward(month, buildBucketPeriodInputs(data));
+  const creditDetailRows = buildCreditDetailRows(
+    data.creditTracking,
+    data.creditTransactions,
+    data.creditInvoices,
+    month,
+  );
   const creditDetailsByKey = creditDetailsByClientCurrency(
-    buildCreditDetailRows(data.creditTracking, data.creditInvoices, month),
+    creditDetailRows.filter(isRetainedCreditDetail),
   );
 
   const clientRows = new Map<string, ClientRollforward>();
@@ -135,12 +152,10 @@ export function buildDeferredRevenueReportFromData(
     }
   }
 
-  // Outstanding credit balances (non-expired, still-remaining tracking rows)
-  // must surface even when the month's movement is nil.
+  // Outstanding credit balances (still-remaining or in-month-movement detail
+  // rows) must surface even when the month's movement is nil.
   for (const [key, details] of creditDetailsByKey) {
-    const hasOutstanding = details.some(
-      (detail) => detail.remainingAmount > 0 && !detail.isExpired,
-    );
+    const hasOutstanding = details.some(isRetainedCreditDetail);
     if (hasOutstanding) {
       const existing = clientRows.get(key);
       if (existing) {
@@ -174,12 +189,10 @@ export function buildDeferredRevenueReportFromData(
   const byCurrency = new Map<string, ClientRollforward[]>();
   for (const row of clientRows.values()) {
     // A zero-balance client is omitted unless it has detail that proves a
-    // balance: outstanding credits (remaining > 0) or contributing bucket
-    // periods. Detail rows for fully-consumed credits (remaining 0) or
-    // future-month credits never retain a client on their own.
-    const hasOutstandingCreditDetail = row.creditDetails.some(
-      (detail) => detail.remainingAmount > 0 && !detail.isExpired,
-    );
+    // balance: retained credit detail (reconstructed remaining > 0 or in-month
+    // movement) or contributing bucket periods. Detail rows for fully-consumed
+    // credits or future-month credits never retain a client on their own.
+    const hasOutstandingCreditDetail = row.creditDetails.some(isRetainedCreditDetail);
     if (!isNonZero(row.total) && row.bucketDetails.length === 0 && !hasOutstandingCreditDetail) {
       continue;
     }
@@ -209,6 +222,12 @@ export function buildDeferredRevenueReportFromData(
   if (hasSpanningPeriods) {
     notes.push(
       'Bucket periods spanning calendar-month boundaries attribute their burn to the month the period ends in.',
+    );
+  }
+
+  if (creditDetailRows.some((detail) => detail.reconstructionLimited)) {
+    notes.push(
+      'Credit balances affected by ledger activity that cannot be attributed to a specific credit (missing credit linkage) are reported at their current remaining balance.',
     );
   }
 

--- a/packages/reporting/src/actions/report-actions/deferred-revenue/compose.ts
+++ b/packages/reporting/src/actions/report-actions/deferred-revenue/compose.ts
@@ -81,7 +81,7 @@ export function buildDeferredRevenueReportFromData(
   const creditRollforward = computeCreditRollforward(month, data.creditTransactions);
   const hoursRollforward = computeHoursRollforward(month, buildBucketPeriodInputs(data));
   const creditDetailsByKey = creditDetailsByClientCurrency(
-    buildCreditDetailRows(data.creditTracking, data.creditInvoices),
+    buildCreditDetailRows(data.creditTracking, data.creditInvoices, month),
   );
 
   const clientRows = new Map<string, ClientRollforward>();
@@ -173,7 +173,14 @@ export function buildDeferredRevenueReportFromData(
 
   const byCurrency = new Map<string, ClientRollforward[]>();
   for (const row of clientRows.values()) {
-    if (!isNonZero(row.total) && row.creditDetails.length === 0 && row.bucketDetails.length === 0) {
+    // A zero-balance client is omitted unless it has detail that proves a
+    // balance: outstanding credits (remaining > 0) or contributing bucket
+    // periods. Detail rows for fully-consumed credits (remaining 0) or
+    // future-month credits never retain a client on their own.
+    const hasOutstandingCreditDetail = row.creditDetails.some(
+      (detail) => detail.remainingAmount > 0 && !detail.isExpired,
+    );
+    if (!isNonZero(row.total) && row.bucketDetails.length === 0 && !hasOutstandingCreditDetail) {
       continue;
     }
     const currencyRows = byCurrency.get(row.currencyCode) ?? [];

--- a/packages/reporting/src/actions/report-actions/deferred-revenue/compose.ts
+++ b/packages/reporting/src/actions/report-actions/deferred-revenue/compose.ts
@@ -1,0 +1,224 @@
+/**
+ * Composition of the deferred-revenue report: merge the credits and hours
+ * rollforwards per client×currency, add tenant-level totals per currency, and
+ * attach per-client detail rows. Pure over the loaded ledger rows, so the
+ * server action is a thin auth+permission wrapper around it.
+ */
+
+import type { Knex } from 'knex';
+
+import { computeCreditRollforward } from './credits';
+import { computeHoursRollforward } from './hours';
+import { monthKeyOf, monthRange } from './month';
+import {
+  buildBucketPeriodInputs,
+  buildCreditDetailRows,
+  loadDeferredRevenueData,
+  type BuildDeferredRevenueInput,
+  type LoadedClient,
+} from './loaders';
+import {
+  addMovement,
+  emptyMovement,
+  type ClientRollforward,
+  type CreditDetailRow,
+  type CurrencySection,
+  type DeferredRevenueReport,
+  type MovementColumns,
+} from './types';
+
+export interface ComposableInputs extends BuildDeferredRevenueInput {
+  clients: LoadedClient[];
+}
+
+function keyOf(clientId: string, currencyCode: string): string {
+  return `${clientId}\u0000${currencyCode}`;
+}
+
+function parseKey(key: string): { clientId: string; currencyCode: string } {
+  const separator = key.indexOf('\u0000');
+  return {
+    clientId: key.slice(0, separator),
+    currencyCode: key.slice(separator + 1),
+  };
+}
+
+function isNonZero(movement: MovementColumns): boolean {
+  return (
+    movement.opening !== 0 ||
+    movement.issued !== 0 ||
+    movement.applied !== 0 ||
+    movement.expired !== 0 ||
+    movement.adjustments !== 0 ||
+    movement.closing !== 0
+  );
+}
+
+function creditDetailsByClientCurrency(
+  details: CreditDetailRow[],
+): Map<string, CreditDetailRow[]> {
+  const byKey = new Map<string, CreditDetailRow[]>();
+  for (const detail of details) {
+    const key = keyOf(detail.clientId, detail.currencyCode);
+    const bucket = byKey.get(key) ?? [];
+    bucket.push(detail);
+    byKey.set(key, bucket);
+  }
+  return byKey;
+}
+
+/**
+ * Build the full report for one calendar month from the live ledgers.
+ *
+ * @param month 'YYYY-MM'
+ */
+export function buildDeferredRevenueReportFromData(
+  data: ComposableInputs,
+  month: string,
+): DeferredRevenueReport {
+  const clientNameById = new Map(data.clients.map((client) => [client.clientId, client.clientName]));
+
+  const creditRollforward = computeCreditRollforward(month, data.creditTransactions);
+  const hoursRollforward = computeHoursRollforward(month, buildBucketPeriodInputs(data));
+  const creditDetailsByKey = creditDetailsByClientCurrency(
+    buildCreditDetailRows(data.creditTracking, data.creditInvoices),
+  );
+
+  const clientRows = new Map<string, ClientRollforward>();
+
+  for (const [key, rollforward] of creditRollforward) {
+    const { clientId, currencyCode } = parseKey(key);
+    clientRows.set(key, {
+      clientId,
+      clientName: clientNameById.get(clientId) ?? 'Unknown client',
+      currencyCode,
+      credits: {
+        opening: rollforward.opening,
+        issued: rollforward.movement.issued,
+        applied: rollforward.movement.applied,
+        expired: rollforward.movement.expired,
+        adjustments: rollforward.movement.adjustments,
+        closing: rollforward.closing,
+      },
+      hours: emptyMovement(),
+      total: emptyMovement(),
+      creditDetails: [],
+      bucketDetails: [],
+    });
+  }
+
+  for (const [key, rollforward] of hoursRollforward) {
+    const { clientId, currencyCode } = parseKey(key);
+    const existing = clientRows.get(key);
+    const hoursMovement: MovementColumns = {
+      opening: rollforward.opening,
+      issued: rollforward.issued,
+      applied: rollforward.applied,
+      expired: rollforward.expired,
+      adjustments: 0,
+      closing: rollforward.closing,
+    };
+    if (existing) {
+      existing.hours = hoursMovement;
+      existing.bucketDetails = rollforward.details;
+    } else {
+      clientRows.set(key, {
+        clientId,
+        clientName: clientNameById.get(clientId) ?? 'Unknown client',
+        currencyCode,
+        credits: emptyMovement(),
+        hours: hoursMovement,
+        total: emptyMovement(),
+        creditDetails: [],
+        bucketDetails: rollforward.details,
+      });
+    }
+  }
+
+  // Outstanding credit balances (non-expired, still-remaining tracking rows)
+  // must surface even when the month's movement is nil.
+  for (const [key, details] of creditDetailsByKey) {
+    const hasOutstanding = details.some(
+      (detail) => detail.remainingAmount > 0 && !detail.isExpired,
+    );
+    if (hasOutstanding) {
+      const existing = clientRows.get(key);
+      if (existing) {
+        existing.creditDetails = details;
+      } else {
+        const { clientId, currencyCode } = parseKey(key);
+        clientRows.set(key, {
+          clientId,
+          clientName: clientNameById.get(clientId) ?? 'Unknown client',
+          currencyCode,
+          credits: emptyMovement(),
+          hours: emptyMovement(),
+          total: emptyMovement(),
+          creditDetails: details,
+          bucketDetails: [],
+        });
+      }
+    }
+  }
+
+  for (const [key, row] of clientRows) {
+    row.total = addMovement(row.credits, row.hours);
+    if (!creditDetailsByKey.has(key)) {
+      row.creditDetails = [];
+    }
+    if (!row.bucketDetails) {
+      row.bucketDetails = [];
+    }
+  }
+
+  const byCurrency = new Map<string, ClientRollforward[]>();
+  for (const row of clientRows.values()) {
+    if (!isNonZero(row.total) && row.creditDetails.length === 0 && row.bucketDetails.length === 0) {
+      continue;
+    }
+    const currencyRows = byCurrency.get(row.currencyCode) ?? [];
+    currencyRows.push(row);
+    byCurrency.set(row.currencyCode, currencyRows);
+  }
+
+  const sections: CurrencySection[] = [];
+  for (const [currencyCode, rows] of byCurrency) {
+    rows.sort((left, right) => left.clientName.localeCompare(right.clientName));
+    const totals = { credits: emptyMovement(), hours: emptyMovement(), total: emptyMovement() };
+    for (const row of rows) {
+      totals.credits = addMovement(totals.credits, row.credits);
+      totals.hours = addMovement(totals.hours, row.hours);
+      totals.total = addMovement(totals.total, row.total);
+    }
+    sections.push({ currencyCode, totals, clients: rows });
+  }
+  sections.sort((left, right) => left.currencyCode.localeCompare(right.currencyCode));
+
+  const hasSpanningPeriods = data.bucketPeriods.some(
+    (period) => monthKeyOf(period.periodStart) !== monthKeyOf(period.periodEnd),
+  );
+
+  const notes: string[] = [];
+  if (hasSpanningPeriods) {
+    notes.push(
+      'Bucket periods spanning calendar-month boundaries attribute their burn to the month the period ends in.',
+    );
+  }
+
+  return {
+    month,
+    generatedAt: new Date().toISOString(),
+    sections,
+    notes,
+  };
+}
+
+export async function buildDeferredRevenueReport(
+  conn: Knex | Knex.Transaction,
+  tenant: string,
+  month: string,
+): Promise<DeferredRevenueReport> {
+  monthRange(month); // validate before touching the database
+  const data = await loadDeferredRevenueData(conn, tenant);
+  return buildDeferredRevenueReportFromData(data, month);
+}

--- a/packages/reporting/src/actions/report-actions/deferred-revenue/creditSource.ts
+++ b/packages/reporting/src/actions/report-actions/deferred-revenue/creditSource.ts
@@ -1,0 +1,109 @@
+/**
+ * Credit source classification for the report's detail rows.
+ *
+ * Mirrors the QBO reachability logic in
+ * packages/billing/src/services/accountingSync/creditApplicationApplier.ts
+ * (resolveNonCreditMemoSource) and the prepayment/negative-total handling in
+ * invoiceModification.ts: credits backed by a prepayment invoice or a
+ * project-deposit issuance never produce a QBO CreditMemo, so their detail
+ * rows carry qboReachable: false.
+ */
+
+import type { CreditSourceKind } from './types';
+
+export interface CreditSourceInvoice {
+  invoiceId: string;
+  invoiceNumber: string | null;
+  isPrepayment: boolean;
+  invoiceType: string | null;
+}
+
+function normalizeMetadata(metadata: unknown): Record<string, unknown> {
+  if (metadata && typeof metadata === 'object') {
+    return metadata as Record<string, unknown>;
+  }
+  if (typeof metadata === 'string') {
+    try {
+      const parsed = JSON.parse(metadata);
+      return parsed && typeof parsed === 'object' ? (parsed as Record<string, unknown>) : {};
+    } catch {
+      return {};
+    }
+  }
+  return {};
+}
+
+function isPrepaymentInvoice(invoice: CreditSourceInvoice | undefined): boolean {
+  return Boolean(
+    invoice &&
+      (invoice.isPrepayment || invoice.invoiceType === 'prepayment'),
+  );
+}
+
+export interface CreditSourceClassification {
+  sourceKind: CreditSourceKind;
+  qboReachable: boolean;
+  invoiceNumber: string | null;
+}
+
+/**
+ * Classify one credit_tracking row from its source transaction.
+ *
+ * @param transactionType the source transaction's `type` column
+ * @param invoiceId the source transaction's invoice_id
+ * @param metadata the source transaction's metadata
+ * @param invoicesByInvoiceId invoices loaded for the tenant, keyed by invoice_id
+ */
+export function classifyCreditSource(
+  transactionType: string | null | undefined,
+  invoiceId: string | null | undefined,
+  metadata: unknown,
+  invoicesByInvoiceId: Map<string, CreditSourceInvoice>,
+): CreditSourceClassification {
+  const meta = normalizeMetadata(metadata);
+  const projectDeposit =
+    meta.project_billing_credit_kind === 'project_deposit';
+
+  if (projectDeposit) {
+    return { sourceKind: 'project_deposit', qboReachable: false, invoiceNumber: null };
+  }
+
+  if (transactionType === 'credit_transfer') {
+    // A transfer inherits the source credit's reachability through its lineage.
+    const sourceInvoiceId =
+      typeof meta.source_invoice_id === 'string' ? meta.source_invoice_id : null;
+    const sourceInvoice = sourceInvoiceId
+      ? invoicesByInvoiceId.get(sourceInvoiceId)
+      : undefined;
+    return {
+      sourceKind: 'transfer_in',
+      qboReachable: !isPrepaymentInvoice(sourceInvoice),
+      invoiceNumber: sourceInvoice?.invoiceNumber ?? null,
+    };
+  }
+
+  if (transactionType === 'credit_issuance_from_negative_invoice') {
+    return { sourceKind: 'negative_invoice', qboReachable: true, invoiceNumber: null };
+  }
+
+  const invoice = invoiceId ? invoicesByInvoiceId.get(invoiceId) : undefined;
+  if (isPrepaymentInvoice(invoice)) {
+    return {
+      sourceKind: 'prepayment',
+      qboReachable: false,
+      invoiceNumber: invoice?.invoiceNumber ?? null,
+    };
+  }
+
+  if (invoiceId) {
+    // credit_issuance with a non-prepayment invoice (legacy credit note).
+    return {
+      sourceKind: 'other',
+      qboReachable: true,
+      invoiceNumber: invoice?.invoiceNumber ?? null,
+    };
+  }
+
+  // Plain grant / direct issuance.
+  return { sourceKind: 'direct_grant', qboReachable: true, invoiceNumber: null };
+}

--- a/packages/reporting/src/actions/report-actions/deferred-revenue/credits.test.ts
+++ b/packages/reporting/src/actions/report-actions/deferred-revenue/credits.test.ts
@@ -3,7 +3,9 @@ import { describe, expect, it } from 'vitest';
 import {
   computeCreditRollforward,
   creditMovementKey,
+  reconstructCreditBalances,
   sumCreditRollforward,
+  type CreditBalanceSource,
   type CreditTransactionRow,
 } from './credits';
 
@@ -22,6 +24,26 @@ function txn(over: Partial<CreditTransactionRow>): CreditTransactionRow {
     createdAt: FEB,
     ...over,
   };
+}
+
+function credit(over: Partial<CreditBalanceSource>): CreditBalanceSource {
+  return {
+    creditId: 'credit-1',
+    transactionId: 'txn-1',
+    clientId: 'client-1',
+    currencyCode: 'USD',
+    amount: 0,
+    remainingAmount: 0,
+    ...over,
+  };
+}
+
+function reconstructFor(
+  month: string,
+  credits: CreditBalanceSource[],
+  transactions: CreditTransactionRow[],
+) {
+  return reconstructCreditBalances(month, credits, transactions);
 }
 
 describe('creditMovementKey sign-convention bucket mapping', () => {
@@ -150,5 +172,183 @@ describe('tie-out invariant against availableCreditByClientQuery', () => {
     const mar = sumCreditRollforward('2026-03', transactions, 'client-1', 'USD');
     expect(feb.closing).toBe(1500);
     expect(mar.opening).toBe(feb.closing);
+  });
+});
+
+describe('reconstructCreditBalances — as-of-month-end from ledger truth (fix round 3)', () => {
+  it('reports the full issuance for month M even when the credit is fully applied in M+1 and current remaining is 0', () => {
+    // Regression: credit issued in M-1 (Jan), fully applied in M+1 (Mar). Today
+    // credit_tracking says remaining 0, but the liability was outstanding at
+    // Feb-end — the reconstruction must say so.
+    const credits = [credit({ creditId: 'c1', transactionId: 'iss-1', amount: 2000, remainingAmount: 0 })];
+    const transactions: CreditTransactionRow[] = [
+      txn({ transactionId: 'iss-1', type: 'credit_issuance', amount: 2000, createdAt: JAN }),
+      txn({
+        transactionId: 'app-1',
+        type: 'credit_application',
+        amount: -2000,
+        createdAt: MAR,
+        metadata: { applied_credits: [{ creditId: 'c1', amount: 2000, transactionId: 'iss-1' }] },
+        relatedTransactionId: 'iss-1',
+      }),
+    ];
+
+    const feb = reconstructFor('2026-02', credits, transactions);
+    expect(feb.get('c1')).toEqual({ remainingAsOfMonthEnd: 2000, inMonthMovement: 0, limited: false });
+
+    // The same month after the application: the credit is exhausted.
+    const mar = reconstructFor('2026-03', credits, transactions);
+    expect(mar.get('c1')).toEqual({ remainingAsOfMonthEnd: 0, inMonthMovement: -2000, limited: false });
+  });
+
+  it('attributed applications dated in-month reduce remaining and count as in-month movement', () => {
+    const credits = [
+      credit({ creditId: 'c1', transactionId: 'iss-1', amount: 3000, remainingAmount: 2000 }),
+      credit({ creditId: 'c2', transactionId: 'iss-2', amount: 1000, remainingAmount: 500 }),
+    ];
+    const transactions: CreditTransactionRow[] = [
+      txn({ transactionId: 'iss-1', type: 'credit_issuance', amount: 3000, createdAt: JAN }),
+      txn({ transactionId: 'iss-2', type: 'credit_issuance', amount: 1000, createdAt: JAN }),
+      txn({
+        transactionId: 'app-1',
+        type: 'credit_application',
+        amount: -1500,
+        createdAt: FEB,
+        metadata: {
+          applied_credits: [
+            { creditId: 'c1', amount: 1000, transactionId: 'iss-1' },
+            { creditId: 'c2', amount: 500, transactionId: 'iss-2' },
+          ],
+        },
+      }),
+    ];
+
+    const feb = reconstructFor('2026-02', credits, transactions);
+    expect(feb.get('c1')).toEqual({ remainingAsOfMonthEnd: 2000, inMonthMovement: -1000, limited: false });
+    expect(feb.get('c2')).toEqual({ remainingAsOfMonthEnd: 500, inMonthMovement: -500, limited: false });
+  });
+
+  it('attributes expirations linked through related_transaction_id to the credit they expire', () => {
+    const credits = [credit({ creditId: 'c1', transactionId: 'iss-1', amount: 800, remainingAmount: 0 })];
+    const transactions: CreditTransactionRow[] = [
+      txn({ transactionId: 'iss-1', type: 'credit_issuance', amount: 800, createdAt: JAN }),
+      txn({ transactionId: 'exp-1', type: 'credit_expiration', amount: -800, createdAt: FEB, relatedTransactionId: 'iss-1' }),
+    ];
+
+    const feb = reconstructFor('2026-02', credits, transactions);
+    expect(feb.get('c1')).toEqual({ remainingAsOfMonthEnd: 0, inMonthMovement: -800, limited: false });
+  });
+
+  it('attributes a reversal adjustment to the credits the reversed application drew from', () => {
+    // Standard-invoice void: credit_adjustment with metadata.reversal_of = the
+    // application transaction, amount positive, restoring the applied pool.
+    const credits = [credit({ creditId: 'c1', transactionId: 'iss-1', amount: 2000, remainingAmount: 2000 })];
+    const transactions: CreditTransactionRow[] = [
+      txn({ transactionId: 'iss-1', type: 'credit_issuance', amount: 2000, createdAt: JAN }),
+      txn({
+        transactionId: 'app-1',
+        type: 'credit_application',
+        amount: -2000,
+        createdAt: FEB,
+        metadata: { applied_credits: [{ creditId: 'c1', amount: 2000, transactionId: 'iss-1' }] },
+        relatedTransactionId: 'iss-1',
+      }),
+      txn({
+        transactionId: 'rev-1',
+        type: 'credit_adjustment',
+        amount: 2000,
+        createdAt: MAR,
+        metadata: { reversal_of: 'app-1', reason: 'invoice_voided' },
+      }),
+    ];
+
+    const feb = reconstructFor('2026-02', credits, transactions);
+    expect(feb.get('c1')).toEqual({ remainingAsOfMonthEnd: 0, inMonthMovement: -2000, limited: false });
+
+    const mar = reconstructFor('2026-03', credits, transactions);
+    expect(mar.get('c1')).toEqual({ remainingAsOfMonthEnd: 2000, inMonthMovement: 2000, limited: false });
+  });
+
+  it('attributes a clawback adjustment through metadata.credit_id', () => {
+    // Credit-note-void clawback: credit_adjustment with credit_id + reversal_of
+    // referencing the issuance, amount negative.
+    const credits = [credit({ creditId: 'c1', transactionId: 'iss-1', amount: 1000, remainingAmount: 0 })];
+    const transactions: CreditTransactionRow[] = [
+      txn({ transactionId: 'iss-1', type: 'credit_issuance', amount: 1000, createdAt: JAN }),
+      txn({
+        transactionId: 'claw-1',
+        type: 'credit_adjustment',
+        amount: -1000,
+        createdAt: FEB,
+        metadata: { reversal_of: 'iss-1', credit_id: 'c1', reason: 'credit_note_voided' },
+      }),
+    ];
+
+    const feb = reconstructFor('2026-02', credits, transactions);
+    expect(feb.get('c1')).toEqual({ remainingAsOfMonthEnd: 0, inMonthMovement: -1000, limited: false });
+  });
+
+  it('attributes a transfer-out to the source credit and the transfer-in to the target credit', () => {
+    const credits = [
+      credit({ creditId: 'c1', transactionId: 'iss-1', clientId: 'client-1', amount: 1500, remainingAmount: 0 }),
+      credit({ creditId: 'c2', transactionId: 'transfer-in-1', clientId: 'client-2', amount: 1500, remainingAmount: 1500 }),
+    ];
+    const transactions: CreditTransactionRow[] = [
+      txn({ transactionId: 'iss-1', clientId: 'client-1', type: 'credit_issuance', amount: 1500, createdAt: JAN }),
+      txn({
+        transactionId: 'transfer-out-1',
+        clientId: 'client-1',
+        type: 'credit_transfer',
+        amount: -1500,
+        createdAt: FEB,
+        relatedTransactionId: 'iss-1',
+        metadata: { transfer_to: 'client-2', transfer_reason: 'admin' },
+      }),
+      txn({
+        transactionId: 'transfer-in-1',
+        clientId: 'client-2',
+        type: 'credit_transfer',
+        amount: 1500,
+        createdAt: FEB,
+        metadata: { transfer_from: 'client-1', transfer_reason: 'admin' },
+      }),
+    ];
+
+    const feb = reconstructFor('2026-02', credits, transactions);
+    expect(feb.get('c1')).toEqual({ remainingAsOfMonthEnd: 0, inMonthMovement: -1500, limited: false });
+    // The transfer-in is the target credit's own issuance — not an adjustment.
+    expect(feb.get('c2')).toEqual({ remainingAsOfMonthEnd: 1500, inMonthMovement: 0, limited: false });
+  });
+
+  it('caps at the current remaining and flags credits touched by an unattributable adjustment', () => {
+    // FinancialService-era reversal: credit_adjustment with only
+    // related_transaction_id (pointing at an application not tied to any
+    // credit). No reversal_of, no credit_id — unattributable. Do not guess:
+    // cap at the current remaining and disclose via the limited flag.
+    const credits = [credit({ creditId: 'c1', transactionId: 'iss-1', amount: 2000, remainingAmount: 0 })];
+    const transactions: CreditTransactionRow[] = [
+      txn({ transactionId: 'iss-1', type: 'credit_issuance', amount: 2000, createdAt: JAN }),
+      txn({ transactionId: 'app-1', type: 'credit_application', amount: -2000, createdAt: FEB }),
+      txn({ transactionId: 'rev-1', type: 'credit_adjustment', amount: 2000, createdAt: MAR, relatedTransactionId: 'app-1' }),
+    ];
+
+    const feb = reconstructFor('2026-02', credits, transactions);
+    expect(feb.get('c1')?.limited).toBe(true);
+    expect(feb.get('c1')?.remainingAsOfMonthEnd).toBe(0);
+    // An unattributable adjustment dated AFTER the month end cannot affect it.
+    const mar = reconstructFor('2026-03', credits, transactions);
+    expect(mar.get('c1')?.limited).toBe(true);
+    expect(mar.get('c1')?.remainingAsOfMonthEnd).toBe(0);
+  });
+
+  it('flags a credit whose only application carries no applied_credits metadata', () => {
+    const credits = [credit({ creditId: 'c1', transactionId: 'iss-1', amount: 2000, remainingAmount: 0 })];
+    const transactions: CreditTransactionRow[] = [
+      txn({ transactionId: 'iss-1', type: 'credit_issuance', amount: 2000, createdAt: JAN }),
+      txn({ transactionId: 'app-1', type: 'credit_application', amount: -2000, createdAt: FEB }),
+    ];
+
+    const feb = reconstructFor('2026-02', credits, transactions);
+    expect(feb.get('c1')).toEqual({ remainingAsOfMonthEnd: 0, inMonthMovement: 0, limited: true });
   });
 });

--- a/packages/reporting/src/actions/report-actions/deferred-revenue/credits.test.ts
+++ b/packages/reporting/src/actions/report-actions/deferred-revenue/credits.test.ts
@@ -1,0 +1,154 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  computeCreditRollforward,
+  creditMovementKey,
+  sumCreditRollforward,
+  type CreditTransactionRow,
+} from './credits';
+
+const JAN = '2026-01-15T10:00:00.000Z';
+const FEB = '2026-02-15T10:00:00.000Z';
+const MAR = '2026-03-15T10:00:00.000Z';
+const APR = '2026-04-15T10:00:00.000Z';
+
+function txn(over: Partial<CreditTransactionRow>): CreditTransactionRow {
+  return {
+    transactionId: 'txn-1',
+    clientId: 'client-1',
+    currencyCode: 'USD',
+    type: 'credit_issuance',
+    amount: 0,
+    createdAt: FEB,
+    ...over,
+  };
+}
+
+describe('creditMovementKey sign-convention bucket mapping', () => {
+  it('maps every credit-affecting type to the correct movement column', () => {
+    expect(creditMovementKey('credit_issuance')).toBe('issued');
+    expect(creditMovementKey('credit_issuance_from_negative_invoice')).toBe('issued');
+    expect(creditMovementKey('prepayment')).toBe('issued');
+    expect(creditMovementKey('credit_application')).toBe('applied');
+    expect(creditMovementKey('credit_expiration')).toBe('expired');
+    expect(creditMovementKey('credit_adjustment')).toBe('adjustments');
+    expect(creditMovementKey('credit_transfer')).toBe('adjustments');
+    // Non-credit ledger rows must not leak into the rollforward.
+    expect(creditMovementKey('payment')).toBeNull();
+    expect(creditMovementKey('invoice_generated')).toBeNull();
+    expect(creditMovementKey('invoice_cancelled')).toBeNull();
+  });
+
+  it('assigns the signed amounts verified against creditActions.ts', () => {
+    // Sign conventions from creditActions.ts / expiredCreditsHandler.ts:
+    // issuances grant (+), application/expiration consume (-), adjustments can
+    // go either way, transfers move liability between clients (+/-).
+    const transactions: CreditTransactionRow[] = [
+      txn({ type: 'credit_issuance', amount: 1000, createdAt: FEB }),
+      txn({ type: 'credit_issuance_from_negative_invoice', amount: 250, createdAt: FEB }),
+      txn({ type: 'credit_application', amount: -400, createdAt: FEB }),
+      txn({ type: 'credit_expiration', amount: -600, createdAt: FEB }),
+      txn({ type: 'credit_adjustment', amount: 150, createdAt: FEB }),
+      txn({ type: 'credit_transfer', amount: -75, createdAt: FEB }),
+    ];
+
+    const rollforward = computeCreditRollforward('2026-02', transactions).get(
+      'client-1\u0000USD',
+    );
+    expect(rollforward?.movement).toEqual({
+      opening: 0,
+      issued: 1250,
+      applied: -400,
+      expired: -600,
+      adjustments: 75,
+      closing: 0,
+    });
+    expect(rollforward?.closing).toBe(1250 - 400 - 600 + 75);
+  });
+});
+
+describe('credits rollforward month boundaries', () => {
+  it('puts pre-month transactions in opening and in-month in movement', () => {
+    const transactions: CreditTransactionRow[] = [
+      txn({ transactionId: 'a', type: 'credit_issuance', amount: 5000, createdAt: JAN }),
+      txn({ transactionId: 'b', type: 'credit_issuance', amount: 2000, createdAt: FEB }),
+      txn({ transactionId: 'c', type: 'credit_application', amount: -1500, createdAt: FEB }),
+      txn({ transactionId: 'd', type: 'credit_issuance', amount: 900, createdAt: MAR }),
+    ];
+
+    const feb = computeCreditRollforward('2026-02', transactions).get('client-1\u0000USD');
+    expect(feb?.opening).toBe(5000);
+    expect(feb?.movement.issued).toBe(2000);
+    expect(feb?.movement.applied).toBe(-1500);
+    expect(feb?.closing).toBe(5000 + 2000 - 1500);
+
+    const mar = computeCreditRollforward('2026-03', transactions).get('client-1\u0000USD');
+    expect(mar?.opening).toBe(5000 + 2000 - 1500);
+    expect(mar?.movement.issued).toBe(900);
+    expect(mar?.closing).toBe(5000 + 2000 - 1500 + 900);
+  });
+
+  it('ignores transactions dated in the following month', () => {
+    const transactions: CreditTransactionRow[] = [
+      txn({ type: 'credit_issuance', amount: 1000, createdAt: FEB }),
+      txn({ type: 'credit_issuance', amount: 1000, createdAt: MAR }),
+      txn({ type: 'credit_issuance', amount: 1000, createdAt: APR }),
+    ];
+    const feb = computeCreditRollforward('2026-02', transactions).get('client-1\u0000USD');
+    expect(feb?.opening).toBe(0);
+    expect(feb?.movement.issued).toBe(1000);
+    expect(feb?.closing).toBe(1000);
+  });
+
+  it('groups per client and currency without mixing', () => {
+    const transactions: CreditTransactionRow[] = [
+      txn({ clientId: 'client-1', currencyCode: 'USD', amount: 1000, createdAt: FEB }),
+      txn({ clientId: 'client-1', currencyCode: 'EUR', amount: 500, createdAt: FEB }),
+      txn({ clientId: 'client-2', currencyCode: 'USD', amount: 250, createdAt: FEB }),
+    ];
+    const rollforward = computeCreditRollforward('2026-02', transactions);
+    expect(rollforward.get('client-1\u0000USD')?.closing).toBe(1000);
+    expect(rollforward.get('client-1\u0000EUR')?.closing).toBe(500);
+    expect(rollforward.get('client-2\u0000USD')?.closing).toBe(250);
+  });
+});
+
+describe('tie-out invariant against availableCreditByClientQuery', () => {
+  // availableCreditByClientQuery (packages/billing/src/lib/creditBalance.ts)
+  // sums credit_tracking.remaining_amount where is_expired = false and the
+  // expiration date has not passed. The ledger rollforward must reconstruct
+  // the same number for the current month when every expiration has been
+  // written to the ledger (the expiry job has run).
+  it('closing equals the derived available credit for the current month', () => {
+    const transactions: CreditTransactionRow[] = [
+      // Prepayment credit, 3000 issued, 0 used.
+      txn({ transactionId: 'a', type: 'credit_issuance', amount: 3000, createdAt: JAN }),
+      // Negative-invoice credit, 1000 issued, 400 applied.
+      txn({ transactionId: 'b', type: 'credit_issuance_from_negative_invoice', amount: 1000, createdAt: JAN }),
+      txn({ transactionId: 'c', type: 'credit_application', amount: -400, createdAt: FEB }),
+      // Direct grant, 800 issued, expired in full in February.
+      txn({ transactionId: 'd', type: 'credit_issuance', amount: 800, createdAt: JAN }),
+      txn({ transactionId: 'e', type: 'credit_expiration', amount: -800, createdAt: FEB }),
+    ];
+
+    // Derived available credit: 3000 + (1000 - 400) = 3600 (the expired grant
+    // is gone). All expiry-related state agrees between ledger and tracking.
+    const currentMonth = computeCreditRollforward('2026-02', transactions).get('client-1\u0000USD');
+    expect(currentMonth?.closing).toBe(3600);
+    expect(currentMonth?.opening).toBe(3000 + 1000 + 800);
+    expect(currentMonth?.closing).toBe(
+      currentMonth!.opening + currentMonth!.movement.applied + currentMonth!.movement.expired,
+    );
+  });
+
+  it('opening of the next month equals closing of the current month', () => {
+    const transactions: CreditTransactionRow[] = [
+      txn({ transactionId: 'a', type: 'credit_issuance', amount: 2000, createdAt: JAN }),
+      txn({ transactionId: 'b', type: 'credit_application', amount: -500, createdAt: FEB }),
+    ];
+    const feb = sumCreditRollforward('2026-02', transactions, 'client-1', 'USD');
+    const mar = sumCreditRollforward('2026-03', transactions, 'client-1', 'USD');
+    expect(feb.closing).toBe(1500);
+    expect(mar.opening).toBe(feb.closing);
+  });
+});

--- a/packages/reporting/src/actions/report-actions/deferred-revenue/credits.test.ts
+++ b/packages/reporting/src/actions/report-actions/deferred-revenue/credits.test.ts
@@ -269,6 +269,80 @@ describe('reconstructCreditBalances — as-of-month-end from ledger truth (fix r
     expect(mar.get('c1')).toEqual({ remainingAsOfMonthEnd: 2000, inMonthMovement: 2000, limited: false });
   });
 
+  it('attributes a FinancialService-shaped reversal (no metadata, only related_transaction_id → the application) via the application\'s applied_credits split', () => {
+    // FinancialService.bulkTransactionOperation (reverse) writes credit_adjustment
+    // rows with only related_transaction_id pointing at the original
+    // credit_application — no metadata. When that application carries canonical
+    // metadata.applied_credits, the reversal must be attributed through the same
+    // split the metadata.reversal_of path uses, restoring the applied pool.
+    const credits = [credit({ creditId: 'c1', transactionId: 'iss-1', amount: 2000, remainingAmount: 2000 })];
+    const transactions: CreditTransactionRow[] = [
+      txn({ transactionId: 'iss-1', type: 'credit_issuance', amount: 2000, createdAt: JAN }),
+      txn({
+        transactionId: 'app-1',
+        type: 'credit_application',
+        amount: -2000,
+        createdAt: FEB,
+        metadata: { applied_credits: [{ creditId: 'c1', amount: 2000, transactionId: 'iss-1' }] },
+        relatedTransactionId: 'iss-1',
+      }),
+      txn({
+        transactionId: 'rev-1',
+        type: 'credit_adjustment',
+        amount: 2000,
+        createdAt: MAR,
+        relatedTransactionId: 'app-1',
+      }),
+    ];
+
+    const feb = reconstructFor('2026-02', credits, transactions);
+    expect(feb.get('c1')).toEqual({ remainingAsOfMonthEnd: 0, inMonthMovement: -2000, limited: false });
+
+    const mar = reconstructFor('2026-03', credits, transactions);
+    expect(mar.get('c1')).toEqual({ remainingAsOfMonthEnd: 2000, inMonthMovement: 2000, limited: false });
+  });
+
+  it('prorates a FinancialService-shaped reversal across the credits the reversed application drew from', () => {
+    // Partial reversal of a two-credit application: the adjustment amount is
+    // apportioned to each credit pro-rata to its applied share.
+    const credits = [
+      credit({ creditId: 'c1', transactionId: 'iss-1', amount: 1000, remainingAmount: 0 }),
+      credit({ creditId: 'c2', transactionId: 'iss-2', amount: 500, remainingAmount: 0 }),
+    ];
+    const transactions: CreditTransactionRow[] = [
+      txn({ transactionId: 'iss-1', type: 'credit_issuance', amount: 1000, createdAt: JAN }),
+      txn({ transactionId: 'iss-2', type: 'credit_issuance', amount: 500, createdAt: JAN }),
+      txn({
+        transactionId: 'app-1',
+        type: 'credit_application',
+        amount: -1500,
+        createdAt: FEB,
+        metadata: {
+          applied_credits: [
+            { creditId: 'c1', amount: 1000, transactionId: 'iss-1' },
+            { creditId: 'c2', amount: 500, transactionId: 'iss-2' },
+          ],
+        },
+      }),
+      txn({
+        transactionId: 'rev-1',
+        type: 'credit_adjustment',
+        amount: 750,
+        createdAt: MAR,
+        relatedTransactionId: 'app-1',
+      }),
+    ];
+
+    const feb = reconstructFor('2026-02', credits, transactions);
+    expect(feb.get('c1')).toEqual({ remainingAsOfMonthEnd: 0, inMonthMovement: -1000, limited: false });
+    expect(feb.get('c2')).toEqual({ remainingAsOfMonthEnd: 0, inMonthMovement: -500, limited: false });
+
+    // Half of each applied share is restored: c1 +500, c2 +250.
+    const mar = reconstructFor('2026-03', credits, transactions);
+    expect(mar.get('c1')).toEqual({ remainingAsOfMonthEnd: 500, inMonthMovement: 500, limited: false });
+    expect(mar.get('c2')).toEqual({ remainingAsOfMonthEnd: 250, inMonthMovement: 250, limited: false });
+  });
+
   it('attributes a clawback adjustment through metadata.credit_id', () => {
     // Credit-note-void clawback: credit_adjustment with credit_id + reversal_of
     // referencing the issuance, amount negative.

--- a/packages/reporting/src/actions/report-actions/deferred-revenue/credits.ts
+++ b/packages/reporting/src/actions/report-actions/deferred-revenue/credits.ts
@@ -47,6 +47,10 @@ export interface CreditTransactionRow {
   type: string;
   amount: number;
   createdAt: string;
+  /** Transaction metadata — `applied_credits` splits, `reversal_of` / `credit_id` linkage. */
+  metadata?: unknown;
+  /** Linked ledger transaction (expirations and transfer-outs point at the credit's issuance). */
+  relatedTransactionId?: string | null;
 }
 
 export interface CreditRollforward {
@@ -145,4 +149,265 @@ export function sumCreditRollforward(
       closing: 0,
     }
   );
+}
+
+/**
+ * The credit_tracking fields the per-credit reconstruction reads. Kept as a
+ * structural subset so this pure module never imports the DB layer.
+ */
+export interface CreditBalanceSource {
+  creditId: string;
+  transactionId: string;
+  clientId: string;
+  currencyCode: string;
+  amount: number;
+  remainingAmount: number;
+}
+
+export interface CreditReconstruction {
+  /** Outstanding balance reconstructed from the ledger as of the month's end. */
+  remainingAsOfMonthEnd: number;
+  /** Credit movement attributed to this credit and dated inside the month (signed). */
+  inMonthMovement: number;
+  /**
+   * True when ledger activity for the credit's client×currency pool could not
+   * be attributed to a specific credit, forcing the reconstructed value to be
+   * capped at the current remaining balance instead of guessed.
+   */
+  limited: boolean;
+}
+
+function normalizeMetadata(metadata: unknown): Record<string, unknown> {
+  if (metadata && typeof metadata === 'object') return metadata as Record<string, unknown>;
+  if (typeof metadata === 'string') {
+    try {
+      const parsed = JSON.parse(metadata);
+      return parsed && typeof parsed === 'object' ? (parsed as Record<string, unknown>) : {};
+    } catch {
+      return {};
+    }
+  }
+  return {};
+}
+
+interface AppliedCreditSplit {
+  creditId?: unknown;
+  transactionId?: unknown;
+  amount?: unknown;
+}
+
+/** `metadata.applied_credits` as written by creditActions.applyCredits: [{creditId, amount, transactionId}]. */
+function appliedCreditsOf(metadata: unknown): AppliedCreditSplit[] {
+  const applied = normalizeMetadata(metadata).applied_credits;
+  if (!Array.isArray(applied)) return [];
+  return applied.filter((entry): entry is AppliedCreditSplit => typeof entry === 'object' && entry !== null);
+}
+
+function splitMatchesCredit(split: AppliedCreditSplit, credit: CreditBalanceSource): boolean {
+  return (
+    (typeof split.creditId === 'string' && split.creditId === credit.creditId) ||
+    (typeof split.transactionId === 'string' && split.transactionId === credit.transactionId)
+  );
+}
+
+function creditKeyOf(txn: { clientId: string; currencyCode?: string | null }): string {
+  return `${txn.clientId}\u0000${txn.currencyCode || 'USD'}`;
+}
+
+interface AdjustmentContribution {
+  amount: number;
+  inMonth: boolean;
+}
+
+/**
+ * Attribute one credit_adjustment / credit_transfer to the credit(s) it moves,
+ * following the ledger's own linkage:
+ *
+ * 1. `metadata.reversal_of` referencing a credit_application → reuse that
+ *    application's `metadata.applied_credits` split, prorated to the
+ *    adjustment's amount (invoice-void reversals restore the applied pool).
+ * 2. `metadata.credit_id` → the named credit (credit-note-void clawbacks).
+ * 3. `related_transaction_id` pointing at a credit's issuance transaction →
+ *    that credit (transfer-outs, issuance reversals).
+ *
+ * Returns the signed per-credit amounts, or null when the adjustment cannot be
+ * tied to any credit (FinancialService-era / pre-metadata adjustments) — the
+ * caller then treats it as unattributable instead of guessing.
+ */
+function attributeAdjustment(
+  txn: CreditTransactionRow,
+  credits: CreditBalanceSource[],
+  creditByTransactionId: Map<string, CreditBalanceSource>,
+  transactionById: Map<string, CreditTransactionRow>,
+): Map<string, number> | null {
+  const meta = normalizeMetadata(txn.metadata);
+  const contributions = new Map<string, number>();
+
+  const reversalOf = meta.reversal_of;
+  if (typeof reversalOf === 'string') {
+    const original = transactionById.get(reversalOf);
+    if (original && original.type === 'credit_application') {
+      const split = appliedCreditsOf(original.metadata);
+      const totalSplit = split.reduce((sum, entry) => sum + (Number(entry.amount) || 0), 0);
+      const adjustmentAmount = Number(txn.amount) || 0;
+      for (const entry of split) {
+        const credit = credits.find((candidate) => splitMatchesCredit(entry, candidate));
+        if (!credit) continue;
+        const share =
+          totalSplit !== 0
+            ? (Number(entry.amount) || 0) * (adjustmentAmount / totalSplit)
+            : split.length > 0
+              ? adjustmentAmount / split.length
+              : 0;
+        contributions.set(credit.creditId, (contributions.get(credit.creditId) ?? 0) + share);
+      }
+      if (contributions.size > 0) return contributions;
+    }
+  }
+
+  const creditId = meta.credit_id;
+  if (typeof creditId === 'string' && credits.some((credit) => credit.creditId === creditId)) {
+    contributions.set(creditId, Number(txn.amount) || 0);
+    return contributions;
+  }
+
+  if (txn.relatedTransactionId) {
+    const credit = creditByTransactionId.get(txn.relatedTransactionId);
+    if (credit) {
+      contributions.set(credit.creditId, Number(txn.amount) || 0);
+      return contributions;
+    }
+  }
+
+  return null;
+}
+
+/**
+ * Reconstruct each credit's remaining balance as of the selected month's end
+ * from the `transactions` ledger — not from the *current* `credit_tracking`
+ * state. A credit issued in month M-1 and fully applied in month M+1 still
+ * shows its full outstanding balance for month M, because the application is
+ * dated after M's end.
+ *
+ * Per credit: issuance amount, minus applications before month end (attributed
+ * through `metadata.applied_credits`), minus expirations before month end
+ * (linked via `related_transaction_id` → the credit's issuance transaction),
+ * plus/minus adjustments before month end (attributed via `reversal_of` /
+ * `credit_id` / `related_transaction_id` linkage).
+ *
+ * Movement that cannot be tied to a specific credit (FinancialService-era /
+ * pre-metadata adjustments) is never guessed: the affected client×currency
+ * pool's credits are capped at their current remaining balance and flagged
+ * `limited` so the report can disclose the limitation.
+ */
+export function reconstructCreditBalances(
+  month: string,
+  credits: CreditBalanceSource[],
+  transactions: CreditTransactionRow[],
+): Map<string, CreditReconstruction> {
+  const [year, monthIndex] = month.split('-').map(Number);
+  const monthStart = Date.UTC(year, monthIndex - 1, 1);
+  const monthEnd = Date.UTC(year, monthIndex, 1);
+
+  const creditByTransactionId = new Map<string, CreditBalanceSource>();
+  for (const credit of credits) {
+    creditByTransactionId.set(credit.transactionId, credit);
+  }
+
+  const datedBeforeMonthEnd = (txn: CreditTransactionRow): boolean => {
+    const ms = Date.parse(txn.createdAt);
+    return Number.isFinite(ms) && ms < monthEnd;
+  };
+  const datedInMonth = (txn: CreditTransactionRow): boolean => {
+    const ms = Date.parse(txn.createdAt);
+    return Number.isFinite(ms) && ms >= monthStart && ms < monthEnd;
+  };
+
+  const applicationTxns = transactions.filter(
+    (txn) => txn.type === 'credit_application' && datedBeforeMonthEnd(txn),
+  );
+  const expirationTxns = transactions.filter(
+    (txn) => txn.type === 'credit_expiration' && datedBeforeMonthEnd(txn),
+  );
+  // Transfer-in rows are the target credit's own issuance (their amount is the
+  // credit's base, not an adjustment), so the adjustment pass skips them.
+  const adjustmentTxns = transactions.filter(
+    (txn) =>
+      (txn.type === 'credit_adjustment' || txn.type === 'credit_transfer') &&
+      datedBeforeMonthEnd(txn) &&
+      !creditByTransactionId.has(txn.transactionId),
+  );
+
+  const transactionById = new Map<string, CreditTransactionRow>();
+  for (const txn of transactions) transactionById.set(txn.transactionId, txn);
+
+  const adjustmentContributions = new Map<string, AdjustmentContribution[]>();
+  const groupsWithUnattributable = new Set<string>();
+
+  for (const txn of adjustmentTxns) {
+    const contribution = attributeAdjustment(txn, credits, creditByTransactionId, transactionById);
+    if (contribution) {
+      for (const [creditId, amount] of contribution) {
+        const list = adjustmentContributions.get(creditId) ?? [];
+        list.push({ amount, inMonth: datedInMonth(txn) });
+        adjustmentContributions.set(creditId, list);
+      }
+    } else {
+      groupsWithUnattributable.add(creditKeyOf(txn));
+    }
+  }
+
+  // An application with no `applied_credits` linkage cannot be attributed to a
+  // specific credit either — same do-not-guess treatment as adjustments.
+  for (const txn of applicationTxns) {
+    const attributedToAnyCredit = appliedCreditsOf(txn.metadata).some((entry) =>
+      credits.some((credit) => splitMatchesCredit(entry, credit)),
+    );
+    if (!attributedToAnyCredit) {
+      groupsWithUnattributable.add(creditKeyOf(txn));
+    }
+  }
+
+  const result = new Map<string, CreditReconstruction>();
+
+  for (const credit of credits) {
+    let remaining = Number(credit.amount) || 0;
+    let inMonthMovement = 0;
+
+    for (const txn of applicationTxns) {
+      if (creditKeyOf(txn) !== creditKeyOf(credit)) continue;
+      const split = appliedCreditsOf(txn.metadata).find((entry) => splitMatchesCredit(entry, credit));
+      if (!split) continue;
+      const share = Number(split.amount) || 0;
+      remaining -= share;
+      if (datedInMonth(txn)) inMonthMovement -= share;
+    }
+
+    for (const txn of expirationTxns) {
+      if (txn.relatedTransactionId !== credit.transactionId) continue;
+      const amount = Number(txn.amount) || 0;
+      remaining += amount; // expiration amounts are negative
+      if (datedInMonth(txn)) inMonthMovement += amount;
+    }
+
+    for (const contribution of adjustmentContributions.get(credit.creditId) ?? []) {
+      remaining += contribution.amount;
+      if (contribution.inMonth) inMonthMovement += contribution.amount;
+    }
+
+    if (remaining < 0) remaining = 0;
+
+    const limited = groupsWithUnattributable.has(creditKeyOf(credit));
+    if (limited) {
+      remaining = Math.min(remaining, Number(credit.remainingAmount) || 0);
+    }
+
+    result.set(credit.creditId, {
+      remainingAsOfMonthEnd: remaining,
+      inMonthMovement,
+      limited,
+    });
+  }
+
+  return result;
 }

--- a/packages/reporting/src/actions/report-actions/deferred-revenue/credits.ts
+++ b/packages/reporting/src/actions/report-actions/deferred-revenue/credits.ts
@@ -1,0 +1,148 @@
+/**
+ * Credits rollforward — pure computation over the `transactions` ledger.
+ *
+ * Sign conventions verified against packages/billing/src/actions/creditActions.ts
+ * and packages/jobs/src/lib/handlers/expiredCreditsHandler.ts:
+ *
+ *   - credit_issuance                         positive (grants balance)
+ *   - credit_issuance_from_negative_invoice   positive
+ *   - prepayment                              positive (legacy; the current
+ *       writer records prepayments as credit_issuance)
+ *   - credit_application                      negative
+ *   - credit_expiration                       negative
+ *   - credit_adjustment                       positive (reversal) or negative (clawback)
+ *   - credit_transfer                         negative on source client, positive on target
+ *
+ * Movement columns are signed sums of `amount` bucketed by transaction type;
+ * opening is the signed sum of all credit-affecting transactions dated before
+ * the month, closing = opening + in-month movement. Credits stay on the
+ * transaction ledger / calendar months — not service-period cadence.
+ */
+
+import { emptyMovement, type MovementColumns } from './types';
+
+export type CreditMovementKey = 'issued' | 'applied' | 'expired' | 'adjustments';
+
+const ISSUED_TYPES = new Set([
+  'credit_issuance',
+  'credit_issuance_from_negative_invoice',
+  'prepayment',
+]);
+const APPLIED_TYPES = new Set(['credit_application']);
+const EXPIRED_TYPES = new Set(['credit_expiration']);
+const ADJUSTMENT_TYPES = new Set(['credit_adjustment', 'credit_transfer']);
+
+export function creditMovementKey(type: string): CreditMovementKey | null {
+  if (ISSUED_TYPES.has(type)) return 'issued';
+  if (APPLIED_TYPES.has(type)) return 'applied';
+  if (EXPIRED_TYPES.has(type)) return 'expired';
+  if (ADJUSTMENT_TYPES.has(type)) return 'adjustments';
+  return null;
+}
+
+export interface CreditTransactionRow {
+  transactionId: string;
+  clientId: string;
+  currencyCode: string;
+  type: string;
+  amount: number;
+  createdAt: string;
+}
+
+export interface CreditRollforward {
+  opening: number;
+  movement: MovementColumns;
+  closing: number;
+}
+
+export interface ClientCurrencyKey {
+  clientId: string;
+  currencyCode: string;
+}
+
+function keyOf(clientId: string, currencyCode: string): string {
+  return `${clientId}\u0000${currencyCode}`;
+}
+
+export function parseClientCurrencyKey(key: string): ClientCurrencyKey {
+  const separator = key.indexOf('\u0000');
+  return {
+    clientId: key.slice(0, separator),
+    currencyCode: key.slice(separator + 1),
+  };
+}
+
+/**
+ * Build the per-client×currency credits rollforward for one calendar month.
+ *
+ * @param month 'YYYY-MM'
+ * @param transactions every credit-affecting transaction for the tenant
+ * @returns map keyed by `${clientId}\u0000${currencyCode}`
+ */
+export function computeCreditRollforward(
+  month: string,
+  transactions: CreditTransactionRow[],
+): Map<string, CreditRollforward> {
+  const [year, monthIndex] = month.split('-').map(Number);
+  const monthStart = Date.UTC(year, monthIndex - 1, 1);
+  const monthEnd = Date.UTC(year, monthIndex, 1);
+
+  const buckets = new Map<string, CreditRollforward>();
+
+  for (const transaction of transactions) {
+    const movementKey = creditMovementKey(transaction.type);
+    if (!movementKey) continue;
+
+    const amount = Number(transaction.amount) || 0;
+    if (amount === 0) continue;
+
+    const key = keyOf(transaction.clientId, transaction.currencyCode || 'USD');
+    const bucket = buckets.get(key) ?? {
+      opening: 0,
+      movement: emptyMovement(),
+      closing: 0,
+    };
+
+    const createdMs = Date.parse(transaction.createdAt);
+    if (Number.isNaN(createdMs)) continue;
+
+    if (createdMs < monthStart) {
+      bucket.opening += amount;
+    } else if (createdMs < monthEnd) {
+      bucket.movement[movementKey] += amount;
+    }
+    // Transactions dated at or after the month end are the next month's business.
+
+    buckets.set(key, bucket);
+  }
+
+  for (const bucket of buckets.values()) {
+    bucket.closing =
+      bucket.opening +
+      bucket.movement.issued +
+      bucket.movement.applied +
+      bucket.movement.expired +
+      bucket.movement.adjustments;
+  }
+
+  return buckets;
+}
+
+/**
+ * Sum the credits rollforward for a single client×currency. Handy for the
+ * tie-out assertion against availableCreditByClientQuery.
+ */
+export function sumCreditRollforward(
+  month: string,
+  transactions: CreditTransactionRow[],
+  clientId: string,
+  currencyCode: string,
+): CreditRollforward {
+  return (
+    computeCreditRollforward(month, transactions).get(keyOf(clientId, currencyCode)) ?? {
+      opening: 0,
+      movement: emptyMovement(),
+      closing: 0,
+    }
+  );
+}

--- a/packages/reporting/src/actions/report-actions/deferred-revenue/credits.ts
+++ b/packages/reporting/src/actions/report-actions/deferred-revenue/credits.ts
@@ -220,6 +220,42 @@ interface AdjustmentContribution {
 }
 
 /**
+ * Apportion an adjustment across the per-credit split recorded by a
+ * `credit_application`'s `metadata.applied_credits`, prorated to the
+ * adjustment's amount. Every adjustment that reverses an application restores
+ * the exact pool the application drew from, so the split is canonical — it must
+ * always be read from `applied_credits`, never from the application row's own
+ * `related_transaction_id` (the writer loop overwrites that with only the LAST
+ * applied credit).
+ *
+ * Returns the signed per-credit amounts, or null when the application carries
+ * no usable `applied_credits` split (genuinely legacy application — the caller
+ * keeps treating the adjustment as unattributable).
+ */
+function attributeViaAppliedCredits(
+  application: CreditTransactionRow,
+  adjustment: CreditTransactionRow,
+  credits: CreditBalanceSource[],
+): Map<string, number> | null {
+  const split = appliedCreditsOf(application.metadata);
+  if (split.length === 0) return null;
+
+  const totalSplit = split.reduce((sum, entry) => sum + (Number(entry.amount) || 0), 0);
+  const adjustmentAmount = Number(adjustment.amount) || 0;
+  const contributions = new Map<string, number>();
+  for (const entry of split) {
+    const credit = credits.find((candidate) => splitMatchesCredit(entry, candidate));
+    if (!credit) continue;
+    const share =
+      totalSplit !== 0
+        ? (Number(entry.amount) || 0) * (adjustmentAmount / totalSplit)
+        : adjustmentAmount / split.length;
+    contributions.set(credit.creditId, (contributions.get(credit.creditId) ?? 0) + share);
+  }
+  return contributions.size > 0 ? contributions : null;
+}
+
+/**
  * Attribute one credit_adjustment / credit_transfer to the credit(s) it moves,
  * following the ledger's own linkage:
  *
@@ -227,12 +263,18 @@ interface AdjustmentContribution {
  *    application's `metadata.applied_credits` split, prorated to the
  *    adjustment's amount (invoice-void reversals restore the applied pool).
  * 2. `metadata.credit_id` → the named credit (credit-note-void clawbacks).
- * 3. `related_transaction_id` pointing at a credit's issuance transaction →
+ * 3. `related_transaction_id` referencing a credit_application that carries
+ *    `metadata.applied_credits` → the same split apportionment as (1).
+ *    FinancialService-era reversals write no metadata at all — only
+ *    `related_transaction_id` pointing back at the original application — so
+ *    the dereferenced application's canonical split is honored here.
+ * 4. `related_transaction_id` pointing at a credit's issuance transaction →
  *    that credit (transfer-outs, issuance reversals).
  *
  * Returns the signed per-credit amounts, or null when the adjustment cannot be
- * tied to any credit (FinancialService-era / pre-metadata adjustments) — the
- * caller then treats it as unattributable instead of guessing.
+ * tied to any credit (genuinely legacy / pre-metadata adjustments whose
+ * referenced application carries no `applied_credits`) — the caller then treats
+ * it as unattributable instead of guessing.
  */
 function attributeAdjustment(
   txn: CreditTransactionRow,
@@ -241,39 +283,32 @@ function attributeAdjustment(
   transactionById: Map<string, CreditTransactionRow>,
 ): Map<string, number> | null {
   const meta = normalizeMetadata(txn.metadata);
-  const contributions = new Map<string, number>();
 
   const reversalOf = meta.reversal_of;
   if (typeof reversalOf === 'string') {
     const original = transactionById.get(reversalOf);
     if (original && original.type === 'credit_application') {
-      const split = appliedCreditsOf(original.metadata);
-      const totalSplit = split.reduce((sum, entry) => sum + (Number(entry.amount) || 0), 0);
-      const adjustmentAmount = Number(txn.amount) || 0;
-      for (const entry of split) {
-        const credit = credits.find((candidate) => splitMatchesCredit(entry, candidate));
-        if (!credit) continue;
-        const share =
-          totalSplit !== 0
-            ? (Number(entry.amount) || 0) * (adjustmentAmount / totalSplit)
-            : split.length > 0
-              ? adjustmentAmount / split.length
-              : 0;
-        contributions.set(credit.creditId, (contributions.get(credit.creditId) ?? 0) + share);
-      }
-      if (contributions.size > 0) return contributions;
+      const contributions = attributeViaAppliedCredits(original, txn, credits);
+      if (contributions) return contributions;
     }
   }
 
   const creditId = meta.credit_id;
   if (typeof creditId === 'string' && credits.some((credit) => credit.creditId === creditId)) {
+    const contributions = new Map<string, number>();
     contributions.set(creditId, Number(txn.amount) || 0);
     return contributions;
   }
 
   if (txn.relatedTransactionId) {
+    const related = transactionById.get(txn.relatedTransactionId);
+    if (related && related.type === 'credit_application') {
+      const contributions = attributeViaAppliedCredits(related, txn, credits);
+      if (contributions) return contributions;
+    }
     const credit = creditByTransactionId.get(txn.relatedTransactionId);
     if (credit) {
+      const contributions = new Map<string, number>();
       contributions.set(credit.creditId, Number(txn.amount) || 0);
       return contributions;
     }

--- a/packages/reporting/src/actions/report-actions/deferred-revenue/deferredRevenueReport.integration.test.ts
+++ b/packages/reporting/src/actions/report-actions/deferred-revenue/deferredRevenueReport.integration.test.ts
@@ -522,4 +522,135 @@ describe.skipIf(SKIP)('deferred revenue report — database-backed integration',
       await db.destroy().catch(() => undefined);
     }
   });
+
+  it('reconstructs month-M detail for a credit issued in M-1 and fully applied in M+1 (fix round 3)', async () => {
+    if (!dbPassword) {
+      throw new Error('Missing secrets/db_password_server — cannot reach the dev database');
+    }
+
+    const db: Knex = knex({
+      client: 'pg',
+      connection: {
+        host: dbHost,
+        port: dbPort,
+        user: dbUser,
+        password: dbPassword,
+        database: dbName,
+      },
+      pool: { min: 1, max: 2 },
+    });
+
+    try {
+      const trx = await db.transaction();
+      try {
+        const clientId = uuidv4();
+        const now = new Date().toISOString();
+        await trx('tenants').insert({
+          tenant: TENANT,
+          client_name: 'Deferred Revenue Integration',
+          email: 'deferred-revenue@example.test',
+          created_at: now,
+          updated_at: now,
+        });
+        await trx('clients').insert({
+          tenant: TENANT,
+          client_id: clientId,
+          client_name: 'Acme Corp',
+          client_type: 'company',
+          is_tax_exempt: false,
+          billing_cycle: 'monthly',
+          default_currency_code: 'USD',
+          lifecycle_status: 'active',
+          created_at: now,
+          updated_at: now,
+        });
+
+        const insertCreditTxn = async (over: {
+          amount: number;
+          type: string;
+          created_at: string;
+          description?: string;
+          related_transaction_id?: string;
+          metadata?: Record<string, unknown>;
+        }) => {
+          const [inserted] = await trx('transactions')
+            .insert({
+              tenant: TENANT,
+              client_id: clientId,
+              amount: over.amount,
+              type: over.type,
+              created_at: over.created_at,
+              status: 'completed',
+              description: over.description ?? over.type,
+              currency_code: 'USD',
+              invoice_id: null,
+              related_transaction_id: over.related_transaction_id ?? null,
+              metadata: over.metadata ?? null,
+            })
+            .returning('transaction_id');
+          return inserted.transaction_id;
+        };
+
+        // Credit issued in M-1 (Jan), fully applied in M+1 (Mar). The current
+        // tracking row says remaining 0 — the February report must still show
+        // the full outstanding liability and reconcile detail to closing.
+        const issuanceId = await insertCreditTxn({
+          amount: 2000,
+          type: 'credit_issuance',
+          created_at: '2026-01-15T10:00:00.000Z',
+          description: 'M-1 prepayment credit',
+        });
+        const creditId = uuidv4();
+        await trx('credit_tracking').insert({
+          tenant: TENANT,
+          credit_id: creditId,
+          transaction_id: issuanceId,
+          client_id: clientId,
+          amount: 2000,
+          remaining_amount: 0,
+          created_at: '2026-01-15T10:00:00.000Z',
+          is_expired: false,
+          updated_at: now,
+          currency_code: 'USD',
+        });
+        await insertCreditTxn({
+          amount: -2000,
+          type: 'credit_application',
+          created_at: '2026-03-10T10:00:00.000Z',
+          description: 'M+1 full application',
+          related_transaction_id: issuanceId,
+          metadata: {
+            applied_credits: [{ creditId, amount: 2000, transactionId: issuanceId }],
+          },
+        });
+
+        const feb = await buildDeferredRevenueReport(trx, TENANT, '2026-02');
+        const usdFeb = feb.sections.find((section) => section.currencyCode === 'USD');
+        expect(usdFeb).toBeDefined();
+        const acmeFeb = clientByName(usdFeb!, 'Acme Corp');
+        expect(acmeFeb.credits.opening).toBe(2000);
+        expect(acmeFeb.credits.closing).toBe(2000);
+        expect(acmeFeb.creditDetails).toHaveLength(1);
+        expect(acmeFeb.creditDetails[0].creditId).toBe(creditId);
+        expect(acmeFeb.creditDetails[0].remainingAmount).toBe(2000);
+        expect(
+          acmeFeb.creditDetails.reduce((sum, detail) => sum + detail.remainingAmount, 0),
+        ).toBe(acmeFeb.credits.closing);
+
+        const mar = await buildDeferredRevenueReport(trx, TENANT, '2026-03');
+        const usdMar = mar.sections.find((section) => section.currencyCode === 'USD');
+        const acmeMar = clientByName(usdMar!, 'Acme Corp');
+        expect(acmeMar.credits.closing).toBe(0);
+        expect(acmeMar.creditDetails).toHaveLength(1);
+        expect(acmeMar.creditDetails[0].remainingAmount).toBe(0);
+        expect(
+          acmeMar.creditDetails.reduce((sum, detail) => sum + detail.remainingAmount, 0),
+        ).toBe(acmeMar.credits.closing);
+      } finally {
+        await trx.rollback().catch(() => undefined);
+      }
+    } finally {
+      await db.destroy().catch(() => undefined);
+    }
+  });
 });

--- a/packages/reporting/src/actions/report-actions/deferred-revenue/deferredRevenueReport.integration.test.ts
+++ b/packages/reporting/src/actions/report-actions/deferred-revenue/deferredRevenueReport.integration.test.ts
@@ -1,0 +1,525 @@
+import { readFileSync } from 'node:fs';
+import path from 'node:path';
+import { describe, expect, it } from 'vitest';
+import { knex, type Knex } from 'knex';
+import { v4 as uuidv4 } from 'uuid';
+
+import { buildDeferredRevenueReport } from './compose';
+import type { ClientRollforward, CurrencySection } from './types';
+
+/**
+ * Database-backed integration test for the deferred-revenue report.
+ *
+ * Connects to the worktree's dev database (DB_HOST / DB_PORT, defaulting to
+ * the local dev stack), seeds a scratch tenant inside a single transaction,
+ * and rolls the transaction back afterwards — nothing is persisted. Set
+ * SKIP_DB_INTEGRATION_TESTS=true to skip when no database is reachable.
+ */
+
+const repoRoot = path.resolve(__dirname, '../../../../../..');
+const SKIP = process.env.SKIP_DB_INTEGRATION_TESTS === 'true';
+
+function readSecret(name: string): string {
+  try {
+    return readFileSync(path.join(repoRoot, 'secrets', name), 'utf8').trim();
+  } catch {
+    return '';
+  }
+}
+
+const dbHost = process.env.DB_HOST || '127.0.0.1';
+const dbPort = parseInt(process.env.DB_PORT || '6472', 10);
+const dbUser = process.env.DB_USER_SERVER || 'app_user';
+const dbPassword = readSecret('db_password_server');
+const dbName = process.env.DB_NAME_SERVER || 'server';
+
+const TENANT = uuidv4();
+
+async function seedFixtures(trx: Knex.Transaction): Promise<{
+  clientAId: string;
+  clientBId: string;
+  contractLineBucketMonthlyId: string;
+}> {
+  const clientAId = uuidv4();
+  const clientBId = uuidv4();
+  const contractId = uuidv4();
+  const lineMonthlyId = uuidv4();
+  const lineRolloverId = uuidv4();
+  const serviceId = uuidv4();
+  const serviceTypeId = uuidv4();
+  const bucketConfigMonthlyId = uuidv4();
+  const bucketConfigRolloverId = uuidv4();
+  const fixedConfigMonthlyId = uuidv4();
+  const invoiceFeeId = uuidv4();
+  const invoicePrepayId = uuidv4();
+  const feeChargeId = uuidv4();
+  const feeDetailId = uuidv4();
+  const now = new Date().toISOString();
+
+  await trx('tenants').insert({
+    tenant: TENANT,
+    client_name: 'Deferred Revenue Integration',
+    email: 'deferred-revenue@example.test',
+    created_at: now,
+    updated_at: now,
+  });
+
+  await trx('service_types').insert({
+    id: serviceTypeId,
+    tenant: TENANT,
+    name: 'Block Hours',
+    standard_service_type_id: null,
+    is_active: true,
+    order_number: 1,
+  });
+
+  await trx('service_catalog').insert({
+    service_id: serviceId,
+    tenant: TENANT,
+    service_name: 'Engineering Block',
+    description: 'Integration fixture',
+    default_rate: 60000,
+    billing_method: 'hourly',
+    custom_service_type_id: serviceTypeId,
+    item_kind: 'service',
+    is_active: true,
+    is_license: false,
+  });
+
+  for (const client of [
+    { client_id: clientAId, client_name: 'Acme Corp' },
+    { client_id: clientBId, client_name: 'Globex' },
+  ]) {
+    await trx('clients').insert({
+      tenant: TENANT,
+      client_id: client.client_id,
+      client_name: client.client_name,
+      client_type: 'company',
+      is_tax_exempt: false,
+      billing_cycle: 'monthly',
+      default_currency_code: 'USD',
+      lifecycle_status: 'active',
+      created_at: now,
+      updated_at: now,
+    });
+  }
+
+  await trx('contracts').insert({
+    tenant: TENANT,
+    contract_id: contractId,
+    contract_name: 'Support Contract',
+    billing_frequency: 'monthly',
+    status: 'active',
+    is_template: false,
+    currency_code: 'USD',
+    is_system_managed_default: false,
+    created_at: now,
+    updated_at: now,
+  });
+
+  const insertLine = async (line: {
+    contract_line_id: string;
+    contract_line_name: string;
+    contract_line_type: string;
+    custom_rate?: number;
+  }) => {
+    await trx('contract_lines').insert({
+      tenant: TENANT,
+      contract_line_id: line.contract_line_id,
+      contract_line_name: line.contract_line_name,
+      billing_frequency: 'monthly',
+      contract_line_type: line.contract_line_type,
+      is_active: true,
+      is_template: false,
+      billing_timing: 'arrears',
+      display_order: 0,
+      enable_proration: false,
+      billing_cycle_alignment: 'start',
+      cadence_owner: 'client',
+      contract_id: contractId,
+      custom_rate: line.custom_rate ?? null,
+      created_at: now,
+      updated_at: now,
+    });
+  };
+
+  await insertLine({
+    contract_line_id: lineMonthlyId,
+    contract_line_name: 'Monthly Block Hours',
+    contract_line_type: 'Bucket',
+  });
+  await insertLine({
+    contract_line_id: lineRolloverId,
+    contract_line_name: 'Rollover Block Hours',
+    contract_line_type: 'Bucket',
+    custom_rate: 60000, // configured-fee fallback path (no invoice)
+  });
+
+  // Bucket config for the monthly line (100h, no rollover) plus a Fixed
+  // config carrying the billed base fee.
+  await trx('contract_line_service_configuration').insert({
+    config_id: bucketConfigMonthlyId,
+    tenant: TENANT,
+    contract_line_id: lineMonthlyId,
+    service_id: serviceId,
+    configuration_type: 'Bucket',
+    created_at: now,
+    updated_at: now,
+  });
+  await trx('contract_line_service_bucket_config').insert({
+    config_id: bucketConfigMonthlyId,
+    tenant: TENANT,
+    total_minutes: 6000,
+    billing_period: 'monthly',
+    overage_rate: 20000,
+    allow_rollover: false,
+    created_at: now,
+    updated_at: now,
+  });
+  await trx('contract_line_service_configuration').insert({
+    config_id: fixedConfigMonthlyId,
+    tenant: TENANT,
+    contract_line_id: lineMonthlyId,
+    service_id: serviceId,
+    configuration_type: 'Fixed',
+    created_at: now,
+    updated_at: now,
+  });
+  await trx('contract_line_service_fixed_config').insert({
+    config_id: fixedConfigMonthlyId,
+    tenant: TENANT,
+    base_rate: 100000,
+    created_at: now,
+    updated_at: now,
+  });
+
+  // Bucket config for the rollover line (50h, rollover allowed).
+  await trx('contract_line_service_configuration').insert({
+    config_id: bucketConfigRolloverId,
+    tenant: TENANT,
+    contract_line_id: lineRolloverId,
+    service_id: serviceId,
+    configuration_type: 'Bucket',
+    created_at: now,
+    updated_at: now,
+  });
+  await trx('contract_line_service_bucket_config').insert({
+    config_id: bucketConfigRolloverId,
+    tenant: TENANT,
+    total_minutes: 3000,
+    billing_period: 'monthly',
+    overage_rate: 20000,
+    allow_rollover: true,
+    created_at: now,
+    updated_at: now,
+  });
+
+  // Finalized invoice billing the monthly line's Feb service period.
+  await trx('invoices').insert({
+    tenant: TENANT,
+    invoice_id: invoiceFeeId,
+    client_id: clientAId,
+    invoice_number: 'INV-FEE-001',
+    invoice_date: '2026-02-01T00:00:00.000Z',
+    due_date: '2026-03-01T00:00:00.000Z',
+    subtotal: 100000,
+    tax: 0,
+    total_amount: 100000,
+    status: 'sent',
+    finalized_at: '2026-02-01T00:00:00.000Z',
+    is_prepayment: false,
+    is_manual: true,
+    currency_code: 'USD',
+    invoice_type: 'standard',
+    credit_applied: 0,
+  });
+  await trx('invoice_charges').insert({
+    tenant: TENANT,
+    item_id: feeChargeId,
+    invoice_id: invoiceFeeId,
+    service_id: serviceId,
+    description: 'Monthly Block Hours',
+    quantity: 1,
+    unit_price: 100000,
+    total_price: 100000,
+    net_amount: 100000,
+    tax_rate: 0,
+    is_manual: true,
+  });
+  await trx('invoice_charge_details').insert({
+    item_detail_id: feeDetailId,
+    item_id: feeChargeId,
+    tenant: TENANT,
+    service_id: serviceId,
+    config_id: fixedConfigMonthlyId,
+    quantity: 1,
+    rate: 100000,
+    service_period_start: '2026-02-01',
+    service_period_end: '2026-02-28',
+    billing_timing: 'arrears',
+  });
+
+  // Prepayment invoice for the credit.
+  await trx('invoices').insert({
+    tenant: TENANT,
+    invoice_id: invoicePrepayId,
+    client_id: clientAId,
+    invoice_number: 'INV-PP-001',
+    invoice_date: '2026-01-05T00:00:00.000Z',
+    due_date: '2026-01-05T00:00:00.000Z',
+    subtotal: 5000,
+    tax: 0,
+    total_amount: 5000,
+    status: 'sent',
+    finalized_at: '2026-01-05T00:00:00.000Z',
+    is_prepayment: true,
+    is_manual: true,
+    currency_code: 'USD',
+    invoice_type: 'prepayment',
+    credit_applied: 0,
+  });
+
+  // ── Credits ledger ─────────────────────────────────────────────────────
+  const insertCreditTxn = async (over: {
+    client_id: string;
+    amount: number;
+    type: string;
+    created_at: string;
+    invoice_id?: string;
+    description?: string;
+    related_transaction_id?: string;
+  }) => {
+    const [inserted] = await trx('transactions')
+      .insert({
+        tenant: TENANT,
+        client_id: over.client_id,
+        amount: over.amount,
+        type: over.type,
+        created_at: over.created_at,
+        status: 'completed',
+        description: over.description ?? over.type,
+        currency_code: 'USD',
+        invoice_id: over.invoice_id ?? null,
+        related_transaction_id: over.related_transaction_id ?? null,
+      })
+      .returning('transaction_id');
+    return inserted.transaction_id;
+  };
+
+  // Prepayment credit: 5000 granted in Jan, backed by the prepayment invoice.
+  const prepayTxnId = await insertCreditTxn({
+    client_id: clientAId,
+    amount: 5000,
+    type: 'credit_issuance',
+    created_at: '2026-01-05T10:00:00.000Z',
+    invoice_id: invoicePrepayId,
+    description: 'Credit issued from prepayment',
+  });
+  await trx('credit_tracking').insert({
+    tenant: TENANT,
+    credit_id: uuidv4(),
+    transaction_id: prepayTxnId,
+    client_id: clientAId,
+    amount: 5000,
+    remaining_amount: 5000,
+    created_at: '2026-01-05T10:00:00.000Z',
+    is_expired: false,
+    updated_at: now,
+    currency_code: 'USD',
+  });
+
+  // Expired credit: 800 granted in Jan, expires in full in Feb.
+  const expiredTxnId = await insertCreditTxn({
+    client_id: clientAId,
+    amount: 800,
+    type: 'credit_issuance',
+    created_at: '2026-01-10T10:00:00.000Z',
+    description: 'Expiring grant',
+  });
+  await trx('credit_tracking').insert({
+    tenant: TENANT,
+    credit_id: uuidv4(),
+    transaction_id: expiredTxnId,
+    client_id: clientAId,
+    amount: 800,
+    remaining_amount: 0,
+    created_at: '2026-01-10T10:00:00.000Z',
+    expiration_date: '2026-02-15T00:00:00.000Z',
+    is_expired: true,
+    updated_at: now,
+    currency_code: 'USD',
+  });
+  await insertCreditTxn({
+    client_id: clientAId,
+    amount: -800,
+    type: 'credit_expiration',
+    created_at: '2026-02-20T10:00:00.000Z',
+    description: 'Credit expired',
+    related_transaction_id: expiredTxnId,
+  });
+
+  // Applied credit: 2000 of the prepayment applied to an invoice in Feb.
+  await insertCreditTxn({
+    client_id: clientAId,
+    amount: -2000,
+    type: 'credit_application',
+    created_at: '2026-02-10T10:00:00.000Z',
+    description: 'Applied credit to invoice',
+  });
+  await trx('credit_tracking')
+    .where({ transaction_id: prepayTxnId })
+    .update({ remaining_amount: 3000, updated_at: now });
+
+  // ── Bucket usage ───────────────────────────────────────────────────────
+  // Monthly line: Feb 1–28, 2000 of 6000 minutes burned (partial burn).
+  await trx('bucket_usage').insert({
+    tenant: TENANT,
+    usage_id: uuidv4(),
+    contract_line_id: lineMonthlyId,
+    client_id: clientAId,
+    service_catalog_id: serviceId,
+    period_start: '2026-02-01 00:00:00+00',
+    period_end: '2026-02-28 00:00:00+00',
+    minutes_used: 2000,
+    overage_minutes: 0,
+    rolled_over_minutes: 0,
+  });
+
+  // Rollover line, spanning month boundaries: period 1 (Jan 15 – Feb 14)
+  // burns 2400 of 3000 → carries 600 to period 2 (Feb 15 – Mar 14), which
+  // burns 900 of (3000 + 600).
+  await trx('bucket_usage').insert({
+    tenant: TENANT,
+    usage_id: uuidv4(),
+    contract_line_id: lineRolloverId,
+    client_id: clientBId,
+    service_catalog_id: serviceId,
+    period_start: '2026-01-15 00:00:00+00',
+    period_end: '2026-02-14 00:00:00+00',
+    minutes_used: 2400,
+    overage_minutes: 0,
+    rolled_over_minutes: 0,
+  });
+  await trx('bucket_usage').insert({
+    tenant: TENANT,
+    usage_id: uuidv4(),
+    contract_line_id: lineRolloverId,
+    client_id: clientBId,
+    service_catalog_id: serviceId,
+    period_start: '2026-02-15 00:00:00+00',
+    period_end: '2026-03-14 00:00:00+00',
+    minutes_used: 900,
+    overage_minutes: 0,
+    rolled_over_minutes: 600,
+  });
+
+  return { clientAId, clientBId, contractLineBucketMonthlyId: lineMonthlyId };
+}
+
+function clientByName(section: CurrencySection, name: string): ClientRollforward {
+  const client = section.clients.find((row) => row.clientName === name);
+  if (!client) throw new Error(`client ${name} not in section`);
+  return client;
+}
+
+describe.skipIf(SKIP)('deferred revenue report — database-backed integration', () => {
+  it('rolls credits and hours forward across two months with the tie-out and carry invariants', async () => {
+    if (!dbPassword) {
+      throw new Error('Missing secrets/db_password_server — cannot reach the dev database');
+    }
+
+    const db: Knex = knex({
+      client: 'pg',
+      connection: {
+        host: dbHost,
+        port: dbPort,
+        user: dbUser,
+        password: dbPassword,
+        database: dbName,
+      },
+      pool: { min: 1, max: 2 },
+    });
+
+    try {
+      const trx = await db.transaction();
+      try {
+        const { clientAId } = await seedFixtures(trx);
+
+        // ── February rollforward ────────────────────────────────────────
+        const feb = await buildDeferredRevenueReport(trx, TENANT, '2026-02');
+        const usdFeb = feb.sections.find((section) => section.currencyCode === 'USD');
+        expect(usdFeb).toBeDefined();
+
+        const acme = clientByName(usdFeb!, 'Acme Corp');
+        // Credits: opening 5000 + 800, applied -2000, expired -800 → 3000.
+        expect(acme.credits.opening).toBe(5800);
+        expect(acme.credits.applied).toBe(-2000);
+        expect(acme.credits.expired).toBe(-800);
+        expect(acme.credits.closing).toBe(3000);
+        // Prepayment credit detail is flagged QBO-unreachable.
+        expect(acme.creditDetails).toHaveLength(2);
+        const prepayDetail = acme.creditDetails.find((detail) => detail.sourceKind === 'prepayment');
+        expect(prepayDetail).toBeDefined();
+        expect(prepayDetail!.qboReachable).toBe(false);
+        expect(prepayDetail!.remainingAmount).toBe(3000);
+        // Hours: monthly bucket (Feb 1–28) issued its fee, burned a partial
+        // allowance, forfeited the rest at period end.
+        expect(acme.hours.issued).toBe(100000);
+        expect(acme.hours.applied).toBeCloseTo(-(2000 * (100000 / 6000)), 6);
+        expect(acme.hours.closing).toBe(0);
+
+        const globex = clientByName(usdFeb!, 'Globex');
+        // Rollover bucket period 1 (Jan 15–Feb 14): opened at full allowance,
+        // burn attributed to Feb (its end month), carry handed to period 2
+        // (started Feb 15) so period 1 closes at zero. Period 2 (Feb 15–Mar
+        // 14) issued its fee and stays active, its closing holding the carry.
+        const rate = 60000 / 3000;
+        expect(globex.hours.opening).toBe(3000 * rate);
+        expect(globex.hours.issued).toBe(60000);
+        expect(globex.hours.applied).toBe(-(2400 * rate));
+        expect(globex.hours.expired).toBe(0);
+        expect(globex.hours.closing).toBe((3000 + 600) * rate);
+        expect(globex.bucketDetails).toHaveLength(2);
+
+        // Tie-out invariant: closing credits ≡ derived available credit, as
+        // availableCreditByClientQuery (packages/billing/src/lib/creditBalance.ts)
+        // defines it — non-expired tracking rows whose expiration has not passed.
+        const available = await trx('credit_tracking')
+          .where({ tenant: TENANT, client_id: clientAId, is_expired: false })
+          .where((qb) => {
+            qb.whereNull('expiration_date').orWhere('expiration_date', '>', new Date().toISOString());
+          })
+          .sum({ total: 'remaining_amount' })
+          .first();
+        expect(Number(available?.total ?? 0)).toBe(acme.credits.closing);
+
+        // ── March rollforward: closing(Feb) = opening(Mar) ─────────────
+        const mar = await buildDeferredRevenueReport(trx, TENANT, '2026-03');
+        const usdMar = mar.sections.find((section) => section.currencyCode === 'USD');
+        expect(usdMar).toBeDefined();
+
+        const acmeMar = clientByName(usdMar!, 'Acme Corp');
+        expect(acmeMar.credits.opening).toBe(acme.credits.closing);
+        expect(acmeMar.credits.closing).toBe(3000);
+        expect(acmeMar.hours.opening).toBe(0);
+
+        const globexMar = clientByName(usdMar!, 'Globex');
+        expect(globexMar.hours.opening).toBe(globex.hours.closing);
+        expect(globexMar.hours.issued).toBe(0);
+        expect(globexMar.hours.applied).toBe(-(900 * rate));
+        // Leftover 2700: 600 rolled-in minutes lapse, 2100 carry to April.
+        expect(globexMar.hours.expired).toBe(-(600 * rate));
+        expect(globexMar.hours.closing).toBe(2100 * rate);
+
+        // The fallback note is disclosed because the rollover bucket spans
+        // month boundaries.
+        expect(feb.notes.length).toBeGreaterThan(0);
+      } finally {
+        // Never persist the scratch tenant: roll back unconditionally.
+        await trx.rollback().catch(() => undefined);
+      }
+    } finally {
+      await db.destroy().catch(() => undefined);
+    }
+  });
+});

--- a/packages/reporting/src/actions/report-actions/deferred-revenue/deferredRevenueReport.integration.test.ts
+++ b/packages/reporting/src/actions/report-actions/deferred-revenue/deferredRevenueReport.integration.test.ts
@@ -12,12 +12,12 @@ import type { ClientRollforward, CurrencySection } from './types';
  *
  * Connects to the worktree's dev database (DB_HOST / DB_PORT, defaulting to
  * the local dev stack), seeds a scratch tenant inside a single transaction,
- * and rolls the transaction back afterwards — nothing is persisted. Set
- * SKIP_DB_INTEGRATION_TESTS=true to skip when no database is reachable.
+ * and rolls the transaction back afterwards — nothing is persisted. The suite
+ * auto-skips when no dev-database secret is present (e.g. in CI, where there is
+ * no local stack), and SKIP_DB_INTEGRATION_TESTS=true forces a skip explicitly.
  */
 
 const repoRoot = path.resolve(__dirname, '../../../../../..');
-const SKIP = process.env.SKIP_DB_INTEGRATION_TESTS === 'true';
 
 function readSecret(name: string): string {
   try {
@@ -32,6 +32,11 @@ const dbPort = parseInt(process.env.DB_PORT || '6472', 10);
 const dbUser = process.env.DB_USER_SERVER || 'app_user';
 const dbPassword = readSecret('db_password_server');
 const dbName = process.env.DB_NAME_SERVER || 'server';
+
+// Skip when explicitly disabled or when the dev-database secret is absent —
+// the missing secret is the reliable "no reachable database" signal (CI, fresh
+// clones), so the suite skips gracefully instead of failing the run.
+const SKIP = process.env.SKIP_DB_INTEGRATION_TESTS === 'true' || !dbPassword;
 
 const TENANT = uuidv4();
 

--- a/packages/reporting/src/actions/report-actions/deferred-revenue/deferredRevenueReport.integration.test.ts
+++ b/packages/reporting/src/actions/report-actions/deferred-revenue/deferredRevenueReport.integration.test.ts
@@ -653,4 +653,135 @@ describe.skipIf(SKIP)('deferred revenue report — database-backed integration',
       await db.destroy().catch(() => undefined);
     }
   });
+
+  it('restores a credit reversed by a FinancialService-shaped credit_adjustment with only related_transaction_id (fix round 3)', async () => {
+    if (!dbPassword) {
+      throw new Error('Missing secrets/db_password_server — cannot reach the dev database');
+    }
+
+    const db: Knex = knex({
+      client: 'pg',
+      connection: {
+        host: dbHost,
+        port: dbPort,
+        user: dbUser,
+        password: dbPassword,
+        database: dbName,
+      },
+      pool: { min: 1, max: 2 },
+    });
+
+    try {
+      const trx = await db.transaction();
+      try {
+        const clientId = uuidv4();
+        const now = new Date().toISOString();
+        await trx('tenants').insert({
+          tenant: TENANT,
+          client_name: 'Deferred Revenue Integration',
+          email: 'deferred-revenue@example.test',
+          created_at: now,
+          updated_at: now,
+        });
+        await trx('clients').insert({
+          tenant: TENANT,
+          client_id: clientId,
+          client_name: 'Acme Corp',
+          client_type: 'company',
+          is_tax_exempt: false,
+          billing_cycle: 'monthly',
+          default_currency_code: 'USD',
+          lifecycle_status: 'active',
+          created_at: now,
+          updated_at: now,
+        });
+
+        const insertCreditTxn = async (over: {
+          amount: number;
+          type: string;
+          created_at: string;
+          description?: string;
+          related_transaction_id?: string;
+          metadata?: Record<string, unknown>;
+        }) => {
+          const [inserted] = await trx('transactions')
+            .insert({
+              tenant: TENANT,
+              client_id: clientId,
+              amount: over.amount,
+              type: over.type,
+              created_at: over.created_at,
+              status: 'completed',
+              description: over.description ?? over.type,
+              currency_code: 'USD',
+              invoice_id: null,
+              related_transaction_id: over.related_transaction_id ?? null,
+              metadata: over.metadata ?? null,
+            })
+            .returning('transaction_id');
+          return inserted.transaction_id;
+        };
+
+        // Credit issued in Jan, fully applied in Feb (canonical
+        // metadata.applied_credits), then reversed in Mar the way
+        // FinancialService.bulkTransactionOperation (reverse) writes it: a
+        // credit_adjustment with only related_transaction_id → the original
+        // application, and no metadata. Tracking is left at the stale 0 the
+        // legacy writer leaves — the reconstruction must restore 2000 from the
+        // ledger for the reversal month without trusting tracking.
+        const issuanceId = await insertCreditTxn({
+          amount: 2000,
+          type: 'credit_issuance',
+          created_at: '2026-01-15T10:00:00.000Z',
+          description: 'Credit reversed via FinancialService',
+        });
+        const creditId = uuidv4();
+        await trx('credit_tracking').insert({
+          tenant: TENANT,
+          credit_id: creditId,
+          transaction_id: issuanceId,
+          client_id: clientId,
+          amount: 2000,
+          remaining_amount: 0,
+          created_at: '2026-01-15T10:00:00.000Z',
+          is_expired: false,
+          updated_at: now,
+          currency_code: 'USD',
+        });
+        const applicationId = await insertCreditTxn({
+          amount: -2000,
+          type: 'credit_application',
+          created_at: '2026-02-10T10:00:00.000Z',
+          description: 'Full application',
+          related_transaction_id: issuanceId,
+          metadata: {
+            applied_credits: [{ creditId, amount: 2000, transactionId: issuanceId }],
+          },
+        });
+        await insertCreditTxn({
+          amount: 2000,
+          type: 'credit_adjustment',
+          created_at: '2026-03-10T10:00:00.000Z',
+          description: 'FinancialService reversal',
+          related_transaction_id: applicationId,
+        });
+
+        const mar = await buildDeferredRevenueReport(trx, TENANT, '2026-03');
+        const usdMar = mar.sections.find((section) => section.currencyCode === 'USD');
+        expect(usdMar).toBeDefined();
+        const acmeMar = clientByName(usdMar!, 'Acme Corp');
+        expect(acmeMar.credits.closing).toBe(2000);
+        expect(acmeMar.creditDetails).toHaveLength(1);
+        expect(acmeMar.creditDetails[0].creditId).toBe(creditId);
+        expect(acmeMar.creditDetails[0].remainingAmount).toBe(2000);
+        expect(
+          acmeMar.creditDetails.reduce((sum, detail) => sum + detail.remainingAmount, 0),
+        ).toBe(acmeMar.credits.closing);
+      } finally {
+        await trx.rollback().catch(() => undefined);
+      }
+    } finally {
+      await db.destroy().catch(() => undefined);
+    }
+  });
 });

--- a/packages/reporting/src/actions/report-actions/deferred-revenue/fee.test.ts
+++ b/packages/reporting/src/actions/report-actions/deferred-revenue/fee.test.ts
@@ -3,8 +3,10 @@ import { describe, expect, it } from 'vitest';
 import { defaultReportMonth, isValidMonth, monthRange, nextMonth, previousMonth } from './month';
 import { resolvePeriodFee, type BilledFeeCandidate, type ConfiguredFee } from './fee';
 import {
+  buildBucketPeriodInputs,
   resolveConfiguredFee,
   resolvePricingScheduleRate,
+  type BuildDeferredRevenueInput,
   type RawBucketPeriodRow,
   type RawPricingScheduleRow,
 } from './loaders';
@@ -43,18 +45,21 @@ describe('resolvePeriodFee', () => {
   const billed: BilledFeeCandidate[] = [
     {
       contractLineId: 'line-1',
+      serviceId: 'svc-1',
       servicePeriodStart: '2026-02-01',
       servicePeriodEnd: '2026-02-28',
       feeCents: 100000,
     },
     {
       contractLineId: 'line-1',
+      serviceId: 'svc-1',
       servicePeriodStart: '2026-02-08',
       servicePeriodEnd: '2026-02-28',
       feeCents: 75000,
     },
     {
       contractLineId: 'line-2',
+      serviceId: 'svc-1',
       servicePeriodStart: '2026-02-01',
       servicePeriodEnd: '2026-02-28',
       feeCents: 90000,
@@ -63,7 +68,7 @@ describe('resolvePeriodFee', () => {
   const configured: ConfiguredFee = { contractLineId: 'line-1', serviceId: 'svc-1', feeCents: 100000 };
 
   it('prefers the billed fee over the configured fallback', () => {
-    const resolved = resolvePeriodFee('2026-02-01', '2026-02-28', 'line-1', billed, configured.feeCents);
+    const resolved = resolvePeriodFee('2026-02-01', '2026-02-28', 'line-1', 'svc-1', billed, configured.feeCents);
     expect(resolved.feeSource).toBe('billed');
     expect(resolved.feeCents).toBe(100000);
   });
@@ -71,33 +76,116 @@ describe('resolvePeriodFee', () => {
   it('matches the prorated billed detail by longest overlap (exact window wins)', () => {
     // A bucket period Feb 1–28 has two overlapping billed details; the exact
     // window (Feb 1–28) is preferred over the prorated Feb 8–28.
-    const resolved = resolvePeriodFee('2026-02-01', '2026-02-28', 'line-1', billed, null);
+    const resolved = resolvePeriodFee('2026-02-01', '2026-02-28', 'line-1', 'svc-1', billed, null);
     expect(resolved.feeSource).toBe('billed');
     expect(resolved.feeCents).toBe(100000);
   });
 
   it('falls back to a prorated billed detail when no exact window exists', () => {
     const onlyProrated: BilledFeeCandidate[] = [billed[1]];
-    const resolved = resolvePeriodFee('2026-02-01', '2026-02-28', 'line-1', onlyProrated, null);
+    const resolved = resolvePeriodFee('2026-02-01', '2026-02-28', 'line-1', 'svc-1', onlyProrated, null);
     expect(resolved.feeSource).toBe('billed');
     expect(resolved.feeCents).toBe(75000);
   });
 
   it('falls back to the configured fee when nothing overlaps the period', () => {
-    const resolved = resolvePeriodFee('2026-03-01', '2026-03-31', 'line-1', billed, configured.feeCents);
+    const resolved = resolvePeriodFee('2026-03-01', '2026-03-31', 'line-1', 'svc-1', billed, configured.feeCents);
     expect(resolved.feeSource).toBe('configured');
     expect(resolved.feeCents).toBe(100000);
   });
 
   it('resolves zero when no billed or configured fee exists', () => {
-    const resolved = resolvePeriodFee('2026-03-01', '2026-03-31', 'line-1', billed, null);
+    const resolved = resolvePeriodFee('2026-03-01', '2026-03-31', 'line-1', 'svc-1', billed, null);
     expect(resolved).toEqual({ feeCents: 0, feeSource: 'configured' });
   });
 
   it('never matches a different contract line', () => {
-    const resolved = resolvePeriodFee('2026-02-01', '2026-02-28', 'line-2', billed, configured.feeCents);
+    const resolved = resolvePeriodFee('2026-02-01', '2026-02-28', 'line-2', 'svc-1', billed, configured.feeCents);
     expect(resolved.feeSource).toBe('billed');
     expect(resolved.feeCents).toBe(90000);
+  });
+});
+
+describe('multi-service billed-fee disambiguation (Defect 2)', () => {
+  it('values each service bucket at its own billed fee on a shared contract line', () => {
+    // One contract line, two Fixed services billed at different finalized fees.
+    const billed: BilledFeeCandidate[] = [
+      {
+        contractLineId: 'line-1',
+        serviceId: 'svc-a',
+        servicePeriodStart: '2026-02-01',
+        servicePeriodEnd: '2026-02-28',
+        feeCents: 100000,
+      },
+      {
+        contractLineId: 'line-1',
+        serviceId: 'svc-b',
+        servicePeriodStart: '2026-02-01',
+        servicePeriodEnd: '2026-02-28',
+        feeCents: 25000,
+      },
+    ];
+    const configured = 99999;
+
+    const svcA = resolvePeriodFee('2026-02-01', '2026-02-28', 'line-1', 'svc-a', billed, configured);
+    const svcB = resolvePeriodFee('2026-02-01', '2026-02-28', 'line-1', 'svc-b', billed, configured);
+    // Each service gets its own billed fee — not the other service's, not the
+    // configured fallback.
+    expect(svcA).toEqual({ feeCents: 100000, feeSource: 'billed' });
+    expect(svcB).toEqual({ feeCents: 25000, feeSource: 'billed' });
+  });
+
+  it('resolves each service bucket to its own billed fee through the loader path', () => {
+    const base: RawBucketPeriodRow = {
+      usageId: 'u-a',
+      contractLineId: 'line-1',
+      contractId: 'contract-1',
+      contractLineName: 'Block Hours',
+      clientId: 'client-1',
+      serviceId: 'svc-a',
+      serviceName: 'Engineering',
+      periodStart: '2026-02-01',
+      periodEnd: '2026-02-28',
+      minutesUsed: 0,
+      rolledOverMinutes: 0,
+      totalMinutes: 6000,
+      allowRollover: false,
+      currencyCode: 'USD',
+      lineCustomRate: 80000,
+      catalogDefaultRate: 70000,
+    };
+    const data: BuildDeferredRevenueInput = {
+      clients: [],
+      creditTransactions: [],
+      creditTracking: [],
+      creditInvoices: new Map(),
+      bucketPeriods: [base, { ...base, usageId: 'u-b', serviceId: 'svc-b' }],
+      billedFees: [
+        {
+          contractLineId: 'line-1',
+          serviceId: 'svc-a',
+          servicePeriodStart: '2026-02-01',
+          servicePeriodEnd: '2026-02-28',
+          feeCents: 100000,
+        },
+        {
+          contractLineId: 'line-1',
+          serviceId: 'svc-b',
+          servicePeriodStart: '2026-02-01',
+          servicePeriodEnd: '2026-02-28',
+          feeCents: 25000,
+        },
+      ],
+      fixedConfigBaseRates: new Map<string, number | null>(),
+      pricingSchedules: [],
+    };
+
+    const inputs = buildBucketPeriodInputs(data);
+    const byUsage = new Map(inputs.map((input) => [input.usageId, input]));
+    expect(byUsage.get('u-a')!.periodFee).toBe(100000);
+    expect(byUsage.get('u-a')!.feeSource).toBe('billed');
+    expect(byUsage.get('u-b')!.periodFee).toBe(25000);
+    expect(byUsage.get('u-b')!.feeSource).toBe('billed');
   });
 });
 

--- a/packages/reporting/src/actions/report-actions/deferred-revenue/fee.test.ts
+++ b/packages/reporting/src/actions/report-actions/deferred-revenue/fee.test.ts
@@ -1,0 +1,148 @@
+import { describe, expect, it } from 'vitest';
+
+import { defaultReportMonth, isValidMonth, monthRange, nextMonth, previousMonth } from './month';
+import { resolvePeriodFee, type BilledFeeCandidate, type ConfiguredFee } from './fee';
+import {
+  resolveConfiguredFee,
+  resolvePricingScheduleRate,
+  type RawBucketPeriodRow,
+  type RawPricingScheduleRow,
+} from './loaders';
+
+describe('month utilities', () => {
+  it('validates YYYY-MM strings', () => {
+    expect(isValidMonth('2026-02')).toBe(true);
+    expect(isValidMonth('2026-13')).toBe(false);
+    expect(isValidMonth('2026-00')).toBe(false);
+    expect(isValidMonth('2026-2')).toBe(false);
+    expect(isValidMonth('garbage')).toBe(false);
+  });
+
+  it('computes inclusive/exclusive boundaries in UTC', () => {
+    expect(monthRange('2026-02')).toEqual({
+      month: '2026-02',
+      start: '2026-02-01',
+      endExclusive: '2026-03-01',
+    });
+    expect(monthRange('2026-12').endExclusive).toBe('2027-01-01');
+  });
+
+  it('moves between months', () => {
+    expect(nextMonth('2026-02')).toBe('2026-03');
+    expect(previousMonth('2026-02')).toBe('2026-01');
+    expect(previousMonth('2026-01')).toBe('2025-12');
+  });
+
+  it('defaults to the previous month for month-end close', () => {
+    expect(defaultReportMonth(new Date('2026-03-10T12:00:00.000Z'))).toBe('2026-02');
+    expect(defaultReportMonth(new Date('2026-01-02T00:00:00.000Z'))).toBe('2025-12');
+  });
+});
+
+describe('resolvePeriodFee', () => {
+  const billed: BilledFeeCandidate[] = [
+    {
+      contractLineId: 'line-1',
+      servicePeriodStart: '2026-02-01',
+      servicePeriodEnd: '2026-02-28',
+      feeCents: 100000,
+    },
+    {
+      contractLineId: 'line-1',
+      servicePeriodStart: '2026-02-08',
+      servicePeriodEnd: '2026-02-28',
+      feeCents: 75000,
+    },
+    {
+      contractLineId: 'line-2',
+      servicePeriodStart: '2026-02-01',
+      servicePeriodEnd: '2026-02-28',
+      feeCents: 90000,
+    },
+  ];
+  const configured: ConfiguredFee = { contractLineId: 'line-1', serviceId: 'svc-1', feeCents: 100000 };
+
+  it('prefers the billed fee over the configured fallback', () => {
+    const resolved = resolvePeriodFee('2026-02-01', '2026-02-28', 'line-1', billed, configured.feeCents);
+    expect(resolved.feeSource).toBe('billed');
+    expect(resolved.feeCents).toBe(100000);
+  });
+
+  it('matches the prorated billed detail by longest overlap (exact window wins)', () => {
+    // A bucket period Feb 1–28 has two overlapping billed details; the exact
+    // window (Feb 1–28) is preferred over the prorated Feb 8–28.
+    const resolved = resolvePeriodFee('2026-02-01', '2026-02-28', 'line-1', billed, null);
+    expect(resolved.feeSource).toBe('billed');
+    expect(resolved.feeCents).toBe(100000);
+  });
+
+  it('falls back to a prorated billed detail when no exact window exists', () => {
+    const onlyProrated: BilledFeeCandidate[] = [billed[1]];
+    const resolved = resolvePeriodFee('2026-02-01', '2026-02-28', 'line-1', onlyProrated, null);
+    expect(resolved.feeSource).toBe('billed');
+    expect(resolved.feeCents).toBe(75000);
+  });
+
+  it('falls back to the configured fee when nothing overlaps the period', () => {
+    const resolved = resolvePeriodFee('2026-03-01', '2026-03-31', 'line-1', billed, configured.feeCents);
+    expect(resolved.feeSource).toBe('configured');
+    expect(resolved.feeCents).toBe(100000);
+  });
+
+  it('resolves zero when no billed or configured fee exists', () => {
+    const resolved = resolvePeriodFee('2026-03-01', '2026-03-31', 'line-1', billed, null);
+    expect(resolved).toEqual({ feeCents: 0, feeSource: 'configured' });
+  });
+
+  it('never matches a different contract line', () => {
+    const resolved = resolvePeriodFee('2026-02-01', '2026-02-28', 'line-2', billed, configured.feeCents);
+    expect(resolved.feeSource).toBe('billed');
+    expect(resolved.feeCents).toBe(90000);
+  });
+});
+
+describe('resolveConfiguredFee fallback chain', () => {
+  const period: RawBucketPeriodRow = {
+    usageId: 'u1',
+    contractLineId: 'line-1',
+    contractId: 'contract-1',
+    contractLineName: 'Block Hours',
+    clientId: 'client-1',
+    serviceId: 'svc-1',
+    serviceName: 'Engineering',
+    periodStart: '2026-02-01',
+    periodEnd: '2026-02-28',
+    minutesUsed: 0,
+    rolledOverMinutes: 0,
+    totalMinutes: 6000,
+    allowRollover: false,
+    currencyCode: 'USD',
+    lineCustomRate: 9000,
+    catalogDefaultRate: 10000,
+  };
+
+  it('prefers a pricing-schedule custom rate over every configured tier', () => {
+    expect(resolveConfiguredFee(period, 8000, 12000)).toBe(12000);
+  });
+
+  it('falls through pricing schedule → line custom rate → fixed base rate → catalog default', () => {
+    expect(resolveConfiguredFee(period, null, null)).toBe(9000);
+    expect(resolveConfiguredFee({ ...period, lineCustomRate: null }, 8000, null)).toBe(8000);
+    expect(resolveConfiguredFee({ ...period, lineCustomRate: null }, null, null)).toBe(10000);
+    expect(resolveConfiguredFee({ ...period, lineCustomRate: null, catalogDefaultRate: null }, null, null)).toBeNull();
+  });
+
+  it('resolves the active pricing schedule for the period (engine exclusivity semantics)', () => {
+    const schedules: RawPricingScheduleRow[] = [
+      { contractId: 'contract-1', effectiveDate: '2026-01-01', endDate: '2026-02-14', customRate: 7000 },
+      { contractId: 'contract-1', effectiveDate: '2026-02-15', endDate: null, customRate: 12000 },
+      { contractId: 'contract-other', effectiveDate: '2026-01-01', endDate: null, customRate: 99999 },
+    ];
+    // Feb 1–28 overlaps only the second schedule (effective Feb 15, no end).
+    expect(resolvePricingScheduleRate('2026-02-01', '2026-02-28', 'contract-1', schedules)).toBe(12000);
+    // A period fully before the first schedule starts resolves null.
+    expect(resolvePricingScheduleRate('2025-12-01', '2025-12-31', 'contract-1', schedules)).toBeNull();
+    // A period that ends after the first schedule's end_date (exclusive) skips it.
+    expect(resolvePricingScheduleRate('2026-02-01', '2026-02-14', 'contract-1', schedules)).toBe(7000);
+  });
+});

--- a/packages/reporting/src/actions/report-actions/deferred-revenue/fee.ts
+++ b/packages/reporting/src/actions/report-actions/deferred-revenue/fee.ts
@@ -1,0 +1,87 @@
+/**
+ * Period-fee resolution for bucket periods.
+ *
+ * Primary source (per the settled design decision): the fee actually billed
+ * for the bucket line's service period on a finalized invoice —
+ * `invoice_charges` joined through `invoice_charge_details.config_id` to the
+ * line's `contract_line_service_configuration` (configuration_type = 'Fixed').
+ * Fallback when the period has not been billed yet: the configured base fee
+ * for the line (custom rate → fixed-config base rate × qty → catalog default
+ * rate × qty), marked notYetBilled in the detail row.
+ */
+
+import type { FeeSource } from './types';
+
+export interface BilledFeeCandidate {
+  contractLineId: string;
+  servicePeriodStart: string;
+  servicePeriodEnd: string;
+  feeCents: number;
+}
+
+export interface ConfiguredFee {
+  contractLineId: string;
+  serviceId: string;
+  feeCents: number | null;
+}
+
+export interface ResolvedFee {
+  feeCents: number;
+  feeSource: FeeSource;
+}
+
+function dayNumber(dateString: string): number {
+  return Math.round(Date.parse(`${dateString.slice(0, 10)}T00:00:00.000Z`) / 86_400_000);
+}
+
+/** Inclusive-overlap length in days between two inclusive date ranges. */
+function overlapDays(
+  periodStart: string,
+  periodEnd: string,
+  candidateStart: string,
+  candidateEnd: string,
+): number {
+  const overlapStart = Math.max(dayNumber(periodStart), dayNumber(candidateStart));
+  const overlapEnd = Math.min(dayNumber(periodEnd), dayNumber(candidateEnd));
+  return Math.max(0, overlapEnd - overlapStart + 1);
+}
+
+/**
+ * Resolve the period fee for one bucket period, preferring the billed fee.
+ *
+ * The billing engine prorates first/last service periods (e.g. a Jul 8–31
+ * invoice window for a Jul 1–31 bucket allowance), so the billed detail is
+ * matched by period overlap rather than exact equality: the candidate with the
+ * longest inclusive overlap wins, and the reported fee is what was actually
+ * billed (prorated amounts included). No overlap at all falls back to the
+ * configured fee.
+ */
+export function resolvePeriodFee(
+  periodStart: string,
+  periodEnd: string,
+  contractLineId: string,
+  billedCandidates: BilledFeeCandidate[],
+  configuredFee: number | null,
+): ResolvedFee {
+  let best: BilledFeeCandidate | null = null;
+  let bestOverlap = 0;
+
+  for (const candidate of billedCandidates) {
+    if (candidate.contractLineId !== contractLineId) continue;
+    const overlap = overlapDays(periodStart, periodEnd, candidate.servicePeriodStart, candidate.servicePeriodEnd);
+    if (overlap > bestOverlap) {
+      bestOverlap = overlap;
+      best = candidate;
+    }
+  }
+
+  if (best && bestOverlap > 0 && best.feeCents > 0) {
+    return { feeCents: best.feeCents, feeSource: 'billed' };
+  }
+
+  if (configuredFee !== null && configuredFee > 0) {
+    return { feeCents: configuredFee, feeSource: 'configured' };
+  }
+
+  return { feeCents: 0, feeSource: 'configured' };
+}

--- a/packages/reporting/src/actions/report-actions/deferred-revenue/fee.ts
+++ b/packages/reporting/src/actions/report-actions/deferred-revenue/fee.ts
@@ -14,6 +14,7 @@ import type { FeeSource } from './types';
 
 export interface BilledFeeCandidate {
   contractLineId: string;
+  serviceId: string;
   servicePeriodStart: string;
   servicePeriodEnd: string;
   feeCents: number;
@@ -49,17 +50,19 @@ function overlapDays(
 /**
  * Resolve the period fee for one bucket period, preferring the billed fee.
  *
- * The billing engine prorates first/last service periods (e.g. a Jul 8–31
- * invoice window for a Jul 1–31 bucket allowance), so the billed detail is
- * matched by period overlap rather than exact equality: the candidate with the
- * longest inclusive overlap wins, and the reported fee is what was actually
- * billed (prorated amounts included). No overlap at all falls back to the
- * configured fee.
+ * The billed detail is matched by contract line AND service (a line can carry
+ * multiple Fixed configs, one per service) and by period overlap. The billing
+ * engine prorates first/last service periods (e.g. a Jul 8–31 invoice window
+ * for a Jul 1–31 bucket allowance), so the billed detail is matched by overlap
+ * rather than exact equality: the candidate with the longest inclusive overlap
+ * wins, and the reported fee is what was actually billed (prorated amounts
+ * included). No overlap at all falls back to the configured fee.
  */
 export function resolvePeriodFee(
   periodStart: string,
   periodEnd: string,
   contractLineId: string,
+  serviceId: string,
   billedCandidates: BilledFeeCandidate[],
   configuredFee: number | null,
 ): ResolvedFee {
@@ -68,6 +71,7 @@ export function resolvePeriodFee(
 
   for (const candidate of billedCandidates) {
     if (candidate.contractLineId !== contractLineId) continue;
+    if (candidate.serviceId !== serviceId) continue;
     const overlap = overlapDays(periodStart, periodEnd, candidate.servicePeriodStart, candidate.servicePeriodEnd);
     if (overlap > bestOverlap) {
       bestOverlap = overlap;

--- a/packages/reporting/src/actions/report-actions/deferred-revenue/hours.test.ts
+++ b/packages/reporting/src/actions/report-actions/deferred-revenue/hours.test.ts
@@ -437,3 +437,117 @@ describe('hours rollforward aggregation', () => {
     expect(feb.opening + feb.issued + feb.applied + feb.expired).toBeCloseTo(feb.closing, 6);
   });
 });
+
+describe('detail emission for selected-month contribution (Defect 1)', () => {
+  it('emits no detail rows for a period entirely in the past', () => {
+    // Dec 1–31, fully burned before February, no carry.
+    const past = period({
+      usageId: 'u-past',
+      periodStart: '2025-12-01',
+      periodEnd: '2025-12-31',
+      totalMinutes: 6000,
+      minutesUsed: 6000,
+      allowRollover: false,
+    });
+    const rollforward = computeHoursRollforward('2026-02', [past]);
+    expect(rollforward.size).toBe(0); // no client×currency surfaces at all
+  });
+
+  it('emits no detail rows for a period entirely in the future', () => {
+    const future = period({
+      usageId: 'u-future',
+      periodStart: '2026-03-01',
+      periodEnd: '2026-03-31',
+    });
+    const rollforward = computeHoursRollforward('2026-02', [future]);
+    expect(rollforward.size).toBe(0);
+  });
+
+  it('still emits a detail row for a carried-in period with no in-month activity', () => {
+    // Allowance opens February with a 1200-minute rollover from January; zero
+    // burn in February. The carried-in liability has nonzero opening/closing so
+    // the period must stay in the report.
+    const carried = period({
+      usageId: 'u-carry',
+      periodStart: '2026-02-01',
+      periodEnd: '2026-02-28',
+      totalMinutes: 6000,
+      rolledOverMinutes: 1200,
+      minutesUsed: 0,
+      allowRollover: true,
+    });
+    const aggregate = computeHoursRollforward('2026-02', [carried]).get('client-1\u0000USD')!;
+    expect(aggregate.opening).toBe(1200 * perMinuteRate(6000, 100000));
+    expect(aggregate.closing).toBe(6000 * perMinuteRate(6000, 100000)); // unused base carries out
+    expect(aggregate.details).toHaveLength(1);
+    expect(aggregate.details[0].usageId).toBe('u-carry');
+  });
+
+  it('emits detail rows only for contributing periods and reconciles to the rollforward', () => {
+    const past = period({
+      usageId: 'u-past',
+      periodStart: '2025-12-01',
+      periodEnd: '2025-12-31',
+      totalMinutes: 6000,
+      minutesUsed: 6000,
+    });
+    const future = period({
+      usageId: 'u-future',
+      periodStart: '2026-03-01',
+      periodEnd: '2026-03-31',
+    });
+    const current = period({
+      usageId: 'u-current',
+      totalMinutes: 6000,
+      minutesUsed: 2400,
+      periodFee: 100000,
+    });
+    const aggregate = computeHoursRollforward('2026-02', [past, future, current]).get('client-1\u0000USD')!;
+
+    expect(aggregate.details.map((detail) => detail.usageId)).toEqual(['u-current']);
+
+    // Every emitted detail reconciles: its movement columns close arithmetically
+    // and its opening/issued/applied/expired/closing sum to the client rollforward.
+    for (const detail of aggregate.details) {
+      const { opening, issued, applied, expired, closing } = detail.movement;
+      expect(opening + issued + applied + expired + 0).toBeCloseTo(closing, 6);
+    }
+    expect(aggregate.details.reduce((sum, detail) => sum + detail.movement.opening, 0)).toBe(aggregate.opening);
+    expect(aggregate.details.reduce((sum, detail) => sum + detail.movement.issued, 0)).toBe(aggregate.issued);
+    expect(aggregate.details.reduce((sum, detail) => sum + detail.movement.applied, 0)).toBe(aggregate.applied);
+    expect(aggregate.details.reduce((sum, detail) => sum + detail.movement.expired, 0)).toBe(aggregate.expired);
+    expect(aggregate.details.reduce((sum, detail) => sum + detail.movement.closing, 0)).toBe(aggregate.closing);
+    expect(aggregate.opening + aggregate.issued + aggregate.applied + aggregate.expired).toBeCloseTo(aggregate.closing, 6);
+  });
+
+  it('keeps contributing and carried-in periods while dropping non-contributors in one mix', () => {
+    // Jan 15–Feb 14 rollover period (active at Feb 1, carry hands off) plus a
+    // December period that is gone by February.
+    const origin = period({
+      usageId: 'u-origin',
+      periodStart: '2026-01-15',
+      periodEnd: '2026-02-14',
+      totalMinutes: 6000,
+      minutesUsed: 4800,
+      allowRollover: true,
+    });
+    const stale = period({
+      usageId: 'u-stale',
+      periodStart: '2025-12-01',
+      periodEnd: '2025-12-31',
+      totalMinutes: 6000,
+      minutesUsed: 6000,
+      allowRollover: true,
+    });
+    const aggregate = computeHoursRollforward('2026-02', [origin, stale]).get('client-1\u0000USD')!;
+    expect(aggregate.details.map((detail) => detail.usageId)).toEqual(['u-origin']);
+    // The origin period carries the full value: 1200-minute carry recognized in
+    // closing only via a successor, so closing here is zero but opening/applied
+    // keep it in the report. Sum of details still equals the rollforward.
+    expect(aggregate.opening).toBe(6000 * perMinuteRate(6000, 100000));
+    expect(aggregate.applied).toBe(-(4800 * perMinuteRate(6000, 100000)));
+    expect(aggregate.details.reduce((sum, detail) => sum + detail.movement.opening, 0)).toBe(aggregate.opening);
+    expect(aggregate.details.reduce((sum, detail) => sum + detail.movement.applied, 0)).toBe(aggregate.applied);
+    expect(aggregate.details.reduce((sum, detail) => sum + detail.movement.closing, 0)).toBe(aggregate.closing);
+  });
+});

--- a/packages/reporting/src/actions/report-actions/deferred-revenue/hours.test.ts
+++ b/packages/reporting/src/actions/report-actions/deferred-revenue/hours.test.ts
@@ -1,0 +1,356 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  computeBucketPeriodMovement,
+  computeHoursRollforward,
+  perMinuteRate,
+  type BucketPeriodInput,
+} from './hours';
+
+function period(over: Partial<BucketPeriodInput>): BucketPeriodInput {
+  return {
+    usageId: 'usage-1',
+    contractLineId: 'line-1',
+    contractLineName: 'Block Hours',
+    clientId: 'client-1',
+    serviceId: 'svc-1',
+    serviceName: 'Engineering',
+    periodStart: '2026-02-01',
+    periodEnd: '2026-02-28',
+    totalMinutes: 6000,
+    rolledOverMinutes: 0,
+    minutesUsed: 0,
+    allowRollover: false,
+    currencyCode: 'USD',
+    periodFee: 100000,
+    feeSource: 'billed',
+    ...over,
+  };
+}
+
+describe('perMinuteRate valuation', () => {
+  it('values an unburned minute as period fee ÷ included minutes', () => {
+    expect(perMinuteRate(6000, 100000)).toBeCloseTo(100000 / 6000, 6);
+  });
+
+  it('returns zero when fee or allowance is missing', () => {
+    expect(perMinuteRate(0, 100000)).toBe(0);
+    expect(perMinuteRate(6000, 0)).toBe(0);
+  });
+
+  it('does not inflate the denominator with rollover minutes', () => {
+    expect(perMinuteRate(6000, 100000)).toBe(perMinuteRate(6000, 100000));
+  });
+});
+
+describe('bucket period fully inside a month', () => {
+  it('rolls the period forward: issued = fee, applied = -burn, expired = -forfeited leftover', () => {
+    // 100 hrs included, fee $1000 → $10/hr. 40 hrs burned, 60 hrs left, no rollover.
+    const movement = computeBucketPeriodMovement('2026-02', period({
+      totalMinutes: 6000,
+      periodFee: 100000,
+      minutesUsed: 2400,
+      allowRollover: false,
+    }));
+
+    expect(movement.opening).toBe(0);
+    expect(movement.issued).toBe(100000);
+    expect(movement.applied).toBe(-(2400 * (100000 / 6000)));
+    expect(movement.expired).toBe(-(3600 * (100000 / 6000)));
+    expect(movement.closing).toBe(0);
+    // Movement columns close arithmetically: 0 + 100000 - 40000 - 60000 = 0.
+    expect(movement.opening + movement.issued + movement.applied + movement.expired).toBeCloseTo(movement.closing, 6);
+    expect(movement.detail.remainingMinutes).toBe(3600);
+    expect(movement.detail.valueRemaining).toBeCloseTo(3600 * (100000 / 6000), 6);
+  });
+
+  it('non-rollover forfeiture is recognized only at the period end', () => {
+    const jan = computeBucketPeriodMovement('2026-01', period({
+      periodStart: '2026-02-01',
+      periodEnd: '2026-02-28',
+      totalMinutes: 6000,
+      minutesUsed: 0,
+    }));
+    const feb = computeBucketPeriodMovement('2026-02', period({
+      periodStart: '2026-02-01',
+      periodEnd: '2026-02-28',
+      totalMinutes: 6000,
+      minutesUsed: 0,
+    }));
+    expect(jan.closing).toBe(0); // period does not exist in January
+    expect(feb.issued).toBe(100000);
+    expect(feb.applied).toBe(0);
+    expect(feb.expired).toBe(-100000); // the whole allowance forfeits at period end
+    expect(feb.closing).toBe(0);
+  });
+
+  it('rollover: carry opens the next month, leftover base carries, rolled-in minutes lapse', () => {
+    // Included 100h, rolled over 20h (carried from Jan), 50h burned in Feb.
+    const movement = computeBucketPeriodMovement('2026-02', period({
+      totalMinutes: 6000,
+      rolledOverMinutes: 1200,
+      minutesUsed: 3000,
+      allowRollover: true,
+    }));
+    const rate = 100000 / 6000;
+
+    // The 20h carry crossed the Jan→Feb boundary: it opens February's balance.
+    expect(movement.opening).toBe(1200 * rate);
+    expect(movement.issued).toBe(100000);
+    expect(movement.applied).toBe(-(3000 * rate));
+    // Leftover = 7200 - 3000 = 4200. Carry to Mar = max(0, 6000-3000) = 3000.
+    // Lapsed = 4200 - 3000 = 1200 (the rolled-in minutes never compound).
+    expect(movement.expired).toBe(-(1200 * rate));
+    expect(movement.closing).toBe(3000 * rate);
+    expect(movement.opening + movement.issued + movement.applied + movement.expired).toBeCloseTo(movement.closing, 6);
+    expect(movement.detail.remainingMinutes).toBe(4200);
+  });
+
+  it('rollover clamps to unused base allowance when overage consumed the carry', () => {
+    const movement = computeBucketPeriodMovement('2026-02', period({
+      totalMinutes: 6000,
+      rolledOverMinutes: 1200,
+      minutesUsed: 6600, // 6600 of 7200 available
+      allowRollover: true,
+    }));
+    const rate = 100000 / 6000;
+    // Leftover = 600, carry = max(0, 6000-6600) = 0 → all 600 lapse.
+    expect(movement.expired).toBe(-(600 * rate));
+    expect(movement.closing).toBe(0);
+  });
+
+  it('caps applied value at the period fee (overage is billed separately)', () => {
+    const movement = computeBucketPeriodMovement('2026-02', period({
+      totalMinutes: 6000,
+      minutesUsed: 9000, // 50% over the allowance
+      allowRollover: false,
+    }));
+    // burn × rate = 9000 × (100000/6000) = 150000 > fee 100000 → capped.
+    expect(movement.applied).toBe(-100000);
+    expect(movement.expired).toBe(0); // nothing left to forfeit
+    expect(movement.closing).toBe(0);
+  });
+});
+
+describe('mid-period month boundaries (spanning periods)', () => {
+  it('attributes a spanning period\'s burn to the month it ends in (v1 fallback)', () => {
+    // Feb 15 – Mar 14, 40h burned of 100h, non-rollover.
+    const base = period({
+      periodStart: '2026-02-15',
+      periodEnd: '2026-03-14',
+      totalMinutes: 6000,
+      minutesUsed: 2400,
+      allowRollover: false,
+    });
+    const rate = 100000 / 6000;
+
+    const feb = computeBucketPeriodMovement('2026-02', base);
+    expect(feb.opening).toBe(0); // starts in Feb
+    expect(feb.issued).toBe(100000);
+    expect(feb.applied).toBe(0); // burn lands in March
+    expect(feb.expired).toBe(0);
+    expect(feb.closing).toBe(100000); // full allowance still on the books
+
+    const mar = computeBucketPeriodMovement('2026-03', base);
+    expect(mar.opening).toBe(100000); // period still active at Mar 1
+    expect(mar.issued).toBe(0);
+    expect(mar.applied).toBe(-(2400 * rate));
+    expect(mar.expired).toBe(-(3600 * rate));
+    expect(mar.closing).toBe(0);
+  });
+
+  it('month in the middle of a spanning period carries the full allowance through', () => {
+    // Dec 15 – Mar 14 spanning period; January sits in the middle.
+    const base = period({
+      periodStart: '2025-12-15',
+      periodEnd: '2026-03-14',
+      totalMinutes: 6000,
+      minutesUsed: 2400,
+      allowRollover: false,
+    });
+    const jan = computeBucketPeriodMovement('2026-01', base);
+    expect(jan.opening).toBe(100000);
+    expect(jan.issued).toBe(0);
+    expect(jan.applied).toBe(0);
+    expect(jan.expired).toBe(0);
+    expect(jan.closing).toBe(100000);
+  });
+
+  it('spanning rollover period: rolled-in minutes lapse at the end, base carries', () => {
+    const base = period({
+      periodStart: '2026-02-15',
+      periodEnd: '2026-03-14',
+      totalMinutes: 6000,
+      rolledOverMinutes: 1200,
+      minutesUsed: 3000,
+      allowRollover: true,
+    });
+    const rate = 100000 / 6000;
+
+    const feb = computeBucketPeriodMovement('2026-02', base);
+    expect(feb.opening).toBe(0); // starts mid-Feb, no carry pending at Feb 1
+    expect(feb.closing).toBe((6000 + 1200) * rate);
+
+    const mar = computeBucketPeriodMovement('2026-03', base);
+    // Leftover = 4200; carry = max(0, 6000-3000) = 3000; lapsed = 1200.
+    expect(mar.expired).toBe(-(1200 * rate));
+    expect(mar.closing).toBe(3000 * rate);
+  });
+
+  it('recognizes a carry that crosses a month boundary in both closing and opening', () => {
+    // Period 1 ends Feb 14 with 600 unused minutes that roll into period 2
+    // (which starts Mar 1 — after February, so the carry is pending at Feb
+    // 28 and must remain on the books).
+    const periodOne = period({
+      usageId: 'u1',
+      periodStart: '2026-01-15',
+      periodEnd: '2026-02-14',
+      totalMinutes: 3000,
+      minutesUsed: 2400,
+      allowRollover: true,
+      periodFee: 60000,
+    });
+    const feb = computeBucketPeriodMovement('2026-02', periodOne, { successorStart: '2026-03-01' });
+    expect(feb.expired).toBe(0); // leftover (600) all carries
+    expect(feb.closing).toBe(600 * perMinuteRate(3000, 60000)); // carry still outstanding
+
+    const mar = computeBucketPeriodMovement('2026-03', periodOne, { successorStart: '2026-03-01' });
+    expect(mar.opening).toBe(0); // period ended Feb 14, contributes nothing in Mar
+
+    // The successor period (period 2) opens March with the carried-in value.
+    const periodTwo = period({
+      usageId: 'u2',
+      periodStart: '2026-03-01',
+      periodEnd: '2026-03-31',
+      totalMinutes: 3000,
+      rolledOverMinutes: 600,
+      minutesUsed: 0,
+      allowRollover: true,
+      periodFee: 60000,
+    });
+    const marTwo = computeBucketPeriodMovement('2026-03', periodTwo);
+    expect(marTwo.opening).toBe(600 * perMinuteRate(3000, 60000));
+    // Period 2 ends in March: the rolled-in 600 minutes lapse (no compounding)
+    // and the unused 3000-minute base carries to April.
+    expect(marTwo.expired).toBe(-(600 * perMinuteRate(3000, 60000)));
+    expect(marTwo.closing).toBe(3000 * perMinuteRate(3000, 60000));
+    expect(marTwo.opening + marTwo.issued + marTwo.applied + marTwo.expired).toBeCloseTo(marTwo.closing, 6);
+  });
+
+  it('hands a within-month carry to the successor instead of counting it twice', () => {
+    // Period 1 ends Feb 14 and period 2 starts Feb 15 — the carry is owned by
+    // the already-active successor by Feb 28, so period 1 closes at zero and
+    // the carry lives inside period 2's closing balance.
+    const periodOne = period({
+      usageId: 'u1',
+      periodStart: '2026-01-15',
+      periodEnd: '2026-02-14',
+      totalMinutes: 3000,
+      minutesUsed: 2400,
+      allowRollover: true,
+      periodFee: 60000,
+    });
+    const feb = computeBucketPeriodMovement('2026-02', periodOne, { successorStart: '2026-02-15' });
+    expect(feb.expired).toBe(0);
+    expect(feb.closing).toBe(0); // carry already inside the successor
+
+    const periodTwo = period({
+      usageId: 'u2',
+      periodStart: '2026-02-15',
+      periodEnd: '2026-03-14',
+      totalMinutes: 3000,
+      rolledOverMinutes: 600,
+      minutesUsed: 0,
+      allowRollover: true,
+      periodFee: 60000,
+    });
+    const febTwo = computeBucketPeriodMovement('2026-02', periodTwo, { successorStart: '2026-03-14' });
+    const rate = perMinuteRate(3000, 60000);
+    expect(febTwo.closing).toBe(3600 * rate); // base + the received carry
+  });
+});
+
+describe('configured (not yet billed) fee', () => {
+  it('marks the detail row as not yet billed and uses the configured fee', () => {
+    const movement = computeBucketPeriodMovement('2026-02', period({
+      totalMinutes: 6000,
+      periodFee: 80000,
+      feeSource: 'configured',
+      minutesUsed: 1200,
+    }));
+    expect(movement.detail.notYetBilled).toBe(true);
+    expect(movement.detail.feeSource).toBe('configured');
+    expect(movement.detail.periodFee).toBe(80000);
+    expect(movement.issued).toBe(80000);
+  });
+});
+
+describe('hours rollforward aggregation', () => {
+  it('merges multiple periods per client×currency', () => {
+    const periods: BucketPeriodInput[] = [
+      period({ usageId: 'u1', totalMinutes: 6000, minutesUsed: 2400, periodFee: 100000 }),
+      period({ usageId: 'u2', contractLineId: 'line-2', totalMinutes: 3000, minutesUsed: 600, periodFee: 50000 }),
+    ];
+    const rollforward = computeHoursRollforward('2026-02', periods).get('client-1\u0000USD');
+    expect(rollforward?.issued).toBe(150000);
+    expect(rollforward?.applied).toBe(-(2400 * (100000 / 6000) + 600 * (50000 / 3000)));
+    expect(rollforward?.details).toHaveLength(2);
+  });
+
+  it('groups by client and currency independently', () => {
+    const periods: BucketPeriodInput[] = [
+      period({ clientId: 'client-1', currencyCode: 'USD', periodFee: 100000 }),
+      period({ clientId: 'client-1', currencyCode: 'EUR', periodFee: 90000 }),
+      period({ clientId: 'client-2', currencyCode: 'USD', periodFee: 70000 }),
+    ];
+    const rollforward = computeHoursRollforward('2026-02', periods);
+    expect(rollforward.get('client-1\u0000USD')?.issued).toBe(100000);
+    expect(rollforward.get('client-1\u0000EUR')?.issued).toBe(90000);
+    expect(rollforward.get('client-2\u0000USD')?.issued).toBe(70000);
+  });
+
+  it('closes arithmetically and carries the rollover across consecutive monthly periods', () => {
+    // Monthly cadence with rollover: Jan 1–31 burns 4800 of 6000 (carry 1200
+    // rolls to Feb), Feb 1–28 opens with that carry and burns 3000 of 7200.
+    const rate = 100000 / 6000;
+    const periods: BucketPeriodInput[] = [
+      period({
+        usageId: 'u1',
+        periodStart: '2026-01-01',
+        periodEnd: '2026-01-31',
+        totalMinutes: 6000,
+        minutesUsed: 4800,
+        allowRollover: true,
+      }),
+      period({
+        usageId: 'u2',
+        periodStart: '2026-02-01',
+        periodEnd: '2026-02-28',
+        totalMinutes: 6000,
+        rolledOverMinutes: 1200,
+        minutesUsed: 3000,
+        allowRollover: true,
+      }),
+    ];
+
+    const jan = computeHoursRollforward('2026-01', periods).get('client-1\u0000USD')!;
+    // Jan: issued 100000, burn 48000, carry 1200 min (20000) still outstanding
+    // at Jan 31 (the successor starts Feb 1, after the month end).
+    expect(jan.opening).toBe(0);
+    expect(jan.issued).toBe(100000);
+    expect(jan.applied).toBe(-(4800 * rate));
+    expect(jan.expired).toBe(0);
+    expect(jan.closing).toBe(1200 * rate);
+    expect(jan.opening + jan.issued + jan.applied + jan.expired).toBeCloseTo(jan.closing, 6);
+
+    const feb = computeHoursRollforward('2026-02', periods).get('client-1\u0000USD')!;
+    // Feb opens with the 1200-minute carry (20000), issues the new allowance,
+    // burns 50000 and lapses the rolled-in minutes (20000).
+    expect(feb.opening).toBe(jan.closing);
+    expect(feb.issued).toBe(100000);
+    expect(feb.applied).toBe(-(3000 * rate));
+    expect(feb.expired).toBe(-(1200 * rate));
+    expect(feb.closing).toBe(3000 * rate);
+    expect(feb.opening + feb.issued + feb.applied + feb.expired).toBeCloseTo(feb.closing, 6);
+  });
+});

--- a/packages/reporting/src/actions/report-actions/deferred-revenue/hours.test.ts
+++ b/packages/reporting/src/actions/report-actions/deferred-revenue/hours.test.ts
@@ -82,6 +82,7 @@ describe('bucket period fully inside a month', () => {
     expect(feb.applied).toBe(0);
     expect(feb.expired).toBe(-100000); // the whole allowance forfeits at period end
     expect(feb.closing).toBe(0);
+    expect(feb.opening + feb.issued + feb.applied + feb.expired).toBeCloseTo(feb.closing, 6);
   });
 
   it('rollover: carry opens the next month, leftover base carries, rolled-in minutes lapse', () => {
@@ -110,13 +111,19 @@ describe('bucket period fully inside a month', () => {
     const movement = computeBucketPeriodMovement('2026-02', period({
       totalMinutes: 6000,
       rolledOverMinutes: 1200,
-      minutesUsed: 6600, // 6600 of 7200 available
+      minutesUsed: 6600, // 6600 of 7200 available — burns into the carried-in minutes
       allowRollover: true,
     }));
     const rate = 100000 / 6000;
+    // The burn consumes the full base plus 600 carried-in minutes, so applied
+    // carries the value of every burned available minute (fee + carry value),
+    // keeping the movement columns closed.
+    expect(movement.opening).toBe(1200 * rate);
+    expect(movement.applied).toBe(-(6600 * rate));
     // Leftover = 600, carry = max(0, 6000-6600) = 0 → all 600 lapse.
     expect(movement.expired).toBe(-(600 * rate));
     expect(movement.closing).toBe(0);
+    expect(movement.opening + movement.issued + movement.applied + movement.expired).toBeCloseTo(movement.closing, 6);
   });
 
   it('caps applied value at the period fee (overage is billed separately)', () => {
@@ -125,10 +132,12 @@ describe('bucket period fully inside a month', () => {
       minutesUsed: 9000, // 50% over the allowance
       allowRollover: false,
     }));
-    // burn × rate = 9000 × (100000/6000) = 150000 > fee 100000 → capped.
+    // burn × rate = 9000 × (100000/6000) = 150000 > available value 100000 →
+    // applied is capped at the fee (no carry to extend the cap).
     expect(movement.applied).toBe(-100000);
     expect(movement.expired).toBe(0); // nothing left to forfeit
     expect(movement.closing).toBe(0);
+    expect(movement.opening + movement.issued + movement.applied + movement.expired).toBeCloseTo(movement.closing, 6);
   });
 });
 
@@ -150,6 +159,7 @@ describe('mid-period month boundaries (spanning periods)', () => {
     expect(feb.applied).toBe(0); // burn lands in March
     expect(feb.expired).toBe(0);
     expect(feb.closing).toBe(100000); // full allowance still on the books
+    expect(feb.opening + feb.issued + feb.applied + feb.expired).toBeCloseTo(feb.closing, 6);
 
     const mar = computeBucketPeriodMovement('2026-03', base);
     expect(mar.opening).toBe(100000); // period still active at Mar 1
@@ -157,6 +167,7 @@ describe('mid-period month boundaries (spanning periods)', () => {
     expect(mar.applied).toBe(-(2400 * rate));
     expect(mar.expired).toBe(-(3600 * rate));
     expect(mar.closing).toBe(0);
+    expect(mar.opening + mar.issued + mar.applied + mar.expired).toBeCloseTo(mar.closing, 6);
   });
 
   it('month in the middle of a spanning period carries the full allowance through', () => {
@@ -174,6 +185,7 @@ describe('mid-period month boundaries (spanning periods)', () => {
     expect(jan.applied).toBe(0);
     expect(jan.expired).toBe(0);
     expect(jan.closing).toBe(100000);
+    expect(jan.opening + jan.issued + jan.applied + jan.expired).toBeCloseTo(jan.closing, 6);
   });
 
   it('spanning rollover period: rolled-in minutes lapse at the end, base carries', () => {
@@ -189,12 +201,22 @@ describe('mid-period month boundaries (spanning periods)', () => {
 
     const feb = computeBucketPeriodMovement('2026-02', base);
     expect(feb.opening).toBe(0); // starts mid-Feb, no carry pending at Feb 1
+    expect(feb.issued).toBe(100000);
+    expect(feb.applied).toBe(0);
+    expect(feb.expired).toBe(0);
     expect(feb.closing).toBe((6000 + 1200) * rate);
+    // The received carry's value lives inside this period's closing balance —
+    // it closes arithmetically only together with the origin period (see the
+    // mid-month carry handoff aggregate test below).
 
     const mar = computeBucketPeriodMovement('2026-03', base);
     // Leftover = 4200; carry = max(0, 6000-3000) = 3000; lapsed = 1200.
+    expect(mar.opening).toBe((6000 + 1200) * rate);
+    expect(mar.issued).toBe(0);
+    expect(mar.applied).toBe(-(3000 * rate));
     expect(mar.expired).toBe(-(1200 * rate));
     expect(mar.closing).toBe(3000 * rate);
+    expect(mar.opening + mar.issued + mar.applied + mar.expired).toBeCloseTo(mar.closing, 6);
   });
 
   it('recognizes a carry that crosses a month boundary in both closing and opening', () => {
@@ -211,11 +233,15 @@ describe('mid-period month boundaries (spanning periods)', () => {
       periodFee: 60000,
     });
     const feb = computeBucketPeriodMovement('2026-02', periodOne, { successorStart: '2026-03-01' });
+    expect(feb.opening).toBe(3000 * perMinuteRate(3000, 60000)); // active at Feb 1
+    expect(feb.applied).toBe(-(2400 * perMinuteRate(3000, 60000)));
     expect(feb.expired).toBe(0); // leftover (600) all carries
     expect(feb.closing).toBe(600 * perMinuteRate(3000, 60000)); // carry still outstanding
+    expect(feb.opening + feb.issued + feb.applied + feb.expired).toBeCloseTo(feb.closing, 6);
 
     const mar = computeBucketPeriodMovement('2026-03', periodOne, { successorStart: '2026-03-01' });
     expect(mar.opening).toBe(0); // period ended Feb 14, contributes nothing in Mar
+    expect(mar.closing).toBe(0);
 
     // The successor period (period 2) opens March with the carried-in value.
     const periodTwo = period({
@@ -267,6 +293,55 @@ describe('mid-period month boundaries (spanning periods)', () => {
     const febTwo = computeBucketPeriodMovement('2026-02', periodTwo, { successorStart: '2026-03-14' });
     const rate = perMinuteRate(3000, 60000);
     expect(febTwo.closing).toBe(3600 * rate); // base + the received carry
+
+    // The carry's value flows between the two periods mid-month, so the
+    // movement columns close at the client×currency aggregate — not per period.
+    const aggregate = computeHoursRollforward('2026-02', [periodOne, periodTwo]).get('client-1\u0000USD')!;
+    expect(aggregate.opening).toBe(3000 * rate); // period 1's balance at Feb 1
+    expect(aggregate.issued).toBe(60000); // period 2's allowance
+    expect(aggregate.applied).toBe(-(2400 * rate)); // period 1's burn
+    expect(aggregate.expired).toBe(0);
+    expect(aggregate.closing).toBe(3600 * rate);
+    expect(aggregate.opening + aggregate.issued + aggregate.applied + aggregate.expired).toBeCloseTo(aggregate.closing, 6);
+  });
+
+  it('mid-month rollover carry closes arithmetically at the client aggregate', () => {
+    // Jan 15–Feb 14 burns 4800 of 6000 (carry 1200) into Feb 15–Mar 14, which
+    // burns 3000 of 7200. February is where the carry changes hands mid-month.
+    const origin = period({
+      usageId: 'u1',
+      periodStart: '2026-01-15',
+      periodEnd: '2026-02-14',
+      totalMinutes: 6000,
+      minutesUsed: 4800,
+      allowRollover: true,
+    });
+    const receiver = period({
+      usageId: 'u2',
+      periodStart: '2026-02-15',
+      periodEnd: '2026-03-14',
+      totalMinutes: 6000,
+      rolledOverMinutes: 1200,
+      minutesUsed: 3000,
+      allowRollover: true,
+    });
+    const rate = 100000 / 6000;
+
+    const feb = computeHoursRollforward('2026-02', [origin, receiver]).get('client-1\u0000USD')!;
+    expect(feb.opening).toBe(6000 * rate); // origin active at Feb 1
+    expect(feb.issued).toBe(100000); // receiver's allowance
+    expect(feb.applied).toBe(-(4800 * rate)); // origin's burn lands in Feb
+    expect(feb.expired).toBe(0); // leftover (1200) all carries
+    expect(feb.closing).toBe(7200 * rate); // receiver holds base + carry at Feb 28
+    expect(feb.opening + feb.issued + feb.applied + feb.expired).toBeCloseTo(feb.closing, 6);
+
+    const mar = computeHoursRollforward('2026-03', [origin, receiver]).get('client-1\u0000USD')!;
+    expect(mar.opening).toBe(feb.closing);
+    expect(mar.issued).toBe(0);
+    expect(mar.applied).toBe(-(3000 * rate));
+    expect(mar.expired).toBe(-(1200 * rate)); // rolled-in minutes lapse
+    expect(mar.closing).toBe(3000 * rate); // unused base carries to April
+    expect(mar.opening + mar.issued + mar.applied + mar.expired).toBeCloseTo(mar.closing, 6);
   });
 });
 
@@ -282,6 +357,7 @@ describe('configured (not yet billed) fee', () => {
     expect(movement.detail.feeSource).toBe('configured');
     expect(movement.detail.periodFee).toBe(80000);
     expect(movement.issued).toBe(80000);
+    expect(movement.opening + movement.issued + movement.applied + movement.expired).toBeCloseTo(movement.closing, 6);
   });
 });
 
@@ -295,6 +371,7 @@ describe('hours rollforward aggregation', () => {
     expect(rollforward?.issued).toBe(150000);
     expect(rollforward?.applied).toBe(-(2400 * (100000 / 6000) + 600 * (50000 / 3000)));
     expect(rollforward?.details).toHaveLength(2);
+    expect(rollforward!.opening + rollforward!.issued + rollforward!.applied + rollforward!.expired).toBeCloseTo(rollforward!.closing, 6);
   });
 
   it('groups by client and currency independently', () => {
@@ -304,9 +381,15 @@ describe('hours rollforward aggregation', () => {
       period({ clientId: 'client-2', currencyCode: 'USD', periodFee: 70000 }),
     ];
     const rollforward = computeHoursRollforward('2026-02', periods);
-    expect(rollforward.get('client-1\u0000USD')?.issued).toBe(100000);
-    expect(rollforward.get('client-1\u0000EUR')?.issued).toBe(90000);
-    expect(rollforward.get('client-2\u0000USD')?.issued).toBe(70000);
+    const usdClient1 = rollforward.get('client-1\u0000USD')!;
+    const eurClient1 = rollforward.get('client-1\u0000EUR')!;
+    const usdClient2 = rollforward.get('client-2\u0000USD')!;
+    expect(usdClient1.issued).toBe(100000);
+    expect(eurClient1.issued).toBe(90000);
+    expect(usdClient2.issued).toBe(70000);
+    for (const aggregate of [usdClient1, eurClient1, usdClient2]) {
+      expect(aggregate.opening + aggregate.issued + aggregate.applied + aggregate.expired).toBeCloseTo(aggregate.closing, 6);
+    }
   });
 
   it('closes arithmetically and carries the rollover across consecutive monthly periods', () => {

--- a/packages/reporting/src/actions/report-actions/deferred-revenue/hours.ts
+++ b/packages/reporting/src/actions/report-actions/deferred-revenue/hours.ts
@@ -1,0 +1,264 @@
+/**
+ * Prepaid-hours rollforward — pure computation over bucket periods.
+ *
+ * Sources: persisted `bucket_usage` period rows plus the bucket allowance
+ * config (`contract_line_service_bucket_config.total_minutes`, allow_rollover).
+ *
+ * Valuation (per settled design decision 2): an unburned minute is worth
+ * `period fee ÷ included minutes`, where the period fee is the fee actually
+ * billed for the bucket period (falling back to the configured fee for
+ * not-yet-billed periods). Rollover minutes add to remaining quantity but not
+ * to the denominator.
+ *
+ * Forfeiture is recognized only when a period actually ends: at period end,
+ * leftover minutes that do not roll (non-rollover buckets) lapse, as do
+ * rolled-in minutes that never compound. Rollover carries at most one period:
+ * the carry is the previous period's unused base allowance, which the next
+ * bucket period persists as rolled_over_minutes.
+ *
+ * Movement for month M (all signed like the credits columns — issued grows the
+ * liability, applied/expired reduce it):
+ *   - issued   = period fee for bucket periods starting in M
+ *   - applied  = −minutes burned in M × rate (capped so a period's recognized
+ *                revenue never exceeds what was billed)
+ *   - expired  = −forfeited minutes at period ends inside M × rate
+ *   - opening  = outstanding value at the start of M × rate
+ *   - closing  = outstanding value at the end of M × rate
+ *
+ * Rollover carry accounting: a carried-in allowance is a liability the moment
+ * the prior period ends and rolls, so a period that ends in M recognizes its
+ * carry in closing unless the successor period has already started by M's end
+ * (then the carry lives inside the successor's balance). Symmetrically, a
+ * period that starts on the first calendar day of M opens with its carried-in
+ * rollover value. This keeps closing(M) = opening(M+1) and makes the movement
+ * columns close arithmetically at the tenant/client level.
+ *
+ * Burn attribution: periods fully inside M burn their minutes_used in M. For
+ * periods spanning month boundaries the v1 fallback attributes the full
+ * period's burn to the month the period ends in — the same derivation the
+ * reconciliation job uses against dated sources, but simpler and robust to the
+ * dated-source gaps. The caller discloses the fallback via report notes.
+ */
+
+import { monthKeyOf, monthRange } from './month';
+import type { BucketDetailRow, FeeSource } from './types';
+
+export interface BucketPeriodInput {
+  usageId: string;
+  contractLineId: string;
+  contractLineName: string;
+  clientId: string;
+  serviceId: string;
+  serviceName: string;
+  /** inclusive calendar day 'YYYY-MM-DD' */
+  periodStart: string;
+  /** inclusive calendar day 'YYYY-MM-DD' */
+  periodEnd: string;
+  totalMinutes: number;
+  rolledOverMinutes: number;
+  minutesUsed: number;
+  allowRollover: boolean;
+  currencyCode: string;
+  /** resolved period fee in minor units (cents). */
+  periodFee: number;
+  feeSource: FeeSource;
+}
+
+export interface BucketPeriodMovement {
+  opening: number;
+  issued: number;
+  applied: number;
+  expired: number;
+  closing: number;
+  detail: BucketDetailRow;
+}
+
+export interface HoursRollforward {
+  opening: number;
+  issued: number;
+  applied: number;
+  expired: number;
+  closing: number;
+  details: BucketDetailRow[];
+}
+
+function numberOrZero(value: number | string | null | undefined): number {
+  const parsed = Number(value ?? 0);
+  return Number.isFinite(parsed) ? parsed : 0;
+}
+
+/** Coerce -0 to +0 so movement columns compare and serialize cleanly. */
+function signedZero(value: number): number {
+  return value === 0 ? 0 : value;
+}
+
+/** Per-minute rate in minor units; zero when the fee or allowance is absent. */
+export function perMinuteRate(totalMinutes: number, periodFee: number): number {
+  const included = Math.max(0, totalMinutes);
+  const fee = Math.max(0, periodFee);
+  if (included <= 0 || fee <= 0) return 0;
+  return fee / included;
+}
+
+/**
+ * Rollforward contribution of one bucket period to one calendar month.
+ *
+ * @param successorStart the earliest `periodStart` of a later period row for
+ *   the same contract line + service. A period that ends in M and rolls its
+ *   unused base allowance to the next period recognizes the carry in closing
+ *   UNLESS the successor has already started by M's end (then the carry lives
+ *   inside the successor's balance and must not be counted twice). When no
+ *   successor exists yet (the current, not-yet-rolled period), the carry is
+ *   still an outstanding liability and stays in closing.
+ */
+export function computeBucketPeriodMovement(
+  month: string,
+  input: BucketPeriodInput,
+  options: { successorStart?: string } = {},
+): BucketPeriodMovement {
+  const { start, endExclusive } = monthRange(month);
+
+  const included = Math.max(0, numberOrZero(input.totalMinutes));
+  const rolledOver = Math.max(0, numberOrZero(input.rolledOverMinutes));
+  const used = Math.max(0, numberOrZero(input.minutesUsed));
+  const fee = Math.max(0, numberOrZero(input.periodFee));
+  const rate = perMinuteRate(included, fee);
+
+  const startKey = monthKeyOf(input.periodStart);
+  const endKey = monthKeyOf(input.periodEnd);
+
+  const startsInMonth = startKey === month;
+  const endsInMonth = endKey === month;
+  const startsAtMonthBoundary = input.periodStart === start;
+  const activeAtMonthStart = input.periodStart < start && start <= input.periodEnd;
+  const overlapsMonth = input.periodStart < endExclusive && input.periodEnd >= start;
+
+  // Issued: the allowance's fee lands in the month the period starts.
+  const issued = startsInMonth ? fee : 0;
+
+  // Opening: the outstanding value this period owns at the start of M. A
+  // period starting on the first calendar day of M opens with its carried-in
+  // rollover value (the liability that crossed the boundary). A period already
+  // active at M-start opens with its full allowance + rollover (burn lands in
+  // the end month under the v1 attribution).
+  let opening = 0;
+  if (startsInMonth) {
+    opening = startsAtMonthBoundary ? rolledOver * rate : 0;
+  } else if (activeAtMonthStart) {
+    opening = (included + rolledOver) * rate;
+  }
+
+  // Applied: the whole period's burn lands in its end month, signed negative,
+  // capped at the fee so a period's recognized revenue never exceeds what was
+  // billed (overage minutes are billed separately as overage).
+  const burn = endsInMonth ? used : 0;
+  const applied = -Math.min(burn * rate, fee);
+
+  // Expired: forfeiture is recognized only at the month the period ends in —
+  // non-rollover leftovers plus rolled-in minutes that never compound.
+  let expired = 0;
+  if (endsInMonth) {
+    const leftover = Math.max(0, included + rolledOver - used);
+    const carry = input.allowRollover ? Math.max(0, included - used) : 0;
+    expired = -Math.max(0, leftover - carry) * rate;
+  }
+
+  // Closing: outstanding value at the end of M. A period that ended in M keeps
+  // its carry unless the successor period has already started (the carry then
+  // lives inside the successor). A still-active period keeps its full
+  // allowance + rollover (burn lands in its end month).
+  let closing = 0;
+  if (overlapsMonth) {
+    if (endsInMonth) {
+      const carry = input.allowRollover ? Math.max(0, included - used) : 0;
+      const successorStartedByMonthEnd =
+        options.successorStart !== undefined && options.successorStart < endExclusive;
+      closing = successorStartedByMonthEnd ? 0 : carry * rate;
+    } else {
+      closing = (included + rolledOver) * rate;
+    }
+  }
+
+  const remainingMinutes = Math.max(0, included + rolledOver - used);
+  const valueRemaining = remainingMinutes * rate;
+
+  return {
+    opening: signedZero(opening),
+    issued: signedZero(issued),
+    applied: signedZero(applied),
+    expired: signedZero(expired),
+    closing: signedZero(closing),
+    detail: {
+      usageId: input.usageId,
+      contractLineId: input.contractLineId,
+      contractLineName: input.contractLineName,
+      serviceId: input.serviceId,
+      serviceName: input.serviceName,
+      periodStart: input.periodStart,
+      periodEnd: input.periodEnd,
+      totalMinutes: included,
+      rolledOverMinutes: rolledOver,
+      minutesUsed: used,
+      remainingMinutes,
+      allowRollover: input.allowRollover,
+      periodFee: fee,
+      perMinuteRate: rate,
+      valueRemaining,
+      feeSource: input.feeSource,
+      notYetBilled: input.feeSource === 'configured',
+    },
+  };
+}
+
+/**
+ * Build the hours rollforward for one calendar month across every bucket
+ * period of a tenant (or client subset). Returns an aggregate per
+ * client×currency together with per-period detail rows.
+ */
+export function computeHoursRollforward(
+  month: string,
+  periods: BucketPeriodInput[],
+): Map<string, HoursRollforward> {
+  const byClientCurrency = new Map<string, HoursRollforward>();
+  const periodList = Array.from(periods);
+
+  for (const period of periodList) {
+    const currencyCode = period.currencyCode ?? 'USD';
+    const key = `${period.clientId}\u0000${currencyCode}`;
+    const aggregate = byClientCurrency.get(key) ?? {
+      opening: 0,
+      issued: 0,
+      applied: 0,
+      expired: 0,
+      closing: 0,
+      details: [],
+    };
+
+    const successorStart = periodList
+      .filter(
+        (candidate) =>
+          candidate.contractLineId === period.contractLineId &&
+          candidate.serviceId === period.serviceId &&
+          candidate.periodStart > period.periodStart,
+      )
+      .reduce<string | undefined>(
+        (earliest, candidate) =>
+          earliest === undefined || candidate.periodStart < earliest
+            ? candidate.periodStart
+            : earliest,
+        undefined,
+      );
+
+    const movement = computeBucketPeriodMovement(month, period, { successorStart });
+    aggregate.opening += movement.opening;
+    aggregate.issued += movement.issued;
+    aggregate.applied += movement.applied;
+    aggregate.expired += movement.expired;
+    aggregate.closing += movement.closing;
+    aggregate.details.push(movement.detail);
+
+    byClientCurrency.set(key, aggregate);
+  }
+
+  return byClientCurrency;
+}

--- a/packages/reporting/src/actions/report-actions/deferred-revenue/hours.ts
+++ b/packages/reporting/src/actions/report-actions/deferred-revenue/hours.ts
@@ -186,13 +186,16 @@ export function computeBucketPeriodMovement(
 
   const remainingMinutes = Math.max(0, included + rolledOver - used);
   const valueRemaining = remainingMinutes * rate;
-
-  return {
+  const signed = {
     opening: signedZero(opening),
     issued: signedZero(issued),
     applied: signedZero(applied),
     expired: signedZero(expired),
     closing: signedZero(closing),
+  };
+
+  return {
+    ...signed,
     detail: {
       usageId: input.usageId,
       contractLineId: input.contractLineId,
@@ -211,8 +214,26 @@ export function computeBucketPeriodMovement(
       valueRemaining,
       feeSource: input.feeSource,
       notYetBilled: input.feeSource === 'configured',
+      movement: { ...signed, adjustments: 0 },
     },
   };
+}
+
+/**
+ * Whether a bucket period contributes any nonzero figure to the selected
+ * month. A period fully before or after the month lands with all movement
+ * columns zero — it carries no liability into the month and must not produce a
+ * detail row or surface the client. A carried-in period (nonzero opening or
+ * closing, even with no in-month activity) is a contributor and keeps its row.
+ */
+export function contributesToMonth(movement: BucketPeriodMovement): boolean {
+  return (
+    movement.opening !== 0 ||
+    movement.issued !== 0 ||
+    movement.applied !== 0 ||
+    movement.expired !== 0 ||
+    movement.closing !== 0
+  );
 }
 
 /**
@@ -230,14 +251,6 @@ export function computeHoursRollforward(
   for (const period of periodList) {
     const currencyCode = period.currencyCode ?? 'USD';
     const key = `${period.clientId}\u0000${currencyCode}`;
-    const aggregate = byClientCurrency.get(key) ?? {
-      opening: 0,
-      issued: 0,
-      applied: 0,
-      expired: 0,
-      closing: 0,
-      details: [],
-    };
 
     const successorStart = periodList
       .filter(
@@ -255,6 +268,19 @@ export function computeHoursRollforward(
       );
 
     const movement = computeBucketPeriodMovement(month, period, { successorStart });
+    // A period with no opening/issued/applied/expired/closing figure for the
+    // month contributes nothing — skip it entirely so the client does not
+    // surface (compose retains clients only via nonzero rows or detail rows).
+    if (!contributesToMonth(movement)) continue;
+
+    const aggregate = byClientCurrency.get(key) ?? {
+      opening: 0,
+      issued: 0,
+      applied: 0,
+      expired: 0,
+      closing: 0,
+      details: [],
+    };
     aggregate.opening += movement.opening;
     aggregate.issued += movement.issued;
     aggregate.applied += movement.applied;

--- a/packages/reporting/src/actions/report-actions/deferred-revenue/hours.ts
+++ b/packages/reporting/src/actions/report-actions/deferred-revenue/hours.ts
@@ -16,14 +16,16 @@
  * the carry is the previous period's unused base allowance, which the next
  * bucket period persists as rolled_over_minutes.
  *
- * Movement for month M (all signed like the credits columns — issued grows the
- * liability, applied/expired reduce it):
- *   - issued   = period fee for bucket periods starting in M
- *   - applied  = −minutes burned in M × rate (capped so a period's recognized
- *                revenue never exceeds what was billed)
- *   - expired  = −forfeited minutes at period ends inside M × rate
- *   - opening  = outstanding value at the start of M × rate
- *   - closing  = outstanding value at the end of M × rate
+  * Movement for month M (all signed like the credits columns — issued grows the
+  * liability, applied/expired reduce it):
+  *   - issued   = period fee for bucket periods starting in M
+  *   - applied  = −minutes burned in M × rate, capped at the value actually
+  *                available (fee + carried-in value), so a period's recognized
+  *                revenue never exceeds what was billed — the carry's value was
+  *                billed in the prior period's fee
+  *   - expired  = −forfeited minutes at period ends inside M × rate
+  *   - opening  = outstanding value at the start of M × rate
+  *   - closing  = outstanding value at the end of M × rate
  *
  * Rollover carry accounting: a carried-in allowance is a liability the moment
  * the prior period ends and rolls, so a period that ends in M recognizes its
@@ -149,10 +151,13 @@ export function computeBucketPeriodMovement(
   }
 
   // Applied: the whole period's burn lands in its end month, signed negative,
-  // capped at the fee so a period's recognized revenue never exceeds what was
-  // billed (overage minutes are billed separately as overage).
+  // capped at the value of the minutes actually available — total allowance +
+  // carried-in rollover. Burned minutes beyond that are overage, billed
+  // separately and outside the prepaid liability. Because the carried-in value
+  // was already billed in the prior period's fee, the cap (fee + carry value)
+  // still means recognized revenue never exceeds cash received.
   const burn = endsInMonth ? used : 0;
-  const applied = -Math.min(burn * rate, fee);
+  const applied = -Math.min(burn, included + rolledOver) * rate;
 
   // Expired: forfeiture is recognized only at the month the period ends in —
   // non-rollover leftovers plus rolled-in minutes that never compound.

--- a/packages/reporting/src/actions/report-actions/deferred-revenue/loaders.contract.test.ts
+++ b/packages/reporting/src/actions/report-actions/deferred-revenue/loaders.contract.test.ts
@@ -1,0 +1,31 @@
+import { readFileSync } from 'node:fs';
+import { describe, expect, it } from 'vitest';
+
+const source = readFileSync(new URL('./loaders.ts', import.meta.url), 'utf8');
+
+describe('deferred revenue loaders tenant-scoped query contract', () => {
+  it('scopes every source read through tenantDb', () => {
+    expect(source).toContain("tenantDb(conn, tenant)");
+    expect(source).toContain(".table('clients')");
+    expect(source).toContain(".table('transactions')");
+    expect(source).toContain(".table('invoices')");
+    expect(source).toContain(".table('bucket_usage as bu')");
+    expect(source).toContain(".table('invoice_charge_details as iid')");
+    expect(source).toContain(".table('contract_line_service_configuration as clsc')");
+
+    // No un-scoped knex table access leaks into the report reads.
+    expect(source).not.toContain("conn.table('transactions')");
+    expect(source).not.toContain("conn.table('credit_tracking')");
+  });
+
+  it('reads every join through the tenant-aware join helper', () => {
+    expect(source).toContain('db.tenantJoin(');
+    // The credit_tracking detail read joins the ledger tenant-scoped.
+    expect(source).toContain("db.tenantJoin(query, 'transactions as t', 'ct.transaction_id', 't.transaction_id'");
+  });
+
+  it('filters billed fees to finalized (non-draft/cancelled/pending) invoices', () => {
+    expect(source).toContain("NON_BILLED_INVOICE_STATUSES");
+    expect(source).toContain("'draft', 'cancelled', 'pending', 'void'");
+  });
+});

--- a/packages/reporting/src/actions/report-actions/deferred-revenue/loaders.ts
+++ b/packages/reporting/src/actions/report-actions/deferred-revenue/loaders.ts
@@ -1,0 +1,529 @@
+/**
+ * Database loaders for the deferred-revenue report. Every read is tenant
+ * scoped through `tenantDb`; the orchestration in getDeferredRevenueReport.ts
+ * composes these into the rollforward payload.
+ */
+
+import type { Knex } from 'knex';
+import { tenantDb } from '@alga-psa/db';
+
+import { resolvePeriodFee, type BilledFeeCandidate } from './fee';
+import { classifyCreditSource, type CreditSourceInvoice } from './creditSource';
+import type { BucketPeriodInput } from './hours';
+import type { CreditTransactionRow } from './credits';
+import type { CreditDetailRow } from './types';
+
+/** Finalized invoice statuses (legacy 'Unpaid' etc. treated as billed). */
+const NON_BILLED_INVOICE_STATUSES = new Set(['draft', 'cancelled', 'pending', 'void']);
+
+export const CREDIT_TRANSACTION_TYPES = [
+  'credit_issuance',
+  'credit_issuance_from_negative_invoice',
+  'prepayment',
+  'credit_application',
+  'credit_expiration',
+  'credit_adjustment',
+  'credit_transfer',
+];
+
+export interface LoadedClient {
+  clientId: string;
+  clientName: string;
+  defaultCurrencyCode: string | null;
+}
+
+export interface CreditTrackingDetailRow {
+  creditId: string;
+  transactionId: string;
+  clientId: string;
+  currencyCode: string;
+  amount: number;
+  remainingAmount: number;
+  expirationDate: string | null;
+  isExpired: boolean;
+  transactionType: string;
+  issuedDate: string;
+  description: string | null;
+  invoiceId: string | null;
+  metadata: unknown;
+}
+
+export interface RawBucketPeriodRow {
+  usageId: string;
+  contractLineId: string;
+  contractId: string;
+  contractLineName: string;
+  clientId: string;
+  serviceId: string;
+  serviceName: string;
+  periodStart: string;
+  periodEnd: string;
+  minutesUsed: number;
+  rolledOverMinutes: number;
+  totalMinutes: number;
+  allowRollover: boolean;
+  currencyCode: string;
+  /** contract_lines.custom_rate in cents, when set. */
+  lineCustomRate: number | null;
+  /** service_catalog.default_rate in cents, when set. */
+  catalogDefaultRate: number | null;
+}
+
+export interface RawPricingScheduleRow {
+  contractId: string;
+  effectiveDate: string;
+  endDate: string | null;
+  customRate: number | null;
+}
+
+export interface RawFixedFeeRow {
+  contractLineId: string;
+  serviceId: string;
+  servicePeriodStart: string | null;
+  servicePeriodEnd: string | null;
+  rate: number;
+  quantity: number;
+}
+
+export interface RawFixedConfigRow {
+  contractLineId: string;
+  serviceId: string;
+  baseRate: number | null;
+  quantity: number;
+}
+
+function toStringValue(value: unknown): string {
+  if (value instanceof Date) return value.toISOString();
+  if (typeof value === 'string') return value;
+  if (value === null || value === undefined) return '';
+  return String(value);
+}
+
+function toNumber(value: unknown): number {
+  const parsed = Number(value ?? 0);
+  return Number.isFinite(parsed) ? parsed : 0;
+}
+
+export async function loadClients(conn: Knex | Knex.Transaction, tenant: string): Promise<LoadedClient[]> {
+  const rows = await tenantDb(conn, tenant)
+    .table('clients')
+    .select('client_id', 'client_name', 'default_currency_code')
+    .where('is_inactive', false);
+  return rows.map((row) => ({
+    clientId: row.client_id,
+    clientName: row.client_name,
+    defaultCurrencyCode: row.default_currency_code ?? null,
+  }));
+}
+
+export async function loadCreditTransactions(
+  conn: Knex | Knex.Transaction,
+  tenant: string,
+): Promise<CreditTransactionRow[]> {
+  const rows = await tenantDb(conn, tenant)
+    .table('transactions')
+    .whereIn('type', CREDIT_TRANSACTION_TYPES)
+    .select('transaction_id', 'client_id', 'currency_code', 'type', 'amount', 'created_at');
+  return rows.map((row) => ({
+    transactionId: row.transaction_id,
+    clientId: row.client_id,
+    currencyCode: row.currency_code || 'USD',
+    type: row.type,
+    amount: toNumber(row.amount),
+    createdAt: toStringValue(row.created_at),
+  }));
+}
+
+export async function loadCreditTrackingDetails(
+  conn: Knex | Knex.Transaction,
+  tenant: string,
+): Promise<CreditTrackingDetailRow[]> {
+  const db = tenantDb(conn, tenant);
+  const query = db.table('credit_tracking as ct');
+  db.tenantJoin(query, 'transactions as t', 'ct.transaction_id', 't.transaction_id', { type: 'left' });
+
+  const rows = await query.select(
+    'ct.credit_id',
+    'ct.transaction_id',
+    'ct.client_id',
+    'ct.currency_code',
+    'ct.amount',
+    'ct.remaining_amount',
+    'ct.expiration_date',
+    'ct.is_expired',
+    't.type as transaction_type',
+    't.created_at as issued_date',
+    't.description',
+    't.invoice_id',
+    't.metadata',
+  );
+
+  return rows.map((row) => ({
+    creditId: row.credit_id,
+    transactionId: row.transaction_id,
+    clientId: row.client_id,
+    currencyCode: row.currency_code || 'USD',
+    amount: toNumber(row.amount),
+    remainingAmount: toNumber(row.remaining_amount),
+    expirationDate: row.expiration_date ? toStringValue(row.expiration_date) : null,
+    isExpired: Boolean(row.is_expired),
+    transactionType: row.transaction_type ?? '',
+    issuedDate: toStringValue(row.issued_date),
+    description: row.description ?? null,
+    invoiceId: row.invoice_id ?? null,
+    metadata: row.metadata ?? null,
+  }));
+}
+
+export async function loadCreditInvoices(
+  conn: Knex | Knex.Transaction,
+  tenant: string,
+  invoiceIds: Array<string | null>,
+): Promise<Map<string, CreditSourceInvoice>> {
+  const distinct = Array.from(new Set(invoiceIds.filter((id): id is string => Boolean(id))));
+  const result = new Map<string, CreditSourceInvoice>();
+  if (distinct.length === 0) return result;
+
+  const rows = await tenantDb(conn, tenant)
+    .table('invoices')
+    .whereIn('invoice_id', distinct)
+    .select('invoice_id', 'invoice_number', 'is_prepayment', 'invoice_type');
+
+  for (const row of rows) {
+    result.set(row.invoice_id, {
+      invoiceId: row.invoice_id,
+      invoiceNumber: row.invoice_number ?? null,
+      isPrepayment: Boolean(row.is_prepayment),
+      invoiceType: row.invoice_type ?? null,
+    });
+  }
+  return result;
+}
+
+export async function loadBucketPeriods(
+  conn: Knex | Knex.Transaction,
+  tenant: string,
+): Promise<RawBucketPeriodRow[]> {
+  const db = tenantDb(conn, tenant);
+  const query = db.table('bucket_usage as bu');
+  db.tenantJoin(query, 'contract_lines as cl', 'bu.contract_line_id', 'cl.contract_line_id');
+  db.tenantJoin(query, 'contracts as ct', 'cl.contract_id', 'ct.contract_id');
+  db.tenantJoin(
+    query,
+    'contract_line_service_configuration as clsc',
+    'bu.contract_line_id',
+    'clsc.contract_line_id',
+    {
+      on: (join) => {
+        join.andOn('bu.service_catalog_id', '=', 'clsc.service_id');
+        join.andOn('clsc.configuration_type', '=', conn.raw('?', ['Bucket']));
+      },
+    },
+  );
+  db.tenantJoin(query, 'contract_line_service_bucket_config as bc', 'clsc.config_id', 'bc.config_id');
+  db.tenantJoin(query, 'service_catalog as sc', 'bu.service_catalog_id', 'sc.service_id');
+
+  const rows = await query.select(
+    'bu.usage_id',
+    'bu.contract_line_id',
+    'bu.client_id',
+    'bu.service_catalog_id',
+    'bu.period_start',
+    'bu.period_end',
+    'bu.minutes_used',
+    'bu.rolled_over_minutes',
+    'bc.total_minutes',
+    'bc.allow_rollover',
+    'ct.contract_id',
+    'cl.contract_line_name',
+    'cl.custom_rate',
+    'ct.currency_code',
+    'sc.service_name',
+    'sc.default_rate',
+  );
+
+  return rows.map((row) => ({
+    usageId: row.usage_id,
+    contractLineId: row.contract_line_id,
+    contractId: row.contract_id,
+    contractLineName: row.contract_line_name ?? 'Unnamed contract line',
+    clientId: row.client_id,
+    serviceId: row.service_catalog_id,
+    serviceName: row.service_name ?? 'Unnamed service',
+    periodStart: toStringValue(row.period_start).slice(0, 10),
+    periodEnd: toStringValue(row.period_end).slice(0, 10),
+    minutesUsed: toNumber(row.minutes_used),
+    rolledOverMinutes: toNumber(row.rolled_over_minutes),
+    totalMinutes: toNumber(row.total_minutes),
+    allowRollover: Boolean(row.allow_rollover),
+    currencyCode: row.currency_code || 'USD',
+    lineCustomRate: row.custom_rate !== null && row.custom_rate !== undefined ? toNumber(row.custom_rate) : null,
+    catalogDefaultRate: row.default_rate !== null && row.default_rate !== undefined ? toNumber(row.default_rate) : null,
+  }));
+}
+
+/**
+ * Active pricing-schedule custom rates per contract. Mirrors the billing
+ * engine's override lookup (billingEngine.ts): the schedule with the latest
+ * effective_date that starts before the period's end (exclusive) and ends
+ * after the period's start (exclusive) wins, and its custom_rate — in cents —
+ * takes precedence over the contract-line custom rate.
+ */
+export async function loadPricingScheduleRates(
+  conn: Knex | Knex.Transaction,
+  tenant: string,
+  contractIds: Array<string>,
+): Promise<RawPricingScheduleRow[]> {
+  const distinct = Array.from(new Set(contractIds.filter(Boolean)));
+  if (distinct.length === 0) return [];
+
+  const rows = await tenantDb(conn, tenant)
+    .table('contract_pricing_schedules')
+    .whereIn('contract_id', distinct)
+    .select('contract_id', 'effective_date', 'end_date', 'custom_rate');
+
+  return rows.map((row) => ({
+    contractId: row.contract_id,
+    effectiveDate: toStringValue(row.effective_date).slice(0, 10),
+    endDate: row.end_date ? toStringValue(row.end_date).slice(0, 10) : null,
+    customRate: row.custom_rate !== null && row.custom_rate !== undefined ? toNumber(row.custom_rate) : null,
+  }));
+}
+
+function addDays(dateString: string, days: number): string {
+  const date = new Date(Date.parse(`${dateString}T00:00:00.000Z`));
+  date.setUTCDate(date.getUTCDate() + days);
+  return date.toISOString().slice(0, 10);
+}
+
+/**
+ * Resolve the pricing-schedule custom rate in effect for an inclusive bucket
+ * period, or null when no schedule overrides it.
+ */
+export function resolvePricingScheduleRate(
+  periodStart: string,
+  periodEnd: string,
+  contractId: string,
+  schedules: RawPricingScheduleRow[],
+): number | null {
+  const startExclusive = periodStart;
+  const endExclusive = addDays(periodEnd, 1);
+
+  let best: RawPricingScheduleRow | null = null;
+  for (const schedule of schedules) {
+    if (schedule.contractId !== contractId) continue;
+    if (schedule.customRate === null) continue;
+    if (schedule.effectiveDate >= endExclusive) continue;
+    if (schedule.endDate !== null && schedule.endDate <= startExclusive) continue;
+    if (best === null || schedule.effectiveDate > best.effectiveDate) {
+      best = schedule;
+    }
+  }
+  return best?.customRate ?? null;
+}
+
+/**
+ * Billed fixed-config fees for bucket lines on finalized invoices:
+ * invoice_charges → invoice_charge_details.config_id →
+ * contract_line_service_configuration (configuration_type = 'Fixed').
+ */
+export async function loadBilledBucketFees(
+  conn: Knex | Knex.Transaction,
+  tenant: string,
+): Promise<BilledFeeCandidate[]> {
+  const db = tenantDb(conn, tenant);
+  const query = db.table('invoice_charge_details as iid');
+  db.tenantJoin(query, 'contract_line_service_configuration as clsc', 'iid.config_id', 'clsc.config_id');
+  db.tenantJoin(query, 'invoice_charges as ic', 'iid.item_id', 'ic.item_id');
+  db.tenantJoin(query, 'invoices as inv', 'ic.invoice_id', 'inv.invoice_id');
+
+  const rows = await query
+    .where('clsc.configuration_type', 'Fixed')
+    .whereNotIn('inv.status', Array.from(NON_BILLED_INVOICE_STATUSES))
+    .select(
+      'clsc.contract_line_id',
+      'clsc.service_id',
+      'iid.service_period_start',
+      'iid.service_period_end',
+      'iid.rate',
+      'iid.quantity',
+    );
+
+  return rows.map((row) => ({
+    contractLineId: row.contract_line_id,
+    serviceId: row.service_id,
+    servicePeriodStart: row.service_period_start ? toStringValue(row.service_period_start).slice(0, 10) : '',
+    servicePeriodEnd: row.service_period_end ? toStringValue(row.service_period_end).slice(0, 10) : '',
+    feeCents: toNumber(row.rate) * Math.max(1, toNumber(row.quantity) || 1),
+  }));
+}
+
+/**
+ * Configured base rate per bucket line×service from the line's Fixed config
+ * (contract_line_service_fixed_config.base_rate × quantity), in cents. The
+ * report's fee fallback resolves: contract-line custom rate → this →
+ * service-catalog default rate.
+ */
+export async function loadFixedConfigBaseRates(
+  conn: Knex | Knex.Transaction,
+  tenant: string,
+): Promise<Map<string, number | null>> {
+  const db = tenantDb(conn, tenant);
+
+  const fixedConfigsQuery = db.table('contract_line_service_configuration as clsc');
+  db.tenantJoin(
+    fixedConfigsQuery,
+    'contract_line_service_fixed_config as fc',
+    'clsc.config_id',
+    'fc.config_id',
+    { type: 'left' },
+  );
+  const fixedConfigs = await fixedConfigsQuery
+    .where('clsc.configuration_type', 'Fixed')
+    .select('clsc.contract_line_id', 'clsc.service_id', 'clsc.quantity as config_quantity', 'fc.base_rate');
+
+  const byLineService = new Map<string, number | null>();
+
+  for (const row of fixedConfigs) {
+    const quantity = Math.max(1, toNumber(row.config_quantity) || 1);
+    const baseRate = row.base_rate !== null && row.base_rate !== undefined ? toNumber(row.base_rate) : null;
+    byLineService.set(`${row.contract_line_id}\u0000${row.service_id}`, baseRate !== null ? baseRate * quantity : null);
+  }
+
+  return byLineService;
+}
+
+export interface BuildDeferredRevenueInput {
+  clients: LoadedClient[];
+  creditTransactions: CreditTransactionRow[];
+  creditTracking: CreditTrackingDetailRow[];
+  creditInvoices: Map<string, CreditSourceInvoice>;
+  bucketPeriods: RawBucketPeriodRow[];
+  billedFees: BilledFeeCandidate[];
+  /** fixed-config base rate × quantity, keyed by `${contractLineId}\u0000${serviceId}`. */
+  fixedConfigBaseRates: Map<string, number | null>;
+  /** contract_pricing_schedules rows for every bucket-period contract. */
+  pricingSchedules: RawPricingScheduleRow[];
+}
+
+export async function loadDeferredRevenueData(
+  conn: Knex | Knex.Transaction,
+  tenant: string,
+): Promise<BuildDeferredRevenueInput> {
+  const [clients, creditTransactions, creditTracking, bucketPeriods, billedFees, fixedConfigBaseRates] =
+    await Promise.all([
+      loadClients(conn, tenant),
+      loadCreditTransactions(conn, tenant),
+      loadCreditTrackingDetails(conn, tenant),
+      loadBucketPeriods(conn, tenant),
+      loadBilledBucketFees(conn, tenant),
+      loadFixedConfigBaseRates(conn, tenant),
+    ]);
+
+  const pricingSchedules = await loadPricingScheduleRates(
+    conn,
+    tenant,
+    bucketPeriods.map((period) => period.contractId),
+  );
+
+  const invoiceIds = [
+    ...creditTracking.map((credit) => credit.invoiceId),
+    ...creditTracking.map((credit) =>
+      typeof credit.metadata === 'object' && credit.metadata !== null
+        ? (credit.metadata as Record<string, unknown>).source_invoice_id
+        : null,
+    ),
+  ].filter((id): id is string => typeof id === 'string' && id.length > 0);
+
+  const creditInvoices = await loadCreditInvoices(conn, tenant, invoiceIds);
+
+  return {
+    clients,
+    creditTransactions,
+    creditTracking,
+    creditInvoices,
+    bucketPeriods,
+    billedFees,
+    fixedConfigBaseRates,
+    pricingSchedules,
+  };
+}
+
+/**
+ * Resolve the fallback (not-yet-billed) period fee for a bucket line×service
+ * in the billing engine's rate-resolution order: pricing-schedule custom rate
+ * → contract-line custom rate → fixed-config base rate × quantity →
+ * service-catalog default rate.
+ */
+export function resolveConfiguredFee(
+  period: RawBucketPeriodRow,
+  baseRateCents: number | null,
+  pricingScheduleRate: number | null,
+): number | null {
+  if (pricingScheduleRate !== null) return pricingScheduleRate;
+  if (period.lineCustomRate !== null) return period.lineCustomRate;
+  if (baseRateCents !== null) return baseRateCents;
+  if (period.catalogDefaultRate !== null) return period.catalogDefaultRate;
+  return null;
+}
+
+/** Build the per-period inputs for the hours rollforward with fees resolved. */
+export function buildBucketPeriodInputs(
+  data: BuildDeferredRevenueInput,
+): BucketPeriodInput[] {
+  return data.bucketPeriods.map((period) => {
+    const pricingScheduleRate = resolvePricingScheduleRate(
+      period.periodStart,
+      period.periodEnd,
+      period.contractId,
+      data.pricingSchedules,
+    );
+    const configuredFee = resolveConfiguredFee(
+      period,
+      data.fixedConfigBaseRates.get(`${period.contractLineId}\u0000${period.serviceId}`) ?? null,
+      pricingScheduleRate,
+    );
+    const resolved = resolvePeriodFee(
+      period.periodStart,
+      period.periodEnd,
+      period.contractLineId,
+      data.billedFees,
+      configuredFee,
+    );
+    return {
+      ...period,
+      periodFee: resolved.feeCents,
+      feeSource: resolved.feeSource,
+    };
+  });
+}
+
+/** Build the credit detail rows for the report payload. */
+export function buildCreditDetailRows(
+  creditTracking: CreditTrackingDetailRow[],
+  creditInvoices: Map<string, CreditSourceInvoice>,
+): CreditDetailRow[] {
+  return creditTracking.map((credit) => {
+    const classification = classifyCreditSource(
+      credit.transactionType,
+      credit.invoiceId,
+      credit.metadata,
+      creditInvoices,
+    );
+    return {
+      creditId: credit.creditId,
+      transactionId: credit.transactionId,
+      clientId: credit.clientId,
+      issuedDate: credit.issuedDate,
+      description: credit.description,
+      amount: credit.amount,
+      remainingAmount: credit.remainingAmount,
+      expirationDate: credit.expirationDate,
+      isExpired: credit.isExpired,
+      sourceKind: classification.sourceKind,
+      qboReachable: classification.qboReachable,
+      invoiceNumber: classification.invoiceNumber,
+      currencyCode: credit.currencyCode,
+    };
+  });
+}

--- a/packages/reporting/src/actions/report-actions/deferred-revenue/loaders.ts
+++ b/packages/reporting/src/actions/report-actions/deferred-revenue/loaders.ts
@@ -487,6 +487,7 @@ export function buildBucketPeriodInputs(
       period.periodStart,
       period.periodEnd,
       period.contractLineId,
+      period.serviceId,
       data.billedFees,
       configuredFee,
     );

--- a/packages/reporting/src/actions/report-actions/deferred-revenue/loaders.ts
+++ b/packages/reporting/src/actions/report-actions/deferred-revenue/loaders.ts
@@ -10,7 +10,7 @@ import { tenantDb } from '@alga-psa/db';
 import { resolvePeriodFee, type BilledFeeCandidate } from './fee';
 import { classifyCreditSource, type CreditSourceInvoice } from './creditSource';
 import type { BucketPeriodInput } from './hours';
-import type { CreditTransactionRow } from './credits';
+import { reconstructCreditBalances, type CreditTransactionRow } from './credits';
 import type { CreditDetailRow } from './types';
 
 /** Finalized invoice statuses (legacy 'Unpaid' etc. treated as billed). */
@@ -123,7 +123,16 @@ export async function loadCreditTransactions(
   const rows = await tenantDb(conn, tenant)
     .table('transactions')
     .whereIn('type', CREDIT_TRANSACTION_TYPES)
-    .select('transaction_id', 'client_id', 'currency_code', 'type', 'amount', 'created_at');
+    .select(
+      'transaction_id',
+      'client_id',
+      'currency_code',
+      'type',
+      'amount',
+      'created_at',
+      'metadata',
+      'related_transaction_id',
+    );
   return rows.map((row) => ({
     transactionId: row.transaction_id,
     clientId: row.client_id,
@@ -131,6 +140,8 @@ export async function loadCreditTransactions(
     type: row.type,
     amount: toNumber(row.amount),
     createdAt: toStringValue(row.created_at),
+    metadata: row.metadata ?? null,
+    relatedTransactionId: row.related_transaction_id ?? null,
   }));
 }
 
@@ -507,14 +518,23 @@ export function buildBucketPeriodInputs(
  * issued before the month's end are kept even when their current remaining
  * balance is zero: a pre-month issuance still explains opening/closing or an
  * in-month application/expiration.
+ *
+ * Each row's `remainingAmount` is reconstructed from the ledger as of the
+ * month's end (see `reconstructCreditBalances`), not read from today's
+ * `credit_tracking` — so a credit issued in M-1 and fully applied in M+1 still
+ * reports its outstanding balance for month M. Retention (whether the row
+ * keeps a client on the report) is decided in compose.ts from this value plus
+ * in-month movement.
  */
 export function buildCreditDetailRows(
   creditTracking: CreditTrackingDetailRow[],
+  creditTransactions: CreditTransactionRow[],
   creditInvoices: Map<string, CreditSourceInvoice>,
   month: string,
 ): CreditDetailRow[] {
   const [year, monthIndex] = month.split('-').map(Number);
   const monthEnd = Date.UTC(year, monthIndex, 1);
+  const reconstruction = reconstructCreditBalances(month, creditTracking, creditTransactions);
 
   return creditTracking
     .filter((credit) => {
@@ -528,6 +548,7 @@ export function buildCreditDetailRows(
         credit.metadata,
         creditInvoices,
       );
+      const reconstructed = reconstruction.get(credit.creditId);
       return {
         creditId: credit.creditId,
         transactionId: credit.transactionId,
@@ -535,7 +556,9 @@ export function buildCreditDetailRows(
         issuedDate: credit.issuedDate,
         description: credit.description,
         amount: credit.amount,
-        remainingAmount: credit.remainingAmount,
+        remainingAmount: reconstructed?.remainingAsOfMonthEnd ?? credit.remainingAmount,
+        inMonthMovement: reconstructed?.inMonthMovement ?? 0,
+        reconstructionLimited: reconstructed?.limited ?? false,
         expirationDate: credit.expirationDate,
         isExpired: credit.isExpired,
         sourceKind: classification.sourceKind,

--- a/packages/reporting/src/actions/report-actions/deferred-revenue/loaders.ts
+++ b/packages/reporting/src/actions/report-actions/deferred-revenue/loaders.ts
@@ -499,32 +499,49 @@ export function buildBucketPeriodInputs(
   });
 }
 
-/** Build the credit detail rows for the report payload. */
+/**
+ * Build the credit detail rows for the report payload, grounded in the
+ * selected month. A credit issued at or after the month's end did not exist
+ * during the month — it can contribute nothing to opening, movement, or
+ * closing, so it must not surface a detail row (or retain its client). Rows
+ * issued before the month's end are kept even when their current remaining
+ * balance is zero: a pre-month issuance still explains opening/closing or an
+ * in-month application/expiration.
+ */
 export function buildCreditDetailRows(
   creditTracking: CreditTrackingDetailRow[],
   creditInvoices: Map<string, CreditSourceInvoice>,
+  month: string,
 ): CreditDetailRow[] {
-  return creditTracking.map((credit) => {
-    const classification = classifyCreditSource(
-      credit.transactionType,
-      credit.invoiceId,
-      credit.metadata,
-      creditInvoices,
-    );
-    return {
-      creditId: credit.creditId,
-      transactionId: credit.transactionId,
-      clientId: credit.clientId,
-      issuedDate: credit.issuedDate,
-      description: credit.description,
-      amount: credit.amount,
-      remainingAmount: credit.remainingAmount,
-      expirationDate: credit.expirationDate,
-      isExpired: credit.isExpired,
-      sourceKind: classification.sourceKind,
-      qboReachable: classification.qboReachable,
-      invoiceNumber: classification.invoiceNumber,
-      currencyCode: credit.currencyCode,
-    };
-  });
+  const [year, monthIndex] = month.split('-').map(Number);
+  const monthEnd = Date.UTC(year, monthIndex, 1);
+
+  return creditTracking
+    .filter((credit) => {
+      const issuedMs = Date.parse(credit.issuedDate);
+      return Number.isFinite(issuedMs) && issuedMs < monthEnd;
+    })
+    .map((credit) => {
+      const classification = classifyCreditSource(
+        credit.transactionType,
+        credit.invoiceId,
+        credit.metadata,
+        creditInvoices,
+      );
+      return {
+        creditId: credit.creditId,
+        transactionId: credit.transactionId,
+        clientId: credit.clientId,
+        issuedDate: credit.issuedDate,
+        description: credit.description,
+        amount: credit.amount,
+        remainingAmount: credit.remainingAmount,
+        expirationDate: credit.expirationDate,
+        isExpired: credit.isExpired,
+        sourceKind: classification.sourceKind,
+        qboReachable: classification.qboReachable,
+        invoiceNumber: classification.invoiceNumber,
+        currencyCode: credit.currencyCode,
+      };
+    });
 }

--- a/packages/reporting/src/actions/report-actions/deferred-revenue/month.ts
+++ b/packages/reporting/src/actions/report-actions/deferred-revenue/month.ts
@@ -1,0 +1,58 @@
+/**
+ * Month math for the deferred-revenue rollforward.
+ *
+ * The report reconstructs any historical calendar month from the ledgers, so
+ * all boundaries are computed in UTC and compared as YYYY-MM-DD strings.
+ */
+
+export interface MonthRange {
+  /** 'YYYY-MM' */
+  month: string;
+  /** 'YYYY-MM-DD' — first calendar day of the month (inclusive). */
+  start: string;
+  /** 'YYYY-MM-DD' — first calendar day of the next month (exclusive). */
+  endExclusive: string;
+}
+
+const MONTH_RE = /^\d{4}-\d{2}$/;
+
+export function isValidMonth(month: string): boolean {
+  if (!MONTH_RE.test(month)) return false;
+  const [year, monthIndex] = month.split('-').map(Number);
+  return monthIndex >= 1 && monthIndex <= 12 && year >= 1970 && year <= 2100;
+}
+
+export function monthRange(month: string): MonthRange {
+  if (!isValidMonth(month)) {
+    throw new Error(`Validation Error: month must be in YYYY-MM format (got ${month})`);
+  }
+  const [year, monthIndex] = month.split('-').map(Number);
+  const start = `${month}-01`;
+  const endDate = new Date(Date.UTC(year, monthIndex, 1)); // next month, day 1
+  const endExclusive = endDate.toISOString().slice(0, 10);
+  return { month, start, endExclusive };
+}
+
+export function nextMonth(month: string): string {
+  return monthRange(month).endExclusive.slice(0, 7);
+}
+
+export function previousMonth(month: string): string {
+  const [year, monthIndex] = month.split('-').map(Number);
+  const prev = new Date(Date.UTC(year, monthIndex - 2, 1));
+  return prev.toISOString().slice(0, 7);
+}
+
+/** Calendar month key ('YYYY-MM') for a YYYY-MM-DD or ISO date string. */
+export function monthKeyOf(dateString: string): string {
+  const dateOnly = dateString.slice(0, 10);
+  if (dateOnly.length !== 10) {
+    return dateOnly.slice(0, 7);
+  }
+  return dateOnly.slice(0, 7);
+}
+
+export function defaultReportMonth(now: Date = new Date()): string {
+  const previous = new Date(Date.UTC(now.getUTCFullYear(), now.getUTCMonth() - 1, 1));
+  return previous.toISOString().slice(0, 7);
+}

--- a/packages/reporting/src/actions/report-actions/deferred-revenue/types.ts
+++ b/packages/reporting/src/actions/report-actions/deferred-revenue/types.ts
@@ -1,0 +1,111 @@
+/**
+ * Shared types for the deferred-revenue / prepaid liability report.
+ *
+ * All monetary values are minor units (cents) of the row's currency_code.
+ * Amounts are grouped per currency and never summed across currencies.
+ */
+
+export interface MovementColumns {
+  opening: number;
+  issued: number;
+  applied: number;
+  expired: number;
+  adjustments: number;
+  closing: number;
+}
+
+export function emptyMovement(): MovementColumns {
+  return { opening: 0, issued: 0, applied: 0, expired: 0, adjustments: 0, closing: 0 };
+}
+
+export function addMovement(left: MovementColumns, right: MovementColumns): MovementColumns {
+  return {
+    opening: left.opening + right.opening,
+    issued: left.issued + right.issued,
+    applied: left.applied + right.applied,
+    expired: left.expired + right.expired,
+    adjustments: left.adjustments + right.adjustments,
+    closing: left.closing + right.closing,
+  };
+}
+
+/**
+ * Source classification for a credit detail row, mirroring the QBO
+ * reachability logic in creditApplicationApplier.resolveNonCreditMemoSource:
+ * credits backed by a prepayment invoice or a project-deposit issuance never
+ * produce a QBO CreditMemo, so they are flagged qboReachable: false.
+ */
+export type CreditSourceKind =
+  | 'prepayment'
+  | 'project_deposit'
+  | 'negative_invoice'
+  | 'direct_grant'
+  | 'transfer_in'
+  | 'other';
+
+export interface CreditDetailRow {
+  creditId: string;
+  transactionId: string;
+  clientId: string;
+  issuedDate: string;
+  description: string | null;
+  amount: number;
+  remainingAmount: number;
+  expirationDate: string | null;
+  isExpired: boolean;
+  sourceKind: CreditSourceKind;
+  qboReachable: boolean;
+  invoiceNumber: string | null;
+  currencyCode: string;
+}
+
+export type FeeSource = 'billed' | 'configured';
+
+export interface BucketDetailRow {
+  usageId: string;
+  contractLineId: string;
+  contractLineName: string;
+  serviceId: string;
+  serviceName: string;
+  periodStart: string;
+  periodEnd: string;
+  totalMinutes: number;
+  rolledOverMinutes: number;
+  minutesUsed: number;
+  remainingMinutes: number;
+  allowRollover: boolean;
+  periodFee: number;
+  perMinuteRate: number;
+  valueRemaining: number;
+  feeSource: FeeSource;
+  notYetBilled: boolean;
+}
+
+export interface ClientRollforward {
+  clientId: string;
+  clientName: string;
+  currencyCode: string;
+  credits: MovementColumns;
+  hours: MovementColumns;
+  total: MovementColumns;
+  creditDetails: CreditDetailRow[];
+  bucketDetails: BucketDetailRow[];
+}
+
+export interface CurrencySection {
+  currencyCode: string;
+  totals: {
+    credits: MovementColumns;
+    hours: MovementColumns;
+    total: MovementColumns;
+  };
+  clients: ClientRollforward[];
+}
+
+export interface DeferredRevenueReport {
+  month: string;
+  generatedAt: string;
+  sections: CurrencySection[];
+  /** Disclosed derivation fallbacks taken (e.g. spanning-period burn attribution). */
+  notes: string[];
+}

--- a/packages/reporting/src/actions/report-actions/deferred-revenue/types.ts
+++ b/packages/reporting/src/actions/report-actions/deferred-revenue/types.ts
@@ -79,6 +79,9 @@ export interface BucketDetailRow {
   valueRemaining: number;
   feeSource: FeeSource;
   notYetBilled: boolean;
+  /** This period's contribution to the selected month — lets each emitted
+   *  detail reconcile to the client rollforward (adjustments always 0). */
+  movement: MovementColumns;
 }
 
 export interface ClientRollforward {

--- a/packages/reporting/src/actions/report-actions/deferred-revenue/types.ts
+++ b/packages/reporting/src/actions/report-actions/deferred-revenue/types.ts
@@ -50,7 +50,12 @@ export interface CreditDetailRow {
   issuedDate: string;
   description: string | null;
   amount: number;
+  /** Outstanding balance reconstructed from the ledger as of the selected month's end. */
   remainingAmount: number;
+  /** Credit movement attributed to this credit and dated inside the selected month (signed). */
+  inMonthMovement: number;
+  /** True when unattributable ledger activity forced a cap at the current remaining balance. */
+  reconstructionLimited: boolean;
   expirationDate: string | null;
   isExpired: boolean;
   sourceKind: CreditSourceKind;

--- a/packages/reporting/src/actions/report-actions/getDeferredRevenueReport.contract.test.ts
+++ b/packages/reporting/src/actions/report-actions/getDeferredRevenueReport.contract.test.ts
@@ -1,0 +1,45 @@
+import { readFileSync } from 'node:fs';
+import { describe, expect, it } from 'vitest';
+
+const source = readFileSync(new URL('./getDeferredRevenueReport.ts', import.meta.url), 'utf8');
+
+function deferredRevenueSection(): string {
+  const start = source.indexOf('export const getDeferredRevenueReport');
+  expect(start).toBeGreaterThanOrEqual(0);
+  return source.slice(start);
+}
+
+describe('deferred revenue report action contract', () => {
+  it('gates on internal-user + reports.read permission independently of the page', () => {
+    const section = deferredRevenueSection();
+
+    expect(section).toContain('assertCanReadDeferredRevenueReport(user, knex)');
+    expect(source).toContain("user.user_type !== 'internal'");
+    expect(source).toContain("hasPermission(user, 'reports', 'read', knex)");
+    expect(source).toContain("throw new Error('Permission denied");
+  });
+
+  it('is a withAuth server action and returns reporting error shapes', () => {
+    const section = deferredRevenueSection();
+
+    expect(section).toContain('withAuth(');
+    expect(source).toContain("'use server';");
+    expect(source).toContain('ReportingActionError');
+    expect(source).toContain('reportingActionErrorFrom(error)');
+  });
+
+  it('validates the month parameter before touching the database', () => {
+    const section = deferredRevenueSection();
+
+    expect(section).toContain('InputSchema.safeParse(input)');
+    expect(source).toContain('isValidMonth');
+  });
+
+  it('derives everything live from the ledgers — no snapshot tables', () => {
+    const section = deferredRevenueSection();
+
+    expect(section).toContain('buildDeferredRevenueReport(knex, tenant,');
+    expect(section).not.toContain('snapshot');
+    expect(section).not.toContain('deferred_revenue_report');
+  });
+});

--- a/packages/reporting/src/actions/report-actions/getDeferredRevenueReport.ts
+++ b/packages/reporting/src/actions/report-actions/getDeferredRevenueReport.ts
@@ -1,0 +1,75 @@
+'use server';
+
+import { z } from 'zod';
+import type { Knex } from 'knex';
+import { withAuth, hasPermission } from '@alga-psa/auth';
+import { createTenantKnex } from '@alga-psa/db';
+import type { IUserWithRoles } from '@alga-psa/types';
+
+import { reportingActionErrorFrom, type ReportingActionError } from './reportingActionErrors';
+import { buildDeferredRevenueReport } from './deferred-revenue/compose';
+import type { DeferredRevenueReport } from './deferred-revenue/types';
+import { isValidMonth } from './deferred-revenue/month';
+
+export type {
+  DeferredRevenueReport,
+  ClientRollforward,
+  CurrencySection,
+  CreditDetailRow,
+  BucketDetailRow,
+  MovementColumns,
+  FeeSource,
+  CreditSourceKind,
+} from './deferred-revenue/types';
+
+const InputSchema = z.object({
+  month: z.string().refine(isValidMonth, {
+    message: 'month must be in YYYY-MM format',
+  }),
+});
+
+export type GetDeferredRevenueReportInput = z.infer<typeof InputSchema>;
+
+/**
+ * Per-client × currency deferred-revenue / prepaid liability rollforward for
+ * one calendar month, covering both client credit balances and unburned
+ * prepaid bucket hours. Every number is derived live from the ledgers — no
+ * snapshot tables.
+ *
+ * Enforced independently of the page: internal users with the `reports.read`
+ * permission (the same resource the billing report actions use).
+ */
+async function assertCanReadDeferredRevenueReport(
+  user: IUserWithRoles,
+  knex: Knex,
+): Promise<void> {
+  if (user.user_type !== 'internal') {
+    throw new Error('Permission denied: this report is for internal users only');
+  }
+  if (!(await hasPermission(user, 'reports', 'read', knex))) {
+    throw new Error('Permission denied: Cannot read reports');
+  }
+}
+
+export const getDeferredRevenueReport = withAuth(
+  async (
+    user,
+    { tenant },
+    input: GetDeferredRevenueReportInput,
+  ): Promise<DeferredRevenueReport | ReportingActionError> => {
+    const validationResult = InputSchema.safeParse(input);
+    if (!validationResult.success) {
+      return reportingActionErrorFrom(validationResult.error)!;
+    }
+
+    try {
+      const { knex } = await createTenantKnex();
+      await assertCanReadDeferredRevenueReport(user, knex);
+      return await buildDeferredRevenueReport(knex, tenant, validationResult.data.month);
+    } catch (error) {
+      const expected = reportingActionErrorFrom(error);
+      if (expected) return expected;
+      throw error;
+    }
+  },
+);

--- a/packages/reporting/src/actions/report-actions/index.ts
+++ b/packages/reporting/src/actions/report-actions/index.ts
@@ -11,3 +11,14 @@ export type { RemainingBucketUnitsResult } from './getRemainingBucketUnits'; // 
 
 export { getUsageDataMetrics } from './getUsageDataMetrics';
 export type { UsageMetricResult } from './getUsageDataMetrics'; // Export type if needed
+
+export { getDeferredRevenueReport } from './getDeferredRevenueReport';
+export type { GetDeferredRevenueReportInput } from './getDeferredRevenueReport';
+export type {
+  DeferredRevenueReport,
+  ClientRollforward,
+  CurrencySection,
+  CreditDetailRow,
+  BucketDetailRow,
+  MovementColumns,
+} from './deferred-revenue/types';

--- a/packages/reporting/src/components/deferred-revenue/DeferredRevenueReport.tsx
+++ b/packages/reporting/src/components/deferred-revenue/DeferredRevenueReport.tsx
@@ -20,20 +20,10 @@ import {
   type CurrencySection,
   type MovementColumns,
 } from '@alga-psa/reporting/actions/report-actions/getDeferredRevenueReport';
+import { defaultReportMonth } from '@alga-psa/reporting/actions/report-actions/deferred-revenue/month';
 
 const isReportActionError = (value: unknown) =>
   isActionMessageError(value) || isActionPermissionError(value);
-
-function currentMonth(): string {
-  const now = new Date();
-  return `${now.getUTCFullYear()}-${String(now.getUTCMonth()).padStart(2, '0')}`;
-}
-
-function previousMonth(month: string): string {
-  const [year, monthIndex] = month.split('-').map(Number);
-  const previous = new Date(Date.UTC(year, monthIndex - 2, 1));
-  return previous.toISOString().slice(0, 7);
-}
 
 function formatCents(cents: number, currency: string, formatCurrency: (value: number, currency: string) => string): string {
   return formatCurrency(cents / 100, currency);
@@ -415,7 +405,7 @@ function ClientRow({
 export default function DeferredRevenueReport() {
   const { t } = useTranslation('msp/reports');
   const { formatCurrency } = useFormatters();
-  const [month, setMonth] = useState<string>(() => previousMonth(currentMonth()));
+  const [month, setMonth] = useState<string>(() => defaultReportMonth());
   const [report, setReport] = useState<DeferredRevenueReportPayload | null>(null);
   const [error, setError] = useState<string | null>(null);
   const [expandedClients, setExpandedClients] = useState<Set<string>>(new Set());

--- a/packages/reporting/src/components/deferred-revenue/DeferredRevenueReport.tsx
+++ b/packages/reporting/src/components/deferred-revenue/DeferredRevenueReport.tsx
@@ -39,6 +39,17 @@ function formatCents(cents: number, currency: string, formatCurrency: (value: nu
   return formatCurrency(cents / 100, currency);
 }
 
+/**
+ * Single source of truth for the expansion key. A client may appear in more
+ * than one currency section, so the key must be the client×currency composite
+ * — and it must be derived in exactly one place so the toggle and the render
+ * check can never drift. The NUL separator cannot appear in a client UUID or
+ * a currency code.
+ */
+function clientExpansionKey(client: { clientId: string; currencyCode: string }): string {
+  return `${client.clientId}\u0000${client.currencyCode}`;
+}
+
 interface CsvColumn {
   key: string;
   header: string;
@@ -325,14 +336,15 @@ function DeferredRevenueTable({
             </tr>
           ) : (
             section.clients.map((client) => {
-              const expanded = expandedClients.has(client.clientId);
+              const key = clientExpansionKey(client);
+              const expanded = expandedClients.has(key);
               return (
                 <ClientRow
-                  key={`${client.clientId}-${client.currencyCode}`}
+                  key={key}
                   client={client}
                   currency={currency}
                   expanded={expanded}
-                  onToggle={() => toggleClient(`${client.clientId}-${client.currencyCode}`)}
+                  onToggle={() => toggleClient(key)}
                   formatCurrency={formatCurrency}
                 />
               );

--- a/packages/reporting/src/components/deferred-revenue/DeferredRevenueReport.tsx
+++ b/packages/reporting/src/components/deferred-revenue/DeferredRevenueReport.tsx
@@ -1,0 +1,636 @@
+'use client';
+
+import { useCallback, useEffect, useMemo, useState } from 'react';
+import { ChevronDown, ChevronRight, Download } from 'lucide-react';
+import { Button } from '@alga-psa/ui/components/Button';
+import { PrintButton } from '@alga-psa/ui/components/PrintButton';
+import { PrintableTable, type PrintableTableColumn } from '@alga-psa/ui/components/PrintableTable';
+import { Skeleton } from '@alga-psa/ui/components/Skeleton';
+import {
+  getErrorMessage,
+  isActionMessageError,
+  isActionPermissionError,
+} from '@alga-psa/ui/lib/errorHandling';
+import { useFormatters, useTranslation } from '@alga-psa/ui/lib/i18n/client';
+import {
+  getDeferredRevenueReport,
+  type DeferredRevenueReport as DeferredRevenueReportPayload,
+  type BucketDetailRow,
+  type CreditDetailRow,
+  type CurrencySection,
+  type MovementColumns,
+} from '@alga-psa/reporting/actions/report-actions/getDeferredRevenueReport';
+
+const isReportActionError = (value: unknown) =>
+  isActionMessageError(value) || isActionPermissionError(value);
+
+function currentMonth(): string {
+  const now = new Date();
+  return `${now.getUTCFullYear()}-${String(now.getUTCMonth()).padStart(2, '0')}`;
+}
+
+function previousMonth(month: string): string {
+  const [year, monthIndex] = month.split('-').map(Number);
+  const previous = new Date(Date.UTC(year, monthIndex - 2, 1));
+  return previous.toISOString().slice(0, 7);
+}
+
+function formatCents(cents: number, currency: string, formatCurrency: (value: number, currency: string) => string): string {
+  return formatCurrency(cents / 100, currency);
+}
+
+interface CsvColumn {
+  key: string;
+  header: string;
+  value: (row: ClientCsvRow) => number | string;
+}
+
+interface ClientCsvRow {
+  clientId: string;
+  clientName: string;
+  currencyCode: string;
+  credits: MovementColumns;
+  hours: MovementColumns;
+  total: MovementColumns;
+}
+
+function csvValue(value: number | string): string {
+  const string = String(value);
+  if (/[",\n]/.test(string)) {
+    return `"${string.replace(/"/g, '""')}"`;
+  }
+  return string;
+}
+
+function downloadCsv(filename: string, headers: string[], rows: ClientCsvRow[], columns: CsvColumn[]): void {
+  const lines = [
+    headers.join(','),
+    ...rows.map((row) => columns.map((column) => csvValue(column.value(row))).join(',')),
+  ];
+  const blob = new Blob([lines.join('\n')], { type: 'text/csv;charset=utf-8;' });
+  const url = URL.createObjectURL(blob);
+  const link = document.createElement('a');
+  link.href = url;
+  link.setAttribute('download', filename);
+  document.body.appendChild(link);
+  link.click();
+  document.body.removeChild(link);
+  URL.revokeObjectURL(url);
+}
+
+function MovementCells({
+  movement,
+  currency,
+  showAdjustments,
+  formatCurrency,
+  className,
+}: {
+  movement: MovementColumns;
+  currency: string;
+  showAdjustments: boolean;
+  formatCurrency: (value: number, currency: string) => string;
+  className?: string;
+}) {
+  const cells = [
+    movement.opening,
+    movement.issued,
+    movement.applied,
+    movement.expired,
+  ];
+  if (showAdjustments) cells.push(movement.adjustments);
+  cells.push(movement.closing);
+
+  return (
+    <>
+      {cells.map((value, index) => (
+        <td
+          key={index}
+          className={`whitespace-nowrap px-3 py-2 text-right tabular-nums text-[rgb(var(--color-text-700))] ${className ?? ''}`}
+        >
+          {formatCents(value, currency, formatCurrency)}
+        </td>
+      ))}
+    </>
+  );
+}
+
+function CreditDetailList({ details, currency, formatCurrency }: { details: CreditDetailRow[]; currency: string; formatCurrency: (value: number, currency: string) => string }) {
+  const { t } = useTranslation('msp/reports');
+  return (
+    <div className="px-4 py-3">
+      <p className="text-xs font-semibold uppercase tracking-wide text-[rgb(var(--color-text-500))]">
+        {t('deferredRevenue.detail.credits', { defaultValue: 'Credit balances' })}
+      </p>
+      {details.length === 0 ? (
+        <p className="mt-2 text-sm text-[rgb(var(--color-text-500))]">
+          {t('deferredRevenue.detail.noCredits', { defaultValue: 'No credit entries.' })}
+        </p>
+      ) : (
+        <div className="mt-2 overflow-x-auto">
+          <table className="min-w-full divide-y divide-[rgb(var(--color-border-200))] text-sm">
+            <thead className="bg-[rgb(var(--color-background-100))]">
+              <tr>
+                <th className="px-3 py-2 text-left font-medium text-[rgb(var(--color-text-600))]">{t('deferredRevenue.detail.date', { defaultValue: 'Issued' })}</th>
+                <th className="px-3 py-2 text-left font-medium text-[rgb(var(--color-text-600))]">{t('deferredRevenue.detail.description', { defaultValue: 'Description' })}</th>
+                <th className="px-3 py-2 text-right font-medium text-[rgb(var(--color-text-600))]">{t('deferredRevenue.detail.remaining', { defaultValue: 'Remaining' })}</th>
+                <th className="px-3 py-2 text-left font-medium text-[rgb(var(--color-text-600))]">{t('deferredRevenue.detail.expires', { defaultValue: 'Expires' })}</th>
+                <th className="px-3 py-2 text-left font-medium text-[rgb(var(--color-text-600))]">{t('deferredRevenue.detail.qbo', { defaultValue: 'QBO' })}</th>
+              </tr>
+            </thead>
+            <tbody className="divide-y divide-[rgb(var(--color-border-200))]">
+              {details.map((detail) => (
+                <tr key={detail.creditId}>
+                  <td className="px-3 py-2 whitespace-nowrap text-[rgb(var(--color-text-700))]">
+                    {detail.issuedDate ? new Date(detail.issuedDate).toLocaleDateString() : '—'}
+                  </td>
+                  <td className="px-3 py-2 text-[rgb(var(--color-text-700))]">
+                    {detail.description || detail.sourceKind}
+                    {detail.invoiceNumber ? <span className="ml-2 text-xs text-[rgb(var(--color-text-500))]">{detail.invoiceNumber}</span> : null}
+                  </td>
+                  <td className="px-3 py-2 text-right tabular-nums text-[rgb(var(--color-text-700))]">
+                    {formatCents(detail.remainingAmount, currency, formatCurrency)}
+                  </td>
+                  <td className="px-3 py-2 whitespace-nowrap text-[rgb(var(--color-text-700))]">
+                    {detail.expirationDate ? new Date(detail.expirationDate).toLocaleDateString() : '—'}
+                  </td>
+                  <td className="px-3 py-2 text-[rgb(var(--color-text-700))]">
+                    {detail.qboReachable ? (
+                      <span className="text-[rgb(var(--color-text-600))]">{t('deferredRevenue.detail.reachable', { defaultValue: 'Synced' })}</span>
+                    ) : (
+                      <span className="font-medium text-[rgb(var(--color-destructive-600))]" title={t('deferredRevenue.detail.notReachableTitle', { defaultValue: 'Prepayment / project-deposit credits never export to QuickBooks — Alga is the system of record.' })}>
+                        {t('deferredRevenue.detail.notReachable', { defaultValue: 'Not in QBO' })}
+                      </span>
+                    )}
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      )}
+    </div>
+  );
+}
+
+function BucketDetailList({ details, currency, formatCurrency }: { details: BucketDetailRow[]; currency: string; formatCurrency: (value: number, currency: string) => string }) {
+  const { t } = useTranslation('msp/reports');
+  return (
+    <div className="px-4 py-3">
+      <p className="text-xs font-semibold uppercase tracking-wide text-[rgb(var(--color-text-500))]">
+        {t('deferredRevenue.detail.buckets', { defaultValue: 'Prepaid bucket hours' })}
+      </p>
+      {details.length === 0 ? (
+        <p className="mt-2 text-sm text-[rgb(var(--color-text-500))]">
+          {t('deferredRevenue.detail.noBuckets', { defaultValue: 'No prepaid bucket periods.' })}
+        </p>
+      ) : (
+        <div className="mt-2 overflow-x-auto">
+          <table className="min-w-full divide-y divide-[rgb(var(--color-border-200))] text-sm">
+            <thead className="bg-[rgb(var(--color-background-100))]">
+              <tr>
+                <th className="px-3 py-2 text-left font-medium text-[rgb(var(--color-text-600))]">{t('deferredRevenue.detail.line', { defaultValue: 'Line' })}</th>
+                <th className="px-3 py-2 text-left font-medium text-[rgb(var(--color-text-600))]">{t('deferredRevenue.detail.period', { defaultValue: 'Period' })}</th>
+                <th className="px-3 py-2 text-right font-medium text-[rgb(var(--color-text-600))]">{t('deferredRevenue.detail.included', { defaultValue: 'Included' })}</th>
+                <th className="px-3 py-2 text-right font-medium text-[rgb(var(--color-text-600))]">{t('deferredRevenue.detail.used', { defaultValue: 'Used' })}</th>
+                <th className="px-3 py-2 text-right font-medium text-[rgb(var(--color-text-600))]">{t('deferredRevenue.detail.remaining', { defaultValue: 'Remaining' })}</th>
+                <th className="px-3 py-2 text-right font-medium text-[rgb(var(--color-text-600))]">{t('deferredRevenue.detail.value', { defaultValue: 'Value' })}</th>
+                <th className="px-3 py-2 text-left font-medium text-[rgb(var(--color-text-600))]">{t('deferredRevenue.detail.feeSource', { defaultValue: 'Fee' })}</th>
+              </tr>
+            </thead>
+            <tbody className="divide-y divide-[rgb(var(--color-border-200))]">
+              {details.map((detail) => (
+                <tr key={detail.usageId}>
+                  <td className="px-3 py-2 text-[rgb(var(--color-text-700))]">
+                    {detail.contractLineName}
+                    <span className="ml-2 text-xs text-[rgb(var(--color-text-500))]">{detail.serviceName}</span>
+                  </td>
+                  <td className="px-3 py-2 whitespace-nowrap text-[rgb(var(--color-text-700))]">
+                    {detail.periodStart} → {detail.periodEnd}
+                    {detail.allowRollover ? (
+                      <span className="ml-1 text-xs text-[rgb(var(--color-text-500))]">{t('deferredRevenue.detail.rollover', { defaultValue: 'rollover' })}</span>
+                    ) : null}
+                  </td>
+                  <td className="px-3 py-2 text-right tabular-nums text-[rgb(var(--color-text-700))]">{detail.totalMinutes}</td>
+                  <td className="px-3 py-2 text-right tabular-nums text-[rgb(var(--color-text-700))]">{detail.minutesUsed}</td>
+                  <td className="px-3 py-2 text-right tabular-nums text-[rgb(var(--color-text-700))]">{detail.remainingMinutes}</td>
+                  <td className="px-3 py-2 text-right tabular-nums text-[rgb(var(--color-text-700))]">
+                    {formatCents(detail.valueRemaining, currency, formatCurrency)}
+                  </td>
+                  <td className="px-3 py-2 text-[rgb(var(--color-text-700))]">
+                    {detail.notYetBilled ? (
+                      <span className="text-[rgb(var(--color-text-500))]">{t('deferredRevenue.detail.notBilled', { defaultValue: 'Not yet billed' })}</span>
+                    ) : (
+                      <span>{t('deferredRevenue.detail.billed', { defaultValue: 'Billed' })}</span>
+                    )}
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      )}
+    </div>
+  );
+}
+
+function SummaryCards({ sections, formatCurrency }: { sections: CurrencySection[]; formatCurrency: (value: number, currency: string) => string }) {
+  const { t } = useTranslation('msp/reports');
+  return (
+    <div className="grid gap-3 md:grid-cols-2 xl:grid-cols-4">
+      {sections.map((section) => {
+        const delta = section.totals.total.closing - section.totals.total.opening;
+        return (
+          <div key={section.currencyCode} className="rounded-md border border-[rgb(var(--color-border-200))] bg-[rgb(var(--color-card))] p-4">
+            <p className="text-xs font-medium uppercase tracking-wide text-[rgb(var(--color-text-500))]">
+              {t('deferredRevenue.summary.totalLiability', { defaultValue: 'Total prepaid liability' })} · {section.currencyCode}
+            </p>
+            <p className="mt-2 text-2xl font-semibold text-[rgb(var(--color-text-900))]">
+              {formatCents(section.totals.total.closing, section.currencyCode, formatCurrency)}
+            </p>
+            <div className="mt-3 space-y-1 text-sm">
+              <div className="flex items-center justify-between">
+                <span className="text-[rgb(var(--color-text-500))]">{t('deferredRevenue.summary.credits', { defaultValue: 'Credits' })}</span>
+                <span className="tabular-nums text-[rgb(var(--color-text-700))]">{formatCents(section.totals.credits.closing, section.currencyCode, formatCurrency)}</span>
+              </div>
+              <div className="flex items-center justify-between">
+                <span className="text-[rgb(var(--color-text-500))]">{t('deferredRevenue.summary.hours', { defaultValue: 'Prepaid hours' })}</span>
+                <span className="tabular-nums text-[rgb(var(--color-text-700))]">{formatCents(section.totals.hours.closing, section.currencyCode, formatCurrency)}</span>
+              </div>
+              <div className="flex items-center justify-between">
+                <span className="text-[rgb(var(--color-text-500))]">{t('deferredRevenue.summary.delta', { defaultValue: 'Change vs prior month' })}</span>
+                <span className={`tabular-nums ${delta >= 0 ? 'text-[rgb(var(--color-text-700))]' : 'text-[rgb(var(--color-destructive-600))]'}`}>
+                  {formatCents(delta, section.currencyCode, formatCurrency)}
+                </span>
+              </div>
+            </div>
+          </div>
+        );
+      })}
+    </div>
+  );
+}
+
+function DeferredRevenueTable({
+  section,
+  expandedClients,
+  toggleClient,
+  formatCurrency,
+}: {
+  section: CurrencySection;
+  expandedClients: Set<string>;
+  toggleClient: (clientId: string) => void;
+  formatCurrency: (value: number, currency: string) => string;
+}) {
+  const { t } = useTranslation('msp/reports');
+  const currency = section.currencyCode;
+
+  return (
+    <div className="overflow-x-auto rounded-md border border-[rgb(var(--color-border-200))]">
+      <table className="min-w-full divide-y divide-[rgb(var(--color-border-200))] text-sm">
+        <thead className="bg-[rgb(var(--color-background-100))]">
+          <tr>
+            <th rowSpan={2} className="px-4 py-3 text-left font-medium text-[rgb(var(--color-text-600))]">
+              {t('deferredRevenue.table.client', { defaultValue: 'Client' })}
+            </th>
+            <th colSpan={6} className="border-b border-[rgb(var(--color-border-200))] px-3 py-2 text-center font-medium text-[rgb(var(--color-text-500))]">
+              {t('deferredRevenue.table.credits', { defaultValue: 'Credits' })}
+            </th>
+            <th colSpan={5} className="border-b border-[rgb(var(--color-border-200))] px-3 py-2 text-center font-medium text-[rgb(var(--color-text-500))]">
+              {t('deferredRevenue.table.hours', { defaultValue: 'Prepaid hours' })}
+            </th>
+            <th rowSpan={2} className="px-3 py-3 text-right font-medium text-[rgb(var(--color-text-600))]">
+              {t('deferredRevenue.table.total', { defaultValue: 'Total closing' })}
+            </th>
+          </tr>
+          <tr>
+            <th className="px-3 py-2 text-right font-medium text-[rgb(var(--color-text-500))]">{t('deferredRevenue.table.opening', { defaultValue: 'Opening' })}</th>
+            <th className="px-3 py-2 text-right font-medium text-[rgb(var(--color-text-500))]">{t('deferredRevenue.table.issued', { defaultValue: 'Issued' })}</th>
+            <th className="px-3 py-2 text-right font-medium text-[rgb(var(--color-text-500))]">{t('deferredRevenue.table.applied', { defaultValue: 'Applied' })}</th>
+            <th className="px-3 py-2 text-right font-medium text-[rgb(var(--color-text-500))]">{t('deferredRevenue.table.expired', { defaultValue: 'Expired' })}</th>
+            <th className="px-3 py-2 text-right font-medium text-[rgb(var(--color-text-500))]">{t('deferredRevenue.table.adjustments', { defaultValue: 'Adj.' })}</th>
+            <th className="px-3 py-2 text-right font-medium text-[rgb(var(--color-text-500))]">{t('deferredRevenue.table.closing', { defaultValue: 'Closing' })}</th>
+            <th className="px-3 py-2 text-right font-medium text-[rgb(var(--color-text-500))]">{t('deferredRevenue.table.opening', { defaultValue: 'Opening' })}</th>
+            <th className="px-3 py-2 text-right font-medium text-[rgb(var(--color-text-500))]">{t('deferredRevenue.table.issued', { defaultValue: 'Issued' })}</th>
+            <th className="px-3 py-2 text-right font-medium text-[rgb(var(--color-text-500))]">{t('deferredRevenue.table.applied', { defaultValue: 'Applied' })}</th>
+            <th className="px-3 py-2 text-right font-medium text-[rgb(var(--color-text-500))]">{t('deferredRevenue.table.expired', { defaultValue: 'Expired' })}</th>
+            <th className="px-3 py-2 text-right font-medium text-[rgb(var(--color-text-500))]">{t('deferredRevenue.table.closing', { defaultValue: 'Closing' })}</th>
+          </tr>
+        </thead>
+        <tbody className="divide-y divide-[rgb(var(--color-border-200))]">
+          {section.clients.length === 0 ? (
+            <tr>
+              <td colSpan={13} className="px-4 py-5 text-center text-[rgb(var(--color-text-500))]">
+                {t('deferredRevenue.table.noClients', { defaultValue: 'No clients with prepaid balances this month.' })}
+              </td>
+            </tr>
+          ) : (
+            section.clients.map((client) => {
+              const expanded = expandedClients.has(client.clientId);
+              return (
+                <ClientRow
+                  key={`${client.clientId}-${client.currencyCode}`}
+                  client={client}
+                  currency={currency}
+                  expanded={expanded}
+                  onToggle={() => toggleClient(`${client.clientId}-${client.currencyCode}`)}
+                  formatCurrency={formatCurrency}
+                />
+              );
+            })
+          )}
+          <tr className="bg-[rgb(var(--color-background-100))]">
+            <td className="px-4 py-3 font-semibold text-[rgb(var(--color-text-900))]">
+              {t('deferredRevenue.table.tenantTotal', { defaultValue: 'Tenant total' })}
+            </td>
+            <MovementCells movement={section.totals.credits} currency={currency} showAdjustments formatCurrency={formatCurrency} className="font-medium text-[rgb(var(--color-text-900))]" />
+            <MovementCells movement={section.totals.hours} currency={currency} showAdjustments={false} formatCurrency={formatCurrency} className="font-medium text-[rgb(var(--color-text-900))]" />
+            <td className="px-3 py-3 text-right font-semibold tabular-nums text-[rgb(var(--color-text-900))]">
+              {formatCents(section.totals.total.closing, currency, formatCurrency)}
+            </td>
+          </tr>
+        </tbody>
+      </table>
+    </div>
+  );
+}
+
+function ClientRow({
+  client,
+  currency,
+  expanded,
+  onToggle,
+  formatCurrency,
+}: {
+  client: CurrencySection['clients'][number];
+  currency: string;
+  expanded: boolean;
+  onToggle: () => void;
+  formatCurrency: (value: number, currency: string) => string;
+}) {
+  return (
+    <>
+      <tr className="cursor-pointer hover:bg-[rgb(var(--color-background-50))]" onClick={onToggle}>
+        <td className="px-4 py-3">
+          <div className="flex items-center gap-2">
+            {expanded ? (
+              <ChevronDown className="h-4 w-4 shrink-0 text-[rgb(var(--color-text-500))]" />
+            ) : (
+              <ChevronRight className="h-4 w-4 shrink-0 text-[rgb(var(--color-text-500))]" />
+            )}
+            <span className="font-medium text-[rgb(var(--color-text-900))]">{client.clientName}</span>
+          </div>
+        </td>
+        <MovementCells movement={client.credits} currency={currency} showAdjustments formatCurrency={formatCurrency} />
+        <MovementCells movement={client.hours} currency={currency} showAdjustments={false} formatCurrency={formatCurrency} />
+        <td className="whitespace-nowrap px-3 py-2 text-right font-medium tabular-nums text-[rgb(var(--color-text-900))]">
+          {formatCents(client.total.closing, currency, formatCurrency)}
+        </td>
+      </tr>
+      {expanded ? (
+        <tr>
+          <td colSpan={13} className="border-t border-[rgb(var(--color-border-200))] bg-[rgb(var(--color-background-50))] p-0">
+            <div className="divide-y divide-[rgb(var(--color-border-200))]">
+              <CreditDetailList details={client.creditDetails} currency={currency} formatCurrency={formatCurrency} />
+              <BucketDetailList details={client.bucketDetails} currency={currency} formatCurrency={formatCurrency} />
+            </div>
+          </td>
+        </tr>
+      ) : null}
+    </>
+  );
+}
+
+export default function DeferredRevenueReport() {
+  const { t } = useTranslation('msp/reports');
+  const { formatCurrency } = useFormatters();
+  const [month, setMonth] = useState<string>(() => previousMonth(currentMonth()));
+  const [report, setReport] = useState<DeferredRevenueReportPayload | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const [expandedClients, setExpandedClients] = useState<Set<string>>(new Set());
+
+  useEffect(() => {
+    let cancelled = false;
+    setReport(null);
+    setError(null);
+    getDeferredRevenueReport({ month })
+      .then((data) => {
+        if (isReportActionError(data)) {
+          if (!cancelled) setError(getErrorMessage(data));
+          return;
+        }
+        if (!cancelled) setReport(data);
+      })
+      .catch((err) => {
+        console.error('Failed to load deferred revenue report:', err);
+        if (!cancelled) {
+          setError(t('deferredRevenue.errors.load', { defaultValue: 'Failed to load the deferred revenue report.' }));
+        }
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [month, t]);
+
+  const toggleClient = useCallback((key: string) => {
+    setExpandedClients((previous) => {
+      const next = new Set(previous);
+      if (next.has(key)) {
+        next.delete(key);
+      } else {
+        next.add(key);
+      }
+      return next;
+    });
+  }, []);
+
+  const csvRows: ClientCsvRow[] = useMemo(() => {
+    if (!report) return [];
+    return report.sections.flatMap((section) =>
+      section.clients.map((client) => ({
+        clientId: client.clientId,
+        clientName: client.clientName,
+        currencyCode: client.currencyCode,
+        credits: client.credits,
+        hours: client.hours,
+        total: client.total,
+      })),
+    );
+  }, [report]);
+
+  const csvColumns: CsvColumn[] = useMemo(() => {
+    const columns: CsvColumn[] = [
+      { key: 'client', header: t('deferredRevenue.csv.client', { defaultValue: 'Client' }), value: (row) => row.clientName },
+      { key: 'currency', header: t('deferredRevenue.csv.currency', { defaultValue: 'Currency' }), value: (row) => row.currencyCode },
+    ];
+    for (const label of ['credits.opening', 'credits.issued', 'credits.applied', 'credits.expired', 'credits.adjustments', 'credits.closing'] as const) {
+      columns.push({ key: label, header: label, value: (row) => row.credits[label.split('.')[1] as keyof MovementColumns] });
+    }
+    for (const label of ['hours.opening', 'hours.issued', 'hours.applied', 'hours.expired', 'hours.closing'] as const) {
+      columns.push({ key: label, header: label, value: (row) => row.hours[label.split('.')[1] as keyof MovementColumns] });
+    }
+    columns.push({ key: 'total.closing', header: 'total.closing', value: (row) => row.total.closing });
+    return columns;
+  }, [t]);
+
+  const printColumns: PrintableTableColumn<ClientCsvRow>[] = useMemo(() => {
+    const label = (key: string, fallback: string) =>
+      t(`deferredRevenue.table.${key}`, { defaultValue: fallback });
+    const cells = (movement: MovementColumns, showAdjustments: boolean) => {
+      const defs: Array<[string, number]> = [
+        [label('opening', 'Opening'), movement.opening],
+        [label('issued', 'Issued'), movement.issued],
+        [label('applied', 'Applied'), movement.applied],
+        [label('expired', 'Expired'), movement.expired],
+      ];
+      if (showAdjustments) defs.push([label('adjustments', 'Adjustments'), movement.adjustments]);
+      defs.push([label('closing', 'Closing'), movement.closing]);
+      return defs;
+    };
+    const creditCells = cells({} as MovementColumns, true).map(([label]) => label);
+    const hourCells = cells({} as MovementColumns, false).map(([label]) => label);
+    return [
+      { key: 'client', header: label('client', 'Client'), render: (row) => row.clientName },
+      { key: 'currency', header: t('deferredRevenue.csv.currency', { defaultValue: 'Currency' }), render: (row) => row.currencyCode },
+      ...creditCells.map((header, index): PrintableTableColumn<ClientCsvRow> => ({
+        key: `credits.${header}`,
+        header: `Credits ${header}`,
+        render: (row) => {
+          const movement = row.credits;
+          const value = index === 0 ? movement.opening : index === 1 ? movement.issued : index === 2 ? movement.applied : index === 3 ? movement.expired : index === 4 ? movement.adjustments : movement.closing;
+          return formatCents(value, row.currencyCode, formatCurrency);
+        },
+      })),
+      ...hourCells.map((header, index): PrintableTableColumn<ClientCsvRow> => ({
+        key: `hours.${header}`,
+        header: `Hours ${header}`,
+        render: (row) => {
+          const movement = row.hours;
+          const value = index === 0 ? movement.opening : index === 1 ? movement.issued : index === 2 ? movement.applied : index === 3 ? movement.expired : movement.closing;
+          return formatCents(value, row.currencyCode, formatCurrency);
+        },
+      })),
+      { key: 'total', header: label('total', 'Total closing'), render: (row) => formatCents(row.total.closing, row.currencyCode, formatCurrency) },
+    ];
+  }, [formatCurrency, t]);
+
+  const handleCsvDownload = useCallback(() => {
+    const filename = `deferred-revenue-${month}.csv`;
+    downloadCsv(filename, csvColumns.map((column) => column.header), csvRows, csvColumns);
+  }, [csvColumns, csvRows, month]);
+
+  return (
+    <div className="space-y-4">
+      <div className="flex flex-col gap-3 md:flex-row md:items-end md:justify-between">
+        <div>
+          <h2 className="text-lg font-semibold text-[rgb(var(--color-text-900))]">
+            {t('deferredRevenue.title', { defaultValue: 'Deferred revenue / prepaid liability' })}
+          </h2>
+          <p className="mt-1 text-sm text-[rgb(var(--color-text-500))]">
+            {t('deferredRevenue.description', {
+              defaultValue: 'Per-client, per-month rollforward of client credit balances and unburned prepaid bucket hours.',
+            })}
+          </p>
+        </div>
+        <div className="flex flex-wrap items-center gap-2">
+          <input
+            id="deferred-revenue-month"
+            type="month"
+            value={month}
+            onChange={(event) => {
+              if (event.target.value) setMonth(event.target.value);
+            }}
+            className="h-9 rounded-md border border-[rgb(var(--color-border-200))] bg-[rgb(var(--color-card))] px-3 text-sm text-[rgb(var(--color-text-900))]"
+          />
+          <Button id="deferred-revenue-csv" size="sm" variant="outline" onClick={handleCsvDownload} disabled={csvRows.length === 0}>
+            <Download className="mr-2 h-4 w-4" />
+            {t('deferredRevenue.actions.csv', { defaultValue: 'Download CSV' })}
+          </Button>
+          <PrintButton id="deferred-revenue-print" size="sm" variant="outline" />
+        </div>
+      </div>
+
+      {error ? (
+        <p className="text-sm text-[rgb(var(--color-destructive-600))]">{error}</p>
+      ) : !report ? (
+        <div className="space-y-4">
+          <div className="grid gap-3 md:grid-cols-2 xl:grid-cols-4">
+            <Skeleton className="h-28" />
+            <Skeleton className="h-28" />
+            <Skeleton className="h-28" />
+            <Skeleton className="h-28" />
+          </div>
+          <Skeleton className="h-72" />
+        </div>
+      ) : (
+        <>
+          {report.notes.length > 0 ? (
+            <p className="text-xs text-[rgb(var(--color-text-500))]">
+              {report.notes.join(' ')}
+            </p>
+          ) : null}
+          {report.sections.length === 0 ? (
+            <p className="rounded-md border border-[rgb(var(--color-border-200))] px-4 py-6 text-sm text-[rgb(var(--color-text-500))]">
+              {t('deferredRevenue.empty', { defaultValue: 'No prepaid liability for this month.' })}
+            </p>
+          ) : (
+            <>
+              <SummaryCards sections={report.sections} formatCurrency={formatCurrency} />
+              {report.sections.map((section) => (
+                <section key={section.currencyCode} aria-label={`${section.currencyCode} rollforward`}>
+                  <h3 className="mb-2 text-sm font-semibold text-[rgb(var(--color-text-900))]">
+                    {t('deferredRevenue.table.currencyHeading', { defaultValue: 'Currency' })}: {section.currencyCode}
+                  </h3>
+                  <DeferredRevenueTable
+                    section={section}
+                    expandedClients={expandedClients}
+                    toggleClient={toggleClient}
+                    formatCurrency={formatCurrency}
+                  />
+                </section>
+              ))}
+            </>
+          )}
+        </>
+      )}
+
+      <div className="app-print-root app-print-only">
+        <header className="app-print-detail-header">
+          <h1>{t('deferredRevenue.title', { defaultValue: 'Deferred revenue / prepaid liability' })}</h1>
+          <p className="app-print-detail-subtitle">
+            {t('deferredRevenue.printSubtitle', { defaultValue: 'Month {{month}}', month })}
+          </p>
+        </header>
+        {report ? (
+          <>
+            <section className="app-print-table-section" style={{ marginBottom: '10pt' }}>
+              <table className="app-print-table" style={{ tableLayout: 'fixed' }}>
+                <tbody>
+                  <tr>
+                    {report.sections.map((section) => (
+                      <td key={section.currencyCode} style={{ verticalAlign: 'top' }}>
+                        <div style={{ fontSize: '8pt', color: '#555', textTransform: 'uppercase', letterSpacing: '0.04em' }}>
+                          {t('deferredRevenue.summary.totalLiability', { defaultValue: 'Total prepaid liability' })} · {section.currencyCode}
+                        </div>
+                        <div style={{ fontSize: '15pt', fontWeight: 700, marginTop: '2pt' }}>
+                          {formatCents(section.totals.total.closing, section.currencyCode, formatCurrency)}
+                        </div>
+                      </td>
+                    ))}
+                  </tr>
+                </tbody>
+              </table>
+            </section>
+            <PrintableTable
+              title={t('deferredRevenue.printTable', { defaultValue: 'Per-client rollforward' })}
+              subtitle={month}
+              rows={csvRows}
+              columns={printColumns}
+              getRowKey={(row) => `${row.clientId}-${row.currencyCode}`}
+              emptyMessage={t('deferredRevenue.empty', { defaultValue: 'No prepaid liability for this month.' })}
+            />
+          </>
+        ) : null}
+      </div>
+    </div>
+  );
+}

--- a/server/public/locales/de/metadata.json
+++ b/server/public/locales/de/metadata.json
@@ -219,7 +219,10 @@
       "title": "Angebotslayouts"
     },
     "reports": {
-      "title": "Berichte"
+      "title": "Berichte",
+      "deferredRevenue": {
+        "title": "Abgegrenzte Umsatzerlöse"
+      }
     },
     "securitySettings": {
       "title": "Sicherheitseinstellungen"

--- a/server/public/locales/de/msp/reports.json
+++ b/server/public/locales/de/msp/reports.json
@@ -164,6 +164,10 @@
       "inventoryGhostUsage": {
         "title": "Ghost-Verbrauch",
         "description": "Geschlossene Hardware-Tickets ohne erfasste Teile — Kosten, die der Betrieb möglicherweise verschluckt hat."
+      },
+      "deferredRevenue": {
+        "title": "Deferred Revenue",
+        "description": "Prepaid liability across clients: credit balances and unburned bucket hours by month."
       }
     },
     "table": {
@@ -439,6 +443,67 @@
       "totalClients": "Gesamtkunden",
       "activeAssignments": "Aktive Zuordnungen",
       "totalBilled": "Insgesamt abgerechnet"
+    }
+  },
+  "deferredRevenue": {
+    "title": "Deferred revenue / prepaid liability",
+    "description": "Per-client, per-month rollforward of client credit balances and unburned prepaid bucket hours.",
+    "printSubtitle": "Month {{month}}",
+    "printTable": "Per-client rollforward",
+    "empty": "No prepaid liability for this month.",
+    "actions": {
+      "csv": "Download CSV"
+    },
+    "errors": {
+      "load": "Failed to load the deferred revenue report."
+    },
+    "summary": {
+      "totalLiability": "Total prepaid liability",
+      "credits": "Credits",
+      "hours": "Prepaid hours",
+      "delta": "Change vs prior month"
+    },
+    "table": {
+      "client": "Client",
+      "credits": "Credits",
+      "hours": "Prepaid hours",
+      "total": "Total closing",
+      "opening": "Opening",
+      "issued": "Issued",
+      "applied": "Applied",
+      "expired": "Expired",
+      "adjustments": "Adj.",
+      "closing": "Closing",
+      "currencyHeading": "Currency",
+      "noClients": "No clients with prepaid balances this month.",
+      "tenantTotal": "Tenant total"
+    },
+    "detail": {
+      "credits": "Credit balances",
+      "noCredits": "No credit entries.",
+      "date": "Issued",
+      "description": "Description",
+      "remaining": "Remaining",
+      "expires": "Expires",
+      "qbo": "QBO",
+      "reachable": "Synced",
+      "notReachable": "Not in QBO",
+      "notReachableTitle": "Prepayment / project-deposit credits never export to QuickBooks — Alga is the system of record.",
+      "buckets": "Prepaid bucket hours",
+      "noBuckets": "No prepaid bucket periods.",
+      "line": "Line",
+      "period": "Period",
+      "included": "Included",
+      "used": "Used",
+      "value": "Value",
+      "feeSource": "Fee",
+      "rollover": "rollover",
+      "notBilled": "Not yet billed",
+      "billed": "Billed"
+    },
+    "csv": {
+      "client": "Client",
+      "currency": "Currency"
     }
   }
 }

--- a/server/public/locales/de/msp/reports.json
+++ b/server/public/locales/de/msp/reports.json
@@ -166,8 +166,8 @@
         "description": "Geschlossene Hardware-Tickets ohne erfasste Teile — Kosten, die der Betrieb möglicherweise verschluckt hat."
       },
       "deferredRevenue": {
-        "title": "Deferred Revenue",
-        "description": "Prepaid liability across clients: credit balances and unburned bucket hours by month."
+        "title": "Abgegrenzte Umsatzerlöse",
+        "description": "Vorausbezahlte Verbindlichkeiten über alle Kunden: Gutschriftensalden und ungenutzte Stunden aus Stundenkontingenten nach Monat."
       }
     },
     "table": {
@@ -446,64 +446,64 @@
     }
   },
   "deferredRevenue": {
-    "title": "Deferred revenue / prepaid liability",
-    "description": "Per-client, per-month rollforward of client credit balances and unburned prepaid bucket hours.",
-    "printSubtitle": "Month {{month}}",
-    "printTable": "Per-client rollforward",
-    "empty": "No prepaid liability for this month.",
+    "title": "Abgegrenzte Umsatzerlöse / vorausbezahlte Verbindlichkeiten",
+    "description": "Fortschreibung der Gutschriftensalden von Kunden und ungenutzter vorausbezahlter Stunden aus Stundenkontingenten – pro Kunde und Monat.",
+    "printSubtitle": "Monat {{month}}",
+    "printTable": "Fortschreibung pro Kunde",
+    "empty": "Keine vorausbezahlten Verbindlichkeiten für diesen Monat.",
     "actions": {
-      "csv": "Download CSV"
+      "csv": "CSV herunterladen"
     },
     "errors": {
-      "load": "Failed to load the deferred revenue report."
+      "load": "Der Bericht zu abgegrenzten Umsatzerlösen konnte nicht geladen werden."
     },
     "summary": {
-      "totalLiability": "Total prepaid liability",
-      "credits": "Credits",
-      "hours": "Prepaid hours",
-      "delta": "Change vs prior month"
+      "totalLiability": "Vorausbezahlte Verbindlichkeiten gesamt",
+      "credits": "Gutschriften",
+      "hours": "Vorausbezahlte Stunden",
+      "delta": "Veränderung zum Vormonat"
     },
     "table": {
-      "client": "Client",
-      "credits": "Credits",
-      "hours": "Prepaid hours",
-      "total": "Total closing",
-      "opening": "Opening",
-      "issued": "Issued",
-      "applied": "Applied",
-      "expired": "Expired",
-      "adjustments": "Adj.",
-      "closing": "Closing",
-      "currencyHeading": "Currency",
-      "noClients": "No clients with prepaid balances this month.",
-      "tenantTotal": "Tenant total"
+      "client": "Kunde",
+      "credits": "Gutschriften",
+      "hours": "Vorausbezahlte Stunden",
+      "total": "Endbestand gesamt",
+      "opening": "Anfangsbestand",
+      "issued": "Ausgestellt",
+      "applied": "Verrechnet",
+      "expired": "Verfallen",
+      "adjustments": "Anp.",
+      "closing": "Endbestand",
+      "currencyHeading": "Währung",
+      "noClients": "Keine Kunden mit vorausbezahlten Salden in diesem Monat.",
+      "tenantTotal": "Mandantensumme"
     },
     "detail": {
-      "credits": "Credit balances",
-      "noCredits": "No credit entries.",
-      "date": "Issued",
-      "description": "Description",
-      "remaining": "Remaining",
-      "expires": "Expires",
+      "credits": "Gutschriftensalden",
+      "noCredits": "Keine Gutschrifteneinträge.",
+      "date": "Ausgestellt",
+      "description": "Beschreibung",
+      "remaining": "Verbleibend",
+      "expires": "Läuft ab",
       "qbo": "QBO",
-      "reachable": "Synced",
-      "notReachable": "Not in QBO",
-      "notReachableTitle": "Prepayment / project-deposit credits never export to QuickBooks — Alga is the system of record.",
-      "buckets": "Prepaid bucket hours",
-      "noBuckets": "No prepaid bucket periods.",
-      "line": "Line",
-      "period": "Period",
-      "included": "Included",
-      "used": "Used",
-      "value": "Value",
-      "feeSource": "Fee",
-      "rollover": "rollover",
-      "notBilled": "Not yet billed",
-      "billed": "Billed"
+      "reachable": "Synchronisiert",
+      "notReachable": "Nicht in QBO",
+      "notReachableTitle": "Gutschriften aus Vorauszahlungen / Projektanzahlungen werden nie nach QuickBooks exportiert – Alga ist das führende System.",
+      "buckets": "Vorausbezahlte Stunden aus Stundenkontingenten",
+      "noBuckets": "Keine vorausbezahlten Stundenkontingent-Zeiträume.",
+      "line": "Position",
+      "period": "Zeitraum",
+      "included": "Enthalten",
+      "used": "Verwendet",
+      "value": "Wert",
+      "feeSource": "Gebühr",
+      "rollover": "Übertrag",
+      "notBilled": "Noch nicht abgerechnet",
+      "billed": "Abgerechnet"
     },
     "csv": {
-      "client": "Client",
-      "currency": "Currency"
+      "client": "Kunde",
+      "currency": "Währung"
     }
   }
 }

--- a/server/public/locales/en/metadata.json
+++ b/server/public/locales/en/metadata.json
@@ -418,7 +418,10 @@
       "title": "Quote Layouts"
     },
     "reports": {
-      "title": "Reports"
+      "title": "Reports",
+      "deferredRevenue": {
+        "title": "Deferred Revenue"
+      }
     },
     "schedule": {
       "title": "Schedule"

--- a/server/public/locales/en/msp/reports.json
+++ b/server/public/locales/en/msp/reports.json
@@ -153,6 +153,10 @@
         "title": "Contract Reports",
         "description": "Contract revenue, renewals, bucket utilization, and profitability."
       },
+      "deferredRevenue": {
+        "title": "Deferred Revenue",
+        "description": "Prepaid liability across clients: credit balances and unburned bucket hours by month."
+      },
       "inventoryMargin": {
         "title": "Margin Report",
         "description": "Per-product revenue, cost of goods sold, and margin from fulfilled sales orders."
@@ -439,6 +443,67 @@
       "totalClients": "Total Clients",
       "activeAssignments": "Active Assignments",
       "totalBilled": "Total Billed"
+    }
+  },
+  "deferredRevenue": {
+    "title": "Deferred revenue / prepaid liability",
+    "description": "Per-client, per-month rollforward of client credit balances and unburned prepaid bucket hours.",
+    "printSubtitle": "Month {{month}}",
+    "printTable": "Per-client rollforward",
+    "empty": "No prepaid liability for this month.",
+    "actions": {
+      "csv": "Download CSV"
+    },
+    "errors": {
+      "load": "Failed to load the deferred revenue report."
+    },
+    "summary": {
+      "totalLiability": "Total prepaid liability",
+      "credits": "Credits",
+      "hours": "Prepaid hours",
+      "delta": "Change vs prior month"
+    },
+    "table": {
+      "client": "Client",
+      "credits": "Credits",
+      "hours": "Prepaid hours",
+      "total": "Total closing",
+      "opening": "Opening",
+      "issued": "Issued",
+      "applied": "Applied",
+      "expired": "Expired",
+      "adjustments": "Adj.",
+      "closing": "Closing",
+      "currencyHeading": "Currency",
+      "noClients": "No clients with prepaid balances this month.",
+      "tenantTotal": "Tenant total"
+    },
+    "detail": {
+      "credits": "Credit balances",
+      "noCredits": "No credit entries.",
+      "date": "Issued",
+      "description": "Description",
+      "remaining": "Remaining",
+      "expires": "Expires",
+      "qbo": "QBO",
+      "reachable": "Synced",
+      "notReachable": "Not in QBO",
+      "notReachableTitle": "Prepayment / project-deposit credits never export to QuickBooks — Alga is the system of record.",
+      "buckets": "Prepaid bucket hours",
+      "noBuckets": "No prepaid bucket periods.",
+      "line": "Line",
+      "period": "Period",
+      "included": "Included",
+      "used": "Used",
+      "value": "Value",
+      "feeSource": "Fee",
+      "rollover": "rollover",
+      "notBilled": "Not yet billed",
+      "billed": "Billed"
+    },
+    "csv": {
+      "client": "Client",
+      "currency": "Currency"
     }
   }
 }

--- a/server/public/locales/es/metadata.json
+++ b/server/public/locales/es/metadata.json
@@ -216,7 +216,10 @@
       "title": "Diseños de cotización"
     },
     "reports": {
-      "title": "Informes"
+      "title": "Informes",
+      "deferredRevenue": {
+        "title": "Ingresos diferidos"
+      }
     },
     "search": {
       "title": "Buscar"

--- a/server/public/locales/es/msp/reports.json
+++ b/server/public/locales/es/msp/reports.json
@@ -166,8 +166,8 @@
         "description": "Tickets de hardware cerrados sin piezas registradas — costos que el taller pudo haber absorbido."
       },
       "deferredRevenue": {
-        "title": "Deferred Revenue",
-        "description": "Prepaid liability across clients: credit balances and unburned bucket hours by month."
+        "title": "Ingresos diferidos",
+        "description": "Pasivo prepagado entre clientes: saldos de crédito y horas de bolsa no consumidas por mes."
       }
     },
     "table": {
@@ -446,64 +446,64 @@
     }
   },
   "deferredRevenue": {
-    "title": "Deferred revenue / prepaid liability",
-    "description": "Per-client, per-month rollforward of client credit balances and unburned prepaid bucket hours.",
-    "printSubtitle": "Month {{month}}",
-    "printTable": "Per-client rollforward",
-    "empty": "No prepaid liability for this month.",
+    "title": "Ingresos diferidos / pasivo prepagado",
+    "description": "Evolución por cliente y por mes de los saldos de crédito de los clientes y de las horas de bolsa prepagadas no consumidas.",
+    "printSubtitle": "Mes {{month}}",
+    "printTable": "Evolución por cliente",
+    "empty": "No hay pasivo prepagado para este mes.",
     "actions": {
-      "csv": "Download CSV"
+      "csv": "Descargar CSV"
     },
     "errors": {
-      "load": "Failed to load the deferred revenue report."
+      "load": "No se pudo cargar el informe de ingresos diferidos."
     },
     "summary": {
-      "totalLiability": "Total prepaid liability",
-      "credits": "Credits",
-      "hours": "Prepaid hours",
-      "delta": "Change vs prior month"
+      "totalLiability": "Pasivo prepagado total",
+      "credits": "Créditos",
+      "hours": "Horas prepagadas",
+      "delta": "Cambio respecto al mes anterior"
     },
     "table": {
-      "client": "Client",
-      "credits": "Credits",
-      "hours": "Prepaid hours",
-      "total": "Total closing",
-      "opening": "Opening",
-      "issued": "Issued",
-      "applied": "Applied",
-      "expired": "Expired",
-      "adjustments": "Adj.",
-      "closing": "Closing",
-      "currencyHeading": "Currency",
-      "noClients": "No clients with prepaid balances this month.",
-      "tenantTotal": "Tenant total"
+      "client": "Cliente",
+      "credits": "Créditos",
+      "hours": "Horas prepagadas",
+      "total": "Cierre total",
+      "opening": "Apertura",
+      "issued": "Emitidos",
+      "applied": "Aplicados",
+      "expired": "Vencidos",
+      "adjustments": "Ajust.",
+      "closing": "Cierre",
+      "currencyHeading": "Moneda",
+      "noClients": "No hay clientes con saldos prepagados este mes.",
+      "tenantTotal": "Total del tenant"
     },
     "detail": {
-      "credits": "Credit balances",
-      "noCredits": "No credit entries.",
-      "date": "Issued",
-      "description": "Description",
-      "remaining": "Remaining",
-      "expires": "Expires",
+      "credits": "Saldos de crédito",
+      "noCredits": "No hay entradas de crédito.",
+      "date": "Emitido",
+      "description": "Descripción",
+      "remaining": "Restante",
+      "expires": "Vence",
       "qbo": "QBO",
-      "reachable": "Synced",
-      "notReachable": "Not in QBO",
-      "notReachableTitle": "Prepayment / project-deposit credits never export to QuickBooks — Alga is the system of record.",
-      "buckets": "Prepaid bucket hours",
-      "noBuckets": "No prepaid bucket periods.",
-      "line": "Line",
-      "period": "Period",
-      "included": "Included",
-      "used": "Used",
-      "value": "Value",
-      "feeSource": "Fee",
-      "rollover": "rollover",
-      "notBilled": "Not yet billed",
-      "billed": "Billed"
+      "reachable": "Sincronizado",
+      "notReachable": "No está en QBO",
+      "notReachableTitle": "Los créditos de prepago / depósito de proyecto nunca se exportan a QuickBooks; Alga es el sistema de registro.",
+      "buckets": "Horas de bolsa prepagadas",
+      "noBuckets": "No hay períodos de bolsa prepagada.",
+      "line": "Línea",
+      "period": "Período",
+      "included": "Incluidas",
+      "used": "Usadas",
+      "value": "Valor",
+      "feeSource": "Tarifa",
+      "rollover": "traspaso",
+      "notBilled": "Aún sin facturar",
+      "billed": "Facturado"
     },
     "csv": {
-      "client": "Client",
-      "currency": "Currency"
+      "client": "Cliente",
+      "currency": "Moneda"
     }
   }
 }

--- a/server/public/locales/es/msp/reports.json
+++ b/server/public/locales/es/msp/reports.json
@@ -164,6 +164,10 @@
       "inventoryGhostUsage": {
         "title": "Uso fantasma",
         "description": "Tickets de hardware cerrados sin piezas registradas — costos que el taller pudo haber absorbido."
+      },
+      "deferredRevenue": {
+        "title": "Deferred Revenue",
+        "description": "Prepaid liability across clients: credit balances and unburned bucket hours by month."
       }
     },
     "table": {
@@ -439,6 +443,67 @@
       "totalClients": "Clientes totales",
       "activeAssignments": "Asignaciones activas",
       "totalBilled": "Total facturado"
+    }
+  },
+  "deferredRevenue": {
+    "title": "Deferred revenue / prepaid liability",
+    "description": "Per-client, per-month rollforward of client credit balances and unburned prepaid bucket hours.",
+    "printSubtitle": "Month {{month}}",
+    "printTable": "Per-client rollforward",
+    "empty": "No prepaid liability for this month.",
+    "actions": {
+      "csv": "Download CSV"
+    },
+    "errors": {
+      "load": "Failed to load the deferred revenue report."
+    },
+    "summary": {
+      "totalLiability": "Total prepaid liability",
+      "credits": "Credits",
+      "hours": "Prepaid hours",
+      "delta": "Change vs prior month"
+    },
+    "table": {
+      "client": "Client",
+      "credits": "Credits",
+      "hours": "Prepaid hours",
+      "total": "Total closing",
+      "opening": "Opening",
+      "issued": "Issued",
+      "applied": "Applied",
+      "expired": "Expired",
+      "adjustments": "Adj.",
+      "closing": "Closing",
+      "currencyHeading": "Currency",
+      "noClients": "No clients with prepaid balances this month.",
+      "tenantTotal": "Tenant total"
+    },
+    "detail": {
+      "credits": "Credit balances",
+      "noCredits": "No credit entries.",
+      "date": "Issued",
+      "description": "Description",
+      "remaining": "Remaining",
+      "expires": "Expires",
+      "qbo": "QBO",
+      "reachable": "Synced",
+      "notReachable": "Not in QBO",
+      "notReachableTitle": "Prepayment / project-deposit credits never export to QuickBooks — Alga is the system of record.",
+      "buckets": "Prepaid bucket hours",
+      "noBuckets": "No prepaid bucket periods.",
+      "line": "Line",
+      "period": "Period",
+      "included": "Included",
+      "used": "Used",
+      "value": "Value",
+      "feeSource": "Fee",
+      "rollover": "rollover",
+      "notBilled": "Not yet billed",
+      "billed": "Billed"
+    },
+    "csv": {
+      "client": "Client",
+      "currency": "Currency"
     }
   }
 }

--- a/server/public/locales/fr/metadata.json
+++ b/server/public/locales/fr/metadata.json
@@ -194,7 +194,10 @@
       "title": "Mises en page des devis"
     },
     "reports": {
-      "title": "Rapports"
+      "title": "Rapports",
+      "deferredRevenue": {
+        "title": "Produits différés"
+      }
     },
     "securitySettings": {
       "title": "Paramètres de sécurité"

--- a/server/public/locales/fr/msp/reports.json
+++ b/server/public/locales/fr/msp/reports.json
@@ -164,6 +164,10 @@
       "inventoryGhostUsage": {
         "title": "Usage fantôme",
         "description": "Tickets matériel fermés sans pièces enregistrées — des coûts que l'atelier a peut-être absorbés."
+      },
+      "deferredRevenue": {
+        "title": "Deferred Revenue",
+        "description": "Prepaid liability across clients: credit balances and unburned bucket hours by month."
       }
     },
     "table": {
@@ -439,6 +443,67 @@
       "totalClients": "Clients totaux",
       "activeAssignments": "Affectations actives",
       "totalBilled": "Total facturé"
+    }
+  },
+  "deferredRevenue": {
+    "title": "Deferred revenue / prepaid liability",
+    "description": "Per-client, per-month rollforward of client credit balances and unburned prepaid bucket hours.",
+    "printSubtitle": "Month {{month}}",
+    "printTable": "Per-client rollforward",
+    "empty": "No prepaid liability for this month.",
+    "actions": {
+      "csv": "Download CSV"
+    },
+    "errors": {
+      "load": "Failed to load the deferred revenue report."
+    },
+    "summary": {
+      "totalLiability": "Total prepaid liability",
+      "credits": "Credits",
+      "hours": "Prepaid hours",
+      "delta": "Change vs prior month"
+    },
+    "table": {
+      "client": "Client",
+      "credits": "Credits",
+      "hours": "Prepaid hours",
+      "total": "Total closing",
+      "opening": "Opening",
+      "issued": "Issued",
+      "applied": "Applied",
+      "expired": "Expired",
+      "adjustments": "Adj.",
+      "closing": "Closing",
+      "currencyHeading": "Currency",
+      "noClients": "No clients with prepaid balances this month.",
+      "tenantTotal": "Tenant total"
+    },
+    "detail": {
+      "credits": "Credit balances",
+      "noCredits": "No credit entries.",
+      "date": "Issued",
+      "description": "Description",
+      "remaining": "Remaining",
+      "expires": "Expires",
+      "qbo": "QBO",
+      "reachable": "Synced",
+      "notReachable": "Not in QBO",
+      "notReachableTitle": "Prepayment / project-deposit credits never export to QuickBooks — Alga is the system of record.",
+      "buckets": "Prepaid bucket hours",
+      "noBuckets": "No prepaid bucket periods.",
+      "line": "Line",
+      "period": "Period",
+      "included": "Included",
+      "used": "Used",
+      "value": "Value",
+      "feeSource": "Fee",
+      "rollover": "rollover",
+      "notBilled": "Not yet billed",
+      "billed": "Billed"
+    },
+    "csv": {
+      "client": "Client",
+      "currency": "Currency"
     }
   }
 }

--- a/server/public/locales/fr/msp/reports.json
+++ b/server/public/locales/fr/msp/reports.json
@@ -166,8 +166,8 @@
         "description": "Tickets matériel fermés sans pièces enregistrées — des coûts que l'atelier a peut-être absorbés."
       },
       "deferredRevenue": {
-        "title": "Deferred Revenue",
-        "description": "Prepaid liability across clients: credit balances and unburned bucket hours by month."
+        "title": "Produits différés",
+        "description": "Passif prépayé par client : soldes de crédits et heures de forfait d’heures non consommées par mois."
       }
     },
     "table": {
@@ -446,64 +446,64 @@
     }
   },
   "deferredRevenue": {
-    "title": "Deferred revenue / prepaid liability",
-    "description": "Per-client, per-month rollforward of client credit balances and unburned prepaid bucket hours.",
-    "printSubtitle": "Month {{month}}",
-    "printTable": "Per-client rollforward",
-    "empty": "No prepaid liability for this month.",
+    "title": "Produits différés / passif prépayé",
+    "description": "Report par client et par mois des soldes de crédits clients et des heures de forfait d’heures prépayées non consommées.",
+    "printSubtitle": "Mois {{month}}",
+    "printTable": "Report par client",
+    "empty": "Aucun passif prépayé pour ce mois.",
     "actions": {
-      "csv": "Download CSV"
+      "csv": "Télécharger le CSV"
     },
     "errors": {
-      "load": "Failed to load the deferred revenue report."
+      "load": "Échec du chargement du rapport des produits différés."
     },
     "summary": {
-      "totalLiability": "Total prepaid liability",
-      "credits": "Credits",
-      "hours": "Prepaid hours",
-      "delta": "Change vs prior month"
+      "totalLiability": "Passif prépayé total",
+      "credits": "Crédits",
+      "hours": "Heures prépayées",
+      "delta": "Variation par rapport au mois précédent"
     },
     "table": {
       "client": "Client",
-      "credits": "Credits",
-      "hours": "Prepaid hours",
-      "total": "Total closing",
-      "opening": "Opening",
-      "issued": "Issued",
-      "applied": "Applied",
-      "expired": "Expired",
-      "adjustments": "Adj.",
-      "closing": "Closing",
-      "currencyHeading": "Currency",
-      "noClients": "No clients with prepaid balances this month.",
-      "tenantTotal": "Tenant total"
+      "credits": "Crédits",
+      "hours": "Heures prépayées",
+      "total": "Solde de clôture total",
+      "opening": "Ouverture",
+      "issued": "Émis",
+      "applied": "Appliqués",
+      "expired": "Expirés",
+      "adjustments": "Ajust.",
+      "closing": "Clôture",
+      "currencyHeading": "Devise",
+      "noClients": "Aucun client avec des soldes prépayés ce mois-ci.",
+      "tenantTotal": "Total du locataire"
     },
     "detail": {
-      "credits": "Credit balances",
-      "noCredits": "No credit entries.",
-      "date": "Issued",
+      "credits": "Soldes de crédits",
+      "noCredits": "Aucune entrée de crédit.",
+      "date": "Émis",
       "description": "Description",
-      "remaining": "Remaining",
-      "expires": "Expires",
+      "remaining": "Restant",
+      "expires": "Expire",
       "qbo": "QBO",
-      "reachable": "Synced",
-      "notReachable": "Not in QBO",
-      "notReachableTitle": "Prepayment / project-deposit credits never export to QuickBooks — Alga is the system of record.",
-      "buckets": "Prepaid bucket hours",
-      "noBuckets": "No prepaid bucket periods.",
-      "line": "Line",
-      "period": "Period",
-      "included": "Included",
-      "used": "Used",
-      "value": "Value",
-      "feeSource": "Fee",
-      "rollover": "rollover",
-      "notBilled": "Not yet billed",
-      "billed": "Billed"
+      "reachable": "Synchronisé",
+      "notReachable": "Absent de QBO",
+      "notReachableTitle": "Les crédits de prépaiement / d’acompte de projet ne sont jamais exportés vers QuickBooks — Alga fait foi.",
+      "buckets": "Heures de forfait d’heures prépayées",
+      "noBuckets": "Aucune période de forfait d’heures prépayée.",
+      "line": "Ligne",
+      "period": "Période",
+      "included": "Incluses",
+      "used": "Utilisées",
+      "value": "Valeur",
+      "feeSource": "Frais",
+      "rollover": "report",
+      "notBilled": "Pas encore facturé",
+      "billed": "Facturé"
     },
     "csv": {
       "client": "Client",
-      "currency": "Currency"
+      "currency": "Devise"
     }
   }
 }

--- a/server/public/locales/it/metadata.json
+++ b/server/public/locales/it/metadata.json
@@ -419,7 +419,10 @@
       "title": "Layout dei preventivi"
     },
     "reports": {
-      "title": "Report"
+      "title": "Report",
+      "deferredRevenue": {
+        "title": "Ricavi differiti"
+      }
     },
     "schedule": {
       "title": "Pianificazione"

--- a/server/public/locales/it/msp/reports.json
+++ b/server/public/locales/it/msp/reports.json
@@ -164,6 +164,10 @@
       "inventoryGhostUsage": {
         "title": "Utilizzo fantasma",
         "description": "Ticket hardware chiusi senza parti registrate — costi che l'officina potrebbe aver assorbito."
+      },
+      "deferredRevenue": {
+        "title": "Deferred Revenue",
+        "description": "Prepaid liability across clients: credit balances and unburned bucket hours by month."
       }
     },
     "table": {
@@ -439,6 +443,67 @@
       "totalClients": "Clienti totali",
       "activeAssignments": "Assegnazioni attive",
       "totalBilled": "Totale fatturato"
+    }
+  },
+  "deferredRevenue": {
+    "title": "Deferred revenue / prepaid liability",
+    "description": "Per-client, per-month rollforward of client credit balances and unburned prepaid bucket hours.",
+    "printSubtitle": "Month {{month}}",
+    "printTable": "Per-client rollforward",
+    "empty": "No prepaid liability for this month.",
+    "actions": {
+      "csv": "Download CSV"
+    },
+    "errors": {
+      "load": "Failed to load the deferred revenue report."
+    },
+    "summary": {
+      "totalLiability": "Total prepaid liability",
+      "credits": "Credits",
+      "hours": "Prepaid hours",
+      "delta": "Change vs prior month"
+    },
+    "table": {
+      "client": "Client",
+      "credits": "Credits",
+      "hours": "Prepaid hours",
+      "total": "Total closing",
+      "opening": "Opening",
+      "issued": "Issued",
+      "applied": "Applied",
+      "expired": "Expired",
+      "adjustments": "Adj.",
+      "closing": "Closing",
+      "currencyHeading": "Currency",
+      "noClients": "No clients with prepaid balances this month.",
+      "tenantTotal": "Tenant total"
+    },
+    "detail": {
+      "credits": "Credit balances",
+      "noCredits": "No credit entries.",
+      "date": "Issued",
+      "description": "Description",
+      "remaining": "Remaining",
+      "expires": "Expires",
+      "qbo": "QBO",
+      "reachable": "Synced",
+      "notReachable": "Not in QBO",
+      "notReachableTitle": "Prepayment / project-deposit credits never export to QuickBooks — Alga is the system of record.",
+      "buckets": "Prepaid bucket hours",
+      "noBuckets": "No prepaid bucket periods.",
+      "line": "Line",
+      "period": "Period",
+      "included": "Included",
+      "used": "Used",
+      "value": "Value",
+      "feeSource": "Fee",
+      "rollover": "rollover",
+      "notBilled": "Not yet billed",
+      "billed": "Billed"
+    },
+    "csv": {
+      "client": "Client",
+      "currency": "Currency"
     }
   }
 }

--- a/server/public/locales/it/msp/reports.json
+++ b/server/public/locales/it/msp/reports.json
@@ -166,8 +166,8 @@
         "description": "Ticket hardware chiusi senza parti registrate — costi che l'officina potrebbe aver assorbito."
       },
       "deferredRevenue": {
-        "title": "Deferred Revenue",
-        "description": "Prepaid liability across clients: credit balances and unburned bucket hours by month."
+        "title": "Ricavi differiti",
+        "description": "Passività anticipata tra i clienti: saldi dei crediti e ore di pacchetto ore non consumate per mese."
       }
     },
     "table": {
@@ -446,64 +446,64 @@
     }
   },
   "deferredRevenue": {
-    "title": "Deferred revenue / prepaid liability",
-    "description": "Per-client, per-month rollforward of client credit balances and unburned prepaid bucket hours.",
-    "printSubtitle": "Month {{month}}",
-    "printTable": "Per-client rollforward",
-    "empty": "No prepaid liability for this month.",
+    "title": "Ricavi differiti / passività anticipata",
+    "description": "Riepilogo per cliente e per mese dei saldi dei crediti del cliente e delle ore di pacchetto ore anticipate non consumate.",
+    "printSubtitle": "Mese {{month}}",
+    "printTable": "Riepilogo per cliente",
+    "empty": "Nessuna passività anticipata per questo mese.",
     "actions": {
-      "csv": "Download CSV"
+      "csv": "Scarica CSV"
     },
     "errors": {
-      "load": "Failed to load the deferred revenue report."
+      "load": "Impossibile caricare il report dei ricavi differiti."
     },
     "summary": {
-      "totalLiability": "Total prepaid liability",
-      "credits": "Credits",
-      "hours": "Prepaid hours",
-      "delta": "Change vs prior month"
+      "totalLiability": "Passività anticipata totale",
+      "credits": "Crediti",
+      "hours": "Ore anticipate",
+      "delta": "Variazione rispetto al mese precedente"
     },
     "table": {
-      "client": "Client",
-      "credits": "Credits",
-      "hours": "Prepaid hours",
-      "total": "Total closing",
-      "opening": "Opening",
-      "issued": "Issued",
-      "applied": "Applied",
-      "expired": "Expired",
-      "adjustments": "Adj.",
-      "closing": "Closing",
-      "currencyHeading": "Currency",
-      "noClients": "No clients with prepaid balances this month.",
-      "tenantTotal": "Tenant total"
+      "client": "Cliente",
+      "credits": "Crediti",
+      "hours": "Ore anticipate",
+      "total": "Saldo finale totale",
+      "opening": "Apertura",
+      "issued": "Emessi",
+      "applied": "Applicati",
+      "expired": "Scaduti",
+      "adjustments": "Rett.",
+      "closing": "Chiusura",
+      "currencyHeading": "Valuta",
+      "noClients": "Nessun cliente con saldi anticipati questo mese.",
+      "tenantTotal": "Totale tenant"
     },
     "detail": {
-      "credits": "Credit balances",
-      "noCredits": "No credit entries.",
-      "date": "Issued",
-      "description": "Description",
-      "remaining": "Remaining",
-      "expires": "Expires",
+      "credits": "Saldi dei crediti",
+      "noCredits": "Nessuna voce di credito.",
+      "date": "Emesso",
+      "description": "Descrizione",
+      "remaining": "Residuo",
+      "expires": "Scade",
       "qbo": "QBO",
-      "reachable": "Synced",
-      "notReachable": "Not in QBO",
-      "notReachableTitle": "Prepayment / project-deposit credits never export to QuickBooks — Alga is the system of record.",
-      "buckets": "Prepaid bucket hours",
-      "noBuckets": "No prepaid bucket periods.",
-      "line": "Line",
-      "period": "Period",
-      "included": "Included",
-      "used": "Used",
-      "value": "Value",
-      "feeSource": "Fee",
-      "rollover": "rollover",
-      "notBilled": "Not yet billed",
-      "billed": "Billed"
+      "reachable": "Sincronizzato",
+      "notReachable": "Non in QBO",
+      "notReachableTitle": "I crediti di pagamento anticipato / deposito di progetto non vengono mai esportati in QuickBooks — Alga è il sistema di riferimento.",
+      "buckets": "Ore di pacchetto ore anticipate",
+      "noBuckets": "Nessun periodo di pacchetto ore anticipato.",
+      "line": "Riga",
+      "period": "Periodo",
+      "included": "Incluse",
+      "used": "Utilizzate",
+      "value": "Valore",
+      "feeSource": "Tariffa",
+      "rollover": "riporto",
+      "notBilled": "Non ancora fatturato",
+      "billed": "Fatturato"
     },
     "csv": {
-      "client": "Client",
-      "currency": "Currency"
+      "client": "Cliente",
+      "currency": "Valuta"
     }
   }
 }

--- a/server/public/locales/nl/metadata.json
+++ b/server/public/locales/nl/metadata.json
@@ -209,7 +209,10 @@
       "title": "Goedkeuringen van offertes"
     },
     "reports": {
-      "title": "Rapporten"
+      "title": "Rapporten",
+      "deferredRevenue": {
+        "title": "Uitgestelde omzet"
+      }
     },
     "securitySettings": {
       "title": "Beveiligingsinstellingen"

--- a/server/public/locales/nl/msp/reports.json
+++ b/server/public/locales/nl/msp/reports.json
@@ -166,8 +166,8 @@
         "description": "Gesloten hardware-tickets zonder geregistreerde onderdelen — kosten die de werkplaats mogelijk heeft opgeslokt."
       },
       "deferredRevenue": {
-        "title": "Deferred Revenue",
-        "description": "Prepaid liability across clients: credit balances and unburned bucket hours by month."
+        "title": "Uitgestelde omzet",
+        "description": "Vooruitbetaalde verplichting over klanten: kredietsaldi en niet-verbruikte urenbundeluren per maand."
       }
     },
     "table": {
@@ -446,64 +446,64 @@
     }
   },
   "deferredRevenue": {
-    "title": "Deferred revenue / prepaid liability",
-    "description": "Per-client, per-month rollforward of client credit balances and unburned prepaid bucket hours.",
-    "printSubtitle": "Month {{month}}",
-    "printTable": "Per-client rollforward",
-    "empty": "No prepaid liability for this month.",
+    "title": "Uitgestelde omzet / vooruitbetaalde verplichting",
+    "description": "Rollforward per klant en per maand van kredietsaldi van klanten en niet-verbruikte vooruitbetaalde urenbundeluren.",
+    "printSubtitle": "Maand {{month}}",
+    "printTable": "Rollforward per klant",
+    "empty": "Geen vooruitbetaalde verplichting voor deze maand.",
     "actions": {
-      "csv": "Download CSV"
+      "csv": "CSV downloaden"
     },
     "errors": {
-      "load": "Failed to load the deferred revenue report."
+      "load": "Het rapport uitgestelde omzet kon niet worden geladen."
     },
     "summary": {
-      "totalLiability": "Total prepaid liability",
-      "credits": "Credits",
-      "hours": "Prepaid hours",
-      "delta": "Change vs prior month"
+      "totalLiability": "Totale vooruitbetaalde verplichting",
+      "credits": "Kredieten",
+      "hours": "Vooruitbetaalde uren",
+      "delta": "Wijziging t.o.v. vorige maand"
     },
     "table": {
-      "client": "Client",
-      "credits": "Credits",
-      "hours": "Prepaid hours",
-      "total": "Total closing",
-      "opening": "Opening",
-      "issued": "Issued",
-      "applied": "Applied",
-      "expired": "Expired",
-      "adjustments": "Adj.",
-      "closing": "Closing",
-      "currencyHeading": "Currency",
-      "noClients": "No clients with prepaid balances this month.",
-      "tenantTotal": "Tenant total"
+      "client": "Klant",
+      "credits": "Kredieten",
+      "hours": "Vooruitbetaalde uren",
+      "total": "Totaal eindstand",
+      "opening": "Beginstand",
+      "issued": "Uitgegeven",
+      "applied": "Toegepast",
+      "expired": "Verlopen",
+      "adjustments": "Aanp.",
+      "closing": "Eindstand",
+      "currencyHeading": "Valuta",
+      "noClients": "Geen klanten met vooruitbetaalde saldi deze maand.",
+      "tenantTotal": "Tenanttotaal"
     },
     "detail": {
-      "credits": "Credit balances",
-      "noCredits": "No credit entries.",
-      "date": "Issued",
-      "description": "Description",
-      "remaining": "Remaining",
-      "expires": "Expires",
+      "credits": "Kredietsaldi",
+      "noCredits": "Geen kredietregels.",
+      "date": "Uitgegeven",
+      "description": "Omschrijving",
+      "remaining": "Resterend",
+      "expires": "Verloopt",
       "qbo": "QBO",
-      "reachable": "Synced",
-      "notReachable": "Not in QBO",
-      "notReachableTitle": "Prepayment / project-deposit credits never export to QuickBooks — Alga is the system of record.",
-      "buckets": "Prepaid bucket hours",
-      "noBuckets": "No prepaid bucket periods.",
-      "line": "Line",
-      "period": "Period",
-      "included": "Included",
-      "used": "Used",
-      "value": "Value",
-      "feeSource": "Fee",
-      "rollover": "rollover",
-      "notBilled": "Not yet billed",
-      "billed": "Billed"
+      "reachable": "Gesynchroniseerd",
+      "notReachable": "Niet in QBO",
+      "notReachableTitle": "Kredieten voor vooruitbetalingen of projectaanbetalingen worden nooit naar QuickBooks geëxporteerd — Alga is het bronsysteem.",
+      "buckets": "Vooruitbetaalde urenbundeluren",
+      "noBuckets": "Geen vooruitbetaalde urenbundelperioden.",
+      "line": "Regel",
+      "period": "Periode",
+      "included": "Inbegrepen",
+      "used": "Gebruikt",
+      "value": "Waarde",
+      "feeSource": "Tarief",
+      "rollover": "overdracht",
+      "notBilled": "Nog niet gefactureerd",
+      "billed": "Gefactureerd"
     },
     "csv": {
-      "client": "Client",
-      "currency": "Currency"
+      "client": "Klant",
+      "currency": "Valuta"
     }
   }
 }

--- a/server/public/locales/nl/msp/reports.json
+++ b/server/public/locales/nl/msp/reports.json
@@ -164,6 +164,10 @@
       "inventoryGhostUsage": {
         "title": "Ghost-verbruik",
         "description": "Gesloten hardware-tickets zonder geregistreerde onderdelen — kosten die de werkplaats mogelijk heeft opgeslokt."
+      },
+      "deferredRevenue": {
+        "title": "Deferred Revenue",
+        "description": "Prepaid liability across clients: credit balances and unburned bucket hours by month."
       }
     },
     "table": {
@@ -439,6 +443,67 @@
       "totalClients": "Totale klanten",
       "activeAssignments": "Actieve toewijzingen",
       "totalBilled": "Totaal gefactureerd"
+    }
+  },
+  "deferredRevenue": {
+    "title": "Deferred revenue / prepaid liability",
+    "description": "Per-client, per-month rollforward of client credit balances and unburned prepaid bucket hours.",
+    "printSubtitle": "Month {{month}}",
+    "printTable": "Per-client rollforward",
+    "empty": "No prepaid liability for this month.",
+    "actions": {
+      "csv": "Download CSV"
+    },
+    "errors": {
+      "load": "Failed to load the deferred revenue report."
+    },
+    "summary": {
+      "totalLiability": "Total prepaid liability",
+      "credits": "Credits",
+      "hours": "Prepaid hours",
+      "delta": "Change vs prior month"
+    },
+    "table": {
+      "client": "Client",
+      "credits": "Credits",
+      "hours": "Prepaid hours",
+      "total": "Total closing",
+      "opening": "Opening",
+      "issued": "Issued",
+      "applied": "Applied",
+      "expired": "Expired",
+      "adjustments": "Adj.",
+      "closing": "Closing",
+      "currencyHeading": "Currency",
+      "noClients": "No clients with prepaid balances this month.",
+      "tenantTotal": "Tenant total"
+    },
+    "detail": {
+      "credits": "Credit balances",
+      "noCredits": "No credit entries.",
+      "date": "Issued",
+      "description": "Description",
+      "remaining": "Remaining",
+      "expires": "Expires",
+      "qbo": "QBO",
+      "reachable": "Synced",
+      "notReachable": "Not in QBO",
+      "notReachableTitle": "Prepayment / project-deposit credits never export to QuickBooks — Alga is the system of record.",
+      "buckets": "Prepaid bucket hours",
+      "noBuckets": "No prepaid bucket periods.",
+      "line": "Line",
+      "period": "Period",
+      "included": "Included",
+      "used": "Used",
+      "value": "Value",
+      "feeSource": "Fee",
+      "rollover": "rollover",
+      "notBilled": "Not yet billed",
+      "billed": "Billed"
+    },
+    "csv": {
+      "client": "Client",
+      "currency": "Currency"
     }
   }
 }

--- a/server/public/locales/pl/metadata.json
+++ b/server/public/locales/pl/metadata.json
@@ -222,7 +222,10 @@
       "title": "Akceptacje wycen"
     },
     "reports": {
-      "title": "Raporty"
+      "title": "Raporty",
+      "deferredRevenue": {
+        "title": "Przychód rozliczany w czasie"
+      }
     },
     "securitySettings": {
       "title": "Ustawienia bezpieczeństwa"

--- a/server/public/locales/pl/msp/reports.json
+++ b/server/public/locales/pl/msp/reports.json
@@ -166,8 +166,8 @@
         "description": "Zamknięte zgłoszenia sprzętowe bez zarejestrowanych części — koszty, które warsztat mógł ponieść."
       },
       "deferredRevenue": {
-        "title": "Deferred Revenue",
-        "description": "Prepaid liability across clients: credit balances and unburned bucket hours by month."
+        "title": "Przychód rozliczany w czasie",
+        "description": "Zobowiązania z przedpłat u klientów: salda kredytów i niewykorzystane godziny z pakietów według miesiąca."
       }
     },
     "table": {
@@ -446,64 +446,64 @@
     }
   },
   "deferredRevenue": {
-    "title": "Deferred revenue / prepaid liability",
-    "description": "Per-client, per-month rollforward of client credit balances and unburned prepaid bucket hours.",
-    "printSubtitle": "Month {{month}}",
-    "printTable": "Per-client rollforward",
-    "empty": "No prepaid liability for this month.",
+    "title": "Przychód rozliczany w czasie / zobowiązania z przedpłat",
+    "description": "Zestawienie zmian sald kredytów klientów oraz niewykorzystanych, przedpłaconych godzin z pakietów w podziale na klienta i miesiąc.",
+    "printSubtitle": "Miesiąc {{month}}",
+    "printTable": "Zestawienie zmian według klienta",
+    "empty": "Brak zobowiązań z przedpłat w tym miesiącu.",
     "actions": {
-      "csv": "Download CSV"
+      "csv": "Pobierz CSV"
     },
     "errors": {
-      "load": "Failed to load the deferred revenue report."
+      "load": "Nie udało się załadować raportu przychodów rozliczanych w czasie."
     },
     "summary": {
-      "totalLiability": "Total prepaid liability",
-      "credits": "Credits",
-      "hours": "Prepaid hours",
-      "delta": "Change vs prior month"
+      "totalLiability": "Łączne zobowiązania z przedpłat",
+      "credits": "Kredyty",
+      "hours": "Przedpłacone godziny",
+      "delta": "Zmiana względem poprzedniego miesiąca"
     },
     "table": {
-      "client": "Client",
-      "credits": "Credits",
-      "hours": "Prepaid hours",
-      "total": "Total closing",
-      "opening": "Opening",
-      "issued": "Issued",
-      "applied": "Applied",
-      "expired": "Expired",
-      "adjustments": "Adj.",
-      "closing": "Closing",
-      "currencyHeading": "Currency",
-      "noClients": "No clients with prepaid balances this month.",
-      "tenantTotal": "Tenant total"
+      "client": "Klient",
+      "credits": "Kredyty",
+      "hours": "Przedpłacone godziny",
+      "total": "Saldo końcowe łącznie",
+      "opening": "Saldo początkowe",
+      "issued": "Wystawione",
+      "applied": "Zastosowane",
+      "expired": "Wygasłe",
+      "adjustments": "Kor.",
+      "closing": "Saldo końcowe",
+      "currencyHeading": "Waluta",
+      "noClients": "Brak klientów z saldami przedpłat w tym miesiącu.",
+      "tenantTotal": "Suma dla tenanta"
     },
     "detail": {
-      "credits": "Credit balances",
-      "noCredits": "No credit entries.",
-      "date": "Issued",
-      "description": "Description",
-      "remaining": "Remaining",
-      "expires": "Expires",
+      "credits": "Salda kredytów",
+      "noCredits": "Brak wpisów kredytowych.",
+      "date": "Wystawiono",
+      "description": "Opis",
+      "remaining": "Pozostało",
+      "expires": "Wygasa",
       "qbo": "QBO",
-      "reachable": "Synced",
-      "notReachable": "Not in QBO",
-      "notReachableTitle": "Prepayment / project-deposit credits never export to QuickBooks — Alga is the system of record.",
-      "buckets": "Prepaid bucket hours",
-      "noBuckets": "No prepaid bucket periods.",
-      "line": "Line",
-      "period": "Period",
-      "included": "Included",
-      "used": "Used",
-      "value": "Value",
-      "feeSource": "Fee",
-      "rollover": "rollover",
-      "notBilled": "Not yet billed",
-      "billed": "Billed"
+      "reachable": "Zsynchronizowano",
+      "notReachable": "Brak w QBO",
+      "notReachableTitle": "Kredyty z przedpłat / zaliczek projektowych nigdy nie są eksportowane do QuickBooks — Alga jest systemem źródłowym.",
+      "buckets": "Przedpłacone godziny z pakietu",
+      "noBuckets": "Brak przedpłaconych okresów pakietu.",
+      "line": "Pozycja",
+      "period": "Okres",
+      "included": "Zawarte",
+      "used": "Wykorzystane",
+      "value": "Wartość",
+      "feeSource": "Opłata",
+      "rollover": "przeniesienie",
+      "notBilled": "Jeszcze nie rozliczone",
+      "billed": "Rozliczone"
     },
     "csv": {
-      "client": "Client",
-      "currency": "Currency"
+      "client": "Klient",
+      "currency": "Waluta"
     }
   }
 }

--- a/server/public/locales/pl/msp/reports.json
+++ b/server/public/locales/pl/msp/reports.json
@@ -164,6 +164,10 @@
       "inventoryGhostUsage": {
         "title": "Zużycie widmowe",
         "description": "Zamknięte zgłoszenia sprzętowe bez zarejestrowanych części — koszty, które warsztat mógł ponieść."
+      },
+      "deferredRevenue": {
+        "title": "Deferred Revenue",
+        "description": "Prepaid liability across clients: credit balances and unburned bucket hours by month."
       }
     },
     "table": {
@@ -439,6 +443,67 @@
       "totalClients": "Łączna liczba klientów",
       "activeAssignments": "Aktywne przypisania",
       "totalBilled": "Łącznie rozliczone"
+    }
+  },
+  "deferredRevenue": {
+    "title": "Deferred revenue / prepaid liability",
+    "description": "Per-client, per-month rollforward of client credit balances and unburned prepaid bucket hours.",
+    "printSubtitle": "Month {{month}}",
+    "printTable": "Per-client rollforward",
+    "empty": "No prepaid liability for this month.",
+    "actions": {
+      "csv": "Download CSV"
+    },
+    "errors": {
+      "load": "Failed to load the deferred revenue report."
+    },
+    "summary": {
+      "totalLiability": "Total prepaid liability",
+      "credits": "Credits",
+      "hours": "Prepaid hours",
+      "delta": "Change vs prior month"
+    },
+    "table": {
+      "client": "Client",
+      "credits": "Credits",
+      "hours": "Prepaid hours",
+      "total": "Total closing",
+      "opening": "Opening",
+      "issued": "Issued",
+      "applied": "Applied",
+      "expired": "Expired",
+      "adjustments": "Adj.",
+      "closing": "Closing",
+      "currencyHeading": "Currency",
+      "noClients": "No clients with prepaid balances this month.",
+      "tenantTotal": "Tenant total"
+    },
+    "detail": {
+      "credits": "Credit balances",
+      "noCredits": "No credit entries.",
+      "date": "Issued",
+      "description": "Description",
+      "remaining": "Remaining",
+      "expires": "Expires",
+      "qbo": "QBO",
+      "reachable": "Synced",
+      "notReachable": "Not in QBO",
+      "notReachableTitle": "Prepayment / project-deposit credits never export to QuickBooks — Alga is the system of record.",
+      "buckets": "Prepaid bucket hours",
+      "noBuckets": "No prepaid bucket periods.",
+      "line": "Line",
+      "period": "Period",
+      "included": "Included",
+      "used": "Used",
+      "value": "Value",
+      "feeSource": "Fee",
+      "rollover": "rollover",
+      "notBilled": "Not yet billed",
+      "billed": "Billed"
+    },
+    "csv": {
+      "client": "Client",
+      "currency": "Currency"
     }
   }
 }

--- a/server/public/locales/pt/metadata.json
+++ b/server/public/locales/pt/metadata.json
@@ -228,7 +228,10 @@
       "title": "Layouts de cotação"
     },
     "reports": {
-      "title": "Relatórios"
+      "title": "Relatórios",
+      "deferredRevenue": {
+        "title": "Receita diferida"
+      }
     },
     "schedule": {
       "title": "Agendar"

--- a/server/public/locales/pt/msp/reports.json
+++ b/server/public/locales/pt/msp/reports.json
@@ -164,6 +164,10 @@
       "inventoryGhostUsage": {
         "title": "Uso Fantasma",
         "description": "Chamados de hardware fechados sem peças registradas — custos que a oficina pode ter absorvido."
+      },
+      "deferredRevenue": {
+        "title": "Deferred Revenue",
+        "description": "Prepaid liability across clients: credit balances and unburned bucket hours by month."
       }
     },
     "table": {
@@ -439,6 +443,67 @@
       "totalClients": "Total de clientes",
       "activeAssignments": "Tarefas ativas",
       "totalBilled": "Total faturado"
+    }
+  },
+  "deferredRevenue": {
+    "title": "Deferred revenue / prepaid liability",
+    "description": "Per-client, per-month rollforward of client credit balances and unburned prepaid bucket hours.",
+    "printSubtitle": "Month {{month}}",
+    "printTable": "Per-client rollforward",
+    "empty": "No prepaid liability for this month.",
+    "actions": {
+      "csv": "Download CSV"
+    },
+    "errors": {
+      "load": "Failed to load the deferred revenue report."
+    },
+    "summary": {
+      "totalLiability": "Total prepaid liability",
+      "credits": "Credits",
+      "hours": "Prepaid hours",
+      "delta": "Change vs prior month"
+    },
+    "table": {
+      "client": "Client",
+      "credits": "Credits",
+      "hours": "Prepaid hours",
+      "total": "Total closing",
+      "opening": "Opening",
+      "issued": "Issued",
+      "applied": "Applied",
+      "expired": "Expired",
+      "adjustments": "Adj.",
+      "closing": "Closing",
+      "currencyHeading": "Currency",
+      "noClients": "No clients with prepaid balances this month.",
+      "tenantTotal": "Tenant total"
+    },
+    "detail": {
+      "credits": "Credit balances",
+      "noCredits": "No credit entries.",
+      "date": "Issued",
+      "description": "Description",
+      "remaining": "Remaining",
+      "expires": "Expires",
+      "qbo": "QBO",
+      "reachable": "Synced",
+      "notReachable": "Not in QBO",
+      "notReachableTitle": "Prepayment / project-deposit credits never export to QuickBooks — Alga is the system of record.",
+      "buckets": "Prepaid bucket hours",
+      "noBuckets": "No prepaid bucket periods.",
+      "line": "Line",
+      "period": "Period",
+      "included": "Included",
+      "used": "Used",
+      "value": "Value",
+      "feeSource": "Fee",
+      "rollover": "rollover",
+      "notBilled": "Not yet billed",
+      "billed": "Billed"
+    },
+    "csv": {
+      "client": "Client",
+      "currency": "Currency"
     }
   }
 }

--- a/server/public/locales/pt/msp/reports.json
+++ b/server/public/locales/pt/msp/reports.json
@@ -166,8 +166,8 @@
         "description": "Chamados de hardware fechados sem peças registradas — custos que a oficina pode ter absorvido."
       },
       "deferredRevenue": {
-        "title": "Deferred Revenue",
-        "description": "Prepaid liability across clients: credit balances and unburned bucket hours by month."
+        "title": "Receita diferida",
+        "description": "Passivo pré-pago entre clientes: saldos de crédito e horas não consumidas do banco de horas por mês."
       }
     },
     "table": {
@@ -446,64 +446,64 @@
     }
   },
   "deferredRevenue": {
-    "title": "Deferred revenue / prepaid liability",
-    "description": "Per-client, per-month rollforward of client credit balances and unburned prepaid bucket hours.",
-    "printSubtitle": "Month {{month}}",
-    "printTable": "Per-client rollforward",
-    "empty": "No prepaid liability for this month.",
+    "title": "Receita diferida / passivo pré-pago",
+    "description": "Movimentação mensal por cliente dos saldos de crédito do cliente e das horas pré-pagas não consumidas do banco de horas.",
+    "printSubtitle": "Mês {{month}}",
+    "printTable": "Movimentação por cliente",
+    "empty": "Nenhum passivo pré-pago para este mês.",
     "actions": {
-      "csv": "Download CSV"
+      "csv": "Baixar CSV"
     },
     "errors": {
-      "load": "Failed to load the deferred revenue report."
+      "load": "Falha ao carregar o relatório de receita diferida."
     },
     "summary": {
-      "totalLiability": "Total prepaid liability",
-      "credits": "Credits",
-      "hours": "Prepaid hours",
-      "delta": "Change vs prior month"
+      "totalLiability": "Passivo pré-pago total",
+      "credits": "Créditos",
+      "hours": "Horas pré-pagas",
+      "delta": "Variação vs. mês anterior"
     },
     "table": {
-      "client": "Client",
-      "credits": "Credits",
-      "hours": "Prepaid hours",
-      "total": "Total closing",
-      "opening": "Opening",
-      "issued": "Issued",
-      "applied": "Applied",
-      "expired": "Expired",
-      "adjustments": "Adj.",
-      "closing": "Closing",
-      "currencyHeading": "Currency",
-      "noClients": "No clients with prepaid balances this month.",
-      "tenantTotal": "Tenant total"
+      "client": "Cliente",
+      "credits": "Créditos",
+      "hours": "Horas pré-pagas",
+      "total": "Saldo final total",
+      "opening": "Saldo inicial",
+      "issued": "Emitido",
+      "applied": "Aplicado",
+      "expired": "Expirado",
+      "adjustments": "Ajs.",
+      "closing": "Saldo final",
+      "currencyHeading": "Moeda",
+      "noClients": "Nenhum cliente com saldos pré-pagos neste mês.",
+      "tenantTotal": "Total do locatário"
     },
     "detail": {
-      "credits": "Credit balances",
-      "noCredits": "No credit entries.",
-      "date": "Issued",
-      "description": "Description",
-      "remaining": "Remaining",
-      "expires": "Expires",
+      "credits": "Saldos de crédito",
+      "noCredits": "Nenhum lançamento de crédito.",
+      "date": "Emitido",
+      "description": "Descrição",
+      "remaining": "Restante",
+      "expires": "Expira",
       "qbo": "QBO",
-      "reachable": "Synced",
-      "notReachable": "Not in QBO",
-      "notReachableTitle": "Prepayment / project-deposit credits never export to QuickBooks — Alga is the system of record.",
-      "buckets": "Prepaid bucket hours",
-      "noBuckets": "No prepaid bucket periods.",
-      "line": "Line",
-      "period": "Period",
-      "included": "Included",
-      "used": "Used",
-      "value": "Value",
-      "feeSource": "Fee",
-      "rollover": "rollover",
-      "notBilled": "Not yet billed",
-      "billed": "Billed"
+      "reachable": "Sincronizado",
+      "notReachable": "Não está no QBO",
+      "notReachableTitle": "Créditos de pré-pagamento / depósito de projeto nunca são exportados para o QuickBooks — o Alga é o sistema de registro.",
+      "buckets": "Horas pré-pagas do banco de horas",
+      "noBuckets": "Nenhum período pré-pago do banco de horas.",
+      "line": "Linha",
+      "period": "Período",
+      "included": "Incluído",
+      "used": "Usado",
+      "value": "Valor",
+      "feeSource": "Taxa",
+      "rollover": "acúmulo",
+      "notBilled": "Ainda não faturado",
+      "billed": "Faturado"
     },
     "csv": {
-      "client": "Client",
-      "currency": "Currency"
+      "client": "Cliente",
+      "currency": "Moeda"
     }
   }
 }

--- a/server/public/locales/xx/metadata.json
+++ b/server/public/locales/xx/metadata.json
@@ -418,7 +418,10 @@
       "title": "11111"
     },
     "reports": {
-      "title": "11111"
+      "title": "11111",
+      "deferredRevenue": {
+        "title": "11111"
+      }
     },
     "schedule": {
       "title": "11111"

--- a/server/public/locales/xx/msp/reports.json
+++ b/server/public/locales/xx/msp/reports.json
@@ -164,6 +164,10 @@
       "inventoryGhostUsage": {
         "title": "11111",
         "description": "11111"
+      },
+      "deferredRevenue": {
+        "title": "Deferred Revenue",
+        "description": "Prepaid liability across clients: credit balances and unburned bucket hours by month."
       }
     },
     "table": {
@@ -439,6 +443,67 @@
       "totalClients": "11111",
       "activeAssignments": "11111",
       "totalBilled": "11111"
+    }
+  },
+  "deferredRevenue": {
+    "title": "Deferred revenue / prepaid liability",
+    "description": "Per-client, per-month rollforward of client credit balances and unburned prepaid bucket hours.",
+    "printSubtitle": "Month {{month}}",
+    "printTable": "Per-client rollforward",
+    "empty": "No prepaid liability for this month.",
+    "actions": {
+      "csv": "Download CSV"
+    },
+    "errors": {
+      "load": "Failed to load the deferred revenue report."
+    },
+    "summary": {
+      "totalLiability": "Total prepaid liability",
+      "credits": "Credits",
+      "hours": "Prepaid hours",
+      "delta": "Change vs prior month"
+    },
+    "table": {
+      "client": "Client",
+      "credits": "Credits",
+      "hours": "Prepaid hours",
+      "total": "Total closing",
+      "opening": "Opening",
+      "issued": "Issued",
+      "applied": "Applied",
+      "expired": "Expired",
+      "adjustments": "Adj.",
+      "closing": "Closing",
+      "currencyHeading": "Currency",
+      "noClients": "No clients with prepaid balances this month.",
+      "tenantTotal": "Tenant total"
+    },
+    "detail": {
+      "credits": "Credit balances",
+      "noCredits": "No credit entries.",
+      "date": "Issued",
+      "description": "Description",
+      "remaining": "Remaining",
+      "expires": "Expires",
+      "qbo": "QBO",
+      "reachable": "Synced",
+      "notReachable": "Not in QBO",
+      "notReachableTitle": "Prepayment / project-deposit credits never export to QuickBooks — Alga is the system of record.",
+      "buckets": "Prepaid bucket hours",
+      "noBuckets": "No prepaid bucket periods.",
+      "line": "Line",
+      "period": "Period",
+      "included": "Included",
+      "used": "Used",
+      "value": "Value",
+      "feeSource": "Fee",
+      "rollover": "rollover",
+      "notBilled": "Not yet billed",
+      "billed": "Billed"
+    },
+    "csv": {
+      "client": "Client",
+      "currency": "Currency"
     }
   }
 }

--- a/server/public/locales/yy/metadata.json
+++ b/server/public/locales/yy/metadata.json
@@ -418,7 +418,10 @@
       "title": "55555"
     },
     "reports": {
-      "title": "55555"
+      "title": "55555",
+      "deferredRevenue": {
+        "title": "55555"
+      }
     },
     "schedule": {
       "title": "55555"

--- a/server/public/locales/yy/msp/reports.json
+++ b/server/public/locales/yy/msp/reports.json
@@ -164,6 +164,10 @@
       "inventoryGhostUsage": {
         "title": "55555",
         "description": "55555"
+      },
+      "deferredRevenue": {
+        "title": "Deferred Revenue",
+        "description": "Prepaid liability across clients: credit balances and unburned bucket hours by month."
       }
     },
     "table": {
@@ -439,6 +443,67 @@
       "totalClients": "55555",
       "activeAssignments": "55555",
       "totalBilled": "55555"
+    }
+  },
+  "deferredRevenue": {
+    "title": "Deferred revenue / prepaid liability",
+    "description": "Per-client, per-month rollforward of client credit balances and unburned prepaid bucket hours.",
+    "printSubtitle": "Month {{month}}",
+    "printTable": "Per-client rollforward",
+    "empty": "No prepaid liability for this month.",
+    "actions": {
+      "csv": "Download CSV"
+    },
+    "errors": {
+      "load": "Failed to load the deferred revenue report."
+    },
+    "summary": {
+      "totalLiability": "Total prepaid liability",
+      "credits": "Credits",
+      "hours": "Prepaid hours",
+      "delta": "Change vs prior month"
+    },
+    "table": {
+      "client": "Client",
+      "credits": "Credits",
+      "hours": "Prepaid hours",
+      "total": "Total closing",
+      "opening": "Opening",
+      "issued": "Issued",
+      "applied": "Applied",
+      "expired": "Expired",
+      "adjustments": "Adj.",
+      "closing": "Closing",
+      "currencyHeading": "Currency",
+      "noClients": "No clients with prepaid balances this month.",
+      "tenantTotal": "Tenant total"
+    },
+    "detail": {
+      "credits": "Credit balances",
+      "noCredits": "No credit entries.",
+      "date": "Issued",
+      "description": "Description",
+      "remaining": "Remaining",
+      "expires": "Expires",
+      "qbo": "QBO",
+      "reachable": "Synced",
+      "notReachable": "Not in QBO",
+      "notReachableTitle": "Prepayment / project-deposit credits never export to QuickBooks — Alga is the system of record.",
+      "buckets": "Prepaid bucket hours",
+      "noBuckets": "No prepaid bucket periods.",
+      "line": "Line",
+      "period": "Period",
+      "included": "Included",
+      "used": "Used",
+      "value": "Value",
+      "feeSource": "Fee",
+      "rollover": "rollover",
+      "notBilled": "Not yet billed",
+      "billed": "Billed"
+    },
+    "csv": {
+      "client": "Client",
+      "currency": "Currency"
     }
   }
 }

--- a/server/src/app/msp/reports/deferred-revenue/page.tsx
+++ b/server/src/app/msp/reports/deferred-revenue/page.tsx
@@ -1,0 +1,34 @@
+import { notFound } from 'next/navigation';
+import type { Metadata } from 'next';
+import { getServerTranslation } from '@alga-psa/ui/lib/i18n/serverOnly';
+import { getCurrentUser, hasPermission } from '@alga-psa/auth';
+import { checkFeatureFlag } from '@/lib/feature-flags/serverFeatureFlags';
+import DeferredRevenueReport from '@alga-psa/reporting/components/deferred-revenue/DeferredRevenueReport';
+
+export async function generateMetadata(): Promise<Metadata> {
+  const { t } = await getServerTranslation(undefined, 'metadata');
+
+  return {
+    title: t('msp.reports.deferredRevenue.title', { defaultValue: 'Deferred revenue' }),
+  };
+}
+
+/**
+ * Deferred-revenue / prepaid liability report. Gated behind the
+ * `release-v1.5-feature` feature flag and the `reports.read` permission for
+ * internal users; flag off (or no permission) yields a 404 so nothing about
+ * the existing UI changes.
+ */
+export default async function DeferredRevenueReportPage() {
+  const currentUser = await getCurrentUser();
+  const [flagEnabled, canReadReports] = await Promise.all([
+    checkFeatureFlag('release-v1.5-feature'),
+    currentUser ? hasPermission(currentUser, 'reports', 'read') : Promise.resolve(false),
+  ]);
+
+  if (!flagEnabled || !currentUser || currentUser.user_type !== 'internal' || !canReadReports) {
+    notFound();
+  }
+
+  return <DeferredRevenueReport />;
+}

--- a/server/src/test/unit/docs/servicePeriodFirstBillingPlan.contract.test.ts
+++ b/server/src/test/unit/docs/servicePeriodFirstBillingPlan.contract.test.ts
@@ -111,6 +111,7 @@ const persistedReaderExclusions = new Set([
 // check so the inventory remains an accurate record of its point in time.
 const billingCycleAlignmentPostInventoryRefs = new Set([
   'packages/billing/src/services/quoteConversionService.ts',
+  'packages/reporting/src/actions/report-actions/deferred-revenue/deferredRevenueReport.integration.test.ts',
   'server/src/lib/api/openapi/routes/contractLines.ts',
   'server/src/lib/mcp/registry.generated.ts',
   'shared/workflow/runtime/actions/__tests__/businessOperations.time.db.test.ts',
@@ -132,6 +133,13 @@ const billingCycleAlignmentPostInventoryRemovals = new Set([
 const servicePeriodPostInventoryRefs = new Set([
   'packages/billing/src/actions/billingAndTax.ts',
   'packages/billing/src/actions/billingCycleActions.ts',
+  // Deferred-revenue reporting reads persisted service-period boundaries to
+  // value prepaid bucket liability; it landed after the pass-0 snapshot.
+  'packages/reporting/src/actions/report-actions/deferred-revenue/compose.test.ts',
+  'packages/reporting/src/actions/report-actions/deferred-revenue/deferredRevenueReport.integration.test.ts',
+  'packages/reporting/src/actions/report-actions/deferred-revenue/fee.test.ts',
+  'packages/reporting/src/actions/report-actions/deferred-revenue/fee.ts',
+  'packages/reporting/src/actions/report-actions/deferred-revenue/loaders.ts',
   // Project-billing wave tests (feature/project-billing) landed after the
   // pass-0 snapshot and reference service-period fields in fixtures/assertions.
   'packages/billing/src/actions/accountingExportActions.test.ts',


### PR DESCRIPTION
## 29.8.22 — Deferred-revenue / prepaid liability reporting

Adds a feature-gated MSP report that calculates deferred-revenue / prepaid liability live from the credit ledger and prepaid bucket usage, with monthly rollforwards by client and currency.

### Summary

- Adds opening, issued, applied, expired, adjustment, and closing balances for customer credits, including prepayment provenance and QBO-unreachable detail.
- Adds unburned prepaid-hours liability, valued pro rata from the billed bucket fee so the balance ties to invoiced amounts. Billed invoice detail wins, followed by pricing-schedule rate, contract-line rate, fixed base rate, and catalog default rate.
- Combines credits and prepaid hours per client/currency without FX conversion, with expandable detail rows.
- Handles credit applications, reversals, adjustments, expirations, and transfers using canonical `metadata.applied_credits` attribution where available.
- Adds CSV export and print output.
- Adds the Reports hub card and `/msp/reports/deferred-revenue` route, both gated behind `release-v1.5-feature`; with the flag off, the existing Reports UI is unchanged and the direct route returns 404.
- Adds focused composition, ledger, fee, hours, loader-contract, UI-expansion, and DB-backed integration coverage, plus the implementation plan.
- Registers the new persisted service-period readers with the repository's pass-0 inventory contract so the complete server unit suite recognizes this post-snapshot reporting work.

### Smoke test

**PASS.** Exercised the real product on port 3827 from the correct worktree. Verified: flag-on Reports card and navigation; July prepaid-hours movement ($1.50 issued, -$1.50 applied); August credit rollforward ($200 issued, -$59 applied, $141 closing) with expandable QBO detail; combined liability totaling $142.50 ($141 credits + $1.50 hours) using one temporary DB-backed bucket row; CSV contents; print trigger/print DOM; and flag-off behavior hiding the card and returning 404 for the direct route. Database values reconciled with the UI, and the temporary bucket row and environment overrides were removed. The board-owned server is running again, with the normal fresh PostHog state currently evaluating the release flag off.

Targeted CI repair verification: `servicePeriodFirstBillingPlan.contract.test.ts` passes all 66 tests locally after registering the new post-inventory service-period references.

### Fidelity compromises

Docker status could not be inspected because this agent lacks Docker-socket access, though the app and wired PostgreSQL/PgBouncer endpoint were verified live. The CSV Blob was captured after a real button click because the remote browser's download directory was inaccessible. The native print dialog was not opened; `window.print` was instrumented to confirm invocation and print content. A transient HMR connection error occurred only during intentional restarts. One stale old Next process initially retained port 3827; it was stopped after confirming its exact worktree/process group, and the board service now owns the port.

Evidence directory: `/tmp/alga-smoke-evidence/deferred-revenue-prepaid-liability-20260812-193451`
