### PR TITLE
fix: stop reading the mailbox user object in Microsoft connection test

### DIFF
--- a/shared/services/email/providers/MicrosoftGraphAdapter.ts
+++ b/shared/services/email/providers/MicrosoftGraphAdapter.ts
@@ -879,13 +879,29 @@ export class MicrosoftGraphAdapter extends BaseEmailAdapter {
   async testConnection(): Promise<{ success: boolean; error?: string }> {
     try {
       const mailboxBase = this.getMailboxBasePath();
-      await this.httpClient.get(mailboxBase);
+      // Test mail-data access rather than reading the mailbox's user object:
+      // for shared mailboxes GET /users/{mailbox} requires directory
+      // permissions (User.Read.All) that the email OAuth scopes do not
+      // include, so it returns 403 even when mail access is fully authorized.
       await this.httpClient.get(`${mailboxBase}/mailFolders`, {
         params: { $top: 1, $select: 'id' },
       });
       return { success: true };
     } catch (error: any) {
-      return { success: false, error: error.message || 'Connection test failed' };
+      const failure = this.classifyGraphFailure(error);
+      const detail = [
+        failure.status,
+        failure.code !== String(failure.status) ? failure.code : undefined,
+        failure.requestId && `request-id=${failure.requestId}`,
+      ]
+        .filter(Boolean)
+        .join(' ');
+      return {
+        success: false,
+        error: detail
+          ? `${failure.message} (${detail})`
+          : failure.message || 'Connection test failed',
+      };
     }
   }
 

--- a/shared/services/email/providers/__tests__/MicrosoftGraphAdapter.sendMail.test.ts
+++ b/shared/services/email/providers/__tests__/MicrosoftGraphAdapter.sendMail.test.ts
@@ -102,6 +102,49 @@ describe('MicrosoftGraphAdapter.sendMail', () => {
   });
 });
 
+describe('MicrosoftGraphAdapter.testConnection', () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('reads only mail data for shared mailboxes, never the mailbox user object', async () => {
+    // GET /users/{mailbox} needs User.Read.All, which the email OAuth scopes
+    // do not include; reading it made every shared-mailbox connection test
+    // fail with 403 under the platform Microsoft app.
+    const adapter = makeAdapter();
+    (adapter as any).authenticatedUserEmail = 'owner@example.com';
+    const get = vi.fn(async () => ({ data: {} }));
+    (adapter as any).httpClient = { get };
+
+    const result = await adapter.testConnection();
+
+    expect(result).toEqual({ success: true });
+    expect(get).toHaveBeenCalledTimes(1);
+    expect(get).toHaveBeenCalledWith('/users/support%2Bdesk%40example.com/mailFolders', {
+      params: { $top: 1, $select: 'id' },
+    });
+  });
+
+  it('surfaces the Graph status, error code, and request id on failure', async () => {
+    const adapter = makeAdapter();
+    (adapter as any).authenticatedUserEmail = 'owner@example.com';
+    const get = vi.fn().mockRejectedValue({
+      message: 'Request failed with status code 403',
+      response: {
+        status: 403,
+        data: { error: { code: 'ErrorAccessDenied', message: 'Access is denied.' } },
+        headers: { 'request-id': 'graph-request-1' },
+      },
+    });
+    (adapter as any).httpClient = { get };
+
+    const result = await adapter.testConnection();
+
+    expect(result.success).toBe(false);
+    expect(result.error).toBe('Access is denied. (403 ErrorAccessDenied request-id=graph-request-1)');
+  });
+});
+
 describe('MicrosoftGraphAdapter.connect', () => {
   it('does not report a failed Graph health check as connected', async () => {
     const adapter = makeAdapter();


### PR DESCRIPTION
## Problem

Since the early-August move of hosted Microsoft email onto the shared platform Entra app, every **shared/delegated mailbox** provider has failed `connect()` with a bare Graph 403 (platform-wide since **Aug 9, 00:03 UTC** — zero occurrences in the prior 30 days of logs). Confirmed affected: EQUIT (alga0002249), Shift Left Security, Augment Tech, Swift Underground.

`testConnection()` opens with `GET /users/{mailbox}` — reading **another user's directory object**, which requires `User.Read.All`/`User.ReadBasic.All`. The email OAuth scopes (`Mail.Read`, `Mail.Read.Shared`, `Mail.Send`, `User.Read`, `offline_access`) can never satisfy it, so the call 403s deterministically whenever the configured mailbox differs from the authenticated user. It used to work only because tenants were on their own Entra apps with broader consents.

Two failure modes, both from this one call:
- **Inbound**: every pointer fetch fails at connect, retries 5x into the DLQ; `maintenance-reconcile` re-enqueues forever (~200 errors/day in email-service).
- **Re-auth death loop**: the OAuth callback runs `connect()` before persisting tokens, so a *fresh, valid consent* is discarded ("provider restored to its prior state") — customers cannot fix it by re-authorizing (observed live for Swift Underground on Aug 13, 13:40 UTC).

## Fix

- `testConnection()` now tests mail-data access (`GET {mailboxBase}/mailFolders`) — exactly the permission the adapter needs and uses — instead of the user object.
- Connection failures now surface the Graph **status, error code, and request-id** (e.g. `Access is denied. (403 ErrorAccessDenied request-id=…)`), so a scope regression is distinguishable from lost mailbox delegation in the connect-failure log.

Two unit tests added: one pins the regression (shared mailbox must never read the user object), one covers the error-detail formatting.

## Rollout

- **email-service** was hot-deployed from this branch at `873e01d` (Argo `email-service-hosted-xq4rk`) to stop ongoing mail loss for tenants with persisted tokens.
- Merging is required for **sebastian** (OAuth callback — un-breaks re-authorization) and **temporal-worker** (webhook maintenance), which bundle their own copies of the shared adapter.
- A Loki-backed Grafana alert (`microsoft-email-connect-failures`, critical → Slack) now fires on ≥5 `[MICROSOFT] Error in connect` lines in email-service within 30 minutes, so this class of failure can't run silent again.