### PR TITLE
Remove legacy EMAIL_ENABLE gate from password recovery

### DIFF
--- a/docs/plans/2026-08-14-password-recovery-email-provider-plan.md
+++ b/docs/plans/2026-08-14-password-recovery-email-provider-plan.md
@@ -1,0 +1,221 @@
+# Password recovery email-provider plan
+
+- Date: 2026-08-14
+- Workflow card: `39158668-f24a-478a-afae-e9ff8c97cbb6`
+- Status: implementation design only
+
+## Outcome
+
+MSP and client-portal password recovery will use one enumeration-safe request path. Once that path finds an active user of the requested portal type, it will always attempt the provider-aware password-reset sender. An enabled tenant SMTP, Resend, or Microsoft provider will therefore work when `EMAIL_ENABLE` is `false` or unset. System SMTP/Resend remains a fallback and remains controlled by `SystemEmailProviderFactory`, including its existing `EMAIL_ENABLE === 'true'` requirement.
+
+The public caller will receive the same success-shaped result for an invalid address, an unknown address, an inactive user, a portal-type mismatch, a provider failure, and a successful send. Internally, a real provider attempt will retain application-log diagnostics, and provider-level sends will continue to create `email_sending_logs` rows that appear in System Monitoring -> Email Log.
+
+## Problem and current code findings
+
+### The live request path is gated before provider selection
+
+- `server/src/app/auth/msp/forgot-password/page.tsx` calls `recoverPassword(email, 'msp')`.
+- `server/src/app/auth/client-portal/forgot-password/ClientPortalForgotPassword.tsx` calls `recoverPassword(email, 'client', portalDomain)`.
+- `server/src/app/auth/check-email/CheckEmailClient.tsx` calls the same action for resend.
+- `ee/server/src/app/api/billing/reactivation-password-reset/route.ts` also calls the MSP form of `recoverPassword`; its existing contract test explicitly requires the real `/auth/password-reset/set-new-password` link.
+- `packages/auth/src/actions/useRegister.tsx` maps `msp` to `users.user_type='internal'` and `client` to `users.user_type='client'`, then checks a module-level `EMAIL_ENABLE` constant before token creation or any email service call. When the flag is false or absent, the tenant provider is never consulted and no send log can exist.
+- The same lookup currently does not reject `users.is_inactive=true`, contrary to the card acceptance criteria.
+
+### There are two divergent request implementations, but only one is usable
+
+- `packages/auth/src/actions/useRegister.tsx::recoverPassword` creates the JWT consumed by the deployed `set-new-password` page. `packages/auth/src/lib/portalDomain.ts::buildPasswordResetLink` targets `/auth/password-reset/set-new-password`, preserves `portal=msp|client`, and carries `portalDomain` for client branding.
+- `packages/auth/src/actions/auth-actions/passwordResetActions.ts::requestPasswordReset` has no runtime caller in the repository. It creates a row in `password_reset_tokens` through `PasswordResetService` but builds `/auth/reset-password`, a route that does not exist.
+- `server/src/app/auth/password-reset/set-new-password/SetNewPasswordClient.tsx` verifies the JWT through `getAccountInfoFromToken` and completes it through `setNewPassword`; it does not use `verifyPasswordResetToken` or `completePasswordReset`.
+- Replacing the live action with the unused implementation without also migrating the completion screen would send unusable links. A database-token migration is a separate security/UX change and is not required to correct provider routing.
+
+### Provider selection and logging already exist below the bad gate
+
+- `server/src/lib/initializeApp.ts` registers `packages/email/src/sendPasswordResetEmail.ts` in `packages/auth/src/lib/emailRegistry.ts`, keeping the auth package independent of the email package.
+- `packages/email/src/sendPasswordResetEmail.ts` resolves recipient locale, uses the `password-reset` database template, and calls `TenantEmailService.getInstance(tenant).sendEmail(...)` with `tenantId` and `userId`.
+- `packages/email/src/TenantEmailService.ts` refreshes `tenant_email_settings` before every actual send, selects the first enabled tenant provider, and retains existing system-provider fallback behavior. A configured tenant provider does not consult `EMAIL_ENABLE`.
+- `packages/email/src/providers/EmailProviderManager.ts` initializes enabled tenant SMTP/Resend/Microsoft settings first. Its fallback calls `SystemEmailProviderFactory` when no enabled tenant provider is available.
+- `packages/email/src/system/SystemEmailProviderFactory.ts` intentionally returns no system provider unless `process.env.EMAIL_ENABLE === 'true'`. It then selects environment-backed SMTP or Resend. This is the correct boundary for the global flag and is not to be weakened.
+- `packages/email/src/BaseEmailService.ts` awaits insertion into `email_sending_logs` after a provider returns or throws. Successful sends are `status='sent'`; provider-level failures are `status='failed'` with `error_message`, provider id/type, recipient, subject, and provider metadata. `packages/email/src/actions/emailLogActions.ts` is the tenant-scoped source for the Email Log UI.
+- If provider initialization produces no provider, `BaseEmailService` returns the preserved `providerInitError` but cannot create a provider-level send row because no wire message/provider exists. That cause must remain in structured application logs; this plan does not invent a fake send record.
+- `sendPasswordResetEmail` currently makes an additional `SystemEmailService` attempt when the tenant service returns failure. If that fallback is unavailable, its generic result can obscure the more useful tenant initialization/send error in the final thrown error. The fallback itself must remain, but both attempt results must be retained diagnostically and the same system provider must not be retried redundantly.
+
+## Design decisions
+
+1. **`recoverPassword` remains the canonical request action.** It is the only request path wired to a usable completion flow and is already consumed by MSP, client portal, resend, and enterprise reactivation callers.
+2. **`requestPasswordReset` becomes a thin compatibility adapter.** Preserve its exported signature and generic `RequestResetResult`, map `internal` to `msp` and `client` to `client`, and delegate to `recoverPassword`. Remove its independent user lookup, provider preflight, token creation, branding lookup, and incorrect URL construction. Mark it deprecated in code so new callers use `recoverPassword`.
+3. **Keep the current JWT contract.** Continue using `createToken`, `buildPasswordResetLink`, `getAccountInfoFromToken`, and `setNewPassword`. Existing and newly issued links keep the current route, one-hour/default configured JWT lifetime, portal marker, and client `portalDomain` behavior.
+4. **Provider readiness is determined by the send path, not an action-level flag or preflight.** Do not read `EMAIL_ENABLE` inside password recovery and do not call `isConfigured()` before sending. A preflight would duplicate provider initialization, race settings changes, and risks reintroducing a gate before `TenantEmailService.sendEmail` can select the tenant provider.
+5. **All public request outcomes are enumeration-safe.** Normalize with `trim().toLowerCase()`. Invalid format, missing user, inactive user, wrong `user_type`, token/send failure, and success all resolve through the same public success contract. Never return provider or lookup details to the form. The UI copy and redirect remain unchanged.
+6. **Only a matched active user produces a token or send attempt.** The lookup remains keyed by normalized email plus the portal-derived user type; explicitly treat `is_inactive` as no match. Do not mint a token, call the email registry, or write an email log for non-matches.
+7. **Tenant provider first; system fallback remains intentional.** Keep the current password-reset helper's system fallback for a genuine tenant-path failure, but do not call it a second time when `TenantEmailService` already attempted the `system-email-provider`. `SystemEmailProviderFactory` continues to decide whether system SMTP/Resend is available.
+8. **Preserve the first useful failure.** Record structured diagnostics for both tenant and system attempts (tenant id, portal/user type, provider id/type when returned, and sanitized error; never the token or reset URL). If both paths fail, throw an internal error that retains both causes. `recoverPassword` logs that internal failure and returns the public success value.
+9. **Use the repository SMTP emulator for repeatable integration coverage.** `packages/emulators/smtp-sink` accepts real SMTP, exposes captured messages, and can deterministically reject mail. GreenMail remains the live/manual parity check through `docker-compose.imap-test.yaml`.
+
+## Canonical behavior
+
+The request sequence is:
+
+1. Accept `email`, `portal`, and optional `portalDomain` in `recoverPassword`.
+2. Normalize the address and derive `userType` (`msp -> internal`, `client -> client`).
+3. If the email is invalid, finish with the generic success result without a lookup or send.
+4. Look up that email and user type. If there is no row or the row is inactive, finish with the same generic success result without creating a token.
+5. Create the existing JWT with the normalized email and matched `user_type`.
+6. Build the existing `/auth/password-reset/set-new-password` link with `portal` and, for client requests, `portalDomain`.
+7. Invoke the registered `sendPasswordResetEmail` implementation with the matched tenant and user display/branding fields.
+8. The email helper attempts `TenantEmailService`, which reads current tenant settings and selects the enabled tenant provider without regard to `EMAIL_ENABLE`.
+9. On tenant-path failure, retain that result and use the existing system fallback only if it is a distinct attempt. The factory may permit system SMTP/Resend only when `EMAIL_ENABLE=true`.
+10. Log all internal failures with sanitized structured context. Return the same public success value in every case.
+
+This preserves the current UI contract (`Promise<boolean>` with `true` as the public success-shaped value). The compatibility `requestPasswordReset` adapter converts that completion into its existing generic message object and never exposes whether a send happened.
+
+## Ordered implementation changes
+
+### 1. Make the live action provider-aware and fully enumeration-safe
+
+File: `packages/auth/src/actions/useRegister.tsx`
+
+- Leave the module-level `EMAIL_ENABLE` constant in place for the separate registration/verification behavior at the bottom of the file; remove only its use around password recovery.
+- Normalize the incoming address once and use the normalized value for validation, lookup, token payload, recipient, and logging context.
+- Keep the portal-to-user-type mapping and current `User.findUserByEmailAndType` lookup, but return the generic success result when `userInfo.is_inactive` is true as well as when no row exists.
+- Move token generation, link building, and registry send directly after the active-match guard, with no environment or provider-configuration precheck.
+- Wrap lookup/token/send failures at the public action boundary. Log a stable event such as `password_recovery_send_failed` with portal/user type, matched tenant when known, and the sanitized error. Do not log the JWT or full reset URL.
+- Always return `true` to the public caller. A provider failure is observable to operators through logs and Email Log, not to an unauthenticated requester.
+- Retain `portalDomain` only as a link/branding parameter. Do not trust it as authorization or use it to override the tenant discovered from the user.
+
+### 2. Eliminate the divergent request implementation
+
+File: `packages/auth/src/actions/auth-actions/passwordResetActions.ts`
+
+- Import the canonical `recoverPassword` action.
+- Replace only `requestPasswordReset` with a deprecated adapter that maps its `userType` parameter to the canonical portal parameter and returns the existing generic `RequestResetResult` shape.
+- Remove request-only imports, constants, console output, admin discovery query, provider `isConfigured()` checks, `PasswordResetService.createResetTokenWithTransaction` call, default-client branding lookup, transaction-scoped send, and the nonexistent `/auth/reset-password` URL.
+- Keep `verifyPasswordResetToken`, `completePasswordReset`, `getPasswordResetHistory`, and `PasswordResetService` intact for compatibility. They are not adopted by the live JWT completion flow in this change.
+- Do not alter the action barrel exports. Existing imports of either request name continue to compile, but all requests enter one implementation.
+
+### 3. Preserve fallback and failure diagnostics in the password-reset sender
+
+File: `packages/email/src/sendPasswordResetEmail.ts`
+
+- Keep locale resolution, `DatabaseTemplateProcessor('password-reset')`, template data, tenant id, user id, and reply-to behavior unchanged.
+- Capture the complete `TenantEmailService.sendEmail` result. On failure, log its provider id/type and sanitized error before considering fallback.
+- Preserve the existing `SystemEmailService` fallback, subject to `SystemEmailProviderFactory` and therefore `EMAIL_ENABLE`. Skip a second system call if the tenant service result identifies `providerId='system-email-provider'`.
+- If fallback succeeds, return success. If it fails or is unavailable, log its separate provider/error details and throw an internal error containing both tenant and fallback causes. Do not replace an actionable tenant SMTP initialization/auth/TLS error with only `Email service is disabled or not configured`.
+- Rely on `BaseEmailService` for `email_sending_logs`: a tenant or system provider attempt that reaches the provider records `sent` or `failed`; an initialization failure remains an application-log diagnostic. Do not write a parallel password-reset-specific log row, which would duplicate Email Log entries.
+
+### 4. Add real DB + real SMTP behavioral coverage
+
+New file: `server/src/test/integration/email/passwordRecoveryEmailProvider.integration.test.ts`
+
+Use the established integration-test database helpers (`server/test-utils/dbConfig.ts`, `server/test-utils/testDataFactory.ts`) and the in-process emulator pattern used by payment integration tests:
+
+- Start `EmulatorHost` with `@alga-psa/emulator-smtp-sink` on ephemeral control/SMTP ports.
+- Register the real email implementation into `registerAuthEmailProvider` exactly as application startup does: real `sendPasswordResetEmail`, `getSystemEmailService`, and `TenantEmailService.getInstance`.
+- Create a disposable tenant, active internal user, active client user, inactive internal user, and tenant email settings whose enabled SMTP provider points to the emulator. Use unique addresses and tenant-scoped cleanup.
+- Set a deterministic `NEXT_PUBLIC_BASE_URL` and token secret for link verification. Restore every environment variable and reset the auth email registry/provider singleton state after the suite. Invalidate `TenantEmailService` state after settings changes so test cases cannot share a cached provider.
+- Clear captured mail and relevant `email_sending_logs` rows between cases. Assertions must be based on SMTP state and database rows, never source strings.
+
+Required cases:
+
+1. **MSP, global email disabled:** with `EMAIL_ENABLE='false'`, call the real `recoverPassword(internalEmail, 'msp')`; assert the public result is `true`, SMTP captured exactly one message to that user, and its subject/body come from the password-reset template.
+2. **Client portal, global flag absent:** delete `EMAIL_ENABLE`, call `recoverPassword(clientEmail, 'client', 'portal.example.test')`; assert exactly one message, the same public result, and a reset link containing the existing set-new-password route, `portal=client`, and encoded `portalDomain`.
+3. **Usable links:** extract the token query parameter from each captured message, verify it with the existing tokenizer (`getInfoFromToken`), and assert the normalized email plus expected `internal|client` type. This proves the message contains a token accepted by the deployed completion flow without mutating the test user's password.
+4. **Email Log visibility:** for each happy path, query tenant-scoped `email_sending_logs` and assert exactly one `status='sent'` row with the emulator-backed tenant SMTP provider id/type and the expected recipient. This is the row consumed by System Monitoring -> Email Log.
+5. **Enumeration guards:** table-drive an invalid address, unknown address, inactive internal user, internal user requested through `client`, and client user requested through `msp`. Each returns the same `true` value and creates zero captured messages and zero new send-log rows.
+6. **Provider failure diagnostics:** arm the emulator's `reject-mail` fault, request recovery for an active matched user, and assert the public result remains `true`, SMTP captures no delivered message, and `email_sending_logs` contains a `status='failed'` row for the tenant SMTP provider whose `error_message` preserves the SMTP rejection. Also spy on the application logger to verify the diagnostic event is emitted without a token/reset URL.
+
+If Vitest package resolution requires explicit workspace dependencies, add `@alga-psa/emulator-host` and `@alga-psa/emulator-smtp-sink` as server test/dev dependencies and update the lockfile deliberately. Do not substitute a mocked `sendPasswordResetEmail`, mocked provider, or source-string assertion; those would miss the original action-to-provider regression.
+
+### 5. Protect provider-boundary behavior with focused unit coverage
+
+Files:
+
+- New or existing test beside `packages/email/src/sendPasswordResetEmail.ts` (or under `server/src/test/unit/email/` if that is the active runner boundary).
+- Existing `server/src/test/unit/emailProviderManagerFallback.unit.test.ts`.
+
+Cover the small cases that are awkward to force through SMTP integration:
+
+- Tenant success does not call the explicit system fallback.
+- Tenant failure calls a distinct system fallback once; system success is accepted.
+- A failure already returned by `system-email-provider` is not retried through `SystemEmailService`.
+- When tenant and system both fail, the thrown/logged diagnostic retains both errors, with the tenant provider cause not masked by the global system-disabled message.
+- Preserve the existing manager assertions that an enabled tenant provider wins and no-enabled-provider can use the system provider. Add a factory-focused assertion only if none exists by implementation time: `SystemEmailProviderFactory.createProvider()` returns `null` for false/unset `EMAIL_ENABLE` and may initialize from environment only for exact `'true'`.
+
+### 6. Update compatibility contracts and comments
+
+Files:
+
+- `ee/server/src/app/api/billing/reactivation-password-reset/route.ts`
+- `server/src/test/unit/billing/reactivationCore.contract.test.ts`
+
+Keep the route calling `recoverPassword(email, 'msp')` and keep its existing usable-link contract. Update only stale comments that contrast it with the now-delegating `requestPasswordReset`. Do not change the signed endpoint response or workflow behavior in this card.
+
+## Verification commands and gates
+
+Run from the repository root unless noted:
+
+1. Focused SMTP/DB integration:
+   `cd server && npx vitest run src/test/integration/email/passwordRecoveryEmailProvider.integration.test.ts --coverage.enabled=false`
+2. Focused sender/provider unit tests:
+   `cd server && npx vitest run src/test/unit/email src/test/unit/emailProviderManagerFallback.unit.test.ts --coverage.enabled=false`
+   (Use the final concrete sender-test filename rather than the directory if the suite is placed elsewhere.)
+3. Existing reactivation contract:
+   `cd server && npx vitest run src/test/unit/billing/reactivationCore.contract.test.ts --coverage.enabled=false`
+4. Auth/email package and server typechecks/build-dependency gate:
+   `npx nx build-deps server`
+   followed by `cd server && npm run typecheck`.
+5. Re-run the relevant server integration tier if focused tests touched shared email behavior. Confirm the executed-test count is nonzero and no suite was silently skipped for lack of a database.
+
+### GreenMail/manual parity check
+
+The automated emulator suite is the required regression gate. Before handoff, also exercise the same behavior against the existing GreenMail rig when available:
+
+1. Start `docker-compose.imap-test.yaml` with GreenMail SMTP (default host port `3025`), IMAP (`3143`), and HTTP API (`8080`), or use the already-wired equivalent ports.
+2. Configure the test tenant's enabled SMTP provider for GreenMail (`secure=false`, test credentials if used) while setting the application process `EMAIL_ENABLE=false` and then with it unset.
+3. Submit one MSP and one client-portal forgot-password request through the live pages.
+4. Assert one message per request in GreenMail, follow each received link to the existing set-new-password screen, and confirm the portal/branding context is correct.
+5. In System Monitoring -> Email Log, verify the corresponding tenant SMTP rows are visible as sent. For a deliberately rejected/unreachable tenant SMTP setting, verify the public page still shows generic success while server logs retain the provider failure and any provider-level attempt is visible as failed.
+
+This manual check is evidence of deployment parity, not a substitute for the deterministic integration test.
+
+## Acceptance criteria / definition of done
+
+- No password-recovery request code checks `EMAIL_ENABLE` before calling the provider-aware sender.
+- Enabled tenant SMTP works for active MSP and client users when `EMAIL_ENABLE` is false and when it is unset.
+- The client message keeps the vanity-domain/branding parameters and both portal types receive a token accepted by the existing completion path.
+- Invalid, unknown, inactive, and portal-mismatched requests have the same public success result and produce neither tokens intended for delivery nor email attempts.
+- A successful tenant or system provider send creates a tenant-scoped `email_sending_logs` row visible in Email Log.
+- Provider send failures create the existing failed log row; initialization/fallback failures retain actionable structured application diagnostics. No provider error, account-existence signal, token, or reset URL reaches the public response/log payload.
+- Existing system SMTP/Resend fallback remains controlled by `SystemEmailProviderFactory` and exact `EMAIL_ENABLE=true`.
+- `requestPasswordReset` no longer implements a second lookup/token/provider flow or emits a link to a nonexistent route.
+- Behavioral tests use a real database, the real server action, real registry wiring, real template processing, real `TenantEmailService`, and real SMTP transport into the repository emulator (plus GreenMail parity where available).
+
+## Migration and compatibility
+
+- **Database:** no schema or data migration. Existing `tenant_email_settings`, email templates, and `email_sending_logs` are reused.
+- **Environment:** no new variable. Appliance installations may keep `EMAIL_ENABLE=false` or omit it; that disables only the environment-backed system provider, not an enabled tenant provider.
+- **Issued links:** existing JWT reset links remain valid because token format, secret lookup, route, and completion actions do not change.
+- **Action callers:** `recoverPassword` keeps its name, arguments, and boolean return. `requestPasswordReset` keeps its exported name, arguments, and result object but delegates to the canonical action.
+- **Provider order:** enabled tenant provider remains first. Existing system fallback is retained rather than promoted ahead of tenant configuration.
+- **Email Log:** no new status/provider identifiers or UI changes. Operators continue using the existing sent/failed rows.
+- **Edition behavior:** do not broaden CE/EE fallback policy. The implementation must preserve the current `TenantEmailService`/`EmailProviderManager` edition behavior and the factory gate exactly.
+
+## Risks and mitigations
+
+- **Accidental oracle through return values or thrown server actions:** make the public action catch all lookup/token/send errors and return the same value; prove this with the failure and non-match cases.
+- **Inactive user mail:** explicitly check `is_inactive` in the canonical path; the current model helper does not filter it.
+- **Duplicate fallback delivery:** never fallback after tenant success and do not retry a result already produced by `system-email-provider`. Preserve current behavior for ambiguous provider-level failures rather than inventing a new retry policy.
+- **Masked SMTP diagnostics:** retain the tenant result before fallback and report both sanitized causes internally. Assert the failed provider row/error in the emulator rejection case.
+- **Singleton/cache test leakage:** invalidate `TenantEmailService` per tenant and reset the auth registry and environment after tests.
+- **False-positive integration tests:** assert SMTP capture, token verification, and database log state together. A mock-only or source-string test cannot satisfy the acceptance gate.
+- **Global email identity ambiguity:** current user-management actions enforce global email uniqueness per `user_type`, but the database key itself is tenant-scoped. This change preserves existing discovery semantics; resolving historical cross-tenant duplicates requires a separate identity-policy decision.
+- **JWT security debt:** the live JWT is not the hashed, single-use database token implemented by `PasswordResetService`. This plan avoids silently combining incompatible token formats; a later migration should address the completion route, concurrency/one-time-use semantics, and already-issued-link compatibility together.
+
+## Explicitly out of scope
+
+- Changing the registration/email-verification use of `VERIFY_EMAIL_ENABLED` or `EMAIL_ENABLE` in `useRegister.tsx`.
+- Removing or weakening `EMAIL_ENABLE` in `SystemEmailProviderFactory`, changing system SMTP/Resend credentials, or redesigning CE/EE fallback policy.
+- Migrating the reset UI from JWTs to `password_reset_tokens`, deleting `PasswordResetService`, changing token lifetime, or adding new rate-limit behavior.
+- Changing forgot-password page copy, routes, check-email navigation, client portal branding UX, or the signed enterprise reactivation endpoint contract.
+- Adding an email-log table/status, a password-reset-specific audit table, monitoring UI, alerts, metrics, or provider-health changes.
+- Repairing historical duplicate identities across tenants or changing global user uniqueness policy.
+- Configuring tenant SMTP for operators, changing appliance Helm defaults, deploying, or modifying inbound email behavior.

