### PR TITLE
fix: repair nightly integration failures from typed status mappings a…

### DIFF
--- a/packages/projects/src/actions/projectTemplateActions.ts
+++ b/packages/projects/src/actions/projectTemplateActions.ts
@@ -292,16 +292,25 @@ export const createTemplateFromProject = withAuth(async (
         ? phaseMap.get(mapping.phase_id) ?? null
         : null;
 
-      const isStandard = Boolean(mapping.is_standard) || Boolean(mapping.standard_status_id);
+      // Classify by which reference is actually present so the row satisfies
+      // the variant_shape_check: standard > tenant > inline (custom-name-only).
+      const standardStatusId = mapping.standard_status_id || null;
+      const tenantStatusId = mapping.status_id || null;
+      const statusSource = standardStatusId ? 'standard' : tenantStatusId ? 'tenant' : 'inline';
+      if (statusSource === 'inline' && !mapping.custom_name) {
+        throw new Error(
+          `Project status mapping ${mapping.project_status_mapping_id} has no status reference or custom name; cannot copy it into a template.`
+        );
+      }
       const [templateStatusMapping] = await tenantScopedTable(trx, 'project_template_status_mappings', tenant)
         .insert({
           tenant,
           template_id: template.template_id,
           template_phase_id: templatePhaseId,
-          status_id: isStandard ? null : (mapping.status_id || null),
-          standard_status_id: isStandard ? (mapping.standard_status_id || null) : null,
+          status_id: statusSource === 'tenant' ? tenantStatusId : null,
+          standard_status_id: statusSource === 'standard' ? standardStatusId : null,
           unresolved_status_id: null,
-          status_source: isStandard ? 'standard' : 'tenant',
+          status_source: statusSource,
           custom_status_name: mapping.custom_name,
           display_order: mapping.display_order
         })

--- a/server/src/test/integration/payments/invoiceEmailPaymentLinks.journey.integration.test.ts
+++ b/server/src/test/integration/payments/invoiceEmailPaymentLinks.journey.integration.test.ts
@@ -175,6 +175,7 @@ vi.mock('@alga-psa/billing/services/pdfGenerationService', () => ({
     generateAndStore: vi.fn(async () => ({ file_id: `file-${uuidv4()}` })),
   })),
   PDFGenerationService: class {},
+  publishGeneratedDocumentsToClient: vi.fn(async () => {}),
 }));
 
 vi.mock('@alga-psa/billing/services', async (importOriginal) => {

--- a/server/src/test/integration/projectTemplatesIntegration.test.ts
+++ b/server/src/test/integration/projectTemplatesIntegration.test.ts
@@ -506,6 +506,7 @@ describe('Project Templates Integration Tests', () => {
             tenant: context.tenantId,
             template_id: template.template_id,
             status_id: null,
+            status_source: 'inline',
             custom_status_name: 'To Do',
             display_order: 1
           },
@@ -513,6 +514,7 @@ describe('Project Templates Integration Tests', () => {
             tenant: context.tenantId,
             template_id: template.template_id,
             status_id: null,
+            status_source: 'inline',
             custom_status_name: 'Done',
             display_order: 2
           }
@@ -719,6 +721,7 @@ describe('Project Templates Integration Tests', () => {
             tenant: context.tenantId,
             template_id: template.template_id,
             status_id: null,
+            status_source: 'inline',
             custom_status_name: 'Backlog',
             display_order: 1
           },
@@ -726,6 +729,7 @@ describe('Project Templates Integration Tests', () => {
             tenant: context.tenantId,
             template_id: template.template_id,
             status_id: null,
+            status_source: 'inline',
             custom_status_name: 'In Review',
             display_order: 2
           },
@@ -733,6 +737,7 @@ describe('Project Templates Integration Tests', () => {
             tenant: context.tenantId,
             template_id: template.template_id,
             status_id: null,
+            status_source: 'inline',
             custom_status_name: 'Completed',
             display_order: 3
           }
@@ -760,7 +765,14 @@ describe('Project Templates Integration Tests', () => {
         .orderBy('display_order');
 
       expect(projectStatusMappings).toHaveLength(3);
-      expect(projectStatusMappings[0].custom_name).toBe('Backlog');
+      // Inline template statuses are materialized as tenant statuses on apply;
+      // the project mapping references the created status rather than copying
+      // the name into custom_name.
+      expect(projectStatusMappings[0].status_id).toBeTruthy();
+      const backlogStatus = await tenantTable('statuses')
+        .where({ status_id: projectStatusMappings[0].status_id })
+        .first();
+      expect(backlogStatus.name).toBe('Backlog');
       expect(projectStatusMappings[0].display_order).toBe(1);
       expect(projectStatusMappings[0].is_visible).toBe(true);
     });
@@ -910,6 +922,7 @@ describe('Project Templates Integration Tests', () => {
         .insert({
           tenant: context.tenantId,
           template_id: template.template_id,
+          status_source: 'inline',
           custom_status_name: 'Custom Status',
           display_order: 1
         });


### PR DESCRIPTION
…nd document filing

- createTemplateFromProject: classify status mappings by which reference is present (standard > tenant > inline) so copied rows satisfy the variant_shape_check constraint; custom-name-only mappings become 'inline' instead of an invalid 'tenant' row
- projectTemplatesIntegration test: set status_source on direct project_template_status_mappings inserts; assert applied inline statuses through the created statuses row instead of legacy custom_name copying
- invoiceEmailPaymentLinks journey test: add publishGeneratedDocumentsToClient to the pdfGenerationService mock, which the send action now imports