### PR TITLE
fix(email): clarify outbound sender identity UX

### DIFF
--- a/ee/server/src/components/settings/email/ManagedEmailSettings.tsx
+++ b/ee/server/src/components/settings/email/ManagedEmailSettings.tsx
@@ -36,6 +36,7 @@ import { EmailProviderConfiguration, EmailSenderIdentityCards } from '@alga-psa/
 import type { EmailProvider } from '@alga-psa/integrations/components';
 import type { TenantEmailSettings } from 'server/src/types/email.types';
 import { createDefaultProviderConfig } from '@alga-psa/email/providerConfig';
+import { isValidEmail } from '@alga-psa/validation';
 import {
   getEmailSettings,
   updateEmailSettings,
@@ -270,7 +271,7 @@ export const ManagedEmailSettings: React.FC<EmailSettingsProps> = () => {
     }
 
     const trimmed = value.trim();
-    if (!/^[^\s@]+@[^\s@]+$/.test(trimmed)) {
+    if (!isValidEmail(trimmed)) {
       return t('managed.validation.invalidEmail');
     }
 
@@ -559,6 +560,12 @@ export const ManagedEmailSettings: React.FC<EmailSettingsProps> = () => {
     }
     if (!from?.trim()) {
       toast.error(t('managed.messages.fromAddressRequired'));
+      return null;
+    }
+    // A junk address here poisons defaultFromDomain (derived below by splitting
+    // on '@'), which then leaks into every synthesized fallback sender.
+    if (!isValidEmail(from)) {
+      toast.error(t('managed.validation.invalidEmail'));
       return null;
     }
 
@@ -941,6 +948,39 @@ export const ManagedEmailSettings: React.FC<EmailSettingsProps> = () => {
                       {t('managed.outbound.smtp.authHint')}
                     </p>
 
+                    <div className="grid grid-cols-2 gap-4">
+                      <div>
+                        <Label htmlFor="smtp-from">{t('managed.outbound.smtp.fromLabel')}</Label>
+                        <Input
+                          id="smtp-from"
+                          type="email"
+                          value={smtpConfig?.config.from || ''}
+                          placeholder={t('managed.outbound.smtp.fromPlaceholder')}
+                          onChange={(e) => updateSmtpField('from', e.target.value)}
+                        />
+                        <p className="text-sm text-muted-foreground mt-1">
+                          {t('managed.outbound.smtp.fromHelp')}
+                        </p>
+                      </div>
+                      <div>
+                        <Label htmlFor="smtp-from-name">
+                          {t('managed.outbound.senderIdentities.notification.nameLabel')}
+                        </Label>
+                        <Input
+                          id="smtp-from-name"
+                          value={smtpConfig?.config.fromName || ''}
+                          placeholder={t('managed.outbound.senderIdentities.notification.namePlaceholder')}
+                          onChange={(e) => updateSmtpField('fromName', e.target.value)}
+                        />
+                        <p className="text-sm text-muted-foreground mt-1">
+                          {t('managed.outbound.senderIdentities.notification.nameHelp', {
+                            company: emailSettings?.tenantCompanyName
+                              || t('managed.outbound.senderIdentities.notification.companyFallback'),
+                          })}
+                        </p>
+                      </div>
+                    </div>
+
                     <div className="border-t pt-4 space-y-4">
                       <h4 className="text-sm font-medium">
                         {t('managed.outbound.smtp.security.title')}
@@ -1062,7 +1102,9 @@ export const ManagedEmailSettings: React.FC<EmailSettingsProps> = () => {
               notificationTitle: t('managed.outbound.senderIdentities.notification.title'),
               notificationDescription: t('managed.outbound.senderIdentities.notification.description'),
               notificationAddressLabel: t('managed.outbound.senderIdentities.notification.addressLabel'),
-              notificationAddressPlaceholder: t('managed.outbound.senderIdentities.notification.addressPlaceholder'),
+              // Effective fallback sender goes in the placeholder, never the value:
+              // rendering it as the value makes an unsaved field look configured.
+              notificationAddressPlaceholder: emailSettings.effectiveNotificationFrom.email,
               notificationAddressHelp: outboundProvider === 'smtp'
                 ? t('managed.outbound.senderIdentities.notification.smtpAddressHelp')
                 : t('managed.outbound.senderIdentities.notification.lockedAddressHelp'),
@@ -1076,11 +1118,20 @@ export const ManagedEmailSettings: React.FC<EmailSettingsProps> = () => {
             ticketName={ticketingFromName}
             connectedInboxes={ticketMailboxOptions}
             ticketFieldsDisabled={loadingOutbound || !outboundDomain}
-            ticketWarning={ticketingFromWarning}
+            ticketWarning={
+              !loadingOutbound && !outboundDomain
+                ? (outboundProvider === 'smtp'
+                    ? t('managed.validation.saveSmtpFirst')
+                    : t('managed.validation.addOutboundFirst'))
+                : ticketingFromWarning
+            }
             ticketError={ticketingFromError}
-            notificationAddress={notificationConfig?.config.from || emailSettings.effectiveNotificationFrom.email}
+            notificationAddress={notificationConfig?.config.from || ''}
             notificationName={notificationConfig?.config.fromName || ''}
-            notificationAddressReadOnly={outboundProvider !== 'smtp'}
+            // Shown only for managed/Microsoft, where the address comes from the
+            // domain or mailbox selection; SMTP edits its identity in the SMTP card.
+            showNotificationCard={outboundProvider !== 'smtp'}
+            notificationAddressReadOnly
             notificationFieldsDisabled={loadingOutbound}
             onTicketAddressChange={handleTicketingFromChange}
             onTicketNameChange={setTicketingFromName}

--- a/packages/integrations/src/actions/email-actions/emailSettingsActions.ts
+++ b/packages/integrations/src/actions/email-actions/emailSettingsActions.ts
@@ -18,6 +18,7 @@ import {
   isActionMessageError,
   type ActionMessageError,
 } from '@alga-psa/ui/lib/errorHandling';
+import { isValidEmail } from '@alga-psa/validation';
 
 type EmailSettingsUpdateInput = Partial<TenantEmailSettings> & {
   defaultFromDomain?: string | null;
@@ -273,7 +274,43 @@ export const updateEmailSettings = withAuth(async (
       updatedAt: now
     };
 
+    // Reject malformed sender data before it persists: a junk config.from
+    // propagates into default_from_domain and every synthesized fallback sender.
+    // Only the fields present in this update are checked, so tenants carrying
+    // legacy junk can still save unrelated settings.
+    if (updates.providerConfigs) {
+      // Provider switches resend stored configs verbatim, so an unchanged
+      // (possibly legacy-junk) From must pass — only new values are checked.
+      const existingFromByType = new Map(
+        (existingSettings?.providerConfigs ?? []).map(config => [
+          config.providerType,
+          typeof config.config?.from === 'string' ? config.config.from.trim() : '',
+        ])
+      );
+      for (const config of normalizedProviderConfigs) {
+        const configFrom = typeof config.config?.from === 'string' ? config.config.from.trim() : '';
+        if (!configFrom || isValidEmail(configFrom)) {
+          continue;
+        }
+        if (configFrom === existingFromByType.get(config.providerType)) {
+          continue;
+        }
+        return actionError(`The ${config.providerType} From address must be a valid email address`);
+      }
+    }
+    if (
+      hasOwnUpdate(updates, 'ticketingFromEmail')
+      && mergedSettings.ticketingFromEmail
+      && !isValidEmail(mergedSettings.ticketingFromEmail)
+    ) {
+      return actionError('Ticketing From address must be a valid email address');
+    }
+
     const targetDomain = mergedSettings.defaultFromDomain?.trim().toLowerCase();
+    // Same schema as the address checks: a domain is valid iff an address on it is.
+    if (hasOwnUpdate(updates, 'defaultFromDomain') && targetDomain && !isValidEmail(`sender@${targetDomain}`)) {
+      return actionError('Outbound sending domain must be a valid domain (e.g. example.com)');
+    }
     if (mergedSettings.ticketingFromEmail) {
       if (!targetDomain) {
         return actionError('Configure an outbound domain before choosing a ticketing From address');

--- a/packages/integrations/src/components/email/admin/EmailSenderIdentityCards.test.tsx
+++ b/packages/integrations/src/components/email/admin/EmailSenderIdentityCards.test.tsx
@@ -52,6 +52,49 @@ describe('EmailSenderIdentityCards', () => {
     expect(screen.getByText('Blank uses Example MSP automatically.')).toBeInTheDocument();
   });
 
+  it('renders read-only addresses as text, with the default shown when empty', () => {
+    render(
+      <EmailSenderIdentityCards
+        copy={copy}
+        ticketAddress=""
+        ticketName=""
+        notificationAddress=""
+        notificationName=""
+        notificationAddressReadOnly
+        onTicketAddressChange={vi.fn()}
+        onTicketNameChange={vi.fn()}
+        onNotificationAddressChange={vi.fn()}
+        onNotificationNameChange={vi.fn()}
+      />
+    );
+
+    // No input for the read-only address: the effective default renders as text.
+    expect(screen.queryByDisplayValue('notifications@example.com')).not.toBeInTheDocument();
+    const readOnlyAddress = document.getElementById('notification-from-address');
+    expect(readOnlyAddress?.tagName).toBe('P');
+    expect(readOnlyAddress).toHaveTextContent('notifications@example.com');
+  });
+
+  it('hides the notification card when the identity is edited elsewhere', () => {
+    render(
+      <EmailSenderIdentityCards
+        copy={copy}
+        ticketAddress=""
+        ticketName=""
+        notificationAddress=""
+        notificationName=""
+        showNotificationCard={false}
+        onTicketAddressChange={vi.fn()}
+        onTicketNameChange={vi.fn()}
+        onNotificationAddressChange={vi.fn()}
+        onNotificationNameChange={vi.fn()}
+      />
+    );
+
+    expect(screen.getByText('Ticket email identity')).toBeInTheDocument();
+    expect(screen.queryByText('All other email identity')).not.toBeInTheDocument();
+  });
+
   it('keeps ticket and notification change handlers independent', () => {
     const onTicketNameChange = vi.fn();
     const onNotificationNameChange = vi.fn();

--- a/packages/integrations/src/components/email/admin/EmailSenderIdentityCards.tsx
+++ b/packages/integrations/src/components/email/admin/EmailSenderIdentityCards.tsx
@@ -45,11 +45,23 @@ interface EmailSenderIdentityCardsProps {
   notificationName: string;
   notificationAddressReadOnly?: boolean;
   notificationFieldsDisabled?: boolean;
+  /** Hide the notification card when the default identity is edited elsewhere (e.g. the SMTP form). */
+  showNotificationCard?: boolean;
   onTicketAddressChange: (value: string) => void;
   onTicketNameChange: (value: string) => void;
   onNotificationAddressChange: (value: string) => void;
   onNotificationNameChange: (value: string) => void;
   actions?: ReactNode;
+}
+
+// Read-only addresses render as plain text: a normal input suggests the value
+// can be typed over, which reads as "configured here" when it is not.
+function ReadOnlyAddress({ id, value, fallback }: { id: string; value: string; fallback: string }) {
+  return (
+    <p id={id} className="text-sm py-1.5">
+      {value || <span className="text-muted-foreground">{fallback}</span>}
+    </p>
+  );
 }
 
 export function EmailSenderIdentityCards({
@@ -65,6 +77,7 @@ export function EmailSenderIdentityCards({
   notificationName,
   notificationAddressReadOnly = false,
   notificationFieldsDisabled = false,
+  showNotificationCard = true,
   onTicketAddressChange,
   onTicketNameChange,
   onNotificationAddressChange,
@@ -79,7 +92,7 @@ export function EmailSenderIdentityCards({
 
   return (
     <div className="space-y-4">
-      <div className="grid gap-4 lg:grid-cols-2">
+      <div className={`grid gap-4 ${showNotificationCard ? 'lg:grid-cols-2' : ''}`}>
         <Card>
           <CardHeader>
             <CardTitle className="flex items-center gap-2">
@@ -112,15 +125,22 @@ export function EmailSenderIdentityCards({
             {(ticketAddressReadOnly || connectedInboxes.length === 0 || ticketAddressOption === 'custom') && (
               <div className="space-y-2">
                 <Label htmlFor="ticket-from-address">{copy.ticketAddressLabel}</Label>
-                <Input
-                  id="ticket-from-address"
-                  type="email"
-                  value={ticketAddress}
-                  readOnly={ticketAddressReadOnly}
-                  disabled={ticketFieldsDisabled}
-                  placeholder={copy.ticketAddressPlaceholder}
-                  onChange={(event) => onTicketAddressChange(event.target.value)}
-                />
+                {ticketAddressReadOnly ? (
+                  <ReadOnlyAddress
+                    id="ticket-from-address"
+                    value={ticketAddress}
+                    fallback={copy.ticketAddressPlaceholder}
+                  />
+                ) : (
+                  <Input
+                    id="ticket-from-address"
+                    type="email"
+                    value={ticketAddress}
+                    disabled={ticketFieldsDisabled}
+                    placeholder={copy.ticketAddressPlaceholder}
+                    onChange={(event) => onTicketAddressChange(event.target.value)}
+                  />
+                )}
                 <p className="text-xs text-muted-foreground">{copy.ticketAddressHelp}</p>
               </div>
             )}
@@ -152,6 +172,7 @@ export function EmailSenderIdentityCards({
           </CardContent>
         </Card>
 
+        {showNotificationCard && (
         <Card>
           <CardHeader>
             <CardTitle className="flex items-center gap-2">
@@ -163,15 +184,22 @@ export function EmailSenderIdentityCards({
           <CardContent className="space-y-4">
             <div className="space-y-2">
               <Label htmlFor="notification-from-address">{copy.notificationAddressLabel}</Label>
-              <Input
-                id="notification-from-address"
-                type="email"
-                value={notificationAddress}
-                readOnly={notificationAddressReadOnly}
-                disabled={notificationFieldsDisabled}
-                placeholder={copy.notificationAddressPlaceholder}
-                onChange={(event) => onNotificationAddressChange(event.target.value)}
-              />
+              {notificationAddressReadOnly ? (
+                <ReadOnlyAddress
+                  id="notification-from-address"
+                  value={notificationAddress}
+                  fallback={copy.notificationAddressPlaceholder}
+                />
+              ) : (
+                <Input
+                  id="notification-from-address"
+                  type="email"
+                  value={notificationAddress}
+                  disabled={notificationFieldsDisabled}
+                  placeholder={copy.notificationAddressPlaceholder}
+                  onChange={(event) => onNotificationAddressChange(event.target.value)}
+                />
+              )}
               <p className="text-xs text-muted-foreground">{copy.notificationAddressHelp}</p>
             </div>
 
@@ -188,6 +216,7 @@ export function EmailSenderIdentityCards({
             </div>
           </CardContent>
         </Card>
+        )}
       </div>
       {actions}
     </div>

--- a/packages/integrations/src/components/email/admin/EmailSettings.tsx
+++ b/packages/integrations/src/components/email/admin/EmailSettings.tsx
@@ -743,7 +743,9 @@ export const EmailSettings: React.FC<EmailSettingsProps> = () => {
                 notificationTitle: t('email.senderIdentities.notification.title'),
                 notificationDescription: t('email.senderIdentities.notification.description'),
                 notificationAddressLabel: t('email.senderIdentities.notification.addressLabel'),
-                notificationAddressPlaceholder: t('email.senderIdentities.notification.addressPlaceholder'),
+                // Effective fallback sender goes in the placeholder, never the value:
+                // rendering it as the value makes an unsaved field look configured.
+                notificationAddressPlaceholder: settings.effectiveNotificationFrom.email,
                 notificationAddressHelp: t('email.senderIdentities.notification.addressHelp'),
                 notificationNameLabel: t('email.senderIdentities.notification.nameLabel'),
                 notificationNamePlaceholder: t('email.senderIdentities.notification.namePlaceholder'),
@@ -764,7 +766,7 @@ export const EmailSettings: React.FC<EmailSettingsProps> = () => {
                   : null
               }
               ticketError={ticketIdentityError}
-              notificationAddress={getCurrentProviderConfig()?.config.from || settings.effectiveNotificationFrom.email}
+              notificationAddress={getCurrentProviderConfig()?.config.from || ''}
               notificationName={getCurrentProviderConfig()?.config.fromName || ''}
               notificationAddressReadOnly={selectedProvider === 'microsoft'}
               onTicketAddressChange={(value) => setSettings({ ...settings, ticketingFromEmail: value || null })}

--- a/server/public/locales/de/msp/email-providers.json
+++ b/server/public/locales/de/msp/email-providers.json
@@ -756,7 +756,7 @@
         "authHint": "Lassen Sie Benutzername und Passwort leer, wenn Ihr Relay E-Mails ohne Authentifizierung akzeptiert.",
         "fromLabel": "Absenderadresse",
         "fromPlaceholder": "noreply@beispiel.de",
-        "fromHelp": "Die Standardabsenderadresse für ausgehende E-Mails.",
+        "fromHelp": "Standardabsender für alle ausgehenden E-Mails. Ticket-E-Mails können unten eine eigene Absenderidentität verwenden.",
         "security": {
           "title": "Verbindungssicherheit",
           "secure": "Implizites TLS verwenden (SSL beim Verbinden, üblicherweise Port 465)",
@@ -833,7 +833,7 @@
           "description": "Versehen Sie Portal-Einladungen, Passwortrücksetzungen, Rechnungen, Projektaktualisierungen und allgemeine Benachrichtigungen unabhängig vom Ticket-Routing mit Ihrem Branding.",
           "addressLabel": "Absenderadresse",
           "addressPlaceholder": "notifications@example.com",
-          "smtpAddressHelp": "Dies ist die Branding-Adresse, die für E-Mails ohne Ticketbezug über Ihren SMTP-Server verwendet wird.",
+          "smtpAddressHelp": "Wird durch die Absenderadresse in der SMTP-Konfiguration oben festgelegt. Alle E-Mails ohne Ticketbezug werden von dieser Adresse gesendet.",
           "lockedAddressHelp": "Diese Adresse wird durch die aktive verwaltete Domain oder das ausgewählte Microsoft 365-Postfach bestimmt.",
           "nameLabel": "Anzeigename des Absenders",
           "namePlaceholder": "Name Ihres Unternehmens",

--- a/server/public/locales/en/msp/email-providers.json
+++ b/server/public/locales/en/msp/email-providers.json
@@ -756,7 +756,7 @@
         "authHint": "Leave username and password blank if your relay accepts mail without authentication.",
         "fromLabel": "From Address",
         "fromPlaceholder": "noreply@example.com",
-        "fromHelp": "The default sender address for outbound emails.",
+        "fromHelp": "Default sender for all outbound email. Ticket email can use its own identity below.",
         "security": {
           "title": "Connection Security",
           "secure": "Use implicit TLS (SSL on connect, typically port 465)",
@@ -833,7 +833,7 @@
           "description": "Brand portal invitations, password resets, invoices, project updates, and general notifications independently from ticket routing.",
           "addressLabel": "From address",
           "addressPlaceholder": "notifications@example.com",
-          "smtpAddressHelp": "This is the branding address used for non-ticket email through your SMTP server.",
+          "smtpAddressHelp": "Set by the From Address in the SMTP configuration above. All non-ticket email is sent from it.",
           "lockedAddressHelp": "This address is determined by the active managed domain or selected Microsoft 365 mailbox.",
           "nameLabel": "Sender display name",
           "namePlaceholder": "Your company name",

--- a/server/public/locales/es/msp/email-providers.json
+++ b/server/public/locales/es/msp/email-providers.json
@@ -756,7 +756,7 @@
         "authHint": "Deje el nombre de usuario y la contraseña en blanco si su retransmisor acepta correo sin autenticación.",
         "fromLabel": "Dirección de remitente",
         "fromPlaceholder": "noreply@ejemplo.com",
-        "fromHelp": "Dirección de remitente predeterminada para los correos salientes.",
+        "fromHelp": "Remitente predeterminado para todos los correos salientes. Los correos de tickets pueden usar su propia identidad más abajo.",
         "security": {
           "title": "Seguridad de la conexión",
           "secure": "Usar TLS implícito (SSL al conectar, normalmente el puerto 465)",
@@ -833,7 +833,7 @@
           "description": "Personalice las invitaciones al portal, los restablecimientos de contraseña, las facturas, las actualizaciones de proyectos y las notificaciones generales de forma independiente del enrutamiento de tickets.",
           "addressLabel": "Dirección del remitente",
           "addressPlaceholder": "notifications@example.com",
-          "smtpAddressHelp": "Esta es la dirección de marca que se usa para los correos electrónicos que no son de tickets a través de su servidor SMTP.",
+          "smtpAddressHelp": "Se establece mediante la Dirección de remitente en la configuración SMTP de arriba. Todos los correos que no son de tickets se envían desde ella.",
           "lockedAddressHelp": "Esta dirección está determinada por el dominio administrado activo o el buzón de Microsoft 365 seleccionado.",
           "nameLabel": "Nombre visible del remitente",
           "namePlaceholder": "Nombre de su empresa",

--- a/server/public/locales/fr/msp/email-providers.json
+++ b/server/public/locales/fr/msp/email-providers.json
@@ -756,7 +756,7 @@
         "authHint": "Laissez le nom d'utilisateur et le mot de passe vides si votre relais accepte les e-mails sans authentification.",
         "fromLabel": "Adresse d'expéditeur",
         "fromPlaceholder": "noreply@exemple.com",
-        "fromHelp": "Adresse d'expéditeur par défaut pour les e-mails sortants.",
+        "fromHelp": "Expéditeur par défaut pour tous les e-mails sortants. Les e-mails de tickets peuvent utiliser leur propre identité ci-dessous.",
         "security": {
           "title": "Sécurité de la connexion",
           "secure": "Utiliser le TLS implicite (SSL à la connexion, généralement le port 465)",
@@ -833,7 +833,7 @@
           "description": "Personnalisez les invitations au portail, les réinitialisations de mot de passe, les factures, les mises à jour de projet et les notifications générales indépendamment du routage des tickets.",
           "addressLabel": "Adresse d'expéditeur",
           "addressPlaceholder": "notifications@example.com",
-          "smtpAddressHelp": "Il s'agit de l'adresse de marque utilisée pour les e-mails hors tickets envoyés par votre serveur SMTP.",
+          "smtpAddressHelp": "Définie par l'adresse d'expéditeur dans la configuration SMTP ci-dessus. Tous les e-mails hors tickets sont envoyés depuis cette adresse.",
           "lockedAddressHelp": "Cette adresse est déterminée par le domaine géré actif ou la boîte aux lettres Microsoft 365 sélectionnée.",
           "nameLabel": "Nom d'affichage de l'expéditeur",
           "namePlaceholder": "Nom de votre entreprise",

--- a/server/public/locales/it/msp/email-providers.json
+++ b/server/public/locales/it/msp/email-providers.json
@@ -756,7 +756,7 @@
         "authHint": "Lascia vuoti nome utente e password se il tuo relay accetta la posta senza autenticazione.",
         "fromLabel": "Indirizzo mittente",
         "fromPlaceholder": "noreply@esempio.it",
-        "fromHelp": "Indirizzo mittente predefinito per le email in uscita.",
+        "fromHelp": "Mittente predefinito per tutte le email in uscita. Le email dei ticket possono usare un'identità dedicata qui sotto.",
         "security": {
           "title": "Sicurezza della connessione",
           "secure": "Usa TLS implicito (SSL alla connessione, in genere porta 465)",
@@ -833,7 +833,7 @@
           "description": "Inviti al portale personalizzato, reimpostazioni della password, fatture, aggiornamenti dei progetti e notifiche generali, indipendentemente dall’instradamento dei ticket.",
           "addressLabel": "Indirizzo mittente",
           "addressPlaceholder": "notifications@example.com",
-          "smtpAddressHelp": "Questo è l’indirizzo associato al marchio usato per le email non relative ai ticket inviate tramite il tuo server SMTP.",
+          "smtpAddressHelp": "Impostato dall'Indirizzo mittente nella configurazione SMTP qui sopra. Tutte le email non relative ai ticket vengono inviate da questo indirizzo.",
           "lockedAddressHelp": "Questo indirizzo è determinato dal dominio gestito attivo o dalla casella di posta Microsoft 365 selezionata.",
           "nameLabel": "Nome visualizzato del mittente",
           "namePlaceholder": "Nome della tua azienda",

--- a/server/public/locales/nl/msp/email-providers.json
+++ b/server/public/locales/nl/msp/email-providers.json
@@ -756,7 +756,7 @@
         "authHint": "Laat gebruikersnaam en wachtwoord leeg als uw relay e-mail zonder authenticatie accepteert.",
         "fromLabel": "Afzenderadres",
         "fromPlaceholder": "noreply@voorbeeld.nl",
-        "fromHelp": "Het standaard afzenderadres voor uitgaande e-mails.",
+        "fromHelp": "Standaardafzender voor alle uitgaande e-mail. Ticket-e-mail kan hieronder een eigen identiteit gebruiken.",
         "security": {
           "title": "Verbindingsbeveiliging",
           "secure": "Impliciete TLS gebruiken (SSL bij verbinden, doorgaans poort 465)",
@@ -833,7 +833,7 @@
           "description": "Geef portaaluitnodigingen, wachtwoordresets, facturen, projectupdates en algemene meldingen onafhankelijk van de ticketroutering een eigen huisstijl.",
           "addressLabel": "Afzenderadres",
           "addressPlaceholder": "notifications@example.com",
-          "smtpAddressHelp": "Dit is het huisstijladres dat via uw SMTP-server wordt gebruikt voor e-mail die niet aan tickets is gerelateerd.",
+          "smtpAddressHelp": "Wordt bepaald door het afzenderadres in de SMTP-configuratie hierboven. Alle e-mail die niet aan tickets is gerelateerd wordt vanaf dit adres verzonden.",
           "lockedAddressHelp": "Dit adres wordt bepaald door het actieve beheerde domein of het geselecteerde Microsoft 365-postvak.",
           "nameLabel": "Weergavenaam van afzender",
           "namePlaceholder": "Uw bedrijfsnaam",

--- a/server/public/locales/pl/msp/email-providers.json
+++ b/server/public/locales/pl/msp/email-providers.json
@@ -756,7 +756,7 @@
         "authHint": "Pozostaw nazwę użytkownika i hasło puste, jeśli przekaźnik akceptuje pocztę bez uwierzytelniania.",
         "fromLabel": "Adres nadawcy",
         "fromPlaceholder": "noreply@przyklad.pl",
-        "fromHelp": "Domyślny adres nadawcy dla poczty wychodzącej.",
+        "fromHelp": "Domyślny nadawca całej poczty wychodzącej. Wiadomości zgłoszeń mogą używać własnej tożsamości poniżej.",
         "security": {
           "title": "Bezpieczeństwo połączenia",
           "secure": "Użyj niejawnego TLS (SSL przy połączeniu, zwykle port 465)",
@@ -833,7 +833,7 @@
           "description": "Oddziel identyfikację nadawcy zaproszeń do portalu, wiadomości o resetowaniu haseł, faktur, aktualizacji projektów i ogólnych powiadomień od routingu zgłoszeń.",
           "addressLabel": "Adres nadawcy",
           "addressPlaceholder": "notifications@example.com",
-          "smtpAddressHelp": "To adres marki używany przez serwer SMTP do wysyłania wiadomości e-mail niezwiązanych ze zgłoszeniami.",
+          "smtpAddressHelp": "Ustalany przez adres nadawcy w konfiguracji SMTP powyżej. Cała poczta niezwiązana ze zgłoszeniami jest wysyłana z tego adresu.",
           "lockedAddressHelp": "Ten adres wynika z aktywnej domeny zarządzanej lub wybranej skrzynki pocztowej Microsoft 365.",
           "nameLabel": "Wyświetlana nazwa nadawcy",
           "namePlaceholder": "Nazwa Twojej firmy",

--- a/server/public/locales/pt/msp/email-providers.json
+++ b/server/public/locales/pt/msp/email-providers.json
@@ -756,7 +756,7 @@
         "authHint": "Deixe o nome de usuário e a senha em branco se o seu relay aceitar e-mails sem autenticação.",
         "fromLabel": "Do endereço",
         "fromPlaceholder": "noreply@example.com",
-        "fromHelp": "O endereço do remetente padrão para e-mails enviados.",
+        "fromHelp": "Remetente padrão de todos os emails enviados. Os emails de tickets podem usar uma identidade própria abaixo.",
         "security": {
           "title": "Segurança da conexão",
           "secure": "Usar TLS implícito (SSL ao conectar, normalmente a porta 465)",
@@ -833,7 +833,7 @@
           "description": "Personalize convites do portal, redefinições de senha, faturas, atualizações de projetos e notificações gerais, independentemente do roteamento de tickets.",
           "addressLabel": "Endereço do remetente",
           "addressPlaceholder": "notifications@example.com",
-          "smtpAddressHelp": "Este é o endereço da marca usado para emails que não são de tickets enviados pelo seu servidor SMTP.",
+          "smtpAddressHelp": "Definido pelo endereço do remetente na configuração SMTP acima. Todos os emails que não são de tickets são enviados a partir dele.",
           "lockedAddressHelp": "Este endereço é determinado pelo domínio gerenciado ativo ou pela caixa de correio selecionada do Microsoft 365.",
           "nameLabel": "Nome de exibição do remetente",
           "namePlaceholder": "Nome da sua empresa",


### PR DESCRIPTION
Move the From address (and display name) into the SMTP card so the save button validates fields it actually contains, and hide the "All other email identity" card for SMTP — it remains only for managed and Microsoft 365 providers, where the address is det
Read-only addresses now render as plain text instead of a fake-editable input, with the effective fallback shown as a hin

Validate sender addresses with the shared isValid
client and server so junk like f@from can no longer poison default_from_domain (only changed values are chec
switches that resend stored configs keep working). Surface the "save SMTP first" hint on the locked ticket ident
the two reworded help strings across all seven locales.

"Who are YOU?" said the Caterpillar to informieren13@from. "I hardly know, sir — I was assembled from a local part and
The read-only looking-glass now shows plainly what is real, and the zod gatekeeper turns away every address with no d