--- a/ee/server/src/app/api/billing/reactivation-password-reset/route.ts
+++ b/ee/server/src/app/api/billing/reactivation-password-reset/route.ts
@@ -49,8 +49,8 @@ export async function POST(req: NextRequest) {
   }
 
   // Use the MSP recover flow: it mints the JWT and links to the real
-  // /auth/password-reset/set-new-password?...&portal=msp page. (requestPasswordReset
-  // pointed at /auth/reset-password, which is not a real page.)
+  // /auth/password-reset/set-new-password?...&portal=msp page. requestPasswordReset
+  // now delegates to this same action, so every recovery request enters one path.
   await recoverPassword(email, 'msp');
   return NextResponse.json({ success: true });
 }

--- a/packages/auth/src/actions/auth-actions/passwordResetActions.ts
+++ b/packages/auth/src/actions/auth-actions/passwordResetActions.ts
@@ -1,14 +1,10 @@
 'use server'
 
 import { createTenantKnex, runWithTenant, tenantDb } from '@alga-psa/db';
-import { getAdminConnection } from '@alga-psa/db/admin';
 import { PasswordResetService } from '@alga-psa/auth';
 import { hashPassword } from '@alga-psa/core/encryption';
-import { isValidEmail } from '@alga-psa/validation';
 
