### PR TITLE
Fix backward month/year navigation in the date picker

### DIFF
--- a/packages/ui/src/components/Calendar.test.tsx
+++ b/packages/ui/src/components/Calendar.test.tsx
@@ -53,4 +53,49 @@ describe('Calendar', () => {
     fireEvent.click(todayButton);
     expect(onSelect).not.toHaveBeenCalled();
   });
+
+  // The month list only ran forwards from the current month, so a date in the
+  // recent past was unreachable from the dropdown.
+  it('navigates to an earlier month and year from the month picker', () => {
+    render(<Calendar mode="single" selected={new Date(2026, 3, 5)} onSelect={vi.fn()} />);
+
+    fireEvent.click(screen.getByRole('button', { name: 'Select month and year' }));
+    fireEvent.click(screen.getByRole('button', { name: 'Jan' }));
+    expect(screen.getByRole('button', { name: 'Select month and year' }).textContent).toContain(
+      'January 2026'
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: 'Select month and year' }));
+    fireEvent.click(screen.getByRole('button', { name: 'Previous year' }));
+    fireEvent.click(screen.getByRole('button', { name: 'Dec' }));
+    expect(screen.getByRole('button', { name: 'Select month and year' }).textContent).toContain(
+      'December 2025'
+    );
+  });
+
+  it('keeps months outside the allowed range unselectable', () => {
+    render(
+      <Calendar
+        mode="single"
+        selected={new Date(2026, 3, 5)}
+        onSelect={vi.fn()}
+        fromDate={new Date(2026, 3, 1)}
+      />
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: 'Select month and year' }));
+
+    expect((screen.getByRole('button', { name: 'Mar' }) as HTMLButtonElement).disabled).toBe(true);
+    expect((screen.getByRole('button', { name: 'May' }) as HTMLButtonElement).disabled).toBe(false);
+    expect(
+      (screen.getByRole('button', { name: 'Previous year' }) as HTMLButtonElement).disabled
+    ).toBe(true);
+  });
+
+  it('suppresses the day-picker caption in favour of our own header row', () => {
+    render(<Calendar mode="single" selected={new Date(2026, 3, 5)} onSelect={vi.fn()} />);
+
+    // Under the pre-v9 key the month title rendered twice, one above the other.
+    expect(document.querySelectorAll('.rdp-caption-hidden')).toHaveLength(1);
+  });
 });

--- a/packages/ui/src/components/Calendar.tsx
+++ b/packages/ui/src/components/Calendar.tsx
@@ -29,27 +29,56 @@ interface CalendarProps extends Omit<React.ComponentProps<typeof DayPicker>, 'mo
 interface MonthYearSelectProps {
   value: Date;
   onChange: (date: Date) => void;
-  fromDate: Date;
+  minMonth: Date;
+  maxMonth: Date;
   locale: Locale;
 }
 
