### PR TITLE
Fix image-only comment visibility and clipped selection ring in grid-view

### DIFF
--- a/packages/tickets/src/components/ticket/CommentItem.tsx
+++ b/packages/tickets/src/components/ticket/CommentItem.tsx
@@ -553,10 +553,11 @@ const CommentItem: React.FC<CommentItemProps> = ({
                   {...withDataAutomationId({ id: `${commentId}-content` })}
                   className={`prose max-w-none w-full min-w-0 overflow-hidden break-words ${
                     isCompact
-                      ? // Compact: drop the editor's side-menu horizontal padding, and hide
-                        // BlockNote's always-appended trailing empty block (identified by its
-                        // ProseMirror trailing break) so a one-line comment reads as one line.
-                        'prose-sm mt-0.5 text-sm leading-snug [&_.bn-editor]:!px-0 [&_.bn-block-outer:last-child:has(br.ProseMirror-trailingBreak)]:hidden'
+                      ? // Compact: shrink the editor's side-menu horizontal padding to the 4px
+                        // node-selection ring width (offset by -mx-1 so text keeps its x), and
+                        // hide BlockNote's always-appended trailing empty block (identified by
+                        // its ProseMirror trailing break) so a one-line comment reads as one line.
+                        'prose-sm mt-0.5 -mx-1 text-sm leading-snug [&_.bn-editor]:!px-1 [&_.bn-block-outer:last-child:has(br.ProseMirror-trailingBreak)]:hidden'
                       : 'mt-1'
                   }`}
                   style={{ overflowWrap: 'anywhere' }}

--- a/packages/tickets/src/lib/commentNoise.test.ts
+++ b/packages/tickets/src/lib/commentNoise.test.ts
@@ -1,0 +1,111 @@
+import { describe, expect, it } from 'vitest';
+
+import { filterHiddenNoiseComments, isHiddenNoiseComment } from './commentNoise';
+
+const comment = (note: string | null, overrides: Record<string, unknown> = {}): any => ({
+  comment_id: 'comment-1',
+  note,
+  ...overrides,
+});
+
+const imageBlock = (url: string) => ({
+  id: 'block-1',
+  type: 'image',
+  props: {
+    textAlignment: 'left',
+    backgroundColor: 'default',
+    name: 'image.png',
+    url,
+    caption: '',
+    showPreview: true,
+  },
+  children: [],
+});
+
+const paragraphBlock = (text: string) => ({
+  id: 'block-0',
+  type: 'paragraph',
+  props: { backgroundColor: 'default', textColor: 'default', textAlignment: 'left' },
+  content: [{ type: 'text', text, styles: {} }],
+  children: [],
+});
+
+describe('isHiddenNoiseComment', () => {
+  it('keeps an image-only comment visible', () => {
+    const note = JSON.stringify([imageBlock('/api/documents/view/file-123')]);
+    expect(isHiddenNoiseComment(comment(note))).toBe(false);
+  });
+
+  it('keeps a media-only comment visible for every media block type', () => {
+    for (const type of ['image', 'video', 'audio', 'file']) {
+      const note = JSON.stringify([{ type, props: { url: '/api/documents/view/file-1' }, children: [] }]);
+      expect(isHiddenNoiseComment(comment(note))).toBe(false);
+    }
+  });
+
+  it('keeps an image nested in a block child visible', () => {
+    const note = JSON.stringify([
+      { id: 'b', type: 'paragraph', props: {}, content: [], children: [imageBlock('/api/documents/view/file-9')] },
+    ]);
+    expect(isHiddenNoiseComment(comment(note))).toBe(false);
+  });
+
+  it('keeps a comment mixing text and an image visible', () => {
+    const note = JSON.stringify([paragraphBlock('hello?'), imageBlock('/api/documents/view/file-2')]);
+    expect(isHiddenNoiseComment(comment(note))).toBe(false);
+  });
+
+  it('hides a truly empty comment', () => {
+    expect(isHiddenNoiseComment(comment(JSON.stringify([paragraphBlock('   ')])))).toBe(true);
+    expect(isHiddenNoiseComment(comment(''))).toBe(true);
+    expect(isHiddenNoiseComment(comment(null))).toBe(true);
+  });
+
+  it('hides an empty media block that carries neither url nor name', () => {
+    const note = JSON.stringify([{ type: 'image', props: { caption: '' }, children: [] }]);
+    expect(isHiddenNoiseComment(comment(note))).toBe(true);
+  });
+
+  it('still hides reply-token-only comments', () => {
+    const note = JSON.stringify([paragraphBlock('[ALGA-REPLY-TOKEN abc-123 ticketId=TICKET-1]')]);
+    expect(isHiddenNoiseComment(comment(note))).toBe(true);
+    expect(isHiddenNoiseComment(comment('[ALGA-REPLY-TOKEN abc-123 ticketId=TICKET-1]'))).toBe(true);
+  });
+
+  it('still hides a reply-token-only comment that carried an image', () => {
+    const note = JSON.stringify([
+      paragraphBlock('[ALGA-REPLY-TOKEN abc-123 ticketId=TICKET-1]'),
+      imageBlock('https://tracker.test/pixel.gif'),
+    ]);
+    expect(isHiddenNoiseComment(comment(note))).toBe(true);
+  });
+
+  it('keeps plain-text (non-JSON) comments visible', () => {
+    expect(isHiddenNoiseComment(comment('a plain note'))).toBe(false);
+  });
+});
+
+describe('filterHiddenNoiseComments', () => {
+  it('retains image-only comments in the rendered list', () => {
+    const imageOnly = comment(JSON.stringify([imageBlock('/api/documents/view/file-1')]), {
+      comment_id: 'image-only',
+    });
+    const empty = comment(JSON.stringify([paragraphBlock('')]), { comment_id: 'empty' });
+
+    const result = filterHiddenNoiseComments([imageOnly, empty]);
+
+    expect(result.map((c) => c.comment_id)).toEqual(['image-only']);
+  });
+
+  it('keeps a hidden noise comment that still has descendants', () => {
+    const parent = comment(JSON.stringify([paragraphBlock('')]), { comment_id: 'parent' });
+    const child = comment(JSON.stringify([paragraphBlock('reply')]), {
+      comment_id: 'child',
+      parent_comment_id: 'parent',
+    });
+
+    const result = filterHiddenNoiseComments([parent, child]);
+
+    expect(result.map((c) => c.comment_id)).toEqual(['parent', 'child']);
+  });
+});

--- a/packages/tickets/src/lib/commentNoise.ts
+++ b/packages/tickets/src/lib/commentNoise.ts
@@ -6,6 +6,10 @@ import type { IComment } from '@alga-psa/types';
 // suppresses the noise in the conversation/timeline views.
 const REPLY_TOKEN_ONLY_REGEX = /^\s*\[ALGA-REPLY-TOKEN [^\]]+\]\s*$/;
 
+// Mirrors TextEditor's MEDIA_BLOCK_TYPES: blocks that carry content in props
+// rather than in text nodes, so a textless comment can still be real content.
+const MEDIA_BLOCK_TYPES = new Set(['image', 'video', 'audio', 'file']);
+
 function collectBlockNoteText(node: unknown): string {
   if (typeof node === 'string') return node;
   if (Array.isArray(node)) {
@@ -25,19 +29,40 @@ function collectBlockNoteText(node: unknown): string {
   return '';
 }
 
-function extractCommentText(note: string | undefined | null): string {
-  if (!note) return '';
-  try {
-    return collectBlockNoteText(JSON.parse(note)).trim();
-  } catch {
-    return note.trim();
+function hasMediaBlock(node: unknown): boolean {
+  if (Array.isArray(node)) return node.some(hasMediaBlock);
+  if (node && typeof node === 'object') {
+    const obj = node as Record<string, unknown>;
+    if (typeof obj.type === 'string' && MEDIA_BLOCK_TYPES.has(obj.type)) {
+      const props = obj.props as Record<string, unknown> | undefined;
+      if (props?.url || props?.name) return true;
+    }
+    if (hasMediaBlock(obj.content)) return true;
+    if (hasMediaBlock(obj.children)) return true;
   }
+  return false;
+}
+
+function readCommentNote(note: string | undefined | null): { text: string; hasMedia: boolean } {
+  if (!note) return { text: '', hasMedia: false };
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(note);
+  } catch {
+    return { text: note.trim(), hasMedia: false };
+  }
+  return { text: collectBlockNoteText(parsed).trim(), hasMedia: hasMediaBlock(parsed) };
 }
 
 export function isHiddenNoiseComment(comment: IComment): boolean {
-  const text = extractCommentText(comment.note);
-  if (text === '') return true;
-  return REPLY_TOKEN_ONLY_REGEX.test(text);
+  const { text, hasMedia } = readCommentNote(comment.note);
+  // Token-only inbound email stays hidden even when the mail carried images,
+  // so signature logos and tracking pixels don't resurrect the noise.
+  if (REPLY_TOKEN_ONLY_REGEX.test(text)) return true;
+  if (text !== '') return false;
+  // Textless is only noise when there is nothing to look at either: a pasted
+  // screenshot with no caption is a real comment.
+  return !hasMedia;
 }
 
 /** Drops noise comments, keeping any that have descendants so children don't orphan. */

--- a/packages/ui/src/editor/blocknote-styles.css
+++ b/packages/ui/src/editor/blocknote-styles.css
@@ -31,3 +31,15 @@
 [contenteditable="false"] .bn-block-content[data-placeholder]::after {
   content: none !important;
 }
+
+/*
+ * Draw the node-selection ring inside the selected block in read-only surfaces.
+ * BlockNote outlines a selected node (e.g. a clicked image) with a 4px outline,
+ * which paints outside the border box and is therefore clipped wherever the
+ * viewer sits in a tight/overflow-hidden wrapper — grid-view comments being the
+ * common case. Insetting the offset keeps the ring visible on all four sides.
+ */
+.bn-container [contenteditable="false"] .bn-block-content.ProseMirror-selectednode > *,
+[contenteditable="false"] .ProseMirror-selectednode > .bn-block-content > * {
+  outline-offset: -4px;
+}


### PR DESCRIPTION
## Summary
Two related fixes for how ticket comments render images in the grid/compact view: a noise-filtering bug was hiding comments that consisted solely of an image (no text), and BlockNote's image-selection outline was being clipped by the compact comment container's tight/overflow-hidden layout.

## Changes
- **Comment noise filtering** (`packages/tickets/src/lib/commentNoise.ts`): `isHiddenNoiseComment` now inspects the parsed BlockNote document for media blocks (`image`, `video`, `audio`, `file`) with a `url`/`name` prop, not just extracted text. A textless comment is only treated as noise if it also has no media — so a pasted screenshot with no caption is kept, while token-only inbound-email replies stay hidden even if the mail carried images.
- **Compact comment padding** (`packages/tickets/src/components/ticket/CommentItem.tsx`): reduced the compact editor's side-menu horizontal padding from fully removed to 4px (matching the node-selection ring width), offset with `-mx-1` so the surrounding text still aligns.
- **Selection ring clipping** (`packages/ui/src/editor/blocknote-styles.css`): added an `outline-offset: -4px` rule for `.ProseMirror-selectednode` content in read-only BlockNote surfaces so the 4px selection outline is drawn inside the block instead of outside, where it was getting clipped by tight/overflow-hidden wrappers like grid-view comments.

## Testing
- `npx vitest run src/lib/commentNoise.test.ts` in `packages/tickets` — 11/11 passing, including new cases added in `commentNoise.test.ts` covering image-only, video-only, and mixed text+media comments.