-import { getAuthEmailRegistry } from '../../lib/emailRegistry';
-
-const PASSWORD_RESET_TENANT_DISCOVERY = 'tenant-discovery';
+import { recoverPassword } from '../useRegister';
 
 export interface RequestResetResult {
   success: boolean;
@@ -38,201 +34,23 @@ export interface CompleteResetResult {
 /**
  * Request a password reset for an email address
  * This is a public action that doesn't require authentication
+ *
+ * @deprecated Use `recoverPassword(email, portal)` directly. This adapter maps
+ * the legacy `internal|client` userType to the canonical `msp|client` portal
+ * parameter and delegates to `recoverPassword`, which mints the JWT consumed by
+ * the deployed `/auth/password-reset/set-new-password` page and returns the same
+ * enumeration-safe success value for every public outcome.
  */
 export async function requestPasswordReset(
   email: string,
   userType: 'internal' | 'client' = 'internal'
 ): Promise<RequestResetResult> {
-  console.log('[PasswordReset] Starting password reset request for:', email, 'userType:', userType);
-  
-  try {
-    if (!email) {
-      console.log('[PasswordReset] Email is required');
-      return { success: false, message: 'Email is required', error: 'Email is required' };
-    }
-
-    // Normalize email
-    const normalizedEmail = email.toLowerCase().trim();
-    console.log('[PasswordReset] Normalized email:', normalizedEmail);
-
-    // Validate email format
-    if (!isValidEmail(normalizedEmail)) {
-      return { success: false, message: 'Invalid email format', error: 'Invalid email format' };
-    }
-
-    // Use admin connection to search across all tenants
-    // For public password reset, we need to find the tenant from the user's email
-    console.log('[PasswordReset] Getting admin connection...');
-    const adminKnex = await getAdminConnection();
-    
-    // Find user across all tenants (this is a special case for password reset)
-    console.log('[PasswordReset] Searching for user with email:', normalizedEmail, 'and type:', userType);
-    const userInfo = await tenantDb(adminKnex, PASSWORD_RESET_TENANT_DISCOVERY)
-      .unscoped('users', 'tenant discovery for public password reset email lookup')
-      .where({
-        email: normalizedEmail,
-        user_type: userType,
-        is_inactive: false
-      })
-      .select('tenant', 'user_id', 'first_name', 'username')
-      .first();
-    
-    console.log('[PasswordReset] User search result:', userInfo ? 'User found' : 'User not found');
-    if (userInfo) {
-      console.log('[PasswordReset] User details - tenant:', userInfo.tenant, 'user_id:', userInfo.user_id);
-    }
-    
-    // Clean up admin connection
-    await adminKnex.destroy();
-
-    // Always return success for security (don't reveal if email exists)
-    if (!userInfo) {
-      console.log('[PasswordReset] No user found, returning success for security');
-      return { 
-        success: true, 
-        message: 'If an account exists with this email, you will receive a password reset link shortly.' 
-      };
-    }
-
-    // Now run the reset token creation in the user's tenant context
-    console.log('[PasswordReset] Running with tenant context:', userInfo.tenant);
-    const result = await runWithTenant(userInfo.tenant, async () => {
-      const { knex: tenantKnex, tenant } = await createTenantKnex(userInfo.tenant);
-
-      if (!tenant) {
-        console.error('[PasswordReset] Tenant context is missing!');
-        throw new Error('Tenant context is required');
-      }
-      console.log('[PasswordReset] Tenant context established:', tenant);
-
-      // Ensure at least one email provider path is configured before proceeding
-      console.log('[PasswordReset] Checking tenant email service configuration...');
-      const tenantEmailService = await getAuthEmailRegistry().getTenantEmailService(tenant);
-      let emailConfigured = await tenantEmailService.isConfigured();
-      console.log('[PasswordReset] Tenant email configured:', emailConfigured);
-      
-      if (!emailConfigured) {
-        console.log('[PasswordReset] Falling back to system email configuration check');
-        const systemEmailService = await getAuthEmailRegistry().getSystemEmailService();
-        emailConfigured = await systemEmailService.isConfigured();
-        console.log('[PasswordReset] System email configured:', emailConfigured);
-        if (!emailConfigured) {
-          console.error('[PasswordReset] Neither tenant nor system email service is configured!');
-          // Still return success for security
-          return { 
-            success: true, 
-            message: 'If an account exists with this email, you will receive a password reset link shortly.' 
-          };
-        }
-      }
-
-      // Use a transaction to ensure atomicity
-      const resetResult = await tenantKnex.transaction(async (trx) => {
-        // Create reset token within transaction
-        console.log('[PasswordReset] Creating reset token...');
-        const tokenResult = await PasswordResetService.createResetTokenWithTransaction(
-          normalizedEmail,
-          userType,  // No conversion needed - use 'internal' directly
-          trx,
-          tenant
-        );
-        console.log('[PasswordReset] Token creation result:', tokenResult);
-
-        if (!tokenResult.success || tokenResult.token === 'dummy') {
-          // Either rate limited or user doesn't exist
-          // Still return success for security
-          console.log('[PasswordReset] Token creation failed or dummy token, skipping email');
-          return { 
-            success: true, 
-            message: 'If an account exists with this email, you will receive a password reset link shortly.',
-            skipEmail: true
-          };
-        }
-
-        // Get the tenant's default client for email branding
-        const tenantDbForReset = tenantDb(trx, tenant);
-        const tenantDefaultClientQuery = tenantDbForReset.table('tenant_companies')
-          .where({ is_default: true });
-        const tenantDefaultClient = await tenantDbForReset.tenantJoin(
-          tenantDefaultClientQuery,
-          'clients',
-          'clients.client_id',
-          'tenant_companies.client_id'
-        )
-          .select('clients.*')
-          .first();
-        
-        const clientName = tenantDefaultClient?.client_name || 'Our Platform';
-        
-        // Get support email from default location if available
-        let supportEmail = 'support@example.com';
-        if (tenantDefaultClient) {
-          const defaultLocation = await tenantDbForReset.table('client_locations')
-            .where({ 
-              client_id: tenantDefaultClient.client_id,
-              is_default: true,
-              is_active: true
-            })
-            .first();
-          
-          if (defaultLocation?.email) {
-            supportEmail = defaultLocation.email;
-          }
-        }
-
-        // Generate password reset URL
-        const baseUrl = process.env.NEXT_PUBLIC_BASE_URL || process.env.NEXTAUTH_URL || (process.env.HOST ? `https://${process.env.HOST}` : '');
-        const resetUrl = `${baseUrl}/auth/reset-password?token=${encodeURIComponent(tokenResult.token || '')}`;
-
-        // Calculate expiration time for display
-        const expirationTime = '1 hour';
-
-        // Send password reset email - if this fails, transaction will rollback
-        console.log('[PasswordReset] Sending email to:', normalizedEmail);
-        console.log('[PasswordReset] Reset URL:', resetUrl);
-        console.log('[PasswordReset] Client name:', clientName);
-        console.log('[PasswordReset] Support email:', supportEmail);
-        
-        await getAuthEmailRegistry().sendPasswordResetEmail({
-          email: normalizedEmail,
-          userName: userInfo.first_name || userInfo.username || normalizedEmail,
-          resetLink: resetUrl,
-          expirationTime: expirationTime,
-          tenant: tenant,
-          supportEmail: supportEmail,
-          clientName: clientName
-        });
-        
-        console.log('[PasswordReset] Email sent successfully');
-
-        return {
-          success: true,
-          message: 'If an account exists with this email, you will receive a password reset link shortly.'
-        };
-      }).catch((error) => {
-        console.error('[PasswordReset] Transaction failed:', error);
-        console.error('[PasswordReset] Error stack:', error.stack);
-        // Still return success for security
-        return {
-          success: true,
-          message: 'If an account exists with this email, you will receive a password reset link shortly.'
-        };
-      });
-
-      return resetResult;
-    });
-
-    return result;
-
-  } catch (error) {
-    console.error('[PasswordReset] Error requesting password reset:', error);
-    console.error('[PasswordReset] Error stack:', error instanceof Error ? error.stack : 'No stack trace available');
-    // Always return success for security (don't reveal errors)
-    return { 
-      success: true, 
-      message: 'If an account exists with this email, you will receive a password reset link shortly.' 
-    };
-  }
+  const portal = userType === 'client' ? 'client' : 'msp';
+  await recoverPassword(email, portal);
+  return {
+    success: true,
+    message: 'If an account exists with this email, you will receive a password reset link shortly.'
+  };
 }
 
 /**

--- a/packages/auth/src/actions/useRegister.tsx
+++ b/packages/auth/src/actions/useRegister.tsx
@@ -136,31 +136,41 @@ export async function recoverPassword(
   portal: 'msp' | 'client' = 'msp',
   portalDomain?: string
 ): Promise<boolean> {
-  if (!isValidEmail(email)) {
-    logger.debug(`Invalid email format: [ ${email} ]`);
-    return true; // Return true for security - don't reveal invalid format
-  }
-
-  logger.debug(`Checking if email [ ${email} ] exists for portal type: ${portal}`);
-  
+  // Normalize the address once; validation, lookup, token payload, recipient,
+  // and logging all share this value.
+  const normalizedEmail = email.trim().toLowerCase();
   // For MSP portal, look for 'internal' users; for client portal, look for 'client' users
   const userType = portal === 'msp' ? 'internal' : 'client';
-  const userInfo = await User.findUserByEmailAndType(email, userType);
-  
-  if (!userInfo) {
-    logger.debug(`No ${userType} user found with email [ ${email} ]`);
-    // For security, always return true to not reveal if user exists
-    // But don't actually send an email since there's no matching user
+
+  // Invalid format is indistinguishable from an unknown address: finish with
+  // the generic success result without a lookup or send attempt.
+  if (!isValidEmail(normalizedEmail)) {
+    logger.debug('Password recovery skipped: invalid email format', { portal, userType });
     return true;
   }
 
-  // Only proceed with email if we found a user of the correct type
-  if (EMAIL_ENABLE) {
-    // For password reset, we only need the email in the token
-    // This makes the token much shorter
+  logger.debug('Checking if email exists for portal type', { portal, userType });
+
+  let matchedTenant: string | undefined;
+  try {
+    const userInfo = await User.findUserByEmailAndType(normalizedEmail, userType);
+
+    // Only a matched, active user of the requested portal type may produce a
+    // token or send attempt. Unknown and inactive users resolve to the same
+    // generic success result and never mint a token or write an email log.
+    if (!userInfo || userInfo.is_inactive) {
+      logger.debug('Password recovery skipped: no active matching user', { portal, userType });
+      return true;
+    }
+    matchedTenant = userInfo.tenant;
+
+    // Provider readiness is decided by the send path, not by an environment
+    // flag here. An enabled tenant SMTP/Resend/Microsoft provider therefore
+    // works even when EMAIL_ENABLE is false or unset; the system fallback
+    // remains controlled by SystemEmailProviderFactory and EMAIL_ENABLE.
     const recoverToken = await createToken({
       username: '',
-      email: email,
+      email: normalizedEmail,
       password: '',
       clientName: '',
       user_type: userType  // Include the correct user type in token
@@ -174,26 +184,36 @@ export async function recoverPassword(
     );
 
     // Use the proper sendPasswordResetEmail function which respects language hierarchy
-    try {
-      await getAuthEmailRegistry().sendPasswordResetEmail({
-        email,
-        userName: `${userInfo.first_name || ''} ${userInfo.last_name || ''}`.trim() || userInfo.username || email,
-        resetLink,
-        expirationTime: '1 hour',
-        tenant: userInfo.tenant,
-        supportEmail: 'support@algapsa.com',
-        clientName: 'AlgaPSA'
-      });
+    await getAuthEmailRegistry().sendPasswordResetEmail({
+      email: normalizedEmail,
+      userName: `${userInfo.first_name || ''} ${userInfo.last_name || ''}`.trim() || userInfo.username || normalizedEmail,
+      resetLink,
+      expirationTime: '1 hour',
+      tenant: userInfo.tenant,
+      supportEmail: 'support@algapsa.com',
+      clientName: 'AlgaPSA'
+    });
 
-      logger.info(`Recover password email sent successfully for User [ ${email} ]`);
-      return true;
-    } catch (error) {
-      logger.error('Failed to send recover password email:', error);
-      return false;
-    }
-  } else {
-    logger.error('Password recovery unavailable: Automatic email functionality is not enabled or configured correctly. Please contact system administrator for manual password reset.');
-    return false;
+    logger.info('Password recovery email sent successfully', {
+      portal,
+      userType,
+      tenant: userInfo.tenant,
+      email: normalizedEmail
+    });
+    return true;
+  } catch (error) {
+    // All lookup, token, and send failures resolve to the same public success
+    // value: an unauthenticated requester must never learn whether an account
+    // exists or whether delivery succeeded. Operators observe failures through
+    // structured application logs and the Email Log. The token and reset URL
+    // are never logged.
+    logger.error('password_recovery_send_failed', {
+      portal,
+      userType,
+      tenant: matchedTenant,
+      error: error instanceof Error ? error.message : String(error)
+    });
+    return true;
   }
 }
 

--- a/packages/auth/src/actions/useRegister.tsx
+++ b/packages/auth/src/actions/useRegister.tsx
@@ -14,6 +14,7 @@ import { isValidEmail } from '@alga-psa/validation';
 
 import { getAuthEmailRegistry } from '../lib/emailRegistry';
 import { buildPasswordResetLink } from '../lib/portalDomain';
+import { resolvePasswordResetOrigin } from '../lib/resetLinkOrigin';
 
 const VERIFY_EMAIL_ENABLED = process.env.VERIFY_EMAIL_ENABLED === 'true';
 const EMAIL_ENABLE = process.env.EMAIL_ENABLE === 'true';
@@ -168,6 +169,26 @@ export async function recoverPassword(
     // flag here. An enabled tenant SMTP/Resend/Microsoft provider therefore
     // works even when EMAIL_ENABLE is false or unset; the system fallback
     // remains controlled by SystemEmailProviderFactory and EMAIL_ENABLE.
+    //
+    // The reset link origin may only come from trusted server-side
+    // configuration. Request-derived headers are never consulted (reset-link
+    // poisoning). If no trusted origin exists, refuse the send: it must be
+    // impossible for a reset email whose link begins with "undefined" (or any
+    // non-absolute origin) to reach a provider.
+    const resetOrigin = resolvePasswordResetOrigin();
+    if (!resetOrigin) {
+      logger.error('password_recovery_send_refused', {
+        portal,
+        userType,
+        tenant: userInfo.tenant,
+        error:
+          'No trusted public origin configured for password-reset links. ' +
+          'Set NEXT_PUBLIC_BASE_URL (or NEXTAUTH_URL, or HOST) to the public ' +
+          'application URL; the reset email was not sent.'
+      });
+      return true;
+    }
+
     const recoverToken = await createToken({
       username: '',
       email: normalizedEmail,
@@ -177,7 +198,7 @@ export async function recoverPassword(
     });
 
     const resetLink = buildPasswordResetLink(
-      process.env.NEXT_PUBLIC_BASE_URL,
+      resetOrigin,
       recoverToken,
       portal,
       portalDomain

--- a/packages/auth/src/lib/resetLinkOrigin.ts
+++ b/packages/auth/src/lib/resetLinkOrigin.ts
@@ -1,0 +1,52 @@
+/**
+ * Canonical public-origin resolution for password-reset links.
+ *
+ * Only trusted server-side configuration may supply the origin, in the same
+ * order the rest of the application uses for outbound links
+ * (`NEXT_PUBLIC_BASE_URL`, then `NEXTAUTH_URL`, then a bare `HOST` hostname).
+ * Request-derived headers (Host, Origin, X-Forwarded-*) are never consulted:
+ * an attacker controls those, and a link built from them is a reset-link
+ * poisoning vector.
+ *
+ * Returns null when no trusted origin can be derived so the caller can refuse
+ * the send instead of handing a provider a link that begins with "undefined"
+ * or points at an attacker-controlled host.
+ */
+
+export interface ResetOriginEnv {
+  NEXT_PUBLIC_BASE_URL?: string;
+  NEXTAUTH_URL?: string;
+  HOST?: string;
+}
+
+export function resolvePasswordResetOrigin(
+  env: ResetOriginEnv | Record<string, string | undefined> = process.env
+): string | null {
+  const candidates: Array<string | undefined> = [
+    env.NEXT_PUBLIC_BASE_URL,
+    env.NEXTAUTH_URL,
+    env.HOST ? `https://${env.HOST}` : undefined,
+  ];
+
+  for (const candidate of candidates) {
+    if (!candidate) continue;
+    const origin = normalizeHttpOrigin(candidate);
+    if (origin) return origin;
+  }
+  return null;
+}
+
+function normalizeHttpOrigin(value: string): string | null {
+  let url: URL;
+  try {
+    url = new URL(value);
+  } catch {
+    return null;
+  }
+  if (url.protocol !== 'http:' && url.protocol !== 'https:') return null;
+  if (!url.host) return null;
+  // Normalize to the origin (scheme + host, no path/trailing slash) so a
+  // configured base with a path or trailing slash cannot produce a malformed
+  // reset path.
+  return url.origin;
+}

--- a/packages/auth/src/lib/resetLinkOrigin.ts
+++ b/packages/auth/src/lib/resetLinkOrigin.ts
@@ -3,10 +3,13 @@
  *
  * Only trusted server-side configuration may supply the origin, in the same
  * order the rest of the application uses for outbound links
- * (`NEXT_PUBLIC_BASE_URL`, then `NEXTAUTH_URL`, then a bare `HOST` hostname).
- * Request-derived headers (Host, Origin, X-Forwarded-*) are never consulted:
- * an attacker controls those, and a link built from them is a reset-link
- * poisoning vector.
+ * (`NEXT_PUBLIC_BASE_URL`, then `NEXTAUTH_URL`, then `HOST`). The repo uses
+ * two `HOST` conventions — a full URL (`server/.env.local` sets
+ * `HOST=http://localhost:3614`) and a bare hostname (the invitation/invoice
+ * sites use `https://${HOST}`) — so `HOST` is parsed as-is first and wrapped
+ * with `https://` only when that fails. Request-derived headers (Host, Origin,
+ * X-Forwarded-*) are never consulted: an attacker controls those, and a link
+ * built from them is a reset-link poisoning vector.
  *
  * Returns null when no trusted origin can be derived so the caller can refuse
  * the send instead of handing a provider a link that begins with "undefined"
@@ -22,17 +25,24 @@ export interface ResetOriginEnv {
 export function resolvePasswordResetOrigin(
   env: ResetOriginEnv | Record<string, string | undefined> = process.env
 ): string | null {
-  const candidates: Array<string | undefined> = [
-    env.NEXT_PUBLIC_BASE_URL,
-    env.NEXTAUTH_URL,
-    env.HOST ? `https://${env.HOST}` : undefined,
-  ];
-
-  for (const candidate of candidates) {
+  for (const candidate of [env.NEXT_PUBLIC_BASE_URL, env.NEXTAUTH_URL]) {
     if (!candidate) continue;
     const origin = normalizeHttpOrigin(candidate);
     if (origin) return origin;
   }
+
+  if (env.HOST) {
+    // A HOST that already carries a scheme (http://localhost:3614,
+    // https://x.example.com/path/) must be used as-is; blindly wrapping it as
+    // `https://${HOST}` parses to a bogus origin whose hostname is "http"
+    // (e.g. https://http), which would email a garbage reset link.
+    const hostAsIs = normalizeHttpOrigin(env.HOST);
+    if (hostAsIs) return hostAsIs;
+    // Bare-hostname convention (`psa.example.com`): https://psa.example.com.
+    const hostWithScheme = normalizeHttpOrigin(`https://${env.HOST}`);
+    if (hostWithScheme) return hostWithScheme;
+  }
+
   return null;
 }
 
@@ -45,6 +55,11 @@ function normalizeHttpOrigin(value: string): string | null {
   }
   if (url.protocol !== 'http:' && url.protocol !== 'https:') return null;
   if (!url.host) return null;
+  // A mis-wrapped scheme yields a bogus origin whose hostname is literally
+  // "http" or "https" (e.g. `https://http://...` -> https://http). No real
+  // public origin has such a hostname, so treat it as invalid rather than
+  // email a garbage reset link.
+  if (url.hostname === 'http' || url.hostname === 'https') return null;
   // Normalize to the origin (scheme + host, no path/trailing slash) so a
   // configured base with a path or trailing slash cannot produce a malformed
   // reset path.

--- a/packages/email/src/sendPasswordResetEmail.ts
+++ b/packages/email/src/sendPasswordResetEmail.ts
@@ -25,8 +25,7 @@ export async function sendPasswordResetEmail({
   supportEmail,
   clientName
 }: SendPasswordResetEmailParams): Promise<boolean> {
-  logger.info('[sendPasswordResetEmail] Starting email send for:', email);
-  logger.info('[sendPasswordResetEmail] Tenant:', tenant);
+  logger.info('[sendPasswordResetEmail] Starting email send', { email, tenant });
 
   try {
     return await runWithTenant(tenant, async () => {
@@ -77,32 +76,69 @@ export async function sendPasswordResetEmail({
       const tenantEmailService = TenantEmailService.getInstance(tenant);
 
       logger.info('[sendPasswordResetEmail] Attempting to send via TenantEmailService');
-      let result = await tenantEmailService.sendEmail(emailParams);
+      const tenantResult = await tenantEmailService.sendEmail(emailParams);
 
-      if (!result.success) {
-        logger.warn('[sendPasswordResetEmail] Tenant email send failed, falling back to SystemEmailService', {
+      if (tenantResult.success) {
+        logger.info('[sendPasswordResetEmail] Email sent successfully via tenant service', {
           tenant,
-          error: result.error || 'unknown_error'
+          providerId: tenantResult.providerId,
+          providerType: tenantResult.providerType
         });
-        const systemEmailService = await getSystemEmailService();
-        result = await systemEmailService.sendEmail(emailParams);
-      }
-      
-      logger.info('[sendPasswordResetEmail] Email send result:', result);
-
-      if (!result.success) {
-        logger.error('[sendPasswordResetEmail] Failed to send password reset email:', result.error);
-        // Throw error to trigger transaction rollback
-        throw new Error(result.error || 'Failed to send password reset email');
+        return true;
       }
 
-      logger.info('[sendPasswordResetEmail] Email sent successfully');
-      return result.success;
+      // Retain the tenant attempt's provider details and sanitized error before
+      // considering the system fallback, so an actionable SMTP initialization
+      // or send error is never masked by a later generic fallback message.
+      logger.warn('[sendPasswordResetEmail] Tenant email send failed', {
+        tenant,
+        providerId: tenantResult.providerId ?? null,
+        providerType: tenantResult.providerType ?? null,
+        error: tenantResult.error || 'unknown_error'
+      });
+
+      // The tenant service may already have attempted the system provider (e.g.
+      // Enterprise fallback when no tenant provider is enabled). Retrying it
+      // through SystemEmailService would hit the same provider a second time.
+      if (tenantResult.providerId === 'system-email-provider') {
+        throw new Error(
+          tenantResult.error || 'Failed to send password reset email via system email provider'
+        );
+      }
+
+      // Preserve the existing system fallback. SystemEmailProviderFactory
+      // (and therefore EMAIL_ENABLE) decides whether a system provider exists.
+      logger.warn('[sendPasswordResetEmail] Falling back to SystemEmailService');
+      const systemEmailService = await getSystemEmailService();
+      const fallbackResult = await systemEmailService.sendEmail(emailParams);
+
+      if (fallbackResult.success) {
+        logger.info('[sendPasswordResetEmail] Email sent successfully via system fallback', {
+          tenant,
+          providerId: fallbackResult.providerId,
+          providerType: fallbackResult.providerType
+        });
+        return true;
+      }
+
+      logger.error('[sendPasswordResetEmail] System email send failed', {
+        tenant,
+        providerId: fallbackResult.providerId ?? null,
+        providerType: fallbackResult.providerType ?? null,
+        error: fallbackResult.error || 'unknown_error'
+      });
+
+      // Both attempts failed: retain both causes so the tenant provider error
+      // is not replaced by the generic system "disabled" message.
+      throw new Error(
+        `Failed to send password reset email: tenant attempt failed (${tenantResult.error || 'unknown_error'}), system fallback failed (${fallbackResult.error || 'unknown_error'})`
+      );
     });
   } catch (error) {
     logger.error('[sendPasswordResetEmail] Error sending password reset email:', error);
-    logger.error('[sendPasswordResetEmail] Error stack:', (error as any).stack);
-    // Re-throw the error to ensure transaction rollback
+    // Re-throw the error so recoverPassword can log its stable
+    // password_recovery_send_failed event; the token and reset URL are never
+    // included in the diagnostic.
     throw error;
   }
 }

--- a/server/src/test/integration/email/passwordRecoveryEmailProvider.integration.test.ts
+++ b/server/src/test/integration/email/passwordRecoveryEmailProvider.integration.test.ts
@@ -20,6 +20,12 @@
  *     nothing, writes a status='failed' row for the tenant SMTP provider, and
  *     emits a password_recovery_send_failed diagnostic without the token or
  *     reset URL.
+ *  7. Canonical-origin guard: with no trusted origin configured
+ *     (NEXT_PUBLIC_BASE_URL/NEXTAUTH_URL/HOST all absent) recovery returns the
+ *     same true value and sends nothing, emitting a password_recovery_send_refused
+ *     diagnostic pointing at the missing configuration. With NEXT_PUBLIC_BASE_URL
+ *     absent but a trusted fallback (NEXTAUTH_URL) configured, the delivered
+ *     link is an absolute URL on that origin and is logged as sent.
  *
  * The only mocked seams are the application logger (to inspect diagnostics)
  * and the @alga-psa/auth barrel that setup.ts globally replaces; the action is
@@ -89,6 +95,8 @@ describe('password recovery email provider path (real DB + real SMTP)', () => {
     EMAIL_ENABLE: undefined,
     SECRET_KEY: undefined,
     NEXT_PUBLIC_BASE_URL: undefined,
+    NEXTAUTH_URL: undefined,
+    HOST: undefined,
   };
 
   async function capturedEmails(): Promise<CapturedEmail[]> {
@@ -112,10 +120,32 @@ describe('password recovery email provider path (real DB + real SMTP)', () => {
     // A settings save elsewhere would have invalidated this; do it explicitly so
     // cases never share a cached provider.
     await TenantEmailService.invalidateTenantSettings(tenantId);
+    // Restore the canonical-origin baseline before every case. Individual cases
+    // override it to prove the guard and the trusted-fallback derivation.
+    process.env.NEXT_PUBLIC_BASE_URL = 'http://localhost:3614';
+    delete process.env.NEXTAUTH_URL;
+    delete process.env.HOST;
     loggerError.mockClear();
     loggerWarn.mockClear();
     loggerInfo.mockClear();
     loggerDebug.mockClear();
+  }
+
+  function resetLinkOf(email: CapturedEmail): string {
+    const text = email.text || email.html || '';
+    const match = text.match(/https?:\/\/[^\s<"']+/);
+    if (!match) throw new Error('No absolute reset link found in delivered message');
+    return match[0];
+  }
+
+  function expectUsableAbsoluteResetLink(email: CapturedEmail, expectedOrigin: string): string {
+    const link = resetLinkOf(email);
+    expect(link).not.toContain('undefined');
+    const url = new URL(link);
+    expect(['http:', 'https:']).toContain(url.protocol);
+    expect(url.origin).toBe(expectedOrigin);
+    expect(url.pathname).toBe('/auth/password-reset/set-new-password');
+    return link;
   }
 
   function expectNoTokenOrUrlIn(payload: unknown): void {
@@ -248,6 +278,7 @@ describe('password recovery email provider path (real DB + real SMTP)', () => {
     expect(emails[0].subject).toBe('Password Reset Request');
     expect(emails[0].text).toContain('/auth/password-reset/set-new-password');
     expect(emails[0].html).toContain('/auth/password-reset/set-new-password');
+    expectUsableAbsoluteResetLink(emails[0], 'http://localhost:3614');
 
     const rows = await db('email_sending_logs').where({ tenant: tenantId });
     expect(rows).toHaveLength(1);
@@ -271,6 +302,7 @@ describe('password recovery email provider path (real DB + real SMTP)', () => {
     expect(emails[0].text).toContain('/auth/password-reset/set-new-password');
     expect(emails[0].text).toContain('portal=client');
     expect(emails[0].text).toContain('portalDomain=portal.example.test');
+    expectUsableAbsoluteResetLink(emails[0], 'http://localhost:3614');
 
     const rows = await db('email_sending_logs').where({ tenant: tenantId });
     expect(rows).toHaveLength(1);
@@ -304,6 +336,59 @@ describe('password recovery email provider path (real DB + real SMTP)', () => {
     expect(clientInfo.errorType).toBeNull();
     expect(clientInfo.userInfo?.email).toBe(clientEmail);
     expect(clientInfo.userInfo?.user_type).toBe('client');
+  });
+
+  it('refuses to send and returns the same success value when no trusted origin is configured', async () => {
+    process.env.EMAIL_ENABLE = 'false';
+    delete process.env.NEXT_PUBLIC_BASE_URL;
+    delete process.env.NEXTAUTH_URL;
+    delete process.env.HOST;
+
+    const result = await recoverPassword(internalEmail, 'msp');
+    expect(result).toBe(true);
+
+    // Nothing was handed to the provider: no message, no send-log row, and no
+    // token minted for delivery.
+    expect(await capturedEmails()).toHaveLength(0);
+    const rows = await db('email_sending_logs').where({ tenant: tenantId });
+    expect(rows).toHaveLength(0);
+
+    // The refusal is diagnosable from server logs with a pointer to the fix.
+    const refusedCalls = loggerError.mock.calls.filter(
+      (call) => call[0] === 'password_recovery_send_refused'
+    );
+    expect(refusedCalls.length).toBeGreaterThan(0);
+    const payload = refusedCalls[refusedCalls.length - 1][1] as Record<string, unknown>;
+    expect(payload.portal).toBe('msp');
+    expect(payload.userType).toBe('internal');
+    expect(payload.tenant).toBe(tenantId);
+    expect(String(payload.error ?? '')).toContain('NEXT_PUBLIC_BASE_URL');
+    expectNoTokenOrUrlIn(payload);
+  });
+
+  it('derives a usable reset link from NEXTAUTH_URL when NEXT_PUBLIC_BASE_URL is absent', async () => {
+    process.env.EMAIL_ENABLE = 'false';
+    delete process.env.NEXT_PUBLIC_BASE_URL;
+    delete process.env.HOST;
+    process.env.NEXTAUTH_URL = 'https://trusted.example.test';
+
+    const result = await recoverPassword(internalEmail, 'msp');
+    expect(result).toBe(true);
+
+    const emails = await capturedEmails();
+    expect(emails).toHaveLength(1);
+    expect(emails[0].to).toContain(internalEmail);
+    // The derivation path must produce an absolute link on the trusted origin,
+    // never one beginning with "undefined".
+    const link = expectUsableAbsoluteResetLink(emails[0], 'https://trusted.example.test');
+    expect(link).not.toContain('undefined');
+
+    const rows = await db('email_sending_logs').where({ tenant: tenantId });
+    expect(rows).toHaveLength(1);
+    expect(rows[0].status).toBe('sent');
+    expect(rows[0].provider_id).toBe(SMTP_PROVIDER_ID);
+    expect(rows[0].provider_type).toBe('smtp');
+    expect(normalizeAddressList(rows[0])).toContain(internalEmail);
   });
 
   it('keeps the public result, mail, and log state identical for every non-match', async () => {

--- a/server/src/test/integration/email/passwordRecoveryEmailProvider.integration.test.ts
+++ b/server/src/test/integration/email/passwordRecoveryEmailProvider.integration.test.ts
@@ -1,0 +1,370 @@
+/**
+ * Password recovery email-provider path: real action + real registry + real
+ * DB + real SMTP into the in-process smtp-sink emulator.
+ *
+ * Regression matrix (plan 2026-08-14-password-recovery-email-provider-plan):
+ *
+ *  1. MSP recovery works with EMAIL_ENABLE='false' via an enabled tenant SMTP
+ *     provider pointed at the emulator; public result is true and exactly one
+ *     message is delivered.
+ *  2. Client-portal recovery works with the global flag unset; the message
+ *     carries the set-new-password link, portal=client, and the encoded
+ *     portalDomain.
+ *  3. The delivered links contain a JWT accepted by the deployed completion
+ *     tokenizer (getInfoFromToken) with the normalized email + portal type.
+ *  4. Each happy path creates exactly one tenant-scoped email_sending_logs row
+ *     with status='sent' for the emulator-backed tenant SMTP provider.
+ *  5. Enumeration guards: invalid/unknown/inactive/portal-mismatched requests
+ *     all return the same true value with zero messages and zero log rows.
+ *  6. Provider failure (reject-mail fault) still returns true publicly, sends
+ *     nothing, writes a status='failed' row for the tenant SMTP provider, and
+ *     emits a password_recovery_send_failed diagnostic without the token or
+ *     reset URL.
+ *
+ * The only mocked seams are the application logger (to inspect diagnostics)
+ * and the @alga-psa/auth barrel that setup.ts globally replaces; the action is
+ * imported through the real @alga-psa/auth/actions source.
+ */
+
+import { afterAll, beforeAll, beforeEach, describe, expect, it, vi } from 'vitest';
+import { v4 as uuidv4 } from 'uuid';
+import type { Knex } from 'knex';
+
+import { tenantDb, resetTenantConnectionPool } from '@alga-psa/db';
+import { EmulatorHost } from '@alga-psa/emulator-host';
+import smtpSink, { CapturedEmail } from '@alga-psa/emulator-smtp-sink';
+import { getSystemEmailService, sendPasswordResetEmail, TenantEmailService } from '@alga-psa/email';
+import { recoverPassword } from '@alga-psa/auth/actions';
+
+import { createTestDbConnection, wireLocalTestDbEnv } from '../../../../test-utils/dbConfig';
+import { createTenant, createUser } from '../../../../test-utils/testDataFactory';
+
+import { getInfoFromToken } from '../../../../../packages/auth/src/lib/tokenizer';
+import {
+  registerAuthEmailProvider,
+  resetAuthEmailRegistry,
+} from '../../../../../packages/auth/src/lib/emailRegistry';
+
+const loggerError = vi.fn();
+const loggerWarn = vi.fn();
+const loggerInfo = vi.fn();
+const loggerDebug = vi.fn();
+vi.mock('@alga-psa/core/logger', () => ({
+  default: {
+    error: (...args: unknown[]) => loggerError(...args),
+    warn: (...args: unknown[]) => loggerWarn(...args),
+    info: (...args: unknown[]) => loggerInfo(...args),
+    debug: (...args: unknown[]) => loggerDebug(...args),
+    system: (...args: unknown[]) => loggerInfo(...args),
+  },
+}));
+
+const SMTP_PROVIDER_ID = 'tenant-smtp-emulator';
+const HOOK_TIMEOUT = 240_000;
+
+function normalizeAddressList(row: any): string[] {
+  const raw = row?.to_addresses;
+  if (Array.isArray(raw)) return raw;
+  if (typeof raw === 'string') {
+    try {
+      return JSON.parse(raw) as string[];
+    } catch {
+      return [];
+    }
+  }
+  return [];
+}
+
+describe('password recovery email provider path (real DB + real SMTP)', () => {
+  let db: Knex;
+  let host: EmulatorHost;
+  let controlUrl: string;
+  let tenantId: string;
+  let internalEmail: string;
+  let clientEmail: string;
+  let inactiveInternalEmail: string;
+  let unknownEmail: string;
+
+  const envBackup: Record<string, string | undefined> = {
+    EMAIL_ENABLE: undefined,
+    SECRET_KEY: undefined,
+    NEXT_PUBLIC_BASE_URL: undefined,
+  };
+
+  async function capturedEmails(): Promise<CapturedEmail[]> {
+    const response = await fetch(`${controlUrl}/control/smtp-sink/state/emails`);
+    const body = await response.json();
+    return (body?.result ?? []) as CapturedEmail[];
+  }
+
+  async function controlPost(path: string, body: unknown): Promise<void> {
+    const response = await fetch(`${controlUrl}/control/smtp-sink/${path}`, {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify(body),
+    });
+    expect(response.ok, `control ${path}: ${response.status}`).toBe(true);
+  }
+
+  async function resetSharedState(): Promise<void> {
+    await host.reset('smtp-sink');
+    await db('email_sending_logs').where({ tenant: tenantId }).del();
+    // A settings save elsewhere would have invalidated this; do it explicitly so
+    // cases never share a cached provider.
+    await TenantEmailService.invalidateTenantSettings(tenantId);
+    loggerError.mockClear();
+    loggerWarn.mockClear();
+    loggerInfo.mockClear();
+    loggerDebug.mockClear();
+  }
+
+  function expectNoTokenOrUrlIn(payload: unknown): void {
+    const serialized = JSON.stringify(payload);
+    expect(serialized).not.toContain('token=');
+    expect(serialized).not.toContain('/auth/password-reset/set-new-password');
+  }
+
+  beforeAll(async () => {
+    if (!process.env.CI) {
+      wireLocalTestDbEnv();
+    }
+
+    db = await createTestDbConnection();
+    await resetTenantConnectionPool();
+
+    host = new EmulatorHost({ emulators: [smtpSink], controlPort: 0, ports: { 'smtp-sink': 0 } });
+    const { controlPort, ports } = await host.start();
+    controlUrl = `http://127.0.0.1:${controlPort}`;
+    const smtpPort = ports['smtp-sink'];
+
+    for (const key of Object.keys(envBackup)) {
+      envBackup[key] = process.env[key];
+    }
+    process.env.NEXT_PUBLIC_BASE_URL = 'http://localhost:3614';
+    process.env.SECRET_KEY = 'password-recovery-integration-test-secret';
+    delete process.env.EMAIL_ENABLE;
+
+    // Wire the real email implementations exactly as initializeApp does.
+    registerAuthEmailProvider({
+      sendPasswordResetEmail,
+      getSystemEmailService: async () => getSystemEmailService(),
+      getTenantEmailService: async (tenant) => TenantEmailService.getInstance(tenant),
+    });
+
+    tenantId = await createTenant(db, 'Password Recovery Tenant');
+
+    const defaultClientId = uuidv4();
+    await tenantDb(db, tenantId).table('clients').insert({
+      client_id: defaultClientId,
+      tenant: tenantId,
+      client_name: 'Password Recovery Tenant',
+      created_at: db.fn.now(),
+      updated_at: db.fn.now(),
+    });
+    await tenantDb(db, tenantId).table('tenant_companies').insert({
+      tenant: tenantId,
+      client_id: defaultClientId,
+      is_default: true,
+    });
+
+    const shortId = tenantId.substring(0, 8);
+    internalEmail = `internal-${shortId}@example.com`;
+    clientEmail = `client-${shortId}@example.com`;
+    inactiveInternalEmail = `inactive-${shortId}@example.com`;
+    unknownEmail = `unknown-${shortId}@example.com`;
+
+    await createUser(db, tenantId, {
+      email: internalEmail,
+      username: 'internal-user',
+      first_name: 'Internal',
+      last_name: 'User',
+      user_type: 'internal',
+    });
+    await createUser(db, tenantId, {
+      email: clientEmail,
+      username: 'client-user',
+      first_name: 'Client',
+      last_name: 'User',
+      user_type: 'client',
+    });
+    await createUser(db, tenantId, {
+      email: inactiveInternalEmail,
+      username: 'inactive-internal-user',
+      user_type: 'internal',
+      is_inactive: true,
+    });
+
+    await tenantDb(db, tenantId).table('tenant_email_settings').insert({
+      tenant: tenantId,
+      default_from_domain: 'example.com',
+      custom_domains: JSON.stringify([]),
+      email_provider: 'smtp',
+      provider_configs: JSON.stringify([
+        {
+          providerId: SMTP_PROVIDER_ID,
+          providerType: 'smtp',
+          isEnabled: true,
+          config: {
+            host: '127.0.0.1',
+            port: smtpPort,
+            secure: false,
+            from: `password-reset@example.com`,
+            rejectUnauthorized: false,
+            requireTLS: false,
+          },
+        },
+      ]),
+      fallback_enabled: true,
+      tracking_enabled: false,
+      created_at: db.fn.now(),
+      updated_at: db.fn.now(),
+    });
+  }, HOOK_TIMEOUT);
+
+  afterAll(async () => {
+    await host?.stop().catch(() => undefined);
+    await db?.destroy();
+    await resetTenantConnectionPool();
+    resetAuthEmailRegistry();
+    for (const [key, value] of Object.entries(envBackup)) {
+      if (value === undefined) delete process.env[key];
+      else process.env[key] = value;
+    }
+  }, HOOK_TIMEOUT);
+
+  beforeEach(async () => {
+    await resetSharedState();
+  });
+
+  it('sends to an active MSP user when EMAIL_ENABLE=false and logs one sent row', async () => {
+    process.env.EMAIL_ENABLE = 'false';
+
+    const result = await recoverPassword(internalEmail, 'msp');
+    expect(result).toBe(true);
+
+    const emails = await capturedEmails();
+    expect(emails).toHaveLength(1);
+    expect(emails[0].to).toContain(internalEmail);
+    expect(emails[0].subject).toBe('Password Reset Request');
+    expect(emails[0].text).toContain('/auth/password-reset/set-new-password');
+    expect(emails[0].html).toContain('/auth/password-reset/set-new-password');
+
+    const rows = await db('email_sending_logs').where({ tenant: tenantId });
+    expect(rows).toHaveLength(1);
+    expect(rows[0].status).toBe('sent');
+    expect(rows[0].provider_id).toBe(SMTP_PROVIDER_ID);
+    expect(rows[0].provider_type).toBe('smtp');
+    expect(normalizeAddressList(rows[0])).toContain(internalEmail);
+    expect(rows[0].subject).toBe('Password Reset Request');
+  });
+
+  it('sends to an active client user with the flag unset, carrying portal and portalDomain', async () => {
+    delete process.env.EMAIL_ENABLE;
+
+    const result = await recoverPassword(clientEmail, 'client', 'portal.example.test');
+    expect(result).toBe(true);
+
+    const emails = await capturedEmails();
+    expect(emails).toHaveLength(1);
+    expect(emails[0].to).toContain(clientEmail);
+
+    expect(emails[0].text).toContain('/auth/password-reset/set-new-password');
+    expect(emails[0].text).toContain('portal=client');
+    expect(emails[0].text).toContain('portalDomain=portal.example.test');
+
+    const rows = await db('email_sending_logs').where({ tenant: tenantId });
+    expect(rows).toHaveLength(1);
+    expect(rows[0].status).toBe('sent');
+    expect(rows[0].provider_id).toBe(SMTP_PROVIDER_ID);
+    expect(rows[0].provider_type).toBe('smtp');
+    expect(normalizeAddressList(rows[0])).toContain(clientEmail);
+  });
+
+  it('mints links whose JWT is accepted by the deployed tokenizer for both portal types', async () => {
+    process.env.EMAIL_ENABLE = 'false';
+
+    await recoverPassword(internalEmail, 'msp');
+    await recoverPassword(clientEmail, 'client', 'portal.example.test');
+
+    const emails = await capturedEmails();
+    expect(emails).toHaveLength(2);
+
+    const tokenOf = (email: CapturedEmail): string => {
+      const match = (email.text || email.html || '').match(/token=([^&\s"]+)/);
+      if (!match) throw new Error('No token parameter found in delivered message');
+      return decodeURIComponent(match[1]);
+    };
+
+    const mspInfo = await getInfoFromToken(tokenOf(emails[0]));
+    expect(mspInfo.errorType).toBeNull();
+    expect(mspInfo.userInfo?.email).toBe(internalEmail);
+    expect(mspInfo.userInfo?.user_type).toBe('internal');
+
+    const clientInfo = await getInfoFromToken(tokenOf(emails[1]));
+    expect(clientInfo.errorType).toBeNull();
+    expect(clientInfo.userInfo?.email).toBe(clientEmail);
+    expect(clientInfo.userInfo?.user_type).toBe('client');
+  });
+
+  it('keeps the public result, mail, and log state identical for every non-match', async () => {
+    process.env.EMAIL_ENABLE = 'false';
+
+    const cases: Array<{ email: string; portal: 'msp' | 'client' }> = [
+      { email: 'not-an-email', portal: 'msp' },
+      { email: unknownEmail, portal: 'msp' },
+      { email: inactiveInternalEmail, portal: 'msp' },
+      { email: internalEmail, portal: 'client' },
+      { email: clientEmail, portal: 'msp' },
+    ];
+
+    for (const { email, portal } of cases) {
+      const result = await recoverPassword(email, portal);
+      expect(result, `${email} via ${portal} must return true`).toBe(true);
+    }
+
+    expect(await capturedEmails()).toHaveLength(0);
+    const rows = await db('email_sending_logs').where({ tenant: tenantId });
+    expect(rows).toHaveLength(0);
+  });
+
+  it('returns true and records a failed tenant SMTP row, retaining the cause, when the provider rejects', async () => {
+    process.env.EMAIL_ENABLE = 'false';
+
+    await controlPost('faults/reject-mail/arm', { code: 552 });
+
+    const result = await recoverPassword(internalEmail, 'msp');
+    expect(result).toBe(true);
+
+    // Nothing was delivered to the sink while the fault was armed.
+    expect(await capturedEmails()).toHaveLength(0);
+
+    // A provider-level attempt was made: the tenant SMTP provider logged a
+    // failed row rather than being masked by the generic system-disabled path.
+    const rows = await db('email_sending_logs').where({ tenant: tenantId });
+    expect(rows).toHaveLength(1);
+    expect(rows[0].status).toBe('failed');
+    expect(rows[0].provider_id).toBe(SMTP_PROVIDER_ID);
+    expect(rows[0].provider_type).toBe('smtp');
+    expect(String(rows[0].error_message ?? '')).toBe(
+      'SMTP send failed. Check the SMTP host, port, credentials, and TLS settings.'
+    );
+    expect(String(rows[0].error_message ?? '')).not.toContain('disabled or not configured');
+    // The SMTP-level rejection reached the log: the provider records the
+    // nodemailer command and error code for the data-phase rejection.
+    expect(rows[0].metadata?.command).toBe('DATA');
+    expect(rows[0].metadata?.errorCode).toBe('EMESSAGE');
+
+    // The action emitted its stable diagnostic with the tenant cause retained
+    // and never the token or reset URL.
+    const failedCalls = loggerError.mock.calls.filter(
+      (call) => call[0] === 'password_recovery_send_failed'
+    );
+    expect(failedCalls.length).toBeGreaterThan(0);
+    const payload = failedCalls[failedCalls.length - 1][1] as Record<string, unknown>;
+    expect(payload.portal).toBe('msp');
+    expect(payload.userType).toBe('internal');
+    expect(payload.tenant).toBe(tenantId);
+    expect(String(payload.error ?? '')).toContain('SMTP');
+    expectNoTokenOrUrlIn(payload);
+  });
+});

--- a/server/src/test/unit/email/sendPasswordResetEmail.fallback.unit.test.ts
+++ b/server/src/test/unit/email/sendPasswordResetEmail.fallback.unit.test.ts
@@ -1,0 +1,141 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+const systemSendEmail = vi.fn();
+
+vi.mock('@alga-psa/core/logger', () => ({
+  default: {
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+    debug: vi.fn(),
+    system: vi.fn(),
+  },
+}));
+
+vi.mock('@alga-psa/db', () => ({
+  getConnection: vi.fn(async () => ({})),
+  runWithTenant: async (_tenant: string, fn: () => Promise<unknown>) => fn(),
+}));
+
+vi.mock('../../../../../packages/email/src/emailLocaleResolver', () => ({
+  getUserInfoForEmail: vi.fn(async () => ({
+    email: 'user@example.com',
+    userId: 'user-1',
+    userType: 'internal',
+  })),
+  resolveEmailLocale: vi.fn(async () => 'en'),
+}));
+
+vi.mock('../../../../../packages/email/src/index', () => ({
+  getSystemEmailService: vi.fn(async () => ({
+    sendEmail: systemSendEmail,
+  })),
+  TenantEmailService: {
+    getInstance: vi.fn(),
+  },
+}));
+
+import {
+  getSystemEmailService,
+  TenantEmailService,
+} from '../../../../../packages/email/src/index';
+import { sendPasswordResetEmail } from '../../../../../packages/email/src/sendPasswordResetEmail';
+
+const mockedGetSystemEmailService = vi.mocked(getSystemEmailService);
+const mockedGetInstance = vi.mocked(TenantEmailService.getInstance);
+
+const baseParams = {
+  email: 'user@example.com',
+  userName: 'Test User',
+  resetLink: 'http://localhost/auth/password-reset/set-new-password?token=abc',
+  expirationTime: '1 hour',
+  tenant: 'tenant-1',
+  supportEmail: 'support@example.com',
+  clientName: 'AlgaPSA',
+} as Parameters<typeof sendPasswordResetEmail>[0];
+
+function sendResult(overrides: Record<string, unknown>): any {
+  return {
+    success: false,
+    error: 'unknown_error',
+    sentAt: new Date('2026-08-14T00:00:00.000Z'),
+    ...overrides,
+  };
+}
+
+describe('sendPasswordResetEmail provider fallback boundary', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    systemSendEmail.mockReset();
+    mockedGetSystemEmailService.mockResolvedValue({ sendEmail: systemSendEmail } as any);
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('does not call the explicit system fallback when the tenant attempt succeeds', async () => {
+    const tenantSendEmail = vi.fn(async () =>
+      sendResult({ success: true, providerId: 'tenant-smtp', providerType: 'smtp' })
+    );
+    mockedGetInstance.mockReturnValue({ sendEmail: tenantSendEmail } as any);
+
+    const result = await sendPasswordResetEmail(baseParams);
+
+    expect(result).toBe(true);
+    expect(tenantSendEmail).toHaveBeenCalledTimes(1);
+    expect(mockedGetSystemEmailService).not.toHaveBeenCalled();
+    expect(systemSendEmail).not.toHaveBeenCalled();
+  });
+
+  it('calls a distinct system fallback once and accepts its success after a tenant failure', async () => {
+    const tenantSendEmail = vi.fn(async () =>
+      sendResult({ providerId: 'tenant-smtp', providerType: 'smtp', error: 'tenant smtp down' })
+    );
+    mockedGetInstance.mockReturnValue({ sendEmail: tenantSendEmail } as any);
+    systemSendEmail.mockResolvedValue(
+      sendResult({ success: true, providerId: 'system-email-provider', providerType: 'smtp' })
+    );
+
+    const result = await sendPasswordResetEmail(baseParams);
+
+    expect(result).toBe(true);
+    expect(tenantSendEmail).toHaveBeenCalledTimes(1);
+    expect(mockedGetSystemEmailService).toHaveBeenCalledTimes(1);
+    expect(systemSendEmail).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not retry a failure already returned by the system-email-provider', async () => {
+    const tenantSendEmail = vi.fn(async () =>
+      sendResult({ providerId: 'system-email-provider', providerType: 'smtp', error: 'system provider rejected' })
+    );
+    mockedGetInstance.mockReturnValue({ sendEmail: tenantSendEmail } as any);
+
+    await expect(sendPasswordResetEmail(baseParams)).rejects.toThrow('system provider rejected');
+
+    expect(tenantSendEmail).toHaveBeenCalledTimes(1);
+    expect(mockedGetSystemEmailService).not.toHaveBeenCalled();
+    expect(systemSendEmail).not.toHaveBeenCalled();
+  });
+
+  it('retains both causes and never masks the tenant SMTP error when both paths fail', async () => {
+    const tenantSendEmail = vi.fn(async () =>
+      sendResult({
+        providerId: 'tenant-smtp',
+        providerType: 'smtp',
+        error: 'SMTP auth failed: bad credentials',
+      })
+    );
+    mockedGetInstance.mockReturnValue({ sendEmail: tenantSendEmail } as any);
+    systemSendEmail.mockResolvedValue(
+      sendResult({ error: 'Email service is disabled or not configured' })
+    );
+
+    const error = await sendPasswordResetEmail(baseParams).catch((e: Error) => e);
+
+    expect(error).toBeInstanceOf(Error);
+    expect(error.message).toContain('SMTP auth failed: bad credentials');
+    expect(error.message).toContain('Email service is disabled or not configured');
+    expect(mockedGetSystemEmailService).toHaveBeenCalledTimes(1);
+  });
+});

--- a/server/src/test/unit/email/systemEmailProviderFactory.unit.test.ts
+++ b/server/src/test/unit/email/systemEmailProviderFactory.unit.test.ts
@@ -1,0 +1,65 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+vi.mock('@alga-psa/core/logger', () => ({
+  default: {
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+    debug: vi.fn(),
+    system: vi.fn(),
+  },
+}));
+
+vi.mock('../../../../../packages/email/src/providers/SMTPEmailProvider', () => ({
+  SMTPEmailProvider: class {
+    providerId = 'system-email-provider';
+    providerType = 'smtp';
+    capabilities = {};
+    async initialize() {}
+    async sendEmail() {
+      return { success: true };
+    }
+  },
+}));
+
+import { SystemEmailProviderFactory } from '../../../../../packages/email/src/system/SystemEmailProviderFactory';
+
+const SAVED_ENV: Record<string, string | undefined> = {
+  EMAIL_ENABLE: process.env.EMAIL_ENABLE,
+  EMAIL_PROVIDER_TYPE: process.env.EMAIL_PROVIDER_TYPE,
+  EMAIL_HOST: process.env.EMAIL_HOST,
+  EMAIL_PORT: process.env.EMAIL_PORT,
+  EMAIL_FROM: process.env.EMAIL_FROM,
+};
+
+afterEach(() => {
+  for (const [key, value] of Object.entries(SAVED_ENV)) {
+    if (value === undefined) delete process.env[key];
+    else process.env[key] = value;
+  }
+});
+
+describe('SystemEmailProviderFactory EMAIL_ENABLE gate', () => {
+  it('returns null when EMAIL_ENABLE is false', async () => {
+    process.env.EMAIL_ENABLE = 'false';
+    await expect(SystemEmailProviderFactory.createProvider()).resolves.toBeNull();
+  });
+
+  it('returns null when EMAIL_ENABLE is unset', async () => {
+    delete process.env.EMAIL_ENABLE;
+    await expect(SystemEmailProviderFactory.createProvider()).resolves.toBeNull();
+  });
+
+  it('initializes the environment-backed system provider only for exact EMAIL_ENABLE=true', async () => {
+    process.env.EMAIL_ENABLE = 'true';
+    process.env.EMAIL_PROVIDER_TYPE = 'smtp';
+    process.env.EMAIL_HOST = '127.0.0.1';
+    process.env.EMAIL_PORT = '3025';
+    process.env.EMAIL_FROM = 'noreply@example.com';
+
+    const provider = await SystemEmailProviderFactory.createProvider();
+    expect(provider).not.toBeNull();
+    expect(provider?.providerId).toBe('system-email-provider');
+    expect(provider?.providerType).toBe('smtp');
+  });
+});

--- a/server/src/test/unit/lib/auth/resetLinkOrigin.test.ts
+++ b/server/src/test/unit/lib/auth/resetLinkOrigin.test.ts
@@ -1,0 +1,45 @@
+import { describe, expect, it } from 'vitest';
+import { resolvePasswordResetOrigin } from '../../../../../../packages/auth/src/lib/resetLinkOrigin';
+
+describe('resolvePasswordResetOrigin', () => {
+  it('uses NEXT_PUBLIC_BASE_URL first and normalizes to the origin', () => {
+    expect(
+      resolvePasswordResetOrigin({
+        NEXT_PUBLIC_BASE_URL: 'https://app.example.com',
+        NEXTAUTH_URL: 'https://nextauth.example.com',
+        HOST: 'host.example.com',
+      })
+    ).toBe('https://app.example.com');
+  });
+
+  it('strips a trailing slash and base path when normalizing', () => {
+    expect(
+      resolvePasswordResetOrigin({ NEXT_PUBLIC_BASE_URL: 'https://app.example.com/app/' })
+    ).toBe('https://app.example.com');
+  });
+
+  it('falls back to NEXTAUTH_URL when NEXT_PUBLIC_BASE_URL is absent', () => {
+    expect(
+      resolvePasswordResetOrigin({ NEXTAUTH_URL: 'https://nextauth.example.com' })
+    ).toBe('https://nextauth.example.com');
+  });
+
+  it('derives an https origin from a bare HOST hostname', () => {
+    expect(resolvePasswordResetOrigin({ HOST: 'psa.example.com' })).toBe(
+      'https://psa.example.com'
+    );
+  });
+
+  it('refuses when every trusted source is absent or invalid', () => {
+    expect(resolvePasswordResetOrigin({})).toBeNull();
+    expect(
+      resolvePasswordResetOrigin({ NEXT_PUBLIC_BASE_URL: 'not-a-url', HOST: 'not a host' })
+    ).toBeNull();
+  });
+
+  it('never accepts a non-http(s) scheme', () => {
+    expect(
+      resolvePasswordResetOrigin({ NEXT_PUBLIC_BASE_URL: 'javascript:alert(1)' })
+    ).toBeNull();
+  });
+});

--- a/server/src/test/unit/lib/auth/resetLinkOrigin.test.ts
+++ b/server/src/test/unit/lib/auth/resetLinkOrigin.test.ts
@@ -30,6 +30,28 @@ describe('resolvePasswordResetOrigin', () => {
     );
   });
 
+  it('accepts a HOST that already carries a scheme', () => {
+    expect(resolvePasswordResetOrigin({ HOST: 'http://localhost:3614' })).toBe(
+      'http://localhost:3614'
+    );
+  });
+
+  it('normalizes a scheme-bearing HOST with a path to its origin', () => {
+    expect(resolvePasswordResetOrigin({ HOST: 'https://x.example.com/path/' })).toBe(
+      'https://x.example.com'
+    );
+  });
+
+  it('never turns a scheme-bearing HOST into a bogus http/https-hostname origin', () => {
+    for (const host of ['http://localhost:3614', 'https://x.example.com/path/', 'http://', 'https://']) {
+      const origin = resolvePasswordResetOrigin({ HOST: host });
+      if (origin) {
+        const url = new URL(origin);
+        expect(['http', 'https'], `HOST=${host}`).not.toContain(url.hostname);
+      }
+    }
+  });
+
   it('refuses when every trusted source is absent or invalid', () => {
     expect(resolvePasswordResetOrigin({})).toBeNull();
     expect(


### PR DESCRIPTION
## Summary

Password recovery no longer consults the legacy process-level `EMAIL_ENABLE` flag before attempting delivery. Enabled tenant SMTP, Resend, or Microsoft providers can now send MSP and client reset emails when `EMAIL_ENABLE` is false or unset; the system SMTP/Resend fallback remains gated inside `SystemEmailProviderFactory`.

The public flow is enumeration-safe: invalid, unknown, inactive, portal-mismatched, and provider-failed requests return the same success result. Only a matched active user of the requested portal type can mint a token or trigger delivery.

Reset links now require a validated canonical origin resolved from trusted server configuration in this order: `NEXT_PUBLIC_BASE_URL`, `NEXTAUTH_URL`, then `HOST`. Scheme-bearing and bare-host `HOST` values are supported, request headers are never trusted, and recovery refuses the send without minting a token when no safe origin can be derived.

## Changes

- Reworked `recoverPassword` to normalize addresses once, remove the legacy gate, enforce active user and portal matching, and route all delivery through the provider-aware email path.
- Added structured `password_recovery_send_failed` and `password_recovery_send_refused` diagnostics without logging reset tokens or URLs.
- Replaced the independent `requestPasswordReset` implementation with a deprecated compatibility adapter to canonical `recoverPassword`, removing the dead `/auth/reset-password` link flow.
- Preserved both tenant-provider and system-fallback failure causes in `sendPasswordResetEmail` and prevented duplicate system-provider attempts.
- Added canonical reset-origin resolution and coverage for missing configuration, `NEXTAUTH_URL`, scheme-bearing `HOST`, bare-host `HOST`, malformed values, and origin normalization.
- Added real-DB/real-SMTP integration coverage for MSP/client delivery with `EMAIL_ENABLE` false or unset, usable links, Email Log persistence, no-send guards, and provider failure diagnostics, plus focused fallback/factory unit coverage.

## Smoke test — PASS with one observability concern

Environment: current HEAD `55b0c17ca5`, real app at `http://localhost:3614`, `EMAIL_ENABLE=false`, real Postgres/Redis, and GreenMail SMTP on `localhost:3025`. Final health check returned HTTP 200; SMTP configuration was restored and the worktree remains clean.

- **MSP recovery — PASS:** `glinda@emeraldcity.oz` received exactly one new message (32→33). Email Log row 256 is Sent via the tenant SMTP provider. The message used `http://localhost:3614`, contained no undefined origin, and opened the real reset screen for the internal user.
- **Client recovery — PASS:** `ozma@emeraldcity.oz` received exactly one new message (2→3). Email Log row 257 is Sent via SMTP, includes `portal=client`, and opened the reset screen identifying a Client Portal User.
- **Unknown address — PASS:** identical enumeration-safe Check Email screen; no GreenMail mailbox/message and no Email Log change.
- **Wrong portal type — PASS:** submitting the internal MSP user through the client form showed the same public success; Glinda's count stayed 33 and no log was added.
- **Inactive user — PASS:** a temporary inactive fixture submitted through the MSP form received the same public success, no mail, and no log. The fixture was deleted afterward.
- **Provider failure — PASS:** the tenant SMTP port was temporarily changed to a closed local port and the real server restarted. The UI remained enumeration-safe and GreenMail stayed unchanged. Server logs emitted `password_recovery_send_failed` and retained both causes: tenant SMTP `ECONNREFUSED` and system fallback disabled by `EMAIL_ENABLE=false`. Port 3025 was restored afterward.
- **Email Log UI — PASS:** authenticated System Monitoring → Email Logs showed the new MSP and client Password Reset Request rows as Sent.

**Observability concern:** provider initialization failure is diagnostic in application logs but creates no `email_sending_logs` row, so that specific failure is not visible in the Email Log UI. SMTP rejection after successful initialization is covered by the repository integration suite, but that more invasive fault was not recreated live. Successful sends log correctly.

## Fidelity disclosures

No mocks or custom simulator were used; GreenMail was the existing compose service. Minimal setup used direct DB insertion for the inactive user and a temporary SMTP-port change, both fully reverted. A freshly created card browser tab was assigned to the desktop host and could not be driven from this worktree host, so evidence was captured through an existing blank browser pane already scoped to this card workspace. System SMTP/Resend success was not exercised; the live failure flow did confirm that the system fallback remains gated by `EMAIL_ENABLE`.

Evidence: `/tmp/alga-smoke-evidence/remove-legacy-email-gate-20260814-143015`
