### PR TITLE
fix(schedule): keep entry end after start

### DIFF
--- a/packages/scheduling/src/components/schedule/EntryPopup.tsx
+++ b/packages/scheduling/src/components/schedule/EntryPopup.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import React, { useState, useEffect } from 'react';
+import React, { useState, useEffect, useMemo, useRef } from 'react';
 import { Dialog } from '@alga-psa/ui/components/Dialog';
 import { Button } from '@alga-psa/ui/components/Button';
 import { Input } from '@alga-psa/ui/components/Input';
@@ -45,6 +45,15 @@ const EntryPopupContext = React.createContext<EntryPopupProps | null>(null);
 
 function isReturnedActionError(value: unknown): value is { actionError: string } | { permissionError: string } {
   return isActionMessageError(value) || isActionPermissionError(value);
+}
+
+const DEFAULT_ENTRY_DURATION_MS = 60 * 60 * 1000;
+
+function durationBetween(start: Date | string, end: Date | string): number {
+  const from = new Date(start).getTime();
+  const to = new Date(end).getTime();
+  if (isNaN(from) || isNaN(to) || to <= from) return DEFAULT_ENTRY_DURATION_MS;
+  return to - from;
 }
 
 interface EntryPopupProps {
@@ -159,6 +168,21 @@ const EntryPopup: React.FC<EntryPopupProps> = ({
   const [isProcessing, setIsProcessing] = useState(false);
   const { t } = useTranslation('msp/schedule');
   const { formatDate } = useFormatters();
+
+  const endsBeforeStart = useMemo(() => {
+    const start = new Date(entryData.scheduled_start);
+    const end = new Date(entryData.scheduled_end);
+    return !isNaN(start.getTime()) && !isNaN(end.getTime()) && end <= start;
+  }, [entryData.scheduled_start, entryData.scheduled_end]);
+
+  // The length the user actually asked for. Reading it back off the two fields
+  // whenever the start moves picked up half-finished picker states — building
+  // 2:35 PM out of hour/minute/period clicks passes through 2:35 AM — and baked
+  // that bogus gap into the end time. It is refreshed only when the entry loads
+  // or the end is edited outright, never from an in-flight start edit.
+  const intendedDurationRef = useRef(
+    durationBetween(entryData.scheduled_start, entryData.scheduled_end)
+  );
 
     // Determine mode and permissions
     const isEditing = !!event;
@@ -294,6 +318,7 @@ const EntryPopup: React.FC<EntryPopupProps> = ({
           assigned_user_ids: event.assigned_user_ids,
           work_item_id: event.work_item_id,
         });
+        intendedDurationRef.current = durationBetween(event.scheduled_start, event.scheduled_end);
 
         // Load recurrence pattern if it exists
         if (event.recurrence_pattern) {
@@ -332,6 +357,7 @@ const EntryPopup: React.FC<EntryPopupProps> = ({
           work_item_type: initialWorkItem?.type ?? 'ad_hoc',
           assigned_user_ids: slot.assigned_user_ids || (focusedTechnicianId ? [focusedTechnicianId] : [currentUserId]),
         });
+        intendedDurationRef.current = durationBetween(slot.start, slot.end);
         if (initialWorkItem) {
           setSelectedWorkItem(initialWorkItem);
         }
@@ -1261,9 +1287,15 @@ const EntryPopup: React.FC<EntryPopupProps> = ({
                 id="scheduled_start"
                 value={entryData.scheduled_start}
                 onChange={(date) => {
+                  // Moving the start used to leave an appointment that finishes
+                  // before it begins. The end now rides along at the length the
+                  // user asked for, which also makes the result independent of
+                  // the order the hour/minute/period buttons were clicked in.
+                  if (isNaN(date.getTime())) return;
                   setEntryData(prev => ({
                     ...prev,
-                    scheduled_start: date
+                    scheduled_start: date,
+                    scheduled_end: new Date(date.getTime() + intendedDurationRef.current)
                   }));
                 }}
                 className="mt-1"
@@ -1278,6 +1310,12 @@ const EntryPopup: React.FC<EntryPopupProps> = ({
                 id="scheduled_end"
                 value={entryData.scheduled_end}
                 onChange={(date) => {
+                  // Editing the end outright is the only thing that redefines
+                  // how long the entry is meant to be; an end that lands before
+                  // the start is flagged inline instead of poisoning the length.
+                  if (!isNaN(date.getTime()) && date > new Date(entryData.scheduled_start)) {
+                    intendedDurationRef.current = durationBetween(entryData.scheduled_start, date);
+                  }
                   setEntryData(prev => ({
                     ...prev,
                     scheduled_end: date
@@ -1289,6 +1327,18 @@ const EntryPopup: React.FC<EntryPopupProps> = ({
               />
             </div>
           </div>
+          {/* Always rendered: letting this line appear and disappear resized the
+              dialog under an open time popover, moving the rows mid-click. */}
+          <p
+            id="schedule-time-hint"
+            className={`min-h-[1.25rem] text-sm ${endsBeforeStart ? 'text-red-500' : 'text-gray-500'}`}
+          >
+            {endsBeforeStart
+              ? t('entryPopup.validation.endAfterStart', {
+                  defaultValue: 'End date must be after start date',
+                })
+              : ''}
+          </p>
           <div>
             <label htmlFor="notes" className="block text-sm font-medium text-gray-700">
               {t('entryPopup.fields.notes', { defaultValue: 'Notes' })}

--- a/packages/scheduling/tests/entryPopup.startEndSync.test.tsx
+++ b/packages/scheduling/tests/entryPopup.startEndSync.test.tsx
@@ -1,0 +1,291 @@
+/**
+ * @vitest-environment jsdom
+ */
+import React from 'react';
+import { fireEvent, render, screen } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import EntryPopup from '../src/components/schedule/EntryPopup';
+
+/**
+ * Moving Start past End left an appointment that finished before it began, and
+ * the dialog said nothing until submit — so the end time had to be re-picked
+ * from scratch every time. Start now drags the end along, and the mismatch is
+ * called out inline.
+ */
+
+const {
+  getTeamsMeetingCapability,
+  getAppointmentRequestById,
+  approveAppointmentRequest,
+  declineAppointmentRequest,
+  getWorkItemById,
+  getUserAvatarUrlsBatchAction,
+} = vi.hoisted(() => ({
+  getTeamsMeetingCapability: vi.fn(),
+  getAppointmentRequestById: vi.fn(),
+  approveAppointmentRequest: vi.fn(),
+  declineAppointmentRequest: vi.fn(),
+  getWorkItemById: vi.fn(),
+  getUserAvatarUrlsBatchAction: vi.fn(),
+}));
+
+vi.mock('@alga-psa/scheduling/actions', () => ({
+  approveAppointmentRequest,
+  declineAppointmentRequest,
+  getTeamsMeetingCapability,
+  getAppointmentRequestById,
+  getWorkItemById,
+}));
+
+vi.mock('@alga-psa/user-composition/actions', () => ({
+  getUserAvatarUrlsBatchAction,
+}));
+
+vi.mock('@alga-psa/ui/lib/i18n/client', () => ({
+  useTranslation: () => ({
+    t: (key: string, options?: string | Record<string, any>) => {
+      if (typeof options === 'string') return options;
+      const template = options?.defaultValue ?? key;
+      return template.replace(/\{\{(\w+)\}\}/g, (_match: string, name: string) =>
+        String(options?.[name] ?? ''),
+      );
+    },
+  }),
+  useFormatters: () => ({
+    formatDate: (value: Date | string) =>
+      new Date(value).toISOString().slice(11, 16),
+  }),
+}));
+
+vi.mock('react-hot-toast', () => ({
+  default: {
+    success: vi.fn(),
+    error: vi.fn(),
+  },
+}));
+
+vi.mock('@alga-psa/ui/lib/errorHandling', () => ({
+  handleError: vi.fn(),
+  getErrorMessage: (value: unknown) => String(value),
+  isActionMessageError: () => false,
+  isActionPermissionError: () => false,
+}));
+
+vi.mock('@alga-psa/ui/components/Dialog', () => ({
+  Dialog: ({ children }: any) => <div>{children}</div>,
+}));
+
+vi.mock('@alga-psa/ui/components/Button', () => ({
+  Button: ({ children, onClick, ...props }: any) => (
+    <button onClick={onClick} {...props}>
+      {children}
+    </button>
+  ),
+}));
+
+vi.mock('@alga-psa/ui/components/Input', () => ({
+  Input: (props: any) => <input {...props} />,
+}));
+
+vi.mock('@alga-psa/ui/components/DatePicker', () => ({
+  DatePicker: (props: any) => <input type="date" {...props} />,
+}));
+
+vi.mock('@alga-psa/ui/components/TextArea', () => ({
+  TextArea: (props: any) => <textarea {...props} />,
+}));
+
+vi.mock('@alga-psa/ui/components/Switch', () => ({
+  Switch: ({ id, checked, onCheckedChange, label }: any) => (
+    <label htmlFor={id}>
+      {label}
+      <input
+        id={id}
+        type="checkbox"
+        checked={checked}
+        onChange={(event) => onCheckedChange(event.target.checked)}
+      />
+    </label>
+  ),
+}));
+
+vi.mock('@alga-psa/ui/components/Alert', () => ({
+  Alert: ({ children }: any) => <div>{children}</div>,
+  AlertDescription: ({ children }: any) => <div>{children}</div>,
+}));
+
+vi.mock('@alga-psa/ui', () => ({
+  useDrawer: () => ({ openDrawer: vi.fn() }),
+  DeleteEntityDialog: () => null,
+}));
+
+vi.mock('@alga-psa/scheduling/components/time-management/time-entry/time-sheet/WorkItemDrawer', () => ({
+  WorkItemDrawer: () => null,
+}));
+
+vi.mock('@alga-psa/scheduling/components/time-management/time-entry/time-sheet/AddWorkItemDialog', () => ({
+  AddWorkItemDialog: () => null,
+}));
+
+vi.mock('@alga-psa/ui/components/CustomSelect', () => ({
+  default: ({ id, options = [], value, onValueChange }: any) => (
+    <select id={id} value={value} onChange={(event) => onValueChange(event.target.value)}>
+      {options.map((option: any) => (
+        <option key={option.value} value={option.value}>
+          {option.label}
+        </option>
+      ))}
+    </select>
+  ),
+}));
+
+vi.mock('@alga-psa/ui/components/UserPicker', () => ({
+  default: ({ id }: any) => <select id={id} />,
+}));
+
+vi.mock('@alga-psa/scheduling/components/time-management/time-entry/time-sheet/SelectedWorkItem', () => ({
+  default: () => null,
+}));
+
+vi.mock('@alga-psa/ui/components/DateTimePicker', () => ({
+  DateTimePicker: ({ id, value, onChange, disabled }: any) => (
+    <input
+      id={id}
+      data-testid={id}
+      type="text"
+      disabled={disabled}
+      value={value ? new Date(value).toISOString() : ''}
+      onChange={(event) => onChange(new Date(event.target.value))}
+    />
+  ),
+}));
+
+vi.mock('@alga-psa/ui/components/ConfirmationDialog', () => ({
+  ConfirmationDialog: () => null,
+}));
+
+vi.mock('@alga-psa/ui/components/Label', () => ({
+  Label: ({ children }: any) => <label>{children}</label>,
+}));
+
+vi.mock('@alga-psa/auth/lib/preCheckDeletion', () => ({
+  preCheckDeletion: vi.fn(),
+}));
+
+const slot = {
+  start: new Date('2026-08-12T14:00:00.000Z'),
+  end: new Date('2026-08-12T14:15:00.000Z'),
+};
+
+// An hour-long entry, the shape you get by dragging out a default slot. The
+// picker commits on every hour/minute/period click, so reaching 14:35 from here
+// walks through intermediate times that must not redefine how long it is.
+const hourLongSlot = {
+  start: new Date('2026-08-12T10:15:00.000Z'),
+  end: new Date('2026-08-12T11:15:00.000Z'),
+};
+
+const END_AFTER_START = 'End date must be after start date';
+
+const renderPopup = (activeSlot: typeof slot = slot, onSave = vi.fn()) => ({
+  onSave,
+  ...render(
+    <EntryPopup
+      event={null}
+      slot={activeSlot}
+      onClose={vi.fn()}
+      onSave={onSave}
+      canAssignMultipleAgents={false}
+      users={[] as any}
+      currentUserId="tech-1"
+      canModifySchedule={true}
+      focusedTechnicianId={null}
+      canAssignOthers={true}
+    />
+  ),
+});
+
+const setPicker = (testId: string, iso: string) => {
+  fireEvent.change(screen.getByTestId(testId), { target: { value: iso } });
+};
+
+describe('EntryPopup start/end synchronisation', () => {
+  beforeEach(() => {
+    getTeamsMeetingCapability.mockResolvedValue({ available: false });
+    getAppointmentRequestById.mockResolvedValue({ success: false });
+    getWorkItemById.mockResolvedValue(null);
+    getUserAvatarUrlsBatchAction.mockResolvedValue({});
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('shifts the end forward, keeping the duration, when the start passes it', () => {
+    renderPopup();
+
+    setPicker('scheduled_start', '2026-08-12T14:35:00.000Z');
+
+    expect((screen.getByTestId('scheduled_end') as HTMLInputElement).value)
+      .toBe('2026-08-12T14:50:00.000Z');
+    expect(screen.queryByText(END_AFTER_START)).toBeNull();
+  });
+
+  it('warns inline while the end is not after the start, without waiting for submit', () => {
+    renderPopup();
+
+    setPicker('scheduled_end', '2026-08-12T13:45:00.000Z');
+
+    expect(screen.getByText(END_AFTER_START)).toBeTruthy();
+
+    setPicker('scheduled_end', '2026-08-12T15:20:00.000Z');
+
+    expect(screen.queryByText(END_AFTER_START)).toBeNull();
+  });
+
+  // Deriving the duration from whatever the fields happened to show meant the
+  // half-built times the hour/minute/period buttons pass through — 02:35 on the
+  // way to 14:35 — were read as the intended length, and the end landed hours
+  // out.
+  it.each([
+    ['hour, minute, then period', ['02:15', '02:35', '14:35']],
+    ['period, hour, then minute', ['22:15', '14:15', '14:35']],
+  ])('keeps the hour-long duration when the start is built %s', (_name, steps) => {
+    renderPopup(hourLongSlot);
+
+    for (const time of steps) {
+      setPicker('scheduled_start', `2026-08-12T${time}:00.000Z`);
+    }
+
+    expect((screen.getByTestId('scheduled_end') as HTMLInputElement).value)
+      .toBe('2026-08-12T15:35:00.000Z');
+    expect(screen.queryByText(END_AFTER_START)).toBeNull();
+  });
+
+  it('adopts a new duration once the end itself is edited', () => {
+    renderPopup(hourLongSlot);
+
+    setPicker('scheduled_end', '2026-08-12T12:45:00.000Z');
+    setPicker('scheduled_start', '2026-08-12T14:35:00.000Z');
+
+    // Two and a half hours, as the edited end asked for — not the original one.
+    expect((screen.getByTestId('scheduled_end') as HTMLInputElement).value)
+      .toBe('2026-08-12T17:05:00.000Z');
+  });
+
+  it('refuses to save an entry that ends before it starts', () => {
+    const { onSave, container } = renderPopup();
+
+    fireEvent.change(container.querySelector('#title') as HTMLInputElement, {
+      target: { name: 'title', value: 'Onsite visit' },
+    });
+    setPicker('scheduled_end', '2026-08-12T13:45:00.000Z');
+    fireEvent.submit(container.querySelector('form') as HTMLFormElement);
+
+    expect(onSave).not.toHaveBeenCalled();
+    expect(screen.getByText('Please fill in the required fields:')).toBeTruthy();
+    // Once inline under the pickers, once in the submit summary.
+    expect(screen.getAllByText(END_AFTER_START)).toHaveLength(2);
+  });
+});


### PR DESCRIPTION
## Summary
In the schedule entry dialog, dragging the Start time past the End time silently produced an invalid entry (end before start) with no feedback until submit, and the End picker didn't move to compensate — forcing users to re-pick it by hand. This change makes End follow Start, preserving the entry's original duration, and surfaces inline validation whenever End is edited to land before Start.

## Changes
### `EntryPopup` (`packages/scheduling/src/components/schedule/EntryPopup.tsx`)
- Track the entry's intended duration in a ref, captured when the entry loads (existing event or new slot) and refreshed only when the End field is edited directly — never re-derived from momentary Start-picker states, so intermediate clicks (e.g. passing through 2:35 AM while building 2:35 PM) can't corrupt it. Falls back to a 1-hour default if the loaded times are invalid or non-positive.
- When Start changes, shift End by the tracked duration so the entry keeps its original length regardless of which order the hour/minute/period controls are clicked.
- When End is edited and lands after Start, adopt the new gap as the intended duration; if it lands at or before Start, leave the duration untouched and flag the entry invalid.
- Add an always-rendered inline hint (reusing the existing `endAfterStart` translation string) below the Start/End pickers, so its appearance/disappearance doesn't resize the dialog under an open time popover.

### Tests (`packages/scheduling/tests/entryPopup.startEndSync.test.tsx`)
- New suite covering: End shifting forward with Start while preserving duration; the inline warning appearing and clearing as End is edited; duration staying stable across multi-step Start edits that pass through intermediate build-up times; adopting a newly edited End as the new intended duration; and submit being blocked (inline + summary error) when End is before Start.

## Testing
- Reviewed the diff and the new test suite (`entryPopup.startEndSync.test.tsx`, jsdom environment), which exercises the sync and validation logic described above via 6 scenarios.