-const MonthYearSelect = ({ value, onChange, fromDate, locale }: MonthYearSelectProps) => {
+const MonthYearSelect = ({ value, onChange, minMonth, maxMonth, locale }: MonthYearSelectProps) => {
   const [isOpen, setIsOpen] = React.useState(false);
-  const buttonRef = React.useRef<HTMLButtonElement>(null);
-  
-  // Generate all available month/year combinations
-  const options = React.useMemo((): Date[] => {
-    const start = new Date(fromDate.getFullYear(), fromDate.getMonth(), 1);
-    const options: Date[] = [];
-    
-    // Generate options for the next 10 years
-    for (let i = 0; i < 120; i++) {
-      options.push(new Date(start));
-      start.setMonth(start.getMonth() + 1);
-    }
-    
-    return options;
-  }, [fromDate]);
+  const [panelYear, setPanelYear] = React.useState(value.getFullYear());
+  const containerRef = React.useRef<HTMLDivElement>(null);
+
+  // A single scrolling list of months could only ever run forwards, so a past
+  // month was unreachable. A year stepper plus a month grid goes both ways.
+  const openPanel = () => {
+    setPanelYear(value.getFullYear());
+    setIsOpen(true);
+  };
+
+  React.useEffect(() => {
+    if (!isOpen) return;
+
+    const handlePointerDown = (event: MouseEvent) => {
+      if (!containerRef.current?.contains(event.target as Node)) {
+        setIsOpen(false);
+      }
+    };
+    const handleKeyDown = (event: KeyboardEvent) => {
+      if (event.key !== 'Escape') return;
+      // Close only this panel, not the surrounding popover/dialog.
+      event.stopPropagation();
+      setIsOpen(false);
+    };
+
+    document.addEventListener('mousedown', handlePointerDown);
+    document.addEventListener('keydown', handleKeyDown, true);
+    return () => {
+      document.removeEventListener('mousedown', handlePointerDown);
+      document.removeEventListener('keydown', handleKeyDown, true);
+    };
+  }, [isOpen]);
+
+  const months = React.useMemo(
+    () => Array.from({ length: 12 }, (_, month) => new Date(panelYear, month, 1)),
+    [panelYear]
+  );
+
+  const isMonthAllowed = (month: Date) =>
+    month.getTime() >= minMonth.getTime() && month.getTime() <= maxMonth.getTime();
+
+  const canGoToPreviousYear = panelYear - 1 >= minMonth.getFullYear();
+  const canGoToNextYear = panelYear + 1 <= maxMonth.getFullYear();
 
   const handleSelect = (date: Date) => {
     onChange(date);
@@ -57,41 +86,59 @@ const MonthYearSelect = ({ value, onChange, fromDate, locale }: MonthYearSelectP
   };
 
   return (
-    <div className="calendar-month-year-select">
+    <div className="calendar-month-year-select" ref={containerRef}>
       <button
-        ref={buttonRef}
-        onClick={() => setIsOpen(!isOpen)}
+        onClick={() => (isOpen ? setIsOpen(false) : openPanel())}
         className="calendar-month-year-button"
         aria-label="Select month and year"
         aria-expanded={isOpen}
+        type="button"
       >
         {format(value, 'MMMM yyyy', { locale })}
         <ChevronDown className="h-4 w-4 opacity-50" />
       </button>
-      
+
       {isOpen && (
-        <div 
-          className="calendar-month-year-dropdown"
-          onWheel={(e) => {
-            e.currentTarget.scrollBy({
-              top: e.deltaY,
-              behavior: 'smooth'
-            });
-            e.stopPropagation();
-          }}
-        >
-          {options.map((date) => (
+        <div className="calendar-month-year-dropdown">
+          <div className="calendar-month-year-yearnav">
             <button
-              key={date.toISOString()}
-              onClick={() => handleSelect(date)}
-              className={cn(
-                'calendar-month-year-option',
-                date.getMonth() === value.getMonth() && date.getFullYear() === value.getFullYear() && 'selected'
-              )}
+              onClick={() => setPanelYear((year) => year - 1)}
+              className="rdp-nav_button"
+              aria-label="Previous year"
+              disabled={!canGoToPreviousYear}
+              type="button"
             >
-              {format(date, 'MMMM yyyy', { locale })}
+              <ChevronLeft className="h-4 w-4" />
             </button>
-          ))}
+            <span className="calendar-month-year-yearlabel">{panelYear}</span>
+            <button
+              onClick={() => setPanelYear((year) => year + 1)}
+              className="rdp-nav_button"
+              aria-label="Next year"
+              disabled={!canGoToNextYear}
+              type="button"
+            >
+              <ChevronRight className="h-4 w-4" />
+            </button>
+          </div>
+          <div className="calendar-month-year-grid">
+            {months.map((month) => (
+              <button
+                key={month.toISOString()}
+                onClick={() => handleSelect(month)}
+                disabled={!isMonthAllowed(month)}
+                type="button"
+                className={cn(
+                  'calendar-month-year-option',
+                  month.getMonth() === value.getMonth() &&
+                    month.getFullYear() === value.getFullYear() &&
+                    'selected'
+                )}
+              >
+                {format(month, 'LLL', { locale })}
+              </button>
+            ))}
+          </div>
         </div>
       )}
     </div>
@@ -111,8 +158,21 @@ function Calendar({
   const i18n = useOptionalI18n();
   const dateFnsLocale = getDateFnsLocale(i18n?.locale ?? LOCALE_CONFIG.defaultLocale);
   const [monthYear, setMonthYear] = React.useState<Date>(selected || new Date());
-  const fromDate = props.fromDate || new Date(new Date().getFullYear(), new Date().getMonth(), 1);
   const today = React.useMemo(() => normalizeDate(new Date()), []);
+  const minMonth = React.useMemo(
+    () =>
+      props.fromDate
+        ? new Date(props.fromDate.getFullYear(), props.fromDate.getMonth(), 1)
+        : new Date(today.getFullYear() - 10, 0, 1),
+    [props.fromDate, today]
+  );
+  const maxMonth = React.useMemo(
+    () =>
+      props.toDate
+        ? new Date(props.toDate.getFullYear(), props.toDate.getMonth(), 1)
+        : new Date(today.getFullYear() + 10, 11, 1),
+    [props.toDate, today]
+  );
   const normalizedFromDate = React.useMemo(
     () => (props.fromDate ? normalizeDate(props.fromDate) : undefined),
     [props.fromDate]
@@ -143,15 +203,12 @@ function Calendar({
     onSelect?.(today);
   };
 
-  const handlePreviousMonth = () => {
-    const newDate = new Date(monthYear.getFullYear(), monthYear.getMonth() - 1, 1);
-    setMonthYear(newDate);
-  };
+  const previousMonth = new Date(monthYear.getFullYear(), monthYear.getMonth() - 1, 1);
+  const nextMonth = new Date(monthYear.getFullYear(), monthYear.getMonth() + 1, 1);
 
-  const handleNextMonth = () => {
-    const newDate = new Date(monthYear.getFullYear(), monthYear.getMonth() + 1, 1);
-    setMonthYear(newDate);
-  };
+  const handlePreviousMonth = () => setMonthYear(previousMonth);
+
+  const handleNextMonth = () => setMonthYear(nextMonth);
 
   return (
     <div className="calendar-container">
@@ -159,7 +216,8 @@ function Calendar({
         <MonthYearSelect
           value={monthYear}
           onChange={setMonthYear}
-          fromDate={fromDate}
+          minMonth={minMonth}
+          maxMonth={maxMonth}
           locale={dateFnsLocale}
         />
         <div className="rdp-nav">
@@ -167,6 +225,7 @@ function Calendar({
             onClick={handlePreviousMonth}
             className="rdp-nav_button"
             aria-label="Previous month"
+            disabled={previousMonth.getTime() < minMonth.getTime()}
             type="button"
           >
             <ChevronLeft className="h-4 w-4" />
@@ -175,6 +234,7 @@ function Calendar({
             onClick={handleNextMonth}
             className="rdp-nav_button"
             aria-label="Next month"
+            disabled={nextMonth.getTime() > maxMonth.getTime()}
             type="button"
           >
             <ChevronRight className="h-4 w-4" />
@@ -188,7 +248,9 @@ function Calendar({
         className={cn('rdp', className)}
         classNames={{
           ...classNames,
-          caption: 'rdp-caption-hidden',
+          // v9 renamed `caption`; without the current key the month title
+          // rendered a second time under our own caption row.
+          month_caption: 'rdp-caption-hidden',
           nav: 'rdp-nav-hidden'
         }}
         mode="single"

--- a/packages/ui/src/styles/calendar.css
+++ b/packages/ui/src/styles/calendar.css
@@ -313,50 +313,54 @@ button[aria-selected="true"].rdp-day {
   left: 0;
   z-index: 50;
   margin-top: 0.25rem;
-  min-width: 12rem;
-  max-height: 15rem;
-  overflow-y: auto;
-  overflow-x: hidden;
+  width: 14rem;
+  padding: 0.5rem;
   background: rgb(var(--color-card));
   border: 1px solid rgb(var(--color-border-200));
   border-radius: 0.375rem;
   box-shadow: 0 10px 15px -3px rgb(0 0 0 / 0.1);
-  scrollbar-width: thin;
-  scrollbar-color: rgb(var(--color-border-300)) transparent;
 }
 
-.calendar-month-year-dropdown::-webkit-scrollbar {
-  width: 6px;
+.calendar-month-year-yearnav {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  margin-bottom: 0.5rem;
 }
 
-.calendar-month-year-dropdown::-webkit-scrollbar-track {
-  background: transparent;
+.calendar-month-year-yearlabel {
+  font-size: 0.875rem;
+  font-weight: 600;
+  color: rgb(var(--color-text-900));
 }
 
-.calendar-month-year-dropdown::-webkit-scrollbar-thumb {
-  background-color: rgb(var(--color-border-300));
-  border-radius: 3px;
-}
-
-.calendar-month-year-dropdown::-webkit-scrollbar-thumb:hover {
-  background-color: rgb(var(--color-border-400));
+.calendar-month-year-grid {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 0.25rem;
 }
 
 .calendar-month-year-option {
   display: block;
   width: 100%;
-  padding: 0.5rem 0.75rem;
-  text-align: left;
+  padding: 0.5rem 0.25rem;
+  text-align: center;
   font-size: 0.875rem;
   color: rgb(var(--color-text-900));
   background: transparent;
   border: none;
+  border-radius: 0.375rem;
   cursor: pointer;
   transition: background-color 0.15s;
 }
 
-.calendar-month-year-option:hover {
+.calendar-month-year-option:hover:not(:disabled) {
   background-color: var(--calendar-hover-bg);
+}
+
+.calendar-month-year-option:disabled {
+  color: var(--calendar-text-disabled);
+  cursor: not-allowed;
 }
 
 .calendar-month-year-option.selected {


### PR DESCRIPTION
## Summary
The Calendar's month/year picker only ever generated a forward-scrolling list of 120 months starting at `fromDate` (or the current month), so there was no way to select a month in the past. This replaces that one-directional list with a year stepper plus a 12-month grid that can move in either direction, and clamps navigation (both the month grid and the prev/next month arrows) to the calendar's actual allowed range instead of a hardcoded forward window. Also picked up a couple of related fixes surfaced while touching this component: click-outside/Escape handling for the month/year dropdown, and a `react-day-picker` v9 classNames key rename that was causing the month caption to render twice.

## Changes
- **Calendar.tsx**
  - Replaced the forward-only, 120-entry month list in `MonthYearSelect` with a year-stepper header (`Previous year` / `Next year`) and a 12-month grid for the selected year, so users can navigate to any month before or after the current one.
  - Derived `minMonth`/`maxMonth` bounds from `fromDate`/`toDate` (defaulting to ±10 years from today) and used them to disable out-of-range months in the grid, the year-stepper buttons, and the header's prev/next month arrows.
  - Added click-outside and Escape-key handling to close the month/year dropdown, scoped so Escape doesn't bubble to a surrounding dialog/popover.
  - Updated the `classNames` override from `caption` to `month_caption` to match `react-day-picker` v9's API, fixing a duplicated month title.
- **calendar.css**
  - Reworked `.calendar-month-year-dropdown` from a scrollable single-column list to a fixed-width panel containing the new year-nav row and a 3-column month grid; removed the now-unused scrollbar styling.
  - Added disabled-state styling for out-of-range month options.
- **Calendar.test.tsx**
  - Added coverage for navigating to an earlier month/year via the picker, for disabling months and the "Previous year" control outside `fromDate`/`toDate` bounds, and for the month caption rendering exactly once.

## Testing
- `npx vitest run src/components/Calendar.test.tsx` (from `packages/ui`) — 5/5 tests passed, including the 3 new cases.
